### PR TITLE
avocado.core.tree: Match whole key in filters.

### DIFF
--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -275,16 +275,16 @@ def apply_filters(tree, filter_only=[], filter_out=[]):
         for path in filter_only:
             if path == '':
                 continue
-            if node.path.startswith(path):
+            if node.path == path:
                 keep_node = True
                 break
-            if node.parent and node.parent.path.startswith(path_parent(path)):
+            if node.parent and node.parent.path == path_parent(path):
                 keep_node = False
                 continue
         for path in filter_out:
             if path == '':
                 continue
-            if node.path.startswith(path):
+            if node.path == path:
                 keep_node = False
                 break
         if not keep_node:


### PR DESCRIPTION
When filtering nodes, use the whole key for comparing.

So if you have `/long` and `/longest` and you're filtering for `/long`, then it will match `/long` alone.

The previous behaviour was using the partial string match, so both `/long` and `/longest` were being returned, which is wrong.

Signed-off-by: Rudá Moura rmoura@redhat.com
