### PR TITLE
avocado.test: Fortify avocado before very nasty exceptions

### DIFF
--- a/avocado/plugins/xunit.py
+++ b/avocado/plugins/xunit.py
@@ -38,7 +38,13 @@ class XmlResult(object):
         return quoteattr(attrib)
 
     def _escape_cdata(self, cdata):
-        return cdata.replace(']]>', ']]>]]&gt;<![CDATA[')
+        try:
+            return cdata.replace(']]>', ']]>]]&gt;<![CDATA[')
+        except AttributeError:
+            try:
+                str(cdata).replace(']]>', ']]>]]&gt;<![CDATA[')
+            except TypeError:
+                return 'ERROR: UnparsableObject'
 
     def get_contents(self):
         return '\n'.join(self.xml)

--- a/avocado/test.py
+++ b/avocado/test.py
@@ -205,25 +205,19 @@ class Test(unittest.TestCase):
         """
         if self.running and self.time_start:
             self.update_time_elapsed()
-        orig = dict(self.__dict__)
-        d = {}
         preserve_attr = ['basedir', 'debugdir', 'depsdir',
                          'fail_reason', 'logdir', 'logfile', 'name',
                          'resultsdir', 'srcdir', 'status', 'sysinfodir',
                          'tag', 'tagged_name', 'text_output', 'time_elapsed',
                          'traceback', 'workdir', 'whiteboard', 'time_start',
-                         'time_end', 'running', 'paused', 'paused_msg']
-        convert_attr = ['fail_class']
-        for key in sorted(orig):
-            if key in preserve_attr:
-                d[key] = orig[key]
-            elif key in convert_attr:
-                d[key] = str(orig[key])
-        d['params'] = dict(orig['params'])
-        d['class_name'] = self.__class__.__name__
-        d['job_logdir'] = self.job.logdir
-        d['job_unique_id'] = self.job.unique_id
-        return d
+                         'time_end', 'running', 'paused', 'paused_msg',
+                         'fail_class']
+        state = {key: self.__dict__.get(key) for key in preserve_attr}
+        state['params'] = dict(self.__dict__['params'])
+        state['class_name'] = self.__class__.__name__
+        state['job_logdir'] = self.job.logdir
+        state['job_unique_id'] = self.job.unique_id
+        return state
 
     def _set_default(self, key, default):
         try:
@@ -468,10 +462,15 @@ class Test(unittest.TestCase):
             self.traceback = stacktrace.prepare_exc_info(sys.exc_info())
         except Exception, detail:
             self.status = 'FAIL'
-            self.fail_class = detail.__class__.__name__
-            self.fail_reason = detail
             tb_info = stacktrace.tb_info(sys.exc_info())
             self.traceback = stacktrace.prepare_exc_info(sys.exc_info())
+            try:
+                self.fail_class = str(detail.__class__.__name__)
+                self.fail_reason = str(detail)
+            except TypeError:
+                self.fail_class = "Exception"
+                self.fail_reason = ("Unable to get exception, check the "
+                                    "traceback for details.")
             for e_line in tb_info:
                 self.log.error(e_line)
         finally:
@@ -489,7 +488,7 @@ class Test(unittest.TestCase):
         if self.fail_reason is not None:
             self.log.error("%s %s -> %s: %s", self.status,
                            self.tagged_name,
-                           self.fail_reason.__class__.__name__,
+                           self.fail_class,
                            self.fail_reason)
 
         else:

--- a/examples/tests/failtest_nasty.py
+++ b/examples/tests/failtest_nasty.py
@@ -1,0 +1,32 @@
+#!/usr/bin/python
+
+from avocado import test
+from avocado import job
+
+
+class NastyException(Exception):
+
+    """ Please never use something like this!!! """
+
+    def __init__(self, msg):
+        self.msg = msg
+
+    def __str__(self):
+        return self.msg
+
+
+class FailTest(test.Test):
+
+    """
+    Very nasty exception test
+    """
+
+    def action(self):
+        """
+        Should fail not-that-badly
+        """
+        raise NastyException("Nasty-string-like-exception")
+
+
+if __name__ == "__main__":
+    job.main()

--- a/examples/tests/failtest_nasty2.py
+++ b/examples/tests/failtest_nasty2.py
@@ -1,0 +1,32 @@
+#!/usr/bin/python
+
+from avocado import test
+from avocado import job
+
+
+class NastyException(Exception):
+
+    """ Please never use something like this!!! """
+
+    def __init__(self, msg):
+        self.msg = msg
+
+    def __str__(self):
+        return self.msg
+
+
+class FailTest(test.Test):
+
+    """
+    Very nasty exception test
+    """
+
+    def action(self):
+        """
+        Should fail.
+        """
+        raise NastyException(None)  # str(Exception) fails!
+
+
+if __name__ == "__main__":
+    job.main()

--- a/selftests/all/functional/avocado/standalone_tests.py
+++ b/selftests/all/functional/avocado/standalone_tests.py
@@ -26,6 +26,7 @@ class StandaloneTests(unittest.TestCase):
         self.assertEqual(result.exit_status, expected_rc,
                          "Stand alone %s did not return rc "
                          "%d:\n%s" % (tstname, expected_rc, result))
+        return result
 
     def test_passtest(self):
         cmd_line = './examples/tests/passtest.py'
@@ -41,6 +42,23 @@ class StandaloneTests(unittest.TestCase):
         cmd_line = './examples/tests/failtest.py'
         expected_rc = 1
         self.run_and_check(cmd_line, expected_rc, 'failtest')
+
+    def test_failtest_nasty(self):
+        cmd_line = './examples/tests/failtest_nasty.py'
+        expected_rc = 1
+        result = self.run_and_check(cmd_line, expected_rc, 'failtest_nasty')
+        exc = "NastyException: Nasty-string-like-exception"
+        count = result.stderr.count("\n%s" % exc)
+        self.assertEqual(count, 2, "Exception \\n%s should be present twice in"
+                         "the log (once from the log, second time when parsing"
+                         "exception details." % (exc))
+
+    def test_failtest_nasty2(self):
+        cmd_line = './examples/tests/failtest_nasty2.py'
+        expected_rc = 1
+        result = self.run_and_check(cmd_line, expected_rc, 'failtest_nasty2')
+        self.assertIn("Exception: Unable to get exception, check the traceback"
+                      " for details.", result.stderr)
 
     def test_errortest(self):
         cmd_line = './examples/tests/errortest.py'


### PR DESCRIPTION
The NastyException error is back:

    class NastyException(Exception):
        def __init__(self, msg):
            self.msg = msg
        def __str__(self):
            return self.msg

crashes Avocado. The problem is we are trying to re-raise the exceptions
and then read the traceback again. Even reading of the details of this
very nasty written exception causes critical failure.

What this patch does instead of handling issues wherever we produce
them, it waits till the exception bubbles to the entry-point and it
tries to read it. If it fails, we log the original traceback
(information about the failure) and then user-friendly message saying
we're unable to retrieve the original failure.

Additionally I had to modify the xunit output as in case of very nasty
inputs it's unable to reproduce the values.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>