### PR TITLE
avocado.utils asset fetcher [v2]

### DIFF
--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -1,0 +1,119 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2016
+# Author: Amador Pahim <apahim@redhat.com>
+
+"""
+Asset fetcher from multiple locations
+
+"""
+
+import logging
+import os
+import urlparse
+
+from . import crypto
+from . import download
+
+
+log = logging.getLogger('avocado.test')
+
+
+def _check_file(filename, expected_hash):
+    if not os.path.isfile(filename):
+        log.error('Asset %s not found.' % filename)
+        return False
+
+    if expected_hash is None:
+        log.debug('Skipping hash check for %s.' % filename)
+        return True
+
+    file_hash = crypto.hash_file(filename)
+    if file_hash == expected_hash:
+        log.debug('Asset %s verified.' % filename)
+        return True
+    else:
+        log.error('Asset %s corrupted.' % filename)
+        return False
+
+
+def fetch(self, search='asset'):
+    """
+    Tries to fetch a file from multiple locations, trying the cache
+    first and caching when successfully fetched.
+
+    Expected yaml format:
+
+    asset:
+        name: <name> # Not null
+        md5sum: <hash> # Optional. Skips the check if null.
+        cache_dir: <path> # Optional. Default is test temporary dir.
+        location: # list of locations to try.
+        - file://<path>
+        - http://<url>
+        - ftp://<url>
+
+    :param self: avocado test self instance.
+    :param search: (optional) search for yaml option with all the asset
+            data. Default is 'asset'.
+    :return: asset path.
+    """
+
+    name = self.params.get('name', '*/%s/*' % search, default=None)
+    md5sum = self.params.get('md5sum', '*/%s/*' % search, default=None)
+    cache_dir = self.params.get('cache_dir', '*/%s/*' % search,
+                                default=self.workdir)
+    location = self.params.get('location', '*/%s/*' % search, default=None)
+
+    dst = os.path.join(cache_dir, name)
+    if name is None:
+        log.error('Asset name is missing.')
+        return None
+    if _check_file(dst, md5sum):
+        return dst
+    if location is None:
+        return None
+
+    for url in location:
+        urlobj = urlparse.urlparse(url)
+        if urlobj.scheme == 'http':
+            log.debug('Trying to download from %s.' % url)
+            try:
+                download._get_file(url, dst)
+            except Exception as e:
+                log.error(e)
+                continue
+            if _check_file(dst, md5sum):
+                return dst
+
+        elif urlobj.scheme == 'ftp':
+            log.debug('Trying to download from %s.' % url)
+            try:
+                download._get_file(url, dst)
+            except Exception as e:
+                log.error(e)
+                continue
+            if _check_file(dst, md5sum):
+                return dst
+
+        elif urlobj.scheme == 'file':
+            log.debug('Trying to copy from %s.' % urlobj.path)
+            try:
+                download._get_file(urlobj.path, dst)
+            except Exception as e:
+                log.error(e)
+                continue
+            if _check_file(dst, md5sum):
+                return dst
+
+    log.error('No more locations to try.')
+    return None

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -345,6 +345,71 @@ In this example, the ``test`` method just gets into the base directory of
 the compiled suite  and executes the ``./synctest`` command, with appropriate
 parameters, using :func:`avocado.utils.process.system`.
 
+Fetching asset files
+====================
+To run third party test suites as mentioned above, you can be interested in
+fetch your tarball during the ``setUp()`` phase as well. To achieve that, we
+offer the ``avocado.utils.asset`` module. It can check if your file is in the
+provided ``cache_dir`` and, if not, try to dowload it from a list of locations.
+Example::
+
+    ...
+    from avocado.utils import asset
+    ...
+
+    ...
+        def setUp(self):
+            tarball = asset.fetch(self)
+            if tarball is None:
+                self.error('tarball not found')
+    ...
+
+The asset data can be provided using a multiplex file in the following format::
+
+    asset:
+        name: stress-1.0.4.tar.gz
+        md5sum: 890a4236dd1656792f3ef9a190cf99ef
+        cache_dir: null
+        location:
+            - http://people.seas.harvard.edu/~apw/stress/stress-1.0.4.tar.gz
+            - file:///usr/local/downloads/stress-1.0.4.tar.gz
+            - ftp://ftp.example.com/pub/stress-1.0.4.tar.gz
+
+The fetcher will look for the ``asset`` key to load the asset data from. This can
+be manipulated by providing a different key if you need, for example, to fetch
+more than one asset in the same job. Example::
+
+    ...
+        def setUp(self):
+            tarball = asset.fetch(self)
+            tarball2 = asset.fetch(self, search='asset2')
+    ...
+
+In that case, the yaml file will look like this::
+
+    asset:
+        name: ...
+    ...
+    asset2:
+        name: ...
+    ...
+
+Detailing the asset data:
+
+ * ``name:`` The name used to name the fetched file.
+ * ``md5sum:`` (optinal) The expected file md5 hash. If ``null`` or missing, we
+   skip the check.
+ * ``cache_dir:`` (optional) The first place we will look for the file. If the
+   file is not there, we will try to fetch from ``location`` list put there. If
+   ``null`` or missing, the temporary test directory will be used. We do
+   recommend not to use temporary directory for big files (i.e. iso files).
+ * ``location:`` (optional) If the file is not already in ``cache_dir``, we try
+   to fetch it from every location, in order. The supported locations are
+   ``http``, ``ftp`` and ``file``. Here you have to inform the full path to the
+   file. The first success will exit the loop.
+
+The expected ``return`` from ``asset.fetch()`` is the file path or ``None``.
+
 Test Output Check and Output Record Mode
 ========================================
 


### PR DESCRIPTION
v1 #993 

Changes:
 - Use full url, including the file name.
 - Docs.
 - Use job temporary dir as `cache_dir` default location.