### PR TITLE
avocado.plugins.jsonresult: JSON test result.

### DIFF
--- a/avocado/plugins/builtin.py
+++ b/avocado/plugins/builtin.py
@@ -29,7 +29,7 @@ Builtins = [('avocado.plugins.runner', 'TestLister'),
             ('avocado.plugins.journal', 'Journal'),
             ('avocado.plugins.datadir', 'DataDirList'),
             ('avocado.plugins.multiplexer', 'Multiplexer'),
-            ('avocado.plugins.collector', 'Collector')]
+            ('avocado.plugins.jsonresult', 'JSON')]
 
 
 def load_builtins(set_globals=True):

--- a/selftests/all/unit/avocado/jsonresult_unittest.py
+++ b/selftests/all/unit/avocado/jsonresult_unittest.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2014
+# Author: Ruda Moura <rmoura@redhat.com>
+
+import unittest
+import os
+import sys
+import json
+import argparse
+from tempfile import mkstemp
+
+# simple magic for using scripts within a source tree
+basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+basedir = os.path.dirname(basedir)
+if os.path.isdir(os.path.join(basedir, 'avocado')):
+    sys.path.append(basedir)
+
+from avocado.plugins import jsonresult
+from avocado import test
+
+
+class _Stream(object):
+
+    def start_file_logging(self, param1, param2):
+        pass
+
+    def log_header(self, param):
+        pass
+
+    def stop_file_logging(self):
+        pass
+
+
+class JSONResultTest(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpfile = mkstemp()
+        args = argparse.Namespace(json_output=self.tmpfile[1],
+                                  test_result_debuglog='debuglog',
+                                  test_result_loglevel='loglevel')
+        stream = _Stream()
+        self.test_result = jsonresult.JSONTestResult(stream, args)
+        self.test_result.filename = self.tmpfile[1]
+        self.test_result.start_tests()
+        self.test1 = test.Test()
+        self.test1.status = 'PASS'
+        self.test1.time_elapsed = 1.23
+
+    def tearDown(self):
+        os.close(self.tmpfile[0])
+        os.remove(self.tmpfile[1])
+
+    def testAddSuccess(self):
+        self.test_result.start_test(self.test1)
+        self.test_result.end_test(self.test1)
+        self.test_result.end_tests()
+        self.assertTrue(self.test_result.json)
+        with open(self.test_result.filename) as fp:
+            j = fp.read()
+        obj = json.loads(j)
+        self.assertTrue(obj)
+        self.assertEqual(len(obj['tests']), 1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
JSON test result output plugin, obsoletes avocado.plugins.collector.
Use parameters `--json` and (optionally) `--json-output <filename>`.

Signed-off-by: Ruda Moura rmoura@redhat.com
