### PR TITLE
avocado.plugins.replay fix crashes when using --replay-test-status [v2]

### DIFF
--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -97,10 +97,18 @@ class Replay(CLI):
 
         view = output.View()
 
-        if args.remote_hostname is not None:
-            msg = "Currently we don't replay jobs in remote hosts."
-            view.notify(event='error', msg=(msg))
-            sys.exit(exit_codes.AVOCADO_JOB_FAIL)
+        err = None
+        if args.replay_teststatus and args.multiplex_files:
+            err = "Option --replay-test-status is incompatible with "\
+                  "--multiplex-files."
+        elif args.replay_teststatus and args.url:
+            err = "Option --replay-test-status is incompatible with "\
+                  "test URLs given on the command line."
+        elif args.remote_hostname:
+            err = "Currently we don't replay jobs in remote hosts."
+        if err is not None:
+            view.notify(event="error", msg=err)
+            sys.exit(exit_codes.AVOCADO_FAIL)
 
         if args.replay_datadir is not None:
             resultsdir = args.replay_datadir
@@ -111,14 +119,14 @@ class Replay(CLI):
             resultsdir = replay.get_resultsdir(self.logdir, args.replay_jobid)
 
         if resultsdir is None:
-            msg = "can't find job results directory in '%s'" % self.logdir
+            msg = "Can't find job results directory in '%s'" % self.logdir
             view.notify(event='error', msg=(msg))
             sys.exit(exit_codes.AVOCADO_JOB_FAIL)
 
         sourcejob = replay.get_id(os.path.join(resultsdir, 'id'),
                                   args.replay_jobid)
         if sourcejob is None:
-            msg = "can't find matching job id '%s' in '%s' directory." % \
+            msg = "Can't find matching job id '%s' in '%s' directory." % \
                   (args.replay_jobid, resultsdir)
             view.notify(event='error', msg=(msg))
             sys.exit(exit_codes.AVOCADO_JOB_FAIL)
@@ -151,7 +159,7 @@ class Replay(CLI):
         else:
             if getattr(args, 'multiplex_files', None) is not None:
                 msg = 'Overriding the replay multiplex with '\
-                      '--multiplex-file.'
+                      '--multiplex-files.'
                 view.notify(event='warning', msg=(msg))
                 # Use absolute paths to avoid problems with os.chdir
                 args.multiplex_files = [os.path.abspath(_)

--- a/selftests/functional/test_replay.py
+++ b/selftests/functional/test_replay.py
@@ -114,11 +114,33 @@ class ReplayTests(unittest.TestCase):
 
     def test_run_replay_remotefail(self):
         cmd_line = ('./scripts/avocado run --replay %s --remote-hostname '
-                    'localhost ' '--job-results-dir %s --replay-data-dir %s '
+                    'localhost --job-results-dir %s --replay-data-dir %s '
                     '--sysinfo=off' % (self.jobid, self.tmpdir, self.jobdir))
-        expected_rc = exit_codes.AVOCADO_JOB_FAIL
+        expected_rc = exit_codes.AVOCADO_FAIL
         result = self.run_and_check(cmd_line, expected_rc)
         msg = "Currently we don't replay jobs in remote hosts."
+        self.assertIn(msg, result.stderr)
+
+    def test_run_replay_status_and_mux(self):
+        cmd_line = ('./scripts/avocado run --replay %s --multiplex '
+                    'examples/mux-environment.yaml --replay-test-status FAIL '
+                    '--job-results-dir %s --replay-data-dir %s '
+                    '--sysinfo=off' % (self.jobid, self.tmpdir, self.jobdir))
+        expected_rc = exit_codes.AVOCADO_FAIL
+        result = self.run_and_check(cmd_line, expected_rc)
+        msg = "Option --replay-test-status is incompatible with "\
+              "--multiplex-files."
+        self.assertIn(msg, result.stderr)
+
+    def test_run_replay_status_and_urls(self):
+        cmd_line = ('./scripts/avocado run sleeptest --replay %s '
+                    '--replay-test-status FAIL --job-results-dir %s '
+                    '--replay-data-dir %s --sysinfo=off' %
+                    (self.jobid, self.tmpdir, self.jobdir))
+        expected_rc = exit_codes.AVOCADO_FAIL
+        result = self.run_and_check(cmd_line, expected_rc)
+        msg = "Option --replay-test-status is incompatible with "\
+              "test URLs given on the command line."
         self.assertIn(msg, result.stderr)
 
     def tearDown(self):


### PR DESCRIPTION
v2:
 - Better error message.
 - Using `if $foo is not None` instead of `if $foo` notation.

v1 #1031  