### PR TITLE
setup.py: Set zip_safe flag to false

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -124,4 +124,5 @@ if __name__ == '__main__':
           data_files=get_data_files(),
           scripts=['scripts/avocado',
                    'scripts/avocado-rest-client'],
+          zip_safe=False,
           test_suite='selftests')


### PR DESCRIPTION
In module avocado.core.plugins.builtin, There is a calling of
os.listdir() to iterate files in the installed python directory.

If avocado is installed in an .egg file which is compressed, it will
fail to load because that path does not really exists.

To avoid this failure, this patch set zip_safe to False explicitly.
So setuptools will install package to a real directory instead of a
zipped .egg file.

The error message I met is as following:
```
# avocado
Traceback (most recent call last):
  File "/usr/bin/avocado", line 4, in <module>
    __import__('pkg_resources').run_script('avocado==0.27.0', 'avocado')
  File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 735, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 1659, in run_script
    exec(script_code, namespace, namespace)
  File "/usr/lib/python2.7/site-packages/avocado-0.27.0-py2.7.egg/EGG-INFO/scripts/avocado", line 27, in <module>
    
  File "/usr/lib/python2.7/site-packages/avocado-0.27.0-py2.7.egg/avocado/__init__.py", line 19, in <module>
  File "/usr/lib/python2.7/site-packages/avocado-0.27.0-py2.7.egg/avocado/core/job.py", line 43, in <module>
  File "/usr/lib/python2.7/site-packages/avocado-0.27.0-py2.7.egg/avocado/core/plugins/manager.py", line 19, in <module>
  File "/usr/lib/python2.7/site-packages/avocado-0.27.0-py2.7.egg/avocado/core/plugins/builtin.py", line 30, in <module>
OSError: [Errno 20] Not a directory: '/usr/lib/python2.7/site-packages/avocado-0.27.0-py2.7.egg/avocado/core/plugins'
```

Signed-off-by: Hao Liu <hliu@redhat.com>