### PR TITLE
Support for multiple tests [V1]

### DIFF
--- a/avocado/loader.py
+++ b/avocado/loader.py
@@ -53,6 +53,19 @@ class TestLoader(object):
             job = _DebugJob()
         self.job = job
 
+    def _is_unittests_like(self, test_class, pattern='test'):
+        for name, _ in inspect.getmembers(test_class, inspect.ismethod):
+            if name.startswith(pattern):
+                return True
+        return False
+
+    def _make_unittests_like(self, test_class, pattern='test'):
+        test_methods = []
+        for name, obj in inspect.getmembers(test_class, inspect.ismethod):
+            if name.startswith(pattern):
+                test_methods.append((name, obj))
+        return test_methods
+
     def _make_missing_test(self, test_name, params):
         test_class = test.MissingTest
         test_parameters = {'name': test_name,
@@ -77,7 +90,7 @@ class TestLoader(object):
                            'job': self.job}
         return test_class, test_parameters
 
-    def _make_test(self, test_name, test_path, params):
+    def _make_tests(self, test_name, test_path, params):
         module_name = os.path.basename(test_path).split('.')[0]
         test_module_dir = os.path.dirname(test_path)
         sys.path.append(test_module_dir)
@@ -103,7 +116,16 @@ class TestLoader(object):
             if test_class is not None:
                 # Module is importable and does have an avocado test class
                 # inside, let's proceed.
-                test_parameters = test_parameters_name
+                if self._is_unittests_like(test_class):
+                    test_factories = []
+                    for test_method in self._make_unittests_like(test_class):
+                        copy_test_parameters_name = test_parameters_name.copy()
+                        copy_test_parameters_name['methodName'] = test_method[0]
+                        copy_test_parameters_name['name'] += '.' + test_method[0]
+                        test_factories.append([test_class, copy_test_parameters_name])
+                    return test_factories
+                else:
+                    test_parameters = test_parameters_name
             else:
                 if os.access(test_path, os.X_OK):
                     # Module does not have an avocado test class inside but
@@ -147,27 +169,26 @@ class TestLoader(object):
 
         sys.path.pop(sys.path.index(test_module_dir))
 
-        return test_class, test_parameters
+        return [(test_class, test_parameters)]
 
-    def discover_test(self, params):
+    def discover_tests(self, params):
         """
-        Try to discover and resolve a test.
+        Try to discover and resolve tests.
 
         :param params: dictionary with test parameters.
         :type params: dict
-        :return: a test factory (a pair of test class and test parameters)
-                 or `None`.
+        :return: a list of test factories (a pair of test class and test parameters).
         """
         test_name = test_path = params.get('id')
         if os.path.exists(test_path):
             if os.access(test_path, os.R_OK) is False:
-                return (AccessDeniedPath,
-                        {'params': {'id': test_path}})
+                return [(AccessDeniedPath, {'params': {'id': test_path}})]
             path_analyzer = path.PathInspector(test_path)
             if path_analyzer.is_python():
