### PR TITLE
Execution of tests remotely copies tests unnecessarily

### DIFF
--- a/avocado/core/remote/result.py
+++ b/avocado/core/remote/result.py
@@ -50,10 +50,11 @@ class RemoteTestResult(HumanTestResult):
         $remote_test_dir + $test_absolute_path.
         :note: Default tests execution is translated into absolute paths too
         """
-        # TODO: Use `avocado.core.loader.TestLoader` instead
-        self.remote.makedir(self.remote_test_dir)
         if self.args.remote_no_copy:    # Leave everything as is
             return
+
+        # TODO: Use `avocado.core.loader.TestLoader` instead
+        self.remote.makedir(self.remote_test_dir)
         paths = set()
         for i in xrange(len(self.urls)):
             url = self.urls[i]

--- a/avocado/core/remote/result.py
+++ b/avocado/core/remote/result.py
@@ -44,7 +44,7 @@ class RemoteTestResult(HumanTestResult):
         self.output = '-'
         self.command_line_arg_name = '--remote-hostname'
 
-    def _copy_tests(self):
+    def copy_tests(self):
         """
         Gather test directories and copy them recursively to
         $remote_test_dir + $test_absolute_path.
@@ -83,7 +83,6 @@ class RemoteTestResult(HumanTestResult):
                                      self.args.remote_username,
                                      self.args.remote_password,
                                      self.args.remote_port)
-        self._copy_tests()
 
     def tear_down(self):
         """ Cleanup after test execution """

--- a/avocado/core/remote/result.py
+++ b/avocado/core/remote/result.py
@@ -62,16 +62,15 @@ class RemoteTestResult(HumanTestResult):
                 url = os.path.join(data_dir.get_test_dir(), '%s.py' % url)
             url = os.path.abspath(url)  # always use abspath; avoid clashes
             # modify url to remote_path + abspath
-            paths.add(os.path.dirname(url))
+            paths.add(url)
             self.urls[i] = self.remote_test_dir + url
-        previous = ' NOT ABSOLUTE PATH'
         for path in sorted(paths):
-            if os.path.commonprefix((path, previous)) == previous:
-                continue    # already copied
             rpath = self.remote_test_dir + path
-            self.remote.makedir(rpath)
+            self.remote.makedir(os.path.dirname(rpath))
             self.remote.send_files(path, os.path.dirname(rpath))
-            previous = path
+            test_data = path + '.data'
+            if os.path.isdir(test_data):
+                self.remote.send_files(test_data, os.path.dirname(rpath))
 
     def setup(self):
         """ Setup remote environment and copy test directories """

--- a/avocado/core/remote/runner.py
+++ b/avocado/core/remote/runner.py
@@ -71,11 +71,6 @@ class RemoteTestRunner(TestRunner):
         :param urls: a string with test URLs.
         :return: a dictionary with test results.
         """
-        avocado_installed_version = self.check_remote_avocado()
-        if not avocado_installed_version[0]:
-            raise exceptions.JobError('Remote machine does not seem to have '
-                                      'avocado installed')
-
         urls_str = " ".join(urls)
         avocado_check_urls_cmd = ('cd %s; avocado list %s '
                                   '--paginator=off' % (self.remote_test_dir,
@@ -157,6 +152,11 @@ class RemoteTestRunner(TestRunner):
         try:
             try:
                 self.result.setup()
+                avocado_installed, _ = self.check_remote_avocado()
+                if not avocado_installed:
+                    raise exceptions.JobError('Remote machine does not seem to have '
+                                              'avocado installed')
+                self.result.copy_tests()
             except Exception, details:
                 stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
                 raise exceptions.JobError(details)

--- a/selftests/all/unit/avocado/remote_unittest.py
+++ b/selftests/all/unit/avocado/remote_unittest.py
@@ -87,6 +87,7 @@ _=/usr/bin/env''', exit_status=0)
                            stream=stream, timeout=None,
                            args=flexmock(show_job_log=False))
         Results.should_receive('setup').once().ordered()
+        Results.should_receive('copy_tests').once().ordered()
         Results.should_receive('start_tests').once().ordered()
         args = {'status': u'PASS', 'whiteboard': '', 'time_start': 0,
                 'name': u'sleeptest.1', 'class_name': 'RemoteTest',

--- a/selftests/all/unit/avocado/remote_unittest.py
+++ b/selftests/all/unit/avocado/remote_unittest.py
@@ -136,27 +136,6 @@ class RemoteTestResultTest(unittest.TestCase):
          .with_args('hostname', 'username', 'password', 22)
          .once().ordered()
          .and_return(Remote))
-        (Remote.should_receive('makedir').with_args('~/avocado/tests')
-         .once().ordered())
-        (flexmock(os.path).should_receive('exists')
-         .with_args('/tests/sleeptest').once().and_return(True).ordered())
-        (flexmock(os.path).should_receive('exists')
-         .with_args('/tests/other/test').once().and_return(True).ordered())
-        (flexmock(os.path).should_receive('exists')
-         .with_args('passtest').once().and_return(False).ordered())
-        (flexmock(data_dir).should_receive('get_test_dir').once()
-         .and_return('/path/to/default/tests/location').ordered())
-        (Remote.should_receive('makedir')
-         .with_args("~/avocado/tests/path/to/default/tests/location")
-         .once().ordered())
-        (Remote.should_receive('send_files')
-         .with_args("/path/to/default/tests/location",
-                    "~/avocado/tests/path/to/default/tests").once().ordered())
-        (Remote.should_receive('makedir')
-         .with_args("~/avocado/tests/tests")
-         .once().ordered())
-        (Remote.should_receive('send_files')
-         .with_args("/tests", "~/avocado/tests").once().ordered())
         Args = flexmock(test_result_total=1,
                         url=['/tests/sleeptest', '/tests/other/test',
                              'passtest'],


### PR DESCRIPTION
This is a proposed fix for the conditions described in:

https://trello.com/c/dowZqjjo/429-running-tests-remotely-copies-tests-unnecessarily