### PR TITLE
Reconsider when the `latest` log symlink is created

### DIFF
--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -232,6 +232,8 @@ def update_latest_job_logs_dir(job_result_dir):
     basedir = os.path.dirname(job_result_dir)
     basename = os.path.basename(job_result_dir)
     latest = os.path.join(basedir, "latest")
+    if os.path.exists(latest) and not os.path.islink(latest):
+        raise OSError('"%s" already exists and is not a symlink' % latest)
     try:
         os.unlink(latest)
     except OSError:

--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -223,24 +223,6 @@ def create_job_logs_dir(logdir=None, unique_id=None):
     return debugdir
 
 
-def update_latest_job_logs_dir(job_result_dir):
-    """
-    Update the latest job result symbolic link [avocado-logs-dir]/latest.
-
-    :param job_result_dir: full path for the current job result.
-    """
-    basedir = os.path.dirname(job_result_dir)
-    basename = os.path.basename(job_result_dir)
-    latest = os.path.join(basedir, "latest")
-    if os.path.exists(latest) and not os.path.islink(latest):
-        raise OSError('"%s" already exists and is not a symlink' % latest)
-    try:
-        os.unlink(latest)
-    except OSError:
-        pass
-    os.symlink(basename, latest)
-
-
 class _TmpDirTracker(Borg):
 
     def __init__(self):

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -443,6 +443,8 @@ class Job(object):
         self.args.test_result_total = mux.get_number_of_tests(test_suite)
 
         self._make_test_result()
+        if not self.standalone:
+            self._update_latest_link()
         self._make_test_runner()
         self._start_sysinfo()
 
@@ -452,8 +454,6 @@ class Job(object):
         failures = self.test_runner.run_suite(test_suite, mux,
                                               timeout=self.timeout)
         self.view.stop_file_logging()
-        if not self.standalone:
-            self._update_latest_link()
         # If it's all good so far, set job status to 'PASS'
         if self.status == 'RUNNING':
             self.status = 'PASS'

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -141,7 +141,19 @@ class Job(object):
             id_file_obj.write("%s\n" % self.unique_id)
 
     def _update_latest_link(self):
-        data_dir.update_latest_job_logs_dir(self.logdir)
+        """
+        Update the latest job result symbolic link [avocado-logs-dir]/latest.
+        """
+        basedir = os.path.dirname(self.logdir)
+        basename = os.path.basename(self.logdir)
+        latest = os.path.join(basedir, "latest")
+        if os.path.exists(latest) and not os.path.islink(latest):
+            raise OSError('"%s" already exists and is not a symlink' % latest)
+        try:
+            os.unlink(latest)
+        except OSError:
+            pass
+        os.symlink(basename, latest)
 
     def _start_sysinfo(self):
         if hasattr(self.args, 'sysinfo'):

--- a/selftests/all/functional/avocado/basic_tests.py
+++ b/selftests/all/functional/avocado/basic_tests.py
@@ -237,6 +237,24 @@ class RunnerOperationTest(unittest.TestCase):
                                                                 result))
         self.assertIn('"status": "ERROR"', result.stdout)
 
+    def test_early_latest_result(self):
+        """
+        Tests that the `latest` link to the latest job results is created early
+        """
+        os.chdir(basedir)
+        cmd_line = ('./scripts/avocado run --sysinfo=off --job-results-dir %s examples/tests/sleeptest.py '
+                    '-m examples/tests/sleeptest.py.data/sleeptest.yaml' % self.tmpdir)
+        avocado_process = process.SubProcess(cmd_line)
+        avocado_process.start()
+        link = os.path.join(self.tmpdir, 'latest')
+        for trial in xrange(0, 50):
+            time.sleep(0.1)
+            if os.path.exists(link) and os.path.islink(link):
+                avocado_process.terminate()
+                break
+        self.assertTrue(os.path.exists(link))
+        self.assertTrue(os.path.islink(link))
+
     def tearDown(self):
         shutil.rmtree(self.tmpdir)
 


### PR DESCRIPTION
Right now the symlink `latest` is created when the job finishes. I'd like to create the symlink when the job starts (after the point where we stop removing the results of incorrect execution like `avocado run`).

The motivation is to be able to use `tail -f $PATH/latest/job.log` to monitor the run of the current job.

This implements the card:

https://trello.com/c/QJ4wCD8x/447-reconsider-when-the-latest-log-symlink-is-created