### PR TITLE
avocado.job: Refactor how multiplexation happens

### DIFF
--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -43,8 +43,6 @@ except ImportError:
     MULTIPLEX_CAPABLE = False
 else:
     MULTIPLEX_CAPABLE = True
-
-if MULTIPLEX_CAPABLE:
     try:
         from yaml import CLoader as Loader
     except ImportError:

--- a/avocado/job.py
+++ b/avocado/job.py
@@ -91,11 +91,6 @@ class Job(object):
         self.show_job_log = getattr(self.args, 'show_job_log', False)
         self.silent = getattr(self.args, 'silent', False)
 
-        if multiplexer.MULTIPLEX_CAPABLE:
-            self.multiplex_files = getattr(self.args, 'multiplex_files', None)
-        else:
-            self.multiplex_files = None
-
         if self.standalone:
             self.show_job_log = True
             if self.args is not None:
@@ -220,34 +215,7 @@ class Job(object):
             human_plugin = result.HumanTestResult(self.view, self.args)
             self.result_proxy.add_output_plugin(human_plugin)
 
-    def _multiplex_params_list(self, params_list, multiplex_files):
-        for mux_file in multiplex_files:
-            if not os.path.exists(mux_file):
-                e_msg = "Multiplex file %s doesn't exist." % mux_file
-                raise exceptions.OptionValidationError(e_msg)
-        result = []
-        for params in params_list:
-            try:
-                variants = multiplexer.multiplex_yamls(multiplex_files,
-                                                       self.args.filter_only,
-                                                       self.args.filter_out)
-            except SyntaxError:
-                variants = None
-            if variants:
-                tag = 1
-                for variant in variants:
-                    env = {}
-                    for t in variant:
-                        env.update(dict(t.environment))
-                    env.update({'tag': tag})
-                    env.update({'id': params['id']})
-                    result.append(env)
-                    tag += 1
-            else:
-                result.append(params)
-        return result
-
-    def _run(self, urls=None, multiplex_files=None):
+    def _run(self, urls=None):
         """
         Unhandled job method. Runs a list of test URLs to its completion.
 
@@ -275,14 +243,7 @@ class Job(object):
 
         params_list = self.test_loader.discover_urls(urls)
 
-        if multiplexer.MULTIPLEX_CAPABLE:
-            if multiplex_files is None:
-                multiplex_files = getattr(self.args, 'multiplex_files', None)
-
-            if multiplex_files is not None:
-                params_list = self._multiplex_params_list(params_list,
-                                                          multiplex_files)
-
+        mux = multiplexer.Mux(self.args)
         self._setup_job_results()
 
         try:
@@ -320,7 +281,7 @@ class Job(object):
         _TEST_LOGGER.info('')
 
         self.view.logfile = self.logfile
-        failures = self.test_runner.run_suite(test_suite)
+        failures = self.test_runner.run_suite(test_suite, mux)
         self.view.stop_file_logging()
         if not self.standalone:
             self._update_latest_link()
@@ -340,7 +301,7 @@ class Job(object):
         else:
             return exit_codes.AVOCADO_TESTS_FAIL
 
-    def run(self, urls=None, multiplex_files=None):
+    def run(self, urls=None):
         """
         Handled main job method. Runs a list of test URLs to its completion.
 
