### PR TITLE
avocado: Handle incorrect yaml files without exception

### DIFF
--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -490,11 +490,15 @@ def create_from_yaml(paths, debug=False):
     try:
         for path in paths:
             merge(data, path)
-    except (yaml.scanner.ScannerError, yaml.parser.ParserError) as err:
-        if 'mapping values are not allowed in this context' in str(err):
-            err = ("%s\n\nMake sure !tags and colons are separated by a space "
-                   "(eg. !include :)" % err)
-        raise SyntaxError(err)
+    except yaml.reader.ReaderError, details:
+        raise IOError(2, "Not a yaml file", details.name)
+    except (yaml.scanner.ScannerError, yaml.parser.ParserError) as details:
+        if 'mapping values are not allowed in this context' in str(details):
+            msg = ("%s\n\nMake sure !tags and colons are separated by a space "
+                   "(eg. !include :)" % details)
+        else:
+            msg = str(details)
+        raise IOError(2, msg, path)
     return data
 
 

--- a/avocado/job.py
+++ b/avocado/job.py
@@ -307,7 +307,12 @@ class Job(object):
                      "filters, typos)")
             raise exceptions.OptionValidationError(e_msg)
 
-        mux = multiplexer.Mux(self.args)
+        try:
+            mux = multiplexer.Mux(self.args)
+        except IOError, details:
+            raise exceptions.OptionValidationError("%s: '%s'"
+                                                   % (details.strerror,
+                                                      details.filename))
         self.args.test_result_total = mux.get_number_of_tests(test_suite)
 
         self._make_test_result()

--- a/avocado/plugins/multiplexer.py
+++ b/avocado/plugins/multiplexer.py
@@ -64,7 +64,12 @@ class Multiplexer(plugin.Plugin):
         multiplex_files = args.multiplex_files
         if args.tree:
             view.notify(event='message', msg='Config file tree structure:')
-            t = tree.create_from_yaml(multiplex_files)
+            try:
+                t = tree.create_from_yaml(multiplex_files)
+            except IOError, details:
+                view.notify(event='error', msg="%s: '%s'" % (details.strerror,
+                                                             details.filename))
+                sys.exit(exit_codes.AVOCADO_JOB_FAIL)
             t = tree.apply_filters(t, args.filter_only, args.filter_out)
             view.notify(event='minor',
                         msg=t.get_ascii(attributes=args.attr))


### PR DESCRIPTION
Avocado shouldn't crash, it should only notify user about the failure.
This patch modifies the existing mux exceptions to reflect this rule and
adds new exception handler for incorrect yaml file.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>