### PR TITLE
trinity example test: don't output ANSI characters to the logs

### DIFF
--- a/examples/tests/trinity.py
+++ b/examples/tests/trinity.py
@@ -41,9 +41,9 @@ class TrinityTest(Test):
         """
         Execute the trinity syscall fuzzer with the appropriate params.
         """
-        cmd = './trinity -I'
+        cmd = './trinity -m -I'
         process.run(cmd)
-        cmd = './trinity'
+        cmd = './trinity -m'
         if self.params.get('stress'):
             cmd += " " + self.params.get('stress')
         if self.params.get('victims_path'):


### PR DESCRIPTION
The logs from the trinity test are full of ANSI characters that add
colors to messages, which makes it difficult to read/manipulate
them.

Fix that by passing -m to trinity. From trinity --help:

   '--monochrome,-m: don't output ANSI codes'