### PR TITLE
FIXME: Params namespaces and resolution order [v2]

### DIFF
--- a/avocado/job.py
+++ b/avocado/job.py
@@ -31,7 +31,7 @@ from avocado import runner
 from avocado import loader
 from avocado import runtime
 from avocado import sysinfo
-from avocado.core import data_dir
+from avocado.core import data_dir, tree
 from avocado.core import exit_codes
 from avocado.core import exceptions
 from avocado.core import job_id
@@ -275,8 +275,13 @@ class Job(object):
                     multiplex_files = self.args.multiplex_files
 
             if multiplex_files is not None:
-                params_list = self._multiplex_params_list(params_list,
-                                                          multiplex_files)
+                mpx_pools = multiplexer.parse_yamls(multiplex_files,
+                                                    self.args.filter_only,
+                                                    self.args.filter_out)
+            else:
+                mpx_pools = [[tree.TreeNode()]]
+        else:
+            mpx_pools = [[tree.TreeNode()]]    # void multiplex params
 
         self._setup_job_results()
 
@@ -307,7 +312,8 @@ class Job(object):
                                      self.loglevel,
                                      self.unique_id)
         self.view.logfile = self.logfile
-        failures = self.test_runner.run_suite(test_suite)
+        failures = self.test_runner.run_suite(test_suite, mpx_pools,
+                                              self.args.mux_entry)
         self.view.stop_file_logging()
         self._update_latest_link()
         # If it's all good so far, set job status to 'PASS'

--- a/avocado/multiplexer.py
+++ b/avocado/multiplexer.py
@@ -65,8 +65,8 @@ def tree2pools(node, mux=True):
     return leaves, pools
 
 
-def multiplex_yamls(input_yamls, filter_only=None, filter_out=None,
-                    debug=False):
+def parse_yamls(input_yamls, filter_only=None, filter_out=None,
+                debug=False):
     if filter_only is None:
         filter_only = []
     if filter_out is None:
@@ -77,4 +77,14 @@ def multiplex_yamls(input_yamls, filter_only=None, filter_out=None,
     leaves, pools = tree2pools(final_tree, final_tree.multiplex)
     if leaves:  # Add remaining leaves (they are not variants, only endpoints
         pools.extend(leaves)
+    return pools
+
+
+def multiplex_pools(pools):
     return itertools.product(*pools)    # *magic required pylint: disable=W0142
+
+
+def multiplex_yamls(input_yamls, filter_only=None, filter_out=None,
+                    debug=False):
+    pools = parse_yamls(input_yamls, filter_only, filter_out, debug)
+    return multiplex_pools(pools)

--- a/avocado/params.py
+++ b/avocado/params.py
@@ -1,0 +1,266 @@
+import re
+from threading import Lock
+
+
+class NoMatchError(KeyError):
+    pass
+
+
+class LeafParams(object):
+
+    """
+    This class wraps the leaf and acts as it's values. In the future it should
+    also report the origin so the underlying params can detect clashes.
+    In the future we might consider merging these features into the TreeNode
+    or alternatively moving these functions here and removeing them from
+    TreeNode.
+    """
+
+    # TODO: Instead of environment use values and descend up until we reach
+    #       the value. Return also the origin to allow comparism of possible
+    #       clashes.
+
+    def __init__(self, leaf):
+        self.name = leaf.path + '/'     # we need the names to be ended with /
+        self.leaf = leaf
+
+    def __contains__(self, key):
+        return key in self.leaf.environment
+
+    def __getitem__(self, key):
+        return self.leaf.environment[key]
+
+    def get(self, key, default=None):
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
+
+class AvocadoParams(object):
+
+    """
+    Main params object. It uses Test.get_resolution_order() to slice the
+    provided list of leaves. Currently only first matching path contain the
+    leaf although it's written to support booth ways.
+
+    It supports quering for params of given path and key and copies the
+    "objects", "object_params" and "object_counts" methods (not tested).
+
+    Unsafely it also supports pickling, although to work properly params would
+    have to be deepcopied.
+    """
+
+    # TODO: Use "test" to log params.get()
+
+    def __init__(self, leaves, test_id, tag, mux_entry):
+        self.lock = Lock()
+        self._rel_paths = []
+        leaves = list(leaves)
+        for i, path in enumerate(mux_entry):
+            path_leaves = self._get_params_from_leaves(path, leaves)
+            self._rel_paths.append(AvocadoParam(path_leaves,
+                                                '%d: %s' % (i, path)))
+        # Don't use non-mux-entry params for relative paths
+        path_leaves = self._get_params_from_leaves('/*', leaves)
+        self._abs_path = AvocadoParam(path_leaves, '*: *')
+        self.id = test_id
+        self.tag = tag
+
+    def __getstate__(self):
+        copy = self.__dict__.copy()
+        del(copy['lock'])
+        return copy
+
+    def __setstate__(self, orig):
+        self.__dict__.update(orig)
+        self.lock = Lock()
+
+    def __str__(self):
+        return "params {%s}" % ", ".join(_.name for _ in self._rel_paths)
+
+    def _get_params_from_leaves(self, path, leaves):
+        path_leaves = []
+        path = self._greedy_path(path)
+        for leaf in [leaf for leaf in leaves if path.match(leaf.path + '/')]:
+            # FIXME: This means used leaves are not reused. Is this expected
+            # behavior? If not remove the following line and as the matching
+            # paths are unique and ordered match in self.get() for first path
+            # match and get the value from there only (instead of get_or_die)
+            leaves.remove(leaf)
+            # FIXME: Do we want to keep absolute paths or should they be
+            # converted to relative paths to `path` instead?
+            path_leaves.append(LeafParams(leaf))
+        return path_leaves
+
+    @staticmethod
+    def _greedy_path(path):
+        """
+        path = ""             => ^$ only
+        path = "/"            => / only
+        path = "/asdf/fdsa"   => /asdf/fdsa only
+        path = "asdf/fdsa"    => .*/asdf/fdsa
+        path = "/*/asdf"      => /[^/]*/asdf
+        path = "asdf/*"       => .*/asdf/.*
+        path = "/asdf/*"      => /asdf/.*
+        """
+        if not path:
+            return re.compile('^$')
+        if path[0] != '/':
+            prefix = '.*/'
+        else:
+            prefix = ''
+        if path[-1] == '*':
+            suffix = ''
+            path = path[:-1]
+        else:
+            suffix = '$'
+        return re.compile(prefix + path.replace('*', '[^/]*') + suffix)
+
+    @staticmethod
+    def _is_abspath(path):
+        if path.pattern and path.pattern[0] == '/':
+            return True
+        else:
+            return False
+
+    def get(self, path, key, default=None):
+        """
+        Get a value according to test's resolution order.
+        :param path: namespace
+        :param key: key you're looking for
+        :param default: default value when not found
+        """
+        # TODO: Add caching here
+        path = self._greedy_path(path)
+        for param in self._rel_paths:
+            # TODO: Spedup: Check if the variant can match the path
+            try:
+                return param.get_or_die(path, key)
+            except NoMatchError:
+                pass
+        if self._is_abspath(path):
+            try:
+                return self._abs_path.get_or_die(path, key)
+            except NoMatchError:
+                pass
+        return default
+
+    def _get_leaf(self, path):
+        path = self._greedy_path(path)
+        for param in self._rel_paths:
+            try:
+                return param.get_leaf(path)
+            except NoMatchError:
+                pass
+        raise NoMatchError('No leaves matchng "%s" pattern found in %s'
+                           % (path.pattern, self))
+
+    def objects(self, key, path=None):
+        """
+        Return the names of objects defined using a given key.
+
+        :param key: The name of the key whose value lists the objects
+                (e.g. 'nics').
+        """
+        return self.get(path, key, "").split()
+
+    def object_params(self, obj_name, path=None):
+        """
+        Return a dict-like object containing the parameters of an individual
+        object.
+
+        This method behaves as follows: the suffix '_' + obj_name is removed
+        from all key names that have it.  Other key names are left unchanged.
+        The values of keys with the suffix overwrite the values of their
+        suffix-less versions.
+
+        :param obj_name: The name of the object (objects are listed by the
+                objects() method).
+        """
+        suffix = "_" + obj_name
+        leaf = self._get_leaf(path)
+        self.lock.acquire()
+        new_dict = leaf.copy()
+        self.lock.release()
+        for key in new_dict.keys():
+            if key.endswith(suffix):
+                new_key = key.split(suffix)[0]
+                new_dict[new_key] = new_dict[key]
+        return new_dict
+
+    def object_counts(self, count_key, base_name, path=None):
+        """
+        This is a generator method: to give it the name of a count key and a
+        base_name, and it returns an iterator over all the values from params
+        """
+        count = self.get(count_key, 1)
+        # Protect in case original is modified for some reason
+        cpy = self._get_leaf(path).copy()
+        for number in xrange(1, int(count) + 1):
+            key = "%s%s" % (base_name, number)
+            yield (key, cpy.get(key))
+
+
+class AvocadoParam(object):
+
+    """
+    This is a single slice params. It can contain multiple leaves and tries to
+    find matching results.
+    Currently it doesn't care about params origin, it requires single result
+    or failure. In future it'll get the origin from LeafParam and if it's the
+    same it'll proceed.
+    """
+
+    def __init__(self, leaves, name):
+        # Basic initialization
+        self._leaves = leaves
+        self.name = name
+
+    @property
+    def _str_leaves_variant(self):
+        leaves = [_.name for _ in self._leaves]
+        return "%s (%s)" % (self.name, leaves)
+
+    def _get_leaves(self, path):
+        return [leaf for leaf in self._leaves if path.match(leaf.name)]
+
+    def get_leaf(self, path):
+        leaves = self._get_leaves(path)
+        if len(leaves) == 1:
+            return leaves[0]
+        elif len(leaves) == 0:
+            raise NoMatchError('No leaves matchng "%s" pattern found in %s'
+                               % (path.pattern, self._str_leaves_variant))
+        else:
+            raise KeyError('Multiple leaves matching "%s" found: %s'
+                           % (path.pattern, self._str_leaves_variant))
+
+    def get(self, path, key, default=None):
+        """
+        Returns value of key from $path path. Multiple matching path are
+        acceptable when only one of them contains the key.
+        """
+        try:
+            self.get_or_die(path, key)
+        except NoMatchError:
+            return default
+
+    def get_or_die(self, path, key):
+        """
+        Get a value or raise exception if not present
+        :raise NoMatchError: When no matches
+        :raise KeyError: When value is not certain (multiple matches)
+        """
+        leaves = self._get_leaves(path)
+        ret = [leaf[key] for leaf in leaves if key in leaf]
+        if len(ret) == 1:
+            return ret[0]
+        elif not ret:
+            raise NoMatchError("No matches to %s =>%s in %s"
+                               % (path, key, self._str_leaves_variant))
+        else:
+            raise ValueError("Multiple %s leaves contain the key %s; %s"
+                             % (path, key,
+                                ["%s=>%s" % (leaf.name, leaf[key])
+                                 for leaf in leaves if key in leaf]))

--- a/avocado/plugins/runner.py
+++ b/avocado/plugins/runner.py
@@ -112,6 +112,9 @@ class TestRunner(plugin.Plugin):
             mux = self.parser.add_argument_group('multiplex arguments')
             mux.add_argument('-m', '--multiplex-files', nargs='*', default=None,
                              help='Path(s) to a avocado multiplex (.yaml) file(s)')
+            mux.add_argument('--mux-entry', nargs='?', action='append',
+                             help='Entry path(s) to search for relative paths '
+                             'in mux trees')
             mux.add_argument('--filter-only', nargs='*', default=[],
                              help='Filter only path(s) from multiplexing')
             mux.add_argument('--filter-out', nargs='*', default=[],

--- a/avocado/test.py
+++ b/avocado/test.py
@@ -11,6 +11,7 @@
 # This code was inspired in the autotest project,
 # client/shared/test.py
 # Authors: Martin J Bligh <mbligh@google.com>, Andy Whitcroft <apw@shadowen.org>
+from avocado.params import AvocadoParams
 
 """
 Contains the base test implementation, used as a base for the actual
@@ -71,11 +72,11 @@ class Test(unittest.TestCase):
             self.name = self.__class__.__name__
 
         if params is None:
-            params = {}
-        self.params = Params(params)
+            params = AvocadoParams([], self, '', tag)
+        self.params = params
         self._raw_params = params
 
-        self.tag = tag or self.params.get('tag')
+        self.tag = tag or self.params.tag
         self.job = job
 
         basename = os.path.basename(self.name)
@@ -123,14 +124,14 @@ class Test(unittest.TestCase):
         self.log.debug('')
         self.log.debug('Test instance parameters:')
 
-        # Set the helper set_default to the params object
-        setattr(self.params, 'set_default', self._set_default)
-
         # Apply what comes from the params dict
+        '''
         for key in sorted(self.params.keys()):
             self.log.debug('    %s = %s', key, self.params.get(key))
         self.log.debug('')
+        '''
 
+        '''
         # Apply what comes from the default_params dict
         self.log.debug('Default parameters:')
         for key in sorted(self.default_params.keys()):
@@ -139,12 +140,13 @@ class Test(unittest.TestCase):
         self.log.debug('')
         self.log.debug('Test instance params override defaults whenever available')
         self.log.debug('')
+        '''
 
         # If there's a timeout set, log a timeout reminder
-        if self.params.timeout:
+        if self.params.get('*', 'timeout'):
             self.log.info('Test timeout set. Will wait %.2f s for '
                           'PID %s to end',
-                          float(self.params.timeout), os.getpid())
+                          float(self.params.get('*', 'timeout')), os.getpid())
             self.log.info('')
 
         self.debugdir = None
@@ -219,17 +221,11 @@ class Test(unittest.TestCase):
                 d[key] = orig[key]
             elif key in convert_attr:
                 d[key] = str(orig[key])
-        d['params'] = dict(orig['params'])
+        d['params'] = orig['params']
         d['class_name'] = self.__class__.__name__
         d['job_logdir'] = self.job.logdir
         d['job_unique_id'] = self.job.unique_id
         return d
-
-    def _set_default(self, key, default):
-        try:
-            self.params[key]
-        except Exception:
-            self.params[key] = default
 
     def get_data_path(self, basename):
         """

--- a/examples/tests/sleeptest.py
+++ b/examples/tests/sleeptest.py
@@ -11,14 +11,13 @@ class SleepTest(test.Test):
     """
     Example test for avocado.
     """
-    default_params = {'sleep_length': 1.0}
-
     def action(self):
         """
         Sleep for length seconds.
         """
-        self.log.debug("Sleeping for %.2f seconds", self.params.sleep_length)
-        time.sleep(self.params.sleep_length)
+        duration = self.params.get('*', 'sleep_length', 1)
+        self.log.debug("Sleeping for %.2f seconds", duration)
+        time.sleep(duration)
 
 
 if __name__ == "__main__":

--- a/examples/tests/sleeptest.py.data/sleeptest.yaml
+++ b/examples/tests/sleeptest.py.data/sleeptest.yaml
@@ -1,3 +1,4 @@
+!using : test
 short:
     sleep_length: 0.5
 medium:


### PR DESCRIPTION
__Please don't waste your time on code style, variable names, module names, etc. and focus only on the purpose of this patch__

This is incomplete demonstration of a way to support resolution order
(meaning slicing the tree according to test needs) and params with
namespaces (paths).

It's incomplete and full of hacks. It's focused on:

1. demonstrating the way to slice the params tree and define the
   params resolution order.
2. show on the "sleeptest" how to relative paths works

It doesn't implement:
1. params origin (to handle clashes in case of multiple values)
2. multiplexation ($DATA/default.yaml)
3. support to specify tests by multiplex file
4. support to inject variants to an individual test (not to all of them)
5. ...

Please use 2734cea9e84961edf1464c899afd877cc09041f4 as base for testing. I'll rebase it when preparing the final version.

V0: https://github.com/avocado-framework/avocado/pull/480

Changelog:

    v0: resolution order => entry point(s)
    v0: resolution order defined on cmdline, not in test
    v0: support for relative paths

How it works:

*  Default entry-point is '/test' (as mainly they are intended as test params)
*  Absolute paths are used as before
*  Relative paths are searched __ONLY__ in entry points (order dependent)
*  Default execution (match): `./scripts/avocado run examples/tests/sleeptest.py --filter-out /test/long /test/longest -m examples/tests/sleeptest.py.data/sleeptest.yaml --sysinfo=off`
*  Set global as default entry point (match): `./scripts/avocado run examples/tests/sleeptest.py --mux-entry '/*' --filter-out /test/long /test/longest -m examples/tests/sleeptest.py.data/sleeptest.yaml --sysinfo=off`
*  Set something else as entry point (uses defaults):  `./scripts/avocado run examples/tests/sleeptest.py --mux-entry '/something/*' --filter-out /test/long /test/longest -m examples/tests/sleeptest.py.data/sleeptest.yaml --sysinfo=off`
*  Set _None_ as path (no relative paths, defaults): `./scripts/avocado run examples/tests/sleeptest.py --mux-entry '' --filter-out /test/long /test/longest -m examples/tests/sleeptest.py.data/sleeptest.yaml --sysinfo=off`

_note: The `!using : test` inside `sleeptest.yaml` is not important. It can either stay as it was before (which might generate collisions with other params like `/config` (in the future)), or it can eg. use `by_duration` and we'd either use `-m /test:sleeptest.yaml` (not yet implemented) to use it with default paths, or set default entry point by `-m sleeptest.yaml --mux-entry '/by_duration'`._

Entry points:

Entry points are intended for combining huge multiplex files eg. from different departments. If we can't change the files to be able to merge them, we can simply combine them in different places and specify the order:

```yaml
QA:
    # Lots of variants with predefined variables
    ....
    release:
        variant1:
        variant2:
        variant3:
    ...
Devel:
    # Slightly adjusted some of the variables
    ....
    custom_params:
    .... 
```
We want to combine arguments from Devel and QA while we're unable to convince QA (or Devel) to export parts of the tree to be able to merge booth of them to single node (eg. `QA => /test`; `Devel => /test`). We can simply create all variants and set the path to `"/Devel/*", "/QA"`. This results in executing all variants and in case of relative paths (eg. params.get('*', 'timeout')) we first search inside `/Devel` and if not found in `/QA`.

There is one drawback, if booth entry points contain multiple variants, we're going to execute multiple variants with the same values. We can:

1. ignore this and let users to `--filter-only|out` the unnecessary variants
1. use variants only from first entry point (or first entry point which defines variants
1. detect the same variants from different entry points and execute them only once