### PR TITLE
avocado.remote: Add support for host-timeout [v2]

### DIFF
--- a/avocado/plugins/remote.py
+++ b/avocado/plugins/remote.py
@@ -61,6 +61,10 @@ class RunRemote(plugin.Plugin):
                                         action='store_true',
                                         help="Don't copy tests and use the "
                                         "exact uri on guest machine.")
+        self.remote_parser.add_argument('--remote-timeout', type=float,
+                                        help="Host timeout before the "
+                                        "connection is cut off and test "
+                                        "set as failed.")
         self.configured = True
 
     @staticmethod

--- a/avocado/plugins/vm.py
+++ b/avocado/plugins/vm.py
@@ -67,6 +67,10 @@ class RunVM(plugin.Plugin):
                                     action='store_true',
                                     help="Don't copy tests and use the "
                                     "exact uri on VM machine.")
+        self.vm_parser.add_argument('--vm-timeout', type=float,
+                                    help="Host timeout before the "
+                                    "connection is cut off and test "
+                                    "set as failed.")
         self.configured = True
 
     @staticmethod

--- a/avocado/remote/result.py
+++ b/avocado/remote/result.py
@@ -43,6 +43,7 @@ class RemoteTestResult(HumanTestResult):
         self.remote = None      # Remote runner initialized during setup
         self.output = '-'
         self.command_line_arg_name = '--remote-hostname'
+        self.timeout = getattr(args, 'remote_timeout', None)
 
     def _copy_tests(self):
         """
@@ -98,6 +99,7 @@ class VMTestResult(RemoteTestResult):
     """
 
     def __init__(self, stream, args):
+        args.remote_timeout = getattr(args, 'vm_timeout', None)
         super(VMTestResult, self).__init__(stream, args)
         self.vm = None
         self.command_line_arg_name = '--vm-domain'

--- a/avocado/remote/runner.py
+++ b/avocado/remote/runner.py
@@ -11,18 +11,18 @@
 #
 # Copyright: Red Hat Inc. 2014-2015
 # Author: Ruda Moura <rmoura@redhat.com>
-
 """Remote test runner."""
 
 import json
 import os
 import re
 
-from avocado.core import status
 from avocado.core import exceptions
-from avocado.utils import archive
-from avocado.runner import TestRunner
+from avocado.core import status
 from avocado.remote.test import RemoteTest
+from avocado.runner import TestRunner
+from avocado.utils import archive
+from fabric.exceptions import CommandTimeout
 
 
 class RemoteTestRunner(TestRunner):
@@ -46,7 +46,7 @@ class RemoteTestRunner(TestRunner):
         """
         result = self.result.remote.run('avocado -v',
                                         ignore_status=True,
-                                        timeout=None)
+                                        timeout=60)
         if result.exit_status == 127:
             return (False, None)
 
@@ -74,7 +74,7 @@ class RemoteTestRunner(TestRunner):
                                                        urls_str))
         check_urls_result = self.result.remote.run(avocado_check_urls_cmd,
                                                    ignore_status=True,
-                                                   timeout=None)
+                                                   timeout=60)
         if check_urls_result.exit_status != 0:
             raise exceptions.JobError(check_urls_result.stdout)
 
@@ -82,8 +82,13 @@ class RemoteTestRunner(TestRunner):
                        '--archive %s' % (self.remote_test_dir,
                                          self.result.stream.job_unique_id,
                                          urls_str))
-        result = self.result.remote.run(avocado_cmd, ignore_status=True,
-                                        timeout=None)
+        try:
+            result = self.result.remote.run(avocado_cmd, ignore_status=True,
+                                            timeout=self.result.timeout)
+        except CommandTimeout:
+            raise exceptions.JobError("Remote execution took longer than "
+                                      "specified timeout (%s). Interrupting."
+                                      % (self.result.timeout))
         json_result = None
         for json_output in result.stdout.splitlines():
             # We expect dictionary:

--- a/selftests/all/unit/avocado/remote_unittest.py
+++ b/selftests/all/unit/avocado/remote_unittest.py
@@ -38,13 +38,13 @@ class RemoteTestRunnerTest(unittest.TestCase):
         args = 'avocado -v'
         version_result = flexmock(stdout='Avocado 1.2.3', exit_status=0)
         (Remote.should_receive('run')
-         .with_args(args, ignore_status=True, timeout=None)
+         .with_args(args, ignore_status=True, timeout=60)
          .once().and_return(version_result))
 
         args = 'cd ~/avocado/tests; avocado list sleeptest --paginator=off'
         urls_result = flexmock(exit_status=0)
         (Remote.should_receive('run')
-         .with_args(args, timeout=None, ignore_status=True)
+         .with_args(args, timeout=60, ignore_status=True)
          .once().and_return(urls_result))
 
         args = ("cd ~/avocado/tests; avocado run --force-job-id sleeptest.1 "
@@ -53,7 +53,7 @@ class RemoteTestRunnerTest(unittest.TestCase):
          .with_args(args, timeout=None, ignore_status=True)
          .once().and_return(test_results))
         Results = flexmock(remote=Remote, urls=['sleeptest'],
-                           stream=stream)
+                           stream=stream, timeout=None)
         Results.should_receive('setup').once().ordered()
         Results.should_receive('start_tests').once().ordered()
         args = {'status': u'PASS', 'whiteboard': '', 'time_start': 0,


### PR DESCRIPTION
Sometimes avocado on guest hangs. This patch adds host timeout to
interrupt the execution.

It's not perfect as we don't get the intermediary results. You can manually connect to the machine and try downloading the results yourself based on job ID. We should probably automate this in the future, but this patch should at least prevent CI from hanging.

#513

v1: https://github.com/avocado-framework/avocado/pull/519

changes:

    v2: Typos fixed