### PR TITLE
selftests/functional/test_replay.py: fix typo that caused sysinfo col…

### DIFF
--- a/selftests/functional/test_replay.py
+++ b/selftests/functional/test_replay.py
@@ -45,7 +45,7 @@ class ReplayTests(unittest.TestCase):
 
     def test_run_replay_noid(self):
         cmd_line = ('./scripts/avocado run --replay %s'
-                    '--job-results-dir %s --replay-data-dir %s--sysinfo=off' %
+                    '--job-results-dir %s --replay-data-dir %s --sysinfo=off' %
                     ('foo', self.tmpdir, self.jobdir))
         expected_rc = exit_codes.AVOCADO_JOB_FAIL
         self.run_and_check(cmd_line, expected_rc)


### PR DESCRIPTION
…lection

I noticed during a run of the self test suite that system information
was being collected (`rpm -qa` and the like can usually be seen using
quite a few resources).

It looks like this little typo was causing that.

Signed-off-by: Cleber Rosa <crosa@redhat.com>