### PR TITLE
[V2] TMP dir management updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,3 +28,4 @@ script:
     - ./selftests/cyclical_deps avocado
     - ./selftests/modules_boundaries
     - ./selftests/run
+    - ./selftests/check_tmp_dirs

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,10 @@ install-requirements-selftests:
 	grep -v '^#' requirements-selftests.txt | xargs -n 1 pip install
 
 check: clean check_cyclical modules_boundaries
+	rm -rf /var/tmp/avocado*
+	rm -rf /tmp/avocado*
 	selftests/checkall
+	selftests/check_tmp_dirs
 
 check_cyclical:
 	selftests/cyclical_deps avocado

--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -232,6 +232,12 @@ class _TmpDirTracker(Borg):
             self.tmp_dir = tempfile.mkdtemp(prefix='avocado_', dir=BASE_TMP_DIR)
         return self.tmp_dir
 
+    def __del__(self):
+        tmp_dir = getattr(self, 'tmp_dir', None)
+        if tmp_dir is not None:
+            if os.path.isdir(tmp_dir):
+                shutil.rmtree(tmp_dir)
+
 _tmp_tracker = _TmpDirTracker()
 
 

--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -245,7 +245,14 @@ def get_tmp_dir():
         * Copies of a test suite source code
         * Compiled test suite source code
     """
-    return _tmp_tracker.get()
+    tmp_dir = _tmp_tracker.get()
+    # This assert is a security mechanism for avoiding re-creating
+    # the temporary directory, since that's a security breach.
+    msg = ('Temporary dir %s no longer exists. This likely means the '
+           'directory was incorrectly deleted before the end of the job' %
+           tmp_dir)
+    assert os.path.isdir(tmp_dir), msg
+    return tmp_dir
 
 
 def clean_tmp_files():
@@ -255,7 +262,10 @@ def clean_tmp_files():
     This is a useful function for avocado entry points looking to clean after
     tests/jobs are done. If OSError is raised, silently ignore the error.
     """
-    tmp_dir = get_tmp_dir()
+    try:
+        tmp_dir = get_tmp_dir()
+    except AssertionError:
+        return
     try:
         shutil.rmtree(tmp_dir, ignore_errors=True)
     except OSError:

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -478,9 +478,6 @@ class Job(object):
         if getattr(self.args, 'archive', False):
             filename = self.logdir + '.zip'
             archive.create(filename, self.logdir)
-        if not settings.get_value('runner.behavior', 'keep_tmp_files',
-                                  key_type=bool, default=False):
-            data_dir.clean_tmp_files()
         _TEST_LOGGER.info('Test results available in %s', self.logdir)
 
         tests_status = not bool(failures)
@@ -539,6 +536,10 @@ class Job(object):
             self.view.notify(event='error', msg=('Report bugs visiting %s' %
                                                  _NEW_ISSUE_LINK))
             return exit_codes.AVOCADO_FAIL
+        finally:
+            if not settings.get_value('runner.behavior', 'keep_tmp_files',
+                                      key_type=bool, default=False):
+                data_dir.clean_tmp_files()
 
 
 class TestProgram(object):

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -127,7 +127,7 @@ class Job(object):
                 self.logdir = data_dir.create_job_logs_dir(logdir=logdir,
                                                            unique_id=self.unique_id)
             else:
-                self.logdir = tempfile.mkdtemp(prefix='avocado-')
+                self.logdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
         else:
             if logdir is None:
                 self.logdir = data_dir.create_job_logs_dir(unique_id=self.unique_id)

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -40,6 +40,7 @@ from ..utils import genio
 from ..utils import path as utils_path
 from ..utils import process
 from ..utils import stacktrace
+from ..utils import data_structures
 
 
 INNER_RUNNER = None
@@ -91,10 +92,6 @@ class Test(unittest.TestCase):
 
         self.job = job
 
-        basename = os.path.basename(self.name)
-
-        tmpdir = data_dir.get_tmp_dir()
-
         self.filename = inspect.getfile(self.__class__).rstrip('co')
         self.basedir = os.path.dirname(self.filename)
         self.datadir = self.filename + '.data'
@@ -104,8 +101,6 @@ class Test(unittest.TestCase):
         self.expected_stderr_file = os.path.join(self.datadir,
                                                  'stderr.expected')
 
-        self.workdir = utils_path.init_dir(tmpdir, basename.replace(':', '_'))
-        self.srcdir = utils_path.init_dir(self.workdir, 'src')
         if base_logdir is None:
             base_logdir = data_dir.create_job_logs_dir()
         base_logdir = os.path.join(base_logdir, 'test-results')
