### PR TITLE
avocado.core.runner: Force methodName on replay_map substitution

### DIFF
--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -192,7 +192,8 @@ class TestRunner(object):
         Creates an instance of TestRunner class.
 
         :param job: an instance of :class:`avocado.core.job.Job`.
-        :param test_result: an instance of :class:`avocado.core.result.TestResultProxy`.
+        :param test_result: an instance of
+                            :class:`avocado.core.result.TestResultProxy`.
         """
         self.job = job
         self.result = test_result
@@ -395,8 +396,8 @@ class TestRunner(object):
                         test_parameters["methodName"] = "test"
                         test_factory = (replay_map[index], test_parameters)
 
-                    break_loop = not self.run_test(test_factory, queue, failures,
-                                                   deadline)
+                    break_loop = not self.run_test(test_factory, queue,
+                                                   failures, deadline)
                     if break_loop:
                         break
             runtime.CURRENT_TEST = None

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -392,6 +392,7 @@ class TestRunner(object):
                 else:
                     if (replay_map is not None and
                             replay_map[index] is not None):
+                        test_parameters["methodName"] = "test"
                         test_factory = (replay_map[index], test_parameters)
 
                     break_loop = not self.run_test(test_factory, queue, failures,

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -367,6 +367,13 @@ class RunnerHumanOutputTest(unittest.TestCase):
         self.assertEqual(os.path.basename(test_dirs[0]),
                          '_bin_echo -ne foo\\\\n\\\'\\"\\\\nbar_baz')
 
+    def test_replay_skip_skipped(self):
+        result = process.run("./scripts/avocado run skiponsetup --json -")
+        result = json.loads(result.stdout)
+        jobid = result["job_id"]
+        process.run(str("./scripts/avocado run --replay %s "
+                        "--replay-test-status PASS" % jobid))
+
     def tearDown(self):
         shutil.rmtree(self.tmpdir)
 


### PR DESCRIPTION
The "replay_map" allows to substitute the test class with custom class.
The problem is, that the "methodName" defined in "test_params" might not
exist in this class.

We have two choices, either leave it up to the user, to substitute with
a compatible class (eg. by creating the "methodName" in "__init__"
before calling the super.__init__), or we can require them to always use
given "methodName". This patch uses the second approach as it seems less
magical to me.

Reproducer:
```
avocado run skiponsetup
avocado run --replay $PREV_ID --replay-test-status PASS
```