### PR TITLE
Functional test fixes

### DIFF
--- a/examples/tests/multiple_tests.py
+++ b/examples/tests/multiple_tests.py
@@ -31,7 +31,7 @@ class MultipleTests(test.Test):
         """
         This method should never execute
         """
-        pass
+        raise Exception('This action method should never be executed.')
 
 if __name__ == '__main__':
     job.main()

--- a/selftests/all/functional/avocado/export_variables_tests.py
+++ b/selftests/all/functional/avocado/export_variables_tests.py
@@ -1,6 +1,8 @@
 import os
 import sys
 import unittest
+import tempfile
+import shutil
 
 # simple magic for using scripts within a source tree
 basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..', '..', '..')
@@ -37,6 +39,7 @@ test "$AVOCADO_VERSION" = "{version}" -a \
 class EnvironmentVariablesTest(unittest.TestCase):
 
     def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
         self.script = script.TemporaryScript(
             'version.sh',
             SCRIPT_CONTENT,
@@ -45,7 +48,7 @@ class EnvironmentVariablesTest(unittest.TestCase):
 
     def test_environment_vars(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --sysinfo=off %s' % self.script.path
+        cmd_line = './scripts/avocado run --job-results-dir %s --sysinfo=off %s' % (self.tmpdir, self.script.path)
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 0
         self.assertEqual(result.exit_status, expected_rc,
@@ -54,7 +57,7 @@ class EnvironmentVariablesTest(unittest.TestCase):
 
     def tearDown(self):
         self.script.remove()
-
+        shutil.rmtree(self.tmpdir)
 
 if __name__ == '__main__':
     unittest.main()

--- a/selftests/all/functional/avocado/gdb_tests.py
+++ b/selftests/all/functional/avocado/gdb_tests.py
@@ -1,6 +1,8 @@
 import os
 import sys
 import unittest
+import shutil
+import tempfile
 
 # simple magic for using scripts within a source tree
 basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..', '..', '..')
@@ -13,16 +15,23 @@ from avocado.utils import process
 
 class GDBPluginTest(unittest.TestCase):
 
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+
     def test_gdb_prerun_commands(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --sysinfo=off --gdb-prerun-commands=/dev/null passtest'
+        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '
+                    '--gdb-prerun-commands=/dev/null passtest' % self.tmpdir)
         process.run(cmd_line)
 
     def test_gdb_multiple_prerun_commands(self):
         os.chdir(basedir)
-        cmd_line = ('./scripts/avocado run --sysinfo=off --gdb-prerun-commands=/dev/null '
-                    '--gdb-prerun-commands=foo:/dev/null passtest')
+        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off --gdb-prerun-commands=/dev/null '
+                    '--gdb-prerun-commands=foo:/dev/null passtest' % self.tmpdir)
         process.run(cmd_line)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
 
 if __name__ == '__main__':
     unittest.main()

--- a/selftests/all/functional/avocado/journal_tests.py
+++ b/selftests/all/functional/avocado/journal_tests.py
@@ -3,6 +3,8 @@ import os
 import sys
 import json
 import sqlite3
+import tempfile
+import shutil
 
 # simple magic for using scripts within a source tree
 basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..', '..', '..')
@@ -17,7 +19,9 @@ class JournalPluginTests(unittest.TestCase):
 
     def setUp(self):
         os.chdir(basedir)
-        self.cmd_line = './scripts/avocado run --sysinfo=off --json - --journal examples/tests/passtest.py'
+        self.tmpdir = tempfile.mkdtemp()
+        self.cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off --json - '
+                         '--journal examples/tests/passtest.py' % self.tmpdir)
         self.result = process.run(self.cmd_line, ignore_status=True)
         data = json.loads(self.result.stdout)
         self.job_id = data['job_id']
@@ -45,6 +49,7 @@ class JournalPluginTests(unittest.TestCase):
 
     def tearDown(self):
         self.db.close()
+        shutil.rmtree(self.tmpdir)
 
 
 if __name__ == '__main__':

--- a/selftests/all/functional/avocado/loader_tests.py
+++ b/selftests/all/functional/avocado/loader_tests.py
@@ -1,5 +1,7 @@
 import os
 import sys
+import tempfile
+import shutil
 
 if sys.version_info[:2] == (2, 6):
     import unittest2 as unittest
@@ -60,12 +62,15 @@ true
 
 class LoaderTestFunctional(unittest.TestCase):
 
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+
     def test_simple(self):
         os.chdir(basedir)
         simple_test = script.TemporaryScript('simpletest.sh', SIMPLE_TEST,
                                              'avocado_loader_test')
         simple_test.save()
-        cmd_line = './scripts/avocado run --sysinfo=off %s' % simple_test.path
+        cmd_line = './scripts/avocado run --job-results-dir %s --sysinfo=off %s' % (self.tmpdir, simple_test.path)
         process.run(cmd_line)
         simple_test.remove()
 
@@ -75,7 +80,7 @@ class LoaderTestFunctional(unittest.TestCase):
                                              'avocado_loader_test',
                                              mode=0664)
         simple_test.save()
