### PR TITLE
Implement --disable-sysinfo feature.

### DIFF
--- a/avocado/job.py
+++ b/avocado/job.py
@@ -29,6 +29,7 @@ from avocado import test
 from avocado import runner
 from avocado import loader
 from avocado import runtime
+from avocado import sysinfo
 from avocado.core import data_dir
 from avocado.core import exit_codes
 from avocado.core import exceptions
@@ -37,6 +38,7 @@ from avocado.core import output
 from avocado.plugins import jsonresult
 from avocado.plugins import xunit
 from avocado.utils import archive
+from avocado.utils import path
 
 
 try:
@@ -104,6 +106,11 @@ class Job(object):
         self.status = "RUNNING"
         self.result_proxy = result.TestResultProxy()
         self.view = output.View(app_args=self.args)
+        self.sysinfo = None
+        if hasattr(self.args, 'disable_sysinfo'):
+            if self.args.disable_sysinfo is False:
+                sysinfo_dir = path.init_dir(self.logdir, 'sysinfo')
+                self.sysinfo = sysinfo.SysInfo(basedir=sysinfo_dir)
 
     def _make_test_loader(self):
         if hasattr(self.args, 'test_loader'):

--- a/avocado/plugins/htmlresult.py
+++ b/avocado/plugins/htmlresult.py
@@ -20,6 +20,7 @@ import shutil
 import sys
 import time
 import webbrowser
+import socket
 
 import pystache
 
@@ -86,6 +87,8 @@ class ReportModel(object):
                 sysinfo_contents = sysinfo_file.read()
         except OSError, details:
             sysinfo_contents = "Error reading %s: %s" % (sysinfo_path, details)
+        except IOError, details:
+            sysinfo_contents = socket.gethostname()
         return sysinfo_contents
 
     def hostname(self):
@@ -122,10 +125,13 @@ class ReportModel(object):
         return test_info
 
     def sysinfo(self):
-        base_path = os.path.join(self._results_dir(relative_links=False), 'sysinfo', 'pre')
-        sysinfo_files = os.listdir(base_path)
-        sysinfo_files.sort()
         sysinfo_list = []
+        base_path = os.path.join(self._results_dir(relative_links=False), 'sysinfo', 'pre')
+        try:
+            sysinfo_files = os.listdir(base_path)
+        except OSError:
+            return sysinfo_list
+        sysinfo_files.sort()
         s_id = 1
         for s_f in sysinfo_files:
             sysinfo_dict = {}

--- a/avocado/plugins/runner.py
+++ b/avocado/plugins/runner.py
@@ -60,6 +60,10 @@ class TestRunner(plugin.Plugin):
                                        'server. You should not use this option '
                                        'unless you know exactly what you\'re doing'))
 
+        self.parser.add_argument('--disable-sysinfo', action='store_true', default=False,
+                                 help=('Disable sysinfo report. Used to disable '
+                                       'the execution of profilers and other system loggings'))
+
         out = self.parser.add_argument_group('output related arguments')
 
         out.add_argument('-s', '--silent', action='store_true', default=False,

--- a/avocado/runner.py
+++ b/avocado/runner.py
@@ -26,7 +26,6 @@ import sys
 import time
 
 from avocado import runtime
-from avocado import sysinfo
 from avocado.core import exceptions
 from avocado.core import output
 from avocado.core import status
@@ -52,8 +51,6 @@ class TestRunner(object):
         """
         self.job = job
         self.result = test_result
-        sysinfo_dir = path.init_dir(self.job.logdir, 'sysinfo')
-        self.sysinfo = sysinfo.SysInfo(basedir=sysinfo_dir)
 
     def run_test(self, test_factory, queue):
         """
@@ -122,7 +119,8 @@ class TestRunner(object):
         :return: a list of test failures.
         """
         failures = []
-        self.sysinfo.start_job_hook()
+        if self.job.sysinfo is not None:
+            self.job.sysinfo.start_job_hook()
         self.result.start_tests()
         q = queues.SimpleQueue()
         test_suite = self.job.test_loader.discover(params_list, q)
@@ -233,5 +231,6 @@ class TestRunner(object):
                 failures.append(test_state['name'])
         runtime.CURRENT_TEST = None
         self.result.end_tests()
-        self.sysinfo.end_job_hook()
+        if self.job.sysinfo is not None:
+            self.job.sysinfo.end_job_hook()
         return failures

--- a/man/avocado.rst
+++ b/man/avocado.rst
@@ -141,6 +141,12 @@ stdout. Even if you specify things like --show-job-log in the CLI, --silent
 will have precedence and you will not get application stdout. Note that --silent
 does not affect on disk job logs, those continue to be generated normally.
 
+SILENCING SYSINFO REPORT
+========================
+
+You may specify --disable-sysinfo and avocado will not run profilers
+and other commands related to the sysinfo report, inside the job result
+directory.
 
 LISTING TESTS
 =============


### PR DESCRIPTION
Implement runner command line option `--disable-sysinfo`,
to turn off any reports created and related to the execution of sysinfo,
like profilers, command lines utilities and other system logs.

Example: avocado run --disable-sysinfo passtest

Signed-off-by: Rudá Moura <rmoura@redhat.com>