### PR TITLE
Introduce sysinfo profilers (journalctl & vmstat) [V4]

### DIFF
--- a/avocado/plugins/htmlresult.py
+++ b/avocado/plugins/htmlresult.py
@@ -220,26 +220,21 @@ class HTMLTestResult(TestResult):
         template = html.get_resource_path('templates', 'report.mustache')
         report_contents = renderer.render(open(template, 'r').read(), context)
         static_basedir = html.get_resource_path('static')
-        if self.output == '-':
-            self.view.notify(event='error', msg="HTML to stdout not supported "
-                                                "(not all HTML resources can be embedded to a single file)")
-            sys.exit(exit_codes.AVOCADO_JOB_FAIL)
-        else:
-            output_dir = os.path.dirname(os.path.abspath(self.output))
-            if not os.path.exists(output_dir):
-                os.makedirs(output_dir)
-            for resource_dir in os.listdir(static_basedir):
-                res_dir = os.path.join(static_basedir, resource_dir)
-                out_dir = os.path.join(output_dir, resource_dir)
-                if os.path.exists(out_dir):
-                    shutil.rmtree(out_dir)
-                shutil.copytree(res_dir, out_dir)
-            with codecs.open(self.output, 'w', 'utf-8') as report_file:
-                report_file.write(report_contents)
+        output_dir = os.path.dirname(os.path.abspath(self.output))
+        if not os.path.exists(output_dir):
+            os.makedirs(output_dir)
+        for resource_dir in os.listdir(static_basedir):
+            res_dir = os.path.join(static_basedir, resource_dir)
+            out_dir = os.path.join(output_dir, resource_dir)
+            if os.path.exists(out_dir):
+                shutil.rmtree(out_dir)
+            shutil.copytree(res_dir, out_dir)
+        with codecs.open(self.output, 'w', 'utf-8') as report_file:
+            report_file.write(report_contents)
 
-            if self.args is not None:
-                if getattr(self.args, 'open_browser'):
-                    webbrowser.open(self.output)
+        if self.args is not None:
+            if getattr(self.args, 'open_browser'):
+                webbrowser.open(self.output)
 
 
 class HTML(plugin.Plugin):
@@ -280,6 +275,13 @@ class HTML(plugin.Plugin):
     def activate(self, app_args):
         try:
             if app_args.html_output:
-                self.parser.application.set_defaults(html_result=HTMLTestResult)
+                if app_args.html_output == '-':
+                    view = output.View(app_args=app_args)
+                    view.notify(event='error',
+                                msg="HTML to stdout not supported "
+                                    "(not all HTML resources can be embedded to a single file)")
+                    sys.exit(exit_codes.AVOCADO_JOB_FAIL)
+                else:
+                    self.parser.application.set_defaults(html_result=HTMLTestResult)
         except AttributeError:
             pass

--- a/avocado/sysinfo.py
+++ b/avocado/sysinfo.py
@@ -208,13 +208,12 @@ class Command(Loggable):
             env["PATH"] = "/usr/bin:/bin"
         logf_path = os.path.join(logdir, self.logf)
         stdin = open(os.devnull, "r")
-        stderr = open(os.devnull, "w")
         stdout = open(logf_path, "w")
         try:
             subprocess.call(self.cmd, stdin=stdin, stdout=stdout,
-                            stderr=stderr, shell=True, env=env)
+                            stderr=subprocess.STDOUT, shell=True, env=env)
         finally:
