### PR TITLE
avocado: Refactor logging initialization

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -106,20 +106,6 @@ class Job(object):
             self.loglevel = mapping[raw_log_level]
         else:
             self.loglevel = logging.DEBUG
-        self.show_job_log = getattr(self.args, 'show_job_log', False)
-        self.silent = getattr(self.args, 'silent', False)
-
-        if self.standalone:
-            self.show_job_log = True
-            if self.args is not None:
-                setattr(self.args, 'show_job_log', True)
-
-        if self.show_job_log:
-            if not self.silent:
-                output.add_console_handler(_TEST_LOGGER)
-                output.add_console_handler(logging.getLogger())
-                _TEST_LOGGER.setLevel(self.loglevel)
-                _TEST_LOGGER.propagate = False
 
         self.test_dir = data_dir.get_test_dir()
         self.test_index = 1
@@ -531,6 +517,8 @@ class TestProgram(object):
     def __init__(self):
         self.defaultTest = sys.argv[0]
         self.progName = os.path.basename(sys.argv[0])
+        output.add_log_handler("", output.ProgressStreamHandler,
+                               fmt="%(message)s")
         self.parseArgs(sys.argv[1:])
         self.runTests()
 
@@ -546,6 +534,7 @@ class TestProgram(object):
     def runTests(self):
         exit_status = exit_codes.AVOCADO_ALL_OK
         self.args.standalone = True
