### PR TITLE
selftests/test_interrupt.py: Make test compatible with psutils 0.6

### DIFF
--- a/selftests/functional/test_interrupt.py
+++ b/selftests/functional/test_interrupt.py
@@ -13,7 +13,6 @@ else:
     import unittest
 
 from avocado.utils import wait
-from avocado.utils import process
 from avocado.utils import script
 from avocado.utils import data_factory
 
@@ -85,7 +84,13 @@ class InterruptTest(unittest.TestCase):
         # Make sure the bad test will be really gone from the process table
         def wait_until_no_badtest():
             bad_test_processes = []
-            for p in psutil.pids():
+
+            try:
+                process_list = psutil.pids()
+            except AttributeError:
+                process_list = psutil.get_pid_list()
+
+            for p in process_list:
                 p_obj = None
                 try:
                     p_obj = psutil.Process(p)
@@ -126,7 +131,13 @@ class InterruptTest(unittest.TestCase):
         # Make sure the good test will be really gone from the process table
         def wait_until_no_goodtest():
             good_test_processes = []
-            for p in psutil.pids():
+
+            try:
+                process_list = psutil.pids()
+            except AttributeError:
+                process_list = psutil.get_pid_list()
+
+            for p in process_list:
                 p_obj = None
                 try:
                     p_obj = psutil.Process(p)


### PR DESCRIPTION
Fedora 21 ships psutils 0.6, that has the API psutil.get_pid_list()
instead of psutil.pids(). Let's make both compatible, for the sake
of running unittests on COPR builds.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>