### PR TITLE
[V3] Software manager - Improvements for debian package management

### DIFF
--- a/avocado/utils/software_manager.py
+++ b/avocado/utils/software_manager.py
@@ -304,14 +304,13 @@ class DpkgBackend(BaseBackend):
             n_cmd = (self.lowlevel_base_cmd + ' -f ' + name +
                      ' Package 2>/dev/null')
             name = process.system_output(n_cmd)
-        i_cmd = (self.lowlevel_base_cmd + "--show -f='${Status}' " +
-                 name + ' 2>/dev/null')
+        i_cmd = self.lowlevel_base_cmd + " -s " + name + ' 2>/dev/null'
         # Checking if package is installed
         package_status = process.system_output(i_cmd, ignore_status=True)
-        dpkg_not_installed = (package_status != self.INSTALLED_OUTPUT)
-        if dpkg_not_installed:
-            return False
-        return True
+        dpkg_installed = (self.INSTALLED_OUTPUT in package_status)
+        if dpkg_installed:
+            return True
+        return False
 
     def list_all(self):
         """

--- a/avocado/utils/software_manager.py
+++ b/avocado/utils/software_manager.py
@@ -663,6 +663,13 @@ class AptBackend(DpkgBackend):
         self.pm_version = ver
 
         log.debug('apt-get version: %s' % self.pm_version)
+        # gdebi-core is necessary for local installation with dependency
+        # handling
+        if not self.check_installed('gdebi-core'):
+            if not self.install('gdebi-core'):
+                log.info("SoftwareManager (AptBackend) can't install packages "
+                         "from local .deb files with dependency resolution: "
+                         "Package 'gdebi-core' could not be installed")
 
     def install(self, name):
         """
@@ -670,8 +677,11 @@ class AptBackend(DpkgBackend):
 
         :param name: Package name.
         """
-        command = 'install'
-        i_cmd = self.base_command + ' ' + command + ' ' + name
+        if os.path.isfile(name):
+            i_cmd = utils_path.find_command('gdebi') + ' -n -q ' + name
+        else:
+            command = 'install'
+            i_cmd = self.base_command + ' ' + command + ' ' + name
 
         try:
             process.system(i_cmd)

--- a/avocado/utils/software_manager.py
+++ b/avocado/utils/software_manager.py
@@ -301,10 +301,9 @@ class DpkgBackend(BaseBackend):
 
     def check_installed(self, name):
         if os.path.isfile(name):
-            n_cmd = (self.lowlevel_base_cmd + ' -f ' + name +
-                     ' Package 2>/dev/null')
+            n_cmd = self.lowlevel_base_cmd + ' -f ' + name + ' Package'
             name = process.system_output(n_cmd)
-        i_cmd = self.lowlevel_base_cmd + " -s " + name + ' 2>/dev/null'
+        i_cmd = self.lowlevel_base_cmd + " -s " + name
         # Checking if package is installed
         package_status = process.system_output(i_cmd, ignore_status=True)
         dpkg_installed = (self.INSTALLED_OUTPUT in package_status)

--- a/debian/control
+++ b/debian/control
@@ -9,5 +9,5 @@ Package: avocado
 Architecture: all
 Homepage: http://avocado-framework.github.io/
 XB-Python-Version: ${python:Versions}
-Depends: ${misc:Depends}, ${python:Depends}, python-yaml, python-lzma, python-pystache
+Depends: ${misc:Depends}, ${python:Depends}, python-yaml, python-lzma, python-pystache, gdebi-core
 Description: Avocado is a framework for fully automated testing.


### PR DESCRIPTION
Follow up to #871.

Some fixes and new features I've got for the deb/apt backend of software_manager.

Changes from v2:
* Remove shell redirection from `DpkgBackend.check_installed` method, as @ldoktor pointed out it doesn't make much sense.

Changes from v1:
* Improved informational message on missing `gdebi`
* Add debian package dependency on `gdebi-core` instead of `gdebi`.
* Split other unrelated fixes from this PR.