### PR TITLE
avocado.core.loader: improve the --loaders [v2b]

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -420,15 +420,14 @@ class FileLoader(TestLoader):
 
     @staticmethod
     def get_decorator_mapping():
-        term_support = output.TermSupport()
-        return {test.SimpleTest: term_support.healthy_str,
-                test.InnerRunnerTest: term_support.healthy_str,
-                test.NotATest: term_support.warn_header_str,
-                test.MissingTest: term_support.fail_header_str,
-                BrokenSymlink: term_support.fail_header_str,
-                AccessDeniedPath: term_support.fail_header_str,
-                test.Test: term_support.healthy_str,
-                FilteredOut: term_support.warn_header_str}
+        return {test.SimpleTest: output.term_support.healthy_str,
+                test.InnerRunnerTest: output.term_support.healthy_str,
+                test.NotATest: output.term_support.warn_header_str,
+                test.MissingTest: output.term_support.fail_header_str,
+                BrokenSymlink: output.term_support.fail_header_str,
+                AccessDeniedPath: output.term_support.fail_header_str,
+                test.Test: output.term_support.healthy_str,
+                FilteredOut: output.term_support.warn_header_str}
 
     def discover(self, url, list_tests=DEFAULT):
         """

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -17,33 +17,26 @@
 Test loader module.
 """
 
+import ast
 import collections
+import fnmatch
 import imp
 import inspect
 import os
-import re
-import sys
 import shlex
-import fnmatch
-import ast
+import sys
 
 from . import data_dir
 from . import output
 from . import test
-from . import exceptions
-from .settings import settings
 from ..utils import path
 from ..utils import stacktrace
-
-try:
-    import cStringIO as StringIO
-except ImportError:
-    import StringIO
+from .settings import settings
 
 
-DEFAULT = False     # Show default tests (for execution)
-AVAILABLE = None    # Available tests (for listing purposes)
-ALL = True          # All tests (inicluding broken ones)
+DEFAULT = False  # Show default tests (for execution)
+AVAILABLE = None  # Available tests (for listing purposes)
+ALL = True  # All tests (inicluding broken ones)
 
 
 class LoaderError(Exception):
@@ -134,12 +127,12 @@ class TestLoaderProxy(object):
             loaders = settings.get_value("plugins", "loaders", list, [])
         if '?' in loaders:
             raise LoaderError("Available loader plugins: %s" % _str_loaders())
-        if "@DEFAULT" in loaders:   # Replace @DEFAULT with unused loaders
+        if "@DEFAULT" in loaders:  # Replace @DEFAULT with unused loaders
             idx = loaders.index("@DEFAULT")
             loaders = (loaders[:idx] + [plugin for plugin in supported_loaders
                                         if plugin not in loaders] +
-                       loaders[idx+1:])
-            while "@DEFAULT" in loaders:    # Remove duplicite @DEFAULT entries
+                       loaders[idx + 1:])
+            while "@DEFAULT" in loaders:  # Remove duplicite @DEFAULT entries
                 loaders.remove("@DEFAULT")
 
         loaders = [_.split(':', 1) for _ in loaders]
@@ -213,7 +206,7 @@ class TestLoaderProxy(object):
                             tests.extend(_test)
                             handled = True
                             if not list_tests:
-                                break    # Don't process other plugins
+                                break  # Don't process other plugins
                     except Exception, details:
                         handle_exception(loader_plugin, details)
                 if not handled:
@@ -261,7 +254,7 @@ class TestLoader(object):
     Base for test loader classes
     """
 
-    def __init__(self, args, extra_params):    # pylint: disable=W0613
+    def __init__(self, args, extra_params):  # pylint: disable=W0613
         self.args = args
 
     def get_extra_listing(self):
@@ -432,7 +425,7 @@ class FileLoader(TestLoader):
         """
         if url is None:
             if list_tests is DEFAULT:
