### PR TITLE
avocado.core.loader: Refactor the loader to be consistent

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -160,7 +160,7 @@ class Job(object):
                     self.test_loader.add_loader_plugin(loader_plugin)
             except TypeError:
                 pass
-        filesystem_loader = loader.TestLoader(self)
+        filesystem_loader = loader.FileLoader(self)
         self.test_loader.add_loader_plugin(filesystem_loader)
 
     def _make_test_runner(self):

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -30,7 +30,7 @@ import fnmatch
 from . import version
 from . import data_dir
 from . import runner
-from .loader import loader
+from . import loader
 from . import sysinfo
 from . import result
 from . import exit_codes
@@ -246,25 +246,15 @@ class Job(object):
         :returns: a test suite (a list of test factories)
         """
         urls = self._handle_urls(urls)
-        loader.load_plugins(self.args)
-        return loader.discover(urls)
-
-    def _validate_test_suite(self, test_suite):
+        loader.loader.load_plugins(self.args)
         try:
-            # Do not attempt to validate the tests given on the command line if
-            # the tests will not be copied from this system to a remote one
-            # using the remote plugin features
-            if not getattr(self.args, 'remote_no_copy', False):
-                error_msg_parts = loader.validate_ui(test_suite)
-            else:
-                error_msg_parts = []
-        except KeyboardInterrupt:
-            raise exceptions.JobError('Command interrupted by user...')
-
-        if error_msg_parts:
+            return loader.loader.discover(urls)
+        except loader.LoaderUnhandledUrlError, details:
             self._remove_job_results()
-            e_msg = '\n'.join(error_msg_parts)
-            raise exceptions.OptionValidationError(e_msg)
+            raise exceptions.OptionValidationError(details)
+        except KeyboardInterrupt:
+            self._remove_job_results()
+            raise exceptions.JobError('Command interrupted by user...')
 
     def _filter_test_suite(self, test_suite):
         # Filter tests methods with params.filter and methodName
@@ -426,11 +416,9 @@ class Job(object):
                 that configure a job failure.
         """
         self._setup_job_results()
-
         test_suite = self._make_test_suite(urls)
-        self._validate_test_suite(test_suite)
-        test_suite = self._filter_test_suite(test_suite)
         if not test_suite:
+            self._remove_job_results()
             e_msg = ("No tests found within the specified path(s) "
                      "(Possible reasons: File ownership, permissions, "
                      "filters, typos)")

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -22,10 +22,12 @@ import inspect
 import os
 import re
 import sys
+import fnmatch
 
 from . import data_dir
 from . import output
 from . import test
+from .settings import settings
 from ..utils import path
 from ..utils import stacktrace
 
@@ -35,11 +37,34 @@ except ImportError:
     import StringIO
 
 
-class InvalidLoaderPlugin(Exception):
+class LoaderError(Exception):
+
+    """ Loader exception """
+
+    pass
+
+
+class InvalidLoaderPlugin(LoaderError):
 
     """ Invalid loader plugin """
 
     pass
+
+
+class LoaderUnhandledUrlError(LoaderError):
+
+    """ Urls not handled by any loader """
+
+    def __init__(self, unhandled_urls, plugins):
+        self.unhandled_urls = unhandled_urls
+        self.plugins = [_.name for _ in plugins]
+
+    def __str__(self):
+        return ("Unable to discover url(s) '%s' with '%s' loader plugin(s), "
+                "try running 'avocado list -V %s' to see the details."
+                % ("', '" .join(self.unhandled_urls),
+                   "', '".join(self.plugins),
+                   " ".join(self.unhandled_urls)))
 
 
 class TestLoaderProxy(object):
@@ -61,15 +86,27 @@ class TestLoaderProxy(object):
 
     def load_plugins(self, args):
         self._initialized_plugins = []
-        for plugin in self.registered_plugins:
-            self._initialized_plugins.append(plugin(args))
         # Add (default) file loader if not already registered
         if FileLoader not in self.registered_plugins:
-            self._initialized_plugins.append(FileLoader(args))
+            self.registered_plugins.append(FileLoader)
+        # Load plugin by the priority from settings
+        plugins = self.registered_plugins[:]
+        names = [_.name for _ in plugins]
+        priority = settings.get_value("plugins", "loader_plugins_priority",
+                                      list, [])
+        sorted_plugins = [plugins[names.index(name)]
+                          for name in priority
+                          if name in names]
+        for plugin in sorted_plugins:
+            self._initialized_plugins.append(plugin(args))
+        for plugin in self.registered_plugins:
+            if plugin in sorted_plugins:
+                continue
+            self._initialized_plugins.append(plugin(args))
 
-    def get_extra_listing(self, args):
+    def get_extra_listing(self):
         for loader_plugin in self._initialized_plugins:
-            loader_plugin.get_extra_listing(args)
+            loader_plugin.get_extra_listing()
 
     def get_base_keywords(self):
         base_path = []
