### PR TITLE
Couple of multiplexer related improvements [v2]

### DIFF
--- a/avocado/core/plugins/multiplexer.py
+++ b/avocado/core/plugins/multiplexer.py
@@ -93,8 +93,8 @@ class Multiplexer(plugin.Plugin):
                 cend = output.term_support.ENDC
                 paths = ', '.join(["%s%s@%s%s" % (_.name, color, _.yaml, cend)
                                    for _ in tpl])
-            view.notify(event='minor', msg='\nVariant %s:    %s' %
-                        (index + 1, paths))
+            view.notify(event='minor', msg='%sVariant %s:    %s' %
+                        (('\n' if args.contents else ''), index + 1, paths))
             if args.contents:
                 env = {}
                 for node in tpl:

--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -533,8 +533,12 @@ def apply_filters(tree, filter_only=None, filter_out=None):
     """
     if filter_only is None:
         filter_only = []
+    else:
+        filter_only = [_.rstrip('/') for _ in filter_only if _]
     if filter_out is None:
         filter_out = []
+    else:
+        filter_out = [_.rstrip('/') for _ in filter_out if _]
     for node in tree.iter_children_preorder():
         keep_node = True
         for path in filter_only:

--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -512,8 +512,6 @@ def path_parent(path):
     :return: the parent path as string.
     """
     parent = path.rpartition('/')[0]
-    if parent == '':
-        return ''
     return parent
 
 


### PR DESCRIPTION
This pull request improves the multiplexer usability by normalizing filter entries and compressing the variants list. It was inspired by @adereis's input.

v1: https://github.com/avocado-framework/avocado/pull/617

Changes:

    v2: Use "rstrip()" instead of removing a single '/'
    v2: New commit with simple avocado.core.tree cleanup