### PR TITLE
Documentation Review (v2)

### DIFF
--- a/avocado/core/plugins/gdb.py
+++ b/avocado/core/plugins/gdb.py
@@ -43,7 +43,7 @@ class GDB(plugin.Plugin):
                              default=[], metavar='BINARY_PATH:COMMANDS_PATH',
                              help=('After loading a binary in binary in GDB, '
                                    'but before actually running it, execute '
-                                   'the given GDB commands in the given file.'
+                                   'the given GDB commands in the given file. '
                                    'BINARY_PATH is optional and if omitted '
                                    'will apply to all binaries'))
 

--- a/docs/source/Configuration.rst
+++ b/docs/source/Configuration.rst
@@ -6,10 +6,10 @@ Avocado utilities have a certain default behavior based on educated, reasonable 
 users like to use their systems. Of course, different people will have different needs and/or dislike our defaults,
 and that's why a configuration system is in place to help with those cases
 
-The avocado config file format is based on the (informal)
+The Avocado config file format is based on the (informal)
 `INI file 'specification' <http://en.wikipedia.org/wiki/INI_file>`__, that is implemented by
-python's  :mod:`ConfigParser`. The format is simple and straightforward, composed by `sections`,
-that contain a number of `keys` and `values`. Take for example a basic avocado config file::
+Python's  :mod:`ConfigParser`. The format is simple and straightforward, composed by `sections`,
+that contain a number of `keys` and `values`. Take for example a basic Avocado config file::
 
     [datadir.paths]
     base_dir = ~/avocado
@@ -18,7 +18,7 @@ that contain a number of `keys` and `values`. Take for example a basic avocado c
     logs_dir = ~/avocado/job-results
 
 The ``datadir.paths`` section contains a number of keys, all of them related to directories used by
-the test runner. The ``base_dir`` is the base directory to other important avocado directories, such
+the test runner. The ``base_dir`` is the base directory to other important Avocado directories, such
 as log, data and test directories. You can also choose to set those other important directories by
 means of the variables ``test_dir``, ``data_dir`` and ``logs_dir``. You can do this by simply editing
 the config files available.
@@ -27,22 +27,22 @@ the config files available.
 Config file parsing order
 =========================
 
-Avocado starts by parsing what it calls system wide config file, that is shipped to all avocado users on a system
+Avocado starts by parsing what it calls system wide config file, that is shipped to all Avocado users on a system
 wide directory, ``/etc/avocado/avocado.conf``. Then it'll verify if there's a local user config file, that is located
 usually in ``~/.config/avocado/avocado.conf``. The order of the parsing matters, so the system wide file is parsed,
 then the user config file is parsed last, so that the user can override values at will. There is another directory
 that will be scanned by extra config files, ``/etc/avocado/conf.d``. This directory may contain plugin config files,
 and extra additional config files that the system administrator/avocado developers might judge necessary to put there.
 
-Please note that for base directories, if you chose a directory that can't be properly used by avocado (some directories
-require read access, others, read and write access), avocado will fall back to some defaults. So if your regular user
-wants to write logs to ``/root/avocado/logs``, avocado will not use that directory, since it can't write files to that
+Please note that for base directories, if you chose a directory that can't be properly used by Avocado (some directories
+require read access, others, read and write access), Avocado will fall back to some defaults. So if your regular user
+wants to write logs to ``/root/avocado/logs``, Avocado will not use that directory, since it can't write files to that
 place. A new location, by default ``~/avocado/job-results`` will be selected instead.
 
 Plugin config files
 ===================
 
-Plugins can also be configured by config files. In order to not disturb the main avocado config file, those plugins,
+Plugins can also be configured by config files. In order to not disturb the main Avocado config file, those plugins,
 if they wish so, may install additional config files to ``/etc/avocado/conf.d/[pluginname].conf``, that will be parsed
 after the system wide config file. Users can override those values as well at the local config file level.
 Considering the config for the hypothethical plugin ``salad``::
@@ -83,7 +83,7 @@ system.
 Config plugin
 =============
 
-A configuration plugin is provided for users that wish to quickly see what's defined in all sections of their avocado
+A configuration plugin is provided for users that wish to quickly see what's defined in all sections of their Avocado
 configuration, after all the files are parsed in their correct resolution order. Example::
 
     $ avocado config
@@ -132,7 +132,7 @@ it will give you an output similar to the one seen below::
         data  $HOME/avocado/data
         logs  $HOME/avocado/job-results
 
-Note that, while avocado will do its best to use the config values you
+Note that, while Avocado will do its best to use the config values you
 provide in the config file, if it can't write values to the locations
 provided, it will fall back to (we hope) reasonable defaults, and we
 notify the user about that in the output of the command.
@@ -140,14 +140,14 @@ notify the user about that in the output of the command.
 The relevant API documentation and meaning of each of those data directories
 is in :mod:`avocado.data_dir`, so it's highly recommended you take a look.
 
-You may set your preferred data dirs by setting them in the avocado config files.
-The only exception for important data dirs here is the avocado tmp dir, used to
+You may set your preferred data dirs by setting them in the Avocado config files.
+The only exception for important data dirs here is the Avocado tmp dir, used to
 place temporary files used by tests. That directory will be in normal circumstances
 `/var/tmp/avocado_XXXXX`, (where `XXXXX` is in actuality a random string) securely
 created on `/var/tmp/`, unless the user has the `$TMPDIR` environment variable set,
 since that is customary among unix programs.
 
 The next section of the documentation explains how you can see and set config
-values that modify the behavior for the avocado utilities and plugins.
+values that modify the behavior for the Avocado utilities and plugins.
 
 [1] For example, autotest.

--- a/docs/source/ContributionGuide.rst
+++ b/docs/source/ContributionGuide.rst
@@ -2,7 +2,7 @@
 Contribution and Community Guide
 ================================
 
-Useful pointers on how to participate of the avocado community and contribute.
+Useful pointers on how to participate of the Avocado community and contribute.
 
 Contact information
 ===================
@@ -10,7 +10,7 @@ Contact information
 - Avocado-devel mailing list: `https://www.redhat.com/mailman/listinfo/avocado-devel <https://www.redhat.com/mailman/listinfo/avocado-devel>`_
 - Avocado IRC channel: `irc.oftc.net #avocado <irc://irc.oftc.net/#avocado>`_
 
-Contributing to avocado
+Contributing to Avocado
 =======================
 
 Avocado uses github and the github pull request development model. You can

--- a/docs/source/DebuggingWithGDB.rst
+++ b/docs/source/DebuggingWithGDB.rst
@@ -19,8 +19,28 @@ other:
 Transparent Execution of Binaries
 ---------------------------------
 
-This feature is implemented as a plugin, that adds the ``--gdb-run-bin``
-option to the Avocado ``run`` command.
+This feature adds a few command line options to the Avocado ``run``
+command::
+
+  $ avocado run --help
+  ...
+  GNU Debugger support:
+  --gdb-run-bin BINARY_PATH
+                        Set a breakpoint on a given binary to be run inside
+                        the GNU debugger. Format should be
+                        "<binary>[:breakpoint]". Breakpoint defaults to "main"
+  --gdb-prerun-commands BINARY_PATH:COMMANDS_PATH
+                        After loading a binary in binary in GDB, but before
+                        actually running it, execute the given GDB commands in
+                        the given file. BINARY_PATH is optional and if omitted
+                        will apply to all binaries
+  --gdb-coredump {on,off}
+                        Automatically generate a core dump when the inferior
+                        process received a fatal signal such as SIGSEGV or
+                        SIGABRT
+  ...
+
+To get started you want to use ``--gdb-run-bin``, as shown in the example bellow.
 
 Example
 ~~~~~~~

