### PR TITLE
  avocado.core.test: Remove the obsoleted "runTest" [v3]

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -35,6 +35,7 @@ from . import data_dir
 from . import sysinfo
 from . import exceptions
 from . import multiplexer
+from . import status
 from .settings import settings
 from .version import VERSION
 from ..utils import genio
@@ -49,11 +50,11 @@ class Test(unittest.TestCase):
     Base implementation for the test class.
 
     You'll inherit from this to write your own tests. Typically you'll want
-    to implement setUp(), runTest() and tearDown() methods on your own tests.
+    to implement setUp(), test*() and tearDown() methods on your own tests.
     """
     default_params = {}
 
-    def __init__(self, methodName='runTest', name=None, params=None,
+    def __init__(self, methodName='test', name=None, params=None,
                  base_logdir=None, tag=None, job=None, runner_queue=None):
         """
         Initializes the test.
@@ -292,7 +293,7 @@ class Test(unittest.TestCase):
 
     def setUp(self):
         """
-        Setup stage that the test needs before passing to the actual runTest.
+        Setup stage that the test needs before passing to the actual test*.
 
         Must be implemented by tests if they want such an stage. Commonly we'll
         download/compile test suites, create files needed for a test, among
@@ -302,9 +303,9 @@ class Test(unittest.TestCase):
 
     def tearDown(self):
         """
-        Cleanup stage after the runTest is done.
+        Cleanup stage after the test* is done.
 
-        Examples of cleanup runTests are deleting temporary files, restoring
+        Examples of cleanup are deleting temporary files, restoring
         firewall configurations or other system settings that were changed
         in setup.
         """
@@ -341,7 +342,7 @@ class Test(unittest.TestCase):
         testMethod = getattr(self, self._testMethodName)
         self._start_logging()
         self.sysinfo_logger.start_test_hook()
-        runTest_exception = None
+        test_exception = None
         cleanup_exception = None
         stdout_check_exception = None
         stderr_check_exception = None
@@ -357,7 +358,7 @@ class Test(unittest.TestCase):
             testMethod()
         except Exception, details:
             stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
-            runTest_exception = details
+            test_exception = details
         finally:
             try:
                 self.tearDown()
@@ -397,8 +398,8 @@ class Test(unittest.TestCase):
                     self.record_reference_stderr()
 
         # pylint: disable=E0702
-        if runTest_exception is not None:
-            raise runTest_exception
+        if test_exception is not None:
+            raise test_exception
         elif cleanup_exception is not None:
             raise exceptions.TestSetupFail(cleanup_exception)
         elif stdout_check_exception is not None:
@@ -445,9 +446,16 @@ class Test(unittest.TestCase):
             self.fail_reason = detail
             self.traceback = stacktrace.prepare_exc_info(sys.exc_info())
         except Exception, detail:
-            self.status = settings.get_value("runner.behavior",
-                                             "generic_exception_result",
-                                             default="ERROR")
+            stat = settings.get_value("runner.behavior",
+                                      "uncaught_exception_result",
+                                      default="ERROR")
+            if stat not in status.mapping:
+                stacktrace.log_message("Incorrect runner.behavior.generic_"
+                                       "exception_result value '%s', using "
+                                       "'ERROR' instead." % stat,
+                                       "avocado.test")
+                stat = "ERROR"
+            self.status = stat
             tb_info = stacktrace.tb_info(sys.exc_info())
             self.traceback = stacktrace.prepare_exc_info(sys.exc_info())
             try:
@@ -548,7 +556,7 @@ class SimpleTest(Test):
         self.log.info("Exit status: %s", result.exit_status)
         self.log.info("Duration: %s", result.duration)
 
-    def runTest(self):
+    def test(self):
         """
         Run the executable, and log its detailed execution.
         """
@@ -578,7 +586,7 @@ class MissingTest(Test):
     Handle when there is no such test module in the test directory.
     """
 
-    def runTest(self):
+    def test(self):
         e_msg = ('Test %s could not be found in the test dir %s '
                  '(or test path does not exist)' %
                  (self.name, data_dir.get_test_dir()))
@@ -594,7 +602,7 @@ class BuggyTest(Test):
     buggy python module.
     """
 
-    def runTest(self):
+    def test(self):
         # pylint: disable=E0702
         raise self.params.get('exception')
 
@@ -608,7 +616,7 @@ class NotATest(Test):
     or a regular, non executable file.
     """
 
