### PR TITLE
avocado.plugins: Simplify commands --xunit/--json.

### DIFF
--- a/avocado/plugins/jsonresult.py
+++ b/avocado/plugins/jsonresult.py
@@ -93,12 +93,12 @@ class JSON(plugin.Plugin):
 
     def configure(self, app_parser, cmd_parser):
         self.parser = app_parser
-        self.parser.add_argument('--json', action='store_true', default=False)
-        self.parser.add_argument('--json-output', default='-', type=str,
+        self.parser.add_argument('--json', type=str,
                                  dest='json_output',
-                                 help='the file where the result should be written')
+                                 help='Enable JSON output to the file where the result should be written.'
+                                      "Use '-' to redirect to the standard output.")
         self.configured = True
 
     def activate(self, app_args):
-        if app_args.json:
+        if app_args.json_output:
             self.parser.set_defaults(json_result=JSONTestResult)

--- a/avocado/plugins/xunit.py
+++ b/avocado/plugins/xunit.py
@@ -229,13 +229,12 @@ class XUnit(plugin.Plugin):
 
     def configure(self, app_parser, cmd_parser):
         self.parser = app_parser
-        app_parser.add_argument('--xunit', action='store_true')
-        app_parser.add_argument('--xunit-output',
-                                default='-', type=str,
+        app_parser.add_argument('--xunit', type=str,
                                 dest='xunit_output',
-                                help='the file where the result should be written')
+                                help=('Enable xUnit output to the file where the result should be written.'
+                                      "Use '-' to redirect to the standard output."))
         self.configured = True
 
     def activate(self, app_args):
-        if app_args.xunit:
+        if app_args.xunit_output:
             self.parser.set_defaults(xunit_result=xUnitTestResult)

--- a/docs/source/OutputPlugins.rst
+++ b/docs/source/OutputPlugins.rst
@@ -18,7 +18,7 @@ avocado is interested in produce are:
 As an example of human readable output, we have the dots that python unittests
 print while executing tests::
 
-    $ unittests/avocado/test_unittest.py 
+    $ unittests/avocado/test_unittest.py
     ss..........
     ----------------------------------------------------------------------
     Ran 12 tests in 1.243s
@@ -53,7 +53,7 @@ automation projects, such as `jenkins <http://jenkins-ci.org/>`__. If you want
 to make avocado to generate xunit output in the standard output of the runner,
 simply use::
 
-    $ scripts/avocado --xunit run "sleeptest failtest synctest"
+    $ scripts/avocado --xunit - run "sleeptest failtest synctest"
     <?xml version="1.0" encoding="UTF-8"?>
     <testsuite name="avocado" tests="3" errors="0" failures="1" skip="0" time="2.88632893562" timestamp="2014-04-24 18:25:39.545588">
         <testcase classname="sleeptest" name="sleeptest.1" time="1.10091400146"/>
@@ -62,6 +62,9 @@ simply use::
         </testcase>
         <testcase classname="synctest" name="synctest.1" time="1.69329714775"/>
 
+Note the dash `-` in the option `--xunit`, it means that the output
+goes through the standard output.
+
 Machine readable output - json
 ------------------------------
 
@@ -69,8 +72,11 @@ Machine readable output - json
 json avocado plugin outputs job information, similarly to the xunit output
 plugin::
 
-    $ scripts/avocado --json run "sleeptest failtest synctest"
+    $ scripts/avocado --json - run "sleeptest failtest synctest"
     {"tests": [{"test": "sleeptest.1", "url": "sleeptest", "status": "PASS", "time": 1.4282619953155518}, {"test": "failtest.1", "url": "failtest", "status": "FAIL", "time": 0.34017300605773926}, {"test": "synctest.1", "url": "synctest", "status": "PASS", "time": 2.109131097793579}], "errors": 0, "skip": 0, "time": 3.87756609916687, "debuglog": "/home/lmr/avocado/logs/run-2014-06-11-01.35.15/debug.log", "pass": 2, "failures": 1, "total": 3}
+
+Note the dash `-` in the option `--json`, it means that the output
+goes through the standard output.
 
 Multiple output plugins
 -----------------------
@@ -79,7 +85,7 @@ You can enable multiple output plugins at once, as long as only one of them
 uses the standard output. For example, it is fine to use the xunit plugin on
 stdout and the JSON plugin to output to a file::
 
-    $ scripts/avocado --xunit --json --json-output /tmp/result.json run "sleeptest synctest"
+    $ scripts/avocado --xunit - --json /tmp/result.json run "sleeptest synctest"
     <?xml version="1.0" encoding="UTF-8"?>
     <testsuite name="avocado" tests="2" errors="0" failures="0" skip="0" time="3.21392536163" timestamp="2014-06-11 01:49:35.858187">
         <testcase classname="sleeptest" name="sleeptest.1" time="1.34533214569"/>
@@ -89,10 +95,10 @@ stdout and the JSON plugin to output to a file::
     $ cat /tmp/result.json
     {"tests": [{"test": "sleeptest.1", "url": "sleeptest", "status": "PASS", "time": 1.345332145690918}, {"test": "synctest.1", "url": "synctest", "status": "PASS", "time": 1.8685932159423828}], "errors": 0, "skip": 0, "time": 3.213925361633301, "debuglog": "/home/lmr/avocado/logs/run-2014-06-11-01.49.35/debug.log", "pass": 2, "failures": 0, "total": 2}
 