@@ -99,47 +136,48 @@ class TestLoaderProxy(object):
         :type list_non_tests: bool
         :return: A list of test factories (tuples (TestClass, test_params))
         """
-        test_factories = []
-        for loader_plugin in self._initialized_plugins:
-            if urls:
-                _urls = urls
+        def handle_exception(plugin, details):
+            # FIXME: Introduce avocado.exceptions logger and use here
+            stacktrace.log_message("Test discovery plugin %s failed: "
+                                   "%s" % (plugin, details),
+                                   'avocado.app.exceptions')
+            # FIXME: Introduce avocado.traceback logger and use here
+            stacktrace.log_exc_info(sys.exc_info(),
+                                    'avocado.app.tracebacks')
+        tests = []
+        unhandeled_urls = []
+        if not urls:
+            for loader_plugin in self._initialized_plugins:
+                urls = loader_plugin.get_base_keywords()
+                for url in urls:
+                    try:
+                        tests.extend(loader_plugin.discover(url,
+                                                            list_non_tests))
+                    except Exception, details:
+                        handle_exception(loader_plugin, details)
+        else:
+            for url in urls:
+                handled = False
+                for loader_plugin in self._initialized_plugins:
+                    try:
+                        _test = loader_plugin.discover(url, list_non_tests)
+                        if _test:
+                            tests.extend(_test)
+                            handled = True
+                            if not list_non_tests:
+                                break    # Don't process other plugins
+                    except Exception, details:
+                        handle_exception(loader_plugin, details)
+                if not handled:
+                    unhandeled_urls.append(url)
+        if unhandeled_urls:
+            if list_non_tests:
+                tests.extend([(test.MissingTest, {'name': url})
+                              for url in list_non_tests])
             else:
-                _urls = loader_plugin.get_base_keywords()
-            for url in _urls:
-                if url in self.url_plugin_mapping:
-                    continue
-                try:
-                    params_list_from_url = loader_plugin.discover_url(url)
-                    if list_non_tests:
-                        for params in params_list_from_url:
-                            params['omit_non_tests'] = False
-                    if params_list_from_url:
-                        test_factory = loader_plugin.discover(params_list_from_url)
-                        self.url_plugin_mapping[url] = loader_plugin
-                        test_factories += test_factory
-                except Exception, details:
-                    # FIXME: Introduce avocado.exceptions logger and use here
-                    stacktrace.log_message("Test discovery plugin %s failed: "
-                                           "%s" % (loader_plugin, details),
-                                           'avocado.app.exceptions')
-                    # FIXME: Introduce avocado.traceback logger and use here
-                    stacktrace.log_exc_info(sys.exc_info(),
-                                            'avocado.app.tracebacks')
-        return test_factories
-
-    def validate_ui(self, test_suite, ignore_missing=False,
-                    ignore_not_test=False, ignore_broken_symlinks=False,
-                    ignore_access_denied=False):
-        e_msg = []
-        for tuple_class_params in test_suite:
-            for key in self.url_plugin_mapping:
-                if tuple_class_params[1]['params']['id'].startswith(key):
-                    loader_plugin = self.url_plugin_mapping[key]
-                    e_msg += loader_plugin.validate_ui(test_suite=[tuple_class_params], ignore_missing=ignore_missing,
-                                                       ignore_not_test=ignore_not_test,
-                                                       ignore_broken_symlinks=ignore_broken_symlinks,
-                                                       ignore_access_denied=ignore_access_denied)
-        return e_msg
+                raise LoaderUnhandledUrlError(unhandeled_urls,
+                                              self._initialized_plugins)
+        return tests
 
     def load_test(self, test_factory):
         """
@@ -163,7 +201,7 @@ class TestLoader(object):
     def __init__(self, args):
         self.args = args
 
-    def get_extra_listing(self, args):
+    def get_extra_listing(self):
         pass
 
     def get_base_keywords(self):
@@ -192,35 +230,13 @@ class TestLoader(object):
         """
         return {}
 
-    def discover_url(self, url):
+    def discover(self, url, list_non_tests=False):
         """
         Discover (possible) tests from an url.
 
         :param url: the url to be inspected.
         :type url: str
         :return: a list of test matching the url as params.
-        """
-        raise NotImplementedError
-
-    def discover(self, params_list):
-        """
-        Discover tests for test suite.
-
-        :param params_list: a list of test parameters.
-        :type params_list: list
-        :return: a test suite (a list of test factories).
-        """
-        raise NotImplementedError
-
-    def validate_ui(self, test_suite, ignore_missing=False,
-                    ignore_not_test=False, ignore_broken_symlinks=False,
-                    ignore_access_denied=False):
-        """
-        Validate test suite and deliver error messages to the UI
-        :param test_suite: List of tuples (test_class, test_params)
-        :type test_suite: list
-        :return: List with error messages
-        :rtype: list
         """
         raise NotImplementedError
 
@@ -233,11 +249,17 @@ class AccessDeniedPath(object):
     pass
 
 
+class FilteredOut(object):
+    pass
+
+
 class FileLoader(TestLoader):
 
     """
     Test loader class.
     """
+
+    name = 'file'
 
     def get_base_keywords(self):
         """ Return default tests directory """
@@ -250,7 +272,8 @@ class FileLoader(TestLoader):
                 test.MissingTest: 'MISSING',
                 BrokenSymlink: 'BROKEN_SYMLINK',
                 AccessDeniedPath: 'ACCESS_DENIED',
-                test.Test: 'INSTRUMENTED'}
+                test.Test: 'INSTRUMENTED',
+                FilteredOut: 'FILTERED'}
 
     def get_decorator_mapping(self):
         term_support = output.TermSupport()
@@ -260,9 +283,10 @@ class FileLoader(TestLoader):
                 test.MissingTest: term_support.fail_header_str,
                 BrokenSymlink: term_support.fail_header_str,
                 AccessDeniedPath: term_support.fail_header_str,
-                test.Test: term_support.healthy_str}
+                test.Test: term_support.healthy_str,
+                FilteredOut: term_support.warn_header_str}
 
-    def discover_url(self, url):
+    def discover(self, url, list_non_tests=False):
         """
         Discover (possible) tests from a directory.
 
@@ -270,46 +294,47 @@ class FileLoader(TestLoader):
         The tests are returned in alphabetic order.
 
         :param url: the directory path to inspect.
