### PR TITLE
Remote test support: extra checks for improved usability

### DIFF
--- a/avocado/job.py
+++ b/avocado/job.py
@@ -279,7 +279,14 @@ class Job(object):
 
         try:
             test_suite = self.test_loader.discover(params_list)
-            error_msg_parts = self.test_loader.validate_ui(test_suite)
+            # Do not attempt to validate the tests given on the command line if
+            # the tests will not be copied from this system to a remote one
+            # using the remote plugin features
+            if (hasattr(self.args, 'remote_no_copy') and
+                    (not self.args.remote_no_copy)):
+                error_msg_parts = self.test_loader.validate_ui(test_suite)
+            else:
+                error_msg_parts = []
         except KeyboardInterrupt:
             raise exceptions.JobError('Command interrupted by user...')
 

--- a/avocado/remote/runner.py
+++ b/avocado/remote/runner.py
@@ -16,6 +16,7 @@
 
 import json
 import os
+import re
 
 from avocado.core import status
 from avocado.core import exceptions
@@ -29,6 +30,30 @@ class RemoteTestRunner(TestRunner):
     """ Tooled TestRunner to run on remote machine using ssh """
     remote_test_dir = '~/avocado/tests'
 
+    remote_version_re = re.compile(r'^Avocado (\d+)\.(\d+)\.(\d+)$')
+
+    def check_remote_avocado(self):
+        """
+        Checks if the remote system appears to have avocado installed
+
+        The "appears to have" description is justified by the fact that the
+        check is rather simplistic, it attempts to run an `avocado -v` command
+        and checks if the output looks like what avocado would print out.
+
+        :rtype: bool
+        :returns: True if avocado appears to be installed and False otherwise
+        """
+        result = self.result.remote.run('avocado -v',
+                                        ignore_status=True,
+                                        timeout=None)
+        if result.exit_status == 127:
+            return False
+
+        if not self.remote_version_re.match(result.stdout):
+            return False
+
+        return True
+
     def run_test(self, urls):
         """
         Run tests.
@@ -36,15 +61,16 @@ class RemoteTestRunner(TestRunner):
         :param urls: a string with test URLs.
         :return: a dictionary with test results.
         """
+        if not self.check_remote_avocado():
+            raise exceptions.JobError('Remote machine does not seem to have '
+                                      'avocado installed')
+
         avocado_cmd = ('cd %s; avocado run --force-job-id %s --json - '
                        '--archive %s' % (self.remote_test_dir,
                                          self.result.stream.job_unique_id,
                                          " ".join(urls)))
         result = self.result.remote.run(avocado_cmd, ignore_status=True,
                                         timeout=None)
-        if result.exit_status == 127:
-            raise exceptions.JobError('Remote machine does not have avocado '
-                                      'installed')
         json_result = None
         for json_output in result.stdout.splitlines():
             # We expect dictionary:

--- a/avocado/remote/runner.py
+++ b/avocado/remote/runner.py
@@ -65,10 +65,20 @@ class RemoteTestRunner(TestRunner):
             raise exceptions.JobError('Remote machine does not seem to have '
                                       'avocado installed')
 
+        urls_str = " ".join(urls)
+        avocado_check_urls_cmd = 'cd %s; avocado list %s' % (self.remote_test_dir,
+                                                             urls_str)
+        check_urls_result = self.result.remote.run(avocado_check_urls_cmd,
+                                                   ignore_status=True,
+                                                   timeout=None)
+        if check_urls_result.exit_status != 0:
+            raise exceptions.JobError('Could not find all tests on the '
+                                      'remote machine')
+
         avocado_cmd = ('cd %s; avocado run --force-job-id %s --json - '
                        '--archive %s' % (self.remote_test_dir,
                                          self.result.stream.job_unique_id,
-                                         " ".join(urls)))
+                                         urls_str))
         result = self.result.remote.run(avocado_cmd, ignore_status=True,
                                         timeout=None)
         json_result = None

--- a/selftests/all/unit/avocado/remote_unittest.py
+++ b/selftests/all/unit/avocado/remote_unittest.py
@@ -41,6 +41,12 @@ class RemoteTestRunnerTest(unittest.TestCase):
          .with_args(args, ignore_status=True, timeout=None)
          .once().and_return(version_result))
 
+        args = 'cd ~/avocado/tests; avocado list sleeptest'
+        urls_result = flexmock(exit_status=0)
+        (Remote.should_receive('run')
+         .with_args(args, timeout=None, ignore_status=True)
+         .once().and_return(urls_result))
+
         args = ("cd ~/avocado/tests; avocado run --force-job-id sleeptest.1 "
                 "--json - --archive sleeptest")
         (Remote.should_receive('run')

--- a/selftests/all/unit/avocado/remote_unittest.py
+++ b/selftests/all/unit/avocado/remote_unittest.py
@@ -35,6 +35,12 @@ class RemoteTestRunnerTest(unittest.TestCase):
         stream = flexmock(job_unique_id='sleeptest.1',
                           debuglog='/local/path/dirname')
         Remote = flexmock()
+        args = ('avocado -v')
+        version_result = flexmock(stdout='Avocado 1.2.3', exit_status=0)
+        (Remote.should_receive('run')
+         .with_args(args, ignore_status=True, timeout=None)
+         .once().and_return(version_result))
+
         args = ("cd ~/avocado/tests; avocado run --force-job-id sleeptest.1 "
                 "--json - --archive sleeptest")
         (Remote.should_receive('run')


### PR DESCRIPTION
This is a collection of fixes and extra checks that make using remote test support more consistent and thus with better usability.

Summary:

* When using --remote-no-copy the test files will neither be copied from the current system nor executed on it, so disable all sorts of checks. Fix for issue #417.
* Improve the checks regarding avocado installation on the remote system
* Add checks for tests before trying to run them