### PR TITLE
Argument parsing job result bugs [V3]

### DIFF
--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -207,8 +207,6 @@ def get_job_logs_dir(args=None, unique_id=None):
     """
     Create a log directory for a job, or a stand alone execution of a test.
 
-    Also, symlink the created dir with [avocado-logs-dir]/latest.
-
     :param args: :class:`argparse.Namespace` instance with cmdline arguments
                  (optional).
     :rtype: basestring
@@ -224,13 +222,23 @@ def get_job_logs_dir(args=None, unique_id=None):
 
     debugbase = 'job-%s-%s' % (start_time, unique_id[:7])
     debugdir = utils_path.init_dir(logdir, debugbase)
-    latestdir = os.path.join(logdir, "latest")
+    return debugdir
+
+
+def update_latest_job_logs_dir(debugdir):
+    """
+    Update the latest job result symbolic link [avocado-logs-dir]/latest.
+
+    :param debubdir: full path for the current job result.
+    """
+    basedir = os.path.dirname(debugdir)
+    basename = os.path.basename(debugdir)
+    latest = os.path.join(basedir, "latest")
     try:
-        os.unlink(latestdir)
+        os.unlink(latest)
     except OSError:
         pass
-    os.symlink(debugbase, latestdir)
-    return debugdir
+    os.symlink(basename, latest)
 
 
 class _TmpDirTracker(Borg):

--- a/avocado/job.py
+++ b/avocado/job.py
@@ -75,16 +75,8 @@ class Job(object):
             self.unique_id = args.unique_job_id or job_id.create_unique_job_id()
         else:
             self.unique_id = job_id.create_unique_job_id()
-
-        if standalone:
-            self.logdir = tempfile.mkdtemp()
-        else:
-            self.logdir = data_dir.get_job_logs_dir(self.args, self.unique_id)
-        self.logfile = os.path.join(self.logdir, "job.log")
-        self.idfile = os.path.join(self.logdir, "id")
-        with open(self.idfile, 'w') as id_file_obj:
-            id_file_obj.write("%s\n" % self.unique_id)
-
+        self.view = output.View(app_args=self.args)
+        self.logdir = None
         if self.args is not None:
             raw_log_level = args.job_log_level
             mapping = {'info': logging.INFO,
@@ -119,12 +111,29 @@ class Job(object):
         self.test_index = 1
         self.status = "RUNNING"
         self.result_proxy = result.TestResultProxy()
-        self.view = output.View(app_args=self.args)
         self.sysinfo = None
+
+    def _setup_job_results(self):
+        if self.standalone:
+            self.logdir = tempfile.mkdtemp()
+        else:
+            self.logdir = data_dir.get_job_logs_dir(self.args, self.unique_id)
+        self.logfile = os.path.join(self.logdir, "job.log")
+        self.idfile = os.path.join(self.logdir, "id")
+        with open(self.idfile, 'w') as id_file_obj:
+            id_file_obj.write("%s\n" % self.unique_id)
+
+    def _update_lastest_link(self):
+        data_dir.update_latest_job_logs_dir(self.logdir)
+
+    def _start_sysinfo(self):
         if hasattr(self.args, 'sysinfo'):
             if self.args.sysinfo == 'on':
                 sysinfo_dir = path.init_dir(self.logdir, 'sysinfo')
                 self.sysinfo = sysinfo.SysInfo(basedir=sysinfo_dir)
+
+    def _remove_job_results(self):
+        shutil.rmtree(self.logdir, ignore_errors=True)
 
     def _make_test_loader(self):
         if hasattr(self.args, 'test_loader'):
@@ -273,6 +282,8 @@ class Job(object):
             params_list = self._multiplex_params_list(params_list,
                                                       multiplex_files)
 
+        self._setup_job_results()
+
         try:
             test_suite = self.test_loader.discover(params_list)
             error_msg_parts = self.test_loader.validate_ui(test_suite)
@@ -280,6 +291,7 @@ class Job(object):
             raise exceptions.JobError('Command interrupted by user...')
 
         if error_msg_parts:
+            self._remove_job_results()
             e_msg = '\n'.join(error_msg_parts)
             raise exceptions.OptionValidationError(e_msg)
 
@@ -293,6 +305,7 @@ class Job(object):
 
         self._make_test_result()
         self._make_test_runner()
+        self._start_sysinfo()
 
         self.view.start_file_logging(self.logfile,
                                      self.loglevel,
@@ -300,6 +313,7 @@ class Job(object):
         self.view.logfile = self.logfile
         failures = self.test_runner.run_suite(test_suite)
         self.view.stop_file_logging()
+        self._update_lastest_link()
         # If it's all good so far, set job status to 'PASS'
         if self.status == 'RUNNING':
             self.status = 'PASS'

--- a/avocado/plugins/runner.py
+++ b/avocado/plugins/runner.py
@@ -45,7 +45,7 @@ class TestRunner(plugin.Plugin):
             'run',
             help='Run one or more tests (native test, test alias, binary or script)')
 
-        self.parser.add_argument('url', type=str, default=[], nargs='*',
+        self.parser.add_argument('url', type=str, default=[], nargs='+',
                                  help='List of test IDs (aliases or paths)')
 
         self.parser.add_argument('-z', '--archive', action='store_true', default=False,

--- a/selftests/all/functional/avocado/argument_parsing_tests.py
+++ b/selftests/all/functional/avocado/argument_parsing_tests.py
@@ -66,5 +66,8 @@ class ArgumentParsingErrorEarlyTest(unittest.TestCase):
     def test_whacky_option(self):
         self.run_but_fail_before_create_job_dir('--whacky-option passtest')
 
+    def test_empty_option(self):
+        self.run_but_fail_before_create_job_dir('')
+
 if __name__ == '__main__':
     unittest.main()

--- a/selftests/all/functional/avocado/argument_parsing_tests.py
+++ b/selftests/all/functional/avocado/argument_parsing_tests.py
@@ -1,0 +1,70 @@
+import os
+import sys
+import glob
+import unittest
+
+# simple magic for using scripts within a source tree
+basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..', '..', '..')
+basedir = os.path.abspath(basedir)
+if os.path.isdir(os.path.join(basedir, 'avocado')):
+    sys.path.append(basedir)
+
+from avocado.core import job_id
+from avocado.core import data_dir
+from avocado.utils import process
+
+
+class ArgumentParsingTest(unittest.TestCase):
+
+    def test_unknown_command(self):
+        os.chdir(basedir)
+        cmd_line = './scripts/avocado whacky-command-that-doesnt-exist'
+        result = process.run(cmd_line, ignore_status=True)
+        expected_rc = 2
+        self.assertEqual(result.exit_status, expected_rc,
+                         'Avocado did not return rc %d:\n%s' % (expected_rc, result))
+
+    def test_known_command_bad_choice(self):
+        os.chdir(basedir)
+        cmd_line = './scripts/avocado run --sysinfo=foo passtest'
+        result = process.run(cmd_line, ignore_status=True)
+        expected_rc = 2
+        self.assertEqual(result.exit_status, expected_rc,
+                         'Avocado did not return rc %d:\n%s' % (expected_rc, result))
+
+    def test_known_command_bad_argument(self):
+        os.chdir(basedir)
+        cmd_line = './scripts/avocado run --sysinfo=off --whacky-argument passtest'
+        result = process.run(cmd_line, ignore_status=True)
+        expected_rc = 2
+        self.assertEqual(result.exit_status, expected_rc,
+                         'Avocado did not return rc %d:\n%s' % (expected_rc, result))
+
+
+class ArgumentParsingErrorEarlyTest(unittest.TestCase):
+
+    def run_but_fail_before_create_job_dir(self, complement_args):
+        """
+        Runs avocado but checks that it fails before creating the job dir
+
+        :param complement_args: the complement arguments to an 'avocado run'
+                                command line
+        """
+        os.chdir(basedir)
+        log_dir = data_dir.get_logs_dir()
+        self.assertIsNotNone(log_dir)
+        job = job_id.create_unique_job_id()
+        cmd_line = './scripts/avocado run --sysinfo=off --force-job-id=%s %s'
+        cmd_line %= (job, complement_args)
+        result = process.run(cmd_line, ignore_status=True)
+        expected_rc = 2
+        self.assertEqual(result.exit_status, expected_rc,
+                         'Avocado did not return rc %d:\n%s' % (expected_rc, result))
+        path_job_glob = os.path.join(log_dir, "job-*-%s" % job[0:7])
+        self.assertEquals(glob.glob(path_job_glob), [])
+
+    def test_whacky_option(self):
+        self.run_but_fail_before_create_job_dir('--whacky-option passtest')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/selftests/all/functional/avocado/basic_tests.py
+++ b/selftests/all/functional/avocado/basic_tests.py
@@ -159,11 +159,9 @@ class RunnerOperationTest(unittest.TestCase):
         cmd_line = './scripts/avocado run --sysinfo=off'
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 2
-        expected_output = 'Empty test ID. A test path or alias must be provided'
-        expected_output_2 = 'usage:'
+        expected_output = 'too few arguments'
         self.assertEqual(result.exit_status, expected_rc)
-        self.assertIn(expected_output, result.stdout)
-        self.assertIn(expected_output_2, result.stdout)
+        self.assertIn(expected_output, result.stderr)
 
     def test_not_found(self):
         os.chdir(basedir)


### PR DESCRIPTION
Folllow up of PR #421.

---

Changes:

* selftests..argument_parsing_tests.py: Use the API `avocado.core.data_dir.get_jobs_log_dir()`.
* selftests..argument_parsing_tests.py: Use `--sysinfo=off` when appropriate.
* Rebased code with current master.