-        :type url: str
-        :return: a list of test params (each one a dictionary).
+        :param list_non_tests: list corrupted/invalid tests too
+        :return: list of matching tests
         """
         ignore_suffix = ('.data', '.pyc', '.pyo', '__init__.py',
                          '__main__.py')
-        params_list = []
 
         # Look for filename:test_method pattern
+        subtests_filter = None
         if ':' in url:
-            url, filter_pattern = url.split(':', 1)
+            _url, _subtests_filter = url.split(':', 1)
+            if os.path.exists(_url):    # otherwise it's ':' in the file name
+                url = _url
+                subtests_filter = _subtests_filter
+
+        if not os.path.isdir(url):  # Single file
+            return self._make_tests(url, list_non_tests, subtests_filter)
+
+        tests = []
+
+        def add_test_from_exception(exception):
+            """ If the exc.filename is valid test it's added to tests """
+            tests.extend(self._make_tests(exception.filename, list_non_tests))
+
+        def skip_non_test(exception):
+            return None
+
+        if list_non_tests:
+            onerror = add_test_from_exception
         else:
-            filter_pattern = None
+            onerror = skip_non_test
 
-        def onerror(exception):
-            norm_url = os.path.abspath(url)
-            norm_error_filename = os.path.abspath(exception.filename)
-            if os.path.isdir(norm_url) and norm_url != norm_error_filename:
-                omit_non_tests = True
-            else:
-                omit_non_tests = False
-
-            params_list.append({'id': exception.filename,
-                                'filter': filter_pattern,
-                                'omit_non_tests': omit_non_tests})
-
-        for dirpath, dirnames, filenames in os.walk(url, onerror=onerror):
-            for dir_name in dirnames:
-                if dir_name.startswith('.'):
-                    dirnames.pop(dirnames.index(dir_name))
+        for dirpath, _, filenames in os.walk(url, onerror=onerror):
             for file_name in filenames:
                 if not file_name.startswith('.'):
-                    ignore = False
                     for suffix in ignore_suffix:
                         if file_name.endswith(suffix):
-                            ignore = True
-                    if not ignore:
+                            break
+                    else:
                         pth = os.path.join(dirpath, file_name)
-                        params_list.append({'id': pth,
-                                            'omit_non_tests': True})
-        return params_list
+                        tests.extend(self._make_tests(pth, list_non_tests))
+        return tests
 
     def _is_unittests_like(self, test_class, pattern='test'):
         for name, _ in inspect.getmembers(test_class, inspect.ismethod):
@@ -324,31 +349,13 @@ class FileLoader(TestLoader):
                 test_methods.append((name, obj))
         return test_methods
 
-    def _make_missing_test(self, test_name, params):
-        test_class = test.MissingTest
-        test_parameters = {'name': test_name,
-                           'params': params}
-        return test_class, test_parameters
-
-    def _make_not_a_test(self, test_name, params):
-        test_class = test.NotATest
-        test_parameters = {'name': test_name,
-                           'params': params}
-        return test_class, test_parameters
-
-    def _make_simple_test(self, test_path, params):
-        test_class = test.SimpleTest
-        test_parameters = {'name': test_path,
-                           'params': params}
-        return test_class, test_parameters
-
-    def _make_tests(self, test_name, test_path, params):
+    def _make_avocado_tests(self, test_path, make_broken, subtests_filter,
+                            test_name=None):
+        if test_name is None:
+            test_name = test_path
         module_name = os.path.basename(test_path).split('.')[0]
         test_module_dir = os.path.dirname(test_path)
         sys.path.append(test_module_dir)
-        test_class = None
-        test_parameters = {'name': test_name,
-                           'params': params}
         stdin, stdout, stderr = sys.stdin, sys.stdout, sys.stderr
         try:
             sys.stdin = None
@@ -357,36 +364,44 @@ class FileLoader(TestLoader):
             f, p, d = imp.find_module(module_name, [test_module_dir])
             test_module = imp.load_module(module_name, f, p, d)
             f.close()
-            for name, obj in inspect.getmembers(test_module):
-                if inspect.isclass(obj) and inspect.getmodule(obj) == test_module:
+            for _, obj in inspect.getmembers(test_module):
+                if (inspect.isclass(obj) and
+                        inspect.getmodule(obj) == test_module):
                     if issubclass(obj, test.Test):
                         test_class = obj
                         break
+            else:
+                if os.access(test_path, os.X_OK):
+                    # Module does not have an avocado test class inside but
+                    # it's executable, let's execute it.
+                    return self._make_test(test.SimpleTest, test_path)
+                else:
+                    # Module does not have an avocado test class inside, and
+                    # it's not executable. Not a Test.
+                    return make_broken(test.NotATest, test_path)
             if test_class is not None:
                 # Module is importable and does have an avocado test class
                 # inside, let's proceed.
                 if self._is_unittests_like(test_class):
                     test_factories = []
+                    test_parameters = {'name': test_name}
+                    if subtests_filter:
+                        test_parameters['params'] = {'filter': subtests_filter}
                     for test_method in self._make_unittests_like(test_class):
-                        copy_test_parameters = test_parameters.copy()
-                        copy_test_parameters['methodName'] = test_method[0]
-                        class_and_method_name = ':%s.%s' % (
-                            test_class.__name__, test_method[0])
-                        copy_test_parameters['name'] += class_and_method_name
-                        test_factories.append(
-                            [test_class, copy_test_parameters])
+                        name = test_name + ':%s.%s' % (test_class.__name__,
+                                                       test_method[0])
+                        if (subtests_filter is not None and
+                                not fnmatch.fnmatch(test_method[0],
+                                                    subtests_filter)):
+                            test_factories.extend(make_broken(FilteredOut,
+                                                              name))
+                        else:
+                            tst = (test_class, {'name': name,
+                                                'methodName': test_method[0]})
+                            test_factories.append(tst)
                     return test_factories
