### PR TITLE
Rename "drop-in test" (DropIn) to "simple test" (SimpleTest).

### DIFF
--- a/avocado/plugins/runner.py
+++ b/avocado/plugins/runner.py
@@ -42,7 +42,7 @@ class TestRunner(plugin.Plugin):
         """
         self.parser = parser.subcommands.add_parser(
             'run',
-            help='Run one or more tests (test module in .py, test alias or dropin)')
+            help='Run one or more tests (native test, test alias, binary or script)')
 
         self.parser.add_argument('url', type=str, default=[], nargs='*',
                                  help='List of test IDs (aliases or paths)')
@@ -110,7 +110,7 @@ class TestRunner(plugin.Plugin):
 
     def run(self, args):
         """
-        Run test modules or dropin tests.
+        Run test modules or simple tests.
 
         :param args: Command line args received from the run subparser.
         """

--- a/avocado/runner.py
+++ b/avocado/runner.py
@@ -104,7 +104,7 @@ class TestRunner(object):
                                            runner_queue=queue)
 
         else:
-            test_class = test.DropinTest
+            test_class = test.SimpleTest
             test_instance = test_class(params=params, path=test_path,
                                        base_logdir=self.job.logdir,
                                        job=self.job)

--- a/avocado/test.py
+++ b/avocado/test.py
@@ -538,7 +538,7 @@ class Test(unittest.TestCase):
                           self.tagged_name)
 
 
-class DropinTest(Test):
+class SimpleTest(Test):
 
     """
     Run an arbitrary command that returns either 0 (PASS) or !=0 (FAIL).
@@ -546,7 +546,7 @@ class DropinTest(Test):
 
     def __init__(self, path, params=None, base_logdir=None, tag=None, job=None):
         self.path = os.path.abspath(path)
-        super(DropinTest, self).__init__(name=path, base_logdir=base_logdir,
+        super(SimpleTest, self).__init__(name=path, base_logdir=base_logdir,
                                          params=params, tag=tag, job=job)
         basedir = os.path.dirname(self.path)
         basename = os.path.basename(self.path)

--- a/docs/source/GetStartedGuide.rst
+++ b/docs/source/GetStartedGuide.rst
@@ -46,7 +46,7 @@ you can run are:
 * Tests written in python, using the avocado API, which we'll call `native`.
 * Any executable in your box, really. The criteria for PASS/FAIL is the return
   code of the executable. If it returns 0, the test PASSed, if it returned
-  != 0, it FAILed. We'll call those tests `dropin`.
+  != 0, it FAILed. We'll call those tests `simple tests`.
 
 Native tests
 ------------
@@ -88,11 +88,11 @@ The idea is to have a unique identifier that can be used for job data, for
 the purposes of joining on a single database results obtained by jobs run
 on different systems.
 
-Drop-In tests
--------------
+Simple Tests
+------------
 
 You can run any number of test in an arbitrary order, as well as mix and match
-native tests and dropin tests::
+native tests and simple tests::
 
     $ echo '#!/bin/bash' > /tmp/script_that_passes.sh
     $ echo 'true' >> /tmp/script_that_passes.sh

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -340,8 +340,8 @@ can select which process outputs will go to the reference files, should you chos
 ``all``, for both stdout and stderr, ``stdout``, for the stdout only, ``stderr``, for only the stderr only, or ``none``,
 to allow neither of them to be recorded and checked.
 
-This process works fine also with dropin tests (random programs/shell scripts
-that return 0 (PASSed) or != 0 (FAILed). Let's consider our bogus example::
+This process works fine also with simple tests, which are programs or shell scripts
+that returns 0 (PASSed) or != 0 (FAILed). Let's consider our bogus example::
 
     $ cat output_record.sh
     #!/bin/bash
@@ -643,11 +643,11 @@ This accomplishes a similar effect to the multiplex setup defined in there.
     15:54:31 test       L0387 INFO |
 
 
-Environment Variables for Dropin Tests
+Environment Variables for Simple Tests
 ======================================
 
 Avocado exports avocado variables and multiplexed variables as BASH environment
-to the running test. Those variables are interesting to drop-in tests, because
+to the running test. Those variables are interesting to simple tests, because
 they can not make use of Avocado API directly with Python, like the native
 tests can do and also they can modify the test parameters.
 

--- a/man/avocado.rst
+++ b/man/avocado.rst
@@ -32,7 +32,7 @@ on them being loaded::
 Real use of avocado depends on running avocado subcommands. This a typical list
 of avocado subcommands::
 
- run         Run one or more tests (test module in .py, test alias or dropin)
+ run         Run one or more tests (native test, test alias, binary or script)
  list        List available test modules
  sysinfo     Collect system information
  multiplex   Generate a list of dictionaries with params from a multiplex file
@@ -404,7 +404,7 @@ for both stdout and stderr, ``stdout``, for the stdout only, ``stderr``, for
 only the stderr only, or ``none``, to allow neither of them to be recorded and
 checked.
 
-This process works fine also with dropin tests (random executables that
+This process works fine also with simple tests, executables that
 return 0 (PASSed) or != 0 (FAILed). Let's consider our bogus example::
 
     $ cat output_record.sh

--- a/selftests/all/functional/avocado/basic_tests.py
+++ b/selftests/all/functional/avocado/basic_tests.py
@@ -198,21 +198,21 @@ class RunnerOperationTest(unittest.TestCase):
         self.assertEqual(len(r['job_id']), 40)
 
 
-class RunnerDropinTest(unittest.TestCase):
+class RunnerSimpleTest(unittest.TestCase):
 
     def setUp(self):
         self.pass_script = script.TemporaryScript(
             'avocado_pass.sh',
             PASS_SCRIPT_CONTENTS,
-            'avocado_dropin_functional')
+            'avocado_simpletest_functional')
         self.pass_script.save()
         self.fail_script = script.TemporaryScript(
             'avocado_fail.sh',
             FAIL_SCRIPT_CONTENTS,
-            'avocado_dropin_functional')
+            'avocado_simpletest_functional')
         self.fail_script.save()
 
-    def test_dropin_pass(self):
+    def test_simpletest_pass(self):
         os.chdir(basedir)
         cmd_line = './scripts/avocado run %s' % self.pass_script.path
         result = process.run(cmd_line, ignore_status=True)
@@ -221,7 +221,7 @@ class RunnerDropinTest(unittest.TestCase):
                          "Avocado did not return rc %d:\n%s" %
                          (expected_rc, result))
 
