### PR TITLE
avocado.core: job replay support [v5]

### DIFF
--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -547,7 +547,7 @@ class View(object):
         """
         self._log_ui_info(term_support.warn_header_str(msg), skip_newline)
 
-    def start_file_logging(self, logfile, loglevel, unique_id):
+    def start_file_logging(self, logfile, loglevel, unique_id, sourcejob=None):
         """
         Start the main file logging.
 
@@ -559,6 +559,7 @@ class View(object):
         self.debuglog = logfile
         self.file_handler = logging.FileHandler(filename=logfile)
         self.file_handler.setLevel(loglevel)
+        self.replay_sourcejob = sourcejob
 
         fmt = ('%(asctime)s %(module)-16.16s L%(lineno)-.4d %('
                'levelname)-5.5s| %(message)s')

--- a/avocado/core/replay.py
+++ b/avocado/core/replay.py
@@ -1,0 +1,113 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2013-2015
+# Author: Amador Pahim <apahim@redhat.com>
+
+import ast
+import glob
+import json
+import os
+import pickle
+import re
+from .settings import settings
+from ..utils import path
+
+"""
+Record/retrieve job information for job replay
+"""
+
+
+def record(args, logdir, mux, urls=None):
+    replay_dir = path.init_dir(logdir, 'replay')
+    path_cfg = os.path.join(replay_dir, 'config')
+    path_urls = os.path.join(replay_dir, 'urls')
+    path_mux = os.path.join(replay_dir, 'multiplex')
+
+    if urls:
+        with open(path_urls, 'w') as f:
+            f.write('%s' % urls)
+
+    with open(path_cfg, 'w') as f:
+        settings.config.write(f)
+
+    with open(path_mux, 'w') as f:
+        pickle.dump(mux, f, pickle.HIGHEST_PROTOCOL)
+
+
+def retrieve_urls(resultsdir):
+    recorded_urls = os.path.join(resultsdir, "replay", "urls")
+    if not os.path.exists(recorded_urls):
+        return None
+
+    with open(recorded_urls, 'r') as f:
+        urls = f.read()
+
+    return ast.literal_eval(urls)
+
+
+def retrieve_mux(resultsdir):
+    pkl_path = os.path.join(resultsdir, 'replay', 'multiplex')
+    if not os.path.exists(pkl_path):
+        return None
+
+    with open(pkl_path, 'r') as f:
+        return pickle.load(f)
+
+
+def retrieve_replay_map(resultsdir, replay_filter):
+    replay_map = None
+    resultsfile = os.path.join(resultsdir, "results.json")
+    if not os.path.exists(resultsfile):
+        return None
+
+    with open(resultsfile, 'r') as results_file_obj:
+        results = json.loads(results_file_obj.read())
+
+    if replay_filter:
+        replay_map = [index for index, test in enumerate(results['tests'])
+                      if test['status'] in replay_filter]
+    else:
+        replay_map = None
+
+    return replay_map
+
+
+def get_resultsdir(logdir, jobid):
+    matches = 0
+    short_jobid = jobid[:7]
+    if len(short_jobid) < 7:
+        short_jobid += '*'
+    idfile_pattern = os.path.join(logdir, 'job-*-%s' % short_jobid, 'id')
+
+    for id_file in glob.glob(idfile_pattern):
+        with open(id_file, 'r') as f:
+            fileid = f.read().strip('\n')
+        if re.match(jobid, fileid):
+            match_file = id_file
+            sourcejob = fileid
+            matches += 1
+
+    if matches == 1:
+        return os.path.dirname(match_file), sourcejob
+    else:
+        return None, None
+
+
+def _get_unused_path(directory, filename):
+    count = 1
+    path = os.path.join(directory, filename)
+    while os.path.exists(path):
+        filename = "%s_%s" % (count, filename)
+        path = os.path.join(directory, filename)
+        count += 1
+
+    return path

