### PR TITLE
avocado: Shorter app output

### DIFF
--- a/avocado/core/result.py
+++ b/avocado/core/result.py
@@ -277,13 +277,14 @@ class HumanTestResult(TestResult):
         Called once after all tests are executed.
         """
         self._reconcile()
-        self.stream.notify(event="message", msg="PASS       : %d" % len(self.passed))
-        self.stream.notify(event="message", msg="ERROR      : %d" % len(self.errors))
-        self.stream.notify(event="message", msg="FAIL       : %d" % len(self.failed))
-        self.stream.notify(event="message", msg="SKIP       : %d" % len(self.skipped))
-        self.stream.notify(event="message", msg="WARN       : %d" % len(self.warned))
-        self.stream.notify(event="message", msg="INTERRUPT  : %d" % len(self.interrupted))
-        self.stream.notify(event="message", msg="TIME       : %.2f s" % self.total_time)
+        self.stream.notify(event="message",
+                           msg="RESULTS    : PASS %d | ERROR %d | FAIL %d | "
+                               "SKIP %d | WARN %d | INTERRUPT %s" %
+                               (len(self.passed), len(self.errors),
+                                len(self.failed), len(self.skipped),
+                                len(self.warned), len(self.interrupted)))
+        self.stream.notify(event="message",
+                           msg="TIME       : %.2f s" % self.total_time)
 
     def start_test(self, state):
         """


### PR DESCRIPTION
Instead of putting outputs on separate lines, condensate
test results summary into a single line. The new output
looks like:

    $ avocado run passtest
    JOB ID     : f2f5060440bd57cba646c1f223ec8c40d03f539b
    JOB LOG    : /home/user/avocado/job-results/job-2015-07-27T17.13-f2f5060/job.log
    JOB HTML   : /home/user/avocado/job-results/job-2015-07-27T17.13-f2f5060/html/results.html
    TESTS      : 1
    (1/1) passtest.py:PassTest.test: PASS (0.00 s)
    RESULTS : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0
    TIME       : 0.00 s

We updated a few unittests in order to not depend on the
looks of the human output anymore, since unless we are
specifically testing for human output behavior, the unittests
should use machine readable output.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>