### PR TITLE
avocado.multiplexer: Use !mux and support for recursive mux [v0]

### DIFF
--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -292,6 +292,8 @@ class TreeNode(object):
         node_name = ', '.join(map(str, [getattr(self, v)
                                         for v in attributes
                                         if hasattr(self, v)]))
+        if self.multiplex:
+            node_name += "-<>"
 
         length = max(2, (len(node_name) + 1) if not self.children or show_internal else 3)
         pad = ' ' * length

--- a/avocado/multiplexer.py
+++ b/avocado/multiplexer.py
@@ -19,6 +19,7 @@
 Multiplex and create variants.
 """
 
+import collections
 import itertools
 import logging
 import re
@@ -29,47 +30,66 @@ from avocado.core import tree
 MULTIPLEX_CAPABLE = tree.MULTIPLEX_CAPABLE
 
 
-def tree2pools(node, mux=True):
+class MuxTree(object):
     """
-    Process tree and flattens the structure to remaining leaves and
-    list of lists of leaves per each multiplex group.
-    :param node: Node to start with
-    :return: tuple(`leaves`, `pools`), where `leaves` are directly inherited
-    leaves of this node (no other multiplex in the middle). `pools` is list of
-    lists of directly inherited leaves of the nested multiplex domains.
+    Object representing part of the tree from the root to leaves or another
+    multiplex domain. Recursively it creates multiplexed variants of the full
+    tree.
     """
-    leaves = []
-    pools = []
-    if mux:
-        # TODO: Get this multiplex leaves filters and store them in this pool
-        # to support 2nd level filtering
-        new_leaves = []
-        for child in node.children:
-            if child.is_leaf:
-                new_leaves.append(child)
+    def __init__(self, root):
+        """
+        :param root: Root of this tree slice
+        """
+        self.pools = []
+        for node in self._iter_mux_leaves(root):
+            if node.is_leaf:
+                self.pools.append(node)
             else:
-                _leaves, _pools = tree2pools(child, node.multiplex)
-                new_leaves.extend(_leaves)
-                # TODO: For 2nd level filters store this separately in case
-                # this branch is filtered out
-                pools.extend(_pools)
-        if new_leaves:
-            # TODO: Filter the new_leaves (and new_pools) before merging
-            # into pools
-            pools.append(new_leaves)
-    else:
-        for child in node.children:
-            if child.is_leaf:
-                leaves.append(child)
+                pools = []
+                for mux_child in node.children:
+                    pools.append(MuxTree(mux_child))
+                self.pools.append(pools)
+
+    @staticmethod
+    def _iter_mux_leaves(node):
+        """ yield leaves or muxes of the tree """
+        queue = collections.deque()
+        while node is not None:
+            if node.is_leaf or node.multiplex:
+                yield node
             else:
-                _leaves, _pools = tree2pools(child, node.multiplex)
-                leaves.extend(_leaves)
-                pools.extend(_pools)
-    return leaves, pools
+                queue.extendleft(reversed(node.children))
+            try:
+                node = queue.popleft()
+            except IndexError:
+                raise StopIteration
+
+    def __iter__(self):
+        """
+        Iterates through variants
+        """
+        pools = []
+        for pool in self.pools:
+            if isinstance(pool, list):
+                pools.append(itertools.chain(*pool))
+            else:
+                pools.append([pool])
+        pools = itertools.product(*pools)
+        while True:
+            # TODO: Implement 2nd level filteres here
+            # TODO: This part takes most of the time, optimize it
+            dirty = pools.next()
+            ret = []
+            for _ in dirty:
+                if isinstance(_, list):
+                    ret.extend(_)
+                else:
+                    ret.append(_)
+            yield ret
 
 
-def parse_yamls(input_yamls, filter_only=None, filter_out=None,
-                debug=False):
+def multiplex_yamls(input_yamls, filter_only=None, filter_out=None,
+                    debug=False):
     if filter_only is None:
         filter_only = []
     if filter_out is None:
@@ -77,20 +97,8 @@ def parse_yamls(input_yamls, filter_only=None, filter_out=None,
     input_tree = tree.create_from_yaml(input_yamls, debug)
     # TODO: Process filters and multiplex simultaneously
     final_tree = tree.apply_filters(input_tree, filter_only, filter_out)
-    leaves, pools = tree2pools(final_tree, final_tree.multiplex)
-    if leaves:  # Add remaining leaves (they are not variants, only endpoints
-        pools.extend(leaves)
-    return pools
-
-
-def multiplex_pools(pools):
-    return itertools.product(*pools)
-
-
-def multiplex_yamls(input_yamls, filter_only=None, filter_out=None,
-                    debug=False):
-    pools = parse_yamls(input_yamls, filter_only, filter_out, debug)
-    return multiplex_pools(pools)
+    result = MuxTree(final_tree)
+    return result
 
 
 # TODO: Create multiplexer plugin and split these functions into multiple files
@@ -438,9 +446,9 @@ class Mux(object):
         filter_only = getattr(args, 'filter_only', None)
         filter_out = getattr(args, 'filter_out', None)
         if mux_files:
-            self.pools = parse_yamls(mux_files, filter_only, filter_out)
+            self.variants = multiplex_yamls(mux_files, filter_only, filter_out)
         else:   # no variants
-            self.pools = None
+            self.variants = None
         self._mux_entry = getattr(args, 'mux_entry', None)
         if self._mux_entry is None:
             self._mux_entry = ['/test/*']
@@ -450,9 +458,9 @@ class Mux(object):
         :return: overall number of tests * multiplex variants
         """
         # Currently number of tests is symetrical
