### PR TITLE
Set timeout per job execution [V1]

### DIFF
--- a/avocado/job.py
+++ b/avocado/job.py
@@ -109,6 +109,22 @@ class Job(object):
         self.status = "RUNNING"
         self.result_proxy = result.TestResultProxy()
         self.sysinfo = None
+        self._setup_timeout()
+
+    def _setup_timeout(self):
+        units = {'s': 1, 'm': 60, 'h': 60 * 60, 'd': 60 * 60 * 24}
+        mult = 1
+        timeout = getattr(self.args, 'job_timeout', None)
+        if timeout is not None:
+            if timeout[-1].lower() in units.keys():
+                mult = units[timeout[-1].lower()]
+                timeout = timeout[:-1]
+            try:
+                self.timeout = int(timeout) * mult
+            except ValueError:
+                self.timeout = 0
+        else:
+            self.timeout = 0
 
     def _setup_job_results(self):
         logdir = getattr(self.args, 'logdir', None)
@@ -320,7 +336,8 @@ class Job(object):
         _TEST_LOGGER.info('')
 
         self.view.logfile = self.logfile
-        failures = self.test_runner.run_suite(test_suite, mux)
+        failures = self.test_runner.run_suite(test_suite, mux,
+                                              timeout=self.timeout)
         self.view.stop_file_logging()
         if not self.standalone:
             self._update_latest_link()

--- a/avocado/plugins/runner.py
+++ b/avocado/plugins/runner.py
@@ -64,6 +64,14 @@ class TestRunner(plugin.Plugin):
                                  help=('Forces to use of an alternate job '
                                        'results directory.'))
 
+        self.parser.add_argument('--job-timeout', action='store',
+                                 default=None, metavar='SECONDS',
+                                 help=('Set the maximum amount of time (in SECONDS) that '
+                                       'tests are allow to execute. '
+                                       'Note that the value zero means "no timeout". '
+                                       'You can also use a number followed by a suffix like: '
+                                       ' s (seconds), m (minutes), h (hours). '))
+
         sysinfo_default = settings.get_value('sysinfo.collect',
                                              'enabled',
                                              key_type='bool',

--- a/avocado/runner.py
+++ b/avocado/runner.py
@@ -25,6 +25,7 @@ import signal
 import sys
 import time
 
+from avocado import test
 from avocado import runtime
 from avocado.core import exceptions
 from avocado.core import output
@@ -111,7 +112,8 @@ class TestRunner(object):
             test_state['text_output'] = log_file_obj.read()
         return test_state
 
-    def _run_test(self, test_factory, q, failures):
+    def _run_test(self, test_factory, q, failures, max_time=None):
+
         p = multiprocessing.Process(target=self.run_test,
                                     args=(test_factory, q,))
 
@@ -134,7 +136,10 @@ class TestRunner(object):
         # for sure if there's a timeout set.
         timeout = (early_state.get('params', {}).get('timeout') or
                    self.DEFAULT_TIMEOUT)
+
         time_deadline = time_started + timeout
+        if max_time is not None:
+            time_deadline = min(time_deadline, max_time)
 
         ctrl_c_count = 0
         ignore_window = 2.0
@@ -216,7 +221,7 @@ class TestRunner(object):
             return False
         return True
 
-    def run_suite(self, test_suite, mux):
+    def run_suite(self, test_suite, mux, timeout=0):
         """
         Run one or more tests and report with test result.
 
@@ -230,11 +235,20 @@ class TestRunner(object):
         self.result.start_tests()
         q = queues.SimpleQueue()
 
+        if timeout > 0:
+            end_time = time.time() + timeout
+        else:
+            end_time = None
+
         for test_template in test_suite:
             for test_factory in mux.itertests(test_template):
-                if not self._run_test(test_factory, q, failures):
-                    break
-        runtime.CURRENT_TEST = None
+                if end_time is not None and time.time() > end_time:
+                    test_factory = (test.TimeOutSkipTest, test_factory[1])
+                    self._run_test(test_factory, q, failures)
+                else:
+                    if not self._run_test(test_factory, q, failures, end_time):
+                        break
+            runtime.CURRENT_TEST = None
         self.result.end_tests()
         if self.job.sysinfo is not None:
             self.job.sysinfo.end_job_hook()

--- a/avocado/test.py
+++ b/avocado/test.py
@@ -605,3 +605,27 @@ class NotATest(Test):
         e_msg = ('File %s is not executable and does not contain an avocado '
                  'test class in it ' % self.name)
         raise exceptions.NotATestError(e_msg)
+
+
+class TimeOutSkipTest(Test):
+
+    """
+    Skip test due job timeout.
+
+    This test is skipped due a job timeout.
+    It will never have a chance to execute.
+    """
+
+    def __init__(self, name=None, params=None, base_logdir=None, tag=None,
+                 job=None, runner_queue=None, path=None):
+        if name is None and path is not None:
+            name = path
+        super(TimeOutSkipTest, self).__init__(
+            name=name,
+            base_logdir=base_logdir,
+            tag=tag, job=job,
+            runner_queue=runner_queue)
+
+    def runTest(self):
+        e_msg = 'Test skipped due a job timeout!'
+        raise exceptions.TestNAError(e_msg)


### PR DESCRIPTION
(Work in Progress) Set the maximum of time that tests will have to execute, with command line option `run --set-jobtimeout SECONDS`. If a job timeout happens in the middle of a test, then the test will set as error and the following tests (if any) will be marked as skipped.

Question: I'm not sure if I should add a class to act as a skip test. Two alternatives I imagine: 1) to construct skip test in a different method (by logging messages and counting values), looks a bit longer to implemente  or 2) Overwrite the code to run the test and raise the TestNAError.

Bug: it may crash with something like...
```
 ./scripts/avocado run synctest /usr/bin/sync passtest sleeptest --job-timeout=2
JOB ID     : 7e6bfa41829ebf26cb2a12f449d5e2eb311a5b8c
JOB LOG    : /home/rmoura/avocado/job-results/job-2015-04-13T17.28-7e6bfa4/job.log
JOB HTML   : /home/rmoura/avocado/job-results/job-2015-04-13T17.28-7e6bfa4/html/results.html
TESTS      : 4
(1/4) synctest.py: ERROR (3.04 s)
(2/4) /usr/bin/sync:  Avocado crashed: KeyError: None
Traceback (most recent call last):

  File "/home/rmoura/Work/avocado.jobtimeout/avocado/job.py", line 340, in _run
    timeout=self.timeout)

  File "/home/rmoura/Work/avocado.jobtimeout/avocado/runner.py", line 250, in run_suite
    self._run_test(test_factory, q, failures)

  File "/home/rmoura/Work/avocado.jobtimeout/avocado/runner.py", line 219, in _run_test
    self.result.check_test(test_state)

  File "/home/rmoura/Work/avocado.jobtimeout/avocado/result.py", line 98, in check_test
    output_plugin.check_test(state)

  File "/home/rmoura/Work/avocado.jobtimeout/avocado/result.py", line 249, in check_test
    add = status_map[state['status']]

KeyError: None

```

Notes:
* Alternative implementation to PR #534.
* See card https://trello.com/c/ZUd59puD/165-option-to-set-timeout-per-job