### PR TITLE
Mass import cleanups

### DIFF
--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -38,7 +38,6 @@ from .settings import settings
 from ..utils import path as utils_path
 from ..utils.data_structures import Borg
 
-
 _BASE_DIR = os.path.join(sys.modules[__name__].__file__, "..", "..", "..")
 _BASE_DIR = os.path.abspath(_BASE_DIR)
 _IN_TREE_TESTS_DIR = os.path.join(_BASE_DIR, 'examples', 'tests')

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -34,7 +34,6 @@ from ..utils import path
 from ..utils import stacktrace
 from .settings import settings
 
-
 DEFAULT = False  # Show default tests (for execution)
 AVAILABLE = None  # Available tests (for listing purposes)
 ALL = True  # All tests (inicluding broken ones)

--- a/avocado/core/multiplexer.py
+++ b/avocado/core/multiplexer.py
@@ -26,7 +26,6 @@ import re
 
 from . import tree
 
-
 MULTIPLEX_CAPABLE = tree.MULTIPLEX_CAPABLE
 
 

--- a/avocado/core/plugins/builtin.py
+++ b/avocado/core/plugins/builtin.py
@@ -23,7 +23,6 @@ from .plugin import Plugin
 from ..settings import settings
 from ...utils import stacktrace
 
-
 log = logging.getLogger("avocado.app")
 
 __all__ = ['load_builtins']

--- a/avocado/core/plugins/htmlresult.py
+++ b/avocado/core/plugins/htmlresult.py
@@ -20,8 +20,9 @@ import shutil
 import sys
 import time
 import subprocess
-import pystache
 import urllib
+
+import pystache
 
 from . import plugin
 from .. import exit_codes

--- a/avocado/core/plugins/journal.py
+++ b/avocado/core/plugins/journal.py
@@ -21,7 +21,6 @@ import datetime
 from . import plugin
 from ..result import TestResult
 
