### PR TITLE
avocado.runner: optimize the run of quick tests

### DIFF
--- a/avocado/runner.py
+++ b/avocado/runner.py
@@ -149,7 +149,7 @@ class TestRunner(object):
                         os.kill(p.pid, signal.SIGUSR1)
                         break
                     wait.wait_for(lambda: not q.empty() or not p.is_alive(),
-                                  cycle_timeout, step=0.1)
+                                  cycle_timeout, first=0.01, step=0.1)
                     if not q.empty():
                         test_state = q.get()
                         if not test_state['running']:
@@ -195,7 +195,7 @@ class TestRunner(object):
             # If test_state is None, the test was aborted before it ended.
             if test_state is None:
                 if p.is_alive() and wait.wait_for(lambda: not q.empty(),
-                                                  cycle_timeout, step=0.1):
+                                                  cycle_timeout, first=0.01, step=0.1):
                     test_state = q.get()
                 else:
                     early_state['time_elapsed'] = time.time() - time_started


### PR DESCRIPTION
If the test is very quick, it may run in less than 0.1 secs, which is the
minimum time we wait for the result to be available in TestRunner::run_suite().

Since utils.wait_for() accepts a "first" parameter, documented as "Time to sleep
before first attempt", let's use it with a very aggressive low value, just
enough for the main process to be put to sleep by the scheduler and give time
for the other process to run.

Benchmark using multiplextest:
    $ TESTS=""; for f in $(seq 1 100); do TESTS="$TESTS examples/tests/multiplextest.py"; done
    $ time scripts/avocado run $TESTS > /dev/null

Before this change:
    real    0m12.114s
    user    0m1.549s
    sys     0m1.038s

After:
    real    0m2.639s
    user    0m1.065s
    sys     0m0.764s

Signed-off-by: Ademar de Souza Reis Jr <areis@redhat.com>