### PR TITLE
avocado.core: Internal attribute to take_action() is now 'dispatch'.

### DIFF
--- a/avocado/core/parser.py
+++ b/avocado/core/parser.py
@@ -72,8 +72,8 @@ class Parser(object):
         # Inject --help if no arguments is present
         default_args = ['--help'] if not sys.argv[1:] else None
         self.args, rest = self.application.parse_known_args(args=default_args)
-        if not hasattr(self.args, 'func'):
-            self.application.set_defaults(func=self.application.print_help)
+        if not hasattr(self.args, 'dispatch'):
+            self.application.set_defaults(dispatch=self.application.print_help)
 
     def finish(self):
         """
@@ -87,4 +87,4 @@ class Parser(object):
         """
         Take some action after parsing arguments.
         """
-        return self.args.func(self.args)
+        return self.args.dispatch(self.args)

--- a/avocado/core/plugins/plugin.py
+++ b/avocado/core/plugins/plugin.py
@@ -69,7 +69,7 @@ class Plugin(object):
         To create a runner plugin, just call this method with `super()`.
         To create a result plugin, just set `configure` to `True`.
         """
-        parser.set_defaults(func=self.run)
+        parser.set_defaults(dispatch=self.run)
         self.configured = True
 
     def activate(self, arguments):


### PR DESCRIPTION
Use the less generic term 'dispatch', for the proper internal
attribute, to dispatch the code to execute, after parsing
command line and so on.

Signed-off-by: Rudá Moura <rmoura@redhat.com>