--- a/docs/source/DebuggingWithGDB.rst
+++ b/docs/source/DebuggingWithGDB.rst
@@ -50,7 +50,7 @@ Transparent Debugging Usage
 ---------------------------
 
 This feature is implemented as a plugin, that adds the ``--gdb-run-bin``
-option to the avocado ``run`` command.
+option to the Avocado ``run`` command.
 
 Example
 ~~~~~~~
@@ -116,7 +116,7 @@ There are a two basic reasons for the mentioned caveats:
 * The architecture of Avocado's GDB feature
 * GDB's own behavior and limitations
 
-When using the Avocado GDB plugin, that is, `--gdb-run-bin`, avocado runs a `gdbserver` instance
+When using the Avocado GDB plugin, that is, `--gdb-run-bin`, Avocado runs a `gdbserver` instance
 transparently and controls it by means of a `gdb` process. When a given event happens, say a
 breakpoint is reached, it disconnects its own `gdb` from the server, and allows the user to use
 a standard `gdb` to connect to the `gdbserver`. This provides a natural and seamless user experience.
@@ -126,7 +126,7 @@ But, `gdbserver` has some limitations at this point, including:
 * Not being able to set a controlling `tty`
 * Not separating its own `STDERR` content from the application being run
 
-These limitations are being addressed both on Avocado and GDB, and will be resolved in future avocado
+These limitations are being addressed both on Avocado and GDB, and will be resolved in future Avocado
 versions.
 
 Workaround

--- a/docs/source/DebuggingWithGDB.rst
+++ b/docs/source/DebuggingWithGDB.rst
@@ -1,53 +1,23 @@
 Debugging with GDB
 ==================
 
-Avocado has two levels of GDB support, one by using the Avocado GDB APIs
-to fire up GDB and interact with it, and other by transparently debugging
-binaries inside the GNU Debugger based on command line only options. This
-later option means that any test that uses :mod:`avocado.utils.process`
-can transparently inspect processes during test run time.
+Avocado has two different types of GDB support that complement each
+other:
 
-API
----
-
-Avocado's GDB module, provides three main classes that lets a test writer
-interact with a `gdb` process, a `gdbserver` process and also use the GDB
-remote protocol for interaction with a remote target.
-
-Please refer to :mod:`avocado.gdb` for more information.
-
-Example
-~~~~~~~
-
-Take a look at ``examples/tests/modify_variable.py`` test::
-
-    def runTest(self):
-        """
-        Execute 'print_variable'.
-        """
-        path = os.path.join(self.srcdir, 'print_variable')
-        app = gdb.GDB()
-        app.set_file(path)
-        app.set_break(6)
-        app.run()
-        self.log.info("\n".join(app.read_until_break()))
-        app.cmd("set variable a = 0xff")
-        app.cmd("c")
-        out = "\n".join(app.read_until_break())
-        self.log.info(out)
-        app.exit()
-        self.assertIn("MY VARIABLE 'A' IS: ff", out)
-
-You can see that instead of running the binary using ``process.run`` we invoke
-``gdb.GDB``. This allows us to automate the interaction with the GDB in means
-of setting breakpoints, executing commands and querying for output.
-
-When you check the output (``--show-job-log``) you can see that despite
-declaring the variable as 0, ff is injected and printed instead.
+* Transparent execution of binaries inside the GNU Debugger. This
+  takes standard and possibly unmodified tests that uses the
+  :mod:`avocado.utils.process` APIs for running processes. By using a
+  command line option, the binary is run on GDB. This allows the user
+  to interact with GDB, but to the test itself, things are pretty much
+  transparent.
+* The :mod:`avocado.gdb` APIs that allows a test to interact with GDB,
+  including setting a binary to be run, setting breakpoints or any
+  other types of commands. This requires a test written with that
+  approach and API in mind.
 
 
-Transparent Debugging Usage
----------------------------
+Transparent Execution of Binaries
+---------------------------------
 
 This feature is implemented as a plugin, that adds the ``--gdb-run-bin``
 option to the Avocado ``run`` command.
@@ -67,7 +37,7 @@ Optionally you can specify single breakpoint using
 It's worth mentioning that when breakpoint is not reached, the test finishes
 without any interruption. This is helpful when you identify regions where you
 should never get in your code, or places which interests you and you can run
-your code in production and gdb variants. If after a long time you get to this
+your code in production and GDB variants. If after a long time you get to this
 place, the test notifies you and you can investigate the problem. This is
 demonstrated in ``examples/tests/doublefree_nasty.py`` test. To unveil the
 power of Avocado, run this test using::
@@ -148,3 +118,42 @@ extension, though, uses :class:`avocado.utils.process.SubProcess` class to
 execute `qemu` in the background.
 
 This limitation will be addressed in future versions of `avocado` and `avocado-virt`.
+
+
+:mod:`avocado.gdb` APIs
+-----------------------
+
+Avocado's GDB module, provides three main classes that lets a test writer
+interact with a `gdb` process, a `gdbserver` process and also use the GDB
+remote protocol for interaction with a remote target.
+
+Please refer to :mod:`avocado.gdb` for more information.
+
+Example
+~~~~~~~
+
+Take a look at ``examples/tests/modify_variable.py`` test::
+
+    def runTest(self):
+        """
+        Execute 'print_variable'.
+        """
+        path = os.path.join(self.srcdir, 'print_variable')
+        app = gdb.GDB()
+        app.set_file(path)
+        app.set_break(6)
+        app.run()
+        self.log.info("\n".join(app.read_until_break()))
+        app.cmd("set variable a = 0xff")
+        app.cmd("c")
+        out = "\n".join(app.read_until_break())
+        self.log.info(out)
+        app.exit()
+        self.assertIn("MY VARIABLE 'A' IS: ff", out)
+
+You can see that instead of running the binary using ``process.run`` we invoke
+``gdb.GDB``. This allows us to automate the interaction with the GDB in means
+of setting breakpoints, executing commands and querying for output.
+
+When you check the output (``--show-job-log``) you can see that despite
+declaring the variable as 0, ff is injected and printed instead.

--- a/docs/source/GetStartedGuide.rst
+++ b/docs/source/GetStartedGuide.rst
@@ -4,18 +4,18 @@
 Getting started guide - users
 =============================
 
-If you want to simply use avocado as a test runner/test API, you can install a
+If you want to simply use Avocado as a test runner/test API, you can install a
 distro package. For Fedora, you can look
-at `lmr's autotest COPR`_, while for Ubuntu, you can look
-at `lmr's avocado PPA`_.
+at `lmr's Autotest COPR`_, while for Ubuntu, you can look
+at `lmr's Avocado PPA`_.
 
 .. _lmr's autotest COPR: http://copr.fedoraproject.org/coprs/lmr/Autotest
 .. _lmr's avocado PPA: https://launchpad.net/~lmr/+archive/avocado
 
 Avocado is primarily being developed on Fedora boxes, but we are making
-reasonable efforts that Ubuntu users can use and develop avocado well.
+reasonable efforts that Ubuntu users can use and develop Avocado well.
 
-Installing avocado - Fedora
+Installing Avocado - Fedora
 ===========================
 
 You can install the rpm package by performing the following commands::
@@ -26,23 +26,23 @@ You can install the rpm package by performing the following commands::
 
 Don't mind the Fedora version here, the same repo file should work for newer distros.
 
