### PR TITLE
API review: implement relative imports also on avocado.core.*

### DIFF
--- a/avocado/core/app.py
+++ b/avocado/core/app.py
@@ -18,9 +18,9 @@ The core Avocado application.
 
 import os
 
-from avocado.core.log import configure
-from avocado.core.parser import Parser
-from avocado.core.plugins.manager import get_plugin_manager
+from .log import configure
+from .parser import Parser
+from .plugins.manager import get_plugin_manager
 
 
 class AvocadoApp(object):

--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -33,8 +33,8 @@ import shutil
 import time
 import tempfile
 
-from avocado.core import job_id
-from avocado.core.settings import settings
+from . import job_id
+from .settings import settings
 from avocado.utils import path as utils_path
 from avocado.utils.data_structures import Borg
 

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -27,26 +27,26 @@ import shutil
 import fnmatch
 
 from avocado import runtime
-from avocado.core import data_dir
-from avocado.core import runner
-from avocado.core import loader
-from avocado.core import sysinfo
-from avocado.core import result
-from avocado.core import exit_codes
-from avocado.core import exceptions
-from avocado.core import job_id
-from avocado.core import output
-from avocado.core import multiplexer
-from avocado.core.settings import settings
-from avocado.core.plugins import jsonresult
-from avocado.core.plugins import xunit
-from avocado.core.plugins.builtin import ErrorsLoading
+from . import data_dir
+from . import runner
+from . import loader
+from . import sysinfo
+from . import result
+from . import exit_codes
+from . import exceptions
+from . import job_id
+from . import output
+from . import multiplexer
+from .settings import settings
+from .plugins import jsonresult
+from .plugins import xunit
+from .plugins.builtin import ErrorsLoading
 from avocado.utils import archive
 from avocado.utils import path
 
 
 try:
-    from avocado.core.plugins import htmlresult
+    from .plugins import htmlresult
     HTML_REPORT_SUPPORT = True
 except ImportError:
     HTML_REPORT_SUPPORT = False

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -23,10 +23,10 @@ import os
 import re
 import sys
 
-from avocado.core import data_dir
-from avocado.core import test
+from . import data_dir
+from . import test
+from . import output
 from avocado.utils import path
-from avocado.core import output
 
 try:
     import cStringIO as StringIO

--- a/avocado/core/multiplexer.py
+++ b/avocado/core/multiplexer.py
@@ -24,7 +24,7 @@ import itertools
 import logging
 import re
 
-from avocado.core import tree
+from . import tree
 
 
 MULTIPLEX_CAPABLE = tree.MULTIPLEX_CAPABLE

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -19,8 +19,8 @@ import logging
 import os
 import sys
 
+from .settings import settings
 from avocado.utils import path as utils_path
-from avocado.core.settings import settings
 
 
 class FilterError(logging.Filter):

--- a/avocado/core/parser.py
+++ b/avocado/core/parser.py
@@ -20,8 +20,8 @@ Avocado application command line parsing.
 import sys
 import argparse
 
-from avocado.core import tree
-from avocado.core import settings
+from . import tree
+from . import settings
 from avocado.version import VERSION
 
 PROG = 'avocado'

--- a/avocado/core/plugins/builtin.py
+++ b/avocado/core/plugins/builtin.py
@@ -18,8 +18,8 @@ import os
 import logging
 from importlib import import_module
 
-from avocado.core.plugins.plugin import Plugin
-from avocado.core.settings import settings
+from .plugin import Plugin
+from ..settings import settings
 
 
 log = logging.getLogger("avocado.app")

--- a/avocado/core/plugins/config.py
+++ b/avocado/core/plugins/config.py
@@ -12,10 +12,10 @@
 # Copyright: Red Hat Inc. 2013-2014
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
-from avocado.core import output
-from avocado.core import data_dir
-from avocado.core.settings import settings
-from avocado.core.plugins import plugin
+from . import plugin
+from .. import output
+from .. import data_dir
+from ..settings import settings
 
 
 class ConfigOptions(plugin.Plugin):

--- a/avocado/core/plugins/distro.py
+++ b/avocado/core/plugins/distro.py
@@ -17,9 +17,9 @@ import bz2
 import sys
 import json
 