-            else:
-                if os.access(test_path, os.X_OK):
-                    # Module does not have an avocado test class inside but
-                    # it's executable, let's execute it.
-                    test_class = test.SimpleTest
-                    test_parameters['name'] = test_path
                 else:
-                    # Module does not have an avocado test class inside, and
-                    # it's not executable. Not a Test.
-                    test_class = test.NotATest
-                    test_parameters['name'] = test_path
+                    return self._make_test(test_class, test_name)
 
         # Since a lot of things can happen here, the broad exception is
         # justified. The user will get it unadulterated anyway, and avocado
@@ -397,8 +412,7 @@ class FileLoader(TestLoader):
             if os.access(test_path, os.X_OK):
                 # Module can't be imported, and it's executable. Let's try to
                 # execute it.
-                test_class = test.SimpleTest
-                test_parameters['name'] = test_path
+                return self._make_test(test.SimpleTest, test_path)
             else:
                 # Module can't be imported and it's not an executable. Let's
                 # see if there's an avocado import into the test. Although
@@ -410,162 +424,73 @@ class FileLoader(TestLoader):
                     patterns = ['^from avocado.* import', '^import avocado.*']
                     for pattern in patterns:
                         if re.search(pattern, test_contents, re.MULTILINE):
-                            likely_avocado_test = True
                             break
-                if likely_avocado_test:
-                    test_class = test.BuggyTest
-                    params['exception'] = details
-                else:
-                    test_class = test.NotATest
+                    else:
+                        return make_broken(test.NotATest, test_path)
+                    return make_broken(test.BuggyTest, test_path,
+                                       {'exception': details})
         finally:
             sys.stdin = stdin
             sys.stdout = stdout
             sys.stderr = stderr
+            sys.path.remove(test_module_dir)
 
-        sys.path.pop(sys.path.index(test_module_dir))
-
-        return [(test_class, test_parameters)]
-
-    def _discover_tests(self, params):
+    @staticmethod
+    def _make_test(klass, uid, params=None):
         """
-        Try to discover and resolve tests.
-
-        :param params: dictionary with test parameters.
-        :type params: dict
-        :return: a list of test factories (a pair of test class and test parameters).
+        Create test template
+        :param klass: test class
+        :param uid: test uid (by default used as id and name)
+        :param params: optional params (id won't be overriden when present)
         """
-        test_name = test_path = params.get('id')
+        if not params:
+            params = {}
+        params.setdefault('id', uid)
+        return [(klass, {'name': uid, 'params': params})]
+
+    def _make_tests(self, test_path, list_non_tests, subtests_filter=None):
+        """
+        Create test templates from given path
+        :param test_path: File system path
+        :param list_non_tests: include bad tests (NotATest, BrokenSymlink,...)
+        :param subtests_filter: optional filter of methods for avocado tests
+        """
+        def ignore_broken(klass, uid, params=None):
+            return []
+
+        if list_non_tests:   # return broken test with params
+            make_broken = self._make_test
+        else:               # return empty set instead
+            make_broken = ignore_broken
+        test_name = test_path
         if os.path.exists(test_path):
             if os.access(test_path, os.R_OK) is False:
-                return [(AccessDeniedPath, {'params': {'id': test_path}})]
+                return make_broken(AccessDeniedPath, test_path)
             path_analyzer = path.PathInspector(test_path)
             if path_analyzer.is_python():
-                test_factories = self._make_tests(test_name,
-                                                  test_path,
-                                                  params)
-                return test_factories
+                return self._make_avocado_tests(test_path, make_broken,
+                                                subtests_filter)
             else:
                 if os.access(test_path, os.X_OK):
-                    test_class, test_parameters = self._make_simple_test(test_path,
-                                                                         params)
+                    return self._make_test(test.SimpleTest, test_path)
                 else:
-                    test_class, test_parameters = self._make_not_a_test(test_path,
-                                                                        params)
+                    return make_broken(test.NotATest, test_path)
         else:
             if os.path.islink(test_path):
                 try:
                     if not os.path.isfile(os.readlink(test_path)):
-                        return [(BrokenSymlink, {'params': {'id': test_path}})]
+                        return make_broken(BrokenSymlink, test_path)
                 except OSError:
-                    return [(AccessDeniedPath, {'params': {'id': test_path}})]
+                    return make_broken(AccessDeniedPath, test_path)
 
             # Try to resolve test ID (keep compatibility)
             rel_path = '%s.py' % test_name
             test_path = os.path.join(data_dir.get_test_dir(), rel_path)
             if os.path.exists(test_path):
-                test_factories = self._make_tests(rel_path, test_path, params)
-                return test_factories
+                return self._make_avocado_tests(test_path, list_non_tests,
+                                                subtests_filter, rel_path)
             else:
-                test_class, test_parameters = self._make_missing_test(
-                    test_name, params)
-        return [(test_class, test_parameters)]
-
-    def discover(self, params_list):
-        """
-        Discover tests for test suite.
-
-        :param params_list: a list of test parameters.
-        :type params_list: list
-        :return: a test suite (a list of test factories).
-        """
-        test_suite = []
-        for params in params_list:
-            test_factories = self._discover_tests(params)
-            for test_factory in test_factories:
-                if test_factory is None:
-                    continue
-                test_class, test_parameters = test_factory
-                if test_class in [test.NotATest, BrokenSymlink, AccessDeniedPath]:
-                    if not params.get('omit_non_tests'):
-                        test_suite.append((test_class, test_parameters))
-                else:
-                    test_suite.append((test_class, test_parameters))
-        return test_suite
-
-    @staticmethod
-    def _validate(test_suite):
-        """
-        Find missing files/non-tests provided by the user in the input.
-
-        Used mostly for user input validation.
-
-        :param test_suite: List with tuples (test_class, test_params)
-        :return: list of missing files.
-        """
-        missing = []
-        not_test = []
-        broken_symlink = []
-        access_denied = []
-        for suite in test_suite:
-            if suite[0] == test.MissingTest:
-                missing.append(suite[1]['params']['id'])
-            elif suite[0] == test.NotATest:
-                not_test.append(suite[1]['params']['id'])
-            elif suite[0] == BrokenSymlink:
-                broken_symlink.append(suite[1]['params']['id'])
-            elif suite[0] == AccessDeniedPath:
-                access_denied.append(suite[1]['params']['id'])
-
-        return missing, not_test, broken_symlink, access_denied
-
-    def validate_ui(self, test_suite, ignore_missing=False,
-                    ignore_not_test=False, ignore_broken_symlinks=False,
-                    ignore_access_denied=False):
-        """
-        Validate test suite and deliver error messages to the UI
-        :param test_suite: List of tuples (test_class, test_params)
-        :type test_suite: list
-        :return: List with error messages
-        :rtype: list
-        """
-        (missing, not_test, broken_symlink,
-         access_denied) = self._validate(test_suite)
-        broken_symlink_msg = ''
-        if (not ignore_broken_symlinks) and broken_symlink:
-            if len(broken_symlink) == 1:
-                broken_symlink_msg = ("Cannot access '%s': Broken symlink" %
-                                      ", ".join(broken_symlink))
-            elif len(broken_symlink) > 1:
-                broken_symlink_msg = ("Cannot access '%s': Broken symlinks" %
-                                      ", ".join(broken_symlink))
-        access_denied_msg = ''
-        if (not ignore_access_denied) and access_denied:
-            if len(access_denied) == 1:
-                access_denied_msg = ("Cannot access '%s': Access denied" %
-                                     ", ".join(access_denied))
-            elif len(access_denied) > 1:
-                access_denied_msg = ("Cannot access '%s': Access denied" %
-                                     ", ".join(access_denied))
-        missing_msg = ''
-        if (not ignore_missing) and missing:
-            if len(missing) == 1:
-                missing_msg = ("Cannot access '%s': File not found" %
-                               ", ".join(missing))
-            elif len(missing) > 1:
-                missing_msg = ("Cannot access '%s': Files not found" %
-                               ", ".join(missing))
-        not_test_msg = ''
-        if (not ignore_not_test) and not_test:
-            if len(not_test) == 1:
-                not_test_msg = ("File '%s' is not an avocado test" %
-                                ", ".join(not_test))
-            elif len(not_test) > 1:
-                not_test_msg = ("Files '%s' are not avocado tests" %
-                                ", ".join(not_test))
-
-        return [msg for msg in
-                [access_denied_msg, broken_symlink_msg, missing_msg,
-                 not_test_msg] if msg]
+                return make_broken(test.MissingTest, test_name)
 
 
 loader = TestLoaderProxy()

--- a/avocado/core/log.py
+++ b/avocado/core/log.py
@@ -78,6 +78,11 @@ DEFAULT_LOGGING = {
             'level': 'INFO',
             'propagate': False,
         },
