### PR TITLE
etc: Use dmesg without `-c` [v2]

### DIFF
--- a/etc/avocado/sysinfo/commands
+++ b/etc/avocado/sysinfo/commands
@@ -1,5 +1,5 @@
 df -mP
-dmesg -c
+dmesg
 uname -a
 lspci -vvnn
 gcc --version


### PR DESCRIPTION
dmesg -c does not work well in multi-user/execution scenario and also it
removes the messages for debugging purposes on the system. Let's store
full dmesg and leave it up-to the users to diff it.

v1: https://github.com/avocado-framework/avocado/pull/844

Changes:

    v2: Use simplest approach by storing the full "dmesg"