-                test_class, test_parameters = self._make_test(test_name,
-                                                              test_path,
-                                                              params)
+                test_factories = self._make_tests(test_name,
+                                                  test_path,
+                                                  params)
+                return test_factories
             else:
                 if os.access(test_path, os.X_OK):
                     test_class, test_parameters = self._make_simple_test(test_path,
@@ -179,21 +200,20 @@ class TestLoader(object):
             if os.path.islink(test_path):
                 try:
                     if not os.path.isfile(os.readlink(test_path)):
-                        return BrokenSymlink, {'params': {'id': test_path}}
+                        return [(BrokenSymlink, {'params': {'id': test_path}})]
                 except OSError:
-                    return AccessDeniedPath, {'params': {'id': test_path}}
+                    return [(AccessDeniedPath, {'params': {'id': test_path}})]
 
             # Try to resolve test ID (keep compatibility)
             rel_path = '%s.py' % test_name
             test_path = os.path.join(data_dir.get_test_dir(), rel_path)
             if os.path.exists(test_path):
-                test_class, test_parameters = self._make_test(rel_path,
-                                                              test_path,
-                                                              params)
+                test_factories = self._make_tests(rel_path, test_path, params)
+                return test_factories
             else:
                 test_class, test_parameters = self._make_missing_test(
                     test_name, params)
-        return test_class, test_parameters
+        return [(test_class, test_parameters)]
 
     def discover_url(self, url):
         """
@@ -264,15 +284,16 @@ class TestLoader(object):
         """
         test_suite = []
         for params in params_list:
-            test_factory = self.discover_test(params)
-            if test_factory is None:
-                continue
-            test_class, test_parameters = test_factory
-            if test_class in [test.NotATest, BrokenSymlink, AccessDeniedPath]:
-                if not params.get('omit_non_tests'):
+            test_factories = self.discover_tests(params)
+            for test_factory in test_factories:
+                if test_factory is None:
+                    continue
+                test_class, test_parameters = test_factory
+                if test_class in [test.NotATest, BrokenSymlink, AccessDeniedPath]:
+                    if not params.get('omit_non_tests'):
+                        test_suite.append((test_class, test_parameters))
+                else:
                     test_suite.append((test_class, test_parameters))
-            else:
-                test_suite.append((test_class, test_parameters))
         return test_suite
 
     @staticmethod

--- a/avocado/test.py
+++ b/avocado/test.py
@@ -48,7 +48,7 @@ class Test(unittest.TestCase):
     Base implementation for the test class.
 
     You'll inherit from this to write your own tests. Typically you'll want
-    to implement setup(), action() and cleanup() methods on your own tests.
+    to implement setUp(), runTest() and tearDown() methods on your own tests.
     """
     default_params = {}
 
@@ -181,7 +181,7 @@ class Test(unittest.TestCase):
         self.runner_queue = runner_queue
 
         self.time_elapsed = None
-        unittest.TestCase.__init__(self)
+        unittest.TestCase.__init__(self, methodName=methodName)
 
     def __str__(self):
         return str(self.name)
@@ -312,9 +312,9 @@ class Test(unittest.TestCase):
 
         return tagged_name
 
-    def setup(self):
+    def setUp(self):
         """
-        Setup stage that the test needs before passing to the actual action.
+        Setup stage that the test needs before passing to the actual runTest.
 
         Must be implemented by tests if they want such an stage. Commonly we'll
         download/compile test suites, create files needed for a test, among
@@ -322,7 +322,7 @@ class Test(unittest.TestCase):
         """
         pass
 
-    def action(self):
+    def runTest(self):
         """
         Actual test payload. Must be implemented by tests.
 
@@ -331,14 +331,13 @@ class Test(unittest.TestCase):
         operations decide if the test pass (let the test complete) or fail
         (raise a test related exception).
         """
-        raise NotImplementedError('Test subclasses must implement an action '
-                                  'method')
+        pass
 
-    def cleanup(self):
+    def tearDown(self):
         """
-        Cleanup stage after the action is done.
+        Cleanup stage after the runTest is done.
 
-        Examples of cleanup actions are deleting temporary files, restoring
+        Examples of cleanup runTests are deleting temporary files, restoring
         firewall configurations or other system settings that were changed
         in setup.
         """
@@ -368,31 +367,33 @@ class Test(unittest.TestCase):
                    'Actual:\n%s\nExpected:\n%s' % (actual, expected))
             self.assertEqual(expected, actual, msg)
 
-    def runTest(self, result=None):
+    def run(self, result=None):
         """
         Run test method, for compatibility with unittest.TestCase.
 
         :result: Unused param, compatibiltiy with :class:`unittest.TestCase`.
         """
+        testMethod = getattr(self, self._testMethodName)
         self.start_logging()
         self.sysinfo_logger.start_test_hook()
-        action_exception = None
+        runTest_exception = None
         cleanup_exception = None
         stdout_check_exception = None
         stderr_check_exception = None
+        self.log.info('methodName %s', self._testMethodName)
         try:
-            self.setup()
+            self.setUp()
         except Exception, details:
             stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
             raise exceptions.TestSetupFail(details)
         try:
-            self.action()
+            testMethod()
         except Exception, details:
             stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
-            action_exception = details
+            runTest_exception = details
         finally:
             try:
-                self.cleanup()
+                self.tearDown()
             except Exception, details:
                 stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
                 cleanup_exception = details
@@ -429,8 +430,8 @@ class Test(unittest.TestCase):
                     self.record_reference_stderr()
 
         # pylint: disable=E0702
-        if action_exception is not None:
-            raise action_exception
+        if runTest_exception is not None:
+            raise runTest_exception
         elif cleanup_exception is not None:
             raise exceptions.TestSetupFail(cleanup_exception)
         elif stdout_check_exception is not None:
@@ -458,14 +459,14 @@ class Test(unittest.TestCase):
 
     def run_avocado(self, result=None):
         """
-        Wraps the runTest method, for execution inside the avocado runner.
+        Wraps the run method, for execution inside the avocado runner.
 
         :result: Unused param, compatibility with :class:`unittest.TestCase`.
         """
         self._setup_environment_variables()
         try:
             self.tag_start()
-            self.runTest(result)
+            self.run(result)
         except exceptions.TestBaseException, detail:
             self.status = detail.status
             self.fail_class = detail.__class__.__name__
@@ -545,7 +546,7 @@ class SimpleTest(Test):
         self.log.info("Exit status: %s", result.exit_status)
         self.log.info("Duration: %s", result.duration)
 
-    def action(self):
+    def runTest(self):
         """
         Run the executable, and log its detailed execution.
         """
@@ -560,8 +561,8 @@ class SimpleTest(Test):
             self._log_detailed_cmd_info(details.result)
             raise exceptions.TestFail(details)
 
-    def runTest(self, result=None):
-        super(SimpleTest, self).runTest(result)
+    def run(self, result=None):
+        super(SimpleTest, self).run(result)
         for line in open(self.logfile):
             if self.re_avocado_log.match(line):
                 raise exceptions.TestWarn("Test passed but there were warnings"
@@ -582,7 +583,7 @@ class MissingTest(Test):
                                           tag=tag, job=job,
                                           runner_queue=runner_queue)
 
-    def action(self):
+    def runTest(self):
         e_msg = ('Test %s could not be found in the test dir %s '
                  '(or test path does not exist)' %
                  (self.name, data_dir.get_test_dir()))
@@ -606,7 +607,7 @@ class BuggyTest(Test):
                                         tag=tag, job=job,
                                         runner_queue=runner_queue)
 
-    def action(self):
+    def runTest(self):
         # pylint: disable=E0702
         raise self.params.get('exception')
 
@@ -627,7 +628,7 @@ class NotATest(Test):
                                        tag=tag, job=job,
                                        runner_queue=runner_queue)
 
-    def action(self):
+    def runTest(self):
         e_msg = ('File %s is not executable and does not contain an avocado '
                  'test class in it ' % self.name)
         raise exceptions.NotATestError(e_msg)

--- a/examples/tests/abort.py
+++ b/examples/tests/abort.py
@@ -13,7 +13,7 @@ class AbortTest(test.Test):
     """
     default_params = {'timeout': 2.0}
 
-    def action(self):
+    def runTest(self):
         os.abort()
 
 

--- a/examples/tests/cabort.py
+++ b/examples/tests/cabort.py
@@ -17,7 +17,7 @@ class CAbort(test.Test):
 
     default_params = {'source': 'abort.c'}
 
-    def setup(self):
+    def setUp(self):
         """
         Build 'abort'.
         """
@@ -29,7 +29,7 @@ class CAbort(test.Test):
                    env={'CFLAGS': '-g -O0'},
                    extra_args='abort')
 
