### PR TITLE
  self.job: Command line options in "jobless mode" [V2]

### DIFF
--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -11,7 +11,7 @@
 #
 # See LICENSE for more details.
 #
-# Copyright: Red Hat Inc. 2013-2014
+# Copyright: Red Hat Inc. 2013-2015
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
 """
@@ -203,18 +203,16 @@ def get_logs_dir():
     return _get_rw_dir(SETTINGS_LOG_DIR, SYSTEM_LOG_DIR, USER_LOG_DIR)
 
 
-def get_job_logs_dir(args=None, unique_id=None):
+def create_job_logs_dir(logdir=None, unique_id=None):
     """
     Create a log directory for a job, or a stand alone execution of a test.
 
-    :param args: :class:`argparse.Namespace` instance with cmdline arguments
-                 (optional).
+    :param logdir: Base log directory, if `None`, use value from configuration.
+    :param unique_id: The unique identification. If `None`, create one.
     :rtype: basestring
     """
     start_time = time.strftime('%Y-%m-%dT%H.%M')
-    if args is not None:
-        logdir = args.logdir or get_logs_dir()
-    else:
+    if logdir is None:
         logdir = get_logs_dir()
     # Stand alone tests handling
     if unique_id is None:

--- a/avocado/job.py
+++ b/avocado/job.py
@@ -9,7 +9,7 @@
 #
 # See LICENSE for more details.
 #
-# Copyright: Red Hat Inc. 2013-2014
+# Copyright: Red Hat Inc. 2013-2015
 # Authors: Lucas Meneghel Rodrigues <lmr@redhat.com>
 #          Ruda Moura <rmoura@redhat.com>
 
@@ -112,7 +112,7 @@ class Job(object):
         if self.standalone:
             self.logdir = tempfile.mkdtemp()
         else:
-            self.logdir = data_dir.get_job_logs_dir(self.args, self.unique_id)
+            self.logdir = data_dir.create_job_logs_dir(unique_id=self.unique_id)
         self.logfile = os.path.join(self.logdir, "job.log")
         self.idfile = os.path.join(self.logdir, "id")
         with open(self.idfile, 'w') as id_file_obj:

--- a/avocado/test.py
+++ b/avocado/test.py
@@ -59,7 +59,7 @@ class Test(unittest.TestCase):
                      reserved for running random executables as tests.
         :param base_logdir: Directory where test logs should go. If None
                             provided, it'll use
-                            :func:`avocado.core.data_dir.get_job_logs_dir`.
+                            :func:`avocado.core.data_dir.create_job_logs_dir`.
         :param tag: Tag that differentiates 2 executions of the same test name.
                     Example: 'long', 'short', so we can differentiate
                     'sleeptest.long' and 'sleeptest.short'.
@@ -98,7 +98,7 @@ class Test(unittest.TestCase):
         self.workdir = utils_path.init_dir(tmpdir, basename)
         self.srcdir = utils_path.init_dir(self.workdir, 'src')
         if base_logdir is None:
-            base_logdir = data_dir.get_job_logs_dir()
+            base_logdir = data_dir.create_job_logs_dir()
         base_logdir = os.path.join(base_logdir, 'test-results')
         self.tagged_name = self.get_tagged_name(base_logdir)
 

--- a/avocado/test.py
+++ b/avocado/test.py
@@ -405,11 +405,14 @@ class Test(unittest.TestCase):
         io.write_file(whiteboard_file, self.whiteboard)
 
         if self.job is not None:
-            job_standalone = self.job.args is None
+            job_standalone = getattr(self.job.args, 'standalone', False)
+            output_check_record = getattr(self.job.args,
+                                          'output_check_record', 'none')
             no_record_mode = (not job_standalone and
-                              self.job.args.output_check_record == 'none')
+                              output_check_record == 'none')
             disable_output_check = (not job_standalone and
-                                    self.job.args.disable_output_check)
+                                    getattr(self.job.args,
+                                            'disable_output_check', False))
 
             if job_standalone or no_record_mode:
                 if not disable_output_check:
@@ -423,11 +426,10 @@ class Test(unittest.TestCase):
                     except Exception, details:
                         stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
                         stderr_check_exception = details
-
             elif not job_standalone:
-                if self.job.args.output_check_record in ['all', 'stdout']:
+                if output_check_record in ['all', 'stdout']:
                     self.record_reference_stdout()
-                if self.job.args.output_check_record in ['all', 'stderr']:
+                if output_check_record in ['all', 'stderr']:
                     self.record_reference_stderr()
 
         # pylint: disable=E0702


### PR DESCRIPTION
Follow up of PR #453 .

---
Changes:
* The Job class has now only one argument `args` (so the previous argument `standalone` goes inside `args`).
* The Job class will always contain a valid `args` (don't need to check for `None`).
* Rename API `avocado.core.data_dir.get_job_logs_dir` to `avocado.core.data_dir.create_job_logs_dir`.
* Rephrase standalone test result to 'Test results available in %s'.
* Rebased code.