### PR TITLE
Interrupt fixes

### DIFF
--- a/avocado/job.py
+++ b/avocado/job.py
@@ -459,6 +459,11 @@ class Job(object):
             self.output_manager.log_fail_header(str(details))
             return error_codes.numeric_status['AVOCADO_JOB_FAIL']
         except KeyboardInterrupt:
+            # Sometimes, the children won't stop right away and a second
+            # Ctrl+C will trigger an error in exit functions of the
+            # multiprocess module. We'll have to be merciless and send -9
+            for child in multiprocessing.active_children():
+                os.kill(child.pid, signal.SIGKILL)
             self.output_manager.log_header('\n')
             self.output_manager.log_header('Interrupted by user request')
             sys.exit(error_codes.numeric_status['AVOCADO_JOB_INTERRUPTED'])

--- a/selftests/all/functional/avocado/basic_tests.py
+++ b/selftests/all/functional/avocado/basic_tests.py
@@ -125,6 +125,25 @@ class RunnerOperationTest(unittest.TestCase):
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %d:\n%s" % (expected_rc, result))
 
+    def test_runner_interrupt(self):
+        os.chdir(basedir)
+        cmd_line = './scripts/avocado run sleeptenmin'
+        sp = process.SubProcess(cmd_line)
+        # Let it run for 3 seconds, then send a SIGINT
+        # (translates to KeyboardInterrupt, that should kill any sp lying around)
+        sp.wait(timeout=3, sig=signal.SIGINT)
+        result = sp.result
+        output = result.stdout + result.stderr
+        expected_rc = 4
+        unexpected_rc = 3
+        self.assertNotEqual(result.exit_status, unexpected_rc,
+                            "Avocado crashed (rc %d):\n%s" % (unexpected_rc, result))
+        self.assertEqual(result.exit_status, expected_rc,
+                         "Avocado did not return rc %d:\n%s" % (expected_rc, result))
+        self.assertIn("Interrupted by user request", output,
+                      "Avocado did not display interruption message. "
+                      "Output:\n%s" % output)
+
 
 class RunnerDropinTest(unittest.TestCase):
 


### PR DESCRIPTION
Better handling of Crtl +C inside avocado. Tested on VMs, virtual envs and ssh connections.