@@ -365,7 +326,7 @@ class Job(object):
         """
         runtime.CURRENT_JOB = self
         try:
-            return self._run(urls, multiplex_files)
+            return self._run(urls)
         except exceptions.JobBaseException, details:
             self.status = details.status
             fail_class = details.__class__.__name__

--- a/avocado/runner.py
+++ b/avocado/runner.py
@@ -111,7 +111,109 @@ class TestRunner(object):
             test_state['text_output'] = log_file_obj.read()
         return test_state
 
-    def run_suite(self, test_suite):
+    def _run_test(self, test_factory, q, failures):
+        p = multiprocessing.Process(target=self.run_test,
+                                    args=(test_factory, q,))
+
+        cycle_timeout = 1
+        time_started = time.time()
+        test_state = None
+
+        p.start()
+
+        early_state = q.get()
+
+        if 'load_exception' in early_state:
+            self.job.view.notify(event='error',
+                                 msg='Avocado crashed during test load. '
+                                     'Some reports might have not been '
+                                     'generated. Aborting...')
+            sys.exit(exit_codes.AVOCADO_FAIL)
+
+        # At this point, the test is already initialized and we know
+        # for sure if there's a timeout set.
+        timeout = early_state['params'].get('timeout', self.DEFAULT_TIMEOUT)
+        time_deadline = time_started + timeout
+
+        ctrl_c_count = 0
+        ignore_window = 2.0
+        ignore_time_started = time.time()
+        stage_1_msg_displayed = False
+        stage_2_msg_displayed = False
+
+        while True:
+            try:
+                if time.time() >= time_deadline:
+                    os.kill(p.pid, signal.SIGUSR1)
+                    break
+                wait.wait_for(lambda: not q.empty() or not p.is_alive(),
+                              cycle_timeout, first=0.01, step=0.1)
+                if not q.empty():
+                    test_state = q.get()
+                    if not test_state['running']:
+                        break
+                    else:
+                        self.job.result_proxy.notify_progress(True)
+                        if test_state['paused']:
+                            msg = test_state['paused_msg']
+                            if msg:
+                                self.job.view.notify(event='partial', msg=msg)
+
+                elif p.is_alive():
+                    if ctrl_c_count == 0:
+                        self.job.result_proxy.notify_progress()
+                else:
+                    break
+
+            except KeyboardInterrupt:
+                time_elapsed = time.time() - ignore_time_started
+                ctrl_c_count += 1
+                if ctrl_c_count == 2:
+                    if not stage_1_msg_displayed:
+                        k_msg_1 = ("SIGINT sent to tests, waiting for their "
+                                   "reaction")
+                        k_msg_2 = ("Ignoring Ctrl+C during the next "
+                                   "%d seconds so they can try to finish" %
+                                   ignore_window)
+                        k_msg_3 = ("A new Ctrl+C sent after that will send a "
+                                   "SIGKILL to them")
+                        self.job.view.notify(event='message', msg=k_msg_1)
+                        self.job.view.notify(event='message', msg=k_msg_2)
+                        self.job.view.notify(event='message', msg=k_msg_3)
+                        stage_1_msg_displayed = True
+                    ignore_time_started = time.time()
+                if (ctrl_c_count > 2) and (time_elapsed > ignore_window):
+                    if not stage_2_msg_displayed:
+                        k_msg_3 = ("Ctrl+C received after the ignore window. "
+                                   "Killing all active tests")
+                        self.job.view.notify(event='message', msg=k_msg_3)
+                        stage_2_msg_displayed = True
+                    os.kill(p.pid, signal.SIGKILL)
+
+        # If test_state is None, the test was aborted before it ended.
+        if test_state is None:
+            if p.is_alive() and wait.wait_for(lambda: not q.empty(),
+                                              cycle_timeout, first=0.01, step=0.1):
+                test_state = q.get()
+            else:
+                early_state['time_elapsed'] = time.time() - time_started
+                test_state = self._fill_aborted_test_state(early_state)
+                test_log = logging.getLogger('avocado.test')
+                test_log.error('ERROR %s -> TestAbortedError: '
+                               'Test aborted unexpectedly',
+                               test_state['name'])
+
+        # don't process other tests from the list
+        if ctrl_c_count > 0:
+            self.job.view.notify(event='minor', msg='')
+            return False
+
+        self.result.check_test(test_state)
+        if not status.mapping[test_state['status']]:
+            failures.append(test_state['name'])
+        return True
+
+    def run_suite(self, test_suite, mux):
         """
         Run one or more tests and report with test result.
 
@@ -125,110 +227,14 @@ class TestRunner(object):
         self.result.start_tests()
         q = queues.SimpleQueue()
 
