### PR TITLE
Cyclical module dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,9 @@ clean:
 check:
 	selftests/checkall
 
+check_cyclical:
+	selftests/cyclical_deps avocado
+
 link:
 	test -d ../avocado-virt/avocado/virt && ln -s ../../avocado-virt/avocado/virt avocado || true
 	test -f ../avocado-virt/avocado/plugins/virt.py && ln -s ../../../avocado-virt/avocado/plugins/virt.py avocado/plugins/ || true

--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -18,7 +18,7 @@
 #
 
 """
-Tree data strucure with nodes.
+Tree data strucure with nodes and YAML.
 
 This tree structure (Tree drawing code) was inspired in the base tree data
 structure of the ETE 2 project:
@@ -48,6 +48,7 @@ else:
     except ImportError:
         from yaml import Loader
 
+from avocado.core import tree_node
 
 # Mapping for yaml flags
 YAML_INCLUDE = 0
@@ -58,283 +59,6 @@ YAML_JOIN = 4
 
 __RE_FILE_SPLIT = re.compile(r'(?<!\\):')   # split by ':' but not '\\:'
 __RE_FILE_SUBS = re.compile(r'(?<!\\)\\:')  # substitute '\\:' but not '\\\\:'
-
-
-class Control(object):  # Few methods pylint: disable=R0903
-
-    """ Container used to identify node vs. control sequence """
-
-    def __init__(self, code, value=None):
-        self.code = code
-        self.value = value
-
-
-class TreeNode(object):
-
-    """
-    Class for bounding nodes into tree-structure.
-    """
-
-    def __init__(self, name='', value=None, parent=None, children=None):
-        if value is None:
-            value = {}
-        if children is None:
-            children = []
-        self.name = name
-        self.value = value
-        self.parent = parent
-        self.children = []
-        self._environment = None
-        self.environment_origin = {}
-        self.ctrl = []
-        self.multiplex = True
-        for child in children:
-            self.add_child(child)
-
-    def __repr__(self):
-        return 'TreeNode(name=%r)' % self.name
-
-    def __str__(self):
-        variables = ['%s=%s' % (k, v) for k, v in self.environment.items()]
-        return '%s: %s' % (self.path, ', '.join(variables))
-
-    def __len__(self):
-        """ Return number of descended leaf nodes """
-        return len(tuple(self.iter_leaves()))
-
-    def __iter__(self):
-        """ Iterate through descended leaf nodes """
-        return self.iter_leaves()
-
-    def __eq__(self, other):
-        """ Compares node to other node or string to name of this node """
-        if isinstance(other, str):  # Compare names
-            if self.name == other:
-                return True
-        else:
-            for attr in ('name', 'value', 'children'):
-                if getattr(self, attr) != getattr(other, attr):
-                    return False
-            return True
-
-    def add_child(self, node):
-        """
-        Append node as child. Nodes with the same name gets merged into the
-        existing position.
-        """
-        if isinstance(node, TreeNode):
-            if node.name in self.children:
-                self.children[self.children.index(node.name)].merge(node)
-            else:
-                node.parent = self
-                self.children.append(node)
-        else:
-            raise ValueError('Bad node type.')
-
-    def merge(self, other):
-        """
-        Merges `other` node into this one without checking the name of the
-        other node. New values are appended, existing values overwritten
-        and unaffected ones are kept. Then all other node children are
-        added as children (recursively they get either appended at the end
-        or merged into existing node in the previous position.
-        """
-        for ctrl in other.ctrl:
-            if isinstance(ctrl, Control):
-                if ctrl.code == YAML_REMOVE_NODE:
-                    remove = []
-                    regexp = re.compile(ctrl.value)
-                    for child in self.children:
-                        if regexp.match(child.name):
-                            remove.append(child)
-                    for child in remove:
-                        self.children.remove(child)
-                elif ctrl.code == YAML_REMOVE_VALUE:
-                    remove = []
-                    regexp = re.compile(ctrl.value)
-                    for key in self.value.iterkeys():
-                        if regexp.match(key):
-                            remove.append(key)
-                    for key in remove:
-                        self.value.pop(key, None)
-        self.multiplex &= other.multiplex
-        self.value.update(other.value)
-        for child in other.children:
-            self.add_child(child)
-
-    @property
-    def is_leaf(self):
-        """ Is this a leaf node? """
-        return not self.children
-
-    @property
-    def root(self):
-        """ Root of this tree """
-        return self.get_root()
-
-    def get_root(self):
-        """ Get root of this tree """
-        root = self
-        for root in self.iter_parents():
-            pass
-        return root
-
-    def iter_parents(self):
-        """ Iterate through parent nodes to root """
-        node = self.parent
-        while True:
-            if node is None:
-                raise StopIteration
-            yield node
-            node = node.parent
-
-    @property
-    def parents(self):
-        """ List of parent nodes """
-        return self.get_parents()
-
-    def get_parents(self):
-        """ Get list of parent nodes """
-        return list(self.iter_parents())
-
-    @property
-    def path(self):
-        """ Node path """
-        return self.get_path()
-
-    def get_path(self, sep='/'):
-        """ Get node path """
-        path = [str(self.name)]
-        for node in self.iter_parents():
-            path.append(str(node.name))
-        return sep.join(reversed(path))
-
-    @property
-    def environment(self):
-        """ Node environment (values + preceding envs) """
-        return self.get_environment()
-
-    def get_environment(self):
-        """ Get node environment (values + preceding envs) """
-        if self._environment is None:
-            self._environment = (self.parent.environment.copy()
-                                 if self.parent else {})
-            self.environment_origin = (self.parent.environment_origin.copy()
-                                       if self.parent else {})
-            for key, value in self.value.iteritems():
-                if isinstance(value, list):
-                    if (key in self._environment and
-                            isinstance(self._environment[key], list)):
-                        self._environment[key] = self._environment[key] + value
-                    else:
-                        self._environment[key] = value
-                else:
-                    self._environment[key] = value
-                self.environment_origin[key] = self
-        return self._environment
-
-    def set_environment_dirty(self):
-        """
-        Set the environment cache dirty. You should call this always when
-        you query for the environment and then change the value or structure.
-        Otherwise you'll get the old environment instead.
-        """
-        for child in self.children:
-            child.set_environment_dirty()
-        self._environment = None
-
-    def iter_children_preorder(self):
-        """ Iterate through children """
-        queue = collections.deque()
-        node = self
-        while node is not None:
-            yield node
-            queue.extendleft(reversed(node.children))
-            try:
-                node = queue.popleft()
-            except IndexError:
-                node = None
-
-    def iter_leaves(self):
-        """ Iterate throuh leaf nodes """
-        for node in self.iter_children_preorder():
-            if node.is_leaf:
-                yield node
-
-    def get_leaves(self):
-        """ Get list of leaf nodes """
-        return list(self.iter_leaves())
-
-    def get_ascii(self, show_internal=True, compact=False, attributes=None):
-        """
-        Get ascii-art tree structure
-        :param show_internal: Show intermediary nodes
-        :param compact: Compress the tree vertically
-        :param attributes: List of node attributes to be printed out ['name']
-        :return: string
-        """
-        (lines, _) = self.ascii_art(show_internal=show_internal,
-                                    compact=compact, attributes=attributes)
-        return '\n' + '\n'.join(lines)
-
-    def ascii_art(self, char1='-', show_internal=True, compact=False,
-                  attributes=None):
-        """
-        Generate ascii-art for this node
-        :param char1: Incomming path character [-]
-        :param show_internal: Show intermediary nodes
-        :param compact: Compress the tree vertically
-        :param attributes: List of node attributes to be printed out ['name']
-        :return: list of strings
-        """
-        if not attributes:
-            attributes = ["name"]
-        node_name = ', '.join(map(str, [getattr(self, v)
-                                        for v in attributes
-                                        if hasattr(self, v)]))
-
-        length = max(2, (len(node_name) + 1) if not self.children or show_internal else 3)
-        pad = ' ' * length
-        _pad = ' ' * (length - 1)
-        if not self.is_leaf:
-            mids = []
-            result = []
-            for char in self.children:
-                if len(self.children) == 1:
-                    char2 = '-'
-                elif char is self.children[0]:
-                    char2 = '/'
-                elif char is self.children[-1]:
-                    char2 = '\\'
-                else:
-                    char2 = '-'
-                (clines, mid) = char.ascii_art(char2, show_internal, compact,
-                                               attributes)
-                mids.append(mid + len(result))
-                result.extend(clines)
-                if not compact:
-                    result.append('')
-            if not compact:
-                result.pop()
-            (low, high, end) = (mids[0], mids[-1], len(result))
-            prefixes = ([pad] * (low + 1) + [_pad + '|'] * (high - low - 1) +
-                        [pad] * (end - high))
-            mid = (low + high) / 2
-            prefixes[mid] = char1 + '-' * (length - 2) + prefixes[mid][-1]
-            result = [p + l for (p, l) in zip(prefixes, result)]
-            if show_internal:
-                stem = result[mid]
-                result[mid] = stem[0] + node_name + stem[len(node_name) + 1:]
-            return result, mid
-        else:
-            return [char1 + '-' + node_name], 0
-
-    def detach(self):
-        """ Detach this node from parent """
-        if self.parent:
-            self.parent.children.remove(self)
-            self.parent = None
-        return self
 
 
 class Value(tuple):     # Few methods pylint: disable=R0903
@@ -351,16 +75,16 @@ class ListOfNodeObjects(list):     # Few methods pylint: disable=R0903
     pass
 
 
-def _create_from_yaml(path, cls_node=TreeNode):
+def _create_from_yaml(path, cls_node=tree_node.TreeNode):
     """ Create tree structure from yaml stream """
     def tree_node_from_values(name, values):
         """ Create `name` node and add values  """
         node = cls_node(str(name))
         using = ''
         for value in values:
-            if isinstance(value, TreeNode):
+            if isinstance(value, tree_node.TreeNode):
                 node.add_child(value)
-            elif isinstance(value[0], Control):
+            elif isinstance(value[0], tree_node.Control):
                 if value[0].code == YAML_INCLUDE:
                     # Include file
                     ypath = value[1]
@@ -422,17 +146,17 @@ def _create_from_yaml(path, cls_node=TreeNode):
             objects = mapping_to_tree_loader(loader, obj)
         else:   # This means it's empty node. Don't call mapping_to_tree_loader
             objects = ListOfNodeObjects()
-        objects.append((Control(YAML_JOIN), None))
+        objects.append((tree_node.Control(YAML_JOIN), None))
         return objects
 
     Loader.add_constructor(u'!include',
-                           lambda loader, node: Control(YAML_INCLUDE))
+                           lambda loader, node: tree_node.Control(YAML_INCLUDE))
     Loader.add_constructor(u'!using',
-                           lambda loader, node: Control(YAML_USING))
+                           lambda loader, node: tree_node.Control(YAML_USING))
     Loader.add_constructor(u'!remove_node',
-                           lambda loader, node: Control(YAML_REMOVE_NODE))
+                           lambda loader, node: tree_node.Control(YAML_REMOVE_NODE))
     Loader.add_constructor(u'!remove_value',
-                           lambda loader, node: Control(YAML_REMOVE_VALUE))
+                           lambda loader, node: tree_node.Control(YAML_REMOVE_VALUE))
     Loader.add_constructor(u'!join', join_loader)
     Loader.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
                            mapping_to_tree_loader)
@@ -480,7 +204,7 @@ def create_from_yaml(paths, debug=False):
         data.merge(_create_from_yaml(path, node_cls))
 
     if not debug:
-        data = TreeNode()
+        data = tree_node.TreeNode()
         merge = _merge
     else:
         from avocado.core import tree_debug

--- a/avocado/core/tree_debug.py
+++ b/avocado/core/tree_debug.py
@@ -25,7 +25,7 @@ import itertools
 import os
 
 from avocado.core import output
-from avocado.core.tree import TreeNode
+from avocado.core.tree_node import TreeNode
 
 
 class OutputValue(object):  # only container pylint: disable=R0903

--- a/avocado/core/tree_node.py
+++ b/avocado/core/tree_node.py
@@ -1,0 +1,321 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2014
+# Copyright: Jaime Huerta-Cepas <jhcepas@gmail.com> 2009
+#
+# Authors: Ruda Moura <rmoura@redhat.com>
+#          Lucas Meneghel Rodrigues <lmr@redhat.com>
+#          Jaime Huerta-Cepas <jhcepas@gmail.com>
+#
+
+"""
+Tree data strucure with nodes.
+
+This tree structure (Tree drawing code) was inspired in the base tree data
+structure of the ETE 2 project:
+
+http://pythonhosted.org/ete2/
+
+A library for analysis of phylogenetics trees.
+
+Explicit permission has been given by the copyright owner of ETE 2
+Jaime Huerta-Cepas <jhcepas@gmail.com> to take ideas/use snippets from his
+original base tree code and re-license under GPLv2+, given that GPLv3 and GPLv2
+(used in some avocado files) are incompatible.
+"""
+
+import collections
+import re
+
+# Mapping for yaml flags
+YAML_INCLUDE = 0
+YAML_USING = 1
+YAML_REMOVE_NODE = 2
+YAML_REMOVE_VALUE = 3
+YAML_JOIN = 4
+
+
+class Control(object):  # Few methods pylint: disable=R0903
+
+    """ Container used to identify node vs. control sequence """
+
+    def __init__(self, code, value=None):
+        self.code = code
+        self.value = value
+
+
+class TreeNode(object):
+
+    """
+    Class for bounding nodes into tree-structure.
+    """
+
+    def __init__(self, name='', value=None, parent=None, children=None):
+        if value is None:
+            value = {}
+        if children is None:
+            children = []
+        self.name = name
+        self.value = value
+        self.parent = parent
+        self.children = []
+        self._environment = None
+        self.environment_origin = {}
+        self.ctrl = []
+        self.multiplex = True
+        for child in children:
+            self.add_child(child)
+
+    def __repr__(self):
+        return 'TreeNode(name=%r)' % self.name
+
+    def __str__(self):
+        variables = ['%s=%s' % (k, v) for k, v in self.environment.items()]
+        return '%s: %s' % (self.path, ', '.join(variables))
+
+    def __len__(self):
+        """ Return number of descended leaf nodes """
+        return len(tuple(self.iter_leaves()))
+
+    def __iter__(self):
+        """ Iterate through descended leaf nodes """
+        return self.iter_leaves()
+
+    def __eq__(self, other):
+        """ Compares node to other node or string to name of this node """
+        if isinstance(other, str):  # Compare names
+            if self.name == other:
+                return True
+        else:
+            for attr in ('name', 'value', 'children'):
+                if getattr(self, attr) != getattr(other, attr):
+                    return False
+            return True
+
+    def add_child(self, node):
+        """
+        Append node as child. Nodes with the same name gets merged into the
+        existing position.
+        """
+        if isinstance(node, TreeNode):
+            if node.name in self.children:
+                self.children[self.children.index(node.name)].merge(node)
+            else:
+                node.parent = self
+                self.children.append(node)
+        else:
+            raise ValueError('Bad node type.')
+
+    def merge(self, other):
+        """
+        Merges `other` node into this one without checking the name of the
+        other node. New values are appended, existing values overwritten
+        and unaffected ones are kept. Then all other node children are
+        added as children (recursively they get either appended at the end
+        or merged into existing node in the previous position.
+        """
+        for ctrl in other.ctrl:
+            if isinstance(ctrl, Control):
+                if ctrl.code == YAML_REMOVE_NODE:
+                    remove = []
+                    regexp = re.compile(ctrl.value)
+                    for child in self.children:
+                        if regexp.match(child.name):
+                            remove.append(child)
+                    for child in remove:
+                        self.children.remove(child)
+                elif ctrl.code == YAML_REMOVE_VALUE:
+                    remove = []
+                    regexp = re.compile(ctrl.value)
+                    for key in self.value.iterkeys():
+                        if regexp.match(key):
+                            remove.append(key)
+                    for key in remove:
+                        self.value.pop(key, None)
+        self.multiplex &= other.multiplex
+        self.value.update(other.value)
+        for child in other.children:
+            self.add_child(child)
+
+    @property
+    def is_leaf(self):
+        """ Is this a leaf node? """
+        return not self.children
+
+    @property
+    def root(self):
+        """ Root of this tree """
+        return self.get_root()
+
+    def get_root(self):
+        """ Get root of this tree """
+        root = self
+        for root in self.iter_parents():
+            pass
+        return root
+
+    def iter_parents(self):
+        """ Iterate through parent nodes to root """
+        node = self.parent
+        while True:
+            if node is None:
+                raise StopIteration
+            yield node
+            node = node.parent
+
+    @property
+    def parents(self):
+        """ List of parent nodes """
+        return self.get_parents()
+
+    def get_parents(self):
+        """ Get list of parent nodes """
+        return list(self.iter_parents())
+
+    @property
+    def path(self):
+        """ Node path """
+        return self.get_path()
+
+    def get_path(self, sep='/'):
+        """ Get node path """
+        path = [str(self.name)]
+        for node in self.iter_parents():
+            path.append(str(node.name))
+        return sep.join(reversed(path))
+
+    @property
+    def environment(self):
+        """ Node environment (values + preceding envs) """
+        return self.get_environment()
+
+    def get_environment(self):
+        """ Get node environment (values + preceding envs) """
+        if self._environment is None:
+            self._environment = (self.parent.environment.copy()
+                                 if self.parent else {})
+            self.environment_origin = (self.parent.environment_origin.copy()
+                                       if self.parent else {})
+            for key, value in self.value.iteritems():
+                if isinstance(value, list):
+                    if (key in self._environment and
+                            isinstance(self._environment[key], list)):
+                        self._environment[key] = self._environment[key] + value
+                    else:
+                        self._environment[key] = value
+                else:
+                    self._environment[key] = value
+                self.environment_origin[key] = self
+        return self._environment
+
+    def set_environment_dirty(self):
+        """
+        Set the environment cache dirty. You should call this always when
+        you query for the environment and then change the value or structure.
+        Otherwise you'll get the old environment instead.
+        """
+        for child in self.children:
+            child.set_environment_dirty()
+        self._environment = None
+
+    def iter_children_preorder(self):
+        """ Iterate through children """
+        queue = collections.deque()
+        node = self
+        while node is not None:
+            yield node
+            queue.extendleft(reversed(node.children))
+            try:
+                node = queue.popleft()
+            except IndexError:
+                node = None
+
+    def iter_leaves(self):
+        """ Iterate throuh leaf nodes """
+        for node in self.iter_children_preorder():
+            if node.is_leaf:
+                yield node
+
+    def get_leaves(self):
+        """ Get list of leaf nodes """
+        return list(self.iter_leaves())
+
+    def get_ascii(self, show_internal=True, compact=False, attributes=None):
+        """
+        Get ascii-art tree structure
+        :param show_internal: Show intermediary nodes
+        :param compact: Compress the tree vertically
+        :param attributes: List of node attributes to be printed out ['name']
+        :return: string
+        """
+        (lines, _) = self.ascii_art(show_internal=show_internal,
+                                    compact=compact, attributes=attributes)
+        return '\n' + '\n'.join(lines)
+
+    def ascii_art(self, char1='-', show_internal=True, compact=False,
+                  attributes=None):
+        """
+        Generate ascii-art for this node
+        :param char1: Incomming path character [-]
+        :param show_internal: Show intermediary nodes
+        :param compact: Compress the tree vertically
+        :param attributes: List of node attributes to be printed out ['name']
+        :return: list of strings
+        """
+        if not attributes:
+            attributes = ["name"]
+        node_name = ', '.join(map(str, [getattr(self, v)
+                                        for v in attributes
+                                        if hasattr(self, v)]))
+
+        length = max(2, (len(node_name) + 1) if not self.children or show_internal else 3)
+        pad = ' ' * length
+        _pad = ' ' * (length - 1)
+        if not self.is_leaf:
+            mids = []
+            result = []
+            for char in self.children:
+                if len(self.children) == 1:
+                    char2 = '-'
+                elif char is self.children[0]:
+                    char2 = '/'
+                elif char is self.children[-1]:
+                    char2 = '\\'
+                else:
+                    char2 = '-'
+                (clines, mid) = char.ascii_art(char2, show_internal, compact,
+                                               attributes)
+                mids.append(mid + len(result))
+                result.extend(clines)
+                if not compact:
+                    result.append('')
+            if not compact:
+                result.pop()
+            (low, high, end) = (mids[0], mids[-1], len(result))
+            prefixes = ([pad] * (low + 1) + [_pad + '|'] * (high - low - 1) +
+                        [pad] * (end - high))
+            mid = (low + high) / 2
+            prefixes[mid] = char1 + '-' * (length - 2) + prefixes[mid][-1]
+            result = [p + l for (p, l) in zip(prefixes, result)]
+            if show_internal:
+                stem = result[mid]
+                result[mid] = stem[0] + node_name + stem[len(node_name) + 1:]
+            return result, mid
+        else:
+            return [char1 + '-' + node_name], 0
+
+    def detach(self):
+        """ Detach this node from parent """
+        if self.parent:
+            self.parent.children.remove(self)
+            self.parent = None
+        return self

--- a/examples/testplans/release.json
+++ b/examples/testplans/release.json
@@ -3,6 +3,12 @@
     "description": "Test Plan to be performed before a release is cut",
 
     "tests": [
+	{"name": "Avocado source is sound",
+	"description": "On your development machine, on a freshen Avocado source to be released, run `$ make check`. Expected result: Make command should say OK."},
+
+	{"name": "Avocado modules does not contains cyclical dependencies",
+	 "description": "Pre-requirements: Python Snakefood (pip install snakefood) and Python NetworkX (yum install python-networkx). On your development machine, on a freshen Avocado source to be released, run `$ make check_cyclical`. Expected result: Make command should say OK."},
+
 	{"name": "Avocado RPM build",
 	 "description": "On your development machine, build the Avocado RPM packages using: `$ make build-rpm-all`. Expected result: SRPM file `SRPMS/avocado-x.y.z-r.distro.src.rpm` and RPM files at `RPMS/noarch`"},
 

--- a/selftests/all/unit/avocado/multiplexer_unittest.py
+++ b/selftests/all/unit/avocado/multiplexer_unittest.py
@@ -4,6 +4,7 @@ import sys
 
 from avocado import multiplexer
 from avocado.core import tree
+from avocado.core import tree_node
 
 if sys.version_info[:2] == (2, 6):
     import unittest2 as unittest
@@ -26,7 +27,7 @@ class TestMultiplex(unittest.TestCase):
     mux_full = tuple(combine(multiplexer.tree2pools(tree)))
 
     def test_empty(self):
-        act = tuple(combine(multiplexer.tree2pools(tree.TreeNode())))
+        act = tuple(combine(multiplexer.tree2pools(tree_node.TreeNode())))
         self.assertEqual(act, ((),))
 
     def test_partial(self):

--- a/selftests/all/unit/avocado/tree_unittest.py
+++ b/selftests/all/unit/avocado/tree_unittest.py
@@ -7,6 +7,7 @@ else:
     import unittest
 
 from avocado.core import tree
+from avocado.core import tree_node
 
 
 class TestTree(unittest.TestCase):
@@ -14,7 +15,7 @@ class TestTree(unittest.TestCase):
     tree = tree.create_from_yaml(['examples/mux-selftest.yaml'])
 
     def test_node_order(self):
-        self.assertIsInstance(self.tree, tree.TreeNode)
+        self.assertIsInstance(self.tree, tree_node.TreeNode)
         self.assertEqual('hw', self.tree.children[0])
         self.assertEqual({'cpu_CFLAGS': '-march=core2'},
                          self.tree.children[0].children[0].children[0].value)
@@ -34,7 +35,7 @@ class TestTree(unittest.TestCase):
         tree2 = copy.deepcopy(self.tree)
         self.assertEqual(self.tree, tree2)
         # Additional node
-        child = tree.TreeNode("20", {'name': 'Heisenbug'})
+        child = tree_node.TreeNode("20", {'name': 'Heisenbug'})
         tree2.children[1].children[1].add_child(child)
         self.assertNotEqual(self.tree, tree2)
         # Should match again
@@ -47,7 +48,7 @@ class TestTree(unittest.TestCase):
         # Different value
         tree2.children[0].children[0].children[0].value = {'something': 'else'}
         self.assertNotEqual(self.tree.children[0], tree2.children[0])
-        tree3 = tree.TreeNode()
+        tree3 = tree_node.TreeNode()
         self.assertNotEqual(tree3, tree2)
         # Merge
         tree3.merge(tree2)
@@ -131,15 +132,15 @@ class TestTree(unittest.TestCase):
 
     def test_merge_trees(self):
         tree2 = copy.deepcopy(self.tree)
-        tree3 = tree.TreeNode()
-        tree3.add_child(tree.TreeNode('hw', {'another_value': 'bbb'}))
-        tree3.children[0].add_child(tree.TreeNode('nic'))
-        tree3.children[0].children[0].add_child(tree.TreeNode('default'))
-        tree3.children[0].children[0].add_child(tree.TreeNode('virtio',
-                                                              {'nic': 'virtio'}
-                                                              ))
-        tree3.children[0].add_child(tree.TreeNode('cpu',
-                                                  {'test_value': ['z']}))
+        tree3 = tree_node.TreeNode()
+        tree3.add_child(tree_node.TreeNode('hw', {'another_value': 'bbb'}))
+        tree3.children[0].add_child(tree_node.TreeNode('nic'))
+        tree3.children[0].children[0].add_child(tree_node.TreeNode('default'))
+        tree3.children[0].children[0].add_child(tree_node.TreeNode('virtio',
+                                                                   {'nic': 'virtio'}
+                                                                   ))
+        tree3.children[0].add_child(tree_node.TreeNode('cpu',
+                                                       {'test_value': ['z']}))
         tree2.merge(tree3)
         exp = ['intel', 'amd', 'arm', 'scsi', 'virtio', 'default', 'virtio',
                'fedora', 'mint', 'prod']

--- a/selftests/cyclical_deps
+++ b/selftests/cyclical_deps
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Simple script to test cyclical dependencies in modules.
+
+Requirements:
+    - SnakeFood (pip install snakefood)
+    - NetworkX (yum/apt-get install python-networkx)
+"""
+
+__author__ = 'Ruda Moura <rmoura@redhat.com>'
+
+import os
+import sys
+import subprocess
+import tempfile
+
+try:
+    import networkx as nx
+except ImportError:
+    print >>sys.stderr, "NetworkX is not installed and is required!"
+    print >>sys.stderr, "Please, install 'python-networkx' with yum or apt."
+    sys.exit(2)
+
+
+def has_snakefood():
+    with open(os.devnull, 'w') as null:
+        try:
+            cmd = ['sfood', '-h']
+            res = subprocess.call(cmd, stdout=null)
+        except Exception as e:
+            print >>sys.stderr, "Could not find sfood utility: %s: %s" % (cmd, e)
+            print >>sys.stderr, "Did you forget to 'pip install python-snakefood'?"
+            return False
+    return True
+
+
+def generate_dot_file(path):
+    cmdline = 'sfood --internal %s | sfood-graph --remove-extensions'
+    output = subprocess.check_output(cmdline % path, shell=True)
+    tmp = tempfile.mktemp()
+    fd = open(tmp, 'w').write(output)
+    return tmp
+
+
+def cyclical_deps(path_dot):
+    graph = nx.DiGraph(nx.read_dot(path_dot))
+    cycles = list(nx.simple_cycles(graph))
+    if cycles:
+        print 'Found cyclical dependencies in module(s):'
+        for cycle in cycles:
+            print '*', ' <=> '.join(cycle)
+        return True
+    else:
+        print 'OK (no cyclical dependencies found)'
+        return False
+
+
+if __name__ == '__main__':
+    if sys.argv[1:] and has_snakefood():
+        dot = generate_dot_file(sys.argv[1])
+        has_cycles = cyclical_deps(dot)
+        os.remove(dot)
+        if has_cycles:
+            sys.exit(1)
+    else:
+        sys.exit(2)
+    sys.exit(0)


### PR DESCRIPTION
This pull requests aims to contribute to remove a cyclical module dependency between the Avocado modules `avocado.core.tree` and `avocado.core.tree_debug`. It also contributes to avoid that we introduce new cyclical dependencies by aims of a new selftest called `cyclical_deps`, which may be run the following make rule: `make check_cyclical' in the top level of Avocado. And finally, there's a new test plan to check for sanity in Avocado sources.