### PR TITLE
pyliblzma: make it optional since it is not essential

### DIFF
--- a/avocado/utils/archive.py
+++ b/avocado/utils/archive.py
@@ -17,10 +17,15 @@
 Module to help extract and create compressed archives.
 """
 
-import lzma
 import os
 import tarfile
 import zipfile
+
+try:
+    import lzma
+    LZMA_SUPPORTED = True
+except ImportError:
+    LZMA_SUPPORTED = False
 
 
 class ArchiveException(Exception):
@@ -31,37 +36,38 @@ class ArchiveException(Exception):
     pass
 
 
-class _WrapLZMA(object):
+if LZMA_SUPPORTED:
+    class _WrapLZMA(object):
 
-    """ wraps tar.xz for python 2.7's tarfile """
+        """ wraps tar.xz for python 2.7's tarfile """
 
-    def __init__(self, filename, mode):
-        """
-        Creates an instance of :class:`ArchiveFile`.
+        def __init__(self, filename, mode):
+            """
+            Creates an instance of :class:`ArchiveFile`.
 
-        :param filename: the archive file name.
-        :param mode: file mode, `r` read, `w` write.
-        """
-        self._engine = tarfile.open(fileobj=lzma.LZMAFile(filename, mode),
-                                    mode=mode)
-        methods = dir(self._engine)
-        for meth in dir(self):
-            try:
-                methods.remove(meth)
-            except ValueError:
-                pass
-        for method in methods:
-            setattr(self, method, getattr(self._engine, method))
+            :param filename: the archive file name.
+            :param mode: file mode, `r` read, `w` write.
+            """
+            self._engine = tarfile.open(fileobj=lzma.LZMAFile(filename, mode),
+                                        mode=mode)
+            methods = dir(self._engine)
+            for meth in dir(self):
+                try:
+                    methods.remove(meth)
+                except ValueError:
+                    pass
+            for method in methods:
+                setattr(self, method, getattr(self._engine, method))
 
-    @classmethod
-    def open(cls, filename, mode='r'):
-        """
-        Creates an instance of :class:`_WrapLZMA`.
+        @classmethod
+        def open(cls, filename, mode='r'):
+            """
+            Creates an instance of :class:`_WrapLZMA`.
 
-        :param filename: the archive file name.
-        :param mode: file mode, `r` read, `w` write.
-        """
-        return cls(filename, mode)
+            :param filename: the archive file name.
+            :param mode: file mode, `r` read, `w` write.
+            """
+            return cls(filename, mode)
 
 
 class ArchiveFile(object):
@@ -79,8 +85,10 @@ class ArchiveFile(object):
         '.tar.gz': (False, True, tarfile.open, ':gz'),
         '.tgz': (False, True, tarfile.open, ':gz'),
         '.tar.bz2': (False, True, tarfile.open, ':bz2'),
-        '.tbz2': (False, True, tarfile.open, ':bz2'),
-        '.xz': (False, True, _WrapLZMA.open, '')}
+        '.tbz2': (False, True, tarfile.open, ':bz2')}
+
+    if LZMA_SUPPORTED:
+        _extension_table['.xz'] = (False, True, _WrapLZMA.open, '')
 
     def __init__(self, filename, mode='r'):
         """


### PR DESCRIPTION
The line above says enough, but let me stress the point that we want
Avocado to be portable enough to run on various and possibly limited
systems.

Embedded systems and lightweight VMs/containers are a very compeling
target for avocado, so IMHO we should strive to make the avocado core
runnable with as little as a standard Python installation.

Signed-off-by: Cleber Rosa <crosa@redhat.com>