### PR TITLE
avocado.job: Give an error message on an empty test list

### DIFF
--- a/avocado/job.py
+++ b/avocado/job.py
@@ -399,6 +399,10 @@ class Job(object):
                 e_msg = "Empty test ID. A test path or alias must be provided"
                 raise exceptions.OptionValidationError(e_msg)
 
+        if not params_list:
+            e_msg = "Empty test ID. A test path or alias must be provided"
+            raise exceptions.OptionValidationError(e_msg)
+
         if self.args is not None:
             self.args.test_result_total = len(params_list)
 

--- a/selftests/all/functional/avocado/basic_tests.py
+++ b/selftests/all/functional/avocado/basic_tests.py
@@ -150,9 +150,17 @@ class RunnerOperationTest(unittest.TestCase):
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 0
         expected_output = ''
-        print repr(result.stdout)
         self.assertEqual(result.exit_status, expected_rc)
         self.assertEqual(result.stderr, expected_output)
+
+    def test_empty_test_list(self):
+        os.chdir(basedir)
+        cmd_line = './scripts/avocado run'
+        result = process.run(cmd_line, ignore_status=True)
+        expected_rc = 2
+        expected_output = 'Empty test ID. A test path or alias must be provided'
+        self.assertEqual(result.exit_status, expected_rc)
+        self.assertIn(expected_output, result.stderr)
 
 
 class RunnerDropinTest(unittest.TestCase):


### PR DESCRIPTION
If an empty list of tests was passed, give an error validation
message and exit. Provide a functional test for it.

Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
