### PR TITLE
avocado.multiplexer: Add 2nd level filters [v1]

### DIFF
--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -291,13 +291,15 @@ class TreeNode(object):
         """
         if not attributes:
             attributes = ["name"]
-        node_name = ', '.join(map(str, [getattr(self, v)
-                                        for v in attributes
-                                        if hasattr(self, v)]))
+        node_name = ','.join((str(getattr(self, attr))
+                              for attr in attributes
+                              if hasattr(self, attr)))
         if self.multiplex:
             node_name += "-<>"
 
-        length = max(2, (len(node_name) + 1) if not self.children or show_internal else 3)
+        length = max(2, ((len(node_name) + 1)
+                         if not self.children or show_internal
+                         else 3))
         pad = ' ' * length
         _pad = ' ' * (length - 1)
         if not self.is_leaf:

--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -433,9 +433,9 @@ def _create_from_yaml(path, cls_node=TreeNode):
                            lambda loader, node: Control(YAML_INCLUDE))
     Loader.add_constructor(u'!using',
                            lambda loader, node: Control(YAML_USING))
-    Loader.add_constructor(u'!remove_node',
+    Loader.add_constructor(u'!remove-node',
                            lambda loader, node: Control(YAML_REMOVE_NODE))
-    Loader.add_constructor(u'!remove_value',
+    Loader.add_constructor(u'!remove-value',
                            lambda loader, node: Control(YAML_REMOVE_VALUE))
     Loader.add_constructor(u'!mux', mux_loader)
     Loader.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,

--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -656,9 +656,8 @@ class TreeNodeDebug(TreeNode):  # only container pylint: disable=R0903
             value = {}
         if srcyaml:
             srcyaml = os.path.relpath(srcyaml)
-        super(TreeNodeDebug, self).__init__(name,
-                                            ValueDict(srcyaml, self, value),
-                                            parent, children)
+        super(TreeNodeDebug, self).__init__(name, None, parent, children)
+        self.value = ValueDict(srcyaml, self, value)
         self.yaml = srcyaml
 
     def merge(self, other):
@@ -669,7 +668,7 @@ class TreeNodeDebug(TreeNode):  # only container pylint: disable=R0903
         if hasattr(other, 'yaml'):
             srcyaml = os.path.relpath(other.yaml)
             # when we use TreeNodeDebug, value is always ValueDict
-            self.value.yaml_per_key.update(other.value.yaml_per_key)    # pylint: disable=E1101
+            self.value.yaml_per_key.update(other.value.yaml_per_key)
         else:
             srcyaml = "Unknown"
         self.yaml = srcyaml

--- a/docs/source/MultiplexConfig.rst
+++ b/docs/source/MultiplexConfig.rst
@@ -294,7 +294,7 @@ Prepends path to the node it's defined in::
 ``bar`` is put into ``baz`` becoming ``/baz/bar`` and everything is put into
 ``/foo``. So the final path of ``bar`` is ``/foo/baz/bar``.
 
-!remove_node
+!remove-node
 ------------
 
 Removes node if it existed during the merge. It can be used to extend
@@ -306,7 +306,7 @@ incompatible YAML files::
             3.11:
             95:
     os:
-        !remove_node : windows
+        !remove-node : windows
         windows:
             win3.11:
             win95:
@@ -317,14 +317,14 @@ it can be replaced by you new structure as shown in the example. It removes
 `windows` with all children and then replaces this structure with slightly
 modified version.
 
-As `!remove_node` is processed during merge, when you reverse the order,
+As `!remove-node` is processed during merge, when you reverse the order,
 windows is not removed and you end-up with `/windows/{win3.11,win95,3.11,95}`
 nodes.
 
-!remove_value
+!remove-value
 -------------
 
-It's similar to `!remove_node`_ only with values.
+It's similar to `!remove-node`_ only with values.
 
 !mux
 ----

--- a/docs/source/MultiplexConfig.rst
+++ b/docs/source/MultiplexConfig.rst
@@ -333,6 +333,37 @@ Children of this node will be multiplexed. This means that in first variant
 it'll return leaves of the first child, in second the leaves of the second
 child, etc. Example is in section `Variants`_
 
+!filter-only
+------------
+
+Defines 2nd level filtering. They are inherited by childern and evaluated
+during multiplexation. It allows one to specify the only compatible branch
+of the tree with the current variant, for example::
+
+    cpu:
+        arm:
+            !filter-only : /disk/virtio
+    disk:
+        virtio:
+        scsi:
+
+will skip the ``[arm, scsi]`` variant and result only in ``[arm, virtio]``
+
+_Note: It's possible to use ``!filter-only`` multiple times with the same
+parent and all allowed variants will be included (unless they are
+filtered-out by ``!filter-out``)_
+
+_Note2: The evaluation order is 1. filter-out, 2. filter-only. This means when
+you booth filter-out and filter-only a branch it won't take part in the
+multiplexed variants._
+
+!filter-out
+-----------
+
+Similarily to `!filter-only`_ only it skips the specified branches and leaves
+the remaining ones. (in the same example the use of
+``!filter-out : /disk/scsi`` results in the same behavior. The difference
+is when you have multiple disk types, ``!filter-only`` is more efficient.
 
 Complete example
 ================

--- a/examples/mux-selftest-advanced.yaml
+++ b/examples/mux-selftest-advanced.yaml
@@ -6,19 +6,19 @@ distro: !mux
     # This line extends the distro branch using include
     !include : mux-selftest-distro.yaml
     # remove node called "mint"
-    !remove_node : mi.*nt
+    !remove-node : mi.*nt
     # This is a new /distro/mint appended as latest child
     mint:
         new_mint: True
     fedora:
-        !remove_value : init.*
+        !remove-value : init.*
         new_init: systemd
     gentoo:
         # This modifies the value of 'is_cool'
         is_cool: True
         # And this removes the original 'is_cool'
         # Setting happens after ctrl so it should be created'
-        !remove_value : is_cool
+        !remove-value : is_cool
 distro: !mux
     gentoo:     # This won't change anything
 # This creates new branch the usual way

--- a/examples/mux-selftest.yaml
+++ b/examples/mux-selftest.yaml
@@ -7,16 +7,27 @@
 #          multiple files and checks that the node ordering works fine.
 # /env/opt_CFLAGS: Should be present in merged node
 # /env/prod/opt_CFLAGS: value should be overridden by latter node
+# !filter-only: All root childern are specified in different levels. They
+#               should be combined and together enable all variants. On the
+#               other hand they should not enable other-level filter-only
+#               filters like /hw/disk/virtio.
 hw:
+    # This filter has no effect whatsoever, it tests the filter inheritance
     cpu: !mux
+        !filter-only : /env
+        # Again, no use only to test leaves inherits it
+        !filter-out : /non/existing/node
         joinlist:
             - first_item
         intel:
+            !filter-only : /hw/disk/virtio
+            !filter-only : /hw/disk/scsi
             cpu_CFLAGS: '-march=core2'
         amd:
             joinlist: ['second', 'third']
             cpu_CFLAGS: '-march=athlon64'
         arm:
+            !filter-only : /hw/disk/virtio
             cpu_CFLAGS: '-mabi=apcs-gnu -march=armv8-a -mtune=arm8'
     disk: !mux
         disk_type: 'virtio'
@@ -28,15 +39,17 @@ hw:
     corruptlist: ['upper_node_list']
 distro: !mux     # This node is set as !multiplex below
     fedora:
+        !filter-out : /hw/disk/scsi
         init: 'systemd'
 env: !mux
     opt_CFLAGS: '-Os'
     prod:
         opt_CFLAGS: 'THIS SHOULD GET OVERWRITTEN'
 env: !mux
+    !filter-only : /distro  # let's see if filters are updated when merging
     prod:
         opt_CFLAGS: '-O2'
 distro: !mux
     mint:
         init: 'systemv'
-
+!filter-only : /hw

--- a/selftests/all/functional/avocado/multiplex_tests.py
+++ b/selftests/all/functional/avocado/multiplex_tests.py
@@ -19,7 +19,7 @@ if os.path.isdir(os.path.join(basedir, 'avocado')):
 
 from avocado.utils import process
 
-DEBUG_OUT = """Variant 16:    amd@examples/mux-environment.yaml, virtio@examples/mux-environment.yaml, mint@examples/mux-environment.yaml, debug@examples/mux-environment.yaml
+DEBUG_OUT = """Variant 12:    amd@examples/mux-environment.yaml, virtio@examples/mux-environment.yaml, mint@examples/mux-environment.yaml, debug@examples/mux-environment.yaml
     corruptlist: nonlist@examples/mux-selftest.yaml:/hw/disk
     cpu_CFLAGS: -march=athlon64@examples/mux-environment.yaml:/hw/cpu/amd
     disk_type: virtio@examples/mux-environment.yaml:/hw/disk/virtio

--- a/selftests/all/unit/avocado/multiplexer_unittest.py
+++ b/selftests/all/unit/avocado/multiplexer_unittest.py
@@ -34,12 +34,12 @@ class TestMultiplex(unittest.TestCase):
 
     def test_partial(self):
         exp = (['intel', 'scsi'], ['intel', 'virtio'], ['amd', 'scsi'],
-               ['amd', 'virtio'], ['arm', 'scsi'], ['arm', 'virtio'])
+               ['amd', 'virtio'], ['arm', 'virtio'])
         act = tuple(multiplexer.MuxTree(self.tree.children[0]))
         self.assertEqual(act, exp)
 
     def test_full(self):
-        self.assertEqual(len(self.mux_full), 12)
+        self.assertEqual(len(self.mux_full), 8)
 
     def test_create_variants(self):
         from_file = multiplexer.multiplex_yamls([PATH_PREFIX + 'examples/mux-selftest.yaml'])
@@ -60,7 +60,7 @@ class TestMultiplex(unittest.TestCase):
                                                 ('/hw/cpu/intel',
                                                  '/distro/fedora',
                                                  '/distro')))
-        self.assertEqual(len(act), 4)
+        self.assertEqual(len(act), 3)
         self.assertEqual(len(act[0]), 3)
         str_act = str(act)
         self.assertIn('amd', str_act)

--- a/selftests/all/unit/avocado/tree_unittest.py
+++ b/selftests/all/unit/avocado/tree_unittest.py
@@ -8,10 +8,15 @@ else:
 
 from avocado.core import tree
 
+if __name__ == "__main__":
+    PATH_PREFIX = "../../../../"
+else:
+    PATH_PREFIX = ""
+
 
 class TestTree(unittest.TestCase):
     # Share tree with all tests
-    tree = tree.create_from_yaml(['examples/mux-selftest.yaml'])
+    tree = tree.create_from_yaml([PATH_PREFIX + 'examples/mux-selftest.yaml'])
 
     def test_node_order(self):
         self.assertIsInstance(self.tree, tree.TreeNode)
@@ -154,7 +159,8 @@ class TestTree(unittest.TestCase):
                          tree2.children[0].children[2].children[1].value)
 
     def test_advanced_yaml(self):
-        tree2 = tree.create_from_yaml(['examples/mux-selftest-advanced.yaml'])
+        tree2 = tree.create_from_yaml([PATH_PREFIX + 'examples/mux-selftest-'
+                                       'advanced.yaml'])
         exp = ['intel', 'amd', 'arm', 'scsi', 'virtio', 'fedora', '6',
                '7', 'gentoo', 'mint', 'prod', 'new_node']
         act = tree2.get_leaves()


### PR DESCRIPTION
This patch adds additional YAML tags !filter-only and !filter-out. Those
filters are inherited same way as values and they are used during
multiplexation. It allows finer granularity of leaves by filtering-out,
resp. filtering-only compatible variants.

v0: https://github.com/avocado-framework/avocado/pull/606

Changes:

    v1: pylint/pep8 refactors
    v1: update filters when merging nodes
    v1: updated docstrings
    v1: use set() to avoid multiple checks of the same filter
    v1: filter-only completely rewritten to support filters of different
        level and multiple filters of the same parent
    v1: added documentation
    v1: updated and extended unittests