### PR TITLE
examples.tests.doublefree: Change behavior to expect success/pass.

### DIFF
--- a/examples/tests/doublefree.py
+++ b/examples/tests/doublefree.py
@@ -2,6 +2,7 @@
 
 import os
 import shutil
+import signal
 
 from avocado import test
 from avocado import job
@@ -34,8 +35,13 @@ class DoubleFreeTest(test.Test):
         Execute 'doublefree'.
         """
         cmd = os.path.join(self.srcdir, 'doublefree')
-        cmd_result = process.run(cmd)
+        cmd_result = process.run(cmd, ignore_status=True)
         self.log.info(cmd_result)
+        expected_exit_status = -signal.SIGABRT
+        output = cmd_result.stdout + cmd_result.stderr
+        self.assertEqual(cmd_result.exit_status, expected_exit_status)
+        self.assertIn('double free or corruption', output)
+
 
 if __name__ == "__main__":
     job.main()

--- a/selftests/all/functional/avocado/output_tests.py
+++ b/selftests/all/functional/avocado/output_tests.py
@@ -22,7 +22,7 @@ class OutputTest(unittest.TestCase):
         os.chdir(basedir)
         cmd_line = './scripts/avocado run --sysinfo=off doublefree'
         result = process.run(cmd_line, ignore_status=True)
-        expected_rc = 1
+        expected_rc = 0
         output = result.stdout + result.stderr
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %d:\n%s" %


### PR DESCRIPTION
Change the behavior to expect the test to pass, by using test asserts.