### PR TITLE
avocado.plugins: Make plugins description uniform

### DIFF
--- a/avocado/plugins/htmlresult.py
+++ b/avocado/plugins/htmlresult.py
@@ -275,7 +275,7 @@ class HTMLTestResult(TestResult):
 class HTML(plugin.Plugin):
 
     """
-    HTML job report.
+    HTML job report
     """
 
     name = 'htmlresult'

--- a/avocado/plugins/multiplexer.py
+++ b/avocado/plugins/multiplexer.py
@@ -25,7 +25,7 @@ from avocado import multiplexer
 class Multiplexer(plugin.Plugin):
 
     """
-    Implements the avocado 'multiplex' subcommand.
+    Implements the avocado 'multiplex' subcommand
     """
 
     name = 'multiplexer'

--- a/avocado/plugins/wrapper.py
+++ b/avocado/plugins/wrapper.py
@@ -23,6 +23,10 @@ from avocado.plugins import plugin
 
 class Wrapper(plugin.Plugin):
 
+    """
+    Implements the '--wrapper' flag for the 'run' subcommand
+    """
+
     name = 'wrapper'
     enabled = True
 

--- a/avocado/plugins/xunit.py
+++ b/avocado/plugins/xunit.py
@@ -219,7 +219,7 @@ class xUnitTestResult(TestResult):
 class XUnit(plugin.Plugin):
 
     """
-    xUnit output.
+    xUnit output
     """
 
     name = 'xunit'


### PR DESCRIPTION
Trivial patch that normalizes description of the
plugins present on the base avocado repository.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>