### PR TITLE
avocado.core.loader: Support discovery of SimpleTests with params

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -24,6 +24,7 @@ import imp
 import inspect
 import os
 import re
+import pipes
 import shlex
 import sys
 
@@ -717,7 +718,8 @@ class FileLoader(TestLoader):
                                                 subtests_filter)
             else:
                 if os.access(test_path, os.X_OK):
-                    return self._make_test(test.SimpleTest, test_path)
+                    return self._make_test(test.SimpleTest,
+                                           pipes.quote(test_path))
                 else:
                     return make_broken(test.NotATest, test_path)
         else:

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -490,6 +490,11 @@ class FileLoader(TestLoader):
                 subtests_filter = _subtests_filter
 
         if not os.path.isdir(url):  # Single file
+            if not self._make_tests(url, DEFAULT, subtests_filter):
+                split_url = shlex.split(url)
+                if (os.access(split_url[0], os.X_OK) and
+                        not os.path.isdir(split_url[0])):
+                    return self._make_test(test.SimpleTest, url)
             return self._make_tests(url, list_tests, subtests_filter)
 
         tests = []

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -582,7 +582,7 @@ class SimpleTest(Test):
         self.log.info("Exit status: %s", result.exit_status)
         self.log.info("Duration: %s", result.duration)
 
-    def test(self, override_command=None):
+    def test(self):
         """
         Run the executable, and log its detailed execution.
         """
@@ -590,13 +590,8 @@ class SimpleTest(Test):
             test_params = dict([(str(key), str(val)) for key, val in
                                 self.params.iteritems()])
 
-            if override_command is not None:
-                command = override_command
-            else:
-                command = pipes.quote(self.path)
-
             # process.run uses shlex.split(), the self.path needs to be escaped
-            result = process.run(command, verbose=True,
+            result = process.run(self.path, verbose=True,
                                  env=test_params)
 
             self._log_detailed_cmd_info(result)
@@ -620,6 +615,7 @@ class ExternalRunnerTest(SimpleTest):
         self.assertIsNotNone(external_runner, "External runner test requires "
                              "external_runner parameter, got None instead.")
         self.external_runner = external_runner
+        name = external_runner.runner + " " + name
         super(ExternalRunnerTest, self).__init__(name, params, base_logdir,
                                                  tag, job)
 
@@ -643,9 +639,7 @@ class ExternalRunnerTest(SimpleTest):
                                new_cwd)
                 os.chdir(new_cwd)
 
-            command = "%s %s" % (self.external_runner.runner, self.path)
-
-            return super(ExternalRunnerTest, self).test(command)
+            return super(ExternalRunnerTest, self).test()
         finally:
             if new_cwd is not None:
                 os.chdir(pre_cwd)

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -343,6 +343,11 @@ class SubProcess(object):
         while True:
             tmp = os.read(fileno, 1024)
             if tmp == '':
+                if self.verbose and bfr:
+                    for line in bfr.splitlines():
+                        log.debug(prefix, line)
+                        if stream_logger is not None:
+                            stream_logger.debug(stream_prefix, line)
                 break
             lock.acquire()
             try:
@@ -350,10 +355,10 @@ class SubProcess(object):
                 if self.verbose:
                     bfr += tmp
                     if tmp.endswith('\n'):
-                        for l in bfr.splitlines():
-                            log.debug(prefix, l)
+                        for line in bfr.splitlines():
+                            log.debug(prefix, line)
                             if stream_logger is not None:
-                                stream_logger.debug(stream_prefix, l)
+                                stream_logger.debug(stream_prefix, line)
                         bfr = ''
             finally:
                 lock.release()


### PR DESCRIPTION
Hello guys, this PR refactors the SimpleTest a bit and then adds support to run SimpleTests with params. Additionally I found out a nasty bug in our SubProcess which dropped output which was not terminated with '\n'. To test this you can use: `avocado run "/bin/echo -ne 'First\tline\nSecond\tline'" /bin/true "/bin/ls -al /" "/bin/rm -rf /" --show-job-log`

PS: Don't run the above command on older distributions :wink: