### PR TITLE
[V10] Virt test compat layer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,5 @@ script:
     - inspekt lint
     - inspekt indent
     - inspekt style
-    - ./selftests/run -v selftests/all/doc
     - ./selftests/run -v selftests/all/functional
     - ./selftests/run -v selftests/all/unit

--- a/avocado.spec
+++ b/avocado.spec
@@ -58,6 +58,7 @@ selftests/run selftests/all/unit
 %config(noreplace)/etc/avocado/avocado.conf
 %config(noreplace)/etc/avocado/conf.d/README
 %config(noreplace)/etc/avocado/conf.d/gdb.conf
+%config(noreplace)/etc/avocado/conf.d/virt-test.conf
 %config(noreplace)/etc/avocado/sysinfo/commands
 %config(noreplace)/etc/avocado/sysinfo/files
 %config(noreplace)/etc/avocado/sysinfo/profilers

--- a/avocado/core/exceptions.py
+++ b/avocado/core/exceptions.py
@@ -86,6 +86,14 @@ class NotATestError(TestBaseException):
     status = "NOT_A_TEST"
 
 
+class TestNotFoundError(TestBaseException):
+
+    """
+    Indicates that the test was not found in the test directory.
+    """
+    status = "ERROR"
+
+
 class TestTimeoutError(TestBaseException):
 
     """

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -26,6 +26,7 @@ import sys
 from avocado import test
 from avocado import data_dir
 from avocado.utils import path
+from avocado.core import output
 
 try:
     import cStringIO as StringIO
@@ -35,8 +36,9 @@ except ImportError:
 
 class _DebugJob(object):
 
-    def __init__(self):
+    def __init__(self, args=None):
         self.logdir = '.'
+        self.args = args
 
 
 class BrokenSymlink(object):
@@ -63,12 +65,46 @@ class TestLoaderProxy(object):
                                       "TestResult" % plugin)
         self.loader_plugins.append(plugin)
 
-    def discover(self, urls):
+    def load_plugins(self, args):
+        for key in args.__dict__.keys():
+            if key.endswith('_loader'):
+                loader_class = getattr(args, key)
+                if issubclass(loader_class, TestLoader):
+                    loader_plugin = loader_class(args=args)
+                    self.add_loader_plugin(loader_plugin)
+        filesystem_loader = TestLoader()
+        self.add_loader_plugin(filesystem_loader)
+
+    def get_extra_listing(self, args):
+        for loader_plugin in self.loader_plugins:
+            loader_plugin.get_extra_listing(args)
+
+    def get_base_keywords(self):
+        base_path = []
+        for loader_plugin in self.loader_plugins:
+            base_path += loader_plugin.get_base_keywords()
+        return base_path
+
+    def get_type_label_mapping(self):
+        mapping = {}
+        for loader_plugin in self.loader_plugins:
+            mapping.update(loader_plugin.get_type_label_mapping())
+        return mapping
+
+    def get_decorator_mapping(self):
+        mapping = {}
+        for loader_plugin in self.loader_plugins:
+            mapping.update(loader_plugin.get_decorator_mapping())
+        return mapping
+
+    def discover(self, urls, list_non_tests=False):
         """
         Discover (possible) tests from test urls.
 
         :param urls: a list of tests urls.
         :type urls: list
+        :param list_non_tests: Whether to list non tests (for listing methods)
+        :type list_non_tests: bool
         :return: A list of test factories (tuples (TestClass, test_params))
         """
         test_factories = []
@@ -76,6 +112,9 @@ class TestLoaderProxy(object):
             for loader_plugin in self.loader_plugins:
                 try:
                     params_list_from_url = loader_plugin.discover_url(url)
+                    if list_non_tests:
+                        for params in params_list_from_url:
+                            params['omit_non_tests'] = False
                     if params_list_from_url:
                         if url not in self.url_plugin_mapping:
                             self.url_plugin_mapping[url] = loader_plugin
@@ -118,10 +157,53 @@ class TestLoader(object):
     Test loader class.
     """
 
-    def __init__(self, job=None):
+    def __init__(self, job=None, args=None):
+
         if job is None:
-            job = _DebugJob()
+            job = _DebugJob(args=args)
         self.job = job
+
+    def get_extra_listing(self, args):
+        pass
+
+    def get_base_keywords(self):
+        """
+        Get base keywords to locate tests (path to test dir in this case).
+
+        Used to list all tests available in virt-test.
+
+        :return: list with path strings.
+        """
+        return [data_dir.get_test_dir()]
+
+    def get_type_label_mapping(self):
+        """
+        Get label mapping for display in test listing.
+
+        :return: Dict {TestClass: 'TEST_LABEL_STRING'}
+        """
+        return {test.SimpleTest: 'SIMPLE',
+                test.BuggyTest: 'BUGGY',
+                test.NotATest: 'NOT_A_TEST',
+                test.MissingTest: 'MISSING',
+                BrokenSymlink: 'BROKEN_SYMLINK',
+                AccessDeniedPath: 'ACCESS_DENIED',
+                test.Test: 'INSTRUMENTED'}
+
+    def get_decorator_mapping(self):
+        """
+        Get label mapping for display in test listing.
+
+        :return: Dict {TestClass: decorator function}
+        """
+        term_support = output.TermSupport()
+        return {test.SimpleTest: term_support.healthy_str,
+                test.BuggyTest: term_support.fail_header_str,
+                test.NotATest: term_support.warn_header_str,
+                test.MissingTest: term_support.fail_header_str,
+                BrokenSymlink: term_support.fail_header_str,
+                AccessDeniedPath: term_support.fail_header_str,
+                test.Test: term_support.healthy_str}
 
     def _is_unittests_like(self, test_class, pattern='test'):
         for name, _ in inspect.getmembers(test_class, inspect.ismethod):

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -403,14 +403,14 @@ class View(object):
         if self.use_paginator:
             self.paginator.close()
 
-    def notify(self, event='message', msg=None):
+    def notify(self, event='message', msg=None, skip_newline=False):
         mapping = {'message': self._log_ui_header,
                    'minor': self._log_ui_minor,
                    'error': self._log_ui_error,
                    'warning': self._log_ui_warning,
                    'partial': self._log_ui_partial}
         if msg is not None:
-            mapping[event](msg)
+            mapping[event](msg=msg, skip_newline=skip_newline)
 
     def notify_progress(self, progress):
         self._log_ui_throbber_progress(progress)
@@ -491,37 +491,37 @@ class View(object):
         """
         self._log_ui_info(term_support.partial_str(msg), skip_newline)
 
-    def _log_ui_header(self, msg):
+    def _log_ui_header(self, msg, skip_newline=False):
         """
         Log a header message.
 
         :param msg: Message to write.
         """
-        self._log_ui_info(term_support.header_str(msg))
+        self._log_ui_info(term_support.header_str(msg), skip_newline)
 
-    def _log_ui_minor(self, msg):
+    def _log_ui_minor(self, msg, skip_newline=False):
         """
         Log a minor message.
 
         :param msg: Message to write.
         """
-        self._log_ui_info(msg)
+        self._log_ui_info(msg, skip_newline)
 
-    def _log_ui_error(self, msg):
+    def _log_ui_error(self, msg, skip_newline=False):
         """
         Log an error message (useful for critical errors).
 
         :param msg: Message to write.
         """
-        self._log_ui_error_base(term_support.fail_header_str(msg))
+        self._log_ui_error_base(term_support.fail_header_str(msg), skip_newline)
 
-    def _log_ui_warning(self, msg):
+    def _log_ui_warning(self, msg, skip_newline=False):
         """
         Log a warning message (useful for warning messages).
 
         :param msg: Message to write.
         """
-        self._log_ui_info(term_support.warn_header_str(msg))
+        self._log_ui_info(term_support.warn_header_str(msg), skip_newline)
 
     def _log_ui_status_pass(self, t_elapsed):
         """

--- a/avocado/core/plugins/test_list.py
+++ b/avocado/core/plugins/test_list.py
@@ -23,59 +23,32 @@ from avocado.utils import astring
 from avocado.core.plugins import plugin
 
 
-class TestList(plugin.Plugin):
+class TestLister(object):
 
     """
-    Implements the avocado 'list' subcommand
+    Lists available test modules
     """
 
-    name = 'test_lister'
-    enabled = True
-    view = None
-    test_loader = loader.TestLoader()
-    term_support = output.TermSupport()
+    def __init__(self, args):
+        use_paginator = args.paginator == 'on'
+        self.view = output.View(app_args=args, use_paginator=use_paginator)
+        self.term_support = output.TermSupport()
+        self.test_loader = loader.TestLoader()
+        self.args = args
 
-    def configure(self, parser):
-        """
-        Add the subparser for the list action.
-
-        :param parser: Main test runner parser.
-        """
-        self.parser = parser.subcommands.add_parser(
-            'list',
-            help='List available test modules')
-        self.parser.add_argument('paths', type=str, default=[], nargs='*',
-                                 help="List of paths. If no paths provided, "
-                                      "avocado will list tests on the "
-                                      "configured test directory, "
-                                      "see 'avocado config --datadir'")
-        self.parser.add_argument('-V', '--verbose',
-                                 action='store_true', default=False,
-                                 help='Whether to show extra information '
-                                      '(headers and summary). Current: %('
-                                      'default)s')
-        self.parser.add_argument('--paginator',
-                                 choices=('on', 'off'), default='on',
-                                 help='Turn the paginator on/off. '
-                                      'Current: %(default)s')
-        super(TestList, self).configure(self.parser)
-
-    def _run(self, args):
-        """
-        List available test modules.
-
-        :param args: Command line args received from the list subparser.
-        """
-        self.view = output.View(app_args=args,
-                                use_paginator=args.paginator == 'on')
-
+    def _set_paths(self):
         paths = [data_dir.get_test_dir()]
-        if args.paths:
-            paths = args.paths
+        if self.args.paths:
+            paths = self.args.paths
+        return paths
+
+    def _get_test_suite(self, paths):
         params_list = self.test_loader.discover_urls(paths)
         for params in params_list:
             params['omit_non_tests'] = False
