### PR TITLE
Test namespace cleanup [3rd round]

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -351,7 +351,8 @@ class Test(unittest.TestCase):
         shutil.copyfile(self._stderr_file, self._expected_stderr_file)
 
     def _check_reference_stdout(self):
-        if os.path.isfile(self._expected_stdout_file):
+        if (self._expected_stdout_file is not None and
+                os.path.isfile(self._expected_stdout_file)):
             expected = genio.read_file(self._expected_stdout_file)
             actual = genio.read_file(self._stdout_file)
             msg = ('Actual test sdtout differs from expected one:\n'
@@ -359,7 +360,8 @@ class Test(unittest.TestCase):
             self.assertEqual(expected, actual, msg)
 
     def _check_reference_stderr(self):
-        if os.path.isfile(self._expected_stderr_file):
+        if (self._expected_stderr_file is not None and
+                os.path.isfile(self._expected_stderr_file)):
             expected = genio.read_file(self._expected_stderr_file)
             actual = genio.read_file(self._stderr_file)
             msg = ('Actual test sdterr differs from expected one:\n'

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -175,7 +175,10 @@ class Test(unittest.TestCase):
         """
         Returns the path to the directory that contains test data files
         """
-        return self.filename + '.data'
+        if self.filename is not None:
+            return self.filename + '.data'
+        else:
+            return None
 
     @property
     def filename(self):

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -462,6 +462,19 @@ class RunnerSimpleTest(unittest.TestCase):
         self.assertIn('ERROR| Error message (ordinary message not changing '
                       'the results)', result.stdout, result)
 
+    def test_non_absolute_path(self):
+        avocado_path = os.path.join(basedir, 'scripts', 'avocado')
+        test_base_dir = os.path.dirname(self.pass_script.path)
+        test_file_name = os.path.basename(self.pass_script.path)
+        os.chdir(test_base_dir)
+        cmd_line = ('%s run --job-results-dir %s --sysinfo=off'
+                    ' %s' % (avocado_path, self.tmpdir, test_file_name))
+        result = process.run(cmd_line, ignore_status=True)
+        expected_rc = exit_codes.AVOCADO_ALL_OK
+        self.assertEqual(result.exit_status, expected_rc,
+                         "Avocado did not return rc %d:\n%s" %
+                         (expected_rc, result))
+
     def tearDown(self):
         self.pass_script.remove()
         self.fail_script.remove()


### PR DESCRIPTION
This is a continuation of the work on the `avocado.Test` class. While these few patches actually don't to much cleaning, they are, as said before, a continuation of the previous work, and they also address an unrelated bug that was found during code reviews.