### PR TITLE
avocado.plugins.remote: Unify test locations and use absolute path [v0]

### DIFF
--- a/avocado/plugins/remote.py
+++ b/avocado/plugins/remote.py
@@ -18,7 +18,6 @@ import os
 import getpass
 import json
 
-from avocado.core import exceptions
 from avocado.core import status
 from avocado.core import data_dir
 from avocado.runner import TestRunner
@@ -107,6 +106,7 @@ class RemoteTestResult(TestResult):
         self.test_dir = os.getcwd()
         self.remote_test_dir = '~/avocado/tests'
         self.output = '-'
+        self.urls = self.args.url
 
     def _copy_tests(self):
         self.remote.makedir(self.remote_test_dir)
@@ -120,12 +120,6 @@ class RemoteTestResult(TestResult):
             self.remote.send_files(test_path, self.remote_test_dir)
 
     def setup(self):
-        self.urls = self.args.url
-        if self.args.remote_hostname is None:
-            e_msg = ('Please set remote machine hostname with option '
-                     '--remote-hostname.')
-            self.stream.notify(event='error', msg=e_msg)
-            raise exceptions.TestSetupFail(e_msg)
         self.stream.notify(event='message', msg="REMOTE LOGIN  : %s@%s:%d" % (self.args.remote_username,
                                                                               self.args.remote_hostname,
                                                                               self.args.remote_port))
@@ -279,10 +273,32 @@ class RunRemote(plugin.Plugin):
                                         help='Specify the password to login on remote machine')
         self.configured = True
 
+    @staticmethod
+    def _check_required_args(app_args, enable_arg, required_args):
+        """
+        :return: True when enable_arg enabled and all required args are set
+        :raise sys.exit: When missing required argument.
+        """
+        if not getattr(app_args, enable_arg):
+            return False
+        missing = []
+        for arg in required_args:
+            if not getattr(app_args, arg):
+                missing.append(arg)
+        if missing:
+            from avocado.core import output, exit_codes
+            import sys
+            view = output.View(app_args=app_args, use_paginator=True)
+            e_msg = ('Use of %s requires %s arguments to be set. Please set %s'
+                     '.' % (enable_arg, ', '.join(required_args),
+                            ', '.join(missing)))
+
+            view.notify(event='error', msg=e_msg)
+            return sys.exit(exit_codes.AVOCADO_FAIL)
+        return True
+
     def activate(self, app_args):
-        try:
-            if app_args.remote_hostname is not None:
-                self.remote_parser.set_defaults(remote_result=RemoteTestResult,
-                                                test_runner=RemoteTestRunner)
-        except AttributeError:
-            pass
+        if self._check_required_args(app_args, 'remote_hostname',
+                                     ('remote_hostname',)):
+            self.remote_parser.set_defaults(remote_result=RemoteTestResult,
+                                            test_runner=RemoteTestRunner)

--- a/avocado/plugins/remote.py
+++ b/avocado/plugins/remote.py
@@ -38,7 +38,6 @@ class RemoteTestRunner(TestRunner):
         :param urls: a string with test URLs.
         :return: a dictionary with test results.
         """
-        urls = urls.split()
         avocado_cmd = ('cd %s; avocado run --force-job-id %s --json - --archive %s' %
                        (self.remote_test_dir, self.result.stream.job_unique_id, " ".join(urls)))
         result = self.result.remote.run(avocado_cmd, ignore_status=True)
@@ -52,7 +51,7 @@ class RemoteTestRunner(TestRunner):
         raise ValueError("Can't parse json out of remote's avocado output:"
                          "\n%s" % result.stdout)
 
-    def run_suite(self, params_list):
+    def run_suite(self, test_suite):
         """
         Run one or more tests and report with test result.
 
@@ -61,10 +60,8 @@ class RemoteTestRunner(TestRunner):
         :return: a list of test failures.
         """
         failures = []
-        urls = [x['id'] for x in params_list]
-        self.result.urls = urls
         self.result.setup()
-        results = self.run_test(' '.join(urls))
+        results = self.run_test(self.result.urls)
         remote_log_dir = os.path.dirname(results['debuglog'])
         self.result.start_tests()
         for tst in results['tests']:
@@ -110,14 +107,23 @@ class RemoteTestResult(TestResult):
 
     def _copy_tests(self):
         self.remote.makedir(self.remote_test_dir)
-        uniq_urls = list(set(self.urls))
-        for url in uniq_urls:
-            parent_dir = url.split(os.path.sep)[0]
-            if os.path.isdir(parent_dir):
-                test_path = os.path.abspath(parent_dir)
-            else:
-                test_path = os.path.join(data_dir.get_test_dir(), "%s*" % url)
-            self.remote.send_files(test_path, self.remote_test_dir)
+        paths = set()
+        for i in xrange(len(self.urls)):
+            url = self.urls[i]
+            if not os.path.exists(url):     # use test_dir path + py
+                url = os.path.join(data_dir.get_test_dir(), '%s.py' % url)
+            url = os.path.abspath(url)  # always use abspath; avoid clashes
+            # modify url to remote_path + abspath
+            paths.add(os.path.dirname(url))
+            self.urls[i] = self.remote_test_dir + url
+        previous = ' NOT ABSOLUTE PATH'
+        for path in sorted(paths):
+            if os.path.commonprefix((path, previous)) == previous:
+                continue    # already copied
+            rpath = self.remote_test_dir + path
+            self.remote.makedir(rpath)
+            self.remote.send_files(path, os.path.dirname(rpath))
+            previous = path
 
     def setup(self):
         self.stream.notify(event='message', msg="REMOTE LOGIN  : %s@%s:%d" % (self.args.remote_username,

--- a/avocado/plugins/remote.py
+++ b/avocado/plugins/remote.py
@@ -21,7 +21,7 @@ import os
 from avocado.core import data_dir
 from avocado.core import status
 from avocado.plugins import plugin
-from avocado.result import TestResult
+from avocado.result import HumanTestResult
 from avocado.runner import TestRunner
 from avocado.test import RemoteTest
 from avocado.utils import archive
@@ -93,7 +93,7 @@ class RemoteTestRunner(TestRunner):
         return failures
 
 
-class RemoteTestResult(TestResult):
+class RemoteTestResult(HumanTestResult):
 
     """
     Remote Machine Test Result class.
