### PR TITLE
Revert "avocado.core.multiplexer: Assign tag to match multiplex variant"

### DIFF
--- a/avocado/core/multiplexer.py
+++ b/avocado/core/multiplexer.py
@@ -421,7 +421,6 @@ class Mux(object):
             i = None
             for i, variant in enumerate(self.variants):
                 test_factory = [template[0], template[1].copy()]
-                test_factory[1]['tag'] = "variant%s" % (i + 1)
                 inject_params = test_factory[1].get('params', {}).get(
                     'avocado_inject_params', False)
                 # Test providers might want to keep their original params and


### PR DESCRIPTION
This reverts commit 913ab2abeedf714fe860be37227ce48578fca377.

Turns out that change appends inconditionally the tags to tests,
even the ones not using the multiplexing system. We need to revert
and figure a better solution.