### PR TITLE
Add new rule 'build-rpm-all' to the Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ all:
 	@echo "make build-deb-src - Generate a source debian package"
 	@echo "make build-deb-bin - Generate a binary debian package"
 	@echo "make build-deb-all - Generate both source and binary debian packages"
+	@echo "make build-rpm-all - Generate both source and binary RPMs"
 	@echo "make clean - Get rid of scratch and byte files"
 
 source:
@@ -37,8 +38,14 @@ build-deb-all: prepare-source
 	# build both source and binary packages
 	dpkg-buildpackage -i -I -rfakeroot
 
+build-rpm-all: source
+	rpmbuild --define '_topdir %{getenv:PWD}' \
+		 --define '_sourcedir %{_topdir}/dist/' \
+		 --define "avocadoversion $(VERSION)" \
+		 -ba avocado.spec
+
 clean:
 	$(PYTHON) setup.py clean
-	$(MAKE) -f $(CURDIR)/debian/rules clean
-	rm -rf build/ MANIFEST
+	$(MAKE) -f $(CURDIR)/debian/rules clean || true
+	rm -rf build/ MANIFEST BUILD BUILDROOT SPECS RPMS SRPMS
 	find . -name '*.pyc' -delete

--- a/avocado.spec
+++ b/avocado.spec
@@ -1,10 +1,10 @@
 Summary: Avocado Test Framework
 Name: avocado
-Version: 0.0.1
+Version: %{avocadoversion}
 Release: 1%{?dist}
 License: GPLv2
 Group: Development/Tools
-URL: https://github.com/lmr/avocado
+URL: http://avocado-framework.readthedocs.org/
 Source: avocado-%{version}.tar.gz
 BuildRequires: python2-devel
 BuildArch: noarch


### PR DESCRIPTION
Add rule to build both source and binary RPMs.

Signed-off-by: Ruda Moura rmoura@redhat.com
