### PR TITLE
selftests..multiplex_tests: Check that vars changes

### DIFF
--- a/examples/tests/env_variables.sh.data/env_variables.yaml
+++ b/examples/tests/env_variables.sh.data/env_variables.yaml
@@ -1,0 +1,6 @@
+short:
+    CUSTOM_VARIABLE: A
+medium:
+    CUSTOM_VARIABLE: ASDFASDF
+long:
+    CUSTOM_VARIABLE: "This is very long\nmultiline\ntext."


### PR DESCRIPTION
Replace test_run_mplex_timeout with test_run_mplex_params test which
executes 'env_variables.sh' and checks that output contain correct
output. This test checks the multiplexer capability to change variable
value.

Signed-off-by: Lukáš Doktor ldoktor@redhat.com