@@ -106,7 +106,7 @@ class RemoteTestResult(TestResult):
         :param stream: an instance of :class:`avocado.core.output.View`.
         :param args: an instance of :class:`argparse.Namespace`.
         """
-        TestResult.__init__(self, stream, args)
+        HumanTestResult.__init__(self, stream, args)
         self.test_dir = os.getcwd()
         self.remote_test_dir = '~/avocado/tests'
         self.output = '-'
@@ -155,125 +155,6 @@ class RemoteTestResult(TestResult):
     def tear_down(self):
         """ Cleanup after test execution """
         pass
-
-    def start_tests(self):
-        """
-        Called once before any tests are executed.
-        """
-        TestResult.start_tests(self)
-        self.stream.notify(event='message',
-                           msg="JOB ID    : %s" % self.stream.job_unique_id)
-        self.stream.notify(event='message',
-                           msg="JOB LOG   : %s" % self.stream.logfile)
-        if self.args is not None:
-            if 'html_output' in self.args:
-                logdir = os.path.dirname(self.stream.logfile)
-                html_file = os.path.join(logdir, 'html', 'results.html')
-                self.stream.notify(event="message",
-                                   msg="JOB HTML  : %s" % html_file)
-        self.stream.notify(event='message',
-                           msg="TESTS     : %s" % self.tests_total)
-        self.stream.set_tests_info({'tests_total': self.tests_total})
-
-    def end_tests(self):
-        """
-        Called once after all tests are executed.
-        """
-        self.stream.notify(event='message',
-                           msg="PASS       : %d" % len(self.passed))
-        self.stream.notify(event='message',
-                           msg="ERROR      : %d" % len(self.errors))
-        self.stream.notify(event='message',
-                           msg="NOT FOUND  : %d" % len(self.not_found))
-        self.stream.notify(event='message',
-                           msg="NOT A TEST : %d" % len(self.not_a_test))
-        self.stream.notify(event='message',
-                           msg="FAIL       : %d" % len(self.failed))
-        self.stream.notify(event='message',
-                           msg="SKIP       : %d" % len(self.skipped))
-        self.stream.notify(event='message',
-                           msg="WARN       : %d" % len(self.warned))
-        self.stream.notify(event='message',
-                           msg="TIME       : %.2f s" % self.total_time)
-
-    def start_test(self, test):
-        """
-        Called when the given test is about to run.
-
-        :param test: :class:`avocado.test.Test` instance.
-        """
-        self.stream.add_test(test)
-
-    def end_test(self, test):
-        """
-        Called when the given test has been run.
-
-        :param test: :class:`avocado.test.Test` instance.
-        """
-        TestResult.end_test(self, test)
-
-    def add_pass(self, test):
-        """
-        Called when a test succeeded.
-
-        :param test: :class:`avocado.test.Test` instance.
-        """
-        TestResult.add_pass(self, test)
-        self.stream.set_test_status(status='PASS', state=test)
-
-    def add_error(self, test):
-        """
-        Called when a test had a setup error.
-
-        :param test: :class:`avocado.test.Test` instance.
-        """
-        TestResult.add_error(self, test)
-        self.stream.set_test_status(status='ERROR', state=test)
-
-    def add_not_found(self, test):
-        """
-        Called when a test path was not found.
-
-        :param test: :class:`avocado.test.Test` instance.
-        """
-        TestResult.add_not_found(self, test)
-        self.stream.set_test_status(status='NOT_FOUND', state=test)
-
-    def add_not_a_test(self, test):
-        """
-        Called when a file is not an avocado test.
-
-        :param test: :class:`avocado.test.Test` instance.
-        """
-        TestResult.add_not_a_test(self, test)
-        self.stream.set_test_status(status='NOT_A_TEST', state=test)
-
-    def add_fail(self, test):
-        """
-        Called when a test fails.
-
-        :param test: :class:`avocado.test.Test` instance.
-        """
-        TestResult.add_fail(self, test)
-        self.stream.set_test_status(status='FAIL', state=test)
-
-    def add_skip(self, test):
-        """
-        Called when a test is skipped.
-
-        :param test: :class:`avocado.test.Test` instance.
-        """
-        TestResult.add_skip(self, test)
-        self.stream.set_test_status(status='SKIP', state=test)
-
-    def add_warn(self, test):
-        """
-        Called when a test had a warning.
-
-        :param test: :class:`avocado.test.Test` instance.
-        """
-        TestResult.add_warn(self, test)
-        self.stream.set_test_status(status='WARN', state=test)
 
 
 class RunRemote(plugin.Plugin):

--- a/avocado/plugins/remote.py
+++ b/avocado/plugins/remote.py
@@ -122,7 +122,7 @@ class RemoteTestResult(TestResult):
                 continue    # already copied
             rpath = self.remote_test_dir + path
             self.remote.makedir(rpath)
-            self.remote.send_files(path, os.path.dirname(rpath))
+            self.remote.rsync(path, os.path.dirname(rpath))
             previous = path
 
     def setup(self):

--- a/avocado/plugins/remote.py
+++ b/avocado/plugins/remote.py
@@ -14,32 +14,37 @@
 
 """Run tests on a remote machine."""
 
-import os
 import getpass
 import json
+import os
 
-from avocado.core import status
 from avocado.core import data_dir
-from avocado.runner import TestRunner
-from avocado.result import TestResult
+from avocado.core import status
 from avocado.plugins import plugin
-from avocado.utils import remote
-from avocado.utils import archive
+from avocado.result import TestResult
+from avocado.runner import TestRunner
 from avocado.test import RemoteTest
+from avocado.utils import archive
+from avocado.utils import remote
 
 
 class RemoteTestRunner(TestRunner):
+
+    """ Tooled TestRunner to run on remote machine using ssh """
     remote_test_dir = '~/avocado/tests'
 
-    def run_test(self, urls):
+    def run_test(self, urls, queue=False):
         """
         Run tests.
 
         :param urls: a string with test URLs.
         :return: a dictionary with test results.
         """
-        avocado_cmd = ('cd %s; avocado run --force-job-id %s --json - --archive %s' %
-                       (self.remote_test_dir, self.result.stream.job_unique_id, " ".join(urls)))
+        del queue   # Remote execution is not using queue
+        avocado_cmd = ('cd %s; avocado run --force-job-id %s --json - '
+                       '--archive %s' % (self.remote_test_dir,
+                                         self.result.stream.job_unique_id,
+                                         " ".join(urls)))
         result = self.result.remote.run(avocado_cmd, ignore_status=True)
         for json_output in result.stdout.splitlines():
             # We expect dictionary:
@@ -59,6 +64,7 @@ class RemoteTestRunner(TestRunner):
 
         :return: a list of test failures.
         """
