### PR TITLE
avocado.test: Support params passing to DropinTests [v2]

### DIFF
--- a/avocado/job.py
+++ b/avocado/job.py
@@ -120,7 +120,7 @@ class TestRunner(object):
 
         else:
             test_class = test.DropinTest
-            test_instance = test_class(path=test_path,
+            test_instance = test_class(params=params, path=test_path,
                                        base_logdir=self.job.logdir,
                                        job=self.job)
 

--- a/avocado/test.py
+++ b/avocado/test.py
@@ -572,7 +572,9 @@ class DropinTest(Test):
         Run the executable, and log its detailed execution.
         """
         try:
-            result = process.run(self.path, verbose=True)
+            test_params = {str(key): str(val)
+                           for key, val in self.params.iteritems()}
+            result = process.run(self.path, verbose=True, env=test_params)
             self._log_detailed_cmd_info(result)
         except exceptions.CmdError, details:
             self._log_detailed_cmd_info(details.result)

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -646,9 +646,10 @@ This accomplishes a similar effect to the multiplex setup defined in there.
 Environment Variables for Dropin Tests
 ======================================
 
-Avocado exports some environment variables to the running test. Those variables are interesting
-to drop-in tests, because they can not make use of Avocado API directly with Python,
-like the native tests can do.
+Avocado exports avocado variables and multiplexed variables as BASH environment
+to the running test. Those variables are interesting to drop-in tests, because
+they can not make use of Avocado API directly with Python, like the native
+tests can do and also they can modify the test parameters.
 
 Here are the current variables that Avocado exports to the tests:
 
@@ -672,6 +673,8 @@ Here are the current variables that Avocado exports to the tests:
 | AVOCADO_TEST_OUTPUTDIR  | Output directory for the test         | $HOME/logs/job-results/job-2014-09-16T14.38-ac332e6/test-results/home.rmoura.my_test.sh.1/data      |
 +-------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
 | AVOCADO_TEST_SYSINFODIR | The system information directory      | $HOME/logs/job-results/job-2014-09-16T14.38-ac332e6/test-results/home.rmoura.my_test.sh.1/sysinfo   |
++-------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
+| *                       | All variables from --multiplex-file   | TIMEOUT=60; IO_WORKERS=10; VM_BYTES=512M; ...                                                       |
 +-------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
 
 Wrap Up

--- a/examples/tests/env_variables.sh
+++ b/examples/tests/env_variables.sh
@@ -10,6 +10,7 @@ echo "Avocado Test logdir: $AVOCADO_TEST_LOGDIR"
 echo "Avocado Test logfile: $AVOCADO_TEST_LOGFILE"
 echo "Avocado Test outputdir: $AVOCADO_TEST_OUTPUTDIR"
 echo "Avocado Test sysinfodir: $AVOCADO_TEST_SYSINFODIR"
+echo "Custom variable: $CUSTOM_VARIABLE"
 
 test -d "$AVOCADO_TEST_BASEDIR" -a \
      -d "$AVOCADO_TEST_WORKDIR" -a \


### PR DESCRIPTION
This patch injects all params as env variables to
DropinTests. This is very useful for multiplexing
these tests.

Additionally the env_variables.sh example test was
adjusted to print CUSTOM_VARIABLE, which can be used
in selftest.

Signed-off-by: Lukáš Doktor ldoktor@redhat.com

v1: https://github.com/avocado-framework/avocado/pull/276

Changes:

```
v2: pass new env as process.run() parameter
v2: updated documentation
```
