### PR TITLE
avocado.core.plugins: Print traceback on failure

### DIFF
--- a/avocado/core/plugins/builtin.py
+++ b/avocado/core/plugins/builtin.py
@@ -15,11 +15,13 @@
 """Builtin plugins."""
 
 import os
+import sys
 import logging
 from importlib import import_module
 
 from .plugin import Plugin
 from ..settings import settings
+from ...utils import stacktrace
 
 
 log = logging.getLogger("avocado.app")
@@ -59,6 +61,8 @@ def load_builtins():
             if name not in skip_notify:
                 log.error('Error loading %s -> %s', name, reason)
             ErrorsLoading.append((name, reason))
+            stacktrace.log_exc_info(sys.exc_info(),
+                                    'avocado.app.tracebacks')
             continue
         for name in plugin_mod.__dict__:
             obj = getattr(plugin_mod, name)


### PR DESCRIPTION
Hello guys,

I spent couple of hours trying to find out why avocado fails when I run it from Jenkins and passes when I run the very same command manually, always getting "IOError" without the file (the file is not set even in err.filename).

Long story short, it was old environment value "AUTOTEST_PATH", which was not valid and set in Jenkins. This extended debug would point me directly to the place where it happens.

Regards,
Lukáš