### PR TITLE
avocado.core.output: Clean previous logging handlers

### DIFF
--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -614,10 +614,18 @@ class View(object):
         formatter = logging.Formatter(fmt=fmt, datefmt='%H:%M:%S')
 
         self.file_handler.setFormatter(formatter)
+        show_job_log = (self.app_args is not None and
+                        getattr(self.app_args, 'show_job_log', False))
         test_logger = logging.getLogger('avocado.test')
+        if not show_job_log:
+            map(test_logger.removeHandler, test_logger.handlers[:])
+            map(test_logger.removeFilter, test_logger.filters[:])
         test_logger.addHandler(self.file_handler)
         test_logger.setLevel(loglevel)
         root_logger = logging.getLogger()
+        if not show_job_log:
+            map(root_logger.removeHandler, root_logger.handlers[:])
+            map(root_logger.removeFilter, root_logger.filters[:])
         root_logger.addHandler(self.file_handler)
         root_logger.setLevel(loglevel)
 


### PR DESCRIPTION
I noticed that on some systems the `avocado run boot` contains the root logger output. I added some logging and identified that it's caused by root logger being initialized during virt-test initialization:

```
  File "./scripts/avocado", line 30, in <module>
    app = AvocadoApp()
  File "/home/jenkins/avocado/avocado/core/app.py", line 42, in __init__
    self.load_plugin_manager(self.parser.args.plugins_dir)
  File "/home/jenkins/avocado/avocado/core/app.py", line 57, in load_plugin_manager
    self.plugin_manager.load_plugins(plugins_dir)
  File "/home/jenkins/avocado/avocado/core/plugins/manager.py", line 133, in load_plugins
    BuiltinPluginManager.load_plugins(self)
  File "/home/jenkins/avocado/avocado/core/plugins/manager.py", line 71, in load_plugins
    for plugin in load_builtins():
  File "/home/jenkins/avocado/avocado/core/plugins/builtin.py", line 55, in load_builtins
    plugin_mod = import_module(module)
  File "/usr/lib64/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/home/jenkins/avocado/avocado/core/plugins/virt_test_list.py", line 56, in <module>
    from virttest.standalone_test import SUPPORTED_TEST_TYPES
  File "/home/jenkins/avocado/virttest/standalone_test.py", line 16, in <module>
    from . import utils_env
  File "/home/jenkins/avocado/virttest/utils_env.py", line 7, in <module>
    import virt_vm
  File "/home/jenkins/avocado/virttest/virt_vm.py", line 14, in <module>
    from . import ppm_utils
  File "/home/jenkins/avocado/virttest/ppm_utils.py", line 17, in <module>
    logging.warning('No python imaging library installed. Windows guest '
  File "/usr/lib64/python2.7/logging/__init__.py", line 1605, in warning
    basicConfig()
  File "/usr/lib64/python2.7/logging/__init__.py", line 1542, in basicConfig
    root.addHandler(hdlr)
  File "/usr/lib64/python2.7/logging/__init__.py", line 1287, in addHandler
    traceback.print_stack()
```

With this patch the output is correct.