### PR TITLE
avocado.core: show the subcommand help on unknown argparse option [v3]

### DIFF
--- a/selftests/functional/test_argument_parsing.py
+++ b/selftests/functional/test_argument_parsing.py
@@ -23,7 +23,7 @@ class ArgumentParsingTest(unittest.TestCase):
         os.chdir(basedir)
         cmd_line = './scripts/avocado whacky-command-that-doesnt-exist'
         result = process.run(cmd_line, ignore_status=True)
-        expected_rc = exit_codes.AVOCADO_JOB_FAIL
+        expected_rc = exit_codes.AVOCADO_FAIL
         self.assertEqual(result.exit_status, expected_rc,
                          'Avocado did not return rc %d:\n%s' % (expected_rc, result))
 
@@ -31,7 +31,7 @@ class ArgumentParsingTest(unittest.TestCase):
         os.chdir(basedir)
         cmd_line = './scripts/avocado run --sysinfo=foo passtest'
         result = process.run(cmd_line, ignore_status=True)
-        expected_rc = exit_codes.AVOCADO_JOB_FAIL
+        expected_rc = exit_codes.AVOCADO_FAIL
         self.assertEqual(result.exit_status, expected_rc,
                          'Avocado did not return rc %d:\n%s' % (expected_rc, result))
 
@@ -39,14 +39,17 @@ class ArgumentParsingTest(unittest.TestCase):
         os.chdir(basedir)
         cmd_line = './scripts/avocado run --sysinfo=off --whacky-argument passtest'
         result = process.run(cmd_line, ignore_status=True)
-        expected_rc = exit_codes.AVOCADO_JOB_FAIL
+        expected_rc = exit_codes.AVOCADO_FAIL
         self.assertEqual(result.exit_status, expected_rc,
                          'Avocado did not return rc %d:\n%s' % (expected_rc, result))
+        subcommand_error_msg = 'avocado run: error: unrecognized arguments: '\
+                               '--whacky-argument'
+        self.assertIn(subcommand_error_msg, result.stderr)
 
 
 class ArgumentParsingErrorEarlyTest(unittest.TestCase):
 
-    def run_but_fail_before_create_job_dir(self, complement_args):
+    def run_but_fail_before_create_job_dir(self, complement_args, expected_rc):
         """
         Runs avocado but checks that it fails before creating the job dir
 
@@ -60,17 +63,18 @@ class ArgumentParsingErrorEarlyTest(unittest.TestCase):
         cmd_line = './scripts/avocado run --sysinfo=off --force-job-id=%s %s'
         cmd_line %= (job, complement_args)
         result = process.run(cmd_line, ignore_status=True)
-        expected_rc = exit_codes.AVOCADO_JOB_FAIL
         self.assertEqual(result.exit_status, expected_rc,
                          'Avocado did not return rc %d:\n%s' % (expected_rc, result))
         path_job_glob = os.path.join(log_dir, "job-*-%s" % job[0:7])
         self.assertEquals(glob.glob(path_job_glob), [])
 
     def test_whacky_option(self):
-        self.run_but_fail_before_create_job_dir('--whacky-option passtest')
+        self.run_but_fail_before_create_job_dir('--whacky-option passtest',
+                                                exit_codes.AVOCADO_FAIL)
 
     def test_empty_option(self):
-        self.run_but_fail_before_create_job_dir('')
+        self.run_but_fail_before_create_job_dir('',
+                                                exit_codes.AVOCADO_JOB_FAIL)
 
 if __name__ == '__main__':
     unittest.main()

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -191,7 +191,7 @@ class RunnerOperationTest(unittest.TestCase):
         os.chdir(basedir)
         cmd_line = './scripts/avocado'
         result = process.run(cmd_line, ignore_status=True)
-        expected_rc = exit_codes.AVOCADO_JOB_FAIL
+        expected_rc = exit_codes.AVOCADO_FAIL
         expected_output = 'error: too few arguments'
         self.assertEqual(result.exit_status, expected_rc)
         self.assertIn(expected_output, result.stderr)

--- a/selftests/functional/test_replay.py
+++ b/selftests/functional/test_replay.py
@@ -75,7 +75,7 @@ class ReplayTests(unittest.TestCase):
         cmd_line = ('./scripts/avocado run --replay %s --replay-ignore foo'
                     '--job-results-dir %s --replay-data-dir %s --sysinfo=off'
                     % (self.jobid, self.tmpdir, self.jobdir))
-        expected_rc = exit_codes.AVOCADO_JOB_FAIL
+        expected_rc = exit_codes.AVOCADO_FAIL
         result = self.run_and_check(cmd_line, expected_rc)
         msg = 'Invalid --replay-ignore option. Valid options are ' \
               '(more than one allowed): mux,config'
@@ -94,7 +94,7 @@ class ReplayTests(unittest.TestCase):
         cmd_line = ('./scripts/avocado run --replay %s --replay-test-status E '
                     '--job-results-dir %s --replay-data-dir %s --sysinfo=off'
                     % (self.jobid, self.tmpdir, self.jobdir))
-        expected_rc = exit_codes.AVOCADO_JOB_FAIL
+        expected_rc = exit_codes.AVOCADO_FAIL
         result = self.run_and_check(cmd_line, expected_rc)
         msg = 'Invalid --replay-test-status option. Valid options are (more ' \
               'than one allowed): SKIP,ERROR,FAIL,WARN,PASS,INTERRUPTED'


### PR DESCRIPTION
v1 #981
v1 #982 

Changes:
  - Changed from print_usage() to print_help() on invalid argument.