### PR TITLE
avocado.plugins.vm: Copy test data to the target.

### DIFF
--- a/avocado/plugins/vm.py
+++ b/avocado/plugins/vm.py
@@ -141,6 +141,9 @@ class VMTestResult(TestResult):
         for url in uniq_urls:
             test_path = os.path.join(self.test_dir, url)
             self.vm.remote.send_files(test_path, self.remote_test_dir)
+            test_data_path = test_path + '.data'
+            if os.path.isdir(test_data_path):
+                self.vm.remote.send_files(test_data_path, self.remote_test_dir)
 
     def setup(self):
         self.urls = self.args.url


### PR DESCRIPTION
When copying tests to the remote virtual machine, copy the test data that the test requires (the .data/ files) to the remote machine.

Signed-off-by: Ruda Moura rmoura@redhat.com