-        test_suite = self.test_loader.discover(params_list)
+        return self.test_loader.discover(params_list)
+
+    def _validate_test_suite(self, test_suite):
         error_msg_parts = self.test_loader.validate_ui(test_suite,
                                                        ignore_not_test=True,
                                                        ignore_access_denied=True,
@@ -86,14 +59,29 @@ class TestList(plugin.Plugin):
             self.view.cleanup()
             sys.exit(exit_codes.AVOCADO_FAIL)
 
+    def _get_test_matrix(self, test_suite):
         test_matrix = []
-        stats = {'simple': 0,
-                 'instrumented': 0,
-                 'buggy': 0,
-                 'missing': 0,
-                 'not_a_test': 0,
-                 'broken_symlink': 0,
-                 'access_denied': 0}
+
+        type_label_mapping = {test.SimpleTest: 'SIMPLE',
+                              test.BuggyTest: 'BUGGY',
+                              test.NotATest: 'NOT_A_TEST',
+                              test.MissingTest: 'MISSING',
+                              loader.BrokenSymlink: 'BROKEN_SYMLINK',
+                              loader.AccessDeniedPath: 'ACCESS_DENIED',
+                              test.Test: 'INSTRUMENTED'}
+
+        decorator_mapping = {test.SimpleTest: self.term_support.healthy_str,
+                             test.BuggyTest: self.term_support.fail_header_str,
+                             test.NotATest: self.term_support.warn_header_str,
+                             test.MissingTest: self.term_support.fail_header_str,
+                             loader.BrokenSymlink: self.term_support.fail_header_str,
+                             loader.AccessDeniedPath: self.term_support.fail_header_str,
+                             test.Test: self.term_support.healthy_str}
+
+        stats = {}
+        for value in type_label_mapping.values():
+            stats[value.lower()] = 0
+
         for cls, params in test_suite:
             id_label = ''
             type_label = cls.__name__
@@ -106,68 +94,51 @@ class TestList(plugin.Plugin):
                 elif 'path' in params:
                     id_label = params['path']
 
-            if cls == test.SimpleTest:
-                stats['simple'] += 1
-                type_label = self.term_support.healthy_str('SIMPLE')
-            elif cls == test.BuggyTest:
-                stats['buggy'] += 1
-                type_label = self.term_support.fail_header_str('BUGGY')
-            elif cls == test.NotATest:
-                if not args.verbose:
-                    continue
-                stats['not_a_test'] += 1
-                type_label = self.term_support.warn_header_str('NOT_A_TEST')
-            elif cls == test.MissingTest:
-                stats['missing'] += 1
-                type_label = self.term_support.fail_header_str('MISSING')
-            elif cls == loader.BrokenSymlink:
-                stats['broken_symlink'] += 1
-                type_label = self.term_support.fail_header_str('BROKEN_SYMLINK')
-            elif cls == loader.AccessDeniedPath:
-                stats['access_denied'] += 1
-                type_label = self.term_support.fail_header_str('ACCESS_DENIED')
-            else:
+            try:
+                type_label = type_label_mapping[cls]
+                decorator = decorator_mapping[cls]
+                stats[type_label.lower()] += 1
+                type_label = decorator(type_label)
+            except KeyError:
                 if issubclass(cls, test.Test):
-                    stats['instrumented'] += 1
+                    cls = test.Test
+                    type_label = type_label_mapping[cls]
+                    decorator = decorator_mapping[cls]
+                    stats[type_label.lower()] += 1
+                    type_label = decorator(type_label)
                     id_label = params['name']
-                    type_label = self.term_support.healthy_str('INSTRUMENTED')
 
             test_matrix.append((type_label, id_label))
 
+        return test_matrix, stats
+
+    def _display(self, test_matrix, stats):
         header = None
-        if args.verbose:
-            header = (self.term_support.header_str('Type'),
-                      self.term_support.header_str('file'))
-        for line in astring.tabular_output(test_matrix,
-                                           header=header).splitlines():
+        if self.args.verbose:
+            header = (self.term_support.header_str('Type'), self.term_support.header_str('ID'))
+
+        for line in astring.tabular_output(test_matrix, header=header).splitlines():
             self.view.notify(event='minor', msg="%s" % line)
 
-        if args.verbose:
+        if self.args.verbose:
             self.view.notify(event='minor', msg='')
+            for key in sorted(stats):
+                self.view.notify(event='message', msg=("%s: %s" % (key.upper(), stats[key])))
 
-            self.view.notify(event='message', msg=("SIMPLE: %s" %
-                                                   stats['simple']))
-            self.view.notify(event='message', msg=("INSTRUMENTED: %s" %
-                                                   stats['instrumented']))
-            self.view.notify(event='message', msg=("BUGGY: %s" %
-                                                   stats['buggy']))
-            self.view.notify(event='message', msg=("MISSING: %s" %
-                                                   stats['missing']))
-            self.view.notify(event='message', msg=("NOT_A_TEST: %s" %
-                                                   stats['not_a_test']))
-            self.view.notify(event='message', msg=("ACCESS_DENIED: %s" %
-                                                   stats['access_denied']))
-            self.view.notify(event='message', msg=("BROKEN_SYMLINK: %s" %
-                                                   stats['broken_symlink']))
+    def _list(self):
+        paths = self._set_paths()
+        test_suite = self._get_test_suite(paths)
+        self._validate_test_suite(test_suite)
+        test_matrix, stats = self._get_test_matrix(test_suite)
+        self._display(test_matrix, stats)
 
-    def run(self, args):
+    def list(self):
         rc = 0
         try:
-            self._run(args)
+            self._list()
         except KeyboardInterrupt:
             rc = exit_codes.AVOCADO_FAIL
-            msg = ('Command interrupted by '
-                   'user...')
+            msg = 'Command interrupted by user...'
             if self.view is not None:
                 self.view.notify(event='error', msg=msg)
             else:
@@ -175,4 +146,40 @@ class TestList(plugin.Plugin):
         finally:
             if self.view:
                 self.view.cleanup()
-        sys.exit(rc)
+        return rc
+
+
+class TestList(plugin.Plugin):
+
+    """
+    Implements the avocado 'list' subcommand
+    """
+
+    name = 'test_lister'
+    enabled = True
+
+    def configure(self, parser):
+        """
+        Add the subparser for the list action.
+
+        :param parser: Main test runner parser.
+        """
+        self.parser = parser.subcommands.add_parser('list', help='List available test modules')
+        self.parser.add_argument('paths', type=str, default=[], nargs='*',
+                                 help="List of paths. If no paths provided, "
+                                      "avocado will list tests on the "
+                                      "configured test directory, "
+                                      "see 'avocado config --datadir'")
+        self.parser.add_argument('-V', '--verbose',
+                                 action='store_true', default=False,
+                                 help='Whether to show extra information '
+                                      '(headers and summary). Current: %(default)s')
+        self.parser.add_argument('--paginator',
+                                 choices=('on', 'off'), default='on',
+                                 help='Turn the paginator on/off. '
+                                      'Current: %(default)s')
+        super(TestList, self).configure(self.parser)
+
+    def run(self, args):
+        test_lister = TestLister(args)
+        return test_lister.list()

--- a/avocado/core/plugins/test_list.py
+++ b/avocado/core/plugins/test_list.py
@@ -15,7 +15,6 @@
 import sys
 
 from avocado import test
-from avocado import data_dir
 from avocado.core import loader
 from avocado.core import output
 from avocado.core import exit_codes
@@ -33,20 +32,21 @@ class TestLister(object):
         use_paginator = args.paginator == 'on'
         self.view = output.View(app_args=args, use_paginator=use_paginator)
         self.term_support = output.TermSupport()
-        self.test_loader = loader.TestLoader()
+        self.test_loader = loader.TestLoaderProxy()
+        self.test_loader.load_plugins(args)
         self.args = args
 
-    def _set_paths(self):
-        paths = [data_dir.get_test_dir()]
-        if self.args.paths:
-            paths = self.args.paths
-        return paths
+    def _extra_listing(self):
+        self.test_loader.get_extra_listing(self.args)
+
+    def _get_keywords(self):
+        keywords = self.test_loader.get_base_keywords()
+        if self.args.keywords:
+            keywords = self.args.keywords
+        return keywords
 
     def _get_test_suite(self, paths):
-        params_list = self.test_loader.discover_urls(paths)
-        for params in params_list:
-            params['omit_non_tests'] = False
-        return self.test_loader.discover(params_list)
+        return self.test_loader.discover(paths, list_non_tests=self.args.verbose)
 
     def _validate_test_suite(self, test_suite):
         error_msg_parts = self.test_loader.validate_ui(test_suite,
@@ -62,21 +62,8 @@ class TestLister(object):
     def _get_test_matrix(self, test_suite):
         test_matrix = []
 
-        type_label_mapping = {test.SimpleTest: 'SIMPLE',
-                              test.BuggyTest: 'BUGGY',
-                              test.NotATest: 'NOT_A_TEST',
-                              test.MissingTest: 'MISSING',
-                              loader.BrokenSymlink: 'BROKEN_SYMLINK',
-                              loader.AccessDeniedPath: 'ACCESS_DENIED',
-                              test.Test: 'INSTRUMENTED'}
-
-        decorator_mapping = {test.SimpleTest: self.term_support.healthy_str,
-                             test.BuggyTest: self.term_support.fail_header_str,
-                             test.NotATest: self.term_support.warn_header_str,
-                             test.MissingTest: self.term_support.fail_header_str,
-                             loader.BrokenSymlink: self.term_support.fail_header_str,
-                             loader.AccessDeniedPath: self.term_support.fail_header_str,
-                             test.Test: self.term_support.healthy_str}
+        type_label_mapping = self.test_loader.get_type_label_mapping()
+        decorator_mapping = self.test_loader.get_decorator_mapping()
 
         stats = {}
         for value in type_label_mapping.values():
@@ -115,7 +102,7 @@ class TestLister(object):
     def _display(self, test_matrix, stats):
         header = None
         if self.args.verbose:
-            header = (self.term_support.header_str('Type'), self.term_support.header_str('ID'))
+            header = (self.term_support.header_str('Type'), self.term_support.header_str('Test'))
 
         for line in astring.tabular_output(test_matrix, header=header).splitlines():
             self.view.notify(event='minor', msg="%s" % line)
@@ -126,8 +113,9 @@ class TestLister(object):
                 self.view.notify(event='message', msg=("%s: %s" % (key.upper(), stats[key])))
 
     def _list(self):
-        paths = self._set_paths()
-        test_suite = self._get_test_suite(paths)
+        self._extra_listing()
+        keywords = self._get_keywords()
+        test_suite = self._get_test_suite(keywords)
         self._validate_test_suite(test_suite)
         test_matrix, stats = self._get_test_matrix(test_suite)
         self._display(test_matrix, stats)
@@ -157,6 +145,7 @@ class TestList(plugin.Plugin):
 
     name = 'test_lister'
     enabled = True
+    priority = 0
 
     def configure(self, parser):
         """
@@ -165,11 +154,16 @@ class TestList(plugin.Plugin):
         :param parser: Main test runner parser.
         """
         self.parser = parser.subcommands.add_parser('list', help='List available test modules')
-        self.parser.add_argument('paths', type=str, default=[], nargs='*',
-                                 help="List of paths. If no paths provided, "
-                                      "avocado will list tests on the "
-                                      "configured test directory, "
-                                      "see 'avocado config --datadir'")
+        self.parser.add_argument('keywords', type=str, default=[], nargs='*',
+                                 help="List of paths, aliases or other "
+                                      "keywords used to locate tests. "
+                                      "If empty, avocado will list tests on "
+                                      "the configured test source, "
+                                      "(see 'avocado config --datadir') Also, "
+                                      "if there are other test loader plugins "
+                                      "active, tests from those plugins might "
+                                      "also show up (behavior may vary among "
+                                      "plugins)")
         self.parser.add_argument('-V', '--verbose',
                                  action='store_true', default=False,
                                  help='Whether to show extra information '
@@ -179,6 +173,7 @@ class TestList(plugin.Plugin):
                                  help='Turn the paginator on/off. '
                                       'Current: %(default)s')
         super(TestList, self).configure(self.parser)
+        parser.lister = self.parser
 
     def run(self, args):
         test_lister = TestLister(args)

--- a/avocado/core/plugins/virt_test.py
+++ b/avocado/core/plugins/virt_test.py
@@ -1,0 +1,1129 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2015
+# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+
+"""
+Avocado virt-test compatibility wrapper
+"""
+
+import os
+import sys
+import logging
+import Queue
+import time
+
+from avocado.core import result
+from avocado.core import loader
+from avocado.core import output
+from avocado.core import exceptions
+from avocado.core.plugins import plugin
+from avocado import test
+from avocado.settings import settings
+from avocado.utils import path
+from avocado import multiplexer
+
+# virt-test supports using autotest from a git checkout, so we'll have to
+# support that as well. The code below will pick up the environment variable
+# $AUTOTEST_PATH and do the import magic needed to make the autotest library
+# available in the system.
+AUTOTEST_PATH = None
+
+if 'AUTOTEST_PATH' in os.environ:
+    AUTOTEST_PATH = os.path.expanduser(os.environ['AUTOTEST_PATH'])
+    client_dir = os.path.join(os.path.abspath(AUTOTEST_PATH), 'client')
+    setup_modules_path = os.path.join(client_dir, 'setup_modules.py')
+    import imp
+    setup_modules = imp.load_source('autotest_setup_modules',
+                                    setup_modules_path)
+    setup_modules.setup(base_path=client_dir,
+                        root_module_name="autotest.client")
+
+from autotest.client import utils
+from autotest.client.shared import error
+
+# The code below is used by this plugin to find the virt test directory,
+# so that it can load the virttest python lib, used by the plugin code.
+# If the user doesn't provide the proper configuration, the plugin will
+# fail to load.
+VIRT_TEST_PATH = None
+
+if 'VIRT_TEST_PATH' in os.environ:
+    VIRT_TEST_PATH = os.environ['VIRT_TEST_PATH']
+else:
+    VIRT_TEST_PATH = settings.get_value(section='virt_test',
+                                        key='virt_test_path', default=None)
+
+if VIRT_TEST_PATH is not None:
+    sys.path.append(os.path.expanduser(VIRT_TEST_PATH))
+
+from virttest import asset
+from virttest import bootstrap
+from virttest import cartesian_config
+from virttest import data_dir
+from virttest import defaults
+from virttest import env_process
+from virttest import funcatexit
+from virttest import standalone_test
+from virttest import utils_env
+from virttest import utils_misc
+from virttest import utils_params
+from virttest import version
+from virttest import storage
+
+from virttest.standalone_test import SUPPORTED_TEST_TYPES
+from virttest.standalone_test import SUPPORTED_LIBVIRT_URIS
+from virttest.standalone_test import SUPPORTED_LIBVIRT_DRIVERS
+from virttest.standalone_test import SUPPORTED_IMAGE_TYPES
+from virttest.standalone_test import SUPPORTED_DISK_BUSES
+from virttest.standalone_test import SUPPORTED_NIC_MODELS
+from virttest.standalone_test import SUPPORTED_NET_TYPES
+from virttest.standalone_test import QEMU_DEFAULT_SET
+from virttest.standalone_test import LIBVIRT_DEFAULT_SET
+from virttest.standalone_test import LVSB_DEFAULT_SET
+from virttest.standalone_test import OVS_DEFAULT_SET
+from virttest.standalone_test import LIBVIRT_INSTALL
+from virttest.standalone_test import LIBVIRT_REMOVE
+
+
+class VirtTestResult(result.HumanTestResult):
+
+    """
+    Virt Test compatibility layer Result class.
+    """
+
+    def __init__(self, stream, args):
+        """
+        Creates an instance of RemoteTestResult.
+
+        :param stream: an instance of :class:`avocado.core.output.View`.
+        :param args: an instance of :class:`argparse.Namespace`.
+        """
+        result.HumanTestResult.__init__(self, stream, args)
+        self.output = '-'
+        self.setup()
+
+    def setup(self):
+        """
+        Run the setup needed before tests start to run (restore test images).
+        """
+        options = self.args
+        if options.vt_config:
+            parent_config_dir = os.path.dirname(os.path.dirname(options.vt_config))
+            parent_config_dir = os.path.dirname(parent_config_dir)
+            options.vt_type = parent_config_dir
+
+        kwargs = {'options': options}
+
+        failed = False
+
+        bg = utils.InterruptedThread(bootstrap.setup, kwargs=kwargs)
+        t_begin = time.time()
+        bg.start()
+
+        self.stream.notify(event='message', msg="SETUP      :  ", skip_newline=True)
+        while bg.isAlive():
+            self.stream.notify_progress(True)
+            time.sleep(0.1)
+
+        reason = None
+        try:
+            bg.join()
+        except Exception, e:
+            failed = True
+            reason = e
+
+        t_end = time.time()
+        t_elapsed = t_end - t_begin
+        state = dict()
+        state['time_elapsed'] = t_elapsed
+        if not failed:
+            self.stream.set_test_status(status='PASS', state=state)
+        else:
+            self.stream.set_test_status(status='FAIL', state=state)
+            self.stream.notify(event='error', msg="Setup error: %s" % reason)
+            sys.exit(-1)
+
+        return True
+
+
+def configure_console_logging(loglevel=logging.DEBUG):
+    """
+    Simple helper for adding a file logger to the root logger.
+    """
+    logger = logging.getLogger()
+    stream_handler = logging.StreamHandler(sys.stdout)
+    stream_handler.setLevel(loglevel)
+
+    fmt = ('%(asctime)s %(module)-10.10s L%(lineno)-.4d %('
+           'levelname)-5.5s| %(message)s')
+    formatter = logging.Formatter(fmt=fmt, datefmt='%H:%M:%S')
+
+    stream_handler.setFormatter(formatter)
+    logger.addHandler(stream_handler)
+
+    return stream_handler
+
+
+def configure_file_logging(logfile, loglevel=logging.DEBUG):
+    """
+    Add a file logger to the root logger.
+
+    This file logger contains the formatting of the avocado
+    job log. This way all things logged by autotest go
+    straight to the avocado job log.
+    """
+    logger = logging.getLogger()
+    file_handler = logging.FileHandler(filename=logfile)
+    file_handler.setLevel(loglevel)
+    fmt = ('%(asctime)s %(module)-10.10s L%(lineno)-.4d %('
+           'levelname)-5.5s| %(message)s')
+    formatter = logging.Formatter(fmt=fmt, datefmt='%H:%M:%S')
+    file_handler.setFormatter(formatter)
+    logger.addHandler(file_handler)
+
+    return file_handler
+
+
+def guest_listing(options, view):
+    term_support = output.TermSupport()
+    if options.vt_type == 'lvsb':
+        view.notify(event='error',
+                    msg="No guest types available for lvsb testing")
+        sys.exit(1)
+    index = 0
+    view.notify(event='minor', msg=("Searched %s for guest images\n" %
+                                    os.path.join(data_dir.get_data_dir(),
+                                                 'images')))
+    view.notify(event='minor', msg="Available guests in config:")
+    view.notify(msg='')
+    for params in standalone_test.get_guest_name_parser(options).get_dicts():
+        index += 1
+        base_dir = params.get("images_base_dir", data_dir.get_data_dir())
+        image_name = storage.get_image_filename(params, base_dir)
+        name = params['name']
+        if os.path.isfile(image_name):
+            out = name
+        else:
+            out = (name + " " +
+                   term_support.warn_header_str("(missing %s)" %
+                                                os.path.basename(image_name)))
+        view.notify(event='minor', msg=out)
+
+
+class VirtTestListJob(object):
+
+    """
+    Mock Job class, used to provide test loaders with a Job object with enough
+    options data for test listing purposes.
+    """
+
+    def __init__(self, args):
+        self.view = output.View()
+        self.logfile = None
+        self.logdir = '.'
+        self.args = args
+        self.args.vt_config = None
+        self.args.vt_verbose = True
+        self.args.vt_log_level = 'debug'
+        self.args.vt_console_level = 'debug'
+        self.args.vt_datadir = data_dir.get_data_dir()
+        self.args.vt_config = None
+        self.args.vt_arch = None
+        self.args.vt_machine_type = None
+        self.args.vt_keep_guest_running = False
+        self.args.vt_keep_image_between_tests = False
+        self.args.vt_mem = 1024
+        self.args.vt_no_filter = ''
+        self.args.vt_qemu_bin = None
+        self.args.vt_dst_qemu_bin = None
+        self.args.vt_nettype = 'user'
+        self.args.vt_only_type_specific = False
+        self.args.vt_tests = ''
+        self.args.vt_connect_uri = 'qemu:///system'
+        self.args.vt_accel = 'kvm'
+        self.args.vt_monitor = 'human'
+        self.args.vt_smp = 1
+        self.args.vt_image_type = 'qcow2'
+        self.args.vt_nic_model = 'virtio_net'
+        self.args.vt_disk_bus = 'virtio_blk'
+        self.args.vt_vhost = 'off'
+        self.args.vt_malloc_perturb = 'yes'
+        self.args.vt_qemu_sandbox = 'on'
+        self.args.vt_tests = ''
+        self.args.show_job_log = False
+        self.args.test_lister = True
+
+
+class VirtTestLoader(loader.TestLoader):
+
+    def __init__(self, job=None, args=None):
+        if job is None:
+            job = VirtTestListJob(args=args)
+        loader.TestLoader.__init__(self, job=job)
+        standalone_test.reset_logging()
+        if self.job.args.show_job_log:
+            configure_console_logging()
+        else:
+            if job.logfile is not None:
+                configure_file_logging(logfile=job.logfile)
+
+    def _get_parser(self):
+        options_processor = VirtTestOptionsProcess(self.job)
+        return options_processor.get_parser()
+
+    def get_extra_listing(self, args):
+        if args.vt_list_guests:
+            use_paginator = args.paginator == 'on'
+            try:
+                view = output.View(use_paginator=use_paginator)
+                guest_listing(args, view)
+            finally:
+                view.cleanup()
+            sys.exit(0)
+
+    def get_base_keywords(self):
+        """
+        Get base keywords to use (when no keywords are passed to 'list').
+
+        Used to list all tests available in virt-test.
+
+        :return: list with keyword strings.
+        """
+        return ['vt_list_all']
+
+    def get_type_label_mapping(self):
+        """
+        Get label mapping for display in test listing.
+
+        :return: Dict {TestClass: 'TEST_LABEL_STRING'}
+        """
+        return {VirtTest: 'VT'}
+
+    def get_decorator_mapping(self):
+        """
+        Get label mapping for display in test listing.
+
+        :return: Dict {TestClass: decorator function}
+        """
+        term_support = output.TermSupport()
+        return {VirtTest: term_support.healthy_str}
+
+    def discover(self, params_list):
+        """
+        Discover tests for test suite.
+
+        :param params_list: a list of test parameters.
+        :type params_list: list
+        :return: a test suite (a list of test factories).
+        """
+        test_suite = []
+        for params in params_list:
+            # We want avocado to inject params coming from its multiplexer into
+            # the test params. This will allow users to access avocado params from
+            # inside virt tests. This feature would only work if the virt test
+            # in question is executed from inside avocado.
+            params['avocado_mux_append'] = True
+            test_name = params.get("_short_name_map_file")["subtests.cfg"]
+            params['id'] = test_name
+            test_parameters = {'name': test_name,
+                               'base_logdir': self.job.logdir,
+                               'params': params,
+                               'job': self.job}
+            test_suite.append((VirtTest, test_parameters))
+        return test_suite
+
+    def validate_ui(self, test_suite, ignore_missing=False,
+                    ignore_not_test=False, ignore_broken_symlinks=False,
+                    ignore_access_denied=False):
+        return []
+
+    def discover_url(self, url):
+        cartesian_parser = self._get_parser()
+        if url != 'vt_list_all':
+            cartesian_parser.only_filter(url)
+        params_list = [t for t in cartesian_parser.get_dicts()]
+        return params_list
+
+
+class VirtTest(test.Test):
+
+    """
+    Mininal test class used to run a virt test.
+    """
+
+    env_version = utils_env.get_env_version()
+
+    def __init__(self, methodName='runTest', name=None, params=None,
+                 base_logdir=None, tag=None, job=None, runner_queue=None):
+        del name
+        options = job.args
+
+        self.bindir = data_dir.get_root_dir()
+        self.virtdir = os.path.join(self.bindir, 'shared')
+        self.builddir = os.path.join(self.bindir, 'backends', params.get("vm_type"))
+        self.srcdir = path.init_dir(os.path.join(self.builddir, 'src'))
+        self.tmpdir = path.init_dir(os.path.join(self.bindir, 'tmp'))
+
+        self.iteration = 0
+        if options.vt_config:
+            name = params.get("shortname")
+        else:
+            name = params.get("_short_name_map_file")["subtests.cfg"]
+        self.outputdir = None
+        self.resultsdir = None
+        self.logfile = None
+        self.file_handler = None
+        self.background_errors = Queue.Queue()
+        super(VirtTest, self).__init__(methodName=methodName, name=name, params=params, base_logdir=base_logdir,
+                                       tag=tag, job=job, runner_queue=runner_queue)
+        self.params = utils_params.Params(params)
+        # Here we turn the data the multiplexer injected into the params and turn it
+        # into an AvocadoParams object, that will allow users to access data from it.
+        # Example: sleep_length = test.avocado_params.get('sleep_length', default=1)
+        p = params.get('avocado_params', None)
+        if p is not None:
+            params, mux_entry = p[0], p[1]
+        else:
+            params, mux_entry = [], []
+        self.avocado_params = multiplexer.AvocadoParams(params, self.name, self.tag,
+                                                        mux_entry,
+                                                        self.default_params)
+
+        self.debugdir = self.logdir
+        utils_misc.set_log_file_dir(self.logdir)
+
+    def start_logging(self):
+        super(VirtTest, self).start_logging()
+        root_logger = logging.getLogger()
+        root_logger.addHandler(self.file_handler)
+
+    def stop_logging(self):
+        super(VirtTest, self).stop_logging()
+        root_logger = logging.getLogger()
+        root_logger.removeHandler(self.file_handler)
+
+    def write_test_keyval(self, d):
+        self.whiteboard = str(d)
+
+    def verify_background_errors(self):
+        """
+        Verify if there are any errors that happened on background threads.
+
+        :raise Exception: Any exception stored on the background_errors queue.
+        """
+        try:
+            exc = self.background_errors.get(block=False)
+        except Queue.Empty:
+            pass
+        else:
+            raise exc[1], None, exc[2]
+
+    def runTest(self):
+        try:
+            self._runTest()
+        # This trick will give better reporting of virt tests
+        # being executed into avocado (skips and errors will display correctly)
+        except error.TestNAError, details:
+            raise exceptions.TestNAError(details)
+        except error.TestError, details:
+            raise exceptions.TestError(details)
+
+    def _runTest(self):
+        params = self.params
+
+        # If a dependency test prior to this test has failed, let's fail
+        # it right away as TestNA.
+        if params.get("dependency_failed") == 'yes':
+            raise error.TestNAError("Test dependency failed")
+
+        # Report virt test version
+        logging.info(version.get_pretty_version_info())
+        # Report the parameters we've received and write them as keyvals
+        logging.info("Starting test %s", self.tag)
+        logging.debug("Test parameters:")
+        keys = params.keys()
+        keys.sort()
+        for key in keys:
+            logging.debug("    %s = %s", key, params[key])
+
+        # Warn of this special condition in related location in output & logs
+        if os.getuid() == 0 and params.get('nettype', 'user') == 'user':
+            logging.warning("")
+            logging.warning("Testing with nettype='user' while running "
+                            "as root may produce unexpected results!!!")
+            logging.warning("")
+
+        # Open the environment file
+        env_filename = os.path.join(
+            data_dir.get_backend_dir(params.get("vm_type")),
+            params.get("env", "env"))
+        env = utils_env.Env(env_filename, self.env_version)
+
+        test_passed = False
+        t_type = None
+
+        try:
+            try:
+                try:
+                    subtest_dirs = []
+
+                    other_subtests_dirs = params.get("other_tests_dirs", "")
+                    for d in other_subtests_dirs.split():
+                        d = os.path.join(*d.split("/"))
+                        subtestdir = os.path.join(self.bindir, d, "tests")
+                        if not os.path.isdir(subtestdir):
+                            raise error.TestError("Directory %s does not "
+                                                  "exist" % subtestdir)
+                        subtest_dirs += data_dir.SubdirList(subtestdir,
+                                                            bootstrap.test_filter)
+
+                    provider = params.get("provider", None)
+
+                    if provider is None:
+                        # Verify if we have the correspondent source file for
+                        # it
+                        for generic_subdir in asset.get_test_provider_subdirs('generic'):
+                            subtest_dirs += data_dir.SubdirList(generic_subdir,
+                                                                bootstrap.test_filter)
+
+                        for specific_subdir in asset.get_test_provider_subdirs(params.get("vm_type")):
+                            subtest_dirs += data_dir.SubdirList(
+                                specific_subdir, bootstrap.test_filter)
+                    else:
+                        provider_info = asset.get_test_provider_info(provider)
+                        for key in provider_info['backends']:
+                            subtest_dirs += data_dir.SubdirList(
+                                provider_info['backends'][key]['path'],
+                                bootstrap.test_filter)
+
+                    subtest_dir = None
+
+                    # Get the test routine corresponding to the specified
+                    # test type
+                    logging.debug("Searching for test modules that match "
+                                  "'type = %s' and 'provider = %s' "
+                                  "on this cartesian dict",
+                                  params.get("type"), params.get("provider", None))
+
+                    t_types = params.get("type").split()
+                    # Make sure we can load provider_lib in tests
+                    for s in subtest_dirs:
+                        if os.path.dirname(s) not in sys.path:
+                            sys.path.insert(0, os.path.dirname(s))
+
+                    test_modules = {}
+                    for t_type in t_types:
+                        for d in subtest_dirs:
+                            module_path = os.path.join(d, "%s.py" % t_type)
+                            if os.path.isfile(module_path):
+                                logging.debug("Found subtest module %s",
+                                              module_path)
+                                subtest_dir = d
+                                break
+                        if subtest_dir is None:
+                            msg = ("Could not find test file %s.py on test"
+                                   "dirs %s" % (t_type, subtest_dirs))
+                            raise error.TestError(msg)
+                        # Load the test module
+                        f, p, d = imp.find_module(t_type, [subtest_dir])
+                        test_modules[t_type] = imp.load_module(t_type, f, p, d)
+                        f.close()
+
+                    # Preprocess
+                    try:
+                        params = env_process.preprocess(self, params, env)
+                    finally:
+                        env.save()
+
+                    # Run the test function
+                    for t_type in t_types:
+                        test_module = test_modules[t_type]
+                        run_func = utils_misc.get_test_entrypoint_func(
+                            t_type, test_module)
+                        try:
+                            run_func(self, params, env)
+                            self.verify_background_errors()
+                        finally:
+                            env.save()
+                    test_passed = True
+                    error_message = funcatexit.run_exitfuncs(env, t_type)
+                    if error_message:
+                        raise error.TestWarn("funcatexit failed with: %s"
+                                             % error_message)
+
+                except Exception:
+                    if t_type is not None:
+                        error_message = funcatexit.run_exitfuncs(env, t_type)
+                        if error_message:
+                            logging.error(error_message)
+                    try:
+                        env_process.postprocess_on_error(self, params, env)
+                    finally:
+                        env.save()
+                    raise
+
+            finally:
+                # Postprocess
+                try:
+                    try:
+                        env_process.postprocess(self, params, env)
+                    except Exception, e:
+                        if test_passed:
+                            raise
+                        logging.error("Exception raised during "
+                                      "postprocessing: %s", e)
+                finally:
+                    env.save()
+
+        except Exception, e:
+            if params.get("abort_on_error") != "yes":
+                raise
+            # Abort on error
+            logging.info("Aborting job (%s)", e)
+            if params.get("vm_type") == "qemu":
+                for vm in env.get_all_vms():
+                    if vm.is_dead():
+                        continue
+                    logging.info("VM '%s' is alive.", vm.name)
+                    for m in vm.monitors:
+                        logging.info("It has a %s monitor unix socket at: %s",
+                                     m.protocol, m.filename)
+                    logging.info("The command line used to start it was:\n%s",
+                                 vm.make_qemu_command())
+                raise error.JobError("Abort requested (%s)" % e)
+
+        return test_passed
+
+
+class VirtTestOptionsProcess(object):
+
+    """
+    Pick virt test options and parse them to get to a cartesian parser.
+    """
+
+    def __init__(self, job):
+        """
+        Parses options and initializes attributes.
+        """
+        self.options = job.args
+        # There are a few options from the original virt-test runner
+        # that don't quite make sense for avocado (avocado implements a better version of the virt-test feature).
+        # So let's just inject some values into options.
+        self.options.vt_verbose = False
+        self.options.vt_log_level = logging.DEBUG
+        self.options.vt_console_level = logging.DEBUG
+        self.options.vt_no_downloads = False
+        self.options.vt_selinux_setup = False
+        # These options can be done by using virt test scripts
+        self.options.vt_list_tests = False
+        self.options.vt_list_guests = False
+
+        # Here we'll inject values from the config file. Doing this makes things configurable yet the number
+        # of options is not overwhelming.
+        # setup section
+        self.options.vt_keep_image = settings.get_value('virt_test.setup', 'keep_image', key_type=bool)
+        self.options.vt_keep_image_between_tests = settings.get_value('virt_test.setup', 'keep_image_between_tests',
+                                                                      key_type=bool)
+        self.options.vt_keep_guest_running = settings.get_value('virt_test.setup', 'keep_guest_running', key_type=bool)
+        # common section
+        self.options.vt_data_dir = settings.get_value('virt_test.common', 'data_dir', default=None)
+        self.options.vt_type_specific = settings.get_value('virt_test.common', 'type_specific_only', key_type=bool)
+        self.options.vt_mem = settings.get_value('virt_test.common', 'mem', key_type=int)
+        self.options.vt_arch = settings.get_value('virt_test.common', 'arch', default=None)
+        self.options.vt_machine_type = settings.get_value('virt_test.common', 'machine_type',
+                                                          default=defaults.DEFAULT_MACHINE_TYPE)
+        # qemu section
+        self.options.vt_accel = settings.get_value('virt_test.qemu', 'accel', default='kvm')
+        self.options.vt_nettype = settings.get_value('virt_test.qemu', 'nettype', default='user')
+        self.options.vt_netdst = settings.get_value('virt_test.qemu', 'netdst', default='virbr0')
+        self.options.vt_vhost = settings.get_value('virt_test.qemu', 'vhost', default='off')
+        self.options.vt_monitor = settings.get_value('virt_test.qemu', 'monitor', default='human')
+        self.options.vt_smp = settings.get_value('virt_test.qemu', 'smp', default='2')
+        self.options.vt_image_type = settings.get_value('virt_test.qemu', 'image_type', default='qcow2')
+        self.options.vt_nic_model = settings.get_value('virt_test.qemu', 'nic_model', default='virtio_net')
+        self.options.vt_disk_bus = settings.get_value('virt_test.qemu', 'disk_bus', default='virtio_blk')
+        self.options.vt_qemu_sandbox = settings.get_value('virt_test.qemu', 'sandbox', default='on')
+        self.options.vt_qemu_defconfig = settings.get_value('virt_test.qemu', 'defconfig', default='yes')
+        self.options.vt_malloc_perturb = settings.get_value('virt_test.qemu', 'malloc_perturb', default='yes')
+
+        # libvirt section
+        self.options.vt_install_guest = settings.get_value('virt_test.libvirt', 'install_guest', key_type=bool,
+                                                           default=False)
+        self.options.vt_remove_guest = settings.get_value('virt_test.libvirt', 'remove_guest', key_type=bool,
+                                                          default=False)
+
+        # debug section
+        self.options.vt_no_cleanup = settings.get_value('virt_test.debug', 'no_cleanup', key_type=bool, default=False)
+
+        self.view = job.view
+        self.cartesian_parser = None
+
+    def _process_qemu_bin(self):
+        """
+        Puts the value of the qemu bin option in the cartesian parser command.
+        """
+        if self.options.vt_config and self.options.vt_qemu_bin is None:
+            logging.info("Config provided and no --vt-qemu-bin set. Not trying "
+                         "to automatically set qemu bin.")
+        else:
+            (qemu_bin_path, qemu_img_path, qemu_io_path,
+             qemu_dst_bin_path) = standalone_test.find_default_qemu_paths(self.options.vt_qemu_bin,
+                                                                          self.options.vt_dst_qemu_bin)
+            self.cartesian_parser.assign("qemu_binary", qemu_bin_path)
+            self.cartesian_parser.assign("qemu_img_binary", qemu_img_path)
+            self.cartesian_parser.assign("qemu_io_binary", qemu_io_path)
+            if qemu_dst_bin_path is not None:
+                self.cartesian_parser.assign("qemu_dst_binary",
+                                             qemu_dst_bin_path)
+
+    def _process_qemu_img(self):
+        """
+        Puts the value of the qemu bin option in the cartesian parser command.
+        """
+        if self.options.vt_config and self.options.vt_qemu_bin is None:
+            logging.info("Config provided and no --vt-qemu-bin set. Not trying "
+                         "to automatically set qemu bin.")
+        else:
+            (_, qemu_img_path,
+             _, _) = standalone_test.find_default_qemu_paths(self.options.vt_qemu_bin,
+                                                             self.options.vt_dst_qemu_bin)
+            self.cartesian_parser.assign("qemu_img_binary", qemu_img_path)
+
+    def _process_qemu_accel(self):
+        """
+        Puts the value of the qemu bin option in the cartesian parser command.
+        """
+        if self.options.vt_accel == 'tcg':
+            self.cartesian_parser.assign("disable_kvm", "yes")
+
+    def _process_bridge_mode(self):
+        if self.options.vt_nettype not in SUPPORTED_NET_TYPES:
+            self.view.notify(event='error', msg="Invalid --vt-nettype option '%s'. Valid options are: (%s)" %
+                             (self.options.vt_nettype, ", ".join(SUPPORTED_NET_TYPES)))
+            sys.exit(1)
+        if self.options.vt_nettype == 'bridge':
+            if os.getuid() != 0:
+                self.view.notify(event='error', msg="In order to use bridge, you need to be root, aborting...")
+                sys.exit(1)
+            self.cartesian_parser.assign("nettype", "bridge")
+            self.cartesian_parser.assign("netdst", self.options.netdst)
+        elif self.options.vt_nettype == 'user':
+            self.cartesian_parser.assign("nettype", "user")
+        elif self.options.vt_nettype == 'none':
+            self.cartesian_parser.assign("nettype", "none")
+
+    def _process_monitor(self):
+        if self.options.vt_monitor == 'qmp':
+            self.cartesian_parser.assign("monitors", "qmp1")
+            self.cartesian_parser.assign("monitor_type_qmp1", "qmp")
+
+    def _process_smp(self):
+        if not self.options.vt_config:
+            if self.options.vt_smp == '1':
+                self.cartesian_parser.only_filter("up")
+            elif self.options.vt_smp == '2':
+                self.cartesian_parser.only_filter("smp2")
+            else:
+                try:
+                    self.cartesian_parser.only_filter("up")
+                    self.cartesian_parser.assign("smp", int(self.options.vt_smp))
+                except ValueError:
+                    self.view.notify(event='error', msg="Invalid option for smp: %s, aborting..." % self.options.vt_smp)
+                    sys.exit(1)
+        else:
+            logging.info("Config provided, ignoring --vt-smp option")
+
+    def _process_arch(self):
+        if self.options.vt_arch is None:
+            pass
+        elif not self.options.vt_config:
+            self.cartesian_parser.only_filter(self.options.vt_arch)
+        else:
+            logging.info("Config provided, ignoring --vt-arch option")
+
+    def _process_machine_type(self):
+        if not self.options.vt_config:
+            if self.options.vt_machine_type is None:
+                # TODO: this is x86-specific, instead we can get the default
+                # arch from qemu binary and run on all supported machine types
+                if self.options.vt_arch is None and self.options.vt_guest_os is None:
+                    import virttest.defaults
+                    self.cartesian_parser.only_filter(
+                        virttest.defaults.DEFAULT_MACHINE_TYPE)
+            else:
+                self.cartesian_parser.only_filter(self.options.vt_machine_type)
+        else:
+            logging.info("Config provided, ignoring --vt-machine-type option")
+
+    def _process_image_type(self):
+        if not self.options.vt_config:
+            if self.options.vt_image_type in SUPPORTED_IMAGE_TYPES:
+                self.cartesian_parser.only_filter(self.options.vt_image_type)
+            else:
+                self.cartesian_parser.only_filter("raw")
+                # The actual param name is image_format.
+                self.cartesian_parser.assign("image_format",
+                                             self.options.vt_image_type)
+        else:
+            logging.info("Config provided, ignoring --vt-image-type option")
+
+    def _process_nic_model(self):
+        if not self.options.vt_config:
+            if self.options.vt_nic_model in SUPPORTED_NIC_MODELS:
+                self.cartesian_parser.only_filter(self.options.vt_nic_model)
+            else:
+                self.cartesian_parser.only_filter("nic_custom")
+                self.cartesian_parser.assign(
+                    "nic_model", self.options.vt_nic_model)
+        else:
+            logging.info("Config provided, ignoring --vt-nic-model option")
+
+    def _process_disk_buses(self):
+        if not self.options.vt_config:
+            if self.options.vt_disk_bus in SUPPORTED_DISK_BUSES:
+                self.cartesian_parser.only_filter(self.options.vt_disk_bus)
+            else:
+                self.view.notify(event='error', msg=("Option %s is not in the list %s, aborting..." %
+                                                     (self.options.vt_disk_bus, SUPPORTED_DISK_BUSES)))
+                sys.exit(1)
+        else:
+            logging.info("Config provided, ignoring --vt-disk-bus option")
+
+    def _process_vhost(self):
+        if not self.options.vt_config:
+            if self.options.vt_nettype == "bridge":
+                if self.options.vt_vhost == "on":
+                    self.cartesian_parser.assign("vhost", "on")
+                elif self.options.vt_vhost == "force":
+                    self.cartesian_parser.assign("netdev_extra_params",
+                                                 '",vhostforce=on"')
+                    self.cartesian_parser.assign("vhost", "on")
+            else:
+                if self.options.vt_vhost in ["on", "force"]:
+                    self.view.notify(event='error', msg=("Nettype %s is incompatible with vhost %s, aborting..." %
+                                                         (self.options.vt_nettype, self.options.vt_vhost)))
+                    sys.exit(1)
+        else:
+            logging.info("Config provided, ignoring --vt-vhost option")
+
+    def _process_qemu_sandbox(self):
+        if not self.options.vt_config:
+            if self.options.vt_qemu_sandbox == "off":
+                self.cartesian_parser.assign("qemu_sandbox", "off")
+        else:
+            logging.info("Config provided, ignoring \"--vt-sandbox <on|off>\" option")
+
+    def _process_qemu_defconfig(self):
+        if not self.options.vt_config:
+            if self.options.vt_qemu_defconfig == "no":
+                self.cartesian_parser.assign("defconfig", "no")
+        else:
+            logging.info("Config provided, ignoring \"--defconfig <yes|no>\" option")
+
+    def _process_malloc_perturb(self):
+        self.cartesian_parser.assign("malloc_perturb",
+                                     self.options.vt_malloc_perturb)
+
+    def _process_qemu_specific_options(self):
+        """
+        Calls for processing all options specific to the qemu test.
+
+        This method modifies the cartesian set by parsing additional lines.
+        """
+
+        self._process_qemu_bin()
+        self._process_qemu_accel()
+        self._process_monitor()
+        self._process_smp()
+        self._process_image_type()
+        self._process_nic_model()
+        self._process_disk_buses()
+        self._process_vhost()
+        self._process_malloc_perturb()
+        self._process_qemu_sandbox()
+
+    def _process_lvsb_specific_options(self):
+        """
+        Calls for processing all options specific to lvsb test
+        """
+        self.options.no_downloads = True
+
+    def _process_libvirt_specific_options(self):
+        """
+        Calls for processing all options specific to libvirt test.
+        """
+        if self.options.vt_connect_uri:
+            driver_found = False
+            for driver in SUPPORTED_LIBVIRT_DRIVERS:
+                if self.options.vt_connect_uri.count(driver):
+                    driver_found = True
+                    self.cartesian_parser.only_filter(driver)
+            if not driver_found:
+                self.view.notify(event='error', msg="Unsupported uri: %s." % self.options.vt_connect_uri)
+                sys.exit(1)
+        else:
+            self.cartesian_parser.only_filter("qemu")
+
+    def _process_guest_os(self):
+        if not self.options.vt_config:
+            if len(standalone_test.get_guest_name_list(self.options)) == 0:
+                self.view.notify(event='error', msg="Guest name %s is not on the known guest os list "
+                                                    "(see --vt-list-guests), aborting..." % self.options.vt_guest_os)
+                sys.exit(1)
+            self.cartesian_parser.only_filter(
+                self.options.vt_guest_os or defaults.DEFAULT_GUEST_OS)
+        else:
+            logging.info("Config provided, ignoring --vt-guest-os option")
+
+    def _process_list(self):
+        if self.options.vt_list_tests:
+            standalone_test.print_test_list(self.options,
+                                            self.cartesian_parser)
+            sys.exit(0)
+        if self.options.vt_list_guests:
+            standalone_test.print_guest_list(self.options)
+            sys.exit(0)
+
+    def _process_tests(self):
+        if not self.options.vt_config:
+            if self.options.vt_type:
+                if self.options.url and self.options.dropin:
+                    self.view.notify(event='error', msg="Option --vt-tests and --vt-run-dropin can't be set at "
+                                                        "the same time")
+                    sys.exit(1)
+                elif self.options.url:
+                    tests = self.options.url
+                    if self.options.vt_type == 'libvirt':
+                        if self.options.install_guest:
+                            tests.insert(0, LIBVIRT_INSTALL)
+                        if self.options.vt_remove_guest:
+                            tests.append(LIBVIRT_REMOVE)
+                    self.cartesian_parser.only_filter(", ".join(tests))
+                elif self.options.dropin:
+                    dropin_tests = os.listdir(os.path.join(data_dir.get_root_dir(), "dropin"))
+                    if len(dropin_tests) <= 1:
+                        self.view.notify(event='error', msg="No drop in tests detected, aborting. "
+                                                            "Make sure you have scripts on the 'dropin' "
+                                                            "directory")
+                        sys.exit(1)
+                    self.cartesian_parser.only_filter("dropin")
+                else:
+                    if self.options.vt_type == 'qemu':
+                        self.cartesian_parser.only_filter(QEMU_DEFAULT_SET)
+                        self.cartesian_parser.no_filter("with_reboot")
+                    elif self.options.vt_type == 'libvirt':
+                        self.cartesian_parser.only_filter(LIBVIRT_DEFAULT_SET)
+                    elif self.options.vt_type == 'lvsb':
+                        self.cartesian_parser.only_filter(LVSB_DEFAULT_SET)
+                    elif self.options.vt_type == 'openvswitch':
+                        self.cartesian_parser.only_filter(OVS_DEFAULT_SET)
+        else:
+            logging.info("Config provided, ignoring --vt-tests option")
+
+    def _process_restart_vm(self):
+        if not self.options.vt_config:
+            if not self.options.vt_keep_guest_running:
+                self.cartesian_parser.assign("kill_vm", "yes")
+
+    def _process_restore_image_between_tests(self):
+        if not self.options.vt_config:
+            if not self.options.vt_keep_image_between_tests:
+                self.cartesian_parser.assign("restore_image", "yes")
+
+    def _process_mem(self):
+        self.cartesian_parser.assign("mem", self.options.vt_mem)
+
+    def _process_tcpdump(self):
+        """
+        Verify whether we can run tcpdump. If we can't, turn it off.
+        """
+        try:
+            tcpdump_path = utils_misc.find_command('tcpdump')
+        except ValueError:
+            tcpdump_path = None
+
+        non_root = os.getuid() != 0
+
+        if tcpdump_path is None or non_root:
+            self.cartesian_parser.assign("run_tcpdump", "no")
+
+    def _process_no_filter(self):
+        if not self.options.vt_config:
+            if self.options.vt_no_filter:
+                no_filter = ", ".join(self.options.vt_no_filter.split(' '))
+                self.cartesian_parser.no_filter(no_filter)
+
+    def _process_only_type_specific(self):
+        if not self.options.vt_config:
+            if self.options.vt_type_specific:
+                self.cartesian_parser.only_filter("(subtest=type_specific)")
+
+    def _process_general_options(self):
+        """
+        Calls for processing all generic options.
+
+        This method modifies the cartesian set by parsing additional lines.
+        """
+        self._process_guest_os()
+        self._process_arch()
+        self._process_machine_type()
+        self._process_restart_vm()
+        self._process_restore_image_between_tests()
+        self._process_mem()
+        self._process_tcpdump()
+        self._process_no_filter()
+        self._process_qemu_img()
+        self._process_bridge_mode()
+        self._process_only_type_specific()
+
+    def _process_options(self):
+        """
+        Process the options given in the command line.
+        """
+
+        if (not self.options.vt_type) and (not self.options.vt_config):
+            self.view.notify(event='error',
+                             msg="No type (--vt-type) or config (--vt-config) options specified, aborting...")
+            sys.exit(0)
+
+        if self.options.vt_type:
+            if self.options.vt_type not in SUPPORTED_TEST_TYPES:
+                self.view.notify(event='error', msg="Invalid test type %s. Valid test types: %s. Aborting..." %
+                                                    (self.options.vt_type, " ".join(SUPPORTED_TEST_TYPES)))
+                sys.exit(1)
+
+        if self.options.vt_data_dir:
+            data_dir.set_backing_data_dir(self.options.vt_data_dir)
+
+        self.cartesian_parser = cartesian_config.Parser(debug=False)
+
+        if self.options.vt_config:
+            cfg = os.path.abspath(self.options.vt_config)
+
+        if not self.options.vt_config:
+            cfg = data_dir.get_backend_cfg_path(self.options.vt_type, 'tests.cfg')
+
+        self.cartesian_parser.parse_file(cfg)
+        if self.options.vt_type != 'lvsb':
+            self._process_general_options()
+
+        if self.options.vt_type == 'qemu':
+            self._process_qemu_specific_options()
+        elif self.options.vt_type == 'lvsb':
+            self._process_lvsb_specific_options()
+        elif self.options.vt_type == 'openvswitch':
+            self._process_qemu_specific_options()
+        elif self.options.vt_type == 'libvirt':
+            self._process_libvirt_specific_options()
+        # List and tests have to be the last things to be processed
+        self._process_list()
+        # Tests won't be processed here. The code of the function will
+        # be utilized elsewhere.
+        # self._process_tests()
+
+    def get_parser(self):
+        self._process_options()
+        return self.cartesian_parser
+
+
+class VirtTestCompatPlugin(plugin.Plugin):
+
+    """
+    Implements the avocado virt test options
+    """
+
+    name = 'virt_test_compat_runner'
+    enabled = True
+
+    def configure(self, parser):
+        """
+        Add the subparser for the run action.
+
+        :param parser: Main test runner parser.
+        """
+        self.parser = parser
+
+        try:
+            qemu_bin_path = standalone_test.find_default_qemu_paths()[0]
+        except ValueError:
+            qemu_bin_path = "Could not find one"
+
+        qemu_nw_msg = "QEMU network option (%s). " % ", ".join(SUPPORTED_NET_TYPES)
+        qemu_nw_msg += "Default: user"
+
+        vt_compat_group_setup = parser.runner.add_argument_group('Virt-Test compat layer - VM Setup options')
+        vt_compat_group_common = parser.runner.add_argument_group('Virt-Test compat layer - Common options')
+        vt_compat_group_qemu = parser.runner.add_argument_group('Virt-Test compat layer - QEMU options')
+        vt_compat_group_libvirt = parser.runner.add_argument_group('Virt-Test compat layer - Libvirt options')
+
+        current_run_setup = settings.get_value('virt_test.setup', 'run_setup', key_type=bool)
+
+        vt_compat_group_setup.add_argument("--vt-setup", action="store_true",
+                                           dest="vt_setup",
+                                           default=current_run_setup,
+                                           help="Run virt test setup actions (restore JeOS image from pristine). "
+                                                "Current: %s" % current_run_setup)
+
+        vt_compat_group_common.add_argument("--vt-config", action="store", dest="vt_config",
+                                            help=("Explicitly choose a cartesian config. "
+                                                  "When choosing this, some options will be "
+                                                  "ignored (see options below)"))
+        vt_compat_group_common.add_argument("--vt-type", action="store", dest="vt_type",
+                                            help="Choose test type (%s). Default: qemu" %
+                                                 ", ".join(SUPPORTED_TEST_TYPES),
+                                            default='qemu')
+        vt_compat_group_common.add_argument("--vt-guest-os", action="store", dest="vt_guest_os",
+                                            default=None,
+                                            help=("Select the guest OS to be used. "
+                                                  "If --vt-config is provided, this will be ignored. "
+                                                  "Default: %s" % defaults.DEFAULT_GUEST_OS))
+        vt_compat_group_common.add_argument("--vt-no-filter", action="store", dest="vt_no_filter", default="",
+                                            help=("List of space separated 'no' filters to be "
+                                                  "passed to the config parser. If --vt-config is "
+                                                  "provided, this will be ignored. Default: ''"))
+        qemu_bin_path_current = settings.get_value('virt_test.qemu', 'qemu_bin',
+                                                   default=qemu_bin_path)
+        vt_compat_group_qemu.add_argument("--vt-qemu-bin", action="store", dest="vt_qemu_bin",
+                                          default=None,
+                                          help=("Path to a custom qemu binary to be tested. "
+                                                "If --vt-config is provided and this flag is omitted, "
+                                                "no attempt to set the qemu binaries will be made. "
+                                                "Current: %s" % qemu_bin_path_current))
+        qemu_dst_bin_path_current = settings.get_value('virt_test.qemu', 'qemu_dst_bin',
+                                                       default=qemu_bin_path)
+        vt_compat_group_qemu.add_argument("--vt-qemu-dst-bin", action="store", dest="vt_dst_qemu_bin",
+                                          default=None,
+                                          help=("Path to a custom qemu binary to be tested for "
+                                                "the destination of a migration, overrides "
+                                                "--vt-qemu-bin. "
+                                                "If --vt-config is provided and this flag is omitted, "
+                                                "no attempt to set the qemu binaries will be made. "
+                                                "Current: %s" % qemu_dst_bin_path_current))
+        connect_uri_current = settings.get_value('virt_test.libvirt', 'connect_uri', default=None)
+        vt_compat_group_libvirt.add_argument("--vt-connect-uri", action="store", dest="vt_connect_uri",
+                                             default=connect_uri_current,
+                                             help="Choose test connect uri for libvirt (E.g: %s). Current: %s" %
+                                                  (", ".join(SUPPORTED_LIBVIRT_URIS), connect_uri_current))
+
+        self.configured = True
+
+    def activate(self, args):
+        """
+        Run test modules or simple tests.
+
+        :param args: Command line args received from the run subparser.
+        """
+        if getattr(args, 'vt_setup', False):
+            self.parser.application.set_defaults(vt_loader=VirtTestLoader, vt_result=VirtTestResult)
+        else:
+            self.parser.application.set_defaults(vt_loader=VirtTestLoader)

--- a/avocado/core/plugins/virt_test_list.py
+++ b/avocado/core/plugins/virt_test_list.py
@@ -1,0 +1,97 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2015
+# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+
+"""
+Avocado plugin that augments 'avocado list' with virt-test related options.
+"""
+
+import os
+import sys
+
+from avocado.settings import settings
+from avocado.core.plugins import plugin
+
+# virt-test supports using autotest from a git checkout, so we'll have to
+# support that as well. The code below will pick up the environment variable
+# $AUTOTEST_PATH and do the import magic needed to make the autotest library
+# available in the system.
+AUTOTEST_PATH = None
+
+if 'AUTOTEST_PATH' in os.environ:
+    AUTOTEST_PATH = os.path.expanduser(os.environ['AUTOTEST_PATH'])
+    client_dir = os.path.join(os.path.abspath(AUTOTEST_PATH), 'client')
+    setup_modules_path = os.path.join(client_dir, 'setup_modules.py')
+    import imp
+    setup_modules = imp.load_source('autotest_setup_modules',
+                                    setup_modules_path)
+    setup_modules.setup(base_path=client_dir,
+                        root_module_name="autotest.client")
+
+# The code below is used by this plugin to find the virt test directory,
+# so that it can load the virttest python lib, used by the plugin code.
+# If the user doesn't provide the proper configuration, the plugin will
+# fail to load.
+VIRT_TEST_DIR = None
+
+if 'VIRT_TEST_DIR' in os.environ:
+    VIRT_TEST_DIR = os.environ['VIRT_TEST_DIR']
+else:
+    VIRT_TEST_DIR = settings.get_value(section='virt_test', key='virt_test_dir', default=None)
+
+if VIRT_TEST_DIR is not None:
+    sys.path.append(os.path.expanduser(VIRT_TEST_DIR))
+
+from virttest.standalone_test import SUPPORTED_TEST_TYPES
+from virttest.defaults import DEFAULT_GUEST_OS
+
+
+class VirtTestListerPlugin(plugin.Plugin):
+
+    """
+    Implements the avocado virt test options
+    """
+
+    name = 'virt_test_compat_lister'
+    enabled = True
+
+    def configure(self, parser):
+        """
+        Add the subparser for the run action.
+
+        :param parser: Main test runner parser.
+        """
+        self.parser = parser
+        vt_compat_group_lister = parser.lister.add_argument_group(
+            'Virt-Test compat layer - Lister options')
+        vt_compat_group_lister.add_argument("--vt-type", action="store",
+                                            dest="vt_type",
+                                            help="Choose test type (%s). "
+                                                 "Default: qemu" %
+                                            ", ".join(SUPPORTED_TEST_TYPES),
+                                            default='qemu')
+        vt_compat_group_lister.add_argument("--vt-guest-os", action="store",
+                                            dest="vt_guest_os",
+                                            default=None,
+                                            help=("Select the guest OS to be "
+                                                  "used (different guests "
+                                                  "support different test "
+                                                  "lists). You can list "
+                                                  "available guests "
+                                                  "with --vt-list-guests. "
+                                                  "Default: %s" %
+                                                  DEFAULT_GUEST_OS))
+        vt_compat_group_lister.add_argument("--vt-list-guests",
+                                            action="store_true",
+                                            default=False,
+                                            help="List available guests")

--- a/avocado/multiplexer.py
+++ b/avocado/multiplexer.py
@@ -422,7 +422,14 @@ class Mux(object):
             i = None
             for i, variant in enumerate(self.variants):
                 test_factory = [template[0], template[1].copy()]
-                test_factory[1]['params'] = (variant, self._mux_entry)
+                mux_append = test_factory[1]['params'].get('avocado_mux_append', False)
+                # Test providers might want to keep their original params and only append
+                # avocado parameters to a special 'avocado_params' key. In order for that
+                # to happen, they need to set params['avocado_mux_append'] = True as well.
+                if not mux_append:
+                    test_factory[1]['params'] = (variant, self._mux_entry)
+                else:
+                    test_factory[1]['params']['avocado_params'] = (variant, self._mux_entry)
                 yield test_factory
             if i is None:   # No variants, use template
                 yield template

--- a/etc/avocado/conf.d/virt-test.conf
+++ b/etc/avocado/conf.d/virt-test.conf
@@ -1,0 +1,74 @@
+[virt_test]
+# Path to virt-test, required for the compatibility plugin to locate
+# virt-test libs. You should set this locally for avocado users.
+# For people working on the compatibility layer itself, you can export the
+# environment variable VIRT_TEST_DIR with that location instead of using
+# the config system.
+virt_test_path=
+[virt_test.setup]
+# Run the setup procedure (uncompress JeOS' pristine image).
+# The keys below help you customize the procedure
+run_setup=False
+# Don't restore the JeOS at the beginning of the test job (faster, but unsafe)
+# This has no effect unless you set run_setup=True or --vt-setup on the cmdline
+keep_image=False
+# Don't restore the JeOS between tests (faster, but unsafe)
+# This has no effect unless you set run_setup=True or --vt-setup on the cmdline
+keep_image_between_tests=False
+# Keep guest running between tests (faster, but unsafe)
+keep_guest_running=False
+[virt_test.common]
+# Data dir path. If none specified, the default virt-test data dir will be used
+data_dir =
+# Enable only type specific tests. Shared tests will not be tested
+type_specific_only = False
+# RAM dedicated to the main VM
+mem = 1024
+# Architecture under test
+arch =
+# Machine type under test
+machine_type =
+[virt_test.qemu]
+# Path to a custom qemu binary to be tested
+qemu_bin =
+# Path to a custom qemu binary to be tested for the
+# destination of a migration, overrides qemu_bin for
+# that particular purpose
+qemu_dst_bin =
+# Accelerator used to run qemu (kvm or tcg)
+accel = kvm
+# Nettype (bridge, user, none)
+nettype = user
+# Bridge name to be used if you select bridge as a nettype
+netdst = virbr0
+# Whether to enable vhost for qemu (on/off/force). Depends on nettype=bridge
+vhost = off
+# Monitor type (human or qmp)
+monitor = human
+# Number of virtual cpus to use (1 or 2)
+smp = 2
+# Image format type to use (any valid qemu format)
+image_type = qcow2
+# Guest network card model (any valid qemu card)
+nic_model = virtio_net
+# Guest disk bus for main image. One of
+# ('ide', 'scsi', 'virtio_blk', 'virtio_scsi', 'lsi_scsi', 'ahci', 'usb2', 'xenblk')
+disk_bus = virtio_blk
+# Enable qemu sandboxing (on/off)
+sandbox = on
+# Prevent qemu from loading sysconfdir/qemu.conf and sysconfdir/target-ARCH.conf at startup
+# (yes/no)
+defconfig = yes
+# Use MALLOC_PERTURB_ env variable set to 1 to help catch memory allocation problems on qemu
+# (yes/no)
+malloc_perturb = yes
+[virt_test.libvirt]
+# Test connect URI for libvirt (qemu:///system', 'lxc:///')
+connect_uri = qemu:///session
+# Install the guest using import method before the tests are run
+install_guest = False
+# Remove the guest from libvirt. This will not delete the guest's disk file
+remove_guest = False
+[virt_test.debug]
+# Don't clean up tmp files or VM processes at the end of a virt-test execution
+no_cleanup = False

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,8 @@ def get_avocado_libexec_dir():
 def get_data_files():
     data_files = [(get_dir(['etc', 'avocado']), ['etc/avocado/avocado.conf'])]
     data_files += [(get_dir(['etc', 'avocado', 'conf.d']),
-                    ['etc/avocado/conf.d/README', 'etc/avocado/conf.d/gdb.conf'])]
+                    ['etc/avocado/conf.d/README', 'etc/avocado/conf.d/gdb.conf',
+                     'etc/avocado/conf.d/virt-test.conf'])]
     data_files += [(get_dir(['etc', 'avocado', 'sysinfo']),
                     ['etc/avocado/sysinfo/commands', 'etc/avocado/sysinfo/files',
                      'etc/avocado/sysinfo/profilers'])]


