### PR TITLE
Review command line options.

### DIFF
--- a/avocado/plugins/gdb.py
+++ b/avocado/plugins/gdb.py
@@ -46,8 +46,8 @@ class GDB(plugin.Plugin):
                                    'BINARY_PATH is optional and if omitted '
                                    'will apply to all binaries'))
 
-        gdb_grp.add_argument('--gdb-enable-core', action='store_true',
-                             default=False,
+        gdb_grp.add_argument('--gdb-coredump', choices=('on', 'off'),
+                             default='off',
                              help=('Automatically generate a core dump when the'
                                    ' inferior process received a fatal signal '
                                    'such as SIGSEGV or SIGABRT'))
@@ -79,8 +79,7 @@ class GDB(plugin.Plugin):
                     runtime.GDB_PRERUN_COMMANDS['binary'] = commands_path
                 else:
                     runtime.GDB_PRERUN_COMMANDS[''] = commands
-            if app_args.gdb_enable_core:
-                runtime.GDB_ENABLE_CORE = True
+            runtime.GDB_ENABLE_CORE = True if app_args.gdb_coredump == 'on' else False
             runtime.GDB_PATH = app_args.gdb_path
             runtime.GDBSERVER_PATH = app_args.gdbserver_path
         except AttributeError:

--- a/avocado/plugins/runner.py
+++ b/avocado/plugins/runner.py
@@ -90,7 +90,10 @@ class TestRunner(plugin.Plugin):
 
         out_check = self.parser.add_argument_group('output check arguments')
 
-        out_check.add_argument('--output-check-record', type=str,
+        out_check.add_argument('--output-check-record', choices=('none',
+                                                                 'all',
+                                                                 'stdout',
+                                                                 'stderr'),
                                default='none',
                                help=('Record output streams of your tests '
                                      'to reference files (valid options: '
@@ -98,15 +101,15 @@ class TestRunner(plugin.Plugin):
                                      'all (record both stdout and stderr), '
                                      'stdout (record only stderr), '
                                      'stderr (record only stderr). '
-                                     'Current: none'))
+                                     'Current: %(default)s'))
 
-        out_check.add_argument('--disable-output-check', action='store_true',
-                               default=False,
-                               help=('Disable test output (stdout/stderr) check. '
-                                     'If this option is selected, no output will '
+        out_check.add_argument('--output-check', choices=('on', 'off'),
+                               default='on',
+                               help=('Enable or disable test output (stdout/stderr) check. '
+                                     'If this option is off, no output will '
                                      'be checked, even if there are reference files '
                                      'present for the test. '
-                                     'Current: False (output check enabled)'))
+                                     'Current: on (output check enabled)'))
 
         if multiplexer.MULTIPLEX_CAPABLE:
             mux = self.parser.add_argument_group('multiplex arguments')

--- a/avocado/plugins/wrapper.py
+++ b/avocado/plugins/wrapper.py
@@ -31,7 +31,15 @@ class Wrapper(plugin.Plugin):
         wrap_group = self.parser.runner.add_argument_group(
             'Wrap avocado.utils.process module')
         wrap_group.add_argument('--wrapper', action='append', default=[],
-                                help='')
+                                metavar='SCRIPT[:PROCESS]',
+                                help='Use a script to wrap the execution of '
+                                'process created by the test. The wrapper is '
+                                'either a path to a script (aka global wrap) or '
+                                'a path to a script followed by colon symbol (:), '
+                                'plus a shell like glob to the target process. '
+                                'So format should be "<script>[:<process>]". '
+                                'Multiples wrap lines are allowed, but only one global '
+                                'wrap can be defined.')
         self.configured = True
 
     def activate(self, app_args):

--- a/avocado/test.py
+++ b/avocado/test.py
@@ -408,7 +408,7 @@ class Test(unittest.TestCase):
                               output_check_record == 'none')
             disable_output_check = (not job_standalone and
                                     getattr(self.job.args,
-                                            'disable_output_check', False))
+                                            'output_check', 'on') == 'off')
 
             if job_standalone or no_record_mode:
                 if not disable_output_check:

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -361,7 +361,7 @@ After the reference files are added, the check process is transparent, in the se
 that you do not need to provide special flags to the test runner.
 Now, every time the test is executed, after it is done running, it will check
 if the outputs are exactly right before considering the test as PASSed. If you want to override the default
-behavior and skip output check entirely, you may provide the flag ``--disable-output-check`` to the test runner.
+behavior and skip output check entirely, you may provide the flag ``--output-check=off`` to the test runner.
 
 The :mod:`avocado.utils.process` APIs have a parameter ``allow_output_check`` (defaults to ``all``), so that you
 can select which process outputs will go to the reference files, should you chose to record them. You may choose

--- a/man/avocado.rst
+++ b/man/avocado.rst
@@ -449,7 +449,7 @@ sense that you do not need to provide special flags to the test runner.
 Now, every time the test is executed, after it is done running, it will check
 if the outputs are exactly right before considering the test as PASSed. If you
 want to override the default behavior and skip output check entirely, you may
-provide the flag ``--disable-output-check`` to the test runner.
+provide the flag ``--output-check=off`` to the test runner.
 
 The ``avocado.utils.process`` APIs have a parameter ``allow_output_check``
 (defaults to ``all``), so that you can select which process outputs will go to

--- a/selftests/all/functional/avocado/output_check_tests.py
+++ b/selftests/all/functional/avocado/output_check_tests.py
@@ -93,7 +93,7 @@ class RunnerSimpleTest(unittest.TestCase):
         stdout_file = os.path.join("%s.data/stdout.expected" % self.output_script.path)
         with open(stdout_file, 'w') as stdout_file_obj:
             stdout_file_obj.write(tampered_msg)
-        cmd_line = './scripts/avocado run --sysinfo=off %s --disable-output-check --xunit -' % self.output_script.path
+        cmd_line = './scripts/avocado run --sysinfo=off %s --output-check=off --xunit -' % self.output_script.path
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 0
         self.assertEqual(result.exit_status, expected_rc,


### PR DESCRIPTION
Changes so far:
* Include a proper help message to the `--wrap` option.
* Add option `--gdb-coredump {on,off}` to deprecate option `--gdb-enable-core`.
* Add option `--output-check {on,off}` to deprecate option `--disable-output-check`. Validate value from  option `--output-check-record`.