### PR TITLE
Make loader registration unique and make dispatcher propagate exceptions

### DIFF
--- a/avocado/core/dispatcher.py
+++ b/avocado/core/dispatcher.py
@@ -27,7 +27,8 @@ class Dispatcher(ExtensionManager):
         self.load_failures = []
         super(Dispatcher, self).__init__(namespace=namespace,
                                          invoke_on_load=True,
-                                         on_load_failure_callback=self.store_load_failure)
+                                         on_load_failure_callback=self.store_load_failure,
+                                         propagate_map_exceptions=True)
 
     @staticmethod
     def store_load_failure(manager, entrypoint, exception):

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -102,7 +102,8 @@ class TestLoaderProxy(object):
     def register_plugin(self, plugin):
         try:
             if issubclass(plugin, TestLoader):
-                self.registered_plugins.append(plugin)
+                if plugin not in self.registered_plugins:
+                    self.registered_plugins.append(plugin)
             else:
                 raise ValueError
         except ValueError:


### PR DESCRIPTION
These are two fixes that were found to be necessary while investigating https://github.com/avocado-framework/avocado-vt/issues/322.