### PR TITLE
avocado.core.loader: Fix subtests filter

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -487,10 +487,11 @@ class FileLoader(TestLoader):
             _url, _subtests_filter = url.split(':', 1)
             if os.path.exists(_url):  # otherwise it's ':' in the file name
                 url = _url
-                subtests_filter = _subtests_filter
+                subtests_filter = re.compile(_subtests_filter)
 
         if not os.path.isdir(url):  # Single file
-            if not self._make_tests(url, DEFAULT, subtests_filter):
+            if (not self._make_tests(url, DEFAULT, subtests_filter) and
+                    not subtests_filter):
                 split_url = shlex.split(url)
                 if (os.access(split_url[0], os.X_OK) and
                         not os.path.isdir(split_url[0])):
@@ -620,6 +621,9 @@ class FileLoader(TestLoader):
                         for test_method in test_methods:
                             name = test_name + \
                                 ':%s.%s' % (test_class, test_method)
+                            if (subtests_filter and
+                                    not subtests_filter.search(name)):
+                                continue
                             tst = (test_class, {'name': name,
                                                 'modulePath': test_path,
                                                 'methodName': test_method})

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -133,6 +133,11 @@ class LoaderTest(unittest.TestCase):
         self.assertTrue(test_class == test.SimpleTest, test_class)
         tc = test_class(**test_parameters)
         tc.test()
+        # Load with params
+        simple_with_params = simple_test.path + " 'foo bar' --baz"
+        suite = self.loader.discover(simple_with_params, True)
+        self.assertEqual(len(suite), 1)
+        self.assertEqual(suite[0][1]["name"], simple_with_params)
         simple_test.remove()
 
     def test_load_simple_not_exec(self):

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -221,6 +221,23 @@ class LoaderTest(unittest.TestCase):
         avocado_multiple_tests.save()
         suite = self.loader.discover(avocado_multiple_tests.path, True)
         self.assertEqual(len(suite), 2)
+        # Try to load only some of the tests
+        suite = self.loader.discover(avocado_multiple_tests.path +
+                                     ':MultipleMethods.testTwo', True)
+        self.assertEqual(len(suite), 1)
+        self.assertEqual(suite[0][1]["methodName"], 'testTwo')
+        # Load using regexp
+        suite = self.loader.discover(avocado_multiple_tests.path +
+                                     ':.*_one', True)
+        self.assertEqual(len(suite), 1)
+        self.assertEqual(suite[0][1]["methodName"], 'test_one')
+        # Load booth
+        suite = self.loader.discover(avocado_multiple_tests.path +
+                                     ':test.*', True)
+        self.assertEqual(len(suite), 2)
+        # Load none should return no tests
+        self.assertTrue(not self.loader.discover(avocado_multiple_tests.path +
+                                                 ":no_match", True))
         avocado_multiple_tests.remove()
 
     def test_load_foreign(self):


### PR DESCRIPTION
We used to support whitelisting of avocado subtests, but it's not working anymore. This patch brings this functionality back and adds unittests.