### PR TITLE
Human output: functional test fixes [v2]

### DIFF
--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -225,6 +225,11 @@ class OutputPluginTest(unittest.TestCase):
                          "Avocado did not return rc %d:\n%s" %
                          (expected_rc, result))
         output_lines = output.splitlines()
+        # The current human output produces 6 lines when running a single test,
+        # with an optional 7th line when the HTML report generation is enabled
+        self.assertGreaterEqual(len(output_lines), 6,
+                                ('Basic human interface did not produce the '
+                                 'expect output. Output produced: "%s"' % output))
         second_line = output_lines[1]
         debug_log = second_line.split()[-1]
         self.check_output_files(debug_log)

--- a/selftests/functional/test_sysinfo.py
+++ b/selftests/functional/test_sysinfo.py
@@ -29,10 +29,14 @@ class SysInfoTest(unittest.TestCase):
         self.assertEqual(result.exit_status, expected_rc,
                          'Avocado did not return rc %d:\n%s' % (expected_rc, result))
         output = result.stdout + result.stderr
+        sysinfo_dir = None
         for line in output.splitlines():
             if 'JOB LOG' in line:
                 job_log = line.split()[-1]
                 sysinfo_dir = os.path.join(os.path.dirname(job_log), 'sysinfo')
+        self.assertIsNotNone(sysinfo_dir,
+                             ('Could not find sysinfo dir from human output. '
+                              'Output produced: "%s" % output'))
         msg = "Avocado didn't create sysinfo directory %s:\n%s" % (sysinfo_dir, result)
         self.assertTrue(os.path.isdir(sysinfo_dir), msg)
         msg = 'The sysinfo directory is empty:\n%s' % result
@@ -50,10 +54,14 @@ class SysInfoTest(unittest.TestCase):
         self.assertEqual(result.exit_status, expected_rc,
                          'Avocado did not return rc %d:\n%s' % (expected_rc, result))
         output = result.stdout + result.stderr
+        sysinfo_dir = None
         for line in output.splitlines():
             if 'JOB LOG' in line:
                 job_log = line.split()[-1]
                 sysinfo_dir = os.path.join(os.path.dirname(job_log), 'sysinfo')
+        self.assertIsNotNone(sysinfo_dir,
+                             ('Could not find sysinfo dir from human output. '
+                              'Output produced: "%s" % output'))
         msg = 'Avocado created sysinfo directory %s:\n%s' % (sysinfo_dir, result)
         self.assertFalse(os.path.isdir(sysinfo_dir), msg)
 


### PR DESCRIPTION
There are a couple of functional unittests that assume that a given
output was produced by the regular UI, that is, the Human output
format.

That is fine, since they're functional tests. But, some situations
lead to test errors, instead of pointing failures. Let's turn those
into explicit checks and fail properly instead of producing errors.

Note: These errors were visible when the human output was disabled, in
the plugin overhaul work, but the fixes still make sense independently
of that work.

Signed-off-by: Cleber Rosa <crosa@redhat.com>

---

Changes from v1:
 * Add generated output to aid debugging in case of failures