### PR TITLE
Remote improvements

### DIFF
--- a/avocado/core/remote/result.py
+++ b/avocado/core/remote/result.py
@@ -84,11 +84,12 @@ class RemoteTestResult(HumanTestResult):
                                    self.args.remote_hostname,
                                    self.args.remote_port,
                                    self.args.remote_timeout)))
-        self.remote = remoter.Remote(self.args.remote_hostname,
-                                     self.args.remote_username,
-                                     self.args.remote_password,
-                                     self.args.remote_port,
-                                     self.args.remote_timeout)
+        self.remote = remoter.Remote(hostname=self.args.remote_hostname,
+                                     username=self.args.remote_username,
+                                     password=self.args.remote_password,
+                                     key_filename=self.args.remote_key_file,
+                                     port=self.args.remote_port,
+                                     timeout=self.args.remote_timeout)
 
     def tear_down(self):
         """ Cleanup after test execution """
@@ -139,6 +140,7 @@ class VMTestResult(RemoteTestResult):
             self.args.remote_port = self.args.vm_port
             self.args.remote_username = self.args.vm_username
             self.args.remote_password = self.args.vm_password
+            self.args.remote_key_file = self.args.vm_key_file
             self.args.remote_no_copy = self.args.vm_no_copy
             self.args.remote_timeout = self.args.vm_timeout
             super(VMTestResult, self).setup()

--- a/avocado/core/remoter.py
+++ b/avocado/core/remoter.py
@@ -80,8 +80,11 @@ class Remote(object):
         Run a remote command.
 
         :param command: the command string to execute.
+        :param ignore_status: Whether to not raise exceptions in case the
+            command's return code is different than zero.
+        :param timeout: Maximum time allowed for the command to return.
 
-        :return: the result of the remote program's output.
+        :return: the result of the remote program's execution.
         :rtype: :class:`avocado.utils.process.CmdResult`.
         :raise fabric.exceptions.CommandTimeout: When timeout exhausted.
         """

--- a/avocado/core/remoter.py
+++ b/avocado/core/remoter.py
@@ -36,6 +36,102 @@ else:
     REMOTE_CAPABLE = True
 
 
+def run(command, ignore_status=False, quiet=True, timeout=60):
+    """
+    Executes a command on the defined fabric hosts.
+
+    This is basically a wrapper to fabric.operations.run, encapsulating
+    the result on an avocado process.CmdResult object. This also assumes
+    the fabric environment was previously (and properly) initialized.
+
+    :param command: the command string to execute.
+    :param ignore_status: Whether to not raise exceptions in case the
+        command's return code is different than zero.
+    :param timeout: Maximum time allowed for the command to return.
+    :param quiet: Whether to not log command stdout/err. Default: True.
+
+    :return: the result of the remote program's execution.
+    :rtype: :class:`avocado.utils.process.CmdResult`.
+    :raise fabric.exceptions.CommandTimeout: When timeout exhausted.
+    """
+
+    result = process.CmdResult()
+    start_time = time.time()
+    end_time = time.time() + (timeout or 0)   # Support timeout=None
+    # Fabric sometimes returns NetworkError even when timeout not reached
+    fabric_result = None
+    fabric_exception = None
+    while True:
+        try:
+            fabric_result = fabric.operations.run(command=command,
+                                                  quiet=quiet,
+                                                  warn_only=True,
+                                                  timeout=timeout)
+            break
+        except fabric.network.NetworkError, details:
+            fabric_exception = details
+            timeout = end_time - time.time()
+        if time.time() < end_time:
+            break
+    if fabric_result is None:
+        if fabric_exception is not None:
+            raise fabric_exception  # it's not None pylint: disable=E0702
+        else:
+            raise fabric.network.NetworkError("Remote execution of '%s'"
+                                              "failed without any "
+                                              "exception. This should not "
+                                              "happen." % command)
+    end_time = time.time()
+    duration = end_time - start_time
+    result.command = command
+    result.stdout = str(fabric_result)
+    result.stderr = fabric_result.stderr
+    result.duration = duration
+    result.exit_status = fabric_result.return_code
+    result.failed = fabric_result.failed
+    result.succeeded = fabric_result.succeeded
+    if not ignore_status:
+        if result.failed:
+            raise process.CmdError(command=command, result=result)
+    return result
+
+
+def send_files(local_path, remote_path):
+    """
+    Send files to the defined fabric host.
+
+    This assumes the fabric environment was previously (and properly)
+    initialized.
+
+    :param local_path: the local path.
+    :param remote_path: the remote path.
+    """
+    try:
+        fabric.operations.put(local_path, remote_path,
+                              mirror_local_mode=True)
+    except ValueError:
+        return False
+    return True
+
+
+def receive_files(local_path, remote_path):
+    """
+    Receive files from the defined fabric host.
+
+    This assumes the fabric environment was previously (and properly)
+    initialized.
+
+    :param local_path: the local path.
+    :param remote_path: the remote path.
+    """
+    try:
+        fabric.operations.get(remote_path,
+                              local_path)
+    except ValueError:
+        return False
+    return True
+
+
 class Remote(object):
 
     """
