### PR TITLE
avocado.main(): avoid an infinite fork loop bomb [v4]

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -540,6 +540,16 @@ class TestProgram(object):
     """
 
     def __init__(self):
+        # Avoid fork loop/bomb when running a test via avocado.main() that
+        # calls avocado.main() itself
+        if os.environ.get('AVOCADO_STANDALONE_IN_MAIN', False):
+            sys.stderr.write('AVOCADO_STANDALONE_IN_MAIN environment variable '
+                             'found. This means that this code is being '
+                             'called recursively. Exiting to avoid an infinite'
+                             ' fork loop.\n')
+            sys.exit(exit_codes.AVOCADO_FAIL)
+        os.environ['AVOCADO_STANDALONE_IN_MAIN'] = 'True'
+
         self.defaultTest = sys.argv[0]
         self.progName = os.path.basename(sys.argv[0])
         self.parseArgs(sys.argv[1:])


### PR DESCRIPTION
Because the current implementation of avocado.main() creates a job
and runs "sys.argv[0]" to implement standalone mode, it ends up
running itself over and over.

This simple proposed fix, prevents avocado.main() from running
itself again if called from itself. Since they are on different
processes, the mechanism chosen to do this is to set an environment
variable, that will be seen by the next process.

Also, by exiting from main() with an error code, the test first
level test will fail. This will let the user know that the chosen
approach (SIMPLE tests written in Python and calling main()) are
not worthy of a PASS.

The functional tests make use of Python's standard library utilities
(subprocess module) directly for running Avocado because of current
issues with Avocado's own process utility module.

This adresses issue #961.

Signed-off-by: Cleber Rosa <crosa@redhat.com>

---
Changes from v3:
 * Use Python subprocess module for running the avocado command line in the functional test, and clean up progress (group) if it doesn't finish properly

Changes from v2:
 * Return an error code to signal that the used approach (calling `main()` is not ideal from a SIMPLE test).

Changes from v1:
 * Add error message to STDERR, warning that main() will exit to avoid a loop.