### PR TITLE
Move remote/vm result functionality to runners [v1]

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -82,6 +82,7 @@ class Job(object):
         if args is None:
             args = argparse.Namespace()
         self.args = args
+        self.urls = getattr(args, "url", [])
         self.standalone = getattr(self.args, 'standalone', False)
         if getattr(self.args, "dry_run", False):  # Modify args for dry-run
             if not self.args.unique_job_id:

--- a/avocado/core/remote/__init__.py
+++ b/avocado/core/remote/__init__.py
@@ -14,6 +14,6 @@
 
 from .test import RemoteTest
 from .result import RemoteTestResult, VMTestResult
-from .runner import RemoteTestRunner
+from .runner import RemoteTestRunner, VMTestRunner
 
-__all__ = ['RemoteTestResult', 'VMTestResult', 'RemoteTestRunner', 'RemoteTest']
+__all__ = ['RemoteTestResult', 'VMTestResult', 'RemoteTestRunner', 'VMTestRunner', 'RemoteTest']

--- a/avocado/core/remote/result.py
+++ b/avocado/core/remote/result.py
@@ -16,11 +16,7 @@
 
 import os
 
-from .. import remoter
-from .. import data_dir
-from .. import exceptions
 from ..result import HumanTestResult
-from ...core import virt
 
 
 class RemoteTestResult(HumanTestResult):
@@ -45,52 +41,6 @@ class RemoteTestResult(HumanTestResult):
         self.remote = None      # Remote runner initialized during setup
         self.output = '-'
 
-    def copy_files(self):
-        """
-        Gather test directories and copy them recursively to
-        $remote_test_dir + $test_absolute_path.
-        :note: Default tests execution is translated into absolute paths too
-        """
-        if self.args.remote_no_copy:    # Leave everything as is
-            return
-
-        # TODO: Use `avocado.core.loader.TestLoader` instead
-        self.remote.makedir(self.remote_test_dir)
-        paths = set()
-        for i in xrange(len(self.urls)):
-            url = self.urls[i]
-            if not os.path.exists(url):     # use test_dir path + py
-                url = os.path.join(data_dir.get_test_dir(), '%s.py' % url)
-            url = os.path.abspath(url)  # always use abspath; avoid clashes
-            # modify url to remote_path + abspath
-            paths.add(url)
-            self.urls[i] = self.remote_test_dir + url
-        for path in sorted(paths):
-            rpath = self.remote_test_dir + path
-            self.remote.makedir(os.path.dirname(rpath))
-            self.remote.send_files(path, os.path.dirname(rpath))
-            test_data = path + '.data'
-            if os.path.isdir(test_data):
-                self.remote.send_files(test_data, os.path.dirname(rpath))
-        for mux_file in getattr(self.args, 'multiplex_files') or []:
-            rpath = os.path.join(self.remote_test_dir, mux_file)
-            self.remote.makedir(os.path.dirname(rpath))
-            self.remote.send_files(mux_file, rpath)
-
-    def setup(self):
-        """ Setup remote environment and copy test directories """
-        self.stream.notify(event='message',
-                           msg=("LOGIN      : %s@%s:%d (TIMEOUT: %s seconds)"
-                                % (self.args.remote_username,
-                                   self.args.remote_hostname,
-                                   self.args.remote_port,
-                                   self.args.remote_timeout)))
-        self.remote = remoter.Remote(self.args.remote_hostname,
-                                     self.args.remote_username,
-                                     self.args.remote_password,
-                                     self.args.remote_port,
-                                     self.args.remote_timeout)
-
     def tear_down(self):
         """ Cleanup after test execution """
         pass
@@ -107,50 +57,3 @@ class VMTestResult(RemoteTestResult):
     def __init__(self, stream, args):
         super(VMTestResult, self).__init__(stream, args)
         self.vm = None
