### PR TITLE
Make sysinfo into a runner Plugin.

### DIFF
--- a/avocado/cli/app.py
+++ b/avocado/cli/app.py
@@ -1,6 +1,7 @@
 """
-Implements the base avocado runner application.
+The core Avocado application.
 """
+
 import imp
 import logging
 import os
@@ -11,10 +12,10 @@ from avocado import sysinfo
 from avocado.plugins.manager import get_plugin_manager
 
 
-class AvocadoRunnerApp(object):
+class AvocadoApp(object):
 
     """
-    Basic avocado runner application.
+    Avocado application.
     """
 
     def __init__(self):
@@ -33,13 +34,6 @@ class AvocadoRunnerApp(object):
         subparsers = self.arg_parser.add_subparsers(title='subcommands',
                                                     description='valid subcommands',
                                                     help='subcommand help')
-
-        psysinfo = subparsers.add_parser('sysinfo',
-                                         help='Collect system information')
-        psysinfo.add_argument('sysinfodir', type=str,
-                              help='Dir where to dump sysinfo',
-                              nargs='?', default='')
-        psysinfo.set_defaults(func=sysinfo.collect_sysinfo)
 
         self.load_plugin_manager(subparsers)
         self.args = self.arg_parser.parse_args()

--- a/avocado/plugins/builtin.py
+++ b/avocado/plugins/builtin.py
@@ -5,6 +5,7 @@ from importlib import import_module
 __all__ = ['load_builtins']
 
 Builtins = [('avocado.plugins.runner', 'TestLister'),
+            ('avocado.plugins.runner', 'SystemInformation'),
             ('avocado.plugins.runner', 'TestRunner'), ]
 
 

--- a/avocado/plugins/runner.py
+++ b/avocado/plugins/runner.py
@@ -26,9 +26,9 @@ class TestLister(plugin.Plugin):
 
         :param parser: Main test runner parser.
         """
-        tlist = parser.add_parser('list',
-                                  help='List available test modules')
-        tlist.set_defaults(func=self.list_tests)
+        myparser = parser.add_parser('list',
+                                     help='List available test modules')
+        myparser.set_defaults(func=self.list_tests)
         self.enabled = True
 
     def list_tests(self, args):
@@ -66,6 +66,7 @@ class TestRunner(plugin.Plugin):
                                     '(space separated)'),
                               nargs='?', default='')
         myparser.set_defaults(func=self.run_tests)
+        self.enabled = True
 
     def run_tests(self, args):
         """
@@ -134,3 +135,22 @@ class TestRunner(plugin.Plugin):
             test_index += 1
 
         output_manager.stop_file_logging()
+
+
+class SystemInformation(plugin.Plugin):
+    """
+    Collect system information and log.
+    """
+    def configure(self, parser):
+        """
+        Add the subparser for the run action.
+
+        :param parser: Main test runner parser.
+        """
+        myparser = parser.add_parser('sysinfo',
+                                     help='Collect system information')
+        myparser.add_argument('sysinfodir', type=str,
+                              help='Dir where to dump sysinfo',
+                              nargs='?', default='')
+        myparser.set_defaults(func=sysinfo.collect_sysinfo)
+        self.enabled = True

--- a/scripts/avocado
+++ b/scripts/avocado
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+
 import os
 import sys
 
@@ -10,5 +11,5 @@ if os.path.isdir(os.path.join(basedir, 'avocado')):
 import avocado
 
 if __name__ == '__main__':
-    app = avocado.cli.app.AvocadoRunnerApp()
+    app = avocado.cli.app.AvocadoApp()
     app.run()


### PR DESCRIPTION
Make sysinfo into a runner Plugin,
rename application from AvocadoRunnerApp to AvocadoApp,
due all options are now implemented as plugins and
Avocado is now a core application.

Signed-off-by: Ruda Moura rmoura@redhat.com
