### PR TITLE
Asset fetcher [v6]

### DIFF
--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -60,81 +60,28 @@ USER_DATA_DIR = os.path.join(USER_BASE_DIR, 'data')
 USER_LOG_DIR = os.path.join(USER_BASE_DIR, 'job-results')
 
 
-def _usable_rw_dir(directory):
-    """
-    Verify wether we can use this dir (read/write).
-
-    Checks for appropriate permissions, and creates missing dirs as needed.
-
-    :param directory: Directory
-    """
-    if os.path.isdir(directory):
-        try:
-            fd, path = tempfile.mkstemp(dir=directory)
-            os.close(fd)
-            os.unlink(path)
-            return True
-        except OSError:
-            pass
-    else:
-        try:
-            utils_path.init_dir(directory)
-            return True
-        except OSError:
-            pass
-
-    return False
-
-
-def _usable_ro_dir(directory):
-    """
-    Verify whether dir exists and we can access its contents.
-
-    If a usable RO is there, use it no questions asked. If not, let's at
-    least try to create one.
-
-    :param directory: Directory
-    """
-    cwd = os.getcwd()
-    if os.path.isdir(directory):
-        try:
-            os.chdir(directory)
-            os.chdir(cwd)
-            return True
-        except OSError:
-            pass
-    else:
-        try:
-            utils_path.init_dir(directory)
-            return True
-        except OSError:
-            pass
-
-    return False
-
-
 def _get_rw_dir(settings_location, system_location, user_location):
-    if _usable_rw_dir(settings_location):
+    if utils_path.usable_rw_dir(settings_location):
         return settings_location
 
-    if _usable_rw_dir(system_location):
+    if utils_path.usable_rw_dir(system_location):
         return system_location
 
     user_location = os.path.expanduser(user_location)
-    if _usable_rw_dir(user_location):
+    if utils_path.usable_rw_dir(user_location):
         return user_location
 
 
 def _get_ro_dir(settings_location, system_location, user_location):
     if not settings.intree:
-        if _usable_ro_dir(settings_location):
+        if utils_path.usable_ro_dir(settings_location):
             return settings_location
 
-    if _usable_ro_dir(system_location):
+    if utils_path.usable_ro_dir(system_location):
         return system_location
 
     user_location = os.path.expanduser(user_location)
-    if _usable_ro_dir(user_location):
+    if utils_path.usable_ro_dir(user_location):
         return user_location
 
 

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -30,12 +30,14 @@ from . import data_dir
 from . import exceptions
 from . import multiplexer
 from . import sysinfo
+from ..utils import asset
 from ..utils import astring
 from ..utils import data_structures
 from ..utils import genio
 from ..utils import path as utils_path
 from ..utils import process
 from ..utils import stacktrace
+from .settings import settings
 from .version import VERSION
 
 if sys.version_info[:2] == (2, 6):
@@ -197,6 +199,18 @@ class Test(unittest.TestCase):
     @data_structures.LazyProperty
     def srcdir(self):
         return utils_path.init_dir(self.workdir, 'src')
+
+    @data_structures.LazyProperty
+    def cachedirs(self):
+        """
+        Returns the list of cache locations.
+        """
+        cache_dirs = settings.get_value('datadir.paths', 'cache_dirs',
+                                        key_type=list, default=[])
+        if isinstance(cache_dirs, str):
+            cache_dirs = [cache_dirs]
+        cache_dirs.append(utils_path.init_dir(self.workdir, 'cache'))
+        return cache_dirs
 
     def __str__(self):
         return str(self.name)
