### PR TITLE
avocado.plugins.runner: Don't create job result directory if runner's option is empty.

### DIFF
--- a/avocado/plugins/runner.py
+++ b/avocado/plugins/runner.py
@@ -126,6 +126,10 @@ class TestRunner(plugin.Plugin):
         :param args: Command line args received from the run subparser.
         """
         view = output.View(app_args=args)
+        if not args.url:
+            self.parser.print_help()
+            view.notify(event='error', msg='Empty test ID. A test path or alias must be provided')
+            return exit_codes.AVOCADO_FAIL
         if args.unique_job_id is not None:
             try:
                 int(args.unique_job_id, 16)
@@ -133,11 +137,8 @@ class TestRunner(plugin.Plugin):
                     raise ValueError
             except ValueError:
                 view.notify(event='error', msg='Unique Job ID needs to be a 40 digit hex number')
-                return sys.exit(exit_codes.AVOCADO_FAIL)
+                return exit_codes.AVOCADO_FAIL
 
         job_instance = job.Job(args)
         rc = job_instance.run()
-        if not args.url:
-            self.parser.print_help()
-
         return rc

--- a/selftests/all/functional/avocado/basic_tests.py
+++ b/selftests/all/functional/avocado/basic_tests.py
@@ -158,7 +158,7 @@ class RunnerOperationTest(unittest.TestCase):
         os.chdir(basedir)
         cmd_line = './scripts/avocado run --sysinfo=off'
         result = process.run(cmd_line, ignore_status=True)
-        expected_rc = 2
+        expected_rc = 3
         expected_output = 'Empty test ID. A test path or alias must be provided'
         expected_output_2 = 'usage:'
         self.assertEqual(result.exit_status, expected_rc)

--- a/selftests/all/functional/avocado/multiplex_tests.py
+++ b/selftests/all/functional/avocado/multiplex_tests.py
@@ -70,7 +70,7 @@ class MultiplexTests(unittest.TestCase):
 
     def test_run_mplex_noid(self):
         cmd_line = './scripts/avocado run --sysinfo=off --multiplex examples/tests/sleeptest.py.data/sleeptest.yaml'
-        expected_rc = 2
+        expected_rc = 3
         self.run_and_check(cmd_line, expected_rc)
 
     def test_run_mplex_passtest(self):


### PR DESCRIPTION
Fix a bug when the runner receives an empty URL, displays help message, but it also creates a job result structure, which doesn't make much sense.
Reference for the bug: https://trello.com/c/Ibl516R0