### PR TITLE
Documentation: Test API and module dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ branches:
 
 before_install:
     - sudo apt-get update
-    - sudo apt-get -y --force-yes install python-libvirt python-lzma libyaml-dev
+    - sudo apt-get -y --force-yes install python-libvirt python-lzma libyaml-dev graphviz
 
 install:
     - pip install -r requirements-travis.txt

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -39,40 +39,43 @@ help:
 	@echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
 
 clean:
-	-rm -rf $(BUILDDIR)
+	-rm -rf $(BUILDDIR) source/modules.png
 
-html:
+pics:
+	cd .. && (sfood --internal avocado | sfood-graph --remove-extensions | grep -v 'size = "8,10"' | sed 's/fontsize=7/fontsize=16/' | dot -Tpng -o docs/source/modules.png)
+
+html: pics
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
-dirhtml:
+dirhtml: pics
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
 
-singlehtml:
+singlehtml: pics
 	$(SPHINXBUILD) -b singlehtml $(ALLSPHINXOPTS) $(BUILDDIR)/singlehtml
 	@echo
 	@echo "Build finished. The HTML page is in $(BUILDDIR)/singlehtml."
 
-pickle:
+pickle: pics
 	$(SPHINXBUILD) -b pickle $(ALLSPHINXOPTS) $(BUILDDIR)/pickle
 	@echo
 	@echo "Build finished; now you can process the pickle files."
 
-json:
+json: pics
 	$(SPHINXBUILD) -b json $(ALLSPHINXOPTS) $(BUILDDIR)/json
 	@echo
 	@echo "Build finished; now you can process the JSON files."
 
-htmlhelp:
+htmlhelp: pics
 	$(SPHINXBUILD) -b htmlhelp $(ALLSPHINXOPTS) $(BUILDDIR)/htmlhelp
 	@echo
 	@echo "Build finished; now you can run HTML Help Workshop with the" \
 	      ".hhp project file in $(BUILDDIR)/htmlhelp."
 
-qthelp:
+qthelp: pics
 	$(SPHINXBUILD) -b qthelp $(ALLSPHINXOPTS) $(BUILDDIR)/qthelp
 	@echo
 	@echo "Build finished; now you can run "qcollectiongenerator" with the" \
@@ -81,7 +84,7 @@ qthelp:
 	@echo "To view the help file:"
 	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/avocado.qhc"
 
-devhelp:
+devhelp: pics
 	$(SPHINXBUILD) -b devhelp $(ALLSPHINXOPTS) $(BUILDDIR)/devhelp
 	@echo
 	@echo "Build finished."
@@ -90,42 +93,42 @@ devhelp:
 	@echo "# cp -r $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/books/Avocado"
 	@echo "# devhelp"
 
-epub:
+epub: pics
 	$(SPHINXBUILD) -b epub $(ALLSPHINXOPTS) $(BUILDDIR)/epub
 	@echo
 	@echo "Build finished. The epub file is in $(BUILDDIR)/epub."
 
-latex:
+latex: pics
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
 	@echo
 	@echo "Build finished; the LaTeX files are in $(BUILDDIR)/latex."
 	@echo "Run \`make' in that directory to run these through (pdf)latex" \
 	      "(use \`make latexpdf' here to do that automatically)."
 
-latexpdf:
+latexpdf: pics
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
 	@echo "Running LaTeX files through pdflatex..."
 	$(MAKE) -C $(BUILDDIR)/latex all-pdf
 	@echo "pdflatex finished; the PDF files are in $(BUILDDIR)/latex."
 
-text:
+text: pics
 	$(SPHINXBUILD) -b text $(ALLSPHINXOPTS) $(BUILDDIR)/text
 	@echo
 	@echo "Build finished. The text files are in $(BUILDDIR)/text."
 
-man:
+man: pics
 	$(SPHINXBUILD) -b man $(ALLSPHINXOPTS) $(BUILDDIR)/man
 	@echo
 	@echo "Build finished. The manual pages are in $(BUILDDIR)/man."
 
-texinfo:
+texinfo: pics
 	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo
 	@echo
 	@echo "Build finished. The Texinfo files are in $(BUILDDIR)/texinfo."
 	@echo "Run \`make' in that directory to run these through makeinfo" \
 	      "(use \`make info' here to do that automatically)."
 
-info:
+info: pics
 	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo
 	@echo "Running Texinfo files through makeinfo..."
 	make -C $(BUILDDIR)/texinfo info

--- a/docs/source/DevelopmentTips.rst
+++ b/docs/source/DevelopmentTips.rst
@@ -150,3 +150,7 @@ My usual workflow is:
 
 This way you always have all the files present and you can easily resume
 your work.
+
+Module Dependencies
+===================
+.. figure:: modules.png

--- a/docs/source/Introduction.rst
+++ b/docs/source/Introduction.rst
@@ -4,15 +4,22 @@ About Avocado
 =============
 
 Avocado is a set of tools and libraries (what people call these days a framework)
-to perform automated testing.
+to perform automated testing. the tests looks like Python unittest but it
+has extra functionalities to perform different kind of tests.
 
 Avocado is composed by:
 
-* Programs that let you run tests. Those tests can be either written on your
+* A test runner that lets you execute tests. Those tests can be either written on your
   language of choice, or use the python API available. In both cases, you get
   facilities such as automated log and system information collection.
 
 * APIs that help you write tests in a concise, yet expressive way.
+  The Test API is the whole set of modules, classes and functions available
+  under the ``avocado`` main module, excluding the `avocado.core` module and
+  their submodules, which is part of application's infrastructure.
+
+* Plugins, where you can extend and add more functionality to the Avocado
+  framework.
 
 Avocado tries as much as possible to comply with standard python testing
 technology. Tests written using the avocado API are derived from the unittest

--- a/requirements-selftests.txt
+++ b/requirements-selftests.txt
@@ -3,6 +3,8 @@
 nose>=1.3.0
 # sphinx (doc build test)
 Sphinx>=1.3b1
+# modules.png
+snakedog>=1.4
 # flexmock (some unittests use it)
 flexmock>=0.9.7
 # inspektor (static and style checks)

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -3,6 +3,7 @@ fabric==1.10.0
 nose==1.3.4
 pystache==0.5.4
 Sphinx==1.3b1
+snakedog==1.4
 flexmock==0.9.7
 inspektor==0.1.15
 pep8==1.6.2


### PR DESCRIPTION
* In the documentation, explain that the test API is everything
under avocado module, but excludes avocado.core.
* Also, Avocado works with plugins, so let's talk about it, in the introduction too.
* Creates a graph (with help of snakedog tool) of Avocado module dependencies and include this information inside "Developement Tips" section, under "Module Dependencies" documentation.