### PR TITLE
[V2] Fix unhelpful message when calling process/GDB APIs

### DIFF
--- a/avocado/utils/gdb.py
+++ b/avocado/utils/gdb.py
@@ -339,11 +339,19 @@ class GDB(object):
         args += self.REQUIRED_ARGS
         args += extra_args
 
-        self.process = subprocess.Popen(args,
-                                        stdin=subprocess.PIPE,
-                                        stdout=subprocess.PIPE,
-                                        stderr=subprocess.PIPE,
-                                        close_fds=True)
+        try:
+            self.process = subprocess.Popen(args,
+                                            stdin=subprocess.PIPE,
+                                            stdout=subprocess.PIPE,
+                                            stderr=subprocess.PIPE,
+                                            close_fds=True)
+        except OSError, details:
+            if details.errno == 2:
+                exc = OSError("File '%s' not found" % args[0])
+                exc.errno = 2
+                raise exc
+            else:
+                raise
 
         fcntl.fcntl(self.process.stdout.fileno(),
                     fcntl.F_SETFL, os.O_NONBLOCK)
@@ -649,11 +657,19 @@ class GDBServer(object):
         _, self.stderr_path = tempfile.mkstemp(prefix=prefix + 'stderr_')
         self.stderr = open(self.stderr_path, 'w')
 
-        self.process = subprocess.Popen(args,
-                                        stdin=subprocess.PIPE,
-                                        stdout=self.stdout,
-                                        stderr=self.stderr,
-                                        close_fds=True)
+        try:
+            self.process = subprocess.Popen(args,
+                                            stdin=subprocess.PIPE,
+                                            stdout=self.stdout,
+                                            stderr=self.stderr,
+                                            close_fds=True)
+        except OSError, details:
+            if details.errno == 2:
+                exc = OSError("File '%s' not found" % args[0])
+                exc.errno = 2
+                raise exc
+            else:
+                raise
 
         if wait_until_running:
             self._wait_until_running()

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -274,11 +274,20 @@ class SubProcess(object):
                 cmd = shlex.split(self.cmd)
             else:
                 cmd = self.cmd
-            self._popen = subprocess.Popen(cmd,
-                                           stdout=subprocess.PIPE,
-                                           stderr=subprocess.PIPE,
-                                           shell=self.shell,
-                                           env=self.env)
+            try:
+                self._popen = subprocess.Popen(cmd,
+                                               stdout=subprocess.PIPE,
+                                               stderr=subprocess.PIPE,
+                                               shell=self.shell,
+                                               env=self.env)
+            except OSError, details:
+                if details.errno == 2:
+                    exc = OSError("File '%s' not found" % self.cmd.split[0])
+                    exc.errno = 2
+                    raise exc
+                else:
+                    raise
+
             self.start_time = time.time()
             self.stdout_file = StringIO.StringIO()
             self.stderr_file = StringIO.StringIO()


### PR DESCRIPTION
The process and gdb related APIs trust on subprocess.Popen
to start a process. When shell=False and the command being
executed is missing, Subprocss.Popen will raise an OSError
with errno 2, with no additional message about what file
is actually missing.

OSError: [Errno 2] No such file or directory

As you might have guessed, my workaround is to capture
OSErrors with errno 2, and re-raise them with a more
helpful message.

'File /usr/bin/gdbserver not found'

Changes from v1:
 * Re-raise the exception when errno != 2 per @ldoktor's review

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>