### PR TITLE
avocado.plugins.wrapper: Don't activate when not enabled

### DIFF
--- a/avocado/plugins/wrapper.py
+++ b/avocado/plugins/wrapper.py
@@ -35,8 +35,10 @@ class Wrapper(plugin.Plugin):
         self.configured = True
 
     def activate(self, app_args):
-        view = output.View(app_args=app_args)
         try:
+            if not app_args.wrapper:    # Not enabled
+                return
+            view = output.View(app_args=app_args)
             for wrap in app_args.wrapper:
                 if ':' not in wrap:
                     if runtime.WRAP_PROCESS is None:


### PR DESCRIPTION
When no wrappers are activated this plugin still checks for
the compatibility with --gdb. Skip activate when no --wrapper set.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>