### PR TITLE
avocado.multiplexer: Add support for including files and removing node/values [v1]

### DIFF
--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -47,6 +47,7 @@ except ImportError:
 
 # Mapping for yaml flags
 YAML_INCLUDE = 0
+YAML_USING = 1
 
 
 class TreeNode(object):
@@ -324,17 +325,31 @@ def _create_from_yaml(path, cls_node=TreeNode):
     def tree_node_from_values(name, values):
         """ Create `name` node and add values  """
         node = cls_node(str(name))
+        using = ''
         for value in values:
             if isinstance(value, TreeNode):
                 node.add_child(value)
             elif isinstance(value[0], Control):
-                # Include file
-                ypath = value[1]
-                if not os.path.isabs(ypath):
-                    ypath = os.path.join(os.path.dirname(path), ypath)
-                node.merge(_create_from_yaml(ypath, cls_node))
+                if value[0] == YAML_INCLUDE:
+                    # Include file
+                    ypath = value[1]
+                    if not os.path.isabs(ypath):
+                        ypath = os.path.join(os.path.dirname(path), ypath)
+                    node.merge(_create_from_yaml(ypath, cls_node))
+                elif value[0] == YAML_USING:
+                    if using:
+                        raise ValueError("!using can be used only once per "
+                                         "node! (%s:%s)" % (path, name))
+                    using = value[1]
+                    if using[0] == '/':
+                        using = using[1:]
+                    if using[-1] == '/':
+                        using = using[:-1]
             else:
                 node.value[value[0]] = value[1]
+        if using:
+            for name in using.split('/')[::-1]:
+                node = cls_node(name, children=[node])
         return node
 
     def mapping_to_tree_loader(loader, node):
@@ -360,6 +375,8 @@ def _create_from_yaml(path, cls_node=TreeNode):
 
     Loader.add_constructor(u'!include',
                            lambda loader, node: Control(YAML_INCLUDE))
+    Loader.add_constructor(u'!using',
+                           lambda loader, node: Control(YAML_USING))
     Loader.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
                            mapping_to_tree_loader)
 

--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -35,6 +35,7 @@ original base tree code and re-license under GPLv2+, given that GPLv3 and GPLv2
 
 import collections
 import os
+import re
 
 import yaml
 
@@ -48,6 +49,16 @@ except ImportError:
 # Mapping for yaml flags
 YAML_INCLUDE = 0
 YAML_USING = 1
+YAML_REMOVE_NODE = 2
+
+
+class Control(object):  # Few methods pylint: disable=R0903
+
+    """ Container used to identify node vs. control sequence """
+
+    def __init__(self, code, value=None):
+        self.code = code
+        self.value = value
 
 
 class TreeNode(object):
@@ -66,6 +77,7 @@ class TreeNode(object):
         self.parent = parent
         self.children = []
         self._environment = None
+        self.ctrl = []
         for child in children:
             self.add_child(child)
 
