### PR TITLE
Makefile: Add 'make check'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,3 +47,6 @@ clean:
 	$(MAKE) -f $(CURDIR)/debian/rules clean || true
 	rm -rf build/ MANIFEST BUILD BUILDROOT SPECS RPMS SRPMS SOURCES
 	find . -name '*.pyc' -delete
+
+check:
+	selftests/checkall

--- a/selftests/checkall
+++ b/selftests/checkall
@@ -1,0 +1,18 @@
+#!/bin/bash
+run_rc() {
+    echo "Running '$1'"
+    $1
+}
+run_rc 'inspekt lint'
+rc1=$?
+echo ""
+run_rc 'inspekt indent'
+rc2=$?
+echo ""
+run_rc 'inspekt style'
+rc3=$?
+echo ""
+run_rc 'selftests/run selftests/all'
+rc4=$?
+exit $rc1 || $rc2 || $rc3 || $rc4
+


### PR DESCRIPTION
One convenient command to run the checks Travis runs on
the code base (less verbose version).

Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
