### PR TITLE
avocado.core.exceptions: Update fail_on_error and rename to fail_on

### DIFF
--- a/avocado/__init__.py
+++ b/avocado/__init__.py
@@ -13,10 +13,10 @@
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
 
-__all__ = ['main', 'Test', 'VERSION', 'fail_on_error']
+__all__ = ['main', 'Test', 'VERSION', 'fail_on']
 
 
 from avocado.core.job import main
 from avocado.core.test import Test
 from avocado.core.version import VERSION
-from avocado.core.exceptions import fail_on_error
+from avocado.core.exceptions import fail_on

--- a/examples/tests/fail_on_exception.py
+++ b/examples/tests/fail_on_exception.py
@@ -3,13 +3,14 @@
 import avocado
 
 
-class FailOnError(avocado.Test):
+class FailOnException(avocado.Test):
 
     """
-    Test illustrating the behavior of the fail_on_error decorator.
+    Test illustrating the behavior of the fail_on decorator.
     """
 
-    @avocado.fail_on_error
+    # @avocado.fail_on(ValueError) also possible
+    @avocado.fail_on
     def test(self):
         """
         This should end with FAIL.

--- a/selftests/all/functional/avocado/basic_tests.py
+++ b/selftests/all/functional/avocado/basic_tests.py
@@ -126,10 +126,10 @@ class RunnerOperationTest(unittest.TestCase):
                                                                 result))
         self.assertIn('"status": "ERROR"', result.stdout)
 
-    def test_fail_on_error(self):
+    def test_fail_on_exception(self):
         os.chdir(basedir)
         cmd_line = ("./scripts/avocado run --sysinfo=off --job-results-dir %s "
-                    "--json - fail_on_error" % self.tmpdir)
+                    "--json - fail_on_exception" % self.tmpdir)
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 1
         self.assertEqual(result.exit_status, expected_rc,


### PR DESCRIPTION
This patch renames the fail_on_error decorator to fail_on and adds
support to supply list of exceptions. This way the decorator can be used
not only to make tests fail on generic exceptions but also to specify
parts of code with expected failures of given type.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>

v1: https://github.com/avocado-framework/avocado/pull/715
v2: https://github.com/avocado-framework/avocado/pull/716

Changes:

    v2: Exceptions must be specified as tuple, not list
    v2: correct the func name in __init__
    v3: Improved docstrings
    v3: Improved Exception vs. function detection mechanism