+        del test_suite     # using self.result.urls instead
         failures = []
         self.result.setup()
         results = self.run_test(self.result.urls)
@@ -77,7 +83,8 @@ class RemoteTestRunner(TestRunner):
                 failures.append(state['tagged_name'])
         local_log_dir = os.path.dirname(self.result.stream.debuglog)
         zip_filename = remote_log_dir + '.zip'
-        zip_path_filename = os.path.join(local_log_dir, os.path.basename(zip_filename))
+        zip_path_filename = os.path.join(local_log_dir,
+                                         os.path.basename(zip_filename))
         self.result.remote.receive_files(local_log_dir, zip_filename)
         archive.uncompress(zip_path_filename, local_log_dir)
         os.remove(zip_path_filename)
@@ -104,8 +111,14 @@ class RemoteTestResult(TestResult):
         self.remote_test_dir = '~/avocado/tests'
         self.output = '-'
         self.urls = self.args.url
+        self.remote = None      # Remote runner initialized during setup
 
     def _copy_tests(self):
+        """
+        Gather test's directories and copy them recursively to
+        $remote_test_dir + $test_absolute_path.
+        :note: Default tests execution is translated into absolute paths too
+        """
         self.remote.makedir(self.remote_test_dir)
         paths = set()
         for i in xrange(len(self.urls)):
@@ -126,9 +139,12 @@ class RemoteTestResult(TestResult):
             previous = path
 
     def setup(self):
-        self.stream.notify(event='message', msg="REMOTE LOGIN  : %s@%s:%d" % (self.args.remote_username,
-                                                                              self.args.remote_hostname,
-                                                                              self.args.remote_port))
+        """ Setup remote environment and copy test's directories """
+        self.stream.notify(event='message',
+                           msg=("REMOTE LOGIN  : %s@%s:%d"
+                                % (self.args.remote_username,
+                                   self.args.remote_hostname,
+                                   self.args.remote_port)))
         self.remote = remote.Remote(self.args.remote_hostname,
                                     self.args.remote_username,
                                     self.args.remote_password,
@@ -137,6 +153,7 @@ class RemoteTestResult(TestResult):
         self._copy_tests()
 
     def tear_down(self):
+        """ Cleanup after test execution """
         pass
 
     def start_tests(self):
@@ -144,28 +161,40 @@ class RemoteTestResult(TestResult):
         Called once before any tests are executed.
         """
         TestResult.start_tests(self)
-        self.stream.notify(event='message', msg="JOB ID    : %s" % self.stream.job_unique_id)
-        self.stream.notify(event='message', msg="JOB LOG   : %s" % self.stream.logfile)
+        self.stream.notify(event='message',
+                           msg="JOB ID    : %s" % self.stream.job_unique_id)
+        self.stream.notify(event='message',
+                           msg="JOB LOG   : %s" % self.stream.logfile)
         if self.args is not None:
             if 'html_output' in self.args:
                 logdir = os.path.dirname(self.stream.logfile)
                 html_file = os.path.join(logdir, 'html', 'results.html')
-                self.stream.notify(event="message", msg="JOB HTML  : %s" % html_file)
-        self.stream.notify(event='message', msg="TESTS     : %s" % self.tests_total)
+                self.stream.notify(event="message",
+                                   msg="JOB HTML  : %s" % html_file)
+        self.stream.notify(event='message',
+                           msg="TESTS     : %s" % self.tests_total)
         self.stream.set_tests_info({'tests_total': self.tests_total})
 
     def end_tests(self):
         """
         Called once after all tests are executed.
         """
-        self.stream.notify(event='message', msg="PASS       : %d" % len(self.passed))
-        self.stream.notify(event='message', msg="ERROR      : %d" % len(self.errors))
-        self.stream.notify(event='message', msg="NOT FOUND  : %d" % len(self.not_found))
-        self.stream.notify(event='message', msg="NOT A TEST : %d" % len(self.not_a_test))
-        self.stream.notify(event='message', msg="FAIL       : %d" % len(self.failed))
-        self.stream.notify(event='message', msg="SKIP       : %d" % len(self.skipped))
-        self.stream.notify(event='message', msg="WARN       : %d" % len(self.warned))
-        self.stream.notify(event='message', msg="TIME       : %.2f s" % self.total_time)
+        self.stream.notify(event='message',
+                           msg="PASS       : %d" % len(self.passed))
+        self.stream.notify(event='message',
+                           msg="ERROR      : %d" % len(self.errors))
+        self.stream.notify(event='message',
+                           msg="NOT FOUND  : %d" % len(self.not_found))
+        self.stream.notify(event='message',
+                           msg="NOT A TEST : %d" % len(self.not_a_test))
+        self.stream.notify(event='message',
+                           msg="FAIL       : %d" % len(self.failed))
+        self.stream.notify(event='message',
+                           msg="SKIP       : %d" % len(self.skipped))
+        self.stream.notify(event='message',
+                           msg="WARN       : %d" % len(self.warned))
+        self.stream.notify(event='message',
+                           msg="TIME       : %.2f s" % self.total_time)
 
     def start_test(self, test):
         """
@@ -255,28 +284,33 @@ class RunRemote(plugin.Plugin):
 
     name = 'run_remote'
     enabled = True
+    remote_parser = None
 
     def configure(self, parser):
-        if remote.remote_capable is False:
+        if remote.REMOTE_CAPABLE is False:
             self.enabled = False
             return
         username = getpass.getuser()
-        self.remote_parser = parser.runner.add_argument_group('run on a remote machine '
-                                                              'arguments')
-        self.remote_parser.add_argument('--remote-hostname', dest='remote_hostname',
-                                        default=None,
-                                        help='Specify the hostname to login on remote machine')
+        msg = 'run on a remote machine arguments'
+        self.remote_parser = parser.runner.add_argument_group(msg)
+        self.remote_parser.add_argument('--remote-hostname',
+                                        dest='remote_hostname', default=None,
+                                        help='Specify the hostname to login on'
+                                        ' remote machine')
         self.remote_parser.add_argument('--remote-port', dest='remote_port',
-                                        default=22, type=int,
-                                        help='Specify the port number to login on remote machine. '
-                                             'Current: 22')
-        self.remote_parser.add_argument('--remote-username', dest='remote_username',
+                                        default=22, type=int, help='Specify '
+                                        'the port number to login on remote '
+                                        'machine. Current: 22')
+        self.remote_parser.add_argument('--remote-username',
+                                        dest='remote_username',
                                         default=username,
-                                        help=('Specify the username to login on remote machine. '
-                                              'Current: %(default)s'))
-        self.remote_parser.add_argument('--remote-password', dest='remote_password',
-                                        default=None,
-                                        help='Specify the password to login on remote machine')
+                                        help='Specify the username to login on'
+                                        ' remote machine. Current: '
+                                        '%(default)s')
+        self.remote_parser.add_argument('--remote-password',
+                                        dest='remote_password', default=None,
+                                        help='Specify the password to login on'
+                                        ' remote machine')
         self.configured = True
 
     @staticmethod