-    def action(self):
+    def runTest(self):
         """
         Execute 'abort'.
         """

--- a/examples/tests/datadir.py
+++ b/examples/tests/datadir.py
@@ -17,7 +17,7 @@ class DataDirTest(test.Test):
 
     default_params = {'source': 'datadir.c'}
 
-    def setup(self):
+    def setUp(self):
         """
         Build 'datadir'.
         """
@@ -29,7 +29,7 @@ class DataDirTest(test.Test):
                    env={'CFLAGS': '-g -O0'},
                    extra_args='datadir')
 
-    def action(self):
+    def runTest(self):
         """
         Execute 'datadir'.
         """

--- a/examples/tests/doublefail.py
+++ b/examples/tests/doublefail.py
@@ -11,17 +11,17 @@ class DoubleFail(test.Test):
     Functional test for avocado. Straight up fail the test.
     """
 
-    def action(self):
+    def runTest(self):
         """
         Should fail.
         """
         raise exceptions.TestFail('This test is supposed to fail')
 
-    def cleanup(self):
+    def tearDown(self):
         """
         Should also fail.
         """
-        raise exceptions.TestError('Failing during cleanup. Yay!')
+        raise exceptions.TestError('Failing during tearDown. Yay!')
 
 
 if __name__ == "__main__":

--- a/examples/tests/doublefree.py
+++ b/examples/tests/doublefree.py
@@ -18,7 +18,7 @@ class DoubleFreeTest(test.Test):
 
     default_params = {'source': 'doublefree.c'}
 
-    def setup(self):
+    def setUp(self):
         """
         Build 'doublefree'.
         """
@@ -30,7 +30,7 @@ class DoubleFreeTest(test.Test):
                    env={'CFLAGS': '-g -O0'},
                    extra_args='doublefree')
 
-    def action(self):
+    def runTest(self):
         """
         Execute 'doublefree'.
         """

--- a/examples/tests/doublefree_nasty.py
+++ b/examples/tests/doublefree_nasty.py
@@ -18,7 +18,7 @@ class DoubleFreeTest(test.Test):
     default_params = {'source': 'doublefree.c'}
     __binary = None     # filename of the compiled program
 
-    def setup(self):
+    def setUp(self):
         """
         Build 'doublefree'.
         """
@@ -29,7 +29,7 @@ class DoubleFreeTest(test.Test):
                    env={'CFLAGS': '-g -O0'},
                    extra_args=self.__binary)
 
-    def action(self):
+    def runTest(self):
         """
         Execute 'doublefree'.
         """

--- a/examples/tests/errortest.py
+++ b/examples/tests/errortest.py
@@ -11,7 +11,7 @@ class ErrorTest(test.Test):
     Functional test for avocado. Throw a TestError.
     """
 
