### PR TITLE
avocado.main(): avoid an infinite fork loop bomb [v2]

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -540,6 +540,16 @@ class TestProgram(object):
     """
 
     def __init__(self):
+        # Avoid fork loop/bomb when running a test via avocado.main() that
+        # calls avocado.main() itself
+        if os.environ.get('AVOCADO_STANDALONE_IN_MAIN', False):
+            sys.stderr.write('AVOCADO_STANDALONE_IN_MAIN environment variable '
+                             'found. This means that this code is being '
+                             'called recursively. Exiting to avoid an infinite'
+                             ' fork loop.\n')
+            return
+        os.environ['AVOCADO_STANDALONE_IN_MAIN'] = 'True'
+
         self.defaultTest = sys.argv[0]
         self.progName = os.path.basename(sys.argv[0])
         self.parseArgs(sys.argv[1:])


### PR DESCRIPTION
Because the current implementation of avocado.main() creates a job
and runs "sys.argv[0]" to implement standalone mode, it ends up
running itself over and over.

This simple proposed fix, prevents avocado.main() from running
itself again if called from itself. Since they are on different
processes, the mechanism chosen to do this is to set an environment
variable, that will be seen by the next process.

This adresses issue #961.

Signed-off-by: Cleber Rosa <crosa@redhat.com>

---

Changes from v1:
 * Add error message to STDERR, warning that main() will exit to avoid a loop.