### PR TITLE
Test ID and "tagged name" construction and convention

### DIFF
--- a/avocado/job.py
+++ b/avocado/job.py
@@ -211,6 +211,8 @@ class Job(object):
 
         if urls is not None:
             for url in urls:
+                if url.startswith(os.path.pardir):
+                    url = os.path.abspath(url)
                 params_list.append({'id': url})
         else:
             e_msg = "Empty test ID. A test path or alias must be provided"


### PR DESCRIPTION
Avocado tries hard to not surprise the user, and attempts to preserve
the test ID (from the command line test urls) in the test result directory
structure. Because of that, we should not keep using a test ID that is a
relative path, because too much can go wrong.

This patch simply checks if a test ID (from an test url) looks like a
relative path, and if so, changes it to an absolute path. Detailed
explanation on how this is currently broken follows:

At TestLoader.discover_test() (from loader.py), a test name is derived
from a test ID:

```
   test_name = params.get('id')
```

The test class itself, along with test parameters (including `id`) are
produced and returned by `TestLoader._make_test()`.

The test class is then instantiated with these parameters, and a "tagged
name" is constructed by `Test.get_tagged_name()`. This tagged name is then
used to construct the log directories and files:

```
   self.logdir = path.init_dir(base_logdir, self.tagged_name)
   io.set_log_file_dir(self.logdir)
   self.logfile = os.path.join(self.logdir, 'debug.log')
```

This will try to create directories completely outside of what was
intended, and can even crash if there's no permission to do so, resulting
in the avocado test runner waiting for the test "early state" forever.

Signed-off-by: Cleber Rosa <crosa@redhat.com>