### PR TITLE
scripts.avocado-bash-utils: Add Avocado bash utils [v3]

### DIFF
--- a/avocado/test.py
+++ b/avocado/test.py
@@ -11,6 +11,7 @@
 # This code was inspired in the autotest project,
 # client/shared/test.py
 # Authors: Martin J Bligh <mbligh@google.com>, Andy Whitcroft <apw@shadowen.org>
+import re
 
 """
 Contains the base test implementation, used as a base for the actual
@@ -518,6 +519,9 @@ class SimpleTest(Test):
     Run an arbitrary command that returns either 0 (PASS) or !=0 (FAIL).
     """
 
+    re_avocado_log = re.compile(r'^\d\d:\d\d:\d\d INFO \|'
+                                r' \d\d:\d\d:\d\d WARN \|')
+
     def __init__(self, path, params=None, base_logdir=None, tag=None, job=None):
         self.path = os.path.abspath(path)
         super(SimpleTest, self).__init__(name=path, base_logdir=base_logdir,
@@ -553,6 +557,14 @@ class SimpleTest(Test):
         except exceptions.CmdError, details:
             self._log_detailed_cmd_info(details.result)
             raise exceptions.TestFail(details)
+
+    def runTest(self, result=None):
+        super(SimpleTest, self).runTest(result)
+        for line in open(self.logfile):
+            if self.re_avocado_log.match(line):
+                raise exceptions.TestWarn("Test passed but there were warnings"
+                                          " on stdout during execution. Check "
+                                          "the log for details.")
 
 
 class MissingTest(Test):

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -711,6 +711,24 @@ Here are the current variables that Avocado exports to the tests:
 | *                       | All variables from --multiplex-file   | TIMEOUT=60; IO_WORKERS=10; VM_BYTES=512M; ...                                                       |
 +-------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
 
+
+Simple Tests BASH extensions
+============================
+
+To simplify the usage of Simple Tests written in BASH, you can use BASH avocado
+library. It can be found inside ``$AVOCADO/scripts/avocado-bash-utils``
+or in ``/usr/bin/avocado-bash-utils`` when avocado is installed. When you
+include this file in your scripts, you can use some of the advanced autotest
+features in BASH. Take a look at ``examples/tests/simplewarning.sh`` for
+inspiration.
+
+*  ``avocado_debug`` - write into DEBUG log
+*  ``avocado_info`` - write into INFO log
+*  ``avocado_warn`` - write into WARN log (similarly to python tests this marks
+   the test dirty and finish with WARN if everything else goes well)
+*  ``avocado_error`` - log into ERROR log
+
+
 Wrap Up
 =======
 

--- a/examples/tests/simplewarning.sh
+++ b/examples/tests/simplewarning.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+. avocado-bash-utils
+
+avocado_debug "Debug message"
+avocado_info "Info message"
+avocado_warn "Warning message (should cause this test to finish with warning)"
+avocado_error "Error message (ordinary message not changing the results)"
+echo "Simple output without log-level specification"
+exit 0  # no error reported

--- a/scripts/avocado
+++ b/scripts/avocado
@@ -20,6 +20,7 @@ import sys
 # simple magic for using scripts within a source tree
 basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if os.path.isdir(os.path.join(basedir, 'avocado')):
+    os.environ['PATH'] += ":" + os.path.join(basedir, 'scripts')
     sys.path.append(basedir)
 
 from avocado.cli.app import AvocadoApp

--- a/scripts/avocado-bash-utils
+++ b/scripts/avocado-bash-utils
@@ -1,0 +1,25 @@
+#!/bin/sh
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2014
+
+# Write to avocado_log
+# First argument is the log level
+avocado_log() {
+    LEVEL=`printf '%-5s' $1`
+    shift
+    echo "`date '+%H:%M:%S'` $LEVEL| $*"
+}
+
+avocado_debug() { avocado_log DEBUG $*; }
+avocado_info() { avocado_log INFO $*; }
+avocado_warn() { avocado_log WARN $*; }
+avocado_error() { avocado_log ERROR $*; }

--- a/selftests/all/functional/avocado/basic_tests.py
+++ b/selftests/all/functional/avocado/basic_tests.py
@@ -262,6 +262,24 @@ class RunnerSimpleTest(unittest.TestCase):
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %d:\n%s" % (expected_rc, result))
 
+    def test_simplewarning(self):
+        """
+        simplewarning.sh uses the avocado-bash-utils
+        """
+        os.chdir(basedir)
+        cmd_line = ('./scripts/avocado run --sysinfo=off '
+                    'examples/tests/simplewarning.sh --show-job-log')
+        result = process.run(cmd_line, ignore_status=True)
+        self.assertEqual(result.exit_status, 0,
+                         "Avocado did not return rc 0:\n%s" %
+                         (result))
+        self.assertIn('DEBUG| Debug message', result.stderr, result)
+        self.assertIn('INFO | Info message', result.stderr)
+        self.assertIn('WARN | Warning message (should cause this test to '
+                      'finish with warning)', result.stderr, result)
+        self.assertIn('ERROR| Error message (ordinary message not changing '
+                      'the results)', result.stderr, result)
+
     def tearDown(self):
         self.pass_script.remove()
         self.fail_script.remove()


### PR DESCRIPTION
This patch is initial support for people using custom bash scripts
with avocado. They can use "source avocado-bash-utils" to get the
functions into their bash script and utilize them.

This version contain functions to write to Test.log the same way it's
possible from python including failing the test with TestWarn in case
avocado_warn was used.

v0: https://github.com/avocado-framework/avocado/pull/419
v1: https://github.com/avocado-framework/avocado/pull/428
v2: https://github.com/avocado-framework/avocado/pull/447

    v1: Instead of custom logging to self and whole job logs use stdout
    v1: Simplify the in-bash-log format to "$time $log_level |"
    v1: Use regexp to check "warning" presense (decrease probability of false-warnings)
    v2: Added documentation
    v2: Added functional test
    v2: Auto-append "$AVOCAOD/scripts" path to PATH when executing from sources
    v2: Added missing space in error message
    v3: Removed the non-verbose execution as it corrupts `stdout`/`stderr`