### PR TITLE
avocado.core: Avoid timeout bug in avocado-vt [v2]

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -674,17 +674,14 @@ class FileLoader(TestLoader):
                 return make_broken(test.NotATest, test_path)
 
     @staticmethod
-    def _make_test(klass, uid, params=None):
+    def _make_test(klass, uid):
         """
         Create test template
         :param klass: test class
         :param uid: test uid (by default used as id and name)
         :param params: optional params (id won't be overriden when present)
         """
-        if not params:
-            params = {}
-        params.setdefault('id', uid)
-        return [(klass, {'name': uid, 'params': params})]
+        return [(klass, {'name': uid})]
 
     def _make_tests(self, test_path, list_non_tests, subtests_filter=None):
         """
@@ -797,8 +794,8 @@ class ExternalLoader(TestLoader):
         """
         if not self._external_runner:
             return []
-        return [(test.ExternalRunnerTest, {'name': url, 'params': {'id': url},
-                                           'external_runner': self._external_runner})]
+        return [(test.ExternalRunnerTest, {'name': url, 'external_runner':
+                                           self._external_runner})]
 
     @staticmethod
     def get_type_label_mapping():

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -200,7 +200,8 @@ class TestLoaderProxy(object):
 
         :param urls: a list of tests urls; if [] use plugin defaults
         :type urls: builtin.list
-        :param which_tests: Limit tests to be displayed (ALL, AVAILABLE or DEFAULT)
+        :param which_tests: Limit tests to be displayed (ALL, AVAILABLE or
+                            DEFAULT)
         :return: A list of test factories (tuples (TestClass, test_params))
         """
         def handle_exception(plugin, details):
@@ -344,7 +345,8 @@ class TestLoader(object):
 
         :param url: the url to be inspected.
         :type url: str
-        :param which_tests: Limit tests to be displayed (ALL, AVAILABLE or DEFAULT)
+        :param which_tests: Limit tests to be displayed (ALL, AVAILABLE or
+                            DEFAULT)
         :return: a list of test matching the url as params.
         """
         raise NotImplementedError
@@ -372,13 +374,13 @@ class FilteredOut(object):
 
 
 def add_loader_options(parser):
