### PR TITLE
[V2] job results: log/record the command line options, config and multiplexing tree (human readable)

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -415,9 +415,9 @@ class Job(object):
         """
         self._log_cmdline()
         self._log_avocado_version()
+        self._log_avocado_plugins()
         self._log_avocado_config()
         self._log_avocado_datadir()
-        self._log_avocado_plugins()
         self._log_mux_tree(mux)
         self._log_job_id()
 

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -290,6 +290,25 @@ class Job(object):
                     filtered_suite.append(test_template)
         return filtered_suite
 
+    @staticmethod
+    def _log_plugin_load_errors():
+        job_log = _TEST_LOGGER
+        for plugin_failed in ErrorsLoading:
+            job_log.error('Error loading %s -> %s' % plugin_failed)
+        job_log.error('')
+
+    def _log_job_id(self):
+        job_log = _TEST_LOGGER
+        job_log.info('Job ID: %s', self.unique_id)
+        job_log.info('')
+
+    def _log_job_debug_info(self):
+        """
+        Log relevant debug information to the job log.
+        """
+        self._log_plugin_load_errors()
+        self._log_job_id()
+
     def _run(self, urls=None):
         """
         Unhandled job method. Runs a list of test URLs to its completion.
@@ -327,12 +346,7 @@ class Job(object):
                                      self.loglevel,
                                      self.unique_id)
 
-        for plugin_failed in ErrorsLoading:
-            _TEST_LOGGER.error('Error loading %s -> %s' % plugin_failed)
-        _TEST_LOGGER.error('')
-
-        _TEST_LOGGER.info('Job ID: %s', self.unique_id)
-        _TEST_LOGGER.info('')
+        self._log_job_debug_info()
 
         self.view.logfile = self.logfile
         failures = self.test_runner.run_suite(test_suite, mux,

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -37,6 +37,7 @@ from . import exceptions
 from . import job_id
 from . import output
 from . import multiplexer
+from . import tree
 from .settings import settings
 from .plugins import jsonresult
 from .plugins import xunit
@@ -383,7 +384,17 @@ class Job(object):
 
         job_log.info('')
 
-    def _log_job_debug_info(self):
+    def _log_mux_tree(self, mux):
+        job_log = _TEST_LOGGER
+        tree_repr = tree.tree_view(mux.variants.tree, verbose=True,
+                                   use_utf8=False)
+        if tree_repr:
+            job_log.info('Multiplex tree representation:')
+            for line in tree_repr.splitlines():
+                job_log.info(line)
+            job_log.info('')
+
+    def _log_job_debug_info(self, mux):
         """
         Log relevant debug information to the job log.
         """
@@ -391,6 +402,7 @@ class Job(object):
         self._log_avocado_version()
         self._log_avocado_config()
         self._log_avocado_plugins()
+        self._log_mux_tree(mux)
         self._log_job_id()
 
     def _run(self, urls=None):
@@ -430,7 +442,7 @@ class Job(object):
                                      self.loglevel,
                                      self.unique_id)
 
-        self._log_job_debug_info()
+        self._log_job_debug_info(mux)
 
         self.view.logfile = self.logfile
         failures = self.test_runner.run_suite(test_suite, mux,

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -325,6 +325,32 @@ class Job(object):
                                             "--abbrev-ref HEAD"))
         job_log.info('')
 