@@ -578,6 +592,22 @@ class Test(unittest.TestCase):
         :type message: str
         """
         raise exceptions.TestSkipError(message)
+
+    def fetch_asset(self, name, asset_hash=None, algorithm='sha1',
+                    locations=None):
+        """
+        Method o call the utils.asset in order to fetch and asset file
+        supporting hash check, caching and multiple locations.
+
+        :param name: the asset filename or URL
+        :param asset_hash: asset hash (optional)
+        :param algorithm: hash algorithm (optional, defaults to sha1)
+        :param locations: list of URLs from where the asset can be
+                          fetched (optional)
+        :returns: asset file local path
+        """
+        return asset.Asset(name, asset_hash, algorithm, locations,
+                           self.cachedirs).path
 
 
 class SimpleTest(Test):

--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -1,0 +1,180 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2016
+# Author: Amador Pahim <apahim@redhat.com>
+
+"""
+Asset fetcher from multiple locationss
+"""
+
+import logging
+import os
+import re
+import urlparse
+
+from . import crypto
+from . import path as utils_path
+from .download import url_download
+
+
+log = logging.getLogger('avocado.test')
+
+
+class Asset(object):
+    """
+    Try to fetch/verify an asset file from multiple locations.
+    """
+
+    def __init__(self, name, asset_hash, algorithm, locations, cache_dirs):
+        """
+        Initialize the Asset() and fetches the asset file. The path for
+        the fetched file can be reached using the self.path attribute.
+
+        :param name: the asset filename. url is also supported
+        :param asset_hash: asset hash
+        :param algorithm: hash algorithm (default sha1)
+        :param locations: list of locations fetch asset from
+        """
+        self.name = name
+        self.asset_hash = asset_hash
+        self.algorithm = algorithm
+        self.locations = locations
+        self.cache_dirs = cache_dirs
+        self.nameobj = urlparse.urlparse(self.name)
+        self.basename = os.path.basename(self.nameobj.path)
+        self.path = self.fetch()
+
+    def fetch(self):
+        urls = []
+
+        # If name is actually an url, it has to be included in urls list
+        if self.nameobj.scheme:
+            urls.append(self.nameobj.geturl())
+
+        # First let's find for the file in all cache locations
+        for cache_dir in self.cache_dirs:
+            cache_dir = os.path.expanduser(cache_dir)
+            self.asset_file = os.path.join(cache_dir, self.basename)
+            if self._check_file(self.asset_file, self.asset_hash, self.algorithm):
+                return self.asset_file
+
+        # If we get to this point, file is not in any cache directory
+        # and we have to download it from a location. A rw cache
+        # directory is then needed. The first rw cache directory will be
+        # used.
+        log.debug("Looking for a writable cache dir.")
+        for cache_dir in self.cache_dirs:
+            cache_dir = os.path.expanduser(cache_dir)
+            self.asset_file = os.path.join(cache_dir, self.basename)
+            if not utils_path.usable_rw_dir(cache_dir):
+                log.debug("Read-only cache dir '%s'. Skiping." %
+                          cache_dir)
+                continue
+            log.debug("Using %s as cache dir." % cache_dir)
+
+            # Adding the user defined locations to the urls list
+            if self.locations is not None:
+                for item in self.locations:
+                    urls.append(item)
+
+            for url in urls:
+                urlobj = urlparse.urlparse(url)
+                if urlobj.scheme == 'http':
+                    log.debug('Downloading from %s.' % url)
+                    try:
+                        url_download(url, self.asset_file)
+                    except Exception as e:
+                        log.error(e)
+                        continue
+                    if self._check_file(self.asset_file, self.asset_hash,
+                                        self.algorithm):
+                        return self.asset_file
+
+                elif urlobj.scheme == 'ftp':
+                    log.debug('Downloading from %s.' % url)
+                    try:
+                        url_download(url, self.asset_file)
+                    except Exception as e:
+                        log.error(e)
+                        continue
+                    if self._check_file(self.asset_file, self.asset_hash,
+                                        self.algorithm):
+                        return self.asset_file
+
+                elif urlobj.scheme == 'file':
+                    if os.path.isdir(urlobj.path):
+                        path = os.path.join(urlobj.path, self.name)
+                    else:
+                        path = urlobj.path
+                    log.debug('Looking for file on %s.' % path)
+                    if self._check_file(path):
+                        os.symlink(path, self.asset_file)
+                        log.debug('Symlink created %s -> %s.' %
+                                  (self.asset_file, path))
+                    else:
+                        continue
+                    if self._check_file(self.asset_file, self.asset_hash,
+                                        self.algorithm):
+                        return self.asset_file
+
+            raise EnvironmentError("Failed to fetch %s." % self.basename)
+        raise EnvironmentError("Can't find a writable cache dir.")
+
+    @staticmethod
+    def _check_file(path, filehash=None, algorithm=None):
+        """
+        Checks if file exists and verifies the hash, when the hash is
+        provided. We try first to find a hash file to verify the hash
+        against and only if the hash file is not present we compute the
+        hash.
+        """
+        if not os.path.isfile(path):
+            log.debug('Asset %s not found.' % path)
+            return False
+
+        if filehash is None:
+            return True
+
+        basename = os.path.basename(path)
+        discovered_hash = None
+        # Try to find a hashfile for the asset file
+        hashfile = '%s.%s' % (path, algorithm)
+        if os.path.isfile(hashfile):
+            with open(hashfile, 'r') as f:
+                for line in f.readlines():
+                    # md5 is 32 chars big and sha512 is 128 chars big.
+                    # others supported algorithms are between those.
+                    pattern = '[a-f0-9]{32,128} %s' % basename
+                    if re.match(pattern, line):
+                        log.debug('Hashfile found for %s.' % path)
+                        discovered_hash = line.split()[0]
+                        break
+
+        # If no hashfile, lets calculate the hash by ourselves
+        if discovered_hash is None:
+            log.debug('No hashfile found for %s. Computing hash.' %
+                      path)
+            discovered_hash = crypto.hash_file(path, algorithm=algorithm)
+
+            # Creating the hashfile for further usage.
+            log.debug('Creating hashfile %s.' % hashfile)
+            with open(hashfile, 'w') as f:
+                content = '%s %s\n' % (discovered_hash, basename)
+                f.write(content)
+
+        if filehash == discovered_hash:
+            log.debug('Asset %s verified.' % path)
+            return True
+        else:
+            log.error('Asset %s corrupted (hash expected:%s, hash found:%s).' %
+                      (path, filehash, discovered_hash))
+            return False

--- a/avocado/utils/path.py
+++ b/avocado/utils/path.py
@@ -18,6 +18,7 @@ Avocado path related functions.
 
 import os
 import stat
+import tempfile
 
 from . import aurl
 
@@ -140,3 +141,56 @@ class PathInspector(object):
                 return True
 
         return self.is_script(language='python')
+
+
+def usable_rw_dir(directory):
+    """
+    Verify wether we can use this dir (read/write).
+
+    Checks for appropriate permissions, and creates missing dirs as needed.
+
+    :param directory: Directory
+    """
+    if os.path.isdir(directory):
+        try:
+            fd, path = tempfile.mkstemp(dir=directory)
+            os.close(fd)
+            os.unlink(path)
+            return True
+        except OSError:
+            pass
+    else:
+        try:
+            init_dir(directory)
+            return True
+        except OSError:
+            pass
+
+    return False
+
+
+def usable_ro_dir(directory):
+    """
+    Verify whether dir exists and we can access its contents.
+
+    If a usable RO is there, use it no questions asked. If not, let's at
+    least try to create one.
+
+    :param directory: Directory
+    """
+    cwd = os.getcwd()
+    if os.path.isdir(directory):
+        try:
+            os.chdir(directory)
+            os.chdir(cwd)
+            return True
+        except OSError:
+            pass
+    else:
+        try:
+            init_dir(directory)
+            return True
+        except OSError:
+            pass
+
+    return False

--- a/etc/avocado/avocado.conf
+++ b/etc/avocado/avocado.conf
@@ -7,6 +7,10 @@ test_dir = /usr/share/avocado/tests
 data_dir = /usr/share/avocado/data
 # You may override the specific job results directory with logs_dir
 logs_dir = ~/avocado/job-results
+# You can set a list of cache directories to be used by the avocado test
+# fetch_asset() with 'cache_dirs'. read-only cache directories are also
+# supported.
+# cache_dirs = ['~/avocado/cache', '/mnt/cache']
 
 [sysinfo.collect]
 # Whether to collect system information during avocado jobs

--- a/selftests/unit/test_utils_asset.py
+++ b/selftests/unit/test_utils_asset.py
@@ -1,0 +1,61 @@
+import os
+import shutil
+import tempfile
+import unittest
+
+from avocado.utils import asset
+
+
+class TestAsset(unittest.TestCase):
+
+    def setUp(self):
+        self.basedir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        self.assetdir = tempfile.mkdtemp(dir=self.basedir)
+        self.assetname = 'foo.tgz'
+        self.assethash = '3a033a8938c1af56eeb793669db83bcbd0c17ea5'
+        self.localpath = os.path.join(self.assetdir, self.assetname)
+        with open(self.localpath, 'w') as f:
+            f.write('Test!')
+        self.url = 'file://%s' % self.localpath
+        self.cache_dir = tempfile.mkdtemp(dir=self.basedir)
+
+    def testFetch_urlname(self):
+        foo_tarball = asset.Asset(self.url,
+                                  asset_hash=self.assethash,
+                                  algorithm='sha1',
+                                  locations=None,
+                                  cache_dirs=[self.cache_dir]).path
+        expected_tarball = os.path.join(self.cache_dir, self.assetname)
+        self.assertEqual(foo_tarball, expected_tarball)
+        hashfile = '.'.join([expected_tarball, 'sha1'])
+        self.assertTrue(os.path.isfile(hashfile))
+        expected_content = '%s %s\n' % (self.assethash, self.assetname)
+        with open(hashfile, 'r') as f:
+            content = f.read()
+        self.assertEqual(content, expected_content)
+
+    def testFetch_location(self):
+        foo_tarball = asset.Asset(self.assetname,
+                                  asset_hash=self.assethash,
+                                  algorithm='sha1',
+                                  locations=[self.url],
+                                  cache_dirs=[self.cache_dir]).path
+        expected_tarball = os.path.join(self.cache_dir, self.assetname)
+        self.assertEqual(foo_tarball, expected_tarball)
+        hashfile = '.'.join([expected_tarball, 'sha1'])
+        self.assertTrue(os.path.isfile(hashfile))
+        expected_content = '%s %s\n' % (self.assethash, self.assetname)
+        with open(hashfile, 'r') as f:
+            content = f.read()
+        self.assertEqual(content, expected_content)
+
+    def testException(self):
+        self.assertRaises(EnvironmentError, asset.Asset, name='bar.tgz',
+                          asset_hash=None, algorithm=None, locations=None,
+                          cache_dirs=[self.cache_dir])
+
+    def tearDown(self):
+        shutil.rmtree(self.basedir)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
v6:
 - Create symbolic links instead of copying file when `file://` location is provided.
 - Changed from `download._get_file()` to `download.url_download()` to be used for `http://` and `ftp://` , since we don't copy files from `file://` locations anymore. 
 - Moved `avocado.core.data_dir._usable_rw_dir()` to `avocado.utils.path.usable_rw_dir()` and use it in asset fetcher.
 -  Some minor code style improvements.

v5: #1028 
 - Support for multiple cache directories in cache_dirs configuration key.
 - Use test temporary workdir as ultimate cache for dowloaded files, if no writable caches are provided using configuration file.
 - Test if cache_dir is writable before using it as a download target.
 - Multiple use cases in docs.
 - Unit tests.

v4: #1004 
 - Now fetch_asset() is an avocado.Test method.
 - Cache_dir defined in config file.
 - New avocado.Tets.cachedir attribute on the API.
 - Look for hashfile first.
 - Create hashfile when hash compute is needed.
 - Raise an exception on fetch_asset error.
 - Support location on asset name.
 - Default SHA1.

v3: #997 
 - Asset() class.
 - Do not depend on yaml/multiplex.

v2: #995 
 - Use full url, including the file name.
 - Docs.
 - Use job temporary dir as `cache_dir` default location.

v1: #993 
 - Utility to find for files in multiple locations, caching it when successfully fetched.