### PR TITLE
avocado.core.loader: Return empty list instead of None:

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -801,7 +801,7 @@ class ExternalLoader(TestLoader):
         :return: list of matching tests
         """
         if not self._external_runner:
-            return None
+            return []
         return [(test.ExternalRunnerTest, {'name': url, 'params': {'id': url},
                                            'external_runner': self._external_runner})]
 


### PR DESCRIPTION
The plugin's discover() method should always return a
list of tests, and not None, since the discover() method
in TestLoaderProxy uses .extend(), that only works with
an iterable. This fixes the issue found when running
`avocado list` (no arguments passed to list):

Test discovery plugin <avocado.core.loader.ExternalLoader object at 0x7f5b42978850> failed: 'NoneType' object is not iterable

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>