-    def runTest(self):
+    def test(self):
         e_msg = ('File %s is not executable and does not contain an avocado '
                  'test class in it ' % self.name)
         raise exceptions.NotATestError(e_msg)
@@ -623,6 +631,6 @@ class TimeOutSkipTest(Test):
     It will never have a chance to execute.
     """
 
-    def runTest(self):
+    def test(self):
         e_msg = 'Test skipped due a job timeout!'
         raise exceptions.TestNAError(e_msg)

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -35,6 +35,7 @@ from . import data_dir
 from . import sysinfo
 from . import exceptions
 from . import multiplexer
+from .settings import settings
 from .version import VERSION
 from ..utils import genio
 from ..utils import path as utils_path
@@ -444,7 +445,9 @@ class Test(unittest.TestCase):
             self.fail_reason = detail
             self.traceback = stacktrace.prepare_exc_info(sys.exc_info())
         except Exception, detail:
-            self.status = 'FAIL'
+            self.status = settings.get_value("runner.behavior",
+                                             "generic_exception_result",
+                                             default="ERROR")
             tb_info = stacktrace.tb_info(sys.exc_info())
             self.traceback = stacktrace.prepare_exc_info(sys.exc_info())
             try:

--- a/docs/source/DebuggingWithGDB.rst
+++ b/docs/source/DebuggingWithGDB.rst
@@ -92,7 +92,7 @@ test::
 
  class HelloOutputTest(Test):
 
-     def runTest(self):
+     def test(self):
          result = process.run("/path/to/hello", ignore_status=True)
          self.assertIn("hello\n", result.stdout)
 
@@ -154,7 +154,7 @@ Example
 
 Take a look at ``examples/tests/modify_variable.py`` test::
 
-    def runTest(self):
+    def test(self):
         """
         Execute 'print_variable'.
         """

--- a/docs/source/ReferenceGuide.rst
+++ b/docs/source/ReferenceGuide.rst
@@ -35,14 +35,18 @@ and match those in a single job.
 Instrumented
 ------------
 
-These are tests written in Python that use the Avocado test API.
+These are tests written in Python or BASH with the Avocado helpers that use the Avocado test API.
 
 To be more precise, the Python file must contain a class derived from :mod:`avocado.test.Test`.
 This means that an executable written in Python is not always an instrumented test, but may work
 as a simple test.
 
-By the way, the term instrumented is used because the Avocado Python test classes allow you to
-get more features for your test, such as logging facilities and more sophisticated test APIs.
+The instrumented tests allows the writer finer control over the process
+including logging, test result status and other more sophisticated test APIs.
+
+Test statuses ``PASS``, ``WARN``, ``START`` and ``TEST_NA`` are considered as
+successful builds. The ``ABORT``, ``ERROR``, ``FAIL``, ``ALERT``, ``RUNNING``,
+``NOSTATUS`` and ``INTERRUPTED`` are considered as failed ones.
 
 Simple
 ------

--- a/etc/avocado/avocado.conf
+++ b/etc/avocado/avocado.conf
@@ -33,6 +33,8 @@ utf8 =
 [runner.behavior]
 # Keep job temporary files after jobs (useful for avocado debugging)
 keep_tmp_files = False
+# Overrides the test result in case of generic exception (FAIL, ERROR, ...)
+generic_exception_result = ERROR
 
 [job.output]
 # Base log level for --show-job-log.

--- a/etc/avocado/avocado.conf
+++ b/etc/avocado/avocado.conf
@@ -33,8 +33,8 @@ utf8 =
 [runner.behavior]
 # Keep job temporary files after jobs (useful for avocado debugging)
 keep_tmp_files = False
-# Overrides the test result in case of generic exception (FAIL, ERROR, ...)
-generic_exception_result = ERROR
+# Overrides the test result in case of uncaught exception (FAIL, ERROR, ...)
+uncaught_exception_result = ERROR
 
 [job.output]
 # Base log level for --show-job-log.

--- a/examples/tests/abort.py
+++ b/examples/tests/abort.py
@@ -14,7 +14,7 @@ class AbortTest(Test):
 
     default_params = {'timeout': 2.0}
 
-    def runTest(self):
+    def test(self):
         os.abort()
 
 

--- a/examples/tests/cabort.py
+++ b/examples/tests/cabort.py
@@ -27,7 +27,7 @@ class CAbort(Test):
                    env={'CFLAGS': '-g -O0'},
                    extra_args='abort')
 
-    def runTest(self):
+    def test(self):
         """
         Execute 'abort'.
         """

--- a/examples/tests/datadir.py
+++ b/examples/tests/datadir.py
@@ -28,7 +28,7 @@ class DataDirTest(Test):
                    env={'CFLAGS': '-g -O0'},
                    extra_args='datadir')
 
-    def runTest(self):
+    def test(self):
         """
         Execute 'datadir'.
         """

--- a/examples/tests/doublefail.py
+++ b/examples/tests/doublefail.py
@@ -10,7 +10,7 @@ class DoubleFail(Test):
     Functional test for avocado. Straight up fail the test.
     """
 
