### PR TITLE
Fix avocado runner problem when running avocado from the base package.

### DIFF
--- a/avocado/job.py
+++ b/avocado/job.py
@@ -40,9 +40,14 @@ from avocado.plugins import jsonresult
 from avocado.plugins import xunit
 from avocado.utils import archive
 from avocado.utils import path
-from avocado.plugins import htmlresult
 
-HTML_REPORT_SUPPORT = htmlresult.HTML_REPORT_CAPABLE
+try:
+    from avocado.plugins import htmlresult
+except ImportError:
+    HTML_REPORT_SUPPORT = False
+else:
+    HTML_REPORT_SUPPORT = htmlresult.HTML_REPORT_CAPABLE
+
 _NEW_ISSUE_LINK = 'https://github.com/avocado-framework/avocado/issues/new'
 
 

--- a/setup.py
+++ b/setup.py
@@ -113,6 +113,7 @@ if __name__ == '__main__':
                     'avocado.linux',
                     'avocado.utils',
                     'avocado.plugins',
+                    'avocado.remote',
                     'avocado.restclient',
                     'avocado.restclient.cli',
                     'avocado.restclient.cli.args',


### PR DESCRIPTION
Fix avocado runner problem when running avocado from the base RPM package:
* Include `avocado.module` inside setup.py.
* Check if htmlresult plugin is installed from the import,
  to set the HTML result feature on or off.


```
$ avocado
Could not import module plugin 'avocado.plugins.runner': cannot import name htmlresult
Could not import module plugin 'avocado.plugins.remote': No module named remote
Could not import module plugin 'avocado.plugins.vm': No module named remote
Could not configure plugin 'journal': 'Parser' object has no attribute 'runner'
Could not configure plugin 'json': 'Parser' object has no attribute 'runner'
Could not configure plugin 'xunit': 'Parser' object has no attribute 'runner'
Could not configure plugin 'gdb': 'Parser' object has no attribute 'runner'
Could not configure plugin 'wrapper': 'Parser' object has no attribute 'runner'
...
```
