### PR TITLE
[V2] Improve test load debug

### DIFF
--- a/avocado/runner.py
+++ b/avocado/runner.py
@@ -30,8 +30,10 @@ from avocado import sysinfo
 from avocado.core import exceptions
 from avocado.core import output
 from avocado.core import status
+from avocado.core import exit_codes
 from avocado.utils import path
 from avocado.utils import wait
+from avocado.utils import stacktrace
 
 
 class TestRunner(object):
@@ -62,13 +64,6 @@ class TestRunner(object):
         :param queue: Multiprocess queue.
         :type queue: :class`multiprocessing.Queue` instance.
         """
-        sys.stdout = output.LoggingFile(logger=logging.getLogger('avocado.test.stdout'))
-        sys.stderr = output.LoggingFile(logger=logging.getLogger('avocado.test.stderr'))
-        instance = self.job.test_loader.load_test(test_factory)
-        runtime.CURRENT_TEST = instance
-        early_state = instance.get_state()
-        queue.put(early_state)
-
         def timeout_handler(signum, frame):
             e_msg = "Timeout reached waiting for %s to end" % instance
             raise exceptions.TestTimeoutError(e_msg)
@@ -76,6 +71,22 @@ class TestRunner(object):
         def interrupt_handler(signum, frame):
             e_msg = "Test %s interrupted by user" % instance
             raise exceptions.TestInterruptedError(e_msg)
+
+        sys.stdout = output.LoggingFile(logger=logging.getLogger('avocado.test.stdout'))
+        sys.stderr = output.LoggingFile(logger=logging.getLogger('avocado.test.stderr'))
+
+        try:
+            instance = self.job.test_loader.load_test(test_factory)
+            runtime.CURRENT_TEST = instance
+            early_state = instance.get_state()
+            queue.put(early_state)
+        except Exception:
+            exc_info = sys.exc_info()
+            app_logger = logging.getLogger('avocado.app')
+            app_logger.exception('Exception loading test')
+            tb_info = stacktrace.tb_info(exc_info)
+            queue.put({'load_exception': tb_info})
+            return
 
         signal.signal(signal.SIGUSR1, timeout_handler)
         signal.signal(signal.SIGINT, interrupt_handler)
@@ -127,6 +138,14 @@ class TestRunner(object):
             p.start()
 
             early_state = q.get()
+
+            if 'load_exception' in early_state:
+                self.job.view.notify(event='error',
+                                     msg='Avocado crashed during test load. '
+                                         'Some reports might have not been '
+                                         'generated. Aborting...')
+                sys.exit(exit_codes.AVOCADO_FAIL)
+
             # At this point, the test is already initialized and we know
             # for sure if there's a timeout set.
             if 'timeout' in early_state['params'].keys():

--- a/avocado/test.py
+++ b/avocado/test.py
@@ -25,7 +25,6 @@ import sys
 import time
 import traceback
 import unittest
-import tempfile
 
 from avocado.core import data_dir
 from avocado.core import exceptions

--- a/avocado/utils/stacktrace.py
+++ b/avocado/utils/stacktrace.py
@@ -1,0 +1,39 @@
+"""
+Traceback standard module plus some additional APIs.
+"""
+from traceback import format_exception
+import logging
+
+
+def tb_info(exc_info):
+    """
+    Prepare traceback info.
+
+    :param exc_info: Exception info produced by sys.exc_info()
+    """
+    exc_type, exc_value, exc_traceback = exc_info
+    return format_exception(exc_type, exc_value, exc_traceback.tb_next)
+
+
+def prepare_exc_info(exc_info):
+    """
+    Prepare traceback info.
+
+    :param exc_info: Exception info produced by sys.exc_info()
+    """
+    return "".join(tb_info(exc_info))
+
+
+def log_exc_info(exc_info, logger='root'):
+    """
+    Log exception info to logger_name.
+
+    :param exc_info: Exception info produced by sys.exc_info()
+    :param logger: Name of the logger (defaults to root)
+    """
+    log = logging.getLogger(logger)
+    log.error('')
+    for line in tb_info(exc_info):
+        for l in line.splitlines():
+            log.error(l)
+    log.error('')


### PR DESCRIPTION
This is a follow up to #348.

This improves the ability to debug avocado in a very delicate spot: Test loading. Since the load happens on a subprocess, and the main avocado process requires a response from the other side to know what to do, our users (and devs) were left in the dark, requiring debug to understand what went wrong. This changes now.

Changes from v1:

 * Changed module name: avocado.utils.tb -> avocado.utils.stacktrace, per @ruda's comments.
 * Improved error message on test load bug, per @clebergnu's comments.
