### PR TITLE
[RFC] Virt test compat layer

### DIFF
--- a/avocado/core/exceptions.py
+++ b/avocado/core/exceptions.py
@@ -86,6 +86,14 @@ class NotATestError(TestBaseException):
     status = "NOT_A_TEST"
 
 
+class TestNotFoundError(TestBaseException):
+
+    """
+    Indicates that the test was not found in the test directory.
+    """
+    status = "ERROR"
+
+
 class TestTimeoutError(TestBaseException):
 
     """

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -108,6 +108,7 @@ class Job(object):
         self.test_index = 1
         self.status = "RUNNING"
         self.result_proxy = result.TestResultProxy()
+        self.test_loader = loader.TestLoaderProxy()
         self.sysinfo = None
         self.timeout = getattr(self.args, 'job_timeout', 0)
 
@@ -145,12 +146,14 @@ class Job(object):
         shutil.rmtree(self.logdir, ignore_errors=True)
 
     def _make_test_loader(self):
-        if hasattr(self.args, 'test_loader'):
-            test_loader_class = self.args.test_loader
-        else:
-            test_loader_class = loader.TestLoader
-
-        self.test_loader = test_loader_class(job=self)
+        filesystem_loader = loader.TestLoader(self)
+        self.test_loader.add_loader_plugin(filesystem_loader)
+        for key in self.args.__dict__.keys():
+            if key.endswith('_loader'):
+                loader_class = getattr(self.args, key)
+                if issubclass(loader_class, loader.TestLoader):
+                    loader_plugin = loader_class(self)
+                    self.test_loader.add_loader_plugin(loader_plugin)
 
     def _make_test_runner(self):
         if hasattr(self.args, 'test_runner'):
@@ -249,9 +252,7 @@ class Job(object):
 
         self._make_test_loader()
 
-        params_list = self.test_loader.discover_urls(urls)
-        test_suite = self.test_loader.discover(params_list)
-        return test_suite
+        return self.test_loader.discover(urls)
 
     def _validate_test_suite(self, test_suite):
         try:

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -47,6 +47,66 @@ class AccessDeniedPath(object):
     pass
 
 
+class InvalidLoaderPlugin(Exception):
+    pass
+
+
+class TestLoaderProxy(object):
+
+    def __init__(self):
+        self.loader_plugins = []
+
+    def add_loader_plugin(self, plugin):
+        if not isinstance(plugin, TestLoader):
+            raise InvalidLoaderPlugin("Object %s is not an instance of "
+                                      "TestResult" % plugin)
+        self.loader_plugins.append(plugin)
+
+    def discover(self, urls):
+        """
+        Discover (possible) tests from test urls.
+
+        :param urls: a list of tests urls.
+        :type urls: list
+        :return: A list of test factories (tuples (TestClass, test_params))
+        """
+        test_factories = []
+        for url in urls:
+            if url == '':
+                continue
+            for loader_plugin in self.loader_plugins:
+                try:
+                    params_list_from_url = loader_plugin.discover_url(url)
+                except Exception:
+                    break
+                test_factories_from_url = loader_plugin.discover(params_list_from_url)
+                if test_factories_from_url:
+                    if test_factories_from_url[0][0] not in [test.MissingTest]:
+                        test_factories += test_factories_from_url
+                        break
+        return test_factories
+
+    def validate_ui(self, test_suite, ignore_missing=False,
+                    ignore_not_test=False, ignore_broken_symlinks=False,
+                    ignore_access_denied=False):
+        for loader_plugin in self.loader_plugins:
+            loader_plugin.validate_ui(test_suite=test_suite, ignore_missing=ignore_missing,
+                                      ignore_not_test=ignore_not_test, ignore_broken_symlinks=ignore_broken_symlinks,
+                                      ignore_access_denied=ignore_access_denied)
+
+    def load_test(self, test_factory):
+        """
+        Load test from the test factory.
+
+        :param test_factory: a pair of test class and parameters.
+        :type params: tuple
+        :return: an instance of :class:`avocado.test.Testself`.
+        """
+        test_class, test_parameters = test_factory
+        test_instance = test_class(**test_parameters)
+        return test_instance
+
+
 class TestLoader(object):
 
     """

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -403,14 +403,14 @@ class View(object):
         if self.use_paginator:
             self.paginator.close()
 
-    def notify(self, event='message', msg=None):
+    def notify(self, event='message', msg=None, skip_newline=False):
         mapping = {'message': self._log_ui_header,
                    'minor': self._log_ui_minor,
                    'error': self._log_ui_error,
                    'warning': self._log_ui_warning,
                    'partial': self._log_ui_partial}
         if msg is not None:
-            mapping[event](msg)
+            mapping[event](msg=msg, skip_newline=skip_newline)
 
     def notify_progress(self, progress):
         self._log_ui_throbber_progress(progress)
@@ -491,37 +491,37 @@ class View(object):
         """
         self._log_ui_info(term_support.partial_str(msg), skip_newline)
 
-    def _log_ui_header(self, msg):
+    def _log_ui_header(self, msg, skip_newline=False):
         """
         Log a header message.
 
         :param msg: Message to write.
         """
-        self._log_ui_info(term_support.header_str(msg))
+        self._log_ui_info(term_support.header_str(msg), skip_newline)
 
-    def _log_ui_minor(self, msg):
+    def _log_ui_minor(self, msg, skip_newline=False):
         """
         Log a minor message.
 
         :param msg: Message to write.
         """
-        self._log_ui_info(msg)
+        self._log_ui_info(msg, skip_newline)
 
-    def _log_ui_error(self, msg):
+    def _log_ui_error(self, msg, skip_newline=False):
         """
         Log an error message (useful for critical errors).
 
         :param msg: Message to write.
         """
-        self._log_ui_error_base(term_support.fail_header_str(msg))
+        self._log_ui_error_base(term_support.fail_header_str(msg), skip_newline)
 
-    def _log_ui_warning(self, msg):
+    def _log_ui_warning(self, msg, skip_newline=False):
         """
         Log a warning message (useful for warning messages).
 
         :param msg: Message to write.
         """
-        self._log_ui_info(term_support.warn_header_str(msg))
+        self._log_ui_info(term_support.warn_header_str(msg), skip_newline)
 
     def _log_ui_status_pass(self, t_elapsed):
         """

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -613,8 +613,10 @@ class View(object):
         self.file_handler.setFormatter(formatter)
         test_logger = logging.getLogger('avocado.test')
         linux_logger = logging.getLogger('avocado.linux')
+        root_logger = logging.getLogger()
         test_logger.addHandler(self.file_handler)
         linux_logger.addHandler(self.file_handler)
