### PR TITLE
Introduce sysinfo daemon logging (journalctl & vmstat) [V2]

### DIFF
--- a/avocado/sysinfo.py
+++ b/avocado/sysinfo.py
@@ -415,6 +415,10 @@ class SysInfo(object):
                              'start_iteration': self.start_iteration_loggables,
                              'end_iteration': self.end_iteration_loggables}
 
+        self.pre_dir = utils.path.init_dir(self.basedir, 'pre')
+        self.post_dir = utils.path.init_dir(self.basedir, 'post')
+        self.profile_dir = utils.path.init_dir(self.basedir, 'profile')
+
         self._set_loggables()
 
     def _get_syslog_watcher(self):
@@ -548,64 +552,58 @@ class SysInfo(object):
         """
         Logging hook called whenever a job starts, and again after reboot.
         """
-        pre_dir = utils.path.init_dir(self.basedir, 'pre')
         for log in self.start_job_loggables:
-            log.run(pre_dir)
+            log.run(self.pre_dir)
 
         if self.log_packages:
-            self._log_installed_packages(pre_dir)
+            self._log_installed_packages(self.pre_dir)
 
     def end_job_hook(self):
         """
         Logging hook called whenever a job starts, and again after reboot.
         """
-        post_dir = utils.path.init_dir(self.basedir, 'post')
         for log in self.end_job_loggables:
-            log.run(post_dir)
+            log.run(self.post_dir)
         # Stop daemon(s) started previously
         for log in self.start_job_loggables:
             log.stop()
 
         if self.log_packages:
-            self._log_modified_packages(post_dir)
+            self._log_modified_packages(self.post_dir)
 
     def start_test_hook(self):
         """
         Logging hook called before a test starts.
         """
-        pre_dir = utils.path.init_dir(self.basedir, 'pre')
         for log in self.start_test_loggables:
-            log.run(pre_dir)
+            log.run(self.pre_dir)
 
         if self.log_packages:
-            self._log_installed_packages(pre_dir)
+            self._log_installed_packages(self.pre_dir)
 
     def end_test_hook(self):
         """
         Logging hook called after a test finishes.
         """
-        post_dir = utils.path.init_dir(self.basedir, 'post')
         for log in self.end_test_loggables:
-            log.run(post_dir)
+            log.run(self.post_dir)
 
         if self.log_packages:
-            self._log_modified_packages(post_dir)
+            self._log_modified_packages(self.post_dir)
 
     def start_iteration_hook(self):
         """
         Logging hook called before a test iteration
         """
-        pre_dir = utils.path.init_dir(self.basedir, 'pre')
         for log in self.start_iteration_loggables:
-            log.run(pre_dir)
+            log.run(self.pre_dir)
 
     def end_iteration_hook(self, test, iteration=None):
         """
         Logging hook called after a test iteration
         """
-        post_dir = utils.path.init_dir(self.basedir, 'post')
         for log in self.end_iteration_loggables:
-            log.run(post_dir)
+            log.run(self.post_dir)
 
 
 def collect_sysinfo(args):
@@ -624,4 +622,5 @@ def collect_sysinfo(args):
 
     sysinfo_logger = SysInfo(basedir=basedir, log_packages=True)
     sysinfo_logger.start_job_hook()
+    sysinfo_logger.end_job_hook()
     log.info("Logged system information to %s", basedir)

--- a/avocado/sysinfo.py
+++ b/avocado/sysinfo.py
@@ -553,7 +553,10 @@ class SysInfo(object):
         Logging hook called whenever a job starts, and again after reboot.
         """
         for log in self.start_job_loggables:
-            log.run(self.pre_dir)
+            if isinstance(log, Daemon):  # log daemons in profile directory
+                log.run(self.profile_dir)
+            else:
+                log.run(self.pre_dir)
 
         if self.log_packages:
             self._log_installed_packages(self.pre_dir)

--- a/avocado/sysinfo.py
+++ b/avocado/sysinfo.py
@@ -407,6 +407,14 @@ class SysInfo(object):
                                                   'profile_daemons',
                                                   key_type='bool',
                                                   default=True)
+            daemons_list = settings.get_value('sysinfo.collect',
+                                              'profile_daemons_list',
+                                              key_type='str',
+                                              default='')
+            if daemons_list == '':
+                self.start_daemons = _DEFAULT_DAEMON_START_JOB
+            else:
+                self.start_daemons = [x for x in daemons_list.split(':') if x != '']
         else:
             self.log_daemons = log_daemons
 
@@ -450,7 +458,7 @@ class SysInfo(object):
 
     def _set_loggables(self):
         if self.log_daemons:
-            for cmd in _DEFAULT_DAEMON_START_JOB:
+            for cmd in self.start_daemons:
                 self.start_job_loggables.add(Daemon(cmd))
 
         for cmd in _DEFAULT_COMMANDS_START_JOB:

--- a/avocado/sysinfo.py
+++ b/avocado/sysinfo.py
@@ -375,7 +375,7 @@ class SysInfo(object):
     * end_job
     """
 
