### PR TITLE
RFC: Avocado Test Developers API

### DIFF
--- a/avocado/api/__init__.py
+++ b/avocado/api/__init__.py
@@ -1,0 +1,14 @@
+"""
+Avocado Test API.
+"""
+
+from os import chdir, getcwd, path
+from shutil import copy
+
+from avocado.test import Test
+from avocado.job import main
+
+from avocado.utils.archive import compress, extract
+from avocado.utils.build import make
+from avocado.utils.process import run, system
+from avocado.utils.data_factory import make_dir_and_populate

--- a/examples/tests/cabort.py
+++ b/examples/tests/cabort.py
@@ -1,15 +1,8 @@
 #!/usr/bin/python
 
-import os
-import shutil
+from avocado import api
 
-from avocado import test
-from avocado import job
-from avocado.utils import build
-from avocado.utils import process
-
-
-class CAbort(test.Test):
+class CAbort(api.Test):
 
     """
     A test that calls C standard lib function abort().
@@ -22,23 +15,23 @@ class CAbort(test.Test):
         Build 'abort'.
         """
         c_file = self.get_data_path(self.params.source)
-        c_file_name = os.path.basename(c_file)
-        dest_c_file = os.path.join(self.srcdir, c_file_name)
-        shutil.copy(c_file, dest_c_file)
-        build.make(self.srcdir,
-                   env={'CFLAGS': '-g -O0'},
-                   extra_args='abort')
+        c_file_name = api.path.basename(c_file)
+        dest_c_file = api.path.join(self.srcdir, c_file_name)
+        api.copy(c_file, dest_c_file)
+        api.make(self.srcdir,
+                 env={'CFLAGS': '-g -O0'},
+                 extra_args='abort')
 
     def action(self):
         """
         Execute 'abort'.
         """
-        cmd = os.path.join(self.srcdir, 'abort')
-        cmd_result = process.run(cmd, ignore_status=True)
+        cmd = api.path.join(self.srcdir, 'abort')
+        cmd_result = api.run(cmd, ignore_status=True)
         self.log.info(cmd_result)
         expected_result = -6  # SIGABRT = 6
         self.assertEqual(cmd_result.exit_status, expected_result)
 
 
 if __name__ == "__main__":
-    job.main()
+    api.main()

--- a/examples/tests/datadir.py
+++ b/examples/tests/datadir.py
@@ -1,15 +1,8 @@
 #!/usr/bin/python
 
-import os
-import shutil
+from avocado import api
 
-from avocado import test
-from avocado import job
-from avocado.utils import build
-from avocado.utils import process
-
-
-class DataDirTest(test.Test):
+class DataDirTest(api.Test):
 
     """
     Test that uses resources from the data dir.
@@ -22,21 +15,21 @@ class DataDirTest(test.Test):
         Build 'datadir'.
         """
         c_file = self.get_data_path(self.params.source)
-        c_file_name = os.path.basename(c_file)
-        dest_c_file = os.path.join(self.srcdir, c_file_name)
-        shutil.copy(c_file, dest_c_file)
-        build.make(self.srcdir,
-                   env={'CFLAGS': '-g -O0'},
-                   extra_args='datadir')
+        c_file_name = api.path.basename(c_file)
+        dest_c_file = api.path.join(self.srcdir, c_file_name)
+        api.copy(c_file, dest_c_file)
+        api.make(self.srcdir,
+                 env={'CFLAGS': '-g -O0'},
+                 extra_args='datadir')
 
     def action(self):
         """
         Execute 'datadir'.
         """
-        cmd = os.path.join(self.srcdir, 'datadir')
-        cmd_result = process.run(cmd)
+        cmd = api.path.join(self.srcdir, 'datadir')
+        cmd_result = api.run(cmd)
         self.log.info(cmd_result)
 
 
 if __name__ == "__main__":
-    job.main()
+    api.main()

--- a/examples/tests/doublefree.py
+++ b/examples/tests/doublefree.py
@@ -4,13 +4,9 @@ import os
 import shutil
 import signal
 
-from avocado import test
-from avocado import job
-from avocado.utils import build
-from avocado.utils import process
+from avocado import api
 
-
-class DoubleFreeTest(test.Test):
+class DoubleFreeTest(api.Test):
 
     """
     Double free test case.
@@ -26,16 +22,16 @@ class DoubleFreeTest(test.Test):
         c_file_name = os.path.basename(c_file)
         dest_c_file = os.path.join(self.srcdir, c_file_name)
         shutil.copy(c_file, dest_c_file)
-        build.make(self.srcdir,
-                   env={'CFLAGS': '-g -O0'},
-                   extra_args='doublefree')
+        api.make(self.srcdir,
+                 env={'CFLAGS': '-g -O0'},
+                 extra_args='doublefree')
 
     def action(self):
         """
         Execute 'doublefree'.
         """
         cmd = os.path.join(self.srcdir, 'doublefree')
-        cmd_result = process.run(cmd, ignore_status=True)
+        cmd_result = api.run(cmd, ignore_status=True)
         self.log.info(cmd_result)
         expected_exit_status = -signal.SIGABRT
         output = cmd_result.stdout + cmd_result.stderr
@@ -44,4 +40,4 @@ class DoubleFreeTest(test.Test):
 
 
 if __name__ == "__main__":
-    job.main()
+    api.main()

--- a/examples/tests/synctest.py
+++ b/examples/tests/synctest.py
@@ -1,15 +1,9 @@
 #!/usr/bin/python
 
-import os
-
-from avocado import test
-from avocado import job
-from avocado.utils import archive
-from avocado.utils import build
-from avocado.utils import process
+from avocado import api
 
 
-class SyncTest(test.Test):
+class SyncTest(api.Test):
 
     """
     Execute the synctest test suite.
