### PR TITLE
[V6] Test discovery and load (Phase II)

### DIFF
--- a/avocado/job.py
+++ b/avocado/job.py
@@ -188,11 +188,39 @@ class Job(object):
             human_plugin = result.HumanTestResult(self.view, self.args)
             self.result_proxy.add_output_plugin(human_plugin)
 
+    def _multiplex_params_list(self, params_list, multiplex_files):
+        for mux_file in multiplex_files:
+            if not os.path.exists(mux_file):
+                e_msg = "Multiplex file %s doesn't exist." % mux_file
+                raise exceptions.OptionValidationError(e_msg)
+        result = []
+        for params in params_list:
+            try:
+                variants = multiplexer.multiplex_yamls(multiplex_files,
+                                                       self.args.filter_only,
+                                                       self.args.filter_out)
+            except SyntaxError:
+                variants = None
+            if variants:
+                tag = 1
+                for variant in variants:
+                    env = {}
+                    for t in variant:
+                        env.update(dict(t.environment))
+                    env.update({'tag': tag})
+                    env.update({'id': params['id']})
+                    result.append(env)
+                    tag += 1
+            else:
+                result.append(params)
+        return result
+
     def _run(self, urls=None, multiplex_files=None):
         """
         Unhandled job method. Runs a list of test URLs to its completion.
 
-        :param urls: String with tests to run.
+        :param urls: String with tests to run, separated by whitespace.
+                     Optionally, a list of tests (each test a string).
         :param multiplex_files: File that multiplexes a given test url.
 
         :return: Integer with overall job status. See
@@ -201,72 +229,47 @@ class Job(object):
                 :class:`avocado.core.exceptions.JobBaseException` errors,
                 that configure a job failure.
         """
-        params_list = []
         if urls is None:
-            if self.args and self.args.url:
+            if self.args and self.args.url is not None:
                 urls = self.args.url
-        else:
-            if isinstance(urls, str):
-                urls = urls.split()
 
-        if urls is not None:
-            for url in urls:
-                if url.startswith(os.path.pardir):
-                    url = os.path.abspath(url)
-                params_list.append({'id': url})
-        else:
+        if isinstance(urls, str):
+            urls = urls.split()
+
+        if not urls:
             e_msg = "Empty test ID. A test path or alias must be provided"
             raise exceptions.OptionValidationError(e_msg)
+
+        self._make_test_loader()
+
+        params_list = self.test_loader.discover_urls(urls)
 
         if multiplex_files is None:
             if self.args and self.args.multiplex_files is not None:
                 multiplex_files = self.args.multiplex_files
-        else:
-            multiplex_files = multiplex_files
 
         if multiplex_files is not None:
-            for mux_file in multiplex_files:
-                if not os.path.exists(mux_file):
-                    e_msg = "Multiplex file %s doesn't exist." % (mux_file)
-                    raise exceptions.OptionValidationError(e_msg)
-            params_list = []
-            if urls is not None:
-                for url in urls:
-                    try:
-                        variants = multiplexer.multiplex_yamls(multiplex_files,
-                                                               self.args.filter_only,
-                                                               self.args.filter_out)
-                    except SyntaxError:
-                        variants = None
-                    if variants:
-                        tag = 1
-                        for variant in variants:
-                            env = {}
-                            for t in variant:
-                                env.update(dict(t.environment))
-                            env.update({'tag': tag})
-                            env.update({'id': url})
-                            params_list.append(env)
-                            tag += 1
-                    else:
-                        params_list.append({'id': url})
+            params_list = self._multiplex_params_list(params_list,
+                                                      multiplex_files)
 
-        if not params_list:
-            e_msg = "Test(s) with empty parameter list or the number of variants is zero"
+        test_suite = self.test_loader.discover(params_list)
+        if not test_suite:
+            e_msg = ("No tests found within the specified path(s) "
+                     "(Check input and tests for typos. Try --show-job-log "
+                     "for more info)")
             raise exceptions.OptionValidationError(e_msg)
 
         if self.args is not None:
-            self.args.test_result_total = len(params_list)
+            self.args.test_result_total = len(test_suite)
 
         self._make_test_result()
         self._make_test_runner()
-        self._make_test_loader()
 
         self.view.start_file_logging(self.logfile,
                                      self.loglevel,
                                      self.unique_id)
         self.view.logfile = self.logfile
-        failures = self.test_runner.run_suite(params_list)
+        failures = self.test_runner.run_suite(test_suite)
         self.view.stop_file_logging()
         # If it's all good so far, set job status to 'PASS'
         if self.status == 'RUNNING':
