### PR TITLE
sysinfo: fix duplicated collection of current mounted filesystems

### DIFF
--- a/etc/avocado/sysinfo/commands
+++ b/etc/avocado/sysinfo/commands
@@ -4,7 +4,6 @@ uname -a
 lspci -vvnn
 gcc --version
 ld --version
-mount
 hostname
 uptime
 dmidecode


### PR DESCRIPTION
By default Avocado's sysinfo collects both the output of the `mount`
command and the content of the /proc/mounts file. This is really the
same information with a very minor formatting change (the addition of
parentheses around mount options).

Since reading a file is supposed to be faster than running a command,
let's remove the `mount` command execution.

Signed-off-by: Cleber Rosa <crosa@redhat.com>