### PR TITLE
avocado.core.test: Merge Simple and External runner code

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -590,6 +590,7 @@ class SimpleTest(Test):
     def __init__(self, name, params=None, base_logdir=None, tag=None, job=None):
         super(SimpleTest, self).__init__(name=name, params=params,
                                          base_logdir=base_logdir, tag=tag, job=job)
+        self._command = self.filename
 
     @property
     def filename(self):
@@ -616,7 +617,7 @@ class SimpleTest(Test):
                                 self.params.iteritems()])
 
             # process.run uses shlex.split(), the self.path needs to be escaped
-            result = process.run(self.filename, verbose=True,
+            result = process.run(self._command, verbose=True,
                                  env=test_params)
 
             self._log_detailed_cmd_info(result)
@@ -668,19 +669,7 @@ class ExternalRunnerTest(SimpleTest):
                                new_cwd)
                 os.chdir(new_cwd)
 
-            try:
-                test_params = dict([(str(key), str(val)) for path, key, val in
-                                    self.params.iteritems()])
-
-                # process.run uses shlex.split(), the self.path needs to be
-                # escaped
-                result = process.run(self._command, verbose=True,
-                                     env=test_params)
-
-                self._log_detailed_cmd_info(result)
-            except process.CmdError, details:
-                self._log_detailed_cmd_info(details.result)
-                raise exceptions.TestFail(details)
+            super(ExternalRunnerTest, self).test()
 
         finally:
             if new_cwd is not None:


### PR DESCRIPTION
The code for executing binary is the same for booth, let's require
self._command to contain the binary and merge the code to avoid future
diversion.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>