### PR TITLE
scripts.avocado-bash-utils: Add Avocado bash utils [v4]

### DIFF
--- a/avocado/plugins/exec_path.py
+++ b/avocado/plugins/exec_path.py
@@ -1,0 +1,59 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2013-2014
+# Author: Ruda Moura <rmoura@redhat.com>
+"""
+Libexec PATHs modifier
+"""
+
+import os
+import sys
+
+from avocado.core import exit_codes
+from avocado.plugins import plugin
+
+
+class TestRunner(plugin.Plugin):
+
+    """
+    Implements the avocado 'exec-path' subcommand
+    """
+
+    name = 'test_runner'
+    enabled = True
+    priority = 0
+
+    def configure(self, parser):
+        """
+        Add the subparser for the exec-path action.
+
+        :param parser: Main test runner parser.
+        """
+        self.parser = parser.subcommands.add_parser(
+            'exec-path',
+            help='Returns path to avocado bash libraries and exits.')
+
+        super(TestRunner, self).configure(self.parser)
+        # Export the test runner parser back to the main parser
+        parser.runner = self.parser
+
+    def run(self, args):
+        """
+        Print libexec path and finish
+
+        :param args: Command line args received from the run subparser.
+        """
+        if 'VIRTUAL_ENV' in os.environ:
+            sys.stdout.write(os.path.join("libexec"))
+        else:
+            sys.stdout.write(os.path.join("/", "usr", "libexec", "avocado"))
+        return sys.exit(exit_codes.AVOCADO_ALL_OK)

--- a/avocado/test.py
+++ b/avocado/test.py
@@ -11,6 +11,7 @@
 # This code was inspired in the autotest project,
 # client/shared/test.py
 # Authors: Martin J Bligh <mbligh@google.com>, Andy Whitcroft <apw@shadowen.org>
+import re
 
 """
 Contains the base test implementation, used as a base for the actual
@@ -524,6 +525,9 @@ class SimpleTest(Test):
     Run an arbitrary command that returns either 0 (PASS) or !=0 (FAIL).
     """
 