@@ -74,7 +170,7 @@ class Remote(object):
 
     def run(self, command, ignore_status=False, quiet=True, timeout=60):
         """
-        Run a remote command.
+        Run a command on the remote host.
 
         :param command: the command string to execute.
         :param ignore_status: Whether to not raise exceptions in case the
@@ -86,52 +182,10 @@ class Remote(object):
         :rtype: :class:`avocado.utils.process.CmdResult`.
         :raise fabric.exceptions.CommandTimeout: When timeout exhausted.
         """
-        return_dict = fabric.tasks.execute(self._run, command, ignore_status,
+        return_dict = fabric.tasks.execute(run, command, ignore_status,
                                            quiet, timeout,
                                            hosts=[self.hostname])
         return return_dict[self.hostname]
-
-    @staticmethod
-    def _run(command, ignore_status=False, quiet=True, timeout=60):
-        result = process.CmdResult()
-        start_time = time.time()
-        end_time = time.time() + (timeout or 0)   # Support timeout=None
-        # Fabric sometimes returns NetworkError even when timeout not reached
-        fabric_result = None
-        fabric_exception = None
-        while True:
-            try:
-                fabric_result = fabric.operations.run(command=command,
-                                                      quiet=quiet,
-                                                      warn_only=True,
-                                                      timeout=timeout)
-                break
-            except fabric.network.NetworkError, details:
-                fabric_exception = details
-                timeout = end_time - time.time()
-            if time.time() < end_time:
-                break
-        if fabric_result is None:
-            if fabric_exception is not None:
-                raise fabric_exception  # it's not None pylint: disable=E0702
-            else:
-                raise fabric.network.NetworkError("Remote execution of '%s'"
-                                                  "failed without any "
-                                                  "exception. This should not "
-                                                  "happen." % command)
-        end_time = time.time()
-        duration = end_time - start_time
-        result.command = command
-        result.stdout = str(fabric_result)
-        result.stderr = fabric_result.stderr
-        result.duration = duration
-        result.exit_status = fabric_result.return_code
-        result.failed = fabric_result.failed
-        result.succeeded = fabric_result.succeeded
-        if not ignore_status:
-            if result.failed:
-                raise process.CmdError(command=command, result=result)
-        return result
 
     def uptime(self):
         """
@@ -154,41 +208,23 @@ class Remote(object):
         self.run('mkdir -p %s' % remote_path)
 
     def send_files(self, local_path, remote_path):
-        result_dict = fabric.tasks.execute(self._send_files, local_path,
-                                           remote_path, hosts=[self.hostname])
-        return result_dict[self.hostname]
-
-    @staticmethod
-    def _send_files(local_path, remote_path):
         """
-        Send files to remote.
+        Send files to remote host.
 
         :param local_path: the local path.
         :param remote_path: the remote path.
         """
-        try:
-            fabric.operations.put(local_path, remote_path,
-                                  mirror_local_mode=True)
-        except ValueError:
-            return False
-        return True
+        result_dict = fabric.tasks.execute(send_files, local_path,
+                                           remote_path, hosts=[self.hostname])
+        return result_dict[self.hostname]
 
     def receive_files(self, local_path, remote_path):
-        result_dict = fabric.tasks.execute(self._receive_files, local_path,
-                                           remote_path, hosts=[self.hostname])
-        return result_dict[self.hostname]
-
-    @staticmethod
-    def _receive_files(self, local_path, remote_path):
         """
-        receive remote files.
+        Receive files from the remote host.
 
         :param local_path: the local path.
         :param remote_path: the remote path.
         """
-        try:
-            fabric.operations.get(remote_path,
-                                  local_path)
-        except ValueError:
-            return False
-        return True
+        result_dict = fabric.tasks.execute(receive_files, local_path,
+                                           remote_path, hosts=[self.hostname])
+        return result_dict[self.hostname]

--- a/avocado/core/remoter.py
+++ b/avocado/core/remoter.py
@@ -66,19 +66,14 @@ class Remote(object):
         self.password = password
         self.port = port
         self.quiet = quiet
-        self._setup_environment(host_string=hostname,
-                                user=username,
-                                password=password,
-                                key_filename=key_filename,
-                                port=port,
-                                timeout=timeout / attempts,
-                                connection_attempts=attempts,
-                                linewise=True)
-
-    @staticmethod
-    def _setup_environment(**kwargs):
-        """ Setup fabric environemnt """
-        fabric.api.env.update(kwargs)
+        fabric.api.env.update(host_string=hostname,
+                              user=username,
+                              password=password,
+                              key_filename=key_filename,
+                              port=port,
+                              timeout=timeout / attempts,
+                              connection_attempts=attempts,
+                              linewise=True)
 
     def run(self, command, ignore_status=False, timeout=60):
         """

--- a/avocado/core/remoter.py
+++ b/avocado/core/remoter.py
@@ -132,6 +132,22 @@ def receive_files(local_path, remote_path):
     return True
 
 
+def _update_fabric_env(method):
+    """
+    Update fabric env with the appropriate parameters.
+
+    :param method: Remote method to wrap.
+    :return: Wrapped method.
+    """
+    def wrapper(*args, **kwargs):
+        fabric.api.env.update(host_string=args[0].hostname,
+                              user=args[0].username,
+                              key_filename=args[0].key_filename,
+                              port=args[0].port)
+        return method(*args, **kwargs)
+    return wrapper
+
+
 class Remote(object):
 
     """
@@ -168,6 +184,7 @@ class Remote(object):
                               connection_attempts=attempts,
                               linewise=True)
 
+    @_update_fabric_env
     def run(self, command, ignore_status=False, quiet=True, timeout=60):
         """
         Run a command on the remote host.
@@ -207,6 +224,7 @@ class Remote(object):
         """
         self.run('mkdir -p %s' % remote_path)
 
+    @_update_fabric_env
     def send_files(self, local_path, remote_path):
         """
         Send files to remote host.
@@ -218,6 +236,7 @@ class Remote(object):
                                            remote_path, hosts=[self.hostname])
         return result_dict[self.hostname]
 