-    def action(self):
+    def runTest(self):
         """
         This should throw a TestError.
         """

--- a/examples/tests/failtest.py
+++ b/examples/tests/failtest.py
@@ -11,7 +11,7 @@ class FailTest(test.Test):
     Functional test for avocado. Straight up fail the test.
     """
 
-    def action(self):
+    def runTest(self):
         """
         Should fail.
         """

--- a/examples/tests/failtest_nasty.py
+++ b/examples/tests/failtest_nasty.py
@@ -21,7 +21,7 @@ class FailTest(test.Test):
     Very nasty exception test
     """
 
-    def action(self):
+    def runTest(self):
         """
         Should fail not-that-badly
         """

--- a/examples/tests/failtest_nasty2.py
+++ b/examples/tests/failtest_nasty2.py
@@ -21,7 +21,7 @@ class FailTest(test.Test):
     Very nasty exception test
     """
 
-    def action(self):
+    def runTest(self):
         """
         Should fail.
         """

--- a/examples/tests/fiotest.py
+++ b/examples/tests/fiotest.py
@@ -21,7 +21,7 @@ class FioTest(test.Test):
     default_params = {'fio_tarball': 'fio-2.1.10.tar.bz2',
                       'fio_job': 'fio-mixed.job'}
 
-    def setup(self):
+    def setUp(self):
         """
         Build 'fio'.
         """
@@ -31,7 +31,7 @@ class FioTest(test.Test):
         self.srcdir = os.path.join(self.srcdir, fio_version)
         build.make(self.srcdir)
 
-    def action(self):
+    def runTest(self):
         """
         Execute 'fio' with appropriate parameters.
         """

--- a/examples/tests/gdbtest.py
+++ b/examples/tests/gdbtest.py
@@ -26,7 +26,7 @@ class GdbTest(test.Test):
                     "-find-me-the-bug",
                     "-auto-debug-it"]
 
-    def setup(self):
+    def setUp(self):
         self.return99_binary_path = os.path.join(self.outputdir, 'return99')
         return99_source_path = self.get_data_path('return99.c')
         process.system('gcc -O0 -g %s -o %s' % (return99_source_path,
@@ -407,7 +407,7 @@ class GdbTest(test.Test):
         r.cmd("qfThreadInfo")
         s.exit()
 
-    def action(self):
+    def runTest(self):
         """
         Execute tests
         """

--- a/examples/tests/gendata.py
+++ b/examples/tests/gendata.py
@@ -41,7 +41,7 @@ class GenDataTest(test.Test):
                   "outputdir": self.outputdir}
         json.dump(output, open(output_path, "w"))
 
-    def action(self):
+    def runTest(self):
         self.generate_bsod()
         self.generate_json()
 

--- a/examples/tests/linuxbuild.py
+++ b/examples/tests/linuxbuild.py
@@ -13,7 +13,7 @@ class LinuxBuildTest(test.Test):
     default_params = {'linux_version': '3.14.5',
                       'linux_config': 'config'}
 
-    def setup(self):
+    def setUp(self):
         kernel_version = self.params.linux_version
         config_path = self.get_data_path('config')
         self.linux_build = kernel_build.KernelBuild(kernel_version,
@@ -23,7 +23,7 @@ class LinuxBuildTest(test.Test):
         self.linux_build.uncompress()
         self.linux_build.configure()
 
-    def action(self):
+    def runTest(self):
         self.linux_build.build()
 
 

--- a/examples/tests/modify_variable.py
+++ b/examples/tests/modify_variable.py
@@ -21,7 +21,7 @@ class PrintVariableTest(test.Test):
     default_params = {'source': 'print_variable.c'}
     __binary = None    # filename of the compiled program
 
-    def setup(self):
+    def setUp(self):
         """
         Build 'print_variable'.
         """
@@ -32,7 +32,7 @@ class PrintVariableTest(test.Test):
                    env={'CFLAGS': '-g -O0'},
                    extra_args=self.__binary)
 
-    def action(self):
+    def runTest(self):
         """
         Execute 'print_variable'.
         """

--- a/examples/tests/multiplextest.py
+++ b/examples/tests/multiplextest.py
@@ -22,7 +22,7 @@ class MultiplexTest(test.Test):
                       'ping_timeout': 10,
                       'ping_tries': 5}
 
-    def setup(self):
+    def setUp(self):
         self.compile_code()
         self.set_hugepages()
         self.set_numa_balance()
@@ -57,7 +57,7 @@ class MultiplexTest(test.Test):
         if self.params.enable_msx_vectors == 'yes':
             self.log.info('Enabling msx vectors')
 
-    def action(self):
+    def runTest(self):
         self.log.info('Executing synctest...')
         self.log.info('synctest --timeout %s --tries %s',
                       self.params.sync_timeout,

--- a/examples/tests/passtest.py
+++ b/examples/tests/passtest.py
@@ -10,7 +10,7 @@ class PassTest(test.Test):
     Example test that passes.
     """
 
