### PR TITLE
[draft] multi-host-support [v0]

### DIFF
--- a/avocado/core/log.py
+++ b/avocado/core/log.py
@@ -98,6 +98,11 @@ DEFAULT_LOGGING = {
             'level': 'DEBUG',
             'propagate': False,
         },
+        'avocado.plugins': {
+            'handlers': ['null'],
+            'level': 'DEBUG',
+            'propagate': False,
+        },
         'paramiko': {
             'handlers': ['null'],
             'level': 'DEBUG',

--- a/avocado/plugins/sync.py
+++ b/avocado/plugins/sync.py
@@ -1,0 +1,211 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2016
+# Author: Lukas Doktor <ldoktor@redhat.com>
+import time
+import atexit
+import logging
+"""
+Multi-host synchronization and communication plugin
+"""
+import SocketServer
+import socket
+import threading
+
+from .base import CLI
+
+
+# TODO: Create "avocado.plugins" log and use __name__ instead
+# TODO: This log must start early and re-log the content when job output dir
+#       is initialized
+LOG = logging.getLogger("avocado.test")
+
+
+class ThreadedTCPRequestHandler(SocketServer.BaseRequestHandler):
+
+    barriers = {}
+    lock = threading.Lock()
+
+    def _abort_barrier(self, name, host):
+        with self.lock:
+            barrier = self.barriers[name]
+            barrier["hosts"].remove(host)
+            if not len(barrier["hosts"]):
+                self.log("REMOVING BARRIER %s ABORT" % name)
+                del self.barriers[name]
+
+    def log(self, msg, level=logging.DEBUG):
+        LOG.log(level, "%s:%s: %s", self.client_address[0],
+                self.client_address[1], msg)
+
+    def _handle_barrier(self, data):
+        # Identify barrier
+        no_clients, name = data.split(':', 1)
+        no_clients = int(no_clients)
+        host = "%s:%s" % self.client_address
+        with self.lock:
+            if name not in self.barriers:
+                self.log("CREATING BARRIER %s" % name, logging.INFO)
+                self.barriers[name] = {"no_clients": no_clients,
+                                       "hosts": [host],
+                                       "handled_hosts": []}
+            elif self.barriers[name]["no_clients"] != no_clients:
+                msg = ("Barrier %s exists with different no_clients"
+                       % name)
+                self.log("ABORT:%s" % msg)
+                self.request.sendall("ABORT:%s" % msg)
+                return
+            elif len(self.barriers[name]["hosts"]) == no_clients:
+                msg = ("ABORT:Barrier %s has got enough clients: %s"
+                       % (name, self.barriers[name]))
+                self.log(msg, logging.ERROR)
+                self.request.sendall(msg)
+                return
+            else:
+                self.log("JOINING BARRIER %s" % name, logging.INFO)
+                self.barriers[name]["hosts"].append(host)
+        # Wait until barrier reached
+        barrier = self.barriers[name]
+        self.request.settimeout(1)
+        data = ""
+        while len(barrier["hosts"]) < no_clients:
+            if barrier.get("abort"):
+                self.request.settimeout(None)
+                self.log("ABORT:%s" % barrier.get("abort"))
+                self.request.sendall("ABORT:%s" % barrier.get("abort"))
+                self._abort_barrier(name, host)
+                return
+            try:
+                data += self.request.recv(1024)
+                self.log(data)
+            except socket.timeout:
+                continue
+            if data.startswith("ABORT:"):
+                barrier["abort"] = "%s: %s" % (host, data[6:])
+                self._abort_barrier(name, host)
+                return
+        # Barrier reached, make sure all clients are there
+        self.request.settimeout(None)
+        self.log("REACHED")
+        self.request.sendall("REACHED")
+        self.request.settimeout(1)
+        deadline = time.time() + 10
+        data = ""
+        while time.time() < deadline:
+            if barrier.get("abort"):
+                self.request.settimeout(None)
+                self.log("ABORT:%s" % barrier.get("abort"))
+                self.request.sendall("ABORT:%s" % barrier.get("abort"))
+                self._abort_barrier(name, host)
+                return
+            try:
+                data += self.request.recv(1024)
+                self.log(data)
+            except socket.timeout:
+                continue
+            if data == "ACK":
+                break
+        else:
+            self.request.settimeout(None)
+            msg = "%s did not responded on REACHED" % host
+            barrier["abort"] = msg
+            self.log("ABORT:%s" % msg)
+            self.request.sendall("ABORT:%s" % msg)
+            self._abort_barrier(name, host)
+            return
+        # Got ack
+        self.request.settimeout(None)
+        self.log("GOGOGO")
+        self.request.sendall("GOGOGO")
+        barrier["handled_hosts"].append(host)
+        # This host is inside barrier, clean this barrier if necessary
+        with self.lock:
+            if len(barrier["hosts"]) == len(barrier["handled_hosts"]):
+                # I'm the last, remove the barrier
+                self.log("REMOVING BARRIER %s PASS" % name, logging.INFO)
+                del self.barriers[name]
+
+    def handle(self):
+        cmd, data = self.request.recv(1024).split(':', 1)
+        self.log("%s:%s" % (cmd, data))
+
+        # TODO: Add support for sending pickled objects
+        if cmd == "BARRIER":
+            return self._handle_barrier(data)
+        else:
+            msg = "Unknown command: %s:%s" % (cmd, data)
+            self.request.sendall("ERROR:" + msg)
+            self.log(msg, level=logging.ERROR)
+
+
+class ThreadedTCPServer(SocketServer.ThreadingMixIn, SocketServer.TCPServer):
+    pass
+
+
+def parse_addr(value):
+    if ':' in value:
+        host, port = value.rsplit(":", 1)
+        return host, int(port)
+    else:
+        return "", int(value)
+
+
+class Sync(CLI):
+
+    """
+    Multi-host synchronization and communication plugin
+    """
+
+    name = 'sync'
+    description = "Allows multi-host synchronization and communication"
+
+    def configure(self, parser):
+        run_subcommand_parser = parser.subcommands.choices.get('run', None)
+        if run_subcommand_parser is None:
+            return
+
+        msg = "multi-host synchronization"
+        group = run_subcommand_parser.add_argument_group(msg)
+        group.add_argument("--sync-server", metavar="ADDR:PORT",
+                           help="Enable listening on given ADDR and PORT.")
+        group.add_argument("--sync", metavar="ADDR:PORT", help="Use this "
+                           "address to connect to the sync server (started "
+                           "by --sync-server). If --sync-server, it's value "
+                           "is used as default for --sync (you can override, "
+                           "though)")
+
+    def run(self, args):
+        def exit_server(server):
+            server.shutdown()
+            server.server_close()
+        if not hasattr(args, "sync_server"):
+            return
+        client = args.sync
+        server = args.sync_server
+        if server:
+            if not client:
+                client = server
+            tcp_server = ThreadedTCPServer(parse_addr(server),
+                                           ThreadedTCPRequestHandler)
+
+            server_thread = threading.Thread(target=tcp_server.serve_forever)
+            server_thread.setDaemon(True)
+            server_thread.start()
+
+            atexit.register(exit_server, tcp_server)
+
+        if client:
+            if not hasattr(args, "default_multiplex_tree"):
+                raise RuntimeError("Multiplexer required by sync plugin is "
+                                   "not avaliable.")
+            node = args.default_multiplex_tree.get_node("/plugins/sync", True)
+            node.value["addr"], node.value["port"] = parse_addr(client)

--- a/examples/tests/passtest.py
+++ b/examples/tests/passtest.py
@@ -14,6 +14,7 @@ class PassTest(Test):
         """
         A test simply doesn't have to fail in order to pass
         """
+        self.avocado.barrier(self.params.get("barrier", default="foo"), 2, 3600)
         pass
 
 

--- a/setup.py
+++ b/setup.py
@@ -134,6 +134,7 @@ if __name__ == '__main__':
                   'html = avocado.plugins.html:HTML',
                   'remote = avocado.plugins.remote:Remote',
                   'replay = avocado.plugins.replay:Replay',
+                  'sync = avocado.plugins.sync:Sync',
                   'vm = avocado.plugins.vm:VM',
                   ],
               'avocado.plugins.cli.cmd': [


### PR DESCRIPTION
Hello guys,

I'm done for today/this week so let's post the multi-host alpha version here. It's usable, but lacks some of the required features like the custom format and also could use some love in order to be merge-ready.

Anyway to avoid possible problems in design, let me demonstrate the usage here:

    avocado run passtest --sync-server :12345
    avocado run passtest --sync :12345

When you run booth at the same time (60s deadline) on the same machine (or provide full address and use 2 machines) should pass, the `--sync-server` contains some valuable info about synchronization.

---------------------------------------

The plan is to support support custom format (still the above will be usable, and probably better fit for CI) and the execution would be:

    avocado run simple.mht

where `simple.mht` contains:

    avocado run passtest
    avocado run passtest --remote-hostname foo

the way this should work is it creates the `--sync-server` (if not provided) and runs all lines simultaneously, extending them of `--sync`. The result would wrap booth runs in a single result. At least that's the idea.

For CI people would still probably use the first way (without the mht files).

----------------------------------------------------------------

One more concept is demonstrated in this PR, it's the `Test.avocado` class. As I mentioned on the meeting, I imagine this to be plugin-extensible, which means the `sync` plugin would only say it extends the `Test.avocado` of `barrier` method and the plugin system would link this method to the `Test.avocado` class. For now we could only use it to store "extra" features to eliminate the unnecessary clashes on user-side.

Anyway if you don't like this concept, I can remove it and move `barrier` directly into `test`.