### PR TITLE
avocado.core.job: Add func at job exit

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -50,6 +50,8 @@ from ..utils import astring
 from ..utils import path
 from ..utils import runtime
 from ..utils import stacktrace
+from ..utils import data_structures
+
 
 try:
     from .plugins import htmlresult
@@ -127,6 +129,9 @@ class Job(object):
         self.result_proxy = result.TestResultProxy()
         self.sysinfo = None
         self.timeout = getattr(self.args, 'job_timeout', 0)
+        self.funcatexit = data_structures.CallbackRegister("JobExit %s"
+                                                           % self.unique_id,
+                                                           _TEST_LOGGER)
 
     def _setup_job_results(self):
         logdir = getattr(self.args, 'logdir', None)

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -105,7 +105,12 @@ class TestStatus(object):
         res = True
         while not self.queue.empty():
             msg = self.queue.get()
-            if not msg.get("running", True):
+            if "func_at_exit" in msg:
+                self.job.funcatexit.register(msg["func_at_exit"],
+                                             msg.get("args", tuple()),
+                                             msg.get("kwargs", {}),
+                                             msg.get("once", False))
+            elif not msg.get("running", True):
                 self.status = msg
                 res = False
                 continue
@@ -357,6 +362,7 @@ class TestRunner(object):
             if break_loop:
                 break
         self.result.end_tests()
+        self.job.funcatexit.run()
         if self.job.sysinfo is not None:
             self.job.sysinfo.end_job_hook()
         return failures


### PR DESCRIPTION
Hello guys,

this pull request cleans the way we handle test status/messages from tests and adds new message which allows tests to registers functions to be called on __job__ exit (don't confuse with test-exit, people should use tearDown for these). The only limitation is the function and all arguments have to be pickable, because they come through `multiprocessing.Queue` from a completely different process.

This function will be used in avocado-vt to cleanup the `env` after all tests finish.

PS: Currently the messages from test to runner are not standardized, nor specified. From the source code I identified those messages with arguments (the `*` one is how we identify the message, the `**` are arguments, which are usually used in this message):

```
* func_at_exit - pickable function
** args - pickable *args ()
** kwargs - pickable **kwargs {}
** repeat - don't check if already registered (the same function with the same params would be executed multiple times)

* paused - test was paused
** paused_msg - reason
** viz Test.get_state

* load_exception - critical failure in early state

* running - test is running
** running - is the test in progress
** status - exit status
... - viz Test.get_state
```

I think we should simplify and define the format in the future. In this PR I wanted to minimize the impact, so I reused the free-form format used nowadays.

v0: https://github.com/avocado-framework/avocado/pull/869
v1: https://github.com/avocado-framework/avocado/pull/877

Changes:

    v1: "FuncAtExit" was moved to "utils.data_structures" and renamed to "CallbackRegister"
    v1: Use "signal.SIGKILL" instead of hardcoded 9
    v1: Fix hardcoded value 10 in log message
    v2: Fix incorrect argument repeat=>once