### PR TITLE
avocado: Remove references to /var/tmp/avocado

### DIFF
--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -54,13 +54,13 @@ if 'VIRTUAL_ENV' in os.environ:
 SYSTEM_TEST_DIR = os.path.join(SYSTEM_BASE_DIR, 'tests')
 SYSTEM_DATA_DIR = os.path.join(SYSTEM_BASE_DIR, 'data')
 SYSTEM_LOG_DIR = os.path.join(SYSTEM_BASE_DIR, 'job-results')
-SYSTEM_TMP_DIR = '/var/tmp/avocado'
+SYSTEM_TMP_DIR = '/var/tmp'
 
 USER_BASE_DIR = os.path.expanduser('~/avocado')
 USER_TEST_DIR = os.path.join(USER_BASE_DIR, 'tests')
 USER_DATA_DIR = os.path.join(USER_BASE_DIR, 'data')
 USER_LOG_DIR = os.path.join(USER_BASE_DIR, 'job-results')
-USER_TMP_DIR = '/var/tmp/avocado'
+USER_TMP_DIR = '/var/tmp'
 
 
 def _usable_rw_dir(directory):

--- a/docs/source/Configuration.rst
+++ b/docs/source/Configuration.rst
@@ -16,7 +16,7 @@ that contain a number of `keys` and `values`. Take for example a basic avocado c
     test_dir = /$HOME/Code/avocado/examples/tests
     data_dir = /usr/share/avocado/data
     logs_dir = ~/avocado/job-results
-    tmp_dir = /var/tmp/avocado
+    tmp_dir = /var/tmp
 
 The ``runner`` section contains a number of keys, all of them related to directories used by
 the test runner. The ``base_dir`` is the base directory to other important avocado directories, such
@@ -82,7 +82,7 @@ configuration, after all the files are parsed in their correct resolution order.
         runner.test_dir $HOME/Code/avocado/examples/tests
         runner.data_dir /usr/share/avocado/data
         runner.logs_dir ~/avocado/job-results
-        runner.tmp_dir  /var/tmp/avocado
+        runner.tmp_dir  /var/tmp
 
 The command also shows the order in which your config files were parsed, giving you a better understanding of
 what's going on. The Section.Key nomenclature was inspired in ``git config --list`` output.
@@ -118,7 +118,7 @@ it will give you an output similar to the one seen below::
         tests $HOME/Code/avocado/examples/tests
         data  $HOME/avocado/data
         logs  $HOME/avocado/job-results
-        tmp   /var/tmp/avocado
+        tmp   /var/tmp
 
 Note that, while avocado will do its best to use the config values you
 provide in the config file, if it can't write values to the locations

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -662,9 +662,9 @@ Here are the current variables that Avocado exports to the tests:
 +-------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
 | AVOCADO_TEST_DATADIR    | Data directory for the test           | $AVOCADO_TEST_BASEDIR/my_test.sh.data                                                               |
 +-------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
-| AVOCADO_TEST_WORKDIR    | Work directory for the test           | /var/tmp/avocado/my_test.sh                                                                         |
+| AVOCADO_TEST_WORKDIR    | Work directory for the test           | /var/tmp/my_test.sh                                                                                 |
 +-------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
-| AVOCADO_TEST_SRCDIR     | Source directory for the test         | /var/tmp/avocado/my-test.sh/src                                                                     |
+| AVOCADO_TEST_SRCDIR     | Source directory for the test         | /var/tmp/my-test.sh/src                                                                             |
 +-------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
 | AVOCADO_TEST_LOGDIR     | Log directory for the test            | $HOME/logs/job-results/job-2014-09-16T14.38-ac332e6/test-results/$HOME/my_test.sh.1                 |
 +-------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
This probably won't work for multi-users and/or
if /var/tmp/avocado exists before avocado is run
for the first time (with different permissions from
a different user). It's also probably a security
issue: a malicious user could create a /var/tmp/avocado
symlink pointing to /home/someone/important-dir.

This patch removes references to /var/tmp/avocado,
fixing this important security bug.

Recommended reading:

https://kurt.seifried.org/2012/03/14/creating-temporary-files-securely/
http://www.linuxsecurity.com/content/view/115462/151/

Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
