### PR TITLE
avocado.core: Record job information for further replay

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -40,6 +40,7 @@ from . import output
 from . import multiplexer
 from . import tree
 from . import test
+from . import replay
 from .settings import settings
 from .plugins import manager
 from .plugins import jsonresult
@@ -153,6 +154,9 @@ class Job(object):
         self.idfile = os.path.join(self.logdir, "id")
         with open(self.idfile, 'w') as id_file_obj:
             id_file_obj.write("%s\n" % self.unique_id)
+
+    def _setup_job_replay(self):
+        self.replay = replay.Replay(self.logdir)
 
     def _update_latest_link(self):
         """
@@ -269,10 +273,10 @@ class Job(object):
                      Optionally, a list of tests (each test a string).
         :returns: a test suite (a list of test factories)
         """
-        urls = self._handle_urls(urls)
+        self.urls = self._handle_urls(urls)
         loader.loader.load_plugins(self.args)
         try:
-            suite = loader.loader.discover(urls)
+            suite = loader.loader.discover(self.urls)
         except loader.LoaderUnhandledUrlError, details:
             self._remove_job_results()
             raise exceptions.OptionValidationError(details)
@@ -450,6 +454,14 @@ class Job(object):
         self._log_mux_variants(mux)
         self._log_job_id()
 
+    def _record_job_replay_info(self):
+        """
+        Record required information for job replay
+        """
+        self.replay.record_urls(self.urls)
+        self.replay.record_config()
+        self.replay.record_mux(self.args.multiplex_files)
+
     def _run(self, urls=None):
         """
         Unhandled job method. Runs a list of test URLs to its completion.
@@ -463,6 +475,7 @@ class Job(object):
                 that configure a job failure.
         """
         self._setup_job_results()
+        self._setup_job_replay()
         self.view.start_file_logging(self.logfile,
                                      self.loglevel,
                                      self.unique_id)
@@ -491,6 +504,7 @@ class Job(object):
         self._start_sysinfo()
 
         self._log_job_debug_info(mux)
+        self._record_job_replay_info()
 
         self.view.logfile = self.logfile
         failures = self.test_runner.run_suite(test_suite, mux,

--- a/avocado/core/replay.py
+++ b/avocado/core/replay.py
@@ -1,0 +1,61 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2013-2015
+# Author: Amador Pahim <apahim@redhat.com>
+
+import os
+from .settings import settings
+from ..utils import path
+
+"""
+Record information and replay jobs using the information recorded
+"""
+
+
+class Replay(object):
+
+    """
+    Object to record and represent the information needed for a job replay
+    """
+
+    def __init__(self, logdir):
+        self.replay_dir = path.init_dir(logdir, 'replay')
+        self.path_cfg = os.path.join(self.replay_dir, 'config')
+        self.path_urls = os.path.join(self.replay_dir, 'urls')
+        self.path_mux = path.init_dir(self.replay_dir, 'multiplex')
+
+    def record_urls(self, urls):
+        with open(self.path_urls, 'w') as f:
+            f.write('%s' % urls)
+
+    def record_config(self):
+        with open(self.path_cfg, 'w') as f:
+            settings.config.write(f)
+
+    def record_mux(self, mux_files):
+        if mux_files:
+            for mux_file in mux_files:
+                file_path = self._get_uniq_path(self.path_mux,
+                                                os.path.basename(mux_file))
+                with open(file_path, 'w') as f:
+                    with open(mux_file, 'r') as source:
+                        f.write(source.read())
+
+    def _get_uniq_path(self, directory, filename):
+        cont = 1
+        path = os.path.join(directory, filename)
+        while os.path.exists(path):
+            filename = "%s_%s" % (cont, filename)
+            path = os.path.join(directory, filename)
+            cont += 1
+
+        return path


### PR DESCRIPTION
To have the inital support for job replay, this commit creates the
replay module and setting job class to record the urls, config and
multiplex information.

Signed-off-by: Amador Pahim <apahim@redhat.com>