### PR TITLE
avocado.core.exit_codes: Change AVOCADO_CRASH to AVOCADO_FAIL

### DIFF
--- a/avocado/core/exit_codes.py
+++ b/avocado/core/exit_codes.py
@@ -20,8 +20,9 @@ The current exit codes are:
     * AVOCADO_JOB_FAIL (2)
         Something went wrong with the Job itself, by explicit
         :class:`avocado.core.exceptions.JobError` exception.
-    * AVOCADO_CRASH (3)
-        Something else went wrong and avocado plain crashed.
+    * AVOCADO_FAIL (3)
+        Something else went wrong and avocado failed (or crashed). Commonly
+        used on command line validation errors.
     * AVOCADO_JOB_INTERRUPTED (4)
         The job was explicitly interrupted. Usually this means that a user
         hit CTRL+C while the job was still running.
@@ -30,5 +31,5 @@ The current exit codes are:
 AVOCADO_ALL_OK = 0
 AVOCADO_TESTS_FAIL = 1
 AVOCADO_JOB_FAIL = 2
-AVOCADO_CRASH = 3
+AVOCADO_FAIL = 3
 AVOCADO_JOB_INTERRUPTED = 4

--- a/avocado/job.py
+++ b/avocado/job.py
@@ -331,7 +331,7 @@ class Job(object):
                                                  'your bug report'))
             self.view.notify(event='error', msg=('Report bugs visiting %s' %
                                                  _NEW_ISSUE_LINK))
-            return exit_codes.AVOCADO_CRASH
+            return exit_codes.AVOCADO_FAIL
 
 
 class TestModuleRunner(object):

--- a/avocado/plugins/distro.py
+++ b/avocado/plugins/distro.py
@@ -350,7 +350,7 @@ class DistroOptions(plugin.Plugin):
                 error_msg = ('Required arguments: name, version, arch, type '
                              'and path')
                 view.notify(event="error", msg=error_msg)
-                sys.exit(exit_codes.AVOCADO_CRASH)
+                sys.exit(exit_codes.AVOCADO_FAIL)
 
             output_file_name = self.get_output_file_name(args)
             if os.path.exists(output_file_name):

--- a/avocado/plugins/runner.py
+++ b/avocado/plugins/runner.py
@@ -122,7 +122,7 @@ class TestRunner(plugin.Plugin):
                     raise ValueError
             except ValueError:
                 view.notify(event='error', msg='Unique Job ID needs to be a 40 digit hex number')
-                return sys.exit(exit_codes.AVOCADO_CRASH)
+                return sys.exit(exit_codes.AVOCADO_FAIL)
 
         job_instance = job.Job(args)
         rc = job_instance.run()

--- a/avocado/plugins/wrapper.py
+++ b/avocado/plugins/wrapper.py
@@ -46,7 +46,7 @@ class Wrapper(plugin.Plugin):
                         view.notify(event='error',
                                     msg="You can't have multiple global"
                                         " wrappers at once.")
-                        sys.exit(exit_codes.AVOCADO_CRASH)
+                        sys.exit(exit_codes.AVOCADO_FAIL)
                 else:
                     script, cmd = wrap.split(':', 1)
                     script = os.path.abspath(script)
@@ -54,11 +54,11 @@ class Wrapper(plugin.Plugin):
                 if not os.path.exists(script):
                     view.notify(event='error',
                                 msg="Wrapper '%s' not found!" % script)
-                    sys.exit(exit_codes.AVOCADO_CRASH)
+                    sys.exit(exit_codes.AVOCADO_FAIL)
             if app_args.gdb_run_bin:
                 view.notify(event='error',
                             msg='Command line option --wrapper is incompatible'
                                 ' with option --gdb-run-bin.')
-                sys.exit(exit_codes.AVOCADO_CRASH)
+                sys.exit(exit_codes.AVOCADO_FAIL)
         except AttributeError:
             pass


### PR DESCRIPTION
At the time it seemed a good idea to have an exit_code.AVOCADO_CRASH
integer, but since we also use it for option validation errors, it's
misleading a good deal of the time. Let's use a more generic
AVOCADO_FAIL, update usages and description.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>