### PR TITLE
[DRAFT] Remote test results

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -188,15 +188,10 @@ class Job(object):
                                              test_result=self.result_proxy)
 
     def _set_output_plugins(self):
-        for key in self.args.__dict__.keys():
-            result_class_candidate = getattr(self.args, key)
-            try:
-                if issubclass(result_class_candidate, result.TestResult):
-                    result_plugin = result_class_candidate(self.view,
-                                                           self.args)
-                    self.result_proxy.add_output_plugin(result_plugin)
-            except TypeError:
-                pass
+        if getattr(self.args, 'test_result_classes', None) is not None:
+            for klass in self.args.test_result_classes:
+                test_result_instance = klass(self.view, self.args)
+                self.result_proxy.add_output_plugin(test_result_instance)
 
     def _make_test_result(self):
         """

--- a/avocado/core/remote/result.py
+++ b/avocado/core/remote/result.py
@@ -29,6 +29,8 @@ class RemoteTestResult(HumanTestResult):
     Remote Machine Test Result class.
     """
 
+    command_line_arg_name = '--remote-hostname'
+
     def __init__(self, stream, args):
         """
         Creates an instance of RemoteTestResult.
@@ -42,7 +44,6 @@ class RemoteTestResult(HumanTestResult):
         self.urls = self.args.url
         self.remote = None      # Remote runner initialized during setup
         self.output = '-'
-        self.command_line_arg_name = '--remote-hostname'
 
     def copy_files(self):
         """
@@ -101,10 +102,11 @@ class VMTestResult(RemoteTestResult):
     Virtual Machine Test Result class.
     """
 
+    command_line_arg_name = '--vm-domain'
+
     def __init__(self, stream, args):
         super(VMTestResult, self).__init__(stream, args)
         self.vm = None
-        self.command_line_arg_name = '--vm-domain'
 
     def setup(self):
         # Super called after VM is found and initialized

--- a/avocado/core/result.py
+++ b/avocado/core/result.py
@@ -48,13 +48,6 @@ class TestResultProxy(object):
     def __init__(self):
         self.output_plugins = []
 
-    def __getattr__(self, attr):
-        for output_plugin in self.output_plugins:
-            if hasattr(output_plugin, attr):
-                return getattr(output_plugin, attr)
-            else:
-                return None
-
     def notify_progress(self, progress_from_test=False):
         for output_plugin in self.output_plugins:
             if hasattr(output_plugin, 'notify_progress'):

--- a/avocado/core/result.py
+++ b/avocado/core/result.py
@@ -27,6 +27,22 @@ class InvalidOutputPlugin(Exception):
     pass
 
 
+def register_test_result_class(application_args, klass):
+    """
+    Register the given test result class to be loaded and enabled by the job
+
+    :param application_args: the parsed application command line arguments.
+                             This is currently being abused to hold various job
+                             settings and feature choices, such as the runner.
+    :type application_args: :class:`argparse.Namespace`
+    :param klass: the test result class to enable
+    :type klass: a subclass of :class:`TestResult`
+    """
+    if getattr(application_args, 'test_result_classes', None) is None:
+        application_args.test_result_classes = set()
+    application_args.test_result_classes.add(klass)
+
+
 class TestResultProxy(object):
 
     def __init__(self):

--- a/avocado/plugins/html.py
+++ b/avocado/plugins/html.py
@@ -19,6 +19,7 @@ import sys
 from avocado.core import exit_codes
 from avocado.core import output
 from avocado.core.html import HTMLTestResult
+from avocado.core.result import register_test_result_class
 from .base import CLI
 
 
@@ -64,4 +65,4 @@ class HTML(CLI):
             sys.exit(exit_codes.AVOCADO_JOB_FAIL)
 
         if 'html_output' in args and args.html_output is not None:
-            args.html_result = HTMLTestResult
+            register_test_result_class(args, HTMLTestResult)

--- a/avocado/plugins/journal.py
+++ b/avocado/plugins/journal.py
@@ -20,6 +20,7 @@ import datetime
 
 from .base import CLI
 from avocado.core.result import TestResult
+from avocado.core.result import register_test_result_class
 
 JOURNAL_FILENAME = ".journal.sqlite"
 
@@ -131,4 +132,4 @@ class Journal(CLI):
 
     def run(self, args):
         if 'journal' in args and args.journal is True:
-            args.journal_result = TestResultJournal
+            register_test_result_class(args, TestResultJournal)

--- a/avocado/plugins/json.py
+++ b/avocado/plugins/json.py
@@ -16,6 +16,7 @@
 JSON output module.
 """
 
