### PR TITLE
Fix fabric logging

### DIFF
--- a/avocado/core/log.py
+++ b/avocado/core/log.py
@@ -83,6 +83,16 @@ DEFAULT_LOGGING = {
             'level': 'DEBUG',
             'propagate': False,
         },
+        'avocado.fabric': {
+            'handlers': ['null'],
+            'level': 'DEBUG',
+            'propagate': False,
+        },
+        'paramiko': {
+            'handlers': ['null'],
+            'level': 'DEBUG',
+            'propagate': False,
+        },
         'avocado.test.stdout': {
             'handlers': ['null'],
             'level': 'DEBUG',

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -285,7 +285,7 @@ class LoggingFile(object):
     """
 
     def __init__(self, prefix='', level=logging.DEBUG,
-                 logger=logging.getLogger()):
+                 logger=[logging.getLogger()]):
         """
         Constructor. Sets prefixes and which logger is going to be used.
 
@@ -295,6 +295,8 @@ class LoggingFile(object):
         self._prefix = prefix
         self._level = level
         self._buffer = []
+        if not isinstance(logger, list):
+            logger = [logger]
         self._logger = logger
 
     def write(self, data):
@@ -326,7 +328,8 @@ class LoggingFile(object):
         """
         Passes lines of output to the logging module.
         """
-        self._logger.log(self._level, self._prefix + line)
+        for lg in self._logger:
+            lg.log(self._level, self._prefix + line)
 
     def _flush_buffer(self):
         if self._buffer:

--- a/avocado/core/remote/result.py
+++ b/avocado/core/remote/result.py
@@ -82,8 +82,7 @@ class RemoteTestResult(HumanTestResult):
         self.remote = remoter.Remote(self.args.remote_hostname,
                                      self.args.remote_username,
                                      self.args.remote_password,
-                                     self.args.remote_port,
-                                     quiet=True)
+                                     self.args.remote_port)
         self._copy_tests()
 
     def tear_down(self):

--- a/avocado/core/remote/runner.py
+++ b/avocado/core/remote/runner.py
@@ -17,8 +17,10 @@ import sys
 import json
 import os
 import re
+import logging
 
 from .test import RemoteTest
+from .. import output
 from .. import exceptions
 from .. import status
 from ..runner import TestRunner
@@ -128,39 +130,59 @@ class RemoteTestRunner(TestRunner):
         if not timeout:     # avoid timeout = 0
             timeout = None
         failures = []
+
+        stdout_backup = sys.stdout
+        stderr_backup = sys.stderr
+        fabric_debugfile = os.path.join(self.job.logdir, 'ssh.log')
+        paramiko_logger = logging.getLogger('paramiko')
+        fabric_logger = logging.getLogger('avocado.fabric')
+        fmt = ('%(asctime)s %(module)-10.10s L%(lineno)-.4d %('
+               'levelname)-5.5s| %(message)s')
+        formatter = logging.Formatter(fmt=fmt, datefmt='%H:%M:%S')
+        file_handler = logging.FileHandler(filename=fabric_debugfile)
+        file_handler.setFormatter(formatter)
+        fabric_logger.addHandler(file_handler)
+        paramiko_logger.addHandler(file_handler)
+
+        sys.stdout = output.LoggingFile(logger=fabric_logger)
+        sys.stderr = output.LoggingFile(logger=fabric_logger)
         try:
