### PR TITLE
Add option to read a custom configuration from a file [v2]

### DIFF
--- a/avocado/core/parser.py
+++ b/avocado/core/parser.py
@@ -21,6 +21,7 @@ import sys
 import argparse
 
 from avocado.core import tree
+from avocado.core import settings
 from avocado.version import VERSION
 
 PROG = 'avocado'
@@ -45,6 +46,8 @@ class Parser(object):
         self.application.add_argument('--plugins', action='store',
                                       help='Load extra plugins from directory',
                                       dest='plugins_dir', default='')
+        self.application.add_argument('--config', metavar='CONFIG_FILE',
+                                      help='Use custom configuration from a file')
 
     def start(self):
         """
@@ -54,6 +57,10 @@ class Parser(object):
         Side effect: update attribute `args` (the namespace).
         """
         self.args, _ = self.application.parse_known_args()
+
+        # Load settings from file, if user provides one
+        if self.args.config is not None:
+            settings.settings.process_config_path(self.args.config)
 
         # Use parent parsing to avoid breaking the output of --help option
         self.application = argparse.ArgumentParser(prog=PROG,

--- a/avocado/core/settings.py
+++ b/avocado/core/settings.py
@@ -166,30 +166,30 @@ class Settings(object):
                                           config_path_intree])
             if config_intree:
                 # In this case, respect only the intree config
-                self._process_config_path(config_path_intree)
+                self.process_config_path(config_path_intree)
                 if config_intree_extra:
                     for extra_file in glob.glob(os.path.join(_config_path_intree_extra, '*.conf')):
-                        self._process_config_path(extra_file)
+                        self.process_config_path(extra_file)
                 self.intree = True
             else:
                 # In this case, load first the global config, then the
                 # local config overrides the global one
                 if config_system:
-                    self._process_config_path(config_path_system)
+                    self.process_config_path(config_path_system)
                     if config_system_extra:
                         for extra_file in glob.glob(os.path.join(_config_dir_system_extra, '*.conf')):
-                            self._process_config_path(extra_file)
+                            self.process_config_path(extra_file)
                 if not config_local:
                     path.init_dir(_config_dir_local)
                     with open(config_path_local, 'w') as config_local_fileobj:
                         config_local_fileobj.write('# You can use this file to override configuration values from '
                                                    '%s and %s\n' % (config_path_system, _config_dir_system_extra))
-                self._process_config_path(config_path_local)
+                self.process_config_path(config_path_local)
         else:
             # Unittests
-            self._process_config_path(config_path)
+            self.process_config_path(config_path)
 
-    def _process_config_path(self, pth):
+    def process_config_path(self, pth):
         read_configs = self.config.read(pth)
         if read_configs:
             self.config_paths += read_configs

--- a/man/avocado.rst
+++ b/man/avocado.rst
@@ -6,7 +6,7 @@
 SYNOPSIS
 ========
 
- avocado [-h] [-v] [--plugins PLUGINS_DIR]
+ avocado [-h] [-v] [--plugins PLUGINS_DIR] [--config CONFIG_FILE]
  {run,list,sysinfo,multiplex,plugins,datadir} ...
 
 DESCRIPTION
@@ -31,6 +31,7 @@ on them being loaded::
  -h, --help             show this help message and exit
  -v, --version          show program's version number and exit
  --plugins PLUGINS_DIR  Load extra plugins from directory
+ --config CONFIG_FILE   Use custom configuration from a file
 
 Real use of avocado depends on running avocado subcommands. This a typical list
 of avocado subcommands::


### PR DESCRIPTION
Changes from PR #657 

From @ldoktor suggestions...
* Fix typos
* Merge commits for the option --config and the man-page.
* Change order of commits, first to expose the method and then the commit to introduce the new option.
