### PR TITLE
RFC: location discovery

### DIFF
--- a/avocado/core/discovery.py
+++ b/avocado/core/discovery.py
@@ -121,3 +121,23 @@ class NamedFileLocationDiscovery(FileLocationDiscovery):
 class PythonFileLocationDiscovery(NamedFileLocationDiscovery):
 
     INCLUDE_LOCATION_NAMES = [re.compile('.*\.py$')]
+
+
+class AccessFileLocationDiscovery(FileLocationDiscovery):
+
+    INCLUDE_MODES = []
+
+    def __init__(self, root):
+        super(AccessFileLocationDiscovery, self).__init__(root)
+        self.INCLUDE_CHECK_FUNCTIONS = [self._check_access_mode]
+
+    def _check_access_mode(self, location):
+        for include_mode in self.INCLUDE_MODES:
+            if os.access(location, include_mode):
+                return True
+        return False
+
+
+class ReadableExecutableFileLocationDiscovery(AccessFileLocationDiscovery):
+
+    INCLUDE_MODES = [os.R_OK | os.X_OK]

--- a/avocado/core/discovery.py
+++ b/avocado/core/discovery.py
@@ -1,0 +1,123 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2015
+# Authors: Cleber Rosa <cleber@redhat.com>
+
+"""
+Test location discovery
+"""
+
+import os
+import re
+
+
+class LocationDiscovery(object):
+
+    """
+    LocationDiscovery should return a list of locations that may contain tests
+
+    It's not up to LocationDiscovery to inspect each location and come up with
+    a list of tests, and not even the type of tests that were found.
+
+    It should, though, for each location root point given, walk through all of
+    its possible underlying members, and return a complete list of them, so
+    that no further location discovery is necessary.
+    """
+
+    #: List of functions to be run on each location. If any function returns
+    #: something that evals to True, then the location being checked is included
+    INCLUDE_CHECK_FUNCTIONS = [lambda location: True]
+
+    #: List of functions to be run on each location. If any function returns
+    #: something that evals to True, then the location being checked is ignored
+    IGNORE_CHECK_FUNCTIONS = []
+
+    def __init__(self, root):
+        self.root = root
+
+    def filter(self, locations):
+        """
+        Runs the include and ignore functions to include and exclude locations
+        """
+        included = []
+        for location in locations:
+            for check in self.INCLUDE_CHECK_FUNCTIONS:
+                if check(location):
+                    included.append(location)
+        result = []
+        for location in included:
+            ignored = False
+            for check in self.IGNORE_CHECK_FUNCTIONS:
+                if check(location):
+                    ignored = True
+                    continue
+            if not ignored:
+                result.append(location)
+        return result
+
+    def discover(self):
+        """
+        Performs the actual discovery for possible test locations
+
+        :returns: the locations where may be possible to find tests
+        :rtype: list
+        """
+        raise NotImplementedError
+
+    def get_locations(self):
+        """
+        Returns a final, filtered version of the discovered locations
+
+        This will run :meth:`discover`, and subsequently will run all locations
+        through the :meth:`filter`.
+
+        :rtype: list
+        """
+        discovered = self.discover()
+        locations = self.filter(discovered)
+        return locations
+
+
+class FileLocationDiscovery(LocationDiscovery):
+
+    def discover(self):
+        locations = []
+
+        if os.path.isfile(self.root):
+            locations.append(self.root)
+
+        elif os.path.isdir(self.root):
+            for dirpath, _, filenames in os.walk(self.root):
+                for filename in filenames:
+                    locations.append(os.path.join(dirpath, filename))
+
+        return locations
+
+
+class NamedFileLocationDiscovery(FileLocationDiscovery):
+
+    INCLUDE_LOCATION_NAMES = [re.compile('.*')]
+
+    def __init__(self, root):
+        super(NamedFileLocationDiscovery, self).__init__(root)
+        self.INCLUDE_CHECK_FUNCTIONS = [self._check_location_name]
+
+    def _check_location_name(self, location):
+        for regex in self.INCLUDE_LOCATION_NAMES:
+            if regex.match(location):
+                return True
+        return False
+
+
+class PythonFileLocationDiscovery(NamedFileLocationDiscovery):
+
+    INCLUDE_LOCATION_NAMES = [re.compile('.*\.py$')]

