### PR TITLE
avocado: Add missing gdb.conf file in setup/RPM packages

### DIFF
--- a/avocado.spec
+++ b/avocado.spec
@@ -57,6 +57,7 @@ selftests/run selftests/all/unit
 %dir /etc/avocado/sysinfo
 %config(noreplace)/etc/avocado/avocado.conf
 %config(noreplace)/etc/avocado/conf.d/README
+%config(noreplace)/etc/avocado/conf.d/gdb.conf
 %config(noreplace)/etc/avocado/sysinfo/commands
 %config(noreplace)/etc/avocado/sysinfo/files
 %config(noreplace)/etc/avocado/sysinfo/profilers

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ def get_avocado_libexec_dir():
 def get_data_files():
     data_files = [(get_dir(['etc', 'avocado']), ['etc/avocado/avocado.conf'])]
     data_files += [(get_dir(['etc', 'avocado', 'conf.d']),
-                    ['etc/avocado/conf.d/README'])]
+                    ['etc/avocado/conf.d/README', 'etc/avocado/conf.d/gdb.conf'])]
     data_files += [(get_dir(['etc', 'avocado', 'sysinfo']),
                     ['etc/avocado/sysinfo/commands', 'etc/avocado/sysinfo/files',
                      'etc/avocado/sysinfo/profilers'])]


### PR DESCRIPTION
We were not shipping the gdb.conf file in our RPM packages,
as well as when installing avocado through the setup.py
method.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>