### PR TITLE
asset fetcher [v5]

### DIFF
--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -1,0 +1,193 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2016
+# Author: Amador Pahim <apahim@redhat.com>
+
+"""
+Asset fetcher from multiple locationss
+"""
+
+import logging
+import os
+import tempfile
+import urlparse
+
+from . import crypto
+from . import download
+from . import path as utils_path
+
+
+log = logging.getLogger('avocado.test')
+
+
+class Asset(object):
+    """
+    Try to fetch/verify an asset file from multiple locations.
+    """
+
+    def __init__(self, name, asset_hash, algorithm, locations, cache_dirs):
+        """
+        Initialize the Asset() and fetches the asset file. The path for
+        the fetched file can be reached using the self.path attribute.
+
+        :param name: the asset filename. url is also supported
+        :param asset_hash: asset hash
+        :param algorithm: hash algorithm (default sha1)
+        :param locations: list of locations fetch asset from
+        """
+        self.name = name
+        self.asset_hash = asset_hash
+        self.algorithm = algorithm
+        self.locations = locations
+        self.cache_dirs = cache_dirs
+        self.path = self.fetch()
+
+    def fetch(self):
+        urls = []
+        nameobj = urlparse.urlparse(self.name)
+        self.basename = os.path.basename(nameobj.path)
+
+        # If name is actually an url, it has to be included in urls list
+        if nameobj.scheme:
+            urls.append(nameobj.geturl())
+
+        # First let's find for the file in all cache locations
+        for cache_dir in self.cache_dirs:
+            cache_dir = os.path.expanduser(cache_dir)
+            self.asset_file = os.path.join(cache_dir, self.basename)
+            if self._check_file():
+                return self.asset_file
+
+        # If we get to this point, file is not in any cache directory
+        # and we have to download it from a location. A rw cache
+        # directory is then needed. The first rw cache directory will be
+        # used.
+        for cache_dir in self.cache_dirs:
+            cache_dir = os.path.expanduser(cache_dir)
+            self.asset_file = os.path.join(cache_dir, self.basename)
+            if not self._writable(cache_dir):
+                log.debug("Read-only cache dir '%s'. Skiping." %
+                          cache_dir)
+                continue
+
+            # Adding the user defined locations to the urls list
+            if self.locations is not None:
+                for item in self.locations:
+                    urls.append(item)
+
+            for url in urls:
+                urlobj = urlparse.urlparse(url)
+                if urlobj.scheme == 'http':
+                    log.debug('Downloading from %s.' % url)
+                    try:
+                        download._get_file(url, self.asset_file)
+                    except Exception as e:
+                        log.error(e)
+                        continue
+                    if self._check_file():
+                        return self.asset_file
+
+                elif urlobj.scheme == 'ftp':
+                    log.debug('Downloading from %s.' % url)
+                    try:
+                        download._get_file(url, self.asset_file)
+                    except Exception as e:
+                        log.error(e)
+                        continue
+                    if self._check_file():
+                        return self.asset_file
+
+                elif urlobj.scheme == 'file':
+                    log.debug('Copying from %s.' % urlobj.path)
+                    if os.path.isdir(urlobj.path):
+                        path = os.path.join(urlobj.path, self.name)
+                    else:
+                        path = urlobj.path
+                    try:
+                        download._get_file(path, self.asset_file)
+                    except Exception as e:
+                        log.error(e)
+                        continue
+                    if self._check_file():
+                        return self.asset_file
+
+        raise EnvironmentError("Failed to fetch %s." % self.basename)
+
+    def _check_file(self):
+        """
+        Checks if file exists and verifies the hash, when the hash is
+        provided. We try first to find a hash file to verify the hash
+        against and only if the hash file is not present we compute the
+        hash.
+        """
+        if not os.path.isfile(self.asset_file):
+            log.debug('Asset %s not found.' % self.asset_file)
+            return False
+
+        if self.asset_hash is None:
+            log.debug('Skipping hash check for %s.' % self.asset_file)
+            return True
+
+        discovered_hash = None
+        # Try to find a hashfile for the asset file
+        hashfile = '.'.join([self.asset_file, self.algorithm])
+        if os.path.isfile(hashfile):
+            with open(hashfile, 'r') as f:
+                for line in f.readlines():
+                    if self.basename in line:
+                        log.debug('Hashfile found for %s.' %
+                                  self.asset_file)
+                        discovered_hash = line.split()[0]
+                        break
+
+        # If no hashfile, lets calculate the hash by ourselves
+        if discovered_hash is None:
+            log.debug('No hashfile found for %s. Computing hash.' %
+                      self.asset_file)
+            discovered_hash = crypto.hash_file(self.asset_file,
+                                               algorithm=self.algorithm)
+
+            # Creating the hashfile for further usage.
+            log.debug('Creating hashfile %s.' % hashfile)
+            with open(hashfile, 'w') as f:
+                content = ' '.join([discovered_hash, self.basename])
+                content += '\n'
+                f.write(content)
+
+        if self.asset_hash == discovered_hash:
+            log.debug('Asset %s verified.' % self.asset_file)
+            return True
+        else:
+            log.error('Asset %s corrupted (hash expected:%s, hash found:%s).' %
+                      (self.asset_file, self.asset_hash, discovered_hash))
+            return False
+
+    def _writable(self, directory):
+        """
+        Checks if a given directory is writable, trying to create it on
+        demand.
+        """
+        if os.path.isdir(directory):
+            try:
+                fd, path = tempfile.mkstemp(dir=directory)
+                os.close(fd)
+                os.unlink(path)
+                return True
+            except OSError:
+                pass
+        else:
+            try:
+                utils_path.init_dir(directory)
+                return True
+            except OSError as e:
+                pass
+        return False

