### PR TITLE
Add new APIs to avocado to accomodate avocado-vt's needs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,9 @@ clean:
 	test -L etc/avocado/conf.d/virt.conf && rm -f etc/avocado/conf.d/virt.conf || true
 	test -L avocado/core/plugins/virt_test.py && rm -f avocado/core/plugins/virt_test.py || true
 	test -L avocado/core/plugins/virt_test_list.py && rm -f avocado/core/plugins/virt_test_list.py || true
+	test -L avocado/core/plugins/virt_test_bootstrap.py && rm -f avocado/core/plugins/virt_test_bootstrap.py || true
 	test -L etc/avocado/conf.d/virt-test.conf && rm -f etc/avocado/conf.d/virt-test.conf || true
+	test -L virttest && rm -f virttest || true
 
 check: clean check_cyclical modules_boundaries
 	selftests/checkall
@@ -88,6 +90,8 @@ link_vt:
 	test -f ../avocado-vt/etc/avocado/conf.d/virt-test.conf && ln -s ../../../../avocado-vt/etc/avocado/conf.d/virt-test.conf etc/avocado/conf.d/ || true
 	test -f ../avocado-vt/avocado/core/plugins/virt_test.py && ln -s ../../../../avocado-vt/avocado/core/plugins/virt_test.py avocado/core/plugins/ || true
 	test -f ../avocado-vt/avocado/core/plugins/virt_test_list.py && ln -s ../../../../avocado-vt/avocado/core/plugins/virt_test_list.py avocado/core/plugins/ || true
+	test -f ../avocado-vt/avocado/core/plugins/virt_test_bootstrap.py && ln -s ../../../../avocado-vt/avocado/core/plugins/virt_test_bootstrap.py avocado/core/plugins/ || true
+	test -d ../avocado-vt/virttest && ln -s ../avocado-vt/virttest . || true
 
 man: man/avocado.1 man/avocado-rest-client.1
 

--- a/avocado/utils/astring.py
+++ b/avocado/utils/astring.py
@@ -65,6 +65,26 @@ def string_to_bitlist(data):
     return result
 
 
