### PR TITLE
avocado.utils.archive: preserve permissions. when extracting.

### DIFF
--- a/avocado/utils/archive.py
+++ b/avocado/utils/archive.py
@@ -184,6 +184,8 @@ class TarArchive(BaseArchive):
                     with open(filename, 'wb') as outfile:
                         if extracted is not None:
                             shutil.copyfileobj(extracted, outfile)
+                            if not member.issym():
+                                os.chmod(filename, member.mode)
                         else:
                             log.error("Member correspondent to file %s does "
                                       "not seem to be a regular file or a link",

--- a/tests/fiotest/fiotest.py
+++ b/tests/fiotest/fiotest.py
@@ -42,13 +42,10 @@ class fiotest(test.Test):
         """
         Build 'fio'.
         """
-        self.cwd = os.getcwd()
         tarball_path = self.get_deps_path(self.params.fio_tarball)
         archive.extract(tarball_path, self.srcdir)
         fio_version = self.params.fio_tarball.split('.tar.')[0]
         self.srcdir = os.path.join(self.srcdir, fio_version)
-        cmd = ('chmod +x %s' % os.path.join(self.srcdir, 'configure'))
-        process.system(cmd)
         build.make(self.srcdir)
 
     def action(self):
@@ -58,7 +55,6 @@ class fiotest(test.Test):
         os.chdir(self.srcdir)
         cmd = ('./fio %s' % self.get_deps_path(self.params.fio_job))
         process.system(cmd)
-        os.chdir(self.cwd)
 
 
 if __name__ == "__main__":

--- a/tests/trinity/trinity.py
+++ b/tests/trinity/trinity.py
@@ -64,7 +64,6 @@ class trinity(test.Test):
         archive.extract(tarball_path, self.srcdir)
         self.srcdir = os.path.join(self.srcdir, 'trinity-1.4')
         os.chdir(self.srcdir)
-        process.run('chmod +x configure.sh')
         process.run('./configure.sh')
         build.make(self.srcdir)
         self.populate_dir()


### PR DESCRIPTION
Preserve file permissions when extracting data from tarballs,
so in some tests we have we don't need to set permissions too.

Not that I'm happy with this module, needs further refactoring.

Signed-off-by: Ruda Moura rmoura@redhat.com
