### PR TITLE
selftests/functional/test_output.py: skip test on absence of PIL library

### DIFF
--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -19,6 +19,14 @@ basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..')
 basedir = os.path.abspath(basedir)
 
 
+def image_output_uncapable():
+    try:
+        import PIL
+        return False
+    except ImportError:
+        return True
+
+
 class OutputTest(unittest.TestCase):
 
     def setUp(self):
@@ -258,6 +266,8 @@ class OutputPluginTest(unittest.TestCase):
             except OSError:
                 pass
 
+    @unittest.skipIf(image_output_uncapable,
+                     "Uncapable of generating images with PIL library")
     def test_gendata(self):
         tmpfile = tempfile.mktemp()
         try:


### PR DESCRIPTION
The `test_gendata` test of `OutputTest` runs the example test
`gendata.py`, but the `gendata.py` itself has a conditional in one of
the tests that make use of the PIL (aka Pillow package) library and
does nothing if it's missing.

PIL (Pillow) is highly dependent on C compilers and libraries to be
able to build itself. This makes systems it harder to run the full
Avocado self tests on more diverse (usually minimalist) systems.

So, let's make that functional test optional, if the libraries are not
present.

Signed-off-by: Cleber Rosa <crosa@redhat.com>