--- a/selftests/unit/test_discovery.py
+++ b/selftests/unit/test_discovery.py
@@ -1,4 +1,5 @@
 import os
+import stat
 import shutil
 import unittest
 import tempfile
@@ -13,11 +14,15 @@ class DiscoverTest(unittest.TestCase):
         self.basedir = tempfile.mkdtemp(prefix='avocado_' + __name__)
         files = ['foo.sh', 'bar', 'nopy']
         self.files = [os.path.join(self.basedir, f) for f in files]
+        self.executable = self.files[0]
         py_files = ['foo.py', 'bar.py']
         self.py_files = [os.path.join(self.basedir, f) for f in py_files]
         self.all_files = self.files + self.py_files
+        old_umask = os.umask(0377)
         for f in self.all_files:
             os.mknod(f)
+        os.umask(old_umask)
+        os.chmod(self.executable, stat.S_IRUSR | stat.S_IXUSR)
 
     def tearDown(self):
         try:
@@ -29,6 +34,11 @@ class DiscoverTest(unittest.TestCase):
         file_discovery = discovery.FileLocationDiscovery(self.basedir)
         locations = file_discovery.get_locations()
         self.assertEquals(locations.sort(), self.all_files.sort())
+
+    def test_readable_executable_file_discovery(self):
+        file_discovery = discovery.ReadableExecutableFileLocationDiscovery(self.basedir)
+        locations = file_discovery.get_locations()
+        self.assertEquals(locations[0], self.executable)
 
     def test_python_file_discovery(self):
         python_discovery = discovery.PythonFileLocationDiscovery(self.basedir)

--- a/selftests/unit/test_discovery.py
+++ b/selftests/unit/test_discovery.py
@@ -1,0 +1,39 @@
+import os
+import shutil
+import unittest
+import tempfile
+
+
+from avocado.core import discovery
+
+
+class DiscoverTest(unittest.TestCase):
+
+    def setUp(self):
+        self.basedir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        files = ['foo.sh', 'bar', 'nopy']
+        self.files = [os.path.join(self.basedir, f) for f in files]
+        py_files = ['foo.py', 'bar.py']
+        self.py_files = [os.path.join(self.basedir, f) for f in py_files]
+        self.all_files = self.files + self.py_files
+        for f in self.all_files:
+            os.mknod(f)
+
+    def tearDown(self):
+        try:
+            shutil.rmtree(self.basedir)
+        except OSError:
+            pass
+
+    def test_file_discovery(self):
+        file_discovery = discovery.FileLocationDiscovery(self.basedir)
+        locations = file_discovery.get_locations()
+        self.assertEquals(locations.sort(), self.all_files.sort())
+
+    def test_python_file_discovery(self):
+        python_discovery = discovery.PythonFileLocationDiscovery(self.basedir)
+        locations = python_discovery.get_locations()
+        self.assertEquals(locations.sort(), self.py_files.sort())
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Right now, Avocado does not have a clear separation during the test
discovery process of what can be a valid test location (think of a
test repository or collection) and, in a more detailed fashion, the
tests (and their types) that could be found in those locations.

One trivial but valid example: a single Python source code file can be
a valid *location* for many individual tests. These tests may be
scattered around many different classes. These classes, may actually
implement tests that Avocado may recognize (and treat) differently,
such as Avocado Instrumented tests or standard Python unittest
TestCase based tests.

This may sound complex, simply because it actually is. IMHO, the
solution to complex is to replace it with something simpler.

This RFC proposes a simple idea to cover the first stage: discoverying
*possible* test locations. Once that is clear and separated enough in
Avocado code, then it should be simpler to support the next stages.

The discovery code intentionally shows different classes that
"discover" test locations based on any files (thing of discovering
/usr/bin/) and then later a class that only cares about Python source
code files. The intention is to be flexible enough to allow for any
custom location discovery, such as:

 * It must be a file must be executable (a valid case for simple tests)
 * It must be reachable over HTTP and its name must end with ".js"

A test "inspector", or something better named, should then receive a list
of locations and detect if they actually contain valid tests, and their
specific types.

The idea is to have a reasonable (but configurable) list of location discovery
classes. Also, with the upcoming plugin refactor, users should be able to enable,
disable and configure individual location discovery classes themselves.

Signed-off-by: Cleber Rosa <crosa@redhat.com>