### PR TITLE
avocado.utils.process.find_command(): move from avocado.utils.process to avocado.utils.path

### DIFF
--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -19,7 +19,7 @@ import logging
 import os
 import sys
 
-from avocado.utils import process
+from avocado.utils import path as utils_path
 
 
 class ProgressStreamHandler(logging.StreamHandler):
@@ -59,8 +59,8 @@ class Paginator(object):
 
     def __init__(self):
         try:
-            paginator = "%s -FRSX" % process.find_command('less')
-        except process.CmdNotFoundError:
+            paginator = "%s -FRSX" % utils_path.find_command('less')
+        except utils_path.CmdNotFoundError:
             paginator = None
 
         paginator = os.environ.get('PAGER', paginator)

--- a/avocado/linux/software_manager.py
+++ b/avocado/linux/software_manager.py
@@ -50,6 +50,7 @@ from avocado.utils import process
 from avocado.utils import data_factory
 from avocado.linux import distro
 from avocado.core import exceptions
+from avocado.utils import path as utils_path
 
 log = logging.getLogger('avocado.test')
 
@@ -81,9 +82,9 @@ class SystemInspector(object):
         list_supported = []
         for high_level_pm in SUPPORTED_PACKAGE_MANAGERS:
             try:
-                process.find_command(high_level_pm)
+                utils_path.find_command(high_level_pm)
                 list_supported.append(high_level_pm)
-            except process.CmdNotFoundError:
+            except utils_path.CmdNotFoundError:
                 pass
 
         pm_supported = None
@@ -184,7 +185,7 @@ class RpmBackend(BaseBackend):
         '%{NAME} %{VERSION} %{RELEASE} %{SIGMD5} %{ARCH}')
 
     def __init__(self):
-        self.lowlevel_base_cmd = process.find_command('rpm')
+        self.lowlevel_base_cmd = utils_path.find_command('rpm')
 
     def _check_installed_version(self, name, version):
         """
@@ -290,7 +291,7 @@ class DpkgBackend(BaseBackend):
     INSTALLED_OUTPUT = 'install ok installed'
 
     def __init__(self):
-        self.lowlevel_base_cmd = process.find_command('dpkg')
+        self.lowlevel_base_cmd = utils_path.find_command('dpkg')
 
     def check_installed(self, name):
         if os.path.isfile(name):
@@ -350,7 +351,7 @@ class YumBackend(RpmBackend):
         Initializes the base command and the yum package repository.
         """
         super(YumBackend, self).__init__()
-        executable = process.find_command('yum')
+        executable = utils_path.find_command('yum')
         base_arguments = '-y'
         self.base_command = executable + ' ' + base_arguments
         self.repo_file_path = '/etc/yum.repos.d/avocado-managed.repo'
@@ -496,7 +497,7 @@ class ZypperBackend(RpmBackend):
         Initializes the base command and the yum package repository.
         """
         super(ZypperBackend, self).__init__()
-        self.base_command = process.find_command('zypper') + ' -n'
+        self.base_command = utils_path.find_command('zypper') + ' -n'
         z_cmd = self.base_command + ' --version'
         cmd_result = process.run(z_cmd, ignore_status=True,
                                  verbose=False)
@@ -623,7 +624,7 @@ class AptBackend(DpkgBackend):
         Initializes the base command and the debian package repository.
         """
         super(AptBackend, self).__init__()
