### PR TITLE
avocado.core.output: Use stdout to log test statuses

### DIFF
--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -416,7 +416,19 @@ class View(object):
             mapping[event](msg=msg, skip_newline=skip_newline)
 
     def notify_progress(self, progress):
-        self._log_ui_throbber_progress(progress)
+        """
+        Give an interactive indicator of the test progress
+
+        :param progress: if indication of progress came explicitly from the
+                         test. If false, it means the test process is running,
+                         but not communicating test specific progress.
+        :type progress: bool
+        :rtype: None
+        """
+        if progress:
+            self._log_ui_healthy(self.throbber.render(), True)
+        else:
+            self._log_ui_partial(self.throbber.render(), True)
 
     def add_test(self, state):
         self._log(msg=self._get_test_tag(state['tagged_name']),
@@ -534,22 +546,6 @@ class View(object):
         :param msg: Message to write.
         """
         self._log_ui_info(term_support.warn_header_str(msg), skip_newline)
-
-    def _log_ui_throbber_progress(self, progress_from_test=False):
-        """
-        Give an interactive indicator of the test progress
-
-        :param progress_from_test: if indication of progress came explicitly
-                                   from the test. If false, it means the test
-                                   process is running, but not communicating
-                                   test specific progress.
-        :type progress_from_test: bool
-        :rtype: None
-        """
-        if progress_from_test:
-            self._log_ui_healthy(self.throbber.render(), True)
-        else:
-            self._log_ui_partial(self.throbber.render(), True)
 
     def start_file_logging(self, logfile, loglevel, unique_id):
         """

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -423,13 +423,22 @@ class View(object):
                   skip_newline=True)
 
     def set_test_status(self, status, state):
-        mapping = {'PASS': self._log_ui_status_pass,
-                   'ERROR': self._log_ui_status_error,
-                   'FAIL': self._log_ui_status_fail,
-                   'SKIP': self._log_ui_status_skip,
-                   'WARN': self._log_ui_status_warn,
-                   'INTERRUPTED': self._log_ui_status_interrupt}
-        mapping[status](state['time_elapsed'])
+        """
+        Log a test status message
+        :param status: the test status
+        :param state: test state (used to get 'time_elapsed')
+        """
+        mapping = {'PASS': term_support.pass_str,
+                   'ERROR': term_support.error_str,
+                   'FAIL': term_support.error_str,
+                   'SKIP': term_support.skip_str,
+                   'WARN': term_support.warn_str,
+                   'INTERRUPTED': term_support.interrupt_str}
+        if status == 'SKIP':
+            msg = mapping[status]()
+        else:
+            msg = mapping[status]() + " (%.2f s)" % state['time_elapsed']
+        self._log_ui_info(msg)
 
     def set_tests_info(self, info):
         self.tests_info.update(info)
@@ -525,60 +534,6 @@ class View(object):
         :param msg: Message to write.
         """
         self._log_ui_info(term_support.warn_header_str(msg), skip_newline)
-
-    def _log_ui_status_pass(self, t_elapsed):
-        """
-        Log a PASS status message for a given operation.
-
-        :param t_elapsed: Time it took for the operation to complete.
-        """
-        normal_pass_msg = term_support.pass_str() + " (%.2f s)" % t_elapsed
-        self._log_ui_info(normal_pass_msg)
-
-    def _log_ui_status_error(self, t_elapsed):
-        """
-        Log an ERROR status message for a given operation.
-
-        :param t_elapsed: Time it took for the operation to complete.
-        """
-        normal_error_msg = term_support.error_str() + " (%.2f s)" % t_elapsed
-        self._log_ui_error_base(normal_error_msg)
-
-    def _log_ui_status_interrupt(self, t_elapsed):
-        """
-        Log an INTERRUPT status message for a given operation.
-
-        :param t_elapsed: Time it took for the operation to complete.
-        """
-        normal_error_msg = term_support.interrupt_str() + " (%.2f s)" % t_elapsed
-        self._log_ui_error_base(normal_error_msg)
-
-    def _log_ui_status_fail(self, t_elapsed):
-        """
-        Log a FAIL status message for a given operation.
-
-        :param t_elapsed: Time it took for the operation to complete.
-        """
-        normal_fail_msg = term_support.fail_str() + " (%.2f s)" % t_elapsed
-        self._log_ui_error_base(normal_fail_msg)
-
-    def _log_ui_status_skip(self, t_elapsed):
-        """
-        Log a SKIP status message for a given operation.
-
-        :param t_elapsed: Time it took for the operation to complete.
-        """
-        normal_skip_msg = term_support.skip_str()
-        self._log_ui_info(normal_skip_msg)
-
-    def _log_ui_status_warn(self, t_elapsed):
-        """
-        Log a WARN status message for a given operation.
-
-        :param t_elapsed: Time it took for the operation to complete.
-        """
-        normal_warn_msg = term_support.warn_str() + " (%.2f s)" % t_elapsed
-        self._log_ui_error_base(normal_warn_msg)
 
     def _log_ui_throbber_progress(self, progress_from_test=False):
         """

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -177,14 +177,17 @@ class TestRunner(object):
                 if not test_state['running']:
                     break
                 else:
-                    self.job.result_proxy.notify_progress(True)
+                    self.job.result_proxy.notify_progress(False)
                     if test_state['paused']:
                         msg = test_state['paused_msg']
                         if msg:
                             self.job.view.notify(event='partial', msg=msg)
 
             elif proc.is_alive():
-                self.job.result_proxy.notify_progress()
+                if test_state and not test_state.get('running'):
+                    self.job.result_proxy.notify_progress(False)
+                else:
+                    self.job.result_proxy.notify_progress(True)
             else:
                 break
 


### PR DESCRIPTION
The human output prints the test name, progress and pass/skip test
statuses into stdout and fail/error/interrupt ones as stderr. This
results in unreadable output. This patch logs all of them in stdout.

Additionally I changed the throbber colors, but that can be ripped off...
@clebergnu what do you think?