### PR TITLE
[Wip] Test discovery and load (Phase II) [V2]

### DIFF
--- a/avocado/job.py
+++ b/avocado/job.py
@@ -187,11 +187,39 @@ class Job(object):
             human_plugin = result.HumanTestResult(self.view, self.args)
             self.result_proxy.add_output_plugin(human_plugin)
 
+    def _multiplex_params_list(self, params_list, multiplex_files):
+        for mux_file in multiplex_files:
+            if not os.path.exists(mux_file):
+                e_msg = "Multiplex file %s doesn't exist." % (mux_file)
+                raise exceptions.OptionValidationError(e_msg)
+        result = []
+        for params in params_list:
+            try:
+                variants = multiplexer.multiplex_yamls(multiplex_files,
+                                                       self.args.filter_only,
+                                                       self.args.filter_out)
+            except SyntaxError:
+                variants = None
+            if variants:
+                tag = 1
+                for variant in variants:
+                    env = {}
+                    for t in variant:
+                        env.update(dict(t.environment))
+                    env.update({'tag': tag})
+                    env.update({'id': params['id']})
+                    result.append(env)
+                    tag += 1
+            else:
+                result.append(params)
+        return result
+
     def _run(self, urls=None, multiplex_files=None):
         """
         Unhandled job method. Runs a list of test URLs to its completion.
 
-        :param urls: String with tests to run.
+        :param urls: String with tests to run, separated by whitespace.
+                     Optionally, a list of tests (each test a string).
         :param multiplex_files: File that multiplexes a given test url.
 
         :return: Integer with overall job status. See
@@ -200,53 +228,25 @@ class Job(object):
                 :class:`avocado.core.exceptions.JobBaseException` errors,
                 that configure a job failure.
         """
-        params_list = []
         if urls is None:
-            if self.args and self.args.url:
+            if self.args and self.args.url is not None:
                 urls = self.args.url
-        else:
-            if isinstance(urls, str):
-                urls = urls.split()
+            else:
+                e_msg = "Empty test ID. A test path or alias must be provided"
+                raise exceptions.OptionValidationError(e_msg)
 
-        if urls is not None:
-            for url in urls:
-                params_list.append({'id': url})
-        else:
-            e_msg = "Empty test ID. A test path or alias must be provided"
-            raise exceptions.OptionValidationError(e_msg)
+        if isinstance(urls, str):
+            urls = urls.split()
+
+        self._make_test_loader()
+        params_list = self.test_loader.discover_urls(urls)
 
         if multiplex_files is None:
             if self.args and self.args.multiplex_files is not None:
                 multiplex_files = self.args.multiplex_files
-        else:
-            multiplex_files = multiplex_files
 
         if multiplex_files is not None:
-            for mux_file in multiplex_files:
-                if not os.path.exists(mux_file):
-                    e_msg = "Multiplex file %s doesn't exist." % (mux_file)
-                    raise exceptions.OptionValidationError(e_msg)
-            params_list = []
-            if urls is not None:
-                for url in urls:
-                    try:
-                        variants = multiplexer.multiplex_yamls(multiplex_files,
-                                                               self.args.filter_only,
-                                                               self.args.filter_out)
-                    except SyntaxError:
-                        variants = None
-                    if variants:
-                        tag = 1
-                        for variant in variants:
-                            env = {}
-                            for t in variant:
-                                env.update(dict(t.environment))
-                            env.update({'tag': tag})
-                            env.update({'id': url})
-                            params_list.append(env)
-                            tag += 1
-                    else:
-                        params_list.append({'id': url})
+            params_list = self._multiplex_params_list(params_list, multiplex_files)
 
         if not params_list:
             e_msg = "Test(s) with empty parameter list or the number of variants is zero"
@@ -257,13 +257,13 @@ class Job(object):
 
         self._make_test_result()
         self._make_test_runner()
-        self._make_test_loader()
 
         self.view.start_file_logging(self.logfile,
                                      self.loglevel,
                                      self.unique_id)
         self.view.logfile = self.logfile
-        failures = self.test_runner.run_suite(params_list)
+        test_suite = self.test_loader.discover(params_list)
+        failures = self.test_runner.run_suite(test_suite)
         self.view.stop_file_logging()
         # If it's all good so far, set job status to 'PASS'
         if self.status == 'RUNNING':
@@ -298,7 +298,8 @@ class Job(object):
         The test runner figures out which tests need to be run on an empty urls
         list by assuming the first component of the shortname is the test url.
 
