### PR TITLE
Makefile: clean auto generated API documentation files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ clean:
 	rm -f man/avocado.1
 	rm -f man/avocado-rest-client.1
 	rm -rf docs/build
+	rm -f docs/build/api/*.rst
 	test -L avocado/virt && rm -f avocado/virt || true
 	test -L avocado/plugins/virt.py && rm -f avocado/plugins/virt.py || true
 	test -L avocado/plugins/virt_bootstrap.py && rm -f avocado/plugins/virt_bootstrap.py || true


### PR DESCRIPTION
The ReST files at doc/build/api are automatically generated by code
on `conf.py` and should also be removed on the `clean` target.

Signed-off-by: Cleber Rosa <crosa@redhat.com>