### PR TITLE
multiplexer: Set root node name to empty string.

### DIFF
--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -40,7 +40,7 @@ import yaml
 
 class TreeNode(object):
 
-    def __init__(self, name='/root', value=None, parent=None, children=None):
+    def __init__(self, name='', value=None, parent=None, children=None):
         if value is None:
             value = collections.OrderedDict()
         if children is None:
@@ -211,7 +211,7 @@ def read_ordered_yaml(fileobj):
     return data
 
 
-def create_from_ordered_data(data, tree=None, root=None, name='/root'):
+def create_from_ordered_data(data, tree=None, root=None, name=''):
     if tree is None:
         tree = TreeNode(name)
     if root is None:

--- a/avocado/multiplexer.py
+++ b/avocado/multiplexer.py
@@ -33,7 +33,7 @@ def path_parent(path):
     """
     parent = path.rpartition('/')[0]
     if parent == '':
-        return '/root'
+        return ''
     return parent
 
 

--- a/examples/mux-environment.yaml
+++ b/examples/mux-environment.yaml
@@ -6,16 +6,16 @@ hw:
             cpu_CFLAGS: '-march=athlon64'
         arm:
             cpu_CFLAGS: '-mabi=apcs-gnu -march=armv8-a -mtune=arm8'
-            filter-only: ['/root/os/linux', '/root/env/debug']
-            filter-out: '/root/hw'
+            filter-only: ['/os/linux', '/env/debug']
+            filter-out: '/hw'
     disk:
         scsi:
             disk_type: 'scsi'
         virtio:
             disk_type: 'virtio'
-            filter-only: '/root/os/linux'
+            filter-only: '/os/linux'
 os:
-    filter-out: '/root/os'
+    filter-out: '/os'
     linux:
         bsod: 'false'
         fedora:
@@ -36,4 +36,4 @@ env:
         debug_CFLAGS: '-O0 -g'
     prod:
         debug_CFLAGS: ''
-        filter-only: '/root/os/win'
+        filter-only: '/os/win'

--- a/selftests/all/unit/avocado/multiplexer_unittest.py
+++ b/selftests/all/unit/avocado/multiplexer_unittest.py
@@ -28,16 +28,16 @@ f_out = []
 class TestPathParent(unittest.TestCase):
 
     def test_empty_string(self):
-        self.assertEqual(path_parent(''), '/root')
+        self.assertEqual(path_parent(''), '')
 
     def test_on_root(self):
-        self.assertEqual(path_parent('/root'), '/root')
+        self.assertEqual(path_parent('/'), '')
 
     def test_direct_parent(self):
-        self.assertEqual(path_parent('/root/os/linux'), '/root/os')
+        self.assertEqual(path_parent('/os/linux'), '/os')
 
     def test_false_direct_parent(self):
-        self.assertNotEqual(path_parent('/root/os/linux'), '/root')
+        self.assertNotEqual(path_parent('/os/linux'), '/')
 
 
 class TestAnySibling(unittest.TestCase):
@@ -55,7 +55,7 @@ class TestAnySibling(unittest.TestCase):
                 win7:
                 win8:
         """
-        t = TreeNode('/root')
+        t = TreeNode()
         os = t.add_child(TreeNode('os'))
         linux = os.add_child(TreeNode('linux'))
         self.mint = linux.add_child(TreeNode('mint'))
@@ -170,15 +170,15 @@ class TestMultiplex(unittest.TestCase):
     def test_multiplex_filter_only(self):
         f_only = ['']
         self.assertEqual(len(list(multiplex(self.leaves3, filter_only=f_only, filter_out=f_out))), 8)
-        f_only = ['/root/arch']
+        f_only = ['/arch']
         self.assertEqual(len(list(multiplex(self.leaves3, filter_only=f_only, filter_out=f_out))), 2)
-        f_only = ['/root/arch', '/root/linux']
+        f_only = ['/arch', '/linux']
         self.assertEqual(len(list(multiplex(self.leaves3, filter_only=f_only, filter_out=f_out))), 4)
