### PR TITLE
GDB: deal with fatal signals and generate core dumps (v2)

### DIFF
--- a/avocado/gdb.py
+++ b/avocado/gdb.py
@@ -88,6 +88,41 @@ def is_break_hit(parsed_mi_msg):
             (parsed_mi_msg.result.reason == "breakpoint-hit"))
 
 
+def is_sigsegv(parsed_mi_msg):
+    return (hasattr(parsed_mi_msg, 'class_') and
+            (parsed_mi_msg.class_ == 'stopped') and
+            hasattr(parsed_mi_msg, 'result') and
+            hasattr(parsed_mi_msg.result, 'signal_name') and
+            (parsed_mi_msg.result.reason == "SIGSEGV"))
+
+
+def is_sigabrt_stopped(parsed_mi_msg):
+    return (hasattr(parsed_mi_msg, 'class_') and
+            (parsed_mi_msg.class_ == 'stopped') and
+            hasattr(parsed_mi_msg, 'record_type') and
+            (parsed_mi_msg.record_type == 'result') and
+            (parsed_mi_msg.result.reason == 'signal-received') and
+            (parsed_mi_msg.result.signal_name == 'SIGABRT'))
+
+
+def is_sigabrt_console(parsed_mi_msg):
+    return (hasattr(parsed_mi_msg, 'record_type') and
+            (parsed_mi_msg.record_type == 'stream') and
+            hasattr(parsed_mi_msg, 'type') and
+            (parsed_mi_msg.type == 'console') and
+            hasattr(parsed_mi_msg, 'value') and
+            parsed_mi_msg.value == 'SIGABRT, Aborted.\n')
+
+
+def is_sigabrt(parsed_mi_msg):
+    return (is_sigabrt_stopped(parsed_mi_msg) or
+            is_sigabrt_console(parsed_mi_msg))
+
+
+def is_fatal_signal(parsed_mi_msg):
+    return is_sigsegv(parsed_mi_msg) or is_sigabrt(parsed_mi_msg)
+
+
 class CommandResult(object):
 
     """

--- a/avocado/plugins/gdb.py
+++ b/avocado/plugins/gdb.py
@@ -29,13 +29,19 @@ class GDB(plugin.Plugin):
 
     def configure(self, parser):
         self.parser = parser
-        runner = self.parser.runner
-        runner.add_argument('--gdb-run-bin', action='append',
-                            default=[], metavar='BINARY_PATH',
-                            help=('Set a breakpoint on a given binary to be '
-                                  'run inside the GNU debugger. Format should '
-                                  'be "<binary>[:breakpoint]". Breakpoint '
-                                  'defaults to "main"'))
+        gdb_grp = self.parser.runner.add_argument_group('GNU Debugger support')
+        gdb_grp.add_argument('--gdb-run-bin', action='append',
+                             default=[], metavar='BINARY_PATH',
+                             help=('Set a breakpoint on a given binary to be '
+                                   'run inside the GNU debugger. Format should '
+                                   'be "<binary>[:breakpoint]". Breakpoint '
+                                   'defaults to "main"'))
+
+        gdb_grp.add_argument('--gdb-enable-core', action='store_true',
+                             default=False,
+                             help=('Automatically generate a core dump when the'
+                                   ' inferior process received a fatal signal '
+                                   'such as SIGSEGV or SIGABRT'))
 
         self.configured = True
 
@@ -43,5 +49,7 @@ class GDB(plugin.Plugin):
         try:
             for binary in app_args.gdb_run_bin:
                 runtime.GDB_RUN_BINARY_NAMES_EXPR.append(binary)
+            if app_args.gdb_enable_core:
+                runtime.GDB_ENABLE_CORE = True
         except AttributeError:
             pass

--- a/avocado/runtime.py
+++ b/avocado/runtime.py
@@ -21,9 +21,9 @@ Module that contains runtime configuration
 #: using the given expression
 GDB_RUN_BINARY_NAMES_EXPR = []
 
-#: Wether to disable the automatic generation of core dumps for applications
+#: Wether to enable the automatic generation of core dumps for applications
 #: that are run inside the GNU debugger
-GDB_DISABLE_CORE = False
+GDB_ENABLE_CORE = False
 
 #: Sometimes it's useful for the framework and API to know about the test that
 #: is currently running, if one exists


### PR DESCRIPTION
This adds two related features:

1) dealing with fatal signals such as SIGSEGV
2) generating core dumps automatically (disabled by default) if requested

So now the behaviour on fatal signals (SISEGV and SIGABRT) for now cause
the test to be skipped. Other ways to deal with this proved to be complex
and not really effective.

Signed-off-by: Cleber Rosa crosa@redhat.com
