### PR TITLE
Set timeout per job execution [V2]

### DIFF
--- a/avocado/job.py
+++ b/avocado/job.py
@@ -109,6 +109,7 @@ class Job(object):
         self.status = "RUNNING"
         self.result_proxy = result.TestResultProxy()
         self.sysinfo = None
+        self.timeout = getattr(self.args, 'job_timeout', 0)
 
     def _setup_job_results(self):
         logdir = getattr(self.args, 'logdir', None)
@@ -320,7 +321,8 @@ class Job(object):
         _TEST_LOGGER.info('')
 
         self.view.logfile = self.logfile
-        failures = self.test_runner.run_suite(test_suite, mux)
+        failures = self.test_runner.run_suite(test_suite, mux,
+                                              timeout=self.timeout)
         self.view.stop_file_logging()
         if not self.standalone:
             self._update_latest_link()

--- a/avocado/runner.py
+++ b/avocado/runner.py
@@ -139,9 +139,9 @@ class TestRunner(object):
 
         test_deadline = time_started + timeout
         if job_deadline > 0:
-            time_deadline = min(test_deadline, job_deadline)
+            deadline = min(test_deadline, job_deadline)
         else:
-            time_deadline = test_deadline
+            deadline = test_deadline
 
         ctrl_c_count = 0
         ignore_window = 2.0
@@ -151,7 +151,7 @@ class TestRunner(object):
 
         while True:
             try:
-                if time.time() >= time_deadline:
+                if time.time() >= deadline:
                     os.kill(p.pid, signal.SIGUSR1)
                     break
                 wait.wait_for(lambda: not q.empty() or not p.is_alive(),
@@ -238,17 +238,17 @@ class TestRunner(object):
         q = queues.SimpleQueue()
 
         if timeout > 0:
-            end_time = time.time() + timeout
+            deadline = time.time() + timeout
         else:
-            end_time = None
+            deadline = None
 
         for test_template in test_suite:
             for test_factory in mux.itertests(test_template):
-                if end_time is not None and time.time() > end_time:
+                if deadline is not None and time.time() > deadline:
                     test_factory = (test.TimeOutSkipTest, test_factory[1])
                     self._run_test(test_factory, q, failures)
                 else:
-                    if not self._run_test(test_factory, q, failures, end_time):
+                    if not self._run_test(test_factory, q, failures, deadline):
                         break
             runtime.CURRENT_TEST = None
         self.result.end_tests()

--- a/avocado/runner.py
+++ b/avocado/runner.py
@@ -25,6 +25,7 @@ import signal
 import sys
 import time
 
+from avocado import test
 from avocado import runtime
 from avocado.core import exceptions
 from avocado.core import output
@@ -111,7 +112,8 @@ class TestRunner(object):
             test_state['text_output'] = log_file_obj.read()
         return test_state
 
-    def _run_test(self, test_factory, q, failures):
+    def _run_test(self, test_factory, q, failures, job_deadline=0):
+
         p = multiprocessing.Process(target=self.run_test,
                                     args=(test_factory, q,))
 
@@ -134,7 +136,12 @@ class TestRunner(object):
         # for sure if there's a timeout set.
         timeout = (early_state.get('params', {}).get('timeout') or
                    self.DEFAULT_TIMEOUT)
-        time_deadline = time_started + timeout
+
+        test_deadline = time_started + timeout
+        if job_deadline > 0:
+            time_deadline = min(test_deadline, job_deadline)
+        else:
+            time_deadline = test_deadline
 
         ctrl_c_count = 0
         ignore_window = 2.0
@@ -216,7 +223,7 @@ class TestRunner(object):
             return False
         return True
 
-    def run_suite(self, test_suite, mux):
+    def run_suite(self, test_suite, mux, timeout=0):
         """
         Run one or more tests and report with test result.
 
@@ -230,11 +237,20 @@ class TestRunner(object):
         self.result.start_tests()
         q = queues.SimpleQueue()
 
+        if timeout > 0:
+            end_time = time.time() + timeout
+        else:
+            end_time = None
+
         for test_template in test_suite:
             for test_factory in mux.itertests(test_template):
-                if not self._run_test(test_factory, q, failures):
-                    break
-        runtime.CURRENT_TEST = None
+                if end_time is not None and time.time() > end_time:
+                    test_factory = (test.TimeOutSkipTest, test_factory[1])
+                    self._run_test(test_factory, q, failures)
+                else:
+                    if not self._run_test(test_factory, q, failures, end_time):
+                        break
+            runtime.CURRENT_TEST = None
         self.result.end_tests()
         if self.job.sysinfo is not None:
             self.job.sysinfo.end_job_hook()

--- a/avocado/test.py
+++ b/avocado/test.py
@@ -549,13 +549,6 @@ class MissingTest(Test):
     Handle when there is no such test module in the test directory.
     """
 
-    def __init__(self, name=None, params=None, base_logdir=None, tag=None,
-                 job=None, runner_queue=None):
-        super(MissingTest, self).__init__(name=name,
-                                          base_logdir=base_logdir,
-                                          tag=tag, job=job,
-                                          runner_queue=runner_queue)
-
     def runTest(self):
         e_msg = ('Test %s could not be found in the test dir %s '
                  '(or test path does not exist)' %
@@ -572,14 +565,6 @@ class BuggyTest(Test):
     buggy python module.
     """
 
-    def __init__(self, name=None, params=None, base_logdir=None, tag=None,
-                 job=None, runner_queue=None):
-        super(BuggyTest, self).__init__(name=name,
-                                        base_logdir=base_logdir,
-                                        params=params,
-                                        tag=tag, job=job,
-                                        runner_queue=runner_queue)
-
     def runTest(self):
         # pylint: disable=E0702
         raise self.params.get('exception')
@@ -593,13 +578,6 @@ class NotATest(Test):
     Either a non executable python module with no avocado test class in it,
     or a regular, non executable file.
     """
-
-    def __init__(self, name=None, params=None, base_logdir=None, tag=None,
-                 job=None, runner_queue=None):
-        super(NotATest, self).__init__(name=name,
-                                       base_logdir=base_logdir,
-                                       tag=tag, job=job,
-                                       runner_queue=runner_queue)
 
     def runTest(self):
         e_msg = ('File %s is not executable and does not contain an avocado '

--- a/avocado/test.py
+++ b/avocado/test.py
@@ -583,3 +583,17 @@ class NotATest(Test):
         e_msg = ('File %s is not executable and does not contain an avocado '
                  'test class in it ' % self.name)
         raise exceptions.NotATestError(e_msg)
+
+
+class TimeOutSkipTest(Test):
+
+    """
+    Skip test due job timeout.
+
+    This test is skipped due a job timeout.
+    It will never have a chance to execute.
+    """
+
+    def runTest(self):
+        e_msg = 'Test skipped due a job timeout!'
+        raise exceptions.TestNAError(e_msg)


### PR DESCRIPTION
Follow up of #540.

---

Changes:
* Rebase code from the current master
* Remove redundant initializations in test classes.
* Move validation of timeout parameter and time units to `avocado.runner.plugin.runner`. Fix help message.
* Using `test_deadline`, `job_deadline` and then `time_deadline`.
* Don't accept fractions of time, just whole numbers.