### PR TITLE
Fix garbage output on remote and vm plugins.

### DIFF
--- a/avocado/plugins/remote.py
+++ b/avocado/plugins/remote.py
@@ -43,8 +43,9 @@ class RemoteTestRunner(TestRunner):
         avocado_cmd = ('cd %s; avocado run --force-job-id %s --json - --archive %s' %
                        (self.remote_test_dir, self.result.stream.job_unique_id, " ".join(urls)))
         result = self.result.remote.run(avocado_cmd, ignore_status=True)
+        json_output = result.stdout.splitlines()[0]
         try:
-            results = json.loads(result.stdout)
+            results = json.loads(json_output)
         except Exception, details:
             raise ValueError('Error loading JSON '
                              '(full output below): %s\n"""\n%s\n"""' %

--- a/avocado/plugins/vm.py
+++ b/avocado/plugins/vm.py
@@ -43,8 +43,9 @@ class VMTestRunner(TestRunner):
         avocado_cmd = ('cd %s; avocado run --force-job-id %s --json - --archive %s' %
                        (self.remote_test_dir, self.result.stream.job_unique_id, " ".join(urls)))
         result = self.result.vm.remote.run(avocado_cmd, ignore_status=True)
+        xunit_output = result.stdout.splitlines()[0]
         try:
-            results = json.loads(result.stdout)
+            results = json.loads(xunit_output)
         except Exception, details:
             raise ValueError('Error loading JSON '
                              '(full output below): %s\n"""\n%s\n"""' %


### PR DESCRIPTION
When using the remote or vm plugins, the JSON (or XML) result from the remote server is coming with garbage at the end. This commit fix this by filtering the result.

Signed-off-by: Rudá Moura rmoura@redhat.com