-    def action(self):
+    def runTest(self):
         """
         A test simply doesn't have to fail in order to pass
         """

--- a/examples/tests/raise.py
+++ b/examples/tests/raise.py
@@ -18,7 +18,7 @@ class Raise(test.Test):
     default_params = {'source': 'raise.c',
                       'signal_number': 15}
 
-    def setup(self):
+    def setUp(self):
         """
         Build 'raise'.
         """
@@ -30,7 +30,7 @@ class Raise(test.Test):
                    env={'CFLAGS': '-g -O0'},
                    extra_args='raise')
 
-    def action(self):
+    def runTest(self):
         """
         Execute 'raise'.
         """

--- a/examples/tests/skiptest.py
+++ b/examples/tests/skiptest.py
@@ -11,7 +11,7 @@ class SkipTest(test.Test):
     Functional test for avocado. Throw a TestNAError (skips the test).
     """
 
-    def action(self):
+    def runTest(self):
         """
         This should throw a TestNAError (skips the test).
         """

--- a/examples/tests/sleeptenmin.py
+++ b/examples/tests/sleeptenmin.py
@@ -16,7 +16,7 @@ class SleepTenMin(test.Test):
                       'sleep_cycles': 1,
                       'sleep_method': 'builtin'}
 
-    def action(self):
+    def runTest(self):
         """
         Sleep for length seconds.
         """

--- a/examples/tests/sleeptest.py
+++ b/examples/tests/sleeptest.py
@@ -13,7 +13,7 @@ class SleepTest(test.Test):
     """
     default_params = {'sleep_length': 1.0}
 
-    def action(self):
+    def runTest(self):
         """
         Sleep for length seconds.
         """

--- a/examples/tests/synctest.py
+++ b/examples/tests/synctest.py
@@ -19,7 +19,7 @@ class SyncTest(test.Test):
                       'sync_loop': 10,
                       'debug_symbols': True}
 
-    def setup(self):
+    def setUp(self):
         """
         Build the synctest suite.
         """
@@ -34,7 +34,7 @@ class SyncTest(test.Test):
         else:
             build.make(self.srcdir)
 
-    def action(self):
+    def runTest(self):
         """
         Execute synctest with the appropriate params.
         """

--- a/examples/tests/timeouttest.py
+++ b/examples/tests/timeouttest.py
@@ -14,7 +14,7 @@ class TimeoutTest(test.Test):
     default_params = {'timeout': 3.0,
                       'sleep_time': 5.0}
 
-    def action(self):
+    def runTest(self):
         """
         This should throw a TestTimeoutError.
         """

--- a/examples/tests/trinity.py
+++ b/examples/tests/trinity.py
@@ -27,7 +27,7 @@ class TrinityTest(test.Test):
                       'victims_path': None,
                       'stress': None}
 
-    def setup(self):
+    def setUp(self):
         """
         Build trinity.
         """
@@ -39,7 +39,7 @@ class TrinityTest(test.Test):
         build.make(self.srcdir)
         self.victims_path = data_factory.make_dir_and_populate(self.workdir)
 
-    def action(self):
+    def runTest(self):
         """
         Execute the trinity syscall fuzzer with the appropriate params.
         """