-Installing avocado - Ubuntu
+Installing Avocado - Ubuntu
 ===========================
 
 You need to add the following lines::
 
     deb http://ppa.launchpad.net/lmr/avocado/ubuntu trusty main
 
-To the file ``/etc/apt/sources.list``. After that you can install avocado by
+To the file ``/etc/apt/sources.list``. After that you can install Avocado by
 performing the following commands::
 
     sudo apt-get update
     sudo apt-get install avocado
 
-Installing avocado - Git
+Installing Avocado - Git
 ========================
 
-To install avocado from the git repository, check this instructions::
+To install Avocado from the git repository, check this instructions::
 
     git clone git@github.com:avocado-framework/avocado.git
     cd avocado
@@ -56,13 +56,13 @@ utilities `python2.7` and `pip2.7`.
 
 For Debian users, use `apt-get` to install the proper dependencies that `yum` installs.
 
-Using the avocado test runner
+Using the Avocado test runner
 =============================
 
 The test runner is designed to conveniently run tests on your local machine. The types of
 tests you can run are:
 
-* Tests written in Python, using the avocado API, which we'll call `instrumented`.
+* Tests written in Python, using the Avocado API, which we'll call `instrumented`.
 * Any executable in your box, really. The criteria for PASS/FAIL is the return
   code of the executable. If it returns 0, the test PASSes, if it returns anything
   else, it FAILs. We'll call those tests `simple tests`.
@@ -72,8 +72,8 @@ Listing tests
 
 The ``avocado`` command line tool also has a ``list`` command, that lists the
 known tests in a given path, be it a path to an individual test, or a path
-to a directory. If no arguments provided, avocado will inspect the contents
-of the test location being used by avocado (if you are in doubt about which
+to a directory. If no arguments provided, Avocado will inspect the contents
+of the test location being used by Avocado (if you are in doubt about which
 one is that, you may use ``avocado config --datadir``). The output looks like::
 
     $ avocado list
@@ -98,9 +98,8 @@ one is that, you may use ``avocado config --datadir``). The output looks like::
     INSTRUMENTED /usr/share/avocado/tests/warntest.py
     INSTRUMENTED /usr/share/avocado/tests/whiteboard.py
 
-Here, ``INSTRUMENTED`` means that the files there are python files with an
-avocado
-test class in them This means those tests have access to all avocado APIs and
+Here, ``INSTRUMENTED`` means that the files there are Python files with an Avocado
+test class in them This means those tests have access to all Avocado APIs and
 facilities. Let's try to list a directory with a bunch of executable shell
 scripts::
 
@@ -113,10 +112,10 @@ scripts::
     SIMPLE examples/wrappers/valgrind.sh
 
 Here, as covered in the previous section, ``SIMPLE`` means that those files are
-executables, that avocado will simply execute and return PASS or FAIL
+executables, that Avocado will simply execute and return PASS or FAIL
 depending on their return codes (PASS -> 0, FAIL -> any integer different
 than 0). You can also provide the ``--verbose``, or ``-V`` flag to display files
-that were detected but are not avocado tests, along with summary information::
+that were detected but are not Avocado tests, along with summary information::
 
     $ avocado list examples/gdb-prerun-scripts/ -V
     Type       file
@@ -195,7 +194,7 @@ Debugging tests
 
 When developing new tests, you frequently want to look at the straight
 output of the job log in the stdout, without having to tail the job log.
-In order to do that, you can use --show-job-log to the avocado test runner::
+In order to do that, you can use --show-job-log to the Avocado test runner::
 
     $ scripts/avocado run examples/tests/sleeptest.py --show-job-log
     Not logging /proc/slabinfo (lack of permissions)
@@ -217,5 +216,5 @@ In order to do that, you can use --show-job-log to the avocado test runner::
 
 As you can see, the UI output is suppressed and only the job log goes to
 stdout, making this a useful feature for test development/debugging. Some more
-involved functionalities for the avocado runner will be discussed as
+involved functionalities for the Avocado runner will be discussed as
 appropriate, during the introduction of important concepts.

--- a/docs/source/GetStartedGuide.rst
+++ b/docs/source/GetStartedGuide.rst
@@ -35,7 +35,7 @@ Ubuntu
 
 You can install Avocado by running the following commands::
 
-    sudo echo "deb http://ppa.launchpad.net/lmr/avocado/ubuntu trusty main" >> /etc/apt/sources.list
+    sudo echo "deb http://ppa.launchpad.net/lmr/avocado/ubuntu utopic main" >> /etc/apt/sources.list
     sudo apt-get update
     sudo apt-get install avocado
 

--- a/docs/source/GetStartedGuide.rst
+++ b/docs/source/GetStartedGuide.rst
@@ -1,24 +1,28 @@
 .. _get-started:
 
-=============================
-Getting started guide - users
-=============================
+===============
+Getting Started
+===============
 
-If you want to simply use Avocado as a test runner/test API, you can install a
-distro package. For Fedora, you can look
-at `lmr's Autotest COPR`_, while for Ubuntu, you can look
-at `lmr's Avocado PPA`_.
+The first step towards using Avocado is, quite obivously, installing it.
 
-.. _lmr's autotest COPR: http://copr.fedoraproject.org/coprs/lmr/Autotest
-.. _lmr's avocado PPA: https://launchpad.net/~lmr/+archive/avocado
+Installing Avocado
+==================
 
-Avocado is primarily being developed on Fedora boxes, but we are making
-reasonable efforts that Ubuntu users can use and develop Avocado well.
+Avocado is available in `RPM packages for Fedora`_, and `DEB packages for Ubuntu`_.
 
-Installing Avocado - Fedora
-===========================
+.. _RPM Packages For Fedora: http://copr.fedoraproject.org/coprs/lmr/Autotest
+.. _DEB packages for Ubuntu: https://launchpad.net/~lmr/+archive/avocado
 
-You can install the rpm package by performing the following commands::
+.. Note: the following text should instead reference the distro tiers levels
+
+Avocado is primarily being developed on Fedora, but reasonable efforts
+are being made to support other platforms such as Ubuntu.
+
+Fedora
+------
+
+You can install the RPM packages by running the following commands::
 
     sudo curl http://copr.fedoraproject.org/coprs/lmr/Autotest/repo/fedora-20/lmr-Autotest-fedora-20.repo -o /etc/yum.repos.d/autotest.repo
     sudo yum update
@@ -26,29 +30,30 @@ You can install the rpm package by performing the following commands::
 
 Don't mind the Fedora version here, the same repo file should work for newer distros.
 
-Installing Avocado - Ubuntu
-===========================
+Ubuntu
+------
 
-You need to add the following lines::
+You can install Avocado by running the following commands::
 
-    deb http://ppa.launchpad.net/lmr/avocado/ubuntu trusty main
-
-To the file ``/etc/apt/sources.list``. After that you can install Avocado by
-performing the following commands::
-
+    sudo echo "deb http://ppa.launchpad.net/lmr/avocado/ubuntu trusty main" >> /etc/apt/sources.list
     sudo apt-get update
     sudo apt-get install avocado
 
-Installing Avocado - Git
-========================
+Generic installation from a GIT repository
+------------------------------------------
 
-To install Avocado from the git repository, check this instructions::
+First make sure you have a basic set of packages installed. The
+following applies to Fedora based distributions, please adapt to
+your platform::
+
+    sudo yum install -y git gcc python-devel python-pip libvirt-devel libyaml-devel
+
+Then to install Avocado from the git repository run::
 
     git clone git@github.com:avocado-framework/avocado.git
     cd avocado
