### PR TITLE
TMP dir management updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,3 +28,4 @@ script:
     - ./selftests/cyclical_deps avocado
     - ./selftests/modules_boundaries
     - ./selftests/run
+    - ./selftests/check_tmp_dirs

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,8 @@ clean:
 	for MAKEFILE in $(AVOCADO_PLUGINS);\
 		do AVOCADO_DIRNAME=$(AVOCADO_DIRNAME) make -C $$MAKEFILE unlink &>/dev/null && echo ">> UNLINK $$MAKEFILE" || echo ">> SKIP $$MAKEFILE";\
 	done
+	rm -rf /var/tmp/avocado*
+	rm -rf /tmp/avocado*
 
 install-requirements-all: install-requirements install-requirements-selftests
 
@@ -75,6 +77,7 @@ install-requirements-selftests:
 
 check: clean check_cyclical modules_boundaries
 	selftests/checkall
+	selftests/check_tmp_dirs
 
 check_cyclical:
 	selftests/cyclical_deps avocado

--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -232,8 +232,6 @@ class _TmpDirTracker(Borg):
     def get(self):
         return self.tmp_dir
 
-_tmp_tracker = _TmpDirTracker()
-
 
 def get_tmp_dir():
     """
@@ -245,6 +243,7 @@ def get_tmp_dir():
         * Copies of a test suite source code
         * Compiled test suite source code
     """
