### PR TITLE
GDB Plugin: Change undefined behavior exception

### DIFF
--- a/avocado/core/plugins/gdb.py
+++ b/avocado/core/plugins/gdb.py
@@ -78,6 +78,6 @@ class GDB(plugin.Plugin):
             gdb.GDBSERVER_PATH = settings.get_value('gdb.paths',
                                                     'gdbserver',
                                                     default=system_gdbserver_path)
-            process.UNDEFINED_BEHAVIOR_EXCEPTION = exceptions.TestNAError
+            process.UNDEFINED_BEHAVIOR_EXCEPTION = exceptions.TestError
         except AttributeError:
             pass


### PR DESCRIPTION
When we changed the policy regarding skipping tests,
we forgot to change how the gdb plugin behaves on
undefined behavior - We are not supposed to be skipping
tests during its execution anymore.

So let's fix the problem by changing the undefined
behavior exception to a TestError instead of a TestNAError.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>