### PR TITLE
loader: Ignore imported classes.

### DIFF
--- a/avocado/loader.py
+++ b/avocado/loader.py
@@ -96,7 +96,7 @@ class TestLoader(object):
             test_module = imp.load_module(module_name, f, p, d)
             f.close()
             for name, obj in inspect.getmembers(test_module):
-                if inspect.isclass(obj):
+                if inspect.isclass(obj) and inspect.getmodule(obj) == test_module:
                     if issubclass(obj, test.Test):
                         test_class = obj
                         break


### PR DESCRIPTION
This allows people to derive indirectly from test.Test and still
import the direct base class like this:

    from base import MyBaseTest

    class MyInheritedTest(MyBaseTest):
        ...

Without this change, the loader might pick `MyBaseTest` as the
class to test instead of `MyInheritedTest`.

Signed-off-by: Marius Vollmer <mvollmer@redhat.com>
Signed-off-by: Cleber Rosa <crosa@redhat.com>