### PR TITLE
Drop features HTML Report and Multiplexer gracefully.

### DIFF
--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -37,13 +37,18 @@ import collections
 import os
 import re
 
-import yaml
-
-
 try:
-    from yaml import CLoader as Loader
+    import yaml
 except ImportError:
-    from yaml import Loader
+    MULTIPLEX_CAPABLE = False
+else:
+    MULTIPLEX_CAPABLE = True
+
+if MULTIPLEX_CAPABLE:
+    try:
+        from yaml import CLoader as Loader
+    except ImportError:
+        from yaml import Loader
 
 
 # Mapping for yaml flags

--- a/avocado/job.py
+++ b/avocado/job.py
@@ -90,7 +90,8 @@ class Job(object):
                 self.loglevel = mapping[raw_log_level]
             else:
                 self.loglevel = logging.DEBUG
-            self.multiplex_files = args.multiplex_files
+            if multiplexer.MULTIPLEX_CAPABLE:
+                self.multiplex_files = args.multiplex_files
             self.show_job_log = args.show_job_log
             self.silent = args.silent
         else:
@@ -259,13 +260,14 @@ class Job(object):
 
         params_list = self.test_loader.discover_urls(urls)
 
-        if multiplex_files is None:
-            if self.args and self.args.multiplex_files is not None:
-                multiplex_files = self.args.multiplex_files
+        if multiplexer.MULTIPLEX_CAPABLE:
+            if multiplex_files is None:
+                if self.args and self.args.multiplex_files is not None:
+                    multiplex_files = self.args.multiplex_files
 
-        if multiplex_files is not None:
-            params_list = self._multiplex_params_list(params_list,
-                                                      multiplex_files)
+            if multiplex_files is not None:
+                params_list = self._multiplex_params_list(params_list,
+                                                          multiplex_files)
 
         try:
             test_suite = self.test_loader.discover(params_list)

--- a/avocado/job.py
+++ b/avocado/job.py
@@ -40,14 +40,9 @@ from avocado.plugins import jsonresult
 from avocado.plugins import xunit
 from avocado.utils import archive
 from avocado.utils import path
+from avocado.plugins import htmlresult
 
-
-try:
-    from avocado.plugins import htmlresult
-    HTML_REPORT_SUPPORT = True
-except ImportError:
-    HTML_REPORT_SUPPORT = False
-
+HTML_REPORT_SUPPORT = htmlresult.HTML_REPORT_CAPABLE
 _NEW_ISSUE_LINK = 'https://github.com/avocado-framework/avocado/issues/new'
 
 

--- a/avocado/multiplexer.py
+++ b/avocado/multiplexer.py
@@ -23,6 +23,8 @@ import itertools
 
 from avocado.core import tree
 
+MULTIPLEX_CAPABLE = tree.MULTIPLEX_CAPABLE
+
 
 def tree2pools(node, mux=True):
     """

--- a/avocado/plugins/htmlresult.py
+++ b/avocado/plugins/htmlresult.py
@@ -21,7 +21,12 @@ import sys
 import time
 import webbrowser
 
-import pystache
+try:
+    import pystache
+except ImportError:
+    HTML_REPORT_CAPABLE = False
+else:
+    HTML_REPORT_CAPABLE = True
 
 from avocado import runtime
 from avocado.core import exit_codes
@@ -248,6 +253,9 @@ class HTML(plugin.Plugin):
     enabled = True
 
     def configure(self, parser):
+        if HTML_REPORT_CAPABLE is False:
+            self.enabled = False
+            return
         self.parser = parser
         self.parser.runner.add_argument(
             '--html', type=str,

--- a/avocado/plugins/multiplexer.py
+++ b/avocado/plugins/multiplexer.py
@@ -32,6 +32,9 @@ class Multiplexer(plugin.Plugin):
     enabled = True
 
     def configure(self, parser):
+        if multiplexer.MULTIPLEX_CAPABLE is False:
+            self.enabled = False
+            return
         self.parser = parser.subcommands.add_parser(
             'multiplex',
             help='Generate a list of dictionaries with params from a multiplex file')

--- a/avocado/plugins/runner.py
+++ b/avocado/plugins/runner.py
@@ -23,6 +23,7 @@ from avocado.core import exit_codes
 from avocado.plugins import plugin
 from avocado.core import output
 from avocado import job
+from avocado import multiplexer
 
 
 class TestRunner(plugin.Plugin):
@@ -107,13 +108,14 @@ class TestRunner(plugin.Plugin):
                                      'present for the test. '
                                      'Current: False (output check enabled)'))
 
-        mux = self.parser.add_argument_group('multiplex arguments')
-        mux.add_argument('-m', '--multiplex-files', nargs='*', default=None,
-                         help='Path(s) to a avocado multiplex (.yaml) file(s)')
-        mux.add_argument('--filter-only', nargs='*', default=[],
-                         help='Filter only path(s) from multiplexing')
-        mux.add_argument('--filter-out', nargs='*', default=[],
-                         help='Filter out path(s) from multiplexing')
+        if multiplexer.MULTIPLEX_CAPABLE:
+            mux = self.parser.add_argument_group('multiplex arguments')
+            mux.add_argument('-m', '--multiplex-files', nargs='*', default=None,
+                             help='Path(s) to a avocado multiplex (.yaml) file(s)')
+            mux.add_argument('--filter-only', nargs='*', default=[],
+                             help='Filter only path(s) from multiplexing')
+            mux.add_argument('--filter-out', nargs='*', default=[],
+                             help='Filter out path(s) from multiplexing')
 
         super(TestRunner, self).configure(self.parser)
         # Export the test runner parser back to the main parser


### PR DESCRIPTION
Instead of breaking Avocado if some required Python modules is not installed, like PyYAML and pystache, we will now graceful disable these features.

Note that installing Avocado from a package or following the documentation instructions, will bring all the features and dependencies that Avocado supports and needs.
But if the user chooses to not install the above modules, Avocado will work with less features (i.e. without the HTML report and the Multiplexer).