### PR TITLE
Better handling of docs/build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ clean:
 	rm -rf build/ MANIFEST BUILD BUILDROOT SPECS RPMS SRPMS SOURCES
 	find . -name '*.pyc' -delete
 	rm -f man/avocado.1
+	rm -rf docs/build
 
 check:
 	selftests/checkall

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -39,7 +39,7 @@ help:
 	@echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
 
 clean:
-	-rm -rf $(BUILDDIR)/*
+	-rm -rf $(BUILDDIR)
 
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html


### PR DESCRIPTION
docs/build is currently present in the git repository, but I see no reason for it. Removing it results in a couple of cleanups.