### PR TITLE
Add option -v | --version to the application.

### DIFF
--- a/avocado/cli/app.py
+++ b/avocado/cli/app.py
@@ -5,6 +5,7 @@ The core Avocado application.
 from argparse import ArgumentParser
 
 from avocado.plugins.manager import get_plugin_manager
+from avocado.version import VERSION
 
 
 class AvocadoApp(object):
@@ -16,8 +17,10 @@ class AvocadoApp(object):
     def __init__(self, external_plugins=None):
         self.external_plugins = external_plugins
         self.plugin_manager = None
-        self.arg_parser = ArgumentParser(description='Avocado Test Runner')
-        self.arg_parser.add_argument('-v', '--verbose', action='store_true',
+        self.arg_parser = ArgumentParser(prog='avocado',
+                                         version=VERSION,
+                                         description='Avocado Test Runner')
+        self.arg_parser.add_argument('-V', '--verbose', action='store_true',
                                      help='print extra debug messages',
                                      dest='verbose')
         self.arg_parser.add_argument('--logdir', action='store',

--- a/avocado/utils/misc.py
+++ b/avocado/utils/misc.py
@@ -94,14 +94,4 @@ def unique(lst):
     :param lst: List with values.
     :return: List with non duplicate elements.
     """
-    n = len(lst)
-    if n == 0:
-        return []
-    u = {}
-    try:
-        for x in lst:
-            u[x] = 1
-    except TypeError:
-        return None
-    else:
-        return u.keys()
+    return list(set(lst))


### PR DESCRIPTION
Actually pass parameter for version when calling ArgumentParser,
so we're leaving -V for --verbose.

Plus: simplify code for utils.unique().

Signed-off-by: Ruda Moura rmoura@redhat.com
