### PR TITLE
avocado.multiplexer: Use !mux and support for recursive mux [v2]

### DIFF
--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -455,7 +455,7 @@ def _create_from_yaml(path, cls_node=TreeNode):
 
     # Add prefix
     if using:
-        loaded_tree = cls_node(using.pop(), children=loaded_tree.children)
+        loaded_tree.name = using.pop()
         while True:
             if not using:
                 break

--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -292,6 +292,8 @@ class TreeNode(object):
         node_name = ', '.join(map(str, [getattr(self, v)
                                         for v in attributes
                                         if hasattr(self, v)]))
+        if self.multiplex:
+            node_name += "-<>"
 
         length = max(2, (len(node_name) + 1) if not self.children or show_internal else 3)
         pad = ' ' * length

--- a/avocado/multiplexer.py
+++ b/avocado/multiplexer.py
@@ -250,63 +250,14 @@ class AvocadoParams(object):
             logging.getLogger("avocado.test").warn(msg)
             return self.get(attr)
 
-    def get(self, *args, **kwargs):
+    def get(self, key, path=None, default=None):
         """
-        Retrieve params
-
-        Old API: ``params.get(key, failobj=None)`` (any matching param)
-        New API: ``params.get(key, path=$MUX_ENTRY/*, default=None)``
-
-        As old and new API overlaps, you must use all 3 arguments or
-        explicitely use key argument "path" or "default".
+        Retrieve value associated with key from params
+        :param key: Key you're looking for
+        :param path: namespace ['*']
+        :param default: default value when not found
+        :raise KeyError: In case of multiple different values (params clash)
         """
-        def compatibility(args, kwargs):
-            """
-            Be 100% compatible with old API while allow _SOME OF_ the new APIs
-            calls:
-            OLD: get(key), get(key, default), get(key, failobj=default)
-            NEW: get(key, path, default), get(key, path=path),
-                 get(key, default=default)
-
-            :warning: We are unable to distinguish old get(key, default) vs.
-                      new get(key, path), therefor if you want to use the new
-                      API you must specify path/default using named arguments
-                      or supply all 3 arguments:
-                      get(key, path, default), get(key, path=path),
-                      get(key, default=default).
-                      This will be removed in final version.
-            """
-            if len(args) < 1:
-                raise TypeError("Incorrect arguments: params.get(%s, %s)"
-                                % (args, kwargs))
-            elif 'failobj' in kwargs:
-                return [args[0], '/*', kwargs['failobj']]   # Old API
-            elif len(args) > 2 or 'default' in kwargs or 'path' in kwargs:
-                try:
-                    if 'default' in kwargs:
-                        default = kwargs['default']
-                    elif len(args) > 2:
-                        default = args[2]
-                    else:
-                        default = None
-                    if 'path' in kwargs:
-                        path = kwargs['path']
-                    elif len(args) > 1:
-                        path = args[1]
-                    else:
-                        path = None
-                    key = args[0]
-                    return [key, path, default]
-                except IndexError:
-                    raise TypeError("Incorrect arguments: params.get(%s, %s)"
-                                    % (args, kwargs))
-            else:   # Old API
-                if len(args) == 1:
-                    return [args[0], '/*', None]
-                else:
-                    return [args[0], '/*', args[1]]
-
-        key, path, default = compatibility(args, kwargs)
         if path is None:    # default path is any relative path
             path = '*'
         try:
@@ -365,10 +316,6 @@ class AvocadoParam(object):
     """
     This is a single slice params. It can contain multiple leaves and tries to
     find matching results.
-    Currently it doesn't care about params origin, it requires single result
-    or failure. In future it'll get the origin from LeafParam and if it's the
-    same it'll proceed, otherwise raise exception (as it can't decide which
-    variable is desired)
     """
 
     def __init__(self, leaves, name):

--- a/avocado/multiplexer.py
+++ b/avocado/multiplexer.py
@@ -19,6 +19,7 @@
 Multiplex and create variants.
 """
 
+import collections
 import itertools
 import logging
 import re
@@ -29,47 +30,66 @@ from avocado.core import tree
 MULTIPLEX_CAPABLE = tree.MULTIPLEX_CAPABLE
 
 
-def tree2pools(node, mux=True):
+class MuxTree(object):
     """
-    Process tree and flattens the structure to remaining leaves and
-    list of lists of leaves per each multiplex group.
-    :param node: Node to start with
-    :return: tuple(`leaves`, `pools`), where `leaves` are directly inherited
-    leaves of this node (no other multiplex in the middle). `pools` is list of
-    lists of directly inherited leaves of the nested multiplex domains.
+    Object representing part of the tree from the root to leaves or another
+    multiplex domain. Recursively it creates multiplexed variants of the full
+    tree.
     """
-    leaves = []
-    pools = []
-    if mux:
-        # TODO: Get this multiplex leaves filters and store them in this pool
-        # to support 2nd level filtering
-        new_leaves = []
-        for child in node.children:
-            if child.is_leaf:
-                new_leaves.append(child)
+    def __init__(self, root):
+        """
+        :param root: Root of this tree slice
+        """
+        self.pools = []
+        for node in self._iter_mux_leaves(root):
+            if node.is_leaf:
+                self.pools.append(node)
             else:
-                _leaves, _pools = tree2pools(child, node.multiplex)
-                new_leaves.extend(_leaves)
-                # TODO: For 2nd level filters store this separately in case
-                # this branch is filtered out
-                pools.extend(_pools)
-        if new_leaves:
-            # TODO: Filter the new_leaves (and new_pools) before merging
-            # into pools
-            pools.append(new_leaves)
-    else:
-        for child in node.children:
-            if child.is_leaf:
-                leaves.append(child)
+                pools = []
+                for mux_child in node.children:
+                    pools.append(MuxTree(mux_child))
+                self.pools.append(pools)
+
+    @staticmethod
+    def _iter_mux_leaves(node):
+        """ yield leaves or muxes of the tree """
+        queue = collections.deque()
+        while node is not None:
+            if node.is_leaf or node.multiplex:
+                yield node
             else:
-                _leaves, _pools = tree2pools(child, node.multiplex)
-                leaves.extend(_leaves)
-                pools.extend(_pools)
-    return leaves, pools
+                queue.extendleft(reversed(node.children))
+            try:
+                node = queue.popleft()
+            except IndexError:
+                raise StopIteration
+
+    def __iter__(self):
+        """
+        Iterates through variants
+        """
+        pools = []
+        for pool in self.pools:
+            if isinstance(pool, list):
+                pools.append(itertools.chain(*pool))
+            else:
+                pools.append([pool])
+        pools = itertools.product(*pools)
+        while True:
+            # TODO: Implement 2nd level filteres here
+            # TODO: This part takes most of the time, optimize it
+            dirty = pools.next()
+            ret = []
+            for _ in dirty:
+                if isinstance(_, list):
+                    ret.extend(_)
+                else:
+                    ret.append(_)
+            yield ret
 
 
-def parse_yamls(input_yamls, filter_only=None, filter_out=None,
-                debug=False):
+def multiplex_yamls(input_yamls, filter_only=None, filter_out=None,
+                    debug=False):
     if filter_only is None:
         filter_only = []
     if filter_out is None:
@@ -77,20 +97,8 @@ def parse_yamls(input_yamls, filter_only=None, filter_out=None,
     input_tree = tree.create_from_yaml(input_yamls, debug)
     # TODO: Process filters and multiplex simultaneously
     final_tree = tree.apply_filters(input_tree, filter_only, filter_out)
-    leaves, pools = tree2pools(final_tree, final_tree.multiplex)
-    if leaves:  # Add remaining leaves (they are not variants, only endpoints
-        pools.extend(leaves)
-    return pools
-
-
-def multiplex_pools(pools):
-    return itertools.product(*pools)
-
-
-def multiplex_yamls(input_yamls, filter_only=None, filter_out=None,
-                    debug=False):
-    pools = parse_yamls(input_yamls, filter_only, filter_out, debug)
-    return multiplex_pools(pools)
+    result = MuxTree(final_tree)
+    return result
 
 
 # TODO: Create multiplexer plugin and split these functions into multiple files
@@ -438,9 +446,9 @@ class Mux(object):
         filter_only = getattr(args, 'filter_only', None)
         filter_out = getattr(args, 'filter_out', None)
         if mux_files:
-            self.pools = parse_yamls(mux_files, filter_only, filter_out)
+            self.variants = multiplex_yamls(mux_files, filter_only, filter_out)
         else:   # no variants
-            self.pools = None
+            self.variants = None
         self._mux_entry = getattr(args, 'mux_entry', None)
         if self._mux_entry is None:
             self._mux_entry = ['/test/*']
@@ -450,9 +458,9 @@ class Mux(object):
         :return: overall number of tests * multiplex variants
         """
         # Currently number of tests is symetrical