-    def __init__(self, basedir=None, log_packages=None):
+    def __init__(self, basedir=None, log_packages=None, log_daemons=None):
         """
         Set sysinfo loggables.
 
@@ -384,6 +384,9 @@ class SysInfo(object):
                              logging packages is a costly operation). If not
                              given explicitly, tries to look in the config
                              files, and if not found, defaults to False.
+        :param log_daemons: Wether to log daemons. If not given explicitly,
+                            tries to look in the config files, and if not found,
+                            defaults to True.
         """
         if basedir is None:
             basedir = utils.path.init_dir(os.getcwd(), 'sysinfo')
@@ -398,6 +401,14 @@ class SysInfo(object):
                                                    default=False)
         else:
             self.log_packages = log_packages
+
+        if log_daemons is None:
+            self.log_daemons = settings.get_value('sysinfo.collect',
+                                                  'profile_daemons',
+                                                  key_type='bool',
+                                                  default=True)
+        else:
+            self.log_daemons = log_daemons
 
         self.start_job_loggables = set()
         self.end_job_loggables = set()
@@ -438,8 +449,9 @@ class SysInfo(object):
         return syslog_watcher
 
     def _set_loggables(self):
-        for cmd in _DEFAULT_DAEMON_START_JOB:
-            self.start_job_loggables.add(Daemon(cmd))
+        if self.log_daemons:
+            for cmd in _DEFAULT_DAEMON_START_JOB:
+                self.start_job_loggables.add(Daemon(cmd))
 
         for cmd in _DEFAULT_COMMANDS_START_JOB:
             self.start_job_loggables.add(Command(cmd))

--- a/etc/avocado/avocado.conf
+++ b/etc/avocado/avocado.conf
@@ -6,3 +6,4 @@ logs_dir = ~/avocado/job-results
 
 [sysinfo.collect]
 installed_packages = False
+profile_daemons = True

--- a/etc/avocado/avocado.conf
+++ b/etc/avocado/avocado.conf
@@ -6,4 +6,5 @@ logs_dir = ~/avocado/job-results
 
 [sysinfo.collect]
 installed_packages = False
-profile_daemons = True
+profile_daemons = False
+profile_daemons_list = vmstat 1:journalctl -f

--- a/selftests/all/unit/avocado/sysinfo_unittest.py
+++ b/selftests/all/unit/avocado/sysinfo_unittest.py
@@ -62,8 +62,8 @@ class SysinfoTest(unittest.TestCase):
         sysinfo_logger = sysinfo.SysInfo(basedir=jobdir)
         sysinfo_logger.start_job_hook()
         self.assertTrue(os.path.isdir(jobdir))
-        self.assertEqual(len(os.listdir(jobdir)), 1,
-                         "Job does not have 'pre' dir")
+        self.assertEqual(len(os.listdir(jobdir)), 3,
+                         "Job does not have 'pre/post/profile' dirs")
         job_predir = os.path.join(jobdir, 'pre')
         self.assertTrue(os.path.isdir(job_predir))
         self.assertGreater(len(os.listdir(job_predir)), 0,
@@ -73,22 +73,24 @@ class SysinfoTest(unittest.TestCase):
         self.assertTrue(os.path.isdir(job_postdir))
         self.assertGreater(len(os.listdir(job_postdir)), 0,
                            "Job post dir is empty")
+        self.assertTrue(os.path.isdir(job_postdir))
+        job_profiledir = os.path.join(jobdir, 'profile')
 
     def test_logger_test_hooks(self):
         testdir = os.path.join(self.tmpdir, 'job', 'test1')
         sysinfo_logger = sysinfo.SysInfo(basedir=testdir)
         sysinfo_logger.start_test_hook()
         self.assertTrue(os.path.isdir(testdir))
-        self.assertEqual(len(os.listdir(testdir)), 1,
-                         "Test does not have 'pre' dir")
+        self.assertEqual(len(os.listdir(testdir)), 3,
+                         "Test does not have 'pre/post/profile' dirs")
         test_predir = os.path.join(testdir, 'pre')
         self.assertTrue(os.path.isdir(test_predir))
         # By default, there are no pre test files
         self.assertEqual(len(os.listdir(test_predir)), 0,
                          "Test pre dir is not empty")
         sysinfo_logger.end_test_hook()
-        self.assertEqual(len(os.listdir(testdir)), 2,
-                         "Test does not have 'pre' dir")
+        self.assertEqual(len(os.listdir(testdir)), 3,
+                         "Test does not have 'pre/post/profile' dirs")
         job_postdir = os.path.join(testdir, 'post')
         self.assertTrue(os.path.isdir(job_postdir))
         # By default, there are no post test files


### PR DESCRIPTION
Follow up of PR #347.

---

Changes:
* Profile daemon logs goes inside `profile` directory. So for every sysinfo invocation, there will be `pre`, `post` and `profile` directories.
* Allows to enable or disable the profile daemons in Avocado configuration.
* Update selftests regarding this changes.
* Fix htmlresult plugin problem detected on test `test_output_incompatible_setup_3` when sysinfo profile daemons are started and then left running, after plugin exits with code 2.
* Read configuration value `profile_daemons_list` to get the list of command line options for profile daemons
* Don't run profile daemons by default.