### PR TITLE
process.py: CmdError class backward compatibility fix

### DIFF
--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -64,9 +64,10 @@ UNDEFINED_BEHAVIOR_EXCEPTION = None
 
 class CmdError(Exception):
 
-    def __init__(self, command=None, result=None):
+    def __init__(self, command=None, result=None, additional_text=None):
         self.command = command
         self.result = result
+        self.additional_text = additional_text
 
     def __str__(self):
         if self.result is not None:
@@ -78,6 +79,8 @@ class CmdError(Exception):
             else:
                 msg = "Command '%s' failed (rc=%d)"
                 msg %= (self.command, self.result.exit_status)
+            if self.additional_text:
+                msg += ", " + self.additional_text
             return msg
         else:
             return "CmdError"


### PR DESCRIPTION
In the newer CmdError class implementation the __init__() doesn't
have anymore the third non-mandatory argument "additional_text".
But still in the different parts of the source code the
CmdError is used with the third argument. If there is no special
reason behind deleting the "additional_text" then I would suggest
to keep for having the backward compatibility.
(for example got argument amount errors while running particular
libvirt tests which had to raise a CmdError exception)