### PR TITLE
avocado.utils.astring: Improve the tabular_output

### DIFF
--- a/avocado/utils/astring.py
+++ b/avocado/utils/astring.py
@@ -144,17 +144,18 @@ def iter_tabular_output(matrix, header=None):
             except IndexError:
                 lengths.append(col_len)
 
-    lengths = tuple(lengths)
-    format_string = ""
-    for length in lengths:
-        format_string += "%-" + str(length) + "s "
+    if not lengths:     # No items...
+        raise StopIteration
+    format_string = " ".join(["%-" + str(leng) + "s"
+                              for leng in lengths[:-1]] +
+                             ["%s"])
 
     if header:
         out_line = format_string % header
-        yield out_line.strip()
+        yield out_line
     for row in matrix:
         out_line = format_string % tuple(row)
-        yield out_line.strip()
+        yield out_line
 
 
 def tabular_output(matrix, header=None):


### PR DESCRIPTION
This patch doesn't generate the trailing whitespaces rather then
removing them from the output afterwards, which was potentially
dangerous as the line might start with the whitespace and got displaced.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>