### PR TITLE
avocado.core.remote.runner: Use re.MULTILINE on avocado version check

### DIFF
--- a/avocado/core/remote/runner.py
+++ b/avocado/core/remote/runner.py
@@ -36,7 +36,10 @@ class RemoteTestRunner(TestRunner):
     """ Tooled TestRunner to run on remote machine using ssh """
     remote_test_dir = '~/avocado/tests'
 
-    remote_version_re = re.compile(r'^Avocado (\d+)\.(\d+)\.(\d+)$')
+    # Let's use re.MULTILINE because sometimes servers might have MOTD
+    # that will introduce a line break on output.
+    remote_version_re = re.compile(r'^Avocado (\d+)\.(\d+)\.(\d+)$',
+                                   re.MULTILINE)
 
     def check_remote_avocado(self):
         """


### PR DESCRIPTION
Sometimes remote servers might have MOTD (message of the day)
banners, that will introduce line breaks on the remote output
of the `avocado -v` command. Let's use re.MULTILINE to fix that.

Signed-off-by: Lucas Meneghel Rodrigues <lookkas@gmail.com>