### PR TITLE
avocado.core.output: Errors should go to stderr, not stdout

### DIFF
--- a/avocado/__init__.py
+++ b/avocado/__init__.py
@@ -21,6 +21,14 @@ DEFAULT_LOGGING = {
             'format': '%(message)s',
         },
     },
+    'filters': {
+        'error': {
+            '()': 'avocado.core.output.FilterError',
+            },
+        'info': {
+            '()': 'avocado.core.output.FilterInfo',
+            },
+        },
     'handlers': {
         'null': {
             'level': 'INFO',
@@ -35,8 +43,15 @@ DEFAULT_LOGGING = {
             'level': 'INFO',
             'class': 'avocado.core.output.ProgressStreamHandler',
             'formatter': 'brief',
+            'filters': ['info'],
             'stream': 'ext://sys.stdout',
         },
+        'error': {
+            'level': 'ERROR',
+            'class': 'logging.StreamHandler',
+            'formatter': 'brief',
+            'filters': ['error'],
+            },
         'debug': {
             'level': 'DEBUG',
             'class': 'avocado.core.output.ProgressStreamHandler',
@@ -49,7 +64,7 @@ DEFAULT_LOGGING = {
             'handlers': ['console'],
         },
         'avocado.app': {
-            'handlers': ['app'],
+            'handlers': ['app', 'error'],
             'level': 'INFO',
             'propagate': False,
         },

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -23,6 +23,18 @@ from avocado.utils import path as utils_path
 from avocado.settings import settings
 
 
+class FilterError(logging.Filter):
+
+    def filter(self, record):
+        return record.levelno >= logging.ERROR
+
+
+class FilterInfo(logging.Filter):
+
+    def filter(self, record):
+        return record.levelno == logging.INFO
+
+
 class ProgressStreamHandler(logging.StreamHandler):
 
     """

--- a/selftests/all/functional/avocado/basic_tests.py
+++ b/selftests/all/functional/avocado/basic_tests.py
@@ -169,19 +169,19 @@ class RunnerOperationTest(unittest.TestCase):
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 2
         self.assertEqual(result.exit_status, expected_rc)
-        self.assertIn('File not found', result.stdout)
+        self.assertIn('File not found', result.stderr)
 
     def test_invalid_unique_id(self):
         cmd_line = './scripts/avocado run --sysinfo=off --force-job-id foobar skiptest'
         result = process.run(cmd_line, ignore_status=True)
         self.assertNotEqual(0, result.exit_status)
-        self.assertIn('needs to be a 40 digit hex', result.stdout)
+        self.assertIn('needs to be a 40 digit hex', result.stderr)
 
     def test_valid_unique_id(self):
         cmd_line = './scripts/avocado run --sysinfo=off --force-job-id 975de258ac05ce5e490648dec4753657b7ccc7d1 skiptest'
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(0, result.exit_status)
-        self.assertNotIn('needs to be a 40 digit hex', result.stdout)
+        self.assertNotIn('needs to be a 40 digit hex', result.stderr)
         self.assertIn('SKIP', result.stdout)
 
     def test_automatic_unique_id(self):

--- a/selftests/all/functional/avocado/loader_tests.py
+++ b/selftests/all/functional/avocado/loader_tests.py
@@ -77,7 +77,7 @@ class LoaderTestFunctional(unittest.TestCase):
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %d:\n%s" %
                          (expected_rc, result))
-        self.assertIn('is not an avocado test', result.stdout)
+        self.assertIn('is not an avocado test', result.stderr)
         simple_test.remove()
 
     def test_pass(self):
@@ -141,7 +141,7 @@ class LoaderTestFunctional(unittest.TestCase):
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %d:\n%s" %
                          (expected_rc, result))
-        self.assertIn('is not an avocado test', result.stdout)
+        self.assertIn('is not an avocado test', result.stderr)
         avocado_not_a_test.remove()
 
 if __name__ == '__main__':


### PR DESCRIPTION
Create an additional logging handler for the avocado application,
that outputs to stderr, and two filters, that filter messages
per logging level. This way, normal information (app output)
goes to stdout and error messages go to stderr. The unittests
were updated accordingly.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>