-    def test_dropin_fail(self):
+    def test_simpletest_fail(self):
         os.chdir(basedir)
         cmd_line = './scripts/avocado run %s' % self.fail_script.path
         result = process.run(cmd_line, ignore_status=True)

--- a/selftests/all/functional/avocado/output_check_tests.py
+++ b/selftests/all/functional/avocado/output_check_tests.py
@@ -20,7 +20,7 @@ echo "Hello, avocado!"
 """
 
 
-class RunnerDropinTest(unittest.TestCase):
+class RunnerSimpleTest(unittest.TestCase):
 
     def setUp(self):
         self.output_script = script.TemporaryScript(

--- a/selftests/all/unit/avocado/test_unittest.py
+++ b/selftests/all/unit/avocado/test_unittest.py
@@ -99,35 +99,35 @@ class TestClassTest(unittest.TestCase):
             shutil.rmtree(self.base_logdir, ignore_errors=True)
 
 
-class DropinClassTest(unittest.TestCase):
+class SimpleTestClassTest(unittest.TestCase):
 
     def setUp(self):
         self.pass_script = script.TemporaryScript(
             'avocado_pass.sh',
             PASS_SCRIPT_CONTENTS,
-            'avocado_dropin_unittest')
+            'avocado_simpletest_unittest')
         self.pass_script.save()
 
         self.fail_script = script.TemporaryScript(
             'avocado_fail.sh',
             FAIL_SCRIPT_CONTENTS,
-            'avocado_dropin_unittest')
+            'avocado_simpletest_unittest')
         self.fail_script.save()
 
-        self.tst_instance_pass = test.DropinTest(
+        self.tst_instance_pass = test.SimpleTest(
             path=self.pass_script.path,
             base_logdir=os.path.dirname(self.pass_script.path))
         self.tst_instance_pass.run_avocado()
 
-        self.tst_instance_fail = test.DropinTest(
+        self.tst_instance_fail = test.SimpleTest(
             path=self.fail_script.path,
             base_logdir=os.path.dirname(self.fail_script.path))
         self.tst_instance_fail.run_avocado()
 
-    def testDropinPassStatus(self):
+    def testSimpleTestPassStatus(self):
         self.assertEqual(self.tst_instance_pass.status, 'PASS')
 
-    def testDropinFailStatus(self):
+    def testSimpleTestFailStatus(self):
         self.assertEqual(self.tst_instance_fail.status, 'FAIL')
 
     def tearDown(self):


### PR DESCRIPTION
Due the concept of "drop-in" tests didn't match the actual
purpose of running any script or binary as a test in Avocado, we're
going to use the term "simple test" (defined in SimpleTest class)
to contrast with "native test", which are Python modules that
uses Avocado's API.

Signed-off-by: Rudá Moura rmoura@redhat.com
