### PR TITLE
 core.loader: Log discover_url exceptions [v1]

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -26,7 +26,7 @@ import sys
 from . import data_dir
 from . import test
 from . import output
-from ..utils import path
+from ..utils import path, stacktrace
 
 try:
     import cStringIO as StringIO
@@ -122,8 +122,14 @@ class TestLoaderProxy(object):
                             self.url_plugin_mapping[url] = loader_plugin
                         if loader_plugin == self.url_plugin_mapping[url]:
                             test_factories += loader_plugin.discover(params_list_from_url)
-                except Exception:
-                    continue
+                except Exception, details:
+                    # FIXME: Introduce avocado.exceptions logger and use here
+                    stacktrace.log_message("Test discovery plugin %s failed: "
+                                           "%s" % (loader_plugin, details),
+                                           'avocado.app.exceptions')
+                    # FIXME: Introduce avocado.traceback logger and use here
+                    stacktrace.log_exc_info(sys.exc_info(),
+                                            'avocado.app.tracebacks')
         return test_factories
 
     def validate_ui(self, test_suite, ignore_missing=False,

--- a/avocado/utils/stacktrace.py
+++ b/avocado/utils/stacktrace.py
@@ -3,6 +3,7 @@ Traceback standard module plus some additional APIs.
 """
 from traceback import format_exception
 import logging
+import inspect
 
 
 def tb_info(exc_info):
@@ -33,6 +34,9 @@ def log_exc_info(exc_info, logger='root'):
     """
     log = logging.getLogger(logger)
     log.error('')
+    called_from = inspect.currentframe().f_back
+    log.error("Reproduced traceback from: %s:%s",
+              called_from.f_code.co_filename, called_from.f_lineno)
     for line in tb_info(exc_info):
         for l in line.splitlines():
             log.error(l)

--- a/avocado/utils/stacktrace.py
+++ b/avocado/utils/stacktrace.py
@@ -41,3 +41,15 @@ def log_exc_info(exc_info, logger='root'):
         for l in line.splitlines():
             log.error(l)
     log.error('')
+
+
+def log_message(message, logger='root'):
+    """
+    Log message to logger.
+
+    :param message: Message
+    :param logger: Name of the logger (defaults to root)
+    """
+    log = logging.getLogger(logger)
+    for line in message.splitlines():
+        log.error(line)


### PR DESCRIPTION
The `discover_url` function should not fail, instead it should return
empty results. In case of failure, it's impossible to find out what
went wrong as we don't log any details, thus it might happen that
`avocado list` shows tests, which are not found during `avocado run`.
This patch temporarily logs reason into the `avocado.app.exceptions`
and traceback into the `avocado.app.traceback` logger. Booth are
enabled by default, but the plan is to make these optional and
show only the `exceptions` by default.