### PR TITLE
Fix HTML report links using multiplexed remote plugin

### DIFF
--- a/avocado/core/plugins/htmlresult.py
+++ b/avocado/core/plugins/htmlresult.py
@@ -21,6 +21,7 @@ import sys
 import time
 import subprocess
 import pystache
+import urllib
 
 from . import plugin
 from .. import exit_codes
@@ -207,8 +208,8 @@ class HTMLTestResult(TestResult):
              'status': state['status'],
              'fail_reason': state['fail_reason'],
              'whiteboard': state['whiteboard'],
-             'logdir': state['logdir'],
-             'logfile': state['logfile']
+             'logdir': urllib.quote(state['logdir']),
+             'logfile': urllib.quote(state['logfile'])
              }
         self.json['tests'].append(t)
 

--- a/avocado/core/remote/runner.py
+++ b/avocado/core/remote/runner.py
@@ -114,7 +114,7 @@ class RemoteTestRunner(TestRunner):
         for t_dict in json_result['tests']:
             logdir = os.path.dirname(self.result.stream.debuglog)
             logdir = os.path.join(logdir, 'test-results')
-            relative_path = t_dict['url'].lstrip('/')
+            relative_path = t_dict['test'].lstrip('/')
             logdir = os.path.join(logdir, relative_path)
             t_dict['logdir'] = logdir
             t_dict['logfile'] = os.path.join(logdir, 'debug.log')

--- a/selftests/unit/test_remote.py
+++ b/selftests/unit/test_remote.py
@@ -98,8 +98,8 @@ _=/usr/bin/env''', exit_status=0)
                 'tagged_name': u'sleeptest.1', 'time_elapsed': 1.23,
                 'fail_class': 'Not supported yet', 'job_unique_id': '',
                 'fail_reason': 'None',
-                'logdir': '/local/path/test-results/sleeptest',
-                'logfile': '/local/path/test-results/sleeptest/debug.log'}
+                'logdir': '/local/path/test-results/sleeptest.1',
+                'logfile': '/local/path/test-results/sleeptest.1/debug.log'}
         Results.should_receive('start_test').once().with_args(args).ordered()
         Results.should_receive('check_test').once().with_args(args).ordered()
         (Remote.should_receive('receive_files')


### PR DESCRIPTION
This fixes an issue I've noticed after testing @ldoktor's latest PR that gave avocado the ability to run multiplexed tests while using remote/vm plugins. It turns out the problem was slightly different than what I thought at first, but the issue is fixed here anyway.