### PR TITLE
Plugins: remove external plugin support

### DIFF
--- a/avocado/core/app.py
+++ b/avocado/core/app.py
@@ -29,17 +29,16 @@ class AvocadoApp(object):
     Avocado application.
     """
 
-    def __init__(self, external_plugins=None):
+    def __init__(self):
 
         # Catch all libc runtime errors to STDERR
         os.environ['LIBC_FATAL_STDERR_'] = '1'
 
         configure()
-        self.external_plugins = external_plugins
         self.plugin_manager = None
         self.parser = Parser()
         self.parser.start()
-        self.load_plugin_manager(self.parser.args.plugins_dir)
+        self.load_plugin_manager()
         self.ready = True
         try:
             self.parser.resume()
@@ -48,15 +47,13 @@ class AvocadoApp(object):
         except IOError:
             self.ready = False
 
-    def load_plugin_manager(self, plugins_dir):
+    def load_plugin_manager(self):
         """Load Plugin Manager.
 
         :param plugins_dir: Extra plugins directory.
         """
         self.plugin_manager = get_plugin_manager()
-        self.plugin_manager.load_plugins(plugins_dir)
-        if self.external_plugins:
-            self.plugin_manager.add_plugins(self.external_plugins)
+        self.plugin_manager.load_plugins()
         self.plugin_manager.configure(self.parser)
 
     def run(self):

--- a/avocado/core/parser.py
+++ b/avocado/core/parser.py
@@ -43,9 +43,6 @@ class Parser(object):
             description=DESCRIPTION)
         self.application.add_argument('-v', '--version', action='version',
                                       version='Avocado %s' % VERSION)
-        self.application.add_argument('--plugins', action='store',
-                                      help='Load extra plugins from directory',
-                                      dest='plugins_dir', default='')
         self.application.add_argument('--config', metavar='CONFIG_FILE',
                                       help='Use custom configuration from a file')
 

--- a/docs/source/Plugins.rst
+++ b/docs/source/Plugins.rst
@@ -91,33 +91,6 @@ point. In this code example it will simply print the plugin's docstring.
 :func:`activate <avocado.core.plugins.plugin.Plugin.activate>`, if necessary,
 will activate your plugin, overriding Avocado core functionality.
 
-Make Avocado aware of the new plugin
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The Avocado command line tool has a ``--plugins`` option that allows you to
-provide a filesystem location that contains plugins that will be automatically
-loaded.
-
-Note that all external plugin files must be prefixed with the ``avocado_`` name,
-otherwise it will not be loaded.
-
-In the Avocado source tree, the ``avocado_hello.py`` example is available under
-``examples/plugins``. So, in order to enable the hello plugin, you can do a::
-
-    $ avocado --plugins examples/plugins/ plugins
-    Plugins enabled:
-        ...
-        hello_world - The classical Hello World! plugin example.
-	...
-
-Run it
-~~~~~~
-
-To run the newly created plugin, you can simply call the Avocado command line
-tool with newly registered runner command ``hello``::
-
-    $ avocado --plugins examples/plugins/ hello
-        The classical Hello World! plugin example.
 
 Wrap Up
 ~~~~~~~

--- a/man/avocado.rst
+++ b/man/avocado.rst
@@ -6,7 +6,7 @@
 SYNOPSIS
 ========
 
- avocado [-h] [-v] [--plugins PLUGINS_DIR] [--config CONFIG_FILE]
+ avocado [-h] [-v] [--config CONFIG_FILE]
  {run,list,sysinfo,multiplex,plugins,datadir} ...
 
 DESCRIPTION
@@ -30,7 +30,6 @@ on them being loaded::
 
  -h, --help             show this help message and exit
  -v, --version          show program's version number and exit
- --plugins PLUGINS_DIR  Load extra plugins from directory
  --config CONFIG_FILE   Use custom configuration from a file
 
 Real use of avocado depends on running avocado subcommands. This a typical list

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -463,48 +463,6 @@ class ExternalRunnerTest(unittest.TestCase):
         shutil.rmtree(self.tmpdir)
 
 
-class ExternalPluginsTest(unittest.TestCase):
-
-    def setUp(self):
-        self.base_sourcedir = tempfile.mkdtemp(prefix='avocado_' + __name__)
-        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
-
-    def test_void_plugin(self):
-        self.void_plugin = script.make_script(
-            os.path.join(self.base_sourcedir, 'avocado_void.py'),
-            VOID_PLUGIN_CONTENTS)
-        os.chdir(basedir)
-        cmd_line = './scripts/avocado --plugins %s plugins' % self.base_sourcedir
-        result = process.run(cmd_line, ignore_status=True)
-        expected_output = 'noname'
-        self.assertIn(expected_output, result.stdout)
-
-    def test_syntax_error_plugin(self):
-        self.syntax_err_plugin = script.make_script(
-            os.path.join(self.base_sourcedir, 'avocado_syntax_err.py'),
-            SYNTAX_ERROR_PLUGIN_CONTENTS)
-        os.chdir(basedir)
-        cmd_line = './scripts/avocado --plugins %s' % self.base_sourcedir
-        result = process.run(cmd_line, ignore_status=True)
-        expected_output = 'invalid syntax'
-        self.assertIn(expected_output, result.stderr)
-
-    def test_hello_plugin(self):
-        self.hello_plugin = script.make_script(
-            os.path.join(self.base_sourcedir, 'avocado_hello.py'),
-            HELLO_PLUGIN_CONTENTS)
-        os.chdir(basedir)
-        cmd_line = './scripts/avocado --plugins %s hello' % self.base_sourcedir
-        result = process.run(cmd_line, ignore_status=True)
-        expected_output = 'Hello World!'
-        self.assertIn(expected_output, result.stdout)
-
-    def tearDown(self):
-        shutil.rmtree(self.tmpdir)
-        if os.path.isdir(self.base_sourcedir):
-            shutil.rmtree(self.base_sourcedir, ignore_errors=True)
-
-
 class AbsPluginsTest(object):
 
     def setUp(self):


### PR DESCRIPTION
In preparation for the large plugin refactor, let's simplify the code ASAP
and drop related (custom) functionality that is going to be replaced.

Standard setuptools entrypoints is going to provide better capability then
our custom code that supports external 'avocado_*.py'module loading.

Signed-off-by: Cleber Rosa <crosa@redhat.com>