### PR TITLE
Sysinfo: make it configurable [v2]

### DIFF
--- a/avocado.spec
+++ b/avocado.spec
@@ -1,7 +1,7 @@
 Summary: Avocado Test Framework
 Name: avocado
 Version: 0.21.0
-Release: 5%{?dist}
+Release: 6%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.github.io/
@@ -54,8 +54,12 @@ selftests/run selftests/all/unit
 %doc README.rst LICENSE
 %dir /etc/avocado
 %dir /etc/avocado/conf.d
+%dir /etc/avocado/sysinfo
 %config(noreplace)/etc/avocado/avocado.conf
 %config(noreplace)/etc/avocado/conf.d/README
+%config(noreplace)/etc/avocado/sysinfo/commands
+%config(noreplace)/etc/avocado/sysinfo/files
+%config(noreplace)/etc/avocado/sysinfo/profilers
 %{python_sitelib}/avocado*
 %{_bindir}/avocado
 %{_bindir}/avocado-rest-client
@@ -99,6 +103,9 @@ examples of how to write tests on your own.
 %{_datadir}/avocado/api
 
 %changelog
+* Mon Apr 13 2015 Cleber Rosa <cleber@redhat.com> - 0.21.0-6
+- Added sysinfo configuration files
+
 * Sat Mar 28 2015 Cleber Rosa <cleber@redhat.com> - 0.21.0-5
 - Change the way man pages are built, now using Makefile targets
 - Reorganized runtime and build requirements

--- a/avocado/sysinfo.py
+++ b/avocado/sysinfo.py
@@ -353,8 +353,7 @@ class SysInfo(object):
                           tries to look in the config files.
         """
         if basedir is None:
-            basedir = utils.path.init_dir(os.getcwd(), 'sysinfo')
-
+            basedir = utils.path.init_dir('sysinfo')
         self.basedir = basedir
 
         self._installed_pkgs = None

--- a/avocado/sysinfo.py
+++ b/avocado/sysinfo.py
@@ -66,20 +66,6 @@ _DEFAULT_FILES_START_JOB = ["/proc/cmdline",
 
 _DEFAULT_FILES_END_JOB = _DEFAULT_FILES_START_JOB
 
-_DEFAULT_COMMANDS_START_ITERATION = []
-_DEFAULT_COMMANDS_END_ITERATION = ["/proc/schedstat",
-                                   "/proc/meminfo",
-                                   "/proc/slabinfo",
-                                   "/proc/interrupts",
-                                   "/proc/buddyinfo"]
-
-_DEFAULT_FILES_START_ITERATION = []
-_DEFAULT_FILES_END_ITERATION = ["/proc/schedstat",
-                                "/proc/meminfo",
-                                "/proc/slabinfo",
-                                "/proc/interrupts",
-                                "/proc/buddyinfo"]
-
 
 class Loggable(object):
 
@@ -350,8 +336,6 @@ class SysInfo(object):
 
     * start_job
     * start_test
-    * start_iteration
-    * end_iteration
     * end_test
     * end_job
     """
@@ -412,15 +396,10 @@ class SysInfo(object):
         self.start_test_loggables = set()
         self.end_test_loggables = set()
 
-        self.start_iteration_loggables = set()
-        self.end_iteration_loggables = set()
-
         self.hook_mapping = {'start_job': self.start_job_loggables,
                              'end_job': self.end_job_loggables,
                              'start_test': self.start_test_loggables,
-                             'end_test': self.end_test_loggables,
-                             'start_iteration': self.start_iteration_loggables,
-                             'end_iteration': self.end_iteration_loggables}
+                             'end_test': self.end_test_loggables}
 
         self.pre_dir = utils.path.init_dir(self.basedir, 'pre')
         self.post_dir = utils.path.init_dir(self.basedir, 'post')
@@ -468,18 +447,6 @@ class SysInfo(object):
         except ValueError, details:
             log.info(details)
 
-        for cmd in _DEFAULT_COMMANDS_START_ITERATION:
-            self.start_iteration_loggables.add(Command(cmd))
-
-        for cmd in _DEFAULT_COMMANDS_END_ITERATION:
-            self.end_iteration_loggables.add(Command(cmd))
-
-        for filename in _DEFAULT_FILES_START_ITERATION:
-            self.start_iteration_loggables.add(Logfile(filename))
-
-        for filename in _DEFAULT_FILES_END_ITERATION:
-            self.end_iteration_loggables.add(Logfile(filename))
-
     def _get_loggables(self, hook):
         loggables = self.hook_mapping.get(hook)
         if loggables is None:
