### PR TITLE
 avocado.multiplexer: Support for overriding entry points and yaml locations [v3]

### DIFF
--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -56,6 +56,9 @@ YAML_REMOVE_NODE = 2
 YAML_REMOVE_VALUE = 3
 YAML_JOIN = 4
 
+__RE_FILE_SPLIT = re.compile(r'(?<!\\):')   # split by ':' but not '\\:'
+__RE_FILE_SUBS = re.compile(r'(?<!\\)\\:')  # substitute '\\:' but not '\\\\:'
+
 
 class Control(object):  # Few methods pylint: disable=R0903
 
@@ -431,8 +434,30 @@ def _create_from_yaml(path, cls_node=TreeNode):
     Loader.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
                            mapping_to_tree_loader)
 
+    # Parse file name ([$using:]$path)
+    path = __RE_FILE_SPLIT.split(path, 1)
+    if len(path) == 1:
+        path = __RE_FILE_SUBS.sub(':', path[0])
+        using = None
+    else:
+        nodes = __RE_FILE_SUBS.sub(':', path[0]).strip('/').split('/')
+        using = [node for node in nodes if node]
+        path = __RE_FILE_SUBS.sub(':', path[1])
+
+    # Load the tree
     with open(path) as stream:
-        return tree_node_from_values('', yaml.load(stream, Loader))
+        loaded_tree = yaml.load(stream, Loader)
+        loaded_tree = tree_node_from_values('', loaded_tree)
+
+    # Add prefix
+    if using:
+        loaded_tree = cls_node(using.pop(), children=loaded_tree.children)
+        while True:
+            if not using:
+                break
+            loaded_tree = cls_node(using.pop(), children=[loaded_tree])
+        loaded_tree = cls_node('', children=[loaded_tree])
+    return loaded_tree
 
 
 def create_from_yaml(paths, debug=False):

--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -289,8 +289,7 @@ class TreeNode(object):
                                         for v in attributes
                                         if hasattr(self, v)]))
 
-        length = max(3, len(node_name)
-                     if not self.children or show_internal else 3)
+        length = max(2, (len(node_name) + 1) if not self.children or show_internal else 3)
         pad = ' ' * length
         _pad = ' ' * (length - 1)
         if not self.is_leaf:
@@ -298,7 +297,7 @@ class TreeNode(object):
             result = []
             for char in self.children:
                 if len(self.children) == 1:
-                    char2 = '/'
+                    char2 = '-'
                 elif char is self.children[0]:
                     char2 = '/'
                 elif char is self.children[-1]:

--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -85,6 +85,7 @@ class TreeNode(object):
         self.parent = parent
         self.children = []
         self._environment = None
+        self.environment_origin = {}
         self.ctrl = []
         self.multiplex = True
         for child in children:
@@ -218,6 +219,8 @@ class TreeNode(object):
         if self._environment is None:
             self._environment = (self.parent.environment.copy()
                                  if self.parent else {})
