### PR TITLE
Test namespace cleanup [2nd round] [v2]

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -88,7 +88,6 @@ class Test(unittest.TestCase):
 
         self.job = job
 
-        self.filename = inspect.getfile(self.__class__).rstrip('co')
         self.basedir = os.path.dirname(self.filename)
 
         if self.datadir is None:
@@ -168,8 +167,14 @@ class Test(unittest.TestCase):
         """
         Returns the path to the directory that contains test data files
         """
-        filename = inspect.getfile(self.__class__).rstrip('co')
-        return filename + '.data'
+        return self.filename + '.data'
+
+    @property
+    def filename(self):
+        """
+        Returns the name of the file (path) that holds the current test
+        """
+        return inspect.getfile(self.__class__).rstrip('co')
 
     @data_structures.LazyProperty
     def workdir(self):

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -592,6 +592,13 @@ class SimpleTest(Test):
         """
         return self.name + '.data'
 
+    @property
+    def filename(self):
+        """
+        Returns the name of the file (path) that holds the current test
+        """
+        return os.path.abspath(self.name)
+
     def _log_detailed_cmd_info(self, result):
         """
         Log detailed command information.

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -109,8 +109,8 @@ class Test(unittest.TestCase):
         self.logfile = os.path.join(self.logdir, 'debug.log')
         self._ssh_logfile = os.path.join(self.logdir, 'remote.log')
 
-        self.stdout_file = os.path.join(self.logdir, 'stdout')
-        self.stderr_file = os.path.join(self.logdir, 'stderr')
+        self._stdout_file = os.path.join(self.logdir, 'stdout')
+        self._stderr_file = os.path.join(self.logdir, 'stderr')
 
         self.outputdir = utils_path.init_dir(self.logdir, 'data')
         self.sysinfodir = utils_path.init_dir(self.logdir, 'sysinfo')
@@ -280,10 +280,10 @@ class Test(unittest.TestCase):
         stream_fmt = '%(message)s'
         stream_formatter = logging.Formatter(fmt=stream_fmt)
 
-        self.stdout_file_handler = self._register_log_file_handler(self.stdout_log, stream_formatter,
-                                                                   self.stdout_file)
-        self.stderr_file_handler = self._register_log_file_handler(self.stderr_log, stream_formatter,
-                                                                   self.stderr_file)
+        self._stdout_file_handler = self._register_log_file_handler(self.stdout_log, stream_formatter,
+                                                                    self._stdout_file)
+        self._stderr_file_handler = self._register_log_file_handler(self.stderr_log, stream_formatter,
+                                                                    self._stderr_file)
         self._ssh_fh = self._register_log_file_handler(logging.getLogger('paramiko'),
                                                        formatter,
                                                        self._ssh_logfile)
@@ -341,16 +341,16 @@ class Test(unittest.TestCase):
 
     def _record_reference_stdout(self):
         utils_path.init_dir(self.datadir)
-        shutil.copyfile(self.stdout_file, self._expected_stdout_file)
+        shutil.copyfile(self._stdout_file, self._expected_stdout_file)
 
     def _record_reference_stderr(self):
         utils_path.init_dir(self.datadir)
-        shutil.copyfile(self.stderr_file, self._expected_stderr_file)
+        shutil.copyfile(self._stderr_file, self._expected_stderr_file)
 
     def _check_reference_stdout(self):
         if os.path.isfile(self._expected_stdout_file):
             expected = genio.read_file(self._expected_stdout_file)
-            actual = genio.read_file(self.stdout_file)
+            actual = genio.read_file(self._stdout_file)
             msg = ('Actual test sdtout differs from expected one:\n'
                    'Actual:\n%s\nExpected:\n%s' % (actual, expected))
             self.assertEqual(expected, actual, msg)
@@ -358,7 +358,7 @@ class Test(unittest.TestCase):
     def _check_reference_stderr(self):
         if os.path.isfile(self._expected_stderr_file):
             expected = genio.read_file(self._expected_stderr_file)
-            actual = genio.read_file(self.stderr_file)
+            actual = genio.read_file(self._stderr_file)
             msg = ('Actual test sdterr differs from expected one:\n'
                    'Actual:\n%s\nExpected:\n%s' % (actual, expected))
             self.assertEqual(expected, actual, msg)

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -465,8 +465,10 @@ class Test(unittest.TestCase):
 
     def _setup_environment_variables(self):
         os.environ['AVOCADO_VERSION'] = VERSION
-        os.environ['AVOCADO_TEST_BASEDIR'] = self.basedir
-        os.environ['AVOCADO_TEST_DATADIR'] = self.datadir
+        if self.basedir is not None:
+            os.environ['AVOCADO_TEST_BASEDIR'] = self.basedir
+        if self.datadir is not None:
+            os.environ['AVOCADO_TEST_DATADIR'] = self.datadir
         os.environ['AVOCADO_TEST_WORKDIR'] = self.workdir
         os.environ['AVOCADO_TEST_SRCDIR'] = self.srcdir
         os.environ['AVOCADO_TEST_LOGDIR'] = self.logdir

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -563,8 +563,8 @@ class SimpleTest(Test):
                                 r' \d\d:\d\d:\d\d WARN \|')
 
     def __init__(self, name, params=None, base_logdir=None, tag=None, job=None):
