### PR TITLE
avocado.plugins.xunit: Add WARN status as PASS

### DIFF
--- a/avocado/plugins/xunit.py
+++ b/avocado/plugins/xunit.py
@@ -184,7 +184,7 @@ class xUnitTestResult(TestResult):
         :type state: dict
         """
         TestResult.end_test(self, state)
-        if state['status'] == 'PASS':
+        if state['status'] in ('PASS', 'WARN'):
             self.xml.add_success(state)
         elif state['status'] == 'TEST_NA':
             self.xml.add_skip(state)


### PR DESCRIPTION
xunit doesn't support WARN test restul and currently is just ignored.
This commit maps WARN test results as PASS.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>