+            self.environment_origin = (self.parent.environment_origin.copy()
+                                       if self.parent else {})
             for key, value in self.value.iteritems():
                 if isinstance(value, list):
                     if (key in self._environment and
@@ -227,6 +230,7 @@ class TreeNode(object):
                         self._environment[key] = value
                 else:
                     self._environment[key] = value
+                self.environment_origin[key] = self
         return self._environment
 
     def set_environment_dirty(self):

--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -283,7 +283,7 @@ class TreeNode(object):
         :param attributes: List of node attributes to be printed out ['name']
         :return: list of strings
         """
-        if attributes is None:
+        if not attributes:
             attributes = ["name"]
         node_name = ', '.join(map(str, [getattr(self, v)
                                         for v in attributes

--- a/avocado/multiplexer.py
+++ b/avocado/multiplexer.py
@@ -467,7 +467,9 @@ class Mux(object):
             self.pools = None
         self._mux_entry = getattr(args, 'mux_entry', None)
         if self._mux_entry is None:
-            self._mux_entry = ['/test/*']
+            self._mux_entry = ['//test/*']
+        else:   # Prepend the root '/' (internal representation uses //)
+            self._mux_entry = ['/' + _ for _ in self._mux_entry]
 
     def get_number_of_tests(self, test_suite):
         # Currently number of tests is symetrical

--- a/avocado/multiplexer.py
+++ b/avocado/multiplexer.py
@@ -331,17 +331,6 @@ class AvocadoParams(object):
                 pass
         return self._default_parmas.get(key, default)
 
-    def _get_leaf(self, path):
-        """ Get single leaf matching the path """
-        path = self._greedy_path(path)
-        for param in self._rel_paths:
-            try:
-                return param.get_leaf(path)
-            except NoMatchError:
-                pass
-        raise NoMatchError('No leaves matching "%s" pattern found in %s'
-                           % (path.pattern, self))
-
     def objects(self, key, path=None):
         """
         Return the names of objects defined using a given key.
@@ -407,33 +396,6 @@ class AvocadoParam(object):
         return [self._leaves[i]
                 for i in xrange(len(self._leaf_names))
                 if path.match(self._leaf_names[i])]
-
-    def get_leaf(self, path):
-        """
-        :param path: Desired path
-        :return: Single leaf containing the path
-        :raise NoMatchError: When no leaf matches the path
-        :raise KeyError: When multiple leaves matches the path
-        """
-        leaves = self._get_leaves(path)
-        if len(leaves) == 1:
-            return leaves[0]
-        elif len(leaves) == 0:
-            raise NoMatchError('No leaves matchng "%s" pattern found in %s'
-                               % (path.pattern, self.str_leaves_variant))
-        else:
-            raise KeyError('Multiple leaves matching "%s" found: %s'
-                           % (path.pattern, self.str_leaves_variant))
-
-    def get(self, path, key, default=None):
-        """
-        Returns value of key from $path path. Multiple matching path are
-        acceptable when only one of them contains the key.
-        """
-        try:
-            self.get_or_die(path, key)
-        except NoMatchError:
-            return default
 
     def get_or_die(self, path, key):
         """

--- a/avocado/multiplexer.py
+++ b/avocado/multiplexer.py
@@ -105,17 +105,11 @@ class AvocadoParams(object):
     absolute and relative paths. For relative paths one can define multiple
     paths to search for the value.
     It contains compatibility wrapper to act as the original avocado Params,
-    but by special useage you can utilize the new API. See ``get()``
+    but by special usage you can utilize the new API. See ``get()``
     docstring for details.
 
-    It supports querying for params of given path and key and copies the
-    "objects", "object_params" and "object_counts" methods (not tested).
-
-    Unsafely it also supports pickling, although to work properly params would
-    have to be deepcopied. This is not required for the current avocado usage.
-
     You can also iterate through all keys, but this can generate quite a lot
-    of duplicite entries inherited from ancestor nodes.  It shouldn't produce
+    of duplicate entries inherited from ancestor nodes.  It shouldn't produce
     false values, though.
 
     In this version each new "get()" call is logged into "avocado.test" log.
@@ -192,11 +186,6 @@ class AvocadoParams(object):
         path = "/*/asdf"      => /[^/]*/asdf
         path = "asdf/*"       => $MUX_ENTRY/?.*/asdf/.*
         path = "/asdf/*"      => /asdf/.*
-        FIXME: __QUESTION__: Should "/path/*/path" match only
-        /path/$anything/path or can multiple levels be present
-        (/path/$multiple/$levels/path). The first is complaint to BASH, the
-        second might be easier to use. Alternatively we can allow multiple
-        levels only when "/*/" is used.
         """
         if not path:
             return re.compile('^$')
@@ -451,6 +440,10 @@ class AvocadoParam(object):
 
 class Mux(object):
 
+    """
+    This is a multiplex object which multiplexes the test_suite.
+    """
+
     def __init__(self, args):
         mux_files = getattr(args, 'multiplex_files', None)
         filter_only = getattr(args, 'filter_only', None)
@@ -466,6 +459,9 @@ class Mux(object):
             self._mux_entry = ['/' + _ for _ in self._mux_entry]
 
     def get_number_of_tests(self, test_suite):
+        """
+        :return: overall number of tests * multiplex variants
+        """
         # Currently number of tests is symetrical
         if self.pools:
             return (len(test_suite) *
@@ -474,6 +470,9 @@ class Mux(object):
             return len(test_suite)
 
     def itertests(self, template):
+        """
+        Processes the template and yields test definition with proper params
+        """
         if self.pools:  # Copy template and modify it's params
             i = None
             for i, variant in enumerate(multiplex_pools(self.pools)):

--- a/avocado/multiplexer.py
+++ b/avocado/multiplexer.py
@@ -465,7 +465,9 @@ class Mux(object):
             self.pools = parse_yamls(mux_files, filter_only, filter_out)
         else:   # no variants
             self.pools = None
-        self._mux_entry = getattr(args, 'mux_entry_point', ['/test/*'])
+        self._mux_entry = getattr(args, 'mux_entry', None)
+        if self._mux_entry is None:
+            self._mux_entry = ['/test/*']
 
     def get_number_of_tests(self, test_suite):
         # Currently number of tests is symetrical
@@ -480,7 +482,7 @@ class Mux(object):
             i = None
             for i, variant in enumerate(multiplex_pools(self.pools)):
                 test_factory = [template[0], template[1].copy()]
-                test_factory[1]['params'] = variant
+                test_factory[1]['params'] = (variant, self._mux_entry)
                 yield test_factory
             if i is None:   # No variants, use template
                 yield template

--- a/avocado/multiplexer.py
+++ b/avocado/multiplexer.py
@@ -164,10 +164,18 @@ class AvocadoParams(object):
         self.__dict__.update(orig)
         self._log = logging.getLogger("avocado.test").debug
 
+    def __repr__(self):
+        return "<AvocadoParams %s>" % self._str()
+
     def __str__(self):
-        return "params {%s, %s}" % (", ".join(_.str_leaves_variant
-                                              for _ in self._rel_paths),
-                                    self._abs_path.str_leaves_variant)
+        return "params {%s}" % self._str()
+
+    def _str(self):
+        out = ",".join(_.str_leaves_variant for _ in self._rel_paths)
+        if out:
+            return self._abs_path.str_leaves_variant + ',' + out
+        else:
+            return self._abs_path.str_leaves_variant
 
     def log(self, key, path, default, value):
         """ Predefined format for displaying params query """

--- a/avocado/multiplexer.py
+++ b/avocado/multiplexer.py
@@ -142,6 +142,17 @@ class AvocadoParams(object):
         # TODO: Get rid of this and prepare something better
         self._default_parmas = default_params
 
+    def __eq__(self, other):
+        if set(self.__dict__.iterkeys()) != set(other.__dict__.iterkeys()):
+            return False
+        for attr in self.__dict__.iterkeys():
+            if (getattr(self, attr) != getattr(other, attr)):
+                return False
+        return True
+
+    def __ne__(self, other):
+        return not (self == other)
+
     def __getstate__(self):
         """ log can't be pickled """
         copy = self.__dict__.copy()
@@ -366,6 +377,15 @@ class AvocadoParam(object):
         # names cache (leaf.path is quite expensive)
         self._leaf_names = [leaf.path + '/' for leaf in leaves]
         self.name = name
+
+    def __eq__(self, other):
+        if self.__dict__ == other.__dict__:
+            return True
+        else:
+            return False
+
+    def __ne__(self, other):
+        return not (self == other)
 
     @property
     def str_leaves_variant(self):

--- a/avocado/multiplexer.py
+++ b/avocado/multiplexer.py
@@ -240,8 +240,8 @@ class AvocadoParams(object):
             msg = ("You're probably retrieving param %s via attributes "
                    " (self.params.$key) which is obsoleted. Use "
                    "self.params.get($key) instead." % attr)
-            self._log.error(msg)
-            self.get(attr)
+            logging.getLogger("avocado.test").warn(msg)
+            return self.get(attr)
 
     def get(self, *args, **kwargs):
         """

--- a/avocado/plugins/multiplexer.py
+++ b/avocado/plugins/multiplexer.py
@@ -49,7 +49,9 @@ class Multiplexer(plugin.Plugin):
 
         self.parser.add_argument('-t', '--tree', action='store_true', default=False,
                                  help='Shows the multiplex tree structure')
-
+        self.parser.add_argument('--attr', nargs='*', default=[],
+                                 help="Which attributes to show when using "
+                                 "--tree (default is 'name')")
         self.parser.add_argument('-c', '--contents', action='store_true', default=False,
                                  help="Shows the variant content (variables)")
         self.parser.add_argument('-d', '--debug', action='store_true',
@@ -64,7 +66,8 @@ class Multiplexer(plugin.Plugin):
             view.notify(event='message', msg='Config file tree structure:')
             t = tree.create_from_yaml(multiplex_files)
             t = tree.apply_filters(t, args.filter_only, args.filter_out)
-            view.notify(event='minor', msg=t.get_ascii())
+            view.notify(event='minor',
+                        msg=t.get_ascii(attributes=args.attr))
             sys.exit(exit_codes.AVOCADO_ALL_OK)
 
         try:

--- a/avocado/plugins/multiplexer.py
+++ b/avocado/plugins/multiplexer.py
@@ -59,14 +59,7 @@ class Multiplexer(plugin.Plugin):
 
     def run(self, args):
         view = output.View(app_args=args)
-        multiplex_files = tuple(os.path.abspath(_)
-                                for _ in args.multiplex_files)
-        for path in multiplex_files:
-            if not os.path.isfile(path):
-                view.notify(event='error',
-                            msg='Invalid multiplex file %s' % path)
-                sys.exit(exit_codes.AVOCADO_JOB_FAIL)
-
+        multiplex_files = args.multiplex_files
         if args.tree:
             view.notify(event='message', msg='Config file tree structure:')
             t = tree.create_from_yaml(multiplex_files)
@@ -74,10 +67,15 @@ class Multiplexer(plugin.Plugin):
             view.notify(event='minor', msg=t.get_ascii())
             sys.exit(exit_codes.AVOCADO_ALL_OK)
 
-        variants = multiplexer.multiplex_yamls(multiplex_files,
-                                               args.filter_only,
-                                               args.filter_out,
-                                               args.debug)
+        try:
+            variants = multiplexer.multiplex_yamls(multiplex_files,
+                                                   args.filter_only,
+                                                   args.filter_out,
+                                                   args.debug)
+        except IOError, details:
+            view.notify(event='error',
+                        msg="%s: '%s'" % (details.strerror, details.filename))
+            sys.exit(exit_codes.AVOCADO_JOB_FAIL)
 
         view.notify(event='message', msg='Variants generated:')
         for (index, tpl) in enumerate(variants):

--- a/avocado/plugins/runner.py
+++ b/avocado/plugins/runner.py
@@ -116,6 +116,8 @@ class TestRunner(plugin.Plugin):
                              help='Filter only path(s) from multiplexing')
             mux.add_argument('--filter-out', nargs='*', default=[],
                              help='Filter out path(s) from multiplexing')
+            mux.add_argument('--mux-entry', nargs='*', default=None,
+                             help="Multiplex entry point(s)")
 
         super(TestRunner, self).configure(self.parser)
         # Export the test runner parser back to the main parser

--- a/avocado/test.py
+++ b/avocado/test.py
@@ -130,14 +130,17 @@ class Test(unittest.TestCase):
         self.stdout_log = logging.getLogger("avocado.test.stdout")
         self.stderr_log = logging.getLogger("avocado.test.stderr")
 
+        mux_entry = ['/test/*']
         if isinstance(params, dict):
             self.default_params = self.default_params.copy()
             self.default_params.update(params)
             params = []
         elif params is None:
             params = []
+        elif isinstance(params, tuple):
+            params, mux_entry = params[0], params[1]
         self.params = multiplexer.AvocadoParams(params, self.name, self.tag,
-                                                ['/test/*'],
+                                                mux_entry,
                                                 self.default_params)
 
         self.log.info('START %s', self.tagged_name)

--- a/examples/mux-selftest-params.yaml
+++ b/examples/mux-selftest-params.yaml
@@ -1,0 +1,29 @@
+!join
+root: "root"
+cache_test: 'cache'
+diff_domain: "text1"
+ch0:
+    diff_domain: "text2"
+    clash1: "equal"
+    clash3: "also equal"
+    ch0.1:
+        ch0.1.1:
+            ch0.1.1.1:
+                unique1: "unique1"
+                clash1: "equal"
+            ch0.1.1.2:
+                unique1: "unique1-2"
+        ch0.1.2:
+            unique3: "unique3"
+            clash3: "also equal"
+        ch0.1.3:
+            clash3: "also equal"
+ch1:
+    unique2: "unique2"
+    clash3: "also equal"
+ch11:
+    clash2: 'equal'
+    ch2.1:
+        unique4: "other_unique"
+ch111:
+    clash2: 'equal'

--- a/selftests/all/functional/avocado/multiplex_tests.py
+++ b/selftests/all/functional/avocado/multiplex_tests.py
@@ -67,7 +67,7 @@ class MultiplexTests(unittest.TestCase):
         cmd_line = './scripts/avocado multiplex nonexist'
         expected_rc = 2
         result = self.run_and_check(cmd_line, expected_rc)
-        self.assertIn('Invalid multiplex file', result.stderr)
+        self.assertIn('No such file or directory', result.stderr)
 
     def test_mplex_debug(self):
         cmd_line = ('./scripts/avocado multiplex -c -d '


### PR DESCRIPTION
1) It adds support to set resolution order by `--mux-entry` on the  command-line. We discussed with Ademar about the way we handle arguments so this patch does it the way I favor. Please review it and let me know whether I should make the same for the other args (like --multiplex, --filter-only, ...) or whether I should modify this commit to use the current approach.
2) Adds support to inject the yaml file into a specific location by `-m [$location:]$file`. What it does is it generates the tree from the yaml file and prepends the $location when specified.
3) Is just bugfix/improvement
4) existing feature enablement on cmdline
5) adds the proper params clash detection
6) style fixups
7) bugfixes
8) unittest

v1: https://github.com/avocado-framework/avocado/pull/530
v2: https://github.com/avocado-framework/avocado/pull/533

Changes:

    v2: Added clash detection mechanism
    v2: Added patch fixing typos from already applied code
    v2: Other style fixups pointed out by @ruda
    v3: Removed debug leftovers
    v3: English spelling
    v3: avocado multiplexer --attributes => --attr and when empty use "name"
    v3: Support for "AvocadoParams" comparison
    v3: __str__ and __repr__ improved
    v3: AvocadoParams error log bugfix
    v3: Unused code cleanup
    v3: Unittest for AvocadoParams (Functional unittest is coming in the next sprint)
