### PR TITLE
[RFC] Record job args to use in --replay

### DIFF
--- a/avocado/core/replay.py
+++ b/avocado/core/replay.py
@@ -37,6 +37,7 @@ def record(args, logdir, mux, urls=None):
     path_urls = os.path.join(replay_dir, 'urls')
     path_mux = os.path.join(replay_dir, 'multiplex')
     path_pwd = os.path.join(replay_dir, 'pwd')
+    path_args = os.path.join(replay_dir, 'args')
 
     if urls:
         with open(path_urls, 'w') as f:
@@ -50,6 +51,9 @@ def record(args, logdir, mux, urls=None):
 
     with open(path_pwd, 'w') as f:
         f.write('%s' % os.getcwd())
+
+    with open(path_args, 'w') as f:
+        pickle.dump(args, f, pickle.HIGHEST_PROTOCOL)
 
 
 def retrieve_pwd(resultsdir):
@@ -74,6 +78,15 @@ def retrieve_urls(resultsdir):
 
 def retrieve_mux(resultsdir):
     pkl_path = os.path.join(resultsdir, 'replay', 'multiplex')
+    if not os.path.exists(pkl_path):
+        return None
+
+    with open(pkl_path, 'r') as f:
+        return pickle.load(f)
+
+
+def retrieve_args(resultsdir):
+    pkl_path = os.path.join(resultsdir, 'replay', 'args')
     if not os.path.exists(pkl_path):
         return None
 

--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -123,21 +123,34 @@ class Replay(CLI):
             view.notify(event='error', msg=(msg))
             sys.exit(exit_codes.AVOCADO_JOB_FAIL)
 
+        current_args = args.__dict__
+
         sourcejob = replay.get_id(os.path.join(resultsdir, 'id'),
-                                  args.replay_jobid)
+                                  current_args['replay_jobid'])
         if sourcejob is None:
             msg = "Can't find matching job id '%s' in '%s' directory." % \
-                  (args.replay_jobid, resultsdir)
+                  (current_args['replay_jobid'], resultsdir)
             view.notify(event='error', msg=(msg))
             sys.exit(exit_codes.AVOCADO_JOB_FAIL)
 
+        source_args = replay.retrieve_args(resultsdir)
+        if source_args is not None:
+            args.__dict__ = source_args.__dict__
+
+        for item in current_args:
+            if current_args[item]:
+                setattr(args, item, current_args[item])
+
         setattr(args, 'replay_sourcejob', sourcejob)
 
-        if getattr(args, 'url', None):
+        if current_args['url']:
             msg = 'Overriding the replay urls with urls provided in '\
                   'command line.'
             view.notify(event='warning', msg=(msg))
+            setattr(args, 'url', current_args['url'])
         else:
+            # Retrieving urls from <job-results-dir>/replay/urls to keep
+            # the compatibility
             urls = replay.retrieve_urls(resultsdir)
             if urls is None:
                 msg = 'Source job urls data not found. Aborting.'
@@ -146,24 +159,24 @@ class Replay(CLI):
             else:
                 setattr(args, 'url', urls)
 
-        if args.replay_ignore and 'config' in args.replay_ignore:
+        if current_args['replay_ignore'] and 'config' in current_args['replay_ignore']:
             msg = "Ignoring configuration from source job with " \
                   "--replay-ignore."
             view.notify(event='warning', msg=(msg))
         else:
             self.load_config(resultsdir)
 
-        if args.replay_ignore and 'mux' in args.replay_ignore:
+        if current_args['replay_ignore'] and 'mux' in current_args['replay_ignore']:
             msg = "Ignoring multiplex from source job with --replay-ignore."
             view.notify(event='warning', msg=(msg))
         else:
-            if getattr(args, 'multiplex_files', None) is not None:
+            if current_args['multiplex_files']:
                 msg = 'Overriding the replay multiplex with '\
                       '--multiplex-files.'
                 view.notify(event='warning', msg=(msg))
                 # Use absolute paths to avoid problems with os.chdir
                 args.multiplex_files = [os.path.abspath(_)
-                                        for _ in args.multiplex_files]
+                                        for _ in current_args['multiplex_files']]
             else:
                 mux = replay.retrieve_mux(resultsdir)
                 if mux is None:
@@ -173,9 +186,9 @@ class Replay(CLI):
                 else:
                     setattr(args, "multiplex_files", mux)
 
-        if args.replay_teststatus:
+        if current_args['replay_teststatus']:
             replay_map = replay.retrieve_replay_map(resultsdir,
-                                                    args.replay_teststatus)
+                                                    current_args['replay_teststatus'])
             setattr(args, 'replay_map', replay_map)
 
         # Use the original directory to discover test urls properly

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -155,18 +155,22 @@ class Run(CLICmd):
         if raw_timeout is not None:
             try:
                 unit = raw_timeout[-1].lower()
+            except TypeError:
+                unit = None
+            try:
                 if unit in units:
                     mult = units[unit]
                     timeout = int(raw_timeout[:-1]) * mult
                 else:
                     timeout = int(raw_timeout)
-                if timeout < 1:
+                if timeout < 0:
                     raise ValueError()
             except (ValueError, TypeError):
                 self.view.notify(
                     event='error',
                     msg=("Invalid number '%s' for job timeout. "
-                         "Use an integer number greater than 0") % raw_timeout)
+                         "Use 0 or an integer number greater than 0") %
+                    raw_timeout)
                 sys.exit(exit_codes.AVOCADO_FAIL)
         else:
             timeout = 0

--- a/selftests/functional/test_job_timeout.py
+++ b/selftests/functional/test_job_timeout.py
@@ -118,7 +118,7 @@ class JobTimeOutTest(unittest.TestCase):
 
     def test_invalid_values(self):
         cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '
-                    '--job-timeout=0 examples/tests/passtest.py' % self.tmpdir)
+                    '--job-timeout=-1 examples/tests/passtest.py' % self.tmpdir)
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_FAIL)
         self.assertIn('Invalid number', result.stderr)

--- a/selftests/functional/test_replay.py
+++ b/selftests/functional/test_replay.py
@@ -44,7 +44,7 @@ class ReplayTests(unittest.TestCase):
         return result
 
     def test_run_replay_noid(self):
-        cmd_line = ('./scripts/avocado run --replay %s'
+        cmd_line = ('./scripts/avocado run --replay %s '
                     '--job-results-dir %s --replay-data-dir %s --sysinfo=off' %
                     ('foo', self.tmpdir, self.jobdir))
         expected_rc = exit_codes.AVOCADO_JOB_FAIL


### PR DESCRIPTION
So far the replay feature loads only the source job urls, multiplex and configuration. Other command line options used in the original job are simply ignored.

This PR makes the replay job reload all source job args, then including the args needed for the replay feature. This fixes the reported issue when replaying a job that used --external-runner and it is also expected to avoid any further issues in consequence of missing arguments from the source job on replay job.

Also, I noticed that for jobs that does not contain --job-timeout, we set job_timeout to 0. But 0 is not accepted as a valid value for the --job-timeout. Replaying a job that did not set a --job-timeout, then reloading the '0' from recorded args, makes avocado crash. So this PR also fixes the --job-timeout to accept 0 or any positive integer without the time unit.