+        self.args.log = ["test", "early"]
         self.job = Job(self.args)
         if self.defaultTest is not None:
             exit_status = self.job.run(urls=[self.defaultTest])

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -417,9 +417,10 @@ class Job(object):
                 that configure a job failure.
         """
         self._setup_job_results()
-        self.view.start_file_logging(self.logfile,
-                                     self.loglevel,
-                                     self.unique_id)
+        self.view.start_job_logging(self.logfile,
+                                    self.loglevel,
+                                    self.unique_id)
+
         try:
             test_suite = self._make_test_suite(urls)
         except loader.LoaderError, details:
@@ -449,7 +450,7 @@ class Job(object):
         self.view.logfile = self.logfile
         failures = self.test_runner.run_suite(test_suite, mux,
                                               timeout=self.timeout)
-        self.view.stop_file_logging()
+        self.view.stop_job_logging()
         # If it's all good so far, set job status to 'PASS'
         if self.status == 'RUNNING':
             self.status = 'PASS'

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -424,7 +424,7 @@ class Job(object):
         try:
             test_suite = self._make_test_suite(urls)
         except loader.LoaderError, details:
-            stacktrace.log_exc_info(sys.exc_info(), 'avocado.app.tracebacks')
+            stacktrace.log_exc_info(sys.exc_info(), 'avocado.app.debug')
             self._remove_job_results()
             raise exceptions.OptionValidationError(details)
         if not test_suite:

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -208,8 +208,7 @@ class TestLoaderProxy(object):
                                    "%s" % (plugin, details),
                                    'avocado.app.exceptions')
             # FIXME: Introduce avocado.traceback logger and use here
-            stacktrace.log_exc_info(sys.exc_info(),
-                                    'avocado.app.tracebacks')
+            stacktrace.log_exc_info(sys.exc_info(), 'avocado.app.debug')
         tests = []
         unhandled_urls = []
         if not urls:

--- a/avocado/core/log.py
+++ b/avocado/core/log.py
@@ -13,125 +13,120 @@
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
 
-__all__ = ['configure', 'DEFAULT_LOGGING']
-
-
+from StringIO import StringIO
 import logging
 import os
+import sys
+
+from . import output
+
+
+__all__ = ["early_start", "enable_stderr", "reconfigure"]
+
 
 if hasattr(logging, 'NullHandler'):
-    NULL_HANDLER = 'logging.NullHandler'
+    NULL_HANDLER = logging.NullHandler
 else:
-    NULL_HANDLER = 'logutils.NullHandler'
-
-DEFAULT_LOGGING = {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'formatters': {
-        'brief': {
-            'format': '%(message)s',
-        },
-    },
-    'filters': {
-        'error': {
-            '()': 'avocado.core.output.FilterError',
-        },
-        'info': {
-            '()': 'avocado.core.output.FilterInfo',
-        },
-    },
-    'handlers': {
-        'null': {
-            'level': 'INFO',
-            'class': NULL_HANDLER,
-        },
-        'console': {
-            'level': 'INFO',
-            'class': 'logging.StreamHandler',
-            'formatter': 'brief',
-        },
-        'app': {
-            'level': 'INFO',
-            'class': 'avocado.core.output.ProgressStreamHandler',
-            'formatter': 'brief',
-            'filters': ['info'],
-            'stream': 'ext://sys.stdout',
-        },
-        'error': {
-            'level': 'ERROR',
-            'class': 'logging.StreamHandler',
-            'formatter': 'brief',
-            'filters': ['error'],
-        },
-        'debug': {
-            'level': 'DEBUG',
-            'class': 'avocado.core.output.ProgressStreamHandler',
-            'formatter': 'brief',
-            'stream': 'ext://sys.stdout',
-        },
-    },
-    'loggers': {
-        '': {
-            'handlers': ['null']
-        },
-        'avocado': {
-            'handlers': ['console'],
-        },
-        'avocado.app': {
-            'handlers': ['app', 'error'],
-            'level': 'INFO',
-            'propagate': False,
-        },
-        'avocado.app.tracebacks': {
-            # Set DEBUG=true to enable debugs
-            'handlers': ['error' if os.environ.get('DEBUG') else 'null'],
-            'level': 'ERROR',
-            'propagate': False,
-        },
-        'avocado.test': {
-            'handlers': ['null'],
-            'level': 'DEBUG',
-            'propagate': False,
-        },
-        'avocado.fabric': {
-            'handlers': ['null'],
-            'level': 'DEBUG',
-            'propagate': False,
-        },
-        'paramiko': {
-            'handlers': ['null'],
-            'level': 'DEBUG',
-            'propagate': False,
-        },
-        'avocado.test.stdout': {
-            'handlers': ['null'],
-            'level': 'DEBUG',
-            'propagate': False,
-        },
-        'avocado.test.stderr': {
-            'handlers': ['null'],
-            'level': 'DEBUG',
-            'propagate': False,
-        },
-        'avocado.sysinfo': {
-            'handlers': ['error'],
-            'level': 'DEBUG',
-            'propagate': False,
-        },
-        'avocado.debug': {
-            'handlers': ['debug'],
-            'level': 'DEBUG',
-            'propagate': False,
-        },
-    }
-}
+    import logutils
+    NULL_HANDLER = logutils.NullHandler
 
 
-def configure(logging_config=DEFAULT_LOGGING):
-    from logging import config
-    if not hasattr(config, 'dictConfig'):
-        from logutils import dictconfig
-        cfg_func = dictconfig.dictConfig
+STDOUT = sys.stdout
+STDERR = sys.stderr
+
+
+def early_start():
+    """
+    Replace all outputs with in-memory handlers
+    """
+    if os.environ.get('DEBUG_AVOCADO'):
+        output.add_log_handler("avocado.app.debug", None, STDERR,
+                               logging.DEBUG)
+    if os.environ.get('DEBUG_EARLY'):
+        output.add_log_handler("", None, STDERR, logging.DEBUG)
+        output.add_log_handler("avocado.test", None, STDERR, logging.DEBUG)
     else:
-        cfg_func = config.dictConfig
-    cfg_func(logging_config)
+        sys.stdout = StringIO()
+        sys.stderr = sys.stdout
+        output.add_log_handler("", output.MemStreamHandler, None,
+                               logging.DEBUG)
+    logging.root.level = logging.DEBUG
+
+
+def enable_stderr():
+    """
+    Enable direct stdout/stderr (useful for handling errors)
+    """
+    if hasattr(sys.stdout, 'getvalue'):
+        STDERR.write(sys.stdout.getvalue())
+    sys.stdout = STDOUT
+    sys.stderr = STDERR
+
+
+def reconfigure(args):
+    """
+    Adjust logging handlers accordingly to app args and re-log messages.
+    """
+    # Reconfigure stream loggers
+    enabled = getattr(args, "log", ["app,early,debug"])
+    if os.environ.get("DEBUG_EARLY") and "early" not in enabled:
+        enabled.append("early")
+    if os.environ.get("DEBUG_AVOCADO") and "debug" not in enabled:
+        enabled.append("debug")
+    if getattr(args, "show_job_log", False) and "test" not in enabled:
+        enabled.append("test")
+    if getattr(args, "silent", False):
+        del enabled[:]
+    if "app" in enabled:
+        appl = logging.getLogger("avocado.app")
+        apph = output.ProgressStreamHandler()
+        apph.setFormatter(logging.Formatter("%(message)s"))
+        apph.addFilter(output.FilterInfo())
+        apph.stream = STDOUT
+        appl.addHandler(apph)
+        appl.propagate = False
+        appl.level = logging.INFO
+        appeh = output.logging.StreamHandler()
+        appeh.setFormatter(logging.Formatter("%(message)s"))
+        appeh.addFilter(output.FilterError())
+        appeh.stream = STDERR
+        appl.addHandler(appeh)
+        appl.propagate = False
+    else:
+        output.disable_log_handler("avocado.app")
+    if not os.environ.get("DEBUG_EARLY"):
+        logging.getLogger("avocado.test.stdout").propagate = False
+        logging.getLogger("avocado.test.stderr").propagate = False
+        if "early" in enabled:
+            enable_stderr()
+            output.add_log_handler("", None, STDERR, logging.DEBUG)
+            output.add_log_handler("avocado.test", None, STDERR,
+                                   logging.DEBUG)
+        else:
+            # FIXME: When log and output are merged, to this in
+            # start_job_logging
+            # Don't relog old messages!
+            sys.stdout = STDOUT
+            sys.stderr = STDERR
+            output.disable_log_handler("")
+            output.disable_log_handler("avocado.test")
+    if "remote" in enabled:
+        output.add_log_handler("avocado.fabric", stream=STDERR)
+        output.add_log_handler("paramiko", stream=STDERR)
+    else:
+        output.disable_log_handler("avocado.fabric")
+        output.disable_log_handler("paramiko")
+    if not os.environ.get('DEBUG_AVOCADO'):     # Not already enabled by env
+        if "debug" in enabled:
+            output.add_log_handler("avocado.app.debug", stream=STDERR)
+        else:
+            output.disable_log_handler("avocado.app.debug")
+
+    # Remove the in-memory handlers
+    for handler in logging.root.handlers:
+        if isinstance(handler, output.MemStreamHandler):
+            logging.root.handlers.remove(handler)
+
+    # Log early_messages
+    for record in output.MemStreamHandler.log:
+        logging.getLogger(record.name).handle(record)

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -22,6 +22,12 @@ import sys
 from .settings import settings
 from ..utils import path as utils_path
 
+if hasattr(logging, 'NullHandler'):
+    NULL_HANDLER = logging.NullHandler
+else:
+    import logutils
+    NULL_HANDLER = logutils.NullHandler
+
 
 class FilterError(logging.Filter):
 
@@ -56,6 +62,18 @@ class ProgressStreamHandler(logging.StreamHandler):
             raise
         except Exception:
             self.handleError(record)
+
+
+class MemStreamHandler(logging.StreamHandler):
+
+    """
+    Handler that stores all records in self.log (shared in all instances)
+    """
+
+    log = []
+
+    def emit(self, record):
+        self.log.append(record)
 
 
 class PagerNotFoundError(Exception):
@@ -135,6 +153,15 @@ def add_log_handler(logger, klass=None, stream=None, level=None, fmt=None):
     console_handler.setFormatter(formatter)
     logging.getLogger(logger).addHandler(console_handler)
     logging.getLogger(logger).propagate = False
+
+
+def disable_log_handler(logger):
+    logger = logging.getLogger(logger)
+    # Handlers might be reused elsewhere, can't delete them
+    while logger.handlers:
+        logger.handlers.pop()
+    logger.handlers.append(NULL_HANDLER())
+    logger.propagate = False
 
 
 class TermSupport(object):
@@ -415,6 +442,8 @@ class View(object):
             self.paginator = None
         self.throbber = Throbber()
         self.tests_info = {}
+        self.file_handler = None
+        self.stream_handler = None
 
     def cleanup(self):
         if self.use_paginator:
@@ -481,14 +510,8 @@ class View(object):
         :param msg: Message to write
         :type msg: string
         """
