### PR TITLE
selftests: Fix return codes

### DIFF
--- a/selftests/checkall
+++ b/selftests/checkall
@@ -1,18 +1,17 @@
 #!/bin/bash
+GR=0
 run_rc() {
     echo "Running '$1'"
     $1
+    if [ $? != 0 ]; then
+        GR=1
+    fi
 }
 run_rc 'inspekt lint'
-rc1=$?
 echo ""
 run_rc 'inspekt indent'
-rc2=$?
 echo ""
 run_rc 'inspekt style'
-rc3=$?
 echo ""
 run_rc 'selftests/run selftests/all'
-rc4=$?
-exit $rc1 || $rc2 || $rc3 || $rc4
-
+exit ${GR}

--- a/selftests/coverageall
+++ b/selftests/coverageall
@@ -1,4 +1,4 @@
 #!/bin/bash
 echo "Cleaning up coverage and running 'selftests/all'"
 ./selftests/run --with-coverage --cover-package=avocado --cover-erase selftests/all
-
+exit $?


### PR DESCRIPTION
Make sure the checkall and coverageall scripts return
failures.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>