### PR TITLE
VM Plugin: attempt to find virtual machine IP address

### DIFF
--- a/avocado/core/plugins/vm.py
+++ b/avocado/core/plugins/vm.py
@@ -47,8 +47,10 @@ class RunVM(plugin.Plugin):
                                     help=('Specify hypervisor URI driver '
                                           'connection. Current: %s' %
                                           default_hypervisor_uri))
-        self.vm_parser.add_argument('--vm-hostname',
-                                    help='Specify VM hostname to login')
+        self.vm_parser.add_argument('--vm-hostname', default=None,
+                                    help=('Specify VM hostname to login. By '
+                                          'default it attempts to automatically'
+                                          ' find the VM IP address.'))
         self.vm_parser.add_argument('--vm-username', default=username,
                                     help='Specify the username to login on VM')
         self.vm_parser.add_argument('--vm-password',
@@ -89,7 +91,6 @@ class RunVM(plugin.Plugin):
         return True
 
     def activate(self, app_args):
-        if self._check_required_args(app_args, 'vm_domain',
-                                     ('vm_domain', 'vm_hostname')):
+        if self._check_required_args(app_args, 'vm_domain', ('vm_domain',)):
             self.vm_parser.set_defaults(remote_result=VMTestResult,
                                         test_runner=RemoteTestRunner)

--- a/avocado/core/remote/result.py
+++ b/avocado/core/remote/result.py
@@ -106,11 +106,6 @@ class VMTestResult(RemoteTestResult):
 
     def setup(self):
         # Super called after VM is found and initialized
-        if self.args.vm_domain is None:
-            e_msg = ('Please set Virtual Machine Domain with option '
-                     '--vm-domain.')
-            self.stream.notify(event='error', msg=e_msg)
-            raise exceptions.JobError(e_msg)
         if self.args.vm_hostname is None:
             e_msg = ('Please set Virtual Machine hostname with option '
                      '--vm-hostname.')

--- a/avocado/core/remote/result.py
+++ b/avocado/core/remote/result.py
@@ -106,11 +106,6 @@ class VMTestResult(RemoteTestResult):
 
     def setup(self):
         # Super called after VM is found and initialized
-        if self.args.vm_hostname is None:
-            e_msg = ('Please set Virtual Machine hostname with option '
-                     '--vm-hostname.')
-            self.stream.notify(event='error', msg=e_msg)
-            raise exceptions.JobError(e_msg)
         self.stream.notify(event='message', msg="DOMAIN     : %s"
                            % self.args.vm_domain)
         self.vm = virt.vm_connect(self.args.vm_domain,
@@ -122,6 +117,14 @@ class VMTestResult(RemoteTestResult):
             e_msg = "Could not start VM '%s'" % self.args.vm_domain
             raise exceptions.JobError(e_msg)
         assert self.vm.domain.isActive() is not False
+        # If hostname wasn't given, let's try to find out the IP address
+        if self.args.vm_hostname is None:
+            self.args.vm_hostname = self.vm.ip_address()
+            if self.args.vm_hostname is None:
+                e_msg = ("Could not find the IP address for VM '%s'. Please "
+                         "set it explicitly with --vm-hostname" %
+                         self.args.vm_domain)
+                raise exceptions.JobError(e_msg)
         if self.args.vm_cleanup is True:
             self.vm.create_snapshot()
             if self.vm.snapshot is None:

--- a/avocado/core/remote/result.py
+++ b/avocado/core/remote/result.py
@@ -110,32 +110,29 @@ class VMTestResult(RemoteTestResult):
             e_msg = ('Please set Virtual Machine Domain with option '
                      '--vm-domain.')
             self.stream.notify(event='error', msg=e_msg)
-            raise exceptions.TestSetupFail(e_msg)
+            raise exceptions.JobError(e_msg)
         if self.args.vm_hostname is None:
             e_msg = ('Please set Virtual Machine hostname with option '
                      '--vm-hostname.')
             self.stream.notify(event='error', msg=e_msg)
-            raise exceptions.TestSetupFail(e_msg)
+            raise exceptions.JobError(e_msg)
         self.stream.notify(event='message', msg="DOMAIN     : %s"
                            % self.args.vm_domain)
         self.vm = virt.vm_connect(self.args.vm_domain,
                                   self.args.vm_hypervisor_uri)
         if self.vm is None:
-            self.stream.notify(event='error',
-                               msg="Could not connect to VM '%s'"
-                               % self.args.vm_domain)
-            raise exceptions.TestSetupFail()
+            e_msg = "Could not connect to VM '%s'" % self.args.vm_domain
+            raise exceptions.JobError(e_msg)
         if self.vm.start() is False:
-            self.stream.notify(event='error', msg="Could not start VM '%s'"
-                               % self.args.vm_domain)
-            raise exceptions.TestSetupFail()
+            e_msg = "Could not start VM '%s'" % self.args.vm_domain
+            raise exceptions.JobError(e_msg)
         assert self.vm.domain.isActive() is not False
         if self.args.vm_cleanup is True:
             self.vm.create_snapshot()
             if self.vm.snapshot is None:
-                self.stream.notify(event='error', msg="Could not create "
-                                   "snapshot on VM '%s'" % self.args.vm_domain)
-                raise exceptions.TestSetupFail()
+                e_msg = ("Could not create snapshot on VM '%s'" %
+                         self.args.vm_domain)
+                raise exceptions.JobError(e_msg)
         try:
             # Finish remote setup and copy the tests
             self.args.remote_hostname = self.args.vm_hostname

--- a/avocado/core/virt.py
+++ b/avocado/core/virt.py
@@ -92,20 +92,6 @@ class Hypervisor(object):
                 return domain
         return None
 
-    def start_domain_with_xml(self, xml):
-        """
-        Start/create domain with XML description.
-
-        :param xml: the XML description.
-        :return: an instance of :class:`libvirt.virDomain`.
-        """
-        dom = None
-        try:
-            dom = self.connection.createXML(xml)
-        except libvirt.libvirtError:
-            pass
-        return dom
-
 
 class VM(object):
 

--- a/avocado/core/virt.py
+++ b/avocado/core/virt.py
@@ -17,6 +17,8 @@ Module to provide classes for Virtual Machines.
 """
 
 import logging
+import subprocess
+import xml.etree.cElementTree as etree
 from xml.dom import minidom
 
 from . import remoter
@@ -265,6 +267,27 @@ class VM(object):
                 self.logged = True
         else:
             self.logged = False
+
+    def ip_address(self):
+        """
+        Returns the IP address associated with the MAC address of this VM
+
+        Inspired from:
+        https://raw.githubusercontent.com/mcepl/virt-addr/master/virt-addr.py
+
+        :returns: either the IP address or None if not found
+        :rtype: str or None
+        """
+        desc = etree.fromstring(self.domain.XMLDesc(0))
+        mac_path = "devices/interface[@type='network']/mac"
+        mac = desc.find(mac_path).attrib["address"].lower().strip()
+        output = subprocess.Popen(["arp", "-n"],
+                                  stdout=subprocess.PIPE).communicate()[0]
+        lines = [line.split() for line in output.split("\n")[1:]]
+        addresses = [line[0] for line in lines if (line and (line[2] == mac))]
+        if addresses:
+            # Just return the first address, this is a best effort attempt
+            return addresses[0]
 
 
 def vm_connect(domain_name, hypervisor_uri='qemu:///system'):

--- a/docs/source/RunningTestsRemotely.rst
+++ b/docs/source/RunningTestsRemotely.rst
@@ -96,7 +96,8 @@ when using the ``run`` command in the Avocado command line tool::
       --vm-domain VM_DOMAIN
                             Specify domain name (Virtual Machine name)
       --vm-hostname VM_HOSTNAME
-                            Specify VM hostname to login
+                            Specify VM hostname to login. By default it attempts
+                            to automatically find the VM IP address.
       --vm-username VM_USERNAME
                             Specify the username to login on VM
       --vm-password VM_PASSWORD
@@ -107,6 +108,11 @@ when using the ``run`` command in the Avocado command line tool::
 From these options, you are normally going to use `--vm-domain`,
 `--vm-hostname` and `--vm-username` in case you did set up your VM with
 password-less SSH connection (through SSH keys).
+
+If you have the VM already running, or have had it running and it a
+"while" back, you can probably skip the `--vm-hostname` option as
+Avocado will attempt to find out the VM IP address based on the MAC
+address and ARP table.
 
 Virtual Machine Setup
 ---------------------


### PR DESCRIPTION
By leveraging the `avocado.core.virt.VM.ip_address` method, let's make
the `--vm-hostname` optional. If the IP address can not be found, then
ask users to manually provide it.
    
If the user has a VM running, or has had it running a "while" back,
chances are pretty high Avocado will be able to find it's IP address.

This PR also includes other related fixes.