-            self.result.setup()
-        except Exception, details:
-            stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
-            raise exceptions.JobError(details)
-        results = self.run_test(self.result.urls, timeout)
-        remote_log_dir = os.path.dirname(results['debuglog'])
-        self.result.start_tests()
-        for tst in results['tests']:
-            test = RemoteTest(name=tst['test'],
-                              time=tst['time'],
-                              start=tst['start'],
-                              end=tst['end'],
-                              status=tst['status'],
-                              logdir=tst['logdir'],
-                              logfile=tst['logfile'],
-                              fail_reason=tst['fail_reason'])
-            state = test.get_state()
-            self.result.start_test(state)
-            self.result.check_test(state)
-            if not status.mapping[state['status']]:
-                failures.append(state['tagged_name'])
-        local_log_dir = os.path.dirname(self.result.stream.debuglog)
-        zip_filename = remote_log_dir + '.zip'
-        zip_path_filename = os.path.join(local_log_dir,
-                                         os.path.basename(zip_filename))
-        self.result.remote.receive_files(local_log_dir, zip_filename)
-        archive.uncompress(zip_path_filename, local_log_dir)
-        os.remove(zip_path_filename)
-        self.result.end_tests()
-        try:
-            self.result.tear_down()
-        except Exception, details:
-            stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
-            raise exceptions.JobError(details)
+            try:
+                self.result.setup()
+            except Exception, details:
+                stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
+                raise exceptions.JobError(details)
+            results = self.run_test(self.result.urls, timeout)
+            remote_log_dir = os.path.dirname(results['debuglog'])
+            self.result.start_tests()
+            for tst in results['tests']:
+                test = RemoteTest(name=tst['test'],
+                                  time=tst['time'],
+                                  start=tst['start'],
+                                  end=tst['end'],
+                                  status=tst['status'],
+                                  logdir=tst['logdir'],
+                                  logfile=tst['logfile'],
+                                  fail_reason=tst['fail_reason'])
+                state = test.get_state()
+                self.result.start_test(state)
+                self.result.check_test(state)
+                if not status.mapping[state['status']]:
+                    failures.append(state['tagged_name'])
+            local_log_dir = os.path.dirname(self.result.stream.debuglog)
+            zip_filename = remote_log_dir + '.zip'
+            zip_path_filename = os.path.join(local_log_dir,
+                                             os.path.basename(zip_filename))
+            self.result.remote.receive_files(local_log_dir, zip_filename)
+            archive.uncompress(zip_path_filename, local_log_dir)
+            os.remove(zip_path_filename)
+            self.result.end_tests()
+            try:
+                self.result.tear_down()
+            except Exception, details:
+                stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
+                raise exceptions.JobError(details)
+        finally:
+            sys.stdout = stdout_backup
+            sys.stderr = stderr_backup
         return failures

--- a/avocado/core/remoter.py
+++ b/avocado/core/remoter.py
@@ -85,16 +85,10 @@ class Remote(object):
         :rtype: :class:`avocado.utils.process.CmdResult`.
         :raise fabric.exceptions.CommandTimeout: When timeout exhausted.
         """
-        if not self.quiet:
-            LOG.info('[%s] Running command %s', self.hostname, command)
         result = process.CmdResult()
-        stdout = output.LoggingFile(logger=logging.getLogger('avocado.test'))
-        stderr = output.LoggingFile(logger=logging.getLogger('avocado.test'))
         start_time = time.time()
         fabric_result = fabric.operations.run(command=command,
                                               quiet=self.quiet,
-                                              stdout=stdout,
-                                              stderr=stderr,
                                               warn_only=True,
                                               timeout=timeout)
         end_time = time.time()
@@ -138,15 +132,11 @@ class Remote(object):
         :param local_path: the local path.
         :param remote_path: the remote path.
         """
-        if not self.quiet:
-            LOG.info('[%s] Sending files %s -> %s', self.hostname,
-                     local_path, remote_path)
-        with fabric.context_managers.quiet():
-            try:
-                fabric.operations.put(local_path, remote_path,
-                                      mirror_local_mode=True)
-            except ValueError:
-                return False
+        try:
+            fabric.operations.put(local_path, remote_path,
+                                  mirror_local_mode=True)
+        except ValueError:
+            return False
         return True
 
     def receive_files(self, local_path, remote_path):
