### PR TITLE
avocado.utils.virt: Be quiet if libvirt is not present

### DIFF
--- a/avocado/plugins/vm.py
+++ b/avocado/plugins/vm.py
@@ -250,6 +250,9 @@ class RunVM(plugin.Plugin):
     enabled = True
 
     def configure(self, app_parser, cmd_parser):
+        if virt.virt_capable is False:
+            self.enabled = False
+            return
         username = getpass.getuser()
         self.parser = app_parser
         app_parser.add_argument('--vm', action='store_true', default=False,

--- a/avocado/utils/virt.py
+++ b/avocado/utils/virt.py
@@ -16,7 +16,12 @@
 Module to provide classes for Virtual Machines.
 """
 
-import libvirt
+try:
+    import libvirt
+except ImportError:
+    virt_capable = False
+else:
+    virt_capable = True
 
 from xml.dom import minidom
 from avocado.utils import remote


### PR DESCRIPTION
Avoid message that libvirt is not installed,
just disable the "run_vm plugin" and stop polluting the output.

Signed-off-by: Ruda Moura rmoura@redhat.com
