### PR TITLE
Hide tracebacks on fatal crashes and improve exception handling in runner

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -519,11 +519,11 @@ class Job(object):
         except exceptions.JobBaseException, details:
             self.status = details.status
             fail_class = details.__class__.__name__
-            self.view.notify(event='error', msg=('Avocado job failed: %s: %s' %
-                                                 (fail_class, details)))
+            self.view.notify(event='error', msg=('\nAvocado job failed: %s: %s'
+                                                 % (fail_class, details)))
             return exit_codes.AVOCADO_JOB_FAIL
         except exceptions.OptionValidationError, details:
-            self.view.notify(event='error', msg=str(details))
+            self.view.notify(event='error', msg='\n' + str(details))
             return exit_codes.AVOCADO_JOB_FAIL
 
         except Exception, details:
@@ -532,7 +532,7 @@ class Job(object):
             tb_info = traceback.format_exception(exc_type, exc_value,
                                                  exc_traceback.tb_next)
             fail_class = details.__class__.__name__
-            self.view.notify(event='error', msg=('Avocado crashed: %s: %s' %
+            self.view.notify(event='error', msg=('\nAvocado crashed: %s: %s' %
                                                  (fail_class, details)))
             for line in tb_info:
                 self.view.notify(event='minor', msg=line)

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -148,11 +148,9 @@ class TestRunner(object):
         early_state = queue.get()
 
         if 'load_exception' in early_state:
-            self.job.view.notify(event='error',
-                                 msg='Avocado crashed during test load. '
-                                     'Some reports might have not been '
-                                     'generated. Aborting...')
-            sys.exit(exit_codes.AVOCADO_FAIL)
+            raise exceptions.TestError('Avocado crashed during test load. '
+                                       'Some reports might have not been '
+                                       'generated. Aborting...')
 
         # At this point, the test is already initialized and we know
         # for sure if there's a timeout set.

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -140,6 +140,11 @@ class TestRunner(object):
 
         proc.start()
 
+        while queue.empty():
+            if not proc.is_alive() and queue.empty():
+                raise exceptions.TestError("Process died before it pushed "
+                                           "early state.")
+            time.sleep(0)
         early_state = queue.get()
 
         if 'load_exception' in early_state:

--- a/scripts/avocado
+++ b/scripts/avocado
@@ -14,8 +14,56 @@
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
 
-import os
 import sys
+try:
+    import logging
+    import os
+    import tempfile
+    import traceback
+except:
+    sys.stderr.write("Unable to import basic python libraries, please "
+                     "reinstall avocado and dependencies.\n")
+    sys.exit(3)
+
+
+def handle_exception(*exc_info):
+    # Print traceback into avocado.app.traceback if initialized
+    msg = "Avocado crashed:\n" + "".join(traceback.format_exception(*exc_info))
+    log = logging.getLogger("avocado.app.tracebacks")
+    if getattr(log, "handlers", False):
+        log.error(msg)
+    # Store traceback in data_dir or TMPDIR
+    avocado_data = None
+    prefix = "avocado-traceback-"
+    try:
+        import time
+        prefix += time.strftime("%F_%T") + "-"
+        from avocado.core import data_dir
+        avocado_data = data_dir.get_data_dir()
+    except:
+        pass
+    tmp, name = tempfile.mkstemp(".log", prefix, avocado_data)
+    os.write(tmp, msg)
+    os.close(tmp)
+    # Print friendly message in console-like output
+    msg = ("Avocado crashed unexpectidly: %s\nYou can find details in %s"
+           % (exc_info[1], name))
+    for name in ("avocado.app", "avocado.test", None):
+        log = logging.getLogger(name)
+        for handler in getattr(log, "handlers", []):
+            if isinstance(handler, logging.StreamHandler):
+                break
+        else:
+            continue
+        log.critical(msg)
+        break
+    else:       # Log not found, use stderr and hope it's enabled
+        sys.stderr.write(msg + '\n')
+    sys.exit(3)
+
+if __name__ == '__main__':
+    sys.excepthook = handle_exception
+
 
 # simple magic for using scripts within a source tree
 basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))


### PR DESCRIPTION
The first commit uses `sys.excepthook` to handle fatal exceptions and tries to notify user in whatever log output is available and ready.

The later two commits fix a possible hang and improve the exception handling in the `avocado.core.runner`.