### PR TITLE
REST Client: introduce API and avocado-rest-client application

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,11 +50,13 @@ clean:
 	rm -rf build/ MANIFEST BUILD BUILDROOT SPECS RPMS SRPMS SOURCES
 	find . -name '*.pyc' -delete
 	rm -f man/avocado.1
+	rm -f man/avocado-rest-client.1
 
 check:
 	selftests/checkall
 
 man:
 	rst2man man/avocado.rst man/avocado.1
+	rst2man man/avocado-rest-client.rst man/avocado-rest-client.1
 
 .PHONY: source install clean check man

--- a/avocado.spec
+++ b/avocado.spec
@@ -64,6 +64,7 @@ examples of how to write tests on your own.
 %files examples
 %{_datadir}/avocado/tests
 %{_datadir}/avocado/wrappers
+%{_datadir}/avocado/api
 
 %changelog
 * Mon Dec 15 2014 Lucas Meneghel Rodrigues <lmr@redhat.com> - 0.17.0-1

--- a/avocado.spec
+++ b/avocado.spec
@@ -20,11 +20,13 @@ these days a framework) to perform automated testing.
 %build
 %{__python} setup.py build
 %{__python2} /usr/bin/rst2man man/avocado.rst man/avocado.1
+%{__python2} /usr/bin/rst2man man/avocado-rest-client.rst man/avocado-rest-client.1
 
 %install
 %{__python} setup.py install --root %{buildroot} --skip-build
 %{__mkdir} -p %{buildroot}%{_mandir}/man1
 %{__install} -m 0644 man/avocado.1 %{buildroot}%{_mandir}/man1/avocado.1
+%{__install} -m 0644 man/avocado-rest-client.1 %{buildroot}%{_mandir}/man1/avocado-rest-client.1
 
 %files
 %defattr(-,root,root,-)
@@ -34,10 +36,12 @@ these days a framework) to perform automated testing.
 %config(noreplace)/etc/avocado/avocado.conf
 %config(noreplace)/etc/avocado/conf.d/README
 %{_bindir}/avocado
