### PR TITLE
[V11] Load/List tests from multiple sources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,9 @@ clean:
 	test -L avocado/virt && rm -f avocado/virt || true
 	test -L avocado/core/plugins/virt.py && rm -f avocado/core/plugins/virt.py || true
 	test -L avocado/core/plugins/virt_bootstrap.py && rm -f avocado/core/plugins/virt_bootstrap.py || true
+	test -L avocado/core/plugins/virt_test.py && rm -f avocado/core/plugins/virt_test.py || true
+	test -L avocado/core/plugins/virt_test_list.py && rm -f avocado/core/plugins/virt_test_list.py || true
+	test -L etc/avocado/conf.d/virt-test.conf && rm -f etc/avocado/conf.d/virt-test.conf || true
 
 check:
 	selftests/checkall
@@ -73,6 +76,9 @@ link:
 	test -d ../avocado-virt/avocado/virt && ln -s ../../avocado-virt/avocado/virt avocado || true
 	test -f ../avocado-virt/avocado/core/plugins/virt.py && ln -s ../../../../avocado-virt/avocado/core/plugins/virt.py avocado/core/plugins/ || true
 	test -f ../avocado-virt/avocado/core/plugins/virt_bootstrap.py && ln -s ../../../../avocado-virt/avocado/core/plugins/virt_bootstrap.py avocado/core/plugins/ || true
+	test -f ../avocado-vt/etc/avocado/conf.d/virt-test.conf && ln -s ../../../../avocado-vt/etc/avocado/conf.d/virt-test.conf etc/avocado/conf.d/ || true
+	test -f ../avocado-vt/avocado/core/plugins/virt_test.py && ln -s ../../../../avocado-vt/avocado/core/plugins/virt_test.py avocado/core/plugins/ || true
+	test -f ../avocado-vt/avocado/core/plugins/virt_test_list.py && ln -s ../../../../avocado-vt/avocado/core/plugins/virt_test_list.py avocado/core/plugins/ || true
 
 man: man/avocado.1 man/avocado-rest-client.1
 

--- a/avocado/core/exceptions.py
+++ b/avocado/core/exceptions.py
@@ -86,6 +86,14 @@ class NotATestError(TestBaseException):
     status = "NOT_A_TEST"
 
 
+class TestNotFoundError(TestBaseException):
+
+    """
+    Indicates that the test was not found in the test directory.
+    """
+    status = "ERROR"
+
+
 class TestTimeoutError(TestBaseException):
 
     """

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -26,6 +26,7 @@ import sys
 from avocado import test
 from avocado import data_dir
 from avocado.utils import path
+from avocado.core import output
 
 try:
     import cStringIO as StringIO
@@ -35,8 +36,9 @@ except ImportError:
 
 class _DebugJob(object):
 
-    def __init__(self):
+    def __init__(self, args=None):
         self.logdir = '.'
+        self.args = args
 
 
 class BrokenSymlink(object):
@@ -63,12 +65,46 @@ class TestLoaderProxy(object):
                                       "TestResult" % plugin)
         self.loader_plugins.append(plugin)
 
-    def discover(self, urls):
+    def load_plugins(self, args):
+        for key in args.__dict__.keys():
+            if key.endswith('_loader'):
+                loader_class = getattr(args, key)
+                if issubclass(loader_class, TestLoader):
+                    loader_plugin = loader_class(args=args)
+                    self.add_loader_plugin(loader_plugin)
+        filesystem_loader = TestLoader()
+        self.add_loader_plugin(filesystem_loader)
+
+    def get_extra_listing(self, args):
+        for loader_plugin in self.loader_plugins:
+            loader_plugin.get_extra_listing(args)
+
+    def get_base_keywords(self):
+        base_path = []
+        for loader_plugin in self.loader_plugins:
+            base_path += loader_plugin.get_base_keywords()
+        return base_path
+
+    def get_type_label_mapping(self):
+        mapping = {}
+        for loader_plugin in self.loader_plugins:
+            mapping.update(loader_plugin.get_type_label_mapping())
+        return mapping
+
+    def get_decorator_mapping(self):
+        mapping = {}
+        for loader_plugin in self.loader_plugins:
+            mapping.update(loader_plugin.get_decorator_mapping())
+        return mapping
+
+    def discover(self, urls, list_non_tests=False):
         """
         Discover (possible) tests from test urls.
 
         :param urls: a list of tests urls.
         :type urls: list
