### PR TITLE
avocado.core.exceptions: Update fail_on_error and rename to fail_on

### DIFF
--- a/avocado/__init__.py
+++ b/avocado/__init__.py
@@ -19,4 +19,4 @@ __all__ = ['main', 'Test', 'VERSION', 'fail_on_error']
 from avocado.core.job import main
 from avocado.core.test import Test
 from avocado.core.version import VERSION
-from avocado.core.exceptions import fail_on_error
+from avocado.core.exceptions import fail_on

--- a/avocado/core/exceptions.py
+++ b/avocado/core/exceptions.py
@@ -15,29 +15,40 @@
 """
 Exception classes, useful for tests, and other parts of the framework code.
 """
+from functools import wraps
 
 
-def fail_on_error(fn):
+def fail_on(exceptions=None):
     """
-    Apply to any test you want to FAIL upon any exception raised.
+    Apply to any function to make it fail rather than error when exception
+    is of provided type.
 
-    Normally only TestFail called explicitly will mark an avocado test with the
-    FAIL state, but this decorator is provided as a convenience for people
-    that need a more relaxed behavior.
-
-    :param fn: Function that will be decorated
+    :param exceptions: List of exceptions to be assumed as FAIL [Exception]
+    :note: Avocado exceptions are re-raised untouched
+    :note: To allow simple usage param "exceptions" must not be callable
     """
-    def new_fn(*args, **kwargs):
-        try:
-            return fn(*args, **kwargs)
-        except TestBaseException:
-            raise
-        except Exception, e:
-            raise TestFail(str(e))
-    new_fn.__name__ = fn.__name__
-    new_fn.__doc__ = fn.__doc__
-    new_fn.__dict__.update(fn.__dict__)
-    return new_fn
+    func = False
+    if callable(exceptions):    # Someone used it as @fail_on without ()
+        func = exceptions
+        exceptions = Exception
+    elif exceptions is None:
+        exceptions = Exception
+
+    def decorate(func):
+        """ Decorator """
+        @wraps(func)
+        def wrap(*args, **kwargs):
+            """ Function wrapper """
+            try:
+                return func(*args, **kwargs)
+            except TestBaseException:
+                raise
+            except exceptions, details:
+                raise TestFail(str(details))
+        return wrap
+    if func:
+        return decorate(func)
+    return decorate
 
 
 class JobBaseException(Exception):

--- a/examples/tests/fail_on_exception.py
+++ b/examples/tests/fail_on_exception.py
@@ -3,13 +3,14 @@
 import avocado
 
 
-class FailOnError(avocado.Test):
+class FailOnException(avocado.Test):
 
     """
-    Test illustrating the behavior of the fail_on_error decorator.
+    Test illustrating the behavior of the fail_on decorator.
     """
 
-    @avocado.fail_on_error
+    # @avocado.fail_on(ValueError) also possible
+    @avocado.fail_on
     def test(self):
         """
         This should end with FAIL.

--- a/selftests/all/functional/avocado/basic_tests.py
+++ b/selftests/all/functional/avocado/basic_tests.py
@@ -126,10 +126,10 @@ class RunnerOperationTest(unittest.TestCase):
                                                                 result))
         self.assertIn('"status": "ERROR"', result.stdout)
 
-    def test_fail_on_error(self):
+    def test_fail_on_exception(self):
         os.chdir(basedir)
         cmd_line = ("./scripts/avocado run --sysinfo=off --job-results-dir %s "
-                    "--json - fail_on_error" % self.tmpdir)
+                    "--json - fail_on_exception" % self.tmpdir)
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 1
         self.assertEqual(result.exit_status, expected_rc,


### PR DESCRIPTION
This patch renames the fail_on_error decorator to fail_on and adds
support to supply list of exceptions. This way the decorator can be used
not only to make tests fail on generic exceptions but also to specify
parts of code with expected failures of given type.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>