### PR TITLE
Include virt API on readthedocs.org

### DIFF
--- a/avocado/__main__.py
+++ b/avocado/__main__.py
@@ -6,8 +6,6 @@ import sys
 
 from avocado.cli.app import AvocadoApp
 
-if sys.argv[0].endswith('__main__.py'):
-    sys.argv[0] = 'python -m avocado'
-
-main = AvocadoApp()
-main.run()
+if __name__ == '__main__':
+    main = AvocadoApp()
+    sys.exit(main.run())

--- a/avocado/cli/parser.py
+++ b/avocado/cli/parser.py
@@ -22,6 +22,9 @@ import argparse
 
 from avocado.version import VERSION
 
+PROG = 'avocado'
+DESCRIPTION = 'Avocado Test Runner'
+
 
 class Parser(object):
 
@@ -31,9 +34,9 @@ class Parser(object):
 
     def __init__(self):
         self.application = argparse.ArgumentParser(
-            prog='avocado',
+            prog=PROG,
             add_help=False,  # see parent parsing
-            description='Avocado Test Runner')
+            description=DESCRIPTION)
         self.application.add_argument('-v', '--version', action='version',
                                       version='Avocado %s' % VERSION)
         self.application.add_argument('--plugins', action='store',
@@ -49,8 +52,10 @@ class Parser(object):
         """
         self.args, _ = self.application.parse_known_args()
 
-        # Use parent parsing to avoid to break the output of --help option
-        self.application = argparse.ArgumentParser(parents=[self.application])
+        # Use parent parsing to avoid breaking the output of --help option
+        self.application = argparse.ArgumentParser(prog=PROG,
+                                                   description=DESCRIPTION,
+                                                   parents=[self.application])
 
         # Subparsers where Avocado subcommands are plugged
         self.subcommands = self.application.add_subparsers(

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2,6 +2,7 @@
 
 import sys
 import os
+import shutil
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -13,10 +14,22 @@ import avocado.version
 from avocado.utils import path
 from avocado.utils import process
 
+# Flag that tells if the docs are being built on readthedocs.org
+ON_RTD = os.environ.get('READTHEDOCS', None) == 'True'
+
 # Auto generate API documentation
 _sphinx_apidoc = path.find_command('sphinx-apidoc')
 _output_dir = os.path.join(root_path, 'docs', 'source', 'api')
 _api_dir = os.path.join(root_path, 'avocado')
+
+if ON_RTD:
+    git = path.find_command('git', False)
+    if git is not False:
+        cmd = "%s clone git://github.com/avocado-framework/avocado-virt.git %s"
+        process.run(cmd % (git, os.path.join(root_path, 'avocado-virt')))
+        shutil.move(os.path.join(root_path, 'avocado-virt', 'avocado', 'virt'),
+                    _api_dir)
+
 process.run("%s -o %s %s" % (_sphinx_apidoc, _output_dir, _api_dir))
 
 extensions = ['sphinx.ext.autodoc',
@@ -31,11 +44,7 @@ copyright = u'2014, Red Hat'
 version = avocado.version.VERSION
 release = avocado.version.VERSION
 
-# on_rtd is whether we are on readthedocs.org, this line of code grabbed from
-# docs.readthedocs.org
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-
-if not on_rtd:  # only import and set the theme if we're building docs locally
+if not ON_RTD:  # only import and set the theme if we're building docs locally
     try:
         import sphinx_rtd_theme
         html_theme = 'sphinx_rtd_theme'


### PR DESCRIPTION
This PR adds the `avocado-virt` API documentation alongside avocado's code API.

This was tested on a separate repo and can be seen at work over at:

https://avocado-doc-tmp.readthedocs.org/en/latest/api/avocado.virt.html