### PR TITLE
core.test: Map generic exceptions to TestError

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -35,6 +35,7 @@ from . import data_dir
 from . import sysinfo
 from . import exceptions
 from . import multiplexer
+from .settings import settings
 from .version import VERSION
 from ..utils import genio
 from ..utils import path as utils_path
@@ -444,7 +445,9 @@ class Test(unittest.TestCase):
             self.fail_reason = detail
             self.traceback = stacktrace.prepare_exc_info(sys.exc_info())
         except Exception, detail:
-            self.status = 'FAIL'
+            self.status = settings.get_value("runner.behavior",
+                                             "generic_exception_result",
+                                             default="ERROR")
             tb_info = stacktrace.tb_info(sys.exc_info())
             self.traceback = stacktrace.prepare_exc_info(sys.exc_info())
             try:

--- a/etc/avocado/avocado.conf
+++ b/etc/avocado/avocado.conf
@@ -33,6 +33,8 @@ utf8 =
 [runner.behavior]
 # Keep job temporary files after jobs (useful for avocado debugging)
 keep_tmp_files = False
+# Overrides the test result in case of generic exception (FAIL, ERROR, ...)
+generic_exception_result = ERROR
 
 [job.output]
 # Base log level for --show-job-log.

--- a/examples/tests/generic_exception.py
+++ b/examples/tests/generic_exception.py
@@ -1,0 +1,20 @@
+#!/usr/bin/python
+
+from avocado import Test
+from avocado import main
+
+
+class ErrorTest(Test):
+
+    """
+    Example test that raises generic exception
+    """
+
+    def runTest(self):
+        """
+        This should end with ERROR (on default config)
+        """
+        raise Exception("This is a generic exception")
+
+if __name__ == "__main__":
+    main()

--- a/selftests/all/functional/avocado/basic_tests.py
+++ b/selftests/all/functional/avocado/basic_tests.py
@@ -115,6 +115,17 @@ class RunnerOperationTest(unittest.TestCase):
                       output,
                       "Test did not fail with action exception:\n%s" % output)
 
+    def test_generic_exception(self):
+        os.chdir(basedir)
+        cmd_line = ("./scripts/avocado run --sysinfo=off --job-results-dir %s "
+                    "--json - generic_exception" % self.tmpdir)
+        result = process.run(cmd_line, ignore_status=True)
+        expected_rc = 1
+        self.assertEqual(result.exit_status, expected_rc,
+                         "Avocado did not return rc %d:\n%s" % (expected_rc,
+                                                                result))
+        self.assertIn('"status": "ERROR"', result.stdout)
+
     def test_runner_timeout(self):
         os.chdir(basedir)
         cmd_line = './scripts/avocado run --sysinfo=off --job-results-dir %s --xunit - timeouttest' % self.tmpdir


### PR DESCRIPTION
On unhandeled unknown exceptions the test should finish with ERROR
rather than FAIL as the test developer didn't think it might happen.

This behavior is configurable in config when the user have a different
opinion.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>