-But you won't be able to do the same without the --json-output flag passed to
+But you won't be able to do the same without the --json flag passed to
 the program::
 
-    $ scripts/avocado --xunit --json run "sleeptest synctest"
+    $ scripts/avocado --xunit - --json - run "sleeptest synctest"
     Avocado could not set --json and --xunit both to output to stdout.
     Please set the output flag of one of them to a file to avoid conflicts.
 

--- a/selftests/all/functional/avocado/basic_tests.py
+++ b/selftests/all/functional/avocado/basic_tests.py
@@ -72,7 +72,7 @@ class RunnerOperationTest(unittest.TestCase):
 
     def test_runner_doublefail(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado --xunit run doublefail'
+        cmd_line = './scripts/avocado --xunit - run doublefail'
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout
         expected_rc = 1
@@ -89,7 +89,7 @@ class RunnerOperationTest(unittest.TestCase):
 
     def test_runner_timeout(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado --xunit run timeouttest'
+        cmd_line = './scripts/avocado --xunit - run timeouttest'
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout
         expected_rc = 1
@@ -104,7 +104,7 @@ class RunnerOperationTest(unittest.TestCase):
 
     def test_runner_abort(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado --xunit run abort'
+        cmd_line = './scripts/avocado --xunit - run abort'
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 1
         unexpected_rc = 3
@@ -181,7 +181,7 @@ class PluginsXunitTest(PluginsSysinfoTest):
     def run_and_check(self, testname, e_rc, e_ntests, e_nerrors,
                       e_nfailures, e_nskip):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado --xunit run %s' % testname
+        cmd_line = './scripts/avocado --xunit - run %s' % testname
         result = process.run(cmd_line, ignore_status=True)
         xml_output = result.stdout
         self.assertEqual(result.exit_status, e_rc,
@@ -247,7 +247,7 @@ class PluginsJSONTest(PluginsSysinfoTest):
     def run_and_check(self, testname, e_rc, e_ntests, e_nerrors,
                       e_nfailures, e_nskip):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado --json run --archive %s' % testname
+        cmd_line = './scripts/avocado --json - run --archive %s' % testname
         result = process.run(cmd_line, ignore_status=True)
         json_output = result.stdout
         self.assertEqual(result.exit_status, e_rc,

--- a/selftests/all/functional/avocado/output_tests.py
+++ b/selftests/all/functional/avocado/output_tests.py
@@ -61,7 +61,7 @@ class OutputPluginTest(unittest.TestCase):
 
     def test_output_incompatible_setup(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado --xunit --json run sleeptest'
+        cmd_line = './scripts/avocado --xunit - --json - run sleeptest'
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 2
         output = result.stdout + result.stderr
@@ -74,7 +74,7 @@ class OutputPluginTest(unittest.TestCase):
 
     def test_output_incompatible_setup_2(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado --vm --json run sleeptest'
+        cmd_line = './scripts/avocado --vm --json - run sleeptest'
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 2
         output = result.stdout + result.stderr
@@ -88,7 +88,7 @@ class OutputPluginTest(unittest.TestCase):
     def test_output_compatible_setup(self):
         tmpfile = tempfile.mktemp()
         os.chdir(basedir)
-        cmd_line = './scripts/avocado --journal --xunit --xunit-output %s --json run sleeptest' % tmpfile
+        cmd_line = './scripts/avocado --journal --xunit %s --json - run sleeptest' % tmpfile
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout + result.stderr
         expected_rc = 0
@@ -108,7 +108,7 @@ class OutputPluginTest(unittest.TestCase):
     def test_output_compatible_setup_2(self):
         tmpfile = tempfile.mktemp()
         os.chdir(basedir)
-        cmd_line = './scripts/avocado --xunit --json --json-output %s run sleeptest' % tmpfile
+        cmd_line = './scripts/avocado --xunit - --json %s run sleeptest' % tmpfile
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout + result.stderr
         expected_rc = 0
@@ -132,7 +132,7 @@ class OutputPluginTest(unittest.TestCase):
         tmpfile = tempfile.mktemp()
         tmpfile2 = tempfile.mktemp()
         os.chdir(basedir)
-        cmd_line = './scripts/avocado --xunit --xunit-output %s --json --json-output %s run sleeptest' % (tmpfile, tmpfile2)
+        cmd_line = './scripts/avocado --xunit %s --json %s run sleeptest' % (tmpfile, tmpfile2)
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout + result.stderr
         expected_rc = 0


### PR DESCRIPTION
Simplify commands for xUnit and JSON output plugins:
- Remove options --xunit-output and --json-output.
- Use '-' to stdout or filename to options --xunit and --json.

Usage examples:

```
avocado --xunit - run sleeptest  # goes to stdout
avocado --xunit /tmp/foo.xml run sleeptest
avocado --xunit - --json /tmp/foo.json run sleeptest.
```

Signed-off-by: Ruda Moura rmoura@redhat.com
