### PR TITLE
[V2] Output tweaks

### DIFF
--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -456,7 +456,7 @@ class View(object):
         self.tests_info.update(info)
 
     def _get_test_tag(self, test_name):
-        return ('(%s/%s) %s:  ' %
+        return (' (%s/%s) %s:  ' %
                 (self.tests_info['tests_run'],
                  self.tests_info['tests_total'], test_name))
 

--- a/avocado/core/result.py
+++ b/avocado/core/result.py
@@ -264,11 +264,6 @@ class HumanTestResult(TestResult):
         TestResult.start_tests(self)
         self.stream.notify(event="message", msg="JOB ID     : %s" % self.stream.job_unique_id)
         self.stream.notify(event="message", msg="JOB LOG    : %s" % self.stream.logfile)
-        if self.args is not None:
-            if 'html_output' in self.args:
-                logdir = os.path.dirname(self.stream.logfile)
-                html_file = os.path.join(logdir, 'html', 'results.html')
-                self.stream.notify(event="message", msg="JOB HTML   : %s" % html_file)
         self.stream.notify(event="message", msg="TESTS      : %s" % self.tests_total)
         self.stream.set_tests_info({'tests_total': self.tests_total})
 
@@ -283,6 +278,12 @@ class HumanTestResult(TestResult):
                                (len(self.passed), len(self.errors),
                                 len(self.failed), len(self.skipped),
                                 len(self.warned), len(self.interrupted)))
+        if self.args is not None:
+            if 'html_output' in self.args:
+                logdir = os.path.dirname(self.stream.logfile)
+                html_file = os.path.join(logdir, 'html', 'results.html')
+                self.stream.notify(event="message", msg=("JOB HTML   : %s" %
+                                                         html_file))
         self.stream.notify(event="message",
                            msg="TIME       : %.2f s" % self.total_time)
 

--- a/docs/source/GetStartedGuide.rst
+++ b/docs/source/GetStartedGuide.rst
@@ -75,10 +75,10 @@ To do so, please run ``avocado`` with the ``run`` sub-command and the chosen tes
     $ avocado run /bin/true
     JOB ID    : 381b849a62784228d2fd208d929cc49f310412dc
     JOB LOG   : $HOME/avocado/job-results/job-2014-08-12T15.39-381b849a/job.log
-    JOB HTML  : $HOME/avocado/job-results/job-2014-08-12T15.39-381b849a/html/results.html
     TESTS     : 1
-    (1/1) /bin/true: PASS (0.01 s)
+     (1/1) /bin/true: PASS (0.01 s)
     RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0
+    JOB HTML  : $HOME/avocado/job-results/job-2014-08-12T15.39-381b849a/html/results.html
     TIME : 0.01 s
 
 You probably noticed that we used ``/bin/true`` as a test, and in accordance with our
@@ -168,15 +168,15 @@ instrumented and simple tests::
     $ avocado run failtest sleeptest synctest failtest synctest /tmp/simple_test.sh
     JOB ID    : 86911e49b5f2c36caeea41307cee4fecdcdfa121
     JOB LOG   : $HOME/avocado/job-results/job-2014-08-12T15.42-86911e49/job.log
-    JOB HTML  : $HOME/avocado/job-results/job-2014-08-12T15.42-86911e49/html/results.html
     TESTS     : 6
-    (1/6) failtest.1: FAIL (0.00 s)
-    (2/6) sleeptest.1: PASS (1.00 s)
-    (3/6) synctest.1: ERROR (0.01 s)
-    (4/6) failtest.2: FAIL (0.00 s)
-    (5/6) synctest.2: ERROR (0.01 s)
-    (6/6) /tmp/simple_test.sh.1: PASS (0.02 s)
+     (1/6) failtest.1: FAIL (0.00 s)
+     (2/6) sleeptest.1: PASS (1.00 s)
+     (3/6) synctest.1: ERROR (0.01 s)
+     (4/6) failtest.2: FAIL (0.00 s)
+     (5/6) synctest.2: ERROR (0.01 s)
+     (6/6) /tmp/simple_test.sh.1: PASS (0.02 s)
     RESULTS    : PASS 2 | ERROR 2 | FAIL 2 | SKIP 0 | WARN 0 | INTERRUPT 0
+    JOB HTML  : $HOME/avocado/job-results/job-2014-08-12T15.42-86911e49/html/results.html
     TIME      : 1.04 s
 
 Debugging tests

