### PR TITLE
avocado.plugins: Fix bug 'Namespace' object has no attribute

### DIFF
--- a/avocado/plugins/journal.py
+++ b/avocado/plugins/journal.py
@@ -134,5 +134,8 @@ class Journal(plugin.Plugin):
         self.configured = True
 
     def activate(self, args):
-        if args.journal:
-            self.parser.application.set_defaults(journal_result=TestResultJournal)
+        try:
+            if args.journal:
+                self.parser.application.set_defaults(journal_result=TestResultJournal)
+        except AttributeError:
+            pass

--- a/avocado/plugins/jsonresult.py
+++ b/avocado/plugins/jsonresult.py
@@ -104,5 +104,8 @@ class JSON(plugin.Plugin):
         self.configured = True
 
     def activate(self, app_args):
-        if app_args.json_output:
-            self.parser.application.set_defaults(json_result=JSONTestResult)
+        try:
+            if app_args.json_output:
+                self.parser.application.set_defaults(json_result=JSONTestResult)
+        except AttributeError:
+            pass

--- a/avocado/plugins/vm.py
+++ b/avocado/plugins/vm.py
@@ -322,6 +322,9 @@ class RunVM(plugin.Plugin):
         self.configured = True
 
     def activate(self, app_args):
-        if app_args.vm:
-            self.parser.set_defaults(vm_result=VMTestResult,
-                                     test_runner=VMTestRunner)
+        try:
+            if app_args.vm:
+                self.parser.set_defaults(vm_result=VMTestResult,
+                                         test_runner=VMTestRunner)
+        except AttributeError:
+            pass

--- a/avocado/plugins/xunit.py
+++ b/avocado/plugins/xunit.py
@@ -240,5 +240,8 @@ class XUnit(plugin.Plugin):
         self.configured = True
 
     def activate(self, app_args):
-        if app_args.xunit_output:
-            self.parser.application.set_defaults(xunit_result=xUnitTestResult)
+        try:
+            if app_args.xunit_output:
+                self.parser.application.set_defaults(xunit_result=xUnitTestResult)
+        except AttributeError:
+            pass

--- a/selftests/all/functional/avocado/basic_tests.py
+++ b/selftests/all/functional/avocado/basic_tests.py
@@ -352,6 +352,17 @@ class PluginsTest(unittest.TestCase):
                          (expected_rc, result))
         self.assertNotIn('Disabled', output)
 
+    def test_Namespace_object_has_no_attribute(self):
+        os.chdir(basedir)
+        cmd_line = './scripts/avocado plugins'
+        result = process.run(cmd_line, ignore_status=True)
+        output = result.stderr
+        expected_rc = 0
+        self.assertEqual(result.exit_status, expected_rc,
+                         "Avocado did not return rc %d:\n%s" %
+                         (expected_rc, result))
+        self.assertNotIn("'Namespace' object has no attribute", output)
+
 
 class ParseXMLError(Exception):
     pass


### PR DESCRIPTION
Fix problem when running Avocado with subcommand other than run:

<pre>
$ avocado plugins
Could not activate plugin 'run_vm': 'Namespace' object has no attribute 'vm'
Could not activate plugin 'json': 'Namespace' object has no attribute 'json_output'
Could not activate plugin 'xunit': 'Namespace' object has no attribute 'xunit_output'
Could not activate plugin 'journal': 'Namespace' object has no attribute 'journal'
Plugins loaded:
    datadir      - Implements the avocado 'datadir' subcommand (Enabled)
    json         - JSON output (Enabled)
    journal      - Test journal (Enabled)
    multiplexer  - Implements the avocado 'multiplex' subcommand. (Enabled)
    plugins_list - Implements the avocado 'plugins' subcommand (Enabled)
    run_vm       - Run tests on a Virtual Machine (Enabled)
    sysinfo      - Collect system information (Enabled)
    test_lister  - Implements the avocado 'list' subcommand (Enabled)
    test_runner  - Implements the avocado 'run' subcommand (Enabled)
    xunit        - xUnit output. (Enabled)
</pre>


Signed-off-by: Ruda Moura rmoura@redhat.com
