### PR TITLE
avocado.utils.iso9660: Be less verbose

### DIFF
--- a/avocado/utils/iso9660.py
+++ b/avocado/utils/iso9660.py
@@ -217,7 +217,7 @@ class Iso9660IsoInfo(BaseIso9660):
                 return ""
 
         cmd.append("-x %s" % fname)
-        result = process.run(" ".join(cmd))
+        result = process.run(" ".join(cmd), verbose=False)
         return result.stdout
 
 


### PR DESCRIPTION
We probably don't want to log the full CDROM content...

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>