### PR TITLE
virtualenv: allow tests to run properly on them

### DIFF
--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/avocado/core/version.py
+++ b/avocado/core/version.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/avocado/utils/kernel_build.py
+++ b/avocado/utils/kernel_build.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/avocado/utils/software_manager.py
+++ b/avocado/utils/software_manager.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -282,7 +282,7 @@ say you want to pick up a test suite written in C that it is in a tarball,
 uncompress it, compile the suite code, and then executing the test. Here's
 an example that does that::
 
-    #!/usr/bin/python
+    #!/usr/bin/env python
 
     import os
 

--- a/examples/tests/abort.py
+++ b/examples/tests/abort.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import os
 

--- a/examples/tests/cabort.py
+++ b/examples/tests/cabort.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import os
 import shutil

--- a/examples/tests/datadir.py
+++ b/examples/tests/datadir.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import os
 import shutil

--- a/examples/tests/doublefail.py
+++ b/examples/tests/doublefail.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from avocado import Test
 from avocado import main

--- a/examples/tests/doublefree.py
+++ b/examples/tests/doublefree.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import os
 import shutil

--- a/examples/tests/doublefree_nasty.py
+++ b/examples/tests/doublefree_nasty.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import os
 import shutil

--- a/examples/tests/errortest.py
+++ b/examples/tests/errortest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from avocado import Test
 from avocado import main

--- a/examples/tests/errortest_nasty.py
+++ b/examples/tests/errortest_nasty.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from avocado import Test
 from avocado import main

--- a/examples/tests/errortest_nasty2.py
+++ b/examples/tests/errortest_nasty2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from avocado import Test
 from avocado import main

--- a/examples/tests/errortest_nasty3.py
+++ b/examples/tests/errortest_nasty3.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from avocado import Test
 from avocado import main

--- a/examples/tests/fail_on_exception.py
+++ b/examples/tests/fail_on_exception.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import avocado
 

--- a/examples/tests/failtest.py
+++ b/examples/tests/failtest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from avocado import Test
 from avocado import main

--- a/examples/tests/fiotest.py
+++ b/examples/tests/fiotest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import os
 

--- a/examples/tests/gdbtest.py
+++ b/examples/tests/gdbtest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import os
 

--- a/examples/tests/gendata.py
+++ b/examples/tests/gendata.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import os
 

--- a/examples/tests/linuxbuild.py
+++ b/examples/tests/linuxbuild.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from avocado import Test
 from avocado import main

--- a/examples/tests/modify_variable.py
+++ b/examples/tests/modify_variable.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import os
 import shutil

--- a/examples/tests/multiple_tests.py
+++ b/examples/tests/multiple_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from avocado import Test
 from avocado import main
 

--- a/examples/tests/multiplextest.py
+++ b/examples/tests/multiplextest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from avocado import Test
 from avocado import main

--- a/examples/tests/passtest.py
+++ b/examples/tests/passtest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from avocado import main
 from avocado import Test

--- a/examples/tests/raise.py
+++ b/examples/tests/raise.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import os
 import shutil

--- a/examples/tests/skip_outside_setup.py
+++ b/examples/tests/skip_outside_setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import avocado
 

--- a/examples/tests/skiponsetup.py
+++ b/examples/tests/skiponsetup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from avocado import Test
 from avocado import main

--- a/examples/tests/sleeptenmin.py
+++ b/examples/tests/sleeptenmin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import os
 import time

--- a/examples/tests/sleeptest.py
+++ b/examples/tests/sleeptest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import time
 

--- a/examples/tests/synctest.py
+++ b/examples/tests/synctest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import os
 

--- a/examples/tests/timeouttest.py
+++ b/examples/tests/timeouttest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import time
 

--- a/examples/tests/trinity.py
+++ b/examples/tests/trinity.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import os
 

--- a/examples/tests/uncaught_exception.py
+++ b/examples/tests/uncaught_exception.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from avocado import Test
 from avocado import main

--- a/examples/tests/warntest.py
+++ b/examples/tests/warntest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from avocado import Test
 from avocado import main

