### PR TITLE
avocado.test: Set the test as WARN when self.log.warn used [v2]

### DIFF
--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -214,8 +214,8 @@ class TreeNode(object):
                                  if self.parent else {})
             for key, value in self.value.iteritems():
                 if isinstance(value, list):
-                    if (key in self._environment
-                            and isinstance(self._environment[key], list)):
+                    if (key in self._environment and
+                            isinstance(self._environment[key], list)):
                         self._environment[key] = self._environment[key] + value
                     else:
                         self._environment[key] = value
@@ -308,8 +308,8 @@ class TreeNode(object):
             if not compact:
                 result.pop()
             (low, high, end) = (mids[0], mids[-1], len(result))
-            prefixes = ([pad] * (low + 1) + [_pad + '|'] * (high - low - 1)
-                        + [pad] * (end - high))
+            prefixes = ([pad] * (low + 1) + [_pad + '|'] * (high - low - 1) +
+                        [pad] * (end - high))
             mid = (low + high) / 2
             prefixes[mid] = char1 + '-' * (length - 2) + prefixes[mid][-1]
             result = [p + l for (p, l) in zip(prefixes, result)]

--- a/avocado/linux/software_manager.py
+++ b/avocado/linux/software_manager.py
@@ -298,8 +298,8 @@ class DpkgBackend(BaseBackend):
             n_cmd = (self.lowlevel_base_cmd + ' -f ' + name +
                      ' Package 2>/dev/null')
             name = process.system_output(n_cmd)
-        i_cmd = (self.lowlevel_base_cmd + "--show -f='${Status}' "
-                 + name + ' 2>/dev/null')
+        i_cmd = (self.lowlevel_base_cmd + "--show -f='${Status}' " +
+                 name + ' 2>/dev/null')
         # Checking if package is installed
         package_status = process.system_output(i_cmd, ignore_status=True)
         dpkg_not_installed = (package_status != self.INSTALLED_OUTPUT)

--- a/avocado/plugins/remote.py
+++ b/avocado/plugins/remote.py
@@ -213,8 +213,8 @@ class RunRemote(plugin.Plugin):
         :return: True when enable_arg enabled and all required args are set
         :raise sys.exit: When missing required argument.
         """
-        if (not hasattr(app_args, enable_arg)
-                or not getattr(app_args, enable_arg)):
+        if (not hasattr(app_args, enable_arg) or
+                not getattr(app_args, enable_arg)):
             return False
         missing = []
         for arg in required_args:

--- a/avocado/plugins/vm.py
+++ b/avocado/plugins/vm.py
@@ -136,8 +136,8 @@ class RunVM(plugin.Plugin):
         :return: True when enable_arg enabled and all required args are set
         :raise sys.exit: When missing required argument.
         """
-        if (not hasattr(app_args, enable_arg)
-                or not getattr(app_args, enable_arg)):
+        if (not hasattr(app_args, enable_arg) or
+                not getattr(app_args, enable_arg)):
             return False
         missing = []
         for arg in required_args:

--- a/avocado/utils/astring.py
+++ b/avocado/utils/astring.py
@@ -93,8 +93,8 @@ def strip_console_codes(output, custom_codes=None):
     while index < len(output):
         tmp_index = 0
         tmp_word = ""
-        while (len(re.findall("\x1b", tmp_word)) < 2
-               and index + tmp_index < len(output)):
+        while (len(re.findall("\x1b", tmp_word)) < 2 and
+               index + tmp_index < len(output)):
             tmp_word += output[index + tmp_index]
             tmp_index += 1
 

--- a/avocado/utils/debug.py
+++ b/avocado/utils/debug.py
@@ -38,8 +38,8 @@ def measure_duration(func):
             return func(*args, **kwargs)
         finally:
             duration = time.time() - start
-            __MEASURE_DURATION[func] = (__MEASURE_DURATION.get(func, 0)
-                                        + duration)
+            __MEASURE_DURATION[func] = (__MEASURE_DURATION.get(func, 0) +
+                                        duration)
             LOGGER.debug("PERF: %s: (%ss, %ss)", func, duration,
                          __MEASURE_DURATION[func])
     return wrapper

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -477,17 +477,25 @@ the following entities:
 * The test expected stdout
 * The test expected stderr
 
-The first one is used for debugging and informational purposes. The framework
-machinery uses logs to give you more detailed info about your test, so they
-are not the most reliable source to compare stdout/err. You may log something
-into the test logs using the methods in :mod:`avocado.test.Test.log` class
-attributes. Consider
-the example::
+The first one is used for debugging and informational purposes. Additionally
+writing to `self.log.warning` causes test to be marked as dirty and when
+everything else goes well the test ends with WARN. This means that the test
+passed but there were non-related unexpected situations described in warning
+log.
+
+You may log something into the test logs using the methods in
+:mod:`avocado.test.Test.log` class attributes. Consider the example::
 
     class output_test(test.Test):
 
         def action(self):
             self.log.info('This goes to the log and it is only informational')
+            self.log.warn('Oh, something unexpected, non-critical happened, '
+                          'but we can continue.')
+            self.log.error('Describe the error here and don't forget to raise '
+                           'exception yourself. Writing to self.log.error '
+                           'won't do that for you.')
+            self.log.debug('Everybody look, I had a good lunch today...')
 
 If you need to write directly to the test stdout and stderr streams, there
 are another 2 class attributes for that, :mod:`avocado.test.Test.stdout_log`

--- a/examples/tests/warntest.py
+++ b/examples/tests/warntest.py
@@ -15,7 +15,7 @@ class WarnTest(test.Test):
         """
         This should throw a TestWarn.
         """
-        raise exceptions.TestWarn('This should throw a TestWarn')
+        self.log.warn("This marks test as WARN")
 
 if __name__ == "__main__":
     job.main()

--- a/selftests/all/functional/avocado/multiplex_tests.py
+++ b/selftests/all/functional/avocado/multiplex_tests.py
@@ -111,8 +111,8 @@ class MultiplexTests(unittest.TestCase):
         expected_rc = 0
         output = self.run_and_check(cmd_line, expected_rc)
         for msg in ('A', 'ASDFASDF', 'This is very long\nmultiline\ntext.'):
-            msg = ('[stdout] Custom variable: '
-                   + '\n[stdout] '.join(msg.splitlines()))
+            msg = ('[stdout] Custom variable: ' +
+                   '\n[stdout] '.join(msg.splitlines()))
             self.assertIn(msg, output, "Multiplexed variable should produce:"
                           "\n  %s\nwhich is not present in the output:\n  %s"
                           % ("\n  ".join(msg.splitlines()),


### PR DESCRIPTION
This patch simplifies the concept of WARN test. In case user uses the
self.log.warn or self.log.warning methods, test is marked as dirty and
in case everything else worked fine it finishes with TestWarn exception.

v0: https://github.com/avocado-framework/avocado/pull/385
v1: https://github.com/avocado-framework/avocado/pull/419

Changes:

    v1: Documentation adjustments about "self.log.warn"
    v1: Make "avocado-bash-utils" work without avocado
    v2: Remove bash-version RFC to speedup the inclusion