@@ -172,6 +167,15 @@ class Test(unittest.TestCase):
 
         self.time_elapsed = None
         unittest.TestCase.__init__(self, methodName=methodName)
+
+    @data_structures.LazyProperty
+    def workdir(self):
+        basename = os.path.basename(self.name)
+        return utils_path.init_dir(data_dir.get_tmp_dir(), basename.replace(':', '_'))
+
+    @data_structures.LazyProperty
+    def srcdir(self):
+        return utils_path.init_dir(self.workdir, 'src')
 
     def __str__(self):
         return str(self.name)

--- a/avocado/utils/data_factory.py
+++ b/avocado/utils/data_factory.py
@@ -69,7 +69,7 @@ def make_dir_and_populate(basedir='/tmp'):
     :rtype: str
     """
     try:
-        path = tempfile.mkdtemp(prefix='avocado-make-dir-and-populate',
+        path = tempfile.mkdtemp(prefix='avocado_' + __name__,
                                 dir=basedir)
         n_files = _RAND_POOL.randint(100, 150)
         for _ in xrange(n_files):

--- a/avocado/utils/data_structures.py
+++ b/avocado/utils/data_structures.py
@@ -36,3 +36,27 @@ class Borg:
 
     def __init__(self):
         self.__dict__ = self.__shared_state
+
+
+class LazyProperty(object):
+
+    """
+    Lazily instantiated property.
+
+    Use this decorator when you want to set a property that will only be
+    evaluated the first time it's accessed. Inspired by the discussion in
+    the Stack Overflow thread below:
+
+    :see: http://stackoverflow.com/questions/15226721/
+    """
+
+    def __init__(self, f_get):
+        self.f_get = f_get
+        self.func_name = f_get.__name__
+
+    def __get__(self, obj, cls):
+        if obj is None:
+            return None
+        value = self.f_get(obj)
+        setattr(obj, self.func_name, value)
+        return value

--- a/avocado/utils/iso9660.py
+++ b/avocado/utils/iso9660.py
@@ -231,7 +231,7 @@ class Iso9660IsoRead(BaseIso9660):
 
     def __init__(self, path):
         super(Iso9660IsoRead, self).__init__(path)
-        self.temp_dir = tempfile.mkdtemp()
+        self.temp_dir = tempfile.mkdtemp(prefix='avocado_' + __name__)
 
     def read(self, path):
         temp_file = os.path.join(self.temp_dir, path)
@@ -261,7 +261,7 @@ class Iso9660Mount(BaseIso9660):
         :type path: str
         """
         super(Iso9660Mount, self).__init__(path)
-        self.mnt_dir = tempfile.mkdtemp()
+        self.mnt_dir = tempfile.mkdtemp(prefix='avocado_' + __name__)
         process.run('mount -t iso9660 -v -o loop,ro %s %s' %
                     (path, self.mnt_dir))
 

--- a/avocado/utils/kernel_build.py
+++ b/avocado/utils/kernel_build.py
@@ -46,7 +46,7 @@ class KernelBuild(object):
         self.version = version
         self.config_path = config_path
         if work_dir is None:
-            work_dir = tempfile.mkdtemp()
+            work_dir = tempfile.mkdtemp(prefix='avocado_' + __name__)
         self.work_dir = work_dir
         self.build_dir = os.path.join(self.work_dir, 'build')
         if not os.path.isdir(self.build_dir):

--- a/examples/tests/vm-cleanup.py
+++ b/examples/tests/vm-cleanup.py
@@ -57,7 +57,7 @@ class VMCleanup(Test):
                       'been given. Please edit the "vm-cleanup.yaml" file '
                       'with the appropriate parameters')
 
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
         clean_test = os.path.join(self.tmpdir, 'clean.py')
         self.clean_test_path = script.make_script(clean_test, CLEAN_TEST)
         dirty_test = os.path.join(self.tmpdir, 'dirty.py')

