### PR TITLE
avocado.core: Rename 'runner' config section to 'datadir.paths'

### DIFF
--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -43,10 +43,10 @@ _BASE_DIR = os.path.join(sys.modules[__name__].__file__, "..", "..", "..")
 _BASE_DIR = os.path.abspath(_BASE_DIR)
 _IN_TREE_TESTS_DIR = os.path.join(_BASE_DIR, 'examples', 'tests')
 
-SETTINGS_BASE_DIR = os.path.expanduser(settings.get_value('runner', 'base_dir'))
-SETTINGS_TEST_DIR = os.path.expanduser(settings.get_value('runner', 'test_dir'))
-SETTINGS_DATA_DIR = os.path.expanduser(settings.get_value('runner', 'data_dir'))
-SETTINGS_LOG_DIR = os.path.expanduser(settings.get_value('runner', 'logs_dir'))
+SETTINGS_BASE_DIR = os.path.expanduser(settings.get_value('datadir.paths', 'base_dir'))
+SETTINGS_TEST_DIR = os.path.expanduser(settings.get_value('datadir.paths', 'test_dir'))
+SETTINGS_DATA_DIR = os.path.expanduser(settings.get_value('datadir.paths', 'data_dir'))
+SETTINGS_LOG_DIR = os.path.expanduser(settings.get_value('datadir.paths', 'logs_dir'))
 
 SYSTEM_BASE_DIR = '/var/lib/avocado'
 if 'VIRTUAL_ENV' in os.environ:

--- a/etc/avocado/avocado.conf
+++ b/etc/avocado/avocado.conf
@@ -1,4 +1,4 @@
-[runner]
+[datadir.paths]
 base_dir = /usr/share/avocado
 test_dir = /usr/share/avocado/tests
 data_dir = /usr/share/avocado/data

--- a/selftests/all/unit/avocado/datadir_unittest.py
+++ b/selftests/all/unit/avocado/datadir_unittest.py
@@ -18,7 +18,7 @@ from avocado import settings
 
 
 def _get_bogus_settings(args):
-    return ('[runner]\n'
+    return ('[datadir.paths]\n'
             'base_dir = %(base_dir)s\n'
             'test_dir = %(test_dir)s\n'
             'data_dir = %(data_dir)s\n'
@@ -52,7 +52,7 @@ class DataDirTest(unittest.TestCase):
         reload(data_dir)
         for key in self.mapping.keys():
             data_dir_func = getattr(data_dir, 'get_%s' % key)
-            self.assertEqual(data_dir_func(), stg.get_value('runner', key))
+            self.assertEqual(data_dir_func(), stg.get_value('datadir.paths', key))
         del data_dir
 
     def tearDown(self):


### PR DESCRIPTION
Strictly speaking, the test runner is a plugin just like any
other, besides, what is being configured there is in fact datadir
paths, hence the rename.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>