### PR TITLE
avocado.core.remoter: Fix error on exception reference

### DIFF
--- a/avocado/core/remoter.py
+++ b/avocado/core/remoter.py
@@ -26,10 +26,12 @@ LOG = logging.getLogger('avocado.test')
 
 try:
     import fabric.api
+    import fabric.network
     import fabric.operations
 except ImportError:
     REMOTE_CAPABLE = False
     LOG.info('Remote module is disabled: could not import fabric')
+    fabric = None
 else:
     REMOTE_CAPABLE = True
 


### PR DESCRIPTION
fabric.network was never imported in avocado.core.remoter,
but fabric.network.NetworkError was referenced in its code,
making the exception to never actually be captured. Let's
fix it.

While at it, let's resolve one complaint of the pycharm
python checker: When importing some module on a try/except
block, make some effort to define the module in case of
failure.

Signed-off-by: Lucas Meneghel Rodrigues <lookkas@gmail.com>