-        if self.pools:
+        if self.variants:
             return (len(test_suite) *
-                    sum(1 for _ in multiplex_pools(self.pools)))
+                    sum(1 for _ in self.variants))
         else:
             return len(test_suite)
 
@@ -460,9 +468,9 @@ class Mux(object):
         """
         Processes the template and yields test definition with proper params
         """
-        if self.pools:  # Copy template and modify it's params
+        if self.variants:  # Copy template and modify it's params
             i = None
-            for i, variant in enumerate(multiplex_pools(self.pools)):
+            for i, variant in enumerate(self.variants):
                 test_factory = [template[0], template[1].copy()]
                 test_factory[1]['params'] = (variant, self._mux_entry)
                 yield test_factory

--- a/docs/source/MultiplexConfig.rst
+++ b/docs/source/MultiplexConfig.rst
@@ -4,197 +4,89 @@
 Multiplex Configuration
 =======================
 
-Multiplex Configuration is a specialized way of providing lists
-of key/value pairs within combination's of various categories,
-that will be passed to avocado test as parameters in a dictionary
-called ``params``. The format simplifies and condenses complex
-multidimensional arrays of test parameters into a flat list. The
-combinatorial result can be filtered and adjusted prior to testing.
+In order to get good coverage one always needs to execute the same test
+with different parameters or in different environment. Avocado uses the
+term ``Multiplexation`` and uses `YAML <http://www.yaml.org/>`_ files
+to define how this multiplexation happens. The benefit of using YAML
+file is we can visibly separate different scopes and even complex setups
+are human readable, unlike multi-dimensional-matrices.
 
-The parser relies on `YAML <http://www.yaml.org/>`_, a human friendly
-markup language.  The YAML format allows one to create, manually or
-with code automation, multiple configurations for the tests. You can use any
-text editor to write YAML files, but choose one that supports syntax
-enhancements and basic validation, it saves time!
+Let's start with an example (line numbers added at the beginning)::
 
-Here is how a simple and valid multiplex configuration looks like::
+     1    hw:
+     2        cpu: !mux
+     3            intel:
+     4                cpu_CFLAGS: '-march=core2'
+     5            amd:
+     6                cpu_CFLAGS: '-march=athlon64'
+     7            arm:
+     8                cpu_CFLAGS: '-mabi=apcs-gnu -march=armv8-a -mtune=arm8'
+     9        disk: !mux
+    10            scsi:
+    11                disk_type: 'scsi'
+    12            virtio:
+    13                disk_type: 'virtio'
+    14    distro: !mux
+    15        fedora:
+    16            init: 'systemd'
+    17        mint:
+    18            init: 'systemv'
+    19    env: !mux
+    20        debug:
+    21            opt_CFLAGS: '-O0 -g'
+    22        prod:
+    23            opt_CFLAGS: '-O2'
 
-    # Multiplex config example, file sleep.yaml
-    short:
-        sleep_length: 1
-    medium:
-        sleep_length: 60
-    long:
-        sleep_length: 600
 
-The key concepts here are ``nodes`` (provides context and scope), ``keys`` (think of variables) and ``values`` (scalar or lists).
+There are couple of key=>value pairs (4,6,8,11,13,...) and there are
+named nodes which define scope (1,2,3,5,7,9,...). There are also additional
+flags (2, 9, 14, 19) which modifies the behavior.
 
-In the next section, we will describe these concepts in more details.
-
-.. _nodes:
 
 Nodes
 =====
 
-Nodes servers for two purposes, to name or describe a discrete point of information
-and to store in a set of key/values (possibly empty). Basically nodes can contains
-other nodes, so will have the parent and child relationship in a tree structure.
+They define context of the key=>value pairs allowing us to easily identify
+for what this values might be used for and also it makes possible to define
+multiple values of the same keys with different scope.
 
-The tree node structure can be obtained by using the command line
-``avocado multiplex --tree <file>`` and for previous example,
-it looks just like this::
+Nodes are organized in parent-child relationship and together they create
+a tree. To view this structure use ``avocado multiplex --tree <file>``::
 
-    avocado multiplex --tree sleep.yaml
-    Config file tree structure:
+                /-intel
+               |
+         /cpu-<>--amd
+        |      |
+      /hw       \-arm
+     |  |
+     |  |        /-scsi
+     |   \disk-<>
+     |           \-virtio
+    -|
+     |          /-fedora
+     |-distro-<>
+     |          \-mint
+     |
+     |       /-debug
+      \env-<>
+             \-prod
 
-         /-short
-        |
-    ----|-medium
-        |
-         \-long
+You can see that ``hw`` has 2 children ``cpu`` and ``disk``. All parameters
+defined in parent node are inherited to children and extended/overwritten by
+their values up to the leaf nodes. The leaf nodes (``intel``, ``amd``, ``arm``,
+``scsi``, ...) are the most important as after multiplexation they form the
+parameters available in tests.
 
-It helps if you see the tree structure as a set of paths
-separated by ``/``, much like paths in the file system.
-
-In the example we have being working on, there are only three paths:
-
-- ``//short``
-- ``//medium``
-- ``//long``
-
-The ending nodes (the leafs on the tree) will become part of all lower-level
-(i.e. further indented) variant stanzas (see section variants_).
-However, the precedence is evaluated in top-down or ``last defined`` order.
-In other words, the last parsed has precedence over earlier definitions.
-
-When you provide multiple files they are processed and merged together using
-the common root (`/`). When certain paths overlap (`$file1:/my/path`,
-`$file2:/my/path`), we first create the tree of `$file1` and then process
-`$file2`. This means all children of `/my/path` of the first file are in
-correct order and `$file2` either updates values or appends new children
-as next ones. This of course happens recursively so you update valures and add
-children of all the nodes beneath.
-
-During this merge it's also possible to remove nodes using python regular
-expressions, which can be useful when extending upstream file using downstream
-yaml files. This is done by `!remove_node : $value_name` directive::
-
-    os:
-        fedora:
-        windows:
-            3.11:
-            95:
-    os:
-        !remove_node : windows
-        windows:
-            win3.11:
-            win95:
-
-Removes the `windows` node from structure. It's different from `filter-out`
-as it really removes the node (and all children) from the tree and
-it can be replaced by you new structure as shown in the example. It removes
-`windows` with all children and then replaces this structure with slightly
-modified version.
-
-As `!remove_node` is processed during merge, when you reverse the order,
-windows is not removed and you end-up with `/windows/{win3.11,win95,3.11,95}`
-nodes.
-
-Due to yaml nature, it's __mandatory__ to put space between `!remove_node`
-and `:`!
-
-Additionally you can prepend multiple nodes to the given node by using
-`!using : $prepended/path`. This is useful when extending complex structure,
-for example imagine having distro variants in separate ymal files. In the
-end you want to merge them into the `/os` node. The main file can be simply::
-
-    # main.yaml
-    os:
-        !include : os/fedora/21.yaml
-        ....
-
-And each file can look either like this::
-
-    # fedora/21.yaml
-    fedora:
-        21:
-            some: value
-
-or you can use `!using` which prepends the `fedora/21`::
-
-    # fedora/21.yaml
-    !using : /fedora/21
-    some: value
-
-To be precise there is a way to define the structure in the main yaml file::
-
-    # main.yaml
-    os:
-        fedora:
-            21:
-                !include : fedora_21.yaml
-
-Or use recursive `!include` (slower)::
-
-    # main.yaml
-    os:
-        fedora:
-            !include : os/fedora.yaml
-    # os/fedora.yaml
-    21:
-        !include : fedora/21.yaml
-    # os/fedora/21.yaml
-    some: value
-
-Due to yaml nature, it's __mandatory__ to put space between `!using` and `:`!
-
-.. _keys_and_values:
 
 Keys and Values
 ===============
 
-Keys and values are the most basic useful facility provided by the
-format. A statement in the form ``<key>: <value>`` sets ``<key>`` to
-``<value>``.
+Every value other than dict (4,6,8,11) is used as value of the antecedent
+node.
 
