### PR TITLE
avocado.core.data_dir: Suppress AttributeError when pickling _TmpDirT…

### DIFF
--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -235,8 +235,11 @@ class _TmpDirTracker(Borg):
     def __del__(self):
         tmp_dir = getattr(self, 'tmp_dir', None)
         if tmp_dir is not None:
-            if os.path.isdir(tmp_dir):
-                shutil.rmtree(tmp_dir)
+            try:
+                if os.path.isdir(tmp_dir):
+                    shutil.rmtree(tmp_dir)
+            except AttributeError:
+                pass
 
 _tmp_tracker = _TmpDirTracker()
 


### PR DESCRIPTION
…racker instances

If the tracker is pickled/unpickled (common in avocado-vt,
for example), we might call garbage collection and the
temporary dir might be long gone, and the original os
and shutil imports as well. So let's handle this case
properly.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>