### PR TITLE
Loader make unittests run

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -618,7 +618,6 @@ class FileLoader(TestLoader):
                             test_name=None):
         if test_name is None:
             test_name = test_path
-        module_name = os.path.basename(test_path).split('.')[0]
         try:
             tests = self._find_avocado_tests(test_path)
             if tests:
@@ -642,29 +641,6 @@ class FileLoader(TestLoader):
                     # Module does not have an avocado test class inside, and
                     # it's not executable. Not a Test.
                     return make_broken(test.NotATest, test_path)
-
-                # Module is importable and does have an avocado test class
-                # inside, let's proceed.
-                if self._is_unittests_like(test_class):
-                    test_factories = []
-                    test_parameters = {'name': test_name}
-                    if subtests_filter:
-                        test_parameters['params'] = {'filter': subtests_filter}
-                    for test_method in self._make_unittests_like(test_class):
-                        name = test_name + ':%s.%s' % (test_class.__name__,
-                                                       test_method[0])
-                        if (subtests_filter is not None and
-                                not fnmatch.fnmatch(test_method[0],
-                                                    subtests_filter)):
-                            test_factories.extend(make_broken(FilteredOut,
-                                                              name))
-                        else:
-                            tst = (test_class, {'name': name,
-                                                'methodName': test_method[0]})
-                            test_factories.append(tst)
-                    return test_factories
-                else:
-                    return self._make_test(test_class, test_name)
 
         # Since a lot of things can happen here, the broad exception is
         # justified. The user will get it unadulterated anyway, and avocado

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -595,6 +595,10 @@ class SimpleTest(Test):
             else:
                 command = pipes.quote(self.path)
 
+            p_analyzer = utils_path.PathInspector(self.path)
+            if p_analyzer.is_python() and not p_analyzer.has_exec_permission():
+                command = '%s %s' % (utils_path.find_command('python'), command)
+
             # process.run uses shlex.split(), the self.path needs to be escaped
             result = process.run(command, verbose=True,
                                  env=test_params)

--- a/selftests/functional/test_loader.py
+++ b/selftests/functional/test_loader.py
@@ -16,6 +16,16 @@ from avocado.utils import process
 basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..')
 basedir = os.path.abspath(basedir)
 
+PYTHON_UNITTEST = """#!/usr/bin/python
+import unittest
+
+class PassTest(unittest.TestCase):
+    def test(self):
+        pass
+
+if __name__ == "__main__":
+    unittest.main()
+"""
 
 AVOCADO_TEST_OK = """#!/usr/bin/python
 from avocado import Test
@@ -107,6 +117,9 @@ class LoaderTestFunctional(unittest.TestCase):
 
     def test_simple_not_exec(self):
         self._test('simpletest.sh', SIMPLE_TEST, 'NOT_A_TEST')
+
+    def test_unittest_not_exec(self):
+        self._test('my_unittest.py', PYTHON_UNITTEST, 'SIMPLE')
 
     def test_pass(self):
         self._test('passtest.py', AVOCADO_TEST_OK, 'INSTRUMENTED')

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -58,6 +58,17 @@ SIMPLE_TEST = """#!/bin/sh
 true
 """
 
+PYTHON_UNIT_TEST = """import unittest
+
+class MultipleMethods(unittest.TestCase):
+    def test_one(self):
+        pass
+    def testTwo(self):
+        pass
+    def foo(self):
+        pass
+"""
+
 AVOCADO_MULTIPLE_TESTS = """from avocado import Test
 
 class MultipleMethods(Test):
@@ -156,6 +167,17 @@ class LoaderTest(unittest.TestCase):
             self.loader.discover(avocado_pass_test.path, True)[0])
         self.assertTrue(test_class == 'PassTest', test_class)
         avocado_pass_test.remove()
+
+    def test_load_unittest(self):
+        my_unittest = script.TemporaryScript('myunittest.py',
+                                             PYTHON_UNIT_TEST,
+                                             'avocado_loader_unittest',
+                                             mode=0664)
+        my_unittest.save()
+        test_class, test_parameters = (
+            self.loader.discover(my_unittest.path, True)[0])
+        self.assertTrue(test_class == test.SimpleTest, test_class)
+        my_unittest.remove()
 
     def test_load_not_a_test(self):
         avocado_not_a_test = script.TemporaryScript('notatest.py',


### PR DESCRIPTION
Proposed solution for the card:

https://trello.com/c/GwjMV3l7/455-bug-avocado-can-t-run-python-unittests-that-have-no-exec-permission