--- a/avocado/plugins/vm.py
+++ b/avocado/plugins/vm.py
@@ -14,114 +14,23 @@
 
 """Run tests on Virtual Machine."""
 
-import os
 import getpass
-import json
 
 from avocado.core import exceptions
-from avocado.core import status
-from avocado.core import data_dir
-from avocado.runner import TestRunner
-from avocado.result import TestResult
+from avocado.plugins.remote import RemoteTestRunner
+from avocado.plugins.remote import RemoteTestResult
 from avocado.plugins import plugin
 from avocado.utils import virt
-from avocado.utils import archive
-from avocado.test import RemoteTest
 
 
-class VMTestRunner(TestRunner):
-    remote_test_dir = '~/avocado/tests'
-
-    def run_test(self, urls):
-        """
-        Run tests.
-
-        :param urls: a string with test URLs.
-        :return: a dictionary with test results.
-        """
-        urls = urls.split()
-        avocado_cmd = ('cd %s; avocado run --force-job-id %s --json - --archive %s' %
-                       (self.remote_test_dir, self.result.stream.job_unique_id, " ".join(urls)))
-        result = self.result.vm.remote.run(avocado_cmd, ignore_status=True)
-        xunit_output = result.stdout.splitlines()[0]
-        try:
-            results = json.loads(xunit_output)
-        except Exception, details:
-            raise ValueError('Error loading JSON '
-                             '(full output below): %s\n"""\n%s\n"""' %
-                             (details, result.stdout))
-        return results
-
-    def run_suite(self, params_list):
-        """
-        Run one or more tests and report with test result.
-
-        :param params_list: a list of param dicts.
-
-        :return: a list of test failures.
-        """
-        failures = []
-        urls = [x['id'] for x in params_list]
-        self.result.urls = urls
-        self.result.setup()
-        results = self.run_test(' '.join(urls))
-        remote_log_dir = os.path.dirname(results['debuglog'])
-        self.result.start_tests()
-        for tst in results['tests']:
-            test = RemoteTest(name=tst['test'],
-                              time=tst['time'],
-                              start=tst['start'],
-                              end=tst['end'],
-                              status=tst['status'])
-            state = test.get_state()
-            self.result.start_test(state)
-            self.result.check_test(state)
-            if not status.mapping[state['status']]:
-                failures.append(state['tagged_name'])
-        local_log_dir = os.path.dirname(self.result.stream.debuglog)
-        zip_filename = remote_log_dir + '.zip'
-        zip_path_filename = os.path.join(local_log_dir, os.path.basename(zip_filename))
-        self.result.vm.remote.receive_files(local_log_dir, zip_filename)
-        archive.uncompress(zip_path_filename, local_log_dir)
-        os.remove(zip_path_filename)
-        self.result.end_tests()
-        self.result.tear_down()
-        return failures
-
-
-class VMTestResult(TestResult):
+class VMTestResult(RemoteTestResult):
 
     """
     Virtual Machine Test Result class.
     """
 
-    command_line_arg_name = '--vm'
-
-    def __init__(self, stream, args):
-        """
-        Creates an instance of VMTestResult.
-
-        :param stream: an instance of :class:`avocado.core.output.View`.
-        :param args: an instance of :class:`argparse.Namespace`.
-        """
-        TestResult.__init__(self, stream, args)
-        self.test_dir = os.getcwd()
-        self.remote_test_dir = '~/avocado/tests'
-        self.output = '-'
-
-    def _copy_tests(self):
-        self.vm.remote.makedir(self.remote_test_dir)
-        uniq_urls = list(set(self.urls))
-        for url in uniq_urls:
-            parent_dir = url.split(os.path.sep)[0]
-            if os.path.isdir(parent_dir):
-                test_path = os.path.abspath(parent_dir)
-            else:
-                test_path = os.path.join(data_dir.get_test_dir(), "%s*" % url)
-            self.vm.remote.send_files(test_path, self.remote_test_dir)
-
     def setup(self):
-        self.urls = self.args.url
+        # Super called after VM is found and initialized
         if self.args.vm_domain is None:
             e_msg = ('Please set Virtual Machine Domain with option '
                      '--vm-domain.')
@@ -133,7 +42,6 @@ class VMTestResult(TestResult):
             self.stream.notify(event='error', msg=e_msg)
             raise exceptions.TestSetupFail(e_msg)
         self.stream.notify(event='message', msg="VM DOMAIN : %s" % self.args.vm_domain)
-        self.stream.notify(event='message', msg="VM LOGIN  : %s@%s" % (self.args.vm_username, self.args.vm_hostname))
         self.vm = virt.vm_connect(self.args.vm_domain,
                                   self.args.vm_hypervisor_uri)
         if self.vm is None:
@@ -149,129 +57,19 @@ class VMTestResult(TestResult):
                 self.stream.notify(event='error', msg="Could not create snapshot on VM '%s'" % self.args.vm_domain)
                 raise exceptions.TestSetupFail()
         try:
-            self.vm.setup_login(self.args.vm_hostname,
-                                self.args.vm_username,
-                                self.args.vm_password)
-        except Exception as err:
-            self.stream.notify(event='error', msg="Could not login on VM '%s': %s" % (self.args.vm_hostname, err))
+            # Finish remote setup and copy the tests
+            self.args.remote_hostname = self.args.vm_hostname
+            self.args.remote_username = self.args.vm_username
+            self.args.remote_password = self.args.vm_password
+            super(VMTestResult, self).setup()
+        except Exception:
             self.tear_down()
