### PR TITLE
Introduce sysinfo profilers (journalctl & vmstat) [V3]

### DIFF
--- a/avocado/sysinfo.py
+++ b/avocado/sysinfo.py
@@ -47,7 +47,8 @@ _DEFAULT_COMMANDS_START_JOB = ["df -mP",
                                "numactl --hardware show",
                                "lscpu",
                                "fdisk -l"]
-_DEFAULT_COMMANDS_END_JOB = []
+
+_DEFAULT_COMMANDS_END_JOB = _DEFAULT_COMMANDS_START_JOB
 
 _DEFAULT_FILES_START_JOB = ["/proc/cmdline",
                             "/proc/mounts",
@@ -63,7 +64,7 @@ _DEFAULT_FILES_START_JOB = ["/proc/cmdline",
                             "/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor",
                             "/sys/devices/system/clocksource/clocksource0/current_clocksource"]
 
-_DEFAULT_FILES_END_JOB = []
+_DEFAULT_FILES_END_JOB = _DEFAULT_FILES_START_JOB
 
 _DEFAULT_COMMANDS_START_TEST = []
 
@@ -158,6 +159,10 @@ class Logfile(Loggable):
             except IOError:
                 log.debug("Not logging %s (lack of permissions)", self.path)
 
+    def stop(self):
+        """Not used."""
+        pass
+
 
 class Command(Loggable):
 
@@ -219,6 +224,49 @@ class Command(Loggable):
                 utils.process.run('gzip -9 "%s"' % logf_path,
                                   ignore_status=True,
                                   verbose=False)
+
+    def stop(self):
+        """Not used."""
+        pass
+
+
+class Daemon(Command):
+
+    """
+    Loggable daemon.
+
+    :param cmd: String with the daemon command.
+    :param logf: Basename of the file where output is logged (optional).
+    :param compress_logf: Wether to compress the output of the command.
+    """
+
+    def run(self, logdir):
+        """
+        Execute the daemon as a subprocess and log its output in logdir.
+
+        :param logdir: Path to a log directory.
+        """
+        env = os.environ.copy()
+        if "PATH" not in env:
+            env["PATH"] = "/usr/bin:/bin"
+        logf_path = os.path.join(logdir, self.logf)
+        stdin = open(os.devnull, "r")
+        stdout = open(logf_path, "w")
+        self.pipe = subprocess.Popen(self.cmd, stdin=stdin, stdout=stdout,
+                                     stderr=subprocess.STDOUT, shell=True, env=env)
+
+    def stop(self):
+        """
+        Stop daemon execution.
+        """
+        retcode = self.pipe.poll()
+        if retcode is None:
+            self.pipe.terminate()
+            retcode = self.pipe.wait()
+        else:
+            log.debug("Daemon process '%s' (pid %d) terminated abnormally (code %d)",
+                      self.cmd, self.pipe.pid, retcode)
+        return retcode
 
 
 class LogWatcher(Loggable):
@@ -324,7 +372,7 @@ class SysInfo(object):
     * end_job
     """
 
-    def __init__(self, basedir=None, log_packages=None):
+    def __init__(self, basedir=None, log_packages=None, profiler=None):
         """
         Set sysinfo loggables.
 
@@ -333,6 +381,9 @@ class SysInfo(object):
                              logging packages is a costly operation). If not
                              given explicitly, tries to look in the config
                              files, and if not found, defaults to False.
