### PR TITLE
Test API: Export data_dir for test developers.

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -32,7 +32,7 @@ from avocado import runner
 from avocado import loader
 from avocado import runtime
 from avocado import sysinfo
-from avocado.core import data_dir
+from avocado import data_dir
 from avocado.core import exit_codes
 from avocado.core import exceptions
 from avocado.core import job_id

--- a/avocado/data_dir.py
+++ b/avocado/data_dir.py
@@ -39,7 +39,7 @@ from avocado.utils.data_structures import Borg
 from avocado.settings import settings
 
 
-_BASE_DIR = os.path.join(sys.modules[__name__].__file__, "..", "..", "..")
+_BASE_DIR = os.path.join(sys.modules[__name__].__file__, "..", "..")
 _BASE_DIR = os.path.abspath(_BASE_DIR)
 _IN_TREE_TESTS_DIR = os.path.join(_BASE_DIR, 'examples', 'tests')
 

--- a/avocado/loader.py
+++ b/avocado/loader.py
@@ -24,7 +24,7 @@ import re
 import sys
 
 from avocado import test
-from avocado.core import data_dir
+from avocado import data_dir
 from avocado.utils import path
 
 try:

--- a/avocado/plugins/config.py
+++ b/avocado/plugins/config.py
@@ -13,7 +13,7 @@
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
 from avocado.core import output
-from avocado.core import data_dir
+from avocado import data_dir
 from avocado.settings import settings
 from avocado.plugins import plugin
 

--- a/avocado/plugins/test_list.py
+++ b/avocado/plugins/test_list.py
@@ -16,7 +16,7 @@ import sys
 
 from avocado import loader
 from avocado import test
-from avocado.core import data_dir
+from avocado import data_dir
 from avocado.core import output
 from avocado.core import exit_codes
 from avocado.utils import astring

--- a/avocado/remote/result.py
+++ b/avocado/remote/result.py
@@ -16,8 +16,8 @@
 
 import os
 
+from avocado import data_dir
 from avocado.core import exceptions
-from avocado.core import data_dir
 from avocado.result import HumanTestResult
 from avocado.utils import remote
 from avocado.utils import virt

--- a/avocado/test.py
+++ b/avocado/test.py
@@ -32,7 +32,7 @@ else:
     import unittest
 
 from avocado import sysinfo, multiplexer
-from avocado.core import data_dir
+from avocado import data_dir
 from avocado.core import exceptions
 from avocado.utils import genio
 from avocado.utils import path as utils_path
@@ -64,7 +64,7 @@ class Test(unittest.TestCase):
                      reserved for running random executables as tests.
         :param base_logdir: Directory where test logs should go. If None
                             provided, it'll use
-                            :func:`avocado.core.data_dir.create_job_logs_dir`.
+                            :func:`avocado.data_dir.create_job_logs_dir`.
         :param tag: Tag that differentiates 2 executions of the same test name.
                     Example: 'long', 'short', so we can differentiate
                     'sleeptest.long' and 'sleeptest.short'.

--- a/docs/source/Configuration.rst
+++ b/docs/source/Configuration.rst
@@ -138,7 +138,7 @@ provided, it will fall back to (we hope) reasonable defaults, and we
 notify the user about that in the output of the command.
 
 The relevant API documentation and meaning of each of those data directories
-is in :mod:`avocado.core.data_dir`, so it's higly recommended you take a look.
+is in :mod:`avocado.data_dir`, so it's highly recommended you take a look.
 
 You may set your preferred data dirs by setting them in the avocado config files.
 The only exception for important data dirs here is the avocado tmp dir, used to

--- a/selftests/all/functional/avocado/argument_parsing_tests.py
+++ b/selftests/all/functional/avocado/argument_parsing_tests.py
@@ -13,8 +13,8 @@ basedir = os.path.abspath(basedir)
 if os.path.isdir(os.path.join(basedir, 'avocado')):
     sys.path.append(basedir)
 
+from avocado import data_dir
 from avocado.core import job_id
-from avocado.core import data_dir
 from avocado.utils import process
 
 

--- a/selftests/all/unit/avocado/datadir_unittest.py
+++ b/selftests/all/unit/avocado/datadir_unittest.py
@@ -47,7 +47,7 @@ class DataDirTest(unittest.TestCase):
             # Trick the module to think we're on a system wide install
             stg.intree = False
             flexmock(settings, settings=stg)
-            from avocado.core import data_dir
+            from avocado import data_dir
             flexmock(data_dir, settings=stg)
             self.assertFalse(data_dir.settings.intree)
             reload(data_dir)

--- a/selftests/all/unit/avocado/remote_unittest.py
+++ b/selftests/all/unit/avocado/remote_unittest.py
@@ -6,9 +6,9 @@ import os
 from flexmock import flexmock, flexmock_teardown
 
 from avocado import remote
+from avocado import data_dir
 from avocado.utils import archive
 from avocado.utils import remote as utils_remote
-from avocado.core import data_dir
 
 cwd = os.getcwd()
 


### PR DESCRIPTION
Move avocado.core.data_dir to avocado.data_dir so that test
developers can make use of it.

Note: I recommend to merge this pull request soon after #575 , prior to #570 #568 #569 #571 

Signed-off-by: Rudá Moura <rmoura@redhat.com>