### PR TITLE
avocado.test: Use job.unique_id to build temporary path.

### DIFF
--- a/avocado/test.py
+++ b/avocado/test.py
@@ -24,6 +24,7 @@ import sys
 import time
 import traceback
 import unittest
+import tempfile
 
 from avocado.core import data_dir
 from avocado.core import exceptions
@@ -120,9 +121,15 @@ class Test(unittest.TestCase):
 
         basename = os.path.basename(self.name)
 
+        if job is not None:
+            tmpdir = tempfile.mkdtemp(dir=data_dir.get_tmp_dir(),
+                                      prefix='job-%s-' % job.unique_id)
+        else:
+            tmpdir = tempfile.mkdtemp(dir=data_dir.get_tmp_dir())
+
         self.basedir = os.path.dirname(inspect.getfile(self.__class__))
         self.datadir = os.path.join(self.basedir, '%s.data' % basename)
-        self.workdir = path.init_dir(data_dir.get_tmp_dir(), basename)
+        self.workdir = path.init_dir(tmpdir, basename)
         self.srcdir = path.init_dir(self.workdir, 'src')
         if base_logdir is None:
             base_logdir = data_dir.get_job_logs_dir()


### PR DESCRIPTION
if job.unique_id is available in test, use this information to build the temporary path used in attribute workdir. The template format is `$TMP/job-<job_unique_id>-<random>`.

Here's an example:

<pre>
$ ./scripts/avocado run tests/synctest.py tests/sleeptest.py --keep-tmp-files
...
$ find /var/tmp/avocado
/var/tmp/avocado
/var/tmp/avocado/job-d7c3acdcabc184990dfa90b69c313a19e12c2c31-gmwbDg
/var/tmp/avocado/job-d7c3acdcabc184990dfa90b69c313a19e12c2c31-gmwbDg/synctest.py
/var/tmp/avocado/job-d7c3acdcabc184990dfa90b69c313a19e12c2c31-gmwbDg/synctest.py/src
/var/tmp/avocado/job-d7c3acdcabc184990dfa90b69c313a19e12c2c31-gmwbDg/synctest.py/src/synctest
/var/tmp/avocado/job-d7c3acdcabc184990dfa90b69c313a19e12c2c31-gmwbDg/synctest.py/src/synctest/synctest
/var/tmp/avocado/job-d7c3acdcabc184990dfa90b69c313a19e12c2c31-gmwbDg/synctest.py/src/synctest/synctest.c
/var/tmp/avocado/job-d7c3acdcabc184990dfa90b69c313a19e12c2c31-gmwbDg/synctest.py/src/synctest/Makefile
/var/tmp/avocado/job-d7c3acdcabc184990dfa90b69c313a19e12c2c31-tZG3kV
/var/tmp/avocado/job-d7c3acdcabc184990dfa90b69c313a19e12c2c31-tZG3kV/sleeptest.py
/var/tmp/avocado/job-d7c3acdcabc184990dfa90b69c313a19e12c2c31-tZG3kV/sleeptest.py/src
</pre>


Signed-off-by: Ruda Moura rmoura@redhat.com
