### PR TITLE
avocado: Fix mistakes in copyright headers

### DIFF
--- a/avocado/__init__.py
+++ b/avocado/__init__.py
@@ -1,6 +1,7 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; specifically version 2 of the License.
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/avocado/cli/__init__.py
+++ b/avocado/cli/__init__.py
@@ -1,6 +1,7 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; specifically version 2 of the License.
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/avocado/cli/app.py
+++ b/avocado/cli/app.py
@@ -1,6 +1,7 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; specifically version 2 of the License.
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/avocado/core/__init__.py
+++ b/avocado/core/__init__.py
@@ -1,6 +1,7 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; specifically version 2 of the License.
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -2,7 +2,8 @@
 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; specifically version 2 of the License.
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/avocado/core/exceptions.py
+++ b/avocado/core/exceptions.py
@@ -1,6 +1,7 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; specifically version 2 of the License.
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -1,6 +1,7 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; specifically version 2 of the License.
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/avocado/job.py
+++ b/avocado/job.py
@@ -1,6 +1,7 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; specifically version 2 of the License.
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/avocado/linux/__init__.py
+++ b/avocado/linux/__init__.py
@@ -1,6 +1,7 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; specifically version 2 of the License.
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/avocado/linux/distro.py
+++ b/avocado/linux/distro.py
@@ -1,6 +1,7 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; specifically version 2 of the License.
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/avocado/linux/software_manager.py
+++ b/avocado/linux/software_manager.py
@@ -2,7 +2,8 @@
 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; specifically version 2 of the License.
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -12,6 +13,9 @@
 #
 # Copyright: RedHat 2013-2014
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+# Author: Higor Vieira Alves <halves@br.ibm.com>
+# Author: Ramon de Carvalho Valle <rcvalle@br.ibm.com>
+
 #
 # This code was adapted from the autotest project,
 # client/shared/software_manager.py

--- a/avocado/plugins/__init__.py
+++ b/avocado/plugins/__init__.py
@@ -1,6 +1,7 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; specifically version 2 of the License.
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/avocado/plugins/builtin.py
+++ b/avocado/plugins/builtin.py
@@ -1,6 +1,7 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; specifically version 2 of the License.
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/avocado/plugins/lister.py
+++ b/avocado/plugins/lister.py
@@ -1,6 +1,7 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; specifically version 2 of the License.
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/avocado/plugins/manager.py
+++ b/avocado/plugins/manager.py
@@ -1,6 +1,7 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; specifically version 2 of the License.
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/avocado/plugins/plugin.py
+++ b/avocado/plugins/plugin.py
@@ -1,6 +1,7 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; specifically version 2 of the License.
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/avocado/plugins/runner.py
+++ b/avocado/plugins/runner.py
@@ -1,6 +1,7 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; specifically version 2 of the License.
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/avocado/plugins/xunit.py
+++ b/avocado/plugins/xunit.py
@@ -1,6 +1,7 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; specifically version 2 of the License.
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/avocado/profiler.py
+++ b/avocado/profiler.py
@@ -8,8 +8,9 @@
 #
 # See LICENSE for more details.
 #
-# Copyright: RedHat 2013-2014
-# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+# This code was inspired in the autotest project,
+# client/profilers
+# Authors: Martin J Bligh <mbligh@google.com>, John Admanski <jadmanski@google.com>
 
 """
 Profilers are programs that run on background, that aim to measure some system

--- a/avocado/result.py
+++ b/avocado/result.py
@@ -1,6 +1,7 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; specifically version 2 of the License.
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/avocado/settings.py
+++ b/avocado/settings.py
@@ -8,11 +8,9 @@
 #
 # See LICENSE for more details.
 #
-# Copyright: RedHat 2013-2014
-# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
-#
 # This code was inspired in the autotest project,
-# client/shared/settings.py, author: Travis Miller <raphtee@google.com>
+# client/shared/settings.py
+# Author: Travis Miller <raphtee@google.com>
 
 """
 Reads the avocado settings from a .ini file (from python ConfigParser).

--- a/avocado/sysinfo.py
+++ b/avocado/sysinfo.py
@@ -8,8 +8,9 @@
 #
 # See LICENSE for more details.
 #
-# Copyright: RedHat 2013-2014
-# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+# This code was inspired in the autotest project,
+# client/shared/settings.py
+# Author: John Admanski <jadmanski@google.com>
 
 import gzip
 import logging

--- a/avocado/test.py
+++ b/avocado/test.py
@@ -8,8 +8,9 @@
 #
 # See LICENSE for more details.
 #
