### PR TITLE
avocado.test: Don't force creation of the test datadir

### DIFF
--- a/avocado/test.py
+++ b/avocado/test.py
@@ -91,7 +91,7 @@ class Test(unittest.TestCase):
 
         self.filename = inspect.getfile(self.__class__).rstrip('co')
         self.basedir = os.path.dirname(self.filename)
-        self.datadir = utils_path.init_dir(self.filename + '.data')
+        self.datadir = self.filename + '.data'
 
         self.expected_stdout_file = os.path.join(self.datadir,
                                                  'stdout.expected')


### PR DESCRIPTION
A test may or may not have a data dir. Also, a test might
be on a read only location, so forcing the creation of
one will raise an OSError. This fixes a problem introduced
with 133b60e8dbae94eef5d9a69411bec6a565e90d45.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>