### PR TITLE
avocado.cli.app: Fix bug regarding `run --help` and broken pipe.

### DIFF
--- a/avocado/cli/app.py
+++ b/avocado/cli/app.py
@@ -38,9 +38,13 @@ class AvocadoApp(object):
         self.parser = Parser()
         self.parser.start()
         self.load_plugin_manager(self.parser.args.plugins_dir)
-        self.parser.resume()
-        self.plugin_manager.activate(self.parser.args)
-        self.parser.finish()
+        self.ready = True
+        try:
+            self.parser.resume()
+            self.plugin_manager.activate(self.parser.args)
+            self.parser.finish()
+        except IOError:
+            self.ready = False
 
     def load_plugin_manager(self, plugins_dir):
         """Load Plugin Manager.
@@ -54,4 +58,5 @@ class AvocadoApp(object):
         self.plugin_manager.configure(self.parser)
 
     def run(self):
-        return self.parser.take_action()
+        if self.ready:
+            return self.parser.take_action()


### PR DESCRIPTION
When running `run --help` piped through a non existing command,
exit gracefully with a shell error and don't print the whole trace
back message.

Reference: https://trello.com/c/Nm4elZrb/363-bug-avocado-should-fail-gracefully-when-redirected-to-a-broken-pipe

Signed-off-by: Rudá Moura <rmoura@redhat.com>