### PR TITLE
loader: make test methods unique when discovering tests

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -587,6 +587,7 @@ class FileLoader(TestLoader):
                     functions = [st.name for st in statement.body if
                                  isinstance(st, ast.FunctionDef) and
                                  st.name.startswith('test')]
+                    functions = list(set(functions))
                     result[statement.name] = functions
                     continue
 
@@ -598,6 +599,7 @@ class FileLoader(TestLoader):
                         functions = [st.name for st in statement.body if
                                      isinstance(st, ast.FunctionDef) and
                                      st.name.startswith('test')]
+                        functions = list(set(functions))
                         result[statement.name] = functions
                         continue
 
@@ -610,6 +612,7 @@ class FileLoader(TestLoader):
                             functions = [st.name for st in statement.body if
                                          isinstance(st, ast.FunctionDef) and
                                          st.name.startswith('test')]
+                            functions = list(set(functions))
                             result[statement.name] = functions
 
         return result

--- a/selftests/functional/test_loader.py
+++ b/selftests/functional/test_loader.py
@@ -67,6 +67,23 @@ if __name__ == "__main__":
     main()
 """
 
+AVOCADO_TEST_MULTIPLE_METHODS_SAME_NAME = """#!/usr/bin/env python
+import time
+
+from avocado import Test
+from avocado import main
+
+class Multiple(Test):
+    def test(self):
+        raise
+
+    def test(self):
+        pass
+
+if __name__ == "__main__":
+    main()
+"""
+
 
 NOT_A_TEST = """
 def hello():
@@ -135,6 +152,10 @@ class LoaderTestFunctional(unittest.TestCase):
     def test_multiple_class(self):
         self._test('multipleclasses.py', AVOCADO_TEST_MULTIPLE_CLASSES,
                    'INSTRUMENTED', 0664, 2)
+
+    def test_multiple_methods_same_name(self):
+        self._test('multiplemethods.py', AVOCADO_TEST_MULTIPLE_METHODS_SAME_NAME,
+                   'INSTRUMENTED', 0664, 1)
 
     def test_load_not_a_test(self):
         self._test('notatest.py', NOT_A_TEST, 'SIMPLE', 0775)

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -69,6 +69,16 @@ class MultipleMethods(Test):
         pass
 """
 
+AVOCADO_MULTIPLE_TESTS_SAME_NAME = """from avocado import Test
+
+class MultipleMethods(Test):
+    def test(self):
+        raise
+    def test(self):
+        raise
+    def test(self):
+        pass
+"""
 
 AVOCADO_FOREIGN_TAGGED_ENABLE = """from foreignlib import Base
 
@@ -238,6 +248,21 @@ class LoaderTest(unittest.TestCase):
         # Load none should return no tests
         self.assertTrue(not self.loader.discover(avocado_multiple_tests.path +
                                                  ":no_match", True))
+        avocado_multiple_tests.remove()
+
+    def test_multiple_methods_same_name(self):
+        avocado_multiple_tests = script.TemporaryScript('multipletests.py',
+                                                        AVOCADO_MULTIPLE_TESTS_SAME_NAME,
+                                                        'avocado_multiple_tests_unittest',
+                                                        mode=0664)
+        avocado_multiple_tests.save()
+        suite = self.loader.discover(avocado_multiple_tests.path, True)
+        self.assertEqual(len(suite), 1)
+        # Try to load only some of the tests
+        suite = self.loader.discover(avocado_multiple_tests.path +
+                                     ':MultipleMethods.test', True)
+        self.assertEqual(len(suite), 1)
+        self.assertEqual(suite[0][1]["methodName"], 'test')
         avocado_multiple_tests.remove()
 
     def test_load_foreign(self):


### PR DESCRIPTION
As per report on issue #952, Avocado currently finds multiple tests
when multiple test names exist in a given Python class. When the
test code itself is loaded and the test class instantiated, only
one test method will remain (others will have been overloaded by
that one).

So, to mimic this in the static, AST based, test discovery, let's
make the test methods unique.

Signed-off-by: Cleber Rosa <crosa@redhat.com>