### PR TITLE
avocado.remote: Accept "timeout" arg

### DIFF
--- a/avocado/plugins/remote.py
+++ b/avocado/plugins/remote.py
@@ -61,10 +61,6 @@ class RunRemote(plugin.Plugin):
                                         action='store_true',
                                         help="Don't copy tests and use the "
                                         "exact uri on guest machine.")
-        self.remote_parser.add_argument('--remote-timeout', type=float,
-                                        help="Host timeout before the "
-                                        "connection is cut off and test "
-                                        "set as failed.")
         self.configured = True
 
     @staticmethod

--- a/avocado/plugins/vm.py
+++ b/avocado/plugins/vm.py
@@ -67,10 +67,6 @@ class RunVM(plugin.Plugin):
                                     action='store_true',
                                     help="Don't copy tests and use the "
                                     "exact uri on VM machine.")
-        self.vm_parser.add_argument('--vm-timeout', type=float,
-                                    help="Host timeout before the "
-                                    "connection is cut off and test "
-                                    "set as failed.")
         self.configured = True
 
     @staticmethod

--- a/avocado/remote/result.py
+++ b/avocado/remote/result.py
@@ -43,7 +43,6 @@ class RemoteTestResult(HumanTestResult):
         self.remote = None      # Remote runner initialized during setup
         self.output = '-'
         self.command_line_arg_name = '--remote-hostname'
-        self.timeout = getattr(args, 'remote_timeout', None)
 
     def _copy_tests(self):
         """
@@ -99,7 +98,6 @@ class VMTestResult(RemoteTestResult):
     """
 
     def __init__(self, stream, args):
-        args.remote_timeout = getattr(args, 'vm_timeout', None)
         super(VMTestResult, self).__init__(stream, args)
         self.vm = None
         self.command_line_arg_name = '--vm-domain'

--- a/selftests/all/unit/avocado/remote_unittest.py
+++ b/selftests/all/unit/avocado/remote_unittest.py
@@ -50,7 +50,7 @@ class RemoteTestRunnerTest(unittest.TestCase):
         args = ("cd ~/avocado/tests; avocado run --force-job-id sleeptest.1 "
                 "--json - --archive sleeptest")
         (Remote.should_receive('run')
-         .with_args(args, timeout=None, ignore_status=True)
+         .with_args(args, timeout=61, ignore_status=True)
          .once().and_return(test_results))
         Results = flexmock(remote=Remote, urls=['sleeptest'],
                            stream=stream, timeout=None)
@@ -85,7 +85,7 @@ class RemoteTestRunnerTest(unittest.TestCase):
 
     def test_run_suite(self):
         """ Test RemoteTestRunner.run_suite() """
-        self.remote.run_suite(None, None)
+        self.remote.run_suite(None, None, 61)
         flexmock_teardown()  # Checks the expectations
 
 


### PR DESCRIPTION
The "timeout" argument was added to "run_testsuite" but not added to
avocado.remote, which now raises exception. This patch merges the
--remote-timeout and --job-timeout keeping only the --job-timeout.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>