### PR TITLE
avocado: Add NullHandler for early 'avocado.test' logger

### DIFF
--- a/avocado/__init__.py
+++ b/avocado/__init__.py
@@ -22,6 +22,10 @@ DEFAULT_LOGGING = {
         },
     },
     'handlers': {
+        'null': {
+            'level': 'INFO',
+            'class': 'logging.NullHandler',
+        },
         'console': {
             'level': 'INFO',
             'class': 'logging.StreamHandler',
@@ -43,6 +47,7 @@ DEFAULT_LOGGING = {
             'propagate': False,
         },
         'avocado.test': {
+            'handlers': ['null'],
             'level': 'DEBUG',
             'propagate': False,
         },


### PR DESCRIPTION
So we avoid those annoying 'no handlers found for avocado.test'
during test.

Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
