### PR TITLE
setup.py: Add missing gdb.conf file in the avocado RPM

### DIFF
--- a/avocado.spec
+++ b/avocado.spec
@@ -1,7 +1,7 @@
 Summary: Avocado Test Framework
 Name: avocado
 Version: 0.24.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.github.io/
@@ -57,6 +57,7 @@ selftests/run selftests/all/unit
 %dir /etc/avocado/sysinfo
 %config(noreplace)/etc/avocado/avocado.conf
 %config(noreplace)/etc/avocado/conf.d/README
+%config(noreplace)/etc/avocado/conf.d/gdb.conf
 %config(noreplace)/etc/avocado/sysinfo/commands
 %config(noreplace)/etc/avocado/sysinfo/files
 %config(noreplace)/etc/avocado/sysinfo/profilers
@@ -103,6 +104,9 @@ examples of how to write tests on your own.
 %{_datadir}/avocado/api
 
 %changelog
+* Mon May 25 2015 Cleber Rosa <cleber@redhat.com> - 0.24.0-2
+- Added previously missing gdb.conf
+
 * Mon May 18 2015 Ruda Moura <rmoura@redhat.com> - 0.24.0-1
 - Update to upstream version 0.24.0
 

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ def get_avocado_libexec_dir():
 def get_data_files():
     data_files = [(get_dir(['etc', 'avocado']), ['etc/avocado/avocado.conf'])]
     data_files += [(get_dir(['etc', 'avocado', 'conf.d']),
-                    ['etc/avocado/conf.d/README'])]
+                    ['etc/avocado/conf.d/README', 'etc/avocado/conf.d/gdb.conf'])]
     data_files += [(get_dir(['etc', 'avocado', 'sysinfo']),
                     ['etc/avocado/sysinfo/commands', 'etc/avocado/sysinfo/files',
                      'etc/avocado/sysinfo/profilers'])]


### PR DESCRIPTION
The GDB config file was not being installed and packaged in the RPM
package. This should fix it.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>
Signed-off-by: Cleber Rosa <crosa@redhat.com>