--- a/docs/source/ResultFormats.rst
+++ b/docs/source/ResultFormats.rst
@@ -24,12 +24,12 @@ that is, the job and its test(s) results are constantly updated::
     $ avocado run sleeptest failtest synctest
     JOB ID    : 5ffe479262ea9025f2e4e84c4e92055b5c79bdc9
     JOB LOG   : $HOME/avocado/job-results/job-2014-08-12T15.57-5ffe4792/job.log
-    JOB HTML  : $HOME/avocado/job-results/job-2014-08-12T15.57-5ffe4792/html/results.html
     TESTS     : 3
-    (1/3) sleeptest.1: PASS (1.01 s)
-    (2/3) failtest.1: FAIL (0.00 s)
-    (3/3) synctest.1: PASS (1.98 s)
+     (1/3) sleeptest.1: PASS (1.01 s)
+     (2/3) failtest.1: FAIL (0.00 s)
+     (3/3) synctest.1: PASS (1.98 s)
     RESULTS    : PASS 1 | ERROR 1 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0
+    JOB HTML  : $HOME/avocado/job-results/job-2014-08-12T15.57-5ffe4792/html/results.html
     TIME      : 3.17 s
 
 The most important thing is to remember that programs should never need to parse

--- a/docs/source/RunningTestsRemotely.rst
+++ b/docs/source/RunningTestsRemotely.rst
@@ -58,8 +58,8 @@ Once the remote machine is properly setup, you may run your test. Example::
     JOB ID    : 60ddd718e7d7bb679f258920ce3c39ce73cb9779
     JOB LOG   : $HOME/avocado/job-results/job-2014-10-23T11.45-a329461/job.log
     TESTS     : 2
-    (1/2) examples/tests/sleeptest.py: PASS (1.00 s)
-    (2/2) examples/tests/failtest.py: FAIL (0.00 s)
+     (1/2) examples/tests/sleeptest.py: PASS (1.00 s)
+     (2/2) examples/tests/failtest.py: FAIL (0.00 s)
     RESULTS    : PASS 1 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0
     TIME      : 1.01 s
 
@@ -133,8 +133,8 @@ Once the virtual machine is properly setup, you may run your test. Example::
     JOB ID    : 60ddd718e7d7bb679f258920ce3c39ce73cb9779
     JOB LOG   : $HOME/avocado/job-results/job-2014-09-16T18.41-60ddd71/job.log
     TESTS     : 2
-    (1/2) examples/tests/sleeptest.py: PASS (1.00 s)
-    (2/2) examples/tests/failtest.py: FAIL (0.00 s)
+     (1/2) examples/tests/sleeptest.py: PASS (1.00 s)
+     (2/2) examples/tests/failtest.py: FAIL (0.00 s)
     RESULTS    : PASS 1 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0
     TIME      : 1.01 s
 

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -156,12 +156,12 @@ generation for sleeptest just like::
     $ avocado run sleeptest --multiplex examples/tests/sleeptest.py.data/sleeptest.yaml
     JOB ID    : d565e8dec576d6040f894841f32a836c751f968f
     JOB LOG   : $HOME/avocado/job-results/job-2014-08-12T15.44-d565e8de/job.log
-    JOB HTML  : $HOME/avocado/job-results/job-2014-08-12T15.44-d565e8de/html/results.html
     TESTS     : 3
-    (1/3) sleeptest: PASS (0.50 s)
-    (2/3) sleeptest.1: PASS (1.01 s)
-    (3/3) sleeptest.2: PASS (5.01 s)
+     (1/3) sleeptest: PASS (0.50 s)
+     (2/3) sleeptest.1: PASS (1.01 s)
+     (3/3) sleeptest.2: PASS (5.01 s)
     RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0
+    JOB HTML  : $HOME/avocado/job-results/job-2014-08-12T15.44-d565e8de/html/results.html
     TIME : 6.52 s
 
 The ``--multiplex`` accepts either only ``$FILE_LOCATION`` or ``$INJECT_TO:$FILE_LOCATION``.
@@ -188,22 +188,17 @@ You can also execute multiple tests with the same multiplex file::
     ./scripts/avocado run sleeptest synctest --multiplex examples/tests/sleeptest.py.data/sleeptest.yaml
     JOB ID     : 72166988c13fec26fcc9c2e504beec8edaad4761
     JOB LOG    : /home/medic/avocado/job-results/job-2015-05-15T11.02-7216698/job.log
-    JOB HTML   : /home/medic/avocado/job-results/job-2015-05-15T11.02-7216698/html/results.html
     TESTS      : 8
