### PR TITLE
RFC: FIXME: Args2multiplexer

### DIFF
--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -89,7 +89,7 @@ class TreeNode(object):
         self._environment = None
         self.environment_origin = {}
         self.ctrl = []
-        self.multiplex = False
+        self.multiplex = None
         for child in children:
             self.add_child(child)
 
@@ -159,7 +159,10 @@ class TreeNode(object):
                             remove.append(key)
                     for key in remove:
                         self.value.pop(key, None)
-        self.multiplex = other.multiplex
+        if other.multiplex is True:
+            self.multiplex = True
+        elif other.multiplex is False:
+            self.multiplex = False
         self.value.update(other.value)
         for child in other.children:
             self.add_child(child)
@@ -244,6 +247,29 @@ class TreeNode(object):
         for child in self.children:
             child.set_environment_dirty()
         self._environment = None
+
+    def get_node(self, path, create=False):
+        """
+        :param path: Path of the desired node (relative to this node)
+        :param create: Create the node (and intermediary ones) when not present
+        :return: the node associated with this path
+        :raise ValueError: When path doesn't exist and create not set
+        """
+        node = self
+        for name in path.split('/'):
+            if not name:
+                continue
+            try:
+                node = node.children[node.children.index(name)]
+            except ValueError:
+                if create:
+                    child = node.__class__(name)
+                    node.add_child(child)
+                    node = child
+                else:
+                    raise ValueError("Path %s does not exists in this tree\n%s"
+                                     % (path, self.get_ascii()))
+        return node
 
     def iter_children_preorder(self):
         """ Iterate through children """

--- a/avocado/multiplexer.py
+++ b/avocado/multiplexer.py
@@ -91,12 +91,14 @@ class MuxTree(object):
 
 
 def multiplex_yamls(input_yamls, filter_only=None, filter_out=None,
-                    debug=False):
+                    debug=False, additional_tree=None):
     if filter_only is None:
         filter_only = []
     if filter_out is None:
         filter_out = []
     input_tree = tree.create_from_yaml(input_yamls, debug)
+    if additional_tree:
+        input_tree.merge(additional_tree)
     # TODO: Process filters and multiplex simultaneously
     final_tree = tree.apply_filters(input_tree, filter_only, filter_out)
     result = MuxTree(final_tree)


### PR DESCRIPTION
This pull request demonstrate other way of modifying the test parameters. Instead of modifying params in test https://github.com/avocado-framework/avocado/pull/613 this creates another tree from 
args and merges it after yaml files are processed.

This version only supports custom `--env [$path]:key:value` setting, but the real usage should be `--qemu-bin` which would map into `/virt/qemu/paths:qemu_bin:$value`.

The same way `ini` files can be processed and mapped to params.

The biggest benefit of this solution is that this happens ones before the multiplexation. Then the tree is frozen and params are read-only.