@@ -493,7 +460,7 @@ class SysInfo(object):
 
         :param cmd: Command to log.
         :param hook: In which hook this cmd should be logged (start job, end
-                     job, start iteration, end iteration).
+                     job).
         """
         loggables = self._get_loggables(hook)
         loggables.add(Command(cmd))
@@ -504,7 +471,7 @@ class SysInfo(object):
 
         :param filename: Path to the file to be logged.
         :param hook: In which hook this file should be logged (start job, end
-                     job, start iteration, end iteration).
+                     job).
         """
         loggables = self._get_loggables(hook)
         loggables.add(Logfile(filename))
@@ -515,7 +482,7 @@ class SysInfo(object):
 
         :param filename: Path to the file to be logged.
         :param hook: In which hook this watcher should be logged (start job, end
-                     job, start iteration, end iteration).
+                     job).
         """
         loggables = self._get_loggables(hook)
         loggables.add(LogWatcher(filename))
@@ -590,20 +557,6 @@ class SysInfo(object):
 
         if self.log_packages:
             self._log_modified_packages(self.post_dir)
-
-    def start_iteration_hook(self):
-        """
-        Logging hook called before a test iteration
-        """
-        for log in self.start_iteration_loggables:
-            log.run(self.pre_dir)
-
-    def end_iteration_hook(self, test, iteration=None):
-        """
-        Logging hook called after a test iteration
-        """
-        for log in self.end_iteration_loggables:
-            log.run(self.post_dir)
 
 
 def collect_sysinfo(args):

--- a/avocado/sysinfo.py
+++ b/avocado/sysinfo.py
@@ -31,38 +31,6 @@ from avocado.settings import settings
 log = logging.getLogger("avocado.sysinfo")
 
 
-_DEFAULT_COMMANDS_JOB = ["df -mP",
-                         "dmesg -c",
-                         "uname -a",
-                         "lspci -vvnn",
-                         "gcc --version",
-                         "ld --version",
-                         "mount",
-                         "hostname",
-                         "uptime",
-                         "dmidecode",
-                         "ifconfig -a",
-                         "brctl show",
-                         "ip link",
-                         "numactl --hardware show",
-                         "lscpu",
-                         "fdisk -l"]
-
-_DEFAULT_FILES_JOB = ["/proc/cmdline",
-                      "/proc/mounts",
-                      "/proc/pci",
-                      "/proc/meminfo",
-                      "/proc/slabinfo",
-                      "/proc/version",
-                      "/proc/cpuinfo",
-                      "/proc/modules",
-                      "/proc/interrupts",
-                      "/proc/partitions",
-                      "/sys/kernel/debug/sched_features",
-                      "/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor",
-                      "/sys/devices/system/clocksource/clocksource0/current_clocksource"]
-
-
 class Collectible(object):
 
     """
@@ -336,7 +304,7 @@ class SysInfo(object):
     * end_job
     """
 
-    def __init__(self, basedir=None, log_packages=None, profilers=None):
+    def __init__(self, basedir=None, log_packages=None, profiler=None):
         """
         Set sysinfo collectibles.
 
@@ -345,8 +313,8 @@ class SysInfo(object):
                              logging packages is a costly operation). If not
                              given explicitly, tries to look in the config
                              files, and if not found, defaults to False.
