### PR TITLE
 Run avocado when called by 'python -m avocado'

### DIFF
--- a/avocado/__main__.py
+++ b/avocado/__main__.py
@@ -1,0 +1,13 @@
+"""
+Main entry point when called by 'python -m'.
+"""
+
+import sys
+
+from avocado.cli.app import AvocadoApp
+
+if sys.argv[0].endswith('__main__.py'):
+    sys.argv[0] = 'python -m avocado'
+
+main = AvocadoApp()
+main.run()


### PR DESCRIPTION
Add a main entry point when avocado is called by the command line option `python -m avocado`.

Signed-off-by: Rudá Moura rmoura@redhat.com