-    def runTest(self):
+    def test(self):
         """
         Should fail.
         """

--- a/examples/tests/doublefree.py
+++ b/examples/tests/doublefree.py
@@ -29,7 +29,7 @@ class DoubleFreeTest(Test):
                    env={'CFLAGS': '-g -O0'},
                    extra_args='doublefree')
 
-    def runTest(self):
+    def test(self):
         """
         Execute 'doublefree'.
         """

--- a/examples/tests/doublefree_nasty.py
+++ b/examples/tests/doublefree_nasty.py
@@ -29,7 +29,7 @@ class DoubleFreeTest(Test):
                    env={'CFLAGS': '-g -O0'},
                    extra_args=self.__binary)
 
-    def runTest(self):
+    def test(self):
         """
         Execute 'doublefree'.
         """

--- a/examples/tests/errortest.py
+++ b/examples/tests/errortest.py
@@ -10,7 +10,7 @@ class ErrorTest(Test):
     Example test that ends with ERROR.
     """
 
-    def runTest(self):
+    def test(self):
         """
         This should end with ERROR.
         """

--- a/examples/tests/failtest.py
+++ b/examples/tests/failtest.py
@@ -10,7 +10,7 @@ class FailTest(Test):
     Example test for avocado. Straight up fail the test.
     """
 
-    def runTest(self):
+    def test(self):
         """
         Should fail.
         """

--- a/examples/tests/failtest_nasty.py
+++ b/examples/tests/failtest_nasty.py
@@ -21,7 +21,7 @@ class FailTest(Test):
     Very nasty exception test
     """
 
-    def runTest(self):
+    def test(self):
         """
         Should fail not-that-badly
         """

--- a/examples/tests/failtest_nasty2.py
+++ b/examples/tests/failtest_nasty2.py
@@ -21,7 +21,7 @@ class FailTest(Test):
     Very nasty exception test
     """
 
-    def runTest(self):
+    def test(self):
         """
         Should fail.
         """

--- a/examples/tests/fiotest.py
+++ b/examples/tests/fiotest.py
@@ -30,7 +30,7 @@ class FioTest(Test):
         self.srcdir = os.path.join(self.srcdir, fio_version)
         build.make(self.srcdir)
 
-    def runTest(self):
+    def test(self):
         """
         Execute 'fio' with appropriate parameters.
         """

--- a/examples/tests/gendata.py
+++ b/examples/tests/gendata.py
@@ -12,7 +12,7 @@ class GenDataTest(Test):
     Simple test that generates data to be persisted after the test is run
     """
 
-    def generate_bsod(self):
+    def test_bsod(self):
         try:
             from PIL import Image
             from PIL import ImageDraw
@@ -34,16 +34,13 @@ class GenDataTest(Test):
             y += 12
         bsod.save(os.path.join(self.outputdir, "bsod.png"))
 
-    def generate_json(self):
+    def test_json(self):
         import json
         output_path = os.path.join(self.outputdir, "test.json")
         output = {"basedir": self.basedir,
                   "outputdir": self.outputdir}
         json.dump(output, open(output_path, "w"))
 
-    def test(self):
-        self.generate_bsod()
-        self.generate_json()
 
 if __name__ == "__main__":
     main()

--- a/examples/tests/gendata.py
+++ b/examples/tests/gendata.py
@@ -41,7 +41,7 @@ class GenDataTest(Test):
                   "outputdir": self.outputdir}
         json.dump(output, open(output_path, "w"))
 
-    def runTest(self):
+    def test(self):
         self.generate_bsod()
         self.generate_json()
 

--- a/examples/tests/generic_exception.py
+++ b/examples/tests/generic_exception.py
@@ -10,7 +10,7 @@ class ErrorTest(Test):
     Example test that raises generic exception
     """
 
