### PR TITLE
API Review: add test methods for SKIP/FAIL/ERROR themselves

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -491,6 +491,39 @@ class Test(unittest.TestCase):
             self.log.info("%s %s", self.status,
                           self.tagged_name)
 
+    def fail(self, message=None):
+        """
+        Fails the currently running test.
+
+        After calling this method a test will be terminated and have its status
+        as FAIL.
+
+        :param message: an optional message that will be recorded in the logs
+        :type message: str
+        """
+        raise exceptions.TestFail(message)
+
+    def error(self, message=None):
+        """
+        Errors the currently running test.
+
+        After calling this method a test will be terminated and have its status
+        as ERROR.
+
+        :param message: an optional message that will be recorded in the logs
+        :type message: str
+        """
+        raise exceptions.TestError(message)
+
+    def skip(self, message=None):
+        """
+        Skips the currently running test
+
+        :param message: an optional message that will be recorded in the logs
+        :type message: str
+        """
+        raise exceptions.TestNAError(message)
+
 
 class SimpleTest(Test):
 

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -360,6 +360,9 @@ class Test(unittest.TestCase):
         stderr_check_exception = None
         try:
             self.setUp()
+        except exceptions.TestNAError, details:
+            stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
+            raise exceptions.TestNAError(details)
         except Exception, details:
             stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
             raise exceptions.TestSetupFail(details)

--- a/examples/tests/doublefail.py
+++ b/examples/tests/doublefail.py
@@ -2,7 +2,6 @@
 
 from avocado import Test
 from avocado import main
-from avocado.core import exceptions
 
 
 class DoubleFail(Test):
@@ -15,13 +14,13 @@ class DoubleFail(Test):
         """
         Should fail.
         """
-        raise exceptions.TestFail('This test is supposed to fail')
+        raise self.fail('This test is supposed to fail')
 
     def tearDown(self):
         """
         Should also fail.
         """
-        raise exceptions.TestError('Failing during tearDown. Yay!')
+        raise self.error('Failing during tearDown. Yay!')
 
 
 if __name__ == "__main__":

--- a/examples/tests/errortest.py
+++ b/examples/tests/errortest.py
@@ -2,20 +2,19 @@
 
 from avocado import Test
 from avocado import main
-from avocado.core import exceptions
 
 
 class ErrorTest(Test):
 
     """
-    Functional test for avocado. Throw a TestError.
+    Example test that ends with ERROR.
     """
 
     def runTest(self):
         """
-        This should throw a TestError.
+        This should end with ERROR.
         """
-        raise exceptions.TestError('This should throw a TestError')
+        self.error('This should end with ERROR.')
 
 if __name__ == "__main__":
     main()

--- a/examples/tests/failtest.py
+++ b/examples/tests/failtest.py
@@ -2,20 +2,19 @@
 
 from avocado import Test
 from avocado import main
-from avocado.core import exceptions
 
 
 class FailTest(Test):
 
     """
-    Functional test for avocado. Straight up fail the test.
+    Example test for avocado. Straight up fail the test.
     """
 
     def runTest(self):
         """
         Should fail.
         """
-        raise exceptions.TestFail('This test is supposed to fail')
+        self.fail('This test is supposed to fail')
 
 
 if __name__ == "__main__":

--- a/examples/tests/skiponsetup.py
+++ b/examples/tests/skiponsetup.py
@@ -1,0 +1,20 @@
+#!/usr/bin/python
+
+from avocado import Test
+from avocado import main
+
+
+class SkipOnSetupTest(Test):
+
+    """
+    Example test that skips the current test, on the setUp phase.
+    """
+
+    def setUp(self):
+        """
+        This should end with SKIP.
+        """
+        self.skip('This should end with SKIP.')
+
+if __name__ == "__main__":
+    main()

--- a/examples/tests/skiptest.py
+++ b/examples/tests/skiptest.py
@@ -2,20 +2,19 @@
 
 from avocado import Test
 from avocado import main
-from avocado.core import exceptions
 
 
 class SkipTest(Test):
 
     """
-    Functional test for avocado. Throw a TestNAError (skips the test).
+    Example test that skips the current test, that is it, ends with SKIP.
     """
 
     def runTest(self):
         """
-        This should throw a TestNAError (skips the test).
+        This should end with SKIP.
         """
-        raise exceptions.TestNAError('This test should be skipped')
+        self.skip('This should end with SKIP.')
 
 if __name__ == "__main__":
     main()

--- a/examples/tests/warntest.py
+++ b/examples/tests/warntest.py
@@ -2,7 +2,6 @@
 
 from avocado import Test
 from avocado import main
-from avocado.core import exceptions
 
 
 class WarnTest(Test):

--- a/selftests/all/functional/avocado/basic_tests.py
+++ b/selftests/all/functional/avocado/basic_tests.py
@@ -491,6 +491,9 @@ class PluginsXunitTest(PluginsTest):
     def test_xunit_plugin_skiptest(self):
         self.run_and_check('skiptest', 0, 1, 0, 0, 0, 1)
 
+    def test_xunit_plugin_skiponsetuptest(self):
+        self.run_and_check('skiponsetup', 0, 1, 0, 0, 0, 1)
+
     def test_xunit_plugin_errortest(self):
         self.run_and_check('errortest', 1, 1, 1, 0, 0, 0)
 
@@ -548,6 +551,9 @@ class PluginsJSONTest(PluginsTest):
 
     def test_json_plugin_skiptest(self):
         self.run_and_check('skiptest', 0, 1, 0, 0, 1)
+
+    def test_json_plugin_skiponsetuptest(self):
+        self.run_and_check('skiponsetup', 0, 1, 0, 0, 1)
 
     def test_json_plugin_errortest(self):
         self.run_and_check('errortest', 1, 1, 1, 0, 0)


### PR DESCRIPTION
This introduces utility methods, preserves the example tests at their current location and add tests for skipping during `setUp()`.