+        root_logger.addHandler(self.file_handler)
 
     def stop_file_logging(self):
         """

--- a/avocado/core/plugins/htmlresult.py
+++ b/avocado/core/plugins/htmlresult.py
@@ -112,7 +112,8 @@ class ReportModel(object):
                    "ALERT": "danger",
                    "RUNNING": "info",
                    "NOSTATUS": "info",
-                   "INTERRUPTED": "danger"}
+                   "INTERRUPTED": "danger",
+                   "NOT_A_TEST": "warning"}
         test_info = self.json['tests']
         results_dir = self.results_dir(False)
         for t in test_info:

--- a/avocado/core/plugins/virt_test.py
+++ b/avocado/core/plugins/virt_test.py
@@ -1,0 +1,1080 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2015
+# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+
+"""
+Avocado virt-test compatibility wrapper
+"""
+
+import os
+import sys
+import logging
+import Queue
+import imp
+import time
+
+from avocado.core import result
+from avocado.core import loader
+from avocado.core.plugins import plugin
+from avocado import test
+from avocado import data_dir as avocado_data_dir
+from avocado.settings import settings
+from avocado.settings import config_path_local
+from avocado.utils import path
+
+if 'VIRT_TEST_DIR' in os.environ:
+    virt_test_dir = os.environ['VIRT_TEST_DIR']
+else:
+    virt_test_dir = settings.get_value(section='virt-test', key='test_suite_path', default=None)
+    if virt_test_dir is None or not os.path.isdir(virt_test_dir):
+        print('Virt test dir not set/invalid. Please make sure you add to %s' % config_path_local)
+        print('')
+        print('[virt-test]')
+        print('test_suite_path=/valid/path/to/virt_test')
+        print('')
+        print('You can also export $VIRT_TEST_DIR (takes precedence over the config file)')
+        print('$ export VIRT_TEST_DIR="/valid/path/to/virt_test"')
+        sys.exit(1)
+
+sys.path.append(os.path.expanduser(virt_test_dir))
+
+from autotest.client import utils
+from autotest.client.shared import error
+
+from virttest import asset
+from virttest import arch
+from virttest import bootstrap
+from virttest import cartesian_config
+from virttest import data_dir
+from virttest import defaults
+from virttest import env_process
+from virttest import funcatexit
+from virttest import standalone_test
+from virttest import utils_env
+from virttest import utils_misc
+from virttest import utils_params
+from virttest import version
+
+from virttest.standalone_test import SUPPORTED_LOG_LEVELS
+from virttest.standalone_test import SUPPORTED_TEST_TYPES
+from virttest.standalone_test import SUPPORTED_LIBVIRT_URIS
+from virttest.standalone_test import SUPPORTED_LIBVIRT_DRIVERS
+from virttest.standalone_test import SUPPORTED_IMAGE_TYPES
+from virttest.standalone_test import SUPPORTED_DISK_BUSES
+from virttest.standalone_test import SUPPORTED_NIC_MODELS
+from virttest.standalone_test import SUPPORTED_NET_TYPES
+from virttest.standalone_test import QEMU_DEFAULT_SET
+from virttest.standalone_test import LIBVIRT_DEFAULT_SET
+from virttest.standalone_test import LVSB_DEFAULT_SET
+from virttest.standalone_test import OVS_DEFAULT_SET
+from virttest.standalone_test import LIBVIRT_INSTALL
+from virttest.standalone_test import LIBVIRT_REMOVE
+
+
+class VirtTestResult(result.HumanTestResult):
+
+    """
+    Virt Test compatibility layer Result class.
+    """
+
+    def __init__(self, stream, args):
+        """
+        Creates an instance of RemoteTestResult.
+
+        :param stream: an instance of :class:`avocado.core.output.View`.
+        :param args: an instance of :class:`argparse.Namespace`.
+        """
+        result.HumanTestResult.__init__(self, stream, args)
+        self.output = '-'
+        self.setup()
+
+    def setup(self):
+        """
+        Run the bootstrap needed before virt-test starts
+
+        This usually includes downloading/restoring JeOS images, among others.
+        """
+        options = self.args
+        test_dir = None
+        if options.type:
+            test_dir = data_dir.get_backend_dir(options.type)
+        elif options.config:
+            parent_config_dir = os.path.dirname(
+                os.path.dirname(options.config))
+            parent_config_dir = os.path.dirname(parent_config_dir)
+            options.type = parent_config_dir
+            test_dir = os.path.abspath(parent_config_dir)
+
+        if options.type == 'qemu':
+            check_modules = arch.get_kvm_module_list()
+        else:
+            check_modules = None
+        online_docs_url = "https://github.com/autotest/virt-test/wiki"
+
+        kwargs = {'test_name': options.type,
+                  'test_dir': test_dir,
+                  'base_dir': avocado_data_dir.get_data_dir(),
+                  'default_userspace_paths': None,
+                  'check_modules': check_modules,
+                  'online_docs_url': online_docs_url,
+                  'selinux': options.selinux_setup,
+                  'restore_image': not(options.no_downloads or
+                                       options.keep_image),
+                  'interactive': False,
+                  'update_providers': options.update_providers,
+                  'guest_os': options.guest_os or defaults.DEFAULT_GUEST_OS}
+
+        failed = False
+        wait_message_printed = False
+
+        bg = utils.InterruptedThread(bootstrap.bootstrap, kwargs=kwargs)
+        t_begin = time.time()
+        bg.start()
+
+        while bg.isAlive():
+            if not wait_message_printed:
+                self.stream.notify(event='message', msg="SETUP      :  ", skip_newline=True)
+                wait_message_printed = True
+            self.stream.notify_progress(True)
+            time.sleep(0.1)
+
+        reason = None
+        try:
+            bg.join()
+        except Exception, e:
+            failed = True
+            reason = e
+
+        t_end = time.time()
+        t_elapsed = t_end - t_begin
+        state = dict()
+        state['time_elapsed'] = t_elapsed
+        if not failed:
+            self.stream.set_test_status(status='PASS', state=state)
+        else:
+            self.stream.set_test_status(status='FAIL', state=state)
+            self.stream.notify(event='error', msg="Setup error: %s" % reason)
+            sys.exit(-1)
+
+        return True
+
+
+class VirtTestLoader(loader.TestLoader):
+
+    def __init__(self, job):
+        loader.TestLoader.__init__(self, job=job)
+
+    def _get_parser(self):
+        options_processor = VirtTestOptionsProcess(self.job)
+        return options_processor.get_parser()
+
+    def discover(self, params_list):
+        """
+        Discover tests for test suite.
+
+        :param params_list: a list of test parameters.
+        :type params_list: list
+        :return: a test suite (a list of test factories).
+        """
+        test_suite = []
+        for params in params_list:
+            test_parameters = {'name': params['shortname'],
+                               'base_logdir': self.job.logdir,
+                               'params': params,
+                               'job': self.job}
+            test_suite.append((VirtTest, test_parameters))
+        return test_suite
+
+    def validate_ui(self, test_suite, ignore_missing=False,
+                    ignore_not_test=False, ignore_broken_symlinks=False,
+                    ignore_access_denied=False):
+        pass
+
+    def discover_url(self, url):
+        cartesian_parser = self._get_parser()
+        cartesian_parser.only_filter(url)
+        params_list = [t for t in cartesian_parser.get_dicts()]
+        return params_list
+
+
+class VirtTest(test.Test):
+
+    """
+    Mininal test class used to run a virt test.
+    """
+
+    env_version = utils_env.get_env_version()
+
+    def __init__(self, methodName='runTest', name=None, params=None,
+                 base_logdir=None, tag=None, job=None, runner_queue=None):
+        del name
+        options = job.args
+
+        self.bindir = data_dir.get_root_dir()
+        self.virtdir = os.path.join(self.bindir, 'shared')
+        self.builddir = os.path.join(self.bindir, 'backends', params.get("vm_type"))
+        self.srcdir = path.init_dir(os.path.join(self.builddir, 'src'))
+        self.tmpdir = path.init_dir(os.path.join(self.bindir, 'tmp'))
+
+        self.iteration = 0
+        if options.config:
+            name = params.get("shortname")
+        else:
+            name = params.get("_short_name_map_file")["subtests.cfg"]
+        self.outputdir = None
+        self.resultsdir = None
+        self.logfile = None
+        self.file_handler = None
+        self.background_errors = Queue.Queue()
+        super(VirtTest, self).__init__(methodName=methodName, name=name, params=params, base_logdir=base_logdir,
+                                       tag=tag, job=job, runner_queue=runner_queue)
+        self.params = utils_params.Params(params)
+        self.debugdir = self.logdir
+        utils_misc.set_log_file_dir(self.logdir)
+
+    def start_logging(self):
+        super(VirtTest, self).start_logging()
+        root_logger = logging.getLogger()
+        root_logger.addHandler(self.file_handler)
+
+    def stop_logging(self):
+        super(VirtTest, self).stop_logging()
+        root_logger = logging.getLogger()
+        root_logger.removeHandler(self.file_handler)
+
+    def write_test_keyval(self, d):
+        self.whiteboard = str(d)
+
+    def verify_background_errors(self):
+        """
+        Verify if there are any errors that happened on background threads.
+
+        :raise Exception: Any exception stored on the background_errors queue.
+        """
+        try:
+            exc = self.background_errors.get(block=False)
+        except Queue.Empty:
+            pass
+        else:
+            raise exc[1], None, exc[2]
+
+    def runTest(self):
+        params = self.params
+
+        # If a dependency test prior to this test has failed, let's fail
+        # it right away as TestNA.
+        if params.get("dependency_failed") == 'yes':
+            raise error.TestNAError("Test dependency failed")
+
+        # Report virt test version
+        logging.info(version.get_pretty_version_info())
+        # Report the parameters we've received and write them as keyvals
+        logging.info("Starting test %s", self.tag)
+        logging.debug("Test parameters:")
+        keys = params.keys()
+        keys.sort()
+        for key in keys:
+            logging.debug("    %s = %s", key, params[key])
+
+        # Warn of this special condition in related location in output & logs
+        if os.getuid() == 0 and params.get('nettype', 'user') == 'user':
+            logging.warning("")
+            logging.warning("Testing with nettype='user' while running "
+                            "as root may produce unexpected results!!!")
+            logging.warning("")
+
+        # Open the environment file
+        env_filename = os.path.join(
+            data_dir.get_backend_dir(params.get("vm_type")),
+            params.get("env", "env"))
+        env = utils_env.Env(env_filename, self.env_version)
+
+        test_passed = False
+        t_type = None
+
+        try:
+            try:
+                try:
+                    subtest_dirs = []
+
+                    other_subtests_dirs = params.get("other_tests_dirs", "")
+                    for d in other_subtests_dirs.split():
+                        d = os.path.join(*d.split("/"))
+                        subtestdir = os.path.join(self.bindir, d, "tests")
+                        if not os.path.isdir(subtestdir):
+                            raise error.TestError("Directory %s does not "
+                                                  "exist" % subtestdir)
+                        subtest_dirs += data_dir.SubdirList(subtestdir,
+                                                            bootstrap.test_filter)
+
+                    provider = params.get("provider", None)
+
+                    if provider is None:
+                        # Verify if we have the correspondent source file for
+                        # it
+                        for generic_subdir in asset.get_test_provider_subdirs('generic'):
+                            subtest_dirs += data_dir.SubdirList(generic_subdir,
+                                                                bootstrap.test_filter)
+
+                        for specific_subdir in asset.get_test_provider_subdirs(params.get("vm_type")):
+                            subtest_dirs += data_dir.SubdirList(
+                                specific_subdir, bootstrap.test_filter)
+                    else:
+                        provider_info = asset.get_test_provider_info(provider)
+                        for key in provider_info['backends']:
+                            subtest_dirs += data_dir.SubdirList(
+                                provider_info['backends'][key]['path'],
+                                bootstrap.test_filter)
+
+                    subtest_dir = None
+
+                    # Get the test routine corresponding to the specified
+                    # test type
+                    logging.debug("Searching for test modules that match "
+                                  "'type = %s' and 'provider = %s' "
+                                  "on this cartesian dict",
+                                  params.get("type"), params.get("provider", None))
+
+                    t_types = params.get("type").split()
+                    # Make sure we can load provider_lib in tests
+                    for s in subtest_dirs:
+                        if os.path.dirname(s) not in sys.path:
+                            sys.path.insert(0, os.path.dirname(s))
+
+                    test_modules = {}
+                    for t_type in t_types:
+                        for d in subtest_dirs:
+                            module_path = os.path.join(d, "%s.py" % t_type)
+                            if os.path.isfile(module_path):
+                                logging.debug("Found subtest module %s",
+                                              module_path)
+                                subtest_dir = d
+                                break
+                        if subtest_dir is None:
+                            msg = ("Could not find test file %s.py on test"
+                                   "dirs %s" % (t_type, subtest_dirs))
+                            raise error.TestError(msg)
+                        # Load the test module
+                        f, p, d = imp.find_module(t_type, [subtest_dir])
+                        test_modules[t_type] = imp.load_module(t_type, f, p, d)
+                        f.close()
+
+                    # Preprocess
+                    try:
+                        params = env_process.preprocess(self, params, env)
+                    finally:
+                        env.save()
+
+                    # Run the test function
+                    for t_type in t_types:
+                        test_module = test_modules[t_type]
+                        run_func = utils_misc.get_test_entrypoint_func(
+                            t_type, test_module)
+                        try:
+                            run_func(self, params, env)
+                            self.verify_background_errors()
+                        finally:
+                            env.save()
+                    test_passed = True
+                    error_message = funcatexit.run_exitfuncs(env, t_type)
+                    if error_message:
+                        raise error.TestWarn("funcatexit failed with: %s"
+                                             % error_message)
+
+                except Exception:
+                    if t_type is not None:
+                        error_message = funcatexit.run_exitfuncs(env, t_type)
+                        if error_message:
+                            logging.error(error_message)
+                    try:
+                        env_process.postprocess_on_error(self, params, env)
+                    finally:
+                        env.save()
+                    raise
+
+            finally:
+                # Postprocess
+                try:
+                    try:
+                        env_process.postprocess(self, params, env)
+                    except Exception, e:
+                        if test_passed:
+                            raise
+                        logging.error("Exception raised during "
+                                      "postprocessing: %s", e)
+                finally:
+                    env.save()
+
+        except Exception, e:
+            if params.get("abort_on_error") != "yes":
+                raise
+            # Abort on error
+            logging.info("Aborting job (%s)", e)
+            if params.get("vm_type") == "qemu":
+                for vm in env.get_all_vms():
+                    if vm.is_dead():
+                        continue
+                    logging.info("VM '%s' is alive.", vm.name)
+                    for m in vm.monitors:
+                        logging.info("It has a %s monitor unix socket at: %s",
+                                     m.protocol, m.filename)
+                    logging.info("The command line used to start it was:\n%s",
+                                 vm.make_qemu_command())
+                raise error.JobError("Abort requested (%s)" % e)
+
+        return test_passed
+
+
+class VirtTestOptionsProcess(object):
+
+    """
+    Pick virt test options and parse them to get to a cartesian parser.
+    """
+
+    def __init__(self, job):
+        """
+        Parses options and initializes attributes.
+        """
+        self.options = job.args
+        self.view = job.view
+        self.cartesian_parser = None
+
+    def _process_qemu_bin(self):
+        """
+        Puts the value of the qemu bin option in the cartesian parser command.
+        """
+        if self.options.config and self.options.qemu is None:
+            logging.info("Config provided and no --vt-qemu-bin set. Not trying "
+                         "to automatically set qemu bin.")
+        else:
+            (qemu_bin_path, qemu_img_path, qemu_io_path,
+             qemu_dst_bin_path) = standalone_test.find_default_qemu_paths(self.options.qemu,
+                                                                          self.options.dst_qemu)
+            self.cartesian_parser.assign("qemu_binary", qemu_bin_path)
+            self.cartesian_parser.assign("qemu_img_binary", qemu_img_path)
+            self.cartesian_parser.assign("qemu_io_binary", qemu_io_path)
+            if qemu_dst_bin_path is not None:
+                self.cartesian_parser.assign("qemu_dst_binary",
+                                             qemu_dst_bin_path)
+
+    def _process_qemu_img(self):
+        """
+        Puts the value of the qemu bin option in the cartesian parser command.
+        """
+        if self.options.config and self.options.qemu is None:
+            logging.info("Config provided and no --vt-qemu-bin set. Not trying "
+                         "to automatically set qemu bin.")
+        else:
+            (_, qemu_img_path,
+             _, _) = standalone_test.find_default_qemu_paths(self.options.qemu,
+                                                             self.options.dst_qemu)
+            self.cartesian_parser.assign("qemu_img_binary", qemu_img_path)
+
+    def _process_qemu_accel(self):
+        """
+        Puts the value of the qemu bin option in the cartesian parser command.
+        """
+        if self.options.accel == 'tcg':
+            self.cartesian_parser.assign("disable_kvm", "yes")
+
+    def _process_bridge_mode(self):
+        if self.options.nettype not in SUPPORTED_NET_TYPES:
+            self.view.notify(event='error', msg="Invalid --vt-nettype option '%s'. Valid options are: (%s)" %
+                             (self.options.nettype, ", ".join(SUPPORTED_NET_TYPES)))
+            sys.exit(1)
+        if self.options.nettype == 'bridge':
+            if os.getuid() != 0:
+                self.view.notify(event='error', msg="In order to use bridge, you need to be root, aborting...")
+                sys.exit(1)
+            self.cartesian_parser.assign("nettype", "bridge")
+            self.cartesian_parser.assign("netdst", self.options.netdst)
+        elif self.options.nettype == 'user':
+            self.cartesian_parser.assign("nettype", "user")
+        elif self.options.nettype == 'none':
+            self.cartesian_parser.assign("nettype", "none")
+
+    def _process_monitor(self):
+        if self.options.monitor == 'qmp':
+            self.cartesian_parser.assign("monitors", "qmp1")
+            self.cartesian_parser.assign("monitor_type_qmp1", "qmp")
+
+    def _process_smp(self):
+        if not self.options.config:
+            if self.options.smp == '1':
+                self.cartesian_parser.only_filter("up")
+            elif self.options.smp == '2':
+                self.cartesian_parser.only_filter("smp2")
+            else:
+                try:
+                    self.cartesian_parser.only_filter("up")
+                    self.cartesian_parser.assign("smp", int(self.options.smp))
+                except ValueError:
+                    self.view.notify(event='error', msg="Invalid option for smp: %s, aborting..." % self.options.smp)
+                    sys.exit(1)
+        else:
+            logging.info("Config provided, ignoring --vt-smp option")
+
+    def _process_arch(self):
+        if self.options.arch is None:
+            pass
+        elif not self.options.config:
+            self.cartesian_parser.only_filter(self.options.arch)
+        else:
+            logging.info("Config provided, ignoring --vt-arch option")
+
+    def _process_machine_type(self):
+        if not self.options.config:
+            if self.options.machine_type is None:
+                # TODO: this is x86-specific, instead we can get the default
+                # arch from qemu binary and run on all supported machine types
+                if self.options.arch is None and self.options.guest_os is None:
+                    import virttest.defaults
+                    self.cartesian_parser.only_filter(
+                        virttest.defaults.DEFAULT_MACHINE_TYPE)
+            else:
+                self.cartesian_parser.only_filter(self.options.machine_type)
+        else:
+            logging.info("Config provided, ignoring --vt-machine-type option")
+
+    def _process_image_type(self):
+        if not self.options.config:
+            if self.options.image_type in SUPPORTED_IMAGE_TYPES:
+                self.cartesian_parser.only_filter(self.options.image_type)
+            else:
+                self.cartesian_parser.only_filter("raw")
+                # The actual param name is image_format.
+                self.cartesian_parser.assign("image_format",
+                                             self.options.image_type)
+        else:
+            logging.info("Config provided, ignoring --vt-image-type option")
+
+    def _process_nic_model(self):
+        if not self.options.config:
+            if self.options.nic_model in SUPPORTED_NIC_MODELS:
+                self.cartesian_parser.only_filter(self.options.nic_model)
+            else:
+                self.cartesian_parser.only_filter("nic_custom")
+                self.cartesian_parser.assign(
+                    "nic_model", self.options.nic_model)
+        else:
+            logging.info("Config provided, ignoring --vt-nic-model option")
+
+    def _process_disk_buses(self):
+        if not self.options.config:
+            if self.options.disk_bus in SUPPORTED_DISK_BUSES:
+                self.cartesian_parser.only_filter(self.options.disk_bus)
+            else:
+                self.view.notify(event='error', msg=("Option %s is not in the list %s, aborting..." %
+                                                     (self.options.disk_bus, SUPPORTED_DISK_BUSES)))
+                sys.exit(1)
+        else:
+            logging.info("Config provided, ignoring --vt-disk-bus option")
+
+    def _process_vhost(self):
+        if not self.options.config:
+            if self.options.nettype == "bridge":
+                if self.options.vhost == "on":
+                    self.cartesian_parser.assign("vhost", "on")
+                elif self.options.vhost == "force":
+                    self.cartesian_parser.assign("netdev_extra_params",
+                                                 '",vhostforce=on"')
+                    self.cartesian_parser.assign("vhost", "on")
+            else:
+                if self.options.vhost in ["on", "force"]:
+                    self.view.notify(event='error', msg=("Nettype %s is incompatible with vhost %s, aborting..." %
+                                                         (self.options.nettype, self.options.vhost)))
+                    sys.exit(1)
+        else:
+            logging.info("Config provided, ignoring --vt-vhost option")
+
+    def _process_qemu_sandbox(self):
+        if not self.options.config:
+            if self.options.qemu_sandbox == "off":
+                self.cartesian_parser.assign("qemu_sandbox", "off")
+        else:
+            logging.info("Config provided, ignoring \"--vt-sandbox <on|off>\" option")
+
+    def _process_malloc_perturb(self):
+        self.cartesian_parser.assign("malloc_perturb",
+                                     self.options.malloc_perturb)
+
+    def _process_qemu_specific_options(self):
+        """
+        Calls for processing all options specific to the qemu test.
+
+        This method modifies the cartesian set by parsing additional lines.
+        """
+
+        self._process_qemu_bin()
+        self._process_qemu_accel()
+        self._process_monitor()
+        self._process_smp()
+        self._process_image_type()
+        self._process_nic_model()
+        self._process_disk_buses()
+        self._process_vhost()
+        self._process_malloc_perturb()
+        self._process_qemu_sandbox()
+
+    def _process_lvsb_specific_options(self):
+        """
+        Calls for processing all options specific to lvsb test
+        """
+        self.options.no_downloads = True
+
+    def _process_libvirt_specific_options(self):
+        """
+        Calls for processing all options specific to libvirt test.
+        """
+        if self.options.uri:
+            driver_found = False
+            for driver in SUPPORTED_LIBVIRT_DRIVERS:
+                if self.options.uri.count(driver):
+                    driver_found = True
+                    self.cartesian_parser.only_filter(driver)
+            if not driver_found:
+                self.view.notify(event='error', msg="Unsupported uri: %s." % self.options.uri)
+                sys.exit(1)
+        else:
+            self.cartesian_parser.only_filter("qemu")
+
+    def _process_guest_os(self):
+        if not self.options.config:
+            if len(standalone_test.get_guest_name_list(self.options)) == 0:
+                self.view.notify(event='error', msg="Guest name %s is not on the known guest os list "
+                                                    "(see --vt-list-guests), aborting..." % self.options.guest_os)
+                sys.exit(1)
+            self.cartesian_parser.only_filter(
+                self.options.guest_os or defaults.DEFAULT_GUEST_OS)
+        else:
+            logging.info("Config provided, ignoring --vt-guest-os option")
+
+    def _process_list(self):
+        if self.options.list:
+            standalone_test.print_test_list(self.options,
+                                            self.cartesian_parser)
+            sys.exit(0)
+        if self.options.list_guests:
+            standalone_test.print_guest_list(self.options)
+            sys.exit(0)
+
+    def _process_tests(self):
+        if not self.options.config:
+            if self.options.type:
+                if self.options.url and self.options.dropin:
+                    self.view.notify(event='error', msg="Option --vt-tests and --vt-run-dropin can't be set at "
+                                                        "the same time")
+                    sys.exit(1)
+                elif self.options.url:
+                    tests = self.options.url
+                    if self.options.type == 'libvirt':
+                        if self.options.install_guest:
+                            tests.insert(0, LIBVIRT_INSTALL)
+                        if self.options.remove_guest:
+                            tests.append(LIBVIRT_REMOVE)
+                    self.cartesian_parser.only_filter(", ".join(tests))
+                elif self.options.dropin:
+                    dropin_tests = os.listdir(os.path.join(data_dir.get_root_dir(), "dropin"))
+                    if len(dropin_tests) <= 1:
+                        self.view.notify(event='error', msg="No drop in tests detected, aborting. "
+                                                            "Make sure you have scripts on the 'dropin' "
+                                                            "directory")
+                        sys.exit(1)
+                    self.cartesian_parser.only_filter("dropin")
+                else:
+                    if self.options.type == 'qemu':
+                        self.cartesian_parser.only_filter(QEMU_DEFAULT_SET)
+                        self.cartesian_parser.no_filter("with_reboot")
+                    elif self.options.type == 'libvirt':
+                        self.cartesian_parser.only_filter(LIBVIRT_DEFAULT_SET)
+                    elif self.options.type == 'lvsb':
+                        self.cartesian_parser.only_filter(LVSB_DEFAULT_SET)
+                    elif self.options.type == 'openvswitch':
+                        self.cartesian_parser.only_filter(OVS_DEFAULT_SET)
+        else:
+            logging.info("Config provided, ignoring --vt-tests option")
+
+    def _process_restart_vm(self):
+        if not self.options.config:
+            if not self.options.keep_guest_running:
+                self.cartesian_parser.assign("kill_vm", "yes")
+
+    def _process_restore_image_between_tests(self):
+        if not self.options.config:
+            if not self.options.keep_image_between_tests:
+                self.cartesian_parser.assign("restore_image", "yes")
+
+    def _process_mem(self):
+        self.cartesian_parser.assign("mem", self.options.mem)
+
+    def _process_tcpdump(self):
+        """
+        Verify whether we can run tcpdump. If we can't, turn it off.
+        """
+        try:
+            tcpdump_path = utils_misc.find_command('tcpdump')
+        except ValueError:
+            tcpdump_path = None
+
+        non_root = os.getuid() != 0
+
+        if tcpdump_path is None or non_root:
+            self.cartesian_parser.assign("run_tcpdump", "no")
+
+    def _process_no_filter(self):
+        if not self.options.config:
+            if self.options.no_filter:
+                no_filter = ", ".join(self.options.no_filter.split(' '))
+                self.cartesian_parser.no_filter(no_filter)
+
+    def _process_only_type_specific(self):
+        if not self.options.config:
+            if self.options.only_type_specific:
+                self.cartesian_parser.only_filter("(subtest=type_specific)")
+
+    def _process_general_options(self):
+        """
+        Calls for processing all generic options.
+
+        This method modifies the cartesian set by parsing additional lines.
+        """
+        self._process_guest_os()
+        self._process_arch()
+        self._process_machine_type()
+        self._process_restart_vm()
+        self._process_restore_image_between_tests()
+        self._process_mem()
+        self._process_tcpdump()
+        self._process_no_filter()
+        self._process_qemu_img()
+        self._process_bridge_mode()
+        self._process_only_type_specific()
+
+    def _process_options(self):
+        """
+        Process the options given in the command line.
+        """
+
+        if (not self.options.type) and (not self.options.config):
+            self.view.notify(event='error',
+                             msg="No type (--vt-type) or config (--vt-config) options specified, aborting...")
+            sys.exit(0)
+
+        if self.options.type:
+            if self.options.type not in SUPPORTED_TEST_TYPES:
+                self.view.notify(event='error', msg="Invalid test type %s. Valid test types: %s. Aborting..." %
+                                                    (self.options.type, " ".join(SUPPORTED_TEST_TYPES)))
+                sys.exit(1)
+
+        if self.options.log_level not in SUPPORTED_LOG_LEVELS:
+            self.view.notify(event='error', msg="Invalid log level '%s'. Valid log levels: %s. "
+                                                "Aborting..." % (self.options.log_level,
+                                                                 " ".join(SUPPORTED_LOG_LEVELS)))
+            sys.exit(1)
+        num_level = getattr(logging, self.options.log_level.upper(), None)
+        self.options.log_level = num_level
+
+        if self.options.console_level not in SUPPORTED_LOG_LEVELS:
+            self.view.notify(event='error', msg="Invalid console level '%s'. Valid console levels: %s. Aborting..." %
+                                                (self.options.console_level, " ".join(SUPPORTED_LOG_LEVELS)))
+            sys.exit(1)
+        num_level_console = getattr(logging,
+                                    self.options.console_level.upper(),
+                                    None)
+        self.options.console_level = num_level_console
+
+        if self.options.datadir:
+            data_dir.set_backing_data_dir(self.options.datadir)
+
+        standalone_test.create_config_files(self.options)
+
+        self.cartesian_parser = cartesian_config.Parser(debug=False)
+
+        if self.options.config:
+            cfg = os.path.abspath(self.options.config)
+
+        if not self.options.config:
+            cfg = data_dir.get_backend_cfg_path(self.options.type, 'tests.cfg')
+
+        self.cartesian_parser.parse_file(cfg)
+        if self.options.type != 'lvsb':
+            self._process_general_options()
+
+        if self.options.type == 'qemu':
+            self._process_qemu_specific_options()
+        elif self.options.type == 'lvsb':
+            self._process_lvsb_specific_options()
+        elif self.options.type == 'openvswitch':
+            self._process_qemu_specific_options()
+        elif self.options.type == 'libvirt':
+            self._process_libvirt_specific_options()
+        # List and tests have to be the last things to be processed
+        self._process_list()
+        # Tests won't be processed here. The code of the function will
+        # be utilized elsewhere.
+        # self._process_tests()
+
+    def get_parser(self):
+        standalone_test.handle_stdout(self.options)
+        self._process_options()
+        standalone_test.reset_logging()
+        standalone_test.configure_console_logging(loglevel=self.options.console_level)
+        return self.cartesian_parser
+
+
+class VirtTestCompatPlugin(plugin.Plugin):
+
+    """
+    Implements the avocado virt test options
+    """
+
+    name = 'virt_test_compat_runner'
+    enabled = True
+
+    def configure(self, parser):
+        """
+        Add the subparser for the run action.
+
+        :param parser: Main test runner parser.
+        """
+        self.parser = parser
+        vt_compat_group = parser.runner.add_argument_group('Virt-Test compatibility layer options')
+
+        try:
+            qemu_bin_path = standalone_test.find_default_qemu_paths()[0]
+        except ValueError:
+            qemu_bin_path = "Could not find one"
+
+        if os.getuid() == 0:
+            nettype_default = 'bridge'
+        else:
+            nettype_default = 'user'
+
+        vt_compat_group.add_argument("--vt-verbose", action="store_true",
+                                     dest="verbose", help=("Exhibit test "
+                                                           "messages in the console "
+                                                           "(used for debugging)"))
+        vt_compat_group.add_argument("--vt-console-level", action="store",
+                                     dest="console_level",
+                                     default="debug",
+                                     help=("Log level of test messages in the console. Only valid "
+                                           "with --vt-verbose. "
+                                           "Supported levels: " +
+                                           ", ".join(SUPPORTED_LOG_LEVELS) +
+                                           ". Default: "))
+        vt_compat_group.add_argument("--vt-show-open-fd", action="store_true",
+                                     dest="show_open_fd", help=("Show how many "
+                                                                "open fds at the end of "
+                                                                "each test "
+                                                                "(used for debugging)"))
+
+        vt_compat_group.add_argument("--vt-bootstrap", action="store_true",
+                                     dest="bootstrap", help=("Perform test suite setup "
+                                                             "procedures, such as "
+                                                             "downloading JeOS and check "
+                                                             "required programs and "
+                                                             "libs. Requires --vt-type to be set"))
+        vt_compat_group.add_argument("--vt-update-config", action="store_true",
+                                     default=False,
+                                     dest="update_config", help=("Forces configuration "
+                                                                 "updates (all manual "
+                                                                 "config file editing "
+                                                                 "will be lost). "
+                                                                 "Requires --vt-type to be set"))
+        vt_compat_group.add_argument("--vt-update-providers", action="store_true",
+                                     default=False,
+                                     dest="update_providers", help=("Forces test "
+                                                                    "providers to be "
+                                                                    "updated (git repos "
+                                                                    "will be pulled)"))
+        vt_compat_group.add_argument("--vt-type", action="store", dest="type",
+                                     help="Choose test type (%s)" % ", ".join(SUPPORTED_TEST_TYPES),
+                                     default='qemu')
+        vt_compat_group.add_argument("--vt-connect-uri", action="store", dest="uri",
+                                     help="Choose test connect uri for libvirt (E.g: %s)" %
+                                     ", ".join(SUPPORTED_LIBVIRT_URIS))
+        vt_compat_group.add_argument("--vt-config", action="store", dest="config",
+                                     help=("Explicitly choose a cartesian config. "
+                                           "When choosing this, some options will be "
+                                           "ignored"))
+        vt_compat_group.add_argument("--vt-no-downloads", action="store_true",
+                                     dest="no_downloads", default=False,
+                                     help="Do not attempt to download JeOS images")
+        vt_compat_group.add_argument("--vt-selinux-setup", action="store_true",
+                                     dest="selinux_setup", default=False,
+                                     help="Define default contexts of directory.")
+        vt_compat_group.add_argument("--vt-setup", action="store_true",
+                                     dest="vt_setup",
+                                     help="Run virt test setup actions (download/restore jeos image)")
+        vt_compat_group.add_argument("--vt-keep-image", action="store_true",
+                                     dest="keep_image",
+                                     help=("Don't restore the JeOS image from pristine "
+                                           "at the beginning of the test suite run "
+                                           "(faster but unsafe). Has no effect unless --vt-setup is provided"))
+        vt_compat_group.add_argument("--vt-keep-image-between-tests",
+                                     action="store_true", default=False,
+                                     dest="keep_image_between_tests",
+                                     help=("Don't restore the JeOS image from pristine "
+                                           "between tests (faster but unsafe). Has no effect unless "
+                                           "--vt-setup is provided"))
+        vt_compat_group.add_argument("--vt-guest-os", action="store", dest="guest_os",
+                                     default=None,
+                                     help=("Select the guest OS to be used. "
+                                           "If -c is provided, this will be ignored. "
+                                           "Default: %s" % defaults.DEFAULT_GUEST_OS))
+        vt_compat_group.add_argument("--vt-arch", action="store", dest="arch",
+                                     default=None,
+                                     help=("Architecture under test. "
+                                           "If -c is provided, this will be ignored. "
+                                           "Default: any that supports the given machine type"))
+        vt_compat_group.add_argument("--vt-machine-type", action="store", dest="machine_type",
+                                     default=None,
+                                     help=("Machine type under test. "
+                                           "If -c is provided, this will be ignored. "
+                                           "Default: all for the chosen guests, %s if "
+                                           "--vt-guest-os not given." % defaults.DEFAULT_MACHINE_TYPE))
+        vt_compat_group.add_argument("--vt-list-tests", action="store_true", dest="list",
+                                     help="List tests available")
+        vt_compat_group.add_argument("--vt-list-guests", action="store_true",
+                                     dest="list_guests",
+                                     help="List guests available")
+        vt_compat_group.add_argument("--vt-logs-dir", action="store", dest="logdir",
+                                     help=("Path to the logs directory. "
+                                           "Default path: %s" % os.path.join(data_dir.get_backing_data_dir(), 'logs')))
+        vt_compat_group.add_argument("--vt-data-dir", action="store", dest="datadir",
+                                     help=("Path to a data dir. "
+                                           "Default path: %s" %
+                                           avocado_data_dir.get_data_dir()))
+        vt_compat_group.add_argument("--vt-keep-guest-running", action="store_true",
+                                     dest="keep_guest_running", default=False,
+                                     help=("Don't shut down guests at the end of each "
+                                           "test (faster but unsafe)"))
+        vt_compat_group.add_argument("--vt-mem", action="store", dest="mem",
+                                     default="1024",
+                                     help=("RAM dedicated to the main VM. Default:"
+                                           ""))
+        vt_compat_group.add_argument("--vt-no", action="store", dest="no_filter", default="",
+                                     help=("List of space separated no filters to be "
+                                           "passed to the config parser. If -c is "
+                                           "provided, this will be ignored"))
+        vt_compat_group.add_argument("--vt-type-specific", action="store_true",
+                                     dest="only_type_specific", default=False,
+                                     help=("Enable only type specific tests. Shared"
+                                           " tests will not be tested."))
+
+        vt_compat_group.add_argument("--vt-run-dropin", action="store_true", dest="dropin",
+                                     default=False,
+                                     help=("Run tests present on the drop in dir on the "
+                                           "host. Incompatible with --vt-tests."))
+
+        vt_compat_group.add_argument("--vt-log-level", action="store", dest="log_level",
+                                     default="debug",
+                                     help=("Set log level for top level log file."
+                                           " Supported levels: " +
+                                           ", ".join(SUPPORTED_LOG_LEVELS) +
+                                           ". Default: "))
+
+        vt_compat_group.add_argument("--vt-no-cleanup", action="store_true",
+                                     dest="no_cleanup",
+                                     default=False,
+                                     help=("Don't clean up tmp files or VM processes at "
+                                           "the end of a virt-test execution (useful "
+                                           "for debugging)"))
+
+        vt_compat_group.add_argument("--vt-qemu-bin", action="store", dest="qemu",
+                                     default=None,
+                                     help=("Path to a custom qemu binary to be tested. "
+                                           "If -c is provided and this flag is omitted, "
+                                           "no attempt to set the qemu binaries will be made. "
+                                           "Default path: %s" % qemu_bin_path))
+        vt_compat_group.add_argument("--vt-qemu-dst-bin", action="store", dest="dst_qemu",
+                                     default=None,
+                                     help=("Path to a custom qemu binary to be tested for "
+                                           "the destination of a migration, overrides "
+                                           "--vt-qemu-bin. "
+                                           "If -c is provided and this flag is omitted, "
+                                           "no attempt to set the qemu binaries will be made. "
+                                           "Default path: %s" % qemu_bin_path))
+        vt_compat_group.add_argument("--vt-use-malloc-perturb", action="store",
+                                     dest="malloc_perturb", default="yes",
+                                     help=("Use MALLOC_PERTURB_ env variable set to 1 "
+                                           "to help catch memory allocation problems on "
+                                           "qemu (yes or no). Default: "))
+        vt_compat_group.add_argument("--vt-accel", action="store", dest="accel", default="kvm",
+                                     help=("Accelerator used to run qemu (kvm or tcg). "
+                                           "Default: kvm"))
+        help_msg = "QEMU network option (%s). " % ", ".join(SUPPORTED_NET_TYPES)
+        help_msg += "Default: "
+        vt_compat_group.add_argument("--vt-nettype", action="store", dest="nettype",
+                                     default=nettype_default, help=help_msg)
+        vt_compat_group.add_argument("--vt-netdst", action="store", dest="netdst",
+                                     default="virbr0",
+                                     help=("Bridge name to be used "
+                                           "(if you chose bridge as nettype). "
+                                           "Default: "))
+        vt_compat_group.add_argument("--vt-vhost", action="store", dest="vhost",
+                                     default="off",
+                                     help=("Whether to enable vhost for qemu "
+                                           "(on/off/force). Depends on nettype=bridge. "
+                                           "If -c is provided, this will be ignored. "
+                                           "Default: "))
+        vt_compat_group.add_argument("--vt-monitor", action="store", dest="monitor",
+                                     default='human',
+                                     help="Monitor type (human or qmp). Default: ")
+        vt_compat_group.add_argument("--vt-smp", action="store", dest="smp",
+                                     default='2',
+                                     help=("Number of virtual cpus to use. "
+                                           "If -c is provided, this will be ignored. "
+                                           "Default: "))
+        vt_compat_group.add_argument("--vt-image-type", action="store", dest="image_type",
+                                     default="qcow2",
+                                     help=("Image format type to use "
+                                           "(any valid qemu format). "
+                                           "If -c is provided, this will be ignored. "
+                                           "Default: "))
+        vt_compat_group.add_argument("--vt-nic-model", action="store", dest="nic_model",
+                                     default="virtio_net",
+                                     help=("Guest network card model. "
+                                           "If -c is provided, this will be ignored. "
+                                           "(any valid qemu format). Default: "))
+        vt_compat_group.add_argument("--vt-disk-bus", action="store", dest="disk_bus",
+                                     default="virtio_blk",
+                                     help=("Guest main image disk bus. One of " +
+                                           " ".join(SUPPORTED_DISK_BUSES) +
+                                           ". If -c is provided, this will be ignored. "
+                                           "Default: "))
+        vt_compat_group.add_argument("--vt-qemu_sandbox", action="store", dest="qemu_sandbox",
+                                     default="on",
+                                     help=("Enable qemu sandboxing "
+                                           "(on/off). Default: "))
+
+        vt_compat_group.add_argument("--vt-install", action="store_true",
+                                     dest="install_guest",
+                                     help=("Install the guest using import method before "
+                                           "the tests are run."))
+        vt_compat_group.add_argument("--vt-remove", action="store_true", dest="remove_guest",
+                                     help=("Remove the guest from libvirt. This will not "
+                                           "delete the guest's disk file."))
+
+        self.configured = True
+
+    def activate(self, args):
+        """
+        Run test modules or simple tests.
+
+        :param args: Command line args received from the run subparser.
+        """
+        if getattr(args, 'vt_setup', False):
+            self.parser.application.set_defaults(vt_loader=VirtTestLoader, vt_result=VirtTestResult)
+        else:
+            self.parser.application.set_defaults(vt_loader=VirtTestLoader)

--- a/avocado/core/plugins/virt_test_bootstrap.py
+++ b/avocado/core/plugins/virt_test_bootstrap.py
@@ -1,0 +1,138 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2015
+# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+
+import os
+import sys
+
+from avocado.core.plugins import plugin
+from avocado import data_dir as avocado_data_dir
+from avocado.settings import settings
+from avocado.settings import config_path_local
+
+if 'VIRT_TEST_DIR' in os.environ:
+    virt_test_dir = os.environ['VIRT_TEST_DIR']
+else:
+    virt_test_dir = settings.get_value(section='virt-test', key='test_suite_path', default=None)
+    if virt_test_dir is None or not os.path.isdir(virt_test_dir):
+        print('Virt test dir not set/invalid. Please make sure you add to %s' % config_path_local)
+        print('')
+        print('[virt-test]')
+        print('test_suite_path=/valid/path/to/virt_test')
+        print('')
+        print('If you are working from an avocado source code repo, please')
+        print('$ export VIRT_TEST_DIR="/valid/path/to/virt_test"')
+        sys.exit(1)
+
+sys.path.append(os.path.expanduser(virt_test_dir))
+
+from virttest import arch
+from virttest import bootstrap
+from virttest import data_dir
+from virttest import defaults
+
+data_dir.get_data_dir = avocado_data_dir.get_data_dir
+
+from virttest.standalone_test import SUPPORTED_TEST_TYPES
+
+
+class VirtBootstrap(plugin.Plugin):
+
+    """
+    Implements the avocado 'vt-bootstrap' subcommand
+    """
+
+    name = 'virt_test_compat_bootstrap'
+    enabled = True
+
+    def configure(self, parser):
+        self.parser = parser.subcommands.add_parser('vt-bootstrap',
+                                                    help='Setup tests for the virt test compatibility layer')
+        self.parser.add_argument("--vt-type", action="store", dest="type",
+                                 help="Choose test type (%s)" % ", ".join(SUPPORTED_TEST_TYPES),
+                                 default='qemu')
+        self.parser.add_argument("--vt-guest-os", action="store", dest="guest_os",
+                                 default=None,
+                                 help=("Select the guest OS to be used. "
+                                       "If -c is provided, this will be ignored. "
+                                       "Default: %s" % defaults.DEFAULT_GUEST_OS))
+        self.parser.add_argument("--vt-selinux-setup", action="store_true",
+                                 dest="selinux_setup", default=False,
+                                 help="Define default contexts of directory.")
+        self.parser.add_argument("--vt-no-downloads", action="store_true",
+                                 dest="no_downloads", default=False,
+                                 help="Do not attempt to download JeOS images")
+        self.parser.add_argument("--vt-update-config", action="store_true",
+                                 default=False,
+                                 dest="update_config", help=("Forces configuration "
+                                                             "updates (all manual "
+                                                             "config file editing "
+                                                             "will be lost). "
+                                                             "Requires --vt-type to be set"))
+        self.parser.add_argument("--vt-update-providers", action="store_true",
+                                 default=False,
+                                 dest="update_providers", help=("Forces test "
+                                                                "providers to be "
+                                                                "updated (git repos "
+                                                                "will be pulled)"))
+        super(VirtBootstrap, self).configure(self.parser)
+
+    def run(self, args):
+        if args.update_config:
+            test_dir = data_dir.get_backend_dir(args.type)
+            shared_dir = os.path.join(data_dir.get_root_dir(), "shared")
+            bootstrap.create_config_files(test_dir, shared_dir,
+                                          interactive=True,
+                                          force_update=False)
+            bootstrap.create_subtests_cfg(args.type)
+            bootstrap.create_guest_os_cfg(args.type)
+            sys.exit(0)
+
+        check_modules = []
+        online_docs_url = None
+        interactive = True
+        default_userspace_paths = []
+
+        if args.type == "qemu":
+            default_userspace_paths = ["/usr/bin/qemu-kvm", "/usr/bin/qemu-img"]
+            check_modules = arch.get_kvm_module_list()
+            online_docs_url = "https://github.com/autotest/virt-test/wiki/GetStarted"
+        elif args.type == "libvirt":
+            default_userspace_paths = ["/usr/bin/qemu-kvm", "/usr/bin/qemu-img"]
+        elif args.type == "libguestfs":
+            default_userspace_paths = ["/usr/bin/libguestfs-test-tool"]
+        elif args.type == "lvsb":
+            default_userspace_paths = ["/usr/bin/virt-sandbox"]
+        elif args.type == "openvswitch":
+            default_userspace_paths = ["/usr/bin/qemu-kvm", "/usr/bin/qemu-img"]
+            check_modules = ["openvswitch"]
+            online_docs_url = "https://github.com/autotest/autotest/wiki/OpenVSwitch"
+        elif args.type == "v2v":
+            default_userspace_paths = ["/usr/bin/virt-v2v"]
+
+        restore_image = not args.no_downloads
+
+        test_dir = data_dir.get_backend_dir(args.type)
+        bootstrap.bootstrap(test_name=args.type, test_dir=test_dir,
+                            base_dir=avocado_data_dir.get_data_dir(),
+                            default_userspace_paths=default_userspace_paths,
+                            check_modules=check_modules,
+                            online_docs_url=online_docs_url,
+                            interactive=interactive,
+                            selinux=args.selinux_setup,
+                            restore_image=restore_image,
+                            verbose=True,
+                            update_providers=args.update_providers,
+                            guest_os=(args.guest_os or
+                                      defaults.DEFAULT_GUEST_OS))
+        sys.exit(0)

--- a/avocado/core/plugins/virt_test_list.py
+++ b/avocado/core/plugins/virt_test_list.py
@@ -1,0 +1,151 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2015
+# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+
+import os
+import sys
+
+from avocado.core import output
+from avocado.core.plugins import plugin
+from avocado import data_dir as avocado_data_dir
+from avocado.settings import settings
+from avocado.settings import config_path_local
+
+if 'VIRT_TEST_DIR' in os.environ:
+    virt_test_dir = os.environ['VIRT_TEST_DIR']
+else:
+    virt_test_dir = settings.get_value(section='virt-test', key='test_suite_path', default=None)
+    if virt_test_dir is None or not os.path.isdir(virt_test_dir):
+        print('Virt test dir not set/invalid. Please make sure you add to %s' % config_path_local)
+        print('')
+        print('[virt-test]')
+        print('test_suite_path=/valid/path/to/virt_test')
+        print('')
+        print('If you are working from an avocado source code repo, please')
+        print('$ export VIRT_TEST_DIR="/valid/path/to/virt_test"')
+        sys.exit(1)
+
+sys.path.append(os.path.expanduser(virt_test_dir))
+
+from virttest import data_dir
+from virttest import standalone_test
+
+data_dir.get_data_dir = avocado_data_dir.get_data_dir
+
+from virttest.standalone_test import SUPPORTED_TEST_TYPES
+
+
+from virt_test import VirtTestOptionsProcess
+
+
+def print_test_list(options, cartesian_parser, view):
+    """
+    Helper function to pretty print the test list.
+
+    This function uses a paginator, if possible (inspired on git).
+
+    :param options: OptParse object with cmdline options.
+    :param cartesian_parser: Cartesian parser object with test options.
+    """
+    index = 0
+
+    view.notify(event='minor', msg=standalone_test.get_cartesian_parser_details(cartesian_parser))
+    if options.tests:
+        tests = options.tests.split(" ")
+        cartesian_parser.only_filter(", ".join(tests))
+    for params in cartesian_parser.get_dicts():
+        virt_test_type = params.get('virt_test_type', "")
+        supported_virt_backends = virt_test_type.split(" ")
+        if options.type in supported_virt_backends:
+            index += 1
+            shortname = params.get("_short_name_map_file")["subtests.cfg"]
+            needs_root = ((params.get('requires_root', 'no') == 'yes') or
+                          (params.get('vm_type') != 'qemu'))
+            basic_out = (standalone_test.bcolors.blue + str(index) + standalone_test.bcolors.end + " " +
+                         shortname)
+            if needs_root:
+                out = (basic_out + standalone_test.bcolors.yellow + " (requires root)" +
+                       standalone_test.bcolors.end + "\n")
+            else:
+                out = basic_out + "\n"
+            view.notify(event='minor', msg=out)
+
+
+class VirtTestLister(plugin.Plugin):
+
+    """
+    Implements the avocado 'vt-list' subcommand
+    """
+
+    name = 'virt_test_compat_lister'
+    enabled = True
+
+    def configure(self, parser):
+        self.parser = parser.subcommands.add_parser('vt-list',
+                                                    help='List tests available by the virt test compatibility layer')
+        self.parser.add_argument("--vt-type", action="store", dest="type",
+                                 help="Choose test type (%s)" % ", ".join(SUPPORTED_TEST_TYPES),
+                                 default='qemu')
+        self.parser.add_argument("--vt-list-tests", action="store_true", dest="list",
+                                 help="List tests available")
+        self.parser.add_argument("--vt-list-tests-filter", action="store", dest="test_list_filter", default='',
+                                 help="Pattern used to filter tests (Ex: usb)")
+        self.parser.add_argument("--vt-list-guests", action="store_true",
+                                 dest="list_guests",
+                                 help="List guests available")
+        super(VirtTestLister, self).configure(self.parser)
+
+    def run(self, args):
+        if os.getuid() == 0:
+            nettype_default = 'bridge'
+        else:
+            nettype_default = 'user'
+        args.verbose = True
+        args.log_level = 'debug'
+        args.console_level = 'debug'
+        args.datadir = data_dir.get_data_dir()
+        args.config = None
+        args.arch = None
+        args.machine_type = None
+        args.guest_os = None
+        args.keep_guest_running = False
+        args.keep_image_between_tests = False
+        args.mem = 1024
+        args.no_filter = ''
+        args.qemu = None
+        args.dst_qemu = None
+        args.nettype = nettype_default
+        args.only_type_specific = False
+        args.tests = ''
+        args.uri = ''
+        args.accel = 'kvm'
+        args.monitor = 'human'
+        args.smp = 1
+        args.image_type = 'qcow2'
+        args.nic_model = 'virtio_net'
+        args.disk_bus = 'virtio_blk'
+        args.vhost = 'off'
+        args.malloc_perturb = 'yes'
+        args.qemu_sandbox = 'on'
+        args.tests = args.test_list_filter
+
+        class TestListJob(object):
+
+            def __init__(self, args, view):
+                self.args = args
+                self.view = view
+
+        view = output.View(app_args=args)
+        test_list_job = TestListJob(args=args, view=view)
+        vt_opt_process = VirtTestOptionsProcess(job=test_list_job)
+        vt_opt_process.get_parser()

--- a/avocado/core/result.py
+++ b/avocado/core/result.py
@@ -245,7 +245,8 @@ class TestResult(object):
                       'FAIL': self.add_fail,
                       'TEST_NA': self.add_skip,
                       'WARN': self.add_warn,
-                      'INTERRUPTED': self.add_interrupt}
+                      'INTERRUPTED': self.add_interrupt,
+                      'NOT_A_TEST': self.add_error}
         add = status_map[state['status']]
         add(state)
         self.end_test(state)

--- a/avocado/core/status.py
+++ b/avocado/core/status.py
@@ -26,7 +26,8 @@ mapping = {"TEST_NA": True,
            "ALERT": False,
            "RUNNING": False,
            "NOSTATUS": False,
-           "INTERRUPTED": False}
+           "INTERRUPTED": False,
+           "NOT_A_TEST": False}
 
 feedback = {
     # Test did not advertise current status, but process running the test is

--- a/etc/avocado/conf.d/virt-test.conf
+++ b/etc/avocado/conf.d/virt-test.conf
@@ -1,0 +1,7 @@
+[virt-test]
+# Path to virt-test, required for the compatibility plugin to locate
+# virt-test libs. You should set this locally for avocado users.
+# For people working on the compatibility layer itself, you can export the
+# environment variable VIRT_TEST_DIR with that location instead of using
+# the config system.
+test_suite_path=

--- a/selftests/all/functional/avocado/basic_tests.py
+++ b/selftests/all/functional/avocado/basic_tests.py
@@ -178,8 +178,8 @@ class RunnerOperationTest(unittest.TestCase):
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 2
         self.assertEqual(result.exit_status, expected_rc)
-        self.assertIn('File not found', result.stderr)
-        self.assertNotIn('File not found', result.stdout)
+        self.assertIn('No tests found within the specified path(s)', result.stderr)
+        self.assertNotIn('No tests found within the specified path(s)', result.stdout)
 
     def test_invalid_unique_id(self):
         cmd_line = './scripts/avocado run --sysinfo=off --force-job-id foobar skiptest'


### PR DESCRIPTION
This is the most fleshed out virt test compat layer to date. It introduces loading of tests from multiple test sources, which allows the mix and match of regular avocado tests and avocado virt-tests:

	$ scripts/avocado run --vt-setup type_specific.io-github-autotest-qemu.migrate.default.tcp examples/tests/passtest.py --open-browser
	SETUP      : PASS (15.66 s)
	JOB ID     : 0a613e41201ee2fa726a6ef8617f6578aa901e3a
	JOB LOG    : /home/lmr/avocado/job-results/job-2015-04-30T01.09-0a613e4/job.log
	JOB HTML   : /home/lmr/avocado/job-results/job-2015-04-30T01.09-0a613e4/html/results.html
	TESTS      : 2
	(1/2) type_specific.io-github-autotest-qemu.migrate.default.tcp: PASS (89.62 s)
	(2/2) examples/tests/passtest.py: PASS (0.00 s)
	PASS       : 2
	ERROR      : 0
	FAIL       : 0
	SKIP       : 0
	WARN       : 0
	INTERRUPT  : 0
	TIME       : 89.62 s

You can try out this work by following the steps:

1) Check out this branch
2) Set the environment variable 'VIRT_TEST_PATH' to a path containing a copy of virt test
3) The copy of virt-test has to be in my new branch `avocado-integration` [1]
4) Bootstrap your testing by running `scripts/avocado vt-bootstrap --vt-type qemu`
5) Run your tests with the command above

You can also list your virt-test tests by doing `scripts/avocado vt-list --vt-type qemu`

Keep in mind that the unittests are not all passing. I'm having trouble deciding the best way to handle the behavior of avocado parsing test strings that might come from multiple sources.

That's it. Virt Test at this point has way too many knobs, and it's challenging to look to each of them and make sure they are working well. I hope that at least you guys enjoy trying this out.

[1] See https://github.com/autotest/virt-test/pull/2176

Bonus: People can now generate HTML reports out of virt-test runs. I imagine there will be people happy with this.

![screenshot from 2015-04-30 01-22-14](https://cloud.githubusercontent.com/assets/296807/7406339/7699689e-eed7-11e4-9214-38a678c105ec.png)