-                return []   # Return empty set when not listing details
+                return []  # Return empty set when not listing details
             else:
                 url = data_dir.get_test_dir()
         ignore_suffix = ('.data', '.pyc', '.pyo', '__init__.py',
@@ -442,7 +435,7 @@ class FileLoader(TestLoader):
         subtests_filter = None
         if ':' in url:
             _url, _subtests_filter = url.split(':', 1)
-            if os.path.exists(_url):    # otherwise it's ':' in the file name
+            if os.path.exists(_url):  # otherwise it's ':' in the file name
                 url = _url
                 subtests_filter = _subtests_filter
 
@@ -459,9 +452,9 @@ class FileLoader(TestLoader):
             """ Always return None """
             return None
 
-        if list_tests:      # ALL => include everything
+        if list_tests:  # ALL => include everything
             onerror = add_test_from_exception
-        else:               # DEFAULT, AVAILABLE => skip missing tests
+        else:  # DEFAULT, AVAILABLE => skip missing tests
             onerror = skip_non_test
 
         for dirpath, _, filenames in os.walk(url, onerror=onerror):
@@ -567,7 +560,8 @@ class FileLoader(TestLoader):
                 for test_class, test_methods in tests.items():
                     if isinstance(test_class, str):
                         for test_method in test_methods:
-                            name = test_name + ':%s.%s' % (test_class, test_method)
+                            name = test_name + \
+                                ':%s.%s' % (test_class, test_method)
                             tst = (test_class, {'name': name,
                                                 'modulePath': test_path,
                                                 'methodName': test_method})
@@ -611,7 +605,7 @@ class FileLoader(TestLoader):
         # will not crash.
         except BaseException, details:  # Ugly python files can raise any exc
             if isinstance(details, KeyboardInterrupt):
-                raise   # Don't ignore ctrl+c
+                raise  # Don't ignore ctrl+c
             if os.access(test_path, os.X_OK):
                 # Module can't be imported, and it's executable. Let's try to
                 # execute it.
@@ -643,9 +637,9 @@ class FileLoader(TestLoader):
             """ Always return empty list """
             return []
 
-        if list_non_tests:   # return broken test with params
+        if list_non_tests:  # return broken test with params
             make_broken = self._make_test
-        else:               # return empty set instead
+        else:  # return empty set instead
             make_broken = ignore_broken
         test_name = test_path
         if os.path.exists(test_path):

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -83,20 +83,11 @@ class TestLoaderProxy(object):
         self._initialized_plugins = []
         self.registered_plugins = []
         self.url_plugin_mapping = {}
-        self._test_types = {}
 
     def register_plugin(self, plugin):
         try:
             if issubclass(plugin, TestLoader):
                 self.registered_plugins.append(plugin)
-                for test_type in plugin.get_type_label_mapping().itervalues():
-                    if (test_type in self._test_types and
-                            self._test_types[test_type] != plugin):
-                        msg = ("Multiple plugins using the same test_type not "
-                               "yet supported (%s, %s)"
-                               % (test_type, self._test_types))
-                        raise NotImplementedError(msg)
-                    self._test_types[test_type] = plugin
             else:
                 raise ValueError
         except ValueError:
@@ -104,44 +95,59 @@ class TestLoaderProxy(object):
                                       "TestLoader" % plugin)
 
     def load_plugins(self, args):
-        def _err_list_loaders():
-            return ("Loaders: %s\nTypes: %s" % (names,
-                                                self._test_types.keys()))
+        def _good_test_types(plugin):
+            """
+            List all supported test types (excluding incorrect ones)
+            """
+            name = plugin.name
+            mapping = plugin.get_type_label_mapping()
+            # Using __func__ to avoid problem with different term_supp instances
+            healthy_func = getattr(output.term_support.healthy_str, '__func__')
+            types = [mapping[_[0]]
+                     for _ in plugin.get_decorator_mapping().iteritems()
+                     if _[1].__func__ is healthy_func]
+            return [name + '.' + _ for _ in types]
+
+        def _str_loaders():
+            """
+            :return: string of sorted loaders and types
+            """
+            return ", ".join(sorted(supported_types + supported_loaders))
+
         self._initialized_plugins = []
         # Add (default) file loader if not already registered
         if FileLoader not in self.registered_plugins:
             self.register_plugin(FileLoader)
+        supported_loaders = [_.name for _ in self.registered_plugins]
+        supported_types = []
+        for plugin in self.registered_plugins:
+            supported_types.extend(_good_test_types(plugin))
         # Load plugin by the priority from settings
-        names = ["@" + _.name for _ in self.registered_plugins]
         loaders = getattr(args, 'loaders', None)
         if not loaders:
             loaders = settings.get_value("plugins", "loaders", list, [])
         if '?' in loaders:
-            raise LoaderError("Loaders: %s\nTypes: %s"
-                              % (names, self._test_types.keys()))
-        if "DEFAULT" in loaders:   # Replace DEFAULT with unused loaders
-            idx = loaders.index("DEFAULT")
-            loaders = (loaders[:idx] + [_ for _ in names if _ not in loaders] +
+            raise LoaderError("Available loader plugins: %s" % _str_loaders())
+        if "@DEFAULT" in loaders:   # Replace @DEFAULT with unused loaders
+            idx = loaders.index("@DEFAULT")
+            loaders = (loaders[:idx] + [plugin for plugin in supported_loaders
+                                        if plugin not in loaders] +
                        loaders[idx+1:])
-            while "DEFAULT" in loaders:    # Remove duplicite DEFAULT entries
-                loaders.remove("DEFAULT")
+            while "@DEFAULT" in loaders:    # Remove duplicite @DEFAULT entries
+                loaders.remove("@DEFAULT")
 
         loaders = [_.split(':', 1) for _ in loaders]
         priority = [_[0] for _ in loaders]
         for i, name in enumerate(priority):
             extra_params = {}
-            if name in names:
-                plugin = self.registered_plugins[names.index(name)]
-            elif name in self._test_types:
-                plugin = self._test_types[name]
-                extra_params['allowed_test_types'] = name
-            else:
-                raise InvalidLoaderPlugin("Loader '%s' not available:\n"
-                                          "Loaders: %s\nTypes: %s"
-                                          % (name, names,
-                                             self._test_types.keys()))
+            if name in supported_types:
+                name, extra_params['allowed_test_types'] = name.split('.', 1)
+            elif name not in supported_loaders:
+                raise InvalidLoaderPlugin("Loader '%s' not available (%s)"
+                                          % (name, _str_loaders()))
             if len(loaders[i]) == 2:
                 extra_params['loader_options'] = loaders[i][1]
+            plugin = self.registered_plugins[supported_loaders.index(name)]
             self._initialized_plugins.append(plugin(args, extra_params))
 
     def get_extra_listing(self):

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -458,10 +458,14 @@ class FileLoader(TestLoader):
                             issubclass(tst[0], filtered_clss)):
                         return None
             else:
+                if self.test_type == 'SIMPLE':
+                    exclude = test.InnerRunnerTest   # InnerRunner is inherited
+                else:
+                    exclude = None
                 test_class = (key for key, value in mapping.iteritems()
                               if value == self.test_type).next()
                 for tst in tests:
-                    if not issubclass(tst[0], test_class):
+                    if not issubclass(tst[0], test_class) or tst[0] == exclude:
                         return None
         return tests
 

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -449,13 +449,10 @@ class FileLoader(TestLoader):
         if self.test_type:
             mapping = self.get_type_label_mapping()
             if self.test_type == 'INSTRUMENTED':
-                # Instrumented is parent of all of supported tests, we need to
-                # exclude the rest of the supported tests
-                filtered_clss = tuple(_ for _ in mapping.iterkeys()
-                                      if _ is not test.Test)
+                # Instrumented tests are defined as string and loaded at the
+                # execution time.
                 for tst in tests:
-                    if (not issubclass(tst[0], test.Test) or
-                            issubclass(tst[0], filtered_clss)):
+                    if not isinstance(tst[0], str):
                         return None
             else:
                 if self.test_type == 'SIMPLE':
@@ -465,7 +462,8 @@ class FileLoader(TestLoader):
                 test_class = (key for key, value in mapping.iteritems()
                               if value == self.test_type).next()
                 for tst in tests:
-                    if not issubclass(tst[0], test_class) or tst[0] == exclude:
+                    if (isinstance(tst[0], str) or
+                            not issubclass(tst[0], test_class)):
                         return None
         return tests
 

--- a/avocado/core/plugins/runner.py
+++ b/avocado/core/plugins/runner.py
@@ -116,7 +116,7 @@ class TestRunner(plugin.Plugin):
                                      'present for the test. '
                                      'Current: on (output check enabled)'))
 
-        loader.add_file_loader_options(self.parser)
+        loader.add_loader_options(self.parser)
 
         if multiplexer.MULTIPLEX_CAPABLE:
             mux = self.parser.add_argument_group('multiplexer use on test execution')

--- a/avocado/core/plugins/test_list.py
+++ b/avocado/core/plugins/test_list.py
@@ -174,7 +174,7 @@ class TestList(plugin.Plugin):
                                  choices=('on', 'off'), default='on',
                                  help='Turn the paginator on/off. '
                                       'Current: %(default)s')
-        loader.add_file_loader_options(self.parser)
+        loader.add_loader_options(self.parser)
         super(TestList, self).configure(self.parser)
         parser.lister = self.parser
 

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -614,39 +614,39 @@ class SimpleTest(Test):
                                           "the log for details.")
 
 
-class InnerRunnerTest(SimpleTest):
+class ExternalRunnerTest(SimpleTest):
 
     def __init__(self, name, params=None, base_logdir=None, tag=None, job=None,
-                 inner_runner=None):
-        self.assertIsNotNone(inner_runner, "Inner runner test requires "
-                             "inner_runner parameter, got None instead.")
-        self.inner_runner = inner_runner
-        super(InnerRunnerTest, self).__init__(name, params, base_logdir, tag,
-                                              job)
+                 external_runner=None):
+        self.assertIsNotNone(external_runner, "External runner test requires "
+                             "external_runner parameter, got None instead.")
+        self.external_runner = external_runner
+        super(ExternalRunnerTest, self).__init__(name, params, base_logdir,
+                                                 tag, job)
 
     def test(self):
         pre_cwd = os.getcwd()
         new_cwd = None
         try:
-            self.log.info('Running test with the inner level test '
-                          'runner: "%s"', self.inner_runner.runner)
+            self.log.info('Running test with the external level test '
+                          'runner: "%s"', self.external_runner.runner)
 
-            # Change work directory if needed by the inner runner
-            if self.inner_runner.chdir == 'runner':
-                new_cwd = os.path.dirname(self.inner_runner.runner)
-            elif self.inner_runner.chdir == 'test':
-                new_cwd = self.inner_runner.test_dir
+            # Change work directory if needed by the external runner
+            if self.external_runner.chdir == 'runner':
+                new_cwd = os.path.dirname(self.external_runner.runner)
+            elif self.external_runner.chdir == 'test':
+                new_cwd = self.external_runner.test_dir
             else:
                 new_cwd = None
             if new_cwd is not None:
                 self.log.debug('Changing working directory to "%s" '
-                               'because of inner runner requirements ',
+                               'because of external runner requirements ',
                                new_cwd)
                 os.chdir(new_cwd)
 
-            command = "%s %s" % (self.inner_runner.runner, self.path)
+            command = "%s %s" % (self.external_runner.runner, self.path)
 
-            return super(InnerRunnerTest, self).test(command)
+            return super(ExternalRunnerTest, self).test(command)
         finally:
             if new_cwd is not None:
                 os.chdir(pre_cwd)

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -10,8 +10,8 @@
 #
 # This code was inspired in the autotest project,
 # client/shared/test.py