+        'avocado.app.tracebacks': {
+            'handlers': ['null'],   # change this to 'error' to see tracebacks
+            'level': 'ERROR',
+            'propagate': False,
+        },
         'avocado.test': {
             'handlers': ['null'],
             'level': 'DEBUG',

--- a/avocado/core/multiplexer.py
+++ b/avocado/core/multiplexer.py
@@ -421,7 +421,7 @@ class Mux(object):
             i = None
             for i, variant in enumerate(self.variants):
                 test_factory = [template[0], template[1].copy()]
-                inject_params = test_factory[1]['params'].get(
+                inject_params = test_factory[1].get('params', {}).get(
                     'avocado_inject_params', False)
                 # Test providers might want to keep their original params and
                 # only append avocado parameters to a special 'avocado_params'

--- a/avocado/core/plugins/test_list.py
+++ b/avocado/core/plugins/test_list.py
@@ -32,7 +32,7 @@ class TestLister(object):
         use_paginator = args.paginator == 'on'
         self.view = output.View(app_args=args, use_paginator=use_paginator)
         self.term_support = output.TermSupport()
-        self.test_loader = loader.TestLoaderProxy()
+        self.test_loader = loader.loader
         self.test_loader.load_plugins(args)
         self.args = args
 

--- a/avocado/core/plugins/test_list.py
+++ b/avocado/core/plugins/test_list.py
@@ -32,38 +32,26 @@ class TestLister(object):
         use_paginator = args.paginator == 'on'
         self.view = output.View(app_args=args, use_paginator=use_paginator)
         self.term_support = output.TermSupport()
-        self.test_loader = loader.loader
-        self.test_loader.load_plugins(args)
+        loader.loader.load_plugins(args)
         self.args = args
 
     def _extra_listing(self):
-        self.test_loader.get_extra_listing(self.args)
-
-    def _get_keywords(self):
-        keywords = self.test_loader.get_base_keywords()
-        if self.args.keywords:
-            keywords = self.args.keywords
-        return keywords
+        loader.loader.get_extra_listing()
 
     def _get_test_suite(self, paths):
-        return self.test_loader.discover(paths, list_non_tests=self.args.verbose)
-
-    def _validate_test_suite(self, test_suite):
-        error_msg_parts = self.test_loader.validate_ui(test_suite,
-                                                       ignore_not_test=True,
-                                                       ignore_access_denied=True,
-                                                       ignore_broken_symlinks=True)
-        if error_msg_parts:
-            for error_msg in error_msg_parts:
-                self.view.notify(event='error', msg=error_msg)
+        try:
+            return loader.loader.discover(paths,
+                                          list_non_tests=self.args.verbose)
+        except loader.LoaderUnhandledUrlError, details:
+            self.view.notify(event="error", msg=str(details))
             self.view.cleanup()
             sys.exit(exit_codes.AVOCADO_FAIL)
 
     def _get_test_matrix(self, test_suite):
         test_matrix = []
 
-        type_label_mapping = self.test_loader.get_type_label_mapping()
-        decorator_mapping = self.test_loader.get_decorator_mapping()
+        type_label_mapping = loader.loader.get_type_label_mapping()
+        decorator_mapping = loader.loader.get_decorator_mapping()
 
         stats = {}
         for value in type_label_mapping.values():
@@ -115,7 +103,6 @@ class TestLister(object):
     def _list(self):
         self._extra_listing()
         test_suite = self._get_test_suite(self.args.keywords)
-        self._validate_test_suite(test_suite)
         test_matrix, stats = self._get_test_matrix(test_suite)
         self._display(test_matrix, stats)
 

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -30,6 +30,7 @@ from . import exceptions
 from . import output
 from . import status
 from . import exit_codes
+from .loader import loader
 from ..utils import wait
 from ..utils import stacktrace
 from ..utils import runtime
@@ -78,7 +79,7 @@ class TestRunner(object):
         sys.stderr = output.LoggingFile(logger=logger_list_stderr)
 
         try:
-            instance = self.job.test_loader.load_test(test_factory)
+            instance = loader.load_test(test_factory)
             if instance.runner_queue is None:
                 instance.runner_queue = queue
             runtime.CURRENT_TEST = instance
@@ -261,6 +262,8 @@ class TestRunner(object):
             deadline = None
 
         for test_template in test_suite:
+            test_template[1]['base_logdir'] = self.job.logdir
+            test_template[1]['job'] = self.job
             for test_factory in mux.itertests(test_template):
                 if deadline is not None and time.time() > deadline:
                     test_parameters = test_factory[1]

--- a/etc/avocado/avocado.conf
+++ b/etc/avocado/avocado.conf
@@ -56,3 +56,6 @@ password =
 # avocado.core.plugins.htmlresult  ImportError No module named pystache
 # add 'avocado.core.plugins.htmlresult' as an element of the list below.
 skip_broken_plugin_notification = []
+# Optionally you can specify the priority of loader plugins. Unspecified
+# plugins will be sorted accordingly to the plugin priorities.
+loader_plugins_priority = ['file']

--- a/selftests/all/functional/avocado/basic_tests.py
+++ b/selftests/all/functional/avocado/basic_tests.py
@@ -200,8 +200,8 @@ class RunnerOperationTest(unittest.TestCase):
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 2
         self.assertEqual(result.exit_status, expected_rc)
-        self.assertIn('File not found', result.stderr)
-        self.assertNotIn('File not found', result.stdout)
+        self.assertIn('Unable to discover url', result.stderr)
+        self.assertNotIn('Unable to discover url', result.stdout)
 
     def test_invalid_unique_id(self):
         cmd_line = './scripts/avocado run --sysinfo=off --force-job-id foobar passtest'
@@ -411,7 +411,7 @@ class PluginsTest(unittest.TestCase):
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %d:\n%s" %
                          (expected_rc, result))
-        self.assertIn("File not found", output)
+        self.assertIn("Unable to discover url", output)
 
     def test_plugin_list(self):
         os.chdir(basedir)

--- a/selftests/all/unit/avocado/loader_unittest.py
+++ b/selftests/all/unit/avocado/loader_unittest.py
@@ -88,7 +88,7 @@ class MultipleMethods(Test):
 class LoaderTest(unittest.TestCase):
 
     def setUp(self):
-        self.loader = loader.FileLoader()
+        self.loader = loader.FileLoader({})
         self.queue = multiprocessing.Queue()
 
     def test_load_simple(self):
@@ -96,7 +96,7 @@ class LoaderTest(unittest.TestCase):
                                              'avocado_loader_unittest')
         simple_test.save()
         test_class, test_parameters = (
-            self.loader._discover_tests(params={'id': simple_test.path})[0])
+            self.loader.discover(simple_test.path, True)[0])
         self.assertTrue(test_class == test.SimpleTest, test_class)
         tc = test_class(**test_parameters)
         tc.test()
@@ -108,7 +108,7 @@ class LoaderTest(unittest.TestCase):
                                              mode=0664)
         simple_test.save()
         test_class, test_parameters = (
-            self.loader._discover_tests(params={'id': simple_test.path})[0])
+            self.loader.discover(simple_test.path, True)[0])
         self.assertTrue(test_class == test.NotATest, test_class)
         tc = test_class(**test_parameters)
         self.assertRaises(exceptions.NotATestError, tc.test)
@@ -120,7 +120,7 @@ class LoaderTest(unittest.TestCase):
                                                    'avocado_loader_unittest')
         avocado_pass_test.save()
         test_class, test_parameters = (
-            self.loader._discover_tests(params={'id': avocado_pass_test.path})[0])
+            self.loader.discover(avocado_pass_test.path, True)[0])
         self.assertTrue(str(test_class) == "<class 'passtest.PassTest'>",
                         str(test_class))
         self.assertTrue(issubclass(test_class, test.Test))
@@ -134,7 +134,7 @@ class LoaderTest(unittest.TestCase):
                                                    'avocado_loader_unittest')
         avocado_base_test.save()
         test_class, test_parameters = (
-            self.loader._discover_tests(params={'id': avocado_base_test.path})[0])
+            self.loader.discover(avocado_base_test.path, True)[0])
         self.assertTrue(str(test_class) == "<class 'base.MyBaseTest'>",
                         str(test_class))
 
