### PR TITLE
avocado.core.html: Fix the unicode handling for older pystache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ sudo: false
 
 install:
     - pip install -r requirements-travis.txt
-    - if [ $TRAVIS_PYTHON_VERSION == '2.6' ]; then pip install -r requirements-travis-python26.txt; fi
+    - if [ $TRAVIS_PYTHON_VERSION == '2.6' ]; then pip install --upgrade -r requirements-travis-python26.txt; fi
 
 script:
     - inspekt lint

--- a/avocado/core/html.py
+++ b/avocado/core/html.py
@@ -56,6 +56,12 @@ class ReportModel(object):
         self.html_output = html_output
         self.html_output_dir = os.path.abspath(os.path.dirname(html_output))
 
+    def update(self, **kwargs):
+        """
+        Hook for updates not supported
+        """
+        pass
+
     def get(self, key, default):
         value = getattr(self, key, default)
         if callable(value):

--- a/avocado/core/html.py
+++ b/avocado/core/html.py
@@ -168,7 +168,7 @@ class ReportModel(object):
             sysinfo_dict = {}
             sysinfo_path = os.path.join(base_path, s_f)
             try:
-                with open(sysinfo_path, 'r') as sysinfo_file:
+                with codecs.open(sysinfo_path, 'r', encoding="utf-8") as sysinfo_file:
                     sysinfo_dict['file'] = " ".join(s_f.split("_"))
                     sysinfo_dict['contents'] = sysinfo_file.read()
                     sysinfo_dict['element_id'] = 'heading_%s' % s_id

--- a/avocado/core/html.py
+++ b/avocado/core/html.py
@@ -259,7 +259,8 @@ class HTMLTestResult(TestResult):
             else:
                 from pystache import view
                 v = view.View(open(template, 'r').read(), context)
-                report_contents = v.render('utf8')
+                report_contents = v.render('utf8')  # encodes into ascii
+                report_contents = codecs.decode("utf8")  # decode to unicode
         except UnicodeDecodeError, details:
             # FIXME: Removeme when UnicodeDecodeError problem is fixed
             import logging

--- a/requirements-travis-python26.txt
+++ b/requirements-travis-python26.txt
@@ -3,3 +3,4 @@ argparse==1.3.0
 logutils==0.3.3
 importlib==1.0.3
 unittest2==1.0.0
+pystache==0.4.1


### PR DESCRIPTION
Hello guys, this addresses the https://github.com/avocado-framework/avocado/issues/891 issue and hopefully fixes it properly. Details are in commit messages.