### PR TITLE
Component Isolation: Linux Distribution Support

### DIFF
--- a/avocado/linux/distro.py
+++ b/avocado/linux/distro.py
@@ -15,8 +15,6 @@
 """
 This module provides the client facilities to detect the Linux Distribution
 it's running under.
-
-This is a replacement for the get_os_vendor() function from the utils module.
 """
 
 import os

--- a/avocado/plugins/distro.py
+++ b/avocado/plugins/distro.py
@@ -12,9 +12,85 @@
 # Copyright: Red Hat Inc. 2015
 # Author: Cleber Rosa <cleber@redhat.com>
 
+import bz2
+import json
+
 from avocado.core import output
 from avocado.plugins import plugin
 from avocado.linux import distro as distro_utils
+
+
+class SoftwarePackage(object):
+
+    '''
+    Definition of relevant information on a software package
+    '''
+
+    def __init__(self, name, version, release, checksum, arch):
+        self.name = name
+        self.version = version
+        self.release = release
+        self.checksum = checksum
+        self.arch = arch
+
+    def to_dict(self):
+        '''
+        Returns the representation as a dictionary
+        '''
+        return {'name': self.name,
+                'version': self.version,
+                'release': self.release,
+                'checksum': self.checksum,
+                'arch': self.arch}
+
+    def to_json(self):
+        '''
+        Returns the representation of the distro as JSON
+        '''
+        return json.dumps(self.to_dict())
+
+
+class DistroDef(distro_utils.LinuxDistro):
+
+    '''
+    More complete information on a given Linux Distribution
+
+    Can and should include all the software packages that ship with the distro,
+    so that an analysis can be made on whether a given package that may be
+    responsible for a regression is part of the official set or an external
+    package.
+    '''
+
+    def __init__(self, name, version, release, arch):
+        super(DistroDef, self).__init__(name, version, release, arch)
+
+        #: All the software packages that ship with this Linux distro
+        self.software_packages = []
+
+        #: A simple text that denotes the software type that makes this distro
+        self.software_packages_type = 'unknown'
+
+    def to_dict(self):
+        '''
+        Returns the representation as a dictionary
+        '''
+        d = {'name': self.name,
+             'version': self.version,
+             'release': self.release,
+             'arch': self.arch,
+             'software_packages_type': self.software_packages_type,
+             'software_packages': []}
+
+        for package in self.software_packages:
+            d['software_packages'].append(package.to_dict())
+
+        return d
+
+    def to_json(self):
+        '''
+        Returns the representation of the distro as JSON
+        '''
+        return json.dumps(self.to_dict())
 
 
 class DistroOptions(plugin.Plugin):

--- a/avocado/plugins/distro.py
+++ b/avocado/plugins/distro.py
@@ -1,0 +1,43 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2015
+# Author: Cleber Rosa <cleber@redhat.com>
+
+from avocado.core import output
+from avocado.plugins import plugin
+from avocado.linux import distro as distro_utils
+
+
+class DistroOptions(plugin.Plugin):
+
+    """
+    Implements the avocado 'distro' subcommand
+    """
+
+    name = 'distro'
+    enabled = True
+
+    def configure(self, parser):
+        self.parser = parser.subcommands.add_parser(
+            'distro',
+            help='Shows detected Linux distribution')
+        super(DistroOptions, self).configure(self.parser)
+
+    def run(self, args):
+        view = output.View()
+        detected = distro_utils.detect()
+        msg = 'Detected distribution: %s (%s) version %s release %s' % (
+            detected.name,
+            detected.arch,
+            detected.version,
+            detected.release)
+        view.notify(event="message", msg=msg)

--- a/man/avocado.rst
+++ b/man/avocado.rst
@@ -37,6 +37,7 @@ of avocado subcommands::
  sysinfo     Collect system information
  multiplex   Generate a list of dictionaries with params from multiplex file(s)
  plugins     List all plugins loaded
+ distro      Shows detected Linux distribution
  datadir     List all relevant directories used by avocado
 
 To get usage instructions for a given subcommand, run it with `--help`. Example::
@@ -477,6 +478,16 @@ The output should look like::
 
 For more information, please consult the topic Remote Machine Plugin
 on Avocado's online documentation.
+
+LINUX DISTRIBUTION UTILITIES
+============================
+
+Avocado has some planned features that depend on knowing the Linux Distribution being used on the sytem.
+The most basic command prints the detected Linux Distribution::
+
+  $ avocado distro
+  Detected distribution: fedora (x86_64) version 21 release 0
+
 
 FILES
 =====

