### PR TITLE
Silence broken plugins

### DIFF
--- a/avocado/core/plugins/builtin.py
+++ b/avocado/core/plugins/builtin.py
@@ -19,6 +19,7 @@ import logging
 from importlib import import_module
 
 from avocado.core.plugins.plugin import Plugin
+from avocado.settings import settings
 
 
 log = logging.getLogger("avocado.app")
@@ -46,13 +47,17 @@ def load_builtins():
     :return: a list of plugin classes, ordered by `priority`.
     """
     plugins = []
+    skip_notify = settings.get_value(section='plugins.load',
+                                     key='skip_broken_plugin_notification',
+                                     key_type=list)
     for module in Builtins:
         try:
             plugin_mod = import_module(module)
         except Exception as err:
             name = str(module)
             reason = '%s %s' % (str(err.__class__.__name__), err)
-            log.error('Error loading %s -> %s', name, reason)
+            if name not in skip_notify:
+                log.error('Error loading %s -> %s', name, reason)
             ErrorsLoading.append((name, reason))
             continue
         for name in plugin_mod.__dict__:

--- a/avocado/settings.py
+++ b/avocado/settings.py
@@ -15,6 +15,7 @@
 """
 Reads the avocado settings from a .ini file (from python ConfigParser).
 """
+import ast
 import ConfigParser
 import os
 import sys
@@ -129,8 +130,7 @@ def convert_value_type(value, value_type):
             return True
 
     if value_type == list:
-        # Split the string using ',' and return a list
-        return [val.strip() for val in sval.split(',')]
+        return ast.literal_eval(sval)
 
     conv_val = value_type(sval)
     return conv_val

--- a/etc/avocado/avocado.conf
+++ b/etc/avocado/avocado.conf
@@ -46,3 +46,11 @@ port = 9405
 username =
 # If authentication is set, pass password
 password =
+
+[plugins.load]
+# Suppress notification about broken plugins in the app standard error.
+# Add the name of each broken plugin you want to suppress the notification
+# in the list. The names can be easily seen from the stderr messages. Example:
+# avocado.core.plugins.htmlresult  ImportError No module named pystache
+# add 'avocado.core.plugins.htmlresult' as an element of the list below.
+skip_broken_plugin_notification = []

--- a/selftests/all/unit/avocado/settings_unittest.py
+++ b/selftests/all/unit/avocado/settings_unittest.py
@@ -20,7 +20,7 @@ str_key = frobnicate
 int_key = 1
 float_key = 1.25
 bool_key = True
-list_key = I, love, settings
+list_key = ['I', 'love', 'settings']
 empty_key =
 """
 


### PR DESCRIPTION
Implement Trello card:

https://trello.com/c/8Yth6z9a/399-allow-broken-plugins-to-be-silenced-by-configuration

Although my solution is a bit more flexible than what's described in the card. Let's discuss.