### PR TITLE
VM/Remote plugin: revert to previous technique for setting result/runner

### DIFF
--- a/avocado/plugins/remote.py
+++ b/avocado/plugins/remote.py
@@ -101,5 +101,5 @@ class Remote(CLI):
     def run(self, args):
         if self._check_required_args(args, 'remote_hostname',
                                      ('remote_hostname',)):
-            args.remote_result = RemoteTestResult
-            args.test_runner = RemoteTestRunner
+            self.remote_parser.set_defaults(remote_result=RemoteTestResult,
+                                            test_runner=RemoteTestRunner)

--- a/avocado/plugins/vm.py
+++ b/avocado/plugins/vm.py
@@ -100,5 +100,5 @@ class VM(CLI):
 
     def run(self, args):
         if self._check_required_args(args, 'vm_domain', ('vm_domain',)):
-            args.remote_result = VMTestResult
-            args.test_runner = RemoteTestRunner
+            self.vm_parser.set_defaults(remote_result=VMTestResult,
+                                        test_runner=RemoteTestRunner)


### PR DESCRIPTION
Turns out that setting the argument value directly does not suit most
of our code. Let's revert back to the old way of setting the remote/vm
result/runner until we implement proper runner and result plugin interfaces.

Signed-off-by: Cleber Rosa <crosa@redhat.com>