+%{_bindir}/avocado-rest-client
 %exclude %{python_sitelib}/avocado/plugins/htmlresult.py*
 %exclude %{python_sitelib}/avocado/plugins/resources/htmlresult/*
 %{python_sitelib}/avocado*
 %{_mandir}/man1/avocado.1.gz
+%{_mandir}/man1/avocado-rest-client.1.gz
 
 %package plugins-output-html
 Summary: Avocado HTML report plugin
@@ -67,6 +71,9 @@ examples of how to write tests on your own.
 %{_datadir}/avocado/api
 
 %changelog
+* Mon Feb  2 2015 Cleber Rosa <cleber@redhat.com> - 0.18.0-1
+- Added avocado-rest-client modules, script, man page and API examples
+
 * Mon Dec 15 2014 Lucas Meneghel Rodrigues <lmr@redhat.com> - 0.17.0-1
 - Update to upstream version 0.17.0
 

--- a/avocado/restclient/__init__.py
+++ b/avocado/restclient/__init__.py
@@ -1,0 +1,13 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2015
+# Author: Cleber Rosa <cleber@redhat.com>

--- a/avocado/restclient/cli/__init__.py
+++ b/avocado/restclient/cli/__init__.py
@@ -1,0 +1,13 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2015
+# Author: Cleber Rosa <cleber@redhat.com>

--- a/avocado/restclient/cli/actions/__init__.py
+++ b/avocado/restclient/cli/actions/__init__.py
@@ -1,0 +1,13 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2015
+# Author: Cleber Rosa <cleber@redhat.com>

--- a/avocado/restclient/cli/actions/base.py
+++ b/avocado/restclient/cli/actions/base.py
@@ -1,0 +1,12 @@
+# Copyright: Red Hat Inc. 2015
+# Author: Cleber Rosa <cleber@redhat.com>
+
+
+def action(function):
+    """
+    Simple function that marks functions as CLI actions
+
+    :param function: the function that will receive the CLI action mark
+    """
+    function.is_action = True
+    return function

--- a/avocado/restclient/cli/actions/server.py
+++ b/avocado/restclient/cli/actions/server.py
@@ -1,0 +1,40 @@
+# Copyright: Red Hat Inc. 2015
+# Author: Cleber Rosa <cleber@redhat.com>
+
+"""
+Module that implements the actions for the CLI App when the job toplevel
+command is used
+"""
+
+from avocado.restclient import connection
+from avocado.restclient.cli.actions import base
+
+
+@base.action
+def status(app):
+    """
+    Shows the server status
+    """
+    data = app.connection.request("version/")
+    app.view.notify(event="message",
+                    msg="Server version: %s" % data.get('version'))
+
+
+@base.action
+def list_brief(app):
+    """
+    Shows the server API list
+    """
+    try:
+        data = app.connection.get_api_list()
+    except connection.UnexpectedHttpStatusCode, e:
+        if e.received == 403:
+            app.view.notify(event="error",
+                            msg="Error: Access Forbidden")
+            return False
+
+    app.view.notify(event="message",
+                    msg="Available APIs:")
+    for name in data:
+        app.view.notify(event="message",
+                        msg=" * %s" % name)

--- a/avocado/restclient/cli/app.py
+++ b/avocado/restclient/cli/app.py
@@ -1,0 +1,134 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2015
+# Author: Cleber Rosa <cleber@redhat.com>
+
+"""
+This is the main entry point for the rest client cli application
+"""
+
+
+import sys
+import types
+import importlib
+import functools
+
+from avocado import settings
+from avocado.core import output
+from avocado.core import exit_codes
+from avocado.restclient import connection
+from avocado.restclient.cli import parser
+
+__all__ = ['App']
+
+
+class App(object):
+
+    """
+    Base class for CLI application
+    """
+
+    def __init__(self):
+        """
+        Initializes a new app instance.
+
+        This class is intended both to be used by the stock arcli application
+        and also to be reused by custom applications. If you want, say, to
+        limit the amount of command line actions and its arguments, you can
+        simply supply another argument parser class to this constructor. Of
+        course another way to customize it is to inherit from this and modify
+        its members at will.
+        """
+        self.connection = None
+        self.parser = parser.Parser()
+        self.parser.add_arguments_on_all_modules()
+        self.view = output.View()
+
+    def initialize_connection(self):
+        """
+        Initialize the connection instance
+        """
+        try:
+            self.connection = connection.Connection(
+                hostname=self.args.hostname,
+                port=self.args.port,
+                username=self.args.username,
+                password=self.args.password)
+        except connection.InvalidConnectionError:
+            self.view.notify(event="error",
+                             msg="Error: could not connect to the server")
+            sys.exit(exit_codes.AVOCADO_JOB_FAIL)
+        except connection.InvalidServerVersionError:
+            self.view.notify(event="error",
+                             msg=("REST server version is higher than "
+                                  "than this client can support."))
+            self.view.notify(event="error",
+                             msg=("Please use a more recent version "
+                                  "of the REST client application."))
+            sys.exit(exit_codes.AVOCADO_JOB_FAIL)
+
+    def dispatch_action(self):
+        """
+        Calls the actions that was specified via command line arguments.
+
+        This involves loading the relevant module file.
+        """
+        module_name = "%s.%s" % ('avocado.restclient.cli.actions',
+                                 self.args.top_level_action)
+
+        try:
+            module = importlib.import_module(module_name)
+        except ImportError:
+            return
+
+        # Filter out the attributes out of the loaded module that look
+        # like command line actions, based on type and 'is_action' attribute
+        module_actions = {}
+        for attribute_name in module.__dict__:
+            attribute = module.__dict__[attribute_name]
+            if (isinstance(attribute, types.FunctionType) and
+                    hasattr(attribute, 'is_action')):
+                if attribute.is_action:
+                    module_actions[attribute_name] = attribute
+
+        chosen_action = None
+        for action in module_actions.keys():
+            if getattr(self.args, action, False):
+                chosen_action = action
+                break
+
+        kallable = module_actions.get(chosen_action, None)
+        if kallable is not None:
+            self.initialize_connection()
+            return kallable(self)
+        else:
+            self.view.notify(event="error",
+                             msg="Action specified is not implemented")
+
+    def run(self):
+        """
+        Main entry point for application
+        """
+        action_result = None
+        try:
+            self.args = self.parser.parse_args()
+            action_result = self.dispatch_action()
+        except KeyboardInterrupt:
+            print 'Interrupted'
+
+        if isinstance(action_result, int):
+            sys.exit(action_result)
+        elif isinstance(action_result, bool):
+            if action_result is True:
+                sys.exit(0)
+            else:
+                sys.exit(1)

--- a/avocado/restclient/cli/args/__init__.py
+++ b/avocado/restclient/cli/args/__init__.py
@@ -1,0 +1,13 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2015
+# Author: Cleber Rosa <cleber@redhat.com>

--- a/avocado/restclient/cli/args/base.py
+++ b/avocado/restclient/cli/args/base.py
@@ -1,0 +1,61 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2015
+# Author: Cleber Rosa <cleber@redhat.com>
+
+"""
+This module has base action arguments that are used on other top level commands
+
+These top level commands import these definitions for uniformity and
+consistency sake
+"""
+
+__all__ = ['ADD', 'LIST_BRIEF', 'LIST_FULL', 'DELETE', 'NAME', 'ID']
+
+
+#
+# Arguments that are treated as actions
+#
+ADD = (('-a', '--add',),
+       {'help': 'add a new entry',
+        'action': 'store_true',
+        'default': False})
+
+
+LIST_BRIEF = (('-l', '--list-brief',),
+              {'help': 'list all records briefly',
+               'action': 'store_true',
+               'default': False})
+
+
+LIST_FULL = (('-L', '--list-full',),
+             {'help': 'list all records with all information',
+              'action': 'store_true',
+              'default': False})
+
+
+DELETE = (('-d', '--delete',),
+          {'help': 'delete an existing object',
+           'action': 'store_true',
+           'default': False})
+
+
+#
+# Other arguments that will influence action behaviour
+#
+NAME = (('-n', '--name'),
+        {'help': 'name of the object'})
+
+
+ID = (('-i', '--id'),
+      {'help': 'numeric identification of the object',
+       'type': int})

--- a/avocado/restclient/cli/args/server.py
+++ b/avocado/restclient/cli/args/server.py
@@ -1,0 +1,42 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2015
+# Author: Cleber Rosa <cleber@redhat.com>
+
+"""
+This module has actions for the server command
+"""
+
+from avocado.restclient.cli.args import base
+
+
+__all__ = ['ACTION_STATUS', 'ACTION_ARGUMENTS', 'ARGUMENTS']
+
+
+#
+# Arguments that are treated as actions
+#
+ACTION_STATUS = (('-s', '--status',),
+                 {'help': 'shows the avocado-server status',
+                  'action': 'store_true',
+                  'default': False})
+
+#
+# Arguments that are treated as actions
+#
+ACTION_ARGUMENTS = [base.LIST_BRIEF,
+                    ACTION_STATUS]
+
+#
+# Other arguments that will influence action behaviour
+#
+ARGUMENTS = []

--- a/avocado/restclient/cli/parser.py
+++ b/avocado/restclient/cli/parser.py
@@ -1,0 +1,128 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2013-2015 Red Hat
+# Author: Cleber Rosa <cleber@redhat.com>
+
+"""
+REST client application command line parsing
+"""
+
+import os
+import glob
+import argparse
+import importlib
+
+from avocado.version import VERSION
+
+
+class Parser(argparse.ArgumentParser):
+
+    '''
+    The main CLI Argument Parser.
+    '''
+
+    def __init__(self, **kwargs):
+        '''
+        Initializes a new parser
+        '''
+        super(Parser, self).__init__(
+            description='Avocado Rest Client %s' % VERSION,
+            **kwargs
+        )
+
+        self._subparsers = None
+        self._add_global_arguments()
+
+    def _add_global_arguments(self):
+        '''
+        Add global arguments, that is, do not depend on a specifc command
+        '''
+        connection_group = self.add_argument_group(
+            'CONNECTION',
+            'Set connection options to an Avocado Server')
+
+        connection_group.add_argument(
+            '--hostname',
+            help='Hostname or IP address for the avocado server',
+            default='localhost')
+
+        connection_group.add_argument(
+            '--port',
+            help='Port where avocado server is listening on',
+            default=9405)
+
+        connection_group.add_argument(
+            '--username',
+            help='Username to authenticate to avocado server')
+
+        connection_group.add_argument(
+            '--password',
+            help='Password to give to avocado server')
+
+    def add_arguments_on_all_modules(self,
+                                     prefix='avocado.restclient.cli.args'):
+        '''
+        Add arguments that are present on all Python modules at a given prefix
+
+        :param prefix: a Python module namespace
+        '''
+        blacklist = ('base', '__init__')
+        basemod = importlib.import_module(prefix)
+        basemod_dir = os.path.dirname(basemod.__file__)
+
+        # FIXME: This works for CPython and IronPython, but not for Jython
+        mod_files_pattern = os.path.join(basemod_dir, "*.py")
+        mod_files = glob.glob(mod_files_pattern)
+        mod_names_with_suffix = [os.path.basename(f) for f in mod_files]
+        mod_names = [n.replace(".py", "")
+                     for n in mod_names_with_suffix]
+        mod_names = [n for n in mod_names if n not in blacklist]
+
+        for module in mod_names:
+            self.add_arguments_on_module(module, prefix)
+
+    def add_arguments_on_module(self, name, prefix):
+        '''
+        Add arguments that are present on a given Python module
+
+        :param name: the name of the Python module, without the namespace
+        '''
+        if self._subparsers is None:
+            self._subparsers = self.add_subparsers(
+                prog='avocado-rest-client',
+                title='Top Level Command',
+                dest='top_level_action'
+            )
+
+        module_name = "%s.%s" % (prefix, name)
+        module = importlib.import_module(module_name)
+
+        parser = self._subparsers.add_parser(name)
+
+        if hasattr(module, 'ACTION_ARGUMENTS'):
+            if module.ACTION_ARGUMENTS:
+                act_grp = parser.add_argument_group("ACTION",
+                                                    "Action to be performed")
+                act_excl = act_grp.add_mutually_exclusive_group(required=True)
+
+                for action in module.ACTION_ARGUMENTS:
+                    act_excl.add_argument(*action[0], **action[1])
+
+        if hasattr(module, 'ARGUMENTS'):
+            if module.ARGUMENTS:
+                for arg in module.ARGUMENTS:
+                    # Support either both short+long options or either one, short OR long
+                    short_and_or_long_opts = arg[0]
+                    if len(short_and_or_long_opts) == 1:
+                        parser.add_argument(arg[0][0], **arg[1])
+                    else:
+                        parser.add_argument(*arg[0], **arg[1])

--- a/avocado/restclient/connection.py
+++ b/avocado/restclient/connection.py
@@ -1,0 +1,211 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2015
+# Author: Cleber Rosa <cleber@redhat.com>
+
+"""
+This module provides connection classes the avocado server.
+
+A connection is a simple wrapper around a HTTP request instance. It is this
+basic object that allows methods to be called on the remote server.
+"""
+
+import requests
+
+from avocado.settings import settings
+
+
+__all__ = ['get_default', 'Connection']
+
+
+#: Minimum required version of server side API
+MIN_REQUIRED_VERSION = (0, 1, 0)
+
+
+class InvalidConnectionError(Exception):
+
+    """
+    Invalid connection for selected server
+    """
+    pass
+
+
+class InvalidServerVersionError(Exception):
+
+    """
+    The server version does not satisfy the minimum required version
+    """
+    pass
+
+
+class UnexpectedHttpStatusCode(Exception):
+
+    """
+    Server has returned a response with a status code different than expected
+    """
+
+    def __init__(self, expected, received):
+        self.expected = expected
+        self.received = received
+
+    def __str__(self):
+        msg = "Unexpected HTTP response status: expected %s, received %s"
+        return msg % (self.expected, self.received)
+
+
+class Connection(object):
+
+    """
+    Connection to the avocado server
+    """
+
+    def __init__(self, hostname=None, port=None, username=None, password=None):
+        """
+        Initializes a connection to an avocado-server instance
+
+        :param hostname: the hostname or IP address to connect to
+        :type hostname: str
+        :param port: the port number where avocado-server is running
+        :type port: int
+        :param username: the name of the user to be authenticated as
+        :type username: str
+        :param password: the password to use for authentication
+        :type password: str
+        """
+        if hostname is None:
+            hostname = settings.get_value('restclient.connection',
+                                          'hostname', default='localhost')
+        self.hostname = hostname
+
+        if port is None:
+            port = settings.get_value('restclient.connection',
+                                      'port', key_type='int',
+                                      default=9405)
+        self.port = port
+
+        if username is None:
+            username = settings.get_value('restclient.connection',
+                                          'username', default='')
+        self.username = username
+
+        if password is None:
+            password = settings.get_value('restclient.connection',
+                                          'password', default='')
+        self.password = password
+
+        try:
+            version = self.request('version')
+        except:
+            raise InvalidConnectionError
+
+        if not self.check_min_version(version):
+            raise InvalidServerVersionError
+
+    def get_url(self, path=None):
+        """
+        Returns a representation of the current connection as an HTTP URL
+        """
+        if path is None:
+            return 'http://%s:%s' % (self.hostname, self.port)
+
+        return 'http://%s:%s/%s' % (self.hostname, self.port, path)
+
+    def request(self, path, method=requests.get, check_status=True, **data):
+        """
+        Performs a request to the server
+
+        This method is heavily used by upper level API methods, and more often
+        than not, those upper level API methods should be used instead.
+
+        :param path: the path on the server where the resource lives
+        :type path: str
+        :param method: the method you want to call on the remote server,
+                       defaults to a HTTP GET
+        :param check_status: wether to check the HTTP status code that comes
+                             with the response. If set to `True`, it will
+                             depend on the method chosen. If set to `False`,
+                             no check will be performed. If an integer is given
+                             then that specific status will be checked for.
+        :param data: keyword arguments to be passed to the remote method
+        :returns: JSON data
+        """
+        url = self.get_url(path)
+
+        if self.username and self.password:
+            response = method(url,
+                              auth=(self.username, self.password),
+                              params=data)
+        else:
+            response = method(url, params=data)
+
+        want_status = None
+        if check_status is True:
+            if method == requests.get:
+                want_status = 200
+            elif method == requests.post:
+                want_status = 201
+            elif method == requests.delete:
+                want_status = 204
+
+        if want_status is not None:
+            if response.status_code != want_status:
+                raise UnexpectedHttpStatusCode(want_status,
+                                               response.status_code)
+
+        return response.json()
+
+    def check_min_version(self, data=None):
+        """
+        Checks the minimum server version
+        """
+        if data is None:
+            response = self.request('version')
+            version = response.get('version')
+            if version is None:
+                return False
+        else:
+            version = data.get('version')
+
+        major, minor, release = version.split('.', 3)
+        version = (int(major), int(minor), int(release))
+        return MIN_REQUIRED_VERSION >= version
+
+    def ping(self):
+        """
+        Tests connectivity to the currently set avocado-server
+
+        This is intentionally a simple method that will only return True if a
+        request is made, and a response is received from the server.
+        """
+        try:
+            self.request('version')
+        except:
+            return False
+        return True
+
+
+#: Global, default connection for ease of use by apps
+CONNECTION = None
+
+
+def get_default():
+    """
+    Returns the global, default connection to avocado-server
+
+    :returns: an avocado.restclient.connection.Connection instance
+    """
+    global CONNECTION
+
+    if CONNECTION is None:
+        CONNECTION = Connection()
+
+    return CONNECTION

--- a/avocado/restclient/connection.py
+++ b/avocado/restclient/connection.py
@@ -28,7 +28,7 @@ __all__ = ['get_default', 'Connection']
 
 
 #: Minimum required version of server side API
-MIN_REQUIRED_VERSION = (0, 1, 0)
+MIN_REQUIRED_VERSION = (0, 2, 0)
 
 
 class InvalidConnectionError(Exception):
@@ -191,6 +191,12 @@ class Connection(object):
         except:
             return False
         return True
+
+    def get_api_list(self):
+        """
+        Gets the list of APIs the server makes availble to the current user
+        """
+        return self.request('')
 
 
 #: Global, default connection for ease of use by apps

--- a/avocado/restclient/response.py
+++ b/avocado/restclient/response.py
@@ -1,0 +1,98 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2015
+# Author: Cleber Rosa <cleber@redhat.com>
+
+"""
+Module with base model functions to manipulate JSON data
+"""
+
+import json
+
+
+class InvalidJSONError(Exception):
+
+    """
+    Data given to a loader/decoder is not valid JSON
+    """
+    pass
+
+
+class InvalidResultResponseError(Exception):
+
+    """
+    Returned result response does not conform to expectation
+
+    Even though the result may be a valid json, it may not have the required
+    or expected information that would normally be sent by avocado-server.
+    """
+    pass
+
+
+class BaseResponse(object):
+
+    """
+    Base class that provides commonly used features for response handling
+    """
+
+    REQUIRED_DATA = []
+
+    def __init__(self, json_data):
+        self._json_data = json_data
+        self._data = None
+        self._load_data()
+
+    def _parse_data(self):
+        try:
+            self._data = json.loads(self._json_data)
+        except ValueError:
+            raise InvalidJSONError(self._json_data)
+
+    def _load_data(self):
+        self._parse_data()
+
+        if self.REQUIRED_DATA:
+            missing_data = []
+            for data_member in self.REQUIRED_DATA:
+                if data_member not in self._data:
+                    missing_data.append(data_member)
+            if missing_data:
+                missing = ", ".join(missing_data)
+                msg = "data member(s) missing from response: %s" % missing
+                raise InvalidResultResponseError(msg)
+
+
+class ResultResponse(BaseResponse):
+
+    """
+    Provides a wrapper around an ideal result response
+
+    This class should be instantiated with the JSON data received from an
+    avocado-server, and will check if the required data members are present
+    and thus the response is well formed.
+    """
+
+    REQUIRED_DATA = ['count', 'next', 'previous', 'results']
+
+    def __init__(self, json_data):
+        self.count = 0
+        self.next = None
+        self.previous = None
+        self.results = []
+        super(ResultResponse, self).__init__(json_data)
+
+    def _load_data(self):
+        super(ResultResponse, self)._load_data()
+        self.count = self._data.get('count')
+        self.next = self._data.get('next')
+        self.previous = self._data.get('previous')
+        self.results = self._data.get('results')

--- a/etc/avocado/avocado.conf
+++ b/etc/avocado/avocado.conf
@@ -6,3 +6,9 @@ logs_dir = ~/avocado/job-results
 
 [sysinfo.collect]
 installed_packages = False
+
+[restclient.connection]
+hostname = localhost
+port = 9405
+username =
+password =

--- a/examples/api/restclient/api.py
+++ b/examples/api/restclient/api.py
@@ -1,0 +1,8 @@
+# Copyright: Red Hat Inc. 2015
+# Author: Cleber Rosa <cleber@redhat.com>
+
+from avocado.restclient import connection
+from avocado.restclient import response
+
+c = connection.get_default()
+print(c.get_api_list())

--- a/examples/api/restclient/ping.py
+++ b/examples/api/restclient/ping.py
@@ -1,0 +1,10 @@
+# Copyright: Red Hat Inc. 2015
+# Author: Cleber Rosa <cleber@redhat.com>
+
+from avocado.restclient import connection
+
+c = connection.get_default()
+if c.ping():
+    print("ping: Success")
+else:
+    print("ping: Failure")

--- a/examples/api/restclient/request.py
+++ b/examples/api/restclient/request.py
@@ -1,0 +1,7 @@
+# Copyright: Red Hat Inc. 2015
+# Author: Cleber Rosa <cleber@redhat.com>
+
+from avocado.restclient import connection
+
+c = connection.get_default()
+print(c.request("version"))

--- a/man/avocado-rest-client.rst
+++ b/man/avocado-rest-client.rst
@@ -36,6 +36,18 @@ on them being loaded::
  --username USERNAME  Username to authenticate to avocado server
  --password PASSWORD  Password to give to avocado server
 
+Real use of avocado depends on running avocado subcommands. This the current list
+of subcommands::
+
+   server             inspects the server status and available functionality
+
+To get usage instructions for a given subcommand, run it with `--help`. Example::
+
+ $ avocado-rest-client server --help
+
+  -l, --list-brief     list all records briefly
+  -s, --status         shows the avocado-server status
+
 FILES
 =====
 

--- a/man/avocado-rest-client.rst
+++ b/man/avocado-rest-client.rst
@@ -1,0 +1,72 @@
+:title: avocado-rest-client
+:subtitle: REST client command line tool
+:title_upper: AVOCADO
+:manual_section: 1
+
+SYNOPSIS
+========
+
+avocado-rest-client [-h] [--hostname HOSTNAME] [--port PORT] [--username USERNAME] [--password PASSWORD]
+
+DESCRIPTION
+===========
+
+Avocado is a modern test framework that is built on the experience
+accumulated with `autotest` (`http://autotest.github.io`).
+
+`avocado-rest-client` is the name of the command line tool that interacts
+with `avocado-server`.
+
+`avocado-server` (`http://github.com/avocado-framework/avocado-server`)
+is an HTTP server that provides an REST API for results job results and
+other features.
+
+For more information about the Avocado project, please check its website:
+http://avocado-framework.github.io/
+
+OPTIONS
+=======
+
+The following list of options are builtin, application level `avocado-rest-client`
+options. Most other options are implemented via plugins and will depend
+on them being loaded::
+
+ --hostname HOSTNAME  Hostname or IP address for the avocado server
+ --port PORT          Port where avocado server is listening on
+ --username USERNAME  Username to authenticate to avocado server
+ --password PASSWORD  Password to give to avocado server
+
+FILES
+=====
+
+::
+
+ /etc/avocado/avocado.conf
+    system wide configuration file
+
+BUGS
+====
+
+If you find a bug, please report it over our github page as an issue.
+
+LICENSE
+================
+
+Avocado is released under GPLv2 (explicit version)
+`http://gnu.org/licenses/gpl-2.0.html`. Even though most of the current code is
+licensed under a "and any later version" clause, some parts are specifically
+bound to the version 2 of the license and therefore that's the official license
+of the prject itself. For more details, please see the LICENSE file in the
+project source code directory.
+
+MORE INFORMATION
+================
+
+For more information please check Avocado's project website, located at
+`http://avocado-framework.github.io/`. There you'll find links to online
+documentation, source code and community resources.
+
+AUTHOR
+======
+
+Avocado Development Team <avocado-devel@redhat.com>

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -5,3 +5,4 @@ pystache==0.5.4
 Sphinx==1.3b1
 flexmock==0.9.7
 inspektor==0.1.12
+requests==1.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ libvirt-python>=1.2.9
 pyliblzma>=0.5.3
 # HTML report plugin (avocado.plugins.htmlresult)
 pystache>=0.5.3
+# REST client (avocado.restclient)
+requests>=1.2.3

--- a/scripts/avocado-rest-client
+++ b/scripts/avocado-rest-client
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2015
+# Author: Cleber Rosa <cleber@redhat.com>
+
+
+import os
+import sys
+
+# simple magic for using scripts within a source tree
+basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if os.path.isdir(os.path.join(basedir, 'avocado')):
+    sys.path.append(basedir)
+
+from avocado.restclient.cli.app import App
+
+if __name__ == '__main__':
+    app = App()
+    sys.exit(app.run())

--- a/selftests/all/unit/avocado/restclient_response_unittest.py
+++ b/selftests/all/unit/avocado/restclient_response_unittest.py
@@ -1,0 +1,66 @@
+import os
+import sys
+import unittest
+
+# simple magic for using scripts within a source tree
+basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+basedir = os.path.dirname(basedir)
+if os.path.isdir(os.path.join(basedir, 'avocado')):
+    sys.path.append(basedir)
+
+from avocado.restclient import response
+
+
+class ResultResponseTest(unittest.TestCase):
+
+    GOOD_DATA = ('{"count": 1, "next": null, "previous": null, '
+                 '"results": [ { "name": "unknown" } ] }')
+
+    BAD_DATA_JSON = '{"count": 1'
+
+    BAD_DATA_COUNT = ('{"counter": 1, "next": null, "previous": null, '
+                      '"results": [ { "name": "unknown" } ] }')
+
+    BAD_DATA_NEXT = ('{"count": 1, "NEXT": null, "previous": null, '
+                     '"results": [ { "name": "unknown" } ] }')
+
+    BAD_DATA_PREVIOUS = ('{"count": 1, "next": null, "prev": null, '
+                         '"results": [ { "name": "unknown" } ] }')
+
+    BAD_DATA_RESULTS = '{"count": 1, "next": null, "prev": null}'
+
+    def test_good_data(self):
+        r = response.ResultResponse(self.GOOD_DATA)
+        self.assertEquals(r.count, 1)
+
+    def test_bad_data_json(self):
+        self.assertRaises(response.InvalidJSONError,
+                          response.ResultResponse,
+                          self.BAD_DATA_JSON)
+
+    def test_bad_data_empty(self):
+        self.assertRaises(response.InvalidJSONError,
+                          response.ResultResponse, '')
+
+    def test_bad_data_count(self):
+        self.assertRaises(response.InvalidResultResponseError,
+                          response.ResultResponse,
+                          self.BAD_DATA_COUNT)
+
+    def test_bad_data_next(self):
+        self.assertRaises(response.InvalidResultResponseError,
+                          response.ResultResponse,
+                          self.BAD_DATA_NEXT)
+
+    def test_bad_data_previous(self):
+        self.assertRaises(response.InvalidResultResponseError,
+                          response.ResultResponse,
+                          self.BAD_DATA_PREVIOUS)
+
+    def test_bad_data_results(self):
+        self.assertRaises(response.InvalidResultResponseError,
+                          response.ResultResponse,
+                          self.BAD_DATA_RESULTS)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,15 @@ def get_wrappers_dir():
         return settings_system_wide
 
 
+def get_api_dir():
+    settings_system_wide = os.path.join('/usr', 'share', 'avocado', 'api')
+    settings_local_install = 'api'
+    if 'VIRTUAL_ENV' in os.environ:
+        return settings_local_install
+    else:
+        return settings_system_wide
+
+
 def get_data_files():
     data_files = [(get_settings_dir(), ['etc/avocado/avocado.conf'])]
     data_files += [(os.path.join(get_settings_dir(), 'conf.d'), ['etc/avocado/conf.d/README'])]
@@ -68,6 +77,7 @@ def get_data_files():
             data_files += [(os.path.join(get_tests_dir(), os.path.basename(data_dir)), [f])]
     data_files.append((get_docs_dir(), ['man/avocado.rst']))
     data_files += [(get_wrappers_dir(), glob.glob('examples/wrappers/*.sh'))]
+    data_files += [(get_api_dir(), glob.glob('examples/api/*/*.py'))]
     return data_files
 
 
