### PR TITLE
avocado.test.SimpleTest: Use parameter name instead of path [V2]

### DIFF
--- a/avocado/loader.py
+++ b/avocado/loader.py
@@ -84,7 +84,7 @@ class TestLoader(object):
 
     def _make_simple_test(self, test_path, params):
         test_class = test.SimpleTest
-        test_parameters = {'path': test_path,
+        test_parameters = {'name': test_path,
                            'base_logdir': self.job.logdir,
                            'params': params,
                            'job': self.job}
@@ -95,7 +95,7 @@ class TestLoader(object):
         test_module_dir = os.path.dirname(test_path)
         sys.path.append(test_module_dir)
         test_class = None
-        test_parameters_simple = {'path': test_path,
+        test_parameters_simple = {'name': test_path,
                                   'base_logdir': self.job.logdir,
                                   'params': params,
                                   'job': self.job}

--- a/avocado/test.py
+++ b/avocado/test.py
@@ -497,9 +497,9 @@ class SimpleTest(Test):
     re_avocado_log = re.compile(r'^\d\d:\d\d:\d\d DEBUG\| \[stdout\]'
                                 r' \d\d:\d\d:\d\d WARN \|')
 
-    def __init__(self, path, params=None, base_logdir=None, tag=None, job=None):
-        self.path = os.path.abspath(path)
-        super(SimpleTest, self).__init__(name=path, base_logdir=base_logdir,
+    def __init__(self, name, params=None, base_logdir=None, tag=None, job=None):
+        self.path = os.path.abspath(name)
+        super(SimpleTest, self).__init__(name=name, base_logdir=base_logdir,
                                          params=params, tag=tag, job=job)
         basedir = os.path.dirname(self.path)
         basename = os.path.basename(self.path)

--- a/selftests/all/unit/avocado/test_unittest.py
+++ b/selftests/all/unit/avocado/test_unittest.py
@@ -109,12 +109,12 @@ class SimpleTestClassTest(unittest.TestCase):
         self.fail_script.save()
 
         self.tst_instance_pass = test.SimpleTest(
-            path=self.pass_script.path,
+            name=self.pass_script.path,
             base_logdir=self.tmpdir)
         self.tst_instance_pass.run_avocado()
 
         self.tst_instance_fail = test.SimpleTest(
-            path=self.fail_script.path,
+            name=self.fail_script.path,
             base_logdir=self.tmpdir)
         self.tst_instance_fail.run_avocado()
 


### PR DESCRIPTION
Follow up of #544 

---

Changes:

* Get rid of `test_parameters_simple` and `test_parameters_name`.