### PR TITLE
avocado.plugins: Change 'Default' with 'Current' wording on --help outpu...

### DIFF
--- a/avocado/plugins/gdb.py
+++ b/avocado/plugins/gdb.py
@@ -60,8 +60,8 @@ class GDB(plugin.Plugin):
         gdb_grp.add_argument('--gdb-path',
                              default=system_gdb_path, metavar='PATH',
                              help=('Path to the GDB executable, should you '
-                                   'need to use a custom GDB version. Defaults '
-                                   'to "%(default)s"'))
+                                   'need to use a custom GDB version. Current: '
+                                   '"%(default)s"'))
 
         default_gdbserver_path = '/usr/bin/gdbserver'
         try:
@@ -71,8 +71,8 @@ class GDB(plugin.Plugin):
         gdb_grp.add_argument('--gdbserver-path',
                              default=system_gdbserver_path, metavar='PATH',
                              help=('Path to the gdbserver executable, should you '
-                                   'need to use a custom version. Defaults '
-                                   'to "%(default)s"'))
+                                   'need to use a custom version. Current: '
+                                   '"%(default)s"'))
 
         self.configured = True
 

--- a/avocado/plugins/htmlresult.py
+++ b/avocado/plugins/htmlresult.py
@@ -257,7 +257,7 @@ class HTML(plugin.Plugin):
             dest='relative_links',
             action='store_true',
             default=False,
-            help=('On the HTML report, generate anchor links with relative instead of absolute paths. Default: %s' %
+            help=('On the HTML report, generate anchor links with relative instead of absolute paths. Current: %s' %
                   False))
         self.parser.runner.add_argument(
             '--open-browser',
@@ -266,7 +266,7 @@ class HTML(plugin.Plugin):
             default=False,
             help='Open the generated report on your preferred browser. '
                  'This works even if --html was not explicitly passed, since an HTML '
-                 'report is always generated on the job results dir. Default: %s' % False)
+                 'report is always generated on the job results dir. Current: %s' % False)
         self.configured = True
 
     def activate(self, app_args):

--- a/avocado/plugins/remote.py
+++ b/avocado/plugins/remote.py
@@ -251,10 +251,11 @@ class RunRemote(plugin.Plugin):
         self.remote_parser.add_argument('--remote-port', dest='remote_port',
                                         default=22, type=int,
                                         help='Specify the port number to login on remote machine. '
-                                             'Default: 22')
+                                             'Current: 22')
         self.remote_parser.add_argument('--remote-username', dest='remote_username',
                                         default=username,
-                                        help='Specify the username to login on remote machine')
+                                        help=('Specify the username to login on remote machine. '
+                                              'Current: %(default)s'))
         self.remote_parser.add_argument('--remote-password', dest='remote_password',
                                         default=None,
                                         help='Specify the password to login on remote machine')

--- a/avocado/plugins/runner.py
+++ b/avocado/plugins/runner.py
@@ -73,7 +73,7 @@ class TestRunner(plugin.Plugin):
         out.add_argument('--job-log-level', action='store',
                          help=("Log level of the job log. Options: "
                                "'debug', 'info', 'warning', 'error', "
-                               "'critical'. Default: debug"),
+                               "'critical'. Current: debug"),
                          default='debug')
 
         out_check = self.parser.add_argument_group('output check arguments')
@@ -81,12 +81,12 @@ class TestRunner(plugin.Plugin):
         out_check.add_argument('--output-check-record', type=str,
                                default='none',
                                help=('Record output streams of your tests '
-                                       'to reference files (valid options: '
-                                       'none (do not record output streams), '
-                                       'all (record both stdout and stderr), '
-                                       'stdout (record only stderr), '
-                                       'stderr (record only stderr). '
-                                       'Default: none'))
+                                     'to reference files (valid options: '
+                                     'none (do not record output streams), '
+                                     'all (record both stdout and stderr), '
+                                     'stdout (record only stderr), '
+                                     'stderr (record only stderr). '
+                                     'Current: none'))
 
         out_check.add_argument('--disable-output-check', action='store_true',
                                default=False,
@@ -94,7 +94,7 @@ class TestRunner(plugin.Plugin):
                                      'If this option is selected, no output will '
                                      'be checked, even if there are reference files '
                                      'present for the test. '
-                                     'Default: False (output check enabled)'))
+                                     'Current: False (output check enabled)'))
 
         mux = self.parser.add_argument_group('multiplex arguments')
         mux.add_argument('-m', '--multiplex-files', nargs='*', default=None,

--- a/avocado/plugins/vm.py
+++ b/avocado/plugins/vm.py
@@ -282,7 +282,7 @@ class RunVM(plugin.Plugin):
                                     dest='vm_hypervisor_uri',
                                     default=default_hypervisor_uri,
                                     help=('Specify hypervisor URI driver '
-                                          'connection. Default: %s' %
+                                          'connection. Current: %s' %
                                           default_hypervisor_uri))
         self.vm_parser.add_argument('--vm-domain', dest='vm_domain',
                                     help=('Specify Libvirt Domain Name'))


### PR DESCRIPTION
...t

Now that we gather values from the config files, 'Current'
becomes more proper term.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>