### PR TITLE
multiplexer: Change the --mux-entry to --mux-path

### DIFF
--- a/avocado/core/multiplexer.py
+++ b/avocado/core/multiplexer.py
@@ -127,21 +127,21 @@ class AvocadoParams(object):
 
     # TODO: Use "test" to log params.get()
 
-    def __init__(self, leaves, test_id, tag, mux_entry, default_params):
+    def __init__(self, leaves, test_id, tag, mux_path, default_params):
         """
         :param leaves: List of TreeNode leaves defining current variant
         :param test_id: test id
         :param tag: test tag
-        :param mux_entry: list of entry points
+        :param mux_path: list of entry points
         :param default_params: dict of params used when no matches found
         """
         self._rel_paths = []
         leaves = list(leaves)
-        for i, path in enumerate(mux_entry):
+        for i, path in enumerate(mux_path):
             path_leaves = self._get_matching_leaves(path, leaves)
             self._rel_paths.append(AvocadoParam(path_leaves,
                                                 '%d: %s' % (i, path)))
-        # Don't use non-mux-entry params for relative paths
+        # Don't use non-mux-path params for relative paths
         path_leaves = self._get_matching_leaves('/*', leaves)
         self._abs_path = AvocadoParam(path_leaves, '*: *')
         self.id = test_id
@@ -397,9 +397,9 @@ class Mux(object):
         if getattr(args, 'default_multiplex_tree', None):
             mux_tree.merge(args.default_multiplex_tree)
         self.variants = MuxTree(mux_tree)
