### PR TITLE
Remove license text from the files that are not essential.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,16 +1,3 @@
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; specifically version 2 of the License.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2013-2014
-# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
-
 # -*- coding: utf-8 -*-
 
 import sys

--- a/examples/plugins/avocado_hello.py
+++ b/examples/plugins/avocado_hello.py
@@ -1,17 +1,3 @@
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2013-2014
-# Author: Ruda Moura <rmoura@redhat.com>
-
 from avocado.plugins import plugin
 
 

--- a/examples/tests/abort.py
+++ b/examples/tests/abort.py
@@ -1,19 +1,5 @@
 #!/usr/bin/python
 
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2014
-# Author: Ruda Moura <rmoura@redhat.com>
-
 import os
 
 from avocado import test

--- a/examples/tests/datadir.py
+++ b/examples/tests/datadir.py
@@ -1,19 +1,5 @@
 #!/usr/bin/python
 
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2014
-# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
-
 import os
 
 from avocado import test

--- a/examples/tests/datadir.py.data/datadir.c
+++ b/examples/tests/datadir.py.data/datadir.c
@@ -1,19 +1,3 @@
-/*
-This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 2 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-
-See LICENSE for more details.
-
-Copyright: Red Hat Inc. 2014
-Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
-*/
-
 #include<stdio.h>
 
 int main()

--- a/examples/tests/doublefail.py
+++ b/examples/tests/doublefail.py
@@ -1,20 +1,5 @@
 #!/usr/bin/python
 
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2013-2014
-# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
-
-
 from avocado import test
 from avocado import job
 from avocado.core import exceptions

--- a/examples/tests/doublefree.py
+++ b/examples/tests/doublefree.py
@@ -1,19 +1,5 @@
 #!/usr/bin/python
 
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2014
-# Author: Ruda Moura <rmoura@redhat.com>
-
 import os
 
 from avocado import test

--- a/examples/tests/doublefree.py.data/doublefree.c
+++ b/examples/tests/doublefree.py.data/doublefree.c
@@ -1,19 +1,3 @@
-/*
-This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 2 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-
-See LICENSE for more details.
-
-Copyright: Red Hat Inc. 2014
-Author: Ruda Moura <rmoura@redhat.com>
-*/
-
 #include <stdlib.h>
 
 int main(int argc, char *argv[])

--- a/examples/tests/errortest.py
+++ b/examples/tests/errortest.py
@@ -1,20 +1,5 @@
 #!/usr/bin/python
 
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2013-2014
-# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
-
-
 from avocado import test
 from avocado import job
 from avocado.core import exceptions

--- a/examples/tests/failtest.py
+++ b/examples/tests/failtest.py
@@ -1,20 +1,5 @@
 #!/usr/bin/python
 
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2013-2014
-# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
-
-
 from avocado import test
 from avocado import job
 from avocado.core import exceptions

--- a/examples/tests/fiotest.py
+++ b/examples/tests/fiotest.py
@@ -1,22 +1,5 @@
 #!/usr/bin/python
 
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2014
-# Author: Ruda Moura <rmoura@redhat.com>
-#
-# Based on Autotest fio test:
-# https://github.com/autotest/autotest-client-tests/tree/master/fio
-
 import os
 
 from avocado import test

--- a/examples/tests/gdbtest.py
+++ b/examples/tests/gdbtest.py
@@ -1,19 +1,5 @@
 #!/usr/bin/python
 
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2014
-# Author: Cleber Rosa <cleber@redhat.com>
-
 import os
 
 from avocado import test

--- a/examples/tests/gendata.py
+++ b/examples/tests/gendata.py
@@ -1,19 +1,5 @@
 #!/usr/bin/python
 
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2014
-# Author: Cleber Rosa <cleber@redhat.com>
-
 import os
 
 from avocado import test

