### PR TITLE
Add "function at job exit" [v0]

### DIFF
--- a/avocado/core/funcatexit.py
+++ b/avocado/core/funcatexit.py
@@ -1,0 +1,78 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# This code was inspired in the virttest project,
+# virttest/funcatexit.py
+# Copyright: Red Hat Inc. 2015
+# Authors: Lukas Doktor <ldoktor@redhat.com>
+
+
+import sys
+import logging
+
+log = logging.getLogger("avocado.test")
+
+
+class FuncAtExit(object):
+
+    """
+    Class for handling cleanups. Don't forget to call `destroy()`.
+    """
+
+    def __init__(self, name):
+        """
+        :param name: Human readable identificator/purpose of this destroyer
+        """
+        self._name = name
+        self._items = []
+
+    def register(self, func, args, kwargs, once=False):
+        """
+        Register function/args to be called on self.destroy()
+        :param func: Pickable function
+        :param args: Pickable positional arguments
+        :param kwargs: Pickable keyword arguments
+        :param once: Add unique (func,args,kwargs) combination only once
+        """
+        item = (func, args, kwargs)
+        if not once or item not in self._items:
+            self._items.append(item)
+
+    def unregister(self, func, args, kwargs):
+        """
+        Unregister (func,args,kwargs) combination
+        :param func: Pickable function
+        :param args: Pickable positional arguments
+        :param kwargs: Pickable keyword arguments
+        """
+        item = (func, args, kwargs)
+        if item in self._items:
+            self._items.remove(item)
+
+    def destroy(self):
+        """
+        Call all registered function
+        """
+        while self._items:
+            item = self._items.pop()
+            try:
+                func, args, kwargs = item
+                func(*args, **kwargs)
+            except:     # Ignore all exceptions pylint: disable=W0702
+                log.error("%s failed to destroy %s:\n%s",
+                          self._name, item, sys.exc_info()[1])
+
+    def __del__(self):
+        """
+        :warning: Always call self.destroy() manually, this is not guarranteed
+                  to be executed!
+        """
+        self.destroy()

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -35,6 +35,7 @@ from . import sysinfo
 from . import result
 from . import exit_codes
 from . import exceptions
+from . import funcatexit
 from . import job_id
 from . import output
 from . import multiplexer
@@ -127,6 +128,7 @@ class Job(object):
         self.result_proxy = result.TestResultProxy()
         self.sysinfo = None
         self.timeout = getattr(self.args, 'job_timeout', 0)
+        self.funcatexit = funcatexit.FuncAtExit("JobExit %s" % self.unique_id)
 
     def _setup_job_results(self):
         logdir = getattr(self.args, 'logdir', None)

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -105,7 +105,12 @@ class TestStatus(object):
         res = True
         while not self.queue.empty():
             msg = self.queue.get()
-            if not msg.get("running", True):
+            if "func_at_exit" in msg:
+                self.job.funcatexit.register(msg["func_at_exit"],
+                                             msg.get("args", tuple()),
+                                             msg.get("kwargs", {}),
+                                             msg.get("repeat", True))
+            elif not msg.get("running", True):
                 self.status = msg
                 res = False
                 continue
@@ -357,6 +362,7 @@ class TestRunner(object):
             if break_loop:
                 break
         self.result.end_tests()
+        self.job.funcatexit.destroy()
         if self.job.sysinfo is not None:
             self.job.sysinfo.end_job_hook()
         return failures


### PR DESCRIPTION
Hello guys,

this pull request cleans the way we handle test status/messages from tests and adds new message which allows tests to registers functions to be called on __job__ exit (don't confuse with test-exit, people should use tearDown for these). The only limitation is the function and all arguments have to be pickable, because they come through `multiprocessing.Queue` from a completely different process.

This function will be used in avocado-vt to cleanup the `env` after all tests finish.

PS: Currently the messages from test to runner are not standardized, nor specified. From the source code I identified those messages with arguments (the `*` one is how we identify the message, the `**` are arguments, which are usually used in this message):

```
* func_at_exit - pickable function
** args - pickable *args ()
** kwargs - pickable **kwargs {}
** repeat - don't check if already registered (the same function with the same params would be executed multiple times)

* paused - test was paused
** paused_msg - reason
** viz Test.get_state

* load_exception - critical failure in early state

* running - test is running
** running - is the test in progress
** status - exit status
... - viz Test.get_state
```

I think we should simplify and define the format in the future. In this PR I wanted to minimize the impact, so I reused the free-form format used nowadays.