### PR TITLE
requirements-travis.txt: Fix inspektor requirement problems

### DIFF
--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -3,7 +3,7 @@ fabric==1.10.0
 pystache==0.5.4
 Sphinx==1.3b1
 flexmock==0.9.7
-inspektor==0.1.16
+inspektor==0.1.19
 pep8==1.6.2
 requests==1.2.3
 PyYAML==3.11


### PR DESCRIPTION
Require inspektor 0.1.18 to fix the pylint requirement
problems on python 2.6.

Signed-off-by: Lucas Meneghel Rodrigues <lookkas@gmail.com>