### PR TITLE
Make use of python-subprocess32 module if available.

### DIFF
--- a/avocado/aexpect.py
+++ b/avocado/aexpect.py
@@ -264,11 +264,15 @@ if __name__ == "__main__":
 
 # The following is the client part of the module.
 
-import subprocess
 import time
 import signal
 import re
 import threading
+
+try:
+    import subprocess32 as subprocess
+except ImportError:
+    import subprocess
 
 from avocado.utils import astring
 from avocado.utils import data_factory

--- a/avocado/gdb.py
+++ b/avocado/gdb.py
@@ -25,7 +25,11 @@ import fcntl
 import socket
 import tempfile
 import commands
-import subprocess
+
+try:
+    import subprocess32 as subprocess
+except ImportError:
+    import subprocess
 
 from avocado.utils import network
 from avocado.external import gdbmi_parser

--- a/avocado/sysinfo.py
+++ b/avocado/sysinfo.py
@@ -16,8 +16,12 @@ import gzip
 import logging
 import os
 import shutil
-import subprocess
 import time
+
+try:
+    import subprocess32 as subprocess
+except ImportError:
+    import subprocess
 
 from avocado import utils
 from avocado.linux import software_manager

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -20,12 +20,18 @@ import logging
 import os
 import StringIO
 import signal
-import subprocess
 import time
 import stat
 import shlex
 import shutil
 import threading
+
+try:
+    import subprocess32 as subprocess
+    SUBPROCESS32_SUPPORT = True
+except ImportError:
+    import subprocess
+    SUBPROCESS32_SUPPORT = False
 
 from avocado import gdb
 from avocado import runtime


### PR DESCRIPTION
python-subprocess32 [https://code.google.com/p/python-subprocess32/]
is a backport of Python 3.2 subprocess module with:
- Better process forking.
- More reliable when running with threads.

Although we're not going to use any feature of subprocess32,
this change turn it possible to use subprocess32 as a drop-in
replacement for the original subprocess module.

Signed-off-by: Rudá Moura rmoura@redhat.com
