### PR TITLE
avocado.utils.process: Improve detection to run cmd in GDB [v2]

### DIFF
--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -864,11 +864,15 @@ def should_run_inside_gdb(cmd):
 
     :param cmd: the command arguments, from where we extract the binary name
     """
+    if not gdb.GDB_RUN_BINARY_NAMES_EXPR:
+        return False
+
     try:
         args = shlex.split(cmd)
     except ValueError:
-        return False
-
+        log.warning("Unable to check whether command '%s' should run inside "
+                    "GDB, fallback to simplified method...", cmd)
+        args = cmd.split()
     cmd_binary_name = os.path.basename(args[0])
 
     for expr in gdb.GDB_RUN_BINARY_NAMES_EXPR:

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -864,7 +864,11 @@ def should_run_inside_gdb(cmd):
 
     :param cmd: the command arguments, from where we extract the binary name
     """
-    args = shlex.split(cmd)
+    try:
+        args = shlex.split(cmd)
+    except ValueError:
+        return False
+
     cmd_binary_name = os.path.basename(args[0])
 
     for expr in gdb.GDB_RUN_BINARY_NAMES_EXPR:

--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -33,6 +33,11 @@ class TestGDBProcess(unittest.TestCase):
         self.assertTrue(process.should_run_inside_gdb('bar 1 2 3'))
         self.assertTrue(process.should_run_inside_gdb('/usr/bin/bar 1 2 3'))
 
+    def test_should_run_inside_gdb_malformed_command(self):
+        gdb.GDB_RUN_BINARY_NAMES_EXPR = ['/bin/virsh']
+        cmd = """/bin/virsh node-memory-tune --shm-sleep-millisecs ~!@#$%^*()-=[]{}|_+":;'`,>?. """
+        self.assertFalse(process.should_run_inside_gdb(cmd))
+
     def test_get_sub_process_klass(self):
         gdb.GDB_RUN_BINARY_NAMES_EXPR = []
         self.assertIs(process.get_sub_process_klass('/bin/true'),

--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -36,7 +36,9 @@ class TestGDBProcess(unittest.TestCase):
     def test_should_run_inside_gdb_malformed_command(self):
         gdb.GDB_RUN_BINARY_NAMES_EXPR = ['/bin/virsh']
         cmd = """/bin/virsh node-memory-tune --shm-sleep-millisecs ~!@#$%^*()-=[]{}|_+":;'`,>?. """
-        self.assertFalse(process.should_run_inside_gdb(cmd))
+        self.assertTrue(process.should_run_inside_gdb(cmd))
+        self.assertFalse(process.should_run_inside_gdb("foo bar baz"))
+        self.assertFalse(process.should_run_inside_gdb("foo ' "))
 
     def test_get_sub_process_klass(self):
         gdb.GDB_RUN_BINARY_NAMES_EXPR = []


### PR DESCRIPTION
shlex.split() can fail on some strange commands (eg. on an unfinished
quotation). This patch fallbacks to simple string.split() in such cases,
which might return incorrect results, but is safer to use. Although it
logs warning about this notifying the user about possible issue.

This is based on https://github.com/avocado-framework/avocado/pull/887 and also https://github.com/avocado-framework/avocado/pull/875