-        super(SimpleTest, self).__init__(name=name, base_logdir=base_logdir,
-                                         params=params, tag=tag, job=job)
+        super(SimpleTest, self).__init__(name=name, params=params,
+                                         base_logdir=base_logdir, tag=tag, job=job)
         self.path = name
 
     @property

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -90,10 +90,15 @@ class Test(unittest.TestCase):
 
         self.filename = inspect.getfile(self.__class__).rstrip('co')
         self.basedir = os.path.dirname(self.filename)
-        self._expected_stdout_file = os.path.join(self.datadir,
-                                                  'stdout.expected')
-        self._expected_stderr_file = os.path.join(self.datadir,
-                                                  'stderr.expected')
+
+        if self.datadir is None:
+            self._expected_stdout_file = None
+            self._expected_stderr_file = None
+        else:
+            self._expected_stdout_file = os.path.join(self.datadir,
+                                                      'stdout.expected')
+            self._expected_stderr_file = os.path.join(self.datadir,
+                                                      'stderr.expected')
 
         if base_logdir is None:
             base_logdir = data_dir.create_job_logs_dir()

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -586,13 +586,6 @@ class SimpleTest(Test):
         self.path = name
 
     @property
-    def datadir(self):
-        """
-        Returns the path to the directory that contains test data files
-        """
-        return self.name + '.data'
-
-    @property
     def filename(self):
         """
         Returns the name of the file (path) that holds the current test

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -90,10 +90,10 @@ class Test(unittest.TestCase):
 
         self.filename = inspect.getfile(self.__class__).rstrip('co')
         self.basedir = os.path.dirname(self.filename)
-        self.expected_stdout_file = os.path.join(self.datadir,
-                                                 'stdout.expected')
-        self.expected_stderr_file = os.path.join(self.datadir,
-                                                 'stderr.expected')
+        self._expected_stdout_file = os.path.join(self.datadir,
+                                                  'stdout.expected')
+        self._expected_stderr_file = os.path.join(self.datadir,
+                                                  'stderr.expected')
 
         if base_logdir is None:
             base_logdir = data_dir.create_job_logs_dir()
@@ -323,23 +323,23 @@ class Test(unittest.TestCase):
 
     def _record_reference_stdout(self):
         utils_path.init_dir(self.datadir)
-        shutil.copyfile(self.stdout_file, self.expected_stdout_file)
+        shutil.copyfile(self.stdout_file, self._expected_stdout_file)
 
     def _record_reference_stderr(self):
         utils_path.init_dir(self.datadir)
-        shutil.copyfile(self.stderr_file, self.expected_stderr_file)
+        shutil.copyfile(self.stderr_file, self._expected_stderr_file)
 
     def _check_reference_stdout(self):
-        if os.path.isfile(self.expected_stdout_file):
-            expected = genio.read_file(self.expected_stdout_file)
+        if os.path.isfile(self._expected_stdout_file):
+            expected = genio.read_file(self._expected_stdout_file)
             actual = genio.read_file(self.stdout_file)
             msg = ('Actual test sdtout differs from expected one:\n'
                    'Actual:\n%s\nExpected:\n%s' % (actual, expected))
             self.assertEqual(expected, actual, msg)
 
     def _check_reference_stderr(self):
-        if os.path.isfile(self.expected_stderr_file):
-            expected = genio.read_file(self.expected_stderr_file)
+        if os.path.isfile(self._expected_stderr_file):
+            expected = genio.read_file(self._expected_stderr_file)
             actual = genio.read_file(self.stderr_file)
             msg = ('Actual test sdterr differs from expected one:\n'
                    'Actual:\n%s\nExpected:\n%s' % (actual, expected))

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -88,8 +88,6 @@ class Test(unittest.TestCase):
 
         self.job = job
 
-        self.basedir = os.path.dirname(self.filename)
-
         if self.datadir is None:
             self._expected_stdout_file = None
             self._expected_stderr_file = None
@@ -161,6 +159,16 @@ class Test(unittest.TestCase):
 
         self.time_elapsed = None
         unittest.TestCase.__init__(self, methodName=methodName)
+
+    @property
+    def basedir(self):
+        """
+        The directory where this test (when backed by a file) is located at
+        """
+        if self.filename is not None:
+            return os.path.dirname(self.filename)
+        else:
+            return None
 
     @property
     def datadir(self):


### PR DESCRIPTION
Another round of cleanups, according to:

https://trello.com/c/W58vhyHR/539-bug-some-avocado-test-methods-and-atributes-are-public

---

Changes from v1:
 * Be more explicit when returning `None` on `basedir`.