@@ -301,7 +304,8 @@ class Job(object):
         The test runner figures out which tests need to be run on an empty urls
         list by assuming the first component of the shortname is the test url.
 
-        :param urls: String with tests to run.
+        :param urls: String with tests to run, separated by whitespace.
+                     Optionally, a list of tests (each test a string).
         :param multiplex_files: File that multiplexes a given test url.
 
         :return: Integer with overall job status. See

--- a/avocado/loader.py
+++ b/avocado/loader.py
@@ -149,8 +149,7 @@ class TestLoader(object):
         :return: a test factory (a pair of test class and test parameters)
                  or `None`.
         """
-        test_name = params.get('id')
-        test_path = os.path.abspath(test_name)
+        test_name = test_path = params.get('id')
         if os.path.exists(test_path):
             if os.access(test_path, os.R_OK) is False:
                 return None

--- a/avocado/loader.py
+++ b/avocado/loader.py
@@ -28,13 +28,21 @@ from avocado.core import data_dir
 from avocado.utils import path
 
 
+class _DebugJob(object):
+
+    def __init__(self):
+        self.logdir = '.'
+
+
 class TestLoader(object):
 
     """
     Test loader class.
     """
 
-    def __init__(self, job):
+    def __init__(self, job=None):
+        if job is None:
+            job = _DebugJob()
         self.job = job
 
     def _make_missing_test(self, test_name, params):
@@ -61,7 +69,7 @@ class TestLoader(object):
                            'job': self.job}
         return test_class, test_parameters
 
-    def _make_test(self, test_name, test_path, params, queue):
+    def _make_test(self, test_name, test_path, params):
         module_name = os.path.basename(test_path).split('.')[0]
         test_module_dir = os.path.dirname(test_path)
         sys.path.append(test_module_dir)
@@ -71,11 +79,10 @@ class TestLoader(object):
                                   'params': params,
                                   'job': self.job}
 
-        test_parameters_queue = {'name': test_name,
-                                 'base_logdir': self.job.logdir,
-                                 'params': params,
-                                 'job': self.job,
-                                 'runner_queue': queue}
+        test_parameters_name = {'name': test_name,
+                                'base_logdir': self.job.logdir,
+                                'params': params,
+                                'job': self.job}
         try:
             f, p, d = imp.find_module(module_name, [test_module_dir])
             test_module = imp.load_module(module_name, f, p, d)
@@ -87,7 +94,7 @@ class TestLoader(object):
             if test_class is not None:
                 # Module is importable and does have an avocado test class
                 # inside, let's proceed.
-                test_parameters = test_parameters_queue
+                test_parameters = test_parameters_name
             else:
                 if os.access(test_path, os.X_OK):
                     # Module does not have an avocado test class inside but
@@ -98,7 +105,7 @@ class TestLoader(object):
                     # Module does not have an avocado test class inside, and
                     # it's not executable. Not a Test.
                     test_class = test.NotATest
-                    test_parameters = test_parameters_queue
+                    test_parameters = test_parameters_name
 
         # Since a lot of things can happen here, the broad exception is
         # justified. The user will get it unadulterated anyway, and avocado
@@ -127,30 +134,31 @@ class TestLoader(object):
                     params['exception'] = details
                 else:
                     test_class = test.NotATest
-                test_parameters = test_parameters_queue
+                test_parameters = test_parameters_name
 
         sys.path.pop(sys.path.index(test_module_dir))
 
         return test_class, test_parameters
 
-    def discover_test(self, params, queue):
+    def discover_test(self, params):
         """
         Try to discover and resolve a test.
 
         :param params: dictionary with test parameters.
         :type params: dict
-        :param queue: a queue for communicating with the test runner.
-        :type queue: an instance of :class:`multiprocessing.Queue`
         :return: a test factory (a pair of test class and test parameters)