-    def runTest(self):
+    def test(self):
         """
         This should end with ERROR (on default config)
         """

--- a/examples/tests/generic_exception.py
+++ b/examples/tests/generic_exception.py
@@ -1,0 +1,20 @@
+#!/usr/bin/python
+
+from avocado import Test
+from avocado import main
+
+
+class ErrorTest(Test):
+
+    """
+    Example test that raises generic exception
+    """
+
+    def runTest(self):
+        """
+        This should end with ERROR (on default config)
+        """
+        raise Exception("This is a generic exception")
+
+if __name__ == "__main__":
+    main()

--- a/examples/tests/linuxbuild.py
+++ b/examples/tests/linuxbuild.py
@@ -22,7 +22,7 @@ class LinuxBuildTest(Test):
         self.linux_build.uncompress()
         self.linux_build.configure()
 
-    def runTest(self):
+    def test(self):
         self.linux_build.build()
 
 

--- a/examples/tests/modify_variable.py
+++ b/examples/tests/modify_variable.py
@@ -32,7 +32,7 @@ class PrintVariableTest(Test):
                    env={'CFLAGS': '-g -O0'},
                    extra_args=self.__binary)
 
-    def runTest(self):
+    def test(self):
         """
         Execute 'print_variable'.
         """

--- a/examples/tests/multiplextest.py
+++ b/examples/tests/multiplextest.py
@@ -55,7 +55,7 @@ class MultiplexTest(Test):
         if enable_msx_vectors == 'yes':
             self.log.info('Enabling msx vectors')
 
-    def runTest(self):
+    def test(self):
         self.log.info('Executing synctest...')
         self.log.info('synctest --timeout %s --tries %s',
                       self.params.get('sync_timeout', default=12),

--- a/examples/tests/passtest.py
+++ b/examples/tests/passtest.py
@@ -10,7 +10,7 @@ class PassTest(Test):
     Example test that passes.
     """
 
-    def runTest(self):
+    def test(self):
         """
         A test simply doesn't have to fail in order to pass
         """

--- a/examples/tests/raise.py
+++ b/examples/tests/raise.py
@@ -28,7 +28,7 @@ class Raise(Test):
                    env={'CFLAGS': '-g -O0'},
                    extra_args='raise')
 
-    def runTest(self):
+    def test(self):
         """
         Execute 'raise'.
         """

--- a/examples/tests/skiptest.py
+++ b/examples/tests/skiptest.py
@@ -10,7 +10,7 @@ class SkipTest(Test):
     Example test that skips the current test, that is it, ends with SKIP.
     """
 
-    def runTest(self):
+    def test(self):
         """
         This should end with SKIP.
         """

--- a/examples/tests/sleeptenmin.py
+++ b/examples/tests/sleeptenmin.py
@@ -13,7 +13,7 @@ class SleepTenMin(Test):
     Sleeps for 10 minutes
     """
 
-    def runTest(self):
+    def test(self):
         """
         Sleep for length seconds.
         """

--- a/examples/tests/sleeptest.py
+++ b/examples/tests/sleeptest.py
@@ -12,7 +12,7 @@ class SleepTest(Test):
     Example test for avocado.
     """
 
-    def runTest(self):
+    def test(self):
         """
         Sleep for length seconds.
         """

--- a/examples/tests/synctest.py
+++ b/examples/tests/synctest.py
@@ -31,7 +31,7 @@ class SyncTest(Test):
         else:
             build.make(self.srcdir)
 
-    def runTest(self):
+    def test(self):
         """
         Execute synctest with the appropriate params.
         """

--- a/examples/tests/timeouttest.py
+++ b/examples/tests/timeouttest.py
@@ -14,7 +14,7 @@ class TimeoutTest(Test):
 
     default_params = {'timeout': 3}
 
-    def runTest(self):
+    def test(self):
         """
         This should throw a TestTimeoutError.
         """

--- a/examples/tests/trinity.py
+++ b/examples/tests/trinity.py
@@ -37,7 +37,7 @@ class TrinityTest(Test):
         build.make(self.srcdir)
         self.victims_path = data_factory.make_dir_and_populate(self.workdir)
 
-    def runTest(self):
+    def test(self):
         """
         Execute the trinity syscall fuzzer with the appropriate params.
         """

--- a/examples/tests/warntest.py
+++ b/examples/tests/warntest.py
@@ -10,7 +10,7 @@ class WarnTest(Test):
     Functional test for avocado. Throw a TestWarn.
     """
 
-    def runTest(self):
+    def test(self):
         """
         This should throw a TestWarn.
         """

--- a/examples/tests/whiteboard.py
+++ b/examples/tests/whiteboard.py
@@ -12,7 +12,7 @@ class WhiteBoard(Test):
     Simple test that saves test custom data to the test whiteboard
     """
 
-    def runTest(self):
+    def test(self):
         data_file = self.params.get('whiteboard_data_file', default='')
         data_size = self.params.get('whiteboard_data_size', default='10')
         if data_file:

--- a/selftests/all/functional/avocado/basic_tests.py
+++ b/selftests/all/functional/avocado/basic_tests.py
@@ -115,6 +115,17 @@ class RunnerOperationTest(unittest.TestCase):
                       output,
                       "Test did not fail with action exception:\n%s" % output)
 
