### PR TITLE
docs: Add a readthedocs specific requirements file

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,7 @@
+# All pip installable requirements pinned for Travis CI
+fabric==1.10.0
+pystache==0.5.4
+requests==1.2.3
+PyYAML==3.11
+Pillow==2.2.1
+aexpect==1.0.0


### PR DESCRIPTION
Add a file specifically for our automated documentation
builds (on readthedocs.org).

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>