### PR TITLE
RFC: Makefile: Move "make link" to plugins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ DESTDIR=/
 BUILDIR=$(CURDIR)/debian/avocado
 PROJECT=avocado
 VERSION=`$(CURDIR)/avocado/core/version.py`
+AVOCADO_PLUGINS=$(filter-out ../avocado/Makefile, $(wildcard ../*/Makefile))
 
 all:
 	@echo "make source - Create source package"
@@ -59,15 +60,9 @@ clean:
 	rm -f man/avocado-rest-client.1
 	rm -rf docs/build
 	find docs/source/api/ -name '*.rst' -delete
-	test -L avocado/virt && rm -f avocado/virt || true
-	test -L avocado/core/plugins/virt.py && rm -f avocado/core/plugins/virt.py || true
-	test -L avocado/core/plugins/virt_bootstrap.py && rm -f avocado/core/plugins/virt_bootstrap.py || true
-	test -L etc/avocado/conf.d/virt.conf && rm -f etc/avocado/conf.d/virt.conf || true
-	test -L avocado/core/plugins/vt.py && rm -f avocado/core/plugins/vt.py || true
-	test -L avocado/core/plugins/vt_list.py && rm -f avocado/core/plugins/vt_list.py || true
-	test -L avocado/core/plugins/vt_bootstrap.py && rm -f avocado/core/plugins/vt_bootstrap.py || true
-	test -L etc/avocado/conf.d/vt.conf && rm -f etc/avocado/conf.d/vt.conf || true
-	test -L virttest && rm -f virttest || true
+	for MAKEFILE in $(AVOCADO_PLUGINS);\
+		do make -f $$MAKEFILE unlink &>/dev/null && echo ">> UNLINK $$MAKEFILE" || echo ">> SKIP $$MAKEFILE";\
+	done
 
 install-requirements-all: install-requirements install-requirements-selftests
 
@@ -86,20 +81,10 @@ check_cyclical:
 modules_boundaries:
 	selftests/modules_boundaries
 
-link: link_virt link_vt
-
-link_virt:
-	test -d ../avocado-virt/avocado/virt && ln -sf ../../avocado-virt/avocado/virt avocado || true
-	test -f ../avocado-virt/etc/avocado/conf.d/virt.conf && ln -sf ../../../../avocado-virt/etc/avocado/conf.d/virt.conf etc/avocado/conf.d/ || true
-	test -f ../avocado-virt/avocado/core/plugins/virt.py && ln -sf ../../../../avocado-virt/avocado/core/plugins/virt.py avocado/core/plugins/ || true
-	test -f ../avocado-virt/avocado/core/plugins/virt_bootstrap.py && ln -sf ../../../../avocado-virt/avocado/core/plugins/virt_bootstrap.py avocado/core/plugins/ || true
-
-link_vt:
-	test -f ../avocado-vt/etc/avocado/conf.d/vt.conf && ln -sf ../../../../avocado-vt/etc/avocado/conf.d/vt.conf etc/avocado/conf.d/ || true
-	test -f ../avocado-vt/avocado/core/plugins/vt.py && ln -sf ../../../../avocado-vt/avocado/core/plugins/vt.py avocado/core/plugins/ || true
-	test -f ../avocado-vt/avocado/core/plugins/vt_list.py && ln -sf ../../../../avocado-vt/avocado/core/plugins/vt_list.py avocado/core/plugins/ || true
-	test -f ../avocado-vt/avocado/core/plugins/vt_bootstrap.py && ln -sf ../../../../avocado-vt/avocado/core/plugins/vt_bootstrap.py avocado/core/plugins/ || true
-	test -d ../avocado-vt/virttest && ln -sf ../avocado-vt/virttest . || true
+link:
+	for MAKEFILE in $(AVOCADO_PLUGINS);\
+		do make -f $$MAKEFILE link &>/dev/null && echo ">> LINK $$MAKEFILE" || echo ">> SKIP $$MAKEFILE";\
+	done
 
 man: man/avocado.1 man/avocado-rest-client.1
 


### PR DESCRIPTION
This patch removes the hardcoded plugin linking and instead queries all
../!(avocado)/Makefile files to link or unlink the plugins. This should
help people to deploy own plugins in the same fashion without the need
to modify avocado's main Makefile.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>