-    sudo python setup.py install
-    sudo yum install -y gcc python-devel python-pip libvirt-devel libyaml-devel
     sudo pip install -r requirements.txt
+    sudo python setup.py install
 
 Note that `python` and `pip` should point to the Python interpreter version 2.7.x.
 If you're having trouble to install, you can try again and use the command line

--- a/docs/source/Introduction.rst
+++ b/docs/source/Introduction.rst
@@ -11,7 +11,7 @@ but any executable can serve as a test.
 Avocado is composed by:
 
 * A test runner that lets you execute tests. Those tests can be either written on your
-  language of choice, or use the python API available. In both cases, you get
+  language of choice, or use the Python API available. In both cases, you get
   facilities such as automated log and system information collection.
 
 * APIs that help you write tests in a concise, yet expressive way.
@@ -23,14 +23,14 @@ Avocado is composed by:
   to the Avocado Framework.
 
 Avocado tries as much as possible to comply with standard Python testing
-technology. Tests written using the avocado API are derived from the unittest
+technology. Tests written using the Avocado API are derived from the unittest
 class, while other methods suited to functional and performance testing were
 added. The test runner is designed to help people to run their tests while
 providing an assortment of system and logging facilities, with no effort,
 and if you want more features, then you can start using the API features
 progressively.
 
-An `extensive set of slides about avocado
+An `extensive set of slides about Avocado
 <https://docs.google.com/presentation/d/1PLyOcmoYooWGAe-rS2gtjmrZ0B9J22FbfpNlQY8fIUE>`__,
 including details about its architecture, main features and status is available
 in google-drive. Mindmap from workshop (2015) demonstrating features on

--- a/docs/source/Introduction.rst
+++ b/docs/source/Introduction.rst
@@ -3,10 +3,11 @@
 About Avocado
 =============
 
-Avocado is a set of tools and libraries to perform automated testing, altogether
-with the possibility of manual interaction. One can call it a test framework with benefits.
-Native tests are written in Python and they follow the :mod:`unittest` pattern,
-but any executable can serve as a test.
+Avocado is a set of tools and libraries to help with automated testing.
+
+One can call it a test framework with benefits. Native tests are
+written in Python and they follow the :mod:`unittest` pattern, but any
+executable can serve as a test.
 
 Avocado is composed by:
 

--- a/docs/source/OutputPlugins.rst
+++ b/docs/source/OutputPlugins.rst
@@ -5,7 +5,7 @@ Output Plugins
 
 A test runner must provide an assortment of ways to clearly communicate results
 to interested parties, be them humans or machines. The types of output that
-avocado is interested in produce are:
+Avocado is interested in produce are:
 
 * Human Readable:
     Textual output that humans can make sense of. Not meant to be
@@ -15,7 +15,7 @@ avocado is interested in produce are:
     and/or stored by programs. This is how the test suite is
     supposed to interact with other programs.
 
-As an example of human readable output, we have the dots that python unittests
+As an example of human readable output, we have the dots that Python unittests
 print while executing tests::
 
     $ unittests/avocado/test_unittest.py
@@ -25,7 +25,7 @@ print while executing tests::
 
     OK (skipped=2)
 
-Or the more verbose avocado output::
+Or the more verbose Avocado output::
 
     $ avocado run sleeptest failtest synctest
     JOB ID    : 5ffe479262ea9025f2e4e84c4e92055b5c79bdc9
@@ -49,11 +49,11 @@ human output to figure out what happened with your test run.
 Machine readable output - xunit
 -------------------------------
 
-The default machine readable output in avocado is
+The default machine readable output in Avocado is
 `xunit <http://help.catchsoftware.com/display/ET/JUnit+Format>`__, an xml format
 that contains test results in a structured form, and are used by other test
 automation projects, such as `jenkins <http://jenkins-ci.org/>`__. If you want
-to make avocado to generate xunit output in the standard output of the runner,
+to make Avocado to generate xunit output in the standard output of the runner,
 simply use::
 
     $ scripts/avocado --xunit - run "sleeptest failtest synctest"
@@ -72,7 +72,7 @@ Machine readable output - json
 ------------------------------
 
 `JSON <http://www.json.org/>`__ is a widely used data exchange format. The
-json avocado plugin outputs job information, similarly to the xunit output
+json Avocado plugin outputs job information, similarly to the xunit output
 plugin::
 
     $ scripts/avocado --json - run "sleeptest failtest synctest"

--- a/docs/source/Plugins.rst
+++ b/docs/source/Plugins.rst
@@ -4,7 +4,7 @@ Avocado Plugins
 ===============
 
 In order to keep the code base approachable, and allow for cleanly extending
-the test runner functionality, avocado has a plugin system. In order to
+the test runner functionality, Avocado has a plugin system. In order to
 exemplify the concepts involved, let's use another old time favorite,
 the "Print hello world" theme.
 
@@ -55,11 +55,11 @@ As you can see, plugins inherit from :class:`avocado.core.plugins.plugin.Plugin`
 that have the methods :func:`avocado.core.plugins.plugin.Plugin.configure` and
 :func:`avocado.core.plugins.plugin.Plugin.activate`. Configure does add the
 command parser to the app test runner, and activate, if necessary will activate
-your plugin, overriding avocado core functionality. In this configure method,
+your plugin, overriding Avocado core functionality. In this configure method,
 we added a new parser for the new command ``hello`` and automatically set
 it to the method ``run``, that will print the plugin's docstring.
 
-Make avocado aware of the new plugin
+Make Avocado aware of the new plugin
 ------------------------------------
 
 Avocado has an option ``--plugins`` that allows you to provide a filesystem
@@ -69,7 +69,7 @@ Note that all external plugins shall be prefixed with this ``avocado_`` name,
 otherwise the Python module will be just ignored and no plugin inside
 will be loaded!
 
-In the avocado source tree, the ``avocado_hello.py`` example is available under
+In the Avocado source tree, the ``avocado_hello.py`` example is available under
 ``examples/plugins``. So, in order to enable the hello plugin, you can do a::
 
     $ avocado --plugins examples/plugins/ plugins
@@ -92,6 +92,6 @@ To run it, you can simply call the newly registered runner command ``hello``::
 Wrap Up
 -------
 
-We have briefly discussed the making of avocado plugins. A look at the module
+We have briefly discussed the making of Avocado plugins. A look at the module
 :mod:`avocado.core.plugins` would be useful to look some of the other possibilities
 available.

--- a/docs/source/ReferenceGuide.rst
+++ b/docs/source/ReferenceGuide.rst
@@ -32,11 +32,14 @@ and match those in a single job.
 Instrumented
 ------------
 
-Tests written in Python that use the Avocado API. To consider a file to contain an instrumented
-test, the Avocado test loader looks for an Avocado test class inside it.
+These are tests written in Python that use the Avocado test API.
 
+To be more precise, the Python file must contain a class derived from :mod:`avocado.test.Test`.
 This means that an executable written in Python is not always an instrumented test, but may work
 as a simple test.
+
+By the way, the term instrumented is used because the Avocado Python test classes allow you to
+get more features for your test, such as logging facilities and more sophisticated test APIs.
 
 Simple
 ------
@@ -44,4 +47,13 @@ Simple
 Any executable in your box. The criteria for PASS/FAIL is the return code of the executable.
 If it returns 0, the test PASSes, if it returns anything else, it FAILs.
 