+    @staticmethod
+    def _log_avocado_config():
+        job_log = _TEST_LOGGER
+        job_log.info('Config files read (in order):')
+        for cfg_path in settings.config_paths:
+            job_log.info(cfg_path)
+        if settings.config_paths_failed:
+            job_log.info('Config files failed to read (in order):')
+            for cfg_path in settings.config_paths_failed:
+                job_log.info(cfg_path)
+        job_log.info('')
+        blength = 0
+        for section in settings.config.sections():
+            for value in settings.config.items(section):
+                clength = len('%s.%s' % (section, value[0]))
+                if clength > blength:
+                    blength = clength
+        job_log.info('Avocado config:')
+        format_str = "%-" + str(blength) + "s %s"
+        job_log.info(format_str % ('Section.Key', 'Value'))
+        for section in settings.config.sections():
+            for value in settings.config.items(section):
+                config_key = ".".join((section, value[0]))
+                job_log.info(format_str % (config_key, value[1]))
+        job_log.info('')
+
     def _log_job_debug_info(self):
         """
         Log relevant debug information to the job log.
@@ -332,6 +358,7 @@ class Job(object):
         self._log_plugin_load_errors()
         self._log_cmdline()
         self._log_avocado_version()
+        self._log_avocado_config()
         self._log_job_id()
 
     def _run(self, urls=None):

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -344,6 +344,21 @@ class Job(object):
             for value in settings.config.items(section):
                 config_key = ".".join((section, value[0]))
                 job_log.info(format_str % (config_key, value[1]))
+
+    @staticmethod
+    def _log_avocado_datadir():
+        job_log = _TEST_LOGGER
+        job_log.info('')
+        job_log.info('Avocado Data Directories:')
+        job_log.info('')
+        job_log.info("Avocado replaces config dirs that can't be accessed")
+        job_log.info('with sensible defaults. Please edit your local config')
+        job_log.info('file to customize values')
+        job_log.info('')
+        job_log.info('base     ' + data_dir.get_base_dir())
+        job_log.info('tests    ' + data_dir.get_test_dir())
+        job_log.info('data     ' + data_dir.get_data_dir())
+        job_log.info('logs     ' + data_dir.get_logs_dir())
         job_log.info('')
 
     @staticmethod
@@ -401,6 +416,7 @@ class Job(object):
         self._log_cmdline()
         self._log_avocado_version()
         self._log_avocado_config()
+        self._log_avocado_datadir()
         self._log_avocado_plugins()
         self._log_mux_tree(mux)
         self._log_job_id()

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -302,11 +302,19 @@ class Job(object):
         job_log.info('Job ID: %s', self.unique_id)
         job_log.info('')
 
+    @staticmethod
+    def _log_cmdline():
+        job_log = _TEST_LOGGER
+        cmdline = " ".join(sys.argv)
+        job_log.info("Command line: %s", cmdline)
+        job_log.info('')
+
     def _log_job_debug_info(self):
         """
         Log relevant debug information to the job log.
         """
         self._log_plugin_load_errors()
+        self._log_cmdline()
         self._log_job_id()
 
     def _run(self, urls=None):

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -26,6 +26,7 @@ import tempfile
 import shutil
 import fnmatch
 
+from . import version
 from . import data_dir
 from . import runner
 from . import loader
@@ -309,12 +310,28 @@ class Job(object):
         job_log.info("Command line: %s", cmdline)
         job_log.info('')
 
+    @staticmethod
+    def _log_avocado_version():
+        job_log = _TEST_LOGGER
+        job_log.info('Avocado version: %s', version.VERSION)
+        if os.path.exists('.git') and os.path.exists('avocado.spec'):
+            job_log.info('Avocado git repo info')
+            import commands
+            job_log.info("Top commit: %s",
+                         commands.getoutput("git show --summary "
+                                            "--pretty='%H' | head -1"))
+            job_log.info("Branch: %s",
+                         commands.getoutput("git rev-parse "
+                                            "--abbrev-ref HEAD"))
+        job_log.info('')
+
     def _log_job_debug_info(self):
         """
         Log relevant debug information to the job log.
         """
         self._log_plugin_load_errors()
         self._log_cmdline()
+        self._log_avocado_version()
         self._log_job_id()
 
     def _run(self, urls=None):

--- a/avocado/core/multiplexer.py
+++ b/avocado/core/multiplexer.py
@@ -42,6 +42,7 @@ class MuxTree(object):
         """
         :param root: Root of this tree slice
         """
+        self.tree = root
         self.pools = []
         for node in self._iter_mux_leaves(root):
             if node.is_leaf:


### PR DESCRIPTION
This implements: https://trello.com/c/jP6FD8bF/386-job-results-log-record-the-command-line-options-config-and-multiplexing-tree-human-readable.

Add the following information to the job log:
 * command line
 * version information
 * config information
 * plugins status
 * multiplex tree representation

To help with debug and bug fixing.

You can see a job log example here -> https://gist.github.com/lmr/5055dbe5b1dd2eebe7b5

Changes from v1:
 * Fixed unittests
 * Added multiplex tree representaion