### PR TITLE
software_manager: Add --allow-unauthenticated to apt options

### DIFF
--- a/avocado/utils/software_manager.py
+++ b/avocado/utils/software_manager.py
@@ -648,7 +648,7 @@ class AptBackend(DpkgBackend):
         """
         super(AptBackend, self).__init__()
         executable = utils_path.find_command('apt-get')
-        self.base_command = executable + ' -y'
+        self.base_command = executable + ' --yes --allow-unauthenticated'
         self.repo_file_path = '/etc/apt/sources.list.d/avocado.list'
         cmd_result = process.run('apt-get -v | head -1',
                                  ignore_status=True,


### PR DESCRIPTION
This is a follow up to #889.

Sometimes we might add a repo that has no GPG keys and
still want to install a package from that repo. We need
--allow-unauthenticated to tell APT that we really want to install
it.

Signed-off-by: Lucas Meneghel Rodrigues <lookkas@gmail.com>