-from avocado.core import output
-from avocado.core import exit_codes
-from avocado.core.plugins import plugin
+from . import plugin
+from .. import output
+from .. import exit_codes
 from avocado.utils import process
 from avocado.utils import path as utils_path
 from avocado.utils import distro as utils_distro

--- a/avocado/core/plugins/exec_path.py
+++ b/avocado/core/plugins/exec_path.py
@@ -17,8 +17,8 @@ Libexec PATHs modifier
 import os
 import sys
 
-from avocado.core import exit_codes, output
-from avocado.core.plugins import plugin
+from . import plugin
+from .. import exit_codes, output
 
 
 class ExecPath(plugin.Plugin):

--- a/avocado/core/plugins/gdb.py
+++ b/avocado/core/plugins/gdb.py
@@ -16,8 +16,8 @@
 
 from avocado import runtime
 from avocado.utils import path as utils_path
-from avocado.core.plugins import plugin
-from avocado.core.settings import settings
+from . import plugin
+from ..settings import settings
 
 
 class GDB(plugin.Plugin):

--- a/avocado/core/plugins/htmlresult.py
+++ b/avocado/core/plugins/htmlresult.py
@@ -22,12 +22,12 @@ import time
 import subprocess
 import pystache
 
+from . import plugin
+from .. import exit_codes
+from .. import output
+from ..result import TestResult
 from avocado import runtime
-from avocado.core import exit_codes
-from avocado.core import output
-from avocado.core.result import TestResult
 from avocado.utils import path as utils_path
-from avocado.core.plugins import plugin
 
 
 class ReportModel(object):

--- a/avocado/core/plugins/journal.py
+++ b/avocado/core/plugins/journal.py
@@ -18,8 +18,8 @@ import os
 import sqlite3
 import datetime
 
-from avocado.core.plugins import plugin
-from avocado.core.result import TestResult
+from . import plugin
+from ..result import TestResult
 
 
 JOURNAL_FILENAME = ".journal.sqlite"

--- a/avocado/core/plugins/jsonresult.py
+++ b/avocado/core/plugins/jsonresult.py
@@ -18,9 +18,9 @@ JSON output module.
 
 import json
 
-from avocado.core import output
-from avocado.core.result import TestResult
-from avocado.core.plugins import plugin
+from . import plugin
+from .. import output
+from ..result import TestResult
 
 
 class JSONTestResult(TestResult):

--- a/avocado/core/plugins/manager.py
+++ b/avocado/core/plugins/manager.py
@@ -16,8 +16,8 @@
 
 import logging
 
-from avocado.core.plugins.builtin import load_builtins
-from avocado.core.plugins.plugin import Plugin
+from .builtin import load_builtins
+from .plugin import Plugin
 
 
 DefaultPluginManager = None

--- a/avocado/core/plugins/multiplexer.py
+++ b/avocado/core/plugins/multiplexer.py
@@ -14,11 +14,11 @@
 
 import sys
 
-from avocado.core.plugins import plugin
-from avocado.core import output
-from avocado.core import exit_codes
-from avocado.core import tree
-from avocado.core import multiplexer
+from . import plugin
+from .. import output
+from .. import exit_codes
+from .. import tree
+from .. import multiplexer
 
 
 class Multiplexer(plugin.Plugin):

--- a/avocado/core/plugins/plugin_list.py
+++ b/avocado/core/plugins/plugin_list.py
@@ -12,10 +12,10 @@
 # Copyright: Red Hat Inc. 2013-2014
 # Author: Ruda Moura <rmoura@redhat.com>
 
-from avocado.core import output
-from avocado.core.plugins import plugin
-from avocado.core.plugins.builtin import ErrorsLoading
-from avocado.core.plugins.manager import get_plugin_manager
+from . import plugin
+from .builtin import ErrorsLoading
+from .manager import get_plugin_manager
+from .. import output
 
 
 class PluginList(plugin.Plugin):

--- a/avocado/core/plugins/remote.py
+++ b/avocado/core/plugins/remote.py
@@ -16,9 +16,9 @@
 
 import getpass
 
-from avocado.core.plugins import plugin
-from avocado.core.remote import RemoteTestResult
-from avocado.core.remote import RemoteTestRunner
+from . import plugin
+from ..remote import RemoteTestResult
+from ..remote import RemoteTestRunner
 from avocado.utils import remote
 
 