--- a/etc/avocado/avocado.conf
+++ b/etc/avocado/avocado.conf
@@ -7,6 +7,10 @@ test_dir = /usr/share/avocado/tests
 data_dir = /usr/share/avocado/data
 # You may override the specific job results directory with logs_dir
 logs_dir = ~/avocado/job-results
+# You can set the cache directories to be used by the avocado test
+# fetch_asset() with 'cache_dirs'. read-only cache directories are also
+# supported.
+# cache_dirs = ~/avocado/cache, /mnt/cache
 
 [sysinfo.collect]
 # Whether to collect system information during avocado jobs

--- a/selftests/unit/test_utils_asset.py
+++ b/selftests/unit/test_utils_asset.py
@@ -1,0 +1,61 @@
+import os
+import shutil
+import tempfile
+import unittest
+
+from avocado.utils import asset
+
+
+class TestAsset(unittest.TestCase):
+
+    def setUp(self):
+        self.basedir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        self.assetdir = tempfile.mkdtemp(dir=self.basedir)
+        self.assetname = 'foo.tgz'
+        self.assethash = '3a033a8938c1af56eeb793669db83bcbd0c17ea5'
+        with open(os.path.join(self.assetdir, self.assetname), 'w') as f:
+            f.write('Test!')
+
+        self.url = 'file://%s' % os.path.join(self.assetdir, self.assetname)
+        self.cache_dir = tempfile.mkdtemp(dir=self.basedir)
+
+    def testFetch_urlname(self):
+        foo_tarball = asset.Asset(self.url,
+                                  asset_hash=self.assethash,
+                                  algorithm='sha1',
+                                  locations=None,
+                                  cache_dirs=[self.cache_dir]).path
+        expected_tarball = os.path.join(self.cache_dir, self.assetname)
+        self.assertEqual(foo_tarball, expected_tarball)
+        hashfile = '.'.join([expected_tarball, 'sha1'])
+        self.assertTrue(os.path.isfile(hashfile))
+        expected_content = '%s %s\n' % (self.assethash, self.assetname)
+        with open(hashfile, 'r') as f:
+            content = f.read()
+        self.assertEqual(content, expected_content)
+
+    def testFetch_location(self):
+        foo_tarball = asset.Asset(self.assetname,
+                                  asset_hash=self.assethash,
+                                  algorithm='sha1',
+                                  locations=[self.url],
+                                  cache_dirs=[self.cache_dir]).path
+        expected_tarball = os.path.join(self.cache_dir, self.assetname)
+        self.assertEqual(foo_tarball, expected_tarball)
+        hashfile = '.'.join([expected_tarball, 'sha1'])
+        self.assertTrue(os.path.isfile(hashfile))
+        expected_content = '%s %s\n' % (self.assethash, self.assetname)
+        with open(hashfile, 'r') as f:
+            content = f.read()
+        self.assertEqual(content, expected_content)
+
+    def testException(self):
+        self.assertRaises(EnvironmentError, asset.Asset, name='bar.tgz',
+                          asset_hash=None, algorithm=None, locations=None,
+                          cache_dirs=[self.cache_dir])
+
+    def tearDown(self):
+        shutil.rmtree(self.basedir)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
v5:
 - Support for multiple cache directories in cache_dirs configuration key.
 - Use test temporary workdir as ultimate cache for dowloaded files, if no writable caches are provided using configuration file.
 - Test if cache_dir is writable before using it as a download target.
 - Multiple use cases in docs.
 - Unit tests.

v4: #1004 
 - Now fetch_asset() is an avocado.Test method.
 - Cache_dir defined in config file.
 - New avocado.Tets.cachedir attribute on the API.
 - Look for hashfile first.
 - Create hashfile when hash compute is needed.
 - Raise an exception on fetch_asset error.
 - Support location on asset name.
 - Default SHA1.

v3: #997 
 - Asset() class.
 - Do not depend on yaml/multiplex.

v2: #995 
 - Use full url, including the file name.
 - Docs.
 - Use job temporary dir as `cache_dir` default location.

v1: #993 
 - Utility to find for files in multiple locations, caching it when successfully fetched.