+        :param profiler: Wether to use the profiler. If not given explicitly,
+                         tries to look in the config files, and if not found,
+                         defaults to False.
         """
         if basedir is None:
             basedir = utils.path.init_dir(os.getcwd(), 'sysinfo')
@@ -347,6 +398,29 @@ class SysInfo(object):
                                                    default=False)
         else:
             self.log_packages = log_packages
+
+        if profiler is None:
+            self.profiler = settings.get_value('sysinfo.collect',
+                                               'profiler',
+                                               key_type='bool',
+                                               default=False)
+        else:
+            self.profiler = profiler
+
+        profiler_commands = settings.get_value('sysinfo.collect',
+                                               'profiler_commands',
+                                               key_type='str',
+                                               default='')
+
+        if self.profiler:
+            if profiler_commands == '':
+                log.info('Profiler disabled: no profiler commands configured')
+                self.profiler_commands = []
+            else:
+                self.profiler_commands = [x for x in profiler_commands.split(':') if x != '']
+                log.info('Profilers to run %s', self.profiler_commands)
+        else:
+            log.info("Profiler disabled")
 
         self.start_job_loggables = set()
         self.end_job_loggables = set()
@@ -363,6 +437,10 @@ class SysInfo(object):
                              'end_test': self.end_test_loggables,
                              'start_iteration': self.start_iteration_loggables,
                              'end_iteration': self.end_iteration_loggables}
+
+        self.pre_dir = utils.path.init_dir(self.basedir, 'pre')
+        self.post_dir = utils.path.init_dir(self.basedir, 'post')
+        self.profile_dir = utils.path.init_dir(self.basedir, 'profile')
 
         self._set_loggables()
 
@@ -383,6 +461,10 @@ class SysInfo(object):
         return syslog_watcher
 
     def _set_loggables(self):
+        if self.profiler:
+            for cmd in self.profiler_commands:
+                self.start_job_loggables.add(Daemon(cmd))
+
         for cmd in _DEFAULT_COMMANDS_START_JOB:
             self.start_job_loggables.add(Command(cmd))
 
@@ -494,61 +576,61 @@ class SysInfo(object):
         """
         Logging hook called whenever a job starts, and again after reboot.
         """
-        pre_dir = utils.path.init_dir(self.basedir, 'pre')
         for log in self.start_job_loggables:
-            log.run(pre_dir)
+            if isinstance(log, Daemon):  # log daemons in profile directory
+                log.run(self.profile_dir)
+            else:
+                log.run(self.pre_dir)
 
         if self.log_packages:
-            self._log_installed_packages(pre_dir)
+            self._log_installed_packages(self.pre_dir)
 
     def end_job_hook(self):
         """
         Logging hook called whenever a job starts, and again after reboot.
         """
-        post_dir = utils.path.init_dir(self.basedir, 'post')
+        for log in self.end_job_loggables:
+            log.run(self.post_dir)
+        # Stop daemon(s) started previously
         for log in self.start_job_loggables:
-            log.run(post_dir)
+            log.stop()
 
         if self.log_packages:
-            self._log_modified_packages(post_dir)
+            self._log_modified_packages(self.post_dir)
 
     def start_test_hook(self):
         """
         Logging hook called before a test starts.
         """
-        pre_dir = utils.path.init_dir(self.basedir, 'pre')
         for log in self.start_test_loggables:
-            log.run(pre_dir)
+            log.run(self.pre_dir)
 
         if self.log_packages:
-            self._log_installed_packages(pre_dir)
+            self._log_installed_packages(self.pre_dir)
 
     def end_test_hook(self):
         """
         Logging hook called after a test finishes.
         """
-        post_dir = utils.path.init_dir(self.basedir, 'post')
         for log in self.end_test_loggables:
-            log.run(post_dir)
+            log.run(self.post_dir)
 
         if self.log_packages:
-            self._log_modified_packages(post_dir)
+            self._log_modified_packages(self.post_dir)
 
     def start_iteration_hook(self):
         """
         Logging hook called before a test iteration
         """
-        pre_dir = utils.path.init_dir(self.basedir, 'pre')
         for log in self.start_iteration_loggables:
-            log.run(pre_dir)
+            log.run(self.pre_dir)
 
     def end_iteration_hook(self, test, iteration=None):
         """
         Logging hook called after a test iteration
         """
-        post_dir = utils.path.init_dir(self.basedir, 'post')
         for log in self.end_iteration_loggables:
-            log.run(post_dir)
+            log.run(self.post_dir)
 
 
 def collect_sysinfo(args):
@@ -567,4 +649,5 @@ def collect_sysinfo(args):
 
     sysinfo_logger = SysInfo(basedir=basedir, log_packages=True)
     sysinfo_logger.start_job_hook()
+    sysinfo_logger.end_job_hook()
     log.info("Logged system information to %s", basedir)

--- a/avocado/sysinfo.py
+++ b/avocado/sysinfo.py
@@ -208,13 +208,12 @@ class Command(Loggable):
             env["PATH"] = "/usr/bin:/bin"
         logf_path = os.path.join(logdir, self.logf)
         stdin = open(os.devnull, "r")
-        stderr = open(os.devnull, "w")
         stdout = open(logf_path, "w")
         try:
             subprocess.call(self.cmd, stdin=stdin, stdout=stdout,
-                            stderr=stderr, shell=True, env=env)
+                            stderr=subprocess.STDOUT, shell=True, env=env)
         finally:
-            for f in (stdin, stdout, stderr):
+            for f in (stdin, stdout):
                 f.close()
             if self._compress_log and os.path.exists(logf_path):
                 utils.process.run('gzip -9 "%s"' % logf_path,

--- a/etc/avocado/avocado.conf
+++ b/etc/avocado/avocado.conf
@@ -6,3 +6,5 @@ logs_dir = ~/avocado/job-results
 
 [sysinfo.collect]
 installed_packages = False
+profiler = False
+profiler_commands = vmstat 1:journalctl -f

--- a/selftests/all/functional/avocado/multiplex_tests.py
+++ b/selftests/all/functional/avocado/multiplex_tests.py
@@ -35,6 +35,8 @@ class MultiplexTests(unittest.TestCase):
                     debug_log = line.split()[-1]
                     debug_log_obj = open(debug_log, 'r')
                     job_log_lines = debug_log_obj.readlines()
+                    # Preserve test information, filter out sysinfo
+                    job_log_lines = [x for x in job_log_lines if ' test ' in x]
                     lines_output = len(job_log_lines)
                     debug_log_obj.close()
             self.assertGreaterEqual(lines_output, expected_lines,
@@ -76,16 +78,16 @@ class MultiplexTests(unittest.TestCase):
     def test_run_mplex_passtest(self):
         cmd_line = './scripts/avocado run passtest --multiplex examples/tests/sleeptest.py.data/sleeptest.yaml'
         expected_rc = 0
-        # A typical pass has about 14 lines of output,
+        # A typical pass has about 13 lines of output,
         # so we expect the full job log has at least 4 times
         # this value. If that is not the case, something is wrong with
         # the output.
-        self.run_and_check(cmd_line, expected_rc, 14 * 4)
+        self.run_and_check(cmd_line, expected_rc, 13 * 4)
 
     def test_run_mplex_doublepass(self):
         cmd_line = './scripts/avocado run passtest passtest --multiplex examples/tests/sleeptest.py.data/sleeptest.yaml'
         # Should run 2-times 4 variants of pass test
-        self.run_and_check(cmd_line, expected_rc=0, expected_lines=2 * 4 * 14)
+        self.run_and_check(cmd_line, expected_rc=0, expected_lines=2 * 4 * 13)
 
     def test_run_mplex_failtest(self):
         cmd_line = './scripts/avocado run passtest failtest --multiplex examples/tests/sleeptest.py.data/sleeptest.yaml'
@@ -97,11 +99,11 @@ class MultiplexTests(unittest.TestCase):
                     'examples/tests/sleeptest.py.data/sleeptest.yaml '
                     'examples/tests/sleeptest.py.data/sleeptest.yaml')
         expected_rc = 0
-        # A typical pass has about 14 lines of output,
+        # A typical pass has about 13 lines of output,
         # so we expect the full job log has at least 4 times
         # this value. If that is not the case, something is wrong with
         # the output.
-        self.run_and_check(cmd_line, expected_rc, 14 * 4)
+        self.run_and_check(cmd_line, expected_rc, 13 * 4)
 
     def test_run_mplex_params(self):
         cmd_line = ('./scripts/avocado run examples/tests/env_variables.sh '

--- a/selftests/all/unit/avocado/sysinfo_unittest.py
+++ b/selftests/all/unit/avocado/sysinfo_unittest.py
@@ -60,8 +60,8 @@ class SysinfoTest(unittest.TestCase):
         sysinfo_logger = sysinfo.SysInfo(basedir=jobdir)
         sysinfo_logger.start_job_hook()
         self.assertTrue(os.path.isdir(jobdir))
-        self.assertEqual(len(os.listdir(jobdir)), 1,
-                         "Job does not have 'pre' dir")
+        self.assertEqual(len(os.listdir(jobdir)), 3,
+                         "Job does not have 'pre/post/profile' dirs")
         job_predir = os.path.join(jobdir, 'pre')
         self.assertTrue(os.path.isdir(job_predir))
         self.assertGreater(len(os.listdir(job_predir)), 0,
@@ -71,22 +71,24 @@ class SysinfoTest(unittest.TestCase):
         self.assertTrue(os.path.isdir(job_postdir))
         self.assertGreater(len(os.listdir(job_postdir)), 0,
                            "Job post dir is empty")
+        self.assertTrue(os.path.isdir(job_postdir))
+        job_profiledir = os.path.join(jobdir, 'profile')
 
     def test_logger_test_hooks(self):
         testdir = os.path.join(self.tmpdir, 'job', 'test1')
         sysinfo_logger = sysinfo.SysInfo(basedir=testdir)
         sysinfo_logger.start_test_hook()
         self.assertTrue(os.path.isdir(testdir))
-        self.assertEqual(len(os.listdir(testdir)), 1,
-                         "Test does not have 'pre' dir")
+        self.assertEqual(len(os.listdir(testdir)), 3,
+                         "Test does not have 'pre/post/profile' dirs")
         test_predir = os.path.join(testdir, 'pre')
         self.assertTrue(os.path.isdir(test_predir))
         # By default, there are no pre test files
         self.assertEqual(len(os.listdir(test_predir)), 0,
                          "Test pre dir is not empty")
         sysinfo_logger.end_test_hook()
-        self.assertEqual(len(os.listdir(testdir)), 2,
-                         "Test does not have 'pre' dir")
+        self.assertEqual(len(os.listdir(testdir)), 3,
+                         "Test does not have 'pre/post/profile' dirs")
         job_postdir = os.path.join(testdir, 'post')
         self.assertTrue(os.path.isdir(job_postdir))
         # By default, there are no post test files


### PR DESCRIPTION
Follow up of PR #360.

---

Changes:
* Rebased code and squashed commits and reorganize them in logic (in my point of view) commits. Suggested by @adereis @clebergnu.
* Use the term "profiler/profilers"  for the feature of running background process (daemons) to get information in job executions. Preserve the class name Daemon. Suggested by @clebergnu.
* Use configuration option `profiler` to enable or disable the sysinfo profiler. Use configuration option `profiler_commands` to describe the command line options for each profiler to execute, so we don't have profilers hardcoded anymore. If `profile_commands` is empty, then no profile will run. Suggested by @clebergnu .
* Log profile status (enable/disable/commands) in `job.log` when running the tests.
* Fix multiplex_tests.