-        self._mux_entry = getattr(args, 'mux_entry', None)
-        if self._mux_entry is None:
-            self._mux_entry = ['/run/*']
+        self._mux_path = getattr(args, 'mux_path', None)
+        if self._mux_path is None:
+            self._mux_path = ['/run/*']
 
     def get_number_of_tests(self, test_suite):
         """
@@ -427,10 +427,10 @@ class Mux(object):
                 # key. In order for that to happen, they need to set
                 # params['avocado_inject_params'] = True as well.
                 if not inject_params:
-                    test_factory[1]['params'] = (variant, self._mux_entry)
+                    test_factory[1]['params'] = (variant, self._mux_path)
                 else:
                     test_factory[1]['params']['avocado_params'] = (
-                        variant, self._mux_entry)
+                        variant, self._mux_path)
                 yield test_factory
             if i is None:   # No variants, use template
                 yield template

--- a/avocado/core/plugins/runner.py
+++ b/avocado/core/plugins/runner.py
@@ -124,7 +124,7 @@ class TestRunner(plugin.Plugin):
                              help='Filter only path(s) from multiplexing')
             mux.add_argument('--filter-out', nargs='*', default=[],
                              help='Filter out path(s) from multiplexing')
-            mux.add_argument('--mux-entry', nargs='*', default=None,
+            mux.add_argument('--mux-path', nargs='*', default=None,
                              help="Multiplex entry point(s)")
             mux.add_argument('--env', default=[], nargs='*',
                              help="Inject [path:]key:node values into the "

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -131,7 +131,7 @@ class Test(unittest.TestCase):
         self.stdout_log = logging.getLogger("avocado.test.stdout")
         self.stderr_log = logging.getLogger("avocado.test.stderr")
 
-        mux_entry = ['/test/*']
+        mux_path = ['/test/*']
         if isinstance(params, dict):
             self.default_params = self.default_params.copy()
             self.default_params.update(params)
@@ -139,9 +139,9 @@ class Test(unittest.TestCase):
         elif params is None:
             params = []
         elif isinstance(params, tuple):
-            params, mux_entry = params[0], params[1]
+            params, mux_path = params[0], params[1]
         self.params = multiplexer.AvocadoParams(params, self.name, self.tag,
-                                                mux_entry,
+                                                mux_path,
                                                 self.default_params)
 
         self.log.info('START %s', self.tagged_name)

--- a/docs/source/MultiplexConfig.rst
+++ b/docs/source/MultiplexConfig.rst
@@ -191,12 +191,12 @@ configurations, or serve as plugin configurations and other advanced setups it i
 possible and commonly desirable to use non-unique names. But always keep those points
 in mind and provide sensible paths.
 
-Multiplexer also supports something called "multiplex entry points" or
-"resolution order". By default it's ``/run/*`` but it can be overridden by
-``--mux-entry``, which accepts multiple arguments. What it does it splits
-leaves by the provided paths. Each query goes one by one through those
-sub-trees and first one to hit the match returns the result. It might not solve
-all problems, but it can help to combine existing YAML files with your ones::
+Multiplexer also supports default paths. By default it's ``/run/*`` but it can
+be overridden by ``--mux-path``, which accepts multiple arguments. What it does
+it splits leaves by the provided paths. Each query goes one by one through
+those sub-trees and first one to hit the match returns the result. It might not
+solve all problems, but it can help to combine existing YAML files with your
+ones::
 
     qa:         # large and complex read-only file, content injected into /qa
         tests:
@@ -209,10 +209,10 @@ all problems, but it can help to combine existing YAML files with your ones::
             timeout: 1000
 
 You want to use an existing test which uses ``params.get('timeout', '*')``.  Then you
-can use ``--mux-entry '/my_variants/*' '/qa/*'`` and it'll first look in your
+can use ``--mux-path '/my_variants/*' '/qa/*'`` and it'll first look in your
 variants. If no matches are found, then it would proceed to ``/qa/*``
 
-Keep in mind that only slices defined in mux-entry are taken into account for
+Keep in mind that only slices defined in mux-path are taken into account for
 relative paths (the ones starting with ``*``)
 
 
@@ -224,7 +224,7 @@ You can run any test with any YAML file by::
     avocado run sleeptest --multiplex file.yaml
 
 This puts the content of ``file.yaml`` into ``/run``
-location, which as mentioned in previous section, is the default ``mux-entry``
+location, which as mentioned in previous section, is the default ``mux-path``
 path. For most simple cases this is the expected behavior as your files
 are available in the default path and you can safely use ``params.get(key)``.
 
@@ -253,7 +253,7 @@ intention of the test writer. There are several ways to access the values:
 * absolute location ``params.get(key, '/my/variants/duration')``
 * absolute location with wildcards ``params.get(key, '/my/*)``
   (or ``/*/duration/*``...)
-* set the mux-entry ``avocado run ... --mux-entry /my/*`` and use relative path
+* set the mux-path ``avocado run ... --mux-path /my/*`` and use relative path
 
 It's recommended to use the simple injection for single YAML files, relative
 injection for multiple simple YAML files and the last option is for very

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -126,11 +126,11 @@ order, then for simple queries you can simply omit the path::
 
 One should always try to avoid param clashes (multiple matching keys for given
 path with different origin). If it's not possible (eg. when
-you use multiple yaml files) you can modify the resolution order by modifying
-``--mux-entry``. What it does is it slices the params and iterates through the
+you use multiple yaml files) you can modify the default paths by modifying
+``--mux-path``. What it does is it slices the params and iterates through the
 paths one by one. When there is a match in the first slice it returns
 it without trying the other slices. Although relative queries only match
-from ``--mux-entry`` slices.
+from ``--mux-path`` slices.
 
 There are many ways to use paths to separate clashing params or just to make
 more clear what your query for. Usually in tests the usage of '*' is sufficient
@@ -176,7 +176,7 @@ The ``$INJECT_TO`` can be either relative path, then it's injected into
 ``/run/$INJECT_TO`` location, or absolute path (starting with ``'/'``), then
 it's injected directly into the specified path and it's up to the test/framework
 developer to get the value from this location (using path or adding the path to
-``mux-entry``). To understand the difference execute those commands::
+``mux-path``). To understand the difference execute those commands::
 
     $ avocado multiplex -t examples/tests/sleeptest.py.data/sleeptest.yaml
     $ avocado multiplex -t duration:examples/tests/sleeptest.py.data/sleeptest.yaml


### PR DESCRIPTION
--mux-entry was a bit confusing as what it does it splits the result
params into multiple slices and while quering for keys they are
evaluated in the specified order, thus behaving the same as Linux PATH
bash variable.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>