### PR TITLE
requirements: Update inspektor requirement

### DIFF
--- a/requirements-selftests.txt
+++ b/requirements-selftests.txt
@@ -6,6 +6,6 @@ Sphinx>=1.3b1
 # flexmock (some unittests use it)
 flexmock>=0.9.7
 # inspektor (static and style checks)
-inspektor>=0.1.12
+inspektor>=0.1.16
 # mock (some unittests use it)
 mock>=1.0.0

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -4,7 +4,7 @@ nose==1.3.4
 pystache==0.5.4
 Sphinx==1.3b1
 flexmock==0.9.7
-inspektor==0.1.15
+inspektor==0.1.16
 pep8==1.6.2
 requests==1.2.3
 PyYAML==3.11


### PR DESCRIPTION
Update inspektor requirement to 0.1.16, since it
fixes the bug of it not requiring pep8.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>