--- a/examples/tests/linuxbuild.py
+++ b/examples/tests/linuxbuild.py
@@ -1,19 +1,5 @@
 #!/usr/bin/python
 
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2014
-# Author: Ruda Moura <rmoura@redhat.com>
-
 from avocado import test
 from avocado import job
 from avocado.linux import kernel_build

--- a/examples/tests/multiplextest.py
+++ b/examples/tests/multiplextest.py
@@ -1,19 +1,5 @@
 #!/usr/bin/python
 
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2014
-# Author: Ruda Moura <rmoura@redhat.com>
-
 from avocado import test
 from avocado import job
 

--- a/examples/tests/passtest.py
+++ b/examples/tests/passtest.py
@@ -1,20 +1,5 @@
 #!/usr/bin/python
 
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2014
-# Author: Cleber Rosa <cleber@redhat.com>
-
-
 from avocado import job
 from avocado import test
 

--- a/examples/tests/skiptest.py
+++ b/examples/tests/skiptest.py
@@ -1,20 +1,5 @@
 #!/usr/bin/python
 
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2013-2014
-# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
-
-
 from avocado import test
 from avocado import job
 from avocado.core import exceptions

--- a/examples/tests/sleeptenmin.py
+++ b/examples/tests/sleeptenmin.py
@@ -1,20 +1,5 @@
 #!/usr/bin/python
 
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2013-2014
-# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
-
-
 import os
 import time
 

--- a/examples/tests/sleeptest.py
+++ b/examples/tests/sleeptest.py
@@ -1,20 +1,5 @@
 #!/usr/bin/python
 
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2013-2014
-# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
-
-
 import time
 
 from avocado import job

--- a/examples/tests/synctest.py
+++ b/examples/tests/synctest.py
@@ -1,19 +1,5 @@
 #!/usr/bin/python
 
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2013-2014
-# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
-
 import os
 
 from avocado import test

--- a/examples/tests/timeouttest.py
+++ b/examples/tests/timeouttest.py
@@ -1,19 +1,5 @@
 #!/usr/bin/python
 
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2013-2014
-# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
-
 import time
 
 from avocado import test

--- a/examples/tests/trinity.py
+++ b/examples/tests/trinity.py
@@ -1,19 +1,5 @@
 #!/usr/bin/python
 
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2013-2014
-# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
-
 import os
 
 from avocado import test

--- a/examples/tests/warntest.py
+++ b/examples/tests/warntest.py
@@ -1,20 +1,5 @@
 #!/usr/bin/python
 
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2013-2014
-# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
-
-
 from avocado import test
 from avocado import job
 from avocado.core import exceptions

--- a/examples/tests/whiteboard.py
+++ b/examples/tests/whiteboard.py
@@ -1,19 +1,5 @@
 #!/usr/bin/python
 
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2014
-# Author: Cleber Rosa <cleber@redhat.com>
-
 from avocado import test
 from avocado import job
 

--- a/examples/wrappers/dummy.sh
+++ b/examples/wrappers/dummy.sh
@@ -1,16 +1,3 @@
 #!/bin/bash
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2014
-# Author: Ruda Moura <rmoura@redhat.com>
 
 exec -- $@

--- a/examples/wrappers/ltrace.sh
+++ b/examples/wrappers/ltrace.sh
@@ -1,17 +1,4 @@
 #!/bin/bash
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2014
-# Author: Ruda Moura <rmoura@redhat.com>
 
 # Map interesting signals to exit codes (see kill -L)
 # Example: SIGHUP (kill -1) 128+1 = 129

--- a/examples/wrappers/perf.sh
+++ b/examples/wrappers/perf.sh
@@ -1,16 +1,3 @@
 #!/bin/bash
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2014
-# Author: Ruda Moura <rmoura@redhat.com>
 
 exec perf record -o $AVOCADO_TEST_LOGDIR/perf.data.$$ -- $@