@@ -156,13 +146,9 @@ class Remote(object):
         :param local_path: the local path.
         :param remote_path: the remote path.
         """
-        if not self.quiet:
-            LOG.info('[%s] Receive remote files %s -> %s', self.hostname,
-                     local_path, remote_path)
-        with fabric.context_managers.quiet():
-            try:
-                fabric.operations.get(remote_path,
-                                      local_path)
-            except ValueError:
-                return False
+        try:
+            fabric.operations.get(remote_path,
+                                  local_path)
+        except ValueError:
+            return False
         return True

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -68,9 +68,14 @@ class TestRunner(object):
         def interrupt_handler(signum, frame):
             e_msg = "Test %s interrupted by user" % instance
             raise exceptions.TestInterruptedError(e_msg)
-
-        sys.stdout = output.LoggingFile(logger=logging.getLogger('avocado.test.stdout'))
-        sys.stderr = output.LoggingFile(logger=logging.getLogger('avocado.test.stderr'))
+        logger_list_stdout = [logging.getLogger('avocado.test.stdout'),
+                              logging.getLogger('avocado.test'),
+                              logging.getLogger('paramiko')]
+        logger_list_stderr = [logging.getLogger('avocado.test.stderr'),
+                              logging.getLogger('avocado.test'),
+                              logging.getLogger('paramiko')]
+        sys.stdout = output.LoggingFile(logger=logger_list_stdout)
+        sys.stderr = output.LoggingFile(logger=logger_list_stderr)
 
         try:
             instance = self.job.test_loader.load_test(test_factory)

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -117,6 +117,7 @@ class Test(unittest.TestCase):
         self.logdir = utils_path.init_dir(base_logdir, tagged_name)
         genio.set_log_file_dir(self.logdir)
         self.logfile = os.path.join(self.logdir, 'debug.log')
+        self._ssh_logfile = os.path.join(self.logdir, 'ssh.log')
 
         self.stdout_file = os.path.join(self.logdir, 'stdout')
         self.stderr_file = os.path.join(self.logdir, 'stderr')
@@ -260,12 +261,16 @@ class Test(unittest.TestCase):
                                                                    self.stdout_file)
         self.stderr_file_handler = self._register_log_file_handler(self.stderr_log, stream_formatter,
                                                                    self.stderr_file)
+        self._ssh_fh = self._register_log_file_handler(logging.getLogger('paramiko'),
+                                                       formatter,
+                                                       self._ssh_logfile)
 
     def _stop_logging(self):
         """
         Stop the logging activity of the test by cleaning the logger handlers.
         """
         self.log.removeHandler(self.file_handler)
+        logging.getLogger('paramiko').removeHandler(self._ssh_fh)
 
     def get_tagged_name(self, logdir):
         """

--- a/avocado/core/virt.py
+++ b/avocado/core/virt.py
@@ -273,8 +273,7 @@ class VM(object):
         :param password: the password.
         """
         if not self.logged:
-            self.remote = remoter.Remote(hostname, username, password,
-                                         quiet=True)
+            self.remote = remoter.Remote(hostname, username, password)
             res = self.remote.uptime()
             if res.succeeded:
                 self.logged = True

--- a/selftests/all/unit/avocado/remote_unittest.py
+++ b/selftests/all/unit/avocado/remote_unittest.py
@@ -32,6 +32,7 @@ class RemoteTestRunnerTest(unittest.TestCase):
     def setUp(self):
         flexmock(remote.RemoteTestRunner).should_receive('__init__')
         self.remote = remote.RemoteTestRunner(None, None)
+        self.remote.job = flexmock(logdir='.')
         test_results = flexmock(stdout=JSON_RESULTS, exit_status=0)
         stream = flexmock(job_unique_id='sleeptest.1',
                           debuglog='/local/path/dirname')
@@ -102,7 +103,7 @@ class RemoteTestResultTest(unittest.TestCase):
         Stream.should_receive('notify').once().ordered()
         remote_remote = flexmock(remoter)
         (remote_remote.should_receive('Remote')
-         .with_args('hostname', 'username', 'password', 22, quiet=True)
+         .with_args('hostname', 'username', 'password', 22)
          .once().ordered()
          .and_return(Remote))
         (Remote.should_receive('makedir').with_args('~/avocado/tests')


### PR DESCRIPTION
We have been using `fabric` for quite some time, but missing on important debugging opportunities. This PR lets us to log the entirety of the SSH logging streams produced by fabric and its underlying library, paramiko. This way we can help users (and ourselves) to figure out bugs related to SSH, as long as the code uses fabric.

An example of a typical `ssh.log` can be seen here:

https://gist.github.com/lmr/8b5277d21969abd6c34d