-Values are numbers, strings and lists. Some examples of literal values:
-
-- Booleans: ``true`` and ``false``.
-- Numbers: 123 (integer), 3.1415 (float point)
-- Strings: 'This is a string'
-
-And lists::
-
-    cflags:
-        - '-O2'
-        - '-g'
-        - '-Wall'
-
-The list above will become ``['-O2', '-g', '-Wall']`` to Python. In fact,
-YAML is compatible to JSON.
-
-It's also possible to remove key using python's regexp, which can be useful
-when extending upstream file using downstream yaml files. This is done by
-`!remove_value : $value_name` directive::
-
-    debug:
-        CFLAGS: '-O0 -g'
-    debug:
-        !remove_value: CFLAGS
-
-removes the CFLAGS value completely from the debug node. This happens during
-the merge and only once. So if you switch the two, CFLAGS would be defined.
-
-Due to yaml nature, it's __mandatory__ to put space between `!remove_value`
-and `:`!
-
-.. _environment:
-
-Environment
-===========
-
-The environment is a set of key/values constructed by the moment
-we walk the path (beginning from the root) until we reach a specific node.
+Each node can define key/value pairs (lines 4,6,8,11,...). Additionally
+each children node inherits values of it's parent and the result is called
+node ``environment``.
 
 Given the node structure bellow::
 
@@ -223,14 +115,111 @@ The environment created for the nodes ``fedora`` and ``osx`` are:
 - Node ``//devtools/fedora`` environment ``compiler: 'gcc'``, ``flags: ['-O2', '-Wall']``
 - None ``//devtools/osx`` environment ``compiler: 'clang'``, ``flags: ['-O2', '-arch i386', '-arch x86_64']``
 