+        :param list_non_tests: Whether to list non tests (for listing methods)
+        :type list_non_tests: bool
         :return: A list of test factories (tuples (TestClass, test_params))
         """
         test_factories = []
@@ -76,6 +112,9 @@ class TestLoaderProxy(object):
             for loader_plugin in self.loader_plugins:
                 try:
                     params_list_from_url = loader_plugin.discover_url(url)
+                    if list_non_tests:
+                        for params in params_list_from_url:
+                            params['omit_non_tests'] = False
                     if params_list_from_url:
                         if url not in self.url_plugin_mapping:
                             self.url_plugin_mapping[url] = loader_plugin
@@ -118,10 +157,53 @@ class TestLoader(object):
     Test loader class.
     """
 
-    def __init__(self, job=None):
+    def __init__(self, job=None, args=None):
+
         if job is None:
-            job = _DebugJob()
+            job = _DebugJob(args=args)
         self.job = job
+
+    def get_extra_listing(self, args):
+        pass
+
+    def get_base_keywords(self):
+        """
+        Get base keywords to locate tests (path to test dir in this case).
+
+        Used to list all tests available in virt-test.
+
+        :return: list with path strings.
+        """
+        return [data_dir.get_test_dir()]
+
+    def get_type_label_mapping(self):
+        """
+        Get label mapping for display in test listing.
+
+        :return: Dict {TestClass: 'TEST_LABEL_STRING'}
+        """
+        return {test.SimpleTest: 'SIMPLE',
+                test.BuggyTest: 'BUGGY',
+                test.NotATest: 'NOT_A_TEST',
+                test.MissingTest: 'MISSING',
+                BrokenSymlink: 'BROKEN_SYMLINK',
+                AccessDeniedPath: 'ACCESS_DENIED',
+                test.Test: 'INSTRUMENTED'}
+
+    def get_decorator_mapping(self):
+        """
+        Get label mapping for display in test listing.
+
+        :return: Dict {TestClass: decorator function}
+        """
+        term_support = output.TermSupport()
+        return {test.SimpleTest: term_support.healthy_str,
+                test.BuggyTest: term_support.fail_header_str,
+                test.NotATest: term_support.warn_header_str,
+                test.MissingTest: term_support.fail_header_str,
+                BrokenSymlink: term_support.fail_header_str,
+                AccessDeniedPath: term_support.fail_header_str,
+                test.Test: term_support.healthy_str}
 
     def _is_unittests_like(self, test_class, pattern='test'):
         for name, _ in inspect.getmembers(test_class, inspect.ismethod):

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -403,14 +403,14 @@ class View(object):
         if self.use_paginator:
             self.paginator.close()
 
-    def notify(self, event='message', msg=None):
+    def notify(self, event='message', msg=None, skip_newline=False):
         mapping = {'message': self._log_ui_header,
                    'minor': self._log_ui_minor,
                    'error': self._log_ui_error,
                    'warning': self._log_ui_warning,
                    'partial': self._log_ui_partial}
         if msg is not None:
-            mapping[event](msg)
+            mapping[event](msg=msg, skip_newline=skip_newline)
 
     def notify_progress(self, progress):
         self._log_ui_throbber_progress(progress)