+def shell_escape(command):
+    """
+    Escape special characters from a command so that it can be passed
+    as a double quoted (" ") string in a (ba)sh command.
+
+    :param command: the command string to escape.
+
+    :return: The escaped command string. The required englobing double
+            quotes are NOT added and so should be added at some point by
+            the caller.
+
+    See also: http://www.tldp.org/LDP/abs/html/escapingsection.html
+    """
+    command = command.replace("\\", "\\\\")
+    command = command.replace("$", r'\$')
+    command = command.replace('"', r'\"')
+    command = command.replace('`', r'\`')
+    return command
+
+
 def strip_console_codes(output, custom_codes=None):
     """
     Remove the Linux console escape and control sequences from the console

--- a/avocado/utils/cpu.py
+++ b/avocado/utils/cpu.py
@@ -1,0 +1,128 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# This code was inspired in the autotest project,
+#
+# client/base_utils.py
+# Original author: Martin J Bligh <mbligh@google.com>
+# Original author: John Admanski <jadmanski@google.com>
+
+
+"""
+Get information from the current's machine CPU.
+"""
+
+import re
+
+
+def _list_matches(lst, pattern):
+    """
+    True if any item in list matches the specified pattern.
+    """
+    compiled = re.compile(pattern)
+    for element in lst:
+        match = compiled.search(element)
+        if match:
+            return 1
+    return 0
+
+
+def _get_cpu_info():
+    """
+    Reads /proc/cpuinfo and returns a list of file lines
+
+    :returns: `list` of lines from /proc/cpuinfo file
+    :rtype: `list`
+    """
+    with open('/proc/cpuinfo', 'r') as f:
+        cpuinfo = f.readlines()
+    return cpuinfo
+
+
+def count_cpus():
+    """
+    Number of CPUs in the local machine according to /proc/cpuinfo
+    """
+    cpuinfo = _get_cpu_info()
+    cpus = 0
+    for line in cpuinfo:
+        if line.lower().startswith('processor'):
+            cpus += 1
+    return cpus
+
+
+def cpu_has_flags(flags):
+    """
+    Check if a list of flags are available on current CPU info
+
+    :param flags: A `list` of cpu flags that must exists on the current CPU.
+    :type flags: `list`
+    :returns: `bool` True if all the flags were found or False if not
+    :rtype: `list`
+    """
+    cpu_info = _get_cpu_info()
+
+    if not isinstance(flags, list):
+        flags = [flags]
+
+    for flag in flags:
+        if not _list_matches(cpu_info, '.*%s.*' % flag):
+            return False
+    return True
+
+
+def get_cpu_vendor_name():
+    """
+    Get the current cpu vendor name
+
+    :returns: string 'intel' or 'amd' or 'power7' depending on the current CPU architecture.
+    :rtype: `string`
+    """
+    vendors_map = {
+        'intel': ("GenuineIntel", ),
+        'amd': ("AMD", ),
+        'power7': ("POWER7", )
+    }
+
+    cpu_info = _get_cpu_info()
+    for vendor, identifiers in vendors_map.items():
+        for identifier in identifiers:
+            if _list_matches(cpu_info, identifier):
+                return vendor
+    return None
+
+
+def get_cpu_arch():
+    """
+    Work out which CPU architecture we're running on
+    """
+    cpuinfo = _get_cpu_info()
+
+    if _list_matches(cpuinfo, '^cpu.*(RS64|POWER3|Broadband Engine)'):
+        return 'power'
+    elif _list_matches(cpuinfo, '^cpu.*POWER4'):
+        return 'power4'
+    elif _list_matches(cpuinfo, '^cpu.*POWER5'):
+        return 'power5'
+    elif _list_matches(cpuinfo, '^cpu.*POWER6'):
+        return 'power6'
+    elif _list_matches(cpuinfo, '^cpu.*POWER7'):
+        return 'power7'
+    elif _list_matches(cpuinfo, '^cpu.*POWER8'):
+        return 'power8'
+    elif _list_matches(cpuinfo, '^cpu.*PPC970'):
+        return 'power970'
+    elif _list_matches(cpuinfo, 'ARM'):
+        return 'arm'
+    elif _list_matches(cpuinfo, '^flags.*:.* lm .*'):
+        return 'x86_64'
+    else:
+        return 'i386'

--- a/avocado/utils/git.py
+++ b/avocado/utils/git.py
@@ -1,0 +1,205 @@
+#!/usr/bin/python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2015
+# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+
+"""
+APIs to download/update git repositories from inside python scripts.
+"""
+
+import os
+import logging
+
+from . import process
+from . import astring
+from . import path
+
+
+__all__ = ["GitRepoHelper", "get_repo"]
+
+
+class GitRepoHelper(object):
+
+    """
+    Helps to deal with git repos, mostly fetching content from a repo
+    """
+
+    def __init__(self, uri, branch='master', lbranch='master', commit=None,
+                 destination_dir=None, base_uri=None):
+        """
+        Instantiates a new GitRepoHelper
+
+        :type uri: string
+        :param uri: git repository url
+        :type branch: string
+        :param branch: git remote branch
+        :type destination_dir: string
+        :param destination_dir: path of a dir where to save downloaded code
+        :type commit: string
+        :param commit: specific commit to download
+        :type lbranch: string
+        :param lbranch: git local branch name, if different from remote
+        :type base_uri: string
+        :param base_uri: a closer, usually local, git repository url from where
+                         to fetch content first
+        """
+        self.uri = uri
+        self.base_uri = base_uri
+        self.branch = branch
+        self.commit = commit
+
+        if destination_dir is None:
+            uri_basename = uri.split("/")[-1]
+            self.destination_dir = os.path.join("/tmp", uri_basename)
+        else:
+            self.destination_dir = destination_dir
+        if lbranch is None:
+            self.lbranch = branch
+        else:
+            self.lbranch = lbranch
+
+        self.cmd = path.find_command('git')
+
+    def init(self):
+        """
+        Initializes a directory for receiving a verbatim copy of git repo
+
+        This creates a directory if necessary, and either resets or inits
+        the repo
+        """
+        if not os.path.exists(self.destination_dir):
+            logging.debug('Creating directory %s for git repo %s',
+                          self.destination_dir, self.uri)
+            os.makedirs(self.destination_dir)
+
+        os.chdir(self.destination_dir)
+        if os.path.exists('.git'):
+            logging.debug('Resetting previously existing git repo at %s for '
+                          'receiving git repo %s',
+                          self.destination_dir, self.uri)
+            self.git_cmd('reset --hard')
+        else:
+            logging.debug('Initializing new git repo at %s for receiving '
+                          'git repo %s',
+                          self.destination_dir, self.uri)
+            self.git_cmd('init')
+
+    def git_cmd(self, cmd, ignore_status=False):
+        """
+        Wraps git commands.
+
+        :param cmd: Command to be executed.
+        :param ignore_status: Whether we should suppress error.CmdError
+                exceptions if the command did return exit code !=0 (True), or
+                not suppress them (False).
+        """
+        os.chdir(self.destination_dir)
+        return process.run(r"%s %s" % (self.cmd, astring.shell_escape(cmd)),
+                           ignore_status=ignore_status)
+
+    def fetch(self, uri):
+        """
+        Performs a git fetch from the remote repo
+        """
+        logging.info("Fetching git [REP '%s' BRANCH '%s'] -> %s",
+                     uri, self.branch, self.destination_dir)
+        self.git_cmd("fetch -q -f -u -t %s %s:%s" %
+                     (uri, self.branch, self.lbranch))
+
+    def get_top_commit(self):
+        """
+        Returns the topmost commit id for the current branch.
+
+        :return: Commit id.
+        """
+        return self.git_cmd('log --pretty=format:%H -1').stdout.strip()
+
+    def get_top_tag(self):
+        """
+        Returns the topmost tag for the current branch.
+
+        :return: Tag.
+        """
+        try:
+            return self.git_cmd('describe').stdout.strip()
+        except process.CmdError:
+            return None
+
+    def checkout(self, branch=None, commit=None):
+        """
+        Performs a git checkout for a given branch and start point (commit)
+
+        :param branch: Remote branch name.
+        :param commit: Specific commit hash.
+        """
+        if branch is None:
+            branch = self.branch
+
+        logging.debug('Checking out branch %s', branch)
+        self.git_cmd("checkout %s" % branch)
+
+        if commit is None:
+            commit = self.commit
+
+        if commit is not None:
+            logging.debug('Checking out commit %s', self.commit)
+            self.git_cmd("checkout %s" % self.commit)
+        else:
+            logging.debug('Specific commit not specified')
+
+        top_commit = self.get_top_commit()
+        top_tag = self.get_top_tag()
+        if top_tag is None:
+            top_tag_desc = 'no tag found'
+        else:
+            top_tag_desc = 'tag %s' % top_tag
+        logging.info("git commit ID is %s (%s)", top_commit, top_tag_desc)
+
+    def execute(self):
+        """
+        Performs all steps necessary to initialize and download a git repo.
+
+        This includes the init, fetch and checkout steps in one single
+        utility method.
+        """
+        self.init()
+        if self.base_uri is not None:
+            self.fetch(self.base_uri)
+        self.fetch(self.uri)
+        self.checkout()
+
+
+def get_repo(uri, branch='master', lbranch='master', commit=None,
+             destination_dir=None, base_uri=None):
+    """
+    Utility function that retrieves a given git code repository.
+
+    :type uri: string
+    :param uri: git repository url
+    :type branch: string
+    :param branch: git remote branch
+    :type destination_dir: string
+    :param destination_dir: path of a dir where to save downloaded code
+    :type commit: string
+    :param commit: specific commit to download
+    :type lbranch: string
+    :param lbranch: git local branch name, if different from remote
+    :type base_uri: string
+    :param uri: a closer, usually local, git repository url from where to
+                fetch content first from
+    """
+    repo = GitRepoHelper(uri, branch, lbranch, commit, destination_dir,
+                         base_uri)
+    repo.execute()
+    return repo.destination_dir

--- a/avocado/utils/iso9660.py
+++ b/avocado/utils/iso9660.py
@@ -1,0 +1,328 @@
+#!/usr/bin/python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2015
+# Author: Cleber Rosa <crosa@redhat.com>
+
+"""
+Basic ISO9660 file-system support.
+
+This code does not attempt (so far) to implement code that knows about
+ISO9660 internal structure. Instead, it uses commonly available support
+either in userspace tools or on the Linux kernel itself (via mount).
+"""
+
+
+__all__ = ['iso9660', 'Iso9660IsoInfo', 'Iso9660IsoRead', 'Iso9660Mount']
+
+
+import os
+import logging
+import tempfile
+import shutil
+import re
+
+from . import process
+
+
+def has_userland_tool(executable):
+    """
+    Returns whether the system has a given executable
+
+    :param executable: the name of the executable
+    :type executable: str
+    :rtype: bool
+    """
+    if os.path.isabs(executable):
+        return os.path.exists(executable)
+    else:
+        for d in os.environ['PATH'].split(':'):
+            f = os.path.join(d, executable)
+            if os.path.exists(f):
+                return True
+    return False
+
+
+def has_isoinfo():
+    """
+    Returns whether the system has the isoinfo executable
+
+    Maybe more checks could be added to see if isoinfo supports the needed
+    features
+
+    :rtype: bool
+    """
+    return has_userland_tool('isoinfo')
+
+
+def has_isoread():
+    """
+    Returns whether the system has the iso-read executable
+
+    Maybe more checks could be added to see if iso-read supports the needed
+    features
+
+    :rtype: bool
+    """
+    return has_userland_tool('iso-read')
+
+
+def can_mount():
+    """
+    Test wether the current user can perform a loop mount
+
+    AFAIK, this means being root, having mount and iso9660 kernel support
+
+    :rtype: bool
+    """
+    if os.getuid() != 0:
+        logging.debug('Can not use mount: current user is not "root"')
+        return False
+
+    if not has_userland_tool('mount'):
+        logging.debug('Can not use mount: missing "mount" tool')
+        return False
+
+    if 'iso9660' not in open('/proc/filesystems').read():
+        logging.debug('Can not use mount: lack of iso9660 kernel support')
+        return False
+
+    return True
+
+
+class BaseIso9660(object):
+
+    """
+    Represents a ISO9660 filesystem
+
+    This class holds common functionality and has many abstract methods
+    """
+
+    def __init__(self, path):
+        self.path = path
+        self._verify_path(path)
+
+    @staticmethod
+    def _verify_path(path):
+        """
+        Verify that the current set path is accessible
+
+        :param path: the path for test
+        :type path: str
+        :raise OSError: path does not exist or path could not be read
+        :rtype: None
+        """
+        if not os.path.exists(path):
+            raise OSError('File or device path does not exist: %s' %
+                          path)
+        if not os.access(path, os.R_OK):
+            raise OSError('File or device path could not be read: %s' %
+                          path)
+
+    def read(self, path):
+        """
+        Abstract method to read data from path
+
+        :param path: path to the file
+        :returns: data content from the file
+        :rtype: str
+        """
+        raise NotImplementedError
+
+    def copy(self, src, dst):
+        """
+        Simplistic version of copy that relies on read()
+
+        :param src: source path
+        :type src: str
+        :param dst: destination path
+        :type dst: str
+        :rtype: None
+        """
+        content = self.read(src)
+        output = open(dst, 'w+b')
+        output.write(content)
+        output.close()
+
+    def close(self):
+        """
+        Cleanup and free any resources being used
+
+        :rtype: None
+        """
+        pass
+
+
+class Iso9660IsoInfo(BaseIso9660):
+
+    """
+    Represents a ISO9660 filesystem
+
+    This implementation is based on the cdrkit's isoinfo tool
+    """
+
+    def __init__(self, path):
+        super(Iso9660IsoInfo, self).__init__(path)
+        self.joliet = False
+        self.rock_ridge = False
+        self.el_torito = False
+        self._get_extensions(path)
+
+    def _get_extensions(self, path):
+        cmd = 'isoinfo -i %s -d' % path
+        output = process.system_output(cmd)
+
+        if re.findall("\nJoliet", output):
+            self.joliet = True
+        if re.findall("\nRock Ridge signatures", output):
+            self.rock_ridge = True
+        if re.findall("\nEl Torito", output):
+            self.el_torito = True
+
+    @staticmethod
+    def _normalize_path(path):
+        if not os.path.isabs(path):
+            path = os.path.join('/', path)
+        return path
+
+    def _get_filename_in_iso(self, path):
+        cmd = 'isoinfo -i %s -f' % self.path
+        flist = process.system_output(cmd)
+
+        fname = re.findall("(%s.*)" % self._normalize_path(path), flist, re.I)
+        if fname:
+            return fname[0]
+        return None
+
+    def read(self, path):
+        cmd = ['isoinfo', '-i %s' % self.path]
+
+        fname = self._normalize_path(path)
+        if self.joliet:
+            cmd.append("-J")
+        elif self.rock_ridge:
+            cmd.append("-R")
+        else:
+            fname = self._get_filename_in_iso(path)
+            if not fname:
+                logging.warn("Could not find '%s' in iso '%s'", path, self.path)
+                return ""
+
+        cmd.append("-x %s" % fname)
+        result = process.run(" ".join(cmd))
+        return result.stdout
+
+
+class Iso9660IsoRead(BaseIso9660):
+
+    """
+    Represents a ISO9660 filesystem
+
+    This implementation is based on the libcdio's iso-read tool
+    """
+
+    def __init__(self, path):
+        super(Iso9660IsoRead, self).__init__(path)
+        self.temp_dir = tempfile.mkdtemp()
+
+    def read(self, path):
+        temp_file = os.path.join(self.temp_dir, path)
+        cmd = 'iso-read -i %s -e %s -o %s' % (self.path, path, temp_file)
+        process.run(cmd)
+        return open(temp_file).read()
+
+    def copy(self, src, dst):
+        cmd = 'iso-read -i %s -e %s -o %s' % (self.path, src, dst)
+        process.run(cmd)
+
+    def close(self):
+        shutil.rmtree(self.temp_dir, True)
+
+
+class Iso9660Mount(BaseIso9660):
+
+    """
+    Represents a mounted ISO9660 filesystem.
+    """
+
+    def __init__(self, path):
+        """
+        initializes a mounted ISO9660 filesystem
+
+        :param path: path to the ISO9660 file
+        :type path: str
+        """
+        super(Iso9660Mount, self).__init__(path)
+        self.mnt_dir = tempfile.mkdtemp()
+        process.run('mount -t iso9660 -v -o loop,ro %s %s' %
+                    (path, self.mnt_dir))
+
+    def read(self, path):
+        """
+        Read data from path
+
+        :param path: path to read data
+        :type path: str
+        :return: data content
+        :rtype: str
+        """
+        full_path = os.path.join(self.mnt_dir, path)
+        return open(full_path).read()
+
+    def copy(self, src, dst):
+        """
+        :param src: source
+        :type src: str
+        :param dst: destination
+        :type dst: str
+        :rtype: None
+        """
+        full_path = os.path.join(self.mnt_dir, src)
+        shutil.copy(full_path, dst)
+
+    def close(self):
+        """
+        Perform umount operation on the temporary dir
+
+        :rtype: None
+        """
+        if os.path.ismount(self.mnt_dir):
+            process.run('fuser -k %s' % self.mnt_dir, ignore_status=True)
+            process.run('umount %s' % self.mnt_dir)
+
+        shutil.rmtree(self.mnt_dir)
+
+
+def iso9660(path):
+    """
+    Checks the avaiable tools on a system and chooses class accordingly
+
+    This is a convinience function, that will pick the first avaialable
+    iso9660 capable tool.
+
+    :param path: path to an iso9660 image file
+    :type path: str
+    :return: an instance of any iso9660 capable tool
+    :rtype: :class:`Iso9660IsoInfo`, :class:`Iso9660IsoRead`,
+            :class:`Iso9660Mount` or None
+    """
+    implementations = [('isoinfo', has_isoinfo, Iso9660IsoInfo),
+                       ('iso-read', has_isoread, Iso9660IsoRead),
+                       ('mount', can_mount, Iso9660Mount)]
+
+    for (name, check, klass) in implementations:
+        if check():
+            logging.debug('Automatically chosen class for iso9660: %s', name)
+            return klass(path)
+
+    return None

--- a/avocado/utils/linux_modules.py
+++ b/avocado/utils/linux_modules.py
@@ -1,0 +1,154 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# This code was inspired in the autotest project,
+#
+# client/base_utils.py
+# Original author: Ross Brattain <ross.b.brattain@intel.com>
+
+"""
+APIs to list and load/unload linux kernel modules.
+"""
+
+import re
+import logging
+from . import process
+
+LOG = logging.getLogger('avocado.test')
+
+
+def load_module(module_name):
+    # Checks if a module has already been loaded
+    if module_is_loaded(module_name):
+        return False
+
+    process.system('/sbin/modprobe ' + module_name)
+    return True
+
+
+def parse_lsmod_for_module(l_raw, module_name, escape=True):
+    """
+    Use a regexp to parse raw lsmod output and get module information
+    :param l_raw: raw output of lsmod
+    :type l_raw:  str
+    :param module_name: Name of module to search for
+    :type module_name: str
+    :param escape: Escape regexp tokens in module_name, default True
+    :type escape: bool
+    :return: Dictionary of module info, name, size, submodules if present
+    :rtype: dict
+    """
+    # re.escape the module name for safety
+    if escape:
+        module_search = re.escape(module_name)
+    else:
+        module_search = module_name
+    # ^module_name spaces size spaces used optional spaces optional submodules
+    # use multiline regex to scan the entire output as one string without
+    # having to splitlines use named matches so we can extract the dictionary
+    # with groupdict
+    pattern = (r"^(?P<name>%s)\s+(?P<size>\d+)\s+(?P<used>\d+)"
+               "\s*(?P<submodules>\S+)?$")
+    lsmod = re.search(pattern % module_search, l_raw, re.M)
+    if lsmod:
+        # default to empty list if no submodules
+        module_info = lsmod.groupdict([])
+        # convert size to integer because it is an integer
+        module_info['size'] = int(module_info['size'])
+        module_info['used'] = int(module_info['used'])
+        if module_info['submodules']:
+            module_info['submodules'] = module_info['submodules'].split(',')
+        return module_info
+    else:
+        # return empty dict to be consistent
+        return {}
+
+
+def loaded_module_info(module_name):
+    """
+    Get loaded module details: Size and Submodules.
+
+    :param module_name: Name of module to search for
+    :type module_name: str
+    :return: Dictionary of module info, name, size, submodules if present
+    :rtype: dict
+    """
+    l_raw = process.system_output('/sbin/lsmod')
+    return parse_lsmod_for_module(l_raw, module_name)
+
+
+def get_submodules(module_name):
+    """
+    Get all submodules of the module.
+
+    :param module_name: Name of module to search for
+    :type module_name: str
+    :return: List of the submodules
+    :rtype: list
+    """
+    module_info = loaded_module_info(module_name)
+    module_list = []
+    try:
+        submodules = module_info["submodules"]
+    except KeyError:
+        LOG.info("Module %s is not loaded" % module_name)
+    else:
+        module_list = submodules
+        for module in submodules:
+            module_list += get_submodules(module)
+    return module_list
+
+
+def unload_module(module_name):
+    """
+    Removes a module. Handles dependencies. If even then it's not possible
+    to remove one of the modules, it will throw an error.CmdError exception.
+
+    :param module_name: Name of the module we want to remove.
+    :type module_name: str
+    """
+    module_info = loaded_module_info(module_name)
+    try:
+        submodules = module_info['submodules']
+    except KeyError:
+        LOG.info("Module %s is already unloaded" % module_name)
+    else:
+        for module in submodules:
+            unload_module(module)
+        module_info = loaded_module_info(module_name)
+        try:
+            module_used = module_info['used']
+        except KeyError:
+            LOG.info("Module %s is already unloaded" % module_name)
+            return
+        if module_used != 0:
+            raise RuntimeError("Module %s is still in use. "
+                               "Can not unload it." % module_name)
+        process.system("/sbin/modprobe -r %s" % module_name)
+        LOG.info("Module %s unloaded" % module_name)
+
+
+def module_is_loaded(module_name):
+    """
+    Is module loaded
+
+    :param module_name: Name of module to search for
+    :type module_name: str
+    :return: True is module is loaded
+    :rtype: bool
+    """
+    module_name = module_name.replace('-', '_')
+    return bool(loaded_module_info(module_name))
+
+
+def get_loaded_modules():
+    lsmod_output = process.system_output('/sbin/lsmod').splitlines()[1:]
+    return [line.split(None, 1)[0] for line in lsmod_output]

--- a/avocado/utils/output.py
+++ b/avocado/utils/output.py
@@ -1,0 +1,150 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# This code was inspired in the autotest project,
+#
+# client/shared/utils.py
+# Original author: Cleber Rosa <crosa@redhat.com>
+#
+# Copyright: Red Hat Inc. 2015
+# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+
+"""
+Utility functions for user friendly display of information.
+"""
+
+import sys
+
+
+def display_data_size(size):
+    """
+    Display data size in human readable units (SI).
+
+    :param size: Data size, in Bytes.
+    :type size: int
+    :return: Human readable string with data size, using SI prefixes.
+    """
+    prefixes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB']
+    factor = float(1000)
+    i = 0
+    while size >= factor:
+        if i >= len(prefixes) - 1:
+            break
+        size /= factor
+        i += 1
+
+    return '%.2f %s' % (size, prefixes[i])
+
+
+class ProgressBar(object):
+
+    """
+    Displays interactively the progress of a given task
+
+    Inspired/adapted from https://gist.github.com/t0xicCode/3306295
+    """
+
+    def __init__(self, minimum=0, maximum=100, width=75, title=''):
+        """
+        Initializes a new progress bar
+
+        :type minimum: integer
+        :param minimum: minimum (initial) value on the progress bar
+        :type maximum: integer
+        :param maximum: maximum (final) value on the progress bar
+        :type width: integer
+        :param with: number of columns, that is screen width
+        """
+        assert maximum > minimum
+
+        self.prog_bar = ''
+        self.old_prog_bar = ''
+
+        if title:
+            width -= len(title)
+
+        self.minimum = minimum
+        self.maximum = maximum
+        self.range = maximum - minimum
+        self.width = width
+        self.title = title
+
+        self.current_amount = minimum
+        self.update_amount(minimum)
+
+    def append_amount(self, amount):
+        """
+        Increments the current amount value.
+        """
+        self.update_amount(self.current_amount + amount)
+
+    def update_percentage(self, percentage):
+        """
+        Updates the progress bar to the new percentage.
+        """
+        self.update_amount((percentage * float(self.maximum)) / 100.0)
+
+    def update_amount(self, amount):
+        """
+        Performs sanity checks and update the current amount.
+        """
+        if amount < self.minimum:
+            amount = self.minimum
+        if amount > self.maximum:
+            amount = self.maximum
+        self.current_amount = amount
+
+        self._update_progress_bar()
+        self.draw()
+
+    def _update_progress_bar(self):
+        """
+        Builds the actual progress bar text.
+        """
+        diff = float(self.current_amount - self.minimum)
+        done = (diff / float(self.range)) * 100.0
+        done = int(round(done))
+
+        all_full = self.width - 2
+        hashes = (done / 100.0) * all_full
+        hashes = int(round(hashes))
+
+        if hashes == 0:
+            screen_text = "[>%s]" % (' '*(all_full-1))
+        elif hashes == all_full:
+            screen_text = "[%s]" % ('='*all_full)
+        else:
+            screen_text = "[%s>%s]" % ('='*(hashes-1), ' '*(all_full-hashes))
+
+        percent_string = str(done) + "%"
+
+        # slice the percentage into the bar
+        screen_text = ' '.join([screen_text, percent_string])
+
+        if self.title:
+            screen_text = '%s: %s' % (self.title,
+                                      screen_text)
+        self.prog_bar = screen_text
+
+    def draw(self):
+        """
+        Prints the updated text to the screen.
+        """
+        if self.prog_bar != self.old_prog_bar:
+            self.old_prog_bar = self.prog_bar
+            sys.stdout.write('\r' + self.prog_bar)
+            sys.stdout.flush()
+
+    def __str__(self):
+        """
+        Returns the current progress bar.
+        """
+        return str(self.prog_bar)

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -158,7 +158,7 @@ def process_in_ptree_is_defunct(ppid):
         return True
     for pid in pids:
         cmd = "ps --no-headers -o cmd %d" % int(pid)
-        proc_name = system_output(cmd, ignore_status=True)
+        proc_name = system_output(cmd, ignore_status=True, verbose=False)
         if '<defunct>' in proc_name:
             defunct = True
             break
@@ -171,7 +171,7 @@ def get_children_pids(ppid):
     param ppid: parent PID
     return: list of PIDs of all children/threads of ppid
     """