-        silent = False
-        show_job_log = False
-        if self.app_args is not None:
-            if hasattr(self.app_args, 'silent'):
-                silent = self.app_args.silent
-            if hasattr(self.app_args, 'show_job_log'):
-                show_job_log = self.app_args.show_job_log
-        if not (silent or show_job_log):
+        enabled = getattr(self.app_args, "log", [])
+        if "app" in enabled:
             if self.use_paginator and (level < logging.ERROR):
                 if not skip_newline:
                     msg += '\n'
@@ -571,6 +594,7 @@ class View(object):
         """
         self.job_unique_id = unique_id
         self.debuglog = logfile
+        # File loggers
         self.file_handler = logging.FileHandler(filename=logfile)
         self.file_handler.setLevel(loglevel)
 
@@ -585,15 +609,24 @@ class View(object):
         root_logger = logging.getLogger()
         root_logger.addHandler(self.file_handler)
         root_logger.setLevel(loglevel)
+        # Console loggers
+        if ('test' in self.app_args.log and
+                'early' not in self.app_args.log):
+            self.stream_handler = ProgressStreamHandler()
+            test_logger.addHandler(self.stream_handler)
+            root_logger.addHandler(self.stream_handler)
 
     def stop_job_logging(self):
         """
         Simple helper for removing a handler from the current logger.
         """
+        # File loggers
         test_logger = logging.getLogger('avocado.test')
-        linux_logger = logging.getLogger('avocado.linux')
         root_logger = logging.getLogger()
         test_logger.removeHandler(self.file_handler)
-        linux_logger.removeHandler(self.file_handler)
         root_logger.removeHandler(self.file_handler)
         self.file_handler.close()
+        # Console loggers
+        if self.stream_handler:
+            test_logger.removeHandler(self.stream_handler)
+            root_logger.removeHandler(self.stream_handler)

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -144,7 +144,7 @@ def add_log_handler(logger, klass=None, stream=None, level=None, fmt=None):
     if stream is None:
         stream = sys.stdout
     if level is None:
-        level = "INFO"
+        level = logging.INFO
     if fmt is None:
         fmt = '%(name)s: %(message)s'
     console_handler = klass(stream)

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -547,7 +547,7 @@ class View(object):
         """
         self._log_ui_info(term_support.warn_header_str(msg), skip_newline)
 