-            raise exceptions.TestSetupFail()
-        if self.vm.logged is False or self.vm.remote.uptime() is '':
-            self.stream.notify(event='error', msg="Could not login on VM '%s'" % self.args.vm_hostname)
-            self.tear_down()
-            raise exceptions.TestSetupFail()
-        self._copy_tests()
+            raise
 
     def tear_down(self):
+        super(VMTestResult, self).tear_down()
         if self.args.vm_cleanup is True and self.vm.snapshot is not None:
             self.vm.restore_snapshot()
-
-    def start_tests(self):
-        """
-        Called once before any tests are executed.
-        """
-        TestResult.start_tests(self)
-        self.stream.notify(event='message', msg="JOB ID    : %s" % self.stream.job_unique_id)
-        self.stream.notify(event='message', msg="JOB LOG   : %s" % self.stream.logfile)
-        if self.args is not None:
-            if 'html_output' in self.args:
-                logdir = os.path.dirname(self.stream.logfile)
-                html_file = os.path.join(logdir, 'html', 'results.html')
-                self.stream.notify(event="message", msg="JOB HTML  : %s" % html_file)
-        self.stream.notify(event='message', msg="TESTS     : %s" % self.tests_total)
-        self.stream.set_tests_info({'tests_total': self.tests_total})
-
-    def end_tests(self):
-        """
-        Called once after all tests are executed.
-        """
-        self.stream.notify(event='message', msg="PASS       : %d" % len(self.passed))
-        self.stream.notify(event='message', msg="ERROR      : %d" % len(self.errors))
-        self.stream.notify(event='message', msg="NOT FOUND  : %d" % len(self.not_found))
-        self.stream.notify(event='message', msg="NOT A TEST : %d" % len(self.not_a_test))
-        self.stream.notify(event='message', msg="FAIL       : %d" % len(self.failed))
-        self.stream.notify(event='message', msg="SKIP       : %d" % len(self.skipped))
-        self.stream.notify(event='message', msg="WARN       : %d" % len(self.warned))
-        self.stream.notify(event='message', msg="TIME       : %.2f s" % self.total_time)
-
-    def start_test(self, test):
-        """
-        Called when the given test is about to run.
-
-        :param test: :class:`avocado.test.Test` instance.
-        """
-        self.stream.add_test(test)
-
-    def end_test(self, test):
-        """
-        Called when the given test has been run.
-
-        :param test: :class:`avocado.test.Test` instance.
-        """
-        TestResult.end_test(self, test)
-
-    def add_pass(self, test):
-        """
-        Called when a test succeeded.
-
-        :param test: :class:`avocado.test.Test` instance.
-        """
-        TestResult.add_pass(self, test)
-        self.stream.set_test_status(status='PASS', state=test)
-
-    def add_error(self, test):
-        """
-        Called when a test had a setup error.
-
-        :param test: :class:`avocado.test.Test` instance.
-        """
-        TestResult.add_error(self, test)
-        self.stream.set_test_status(status='ERROR', state=test)
-
-    def add_not_found(self, test):
-        """
-        Called when a test path was not found.
-
-        :param test: :class:`avocado.test.Test` instance.
-        """
-        TestResult.add_not_found(self, test)
-        self.stream.set_test_status(status='NOT_FOUND', state=test)
-
-    def add_not_a_test(self, test):
-        """
-        Called when a file is not an avocado test.
-
-        :param test: :class:`avocado.test.Test` instance.
-        """
-        TestResult.add_not_a_test(self, test)
-        self.stream.set_test_status(status='NOT_A_TEST', state=test)
-
-    def add_fail(self, test):
-        """
-        Called when a test fails.
-
-        :param test: :class:`avocado.test.Test` instance.
-        """
-        TestResult.add_fail(self, test)
-        self.stream.set_test_status(status='FAIL', state=test)
-
-    def add_skip(self, test):
-        """
-        Called when a test is skipped.
-
-        :param test: :class:`avocado.test.Test` instance.
-        """
-        TestResult.add_skip(self, test)
-        self.stream.set_test_status(status='SKIP', state=test)
-
-    def add_warn(self, test):
-        """
-        Called when a test had a warning.
-
-        :param test: :class:`avocado.test.Test` instance.
-        """
-        TestResult.add_warn(self, test)
-        self.stream.set_test_status(status='WARN', state=test)
 
 
 class RunVM(plugin.Plugin):
@@ -292,17 +90,14 @@ class RunVM(plugin.Plugin):
         self.vm_parser = parser.runner.add_argument_group('run on a libvirt domain '
                                                           'arguments')
 
-        self.vm_parser.add_argument('--vm', action='store_true', default=False,
-                                    help=('Run tests on a Virtual Machine '
-                                          '(Libvirt Domain)'))
+        self.vm_parser.add_argument('--vm-domain', dest='vm_domain',
+                                    help=('Specify Libvirt Domain Name'))
         self.vm_parser.add_argument('--vm-hypervisor-uri',
                                     dest='vm_hypervisor_uri',
                                     default=default_hypervisor_uri,
                                     help=('Specify hypervisor URI driver '
                                           'connection. Current: %s' %
                                           default_hypervisor_uri))
-        self.vm_parser.add_argument('--vm-domain', dest='vm_domain',
-                                    help=('Specify Libvirt Domain Name'))
         self.vm_parser.add_argument('--vm-hostname', dest='vm_hostname',
                                     help='Specify VM hostname to login')
         self.vm_parser.add_argument('--vm-username', dest='vm_username',
@@ -318,10 +113,32 @@ class RunVM(plugin.Plugin):
                                           'running tests'))
         self.configured = True
 
+    @staticmethod
+    def _check_required_args(app_args, enable_arg, required_args):
+        """
+        :return: True when enable_arg enabled and all required args are set
+        :raise sys.exit: When missing required argument.
+        """
+        if not getattr(app_args, enable_arg):
+            return False
+        missing = []
+        for arg in required_args:
+            if not getattr(app_args, arg):
+                missing.append(arg)
+        if missing:
+            from avocado.core import output, exit_codes
+            import sys
+            view = output.View(app_args=app_args, use_paginator=True)
+            e_msg = ('Use of %s requires %s arguments to be set. Please set %s'
+                     '.' % (enable_arg, ', '.join(required_args),
+                            ', '.join(missing)))
+
+            view.notify(event='error', msg=e_msg)
+            return sys.exit(exit_codes.AVOCADO_FAIL)
+        return True
+
     def activate(self, app_args):