+    def test_generic_exception(self):
+        os.chdir(basedir)
+        cmd_line = ("./scripts/avocado run --sysinfo=off --job-results-dir %s "
+                    "--json - generic_exception" % self.tmpdir)
+        result = process.run(cmd_line, ignore_status=True)
+        expected_rc = 1
+        self.assertEqual(result.exit_status, expected_rc,
+                         "Avocado did not return rc %d:\n%s" % (expected_rc,
+                                                                result))
+        self.assertIn('"status": "ERROR"', result.stdout)
+
     def test_runner_timeout(self):
         os.chdir(basedir)
         cmd_line = './scripts/avocado run --sysinfo=off --job-results-dir %s --xunit - timeouttest' % self.tmpdir

--- a/selftests/all/functional/avocado/loader_tests.py
+++ b/selftests/all/functional/avocado/loader_tests.py
@@ -22,7 +22,7 @@ from avocado import Test
 from avocado import main
 
 class PassTest(Test):
-    def runTest(self):
+    def test(self):
         pass
 
 if __name__ == "__main__":
@@ -35,7 +35,7 @@ from avocado import main
 import adsh
 
 class PassTest(Test):
-    def runTest(self):
+    def test(self):
         pass
 
 if __name__ == "__main__":

--- a/selftests/all/functional/avocado/output_tests.py
+++ b/selftests/all/functional/avocado/output_tests.py
@@ -244,10 +244,9 @@ class OutputPluginTest(unittest.TestCase):
                              (expected_rc, result))
             with open(tmpfile, 'r') as fp:
                 json_results = json.load(fp)
-                debug_log = json_results['debuglog']
-                debug_dir = os.path.dirname(debug_log)
-                test_result_dir = os.path.join(debug_dir, 'test-results', 'whiteboard.py')
-                whiteboard_path = os.path.join(test_result_dir, 'whiteboard')
+                logfile = json_results['tests'][0]['logfile']
+                debug_dir = os.path.dirname(logfile)
+                whiteboard_path = os.path.join(debug_dir, 'whiteboard')
                 self.assertTrue(os.path.exists(whiteboard_path),
                                 'Missing whiteboard file %s' % whiteboard_path)
         finally:

--- a/selftests/all/functional/avocado/output_tests.py
+++ b/selftests/all/functional/avocado/output_tests.py
@@ -255,6 +255,45 @@ class OutputPluginTest(unittest.TestCase):
             except OSError:
                 pass
 
