### PR TITLE
Job main loop: functional tests timing

### DIFF
--- a/selftests/all/functional/avocado/basic_tests.py
+++ b/selftests/all/functional/avocado/basic_tests.py
@@ -208,9 +208,9 @@ class RunnerDropinTest(unittest.TestCase):
     def test_runner_onehundred_fail_timing(self):
         """
         We can be pretty sure that a failtest should return immediattely. Let's
-        run 100 of them and assure they not take more than 2 seconds to run.
+        run 100 of them and assure they not take more than 3 seconds to run.
 
-        Notice: on a current machine this takes about 0.12s, so 2 second is
+        Notice: on a current machine this takes about 0.12s, so 3 second is
         pretty safe here.
         """
         os.chdir(basedir)
@@ -219,7 +219,7 @@ class RunnerDropinTest(unittest.TestCase):
         initial_time = time.time()
         result = process.run(cmd_line, ignore_status=True)
         actual_time = time.time() - initial_time
-        self.assertLess(actual_time, 2.0)
+        self.assertLess(actual_time, 3.0)
         expected_rc = 1
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %d:\n%s" % (expected_rc, result))
@@ -235,7 +235,7 @@ class RunnerDropinTest(unittest.TestCase):
         initial_time = time.time()
         result = process.run(cmd_line, ignore_status=True)
         actual_time = time.time() - initial_time
-        self.assertLess(actual_time, 4.0)
+        self.assertLess(actual_time, 6.0)
         expected_rc = 1
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %d:\n%s" % (expected_rc, result))


### PR DESCRIPTION
Looks like test bots, such as travis, can have very little resources
at times and run things really slowly, example:

```
======================================================================
FAIL: Sleeptest is supposed to take 1 second, let's make a sandwich of
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/build/avocado-framework/avocado/selftests/all/
functional/avocado/basic_tests.py", line 238, in test_runner_sleep_fail_sleep_timing
    self.assertLess(actual_time, 4.0)
AssertionError: 4.036144018173218 not less than 4.0
```

Let's increase the maximum expected times.

Signed-off-by: Cleber Rosa crosa@redhat.com
