### PR TITLE
GDB support in process: be more robust against malformed commands

### DIFF
--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -864,7 +864,11 @@ def should_run_inside_gdb(cmd):
 
     :param cmd: the command arguments, from where we extract the binary name
     """
-    args = shlex.split(cmd)
+    try:
+        args = shlex.split(cmd)
+    except ValueError:
+        return False
+
     cmd_binary_name = os.path.basename(args[0])
 
     for expr in gdb.GDB_RUN_BINARY_NAMES_EXPR:

--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -33,6 +33,11 @@ class TestGDBProcess(unittest.TestCase):
         self.assertTrue(process.should_run_inside_gdb('bar 1 2 3'))
         self.assertTrue(process.should_run_inside_gdb('/usr/bin/bar 1 2 3'))
 
+    def test_should_run_inside_gdb_malformed_command(self):
+        gdb.GDB_RUN_BINARY_NAMES_EXPR = ['/bin/virsh']
+        cmd = """/bin/virsh node-memory-tune --shm-sleep-millisecs ~!@#$%^*()-=[]{}|_+":;'`,>?. """
+        self.assertFalse(process.should_run_inside_gdb(cmd))
+
     def test_get_sub_process_klass(self):
         gdb.GDB_RUN_BINARY_NAMES_EXPR = []
         self.assertIs(process.get_sub_process_klass('/bin/true'),


### PR DESCRIPTION
It has been reported that avocado crashes when a malformed command
is attempted to be executed, even when using `shell=True`.

The reason is that `shlex.split` will raise `ValueError` on those
commands. Since improving `shlex.split` may be too complex, and
possibly not the best place to "fix" this, let's just assume safely
that this command should be run on GDB.

This is related to PR #875.

Signed-off-by: Cleber Rosa <crosa@redhat.com>