### PR TITLE
Makefile: pip adjustments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,10 +118,10 @@ clean:
 
 requirements:
 	- pip install "pip>=6.0.1"
-	- pip install -r requirements.txt --upgrade
+	- pip install -r requirements.txt
 
 requirements-selftests: requirements
-	- pip install -r requirements-selftests.txt --upgrade
+	- pip install -r requirements-selftests.txt
 
 smokecheck:
 	./scripts/avocado run passtest

--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,7 @@ clean:
 	find . -name '*.pyc' -delete
 
 requirements:
+	- pip install "pip>=6.0.1"
 	- pip install -r requirements.txt --upgrade
 
 requirements-selftests: requirements


### PR DESCRIPTION
Hello guys,

this reacts to https://github.com/avocado-framework/avocado/pull/1033

Our `requirements.txt` depends on `pip>=6.1` so in my opinion we have to include this in the requirements. We can't do it in `requirements.txt` as older `pip` can't cope with that, so let's use `make requirements` target to check the pip version first.

On systems with matching pip (F22+) nothing happens, the user only sees his pip version matches the requirements and nothing is upgraded. On older systems (F21, or debian jessie) this upgrades the pip and then runs our requirements, which should be correctly installed. Without the upgrade the user gets ugly python traceback.

The last modification is probably my fault. I used `--upgrade`, because I though pip works as `yum`. It works differently and the `--upgrade` is not needed and with it it's quite intrusive and always upgrades to the latest matching version available.

Feel free to disagree, but in my opinion it's a project dependency and we ought to list it.