### PR TITLE
[option 2] avocado.core.test: Fix problem with unittest compatibility

### DIFF
--- a/avocado/core/exceptions.py
+++ b/avocado/core/exceptions.py
@@ -130,10 +130,14 @@ class TestNAError(TestBaseException):
     status = "TEST_NA"
 
 
-class TestFail(TestBaseException):
+class TestFail(AssertionError):
 
     """
-    Indicates that the test failed. The test job will continue, though.
+    Indicates that the test failed.
+
+    TestFail inherits from AssertionError in order to keep compatibility
+    with vanilla python unittests (they only consider failures the ones
+    deriving from AssertionError).
     """
     status = "FAIL"
 

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -300,17 +300,6 @@ class Test(unittest.TestCase):
         """
         pass
 
-    def runTest(self):
-        """
-        Actual test payload. Must be implemented by tests.
-
-        In case of an existing test suite wrapper, it'll execute the suite,
-        or perform a series of operations, and based in the results of the
-        operations decide if the test pass (let the test complete) or fail
-        (raise a test related exception).
-        """
-        pass
-
     def tearDown(self):
         """
         Cleanup stage after the runTest is done.
@@ -345,11 +334,9 @@ class Test(unittest.TestCase):
                    'Actual:\n%s\nExpected:\n%s' % (actual, expected))
             self.assertEqual(expected, actual, msg)
 
-    def run(self, result=None):
+    def _run_avocado(self):
         """
-        Run test method, for compatibility with unittest.TestCase.
-
-        :result: Unused param, compatibiltiy with :class:`unittest.TestCase`.
+        Auxiliary method to run_avocado.
         """
         testMethod = getattr(self, self._testMethodName)
         self.start_logging()
@@ -437,7 +424,7 @@ class Test(unittest.TestCase):
         os.environ['AVOCADO_TEST_OUTPUTDIR'] = self.outputdir
         os.environ['AVOCADO_TEST_SYSINFODIR'] = self.sysinfodir
 
-    def run_avocado(self, result=None):
+    def run_avocado(self):
         """
         Wraps the run method, for execution inside the avocado runner.
 
@@ -446,7 +433,7 @@ class Test(unittest.TestCase):
         self._setup_environment_variables()
         try:
             self.tag_start()
-            self.run(result)
+            self._run_avocado()
         except exceptions.TestBaseException, detail:
             self.status = detail.status
             self.fail_class = detail.__class__.__name__

--- a/examples/tests/skiponsetup.py
+++ b/examples/tests/skiponsetup.py
@@ -16,5 +16,11 @@ class SkipOnSetupTest(Test):
         """
         self.skip('This should end with SKIP.')
 
+    def test_wont_be_executed(self):
+        """
+        This won't get to be executed, given that setUp calls .skip().
+        """
+        pass
+
 if __name__ == "__main__":
     main()

--- a/selftests/all/functional/avocado/unittest_compat.py
+++ b/selftests/all/functional/avocado/unittest_compat.py
@@ -1,0 +1,95 @@
+import os
+import sys
+
+if sys.version_info[:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
+
+# simple magic for using scripts within a source tree
+basedir = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), '..', '..', '..', '..')
+basedir = os.path.abspath(basedir)
+if os.path.isdir(os.path.join(basedir, 'avocado')):
+    sys.path.append(basedir)
+
+from avocado.utils import script
+from avocado.utils import process
+
+UNITTEST_GOOD = """from avocado import Test
+from unittest import main
+class AvocadoPassTest(Test):
+    def runTest(self):
+        self.assertTrue(True)
+if __name__ == '__main__':
+    main()
+"""
+
+UNITTEST_FAIL = """from avocado import Test
+from unittest import main
+class AvocadoFailTest(Test):
+    def runTest(self):
+        self.fail('This test is supposed to fail')
+if __name__ == '__main__':
+    main()
+"""
+
+UNITTEST_ERROR = """from avocado import Test
+from unittest import main
+class AvocadoErrorTest(Test):
+    def runTest(self):
+        self.error('This test is supposed to error')
+if __name__ == '__main__':
+    main()
+"""
+
+
+class UnittestCompat(unittest.TestCase):
+
+    def setUp(self):
+        self.original_pypath = os.environ.get('PYTHONPATH')
+        if self.original_pypath is not None:
+            os.environ['PYTHONPATH'] = '%s:%s' % (
+                basedir, self.original_pypath)
+        else:
+            os.environ['PYTHONPATH'] = '%s' % basedir
+        self.unittest_script_good = script.TemporaryScript(
+            'unittest_good.py',
+            UNITTEST_GOOD,
+            'avocado_as_unittest_functional')
+        self.unittest_script_good.save()
+        self.unittest_script_fail = script.TemporaryScript(
+            'unittest_fail.py',
+            UNITTEST_FAIL,
+            'avocado_as_unittest_functional')
+        self.unittest_script_fail.save()
+        self.unittest_script_error = script.TemporaryScript(
+            'unittest_error.py',
+            UNITTEST_ERROR,
+            'avocado_as_unittest_functional')
+        self.unittest_script_error.save()
+
+    def test_run_pass(self):
+        cmd_line = '%s %s' % (sys.executable, self.unittest_script_good)
+        result = process.run(cmd_line)
+        self.assertEqual(0, result.exit_status)
+        self.assertIn('Ran 1 test in', result.stderr)
+
+    def test_run_fail(self):
+        cmd_line = '%s %s' % (sys.executable, self.unittest_script_fail)
+        result = process.run(cmd_line, ignore_status=True)
+        self.assertEqual(1, result.exit_status)
+        self.assertIn('Ran 1 test in', result.stderr)
+        self.assertIn('This test is supposed to fail', result.stderr)
+        self.assertIn('FAILED (failures=1)', result.stderr)
+
+    def test_run_error(self):
+        cmd_line = '%s %s' % (sys.executable, self.unittest_script_error)
+        result = process.run(cmd_line, ignore_status=True)
+        self.assertEqual(1, result.exit_status)
+        self.assertIn('Ran 1 test in', result.stderr)
+        self.assertIn('This test is supposed to error', result.stderr)
+        self.assertIn('FAILED (errors=1)', result.stderr)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/selftests/all/unit/avocado/jsonresult_unittest.py
+++ b/selftests/all/unit/avocado/jsonresult_unittest.py
@@ -41,6 +41,12 @@ class _Stream(object):
 class JSONResultTest(unittest.TestCase):
 
     def setUp(self):
