### PR TITLE
avocado.test: Add missing argument to test.MissingTest

### DIFF
--- a/avocado/test.py
+++ b/avocado/test.py
@@ -585,10 +585,11 @@ class MissingTest(Test):
     """
 
     def __init__(self, name=None, params=None, base_logdir=None, tag=None,
-                 job=None):
+                 job=None, runner_queue=None):
         super(MissingTest, self).__init__(name=name,
                                           base_logdir=base_logdir,
-                                          tag=tag, job=job)
+                                          tag=tag, job=job,
+                                          runner_queue=runner_queue)
 
     def action(self):
         e_msg = ('Test %s could not be found in the test dir %s '


### PR DESCRIPTION
When importing of the test fails, it's class is set to MissingTest
and then it's executed. But running requires runner_queue param.
Without it the test fails and Avocado hangs for infinity for early
status.

The hang can be reproduced by importing missing library in `passtest` (eg `import asdf`), which causes the test to be set as `test.MissingTest` instead of normal test and infinity hang. This is only a bugfix which makes this test work. Similar change needs to be done to `RemoteTest`.

Last but not least I don't like the way this works. IMO we need to provide the traceback to help user identify the problem. Currently when there is a problem parsing the file, Avocado crashes with traceback. Only when there is a `ImportError` it's silently ignored and missing test is runned instead.

I haven't created any sophisticated changes to this as https://github.com/avocado-framework/avocado/pull/323 is in progress and those fixes should be considered there. (@ruda, @lmr).