### PR TITLE
selftests/run: Ensure bad statuses trigger an exit code != 0

### DIFF
--- a/selftests/run
+++ b/selftests/run
@@ -28,4 +28,6 @@ def test_suite():
 
 if __name__ == '__main__':
     runner = unittest.TextTestRunner()
-    runner.run(test_suite())
+    result = runner.run(test_suite())
+    if result.failures or result.errors:
+        sys.exit(1)


### PR DESCRIPTION
The way we built the unittest runner will happily
ignore errors, which is bad from a CI standpoint.
Let's ensure that errors don't go unnoticed by
analyzing the results object and see if it's got
errors or failures.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>