### PR TITLE
avocado.core.loader: Discover only per-plugin-default tests [v2]

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -103,25 +103,30 @@ class TestLoaderProxy(object):
         """
         Discover (possible) tests from test urls.
 
-        :param urls: a list of tests urls.
+        :param urls: a list of tests urls; if [] use plugin defaults
         :type urls: list
         :param list_non_tests: Whether to list non tests (for listing methods)
         :type list_non_tests: bool
         :return: A list of test factories (tuples (TestClass, test_params))
         """
         test_factories = []
-        for url in urls:
-            for loader_plugin in self.loader_plugins:
+        for loader_plugin in self.loader_plugins:
+            if urls:
+                _urls = urls
+            else:
+                _urls = loader_plugin.get_base_keywords()
+            for url in _urls:
+                if url in self.url_plugin_mapping:
+                    continue
                 try:
                     params_list_from_url = loader_plugin.discover_url(url)
                     if list_non_tests:
                         for params in params_list_from_url:
                             params['omit_non_tests'] = False
                     if params_list_from_url:
-                        if url not in self.url_plugin_mapping:
-                            self.url_plugin_mapping[url] = loader_plugin
-                        if loader_plugin == self.url_plugin_mapping[url]:
-                            test_factories += loader_plugin.discover(params_list_from_url)
+                        test_factory = loader_plugin.discover(params_list_from_url)
+                        self.url_plugin_mapping[url] = loader_plugin
+                        test_factories += test_factory
                 except Exception, details:
                     # FIXME: Introduce avocado.exceptions logger and use here
                     stacktrace.log_message("Test discovery plugin %s failed: "

--- a/avocado/core/plugins/test_list.py
+++ b/avocado/core/plugins/test_list.py
@@ -114,8 +114,7 @@ class TestLister(object):
 
     def _list(self):
         self._extra_listing()
-        keywords = self._get_keywords()
-        test_suite = self._get_test_suite(keywords)
+        test_suite = self._get_test_suite(self.args.keywords)
         self._validate_test_suite(test_suite)
         test_matrix, stats = self._get_test_matrix(test_suite)
         self._display(test_matrix, stats)


### PR DESCRIPTION
Loader plugins can specify default set of tests, when none supplied.
Currently list of these defaults is generated and then examined by
all loader plugins. This might generate clashes and false-negative
results, for example avocado-vt defines "vt_list_all" which obviously
shouldn't be parsed by file-plugin.

This patch changes the behavior so when no urls specified each plugin
chose and processes only his own defaults. To do this it was necessary
to reorder the recognition thus now you get all successful hits of all
urls from the first plugin, then the second....

Additionally small optimization was added to skip urls which are already
successfully assigned. This doesn't affects the results as they were
only added when not already handled.

Last minor tweak avoids false-positive result when exception occurs
during the "discover" phase as mapping is assigned after successful
discovery.

v1: https://github.com/avocado-framework/avocado/pull/685

Changes:

    v2: Commit message typos
    v2: Removed "print"