@@ -143,7 +143,7 @@ class LoaderTest(unittest.TestCase):
                                                         'avocado_loader_unittest')
         avocado_inherited_test.save()
         test_class, test_parameters = (
-            self.loader._discover_tests(params={'id': avocado_inherited_test.path})[0])
+            self.loader.discover(avocado_inherited_test.path, True)[0])
         self.assertTrue(str(test_class) == "<class 'inherited.MyInheritedTest'>",
                         str(test_class))
         avocado_base_test.remove()
@@ -155,7 +155,7 @@ class LoaderTest(unittest.TestCase):
                                                     'avocado_loader_unittest')
         avocado_buggy_test.save()
         test_class, test_parameters = (
-            self.loader._discover_tests(params={'id': avocado_buggy_test.path})[0])
+            self.loader.discover(avocado_buggy_test.path, True)[0])
         self.assertTrue(test_class == test.SimpleTest, test_class)
         tc = test_class(**test_parameters)
         self.assertRaises(exceptions.TestFail, tc.test)
@@ -168,7 +168,7 @@ class LoaderTest(unittest.TestCase):
                                                     mode=0664)
         avocado_buggy_test.save()
         test_class, test_parameters = (
-            self.loader._discover_tests(params={'id': avocado_buggy_test.path})[0])
+            self.loader.discover(avocado_buggy_test.path, True)[0])
         self.assertTrue(test_class == test.BuggyTest, test_class)
         tc = test_class(**test_parameters)
         self.assertRaises(ImportError, tc.test)
@@ -181,7 +181,7 @@ class LoaderTest(unittest.TestCase):
                                                     mode=0664)
         avocado_not_a_test.save()
         test_class, test_parameters = (
-            self.loader._discover_tests(params={'id': avocado_not_a_test.path})[0])
+            self.loader.discover(avocado_not_a_test.path, True)[0])
         self.assertTrue(test_class == test.NotATest, test_class)
         tc = test_class(**test_parameters)
         self.assertRaises(exceptions.NotATestError, tc.test)
@@ -192,7 +192,7 @@ class LoaderTest(unittest.TestCase):
                                                     'avocado_loader_unittest')
         avocado_not_a_test.save()
         test_class, test_parameters = (
-            self.loader._discover_tests(params={'id': avocado_not_a_test.path})[0])
+            self.loader.discover(avocado_not_a_test.path, True)[0])
         self.assertTrue(test_class == test.SimpleTest, test_class)
         tc = test_class(**test_parameters)
         # The test can't be executed (no shebang), raising an OSError
@@ -206,7 +206,7 @@ class LoaderTest(unittest.TestCase):
                                                      'avocado_loader_unittest')
         avocado_simple_test.save()
         test_class, test_parameters = (
-            self.loader._discover_tests(params={'id': avocado_simple_test.path})[0])
+            self.loader.discover(avocado_simple_test.path, True)[0])
         self.assertTrue(test_class == test.SimpleTest)
         tc = test_class(**test_parameters)
         tc.test()
@@ -219,7 +219,7 @@ class LoaderTest(unittest.TestCase):
                                                      mode=0664)
         avocado_simple_test.save()
         test_class, test_parameters = (
-            self.loader._discover_tests(params={'id': avocado_simple_test.path})[0])
+            self.loader.discover(avocado_simple_test.path, True)[0])
         self.assertTrue(test_class == test.NotATest)
         tc = test_class(**test_parameters)
         self.assertRaises(exceptions.NotATestError, tc.test)
@@ -231,7 +231,7 @@ class LoaderTest(unittest.TestCase):
                                                         'avocado_multiple_tests_unittest',
                                                         mode=0664)
         avocado_multiple_tests.save()
-        suite = self.loader._discover_tests(params={'id': avocado_multiple_tests.path})
+        suite = self.loader.discover(avocado_multiple_tests.path, True)
         self.assertEqual(len(suite), 2)
         avocado_multiple_tests.remove()
 

--- a/selftests/all/unit/avocado/loader_unittest.py
+++ b/selftests/all/unit/avocado/loader_unittest.py
@@ -17,6 +17,7 @@ from avocado.core import exceptions
 from avocado.core import loader
 from avocado.utils import script
 
+# We need to access protected members pylint: disable=W0212
 
 AVOCADO_TEST_OK = """#!/usr/bin/python
 from avocado import Test
@@ -84,15 +85,10 @@ class MultipleMethods(Test):
 """
 
 
-class _DebugJob(object):
-    logdir = tempfile.mkdtemp()
-
-
 class LoaderTest(unittest.TestCase):
 
     def setUp(self):
-        self.job = _DebugJob
-        self.loader = loader.TestLoader(job=self.job)
+        self.loader = loader.FileLoader()
         self.queue = multiprocessing.Queue()
 
     def test_load_simple(self):
@@ -100,7 +96,7 @@ class LoaderTest(unittest.TestCase):
                                              'avocado_loader_unittest')
         simple_test.save()
         test_class, test_parameters = (
-            self.loader.discover_tests(params={'id': simple_test.path})[0])
+            self.loader._discover_tests(params={'id': simple_test.path})[0])
         self.assertTrue(test_class == test.SimpleTest, test_class)
         tc = test_class(**test_parameters)
         tc.test()
@@ -112,7 +108,7 @@ class LoaderTest(unittest.TestCase):
                                              mode=0664)
         simple_test.save()
         test_class, test_parameters = (
-            self.loader.discover_tests(params={'id': simple_test.path})[0])
+            self.loader._discover_tests(params={'id': simple_test.path})[0])
         self.assertTrue(test_class == test.NotATest, test_class)
         tc = test_class(**test_parameters)
         self.assertRaises(exceptions.NotATestError, tc.test)
