### PR TITLE
avocado.utils.archive: Add support for .tar.xz [V3]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ virtualenv:
 
 before_script:
     - sudo apt-get update
-    - sudo apt-get -y --force-yes install python-libvirt build-essential python-yaml
+    - sudo apt-get -y --force-yes install python-libvirt build-essential python-yaml python-lzma
 
 install:
     - pip install sphinx tox pylint autopep8 flexmock

--- a/avocado.spec
+++ b/avocado.spec
@@ -8,7 +8,7 @@ URL: http://avocado-framework.readthedocs.org/
 Source: avocado-%{version}.tar.gz
 BuildRequires: python2-devel, python-docutils, python-yaml
 BuildArch: noarch
-Requires: python, python-requests, python-yaml, fabric
+Requires: python, python-requests, python-yaml, fabric, pyliblzma
 
 %description
 Avocado is a set of tools and libraries (what people call

--- a/debian/control
+++ b/debian/control
@@ -9,5 +9,5 @@ Package: avocado
 Architecture: all
 Homepage: http://autotest.github.com/
 XB-Python-Version: ${python:Versions}
-Depends: ${misc:Depends}, ${python:Depends}, python-yaml
+Depends: ${misc:Depends}, ${python:Depends}, python-yaml, python-lzma
 Description: Avocado is a framework for fully automated testing.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ virtualenv==1.9.1
 mysql-python==1.2.3
 requests==1.2.3
 fabric==1.7.0
+pyliblzma==0.5.3


### PR DESCRIPTION
ISSUE: https://github.com/avocado-framework/avocado/issues/80

This patch wraps LZMA archive in order to work with python 2.7 tarfile.

Signed-off-by: Lukáš Doktor ldoktor@redhat.com

Changes V2
- sorted out Travis CI dependencies

Changes V3
- rpm/deb dependencies