-    return system_output("ps -L --ppid=%d -o lwp" % ppid).split('\n')[1:]
+    return system_output("ps -L --ppid=%d -o lwp" % ppid, verbose=False).split('\n')[1:]
 
 
 class CmdResult(object):

--- a/avocado/utils/service.py
+++ b/avocado/utils/service.py
@@ -1,0 +1,797 @@
+#  Copyright(c) 2013 Intel Corporation.
+#
+#  This program is free software; you can redistribute it and/or modify it
+#  under the terms and conditions of the GNU General Public License,
+#  version 2, as published by the Free Software Foundation.
+#
+#  This program is distributed in the hope it will be useful, but WITHOUT
+#  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+#  more details.
+#
+#  You should have received a copy of the GNU General Public License along with
+#  this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
+#
+#  The full GNU General Public License is included in this distribution in
+#  the file called "COPYING".
+#
+# This code was inspired in the autotest project,
+#
+# client/shared/service.py
+# Original author: Ross Brattain <ross.b.brattain@intel.com>
+
+import os
+import re
+import logging
+from tempfile import mktemp
+
+from . import process
+
+LOG = logging.getLogger('avocado.test')
+
+_COMMAND_TABLE_DOC = """
+
+Taken from http://fedoraproject.org/wiki/SysVinit_to_Systemd_Cheatsheet
+
+service frobozz start
+systemctl start frobozz.service
+ Used to start a service (not reboot persistent)
+
+service frobozz stop
+systemctl stop frobozz.service
+ Used to stop a service (not reboot persistent)
+
+service frobozz restart
+systemctl restart frobozz.service
+ Used to stop and then start a service
+
+service frobozz reload
+systemctl reload frobozz.service
+ When supported, reloads the config file without interrupting pending operations.
+
+service frobozz condrestart
+systemctl condrestart frobozz.service
+ Restarts if the service is already running.
+
+service frobozz status
+systemctl status frobozz.service
+ Tells whether a service is currently running.
+
+ls /etc/rc.d/init.d/
+systemctl list-unit-files --type=service (preferred)
+ Used to list the services that can be started or stopped
+ls /lib/systemd/system/*.service /etc/systemd/system/*.service
+ Used to list all the services and other units
+
+chkconfig frobozz on
+systemctl enable frobozz.service
+ Turn the service on, for start at next boot, or other trigger.
+
+chkconfig frobozz off
+systemctl disable frobozz.service
+ Turn the service off for the next reboot, or any other trigger.
+
+chkconfig frobozz
+systemctl is-enabled frobozz.service
+ Used to check whether a service is configured to start or not in the current environment.
+
+chkconfig --list
+systemctl list-unit-files --type=service(preferred)
+ls /etc/systemd/system/*.wants/
+ Print a table of services that lists which runlevels each is configured on or off
+
+chkconfig frobozz --list
+ls /etc/systemd/system/*.wants/frobozz.service
+ Used to list what levels this service is configured on or off
+
+chkconfig frobozz --add
+systemctl daemon-reload
+ Used when you create a new service file or modify any configuration
+
+
+"""
+
+
+def sys_v_init_result_parser(command):
+    """
+    Parse results from sys_v style commands.
+
+    command status: return true if service is running.
+    command is_enabled: return true if service is enalbled.
+    command list: return a dict from service name to status.
+    command others: return true if operate success.
+
+    :param command: command.
+    :type command: str.
+    :return: different from the command.
+    """
+    if command == "status":
+        def method(cmdResult):
+            """
+            Parse method for service XXX status.
+
+            Returns True if XXX is running.
+            Returns False if XXX is stopped.
+            Returns None if XXX is unrecognized.
+            """
+            # If service is stopped, exit_status is also not zero.
+            # So, we can't use exit_status to check result.
+            output = cmdResult.stdout.lower()
+            # Returns None if XXX is unrecognized.
+            if re.search(r"unrecognized", output):
+                return None
+            # Returns False if XXX is stopped.
+            dead_flags = [r"stopped", r"not running", r"dead"]
+            for flag in dead_flags:
+                if re.search(flag, output):
+                    return False
+            # If output does not contain a dead flag, check it with "running".
+            return bool(re.search(r"running", output))
+        return method
+    elif command == "list":
+        def method(cmdResult):
+            """
+            Parse method for service XXX list.
+
+            Return dict from service name to status.
+
+            e.g:
+                {"sshd": {0: 'off', 1: 'off', 2: 'off', 3: 'off', 4: 'off', 5: 'off', 6: 'off'},
+                 "vsftpd": {0: 'off', 1: 'off', 2: 'off', 3: 'off', 4: 'off', 5: 'off', 6: 'off'},
+                 "xinetd": {'discard-dgram:': 'off', 'rsync:': 'off'...'chargen-stream:': 'off'},
+                 ...
+                 }
+            """
+            if cmdResult.exit_status:
+                raise process.CmdError(cmdResult.command, cmdResult)
+            # The final dict to return.
+            _service2statusOnTarget_dict = {}
+            # Dict to store status on every target for each service.
+            _status_on_target = {}
+            # Dict to store the status for service based on xinetd.
+            _service2statusOnXinet_dict = {}
+            lines = cmdResult.stdout.strip().splitlines()
+            for line in lines:
+                sublines = line.strip().split()
+                if len(sublines) == 8:
+                    # Service and status on each target.
+                    service_name = sublines[0]
+                    # Store the status of each target in _status_on_target.
+                    for target in range(7):
+                        status = sublines[target + 1].split(":")[-1]
+                        _status_on_target[target] = status
+                    _service2statusOnTarget_dict[service_name] = _status_on_target.copy()
+
+                elif len(sublines) == 2:
+                    # Service based on xinetd.
+                    service_name = sublines[0].strip(":")
+                    status = sublines[-1]
+                    _service2statusOnXinet_dict[service_name] = status
+
+                else:
+                    # Header or some lines useless.
+                    continue
+            # Add xinetd based service in the main dict.
+            _service2statusOnTarget_dict["xinetd"] = _service2statusOnXinet_dict
+            return _service2statusOnTarget_dict
+        return method
+    else:
+        return _ServiceResultParser.default_method
+
+
+def systemd_result_parser(command):
+    """
+    Parse results from systemd style commands.
+
+    command status: return true if service is running.
+    command is_enabled: return true if service is enalbled.
+    command list: return a dict from service name to status.
+    command others: return true if operate success.
+
+    :param command: command.
+    :type command: str.
+    :return: different from the command.
+    """
+    if command == "status":
+        def method(cmdResult):
+            """
+            Parse method for systemctl status XXX.service.
+
+            Returns True if XXX.service is running.
+            Returns False if XXX.service is stopped.
+            Returns None if XXX.service is not loaded.
+            """
+            # If service is stopped, exit_status is also not zero.
+            # So, we can't use exit_status to check result.
+            output = cmdResult.stdout
+            # Returns None if XXX is not loaded.
+            if not re.search(r"Loaded: loaded", output):
+                return None
+            # Check it with Active status.
+            return (output.count("Active: active") > 0)
+        return method
+    elif command == "list":
+        def method(cmdResult):
+            """
+            Parse method for systemctl list XXX.service.
+
+            Return a dict from service name to status.
+
+            e.g:
+                {"sshd": "enabled",
+                 "vsftpd": "disabled",
+                 "systemd-sysctl": "static",
+                 ...
+                 }
+            """
+            if cmdResult.exit_status:
+                raise process.CmdError(cmdResult.command, cmdResult)
+            # Dict to store service name to status.
+            _service2status_dict = {}
+            lines = cmdResult.stdout.strip().splitlines()
+            for line in lines:
+                sublines = line.strip().split()
+                if (not len(sublines) == 2) or (not sublines[0].endswith("service")):
+                    # Some lines useless.
+                    continue
+                service_name = sublines[0].rstrip(".service")
+                status = sublines[-1]
+                _service2status_dict[service_name] = status
+            return _service2status_dict
+        return method
+    else:
+        return _ServiceResultParser.default_method
+
+
+def sys_v_init_command_generator(command):
+    """
+    Generate lists of command arguments for sys_v style inits.
+
+    :param command: start,stop,restart, etc.
+    :type command: str
+    :return: list of commands to pass to process.run or similar function
+    :rtype: list
+    """
+    command_name = "service"
+    if command == "is_enabled":
+        command_name = "chkconfig"
+        command = ""
+    elif command == 'enable':
+        command_name = "chkconfig"
+        command = "on"
+    elif command == 'disable':
+        command_name = "chkconfig"
+        command = "off"
+    elif command == 'list':
+        # noinspection PyUnusedLocal
+        def list_command(service_name):
+            return ["chkconfig", "--list"]
+        return list_command
+    elif command == "set_target":
+        def set_target_command(target):
+            target = convert_systemd_target_to_runlevel(target)
+            return ["telinit", target]
+        return set_target_command
+
+    def method(service_name):
+        return [command_name, service_name, command]
+    return method
+
+
+def systemd_command_generator(command):
+    """
+    Generate list of command line argument strings for systemctl.
+    One argument per string for compatibility Popen
+
+    WARNING: If systemctl detects that it is running on a tty it will use color,
+    pipe to $PAGER, change column sizes and not truncate unit names.
+    Use --no-pager to suppress pager output, or set PAGER=cat in the environment.
+    You may need to take other steps to suppress color output.
+    See https://bugzilla.redhat.com/show_bug.cgi?id=713567
+
+    :param command: start,stop,restart, etc.
+    :type command: str
+    :return: list of command and arguments to pass to process.run or similar functions
+    :rtype: list
+    """
+    command_name = "systemctl"
+    if command == "is_enabled":
+        command = "is-enabled"
+    elif command == "list":
+        # noinspection PyUnusedLocal
+        def list_command(service_name):
+            # systemctl pipes to `less` or $PAGER by default. Workaround this
+            # add '--full' to avoid systemctl truncates service names.
+            return [command_name, "list-unit-files",
+                    "--type=service", "--no-pager", "--full"]
+        return list_command
+    elif command == "set_target":
+        def set_target_command(target):
+            return [command_name, "isolate", target]
+        return set_target_command
+
+    def method(service_name):
+        return [command_name, command, "%s.service" % service_name]
+    return method
+
+
+COMMANDS = (
+    "start",
+    "stop",
+    "reload",
+    "restart",
+    "condrestart",
+    "status",
+    "enable",
+    "disable",
+    "is_enabled",
+    "list",
+    "set_target",
+)
+
+
+class _ServiceResultParser(object):
+
+    """
+    A class that contains staticmethods to parse the result of service command.
+    """
+
+    def __init__(self, result_parser, command_list=COMMANDS):
+        """
+            Create staticmethods for each command in command_list using setattr and the
+            result_parser
+
+            :param result_parser: function that generates functions that parse the result of command.
+            :type result_parser: function
+            :param command_list: list of all the commands, e.g. start, stop, restart, etc.
+            :type command_list: list
+        """
+        self.commands = command_list
+        for command in self.commands:
+            setattr(self, command, result_parser(command))
+
+    @staticmethod
+    def default_method(cmdResult):
+        """
+        Default method to parse result from command which is not 'list' nor 'status'.
+
+        Returns True if command was executed successfully.
+        """
+        if cmdResult.exit_status:
+            LOG.debug(cmdResult)
+            return False
+        else:
+            return True
+
+
+class _ServiceCommandGenerator(object):
+
+    """
+    A class that contains staticmethods that generate partial functions that
+    generate command lists for starting/stopping services.
+    """
+
+    def __init__(self, command_generator, command_list=COMMANDS):
+        """
+            Create staticmethods for each command in command_list using setattr and the
+            command_generator
+
+            :param command_generator: function that generates functions that generate lists of command strings
+            :type command_generator: function
+            :param command_list: list of all the commands, e.g. start, stop, restart, etc.
+            :type command_list: list
+        """
+        self.commands = command_list
+        for command in self.commands:
+            setattr(self, command, command_generator(command))
+
+
+def _get_name_of_init(run=process.run):
+    """
+    Internal function to determine what executable is PID 1,
+    aka init by checking /proc/1/exe
+    :return: executable name for PID 1, aka init
+    :rtype:  str
+    """
+    # /proc/1/comm was added in 2.6.33 and is not in RHEL6.x, so use cmdline
+    # Non-root can read cmdline
+    # return os.path.basename(open("/proc/1/cmdline").read().split(chr(0))[0])
+    # readlink /proc/1/exe requires root
+    # inspired by openvswitch.py:ServiceManagerInterface.get_version()
+    output = run("readlink /proc/1/exe").stdout.strip()
+    return os.path.basename(output)
+
+
+def get_name_of_init(run=process.run):
+    """
+    Determine what executable is PID 1, aka init by checking /proc/1/exe
+    This init detection will only run once and cache the return value.
+
+    :return: executable name for PID 1, aka init
+    :rtype:  str
+    """
+    # _init_name is explicitly undefined so that we get the NameError on first access
+    # pylint: disable=W0601
+    global _init_name
+    try:
+        return _init_name
+    except (NameError, AttributeError):
+        _init_name = _get_name_of_init(run)
+        return _init_name
+
+
+class _SpecificServiceManager(object):
+
+    def __init__(self, service_name, service_command_generator, service_result_parser, run=process.run):
+        """
+        Create staticmethods that call process.run with the given service_name
+        for each command in service_command_generator.
+
+        lldpad = SpecificServiceManager("lldpad", auto_create_specific_service_command_generator())
+        lldpad.start()
+        lldpad.stop()
+
+        :param service_name: init service name or systemd unit name
+        :type service_name: str
+        :param service_command_generator: a sys_v_init or systemd command generator
+        :type service_command_generator: _ServiceCommandGenerator
+        :param run: function that executes the commands and return CmdResult object, default process.run
+        :type run: function
+        """
+        for cmd in service_command_generator.commands:
+            setattr(self, cmd,
+                    self.generate_run_function(run,
+                                               getattr(service_result_parser, cmd),
+                                               getattr(service_command_generator, cmd),
+                                               service_name))
+
+    @staticmethod
+    def generate_run_function(run_func, parse_func, command, service_name):
+        """
+        Generate the wrapped call to process.run for the given service_name.
+
+        :param run_func:  function to execute command and return CmdResult object.
+        :type run_func:  function
+        :param parse_func: function to parse the result from run.
+        :type parse_func: function
+        :param command: partial function that generates the command list
+        :type command: function
+        :param service_name: init service name or systemd unit name
+        :type service_name: str
+        :return: wrapped process.run function.
+        :rtype: function
+        """
+        def run(**kwargs):
+            """
+            Wrapped process.run invocation that will start, stop, restart, etc. a service.
+
+            :param kwargs: extra arguments to process.run, .e.g. timeout. But not for ignore_status.
+                We need a CmdResult to parse and raise a error.TestError if command failed.
+                We will not let the CmdError out.
+            :return: result of parse_func.
+            """
+            # If run_func is process.run by default, we need to set
+            # ignore_status = True. Otherwise, skip this setting.
+            if run_func is process.run:
+                LOG.debug("Setting ignore_status to True.")
+                kwargs["ignore_status"] = True
+            result = run_func(" ".join(command(service_name)), **kwargs)
+            return parse_func(result)
+        return run
+
+
+class _GenericServiceManager(object):
+
+    """
+    Base class for SysVInitServiceManager and SystemdServiceManager.
+    """
+
+    def __init__(self, service_command_generator, service_result_parser, run=process.run):
+        """
+        Create staticmethods for each service command, e.g. start, stop, restart.
+        These staticmethods take as an argument the service to be started or stopped.
+
+        systemd = SpecificServiceManager(auto_create_specific_service_command_generator())
+        systemd.start("lldpad")
+        systemd.stop("lldpad")
+
+        :param service_command_generator: a sys_v_init or systemd command generator
+        :type service_command_generator: _ServiceCommandGenerator
+        :param run: function to call the run the commands, default process.run
+        :type run: function
+        """
+        # create staticmethods in class attributes (not used)
+        # for cmd in service_command_generator.commands:
+        #     setattr(self.__class__, cmd,
+        #             staticmethod(self.generate_run_function(run, getattr(service_command_generator, cmd))))
+        # create functions in instance attributes
+        for cmd in service_command_generator.commands:
+            setattr(self, cmd,
+                    self.generate_run_function(run,
+                                               getattr(service_result_parser, cmd),
+                                               getattr(service_command_generator, cmd)))
+
+    @staticmethod
+    def generate_run_function(run_func, parse_func, command):
+        """
+        Generate the wrapped call to process.run for the service command, "service" or "systemctl"
+
+        :param run_func:  process.run
+        :type run_func:  function
+        :param command: partial function that generates the command list
+        :type command: function
+        :return: wrapped process.run function.
+        :rtype: function
+        """
+        def run(service="", **kwargs):
+            """
+            Wrapped process.run invocation that will start, stop, restart, etc. a service.
+
+            :param service: service name, e.g. crond, dbus, etc.
+            :param kwargs: extra arguments to process.run, .e.g. timeout. But not for ignore_status.
+                We need a CmdResult to parse and raise a error.TestError if command failed.
+                We will not let the CmdError out.
+            :return: result of parse_func.
+            """
+            # If run_func is process.run by default, we need to set
+            # ignore_status = True. Otherwise, skip this setting.
+            if run_func is process.run:
+                LOG.debug("Setting ignore_status to True.")
+                kwargs["ignore_status"] = True
+            result = run_func(" ".join(command(service)), **kwargs)
+            return parse_func(result)
+        return run
+
+
+class _SysVInitServiceManager(_GenericServiceManager):
+
+    """
+    Concrete class that implements the SysVInitServiceManager
+    """
+
+    def __init__(self, service_command_generator, service_result_parser, run=process.run):
+        """
+        Create the GenericServiceManager for SysV services.
+
+        :param service_command_generator:
+        :type service_command_generator: _ServiceCommandGenerator
+        :param run: function to call to run the commands, default process.run
+        :type run: function
+        """
+        super(_SysVInitServiceManager, self).__init__(service_command_generator,
+                                                      service_result_parser, run)
+
+    # @staticmethod
+    # def change_default_runlevel(runlevel='3'):
+    #     """
+    #     Set the default sys_v runlevel
+    #
+    #     :param runlevel: sys_v runlevel to set as default in inittab
+    #     :type runlevel: str
+    #     """
+    #     raise NotImplemented
+
+
+def convert_sysv_runlevel(level):
+    """
+    Convert runlevel to systemd target.
+
+    :param level: sys_v runlevel
+    :type level: str or int
+    :return: systemd target
+    :rtype: str
+    :raise ValueError: when runlevel is unknown
+    """
+    runlevel = str(level)
+    if runlevel == '0':
+        target = "poweroff.target"
+    elif runlevel in ['1', "s", "single"]:
+        target = "rescue.target"
+    elif runlevel in ['2', '3', '4']:
+        target = "multi-user.target"
+    elif runlevel == '5':
+        target = "graphical.target"
+    elif runlevel == '6':
+        target = "reboot.target"
+    else:
+        raise ValueError("unknown runlevel %s" % level)
+    return target
+
+
+def convert_systemd_target_to_runlevel(target):
+    """
+    Convert systemd target to runlevel.
+
+    :param target: systemd target
+    :type target: str
+    :return: sys_v runlevel
+    :rtype: str
+    :raise ValueError: when systemd target is unknown
+    """
+    if target == "poweroff.target":
+        runlevel = '0'
+    elif target == "rescue.target":
+        runlevel = 's'
+    elif target == "multi-user.target":
+        runlevel = '3'
+    elif target == "graphical.target":
+        runlevel = '5'
+    elif target == "reboot.target":
+        runlevel = '6'
+    else:
+        raise ValueError("unknown target %s" % target)
+    return runlevel
+
+
+class _SystemdServiceManager(_GenericServiceManager):
+
+    """
+    Concrete class that implements the SystemdServiceManager
+    """
+
+    def __init__(self, service_command_generator, service_result_parser, run=process.run):
+        """
+        Create the GenericServiceManager for systemd services.
+
+        :param service_command_generator:
+        :type service_command_generator: _ServiceCommandGenerator
+        :param run: function to call to run the commands, default process.run
+        :type run: function
+        """
+        super(_SystemdServiceManager, self).__init__(service_command_generator,
+                                                     service_result_parser, run)
+
+    @staticmethod
+    def change_default_runlevel(runlevel='multi-user.target'):
+        # atomic symlinking, symlink and then rename
+        """
+        Set the default systemd target.
+        Create the symlink in a temp directory and then use
+        atomic rename to move the symlink into place.
+
+        :param runlevel: default systemd target
+        :type runlevel: str
+        """
+        tmp_symlink = mktemp(dir="/etc/systemd/system")
+        os.symlink("/usr/lib/systemd/system/%s" % runlevel, tmp_symlink)
+        os.rename(tmp_symlink, "/etc/systemd/system/default.target")
+
+
+_command_generators = {"init": sys_v_init_command_generator,
+                       "systemd": systemd_command_generator}
+
+_result_parsers = {"init": sys_v_init_result_parser,
+                   "systemd": systemd_result_parser}
+
+_service_managers = {"init": _SysVInitServiceManager,
+                     "systemd": _SystemdServiceManager}
+
+
+def _get_service_result_parser(run=process.run):
+    """
+    Get the ServiceResultParser using the auto-detect init command.
+
+    :return: ServiceResultParser fro the current init command.
+    :rtype: _ServiceResultParser
+    """
+    # pylint: disable=W0601
+    global _service_result_parser
+    try:
+        return _service_result_parser
+    except NameError:
+        result_parser = _result_parsers[get_name_of_init(run)]
+        _service_result_parser = _ServiceResultParser(result_parser)
+        return _service_result_parser
+
+
+def _get_service_command_generator(run=process.run):
+    """
+    Lazy initializer for ServiceCommandGenerator using the auto-detect init command.
+
+    :return: ServiceCommandGenerator for the current init command.
+    :rtype: _ServiceCommandGenerator
+    """
+    # _service_command_generator is explicitly undefined so that we get the NameError on first access
+    # pylint: disable=W0601
+    global _service_command_generator
+    try:
+        return _service_command_generator
+    except NameError:
+        command_generator = _command_generators[get_name_of_init(run)]
+        _service_command_generator = _ServiceCommandGenerator(
+            command_generator)
+        return _service_command_generator
+
+
+def ServiceManager(run=process.run):
+    """
+    Detect which init program is being used, init or systemd and return a
+    class has methods to start/stop services.
+
+    # Get the system service manager
+    >> service_manager = ServiceManager()
+
+    # Stating service/unit "sshd"
+    >> service_manager.start("sshd")
+
+    # Getting a list of available units
+    >> units = service_manager.list()
+
+    # Disabling and stopping a list of services
+    >> services_to_disable = ['ntpd', 'httpd']
+
+    >> for s in services_to_disable:
+    >>    service_manager.disable(s)
+    >>    service_manager.stop(s)
+
+    :return: SysVInitServiceManager or SystemdServiceManager
+    :rtype: _GenericServiceManager
+    """
+    service_manager = _service_managers[get_name_of_init(run)]
+    # _service_command_generator is explicitly undefined so that we get the NameError on first access
+    # pylint: disable=W0601
+    global _service_manager
+    try:
+        return _service_manager
+    except NameError:
+        _service_manager = service_manager(_get_service_command_generator(run),
+                                           _get_service_result_parser(run))
+        return _service_manager
+
+
+def _auto_create_specific_service_result_parser(run=process.run):
+    """
+    Create a class that will create partial functions that generate result_parser
+    for the current init command.
+
+    :return: A ServiceResultParser for the auto-detected init command.
+    :rtype: _ServiceResultParser
+    """
+    result_parser = _result_parsers[get_name_of_init(run)]
+    # remove list method
+    command_list = [c for c in COMMANDS if c not in ["list", "set_target"]]
+    return _ServiceResultParser(result_parser, command_list)
+
+
+def _auto_create_specific_service_command_generator(run=process.run):
+    """
+    Create a class that will create partial functions that generate commands
+    for the current init command.
+
+    lldpad = SpecificServiceManager("lldpad", auto_create_specific_service_command_generator())
+    lldpad.start()
+    lldpad.stop()
+
+    :return: A ServiceCommandGenerator for the auto-detected init command.
+    :rtype: _ServiceCommandGenerator
+    """
+    command_generator = _command_generators[get_name_of_init(run)]
+    # remove list method
+    command_list = [c for c in COMMANDS if c not in ["list", "set_target"]]
+    return _ServiceCommandGenerator(command_generator, command_list)
+
+
+def SpecificServiceManager(service_name, run=process.run):
+    """
+
+    # Get the specific service manager for sshd
+    sshd = SpecificServiceManager("sshd")
+    sshd.start()
+    sshd.stop()
+    sshd.reload()
+    sshd.restart()
+    sshd.condrestart()
+    sshd.status()
+    sshd.enable()
+    sshd.disable()
+    sshd.is_enabled()
+
+    :param service_name: systemd unit or init.d service to manager
+    :type service_name: str
+    :return: SpecificServiceManager that has start/stop methods
+    :rtype: _SpecificServiceManager
+    """
+    return _SpecificServiceManager(service_name,
+                                   _auto_create_specific_service_command_generator(run),
+                                   _get_service_result_parser(run), run)

