### PR TITLE
scripts.avocado-bash-utils: Add Avocado bash utils [v1]

### DIFF
--- a/avocado/test.py
+++ b/avocado/test.py
@@ -11,6 +11,7 @@
 # This code was inspired in the autotest project,
 # client/shared/test.py
 # Authors: Martin J Bligh <mbligh@google.com>, Andy Whitcroft <apw@shadowen.org>
+import re
 
 """
 Contains the base test implementation, used as a base for the actual
@@ -505,6 +506,9 @@ class SimpleTest(Test):
     Run an arbitrary command that returns either 0 (PASS) or !=0 (FAIL).
     """
 
+    re_avocado_log = re.compile(r'^\d\d:\d\d:\d\d INFO \|'
+                                r' \d\d:\d\d:\d\d WARN \|')
+
     def __init__(self, path, params=None, base_logdir=None, tag=None, job=None):
         self.path = os.path.abspath(path)
         super(SimpleTest, self).__init__(name=path, base_logdir=base_logdir,
@@ -540,6 +544,14 @@ class SimpleTest(Test):
         except exceptions.CmdError, details:
             self._log_detailed_cmd_info(details.result)
             raise exceptions.TestFail(details)
+
+    def runTest(self, result=None):
+        super(SimpleTest, self).runTest(result)
+        for line in open(self.logfile):
+            if self.re_avocado_log.match(line):
+                raise exceptions.TestWarn("Test passed but there were warnings"
+                                          "on stdout during execution. Check "
+                                          "the log for details.")
 
 
 class MissingTest(Test):

--- a/scripts/avocado-bash-utils
+++ b/scripts/avocado-bash-utils
@@ -1,0 +1,25 @@
+#!/bin/bash
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2014
+
+# Write to avocado_log
+# First argument is the log level
+function avocado_log {
+    LEVEL=`printf '%-5s' $1`
+    shift
+    echo "`date '+%H:%M:%S'` $LEVEL| $*"
+}
+
+function avocado_debug { avocado_log DEBUG $*; }
+function avocado_info { avocado_log INFO $*; }
+function avocado_warn { avocado_log WARN $*; }
+function avocado_error { avocado_log ERROR $*; }


### PR DESCRIPTION
FIXME: Missing documentation, initial support

This patch is initial support for people using custom bash scripts
with avocado. They can use "source avocado-bash-utils" to get the
functions into their bash script and utilize them.

This version contain functions to write to Test.log the same way it's
possible from python including failing the test with TestWarn in case
avocado_warn was used.

v0: https://github.com/avocado-framework/avocado/pull/419

    v1: Instead of custom logging to self and whole job logs use stdout
    v1: Simplify the in-bash-log format to "$time $log_level |"
    v1: Use regexp to check "warning" presense (decrease probability of false-warnings)