@@ -491,37 +491,37 @@ class View(object):
         """
         self._log_ui_info(term_support.partial_str(msg), skip_newline)
 
-    def _log_ui_header(self, msg):
+    def _log_ui_header(self, msg, skip_newline=False):
         """
         Log a header message.
 
         :param msg: Message to write.
         """
-        self._log_ui_info(term_support.header_str(msg))
+        self._log_ui_info(term_support.header_str(msg), skip_newline)
 
-    def _log_ui_minor(self, msg):
+    def _log_ui_minor(self, msg, skip_newline=False):
         """
         Log a minor message.
 
         :param msg: Message to write.
         """
-        self._log_ui_info(msg)
+        self._log_ui_info(msg, skip_newline)
 
-    def _log_ui_error(self, msg):
+    def _log_ui_error(self, msg, skip_newline=False):
         """
         Log an error message (useful for critical errors).
 
         :param msg: Message to write.
         """
-        self._log_ui_error_base(term_support.fail_header_str(msg))
+        self._log_ui_error_base(term_support.fail_header_str(msg), skip_newline)
 
-    def _log_ui_warning(self, msg):
+    def _log_ui_warning(self, msg, skip_newline=False):
         """
         Log a warning message (useful for warning messages).
 
         :param msg: Message to write.
         """
-        self._log_ui_info(term_support.warn_header_str(msg))
+        self._log_ui_info(term_support.warn_header_str(msg), skip_newline)
 
     def _log_ui_status_pass(self, t_elapsed):
         """

--- a/avocado/core/plugins/test_list.py
+++ b/avocado/core/plugins/test_list.py
@@ -23,59 +23,32 @@ from avocado.utils import astring
 from avocado.core.plugins import plugin
 
 
-class TestList(plugin.Plugin):
+class TestLister(object):
 
     """
-    Implements the avocado 'list' subcommand
+    Lists available test modules
     """
 
-    name = 'test_lister'
-    enabled = True
-    view = None
-    test_loader = loader.TestLoader()
-    term_support = output.TermSupport()
+    def __init__(self, args):
+        use_paginator = args.paginator == 'on'
+        self.view = output.View(app_args=args, use_paginator=use_paginator)
+        self.term_support = output.TermSupport()
+        self.test_loader = loader.TestLoader()
+        self.args = args
 
-    def configure(self, parser):
-        """
-        Add the subparser for the list action.
-
-        :param parser: Main test runner parser.
-        """
-        self.parser = parser.subcommands.add_parser(
-            'list',
-            help='List available test modules')
-        self.parser.add_argument('paths', type=str, default=[], nargs='*',
-                                 help="List of paths. If no paths provided, "
-                                      "avocado will list tests on the "
-                                      "configured test directory, "
-                                      "see 'avocado config --datadir'")
-        self.parser.add_argument('-V', '--verbose',
-                                 action='store_true', default=False,
-                                 help='Whether to show extra information '
-                                      '(headers and summary). Current: %('
-                                      'default)s')
-        self.parser.add_argument('--paginator',
-                                 choices=('on', 'off'), default='on',
-                                 help='Turn the paginator on/off. '
-                                      'Current: %(default)s')
-        super(TestList, self).configure(self.parser)
-
-    def _run(self, args):
-        """
-        List available test modules.
-
-        :param args: Command line args received from the list subparser.
-        """
-        self.view = output.View(app_args=args,
-                                use_paginator=args.paginator == 'on')
-
+    def _set_paths(self):
         paths = [data_dir.get_test_dir()]
-        if args.paths:
-            paths = args.paths
+        if self.args.paths:
+            paths = self.args.paths
+        return paths
+
+    def _get_test_suite(self, paths):
         params_list = self.test_loader.discover_urls(paths)
         for params in params_list:
             params['omit_non_tests'] = False
