### PR TITLE
avocado.plugins.manager: Make loading plugins robust.

### DIFF
--- a/examples/avocado_example_plugins.py
+++ b/examples/avocado_example_plugins.py
@@ -57,4 +57,6 @@ class PluginsList(plugin.Plugin):
         pipe.write(bcolors.header_str('Plugins loaded:'))
         pipe.write('\n')
         for plug in pm.plugins:
-            pipe.write('    %s - %s\n' % (plug.name, plug.__doc__.strip()))
+            status = "Enabled" if plug.enabled else "Disabled"
+            pipe.write('    %s - %s (%s)\n' % (plug.name, plug.__doc__.strip(),
+                                               status))


### PR DESCRIPTION
Make loading plugins robust (ignore and log errors when loading).

Signed-off-by: Ruda Moura rmoura@redhat.com
