### PR TITLE
Plugins improve list view [v2]

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -45,10 +45,10 @@ from avocado.settings import settings
 
 try:
     from avocado.core.plugins import htmlresult
+    HTML_REPORT_SUPPORT = True
 except ImportError:
     HTML_REPORT_SUPPORT = False
-else:
-    HTML_REPORT_SUPPORT = htmlresult.HTML_REPORT_CAPABLE
+
 
 _NEW_ISSUE_LINK = 'https://github.com/avocado-framework/avocado/issues/new'
 

--- a/avocado/core/plugins/builtin.py
+++ b/avocado/core/plugins/builtin.py
@@ -36,6 +36,8 @@ Exclude = ['avocado.core.plugins.__init__',
 
 Builtins = [x for x in Modules if x not in Exclude]
 
+ErrorsLoading = []
+
 
 def load_builtins():
     """
@@ -47,11 +49,10 @@ def load_builtins():
     for module in Builtins:
         try:
             plugin_mod = import_module(module)
-        except ImportError as err:
-            log.error("Could not import module plugin '%s': %s", module, err)
-            continue
         except Exception as err:
-            log.error("Module plugin '%s' with error: %s", module, err)
+            name = str(module)
+            reason = '%s %s' % (str(err.__class__.__name__), err)
+            ErrorsLoading.append((name, reason))
             continue
         for name in plugin_mod.__dict__:
             obj = getattr(plugin_mod, name)

--- a/avocado/core/plugins/htmlresult.py
+++ b/avocado/core/plugins/htmlresult.py
@@ -20,13 +20,7 @@ import shutil
 import sys
 import time
 import subprocess
-
-try:
-    import pystache
-except ImportError:
-    HTML_REPORT_CAPABLE = False
-else:
-    HTML_REPORT_CAPABLE = True
+import pystache
 
 from avocado import runtime
 from avocado.core import exit_codes
@@ -282,9 +276,6 @@ class HTML(plugin.Plugin):
     enabled = True
 
     def configure(self, parser):
-        if HTML_REPORT_CAPABLE is False:
-            self.enabled = False
-            return
         self.parser = parser
         self.parser.runner.output.add_argument(
             '--html', type=str,

--- a/avocado/core/plugins/manager.py
+++ b/avocado/core/plugins/manager.py
@@ -35,7 +35,6 @@ class PluginManager(object):
 
     def __init__(self):
         self.plugins = []
-        self.disabled_plugins = []
 
     def add_plugin(self, plugin):
         self.plugins.append(plugin)


### PR DESCRIPTION
Show a better output to the user in case our plugins are disabled or unloadable.

Changes from v1:

* Instead of guessing the plugin disable cause, use a more generic but accurate description.  The description chosen is to simply say that the plugin was disabled during configuration (`configure()`), which is often done, but not limited to, missing dependencies.
* Changed the presentation from having colored `Enabled` or `Disabled` at the RHS of the plugin description to a single colored header.
* Increased one space in the formatting string (`format_str`)
* Dropped the use of FailedPlugin in favor of a simpler (name, reason) tuple.
* Catch a single, and more broad `Exception` since `ImportError`s will also be caught and treated the same way.
