### PR TITLE
avocado.multiplexer: Support for multiplex domains [v0]

### DIFF
--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -79,6 +79,7 @@ class TreeNode(object):
         self.children = []
         self._environment = None
         self.ctrl = []
+        self.mux_domain = False
         for child in children:
             self.add_child(child)
 
@@ -390,6 +391,13 @@ def _create_from_yaml(path, cls_node=TreeNode):
                 objects.append(Value((name, values)))
         return objects
 
+    def mux_loader(loader, obj):
+        objects = mapping_to_tree_loader(loader, obj)
+        for obj in objects:     # Every child is separate mux-domain
+            if isinstance(obj, TreeNode):
+                obj.mux_domain = True
+        return objects
+
     Loader.add_constructor(u'!include',
                            lambda loader, node: Control(YAML_INCLUDE))
     Loader.add_constructor(u'!using',
@@ -398,6 +406,7 @@ def _create_from_yaml(path, cls_node=TreeNode):
                            lambda loader, node: Control(YAML_REMOVE_NODE))
     Loader.add_constructor(u'!remove_value',
                            lambda loader, node: Control(YAML_REMOVE_VALUE))
+    Loader.add_constructor(u'!mux-domain', mux_loader)
     Loader.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
                            mapping_to_tree_loader)
 

--- a/avocado/multiplexer.py
+++ b/avocado/multiplexer.py
@@ -19,62 +19,48 @@
 Multiplex and create variants.
 """
 
-import collections
+import itertools
 
 from avocado.core import tree
 
 
-def any_sibling(*nodes):
+def tree2pools(node):
     """
-    Check if there is any sibling.
-
-    :param nodes: the nodes to check.
-    :return: `True` if there is any sibling or `False`.
+    Process tree and flattens the structure to remaining leaves and
+    list of lists of leaves per each multiplex group.
+    :param node: Node to start with
+    :return: tuple(`leaves`, `pools`), where `leaves` are directly inherited
+    leafs of this node (no other mux_domain in the middle). `pools` is list of
+    lists of directly inherited leafs of the nested multiplex domains.
     """
-    if len(nodes) < 2:
-        return False
-    parents = set(node.parent for node in nodes)
-    return len(nodes) != len(parents)
-
-
-def multiplex(*args):
     leaves = []
-    parents = collections.OrderedDict()
-    # filter args and create a set of parents
-    for arg in args[0]:
-        leaves.append(arg)
-        parents[arg.parent] = True
-
     pools = []
-    for p in parents.keys():
-        pools.append(leaves)
-        leaves = [x for x in leaves if x.parent != p]
-
-    result = [[]]
-    result_prev = [[]]
-    for pool in pools:
-
-        # second level of filtering above should use the filter strings
-        # extracted from the node being worked on
-        items = []
-        for x in result:
-            for y in pool:
-                item = x + [y]
-                if any_sibling(*item) is False:
-                    items.append(item)
-        result = items
-
-        # if a pool gets totally filtered out above, result will be empty
-        if len(result) == 0:
-            result = result_prev
-        else:
-            result_prev = result
-
-    if result == [[]]:
-        return
-
-    for prod in result:
-        yield tuple(prod)
+    if not node.mux_domain:
+        for child in node.children:
+            if child.is_leaf:
+                leaves.append(child)
+            else:
+                _leafs, _pools = tree2pools(child)
+                leaves.extend(_leafs)
+                pools.extend(_pools)
+    else:
+        # TODO: Get this mux_domain leaves filters and store them in this pool
+        # to support 2nd level filtering
+        new_leafs = []
+        for child in node.children:
+            if child.is_leaf:
+                new_leafs.append(child)
+            else:
+                _leafs, _pools = tree2pools(child)
+                new_leafs.extend(_leafs)
+                # TODO: For 2nd level filters store this separately in case
+                # this branch is filtered out
+                pools.extend(_pools)
+        if new_leafs:
+            # TODO: Filter the new_leafs (and new_pools) before merging
+            # into pools
+            pools.append(new_leafs)
+    return leaves, pools
 
 
 def multiplex_yamls(input_yamls, filter_only=None, filter_out=None,
@@ -84,7 +70,9 @@ def multiplex_yamls(input_yamls, filter_only=None, filter_out=None,
     if filter_out is None:
         filter_out = []
     input_tree = tree.create_from_yaml(input_yamls, debug)
+    # TODO: Process filters and multiplex simultaneously
     final_tree = tree.apply_filters(input_tree, filter_only, filter_out)
-    leaves = (x for x in final_tree.iter_leaves() if x.parent is not None)
-    variants = multiplex(leaves)
-    return variants
+    leaves, pools = tree2pools(final_tree)
+    if leaves:  # Add remaining leaves (they are not variants, only endpoints
+        pools.extend(leaves)
+    return itertools.product(*pools)    # *magic required pylint: disable=W0142

--- a/avocado/multiplexer.py
+++ b/avocado/multiplexer.py
@@ -24,7 +24,7 @@ import itertools
 from avocado.core import tree
 
 
-def tree2pools(node):
+def tree2pools(node, mux=False):
     """
     Process tree and flattens the structure to remaining leaves and
     list of lists of leaves per each multiplex group.
