### PR TITLE
avocado.multiplexer: Fix mux-entry path

### DIFF
--- a/avocado/multiplexer.py
+++ b/avocado/multiplexer.py
@@ -444,9 +444,7 @@ class Mux(object):
             self.pools = None
         self._mux_entry = getattr(args, 'mux_entry', None)
         if self._mux_entry is None:
-            self._mux_entry = ['//test/*']
-        else:   # Prepend the root '/' (internal representation uses //)
-            self._mux_entry = ['/' + _ for _ in self._mux_entry]
+            self._mux_entry = ['/test/*']
 
     def get_number_of_tests(self, test_suite):
         """


### PR DESCRIPTION
The '/' prefix is leftover from -m $using:$path development and was
already solved in -m patch. Remove this code which actually breaks the
params resolving.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>