### PR TITLE
requirements: Limit python 2.6 version of stevedore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ sudo: false
 
 install:
     - pip install -r requirements-travis.txt
+    - if [ $TRAVIS_PYTHON_VERSION == '2.6' ]; then pip install -r requirements-travis-python26.txt; fi
 
 script:
     - inspekt lint

--- a/Makefile
+++ b/Makefile
@@ -117,8 +117,8 @@ clean:
 	find . -name '*.pyc' -delete
 
 requirements:
-	- if $$(python -V 2>&1 | grep 2.6 -q); then grep -v '^#' requirements-python26.txt | xargs -n 1 pip install --upgrade; fi
 	- grep -v '^#' requirements.txt | xargs -n 1 pip install --upgrade
+	- if $$(python -V 2>&1 | grep 2.6 -q); then grep -v '^#' requirements-python26.txt | xargs -n 1 pip install --upgrade; fi
 
 requirements-selftests: requirements
 	- grep -v '^#' requirements-selftests.txt | xargs -n 1 pip install --upgrade

--- a/Makefile
+++ b/Makefile
@@ -117,10 +117,11 @@ clean:
 	find . -name '*.pyc' -delete
 
 requirements:
-	- pip install -r requirements.txt --upgrade
+	- if $$(python -V 2>&1 | grep 2.6 -q); then grep -v '^#' requirements-python26.txt | xargs -n 1 pip install --upgrade; fi
+	- grep -v '^#' requirements.txt | xargs -n 1 pip install --upgrade
 
 requirements-selftests: requirements
-	- pip install -r requirements-selftests.txt --upgrade
+	- grep -v '^#' requirements-selftests.txt | xargs -n 1 pip install --upgrade
 
 smokecheck:
 	./scripts/avocado run passtest

--- a/requirements-python26.txt
+++ b/requirements-python26.txt
@@ -3,3 +3,4 @@ argparse>=1.3.0
 logutils>=0.3.3
 importlib>=1.0.3
 unittest2>=1.0.0
+stevedore>=1.8.0,<=1.10.0

--- a/requirements-python26.txt
+++ b/requirements-python26.txt
@@ -1,0 +1,5 @@
+# Additional python 2.6 specific requirements for avocado and unittests (backports)
+argparse>=1.3.0
+logutils>=0.3.3
+importlib>=1.0.3
+unittest2>=1.0.0

--- a/requirements-travis-python26.txt
+++ b/requirements-travis-python26.txt
@@ -1,0 +1,5 @@
+# All python 2.6 specific requirements (backports)
+argparse==1.3.0
+logutils==0.3.3
+importlib==1.0.3
+unittest2==1.0.0

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -16,8 +16,3 @@ aexpect==1.0.0
 psutil==3.1.1
 # stevedore for loading "new style" plugins
 stevedore==1.8.0
-# All python 2.6 specific requirements (backports)
-argparse==1.3.0; python_version < '2.7'
-logutils==0.3.3; python_version < '2.7'
-importlib==1.0.3; python_version < '2.7'
-unittest2==1.0.0; python_version < '2.7'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 # Avocado functional requirements
 # SSH lib (avocado.utils.remote)
 fabric>=1.7.0
+pycrypto>=2.6.1
+ecdsa>=0.13
 # multiplexer (avocado.core.tree)
 PyYAML>=3.11
 # vm plugin (avocado.core.plugins.vm)

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,11 +12,4 @@ pystache>=0.5.3
 # REST client (avocado.core.restclient)
 requests>=1.2.3
 # stevedore for loading "new style" plugins
-stevedore>=1.8.0; python_version >= '2.7'
-# stevedore-1.11.0 won't support python2.6 anymore
-stevedore>=1.8.0,<=1.10.0; python_version < '2.7'
-# Additional python 2.6 specific requirements for avocado and unittests (backports)
-argparse>=1.3.0; python_version < '2.7'
-logutils>=0.3.3; python_version < '2.7'
-importlib>=1.0.3; python_version < '2.7'
-unittest2>=1.0.0; python_version < '2.7'
+stevedore>=1.8.0


### PR DESCRIPTION
Newer stevedore does not support python 2.6. This commit limits the
stevedore version in requirements-python26.txt and reorders Makefile to
first install generic requirements and then requirements-python26.txt.
Altogether with --upgrade it also downgrades the installed stevedore
version.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>