### PR TITLE
avocado/job.py: disable local test file checks when running on remote ma...

### DIFF
--- a/avocado/job.py
+++ b/avocado/job.py
@@ -282,7 +282,14 @@ class Job(object):
 
         try:
             test_suite = self.test_loader.discover(params_list)
-            error_msg_parts = self.test_loader.validate_ui(test_suite)
+            # Do not attempt to validate the tests given on the command line if
+            # the tests will not be copied from this system to a remote one
+            # using the remote plugin features
+            if (hasattr(self.args, 'remote_no_copy') and
+                    (not self.args.remote_no_copy)):
+                error_msg_parts = self.test_loader.validate_ui(test_suite)
+            else:
+                error_msg_parts = []
         except KeyboardInterrupt:
             raise exceptions.JobError('Command interrupted by user...')
 


### PR DESCRIPTION
...chines

When using `--remote-no-copy` the test files will neither be copied from the
current system nor executed on it, so disable all sorts of checks.

This is a fix for the local check only. A more complicated issue is to perform
similar checks on the RemoteTestRunner and report possible failures in a clean
way.

This address the github issue #417.

Signed-off-by: Cleber Rosa <crosa@redhat.com>