### PR TITLE
  Review command line options. [V2]

### DIFF
--- a/avocado/cli/parser.py
+++ b/avocado/cli/parser.py
@@ -35,9 +35,6 @@ class Parser(object):
             version='Avocado %s' % VERSION,
             add_help=False,  # see parent parsing
             description='Avocado Test Runner')
-        self.application.add_argument('--logdir', action='store',
-                                      help='Alternate logs directory',
-                                      dest='logdir', default='')
         self.application.add_argument('--plugins', action='store',
                                       help='Load extra plugins from directory',
                                       dest='plugins_dir', default='')

--- a/avocado/job.py
+++ b/avocado/job.py
@@ -111,8 +111,8 @@ class Job(object):
         self.sysinfo = None
 
     def _setup_job_results(self):
+        logdir = getattr(self.args, 'logdir', None)
         if self.standalone:
-            logdir = getattr(self.args, 'logdir', None)
             if logdir is not None:
                 logdir = os.path.abspath(logdir)
                 self.logdir = data_dir.create_job_logs_dir(logdir=logdir,
@@ -120,7 +120,12 @@ class Job(object):
             else:
                 self.logdir = tempfile.mkdtemp(prefix='avocado-')
         else:
-            self.logdir = data_dir.create_job_logs_dir(unique_id=self.unique_id)
+            if logdir is None:
+                self.logdir = data_dir.create_job_logs_dir(unique_id=self.unique_id)
+            else:
+                logdir = os.path.abspath(logdir)
+                self.logdir = data_dir.create_job_logs_dir(logdir=logdir,
+                                                           unique_id=self.unique_id)
         self.logfile = os.path.join(self.logdir, "job.log")
         self.idfile = os.path.join(self.logdir, "id")
         with open(self.idfile, 'w') as id_file_obj:

--- a/avocado/plugins/gdb.py
+++ b/avocado/plugins/gdb.py
@@ -46,8 +46,8 @@ class GDB(plugin.Plugin):
                                    'BINARY_PATH is optional and if omitted '
                                    'will apply to all binaries'))
 