--- a/examples/wrappers/strace.sh
+++ b/examples/wrappers/strace.sh
@@ -1,16 +1,3 @@
 #!/bin/bash
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2014
-# Author: Ademar de Souza Reis Jr <areis@redhat.com>
 
 exec strace -ff -o $AVOCADO_TEST_LOGDIR/strace.log -- $@

--- a/examples/wrappers/valgrind.sh
+++ b/examples/wrappers/valgrind.sh
@@ -1,17 +1,4 @@
 #!/bin/bash
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2014
-# Author: Ruda Moura <rmoura@redhat.com>
 
 valgrind \
     --tool=memcheck \

--- a/selftests/all/functional/avocado/basic_tests.py
+++ b/selftests/all/functional/avocado/basic_tests.py
@@ -1,19 +1,5 @@
 #!/usr/bin/env python
 
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2013-2014
-# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
-
 import json
 import unittest
 import os

--- a/selftests/all/functional/avocado/export_variables_tests.py
+++ b/selftests/all/functional/avocado/export_variables_tests.py
@@ -1,19 +1,5 @@
 #!/usr/bin/env python
 
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2014
-# Author: Ruda Moura <rmoura@redhat.com>
-
 import os
 import sys
 import shutil

--- a/selftests/all/functional/avocado/gdb_tests.py
+++ b/selftests/all/functional/avocado/gdb_tests.py
@@ -1,19 +1,5 @@
 #!/usr/bin/env python
 
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2014
-# Author: Cleber Rosa <cleber@redhat.com>
-
 import os
 import sys
 import unittest

--- a/selftests/all/functional/avocado/journal_tests.py
+++ b/selftests/all/functional/avocado/journal_tests.py
@@ -1,19 +1,5 @@
 #!/usr/bin/env python
 
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2014
-# Author: Ruda Moura <rmoura@redhat.com>
-
 import unittest
 import os
 import sys

--- a/selftests/all/functional/avocado/multiplex_tests.py
+++ b/selftests/all/functional/avocado/multiplex_tests.py
@@ -1,19 +1,5 @@
 #!/usr/bin/env python
 
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2013-2014
-# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
-
 import unittest
 import os
 import sys

--- a/selftests/all/functional/avocado/output_check_tests.py
+++ b/selftests/all/functional/avocado/output_check_tests.py
@@ -1,19 +1,5 @@
 #!/usr/bin/env python
 
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2013-2014
-# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
-
 import os
 import shutil
 import sys

--- a/selftests/all/functional/avocado/output_tests.py
+++ b/selftests/all/functional/avocado/output_tests.py
@@ -1,19 +1,5 @@
 #!/usr/bin/env python
 
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2013-2014
-# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
-
 import json
 import tempfile
 import unittest

--- a/selftests/all/functional/avocado/standalone_tests.py
+++ b/selftests/all/functional/avocado/standalone_tests.py
@@ -1,19 +1,5 @@
 #!/usr/bin/env python
 
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2013-2014
-# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
-
 import unittest
 import os
 import sys

--- a/selftests/all/functional/avocado/utils_tests.py
+++ b/selftests/all/functional/avocado/utils_tests.py
@@ -1,19 +1,5 @@
 #!/usr/bin/env python
 
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2014
-# Author: Ruda Moura <rmoura@redhat.com>
-
 import os
 import sys
 import unittest

--- a/selftests/all/functional/avocado/wrapper_tests.py
+++ b/selftests/all/functional/avocado/wrapper_tests.py
@@ -1,19 +1,5 @@
 #!/usr/bin/env python
 
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2014
-# Author: Ruda Moura <rmoura@redhat.com>
-
 import os
 import sys
 import unittest

--- a/selftests/all/unit/avocado/archive_unittest.py
+++ b/selftests/all/unit/avocado/archive_unittest.py
@@ -1,20 +1,5 @@
 #!/usr/bin/env python
 
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2013-2014
-# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
-
-
 import unittest
 import tempfile
 import os

