### PR TITLE
Makefile: require a clean source tree before running local checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ clean:
 	test -L avocado/core/plugins/virt_test_list.py && rm -f avocado/core/plugins/virt_test_list.py || true
 	test -L etc/avocado/conf.d/virt-test.conf && rm -f etc/avocado/conf.d/virt-test.conf || true
 
-check:
+check: clean
 	selftests/checkall
 
 check_cyclical:


### PR DESCRIPTION
Sometimes the local checks, including documentation builds and other
unit and functional tests will fail because of either stale state
or because of external plugins.

Let's require a clean source tree before running local checks to
avoid those false positives.

Signed-off-by: Cleber Rosa <crosa@redhat.com>