### PR TITLE
avocado.core.test: Remove extra logged line after test starts

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -145,7 +145,6 @@ class Test(unittest.TestCase):
                                                 self.default_params)
 
         self.log.info('START %s', self.tagged_name)
-        self.log.debug('')
 
         self.debugdir = None
         self.resultsdir = None


### PR DESCRIPTION
The extra line was confusing, therefore, we shall remove
it from the logs.

Log excerpt:

        Job ID: eb8975442b95f700697e20f6f2da8012f7e49454

        START examples/tests/sleeptest.py
        PARAMS (key=timeout, path=*, default=None) => None
        PARAMS (key=sleep_length, path=*, default=1) => 1
        Sleeping for 1.00 seconds
        PASS examples/tests/sleeptest.py
