### PR TITLE
RFC: Introduce command line option to read configuration from a file.

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -41,7 +41,6 @@ from avocado.core.plugins import jsonresult
 from avocado.core.plugins import xunit
 from avocado.utils import archive
 from avocado.utils import path
-from avocado.settings import settings
 
 try:
     from avocado.core.plugins import htmlresult
@@ -80,8 +79,11 @@ class Job(object):
         self.unique_id = unique_id
         self.view = output.View(app_args=self.args)
         self.logdir = None
-        raw_log_level = settings.get_value('job.output', 'loglevel',
-                                           default='debug')
+        if hasattr(args, 'settings'):
+            raw_log_level = args.settings.get_value(
+                'job.output', 'loglevel', default='debug')
+        else:
+            raw_log_level = 'debug'
         mapping = {'info': logging.INFO,
                    'debug': logging.DEBUG,
                    'warning': logging.WARNING,
@@ -189,6 +191,7 @@ class Job(object):
         # Setup the xunit plugin to output to the debug directory
         xunit_file = os.path.join(self.logdir, 'results.xml')
         args = argparse.Namespace()
+        args.settings = self.args.settings
         args.xunit_output = xunit_file
         xunit_plugin = xunit.xUnitTestResult(self.view, args)
         self.result_proxy.add_output_plugin(xunit_plugin)
@@ -196,6 +199,7 @@ class Job(object):
         # Setup the json plugin to output to the debug directory
         json_file = os.path.join(self.logdir, 'results.json')
         args = argparse.Namespace()
+        args.settings = self.args.settings
         args.json_output = json_file
         json_plugin = jsonresult.JSONTestResult(self.view, args)
         self.result_proxy.add_output_plugin(json_plugin)
@@ -204,6 +208,7 @@ class Job(object):
         if HTML_REPORT_SUPPORT:
             html_file = os.path.join(self.logdir, 'html', 'results.html')
             args = argparse.Namespace()
+            args.settings = self.args.settings
             args.html_output = html_file
             args.open_browser = getattr(self.args, 'open_browser', False)
             args.relative_links = True
@@ -336,8 +341,8 @@ class Job(object):
         if getattr(self.args, 'archive', False):
             filename = self.logdir + '.zip'
             archive.create(filename, self.logdir)
-        if not settings.get_value('runner.behavior', 'keep_tmp_files',
-                                  key_type=bool, default=False):
+        if not self.args.settings.get_value('runner.behavior', 'keep_tmp_files',
+                                            key_type=bool, default=False):
             data_dir.clean_tmp_files()
         _TEST_LOGGER.info('Test results available in %s', self.logdir)
 

--- a/avocado/core/parser.py
+++ b/avocado/core/parser.py
@@ -21,6 +21,7 @@ import sys
 import argparse
 
 from avocado.version import VERSION
+from avocado.settings import Settings
 
 PROG = 'avocado'
 DESCRIPTION = 'Avocado Test Runner'
@@ -39,6 +40,8 @@ class Parser(object):
             description=DESCRIPTION)
         self.application.add_argument('-v', '--version', action='version',
                                       version='Avocado %s' % VERSION)
+        self.application.add_argument('-c', '--config',
+                                      dest='avocado_conf', default=None)
         self.application.add_argument('--plugins', action='store',
                                       help='Load extra plugins from directory',
                                       dest='plugins_dir', default='')
@@ -51,6 +54,7 @@ class Parser(object):
         Side effect: update attribute `args` (the namespace).
         """
         self.args, _ = self.application.parse_known_args()
+        self.args.settings = Settings(self.args.avocado_conf)
 
         # Use parent parsing to avoid breaking the output of --help option
         self.application = argparse.ArgumentParser(prog=PROG,
@@ -79,9 +83,12 @@ class Parser(object):
         """
         Finish the process of parsing arguments.
 
-        Side effect: set the final value for attribute `args`.
+        Side effects:
+        - Set the final value for attribute `args`.
+        - Set the configuration settings to attribute `settings`.
         """
         self.args = self.application.parse_args()
+        self.args.settings = Settings(self.args.avocado_conf)
 
     def take_action(self):
         """

--- a/avocado/core/plugins/config.py
+++ b/avocado/core/plugins/config.py
@@ -14,7 +14,6 @@
 
 from avocado.core import output
 from avocado import data_dir
