### PR TITLE
avocado/sysinfo.py: simple formatting fix for the Command class

### DIFF
--- a/avocado/sysinfo.py
+++ b/avocado/sysinfo.py
@@ -178,7 +178,7 @@ class Command(Loggable):
 
     def __repr__(self):
         r = "sysinfo.Command(%r, %r, %r)"
-        r %= (self.cmd, self.logf)
+        r %= (self.cmd, self.logf, self._compress_log)
         return r
 
     def __eq__(self, other):


### PR DESCRIPTION
It looks like there was intention to add the extra parameter that
the Command class takes (whether to compress the log file or not),
but it wasn't added as a parameter to the string formatting operation.

Signed-off-by: Cleber Rosa <crosa@redhat.com>