### PR TITLE
Test loader: replace list_tests parameter name for a better description

### DIFF
--- a/avocado/core/plugins/test_list.py
+++ b/avocado/core/plugins/test_list.py
@@ -44,10 +44,10 @@ class TestLister(object):
         loader.loader.get_extra_listing()
 
     def _get_test_suite(self, paths):
-        list_tests = loader.ALL if self.args.verbose else loader.AVAILABLE
+        which_tests = loader.ALL if self.args.verbose else loader.AVAILABLE
         try:
             return loader.loader.discover(paths,
-                                          list_tests=list_tests)
+                                          which_tests=which_tests)
         except loader.LoaderUnhandledUrlError, details:
             self.view.notify(event="error", msg=str(details))
             self.view.cleanup()


### PR DESCRIPTION
The 'list_tests' parameters is used to select which tests should be
listed.  IMHO, it sounds like a boolean kind of parameter, which will
either list tests or not. Let's replace that parameter name with
'which_tests', that IMHO give a better message about its intended
usage.

Also, let's standardize the docstrings, and use the declared supported
symbols for these parameters (DEFAULT, AVAILABLE or ALL) instead of their
values (False, etc).

Signed-off-by: Cleber Rosa <crosa@redhat.com>