### PR TITLE
Job standalone mode

### DIFF
--- a/avocado/aexpect.py
+++ b/avocado/aexpect.py
@@ -15,6 +15,8 @@ import tempfile
 import logging
 import shutil
 
+from avocado.utils import path as utils_path
+
 BASE_DIR = os.environ.get('TMPDIR', '/tmp')
 # If you want to debug problems with your aexpect instances, setting
 # DEBUG = True will leave the temporary files created by aexpect around
@@ -527,7 +529,7 @@ class Spawn(object):
 
         # Define filenames for communication with server
         try:
-            os.makedirs(base_dir)
+            utils_path.init_dir(base_dir)
         except Exception:
             pass
         (self.shell_pid_filename,

--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -34,7 +34,7 @@ import time
 import tempfile
 
 from avocado.core import job_id
-from avocado.utils import path
+from avocado.utils import path as utils_path
 from avocado.utils.data_structures import Borg
 from avocado.settings import settings
 
@@ -81,7 +81,7 @@ def _usable_rw_dir(directory):
             pass
     else:
         try:
-            os.makedirs(directory)
+            utils_path.init_dir(directory)
             return True
         except OSError:
             pass
@@ -108,7 +108,7 @@ def _usable_ro_dir(directory):
             pass
     else:
         try:
-            os.makedirs(directory)
+            utils_path.init_dir(directory)
             return True
         except OSError:
             pass
@@ -223,7 +223,7 @@ def get_job_logs_dir(args=None, unique_id=None):
         unique_id = job_id.create_unique_job_id()
 
     debugbase = 'job-%s-%s' % (start_time, unique_id[:7])
-    debugdir = path.init_dir(logdir, debugbase)
+    debugdir = utils_path.init_dir(logdir, debugbase)
     latestdir = os.path.join(logdir, "latest")
     try:
         os.unlink(latestdir)

--- a/avocado/plugins/htmlresult.py
+++ b/avocado/plugins/htmlresult.py
@@ -28,6 +28,7 @@ from avocado.core import exit_codes
 from avocado.core import output
 from avocado.plugins import plugin
 from avocado.result import TestResult
+from avocado.utils import path as utils_path
 
 
 class ReportModel(object):
@@ -226,8 +227,7 @@ class HTMLTestResult(TestResult):
             sys.exit(exit_codes.AVOCADO_JOB_FAIL)
         else:
             output_dir = os.path.dirname(os.path.abspath(self.output))
-            if not os.path.exists(output_dir):
-                os.makedirs(output_dir)
+            utils_path.init_dir(output_dir)
             for resource_dir in os.listdir(static_basedir):
                 res_dir = os.path.join(static_basedir, resource_dir)
                 out_dir = os.path.join(output_dir, resource_dir)

--- a/avocado/test.py
+++ b/avocado/test.py
@@ -28,7 +28,7 @@ import unittest
 from avocado.core import data_dir
 from avocado.core import exceptions
 from avocado.utils import io
-from avocado.utils import path
+from avocado.utils import path as utils_path
 from avocado.utils import process
 from avocado.utils import stacktrace
 from avocado.utils.params import Params
@@ -90,8 +90,8 @@ class Test(unittest.TestCase):
         self.expected_stderr_file = os.path.join(self.datadir,
                                                  'stderr.expected')
 
-        self.workdir = path.init_dir(tmpdir, basename)
-        self.srcdir = path.init_dir(self.workdir, 'src')
+        self.workdir = utils_path.init_dir(tmpdir, basename)
+        self.srcdir = utils_path.init_dir(self.workdir, 'src')
         if base_logdir is None:
             base_logdir = data_dir.get_job_logs_dir()
         base_logdir = os.path.join(base_logdir, 'test-results')
@@ -103,15 +103,15 @@ class Test(unittest.TestCase):
         if tagged_name.startswith('/'):
             tagged_name = tagged_name[1:]
 
-        self.logdir = path.init_dir(base_logdir, tagged_name)
+        self.logdir = utils_path.init_dir(base_logdir, tagged_name)
         io.set_log_file_dir(self.logdir)
         self.logfile = os.path.join(self.logdir, 'debug.log')
 
         self.stdout_file = os.path.join(self.logdir, 'stdout')
         self.stderr_file = os.path.join(self.logdir, 'stderr')
 
-        self.outputdir = path.init_dir(self.logdir, 'data')
-        self.sysinfodir = path.init_dir(self.logdir, 'sysinfo')
+        self.outputdir = utils_path.init_dir(self.logdir, 'data')
+        self.sysinfodir = utils_path.init_dir(self.logdir, 'sysinfo')
         self.sysinfo_logger = sysinfo.SysInfo(basedir=self.sysinfodir)
 
         self.log = logging.getLogger("avocado.test")
@@ -339,13 +339,11 @@ class Test(unittest.TestCase):
         pass
 
     def record_reference_stdout(self):
-        if not os.path.isdir(self.datadir):
-            os.makedirs(self.datadir)
+        utils_path.init_dir(self.datadir)
         shutil.copyfile(self.stdout_file, self.expected_stdout_file)
 
     def record_reference_stderr(self):
-        if not os.path.isdir(self.datadir):
-            os.makedirs(self.datadir)
+        utils_path.init_dir(self.datadir)
         shutil.copyfile(self.stderr_file, self.expected_stderr_file)
 
     def check_reference_stdout(self):

--- a/avocado/utils/io.py
+++ b/avocado/utils/io.py
@@ -20,8 +20,7 @@ import logging
 import os
 import time
 
-from avocado.utils import path as apath
-
+from avocado.utils import path as utils_path
 
 log = logging.getLogger('avocado.test')
 
@@ -40,13 +39,13 @@ def log_line(filename, line):
     """
     global _open_log_files, _log_file_dir
 
-    path = apath.get_path(_log_file_dir, filename)
+    path = utils_path.get_path(_log_file_dir, filename)
     if path not in _open_log_files:
         # First, let's close the log files opened in old directories
         close_log_file(filename)
         # Then, let's open the new file
         try:
-            os.makedirs(os.path.dirname(path))
+            utils_path.init_dir(os.path.dirname(path))
         except OSError:
             pass
         _open_log_files[path] = open(path, "w")

--- a/avocado/utils/script.py
+++ b/avocado/utils/script.py
@@ -20,6 +20,8 @@ import os
 import tempfile
 import shutil
 
+from avocado.utils import path as utils_path
+
 
 class Script(object):
 
@@ -64,8 +66,8 @@ class Script(object):
 
         :return: `True` if script has been stored, otherwise `False`.
         """
-        if not os.path.isdir(os.path.dirname(self.path)):
-            os.makedirs(os.path.dirname(self.path))
+        dirname = os.path.dirname(self.path)
+        utils_path.init_dir(dirname)
         with open(self.path, 'w') as fd:
             fd.write(self.content)
             os.chmod(self.path, self.mode)


### PR DESCRIPTION
The idea of the standalone mode is to be able to have a avocado test to behave like a regular script, outputing to STDOUT the basic log (the same as --show-job-log would) and return an meaningful status code). This should help avocado tests to be run along any other test code or framework.
    
In this mode, a job will still be created, and the basic output files will also be created, but will be hidden from the user, and removed after the job finishes running.
    
This is a partial solution to the so called "jobless" mode, which would allow a test to run without a job.

Also, an initially related, now unrelated commit, that unifies the usage of directory creation on our code base.