### PR TITLE
avocado.aexpect: Fix bugs that broke avocado-virt

### DIFF
--- a/avocado/aexpect.py
+++ b/avocado/aexpect.py
@@ -15,10 +15,6 @@ import tempfile
 import logging
 import shutil
 
-from avocado.utils import genio
-from avocado.utils import path as utils_path
-
-
 BASE_DIR = os.environ.get('TMPDIR', '/tmp')
 # If you want to debug problems with your aexpect instances, setting
 # DEBUG = True will leave the temporary files created by aexpect around
@@ -277,7 +273,9 @@ except ImportError:
 from avocado.utils import astring
 from avocado.utils import data_factory
 from avocado.utils import process
+from avocado.utils import genio
 from avocado.utils import wait
+from avocado.utils import path as utils_path
 
 
 class ExpectError(Exception):

--- a/avocado/aexpect.py
+++ b/avocado/aexpect.py
@@ -15,6 +15,13 @@ import tempfile
 import logging
 import shutil
 
+# ATTENTION: Do not import avocado libraries in this side of the aexpect
+# module. This side of the module will be executed stand alone and will not
+# have access to the avocado libraries. If you do that, the server won't
+# start, making the client to wait indefinitely for the server and creating
+# a deadlock. Import avocado libs if necessary below, where the other avocado
+# imports are defined.
+
 BASE_DIR = os.environ.get('TMPDIR', '/tmp')
 # If you want to debug problems with your aexpect instances, setting
 # DEBUG = True will leave the temporary files created by aexpect around


### PR DESCRIPTION
We can't require avocado imports in the server part of
the aexpect process because that will be executed
stand alone, and will not have access to the rest
of the avocado libraries. The bugs were introduced
in commits:

6f380e0d77d839dac1b30987e84fa300b4a99058
3fa9077f133b2445f839056cd568d21d14f7975d

This patch fixes the problem by moving the imports
to the client side of the module.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>