-        :param urls: String with tests to run.
+        :param urls: String with tests to run, separated by whitespace.
+                     Optionally, a list of tests (each test a string).
         :param multiplex_files: File that multiplexes a given test url.
 
         :return: Integer with overall job status. See

--- a/avocado/job.py
+++ b/avocado/job.py
@@ -239,7 +239,11 @@ class Job(object):
             urls = urls.split()
 
         self._make_test_loader()
+
         params_list = self.test_loader.discover_urls(urls)
+        if not params_list:
+            e_msg = "No tests found within the specified path(s)"
+            raise exceptions.OptionValidationError(e_msg)
 
         if multiplex_files is None:
             if self.args and self.args.multiplex_files is not None:
@@ -247,10 +251,9 @@ class Job(object):
 
         if multiplex_files is not None:
             params_list = self._multiplex_params_list(params_list, multiplex_files)
-
-        if not params_list:
-            e_msg = "Test(s) with empty parameter list or the number of variants is zero"
-            raise exceptions.OptionValidationError(e_msg)
+            if not params_list:
+                e_msg = "The number of test variants is zero"
+                raise exceptions.OptionValidationError(e_msg)
 
         if self.args is not None:
             self.args.test_result_total = len(params_list)

--- a/avocado/loader.py
+++ b/avocado/loader.py
@@ -83,8 +83,7 @@ class TestLoader(object):
         :type params: dict
         :return: a test factory (a pair of test class and test parameters)
         """
-        test_name = params.get('id')
-        test_path = os.path.abspath(test_name)
+        test_name = test_path = params.get('id')
         if os.path.exists(test_path):
             path_analyzer = path.PathInspector(test_path)
             if path_analyzer.is_python():

--- a/avocado/plugins/runner.py
+++ b/avocado/plugins/runner.py
@@ -16,8 +16,6 @@
 Base Test Runner Plugins.
 """
 
-import sys
-
 from avocado.core import exit_codes
 from avocado.plugins import plugin
 from avocado.core import output
@@ -114,6 +112,7 @@ class TestRunner(plugin.Plugin):
 
         :param args: Command line args received from the run subparser.
         """
+
         view = output.View(app_args=args, use_paginator=True)
         if args.unique_job_id is not None:
             try:
@@ -122,11 +121,12 @@ class TestRunner(plugin.Plugin):
                     raise ValueError
             except ValueError:
                 view.notify(event='error', msg='Unique Job ID needs to be a 40 digit hex number')
-                return sys.exit(exit_codes.AVOCADO_CRASH)
+                return exit_codes.AVOCADO_CRASH
+        if not args.url:
+            self.parser.print_help()
+            view.notify(event='error', msg='Empty test ID. A test path or alias must be provided')
+            return exit_codes.AVOCADO_CRASH
 
         job_instance = job.Job(args)
         rc = job_instance.run()
-        if not args.url:
-            self.parser.print_help()
-
         return rc

--- a/avocado/plugins/test_lister.py
+++ b/avocado/plugins/test_lister.py
@@ -52,7 +52,7 @@ class TestLister(plugin.Plugin):
         test_files = os.listdir(base_test_dir)
         test_dirs = []
         blength = 0
-        for t in test_files:
+        for t in sorted(test_files):
             inspector = path.PathInspector(path=t)
             if inspector.is_python():
                 clength = len((t.split('.')[0]))

--- a/avocado/runner.py
+++ b/avocado/runner.py
@@ -65,6 +65,8 @@ class TestRunner(object):
         sys.stdout = output.LoggingFile(logger=logging.getLogger('avocado.test.stdout'))
         sys.stderr = output.LoggingFile(logger=logging.getLogger('avocado.test.stderr'))
         instance = self.job.test_loader.load_test(test_factory)
+        if instance.runner_queue is None:
+            instance.runner_queue = queue
         runtime.CURRENT_TEST = instance
         early_state = instance.get_state()
         queue.put(early_state)
@@ -102,19 +104,17 @@ class TestRunner(object):
             test_state['text_output'] = log_file_obj.read()
         return test_state
 
-    def run_suite(self, params_list):
+    def run_suite(self, test_suite):
         """
         Run one or more tests and report with test result.
 