@@ -124,7 +120,7 @@ class LoaderTest(unittest.TestCase):
                                                    'avocado_loader_unittest')
         avocado_pass_test.save()
         test_class, test_parameters = (
-            self.loader.discover_tests(params={'id': avocado_pass_test.path})[0])
+            self.loader._discover_tests(params={'id': avocado_pass_test.path})[0])
         self.assertTrue(str(test_class) == "<class 'passtest.PassTest'>",
                         str(test_class))
         self.assertTrue(issubclass(test_class, test.Test))
@@ -138,7 +134,7 @@ class LoaderTest(unittest.TestCase):
                                                    'avocado_loader_unittest')
         avocado_base_test.save()
         test_class, test_parameters = (
-            self.loader.discover_tests(params={'id': avocado_base_test.path})[0])
+            self.loader._discover_tests(params={'id': avocado_base_test.path})[0])
         self.assertTrue(str(test_class) == "<class 'base.MyBaseTest'>",
                         str(test_class))
 
@@ -147,7 +143,7 @@ class LoaderTest(unittest.TestCase):
                                                         'avocado_loader_unittest')
         avocado_inherited_test.save()
         test_class, test_parameters = (
-            self.loader.discover_tests(params={'id': avocado_inherited_test.path})[0])
+            self.loader._discover_tests(params={'id': avocado_inherited_test.path})[0])
         self.assertTrue(str(test_class) == "<class 'inherited.MyInheritedTest'>",
                         str(test_class))
         avocado_base_test.remove()
@@ -159,7 +155,7 @@ class LoaderTest(unittest.TestCase):
                                                     'avocado_loader_unittest')
         avocado_buggy_test.save()
         test_class, test_parameters = (
-            self.loader.discover_tests(params={'id': avocado_buggy_test.path})[0])
+            self.loader._discover_tests(params={'id': avocado_buggy_test.path})[0])
         self.assertTrue(test_class == test.SimpleTest, test_class)
         tc = test_class(**test_parameters)
         self.assertRaises(exceptions.TestFail, tc.test)
@@ -172,7 +168,7 @@ class LoaderTest(unittest.TestCase):
                                                     mode=0664)
         avocado_buggy_test.save()
         test_class, test_parameters = (
-            self.loader.discover_tests(params={'id': avocado_buggy_test.path})[0])
+            self.loader._discover_tests(params={'id': avocado_buggy_test.path})[0])
         self.assertTrue(test_class == test.BuggyTest, test_class)
         tc = test_class(**test_parameters)
         self.assertRaises(ImportError, tc.test)
@@ -185,7 +181,7 @@ class LoaderTest(unittest.TestCase):
                                                     mode=0664)
         avocado_not_a_test.save()
         test_class, test_parameters = (
-            self.loader.discover_tests(params={'id': avocado_not_a_test.path})[0])
+            self.loader._discover_tests(params={'id': avocado_not_a_test.path})[0])
         self.assertTrue(test_class == test.NotATest, test_class)
         tc = test_class(**test_parameters)
         self.assertRaises(exceptions.NotATestError, tc.test)
@@ -196,7 +192,7 @@ class LoaderTest(unittest.TestCase):
                                                     'avocado_loader_unittest')
         avocado_not_a_test.save()
         test_class, test_parameters = (
-            self.loader.discover_tests(params={'id': avocado_not_a_test.path})[0])
+            self.loader._discover_tests(params={'id': avocado_not_a_test.path})[0])
         self.assertTrue(test_class == test.SimpleTest, test_class)
         tc = test_class(**test_parameters)
         # The test can't be executed (no shebang), raising an OSError
@@ -210,7 +206,7 @@ class LoaderTest(unittest.TestCase):
                                                      'avocado_loader_unittest')
         avocado_simple_test.save()
         test_class, test_parameters = (
-            self.loader.discover_tests(params={'id': avocado_simple_test.path})[0])
+            self.loader._discover_tests(params={'id': avocado_simple_test.path})[0])
         self.assertTrue(test_class == test.SimpleTest)
         tc = test_class(**test_parameters)
         tc.test()
@@ -223,7 +219,7 @@ class LoaderTest(unittest.TestCase):
                                                      mode=0664)
         avocado_simple_test.save()
         test_class, test_parameters = (
-            self.loader.discover_tests(params={'id': avocado_simple_test.path})[0])
+            self.loader._discover_tests(params={'id': avocado_simple_test.path})[0])
         self.assertTrue(test_class == test.NotATest)
         tc = test_class(**test_parameters)
         self.assertRaises(exceptions.NotATestError, tc.test)
@@ -235,13 +231,10 @@ class LoaderTest(unittest.TestCase):
                                                         'avocado_multiple_tests_unittest',
                                                         mode=0664)
         avocado_multiple_tests.save()
-        suite = self.loader.discover_tests(params={'id': avocado_multiple_tests.path})
+        suite = self.loader._discover_tests(params={'id': avocado_multiple_tests.path})
         self.assertEqual(len(suite), 2)
         avocado_multiple_tests.remove()
 
-    def tearDown(self):
-        if os.path.isdir(self.job.logdir):
-            shutil.rmtree(self.job.logdir)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This pull request is focused on loader plugins unification. First few commits are helpers I used to work on it and think they might be useful.

The important commits are:

5b86b88 which removes `job` from test loaders and adds it just before the execution. This is only a step no.1, now we should focus on removing the `job` from `test` params completely as it's not safe having the job access to the job underneath. Currently it's needed to discover test tag and to handle stdout/stderr check. It should be implemented in job instead.

2ad09fb which changes the test discovery API. Instead of having special test loader which handles the broken tests it makes the plugins return empty set when even a single subtest associated with this url is invalid. In the end the `loader_proxy` is responsible for raising Exception when some URLs are not handled. User can use `avocado list -V` to see the root cause behind the failure.