### PR TITLE
Recent fixes [v2]

### DIFF
--- a/avocado/core/remote/runner.py
+++ b/avocado/core/remote/runner.py
@@ -16,6 +16,7 @@
 import sys
 import json
 import os
+import pipes
 import re
 import logging
 
@@ -26,6 +27,7 @@ from .. import output
 from .. import exceptions
 from .. import status
 from ..runner import TestRunner
+from ...utils import astring
 from ...utils import archive
 from ...utils import stacktrace
 
@@ -118,7 +120,7 @@ class RemoteTestRunner(TestRunner):
         for t_dict in json_result['tests']:
             logdir = os.path.dirname(self.result.stream.debuglog)
             logdir = os.path.join(logdir, 'test-results')
-            relative_path = t_dict['test'].lstrip('/')
+            relative_path = astring.string_to_safe_path(t_dict['test'])
             logdir = os.path.join(logdir, relative_path)
             t_dict['logdir'] = logdir
             t_dict['logfile'] = os.path.join(logdir, 'debug.log')

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -30,6 +30,7 @@ from . import data_dir
 from . import exceptions
 from . import multiplexer
 from . import sysinfo
+from ..utils import astring
 from ..utils import data_structures
 from ..utils import genio
 from ..utils import path as utils_path
@@ -102,7 +103,7 @@ class Test(unittest.TestCase):
         self.tagged_name = self.get_tagged_name(base_logdir)
 
         # Replace '/' with '_' to avoid splitting name into multiple dirs
-        safe_tagged_name = self.tagged_name.replace(os.path.sep, '_')
+        safe_tagged_name = astring.string_to_safe_path(self.tagged_name)
         self.logdir = utils_path.init_dir(base_logdir, safe_tagged_name)
         genio.set_log_file_dir(self.logdir)
         self.logfile = os.path.join(self.logdir, 'debug.log')

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -21,7 +21,6 @@ framework tests.
 import inspect
 import logging
 import os
-import pipes
 import re
 import shutil
 import sys

--- a/avocado/utils/astring.py
+++ b/avocado/utils/astring.py
@@ -25,6 +25,7 @@ string. Even with the dot notation, people may try to do things like
 And not notice until their code starts failing.
 """
 
+import os.path
 import re
 
 
@@ -192,3 +193,12 @@ def tabular_output(matrix, header=None):
     :rtype: str
     """
     return "\n".join(iter_tabular_output(matrix, header))
+
+
+def string_to_safe_path(string):
+    """
+    Convert string to a valid file/dir name.
+    :param string: String to be converted
+    :return: String which is safe to pass as a file/dir name (on recent fs)
+    """
+    return string.replace(os.path.sep, '_')

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -343,6 +343,11 @@ class SubProcess(object):
         while True:
             tmp = os.read(fileno, 1024)
             if tmp == '':
+                if self.verbose and bfr:
+                    for line in bfr.splitlines():
+                        log.debug(prefix, line)
+                        if stream_logger is not None:
+                            stream_logger.debug(stream_prefix, line)
                 break
             lock.acquire()
             try:

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -5,6 +5,7 @@ import time
 import sys
 import tempfile
 import xml.dom.minidom
+import glob
 
 if sys.version_info[:2] == (2, 6):
     import unittest2 as unittest
@@ -333,6 +334,32 @@ class RunnerHumanOutputTest(unittest.TestCase):
                          (expected_rc, result))
         self.assertIn('skiponsetup.py:SkipOnSetupTest.test_wont_be_executed:'
                       '  SKIP', result.stdout)
+
+    def test_ugly_echo_cmd(self):
+        if not os.path.exists("/bin/echo"):
+            self.skipTest("Program /bin/echo does not exist")
+        os.chdir(basedir)
+        cmd_line = ('./scripts/avocado run "/bin/echo -ne '
+                    'foo\\\\\\n\\\'\\\\\\"\\\\\\nbar/baz" --job-results-dir %s'
+                    ' --sysinfo=off  --show-job-log' % self.tmpdir)
+        result = process.run(cmd_line, ignore_status=True)
+        expected_rc = exit_codes.AVOCADO_ALL_OK
+        self.assertEqual(result.exit_status, expected_rc,
+                         "Avocado did not return rc %s:\n%s" %
+                         (expected_rc, result))
+        self.assertIn('[stdout] foo', result.stdout, result)
+        self.assertIn('[stdout] \'"', result.stdout, result)
+        self.assertIn('[stdout] bar/baz', result.stdout, result)
+        self.assertIn('PASS /bin/echo -ne foo\\\\n\\\'\\"\\\\nbar/baz',
+                      result.stdout, result)
+        # logdir name should escape special chars (/)
+        test_dirs = glob.glob(os.path.join(self.tmpdir, 'latest',
+                                           'test-results', '*'))
+        self.assertEqual(len(test_dirs), 1, "There are multiple directories in"
+                         " test-results dir, but only one test was executed: "
+                         "%s" % (test_dirs))
+        self.assertEqual(os.path.basename(test_dirs[0]),
+                         '_bin_echo -ne foo\\\\n\\\'\\"\\\\nbar_baz')
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir)
@@ -695,6 +722,7 @@ class PluginsJSONTest(AbsPluginsTest, unittest.TestCase):
         n_skip = json_data['skip']
         self.assertEqual(n_skip, e_nskip,
                          "Different number of skipped tests")
+        return json_data
 
     def test_json_plugin_passtest(self):
         self.run_and_check('passtest', exit_codes.AVOCADO_ALL_OK,
@@ -711,6 +739,19 @@ class PluginsJSONTest(AbsPluginsTest, unittest.TestCase):
     def test_json_plugin_errortest(self):
         self.run_and_check('errortest', exit_codes.AVOCADO_TESTS_FAIL,
                            1, 1, 0, 0)
+
+    def test_ugly_echo_cmd(self):
+        if not os.path.exists("/bin/echo"):
+            self.skipTest("Program /bin/echo does not exist")
+        data = self.run_and_check('"/bin/echo -ne foo\\\\\\n\\\'\\\\\\"\\\\\\'
+                                  'nbar/baz"', exit_codes.AVOCADO_ALL_OK, 1, 0,
+                                  0, 0)
+        # The executed test should be this
+        self.assertEqual(data['tests'][0]['url'],
+                         '/bin/echo -ne foo\\\\n\\\'\\"\\\\nbar/baz')
+        # logdir name should escape special chars (/)
+        self.assertEqual(os.path.basename(data['tests'][0]['logdir']),
+                         '_bin_echo -ne foo\\\\n\\\'\\"\\\\nbar_baz')
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir)


### PR DESCRIPTION
This PR contains fixes to few recent PR.

1. It fixes the log-remaining-buffer-on-exit
2. Refactors the safe-path generation into a utils.astring function
3. Adds selftest to make sure we support quotation properly (linux only)

v1: https://github.com/avocado-framework/avocado/pull/864

Changes:

    v2: Fixed typo in commit message
    v2: Removed the fix for quoted chars in remote which was causing troubles