### PR TITLE
data_dir.py: tmp file permissions fix

### DIFF
--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -243,6 +243,7 @@ class _TmpDirTracker(Borg):
     def get(self):
         if not hasattr(self, 'tmp_dir'):
             self.tmp_dir = tempfile.mkdtemp(prefix='avocado_')
+            os.chmod(self.tmp_dir, 0755)
         return self.tmp_dir
 
     def __del__(self):


### PR DESCRIPTION
for some virttest test providers (e.g. blockjob) the temporay file
permissions should have limitations (0755).

Otherwise the tests fail with "permission denied" for the tmp files