+                 or `None`.
         """
         test_name = params.get('id')
         test_path = os.path.abspath(test_name)
         if os.path.exists(test_path):
+            if os.access(test_path, os.R_OK) is False:
+                return None
             path_analyzer = path.PathInspector(test_path)
             if path_analyzer.is_python():
                 test_class, test_parameters = self._make_test(test_name,
                                                               test_path,
-                                                              params, queue)
+                                                              params)
             else:
                 if os.access(test_path, os.X_OK):
                     test_class, test_parameters = self._make_simple_test(test_path,
@@ -165,25 +173,90 @@ class TestLoader(object):
             if os.path.exists(test_path):
                 test_class, test_parameters = self._make_test(rel_path,
                                                               test_path,
-                                                              params, queue)
+                                                              params)
             else:
                 test_class, test_parameters = self._make_missing_test(
                     test_name, params)
         return test_class, test_parameters
 
-    def discover(self, params_list, queue):
+    def discover_directory(self, dir_path='.', ignore_suffix=None):
+        """
+        Discover (possible) tests from a directory.
+
+        Recursively walk in a directory and find tests params.
+        The tests are returned in alphabetic order.
+
+        :param dir_path: the directory path to inspect.
+        :type dir_path: str
+        :param ignore_suffix: list of suffix to ignore in paths.
+        :type ignore_suffix: list
+        :return: a list of test params (each one a dictionary).
+        """
+        if ignore_suffix is None:
+            ignore_suffix = ('.data', '.pyc', '.pyo')
+        params_list = []
+        try:
+            entries = sorted(os.listdir(os.path.abspath(dir_path)))
+        except OSError:
+            return params_list
+        for entry in entries:
+            new_path = os.path.join(dir_path, entry)
+            if entry.startswith('.'):
+                continue
+            elif entry.endswith(ignore_suffix):
+                continue
+            elif os.path.isdir(new_path):
+                params_list.extend(self.discover_directory(new_path))
+            else:
+                params_list.append({'id': new_path})
+        return params_list
+
+    def discover_url(self, url):
+        """
+        Discover (possible) test from test url.
+
+        :params url: the test url to discover.
+        :type url: str
+        :return: a list of test params (each one a dictionary).
+        """
+        if os.path.isdir(os.path.abspath(url)):
+            params_list = self.discover_directory(url)
+            if params_list:
+                return params_list
+            else:
+                return []
+        else:
+            return [{'id': url}]
+
+    def discover_urls(self, urls):
+        """
+        Discover (possible) tests from test urls.
+
+        :param urls: a list of tests urls.
+        :type urls: list
+        :return: a list of test params (each one a dictioanry).
+        """
+        params_list = []
+        for url in urls:
+            if url == '':
+                continue
+            params_list.extend(self.discover_url(url))
+        return params_list
+
+    def discover(self, params_list):
         """
         Discover tests for test suite.
 
         :param params_list: a list of test parameters.
         :type params_list: list
-        :param queue: a queue for communicating with the test runner.
-        :type queue: an instance of :class:`multiprocessing.Queue`
         :return: a test suite (a list of test factories).
         """
         test_suite = []
         for params in params_list:
-            test_class, test_parameters = self.discover_test(params, queue)
+            test_factory = self.discover_test(params)
+            if test_factory is None:
+                continue
+            test_class, test_parameters = test_factory
             test_suite.append((test_class, test_parameters))
         return test_suite
 

--- a/avocado/plugins/test_lister.py
+++ b/avocado/plugins/test_lister.py
@@ -52,7 +52,7 @@ class TestLister(plugin.Plugin):
         test_files = os.listdir(base_test_dir)
         test_dirs = []
         blength = 0
-        for t in test_files:
+        for t in sorted(test_files):
             inspector = path.PathInspector(path=t)
             if inspector.is_python():
                 clength = len((t.split('.')[0]))

--- a/avocado/runner.py
+++ b/avocado/runner.py
@@ -77,6 +77,8 @@ class TestRunner(object):
 
         try:
             instance = self.job.test_loader.load_test(test_factory)
+            if instance.runner_queue is None:
+                instance.runner_queue = queue
             runtime.CURRENT_TEST = instance
             early_state = instance.get_state()
             queue.put(early_state)
@@ -113,11 +115,11 @@ class TestRunner(object):
             test_state['text_output'] = log_file_obj.read()
         return test_state
 
-    def run_suite(self, params_list):
+    def run_suite(self, test_suite):
         """
         Run one or more tests and report with test result.
 
