### PR TITLE
requirements-travis.txt: Require inspektor 0.2.0

### DIFF
--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -3,7 +3,7 @@ fabric==1.10.0
 pystache==0.5.4
 Sphinx==1.3b1
 flexmock==0.9.7
-inspektor==0.1.19
+inspektor==0.2.0
 pep8==1.6.2
 requests==1.2.3
 PyYAML==3.11

--- a/selftests/check_tmp_dirs
+++ b/selftests/check_tmp_dirs
@@ -11,8 +11,6 @@ if os.path.isdir(os.path.join(basedir, 'avocado')):
     os.environ['PATH'] += ":" + os.path.join(basedir, 'libexec')
     sys.path.append(basedir)
 
-from avocado.core import data_dir
-
 
 def check_tmp_dirs():
     dirs_to_check = [tempfile.gettempdir()]


### PR DESCRIPTION
Inspektor 0.2.0 has some improvements in the queue,
mainly now by default we are going to start being
picky on unused imports. Which is something I wanted
to do for a long time.

Signed-off-by: Lucas Meneghel Rodrigues <lookkas@gmail.com>