### PR TITLE
avocado.runner: Remove root logger logging upon timeout

### DIFF
--- a/avocado/runner.py
+++ b/avocado/runner.py
@@ -164,7 +164,6 @@ class TestRunner(object):
             while True:
                 try:
                     if time.time() >= time_deadline:
-                        logging.error("timeout")
                         os.kill(p.pid, signal.SIGUSR1)
                         break
                     wait.wait_for(lambda: not q.empty() or not p.is_alive(),


### PR DESCRIPTION
Having it here was a mistake caused by commit 5347d8ec
causing timeout to be printed to avocado stdout. Let's
fix that.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>