### PR TITLE
setup.py: add missing module avocado.utils.external

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -108,6 +108,7 @@ if __name__ == '__main__':
                     'avocado.core',
                     'avocado.core.plugins',
                     'avocado.utils',
+                    'avocado.utils.external',
                     'avocado.core.remote',
                     'avocado.core.restclient',
                     'avocado.core.restclient.cli',


### PR DESCRIPTION
The new location was not reflected on the setup.py script, resulting
in the module not being present after installation.

Signed-off-by: Cleber Rosa <crosa@redhat.com>