### PR TITLE
examples/mux-environmentyaml: Don't use local filters.

### DIFF
--- a/examples/mux-environment.yaml
+++ b/examples/mux-environment.yaml
@@ -6,16 +6,12 @@ hw:
             cpu_CFLAGS: '-march=athlon64'
         arm:
             cpu_CFLAGS: '-mabi=apcs-gnu -march=armv8-a -mtune=arm8'
-            filter-only: ['/os/linux', '/env/debug']
-            filter-out: '/hw'
     disk:
         scsi:
             disk_type: 'scsi'
         virtio:
             disk_type: 'virtio'
-            filter-only: '/os/linux'
 os:
-    filter-out: '/os'
     linux:
         bsod: 'false'
         fedora:
@@ -36,4 +32,3 @@ env:
         debug_CFLAGS: '-O0 -g'
     prod:
         debug_CFLAGS: ''
-        filter-only: '/os/win'


### PR DESCRIPTION
Remove lines that contains local filters, which is a feature that is disabled by now (it's broken).

Signed-off-by: Rudá Moura rmoura@redhat.com
