### PR TITLE
HTML output support: behave when the plugin is not installed

### DIFF
--- a/avocado/core/html.py
+++ b/avocado/core/html.py
@@ -30,6 +30,18 @@ from ..utils import path as utils_path
 from ..utils import runtime
 
 
+def check_resource_requirements():
+    """
+    Checks if necessary resource files to render the report are in place
+
+    Currently, only the template file is looked for
+    """
+    base_path = os.path.dirname(sys.modules[__name__].__file__)
+    html_resources_path = os.path.join(base_path, 'resources', 'htmlresult')
+    template = os.path.join(html_resources_path, 'templates', 'report.mustache')
+    return os.path.exists(template)
+
+
 class ReportModel(object):
 
     """

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -53,7 +53,7 @@ from ..utils import data_structures
 
 try:
     from . import html
-    HTML_REPORT_SUPPORT = True
+    HTML_REPORT_SUPPORT = html.check_resource_requirements()
 except ImportError:
     HTML_REPORT_SUPPORT = False
 


### PR DESCRIPTION
We currently only set HTML support as disabled if the `html.py`
library fails to import. The truth is that missing files that
are intended to be present on the (separately packaged) HTML
plugin package can cause other kinds of exceptions.

Let's add an extra check, looking if the resource files are
present (currently the template file).

Note: there's one outstanding bug, for which a fix is being
worked on. When Avocado is installed, either from packages
or from source code, the HTML plugin entry point is always
registered. That means the plugin Python module is always
tried to be loaded. If the plugin *package* is not installed,
an error message is given on the command line.

Signed-off-by: Cleber Rosa <crosa@redhat.com>