+Test Resolution
+===============
+
+When you use the Avocado runner, frequently you'll provide paths to files,
+that will be inspected, and acted upon depending on their contents. The
+diagram below shows how Avocado analyzes a file and decides what to do with
+it:
+
+.. figure:: diagram.png
 .. [#f1] Avocado plugins can introduce additional test types.

--- a/docs/source/ReferenceGuide.rst
+++ b/docs/source/ReferenceGuide.rst
@@ -1,0 +1,47 @@
+.. _reference-guide:
+
+===============
+Reference Guide
+===============
+
+This guide presents information on the Avocado basic design and its internals.
+
+.. _job-id:
+
+Job ID
+======
+
+The Job ID is a SHA1 string that has some information encoded:
+
+* Hostname
+* ISO timestamp
+* 64 bit integer
+
+The idea is to have a unique identifier that can be used for job data, for
+the purposes of joining on a single database results obtained by jobs run
+on different systems.
+
+.. _test-types:
+
+Test Types
+==========
+
+Avocado at its simplest configuration can run two different types of tests [#f1]_. You can mix
+and match those in a single job.
+
+Instrumented
+------------
+
+Tests written in Python that use the Avocado API. To consider a file to contain an instrumented
+test, the Avocado test loader looks for an Avocado test class inside it.
+
+This means that an executable written in Python is not always an instrumented test, but may work
+as a simple test.
+
+Simple
+------
+
+Any executable in your box. The criteria for PASS/FAIL is the return code of the executable.
+If it returns 0, the test PASSes, if it returns anything else, it FAILs.
+
+.. [#f1] Avocado plugins can introduce additional test types.

--- a/docs/source/RemoteMachinePlugin.rst
+++ b/docs/source/RemoteMachinePlugin.rst
@@ -20,7 +20,7 @@ You can check for its presence by listing your plugins::
         run_remote - Run tests on a remote machine (Enabled)
         ...
 
-This plugin adds a number of options to the avocado test runner::
+This plugin adds a number of options to the Avocado test runner::
 
       --remote-hostname REMOTE_HOSTNAME
                             Specify the hostname to login on remote machine
@@ -69,7 +69,7 @@ Once everything is verified and covered, you may run your test. Example::
     WARN      : 0
     TIME      : 1.01 s
 
-As you can see, avocado will copy the tests you have to your remote machine and
+As you can see, Avocado will copy the tests you have to your remote machine and
 execute them. A bit of extra logging information is added to your job summary,
 mainly to distinguish the regular execution from the remote one. Note here that
 we did not need `--remote-password` because the SSH key is already setup.

--- a/docs/source/ResultsSpecification.rst
+++ b/docs/source/ResultsSpecification.rst
@@ -3,7 +3,7 @@ Results Specification
 =====================
 
 On a machine that executed tests, job results are available under
-``[job-results]/job-[timestamp]-[short job ID]``, where ``logdir`` is the configured avocado
+``[job-results]/job-[timestamp]-[short job ID]``, where ``logdir`` is the configured Avocado
 logs directory (see the data dir plugin), and the directory name includes
 a timestamp, such as ``job-2014-08-12T15.44-565e8de``. A typical
 results directory structure can be seen below ::

--- a/docs/source/VirtualMachinePlugin.rst
+++ b/docs/source/VirtualMachinePlugin.rst
@@ -13,7 +13,7 @@ provided that you properly set up that VM.
 VM Plugin Basics
 ================
 
-The vm plugin is one of the basic plugins provided by avocado. You can check
+The vm plugin is one of the basic plugins provided by Avocado. You can check
 for its presence by listing your plugins::
 
     $ scripts/avocado plugins
@@ -22,7 +22,7 @@ for its presence by listing your plugins::
         run_vm - Run tests on a Virtual Machine (Enabled)
         ...
 
-This plugin adds a number of options to the avocado test runner::
+This plugin adds a number of options to the Avocado test runner::
 
       --vm                  Run tests on Virtual Machine
       --vm-hypervisor-uri VM_HYPERVISOR_URI
@@ -47,7 +47,7 @@ VM Setup
 
 Make sure you have:
 
- 1) A libvirt domain with an avocado RPM installed. You can see more info on
+ 1) A libvirt domain with an Avocado RPM installed. You can see more info on
     how to do that in the Getting Started Guide.
  2) The domain IP address or fully qualified hostname
  3) All pre-requesites for your test to run installed inside the VM
@@ -76,7 +76,7 @@ Once everything is verified and covered, you may run your test. Example::
     WARN      : 0
     TIME      : 1.01 s
 
-As you can see, avocado will copy the tests you have to your libvirt domain and
+As you can see, Avocado will copy the tests you have to your libvirt domain and
 execute them. A bit of extra logging information is added to your job summary,
 mainly to distinguish the regular execution from the remote one. Note here that
 we did not need `--vm-password` because the SSH key is already setup.

--- a/docs/source/WrapProcess.rst
+++ b/docs/source/WrapProcess.rst
@@ -1,17 +1,17 @@
 Wrap process in tests
 =====================
 
-Avocado allows the instrumentation of applications being
-run by a test in a transparent way.
+Avocado allows the instrumentation of applications being run by a test
+in a transparent way. The user specifies a script ("the wrapper") to be
+used to run the actual program called by the test.
 
-The user specifies a script ("the wrapper") to be used to run the actual
-program called by the test.  If the instrument is
-implemented correctly, it should not interfere with the test behavior.
+If the instrumentation script is implemented correctly, it should not
+interfere with the test behavior. That is, the wrapper should avoid
+changing the return status, standard output and standard error messages
+of the original process.
 
-So it means that the wrapper should avoid to change the return status,
-standard output and standard error messages of the process.
-
-The user can optionally specify a target program to wrap.
+The user can be specific about which program to wrap, or if that is omitted,
+a global wrapper that will apply to all programs called by the test.
 
 Usage
 -----
@@ -25,37 +25,35 @@ Example of a transparent way of running strace as a wrapper::
     #!/bin/sh
     exec strace -ff -o $AVOCADO_TEST_LOGDIR/strace.log -- $@
 
+To have all programs started by ``test.py`` wrapped with ``~/bin/my-wrapper.sh``::
 
-Now you can run::
-
-    # run all programs started by test.py with ~/bin/my-wrapper.sh
     $ scripts/avocado run --wrapper ~/bin/my-wrapper.sh tests/test.py
 
-    # run only my-binary (if/when started by a test) with ~/bin/my-wrapper.sh
-    $ scripts/avocado run --wrapper ~/bin/my-wrapper.sh:my-binary tests/test.py
+To have only ``my-binary`` wrapped with ``~/bin/my-wrapper.sh``::
 
+  $ scripts/avocado run --wrapper ~/bin/my-wrapper.sh:my-binary tests/test.py
 
 Caveats
 -------
 
 * It is not possible to debug with GDB (`--gdb-run-bin`) and use
-  wrappers (`--wrapper`), both options together are incompatible.
+  wrappers (`--wrapper`) at the same time. These two options are
+  mutually exclusive.
 
-* You cannot set multiples (global) wrappers
-  -- like `--wrapper foo.sh --wrapper bar.sh` -- it will trigger an error.
-  You should use a single script that performs both things
-  you are trying to achieve.
+* You can only set one (global) wrapper. If you need functionality
+  present in two wrappers, you have to combine those into a single
+  wrapper script.
 
-* The only process that can be wrapper are those that uses the Avocado
-  module `avocado.utils.process` and the modules that make use of it,
-  like `avocado.utils.build` and so on.
+* Only processes that are run with the :mod:`avocado.utils.process` APIs
+  (and other API modules that make use of it, like mod:`avocado.utils.build`)
+  are affected by this feature.
 
 * If paths are not absolute, then the process name matches with the base name,
   so `--wrapper foo.sh:make` will match `/usr/bin/make`, `/opt/bin/make`
