### PR TITLE
RFC: Use writes to self.log.warn to set the test dirty and add bash utils

### DIFF
--- a/avocado/test.py
+++ b/avocado/test.py
@@ -529,6 +529,10 @@ class SimpleTest(Test):
                                                  'stdout.expected')
         self.expected_stderr_file = os.path.join(self.datadir,
                                                  'stderr.expected')
+        # Simple test might need to write directly to main log
+        if base_logdir is None:
+            base_logdir = self.logdir[:-len(self.name)]
+        os.environ['AVOCADO_TESTSUITE_LOGDIR'] = base_logdir
 
     def _log_detailed_cmd_info(self, result):
         """
@@ -552,6 +556,14 @@ class SimpleTest(Test):
         except exceptions.CmdError, details:
             self._log_detailed_cmd_info(details.result)
             raise exceptions.TestFail(details)
+
+    def runTest(self, result=None):
+        super(SimpleTest, self).runTest(result)
+        for line in open(self.logfile):
+            if line[26:30] == 'WARN':
+                raise exceptions.TestWarn("Test passed but there were warnings"
+                                          "during execution. Check the log for"
+                                          " details.")
 
 
 class MissingTest(Test):

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -477,17 +477,25 @@ the following entities:
 * The test expected stdout
 * The test expected stderr
 
-The first one is used for debugging and informational purposes. The framework
-machinery uses logs to give you more detailed info about your test, so they
-are not the most reliable source to compare stdout/err. You may log something
-into the test logs using the methods in :mod:`avocado.test.Test.log` class
-attributes. Consider
-the example::
+The first one is used for debugging and informational purposes. Additionally
+writing to `self.log.warning` causes test to be marked as dirty and when
+everything else goes well the test ends with WARN. This means that the test
+passed but there were non-related unexpected situations described in warning
+log.
+
+You may log something into the test logs using the methods in
+:mod:`avocado.test.Test.log` class attributes. Consider the example::
 
     class output_test(test.Test):
 
         def action(self):
             self.log.info('This goes to the log and it is only informational')
+            self.log.warn('Oh, something unexpected, non-critical happened, '
+                          'but we can continue.')
+            self.log.error('Describe the error here and don't forget to raise '
+                           'exception yourself. Writing to self.log.error '
+                           'won't do that for you.')
+            self.log.debug('Everybody look, I had a good lunch today...')
 
 If you need to write directly to the test stdout and stderr streams, there
 are another 2 class attributes for that, :mod:`avocado.test.Test.stdout_log`

--- a/examples/tests/warntest.py
+++ b/examples/tests/warntest.py
@@ -15,7 +15,7 @@ class WarnTest(test.Test):
         """
         This should throw a TestWarn.
         """
-        raise exceptions.TestWarn('This should throw a TestWarn')
+        self.log.warn("This marks test as WARN")
 
 if __name__ == "__main__":
     job.main()

--- a/scripts/avocado-bash-utils
+++ b/scripts/avocado-bash-utils
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Avocado BASH utils
+
+# Debug mode...
+[ -z $AVOCADO_TEST_LOGFILE ] && export AVOCADO_TEST_LOGFILE=/dev/stdout
+if [ -z $AVOCADO_TESTSUITE_LOGDIR ]; then
+    export AVOCADO_TESTSUITE_JOBLOG=/dev/null
+else
+    export AVOCADO_TESTSUITE_JOBLOG=$AVOCADO_TESTSUITE_LOGDIR/job.log
+fi
+
+# Write to avocado_log
+# First argument has to be log level
+function avocado_log {
+    LEVEL=`printf '%-5s' $1`
+    shift
+    echo `date '+%H:%M:%S'`" bash             $LEVEL| $*" >> $AVOCADO_TEST_LOGFILE
+    echo `date '+%H:%M:%S'`" bash             $LEVEL| $*" >> $AVOCADO_TESTSUITE_JOBLOG
+}
+
+function avocado_debug { avocado_log DEBUG $*; }
+function avocado_info { avocado_log INFO $*; }
+function avocado_warn { avocado_log WARN $*; }
+function avocado_error { avocado_log ERROR $*; }


### PR DESCRIPTION
Hi guys,

This patch simplifies the concept of WARN test. In case user uses the
self.log.warn or self.log.warning methods, test is marked as dirty and
in case everything else worked fine it finishes with TestWarn exception.

Additionally I added basic support for the same feature for people using simple bash scripts. The second commit is only an example and will be either removed before merging or applied separately when ready. It also shows the way we can help people who prefer bash to use Avocado features. Take it as RFC and not as part of this pull request.

Kind regards,
Lukáš

v0: https://github.com/avocado-framework/avocado/pull/385

Changes:

    v1: Documentation adjustments about "self.log.warn"
    v1: Make "avocado-bash-utils" work without avocado