+from avocado.core.result import register_test_result_class
 from avocado.core.jsonresult import JSONTestResult
 
 from .base import CLI
@@ -43,4 +44,4 @@ class JSON(CLI):
 
     def run(self, args):
         if 'json_output' in args and args.json_output is not None:
-            args.json_result = JSONTestResult
+            register_test_result_class(args, JSONTestResult)

--- a/avocado/plugins/remote.py
+++ b/avocado/plugins/remote.py
@@ -22,6 +22,7 @@ from avocado.core import exit_codes
 from avocado.core import remoter
 from avocado.core.remote import RemoteTestResult
 from avocado.core.remote import RemoteTestRunner
+from avocado.core.result import register_test_result_class
 from .base import CLI
 
 
@@ -101,5 +102,5 @@ class Remote(CLI):
     def run(self, args):
         if self._check_required_args(args, 'remote_hostname',
                                      ('remote_hostname',)):
-            args.remote_result = RemoteTestResult
+            register_test_result_class(args, RemoteTestResult)
             args.test_runner = RemoteTestRunner

--- a/avocado/plugins/vm.py
+++ b/avocado/plugins/vm.py
@@ -22,6 +22,7 @@ from avocado.core import exit_codes
 from avocado.core import virt
 from avocado.core.remote import VMTestResult
 from avocado.core.remote import RemoteTestRunner
+from avocado.core.result import register_test_result_class
 from .base import CLI
 
 
@@ -104,5 +105,5 @@ class VM(CLI):
 
     def run(self, args):
         if self._check_required_args(args, 'vm_domain', ('vm_domain',)):
-            args.remote_result = VMTestResult
+            register_test_result_class(args, VMTestResult)
             args.test_runner = RemoteTestRunner

--- a/avocado/plugins/xunit.py
+++ b/avocado/plugins/xunit.py
@@ -14,6 +14,7 @@
 
 """xUnit module."""
 
+from avocado.core.result import register_test_result_class
 from avocado.core.xunit import xUnitTestResult
 from .base import CLI
 
@@ -40,4 +41,4 @@ class XUnit(CLI):
 
     def run(self, args):
         if 'xunit_output' in args and args.xunit_output is not None:
-            args.xunit_result = xUnitTestResult
+            register_test_result_class(args, xUnitTestResult)

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -74,9 +74,10 @@ class OutputPluginTest(unittest.TestCase):
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %d:\n%s" %
                          (expected_rc, result))
-        error_excerpt = "Options --json --xunit are trying to use stdout simultaneously"
-        self.assertIn(error_excerpt, output,
-                      "Missing excerpt error message from output:\n%s" % output)
+        error_regex = re.compile(r'Options (--json --xunit)|(--xunit --son) '
+                                 'are trying to use stdout simultaneously')
+        self.assertIsNotNone(error_regex.match(output),
+                             "Missing error message from output:\n%s" % output)
 
     def test_output_incompatible_setup_2(self):
         os.chdir(basedir)


### PR DESCRIPTION
This is a PR mostly addressed to @lmr since he reported the general issues with running custom test result implementations.

The first 2 commits are general improvements, but not critical changes. The last 2 commits really addresses the very broken state of remote test results and remote test runners. More complete description of the issues are on the commit message themselves.