+    _tmp_tracker = _TmpDirTracker()
     return _tmp_tracker.get()
 
 

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -512,17 +512,16 @@ class Job(object):
         """
         runtime.CURRENT_JOB = self
         try:
-            return self._run(urls)
+            rc = self._run(urls)
         except exceptions.JobBaseException, details:
             self.status = details.status
             fail_class = details.__class__.__name__
             self.view.notify(event='error', msg=('Avocado job failed: %s: %s' %
                                                  (fail_class, details)))
-            return exit_codes.AVOCADO_JOB_FAIL
+            rc = exit_codes.AVOCADO_JOB_FAIL
         except exceptions.OptionValidationError, details:
             self.view.notify(event='error', msg=str(details))
-            return exit_codes.AVOCADO_JOB_FAIL
-
+            rc = exit_codes.AVOCADO_JOB_FAIL
         except Exception, details:
             self.status = "ERROR"
             exc_type, exc_value, exc_traceback = sys.exc_info()
@@ -538,7 +537,10 @@ class Job(object):
                                                  'your bug report'))
             self.view.notify(event='error', msg=('Report bugs visiting %s' %
                                                  _NEW_ISSUE_LINK))
-            return exit_codes.AVOCADO_FAIL
+            rc = exit_codes.AVOCADO_FAIL
+        finally:
+            data_dir.clean_tmp_files()
+        return rc
 
 
 class TestProgram(object):

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -40,6 +40,7 @@ from ..utils import genio
 from ..utils import path as utils_path
 from ..utils import process
 from ..utils import stacktrace
+from ..utils import data_structures
 
 
 INNER_RUNNER = None
@@ -91,8 +92,6 @@ class Test(unittest.TestCase):
 
         self.job = job
 
-        basename = os.path.basename(self.name)
-
         self.filename = inspect.getfile(self.__class__).rstrip('co')
         self.basedir = os.path.dirname(self.filename)
         self.datadir = self.filename + '.data'
@@ -101,10 +100,6 @@ class Test(unittest.TestCase):
                                                  'stdout.expected')
         self.expected_stderr_file = os.path.join(self.datadir,
                                                  'stderr.expected')
-        tmpdir = data_dir.get_tmp_dir()
-        assert os.path.isdir(tmpdir)
-        self.workdir = utils_path.init_dir(tmpdir, basename.replace(':', '_'))
-        self.srcdir = utils_path.init_dir(self.workdir, 'src')
         if base_logdir is None:
             base_logdir = data_dir.create_job_logs_dir()
         base_logdir = os.path.join(base_logdir, 'test-results')
@@ -171,6 +166,18 @@ class Test(unittest.TestCase):
 
         self.time_elapsed = None
         unittest.TestCase.__init__(self, methodName=methodName)
+
+    @data_structures.LazyProperty
+    def workdir(self):
+        tmp_dir = data_dir.get_tmp_dir()
+        assert os.path.isdir(tmp_dir)
+        basename = os.path.basename(self.name)
+        return utils_path.init_dir(tmp_dir, basename.replace(':', '_'))
+
+    @data_structures.LazyProperty
+    def srcdir(self):
+        assert os.path.isdir(self.workdir)
+        return utils_path.init_dir(self.workdir, 'src')
 
     def __str__(self):
         return str(self.name)

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -93,8 +93,6 @@ class Test(unittest.TestCase):
 
         basename = os.path.basename(self.name)
 
-        tmpdir = data_dir.get_tmp_dir()
-
         self.filename = inspect.getfile(self.__class__).rstrip('co')
         self.basedir = os.path.dirname(self.filename)
         self.datadir = self.filename + '.data'
@@ -103,7 +101,8 @@ class Test(unittest.TestCase):
                                                  'stdout.expected')
         self.expected_stderr_file = os.path.join(self.datadir,
                                                  'stderr.expected')
-
+        tmpdir = data_dir.get_tmp_dir()
+        assert os.path.isdir(tmpdir)
         self.workdir = utils_path.init_dir(tmpdir, basename.replace(':', '_'))
         self.srcdir = utils_path.init_dir(self.workdir, 'src')
         if base_logdir is None:

--- a/avocado/utils/data_structures.py
+++ b/avocado/utils/data_structures.py
@@ -36,3 +36,27 @@ class Borg:
 
     def __init__(self):
         self.__dict__ = self.__shared_state
+
+
+class LazyProperty(object):
+
+    """
+    Lazily instantiated property.
+
+    Use this decorator when you want to set a property that will only be
+    evaluated the first time it's accessed. Inspired by the discussion in
+    the Stack Overflow thread below:
+
+    :see: http://stackoverflow.com/questions/15226721/
+    """
+
+    def __init__(self, f_get):
+        self.f_get = f_get
+        self.func_name = f_get.__name__
+
+    def __get__(self, obj, cls):
+        if obj is None:
+            return None
+        value = self.f_get(obj)
+        setattr(obj, self.func_name, value)
+        return value

--- a/avocado/utils/iso9660.py
+++ b/avocado/utils/iso9660.py
@@ -231,7 +231,7 @@ class Iso9660IsoRead(BaseIso9660):
 
     def __init__(self, path):
         super(Iso9660IsoRead, self).__init__(path)
-        self.temp_dir = tempfile.mkdtemp()
+        self.temp_dir = tempfile.mkdtemp(prefix='avocado-iso9660')
 
     def read(self, path):
         temp_file = os.path.join(self.temp_dir, path)
@@ -261,7 +261,7 @@ class Iso9660Mount(BaseIso9660):
         :type path: str
         """
         super(Iso9660Mount, self).__init__(path)
-        self.mnt_dir = tempfile.mkdtemp()
+        self.mnt_dir = tempfile.mkdtemp(prefix='avocado-iso9660')
         process.run('mount -t iso9660 -v -o loop,ro %s %s' %
                     (path, self.mnt_dir))
 

--- a/avocado/utils/kernel_build.py
+++ b/avocado/utils/kernel_build.py
@@ -46,7 +46,7 @@ class KernelBuild(object):
         self.version = version
         self.config_path = config_path
         if work_dir is None:
-            work_dir = tempfile.mkdtemp()
+            work_dir = tempfile.mkdtemp(prefix='avocado-kernelbuild')
         self.work_dir = work_dir
         self.build_dir = os.path.join(self.work_dir, 'build')
         if not os.path.isdir(self.build_dir):

--- a/examples/tests/vm-cleanup.py
+++ b/examples/tests/vm-cleanup.py
@@ -57,7 +57,7 @@ class VMCleanup(Test):
                       'been given. Please edit the "vm-cleanup.yaml" file '
                       'with the appropriate parameters')
 
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado-vm-plugin')
         clean_test = os.path.join(self.tmpdir, 'clean.py')
         self.clean_test_path = script.make_script(clean_test, CLEAN_TEST)
         dirty_test = os.path.join(self.tmpdir, 'dirty.py')

