### PR TITLE
Spec files Update

### DIFF
--- a/avocado.spec
+++ b/avocado.spec
@@ -1,14 +1,14 @@
 Summary: Avocado Test Framework
 Name: avocado
 Version: 0.28.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.github.io/
 Source: avocado-%{version}.tar.gz
 BuildArch: noarch
 Requires: python, python-requests, fabric, pyliblzma, libvirt-python, pystache, gdb, gdb-gdbserver
-BuildRequires: python2-devel, python-docutils, python-mock
+BuildRequires: python2-devel, python-docutils, python-mock, python-psutil, python-sphinx, python-requests, aexpect, pystache, yum
 
 %if 0%{?el6}
 Requires: PyYAML
@@ -46,7 +46,7 @@ these days a framework) to perform automated testing.
 # on EPEL7.
 %if !0%{?rhel}
 %check
-selftests/run selftests/all/unit
+selftests/run
 %endif
 
 %files
@@ -104,6 +104,9 @@ examples of how to write tests on your own.
 %{_datadir}/avocado/wrappers
 
 %changelog
+* Wed Sep 16 2015 Lucas Meneghel Rodrigues <lmr@redhat.com> - 0.28.0-2
+- Add pystache, aexpect, psutil, sphinx and yum/dnf dependencies for functional/unittests
+
 * Wed Sep 16 2015 Lucas Meneghel Rodrigues <lmr@redhat.com> - 0.28.0-1
 - New upstream release 0.28.0
 

--- a/selftests/functional/test_interrupt.py
+++ b/selftests/functional/test_interrupt.py
@@ -85,10 +85,12 @@ class InterruptTest(unittest.TestCase):
         def wait_until_no_badtest():
             bad_test_processes = []
 
+            old_psutil = False
             try:
                 process_list = psutil.pids()
             except AttributeError:
                 process_list = psutil.get_pid_list()
+                old_psutil = True
 
             for p in process_list:
                 p_obj = None
@@ -97,7 +99,11 @@ class InterruptTest(unittest.TestCase):
                 except psutil.NoSuchProcess:
                     pass
                 if p_obj is not None:
-                    if bad_test.path in " ".join(psutil.Process(p).cmdline()):
+                    if old_psutil:
+                        cmdline_list = psutil.Process(p).cmdline
+                    else:
+                        cmdline_list = psutil.Process(p).cmdline()
+                    if bad_test.path in " ".join(cmdline_list):
                         bad_test_processes.append(p_obj)
             return len(bad_test_processes) == 0
 
@@ -132,10 +138,12 @@ class InterruptTest(unittest.TestCase):
         def wait_until_no_goodtest():
             good_test_processes = []
 
+            old_psutil = False
             try:
                 process_list = psutil.pids()
             except AttributeError:
                 process_list = psutil.get_pid_list()
+                old_psutil = True
 
             for p in process_list:
                 p_obj = None
@@ -144,7 +152,11 @@ class InterruptTest(unittest.TestCase):
                 except psutil.NoSuchProcess:
                     pass
                 if p_obj is not None:
-                    if good_test.path in " ".join(psutil.Process(p).cmdline()):
+                    if old_psutil:
+                        cmdline_list = psutil.Process(p).cmdline
+                    else:
+                        cmdline_list = psutil.Process(p).cmdline()
+                    if good_test.path in " ".join(cmdline_list):
                         good_test_processes.append(p_obj)
             return len(good_test_processes) == 0
 


### PR DESCRIPTION
An interesting side effect of @clebergnu's work of ditching nose and standardizing all the unittests and functional tests is that all the tests are run at rpm build time. While a great idea, it made building our avocado packages on different chroots challenging. 

This solves yet another problem I found in Fedora, the only ones remaining now are the result of bugs in Fedora 23 and Rawhide, so this covers our bases (mostly).