### PR TITLE
setup.py: add missing !#/bin/env python header

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+#!/bin/env python
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or


### PR DESCRIPTION
Without it, setup.py is interpreted as a bash script.
