### PR TITLE
Jobless mode (part 2)

### DIFF
--- a/avocado/__init__.py
+++ b/avocado/__init__.py
@@ -83,6 +83,11 @@ DEFAULT_LOGGING = {
             'level': 'DEBUG',
             'propagate': False,
         },
+        'avocado.sysinfo': {
+            'handlers': ['error'],
+            'level': 'DEBUG',
+            'propagate': False,
+        },
         'avocado.debug': {
             'handlers': ['debug'],
             'level': 'DEBUG',

--- a/avocado/sysinfo.py
+++ b/avocado/sysinfo.py
@@ -28,7 +28,7 @@ from avocado.linux import software_manager
 from avocado.core import output
 from avocado.settings import settings
 
-log = logging.getLogger("avocado.test")
+log = logging.getLogger("avocado.sysinfo")
 
 
 _DEFAULT_COMMANDS_START_JOB = ["df -mP",
@@ -256,7 +256,7 @@ class Daemon(Command):
             self.pipe.terminate()
             retcode = self.pipe.wait()
         else:
-            log.debug("Daemon process '%s' (pid %d) terminated abnormally (code %d)",
+            log.error("Daemon process '%s' (pid %d) terminated abnormally (code %d)",
                       self.cmd, self.pipe.pid, retcode)
         return retcode
 

--- a/avocado/test.py
+++ b/avocado/test.py
@@ -193,6 +193,7 @@ class Test(unittest.TestCase):
         self.time_end = time.time()
         # for consistency sake, always use the same stupid method
         self.update_time_elapsed(self.time_end)
+        self.log.info('END %s', self.tagged_name)
 
     def update_time_elapsed(self, current_time=None):
         if current_time is None:

--- a/docs/source/GetStartedGuide.rst
+++ b/docs/source/GetStartedGuide.rst
@@ -194,7 +194,6 @@ output of the job log in the stdout, without having to tail the job log.
 In order to do that, you can use --show-job-log to the avocado test runner::
 
     $ scripts/avocado run examples/tests/sleeptest.py --show-job-log
-    Not logging /proc/slabinfo (lack of permissions)
     START examples/tests/sleeptest.py
 
     Test instance parameters:
@@ -206,10 +205,8 @@ In order to do that, you can use --show-job-log to the avocado test runner::
     Test instance params override defaults whenever available
 
     Sleeping for 1.00 seconds
-    Not logging /var/log/messages (lack of permissions)
+    END examples/tests/sleeptest.py
     PASS examples/tests/sleeptest.py
-
-    Not logging /proc/slabinfo (lack of permissions)
 
 As you can see, the UI output is suppressed and only the job log goes to
 stdout, making this a useful feature for test development/debugging. Some more

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -455,6 +455,7 @@ Verifying the failure reason::
     20:52:38 test       L0063 ERROR| Hello, avocado!
     20:52:38 test       L0063 ERROR|
     20:52:38 test       L0064 ERROR|
+    20:52:38 test       L0195 INFO | END home/$USER/Code/avocado/output_record.sh
     20:52:38 test       L0529 ERROR| FAIL home/$USER/Code/avocado/output_record.sh -> AssertionError: Actual test sdtout differs from expected one:
     Actual:
     Hello, world!
@@ -591,6 +592,7 @@ impact your test grid. You can account for that possibility and set up a
     15:52:54 test       L0060 ERROR|     raise exceptions.TestTimeoutError(e_msg)
     15:52:54 test       L0060 ERROR| TestTimeoutError: Timeout reached waiting for sleeptest to end
     15:52:54 test       L0061 ERROR|
+    15:52:54 test       L0195 INFO | END sleeptest.1
     15:52:54 test       L0400 ERROR| ERROR sleeptest.1 -> TestTimeoutError: Timeout reached waiting for sleeptest to end
     15:52:54 test       L0387 INFO |
 
@@ -673,6 +675,7 @@ This accomplishes a similar effect to the multiplex setup defined in there.
     15:54:31 test       L0060 ERROR|     raise exceptions.TestTimeoutError(e_msg)
     15:54:31 test       L0060 ERROR| TestTimeoutError: Timeout reached waiting for timeouttest to end
     15:54:31 test       L0061 ERROR|
+    15:54:31 test       L0195 INFO | END timeouttest.1
     15:54:31 test       L0400 ERROR| ERROR timeouttest.1 -> TestTimeoutError: Timeout reached waiting for timeouttest to end
     15:54:31 test       L0387 INFO |
 


### PR DESCRIPTION
This is a follow up of #455 .

--- 

Changes:

* Insert a mark the end of the test.
* Use a exclusive log handler for sysinfo (don't show sysinfo messages on test log by default).
* Update command line option for running in "jobless" mode, accepts `--keep-test-results` and `--test-resutls-dir`.