### PR TITLE
selftests/functional/test_basic.py: remove references to old Plugin

### DIFF
--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -33,29 +33,6 @@ false
 
 FAIL_SHELL_CONTENTS = "exit 1"
 
-VOID_PLUGIN_CONTENTS = """#!/usr/bin/env python
-from avocado.core.plugins.plugin import Plugin
-class VoidPlugin(Plugin):
-    pass
-"""
-
-SYNTAX_ERROR_PLUGIN_CONTENTS = """#!/usr/bin/env python
-from avocado.core.plugins.plugin import Plugin
-class VoidPlugin(Plugin)
-"""
-
-HELLO_PLUGIN_CONTENTS = """#!/usr/bin/env python
-from avocado.core.plugins.plugin import Plugin
-class HelloWorld(Plugin):
-    name = 'hello'
-    enabled = True
-    def configure(self, parser):
-        self.parser = parser.subcommands.add_parser('hello')
-        super(HelloWorld, self).configure(self.parser)
-    def run(self, args):
-        print('Hello World!')
-"""
-
 HELLO_LIB_CONTENTS = """
 def hello():
     return 'Hello world'


### PR DESCRIPTION
There are a few leftover references to the old Plugin classes in
the functional tests. Let's remove them.

Signed-off-by: Cleber Rosa <crosa@redhat.com>