--- a/avocado/core/result.py
+++ b/avocado/core/result.py
@@ -263,6 +263,9 @@ class HumanTestResult(TestResult):
         """
         TestResult.start_tests(self)
         self.stream.notify(event="message", msg="JOB ID     : %s" % self.stream.job_unique_id)
+        if self.stream.replay_sourcejob is not None:
+            self.stream.notify(event="message", msg="SRC JOB ID : %s" %
+                               self.stream.replay_sourcejob)
         self.stream.notify(event="message", msg="JOB LOG    : %s" % self.stream.logfile)
         self.stream.notify(event="message", msg="TESTS      : %s" % self.tests_total)
         self.stream.set_tests_info({'tests_total': self.tests_total})

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -687,6 +687,23 @@ class TimeOutSkipTest(Test):
         raise NotImplementedError("This should never be executed!")
 
 
+class ReplaySkipTest(Test):
+
+    """
+    Skip test due to replay filter.
+
+    This test is skipped due to a job replay filter.
+    """
+
+    _skip_reason = "Test skipped due a job replay filter!"
+
+    def setUp(self):
+        raise exceptions.TestNAError(self._skip_reason)
+
+    def test(self):
+        raise NotImplementedError("This should never be executed!")
+
+
 class DryRunTest(TimeOutSkipTest):
 
     """

--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -1,0 +1,128 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2013-2014
+# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+
+import os
+import sys
+
+from .base import CLI
+from avocado.core import replay
+from avocado.core import exit_codes
+from avocado.core import output
+from avocado.core.settings import settings
+
+
+class Replay(CLI):
+
+    """
+    Replay a job
+    """
+
+    name = 'replay'
+    description = "Replay options for 'run' subcommand"
+
+    def configure(self, parser):
+        run_subcommand_parser = parser.subcommands.choices.get('run', None)
+        if run_subcommand_parser is None:
+            return
+
+        msg = 'job replay'
+        self.replay_parser = run_subcommand_parser.add_argument_group(msg)
+        self.replay_parser.add_argument('--replay', dest='replay_jobid',
+                                        default=None,
+                                        help='Replay a job identified by its '
+                                        '(partial) hash id')
+        self.replay_parser.add_argument('--replay-test-status',
+                                        dest='replay_teststatus',
+                                        default=None,
+                                        help='Filter tests to replay by '
+                                        'test status')
+        self.replay_parser.add_argument('--replay-ignore',
+                                        dest='replay_ignore',
+                                        default=None,
+                                        help='Ignore multiplex (mux) and/or '
+                                        'configuration (config) from the '
+                                        'source job')
+        self.replay_parser.add_argument('--replay-data-dir',
+                                        dest='replay_datadir',
+                                        default=None,
+                                        help='Load replay data from an '
+                                        'alternative location')
+
+    def _check_args(self, args):
+        view = output.View()
+        valid_ignore = frozenset(['config', 'mux'])
+        valid_status = frozenset(['FAIL', 'PASS', 'ERROR', 'SKIP', 'WARN',
+                                 'INTERRUPT'])
+
+        replay_teststatus = getattr(args, 'replay_teststatus')
+        replay_ignore = getattr(args, 'replay_ignore')
+
+        resultsdir = getattr(args, 'replay_resultsdir')
+        if resultsdir is None:
+            msg = 'Job data not found in %s. Please make sure you\'re '\
+                  'informing a valid and unique enough hash.' % self.logdir
+            view.notify(event='error', msg=(msg))
+            return sys.exit(exit_codes.AVOCADO_JOB_FAIL)
+
+        if replay_teststatus is not None:
+            for item in replay_teststatus.split(','):
+                if item not in valid_status:
+                    e_msg = 'Invalid --replay-test-status option. Valid ' \
+                            'options are (more than one allowed): %s' % \
+                            ','.join(valid_status)
+                    view.notify(event='error', msg=e_msg)
+                    return sys.exit(exit_codes.AVOCADO_FAIL)
+
+        if replay_ignore is not None:
+            for item in replay_ignore.split(','):
+                if item not in valid_ignore:
+                    e_msg = 'Invalid --replay-ignore option. Valid ' \
+                            'options are (more than one allowed): %s' % \
+                            ','.join(valid_ignore)
+                    view.notify(event='error', msg=e_msg)
+                    return sys.exit(exit_codes.AVOCADO_FAIL)
+                if item == 'config':
+                    msg = '* Ignoring configuration from source job.'
+                    view.notify(event='warning', msg=(msg))
+                elif item == 'mux':
+                    msg = '* Ignoring multiplex-files from source job.'
+                    view.notify(event='warning', msg=(msg))
+
+        return True
+
+    def _load_config(self, args):
+        replay_ignore = getattr(args, 'replay_ignore')
+        if replay_ignore is None or 'config' not in replay_ignore.split(','):
+            replay_config = os.path.join(getattr(args, 'replay_resultsdir'),
+                                         'replay', 'config')
+            with open(replay_config, 'r') as f:
+                settings.process_config_path(f.read())
+
+    def run(self, args):
+        replay_jobid = getattr(args, 'replay_jobid')
+        replay_datadir = getattr(args, 'replay_datadir')
+        if replay_datadir is not None:
+            self.logdir = os.path.expanduser(replay_datadir)
+        else:
+            logs_dir = settings.get_value('datadir.paths', 'logs_dir',
+                                          default=None)
+            self.logdir = os.path.expanduser(logs_dir)
+
+        resultsdir, sourcejob = replay.get_resultsdir(self.logdir,
+                                                      replay_jobid)
+        setattr(args, 'replay_resultsdir', resultsdir)
+        setattr(args, 'replay_sourcejob', sourcejob)
+
+        if self._check_args(args):
+            self._load_config(args)

