### PR TITLE
Remove occurences of old `print` statement syntax

### DIFF
--- a/avocado/aexpect.py
+++ b/avocado/aexpect.py
@@ -184,7 +184,7 @@ if __name__ == "__main__":
         fileobj.close()
 
         # Print something to stdout so the client can start working
-        print "Server %s ready" % a_id
+        print("Server %s ready" % a_id)
         sys.stdout.flush()
 
         # Initialize buffers

--- a/docs/source/Plugins.rst
+++ b/docs/source/Plugins.rst
@@ -49,7 +49,7 @@ runner, ``hello``. This is how you'd do it::
             super(HelloWorld, self).configure(self.parser)
 
         def run(self, args):
-            print self.__doc__
+            print(self.__doc__)
 
 As you can see, plugins inherit from :class:`avocado.plugins.plugin.Plugin`,
 that have the methods :func:`avocado.plugins.plugin.Plugin.configure` and

--- a/examples/plugins/avocado_hello.py
+++ b/examples/plugins/avocado_hello.py
@@ -23,4 +23,4 @@ class HelloWorld(plugin.Plugin):
         """
         This method is called whenever we use the command 'hello'.
         """
-        print self.__doc__
+        print(self.__doc__)

--- a/scripts/avocado-journal-replay
+++ b/scripts/avocado-journal-replay
@@ -69,7 +69,6 @@ class App(object):
         if r.status_code == 200:
             return True
         else:
-            print r.text
             return False
 
     def create_job(self, unique_id):

--- a/selftests/all/doc/doc_build_test.py
+++ b/selftests/all/doc/doc_build_test.py
@@ -35,7 +35,7 @@ def test_build_docs():
         ignore_msg = False
         for ignore in ignore_list:
             if ignore in line:
-                print 'Expected warning ignored: %s' % line
+                print('Expected warning ignored: %s' % line)
                 ignore_msg = True
         if ignore_msg:
             continue

--- a/selftests/all/functional/avocado/basic_tests.py
+++ b/selftests/all/functional/avocado/basic_tests.py
@@ -44,7 +44,7 @@ class HelloWorld(Plugin):
         self.parser = parser.subcommands.add_parser('hello')
         super(HelloWorld, self).configure(self.parser)
     def run(self, args):
-        print 'Hello World!'
+        print('Hello World!')
 """
 
 

--- a/selftests/all/functional/avocado/loader_tests.py
+++ b/selftests/all/functional/avocado/loader_tests.py
@@ -38,12 +38,12 @@ if __name__ == "__main__":
 
 NOT_A_TEST = """
 def hello():
-    print 'Hello World!'
+    print('Hello World!')
 """
 
 PY_SIMPLE_TEST = """#!/usr/bin/python
 def hello():
-    print 'Hello World!'
+    print('Hello World!')
 
 if __name__ == "__main__":
     hello()

--- a/selftests/all/functional/avocado/utils_tests.py
+++ b/selftests/all/functional/avocado/utils_tests.py
@@ -79,8 +79,8 @@ class FakeVMStat(object):
         return 0
 
     def start(self):
-        print "procs -----------memory---------- ---swap-- -----io---- -system-- ------cpu-----"
-        print " r  b   swpd   free   buff  cache   si   so    bi    bo   in   cs us sy id wa st"
+        print("procs -----------memory---------- ---swap-- -----io---- -system-- ------cpu-----")
+        print(" r  b   swpd   free   buff  cache   si   so    bi    bo   in   cs us sy id wa st")
         while True:
             r = self.get_r()
             b = self.get_b()
@@ -99,9 +99,9 @@ class FakeVMStat(object):
             m_id = self.get_id()
             wa = self.get_wa()
             st = self.get_st()
-            print ("%2d %2d  %2d   %7d %6d %7d    %1d    %1d    %2d  %3d %4d %2d %2d %1d  %3d  %1d  %1d" %
-                   (r, b, swpd, free, buff, cache, si, so, bi, bo, m_in, cs,
-                    us, sy, m_id, wa, st))
+            print("%2d %2d  %2d   %7d %6d %7d    %1d    %1d    %2d  %3d %4d %2d %2d %1d  %3d  %1d  %1d" %
+                  (r, b, swpd, free, buff, cache, si, so, bi, bo, m_in, cs,
+                   us, sy, m_id, wa, st))
             time.sleep(self.interval)
 
 if __name__ == '__main__':
@@ -111,7 +111,7 @@ if __name__ == '__main__':
 
 FAKE_UPTIME_CONTENTS = """#!/usr/bin/python
 if __name__ == '__main__':
-    print "17:56:34 up  8:06,  7 users,  load average: 0.26, 0.20, 0.21"
+    print("17:56:34 up  8:06,  7 users,  load average: 0.26, 0.20, 0.21")
 
 """
 

--- a/selftests/all/unit/avocado/loader_unittest.py
+++ b/selftests/all/unit/avocado/loader_unittest.py
@@ -42,12 +42,12 @@ if __name__ == "__main__":
 
 NOT_A_TEST = """
 def hello():
-    print 'Hello World!'
+    print('Hello World!')
 """
 
 PY_SIMPLE_TEST = """#!/usr/bin/python
 def hello():
-    print 'Hello World!'
+    print('Hello World!')
 
 if __name__ == "__main__":
     hello()


### PR DESCRIPTION
OK, I did it. This has got to be the most stupid commit ever on this repo.
Still, "print 'foo'" annoys me, and if want to have Avocado running on
Python 3 anytime, we would have to do this anyway.

Signed-off-by: Cleber Rosa <crosa@redhat.com>