--- a/examples/tests/warntest.py
+++ b/examples/tests/warntest.py
@@ -11,7 +11,7 @@ class WarnTest(test.Test):
     Functional test for avocado. Throw a TestWarn.
     """
 
-    def action(self):
+    def runTest(self):
         """
         This should throw a TestWarn.
         """

--- a/examples/tests/whiteboard.py
+++ b/examples/tests/whiteboard.py
@@ -16,7 +16,7 @@ class WhiteBoard(test.Test):
                       'whiteboard_data_size': '10',
                       'whiteboard_writes': '1'}
 
-    def action(self):
+    def runTest(self):
         if self.params.whiteboard_data_file:
             self.log.info('Writing data to whiteboard from file: %s',
                           self.params.whiteboard_data_file)

--- a/selftests/all/functional/avocado/basic_tests.py
+++ b/selftests/all/functional/avocado/basic_tests.py
@@ -104,7 +104,7 @@ class RunnerOperationTest(unittest.TestCase):
                             "Avocado crashed (rc %d):\n%s" % (unexpected_rc, result))
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %d:\n%s" % (expected_rc, result))
-        self.assertIn("TestError: Failing during cleanup. Yay!", output,
+        self.assertIn("TestError: Failing during tearDown. Yay!", output,
                       "Cleanup exception not printed to log output")
         self.assertIn("TestFail: This test is supposed to fail",
                       output,

--- a/selftests/all/functional/avocado/loader_tests.py
+++ b/selftests/all/functional/avocado/loader_tests.py
@@ -20,7 +20,7 @@ from avocado import job
 from avocado import test
 
 class PassTest(test.Test):
-    def action(self):
+    def runTest(self):
         pass
 
 if __name__ == "__main__":
@@ -33,7 +33,7 @@ from avocado import test
 import adsh
 
 class PassTest(test.Test):
-    def action(self):
+    def runTest(self):
         pass
 
 if __name__ == "__main__":

--- a/selftests/all/unit/avocado/loader_unittest.py
+++ b/selftests/all/unit/avocado/loader_unittest.py
@@ -22,7 +22,7 @@ from avocado import job
 from avocado import test
 
 class PassTest(test.Test):
-    def action(self):
+    def runTest(self):
         pass
 
 if __name__ == "__main__":
@@ -35,7 +35,7 @@ from avocado import test
 import adsh
 
 class PassTest(test.Test):
-    def action(self):
+    def runTest(self):
         pass
 
 if __name__ == "__main__":
@@ -91,7 +91,7 @@ class LoaderTest(unittest.TestCase):
             self.loader.discover_test(params={'id': simple_test.path}))
         self.assertTrue(test_class == test.SimpleTest, test_class)
         tc = test_class(**test_parameters)
-        tc.action()
+        tc.runTest()
         simple_test.remove()
 
     def test_load_simple_not_exec(self):
@@ -103,7 +103,7 @@ class LoaderTest(unittest.TestCase):
             self.loader.discover_test(params={'id': simple_test.path}))
         self.assertTrue(test_class == test.NotATest, test_class)
         tc = test_class(**test_parameters)
-        self.assertRaises(exceptions.NotATestError, tc.action)
+        self.assertRaises(exceptions.NotATestError, tc.runTest)
         simple_test.remove()
 
     def test_load_pass(self):
@@ -117,7 +117,7 @@ class LoaderTest(unittest.TestCase):
                         str(test_class))
         self.assertTrue(issubclass(test_class, test.Test))
         tc = test_class(**test_parameters)
-        tc.action()
+        tc.runTest()
         avocado_pass_test.remove()
 
     def test_load_inherited(self):
@@ -150,7 +150,7 @@ class LoaderTest(unittest.TestCase):
             self.loader.discover_test(params={'id': avocado_buggy_test.path}))
         self.assertTrue(test_class == test.SimpleTest, test_class)
         tc = test_class(**test_parameters)
-        self.assertRaises(exceptions.TestFail, tc.action)
+        self.assertRaises(exceptions.TestFail, tc.runTest)
         avocado_buggy_test.remove()
 
     def test_load_buggy_not_exec(self):
@@ -163,7 +163,7 @@ class LoaderTest(unittest.TestCase):
             self.loader.discover_test(params={'id': avocado_buggy_test.path}))
         self.assertTrue(test_class == test.BuggyTest, test_class)
         tc = test_class(**test_parameters)
-        self.assertRaises(ImportError, tc.action)
+        self.assertRaises(ImportError, tc.runTest)
         avocado_buggy_test.remove()
 
     def test_load_not_a_test(self):
@@ -176,7 +176,7 @@ class LoaderTest(unittest.TestCase):
             self.loader.discover_test(params={'id': avocado_not_a_test.path}))
         self.assertTrue(test_class == test.NotATest, test_class)
         tc = test_class(**test_parameters)
-        self.assertRaises(exceptions.NotATestError, tc.action)
+        self.assertRaises(exceptions.NotATestError, tc.runTest)
         avocado_not_a_test.remove()
 
     def test_load_not_a_test_exec(self):
@@ -189,7 +189,7 @@ class LoaderTest(unittest.TestCase):
         tc = test_class(**test_parameters)
         # The test can't be executed (no shebang), raising an OSError
         # (OSError: [Errno 8] Exec format error)
-        self.assertRaises(OSError, tc.action)
+        self.assertRaises(OSError, tc.runTest)
         avocado_not_a_test.remove()
 
     def test_py_simple_test(self):
@@ -201,7 +201,7 @@ class LoaderTest(unittest.TestCase):
             self.loader.discover_test(params={'id': avocado_simple_test.path}))
         self.assertTrue(test_class == test.SimpleTest)
         tc = test_class(**test_parameters)
-        tc.action()
+        tc.runTest()
         avocado_simple_test.remove()
 
     def test_py_simple_test_notexec(self):
@@ -214,7 +214,7 @@ class LoaderTest(unittest.TestCase):
             self.loader.discover_test(params={'id': avocado_simple_test.path}))
         self.assertTrue(test_class == test.NotATest)
         tc = test_class(**test_parameters)
-        self.assertRaises(exceptions.NotATestError, tc.action)
+        self.assertRaises(exceptions.NotATestError, tc.runTest)
         avocado_simple_test.remove()
 
     def tearDown(self):

--- a/selftests/all/unit/avocado/loader_unittest.py
+++ b/selftests/all/unit/avocado/loader_unittest.py
@@ -88,7 +88,7 @@ class LoaderTest(unittest.TestCase):
                                              'avocado_loader_unittest')
         simple_test.save()
         test_class, test_parameters = (
-            self.loader.discover_test(params={'id': simple_test.path}))
+            self.loader.discover_tests(params={'id': simple_test.path})[0])
         self.assertTrue(test_class == test.SimpleTest, test_class)
         tc = test_class(**test_parameters)
         tc.runTest()
@@ -100,7 +100,7 @@ class LoaderTest(unittest.TestCase):
                                              mode=0664)
         simple_test.save()
         test_class, test_parameters = (
-            self.loader.discover_test(params={'id': simple_test.path}))
+            self.loader.discover_tests(params={'id': simple_test.path})[0])
         self.assertTrue(test_class == test.NotATest, test_class)
         tc = test_class(**test_parameters)
         self.assertRaises(exceptions.NotATestError, tc.runTest)
@@ -112,7 +112,7 @@ class LoaderTest(unittest.TestCase):
                                                    'avocado_loader_unittest')
         avocado_pass_test.save()
         test_class, test_parameters = (
-            self.loader.discover_test(params={'id': avocado_pass_test.path}))
+            self.loader.discover_tests(params={'id': avocado_pass_test.path})[0])
         self.assertTrue(str(test_class) == "<class 'passtest.PassTest'>",
                         str(test_class))
         self.assertTrue(issubclass(test_class, test.Test))
@@ -126,7 +126,7 @@ class LoaderTest(unittest.TestCase):
                                                    'avocado_loader_unittest')
         avocado_base_test.save()
         test_class, test_parameters = (
-            self.loader.discover_test(params={'id': avocado_base_test.path}))
+            self.loader.discover_tests(params={'id': avocado_base_test.path})[0])
         self.assertTrue(str(test_class) == "<class 'base.MyBaseTest'>",
                         str(test_class))
 
@@ -135,7 +135,7 @@ class LoaderTest(unittest.TestCase):
                                                         'avocado_loader_unittest')
         avocado_inherited_test.save()
         test_class, test_parameters = (
-            self.loader.discover_test(params={'id': avocado_inherited_test.path}))
+            self.loader.discover_tests(params={'id': avocado_inherited_test.path})[0])
         self.assertTrue(str(test_class) == "<class 'inherited.MyInheritedTest'>",
                         str(test_class))
         avocado_base_test.remove()
@@ -147,7 +147,7 @@ class LoaderTest(unittest.TestCase):
                                                     'avocado_loader_unittest')
         avocado_buggy_test.save()
         test_class, test_parameters = (
-            self.loader.discover_test(params={'id': avocado_buggy_test.path}))
+            self.loader.discover_tests(params={'id': avocado_buggy_test.path})[0])
         self.assertTrue(test_class == test.SimpleTest, test_class)
         tc = test_class(**test_parameters)
         self.assertRaises(exceptions.TestFail, tc.runTest)
@@ -160,7 +160,7 @@ class LoaderTest(unittest.TestCase):
                                                     mode=0664)
         avocado_buggy_test.save()
         test_class, test_parameters = (
-            self.loader.discover_test(params={'id': avocado_buggy_test.path}))
+            self.loader.discover_tests(params={'id': avocado_buggy_test.path})[0])
         self.assertTrue(test_class == test.BuggyTest, test_class)
         tc = test_class(**test_parameters)
         self.assertRaises(ImportError, tc.runTest)
@@ -173,7 +173,7 @@ class LoaderTest(unittest.TestCase):
                                                     mode=0664)
         avocado_not_a_test.save()
         test_class, test_parameters = (
-            self.loader.discover_test(params={'id': avocado_not_a_test.path}))
+            self.loader.discover_tests(params={'id': avocado_not_a_test.path})[0])
         self.assertTrue(test_class == test.NotATest, test_class)
         tc = test_class(**test_parameters)
         self.assertRaises(exceptions.NotATestError, tc.runTest)
@@ -184,7 +184,7 @@ class LoaderTest(unittest.TestCase):
                                                     'avocado_loader_unittest')
         avocado_not_a_test.save()
         test_class, test_parameters = (
-            self.loader.discover_test(params={'id': avocado_not_a_test.path}))
+            self.loader.discover_tests(params={'id': avocado_not_a_test.path})[0])
         self.assertTrue(test_class == test.SimpleTest, test_class)
         tc = test_class(**test_parameters)
         # The test can't be executed (no shebang), raising an OSError
@@ -198,7 +198,7 @@ class LoaderTest(unittest.TestCase):
                                                      'avocado_loader_unittest')
         avocado_simple_test.save()
         test_class, test_parameters = (
-            self.loader.discover_test(params={'id': avocado_simple_test.path}))
+            self.loader.discover_tests(params={'id': avocado_simple_test.path})[0])
         self.assertTrue(test_class == test.SimpleTest)
         tc = test_class(**test_parameters)
         tc.runTest()
@@ -211,7 +211,7 @@ class LoaderTest(unittest.TestCase):
                                                      mode=0664)
         avocado_simple_test.save()
         test_class, test_parameters = (
-            self.loader.discover_test(params={'id': avocado_simple_test.path}))
+            self.loader.discover_tests(params={'id': avocado_simple_test.path})[0])
         self.assertTrue(test_class == test.NotATest)
         tc = test_class(**test_parameters)
         self.assertRaises(exceptions.NotATestError, tc.runTest)

--- a/selftests/all/unit/avocado/multiples_tests.py
+++ b/selftests/all/unit/avocado/multiples_tests.py
@@ -1,0 +1,26 @@
+#!/usr/bin/python
+
+from avocado import test
+from avocado import job
+
+
+class MultiplesTests(test.Test):
+
+    def setUp(self):
+        self.hello = "Hi there!"
+
+    def test_hello(self):
+        self.assertEqual(self.hello, "Hi there!")
+
+    def testIdentity(self):
+        self.assertTrue(1, 1)
+
+    def division_by_zero(self):
+        return 1 / 0
+
+    def action(self):
+        pass
+
+
+if __name__ == '__main__':
+    job.main()

--- a/selftests/all/unit/avocado/test_unittest.py
+++ b/selftests/all/unit/avocado/test_unittest.py
@@ -21,17 +21,17 @@ from avocado.utils import script
 @unittest.skip("This class should not be tested per se")
 class AvocadoPass(test.Test):
 
-    def action(self):
+    def runTest(self):
         variable = True
         self.assertTrue(variable)
         self.whiteboard = 'foo'
 
 
 @unittest.skip("This class should not be tested per se")
-class AvocadoFailNoAction(test.Test):
+class EmptyTest(test.Test):
 
     """
