### PR TITLE
Use sudo --non-interactive whenever possible in ServiceManager() and SoftwareManager()

### DIFF
--- a/avocado/utils/service.py
+++ b/avocado/utils/service.py
@@ -27,6 +27,7 @@ import logging
 from tempfile import mktemp
 
 from . import process
+from . import path
 
 LOG = logging.getLogger('avocado.test')
 
@@ -322,18 +323,19 @@ def systemd_command_generator(command):
     return method
 
 
+# mapping command/whether it requires root
 COMMANDS = (
-    "start",
-    "stop",
-    "reload",
-    "restart",
-    "condrestart",
-    "status",
-    "enable",
-    "disable",
-    "is_enabled",
-    "list",
-    "set_target",
+    ("start", True),
+    ("stop", True),
+    ("reload", True),
+    ("restart", True),
+    ("condrestart", True),
+    ("status", False),
+    ("enable", True),
+    ("disable", True),
+    ("is_enabled", False),
+    ("list", False),
+    ("set_target", True),
 )
 
 
@@ -355,7 +357,7 @@ class _ServiceResultParser(object):
         :type command_list: list
         """
         self.commands = command_list
-        for command in self.commands:
+        for command, requires_root in self.commands:
             setattr(self, command, result_parser(command))
 
     @staticmethod
@@ -390,7 +392,7 @@ class _ServiceCommandGenerator(object):
             :type command_list: list
         """
         self.commands = command_list
-        for command in self.commands:
+        for command, requires_root in self.commands:
             setattr(self, command, command_generator(command))
 
 
@@ -457,7 +459,7 @@ class _SpecificServiceManager(object):
                 object, default process.run
         :type run: function
         """
-        for cmd in service_command_generator.commands:
+        for cmd, requires_root in service_command_generator.commands:
             run_func = run
             parse_func = getattr(service_result_parser, cmd)
             command = getattr(service_command_generator, cmd)
@@ -465,10 +467,12 @@ class _SpecificServiceManager(object):
                     self.generate_run_function(run_func=run_func,
                                                parse_func=parse_func,
                                                command=command,
-                                               service_name=service_name))
+                                               service_name=service_name,
+                                               requires_root=requires_root))
 
     @staticmethod
-    def generate_run_function(run_func, parse_func, command, service_name):
+    def generate_run_function(run_func, parse_func, command, service_name,
+                              requires_root):
         """
         Generate the wrapped call to process.run for the given service_name.
 
@@ -481,6 +485,8 @@ class _SpecificServiceManager(object):
         :type command: function
         :param service_name: init service name or systemd unit name
         :type service_name: str
+        :param requires_root: whether command needs superuser privileges
+        :type requires_root: bool
         :return: wrapped process.run function.
         :rtype: function
         """
@@ -500,7 +506,12 @@ class _SpecificServiceManager(object):
             if run_func is process.run:
                 LOG.debug("Setting ignore_status to True.")
                 kwargs["ignore_status"] = True
-            result = run_func(" ".join(command(service_name)), **kwargs)
+            cmd = " ".join(command(service_name))
+            uid = os.getcwd()
+            if uid != 0 and requires_root:
+                cmd = ("%s --non-interactive %s" %
+                       (path.find_command('sudo'), cmd))
+            result = run_func(cmd, **kwargs)
             return parse_func(result)
         return run
 
@@ -530,16 +541,17 @@ class _GenericServiceManager(object):
         :param run: function to call the run the commands, default process.run
         :type run: function
         """
-        for cmd in service_command_generator.commands:
+        for cmd, requires_root in service_command_generator.commands:
             parse_func = getattr(service_result_parser, cmd)
             command = getattr(service_command_generator, cmd)
             setattr(self, cmd,
                     self.generate_run_function(run_func=run,
                                                parse_func=parse_func,
-                                               command=command))
+                                               command=command,
+                                               requires_root=requires_root))
 
     @staticmethod
