### PR TITLE
avocado.core.plugins.multiplexer: Support for --tree-view [v2]

### DIFF
--- a/avocado/core/plugins/multiplexer.py
+++ b/avocado/core/plugins/multiplexer.py
@@ -130,10 +130,15 @@ class Multiplexer(plugin.Plugin):
             view.notify(event='minor', msg='%sVariant %s:    %s' %
                         (('\n' if args.contents else ''), index + 1, paths))
             if args.contents:
-                env = {}
+                env = set()
                 for node in tpl:
-                    env.update(node.environment)
-                for k in sorted(env.keys()):
-                    view.notify(event='minor', msg='    %s: %s' % (k, env[k]))
+                    for key, value in node.environment.iteritems():
+                        origin = node.environment_origin[key]
+                        env.add(("%s:%s" % (origin, key), repr(value)))
+                if not env:
+                    continue
+                fmt = '    %%-%ds => %%s' % max([len(_[0]) for _ in env])
+                for record in sorted(env):
+                    view.notify(event='minor', msg=fmt % record)
 
         sys.exit(exit_codes.AVOCADO_ALL_OK)

--- a/avocado/core/plugins/multiplexer.py
+++ b/avocado/core/plugins/multiplexer.py
@@ -45,6 +45,9 @@ class Multiplexer(plugin.Plugin):
 
         self.parser.add_argument('--filter-out', nargs='*', default=[],
                                  help='Filter out path(s) from multiplexing')
+        self.parser.add_argument('-s', '--system-wide', action='store_true',
+                                 help="Combine the files with the default "
+                                 "tree.")
 
         self.parser.add_argument('-t', '--tree', action='store_true', default=False,
                                  help='Shows the multiplex tree structure')
@@ -58,6 +61,7 @@ class Multiplexer(plugin.Plugin):
                                  "files.")
         self.parser.add_argument('--env', default=[], nargs='*')
         super(Multiplexer, self).configure(self.parser)
+        self._from_args_tree = tree.TreeNode()
 
     def activate(self, args):
         # Extend default multiplex tree of --env values
@@ -67,9 +71,9 @@ class Multiplexer(plugin.Plugin):
                 raise ValueError("key:value pairs required, found only %s"
                                  % (value))
             elif len(value) == 2:
-                args.default_multiplex_tree.value[value[0]] = value[1]
+                self._from_args_tree.value[value[0]] = value[1]
             else:
-                node = args.default_multiplex_tree.get_node(value[0], True)
+                node = self._from_args_tree.get_node(value[0], True)
                 node.value[value[1]] = value[2]
 
     def run(self, args):
@@ -82,7 +86,9 @@ class Multiplexer(plugin.Plugin):
             view.notify(event='error',
                         msg=details.strerror)
             sys.exit(exit_codes.AVOCADO_JOB_FAIL)
-        mux_tree.merge(args.default_multiplex_tree)
+        if args.system_wide:
+            mux_tree.merge(args.default_multiplex_tree)
+        mux_tree.merge(self._from_args_tree)
         if args.tree:
             view.notify(event='message', msg='Config file tree structure:')
             view.notify(event='minor',

--- a/avocado/core/plugins/multiplexer.py
+++ b/avocado/core/plugins/multiplexer.py
@@ -30,6 +30,10 @@ class Multiplexer(plugin.Plugin):
     name = 'multiplexer'
     enabled = True
 
+    def __init__(self, *args, **kwargs):
+        super(Multiplexer, self).__init__(*args, **kwargs)
+        self._from_args_tree = tree.TreeNode()
+
     def configure(self, parser):
         if multiplexer.MULTIPLEX_CAPABLE is False:
             self.enabled = False
@@ -63,7 +67,6 @@ class Multiplexer(plugin.Plugin):
                                  "files.")
         self.parser.add_argument('--env', default=[], nargs='*')
         super(Multiplexer, self).configure(self.parser)
-        self._from_args_tree = tree.TreeNode()
 
     def activate(self, args):
         # Extend default multiplex tree of --env values

--- a/avocado/core/plugins/multiplexer.py
+++ b/avocado/core/plugins/multiplexer.py
@@ -54,6 +54,8 @@ class Multiplexer(plugin.Plugin):
         self.parser.add_argument('--attr', nargs='*', default=[],
                                  help="Which attributes to show when using "
                                  "--tree (default is 'name')")
+        self.parser.add_argument('-T', '--tree-view', action='store_true',
+                                 help='Shows the multiplex tree view')
         self.parser.add_argument('-c', '--contents', action='store_true', default=False,
                                  help="Shows the variant content (variables)")
         self.parser.add_argument('-d', '--debug', action='store_true',
@@ -93,6 +95,10 @@ class Multiplexer(plugin.Plugin):
             view.notify(event='message', msg='Config file tree structure:')
             view.notify(event='minor',
                         msg=mux_tree.get_ascii(attributes=args.attr))
+            sys.exit(exit_codes.AVOCADO_ALL_OK)
+        elif args.tree_view:
+            view.notify(event='message', msg=tree.tree_view(mux_tree,
+                                                            args.contents))
             sys.exit(exit_codes.AVOCADO_ALL_OK)
 
         variants = multiplexer.MuxTree(mux_tree)

--- a/avocado/core/plugins/multiplexer.py
+++ b/avocado/core/plugins/multiplexer.py
@@ -66,6 +66,8 @@ class Multiplexer(plugin.Plugin):
                                  default=False, help="Debug multiplexed "
                                  "files.")
         self.parser.add_argument('--env', default=[], nargs='*')
+        tree_parser.add_argument('-e', '--environment', action="store_true",
+                                 help="Show environment rather than value")
         super(Multiplexer, self).configure(self.parser)
 
     def activate(self, args):
