### PR TITLE
avocado.core.data_dir: Make data dir to honor settings when running f…

### DIFF
--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -117,9 +117,8 @@ def _usable_ro_dir(directory):
 
 
 def _get_rw_dir(settings_location, system_location, user_location):
-    if not settings.intree:
-        if _usable_rw_dir(settings_location):
-            return settings_location
+    if _usable_rw_dir(settings_location):
+        return settings_location
 
     if _usable_rw_dir(system_location):
         return system_location


### PR DESCRIPTION
…rom git repos

We should be honoring the setting in the avocado config files
if running from git repos.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>