-    I don't have an action() method defined!
+    I don't have runTest() defined!
     """
     pass
 
@@ -51,19 +51,14 @@ class TestClassTest(unittest.TestCase):
         self.tst_instance_pass = AvocadoPass(base_logdir=self.base_logdir)
         self.tst_instance_pass.run_avocado()
 
-    def testFailNoActionRunTest(self):
-        tst_instance = AvocadoFailNoAction()
-        try:
-            tst_instance.action()
-            raise AssertionError("Test instance did not raise NotImplementedError")
-        except NotImplementedError:
-            pass
+    def testRunTest(self):
+        tst = EmptyTest()
+        self.assertEqual(tst.runTest(), None)
 
-    def testFailNoActionRunAvocado(self):
-        tst_instance = AvocadoFailNoAction()
-        tst_instance.run_avocado()
-        self.assertEqual(tst_instance.status, 'FAIL')
-        self.assertEqual(tst_instance.fail_class, 'NotImplementedError')
+    def testRunAvocado(self):
+        tst = EmptyTest()
+        tst.run_avocado()
+        self.assertEqual(tst.status, 'PASS')
 
     def testClassAttributesName(self):
         self.assertEqual(self.tst_instance_pass.name, 'AvocadoPass')


### PR DESCRIPTION
* Allow to write multiples tests defined in the Avocado test class. The multiples tests looks like the unittest test methods defined as the pattern"`test*`.
* The second major update is to obsolete the `action()` method and make use of `runTest()` method (like the unittest does). So now, it's possible to run multiples tests with a class defined like this:

```python
# Adapted from an example in unittest documentation.

import random

from avocado import test
from avocado import job

class TestSequenceFunctions(test.Test):

    def setUp(self):
        self.seq = range(10)

    def test_shuffle(self):
        # make sure the shuffled sequence does not lose any elements
        random.shuffle(self.seq)
        self.seq.sort()
        self.assertEqual(self.seq, range(10))

        # should raise an exception for an immutable sequence
        self.assertRaises(TypeError, random.shuffle, (1, 2, 3))

    def test_choice(self):
        element = random.choice(self.seq)
        self.assertTrue(element in self.seq)

    def test_sample(self):
        with self.assertRaises(ValueError):
            random.sample(self.seq, 20)
        for element in random.sample(self.seq, 5):
            self.assertTrue(element in self.seq)


if __name__ == '__main__':
    job.main()
 ```