### PR TITLE
Include wrappers script when creating `avocado-examples` package.

### DIFF
--- a/avocado.spec
+++ b/avocado.spec
@@ -61,8 +61,12 @@ examples of how to write tests on your own.
 
 %files examples
 %{_datadir}/avocado/tests
+%{_datadir}/avocado/wrappers
 
 %changelog
+* Wed Dec  3 2014 Ruda Moura <rmoura@redhat.com> - 0.14.0-2
+- Include all wrappers scripts to examples subpackage.
+
 * Mon Oct 13 2014 Lucas Meneghel Rodrigues <lmr@redhat.com> - 0.14.0-1
 - New upstream release
 

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,15 @@ def get_docs_dir():
         return settings_system_wide
 
 
+def get_wrappers_dir():
+    settings_system_wide = os.path.join('/usr', 'share', 'avocado', 'wrappers')
+    settings_local_install = 'wrappers'
+    if 'VIRTUAL_ENV' in os.environ:
+        return settings_local_install
+    else:
+        return settings_system_wide
+
+
 def get_data_files():
     data_files = [(get_settings_dir(), ['etc/settings.ini'])]
     data_files += [(get_tests_dir(), glob.glob('examples/tests/*.py'))]
@@ -57,6 +66,7 @@ def get_data_files():
         for f in glob.glob(fmt_str):
             data_files += [(os.path.join(get_tests_dir(), os.path.basename(data_dir)), [f])]
     data_files.append((get_docs_dir(), ['man/avocado.rst']))
+    data_files += [(get_wrappers_dir(), glob.glob('examples/wrappers/*.sh'))]
     return data_files
 
 


### PR DESCRIPTION
Include all examples/wrappers/*.sh scripts when building the `avocado-examples` package.
The scripts will live under `/usr/share/avocado/wrappers` when installed.

Signed-off-by: Rudá Moura rmoura@redhat.com
