### PR TITLE
docs: Add Multiplexation to WritingTests.html#basic-example

### DIFF
--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -91,7 +91,7 @@ Avocado finds and populates ``self.params`` with all parameters you define on
 a Multiplex Config file (see :doc:`MultiplexConfig`). As an example, consider
 the following multiplex file for sleeptest::
 
-    sleeptest:
+    sleeptest: !mux
         type: "builtin"
         short:
             sleep_length: 0.5


### PR DESCRIPTION
Currently the yaml contents in this page is missing '!mux'
keyword, run as-is will show users errors. Fixing by adding
keyword '!mux' to the yaml content.

Signed-off-by: Srikanth Aithal <sraithal@linux.vnet.ibm.com>