### PR TITLE
avocado/core/virt.py: avoid crashing when trying to detect VM IP address

### DIFF
--- a/avocado/core/virt.py
+++ b/avocado/core/virt.py
@@ -280,7 +280,15 @@ class VM(object):
         """
         desc = etree.fromstring(self.domain.XMLDesc(0))
         mac_path = "devices/interface[@type='network']/mac"
-        mac = desc.find(mac_path).attrib["address"].lower().strip()
+        node = desc.find(mac_path)
+        if node is None:
+            return None
+
+        mac = node.get("address")
+        if mac is None:
+            return None
+
+        mac = mac.lower().strip()
         output = subprocess.Popen(["arp", "-n"],
                                   stdout=subprocess.PIPE).communicate()[0]
         lines = [line.split() for line in output.split("\n")[1:]]


### PR DESCRIPTION
The current code assumes that libvirt will always return information
about the VM in a given format, and also assumes that the VM will have
a NIC, which may not be the case.

This adds better checks if the conditions are not met, skipping the
IP detection feature, instead of crashing.

Signed-off-by: Cleber Rosa <crosa@redhat.com>