### PR TITLE
avocado.main(): avoid an infinite fork loop bomb [v3]

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -540,6 +540,16 @@ class TestProgram(object):
     """
 
     def __init__(self):
+        # Avoid fork loop/bomb when running a test via avocado.main() that
+        # calls avocado.main() itself
+        if os.environ.get('AVOCADO_STANDALONE_IN_MAIN', False):
+            sys.stderr.write('AVOCADO_STANDALONE_IN_MAIN environment variable '
+                             'found. This means that this code is being '
+                             'called recursively. Exiting to avoid an infinite'
+                             ' fork loop.\n')
+            sys.exit(exit_codes.AVOCADO_FAIL)
+        os.environ['AVOCADO_STANDALONE_IN_MAIN'] = 'True'
+
         self.defaultTest = sys.argv[0]
         self.progName = os.path.basename(sys.argv[0])
         self.parseArgs(sys.argv[1:])

--- a/selftests/functional/test_loader.py
+++ b/selftests/functional/test_loader.py
@@ -9,6 +9,7 @@ if sys.version_info[:2] == (2, 6):
 else:
     import unittest
 
+from avocado.core import exit_codes
 from avocado.utils import script
 from avocado.utils import process
 
@@ -82,7 +83,6 @@ if __name__ == "__main__":
     main()
 """
 
-
 NOT_A_TEST = """
 def hello():
     print('Hello World!')
@@ -98,6 +98,40 @@ if __name__ == "__main__":
 
 SIMPLE_TEST = """#!/bin/sh
 true
+"""
+
+AVOCADO_SIMPLE_PYTHON_LIKE_MULTIPLE_FILES = """#!/usr/bin/env python
+# A simple test (executable bit set when saved to file) that looks like
+# an Avocado instrumented test, with base class on separate file
+from avocado import Test
+from avocado import main
+from test2 import *
+
+class BasicTestSuite(SuperTest):
+
+    def test1(self):
+        self.xxx()
+        self.assertTrue(True)
+
+if __name__ == '__main__':
+    main()
+"""
+
+AVOCADO_SIMPLE_PYTHON_LIKE_MULTIPLE_FILES_LIB = """
+#!/usr/bin/python
+
+from avocado import Test
+
+class SuperTest(Test):
+    def xxx(self):
+        print "ahoj"
+"""
+
+AVOCADO_TEST_SIMPLE_USING_MAIN = """#!/usr/bin/env python
+from avocado import main
+
+if __name__ == "__main__":
+    main()
 """
 
 
@@ -160,6 +194,41 @@ class LoaderTestFunctional(unittest.TestCase):
 
     def test_load_not_a_test_not_exec(self):
         self._test('notatest.py', NOT_A_TEST, 'NOT_A_TEST')
+
+    def test_runner_simple_python_like_multiple_files(self):
+        mylib = script.TemporaryScript(
+            'test2.py',
+            AVOCADO_SIMPLE_PYTHON_LIKE_MULTIPLE_FILES_LIB,
+            'avocado_simpletest_functional',
+            0644)
+        mylib.save()
+        mytest = script.Script(
+            os.path.join(os.path.dirname(mylib.path), 'test.py'),
+            AVOCADO_SIMPLE_PYTHON_LIKE_MULTIPLE_FILES)
+        os.chdir(basedir)
+        mytest.save()
+        cmd_line = "./scripts/avocado list -V %s" % mytest
+        result = process.run(cmd_line)
+        self.assertIn('SIMPLE: 1', result.stdout)
+        # job should be able to finish under 5 seconds. If this fails, it's
+        # possible that we hit the "simple test fork bomb" bug
+        cmd_line = ("./scripts/avocado run --sysinfo=off --job-results-dir %s "
+                    "--job-timeout=5s %s" % (self.tmpdir, mytest))
+        result = process.run(cmd_line, ignore_status=True)
+        self.assertEquals(result.exit_status, exit_codes.AVOCADO_TESTS_FAIL)
+
+    def test_simple_using_main(self):
+        mytest = script.TemporaryScript("simple_using_main.py",
+                                        AVOCADO_TEST_SIMPLE_USING_MAIN,
+                                        'avocado_simpletest_functional')
+        mytest.save()
+        os.chdir(basedir)
+        # job should be able to finish under 5 seconds. If this fails, it's
+        # possible that we hit the "simple test fork bomb" bug
+        cmd_line = ("./scripts/avocado run --sysinfo=off --job-results-dir %s "
+                    "--job-timeout=5s %s" % (self.tmpdir, mytest))
+        result = process.run(cmd_line, ignore_status=True)
+        self.assertEquals(result.exit_status, exit_codes.AVOCADO_TESTS_FAIL)
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir)


### PR DESCRIPTION
Because the current implementation of avocado.main() creates a job
and runs "sys.argv[0]" to implement standalone mode, it ends up
running itself over and over.

This simple proposed fix, prevents avocado.main() from running
itself again if called from itself. Since they are on different
processes, the mechanism chosen to do this is to set an environment
variable, that will be seen by the next process.

Also, by exiting from main() with an error code, the test first
level test will fail. This will let the user know that the chosen
approach (SIMPLE tests written in Python and calling main()) are
not worthy of a PASS.

This adresses issue #961.

Signed-off-by: Cleber Rosa <crosa@redhat.com>

---
Changes from v2:
 * Return an error code to signal that the used approach (calling `main()` is not ideal from a SIMPLE test).

Changes from v1:
 * Add error message to STDERR, warning that main() will exit to avoid a loop.