### PR TITLE
avocado.core.plugins.multiplexer: Support for --tree-view [v1]

### DIFF
--- a/avocado/core/plugins/multiplexer.py
+++ b/avocado/core/plugins/multiplexer.py
@@ -45,6 +45,9 @@ class Multiplexer(plugin.Plugin):
 
         self.parser.add_argument('--filter-out', nargs='*', default=[],
                                  help='Filter out path(s) from multiplexing')
+        self.parser.add_argument('-s', '--system-wide', action='store_true',
+                                 help="Combine the files with the default "
+                                 "tree.")
 
         self.parser.add_argument('-t', '--tree', action='store_true', default=False,
                                  help='Shows the multiplex tree structure')
@@ -58,6 +61,7 @@ class Multiplexer(plugin.Plugin):
                                  "files.")
         self.parser.add_argument('--env', default=[], nargs='*')
         super(Multiplexer, self).configure(self.parser)
+        self._from_args_tree = tree.TreeNode()
 
     def activate(self, args):
         # Extend default multiplex tree of --env values
@@ -67,9 +71,9 @@ class Multiplexer(plugin.Plugin):
                 raise ValueError("key:value pairs required, found only %s"
                                  % (value))
             elif len(value) == 2:
-                args.default_multiplex_tree.value[value[0]] = value[1]
+                self._from_args_tree.value[value[0]] = value[1]
             else:
-                node = args.default_multiplex_tree.get_node(value[0], True)
+                node = self._from_args_tree.get_node(value[0], True)
                 node.value[value[1]] = value[2]
 
     def run(self, args):
@@ -82,7 +86,9 @@ class Multiplexer(plugin.Plugin):
             view.notify(event='error',
                         msg=details.strerror)
             sys.exit(exit_codes.AVOCADO_JOB_FAIL)
-        mux_tree.merge(args.default_multiplex_tree)
+        if args.system_wide:
+            mux_tree.merge(args.default_multiplex_tree)
+        mux_tree.merge(self._from_args_tree)
         if args.tree:
             view.notify(event='message', msg='Config file tree structure:')
             view.notify(event='minor',

--- a/avocado/core/plugins/multiplexer.py
+++ b/avocado/core/plugins/multiplexer.py
@@ -54,6 +54,8 @@ class Multiplexer(plugin.Plugin):
         self.parser.add_argument('--attr', nargs='*', default=[],
                                  help="Which attributes to show when using "
                                  "--tree (default is 'name')")
+        self.parser.add_argument('-T', '--tree-view', action='store_true',
+                                 help='Shows the multiplex tree view')
         self.parser.add_argument('-c', '--contents', action='store_true', default=False,
                                  help="Shows the variant content (variables)")
         self.parser.add_argument('-d', '--debug', action='store_true',
@@ -93,6 +95,10 @@ class Multiplexer(plugin.Plugin):
             view.notify(event='message', msg='Config file tree structure:')
             view.notify(event='minor',
                         msg=mux_tree.get_ascii(attributes=args.attr))
+            sys.exit(exit_codes.AVOCADO_ALL_OK)
+        elif args.tree_view:
+            view.notify(event='message', msg=tree.tree_view(mux_tree,
+                                                            args.contents))
             sys.exit(exit_codes.AVOCADO_ALL_OK)
 
         variants = multiplexer.MuxTree(mux_tree)


### PR DESCRIPTION
This patchset adds the support for `--tree-view` and additionally tweaks the multiplexer plugin to allow enable/disable system-wide tree modifications (eg. branches added by avocado-virt).