### PR TITLE
avocado/utils/data_factory.py: replace prefix of temporary directory nam...

### DIFF
--- a/avocado/utils/data_factory.py
+++ b/avocado/utils/data_factory.py
@@ -69,7 +69,7 @@ def make_dir_and_populate(basedir='/tmp'):
     :rtype: str
     """
     try:
-        path = tempfile.mkdtemp(prefix='trinity-victims',
+        path = tempfile.mkdtemp(prefix='avocado-make-dir-and-populate',
                                 dir=basedir)
         n_files = _RAND_POOL.randint(100, 150)
         for _ in xrange(n_files):


### PR DESCRIPTION
...e

The prefix name is a leftover from a test refactor. Let's replace it
by a more sensible name.

Signed-off-by: Cleber Rosa <crosa@redhat.com>