-    (1/8) sleeptest.py: PASS (1.00 s)
-    (2/8) sleeptest.py.1: PASS (1.00 s)
-    (3/8) sleeptest.py.2: PASS (1.00 s)
-    (4/8) sleeptest.py.3: PASS (1.00 s)
-    (5/8) synctest.py: PASS (1.31 s)
-    (6/8) synctest.py.1: PASS (1.48 s)
-    (7/8) synctest.py.2: PASS (3.36 s)
-    (8/8) synctest.py.3: PASS (3.59 s)
-    PASS       : 8
-    ERROR      : 0
-    FAIL       : 0
-    SKIP       : 0
-    WARN       : 0
-    INTERRUPT  : 0
+     (1/8) sleeptest.py: PASS (1.00 s)
+     (2/8) sleeptest.py.1: PASS (1.00 s)
+     (3/8) sleeptest.py.2: PASS (1.00 s)
+     (4/8) sleeptest.py.3: PASS (1.00 s)
+     (5/8) synctest.py: PASS (1.31 s)
+     (6/8) synctest.py.1: PASS (1.48 s)
+     (7/8) synctest.py.2: PASS (3.36 s)
+     (8/8) synctest.py.3: PASS (3.59 s)
+    RESULTS    : PASS 8 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0
+    JOB HTML   : /home/medic/avocado/job-results/job-2015-05-15T11.02-7216698/html/results.html
     TIME       : 13.76 s
 
 :class:`unittest.TestCase` heritage
@@ -387,7 +382,7 @@ option --output-check-record all to the test runner::
     JOB ID    : bcd05e4fd33e068b159045652da9eb7448802be5
     JOB LOG   : $HOME/avocado/job-results/job-2014-09-25T20.20-bcd05e4/job.log
     TESTS     : 1
-    (1/1) synctest.py: PASS (2.20 s)
+     (1/1) synctest.py: PASS (2.20 s)
     RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0
     TIME      : 2.20 s
 
@@ -416,7 +411,7 @@ Let's record the output for this one::
     JOB ID    : 25c4244dda71d0570b7f849319cd71fe1722be8b
     JOB LOG   : $HOME/avocado/job-results/job-2014-09-25T20.49-25c4244/job.log
     TESTS     : 1
-    (1/1) home/$USER/Code/avocado/output_record.sh: PASS (0.01 s)
+     (1/1) home/$USER/Code/avocado/output_record.sh: PASS (0.01 s)
     RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0
     TIME      : 0.01 s
 
@@ -441,7 +436,7 @@ happens if we change the ``stdout.expected`` file contents to ``Hello, Avocado!`
     JOB ID    : f0521e524face93019d7cb99c5765aedd933cb2e
     JOB LOG   : $HOME/avocado/job-results/job-2014-09-25T20.52-f0521e5/job.log
     TESTS     : 1
-    (1/1) home/$USER/Code/avocado/output_record.sh: FAIL (0.02 s)
+     (1/1) home/$USER/Code/avocado/output_record.sh: FAIL (0.02 s)
     RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0
     TIME      : 0.02 s
 
@@ -575,7 +570,7 @@ impact your test grid. You can account for that possibility and set up a
     JOB LOG   : $HOME/avocado/job-results/job-2014-08-12T15.52-6d5a2ff1/job.log
     JOB HTML  : $HOME/avocado/job-results/job-2014-08-12T15.52-6d5a2ff1/html/results.html
     TESTS     : 1
-    (1/1) sleeptest.1: ERROR (2.97 s)
+     (1/1) sleeptest.1: ERROR (2.97 s)
     RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0
     TIME      : 2.97 s
 
@@ -661,7 +656,7 @@ This accomplishes a similar effect to the multiplex setup defined in there.
     JOB LOG   : $HOME/avocado/job-results/job-2014-08-12T15.54-d78498a5/job.log
     JOB HTML  : $HOME/avocado/job-results/job-2014-08-12T15.54-d78498a5/html/results.html
     TESTS     : 1
-    (1/1) timeouttest.1: ERROR (2.97 s)
+     (1/1) timeouttest.1: ERROR (2.97 s)
     RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0
     TIME      : 2.97 s
 


### PR DESCRIPTION
Implements the card

https://trello.com/c/NcxQk6tv/472-show-link-to-html-report-at-end-of-job-not-beginning

See the before/after each commit in the individual commit messages.

Changes from v1:
* Documentation updated according to a few misses spotted by @ldoktor 