### PR TITLE
requirements-travis.txt: Require the latest version of inspektor

### DIFF
--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -4,4 +4,4 @@ nose==1.3.4
 pystache==0.5.4
 Sphinx==1.3b1
 flexmock==0.9.7
-inspektor==0.1.12
+inspektor==0.1.14


### PR DESCRIPTION
It'll be necessary so that we can start ignoring error E402
during pylint checking.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>