--- a/selftests/check_tmp_dirs
+++ b/selftests/check_tmp_dirs
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+import os
+import sys
+
+# simple magic for using scripts within a source tree
+basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if os.path.isdir(os.path.join(basedir, 'avocado')):
+    os.environ['PATH'] += ":" + os.path.join(basedir, 'scripts')
+    os.environ['PATH'] += ":" + os.path.join(basedir, 'libexec')
+    sys.path.append(basedir)
+
+from avocado.core import data_dir
+
+
+def check_tmp_dirs():
+    dirs_to_check = ['/tmp', data_dir.BASE_TMP_DIR]
+    fail = False
+    for dir_to_check in dirs_to_check:
+        dir_list = os.listdir(dir_to_check)
+        avocado_tmp_dirs = [d for d in dir_list if d.startswith('avocado')]
+        try:
+            assert len(avocado_tmp_dirs) == 0
+            print('No temporary avocado dirs lying around in %s' %
+                  dir_to_check)
+        except AssertionError:
+            print('There are temporary avocado dirs lying around after test: %s',
+                  avocado_tmp_dirs)
+            fail = True
+    if fail:
+        sys.exit(1)
+    else:
+        sys.exit(0)
+
+
+if __name__ == '__main__':
+    check_tmp_dirs()

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -58,7 +58,7 @@ class HelloWorld(Plugin):
 class RunnerOperationTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
 
     def test_runner_all_ok(self):
         os.chdir(basedir)
@@ -264,7 +264,7 @@ class RunnerOperationTest(unittest.TestCase):
 class RunnerHumanOutputTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
 
     def test_output_pass(self):
         os.chdir(basedir)
