### PR TITLE
sysinfo: Replace "dmesg -c" with non-destructive alternative [v2]

### DIFF
--- a/etc/avocado/sysinfo/commands
+++ b/etc/avocado/sysinfo/commands
@@ -1,5 +1,4 @@
 df -mP
-dmesg -c
 uname -a
 lspci -vvnn
 gcc --version


### PR DESCRIPTION
"dmesg -c" cleans previous output, which:

1. requires root
2. is not nice for later usage of the machine
3. does not work for multiple simultaneous executions

This uses a python class, which stores only the output between it's
initialization and collection. It's not perfect, but, as we don't
support any way of passing arguments between pre and post hooks, is
usable.

v1: https://github.com/avocado-framework/avocado/pull/838

Changes:

    v2: Generic implementation of CmdDiffStore rather than dmesg specific class
    v2: Use Popen instead of check_output (which is not in python 2.6)