-        if self.pools:
+        if self.variants:
             return (len(test_suite) *
-                    sum(1 for _ in multiplex_pools(self.pools)))
+                    sum(1 for _ in self.variants))
         else:
             return len(test_suite)
 
@@ -460,9 +468,9 @@ class Mux(object):
         """
         Processes the template and yields test definition with proper params
         """
-        if self.pools:  # Copy template and modify it's params
+        if self.variants:  # Copy template and modify it's params
             i = None
-            for i, variant in enumerate(multiplex_pools(self.pools)):
+            for i, variant in enumerate(self.variants):
                 test_factory = [template[0], template[1].copy()]
                 test_factory[1]['params'] = (variant, self._mux_entry)
                 yield test_factory

--- a/examples/mux-environment.yaml
+++ b/examples/mux-environment.yaml
@@ -1,22 +1,22 @@
 hw:
-    cpu:
+    cpu: !mux
         intel:
             cpu_CFLAGS: '-march=core2'
         amd:
             cpu_CFLAGS: '-march=athlon64'
         arm:
             cpu_CFLAGS: '-mabi=apcs-gnu -march=armv8-a -mtune=arm8'
-    disk:
+    disk: !mux
         scsi:
             disk_type: 'scsi'
         virtio:
             disk_type: 'virtio'
-distro:
+distro: !mux
     fedora:
         init: 'systemd'
     mint:
         init: 'systemv'
-env:
+env: !mux
     debug:
         opt_CFLAGS: '-O0 -g'
     prod:

--- a/examples/mux-selftest-advanced.yaml
+++ b/examples/mux-selftest-advanced.yaml
@@ -2,7 +2,7 @@
 !using : virt
 # Following line makes it look exactly as mux-selftest.yaml
 !include : mux-selftest.yaml
-distro:
+distro: !mux
     # This line extends the distro branch using include
     !include : mux-selftest-distro.yaml
     # remove node called "mint"
@@ -19,14 +19,7 @@ distro:
         # And this removes the original 'is_cool'
         # Setting happens after ctrl so it should be created'
         !remove_value : is_cool
-# Following node is an empty node with only Control object. During merge
-# it setls /env node as !join (disable multiplexation)
-env: !join
-distro: !join
-    # Set !join here, it won't be overwritten below as it's defined as
-    # &=.
-    mint:   # This won't change anything
-distro:
+distro: !mux
     gentoo:     # This won't change anything
 # This creates new branch the usual way
 new_node:

--- a/examples/mux-selftest-distro.yaml
+++ b/examples/mux-selftest-distro.yaml
@@ -1,8 +1,9 @@
-RHEL:
+!mux
+RHEL: !mux
     enterprise: true
     6:
         init: 'systemv'
     7:
         init: 'systemd'
-gentoo:
+gentoo: !mux
     is_cool: False

--- a/examples/mux-selftest-params.yaml
+++ b/examples/mux-selftest-params.yaml
@@ -1,4 +1,3 @@
-!join
 root: "root"
 cache_test: 'cache'
 diff_domain: "text1"
@@ -7,12 +6,13 @@ ch0:
     clash1: "equal"
     clash3: "also equal"
     ch0.1:
-        ch0.1.1:
+        ch0.1.1: !mux
             ch0.1.1.1:
                 unique1: "unique1"
                 clash1: "equal"
             ch0.1.1.2:
                 unique1: "unique1-2"
+    ch0.1b: !mux
         ch0.1.2:
             unique3: "unique3"
             clash3: "also equal"

--- a/examples/mux-selftest.yaml
+++ b/examples/mux-selftest.yaml
@@ -8,7 +8,7 @@
 # /env/opt_CFLAGS: Should be present in merged node
 # /env/prod/opt_CFLAGS: value should be overridden by latter node
 hw:
-    cpu:
+    cpu: !mux
         joinlist:
             - first_item
         intel:
@@ -18,7 +18,7 @@ hw:
             cpu_CFLAGS: '-march=athlon64'
         arm:
             cpu_CFLAGS: '-mabi=apcs-gnu -march=armv8-a -mtune=arm8'
-    disk:
+    disk: !mux
         disk_type: 'virtio'
         corruptlist: 'nonlist'
         scsi:
@@ -26,17 +26,17 @@ hw:
             disk_type: 'scsi'
         virtio:
     corruptlist: ['upper_node_list']
-distro:     # This node is set as !multiplex below
+distro: !mux     # This node is set as !multiplex below
     fedora:
         init: 'systemd'
-env:
+env: !mux
     opt_CFLAGS: '-Os'
     prod:
         opt_CFLAGS: 'THIS SHOULD GET OVERWRITTEN'
-env:
+env: !mux
     prod:
         opt_CFLAGS: '-O2'
-distro:
+distro: !mux
     mint:
         init: 'systemv'
 

--- a/examples/tests/doublefree_nasty.py.data/iterations.yaml
+++ b/examples/tests/doublefree_nasty.py.data/iterations.yaml
@@ -1,4 +1,4 @@
-iterations:
+iterations: !mux
     1:
     2:
     3:

--- a/examples/tests/env_variables.sh.data/env_variables.yaml
+++ b/examples/tests/env_variables.sh.data/env_variables.yaml
@@ -1,3 +1,4 @@
+!mux
 short:
     CUSTOM_VARIABLE: A
 medium:

--- a/examples/tests/multiplextest.py.data/multiplextest.yaml
+++ b/examples/tests/multiplextest.py.data/multiplextest.yaml
@@ -1,4 +1,4 @@
-env:
+env: !mux
     production:
        malloc_perturb:  no
        gcc_flags:  -O3
@@ -8,11 +8,11 @@ env:
 
 host:
     kernel_config:
-        page_size:
+        page_size: !mux
             default:
             huge_pages:
                 huge_pages:  yes
-        numa:
+        numa: !mux
             default:
             numa_ballance_aggressive:
                 numa_balancing:  1
@@ -24,8 +24,8 @@ host:
                 numa_balancing_scan_size_mb:  32
 
 guest:
-    os: !join
-        windows:
+    os: !mux
+        windows: !mux
             os_type: windows
             xp:
                 win: xp
@@ -33,7 +33,7 @@ guest:
                 win: 2k12
             7:
                 win: 7
-        linux:
+        linux: !mux
             os_type:  linux
             fedora:
                 distro:  fedora
@@ -41,12 +41,12 @@ guest:
                 distro:  ubuntu
 
 hardware:
-    disks:
+    disks: !mux
         ide:
             drive_format: ide
         scsi:
             drive_format: scsi
-    network:
+    network: !mux
         rtl_8139:
             nic_model: rtl8139
         e1000:
@@ -55,15 +55,15 @@ hardware:
             nic_model: virtio
             enable_msix_vectors: yes
 
-tests:
-    sync_test:
+tests: !mux
+    sync_test: !mux
         standard:
             sync_timeout: 30
             sync_tries:   10
         aggressive:
             sync_timeout: 10
             sync_tries:   20
-    ping_test:
+    ping_test: !mux
         standard:
             ping_tries:   10
             ping_timeout: 20

--- a/examples/tests/raise.py.data/raise.yaml
+++ b/examples/tests/raise.py.data/raise.yaml
@@ -1,3 +1,4 @@
+!mux
 sigint:
     signal_number: 2
 siguser1:

--- a/examples/tests/sleeptenmin.py.data/sleeptenmin.mplx
+++ b/examples/tests/sleeptenmin.py.data/sleeptenmin.mplx
@@ -1,20 +1,18 @@
-variants:
-    - sleeptenmin:
-        variants:
-            - builtin:
-                sleep_method = builtin
-            - shell:
-                sleep_method = shell
-        variants:
-            - one_cycle:
-                sleep_cycles = 1
-                sleep_length = 600
-            - six_cycles:
-                sleep_cycles = 6
-                sleep_length = 100
-            - one_hundred_cycles:
-                sleep_cycles = 100
-                sleep_length = 6
-            - six_hundred_cycles:
-                sleep_cycles = 600
-                sleep_length = 1
+sleeptenmin: !mux
+    builtin:
+        sleep_method: builtin
+    shell:
+        sleep_method: shell
+variants: !mux
+    one_cycle:
+        sleep_cycles: 1
+        sleep_length: 600
+    six_cycles:
+        sleep_cycles: 6
+        sleep_length: 100
+    one_hundred_cycles:
+        sleep_cycles: 100
+        sleep_length: 6
+    six_hundred_cycles:
+        sleep_cycles: 600
+        sleep_length: 1

--- a/examples/tests/sleeptest.py.data/sleeptest.yaml
+++ b/examples/tests/sleeptest.py.data/sleeptest.yaml
@@ -1,3 +1,4 @@
+!mux
 !using : test
 short:
     sleep_length: 0.5

--- a/examples/tests/synctest.py.data/synctest.yaml
+++ b/examples/tests/synctest.py.data/synctest.yaml
@@ -1,12 +1,12 @@
 sync_tarball: synctest.tar.bz2
-loop:
+loop: !mux
     short:
         sync_loop:  10
     medium:
         sync_loop: 50
     long:
         sync_loop: 100
-length:
+length: !mux
     short:
         sync_length: 100
     medium:

--- a/examples/tests/whiteboard.py.data/whiteboard.yaml
+++ b/examples/tests/whiteboard.py.data/whiteboard.yaml
@@ -1,15 +1,15 @@
-source:
+source: !mux
     string:
         whiteboard_data_text: 'foo bar foo baz'
     urandom:
         whiteboard_data_file: '/dev/urandom'
 
-iterations:
+iterations: !mux
     single:
         whiteboard_writes: 1
     dozen:
         whiteboard_writes: 12
-size:
+size: !mux
     onekilo:
         whiteboard_data_size: 1024
     onemega:

--- a/selftests/all/unit/avocado/tree_unittest.py
+++ b/selftests/all/unit/avocado/tree_unittest.py
@@ -170,20 +170,20 @@ class TestTree(unittest.TestCase):
         self.assertEqual({'new_value': 'something'},
                          oldroot.children[3].children[0].children[0].value)
         # multiplex root (always True)
-        self.assertEqual(tree2.multiplex, True)
+        self.assertEqual(tree2.multiplex, False)
         # multiplex /virt/
-        self.assertEqual(tree2.children[0].multiplex, True)
+        self.assertEqual(tree2.children[0].multiplex, False)
         # multiplex /virt/hw
-        self.assertEqual(tree2.children[0].children[0].multiplex, True)
+        self.assertEqual(tree2.children[0].children[0].multiplex, False)
         # multiplex /virt/distro
-        self.assertEqual(tree2.children[0].children[1].multiplex, False)
+        self.assertEqual(tree2.children[0].children[1].multiplex, True)
         # multiplex /virt/env
-        self.assertEqual(tree2.children[0].children[2].multiplex, False)
+        self.assertEqual(tree2.children[0].children[2].multiplex, True)
         # multiplex /virt/absolutly
-        self.assertEqual(tree2.children[0].children[3].multiplex, True)
+        self.assertEqual(tree2.children[0].children[3].multiplex, False)
         # multiplex /virt/distro/fedora
         self.assertEqual(tree2.children[0].children[1].children[0].multiplex,
-                         True)
+                         False)
 
 
 class TestPathParent(unittest.TestCase):


### PR DESCRIPTION
This patch modifies the multiplexer logic to support full recursive
multiplexation, unlike the old version which only flattened the
multiplexed nodes. This allows greater flexibility.

Additionally it removes the !join flag and inverts the logic to use !mux
instead. By default leaves are not multiplexed and all are part of the
current params. Users can specify exact nodes which get multiplexed by
using !mux keyword.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>

_PS: Documentation was not modified and the code is not optimized (it's 20-times slower than previous version, still it's incomparably faster then the original solution so it's probably not that bad)_