-        :param params_list: a list of param dicts.
-
+        :param test_suite: a list of tests to run.
         :return: a list of test failures.
         """
         failures = []
         self.sysinfo.start_job_hook()
         self.result.start_tests()
         q = queues.SimpleQueue()
-        test_suite = self.job.test_loader.discover(params_list, q)
 
         for test_factory in test_suite:
             p = multiprocessing.Process(target=self.run_test,

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -25,6 +25,7 @@ import stat
 import shlex
 import shutil
 import threading
+import fnmatch
 
 try:
     import subprocess32 as subprocess
@@ -868,11 +869,8 @@ def should_run_inside_wrapper(cmd):
     args = shlex.split(cmd)
     cmd_binary_name = args[0]
 
-    for script, cmd in runtime.WRAP_PROCESS_NAMES_EXPR:
-        if os.path.isabs(cmd_binary_name) and os.path.isabs(cmd) is False:
-            cmd_binary_name = os.path.basename(cmd_binary_name)
-            cmd = os.path.basename(cmd)
-        if cmd_binary_name == cmd:
+    for script, cmd_expr in runtime.WRAP_PROCESS_NAMES_EXPR:
+        if fnmatch.fnmatch(cmd_binary_name, cmd_expr):
             runtime.CURRENT_WRAPPER = script
 
     if runtime.WRAP_PROCESS is not None and runtime.CURRENT_WRAPPER is None:

--- a/selftests/all/functional/avocado/basic_tests.py
+++ b/selftests/all/functional/avocado/basic_tests.py
@@ -161,7 +161,7 @@ class RunnerOperationTest(unittest.TestCase):
         cmd_line = './scripts/avocado run'
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 2
-        expected_output = 'Empty test ID. A test path or alias must be provided'
+        expected_output = 'Test(s) with empty parameter list or the number of variants is zero'
         expected_output_2 = 'usage:'
         self.assertEqual(result.exit_status, expected_rc)
         self.assertIn(expected_output, result.stdout)

--- a/selftests/all/functional/avocado/basic_tests.py
+++ b/selftests/all/functional/avocado/basic_tests.py
@@ -160,8 +160,8 @@ class RunnerOperationTest(unittest.TestCase):
         os.chdir(basedir)
         cmd_line = './scripts/avocado run'
         result = process.run(cmd_line, ignore_status=True)
-        expected_rc = 2
-        expected_output = 'Test(s) with empty parameter list or the number of variants is zero'
+        expected_rc = 3
+        expected_output = 'Empty test ID. A test path or alias must be provided'
         expected_output_2 = 'usage:'
         self.assertEqual(result.exit_status, expected_rc)
         self.assertIn(expected_output, result.stdout)

--- a/selftests/all/functional/avocado/multiplex_tests.py
+++ b/selftests/all/functional/avocado/multiplex_tests.py
@@ -70,7 +70,7 @@ class MultiplexTests(unittest.TestCase):
 
     def test_run_mplex_noid(self):
         cmd_line = './scripts/avocado run --multiplex examples/tests/sleeptest.py.data/sleeptest.yaml'
-        expected_rc = 2
+        expected_rc = 3
         self.run_and_check(cmd_line, expected_rc)
 
     def test_run_mplex_passtest(self):

--- a/selftests/all/functional/avocado/wrapper_tests.py
+++ b/selftests/all/functional/avocado/wrapper_tests.py
@@ -52,7 +52,7 @@ class WrapperTest(unittest.TestCase):
 
     def test_process_wrapper(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --wrapper %s:datadir examples/tests/datadir.py' % self.script.path
+        cmd_line = './scripts/avocado run --wrapper %s:*/datadir examples/tests/datadir.py' % self.script.path
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 0
         self.assertEqual(result.exit_status, expected_rc,
@@ -63,7 +63,7 @@ class WrapperTest(unittest.TestCase):
 
     def test_both_wrappers(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --wrapper %s --wrapper %s:datadir examples/tests/datadir.py' % (self.dummy.path, self.script.path)
+        cmd_line = './scripts/avocado run --wrapper %s --wrapper %s:*/datadir examples/tests/datadir.py' % (self.dummy.path, self.script.path)
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 0
         self.assertEqual(result.exit_status, expected_rc,


### PR DESCRIPTION
Follow up of #317.

Changes:
*  avocado.loader: Locate SimpleTests using the full path.
* avocado.job: Set different messages when the number of tests found is zero [No tests found within the specified path(s)] or when the number of variants is zero [The number of test variants is zero].
* avocado.loader: Skip directory if we don't have permission to walk. Also skip tests that are not tests, so Avocado stops crashing when walking in a directory, looking for tests.
* avocado.utils.process: Use shell glob style when matching wrap scripts.
* test_lister plugin: Sort output in alphabetic order.
