### PR TITLE
Documentation: Add section about installing from git repository.

### DIFF
--- a/docs/source/GetStartedGuide.rst
+++ b/docs/source/GetStartedGuide.rst
@@ -37,6 +37,23 @@ performing the following commands::
     sudo apt-get update
     sudo apt-get install avocado
 
+Installing avocado - Git
+========================
+
+To install avocado from the git repository, check this instructions::
+
+    git clone git@github.com:avocado-framework/avocado.git
+    cd avocado
+    sudo python setup.py install
+    sudo yum install -y gcc python-devel python-pip libvirt-devel libyaml-devel
+    sudo pip install -r requirements.txt
+
+Note that `python` and `pip` should point to the Python interpreter version 2.7.x.
+If you're having trouble to install, you can try again and use the command line
+utilities `python2.7` and `pip2.7`.
+
+For Debian users, use `apt-get` to install the proper dependencies that `yum` installs.
+
 Using the avocado test runner
 =============================
 


### PR DESCRIPTION
Add a new section inside the "Getting started guide", about installing Avocado from the git repository with confidence that the dependencies will be installed.