@@ -102,7 +112,8 @@ if __name__ == '__main__':
                     'avocado.external',
                     'avocado.linux',
                     'avocado.utils',
-                    'avocado.plugins'],
+                    'avocado.plugins',
+                    'avocado.restclient'],
           package_data={'avocado.plugins': _get_plugin_resource_files(
               'avocado/plugins/resources')},
           data_files=get_data_files(),

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ def get_data_files():
         fmt_str = '%s/*' % data_dir
         for f in glob.glob(fmt_str):
             data_files += [(os.path.join(get_tests_dir(), os.path.basename(data_dir)), [f])]
-    data_files.append((get_docs_dir(), ['man/avocado.rst']))
+    data_files.append((get_docs_dir(), ['man/avocado.rst', 'man/avocado-rest-client.rst']))
     data_files += [(get_wrappers_dir(), glob.glob('examples/wrappers/*.sh'))]
     data_files += [(get_api_dir(), glob.glob('examples/api/*/*.py'))]
     return data_files
@@ -113,8 +113,11 @@ if __name__ == '__main__':
                     'avocado.linux',
                     'avocado.utils',
                     'avocado.plugins',
-                    'avocado.restclient'],
+                    'avocado.restclient',
+                    'avocado.restclient.cli',
+                    'avocado.restclient.cli.args'],
           package_data={'avocado.plugins': _get_plugin_resource_files(
               'avocado/plugins/resources')},
           data_files=get_data_files(),
-          scripts=['scripts/avocado'])
+          scripts=['scripts/avocado',
+                   'scripts/avocado-rest-client'])


### PR DESCRIPTION
Introduce REST client API modules, allowing scripts that interact with `avocado-server` easier to write, and also a command line `avocado-rest-client` application.

This work is derived from experience and code from the Autotest RPC Client (https://github.com/autotest/arc).