-    def generate_run_function(run_func, parse_func, command):
+    def generate_run_function(run_func, parse_func, command, requires_root):
         """
         Generate the wrapped call to process.run for the service command.
 
@@ -547,6 +559,8 @@ class _GenericServiceManager(object):
         :type run_func:  function
         :param command: partial function that generates the command list
         :type command: function
+        :param requires_root: whether command needs superuser privileges
+        :type requires_root: bool
         :return: wrapped process.run function.
         :rtype: function
         """
@@ -566,7 +580,12 @@ class _GenericServiceManager(object):
             if run_func is process.run:
                 LOG.debug("Setting ignore_status to True.")
                 kwargs["ignore_status"] = True
-            result = run_func(" ".join(command(service)), **kwargs)
+            uid = os.getcwd()
+            cmd = " ".join(command(service))
+            if uid != 0 and requires_root:
+                cmd = ("%s --non-interactive %s" %
+                       (path.find_command('sudo'), cmd))
+            result = run_func(cmd, **kwargs)
             return parse_func(result)
         return run
 
@@ -777,7 +796,8 @@ def _auto_create_specific_service_result_parser(run=process.run):
     """
     result_parser = _result_parsers[get_name_of_init(run)]
     # remove list method
-    command_list = [c for c in COMMANDS if c not in ["list", "set_target"]]
+    command_list = [(c, r) for (c, r) in COMMANDS if
+                    c not in ["list", "set_target"]]
     return _ServiceResultParser(result_parser, command_list)
 
 
@@ -796,7 +816,8 @@ def _auto_create_specific_service_command_generator(run=process.run):
     """
     command_generator = _command_generators[get_name_of_init(run)]
     # remove list method
-    command_list = [c for c in COMMANDS if c not in ["list", "set_target"]]
+    command_list = [(c, r) for (c, r) in COMMANDS if
+                    c not in ["list", "set_target"]]
     return _ServiceCommandGenerator(command_generator, command_list)
 
 

--- a/avocado/utils/software_manager.py
+++ b/avocado/utils/software_manager.py
@@ -59,6 +59,15 @@ log = logging.getLogger('avocado.test')
 
 SUPPORTED_PACKAGE_MANAGERS = ['apt-get', 'yum', 'zypper', 'dnf']
 
+_UID = os.getuid()
+
+
+def _requires_root_cmd(cmd):
+    if _UID != 0:
+        cmd = ("%s --non-interactive %s" %
+               (utils_path.find_command('sudo'), cmd))
+    return cmd
+
 
 class SystemInspector(object):
 
@@ -384,13 +393,16 @@ class YumBackend(RpmBackend):
         """
         Clean up the yum cache so new package information can be downloaded.
         """
-        process.system("yum clean all")
+        cmd = _requires_root_cmd("yum clean all")
+
+        process.system(cmd)
 
     def install(self, name):
         """
         Installs package [name]. Handles local installs.
         """
-        i_cmd = self.base_command + ' ' + 'install' + ' ' + name
+        i_cmd = _requires_root_cmd(self.base_command +
+                                   ' ' + 'install' + ' ' + name)
 
         try:
             process.system(i_cmd)
@@ -404,7 +416,8 @@ class YumBackend(RpmBackend):
 
         :param name: Package name (eg. 'ipython').
         """
-        r_cmd = self.base_command + ' ' + 'erase' + ' ' + name
+        r_cmd = _requires_root_cmd(self.base_command +
+                                   ' ' + 'erase' + ' ' + name)
         try:
             process.system(r_cmd)
             return True
@@ -461,6 +474,8 @@ class YumBackend(RpmBackend):
             r_cmd = self.base_command + ' ' + 'update'
         else:
             r_cmd = self.base_command + ' ' + 'update' + ' ' + name
+
+        r_cmd = _requires_root_cmd(r_cmd)
 
         try:
             process.system(r_cmd)
@@ -538,7 +553,7 @@ class ZypperBackend(RpmBackend):
 
         :param name: Package Name.
         """