-from avocado.settings import settings
 from avocado.core.plugins import plugin
 
 
@@ -36,20 +35,20 @@ class ConfigOptions(plugin.Plugin):
         super(ConfigOptions, self).configure(self.parser)
 
     def run(self, args):
-        view = output.View()
+        view = output.View(args)
         view.notify(event="message", msg='Config files read (in order):')
-        for cfg_path in settings.config_paths:
+        for cfg_path in args.settings.config_paths:
             view.notify(event="message", msg='    %s' % cfg_path)
-        if settings.config_paths_failed:
+        if args.settings.config_paths_failed:
             view.notify(event="minor", msg='')
             view.notify(event="error", msg='Config files that failed to read:')
-            for cfg_path in settings.config_paths_failed:
+            for cfg_path in args.settings.config_paths_failed:
                 view.notify(event="error", msg='    %s' % cfg_path)
         view.notify(event="minor", msg='')
         if not args.datadir:
             blength = 0
-            for section in settings.config.sections():
-                for value in settings.config.items(section):
+            for section in args.settings.config.sections():
+                for value in args.settings.config.items(section):
                     clength = len('%s.%s' % (section, value[0]))
                     if clength > blength:
                         blength = clength
@@ -57,8 +56,8 @@ class ConfigOptions(plugin.Plugin):
             format_str = "    %-" + str(blength) + "s %s"
 
             view.notify(event="minor", msg=format_str % ('Section.Key', 'Value'))
-            for section in settings.config.sections():
-                for value in settings.config.items(section):
+            for section in args.settings.config.sections():
+                for value in args.settings.config.items(section):
                     config_key = ".".join((section, value[0]))
                     view.notify(event="minor", msg=format_str % (config_key, value[1]))
         else:

--- a/avocado/core/plugins/distro.py
+++ b/avocado/core/plugins/distro.py
@@ -343,7 +343,7 @@ class DistroOptions(plugin.Plugin):
                                         args.distro_def_arch)
 
     def run(self, args):
-        view = output.View()
+        view = output.View(args)
         if args.distro_def_create:
             if not (args.distro_def_name and args.distro_def_version and
                     args.distro_def_arch and args.distro_def_type and

--- a/avocado/core/plugins/gdb.py
+++ b/avocado/core/plugins/gdb.py
@@ -17,7 +17,6 @@
 from avocado import runtime
 from avocado.utils import path as utils_path
 from avocado.core.plugins import plugin
-from avocado.settings import settings
 
 
 class GDB(plugin.Plugin):
@@ -67,12 +66,11 @@ class GDB(plugin.Plugin):
                     runtime.GDB_PRERUN_COMMANDS[''] = commands
             runtime.GDB_ENABLE_CORE = True if app_args.gdb_coredump == 'on' else False
             system_gdb_path = utils_path.find_command('gdb', '/usr/bin/gdb')
-            runtime.GDB_PATH = settings.get_value('gdb.paths', 'gdb',
-                                                  default=system_gdb_path)
-            system_gdbserver_path = utils_path.find_command('gdbserver',
-                                                            '/usr/bin/gdbserver')
-            runtime.GDBSERVER_PATH = settings.get_value('gdb.paths',
-                                                        'gdbserver',
-                                                        default=system_gdbserver_path)
+            runtime.GDB_PATH = app_args.settings.get_value(
+                'gdb.paths', 'gdb', default=system_gdb_path)
+            system_gdbserver_path = utils_path.find_command(
+                'gdbserver', '/usr/bin/gdbserver')
+            runtime.GDBSERVER_PATH = app_args.settings.get_value(
+                'gdb.paths', 'gdbserver', default=system_gdbserver_path)
         except AttributeError:
             pass

--- a/avocado/core/plugins/plugin_list.py
+++ b/avocado/core/plugins/plugin_list.py
@@ -57,7 +57,7 @@ class PluginList(plugin.Plugin):
         format_str = "    %-" + str(blength + 1) + "s %s"
 
         if enabled:
-            view.notify(event='message', msg=output.term_support.healthy_str("Plugins enabled:"))
+            view.notify(event='message', msg=view.term_support.healthy_str("Plugins enabled:"))
             for plug in sorted(enabled):
                 view.notify(event='minor', msg=format_str % (plug.name, plug.description))
 

--- a/avocado/core/plugins/runner.py
+++ b/avocado/core/plugins/runner.py
@@ -18,7 +18,6 @@ Base Test Runner Plugins.
 
 import sys
 
-from avocado.settings import settings
 from avocado.core import exit_codes
 from avocado.core.plugins import plugin
 from avocado.core import output
@@ -72,10 +71,8 @@ class TestRunner(plugin.Plugin):
                                        'You can also use suffixes, like: '
                                        ' s (seconds), m (minutes), h (hours). '))
 
