### PR TITLE
Let Subprocesses to run inside threads

### DIFF
--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -154,8 +154,8 @@ class TestRunner(object):
 
         # At this point, the test is already initialized and we know
         # for sure if there's a timeout set.
-        timeout = (early_state.get('params', {}).get('timeout') or
-                   self.DEFAULT_TIMEOUT)
+        timeout = float(early_state.get('params', {}).get('timeout') or
+                        self.DEFAULT_TIMEOUT)
 
         test_deadline = time_started + timeout
         if job_deadline > 0:

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -298,8 +298,11 @@ class SubProcess(object):
             def signal_handler(signum, frame):
                 self.result.interrupted = True
                 self.wait()
-
-            signal.signal(signal.SIGINT, signal_handler)
+            try:
+                signal.signal(signal.SIGINT, signal_handler)
+            except ValueError:
+                if self.verbose:
+                    log.info("Command %s running on a thread", self.cmd)
 
     def _fd_drainer(self, input_pipe):
         """


### PR DESCRIPTION
Fix a problem I found while testing avocado-vt's libvirt backend, that's related with the `avocado.utils.process` APIs.