### PR TITLE
Unittests: remove shebangs and license headers

### DIFF
--- a/selftests/all/doc/doc_build_test.py
+++ b/selftests/all/doc/doc_build_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 """
 Build documentation and report whether we had warning/error messages.
 

--- a/selftests/all/functional/avocado/basic_tests.py
+++ b/selftests/all/functional/avocado/basic_tests.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import json
 import unittest
 import os

--- a/selftests/all/functional/avocado/export_variables_tests.py
+++ b/selftests/all/functional/avocado/export_variables_tests.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import os
 import sys
 import shutil

--- a/selftests/all/functional/avocado/gdb_tests.py
+++ b/selftests/all/functional/avocado/gdb_tests.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import os
 import sys
 import unittest

--- a/selftests/all/functional/avocado/journal_tests.py
+++ b/selftests/all/functional/avocado/journal_tests.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import unittest
 import os
 import sys

--- a/selftests/all/functional/avocado/loader_tests.py
+++ b/selftests/all/functional/avocado/loader_tests.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import os
 import sys
 import unittest

--- a/selftests/all/functional/avocado/output_check_tests.py
+++ b/selftests/all/functional/avocado/output_check_tests.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import os
 import shutil
 import sys

--- a/selftests/all/functional/avocado/output_tests.py
+++ b/selftests/all/functional/avocado/output_tests.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import json
 import tempfile
 import unittest

--- a/selftests/all/functional/avocado/standalone_tests.py
+++ b/selftests/all/functional/avocado/standalone_tests.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import unittest
 import os
 import sys

--- a/selftests/all/functional/avocado/utils_tests.py
+++ b/selftests/all/functional/avocado/utils_tests.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import os
 import sys
 import unittest

--- a/selftests/all/functional/avocado/wrapper_tests.py
+++ b/selftests/all/functional/avocado/wrapper_tests.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import os
 import sys
 import unittest

--- a/selftests/all/unit/avocado/archive_unittest.py
+++ b/selftests/all/unit/avocado/archive_unittest.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import unittest
 import tempfile
 import os

--- a/selftests/all/unit/avocado/datadir_unittest.py
+++ b/selftests/all/unit/avocado/datadir_unittest.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import unittest
 import os
 import sys

--- a/selftests/all/unit/avocado/distro_unittest.py
+++ b/selftests/all/unit/avocado/distro_unittest.py
@@ -1,18 +1,3 @@
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2014
-# Authors: Cleber Rosa <cleber@redhat.com>
-
-
 import os
 import re
 import sys

--- a/selftests/all/unit/avocado/gdb_unittest.py
+++ b/selftests/all/unit/avocado/gdb_unittest.py
@@ -1,18 +1,3 @@
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: Red Hat Inc. 2014
-# Authors: Cleber Rosa <cleber@redhat.com>
-
-
 import os
 import sys
 import unittest

--- a/selftests/all/unit/avocado/jsonresult_unittest.py
+++ b/selftests/all/unit/avocado/jsonresult_unittest.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import unittest
 import os
 import sys

--- a/selftests/all/unit/avocado/loader_unittest.py
+++ b/selftests/all/unit/avocado/loader_unittest.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import os
 import sys
 import unittest

--- a/selftests/all/unit/avocado/multiplexer_unittest.py
+++ b/selftests/all/unit/avocado/multiplexer_unittest.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import unittest
 
 from avocado import multiplexer

--- a/selftests/all/unit/avocado/plugins_unittest.py
+++ b/selftests/all/unit/avocado/plugins_unittest.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import sys
 import os
 import unittest

--- a/selftests/all/unit/avocado/remote_unittest.py
+++ b/selftests/all/unit/avocado/remote_unittest.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import unittest
 import os
 import sys

--- a/selftests/all/unit/avocado/settings_unittest.py
+++ b/selftests/all/unit/avocado/settings_unittest.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import unittest
 import os
 import sys

--- a/selftests/all/unit/avocado/sysinfo_unittest.py
+++ b/selftests/all/unit/avocado/sysinfo_unittest.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import os
 import sys
 import unittest

--- a/selftests/all/unit/avocado/test_unittest.py
+++ b/selftests/all/unit/avocado/test_unittest.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import unittest
 import os
 import shutil

--- a/selftests/all/unit/avocado/tree_unittest.py
+++ b/selftests/all/unit/avocado/tree_unittest.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import copy
 import unittest
 

--- a/selftests/all/unit/avocado/utils_params_unittest.py
+++ b/selftests/all/unit/avocado/utils_params_unittest.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 import unittest
 
 from avocado.utils import params

--- a/selftests/all/unit/avocado/utils_process_unittest.py
+++ b/selftests/all/unit/avocado/utils_process_unittest.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 import unittest
 
 from avocado import runtime

--- a/selftests/all/unit/avocado/vm_unittest.py
+++ b/selftests/all/unit/avocado/vm_unittest.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import unittest
 import os
 import sys

--- a/selftests/all/unit/avocado/xunit_unittest.py
+++ b/selftests/all/unit/avocado/xunit_unittest.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import argparse
 import unittest
 import os


### PR DESCRIPTION
This PR introduces two cleanup to unittests:
* removes shebangs since unittests are no longer have executable bits set
* removes left over license headers