-        sysinfo_default = settings.get_value('sysinfo.collect',
-                                             'enabled',
-                                             key_type='bool',
-                                             default=True)
+        sysinfo_default = parser.args.settings.get_value(
+            'sysinfo.collect', 'enabled', key_type='bool', default=True)
         sysinfo_default = 'on' if sysinfo_default is True else 'off'
         self.parser.add_argument('--sysinfo', choices=('on', 'off'), default=sysinfo_default,
                                  help=('Enable or disable system information '

--- a/avocado/core/plugins/test_list.py
+++ b/avocado/core/plugins/test_list.py
@@ -33,7 +33,6 @@ class TestList(plugin.Plugin):
     enabled = True
     view = None
     test_loader = loader.TestLoader()
-    term_support = output.TermSupport()
 
     def configure(self, parser):
         """
@@ -108,36 +107,36 @@ class TestList(plugin.Plugin):
 
             if cls == test.SimpleTest:
                 stats['simple'] += 1
-                type_label = self.term_support.healthy_str('SIMPLE')
+                type_label = self.view.term_support.healthy_str('SIMPLE')
             elif cls == test.BuggyTest:
                 stats['buggy'] += 1
-                type_label = self.term_support.fail_header_str('BUGGY')
+                type_label = self.view.term_support.fail_header_str('BUGGY')
             elif cls == test.NotATest:
                 if not args.verbose:
                     continue
                 stats['not_a_test'] += 1
-                type_label = self.term_support.warn_header_str('NOT_A_TEST')
+                type_label = self.view.term_support.warn_header_str('NOT_A_TEST')
             elif cls == test.MissingTest:
                 stats['missing'] += 1
-                type_label = self.term_support.fail_header_str('MISSING')
+                type_label = self.view.term_support.fail_header_str('MISSING')
             elif cls == loader.BrokenSymlink:
                 stats['broken_symlink'] += 1
-                type_label = self.term_support.fail_header_str('BROKEN_SYMLINK')
+                type_label = self.view.term_support.fail_header_str('BROKEN_SYMLINK')
             elif cls == loader.AccessDeniedPath:
                 stats['access_denied'] += 1
-                type_label = self.term_support.fail_header_str('ACCESS_DENIED')
+                type_label = self.view.term_support.fail_header_str('ACCESS_DENIED')
             else:
                 if issubclass(cls, test.Test):
                     stats['instrumented'] += 1
                     id_label = params['name']
-                    type_label = self.term_support.healthy_str('INSTRUMENTED')
+                    type_label = self.view.term_support.healthy_str('INSTRUMENTED')
 
             test_matrix.append((type_label, id_label))
 
         header = None
         if args.verbose:
-            header = (self.term_support.header_str('Type'),
-                      self.term_support.header_str('file'))
+            header = (self.view.term_support.header_str('Type'),
+                      self.view.term_support.header_str('file'))
         for line in astring.tabular_output(test_matrix,
                                            header=header).splitlines():
             self.view.notify(event='minor', msg="%s" % line)

--- a/avocado/core/restclient/cli/app.py
+++ b/avocado/core/restclient/cli/app.py
@@ -20,9 +20,7 @@ This is the main entry point for the rest client cli application
 import sys
 import types
 import importlib
-import functools
 
-from avocado import settings
 from avocado.restclient import connection
 from avocado.core import output
 from avocado.core import exit_codes


### PR DESCRIPTION
This introduce the command line -c or --config to read configuration
from a file. In order to this take effect, the avocado parser
now expose the settings read from the configuration inside the
proper arguments namespace.

How to test it:
* copy etc/avocado.conf to some place and edit what you want. For example, set color output to false.
* run `avocado -c avocado.conf config` or `avocado -c avocado.conf run passtest`.