-# Authors: Martin J Bligh <mbligh@google.com>, Andy Whitcroft <apw@shadowen.org>
-import re
+# Authors: Martin J Bligh <mbligh@google.com>,
+#          Andy Whitcroft <apw@shadowen.org>
 
 """
 Contains the base test implementation, used as a base for the actual
@@ -22,25 +22,27 @@ import inspect
 import logging
 import os
 import pipes
+import re
 import shutil
 import sys
 import time
+
+from . import data_dir
+from . import exceptions
+from . import multiplexer
+from . import sysinfo
+from ..utils import data_structures
+from ..utils import genio
+from ..utils import path as utils_path
+from ..utils import process
+from ..utils import stacktrace
+from .version import VERSION
+
 
 if sys.version_info[:2] == (2, 6):
     import unittest2 as unittest
 else:
     import unittest
-
-from . import data_dir
-from . import sysinfo
-from . import exceptions
-from . import multiplexer
-from .version import VERSION
-from ..utils import genio
-from ..utils import path as utils_path
-from ..utils import process
-from ..utils import stacktrace
-from ..utils import data_structures
 
 
 class Test(unittest.TestCase):
@@ -358,7 +360,7 @@ class Test(unittest.TestCase):
         except exceptions.TestNAError, details:
             stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
             raise exceptions.TestNAError(details)
-        except:     # Old-style exceptions are not inherited from Exception()
+        except:  # Old-style exceptions are not inherited from Exception()
             stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
             details = sys.exc_info()[1]
             raise exceptions.TestSetupFail(details)
@@ -371,7 +373,7 @@ class Test(unittest.TestCase):
                                 'must fix your test. Original skip exception: '
                                 '%s' % details)
             raise exceptions.TestError(skip_illegal_msg)
-        except:     # Old-style exceptions are not inherited from Exception()
+        except:  # Old-style exceptions are not inherited from Exception()
             stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
             details = sys.exc_info()[1]
             if not isinstance(details, Exception):  # Avoid passing nasty exc
@@ -387,7 +389,7 @@ class Test(unittest.TestCase):
                                     'you must fix your test. Original skip '
                                     'exception: %s' % details)
                 raise exceptions.TestError(skip_illegal_msg)
-            except:     # avoid old-style exception failures
+            except:  # avoid old-style exception failures
                 stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
                 details = sys.exc_info()[1]
                 cleanup_exception = exceptions.TestSetupFail(details)
@@ -410,12 +412,14 @@ class Test(unittest.TestCase):
                     try:
                         self.check_reference_stdout()
                     except Exception, details:
-                        stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
+                        stacktrace.log_exc_info(sys.exc_info(),
+                                                logger='avocado.test')
                         stdout_check_exception = details
                     try:
                         self.check_reference_stderr()
                     except Exception, details:
-                        stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
+                        stacktrace.log_exc_info(sys.exc_info(),
+                                                logger='avocado.test')
                         stderr_check_exception = details
             elif not job_standalone:
                 if output_check_record in ['all', 'stdout']:

--- a/docs/source/GetStartedGuide.rst
+++ b/docs/source/GetStartedGuide.rst
@@ -178,10 +178,10 @@ instrumented and simple tests::
     JOB HTML  : $HOME/avocado/job-results/job-2014-08-12T15.42-86911e49/html/results.html
     TIME      : 1.04 s
 
-.. _running-inner-runner:
+.. _running-external-runner:
 
-Running Tests With An Inner Runner
-==================================
+Running Tests With An External Runner
+=====================================
 
 It's quite common to have organically grown test suites in most
 software projects. These usually include a custom built, very specific
@@ -193,25 +193,25 @@ human and machine readable formats, collecting system information
 alongside those tests (the Avocado's `sysinfo` functionality), and
 more.
 
-Avocado makes that possible by means of its "inner runner" feature. The
+Avocado makes that possible by means of its "external runner" feature. The
 most basic way of using it is::
 
-    $ avocado run --inner-runner=/path/to/inner_runner foo bar baz
+    $ avocado run --external-runner=/path/to/external_runner foo bar baz
 
 In this example, Avocado will report individual test results for tests
 `foo`, `bar` and `baz`. The actual results will be based on the return
-code of individual executions of `/path/to/inner_runner foo`,
-`/path/to/inner_runner bar` and finally `/path/to/inner_runner baz`.
+code of individual executions of `/path/to/external_runner foo`,
+`/path/to/external_runner bar` and finally `/path/to/external_runner baz`.
 
 As another way to explain an show how this feature works, think of the
-"inner runner" as some kind of interpreter and the individual tests as
+"external runner" as some kind of interpreter and the individual tests as
 anything that this interpreter recognizes and is able to execute. A
-UNIX shell, say `/bin/sh` could be considered an inner runner, and
+UNIX shell, say `/bin/sh` could be considered an external runner, and
 files with shell code could be considered tests::
 
     $ echo "exit 0" > /tmp/pass
     $ echo "exit 1" > /tmp/fail
-    $ avocado run --inner-runner=/bin/sh /tmp/pass /tmp/fail
+    $ avocado run --external-runner=/bin/sh /tmp/pass /tmp/fail
     JOB ID     : 4a2a1d259690cc7b226e33facdde4f628ab30741
     JOB LOG    : /home/<user>/avocado/job-results/job-<date>-<shortid>/job.log
     JOB HTML   : /home/<user>/avocado/job-results/job-<date>-<shortid>/html/results.html
@@ -228,7 +228,7 @@ them executable (`chmod +x /tmp/pass /tmp/fail)`, and running them as
 
 But now consider the following example::
 
-    $ avocado run --inner-runner=/bin/curl http://local-avocado-server:9405/jobs/ \
+    $ avocado run --external-runner=/bin/curl http://local-avocado-server:9405/jobs/ \
                                            http://remote-avocado-server:9405/jobs/
     JOB ID     : 56016a1ffffaba02492fdbd5662ac0b958f51e11
     JOB LOG    : /home/<user>/avocado/job-results/job-<date>-<shortid>/job.log
@@ -239,7 +239,7 @@ But now consider the following example::
     RESULTS    : PASS 1 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0
     TIME       : 3.04 s
 
-This effectively makes `/bin/curl` an "inner test runner", responsible for
+This effectively makes `/bin/curl` an "external test runner", responsible for
 trying to fetch those URLs, and reporting PASS or FAIL for each of them.
 
 Debugging tests

--- a/docs/source/Loaders.rst
+++ b/docs/source/Loaders.rst
@@ -24,13 +24,14 @@ settings (``/etc/avocado/``), or temporarily using ``--loaders``
 This option allows you to specify order and some params of the available test
 loaders. You can specify either loader_name (``file``), loader_name +
 TEST_TYPE (``file.SIMPLE``) and for some loaders even additional params
-passed after ``:`` (``@file:/bin/echo -e``. You can also supply ``@DEFAULT``,
-which injects into that position all the remaining unused loaders.
+passed after ``:`` (``inner_runner:/bin/echo -e``. You can also supply
+``@DEFAULT``, which injects into that position all the remaining unused
+loaders.
 
 To get help about ``--loaders``::
 
     $ avocado run --loaders ?
-    $ avocado run --loaders file:?
+    $ avocado run --loaders inner_runner:?
 
 Example of how ``--loaders`` affects the produced tests (manually gathered
 as some of them result in error)::
@@ -40,12 +41,12 @@ as some of them result in error)::
         > VT           io-github-autotest-qemu.boot
         > MISSING      this_does_not_exist
         > SIMPLE       /bin/echo
-    $ avocado run passtest boot this_does_not_exist /bin/echo --loaders @DEFAULT "file:/bin/echo -e"
+    $ avocado run passtest boot this_does_not_exist /bin/echo --loaders @DEFAULT "inner_runner:/bin/echo -e"
         > INSTRUMENTED passtest.py:PassTest.test
         > VT           io-github-autotest-qemu.boot
         > INNER_RUNNER this_does_not_exist
         > SIMPLE       /bin/echo
-    $ avocado run passtest boot this_does_not_exist /bin/echo --loaders file.SIMPLE file.INSTRUMENTED @DEFAULT file.INNER_RUNNER:/bin/echo
+    $ avocado run passtest boot this_does_not_exist /bin/echo --loaders file.SIMPLE file.INSTRUMENTED @DEFAULT inner_runner.INNER_RUNNER:/bin/echo
         > INSTRUMENTED passtest.py:PassTest.test
         > VT           io-github-autotest-qemu.boot
         > INNER_RUNNER this_does_not_exist

--- a/docs/source/Loaders.rst
+++ b/docs/source/Loaders.rst
@@ -12,7 +12,7 @@ The order of test loaders
 Avocado supports different types of test starting with `SIMPLE` tests, which
 are simply executable files, then unittest-like tests called `INSTRUMENTED`
 up to some tests like the `avocado-vt` ones, which uses complex
-matrix of tests from config files that don't directl map to existing files.
+matrix of tests from config files that don't directly map to existing files.
 Given the number of loaders, the mapping from test names on the command line
 to executed tests might not always be unique. Additionally some people might
 always (or for given run) want to execute only tests of a single type.
@@ -22,16 +22,15 @@ settings (``/etc/avocado/``), or temporarily using ``--loaders``
 (option of ``avocado run``) option.
 
 This option allows you to specify order and some params of the available test
-loaders. You can specify either ``@`` + loader_name (``@file``),
-TEST_TYPE (``SIMPLE``) and for some loaders even additional params passed
-after ``:`` (``@file:/bin/echo -e`` or ``INNER_RUNNER:/bin/echo -e``). You can
-also supply ``DEFAULT``, which injects into that position all the remaining
-unused loaders.
+loaders. You can specify either loader_name (``file``), loader_name +
+TEST_TYPE (``file.SIMPLE``) and for some loaders even additional params
+passed after ``:`` (``@file:/bin/echo -e``. You can also supply ``@DEFAULT``,
+which injects into that position all the remaining unused loaders.
 
 To get help about ``--loaders``::
 
     $ avocado run --loaders ?
-    $ avocado run --loaders @file:?
+    $ avocado run --loaders file:?
 
 Example of how ``--loaders`` affects the produced tests (manually gathered
 as some of them result in error)::
@@ -41,12 +40,12 @@ as some of them result in error)::
         > VT           io-github-autotest-qemu.boot
         > MISSING      this_does_not_exist
         > SIMPLE       /bin/echo
-    $ avocado run passtest boot this_does_not_exist /bin/echo --loaders DEFAULT "@file:/bin/echo -e"
+    $ avocado run passtest boot this_does_not_exist /bin/echo --loaders @DEFAULT "file:/bin/echo -e"
         > INSTRUMENTED passtest.py:PassTest.test
         > VT           io-github-autotest-qemu.boot
         > INNER_RUNNER this_does_not_exist
         > SIMPLE       /bin/echo
-    $ avocado run passtest boot this_does_not_exist /bin/echo --loaders SIMPLE INSTRUMENTED DEFAULT INNER_RUNNER:/bin/echo
+    $ avocado run passtest boot this_does_not_exist /bin/echo --loaders file.SIMPLE file.INSTRUMENTED @DEFAULT file.INNER_RUNNER:/bin/echo
         > INSTRUMENTED passtest.py:PassTest.test
         > VT           io-github-autotest-qemu.boot
         > INNER_RUNNER this_does_not_exist

--- a/docs/source/Loaders.rst
+++ b/docs/source/Loaders.rst
@@ -24,14 +24,14 @@ settings (``/etc/avocado/``), or temporarily using ``--loaders``
 This option allows you to specify order and some params of the available test
 loaders. You can specify either loader_name (``file``), loader_name +
 TEST_TYPE (``file.SIMPLE``) and for some loaders even additional params
-passed after ``:`` (``inner_runner:/bin/echo -e``. You can also supply
+passed after ``:`` (``external:/bin/echo -e``. You can also supply
 ``@DEFAULT``, which injects into that position all the remaining unused
 loaders.
 
 To get help about ``--loaders``::
 
     $ avocado run --loaders ?
-    $ avocado run --loaders inner_runner:?
+    $ avocado run --loaders external:?
 
 Example of how ``--loaders`` affects the produced tests (manually gathered
 as some of them result in error)::
@@ -41,14 +41,14 @@ as some of them result in error)::
         > VT           io-github-autotest-qemu.boot
         > MISSING      this_does_not_exist
         > SIMPLE       /bin/echo
-    $ avocado run passtest boot this_does_not_exist /bin/echo --loaders @DEFAULT "inner_runner:/bin/echo -e"
+    $ avocado run passtest boot this_does_not_exist /bin/echo --loaders @DEFAULT "external:/bin/echo -e"
         > INSTRUMENTED passtest.py:PassTest.test
         > VT           io-github-autotest-qemu.boot
-        > INNER_RUNNER this_does_not_exist
+        > EXTERNAL     this_does_not_exist
         > SIMPLE       /bin/echo
-    $ avocado run passtest boot this_does_not_exist /bin/echo --loaders file.SIMPLE file.INSTRUMENTED @DEFAULT inner_runner.INNER_RUNNER:/bin/echo
+    $ avocado run passtest boot this_does_not_exist /bin/echo --loaders file.SIMPLE file.INSTRUMENTED @DEFAULT external.EXTERNAL:/bin/echo
         > INSTRUMENTED passtest.py:PassTest.test
         > VT           io-github-autotest-qemu.boot
-        > INNER_RUNNER this_does_not_exist
+        > EXTERNAL     this_does_not_exist
         > SIMPLE       /bin/echo
 

--- a/etc/avocado/avocado.conf
+++ b/etc/avocado/avocado.conf
@@ -56,10 +56,10 @@ password =
 # avocado.core.plugins.htmlresult  ImportError No module named pystache
 # add 'avocado.core.plugins.htmlresult' as an element of the list below.
 skip_broken_plugin_notification = []
-# Optionally you can specify the priority of test loaders (@file) or test
-# types (SIMPLE). Some of the plugins even support extra params
-# (INNER_RUNNER:/bin/echo -e). Plugins will be used accordingly to the plugin
+# Optionally you can specify the priority of test loaders (file) or test
+# types (file.SIMPLE). Some of the plugins even support extra params
+# (file:/bin/echo -e). Plugins will be used accordingly to the plugin
 # priorities. It's possible to list plugins multiple times (with different
-# options or just types).
-# The type "DEFAULT" will be replaced with all available unused loaders.
-loaders = ['@file', 'DEFAULT']
+# options or test types).
+# The keyword "@DEFAULT" will be replaced with all available unused loaders.
+loaders = ['file', '@DEFAULT']

--- a/etc/avocado/avocado.conf
+++ b/etc/avocado/avocado.conf
@@ -58,7 +58,7 @@ password =
 skip_broken_plugin_notification = []
 # Optionally you can specify the priority of test loaders (file) or test
 # types (file.SIMPLE). Some of the plugins even support extra params
-# (file:/bin/echo -e). Plugins will be used accordingly to the plugin
+# (inner_runner:/bin/echo -e). Plugins will be used accordingly to the plugin
 # priorities. It's possible to list plugins multiple times (with different
 # options or test types).
 # The keyword "@DEFAULT" will be replaced with all available unused loaders.

--- a/etc/avocado/avocado.conf
+++ b/etc/avocado/avocado.conf
@@ -58,7 +58,7 @@ password =
 skip_broken_plugin_notification = []
 # Optionally you can specify the priority of test loaders (file) or test
 # types (file.SIMPLE). Some of the plugins even support extra params
-# (inner_runner:/bin/echo -e). Plugins will be used accordingly to the plugin
+# (external:/bin/echo -e). Plugins will be used accordingly to the plugin
 # priorities. It's possible to list plugins multiple times (with different
 # options or test types).
 # The keyword "@DEFAULT" will be replaced with all available unused loaders.

--- a/man/avocado.rst
+++ b/man/avocado.rst
@@ -451,8 +451,8 @@ the execution of ``perf.sh``. ::
 Note that it is not possible to use ``--gdb-run-bin`` together
 with ``--wrapper``, they are incompatible.
 
-RUNNING TESTS WITH AN INNER RUNNER
-==================================
+RUNNING TESTS WITH AN EXTERNAL RUNNER
+=====================================
 
 It's quite common to have organically grown test suites in most
 software projects. These usually include a custom built, very specific
@@ -464,25 +464,25 @@ human and machine readable formats, collecting system information
 alongside those tests (the Avocado's `sysinfo` functionality), and
 more.
 
-Avocado makes that possible by means of its "inner runner" feature. The
+Avocado makes that possible by means of its "external runner" feature. The
 most basic way of using it is::
 
-    $ avocado run --inner-runner=/path/to/inner_runner foo bar baz
+    $ avocado run --external-runner=/path/to/external_runner foo bar baz
 
 In this example, Avocado will report individual test results for tests
 `foo`, `bar` and `baz`. The actual results will be based on the return
-code of individual executions of `/path/to/inner_runner foo`,
-`/path/to/inner_runner bar` and finally `/path/to/inner_runner baz`.
+code of individual executions of `/path/to/external_runner foo`,
+`/path/to/external_runner bar` and finally `/path/to/external_runner baz`.
 
 As another way to explain an show how this feature works, think of the
-"inner runner" as some kind of interpreter and the individual tests as
+"external runner" as some kind of interpreter and the individual tests as
 anything that this interpreter recognizes and is able to execute. A
-UNIX shell, say `/bin/sh` could be considered an inner runner, and
+UNIX shell, say `/bin/sh` could be considered an external runner, and
 files with shell code could be considered tests::
 
     $ echo "exit 0" > /tmp/pass
     $ echo "exit 1" > /tmp/fail
-    $ avocado run --inner-runner=/bin/sh /tmp/pass /tmp/fail
+    $ avocado run --external-runner=/bin/sh /tmp/pass /tmp/fail
     JOB ID     : 4a2a1d259690cc7b226e33facdde4f628ab30741
     JOB LOG    : /home/<user>/avocado/job-results/job-<date>-<shortid>/job.log
     JOB HTML   : /home/<user>/avocado/job-results/job-<date>-<shortid>/html/results.html
@@ -499,7 +499,7 @@ them executable (`chmod +x /tmp/pass /tmp/fail)`, and running them as
 
 But now consider the following example::
 
-    $ avocado run --inner-runner=/bin/curl http://local-avocado-server:9405/jobs/ \
+    $ avocado run --external-runner=/bin/curl http://local-avocado-server:9405/jobs/ \
                                            http://remote-avocado-server:9405/jobs/
     JOB ID     : 56016a1ffffaba02492fdbd5662ac0b958f51e11
     JOB LOG    : /home/<user>/avocado/job-results/job-<date>-<shortid>/job.log
@@ -510,7 +510,7 @@ But now consider the following example::
     RESULTS    : PASS 1 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0
     TIME       : 3.04 s
 
-This effectively makes `/bin/curl` an "inner test runner", responsible for
+This effectively makes `/bin/curl` an "external test runner", responsible for
 trying to fetch those URLs, and reporting PASS or FAIL for each of them.
 
 RECORDING TEST REFERENCE OUTPUT

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -408,24 +408,24 @@ class RunnerSimpleTest(unittest.TestCase):
         shutil.rmtree(self.tmpdir)
 
 
-class InnerRunnerTest(unittest.TestCase):
+class ExternalRunnerTest(unittest.TestCase):
 
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
         self.pass_script = script.TemporaryScript(
             'pass',
             PASS_SHELL_CONTENTS,
-            'avocado_innerrunner_functional')
+            'avocado_externalrunner_functional')
         self.pass_script.save()
         self.fail_script = script.TemporaryScript(
             'fail',
             FAIL_SHELL_CONTENTS,
-            'avocado_innerrunner_functional')
+            'avocado_externalrunner_functional')
         self.fail_script.save()
 
-    def test_innerrunner_pass(self):
+    def test_externalrunner_pass(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --job-results-dir %s --sysinfo=off --inner-runner=/bin/sh %s'
+        cmd_line = './scripts/avocado run --job-results-dir %s --sysinfo=off --external-runner=/bin/sh %s'
         cmd_line %= (self.tmpdir, self.pass_script.path)
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 0
@@ -433,9 +433,9 @@ class InnerRunnerTest(unittest.TestCase):
                          "Avocado did not return rc %d:\n%s" %
                          (expected_rc, result))
 
-    def test_innerrunner_fail(self):
+    def test_externalrunner_fail(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --job-results-dir %s --sysinfo=off --inner-runner=/bin/sh %s'
+        cmd_line = './scripts/avocado run --job-results-dir %s --sysinfo=off --external-runner=/bin/sh %s'
         cmd_line %= (self.tmpdir, self.fail_script.path)
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 1
@@ -443,14 +443,14 @@ class InnerRunnerTest(unittest.TestCase):
                          "Avocado did not return rc %d:\n%s" %
                          (expected_rc, result))
 
-    def test_innerrunner_chdir_no_testdir(self):
+    def test_externalrunner_chdir_no_testdir(self):
         os.chdir(basedir)
-        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off --inner-runner=/bin/sh '
-                    '--inner-runner-chdir=test %s')
+        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off --external-runner=/bin/sh '
+                    '--external-runner-chdir=test %s')
         cmd_line %= (self.tmpdir, self.pass_script.path)
         result = process.run(cmd_line, ignore_status=True)
-        expected_output = ('Option "--inner-runner-chdir=test" requires '
-                           '"--inner-runner-testdir" to be set')
+        expected_output = ('Option "--external-runner-chdir=test" requires '
+                           '"--external-runner-testdir" to be set')
         self.assertIn(expected_output, result.stderr)
         expected_rc = 2
         self.assertEqual(result.exit_status, expected_rc,

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -245,7 +245,8 @@ class RunnerOperationTest(unittest.TestCase):
         Tests that the `latest` link to the latest job results is created early
         """
         os.chdir(basedir)
