### PR TITLE
Makefile: replace source tarball generation from distutils to git

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@ all:
 	@echo "make clean - Get rid of scratch and byte files"
 
 source:
-	$(PYTHON) setup.py sdist $(COMPILE) --dist-dir=SOURCES --prune
+	if test ! -d SOURCES; then mkdir SOURCES; fi
+	git archive --prefix="avocado-$(VERSION)/" -o "SOURCES/avocado-$(VERSION).tar.gz" HEAD
 
 install:
 	$(PYTHON) setup.py install --root $(DESTDIR) $(COMPILE)


### PR DESCRIPTION
It was noted that, on some Python version, the generated tarballs
actually have a lot of files missing. IMHO, if we track a file on git,
then it should make into the tarball. Also IMHO, the distutils sdist
code is a nice thing to have if you can't export your code right from
your SCM.

This is kept simple on purpose so that if we hit any unintended side
effect we can revert to the previous way of generation source
tarballs.

Signed-off-by: Cleber Rosa <crosa@redhat.com>