--- a/selftests/check_tmp_dirs
+++ b/selftests/check_tmp_dirs
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+import os
+import sys
+
+# simple magic for using scripts within a source tree
+basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if os.path.isdir(os.path.join(basedir, 'avocado')):
+    os.environ['PATH'] += ":" + os.path.join(basedir, 'scripts')
+    os.environ['PATH'] += ":" + os.path.join(basedir, 'libexec')
+    sys.path.append(basedir)
+
+from avocado.core import data_dir
+
+
+def check_tmp_dirs():
+    dirs_to_check = ['/tmp', data_dir.BASE_TMP_DIR]
+    fail = False
+    for dir_to_check in dirs_to_check:
+        dir_list = os.listdir(dir_to_check)
+        avocado_tmp_dirs = [d for d in dir_list if d.startswith('avocado')]
+        try:
+            assert len(avocado_tmp_dirs) == 0
+            print('No temporary avocado dirs lying around in %s' %
+                  dir_to_check)
+        except AssertionError:
+            print('There are temporary avocado dirs lying around after test: %s',
+                  avocado_tmp_dirs)
+            fail = True
+    if fail:
+        sys.exit(1)
+    else:
+        sys.exit(0)
+
+
+if __name__ == '__main__':
+    check_tmp_dirs()

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -59,7 +59,7 @@ class HelloWorld(Plugin):
 class RunnerOperationTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_runner_op')
 
     def verifyAvocadoTempDirs(self):
         dir_list = os.listdir(data_dir.BASE_TMP_DIR)
@@ -297,7 +297,7 @@ class RunnerOperationTest(unittest.TestCase):
 class RunnerHumanOutputTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_runner_human')
 
     def test_output_pass(self):
         os.chdir(basedir)
