### PR TITLE
[v4] avocado.core: Initial job replay support

### DIFF
--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -401,6 +401,7 @@ class View(object):
             self.paginator = None
         self.throbber = Throbber()
         self.tests_info = {}
+        self.replay_sourcejob = None
 
     def cleanup(self):
         if self.use_paginator:
@@ -547,7 +548,7 @@ class View(object):
         """
         self._log_ui_info(term_support.warn_header_str(msg), skip_newline)
 
-    def start_file_logging(self, logfile, loglevel, unique_id):
+    def start_file_logging(self, logfile, loglevel, unique_id, sourcejob):
         """
         Start the main file logging.
 
@@ -559,6 +560,8 @@ class View(object):
         self.debuglog = logfile
         self.file_handler = logging.FileHandler(filename=logfile)
         self.file_handler.setLevel(loglevel)
+        if sourcejob is not None:
+            self.replay_sourcejob = sourcejob
 
         fmt = ('%(asctime)s %(module)-16.16s L%(lineno)-.4d %('
                'levelname)-5.5s| %(message)s')

--- a/avocado/core/replay.py
+++ b/avocado/core/replay.py
@@ -1,0 +1,100 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2013-2015
+# Author: Amador Pahim <apahim@redhat.com>
+
+import ast
+import glob
+import json
+import os
+import pickle
+import re
+from .settings import settings
+from ..utils import path
+
+"""
+Record/retrieve job information for job replay
+"""
+
+
+def record(args, logdir, mux, urls=None):
+    replay_dir = path.init_dir(logdir, 'replay')
+    path_cfg = os.path.join(replay_dir, 'config')
+    path_urls = os.path.join(replay_dir, 'urls')
+    path_mux = os.path.join(replay_dir, 'multiplex')
+
+    if urls:
+        with open(path_urls, 'w') as f:
+            f.write('%s' % urls)
+
+    with open(path_cfg, 'w') as f:
+        settings.config.write(f)
+
+    with open(path_mux, 'w') as f:
+        pickle.dump(mux, f, pickle.HIGHEST_PROTOCOL)
+
+
+def retrieve_urls(resultsdir):
+    recorded_urls = os.path.join(resultsdir, "replay", "urls")
+    with open(recorded_urls, 'r') as f:
+        urls = f.read()
+
+    return ast.literal_eval(urls)
+
+
+def retrieve_mux(resultsdir):
+    pkl_path = os.path.join(resultsdir, 'replay', 'multiplex')
+    with open(pkl_path, 'r') as f:
+        return pickle.load(f)
+
+
+def retrieve_replay_map(resultsdir, replay_filter):
+    replay_map = None
+    resultsfile = os.path.join(resultsdir, "results.json")
+    with open(resultsfile, 'r') as results_file_obj:
+        results = json.loads(results_file_obj.read())
+
+    if replay_filter:
+        replay_map = [index for index, test in enumerate(results['tests'])
+                      if test['status'] in replay_filter]
+    else:
+        replay_map = None
+
+    return replay_map
+
+
+def get_resultsdir(logdir, jobid):
+    matches = 0
+    idfile_pattern = os.path.join(logdir, 'job-*', 'id')
+    for id_file in glob.glob(idfile_pattern):
+        with open(id_file, 'r') as f:
+            fileid = f.read().strip('\n')
+        if re.search(jobid, fileid):
+            match_file = id_file
+            sourcejob = fileid
+            matches += 1
+
+    if matches == 1:
+        return os.path.dirname(match_file), sourcejob
+    else:
+        return None, None
+
+
+def _get_unused_path(directory, filename):
+    count = 1
+    path = os.path.join(directory, filename)
+    while os.path.exists(path):
+        filename = "%s_%s" % (count, filename)
+        path = os.path.join(directory, filename)
+        count += 1
+
+    return path

--- a/avocado/core/result.py
+++ b/avocado/core/result.py
@@ -263,6 +263,9 @@ class HumanTestResult(TestResult):
         """
         TestResult.start_tests(self)
         self.stream.notify(event="message", msg="JOB ID     : %s" % self.stream.job_unique_id)
+        if self.stream.replay_sourcejob is not None:
+            self.stream.notify(event="message", msg="SRC JOB ID : %s" %
+                               self.stream.replay_sourcejob)
         self.stream.notify(event="message", msg="JOB LOG    : %s" % self.stream.logfile)
         self.stream.notify(event="message", msg="TESTS      : %s" % self.tests_total)
         self.stream.set_tests_info({'tests_total': self.tests_total})

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -323,12 +323,13 @@ class TestRunner(object):
             return False
         return True
 
-    def run_suite(self, test_suite, mux, timeout=0):
+    def run_suite(self, test_suite, mux, replay_map=None, timeout=0):
         """
         Run one or more tests and report with test result.
 
         :param test_suite: a list of tests to run.
         :param mux: the multiplexer.
+        :param replay_map: map with the test indexes to replay
         :param timeout: maximum amount of time (in seconds) to execute.
         :return: a list of test failures.
         """
@@ -343,11 +344,15 @@ class TestRunner(object):
         else:
             deadline = None
 
+        index = -1
         for test_template in test_suite:
             test_template[1]['base_logdir'] = self.job.logdir
             test_template[1]['job'] = self.job
             break_loop = False
             for test_factory in mux.itertests(test_template):
+                index += 1
+                if replay_map is not None and index not in replay_map:
+                    continue
                 if deadline is not None and time.time() > deadline:
                     test_parameters = test_factory[1]
                     if 'methodName' in test_parameters:

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -136,6 +136,27 @@ class Run(CLICmd):
                              help="Inject [path:]key:node values into the "
                              "final multiplex tree.")
 
+        replay = parser.add_argument_group('replay job options')
+
+        replay.add_argument('--replay', dest='replay_jobid', type=str,
+                            default=None,
+                            help='Replay a job identified by its (partial) '
+                                 'hash id.')
+
+        replay.add_argument('--replay-test-status', dest='replay_filter',
+                            type=str, default=None,
+                            help='Filter tests to replay by status '
+                                 '(FAIL,PASS).')
+
+        replay.add_argument('--replay-ignore', dest='replay_ignore',
+                            type=str, default=None,
+                            help='Ignore multiplex(mux) and/or config from the '
+                                 ' source job.')
+
+        super(TestRunner, self).configure(self.parser)
+        # Export the test runner parser back to the main parser
+        parser.runner = self.parser
+
     def _activate(self, args):
         # Extend default multiplex tree of --mux_inject values
         for value in getattr(args, "mux_inject", []):


### PR DESCRIPTION
The initial job replay support using the run option "--replay <job-id>"
implements the job replay, retrieving the original job urls, multiplex and
configuration.

The option "--replay-test-status <STATUS>" is fully functional,
allowing users to replay only the variants that faced a given status in
the original job.

To ignore some original job information, the option
"--replay-job-ignore <mux|config>" can be used.

Notice if can inform the urls and/or the multiplex using the command line.
The options informed in the command line will be used, making the replay job ignore
that information from the source job.

Signed-off-by: Amador Pahim <apahim@redhat.com>