### PR TITLE
[RFC] Fix unhelpful message when calling process/GDB APIs

### DIFF
--- a/avocado/utils/gdb.py
+++ b/avocado/utils/gdb.py
@@ -339,11 +339,17 @@ class GDB(object):
         args += self.REQUIRED_ARGS
         args += extra_args
 
-        self.process = subprocess.Popen(args,
-                                        stdin=subprocess.PIPE,
-                                        stdout=subprocess.PIPE,
-                                        stderr=subprocess.PIPE,
-                                        close_fds=True)
+        try:
+            self.process = subprocess.Popen(args,
+                                            stdin=subprocess.PIPE,
+                                            stdout=subprocess.PIPE,
+                                            stderr=subprocess.PIPE,
+                                            close_fds=True)
+        except OSError, details:
+            if details.errno == 2:
+                exc = OSError("File '%s' not found" % args[0])
+                exc.errno = 2
+                raise exc
 
         fcntl.fcntl(self.process.stdout.fileno(),
                     fcntl.F_SETFL, os.O_NONBLOCK)
@@ -649,11 +655,17 @@ class GDBServer(object):
         _, self.stderr_path = tempfile.mkstemp(prefix=prefix + 'stderr_')
         self.stderr = open(self.stderr_path, 'w')
 
-        self.process = subprocess.Popen(args,
-                                        stdin=subprocess.PIPE,
-                                        stdout=self.stdout,
-                                        stderr=self.stderr,
-                                        close_fds=True)
+        try:
+            self.process = subprocess.Popen(args,
+                                            stdin=subprocess.PIPE,
+                                            stdout=self.stdout,
+                                            stderr=self.stderr,
+                                            close_fds=True)
+        except OSError, details:
+            if details.errno == 2:
+                exc = OSError("File '%s' not found" % args[0])
+                exc.errno = 2
+                raise exc
 
         if wait_until_running:
             self._wait_until_running()

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -274,11 +274,18 @@ class SubProcess(object):
                 cmd = shlex.split(self.cmd)
             else:
                 cmd = self.cmd
-            self._popen = subprocess.Popen(cmd,
-                                           stdout=subprocess.PIPE,
-                                           stderr=subprocess.PIPE,
-                                           shell=self.shell,
-                                           env=self.env)
+            try:
+                self._popen = subprocess.Popen(cmd,
+                                               stdout=subprocess.PIPE,
+                                               stderr=subprocess.PIPE,
+                                               shell=self.shell,
+                                               env=self.env)
+            except OSError, details:
+                if details.errno == 2:
+                    exc = OSError("File '%s' not found" % self.cmd.split[0])
+                    exc.errno = 2
+                    raise exc
+
             self.start_time = time.time()
             self.stdout_file = StringIO.StringIO()
             self.stderr_file = StringIO.StringIO()


### PR DESCRIPTION
This implements the card

https://trello.com/c/P1pIdFg0/480-improve-error-message-when-gdb-or-gdbserver-is-missing

This could use some more testing, and perhaps some better implementation of the exception class, so that we get an error string closer to the original OSError exception. I'd like to get more opinions on that.