### PR TITLE
avocado.test: export environment variables to tests.

### DIFF
--- a/avocado/test.py
+++ b/avocado/test.py
@@ -31,6 +31,7 @@ from avocado.utils import path
 from avocado.utils import process
 from avocado.utils.params import Params
 from avocado import sysinfo
+from avocado.version import VERSION
 
 log = logging.getLogger("avocado.test")
 
@@ -335,12 +336,24 @@ class Test(unittest.TestCase):
         self.status = 'PASS'
         self.sysinfo_logger.end_test_hook()
 
+    def _setup_environment_variables(self):
+        os.environ['AVOCADO_VERSION'] = VERSION
+        os.environ['AVOCADO_TEST_BASEDIR'] = self.basedir
+        os.environ['AVOCADO_TEST_DATADIR'] = self.datadir
+        os.environ['AVOCADO_TEST_WORKDIR'] = self.workdir
+        os.environ['AVOCADO_TEST_SRCDIR'] = self.srcdir
+        os.environ['AVOCADO_TEST_LOGDIR'] = self.logdir
+        os.environ['AVOCADO_TEST_LOGFILE'] = self.logfile
+        os.environ['AVOCADO_TEST_OUTPUTDIR'] = self.outputdir
+        os.environ['AVOCADO_TEST_SYSINFODIR'] = self.sysinfodir
+
     def run_avocado(self, result=None):
         """
         Wraps the runTest metod, for execution inside the avocado runner.
 
         :result: Unused param, compatibiltiy with :class:`unittest.TestCase`.
         """
+        self._setup_environment_variables()
         start_time = time.time()
         try:
             self.runTest(result)

--- a/selftests/all/functional/avocado/export_variables_tests.py
+++ b/selftests/all/functional/avocado/export_variables_tests.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2014
+# Author: Ruda Moura <rmoura@redhat.com>
+
+import os
+import sys
+import shutil
+import tempfile
+import unittest
+
+# simple magic for using scripts within a source tree
+basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..', '..', '..')
+basedir = os.path.abspath(basedir)
+if os.path.isdir(os.path.join(basedir, 'avocado')):
+    sys.path.append(basedir)
+
+from avocado.version import VERSION
+from avocado.utils import process
+
+SCRIPT_CONTENT = """#!/bin/sh
+echo "Avocado Version: $AVOCADO_VERSION"
+echo "Avocado Test basedir: $AVOCADO_TEST_BASEDIR"
+echo "Avocado Test datadir: $AVOCADO_TEST_DATADIR"
+echo "Avocado Test workdir: $AVOCADO_TEST_WORKDIR"
+echo "Avocado Test srcdir: $AVOCADO_TEST_SRCDIR"
+echo "Avocado Test logdir: $AVOCADO_TEST_LOGDIR"
+echo "Avocado Test logfile: $AVOCADO_TEST_LOGFILE"
+echo "Avocado Test outputdir: $AVOCADO_TEST_OUTPUTDIR"
+echo "Avocado Test sysinfodir: $AVOCADO_TEST_SYSINFODIR"
+
+test "$AVOCADO_VERSION" = "{version}" -a \
+     -d "$AVOCADO_TEST_BASEDIR" -a \
+     -d "$AVOCADO_TEST_WORKDIR" -a \
+     -d "$AVOCADO_TEST_SRCDIR" -a \
+     -d "$AVOCADO_TEST_LOGDIR" -a \
+     -f "$AVOCADO_TEST_LOGFILE" -a \
+     -d "$AVOCADO_TEST_OUTPUTDIR" -a \
+     -d "$AVOCADO_TEST_SYSINFODIR"
+""".format(version=VERSION)
+
+
+class EnvironmentVariablesTest(unittest.TestCase):
+
+    def setUp(self):
+        self.base_logdir = tempfile.mkdtemp(prefix='avocado_env_vars_functional')
+        self.script = os.path.join(self.base_logdir, 'version.sh')
+        with open(self.script, 'w') as script_obj:
+            script_obj.write(SCRIPT_CONTENT)
+        os.chmod(self.script, 0775)
+
+    def test_environment_vars(self):
+        os.chdir(basedir)
+        cmd_line = './scripts/avocado run %s' % self.script
+        result = process.run(cmd_line, ignore_status=True)
+        expected_rc = 0
+        self.assertEqual(result.exit_status, expected_rc,
+                         "Avocado did not return rc %d:\n%s" %
+                         (expected_rc, result))
+
+    def tearDown(self):
+        if os.path.isdir(self.base_logdir):
+            shutil.rmtree(self.base_logdir, ignore_errors=True)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Export environment variables to the running test.
Really effective when using drop-in tests, that can make use of shell
variables "AVOCADO_*".

Example:

Export variable AVOCADO_VERSION with the current version of Avocado,
then the drop-in test can use $AVOCADO_VERSION within, and so on.

For the script above:

<pre>
#!/bin/sh
echo "Avocado Version $AVOCADO_VERSION"
echo "Avocado Test basedir $AVOCADO_TEST_BASEDIR"
echo "Avocado Test datadir $AVOCADO_TEST_DATADIR"
echo "Avocado Test workdir $AVOCADO_TEST_WORKDIR"
echo "Avocado Test srcdir $AVOCADO_TEST_SRCDIR"
echo "Avocado Test logdir $AVOCADO_TEST_LOGDIR"
echo "Avocado Test logfile $AVOCADO_TEST_LOGFILE"
echo "Avocado Test outputdir $AVOCADO_TEST_OUTPUTDIR"
echo "Avocado Test sysinfodir $AVOCADO_TEST_SYSINFODIR"
</pre>


The expected output is:

<pre>
...
21:12:30 process    L0123 INFO | Running '/home/rmoura/test_avocado_variables.sh'
21:12:30 process    L0173 DEBUG| [stdout] Avocado Version 0.8.0
21:12:30 process    L0173 DEBUG| [stdout] Avocado Test basedir /home/rmoura/Work/avocado.git/avocado
21:12:30 process    L0173 DEBUG| [stdout] Avocado Test datadir /home/rmoura/Work/avocado.git/avocado/test_avocado_variables.sh.data
21:12:30 process    L0173 DEBUG| [stdout] Avocado Test workdir /var/tmp/avocado/test_avocado_variables.sh
21:12:30 process    L0173 DEBUG| [stdout] Avocado Test srcdir /var/tmp/avocado/test_avocado_variables.sh/src
21:12:30 process    L0173 DEBUG| [stdout] Avocado Test logdir /home/rmoura/avocado/logs/run-2014-08-04-21.12.30/home.rmoura.test_avocado_variables.sh.1
21:12:30 process    L0173 DEBUG| [stdout] Avocado Test logfile /home/rmoura/avocado/logs/run-2014-08-04-21.12.30/home.rmoura.test_avocado_variables.sh.1/debug.log
21:12:30 process    L0173 DEBUG| [stdout] Avocado Test outputdir /home/rmoura/avocado/logs/run-2014-08-04-21.12.30/home.rmoura.test_avocado_variables.sh.1/data
21:12:30 process    L0173 DEBUG| [stdout] Avocado Test sysinfodir /home/rmoura/avocado/logs/run-2014-08-04-21.12.30/home.rmoura.test_avocado_variables.sh.1/sysinfo
...
</pre>


<pre>
</pre>


Signed-off-by: Ruda Moura rmoura@redhat.com
