### PR TITLE
functional tests: claim back 3 seconds by using passtest instead of slee...

### DIFF
--- a/selftests/all/functional/avocado/gdb_tests.py
+++ b/selftests/all/functional/avocado/gdb_tests.py
@@ -15,13 +15,13 @@ class GDBPluginTest(unittest.TestCase):
 
     def test_gdb_prerun_commands(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --sysinfo=off --gdb-prerun-commands=/dev/null sleeptest'
+        cmd_line = './scripts/avocado run --sysinfo=off --gdb-prerun-commands=/dev/null passtest'
         process.run(cmd_line)
 
     def test_gdb_multiple_prerun_commands(self):
         os.chdir(basedir)
         cmd_line = ('./scripts/avocado run --sysinfo=off --gdb-prerun-commands=/dev/null '
-                    '--gdb-prerun-commands=foo:/dev/null sleeptest')
+                    '--gdb-prerun-commands=foo:/dev/null passtest')
         process.run(cmd_line)
 
 if __name__ == '__main__':

--- a/selftests/all/functional/avocado/output_tests.py
+++ b/selftests/all/functional/avocado/output_tests.py
@@ -75,7 +75,7 @@ class OutputPluginTest(unittest.TestCase):
 
     def test_output_incompatible_setup_3(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --sysinfo=off --html - sleeptest'
+        cmd_line = './scripts/avocado run --sysinfo=off --html - passtest'
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 2
         output = result.stdout + result.stderr


### PR DESCRIPTION
...ptest

Even though we have changed functional tests to use passtest instead of
sleeptest, there still has 3 more tests can go with passtest.

Signed-off-by: Cleber Rosa <crosa@redhat.com>