### PR TITLE
GDB: support for setting gdb/gdbserver paths [v2]

### DIFF
--- a/avocado/plugins/gdb.py
+++ b/avocado/plugins/gdb.py
@@ -55,6 +55,17 @@ class GDB(plugin.Plugin):
                                    'need to use a custom GDB version. Defaults '
                                    'to "%(default)s"'))
 
+        default_gdbserver_path = '/usr/bin/gdbserver'
+        try:
+            system_gdbserver_path = process.find_command('gdbserver')
+        except process.CmdNotFoundError:
+            system_gdbserver_path = default_gdbserver_path
+        gdb_grp.add_argument('--gdbserver-path',
+                             default=system_gdbserver_path, metavar='PATH',
+                             help=('Path to the gdbserver executable, should you '
+                                   'need to use a custom version. Defaults '
+                                   'to "%(default)s"'))
+
         self.configured = True
 
     def activate(self, app_args):
@@ -64,5 +75,6 @@ class GDB(plugin.Plugin):
             if app_args.gdb_enable_core:
                 runtime.GDB_ENABLE_CORE = True
             runtime.GDB_PATH = app_args.gdb_path
+            runtime.GDBSERVER_PATH = app_args.gdbserver_path
         except AttributeError:
             pass

--- a/avocado/runtime.py
+++ b/avocado/runtime.py
@@ -28,6 +28,9 @@ GDB_ENABLE_CORE = False
 #: Path to the GDB binary
 GDB_PATH = None
 
+#: Path to the gdbserver binary
+GDBSERVER_PATH = None
+
 #: Sometimes it's useful for the framework and API to know about the test that
 #: is currently running, if one exists
 CURRENT_TEST = None

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -553,7 +553,7 @@ class GDBSubProcess(object):
         self.binary_path = os.path.abspath(self.cmd)
         self.result = CmdResult(cmd)
 
-        self.gdb_server = gdb.GDBServer()
+        self.gdb_server = gdb.GDBServer(runtime.GDBSERVER_PATH)
         self.gdb = gdb.GDB(runtime.GDB_PATH)
         self.gdb.connect(self.gdb_server.port)
         self.gdb.set_file(self.binary)

--- a/man/avocado.rst
+++ b/man/avocado.rst
@@ -292,6 +292,10 @@ you can override that with::
 
  $ avocado run --gdb-path=~/code/gdb/gdb --gdb-run-bin=foo:main footest
 
+The same applies to `gdbserver`, which can be chosen with a command line like::
+
+ $ avocado run --gdbserver-path=~/code/gdb/gdbserver --gdb-run-bin=foo:main footest
+
 RECORDING TEST REFERENCE OUTPUT
 ===============================
 


### PR DESCRIPTION
Developers using Avocado's GDB support may need to use their custom build of gdb and gdbserver, or simply their system has those at a different location.

Changes from v1:
- use `avocado.utils.process.find_command()` as the first default location for the gdb/gdbserver binary, falling back to the hard coded defaults `/usr/bin/gdb` and `/usr/bin/gdbserver` if those fail. Suggested by @lmr.