-        gdb_grp.add_argument('--gdb-enable-core', action='store_true',
-                             default=False,
+        gdb_grp.add_argument('--gdb-coredump', choices=('on', 'off'),
+                             default='off',
                              help=('Automatically generate a core dump when the'
                                    ' inferior process received a fatal signal '
                                    'such as SIGSEGV or SIGABRT'))
@@ -79,8 +79,7 @@ class GDB(plugin.Plugin):
                     runtime.GDB_PRERUN_COMMANDS['binary'] = commands_path
                 else:
                     runtime.GDB_PRERUN_COMMANDS[''] = commands
-            if app_args.gdb_enable_core:
-                runtime.GDB_ENABLE_CORE = True
+            runtime.GDB_ENABLE_CORE = True if app_args.gdb_coredump == 'on' else False
             runtime.GDB_PATH = app_args.gdb_path
             runtime.GDBSERVER_PATH = app_args.gdbserver_path
         except AttributeError:

--- a/avocado/plugins/htmlresult.py
+++ b/avocado/plugins/htmlresult.py
@@ -281,7 +281,7 @@ class HTML(plugin.Plugin):
             self.enabled = False
             return
         self.parser = parser
-        self.parser.runner.add_argument(
+        self.parser.runner.output.add_argument(
             '--html', type=str,
             dest='html_output',
             help=('Enable HTML output to the file where the result should be '
@@ -289,14 +289,14 @@ class HTML(plugin.Plugin):
                   'since not all HTML resources can be embedded into a '
                   'single file (page resources will be copied to the '
                   'output file dir)'))
-        self.parser.runner.add_argument(
+        self.parser.runner.output.add_argument(
             '--relative-links',
             dest='relative_links',
             action='store_true',
             default=False,
             help=('On the HTML report, generate anchor links with relative '
                   'instead of absolute paths. Current: %s' % False))
-        self.parser.runner.add_argument(
+        self.parser.runner.output.add_argument(
             '--open-browser',
             dest='open_browser',
             action='store_true',

--- a/avocado/plugins/journal.py
+++ b/avocado/plugins/journal.py
@@ -123,7 +123,7 @@ class Journal(plugin.Plugin):
 
     def configure(self, parser):
         self.parser = parser
-        self.parser.runner.add_argument(
+        self.parser.runner.output.add_argument(
             '--journal', action='store_true',
             help='Records test status changes')
         self.configured = True

--- a/avocado/plugins/jsonresult.py
+++ b/avocado/plugins/jsonresult.py
@@ -102,7 +102,7 @@ class JSON(plugin.Plugin):
 
     def configure(self, parser):
         self.parser = parser
-        self.parser.runner.add_argument(
+        self.parser.runner.output.add_argument(
             '--json', type=str,
             dest='json_output',
             help='Enable JSON output to the file where the result should be written. '

--- a/avocado/plugins/runner.py
+++ b/avocado/plugins/runner.py
@@ -77,21 +77,24 @@ class TestRunner(plugin.Plugin):
                                        '(hardware details, profilers, etc.). '
                                        'Current:  %(default)s'))
 
-        out = self.parser.add_argument_group('output related arguments')
+        self.parser.output = self.parser.add_argument_group('output related arguments')
 
-        out.add_argument('-s', '--silent', action='store_true', default=False,
-                         help='Silence stdout')
+        self.parser.output.add_argument(
+            '-s', '--silent', action='store_true', default=False,
+            help='Silence stdout')
 
-        out.add_argument('--show-job-log', action='store_true', default=False,
-                         help=('Display only the job log on stdout. Useful '
-                               'for test debugging purposes. No output will '
-                               'be displayed if you also specify --silent'))
+        self.parser.output.add_argument(
+            '--show-job-log', action='store_true', default=False,
+            help=('Display only the job log on stdout. Useful '
+                  'for test debugging purposes. No output will '
+                  'be displayed if you also specify --silent'))
 
-        out.add_argument('--job-log-level', action='store',
-                         help=("Log level of the job log. Options: "
-                               "'debug', 'info', 'warning', 'error', "
-                               "'critical'. Current: debug"),
-                         default='debug')
+        self.parser.output.add_argument(
+            '--job-log-level', action='store',
+            help=("Log level of the job log. Options: "
+                  "'debug', 'info', 'warning', 'error', "
+                  "'critical'. Current: debug"),
+            default='debug')
 
         out_check = self.parser.add_argument_group('output check arguments')
 

--- a/avocado/plugins/runner.py
+++ b/avocado/plugins/runner.py
@@ -62,6 +62,11 @@ class TestRunner(plugin.Plugin):
                                        'server. You should not use this option '
                                        'unless you know exactly what you\'re doing'))
 
+        self.parser.add_argument('--job-results-dir', action='store',
+                                 dest='logdir', default=None, metavar='DIRECTORY',
+                                 help=('Forces to use of an alternate job '
+                                       'results directory.'))
+
         sysinfo_default = settings.get_value('sysinfo.collect',
                                              'enabled',
                                              key_type='bool',

--- a/avocado/plugins/runner.py
+++ b/avocado/plugins/runner.py
@@ -90,7 +90,10 @@ class TestRunner(plugin.Plugin):
 
         out_check = self.parser.add_argument_group('output check arguments')
 
-        out_check.add_argument('--output-check-record', type=str,
+        out_check.add_argument('--output-check-record', choices=('none',
+                                                                 'all',
+                                                                 'stdout',
+                                                                 'stderr'),
                                default='none',
                                help=('Record output streams of your tests '
                                      'to reference files (valid options: '
@@ -98,15 +101,15 @@ class TestRunner(plugin.Plugin):
                                      'all (record both stdout and stderr), '
                                      'stdout (record only stderr), '
                                      'stderr (record only stderr). '
-                                     'Current: none'))
+                                     'Current: %(default)s'))
 
-        out_check.add_argument('--disable-output-check', action='store_true',
-                               default=False,
-                               help=('Disable test output (stdout/stderr) check. '
-                                     'If this option is selected, no output will '
+        out_check.add_argument('--output-check', choices=('on', 'off'),
+                               default='on',
+                               help=('Enable or disable test output (stdout/stderr) check. '
+                                     'If this option is off, no output will '
                                      'be checked, even if there are reference files '
                                      'present for the test. '
-                                     'Current: False (output check enabled)'))
+                                     'Current: on (output check enabled)'))
 
         if multiplexer.MULTIPLEX_CAPABLE:
             mux = self.parser.add_argument_group('multiplex arguments')

--- a/avocado/plugins/wrapper.py
+++ b/avocado/plugins/wrapper.py
@@ -31,7 +31,14 @@ class Wrapper(plugin.Plugin):
         wrap_group = self.parser.runner.add_argument_group(
             'Wrap avocado.utils.process module')
         wrap_group.add_argument('--wrapper', action='append', default=[],
-                                help='')
+                                metavar='SCRIPT[:PROCESS]',
+                                help='Use a script to wrap the execution of '
+                                'process created by the test. The wrapper is '
+                                'either a path to a script (aka global wrap) or '
+                                'a path to a script followed by colon symbol (:), '
+                                'plus a shell like glob to the target process. '
+                                'Multiples wrap lines are allowed, but only one global '
+                                'wrap can be defined.')
         self.configured = True
 
     def activate(self, app_args):

--- a/avocado/plugins/xunit.py
+++ b/avocado/plugins/xunit.py
@@ -227,7 +227,7 @@ class XUnit(plugin.Plugin):
 
     def configure(self, parser):
         self.parser = parser
-        self.parser.runner.add_argument(
+        self.parser.runner.output.add_argument(
             '--xunit', type=str, dest='xunit_output',
             help=('Enable xUnit output to the file where the result should be written. '
                   "Use '-' to redirect to the standard output."))

--- a/avocado/test.py
+++ b/avocado/test.py
@@ -408,7 +408,7 @@ class Test(unittest.TestCase):
                               output_check_record == 'none')
             disable_output_check = (not job_standalone and
                                     getattr(self.job.args,
-                                            'disable_output_check', False))
+                                            'output_check', 'on') == 'off')
 
             if job_standalone or no_record_mode:
                 if not disable_output_check:

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -361,7 +361,7 @@ After the reference files are added, the check process is transparent, in the se
 that you do not need to provide special flags to the test runner.
 Now, every time the test is executed, after it is done running, it will check
 if the outputs are exactly right before considering the test as PASSed. If you want to override the default
-behavior and skip output check entirely, you may provide the flag ``--disable-output-check`` to the test runner.
+behavior and skip output check entirely, you may provide the flag ``--output-check=off`` to the test runner.
 
 The :mod:`avocado.utils.process` APIs have a parameter ``allow_output_check`` (defaults to ``all``), so that you
 can select which process outputs will go to the reference files, should you chose to record them. You may choose

--- a/man/avocado.rst
+++ b/man/avocado.rst
@@ -449,7 +449,7 @@ sense that you do not need to provide special flags to the test runner.
 Now, every time the test is executed, after it is done running, it will check
 if the outputs are exactly right before considering the test as PASSed. If you
 want to override the default behavior and skip output check entirely, you may
-provide the flag ``--disable-output-check`` to the test runner.
+provide the flag ``--output-check=off`` to the test runner.
 
 The ``avocado.utils.process`` APIs have a parameter ``allow_output_check``
 (defaults to ``all``), so that you can select which process outputs will go to

--- a/man/avocado.rst
+++ b/man/avocado.rst
@@ -6,7 +6,7 @@
 SYNOPSIS
 ========
 
- avocado [-h] [-v] [--logdir LOGDIR] [--loglevel LOG_LEVEL] [--plugins PLUGINS_DIR]
+ avocado [-h] [-v] [--plugins PLUGINS_DIR]
  {run,list,sysinfo,multiplex,plugins,datadir} ...
 
 DESCRIPTION
@@ -30,7 +30,6 @@ on them being loaded::
 
  -h, --help             show this help message and exit
  -v, --version          show program's version number and exit
- --logdir LOGDIR        Alternate logs directory
  --plugins PLUGINS_DIR  Load extra plugins from directory
 
 Real use of avocado depends on running avocado subcommands. This a typical list

--- a/selftests/all/functional/avocado/output_check_tests.py
+++ b/selftests/all/functional/avocado/output_check_tests.py
@@ -93,7 +93,7 @@ class RunnerSimpleTest(unittest.TestCase):
         stdout_file = os.path.join("%s.data/stdout.expected" % self.output_script.path)
         with open(stdout_file, 'w') as stdout_file_obj:
             stdout_file_obj.write(tampered_msg)
-        cmd_line = './scripts/avocado run --sysinfo=off %s --disable-output-check --xunit -' % self.output_script.path
+        cmd_line = './scripts/avocado run --sysinfo=off %s --output-check=off --xunit -' % self.output_script.path
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 0
         self.assertEqual(result.exit_status, expected_rc,


### PR DESCRIPTION
Follow up of PR #485 .

--

Changes:

* Strip redundant description about `--wrap`.
* Group together json, xunit, html and journal test results inside "output related arguments" when getting help. Export `parser.runner.output` to the plugins.