### PR TITLE
avocado.core.test: Avoid passing ugly exceptions

### DIFF
--- a/examples/tests/failtest_nasty3.py
+++ b/examples/tests/failtest_nasty3.py
@@ -1,0 +1,32 @@
+#!/usr/bin/python
+
+from avocado import Test
+from avocado import main
+
+
+class NastyException:
+
+    """ Please never use something like this!!! (old-style exception) """
+
+    def __init__(self, msg):
+        self.msg = msg
+
+    def __str__(self):
+        return self.msg
+
+
+class FailTest(Test):
+
+    """
+    This test raises old-style-class exception
+    """
+
+    def test(self):
+        """
+        Should fail not-that-badly
+        """
+        raise NastyException("Nasty-string-like-exception")
+
+
+if __name__ == "__main__":
+    main()

--- a/selftests/functional/test_standalone.py
+++ b/selftests/functional/test_standalone.py
@@ -62,6 +62,13 @@ class StandaloneTests(unittest.TestCase):
         self.assertIn("Exception: Unable to get exception, check the traceback"
                       " for details.", result.stdout)
 
+    def test_failtest_nasty3(self):
+        cmd_line = './examples/tests/failtest_nasty3.py -r'
+        expected_rc = 1
+        result = self.run_and_check(cmd_line, expected_rc, 'failtest_nasty3')
+        self.assertIn("TestError: <failtest_nasty3.NastyException instance at ",
+                      result.stdout)
+
     def test_errortest(self):
         cmd_line = './examples/tests/errortest.py -r'
         expected_rc = 1


### PR DESCRIPTION
Currently when one passes exception, which is not instance of Exception,
avocado proceeds and returns "INTERRUPTED" test instead of "ERROR". This
for example happens when old-style-class is used as exception. This
patch uses pure "except" without any argument to catch such exceptions
and then it wraps them in "exceptions.TestError" instead.

The same applies to "setUp" and "tearDown", they only use different
class as a wrapper.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>