@@ -35,12 +35,12 @@ def tree2pools(node):
     """
     leaves = []
     pools = []
-    if not node.mux_domain:
+    if not mux:
         for child in node.children:
             if child.is_leaf:
                 leaves.append(child)
             else:
-                _leafs, _pools = tree2pools(child)
+                _leafs, _pools = tree2pools(child, node.mux_domain)
                 leaves.extend(_leafs)
                 pools.extend(_pools)
     else:
@@ -51,7 +51,7 @@ def tree2pools(node):
             if child.is_leaf:
                 new_leafs.append(child)
             else:
-                _leafs, _pools = tree2pools(child)
+                _leafs, _pools = tree2pools(child, node.mux_domain)
                 new_leafs.extend(_leafs)
                 # TODO: For 2nd level filters store this separately in case
                 # this branch is filtered out


### PR DESCRIPTION
Hello guys, another v0 multiplexer patch follows. It completely changes to multiplexer behavior similar to https://www.redhat.com/archives/virt-test-devel/2014-November/msg00004.html and https://www.redhat.com/archives/virt-test-devel/2014-November/msg00006.html . This version doesn't support multiple yaml files (tree merging), because there is a decision to be made, which strongly affects the code. So what we can do:

1. mark node, whose children will be all in separate multiplex domain
2. mark each multiplex domain

The biggest difference is, that ad1) it's simpler to define and IMO less prone to upstream-downstream modifications (once you define node to be `mux-domain`, all following nodes will be in separate mux-domains. ad2) is slightly easier to read (for humans) in the `yaml` file, but can lead to accidentally non-mux domain nodes. Let me show you the difference in `yaml`:


```yaml
# version 1 (mark parent)
hw: !mux-doman
    cpu:
        intel:
        amd:
    disk:
        virtio:
        scsi:
    machine:
        host:

# version 2 (mark each node)
hw:
    cpu: !mux
        intel:
        amd:
    disk: !mux
        virtio:
        scsi:
    machine: !mux
        host:
```
As you can see, version 1 doesn't support mixed `mux`/`nomux` nodes, so when you extend it, all children are marked either `mux` or `nomux`.

In version 2 when you don't mark node as `mux`, it's `nomux` and will extend the upper-level mux domain leaf list. This is slightly more flexible, but at the same time can lead to very weird results:
```
# cpu/disk/machine mux
1. intel, virtio, host
2. intel, scsi, host
3. amd, virtio, host
4. amd, scsi, host

# cpu/machine mux; disk nomux
1. intel, virtio, scsi, host
2. amd, virtio, scsi, host
```
Anyway booth are valid versions so I'd like to ask you to think about it and help me decide.

Also as this is just v0 I haven't bother with documentation. There is an example yaml file:
```yaml
!mux-domain
virt:
    hw: !mux-domain
        cpu:
            intel:
                32:
                64:
            amd:
        disk:
            virito:
            scsi:
        machine:
            host:
os:
    fedora:
tests:
    test1:
    test2:
    test3:
```
Which multiplexes all root nodes and all hw nodes (as you'd expect). Note that this example is impossible to do with current multiplexer (you can do it, but you'd have to manually move some nodes into the global namespace and duplicate the intel32/intel64 nodes).

I also tested the performance (even thought it's way too early for that). At first I was humiliated as original version was 10times faster. Then I realized, that due to implementation the expensive product part happens during the listing of the variants. So if you want to compare the speed, it's necessarily to put:
```py
for _ in variants:
    pass
```
which forces the real variants generation. Then the original `any_sibling` version took 50s and `mux-domain` version only 0.0045s (the yaml file containe `!mux-domain` at every branch so the results were identical - 531441 variants flat structure, similar results with deep structure). Partial example of the huge tree:
```
# Flat
!mux-domain
a:
    1:
...
    9:
b:
    1:
...
    9:
...
f:
    1:
...
   9:
# deep
!mux-domain
a: !mux-domain
    b: !mux-domain
        c: !mux-domain
            d: !mux-domain
                e: !mux-domain
                    i:
                        1:
...
                        9:
                    1:
...
                    9:
...
n:
    1:
...
    9:

```

I also thought about the 2nd level filters, they should be quite easy to implement in this structure. Also the support for multiple files (tree merging) is quite simple, it only depends on the version (1 or 2) we choose so I didn't waste time putting it here.