### PR TITLE
avocado.core.plugins: Rename --env and improve --mux-path desc [v2]

### DIFF
--- a/avocado/core/plugins/multiplexer.py
+++ b/avocado/core/plugins/multiplexer.py
@@ -56,7 +56,7 @@ class Multiplexer(plugin.Plugin):
         self.parser.add_argument('-c', '--contents', action='store_true',
                                  default=False, help="Shows the node content "
                                  "(variables)")
-        self.parser.add_argument('--env', default=[], nargs='*',
+        self.parser.add_argument('--mux-inject', default=[], nargs='*',
                                  help="Inject [path:]key:node values into "
                                  "the final multiplex tree.")
         env_parser = self.parser.add_argument_group("environment view options")
@@ -73,7 +73,7 @@ class Multiplexer(plugin.Plugin):
 
     def activate(self, args):
         # Extend default multiplex tree of --env values
-        for value in getattr(args, "env", []):
+        for value in getattr(args, "mux_inject", []):
             value = value.split(':', 2)
             if len(value) < 2:
                 raise ValueError("key:value pairs required, found only %s"

--- a/avocado/core/plugins/runner.py
+++ b/avocado/core/plugins/runner.py
@@ -126,8 +126,9 @@ class TestRunner(plugin.Plugin):
             mux.add_argument('--filter-out', nargs='*', default=[],
                              help='Filter out path(s) from multiplexing')
             mux.add_argument('--mux-path', nargs='*', default=None,
-                             help="Multiplex entry point(s)")
-            mux.add_argument('--env', default=[], nargs='*',
+                             help="List of paths used to determine path "
+                             "priority when querying for parameters")
+            mux.add_argument('--mux-inject', default=[], nargs='*',
                              help="Inject [path:]key:node values into the "
                              "final multiplex tree.")
         super(TestRunner, self).configure(self.parser)
@@ -135,8 +136,8 @@ class TestRunner(plugin.Plugin):
         parser.runner = self.parser
 
     def activate(self, args):
-        # Extend default multiplex tree of --env values
-        for value in getattr(args, "env", []):
+        # Extend default multiplex tree of --mux_inject values
+        for value in getattr(args, "mux_inject", []):
             value = value.split(':', 2)
             if len(value) < 2:
                 raise ValueError("key:value pairs required, found only %s"


### PR DESCRIPTION
--env injects node/key/values into the multiplexed tree. It's 100%
related to mux therefor --mux-inject would better reflect the
functionality.

The --mux-path description was rather misleading, hopefully this will
help users to get better notion (although reading the documentation is
still preferred).

v1: https://github.com/avocado-framework/avocado/pull/706

Changes:

    v2: Improved "--mux-path" description by lmr