### PR TITLE
Test Loader: support for enable/disable docstring tags [v0]

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -46,6 +46,28 @@ AVAILABLE = None    # Available tests (for listing purposes)
 ALL = True          # All tests (inicluding broken ones)
 
 
+#: Gets the tag value from a string. Used to tag a test class in various ways
+AVOCADO_DOCSTRING_TAG_RE = re.compile(r'\s*:avocado:\s*(\S+)\s*')
+
+
+def get_docstring_tag(docstring):
+    if docstring is None:
+        return None
+    result = AVOCADO_DOCSTRING_TAG_RE.search(docstring)
+    if result is not None:
+        return result.groups()[0]
+
+
+def is_docstring_tag_enable(docstring):
+    result = get_docstring_tag(docstring)
+    return result == 'enable'
+
+
+def is_docstring_tag_disable(docstring):
+    result = get_docstring_tag(docstring)
+    return result == 'disable'
+
+
 class LoaderError(Exception):
 
     """ Loader exception """

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -122,7 +122,7 @@ class TestLoaderProxy(object):
         if "DEFAULT" in loaders:   # Replace DEFAULT with unused loaders
             idx = loaders.index("DEFAULT")
             loaders = (loaders[:idx] + [_ for _ in names if _ not in loaders] +
-                       loaders[idx+1:])
+                       loaders[idx + 1:])
             while "DEFAULT" in loaders:    # Remove duplicite DEFAULT entries
                 loaders.remove("DEFAULT")
 

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -1,4 +1,5 @@
 import os
+import re
 import sys
 import unittest
 import multiprocessing
@@ -153,6 +154,33 @@ class LoaderTest(unittest.TestCase):
         self.assertEqual(len(suite), 2)
         avocado_multiple_tests.remove()
 
+
+class DocstringTagTests(unittest.TestCase):
+
+    def test_longline(self):
+        docstring = ("This is a very long docstring in a single line. "
+                     "Since we have nothing useful to put in here let's just "
+                     "mention avocado: it's awesome, but that was not a tag. "
+                     "a tag would be something line this: :avocado: enable")
+        self.assertIsNotNone(loader.get_docstring_tag(docstring))
+
+    def test_newlines(self):
+        docstring = ("\n\n\nThis is a docstring with many new\n\nlines "
+                     "followed by an avocado tag\n"
+                     "\n\n:avocado: enable\n\n")
+        self.assertIsNotNone(loader.get_docstring_tag(docstring))
+
+    def test_enabled(self):
+        self.assertTrue(loader.is_docstring_tag_enable(":avocado: enable"))
+        self.assertTrue(loader.is_docstring_tag_enable(":avocado:\tenable"))
+        self.assertFalse(loader.is_docstring_tag_enable(":AVOCADO: ENABLE"))
+        self.assertFalse(loader.is_docstring_tag_enable(":avocado: enabled"))
+
+    def test_disabled(self):
+        self.assertTrue(loader.is_docstring_tag_disable(":avocado: disable"))
+        self.assertTrue(loader.is_docstring_tag_disable(":avocado:\tdisable"))
+        self.assertFalse(loader.is_docstring_tag_disable(":AVOCADO: DISABLE"))
+        self.assertFalse(loader.is_docstring_tag_disable(":avocado: disabled"))
 
 if __name__ == '__main__':
     unittest.main()

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -25,6 +25,22 @@ if __name__ == "__main__":
     main()
 """
 
+AVOCADO_TEST_OK_DISABLED = """#!/usr/bin/python
+from avocado import Test
+from avocado import main
+
+class PassTest(Test):
+    '''
+    Instrumented test, but disabled using an Avocado docstring tag
+    :avocado: disable
+    '''
+    def test(self):
+        pass
+
+if __name__ == "__main__":
+    main()
+"""
+
 NOT_A_TEST = """
 def hello():
     print('Hello World!')
@@ -50,6 +66,22 @@ class MultipleMethods(Test):
     def testTwo(self):
         pass
     def foo(self):
+        pass
+"""
+
+
+AVOCADO_FOREIGN_TAGGED_ENABLE = """from foreignlib import Base
+
+class First(Base):
+    '''
+    First actual test based on library base class
+
+    This Base class happens to, fictionally, inherit from avocado.Test. Because
+    Avocado can't tell that, a tag is necessary to signal that.
+
+    :avocado: enable
+    '''
+    def test(self):
         pass
 """
 
@@ -153,6 +185,27 @@ class LoaderTest(unittest.TestCase):
         suite = self.loader.discover(avocado_multiple_tests.path, True)
         self.assertEqual(len(suite), 2)
         avocado_multiple_tests.remove()
+
+    def test_load_foreign(self):
+        avocado_pass_test = script.TemporaryScript('foreign.py',
+                                                   AVOCADO_FOREIGN_TAGGED_ENABLE,
+                                                   'avocado_loader_unittest')
+        avocado_pass_test.save()
+        test_class, test_parameters = (
+            self.loader.discover(avocado_pass_test.path, True)[0])
+        self.assertTrue(test_class == 'First', test_class)
+        avocado_pass_test.remove()
+
+    def test_load_pass_disable(self):
+        avocado_pass_test = script.TemporaryScript('disable.py',
+                                                   AVOCADO_TEST_OK_DISABLED,
+                                                   'avocado_loader_unittest',
+                                                   0664)
+        avocado_pass_test.save()
+        test_class, test_parameters = (
+            self.loader.discover(avocado_pass_test.path, True)[0])
+        self.assertTrue(test_class == test.NotATest)
+        avocado_pass_test.remove()
 
 
 class DocstringTagTests(unittest.TestCase):


### PR DESCRIPTION
Since the test loader now attempts to find Avocado instrumented tests by using a parser and doesn't really load/execute test files, it can't tell if a given class inherits from avocado.Test.

For those cases, a developer may signal, using a docstring tag, that either:

* A test class that doesn't look like an Avocado test class is indeed one (":avocado: enable")
* A test class that looks like an Avocado test class should not be treated as such (":avocado: disable")

Also included is a a simple optimization by breaking earlier from the parser loop.

Please test these, and for v1 I'll update the diagrams and documentations.