--- a/man/avocado.rst
+++ b/man/avocado.rst
@@ -488,6 +488,27 @@ The most basic command prints the detected Linux Distribution::
   $ avocado distro
   Detected distribution: fedora (x86_64) version 21 release 0
 
+Other features are available with the same command when command line options are given, as shown by the
+`--help` option.
+
+For instance, it possible to create a so-called "Linux Distribution Definition" file, by inspecting an installation
+tree. The installation tree could be the contents of the official installation ISO or a local network mirror.
+
+These files let Avocado pinpoint if a given installed package is part of the original Linux Distribution or
+something else that was installed from an external repository or even manually. This, in turn, can help
+detecting regressions in base system pacakges that affected a given test result.
+
+To generate a definition file run::
+
+  $ avocado distro --distro-def-create --distro-def-name avocadix  \
+                   --distro-def-version 1 --distro-def-arch x86_64 \
+                   --distro-def-type rpm --distro-def-path /mnt/dvd
+
+And the output will be something like::
+
+   Loading distro information from tree... Please wait...
+   Distro information saved to "avocadix-1-x86_64.distro"
+
 
 FILES
 =====

--- a/selftests/all/unit/avocado/distro_unittest.py
+++ b/selftests/all/unit/avocado/distro_unittest.py
@@ -1,0 +1,98 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2014
+# Authors: Cleber Rosa <cleber@redhat.com>
+
+
+import os
+import re
+import sys
+import unittest
+
+from flexmock import flexmock
+
+# simple magic for using scripts within a source tree
+basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+basedir = os.path.dirname(basedir)
+if os.path.isdir(os.path.join(basedir, 'avocado')):
+    sys.path.append(basedir)
+
+
+from avocado.linux import distro
+
+
+class ProbeTest(unittest.TestCase):
+
+    def test_check_name_for_file_fail(self):
+        class MyProbe(distro.Probe):
+            CHECK_FILE = '/etc/issue'
+
+        my_probe = MyProbe()
+        self.assertFalse(my_probe.check_name_for_file())
+
+    def test_check_name_for_file(self):
+        class MyProbe(distro.Probe):
+            CHECK_FILE = '/etc/issue'
+            CHECK_FILE_DISTRO_NAME = 'superdistro'
+
+        my_probe = MyProbe()
+        self.assertTrue(my_probe.check_name_for_file())
+
+    def test_check_name_for_file_contains_fail(self):
+        class MyProbe(distro.Probe):
+            CHECK_FILE = '/etc/issue'
+            CHECK_FILE_CONTAINS = 'text'
+
+        my_probe = MyProbe()
+        self.assertFalse(my_probe.check_name_for_file_contains())
+
+    def test_check_name_for_file_contains(self):
+        class MyProbe(distro.Probe):
+            CHECK_FILE = '/etc/issue'
+            CHECK_FILE_CONTAINS = 'text'
+            CHECK_FILE_DISTRO_NAME = 'superdistro'
+
+        my_probe = MyProbe()
+        self.assertTrue(my_probe.check_name_for_file_contains())
+
+    def test_check_version_fail(self):
+        class MyProbe(distro.Probe):
+            CHECK_VERSION_REGEX = re.compile(r'distro version (\d+)')
+
+        my_probe = MyProbe()
+        self.assertFalse(my_probe.check_version())
+
+    def test_version_returnable(self):
+        class MyProbe(distro.Probe):
+            CHECK_FILE = '/etc/distro-release'
+            CHECK_VERSION_REGEX = re.compile(r'distro version (\d+)')
+
+        my_probe = MyProbe()
+        self.assertTrue(my_probe.check_version())
+
+    def test_name_for_file(self):
+        distro_file = '/etc/superdistro-issue'
+        distro_name = 'superdistro'
+
+        class MyProbe(distro.Probe):
+            CHECK_FILE = distro_file
+            CHECK_FILE_DISTRO_NAME = distro_name
+
+        flexmock(os.path)
+        os.path.should_receive('exists').and_return(True)
+        my_probe = MyProbe()
+        probed_distro_name = my_probe.name_for_file()
+        self.assertEqual(distro_name, probed_distro_name)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Avocado has some planned features that depend on knowing the Linux Distribution being used on the system and knowing its details. Information such as all currently installed packages, the packages that ship with the distribution, packages that were added on top of the system and others are necessary for those planned features.

This PR brings in this kind of support, as another step towards the implementation of the Component Isolation grand feature.  