-        for test_factory in test_suite:
-            p = multiprocessing.Process(target=self.run_test,
-                                        args=(test_factory, q,))
-
-            cycle_timeout = 1
-            time_started = time.time()
-            test_state = None
-
-            p.start()
-
-            early_state = q.get()
-
-            if 'load_exception' in early_state:
-                self.job.view.notify(event='error',
-                                     msg='Avocado crashed during test load. '
-                                         'Some reports might have not been '
-                                         'generated. Aborting...')
-                sys.exit(exit_codes.AVOCADO_FAIL)
-
-            # At this point, the test is already initialized and we know
-            # for sure if there's a timeout set.
-            if 'timeout' in early_state['params'].keys():
-                timeout = float(early_state['params']['timeout'])
-            else:
-                timeout = self.DEFAULT_TIMEOUT
-
-            time_deadline = time_started + timeout
-
-            ctrl_c_count = 0
-            ignore_window = 2.0
-            ignore_time_started = time.time()
-            stage_1_msg_displayed = False
-            stage_2_msg_displayed = False
-
-            while True:
-                try:
-                    if time.time() >= time_deadline:
-                        os.kill(p.pid, signal.SIGUSR1)
-                        break
-                    wait.wait_for(lambda: not q.empty() or not p.is_alive(),
-                                  cycle_timeout, first=0.01, step=0.1)
-                    if not q.empty():
-                        test_state = q.get()
-                        if not test_state['running']:
-                            break
-                        else:
-                            self.job.result_proxy.notify_progress(True)
-                            if test_state['paused']:
-                                msg = test_state['paused_msg']
-                                if msg:
-                                    self.job.view.notify(event='partial', msg=msg)
-
-                    elif p.is_alive():
-                        if ctrl_c_count == 0:
-                            self.job.result_proxy.notify_progress()
-                    else:
-                        break
-
-                except KeyboardInterrupt:
-                    time_elapsed = time.time() - ignore_time_started
-                    ctrl_c_count += 1
-                    if ctrl_c_count == 2:
-                        if not stage_1_msg_displayed:
-                            k_msg_1 = ("SIGINT sent to tests, waiting for their "
-                                       "reaction")
-                            k_msg_2 = ("Ignoring Ctrl+C during the next "
-                                       "%d seconds so they can try to finish" %
-                                       ignore_window)
-                            k_msg_3 = ("A new Ctrl+C sent after that will send a "
-                                       "SIGKILL to them")
-                            self.job.view.notify(event='message', msg=k_msg_1)
-                            self.job.view.notify(event='message', msg=k_msg_2)
-                            self.job.view.notify(event='message', msg=k_msg_3)
-                            stage_1_msg_displayed = True
-                        ignore_time_started = time.time()
-                    if (ctrl_c_count > 2) and (time_elapsed > ignore_window):
-                        if not stage_2_msg_displayed:
-                            k_msg_3 = ("Ctrl+C received after the ignore window. "
-                                       "Killing all active tests")
-                            self.job.view.notify(event='message', msg=k_msg_3)
-                            stage_2_msg_displayed = True
-                        os.kill(p.pid, signal.SIGKILL)
-
-            # If test_state is None, the test was aborted before it ended.
-            if test_state is None:
-                if p.is_alive() and wait.wait_for(lambda: not q.empty(),
-                                                  cycle_timeout, first=0.01, step=0.1):
-                    test_state = q.get()
-                else:
-                    early_state['time_elapsed'] = time.time() - time_started
-                    test_state = self._fill_aborted_test_state(early_state)
-                    test_log = logging.getLogger('avocado.test')
-                    test_log.error('ERROR %s -> TestAbortedError: '
-                                   'Test aborted unexpectedly',
-                                   test_state['name'])
-
-            # don't process other tests from the list
-            if ctrl_c_count > 0:
-                self.job.view.notify(event='minor', msg='')
+        ctrl_c = False
+        for test_template in test_suite:
+            for test_factory in mux.itertests(test_template):
+                if not self._run_test(test_factory, q, failures):
+                    ctrl_c = True
+                    break
+            if ctrl_c:
                 break
-
-            self.result.check_test(test_state)
-            if not status.mapping[test_state['status']]:
-                failures.append(test_state['name'])
         runtime.CURRENT_TEST = None
         self.result.end_tests()
         if self.job.sysinfo is not None:

--- a/avocado/test.py
+++ b/avocado/test.py
@@ -291,28 +291,23 @@ class Test(unittest.TestCase):
         """
         Get a test tagged name.
 
-        If a test tag is defined, just return name.tag. If tag is absent,
-        it'll try to find a tag that is not already taken (so there are no
-        clashes in the results directory).
+        Combines name + tag (if present) to obtain unique name. When associated
+        directory already exists, appends ".$number" until unused name
+        is generated to avoid clashes.
 
         :param logdir: Log directory being in use for result storage.
 
-        :return: String `test.tag`.
+        :return: Unique test name
         """
+        name = self.name
         if self.tag is not None:
-            return "%s.%s" % (self.name, self.tag)
-
+            name += ".%s" % self.tag
         tag = 0
-        if tag == 0:
-            tagged_name = self.name
-        else:
-            tagged_name = "%s.%s" % (self.name, tag)
-        test_logdir = os.path.join(logdir, tagged_name)
-        while os.path.isdir(test_logdir):
+        tagged_name = name
+        while os.path.isdir(os.path.join(logdir, tagged_name)):
             tag += 1
-            tagged_name = "%s.%s" % (self.name, tag)
-            test_logdir = os.path.join(logdir, tagged_name)
-        self.tag = str(tag)
+            tagged_name = "%s.%s" % (name, tag)
+        self.tag = "%s.%s" % (self.tag, tag) if self.tag else str(tag)
 
         return tagged_name
 


### PR DESCRIPTION
Hello guys,

apart from one bugfix this patch makes no real changes (therefor no unittests needs to be adjusted), it only refactors how we generate multiplexed variants. It prepares the code for the "real" multiplexer with namespaces support. I'd like to do these little steps rather then preparing a big patch set with all the changes.

Regards,
Lukáš