### PR TITLE
avocado.core.multiplexer: Assign tag to match multiplex variant

### DIFF
--- a/avocado/core/multiplexer.py
+++ b/avocado/core/multiplexer.py
@@ -421,6 +421,7 @@ class Mux(object):
             i = None
             for i, variant in enumerate(self.variants):
                 test_factory = [template[0], template[1].copy()]
+                test_factory[1]['tag'] = str(i + 1)
                 inject_params = test_factory[1].get('params', {}).get(
                     'avocado_inject_params', False)
                 # Test providers might want to keep their original params and


### PR DESCRIPTION
"avocado multiplex" and "avocado run" should share the same variant
numbers. This patch forces multiplexer to set the tag when generating
multiple variants. This way the tag is always set accordingly to the
variant.

When multiple tests of the same name are executed, the first argument is
the multiplexed variant number and additional `.$num` is added to
generate unique name.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>