### PR TITLE
avocado: Fix renamed attribute from avocado.core.output

### DIFF
--- a/avocado/plugins/datadir.py
+++ b/avocado/plugins/datadir.py
@@ -33,7 +33,7 @@ class DataDirList(plugin.Plugin):
         self.configured = True
 
     def list_data_dirs(self, args):
-        bcolors = output.colors
+        bcolors = output.term_support
         pipe = output.get_paginator()
         pipe.write(bcolors.header_str('Avocado Data Directories:'))
         pipe.write('\n    base dir:        ' + data_dir.get_base_dir())

--- a/avocado/plugins/lister.py
+++ b/avocado/plugins/lister.py
@@ -33,7 +33,7 @@ class PluginsList(plugin.Plugin):
         self.configured = True
 
     def list_plugins(self, args):
-        bcolors = output.colors
+        bcolors = output.term_support
         pipe = output.get_paginator()
         pm = get_plugin_manager()
         pipe.write(bcolors.header_str('Plugins loaded:'))

--- a/avocado/plugins/runner.py
+++ b/avocado/plugins/runner.py
@@ -52,7 +52,7 @@ class TestLister(plugin.Plugin):
 
         :param args: Command line args received from the list subparser.
         """
-        bcolors = output.colors
+        bcolors = output.term_support
         pipe = output.get_paginator()
         test_files = os.listdir(data_dir.get_test_dir())
         test_dirs = []


### PR DESCRIPTION
The reference was incorrect, causing some of the plugins
to crash.

Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
