### PR TITLE
avocado/core/data_dir.py: rely on `tempfile.mkstemp()` to choose a te…

### DIFF
--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -59,8 +59,6 @@ USER_TEST_DIR = os.path.join(USER_BASE_DIR, 'tests')
 USER_DATA_DIR = os.path.join(USER_BASE_DIR, 'data')
 USER_LOG_DIR = os.path.join(USER_BASE_DIR, 'job-results')
 
-BASE_TMP_DIR = os.environ.get('TMPDIR', '/var/tmp')
-
 
 def _usable_rw_dir(directory):
     """
@@ -244,7 +242,7 @@ class _TmpDirTracker(Borg):
 
     def get(self):
         if not hasattr(self, 'tmp_dir'):
-            self.tmp_dir = tempfile.mkdtemp(prefix='avocado_', dir=BASE_TMP_DIR)
+            self.tmp_dir = tempfile.mkdtemp(prefix='avocado_')
         return self.tmp_dir
 
     def __del__(self):

--- a/selftests/check_tmp_dirs
+++ b/selftests/check_tmp_dirs
@@ -2,6 +2,7 @@
 
 import os
 import sys
+import tempfile
 
 # simple magic for using scripts within a source tree
 basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -14,7 +15,7 @@ from avocado.core import data_dir
 
 
 def check_tmp_dirs():
-    dirs_to_check = ['/tmp', data_dir.BASE_TMP_DIR]
+    dirs_to_check = [tempfile.gettempdir()]
     fail = False
     for dir_to_check in dirs_to_check:
         dir_list = os.listdir(dir_to_check)


### PR DESCRIPTION
…mp dir

From the Python `tempfile.mkstemp()` docs:

The default directory is chosen from a platform-dependent list, but
the user of the application can control the directory location by
setting the TMPDIR, TEMP or TMP environment variables.

So, let's let `tempfile.mkstemp()` itself choose the temp dir, based
on what the use may have set in environment variables.

Signed-off-by: Cleber Rosa <crosa@redhat.com>