### PR TITLE
Functional tests: add tests for behavior on bad command line arguments

### DIFF
--- a/avocado/job.py
+++ b/avocado/job.py
@@ -221,9 +221,6 @@ class Job(object):
                 if url.startswith(os.path.pardir):
                     url = os.path.abspath(url)
                 params_list.append({'id': url})
-        else:
-            e_msg = "Empty test ID. A test path or alias must be provided"
-            raise exceptions.OptionValidationError(e_msg)
 
         if multiplex_files is None:
             if self.args and self.args.multiplex_files is not None:

--- a/avocado/plugins/runner.py
+++ b/avocado/plugins/runner.py
@@ -45,7 +45,7 @@ class TestRunner(plugin.Plugin):
             'run',
             help='Run one or more tests (native test, test alias, binary or script)')
 
-        self.parser.add_argument('url', type=str, default=[], nargs='*',
+        self.parser.add_argument('url', type=str, default=[], nargs='+',
                                  help='List of test IDs (aliases or paths)')
 
         self.parser.add_argument('-z', '--archive', action='store_true', default=False,

--- a/selftests/all/functional/avocado/argument_parsing_tests.py
+++ b/selftests/all/functional/avocado/argument_parsing_tests.py
@@ -1,0 +1,79 @@
+import os
+import re
+import sys
+import glob
+import unittest
+
+# simple magic for using scripts within a source tree
+basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..', '..', '..')
+basedir = os.path.abspath(basedir)
+if os.path.isdir(os.path.join(basedir, 'avocado')):
+    sys.path.append(basedir)
+
+from avocado.core import job_id
+from avocado.utils import process
+
+
+class ArgumentParsingTest(unittest.TestCase):
+
+    def test_unknown_command(self):
+        os.chdir(basedir)
+        cmd_line = './scripts/avocado whacky-command-that-doesnt-exist'
+        result = process.run(cmd_line, ignore_status=True)
+        expected_rc = 2
+        self.assertEqual(result.exit_status, expected_rc,
+                         'Avocado did not return rc %d:\n%s' % (expected_rc, result))
+
+    def test_known_command_bad_choice(self):
+        os.chdir(basedir)
+        cmd_line = './scripts/avocado run --sysinfo=foo passtest'
+        result = process.run(cmd_line, ignore_status=True)
+        expected_rc = 2
+        self.assertEqual(result.exit_status, expected_rc,
+                         'Avocado did not return rc %d:\n%s' % (expected_rc, result))
+
+    def test_known_command_bad_argument(self):
+        os.chdir(basedir)
+        cmd_line = './scripts/avocado run --whacky-argument passtest'
+        result = process.run(cmd_line, ignore_status=True)
+        expected_rc = 2
+        self.assertEqual(result.exit_status, expected_rc,
+                         'Avocado did not return rc %d:\n%s' % (expected_rc, result))
+
+
+class ArgumentParsingErrorEarlyTest(unittest.TestCase):
+
+    def get_log_dir(self):
+        os.chdir(basedir)
+        config = process.system_output('./scripts/avocado config --datadir')
+        for line in config.split('\n'):
+            match = re.match(r'\s*logs\s*(.*)', line)
+            if match:
+                return match.groups()[0]
+        return None
+
+    def run_but_fail_before_create_job_dir(self, complement_args):
+        """
+        Runs avocado but checks that it fails before creating the job dir
+
+        :param complement_args: the complement arguments to an 'avocado run'
+                                command line
+        """
+        os.chdir(basedir)
+        log_dir = self.get_log_dir()
+        self.assertIsNotNone(log_dir)
+        job = job_id.create_unique_job_id()
+        cmd_line = './scripts/avocado run --force-job-id=%s %s'
+        cmd_line %= (job, complement_args)
+        result = process.run(cmd_line, ignore_status=True)
+        expected_rc = 2
+        self.assertEqual(result.exit_status, expected_rc,
+                         'Avocado did not return rc %d:\n%s' % (expected_rc, result))
+        path_job_glob = os.path.join(log_dir, "job-*-%s" % job[0:7])
+        self.assertEquals(glob.glob(path_job_glob), [])
+
+    def test_whacky_option(self):
+        self.run_but_fail_before_create_job_dir('--whacky-option passtest')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/selftests/all/functional/avocado/argument_parsing_tests.py
+++ b/selftests/all/functional/avocado/argument_parsing_tests.py
@@ -75,5 +75,8 @@ class ArgumentParsingErrorEarlyTest(unittest.TestCase):
     def test_whacky_option(self):
         self.run_but_fail_before_create_job_dir('--whacky-option passtest')
 
+    def test_empty_option(self):
+        self.run_but_fail_before_create_job_dir('')
+
 if __name__ == '__main__':
     unittest.main()

--- a/selftests/all/functional/avocado/basic_tests.py
+++ b/selftests/all/functional/avocado/basic_tests.py
@@ -159,11 +159,9 @@ class RunnerOperationTest(unittest.TestCase):
         cmd_line = './scripts/avocado run --sysinfo=off'
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 2
-        expected_output = 'Empty test ID. A test path or alias must be provided'
-        expected_output_2 = 'usage:'
+        expected_output = 'too few arguments'
         self.assertEqual(result.exit_status, expected_rc)
-        self.assertIn(expected_output, result.stdout)
-        self.assertIn(expected_output_2, result.stdout)
+        self.assertIn(expected_output, result.stderr)
 
     def test_not_found(self):
         os.chdir(basedir)


### PR DESCRIPTION
Some obvious, but AFAICT not yet existing tests, that check if when
using bad command line arguments, avocado exists with a proper status
code.

Also, a more complex command line behavior test that checks if avocado
errors out early, before it creates the job result directory.

Signed-off-by: Cleber Rosa <crosa@redhat.com>