### PR TITLE
selftests: Add run_coverage

### DIFF
--- a/selftests/run_coverage
+++ b/selftests/run_coverage
@@ -1,0 +1,13 @@
+#!/bin/bash +x
+# Execute all unittests with coverage and report code coverage.
+#
+# Copyright: Red Hat Inc.
+# License: GPLv2
+# Author: Lukas Doktor <ldoktor@redhat.com>
+
+coverage erase
+coverage run --include "avocado/*" ./selftests/run
+echo
+coverage report -m --include "avocado/core/*"
+echo
+coverage report -m --include "avocado/utils/*"


### PR DESCRIPTION
The https://github.com/clebergnu/avocado/commit/e9c0d8134fcd185b20e1628d106631275f6e3e14 removed the code coverage script. From time to time it's useful. It requires `python-coverage` to be installed, but as it's only an extra feature, I did not add it to the requirements. Those who are suppose to utilize it should be familiar with enough with the process...