### PR TITLE
Use pure git URL for users getting started with Avocado

### DIFF
--- a/docs/source/GetStartedGuide.rst
+++ b/docs/source/GetStartedGuide.rst
@@ -50,7 +50,7 @@ your platform::
 
 Then to install Avocado from the git repository run::
 
-    git clone git@github.com:avocado-framework/avocado.git
+    git clone git://github.com/avocado-framework/avocado.git
     cd avocado
     sudo pip install -r requirements.txt
     sudo python setup.py install


### PR DESCRIPTION
The other URL, which denotes git+ssh, requires the user to acknowledge
host SSH keys and so forth. Let's keep things simple.

Signed-off-by: Cleber Rosa <crosa@redhat.com>