### PR TITLE
avocado: Fix use of itervalues() in args dict

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -148,7 +148,8 @@ class Job(object):
         shutil.rmtree(self.logdir, ignore_errors=True)
 
     def _make_test_loader(self):
-        for loader_class_candidate in self.args.__dict__.itervalues():
+        for key in self.args.__dict__.keys():
+            loader_class_candidate = getattr(self.args, key)
             try:
                 if issubclass(loader_class_candidate, loader.TestLoader):
                     loader_plugin = loader_class_candidate(self)
@@ -168,7 +169,8 @@ class Job(object):
                                              test_result=self.result_proxy)
 
     def _set_output_plugins(self):
-        for result_class_candidate in self.args.__dict__.itervalues():
+        for key in self.args.__dict__.keys():
+            result_class_candidate = getattr(self.args, key)
             try:
                 if issubclass(result_class_candidate, result.TestResult):
                     result_plugin = result_class_candidate(self.view,

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -66,7 +66,8 @@ class TestLoaderProxy(object):
         self.loader_plugins.append(plugin)
 
     def load_plugins(self, args):
-        for loader_class_candidate in args.__dict__.itervalues():
+        for key in args.__dict__.keys():
+            loader_class_candidate = getattr(args, key)
             try:
                 if issubclass(loader_class_candidate, TestLoader):
                     loader_plugin = loader_class_candidate(args=args)


### PR DESCRIPTION
This fixes a bug introduced by cb751ea5e238cbfab735144173d56a1cc48e5ab5.
It turns out that .itervalues() is a bad idea, given that the
args dictionary is modified by plugins, leading to a bug when
we have multiple test source plugins enabled at once.

I'm sorry I didn't notice this before the commit was merged.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>