### PR TITLE
avocado.multiplexer: Add support for including files and removing node/values [v0]

### DIFF
--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -127,7 +127,7 @@ class TreeNode(object):
 
     def get_root(self):
         """ Get root of this tree """
-        root = None
+        root = self
         for root in self.iter_parents():
             pass
         return root

--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -34,6 +34,7 @@ original base tree code and re-license under GPLv2+, given that GPLv3 and GPLv2
 """
 
 import collections
+import os
 
 import yaml
 
@@ -42,6 +43,10 @@ try:
     from yaml import CLoader as Loader
 except ImportError:
     from yaml import Loader
+
+
+# Mapping for yaml flags
+YAML_INCLUDE = 0
 
 
 class TreeNode(object):
@@ -294,18 +299,43 @@ class Value(tuple):     # Few methods pylint: disable=R0903
     pass
 
 
+class Control(object):  # Few methods pylint: disable=R0903
+
+    """ Container used to identify node vs. control sequence """
+
+    def __init__(self, ctr_type):
+        self.ctr_type = ctr_type
+
+    def __eq__(self, other):
+        if isinstance(other, Control):
+            return self.ctr_type == other.ctr_type
+        else:
+            return self.ctr_type == other
+
+    def __req__(self, other):
+        return self == other
+
+    def __str__(self):
+        return self.ctr_type
+
+
 def _create_from_yaml(path, cls_node=TreeNode):
     """ Create tree structure from yaml stream """
     def tree_node_from_values(name, values):
         """ Create `name` node and add values  """
-        node_children = []
-        node_values = []
+        node = cls_node(str(name))
         for value in values:
             if isinstance(value, TreeNode):
-                node_children.append(value)
+                node.add_child(value)
+            elif isinstance(value[0], Control):
+                # Include file
+                ypath = value[1]
+                if ypath[0] != '/':
+                    ypath = os.path.join(os.path.dirname(path), ypath)
+                node.merge(_create_from_yaml(ypath, cls_node))
             else:
-                node_values.append(value)
-        return cls_node(name, dict(node_values), children=node_children)
+                node.value[value[0]] = value[1]
+        return node
 
     def mapping_to_tree_loader(loader, node):
         """ Maps yaml mapping tag to TreeNode structure """
@@ -323,10 +353,13 @@ def _create_from_yaml(path, cls_node=TreeNode):
             if is_node(values):    # New node
                 objects.append(tree_node_from_values(name, values))
             elif values is None:            # Empty node
-                objects.append(cls_node(name))
+                objects.append(cls_node(str(name)))
             else:                           # Values
                 objects.append(Value((name, values)))
         return objects
+
+    Loader.add_constructor(u'!include',
+                           lambda loader, node: Control(YAML_INCLUDE))
     Loader.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
                            mapping_to_tree_loader)
 

--- a/examples/mux-selftest-advanced.yaml
+++ b/examples/mux-selftest-advanced.yaml
@@ -1,10 +1,15 @@
 # Put everything into /virt
-!using : /virt
+!using : virt
 # Following line makes it look exactly as mux-selftest.yaml
 !include : mux-selftest.yaml
 distro:
     # This line extends the distro branch using include
     !include : mux-selftest-distro.yaml
+    # remove node called "mint"
+    !remove_node : mint
+    # This is a new /distro/mint appended as latest child
+    mint:
+        new_mint: True
 # This creates new branch the usual way
 new_node:
     # Put this new_node into /absolutely/fresh/

--- a/examples/mux-selftest-advanced.yaml
+++ b/examples/mux-selftest-advanced.yaml
@@ -1,3 +1,5 @@
+# Put everything into /virt
+!using : /virt
 # Following line makes it look exactly as mux-selftest.yaml
 !include : mux-selftest.yaml
 distro:
@@ -5,4 +7,6 @@ distro:
     !include : mux-selftest-distro.yaml
 # This creates new branch the usual way
 new_node:
+    # Put this new_node into /absolutely/fresh/
+    !using : /absolutely/fresh/
     new_value: "something"

--- a/examples/mux-selftest-advanced.yaml
+++ b/examples/mux-selftest-advanced.yaml
@@ -1,0 +1,8 @@
+# Following line makes it look exactly as mux-selftest.yaml
+!include : mux-selftest.yaml
+distro:
+    # This line extends the distro branch using include
+    !include : mux-selftest-distro.yaml
+# This creates new branch the usual way
+new_node:
+    new_value: "something"

--- a/examples/mux-selftest-advanced.yaml
+++ b/examples/mux-selftest-advanced.yaml
@@ -10,6 +10,15 @@ distro:
     # This is a new /distro/mint appended as latest child
     mint:
         new_mint: True
+    fedora:
+        !remove_value : init
+        new_init: systemd
+    gentoo:
+        # This modifies the value of 'is_cool'
+        is_cool: True
+        # And this removes the original 'is_cool'
+        # Setting happens after ctrl so it should be created'
+        !remove_value : is_cool
 # This creates new branch the usual way
 new_node:
     # Put this new_node into /absolutely/fresh/

--- a/examples/mux-selftest-distro.yaml
+++ b/examples/mux-selftest-distro.yaml
@@ -1,0 +1,6 @@
+RHEL:
+    enterprise: true
+    6:
+        init: 'systemv'
+    7:
+        init: 'systemd'

--- a/examples/mux-selftest-distro.yaml
+++ b/examples/mux-selftest-distro.yaml
@@ -4,3 +4,5 @@ RHEL:
         init: 'systemv'
     7:
         init: 'systemd'
+gentoo:
+    is_cool: False

--- a/selftests/all/unit/avocado/tree_unittest.py
+++ b/selftests/all/unit/avocado/tree_unittest.py
@@ -152,6 +152,18 @@ class TestTree(unittest.TestCase):
         self.assertEqual({'nic': 'virtio'},
                          tree2.children[0].children[2].children[1].value)
 
+    def test_advanced_yaml(self):
+        tree2 = tree.create_from_yaml(['examples/mux-selftest-advanced.yaml'])
+        exp = ['intel', 'amd', 'arm', 'scsi', 'virtio', 'fedora', 'mint', '6',
+               '7', 'prod', 'new_node']
+        act = tree2.get_leaves()
+        self.assertEqual(exp, act)
+        self.assertEqual({'enterprise': True},
+                         tree2.children[1].children[2].value)
+        self.assertEqual({'init': 'systemd'},
+                         tree2.children[1].children[0].value)
+        self.assertEqual({'new_value': 'something'}, tree2.children[3].value)
+
 
 class TestPathParent(unittest.TestCase):
 

--- a/selftests/all/unit/avocado/tree_unittest.py
+++ b/selftests/all/unit/avocado/tree_unittest.py
@@ -153,14 +153,16 @@ class TestTree(unittest.TestCase):
     def test_advanced_yaml(self):
         tree2 = tree.create_from_yaml(['examples/mux-selftest-advanced.yaml'])
         exp = ['intel', 'amd', 'arm', 'scsi', 'virtio', 'fedora', '6',
-               '7', 'mint', 'prod', 'new_node']
+               '7', 'gentoo', 'mint', 'prod', 'new_node']
         act = tree2.get_leaves()
         oldroot = tree2.children[0]
         self.assertEqual(exp, act)
         self.assertEqual({'enterprise': True},
                          oldroot.children[1].children[1].value)
-        self.assertEqual({'init': 'systemd'},
+        self.assertEqual({'new_init': 'systemd'},
                          oldroot.children[1].children[0].value)
+        self.assertEqual({'is_cool': True},
+                         oldroot.children[1].children[2].value)
         self.assertEqual({'new_value': 'something'},
                          oldroot.children[3].children[0].children[0].value)
 

--- a/selftests/all/unit/avocado/tree_unittest.py
+++ b/selftests/all/unit/avocado/tree_unittest.py
@@ -52,8 +52,6 @@ class TestTree(unittest.TestCase):
         # Add_child existing
         tree3.add_child(tree2.children[0])
         self.assertEqual(tree3, tree2)
-        # Add_child incorrect class
-        self.assertRaises(ValueError, tree3.add_child, 'probably_bad_type')
 
     def test_links(self):
         """ Verify child->parent links """
@@ -154,13 +152,13 @@ class TestTree(unittest.TestCase):
 
     def test_advanced_yaml(self):
         tree2 = tree.create_from_yaml(['examples/mux-selftest-advanced.yaml'])
-        exp = ['intel', 'amd', 'arm', 'scsi', 'virtio', 'fedora', 'mint', '6',
-               '7', 'prod', 'new_node']
+        exp = ['intel', 'amd', 'arm', 'scsi', 'virtio', 'fedora', '6',
+               '7', 'mint', 'prod', 'new_node']
         act = tree2.get_leaves()
         oldroot = tree2.children[0]
         self.assertEqual(exp, act)
         self.assertEqual({'enterprise': True},
-                         oldroot.children[1].children[2].value)
+                         oldroot.children[1].children[1].value)
         self.assertEqual({'init': 'systemd'},
                          oldroot.children[1].children[0].value)
         self.assertEqual({'new_value': 'something'},

--- a/selftests/all/unit/avocado/tree_unittest.py
+++ b/selftests/all/unit/avocado/tree_unittest.py
@@ -157,12 +157,14 @@ class TestTree(unittest.TestCase):
         exp = ['intel', 'amd', 'arm', 'scsi', 'virtio', 'fedora', 'mint', '6',
                '7', 'prod', 'new_node']
         act = tree2.get_leaves()
+        oldroot = tree2.children[0]
         self.assertEqual(exp, act)
         self.assertEqual({'enterprise': True},
-                         tree2.children[1].children[2].value)
+                         oldroot.children[1].children[2].value)
         self.assertEqual({'init': 'systemd'},
-                         tree2.children[1].children[0].value)
-        self.assertEqual({'new_value': 'something'}, tree2.children[3].value)
+                         oldroot.children[1].children[0].value)
+        self.assertEqual({'new_value': 'something'},
+                         oldroot.children[3].children[0].children[0].value)
 
 
 class TestPathParent(unittest.TestCase):


### PR DESCRIPTION
Hi guys,

Currently I didn't pay attention to documentation as the concept might vary during review phase. I'll add it into the final version.

New features:

* Support for `!include` to include other yaml file (either absolute path, or relative to the __current__ yaml file.
* Support for `!using` to prepend multiple nodes (prepend only, It's impossible to move it outside the current position)
* Support for `!remove_node` to remove node (It's similar to `only` filter, but you're able to recreate any complex structure and reuse it. This feature should help building upstream->downstream configs.
* Support for `!remove_value` to remove value (The same usecase as `!remove_node`. This one I'm not fully convinced about as you can just change the value instead. I added it to double the `node` version).

I'd like to ask a question, do you think it'd be useful to have way to remove all nodes and/or all values from given node? And if so, would you like to have different tag for it, or just use `!remove_node : True/None` (it'd result into boolean, nodes can't be named this way so it's guaranteed not to collide with a name.

Regards,
Lukáš