### PR TITLE
avocado.test: Support params passing to DropinTests

### DIFF
--- a/avocado/job.py
+++ b/avocado/job.py
@@ -120,7 +120,7 @@ class TestRunner(object):
 
         else:
             test_class = test.DropinTest
-            test_instance = test_class(path=test_path,
+            test_instance = test_class(params=params, path=test_path,
                                        base_logdir=self.job.logdir,
                                        job=self.job)
 

--- a/avocado/test.py
+++ b/avocado/test.py
@@ -572,6 +572,8 @@ class DropinTest(Test):
         Run the executable, and log its detailed execution.
         """
         try:
+            os.environ.update({str(key): str(val)
+                               for key, val in self.params.iteritems()})
             result = process.run(self.path, verbose=True)
             self._log_detailed_cmd_info(result)
         except exceptions.CmdError, details:

--- a/examples/tests/env_variables.sh
+++ b/examples/tests/env_variables.sh
@@ -10,6 +10,7 @@ echo "Avocado Test logdir: $AVOCADO_TEST_LOGDIR"
 echo "Avocado Test logfile: $AVOCADO_TEST_LOGFILE"
 echo "Avocado Test outputdir: $AVOCADO_TEST_OUTPUTDIR"
 echo "Avocado Test sysinfodir: $AVOCADO_TEST_SYSINFODIR"
+echo "Custom variable: $CUSTOM_VARIABLE"
 
 test -d "$AVOCADO_TEST_BASEDIR" -a \
      -d "$AVOCADO_TEST_WORKDIR" -a \


### PR DESCRIPTION
This patch injects all params as env variables to
DropinTests. This is very useful for multiplexing
these tests.

Additionally the env_variables.sh example test was
adjusted to print CUSTOM_VARIABLE, which can be used
in selftest.

Signed-off-by: Lukáš Doktor ldoktor@redhat.com
