### PR TITLE
avocado.core.html: Fix the unicode handling for older pystache [v2]

### DIFF
--- a/avocado/core/html.py
+++ b/avocado/core/html.py
@@ -56,6 +56,12 @@ class ReportModel(object):
         self.html_output = html_output
         self.html_output_dir = os.path.abspath(os.path.dirname(html_output))
 
+    def update(self, **kwargs):
+        """
+        Hook for updates not supported
+        """
+        pass
+
     def get(self, key, default):
         value = getattr(self, key, default)
         if callable(value):

--- a/avocado/core/html.py
+++ b/avocado/core/html.py
@@ -168,7 +168,7 @@ class ReportModel(object):
             sysinfo_dict = {}
             sysinfo_path = os.path.join(base_path, s_f)
             try:
-                with open(sysinfo_path, 'r') as sysinfo_file:
+                with codecs.open(sysinfo_path, 'r', encoding="utf-8") as sysinfo_file:
                     sysinfo_dict['file'] = " ".join(s_f.split("_"))
                     sysinfo_dict['contents'] = sysinfo_file.read()
                     sysinfo_dict['element_id'] = 'heading_%s' % s_id

--- a/avocado/core/html.py
+++ b/avocado/core/html.py
@@ -259,7 +259,8 @@ class HTMLTestResult(TestResult):
             else:
                 from pystache import view
                 v = view.View(open(template, 'r').read(), context)
-                report_contents = v.render('utf8')
+                report_contents = v.render('utf8')  # encodes into ascii
+                report_contents = codecs.decode("utf8")  # decode to unicode
         except UnicodeDecodeError, details:
             # FIXME: Removeme when UnicodeDecodeError problem is fixed
             import logging

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,6 +1,7 @@
 # All pip installable requirements pinned for Travis CI
 fabric==1.10.0
-pystache==0.5.4
+pystache==0.4.1; python_version < '2.7'
+pystache==0.5.4; python_version >= '2.7'
 Sphinx==1.3b1
 flexmock==0.9.7
 inspektor==0.2.0


### PR DESCRIPTION
Hello guys, this addresses the https://github.com/avocado-framework/avocado/issues/891 issue and hopefully fixes it properly. Details are in commit messages.

v1: https://github.com/avocado-framework/avocado/pull/1030

Chages:

    v2: Rebase
    v2: Use new requirements.txt scheme