### PR TITLE
Add plugin to collect test results as JSON.

### DIFF
--- a/avocado/plugins/builtin.py
+++ b/avocado/plugins/builtin.py
@@ -28,6 +28,7 @@ Builtins = [('avocado.plugins.runner', 'TestLister'),
             ('avocado.plugins.lister', 'PluginsList'),
             ('avocado.plugins.journal', 'Journal'),
             ('avocado.plugins.datadir', 'DataDirList'),
+            ('avocado.plugins.collector', 'Collector'),
             ('avocado.plugins.multiplexer', 'Multiplexer')]
 
 

--- a/avocado/plugins/collector.py
+++ b/avocado/plugins/collector.py
@@ -1,0 +1,95 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2013-2014
+# Author: Ruda Moura <rmoura@redhat.com>
+
+"""
+Collect test results for further usage.
+"""
+
+import json
+
+from avocado.plugins import plugin
+from avocado.result import TestResult
+
+
+class CollectorTestResult(TestResult):
+
+    """
+    Collector TestResult class.
+    """
+
+    def __init__(self, stream=None, debuglog=None, loglevel=None,
+                 urls=[], args=None):
+        TestResult.__init__(self, stream, debuglog, loglevel, urls, args)
+        self.json = {'debuglog': debuglog,
+                     'tests': []}
+        if hasattr(self.args, 'collect_output'):
+            self.filename = self.args.collect_output
+        else:
+            self.filename = '-'
+
+    def start_tests(self):
+        TestResult.start_tests(self)
+        self.stream.start_file_logging(self.debuglog, self.loglevel)
+
+    def end_test(self, test):
+        TestResult.end_test(self, test)
+        self.stream.stop_file_logging()
+        # TODO: do real Test class serialization
+        t = {'test': test.tagged_name,
+             'url': test.name,
+             'time': test.time_elapsed,
+             'status': test.status,
+             }
+        self.json['tests'].append(t)
+        self.json.update({
+            'total': self.tests_total,
+            'pass': len(self.passed),
+            'errors': len(self.errors),
+            'failures': len(self.failed),
+            'skip': len(self.skipped),
+            'time': self.total_time
+        })
+
+    def end_tests(self):
+        TestResult.end_tests(self)
+        self.json = json.dumps(self.json, indent=4)
+        if self.filename is None:
+            print self.json
+        else:
+            with open(self.filename, 'w') as fp:
+                fp.write(self.json)
+
+
+class Collector(plugin.Plugin):
+
+    """
+    Tests results in JSON format.
+    """
+
+    name = 'collector'
+    enabled = True
+
+    def configure(self, app_parser, cmd_parser):
+        self.parser = app_parser
+        app_parser.add_argument('--collect', action='store_true')
+        app_parser.add_argument('--collect-output',
+                                default=None, type=str,
+                                dest='collect_output',
+                                help='the file where the result should be written.'
+                                'Default to print on screen.')
+        self.configured = True
+
+    def activate(self, app_args):
+        if app_args.collect:
+            self.parser.set_defaults(test_result=CollectorTestResult)

--- a/selftests/all/unit/avocado/collector_unittest.py
+++ b/selftests/all/unit/avocado/collector_unittest.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2014
+# Author: Ruda Moura <rmoura@redhat.com>
+
+import unittest
+import os
+import sys
+from tempfile import mkstemp
+import logging
+import json
+
+# simple magic for using scripts within a source tree
+basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+basedir = os.path.dirname(basedir)
+if os.path.isdir(os.path.join(basedir, 'avocado')):
+    sys.path.append(basedir)
+
+from avocado.core import output
+from avocado.core import data_dir
+from avocado.plugins import collector
+from avocado import test
+
+
+class CollectorTest(unittest.TestCase):
+
+    def setUp(self):
+        self.output_manager = output.OutputManager()
+        self.debugdir = data_dir.get_job_logs_dir()
+        self.debuglog = os.path.join(self.debugdir, "debug.log")
+        self.tmpfile = mkstemp()
+        self.test_result = collector.CollectorTestResult(stream=self.output_manager,
+                                                         debuglog=self.debuglog,
+                                                         loglevel=logging.INFO)
+        self.test_result.filename = self.tmpfile[1]
+        self.test_result.start_tests()
+        self.test1 = test.Test()
+        self.test1.status = 'PASS'
+        self.test1.time_elapsed = 1.23
+
+    def tearDown(self):
+        os.close(self.tmpfile[0])
+        os.remove(self.tmpfile[1])
+
+    def testAddSuccess(self):
+        self.test_result.start_test(self.test1)
+        self.test_result.end_test(self.test1)
+        self.test_result.end_tests()
+        self.assertTrue(self.test_result.json)
+        with open(self.test_result.filename) as fp:
+            content = fp.read()
+        j = json.loads(content)
+        self.assertEqual(len(j['tests']), 1)
+        self.assertEqual(j['tests'][0]['status'], 'PASS')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Run Avocado and return the test results as JSON.

Note: This PR is an improved version of collector.py inside the PR #62 with unit test included.

Example:

avocado --collect run 'sleeptest failtest'

<pre>
{
    "tests": [
        {
            "test": "sleeptest.1",
            "url": "sleeptest",
            "status": "PASS",
            "time": 1.200882911682129
        },
        {
            "test": "failtest.1",
            "url": "failtest",
            "status": "FAIL",
            "time": 0.19649291038513184
        }
    ],
    "errors": 0,
    "skip": 0,
    "time": 1.3973758220672607,
    "debuglog": "/home/rmoura/avocado/logs/run-2014-05-15-15.07.46/debug.log",
    "pass": 1,
    "failures": 1,
    "total": 2
}
</pre>

Signed-off-by: Ruda Moura rmoura@redhat.com
