### PR TITLE
avocado: Introducing copyright headers to the files

### DIFF
--- a/avocado/__init__.py
+++ b/avocado/__init__.py
@@ -1,3 +1,16 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: RedHat 2013-2014
+# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+
 import cli
 import core
 

--- a/avocado/cli/__init__.py
+++ b/avocado/cli/__init__.py
@@ -1,1 +1,14 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: RedHat 2013-2014
+# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+
 import app

--- a/avocado/cli/app.py
+++ b/avocado/cli/app.py
@@ -1,3 +1,16 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: RedHat 2013-2014
+# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+
 """
 The core Avocado application.
 """

--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -1,4 +1,18 @@
 #!/usr/bin/python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: RedHat 2013-2014
+# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+
 """
 Library used to let avocado tests find important paths in the system.
 """

--- a/avocado/core/exceptions.py
+++ b/avocado/core/exceptions.py
@@ -1,3 +1,16 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: RedHat 2013-2014
+# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+
 """
 Exception classes, useful for tests, and other parts of the framework code.
 """

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -1,3 +1,16 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: RedHat 2013-2014
+# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+
 """
 Manages output and logging in avocado applications.
 """

--- a/avocado/job.py
+++ b/avocado/job.py
@@ -1,3 +1,16 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: RedHat 2013-2014
+# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+
 """
 Class that describes a sequence of automated operations.
 """

--- a/avocado/linux/distro.py
+++ b/avocado/linux/distro.py
@@ -1,3 +1,16 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: RedHat 2013-2014
+# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+
 """
 This module provides the client facilities to detect the Linux Distribution
 it's running under.

--- a/avocado/linux/software_manager.py
+++ b/avocado/linux/software_manager.py
@@ -1,4 +1,21 @@
 #!/usr/bin/python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: RedHat 2013-2014
+# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+#
+# This code was adapted from the autotest project,
+# client/shared/software_manager.py
+
 """
 Software package management library.
 

--- a/avocado/plugins/builtin.py
+++ b/avocado/plugins/builtin.py
@@ -1,3 +1,16 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: RedHat 2013-2014
+# Author: Ruda Moura <rmoura@redhat.com>
+
 """Builtin plugins."""
 
 from importlib import import_module

--- a/avocado/plugins/manager.py
+++ b/avocado/plugins/manager.py
@@ -1,3 +1,16 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: RedHat 2013-2014
+# Author: Ruda Moura <rmoura@redhat.com>
+
 """Plugin Managers."""
 
 from avocado.plugins.builtin import load_builtins

--- a/avocado/plugins/plugin.py
+++ b/avocado/plugins/plugin.py
@@ -1,3 +1,16 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: RedHat 2013-2014
+# Author: Ruda Moura <rmoura@redhat.com>
+
 """Plugins basic structure."""
 
 

--- a/avocado/plugins/runner.py
+++ b/avocado/plugins/runner.py
@@ -1,3 +1,16 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: RedHat 2013-2014
+# Author: Ruda Moura <rmoura@redhat.com>
+
 """
 Base Test Runner Plugins.
 """

--- a/avocado/profiler.py
+++ b/avocado/profiler.py
@@ -1,3 +1,16 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: RedHat 2013-2014
+# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+
 """
 Profilers are programs that run on background, that aim to measure some system
 aspect, such as CPU usage, IO throughput, memory usage, syscall count, among

--- a/avocado/result.py
+++ b/avocado/result.py
@@ -1,3 +1,16 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: RedHat 2013-2014
+# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+
 """Test result module."""
 
 

--- a/avocado/settings.py
+++ b/avocado/settings.py
@@ -1,3 +1,19 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: RedHat 2013-2014
+# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+#
+# This code was inspired in the autotest project,
+# client/shared/settings.py, author: Travis Miller <raphtee@google.com>
+
 """
 Reads the avocado settings from a .ini file (from python ConfigParser).
 """

--- a/avocado/sysinfo.py
+++ b/avocado/sysinfo.py
@@ -1,3 +1,16 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: RedHat 2013-2014
+# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+
 import gzip
 import logging
 import os

--- a/avocado/test.py
+++ b/avocado/test.py
@@ -1,3 +1,16 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: RedHat 2013-2014
+# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+
 """
 Contains the base test implementation, used as a base for the actual
 framework tests.

--- a/avocado/utils/__init__.py
+++ b/avocado/utils/__init__.py
@@ -1,3 +1,16 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: RedHat 2013-2014
+# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+
 import logging
 import random
 import string

--- a/avocado/utils/archive.py
+++ b/avocado/utils/archive.py
@@ -1,3 +1,15 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+
+
 """
 Based on django.utils.archive, which is on its turn Based on "python-archive"
 http://pypi.python.org/pypi/python-archive/

--- a/avocado/utils/build.py
+++ b/avocado/utils/build.py
@@ -1,3 +1,16 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: RedHat 2013-2014
+# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+
 import os
 import process
 

--- a/avocado/utils/crypto.py
+++ b/avocado/utils/crypto.py
@@ -1,3 +1,16 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: RedHat 2013-2014
+# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+
 import random
 import string
 import os

--- a/avocado/utils/download.py
+++ b/avocado/utils/download.py
@@ -1,3 +1,16 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: RedHat 2013-2014
+# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+
 """
 Methods to download URLs and regular files.
 """

--- a/avocado/utils/memory.py
+++ b/avocado/utils/memory.py
@@ -1,3 +1,16 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: RedHat 2013-2014
+# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+
 import re
 import glob
 import math

--- a/avocado/utils/misc.py
+++ b/avocado/utils/misc.py
@@ -1,3 +1,16 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: RedHat 2013-2014
+# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+
 import logging
 import os
 

--- a/avocado/utils/network.py
+++ b/avocado/utils/network.py
@@ -1,0 +1,12 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: RedHat 2013-2014
+# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -1,3 +1,16 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: RedHat 2013-2014
+# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+
 """
 Functions dedicated to find and run external commands.
 """

--- a/avocado/version.py
+++ b/avocado/version.py
@@ -1,4 +1,18 @@
 #!/usr/bin/python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: RedHat 2013-2014
+# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+
 __all__ = ['MAJOR', 'MINOR', 'RELEASE', 'VERSION']
 
 

--- a/examples/avocado_example_plugins.py
+++ b/examples/avocado_example_plugins.py
@@ -1,3 +1,16 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: RedHat 2013-2014
+# Author: Ruda Moura <rmoura@redhat.com>
+
 from avocado.plugins import plugin
 from avocado.plugins.manager import get_plugin_manager
 from avocado.core import output

--- a/scripts/avocado
+++ b/scripts/avocado
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: RedHat 2013-2014
+# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+
+
 import os
 import sys
 

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,16 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: RedHat 2013-2014
+# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+
 import glob
 from distutils.core import setup
 

--- a/unittests/avocado/settings_unittest.py
+++ b/unittests/avocado/settings_unittest.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: RedHat 2013-2014
+# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+
+
 import unittest
 import os
 import sys

--- a/unittests/avocado/sysinfo_unittest.py
+++ b/unittests/avocado/sysinfo_unittest.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: RedHat 2013-2014
+# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+
+
 import unittest
 import os
 import sys


### PR DESCRIPTION
Use the new inspektor functionality (with a few manual
tweaks later) to add copyright headers into each avocado
file.

Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