@@ -23,28 +17,28 @@ class SyncTest(test.Test):
         """
         Build the synctest suite.
         """
-        self.cwd = os.getcwd()
+        self.cwd = api.getcwd()
         tarball_path = self.get_data_path(self.params.sync_tarball)
-        archive.extract(tarball_path, self.srcdir)
-        self.srcdir = os.path.join(self.srcdir, 'synctest')
+        api.extract(tarball_path, self.srcdir)
+        self.srcdir = api.path.join(self.srcdir, 'synctest')
         if self.params.debug_symbols:
-            build.make(self.srcdir,
-                       env={'CFLAGS': '-g -O0'},
-                       extra_args='synctest')
+            api.make(self.srcdir,
+                     env={'CFLAGS': '-g -O0'},
+                     extra_args='synctest')
         else:
-            build.make(self.srcdir)
+            api.make(self.srcdir)
 
     def action(self):
         """
         Execute synctest with the appropriate params.
         """
-        os.chdir(self.srcdir)
-        path = os.path.join(os.getcwd(), 'synctest')
+        api.chdir(self.srcdir)
+        path = api.path.join(api.getcwd(), 'synctest')
         cmd = ('%s %s %s' %
                (path, self.params.sync_length, self.params.sync_loop))
-        process.system(cmd)
-        os.chdir(self.cwd)
+        api.system(cmd)
+        api.chdir(self.cwd)
 
 
 if __name__ == "__main__":
-    job.main()
+    api.main()

--- a/examples/tests/trinity.py
+++ b/examples/tests/trinity.py
@@ -1,16 +1,10 @@
 #!/usr/bin/python
 
-import os
-
-from avocado import test
-from avocado import job
-from avocado.utils import archive
-from avocado.utils import build
-from avocado.utils import process
+from avocado import api
 from avocado.utils import data_factory
 
 
-class TrinityTest(test.Test):
+class TrinityTest(api.Test):
 
     """
     Trinity syscall fuzzer wrapper.
@@ -32,19 +26,19 @@ class TrinityTest(test.Test):
         Build trinity.
         """
         tarball_path = self.get_data_path(self.params.tarball)
-        archive.extract(tarball_path, self.srcdir)
-        self.srcdir = os.path.join(self.srcdir, 'trinity-1.4')
-        os.chdir(self.srcdir)
-        process.run('./configure.sh')
-        build.make(self.srcdir)
-        self.victims_path = data_factory.make_dir_and_populate(self.workdir)
+        api.extract(tarball_path, self.srcdir)
+        self.srcdir = api.path.join(self.srcdir, 'trinity-1.4')
+        api.chdir(self.srcdir)
+        api.run('./configure.sh')
+        api.make(self.srcdir)
+        self.victims_path = api.make_dir_and_populate(self.workdir)
 
     def action(self):
         """
         Execute the trinity syscall fuzzer with the appropriate params.
         """
         cmd = './trinity -I'
-        process.run(cmd)
+        api.run(cmd)
         cmd = './trinity'
         if self.params.stress:
             cmd += " " + self.params.stress
@@ -52,8 +46,8 @@ class TrinityTest(test.Test):
             cmd += " -V " + self.params.victims_path
         else:
             cmd += " -V " + self.victims_path
-        process.run(cmd)
+        api.run(cmd)
 
 
 if __name__ == "__main__":
-    job.main()
+    api.main()


### PR DESCRIPTION
This is a proof of concept of defining a common set of functions that the Avocado test developer should use. The general idea is to define, inside the module `avocado.api`, the functions that we want to share, exporting selected functions (or creating functions that simplifies) from the Python standard lib (or maybe not [1]) and from other Avocado modules (like `avocado.utils.*`) and the common `Test` class and `avocado.job.main` [2]. So the test developer will just import `avocado.api` to use the main features of Avocado, expecting that this API is guarantee to be stable.

In resume, we will provide for test developers:

* Methods defined in Avocado Test class (the logs, asserts and so on);
* Selected functions from standard lib and from Avocado, defined inside the module `avocado.api`.

[1] Maybe just select a few functions from `os`, `sys`, `shutils`, the test developer is free to use the standard lib the way he/she likes.
[2] I like the idea of exporting the test class and the main from job directly in module `avocado`. See PR #470 .
Then the test module should be like this:
```
import avocado
import avocado.api  # or from avocado import api

class MyTest(avocado.Test):
    def action(self):
        avocado.api.run("true")

if __main__ == '__main__':
    avocado.main()
```