-        :param params_list: a list of param dicts.
+        :param test_suite: a list of tests to run.
 
         :return: a list of test failures.
         """
@@ -125,7 +127,6 @@ class TestRunner(object):
         self.sysinfo.start_job_hook()
         self.result.start_tests()
         q = queues.SimpleQueue()
-        test_suite = self.job.test_loader.discover(params_list, q)
 
         for test_factory in test_suite:
             p = multiprocessing.Process(target=self.run_test,

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -25,6 +25,7 @@ import stat
 import shlex
 import shutil
 import threading
+import fnmatch
 
 try:
     import subprocess32 as subprocess
@@ -868,11 +869,8 @@ def should_run_inside_wrapper(cmd):
     args = shlex.split(cmd)
     cmd_binary_name = args[0]
 
-    for script, cmd in runtime.WRAP_PROCESS_NAMES_EXPR:
-        if os.path.isabs(cmd_binary_name) and os.path.isabs(cmd) is False:
-            cmd_binary_name = os.path.basename(cmd_binary_name)
-            cmd = os.path.basename(cmd)
-        if cmd_binary_name == cmd:
+    for script, cmd_expr in runtime.WRAP_PROCESS_NAMES_EXPR:
+        if fnmatch.fnmatch(cmd_binary_name, cmd_expr):
             runtime.CURRENT_WRAPPER = script
 
     if runtime.WRAP_PROCESS is not None and runtime.CURRENT_WRAPPER is None:

--- a/selftests/all/functional/avocado/wrapper_tests.py
+++ b/selftests/all/functional/avocado/wrapper_tests.py
@@ -6,7 +6,8 @@ import unittest
 import tempfile
 
 # simple magic for using scripts within a source tree
-basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..', '..', '..')
+basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..',
+                       '..', '..')
 basedir = os.path.abspath(basedir)
 if os.path.isdir(os.path.join(basedir, 'avocado')):
     sys.path.append(basedir)
@@ -41,36 +42,46 @@ class WrapperTest(unittest.TestCase):
 
     def test_global_wrapper(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --wrapper %s examples/tests/datadir.py' % self.script.path
+        cmd_line = ('./scripts/avocado run --wrapper %s '
+                    'examples/tests/datadir.py' % self.script.path)
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 0
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %d:\n%s" %
                          (expected_rc, result))
         self.assertTrue(os.path.exists(self.tmpfile),
-                        "Wrapper did not create file %s" % self.tmpfile)
+                        "Wrapper did not touch the tmp file %s\nStdout: "
+                        "%s\nCmdline: %s" %
+                        (self.tmpfile, result.stdout, cmd_line))
 
     def test_process_wrapper(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --wrapper %s:datadir examples/tests/datadir.py' % self.script.path
+        cmd_line = ('./scripts/avocado run --wrapper %s:*/datadir '
+                    'examples/tests/datadir.py' % self.script.path)
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 0
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %d:\n%s" %
                          (expected_rc, result))
         self.assertTrue(os.path.exists(self.tmpfile),
-                        "Wrapper did not create file %s" % self.tmpfile)
+                        "Wrapper did not touch the tmp file %s\nStdout: "
+                        "%s\nStdout: %s" %
+                        (self.tmpfile, cmd_line, result.stdout))
 
     def test_both_wrappers(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --wrapper %s --wrapper %s:datadir examples/tests/datadir.py' % (self.dummy.path, self.script.path)
+        cmd_line = ('./scripts/avocado run --wrapper %s --wrapper %s:*/datadir '
+                    'examples/tests/datadir.py' % (self.dummy.path,
+                                                   self.script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 0
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %d:\n%s" %
                          (expected_rc, result))
         self.assertTrue(os.path.exists(self.tmpfile),
-                        "Wrapper did not create file %s" % self.tmpfile)
+                        "Wrapper did not touch the tmp file %s\nStdout: "
+                        "%s\nStdout: %s" %
+                        (self.tmpfile, cmd_line, result.stdout))
 
     def tearDown(self):
         self.script.remove()

--- a/selftests/all/unit/avocado/loader_unittest.py
+++ b/selftests/all/unit/avocado/loader_unittest.py
@@ -75,8 +75,7 @@ class LoaderTest(unittest.TestCase):
                                              'avocado_loader_unittest')
         simple_test.save()
         test_class, test_parameters = (
-            self.loader.discover_test(params={'id': simple_test.path},
-                                      queue=self.queue))
+            self.loader.discover_test(params={'id': simple_test.path}))
         self.assertTrue(test_class == test.SimpleTest, test_class)
         tc = test_class(**test_parameters)
         tc.action()
@@ -88,8 +87,7 @@ class LoaderTest(unittest.TestCase):
                                              mode=0664)
         simple_test.save()
         test_class, test_parameters = (
-            self.loader.discover_test(params={'id': simple_test.path},
-                                      queue=self.queue))
+            self.loader.discover_test(params={'id': simple_test.path}))
         self.assertTrue(test_class == test.NotATest, test_class)
         tc = test_class(**test_parameters)
         self.assertRaises(exceptions.NotATestError, tc.action)
@@ -101,8 +99,7 @@ class LoaderTest(unittest.TestCase):
                                                    'avocado_loader_unittest')
         avocado_pass_test.save()
         test_class, test_parameters = (
-            self.loader.discover_test(params={'id': avocado_pass_test.path},
-                                      queue=self.queue))
+            self.loader.discover_test(params={'id': avocado_pass_test.path}))
         self.assertTrue(str(test_class) == "<class 'passtest.PassTest'>",
                         str(test_class))
         self.assertTrue(issubclass(test_class, test.Test))
@@ -116,8 +113,7 @@ class LoaderTest(unittest.TestCase):
                                                     'avocado_loader_unittest')
         avocado_buggy_test.save()
         test_class, test_parameters = (
-            self.loader.discover_test(params={'id': avocado_buggy_test.path},
-                                      queue=self.queue))
+            self.loader.discover_test(params={'id': avocado_buggy_test.path}))
         self.assertTrue(test_class == test.SimpleTest, test_class)
         tc = test_class(**test_parameters)
         self.assertRaises(exceptions.TestFail, tc.action)
@@ -130,8 +126,7 @@ class LoaderTest(unittest.TestCase):
                                                     mode=0664)
         avocado_buggy_test.save()
         test_class, test_parameters = (
-            self.loader.discover_test(params={'id': avocado_buggy_test.path},
-                                      queue=self.queue))
+            self.loader.discover_test(params={'id': avocado_buggy_test.path}))
         self.assertTrue(test_class == test.BuggyTest, test_class)
         tc = test_class(**test_parameters)
         self.assertRaises(ImportError, tc.action)
@@ -144,8 +139,7 @@ class LoaderTest(unittest.TestCase):
                                                     mode=0664)
         avocado_not_a_test.save()
         test_class, test_parameters = (
-            self.loader.discover_test(params={'id': avocado_not_a_test.path},
-                                      queue=self.queue))
+            self.loader.discover_test(params={'id': avocado_not_a_test.path}))
         self.assertTrue(test_class == test.NotATest, test_class)
         tc = test_class(**test_parameters)
         self.assertRaises(exceptions.NotATestError, tc.action)
@@ -156,8 +150,7 @@ class LoaderTest(unittest.TestCase):
                                                     'avocado_loader_unittest')
         avocado_not_a_test.save()
         test_class, test_parameters = (
-            self.loader.discover_test(params={'id': avocado_not_a_test.path},
-                                      queue=self.queue))
+            self.loader.discover_test(params={'id': avocado_not_a_test.path}))
         self.assertTrue(test_class == test.SimpleTest, test_class)
         tc = test_class(**test_parameters)
         # The test can't be executed (no shebang), raising an OSError
@@ -171,8 +164,7 @@ class LoaderTest(unittest.TestCase):
                                                      'avocado_loader_unittest')
         avocado_simple_test.save()
         test_class, test_parameters = (
-            self.loader.discover_test(params={'id': avocado_simple_test.path},
-                                      queue=self.queue))
+            self.loader.discover_test(params={'id': avocado_simple_test.path}))
         self.assertTrue(test_class == test.SimpleTest)
         tc = test_class(**test_parameters)
         tc.action()
@@ -185,8 +177,7 @@ class LoaderTest(unittest.TestCase):
                                                      mode=0664)
         avocado_simple_test.save()
         test_class, test_parameters = (
-            self.loader.discover_test(params={'id': avocado_simple_test.path},
-                                      queue=self.queue))
+            self.loader.discover_test(params={'id': avocado_simple_test.path}))
         self.assertTrue(test_class == test.NotATest)
         tc = test_class(**test_parameters)
         self.assertRaises(exceptions.NotATestError, tc.action)


### PR DESCRIPTION
This is a follow up to #349. I guess this can't be merged right now due to the stack of dependent PRs.

Anyway, this solves all problems we had so far, I think.

Changes from V4 and V5:

 * Rebase the code
 * Consolidated commits
 * Now when users provide paths to explicit files, then it analyzes them. If a dir is provided, non tests are not listed/their execution is attempted. Fixing comments by @ldoktor.

Changes from V3:

Fixed problems found by @ldoktor, mainly:

* Remove remaining references to MissingTests inside the code
* Fix crash when tests have bugs that prevent their modules from being imported
* Append base test directory to `sys.path` to ensure dependent modules in the same dir are imp.ortable

Changes from V2:

* Completely remove the concept of MissingTests. It wasn't very useful to begin with.
* Break the need for test classes to be named after the module names.
* Mass rename the current avocado test class names
* Update docs to reflect the new *status quo*

Changes from V1:

* avocado.loader: Locate SimpleTests using the full path.
* avocado.job: Set different messages when the number of tests found is zero [No tests found within the  specified path(s)] or when the number of variants is zero [The number of test variants is zero].
* avocado.loader: Skip directory if we don't have permission to walk. Also skip tests that are not tests, so Avocado stops crashing when walking in a directory, looking for tests.
* avocado.utils.process: Use shell glob style when matching wrap scripts.
test_lister plugin: Sort output in alphabetic order.