+    def test_gendata(self):
+        tmpfile = tempfile.mktemp()
+        try:
+            os.chdir(basedir)
+            cmd_line = ("./scripts/avocado run --job-results-dir %s "
+                        "--sysinfo=off gendata --json %s" %
+                        (self.tmpdir, tmpfile))
+            result = process.run(cmd_line, ignore_status=True)
+            expected_rc = 0
+            self.assertEqual(result.exit_status, expected_rc,
+                             "Avocado did not return rc %d:\n%s" %
+                             (expected_rc, result))
+            with open(tmpfile, 'r') as fp:
+                json_results = json.load(fp)
+                bsod_dir = None
+                json_dir = None
+                for test in json_results['tests']:
+                    if "test_bsod" in test['url']:
+                        bsod_dir = test['logfile']
+                    elif "test_json" in test['url']:
+                        json_dir = test['logfile']
+                self.assertTrue(bsod_dir, "Failed to get test_bsod output "
+                                "directory")
+                self.assertTrue(json_dir, "Failed to get test_json output "
+                                "directory")
+                bsod_dir = os.path.join(os.path.dirname(bsod_dir), "data",
+                                        "bsod.png")
+                json_dir = os.path.join(os.path.dirname(json_dir), "data",
+                                        "test.json")
+                self.assertTrue(os.path.exists(bsod_dir), "File %s produced by"
+                                "test does not exists." % bsod_dir)
+                self.assertTrue(os.path.exists(json_dir), "File %s produced by"
+                                "test does not exists." % json_dir)
+        finally:
+            try:
+                os.remove(tmpfile)
+            except OSError:
+                pass
+
     def test_redirect_output(self):
         redirected_output_path = tempfile.mktemp()
         try:

--- a/selftests/all/functional/avocado/unittest_compat.py
+++ b/selftests/all/functional/avocado/unittest_compat.py
@@ -19,7 +19,7 @@ from avocado.utils import process
 UNITTEST_GOOD = """from avocado import Test
 from unittest import main
 class AvocadoPassTest(Test):
-    def runTest(self):
+    def test(self):
         self.assertTrue(True)
 if __name__ == '__main__':
     main()
@@ -28,7 +28,7 @@ if __name__ == '__main__':
 UNITTEST_FAIL = """from avocado import Test
 from unittest import main
 class AvocadoFailTest(Test):
-    def runTest(self):
+    def test(self):
         self.fail('This test is supposed to fail')
 if __name__ == '__main__':
     main()
