### PR TITLE
plugins.htmlresult: Use tagged_name instead of uid

### DIFF
--- a/avocado/core/plugins/resources/htmlresult/templates/report.mustache
+++ b/avocado/core/plugins/resources/htmlresult/templates/report.mustache
@@ -68,7 +68,7 @@
             {{#tests}}
                 <tr class="{{row_class}}">
                     <td>{{time_start}}</td>
-                    <td><a href="{{logdir}}">{{url}}</a></td>
+                    <td><a href="{{logdir}}">{{test}}</a></td>
                     <td>{{status}}</td>
                     <td>{{time}}</td>
                     <td>{{& fail_reason}}</td>


### PR DESCRIPTION
The uid is only a test name and is not unique across the execution. We
should use tagged_name which consists of the uid and the optional tag to
be consistent with avocado runner.

Changes:

    v1: Add reason for this change