-        :param profilers: Wether to use the profiler. If not given explicitly,
-                          tries to look in the config files.
+        :param profiler: Wether to use the profiler. If not given explicitly,
+                         tries to look in the config files.
         """
         if basedir is None:
             basedir = utils.path.init_dir('sysinfo')
@@ -361,26 +329,41 @@ class SysInfo(object):
         else:
             self.log_packages = log_packages
 
-        if profilers is None:
+        commands_file = settings.get_value('sysinfo.collectibles',
+                                           'commands',
+                                           key_type='str',
+                                           default='')
+        log.info('Commands configured by file: %s', commands_file)
+        self.commands = utils.genio.read_all_lines(commands_file)
+
+        files_file = settings.get_value('sysinfo.collectibles',
+                                        'files',
+                                        key_type='str',
+                                        default='')
+        log.info('Files configured by file: %s', files_file)
+        self.files = utils.genio.read_all_lines(files_file)
+
+        if profiler is None:
             self.profiler = settings.get_value('sysinfo.collect',
                                                'profiler',
                                                key_type='bool',
                                                default=False)
-            profiler_commands = settings.get_value('sysinfo.collect',
-                                                   'profiler_commands',
-                                                   key_type='str',
-                                                   default='')
         else:
-            self.profiler = True
-            profiler_commands = profilers
+            self.profiler = profiler
 
-        self.profiler_commands = [x for x in profiler_commands.split(':') if x.strip()]
-        log.info('Profilers declared: %s', self.profiler_commands)
-        if not self.profiler_commands:
+        profiler_file = settings.get_value('sysinfo.collectibles',
+                                           'profilers',
+                                           key_type='str',
+                                           default='')
+        self.profilers = utils.genio.read_all_lines(profiler_file)
+
+        log.info('Profilers configured by file: %s', profiler_file)
+        log.info('Profilers declared: %s', self.profilers)
+        if not self.profilers:
             self.profiler = False
 
         if self.profiler is False:
-            if not self.profiler_commands:
+            if not self.profilers:
                 log.info('Profiler disabled: no profiler commands configured')
             else:
                 log.info('Profiler disabled')
@@ -420,14 +403,14 @@ class SysInfo(object):
 
     def _set_collectibles(self):
         if self.profiler:
-            for cmd in self.profiler_commands:
+            for cmd in self.profilers:
                 self.start_job_collectibles.add(Daemon(cmd))
 
-        for cmd in _DEFAULT_COMMANDS_JOB:
+        for cmd in self.commands:
             self.start_job_collectibles.add(Command(cmd))
             self.end_job_collectibles.add(Command(cmd))
 
-        for filename in _DEFAULT_FILES_JOB:
+        for filename in self.files:
             self.start_job_collectibles.add(Logfile(filename))
             self.end_job_collectibles.add(Logfile(filename))
 

--- a/avocado/sysinfo.py
+++ b/avocado/sysinfo.py
@@ -31,40 +31,36 @@ from avocado.settings import settings
 log = logging.getLogger("avocado.sysinfo")
 
 
-_DEFAULT_COMMANDS_START_JOB = ["df -mP",
-                               "dmesg -c",
-                               "uname -a",
-                               "lspci -vvnn",
-                               "gcc --version",
-                               "ld --version",
-                               "mount",
-                               "hostname",
-                               "uptime",
-                               "dmidecode",
-                               "ifconfig -a",
-                               "brctl show",
-                               "ip link",
-                               "numactl --hardware show",
-                               "lscpu",
-                               "fdisk -l"]
+_DEFAULT_COMMANDS_JOB = ["df -mP",
+                         "dmesg -c",
+                         "uname -a",
+                         "lspci -vvnn",
+                         "gcc --version",
+                         "ld --version",
+                         "mount",
+                         "hostname",
+                         "uptime",
+                         "dmidecode",
+                         "ifconfig -a",
+                         "brctl show",
+                         "ip link",
+                         "numactl --hardware show",
+                         "lscpu",
+                         "fdisk -l"]
 
-_DEFAULT_COMMANDS_END_JOB = _DEFAULT_COMMANDS_START_JOB
-
-_DEFAULT_FILES_START_JOB = ["/proc/cmdline",
-                            "/proc/mounts",
-                            "/proc/pci",
-                            "/proc/meminfo",
-                            "/proc/slabinfo",
-                            "/proc/version",
-                            "/proc/cpuinfo",
-                            "/proc/modules",
-                            "/proc/interrupts",
-                            "/proc/partitions",
-                            "/sys/kernel/debug/sched_features",
-                            "/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor",
-                            "/sys/devices/system/clocksource/clocksource0/current_clocksource"]
-
-_DEFAULT_FILES_END_JOB = _DEFAULT_FILES_START_JOB
+_DEFAULT_FILES_JOB = ["/proc/cmdline",
+                      "/proc/mounts",
+                      "/proc/pci",
+                      "/proc/meminfo",
+                      "/proc/slabinfo",
+                      "/proc/version",
+                      "/proc/cpuinfo",
+                      "/proc/modules",
+                      "/proc/interrupts",
+                      "/proc/partitions",
+                      "/sys/kernel/debug/sched_features",
+                      "/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor",
+                      "/sys/devices/system/clocksource/clocksource0/current_clocksource"]
 
 
 class Loggable(object):
@@ -427,16 +423,12 @@ class SysInfo(object):
             for cmd in self.profiler_commands:
                 self.start_job_loggables.add(Daemon(cmd))
 
-        for cmd in _DEFAULT_COMMANDS_START_JOB:
+        for cmd in _DEFAULT_COMMANDS_JOB:
             self.start_job_loggables.add(Command(cmd))
-
-        for cmd in _DEFAULT_COMMANDS_END_JOB:
             self.end_job_loggables.add(Command(cmd))
 
-        for filename in _DEFAULT_FILES_START_JOB:
+        for filename in _DEFAULT_FILES_JOB:
             self.start_job_loggables.add(Logfile(filename))
-
-        for filename in _DEFAULT_FILES_END_JOB:
             self.end_job_loggables.add(Logfile(filename))
 
         # As the system log path is not standardized between distros,

--- a/avocado/sysinfo.py
+++ b/avocado/sysinfo.py
@@ -66,14 +66,6 @@ _DEFAULT_FILES_START_JOB = ["/proc/cmdline",
 
 _DEFAULT_FILES_END_JOB = _DEFAULT_FILES_START_JOB
 
-_DEFAULT_COMMANDS_START_TEST = []
-
-_DEFAULT_COMMANDS_END_TEST = []
-
-_DEFAULT_FILES_START_TEST = []
-
-_DEFAULT_FILES_END_TEST = []
-
 _DEFAULT_COMMANDS_START_ITERATION = []
 _DEFAULT_COMMANDS_END_ITERATION = ["/proc/schedstat",
                                    "/proc/meminfo",
@@ -469,24 +461,12 @@ class SysInfo(object):
         for filename in _DEFAULT_FILES_END_JOB:
             self.end_job_loggables.add(Logfile(filename))
 
-        for cmd in _DEFAULT_COMMANDS_START_TEST:
-            self.start_test_loggables.add(Command(cmd))
-
-        for cmd in _DEFAULT_COMMANDS_END_TEST:
-            self.end_test_loggables.add(Command(cmd))
-
         # As the system log path is not standardized between distros,
         # we have to probe and find out the correct path.
         try:
             self.end_test_loggables.add(self._get_syslog_watcher())
         except ValueError, details:
             log.info(details)
-
-        for filename in _DEFAULT_FILES_START_TEST:
-            self.start_test_loggables.add(Logfile(filename))
-
-        for filename in _DEFAULT_FILES_END_TEST:
-            self.end_test_loggables.add(Logfile(filename))
 
         for cmd in _DEFAULT_COMMANDS_START_ITERATION:
             self.start_iteration_loggables.add(Command(cmd))

--- a/avocado/utils/genio.py
+++ b/avocado/utils/genio.py
@@ -126,6 +126,32 @@ def read_one_line(filename):
     return line
 
 
+def read_all_lines(filename):
+    """
+    Return all lines of a given file
+
+    This utility method returns an empty list in any error scenario,
+    that is, it doesn't attempt to identify error paths and raise
+    appropriate exceptions. It does exactly the opposite to that.
+
+    This should be used when it's fine or desirable to have an empty
+    set of lines if a file is missing or is unreadable.
+
+    :param filename: Path to the file.
+    :type filename: str
+
+    :return: all lines of the file as list
+    :rtype: list
+    """
+    contents = []
+    try:
+        with open(filename, 'r') as file_obj:
+            contents = [line.rstrip('\n') for line in file_obj.readlines()]
+    except:
+        pass
+    return contents
+
+
 def write_file(filename, data):
     """
     Write data to a file.

