### PR TITLE
avocado.core.test: Use GDB-friendly srcdir

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -99,7 +99,7 @@ class Test(unittest.TestCase):
         self.expected_stderr_file = os.path.join(self.datadir,
                                                  'stderr.expected')
 
-        self.workdir = utils_path.init_dir(tmpdir, basename)
+        self.workdir = utils_path.init_dir(tmpdir, basename.replace(':', '_'))
         self.srcdir = utils_path.init_dir(self.workdir, 'src')
         if base_logdir is None:
             base_logdir = data_dir.create_job_logs_dir()


### PR DESCRIPTION
Avocado allows the usage of GDB, but our default self.srcdir is
incompatible with it causing many tests to fail. This patch simply
replaces the ':' in basename to '_'. It's already created in a temporary
directory, so there shouldn't be any name clashes.

This patch fixes the `modify_variable` test and probably can supersede the:

https://github.com/clebergnu/avocado/commit/d9cf28921f0d2a9f82c23908d23881b09bd5650c

commit. (but I need to check it first)