### PR TITLE
avocado.core.loader: Append test directory to sys.path

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -258,8 +258,13 @@ class TestLoaderProxy(object):
         if isinstance(test_class, str):
             module_name = os.path.basename(test_path).split('.')[0]
             test_module_dir = os.path.dirname(test_path)
-            f, p, d = imp.find_module(module_name, [test_module_dir])
-            test_module = imp.load_module(module_name, f, p, d)
+            # Tests with local dir imports need this
+            try:
+                sys.path.insert(0, test_module_dir)
+                f, p, d = imp.find_module(module_name, [test_module_dir])
+                test_module = imp.load_module(module_name, f, p, d)
+            finally:
+                sys.path.pop(0)
             for _, obj in inspect.getmembers(test_module):
                 if (inspect.isclass(obj) and obj.__name__ == test_class and
                         inspect.getmodule(obj) == test_module):
@@ -267,6 +272,7 @@ class TestLoaderProxy(object):
                         test_class = obj
                         break
         test_instance = test_class(**test_parameters)
+
         return test_instance
 
 

--- a/examples/tests/test_local_imports/mylib.py
+++ b/examples/tests/test_local_imports/mylib.py
@@ -1,0 +1,2 @@
+def hello():
+    return 'Hello world'

--- a/examples/tests/test_local_imports/test_local_imports.py
+++ b/examples/tests/test_local_imports/test_local_imports.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+from avocado import main
+from avocado import Test
+
+from mylib import hello
+
+
+class LocalImportTest(Test):
+
+    """
+    Functional avocado test for local imports.
+    """
+
+    def test(self):
+        """
+        Log a string coming from a local import.
+        """
+        self.log.info(hello())
+
+
+if __name__ == "__main__":
+    main()

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -84,6 +84,13 @@ class RunnerOperationTest(unittest.TestCase):
                     "examples/tests/passtest.py" % self.tmpdir)
         process.run(cmd_line)
 
+    def test_runner_test_with_local_imports(self):
+        os.chdir(basedir)
+        cmd_line = ("./scripts/avocado run --sysinfo=off --job-results-dir %s "
+                    "examples/tests/test_local_imports/test_local_imports.py " %
+                    self.tmpdir)
+        process.run(cmd_line)
+
     def test_runner_tests_fail(self):
         os.chdir(basedir)
         cmd_line = './scripts/avocado run --sysinfo=off --job-results-dir %s passtest failtest passtest' % self.tmpdir


### PR DESCRIPTION
If a test has local imports (a fairly common use case),
we have to append the base test dir to sys.path. Otherwise,
we end up having a horrible traceback as a result:

Exception loading test
Traceback (most recent call last):
  File "/home/lmr/Code/avocado.lmr/avocado/core/runner.py", line 200, in _run_test
    instance = loader.load_test(test_factory)
  File "/home/lmr/Code/avocado.lmr/avocado/core/loader.py", line 262, in load_test
    test_module = imp.load_module(module_name, f, p, d)
  File "scylla_longevity.py", line 5, in <module>
    from sdcm.tester import ScyllaClusterTester
ImportError: No module named sdcm.tester

Which is clearly not wanted. We had this problem before
and now we have a regression. It's time for a functional
test to make sure we don't regress again.

Signed-off-by: Lucas Meneghel Rodrigues <lookkas@gmail.com>