### PR TITLE
avocado.utils.process: Add function to get first binary from shell cmd [v2]

### DIFF
--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -202,5 +202,21 @@ class TestProcessRun(unittest.TestCase):
         p = process.run(cmd='ls -l', sudo=True, shell=True, ignore_status=True)
         self.assertEqual(p.command, expected_command)
 
+
+class MiscProcessTests(unittest.TestCase):
+
+    def test_binary_from_shell(self):
+        self.assertEqual("binary", process.binary_from_shell_cmd("binary"))
+        res = process.binary_from_shell_cmd("MY_VAR=foo myV4r=123 "
+                                            "quote='a b c' QUOTE=\"1 2 && b\" "
+                                            "QuOtE=\"1 2\"foo' 3 4' first_bin "
+                                            "second_bin VAR=xyz")
+        self.assertEqual("first_bin", res)
+        res = process.binary_from_shell_cmd("VAR=VALUE 1st_binary var=value "
+                                            "second_binary")
+        self.assertEqual("1st_binary", res)
+        res = process.binary_from_shell_cmd("FOO=bar ./bin var=value")
+        self.assertEqual("./bin", res)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This function is useful, when one executes shell=True commands where
he sets values and then executes command. He can use this function
to get the actual binary path instead of the first variable=value
assignment.

v1: https://github.com/avocado-framework/avocado/pull/1009

Changes:

    v2: Added unittest
    v2: Improved docstring
    v2: Fixed typo in commit message