### PR TITLE
New feature: silent (human) test result.

### DIFF
--- a/avocado/job.py
+++ b/avocado/job.py
@@ -340,8 +340,12 @@ class Job(object):
         self.result_proxy.add_output_plugin(json_plugin)
 
         # If there are no active output plugins besides xunit and json,
-        # set up the human output.
-        if len(self.result_proxy.output_plugins) == 2:
+        # and the option --silent is not present, then set up the human output.
+        if hasattr(self.args, 'silent') and self.args.silent:
+            human = False
+        else:
+            human = True
+        if len(self.result_proxy.output_plugins) == 2 and human:
             human_plugin = result.HumanTestResult(self.output_manager, self.args)
             self.result_proxy.add_output_plugin(human_plugin)
 

--- a/avocado/plugins/builtin.py
+++ b/avocado/plugins/builtin.py
@@ -24,6 +24,7 @@ __all__ = ['load_builtins']
 Builtins = [('avocado.plugins.runner', 'TestLister'),
             ('avocado.plugins.runner', 'SystemInformation'),
             ('avocado.plugins.runner', 'TestRunner'),
+            ('avocado.plugins.silentresult', 'Silent'),
             ('avocado.plugins.xunit', 'XUnit'),
             ('avocado.plugins.lister', 'PluginsList'),
             ('avocado.plugins.journal', 'Journal'),

--- a/avocado/plugins/silentresult.py
+++ b/avocado/plugins/silentresult.py
@@ -1,0 +1,36 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2014
+# Author: Ruda Moura <rmoura@redhat.com>
+
+"""
+Silent output module.
+"""
+
+import json
+
+from avocado.plugins import plugin
+
+
+class Silent(plugin.Plugin):
+
+    """
+    Silent output plugin.
+    """
+
+    name = 'silent_output'
+    enabled = True
+
+    def configure(self, app_parser, cmd_parser):
+        self.parser = app_parser
+        self.parser.add_argument('--silent', action='store_true', default=False)
+        self.configured = True

--- a/docs/source/OutputPlugins.rst
+++ b/docs/source/OutputPlugins.rst
@@ -79,6 +79,19 @@ plugin::
 Note the dash `-` in the option `--json`, it means that the output
 goes through the standard output.
 
+Silent output
+-------------
+
+If you are not interested in output, you can suppress it by using
+the command line option `--silent`. The tests will be performed as expected,
+with logs being created, but the human output will not be displayed.
+
+Example::
+
+    $ scripts/avocado --silent run failtest
+    $ echo $?
+    1
+
 Multiple output plugins
 -----------------------
 

--- a/selftests/all/functional/avocado/basic_tests.py
+++ b/selftests/all/functional/avocado/basic_tests.py
@@ -144,6 +144,16 @@ class RunnerOperationTest(unittest.TestCase):
                       "Avocado did not display interruption message. "
                       "Output:\n%s" % output)
 
+    def test_silent_output(self):
+        os.chdir(basedir)
+        cmd_line = './scripts/avocado --silent run sleeptest'
+        result = process.run(cmd_line, ignore_status=True)
+        expected_rc = 0
+        expected_output = ''
+        print repr(result.stdout)
+        self.assertEqual(result.exit_status, expected_rc)
+        self.assertEqual(result.stderr, expected_output)
+
 
 class RunnerDropinTest(unittest.TestCase):
 


### PR DESCRIPTION
Implement new option --silent, to mute the human test result.
It has no effect with --json or --xunit options.

Example:

$ avocado --silent run failtest
$ echo $?
$ 1

Signed-off-by: Ruda Moura rmoura@redhat.com
