### PR TITLE
[RFC] avocado.core.runner: Make default params configurable per test

### DIFF
--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -278,7 +278,18 @@ class TestRunner(object):
 
         # At this point, the test is already initialized and we know
         # for sure if there's a timeout set.
-        timeout = test_status.early_status.get('params', {}).get('timeout')
+        early_params = test_status.early_status.get('params', {})
+        # Give preference to timeouts defined for specific methods, if any
+        timeout = None
+        try:
+            method_name = test_factory[1]['methodName']
+            method_params = early_params.get(method_name, None)
+            if method_params is not None:
+                timeout = method_params.get('timeout', None)
+        except KeyError:
+            pass
+        if timeout is None:
+            timeout = early_params.get('timeout')
         timeout = float(timeout or self.DEFAULT_TIMEOUT)
 
         test_deadline = time_started + timeout

--- a/examples/tests/multipletimeouttest.py
+++ b/examples/tests/multipletimeouttest.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+
+import time
+
+from avocado import Test
+from avocado import main
+
+
+class MultipleTimeoutTest(Test):
+
+    """
+    Demonstrates setting up per test timeouts.
+
+    :param sleep_time: How long should the test sleep
+    """
+
+    default_params = {'test_one': {'timeout': 3},
+                      'test_two': {'timeout': 4}}
+
+    def test_one(self):
+        """
+        This should throw a TestTimeoutError.
+        """
+        sleep_time = self.params.get('test_one').get('sleep_time', 5)
+        self.log.info('Sleeping for %.2f seconds (2 more than the timeout)',
+                      sleep_time)
+        time.sleep(sleep_time)
+
+    def test_two(self):
+        """
+        This should throw a TestTimeoutError.
+        """
+        sleep_time = self.params.get('test_two').get('sleep_time', 5)
+        self.log.info('Sleeping for %.2f seconds (1 more than the timeout)',
+                      sleep_time)
+        time.sleep(sleep_time)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This RFC shows a general idea to solve a perceived problem
in the way test writers can specify test timeouts.

Currently, we have a bunch of different ways to let users
specify timeouts:

1) 'avocado run --job-timeout [timeout]' parameter
2) default_params defined at the test class level
3) Param 'timeout' coming from the multiplexer

When avocado went from single run method per test class
to a more unit test like approach (multiple test methods
per test class), 2) became a bit too coarse, and 1) and
3) are inherently less flexible [1].

So we can let tests define default parameter dicts
that are themselves values of the main default_params
dict, then avocado can identify if there are test method
specific timeouts defined and use them.

The attached test exemplifies how this would work.

[1] Unless we can come up with some multiplexer file
    based solution, which I tried to think about but
    couldn't figure it out in the time I have available.

Signed-off-by: Lucas Meneghel Rodrigues <lookkas@gmail.com>