### PR TITLE
examples: Add a folder with simple tests

### DIFF
--- a/avocado.spec
+++ b/avocado.spec
@@ -100,6 +100,7 @@ examples of how to write tests on your own.
 
 %files examples
 %{_datadir}/avocado/tests
+%{_datadir}/avocado/simpletests
 %{_datadir}/avocado/wrappers
 
 %changelog

--- a/docs/source/GetStartedGuide.rst
+++ b/docs/source/GetStartedGuide.rst
@@ -130,13 +130,9 @@ tests.
 Let's now list a directory with a bunch of executable shell
 scripts::
 
-   $ avocado list /usr/share/avocado/examples/wrappers
-    SIMPLE examples/wrappers/dummy.sh
-    SIMPLE examples/wrappers/ltrace.sh
-    SIMPLE examples/wrappers/perf.sh
-    SIMPLE examples/wrappers/strace.sh
-    SIMPLE examples/wrappers/time.sh
-    SIMPLE examples/wrappers/valgrind.sh
+   $ avocado list /usr/share/avocado/simpletests/
+   SIMPLE /usr/share/avocado/simpletests/failtest.sh
+   SIMPLE /usr/share/avocado/simpletests/passtest.sh
 
 Here, as mentioned before, ``SIMPLE`` means that those files are executables
 treated as simple tests. You can also give the ``--verbose`` or ``-V`` flag to

--- a/examples/simpletests/failtest.sh
+++ b/examples/simpletests/failtest.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+false
+

--- a/examples/simpletests/passtest.sh
+++ b/examples/simpletests/passtest.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+true
+

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,11 @@ def get_data_files():
     data_files += [(get_dir(['usr', 'share', 'avocado', 'wrappers'],
                             ['wrappers']),
                     glob.glob('examples/wrappers/*.sh'))]
+
+    data_files += [(get_dir(['usr', 'share', 'avocado', 'simpletests'],
+                            ['simpletests']),
+                    glob.glob('examples/simpletests/*.sh'))]
+
     data_files.append((get_avocado_libexec_dir(), glob.glob('libexec/*')))
     return data_files
 


### PR DESCRIPTION
This fixes #628.

Add a couple of simple shell scripts that can be listed
and executed with avocado. Let's update our documentation
to use this new dir and avoid people confused with our
wrappers.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>