-        cmd_line = './scripts/avocado run --sysinfo=off %s' % simple_test.path
+        cmd_line = './scripts/avocado run --job-results-dir %s --sysinfo=off %s' % (self.tmpdir, simple_test.path)
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 2
         self.assertEqual(result.exit_status, expected_rc,
@@ -90,7 +95,7 @@ class LoaderTestFunctional(unittest.TestCase):
                                                    AVOCADO_TEST_OK,
                                                    'avocado_loader_test')
         avocado_pass_test.save()
-        cmd_line = './scripts/avocado run --sysinfo=off %s' % avocado_pass_test.path
+        cmd_line = './scripts/avocado run --job-results-dir %s --sysinfo=off %s' % (self.tmpdir, avocado_pass_test.path)
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 0
         self.assertEqual(result.exit_status, expected_rc,
@@ -102,7 +107,8 @@ class LoaderTestFunctional(unittest.TestCase):
                                                     AVOCADO_TEST_BUGGY,
                                                     'avocado_loader_test')
         avocado_buggy_test.save()
-        cmd_line = './scripts/avocado run --sysinfo=off %s' % avocado_buggy_test.path
+        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off %s' %
+                    (self.tmpdir, avocado_buggy_test.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 1
         self.assertEqual(result.exit_status, expected_rc,
@@ -115,7 +121,8 @@ class LoaderTestFunctional(unittest.TestCase):
                                                     'avocado_loader_test',
                                                     mode=0664)
         avocado_buggy_test.save()
-        cmd_line = './scripts/avocado run --sysinfo=off %s' % avocado_buggy_test.path
+        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off %s' %
+                    (self.tmpdir, avocado_buggy_test.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 1
         self.assertEqual(result.exit_status, expected_rc,
@@ -127,7 +134,8 @@ class LoaderTestFunctional(unittest.TestCase):
         avocado_not_a_test = script.TemporaryScript('notatest.py', NOT_A_TEST,
                                                     'avocado_loader_test')
         avocado_not_a_test.save()
-        cmd_line = './scripts/avocado run --sysinfo=off %s' % avocado_not_a_test.path
+        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off %s' %
+                    (self.tmpdir, avocado_not_a_test.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 1
         self.assertEqual(result.exit_status, expected_rc,
@@ -140,7 +148,8 @@ class LoaderTestFunctional(unittest.TestCase):
                                                     'avocado_loader_test',
                                                     mode=0664)
         avocado_not_a_test.save()
-        cmd_line = './scripts/avocado run --sysinfo=off %s' % avocado_not_a_test.path
+        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off %s' %
+                    (self.tmpdir, avocado_not_a_test.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 2
         self.assertEqual(result.exit_status, expected_rc,
@@ -148,6 +157,10 @@ class LoaderTestFunctional(unittest.TestCase):
                          (expected_rc, result))
         self.assertIn('is not an avocado test', result.stderr)
         avocado_not_a_test.remove()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/selftests/all/functional/avocado/output_check_tests.py
+++ b/selftests/all/functional/avocado/output_check_tests.py
@@ -1,5 +1,7 @@
 import os
 import sys
+import tempfile
+import shutil
 
 if sys.version_info[:2] == (2, 6):
     import unittest2 as unittest
@@ -23,6 +25,7 @@ echo "Hello, avocado!"
 class RunnerSimpleTest(unittest.TestCase):
 
     def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
         self.output_script = script.TemporaryScript(
             'output_check.sh',
             OUTPUT_SCRIPT_CONTENTS,
@@ -31,7 +34,8 @@ class RunnerSimpleTest(unittest.TestCase):
 
     def test_output_record_none(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --sysinfo=off %s --output-check-record none' % self.output_script.path
+        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off %s --output-check-record none' %
+                    (self.tmpdir, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 0
         self.assertEqual(result.exit_status, expected_rc,
@@ -44,7 +48,8 @@ class RunnerSimpleTest(unittest.TestCase):
 
     def test_output_record_stdout(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --sysinfo=off %s --output-check-record stdout' % self.output_script.path
+        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off %s --output-check-record stdout' %
+                    (self.tmpdir, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 0
         self.assertEqual(result.exit_status, expected_rc,
@@ -57,7 +62,8 @@ class RunnerSimpleTest(unittest.TestCase):
 
     def test_output_record_all(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --sysinfo=off %s --output-check-record all' % self.output_script.path
+        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off %s --output-check-record all' %
+                    (self.tmpdir, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 0
         self.assertEqual(result.exit_status, expected_rc,
@@ -70,7 +76,8 @@ class RunnerSimpleTest(unittest.TestCase):
 
     def test_output_record_and_check(self):
         self.test_output_record_all()
-        cmd_line = './scripts/avocado run --sysinfo=off %s' % self.output_script.path
+        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off %s' %
+                    (self.tmpdir, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 0
         self.assertEqual(result.exit_status, expected_rc,
@@ -83,7 +90,8 @@ class RunnerSimpleTest(unittest.TestCase):
         stdout_file = os.path.join("%s.data/stdout.expected" % self.output_script.path)
         with open(stdout_file, 'w') as stdout_file_obj:
             stdout_file_obj.write(tampered_msg)
-        cmd_line = './scripts/avocado run --sysinfo=off %s --xunit -' % self.output_script.path
+        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off %s --xunit -' %
+                    (self.tmpdir, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 1
         self.assertEqual(result.exit_status, expected_rc,
@@ -97,7 +105,8 @@ class RunnerSimpleTest(unittest.TestCase):
         stdout_file = os.path.join("%s.data/stdout.expected" % self.output_script.path)
         with open(stdout_file, 'w') as stdout_file_obj:
             stdout_file_obj.write(tampered_msg)
-        cmd_line = './scripts/avocado run --sysinfo=off %s --output-check=off --xunit -' % self.output_script.path
+        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off %s --output-check=off --xunit -' %
+                    (self.tmpdir, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 0
         self.assertEqual(result.exit_status, expected_rc,
@@ -107,6 +116,7 @@ class RunnerSimpleTest(unittest.TestCase):
 
     def tearDown(self):
         self.output_script.remove()
+        shutil.rmtree(self.tmpdir)
 
 if __name__ == '__main__':
     unittest.main()

--- a/selftests/all/functional/avocado/output_tests.py
+++ b/selftests/all/functional/avocado/output_tests.py
@@ -23,9 +23,12 @@ from avocado.core.output import TermSupport
 
 class OutputTest(unittest.TestCase):
 
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+
     def test_output_doublefree(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --sysinfo=off doublefree'
+        cmd_line = './scripts/avocado run --job-results-dir %s --sysinfo=off doublefree' % self.tmpdir
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 0
         output = result.stdout + result.stderr
@@ -37,8 +40,14 @@ class OutputTest(unittest.TestCase):
                          "Libc double free can be seen in avocado "
                          "doublefree output:\n%s" % output)
 
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
 
 class OutputPluginTest(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
 
     def check_output_files(self, debug_log):
         base_dir = os.path.dirname(debug_log)
@@ -52,7 +61,7 @@ class OutputPluginTest(unittest.TestCase):
 
     def test_output_incompatible_setup(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --sysinfo=off --xunit - --json - passtest'
+        cmd_line = './scripts/avocado run --job-results-dir %s --sysinfo=off --xunit - --json - passtest' % self.tmpdir
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 2
         output = result.stdout + result.stderr
@@ -65,7 +74,7 @@ class OutputPluginTest(unittest.TestCase):
 
     def test_output_incompatible_setup_2(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --sysinfo=off --html - passtest'
+        cmd_line = './scripts/avocado run --job-results-dir %s --sysinfo=off --html - passtest' % self.tmpdir
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 2
         output = result.stdout + result.stderr
@@ -79,7 +88,8 @@ class OutputPluginTest(unittest.TestCase):
     def test_output_compatible_setup(self):
         tmpfile = tempfile.mktemp()
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --sysinfo=off --journal --xunit %s --json - passtest' % tmpfile
+        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off --journal --xunit %s --json - passtest' %
+                    (self.tmpdir, tmpfile))
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout + result.stderr
         expected_rc = 0
@@ -99,7 +109,8 @@ class OutputPluginTest(unittest.TestCase):
     def test_output_compatible_setup_2(self):
         tmpfile = tempfile.mktemp()
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --sysinfo=off --xunit - --json %s passtest' % tmpfile
+        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off --xunit - --json %s passtest' %
+                    (self.tmpdir, tmpfile))
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout + result.stderr
         expected_rc = 0
@@ -125,8 +136,8 @@ class OutputPluginTest(unittest.TestCase):
         tmpdir = tempfile.mkdtemp()
         tmpfile3 = tempfile.mktemp(dir=tmpdir)
         os.chdir(basedir)
-        cmd_line = ('./scripts/avocado run --sysinfo=off --xunit %s --json %s --html %s passtest' %
-                    (tmpfile, tmpfile2, tmpfile3))
+        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off --xunit %s --json %s --html %s passtest' %
+                    (self.tmpdir, tmpfile, tmpfile2, tmpfile3))
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout + result.stderr
         expected_rc = 0
@@ -156,7 +167,8 @@ class OutputPluginTest(unittest.TestCase):
         tmpfile = tempfile.mktemp()
         tmpfile2 = tempfile.mktemp()
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --sysinfo=off --silent --xunit %s --json %s passtest' % (tmpfile, tmpfile2)
+        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off --silent --xunit %s --json %s passtest' %
+                    (self.tmpdir, tmpfile, tmpfile2))
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout + result.stderr
         expected_rc = 0
@@ -180,7 +192,7 @@ class OutputPluginTest(unittest.TestCase):
 
     def test_show_job_log(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --sysinfo=off passtest --show-job-log'
+        cmd_line = './scripts/avocado run --job-results-dir %s --sysinfo=off passtest --show-job-log' % self.tmpdir
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 0
         self.assertEqual(result.exit_status, expected_rc,
@@ -195,7 +207,8 @@ class OutputPluginTest(unittest.TestCase):
 
     def test_silent_trumps_show_job_log(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --sysinfo=off passtest --show-job-log --silent'
+        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off passtest --show-job-log --silent' %
+                    self.tmpdir)
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout + result.stderr
         expected_rc = 0
@@ -206,7 +219,7 @@ class OutputPluginTest(unittest.TestCase):
 
     def test_default_enabled_plugins(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --sysinfo=off passtest'
+        cmd_line = './scripts/avocado run --job-results-dir %s --sysinfo=off passtest' % self.tmpdir
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout + result.stderr
         expected_rc = 0
@@ -222,7 +235,8 @@ class OutputPluginTest(unittest.TestCase):
         tmpfile = tempfile.mktemp()
         try:
             os.chdir(basedir)
-            cmd_line = './scripts/avocado run --sysinfo=off whiteboard --json %s' % tmpfile
+            cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off whiteboard --json %s' %
+                        (self.tmpdir, tmpfile))
             result = process.run(cmd_line, ignore_status=True)
             expected_rc = 0
             self.assertEqual(result.exit_status, expected_rc,
@@ -246,7 +260,8 @@ class OutputPluginTest(unittest.TestCase):
         redirected_output_path = tempfile.mktemp()
         try:
             os.chdir(basedir)
-            cmd_line = './scripts/avocado run --sysinfo=off passtest > %s' % redirected_output_path
+            cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off passtest > %s' %
+                        (self.tmpdir, redirected_output_path))
             result = process.run(cmd_line, ignore_status=True, shell=True)
             output = result.stdout + result.stderr
             expected_rc = 0
@@ -265,6 +280,9 @@ class OutputPluginTest(unittest.TestCase):
                 os.remove(redirected_output_path)
             except OSError:
                 pass
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
 
 
 if __name__ == '__main__':

--- a/selftests/all/functional/avocado/standalone_tests.py
+++ b/selftests/all/functional/avocado/standalone_tests.py
@@ -33,27 +33,27 @@ class StandaloneTests(unittest.TestCase):
         return result
 
     def test_passtest(self):
-        cmd_line = './examples/tests/passtest.py'
+        cmd_line = './examples/tests/passtest.py -r'
         expected_rc = 0
         self.run_and_check(cmd_line, expected_rc, 'passtest')
 
     def test_skiptest(self):
-        cmd_line = './examples/tests/skiptest.py'
+        cmd_line = './examples/tests/skiptest.py -r'
         expected_rc = 0
         self.run_and_check(cmd_line, expected_rc, 'skiptest')
 
     def test_warntest(self):
-        cmd_line = './examples/tests/warntest.py'
+        cmd_line = './examples/tests/warntest.py -r'
         expected_rc = 0
         self.run_and_check(cmd_line, expected_rc, 'warntest')
 
     def test_failtest(self):
-        cmd_line = './examples/tests/failtest.py'
+        cmd_line = './examples/tests/failtest.py -r'
         expected_rc = 1
         self.run_and_check(cmd_line, expected_rc, 'failtest')
 
     def test_failtest_nasty(self):
-        cmd_line = './examples/tests/failtest_nasty.py'
+        cmd_line = './examples/tests/failtest_nasty.py -r'
         expected_rc = 1
         result = self.run_and_check(cmd_line, expected_rc, 'failtest_nasty')
         exc = "NastyException: Nasty-string-like-exception"
@@ -63,14 +63,14 @@ class StandaloneTests(unittest.TestCase):
                          "exception details." % (exc))
 
     def test_failtest_nasty2(self):
-        cmd_line = './examples/tests/failtest_nasty2.py'
+        cmd_line = './examples/tests/failtest_nasty2.py -r'
         expected_rc = 1
         result = self.run_and_check(cmd_line, expected_rc, 'failtest_nasty2')
         self.assertIn("Exception: Unable to get exception, check the traceback"
                       " for details.", result.stdout)
 
     def test_errortest(self):
-        cmd_line = './examples/tests/errortest.py'
+        cmd_line = './examples/tests/errortest.py -r'
         expected_rc = 1
         self.run_and_check(cmd_line, expected_rc, 'errortest')
 

--- a/selftests/all/functional/avocado/sysinfo_tests.py
+++ b/selftests/all/functional/avocado/sysinfo_tests.py
@@ -1,5 +1,7 @@
 import os
 import sys
+import shutil
+import tempfile
 
 if sys.version_info[:2] == (2, 6):
     import unittest2 as unittest
@@ -17,9 +19,12 @@ from avocado.utils import process
 
 class SysInfoTest(unittest.TestCase):
 
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+
     def test_sysinfo_enabled(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --sysinfo=on passtest'
+        cmd_line = './scripts/avocado run --job-results-dir %s --sysinfo=on passtest' % self.tmpdir
         result = process.run(cmd_line)
         expected_rc = 0
         self.assertEqual(result.exit_status, expected_rc,
@@ -40,7 +45,7 @@ class SysInfoTest(unittest.TestCase):
 
     def test_sysinfo_disabled(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --sysinfo=off passtest'
+        cmd_line = './scripts/avocado run --job-results-dir %s --sysinfo=off passtest' % self.tmpdir
         result = process.run(cmd_line)
         expected_rc = 0
         self.assertEqual(result.exit_status, expected_rc,
@@ -53,6 +58,8 @@ class SysInfoTest(unittest.TestCase):
         msg = 'Avocado created sysinfo directory %s:\n%s' % (sysinfo_dir, result)
         self.assertFalse(os.path.isdir(sysinfo_dir), msg)
 
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
 
 if __name__ == '__main__':
     unittest.main()

--- a/selftests/all/functional/avocado/utils_tests.py
+++ b/selftests/all/functional/avocado/utils_tests.py
@@ -2,6 +2,7 @@ import os
 import sys
 import time
 import tempfile
+import shutil
 
 if sys.version_info[:2] == (2, 6):
     import unittest2 as unittest
@@ -150,6 +151,8 @@ class ProcessTest(unittest.TestCase):
         self.assertEqual(result.exit_status, 0, 'result: %s' % result)
         self.assertIn('load average', result.stdout)
 
+    def tearDown(self):
+        shutil.rmtree(self.base_logdir)
 
 if __name__ == '__main__':
     unittest.main()

--- a/selftests/all/functional/avocado/wrapper_tests.py
+++ b/selftests/all/functional/avocado/wrapper_tests.py
@@ -2,6 +2,7 @@ import os
 import sys
 import unittest
 import tempfile
+import shutil
 
 # simple magic for using scripts within a source tree
 basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..',
@@ -26,6 +27,7 @@ exec -- $@
 class WrapperTest(unittest.TestCase):
 
     def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
         self.tmpfile = tempfile.mktemp()
         self.script = script.TemporaryScript(
             'success.sh',
@@ -40,8 +42,8 @@ class WrapperTest(unittest.TestCase):
 
     def test_global_wrapper(self):
         os.chdir(basedir)
-        cmd_line = ('./scripts/avocado run --sysinfo=off --wrapper %s '
-                    'examples/tests/datadir.py' % self.script.path)
+        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off --wrapper %s '
+                    'examples/tests/datadir.py' % (self.tmpdir, self.script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 0
         self.assertEqual(result.exit_status, expected_rc,
@@ -54,8 +56,8 @@ class WrapperTest(unittest.TestCase):
 
     def test_process_wrapper(self):
         os.chdir(basedir)
-        cmd_line = ('./scripts/avocado run --sysinfo=off --wrapper %s:*/datadir '
-                    'examples/tests/datadir.py' % self.script.path)
+        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off --wrapper %s:*/datadir '
+                    'examples/tests/datadir.py' % (self.tmpdir, self.script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 0
         self.assertEqual(result.exit_status, expected_rc,
@@ -68,8 +70,8 @@ class WrapperTest(unittest.TestCase):
 
     def test_both_wrappers(self):
         os.chdir(basedir)
-        cmd_line = ('./scripts/avocado run --sysinfo=off --wrapper %s --wrapper %s:*/datadir '
-                    'examples/tests/datadir.py' % (self.dummy.path,
+        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off --wrapper %s --wrapper %s:*/datadir '
+                    'examples/tests/datadir.py' % (self.tmpdir, self.dummy.path,
                                                    self.script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 0
@@ -88,6 +90,7 @@ class WrapperTest(unittest.TestCase):
             os.remove(self.tmpfile)
         except OSError:
             pass
+        shutil.rmtree(self.tmpdir)
 
 
 if __name__ == '__main__':

--- a/selftests/all/unit/avocado/datadir_unittest.py
+++ b/selftests/all/unit/avocado/datadir_unittest.py
@@ -41,17 +41,22 @@ class DataDirTest(unittest.TestCase):
         """
         When avocado.conf is present, honor the values coming from it.
         """
+        stg_orig = settings.settings
         stg = settings.Settings(self.config_file.name)
-        # Trick the module to think we're on a system wide install
-        stg.intree = False
-        flexmock(settings, settings=stg)
-        from avocado.core import data_dir
-        flexmock(data_dir, settings=stg)
-        self.assertFalse(data_dir.settings.intree)
-        reload(data_dir)
-        for key in self.mapping.keys():
-            data_dir_func = getattr(data_dir, 'get_%s' % key)
-            self.assertEqual(data_dir_func(), stg.get_value('datadir.paths', key))
+        try:
+            # Trick the module to think we're on a system wide install
+            stg.intree = False
+            flexmock(settings, settings=stg)
+            from avocado.core import data_dir
+            flexmock(data_dir, settings=stg)
+            self.assertFalse(data_dir.settings.intree)
+            reload(data_dir)
+            for key in self.mapping.keys():
+                data_dir_func = getattr(data_dir, 'get_%s' % key)
+                self.assertEqual(data_dir_func(), stg.get_value('datadir.paths', key))
+        finally:
+            flexmock(settings, settings=stg_orig)
+            reload(data_dir)
         del data_dir
 
     def tearDown(self):

--- a/selftests/all/unit/avocado/jsonresult_unittest.py
+++ b/selftests/all/unit/avocado/jsonresult_unittest.py
@@ -3,7 +3,8 @@ import os
 import sys
 import json
 import argparse
-from tempfile import mkstemp
+import tempfile
+import shutil
 
 # simple magic for using scripts within a source tree
 basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -40,20 +41,22 @@ class _Stream(object):
 class JSONResultTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpfile = mkstemp()
+        self.tmpfile = tempfile.mkstemp()
+        self.tmpdir = tempfile.mkdtemp()
         args = argparse.Namespace(json_output=self.tmpfile[1])
         stream = _Stream()
         stream.logfile = 'debug.log'
         self.test_result = jsonresult.JSONTestResult(stream, args)
         self.test_result.filename = self.tmpfile[1]
         self.test_result.start_tests()
-        self.test1 = test.Test(job=job.Job())
+        self.test1 = test.Test(job=job.Job(), base_logdir=self.tmpdir)
         self.test1.status = 'PASS'
         self.test1.time_elapsed = 1.23
 
     def tearDown(self):
         os.close(self.tmpfile[0])
         os.remove(self.tmpfile[1])
+        shutil.rmtree(self.tmpdir)
 
     def testAddSuccess(self):
         self.test_result.start_test(self.test1)

--- a/selftests/all/unit/avocado/multiples_tests.py
+++ b/selftests/all/unit/avocado/multiples_tests.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-
 from avocado import test
 from avocado import job
 
@@ -23,13 +22,16 @@ class MultipleTests(test.Test):
         self.assertTrue(1, 1)
 
     def division_by_zero(self):
-        "This method should never execute"
+        """
+        This method should never execute
+        """
         return 1 / 0
 
     def action(self):
-        "This method should never execute"
+        """
+        This method should never execute
+        """
         pass
-
 
 if __name__ == '__main__':
     job.main()

--- a/selftests/all/unit/avocado/sysinfo_unittest.py
+++ b/selftests/all/unit/avocado/sysinfo_unittest.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import tempfile
+import shutil
 
 if sys.version_info[:2] == (2, 6):
     import unittest2 as unittest
@@ -98,10 +99,7 @@ class SysinfoTest(unittest.TestCase):
                          "Test post dir is not empty")
 
     def tearDown(self):
-        try:
-            os.rmdir(self.tmpdir)
-        except OSError:
-            pass
+        shutil.rmtree(self.tmpdir)
 
 if __name__ == '__main__':
     unittest.main()

--- a/selftests/all/unit/avocado/xunit_unittest.py
+++ b/selftests/all/unit/avocado/xunit_unittest.py
@@ -3,7 +3,8 @@ import unittest
 import os
 import sys
 from xml.dom import minidom
-from tempfile import mkstemp
+import tempfile
+import shutil
 
 # simple magic for using scripts within a source tree
 basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -44,18 +45,20 @@ class _Stream(object):
 class xUnitSucceedTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpfile = mkstemp()
+        self.tmpfile = tempfile.mkstemp()
+        self.tmpdir = tempfile.mkdtemp()
         args = argparse.Namespace()
         args.xunit_output = self.tmpfile[1]
         self.test_result = xunit.xUnitTestResult(stream=_Stream(), args=args)
         self.test_result.start_tests()
-        self.test1 = test.Test(job=job.Job())
+        self.test1 = test.Test(job=job.Job(), base_logdir=self.tmpdir)
         self.test1.status = 'PASS'
         self.test1.time_elapsed = 1.23
 
     def tearDown(self):
         os.close(self.tmpfile[0])
         os.remove(self.tmpfile[1])
+        shutil.rmtree(self.tmpdir)
 
     def testAddSuccess(self):
         self.test_result.start_test(self.test1)


### PR DESCRIPTION
Getting to eliminate all places where we were not properly cleaning up temporary test results in both /tmp and ~/avocado/job-results was harder than I thought. But I finally got there.

Changes from v1:
 * Addressed comments from @ldoktor and @clebergnu.