### PR TITLE
plugins.{json,xunit}: Add missing space in --help

### DIFF
--- a/avocado/plugins/jsonresult.py
+++ b/avocado/plugins/jsonresult.py
@@ -99,7 +99,7 @@ class JSON(plugin.Plugin):
         self.parser.runner.add_argument(
             '--json', type=str,
             dest='json_output',
-            help='Enable JSON output to the file where the result should be written.'
+            help='Enable JSON output to the file where the result should be written. '
                  "Use '-' to redirect to the standard output.")
         self.configured = True
 

--- a/avocado/plugins/xunit.py
+++ b/avocado/plugins/xunit.py
@@ -235,7 +235,7 @@ class XUnit(plugin.Plugin):
         self.parser = parser
         self.parser.runner.add_argument(
             '--xunit', type=str, dest='xunit_output',
-            help=('Enable xUnit output to the file where the result should be written.'
+            help=('Enable xUnit output to the file where the result should be written. '
                   "Use '-' to redirect to the standard output."))
         self.configured = True
 


### PR DESCRIPTION
Trivial fix: missing space in a help sentence.