+    re_avocado_log = re.compile(r'^\d\d:\d\d:\d\d DEBUG\| \[stdout\]'
+                                r' \d\d:\d\d:\d\d WARN \|')
+
     def __init__(self, path, params=None, base_logdir=None, tag=None, job=None):
         self.path = os.path.abspath(path)
         super(SimpleTest, self).__init__(name=path, base_logdir=base_logdir,
@@ -543,9 +547,8 @@ class SimpleTest(Test):
 
         :param result: :class:`avocado.utils.process.CmdResult` instance.
         """
-        run_info = str(result)
-        for line in run_info.splitlines():
-            self.log.info(line)
+        self.log.info("Exit status: %s", result.exit_status)
+        self.log.info("Duration: %s", result.duration)
 
     def action(self):
         """
@@ -561,6 +564,14 @@ class SimpleTest(Test):
         except exceptions.CmdError, details:
             self._log_detailed_cmd_info(details.result)
             raise exceptions.TestFail(details)
+
+    def runTest(self, result=None):
+        super(SimpleTest, self).runTest(result)
+        for line in open(self.logfile):
+            if self.re_avocado_log.match(line):
+                raise exceptions.TestWarn("Test passed but there were warnings"
+                                          " on stdout during execution. Check "
+                                          "the log for details.")
 
 
 class MissingTest(Test):

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -711,6 +711,20 @@ Here are the current variables that Avocado exports to the tests:
 | *                       | All variables from --multiplex-file   | TIMEOUT=60; IO_WORKERS=10; VM_BYTES=512M; ...                                                       |
 +-------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
 
+
+Simple Tests BASH extensions
+============================
+
+To enhance simple tests one can use supported set of libraries we created. The
+only requirement is to use::
+
+    PATH=$(avocado "exec-path"):$PATH
+
+which injects path to avocado utils into shell PATH. Take a look into
+``avocado exec-path`` to see list of available functions and take a look at
+``examples/tests/simplewarning.sh`` for inspiration.
+
+
 Wrap Up
 =======
 

--- a/examples/tests/simplewarning.sh
+++ b/examples/tests/simplewarning.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+PATH=$(avocado "exec-path"):$PATH
+
+avocado_debug "Debug message"
+avocado_info "Info message"
+avocado_warn "Warning message (should cause this test to finish with warning)"
+avocado_error "Error message (ordinary message not changing the results)"
+echo "Simple output without log-level specification"
+exit 0  # no error reported

--- a/libexec/avocado-bash-utils
+++ b/libexec/avocado-bash-utils
@@ -1,0 +1,20 @@
+#!/bin/sh
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2014
+
+# Write to avocado_log
+# First argument is the log level
+avocado_log() {
+    LEVEL=`printf '%-5s' $1`
+    shift
+    echo "`date '+%H:%M:%S'` $LEVEL| $*"
+}

--- a/libexec/avocado_debug
+++ b/libexec/avocado_debug
@@ -1,0 +1,4 @@
+#!/bin/sh
+. avocado-bash-utils
+
+avocado_log DEBUG $*

--- a/libexec/avocado_error
+++ b/libexec/avocado_error
@@ -1,0 +1,4 @@
+#!/bin/sh
+. avocado-bash-utils
+
+avocado_log ERROR $*

--- a/libexec/avocado_info
+++ b/libexec/avocado_info
@@ -1,0 +1,4 @@
+#!/bin/sh
+. avocado-bash-utils
+
+avocado_log INFO $*

--- a/libexec/avocado_warn
+++ b/libexec/avocado_warn
@@ -1,0 +1,4 @@
+#!/bin/sh
+. avocado-bash-utils
+
+avocado_log WARN $*

--- a/scripts/avocado
+++ b/scripts/avocado
@@ -20,6 +20,7 @@ import sys
 # simple magic for using scripts within a source tree
 basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if os.path.isdir(os.path.join(basedir, 'avocado')):
+    os.environ['PATH'] += ":" + os.path.join(basedir, 'libexec')
     sys.path.append(basedir)
 
 from avocado.cli.app import AvocadoApp

--- a/selftests/all/functional/avocado/basic_tests.py
+++ b/selftests/all/functional/avocado/basic_tests.py
@@ -266,6 +266,24 @@ class RunnerSimpleTest(unittest.TestCase):
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %d:\n%s" % (expected_rc, result))
 
+    def test_simplewarning(self):
+        """
+        simplewarning.sh uses the avocado-bash-utils
+        """
+        os.chdir(basedir)
+        cmd_line = ('./scripts/avocado run --sysinfo=off '
+                    'examples/tests/simplewarning.sh --show-job-log')
+        result = process.run(cmd_line, ignore_status=True)
+        self.assertEqual(result.exit_status, 0,
+                         "Avocado did not return rc 0:\n%s" %
+                         (result))
+        self.assertIn('DEBUG| Debug message', result.stdout, result)
+        self.assertIn('INFO | Info message', result.stdout)
+        self.assertIn('WARN | Warning message (should cause this test to '
+                      'finish with warning)', result.stdout, result)
+        self.assertIn('ERROR| Error message (ordinary message not changing '
+                      'the results)', result.stdout, result)
+
     def tearDown(self):
         self.pass_script.remove()
         self.fail_script.remove()

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,8 @@ def get_data_files():
                     glob.glob('examples/wrappers/*.sh'))]
     data_files += [(get_dir(['usr', 'share', 'avocado', 'api'], ['api']),
                     glob.glob('examples/api/*/*.py'))]
+    data_files.append((get_dir(['usr', 'libexec', 'avocado'], ['libexec']),
+                       glob.glob('libexec/*')))
     return data_files
 
 

--- a/setup.py
+++ b/setup.py
@@ -22,62 +22,48 @@ from distutils.core import setup
 import avocado.version
 
 
-def get_settings_dir():
-    settings_system_wide = os.path.join('/etc', 'avocado')
-    settings_local_install = os.path.join('etc', 'avocado')
-    if 'VIRTUAL_ENV' in os.environ:
-        return settings_local_install
+VIRTUAL_ENV = 'VIRTUAL_ENV' in os.environ
+
+
+def get_dir(system_path=None, virtual_path=None):
+    """
+    Retrieve VIRTUAL_ENV friendly path
+    :param system_path: Relative system path
+    :param virtual_path: Overrides system_path for virtual_env only
+    :return: VIRTUAL_ENV friendly path
+    """
+    if virtual_path is None:
+        virtual_path = system_path
+    if VIRTUAL_ENV:
+        if virtual_path is None:
+            virtual_path = []
+        return os.path.join(virtual_path)
     else:
