### PR TITLE
Fix list doesnt display errors

### DIFF
--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -454,10 +454,13 @@ class View(object):
             if hasattr(self.app_args, 'show_job_log'):
                 show_job_log = self.app_args.show_job_log
         if not (silent or show_job_log):
-            if self.use_paginator and (level < logging.ERROR):
+            if self.use_paginator:
                 if not skip_newline:
                     msg += '\n'
                 self.paginator.write(msg)
+                if level >= logging.ERROR:
+                    extra = {'skip_newline': skip_newline}
+                    self.console_log.log(level=level, msg=msg, extra=extra)
             else:
                 extra = {'skip_newline': skip_newline}
                 self.console_log.log(level=level, msg=msg, extra=extra)

--- a/avocado/core/plugins/test_list.py
+++ b/avocado/core/plugins/test_list.py
@@ -15,6 +15,7 @@
 import sys
 
 from . import plugin
+from . import builtin
 from .. import test
 from .. import loader
 from .. import output
@@ -33,6 +34,12 @@ class TestLister(object):
         self.view = output.View(app_args=args, use_paginator=use_paginator)
         self.term_support = output.TermSupport()
         loader.loader.load_plugins(args)
+        if self.view.use_paginator:
+            if builtin.ErrorsLoading:
+                for name, reason in builtin.ErrorsLoading:
+                    self.view.notify(event='error',
+                                     msg=('Error loading %s -> %s' %
+                                          (name, reason)))
         self.args = args
 
     def _extra_listing(self):


### PR DESCRIPTION
Fixes the card https://trello.com/c/WOPxkrZ8/450-bug-the-paginator-is-hiding-warnings-errors

It does that by fixing a View bug, and making the lister plugin to display plugin loading errors in case the paginator is enabled.