### PR TITLE
Temporary dirs: respect TMPDIR environment variable

### DIFF
--- a/avocado/utils/data_factory.py
+++ b/avocado/utils/data_factory.py
@@ -57,7 +57,7 @@ def generate_random_string(length, ignore=string.punctuation,
     return result
 
 
-def make_dir_and_populate(basedir='/tmp'):
+def make_dir_and_populate(basedir=None):
     """
     Create a directory in basedir and populate with a number of files.
 
@@ -68,6 +68,8 @@ def make_dir_and_populate(basedir='/tmp'):
     :return: Path of the dir created and populated.
     :rtype: str
     """
+    if basedir is None:
+        basedir = os.environ.get('TMPDIR', '/var/tmp')
     try:
         path = tempfile.mkdtemp(prefix='avocado_' + __name__,
                                 dir=basedir)

--- a/avocado/utils/git.py
+++ b/avocado/utils/git.py
@@ -18,6 +18,7 @@ APIs to download/update git repositories from inside python scripts.
 
 import os
 import logging
+import tempfile
 
 from . import process
 from . import astring
@@ -58,7 +59,9 @@ class GitRepoHelper(object):
 
         if destination_dir is None:
             uri_basename = uri.split("/")[-1]
-            self.destination_dir = os.path.join("/tmp", uri_basename)
+            prefix = 'avocado_%s_%s_' % (__name__, uri_basename)
+            base_dir = os.environ.get('TMPDIR', '/var/tmp')
+            self.destination_dir = tempfile.mkdtemp(prefix=prefix, dir=base_dir)
         else:
             self.destination_dir = destination_dir
         if lbranch is None:


### PR DESCRIPTION
Some of our APIs still create temporary directories without respecting
the TMPDIR environment variable.

Let's fix the remaining occurrences, following the same logigc that
has been applied to `avocado.core.data_dir.get_tmp_dir()`.

Signed-off-by: Cleber Rosa <crosa@redhat.com>