-# Copyright: RedHat 2013-2014
-# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+# This code was inspired in the autotest project,
+# client/shared/test.py
+# Authors: Martin J Bligh <mbligh@google.com>, Andy Whitcroft <apw@shadowen.org>
 
 """
 Contains the base test implementation, used as a base for the actual

--- a/avocado/utils/__init__.py
+++ b/avocado/utils/__init__.py
@@ -1,6 +1,7 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; specifically version 2 of the License.
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/avocado/utils/archive.py
+++ b/avocado/utils/archive.py
@@ -1,38 +1,30 @@
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; specifically version 2 of the License.
+# license: MIT
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# Based on django.utils.archive, which is on its turn Based on "python-archive"
+# http://pypi.python.org/pypi/python-archive/
 #
-# See LICENSE for more details.
+# Copyright (c) 2010 Gary Wilson Jr. <gary.wilson@gmail.com> and contributors.
 #
-
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 
 """
-Based on django.utils.archive, which is on its turn Based on "python-archive"
-http://pypi.python.org/pypi/python-archive/
-
-Copyright (c) 2010 Gary Wilson Jr. <gary.wilson@gmail.com> and contributors.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+Library used to transparently uncompress compressed files.
 """
 import os
 import shutil

--- a/avocado/utils/build.py
+++ b/avocado/utils/build.py
@@ -1,6 +1,7 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; specifically version 2 of the License.
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/avocado/utils/crypto.py
+++ b/avocado/utils/crypto.py
@@ -1,6 +1,7 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; specifically version 2 of the License.
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/avocado/utils/download.py
+++ b/avocado/utils/download.py
@@ -8,8 +8,10 @@
 #
 # See LICENSE for more details.
 #
-# Copyright: RedHat 2013-2014
-# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+# This code was inspired in the autotest project,
+# client/shared/utils.py
+# Authors: Martin J Bligh <mbligh@google.com>, Andy Whitcroft <apw@shadowen.org>
+
 
 """
 Methods to download URLs and regular files.

--- a/avocado/utils/memory.py
+++ b/avocado/utils/memory.py
@@ -1,6 +1,7 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; specifically version 2 of the License.
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -9,7 +10,12 @@
 # See LICENSE for more details.
 #
 # Copyright: RedHat 2013-2014
-# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+# Author: Yiqiao Pu <ypu@redhat.com>
+#
+# This code was inspired in the autotest project,
+# client/shared/utils.py
+# Authors: Yiqiao Pu <ypu@redhat.com>
+
 
 import re
 import glob

--- a/avocado/utils/misc.py
+++ b/avocado/utils/misc.py
@@ -8,8 +8,9 @@
 #
 # See LICENSE for more details.
 #
-# Copyright: RedHat 2013-2014
-# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+# This code was inspired in the autotest project,
+# client/shared/utils.py
+# Authors: Martin J Bligh <mbligh@google.com>, Andy Whitcroft <apw@shadowen.org>
 
 import logging
 import os

--- a/avocado/utils/network.py
+++ b/avocado/utils/network.py
@@ -1,6 +1,7 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; specifically version 2 of the License.
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -1,6 +1,7 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; specifically version 2 of the License.
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/avocado/version.py
+++ b/avocado/version.py
@@ -2,7 +2,8 @@
 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; specifically version 2 of the License.
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/examples/plugins/avocado_hello.py
+++ b/examples/plugins/avocado_hello.py
@@ -1,6 +1,7 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; specifically version 2 of the License.
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; specifically version 2 of the License.
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/tests/failtest/failtest.py
+++ b/tests/failtest/failtest.py
@@ -2,7 +2,8 @@
 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; specifically version 2 of the License.
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/tests/sleeptest/sleeptest.py
+++ b/tests/sleeptest/sleeptest.py
@@ -2,7 +2,8 @@
 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; specifically version 2 of the License.
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/tests/synctest/synctest.py
+++ b/tests/synctest/synctest.py
@@ -2,7 +2,8 @@
 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; specifically version 2 of the License.
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/unittests/avocado/settings_unittest.py
+++ b/unittests/avocado/settings_unittest.py
@@ -2,7 +2,8 @@
 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; specifically version 2 of the License.
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/unittests/avocado/sysinfo_unittest.py
+++ b/unittests/avocado/sysinfo_unittest.py
@@ -2,7 +2,8 @@
 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; specifically version 2 of the License.
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/unittests/runtests.py
+++ b/unittests/runtests.py
@@ -3,7 +3,8 @@
 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; specifically version 2 of the License.
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of


### PR DESCRIPTION
I went through all python files in avocado code, and
some changes were made:
- Files entirely written by the current avocado dev
  team were changed to be GPL v2+
- Files with a significant portion of code derived
  from autotest remain GPL v2 strict, and original
  authorship was re-established

Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
