### PR TITLE
avocado.core.tree: Improve error message on missing !include file [v1]

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -461,8 +461,8 @@ class Job(object):
 
         try:
             mux = multiplexer.Mux(self.args)
-        except IOError, details:
-            raise exceptions.OptionValidationError(details.strerror)
+        except (IOError, ValueError), details:
+            raise exceptions.OptionValidationError(details)
         self.args.test_result_total = mux.get_number_of_tests(test_suite)
 
         self._make_test_result()

--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -333,6 +333,9 @@ def _create_from_yaml(path, cls_node=TreeNode):
                     ypath = value[1]
                     if not os.path.isabs(ypath):
                         ypath = os.path.join(os.path.dirname(path), ypath)
+                    if not os.path.exists(ypath):
+                        raise ValueError("File '%s' included from '%s' does not "
+                                         "exist." % (ypath, path))
                     node.merge(_create_from_yaml('/:' + ypath, cls_node))
                 elif value[0].code == YAML_USING:
                     if using:


### PR DESCRIPTION
When a multiplex file includes a missing file, avocado only reports
"there is a missing file" without any explanations whatsoever. This
patch changes it to a ValueError with the original file and the
missing one.

Additionally it adds missing Exception to try/except, which was
already possible on certain errors, to avoid tracebacks.

Comes from https://github.com/avocado-framework/avocado/pull/813