### PR TITLE
avocado.plugins.xunit: Consider "not found" as error.

### DIFF
--- a/avocado/plugins/xunit.py
+++ b/avocado/plugins/xunit.py
@@ -22,6 +22,9 @@ from avocado.plugins import plugin
 from avocado.result import TestResult
 
 
+# We use a subset of the XML format defined in this URL:
+# https://svn.jenkins-ci.org/trunk/hudson/dtkit/dtkit-format/dtkit-junit-model/src/main/resources/com/thalesgroup/dtkit/junit/model/xsd/junit-4.xsd
+
 class XmlResult(object):
 
     """
@@ -46,8 +49,7 @@ class XmlResult(object):
         """
         if filename is None:
             filename = self.output
-        xml = '\n'.join(self.xml)
-        xml += '\n'
+        xml = '\n'.join(self.xml) + '\n'
         if filename == '-':
             sys.stdout.write(xml)
         else:
@@ -60,7 +62,7 @@ class XmlResult(object):
 
         :param timestamp: Timestamp string in date/time format.
         """
-        self.testsuite = '<testsuite name="avocado" tests="{tests}" errors="{errors}" failures="{failures}" not_found="{not_found}" skip="{skip}" time="{total_time}" timestamp="%s">' % timestamp
+        self.testsuite = '<testsuite name="avocado" tests="{tests}" errors="{errors}" failures="{failures}" skip="{skip}" time="{total_time}" timestamp="%s">' % timestamp
         self.testcases = []
 
     def end_testsuite(self, tests, errors, not_found, failures, skip, total_time):
@@ -73,6 +75,7 @@ class XmlResult(object):
         :param skip: Number of test skipped.
         :param total_time: The total time of test execution.
         """
+        errors += not_found  # In XML count "not found tests" as error
         values = {'tests': tests,
                   'errors': errors,
                   'not_found': not_found,

--- a/selftests/all/functional/avocado/basic_tests.py
+++ b/selftests/all/functional/avocado/basic_tests.py
@@ -411,8 +411,8 @@ class PluginsXunitTest(PluginsTest):
         self.assertEqual(len(testsuite_list), 1, 'More than one testsuite tag')
 
         testsuite_tag = testsuite_list[0]
-        self.assertEqual(len(testsuite_tag.attributes), 8,
-                         'The testsuite tag does not have 8 attributes. '
+        self.assertEqual(len(testsuite_tag.attributes), 7,
+                         'The testsuite tag does not have 7 attributes. '
                          'XML:\n%s' % xml_output)
 
         n_tests = int(testsuite_tag.attributes['tests'].value)
@@ -423,11 +423,6 @@ class PluginsXunitTest(PluginsTest):
         n_errors = int(testsuite_tag.attributes['errors'].value)
         self.assertEqual(n_errors, e_nerrors,
                          "Unexpected number of test errors, "
-                         "XML:\n%s" % xml_output)
-
-        n_not_found = int(testsuite_tag.attributes['not_found'].value)
-        self.assertEqual(n_not_found, e_nnotfound,
-                         "Unexpected number of test not found, "
                          "XML:\n%s" % xml_output)
 
         n_failures = int(testsuite_tag.attributes['failures'].value)
@@ -453,11 +448,11 @@ class PluginsXunitTest(PluginsTest):
         self.run_and_check('errortest', 1, 1, 1, 0, 0, 0)
 
     def test_xunit_plugin_notfoundtest(self):
-        self.run_and_check('sbrubles', 1, 1, 0, 1, 0, 0)
+        self.run_and_check('sbrubles', 1, 1, 1, 0, 0, 0)
 
     def test_xunit_plugin_mixedtest(self):
         self.run_and_check('sleeptest failtest skiptest errortest sbrubles',
-                           1, 5, 1, 1, 1, 1)
+                           1, 5, 2, 0, 1, 1)
 
 
 class ParseJSONError(Exception):


### PR DESCRIPTION
In the XML output, we can't use an exclusive attribute "not_found"
for tests that has been not found. So we're going to count
"not found" as error and remove the attribute "not_found".

Signed-off-by: Ruda Moura rmoura@redhat.com