-  and  `/long/path/to/make`.
+  and `/long/path/to/make`.
 
-*  When you use a relative path to a script, it will use the current path
-   of the running Avocado program.
-   Example: If I'm running Avocado on `/home/user/project/avocado`,
-   then `avocado run --wrapper examples/wrappers/strace.sh datadir`  will
-   set the wrapper to `/home/user/project/avocado/examples/wrappers/strace.sh`
+* When you use a relative path to a script, it will use the current path
+  of the running Avocado program. Example: If I'm running Avocado on
+  `/home/user/project/avocado`, then `avocado run --wrapper
+  examples/wrappers/strace.sh datadir`  will set the wrapper to
+  `/home/user/project/avocado/examples/wrappers/strace.sh`

--- a/docs/source/WrapProcess.rst
+++ b/docs/source/WrapProcess.rst
@@ -18,7 +18,7 @@ Usage
 
 This feature is implemented as a plugin, that adds the `--wrapper` option
 to the Avocado `run` command.  For a detailed explanation please consult the     
-avocado man page.
+Avocado man page.
 
 Example of a transparent way of running strace as a wrapper::
 
@@ -55,7 +55,7 @@ Caveats
   and  `/long/path/to/make`.
 
 *  When you use a relative path to a script, it will use the current path
-   of the running avocado program.
-   Example: If I'm running avocado on `/home/user/project/avocado`,
+   of the running Avocado program.
+   Example: If I'm running Avocado on `/home/user/project/avocado`,
    then `avocado run --wrapper examples/wrappers/strace.sh datadir`  will
    set the wrapper to `/home/user/project/avocado/examples/wrappers/strace.sh`

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -4,35 +4,11 @@
 Writing Avocado Tests
 =====================
 
-Test Resolution in Avocado - simple tests vs instrumented tests
-===============================================================
+We are going to write an Avocado test in Python and we are going to inherit from
+:class:`avocado.test.Test`. This makes this test a so-called instrumented test.
 
-What is a test in the Avocado context? Either one of:
-
-* An executable file, that returns exit code 0 (PASS) or != 0 (FAIL). This
-  is known as a SimpleTest, in Avocado terminology.
-* A Python module containing a class derived from :mod:`avocado.Test`.
-  This is known as an instrumented test, in Avocado terminology. The term
-  instrumented is used because the Avocado Python test classes allow you to
-  get more features for your test, such as logging facilities and more
-  sophisticated test APIs.
-
-When you use the Avocado runner, frequently you'll provide paths to files,
-that will be inspected, and acted upon depending on their contents. The
-diagram below shows how Avocado analyzes a file and decides what to do with
-it:
-
-.. figure:: diagram.png
-
-Now that we covered how avocado resolves tests, let's get to business.
-This section is concerned with writing an Avocado test. The process is not
-hard, all you need to do is to create a test module, which is a Python file
-with a class that inherits from :class:`avocado.Test`. This class only
-really needs to implement a method called `runTest`, which represents the actual
-sequence of test operations.
-
-Simple example
-==============
+Basic example
+=============
 
 Let's re-create an old time favorite, ``sleeptest``, which is a functional
 test for Avocado (old because we also use such a test for autotest). It does

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -5,14 +5,13 @@ Writing Avocado Tests
 =====================
 
 We are going to write an Avocado test in Python and we are going to inherit from
-:class:`avocado.test.Test`. This makes this test a so-called instrumented test.
+:class:`avocado.Test`. This makes this test a so-called instrumented test.
 
 Basic example
 =============
 
-Let's re-create an old time favorite, ``sleeptest``, which is a functional
-test for Avocado (old because we also use such a test for autotest). It does
-nothing but ``time.sleep([number-seconds])``::
+Let's re-create an old time favorite, ``sleeptest`` [#f1]_.  It is so simple, it
+does nothing besides sleeping for a while::
 
         import time
 
@@ -25,20 +24,38 @@ nothing but ``time.sleep([number-seconds])``::
                 self.log.debug("Sleeping for %.2f seconds", sleep_length)
                 time.sleep(sleep_length)
 
-This is about the simplest test you can write for Avocado (at least, one using
-the Avocado APIs). An avocado test is basically a class that inherits from
-:mod:`avocado.Test` and could have any name you might like (we'll trust
-you'll choose a good name, although we do recommend that the name uses the
-CamelCase convention, for PEP8 consistency).
+This is about the simplest test you can write for Avocado, while still
+leveraging its API power.
 
-Note that the test object provides you with a number of convenience
-attributes, such as ``self.log``, that lets you log debug, info, error and
-warning messages. Also, we note the parameter passing system that Avocado
-provides: We frequently want to pass parameters to tests, and we can do that
-through what we call a `multiplex file`, which is a configuration file that
-not only allows you to provide params to your test, but also easily create a
-validation matrix in a concise way. You can find more about the multiplex
-file format on :doc:`MultiplexConfig`.
+What is an Avocado Test
+-----------------------
+
+As can be seen in the example above, an Avocado test is a method that
+starts with ``test`` in a class that inherits from :mod:`avocado.Test`.
+
+Multiple tests and naming conventions
+-------------------------------------
+
+You can have multiple tests in a single class.
+
+To do so, just give the methods names that start with ``test``, say
+``test_foo``, ``test_bar`` and so on. We recommend you follow this naming
+style, as defined in the `PEP8 Function Names`_ section.
+
+For the class name, you can pick any name you like, but we also recommend
+that it follows the CamelCase convention, also known as CapWords, defined
+in the PEP 8 document under `Class Names`_.
+
+Convenience Attributes
+----------------------
+
+Note that the test class provides you with a number of convenience attributes:
+
+* A ready to use log mechanism for your test, that can be accessed by means
+  of ``self.log``. It lets you log debug, info, error and warning messages.
+* A parameter passing system (and fetching system) that can be accessed by
+  means of ``self.params``. This is hooked to the Multiplexer, about which
+  you can find that more information at :doc:`MultiplexConfig`.
 
 Saving test generated (custom) data
 ===================================
@@ -751,3 +768,10 @@ the Avocado self test suite to do functional testing of Avocado itself.
 
 It is also recommended that you take a look at the
 :doc:`API documentation <api/modules>` for more possibilities.