-        f_only = ['/root/arch', '/root/linux/fedora']
+        f_only = ['/arch', '/linux/fedora']
         self.assertEqual(len(list(multiplex(self.leaves3, filter_only=f_only, filter_out=f_out))), 2)
 
     def test_multiplex_filter_only_invalid(self):
-        f_only = ['/root/stage']
+        f_only = ['/stage']
         self.assertEqual(len(list(multiplex(self.leaves3, filter_only=f_only, filter_out=f_out))), 0)
         self.assertEqual(len(list(multiplex(self.leaves4, filter_only=f_only, filter_out=f_out))), 0)
 
@@ -190,31 +190,31 @@ class TestMultiplex(unittest.TestCase):
     def test_multiplex_filter_out(self):
         f_out = ['']
         self.assertEqual(len(list(multiplex(self.leaves3, filter_only=f_only, filter_out=f_out))), 8)
-        f_out = ['/root/arch']
+        f_out = ['/arch']
         self.assertEqual(len(list(multiplex(self.leaves3, filter_only=f_only, filter_out=f_out))), 4)
-        f_out = ['/root/arch', '/root/linux']
+        f_out = ['/arch', '/linux']
         self.assertEqual(len(list(multiplex(self.leaves3, filter_only=f_only, filter_out=f_out))), 2)
-        f_out = ['/root/arch', '/root/linux/fedora']
+        f_out = ['/arch', '/linux/fedora']
         self.assertEqual(len(list(multiplex(self.leaves3, filter_only=f_only, filter_out=f_out))), 2)
 
     def test_multiplex_filter_combined(self):
         f_out = ['']
         f_only = ['']
         self.assertEqual(len(list(multiplex(self.leaves3, filter_only=f_only, filter_out=f_out))), 8)
-        f_only = ['/root/arch']
-        f_out = ['/root/arch']
+        f_only = ['/arch']
+        f_out = ['/arch']
         self.assertEqual(len(list(multiplex(self.leaves3, filter_only=f_only, filter_out=f_out))), 0)
-        f_out = ['/root/arch']
-        f_only = ['/root/arch']
+        f_out = ['/arch']
+        f_only = ['/arch']
         self.assertEqual(len(list(multiplex(self.leaves3, filter_only=f_only, filter_out=f_out))), 0)
-        f_out = ['/root/arch', '/root/linux']
-        f_only = ['/root/linux/fedora']
+        f_out = ['/arch', '/linux']
+        f_only = ['/linux/fedora']
         self.assertEqual(len(list(multiplex(self.leaves3, filter_only=f_only, filter_out=f_out))), 2)
-        f_out = ['/root/arch']
-        f_only = ['/root/linux']
+        f_out = ['/arch']
+        f_only = ['/linux']
         self.assertEqual(len(list(multiplex(self.leaves3, filter_only=f_only, filter_out=f_out))), 2)
-        f_out = ['/root/arch']
-        f_only = ['/root/linux']
+        f_out = ['/arch']
+        f_only = ['/linux']
         self.assertEqual(len(list(multiplex(self.leaves3, filter_only=f_only, filter_out=f_out))), 2)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Get rid of "/root" for the root node and use empty string as name,
in order to avoid to prefix filters and to display information
with the /root prefix in every output.

The output will be just like this:

<pre>
./scripts/avocado multiplex mux.yaml --filter-only /hw/cpu/arm --filter-out /os
Variants generated:
Variant 1:    /hw/cpu/arm, /hw/disk/scsi, /env/debug
Variant 2:    /hw/cpu/arm, /hw/disk/scsi, /env/prod
Variant 3:    /hw/cpu/arm, /hw/disk/virtio, /env/debug
Variant 4:    /hw/cpu/arm, /hw/disk/virtio, /env/prod
</pre>


Signed-off-by: Ruda Moura rmoura@redhat.com
