### PR TITLE
Process init on demand

### DIFF
--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -347,6 +347,9 @@ class SubProcess(object):
         self.result.stdout = self.get_stdout()
         self.result.stderr = self.get_stderr()
 
+    def start(self):
+        self._init_sp()
+
     def get_stdout(self):
         """
         Get the full stdout of the subprocess so far.


### PR DESCRIPTION
Move SubProcess() internal subprocess initialization to a separate method, and don't execute it at init time. Add a new .start() method, for people wanting to use background processes, such as QEMU instances inside a virt related test.

With this, we honor the user's expectation for the run() method - start a process and wait until it ends. Also, it requires a minimal change in the virt plugin (calling the .start() method in the QEMU SubProcess() call).