### PR DESCRIPTION
This is a follow up to PR #626

This is the most fleshed out virt test compat layer to date. It introduces loading of tests from multiple test sources, which allows the mix and match of regular avocado tests and avocado virt-tests:

	$ scripts/avocado run --vt-setup type_specific.io-github-autotest-qemu.migrate.default.tcp examples/tests/passtest.py --open-browser
	SETUP      : PASS (15.66 s)
	JOB ID     : 0a613e41201ee2fa726a6ef8617f6578aa901e3a
	JOB LOG    : /home/lmr/avocado/job-results/job-2015-04-30T01.09-0a613e4/job.log
	JOB HTML   : /home/lmr/avocado/job-results/job-2015-04-30T01.09-0a613e4/html/results.html
	TESTS      : 2
	(1/2) type_specific.io-github-autotest-qemu.migrate.default.tcp: PASS (89.62 s)
	(2/2) examples/tests/passtest.py: PASS (0.00 s)
	PASS       : 2
	ERROR      : 0
	FAIL       : 0
	SKIP       : 0
	WARN       : 0
	INTERRUPT  : 0
	TIME       : 89.62 s

You can also do cool things like listing all virt test `migrate` subtests:

        $ scripts/avocado list migrate --verbose
        Type Test                                                                  
        VT   type_specific.io-github-autotest-qemu.migrate.default.x-rdma                   
        VT   type_specific.io-github-autotest-qemu.migrate.default.rdma                     
        VT   type_specific.io-github-autotest-qemu.migrate.default.tcp                      
        VT   type_specific.io-github-autotest-qemu.migrate.default.unix                     
        VT   type_specific.io-github-autotest-qemu.migrate.default.exec.default_exec        
        VT   type_specific.io-github-autotest-qemu.migrate.default.exec.gzip_exec           
        VT   type_specific.io-github-autotest-qemu.migrate.default.fd                       
        VT   type_specific.io-github-autotest-qemu.migrate.default.mig_cancel               
        VT   type_specific.io-github-autotest-qemu.migrate.default.mig_cancel_x_rdma        
        VT   type_specific.io-github-autotest-qemu.migrate.default.mig_cancel_rdma          
        VT   type_specific.io-github-autotest-qemu.migrate.with_set_speed.x-rdma            
        VT   type_specific.io-github-autotest-qemu.migrate.with_set_speed.rdma              
        VT   type_specific.io-github-autotest-qemu.migrate.with_set_speed.tcp               
        VT   type_specific.io-github-autotest-qemu.migrate.with_set_speed.unix              
        VT   type_specific.io-github-autotest-qemu.migrate.with_set_speed.exec.default_exec 
        VT   type_specific.io-github-autotest-qemu.migrate.with_set_speed.exec.gzip_exec    
        VT   type_specific.io-github-autotest-qemu.migrate.with_set_speed.fd                
        VT   type_specific.io-github-autotest-qemu.migrate.with_reboot.x-rdma               
        VT   type_specific.io-github-autotest-qemu.migrate.with_reboot.rdma                 
        VT   type_specific.io-github-autotest-qemu.migrate.with_reboot.tcp                  
        VT   type_specific.io-github-autotest-qemu.migrate.with_reboot.unix                 
        VT   type_specific.io-github-autotest-qemu.migrate.with_reboot.exec.default_exec    
        VT   type_specific.io-github-autotest-qemu.migrate.with_reboot.exec.gzip_exec       
        VT   type_specific.io-github-autotest-qemu.migrate.with_reboot.fd                   

        ACCESS_DENIED: 0
        BROKEN_SYMLINK: 0
        BUGGY: 0
        INSTRUMENTED: 0
        MISSING: 0
        NOT_A_TEST: 0
        SIMPLE: 0
        VT: 24