-        executable = process.find_command('apt-get')
+        executable = utils_path.find_command('apt-get')
         self.base_command = executable + ' -y'
         self.repo_file_path = '/etc/apt/sources.list.d/avocado.list'
         cmd_result = process.run('apt-get -v | head -1',
@@ -736,10 +737,10 @@ class AptBackend(DpkgBackend):
         :param path: File path.
         """
         try:
-            command = process.find_command('apt-file')
-        except process.CmdNotFoundError:
+            command = utils_path.find_command('apt-file')
+        except utils_path.CmdNotFoundError:
             self.install('apt-file')
-            command = process.find_command('apt-file')
+            command = utils_path.find_command('apt-file')
 
         cache_update_cmd = command + ' update'
         try:

--- a/avocado/linux/software_manager.py
+++ b/avocado/linux/software_manager.py
@@ -737,7 +737,7 @@ class AptBackend(DpkgBackend):
         """
         try:
             command = process.find_command('apt-file')
-        except ValueError:
+        except process.CmdNotFoundError:
             self.install('apt-file')
             command = process.find_command('apt-file')
 

--- a/avocado/plugins/distro.py
+++ b/avocado/plugins/distro.py
@@ -21,6 +21,7 @@ from avocado.core import output
 from avocado.core import exit_codes
 from avocado.plugins import plugin
 from avocado.utils import process
+from avocado.utils import path as utils_path
 from avocado.linux import distro as distro_utils
 
 
@@ -168,9 +169,9 @@ class DistroPkgInfoLoaderRpm(DistroPkgInfoLoader):
     def __init__(self, path):
         super(DistroPkgInfoLoaderRpm, self).__init__(path)
         try:
-            process.find_command('rpm')
+            utils_path.find_command('rpm')
             self.capable = True
-        except process.CmdNotFoundError:
+        except utils_path.CmdNotFoundError:
             self.capable = False
 
     def is_software_package(self, path):
@@ -198,9 +199,9 @@ class DistroPkgInfoLoaderDeb(DistroPkgInfoLoader):
     def __init__(self, path):
         super(DistroPkgInfoLoaderDeb, self).__init__(path)
         try:
-            process.find_command('dpkg-deb')
+            utils_path.find_command('dpkg-deb')
             self.capable = True
-        except process.CmdNotFoundError:
+        except utils_path.CmdNotFoundError:
             self.capable = False
 
     def is_software_package(self, path):

--- a/avocado/plugins/gdb.py
+++ b/avocado/plugins/gdb.py
@@ -16,6 +16,7 @@
 
 from avocado import runtime
 from avocado.utils import process
+from avocado.utils import path as utils_path
 from avocado.plugins import plugin
 
 
@@ -54,8 +55,8 @@ class GDB(plugin.Plugin):
 
         default_gdb_path = '/usr/bin/gdb'
         try:
-            system_gdb_path = process.find_command('gdb')
-        except process.CmdNotFoundError:
+            system_gdb_path = utils_path.find_command('gdb')
+        except utils_path.CmdNotFoundError:
             system_gdb_path = default_gdb_path
         gdb_grp.add_argument('--gdb-path',
                              default=system_gdb_path, metavar='PATH',
@@ -65,8 +66,8 @@ class GDB(plugin.Plugin):
 
         default_gdbserver_path = '/usr/bin/gdbserver'
         try:
-            system_gdbserver_path = process.find_command('gdbserver')
-        except process.CmdNotFoundError:
+            system_gdbserver_path = utils_path.find_command('gdbserver')
+        except utils_path.CmdNotFoundError:
             system_gdbserver_path = default_gdbserver_path
         gdb_grp.add_argument('--gdbserver-path',
                              default=system_gdbserver_path, metavar='PATH',

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -43,25 +43,6 @@ stdout_log = logging.getLogger('avocado.test.stdout')
 stderr_log = logging.getLogger('avocado.test.stderr')
 
 
-class CmdNotFoundError(Exception):
-
-    """
-    Indicates that the command was not found in the system after a search.
-
-    :param cmd: String with the command.
-    :param paths: List of paths where we looked after.
-    """
-
-    def __init__(self, cmd, paths):
-        super(CmdNotFoundError, self)
-        self.cmd = cmd
-        self.paths = paths
-
-    def __str__(self):
-        return ("Command '%s' could not be found in any of the PATH dirs: %s" %
-                (self.cmd, self.paths))
-
-
 class GDBInferiorProcessExitedError(exceptions.TestNAError):
 
     """
@@ -74,30 +55,6 @@ class GDBInferiorProcessExitedError(exceptions.TestNAError):
     test will be skipped.
     """
     pass
-
-
-def find_command(cmd):
-    """
-    Try to find a command in the PATH, paranoid version.
-
-    :param cmd: Command to be found.
-    :raise: :class:`avocado.utils.process.CmdNotFoundError` in case the
-            command was not found.
-    """
-    common_bin_paths = ["/usr/libexec", "/usr/local/sbin", "/usr/local/bin",
-                        "/usr/sbin", "/usr/bin", "/sbin", "/bin"]
-    try:
-        path_paths = os.environ['PATH'].split(":")
-    except IndexError:
-        path_paths = []
-    path_paths = list(set(common_bin_paths + path_paths))
-
-    for dir_path in path_paths:
-        cmd_path = os.path.join(dir_path, cmd)
-        if os.path.isfile(cmd_path):
-            return os.path.abspath(cmd_path)
-
-    raise CmdNotFoundError(cmd, path_paths)
 
 
 def pid_exists(pid):

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,10 +10,11 @@ root_path = os.path.abspath(os.path.join("..", ".."))
 sys.path.insert(0, root_path)
 
 import avocado.version
+from avocado.utils import path
 from avocado.utils import process
 
 # Auto generate API documentation
-_sphinx_apidoc = process.find_command('sphinx-apidoc')
+_sphinx_apidoc = path.find_command('sphinx-apidoc')
 _output_dir = os.path.join(root_path, 'docs', 'source', 'api')
 _api_dir = os.path.join(root_path, 'avocado')
 process.run("%s -o %s %s" % (_sphinx_apidoc, _output_dir, _api_dir))


### PR DESCRIPTION
The reasons for the proposed move include:

1) Even though `find_command()` looks for executables, it doesn't really try to execute them as a living process.
2) The implementation looks for it in a `$PATH` like list, so, out of a possibly better choice, `avocado.utils.path` was chosen.
3) Other modules can use that functionality, but not the execution of process.
4) Avoid circular dependencies: this is actually the first motivation of the proposed change, and a true story with the GDB plugin/test. Since `avocado.utils.process` depends on `avocado.gdb`, this module can not use `find_command()` to look for `gdb`/`gdbserver` binaries.

Also, included is a fix to `software_manager.py` that was found in the process.