### PR TITLE
Add requirements install for python 2.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,10 +98,10 @@ clean:
 install-requirements-all: install-requirements install-requirements-selftests
 
 install-requirements:
-	grep -v '^#' requirements.txt | xargs -n 1 pip install
+	./install-python-requirements --mode install
 
 install-requirements-selftests:
-	grep -v '^#' requirements-selftests.txt | xargs -n 1 pip install
+	./install-python-requirements --mode selftests
 
 check: clean check_cyclical modules_boundaries
 	rm -rf /var/tmp/avocado*

--- a/install-python-requirements
+++ b/install-python-requirements
@@ -1,0 +1,72 @@
+#!/bin/env python
+import sys
+import pip
+import argparse
+
+version = None
+PY_26 = False
+PY_27 = False
+# Add the try/except block just in case we're running on some ancient
+# python version (pre 2.0)
+try:
+    version = sys.version_info[0:2]
+except AttributeError:
+    pass
+if version == (2, 6):
+    PY_26 = True
+elif version == (2, 7):
+    PY_27 = True
+else:
+    if version is None:
+        version = 'pre 2.0'
+    print('Incorrect python version %s. avocado is currently supported '
+          'on python 2.6 or 2.7' % version)
+    sys.exit(1)
+
+
+class Parser(argparse.ArgumentParser):
+
+    def __init__(self):
+        super(Parser, self).__init__(
+            prog='install-python-deps.py',
+            description='Install python dependencies')
+
+        self.add_argument('-m', '--mode', default='install',
+                          help="Install mode ('install' for deps needed for "
+                               "avocado itself to work, 'selftests' for deps "
+                               "needed to run the unit and regression tests)")
+
+
+class App(object):
+
+    def __init__(self):
+        self.parser = Parser()
+        self.args = None
+
+    def run(self):
+        self.args, _ = self.parser.parse_known_args()
+        return self.install_requirements(self.args.mode)
+
+    @staticmethod
+    def install_requirements(mode='install'):
+        valid_modes = ['install', 'selftests']
+        if mode not in valid_modes:
+            print('Invalid install requirements mode %s' % mode)
+            return 2
+
+        if PY_26:
+            if mode == 'install':
+                pip.main(args=['install', '-r', 'requirements-python26.txt'])
+            elif mode == 'selftests':
+                pip.main(args=['install', '-r',
+                               'requirements-selftests-python26.txt'])
+        elif PY_27:
+            if mode == 'install':
+                pip.main(args=['install', '-r', 'requirements.txt'])
+            elif mode == 'selftests':
+                pip.main(args=['install', '-r', 'requirements-selftests.txt'])
+        return 0
+
+if __name__ == '__main__':
+    app = App()
+    sys.exit(app.run())

--- a/requirements-python26.txt
+++ b/requirements-python26.txt
@@ -1,0 +1,17 @@
+# Avocado functional requirements
+# SSH lib (avocado.utils.remote)
+fabric>=1.7.0
+# multiplexer (avocado.core.tree)
+PyYAML>=3.11
+# vm plugin (avocado.core.plugins.vm)
+libvirt-python>=1.2.9
+# .tar.xz support (avocado.utils.archive)
+pyliblzma>=0.5.3
+# HTML report plugin (avocado.core.plugins.htmlresult)
+pystache>=0.5.3
+# REST client (avocado.core.restclient)
+requests>=1.2.3
+# All python 2.6 specific requirements (backports)
+argparse>=1.3.0
+logutils>=0.3.3
+importlib>=1.0.3

--- a/requirements-selftests-python26.txt
+++ b/requirements-selftests-python26.txt
@@ -1,0 +1,25 @@
+# Avocado test requirements
+# Setuptools
+setuptools>=18.0.0
+# sphinx (doc build test)
+Sphinx>=1.3b1
+# flexmock (some unittests use it)
+flexmock>=0.9.7
+# inspektor (static and style checks)
+inspektor>=0.1.16
+# mock (some unittests use it)
+mock>=1.0.0
+# six
+six>=1.9.0
+# funcsigs
+funcsigs>=0.4
+# To run make check
+pep8>=1.6.2
+Pillow>=2.2.1
+snakefood>=1.4
+networkx>=1.9.1
+pygraphviz>=1.3rc2
+aexpect>=1.0.0
+psutil>=3.1.1
+# All python 2.6 specific requirements (backports)
+unittest2>=1.0.0


### PR DESCRIPTION
Add handling dependencies install on python 2.6. This is a proposal to resolve issue #880.

Please check this thoroughly, as I had to write it on a rush (I'm having a bit of a hectic week around here).