### PR TITLE
Makefile: Add requirements-python26

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,10 +98,10 @@ clean:
 install-requirements-all: install-requirements install-requirements-selftests
 
 install-requirements:
-	grep -v '^#' requirements.txt | xargs -n 1 pip install
+	grep -v '^#' requirements.txt | xargs -n 1 pip install --upgrade
 
 install-requirements-selftests:
-	grep -v '^#' requirements-selftests.txt | xargs -n 1 pip install
+	grep -v '^#' requirements-selftests.txt | xargs -n 1 pip install --upgrade
 
 check: clean check_cyclical modules_boundaries
 	rm -rf /var/tmp/avocado*

--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ install-requirements-all: install-requirements install-requirements-selftests
 
 install-requirements:
 	grep -v '^#' requirements.txt | xargs -n 1 pip install --upgrade
+	if $$(python -V 2>&1 | grep 2.6 -q); then grep -v '^#' requirements-python26.txt | xargs -n 1 pip install --upgrade; fi
 
 install-requirements-selftests:
 	grep -v '^#' requirements-selftests.txt | xargs -n 1 pip install --upgrade

--- a/requirements-python26.txt
+++ b/requirements-python26.txt
@@ -1,0 +1,5 @@
+# Additional python 2.6 specific requirements for avocado and unittests (backports)
+argparse>=1.3.0
+logutils>=0.3.3
+importlib>=1.0.3
+unittest2>=1.0.0


### PR DESCRIPTION
This PR fixes an old issue with `make install-requirements` and adds python2.6 requirements. It's based on https://github.com/avocado-framework/avocado/pull/881