### PR TITLE
tests/synctest: allow it to be built with debug symbols

### DIFF
--- a/tests/synctest.py
+++ b/tests/synctest.py
@@ -30,7 +30,8 @@ class synctest(test.Test):
     """
     default_params = {'sync_tarball': 'synctest.tar.bz2',
                       'sync_length': 100,
-                      'sync_loop': 10}
+                      'sync_loop': 10,
+                      'debug_symbols': True}
 
     def setup(self):
         """
@@ -40,15 +41,21 @@ class synctest(test.Test):
         tarball_path = self.get_data_path(self.params.sync_tarball)
         archive.extract(tarball_path, self.srcdir)
         self.srcdir = os.path.join(self.srcdir, 'synctest')
-        build.make(self.srcdir)
+        if self.params.debug_symbols:
+            build.make(self.srcdir,
+                       env='CFLAGS="-g -O0"',
+                       extra_args='synctest')
+        else:
+            build.make(self.srcdir)
 
     def action(self):
         """
         Execute synctest with the appropriate params.
         """
         os.chdir(self.srcdir)
-        cmd = ('./synctest %s %s' %
-               (self.params.sync_length, self.params.sync_loop))
+        path = os.path.join(os.getcwd(), 'synctest')
+        cmd = ('%s %s %s' %
+               (path, self.params.sync_length, self.params.sync_loop))
         process.system(cmd)
         os.chdir(self.cwd)
 


### PR DESCRIPTION
And small fixes to make it run properly under GDB.

Signed-off-by: Cleber Rosa crosa@redhat.com
