### PR TITLE
avocado.core.job: Print variants after the tree representation

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -401,6 +401,16 @@ class Job(object):
                 job_log.info(line)
             job_log.info('')
 
+    def _log_mux_variants(self, mux):
+        job_log = _TEST_LOGGER
+
+        for (index, tpl) in enumerate(mux.variants):
+            paths = ', '.join([x.path for x in tpl])
+            job_log.info('Variant %s:    %s', index + 1, paths)
+
+        if mux.variants:
+            job_log.info('')
+
     def _log_job_debug_info(self, mux):
         """
         Log relevant debug information to the job log.
@@ -411,6 +421,7 @@ class Job(object):
         self._log_avocado_config()
         self._log_avocado_datadir()
         self._log_mux_tree(mux)
+        self._log_mux_variants(mux)
         self._log_job_id()
 
     def _run(self, urls=None):


### PR DESCRIPTION
Implements the card:

https://trello.com/c/NWsedWVd/483-print-out-the-multiplex-variants-right-after-the-tree