+    @_update_fabric_env
     def receive_files(self, local_path, remote_path):
         """
         Receive files from the remote host.

--- a/avocado/core/remoter.py
+++ b/avocado/core/remoter.py
@@ -43,13 +43,16 @@ class Remote(object):
     """
 
     def __init__(self, hostname, username=None, password=None,
-                 port=22, timeout=60, attempts=10, quiet=False):
+                 key_filename=None, port=22, timeout=60, attempts=10,
+                 quiet=False):
         """
         Creates an instance of :class:`Remote`.
 
         :param hostname: the hostname.
         :param username: the username. Default: autodetect.
         :param password: the password. Default: try to use public key.
+        :param key_filename: path to an identity file (Example: .pem files
+            from Amazon EC2).
         :param timeout: remote command timeout, in seconds. Default: 60.
         :param attempts: number of attempts to connect. Default: 10.
         :param quiet: performs quiet operations. Default: True.
@@ -58,6 +61,7 @@ class Remote(object):
         if username is None:
             username = getpass.getuser()
         self.username = username
+        self.key_filename = key_filename
         # None = use public key
         self.password = password
         self.port = port
@@ -65,6 +69,7 @@ class Remote(object):
         self._setup_environment(host_string=hostname,
                                 user=username,
                                 password=password,
+                                key_filename=key_filename,
                                 port=port,
                                 timeout=timeout / attempts,
                                 connection_attempts=attempts,

--- a/avocado/core/remoter.py
+++ b/avocado/core/remoter.py
@@ -88,6 +88,11 @@ class Remote(object):
         :rtype: :class:`avocado.utils.process.CmdResult`.
         :raise fabric.exceptions.CommandTimeout: When timeout exhausted.
         """
