### PR TITLE
avocado.core.remote.runner: Relax regexp

### DIFF
--- a/avocado/core/remote/runner.py
+++ b/avocado/core/remote/runner.py
@@ -38,7 +38,7 @@ class RemoteTestRunner(TestRunner):
 
     # Let's use re.MULTILINE because sometimes servers might have MOTD
     # that will introduce a line break on output.
-    remote_version_re = re.compile(r'^Avocado (\d+)\.(\d+)\.(\d+)$',
+    remote_version_re = re.compile(r'Avocado (\d+)\.(\d+)\.(\d+)$',
                                    re.MULTILINE)
 
     def check_remote_avocado(self):


### PR DESCRIPTION
It turns out that with MOTDs on, the ^ requirement
of the regexp needs to be dropped. A real example:

23:19:41 output     L0332 DEBUG| [52.91.252.44] out: [mAvocado 0.30.0

Signed-off-by: Lucas Meneghel Rodrigues <lookkas@gmail.com>