-        cmd_line = ('./scripts/avocado run --sysinfo=off --job-results-dir %s examples/tests/passtest.py' % self.tmpdir)
+        cmd_line = ('./scripts/avocado run --sysinfo=off --job-results-dir %s '
+                    'examples/tests/passtest.py' % self.tmpdir)
         avocado_process = process.SubProcess(cmd_line)
         avocado_process.start()
         link = os.path.join(self.tmpdir, 'latest')
@@ -304,7 +305,8 @@ class RunnerHumanOutputTest(unittest.TestCase):
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %d:\n%s" %
                          (expected_rc, result))
-        self.assertIn('skiponsetup.py:SkipOnSetupTest.test_wont_be_executed:  SKIP', result.stdout)
+        self.assertIn('skiponsetup.py:SkipOnSetupTest.test_wont_be_executed:'
+                      '  SKIP', result.stdout)
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir)
@@ -319,15 +321,16 @@ class RunnerSimpleTest(unittest.TestCase):
             PASS_SCRIPT_CONTENTS,
             'avocado_simpletest_functional')
         self.pass_script.save()
-        self.fail_script = script.TemporaryScript(
-            'avocado_fail.sh',
-            FAIL_SCRIPT_CONTENTS,
-            'avocado_simpletest_functional')
+        self.fail_script = script.TemporaryScript('avocado_fail.sh',
+                                                  FAIL_SCRIPT_CONTENTS,
+                                                  'avocado_simpletest_'
+                                                  'functional')
         self.fail_script.save()
 
     def test_simpletest_pass(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --job-results-dir %s --sysinfo=off %s' % (self.tmpdir, self.pass_script.path)
+        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off'
+                    ' %s' % (self.tmpdir, self.pass_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 0
         self.assertEqual(result.exit_status, expected_rc,
@@ -336,7 +339,8 @@ class RunnerSimpleTest(unittest.TestCase):
 
     def test_simpletest_fail(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --job-results-dir %s --sysinfo=off %s' % (self.tmpdir, self.fail_script.path)
+        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off'
+                    ' %s' % (self.tmpdir, self.fail_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = 1
         self.assertEqual(result.exit_status, expected_rc,
@@ -353,7 +357,8 @@ class RunnerSimpleTest(unittest.TestCase):
         """
         os.chdir(basedir)
         one_hundred = 'failtest ' * 100
-        cmd_line = './scripts/avocado run --job-results-dir %s --sysinfo=off %s' % (self.tmpdir, one_hundred)
+        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off'
+                    ' %s' % (self.tmpdir, one_hundred))
         initial_time = time.time()
         result = process.run(cmd_line, ignore_status=True)
         actual_time = time.time() - initial_time
@@ -369,7 +374,8 @@ class RunnerSimpleTest(unittest.TestCase):
         """
         os.chdir(basedir)
         sleep_fail_sleep = 'sleeptest ' + 'failtest ' * 100 + 'sleeptest'
-        cmd_line = './scripts/avocado run --job-results-dir %s --sysinfo=off %s' % (self.tmpdir, sleep_fail_sleep)
+        cmd_line = './scripts/avocado run --job-results-dir %s --sysinfo=off %s' % (
+            self.tmpdir, sleep_fail_sleep)
         initial_time = time.time()
         result = process.run(cmd_line, ignore_status=True)
         actual_time = time.time() - initial_time
@@ -602,7 +608,8 @@ class PluginsXunitTest(AbsPluginsTest, unittest.TestCase):
     def run_and_check(self, testname, e_rc, e_ntests, e_nerrors,
                       e_nnotfound, e_nfailures, e_nskip):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --job-results-dir %s --sysinfo=off --xunit - %s' % (self.tmpdir, testname)
+        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off'
+                    ' --xunit - %s' % (self.tmpdir, testname))
         result = process.run(cmd_line, ignore_status=True)
         xml_output = result.stdout
         self.assertEqual(result.exit_status, e_rc,


### PR DESCRIPTION
This pull request fixes some issues and changes the --loaders behavior to only accept test types of given plugin (file.SIMPLE vs. SIMPLE) and only correct test types (excluding MISSING, BROKEN...).

Additionally it moves the inner_runner as a separate loader plugin and renames it to external_runner.

v1: https://github.com/avocado-framework/avocado/pull/823

Changes:

    v2:  Use __func__ instead of im_func
    v2:  Fix typos and English sentences
    v2b: Take care of "allowed_test_types" for simple plugins
    v2b: Check that all extra_params were handled