@@ -95,13 +97,14 @@ class Multiplexer(plugin.Plugin):
             mux_tree.merge(args.default_multiplex_tree)
         mux_tree.merge(self._from_args_tree)
         if args.tree:
-            view.notify(event='message', msg='Config file tree structure:')
-            view.notify(event='minor',
-                        msg=mux_tree.get_ascii(attributes=args.attr))
-            sys.exit(exit_codes.AVOCADO_ALL_OK)
-        elif args.tree_view:
+            if args.environment:
+                verbose = 2
+            elif args.contents:
+                verbose = 1
+            else:
+                verbose = 0
             view.notify(event='message', msg=tree.tree_view(mux_tree,
-                                                            args.contents))
+                                                            verbose))
             sys.exit(exit_codes.AVOCADO_ALL_OK)
 
         variants = multiplexer.MuxTree(mux_tree)

--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -238,7 +238,7 @@ class TreeNode(object):
                         self._environment[key] = value
                 else:
                     self._environment[key] = value
-                self.environment_origin[key] = self
+                self.environment_origin[key] = self.path
         return self._environment
 
     def set_environment_dirty(self):

--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -210,6 +210,8 @@ class TreeNode(object):
 
     def get_path(self, sep='/'):
         """ Get node path """
+        if not self.parent:
+            return sep + str(self.name)
         path = [str(self.name)]
         for node in self.iter_parents():
             path.append(str(node.name))

--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -658,8 +658,7 @@ def get_named_tree_cls(path):
     return NamedTreeNodeDebug
 
 
-def tree_view(root, content=True):
-
+def tree_view(root, verbose=None):
     """
     Generate tree-view of the given node
     :param root: root node
@@ -693,9 +692,14 @@ def tree_view(root, content=True):
             down_right = charset['DownRight']
             right = charset['Right']
         out = [node.name]
-        if content and node.value:
-            val = charset['Value']
+        if verbose == 1 and node.value:
             values = node.value.iteritems()
+        elif verbose > 1 and node.environment:
+            values = node.environment.iteritems()
+        else:
+            values = None
+        if values:
+            val = charset['Value']
             if node.children:
                 val_prefix = down + ' '
             else:
@@ -740,9 +744,15 @@ def tree_view(root, content=True):
         down_right = charset['DownRight']
         right = charset['Right']
     out = []
-    if content:
+    if verbose == 1:
+        values = root.value.iteritems()
+    elif verbose > 1:
+        values = root.environment.iteritems()
+    else:
+        values = None
+    if values:
         prefix = charset['Value'].lstrip()
-        for key, value in root.value.iteritems():
+        for key, value in values:
             out.extend(prefixed_write(prefix, key + ': ', value))
     if root.children:
         for child in root.children[:-1]:

--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -730,17 +730,18 @@ def tree_view(root, content=True):
     :return: string representing this node's tree structure
     """
 
-    def prefixed_write(prefix, value):
+    def prefixed_write(prefix1, prefix2, value):
         """
         Split value's lines and prepend empty prefix to 2nd+ lines
         :return: list of lines
         """
         value = str(value)
         if '\n' not in value:
-            return [prefix + value]
+            return [prefix1 + prefix2 + value]
         value = value.splitlines()
-        empty_prefix = ' ' * len(prefix)
-        return [prefix + value[0]] + [empty_prefix + _ for _ in value[1:]]
+        empty_prefix2 = ' ' * len(prefix2)
+        return [prefix1 + prefix2 + value[0]] + [prefix1 + empty_prefix2 +
+                                                 _ for _ in value[1:]]
 
     def process_node(node):
         """
@@ -755,20 +756,17 @@ def tree_view(root, content=True):
             down = charset['Down']
             down_right = charset['DownRight']
             right = charset['Right']
+        out = [node.name]
         if content and node.value:
             val = charset['Value']
             values = node.value.iteritems()
             if node.children:
-                val_prefix = down + ' ' * (len(node.name) + 1 - len(down))
+                val_prefix = down + ' '
             else:
-                val_prefix = ' ' * (len(node.name) + 1)
-            key, value = values.next()
-            out = prefixed_write(node.name + ' ' + val + key + ': ', value)
+                val_prefix = '    '
             for key, value in values:
-                out.extend(prefixed_write(val_prefix + val + key + ': ',
+                out.extend(prefixed_write(val_prefix, val + key + ': ',
                                           value))
-        else:
-            out = [node.name]
         if node.children:
             for child in node.children[:-1]:
                 lines = process_node(child)
@@ -808,7 +806,7 @@ def tree_view(root, content=True):
     if content:
         prefix = charset['Value'].lstrip()
         for key, value in root.value.iteritems():
-            out.extend(prefixed_write(prefix + key + ': ', value))
+            out.extend(prefixed_write(prefix, key + ': ', value))
     if root.children:
         for child in root.children[:-1]:
             lines = process_node(child)


### PR DESCRIPTION
This patchset adds the support for --tree-view and additionally tweaks the multiplexer plugin to allow enable/disable system-wide tree modifications (eg. branches added by avocado-virt).

v1: https://github.com/avocado-framework/avocado/pull/654

Changelog:

    v2: Align values inside the node
    v2: better locale handling
    v2: fix root node path
    v2: fix store origin as path rather than name
    v2: add possibility to show environment instead of values
    v2: reorganize arguments and handle clashes
    v2: add support for path in default/environment view

_NOTE: I added each new feature as separate commit to be able to remove them when we decide not to use it. The final version will have the patches reorganized and squashed. There is no need to point that something should be part of a different patch._