--- a/examples/tests/whiteboard.py
+++ b/examples/tests/whiteboard.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import base64
 

--- a/selftests/functional/test_interrupt.py
+++ b/selftests/functional/test_interrupt.py
@@ -33,7 +33,7 @@ if __name__ == "__main__":
         time.sleep(0.1)
 """
 
-GOOD_TEST = """#!/usr/bin/python
+GOOD_TEST = """#!/usr/bin/env python
 import time
 from avocado import Test
 from avocado import main

--- a/selftests/functional/test_loader.py
+++ b/selftests/functional/test_loader.py
@@ -17,7 +17,7 @@ basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..')
 basedir = os.path.abspath(basedir)
 
 
-AVOCADO_TEST_OK = """#!/usr/bin/python
+AVOCADO_TEST_OK = """#!/usr/bin/env python
 from avocado import Test
 from avocado import main
 
@@ -30,7 +30,7 @@ if __name__ == "__main__":
 """
 
 
-AVOCADO_TEST_SLEEP_ELEVEN = """#!/usr/bin/python
+AVOCADO_TEST_SLEEP_ELEVEN = """#!/usr/bin/env python
 import time
 
 from avocado import Test
@@ -49,7 +49,7 @@ if __name__ == "__main__":
 """
 
 
-AVOCADO_TEST_MULTIPLE_CLASSES = """#!/usr/bin/python
+AVOCADO_TEST_MULTIPLE_CLASSES = """#!/usr/bin/env python
 import time
 
 from avocado import Test
@@ -73,7 +73,7 @@ def hello():
     print('Hello World!')
 """
 
-PY_SIMPLE_TEST = """#!/usr/bin/python
+PY_SIMPLE_TEST = """#!/usr/bin/env python
 def hello():
     print('Hello World!')
 

--- a/selftests/functional/test_utils.py
+++ b/selftests/functional/test_utils.py
@@ -11,7 +11,7 @@ else:
 
 from avocado.utils import process
 
-FAKE_VMSTAT_CONTENTS = """#!/usr/bin/python
+FAKE_VMSTAT_CONTENTS = """#!/usr/bin/env python
 import time
 import random
 import signal
@@ -108,7 +108,7 @@ if __name__ == '__main__':
     vmstat.start()
 """
 
-FAKE_UPTIME_CONTENTS = """#!/usr/bin/python
+FAKE_UPTIME_CONTENTS = """#!/usr/bin/env python
 if __name__ == '__main__':
     print("17:56:34 up  8:06,  7 users,  load average: 0.26, 0.20, 0.21")
 

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -13,7 +13,7 @@ from avocado.utils import script
 
 # We need to access protected members pylint: disable=W0212
 
-AVOCADO_TEST_OK = """#!/usr/bin/python
+AVOCADO_TEST_OK = """#!/usr/bin/env python
 from avocado import Test
 from avocado import main
 
@@ -25,7 +25,7 @@ if __name__ == "__main__":
     main()
 """
 
-AVOCADO_TEST_OK_DISABLED = """#!/usr/bin/python
+AVOCADO_TEST_OK_DISABLED = """#!/usr/bin/env python
 from avocado import Test
 from avocado import main
 
@@ -46,7 +46,7 @@ def hello():
     print('Hello World!')
 """
 
-PY_SIMPLE_TEST = """#!/usr/bin/python
+PY_SIMPLE_TEST = """#!/usr/bin/env python
 def hello():
     print('Hello World!')
 


### PR DESCRIPTION
While going through the dependency list (requirements*.txt files) and
performing our self tests out of virtual environments, I noticed that
some tests are run outside the virtual environments.

The reason is that, even though the virtual environment is activated
for the test session (and say, `which python` gives `/venv/bin/python`),
we have hard coded `/usr/bin/python` in most places.

According to the some discussions on the virtualenv project itself[1],
a quick solution is to revert to the also common `/usr/bin/env python`
way of pointing to the Python interpreter.

[1] - https://github.com/pypa/virtualenv/issues/124

Signed-off-by: Cleber Rosa <crosa@redhat.com>