### PR TITLE
avocado.plugins.replay Use user friendly status for --replay-test-status

### DIFF
--- a/avocado/core/status.py
+++ b/avocado/core/status.py
@@ -28,6 +28,13 @@ mapping = {"TEST_NA": True,
            "NOSTATUS": False,
            "INTERRUPTED": False}
 
+user_facing_statusmap = {"SKIP": "TEST_NA",
+                         "ERROR": "ERROR",
+                         "WARN": "WARN",
+                         "FAIL": "FAIL",
+                         "PASS": "PASS",
+                         "INTERRUPT": "INTERRUPTED"}
+
 feedback = {
     # Test did not advertise current status, but process running the test is
     # known to be still running

--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -66,10 +66,10 @@ class Replay(CLI):
     def _valid_status(self, string):
         status_list = string.split(',')
         for item in status_list:
-            if item not in status.mapping:
+            if item not in status.user_facing_statusmap:
                 msg = 'Invalid --replay-test-status option. Valid ' \
                      'options are (more than one allowed): %s' % \
-                     ','.join([item for item in status.mapping])
+                     ','.join([item for item in status.user_facing_statusmap])
                 raise argparse.ArgumentTypeError(msg)
 
         return status_list
@@ -163,8 +163,10 @@ class Replay(CLI):
                     setattr(args, 'replay_mux', mux)
 
         if args.replay_teststatus:
+            internal_status = [status.user_facing_statusmap[item]
+                               for item in args.replay_teststatus]
             replay_map = replay.retrieve_replay_map(resultsdir,
-                                                    args.replay_teststatus)
+                                                    internal_status)
             setattr(args, 'replay_map', replay_map)
 
         pwd = replay.retrieve_pwd(resultsdir)

--- a/selftests/functional/test_replay.py
+++ b/selftests/functional/test_replay.py
@@ -97,8 +97,7 @@ class ReplayTests(unittest.TestCase):
         expected_rc = exit_codes.AVOCADO_JOB_FAIL
         result = self.run_and_check(cmd_line, expected_rc)
         msg = 'Invalid --replay-test-status option. Valid options are (more ' \
-              'than one allowed): NOSTATUS,INTERRUPTED,WARN,START,ERROR,'\
-              'FAIL,PASS,TEST_NA,ALERT,RUNNING,ABORT'
+              'than one allowed): SKIP,ERROR,WARN,INTERRUPT,PASS,FAIL'
         self.assertIn(msg, result.stderr)
 
     def test_run_replay_statusfail(self):


### PR DESCRIPTION
Currently replay is using status.mapping as the list of valid status
for the --replay-test-status option. But status.mapping has some internal
status that users should not have to deal with. Also, some status are
translated internally (i.e. SKIP -> TEST_NA).

This patch creates an external:internal status map containing only
the options relevant to users and makes the job replay feature take
advantage of it.

Signed-off-by: Amador Pahim <apahim@redhat.com>