### PR TITLE
.travis.yml: Skip installing packages using apt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,6 @@ branches:
 
 sudo: false
 
-addons:
-    apt:
-        packages:
-            - python-libvirt
-            - python-lzma
-            - libyaml-dev
-
 install:
     - pip install -r requirements-travis.txt
     - if [ $TRAVIS_PYTHON_VERSION == '2.6' ]; then pip install -r requirements-travis-python26.txt; fi


### PR DESCRIPTION
Those packages are not being installed anyway, and do not
interfere with general CI testing.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>