### PR TITLE
A few contributions to examples: bind_cpu0, cabort and raise.

### DIFF
--- a/examples/tests/cabort.py
+++ b/examples/tests/cabort.py
@@ -1,0 +1,44 @@
+#!/usr/bin/python
+
+import os
+
+from avocado import test
+from avocado import job
+from avocado.utils import build
+from avocado.utils import process
+
+
+class CAbort(test.Test):
+
+    """
+    A test that calls C standard lib function abort().
+    """
+
+    default_params = {'source': 'abort.c'}
+
+    def setup(self):
+        """
+        Build 'abort'.
+        """
+        self.cwd = os.getcwd()
+        c_file = self.get_data_path(self.params.source)
+        self.srcdir = os.path.dirname(c_file)
+        build.make(self.srcdir, extra_args='abort')
+
+    def action(self):
+        """
+        Execute 'abort'.
+        """
+        cmd = os.path.join(self.srcdir, 'abort')
+        cmd_result = process.run(cmd)
+        self.log.info(cmd_result)
+
+    def cleanup(self):
+        """
+        Clean up 'abort'.
+        """
+        os.unlink(os.path.join(self.srcdir, 'abort'))
+
+
+if __name__ == "__main__":
+    job.main()

--- a/examples/tests/cabort.py.data/abort.c
+++ b/examples/tests/cabort.py.data/abort.c
@@ -1,0 +1,7 @@
+#include <stdlib.h>
+
+int
+main(void)
+{
+	abort();
+}

--- a/examples/tests/raise.py
+++ b/examples/tests/raise.py
@@ -1,0 +1,45 @@
+#!/usr/bin/python
+
+import os
+
+from avocado import test
+from avocado import job
+from avocado.utils import build
+from avocado.utils import process
+
+
+class Raise(test.Test):
+
+    """
+    A test that calls raise() to signals to itself.
+    """
+
+    default_params = {'source': 'raise.c',
+                      'signal_number': 15}
+
+    def setup(self):
+        """
+        Build 'raise'.
+        """
+        self.cwd = os.getcwd()
+        c_file = self.get_data_path(self.params.source)
+        self.srcdir = os.path.dirname(c_file)
+        build.make(self.srcdir, extra_args='raise')
+
+    def action(self):
+        """
+        Execute 'raise'.
+        """
+        cmd = os.path.join(self.srcdir, 'raise %d' % self.params.signal_number)
+        cmd_result = process.run(cmd)
+        self.log.info(cmd_result)
+
+    def cleanup(self):
+        """
+        Clean up 'raise'.
+        """
+        os.unlink(os.path.join(self.srcdir, 'raise'))
+
+
+if __name__ == "__main__":
+    job.main()

--- a/examples/tests/raise.py.data/raise.c
+++ b/examples/tests/raise.py.data/raise.c
@@ -1,0 +1,18 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <signal.h>
+
+int
+main(int argc, char *argv[])
+{
+	int res;
+
+	if (argc == 1) {
+		printf("Usage: raise SIGNAL_NUMBER\n");
+		return 1;
+	}
+	res = raise(atoi(argv[1]));
+	if (res != 0)
+		perror("raise");
+	return res;
+}

--- a/examples/tests/raise.py.data/raise.yaml
+++ b/examples/tests/raise.py.data/raise.yaml
@@ -1,0 +1,12 @@
+sigterm:
+    signal_number: 2
+sigterm:
+    signal_number: 15
+sigkill:
+    signal_number: 9
+sigquit:
+    signal_number: 3
+sigsegv:
+    signal_number: 11
+invalid:
+    signal_number: 1024

--- a/examples/wrappers/bind_cpu0.sh
+++ b/examples/wrappers/bind_cpu0.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#
+# Bind process to CPU 0.
+#
+
+exec taskset -c 0 "$@"


### PR DESCRIPTION
A few contributions to examples:
* A new wrapper to bind process to CPU 0.
* Two new tests, one to call abort() from C and another to call raise() from C. We can make use of it to check if Avocado is behaving well on signals.