-        i_cmd = self.base_command + ' install -l ' + name
+        i_cmd = _requires_root_cmd(self.base_command + ' install -l ' + name)
         try:
             process.system(i_cmd)
             return True
@@ -551,7 +566,7 @@ class ZypperBackend(RpmBackend):
 
         :param url: URL for the package repository.
         """
-        ar_cmd = self.base_command + ' addrepo ' + url
+        ar_cmd = _requires_root_cmd(self.base_command + ' addrepo ' + url)
         try:
             process.system(ar_cmd)
             return True
@@ -564,7 +579,7 @@ class ZypperBackend(RpmBackend):
 
         :param url: URL for the package repository.
         """
-        rr_cmd = self.base_command + ' removerepo ' + url
+        rr_cmd = _requires_root_cmd(self.base_command + ' removerepo ' + url)
         try:
             process.system(rr_cmd)
             return True
@@ -575,7 +590,8 @@ class ZypperBackend(RpmBackend):
         """
         Removes package [name].
         """
-        r_cmd = self.base_command + ' ' + 'erase' + ' ' + name
+        r_cmd = _requires_root_cmd(self.base_command +
+                                   ' ' + 'erase' + ' ' + name)
 
         try:
             process.system(r_cmd)
@@ -596,6 +612,8 @@ class ZypperBackend(RpmBackend):
             u_cmd = self.base_command + ' update -l'
         else:
             u_cmd = self.base_command + ' ' + 'update' + ' ' + name
+
+        u_cmd = _requires_root_cmd(u_cmd)
 
         try:
             process.system(u_cmd)
@@ -682,6 +700,8 @@ class AptBackend(DpkgBackend):
             command = 'install'
             i_cmd = self.base_command + ' ' + command + ' ' + name
 
+        i_cmd = _requires_root_cmd(i_cmd)
+
         try:
             process.system(i_cmd)
             return True
@@ -696,7 +716,8 @@ class AptBackend(DpkgBackend):
         """
         command = 'remove'
         flag = '--purge'
-        r_cmd = self.base_command + ' ' + command + ' ' + flag + ' ' + name
+        r_cmd = _requires_root_cmd(self.base_command +
+                                   ' ' + command + ' ' + flag + ' ' + name)
 
         try:
             process.system(r_cmd)
@@ -744,7 +765,7 @@ class AptBackend(DpkgBackend):
         :type name: str
         """
         ud_command = 'update'
-        ud_cmd = self.base_command + ' ' + ud_command
+        ud_cmd = _requires_root_cmd(self.base_command + ' ' + ud_command)
         try:
             process.system(ud_cmd)
         except process.CmdError:
@@ -757,6 +778,7 @@ class AptBackend(DpkgBackend):
             up_command = 'upgrade'
             up_cmd = self.base_command + ' ' + up_command
 
+        up_cmd = _requires_root_cmd(up_cmd)
         try:
             process.system(up_cmd)
             return True

--- a/selftests/unit/test_utils_service.py
+++ b/selftests/unit/test_utils_service.py
@@ -16,11 +16,18 @@
 #  The full GNU General Public License is included in this distribution in
 #  the file called "COPYING".
 
-import unittest
+import sys
+import os
+
+if sys.version_info[:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
 
 from mock import MagicMock, patch
 
 from avocado.utils import service
+from avocado.utils import path
 
 
 class TestSystemd(unittest.TestCase):
@@ -33,7 +40,9 @@ class TestSystemd(unittest.TestCase):
             command_generator)
 
     def test_all_commands(self):
-        for cmd in (c for c in self.service_command_generator.commands if c not in ["list", "set_target"]):
+        for cmd, requires_root in ((c, r) for (c, r) in
+                                   self.service_command_generator.commands if
+                                   c not in ["list", "set_target"]):
             ret = getattr(
                 self.service_command_generator, cmd)(self.service_name)
             if cmd == "is_enabled":
