### PR TITLE
selftests/test_interrupt.py: Handle timing problems

### DIFF
--- a/selftests/functional/test_interrupt.py
+++ b/selftests/functional/test_interrupt.py
@@ -152,12 +152,18 @@ class InterruptTest(unittest.TestCase):
                 except psutil.NoSuchProcess:
                     pass
                 if p_obj is not None:
-                    if old_psutil:
-                        cmdline_list = psutil.Process(p).cmdline
-                    else:
-                        cmdline_list = psutil.Process(p).cmdline()
-                    if good_test.path in " ".join(cmdline_list):
-                        good_test_processes.append(p_obj)
+                    try:
+                        if old_psutil:
+                            cmdline_list = psutil.Process(p).cmdline
+                        else:
+                            cmdline_list = psutil.Process(p).cmdline()
+                        if good_test.path in " ".join(cmdline_list):
+                            good_test_processes.append(p_obj)
+                    # psutil.NoSuchProcess happens when the original
+                    # process already ended and left the process table
+                    except psutil.NoSuchProcess:
+                        pass
+
             return len(good_test_processes) == 0
 
         wait.wait_for(wait_until_no_goodtest, timeout=2)


### PR DESCRIPTION
In InterruptTest.test_well_behaved, sometimes it
takes a bit extra time for avocado to end, causing
a psutil.NoSuchProcess exception by the time the test
tries to access .cmdline() in the Process() object.

That condition means the process is already out of
the process list, which means the test passed. Let's
handle the NoSuchProcess exception accordingly.

Signed-off-by: Lucas Meneghel Rodrigues <lookkas@gmail.com>