### PR TITLE
Spec files update

### DIFF
--- a/avocado.spec
+++ b/avocado.spec
@@ -1,14 +1,14 @@
 Summary: Avocado Test Framework
 Name: avocado
 Version: 0.28.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.github.io/
 Source: avocado-%{version}.tar.gz
 BuildArch: noarch
 Requires: python, python-requests, fabric, pyliblzma, libvirt-python, pystache, gdb, gdb-gdbserver
-BuildRequires: python2-devel, python-docutils, python-mock
+BuildRequires: python2-devel, python-docutils, python-mock, python-psutil, python-sphinx, python-requests, aexpect, pystache, yum
 
 %if 0%{?el6}
 Requires: PyYAML
@@ -46,7 +46,7 @@ these days a framework) to perform automated testing.
 # on EPEL7.
 %if !0%{?rhel}
 %check
-selftests/run selftests/all/unit
+selftests/run
 %endif
 
 %files
@@ -104,6 +104,9 @@ examples of how to write tests on your own.
 %{_datadir}/avocado/wrappers
 
 %changelog
+* Wed Sep 16 2015 Lucas Meneghel Rodrigues <lmr@redhat.com> - 0.28.0-2
+- Add pystache, aexpect, psutil, sphinx and yum/dnf dependencies for functional/unittests
+
 * Wed Sep 16 2015 Lucas Meneghel Rodrigues <lmr@redhat.com> - 0.28.0-1
 - New upstream release 0.28.0
 

--- a/avocado.spec
+++ b/avocado.spec
@@ -1,7 +1,7 @@
 Summary: Avocado Test Framework
 Name: avocado
 Version: 0.28.0
-Release: 2%{?dist}
+Release: 3%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.github.io/
@@ -40,14 +40,6 @@ these days a framework) to perform automated testing.
 %{__mkdir} -p %{buildroot}%{_mandir}/man1
 %{__install} -m 0644 man/avocado.1 %{buildroot}%{_mandir}/man1/avocado.1
 %{__install} -m 0644 man/avocado-rest-client.1 %{buildroot}%{_mandir}/man1/avocado-rest-client.1
-
-# Running the unittests is currently disabled on EL6 because fabric is
-# missing on EPEL 6 and also on EL7 because python-flexmock is missing
-# on EPEL7.
-%if !0%{?rhel}
-%check
-selftests/run
-%endif
 
 %files
 %defattr(-,root,root,-)


### PR DESCRIPTION
An interesting side effect of @clebergnu's work of ditching nose and standardizing all the unittests and functional tests is that all the tests are run at rpm build time. While a great idea, it made building our avocado packages on different chroots challenging. 

So this PR contains some fixes and one workaround I had to deploy to have a successful build of avocado in all targets I possibly could. We'll have to undo the workaround for the next release.