### PR TITLE
Rename TEST_NA and handle status options in --replay-test-status

### DIFF
--- a/avocado/core/exceptions.py
+++ b/avocado/core/exceptions.py
@@ -157,16 +157,16 @@ class TestAbortError(TestBaseException):
     status = "ERROR"
 
 
-class TestNAError(TestBaseException):
+class TestSkipError(TestBaseException):
 
     """
-    Indictates that the test is Not Applicable.
+    Indictates that the test is skipped.
 
     Should be thrown when various conditions are such that the test is
     inappropriate. For example, inappropriate architecture, wrong OS version,
     program being tested does not have the expected capability (older version).
     """
-    status = "TEST_NA"
+    status = "SKIP"
 
 
 class TestFail(TestBaseException, AssertionError):

--- a/avocado/core/html.py
+++ b/avocado/core/html.py
@@ -114,7 +114,7 @@ class ReportModel(object):
 
     @property
     def tests(self):
-        mapping = {"TEST_NA": "warning",
+        mapping = {"SKIP": "warning",
                    "ABORT": "danger",
                    "ERROR": "danger",
                    "FAIL": "danger",

--- a/avocado/core/result.py
+++ b/avocado/core/result.py
@@ -243,7 +243,7 @@ class TestResult(object):
         status_map = {'PASS': self.add_pass,
                       'ERROR': self.add_error,
                       'FAIL': self.add_fail,
-                      'TEST_NA': self.add_skip,
+                      'SKIP': self.add_skip,
                       'WARN': self.add_warn,
                       'INTERRUPTED': self.add_interrupt}
         add = status_map[state['status']]

--- a/avocado/core/status.py
+++ b/avocado/core/status.py
@@ -28,6 +28,13 @@ mapping = {"SKIP": True,
            "NOSTATUS": False,
            "INTERRUPTED": False}
 
+user_facing_status = ["SKIP",
+                      "ERROR",
+                      "FAIL",
+                      "WARN",
+                      "PASS",
+                      "INTERRUPTED"]
+
 feedback = {
     # Test did not advertise current status, but process running the test is
     # known to be still running

--- a/avocado/core/status.py
+++ b/avocado/core/status.py
@@ -16,7 +16,7 @@ This is used by methods and functions to return a cut and dry answer to wether
 a test or a job in avocado PASSed or FAILed.
 """
 
-mapping = {"TEST_NA": True,
+mapping = {"SKIP": True,
            "ABORT": False,
            "ERROR": False,
            "FAIL": False,

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -352,16 +352,16 @@ class Test(unittest.TestCase):
         stderr_check_exception = None
         try:
             self.setUp()
-        except exceptions.TestNAError, details:
+        except exceptions.TestSkipError, details:
             stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
-            raise exceptions.TestNAError(details)
+            raise exceptions.TestSkipError(details)
         except:  # Old-style exceptions are not inherited from Exception()
             stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
             details = sys.exc_info()[1]
             raise exceptions.TestSetupFail(details)
         try:
             testMethod()
-        except exceptions.TestNAError, details:
+        except exceptions.TestSkipError, details:
             stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
             skip_illegal_msg = ('Calling skip() in places other than '
                                 'setUp() is not allowed in avocado, you '
@@ -377,7 +377,7 @@ class Test(unittest.TestCase):
         finally:
             try:
                 self.tearDown()
-            except exceptions.TestNAError, details:
+            except exceptions.TestSkipError, details:
                 stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
                 skip_illegal_msg = ('Calling skip() in places other than '
                                     'setUp() is not allowed in avocado, '
@@ -544,7 +544,7 @@ class Test(unittest.TestCase):
         :param message: an optional message that will be recorded in the logs
         :type message: str
         """
-        raise exceptions.TestNAError(message)
+        raise exceptions.TestSkipError(message)
 
 
 class SimpleTest(Test):
@@ -681,7 +681,7 @@ class TimeOutSkipTest(Test):
     _skip_reason = "Test skipped due a job timeout!"
 
     def setUp(self):
-        raise exceptions.TestNAError(self._skip_reason)
+        raise exceptions.TestSkipError(self._skip_reason)
 
     def test(self):
         raise NotImplementedError("This should never be executed!")

--- a/avocado/core/xunit.py
+++ b/avocado/core/xunit.py
@@ -189,7 +189,7 @@ class xUnitTestResult(TestResult):
         TestResult.end_test(self, state)
         if state['status'] in ('PASS', 'WARN'):
             self.xml.add_success(state)
-        elif state['status'] == 'TEST_NA':
+        elif state['status'] == 'SKIP':
             self.xml.add_skip(state)
         elif state['status'] == 'FAIL':
             self.xml.add_failure(state)

--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -66,10 +66,10 @@ class Replay(CLI):
     def _valid_status(self, string):
         status_list = string.split(',')
         for item in status_list:
-            if item not in status.mapping:
+            if item not in status.user_facing_status:
                 msg = 'Invalid --replay-test-status option. Valid ' \
                      'options are (more than one allowed): %s' % \
-                     ','.join([item for item in status.mapping])
+                     ','.join([item for item in status.user_facing_status])
                 raise argparse.ArgumentTypeError(msg)
 
         return status_list

--- a/docs/source/ReferenceGuide.rst
+++ b/docs/source/ReferenceGuide.rst
@@ -44,7 +44,7 @@ as a simple test.
 The instrumented tests allows the writer finer control over the process
 including logging, test result status and other more sophisticated test APIs.
 
-Test statuses ``PASS``, ``WARN``, ``START`` and ``TEST_NA`` are considered as
+Test statuses ``PASS``, ``WARN``, ``START`` and ``SKIP`` are considered as
 successful builds. The ``ABORT``, ``ERROR``, ``FAIL``, ``ALERT``, ``RUNNING``,
 ``NOSTATUS`` and ``INTERRUPTED`` are considered as failed ones.
 

--- a/selftests/functional/test_replay.py
+++ b/selftests/functional/test_replay.py
@@ -97,8 +97,7 @@ class ReplayTests(unittest.TestCase):
         expected_rc = exit_codes.AVOCADO_JOB_FAIL
         result = self.run_and_check(cmd_line, expected_rc)
         msg = 'Invalid --replay-test-status option. Valid options are (more ' \
-              'than one allowed): SKIP,NOSTATUS,INTERRUPTED,WARN,START,ERROR,'\
-              'FAIL,PASS,ALERT,RUNNING,ABORT'
+              'than one allowed): SKIP,ERROR,FAIL,WARN,PASS,INTERRUPTED'
         self.assertIn(msg, result.stderr)
 
     def test_run_replay_statusfail(self):

--- a/selftests/functional/test_replay.py
+++ b/selftests/functional/test_replay.py
@@ -97,8 +97,8 @@ class ReplayTests(unittest.TestCase):
         expected_rc = exit_codes.AVOCADO_JOB_FAIL
         result = self.run_and_check(cmd_line, expected_rc)
         msg = 'Invalid --replay-test-status option. Valid options are (more ' \
-              'than one allowed): NOSTATUS,INTERRUPTED,WARN,START,ERROR,'\
-              'FAIL,PASS,TEST_NA,ALERT,RUNNING,ABORT'
+              'than one allowed): SKIP,NOSTATUS,INTERRUPTED,WARN,START,ERROR,'\
+              'FAIL,PASS,ALERT,RUNNING,ABORT'
         self.assertIn(msg, result.stderr)
 
     def test_run_replay_statusfail(self):


### PR DESCRIPTION
Merging the concepts of TEST_NA and SKIP and limiting the status list to be used in --replay-test-status option.

avocado-vt pull request:
https://github.com/avocado-framework/avocado-vt/pull/338