### PR TITLE
avocado.core.runner: Make getting the timeout from test plugins more robust

### DIFF
--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -154,8 +154,8 @@ class TestRunner(object):
 
         # At this point, the test is already initialized and we know
         # for sure if there's a timeout set.
-        timeout = (early_state.get('params', {}).get('timeout') or
-                   self.DEFAULT_TIMEOUT)
+        timeout = float(early_state.get('params', {}).get('timeout') or
+                        self.DEFAULT_TIMEOUT)
 
         test_deadline = time_started + timeout
         if job_deadline > 0:


### PR DESCRIPTION
Some test loader plugins will return the 'timeout' parameter
as a string, so this will cause avocado to break, given that
it will add the timeout to another float value later in the
runner code. Let's ensure that value will be converted to
a float before the addition is made.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>