--- a/selftests/all/unit/avocado/datadir_unittest.py
+++ b/selftests/all/unit/avocado/datadir_unittest.py
@@ -1,20 +1,5 @@
 #!/usr/bin/env python
 
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2013-2014
-# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
-
-
 import unittest
 import os
 import sys

--- a/selftests/all/unit/avocado/jsonresult_unittest.py
+++ b/selftests/all/unit/avocado/jsonresult_unittest.py
@@ -1,19 +1,5 @@
 #!/usr/bin/env python
 
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2014
-# Author: Ruda Moura <rmoura@redhat.com>
-
 import unittest
 import os
 import sys

--- a/selftests/all/unit/avocado/multiplexer_unittest.py
+++ b/selftests/all/unit/avocado/multiplexer_unittest.py
@@ -1,21 +1,5 @@
 #!/usr/bin/env python
 
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2014
-#
-# Authors: Ruda Moura <rmoura@redhat.com>
-#          Ademar Reis <areis@redhat.com>
-
 import unittest
 
 from avocado.core.tree import *

--- a/selftests/all/unit/avocado/plugins_unittest.py
+++ b/selftests/all/unit/avocado/plugins_unittest.py
@@ -1,19 +1,5 @@
 #!/usr/bin/env python
 
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2014
-# Author: Ruda Moura <rmoura@redhat.com>
-
 import sys
 import os
 import unittest

--- a/selftests/all/unit/avocado/remote_unittest.py
+++ b/selftests/all/unit/avocado/remote_unittest.py
@@ -1,19 +1,5 @@
 #!/usr/bin/env python
 
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2014
-# Author: Ruda Moura <rmoura@redhat.com>
-
 import unittest
 import os
 import sys

--- a/selftests/all/unit/avocado/settings_unittest.py
+++ b/selftests/all/unit/avocado/settings_unittest.py
@@ -1,20 +1,5 @@
 #!/usr/bin/env python
 
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2013-2014
-# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
-
-
 import unittest
 import os
 import sys

--- a/selftests/all/unit/avocado/sysinfo_unittest.py
+++ b/selftests/all/unit/avocado/sysinfo_unittest.py
@@ -1,20 +1,5 @@
 #!/usr/bin/env python
 
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2013-2014
-# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
-
-
 import os
 import sys
 import unittest

--- a/selftests/all/unit/avocado/test_unittest.py
+++ b/selftests/all/unit/avocado/test_unittest.py
@@ -1,20 +1,5 @@
 #!/usr/bin/env python
 
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2013-2014
-# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
-
-
 import unittest
 import os
 import shutil

--- a/selftests/all/unit/avocado/tree_unittest.py
+++ b/selftests/all/unit/avocado/tree_unittest.py
@@ -1,20 +1,5 @@
 #!/usr/bin/env python
 
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2014
-#
-# Author: Ruda Moura <rmoura@redhat.com>
-
 import unittest
 import StringIO
 

--- a/selftests/all/unit/avocado/vm_unittest.py
+++ b/selftests/all/unit/avocado/vm_unittest.py
@@ -1,19 +1,5 @@
 #!/usr/bin/env python
 
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2014
-# Author: Ruda Moura <rmoura@redhat.com>
-
 import unittest
 import os
 import sys

--- a/selftests/all/unit/avocado/xunit_unittest.py
+++ b/selftests/all/unit/avocado/xunit_unittest.py
@@ -1,19 +1,5 @@
 #!/usr/bin/env python
 
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2014
-# Author: Ruda Moura <rmoura@redhat.com>
-
 import argparse
 import unittest
 import os

--- a/selftests/run
+++ b/selftests/run
@@ -1,20 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: 2014 Red Hat
-# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
-
 __author__ = 'Lucas Meneghel Rodrigues <lmr@redhat.com>'
 
 from nose.selector import Selector


### PR DESCRIPTION
Remove the license text from files inside `docs`, `examples` and `selftest`, to keep the license text only in relevant parts of the project.
