### PR TITLE
Test discovery and load (Phase II)

### DIFF
--- a/avocado/job.py
+++ b/avocado/job.py
@@ -187,11 +187,39 @@ class Job(object):
             human_plugin = result.HumanTestResult(self.view, self.args)
             self.result_proxy.add_output_plugin(human_plugin)
 
+    def _multiplex_params_list(self, params_list, multiplex_files):
+        for mux_file in multiplex_files:
+            if not os.path.exists(mux_file):
+                e_msg = "Multiplex file %s doesn't exist." % (mux_file)
+                raise exceptions.OptionValidationError(e_msg)
+        result = []
+        for params in params_list:
+            try:
+                variants = multiplexer.multiplex_yamls(multiplex_files,
+                                                       self.args.filter_only,
+                                                       self.args.filter_out)
+            except SyntaxError:
+                variants = None
+            if variants:
+                tag = 1
+                for variant in variants:
+                    env = {}
+                    for t in variant:
+                        env.update(dict(t.environment))
+                    env.update({'tag': tag})
+                    env.update({'id': params['id']})
+                    result.append(env)
+                    tag += 1
+            else:
+                result.append(params)
+        return result
+
     def _run(self, urls=None, multiplex_files=None):
         """
         Unhandled job method. Runs a list of test URLs to its completion.
 
-        :param urls: String with tests to run.
+        :param urls: String with tests to run, separated by whitespace.
+                     Optionally, a list of tests (each test a string).
         :param multiplex_files: File that multiplexes a given test url.
 
         :return: Integer with overall job status. See
@@ -200,53 +228,25 @@ class Job(object):
                 :class:`avocado.core.exceptions.JobBaseException` errors,
                 that configure a job failure.
         """
-        params_list = []
         if urls is None:
-            if self.args and self.args.url:
+            if self.args and self.args.url is not None:
                 urls = self.args.url
-        else:
-            if isinstance(urls, str):
-                urls = urls.split()
+            else:
+                e_msg = "Empty test ID. A test path or alias must be provided"
+                raise exceptions.OptionValidationError(e_msg)
 
-        if urls is not None:
-            for url in urls:
-                params_list.append({'id': url})
-        else:
-            e_msg = "Empty test ID. A test path or alias must be provided"
-            raise exceptions.OptionValidationError(e_msg)
+        if isinstance(urls, str):
+            urls = urls.split()
+
+        self._make_test_loader()
+        params_list = self.test_loader.discover_urls(urls)
 
         if multiplex_files is None:
             if self.args and self.args.multiplex_files is not None:
                 multiplex_files = self.args.multiplex_files
-        else:
-            multiplex_files = multiplex_files
 
         if multiplex_files is not None:
-            for mux_file in multiplex_files:
-                if not os.path.exists(mux_file):
-                    e_msg = "Multiplex file %s doesn't exist." % (mux_file)
-                    raise exceptions.OptionValidationError(e_msg)
-            params_list = []
-            if urls is not None:
-                for url in urls:
-                    try:
-                        variants = multiplexer.multiplex_yamls(multiplex_files,
-                                                               self.args.filter_only,
-                                                               self.args.filter_out)
-                    except SyntaxError:
-                        variants = None
-                    if variants:
-                        tag = 1
-                        for variant in variants:
-                            env = {}
-                            for t in variant:
-                                env.update(dict(t.environment))
-                            env.update({'tag': tag})
-                            env.update({'id': url})
-                            params_list.append(env)
-                            tag += 1
-                    else:
-                        params_list.append({'id': url})
+            params_list = self._multiplex_params_list(params_list, multiplex_files)
 
         if not params_list:
             e_msg = "Test(s) with empty parameter list or the number of variants is zero"
@@ -257,13 +257,13 @@ class Job(object):
 
         self._make_test_result()
         self._make_test_runner()
-        self._make_test_loader()
 
         self.view.start_file_logging(self.logfile,
                                      self.loglevel,
                                      self.unique_id)
         self.view.logfile = self.logfile
-        failures = self.test_runner.run_suite(params_list)
+        test_suite = self.test_loader.discover(params_list)
+        failures = self.test_runner.run_suite(test_suite)
         self.view.stop_file_logging()
         # If it's all good so far, set job status to 'PASS'
         if self.status == 'RUNNING':
@@ -298,7 +298,8 @@ class Job(object):
         The test runner figures out which tests need to be run on an empty urls
         list by assuming the first component of the shortname is the test url.
 
-        :param urls: String with tests to run.
+        :param urls: String with tests to run, separated by whitespace.
+                     Optionally, a list of tests (each test a string).
         :param multiplex_files: File that multiplexes a given test url.
 
         :return: Integer with overall job status. See

--- a/avocado/loader.py
+++ b/avocado/loader.py
@@ -83,8 +83,7 @@ class TestLoader(object):
         :type params: dict
         :return: a test factory (a pair of test class and test parameters)
         """
-        test_name = params.get('id')
-        test_path = os.path.abspath(test_name)
+        test_name = test_path = params.get('id')
         if os.path.exists(test_path):
             path_analyzer = path.PathInspector(test_path)
             if path_analyzer.is_python():

--- a/avocado/runner.py
+++ b/avocado/runner.py
@@ -65,6 +65,8 @@ class TestRunner(object):
         sys.stdout = output.LoggingFile(logger=logging.getLogger('avocado.test.stdout'))
         sys.stderr = output.LoggingFile(logger=logging.getLogger('avocado.test.stderr'))
         instance = self.job.test_loader.load_test(test_factory)
+        if instance.runner_queue is None:
+            instance.runner_queue = queue
         runtime.CURRENT_TEST = instance
         early_state = instance.get_state()
         queue.put(early_state)
@@ -102,19 +104,17 @@ class TestRunner(object):
             test_state['text_output'] = log_file_obj.read()
         return test_state
 
-    def run_suite(self, params_list):
+    def run_suite(self, test_suite):
         """
         Run one or more tests and report with test result.
 
-        :param params_list: a list of param dicts.
-
+        :param test_suite: a list of tests to run.
         :return: a list of test failures.
         """
         failures = []
         self.sysinfo.start_job_hook()
         self.result.start_tests()
         q = queues.SimpleQueue()
-        test_suite = self.job.test_loader.discover(params_list, q)
 
         for test_factory in test_suite:
             p = multiprocessing.Process(target=self.run_test,

--- a/selftests/all/functional/avocado/basic_tests.py
+++ b/selftests/all/functional/avocado/basic_tests.py
@@ -161,7 +161,7 @@ class RunnerOperationTest(unittest.TestCase):
         cmd_line = './scripts/avocado run'
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 2
-        expected_output = 'Empty test ID. A test path or alias must be provided'
+        expected_output = 'Test(s) with empty parameter list or the number of variants is zero'
         expected_output_2 = 'usage:'
         self.assertEqual(result.exit_status, expected_rc)
         self.assertIn(expected_output, result.stdout)


### PR DESCRIPTION
* Add support to inspect and find tests inside a directory, recursively,
by using the method `discover_directory()`. It takes a path and
returns the tests parameters it discovers.
* Change how we discover tests so that we don't set the queue for
communicating, by the time we're looking for tests. Leave it for
the runner module.
* Add methods `discover_url()` and `discover_urls()`, which will return
tests parameters from a list of urls (paths).
* Rewrite code inside `_run()` method in order to make use
of `_multiplex_params_list()` method, containing the logic
to create test variants from the param lists and multiplex_files.
