### PR TITLE
avocado.core.loader: Append test directory to sys.path [v2]

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -258,8 +258,13 @@ class TestLoaderProxy(object):
         if isinstance(test_class, str):
             module_name = os.path.basename(test_path).split('.')[0]
             test_module_dir = os.path.dirname(test_path)
-            f, p, d = imp.find_module(module_name, [test_module_dir])
-            test_module = imp.load_module(module_name, f, p, d)
+            # Tests with local dir imports need this
+            try:
+                sys.path.insert(0, test_module_dir)
+                f, p, d = imp.find_module(module_name, [test_module_dir])
+                test_module = imp.load_module(module_name, f, p, d)
+            finally:
+                sys.path.pop(0)
             for _, obj in inspect.getmembers(test_module):
                 if (inspect.isclass(obj) and obj.__name__ == test_class and
                         inspect.getmodule(obj) == test_module):
@@ -267,6 +272,7 @@ class TestLoaderProxy(object):
                         test_class = obj
                         break
         test_instance = test_class(**test_parameters)
+
         return test_instance
 
 

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -56,6 +56,20 @@ class HelloWorld(Plugin):
         print('Hello World!')
 """
 
+HELLO_LIB_CONTENTS = """
+def hello():
+    return 'Hello world'
+"""
+
+LOCAL_IMPORT_TEST_CONTENTS = '''
+from avocado import Test
+from mylib import hello
+
+class LocalImportTest(Test):
+    def test(self):
+        self.log.info(hello())
+'''
+
 
 class RunnerOperationTest(unittest.TestCase):
 
@@ -82,6 +96,21 @@ class RunnerOperationTest(unittest.TestCase):
         os.chdir(basedir)
         cmd_line = ("./scripts/avocado run --sysinfo=off --job-results-dir %s examples/tests/passtest.py "
                     "examples/tests/passtest.py" % self.tmpdir)
+        process.run(cmd_line)
+
+    def test_runner_test_with_local_imports(self):
+        mylib = script.TemporaryScript(
+            'mylib.py',
+            HELLO_LIB_CONTENTS,
+            'avocado_simpletest_functional')
+        mylib.save()
+        mytest = script.Script(
+            os.path.join(os.path.dirname(mylib.path), 'test_local_imports.py'),
+            LOCAL_IMPORT_TEST_CONTENTS)
+        os.chdir(basedir)
+        mytest.save()
+        cmd_line = ("./scripts/avocado run --sysinfo=off --job-results-dir %s "
+                    "%s" % (self.tmpdir, mytest))
         process.run(cmd_line)
 
     def test_runner_tests_fail(self):


### PR DESCRIPTION
If a test has local imports (a fairly common use case),
we have to append the base test dir to sys.path. Otherwise,
we end up having a horrible traceback as a result:

Exception loading test
Traceback (most recent call last):
  File "/home/lmr/Code/avocado.lmr/avocado/core/runner.py", line 200, in _run_test
    instance = loader.load_test(test_factory)
  File "/home/lmr/Code/avocado.lmr/avocado/core/loader.py", line 262, in load_test
    test_module = imp.load_module(module_name, f, p, d)
  File "scylla_longevity.py", line 5, in <module>
    from sdcm.tester import ScyllaClusterTester
ImportError: No module named sdcm.tester

Which is clearly not wanted. We had this problem before
and now we have a regression. It's time for a functional
test to make sure we don't regress again.

Signed-off-by: Lucas Meneghel Rodrigues <lookkas@gmail.com>
Signed-off-by: Cleber Rosa <crosa@redhat.com>

---

Changes from v1:
 * Made functional test sources (`mylib.py` and `test_local_imports.py`) inline