+
+        class SimpleTest(Test):
+
+            def runTest(self):
+                pass
+
         self.tmpfile = tempfile.mkstemp()
         self.tmpdir = tempfile.mkdtemp()
         args = argparse.Namespace(json_output=self.tmpfile[1])
@@ -49,7 +55,7 @@ class JSONResultTest(unittest.TestCase):
         self.test_result = jsonresult.JSONTestResult(stream, args)
         self.test_result.filename = self.tmpfile[1]
         self.test_result.start_tests()
-        self.test1 = Test(job=job.Job(), base_logdir=self.tmpdir)
+        self.test1 = SimpleTest(job=job.Job(), base_logdir=self.tmpdir)
         self.test1.status = 'PASS'
         self.test1.time_elapsed = 1.23
 

--- a/selftests/all/unit/avocado/test_unittest.py
+++ b/selftests/all/unit/avocado/test_unittest.py
@@ -36,26 +36,11 @@ class TestClassTest(unittest.TestCase):
                 self.assertTrue(variable)
                 self.whiteboard = 'foo'
 
-        class EmptyTest(test.Test):
-
-            """
-            I don't have runTest() defined!
-            """
-            pass
-
         self.base_logdir = tempfile.mkdtemp(prefix='avocado_test_unittest')
         self.tst_instance_pass = AvocadoPass(base_logdir=self.base_logdir)
         self.tst_instance_pass.run_avocado()
         self.tst_instance_pass_new = AvocadoPass(base_logdir=self.base_logdir)
         self.tst_instance_pass_new.run_avocado()
-        self.tst_instance_empty = EmptyTest(base_logdir=self.base_logdir)
-        self.tst_instance_empty.run_avocado()
-
-    def testRunTest(self):
-        self.assertEqual(self.tst_instance_empty.runTest(), None)
-
-    def testRunAvocado(self):
-        self.assertEqual(self.tst_instance_empty.status, 'PASS')
 
     def testClassAttributesName(self):
         self.assertEqual(self.tst_instance_pass.name, 'AvocadoPass')

--- a/selftests/all/unit/avocado/xunit_unittest.py
+++ b/selftests/all/unit/avocado/xunit_unittest.py
@@ -45,13 +45,19 @@ class _Stream(object):
 class xUnitSucceedTest(unittest.TestCase):
 
     def setUp(self):
+
+        class SimpleTest(Test):
+
+            def runTest(self):
+                pass
+
         self.tmpfile = tempfile.mkstemp()
         self.tmpdir = tempfile.mkdtemp()
         args = argparse.Namespace()
         args.xunit_output = self.tmpfile[1]
         self.test_result = xunit.xUnitTestResult(stream=_Stream(), args=args)
         self.test_result.start_tests()
-        self.test1 = Test(job=job.Job(), base_logdir=self.tmpdir)
+        self.test1 = SimpleTest(job=job.Job(), base_logdir=self.tmpdir)
         self.test1.status = 'PASS'
         self.test1.time_elapsed = 1.23
 


### PR DESCRIPTION
Introduced with commit d6abdcd4a6ea382c0447ece49f983b37823de245,
avocado tests no longer report correctly to the unittest runner.
The reason is that there is a structure that must be correctly
updated by the run() method (the result instance), that was not
being updated in the new implementation.

Therefore, one possible fix, presented here, is to once again
*not* implement run() at all. this way we avoid messing around
with internal data structures, and when avocado is executed
under nosetests, or the default unittest runner, we get the
expected behavior of the method. The downside is that we have
less perceived integration among both classes.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>