### PR TITLE
RFC: export test.Test and job.main in avocado module.

### DIFF
--- a/avocado/__init__.py
+++ b/avocado/__init__.py
@@ -13,6 +13,10 @@
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
 
+from avocado.test import Test
+from avocado.job import main
+
+
 DEFAULT_LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
@@ -93,3 +97,5 @@ DEFAULT_LOGGING = {
 
 from logging import config
 config.dictConfig(DEFAULT_LOGGING)
+
+del config

--- a/examples/tests/abort.py
+++ b/examples/tests/abort.py
@@ -2,11 +2,9 @@
 
 import os
 
-from avocado import test
-from avocado import job
+import avocado
 
-
-class AbortTest(test.Test):
+class AbortTest(avocado.Test):
 
     """
     A test that just calls abort() (and abort).
@@ -18,4 +16,4 @@ class AbortTest(test.Test):
 
 
 if __name__ == "__main__":
-    job.main()
+    avocado.main()

--- a/examples/tests/cabort.py
+++ b/examples/tests/cabort.py
@@ -3,13 +3,13 @@
 import os
 import shutil
 
-from avocado import test
-from avocado import job
+import avocado
+
 from avocado.utils import build
 from avocado.utils import process
 
 
-class CAbort(test.Test):
+class CAbort(avocado.Test):
 
     """
     A test that calls C standard lib function abort().
@@ -41,4 +41,4 @@ class CAbort(test.Test):
 
 
 if __name__ == "__main__":
-    job.main()
+    avocado.main()

--- a/examples/tests/datadir.py
+++ b/examples/tests/datadir.py
@@ -3,13 +3,13 @@
 import os
 import shutil
 
-from avocado import test
-from avocado import job
+import avocado
+
 from avocado.utils import build
 from avocado.utils import process
 
 
-class DataDirTest(test.Test):
+class DataDirTest(avocado.Test):
 
     """
     Test that uses resources from the data dir.
@@ -39,4 +39,4 @@ class DataDirTest(test.Test):
 
 
 if __name__ == "__main__":
-    job.main()
+    avocado.main()

--- a/examples/tests/doublefail.py
+++ b/examples/tests/doublefail.py
@@ -1,11 +1,11 @@
 #!/usr/bin/python
 
-from avocado import test
-from avocado import job
+import avocado
+
 from avocado.core import exceptions
 
 
-class DoubleFail(test.Test):
+class DoubleFail(avocado.Test):
 
     """
     Functional test for avocado. Straight up fail the test.
@@ -25,4 +25,4 @@ class DoubleFail(test.Test):
 
 
 if __name__ == "__main__":
-    job.main()
+    avocado.main()

--- a/examples/tests/doublefree.py
+++ b/examples/tests/doublefree.py
@@ -4,13 +4,13 @@ import os
 import shutil
 import signal
 
-from avocado import test
-from avocado import job
+import avocado
+
 from avocado.utils import build
 from avocado.utils import process
 
 
-class DoubleFreeTest(test.Test):
+class DoubleFreeTest(avocado.Test):
 
     """
     Double free test case.
@@ -44,4 +44,4 @@ class DoubleFreeTest(test.Test):
 
 
 if __name__ == "__main__":
-    job.main()
+    avocado.main()

--- a/examples/tests/doublefree_nasty.py
+++ b/examples/tests/doublefree_nasty.py
@@ -3,13 +3,13 @@
 import os
 import shutil
 
-from avocado import job
-from avocado import test
+import avocado
+
 from avocado.utils import build
 from avocado.utils import process
 
 
-class DoubleFreeTest(test.Test):
+class DoubleFreeTest(avocado.Test):
 
     """
     10% chance to execute double free exception.
@@ -38,4 +38,4 @@ class DoubleFreeTest(test.Test):
         self.log.info(cmd_result)
 
 if __name__ == "__main__":
-    job.main()
+    avocado.main()

--- a/examples/tests/errortest.py
+++ b/examples/tests/errortest.py
@@ -1,11 +1,11 @@
 #!/usr/bin/python
 
-from avocado import test
-from avocado import job
+import avocado
+
 from avocado.core import exceptions
 
 
-class ErrorTest(test.Test):
+class ErrorTest(avocado.Test):
 
     """
     Functional test for avocado. Throw a TestError.
@@ -18,4 +18,4 @@ class ErrorTest(test.Test):
         raise exceptions.TestError('This should throw a TestError')
 
 if __name__ == "__main__":
-    job.main()
+    avocado.main()

--- a/examples/tests/failtest.py
+++ b/examples/tests/failtest.py
@@ -1,11 +1,11 @@
 #!/usr/bin/python
 
-from avocado import test
-from avocado import job
+import avocado
+
 from avocado.core import exceptions
 
 
-class FailTest(test.Test):
+class FailTest(avocado.Test):
 
     """
     Functional test for avocado. Straight up fail the test.
@@ -19,4 +19,4 @@ class FailTest(test.Test):
 
 
 if __name__ == "__main__":
-    job.main()
+    avocado.main()

--- a/examples/tests/failtest_nasty.py
+++ b/examples/tests/failtest_nasty.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 
-from avocado import test
-from avocado import job
+import avocado
 
 
 class NastyException(Exception):
@@ -15,7 +14,7 @@ class NastyException(Exception):
         return self.msg
 
 
-class FailTest(test.Test):
+class FailTest(avocado.Test):
 
     """
     Very nasty exception test
@@ -29,4 +28,4 @@ class FailTest(test.Test):
 
 
 if __name__ == "__main__":
-    job.main()
+    avocado.main()

--- a/examples/tests/failtest_nasty2.py
+++ b/examples/tests/failtest_nasty2.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 
-from avocado import test
-from avocado import job
+import avocado
 
 
 class NastyException(Exception):
@@ -15,7 +14,7 @@ class NastyException(Exception):
         return self.msg
 
 
-class FailTest(test.Test):
+class FailTest(avocado.Test):
 
     """
     Very nasty exception test
@@ -29,4 +28,4 @@ class FailTest(test.Test):
 
 
 if __name__ == "__main__":
-    job.main()
+    avocado.main()

--- a/examples/tests/fiotest.py
+++ b/examples/tests/fiotest.py
@@ -2,14 +2,14 @@
 
 import os
 
-from avocado import test
-from avocado import job
+import avocado
+
 from avocado.utils import archive
 from avocado.utils import build
 from avocado.utils import process
 
 
-class FioTest(test.Test):
+class FioTest(avocado.Test):
 
     """
     fio is an I/O tool meant to be used both for benchmark and
@@ -41,4 +41,4 @@ class FioTest(test.Test):
 
 
 if __name__ == "__main__":
-    job.main()
+    avocado.main()

--- a/examples/tests/gdbtest.py
+++ b/examples/tests/gdbtest.py
@@ -2,13 +2,14 @@
 
 import os
 
-from avocado import test
+import avocado
+
 from avocado import gdb
 from avocado import job
 from avocado.utils import process
 
 
-class GdbTest(test.Test):
+class GdbTest(avocado.Test):
 
     """
     Execute the gdb test
@@ -435,4 +436,4 @@ class GdbTest(test.Test):
         self.test_remote()
 
 if __name__ == '__main__':
-    job.main()
+    avocado.main()

--- a/examples/tests/gendata.py
+++ b/examples/tests/gendata.py
@@ -2,11 +2,10 @@
 
 import os
 
-from avocado import test
-from avocado import job
+import avocado
 
 
-class GenDataTest(test.Test):
+class GenDataTest(avocado.Test):
 
     """
     Simple test that generates data to be persisted after the test is run
@@ -46,4 +45,4 @@ class GenDataTest(test.Test):
         self.generate_json()
 
 if __name__ == "__main__":
-    job.main()
+    avocado.main()

--- a/examples/tests/linuxbuild.py
+++ b/examples/tests/linuxbuild.py
@@ -1,11 +1,11 @@
 #!/usr/bin/python
 
-from avocado import test
-from avocado import job
+import avocado
+
 from avocado.linux import kernel_build
 
 
-class LinuxBuildTest(test.Test):
+class LinuxBuildTest(avocado.Test):
 
     """
     Execute the Linux Build test.
@@ -28,4 +28,4 @@ class LinuxBuildTest(test.Test):
 
 
 if __name__ == "__main__":
-    job.main()
+    avocado.main()

--- a/examples/tests/modify_variable.py
+++ b/examples/tests/modify_variable.py
@@ -3,13 +3,13 @@
 import os
 import shutil
 
-from avocado import gdb
-from avocado import job
-from avocado import test
+import avocado
+
+import avocado import gdb
 from avocado.utils import build
 
 
-class PrintVariableTest(test.Test):
+class PrintVariableTest(avocado.Test):
 
     """
     This demonstrates the GDB API
@@ -51,4 +51,4 @@ class PrintVariableTest(test.Test):
 
 
 if __name__ == "__main__":
-    job.main()
+    avocado.main()

--- a/examples/tests/multiplextest.py
+++ b/examples/tests/multiplextest.py
@@ -1,10 +1,9 @@
 #!/usr/bin/python
 
-from avocado import test
-from avocado import job
+import avocado
 
 
-class MultiplexTest(test.Test):
+class MultiplexTest(avocado.Test):
 
     """
     Execute a test that uses provided parameters (for multiplexing testing).
@@ -74,4 +73,4 @@ class MultiplexTest(test.Test):
 
 
 if __name__ == "__main__":
-    job.main()
+    avocado.main()

--- a/examples/tests/passtest.py
+++ b/examples/tests/passtest.py
@@ -1,10 +1,9 @@
 #!/usr/bin/python
 
-from avocado import job
-from avocado import test
+import avocado
 
 
-class PassTest(test.Test):
+class PassTest(avocado.Test):
 
     """
     Example test that passes.
@@ -18,4 +17,4 @@ class PassTest(test.Test):
 
 
 if __name__ == "__main__":
-    job.main()
+    avocado.main()

--- a/examples/tests/raise.py
+++ b/examples/tests/raise.py
@@ -3,13 +3,13 @@
 import os
 import shutil
 
-from avocado import test
-from avocado import job
+import avocado
+
 from avocado.utils import build
 from avocado.utils import process
 
 
-class Raise(test.Test):
+class Raise(avocado.Test):
 
     """
     A test that calls raise() to signals to itself.
@@ -50,4 +50,4 @@ class Raise(test.Test):
 
 
 if __name__ == "__main__":
-    job.main()
+    avocado.main()

--- a/examples/tests/skiptest.py
+++ b/examples/tests/skiptest.py
@@ -1,11 +1,11 @@
 #!/usr/bin/python
 
-from avocado import test
-from avocado import job
+import avocado
+
 from avocado.core import exceptions
 
 
-class SkipTest(test.Test):
+class SkipTest(avocado.Test):
 
     """
     Functional test for avocado. Throw a TestNAError (skips the test).
@@ -18,4 +18,4 @@ class SkipTest(test.Test):
         raise exceptions.TestNAError('This test should be skipped')
 
 if __name__ == "__main__":
-    job.main()
+    avocado.main()

--- a/examples/tests/sleeptenmin.py
+++ b/examples/tests/sleeptenmin.py
@@ -3,11 +3,10 @@
 import os
 import time
 
-from avocado import job
-from avocado import test
+import avocado
 
 
-class SleepTenMin(test.Test):
+class SleepTenMin(avocado.Test):
 
     """
     Sleeps for 10 minutes
@@ -32,4 +31,4 @@ class SleepTenMin(test.Test):
             self.report_state()
 
 if __name__ == "__main__":
-    job.main()
+    avocado.main()

--- a/examples/tests/sleeptest.py
+++ b/examples/tests/sleeptest.py
@@ -2,11 +2,10 @@
 
 import time
 
-from avocado import job
-from avocado import test
+import avocado
 
 
-class SleepTest(test.Test):
+class SleepTest(avocado.Test):
 
     """
     Example test for avocado.
@@ -22,4 +21,4 @@ class SleepTest(test.Test):
 
 
 if __name__ == "__main__":
-    job.main()
+    avocado.main()

--- a/examples/tests/synctest.py
+++ b/examples/tests/synctest.py
@@ -2,14 +2,14 @@
 
 import os
 
-from avocado import test
-from avocado import job
+import avocado
+
 from avocado.utils import archive
 from avocado.utils import build
 from avocado.utils import process
 
 
-class SyncTest(test.Test):
+class SyncTest(avocado.Test):
 
     """
     Execute the synctest test suite.
@@ -47,4 +47,4 @@ class SyncTest(test.Test):
 
 
 if __name__ == "__main__":
-    job.main()
+    avocado.main()

--- a/examples/tests/timeouttest.py
+++ b/examples/tests/timeouttest.py
@@ -2,11 +2,10 @@
 
 import time
 
-from avocado import test
-from avocado import job
+import avocado
 
 
-class TimeoutTest(test.Test):
+class TimeoutTest(avocado.Test):
 
     """
     Functional test for avocado. Throw a TestTimeoutError.
@@ -24,4 +23,4 @@ class TimeoutTest(test.Test):
 
 
 if __name__ == "__main__":
-    job.main()
+    avocado.main()

--- a/examples/tests/trinity.py
+++ b/examples/tests/trinity.py
@@ -2,15 +2,15 @@
 
 import os
 
-from avocado import test
-from avocado import job
+import avocado
+
 from avocado.utils import archive
 from avocado.utils import build
 from avocado.utils import process
 from avocado.utils import data_factory
 
 
-class TrinityTest(test.Test):
+class TrinityTest(avocado.Test):
 
     """
     Trinity syscall fuzzer wrapper.
@@ -56,4 +56,4 @@ class TrinityTest(test.Test):
 
 
 if __name__ == "__main__":
-    job.main()
+    avocado.main()

--- a/examples/tests/warntest.py
+++ b/examples/tests/warntest.py
@@ -1,11 +1,11 @@
 #!/usr/bin/python
 
-from avocado import test
-from avocado import job
+import avocado
+
 from avocado.core import exceptions
 
 
-class WarnTest(test.Test):
+class WarnTest(avocado.Test):
 
     """
     Functional test for avocado. Throw a TestWarn.
@@ -18,4 +18,4 @@ class WarnTest(test.Test):
         self.log.warn("This marks test as WARN")
 
 if __name__ == "__main__":
-    job.main()
+    avocado.main()

--- a/examples/tests/whiteboard.py
+++ b/examples/tests/whiteboard.py
@@ -2,11 +2,10 @@
 
 import base64
 
-from avocado import test
-from avocado import job
+import avocado
 
 
-class WhiteBoard(test.Test):
+class WhiteBoard(avocado.Test):
 
     """
     Simple test that saves test custom data to the test whiteboard
@@ -35,4 +34,4 @@ class WhiteBoard(test.Test):
         self.whiteboard = base64.encodestring(result)
 
 if __name__ == "__main__":
-    job.main()
+    avocado.main()


### PR DESCRIPTION
This is something that the unittest does, so we can do this too.

How about to export the test case class (avocado.test.Test) and
the main function (avocado.job.main) to call avocado tests in the command line.

Doing this,  will cut the two imports from the users's test module,
to just one import, as we can see in this sample test:

```
import avocado

class Pass(avocado.Test):
    def action(self):
        pass

if __name__ == '__main__':
    avocado.main()
```

Also, I we shouldn't export config from avocado module.

Signed-off-by: Rudá Moura <rmoura@redhat.com>