### PR TITLE
avocado.core.log: Initialize "root" logger [v2]

### DIFF
--- a/avocado/core/log.py
+++ b/avocado/core/log.py
@@ -70,6 +70,9 @@ DEFAULT_LOGGING = {
         },
     },
     'loggers': {
+        '': {
+            'handlers': ['null']
+        },
         'avocado': {
             'handlers': ['console'],
         },


### PR DESCRIPTION
Initialize "root" logger as "NullHandler" to prevent other libraries
from initializing. Avocado adds file or stream handlers when it
requires them (avocado-vt).

v1: https://github.com/avocado-framework/avocado/pull/742#issuecomment-129687841

Changelog:

v2: Rather than removing handlers this correctly initialize the "root" logger

Test:

1. remove Pillow (pip uninstall Pillow)
2. avocado run boot
=> without the patch it shows the full avocado-vt log in console altogether with `avocado.ui`
=> with the patch everything goes into correct logger

__Question: Side effect is, that the warning about missing "python-imaging" is ignored. There are couple of solutions:__

* Use v1, which displays the warning in stdout and then removes the handlers
* Make the PIL import/warning later in the code, when the root logger is redirected to the test file (after plugin initialization)
* Raise the warning every time we try to use Image

I'd go with this version (which ignores the warning). I'd start working correctly once we implement early print https://trello.com/c/0YUsLUmx/506-improve-the-logging-system (and it's the least hackish version)