@@ -57,7 +66,9 @@ class TestSysVInit(unittest.TestCase):
 
     def test_all_commands(self):
         command_name = "service"
-        for cmd in (c for c in self.service_command_generator.commands if c not in ["list", "set_target"]):
+        for cmd, requires_root in ((c, r) for (c, r) in
+                                   self.service_command_generator.commands if
+                                   c not in ["list", "set_target"]):
             ret = getattr(
                 self.service_command_generator, cmd)(self.service_name)
             if cmd == "is_enabled":
@@ -98,16 +109,23 @@ class TestSpecificServiceManager(unittest.TestCase):
             service_result_parser, self.run_mock)
 
     def test_start(self):
-        service = "lldpad"
+        srv = "lldpad"
         self.service_manager.start()
-        assert self.run_mock.call_args[0][
-            0] == "service boot.%s start" % service
+        cmd = "service boot.%s start" % srv
+        if os.getuid() != 0:
+            cmd = ("%s --non-interactive %s" %
+                   (path.find_command('sudo'), cmd))
+        self.assertEqual(self.run_mock.call_args[0][0], cmd)
 
     def test_stop_with_args(self):
-        service = "lldpad"
+        srv = "lldpad"
         self.service_manager.stop(ignore_status=True)
-        assert self.run_mock.call_args[0][
-            0] == "service boot.%s stop" % service
+        cmd = "service boot.%s stop" % srv
+        if os.getuid() != 0:
+            cmd = ("%s --non-interactive %s" %
+                   (path.find_command('sudo'), cmd))
+        self.assertEqual(self.run_mock.call_args[0][0],
+                         cmd)
 
     def test_list_is_not_present_in_SpecifcServiceManager(self):
         assert not hasattr(self.service_manager, "list")
@@ -139,10 +157,13 @@ class TestSystemdServiceManager(TestServiceManager):
                                                                                  self.run_mock)
 
     def test_start(self):
-        service = "lldpad"
-        self.service_manager.start(service)
-        assert self.run_mock.call_args[0][
-            0] == "systemctl start %s.service" % service
+        srv = "lldpad"
+        self.service_manager.start(srv)
+        cmd = "systemctl start %s.service" % srv
+        if os.getuid() != 0:
+            cmd = ("%s --non-interactive %s" %
+                   (path.find_command('sudo'), cmd))
+        self.assertEqual(self.run_mock.call_args[0][0], cmd)
 
     def test_list(self):
         list_result_mock = MagicMock(exit_status=0, stdout="sshd.service enabled\n"
@@ -218,9 +239,13 @@ class TestSysVInitServiceManager(TestServiceManager):
                                'xinetd': {'amanda': "off", 'chargen-dgram': "on"}}
 
     def test_enable(self):
-        service = "lldpad"
-        self.service_manager.enable(service)
-        assert self.run_mock.call_args[0][0] == "chkconfig lldpad on"
+        srv = "lldpad"
+        self.service_manager.enable(srv)
+        cmd = "chkconfig lldpad on"
+        if os.getuid() != 0:
+            cmd = ("%s --non-interactive %s" %
+                   (path.find_command('sudo'), cmd))
+        self.assertEqual(self.run_mock.call_args[0][0], cmd)
 
     def test_unknown_runlevel(self):
         self.assertRaises(ValueError,


### PR DESCRIPTION
In order to improve user experience running under EC2 images, add `sudo --non-interactive` to API commands that require root, for `SoftwareManager` and `ServiceManager`.

The reason is that some EC2 instances (notably Fedora based ones) are moving away from letting the user to ssh into the instance as root, but they allow sudo to be used with the provided user (in the Fedora example, the user is named `fedora`). By providing tansparent handling of sudo in such APIs makes the users lives easier.