-        test_suite = self.test_loader.discover(params_list)
+        return self.test_loader.discover(params_list)
+
+    def _validate_test_suite(self, test_suite):
         error_msg_parts = self.test_loader.validate_ui(test_suite,
                                                        ignore_not_test=True,
                                                        ignore_access_denied=True,
@@ -86,14 +59,29 @@ class TestList(plugin.Plugin):
             self.view.cleanup()
             sys.exit(exit_codes.AVOCADO_FAIL)
 
+    def _get_test_matrix(self, test_suite):
         test_matrix = []
-        stats = {'simple': 0,
-                 'instrumented': 0,
-                 'buggy': 0,
-                 'missing': 0,
-                 'not_a_test': 0,
-                 'broken_symlink': 0,
-                 'access_denied': 0}
+
+        type_label_mapping = {test.SimpleTest: 'SIMPLE',
+                              test.BuggyTest: 'BUGGY',
+                              test.NotATest: 'NOT_A_TEST',
+                              test.MissingTest: 'MISSING',
+                              loader.BrokenSymlink: 'BROKEN_SYMLINK',
+                              loader.AccessDeniedPath: 'ACCESS_DENIED',
+                              test.Test: 'INSTRUMENTED'}
+
+        decorator_mapping = {test.SimpleTest: self.term_support.healthy_str,
+                             test.BuggyTest: self.term_support.fail_header_str,
+                             test.NotATest: self.term_support.warn_header_str,
+                             test.MissingTest: self.term_support.fail_header_str,
+                             loader.BrokenSymlink: self.term_support.fail_header_str,
+                             loader.AccessDeniedPath: self.term_support.fail_header_str,
+                             test.Test: self.term_support.healthy_str}
+
+        stats = {}
+        for value in type_label_mapping.values():
+            stats[value.lower()] = 0
+
         for cls, params in test_suite:
             id_label = ''
             type_label = cls.__name__
@@ -106,68 +94,51 @@ class TestList(plugin.Plugin):
                 elif 'path' in params:
                     id_label = params['path']
 
-            if cls == test.SimpleTest:
-                stats['simple'] += 1
-                type_label = self.term_support.healthy_str('SIMPLE')
-            elif cls == test.BuggyTest:
-                stats['buggy'] += 1
-                type_label = self.term_support.fail_header_str('BUGGY')
-            elif cls == test.NotATest:
-                if not args.verbose:
-                    continue
-                stats['not_a_test'] += 1
-                type_label = self.term_support.warn_header_str('NOT_A_TEST')
-            elif cls == test.MissingTest:
-                stats['missing'] += 1
-                type_label = self.term_support.fail_header_str('MISSING')
-            elif cls == loader.BrokenSymlink:
-                stats['broken_symlink'] += 1
-                type_label = self.term_support.fail_header_str('BROKEN_SYMLINK')
-            elif cls == loader.AccessDeniedPath:
-                stats['access_denied'] += 1
-                type_label = self.term_support.fail_header_str('ACCESS_DENIED')
-            else:
+            try:
+                type_label = type_label_mapping[cls]
+                decorator = decorator_mapping[cls]
+                stats[type_label.lower()] += 1
+                type_label = decorator(type_label)
+            except KeyError:
                 if issubclass(cls, test.Test):
-                    stats['instrumented'] += 1
+                    cls = test.Test
+                    type_label = type_label_mapping[cls]
+                    decorator = decorator_mapping[cls]
+                    stats[type_label.lower()] += 1
+                    type_label = decorator(type_label)
                     id_label = params['name']
-                    type_label = self.term_support.healthy_str('INSTRUMENTED')
 
             test_matrix.append((type_label, id_label))
 
+        return test_matrix, stats
+
+    def _display(self, test_matrix, stats):
         header = None
-        if args.verbose:
-            header = (self.term_support.header_str('Type'),
-                      self.term_support.header_str('file'))
-        for line in astring.tabular_output(test_matrix,
-                                           header=header).splitlines():
+        if self.args.verbose:
+            header = (self.term_support.header_str('Type'), self.term_support.header_str('ID'))
+
+        for line in astring.tabular_output(test_matrix, header=header).splitlines():
             self.view.notify(event='minor', msg="%s" % line)
 
-        if args.verbose:
+        if self.args.verbose:
             self.view.notify(event='minor', msg='')
+            for key in sorted(stats):
+                self.view.notify(event='message', msg=("%s: %s" % (key.upper(), stats[key])))
 
-            self.view.notify(event='message', msg=("SIMPLE: %s" %
-                                                   stats['simple']))
-            self.view.notify(event='message', msg=("INSTRUMENTED: %s" %
-                                                   stats['instrumented']))
-            self.view.notify(event='message', msg=("BUGGY: %s" %
-                                                   stats['buggy']))
-            self.view.notify(event='message', msg=("MISSING: %s" %
-                                                   stats['missing']))
-            self.view.notify(event='message', msg=("NOT_A_TEST: %s" %
-                                                   stats['not_a_test']))
-            self.view.notify(event='message', msg=("ACCESS_DENIED: %s" %
-                                                   stats['access_denied']))
-            self.view.notify(event='message', msg=("BROKEN_SYMLINK: %s" %
-                                                   stats['broken_symlink']))
+    def _list(self):
+        paths = self._set_paths()
+        test_suite = self._get_test_suite(paths)
+        self._validate_test_suite(test_suite)
+        test_matrix, stats = self._get_test_matrix(test_suite)
+        self._display(test_matrix, stats)
 
-    def run(self, args):
+    def list(self):
         rc = 0
         try:
-            self._run(args)
+            self._list()
         except KeyboardInterrupt:
             rc = exit_codes.AVOCADO_FAIL
-            msg = ('Command interrupted by '
-                   'user...')
+            msg = 'Command interrupted by user...'
             if self.view is not None:
                 self.view.notify(event='error', msg=msg)
             else:
@@ -175,4 +146,40 @@ class TestList(plugin.Plugin):
         finally:
             if self.view:
                 self.view.cleanup()
-        sys.exit(rc)
+        return rc
+
+
+class TestList(plugin.Plugin):
+
+    """
+    Implements the avocado 'list' subcommand
+    """
+
+    name = 'test_lister'
+    enabled = True
+
+    def configure(self, parser):
+        """
+        Add the subparser for the list action.
+
+        :param parser: Main test runner parser.
+        """
+        self.parser = parser.subcommands.add_parser('list', help='List available test modules')
+        self.parser.add_argument('paths', type=str, default=[], nargs='*',
+                                 help="List of paths. If no paths provided, "
+                                      "avocado will list tests on the "
+                                      "configured test directory, "
+                                      "see 'avocado config --datadir'")
+        self.parser.add_argument('-V', '--verbose',
+                                 action='store_true', default=False,
+                                 help='Whether to show extra information '
+                                      '(headers and summary). Current: %(default)s')
+        self.parser.add_argument('--paginator',
+                                 choices=('on', 'off'), default='on',
+                                 help='Turn the paginator on/off. '
+                                      'Current: %(default)s')
+        super(TestList, self).configure(self.parser)
+
+    def run(self, args):
+        test_lister = TestLister(args)
+        return test_lister.list()

--- a/avocado/core/plugins/test_list.py
+++ b/avocado/core/plugins/test_list.py
@@ -15,7 +15,6 @@
 import sys
 
 from avocado import test
-from avocado import data_dir
 from avocado.core import loader
 from avocado.core import output
 from avocado.core import exit_codes
@@ -33,20 +32,21 @@ class TestLister(object):
         use_paginator = args.paginator == 'on'
         self.view = output.View(app_args=args, use_paginator=use_paginator)
         self.term_support = output.TermSupport()
-        self.test_loader = loader.TestLoader()
+        self.test_loader = loader.TestLoaderProxy()
+        self.test_loader.load_plugins(args)
         self.args = args
 
-    def _set_paths(self):
-        paths = [data_dir.get_test_dir()]
-        if self.args.paths:
-            paths = self.args.paths
-        return paths
+    def _extra_listing(self):
+        self.test_loader.get_extra_listing(self.args)
+
+    def _get_keywords(self):
+        keywords = self.test_loader.get_base_keywords()
+        if self.args.keywords:
+            keywords = self.args.keywords
+        return keywords
 
     def _get_test_suite(self, paths):
-        params_list = self.test_loader.discover_urls(paths)
-        for params in params_list:
-            params['omit_non_tests'] = False
-        return self.test_loader.discover(params_list)
+        return self.test_loader.discover(paths, list_non_tests=self.args.verbose)
 
     def _validate_test_suite(self, test_suite):
         error_msg_parts = self.test_loader.validate_ui(test_suite,
@@ -62,21 +62,8 @@ class TestLister(object):
     def _get_test_matrix(self, test_suite):
         test_matrix = []
 
-        type_label_mapping = {test.SimpleTest: 'SIMPLE',
-                              test.BuggyTest: 'BUGGY',
-                              test.NotATest: 'NOT_A_TEST',
-                              test.MissingTest: 'MISSING',
-                              loader.BrokenSymlink: 'BROKEN_SYMLINK',
-                              loader.AccessDeniedPath: 'ACCESS_DENIED',
-                              test.Test: 'INSTRUMENTED'}
-
-        decorator_mapping = {test.SimpleTest: self.term_support.healthy_str,
-                             test.BuggyTest: self.term_support.fail_header_str,
-                             test.NotATest: self.term_support.warn_header_str,
-                             test.MissingTest: self.term_support.fail_header_str,
-                             loader.BrokenSymlink: self.term_support.fail_header_str,
-                             loader.AccessDeniedPath: self.term_support.fail_header_str,
-                             test.Test: self.term_support.healthy_str}
+        type_label_mapping = self.test_loader.get_type_label_mapping()
+        decorator_mapping = self.test_loader.get_decorator_mapping()
 
         stats = {}
         for value in type_label_mapping.values():
@@ -115,7 +102,7 @@ class TestLister(object):
     def _display(self, test_matrix, stats):
         header = None
         if self.args.verbose:
-            header = (self.term_support.header_str('Type'), self.term_support.header_str('ID'))
+            header = (self.term_support.header_str('Type'), self.term_support.header_str('Test'))
 
         for line in astring.tabular_output(test_matrix, header=header).splitlines():
             self.view.notify(event='minor', msg="%s" % line)
@@ -126,8 +113,9 @@ class TestLister(object):
                 self.view.notify(event='message', msg=("%s: %s" % (key.upper(), stats[key])))
 
     def _list(self):
-        paths = self._set_paths()
-        test_suite = self._get_test_suite(paths)
+        self._extra_listing()
+        keywords = self._get_keywords()
+        test_suite = self._get_test_suite(keywords)
         self._validate_test_suite(test_suite)
         test_matrix, stats = self._get_test_matrix(test_suite)
         self._display(test_matrix, stats)
@@ -157,6 +145,7 @@ class TestList(plugin.Plugin):
 
     name = 'test_lister'
     enabled = True
+    priority = 0
 
     def configure(self, parser):
         """
@@ -165,11 +154,16 @@ class TestList(plugin.Plugin):
         :param parser: Main test runner parser.
         """
         self.parser = parser.subcommands.add_parser('list', help='List available test modules')
-        self.parser.add_argument('paths', type=str, default=[], nargs='*',
-                                 help="List of paths. If no paths provided, "
-                                      "avocado will list tests on the "
-                                      "configured test directory, "
-                                      "see 'avocado config --datadir'")
+        self.parser.add_argument('keywords', type=str, default=[], nargs='*',
+                                 help="List of paths, aliases or other "
+                                      "keywords used to locate tests. "
+                                      "If empty, avocado will list tests on "
+                                      "the configured test source, "
+                                      "(see 'avocado config --datadir') Also, "
+                                      "if there are other test loader plugins "
+                                      "active, tests from those plugins might "
+                                      "also show up (behavior may vary among "
+                                      "plugins)")
         self.parser.add_argument('-V', '--verbose',
                                  action='store_true', default=False,
                                  help='Whether to show extra information '
@@ -179,6 +173,7 @@ class TestList(plugin.Plugin):
                                  help='Turn the paginator on/off. '
                                       'Current: %(default)s')
         super(TestList, self).configure(self.parser)
+        parser.lister = self.parser
 
     def run(self, args):
         test_lister = TestLister(args)

--- a/avocado/multiplexer.py
+++ b/avocado/multiplexer.py
@@ -422,7 +422,14 @@ class Mux(object):
             i = None
             for i, variant in enumerate(self.variants):
                 test_factory = [template[0], template[1].copy()]
-                test_factory[1]['params'] = (variant, self._mux_entry)
+                mux_append = test_factory[1]['params'].get('avocado_mux_append', False)
+                # Test providers might want to keep their original params and only append
+                # avocado parameters to a special 'avocado_params' key. In order for that
+                # to happen, they need to set params['avocado_mux_append'] = True as well.
+                if not mux_append:
+                    test_factory[1]['params'] = (variant, self._mux_entry)
+                else:
+                    test_factory[1]['params']['avocado_params'] = (variant, self._mux_entry)
                 yield test_factory
             if i is None:   # No variants, use template
                 yield template


### PR DESCRIPTION
This is a follow up to PR #630 

The PR has been renamed because it no longer contains the actual virt test compatibility plugins. However, you definitely want to test this together with the avocado-vt initial pull request (see below).

This is the most fleshed out virt test compat layer to date. It introduces loading of tests from multiple test sources, which allows the mix and match of regular avocado tests and avocado virt-tests:

	$ scripts/avocado run --vt-setup type_specific.io-github-autotest-qemu.migrate.default.tcp examples/tests/passtest.py --open-browser
	SETUP      : PASS (15.66 s)
	JOB ID     : 0a613e41201ee2fa726a6ef8617f6578aa901e3a
	JOB LOG    : /home/lmr/avocado/job-results/job-2015-04-30T01.09-0a613e4/job.log
	JOB HTML   : /home/lmr/avocado/job-results/job-2015-04-30T01.09-0a613e4/html/results.html
	TESTS      : 2
	(1/2) type_specific.io-github-autotest-qemu.migrate.default.tcp: PASS (89.62 s)
	(2/2) examples/tests/passtest.py: PASS (0.00 s)
	PASS       : 2
	ERROR      : 0
	FAIL       : 0
	SKIP       : 0
	WARN       : 0
	INTERRUPT  : 0
	TIME       : 89.62 s

You can also do cool things like listing all virt test `migrate` subtests:

        $ scripts/avocado list migrate --verbose
        Type Test                                                                  
        VT   type_specific.io-github-autotest-qemu.migrate.default.x-rdma                   
        VT   type_specific.io-github-autotest-qemu.migrate.default.rdma                     
        VT   type_specific.io-github-autotest-qemu.migrate.default.tcp                      
        VT   type_specific.io-github-autotest-qemu.migrate.default.unix                     
        VT   type_specific.io-github-autotest-qemu.migrate.default.exec.default_exec        
        VT   type_specific.io-github-autotest-qemu.migrate.default.exec.gzip_exec           
        VT   type_specific.io-github-autotest-qemu.migrate.default.fd                       
        VT   type_specific.io-github-autotest-qemu.migrate.default.mig_cancel               
        VT   type_specific.io-github-autotest-qemu.migrate.default.mig_cancel_x_rdma        
        VT   type_specific.io-github-autotest-qemu.migrate.default.mig_cancel_rdma          
        VT   type_specific.io-github-autotest-qemu.migrate.with_set_speed.x-rdma            
        VT   type_specific.io-github-autotest-qemu.migrate.with_set_speed.rdma              
        VT   type_specific.io-github-autotest-qemu.migrate.with_set_speed.tcp               
        VT   type_specific.io-github-autotest-qemu.migrate.with_set_speed.unix              
        VT   type_specific.io-github-autotest-qemu.migrate.with_set_speed.exec.default_exec 
        VT   type_specific.io-github-autotest-qemu.migrate.with_set_speed.exec.gzip_exec    
        VT   type_specific.io-github-autotest-qemu.migrate.with_set_speed.fd                
        VT   type_specific.io-github-autotest-qemu.migrate.with_reboot.x-rdma               
        VT   type_specific.io-github-autotest-qemu.migrate.with_reboot.rdma                 
        VT   type_specific.io-github-autotest-qemu.migrate.with_reboot.tcp                  
        VT   type_specific.io-github-autotest-qemu.migrate.with_reboot.unix                 
        VT   type_specific.io-github-autotest-qemu.migrate.with_reboot.exec.default_exec    
        VT   type_specific.io-github-autotest-qemu.migrate.with_reboot.exec.gzip_exec       
        VT   type_specific.io-github-autotest-qemu.migrate.with_reboot.fd                   

        ACCESS_DENIED: 0
        BROKEN_SYMLINK: 0
        BUGGY: 0
        INSTRUMENTED: 0
        MISSING: 0
        NOT_A_TEST: 0
        SIMPLE: 0
        VT: 24

You can try out this work by following the steps:

1) Check out this branch
2) Set the environment variable 'VIRT_TEST_PATH' to a path containing a copy of virt test
3) The copy of virt-test has to be in my new branch `avocado-integration-v4` [1]
4) Check out the avocado-vt repo, then merge PR 1 -> https://github.com/avocado-framework/avocado-vt/pull/3. The code checked out has to be in the same base dir as your copy of avocado
5) Type `make link` in the avocado dir, so that the plugins can be properly linked.
6) Bootstrap your testing in the virt test dir by running `./run -t qemu --bootstrap`
7) Run your tests with the command above
8) Now you can use `scripts/avocado list` to see virt-tests listed there.