--- a/etc/avocado/avocado.conf
+++ b/etc/avocado/avocado.conf
@@ -15,8 +15,14 @@ enabled = True
 installed_packages = False
 # Whether to run certain commands in bg to give extra job debug information
 profiler = False
-# Commands to run in bg (colon separated)
-profiler_commands = vmstat 1:journalctl -f
+
+[sysinfo.collectibles]
+# File with list of commands that will be executed and have their output collected
+commands = /etc/avocado/sysinfo/commands
+# File with list of files that will be collected verbatim
+files = /etc/avocado/sysinfo/files
+# File with list of commands that will run alongside the job/test
+profilers = /etc/avocado/sysinfo/profilers
 
 [runner.output]
 # Whether to display colored output in terminals that support it

--- a/etc/avocado/sysinfo/commands
+++ b/etc/avocado/sysinfo/commands
@@ -1,0 +1,16 @@
+df -mP
+dmesg -c
+uname -a
+lspci -vvnn
+gcc --version
+ld --version
+mount
+hostname
+uptime
+dmidecode
+ifconfig -a
+brctl show
+ip link
+numactl --hardware show
+lscpu
+fdisk -l

--- a/etc/avocado/sysinfo/files
+++ b/etc/avocado/sysinfo/files
@@ -1,0 +1,13 @@
+/proc/cmdline
+/proc/mounts
+/proc/pci
+/proc/meminfo
+/proc/slabinfo
+/proc/version
+/proc/cpuinfo
+/proc/modules
+/proc/interrupts
+/proc/partitions
+/sys/kernel/debug/sched_features
+/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
+/sys/devices/system/clocksource/clocksource0/current_clocksource