+        return_dict = fabric.tasks.execute(self._run, command, ignore_status,
+                                           timeout, hosts=[self.hostname])
+        return return_dict[self.hostname]
+
+    def _run(self, command, ignore_status=False, timeout=60):
         result = process.CmdResult()
         start_time = time.time()
         end_time = time.time() + (timeout or 0)   # Support timeout=None
@@ -149,6 +154,12 @@ class Remote(object):
         self.run('mkdir -p %s' % remote_path)
 
     def send_files(self, local_path, remote_path):
+        result_dict = fabric.tasks.execute(self._send_files, local_path,
+                                           remote_path, hosts=[self.hostname])
+        return result_dict[self.hostname]
+
+    @staticmethod
+    def _send_files(local_path, remote_path):
         """
         Send files to remote.
 
@@ -163,6 +174,12 @@ class Remote(object):
         return True
 
     def receive_files(self, local_path, remote_path):
+        result_dict = fabric.tasks.execute(self._receive_files, local_path,
+                                           remote_path, hosts=[self.hostname])
+        return result_dict[self.hostname]
+
+    @staticmethod
+    def _receive_files(self, local_path, remote_path):
         """
         receive remote files.
 

--- a/avocado/plugins/remote.py
+++ b/avocado/plugins/remote.py
@@ -62,6 +62,11 @@ class Remote(CLI):
                                         dest='remote_password', default=None,
                                         help='Specify the password to login on'
                                         ' remote machine')
+        self.remote_parser.add_argument('--remote-key-file',
+                                        dest='remote_key_file', default=None,
+                                        help='Specify an identity file with '
+                                        'a private key instead of a password '
+                                        '(Example: .pem files from Amazon EC2)')
         self.remote_parser.add_argument('--remote-no-copy',
                                         dest='remote_no_copy',
                                         action='store_true',

--- a/avocado/plugins/vm.py
+++ b/avocado/plugins/vm.py
@@ -64,6 +64,11 @@ class VM(CLI):
         self.vm_parser.add_argument('--vm-password',
                                     default=None,
                                     help='Specify the password to login on VM')
+        self.vm_parser.add_argument('--vm-key-file',
+                                    dest='vm_key_file', default=None,
+                                    help='Specify an identity file with '
+                                    'a private key instead of a password '
+                                    '(Example: .pem files from Amazon EC2)')
         self.vm_parser.add_argument('--vm-cleanup',
                                     action='store_true', default=False,
                                     help='Restore VM to a previous state, '

--- a/selftests/unit/test_remote.py
+++ b/selftests/unit/test_remote.py
@@ -136,7 +136,8 @@ class RemoteTestResultTest(unittest.TestCase):
         Stream.should_receive('notify').once().ordered()
         remote_remote = flexmock(remoter)
         (remote_remote.should_receive('Remote')
-         .with_args('hostname', 'username', 'password', 22, 60)
+         .with_args(hostname='hostname', username='username',
+                    password='password', key_filename=None, port=22, timeout=60)
          .once().ordered()
          .and_return(Remote))
         Args = flexmock(test_result_total=1,
@@ -146,6 +147,7 @@ class RemoteTestResultTest(unittest.TestCase):
                         remote_hostname='hostname',
                         remote_port=22,
                         remote_password='password',
+                        remote_key_file=None,
                         remote_no_copy=False,
                         remote_timeout=60)
         self.remote = remote.RemoteTestResult(Stream, Args)

--- a/selftests/unit/test_vm.py
+++ b/selftests/unit/test_vm.py
@@ -45,6 +45,7 @@ class VMTestResultTest(unittest.TestCase):
                         vm_hostname='hostname',
                         vm_port=22,
                         vm_password='password',
+                        vm_key_file=None,
                         vm_cleanup=True,
                         vm_no_copy=False,
                         vm_timeout=120,


### PR DESCRIPTION
This contains a number of changes made to support my AWS cluster tests.

Those changes basically refactor a number of things in the remote class, enable multiple instances to be executed on the same test, and work around a Paramiko bug [2].

Now, considering that `fabric` has no thread safety, and doesn't play nice with `logging`, I think the only correct solution is to throw fabric out [1] and have our own SSH library. But let's tackle one thing at a time.

[1] Possibly Paramiko as well (the keys handling bug is specially annoying). I'm seriously thinking about reusing the autotest SSH host classes and have something that works with raw ssh and paramiko interchangeably.
[2] https://github.com/paramiko/paramiko/issues/387