### PR TITLE
avocado.core.loader: Discover only per-plugin-default tests

### DIFF
--- a/avocado/core/plugins/test_list.py
+++ b/avocado/core/plugins/test_list.py
@@ -114,8 +114,7 @@ class TestLister(object):
 
     def _list(self):
         self._extra_listing()
-        keywords = self._get_keywords()
-        test_suite = self._get_test_suite(keywords)
+        test_suite = self._get_test_suite(self.args.keywords)
         self._validate_test_suite(test_suite)
         test_matrix, stats = self._get_test_matrix(test_suite)
         self._display(test_matrix, stats)


### PR DESCRIPTION
Loader plugins can specify default set of tests, when none supplied.
Currently list of these defaults is generated and then examined by
all loader plugins. This might generate clashes and false-negative
results, for example avocado-vt defines "vt_list_all" which obviously
shouldn't be parsed by file-plugin.

This patch changes the behavior so when no urls specified each plugin
choses and processes only his own defaults. To do this it was necessarily
to reorder the recognition thus now you get all successful hits of all
urls from the first plugin, then the second....

Additionally small optimization was added to skip urls which are already
successfully assignend. This doesn't affects the results as they were
only added when not already handled.

Last minor tweak avoids false-positive result when exception occurs
during the "discover" phase as mapping is assigned after successful
discovery.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>