### PR TITLE
avocado.core.output: Fix incorrect exception handling in get_paginator()

### DIFF
--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -56,7 +56,7 @@ def get_paginator():
     try:
         less_cmd = process.find_command('less')
         return os.popen('%s -FRSX' % less_cmd, 'w')
-    except ValueError:
+    except process.CmdNotFoundError:
         return sys.stdout
 
 


### PR DESCRIPTION
The actual exception we're throwing in process.find_command
is process.CmdNotFoundError.

Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