-    def start_file_logging(self, logfile, loglevel, unique_id):
+    def start_job_logging(self, logfile, loglevel, unique_id):
         """
         Start the main file logging.
 
@@ -572,7 +572,7 @@ class View(object):
         root_logger.addHandler(self.file_handler)
         root_logger.setLevel(loglevel)
 
-    def stop_file_logging(self):
+    def stop_job_logging(self):
         """
         Simple helper for removing a handler from the current logger.
         """

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -111,16 +111,30 @@ def get_paginator():
     return Paginator()
 
 
-def add_console_handler(logger):
+def add_log_handler(logger, klass=None, stream=None, level=None, fmt=None):
     """
-    Add a console handler to a logger.
+    Add handler to a logger.
 
     :param logger: `logging.Logger` instance.
+    :param klass: Handler class [`logging.StreamHandler`]
+    :param stream: Logging stream (klass argument) [`sys.stdout`]
+    :param level: Log level [`INFO`]
+    :param fmt: Formatter [`%(name)s: %(message)s`]
     """
-    console_handler = logging.StreamHandler(sys.stdout)
-    formatter = logging.Formatter(fmt='%(message)s')
+    if klass is None:
+        klass = logging.StreamHandler
+    if stream is None:
+        stream = sys.stdout
+    if level is None:
+        level = "INFO"
+    if fmt is None:
+        fmt = '%(name)s: %(message)s'
+    console_handler = klass(stream)
+    console_handler.setLevel(level)
+    formatter = logging.Formatter(fmt=fmt)
     console_handler.setFormatter(formatter)
-    logger.addHandler(console_handler)
+    logging.getLogger(logger).addHandler(console_handler)
+    logging.getLogger(logger).propagate = False
 
 
 class TermSupport(object):

--- a/avocado/core/parser.py
+++ b/avocado/core/parser.py
@@ -18,6 +18,7 @@ Avocado application command line parsing.
 """
 
 import argparse