+
+.. [#f1] sleeptest is a functional test for Avocado. It's "old" because we
+	 also have had such a test for `Autotest`_ for a long time.
+
+.. _Autotest: http://autotest.github.io
+.. _Class Names: https://www.python.org/dev/peps/pep-0008/
+.. _PEP8 Function Names: https://www.python.org/dev/peps/pep-0008/#function-names

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -4,29 +4,29 @@
 Writing Avocado Tests
 =====================
 
-Test Resolution in avocado - simple tests vs instrumented tests
+Test Resolution in Avocado - simple tests vs instrumented tests
 ===============================================================
 
-What is a test in the avocado context? Either one of:
+What is a test in the Avocado context? Either one of:
 
 * An executable file, that returns exit code 0 (PASS) or != 0 (FAIL). This
-  is known as a SimpleTest, in avocado terminology.
-* A python module containing a class derived from :mod:`avocado.Test`.
-  This is known as an instrumented test, in avocado terminology. The term
-  instrumented is used because the avocado python test classes allow you to
+  is known as a SimpleTest, in Avocado terminology.
+* A Python module containing a class derived from :mod:`avocado.Test`.
+  This is known as an instrumented test, in Avocado terminology. The term
+  instrumented is used because the Avocado Python test classes allow you to
   get more features for your test, such as logging facilities and more
   sophisticated test APIs.
 
-When you use the avocado runner, frequently you'll provide paths to files,
+When you use the Avocado runner, frequently you'll provide paths to files,
 that will be inspected, and acted upon depending on their contents. The
-diagram below shows how avocado analyzes a file and decides what to do with
+diagram below shows how Avocado analyzes a file and decides what to do with
 it:
 
 .. figure:: diagram.png
 
 Now that we covered how avocado resolves tests, let's get to business.
-This section is concerned with writing an avocado test. The process is not
-hard, all you need to do is to create a test module, which is a python file
+This section is concerned with writing an Avocado test. The process is not
+hard, all you need to do is to create a test module, which is a Python file
 with a class that inherits from :class:`avocado.Test`. This class only
 really needs to implement a method called `runTest`, which represents the actual
 sequence of test operations.
@@ -35,7 +35,7 @@ Simple example
 ==============
 
 Let's re-create an old time favorite, ``sleeptest``, which is a functional
-test for avocado (old because we also use such a test for autotest). It does
+test for Avocado (old because we also use such a test for autotest). It does
 nothing but ``time.sleep([number-seconds])``::
 
         #!/usr/bin/python
@@ -49,7 +49,7 @@ nothing but ``time.sleep([number-seconds])``::
         class SleepTest(Test):
 
             """
-            Example test for avocado.
+            Example test for Avocado.
             """
 
             def runTest(self):
@@ -72,7 +72,7 @@ CamelCase convention, for PEP8 consistency).
 
 Note that the test object provides you with a number of convenience
 attributes, such as ``self.log``, that lets you log debug, info, error and
-warning messages. Also, we note the parameter passing system that avocado
+warning messages. Also, we note the parameter passing system that Avocado
 provides: We frequently want to pass parameters to tests, and we can do that
 through what we call a `multiplex file`, which is a configuration file that
 not only allows you to provide params to your test, but also easily create a
@@ -175,7 +175,7 @@ More details on that are in :doc:`MultiplexConfig`
 Using a multiplex file
 ======================
 
-You may use the avocado runner with a multiplex file to provide params and matrix
+You may use the Avocado runner with a multiplex file to provide params and matrix
 generation for sleeptest just like::
 
     $ avocado run sleeptest --multiplex examples/tests/sleeptest.py.data/sleeptest.yaml
@@ -239,7 +239,7 @@ You can also execute multiple tests with the same multiplex file::
 Avocado tests are also unittests
 ================================
 
-Since avocado tests inherit from :class:`unittest.TestCase`, you can use all
+Since Avocado tests inherit from :class:`unittest.TestCase`, you can use all
 the :func:`assert` class methods on your tests. Some silly examples::
 
     class RandomExamples(test.Test):
@@ -257,12 +257,12 @@ the :func:`assert` class methods on your tests. Some silly examples::
             self.assertIsInstance(self, test.Test)
 
 The reason why we have a shebang in the beginning of the test is because
-avocado tests, similarly to unittests, can use an entry point, called
+Avocado tests, similarly to unittests, can use an entry point, called
 :func:`avocado.main`, that calls avocado libs to look for test classes and execute
 its main entry point. This is an optional, but fairly handy feature. In case
 you want to use it, don't forget to ``chmod +x`` your test.
 
-Executing an avocado test gives::
+Executing an Avocado test gives::
 
     $ examples/tests/sleeptest.py
     JOB ID    : de6c1e4c227c786dc4d926f6fca67cda34d96276
@@ -281,10 +281,10 @@ Executing an avocado test gives::
 Running tests with nosetests
 ============================
 
-`nose <https://nose.readthedocs.org/>`__ is a python testing framework with
-similar goals as avocado, except that avocado also intends to provide tools to
+`nose <https://nose.readthedocs.org/>`__ is a Python testing framework with
+similar goals as Avocado, except that avocado also intends to provide tools to
 assemble a fully automated test grid, plus richer test API for tests on the
-Linux platform. Regardless, the fact that an avocado class is also an unittest
+Linux platform. Regardless, the fact that an Avocado class is also an unittest
 cass, you can run them with the ``nosetests`` application::
 
     $ nosetests examples/tests/sleeptest.py
@@ -305,7 +305,7 @@ Running third party test suites
 ===============================
 
 It is very common in test automation workloads to use test suites developed
-by third parties. By wrapping the execution code inside an avocado test module,
+by third parties. By wrapping the execution code inside an Avocado test module,
 you gain access to the facilities and API provided by the framework. Let's
 say you want to pick up a test suite written in C that it is in a tarball,
 uncompress it, compile the suite code, and then executing the test. Here's
@@ -386,7 +386,7 @@ both, if you specified ``all``) being executed to reference files: ``stdout.expe
 and ``stderr.expected``. Those files will be recorded in the test data dir. The
 data dir is in the same directory as the test source file, named
 ``[source_file_name.data]``. Let's take as an example the test ``synctest.py``. In a
-fresh checkout of avocado, you can see::
+fresh checkout of Avocado, you can see::
 
         examples/tests/synctest.py.data/stderr.expected
         examples/tests/synctest.py.data/stdout.expected
@@ -460,7 +460,7 @@ Let's look what's in each of them::
 
 Now, every time this test runs, it'll take into account the expected files that
 were recorded, no need to do anything else but run the test. Let's see what
-happens if we change the ``stdout.expected`` file contents to ``Hello, avocado!``::
+happens if we change the ``stdout.expected`` file contents to ``Hello, Avocado!``::
 
     $ scripts/avocado run output_record.sh
     JOB ID    : f0521e524face93019d7cb99c5765aedd933cb2e
@@ -508,7 +508,7 @@ Verifying the failure reason::
     20:52:38 test       L0063 ERROR| Hello, world!
     20:52:38 test       L0063 ERROR|
     20:52:38 test       L0063 ERROR| Expected:
-    20:52:38 test       L0063 ERROR| Hello, avocado!
+    20:52:38 test       L0063 ERROR| Hello, Avocado!
     20:52:38 test       L0063 ERROR|
     20:52:38 test       L0064 ERROR|
     20:52:38 test       L0529 ERROR| FAIL home/$USER/Code/avocado/output_record.sh -> AssertionError: Actual test sdtout differs from expected one:
@@ -516,13 +516,13 @@ Verifying the failure reason::
     Hello, world!
 
     Expected:
-    Hello, avocado!
+    Hello, Avocado!
 
     20:52:38 test       L0516 INFO |
 
 As expected, the test failed because we changed its expectations.
 
-Test log, stdout and stderr in native avocado modules
+Test log, stdout and stderr in native Avocado modules
 =====================================================
 
 If needed, you can write directly to the expected stdout and stderr files
@@ -575,8 +575,8 @@ Avocado Tests run on a separate process
 =======================================
 
 In order to avoid tests to mess around the environment used by the main
-avocado runner process, tests are run on a forked subprocess. This allows
-for more robustness (tests are not easily able to mess/break avocado) and
+Avocado runner process, tests are run on a forked subprocess. This allows
+for more robustness (tests are not easily able to mess/break Avocado) and
 some nifty features, such as setting test timeouts.
 
 Setting a Test Timeout
@@ -652,7 +652,7 @@ impact your test grid. You can account for that possibility and set up a
 
 
 If you pass that multiplex file to the runner multiplexer, this will register
