### PR TITLE
avocado/core/data_dir.py: do not create temp dir on Borg instantiation

### DIFF
--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -226,10 +226,10 @@ class _TmpDirTracker(Borg):
 
     def __init__(self):
         Borg.__init__(self)
-        if not hasattr(self, 'tmp_dir'):
-            self.tmp_dir = tempfile.mkdtemp(prefix='avocado_', dir=BASE_TMP_DIR)
 
     def get(self):
+        if not hasattr(self, 'tmp_dir'):
+            self.tmp_dir = tempfile.mkdtemp(prefix='avocado_', dir=BASE_TMP_DIR)
         return self.tmp_dir
 
 _tmp_tracker = _TmpDirTracker()


### PR DESCRIPTION
We only want a temporary directory to be created when
`datadir.get_tmp_dir()` is called, and not when the Borg class is
instantiated.

This fixes the issue when temporary directories are created regardless
if a proper job is created or not.

Signed-off-by: Cleber Rosa <crosa@redhat.com>