### PR TITLE
avocado.core.data_dir: Make logdir creation safer [v3]

### DIFF
--- a/selftests/unit/test_datadir.py
+++ b/selftests/unit/test_datadir.py
@@ -52,6 +52,27 @@ class DataDirTest(unittest.TestCase):
             reload(data_dir)
         del data_dir
 
+    def testUniqueLogDir(self):
+        """
+        Tests that multiple queries for a logdir at the same time provides
+        unique results.
+        """
+        from avocado.core import data_dir
+        flexmock(data_dir.time).should_receive('strftime').and_return("date")
+        logdir = os.path.join(self.mapping['base_dir'], "foor", "bar", "baz")
+        path_prefix = os.path.join(logdir, "job-date-")
+        uid = "1234567890"*4
+        for i in xrange(7, 40):
+            path = data_dir.create_job_logs_dir(logdir, uid)
+            self.assertEqual(path, path_prefix + uid[:i])
+            self.assertTrue(os.path.exists(path))
+        path = data_dir.create_job_logs_dir(logdir, uid)
+        self.assertEqual(path, path_prefix + uid + ".0")
+        self.assertTrue(os.path.exists(path))
+        path = data_dir.create_job_logs_dir(logdir, uid)
+        self.assertEqual(path, path_prefix + uid + ".1")
+        self.assertTrue(os.path.exists(path))
+
     def tearDown(self):
         os.unlink(self.config_file.name)
         shutil.rmtree(self.mapping['base_dir'])


### PR DESCRIPTION
When one execute 2 jobs with first 7 chars of unique id at the same
time, they end-up in the same logdir.

This patch makes the creation safer. First it creates the main
directory, then it tries to create the directory with 7 chars of the
unique id. On failure it adds another char until it finds empty dir.

In case you spawn 2 jobs with the same id at the same time, it adds
a number starting with 0.

If you spawn more tham 1000 jobs at the same time with the exact same
id, it fails with IOError.

v1: https://github.com/avocado-framework/avocado/pull/813

Changes:

    v2: Create the logdir even when logdir is specified
    v2: Pylint fixes
    v2: Added unittest
    v3: Add `assert` in unittest