-a timeout of 3 seconds before avocado ends the test forcefully by sending a
+a timeout of 3 seconds before Avocado ends the test forcefully by sending a
 :class:`signal.SIGTERM` to the test, making it raise a
 :class:`avocado.core.exceptions.TestTimeoutError`.
 
@@ -669,7 +669,7 @@ a timeout of 3 seconds before avocado ends the test forcefully by sending a
     class TimeoutTest(Test):
 
         """
-        Functional test for avocado. Throw a TestTimeoutError.
+        Functional test for Avocado. Throw a TestTimeoutError.
         """
         default_params = {'timeout': 3.0,
                           'sleep_time': 5.0}
@@ -738,7 +738,7 @@ This accomplishes a similar effect to the multiplex setup defined in there.
 Environment Variables for Simple Tests
 ======================================
 
-Avocado exports avocado variables and multiplexed variables as BASH environment
+Avocado exports Avocado variables and multiplexed variables as BASH environment
 to the running test. Those variables are interesting to simple tests, because
 they can not make use of Avocado API directly with Python, like the native
 tests can do and also they can modify the test parameters.
@@ -778,7 +778,7 @@ only requirement is to use::
 
     PATH=$(avocado "exec-path"):$PATH
 
-which injects path to avocado utils into shell PATH. Take a look into
+which injects path to Avocado utils into shell PATH. Take a look into
 ``avocado exec-path`` to see list of available functions and take a look at
 ``examples/tests/simplewarning.sh`` for inspiration.
 
@@ -789,7 +789,7 @@ Wrap Up
 We recommend you take a look at the example tests present in the
 ``examples/tests`` directory, that contains a few samples to take some
 inspiration from. That directory, besides containing examples, is also used by
-the avocado self test suite to do functional testing of avocado itself.
+the Avocado self test suite to do functional testing of Avocado itself.
 
 It is also recommended that you take a look at the
 :doc:`API documentation <api/modules>` for more possibilities.

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -14,34 +14,19 @@ Let's re-create an old time favorite, ``sleeptest``, which is a functional
 test for Avocado (old because we also use such a test for autotest). It does
 nothing but ``time.sleep([number-seconds])``::
 
-        #!/usr/bin/python
-
         import time
 
         from avocado import Test
-        from avocado import main
-
 
         class SleepTest(Test):
 
-            """
-            Example test for Avocado.
-            """
-
-            def runTest(self):
-                """
-                Sleep for length seconds.
-                """
+            def test(self):
                 sleep_length = self.params.get('sleep_length', default=1)
                 self.log.debug("Sleeping for %.2f seconds", sleep_length)
                 time.sleep(sleep_length)
 
-
-        if __name__ == "__main__":
-            main()
-
-This is about the simplest test you can write for avocado (at least, one using
-the avocado APIs). An avocado test is basically a class that inherits from
+This is about the simplest test you can write for Avocado (at least, one using
+the Avocado APIs). An avocado test is basically a class that inherits from
 :mod:`avocado.Test` and could have any name you might like (we'll trust
 you'll choose a good name, although we do recommend that the name uses the
 CamelCase convention, for PEP8 consistency).
@@ -67,10 +52,7 @@ encoded it first (base64 is the obvious choice).
 Building on the previously demonstrated ``sleeptest``, suppose that you want to save the
 sleep length to be used by some other script or data analysis tool::
 
-        def runTest(self):
-            """
-            Sleep for length seconds.
-            """
+        def test(self):
             sleep_length = self.params.get('sleep_length', default=1)
             self.log.debug("Sleeping for %.2f seconds", sleep_length)
             time.sleep(sleep_length)
@@ -219,7 +201,7 @@ Since Avocado tests inherit from :class:`unittest.TestCase`, you can use all
 the :func:`assert` class methods on your tests. Some silly examples::
 
     class RandomExamples(test.Test):
-        def runTest(self):
+        def test(self):
             self.log.debug("Verifying some random math...")
             four = 2 * 2
             four_ = 2 + 2
@@ -318,7 +300,7 @@ an example that does that::
             self.srcdir = os.path.join(self.srcdir, 'synctest')
             build.make(self.srcdir)
 
-        def runTest(self):
+        def test(self):
             """
             Execute synctest with the appropriate params.
             """
@@ -520,7 +502,7 @@ You may log something into the test logs using the methods in
 
     class output_test(Test):
 
-        def runTest(self):
+        def test(self):
             self.log.info('This goes to the log and it is only informational')
             self.log.warn('Oh, something unexpected, non-critical happened, '
                           'but we can continue.')
@@ -537,7 +519,7 @@ stderr streams, you can do something like::
 
     class output_test(Test):
 
-        def runTest(self):
+        def test(self):
             self.log.info('This goes to the log and it is only informational')
             self.stdout_log.info('This goes to the test stdout (will be recorded)')
             self.stderr_log.info('This goes to the test stderr (will be recorded)')
@@ -650,7 +632,7 @@ a timeout of 3 seconds before Avocado ends the test forcefully by sending a
         default_params = {'timeout': 3.0,
                           'sleep_time': 5.0}
 
-        def runTest(self):
+        def test(self):
             """
             This should throw a TestTimeoutError.
             """

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,7 +30,7 @@ extensions = ['sphinx.ext.autodoc',
 
 master_doc = 'index'
 project = u'Avocado'
-copyright = u'2014, Red Hat'
+copyright = u'2014-2015, Red Hat'
 
 version = avocado.version.VERSION
 release = avocado.version.VERSION

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -47,17 +47,17 @@ htmlhelp_basename = 'avocadodoc'
 
 latex_documents = [
     ('index', 'avocado.tex', u'avocado Documentation',
-     u'Lucas Meneghel Rodrigues', 'manual'),
+     u'Avocado Development Team', 'manual'),
 ]
 
 man_pages = [
     ('index', 'avocado', u'avocado Documentation',
-     [u'Lucas Meneghel Rodrigues'], 1)
+     [u'Avocado Development Team'], 1)
 ]
 
 texinfo_documents = [
     ('index', 'avocado', u'avocado Documentation',
-     u'Lucas Meneghel Rodrigues', 'avocado', 'One line description of project.',
+     u'Avocado Development Team', 'avocado', 'One line description of project.',
      'Miscellaneous'),
 ]
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,6 +19,7 @@ Contents:
    RemoteMachinePlugin
    DebuggingWithGDB
    WrapProcess
+   ReferenceGuide
    ContributionGuide
    DevelopmentTips
    api/modules

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,8 +9,8 @@ Contents:
 
    Introduction
    GetStartedGuide
-   Configuration
    WritingTests
+   Configuration
    ResultsSpecification
    MultiplexConfig
    Plugins

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,8 +1,3 @@
-.. avocado documentation master file, created by
-   sphinx-quickstart on Wed Mar  5 14:44:57 2014.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
 ======================
 Avocado Test Framework
 ======================


### PR DESCRIPTION
This is a general review of our documentation, both on a macro and micro level.

I've gone through the first sections thinking of myself as a novice user, and this has changed the organization of the Getting Started Guide.

There are still some tasks in progress or pending, including:
* The API docs reorganization, which is dependent on #636  and it's kept for a later PR
* The man-pages should comprehensively (automatically) include all command line options
* Reorganization of other sections

Changes from v1:
* Wording changes suggested by Lucas.
* Mention the function naming conventions for the test methods and
  link to PEP 8 relevant section for functions and classes.
* Break into finer grained sections.
* Updated Ubuntu repository version

---

This is a follow up of #639.