### PR TITLE
[V3] Test discovery and load (Phase II)

### DIFF
--- a/avocado/job.py
+++ b/avocado/job.py
@@ -241,9 +241,6 @@ class Job(object):
         self._make_test_loader()
 
         params_list = self.test_loader.discover_urls(urls)
-        if not params_list:
-            e_msg = "No tests found within the specified path(s)"
-            raise exceptions.OptionValidationError(e_msg)
 
         if multiplex_files is None:
             if self.args and self.args.multiplex_files is not None:
@@ -251,12 +248,14 @@ class Job(object):
 
         if multiplex_files is not None:
             params_list = self._multiplex_params_list(params_list, multiplex_files)
-            if not params_list:
-                e_msg = "The number of test variants is zero"
-                raise exceptions.OptionValidationError(e_msg)
+
+        test_suite = self.test_loader.discover(params_list)
+        if not test_suite:
+            e_msg = "No tests found within the specified path(s) (Check input for typos)"
+            raise exceptions.OptionValidationError(e_msg)
 
         if self.args is not None:
-            self.args.test_result_total = len(params_list)
+            self.args.test_result_total = len(test_suite)
 
         self._make_test_result()
         self._make_test_runner()
@@ -265,7 +264,6 @@ class Job(object):
                                      self.loglevel,
                                      self.unique_id)
         self.view.logfile = self.logfile
-        test_suite = self.test_loader.discover(params_list)
         failures = self.test_runner.run_suite(test_suite)
         self.view.stop_file_logging()
         # If it's all good so far, set job status to 'PASS'

--- a/avocado/job.py
+++ b/avocado/job.py
@@ -187,11 +187,39 @@ class Job(object):
             human_plugin = result.HumanTestResult(self.view, self.args)
             self.result_proxy.add_output_plugin(human_plugin)
 
+    def _multiplex_params_list(self, params_list, multiplex_files):
+        for mux_file in multiplex_files:
+            if not os.path.exists(mux_file):
+                e_msg = "Multiplex file %s doesn't exist." % (mux_file)
+                raise exceptions.OptionValidationError(e_msg)
+        result = []
+        for params in params_list:
+            try:
+                variants = multiplexer.multiplex_yamls(multiplex_files,
+                                                       self.args.filter_only,
+                                                       self.args.filter_out)
+            except SyntaxError:
+                variants = None
+            if variants:
+                tag = 1
+                for variant in variants:
+                    env = {}
+                    for t in variant:
+                        env.update(dict(t.environment))
+                    env.update({'tag': tag})
+                    env.update({'id': params['id']})
+                    result.append(env)
+                    tag += 1
+            else:
+                result.append(params)
+        return result
+
     def _run(self, urls=None, multiplex_files=None):
         """
         Unhandled job method. Runs a list of test URLs to its completion.
 
-        :param urls: String with tests to run.
+        :param urls: String with tests to run, separated by whitespace.
+                     Optionally, a list of tests (each test a string).
         :param multiplex_files: File that multiplexes a given test url.
 
         :return: Integer with overall job status. See
@@ -200,53 +228,25 @@ class Job(object):
                 :class:`avocado.core.exceptions.JobBaseException` errors,
                 that configure a job failure.
         """
-        params_list = []
         if urls is None:
-            if self.args and self.args.url:
+            if self.args and self.args.url is not None:
                 urls = self.args.url
-        else:
-            if isinstance(urls, str):
-                urls = urls.split()
+            else:
+                e_msg = "Empty test ID. A test path or alias must be provided"
+                raise exceptions.OptionValidationError(e_msg)
 
-        if urls is not None:
-            for url in urls:
-                params_list.append({'id': url})
-        else:
-            e_msg = "Empty test ID. A test path or alias must be provided"
-            raise exceptions.OptionValidationError(e_msg)
+        if isinstance(urls, str):
+            urls = urls.split()
+
+        self._make_test_loader()
+        params_list = self.test_loader.discover_urls(urls)
 
         if multiplex_files is None:
             if self.args and self.args.multiplex_files is not None:
                 multiplex_files = self.args.multiplex_files
-        else:
-            multiplex_files = multiplex_files
 
         if multiplex_files is not None:
