### PR TITLE
avocado: Handle incorrect yaml files without exception [v2]

### DIFF
--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -487,14 +487,17 @@ def create_from_yaml(paths, debug=False):
         data = tree_debug.TreeNodeDebug()
         merge = _merge_debug
 
+    path = None
     try:
         for path in paths:
             merge(data, path)
-    except (yaml.scanner.ScannerError, yaml.parser.ParserError) as err:
-        if 'mapping values are not allowed in this context' in str(err):
-            err = ("%s\n\nMake sure !tags and colons are separated by a space "
-                   "(eg. !include :)" % err)
-        raise SyntaxError(err)
+    # Yaml can raise IndexError on some files
+    except (yaml.YAMLError, IndexError) as details:
+        if 'mapping values are not allowed in this context' in str(details):
+            details = ("%s\nMake sure !tags and colons are separated by a "
+                       "space (eg. !include :)" % details)
+        msg = "Invalid multiplex file '%s': %s" % (path, details)
+        raise IOError(2, msg, path)
     return data
 
 

--- a/avocado/job.py
+++ b/avocado/job.py
@@ -307,7 +307,10 @@ class Job(object):
                      "filters, typos)")
             raise exceptions.OptionValidationError(e_msg)
 
-        mux = multiplexer.Mux(self.args)
+        try:
+            mux = multiplexer.Mux(self.args)
+        except IOError, details:
+            raise exceptions.OptionValidationError(details.strerror)
         self.args.test_result_total = mux.get_number_of_tests(test_suite)
 
         self._make_test_result()

--- a/avocado/plugins/multiplexer.py
+++ b/avocado/plugins/multiplexer.py
@@ -64,7 +64,11 @@ class Multiplexer(plugin.Plugin):
         multiplex_files = args.multiplex_files
         if args.tree:
             view.notify(event='message', msg='Config file tree structure:')
-            t = tree.create_from_yaml(multiplex_files)
+            try:
+                t = tree.create_from_yaml(multiplex_files)
+            except IOError, details:
+                view.notify(event='error', msg=details.strerror)
+                sys.exit(exit_codes.AVOCADO_JOB_FAIL)
             t = tree.apply_filters(t, args.filter_only, args.filter_out)
             view.notify(event='minor',
                         msg=t.get_ascii(attributes=args.attr))
@@ -77,7 +81,7 @@ class Multiplexer(plugin.Plugin):
                                                    args.debug)
         except IOError, details:
             view.notify(event='error',
-                        msg="%s: '%s'" % (details.strerror, details.filename))
+                        msg=details.strerror)
             sys.exit(exit_codes.AVOCADO_JOB_FAIL)
 
         view.notify(event='message', msg='Variants generated:')


### PR DESCRIPTION
Avocado shouldn't crash, it should only notify user about the failure.
This patch modifies the existing mux exceptions to reflect this rule and
adds new exception handler for incorrect yaml file.

v1: https://github.com/avocado-framework/avocado/pull/576

Changes

    v2: Instead of catching exact yaml errors, use yaml.YamlError instead
    v2: Catch IndexError raised on some occasions (eg. when parsing /etc/passwd)