-            for f in (stdin, stdout, stderr):
+            for f in (stdin, stdout):
                 f.close()
             if self._compress_log and os.path.exists(logf_path):
                 utils.process.run('gzip -9 "%s"' % logf_path,

--- a/avocado/sysinfo.py
+++ b/avocado/sysinfo.py
@@ -47,7 +47,8 @@ _DEFAULT_COMMANDS_START_JOB = ["df -mP",
                                "numactl --hardware show",
                                "lscpu",
                                "fdisk -l"]
-_DEFAULT_COMMANDS_END_JOB = []
+
+_DEFAULT_COMMANDS_END_JOB = _DEFAULT_COMMANDS_START_JOB
 
 _DEFAULT_FILES_START_JOB = ["/proc/cmdline",
                             "/proc/mounts",
@@ -63,7 +64,7 @@ _DEFAULT_FILES_START_JOB = ["/proc/cmdline",
                             "/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor",
                             "/sys/devices/system/clocksource/clocksource0/current_clocksource"]
 
-_DEFAULT_FILES_END_JOB = []
+_DEFAULT_FILES_END_JOB = _DEFAULT_FILES_START_JOB
 
 _DEFAULT_COMMANDS_START_TEST = []
 
@@ -496,7 +497,7 @@ class SysInfo(object):
 
     def start_job_hook(self):
         """
-        Logging hook called whenever a job starts, and again after reboot.
+        Logging hook called whenever a job starts.
         """
         for log in self.start_job_loggables:
             log.run(pre_dir)
@@ -506,9 +507,11 @@ class SysInfo(object):
 
     def end_job_hook(self):
         """
-        Logging hook called whenever a job starts, and again after reboot.
+        Logging hook called whenever a job finishes.
         """
-        post_dir = utils.path.init_dir(self.basedir, 'post')
+        for log in self.end_job_loggables:
+            log.run(self.post_dir)
+        # Stop daemon(s) started previously
         for log in self.start_job_loggables:
             log.run(post_dir)
 
@@ -566,4 +569,5 @@ def collect_sysinfo(args):
 
     sysinfo_logger = SysInfo(basedir=basedir, log_packages=True)
     sysinfo_logger.start_job_hook()
+    sysinfo_logger.end_job_hook()
     log.info("Logged system information to %s", basedir)

--- a/avocado/sysinfo.py
+++ b/avocado/sysinfo.py
@@ -364,6 +364,10 @@ class SysInfo(object):
                              'start_iteration': self.start_iteration_loggables,
                              'end_iteration': self.end_iteration_loggables}
 
+        self.pre_dir = utils.path.init_dir(self.basedir, 'pre')
+        self.post_dir = utils.path.init_dir(self.basedir, 'post')
+        self.profile_dir = utils.path.init_dir(self.basedir, 'profile')
+
         self._set_loggables()
 
     def _get_syslog_watcher(self):
@@ -494,12 +498,11 @@ class SysInfo(object):
         """
         Logging hook called whenever a job starts, and again after reboot.
         """
-        pre_dir = utils.path.init_dir(self.basedir, 'pre')
         for log in self.start_job_loggables:
             log.run(pre_dir)
 
         if self.log_packages:
-            self._log_installed_packages(pre_dir)
+            self._log_installed_packages(self.pre_dir)
 
     def end_job_hook(self):
         """
@@ -510,45 +513,41 @@ class SysInfo(object):
             log.run(post_dir)
 
         if self.log_packages:
-            self._log_modified_packages(post_dir)
+            self._log_modified_packages(self.post_dir)
 
     def start_test_hook(self):
         """
         Logging hook called before a test starts.
         """
-        pre_dir = utils.path.init_dir(self.basedir, 'pre')
         for log in self.start_test_loggables:
-            log.run(pre_dir)
+            log.run(self.pre_dir)
 
         if self.log_packages:
-            self._log_installed_packages(pre_dir)
+            self._log_installed_packages(self.pre_dir)
 
     def end_test_hook(self):
         """
         Logging hook called after a test finishes.
         """
-        post_dir = utils.path.init_dir(self.basedir, 'post')
         for log in self.end_test_loggables:
-            log.run(post_dir)
+            log.run(self.post_dir)
 
         if self.log_packages:
-            self._log_modified_packages(post_dir)
+            self._log_modified_packages(self.post_dir)
 
     def start_iteration_hook(self):
         """
         Logging hook called before a test iteration
         """
-        pre_dir = utils.path.init_dir(self.basedir, 'pre')
         for log in self.start_iteration_loggables:
-            log.run(pre_dir)
+            log.run(self.pre_dir)
 
     def end_iteration_hook(self, test, iteration=None):
         """
         Logging hook called after a test iteration
         """
-        post_dir = utils.path.init_dir(self.basedir, 'post')
         for log in self.end_iteration_loggables:
-            log.run(post_dir)
+            log.run(self.post_dir)
 
 
 def collect_sysinfo(args):

--- a/etc/avocado/avocado.conf
+++ b/etc/avocado/avocado.conf
@@ -7,3 +7,5 @@ logs_dir = ~/avocado/job-results
 [sysinfo.collect]
 enabled = True
 installed_packages = False
+profiler = False
+profiler_commands = vmstat 1:journalctl -f

--- a/selftests/all/functional/avocado/multiplex_tests.py
+++ b/selftests/all/functional/avocado/multiplex_tests.py
@@ -41,7 +41,7 @@ class MultiplexTests(unittest.TestCase):
                                     'The multiplexed job log output has less '
                                     'lines than expected\n%s' %
                                     "".join(job_log_lines))
-            self.assertLess(lines_output, expected_lines * 1.1,
+            self.assertLess(lines_output, expected_lines * 1.2,
                             'The multiplexed job log output has more '
                             'lines than expected\n%s'
                             % "".join(job_log_lines))

--- a/selftests/all/unit/avocado/sysinfo_unittest.py
+++ b/selftests/all/unit/avocado/sysinfo_unittest.py
@@ -60,8 +60,8 @@ class SysinfoTest(unittest.TestCase):
         sysinfo_logger = sysinfo.SysInfo(basedir=jobdir)
         sysinfo_logger.start_job_hook()
         self.assertTrue(os.path.isdir(jobdir))
-        self.assertEqual(len(os.listdir(jobdir)), 1,
-                         "Job does not have 'pre' dir")
+        self.assertGreaterEqual(len(os.listdir(jobdir)), 1,
+                                "Job does not have 'pre' dir")
         job_predir = os.path.join(jobdir, 'pre')
         self.assertTrue(os.path.isdir(job_predir))
         self.assertGreater(len(os.listdir(job_predir)), 0,
@@ -77,16 +77,16 @@ class SysinfoTest(unittest.TestCase):
         sysinfo_logger = sysinfo.SysInfo(basedir=testdir)
         sysinfo_logger.start_test_hook()
         self.assertTrue(os.path.isdir(testdir))
-        self.assertEqual(len(os.listdir(testdir)), 1,
-                         "Test does not have 'pre' dir")
+        self.assertGreaterEqual(len(os.listdir(testdir)), 1,
+                                "Test does not have 'pre' dir")
         test_predir = os.path.join(testdir, 'pre')
         self.assertTrue(os.path.isdir(test_predir))
         # By default, there are no pre test files
         self.assertEqual(len(os.listdir(test_predir)), 0,
                          "Test pre dir is not empty")
         sysinfo_logger.end_test_hook()
-        self.assertEqual(len(os.listdir(testdir)), 2,
-                         "Test does not have 'pre' dir")
+        self.assertGreaterEqual(len(os.listdir(testdir)), 2,
+                                "Test does not have 'pre' dir")
         job_postdir = os.path.join(testdir, 'post')
         self.assertTrue(os.path.isdir(job_postdir))
         # By default, there are no post test files


### PR DESCRIPTION
Follow up of PR #373 

---

Changes:

* New option `profilers` in class Sysinfo. This is a string to contain the command line options for the profilers (like the configuration option `profiler_commands`). Remove `profiler` option, which was just a On/Off option.
* Define .stop() just for the Daemon class, remove from the other classes.
* Apply recommendations from @clebergnu and @adereis  about `.strip()`, documentation and order of commits.
* Rebased code from the upstream.