### PR TITLE
avocado.utils.process: Let SubProcesses to run in threads

### DIFF
--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -298,8 +298,11 @@ class SubProcess(object):
             def signal_handler(signum, frame):
                 self.result.interrupted = True
                 self.wait()
-
-            signal.signal(signal.SIGINT, signal_handler)
+            try:
+                signal.signal(signal.SIGINT, signal_handler)
+            except ValueError:
+                if self.verbose:
+                    log.info("Command %s running on a thread", self.cmd)
 
     def _fd_drainer(self, input_pipe):
         """


### PR DESCRIPTION
We can't set signal handlers inside a thread. In such
cases, let's not try to set the signal handler. This
fixes a problem where subprocesses executed with
`avocado.utils.process` APIs would fail if executed
inside threads.

One example of a thread that runs subprocesses can
be found on our avocado-vt plugin: The virt related
tests run a screendump thread, that will produce
screendumps on a specific directory. These screendumps
will be encoded later into a video. The libvirt VM
implementation takes screendumps by executing
process.run('virsh screendump'). So that's one of
the possible examples where process APIs can be used
inside of threads, and we should support such examples.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>