### PR TITLE
avocado.plugins.manager: Skip loading bad builtin plugins.

### DIFF
--- a/avocado/plugins/manager.py
+++ b/avocado/plugins/manager.py
@@ -68,7 +68,15 @@ class BuiltinPluginManager(PluginManager):
 
     def load_plugins(self):
         for plugin in load_builtins():
-            self.add_plugin(plugin())
+            try:
+                self.add_plugin(plugin())
+            except Exception as err:
+                if hasattr(plugin, 'name'):
+                    name = plugin.name
+                else:
+                    name = str(plugin)
+                log.error("Could not activate builtin plugin '%s': %s",
+                          name, err)
 
 
 class ExternalPluginManager(PluginManager):


### PR DESCRIPTION
Signed-off-by: Ruda Moura rmoura@redhat.com