-            for mux_file in multiplex_files:
-                if not os.path.exists(mux_file):
-                    e_msg = "Multiplex file %s doesn't exist." % (mux_file)
-                    raise exceptions.OptionValidationError(e_msg)
-            params_list = []
-            if urls is not None:
-                for url in urls:
-                    try:
-                        variants = multiplexer.multiplex_yamls(multiplex_files,
-                                                               self.args.filter_only,
-                                                               self.args.filter_out)
-                    except SyntaxError:
-                        variants = None
-                    if variants:
-                        tag = 1
-                        for variant in variants:
-                            env = {}
-                            for t in variant:
-                                env.update(dict(t.environment))
-                            env.update({'tag': tag})
-                            env.update({'id': url})
-                            params_list.append(env)
-                            tag += 1
-                    else:
-                        params_list.append({'id': url})
+            params_list = self._multiplex_params_list(params_list, multiplex_files)
 
         if not params_list:
             e_msg = "Test(s) with empty parameter list or the number of variants is zero"
@@ -257,13 +257,13 @@ class Job(object):
 
         self._make_test_result()
         self._make_test_runner()
-        self._make_test_loader()
 
         self.view.start_file_logging(self.logfile,
                                      self.loglevel,
                                      self.unique_id)
         self.view.logfile = self.logfile
-        failures = self.test_runner.run_suite(params_list)
+        test_suite = self.test_loader.discover(params_list)
+        failures = self.test_runner.run_suite(test_suite)
         self.view.stop_file_logging()
         # If it's all good so far, set job status to 'PASS'
         if self.status == 'RUNNING':
@@ -298,7 +298,8 @@ class Job(object):
         The test runner figures out which tests need to be run on an empty urls
         list by assuming the first component of the shortname is the test url.
 
-        :param urls: String with tests to run.
+        :param urls: String with tests to run, separated by whitespace.
+                     Optionally, a list of tests (each test a string).
         :param multiplex_files: File that multiplexes a given test url.
 
         :return: Integer with overall job status. See

--- a/avocado/job.py
+++ b/avocado/job.py
@@ -239,7 +239,11 @@ class Job(object):
             urls = urls.split()
 
         self._make_test_loader()
+
         params_list = self.test_loader.discover_urls(urls)
+        if not params_list:
+            e_msg = "No tests found within the specified path(s)"
+            raise exceptions.OptionValidationError(e_msg)
 
         if multiplex_files is None:
             if self.args and self.args.multiplex_files is not None:
@@ -247,10 +251,9 @@ class Job(object):
 
         if multiplex_files is not None:
             params_list = self._multiplex_params_list(params_list, multiplex_files)
-
-        if not params_list:
-            e_msg = "Test(s) with empty parameter list or the number of variants is zero"
-            raise exceptions.OptionValidationError(e_msg)
+            if not params_list:
+                e_msg = "The number of test variants is zero"
+                raise exceptions.OptionValidationError(e_msg)
 
         if self.args is not None:
             self.args.test_result_total = len(params_list)

--- a/avocado/job.py
+++ b/avocado/job.py
@@ -342,20 +342,8 @@ class TestModuleRunner(object):
     Convenience class to make avocado test modules executable.
     """
 
-    def __init__(self, module='__main__'):
-        if isinstance(module, basestring):
-            self.module = __import__(module)
-            for part in module.split('.')[1:]:
-                self.module = getattr(self.module, part)
-        else:
-            self.module = module
-        self.url = None
-        for key, value in self.module.__dict__.iteritems():
-            try:
-                if issubclass(value, test.Test):
-                    self.url = key
-            except TypeError:
-                pass
+    def __init__(self):
+        self.url = sys.argv[0]
         self.job = Job()
         if self.url is not None:
             sys.exit(self.job.run(urls=[self.url]))

--- a/avocado/loader.py
+++ b/avocado/loader.py
@@ -83,8 +83,7 @@ class TestLoader(object):
         :type params: dict
         :return: a test factory (a pair of test class and test parameters)
         """
-        test_name = params.get('id')
-        test_path = os.path.abspath(test_name)
+        test_name = test_path = params.get('id')
         if os.path.exists(test_path):
             path_analyzer = path.PathInspector(test_path)
             if path_analyzer.is_python():

--- a/avocado/loader.py
+++ b/avocado/loader.py
@@ -97,8 +97,7 @@ class TestLoader(object):
                 test_class, test_parameters = self._make_simple_test(test_path,
                                                                      params)
             else:
-                test_class, test_parameters = self._make_missing_test(test_name,
-                                                                      params)
+                return None
         else:
             # Try to resolve test ID (keep compatibility)
             rel_path = '%s.py' % test_name
@@ -108,8 +107,7 @@ class TestLoader(object):
                                                               test_path,
                                                               params)
             else:
-                test_class, test_parameters = self._make_missing_test(
-                    test_name, params)
+                return None
         return test_class, test_parameters
 
     def discover_directory(self, dir_path='.', ignore_suffix=None):

--- a/avocado/loader.py
+++ b/avocado/loader.py
@@ -42,14 +42,6 @@ class TestLoader(object):
             job = _DebugJob()
         self.job = job
 