You can try out this work by following the steps:

1) Check out this branch
2) Set the environment variable 'VIRT_TEST_PATH' to a path containing a copy of virt test
3) The copy of virt-test has to be in my new branch `avocado-integration-v3` [1]
4) Bootstrap your testing in the virt test dir by running `./run -t qemu --bootstrap`
5) Run your tests with the command above
6) Now you can use `scripts/avocado list` to see virt-tests listed there.

That's it. Virt Test at this point has way too many knobs, and it's challenging to look to each of them and make sure they are working well. I hope that at least you guys enjoy trying this out.
 
Known issues:
* Some unittests fail because now we say on stdout that plugins have failed to load.

Changes from v9:
* Now the plugin honors the old virt test setting of `$AUTOTEST_PATH`, in case you want to use autotest from a git repo instead of from an RPM. In order to get consistency with that option, we changed `$VIRT_TEST_DIR` -> `$VIRT_TEST_PATH`.
* `avocado list --vt-guests`: Filter by guest list `i440fx`, which prevents issues with the `q35` variant not listing tests
* Set priority of test lister to be 0, to prevent issue when the virt test lister is loaded before the test lister: `virt_test_compat_lister': 'Parser' object has no attribute 'lister'`

Changes from v8:
* Finally the `avocado list` functionality is complete. You can list tests by `scripts/avocado list`, use `--vt-type` (different test types generate different test lists) and even list guests com `scripts/avocado --vt-list-guests` (different guests generate different test lists).

