### PR TITLE
Test Loader: support for enable/disable docstring tags [v1]

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -262,7 +262,7 @@ class TestLoaderProxy(object):
             f, p, d = imp.find_module(module_name, [test_module_dir])
             test_module = imp.load_module(module_name, f, p, d)
             for _, obj in inspect.getmembers(test_module):
-                if (inspect.isclass(obj) and
+                if (inspect.isclass(obj) and obj.__name__ == test_class and
                         inspect.getmodule(obj) == test_module):
                     if issubclass(obj, test.Test):
                         test_class = obj
@@ -557,6 +557,7 @@ class FileLoader(TestLoader):
             # Looking for a 'from avocado import Test'
             if (isinstance(statement, ast.ImportFrom) and
                     statement.module == 'avocado'):
+
                 for name in statement.names:
                     if name.name == 'Test':
                         test_import = True
@@ -567,7 +568,7 @@ class FileLoader(TestLoader):
                         break
 
             # Looking for a 'import avocado'
-            if isinstance(statement, ast.Import):
+            elif isinstance(statement, ast.Import):
                 for name in statement.names:
                     if name.name == 'avocado':
                         mod_import = True
@@ -576,25 +577,39 @@ class FileLoader(TestLoader):
                         else:
                             mod_import_name = name.name
 
-            # Looking for a 'class FooTest(Test):'
-            if isinstance(statement, ast.ClassDef) and test_import:
-                base_ids = [base.id for base in statement.bases]
-                if test_import_name in base_ids:
+            # Looking for a 'class Anything(anything):'
+            elif isinstance(statement, ast.ClassDef):
+                docstring = ast.get_docstring(statement)
+                # Looking for a class that has in the docstring either
+                # ":avocado: enable" or ":avocado: disable
+                if is_docstring_tag_disable(docstring):
+                    continue
+                elif is_docstring_tag_enable(docstring):
                     functions = [st.name for st in statement.body if
                                  isinstance(st, ast.FunctionDef) and
                                  st.name.startswith('test')]
                     result[statement.name] = functions
+                    continue
 
-            # Looking for a 'class FooTest(avocado.Test):'
-            if isinstance(statement, ast.ClassDef) and mod_import:
-                for base in statement.bases:
-                    module = base.value.id
-                    klass = base.attr
-                    if module == mod_import_name and klass == 'Test':
+                if test_import:
+                    base_ids = [base.id for base in statement.bases]
+                    # Looking for a 'class FooTest(Test):'
+                    if test_import_name in base_ids:
                         functions = [st.name for st in statement.body if
                                      isinstance(st, ast.FunctionDef) and
                                      st.name.startswith('test')]
                         result[statement.name] = functions
+
+                # Looking for a 'class FooTest(avocado.Test):'
+                elif mod_import:
+                    for base in statement.bases:
+                        module = base.value.id
+                        klass = base.attr
+                        if module == mod_import_name and klass == 'Test':
+                            functions = [st.name for st in statement.body if
+                                         isinstance(st, ast.FunctionDef) and
+                                         st.name.startswith('test')]
+                            result[statement.name] = functions
 
         return result
 

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -23,6 +23,7 @@ import fnmatch
 import imp
 import inspect
 import os
+import re
 import shlex
 import sys
 
@@ -37,6 +38,28 @@ from .settings import settings
 DEFAULT = False  # Show default tests (for execution)
 AVAILABLE = None  # Available tests (for listing purposes)
 ALL = True  # All tests (inicluding broken ones)
+
+
+#: Gets the tag value from a string. Used to tag a test class in various ways
+AVOCADO_DOCSTRING_TAG_RE = re.compile(r'\s*:avocado:\s*(\S+)\s*')
+
+
+def get_docstring_tag(docstring):
+    if docstring is None:
+        return None
+    result = AVOCADO_DOCSTRING_TAG_RE.search(docstring)
+    if result is not None:
+        return result.groups()[0]
+
+
+def is_docstring_tag_enable(docstring):
+    result = get_docstring_tag(docstring)
+    return result == 'enable'
+
+
+def is_docstring_tag_disable(docstring):
+    result = get_docstring_tag(docstring)
+    return result == 'disable'
 
 
 class LoaderError(Exception):

--- a/selftests/doc/test_doc_build.py
+++ b/selftests/doc/test_doc_build.py
@@ -5,7 +5,12 @@ This is geared towards documentation build regression testing.
 """
 import os
 import sys
-import unittest
+import urllib
+
+if sys.version_info[:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
 
 from avocado.utils import process
 
@@ -18,8 +23,26 @@ class DocBuildError(Exception):
     pass
 
 
+def has_no_external_connectivity():
+    """
+    Check condition for building the docs with Sphinx
+
+    Sphinx will attempt to fetch the Python objects inventory during the build
+    process. If for some reason, this test is being run on a machine that can
+    not access that address simply because of network restrictions (or the
+    developer may simply be on a plane) then it's better to SKIP the test than
+    to give a false positive.
+    """
+    try:
+        urllib.urlopen('http://docs.python.org/objects.inv')
+        return False
+    except:
+        return True
+
+
 class DocBuildTest(unittest.TestCase):
 
+    @unittest.skipIf(has_no_external_connectivity(), "No external connectivity")
     def test_build_docs(self):
         """
         Build avocado HTML docs, reporting failures
@@ -52,3 +75,7 @@ class DocBuildTest(unittest.TestCase):
             e_msg += ('Full output: %s\n' % '\n'.join(output_lines))
             e_msg += 'Please check the output and fix your docstrings/.rst docs'
             raise DocBuildError(e_msg)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -1,9 +1,14 @@
 import os
+import re
 import sys
-import unittest
 import multiprocessing
 import tempfile
 import shutil
+
+if sys.version_info[:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
 
 from avocado.core import test
 from avocado.core import exceptions
@@ -153,6 +158,33 @@ class LoaderTest(unittest.TestCase):
         self.assertEqual(len(suite), 2)
         avocado_multiple_tests.remove()
 
+
+class DocstringTagTests(unittest.TestCase):
+
+    def test_longline(self):
+        docstring = ("This is a very long docstring in a single line. "
+                     "Since we have nothing useful to put in here let's just "
+                     "mention avocado: it's awesome, but that was not a tag. "
+                     "a tag would be something line this: :avocado: enable")
+        self.assertIsNotNone(loader.get_docstring_tag(docstring))
+
+    def test_newlines(self):
+        docstring = ("\n\n\nThis is a docstring with many new\n\nlines "
+                     "followed by an avocado tag\n"
+                     "\n\n:avocado: enable\n\n")
+        self.assertIsNotNone(loader.get_docstring_tag(docstring))
+
+    def test_enabled(self):
+        self.assertTrue(loader.is_docstring_tag_enable(":avocado: enable"))
+        self.assertTrue(loader.is_docstring_tag_enable(":avocado:\tenable"))
+        self.assertFalse(loader.is_docstring_tag_enable(":AVOCADO: ENABLE"))
+        self.assertFalse(loader.is_docstring_tag_enable(":avocado: enabled"))
+
+    def test_disabled(self):
+        self.assertTrue(loader.is_docstring_tag_disable(":avocado: disable"))
+        self.assertTrue(loader.is_docstring_tag_disable(":avocado:\tdisable"))
+        self.assertFalse(loader.is_docstring_tag_disable(":AVOCADO: DISABLE"))
+        self.assertFalse(loader.is_docstring_tag_disable(":avocado: disabled"))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION



Since the test loader now attempts to find Avocado instrumented tests by using a parser and doesn't really load/execute test files, it can't tell if a given class inherits from avocado.Test.

For those cases, a developer may signal, using a docstring tag, that either:

* A test class that doesn't look like an Avocado test class is indeed one (":avocado: enable")
* A test class that looks like an Avocado test class should not be treated as such (":avocado: disable")

Also included is a a simple optimization by breaking earlier from the parser loop.

Please test these, and for v1 I'll update the diagrams and documentations.

**This is basically a PR for checking if CI likes the Python 2.6 fixes. Following up is the docs/diagram update.**

---

Changes from v0:
 * Use unittest2 on Python 2.6
 * Added fix reported by Lukáš Doktor