### PR TITLE
Reorganize requirements.txt and Travis CI job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,18 +9,16 @@ branches:
 virtualenv:
     system_site_packages: true
 
-before_script:
-    - sudo apt-get update
-    - sudo apt-get -y --force-yes install python-libvirt build-essential python-yaml python-lzma
+before_install:
+    - sudo apt-get -y --force-yes install python-libvirt python-lzma python-yaml
 
 install:
-    - pip install sphinx tox pylint autopep8 flexmock
-    - pip install inspektor
-    - pip install -r requirements.txt
+    - pip install -r requirements-travis.txt
 
 script:
     - inspekt lint
+    - inspekt indent
     - inspekt style
-    - ./selftests/run -v selftests/all/doc
-    - ./selftests/run -v selftests/all/functional
-    - ./selftests/run -v selftests/all/unit
+    - ./selftests/run selftests/all/doc
+    - ./selftests/run selftests/all/functional
+    - ./selftests/run selftests/all/unit

--- a/requirements-selftests.txt
+++ b/requirements-selftests.txt
@@ -1,0 +1,9 @@
+# Avocado test requirements
+# nose (selftests)
+nose>=1.3.0
+# sphinx (doc build test)
+Sphinx>=1.3b1
+# flexmock (some unittests use it)
+flexmock>=0.9.7
+# inspektor (static and style checks)
+inspektor>=0.1.12

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,0 +1,7 @@
+# All pip installable requirements pinned for Travis CI
+fabric==1.10.0
+nose==1.3.4
+pystache==0.5.4
+Sphinx==1.3b1
+flexmock==0.9.7
+inspektor==0.1.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,11 @@
-coverage==3.6
-nose==1.3.0
-nosexcover==1.0.8
-tox==1.5.0
-virtualenv==1.9.1
-mysql-python==1.2.3
-requests==1.2.3
-fabric==1.7.0
-pyliblzma==0.5.3
-pystache>0.5.0
+# Avocado functional requirements
+# SSH lib (avocado.utils.remote)
+fabric>=1.7.0
+# multiplexer (avocado.core.tree)
+PyYAML>=3.11
+# vm plugin (avocado.plugins.vm)
+libvirt-python>=1.2.9
+# .tar.xz support (avocado.utils.archive)
+pyliblzma>=0.5.3
+# HTML report plugin (avocado.plugins.htmlresult)
+pystache>=0.5.3


### PR DESCRIPTION
Document requirements.txt, split it into 3 files:
- requirements.txt - Used to install deps for functionality
- tests-requirements-tests.txt - Used to install deps to test avocado
- travis-requirements.txt - Used exclusively for Travis CI jobs 

Also, clean up and simplify Travis install job section.
