### PR TITLE
.travis.yml: Run selftests in verbose mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,6 @@ script:
     - inspekt lint
     - inspekt indent
     - inspekt style
-    - ./selftests/run selftests/all/doc
-    - ./selftests/run selftests/all/functional
-    - ./selftests/run selftests/all/unit
+    - ./selftests/run -v selftests/all/doc
+    - ./selftests/run -v selftests/all/functional
+    - ./selftests/run -v selftests/all/unit


### PR DESCRIPTION
In case of timeout we might want to get the name of the last running
test, therefor setting verbose mode for them.

Signed-off-by: Lukáš Doktor ldoktor@redhat.com
