### PR TITLE
journal plugin: put the journal file in the right directory

### DIFF
--- a/avocado/plugins/journal.py
+++ b/avocado/plugins/journal.py
@@ -67,7 +67,7 @@ class TestResultJournal(TestResult):
     def lazy_init_journal(self, state):
         # lazy init because we need the toplevel logdir for the job
         if not self.journal_initialized:
-            self._init_journal(os.path.dirname(state['logdir']))
+            self._init_journal(state['job_logdir'])
             self._record_job_info(state)
             self.journal_initialized = True
 

--- a/avocado/test.py
+++ b/avocado/test.py
@@ -246,6 +246,7 @@ class Test(unittest.TestCase):
                 d[key] = orig[key]
         d['params'] = dict(orig['params'])
         d['class_name'] = self.__class__.__name__
+        d['job_logdir'] = self.job.logdir
         d['job_unique_id'] = self.job.unique_id
         return d
 

--- a/selftests/all/functional/avocado/journal_tests.py
+++ b/selftests/all/functional/avocado/journal_tests.py
@@ -37,8 +37,7 @@ class JournalPluginTests(unittest.TestCase):
         self.result = process.run(self.cmd_line, ignore_status=True)
         data = json.loads(self.result.stdout)
         self.job_id = data['job_id']
-        jfile = os.path.join(os.path.dirname(data['debuglog']),
-                             'test-results/examples/tests/.journal.sqlite')
+        jfile = os.path.join(os.path.dirname(data['debuglog']), '.journal.sqlite')
         self.db = sqlite3.connect(jfile)
 
     def test_journal_job_id(self):


### PR DESCRIPTION
Here right directory means the top log job result directory,
along with the job id file and the job.log file, etc.

Looks like there was a change in the meaning of `job.logdir`
and because of that, the journal plugin was saving the file
one directory up the tree.

Also, we needed the job logdir as part of the test state, just
like we need the job unique id.

Signed-off-by: Cleber Rosa crosa@redhat.com
