### PR TITLE
avocado: Couple of minor --replay changes

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -271,8 +271,7 @@ class Job(object):
         """
         loader.loader.load_plugins(self.args)
         try:
-            replay_path = getattr(self.args, 'replay_path', None)
-            suite = loader.loader.discover(urls, replay_path=replay_path)
+            suite = loader.loader.discover(urls)
         except loader.LoaderUnhandledUrlError, details:
             self._remove_job_results()
             raise exceptions.OptionValidationError(details)

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -437,8 +437,9 @@ class Job(object):
                      "for details" % (" ".join(urls) if urls else "\b"))
             raise exceptions.OptionValidationError(e_msg)
 
-        if getattr(self.args, 'replay_mux', None) is not None:
-            mux = self.args.replay_mux
+        if isinstance(getattr(self.args, 'multiplex_files', None),
+                      multiplexer.Mux):
+            mux = self.args.multiplex_files     # pylint: disable=E1101
         else:
             try:
                 mux = multiplexer.Mux(self.args)

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -194,7 +194,7 @@ class TestLoaderProxy(object):
             mapping.update(loader_plugin.get_decorator_mapping())
         return mapping
 
-    def discover(self, urls, which_tests=DEFAULT, replay_path=None):
+    def discover(self, urls, which_tests=DEFAULT):
         """
         Discover (possible) tests from test urls.
 
@@ -213,8 +213,6 @@ class TestLoaderProxy(object):
                                     'avocado.app.tracebacks')
         tests = []
         unhandled_urls = []
-        if replay_path is not None and os.path.exists(replay_path):
-            os.chdir(replay_path)
         if not urls:
             for loader_plugin in self._initialized_plugins:
                 try:

--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -167,6 +167,12 @@ class Replay(CLI):
                                                     args.replay_teststatus)
             setattr(args, 'replay_map', replay_map)
 
+        # Use the original directory to discover test urls properly
         pwd = replay.retrieve_pwd(resultsdir)
         if pwd is not None:
-            setattr(args, 'replay_path', pwd)
+            if os.path.exists(pwd):
+                os.chdir(pwd)
+            else:
+                view.notify(event="warning", msg="Directory used in the replay"
+                            " source job '%s' does not exists, using '.' "
+                            "instead" % pwd)

--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -39,29 +39,29 @@ class Replay(CLI):
             return
 
         msg = 'job replay'
-        self.replay_parser = run_subcommand_parser.add_argument_group(msg)
-        self.replay_parser.add_argument('--replay', dest='replay_jobid',
-                                        default=None,
-                                        help='Replay a job identified by its '
-                                        '(partial) hash id')
-        self.replay_parser.add_argument('--replay-test-status',
-                                        dest='replay_teststatus',
-                                        type=self._valid_status,
-                                        default=None,
-                                        help='Filter tests to replay by '
-                                        'test status')
-        self.replay_parser.add_argument('--replay-ignore',
-                                        dest='replay_ignore',
-                                        type=self._valid_ignore,
-                                        default=None,
-                                        help='Ignore multiplex (mux) and/or '
-                                        'configuration (config) from the '
-                                        'source job')
-        self.replay_parser.add_argument('--replay-data-dir',
-                                        dest='replay_datadir',
-                                        default=None,
-                                        help='Load replay data from an '
-                                        'alternative location')
+        replay_parser = run_subcommand_parser.add_argument_group(msg)
+        replay_parser.add_argument('--replay', dest='replay_jobid',
+                                   default=None,
+                                   help='Replay a job identified by its '
+                                   '(partial) hash id')
+        replay_parser.add_argument('--replay-test-status',
+                                   dest='replay_teststatus',
+                                   type=self._valid_status,
+                                   default=None,
+                                   help='Filter tests to replay by '
+                                   'test status')
+        replay_parser.add_argument('--replay-ignore',
+                                   dest='replay_ignore',
+                                   type=self._valid_ignore,
+                                   default=None,
+                                   help='Ignore multiplex (mux) and/or '
+                                   'configuration (config) from the '
+                                   'source job')
+        replay_parser.add_argument('--replay-data-dir',
+                                   dest='replay_datadir',
+                                   default=None,
+                                   help='Load replay data from an '
+                                   'alternative location')
 
     def _valid_status(self, string):
         status_list = string.split(',')

--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -153,6 +153,9 @@ class Replay(CLI):
                 msg = 'Overriding the replay multiplex with '\
                       '--multiplex-file.'
                 view.notify(event='warning', msg=(msg))
+                # Use absolute paths to avoid problems with os.chdir
+                args.multiplex_files = [os.path.abspath(_)
+                                        for _ in args.multiplex_files]
             else:
                 mux = replay.retrieve_mux(resultsdir)
                 if mux is None:
@@ -160,7 +163,7 @@ class Replay(CLI):
                     view.notify(event='error', msg=(msg))
                     sys.exit(exit_codes.AVOCADO_JOB_FAIL)
                 else:
-                    setattr(args, 'replay_mux', mux)
+                    setattr(args, "multiplex_files", mux)
 
         if args.replay_teststatus:
             replay_map = replay.retrieve_replay_map(resultsdir,


### PR DESCRIPTION
Hi guys (especially @apahim),

there are few minor things I mentioned in review, but were not as important to prevent inclusion. I'd like to avoid special handling in `job` for plugins as much as possible. The commit 188b812 is maybe a bit controversial, but I can see the benefit for other future plugins (maybe we can rename the `--multiplex-files` to `--multiplex` which would make it less confusing).