### PR TITLE
 avocado.test: Set the test as WARN when self.log.warn used [v3]

### DIFF
--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -477,17 +477,25 @@ the following entities:
 * The test expected stdout
 * The test expected stderr
 
-The first one is used for debugging and informational purposes. The framework
-machinery uses logs to give you more detailed info about your test, so they
-are not the most reliable source to compare stdout/err. You may log something
-into the test logs using the methods in :mod:`avocado.test.Test.log` class
-attributes. Consider
-the example::
+The first one is used for debugging and informational purposes. Additionally
+writing to `self.log.warning` causes test to be marked as dirty and when
+everything else goes well the test ends with WARN. This means that the test
+passed but there were non-related unexpected situations described in warning
+log.
+
+You may log something into the test logs using the methods in
+:mod:`avocado.test.Test.log` class attributes. Consider the example::
 
     class output_test(test.Test):
 
         def action(self):
             self.log.info('This goes to the log and it is only informational')
+            self.log.warn('Oh, something unexpected, non-critical happened, '
+                          'but we can continue.')
+            self.log.error('Describe the error here and don't forget to raise '
+                           'an exception yourself. Writing to self.log.error '
+                           'won't do that for you.')
+            self.log.debug('Everybody look, I had a good lunch today...')
 
 If you need to write directly to the test stdout and stderr streams, there
 are another 2 class attributes for that, :mod:`avocado.test.Test.stdout_log`

--- a/examples/tests/warntest.py
+++ b/examples/tests/warntest.py
@@ -15,7 +15,7 @@ class WarnTest(test.Test):
         """
         This should throw a TestWarn.
         """
-        raise exceptions.TestWarn('This should throw a TestWarn')
+        self.log.warn("This marks test as WARN")
 
 if __name__ == "__main__":
     job.main()


### PR DESCRIPTION
This patch simplifies the concept of WARN test. In case user uses the
self.log.warn or self.log.warning methods, test is marked as dirty and
in case everything else worked fine it finishes with TestWarn exception.

v0: https://github.com/avocado-framework/avocado/pull/385
v1: https://github.com/avocado-framework/avocado/pull/419
v2: https://github.com/avocado-framework/avocado/pull/422


Changes:

    v1: Documentation adjustments about "self.log.warn"
    v1: Make "avocado-bash-utils" work without avocado
    v2: Remove bash-version RFC to speedup the inclusion
    v3: English language correction