-.. _multiple_files:
+
+Variants
+========
+
+In the end all leafs are gathered and turned into parameters, more specifically into
+``AvocadoParams``::
+
+    setup:
+        graphic:
+            user: "guest"
+            password: "pass"
+        text:
+            user: "root"
+            password: "123456"
+
+produces ``[graphic, text]``. In the test code you'll be able to query only
+those leaves. Intermediary or root nodes are available.
+
+The example above generates a single test execution with parameters separated
+by path. But the most powerful multiplexer feature is that it can generate
+multiple variants. To do that you need to tag a node whose children are
+ment to be multiplexed. Effectively it returns only leaves of one child at the
+time.In order to generate all possible variants multiplexer creates cartesian
+product of all of these variants::
+
+    cpu: !mux
+        intel:
+        amd:
+        arm:
+    fmt: !mux
+        qcow2:
+        raw:
+
+Produces 6 variants::
+
+    /cpu/intel, /fmt/qcow2
+    /cpu/intel, /fmt/raw
+    ...
+    /cpu/arm, /fmt/raw
+
+The !mux evaluation is recursive so one variant can expand to multiple
+ones::
+
+    fmt: !mux
+        qcow: !mux
+            2:
+            2v3:
+        raw:
+
+Results in::
+
+    /fmt/qcow2/2
+    /fmt/qcow2/2v3
+    /raw
+
+
+Resolution order
+================
+
+You can see that only leaves are part of the test parameters. It might happen
+that some of these leaves contain different values of the same key. Then
+you need to make sure your queries separate them by different paths. When
+the path matches multiple results with different origin, an exception is raised
+as it's impossible to guess which key was originally intended.
+
+To avoid these problems it's recommended to use unique names in test parameters if
+possible, to avoid the mentioned clashes. It also makes it easier to extend or mix
+multiple YAML files for a test.
+
+For multiplex YAML files that are part of a framework, contain default
+configurations, or serve as plugin configurations and other advanced setups it is
+possible and commonly desirable to use non-unique names. But always keep those points
+in mind and provide sensible paths.
+
+Multiplexer also supports something called "multiplex entry points" or
+"resolution order". By default it's ``/tests/*`` but it can be overridden by
+``--mux-entry``, which accepts multiple arguments. What it does it splits
+leaves by the provided paths. Each query goes one by one through those
+sub-trees and first one to hit the match returns the result. It might not solve
+all problems, but it can help to combine existing YAML files with your ones::
+
+    qa:         # large and complex read-only file, content injected into /qa
+        tests:
+            timeout: 10
+        ...
+    my_variants: !mux        # your YAML file injected into /my_variants
+        short:
+            timeout: 1
+        long:
+            timeout: 1000
+
+You want to use an existing test which uses ``params.get('timeout', '*')``.  Then you
+can use ``--mux-entry '/my_variants/*' '/qa/*'`` and it'll first look in your
+variants. If no matches are found, then it would proceed to ``/qa/*``
+
+Keep in mind that only slices defined in mux-entry are taken into account for
+relative paths (the ones starting with ``*``)
+
 
 Multiple files
 ==============
 
 You can provide multiple files. In such scenario final tree is a combination
 of the provided files where later nodes with the same name override values of
-the precending corresponding node. New nodes are appended as new children::
+the preceding corresponding node. New nodes are appended as new children::
 
     file-1.yaml:
         debug:
@@ -253,8 +242,8 @@ results in::
     fast:
         CFLAGS: '-Ofast'    # appended
 
-It's also possilbe to include existing file into other file's node. This
-is done by `!include : $path` directive::
+It's also possible to include existing file into another a given node in another
+file. This is done by the `!include : $path` directive::
 
     os:
         fedora:
@@ -262,117 +251,161 @@ is done by `!include : $path` directive::
         gentoo:
             !include : gentoo.yaml
 
-Due to yaml nature, it's __mandatory__ to put space between `!include` and `:`!
+Due to YAML nature, it's __mandatory__ to put space between `!include` and `:`!
 
-The file location can be either absolute path or relative path to the yaml
+The file location can be either absolute path or relative path to the YAML
 file where the `!include` is called (even when it's nested).
 
 Whole file is __merged__ into the node where it's defined.
 
-.. _variants:
 
-Variants
-========
+Advanced YAML tags
+==================
 
-When tree parsing and filtering is finished, we create set of variants.
-Each variant uses one leaf of each sibling group. For example::
+There are additional features related to YAML files. Most of them require values
+separated by ``:``. Again, in all such cases it's mandatory to add a white space (``
+``) between the tag and the ``:``, otherwise ``:`` is part of the tag name and the
+parsing fails.
 
-    cpu:
-        intel:
-        amd:
-        arm:
-    fmt:
-        qcow2:
-        raw:
+!include
+--------
 
-Produces 2 groups `[intel, amd, arm]` and `[qcow2, raw]`, which results in
-6 variants (all combinations; product of the groups)
+Includes other file and injects it into the node it's specified in::
 
-It's also possible to join current node and its children by `!join` tag::
+    my_other_file:
+        !include : other.yaml
 
-    fmt: !join
-        qcow:
-            2:
-            2v3:
-        raw:
+The content of ``/my_other_file`` would be parsed from the ``other.yaml``. It's
+the hardcoded equivalent of the ``-m $using:$path``.
 
-Without the join this would produce 2 groups `[2, 2v3]` and `[raw]` resulting
-in 2 variants `[2, raw]` and `[2v3, raw]`, which is really not useful.
-But we said that `fmt` children should join this sibling group
-so it results in one group `[qcow/2, qcow/2v3, raw]` resulting in 3 variants
-each of different fmt. This is useful when some
-of the variants share some common key. These keys are set inside the
-parent, for example here `qcow2.0` and `qcow2.2v3` share the same key
-`type: qcow2` and `qcow2.2v3` adds `extra_params` into his params::
+Relative paths start from the original file's directory.
 
-    fmt:
-        qcow2:
-            type: qcow2
-            0:
-            v3:
-                extra_params: "compat=1.1"
-        raw:
-            type: raw
+!using
+------
 
-Complete example::
+Prepends path to the node it's defined in::
 
-    hw:
-        cpu:
-            intel:
-            amd:
-            arm:
-        fmt: !join
-            qcow:
-                qcow2:
-                qcow2v3:
-            raw:
-    os: !join
-        linux: !join
-            Fedora:
-                19:
-            Gentoo:
+    !using : /foo
+    bar:
+        !using : baz
+
+``bar`` is put into ``baz`` becoming ``/baz/bar`` and everything is put into
+``/foo``. So the final path of ``bar`` is ``/foo/baz/bar``.
+
+!remove_node
+------------
+
+Removes node if it existed during the merge. It can be used to extend
+incompatible YAML files::
+
+    os:
+        fedora:
         windows:
             3.11:
+            95:
+    os:
+        !remove_node : windows
+        windows:
+            win3.11:
+            win95:
 
-While preserving names and environment values. Then all combinations are
-created resulting into 27 unique variants covering all possible combinations
-of given tree::
+Removes the `windows` node from structure. It's different from `filter-out`
+as it really removes the node (and all children) from the tree and
+it can be replaced by you new structure as shown in the example. It removes
+`windows` with all children and then replaces this structure with slightly
+modified version.
 
-	Variant 1:    /hw/cpu/intel, /hw/fmt/qcow/qcow2, /os/linux/Fedora/19
-	Variant 2:    /hw/cpu/intel, /hw/fmt/qcow/qcow2, /os/linux/Gentoo
-	Variant 3:    /hw/cpu/intel, /hw/fmt/qcow/qcow2, /os/windows/3.11
-	Variant 4:    /hw/cpu/intel, /hw/fmt/qcow/qcow2v3, /os/linux/Fedora/19
-	Variant 5:    /hw/cpu/intel, /hw/fmt/qcow/qcow2v3, /os/linux/Gentoo
-	Variant 6:    /hw/cpu/intel, /hw/fmt/qcow/qcow2v3, /os/windows/3.11
-	Variant 7:    /hw/cpu/intel, /hw/fmt/raw, /os/linux/Fedora/19
-	Variant 8:    /hw/cpu/intel, /hw/fmt/raw, /os/linux/Gentoo
-	Variant 9:    /hw/cpu/intel, /hw/fmt/raw, /os/windows/3.11
-	Variant 10:    /hw/cpu/amd, /hw/fmt/qcow/qcow2, /os/linux/Fedora/19
-	Variant 11:    /hw/cpu/amd, /hw/fmt/qcow/qcow2, /os/linux/Gentoo
-	Variant 12:    /hw/cpu/amd, /hw/fmt/qcow/qcow2, /os/windows/3.11
-	Variant 13:    /hw/cpu/amd, /hw/fmt/qcow/qcow2v3, /os/linux/Fedora/19
-	Variant 14:    /hw/cpu/amd, /hw/fmt/qcow/qcow2v3, /os/linux/Gentoo
-	Variant 15:    /hw/cpu/amd, /hw/fmt/qcow/qcow2v3, /os/windows/3.11
-	Variant 16:    /hw/cpu/amd, /hw/fmt/raw, /os/linux/Fedora/19
-	Variant 17:    /hw/cpu/amd, /hw/fmt/raw, /os/linux/Gentoo
-	Variant 18:    /hw/cpu/amd, /hw/fmt/raw, /os/windows/3.11
-	Variant 19:    /hw/cpu/arm, /hw/fmt/qcow/qcow2, /os/linux/Fedora/19
-	Variant 20:    /hw/cpu/arm, /hw/fmt/qcow/qcow2, /os/linux/Gentoo
-	Variant 21:    /hw/cpu/arm, /hw/fmt/qcow/qcow2, /os/windows/3.11
-	Variant 22:    /hw/cpu/arm, /hw/fmt/qcow/qcow2v3, /os/linux/Fedora/19
-	Variant 23:    /hw/cpu/arm, /hw/fmt/qcow/qcow2v3, /os/linux/Gentoo
-	Variant 24:    /hw/cpu/arm, /hw/fmt/qcow/qcow2v3, /os/windows/3.11
-	Variant 25:    /hw/cpu/arm, /hw/fmt/raw, /os/linux/Fedora/19
-	Variant 26:    /hw/cpu/arm, /hw/fmt/raw, /os/linux/Gentoo
-	Variant 27:    /hw/cpu/arm, /hw/fmt/raw, /os/windows/3.11
+As `!remove_node` is processed during merge, when you reverse the order,
+windows is not removed and you end-up with `/windows/{win3.11,win95,3.11,95}`
+nodes.
 
-You can generate this list yourself by executing::
+!remove_value
+-------------
 
-    avocado multiplex /path/to/multiplex.yaml [-c]
+It's similar to `!remove_node`_ only with values.
 
-Note that there's no need to put extensions to a multiplex file, although
-doing so helps with organization. The optional -c param is used to provide
-the contents of the dictionaries generated, not only their shortnames.
+!mux
+----
 
-With Nodes, Keys, Values & Filters, we have most of what you
-actually need to construct most multiplex files.
+Children of this node will be multiplexed. This means that in first variant
+it'll return leaves of the first child, in second the leaves of the second
+child, etc. Example is in section `Variants`_
+
+
+Complete example
+================
+
+Let's take a second look at the first example::
+
+     1    hw:
+     2        cpu: !mux
+     3            intel:
+     4                cpu_CFLAGS: '-march=core2'
+     5            amd:
+     6                cpu_CFLAGS: '-march=athlon64'
+     7            arm:
+     8                cpu_CFLAGS: '-mabi=apcs-gnu -march=armv8-a -mtune=arm8'
+     9        disk: !mux
+    10            scsi:
+    11                disk_type: 'scsi'
+    12            virtio:
+    13                disk_type: 'virtio'
+    14    distro: !mux
+    15        fedora:
+    16            init: 'systemd'
+    17        mint:
+    18            init: 'systemv'
+    19    env: !mux
+    20        debug:
+    21            opt_CFLAGS: '-O0 -g'
+    22        prod:
+    23            opt_CFLAGS: '-O2'
+
+After filters are applied (simply removes non-matching variants), leaves
+are gathered and all variants are generated::
+
+    ./scripts/avocado multiplex examples/mux-environment.yaml 
+    Variants generated:
+    Variant 1:    /hw/cpu/intel, /hw/disk/scsi, /distro/fedora, /env/debug
+    Variant 2:    /hw/cpu/intel, /hw/disk/scsi, /distro/fedora, /env/prod
+    Variant 3:    /hw/cpu/intel, /hw/disk/scsi, /distro/mint, /env/debug
+    Variant 4:    /hw/cpu/intel, /hw/disk/scsi, /distro/mint, /env/prod
+    Variant 5:    /hw/cpu/intel, /hw/disk/virtio, /distro/fedora, /env/debug
+    Variant 6:    /hw/cpu/intel, /hw/disk/virtio, /distro/fedora, /env/prod
+    Variant 7:    /hw/cpu/intel, /hw/disk/virtio, /distro/mint, /env/debug
+    Variant 8:    /hw/cpu/intel, /hw/disk/virtio, /distro/mint, /env/prod
+    Variant 9:    /hw/cpu/amd, /hw/disk/scsi, /distro/fedora, /env/debug
+    Variant 10:    /hw/cpu/amd, /hw/disk/scsi, /distro/fedora, /env/prod
+    Variant 11:    /hw/cpu/amd, /hw/disk/scsi, /distro/mint, /env/debug
+    Variant 12:    /hw/cpu/amd, /hw/disk/scsi, /distro/mint, /env/prod
+    Variant 13:    /hw/cpu/amd, /hw/disk/virtio, /distro/fedora, /env/debug
+    Variant 14:    /hw/cpu/amd, /hw/disk/virtio, /distro/fedora, /env/prod
+    Variant 15:    /hw/cpu/amd, /hw/disk/virtio, /distro/mint, /env/debug
+    Variant 16:    /hw/cpu/amd, /hw/disk/virtio, /distro/mint, /env/prod
+    Variant 17:    /hw/cpu/arm, /hw/disk/scsi, /distro/fedora, /env/debug
+    Variant 18:    /hw/cpu/arm, /hw/disk/scsi, /distro/fedora, /env/prod
+    Variant 19:    /hw/cpu/arm, /hw/disk/scsi, /distro/mint, /env/debug
+    Variant 20:    /hw/cpu/arm, /hw/disk/scsi, /distro/mint, /env/prod
+    Variant 21:    /hw/cpu/arm, /hw/disk/virtio, /distro/fedora, /env/debug
+    Variant 22:    /hw/cpu/arm, /hw/disk/virtio, /distro/fedora, /env/prod
+    Variant 23:    /hw/cpu/arm, /hw/disk/virtio, /distro/mint, /env/debug
+    Variant 24:    /hw/cpu/arm, /hw/disk/virtio, /distro/mint, /env/prod
+
+Where the first variant contains::
+
+    /hw/cpu/intel/  => cpu_CFLAGS: -march=core2
+    /hw/disk/       => disk_type: scsi
+    /distro/fedora/ => init: systemd
+    /env/debug/     => opt_CFLAGS: -O0 -g
+
+The second one::
+
+    /hw/cpu/intel/  => cpu_CFLAGS: -march=core2
+    /hw/disk/       => disk_type: scsi
+    /distro/fedora/ => init: systemd
+    /env/prod/      => opt_CFLAGS: -O2
+
+From this example you can see that querying for ``/env/debug`` works only in
+the first variant, but returns nothing in the second variant. Keep this in mind
+and when you use the ``!mux`` flag always query for the pre-mux path,
+``/env/*`` in this example.

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -110,34 +110,66 @@ to analyze that particular benchmark result).
 Accessing test parameters
 =========================
 
-Each test has a set of parameters that can be accessed through ``self.params.[param-name]``.
-Avocado finds and populates ``self.params`` with all parameters you define on a Multiplex
-Config file (see :doc:`MultiplexConfig`), in a way that they are available as attributes,
-not just dict keys. This has the advantage of reducing the boilerplate code necessary to
-access those parameters. As an example, consider the following multiplex file for sleeptest::
+Each test has a set of parameters that can be accessed through
+``self.params.get($name, $path=None, $default=None)``.
+Avocado finds and populates ``self.params`` with all parameters you define on
+a Multiplex Config file (see :doc:`MultiplexConfig`). As an example, consider
+the following multiplex file for sleeptest::
 
-    variants:
-        - sleeptest:
-            sleep_length_type = float
-            variants:
-                - short:
-                    sleep_length = 0.5
-                - medium:
-                    sleep_length = 1
-                - long:
-                    sleep_length = 5
+    test:
+        sleeptest:
+            type: "builtin"
+            short:
+                sleep_length: 0.5
+            medium:
+                sleep_length: 1
+            long:
+                sleep_length: 5
 
-You may notice some things here: there is one test param to sleeptest, called ``sleep_length``. We could have named it
-``length`` really, but I prefer to create a param namespace of sorts here. Then, I defined
-``sleep_length_type``, that is used by the config system to convert a value (by default a
-:class:`basestring`) to an appropriate value type (in this case, we need to pass a :class:`float`
-to :func:`time.sleep` anyway). Note that this is an optional feature, and you can always use
-:func:`float` to convert the string value coming from the configuration anyway.
+In this example 3 variants are executed (see :doc:`MultiplexConfig` for
+details). All of them contain variable "type" and "sleep_length". To obtain
+current value, you need the name ("sleep_length") and it's path. The path
+differs for each variant so it's needed to use the most suitable portion
+of the path, in this example: "/test/sleeptest/*" or perhaps "sleeptest/*"
+might be enough. It depends on how your setups looks like.
 
-Another important design detail is that sometimes we might not want to use the config system
-at all (for example, when we run an avocado test as a stand alone test). To account for this
-case, we have to specify a ``default_params`` dictionary that contains the default values
-for when we are not providing config from a multiplex file.
+The default value is optional, but always keep in mind to handle them nicely.
+Someone might be executing your test with different params or without any
+params at all. It should work fine.
+
+So the complete example on how to access the "sleep_length" would be::
+
+    self.params.get("sleep_length", "/*/sleeptest/*", 1)
+
+There is one way to make this even simpler. It's possible to define resolution
+order, then for simple queries you can simply omit the path::
+
+    self.params.get("sleep_length", None, 1)
+    self.params.get("sleep_length", '*', 1)
+    self.params.get("sleep_length", default=1)
+
+One should always try to avoid param clashes (multiple matching keys for given
+path with different origin). If it's not possible (eg. when
+you use multiple yaml files) you can modify the resolution order by modifying
+``--mux-entry``. What it does is it slices the params and iterates through the
+paths one by one. When there is a match in the first slice it returns
+it without trying the other slices. Although relative queries only match
+from ``--mux-entry`` slices.
+
+There are many ways to use paths to separate clashing params or just to make
+more clear what your query for. Usually in tests the usage of '*' is sufficient
+and the namespacing is not necessarily, but it helps make advanced usage
+clearer and easier to follow.
+
+When thinking of the path always think about users. It's common to extend
+default config with additional variants or combine them with different
+ones to generate just the right scenarios they need. People might
+simply inject the values elsewhere (eg. `/test/sleeptest` =>
+`/upstream/test/sleeptest`) or they can merge other clashing file into the
+default path, which won't generate clash, but would return their values
+instead. Then you need to clarify the path (eg. `'*'` =>  `sleeptest/*`)
+
+More details on that are in :doc:`MultiplexConfig`
 
 Using a multiplex file
 ======================

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -145,14 +145,14 @@ Using a multiplex file
 You may use the avocado runner with a multiplex file to provide params and matrix
 generation for sleeptest just like::
 
-    $ avocado run sleeptest --multiplex examples/tests/sleeptest.py.data/sleeptest.yaml
+    $ avocado run sleeptest --multiplex /test:examples/tests/sleeptest.py.data/sleeptest.yaml
     JOB ID    : d565e8dec576d6040f894841f32a836c751f968f
     JOB LOG   : $HOME/avocado/job-results/job-2014-08-12T15.44-d565e8de/job.log
     JOB HTML  : $HOME/avocado/job-results/job-2014-08-12T15.44-d565e8de/html/results.html
     TESTS     : 3
-    (1/3) sleeptest.short: PASS (0.50 s)
-    (2/3) sleeptest.medium: PASS (1.01 s)
-    (3/3) sleeptest.long: PASS (5.01 s)
+    (1/3) sleeptest: PASS (0.50 s)
+    (2/3) sleeptest.1: PASS (1.01 s)
+    (3/3) sleeptest.2: PASS (5.01 s)
     PASS      : 3
     ERROR     : 0
     FAIL      : 0
@@ -161,30 +161,43 @@ generation for sleeptest just like::
     INTERRUPT : 0
     TIME : 6.52 s
 
+The ``--multiplex`` accepts either only ``$FILE_LOCATION`` or ``$INJECT_TO:$FILE_LOCATION``.
+By later you can combine multiple simple YAML files and inject them into a specific location
+as shown in the example above. As you learned in previous section the ``/test`` location
+is part of default ``mux-entry`` path thus sleeptest can access the values without specifying
+the path. To understand the difference execute those commands::
+
+    $ avocado multiplex -t examples/tests/sleeptest.py.data/sleeptest.yaml
+    $ avocado multiplex -t /test:examples/tests/sleeptest.py.data/sleeptest.yaml
+
 Note that, as your multiplex file specifies all parameters for sleeptest, you
 can't leave the test ID empty::
 
-    $ scripts/avocado run --multiplex examples/tests/sleeptest/sleeptest.yaml
+    $ scripts/avocado run --multiplex /test:examples/tests/sleeptest/sleeptest.yaml
     Empty test ID. A test path or alias must be provided
 
-If you want to run some tests that don't require params set by the multiplex file, you can::
+You can also execute multiple tests with the same multiplex file::
 
-    $ avocado run sleeptest synctest --multiplex examples/tests/sleeptest.py.data/sleeptest.yaml
-    JOB ID    : dd91ea5f8b42b2f084702315688284f7e8aa220a
-    JOB LOG   : $HOME/avocado/job-results/job-2014-08-12T15.49-dd91ea5f/job.log
-    JOB HTML  : $HOME/avocado/job-results/job-2014-08-12T15.49-dd91ea5f/html/results.html
-    TESTS     : 4
-    (1/4) sleeptest.short: PASS (0.50 s)
-    (2/4) sleeptest.medium: PASS (1.01 s)
-    (3/4) sleeptest.long: PASS (5.01 s)
-    (4/4) synctest.1: ERROR (1.85 s)
-    PASS      : 3
-    ERROR     : 1
-    FAIL      : 0
-    SKIP      : 0
-    WARN      : 0
-    INTERRUPT : 0
-    TIME : 8.69 s
+    ./scripts/avocado run sleeptest synctest --multiplex examples/tests/sleeptest.py.data/sleeptest.yaml
+    JOB ID     : 72166988c13fec26fcc9c2e504beec8edaad4761
+    JOB LOG    : /home/medic/avocado/job-results/job-2015-05-15T11.02-7216698/job.log
+    JOB HTML   : /home/medic/avocado/job-results/job-2015-05-15T11.02-7216698/html/results.html
+    TESTS      : 8
+    (1/8) sleeptest.py: PASS (1.00 s)
+    (2/8) sleeptest.py.1: PASS (1.00 s)
+    (3/8) sleeptest.py.2: PASS (1.00 s)
+    (4/8) sleeptest.py.3: PASS (1.00 s)
+    (5/8) synctest.py: PASS (1.31 s)
+    (6/8) synctest.py.1: PASS (1.48 s)
+    (7/8) synctest.py.2: PASS (3.36 s)
+    (8/8) synctest.py.3: PASS (3.59 s)
+    PASS       : 8
+    ERROR      : 0
+    FAIL       : 0
+    SKIP       : 0
+    WARN       : 0
+    INTERRUPT  : 0
+    TIME       : 13.76 s
 
 Avocado tests are also unittests
 ================================
@@ -542,16 +555,14 @@ impact your test grid. You can account for that possibility and set up a
 
 ::
 
-    variants:
-        - sleeptest:
-            sleep_length = 5
-            sleep_length_type = float
-            timeout = 3
-            timeout_type = float
+    sleep_length = 5
+    sleep_length_type = float
+    timeout = 3
+    timeout_type = float
 
 ::
 
-    $ avocado run sleeptest --multiplex /tmp/sleeptest-example.mplx
+    $ avocado run sleeptest --multiplex /test:/tmp/sleeptest-example.mplx
     JOB ID    : 6d5a2ff16bb92395100fbc3945b8d253308728c9
     JOB LOG   : $HOME/avocado/job-results/job-2014-08-12T15.52-6d5a2ff1/job.log
     JOB HTML  : $HOME/avocado/job-results/job-2014-08-12T15.52-6d5a2ff1/html/results.html

--- a/examples/mux-environment.yaml
+++ b/examples/mux-environment.yaml
@@ -1,22 +1,22 @@
 hw:
-    cpu:
+    cpu: !mux
         intel:
             cpu_CFLAGS: '-march=core2'
         amd:
             cpu_CFLAGS: '-march=athlon64'
         arm:
             cpu_CFLAGS: '-mabi=apcs-gnu -march=armv8-a -mtune=arm8'
-    disk:
+    disk: !mux
         scsi:
             disk_type: 'scsi'
         virtio:
             disk_type: 'virtio'
-distro:
+distro: !mux
     fedora:
         init: 'systemd'
     mint:
         init: 'systemv'
-env:
+env: !mux
     debug:
         opt_CFLAGS: '-O0 -g'
     prod:

--- a/examples/mux-selftest-advanced.yaml
+++ b/examples/mux-selftest-advanced.yaml
@@ -2,7 +2,7 @@
 !using : virt
 # Following line makes it look exactly as mux-selftest.yaml
 !include : mux-selftest.yaml
-distro:
+distro: !mux
     # This line extends the distro branch using include
     !include : mux-selftest-distro.yaml
     # remove node called "mint"
@@ -19,14 +19,7 @@ distro:
         # And this removes the original 'is_cool'
         # Setting happens after ctrl so it should be created'
         !remove_value : is_cool
-# Following node is an empty node with only Control object. During merge
-# it setls /env node as !join (disable multiplexation)
-env: !join
-distro: !join
-    # Set !join here, it won't be overwritten below as it's defined as
-    # &=.
-    mint:   # This won't change anything
-distro:
+distro: !mux
     gentoo:     # This won't change anything
 # This creates new branch the usual way
 new_node:

--- a/examples/mux-selftest-distro.yaml
+++ b/examples/mux-selftest-distro.yaml
@@ -1,8 +1,9 @@
-RHEL:
+!mux
+RHEL: !mux
     enterprise: true
     6:
         init: 'systemv'
     7:
         init: 'systemd'
-gentoo:
+gentoo: !mux
     is_cool: False

--- a/examples/mux-selftest-params.yaml
+++ b/examples/mux-selftest-params.yaml
@@ -1,4 +1,3 @@
-!join
 root: "root"
 cache_test: 'cache'
 diff_domain: "text1"
@@ -7,12 +6,13 @@ ch0:
     clash1: "equal"
     clash3: "also equal"
     ch0.1:
-        ch0.1.1:
+        ch0.1.1: !mux
             ch0.1.1.1:
                 unique1: "unique1"
                 clash1: "equal"
             ch0.1.1.2:
                 unique1: "unique1-2"
+    ch0.1b: !mux
         ch0.1.2:
             unique3: "unique3"
             clash3: "also equal"

--- a/examples/mux-selftest.yaml
+++ b/examples/mux-selftest.yaml
@@ -8,7 +8,7 @@
 # /env/opt_CFLAGS: Should be present in merged node
 # /env/prod/opt_CFLAGS: value should be overridden by latter node
 hw:
-    cpu:
+    cpu: !mux
         joinlist:
             - first_item
         intel:
@@ -18,7 +18,7 @@ hw:
             cpu_CFLAGS: '-march=athlon64'
         arm:
             cpu_CFLAGS: '-mabi=apcs-gnu -march=armv8-a -mtune=arm8'
-    disk:
+    disk: !mux
         disk_type: 'virtio'
         corruptlist: 'nonlist'
         scsi:
@@ -26,17 +26,17 @@ hw:
             disk_type: 'scsi'
         virtio:
     corruptlist: ['upper_node_list']
-distro:     # This node is set as !multiplex below
+distro: !mux     # This node is set as !multiplex below
     fedora:
         init: 'systemd'
-env:
+env: !mux
     opt_CFLAGS: '-Os'
     prod:
         opt_CFLAGS: 'THIS SHOULD GET OVERWRITTEN'
-env:
+env: !mux
     prod:
         opt_CFLAGS: '-O2'
-distro:
+distro: !mux
     mint:
         init: 'systemv'
 

--- a/examples/tests/cabort.py
+++ b/examples/tests/cabort.py
@@ -19,7 +19,7 @@ class CAbort(test.Test):
         """
         Build 'abort'.
         """
-        c_file = self.get_data_path(self.params.get('source', 'abort.c'))
+        c_file = self.get_data_path(self.params.get('source', default='abort.c'))
         c_file_name = os.path.basename(c_file)
         dest_c_file = os.path.join(self.srcdir, c_file_name)
         shutil.copy(c_file, dest_c_file)

--- a/examples/tests/datadir.py
+++ b/examples/tests/datadir.py
@@ -19,7 +19,8 @@ class DataDirTest(test.Test):
         """
         Build 'datadir'.
         """
-        c_file = self.get_data_path(self.params.get('source', 'datadir.c'))
+        c_file = self.get_data_path(self.params.get('source',
+                                                    default='datadir.c'))
         c_file_name = os.path.basename(c_file)
         dest_c_file = os.path.join(self.srcdir, c_file_name)
         shutil.copy(c_file, dest_c_file)

--- a/examples/tests/doublefree.py
+++ b/examples/tests/doublefree.py
@@ -20,7 +20,8 @@ class DoubleFreeTest(test.Test):
         """
         Build 'doublefree'.
         """
-        c_file = self.get_data_path(self.params.get('source', 'doublefree.c'))
+        c_file = self.get_data_path(self.params.get('source',
+                                                    default='doublefree.c'))
         c_file_name = os.path.basename(c_file)
         dest_c_file = os.path.join(self.srcdir, c_file_name)
         shutil.copy(c_file, dest_c_file)

--- a/examples/tests/doublefree_nasty.py
+++ b/examples/tests/doublefree_nasty.py
@@ -21,7 +21,7 @@ class DoubleFreeTest(test.Test):
         """
         Build 'doublefree'.
         """
-        source = self.params.get('source', 'doublefree.c')
+        source = self.params.get('source', default='doublefree.c')
         c_file = self.get_data_path(source)
         shutil.copy(c_file, self.srcdir)
         self.__binary = source.rsplit('.', 1)[0]

--- a/examples/tests/doublefree_nasty.py.data/iterations.yaml
+++ b/examples/tests/doublefree_nasty.py.data/iterations.yaml
@@ -1,4 +1,4 @@
-iterations:
+iterations: !mux
     1:
     2:
     3:

--- a/examples/tests/env_variables.sh.data/env_variables.yaml
+++ b/examples/tests/env_variables.sh.data/env_variables.yaml
@@ -1,3 +1,4 @@
+!mux
 short:
     CUSTOM_VARIABLE: A
 medium:

--- a/examples/tests/fiotest.py
+++ b/examples/tests/fiotest.py
@@ -22,7 +22,8 @@ class FioTest(test.Test):
         """
         Build 'fio'.
         """
-        fio_tarball = self.params.get('fio_tarball', 'fio-2.1.10.tar.bz2')
+        fio_tarball = self.params.get('fio_tarball',
+                                      default='fio-2.1.10.tar.bz2')
         tarball_path = self.get_data_path(fio_tarball)
         archive.extract(tarball_path, self.srcdir)
         fio_version = fio_tarball.split('.tar.')[0]
@@ -34,7 +35,7 @@ class FioTest(test.Test):
         Execute 'fio' with appropriate parameters.
         """
         os.chdir(self.srcdir)
-        fio_job = self.params.get('fio_job', 'fio-mixed.job')
+        fio_job = self.params.get('fio_job', default='fio-mixed.job')
         cmd = ('./fio %s' % self.get_data_path(fio_job))
         process.system(cmd)
 

--- a/examples/tests/linuxbuild.py
+++ b/examples/tests/linuxbuild.py
@@ -12,8 +12,8 @@ class LinuxBuildTest(test.Test):
     """
 
     def setUp(self):
-        kernel_version = self.params.get('linux_version', '3.14.5')
-        linux_config = self.params.get('linux_config', 'config')
+        kernel_version = self.params.get('linux_version', default='3.14.5')
+        linux_config = self.params.get('linux_config', default='config')
         config_path = self.get_data_path(linux_config)
         self.linux_build = kernel_build.KernelBuild(kernel_version,
                                                     config_path,

--- a/examples/tests/modify_variable.py
+++ b/examples/tests/modify_variable.py
@@ -24,7 +24,7 @@ class PrintVariableTest(test.Test):
         """
         Build 'print_variable'.
         """
-        source = self.params.get('source', 'print_variable.c')
+        source = self.params.get('source', default='print_variable.c')
         c_file = self.get_data_path(source)
         shutil.copy(c_file, self.srcdir)
         self.__binary = source.rsplit('.', 1)[0]

--- a/examples/tests/multiplextest.py
+++ b/examples/tests/multiplextest.py
@@ -16,7 +16,7 @@ class MultiplexTest(test.Test):
         self.set_numa_balance()
         self.assembly_vm()
 
-        os_type = self.params.get('os_type', 'linux')
+        os_type = self.params.get('os_type', default='linux')
         if os_type == 'windows':
             self.log.info('Preparing VM with Windows (%s)',
                           self.params.get('win'))
@@ -26,16 +26,17 @@ class MultiplexTest(test.Test):
 
     def compile_code(self):
         self.log.info('Compile code')
-        self.log.info('gcc %s %s', self.params.get('gcc_flags', '-O2'),
+        self.log.info('gcc %s %s', self.params.get('gcc_flags', default='-O2'),
                       'code.c')
 
     def set_hugepages(self):
-        if self.params.get('huge_pages', 'yes') == 'yes':
+        if self.params.get('huge_pages', default='yes') == 'yes':
             self.log.info('Setting hugepages')
 
     def set_numa_balance(self):
-        numa_balancing = self.params.get('numa_balancing', 'yes')
-        numa_migrate = self.params.get('numa_balancing_migrate_deferred', 'no')
+        numa_balancing = self.params.get('numa_balancing', default='yes')
+        numa_migrate = self.params.get('numa_balancing_migrate_deferred',
+                                       default='no')
         if numa_balancing:
             self.log.info('Numa balancing: %s', numa_balancing)
         if numa_migrate:
@@ -43,9 +44,10 @@ class MultiplexTest(test.Test):
 
     def assembly_vm(self):
         self.log.info('Assembling VM')
-        drive_format = self.params.get('drive_format', 'virtio_blk')
-        nic_model = self.params.get('nic_model', 'virtio_net')
-        enable_msx_vectors = self.params.get('enable_msx_vectors', 'yes')
+        drive_format = self.params.get('drive_format', default='virtio_blk')
+        nic_model = self.params.get('nic_model', default='virtio_net')
+        enable_msx_vectors = self.params.get('enable_msx_vectors',
+                                             default='yes')
         if drive_format:
             self.log.info('Drive format: %s', drive_format)
         if nic_model:
@@ -56,13 +58,13 @@ class MultiplexTest(test.Test):
     def runTest(self):
         self.log.info('Executing synctest...')
         self.log.info('synctest --timeout %s --tries %s',
-                      self.params.get('sync_timeout', 12),
-                      self.params.get('sync_tries', 3))
+                      self.params.get('sync_timeout', default=12),
+                      self.params.get('sync_tries', default=3))
 
         self.log.info('Executing ping test...')
         cmdline = ('ping --timeout %s --tries %s'
-                   % (self.params.get('ping_timeout', 10),
-                      self.params.get('ping_tries', 5)))
+                   % (self.params.get('ping_timeout', default=10),
+                      self.params.get('ping_tries', default=5)))
 
         ping_flags = self.params.get('ping_flags')
         if ping_flags:

--- a/examples/tests/multiplextest.py.data/multiplextest.yaml
+++ b/examples/tests/multiplextest.py.data/multiplextest.yaml
@@ -1,4 +1,4 @@
-env:
+env: !mux
     production:
        malloc_perturb:  no
        gcc_flags:  -O3
@@ -8,11 +8,11 @@ env:
 
 host:
     kernel_config:
-        page_size:
+        page_size: !mux
             default:
             huge_pages:
                 huge_pages:  yes
-        numa:
+        numa: !mux
             default:
             numa_ballance_aggressive:
                 numa_balancing:  1
@@ -24,8 +24,8 @@ host:
                 numa_balancing_scan_size_mb:  32
 
 guest:
-    os: !join
-        windows:
+    os: !mux
+        windows: !mux
             os_type: windows
             xp:
                 win: xp
@@ -33,7 +33,7 @@ guest:
                 win: 2k12
             7:
                 win: 7
-        linux:
+        linux: !mux
             os_type:  linux
             fedora:
                 distro:  fedora
@@ -41,12 +41,12 @@ guest:
                 distro:  ubuntu
 
 hardware:
-    disks:
+    disks: !mux
         ide:
             drive_format: ide
         scsi:
             drive_format: scsi
-    network:
+    network: !mux
         rtl_8139:
             nic_model: rtl8139
         e1000:
@@ -55,15 +55,15 @@ hardware:
             nic_model: virtio
             enable_msix_vectors: yes
 
-tests:
-    sync_test:
+tests: !mux
+    sync_test: !mux
         standard:
             sync_timeout: 30
             sync_tries:   10
         aggressive:
             sync_timeout: 10
             sync_tries:   20
-    ping_test:
+    ping_test: !mux
         standard:
             ping_tries:   10
             ping_timeout: 20

--- a/examples/tests/raise.py
+++ b/examples/tests/raise.py
@@ -19,7 +19,8 @@ class Raise(test.Test):
         """
         Build 'raise'.
         """
-        c_file = self.get_data_path(self.params.get('source', 'raise.c'))
+        c_file = self.get_data_path(self.params.get('source',
+                                    default='raise.c'))
         c_file_name = os.path.basename(c_file)
         dest_c_file = os.path.join(self.srcdir, c_file_name)
         shutil.copy(c_file, dest_c_file)
@@ -31,7 +32,7 @@ class Raise(test.Test):
         """
         Execute 'raise'.
         """
-        signum = self.params.get('signal_number', 15)
+        signum = self.params.get('signal_number', default=15)
         cmd = os.path.join(self.srcdir, 'raise %d' % signum)
         cmd_result = process.run(cmd, ignore_status=True)
         self.log.info(cmd_result)

--- a/examples/tests/raise.py.data/raise.yaml
+++ b/examples/tests/raise.py.data/raise.yaml
@@ -1,3 +1,4 @@
+!mux
 sigint:
     signal_number: 2
 siguser1:

--- a/examples/tests/sleeptenmin.py
+++ b/examples/tests/sleeptenmin.py
@@ -17,9 +17,9 @@ class SleepTenMin(test.Test):
         """
         Sleep for length seconds.
         """
-        cycles = int(self.params.get('sleep_cycles', 1))
-        length = int(self.params.get('sleep_length', 600))
-        method = self.params.get('sleep_method', 'builtin')
+        cycles = int(self.params.get('sleep_cycles', default=1))
+        length = int(self.params.get('sleep_length', default=600))
+        method = self.params.get('sleep_method', default='builtin')
 
         for cycle in xrange(0, cycles):
             self.log.debug("Sleeping for %.2f seconds", length)

--- a/examples/tests/sleeptenmin.py.data/sleeptenmin.mplx
+++ b/examples/tests/sleeptenmin.py.data/sleeptenmin.mplx
@@ -1,20 +1,18 @@
-variants:
-    - sleeptenmin:
-        variants:
-            - builtin:
-                sleep_method = builtin
-            - shell:
-                sleep_method = shell
-        variants:
-            - one_cycle:
-                sleep_cycles = 1
-                sleep_length = 600
-            - six_cycles:
-                sleep_cycles = 6
-                sleep_length = 100
-            - one_hundred_cycles:
-                sleep_cycles = 100
-                sleep_length = 6
-            - six_hundred_cycles:
-                sleep_cycles = 600
-                sleep_length = 1
+sleeptenmin: !mux
+    builtin:
+        sleep_method: builtin
+    shell:
+        sleep_method: shell
+variants: !mux
+    one_cycle:
+        sleep_cycles: 1
+        sleep_length: 600
+    six_cycles:
+        sleep_cycles: 6
+        sleep_length: 100
+    one_hundred_cycles:
+        sleep_cycles: 100
+        sleep_length: 6
+    six_hundred_cycles:
+        sleep_cycles: 600
+        sleep_length: 1

--- a/examples/tests/sleeptest.py.data/sleeptest.yaml
+++ b/examples/tests/sleeptest.py.data/sleeptest.yaml
@@ -1,3 +1,4 @@
+!mux
 !using : test
 short:
     sleep_length: 0.5

--- a/examples/tests/sleeptest.py.data/sleeptest.yaml
+++ b/examples/tests/sleeptest.py.data/sleeptest.yaml
@@ -1,5 +1,4 @@
 !mux
-!using : test
 short:
     sleep_length: 0.5
 medium:

--- a/examples/tests/synctest.py
+++ b/examples/tests/synctest.py
@@ -21,7 +21,7 @@ class SyncTest(test.Test):
         """
         self.cwd = os.getcwd()
         tarball_path = self.get_data_path(self.params.get('sync_tarball', '*',
-                                                          default='synctest.tar.bz2'))
+                                                          'synctest.tar.bz2'))
         archive.extract(tarball_path, self.srcdir)
         self.srcdir = os.path.join(self.srcdir, 'synctest')
         if self.params.get('debug_symbols', default=True):

--- a/examples/tests/synctest.py
+++ b/examples/tests/synctest.py
@@ -20,11 +20,11 @@ class SyncTest(test.Test):
         Build the synctest suite.
         """
         self.cwd = os.getcwd()
-        tarball_path = self.get_data_path(self.params.get('sync_tarball',
-                                                          'synctest.tar.bz2'))
+        tarball_path = self.get_data_path(self.params.get('sync_tarball', '*',
+                                                          default='synctest.tar.bz2'))
         archive.extract(tarball_path, self.srcdir)
         self.srcdir = os.path.join(self.srcdir, 'synctest')
-        if self.params.get('debug_symbols', True):
+        if self.params.get('debug_symbols', default=True):
             build.make(self.srcdir,
                        env={'CFLAGS': '-g -O0'},
                        extra_args='synctest')
@@ -38,8 +38,8 @@ class SyncTest(test.Test):
         os.chdir(self.srcdir)
         path = os.path.join(os.getcwd(), 'synctest')
         cmd = ('%s %s %s' %
-               (path, self.params.get('sync_length', 100),
-                self.params.get('sync_loop', 10)))
+               (path, self.params.get('sync_length', default=100),
+                self.params.get('sync_loop', default=10)))
         process.system(cmd)
         os.chdir(self.cwd)
 

--- a/examples/tests/synctest.py.data/synctest.yaml
+++ b/examples/tests/synctest.py.data/synctest.yaml
@@ -1,12 +1,12 @@
 sync_tarball: synctest.tar.bz2
-loop:
+loop: !mux
     short:
         sync_loop:  10
     medium:
         sync_loop: 50
     long:
         sync_loop: 100
-length:
+length: !mux
     short:
         sync_length: 100
     medium:

--- a/examples/tests/timeouttest.py
+++ b/examples/tests/timeouttest.py
@@ -18,7 +18,7 @@ class TimeoutTest(test.Test):
         """
         This should throw a TestTimeoutError.
         """
-        sleep_time = self.params.get('sleep_time', 5)
+        sleep_time = self.params.get('sleep_time', default=5)
         self.log.info('Sleeping for %.2f seconds (2 more than the timeout)',
                       sleep_time)
         time.sleep(sleep_time)

--- a/examples/tests/whiteboard.py
+++ b/examples/tests/whiteboard.py
@@ -13,8 +13,8 @@ class WhiteBoard(test.Test):
     """
 
     def runTest(self):
-        data_file = self.params.get('whiteboard_data_file', '')
-        data_size = self.params.get('whiteboard_data_size', '10')
+        data_file = self.params.get('whiteboard_data_file', default='')
+        data_size = self.params.get('whiteboard_data_size', default='10')
         if data_file:
             self.log.info('Writing data to whiteboard from file: %s',
                           data_file)
@@ -24,9 +24,9 @@ class WhiteBoard(test.Test):
         else:
             offset = int(data_size) - 1
             data = self.params.get('whiteboard_data_text',
-                                   'default whiteboard text')[0:offset]
+                                   default='default whiteboard text')[0:offset]
 
-        iterations = int(self.params.get('whiteboard_writes', 1))
+        iterations = int(self.params.get('whiteboard_writes', default=1))
 
         result = ''
         for _ in xrange(0, iterations):

--- a/examples/tests/whiteboard.py.data/whiteboard.yaml
+++ b/examples/tests/whiteboard.py.data/whiteboard.yaml
@@ -1,15 +1,15 @@
-source:
+source: !mux
     string:
         whiteboard_data_text: 'foo bar foo baz'
     urandom:
         whiteboard_data_file: '/dev/urandom'
 
-iterations:
+iterations: !mux
     single:
         whiteboard_writes: 1
     dozen:
         whiteboard_writes: 12
-size:
+size: !mux
     onekilo:
         whiteboard_data_size: 1024
     onemega:

--- a/selftests/all/unit/avocado/multiplexer_unittest.py
+++ b/selftests/all/unit/avocado/multiplexer_unittest.py
@@ -92,12 +92,6 @@ class TestAvocadoParams(unittest.TestCase):
         str(multiplexer.AvocadoParams([], 'Unittest', None, [], {}))
         self.assertEqual(26, sum([1 for _ in self.params1.iteritems()]))
 
-    def test_get_old_api(self):
-        self.assertEqual(self.params1.get('unique1'), 'unique1')
-        self.assertEqual(self.params1.get('missing'), None)
-        self.assertEqual(self.params1.get('missing', 'aaa'), 'aaa')
-        self.assertEqual(self.params1.root, 'root')
-
     def test_get_abs_path(self):
         # /ch0/ is not leaf thus it's not queryable
         self.assertEqual(self.params1.get('root', '/ch0/', 'bbb'), 'bbb')

--- a/selftests/all/unit/avocado/tree_unittest.py
+++ b/selftests/all/unit/avocado/tree_unittest.py
@@ -170,20 +170,20 @@ class TestTree(unittest.TestCase):
         self.assertEqual({'new_value': 'something'},
                          oldroot.children[3].children[0].children[0].value)
         # multiplex root (always True)
-        self.assertEqual(tree2.multiplex, True)
+        self.assertEqual(tree2.multiplex, False)
         # multiplex /virt/
-        self.assertEqual(tree2.children[0].multiplex, True)
+        self.assertEqual(tree2.children[0].multiplex, False)
         # multiplex /virt/hw
-        self.assertEqual(tree2.children[0].children[0].multiplex, True)
+        self.assertEqual(tree2.children[0].children[0].multiplex, False)
         # multiplex /virt/distro
-        self.assertEqual(tree2.children[0].children[1].multiplex, False)
+        self.assertEqual(tree2.children[0].children[1].multiplex, True)
         # multiplex /virt/env
-        self.assertEqual(tree2.children[0].children[2].multiplex, False)
+        self.assertEqual(tree2.children[0].children[2].multiplex, True)
         # multiplex /virt/absolutly
-        self.assertEqual(tree2.children[0].children[3].multiplex, True)
+        self.assertEqual(tree2.children[0].children[3].multiplex, False)
         # multiplex /virt/distro/fedora
         self.assertEqual(tree2.children[0].children[1].children[0].multiplex,
-                         True)
+                         False)
 
 
 class TestPathParent(unittest.TestCase):


### PR DESCRIPTION
This patch modifies the multiplexer logic to support full recursive
multiplexation, unlike the old version which only flattened the
multiplexed nodes. This allows greater flexibility.

Additionally it removes the !join flag and inverts the logic to use !mux
instead. By default leaves are not multiplexed and all are part of the
current params. Users can specify exact nodes which get multiplexed by
using !mux keyword.

v0: https://github.com/avocado-framework/avocado/pull/584
v1: https://github.com/avocado-framework/avocado/pull/596

Changes:

    v1: Added documentation
    v1: Updated docstrings
    v2: All tests ported to the new API
    v2: Removed old API unittests
    v2: Fixed bug when using "-m $location:$path" (separate commit)