### PR TITLE
[RFC] Virt test compat layer [V4]

### DIFF
--- a/avocado/core/exceptions.py
+++ b/avocado/core/exceptions.py
@@ -86,6 +86,14 @@ class NotATestError(TestBaseException):
     status = "NOT_A_TEST"
 
 
+class TestNotFoundError(TestBaseException):
+
+    """
+    Indicates that the test was not found in the test directory.
+    """
+    status = "ERROR"
+
+
 class TestTimeoutError(TestBaseException):
 
     """

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -108,6 +108,7 @@ class Job(object):
         self.test_index = 1
         self.status = "RUNNING"
         self.result_proxy = result.TestResultProxy()
+        self.test_loader = loader.TestLoaderProxy()
         self.sysinfo = None
         self.timeout = getattr(self.args, 'job_timeout', 0)
 
@@ -145,12 +146,14 @@ class Job(object):
         shutil.rmtree(self.logdir, ignore_errors=True)
 
     def _make_test_loader(self):
-        if hasattr(self.args, 'test_loader'):
-            test_loader_class = self.args.test_loader
-        else:
-            test_loader_class = loader.TestLoader
-
-        self.test_loader = test_loader_class(job=self)
+        for key in self.args.__dict__.keys():
+            if key.endswith('_loader'):
+                loader_class = getattr(self.args, key)
+                if issubclass(loader_class, loader.TestLoader):
+                    loader_plugin = loader_class(self)
+                    self.test_loader.add_loader_plugin(loader_plugin)
+        filesystem_loader = loader.TestLoader(self)
+        self.test_loader.add_loader_plugin(filesystem_loader)
 
     def _make_test_runner(self):
         if hasattr(self.args, 'test_runner'):
@@ -249,9 +252,7 @@ class Job(object):
 
         self._make_test_loader()
 
-        params_list = self.test_loader.discover_urls(urls)
-        test_suite = self.test_loader.discover(params_list)
-        return test_suite
+        return self.test_loader.discover(urls)
 
     def _validate_test_suite(self, test_suite):
         try:

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -403,14 +403,14 @@ class View(object):
         if self.use_paginator:
             self.paginator.close()
 
-    def notify(self, event='message', msg=None):
+    def notify(self, event='message', msg=None, skip_newline=False):
         mapping = {'message': self._log_ui_header,
                    'minor': self._log_ui_minor,
                    'error': self._log_ui_error,
                    'warning': self._log_ui_warning,
                    'partial': self._log_ui_partial}
         if msg is not None:
-            mapping[event](msg)
+            mapping[event](msg=msg, skip_newline=skip_newline)
 
     def notify_progress(self, progress):
         self._log_ui_throbber_progress(progress)
@@ -491,37 +491,37 @@ class View(object):
         """
         self._log_ui_info(term_support.partial_str(msg), skip_newline)
 
-    def _log_ui_header(self, msg):
+    def _log_ui_header(self, msg, skip_newline=False):
         """
         Log a header message.
 
         :param msg: Message to write.
         """
-        self._log_ui_info(term_support.header_str(msg))
+        self._log_ui_info(term_support.header_str(msg), skip_newline)
 
-    def _log_ui_minor(self, msg):
+    def _log_ui_minor(self, msg, skip_newline=False):
         """
         Log a minor message.
 
         :param msg: Message to write.
         """
-        self._log_ui_info(msg)
+        self._log_ui_info(msg, skip_newline)
 
-    def _log_ui_error(self, msg):
+    def _log_ui_error(self, msg, skip_newline=False):
         """
         Log an error message (useful for critical errors).
 
         :param msg: Message to write.
         """
-        self._log_ui_error_base(term_support.fail_header_str(msg))
+        self._log_ui_error_base(term_support.fail_header_str(msg), skip_newline)
 
-    def _log_ui_warning(self, msg):
+    def _log_ui_warning(self, msg, skip_newline=False):
         """
         Log a warning message (useful for warning messages).
 
         :param msg: Message to write.
         """
-        self._log_ui_info(term_support.warn_header_str(msg))
+        self._log_ui_info(term_support.warn_header_str(msg), skip_newline)
 
     def _log_ui_status_pass(self, t_elapsed):
         """

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -613,8 +613,10 @@ class View(object):
         self.file_handler.setFormatter(formatter)
         test_logger = logging.getLogger('avocado.test')
         linux_logger = logging.getLogger('avocado.linux')
+        root_logger = logging.getLogger()
         test_logger.addHandler(self.file_handler)
         linux_logger.addHandler(self.file_handler)
+        root_logger.addHandler(self.file_handler)
 
     def stop_file_logging(self):
         """

--- a/avocado/core/plugins/htmlresult.py
+++ b/avocado/core/plugins/htmlresult.py
@@ -112,7 +112,8 @@ class ReportModel(object):
                    "ALERT": "danger",
                    "RUNNING": "info",
                    "NOSTATUS": "info",
-                   "INTERRUPTED": "danger"}
+                   "INTERRUPTED": "danger",
+                   "NOT_A_TEST": "warning"}
         test_info = self.json['tests']
         results_dir = self.results_dir(False)
         for t in test_info:

--- a/avocado/core/plugins/virt_test.py
+++ b/avocado/core/plugins/virt_test.py
@@ -1,0 +1,1014 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2015
+# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+
+"""
+Avocado virt-test compatibility wrapper
+"""
+
+import os
+import sys
+import logging
+import Queue
+import imp
+import time
+
+from avocado.core import result
+from avocado.core import loader
+from avocado.core.plugins import plugin
+from avocado import test
+from avocado.settings import settings
+from avocado.settings import config_path_local
+from avocado.utils import path
+
+if 'VIRT_TEST_DIR' in os.environ:
+    virt_test_dir = os.environ['VIRT_TEST_DIR']
+else:
+    virt_test_dir = settings.get_value(section='virt_test', key='virt_test_dir', default=None)
+    if virt_test_dir is None or not os.path.isdir(virt_test_dir):
+        print('Virt test dir not set/invalid. Please make sure you add to %s' % config_path_local)
+        print('')
+        print('[virt-test]')
+        print('virt_test_dir=/valid/path/to/virt_test')
+        print('')
+        print('You can also export $VIRT_TEST_DIR (takes precedence over the config file)')
+        print('$ export VIRT_TEST_DIR="/valid/path/to/virt_test"')
+        sys.exit(1)
+
+sys.path.append(os.path.expanduser(virt_test_dir))
+
+from autotest.client import utils
+from autotest.client.shared import error
+
+from virttest import asset
+from virttest import arch
+from virttest import bootstrap
+from virttest import cartesian_config
+from virttest import data_dir
+from virttest import defaults
+from virttest import env_process
+from virttest import funcatexit
+from virttest import standalone_test
+from virttest import utils_env
+from virttest import utils_misc
+from virttest import utils_params
+from virttest import version
+
+from virttest.standalone_test import SUPPORTED_TEST_TYPES
+from virttest.standalone_test import SUPPORTED_LIBVIRT_URIS
+from virttest.standalone_test import SUPPORTED_LIBVIRT_DRIVERS
+from virttest.standalone_test import SUPPORTED_IMAGE_TYPES
+from virttest.standalone_test import SUPPORTED_DISK_BUSES
+from virttest.standalone_test import SUPPORTED_NIC_MODELS
+from virttest.standalone_test import SUPPORTED_NET_TYPES
+from virttest.standalone_test import QEMU_DEFAULT_SET
+from virttest.standalone_test import LIBVIRT_DEFAULT_SET
+from virttest.standalone_test import LVSB_DEFAULT_SET
+from virttest.standalone_test import OVS_DEFAULT_SET
+from virttest.standalone_test import LIBVIRT_INSTALL
+from virttest.standalone_test import LIBVIRT_REMOVE
+
+
+class VirtTestResult(result.HumanTestResult):
+
+    """
+    Virt Test compatibility layer Result class.
+    """
+
+    def __init__(self, stream, args):
+        """
+        Creates an instance of RemoteTestResult.
+
+        :param stream: an instance of :class:`avocado.core.output.View`.
+        :param args: an instance of :class:`argparse.Namespace`.
+        """
+        result.HumanTestResult.__init__(self, stream, args)
+        self.output = '-'
+        self.setup()
+
+    def setup(self):
+        """
+        Run the bootstrap needed before virt-test starts
+
+        This usually includes downloading/restoring JeOS images, among others.
+        """
+        options = self.args
+        test_dir = None
+        if options.vt_type:
+            test_dir = data_dir.get_backend_dir(options.vt_type)
+        elif options.vt_config:
+            parent_config_dir = os.path.dirname(os.path.dirname(options.vt_config))
+            parent_config_dir = os.path.dirname(parent_config_dir)
+            options.vt_type = parent_config_dir
+            test_dir = os.path.abspath(parent_config_dir)
+
+        if options.vt_type == 'qemu':
+            check_modules = arch.get_kvm_module_list()
+        else:
+            check_modules = None
+        online_docs_url = "https://github.com/autotest/virt-test/wiki"
+
+        kwargs = {'test_name': options.vt_type,
+                  'test_dir': test_dir,
+                  'base_dir': data_dir.get_data_dir(),
+                  'default_userspace_paths': None,
+                  'check_modules': check_modules,
+                  'online_docs_url': online_docs_url,
+                  'selinux': options.vt_selinux_setup,
+                  'restore_image': not(options.vt_no_downloads or
+                                       options.vt_keep_image),
+                  'interactive': False,
+                  'update_providers': False,
+                  'guest_os': options.vt_guest_os or defaults.DEFAULT_GUEST_OS}
+
+        failed = False
+        wait_message_printed = False
+
+        bg = utils.InterruptedThread(bootstrap.bootstrap, kwargs=kwargs)
+        t_begin = time.time()
+        bg.start()
+
+        while bg.isAlive():
+            if not wait_message_printed:
+                self.stream.notify(event='message', msg="SETUP      :  ", skip_newline=True)
+                wait_message_printed = True
+            self.stream.notify_progress(True)
+            time.sleep(0.1)
+
+        reason = None
+        try:
+            bg.join()
+        except Exception, e:
+            failed = True
+            reason = e
+
+        t_end = time.time()
+        t_elapsed = t_end - t_begin
+        state = dict()
+        state['time_elapsed'] = t_elapsed
+        if not failed:
+            self.stream.set_test_status(status='PASS', state=state)
+        else:
+            self.stream.set_test_status(status='FAIL', state=state)
+            self.stream.notify(event='error', msg="Setup error: %s" % reason)
+            sys.exit(-1)
+
+        return True
+
+
+class VirtTestLoader(loader.TestLoader):
+
+    def __init__(self, job):
+        loader.TestLoader.__init__(self, job=job)
+
+    def _get_parser(self):
+        options_processor = VirtTestOptionsProcess(self.job)
+        return options_processor.get_parser()
+
+    def discover(self, params_list):
+        """
+        Discover tests for test suite.
+
+        :param params_list: a list of test parameters.
+        :type params_list: list
+        :return: a test suite (a list of test factories).
+        """
+        test_suite = []
+        for params in params_list:
+            test_parameters = {'name': params['shortname'],
+                               'base_logdir': self.job.logdir,
+                               'params': params,
+                               'job': self.job}
+            test_suite.append((VirtTest, test_parameters))
+        return test_suite
+
+    def validate_ui(self, test_suite, ignore_missing=False,
+                    ignore_not_test=False, ignore_broken_symlinks=False,
+                    ignore_access_denied=False):
+        pass
+
+    def discover_url(self, url):
+        cartesian_parser = self._get_parser()
+        cartesian_parser.only_filter(url)
+        params_list = [t for t in cartesian_parser.get_dicts()]
+        return params_list
+
+
+class VirtTest(test.Test):
+
+    """
+    Mininal test class used to run a virt test.
+    """
+
+    env_version = utils_env.get_env_version()
+
+    def __init__(self, methodName='runTest', name=None, params=None,
+                 base_logdir=None, tag=None, job=None, runner_queue=None):
+        del name
+        options = job.args
+
+        self.bindir = data_dir.get_root_dir()
+        self.virtdir = os.path.join(self.bindir, 'shared')
+        self.builddir = os.path.join(self.bindir, 'backends', params.get("vm_type"))
+        self.srcdir = path.init_dir(os.path.join(self.builddir, 'src'))
+        self.tmpdir = path.init_dir(os.path.join(self.bindir, 'tmp'))
+
+        self.iteration = 0
+        if options.vt_config:
+            name = params.get("shortname")
+        else:
+            name = params.get("_short_name_map_file")["subtests.cfg"]
+        self.outputdir = None
+        self.resultsdir = None
+        self.logfile = None
+        self.file_handler = None
+        self.background_errors = Queue.Queue()
+        super(VirtTest, self).__init__(methodName=methodName, name=name, params=params, base_logdir=base_logdir,
+                                       tag=tag, job=job, runner_queue=runner_queue)
+        self.params = utils_params.Params(params)
+        self.debugdir = self.logdir
+        utils_misc.set_log_file_dir(self.logdir)
+
+    def start_logging(self):
+        super(VirtTest, self).start_logging()
+        root_logger = logging.getLogger()
+        root_logger.addHandler(self.file_handler)
+
+    def stop_logging(self):
+        super(VirtTest, self).stop_logging()
+        root_logger = logging.getLogger()
+        root_logger.removeHandler(self.file_handler)
+
+    def write_test_keyval(self, d):
+        self.whiteboard = str(d)
+
+    def verify_background_errors(self):
+        """
+        Verify if there are any errors that happened on background threads.
+
+        :raise Exception: Any exception stored on the background_errors queue.
+        """
+        try:
+            exc = self.background_errors.get(block=False)
+        except Queue.Empty:
+            pass
+        else:
+            raise exc[1], None, exc[2]
+
+    def runTest(self):
+        params = self.params
+
+        # If a dependency test prior to this test has failed, let's fail
+        # it right away as TestNA.
+        if params.get("dependency_failed") == 'yes':
+            raise error.TestNAError("Test dependency failed")
+
+        # Report virt test version
+        logging.info(version.get_pretty_version_info())
+        # Report the parameters we've received and write them as keyvals
+        logging.info("Starting test %s", self.tag)
+        logging.debug("Test parameters:")
+        keys = params.keys()
+        keys.sort()
+        for key in keys:
+            logging.debug("    %s = %s", key, params[key])
+
+        # Warn of this special condition in related location in output & logs
+        if os.getuid() == 0 and params.get('nettype', 'user') == 'user':
+            logging.warning("")
+            logging.warning("Testing with nettype='user' while running "
+                            "as root may produce unexpected results!!!")
+            logging.warning("")
+
+        # Open the environment file
+        env_filename = os.path.join(
+            data_dir.get_backend_dir(params.get("vm_type")),
+            params.get("env", "env"))
+        env = utils_env.Env(env_filename, self.env_version)
+
+        test_passed = False
+        t_type = None
+
+        try:
+            try:
+                try:
+                    subtest_dirs = []
+
+                    other_subtests_dirs = params.get("other_tests_dirs", "")
+                    for d in other_subtests_dirs.split():
+                        d = os.path.join(*d.split("/"))
+                        subtestdir = os.path.join(self.bindir, d, "tests")
+                        if not os.path.isdir(subtestdir):
+                            raise error.TestError("Directory %s does not "
+                                                  "exist" % subtestdir)
+                        subtest_dirs += data_dir.SubdirList(subtestdir,
+                                                            bootstrap.test_filter)
+
+                    provider = params.get("provider", None)
+
+                    if provider is None:
+                        # Verify if we have the correspondent source file for
+                        # it
+                        for generic_subdir in asset.get_test_provider_subdirs('generic'):
+                            subtest_dirs += data_dir.SubdirList(generic_subdir,
+                                                                bootstrap.test_filter)
+
+                        for specific_subdir in asset.get_test_provider_subdirs(params.get("vm_type")):
+                            subtest_dirs += data_dir.SubdirList(
+                                specific_subdir, bootstrap.test_filter)
+                    else:
+                        provider_info = asset.get_test_provider_info(provider)
+                        for key in provider_info['backends']:
+                            subtest_dirs += data_dir.SubdirList(
+                                provider_info['backends'][key]['path'],
+                                bootstrap.test_filter)
+
+                    subtest_dir = None
+
+                    # Get the test routine corresponding to the specified
+                    # test type
+                    logging.debug("Searching for test modules that match "
+                                  "'type = %s' and 'provider = %s' "
+                                  "on this cartesian dict",
+                                  params.get("type"), params.get("provider", None))
+
+                    t_types = params.get("type").split()
+                    # Make sure we can load provider_lib in tests
+                    for s in subtest_dirs:
+                        if os.path.dirname(s) not in sys.path:
+                            sys.path.insert(0, os.path.dirname(s))
+
+                    test_modules = {}
+                    for t_type in t_types:
+                        for d in subtest_dirs:
+                            module_path = os.path.join(d, "%s.py" % t_type)
+                            if os.path.isfile(module_path):
+                                logging.debug("Found subtest module %s",
+                                              module_path)
+                                subtest_dir = d
+                                break
+                        if subtest_dir is None:
+                            msg = ("Could not find test file %s.py on test"
+                                   "dirs %s" % (t_type, subtest_dirs))
+                            raise error.TestError(msg)
+                        # Load the test module
+                        f, p, d = imp.find_module(t_type, [subtest_dir])
+                        test_modules[t_type] = imp.load_module(t_type, f, p, d)
+                        f.close()
+
+                    # Preprocess
+                    try:
+                        params = env_process.preprocess(self, params, env)
+                    finally:
+                        env.save()
+
+                    # Run the test function
+                    for t_type in t_types:
+                        test_module = test_modules[t_type]
+                        run_func = utils_misc.get_test_entrypoint_func(
+                            t_type, test_module)
+                        try:
+                            run_func(self, params, env)
+                            self.verify_background_errors()
+                        finally:
+                            env.save()
+                    test_passed = True
+                    error_message = funcatexit.run_exitfuncs(env, t_type)
+                    if error_message:
+                        raise error.TestWarn("funcatexit failed with: %s"
+                                             % error_message)
+
+                except Exception:
+                    if t_type is not None:
+                        error_message = funcatexit.run_exitfuncs(env, t_type)
+                        if error_message:
+                            logging.error(error_message)
+                    try:
+                        env_process.postprocess_on_error(self, params, env)
+                    finally:
+                        env.save()
+                    raise
+
+            finally:
+                # Postprocess
+                try:
+                    try:
+                        env_process.postprocess(self, params, env)
+                    except Exception, e:
+                        if test_passed:
+                            raise
+                        logging.error("Exception raised during "
+                                      "postprocessing: %s", e)
+                finally:
+                    env.save()
+
+        except Exception, e:
+            if params.get("abort_on_error") != "yes":
+                raise
+            # Abort on error
+            logging.info("Aborting job (%s)", e)
+            if params.get("vm_type") == "qemu":
+                for vm in env.get_all_vms():
+                    if vm.is_dead():
+                        continue
+                    logging.info("VM '%s' is alive.", vm.name)
+                    for m in vm.monitors:
+                        logging.info("It has a %s monitor unix socket at: %s",
+                                     m.protocol, m.filename)
+                    logging.info("The command line used to start it was:\n%s",
+                                 vm.make_qemu_command())
+                raise error.JobError("Abort requested (%s)" % e)
+
+        return test_passed
+
+
+class VirtTestOptionsProcess(object):
+
+    """
+    Pick virt test options and parse them to get to a cartesian parser.
+    """
+
+    def __init__(self, job):
+        """
+        Parses options and initializes attributes.
+        """
+        self.options = job.args
+        # There are a few options from the original virt-test runner
+        # that don't quite make sense for avocado (avocado implements a better version of the virt-test feature).
+        # So let's just inject some values into options.
+        self.options.vt_verbose = False
+        self.options.vt_log_level = logging.DEBUG
+        self.options.vt_console_level = logging.DEBUG
+        self.options.vt_no_downloads = False
+        self.options.vt_selinux_setup = False
+        # These options can be done by using virt test scripts
+        self.options.vt_list_tests = False
+        self.options.vt_list_guests = False
+        # Here we'll inject values from the config file. Doing this makes things configurable yet the number
+        # of options is not overwhelming.
+        # setup section
+        self.options.vt_keep_image = settings.get_value('virt_test.setup', 'keep_image', key_type=bool)
+        self.options.vt_keep_image_between_tests = settings.get_value('virt_test.setup', 'keep_image_between_tests',
+                                                                      key_type=bool)
+        self.options.vt_keep_guest_running = settings.get_value('virt_test.setup', 'keep_guest_running', key_type=bool)
+        # common section
+        self.options.vt_data_dir = settings.get_value('virt_test.common', 'data_dir', default=data_dir.get_data_dir())
+        self.options.vt_type_specific = settings.get_value('virt_test.common', 'type_specific_only', key_type=bool)
+        self.options.vt_mem = settings.get_value('virt_test.common', 'mem', key_type=int)
+
+        self.view = job.view
+        self.cartesian_parser = None
+
+    def _process_qemu_bin(self):
+        """
+        Puts the value of the qemu bin option in the cartesian parser command.
+        """
+        if self.options.vt_config and self.options.vt_qemu_bin is None:
+            logging.info("Config provided and no --vt-qemu-bin set. Not trying "
+                         "to automatically set qemu bin.")
+        else:
+            (qemu_bin_path, qemu_img_path, qemu_io_path,
+             qemu_dst_bin_path) = standalone_test.find_default_qemu_paths(self.options.vt_qemu_bin,
+                                                                          self.options.vt_dst_qemu_bin)
+            self.cartesian_parser.assign("qemu_binary", qemu_bin_path)
+            self.cartesian_parser.assign("qemu_img_binary", qemu_img_path)
+            self.cartesian_parser.assign("qemu_io_binary", qemu_io_path)
+            if qemu_dst_bin_path is not None:
+                self.cartesian_parser.assign("qemu_dst_binary",
+                                             qemu_dst_bin_path)
+
+    def _process_qemu_img(self):
+        """
+        Puts the value of the qemu bin option in the cartesian parser command.
+        """
+        if self.options.vt_config and self.options.vt_qemu_bin is None:
+            logging.info("Config provided and no --vt-qemu-bin set. Not trying "
+                         "to automatically set qemu bin.")
+        else:
+            (_, qemu_img_path,
+             _, _) = standalone_test.find_default_qemu_paths(self.options.vt_qemu_bin,
+                                                             self.options.vt_dst_qemu_bin)
+            self.cartesian_parser.assign("qemu_img_binary", qemu_img_path)
+
+    def _process_qemu_accel(self):
+        """
+        Puts the value of the qemu bin option in the cartesian parser command.
+        """
+        if self.options.vt_accel == 'tcg':
+            self.cartesian_parser.assign("disable_kvm", "yes")
+
+    def _process_bridge_mode(self):
+        if self.options.vt_nettype not in SUPPORTED_NET_TYPES:
+            self.view.notify(event='error', msg="Invalid --vt-nettype option '%s'. Valid options are: (%s)" %
+                             (self.options.vt_nettype, ", ".join(SUPPORTED_NET_TYPES)))
+            sys.exit(1)
+        if self.options.vt_nettype == 'bridge':
+            if os.getuid() != 0:
+                self.view.notify(event='error', msg="In order to use bridge, you need to be root, aborting...")
+                sys.exit(1)
+            self.cartesian_parser.assign("nettype", "bridge")
+            self.cartesian_parser.assign("netdst", self.options.netdst)
+        elif self.options.vt_nettype == 'user':
+            self.cartesian_parser.assign("nettype", "user")
+        elif self.options.vt_nettype == 'none':
+            self.cartesian_parser.assign("nettype", "none")
+
+    def _process_monitor(self):
+        if self.options.vt_monitor == 'qmp':
+            self.cartesian_parser.assign("monitors", "qmp1")
+            self.cartesian_parser.assign("monitor_type_qmp1", "qmp")
+
+    def _process_smp(self):
+        if not self.options.vt_config:
+            if self.options.vt_smp == '1':
+                self.cartesian_parser.only_filter("up")
+            elif self.options.vt_smp == '2':
+                self.cartesian_parser.only_filter("smp2")
+            else:
+                try:
+                    self.cartesian_parser.only_filter("up")
+                    self.cartesian_parser.assign("smp", int(self.options.vt_smp))
+                except ValueError:
+                    self.view.notify(event='error', msg="Invalid option for smp: %s, aborting..." % self.options.vt_smp)
+                    sys.exit(1)
+        else:
+            logging.info("Config provided, ignoring --vt-smp option")
+
+    def _process_arch(self):
+        if self.options.vt_arch is None:
+            pass
+        elif not self.options.vt_config:
+            self.cartesian_parser.only_filter(self.options.vt_arch)
+        else:
+            logging.info("Config provided, ignoring --vt-arch option")
+
+    def _process_machine_type(self):
+        if not self.options.vt_config:
+            if self.options.vt_machine_type is None:
+                # TODO: this is x86-specific, instead we can get the default
+                # arch from qemu binary and run on all supported machine types
+                if self.options.vt_arch is None and self.options.vt_guest_os is None:
+                    import virttest.defaults
+                    self.cartesian_parser.only_filter(
+                        virttest.defaults.DEFAULT_MACHINE_TYPE)
+            else:
+                self.cartesian_parser.only_filter(self.options.vt_machine_type)
+        else:
+            logging.info("Config provided, ignoring --vt-machine-type option")
+
+    def _process_image_type(self):
+        if not self.options.vt_config:
+            if self.options.vt_image_type in SUPPORTED_IMAGE_TYPES:
+                self.cartesian_parser.only_filter(self.options.vt_image_type)
+            else:
+                self.cartesian_parser.only_filter("raw")
+                # The actual param name is image_format.
+                self.cartesian_parser.assign("image_format",
+                                             self.options.vt_image_type)
+        else:
+            logging.info("Config provided, ignoring --vt-image-type option")
+
+    def _process_nic_model(self):
+        if not self.options.vt_config:
+            if self.options.vt_nic_model in SUPPORTED_NIC_MODELS:
+                self.cartesian_parser.only_filter(self.options.vt_nic_model)
+            else:
+                self.cartesian_parser.only_filter("nic_custom")
+                self.cartesian_parser.assign(
+                    "nic_model", self.options.vt_nic_model)
+        else:
+            logging.info("Config provided, ignoring --vt-nic-model option")
+
+    def _process_disk_buses(self):
+        if not self.options.vt_config:
+            if self.options.vt_disk_bus in SUPPORTED_DISK_BUSES:
+                self.cartesian_parser.only_filter(self.options.vt_disk_bus)
+            else:
+                self.view.notify(event='error', msg=("Option %s is not in the list %s, aborting..." %
+                                                     (self.options.vt_disk_bus, SUPPORTED_DISK_BUSES)))
+                sys.exit(1)
+        else:
+            logging.info("Config provided, ignoring --vt-disk-bus option")
+
+    def _process_vhost(self):
+        if not self.options.vt_config:
+            if self.options.vt_nettype == "bridge":
+                if self.options.vt_vhost == "on":
+                    self.cartesian_parser.assign("vhost", "on")
+                elif self.options.vt_vhost == "force":
+                    self.cartesian_parser.assign("netdev_extra_params",
+                                                 '",vhostforce=on"')
+                    self.cartesian_parser.assign("vhost", "on")
+            else:
+                if self.options.vt_vhost in ["on", "force"]:
+                    self.view.notify(event='error', msg=("Nettype %s is incompatible with vhost %s, aborting..." %
+                                                         (self.options.vt_nettype, self.options.vt_vhost)))
+                    sys.exit(1)
+        else:
+            logging.info("Config provided, ignoring --vt-vhost option")
+
+    def _process_qemu_sandbox(self):
+        if not self.options.vt_config:
+            if self.options.vt_qemu_sandbox == "off":
+                self.cartesian_parser.assign("qemu_sandbox", "off")
+        else:
+            logging.info("Config provided, ignoring \"--vt-sandbox <on|off>\" option")
+
+    def _process_qemu_defconfig(self):
+        if not self.options.vt_config:
+            if self.options.vt_qemu_defconfig == "no":
+                self.cartesian_parser.assign("defconfig", "no")
+        else:
+            logging.info("Config provided, ignoring \"--defconfig <yes|no>\" option")
+
+    def _process_malloc_perturb(self):
+        self.cartesian_parser.assign("malloc_perturb",
+                                     self.options.vt_malloc_perturb)
+
+    def _process_qemu_specific_options(self):
+        """
+        Calls for processing all options specific to the qemu test.
+
+        This method modifies the cartesian set by parsing additional lines.
+        """
+
+        self._process_qemu_bin()
+        self._process_qemu_accel()
+        self._process_monitor()
+        self._process_smp()
+        self._process_image_type()
+        self._process_nic_model()
+        self._process_disk_buses()
+        self._process_vhost()
+        self._process_malloc_perturb()
+        self._process_qemu_sandbox()
+
+    def _process_lvsb_specific_options(self):
+        """
+        Calls for processing all options specific to lvsb test
+        """
+        self.options.no_downloads = True
+
+    def _process_libvirt_specific_options(self):
+        """
+        Calls for processing all options specific to libvirt test.
+        """
+        if self.options.uri:
+            driver_found = False
+            for driver in SUPPORTED_LIBVIRT_DRIVERS:
+                if self.options.uri.count(driver):
+                    driver_found = True
+                    self.cartesian_parser.only_filter(driver)
+            if not driver_found:
+                self.view.notify(event='error', msg="Unsupported uri: %s." % self.options.uri)
+                sys.exit(1)
+        else:
+            self.cartesian_parser.only_filter("qemu")
+
+    def _process_guest_os(self):
+        if not self.options.vt_config:
+            if len(standalone_test.get_guest_name_list(self.options)) == 0:
+                self.view.notify(event='error', msg="Guest name %s is not on the known guest os list "
+                                                    "(see --vt-list-guests), aborting..." % self.options.vt_guest_os)
+                sys.exit(1)
+            self.cartesian_parser.only_filter(
+                self.options.vt_guest_os or defaults.DEFAULT_GUEST_OS)
+        else:
+            logging.info("Config provided, ignoring --vt-guest-os option")
+
+    def _process_list(self):
+        if self.options.vt_list_tests:
+            standalone_test.print_test_list(self.options,
+                                            self.cartesian_parser)
+            sys.exit(0)
+        if self.options.vt_list_guests:
+            standalone_test.print_guest_list(self.options)
+            sys.exit(0)
+
+    def _process_tests(self):
+        if not self.options.vt_config:
+            if self.options.vt_type:
+                if self.options.url and self.options.dropin:
+                    self.view.notify(event='error', msg="Option --vt-tests and --vt-run-dropin can't be set at "
+                                                        "the same time")
+                    sys.exit(1)
+                elif self.options.url:
+                    tests = self.options.url
+                    if self.options.vt_type == 'libvirt':
+                        if self.options.install_guest:
+                            tests.insert(0, LIBVIRT_INSTALL)
+                        if self.options.vt_remove_guest_guest:
+                            tests.append(LIBVIRT_REMOVE)
+                    self.cartesian_parser.only_filter(", ".join(tests))
+                elif self.options.dropin:
+                    dropin_tests = os.listdir(os.path.join(data_dir.get_root_dir(), "dropin"))
+                    if len(dropin_tests) <= 1:
+                        self.view.notify(event='error', msg="No drop in tests detected, aborting. "
+                                                            "Make sure you have scripts on the 'dropin' "
+                                                            "directory")
+                        sys.exit(1)
+                    self.cartesian_parser.only_filter("dropin")
+                else:
+                    if self.options.vt_type == 'qemu':
+                        self.cartesian_parser.only_filter(QEMU_DEFAULT_SET)
+                        self.cartesian_parser.no_filter("with_reboot")
+                    elif self.options.vt_type == 'libvirt':
+                        self.cartesian_parser.only_filter(LIBVIRT_DEFAULT_SET)
+                    elif self.options.vt_type == 'lvsb':
+                        self.cartesian_parser.only_filter(LVSB_DEFAULT_SET)
+                    elif self.options.vt_type == 'openvswitch':
+                        self.cartesian_parser.only_filter(OVS_DEFAULT_SET)
+        else:
+            logging.info("Config provided, ignoring --vt-tests option")
+
+    def _process_restart_vm(self):
+        if not self.options.vt_config:
+            if not self.options.vt_keep_guest_running:
+                self.cartesian_parser.assign("kill_vm", "yes")
+
+    def _process_restore_image_between_tests(self):
+        if not self.options.vt_config:
+            if not self.options.vt_keep_image_between_tests:
+                self.cartesian_parser.assign("restore_image", "yes")
+
+    def _process_mem(self):
+        self.cartesian_parser.assign("mem", self.options.vt_mem)
+
+    def _process_tcpdump(self):
+        """
+        Verify whether we can run tcpdump. If we can't, turn it off.
+        """
+        try:
+            tcpdump_path = utils_misc.find_command('tcpdump')
+        except ValueError:
+            tcpdump_path = None
+
+        non_root = os.getuid() != 0
+
+        if tcpdump_path is None or non_root:
+            self.cartesian_parser.assign("run_tcpdump", "no")
+
+    def _process_no_filter(self):
+        if not self.options.vt_config:
+            if self.options.vt_no_filter:
+                no_filter = ", ".join(self.options.vt_no_filter.split(' '))
+                self.cartesian_parser.no_filter(no_filter)
+
+    def _process_only_type_specific(self):
+        if not self.options.vt_config:
+            if self.options.vt_type_specific:
+                self.cartesian_parser.only_filter("(subtest=type_specific)")
+
+    def _process_general_options(self):
+        """
+        Calls for processing all generic options.
+
+        This method modifies the cartesian set by parsing additional lines.
+        """
+        self._process_guest_os()
+        self._process_arch()
+        self._process_machine_type()
+        self._process_restart_vm()
+        self._process_restore_image_between_tests()
+        self._process_mem()
+        self._process_tcpdump()
+        self._process_no_filter()
+        self._process_qemu_img()
+        self._process_bridge_mode()
+        self._process_only_type_specific()
+
+    def _process_options(self):
+        """
+        Process the options given in the command line.
+        """
+
+        if (not self.options.vt_type) and (not self.options.vt_config):
+            self.view.notify(event='error',
+                             msg="No type (--vt-type) or config (--vt-config) options specified, aborting...")
+            sys.exit(0)
+
+        if self.options.vt_type:
+            if self.options.vt_type not in SUPPORTED_TEST_TYPES:
+                self.view.notify(event='error', msg="Invalid test type %s. Valid test types: %s. Aborting..." %
+                                                    (self.options.vt_type, " ".join(SUPPORTED_TEST_TYPES)))
+                sys.exit(1)
+
+        if self.options.vt_data_dir:
+            data_dir.set_backing_data_dir(self.options.vt_data_dir)
+
+        standalone_test.create_config_files(self.options)
+
+        self.cartesian_parser = cartesian_config.Parser(debug=False)
+
+        if self.options.vt_config:
+            cfg = os.path.abspath(self.options.vt_config)
+
+        if not self.options.vt_config:
+            cfg = data_dir.get_backend_cfg_path(self.options.vt_type, 'tests.cfg')
+
+        self.cartesian_parser.parse_file(cfg)
+        if self.options.vt_type != 'lvsb':
+            self._process_general_options()
+
+        if self.options.vt_type == 'qemu':
+            self._process_qemu_specific_options()
+        elif self.options.vt_type == 'lvsb':
+            self._process_lvsb_specific_options()
+        elif self.options.vt_type == 'openvswitch':
+            self._process_qemu_specific_options()
+        elif self.options.vt_type == 'libvirt':
+            self._process_libvirt_specific_options()
+        # List and tests have to be the last things to be processed
+        self._process_list()
+        # Tests won't be processed here. The code of the function will
+        # be utilized elsewhere.
+        # self._process_tests()
+
+    def get_parser(self):
+        if not self.options.show_job_log:
+            standalone_test.handle_stdout(self.options)
+        self._process_options()
+        standalone_test.reset_logging()
+        standalone_test.configure_console_logging(loglevel=logging.INFO)
+        return self.cartesian_parser
+
+
+class VirtTestCompatPlugin(plugin.Plugin):
+
+    """
+    Implements the avocado virt test options
+    """
+
+    name = 'virt_test_compat_runner'
+    enabled = True
+
+    def configure(self, parser):
+        """
+        Add the subparser for the run action.
+
+        :param parser: Main test runner parser.
+        """
+        self.parser = parser
+
+        try:
+            qemu_bin_path = standalone_test.find_default_qemu_paths()[0]
+        except ValueError:
+            qemu_bin_path = "Could not find one"
+
+        if os.getuid() == 0:
+            nettype_default = 'bridge'
+        else:
+            nettype_default = 'user'
+
+        qemu_nw_msg = "QEMU network option (%s). " % ", ".join(SUPPORTED_NET_TYPES)
+        qemu_nw_msg += "Default: user"
+
+        vt_compat_group_setup = parser.runner.add_argument_group('Virt-Test compat layer - VM Setup options')
+        vt_compat_group_common = parser.runner.add_argument_group('Virt-Test compat layer - Common options')
+        vt_compat_group_qemu = parser.runner.add_argument_group('Virt-Test compat layer - QEMU options')
+        vt_compat_group_libvirt = parser.runner.add_argument_group('Virt-Test compat layer - Libvirt options')
+        vt_compat_group_debug = parser.runner.add_argument_group('Virt-Test compat layer - Debug options')
+
+        current_run_setup = settings.get_value('virt_test.setup', 'run_setup', key_type=bool)
+
+        vt_compat_group_setup.add_argument("--vt-setup", action="store_true",
+                                           dest="vt_setup",
+                                           default=current_run_setup,
+                                           help="Run virt test setup actions (restore JeOS image from pristine). "
+                                                "Current: %s" % current_run_setup)
+
+        vt_compat_group_common.add_argument("--vt-config", action="store", dest="vt_config",
+                                            help=("Explicitly choose a cartesian config. "
+                                                  "When choosing this, some options will be "
+                                                  "ignored (see options below)"))
+        vt_compat_group_common.add_argument("--vt-type", action="store", dest="vt_type",
+                                            help="Choose test type (%s). Default: qemu" %
+                                                 ", ".join(SUPPORTED_TEST_TYPES),
+                                            default='qemu')
+        vt_compat_group_common.add_argument("--vt-guest-os", action="store", dest="vt_guest_os",
+                                            default=None,
+                                            help=("Select the guest OS to be used. "
+                                                  "If --vt-config is provided, this will be ignored. "
+                                                  "Default: %s" % defaults.DEFAULT_GUEST_OS))
+        vt_compat_group_common.add_argument("--vt-no-filter", action="store", dest="vt_no_filter", default="",
+                                            help=("List of space separated 'no' filters to be "
+                                                  "passed to the config parser. If --vt-config is "
+                                                  "provided, this will be ignored. Default: ''"))
+        vt_compat_group_common.add_argument("--vt-arch", action="store", dest="vt_arch",
+                                            default=None,
+                                            help=("Architecture under test. "
+                                                  "If --vt-config is provided, this will be ignored. "
+                                                  "Default: any that supports the given machine type"))
+        vt_compat_group_common.add_argument("--vt-machine-type", action="store", dest="vt_machine_type",
+                                            default=None,
+                                            help=("Machine type under test. "
+                                                  "If --vt-config is provided, this will be ignored. "
+                                                  "Default: all for the chosen guests, %s if "
+                                                  "--vt-guest-os not given." % defaults.DEFAULT_MACHINE_TYPE))
+        vt_compat_group_qemu.add_argument("--vt-qemu-bin", action="store", dest="vt_qemu_bin",
+                                          default=None,
+                                          help=("Path to a custom qemu binary to be tested. "
+                                                "If --vt-config is provided and this flag is omitted, "
+                                                "no attempt to set the qemu binaries will be made. "
+                                                "Default path: %s" % qemu_bin_path))
+        vt_compat_group_qemu.add_argument("--vt-qemu-dst-bin", action="store", dest="vt_dst_qemu_bin",
+                                          default=None,
+                                          help=("Path to a custom qemu binary to be tested for "
+                                                "the destination of a migration, overrides "
+                                                "--vt-qemu-bin. "
+                                                "If --vt-config is provided and this flag is omitted, "
+                                                "no attempt to set the qemu binaries will be made. "
+                                                "Default path: %s" % qemu_bin_path))
+        vt_compat_group_qemu.add_argument("--vt-accel", action="store", dest="vt_accel", default="kvm",
+                                          help=("Accelerator used to run qemu (kvm or tcg). "
+                                                "Default: kvm"))
+        vt_compat_group_qemu.add_argument("--vt-nettype", action="store", dest="vt_nettype",
+                                          default=nettype_default, help=qemu_nw_msg)
+        vt_compat_group_qemu.add_argument("--vt-netdst", action="store", dest="vt_netdst",
+                                          default="virbr0",
+                                          help=("Bridge name to be used "
+                                                "(if you chose bridge as nettype). "
+                                                "Default: virbr0"))
+        vt_compat_group_qemu.add_argument("--vt-vhost", action="store", dest="vt_vhost",
+                                          default="off",
+                                          help=("Whether to enable vhost for qemu "
+                                                "(on/off/force). Depends on nettype=bridge. "
+                                                "If --vt-config is provided, this will be ignored. "
+                                                "Default: off"))
+        vt_compat_group_qemu.add_argument("--vt-monitor", action="store", dest="vt_monitor",
+                                          default='human',
+                                          help="Monitor type (human or qmp). Default: human")
+        vt_compat_group_qemu.add_argument("--vt-smp", action="store", dest="vt_smp",
+                                          default='2',
+                                          help=("Number of virtual cpus to use (1 or 2). "
+                                                "If --vt-config is provided, this will be ignored. "
+                                                "Default: 2"))
+        vt_compat_group_qemu.add_argument("--vt-image-type", action="store", dest="vt_image_type",
+                                          default="qcow2",
+                                          help=("Image format type to use "
+                                                "(any valid qemu format). "
+                                                "If --vt-config is provided, this will be ignored. "
+                                                "Default: qcow2"))
+        vt_compat_group_qemu.add_argument("--vt-nic-model", action="store", dest="vt_nic_model",
+                                          default="virtio_net",
+                                          help=("Guest network card model. "
+                                                "If --vt-config is provided, this will be ignored. "
+                                                "(any valid qemu format). Default: virtio_net"))
+        vt_compat_group_qemu.add_argument("--vt-disk-bus", action="store", dest="vt_disk_bus",
+                                          default="virtio_blk",
+                                          help=("Guest main image disk bus. One of " +
+                                                " ".join(SUPPORTED_DISK_BUSES) +
+                                                ". If --vt-config is provided, this will be ignored. "
+                                                "Default: virtio_blk"))
+        vt_compat_group_qemu.add_argument("--vt-qemu-sandbox", action="store", dest="vt_qemu_sandbox",
+                                          default="on",
+                                          help=("Enable qemu sandboxing "
+                                                "(on/off). Default: on"))
+        vt_compat_group_qemu.add_argument("--vt_qemu_defconfig", action="store", dest="vt_qemu_defconfig",
+                                          default="yes",
+                                          help=("Prevent qemu from loading sysconfdir/qemu.conf "
+                                                "and sysconfdir/target-ARCH.conf at startup. "
+                                                "(yes/no). Default: yes"))
+        vt_compat_group_qemu.add_argument("--vt-malloc-perturb", action="store",
+                                          dest="vt_malloc_perturb", default="yes",
+                                          help=("Use MALLOC_PERTURB_ env variable set to 1 "
+                                                "to help catch memory allocation problems on "
+                                                "qemu (yes or no). Default: yes"))
+        vt_compat_group_libvirt.add_argument("--vt-connect-uri", action="store", dest="vt_connect_uri",
+                                             help="Choose test connect uri for libvirt (E.g: %s)" %
+                                             ", ".join(SUPPORTED_LIBVIRT_URIS))
+        vt_compat_group_libvirt.add_argument("--vt-install-guest", action="store_true",
+                                             dest="vt_install_guest",
+                                             help=("Install the guest using import method before "
+                                                   "the tests are run."))
+        vt_compat_group_libvirt.add_argument("--vt-remove-guest", action="store_true", dest="vt-remove_guest",
+                                             help=("Remove the guest from libvirt. This will not "
+                                                   "delete the guest's disk file."))
+        vt_compat_group_debug.add_argument("--vt-no-cleanup", action="store_true",
+                                           dest="vt_no_cleanup",
+                                           default=False,
+                                           help=("Don't clean up tmp files or VM processes at "
+                                                 "the end of a virt-test execution. Default: False"))
+
+        self.configured = True
+
+    def activate(self, args):
+        """
+        Run test modules or simple tests.
+
+        :param args: Command line args received from the run subparser.
+        """
+        if getattr(args, 'vt_setup', False):
+            self.parser.application.set_defaults(vt_loader=VirtTestLoader, vt_result=VirtTestResult)
+        else:
+            self.parser.application.set_defaults(vt_loader=VirtTestLoader)

