### PR TITLE
Use environment marker for conditional requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ sudo: false
 
 install:
     - pip install -r requirements-travis.txt
-    - if [ $TRAVIS_PYTHON_VERSION == '2.6' ]; then pip install -r requirements-travis-python26.txt; fi
 
 script:
     - inspekt lint

--- a/Makefile
+++ b/Makefile
@@ -117,11 +117,10 @@ clean:
 	find . -name '*.pyc' -delete
 
 requirements:
-	- if $$(python -V 2>&1 | grep 2.6 -q); then grep -v '^#' requirements-python26.txt | xargs -n 1 pip install --upgrade; fi
-	- grep -v '^#' requirements.txt | xargs -n 1 pip install --upgrade
+	- pip install -r requirements.txt --upgrade
 
 requirements-selftests: requirements
-	- grep -v '^#' requirements-selftests.txt | xargs -n 1 pip install --upgrade
+	- pip install -r requirements-selftests.txt --upgrade
 
 smokecheck:
 	./scripts/avocado run passtest

--- a/requirements-python26.txt
+++ b/requirements-python26.txt
@@ -1,5 +1,0 @@
-# Additional python 2.6 specific requirements for avocado and unittests (backports)
-argparse>=1.3.0
-logutils>=0.3.3
-importlib>=1.0.3
-unittest2>=1.0.0

--- a/requirements-travis-python26.txt
+++ b/requirements-travis-python26.txt
@@ -1,5 +1,0 @@
-# All python 2.6 specific requirements (backports)
-argparse==1.3.0
-logutils==0.3.3
-importlib==1.0.3
-unittest2==1.0.0

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -16,3 +16,8 @@ aexpect==1.0.0
 psutil==3.1.1
 # stevedore for loading "new style" plugins
 stevedore==1.8.0
+# All python 2.6 specific requirements (backports)
+argparse==1.3.0; python_version < '2.7'
+logutils==0.3.3; python_version < '2.7'
+importlib==1.0.3; python_version < '2.7'
+unittest2==1.0.0; python_version < '2.7'

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,11 @@ pystache>=0.5.3
 # REST client (avocado.core.restclient)
 requests>=1.2.3
 # stevedore for loading "new style" plugins
-stevedore>=1.8.0
+stevedore>=1.8.0; python_version >= '2.7'
+# stevedore-1.11.0 won't support python2.6 anymore
+stevedore>=1.8.0,<=1.10.0; python_version < '2.7'
+# Additional python 2.6 specific requirements for avocado and unittests (backports)
+argparse>=1.3.0; python_version < '2.7'
+logutils>=0.3.3; python_version < '2.7'
+importlib>=1.0.3; python_version < '2.7'
+unittest2>=1.0.0; python_version < '2.7'


### PR DESCRIPTION
Managing different requirements files for different python version
requires much more efforts when the requirements became too complex.

This issue emerged when a required package `stevedore` decide not
supporting Python 2.6 since version `1.11.0`.

```
>>> import stevedore
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python2.6/site-packages/stevedore/__init__.py", line 23, in <module>
    LOG.addHandler(logging.NullHandler())
AttributeError: 'module' object has no attribute 'NullHandler
```

Pip provides a feature named [Environment Markers](https://www.python.org/dev/peps/pep-0496/)
for requirements file to include specific packages conditionally which could
properly solve this issue.

This fix:
1. Use environment markers and merge python version specific
requirements files;
2. Remove python version specific requirements files references in
`Makefile` and Travis configuration;
3. Use `pip install -r requirements.txt` to replace per-line package
installation;
4. Restrain package `stevedore` on Python 2.6 to `1.10.0`.

Signed-off-by: Hao Liu <hliu@redhat.com>