-    def _make_missing_test(self, test_name, params):
-        test_class = test.MissingTest
-        test_parameters = {'name': test_name,
-                           'base_logdir': self.job.logdir,
-                           'params': params,
-                           'job': self.job}
-        return test_class, test_parameters
-
     def _make_simple_test(self, test_path, params):
         test_class = test.SimpleTest
         test_parameters = {'path': test_path,

--- a/avocado/plugins/htmlresult.py
+++ b/avocado/plugins/htmlresult.py
@@ -70,7 +70,12 @@ class ReportModel(object):
         return self.json['pass']
 
     def pass_rate(self):
-        pr = 100 * (float(self.json['pass']) / float(self.json['total']))
+        total = self.json['total']
+        passed = self.json['pass']
+        if int(total) > 0:
+            pr = 100 * (float(passed) / float(total))
+        else:
+            pr = 0
         return "%.2f" % pr
 
     def _get_sysinfo(self, sysinfo_file):
@@ -156,7 +161,12 @@ class HTMLTestResult(TestResult):
         Called once before any tests are executed.
         """
         TestResult.start_tests(self)
+        logdir = os.path.dirname(self.stream.logfile)
+        id_path = os.path.join(logdir, 'id')
+        with open(id_path, 'r') as id_file:
+            job_id = id_file.read()
         self.json = {'debuglog': self.stream.logfile,
+                     'job_id': job_id,
                      'tests': []}
 
     def end_test(self, state):
@@ -167,8 +177,6 @@ class HTMLTestResult(TestResult):
         :type state: dict
         """
         TestResult.end_test(self, state)
-        if 'job_id' not in self.json:
-            self.json['job_id'] = state['job_unique_id']
         if state['fail_reason'] is None:
             state['fail_reason'] = ''
         else:

--- a/avocado/plugins/runner.py
+++ b/avocado/plugins/runner.py
@@ -16,8 +16,6 @@
 Base Test Runner Plugins.
 """
 
-import sys
-
 from avocado.core import exit_codes
 from avocado.plugins import plugin
 from avocado.core import output
@@ -114,6 +112,7 @@ class TestRunner(plugin.Plugin):
 
         :param args: Command line args received from the run subparser.
         """
+
         view = output.View(app_args=args, use_paginator=True)
         if args.unique_job_id is not None:
             try:
@@ -122,11 +121,12 @@ class TestRunner(plugin.Plugin):
                     raise ValueError
             except ValueError:
                 view.notify(event='error', msg='Unique Job ID needs to be a 40 digit hex number')
-                return sys.exit(exit_codes.AVOCADO_CRASH)
+                return exit_codes.AVOCADO_CRASH
+        if not args.url:
+            self.parser.print_help()
+            view.notify(event='error', msg='Empty test ID. A test path or alias must be provided')
+            return exit_codes.AVOCADO_CRASH
 
         job_instance = job.Job(args)
         rc = job_instance.run()
-        if not args.url:
-            self.parser.print_help()
-
         return rc

--- a/avocado/plugins/test_lister.py
+++ b/avocado/plugins/test_lister.py
@@ -52,7 +52,7 @@ class TestLister(plugin.Plugin):
         test_files = os.listdir(base_test_dir)
         test_dirs = []
         blength = 0
-        for t in test_files:
+        for t in sorted(test_files):
             inspector = path.PathInspector(path=t)
             if inspector.is_python():
                 clength = len((t.split('.')[0]))

--- a/avocado/runner.py
+++ b/avocado/runner.py
@@ -65,6 +65,8 @@ class TestRunner(object):
         sys.stdout = output.LoggingFile(logger=logging.getLogger('avocado.test.stdout'))
         sys.stderr = output.LoggingFile(logger=logging.getLogger('avocado.test.stderr'))
         instance = self.job.test_loader.load_test(test_factory)
+        if instance.runner_queue is None:
+            instance.runner_queue = queue
         runtime.CURRENT_TEST = instance
         early_state = instance.get_state()
         queue.put(early_state)
@@ -102,19 +104,17 @@ class TestRunner(object):
             test_state['text_output'] = log_file_obj.read()
         return test_state
 
-    def run_suite(self, params_list):
+    def run_suite(self, test_suite):
         """
         Run one or more tests and report with test result.
 
-        :param params_list: a list of param dicts.
-
+        :param test_suite: a list of tests to run.
         :return: a list of test failures.
         """
         failures = []
         self.sysinfo.start_job_hook()
         self.result.start_tests()
         q = queues.SimpleQueue()
-        test_suite = self.job.test_loader.discover(params_list, q)
 
         for test_factory in test_suite:
             p = multiprocessing.Process(target=self.run_test,

--- a/avocado/test.py
+++ b/avocado/test.py
@@ -578,26 +578,6 @@ class SimpleTest(Test):
             raise exceptions.TestFail(details)
 
 
-class MissingTest(Test):
-
-    """
-    Handle when there is no such test module in the test directory.
-    """
-
-    def __init__(self, name=None, params=None, base_logdir=None, tag=None,
-                 job=None, runner_queue=None):
-        super(MissingTest, self).__init__(name=name,
-                                          base_logdir=base_logdir,
-                                          tag=tag, job=job,
-                                          runner_queue=runner_queue)
-
-    def action(self):
-        e_msg = ('Test %s could not be found in the test dir %s '
-                 '(or test path does not exist)' %
-                 (self.name, data_dir.get_test_dir()))
-        raise exceptions.TestNotFoundError(e_msg)
-
-
 class RemoteTest(object):
 
     """

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -25,6 +25,7 @@ import stat
 import shlex
 import shutil
 import threading
+import fnmatch
 
 try:
     import subprocess32 as subprocess
@@ -868,11 +869,8 @@ def should_run_inside_wrapper(cmd):
     args = shlex.split(cmd)
     cmd_binary_name = args[0]
 
-    for script, cmd in runtime.WRAP_PROCESS_NAMES_EXPR:
-        if os.path.isabs(cmd_binary_name) and os.path.isabs(cmd) is False:
-            cmd_binary_name = os.path.basename(cmd_binary_name)
-            cmd = os.path.basename(cmd)
-        if cmd_binary_name == cmd:
+    for script, cmd_expr in runtime.WRAP_PROCESS_NAMES_EXPR:
+        if fnmatch.fnmatch(cmd_binary_name, cmd_expr):
             runtime.CURRENT_WRAPPER = script
 
     if runtime.WRAP_PROCESS is not None and runtime.CURRENT_WRAPPER is None:

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -24,7 +24,7 @@ nothing but ``time.sleep([number-seconds])``::
     from avocado import test
 
 
-    class sleeptest(test.Test):
+    class SleepTest(test.Test):
 
         """
         Example test for avocado.
@@ -43,7 +43,10 @@ nothing but ``time.sleep([number-seconds])``::
         job.main()
 
 This is about the simplest test you can write for avocado (at least, one using
-the avocado APIs). Note that the test object provides you with a number of
+the avocado APIs). An avocado test is basically a class that inherits from :mod:`avocado.test.Test`
+and could have any name you might like (we'll trust you'll choose a good name).
+
+Note that the test object provides you with a number of
 convenience attributes, such as ``self.log``, that lets you log debug, info, error
 and warning messages. Also, we note the parameter passing system that avocado provides:
 We frequently want to pass parameters to tests, and we can do that through what

--- a/examples/tests/abort.py
+++ b/examples/tests/abort.py
@@ -6,7 +6,7 @@ from avocado import test
 from avocado import job
 
 
-class abort(test.Test):
+class AbortTest(test.Test):
 
     """
     A test that just calls abort() (and abort).

--- a/examples/tests/datadir.py
+++ b/examples/tests/datadir.py
@@ -8,7 +8,7 @@ from avocado.utils import build
 from avocado.utils import process
 
 
-class datadir(test.Test):
+class DataDirTest(test.Test):
 
     """
     Test that uses resources from the data dir.

--- a/examples/tests/doublefail.py
+++ b/examples/tests/doublefail.py
@@ -5,7 +5,7 @@ from avocado import job
 from avocado.core import exceptions
 
 
-class doublefail(test.Test):
+class DoubleFail(test.Test):
 
     """
     Functional test for avocado. Straight up fail the test.

--- a/examples/tests/doublefree.py
+++ b/examples/tests/doublefree.py
@@ -8,7 +8,7 @@ from avocado.utils import build
 from avocado.utils import process
 
 
-class doublefree(test.Test):
+class DoubleFreeTest(test.Test):
 
     """
     Double free test case.

--- a/examples/tests/errortest.py
+++ b/examples/tests/errortest.py
@@ -5,7 +5,7 @@ from avocado import job
 from avocado.core import exceptions
 
 
-class errortest(test.Test):
+class ErrorTest(test.Test):
 
     """
     Functional test for avocado. Throw a TestError.

--- a/examples/tests/failtest.py
+++ b/examples/tests/failtest.py
@@ -5,7 +5,7 @@ from avocado import job
 from avocado.core import exceptions
 
 
-class failtest(test.Test):
+class FailTest(test.Test):
 
     """
     Functional test for avocado. Straight up fail the test.

--- a/examples/tests/fiotest.py
+++ b/examples/tests/fiotest.py
@@ -9,7 +9,7 @@ from avocado.utils import build
 from avocado.utils import process
 
 
-class fiotest(test.Test):
+class FioTest(test.Test):
 
     """
     fio is an I/O tool meant to be used both for benchmark and

--- a/examples/tests/gdbtest.py
+++ b/examples/tests/gdbtest.py
@@ -8,7 +8,7 @@ from avocado import runtime
 from avocado.utils import process
 
 
-class gdbtest(test.Test):
+class GdbTest(test.Test):
 
     """
     Execute the gdb test

--- a/examples/tests/gendata.py
+++ b/examples/tests/gendata.py
@@ -6,7 +6,7 @@ from avocado import test
 from avocado import job
 
 
-class gendata(test.Test):
+class GenDataTest(test.Test):
 
     """
     Simple test that generates data to be persisted after the test is run

--- a/examples/tests/linuxbuild.py
+++ b/examples/tests/linuxbuild.py
@@ -5,7 +5,7 @@ from avocado import job
 from avocado.linux import kernel_build
 
 
-class linuxbuild(test.Test):
+class LinuxBuildTest(test.Test):
 
     """
     Execute the Linux Build test.

--- a/examples/tests/multiplextest.py
+++ b/examples/tests/multiplextest.py
@@ -4,10 +4,10 @@ from avocado import test
 from avocado import job
 
 
-class multiplextest(test.Test):
+class MultiplexTest(test.Test):
 
     """
-    Execute the Linux Build test.
+    Execute a test that uses provided parameters (for multiplexing testing).
     """
     default_params = {'os_type': 'linux',
                       'gcc_flags': '-O2',

--- a/examples/tests/passtest.py
+++ b/examples/tests/passtest.py
@@ -4,7 +4,7 @@ from avocado import job
 from avocado import test
 
 
-class passtest(test.Test):
+class PassTest(test.Test):
 
     """
     Example test that passes.

--- a/examples/tests/skiptest.py
+++ b/examples/tests/skiptest.py
@@ -5,7 +5,7 @@ from avocado import job
 from avocado.core import exceptions
 
 
-class skiptest(test.Test):
+class SkipTest(test.Test):
 
     """
     Functional test for avocado. Throw a TestNAError (skips the test).

--- a/examples/tests/sleeptenmin.py
+++ b/examples/tests/sleeptenmin.py
@@ -7,7 +7,7 @@ from avocado import job
 from avocado import test
 
 
-class sleeptenmin(test.Test):
+class SleepTenMin(test.Test):
 
     """
     Sleeps for 10 minutes

--- a/examples/tests/sleeptest.py
+++ b/examples/tests/sleeptest.py
@@ -6,7 +6,7 @@ from avocado import job
 from avocado import test
 
 
-class sleeptest(test.Test):
+class SleepTest(test.Test):
 
     """
     Example test for avocado.

--- a/examples/tests/synctest.py
+++ b/examples/tests/synctest.py
@@ -9,7 +9,7 @@ from avocado.utils import build
 from avocado.utils import process
 
 
-class synctest(test.Test):
+class SyncTest(test.Test):
 
     """
     Execute the synctest test suite.

--- a/examples/tests/timeouttest.py
+++ b/examples/tests/timeouttest.py
@@ -6,7 +6,7 @@ from avocado import test
 from avocado import job
 
 
-class timeouttest(test.Test):
+class TimeoutTest(test.Test):
 
     """
     Functional test for avocado. Throw a TestTimeoutError.

--- a/examples/tests/trinity.py
+++ b/examples/tests/trinity.py
@@ -10,7 +10,7 @@ from avocado.utils import process
 from avocado.utils import data_factory
 
 
-class trinity(test.Test):
+class TrinityTest(test.Test):
 
     """
     Trinity syscall fuzzer wrapper.

--- a/examples/tests/warntest.py
+++ b/examples/tests/warntest.py
@@ -5,7 +5,7 @@ from avocado import job
 from avocado.core import exceptions
 
 
-class warntest(test.Test):
+class WarnTest(test.Test):
 
     """
     Functional test for avocado. Throw a TestWarn.

--- a/examples/tests/whiteboard.py
+++ b/examples/tests/whiteboard.py
@@ -6,7 +6,7 @@ from avocado import job
 import base64
 
 
-class whiteboard(test.Test):
+class WhiteBoard(test.Test):
 
     """
     Simple test that saves test custom data to the test whiteboard

--- a/selftests/all/functional/avocado/basic_tests.py
+++ b/selftests/all/functional/avocado/basic_tests.py
@@ -161,7 +161,7 @@ class RunnerOperationTest(unittest.TestCase):
         cmd_line = './scripts/avocado run'
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 2
-        expected_output = 'Empty test ID. A test path or alias must be provided'
+        expected_output = 'Test(s) with empty parameter list or the number of variants is zero'
         expected_output_2 = 'usage:'
         self.assertEqual(result.exit_status, expected_rc)
         self.assertIn(expected_output, result.stdout)

--- a/selftests/all/functional/avocado/basic_tests.py
+++ b/selftests/all/functional/avocado/basic_tests.py
@@ -84,7 +84,7 @@ class RunnerOperationTest(unittest.TestCase):
         os.chdir(basedir)
         cmd_line = './scripts/avocado run bogustest'
         result = process.run(cmd_line, ignore_status=True)
-        expected_rc = 1
+        expected_rc = 2
         unexpected_rc = 3
         self.assertNotEqual(result.exit_status, unexpected_rc,
                             "Avocado crashed (rc %d):\n%s" % (unexpected_rc, result))
@@ -171,10 +171,9 @@ class RunnerOperationTest(unittest.TestCase):
         os.chdir(basedir)
         cmd_line = './scripts/avocado run sbrubles'
         result = process.run(cmd_line, ignore_status=True)
-        expected_rc = 1
+        expected_rc = 2
         self.assertEqual(result.exit_status, expected_rc)
-        self.assertIn('NOT_FOUND', result.stdout)
-        self.assertIn('NOT FOUND : 1', result.stdout)
+        self.assertIn('No tests found within the specified path(s)', result.stdout)
 
     def test_invalid_unique_id(self):
         cmd_line = './scripts/avocado run --force-job-id foobar skiptest'
@@ -389,7 +388,7 @@ class ParseXMLError(Exception):
 class PluginsXunitTest(PluginsTest):
 
     def run_and_check(self, testname, e_rc, e_ntests, e_nerrors,
-                      e_nnotfound, e_nfailures, e_nskip):
+                      e_nfailures, e_nskip):
         os.chdir(basedir)
         cmd_line = './scripts/avocado run --xunit - %s' % testname
         result = process.run(cmd_line, ignore_status=True)
@@ -397,58 +396,59 @@ class PluginsXunitTest(PluginsTest):
         self.assertEqual(result.exit_status, e_rc,
                          "Avocado did not return rc %d:\n%s" %
                          (e_rc, result))
-        try:
-            xunit_doc = xml.dom.minidom.parseString(xml_output)
-        except Exception, detail:
-            raise ParseXMLError("Failed to parse content: %s\n%s" %
-                                (detail, xml_output))
+        if e_rc == 0:
+            try:
+                xunit_doc = xml.dom.minidom.parseString(xml_output)
+            except Exception, detail:
+                raise ParseXMLError("Failed to parse content: %s\n%s" %
+                                    (detail, xml_output))
 
-        testsuite_list = xunit_doc.getElementsByTagName('testsuite')
-        self.assertEqual(len(testsuite_list), 1, 'More than one testsuite tag')
+            testsuite_list = xunit_doc.getElementsByTagName('testsuite')
+            self.assertEqual(len(testsuite_list), 1, 'More than one testsuite tag')
 
-        testsuite_tag = testsuite_list[0]
-        self.assertEqual(len(testsuite_tag.attributes), 7,
-                         'The testsuite tag does not have 7 attributes. '
-                         'XML:\n%s' % xml_output)
+            testsuite_tag = testsuite_list[0]
+            self.assertEqual(len(testsuite_tag.attributes), 7,
+                             'The testsuite tag does not have 7 attributes. '
+                             'XML:\n%s' % xml_output)
 
-        n_tests = int(testsuite_tag.attributes['tests'].value)
-        self.assertEqual(n_tests, e_ntests,
-                         "Unexpected number of executed tests, "
-                         "XML:\n%s" % xml_output)
+            n_tests = int(testsuite_tag.attributes['tests'].value)
+            self.assertEqual(n_tests, e_ntests,
+                             "Unexpected number of executed tests, "
+                             "XML:\n%s" % xml_output)
 
-        n_errors = int(testsuite_tag.attributes['errors'].value)
-        self.assertEqual(n_errors, e_nerrors,
-                         "Unexpected number of test errors, "
-                         "XML:\n%s" % xml_output)
+            n_errors = int(testsuite_tag.attributes['errors'].value)
+            self.assertEqual(n_errors, e_nerrors,
+                             "Unexpected number of test errors, "
+                             "XML:\n%s" % xml_output)
 
-        n_failures = int(testsuite_tag.attributes['failures'].value)
-        self.assertEqual(n_failures, e_nfailures,
-                         "Unexpected number of test failures, "
-                         "XML:\n%s" % xml_output)
+            n_failures = int(testsuite_tag.attributes['failures'].value)
+            self.assertEqual(n_failures, e_nfailures,
+                             "Unexpected number of test failures, "
+                             "XML:\n%s" % xml_output)
 
-        n_skip = int(testsuite_tag.attributes['skip'].value)
-        self.assertEqual(n_skip, e_nskip,
-                         "Unexpected number of test skips, "
-                         "XML:\n%s" % xml_output)
+            n_skip = int(testsuite_tag.attributes['skip'].value)
+            self.assertEqual(n_skip, e_nskip,
+                             "Unexpected number of test skips, "
+                             "XML:\n%s" % xml_output)
 
     def test_xunit_plugin_passtest(self):
-        self.run_and_check('passtest', 0, 1, 0, 0, 0, 0)
+        self.run_and_check('passtest', 0, 1, 0, 0, 0)
 
     def test_xunit_plugin_failtest(self):
-        self.run_and_check('failtest', 1, 1, 0, 0, 1, 0)
+        self.run_and_check('failtest', 1, 1, 0, 1, 0)
 
     def test_xunit_plugin_skiptest(self):
-        self.run_and_check('skiptest', 0, 1, 0, 0, 0, 1)
+        self.run_and_check('skiptest', 0, 1, 0, 0, 1)
 
     def test_xunit_plugin_errortest(self):
-        self.run_and_check('errortest', 1, 1, 1, 0, 0, 0)
+        self.run_and_check('errortest', 1, 1, 1, 0, 0)
 
     def test_xunit_plugin_notfoundtest(self):
-        self.run_and_check('sbrubles', 1, 1, 1, 0, 0, 0)
+        self.run_and_check('sbrubles', 2, 1, 1, 0, 0)
 
     def test_xunit_plugin_mixedtest(self):
         self.run_and_check('passtest failtest skiptest errortest sbrubles',
-                           1, 5, 2, 0, 1, 1)
+                           1, 4, 2, 1, 1)
 
 
 class ParseJSONError(Exception):
@@ -457,7 +457,7 @@ class ParseJSONError(Exception):
 
 class PluginsJSONTest(PluginsTest):
 
-    def run_and_check(self, testname, e_rc, e_ntests, e_nerrors, e_nnotfound,
+    def run_and_check(self, testname, e_rc, e_ntests, e_nerrors,
                       e_nfailures, e_nskip):
         os.chdir(basedir)
         cmd_line = './scripts/avocado run --json - --archive %s' % testname
@@ -466,48 +466,46 @@ class PluginsJSONTest(PluginsTest):
         self.assertEqual(result.exit_status, e_rc,
                          "Avocado did not return rc %d:\n%s" %
                          (e_rc, result))
-        try:
-            json_data = json.loads(json_output)
-        except Exception, detail:
-            raise ParseJSONError("Failed to parse content: %s\n%s" %
-                                 (detail, json_output))
-        self.assertTrue(json_data, "Empty JSON result:\n%s" % json_output)
-        self.assertIsInstance(json_data['tests'], list,
-                              "JSON result lacks 'tests' list")
-        n_tests = len(json_data['tests'])
-        self.assertEqual(n_tests, e_ntests,
-                         "Different number of expected tests")
-        n_errors = json_data['errors']
-        self.assertEqual(n_errors, e_nerrors,
-                         "Different number of expected tests")
-        n_not_found = json_data['not_found']
-        self.assertEqual(n_not_found, e_nnotfound,
-                         "Different number of not found tests")
-        n_failures = json_data['failures']
-        self.assertEqual(n_failures, e_nfailures,
-                         "Different number of expected tests")
-        n_skip = json_data['skip']
-        self.assertEqual(n_skip, e_nskip,
-                         "Different number of skipped tests")
+        if e_rc == 0:
+            try:
+                json_data = json.loads(json_output)
+            except Exception, detail:
+                raise ParseJSONError("Failed to parse content: %s\n%s" %
+                                     (detail, json_output))
+            self.assertTrue(json_data, "Empty JSON result:\n%s" % json_output)
+            self.assertIsInstance(json_data['tests'], list,
+                                  "JSON result lacks 'tests' list")
+            n_tests = len(json_data['tests'])
+            self.assertEqual(n_tests, e_ntests,
+                             "Different number of expected tests")
+            n_errors = json_data['errors']
+            self.assertEqual(n_errors, e_nerrors,
+                             "Different number of expected tests")
+            n_failures = json_data['failures']
+            self.assertEqual(n_failures, e_nfailures,
+                             "Different number of expected tests")
+            n_skip = json_data['skip']
+            self.assertEqual(n_skip, e_nskip,
+                             "Different number of skipped tests")
 
     def test_json_plugin_passtest(self):
-        self.run_and_check('passtest', 0, 1, 0, 0, 0, 0)
+        self.run_and_check('passtest', 0, 1, 0, 0, 0)
 
     def test_json_plugin_failtest(self):
-        self.run_and_check('failtest', 1, 1, 0, 0, 1, 0)
+        self.run_and_check('failtest', 1, 1, 0, 1, 0)
 
     def test_json_plugin_skiptest(self):
-        self.run_and_check('skiptest', 0, 1, 0, 0, 0, 1)
+        self.run_and_check('skiptest', 0, 1, 0, 0, 1)
 
     def test_json_plugin_errortest(self):
-        self.run_and_check('errortest', 1, 1, 1, 0, 0, 0)
+        self.run_and_check('errortest', 1, 1, 1, 0, 0)
 
     def test_json_plugin_notfoundtest(self):
-        self.run_and_check('sbrubles', 1, 1, 0, 1, 0, 0)
+        self.run_and_check('sbrubles', 2, 0, 0, 0, 0)
 
     def test_json_plugin_mixedtest(self):
         self.run_and_check('passtest failtest skiptest errortest sbrubles',
-                           1, 5, 1, 1, 1, 1)
+                           1, 4, 1, 1, 1)
 
 if __name__ == '__main__':
     unittest.main()

--- a/selftests/all/functional/avocado/basic_tests.py
+++ b/selftests/all/functional/avocado/basic_tests.py
@@ -160,8 +160,8 @@ class RunnerOperationTest(unittest.TestCase):
         os.chdir(basedir)
         cmd_line = './scripts/avocado run'
         result = process.run(cmd_line, ignore_status=True)
-        expected_rc = 2
-        expected_output = 'Test(s) with empty parameter list or the number of variants is zero'
+        expected_rc = 3
+        expected_output = 'Empty test ID. A test path or alias must be provided'
         expected_output_2 = 'usage:'
         self.assertEqual(result.exit_status, expected_rc)
         self.assertIn(expected_output, result.stdout)

--- a/selftests/all/functional/avocado/multiplex_tests.py
+++ b/selftests/all/functional/avocado/multiplex_tests.py
@@ -70,7 +70,7 @@ class MultiplexTests(unittest.TestCase):
 
     def test_run_mplex_noid(self):
         cmd_line = './scripts/avocado run --multiplex examples/tests/sleeptest.py.data/sleeptest.yaml'
-        expected_rc = 2
+        expected_rc = 3
         self.run_and_check(cmd_line, expected_rc)
 
     def test_run_mplex_passtest(self):

--- a/selftests/all/functional/avocado/wrapper_tests.py
+++ b/selftests/all/functional/avocado/wrapper_tests.py
@@ -52,7 +52,7 @@ class WrapperTest(unittest.TestCase):
 
     def test_process_wrapper(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --wrapper %s:datadir examples/tests/datadir.py' % self.script.path
+        cmd_line = './scripts/avocado run --wrapper %s:*/datadir examples/tests/datadir.py' % self.script.path
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 0
         self.assertEqual(result.exit_status, expected_rc,
@@ -63,7 +63,7 @@ class WrapperTest(unittest.TestCase):
 
     def test_both_wrappers(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --wrapper %s --wrapper %s:datadir examples/tests/datadir.py' % (self.dummy.path, self.script.path)
+        cmd_line = './scripts/avocado run --wrapper %s --wrapper %s:*/datadir examples/tests/datadir.py' % (self.dummy.path, self.script.path)
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 0
         self.assertEqual(result.exit_status, expected_rc,


### PR DESCRIPTION
Follow up of #320.

Changes from V2:

* Completely remove the concept of MissingTests. It wasn't very useful to begin with.
* Break the need for test classes to be named after the module names.
* Mass rename the current avocado test class names
* Update docs to reflect the new *status quo*

Changes from V1:

* avocado.loader: Locate SimpleTests using the full path.
* avocado.job: Set different messages when the number of tests found is zero [No tests found within the  specified path(s)] or when the number of variants is zero [The number of test variants is zero].
* avocado.loader: Skip directory if we don't have permission to walk. Also skip tests that are not tests, so Avocado stops crashing when walking in a directory, looking for tests.
* avocado.utils.process: Use shell glob style when matching wrap scripts.
test_lister plugin: Sort output in alphabetic order.