### PR TITLE
plugins.xunit: Add class XmlResult.

### DIFF
--- a/tests/failtest/failtest.py
+++ b/tests/failtest/failtest.py
@@ -26,9 +26,9 @@ class failtest(test.Test):
     Functional test for avocado. Straight up fail the test.
     """
 
-    def action(self, length=1):
+    def action(self):
         """
-        Sleep for length seconds.
+        Should fail.
         """
         raise exceptions.TestFail('This test is supposed to fail')
 


### PR DESCRIPTION
The default output of XML is to standard output, use `--xunit-output` to create a file.
Improvements for using xUnit  in Jenkins (Junit).
Now the actual XML result is handled in class XmlResult.
Also minor fix (cosmetics) in tests.failtest.

Signed-off-by: Ruda Moura rmoura@redhat.com
