### PR TITLE
RFC: FIXME: Draft of params.set()

### DIFF
--- a/examples/tests/passtest.py
+++ b/examples/tests/passtest.py
@@ -14,6 +14,10 @@ class PassTest(test.Test):
         """
         A test simply doesn't have to fail in order to pass
         """
+        self.params.get('asdf', 'aaa/*', 1)
+        self.params.set('asdf', '**', 2)
+        self.params.get('asdf', 'aaa/*', 3)
+        self.params.get('asdf', '/*', 4)
         pass
 
 


### PR DESCRIPTION
Currently `avocado-virt` tries to override `--qemu-bin` by writing to params. With the new layout this is not supported. This pull request demonstrates one way to solve this problem by overriding all occurrences of the key for given path + defaults. It's one of the safest methods, another - less intrusive - variant would be to only update cache, which would require the queries to be always the same (even different default would cause cache-miss and lookup from params).

Anyway there is one big drawback. This solution modifies directly the mux-tree, which means the following variant would have these values set. So in order to support this properly we'd have to either copy the variant or use additional storage for these queries.

The worst thing about this is theoretical. In my opinion test parameters are by definition static. They shouldn't be writable and that's actually something I did on purpose. When developing it I thought on this and now the time probably come, here is an alternative version, which I had in mind but thought it's not yet required: https://github.com/avocado-framework/avocado/pull/614