--- a/avocado/core/result.py
+++ b/avocado/core/result.py
@@ -245,7 +245,8 @@ class TestResult(object):
                       'FAIL': self.add_fail,
                       'TEST_NA': self.add_skip,
                       'WARN': self.add_warn,
-                      'INTERRUPTED': self.add_interrupt}
+                      'INTERRUPTED': self.add_interrupt,
+                      'NOT_A_TEST': self.add_error}
         add = status_map[state['status']]
         add(state)
         self.end_test(state)

--- a/avocado/core/status.py
+++ b/avocado/core/status.py
@@ -26,7 +26,8 @@ mapping = {"TEST_NA": True,
            "ALERT": False,
            "RUNNING": False,
            "NOSTATUS": False,
-           "INTERRUPTED": False}
+           "INTERRUPTED": False,
+           "NOT_A_TEST": False}
 
 feedback = {
     # Test did not advertise current status, but process running the test is

--- a/etc/avocado/conf.d/virt-test.conf
+++ b/etc/avocado/conf.d/virt-test.conf
@@ -1,0 +1,26 @@
+[virt_test]
+# Path to virt-test, required for the compatibility plugin to locate
+# virt-test libs. You should set this locally for avocado users.
+# For people working on the compatibility layer itself, you can export the
+# environment variable VIRT_TEST_DIR with that location instead of using
+# the config system.
+virt_test_dir=
+[virt_test.setup]
+# Run the setup procedure (uncompress JeOS' pristine image).
+# The keys below help you customize the procedure
+run_setup=False
+# Don't restore the JeOS at the beginning of the test job (faster, but unsafe)
+# This has no effect unless you set run_setup=True or --vt-setup on the cmdline
+keep_image=False
+# Don't restore the JeOS between tests (faster, but unsafe)
+# This has no effect unless you set run_setup=True or --vt-setup on the cmdline
+keep_image_between_tests=False
+# Keep guest running between tests (faster, but unsafe)
+keep_guest_running=False
+[virt_test.common]
+# Data dir path. If none specified, the default virt-test data dir will be used
+data_dir_path =
+# Enable only type specific tests. Shared tests will not be tested
+type_specific_only = False
+# RAM dedicated to the main VM
+mem = 1024

--- a/selftests/all/functional/avocado/basic_tests.py
+++ b/selftests/all/functional/avocado/basic_tests.py
@@ -178,8 +178,8 @@ class RunnerOperationTest(unittest.TestCase):
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 2
         self.assertEqual(result.exit_status, expected_rc)
-        self.assertIn('File not found', result.stderr)
-        self.assertNotIn('File not found', result.stdout)
+        self.assertIn('No tests found within the specified path(s)', result.stderr)
+        self.assertNotIn('No tests found within the specified path(s)', result.stdout)
 
     def test_invalid_unique_id(self):
         cmd_line = './scripts/avocado run --sysinfo=off --force-job-id foobar skiptest'


### PR DESCRIPTION
This is a follow up to PR #603

This is the most fleshed out virt test compat layer to date. It introduces loading of tests from multiple test sources, which allows the mix and match of regular avocado tests and avocado virt-tests:

	$ scripts/avocado run --vt-setup type_specific.io-github-autotest-qemu.migrate.default.tcp examples/tests/passtest.py --open-browser
	SETUP      : PASS (15.66 s)
	JOB ID     : 0a613e41201ee2fa726a6ef8617f6578aa901e3a
	JOB LOG    : /home/lmr/avocado/job-results/job-2015-04-30T01.09-0a613e4/job.log
	JOB HTML   : /home/lmr/avocado/job-results/job-2015-04-30T01.09-0a613e4/html/results.html
	TESTS      : 2
	(1/2) type_specific.io-github-autotest-qemu.migrate.default.tcp: PASS (89.62 s)
	(2/2) examples/tests/passtest.py: PASS (0.00 s)
	PASS       : 2
	ERROR      : 0
	FAIL       : 0
	SKIP       : 0
	WARN       : 0
	INTERRUPT  : 0
	TIME       : 89.62 s

You can try out this work by following the steps:

1) Check out this branch
2) Set the environment variable 'VIRT_TEST_PATH' to a path containing a copy of virt test
3) The copy of virt-test has to be in my new branch `avocado-integration` [1]
4) Bootstrap your testing by running `scripts/avocado vt-bootstrap --vt-type qemu`
5) Run your tests with the command above

You can also list your virt-test tests by doing `scripts/avocado vt-list --vt-type qemu`

Keep in mind that the unittests are not all passing. I'm having trouble deciding the best way to handle the behavior of avocado parsing test strings that might come from multiple sources.

That's it. Virt Test at this point has way too many knobs, and it's challenging to look to each of them and make sure they are working well. I hope that at least you guys enjoy trying this out.

Changes from v3:
 * Removed the list and bootstrap plugins. virt-test can already do that functionality for the user.
 * Went to a excruciatingly detailed review of command line options. Many options that don't make sense in avocado were removed, text reviewed, and options grouped logically. Next step is to move unneeded options to the config file.

[1] See https://github.com/autotest/virt-test/pull/2176

Bonus: People can now generate HTML reports out of virt-test runs. I imagine there will be people happy with this.

![screenshot from 2015-04-30 01-22-14](https://cloud.githubusercontent.com/assets/296807/7406339/7699689e-eed7-11e4-9214-38a678c105ec.png)