@@ -37,7 +37,7 @@ if __name__ == '__main__':
 UNITTEST_ERROR = """from avocado import Test
 from unittest import main
 class AvocadoErrorTest(Test):
-    def runTest(self):
+    def test(self):
         self.error('This test is supposed to error')
 if __name__ == '__main__':
     main()

--- a/selftests/all/unit/avocado/jsonresult_unittest.py
+++ b/selftests/all/unit/avocado/jsonresult_unittest.py
@@ -44,7 +44,7 @@ class JSONResultTest(unittest.TestCase):
 
         class SimpleTest(Test):
 
-            def runTest(self):
+            def test(self):
                 pass
 
         self.tmpfile = tempfile.mkstemp()

--- a/selftests/all/unit/avocado/loader_unittest.py
+++ b/selftests/all/unit/avocado/loader_unittest.py
@@ -23,7 +23,7 @@ from avocado import Test
 from avocado import main
 
 class PassTest(Test):
-    def runTest(self):
+    def test(self):
         pass
 
 if __name__ == "__main__":
@@ -36,7 +36,7 @@ from avocado import main
 import adsh
 
 class PassTest(Test):
-    def runTest(self):
+    def test(self):
         pass
 
 if __name__ == "__main__":
@@ -103,7 +103,7 @@ class LoaderTest(unittest.TestCase):
             self.loader.discover_tests(params={'id': simple_test.path})[0])
         self.assertTrue(test_class == test.SimpleTest, test_class)
         tc = test_class(**test_parameters)
-        tc.runTest()
+        tc.test()
         simple_test.remove()
 
     def test_load_simple_not_exec(self):
@@ -115,7 +115,7 @@ class LoaderTest(unittest.TestCase):
             self.loader.discover_tests(params={'id': simple_test.path})[0])
         self.assertTrue(test_class == test.NotATest, test_class)
         tc = test_class(**test_parameters)
-        self.assertRaises(exceptions.NotATestError, tc.runTest)
+        self.assertRaises(exceptions.NotATestError, tc.test)
         simple_test.remove()
 
     def test_load_pass(self):
@@ -129,7 +129,7 @@ class LoaderTest(unittest.TestCase):
                         str(test_class))
         self.assertTrue(issubclass(test_class, test.Test))
         tc = test_class(**test_parameters)
-        tc.runTest()
+        tc.test()
         avocado_pass_test.remove()
 
     def test_load_inherited(self):
@@ -162,7 +162,7 @@ class LoaderTest(unittest.TestCase):
             self.loader.discover_tests(params={'id': avocado_buggy_test.path})[0])
         self.assertTrue(test_class == test.SimpleTest, test_class)
         tc = test_class(**test_parameters)
-        self.assertRaises(exceptions.TestFail, tc.runTest)
+        self.assertRaises(exceptions.TestFail, tc.test)
         avocado_buggy_test.remove()
 
     def test_load_buggy_not_exec(self):
@@ -175,7 +175,7 @@ class LoaderTest(unittest.TestCase):
             self.loader.discover_tests(params={'id': avocado_buggy_test.path})[0])
         self.assertTrue(test_class == test.BuggyTest, test_class)
         tc = test_class(**test_parameters)
-        self.assertRaises(ImportError, tc.runTest)
+        self.assertRaises(ImportError, tc.test)
         avocado_buggy_test.remove()
 
     def test_load_not_a_test(self):
@@ -188,7 +188,7 @@ class LoaderTest(unittest.TestCase):
             self.loader.discover_tests(params={'id': avocado_not_a_test.path})[0])
         self.assertTrue(test_class == test.NotATest, test_class)
         tc = test_class(**test_parameters)
-        self.assertRaises(exceptions.NotATestError, tc.runTest)
+        self.assertRaises(exceptions.NotATestError, tc.test)
         avocado_not_a_test.remove()
 
     def test_load_not_a_test_exec(self):
@@ -201,7 +201,7 @@ class LoaderTest(unittest.TestCase):
         tc = test_class(**test_parameters)
         # The test can't be executed (no shebang), raising an OSError
         # (OSError: [Errno 8] Exec format error)
-        self.assertRaises(OSError, tc.runTest)
+        self.assertRaises(OSError, tc.test)
         avocado_not_a_test.remove()
 
     def test_py_simple_test(self):
@@ -213,7 +213,7 @@ class LoaderTest(unittest.TestCase):
             self.loader.discover_tests(params={'id': avocado_simple_test.path})[0])
         self.assertTrue(test_class == test.SimpleTest)
         tc = test_class(**test_parameters)
-        tc.runTest()
+        tc.test()
         avocado_simple_test.remove()
 
     def test_py_simple_test_notexec(self):
@@ -226,7 +226,7 @@ class LoaderTest(unittest.TestCase):
             self.loader.discover_tests(params={'id': avocado_simple_test.path})[0])
         self.assertTrue(test_class == test.NotATest)
         tc = test_class(**test_parameters)
-        self.assertRaises(exceptions.NotATestError, tc.runTest)
+        self.assertRaises(exceptions.NotATestError, tc.test)
         avocado_simple_test.remove()
 
     def test_multiple_methods(self):

--- a/selftests/all/unit/avocado/test_unittest.py
+++ b/selftests/all/unit/avocado/test_unittest.py
@@ -31,7 +31,7 @@ class TestClassTest(unittest.TestCase):
     def setUp(self):
         class AvocadoPass(test.Test):
 
-            def runTest(self):
+            def test(self):
                 variable = True
                 self.assertTrue(variable)
                 self.whiteboard = 'foo'

--- a/selftests/all/unit/avocado/xunit_unittest.py
+++ b/selftests/all/unit/avocado/xunit_unittest.py
@@ -48,7 +48,7 @@ class xUnitSucceedTest(unittest.TestCase):
 
         class SimpleTest(Test):
 
-            def runTest(self):
+            def test(self):
                 pass
 
         self.tmpfile = tempfile.mkstemp()


### PR DESCRIPTION
This patchset removes the support for obsoleted "runTest" and replaces it with "test" instead. Additionally it splits the "gendata" test into two subtests and adds unittest which verifies it creates 2 tests and that files are created correct locations.

v1: https://github.com/avocado-framework/avocado/pull/687
v2: https://github.com/avocado-framework/avocado/pull/689

Changes:

    v2: Check if user defined exception is valid
    v3: Inspect lint problems
    v3: Add documentation about possible test statuses

_Note: This patchset is built on top of the https://github.com/avocado-framework/avocado/pull/686 pull request in order to fix the test which is added there._