+import sys
 
 from . import tree
 from . import settings
@@ -25,6 +26,27 @@ from .version import VERSION
 
 PROG = 'avocado'
 DESCRIPTION = 'Avocado Test Runner'
+
+
+def log_type(value):
+    valid_streams = ["app", "test", "debug", "remote", "early", "all", "none"]
+    value = value.split(',')
+    if any(_ not in valid_streams for _ in value):
+        sys.stderr.write("Invalid logging stream selected. Supported log "
+                         "streams are:\n app - application output\n "
+                         "test - test output\n debug - tracebacks and other "
+                         "debugging info\n remote - fabric/paramiko debug\n "
+                         "early - early logging of other streams (very "
+                         "verbose\n all - everything\n none - disable "
+                         "everything\n")
+        sys.exit(-1)
+
+    if 'all' in value:
+        return ["app", "test", "debug", "remote", "early"]
+    elif 'none' in value:
+        return []
+    else:
+        return value
 
 
 class Parser(object):
@@ -44,6 +66,12 @@ class Parser(object):
                                       version='Avocado %s' % VERSION)
         self.application.add_argument('--config', metavar='CONFIG_FILE',
                                       help='Use custom configuration from a file')
+        self.application.add_argument('--log', action="store",
+                                      type=log_type,
+                                      metavar='STREAMS', default=['app'],
+                                      help="Comma separated list of logging "
+                                      "streams to be enabled (app,test,debug,"
+                                      "remote,early); By default 'app'")
 
     def start(self):
         """

--- a/avocado/core/remote/runner.py
+++ b/avocado/core/remote/runner.py
@@ -157,7 +157,7 @@ class RemoteTestRunner(TestRunner):
         logger_list = [fabric_logger]
         if self.result.args.show_job_log:
             logger_list.append(app_logger)
-            output.add_console_handler(paramiko_logger)
+            output.add_log_handler(paramiko_logger.name)
         sys.stdout = output.LoggingFile(logger=logger_list)
         sys.stderr = output.LoggingFile(logger=logger_list)
         try:

--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -541,7 +541,7 @@ def collect_sysinfo(args):
 
     :param args: :class:`argparse.Namespace` object with command line params.
     """
-    output.add_console_handler(log)
+    output.add_log_handler(log.name)
 
     basedir = args.sysinfodir
     if not basedir:

--- a/avocado/plugins/multiplex.py
+++ b/avocado/plugins/multiplex.py
@@ -90,7 +90,6 @@ class Multiplex(CLICmd):
         elif not args.tree and args.inherit:
             err = "Option --inherit can be only used with --tree"
         if err:
-            view.notify(event="minor", msg=self.parser.format_help())
             view.notify(event="error", msg=err)
             sys.exit(exit_codes.AVOCADO_FAIL)
         try:

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -347,11 +347,11 @@ class RunnerHumanOutputTest(unittest.TestCase):
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %s:\n%s" %
                          (expected_rc, result))
-        self.assertIn('[stdout] foo', result.stdout, result)
-        self.assertIn('[stdout] \'"', result.stdout, result)
-        self.assertIn('[stdout] bar/baz', result.stdout, result)
+        self.assertIn('[stdout] foo', result.stderr, result)
+        self.assertIn('[stdout] \'"', result.stderr, result)
+        self.assertIn('[stdout] bar/baz', result.stderr, result)
         self.assertIn('PASS /bin/echo -ne foo\\\\n\\\'\\"\\\\nbar/baz',
-                      result.stdout, result)
+                      result.stderr, result)
         # logdir name should escape special chars (/)
         test_dirs = glob.glob(os.path.join(self.tmpdir, 'latest',
                                            'test-results', '*'))
@@ -449,12 +449,12 @@ class RunnerSimpleTest(unittest.TestCase):
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %s:\n%s" %
                          (expected_rc, result))
