### PR TITLE
pyliblzma: make it optional since it is not essential [v2]

### DIFF
--- a/avocado/utils/archive.py
+++ b/avocado/utils/archive.py
@@ -17,10 +17,15 @@
 Module to help extract and create compressed archives.
 """
 
-import lzma
 import os
 import tarfile
 import zipfile
+
+try:
+    import lzma
+    LZMA_CAPABLE = True
+except ImportError:
+    LZMA_CAPABLE = False
 
 
 class ArchiveException(Exception):
@@ -79,8 +84,10 @@ class ArchiveFile(object):
         '.tar.gz': (False, True, tarfile.open, ':gz'),
         '.tgz': (False, True, tarfile.open, ':gz'),
         '.tar.bz2': (False, True, tarfile.open, ':bz2'),
-        '.tbz2': (False, True, tarfile.open, ':bz2'),
-        '.xz': (False, True, _WrapLZMA.open, '')}
+        '.tbz2': (False, True, tarfile.open, ':bz2')}
+
+    if LZMA_CAPABLE:
+        _extension_table['.xz'] = (False, True, _WrapLZMA.open, '')
 
     def __init__(self, filename, mode='r'):
         """


### PR DESCRIPTION
The line above says enough, but let me stress the point that we want
Avocado to be portable enough to run on various and possibly limited
systems.

Embedded systems and lightweight VMs/containers are a very compeling
target for avocado, so IMHO we should strive to make the avocado core
runnable with as little as a standard Python installation.

Changes from v1:
* Renamed LZMA_SUPPORTED to LZMA_CAPABLE
* There's no need to make _WrapLZMA class definition conditional

Signed-off-by: Cleber Rosa <crosa@redhat.com>