-
 JOURNAL_FILENAME = ".journal.sqlite"
 
 SCHEMA = {'job_info': 'CREATE TABLE job_info (unique_id TEXT UNIQUE)',

--- a/avocado/core/remote/runner.py
+++ b/avocado/core/remote/runner.py
@@ -19,6 +19,8 @@ import os
 import re
 import logging
 
+from fabric.exceptions import CommandTimeout
+
 from .test import RemoteTest
 from .. import output
 from .. import exceptions
@@ -26,7 +28,6 @@ from .. import status
 from ..runner import TestRunner
 from ...utils import archive
 from ...utils import stacktrace
-from fabric.exceptions import CommandTimeout
 
 
 class RemoteTestRunner(TestRunner):

--- a/avocado/core/remoter.py
+++ b/avocado/core/remoter.py
@@ -20,9 +20,7 @@ import getpass
 import logging
 import time
 
-from . import output
 from ..utils import process
-
 
 LOG = logging.getLogger('avocado.test')
 

--- a/avocado/core/restclient/cli/app.py
+++ b/avocado/core/restclient/cli/app.py
@@ -16,18 +16,14 @@
 This is the main entry point for the rest client cli application
 """
 
-
 import sys
 import types
 import importlib
-import functools
 
 from . import parser
 from .. import connection
-from ... import settings
 from ... import output
 from ... import exit_codes
-
 
 __all__ = ['App']
 

--- a/avocado/core/settings.py
+++ b/avocado/core/settings.py
@@ -23,7 +23,6 @@ import glob
 
 from ..utils import path
 
-
 if 'VIRTUAL_ENV' in os.environ:
     CFG_DIR = os.path.join(os.environ['VIRTUAL_ENV'], 'etc')
 else:

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -38,7 +38,6 @@ from ..utils import process
 from ..utils import stacktrace
 from .version import VERSION
 
-
 if sys.version_info[:2] == (2, 6):
     import unittest2 as unittest
 else:

--- a/avocado/utils/download.py
+++ b/avocado/utils/download.py
@@ -27,7 +27,6 @@ from . import aurl
 from . import output
 from . import crypto
 
-
 log = logging.getLogger('avocado.test')
 
 

--- a/avocado/utils/genio.py
+++ b/avocado/utils/genio.py
@@ -22,7 +22,6 @@ import time
 
 from . import path as utils_path
 
-
 log = logging.getLogger('avocado.test')
 
 

--- a/avocado/utils/git.py
+++ b/avocado/utils/git.py
@@ -23,7 +23,6 @@ from . import process
 from . import astring
 from . import path
 
-
 __all__ = ["GitRepoHelper", "get_repo"]
 
 

--- a/avocado/utils/iso9660.py
+++ b/avocado/utils/iso9660.py
@@ -23,7 +23,6 @@ either in userspace tools or on the Linux kernel itself (via mount).
 
 __all__ = ['iso9660', 'Iso9660IsoInfo', 'Iso9660IsoRead', 'Iso9660Mount']
 
-
 import os
 import logging
 import tempfile

--- a/avocado/utils/kernel_build.py
+++ b/avocado/utils/kernel_build.py
@@ -21,7 +21,6 @@ import tempfile
 
 from . import download, archive, build
 
-
 log = logging.getLogger('avocado.test')
 
 

--- a/avocado/utils/linux_modules.py
+++ b/avocado/utils/linux_modules.py
@@ -20,6 +20,7 @@ APIs to list and load/unload linux kernel modules.
 
 import re
 import logging
+
 from . import process
 
 LOG = logging.getLogger('avocado.test')

--- a/avocado/utils/path.py
+++ b/avocado/utils/path.py
@@ -21,7 +21,6 @@ import stat
 
 from . import aurl
 
-
 PY_EXTENSIONS = ['.py']
 SHEBANG = '#!'
 

--- a/examples/tests/linuxbuild.py
+++ b/examples/tests/linuxbuild.py
@@ -1,8 +1,5 @@
 #!/usr/bin/python
 
-import shutil
-import tempfile
-
 from avocado import Test
 from avocado import main
 from avocado.utils import kernel_build

--- a/examples/tests/vm-cleanup.py
+++ b/examples/tests/vm-cleanup.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import shutil
 import tempfile
 

--- a/scripts/avocado-run-testplan
+++ b/scripts/avocado-run-testplan
@@ -14,7 +14,6 @@
 # Author: Cleber Rosa <cleber@redhat.com>
 
 
-import os
 import sys
 import json
 import getpass

--- a/selftests/functional/test_export_variables.py
+++ b/selftests/functional/test_export_variables.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import unittest
 import tempfile
 import shutil
@@ -7,7 +6,6 @@ import shutil
 from avocado import VERSION
 from avocado.utils import process
 from avocado.utils import script
-
 
 basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..')
 basedir = os.path.abspath(basedir)

--- a/selftests/functional/test_gdb.py
+++ b/selftests/functional/test_gdb.py
@@ -1,11 +1,9 @@
 import os
-import sys
 import unittest
 import shutil
 import tempfile
 
 from avocado.utils import process
-
 
 basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..')
 basedir = os.path.abspath(basedir)

--- a/selftests/functional/test_journal.py
+++ b/selftests/functional/test_journal.py
@@ -1,13 +1,11 @@
 import unittest
 import os
-import sys
 import json
 import sqlite3
 import tempfile
 import shutil
 
 from avocado.utils import process
-
 
 basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..')
 basedir = os.path.abspath(basedir)

--- a/selftests/functional/test_wrapper.py
+++ b/selftests/functional/test_wrapper.py
@@ -1,12 +1,10 @@
 import os
-import sys
 import unittest
 import tempfile
 import shutil
 
 from avocado.utils import process
 from avocado.utils import script
-
 
 basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..')
 basedir = os.path.abspath(basedir)

--- a/selftests/unit/test_archive.py
+++ b/selftests/unit/test_archive.py
@@ -1,7 +1,6 @@
 import unittest
 import tempfile
 import os
-import sys
 import shutil
 import random
 

--- a/selftests/unit/test_astring.py
+++ b/selftests/unit/test_astring.py
@@ -1,6 +1,4 @@
 import unittest
-import os
-import sys
 
 from avocado.utils import astring
 

--- a/selftests/unit/test_datadir.py
+++ b/selftests/unit/test_datadir.py
@@ -1,6 +1,5 @@
 import unittest
 import os
-import sys
 import shutil
 import tempfile
 

--- a/selftests/unit/test_distro.py
+++ b/selftests/unit/test_distro.py
@@ -1,6 +1,5 @@
 import os
 import re
-import sys
 import unittest
 
 from flexmock import flexmock

--- a/selftests/unit/test_gdb.py
+++ b/selftests/unit/test_gdb.py
@@ -1,5 +1,3 @@
-import os
-import sys
 import unittest
 
 from avocado.utils import gdb

--- a/selftests/unit/test_jsonresult.py
+++ b/selftests/unit/test_jsonresult.py
@@ -1,6 +1,5 @@
 import unittest
 import os
-import sys
 import json
 import argparse
 import tempfile

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -1,9 +1,5 @@
-import os
-import re
 import sys
 import multiprocessing
-import tempfile
-import shutil
 
 if sys.version_info[:2] == (2, 6):
     import unittest2 as unittest

--- a/selftests/unit/test_plugins.py
+++ b/selftests/unit/test_plugins.py
@@ -1,5 +1,3 @@
-import sys
-import os
 import unittest
 
 from avocado.core.plugins import plugin

--- a/selftests/unit/test_remote.py
+++ b/selftests/unit/test_remote.py
@@ -5,11 +5,9 @@ import os
 
 from flexmock import flexmock, flexmock_teardown
 
-from avocado.core import data_dir
 from avocado.core import remote
 from avocado.core import remoter
 from avocado.utils import archive
-
 
 cwd = os.getcwd()
 

--- a/selftests/unit/test_restclient_response.py
+++ b/selftests/unit/test_restclient_response.py
@@ -1,5 +1,3 @@
-import os
-import sys
 import unittest
 
 from avocado.core.restclient import response

--- a/selftests/unit/test_utils_linux_modules.py
+++ b/selftests/unit/test_utils_linux_modules.py
@@ -1,6 +1,4 @@
 import unittest
-import os
-import sys
 
 from avocado.utils import linux_modules
 

--- a/selftests/unit/test_utils_output.py
+++ b/selftests/unit/test_utils_output.py
@@ -1,6 +1,4 @@
 import unittest
-import os
-import sys
 
 from avocado.utils import output
 

--- a/selftests/unit/test_utils_service.py
+++ b/selftests/unit/test_utils_service.py
@@ -17,6 +17,7 @@
 #  the file called "COPYING".
 
 import unittest
+
 from mock import MagicMock, patch
 
 from avocado.utils import service

--- a/selftests/unit/test_vm.py
+++ b/selftests/unit/test_vm.py
@@ -9,7 +9,6 @@ from avocado.core.remote import VMTestResult
 from avocado.core.remote import RemoteTestResult
 from avocado.core import virt
 
-
 JSON_RESULTS = ('Something other than json\n'
                 '{"tests": [{"test": "sleeptest.1", "url": "sleeptest", '
                 '"status": "PASS", "time": 1.23, "start": 0, "end": 1.23}],'

--- a/selftests/unit/test_xunit.py
+++ b/selftests/unit/test_xunit.py
@@ -1,7 +1,6 @@
 import argparse
 import unittest
 import os
-import sys
 from xml.dom import minidom
 import tempfile
 import shutil


### PR DESCRIPTION
This is an automated mass import cleanup across all
avocado source files:

1) Imports follow the order:
 * Standard library imports
 * Non standard library external imports
 * Internal imports
 All separated by a single line

2) One line between imports and the rest of the code

3) Remove unused imports in the process

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>