### PR TITLE
Record job args to use in --replay [v2]

### DIFF
--- a/avocado/core/replay.py
+++ b/avocado/core/replay.py
@@ -37,6 +37,7 @@ def record(args, logdir, mux, urls=None):
     path_urls = os.path.join(replay_dir, 'urls')
     path_mux = os.path.join(replay_dir, 'multiplex')
     path_pwd = os.path.join(replay_dir, 'pwd')
+    path_args = os.path.join(replay_dir, 'args')
 
     if urls:
         with open(path_urls, 'w') as f:
@@ -50,6 +51,9 @@ def record(args, logdir, mux, urls=None):
 
     with open(path_pwd, 'w') as f:
         f.write('%s' % os.getcwd())
+
+    with open(path_args, 'w') as f:
+        pickle.dump(args, f, pickle.HIGHEST_PROTOCOL)
 
 
 def retrieve_pwd(resultsdir):
@@ -74,6 +78,15 @@ def retrieve_urls(resultsdir):
 
 def retrieve_mux(resultsdir):
     pkl_path = os.path.join(resultsdir, 'replay', 'multiplex')
+    if not os.path.exists(pkl_path):
+        return None
+
+    with open(pkl_path, 'r') as f:
+        return pickle.load(f)
+
+
+def retrieve_args(resultsdir):
+    pkl_path = os.path.join(resultsdir, 'replay', 'args')
     if not os.path.exists(pkl_path):
         return None
 

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -152,7 +152,7 @@ class Run(CLICmd):
     def _validate_job_timeout(self, raw_timeout):
         units = {'s': 1, 'm': 60, 'h': 3600, 'd': 86400}
         mult = 1
-        if raw_timeout is not None:
+        if isinstance(raw_timeout, basestring):
             try:
                 unit = raw_timeout[-1].lower()
                 if unit in units:
@@ -168,8 +168,11 @@ class Run(CLICmd):
                     msg=("Invalid number '%s' for job timeout. "
                          "Use an integer number greater than 0") % raw_timeout)
                 sys.exit(exit_codes.AVOCADO_FAIL)
-        else:
+        elif raw_timeout is None:
             timeout = 0
+        else:
+            timeout = raw_timeout
+
         return timeout
 
     def run(self, args):

--- a/selftests/functional/test_replay.py
+++ b/selftests/functional/test_replay.py
@@ -44,7 +44,7 @@ class ReplayTests(unittest.TestCase):
         return result
 
     def test_run_replay_noid(self):
-        cmd_line = ('./scripts/avocado run --replay %s'
+        cmd_line = ('./scripts/avocado run --replay %s '
                     '--job-results-dir %s --replay-data-dir %s --sysinfo=off' %
                     ('foo', self.tmpdir, self.jobdir))
         expected_rc = exit_codes.AVOCADO_JOB_FAIL


### PR DESCRIPTION
v2:
 - Improved a/p/run job_timeout validation.
 - Removed specific options override message for a general message informing that command line options will override source job options.

v1: #1034 
So far the replay feature loads only the source job urls, multiplex and configuration. Other command line options used in the original job are simply ignored.

This PR makes the replay job reload all source job args, then including the args needed for the replay feature. This fixes the reported issue when replaying a job that used --external-runner and it is also expected to avoid any further issues in consequence of missing arguments from the source job on replay job.

Also, I noticed that for jobs that does not contain --job-timeout, we set job_timeout to 0. But 0 is not accepted as a valid value for the --job-timeout. Replaying a job that did not set a --job-timeout, then reloading the '0' from recorded args, makes avocado crash. So this PR also fixes the --job-timeout to accept any integer without the time unit.
