### PR TITLE
[V2] Add DNF backend to software manager

### DIFF
--- a/avocado/utils/software_manager.py
+++ b/avocado/utils/software_manager.py
@@ -387,13 +387,7 @@ class YumBackend(RpmBackend):
         """
         Installs package [name]. Handles local installs.
         """
-        if os.path.isfile(name):
-            name = os.path.abspath(name)
-            command = 'localinstall'
-        else:
-            command = 'install'
-
-        i_cmd = self.base_command + ' ' + command + ' ' + name
+        i_cmd = self.base_command + ' ' + 'install' + ' ' + name
 
         try:
             process.system(i_cmd)


### PR DESCRIPTION
This is a follow up to PR #853.

Changes from v1:
* Simplify install() on YumBackend proper
* Refactor YumBackend to make the base cmd selectable, so that DnfBackend can use the same code, replacing `yum` with `dnf`.