### PR TITLE
avocado.multiplexer: Support for multiplex domains [v1]

### DIFF
--- a/avocado/multiplexer.py
+++ b/avocado/multiplexer.py
@@ -19,62 +19,48 @@
 Multiplex and create variants.
 """
 
-import collections
+import itertools
 
 from avocado.core import tree
 
 
-def any_sibling(*nodes):
+def tree2pools(node, mux=False):
     """
-    Check if there is any sibling.
-
-    :param nodes: the nodes to check.
-    :return: `True` if there is any sibling or `False`.
+    Process tree and flattens the structure to remaining leaves and
+    list of lists of leaves per each multiplex group.
+    :param node: Node to start with
+    :return: tuple(`leaves`, `pools`), where `leaves` are directly inherited
+    leafs of this node (no other multiplex in the middle). `pools` is list of
+    lists of directly inherited leafs of the nested multiplex domains.
     """
-    if len(nodes) < 2:
-        return False
-    parents = set(node.parent for node in nodes)
-    return len(nodes) != len(parents)
-
-
-def multiplex(*args):
     leaves = []
-    parents = collections.OrderedDict()
-    # filter args and create a set of parents
-    for arg in args[0]:
-        leaves.append(arg)
-        parents[arg.parent] = True
-
     pools = []
-    for p in parents.keys():
-        pools.append(leaves)
-        leaves = [x for x in leaves if x.parent != p]
-
-    result = [[]]
-    result_prev = [[]]
-    for pool in pools:
-
-        # second level of filtering above should use the filter strings
-        # extracted from the node being worked on
-        items = []
-        for x in result:
-            for y in pool:
-                item = x + [y]
-                if any_sibling(*item) is False:
-                    items.append(item)
-        result = items
-
-        # if a pool gets totally filtered out above, result will be empty
-        if len(result) == 0:
-            result = result_prev
-        else:
-            result_prev = result
-
-    if result == [[]]:
-        return
-
-    for prod in result:
-        yield tuple(prod)
+    if not mux:
+        for child in node.children:
+            if child.is_leaf:
+                leaves.append(child)
+            else:
+                _leafs, _pools = tree2pools(child, node.multiplex)
+                leaves.extend(_leafs)
+                pools.extend(_pools)
+    else:
+        # TODO: Get this multiplex leaves filters and store them in this pool
+        # to support 2nd level filtering
+        new_leafs = []
+        for child in node.children:
+            if child.is_leaf:
+                new_leafs.append(child)
+            else:
+                _leafs, _pools = tree2pools(child, node.multiplex)
+                new_leafs.extend(_leafs)
+                # TODO: For 2nd level filters store this separately in case
+                # this branch is filtered out
+                pools.extend(_pools)
+        if new_leafs:
+            # TODO: Filter the new_leafs (and new_pools) before merging
+            # into pools
+            pools.append(new_leafs)
+    return leaves, pools
 
 
 def multiplex_yamls(input_yamls, filter_only=None, filter_out=None,
@@ -84,7 +70,9 @@ def multiplex_yamls(input_yamls, filter_only=None, filter_out=None,
     if filter_out is None:
         filter_out = []
     input_tree = tree.create_from_yaml(input_yamls, debug)
+    # TODO: Process filters and multiplex simultaneously
     final_tree = tree.apply_filters(input_tree, filter_only, filter_out)
-    leaves = (x for x in final_tree.iter_leaves() if x.parent is not None)
-    variants = multiplex(leaves)
-    return variants
+    leaves, pools = tree2pools(final_tree, final_tree.multiplex)
+    if leaves:  # Add remaining leaves (they are not variants, only endpoints
+        pools.extend(leaves)
+    return itertools.product(*pools)    # *magic required pylint: disable=W0142

--- a/examples/mux-selftest-advanced.yaml
+++ b/examples/mux-selftest-advanced.yaml
@@ -19,6 +19,16 @@ distro:
         # And this removes the original 'is_cool'
         # Setting happens after ctrl so it should be created'
         !remove_value : is_cool
+distro: !multiplex
+    # Only set !multiplex flag on 'distro', which was aoriginally created
+    # as leafs-only
+    # Note: It doesn't make sense to define distro as !multiplex, it's used
+    #       here only to test |= feature
+    mint:   # This won't change anything
+distro:
+    # Again define distro without !multiplex. As !multiplex flag is defined
+    # as |=, this shouldn't affect the node and it should stay as !multiplex
+    gentoo:     # This won't change anything
 # This creates new branch the usual way
 new_node:
     # Put this new_node into /absolutely/fresh/ ('/' are automatically

--- a/examples/mux-selftest.yaml
+++ b/examples/mux-selftest.yaml
@@ -7,8 +7,8 @@
 #          multiple files and checks that the node ordering works fine.
 # /env/opt_CFLAGS: Should be present in merged node
 # /env/prod/opt_CFLAGS: value should be overridden by latter node
-
-hw:
+!multiplex
+hw: !multiplex
     cpu:
         joinlist:
             - first_item
@@ -27,7 +27,7 @@ hw:
             disk_type: 'scsi'
         virtio:
     corruptlist: ['upper_node_list']
-distro:
+distro:     # This node is set as !multiplex bellow
     fedora:
         init: 'systemd'
 env:

--- a/examples/tests/env_variables.sh.data/env_variables.yaml
+++ b/examples/tests/env_variables.sh.data/env_variables.yaml
@@ -1,3 +1,4 @@
+!multiplex
 short:
     CUSTOM_VARIABLE: A
 medium:

--- a/examples/tests/sleeptest.py.data/sleeptest.yaml
+++ b/examples/tests/sleeptest.py.data/sleeptest.yaml
@@ -1,3 +1,4 @@
+!multiplex
 short:
     sleep_length: 0.5
 medium:

--- a/selftests/all/unit/avocado/multiplexer_unittest.py
+++ b/selftests/all/unit/avocado/multiplexer_unittest.py
@@ -4,52 +4,31 @@ import unittest
 
 from avocado import multiplexer
 from avocado.core import tree
+import itertools
 
 
 TREE = tree.create_from_yaml(['examples/mux-selftest.yaml'])
 
 
-class TestAnySibling(unittest.TestCase):
-    # /hw/cpu/{intel,amd,arm}
-    tree = TREE
-    sibl_a_1 = tree.children[0].children[0].children[0]
-    sibl_a_2 = tree.children[0].children[0].children[1]
-    sibl_a_3 = tree.children[0].children[0].children[2]
-    # /hw/{cpu,disk}
-    sibl_b_1 = tree.children[1].children[0]
-    sibl_b_2 = tree.children[1].children[1]
-
-    def test_empty(self):
-        self.assertFalse(multiplexer.any_sibling())
-
-    def test_one_node(self):
-        single_node = self.tree.children[2].children[0]
-        self.assertFalse(multiplexer.any_sibling(single_node))
-
-    def test_all_siblings(self):
-        self.assertTrue(multiplexer.any_sibling(self.sibl_b_1, self.sibl_b_2))
-        self.assertTrue(multiplexer.any_sibling(self.sibl_a_1, self.sibl_a_2,
-                                                self.sibl_a_3))
-
-    def test_mixed(self):
-        self.assertTrue(multiplexer.any_sibling(self.sibl_a_1, self.sibl_a_2,
-                                                self.sibl_b_1))
-
-    def test_no_relation(self):
-        self.assertFalse(multiplexer.any_sibling(self.sibl_a_1, self.sibl_b_1))
+def combine(leaves_pools):
+    ''' Joins remaining leafs and pools and create product '''
+    if leaves_pools[0]:
+        leaves_pools[1].extend(leaves_pools[0])
+    return itertools.product(*leaves_pools[1])
 
 
 class TestMultiplex(unittest.TestCase):
     tree = TREE
-    mux_full = tuple(multiplexer.multiplex(tree))
+    mux_full = tuple(combine(multiplexer.tree2pools(tree)))
 
     def test_empty(self):
-        self.assertEqual(tuple(multiplexer.multiplex([])), tuple())
+        act = tuple(combine(multiplexer.tree2pools(tree.TreeNode())))
+        self.assertEqual(act, ((),))
 
     def test_partial(self):
         exp = (('intel', 'scsi'), ('intel', 'virtio'), ('amd', 'scsi'),
                ('amd', 'virtio'), ('arm', 'scsi'), ('arm', 'virtio'))
-        act = tuple(multiplexer.multiplex(self.tree.children[0]))
+        act = tuple(combine(multiplexer.tree2pools(self.tree.children[0])))
         self.assertEqual(act, exp)
 
     def test_full(self):

--- a/selftests/all/unit/avocado/tree_unittest.py
+++ b/selftests/all/unit/avocado/tree_unittest.py
@@ -165,6 +165,21 @@ class TestTree(unittest.TestCase):
                          oldroot.children[1].children[2].value)
         self.assertEqual({'new_value': 'something'},
                          oldroot.children[3].children[0].children[0].value)
+        # multiplex root (always False)
+        self.assertEqual(tree2.multiplex, False)
+        # multiplex /
+        self.assertEqual(tree2.children[0].multiplex, True)
+        # multiplex /hw
+        self.assertEqual(tree2.children[0].children[0].multiplex, True)
+        # multiplex /distro
+        self.assertEqual(tree2.children[0].children[1].multiplex, True)
+        # multiplex /env
+        self.assertEqual(tree2.children[0].children[2].multiplex, False)
+        # multiplex /absolutly
+        self.assertEqual(tree2.children[0].children[3].multiplex, False)
+        # multiplex /distr/fedora
+        self.assertEqual(tree2.children[0].children[1].children[0].multiplex,
+                         False)
 
 
 class TestPathParent(unittest.TestCase):


### PR DESCRIPTION
This patch completely changes the way multiplexation works. Instead
of multiplexing all non-sibling leaves it allows to specify multiplex
domains. These domains create leaves pools, which are then combined
into result variants. See documentation for details.

The easiest way to convert your existing multiplex files is set all
nodes as multiplex domains. That way you get the same results.

v0: https://github.com/avocado-framework/avocado/pull/324

Changelog:

    v1: !mux-domain yaml tag renamed to !multiplex
    v1: Support for node merging
    v1: Merging !multiplex tag is |= as people tend to specify it in first, not last node.
        (when needed, we can create !nomultiplex flag to reset the flag)
    v1: Documentation
    v1: Selftests & example yaml files adjusted