Changes from v7:
* Allow avocado list to show tests from all test loader plugins. This way, when enabled, virt-tests are displayed. There's one last thing lacking here, how to add new arguments to the lister plugin. I know how to do that for the runner plugin, I'll need @ruda's help to understand how to do it.

Changes from v6:
* Fixed bug running virt tests with multiplex file specified in the command line
* Added an avocado_params attribute to the virt test class of the plugin, allowing users to use 'frankenstein mode' - access avocado specific muliplexed params from inside virt-tests.
* Removed the aggressive error message when the virt plugin is not configured.

Changes from v5:
* Cleaned up the plugin code and adapted it to the refactorings I made on `virt-test`'s side.

Changes from v4:
 * Finally resolved the problem with loading multiple test sources, while keeping the base filesystem plugin working the way it usually does. With this, unittest hacks could be thrown away. Unfortunately, the overhead with the virt plugin enabled makes a couple of unittests to fail, but since the compat plugin is going to be on a separate project, that isn't a big problem per se. Now, I'm certain that there are ways to make the multiple test loading more efficient. Figuring it all out at once is not easy, though.

Changes from v3:
 * Removed the list and bootstrap plugins. virt-test can already do that functionality for the user.
 * Went to a excruciatingly detailed review of command line options. Many options that don't make sense in avocado were removed, text reviewed, and options grouped logically. Next step is to move unneeded options to the config file.

[1] See https://github.com/autotest/virt-test/pull/2176

Bonus: People can now generate HTML reports out of virt-test runs. I imagine there will be people happy with this.

![screenshot from 2015-04-30 01-22-14](https://cloud.githubusercontent.com/assets/296807/7406339/7699689e-eed7-11e4-9214-38a678c105ec.png)
