### PR TITLE
A few contributions to examples: bind_cpu0, cabort and raise [V2].

### DIFF
--- a/examples/tests/cabort.py
+++ b/examples/tests/cabort.py
@@ -1,0 +1,44 @@
+#!/usr/bin/python
+
+import os
+import shutil
+
+from avocado import test
+from avocado import job
+from avocado.utils import build
+from avocado.utils import process
+
+
+class CAbort(test.Test):
+
+    """
+    A test that calls C standard lib function abort().
+    """
+
+    default_params = {'source': 'abort.c'}
+
+    def setup(self):
+        """
+        Build 'abort'.
+        """
+        c_file = self.get_data_path(self.params.source)
+        c_file_name = os.path.basename(c_file)
+        dest_c_file = os.path.join(self.srcdir, c_file_name)
+        shutil.copy(c_file, dest_c_file)
+        build.make(self.srcdir,
+                   env={'CFLAGS': '-g -O0'},
+                   extra_args='abort')
+
+    def action(self):
+        """
+        Execute 'abort'.
+        """
+        cmd = os.path.join(self.srcdir, 'abort')
+        cmd_result = process.run(cmd, ignore_status=True)
+        self.log.info(cmd_result)
+        expected_result = -6  # SIGABRT = 6
+        self.assertEqual(cmd_result.exit_status, expected_result)
+
+
+if __name__ == "__main__":
+    job.main()

--- a/examples/tests/cabort.py.data/abort.c
+++ b/examples/tests/cabort.py.data/abort.c
@@ -1,0 +1,7 @@
+#include <stdlib.h>
+
+int
+main(void)
+{
+	abort();
+}

--- a/examples/tests/datadir.py
+++ b/examples/tests/datadir.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 
 import os
+import shutil
 
 from avocado import test
 from avocado import job
@@ -20,10 +21,13 @@ class DataDirTest(test.Test):
         """
         Build 'datadir'.
         """
-        self.cwd = os.getcwd()
         c_file = self.get_data_path(self.params.source)
-        self.srcdir = os.path.dirname(c_file)
-        build.make(self.srcdir, extra_args='datadir')
+        c_file_name = os.path.basename(c_file)
+        dest_c_file = os.path.join(self.srcdir, c_file_name)
+        shutil.copy(c_file, dest_c_file)
+        build.make(self.srcdir,
+                   env={'CFLAGS': '-g -O0'},
+                   extra_args='datadir')
 
     def action(self):
         """
@@ -33,11 +37,6 @@ class DataDirTest(test.Test):
         cmd_result = process.run(cmd)
         self.log.info(cmd_result)
 
-    def cleanup(self):
-        """
-        Clean up 'datadir'.
-        """
-        os.unlink(os.path.join(self.srcdir, 'datadir'))
 
 if __name__ == "__main__":
     job.main()

--- a/examples/tests/raise.py
+++ b/examples/tests/raise.py
@@ -1,0 +1,53 @@
+#!/usr/bin/python
+
+import os
+import shutil
+
+from avocado import test
+from avocado import job
+from avocado.utils import build
+from avocado.utils import process
+
+
+class Raise(test.Test):
+
+    """
+    A test that calls raise() to signals to itself.
+    """
+
+    default_params = {'source': 'raise.c',
+                      'signal_number': 15}
+
+    def setup(self):
+        """
+        Build 'raise'.
+        """
+        c_file = self.get_data_path(self.params.source)
+        c_file_name = os.path.basename(c_file)
+        dest_c_file = os.path.join(self.srcdir, c_file_name)
+        shutil.copy(c_file, dest_c_file)
+        build.make(self.srcdir,
+                   env={'CFLAGS': '-g -O0'},
+                   extra_args='raise')
+
+    def action(self):
+        """
+        Execute 'raise'.
+        """
+        cmd = os.path.join(self.srcdir, 'raise %d' % self.params.signal_number)
+        cmd_result = process.run(cmd, ignore_status=True)
+        self.log.info(cmd_result)
+        signum = self.params.signal_number
+        if signum == 0:
+            expected_result = 0
+            self.assertIn("I'm alive!", cmd_result.stdout)
+        elif 0 < signum < 65:
+            expected_result = -signum
+        else:
+            expected_result = 255
+            self.assertIn("raise: Invalid argument", cmd_result.stderr)
+        self.assertEqual(cmd_result.exit_status, expected_result)
+
+
+if __name__ == "__main__":
+    job.main()

--- a/examples/tests/raise.py.data/raise.c
+++ b/examples/tests/raise.py.data/raise.c
@@ -1,0 +1,31 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <signal.h>
+
+/*
+ * Signal numbers are translated to exit code by the shell.
+ * For example, if SIGUSR1 is raised (sinal number 10) then
+ * the exit code will be 128+10 = 138.
+ *
+ * In the case of avocado.utils.process.SubProcess, the exit code is
+ * the negative value of the signal, so SIGUSR1 will return -10.
+ *
+ * See http://tldp.org/LDP/abs/html/exitcodes.html
+ */
+
+int
+main(int argc, char *argv[])
+{
+	int res;
+
+	if (argc == 1) {
+		printf("Usage: raise SIGNAL_NUMBER\n");
+		return 1;
+	}
+	res = raise(atoi(argv[1]));
+	if (res != 0)
+		perror("raise");
+	else
+		printf("I'm alive!\n");
+	return res;
+}

--- a/examples/tests/raise.py.data/raise.yaml
+++ b/examples/tests/raise.py.data/raise.yaml
@@ -1,0 +1,18 @@
+sigint:
+    signal_number: 2
+siguser1:
+    signal_number: 10
+sigterm:
+    signal_number: 15
+sigkill:
+    signal_number: 9
+sigquit:
+    signal_number: 3
+sigsegv:
+    signal_number: 11
+invalid:
+    signal_number: 1024
+invalid_negative:
+    signal_number: -1
+is_alive:
+    signal_number: 0

--- a/examples/wrappers/bind_cpu0.sh
+++ b/examples/wrappers/bind_cpu0.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#
+# Bind process to CPU 0.
+#
+
+exec taskset -c 0 "$@"


### PR DESCRIPTION
Follow up of PR #438.

---

Changes:

From @clebergnu questions and suggestions, we've got now:

* Include an updated `datadir` test to use the proper temporary dir to build the binary. (like the `doublefree` test is doing now).
* Update `cabort` and `raise` tests to use the proper temporary dir to build the binaries.
* Check for exit code `-6` when running the test `cabort`, so it now looks like a real test.
* Check for exit codes and messages when running the test `raise`, so it now looks like a real test.
* Rebased.