### PR TITLE
avocado.core.remote: Add support for multiplex files on remote machine

### DIFF
--- a/avocado/core/remote/result.py
+++ b/avocado/core/remote/result.py
@@ -44,7 +44,7 @@ class RemoteTestResult(HumanTestResult):
         self.output = '-'
         self.command_line_arg_name = '--remote-hostname'
 
-    def copy_tests(self):
+    def copy_files(self):
         """
         Gather test directories and copy them recursively to
         $remote_test_dir + $test_absolute_path.
@@ -71,6 +71,10 @@ class RemoteTestResult(HumanTestResult):
             test_data = path + '.data'
             if os.path.isdir(test_data):
                 self.remote.send_files(test_data, os.path.dirname(rpath))
+        for mux_file in getattr(self.args, 'multiplex_files') or []:
+            rpath = os.path.join(self.remote_test_dir, mux_file)
+            self.remote.makedir(os.path.dirname(rpath))
+            self.remote.send_files(mux_file, rpath)
 
     def setup(self):
         """ Setup remote environment and copy test directories """

--- a/selftests/unit/test_remote.py
+++ b/selftests/unit/test_remote.py
@@ -79,15 +79,17 @@ _=/usr/bin/env''', exit_status=0)
          .once().and_return(urls_result))
 
         args = ("cd ~/avocado/tests; avocado run --force-job-id sleeptest.1 "
-                "--json - --archive sleeptest")
+                "--json - --archive sleeptest --multiplex-files "
+                "~/avocado/tests/foo.yaml ~/avocado/tests/bar/baz.yaml")
         (Remote.should_receive('run')
          .with_args(args, timeout=61, ignore_status=True)
          .once().and_return(test_results))
         Results = flexmock(remote=Remote, urls=['sleeptest'],
                            stream=stream, timeout=None,
-                           args=flexmock(show_job_log=False))
+                           args=flexmock(show_job_log=False,
+                           multiplex_files=['foo.yaml', 'bar/baz.yaml']))
         Results.should_receive('setup').once().ordered()
-        Results.should_receive('copy_tests').once().ordered()
+        Results.should_receive('copy_files').once().ordered()
         Results.should_receive('start_tests').once().ordered()
         args = {'status': u'PASS', 'whiteboard': '', 'time_start': 0,
                 'name': u'sleeptest.1', 'class_name': 'RemoteTest',


### PR DESCRIPTION
This patch adds support for using multiplex files and remote plugin
together. It copies all of the specified multiplex files and then
uses them in execution.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>