### PR TITLE
selftest.run: Don't use coverage and xunit by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,4 @@ script:
     - inspekt style
     - ./selftests/run -v selftests/all/doc
     - ./selftests/run -v selftests/all/functional
-    - ./selftests/run selftests/all/unit -c selftests/.nose.cfg
+    - ./selftests/run -v selftests/all/unit

--- a/selftests/coverageall
+++ b/selftests/coverageall
@@ -1,0 +1,4 @@
+#!/bin/bash
+echo "Cleaning up coverage and running 'selftests/all'"
+./selftests/run --with-coverage --cover-package=avocado --cover-erase selftests/all
+

--- a/selftests/run
+++ b/selftests/run
@@ -21,8 +21,6 @@ from nose.selector import Selector
 
 from nose.plugins import Plugin
 from nose.plugins.attrib import AttributeSelector
-from nose.plugins.xunit import Xunit
-from nose.plugins.cover import Coverage
 
 import logging
 import os
@@ -84,6 +82,4 @@ class AvocadoTestRunner(Plugin):
 
 if __name__ == '__main__':
     nose.main(addplugins=[AvocadoTestRunner(),
-                          AttributeSelector(),
-                          Xunit(),
-                          Coverage()])
+                          AttributeSelector()])


### PR DESCRIPTION
```
Usually coverage and xunit are unused and only slows down CI. This patch
disables it by default. In order to get coverage please run
`selftest/coverageall`.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>
```