--- a/etc/avocado/sysinfo/profilers
+++ b/etc/avocado/sysinfo/profilers
@@ -1,0 +1,2 @@
+vmstat 1
+journalctl -f

--- a/selftests/all/functional/avocado/sysinfo_tests.py
+++ b/selftests/all/functional/avocado/sysinfo_tests.py
@@ -40,8 +40,8 @@ class SysInfoTest(unittest.TestCase):
         self.assertGreater(len(os.listdir(sysinfo_dir)), 0, msg)
         for hook in ('pre', 'post'):
             sysinfo_subdir = os.path.join(sysinfo_dir, hook)
-            msg = 'The sysinfo/%s subdirectory is empty:\n%s' % (hook, result)
-            self.assertGreater(len(os.listdir(sysinfo_subdir)), 0, msg)
+            msg = 'The sysinfo/%s subdirectory does not exist:\n%s' % (hook, result)
+            self.assertTrue(os.path.exists(sysinfo_subdir), msg)
 
     def test_sysinfo_disabled(self):
         os.chdir(basedir)

--- a/selftests/all/unit/avocado/sysinfo_unittest.py
+++ b/selftests/all/unit/avocado/sysinfo_unittest.py
@@ -69,13 +69,9 @@ class SysinfoTest(unittest.TestCase):
                                 "Job does not have 'pre' dir")
         job_predir = os.path.join(jobdir, 'pre')
         self.assertTrue(os.path.isdir(job_predir))
-        self.assertGreater(len(os.listdir(job_predir)), 0,
-                           "Job pre dir is empty")
         sysinfo_logger.end_job_hook()
         job_postdir = os.path.join(jobdir, 'post')
         self.assertTrue(os.path.isdir(job_postdir))
-        self.assertGreater(len(os.listdir(job_postdir)), 0,
-                           "Job post dir is empty")
 
     def test_logger_test_hooks(self):
         testdir = os.path.join(self.tmpdir, 'job', 'test1')

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,9 @@ def get_data_files():
     data_files = [(get_dir(['etc', 'avocado']), ['etc/avocado/avocado.conf'])]
     data_files += [(get_dir(['etc', 'avocado', 'conf.d']),
                     ['etc/avocado/conf.d/README'])]
+    data_files += [(get_dir(['etc', 'avocado', 'sysinfo']),
+                    ['etc/avocado/sysinfo/commands', 'etc/avocado/sysinfo/files',
+                     'etc/avocado/sysinfo/profilers'])]
     data_files += [(get_tests_dir(), glob.glob('examples/tests/*.py'))]
     for data_dir in glob.glob('examples/tests/*.data'):
         fmt_str = '%s/*' % data_dir


### PR DESCRIPTION
This PR turns the hard coded configuration of files/commands into something more flexible by being configurable with external files.

Changes from v1:
* Return the default `profiler` parameter value to `None`, so that it looks at the configuration value by default
* Fix typo in docstring