### PR TITLE
avocado config: Add --paginator to command

### DIFF
--- a/avocado/core/plugins/config.py
+++ b/avocado/core/plugins/config.py
@@ -33,41 +33,48 @@ class ConfigOptions(plugin.Plugin):
             help='Shows avocado config keys')
         self.parser.add_argument('--datadir', action='store_true', default=False,
                                  help='Shows the data directories currently being used by avocado')
+        self.parser.add_argument('--paginator',
+                                 choices=('on', 'off'), default='on',
+                                 help='Turn the paginator on/off. '
+                                      'Current: %(default)s')
         super(ConfigOptions, self).configure(self.parser)
 
     def run(self, args):
-        view = output.View()
-        view.notify(event="message", msg='Config files read (in order):')
-        for cfg_path in settings.config_paths:
-            view.notify(event="message", msg='    %s' % cfg_path)
-        if settings.config_paths_failed:
+        view = output.View(use_paginator=(args.paginator == 'on'))
+        try:
+            view.notify(event="message", msg='Config files read (in order):')
+            for cfg_path in settings.config_paths:
+                view.notify(event="message", msg='    %s' % cfg_path)
+            if settings.config_paths_failed:
+                view.notify(event="minor", msg='')
+                view.notify(event="error", msg='Config files that failed to read:')
+                for cfg_path in settings.config_paths_failed:
+                    view.notify(event="error", msg='    %s' % cfg_path)
             view.notify(event="minor", msg='')
-            view.notify(event="error", msg='Config files that failed to read:')
-            for cfg_path in settings.config_paths_failed:
-                view.notify(event="error", msg='    %s' % cfg_path)
-        view.notify(event="minor", msg='')
-        if not args.datadir:
-            blength = 0
-            for section in settings.config.sections():
-                for value in settings.config.items(section):
-                    clength = len('%s.%s' % (section, value[0]))
-                    if clength > blength:
-                        blength = clength
+            if not args.datadir:
+                blength = 0
+                for section in settings.config.sections():
+                    for value in settings.config.items(section):
+                        clength = len('%s.%s' % (section, value[0]))
+                        if clength > blength:
+                            blength = clength
 
-            format_str = "    %-" + str(blength) + "s %s"
+                format_str = "    %-" + str(blength) + "s %s"
 
-            view.notify(event="minor", msg=format_str % ('Section.Key', 'Value'))
-            for section in settings.config.sections():
-                for value in settings.config.items(section):
-                    config_key = ".".join((section, value[0]))
-                    view.notify(event="minor", msg=format_str % (config_key, value[1]))
-        else:
-            view.notify(event="minor", msg="Avocado replaces config dirs that can't be accessed")
-            view.notify(event="minor", msg="with sensible defaults. Please edit your local config")
-            view.notify(event="minor", msg="file to customize values")
-            view.notify(event="message", msg='')
-            view.notify(event="message", msg='Avocado Data Directories:')
-            view.notify(event="minor", msg='    base     ' + data_dir.get_base_dir())
-            view.notify(event="minor", msg='    tests    ' + data_dir.get_test_dir())
-            view.notify(event="minor", msg='    data     ' + data_dir.get_data_dir())
-            view.notify(event="minor", msg='    logs     ' + data_dir.get_logs_dir())
+                view.notify(event="minor", msg=format_str % ('Section.Key', 'Value'))
+                for section in settings.config.sections():
+                    for value in settings.config.items(section):
+                        config_key = ".".join((section, value[0]))
+                        view.notify(event="minor", msg=format_str % (config_key, value[1]))
+            else:
+                view.notify(event="minor", msg="Avocado replaces config dirs that can't be accessed")
+                view.notify(event="minor", msg="with sensible defaults. Please edit your local config")
+                view.notify(event="minor", msg="file to customize values")
+                view.notify(event="message", msg='')
+                view.notify(event="message", msg='Avocado Data Directories:')
+                view.notify(event="minor", msg='    base     ' + data_dir.get_base_dir())
+                view.notify(event="minor", msg='    tests    ' + data_dir.get_test_dir())
+                view.notify(event="minor", msg='    data     ' + data_dir.get_data_dir())
+                view.notify(event="minor", msg='    logs     ' + data_dir.get_logs_dir())
+        finally:
+            view.cleanup()

--- a/selftests/all/functional/avocado/basic_tests.py
+++ b/selftests/all/functional/avocado/basic_tests.py
@@ -394,7 +394,7 @@ class PluginsTest(unittest.TestCase):
 
     def test_config_plugin(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado config'
+        cmd_line = './scripts/avocado config --paginator off'
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout
         expected_rc = 0
@@ -405,7 +405,7 @@ class PluginsTest(unittest.TestCase):
 
     def test_config_plugin_datadir(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado config --datadir'
+        cmd_line = './scripts/avocado config --datadir --paginator off'
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout
         expected_rc = 0


### PR DESCRIPTION
Add the --paginator (on|off) option to 'avocado config'.
This option has been missing from that command, which
is inconsistent with the other listing options we have.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>