### PR TITLE
avocado.core.runner: Support sigtstp to interrupt tests [v3]

### DIFF
--- a/avocado/core/app.py
+++ b/avocado/core/app.py
@@ -17,6 +17,7 @@ The core Avocado application.
 """
 
 import os
+import signal
 
 from .log import configure as configure_log
 from .parser import Parser
@@ -38,6 +39,7 @@ class AvocadoApp(object):
         os.environ['LIBC_FATAL_STDERR_'] = '1'
 
         configure_log()
+        signal.signal(signal.SIGTSTP, signal.SIG_IGN)   # ignore ctrl+z
         self.parser = Parser()
         self.cli_dispatcher = CLIDispatcher()
         self.cli_cmd_dispatcher = CLICmdDispatcher()

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -33,6 +33,7 @@ from .loader import loader
 from ..utils import wait
 from ..utils import stacktrace
 from ..utils import runtime
+from ..utils import process
 
 
 class TestStatus(object):
@@ -197,6 +198,7 @@ class TestRunner(object):
         """
         self.job = job
         self.result = test_result
+        self.sigstopped = False
 
     def _run_test(self, test_factory, queue):
         """
@@ -212,6 +214,7 @@ class TestRunner(object):
         :param queue: Multiprocess queue.
         :type queue: :class`multiprocessing.Queue` instance.
         """
+        signal.signal(signal.SIGTSTP, signal.SIG_IGN)
         logger_list_stdout = [logging.getLogger('avocado.test.stdout'),
                               logging.getLogger('avocado.test'),
                               logging.getLogger('paramiko')]
@@ -267,6 +270,30 @@ class TestRunner(object):
         :param job_deadline: Maximum time to execute.
         :type job_deadline: int.
         """
+        proc = None
+        sigtstp = multiprocessing.Lock()
+
+        def sigtstp_handler(signum, frame):     # pylint: disable=W0613
+            """ SIGSTOP all test processes on SIGTSTP """
+            if not proc:    # Ignore ctrl+z when proc not yet started
+                return
+            with sigtstp:
+                msg = "ctrl+z pressed, %%s test (%s)" % proc.pid
+                if self.sigstopped:
+                    logging.getLogger("avocado.app").info("\n" + msg,
+                                                          "resumming")
+                    logging.getLogger("avocado.test").info(msg, "resumming")
+                    process.kill_process_tree(proc.pid, signal.SIGCONT, False)
+                    self.sigstopped = False
+                else:
+                    logging.getLogger("avocado.app").info("\n" + msg,
+                                                          "stopping")
+                    logging.getLogger("avocado.test").info(msg, "stopping")
+                    process.kill_process_tree(proc.pid, signal.SIGSTOP, False)
+                    self.sigstopped = True
+
+        signal.signal(signal.SIGTSTP, sigtstp_handler)
+
         proc = multiprocessing.Process(target=self._run_test,
                                        args=(test_factory, queue,))
         test_status = TestStatus(self.job, queue)
@@ -310,7 +337,8 @@ class TestRunner(object):
                     break
                 if proc.is_alive():
                     if ctrl_c_count == 0:
-                        if test_status.status.get('running'):
+                        if (test_status.status.get('running') or
+                                self.sigstopped):
                             self.job.result_proxy.notify_progress(False)
                         else:
                             self.job.result_proxy.notify_progress(True)
@@ -407,4 +435,5 @@ class TestRunner(object):
         self.job.funcatexit.run()
         if self.job.sysinfo is not None:
             self.job.sysinfo.end_job_hook()
+        signal.signal(signal.SIGTSTP, signal.SIG_IGN)
         return failures

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -113,7 +113,7 @@ def safe_kill(pid, signal):
         return False
 
 
-def kill_process_tree(pid, sig=signal.SIGKILL):
+def kill_process_tree(pid, sig=signal.SIGKILL, send_sigcont=True):
     """
     Signal a process and all of its children.
 
@@ -129,7 +129,8 @@ def kill_process_tree(pid, sig=signal.SIGKILL):
     for child in children:
         kill_process_tree(int(child), sig)
     safe_kill(pid, sig)
-    safe_kill(pid, signal.SIGCONT)
+    if send_sigcont:
+        safe_kill(pid, signal.SIGCONT)
 
 
 def kill_process_by_pattern(pattern):

--- a/docs/source/DevelopmentTips.rst
+++ b/docs/source/DevelopmentTips.rst
@@ -2,6 +2,15 @@
 Avocado development tips
 ========================
 
+Interrupting test
+=================
+
+In case you want to "pause" the running test, you can use SIGTSTP (ctrl+z)
+signal sent to the main avocado process. This signal is forwarded to test
+and it's children processes. To resume testing you repeat the same signal.
+
+Note: that the job/test timeouts are still enabled on stopped processes.
+
 In tree utils
 =============
 


### PR DESCRIPTION
Sometimes it's useful for debugging purposes to pause the running test.
This is currently hard as tests run as subprocess. This patch adds
a special handler for SIGTSTP (ctrl+z) which sends SIGSTOP/SIGCONT
to the test process and it's children.

v1: https://github.com/avocado-framework/avocado/pull/1003
v2: https://github.com/avocado-framework/avocado/pull/1014

Changes:

    v2: Use Lock to avoid concurrent execution
    v2: Remove "\n" from job.log
    v3: Added fix for infinite hang in avocado (new commit)