### PR TITLE
Makefile: Use mock to build RPMs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,24 @@
-PYTHON=`which python`
+#
+# NOTE: to build Avocado RPM packages extra deps not present out of the box
+# are necessary. These packages are currently hosted at:
+# https://copr.fedoraproject.org/coprs/lmr/Autotest/
+#
+# Since the RPM build steps are based on mock, edit your chroot config
+# file (/etc/mock/<your-config>.cnf) and add the COPR repo configuration there.
+#
+
+PYTHON=$(shell which python)
+VERSION=$(shell $(PYTHON) $(CURDIR)/avocado/core/version.py)
 DESTDIR=/
 BUILDIR=$(CURDIR)/debian/avocado
 PROJECT=avocado
-VERSION=`$(CURDIR)/avocado/core/version.py`
 AVOCADO_DIRNAME=$(shell echo $${PWD\#\#*/})
 AVOCADO_PLUGINS=$(filter-out ../$(AVOCADO_DIRNAME), $(wildcard ../*))
+RELEASE_COMMIT=$(shell git log --pretty=format:'%H' -n 1 $(VERSION))
+RELEASE_SHORT_COMMIT=$(shell git log --pretty=format:'%h' -n 1 $(VERSION))
+
+COMMIT=$(shell git log --pretty=format:'%H' -n 1)
+SHORT_COMMIT=$(shell git log --pretty=format:'%h' -n 1)
 
 all:
 	@echo "make source - Create source package"
@@ -12,15 +26,23 @@ all:
 	@echo "make build-deb-src - Generate a source debian package"
 	@echo "make build-deb-bin - Generate a binary debian package"
 	@echo "make build-deb-all - Generate both source and binary debian packages"
-	@echo "make build-rpm-src - Generate a source RPM package (.srpm)"
-	@echo "make build-rpm-all - Generate both source and binary RPMs"
+	@echo "make srpm - Generate a source RPM package (.srpm)"
+	@echo "make rpm  - Generate binary RPMs"
 	@echo "make man - Generate the avocado man page"
 	@echo "make check - Runs tree static check, unittests and functional tests"
 	@echo "make clean - Get rid of scratch and byte files"
+	@echo "Release related targets:"
+	@echo "make source-release - Create source package for the latest tagged release"
+	@echo "make srpm-release - Generate a source RPM package (.srpm) for the latest tagged release"
+	@echo "make rpm-release  - Generate binary RPMs for the latest tagged release"
 
-source:
+source: clean
 	if test ! -d SOURCES; then mkdir SOURCES; fi
-	git archive --prefix="avocado-$(VERSION)/" -o "SOURCES/avocado-$(VERSION).tar.gz" HEAD
+	git archive --prefix="avocado-$(COMMIT)/" -o "SOURCES/avocado-$(VERSION)-$(SHORT_COMMIT).tar.gz" HEAD
+
+source-release: clean
+	if test ! -d SOURCES; then mkdir SOURCES; fi
+	git archive --prefix="avocado-$(RELEASE_COMMIT)/" -o "SOURCES/avocado-$(VERSION)-$(RELEASE_SHORT_COMMIT).tar.gz" $(VERSION)
 
 install:
 	$(PYTHON) setup.py install --root $(DESTDIR) $(COMPILE)
@@ -44,13 +66,21 @@ build-deb-all: prepare-source
 	# build both source and binary packages
 	dpkg-buildpackage -i -I -rfakeroot
 
-build-rpm-src: source
-	rpmbuild --define '_topdir %{getenv:PWD}' \
-		 -bs avocado.spec
+srpm: source
+	if test ! -d BUILD/SRPM; then mkdir -p BUILD/SRPM; fi
+	mock --resultdir BUILD/SRPM -D "commit $(COMMIT)" --buildsrpm --spec avocado.spec --sources SOURCES
 
-build-rpm-all: source
-	rpmbuild --define '_topdir %{getenv:PWD}' \
-		 -ba avocado.spec
+rpm: srpm
+	if test ! -d BUILD/RPM; then mkdir -p BUILD/RPM; fi
+	mock --resultdir BUILD/RPM -D "commit $(COMMIT)" --rebuild BUILD/SRPM/avocado-$(VERSION)-*.src.rpm
+
+srpm-release: source-release
+	if test ! -d BUILD/SRPM; then mkdir -p BUILD/SRPM; fi
+	mock --resultdir BUILD/SRPM -D "commit $(RELEASE_COMMIT)" --buildsrpm --spec avocado.spec --sources SOURCES
+
+rpm-release: srpm-release
+	if test ! -d BUILD/RPM; then mkdir -p BUILD/RPM; fi
+	mock --resultdir BUILD/RPM -D "commit $(RELEASE_COMMIT)" --rebuild BUILD/SRPM/avocado-$(VERSION)-*.src.rpm
 
 clean:
 	$(PYTHON) setup.py clean

--- a/avocado.spec
+++ b/avocado.spec
@@ -1,3 +1,9 @@
+%global modulename avocado
+%if ! 0%{?commit:1}
+ %define commit 4cfe3872bc104151c57928577f6deea501def8a4
+%endif
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+
 Summary: Avocado Test Framework
 Name: avocado
 Version: 0.29.0
@@ -5,7 +11,7 @@ Release: 2%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.github.io/
-Source: avocado-%{version}.tar.gz
+Source0: https://github.com/avocado-framework/%{name}/archive/%{commit}/%{name}-%{version}-%{shortcommit}.tar.gz
 BuildArch: noarch
 Requires: python, python-requests, fabric, pyliblzma, libvirt-python, pystache, gdb, gdb-gdbserver
 BuildRequires: python2-devel, python-setuptools, python-docutils, python-mock, python-psutil, python-sphinx, python-requests, aexpect, pystache, yum
@@ -29,7 +35,7 @@ Avocado is a set of tools and libraries (what people call
 these days a framework) to perform automated testing.
 
 %prep
-%setup -q
+%setup -q -n %{name}-%{commit}
 
 %build
 %{__python} setup.py build


### PR DESCRIPTION
Instead of trusting in rpmbuild to do the rpm builds,
use mock - a program that builds the rpms from fresh
chroots. This ensures that BuildRequires are correct
and that the binary rpms build cleanly.

This requires a few changes to the Makefile targets
and the avocado spec file, laid out in this patch.

Also, add instructions on how to fulfill deps to build
RPM packages.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>
Signed-off-by: Cleber Rosa <crosa@redhat.com>