### PR TITLE
Option to set timeout per job

### DIFF
--- a/avocado/plugins/runner.py
+++ b/avocado/plugins/runner.py
@@ -64,6 +64,14 @@ class TestRunner(plugin.Plugin):
                                  help=('Forces to use of an alternate job '
                                        'results directory.'))
 
+        self.parser.add_argument('--job-timeout', action='store',
+                                 default=None, metavar='SECONDS',
+                                 help=('Set the maximum amount of time (in SECONDS) that '
+                                       'tests are allow to execute. '
+                                       'Note that the value zero means "no timeout". '
+                                       'You can also use a number followed by a suffix like: '
+                                       ' s (seconds), m (minutes), h (hours). '))
+
         sysinfo_default = settings.get_value('sysinfo.collect',
                                              'enabled',
                                              key_type='bool',

--- a/avocado/runner.py
+++ b/avocado/runner.py
@@ -108,8 +108,11 @@ class TestRunner(object):
         test_state['status'] = exceptions.TestAbortError.status
         test_state['fail_class'] = exceptions.TestAbortError.__class__.__name__
         test_state['traceback'] = 'Traceback not available'
-        with open(test_state['logfile'], 'r') as log_file_obj:
-            test_state['text_output'] = log_file_obj.read()
+        try:
+            with open(test_state['logfile'], 'r') as log_file_obj:
+                test_state['text_output'] = log_file_obj.read()
+        except IOError:
+            test_state['text_output'] = ''
         return test_state
 
     def _run_test(self, test_factory, q, failures):

--- a/avocado/runner.py
+++ b/avocado/runner.py
@@ -32,6 +32,7 @@ from avocado.core import status
 from avocado.core import exit_codes
 from avocado.utils import wait
 from avocado.utils import stacktrace
+from avocado import test
 
 
 class TestRunner(object):
@@ -197,24 +198,27 @@ class TestRunner(object):
                                               cycle_timeout, first=0.01, step=0.1):
                 test_state = q.get()
             else:
-                early_state['time_elapsed'] = time.time() - time_started
+                time_elapsed = time.time() - time_started
+                early_state['time_elapsed'] = time_elapsed
                 test_state = self._fill_aborted_test_state(early_state)
                 test_log = logging.getLogger('avocado.test')
                 test_log.error('ERROR %s -> TestAbortedError: '
                                'Test aborted unexpectedly',
                                test_state['name'])
 
+        time_elapsed = time.time() - time_started
+
         # don't process other tests from the list
         if ctrl_c_count > 0:
             self.job.view.notify(event='minor', msg='')
-            return False
+            return False, time_elapsed
 
         self.result.check_test(test_state)
         if not status.mapping[test_state['status']]:
             failures.append(test_state['name'])
-        return True
+        return True, time_elapsed
 
-    def run_suite(self, test_suite, mux):
+    def run_suite(self, test_suite, mux, timeout=0):
         """
         Run one or more tests and report with test result.
 
@@ -227,11 +231,27 @@ class TestRunner(object):
             self.job.sysinfo.start_job_hook()
         self.result.start_tests()
         q = queues.SimpleQueue()
-
         ctrl_c = False
+        skip_timeout = False
+        time_elapsed = 0
         for test_template in test_suite:
             for test_factory in mux.itertests(test_template):
-                if not self._run_test(test_factory, q, failures):
+                # Check if we should run the tests with a global timeout
+                if timeout > 0:
+                    if time_elapsed > timeout:
+                        skip_timeout = True
+                    remaing_time = timeout - time_elapsed
+                    if hasattr(test_factory[1]['params'], 'timeout'):
+                        test_timeout = test_factory[1]['params']['timeout']
+                        if test_timeout > remaing_time:
+                            test_factory[1]['params']['timeout'] = remaing_time
+                    else:
+                        test_factory[1]['params']['timeout'] = remaing_time
+                if skip_timeout:
+                    test_factory = test.TimeOutSkipTest, test_factory[1]
+                status, delta = self._run_test(test_factory, q, failures)
+                time_elapsed += delta
+                if status is False:
                     ctrl_c = True
                     break
             if ctrl_c:

--- a/avocado/test.py
+++ b/avocado/test.py
@@ -499,6 +499,7 @@ class SimpleTest(Test):
 
     def __init__(self, path, params=None, base_logdir=None, tag=None, job=None):
         self.path = os.path.abspath(path)
+        self.name = self.path
         super(SimpleTest, self).__init__(name=path, base_logdir=base_logdir,
                                          params=params, tag=tag, job=job)
         basedir = os.path.dirname(self.path)
@@ -605,3 +606,27 @@ class NotATest(Test):
         e_msg = ('File %s is not executable and does not contain an avocado '
                  'test class in it ' % self.name)
         raise exceptions.NotATestError(e_msg)
+
+
+class TimeOutSkipTest(Test):
+
+    """
+    Skip test due job timeout.
+
+    This test is skipped due a job timeout.
+    It will never have a chance to execute.
+    """
+
+    def __init__(self, name=None, params=None, base_logdir=None, tag=None,
+                 job=None, runner_queue=None, path=None):
+        if name is None and path is not None:
+            name = path
+        super(TimeOutSkipTest, self).__init__(
+            name=name,
+            base_logdir=base_logdir,
+            tag=tag, job=job,
+            runner_queue=runner_queue)
+
+    def runTest(self):
+        e_msg = 'Test skipped due a job timeout!'
+        raise exceptions.TestNAError(e_msg)


### PR DESCRIPTION
Still in progress, but able to set the amount of time that tests will have to execute, with command line option `run --set-jobtimeout SECONDS`. If a job timeout happens in the middle of a test, then the test will set as error and the following tests (if any) will be marked as skipped.

There's some corner cases causing bugs, like setting a very small amount of time (say `job-timeout=0.0001`) and running tests may turn odd test results.

See also https://trello.com/c/ZUd59puD/165-option-to-set-timeout-per-job