### PR TITLE
avocado.utils.process: Fix system_output() call

### DIFF
--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -130,7 +130,8 @@ def kill_process_tree(pid, sig=signal.SIGKILL):
     """
     if not safe_kill(pid, signal.SIGSTOP):
         return
-    children = system_output("ps --ppid=%d -o pid=" % pid).split()
+    children = system_output("ps --ppid=%d -o pid=" % pid, ignore_status=True,
+                             verbose=False).split()
     for child in children:
         kill_process_tree(int(child), sig)
     safe_kill(pid, sig)


### PR DESCRIPTION
Suppress debug output in this call, which is unnecessary.
Also, ignore its rc, given that we'll kill child processes
only if they actually exist.

Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
