### PR TITLE
.gitignore: Add .idea directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .pydevproject
 .settings
 .coverage
+.idea/*
 coverage.xml
 xunit.xml
 tmp/*


### PR DESCRIPTION
This is a directory used by PyCharm, one of the IDEs some
of the team members are using. Let's add it to .gitignore.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>