### PR TITLE
Remote/VM timeouts: introduce timeout command line options

### DIFF
--- a/avocado/core/plugins/remote.py
+++ b/avocado/core/plugins/remote.py
@@ -62,6 +62,12 @@ class RunRemote(plugin.Plugin):
                                         action='store_true',
                                         help="Don't copy tests and use the "
                                         "exact uri on guest machine.")
+        self.remote_parser.add_argument('--remote-timeout', metavar='SECONDS',
+                                        help=("Amount of time (in seconds) to "
+                                              "wait for a successful connection"
+                                              " to the remote machine. Defaults"
+                                              " to %(default)s seconds."),
+                                        default=60, type=int)
         self.configured = True
 
     @staticmethod

--- a/avocado/core/plugins/vm.py
+++ b/avocado/core/plugins/vm.py
@@ -61,6 +61,12 @@ class RunVM(plugin.Plugin):
         self.vm_parser.add_argument('--vm-no-copy', action='store_true',
                                     help="Don't copy tests and use the "
                                     "exact uri on VM machine.")
+        self.vm_parser.add_argument('--vm-timeout', metavar='SECONDS',
+                                    help=("Amount of time (in seconds) to "
+                                          "wait for a successful connection"
+                                          " to the virtual machine. Defaults"
+                                          " to %(default)s seconds."),
+                                    default=120, type=int)
         self.configured = True
 
     @staticmethod

--- a/avocado/core/remote/result.py
+++ b/avocado/core/remote/result.py
@@ -79,14 +79,16 @@ class RemoteTestResult(HumanTestResult):
     def setup(self):
         """ Setup remote environment and copy test directories """
         self.stream.notify(event='message',
-                           msg=("LOGIN      : %s@%s:%d"
+                           msg=("LOGIN      : %s@%s:%d (TIMEOUT: %s seconds)"
                                 % (self.args.remote_username,
                                    self.args.remote_hostname,
-                                   self.args.remote_port)))
+                                   self.args.remote_port,
+                                   self.args.remote_timeout)))
         self.remote = remoter.Remote(self.args.remote_hostname,
                                      self.args.remote_username,
                                      self.args.remote_password,
-                                     self.args.remote_port)
+                                     self.args.remote_port,
+                                     self.args.remote_timeout)
 
     def tear_down(self):
         """ Cleanup after test execution """
@@ -142,6 +144,7 @@ class VMTestResult(RemoteTestResult):
             self.args.remote_username = self.args.vm_username
             self.args.remote_password = self.args.vm_password
             self.args.remote_no_copy = self.args.vm_no_copy
+            self.args.remote_timeout = self.args.vm_timeout
             super(VMTestResult, self).setup()
         except Exception:
             self.tear_down()

--- a/avocado/core/remoter.py
+++ b/avocado/core/remoter.py
@@ -43,7 +43,7 @@ class Remote(object):
     """
 
     def __init__(self, hostname, username=None, password=None,
-                 port=22, timeout=60, attempts=3, quiet=False):
+                 port=22, timeout=60, attempts=10, quiet=False):
         """
         Creates an instance of :class:`Remote`.
 
@@ -51,7 +51,7 @@ class Remote(object):
         :param username: the username. Default: autodetect.
         :param password: the password. Default: try to use public key.
         :param timeout: remote command timeout, in seconds. Default: 60.
-        :param attempts: number of attempts to connect. Default: 3.
+        :param attempts: number of attempts to connect. Default: 10.
         :param quiet: performs quiet operations. Default: True.
         """
         self.hostname = hostname
@@ -66,7 +66,7 @@ class Remote(object):
                                 user=username,
                                 password=password,
                                 port=port,
-                                connection_timeout=timeout,
+                                timeout=timeout / attempts,
                                 connection_attempts=attempts,
                                 linewise=True)
 

--- a/selftests/unit/test_remote.py
+++ b/selftests/unit/test_remote.py
@@ -87,7 +87,7 @@ _=/usr/bin/env''', exit_status=0)
         Results = flexmock(remote=Remote, urls=['sleeptest'],
                            stream=stream, timeout=None,
                            args=flexmock(show_job_log=False,
-                           multiplex_files=['foo.yaml', 'bar/baz.yaml']))
+                                         multiplex_files=['foo.yaml', 'bar/baz.yaml']))
         Results.should_receive('setup').once().ordered()
         Results.should_receive('copy_files').once().ordered()
         Results.should_receive('start_tests').once().ordered()
@@ -136,7 +136,7 @@ class RemoteTestResultTest(unittest.TestCase):
         Stream.should_receive('notify').once().ordered()
         remote_remote = flexmock(remoter)
         (remote_remote.should_receive('Remote')
-         .with_args('hostname', 'username', 'password', 22)
+         .with_args('hostname', 'username', 'password', 22, 60)
          .once().ordered()
          .and_return(Remote))
         Args = flexmock(test_result_total=1,
@@ -146,7 +146,8 @@ class RemoteTestResultTest(unittest.TestCase):
                         remote_hostname='hostname',
                         remote_port=22,
                         remote_password='password',
-                        remote_no_copy=False)
+                        remote_no_copy=False,
+                        remote_timeout=60)
         self.remote = remote.RemoteTestResult(Stream, Args)
 
     def tearDown(self):

--- a/selftests/unit/test_vm.py
+++ b/selftests/unit/test_vm.py
@@ -48,6 +48,7 @@ class VMTestResultTest(unittest.TestCase):
                         vm_password='password',
                         vm_cleanup=True,
                         vm_no_copy=False,
+                        vm_timeout=120,
                         vm_hypervisor_uri='my_hypervisor_uri')
         self.remote = VMTestResult(Stream, Args)
         # vm.RemoteTestResult.tear_down()


### PR DESCRIPTION
And fix/improve the current implementation by:

 - Properly passing the fabric environment parameter (named "timeout",
   and not "connection_timeout").
 - Set different timeouts for Remote (60 seconds) and VM (120
   seconds). The reasoning is that for VM it may be needed to start
   the VM itself.
 - The timeout passed to fabric is now the timeout the user gives,
   divided by the number of attempts.
 - Change the default attempts from 3 to 10 so that the overall
   timeout is broken in smaller pieces and user hopefully waits less
   time for a successful outcome.

This was tested using an EL7 VM using TCG (non-kvm).

Signed-off-by: Cleber Rosa <crosa@redhat.com>