@@ -339,11 +339,14 @@ class RunnerHumanOutputTest(unittest.TestCase):
                          (expected_rc, result))
         self.assertIn('skiponsetup.py:SkipOnSetupTest.test_wont_be_executed:  SKIP', result.stdout)
 
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
 
 class RunnerSimpleTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_runner_simple')
         self.pass_script = script.TemporaryScript(
             'avocado_pass.sh',
             PASS_SCRIPT_CONTENTS,
@@ -435,7 +438,7 @@ class RunnerSimpleTest(unittest.TestCase):
 class InnerRunnerTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_inner_runner')
         self.pass_script = script.TemporaryScript(
             'pass',
             PASS_SHELL_CONTENTS,
@@ -490,7 +493,7 @@ class ExternalPluginsTest(unittest.TestCase):
 
     def setUp(self):
         self.base_sourcedir = tempfile.mkdtemp(prefix='avocado_source_plugins')
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_external_plugins')
 
     def test_void_plugin(self):
         self.void_plugin = script.make_script(
@@ -622,7 +625,7 @@ class ParseXMLError(Exception):
 class PluginsXunitTest(PluginsTest):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_plugins_xunit')
         super(PluginsXunitTest, self).setUp()
 
     def run_and_check(self, testname, e_rc, e_ntests, e_nerrors,
@@ -692,7 +695,7 @@ class ParseJSONError(Exception):
 class PluginsJSONTest(PluginsTest):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_plugins_json')
         super(PluginsJSONTest, self).setUp()
 
     def run_and_check(self, testname, e_rc, e_ntests, e_nerrors,

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -245,15 +245,14 @@ class RunnerOperationTest(unittest.TestCase):
         Tests that the `latest` link to the latest job results is created early
         """
         os.chdir(basedir)
-        cmd_line = ('./scripts/avocado run --sysinfo=off --job-results-dir %s examples/tests/sleeptest.py '
-                    '-m examples/tests/sleeptest.py.data/sleeptest.yaml' % self.tmpdir)
+        cmd_line = ('./scripts/avocado run --sysinfo=off --job-results-dir %s examples/tests/passtest.py' % self.tmpdir)
         avocado_process = process.SubProcess(cmd_line)
         avocado_process.start()
         link = os.path.join(self.tmpdir, 'latest')
         for trial in xrange(0, 50):
             time.sleep(0.1)
             if os.path.exists(link) and os.path.islink(link):
-                avocado_process.terminate()
+                avocado_process.wait()
                 break
         self.assertTrue(os.path.exists(link))
         self.assertTrue(os.path.islink(link))

--- a/selftests/functional/test_export_variables.py
+++ b/selftests/functional/test_export_variables.py
@@ -38,7 +38,7 @@ test "$AVOCADO_VERSION" = "{version}" -a \
 class EnvironmentVariablesTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_env_variables')
         self.script = script.TemporaryScript(
             'version.sh',
             SCRIPT_CONTENT,

--- a/selftests/functional/test_gdb.py
+++ b/selftests/functional/test_gdb.py
@@ -14,7 +14,7 @@ basedir = os.path.abspath(basedir)
 class GDBPluginTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_test_gdb')
 
     def test_gdb_prerun_commands(self):
         os.chdir(basedir)

--- a/selftests/functional/test_interrupt.py
+++ b/selftests/functional/test_interrupt.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
 class InterruptTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_test_interrupt')
 
     def test_badly_behaved(self):
         """

--- a/selftests/functional/test_job_timeout.py
+++ b/selftests/functional/test_job_timeout.py
@@ -52,7 +52,7 @@ class JobTimeOutTest(unittest.TestCase):
             PYTHON_CONTENT,
             'avocado_timeout_functional')
         self.py.save()
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_job_timeout')
         os.chdir(basedir)
 
     def run_and_check(self, cmd_line, e_rc, e_ntests, e_nerrors, e_nfailures,

--- a/selftests/functional/test_journal.py
+++ b/selftests/functional/test_journal.py
@@ -17,7 +17,7 @@ class JournalPluginTests(unittest.TestCase):
 
     def setUp(self):
         os.chdir(basedir)
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_journal_plugin')
         self.cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off --json - '
                          '--journal examples/tests/passtest.py' % self.tmpdir)
         self.result = process.run(self.cmd_line, ignore_status=True)

--- a/selftests/functional/test_loader.py
+++ b/selftests/functional/test_loader.py
@@ -63,7 +63,7 @@ class LoaderTestFunctional(unittest.TestCase):
 
     def setUp(self):
         os.chdir(basedir)
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_loader')
 
     def _test(self, name, content, exp_str, mode=0664):
         test_script = script.TemporaryScript(name, content,

--- a/selftests/functional/test_multiplex.py
+++ b/selftests/functional/test_multiplex.py
@@ -31,7 +31,7 @@ DEBUG_OUT = """Variant 16:    amd@examples/mux-environment.yaml, virtio@examples
 class MultiplexTests(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_multiplex')
 
     def run_and_check(self, cmd_line, expected_rc):
         os.chdir(basedir)

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -22,7 +22,7 @@ basedir = os.path.abspath(basedir)
 class OutputTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_output')
 
     def test_output_doublefree(self):
         os.chdir(basedir)
@@ -45,7 +45,7 @@ class OutputTest(unittest.TestCase):
 class OutputPluginTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_output_plugin')
 
     def check_output_files(self, debug_log):
         base_dir = os.path.dirname(debug_log)
@@ -129,9 +129,9 @@ class OutputPluginTest(unittest.TestCase):
                 pass
 
     def test_output_compatible_setup_3(self):
-        tmpfile = tempfile.mktemp()
-        tmpfile2 = tempfile.mktemp()
-        tmpdir = tempfile.mkdtemp()
+        tmpfile = tempfile.mktemp(prefix='avocado_output_compatible')
+        tmpfile2 = tempfile.mktemp(prefix='avocado_output_compatible')
+        tmpdir = tempfile.mkdtemp(prefix='avocado_output_compatible')
         tmpfile3 = tempfile.mktemp(dir=tmpdir)
         os.chdir(basedir)
         cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off --xunit %s --json %s --html %s passtest' %

--- a/selftests/functional/test_output_check.py
+++ b/selftests/functional/test_output_check.py
@@ -24,7 +24,7 @@ echo "Hello, avocado!"
 class RunnerSimpleTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_runner_simple')
         self.output_script = script.TemporaryScript(
             'output_check.sh',
             OUTPUT_SCRIPT_CONTENTS,

--- a/selftests/functional/test_sysinfo.py
+++ b/selftests/functional/test_sysinfo.py
@@ -18,7 +18,7 @@ basedir = os.path.abspath(basedir)
 class SysInfoTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_sysinfo')
 
     def test_sysinfo_enabled(self):
         os.chdir(basedir)

--- a/selftests/functional/test_wrapper.py
+++ b/selftests/functional/test_wrapper.py
@@ -25,7 +25,7 @@ exec -- $@
 class WrapperTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_wrapper')
         self.tmpfile = tempfile.mktemp()
         self.script = script.TemporaryScript(
             'success.sh',

--- a/selftests/unit/test_jsonresult.py
+++ b/selftests/unit/test_jsonresult.py
@@ -42,7 +42,7 @@ class JSONResultTest(unittest.TestCase):
                 pass
 
         self.tmpfile = tempfile.mkstemp()
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_json_result')
         args = argparse.Namespace(json_output=self.tmpfile[1])
         stream = _Stream()
         stream.logfile = 'debug.log'

--- a/selftests/unit/test_remote.py
+++ b/selftests/unit/test_remote.py
@@ -87,7 +87,7 @@ _=/usr/bin/env''', exit_status=0)
         Results = flexmock(remote=Remote, urls=['sleeptest'],
                            stream=stream, timeout=None,
                            args=flexmock(show_job_log=False,
-                           multiplex_files=['foo.yaml', 'bar/baz.yaml']))
+                                         multiplex_files=['foo.yaml', 'bar/baz.yaml']))
         Results.should_receive('setup').once().ordered()
         Results.should_receive('copy_files').once().ordered()
         Results.should_receive('start_tests').once().ordered()

--- a/selftests/unit/test_test.py
+++ b/selftests/unit/test_test.py
@@ -8,6 +8,7 @@ if sys.version_info[:2] == (2, 6):
 else:
     import unittest
 
+from avocado.core import data_dir
 from avocado.core import test
 from avocado.utils import script
 
@@ -70,6 +71,9 @@ class TestClassTest(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.base_logdir)
 
+    def __del__(self):
+        data_dir.clean_tmp_files()
+
 
 class SimpleTestClassTest(unittest.TestCase):
 
@@ -107,6 +111,9 @@ class SimpleTestClassTest(unittest.TestCase):
         self.pass_script.remove()
         self.fail_script.remove()
         shutil.rmtree(self.tmpdir)
+
+    def __del__(self):
+        data_dir.clean_tmp_files()
 
 if __name__ == '__main__':
     unittest.main()

--- a/selftests/unit/test_test.py
+++ b/selftests/unit/test_test.py
@@ -78,7 +78,7 @@ class TestClassTest(unittest.TestCase):
 class SimpleTestClassTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_simple_test_class')
         self.pass_script = script.TemporaryScript(
             'avocado_pass.sh',
             PASS_SCRIPT_CONTENTS,

--- a/selftests/unit/test_xunit.py
+++ b/selftests/unit/test_xunit.py
@@ -46,7 +46,7 @@ class xUnitSucceedTest(unittest.TestCase):
                 pass
 
         self.tmpfile = tempfile.mkstemp()
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_xunit_succeed')
         args = argparse.Namespace()
         args.xunit_output = self.tmpfile[1]
         self.test_result = xunit.xUnitTestResult(stream=_Stream(), args=args)


### PR DESCRIPTION
Clean and fix a number of issues with temporary data management in avocado. In particular, unittests are better now and we have more confidence that they are cleaning up after themselves properly.

Also, this fixes the Trello card: https://trello.com/c/fsPcqePU/475-bug-avocado-help-leaves-a-temporary-dir-in-var-tmp

Of course, there are more things to take care of, but now in the plugins, such as `avocado-vt`.