### PR TITLE
avocado.multiplexer: Never let path to be None

### DIFF
--- a/avocado/multiplexer.py
+++ b/avocado/multiplexer.py
@@ -287,7 +287,7 @@ class AvocadoParams(object):
                     elif len(args) > 1:
                         path = args[1]
                     else:
-                        path = None
+                        path = '/*'
                     key = args[0]
                     return [key, path, default]
                 except IndexError:


### PR DESCRIPTION
With this, the simplest sleeptest params retrieval:

        sleep_length = self.params.get('sleep_length', default=1)

Returns incorrectly. This patch fixes this issue.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>