--- a/selftests/all/unit/avocado/utils_linux_modules_unittest.py
+++ b/selftests/all/unit/avocado/utils_linux_modules_unittest.py
@@ -1,0 +1,81 @@
+import unittest
+import os
+import sys
+
+# simple magic for using scripts within a source tree
+basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+basedir = os.path.dirname(basedir)
+if os.path.isdir(os.path.join(basedir, 'avocado')):
+    sys.path.append(basedir)
+
+from avocado.utils import linux_modules
+
+
+class TestLsmod(unittest.TestCase):
+
+    LSMOD_OUT = """\
+Module                  Size  Used by
+ccm                    17773  2
+ip6t_rpfilter          12546  1
+ip6t_REJECT            12939  2
+xt_conntrack           12760  9
+ebtable_nat            12807  0
+ebtable_broute         12731  0
+bridge                110862  1 ebtable_broute
+stp                    12868  1 bridge
+llc                    13941  2 stp,bridge
+ebtable_filter         12827  0
+ebtables               30758  3 ebtable_broute,ebtable_nat,ebtable_filter
+ip6table_nat           13015  1
+nf_conntrack_ipv6      18738  6
+nf_defrag_ipv6         34712  1 nf_conntrack_ipv6
+nf_nat_ipv6            13213  1 ip6table_nat
+ip6table_mangle        12700  1
+ip6table_security      12710  1
+ip6table_raw           12683  1
+ip6table_filter        12815  1
+"""
+
+    def test_parse_lsmod(self):
+        lsmod_info = linux_modules.parse_lsmod_for_module(
+            self.LSMOD_OUT, "ebtables")
+        submodules = ['ebtable_broute', 'ebtable_nat', 'ebtable_filter']
+        assert lsmod_info['submodules'] == submodules
+        assert lsmod_info == {
+            'name': "ebtables",
+            'size': 30758,
+            'used': 3,
+            'submodules': submodules
+        }
+
+    @staticmethod
+    def test_parse_lsmod_is_empty():
+        lsmod_info = linux_modules.parse_lsmod_for_module("", "ebtables")
+        assert lsmod_info == {}
+
+    def test_parse_lsmod_no_submodules(self):
+        lsmod_info = linux_modules.parse_lsmod_for_module(self.LSMOD_OUT, "ccm")
+        submodules = []
+        assert lsmod_info['submodules'] == submodules
+        assert lsmod_info == {
+            'name': "ccm",
+            'size': 17773,
+            'used': 2,
+            'submodules': submodules
+        }
+
+    def test_parse_lsmod_single_submodules(self):
+        lsmod_info = linux_modules.parse_lsmod_for_module(
+            self.LSMOD_OUT, "bridge")
+        submodules = ['ebtable_broute']
+        assert lsmod_info['submodules'] == submodules
+        assert lsmod_info == {
+            'name': "bridge",
+            'size': 110862,
+            'used': 1,
+            'submodules': submodules
+        }
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/selftests/all/unit/avocado/utils_output_unittest.py
+++ b/selftests/all/unit/avocado/utils_output_unittest.py
@@ -1,0 +1,35 @@
+import unittest
+import os
+import sys
+
+# simple magic for using scripts within a source tree
+basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+basedir = os.path.dirname(basedir)
+if os.path.isdir(os.path.join(basedir, 'avocado')):
+    sys.path.append(basedir)
+
+from avocado.utils import output
+
+
+class UtilsOutputTest(unittest.TestCase):
+
+    def testDisplayDataSizeFactor1024(self):
+        self.assertEqual(output.display_data_size(103), '103.00 B')
+        self.assertEqual(output.display_data_size(1024**1), '1.02 KB')
+        self.assertEqual(output.display_data_size(1024**2), '1.05 MB')
+        self.assertEqual(output.display_data_size(1024**3), '1.07 GB')
+        self.assertEqual(output.display_data_size(1024**4), '1.10 TB')
+        self.assertEqual(output.display_data_size(1024**5), '1.13 PB')
+        self.assertEqual(output.display_data_size(1024**6), '1152.92 PB')
+
+    def testDisplayDataSizeFactor1000(self):
+        self.assertEqual(output.display_data_size(1000**1), '1.00 KB')
+        self.assertEqual(output.display_data_size(1000**2), '1.00 MB')
+        self.assertEqual(output.display_data_size(1000**3), '1.00 GB')
+        self.assertEqual(output.display_data_size(1000**4), '1.00 TB')
+        self.assertEqual(output.display_data_size(1000**5), '1.00 PB')
+        self.assertEqual(output.display_data_size(1000**6), '1000.00 PB')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
In the process of merging virt-test into avocado-vt (see https://github.com/avocado-framework/avocado-vt/pull/30), we mostly dropped virt-test's autotest API calls, replacing them with equivalent avocado API calls. Of course, avocado didn't have some of the expected APIs, and that's the purpose of this Pull Request: to add the missing ones.

Update: There's no more `exceptions.context` API added here. We decided it was best to find a better way to do that in avocado, so virt-test's got its own implementation of the context APIs.