### PR TITLE
Plugins improve list view

### DIFF
--- a/avocado/plugins/builtin.py
+++ b/avocado/plugins/builtin.py
@@ -19,6 +19,7 @@ import logging
 from importlib import import_module
 
 from avocado.plugins.plugin import Plugin
+from avocado.plugins.plugin import FailedPlugin
 
 
 log = logging.getLogger("avocado.plugins")
@@ -36,6 +37,8 @@ Exclude = ['avocado.plugins.__init__',
 
 Builtins = [x for x in Modules if x not in Exclude]
 
+ErrorsLoading = []
+
 
 def load_builtins():
     """
@@ -48,10 +51,12 @@ def load_builtins():
         try:
             plugin_mod = import_module(module)
         except ImportError as err:
-            log.error("Could not import module plugin '%s': %s", module, err)
+            failed_plugin = FailedPlugin(str(module), err)
+            ErrorsLoading.append(failed_plugin)
             continue
         except Exception as err:
-            log.error("Module plugin '%s' with error: %s", module, err)
+            failed_plugin = FailedPlugin(str(module), err)
+            ErrorsLoading.append(failed_plugin)
             continue
         for name in plugin_mod.__dict__:
             obj = getattr(plugin_mod, name)

--- a/avocado/plugins/htmlresult.py
+++ b/avocado/plugins/htmlresult.py
@@ -284,6 +284,7 @@ class HTML(plugin.Plugin):
     def configure(self, parser):
         if HTML_REPORT_CAPABLE is False:
             self.enabled = False
+            self.disable_reason = "Python library 'pystache' unavailable"
             return
         self.parser = parser
         self.parser.runner.output.add_argument(

--- a/avocado/plugins/multiplexer.py
+++ b/avocado/plugins/multiplexer.py
@@ -34,6 +34,7 @@ class Multiplexer(plugin.Plugin):
     def configure(self, parser):
         if multiplexer.MULTIPLEX_CAPABLE is False:
             self.enabled = False
+            self.disable_reason = "Python library 'PyYAML' unavailable"
             return
         self.parser = parser.subcommands.add_parser(
             'multiplex',

--- a/avocado/plugins/plugin.py
+++ b/avocado/plugins/plugin.py
@@ -18,6 +18,17 @@ import sys
 """Plugins basic structure."""
 
 
+class FailedPlugin(object):
+
+    name = 'noname'
+    disable_reason = ''
+    enabled = False
+
+    def __init__(self, name, disable_reason):
+        self.name = name
+        self.disable_reason = '%s %s' % (str(disable_reason.__class__.__name__), disable_reason)
+
+
 class Plugin(object):
 
     """
@@ -30,6 +41,7 @@ class Plugin(object):
     enabled = False
     priority = 3
     parser = None
+    disable_reason = ''
 
     def __init__(self, name=None, enabled=None):
         """Creates a new plugin instance.

--- a/avocado/plugins/remote.py
+++ b/avocado/plugins/remote.py
@@ -34,6 +34,7 @@ class RunRemote(plugin.Plugin):
     def configure(self, parser):
         if remote.REMOTE_CAPABLE is False:
             self.enabled = False
+            self.disable_reason = "Python library 'fabric' unavailable"
             return
         username = getpass.getuser()
         msg = 'run on a remote machine arguments'

--- a/avocado/plugins/vm.py
+++ b/avocado/plugins/vm.py
@@ -35,6 +35,7 @@ class RunVM(plugin.Plugin):
     def configure(self, parser):
         if virt.VIRT_CAPABLE is False:
             self.enabled = False
+            self.disable_reason = "Python library 'libvirt-python' unavailable"
             return
         username = getpass.getuser()
         default_hypervisor_uri = 'qemu:///system'


### PR DESCRIPTION
Show a better output to the user in case our plugins are disabled/buggy:

	$ scripts/avocado plugins
	Plugins enabled:
	    Name                Description 
	    config              Implements the avocado 'config' subcommand (Enabled)
	    distro              Implements the avocado 'distro' subcommand (Enabled)
	    exec_path           Implements the avocado 'exec-path' subcommand (Enabled)
	    json                JSON output (Enabled)
	    journal             Test journal (Enabled)
	    multiplexer         Implements the avocado 'multiplex' subcommand (Enabled)
	    plugins_list        Implements the avocado 'plugins' subcommand (Enabled)
	    run_remote          Run tests on a remote machine (Enabled)
	    run_vm              Run tests on a Virtual Machine (Enabled)
	    sysinfo             Collect system information (Enabled)
	    test_lister         Implements the avocado 'list' subcommand (Enabled)
	    test_runner         Implements the avocado 'run' subcommand (Enabled)
	    wrapper             Implements the '--wrapper' flag for the 'run' subcommand (Enabled)
	    xunit               xUnit output (Enabled)
	Plugins disabled:
	    Name                Reason 
	    htmlresult          Python library 'pystache' unavailable (Disabled)
	Plugins that failed to load (bugs/missing libs):
	    Module              Reason 
	    avocado.plugins.gdb NameError name 'ble' is not defined (Disabled)

I understand this still doesn't implement the suggestions made during the sprint review, but I wanted to get it out to public consumption so we can work on the details.