### PR TITLE
avocado.remote: Add support for host-timeout

### DIFF
--- a/avocado/plugins/remote.py
+++ b/avocado/plugins/remote.py
@@ -61,6 +61,10 @@ class RunRemote(plugin.Plugin):
                                         action='store_true',
                                         help="Don't copy tests and use the "
                                         "exact uri on guest machine.")
+        self.remote_parser.add_argument('--remote-timeout', type=float,
+                                        help="Host timeout before the "
+                                        "connection is cut off and test "
+                                        "set as failed.")
         self.configured = True
 
     @staticmethod

--- a/avocado/plugins/vm.py
+++ b/avocado/plugins/vm.py
@@ -67,6 +67,10 @@ class RunVM(plugin.Plugin):
                                     action='store_true',
                                     help="Don't copy tests and use the "
                                     "exact uri on VM machine.")
+        self.vm_parser.add_argument('--vm-timeout', type=float,
+                                    help="Host timeout before the "
+                                    "connection is cut off and test "
+                                    "set as failed.")
         self.configured = True
 
     @staticmethod

--- a/avocado/remote/result.py
+++ b/avocado/remote/result.py
@@ -43,6 +43,7 @@ class RemoteTestResult(HumanTestResult):
         self.remote = None      # Remote runner initialized during setup
         self.output = '-'
         self.command_line_arg_name = '--remote-hostname'
+        self.timeout = getattr(args, 'remote_timeout', None)
 
     def _copy_tests(self):
         """
@@ -98,6 +99,7 @@ class VMTestResult(RemoteTestResult):
     """
 
     def __init__(self, stream, args):
+        args.remote_timeout = getattr(args, 'vm_timeout', None)
         super(VMTestResult, self).__init__(stream, args)
         self.vm = None
         self.command_line_arg_name = '--vm-domain'

--- a/selftests/all/unit/avocado/remote_unittest.py
+++ b/selftests/all/unit/avocado/remote_unittest.py
@@ -38,13 +38,13 @@ class RemoteTestRunnerTest(unittest.TestCase):
         args = 'avocado -v'
         version_result = flexmock(stdout='Avocado 1.2.3', exit_status=0)
         (Remote.should_receive('run')
-         .with_args(args, ignore_status=True, timeout=None)
+         .with_args(args, ignore_status=True, timeout=60)
          .once().and_return(version_result))
 
         args = 'cd ~/avocado/tests; avocado list sleeptest --paginator=off'
         urls_result = flexmock(exit_status=0)
         (Remote.should_receive('run')
-         .with_args(args, timeout=None, ignore_status=True)
+         .with_args(args, timeout=60, ignore_status=True)
          .once().and_return(urls_result))
 
         args = ("cd ~/avocado/tests; avocado run --force-job-id sleeptest.1 "
@@ -53,7 +53,7 @@ class RemoteTestRunnerTest(unittest.TestCase):
          .with_args(args, timeout=None, ignore_status=True)
          .once().and_return(test_results))
         Results = flexmock(remote=Remote, urls=['sleeptest'],
-                           stream=stream)
+                           stream=stream, timeout=None)
         Results.should_receive('setup').once().ordered()
         Results.should_receive('start_tests').once().ordered()
         args = {'status': u'PASS', 'whiteboard': '', 'time_start': 0,


### PR DESCRIPTION
Sometimes avocado on guest hangs. This patch adds host timeout to
interrupt the execution.

It's not perfect as we don't get the intermediary results. You can manually connect to the machine and try downloading the results yourself based on job ID. We should probably automate this in the future, but this patch should at least prevent CI from hanging.

https://github.com/avocado-framework/avocado/issues/513