--- a/docs/source/Replay.rst
+++ b/docs/source/Replay.rst
@@ -1,0 +1,205 @@
+.. _job_replay_:
+
+==========
+Job Replay
+==========
+
+In order to reproduce a given job using the same data, one can use the
+``--replay`` option for the ``run`` command, informing the hash id from
+the original job to be replayed. The hash id can be partial, as long as
+the provided part corresponds to the inital characters of the original
+job id and it is also unique enough.
+
+Let's see an example. First, running a simple job with two urls::
+
+  $ avocado run /bin/true /bin/false
+  JOB ID     : 825b860b0c2f6ec48953c638432e3e323f8d7cad
+  JOB LOG    : ~/avocado/job-results/job-2016-01-11T16.14-825b860/job.log
+  TESTS      : 2
+   (1/2) /bin/true: PASS (0.01 s)
+   (2/2) /bin/false: FAIL (0.01 s)
+  RESULTS    : PASS 1 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0
+  JOB HTML   : ~/avocado/job-results/job-2016-01-11T16.14-825b860/html/results.html
+  TIME       : 0.02 s
+
+Now we can replay the job by running::
+
+  $ avocado run --replay 825b86
+  JOB ID     : 55a0d10132c02b8cc87deb2b480bfd8abbd956c3
+  SRC JOB ID : 825b860b0c2f6ec48953c638432e3e323f8d7cad
+  JOB LOG    : ~/avocado/job-results/job-2016-01-11T16.18-55a0d10/job.log
+  TESTS      : 2
+   (1/2) /bin/true: PASS (0.01 s)
+   (2/2) /bin/false: FAIL (0.01 s)
+  RESULTS    : PASS 1 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0
+  JOB HTML   : ~/avocado/job-results/job-2016-01-11T16.18-55a0d10/html/results.html
+  TIME       : 0.01 s
+
+The replay feature will retrieve the original job urls, the multiplex
+tree and the configuration. Let's see another example, now using
+multiplex file::
+
+  $ avocado run /bin/true /bin/false --multiplex-files mux-environment.yaml
+  JOB ID     : bd6aa3b852d4290637b5e771b371537541043d1d
+  JOB LOG    : ~/avocado/job-results/job-2016-01-11T21.56-bd6aa3b/job.log
+  TESTS      : 48
+   (1/48) /bin/true.variant1: PASS (0.01 s)
+   (2/48) /bin/true.variant2: PASS (0.01 s)
+   (3/48) /bin/true.variant3: PASS (0.01 s)
+   (4/48) /bin/true.variant4: PASS (0.01 s)
+   (5/48) /bin/true.variant5: PASS (0.01 s)
+   (6/48) /bin/true.variant6: PASS (0.01 s)
+   (7/48) /bin/true.variant7: PASS (0.01 s)
+   (8/48) /bin/true.variant8: PASS (0.01 s)
+   (9/48) /bin/true.variant9: PASS (0.01 s)
+   (10/48) /bin/true.variant10: PASS (0.01 s)
+   (11/48) /bin/true.variant11: PASS (0.01 s)
+   (12/48) /bin/true.variant12: PASS (0.01 s)
+   (13/48) /bin/true.variant13: PASS (0.01 s)
+   (14/48) /bin/true.variant14: PASS (0.01 s)
+   (15/48) /bin/true.variant15: PASS (0.01 s)
+   (16/48) /bin/true.variant16: PASS (0.01 s)
+   (17/48) /bin/true.variant17: PASS (0.01 s)
+   (18/48) /bin/true.variant18: PASS (0.01 s)
+   (19/48) /bin/true.variant19: PASS (0.01 s)
+   (20/48) /bin/true.variant20: PASS (0.01 s)
+   (21/48) /bin/true.variant21: PASS (0.01 s)
+   (22/48) /bin/true.variant22: PASS (0.01 s)
+   (23/48) /bin/true.variant23: PASS (0.01 s)
+   (24/48) /bin/true.variant24: PASS (0.01 s)
+   (25/48) /bin/false.variant1: FAIL (0.01 s)
+   (26/48) /bin/false.variant2: FAIL (0.01 s)
+   (27/48) /bin/false.variant3: FAIL (0.01 s)
+   (28/48) /bin/false.variant4: FAIL (0.01 s)
+   (29/48) /bin/false.variant5: FAIL (0.01 s)
+   (30/48) /bin/false.variant6: FAIL (0.01 s)
+   (31/48) /bin/false.variant7: FAIL (0.01 s)
+   (32/48) /bin/false.variant8: FAIL (0.01 s)
+   (33/48) /bin/false.variant9: FAIL (0.01 s)
+   (34/48) /bin/false.variant10: FAIL (0.01 s)
+   (35/48) /bin/false.variant11: FAIL (0.01 s)
+   (36/48) /bin/false.variant12: FAIL (0.01 s)
+   (37/48) /bin/false.variant13: FAIL (0.01 s)
+   (38/48) /bin/false.variant14: FAIL (0.01 s)
+   (39/48) /bin/false.variant15: FAIL (0.01 s)
+   (40/48) /bin/false.variant16: FAIL (0.01 s)
+   (41/48) /bin/false.variant17: FAIL (0.01 s)
+   (42/48) /bin/false.variant18: FAIL (0.01 s)
+   (43/48) /bin/false.variant19: FAIL (0.01 s)
+   (44/48) /bin/false.variant20: FAIL (0.01 s)
+   (45/48) /bin/false.variant21: FAIL (0.01 s)
+   (46/48) /bin/false.variant22: FAIL (0.01 s)
+   (47/48) /bin/false.variant23: FAIL (0.01 s)
+   (48/48) /bin/false.variant24: FAIL (0.01 s)
+  RESULTS    : PASS 24 | ERROR 0 | FAIL 24 | SKIP 0 | WARN 0 | INTERRUPT 0
+  JOB HTML   : ~/avocado/job-results/job-2016-01-11T21.56-bd6aa3b/html/results.html
+  TIME       : 0.29 s
+
+We can replay the job as is, using ``$ avocado run --replay bd6aa3b``,
+or replay the job ignoring the multiplex file, as bellow::
+
+  $ avocado run --replay bd6aa3b --replay-ignore mux
+  * Ignoring multiplex-files from source job.
+  JOB ID     : d5a46186ee0fb4645e3f7758814003d76c980bf9
+  SRC JOB ID : bd6aa3b852d4290637b5e771b371537541043d1d
+  JOB LOG    : ~/avocado/job-results/job-2016-01-11T22.01-d5a4618/job.log
+  TESTS      : 2
+   (1/2) /bin/true: PASS (0.01 s)
+   (2/2) /bin/false: FAIL (0.01 s)
+  RESULTS    : PASS 1 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0
+  JOB HTML   : ~/avocado/job-results/job-2016-01-11T22.01-d5a4618/html/results.html
+  TIME       : 0.02 s
+
+Also, it is possible to replay only the variants that faced a given
+result, using the option ``--replay-test-status``. Using the same job
+``bd6aa3b``, see the example bellow::
+
+    $ avocado run --replay bd6aa3b --replay-test-status FAIL
+    JOB ID     : 2e1dc41af6ed64895f3bb45e3820c5cc62a9b6eb
+    SRC JOB ID : bd6aa3b852d4290637b5e771b371537541043d1d
+    JOB LOG    : ~/avocado/job-results/job-2016-01-12T00.38-2e1dc41/job.log
+    TESTS      : 48
+     (1/48) /bin/true.variant1: SKIP
+     (2/48) /bin/true.variant2: SKIP
+     (3/48) /bin/true.variant3: SKIP
+     (4/48) /bin/true.variant4: SKIP
+     (5/48) /bin/true.variant5: SKIP
+     (6/48) /bin/true.variant6: SKIP
+     (7/48) /bin/true.variant7: SKIP
+     (8/48) /bin/true.variant8: SKIP
+     (9/48) /bin/true.variant9: SKIP
+     (10/48) /bin/true.variant10: SKIP
+     (11/48) /bin/true.variant11: SKIP
+     (12/48) /bin/true.variant12: SKIP
+     (13/48) /bin/true.variant13: SKIP
+     (14/48) /bin/true.variant14: SKIP
+     (15/48) /bin/true.variant15: SKIP
+     (16/48) /bin/true.variant16: SKIP
+     (17/48) /bin/true.variant17: SKIP
+     (18/48) /bin/true.variant18: SKIP
+     (19/48) /bin/true.variant19: SKIP
+     (20/48) /bin/true.variant20: SKIP
+     (21/48) /bin/true.variant21: SKIP
+     (22/48) /bin/true.variant22: SKIP
+     (23/48) /bin/true.variant23: SKIP
+     (24/48) /bin/true.variant24: SKIP
+     (25/48) /bin/false.variant1: FAIL (0.01 s)
+     (26/48) /bin/false.variant2: FAIL (0.01 s)
+     (27/48) /bin/false.variant3: FAIL (0.01 s)
+     (28/48) /bin/false.variant4: FAIL (0.01 s)
+     (29/48) /bin/false.variant5: FAIL (0.01 s)
+     (30/48) /bin/false.variant6: FAIL (0.01 s)
+     (31/48) /bin/false.variant7: FAIL (0.01 s)
+     (32/48) /bin/false.variant8: FAIL (0.01 s)
+     (33/48) /bin/false.variant9: FAIL (0.01 s)
+     (34/48) /bin/false.variant10: FAIL (0.01 s)
+     (35/48) /bin/false.variant11: FAIL (0.01 s)
+     (36/48) /bin/false.variant12: FAIL (0.01 s)
+     (37/48) /bin/false.variant13: FAIL (0.01 s)
+     (38/48) /bin/false.variant14: FAIL (0.01 s)
+     (39/48) /bin/false.variant15: FAIL (0.01 s)
+     (40/48) /bin/false.variant16: FAIL (0.01 s)
+     (41/48) /bin/false.variant17: FAIL (0.01 s)
+     (42/48) /bin/false.variant18: FAIL (0.01 s)
+     (43/48) /bin/false.variant19: FAIL (0.01 s)
+     (44/48) /bin/false.variant20: FAIL (0.01 s)
+     (45/48) /bin/false.variant21: FAIL (0.01 s)
+     (46/48) /bin/false.variant22: FAIL (0.01 s)
+     (47/48) /bin/false.variant23: FAIL (0.01 s)
+     (48/48) /bin/false.variant24: FAIL (0.01 s)
+    RESULTS    : PASS 0 | ERROR 0 | FAIL 24 | SKIP 24 | WARN 0 | INTERRUPT 0
+    JOB HTML   : ~/avocado/job-results/job-2016-01-12T00.38-2e1dc41/html/results.html
+    TIME       : 0.19 s
+
+To be able to replay a job, avocado records the job data in the same
+job results directory, inside a subdirectory named ``replay``. If a
+given job has a non-default path to record the logs, when the replay
+time comes, we need to inform where the logs are. See the example
+bellow::
+
+  $ avocado run /bin/true --job-results-dir /tmp/avocado_results/
+  JOB ID     : f1b1c870ad892eac6064a5332f1bbe38cda0aaf3
+  JOB LOG    : /tmp/avocado_results/job-2016-01-11T22.10-f1b1c87/job.log
+  TESTS      : 1
+   (1/1) /bin/true: PASS (0.01 s)
+  RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0
+  JOB HTML   : /tmp/avocado_results/job-2016-01-11T22.10-f1b1c87/html/results.html
+  TIME       : 0.01 s
+
+Trying to replay the job, it fails::
+
+  $ avocado run --replay f1b1
+  Job data not found in ~/avocado/job-results. Please make sure you're
+  informing a valid and unique enough hash.
+
+In this case, we have to inform where the job results dir is located::
+
+  $ avocado run --replay f1b1 --replay-data-dir /tmp/avocado_results
+  JOB ID     : 19c76abb29f29fe410a9a3f4f4b66387570edffa
+  SRC JOB ID : f1b1c870ad892eac6064a5332f1bbe38cda0aaf3
+  JOB LOG    : ~/avocado/job-results/job-2016-01-11T22.15-19c76ab/job.log
+  TESTS      : 1
+   (1/1) /bin/true: PASS (0.01 s)
+  RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0
+  JOB HTML   : ~/avocado/job-results/job-2016-01-11T22.15-19c76ab/html/results.html
+  TIME       : 0.01 s

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,6 +14,7 @@ Contents:
    Configuration
    Loaders
    MultiplexConfig
+   Replay
    RunningTestsRemotely
    DebuggingWithGDB
    WrapProcess

--- a/setup.py
+++ b/setup.py
@@ -133,6 +133,7 @@ if __name__ == '__main__':
                   'journal = avocado.plugins.journal:Journal',
                   'html = avocado.plugins.html:HTML',
                   'remote = avocado.plugins.remote:Remote',
+                  'replay = avocado.plugins.replay:Replay',
                   'vm = avocado.plugins.vm:VM',
                   ],
               'avocado.plugins.cli.cmd': [


### PR DESCRIPTION
job replay support using the run option "--replay <job-id>"
implements the job replay, retrieving the original job urls, multiplex and
configuration.

The option "--replay-test-status <STATUS>" is fully functional,
allowing users to replay only the variants that faced a given status in
the original job.

To ignore some original job information, the option
"--replay-job-ignore <mux|config>" can be used.

Notice if can inform the urls and/or the multiplex using the command line.
The options informed in the command line will be used, making the replay job ignore
that information from the source job.


v4 #925
v3 #920 
v2 #915
v1 #914 

Changes:
- created replay plugin to handle command line options
- minor adjustments requested in v4 code review
- feature documentation

Signed-off-by: Amador Pahim <apahim@redhat.com>