-    loader = parser.add_argument_group('loader options')
-    loader.add_argument('--loaders', nargs='*', help="Overrides the priority "
+    arggrp = parser.add_argument_group('loader options')
+    arggrp.add_argument('--loaders', nargs='*', help="Overrides the priority "
                         "of the test loaders. You can specify either "
                         "@loader_name or TEST_TYPE. By default it tries all "
                         "available loaders according to priority set in "
                         "settings->plugins.loaders.")
-    loader.add_argument('--external-runner', default=None,
+    arggrp.add_argument('--external-runner', default=None,
                         metavar='EXECUTABLE',
                         help=('Path to an specific test runner that '
                               'allows the use of its own tests. This '
@@ -397,11 +399,11 @@ def add_loader_options(parser):
                   'where those files are located, use "test" here and '
                   'specify the test directory with the option '
                   '"--external-runner-testdir". Defaults to "%(default)s"')
-    loader.add_argument('--external-runner-chdir', default='off',
+    arggrp.add_argument('--external-runner-chdir', default='off',
                         choices=('runner', 'test', 'off'),
                         help=chdir_help)
 
-    loader.add_argument('--external-runner-testdir', metavar='DIRECTORY',
+    arggrp.add_argument('--external-runner-testdir', metavar='DIRECTORY',
                         default=None,
                         help=('Where test files understood by the external'
                               ' test runner are located in the '
@@ -455,7 +457,8 @@ class FileLoader(TestLoader):
         partial match).
 
         :param url: the directory path to inspect.
-        :param which_tests: Limit tests to be displayed (ALL, AVAILABLE or DEFAULT)
+        :param which_tests: Limit tests to be displayed (ALL, AVAILABLE or
+                            DEFAULT)
         :return: list of matching tests
         """
         tests = self._discover(url, which_tests)
@@ -482,7 +485,8 @@ class FileLoader(TestLoader):
         The tests are returned in alphabetic order.
 
         :param url: the directory path to inspect.
-        :param which_tests: Limit tests to be displayed (ALL, AVAILABLE or DEFAULT)
+        :param which_tests: Limit tests to be displayed (ALL, AVAILABLE or
+                            DEFAULT)
         :return: list of matching tests
         """
         if url is None:
@@ -789,7 +793,8 @@ class ExternalLoader(TestLoader):
     def discover(self, url, which_tests=DEFAULT):
         """
         :param url: arguments passed to the external_runner
-        :param which_tests: Limit tests to be displayed (ALL, AVAILABLE or DEFAULT)
+        :param which_tests: Limit tests to be displayed (ALL, AVAILABLE or
+                            DEFAULT)
         :return: list of matching tests
         """
         if not self._external_runner:

--- a/avocado/core/multiplexer.py
+++ b/avocado/core/multiplexer.py
@@ -419,17 +419,12 @@ class Mux(object):
                 test_factory = [template[0], template[1].copy()]
                 if self._has_multiple_variants:
                     test_factory[1]['tag'] = "variant%s" % (i + 1)
-                inject_params = test_factory[1].get('params', {}).get(
-                    'avocado_inject_params', False)
-                # Test providers might want to keep their original params and
-                # only append avocado parameters to a special 'avocado_params'
-                # key. In order for that to happen, they need to set
-                # params['avocado_inject_params'] = True as well.
-                if not inject_params:
-                    test_factory[1]['params'] = (variant, self._mux_path)
-                else:
-                    test_factory[1]['params']['avocado_params'] = (
-                        variant, self._mux_path)
+                if "params" in test_factory[1]:
+                    msg = ("Unable to multiplex test %s, params are already "
+                           "present in test factory: %s"
+                           % (test_factory[0], test_factory[1]))
+                    raise ValueError(msg)
+                test_factory[1]['params'] = (variant, self._mux_path)
                 yield test_factory
             if i is None:   # No variants, use template
                 yield template

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -278,7 +278,7 @@ class TestRunner(object):
 
         # At this point, the test is already initialized and we know
         # for sure if there's a timeout set.
-        timeout = test_status.early_status.get('params', {}).get('timeout')
+        timeout = test_status.early_status.get('timeout')
         timeout = float(timeout or self.DEFAULT_TIMEOUT)
 
         test_deadline = time_started + timeout

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -136,6 +136,9 @@ class Test(unittest.TestCase):
         self.params = multiplexer.AvocadoParams(params, self.name, self.tag,
                                                 mux_path,
                                                 self.default_params)
+        timeout = self.params.get("timeout")
+        if timeout is not None:
+            self.timeout = timeout
 
         self.log.info('START %s', self.tagged_name)
 
@@ -236,7 +239,7 @@ class Test(unittest.TestCase):
                          'tag', 'tagged_name', 'text_output', 'time_elapsed',
                          'traceback', 'workdir', 'whiteboard', 'time_start',
                          'time_end', 'running', 'paused', 'paused_msg',
-                         'fail_class', 'params']
+                         'fail_class', 'params', "timeout"]
         state = dict([(key, self.__dict__.get(key)) for key in preserve_attr])
         state['class_name'] = self.__class__.__name__
         state['job_logdir'] = self.job.logdir


### PR DESCRIPTION
This PR first removes the possibility to initialize params in loader, which does not even work. Then it removes the "avocado_inject_params" hack, which should be superseded by different avocado-vt init https://github.com/avocado-framework/avocado-vt/pull/353 . On top of this cleanup it sets `self.timeout` in `Test.__init__`, which is then used by the `runner` instead of `Test.params.get("timeout")`, which gives incorrect results on avocado-vt as `self.params` contains different params.

v1: https://github.com/avocado-framework/avocado/pull/990

Changes:

    v2: Everything except the idea of "self.timeout"

__This commit breaks avocado-vt. The avocado-framework/avocado-vt#353 is required first.__