@@ -306,11 +306,14 @@ class RunnerHumanOutputTest(unittest.TestCase):
                          (expected_rc, result))
         self.assertIn('skiponsetup.py:SkipOnSetupTest.test_wont_be_executed:  SKIP', result.stdout)
 
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
 
 class RunnerSimpleTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
         self.pass_script = script.TemporaryScript(
             'avocado_pass.sh',
             PASS_SCRIPT_CONTENTS,
@@ -402,7 +405,7 @@ class RunnerSimpleTest(unittest.TestCase):
 class InnerRunnerTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
         self.pass_script = script.TemporaryScript(
             'pass',
             PASS_SHELL_CONTENTS,
@@ -456,8 +459,8 @@ class InnerRunnerTest(unittest.TestCase):
 class ExternalPluginsTest(unittest.TestCase):
 
     def setUp(self):
-        self.base_sourcedir = tempfile.mkdtemp(prefix='avocado_source_plugins')
-        self.tmpdir = tempfile.mkdtemp()
+        self.base_sourcedir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
 
     def test_void_plugin(self):
         self.void_plugin = script.make_script(
@@ -498,7 +501,7 @@ class ExternalPluginsTest(unittest.TestCase):
 class AbsPluginsTest(object):
 
     def setUp(self):
-        self.base_outputdir = tempfile.mkdtemp(prefix='avocado_plugins')
+        self.base_outputdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
 
     def tearDown(self):
         shutil.rmtree(self.base_outputdir)
@@ -592,7 +595,7 @@ class ParseXMLError(Exception):
 class PluginsXunitTest(AbsPluginsTest, unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
         super(PluginsXunitTest, self).setUp()
 
     def run_and_check(self, testname, e_rc, e_ntests, e_nerrors,
@@ -662,7 +665,7 @@ class ParseJSONError(Exception):
 class PluginsJSONTest(AbsPluginsTest, unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
         super(PluginsJSONTest, self).setUp()
 
     def run_and_check(self, testname, e_rc, e_ntests, e_nerrors,

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -245,15 +245,14 @@ class RunnerOperationTest(unittest.TestCase):
         Tests that the `latest` link to the latest job results is created early
         """
         os.chdir(basedir)
-        cmd_line = ('./scripts/avocado run --sysinfo=off --job-results-dir %s examples/tests/sleeptest.py '
-                    '-m examples/tests/sleeptest.py.data/sleeptest.yaml' % self.tmpdir)
+        cmd_line = ('./scripts/avocado run --sysinfo=off --job-results-dir %s examples/tests/passtest.py' % self.tmpdir)
         avocado_process = process.SubProcess(cmd_line)
         avocado_process.start()
         link = os.path.join(self.tmpdir, 'latest')
         for trial in xrange(0, 50):
             time.sleep(0.1)
             if os.path.exists(link) and os.path.islink(link):
-                avocado_process.terminate()
+                avocado_process.wait()
                 break
         self.assertTrue(os.path.exists(link))
         self.assertTrue(os.path.islink(link))

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -497,6 +497,7 @@ class ExternalPluginsTest(unittest.TestCase):
 
 
 class AbsPluginsTest(object):
+
     def setUp(self):
         self.base_outputdir = tempfile.mkdtemp(prefix='avocado_plugins')
 

--- a/selftests/functional/test_export_variables.py
+++ b/selftests/functional/test_export_variables.py
@@ -38,7 +38,7 @@ test "$AVOCADO_VERSION" = "{version}" -a \
 class EnvironmentVariablesTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
         self.script = script.TemporaryScript(
             'version.sh',
             SCRIPT_CONTENT,

--- a/selftests/functional/test_gdb.py
+++ b/selftests/functional/test_gdb.py
@@ -14,7 +14,7 @@ basedir = os.path.abspath(basedir)
 class GDBPluginTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
 
     def test_gdb_prerun_commands(self):
         os.chdir(basedir)

--- a/selftests/functional/test_interrupt.py
+++ b/selftests/functional/test_interrupt.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
 class InterruptTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
 
     def test_badly_behaved(self):
         """

--- a/selftests/functional/test_job_timeout.py
+++ b/selftests/functional/test_job_timeout.py
@@ -52,7 +52,7 @@ class JobTimeOutTest(unittest.TestCase):
             PYTHON_CONTENT,
             'avocado_timeout_functional')
         self.py.save()
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
         os.chdir(basedir)
 
     def run_and_check(self, cmd_line, e_rc, e_ntests, e_nerrors, e_nfailures,

--- a/selftests/functional/test_journal.py
+++ b/selftests/functional/test_journal.py
@@ -17,7 +17,7 @@ class JournalPluginTests(unittest.TestCase):
 
     def setUp(self):
         os.chdir(basedir)
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
         self.cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off --json - '
                          '--journal examples/tests/passtest.py' % self.tmpdir)
         self.result = process.run(self.cmd_line, ignore_status=True)

--- a/selftests/functional/test_loader.py
+++ b/selftests/functional/test_loader.py
@@ -63,7 +63,7 @@ class LoaderTestFunctional(unittest.TestCase):
 
     def setUp(self):
         os.chdir(basedir)
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
 
     def _test(self, name, content, exp_str, mode=0664):
         test_script = script.TemporaryScript(name, content,

--- a/selftests/functional/test_multiplex.py
+++ b/selftests/functional/test_multiplex.py
@@ -31,7 +31,7 @@ DEBUG_OUT = """Variant 16:    amd@examples/mux-environment.yaml, virtio@examples
 class MultiplexTests(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
 
     def run_and_check(self, cmd_line, expected_rc):
         os.chdir(basedir)

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -22,7 +22,7 @@ basedir = os.path.abspath(basedir)
 class OutputTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
 
     def test_output_doublefree(self):
         os.chdir(basedir)
@@ -45,7 +45,7 @@ class OutputTest(unittest.TestCase):
 class OutputPluginTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
 
     def check_output_files(self, debug_log):
         base_dir = os.path.dirname(debug_log)
@@ -129,9 +129,9 @@ class OutputPluginTest(unittest.TestCase):
                 pass
 
     def test_output_compatible_setup_3(self):
-        tmpfile = tempfile.mktemp()
-        tmpfile2 = tempfile.mktemp()
-        tmpdir = tempfile.mkdtemp()
+        tmpfile = tempfile.mktemp(prefix='avocado_' + __name__)
+        tmpfile2 = tempfile.mktemp(prefix='avocado_' + __name__)
+        tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
         tmpfile3 = tempfile.mktemp(dir=tmpdir)
         os.chdir(basedir)
         cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off --xunit %s --json %s --html %s passtest' %

--- a/selftests/functional/test_output_check.py
+++ b/selftests/functional/test_output_check.py
@@ -24,7 +24,7 @@ echo "Hello, avocado!"
 class RunnerSimpleTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
         self.output_script = script.TemporaryScript(
             'output_check.sh',
             OUTPUT_SCRIPT_CONTENTS,

--- a/selftests/functional/test_sysinfo.py
+++ b/selftests/functional/test_sysinfo.py
@@ -18,7 +18,7 @@ basedir = os.path.abspath(basedir)
 class SysInfoTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
 
     def test_sysinfo_enabled(self):
         os.chdir(basedir)

--- a/selftests/functional/test_utils.py
+++ b/selftests/functional/test_utils.py
@@ -118,7 +118,7 @@ if __name__ == '__main__':
 class ProcessTest(unittest.TestCase):
 
     def setUp(self):
-        self.base_logdir = tempfile.mkdtemp(prefix='avocado_process_functional')
+        self.base_logdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
         self.fake_vmstat = os.path.join(self.base_logdir, 'vmstat')
         with open(self.fake_vmstat, 'w') as fake_vmstat_obj:
             fake_vmstat_obj.write(FAKE_VMSTAT_CONTENTS)

--- a/selftests/functional/test_wrapper.py
+++ b/selftests/functional/test_wrapper.py
@@ -25,7 +25,7 @@ exec -- $@
 class WrapperTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
         self.tmpfile = tempfile.mktemp()
         self.script = script.TemporaryScript(
             'success.sh',

--- a/selftests/unit/test_archive.py
+++ b/selftests/unit/test_archive.py
@@ -13,7 +13,7 @@ from avocado.utils import data_factory
 class ArchiveTest(unittest.TestCase):
 
     def setUp(self):
-        self.basedir = tempfile.mkdtemp(prefix='archive_datadir_unittest')
+        self.basedir = tempfile.mkdtemp(prefix='avocado_' + __name__)
         self.compressdir = tempfile.mkdtemp(dir=self.basedir)
         self.decompressdir = tempfile.mkdtemp(dir=self.basedir)
         self.sys_random = random.SystemRandom()

--- a/selftests/unit/test_datadir.py
+++ b/selftests/unit/test_datadir.py
@@ -20,7 +20,7 @@ def _get_bogus_settings(args):
 class DataDirTest(unittest.TestCase):
 
     def setUp(self):
-        tbase = tempfile.mkdtemp(prefix='avocado_datadir_unittest')
+        tbase = tempfile.mkdtemp(prefix='avocado_' + __name__)
         tdir = os.path.join(tbase, 'tests')
         tdata = os.path.join(tbase, 'data')
         tlogs = os.path.join(tbase, 'logs')

--- a/selftests/unit/test_jsonresult.py
+++ b/selftests/unit/test_jsonresult.py
@@ -42,7 +42,7 @@ class JSONResultTest(unittest.TestCase):
                 pass
 
         self.tmpfile = tempfile.mkstemp()
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
         args = argparse.Namespace(json_output=self.tmpfile[1])
         stream = _Stream()
         stream.logfile = 'debug.log'

--- a/selftests/unit/test_remote.py
+++ b/selftests/unit/test_remote.py
@@ -87,7 +87,7 @@ _=/usr/bin/env''', exit_status=0)
         Results = flexmock(remote=Remote, urls=['sleeptest'],
                            stream=stream, timeout=None,
                            args=flexmock(show_job_log=False,
-                           multiplex_files=['foo.yaml', 'bar/baz.yaml']))
+                                         multiplex_files=['foo.yaml', 'bar/baz.yaml']))
         Results.should_receive('setup').once().ordered()
         Results.should_receive('copy_files').once().ordered()
         Results.should_receive('start_tests').once().ordered()

--- a/selftests/unit/test_test.py
+++ b/selftests/unit/test_test.py
@@ -30,7 +30,7 @@ class TestClassTest(unittest.TestCase):
                 self.assertTrue(variable)
                 self.whiteboard = 'foo'
 
-        self.base_logdir = tempfile.mkdtemp(prefix='avocado_test_unittest')
+        self.base_logdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
         self.tst_instance_pass = AvocadoPass(base_logdir=self.base_logdir)
         self.tst_instance_pass.run_avocado()
         self.tst_instance_pass_new = AvocadoPass(base_logdir=self.base_logdir)
@@ -74,7 +74,7 @@ class TestClassTest(unittest.TestCase):
 class SimpleTestClassTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
         self.pass_script = script.TemporaryScript(
             'avocado_pass.sh',
             PASS_SCRIPT_CONTENTS,

--- a/selftests/unit/test_xunit.py
+++ b/selftests/unit/test_xunit.py
@@ -46,7 +46,7 @@ class xUnitSucceedTest(unittest.TestCase):
                 pass
 
         self.tmpfile = tempfile.mkstemp()
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
         args = argparse.Namespace()
         args.xunit_output = self.tmpfile[1]
         self.test_result = xunit.xUnitTestResult(stream=_Stream(), args=args)


### PR DESCRIPTION
Clean and fix a number of issues with temporary data management in avocado. In particular, unittests are better now and we have more confidence that they are cleaning up after themselves properly.

Also, this fixes the Trello card: https://trello.com/c/fsPcqePU/475-bug-avocado-help-leaves-a-temporary-dir-in-var-tmp

Of course, there are more things to take care of, but now in the plugins, such as `avocado-vt`.

Changed from V1:

* Moved asserts to `data_dir.get_tmp_dir` function
* Prefixes to `tempfile.mkdtemp` now are in the form `'avocado_' + __name__`