### PR TITLE
Process init on demand [V2]

### DIFF
--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -389,16 +389,22 @@ class SubProcess(object):
     def terminate(self):
         """
         Send a :attr:`signal.SIGTERM` to the process.
+
+        After the process is terminated, we wait on it to fill result objects.
         """
         self._init_sp()
         self.send_signal(signal.SIGTERM)
+        self.wait()
 
     def kill(self):
         """
         Send a :attr:`signal.SIGKILL` to the process.
+
+        After the process is terminated, we wait on it to fill result objects.
         """
         self._init_sp()
         self.send_signal(signal.SIGKILL)
+        self.wait()
 
     def send_signal(self, sig):
         """


### PR DESCRIPTION
Follow up of PR #239.

Move SubProcess() internal subprocess initialization to a separate method, and don't execute it at init time. Add a new .start() method, for people wanting to use background processes, such as QEMU instances inside a virt related test.

With this, we honor the user's expectation for the run() method - start a process and wait until it ends. Also, it requires a minimal change in the virt plugin (calling the .start() method in the QEMU SubProcess() call).

Changelog:

https://github.com/lmr/avocado/compare/process_init_on_demand...process_init_on_demand_v2?diff=split

v1 -> v2: Addressed comments by @ruda:
- Added .start() method docstring
- Made .start() to return the subprocess PID