-        try:
-            if app_args.vm:
-                self.vm_parser.set_defaults(vm_result=VMTestResult,
-                                            test_runner=VMTestRunner)
-        except AttributeError:
-            pass
+        if self._check_required_args(app_args, 'vm_domain',
+                                     ('vm_domain', 'vm_hostname')):
+            self.vm_parser.set_defaults(remote_result=VMTestResult,
+                                        test_runner=RemoteTestRunner)

--- a/avocado/plugins/vm.py
+++ b/avocado/plugins/vm.py
@@ -29,6 +29,10 @@ class VMTestResult(RemoteTestResult):
     Virtual Machine Test Result class.
     """
 
+    def __init__(self, stream, args):
+        super(VMTestResult, self).__init__(stream, args)
+        self.vm = None
+
     def setup(self):
         # Super called after VM is found and initialized
         if self.args.vm_domain is None:

--- a/avocado/plugins/vm.py
+++ b/avocado/plugins/vm.py
@@ -17,9 +17,9 @@
 import getpass
 
 from avocado.core import exceptions
-from avocado.plugins.remote import RemoteTestRunner
-from avocado.plugins.remote import RemoteTestResult
 from avocado.plugins import plugin
+from avocado.plugins.remote import RemoteTestResult
+from avocado.plugins.remote import RemoteTestRunner
 from avocado.utils import virt
 
 
@@ -45,20 +45,25 @@ class VMTestResult(RemoteTestResult):
                      '--vm-hostname.')
             self.stream.notify(event='error', msg=e_msg)
             raise exceptions.TestSetupFail(e_msg)
-        self.stream.notify(event='message', msg="VM DOMAIN : %s" % self.args.vm_domain)
+        self.stream.notify(event='message', msg="VM DOMAIN : %s"
+                           % self.args.vm_domain)
         self.vm = virt.vm_connect(self.args.vm_domain,
                                   self.args.vm_hypervisor_uri)
         if self.vm is None:
-            self.stream.notify(event='error', msg="Could not connect to VM '%s'" % self.args.vm_domain)
+            self.stream.notify(event='error',
+                               msg="Could not connect to VM '%s'"
+                               % self.args.vm_domain)
             raise exceptions.TestSetupFail()
         if self.vm.start() is False:
-            self.stream.notify(event='error', msg="Could not start VM '%s'" % self.args.vm_domain)
+            self.stream.notify(event='error', msg="Could not start VM '%s'"
+                               % self.args.vm_domain)
             raise exceptions.TestSetupFail()
         assert self.vm.domain.isActive() is not False
         if self.args.vm_cleanup is True:
             self.vm.create_snapshot()
             if self.vm.snapshot is None:
-                self.stream.notify(event='error', msg="Could not create snapshot on VM '%s'" % self.args.vm_domain)
+                self.stream.notify(event='error', msg="Could not create "
+                                   "snapshot on VM '%s'" % self.args.vm_domain)
                 raise exceptions.TestSetupFail()
         try:
             # Finish remote setup and copy the tests
@@ -84,15 +89,16 @@ class RunVM(plugin.Plugin):
 
     name = 'run_vm'
     enabled = True
+    vm_parser = None
 
     def configure(self, parser):
-        if virt.virt_capable is False:
+        if virt.VIRT_CAPABLE is False:
             self.enabled = False
             return
         username = getpass.getuser()
         default_hypervisor_uri = 'qemu:///system'
-        self.vm_parser = parser.runner.add_argument_group('run on a libvirt domain '
-                                                          'arguments')
+        self.vm_parser = parser.runner.add_argument_group('run on a libvirt '
+                                                          'domain arguments')
 
         self.vm_parser.add_argument('--vm-domain', dest='vm_domain',
                                     help=('Specify Libvirt Domain Name'))
@@ -113,8 +119,8 @@ class RunVM(plugin.Plugin):
         self.vm_parser.add_argument('--vm-cleanup', dest='vm_cleanup',
                                     action='store_true',
                                     default=False,
-                                    help=('Restore VM to a previous state, before '
-                                          'running tests'))
+                                    help='Restore VM to a previous state, '
+                                    'before running tests')
         self.configured = True
 
     @staticmethod

--- a/avocado/utils/remote.py
+++ b/avocado/utils/remote.py
@@ -18,25 +18,25 @@ Module to provide remote operations.
 
 import getpass
 import logging
-import time
-import tempfile
 import os
+import tempfile
+import time
 
-log = logging.getLogger('avocado.test')
+from avocado.core import exceptions
+from avocado.core import output
+from avocado.utils import process
+
+LOG = logging.getLogger('avocado.test')
 
 try:
     import fabric.api
     import fabric.operations
     from fabric.contrib.project import rsync_project
 except ImportError:
-    remote_capable = False
-    log.info('Remote module is disabled: could not import fabric')
+    REMOTE_CAPABLE = False
+    LOG.info('Remote module is disabled: could not import fabric')
 else:
-    remote_capable = True
-
-from avocado.core import output
-from avocado.core import exceptions
-from avocado.utils import process
+    REMOTE_CAPABLE = True
 
 
 class Remote(object):
@@ -73,7 +73,9 @@ class Remote(object):
                                 connection_attempts=attempts,
                                 linewise=True)
 
-    def _setup_environment(self, **kwargs):
+    @staticmethod
+    def _setup_environment(**kwargs):
+        """ Setup fabric environemnt """
         fabric.api.env.update(kwargs)
 
     def run(self, command, ignore_status=False):
@@ -86,7 +88,7 @@ class Remote(object):
         :rtype: :class:`avocado.utils.process.CmdResult`.
         """
         if not self.quiet:
-            log.info('[%s] Running command %s', self.hostname, command)
+            LOG.info('[%s] Running command %s', self.hostname, command)
         result = process.CmdResult()
         stdout = output.LoggingFile(logger=logging.getLogger('avocado.test'))
         stderr = output.LoggingFile(logger=logging.getLogger('avocado.test'))
@@ -138,7 +140,7 @@ class Remote(object):
         :param remote_path: the remote path.
         """
         if not self.quiet:
-            log.info('[%s] Sending files %s -> %s', self.hostname,
+            LOG.info('[%s] Sending files %s -> %s', self.hostname,
                      local_path, remote_path)
         with fabric.context_managers.quiet():
             try:
@@ -156,7 +158,7 @@ class Remote(object):
         :param remote_path: the remote path.
         """
         if not self.quiet:
-            log.info('[%s] rsync-ing files %s -> %s', self.hostname,
+            LOG.info('[%s] rsync-ing files %s -> %s', self.hostname,
                      local_path, remote_path)
         with fabric.context_managers.quiet():
             try:
@@ -182,7 +184,7 @@ class Remote(object):
         :param remote_path: the remote path.
         """
         if not self.quiet:
-            log.info('[%s] Receive remote files %s -> %s', self.hostname,
+            LOG.info('[%s] Receive remote files %s -> %s', self.hostname,
                      local_path, remote_path)
         with fabric.context_managers.quiet():
             try:

--- a/avocado/utils/virt.py
+++ b/avocado/utils/virt.py
@@ -17,23 +17,23 @@ Module to provide classes for Virtual Machines.
 """
 
 import logging
+from xml.dom import minidom
 
-log = logging.getLogger('avocado.test')
+from avocado.utils import remote
+LOG = logging.getLogger('avocado.test')
 
 try:
     import libvirt
 except ImportError:
-    virt_capable = False
-    log.info('Virt module is disabled: could not import libvirt')
+    VIRT_CAPABLE = False
+    LOG.info('Virt module is disabled: could not import libvirt')
 else:
-    virt_capable = True
+    VIRT_CAPABLE = True
 
-from xml.dom import minidom
-from avocado.utils import remote
 
-if remote.remote_capable is False:
-    virt_capable = False
-    log.info('Virt module is disabled: remote module is disabled')
+if remote.REMOTE_CAPABLE is False:
+    VIRT_CAPABLE = False
+    LOG.info('Virt module is disabled: remote module is disabled')
 
 
 class Hypervisor(object):

--- a/selftests/all/unit/avocado/remote_unittest.py
+++ b/selftests/all/unit/avocado/remote_unittest.py
@@ -1,76 +1,202 @@
 #!/usr/bin/env python
 
 import unittest
-import os
-import sys
-import json
-import argparse
 
 # simple magic for using scripts within a source tree
-basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-basedir = os.path.dirname(basedir)
-if os.path.isdir(os.path.join(basedir, 'avocado')):
-    sys.path.append(basedir)
-
-from avocado.core import status
-from avocado.core import job_id
 from avocado.plugins import remote
 
 
-class _Stream(object):
-    job_unique_id = job_id.create_unique_job_id()
-
-    def start_file_logging(self, param1, param2):
-        pass
-
-    def stop_file_logging(self):
-        pass
-
-    def set_tests_info(self, info):
-        pass
-
-    def notify(self, event, msg):
-        pass
-
-    def add_test(self, state):
-        pass
-
-    def set_test_status(self, status, state):
-        pass
+def mock_function(name, executed, ret=None):
+    """
+    Creates function which logs itself into executed and returns ret value
+    """
+    def new_fction(*args, **kwargs):
+        """ Logs itself and return expected return """
+        executed.append("%s %s %s" % (name, args, kwargs))
+        return ret
+    return new_fction
 
 
-class RemoteResultTest(unittest.TestCase):
+def mock(originals, func, log, ret=None):   # UsedByEval pylint: disable=W0613
+    """
+    Ugly way to override existing functions from other modules:
+    :param originals: Dictionary with original functions
+    :param func: Name of the function you wan't to mock
+    :param log: In which log this function should append itself when executed
+    :param ret: Return value of new function
+    """
+    originals[func] = eval(func)    # pylint: disable=W0123
+    exec("%s = mock_function(func, log, ret)" % func)  # pylint: disable=W0122
+
+
+def unmock_all(originals):
+    """
+    Ugly way to restore original functions.
+    :param originals: Dict of original names and functions.
+    """
+    for name in originals.iterkeys():
+        exec("%s = originals[name]" % name)  # pylint: disable=W0122
+
+
+class BetterObject(object):     # pylint: disable=R0903
+
+    """ Original 'object' doesn't allow setattr. This one does """
+    pass
+
+
+class Remote(object):   # pylint: disable=R0903
+
+    """ Fake remote class """
+
+    def __init__(self, log):
+        self.receive_files = mock_function('Remote.receive_files', log)
+        stdout = ('Something other than json\n'
+                  '{"tests": [{"test": "sleeptest.1", "url": "sleeptest", '
+                  '"status": "PASS", "time": 1.23, "start": 0, "end": 1.23}],'
+                  '"debuglog": "/home/user/avocado/logs/run-2014-05-26-15.45.'
+                  '37/debug.log", "errors": 0, "skip": 0, "time": 1.4, '
+                  '"start": 0, "end": 1.4, "pass": 1, "failures": 0, "total": '
+                  '1}\nAdditional stuff other than json')
+        result = BetterObject()
+        result.stdout = stdout
+        self.run = mock_function('Remote.run', log, result)
+        self.makedir = mock_function('Remote.makedir', log)
+        self.rsync = mock_function('Remote.rsync', log)
+
+
+class Results(object):  # pylint: disable=R0902,R0903
+
+    """ Fake results class """
+
+    def __init__(self, log):
+        self.remote = Remote(log)
+        self.setup = mock_function('Results.setup', log)
+        self.urls = ['sleeptest']
+        self.start_tests = mock_function('Results.start_tests', log)
+        self.stream = BetterObject()
+        self.stream.job_unique_id = 'sleeptest.1'
+        self.stream.debuglog = '/local/path'
+        self.start_test = mock_function('Results.start_test', log)
+        self.check_test = mock_function('Results.check_test', log)
+        self.end_tests = mock_function('Results.end_tests', log)
+        self.tear_down = mock_function('Results.tear_down', log)
+
+
+class RemoteTestRunnerTest(unittest.TestCase):
+
+    """ Tests RemoteTestRunner """
 
     def setUp(self):
-        args = argparse.Namespace()
-        stream = _Stream()
-        stream.logfile = 'debug.log'
-        self.test_result = remote.RemoteTestResult(stream, args)
-        j = '''{"tests": [{"test": "sleeptest.1", "url": "sleeptest", "status": "PASS",
-                "time": 1.23, "start": 0, "end": 1.23}],
-                "debuglog": "/home/user/avocado/logs/run-2014-05-26-15.45.37/debug.log",
-                "errors": 0, "skip": 0, "time": 1.4, "start": 0, "end": 1.4,
-                "pass": 1, "failures": 0, "total": 1}'''
-        self.results = json.loads(j)
+        self.log = []
+        self.__mock = {}
+        mock(self.__mock, 'remote.os.remove', self.log)
+        mock(self.__mock, 'remote.archive.uncompress', self.log)
+        remote.RemoteTestRunner.__init__ = lambda self: None
+        self.remote = remote.RemoteTestRunner()
+        self.remote.result = Results(self.log)
 
-    def test_check(self):
-        failures = []
-        self.test_result.start_tests()
-        for tst in self.results['tests']:
-            test = remote.RemoteTest(name=tst['test'],
-                                     time=tst['time'],
-                                     start=tst['start'],
-                                     end=tst['end'],
-                                     status=tst['status'])
-            self.test_result.start_test(test.get_state())
-            self.test_result.check_test(test.get_state())
-            if not status.mapping[test.status]:
-                failures.append(test.tagged_name)
-        self.test_result.end_tests()
-        self.assertEqual(self.test_result.tests_total, 1)
-        self.assertEqual(len(self.test_result.passed), 1)
-        self.assertEqual(len(self.test_result.failed), 0)
-        self.assertEqual(len(failures), 0)
+    def tearDown(self):
+        unmock_all(self.__mock)
+
+    def test_run_suite(self):
+        """ Test RemoteTestRunner.run_suite() """
+        self.remote.run_suite(None)
+        # FIXME: Why remote.archive.uncompress path is /local when /local/path
+        # is set?
+        exps = ["Results.setup () {}",
+                ("Remote.run ('cd ~/avocado/tests; avocado run --force-job-id "
+                 "sleeptest.1 --json - --archive sleeptest',) "
+                 "{'ignore_status': True}"),
+                "Results.start_tests () {}",
+                ("Results.start_test ({'status': u'PASS', 'whiteboard': '', "
+                 "'time_start': 0, 'name': u'sleeptest.1', 'class_name': "
+                 "'RemoteTest', 'traceback': 'Not supported yet', "
+                 "'text_output': 'Not supported yet', 'time_end': 1.23, "
+                 "'tagged_name': u'sleeptest.1', 'time_elapsed': 1.23, "
+                 "'fail_class': 'Not supported yet', 'job_unique_id': '', "
+                 "'fail_reason': 'Not supported yet'},) {}"),
+                ("Results.check_test ({'status': u'PASS', 'whiteboard': '', "
+                 "'time_start': 0, 'name': u'sleeptest.1', 'class_name': "
+                 "'RemoteTest', 'traceback': 'Not supported yet', "
+                 "'text_output': 'Not supported yet', 'time_end': 1.23, "
+                 "'tagged_name': u'sleeptest.1', 'time_elapsed': 1.23, "
+                 "'fail_class': 'Not supported yet', 'job_unique_id': '', "
+                 "'fail_reason': 'Not supported yet'},) {}"),
+                ("Remote.receive_files ('/local', u'/home/user/avocado/logs/"
+                 "run-2014-05-26-15.45.37.zip') {}"),
+                "Results.end_tests () {}",
+                "Results.tear_down () {}"]
+        iexps = iter(exps)
+        try:
+            exp = iexps.next()
+            for line in self.log:
+                if line == exp:
+                    exp = iexps.next()
+            self.assertTrue(False, "Expected log:\n%s\nActual log:\n%s\n"
+                            "Fail to find:\n  %s"
+                            % ("\n  ".join(exps), "\n  ".join(self.log), exp))
+        except StopIteration:
+            pass
+
+
+class Stream(object):  # pylint: disable=R0903
+
+    """ Fake stream object """
+
+    def __init__(self, log):
+        self.notify = mock_function('Stream.notify', log)
+
+
+class Args(object):     # pylint: disable=R0903
+
+    """ Fake args object """
+
+    def __init__(self):
+        self.test_result_total = 1
+        self.url = ['/tests/sleeptest', '/tests/other/test',
+                    '/other/tests/test']
+        self.remote_username = 'username'
+        self.remote_hostname = 'hostname'
+        self.remote_port = 22
+        self.remote_password = 'password'
+
+
+class RemoteTestResultTest(unittest.TestCase):
+
+    """ Tests the RemoteTestResult """
+
+    def setUp(self):
+        self.log = []
+        self.__mock = {}
+        mock(self.__mock, 'remote.os.getcwd', self.log, "/currrent/directory")
+        mock(self.__mock, 'remote.os.path.exists', self.log, True)
+        mock(self.__mock, 'remote.remote.Remote', self.log, Remote(self.log))
+        self.remote = remote.RemoteTestResult(Stream(self.log), Args())
+
+    def tearDown(self):
+        unmock_all(self.__mock)
+
+    def test_setup(self):
+        """ Tests RemoteTestResult.test_setup() """
+        self.remote.setup()
+        exps = [("remote.remote.Remote "
+                 "('hostname', 'username', 'password', 22) {'quiet': True}"),
+                "Remote.makedir ('~/avocado/tests',) {}",
+                "Remote.makedir ('~/avocado/tests/other/tests',) {}",
+                "Remote.rsync ('/other/tests', '~/avocado/tests/other') {}",
+                "Remote.makedir ('~/avocado/tests/tests',) {}",
+                "Remote.rsync ('/tests', '~/avocado/tests') {}"]
+        iexps = iter(exps)
+        try:
+            exp = iexps.next()
+            for line in self.log:
+                if line == exp:
+                    exp = iexps.next()
+            self.assertTrue(False, "Expected log:\n%s\nActual log:\n%s\n"
+                            "Fail to find:\n  %s"
+                            % ("\n  ".join(exps), "\n  ".join(self.log), exp))
+        except StopIteration:
+            pass
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hi guys, especially @jscotka, @lmr and @ruda,

this pull request unifies test locations for remote plugin. It might be one of possible solutions to the https://github.com/avocado-framework/avocado/issues/352 . There are couple of changes from before.

#. set fabric to copy file mode (tests have to be executable)
#. remote plugin turns each url into aboslute path
#. parent dirs are copied recursively into `$remote_test_dir` + `$absolute_path`
#. remote execution uses `$remote_test_dir` + `$absolute_path` to avoid clashes
#. remote paths are logged in results

I tested various executions and it seems to be more consistent. But I might missed something so please think about it for a while.