-        self.assertIn('DEBUG| Debug message', result.stdout, result)
-        self.assertIn('INFO | Info message', result.stdout, result)
+        self.assertIn('DEBUG| Debug message', result.stderr, result)
+        self.assertIn('INFO | Info message', result.stderr, result)
         self.assertIn('WARN | Warning message (should cause this test to '
-                      'finish with warning)', result.stdout, result)
+                      'finish with warning)', result.stderr, result)
         self.assertIn('ERROR| Error message (ordinary message not changing '
-                      'the results)', result.stdout, result)
+                      'the results)', result.stderr, result)
 
     def tearDown(self):
         self.pass_script.remove()

--- a/selftests/functional/test_multiplex.py
+++ b/selftests/functional/test_multiplex.py
@@ -103,11 +103,11 @@ class MultiplexTests(unittest.TestCase):
         for msg in ('A', 'ASDFASDF', 'This is very long\nmultiline\ntext.'):
             msg = ('[stdout] Custom variable: ' +
                    '\n[stdout] '.join(msg.splitlines()))
-            self.assertIn(msg, result.stdout, "Multiplexed variable should "
+            self.assertIn(msg, result.stderr, "Multiplexed variable should "
                                               "produce:"
                           "\n  %s\nwhich is not present in the output:\n  %s"
                           % ("\n  ".join(msg.splitlines()),
-                             "\n  ".join(result.stdout.splitlines())))
+                             "\n  ".join(result.stderr.splitlines())))
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir)

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -89,7 +89,7 @@ class OutputPluginTest(unittest.TestCase):
                          (expected_rc, result))
         error_excerpt = "HTML to stdout not supported"
         self.assertIn(error_excerpt, output,
-                      "Missing excerpt error message from output:\n%s" % output)
+                      "Missing except error message from output:\n%s" % output)
 
     def test_output_compatible_setup(self):
         tmpfile = tempfile.mktemp()
@@ -204,10 +204,10 @@ class OutputPluginTest(unittest.TestCase):
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %d:\n%s" %
                          (expected_rc, result))
-        job_id_list = re.findall('Job ID: (.*)', result.stdout,
+        job_id_list = re.findall('Job ID: (.*)', result.stderr,
                                  re.MULTILINE)
-        self.assertTrue(job_id_list, 'No Job ID in stdout:\n%s' %
-                        result.stdout)
+        self.assertTrue(job_id_list, 'No Job ID in stderr:\n%s' %
+                        result.stderr)
         job_id = job_id_list[0]
         self.assertEqual(len(job_id), 40)
 

--- a/selftests/unit/test_jsonresult.py
+++ b/selftests/unit/test_jsonresult.py
@@ -12,10 +12,10 @@ from avocado.core import job
 
 class _Stream(object):
 
-    def start_file_logging(self, param1, param2):
+    def start_job_logging(self, param1, param2):
         pass
 
-    def stop_file_logging(self):
+    def stop_job_logging(self):
         pass
 
     def set_tests_info(self, info):

--- a/selftests/unit/test_xunit.py
+++ b/selftests/unit/test_xunit.py
@@ -16,10 +16,10 @@ class ParseXMLError(Exception):
 
 class _Stream(object):
 
-    def start_file_logging(self, param1, param2):
+    def start_job_logging(self, param1, param2):
         pass
 
-    def stop_file_logging(self):
+    def stop_job_logging(self):
         pass
 
     def set_tests_info(self, info):


### PR DESCRIPTION
Hello guys,

this complex PR is a first step to refactor the logging. What it does is it changes the initialization of logging to by design avoid problems with --silent not ready during parser initialization.

The missing pieces are:

1. merge "log.py" and "output.py" as they serve the same purpose and are interconnected a lot
2. remove the concept of "View". Instead during "reconfigure" (when paginator==on) replace the stdout/stderr/enabled_logs with handler, which outputs in paginator. This again by design merge all outputs into paginator (avoids the problem where paginator overrode traceback logging streams) and also as there will be a single place to initialize, and cleanup the paginator it should make it easier to ensure cleanup is called. The "View().minor()" and similar calls should become simply "logging.getLogger(...).debug()".
3. review the "standalone", "show-job-log" and "silent" args and remove unnecessary handling (some handling is still needed until (2) is done)