### PR TITLE
Makefile: move the removal of avocado directories to the clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,8 @@ clean:
 		do AVOCADO_DIRNAME=$(AVOCADO_DIRNAME) make -C $$MAKEFILE unlink &>/dev/null && echo ">> UNLINK $$MAKEFILE" || echo ">> SKIP $$MAKEFILE";\
 	done
 	$(PYTHON) setup.py develop --uninstall --user
+	rm -rf /var/tmp/avocado*
+	rm -rf /tmp/avocado*
 
 requirements:
 	- if $$(python -V 2>&1 | grep 2.6 -q); then grep -v '^#' requirements-python26.txt | xargs -n 1 pip install --upgrade; fi
@@ -122,8 +124,6 @@ requirements-selftests: requirements
 	- grep -v '^#' requirements-selftests.txt | xargs -n 1 pip install --upgrade
 
 check: clean check_cyclical modules_boundaries
-	rm -rf /var/tmp/avocado*
-	rm -rf /tmp/avocado*
 	selftests/checkall
 	selftests/check_tmp_dirs
 


### PR DESCRIPTION
The check target have a couple of (relevant) directory cleaning up
commands that are, IMHO, out of place. Let's move them to the clean
target.

Signed-off-by: Cleber Rosa <crosa@redhat.com>