### PR TITLE
examples.tests: Rename failtest_nasty* to errortest_nasty*

### DIFF
--- a/examples/tests/errortest_nasty.py
+++ b/examples/tests/errortest_nasty.py
@@ -4,9 +4,9 @@ from avocado import Test
 from avocado import main
 
 
-class NastyException:
+class NastyException(Exception):
 
-    """ Please never use something like this!!! (old-style exception) """
+    """ Please never use something like this!!! """
 
     def __init__(self, msg):
         self.msg = msg
@@ -18,12 +18,12 @@ class NastyException:
 class FailTest(Test):
 
     """
-    This test raises old-style-class exception
+    Very nasty exception test
     """
 
     def test(self):
         """
-        Should fail not-that-badly
+        Avocado should report this as TestError.
         """
         raise NastyException("Nasty-string-like-exception")
 

--- a/examples/tests/errortest_nasty2.py
+++ b/examples/tests/errortest_nasty2.py
@@ -23,9 +23,9 @@ class FailTest(Test):
 
     def test(self):
         """
-        Should fail not-that-badly
+        Avocado should report this as TestError.
         """
-        raise NastyException("Nasty-string-like-exception")
+        raise NastyException(None)  # str(Exception) fails!
 
 
 if __name__ == "__main__":

--- a/examples/tests/errortest_nasty3.py
+++ b/examples/tests/errortest_nasty3.py
@@ -4,9 +4,9 @@ from avocado import Test
 from avocado import main
 
 
-class NastyException(Exception):
+class NastyException:
 
-    """ Please never use something like this!!! """
+    """ Please never use something like this!!! (old-style exception) """
 
     def __init__(self, msg):
         self.msg = msg
@@ -18,14 +18,14 @@ class NastyException(Exception):
 class FailTest(Test):
 
     """
-    Very nasty exception test
+    This test raises old-style-class exception
     """
 
     def test(self):
         """
-        Should fail.
+        Avocado should report this as TestError.
         """
-        raise NastyException(None)  # str(Exception) fails!
+        raise NastyException("Nasty-string-like-exception")
 
 
 if __name__ == "__main__":

--- a/selftests/functional/test_standalone.py
+++ b/selftests/functional/test_standalone.py
@@ -45,28 +45,28 @@ class StandaloneTests(unittest.TestCase):
         expected_rc = 1
         self.run_and_check(cmd_line, expected_rc, 'failtest')
 
-    def test_failtest_nasty(self):
-        cmd_line = './examples/tests/failtest_nasty.py -r'
+    def test_errortest_nasty(self):
+        cmd_line = './examples/tests/errortest_nasty.py -r'
         expected_rc = 1
-        result = self.run_and_check(cmd_line, expected_rc, 'failtest_nasty')
+        result = self.run_and_check(cmd_line, expected_rc, 'errortest_nasty')
         exc = "NastyException: Nasty-string-like-exception"
         count = result.stdout.count("\n%s" % exc)
         self.assertEqual(count, 2, "Exception \\n%s should be present twice in"
                          "the log (once from the log, second time when parsing"
                          "exception details." % (exc))
 
-    def test_failtest_nasty2(self):
-        cmd_line = './examples/tests/failtest_nasty2.py -r'
+    def test_errortest_nasty2(self):
+        cmd_line = './examples/tests/errortest_nasty2.py -r'
         expected_rc = 1
-        result = self.run_and_check(cmd_line, expected_rc, 'failtest_nasty2')
+        result = self.run_and_check(cmd_line, expected_rc, 'errortest_nasty2')
         self.assertIn("Exception: Unable to get exception, check the traceback"
                       " for details.", result.stdout)
 
-    def test_failtest_nasty3(self):
-        cmd_line = './examples/tests/failtest_nasty3.py -r'
+    def test_errortest_nasty3(self):
+        cmd_line = './examples/tests/errortest_nasty3.py -r'
         expected_rc = 1
-        result = self.run_and_check(cmd_line, expected_rc, 'failtest_nasty3')
-        self.assertIn("TestError: <failtest_nasty3.NastyException instance at ",
+        result = self.run_and_check(cmd_line, expected_rc, 'errortest_nasty3')
+        self.assertIn("TestError: <errortest_nasty3.NastyException instance at ",
                       result.stdout)
 
     def test_errortest(self):


### PR DESCRIPTION
This patch is a response to @clebergnu recommendation from https://github.com/avocado-framework/avocado/pull/789