-        return settings_system_wide
+        if system_path is None:
+            system_path = []
+        return os.path.join(*(['/'] + system_path))
 
 
 def get_tests_dir():
-    settings_system_wide = os.path.join('/usr', 'share', 'avocado', 'tests')
-    settings_local_install = os.path.join('tests')
-    if 'VIRTUAL_ENV' in os.environ:
-        return settings_local_install
-    else:
-        return settings_system_wide
-
-
-def get_docs_dir():
-    settings_system_wide = os.path.join('/usr', 'share', 'doc', 'avocado')
-    settings_local_install = ''
-    if 'VIRTUAL_ENV' in os.environ:
-        return settings_local_install
-    else:
-        return settings_system_wide
-
-
-def get_wrappers_dir():
-    settings_system_wide = os.path.join('/usr', 'share', 'avocado', 'wrappers')
-    settings_local_install = 'wrappers'
-    if 'VIRTUAL_ENV' in os.environ:
-        return settings_local_install
-    else:
-        return settings_system_wide
-
-
-def get_api_dir():
-    settings_system_wide = os.path.join('/usr', 'share', 'avocado', 'api')
-    settings_local_install = 'api'
-    if 'VIRTUAL_ENV' in os.environ:
-        return settings_local_install
-    else:
-        return settings_system_wide
+    return get_dir(['usr', 'share', 'avocado', 'tests'], ['tests'])
 
 
 def get_data_files():
-    data_files = [(get_settings_dir(), ['etc/avocado/avocado.conf'])]
-    data_files += [(os.path.join(get_settings_dir(), 'conf.d'), ['etc/avocado/conf.d/README'])]
+    data_files = [(get_dir(['etc']), ['etc/avocado/avocado.conf'])]
+    data_files += [(get_dir(['etc', 'conf.d']), ['etc/avocado/conf.d/README'])]
     data_files += [(get_tests_dir(), glob.glob('examples/tests/*.py'))]
     for data_dir in glob.glob('examples/tests/*.data'):
         fmt_str = '%s/*' % data_dir
         for f in glob.glob(fmt_str):
-            data_files += [(os.path.join(get_tests_dir(), os.path.basename(data_dir)), [f])]
-    data_files.append((get_docs_dir(), ['man/avocado.rst', 'man/avocado-rest-client.rst']))
-    data_files += [(get_wrappers_dir(), glob.glob('examples/wrappers/*.sh'))]
-    data_files += [(get_api_dir(), glob.glob('examples/api/*/*.py'))]
+            data_files += [(os.path.join(get_tests_dir(),
+                                         os.path.basename(data_dir)), [f])]
+    data_files.append((get_dir(['usr', 'share', 'doc', 'avocado'], []),
+                       ['man/avocado.rst', 'man/avocado-rest-client.rst']))
+    data_files += [(get_dir(['usr', 'share', 'avocado', 'wrappers'],
+                            ['wrappers']),
+                    glob.glob('examples/wrappers/*.sh'))]
+    data_files += [(get_dir(['usr', 'share', 'avocado', 'api'], ['api']),
+                    glob.glob('examples/api/*/*.py'))]
     return data_files
 
 


### PR DESCRIPTION
This patch is initial support for people using custom bash scripts
with avocado. They can use "source avocado-bash-utils" to get the
functions into their bash script and utilize them.

This version contain functions to write to Test.log the same way it's
possible from python including failing the test with TestWarn in case
avocado_warn was used.

v0: https://github.com/avocado-framework/avocado/pull/419
v1: https://github.com/avocado-framework/avocado/pull/428
v2: https://github.com/avocado-framework/avocado/pull/447
v3: https://github.com/avocado-framework/avocado/pull/460

    v1: Instead of custom logging to self and whole job logs use stdout
    v1: Simplify the in-bash-log format to "$time $log_level |"
    v1: Use regexp to check "warning" presense (decrease probability of false-warnings)
    v2: Added documentation
    v2: Added functional test
    v2: Auto-append "$AVOCAOD/scripts" path to PATH when executing from sources
    v2: Added missing space in error message
    v3: Removed the non-verbose execution as it corrupts `stdout`/`stderr`
    v4: Add support for "avocado exec-path"
    v4: Use '''PATH=$(avocado "exec-path"):$PATH''' to enable bash utils
    v4: Modify "setup.py" to be more readable
    v4: Install bash utils to /usr/libexec/avocado