### PR TITLE
Fix compatibility problem with vm and remote plugins and htmlresult feature.

### DIFF
--- a/avocado/plugins/jsonresult.py
+++ b/avocado/plugins/jsonresult.py
@@ -56,6 +56,8 @@ class JSONTestResult(TestResult):
             self.json['job_id'] = state['job_unique_id']
         t = {'test': state['tagged_name'],
              'url': state['name'],
+             'start': state['time_start'],
+             'end': state['time_end'],
              'time': state['time_elapsed'],
              'status': state['status'],
              'whiteboard': state['whiteboard'],

--- a/avocado/plugins/remote.py
+++ b/avocado/plugins/remote.py
@@ -70,19 +70,21 @@ class RemoteTestRunner(TestRunner):
         for tst in results['tests']:
             test = RemoteTest(name=tst['test'],
                               time=tst['time'],
+                              start=tst['start'],
+                              end=tst['end'],
                               status=tst['status'])
             state = test.get_state()
             self.result.start_test(state)
             self.result.check_test(state)
             if not status.mapping[state['status']]:
                 failures.append(state['tagged_name'])
-        self.result.end_tests()
         local_log_dir = os.path.dirname(self.result.stream.debuglog)
         zip_filename = remote_log_dir + '.zip'
         zip_path_filename = os.path.join(local_log_dir, os.path.basename(zip_filename))
         self.result.remote.receive_files(local_log_dir, zip_filename)
         archive.uncompress(zip_path_filename, local_log_dir)
         os.remove(zip_path_filename)
+        self.result.end_tests()
         self.result.tear_down()
         return failures
 
@@ -143,6 +145,11 @@ class RemoteTestResult(TestResult):
         TestResult.start_tests(self)
         self.stream.notify(event='message', msg="JOB ID    : %s" % self.stream.job_unique_id)
         self.stream.notify(event='message', msg="JOB LOG   : %s" % self.stream.logfile)
+        if self.args is not None:
+            if 'html_output' in self.args:
+                logdir = os.path.dirname(self.stream.logfile)
+                html_file = os.path.join(logdir, 'html', 'results.html')
+                self.stream.notify(event="message", msg="JOB HTML  : %s" % html_file)
         self.stream.notify(event='message', msg="TESTS     : %s" % self.tests_total)
         self.stream.set_tests_info({'tests_total': self.tests_total})
 

--- a/avocado/test.py
+++ b/avocado/test.py
@@ -604,12 +604,14 @@ class RemoteTest(object):
     Mimics :class:`avocado.test.Test` for remote tests.
     """
 
-    def __init__(self, name, status, time):
+    def __init__(self, name, status, time, start, end):
         note = "Not supported yet"
         self.name = name
         self.tagged_name = name
         self.status = status
         self.time_elapsed = time
+        self.time_start = start
+        self.time_end = end
         self.fail_class = note
         self.traceback = note
         self.text_output = note

--- a/selftests/all/unit/avocado/remote_unittest.py
+++ b/selftests/all/unit/avocado/remote_unittest.py
@@ -46,9 +46,10 @@ class RemoteResultTest(unittest.TestCase):
         stream = _Stream()
         stream.logfile = 'debug.log'
         self.test_result = remote.RemoteTestResult(stream, args)
-        j = '''{"tests": [{"test": "sleeptest.1", "url": "sleeptest", "status": "PASS", "time": 1.23}],
+        j = '''{"tests": [{"test": "sleeptest.1", "url": "sleeptest", "status": "PASS",
+                "time": 1.23, "start": 0, "end": 1.23}],
                 "debuglog": "/home/user/avocado/logs/run-2014-05-26-15.45.37/debug.log",
-                "errors": 0, "skip": 0, "time": 1.4,
+                "errors": 0, "skip": 0, "time": 1.4, "start": 0, "end": 1.4,
                 "pass": 1, "failures": 0, "total": 1}'''
         self.results = json.loads(j)
 
@@ -58,6 +59,8 @@ class RemoteResultTest(unittest.TestCase):
         for tst in self.results['tests']:
             test = remote.RemoteTest(name=tst['test'],
                                      time=tst['time'],
+                                     start=tst['start'],
+                                     end=tst['end'],
                                      status=tst['status'])
             self.test_result.start_test(test.get_state())
             self.test_result.check_test(test.get_state())

--- a/selftests/all/unit/avocado/vm_unittest.py
+++ b/selftests/all/unit/avocado/vm_unittest.py
@@ -46,7 +46,8 @@ class VMResultTest(unittest.TestCase):
         stream = _Stream()
         stream.logfile = 'debug.log'
         self.test_result = vm.VMTestResult(stream, args)
-        j = '''{"tests": [{"test": "sleeptest.1", "url": "sleeptest", "status": "PASS", "time": 1.23}],
+        j = '''{"tests": [{"test": "sleeptest.1", "url": "sleeptest", "status": "PASS",
+                "time": 1.23, "start": 0.0, "end": 1.23}],
                 "debuglog": "/home/user/avocado/logs/run-2014-05-26-15.45.37/debug.log",
                 "errors": 0, "skip": 0, "time": 1.4,
                 "pass": 1, "failures": 0, "total": 1}'''
@@ -58,6 +59,8 @@ class VMResultTest(unittest.TestCase):
         for tst in self.results['tests']:
             test = vm.RemoteTest(name=tst['test'],
                                  time=tst['time'],
+                                 start=tst['start'],
+                                 end=tst['end'],
                                  status=tst['status'])
             self.test_result.start_test(test.get_state())
             self.test_result.check_test(test.get_state())


### PR DESCRIPTION
Fix the compatibility with HTML result plugin when using together with remote or vm plugins:
* Define time_start and time_end attributes on class RemoteTest..
* Move self.result.end_tests() close to tear_down() in order to have sysinfo files unarchived on remote and vm plugins.