### PR TITLE
Print Job ID in job log

### DIFF
--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -117,7 +117,7 @@ def add_console_handler(logger):
 
     :param logger: `logging.Logger` instance.
     """
-    console_handler = logging.StreamHandler()
+    console_handler = logging.StreamHandler(sys.stdout)
     formatter = logging.Formatter(fmt='%(message)s')
     console_handler.setFormatter(formatter)
     logger.addHandler(console_handler)

--- a/avocado/job.py
+++ b/avocado/job.py
@@ -50,6 +50,8 @@ else:
 
 _NEW_ISSUE_LINK = 'https://github.com/avocado-framework/avocado/issues/new'
 
+_TEST_LOGGER = logging.getLogger('avocado.test')
+
 
 class Job(object):
 
@@ -101,9 +103,9 @@ class Job(object):
 
         if self.show_job_log:
             if not self.silent:
-                test_logger = logging.getLogger('avocado.test')
-                output.add_console_handler(test_logger)
-                test_logger.setLevel(self.loglevel)
+                output.add_console_handler(_TEST_LOGGER)
+                _TEST_LOGGER.setLevel(self.loglevel)
+
         self.test_dir = data_dir.get_test_dir()
         self.test_index = 1
         self.status = "RUNNING"
@@ -314,6 +316,9 @@ class Job(object):
         self.view.start_file_logging(self.logfile,
                                      self.loglevel,
                                      self.unique_id)
+        _TEST_LOGGER.info('Job ID: %s', self.unique_id)
+        _TEST_LOGGER.info('')
+
         self.view.logfile = self.logfile
         failures = self.test_runner.run_suite(test_suite)
         self.view.stop_file_logging()

--- a/selftests/all/functional/avocado/multiplex_tests.py
+++ b/selftests/all/functional/avocado/multiplex_tests.py
@@ -117,11 +117,11 @@ class MultiplexTests(unittest.TestCase):
         for msg in ('A', 'ASDFASDF', 'This is very long\nmultiline\ntext.'):
             msg = ('[stdout] Custom variable: ' +
                    '\n[stdout] '.join(msg.splitlines()))
-            self.assertIn(msg, result.stderr, "Multiplexed variable should "
+            self.assertIn(msg, result.stdout, "Multiplexed variable should "
                                               "produce:"
                           "\n  %s\nwhich is not present in the output:\n  %s"
                           % ("\n  ".join(msg.splitlines()),
-                             "\n  ".join(result.stderr.splitlines())))
+                             "\n  ".join(result.stdout.splitlines())))
 
 if __name__ == '__main__':
     unittest.main()

--- a/selftests/all/functional/avocado/output_tests.py
+++ b/selftests/all/functional/avocado/output_tests.py
@@ -1,6 +1,7 @@
 import json
 import tempfile
 import os
+import re
 import sys
 import shutil
 from xml.dom import minidom
@@ -185,6 +186,12 @@ class OutputPluginTest(unittest.TestCase):
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %d:\n%s" %
                          (expected_rc, result))
+        job_id_list = re.findall('Job ID: (.*)', result.stdout,
+                                 re.MULTILINE)
+        self.assertTrue(job_id_list, 'No Job ID in stdout:\n%s' %
+                        result.stdout)
+        job_id = job_id_list[0]
+        self.assertEqual(len(job_id), 40)
 
     def test_silent_trumps_show_job_log(self):
         os.chdir(basedir)

--- a/selftests/all/functional/avocado/standalone_tests.py
+++ b/selftests/all/functional/avocado/standalone_tests.py
@@ -57,7 +57,7 @@ class StandaloneTests(unittest.TestCase):
         expected_rc = 1
         result = self.run_and_check(cmd_line, expected_rc, 'failtest_nasty')
         exc = "NastyException: Nasty-string-like-exception"
-        count = result.stderr.count("\n%s" % exc)
+        count = result.stdout.count("\n%s" % exc)
         self.assertEqual(count, 2, "Exception \\n%s should be present twice in"
                          "the log (once from the log, second time when parsing"
                          "exception details." % (exc))
@@ -67,7 +67,7 @@ class StandaloneTests(unittest.TestCase):
         expected_rc = 1
         result = self.run_and_check(cmd_line, expected_rc, 'failtest_nasty2')
         self.assertIn("Exception: Unable to get exception, check the traceback"
-                      " for details.", result.stderr)
+                      " for details.", result.stdout)
 
     def test_errortest(self):
         cmd_line = './examples/tests/errortest.py'


### PR DESCRIPTION
Implements card

https://trello.com/c/H1Yz0AQl/349-print-job-id-results-dir-in-the-debug-log