### PR TITLE
VM plugin: add port number as option

### DIFF
--- a/avocado/core/remote/result.py
+++ b/avocado/core/remote/result.py
@@ -136,6 +136,7 @@ class VMTestResult(RemoteTestResult):
         try:
             # Finish remote setup and copy the tests
             self.args.remote_hostname = self.args.vm_hostname
+            self.args.remote_port = self.args.vm_port
             self.args.remote_username = self.args.vm_username
             self.args.remote_password = self.args.vm_password
             self.args.remote_no_copy = self.args.vm_no_copy

--- a/avocado/plugins/vm.py
+++ b/avocado/plugins/vm.py
@@ -55,6 +55,10 @@ class VM(CLI):
                                           'default Avocado attempts to '
                                           'automatically find the VM IP '
                                           'address.'))
+        self.vm_parser.add_argument('--vm-port', dest='vm_port',
+                                    default=22, type=int, help='Specify '
+                                    'the port number to login on VM. '
+                                    'Current: 22')
         self.vm_parser.add_argument('--vm-username', default=getpass.getuser(),
                                     help='Specify the username to login on VM')
         self.vm_parser.add_argument('--vm-password',


### PR DESCRIPTION
For parity of features with the remote plugin, let's add the SSH
port as an option of the VM plugin as well.

Signed-off-by: Cleber Rosa <crosa@redhat.com>