--- a/avocado/core/plugins/runner.py
+++ b/avocado/core/plugins/runner.py
@@ -18,12 +18,12 @@ Base Test Runner Plugins.
 
 import sys
 
-from avocado.core.settings import settings
-from avocado.core import exit_codes
-from avocado.core.plugins import plugin
-from avocado.core import output
-from avocado.core import job
-from avocado.core import multiplexer
+from . import plugin
+from .. import exit_codes
+from .. import output
+from .. import job
+from .. import multiplexer
+from ..settings import settings
 
 
 class TestRunner(plugin.Plugin):

--- a/avocado/core/plugins/sysinfo.py
+++ b/avocado/core/plugins/sysinfo.py
@@ -15,8 +15,8 @@
 System information plugin
 """
 
-from avocado.core import sysinfo
-from avocado.core.plugins import plugin
+from . import plugin
+from .. import sysinfo
 
 
 class SystemInformation(plugin.Plugin):

--- a/avocado/core/plugins/test_list.py
+++ b/avocado/core/plugins/test_list.py
@@ -14,12 +14,12 @@
 
 import sys
 
-from avocado.core import test
-from avocado.core import loader
-from avocado.core import output
-from avocado.core import exit_codes
+from . import plugin
+from .. import test
+from .. import loader
+from .. import output
+from .. import exit_codes
 from avocado.utils import astring
-from avocado.core.plugins import plugin
 
 
 class TestLister(object):

--- a/avocado/core/plugins/vm.py
+++ b/avocado/core/plugins/vm.py
@@ -16,9 +16,9 @@
 
 import getpass
 
-from avocado.core.plugins import plugin
-from avocado.core.remote import VMTestResult
-from avocado.core.remote import RemoteTestRunner
+from . import plugin
+from ..remote import VMTestResult
+from ..remote import RemoteTestRunner
 from avocado.utils import virt
 
 

--- a/avocado/core/plugins/wrapper.py
+++ b/avocado/core/plugins/wrapper.py
@@ -15,10 +15,10 @@
 import os
 import sys
 
+from . import plugin
+from .. import exit_codes
+from .. import output
 from avocado import runtime
-from avocado.core import exit_codes
-from avocado.core import output
-from avocado.core.plugins import plugin
 
 
 class Wrapper(plugin.Plugin):

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -26,11 +26,11 @@ import sys
 import time
 
 from avocado import runtime
-from avocado.core import test
-from avocado.core import exceptions
-from avocado.core import output
-from avocado.core import status
-from avocado.core import exit_codes
+from . import test
+from . import exceptions
+from . import output
+from . import status
+from . import exit_codes
 from avocado.utils import wait
 from avocado.utils import stacktrace
 

--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -23,12 +23,12 @@ try:
 except ImportError:
     import subprocess
 
+from . import output
+from .settings import settings
 from avocado.utils import genio
 from avocado.utils import process
 from avocado.utils import software_manager
 from avocado.utils import path as utils_path
-from avocado.core import output
-from avocado.core.settings import settings
 
 log = logging.getLogger("avocado.sysinfo")
 

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -31,10 +31,10 @@ if sys.version_info[:2] == (2, 6):
 else:
     import unittest
 
-from avocado.core import data_dir
-from avocado.core import sysinfo
-from avocado.core import exceptions
-from avocado.core import multiplexer
+from . import data_dir
+from . import sysinfo
+from . import exceptions
+from . import multiplexer
 from avocado.utils import genio
 from avocado.utils import path as utils_path
 from avocado.utils import process

--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -49,7 +49,7 @@ else:
     except ImportError:
         from yaml import Loader
 
-from avocado.core import output
+from . import output
 
 # Mapping for yaml flags
 YAML_INCLUDE = 0


### PR DESCRIPTION
The same approach has already been applied to avocado.utils itself.

The references to avocado.utils in avocado.core, though, were not
made relative. The reason is that, according to the PEP 328, going
up three levels while "legal, it's certainly discouraged"[1].

If we reach a consensus that we should do it all the way, then
another commit can deal with that. If not, we may even think about
making avocado.utils a library (repo?) by itself.

[1] - https://www.python.org/dev/peps/pep-0328/#guido-s-decision

Signed-off-by: Cleber Rosa <crosa@redhat.com>