### PR TITLE
RFC: avocado.test: Set the test as WARN when self.log.warn used

### DIFF
--- a/avocado/test.py
+++ b/avocado/test.py
@@ -565,6 +565,10 @@ class SimpleTest(Test):
                                                  'stdout.expected')
         self.expected_stderr_file = os.path.join(self.datadir,
                                                  'stderr.expected')
+        # Simple test might need to write directly to main log
+        if base_logdir is None:
+            base_logdir = self.logdir[:-len(self.name)]
+        os.environ['AVOCADO_TESTSUITE_LOGDIR'] = base_logdir
 
     def _log_detailed_cmd_info(self, result):
         """
@@ -588,6 +592,14 @@ class SimpleTest(Test):
         except exceptions.CmdError, details:
             self._log_detailed_cmd_info(details.result)
             raise exceptions.TestFail(details)
+
+    def runTest(self, result=None):
+        super(SimpleTest, self).runTest(result)
+        for line in open(self.logfile):
+            if line[26:30] == 'WARN':
+                raise exceptions.TestWarn("Test passed but there were warnings"
+                                          "during execution. Check the log for"
+                                          " details.")
 
 
 class MissingTest(Test):

--- a/avocado/test.py
+++ b/avocado/test.py
@@ -103,6 +103,11 @@ class Test(unittest.TestCase):
                     'sleeptest.long' and 'sleeptest.short'.
         :param job: The job that this test is part of.
         """
+        def record_and_warn(*args, **kwargs):
+            """ Record call to this function and log warning """
+            self.__log_warn_used = True
+            return original_log_warn(*args, **kwargs)
+
         if name is not None:
             self.name = name
         else:
@@ -147,6 +152,9 @@ class Test(unittest.TestCase):
         self.sysinfo_logger = sysinfo.SysInfo(basedir=self.sysinfodir)
 
         self.log = logging.getLogger("avocado.test")
+        original_log_warn = self.log.warning
+        self.__log_warn_used = False
+        self.log.warn = self.log.warning = record_and_warn
 
         self.stdout_log = logging.getLogger("avocado.test.stdout")
         self.stderr_log = logging.getLogger("avocado.test.stderr")
@@ -465,6 +473,10 @@ class Test(unittest.TestCase):
             raise stdout_check_exception
         elif stderr_check_exception is not None:
             raise stderr_check_exception
+        elif self.__log_warn_used:
+            raise exceptions.TestWarn("Test passed but there were warnings "
+                                      "during execution. Check the log for "
+                                      "details.")
 
         self.status = 'PASS'
         self.sysinfo_logger.end_test_hook()

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -480,17 +480,23 @@ the following entities:
 * The test expected stdout
 * The test expected stderr
 
-The first one is used for debugging and informational purposes. The framework
-machinery uses logs to give you more detailed info about your test, so they
-are not the most reliable source to compare stdout/err. You may log something
-into the test logs using the methods in :mod:`avocado.test.Test.log` class
-attributes. Consider
-the example::
+The first one is used for debugging and informational purposes. This log can
+also be used to mark unexpected situation not critical to the test. When
+you write something into log.warning() it'll be recorded and when everything
+else goes well the test finishes as WARN. By definition this means the test
+passed but there were non-related unexpected situations described in
+warning log.
+
+You may log something into the test logs using the methods in
+:mod:`avocado.test.Test.log` class attributes. Consider the example::
 
     class output_test(test.Test):
 
         def action(self):
             self.log.info('This goes to the log and it is only informational')
+            self.log.warn('Oh, something unexpected, non-critical happened, '
+                          'the test will finish as WARN instead of PASS')
+            self.log.debug('Everybody look, I had a good lunch today...')
 
 If you need to write directly to the test stdout and stderr streams, there
 are another 2 class attributes for that, :mod:`avocado.test.Test.stdout_log`

--- a/examples/tests/warntest.py
+++ b/examples/tests/warntest.py
@@ -15,7 +15,7 @@ class WarnTest(test.Test):
         """
         This should throw a TestWarn.
         """
-        raise exceptions.TestWarn('This should throw a TestWarn')
+        self.log.warn("This marks test as WARN")
 
 if __name__ == "__main__":
     job.main()

--- a/scripts/avocado-bash-utils
+++ b/scripts/avocado-bash-utils
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Avocado BASH utils
+
+# Debug mode...
+[ -z $AVOCADO_TEST_LOGFILE ] && export AVOCADO_TEST_LOGFILE=/dev/stdout
+[ -z $AVOCADO_TESTSUITE_LOGDIR ] && export AVOCADO_TESTSUITE_LOGDIR=/dev/null
+
+# Write to avocado_log
+# First argument has to be log level
+function avocado_log {
+    LEVEL=`printf '%-5s' $1`
+    shift
+    echo `date '+%H:%M:%S'`" bash             $LEVEL| $*" >> $AVOCADO_TEST_LOGFILE
+    echo `date '+%H:%M:%S'`" bash             $LEVEL| $*" >> $AVOCADO_TESTSUITE_LOGDIR/job.log
+}
+
+function avocado_debug { avocado_log DEBUG $*; }
+function avocado_info { avocado_log INFO $*; }
+function avocado_warn { avocado_log WARN $*; }
+function avocado_error { avocado_log ERROR $*; }


### PR DESCRIPTION
Hi guys,

This patch simplifies the concept of WARN test. In case user uses the
self.log.warn or self.log.warning methods, test is marked as dirty and
in case everything else worked fine it finishes with TestWarn exception.

Additionally I added basic support for the same feature for people using simple bash scripts. The second commit is only an example and will be either removed before merging or applied separately when ready. It also shows the way we can help people who prefer bash to use Avocado features. Take it as RFC and not as part of this pull request.

Kind regards,
Lukáš