### PR TITLE
avocado.core.job_id: Ensure the Job ID is a SHA1

### DIFF
--- a/avocado/core/job_id.py
+++ b/avocado/core/job_id.py
@@ -12,7 +12,9 @@
 # Copyright: Red Hat Inc. 2013-2014
 # Authors: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
+import hashlib
 import random
+
 
 _RAND_POOL = random.SystemRandom()
 
@@ -25,6 +27,4 @@ def create_unique_job_id():
     :return: 40 digit hex number string
     :rtype: str
     """
-
-    n = _RAND_POOL.getrandbits(160)
-    return str(hex(n))[2:-1]
+    return hashlib.sha1(hex(_RAND_POOL.getrandbits(160))).hexdigest()


### PR DESCRIPTION
Return the SHA1 of the random data, rather than trusting
that the random number is large enough to fill the 40
character requirement.

This fixes a bug where on occasions the job ID had less
than 40 characters on Travis (later verified to happen
in our machines as well, we just didn't know).

Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