-
-    def setup(self):
-        # Super called after VM is found and initialized
-        self.stream.notify(event='message', msg="DOMAIN     : %s"
-                           % self.args.vm_domain)
-        self.vm = virt.vm_connect(self.args.vm_domain,
-                                  self.args.vm_hypervisor_uri)
-        if self.vm is None:
-            e_msg = "Could not connect to VM '%s'" % self.args.vm_domain
-            raise exceptions.JobError(e_msg)
-        if self.vm.start() is False:
-            e_msg = "Could not start VM '%s'" % self.args.vm_domain
-            raise exceptions.JobError(e_msg)
-        assert self.vm.domain.isActive() is not False
-        # If hostname wasn't given, let's try to find out the IP address
-        if self.args.vm_hostname is None:
-            self.args.vm_hostname = self.vm.ip_address()
-            if self.args.vm_hostname is None:
-                e_msg = ("Could not find the IP address for VM '%s'. Please "
-                         "set it explicitly with --vm-hostname" %
-                         self.args.vm_domain)
-                raise exceptions.JobError(e_msg)
-        if self.args.vm_cleanup is True:
-            self.vm.create_snapshot()
-            if self.vm.snapshot is None:
-                e_msg = ("Could not create snapshot on VM '%s'" %
-                         self.args.vm_domain)
-                raise exceptions.JobError(e_msg)
-        try:
-            # Finish remote setup and copy the tests
-            self.args.remote_hostname = self.args.vm_hostname
-            self.args.remote_port = self.args.vm_port
-            self.args.remote_username = self.args.vm_username
-            self.args.remote_password = self.args.vm_password
-            self.args.remote_no_copy = self.args.vm_no_copy
-            self.args.remote_timeout = self.args.vm_timeout
-            super(VMTestResult, self).setup()
-        except Exception:
-            self.tear_down()
-            raise
-
-    def tear_down(self):
-        super(VMTestResult, self).tear_down()
-        if self.args.vm_cleanup is True:
-            self.vm.stop()
-            if self.vm.snapshot is not None:
-                self.vm.restore_snapshot()

--- a/avocado/core/remote/runner.py
+++ b/avocado/core/remote/runner.py
@@ -81,12 +81,12 @@ class RemoteTestRunner(TestRunner):
         """
         extra_params = []
         mux_files = [os.path.join(self.remote_test_dir, mux_file)
-                     for mux_file in getattr(self.result.args,
+                     for mux_file in getattr(self.job.args,
                                              'multiplex_files') or []]
         if mux_files:
             extra_params.append("--multiplex-files %s" % " ".join(mux_files))
 
-        if getattr(self.result.args, "dry_run", False):
+        if getattr(self.job.args, "dry_run", False):
             extra_params.append("--dry-run")
         urls_str = " ".join(urls)
         avocado_check_urls_cmd = ('cd %s; avocado list %s '
@@ -161,7 +161,7 @@ class RemoteTestRunner(TestRunner):
         fabric_logger.addHandler(file_handler)
         paramiko_logger.addHandler(file_handler)
         logger_list = [fabric_logger]
-        if self.result.args.show_job_log:
+        if self.job.args.show_job_log:
             logger_list.append(app_logger)
             output.add_console_handler(paramiko_logger)
         sys.stdout = output.LoggingFile(logger=logger_list)

--- a/avocado/core/result.py
+++ b/avocado/core/result.py
@@ -48,13 +48,6 @@ class TestResultProxy(object):
     def __init__(self):
         self.output_plugins = []
 
-    def __getattr__(self, attr):
-        for output_plugin in self.output_plugins:
-            if hasattr(output_plugin, attr):
-                return getattr(output_plugin, attr)
-            else:
-                return None
-
     def notify_progress(self, progress_from_test=False):
         for output_plugin in self.output_plugins:
             if hasattr(output_plugin, 'notify_progress'):

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -267,6 +267,18 @@ class TestRunner(object):
         finally:
             queue.put(instance.get_state())
 
+    def setup(self):
+        """
+        (Optional) initialization method for the test runner
+        """
+        pass
+
+    def tear_down(self):
+        """
+        (Optional) cleanup method for the test runner
+        """
+        pass
+
     def run_test(self, test_factory, queue, failures, job_deadline=0):
         """
         Run a test instance inside a subprocess.

--- a/avocado/plugins/vm.py
+++ b/avocado/plugins/vm.py
@@ -21,7 +21,7 @@ from avocado.core import output
 from avocado.core import exit_codes
 from avocado.core import virt
 from avocado.core.remote import VMTestResult
-from avocado.core.remote import RemoteTestRunner
+from avocado.core.remote import VMTestRunner
 from avocado.core.result import register_test_result_class
 from .base import CLI
 
@@ -106,4 +106,4 @@ class VM(CLI):
     def run(self, args):
         if self._check_required_args(args, 'vm_domain', ('vm_domain',)):
             register_test_result_class(args, VMTestResult)
-            args.test_runner = RemoteTestRunner
+            args.test_runner = VMTestRunner


### PR DESCRIPTION
This change was intended to fix a "simple" bug, that is, to allow remote/vm runners to be used alongside with extra results (HTML, JSON, etc), but it turned out to be a reasonable refactor.

Besides review, this PR is lacking one last fix to one of the affected unit tests. The last commit brings a WiP version of a final fix.

v0: https://github.com/avocado-framework/avocado/pull/1024

Changes:

    v1: Initialize "job.urls" in "job.__init__"
    v1: Unittest fixes
    v1: New commit which removes unused code from "job"