### PR TITLE
PEP8 fixes: W503

### DIFF
--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -214,8 +214,8 @@ class TreeNode(object):
                                  if self.parent else {})
             for key, value in self.value.iteritems():
                 if isinstance(value, list):
-                    if (key in self._environment
-                            and isinstance(self._environment[key], list)):
+                    if (key in self._environment and
+                            isinstance(self._environment[key], list)):
                         self._environment[key] = self._environment[key] + value
                     else:
                         self._environment[key] = value
@@ -308,8 +308,8 @@ class TreeNode(object):
             if not compact:
                 result.pop()
             (low, high, end) = (mids[0], mids[-1], len(result))
-            prefixes = ([pad] * (low + 1) + [_pad + '|'] * (high - low - 1)
-                        + [pad] * (end - high))
+            prefixes = ([pad] * (low + 1) + [_pad + '|'] * (high - low - 1) +
+                        [pad] * (end - high))
             mid = (low + high) / 2
             prefixes[mid] = char1 + '-' * (length - 2) + prefixes[mid][-1]
             result = [p + l for (p, l) in zip(prefixes, result)]

--- a/avocado/linux/software_manager.py
+++ b/avocado/linux/software_manager.py
@@ -298,8 +298,8 @@ class DpkgBackend(BaseBackend):
             n_cmd = (self.lowlevel_base_cmd + ' -f ' + name +
                      ' Package 2>/dev/null')
             name = process.system_output(n_cmd)
-        i_cmd = (self.lowlevel_base_cmd + "--show -f='${Status}' "
-                 + name + ' 2>/dev/null')
+        i_cmd = (self.lowlevel_base_cmd + "--show -f='${Status}' " +
+                 name + ' 2>/dev/null')
         # Checking if package is installed
         package_status = process.system_output(i_cmd, ignore_status=True)
         dpkg_not_installed = (package_status != self.INSTALLED_OUTPUT)

--- a/avocado/plugins/remote.py
+++ b/avocado/plugins/remote.py
@@ -213,8 +213,8 @@ class RunRemote(plugin.Plugin):
         :return: True when enable_arg enabled and all required args are set
         :raise sys.exit: When missing required argument.
         """
-        if (not hasattr(app_args, enable_arg)
-                or not getattr(app_args, enable_arg)):
+        if (not hasattr(app_args, enable_arg) or
+                not getattr(app_args, enable_arg)):
             return False
         missing = []
         for arg in required_args:

--- a/avocado/plugins/vm.py
+++ b/avocado/plugins/vm.py
@@ -136,8 +136,8 @@ class RunVM(plugin.Plugin):
         :return: True when enable_arg enabled and all required args are set
         :raise sys.exit: When missing required argument.
         """
-        if (not hasattr(app_args, enable_arg)
-                or not getattr(app_args, enable_arg)):
+        if (not hasattr(app_args, enable_arg) or
+                not getattr(app_args, enable_arg)):
             return False
         missing = []
         for arg in required_args:

--- a/avocado/utils/astring.py
+++ b/avocado/utils/astring.py
@@ -93,8 +93,8 @@ def strip_console_codes(output, custom_codes=None):
     while index < len(output):
         tmp_index = 0
         tmp_word = ""
-        while (len(re.findall("\x1b", tmp_word)) < 2
-               and index + tmp_index < len(output)):
+        while (len(re.findall("\x1b", tmp_word)) < 2 and
+               index + tmp_index < len(output)):
             tmp_word += output[index + tmp_index]
             tmp_index += 1
 

--- a/avocado/utils/debug.py
+++ b/avocado/utils/debug.py
@@ -38,8 +38,8 @@ def measure_duration(func):
             return func(*args, **kwargs)
         finally:
             duration = time.time() - start
-            __MEASURE_DURATION[func] = (__MEASURE_DURATION.get(func, 0)
-                                        + duration)
+            __MEASURE_DURATION[func] = (__MEASURE_DURATION.get(func, 0) +
+                                        duration)
             LOGGER.debug("PERF: %s: (%ss, %ss)", func, duration,
                          __MEASURE_DURATION[func])
     return wrapper

--- a/selftests/all/functional/avocado/multiplex_tests.py
+++ b/selftests/all/functional/avocado/multiplex_tests.py
@@ -111,8 +111,8 @@ class MultiplexTests(unittest.TestCase):
         expected_rc = 0
         output = self.run_and_check(cmd_line, expected_rc)
         for msg in ('A', 'ASDFASDF', 'This is very long\nmultiline\ntext.'):
-            msg = ('[stdout] Custom variable: '
-                   + '\n[stdout] '.join(msg.splitlines()))
+            msg = ('[stdout] Custom variable: ' +
+                   '\n[stdout] '.join(msg.splitlines()))
             self.assertIn(msg, output, "Multiplexed variable should produce:"
                           "\n  %s\nwhich is not present in the output:\n  %s"
                           % ("\n  ".join(msg.splitlines()),


### PR DESCRIPTION
The new pep8 adds W503 line break before %s check. This is mass style
update of avocado framework without any actual changes.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>