That's it. Virt Test at this point has way too many knobs, and it's challenging to look to each of them and make sure they are working well. I hope that at least you guys enjoy trying this out.
 
Changes from v10:
* First version where the actual plugins are in a separate repo. Please refer to https://github.com/avocado-framework/avocado-vt/pull/1 to review that code. This PR only has the avocado relevant parts. Now this is aiming for inclusion. Let's do this, guys.

Changes from v9:
* Now the plugin honors the old virt test setting of `$AUTOTEST_PATH`, in case you want to use autotest from a git repo instead of from an RPM. In order to get consistency with that option, we changed `$VIRT_TEST_DIR` -> `$VIRT_TEST_PATH`.
* `avocado list --vt-guests`: Filter by guest list `i440fx`, which prevents issues with the `q35` variant not listing tests
* Set priority of test lister to be 0, to prevent issue when the virt test lister is loaded before the test lister: `virt_test_compat_lister': 'Parser' object has no attribute 'lister'`

Changes from v8:
* Finally the `avocado list` functionality is complete. You can list tests by `scripts/avocado list`, use `--vt-type` (different test types generate different test lists) and even list guests com `scripts/avocado --vt-list-guests` (different guests generate different test lists).

Changes from v7:
* Allow avocado list to show tests from all test loader plugins. This way, when enabled, virt-tests are displayed. There's one last thing lacking here, how to add new arguments to the lister plugin. I know how to do that for the runner plugin, I'll need @ruda's help to understand how to do it.

Changes from v6:
* Fixed bug running virt tests with multiplex file specified in the command line
* Added an avocado_params attribute to the virt test class of the plugin, allowing users to use 'frankenstein mode' - access avocado specific muliplexed params from inside virt-tests.
* Removed the aggressive error message when the virt plugin is not configured.

Changes from v5:
* Cleaned up the plugin code and adapted it to the refactorings I made on `virt-test`'s side.

Changes from v4:
 * Finally resolved the problem with loading multiple test sources, while keeping the base filesystem plugin working the way it usually does. With this, unittest hacks could be thrown away. Unfortunately, the overhead with the virt plugin enabled makes a couple of unittests to fail, but since the compat plugin is going to be on a separate project, that isn't a big problem per se. Now, I'm certain that there are ways to make the multiple test loading more efficient. Figuring it all out at once is not easy, though.

Changes from v3:
 * Removed the list and bootstrap plugins. virt-test can already do that functionality for the user.
 * Went to a excruciatingly detailed review of command line options. Many options that don't make sense in avocado were removed, text reviewed, and options grouped logically. Next step is to move unneeded options to the config file.

[1] See https://github.com/autotest/virt-test/pull/2208
