### PR TITLE
avocado.job: output a line break after Ctrl+C

### DIFF
--- a/avocado/job.py
+++ b/avocado/job.py
@@ -267,6 +267,7 @@ class TestRunner(object):
 
             # don't process other tests from the list
             if ctrl_c_count > 0:
+                self.job.output_manager.log_header("")
                 break
 
             self.result.check_test(test_state)


### PR DESCRIPTION
Otherwise, the rest of the console UI ("PASS: ...") will stay in the same
line as the throbber.

Before the patch:
    ...
    TESTS     : 1
    (1/1) linuxbuild.py:  ^CPASS      : 0
    ERROR     : 0
    FAIL      : 0
    ...

After:
    ...
    TESTS     : 1
    (1/1) linuxbuild.py:  ^C
    PASS      : 0
    ERROR     : 0
    ...

Signed-off-by: Ademar de Souza Reis Jr areis@redhat.com