@@ -118,6 +130,16 @@ class TreeNode(object):
         or merged into existing node in the previous position.
         """
         self.value.update(other.value)
+        for ctrl in other.ctrl:
+            if isinstance(ctrl, Control):
+                if ctrl.code == YAML_REMOVE_NODE:
+                    remove = []
+                    regexp = re.compile(ctrl.value)
+                    for child in self.children:
+                        if regexp.match(child.name):
+                            remove.append(child)
+                    for child in remove:
+                        self.children.remove(child)
         for child in other.children:
             self.add_child(child)
 
@@ -300,26 +322,6 @@ class Value(tuple):     # Few methods pylint: disable=R0903
     pass
 
 
-class Control(object):  # Few methods pylint: disable=R0903
-
-    """ Container used to identify node vs. control sequence """
-
-    def __init__(self, ctr_type):
-        self.ctr_type = ctr_type
-
-    def __eq__(self, other):
-        if isinstance(other, Control):
-            return self.ctr_type == other.ctr_type
-        else:
-            return self.ctr_type == other
-
-    def __req__(self, other):
-        return self == other
-
-    def __str__(self):
-        return self.ctr_type
-
-
 def _create_from_yaml(path, cls_node=TreeNode):
     """ Create tree structure from yaml stream """
     def tree_node_from_values(name, values):
@@ -330,13 +332,13 @@ def _create_from_yaml(path, cls_node=TreeNode):
             if isinstance(value, TreeNode):
                 node.add_child(value)
             elif isinstance(value[0], Control):
-                if value[0] == YAML_INCLUDE:
+                if value[0].code == YAML_INCLUDE:
                     # Include file
                     ypath = value[1]
                     if not os.path.isabs(ypath):
                         ypath = os.path.join(os.path.dirname(path), ypath)
                     node.merge(_create_from_yaml(ypath, cls_node))
-                elif value[0] == YAML_USING:
+                elif value[0].code == YAML_USING:
                     if using:
                         raise ValueError("!using can be used only once per "
                                          "node! (%s:%s)" % (path, name))
@@ -345,6 +347,9 @@ def _create_from_yaml(path, cls_node=TreeNode):
                         using = using[1:]
                     if using[-1] == '/':
                         using = using[:-1]
+                elif value[0].code == YAML_REMOVE_NODE:
+                    value[0].value = value[1]   # set the name
+                    node.ctrl.append(value[0])    # add "blue pill" of death
             else:
                 node.value[value[0]] = value[1]
         if using:
@@ -377,6 +382,8 @@ def _create_from_yaml(path, cls_node=TreeNode):
                            lambda loader, node: Control(YAML_INCLUDE))
     Loader.add_constructor(u'!using',
                            lambda loader, node: Control(YAML_USING))
+    Loader.add_constructor(u'!remove_node',
+                           lambda loader, node: Control(YAML_REMOVE_NODE))
     Loader.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
                            mapping_to_tree_loader)
 

--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -127,7 +127,7 @@ class TreeNode(object):
 
     def get_root(self):
         """ Get root of this tree """
-        root = None
+        root = self
         for root in self.iter_parents():
             pass
         return root

--- a/docs/source/MultiplexConfig.rst
+++ b/docs/source/MultiplexConfig.rst
@@ -66,6 +66,34 @@ The ending nodes (the leafs on the tree) will become part of all lower-level
 However, the precedence is evaluated in top-down or ``last defined`` order.
 In other words, the last parsed has precedence over earlier definitions.
 
+It's also possible to remove node using python's regexp, which can be useful
+when extending upstream file using downstream yaml files. This is done by
+`!remove_node : $value_name` directive::
+
+    os:
+        fedora:
+        windows:
+            3.11:
+            95:
+    os:
+        !remove_node : windows
+        windows:
+            win3.11:
+            win95:
+
+Removes the `windows` node from structure. It's different from `filter-out`
+as it really removes the node (and all children) from the tree and
+it can be replaced by you new structure as shown in the example. It removes
+`windows` with all children and then replaces this structure with slightly
+modified version.
+
+As `!remove_node` is processed during merge, when you reverse the order,
+windows is not removed and you end-up with `/windows/{win3.11,win95,3.11,95}`
+nodes.
+
+Due to yaml nature, it's __mandatory__ to put space between `!remove_node`
+and `:`!
+
 Additionally you can prepend multiple nodes to the given node by using
 `!using : $prepended/path`. This is useful when extending complex structure,
 for example imagine having distro variants in separate ymal files. In the

--- a/docs/source/MultiplexConfig.rst
+++ b/docs/source/MultiplexConfig.rst
@@ -155,6 +155,21 @@ results in::
     fast:
         CFLAGS: '-Ofast'    # appended
 
+It's also possilbe to include existing file into other file's node. This
+is done by `!include : $path` directive::
+
+    os:
+        fedora:
+            !include : fedora.yaml
+        gentoo:
+            !include : gentoo.yaml
+
+Due to yaml nature, it's __mandatory__ to put space between `!include` and `:`!
+
+The file location can be either absolute path or relative path to the yaml
+file where the `!include` is called (even when it's nested).
+
+Whole file is __merged__ into the node where it's defined.
 
 .. _variants:
 

--- a/docs/source/MultiplexConfig.rst
+++ b/docs/source/MultiplexConfig.rst
@@ -163,6 +163,22 @@ And lists::
 
 The list above will become ``['-O2', '-g', '-Wall']`` to Python. In fact,
 YAML is compatible to JSON.
+
+It's also possible to remove key using python's regexp, which can be useful
+when extending upstream file using downstream yaml files. This is done by
+`!remove_value : $value_name` directive::
+
+    debug:
+        CFLAGS: '-O0 -g'
+    debug:
+        !remove_value: CFLAGS
+
+removes the CFLAGS value completely from the debug node. This happens during
+the merge and only once. So if you switch the two, CFLAGS would be defined.
+
+Due to yaml nature, it's __mandatory__ to put space between `!remove_value`
+and `:`!
+
 .. _environment:
 
 Environment

--- a/docs/source/MultiplexConfig.rst
+++ b/docs/source/MultiplexConfig.rst
@@ -66,6 +66,51 @@ The ending nodes (the leafs on the tree) will become part of all lower-level
 However, the precedence is evaluated in top-down or ``last defined`` order.
 In other words, the last parsed has precedence over earlier definitions.
 
+Additionally you can prepend multiple nodes to the given node by using
+`!using : $prepended/path`. This is useful when extending complex structure,
+for example imagine having distro variants in separate ymal files. In the
+end you want to merge them into the `/os` node. The main file can be simply::
+
+    # main.yaml
+    os:
+        !include : os/fedora/21.yaml
+        ....
+
+And each file can look either like this::
+
+    # fedora/21.yaml
+    fedora:
+        21:
+            some: value
+
+or you can use `!using` which prepends the `fedora/21`::
+
+    # fedora/21.yaml
+    !using : /fedora/21
+    some: value
+
+To be precise there is a way to define the structure in the main yaml file::
+
+    # main.yaml
+    os:
+        fedora:
+            21:
+                !include : fedora_21.yaml
+
+Or use recursive `!include` (slower)::
+
+    # main.yaml
+    os:
+        fedora:
+            !include : os/fedora.yaml
+    # os/fedora.yaml
+    21:
+        !include : fedora/21.yaml
+    # os/fedora/21.yaml
+    some: value
+
+Due to yaml nature, it's __mandatory__ to put space between `!using` and `:`!
+
 .. _keys_and_values:
 
 Keys and Values

--- a/examples/mux-selftest-advanced.yaml
+++ b/examples/mux-selftest-advanced.yaml
@@ -1,10 +1,15 @@
 # Put everything into /virt
-!using : /virt
+!using : virt
 # Following line makes it look exactly as mux-selftest.yaml
 !include : mux-selftest.yaml
 distro:
     # This line extends the distro branch using include
     !include : mux-selftest-distro.yaml
+    # remove node called "mint"
+    !remove_node : mi.*nt
+    # This is a new /distro/mint appended as latest child
+    mint:
+        new_mint: True
 # This creates new branch the usual way
 new_node:
     # Put this new_node into /absolutely/fresh/ ('/' are automatically

--- a/examples/mux-selftest-advanced.yaml
+++ b/examples/mux-selftest-advanced.yaml
@@ -1,3 +1,5 @@
+# Put everything into /virt
+!using : /virt
 # Following line makes it look exactly as mux-selftest.yaml
 !include : mux-selftest.yaml
 distro:
@@ -5,4 +7,8 @@ distro:
     !include : mux-selftest-distro.yaml
 # This creates new branch the usual way
 new_node:
+    # Put this new_node into /absolutely/fresh/ ('/' are automatically
+    # removed during parse time, absolute location is not supported and
+    # not even planned)
+    !using : /absolutely/fresh/
     new_value: "something"

--- a/examples/mux-selftest-advanced.yaml
+++ b/examples/mux-selftest-advanced.yaml
@@ -10,6 +10,15 @@ distro:
     # This is a new /distro/mint appended as latest child
     mint:
         new_mint: True
+    fedora:
+        !remove_value : init.*
+        new_init: systemd
+    gentoo:
+        # This modifies the value of 'is_cool'
+        is_cool: True
+        # And this removes the original 'is_cool'
+        # Setting happens after ctrl so it should be created'
+        !remove_value : is_cool
 # This creates new branch the usual way
 new_node:
     # Put this new_node into /absolutely/fresh/ ('/' are automatically

--- a/examples/mux-selftest-advanced.yaml
+++ b/examples/mux-selftest-advanced.yaml
@@ -1,0 +1,8 @@
+# Following line makes it look exactly as mux-selftest.yaml
+!include : mux-selftest.yaml
+distro:
+    # This line extends the distro branch using include
+    !include : mux-selftest-distro.yaml
+# This creates new branch the usual way
+new_node:
+    new_value: "something"

--- a/examples/mux-selftest-distro.yaml
+++ b/examples/mux-selftest-distro.yaml
@@ -1,0 +1,6 @@
+RHEL:
+    enterprise: true
+    6:
+        init: 'systemv'
+    7:
+        init: 'systemd'

--- a/examples/mux-selftest-distro.yaml
+++ b/examples/mux-selftest-distro.yaml
@@ -4,3 +4,5 @@ RHEL:
         init: 'systemv'
     7:
         init: 'systemd'
+gentoo:
+    is_cool: False

--- a/selftests/all/unit/avocado/tree_unittest.py
+++ b/selftests/all/unit/avocado/tree_unittest.py
@@ -152,6 +152,18 @@ class TestTree(unittest.TestCase):
         self.assertEqual({'nic': 'virtio'},
                          tree2.children[0].children[2].children[1].value)
 
+    def test_advanced_yaml(self):
+        tree2 = tree.create_from_yaml(['examples/mux-selftest-advanced.yaml'])
+        exp = ['intel', 'amd', 'arm', 'scsi', 'virtio', 'fedora', 'mint', '6',
+               '7', 'prod', 'new_node']
+        act = tree2.get_leaves()
+        self.assertEqual(exp, act)
+        self.assertEqual({'enterprise': True},
+                         tree2.children[1].children[2].value)
+        self.assertEqual({'init': 'systemd'},
+                         tree2.children[1].children[0].value)
+        self.assertEqual({'new_value': 'something'}, tree2.children[3].value)
+
 
 class TestPathParent(unittest.TestCase):
 

--- a/selftests/all/unit/avocado/tree_unittest.py
+++ b/selftests/all/unit/avocado/tree_unittest.py
@@ -153,14 +153,16 @@ class TestTree(unittest.TestCase):
     def test_advanced_yaml(self):
         tree2 = tree.create_from_yaml(['examples/mux-selftest-advanced.yaml'])
         exp = ['intel', 'amd', 'arm', 'scsi', 'virtio', 'fedora', '6',
-               '7', 'mint', 'prod', 'new_node']
+               '7', 'gentoo', 'mint', 'prod', 'new_node']
         act = tree2.get_leaves()
         oldroot = tree2.children[0]
         self.assertEqual(exp, act)
         self.assertEqual({'enterprise': True},
                          oldroot.children[1].children[1].value)
-        self.assertEqual({'init': 'systemd'},
+        self.assertEqual({'new_init': 'systemd'},
                          oldroot.children[1].children[0].value)
+        self.assertEqual({'is_cool': True},
+                         oldroot.children[1].children[2].value)
         self.assertEqual({'new_value': 'something'},
                          oldroot.children[3].children[0].children[0].value)
 

--- a/selftests/all/unit/avocado/tree_unittest.py
+++ b/selftests/all/unit/avocado/tree_unittest.py
@@ -52,8 +52,6 @@ class TestTree(unittest.TestCase):
         # Add_child existing
         tree3.add_child(tree2.children[0])
         self.assertEqual(tree3, tree2)
-        # Add_child incorrect class
-        self.assertRaises(ValueError, tree3.add_child, 'probably_bad_type')
 
     def test_links(self):
         """ Verify child->parent links """
@@ -154,13 +152,13 @@ class TestTree(unittest.TestCase):
 
     def test_advanced_yaml(self):
         tree2 = tree.create_from_yaml(['examples/mux-selftest-advanced.yaml'])
-        exp = ['intel', 'amd', 'arm', 'scsi', 'virtio', 'fedora', 'mint', '6',
-               '7', 'prod', 'new_node']
+        exp = ['intel', 'amd', 'arm', 'scsi', 'virtio', 'fedora', '6',
+               '7', 'mint', 'prod', 'new_node']
         act = tree2.get_leaves()
         oldroot = tree2.children[0]
         self.assertEqual(exp, act)
         self.assertEqual({'enterprise': True},
-                         oldroot.children[1].children[2].value)
+                         oldroot.children[1].children[1].value)
         self.assertEqual({'init': 'systemd'},
                          oldroot.children[1].children[0].value)
         self.assertEqual({'new_value': 'something'},

--- a/selftests/all/unit/avocado/tree_unittest.py
+++ b/selftests/all/unit/avocado/tree_unittest.py
@@ -157,12 +157,14 @@ class TestTree(unittest.TestCase):
         exp = ['intel', 'amd', 'arm', 'scsi', 'virtio', 'fedora', 'mint', '6',
                '7', 'prod', 'new_node']
         act = tree2.get_leaves()
+        oldroot = tree2.children[0]
         self.assertEqual(exp, act)
         self.assertEqual({'enterprise': True},
-                         tree2.children[1].children[2].value)
+                         oldroot.children[1].children[2].value)
         self.assertEqual({'init': 'systemd'},
-                         tree2.children[1].children[0].value)
-        self.assertEqual({'new_value': 'something'}, tree2.children[3].value)
+                         oldroot.children[1].children[0].value)
+        self.assertEqual({'new_value': 'something'},
+                         oldroot.children[3].children[0].children[0].value)
 
 
 class TestPathParent(unittest.TestCase):


### PR DESCRIPTION
This pull request adds following multiplexer features.
 
* Support for !include to include other yaml file (either absolute path, or relative to the current yaml file.
* Support for !using to prepend multiple nodes (prepend only, It's impossible to move it outside the current position)
* Support for !remove_node to remove node (It's similar to only filter, but you're able to recreate any complex structure and reuse it. This feature should help building upstream->downstream configs.
* Support for !remove_value to remove value (The same usecase as !remove_node. This one I'm not fully convinced about as you can just change the value instead. I added it to double the node version).

v0: https://github.com/avocado-framework/avocado/pull/316

Changes:

    v1: Support python's regexp to specify node/keys to be removed
    v1: Use os.path.abspath() to determine path type
    v1: Remove only sinlge '/' at the beginning, resp. end of the '!using' directive
    v1: Documentation
    v1: Additional explanation in 'mux-selftest-advanced' to avoid confusions