### PR TITLE
Python 3 partial support

### DIFF
--- a/avocado/core/exceptions.py
+++ b/avocado/core/exceptions.py
@@ -48,7 +48,7 @@ def fail_on(exceptions=None):
                 return func(*args, **kwargs)
             except TestBaseException:
                 raise
-            except exceptions, details:
+            except exceptions as details:
                 raise TestFail(str(details))
         return wrap
     if func:

--- a/avocado/core/html.py
+++ b/avocado/core/html.py
@@ -109,9 +109,9 @@ class ReportModel(object):
         try:
             with open(sysinfo_path, 'r') as sysinfo_file:
                 sysinfo_contents = sysinfo_file.read()
-        except OSError, details:
+        except OSError as details:
             sysinfo_contents = "Error reading %s: %s" % (sysinfo_path, details)
-        except IOError, details:
+        except IOError as details:
             sysinfo_contents = os.uname()[1]
         return sysinfo_contents
 
@@ -261,7 +261,7 @@ class HTMLTestResult(TestResult):
                 v = view.View(open(template, 'r').read(), context)
                 report_contents = v.render('utf8')  # encodes into ascii
                 report_contents = codecs.decode("utf8")  # decode to unicode
-        except UnicodeDecodeError, details:
+        except UnicodeDecodeError as details:
             # FIXME: Removeme when UnicodeDecodeError problem is fixed
             import logging
             ui = logging.getLogger("avocado.app")

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -259,7 +259,7 @@ class Job(object):
         loader.loader.load_plugins(self.args)
         try:
             suite = loader.loader.discover(urls)
-        except loader.LoaderUnhandledUrlError, details:
+        except loader.LoaderUnhandledUrlError as details:
             self._remove_job_results()
             raise exceptions.OptionValidationError(details)
         except KeyboardInterrupt:
@@ -411,7 +411,7 @@ class Job(object):
                                      self.replay_sourcejob)
         try:
             test_suite = self._make_test_suite(self.urls)
-        except loader.LoaderError, details:
+        except loader.LoaderError as details:
             stacktrace.log_exc_info(sys.exc_info(), 'avocado.app.tracebacks')
             self._remove_job_results()
             raise exceptions.OptionValidationError(details)
@@ -427,7 +427,7 @@ class Job(object):
         else:
             try:
                 mux = multiplexer.Mux(self.args)
-            except (IOError, ValueError), details:
+            except (IOError, ValueError) as details:
                 raise exceptions.OptionValidationError(details)
         self.args.test_result_total = mux.get_number_of_tests(test_suite)
 
@@ -483,17 +483,17 @@ class Job(object):
         runtime.CURRENT_JOB = self
         try:
             return self._run()
-        except exceptions.JobBaseException, details:
+        except exceptions.JobBaseException as details:
             self.status = details.status
             fail_class = details.__class__.__name__
             self.view.notify(event='error', msg=('\nAvocado job failed: %s: %s'
                                                  % (fail_class, details)))
             return exit_codes.AVOCADO_JOB_FAIL
-        except exceptions.OptionValidationError, details:
+        except exceptions.OptionValidationError as details:
             self.view.notify(event='error', msg='\n' + str(details))
             return exit_codes.AVOCADO_JOB_FAIL
 
-        except Exception, details:
+        except Exception as details:
             self.status = "ERROR"
             exc_type, exc_value, exc_traceback = sys.exc_info()
             tb_info = traceback.format_exception(exc_type, exc_value,

--- a/avocado/core/job_id.py
+++ b/avocado/core/job_id.py
@@ -27,4 +27,4 @@ def create_unique_job_id():
     :return: 40 digit hex number string
     :rtype: str
     """
-    return hashlib.sha1(hex(_RAND_POOL.getrandbits(160))).hexdigest()
+    return hashlib.sha1(hex(_RAND_POOL.getrandbits(160)).encode()).hexdigest()

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -218,7 +218,7 @@ class TestLoaderProxy(object):
             for loader_plugin in self._initialized_plugins:
                 try:
                     tests.extend(loader_plugin.discover(None, which_tests))
-                except Exception, details:
+                except Exception as details:
                     handle_exception(loader_plugin, details)
         else:
             for url in urls:
@@ -231,7 +231,7 @@ class TestLoaderProxy(object):
                             handled = True
                             if not which_tests:
                                 break  # Don't process other plugins
-                    except Exception, details:
+                    except Exception as details:
                         handle_exception(loader_plugin, details)
                 if not handled:
                     unhandled_urls.append(url)
@@ -265,7 +265,7 @@ class TestLoaderProxy(object):
                 sys.path.insert(0, test_module_dir)
                 f, p, d = imp.find_module(module_name, [test_module_dir])
                 test_module = imp.load_module(module_name, f, p, d)
-            except ImportError, details:
+            except ImportError as details:
                 raise ImportError("Unable to import test's module with "
                                   "sys.path=%s\n\n%s" % (", ".join(sys.path),
                                                          details))
@@ -667,7 +667,7 @@ class FileLoader(TestLoader):
         # Since a lot of things can happen here, the broad exception is
         # justified. The user will get it unadulterated anyway, and avocado
         # will not crash.
-        except BaseException, details:  # Ugly python files can raise any exc
+        except BaseException as details:  # Ugly python files can raise any exc
             if isinstance(details, KeyboardInterrupt):
                 raise  # Don't ignore ctrl+c
             if os.access(test_path, os.X_OK):

--- a/avocado/core/remote/runner.py
+++ b/avocado/core/remote/runner.py
@@ -222,7 +222,7 @@ class RemoteTestRunner(TestRunner):
                     raise exceptions.JobError('Remote machine does not seem to have '
                                               'avocado installed')
                 self._copy_files()
-            except Exception, details:
+            except Exception as details:
                 stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
                 raise exceptions.JobError(details)
             results = self.run_test(self.job.urls, timeout)
@@ -252,7 +252,7 @@ class RemoteTestRunner(TestRunner):
             self.result.end_tests()
             try:
                 self.tear_down()
-            except Exception, details:
+            except Exception as details:
                 stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
                 raise exceptions.JobError(details)
         finally:

--- a/avocado/core/remoter.py
+++ b/avocado/core/remoter.py
@@ -98,7 +98,7 @@ class Remote(object):
                                                       warn_only=True,
                                                       timeout=timeout)
                 break
-            except fabric.network.NetworkError, details:
+            except fabric.network.NetworkError as details:
                 fabric_exception = details
                 timeout = end_time - time.time()
             if time.time() < end_time:

--- a/avocado/core/restclient/cli/actions/server.py
+++ b/avocado/core/restclient/cli/actions/server.py
@@ -27,7 +27,7 @@ def list_brief(app):
     """
     try:
         data = app.connection.get_api_list()
-    except connection.UnexpectedHttpStatusCode, e:
+    except connection.UnexpectedHttpStatusCode as e:
         if e.received == 403:
             app.view.notify(event="error",
                             msg="Error: Access Forbidden")

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -64,7 +64,7 @@ class TestStatus(object):
             return self.queue.get()
         # Let's catch all exceptions, since errors here mean a
         # crash in avocado.
-        except Exception, details:
+        except Exception as details:
             e_msg = ("\nError receiving message from test: %s -> %s" %
                      (details.__class__, details))
             self.job.view.notify(event="error",

--- a/avocado/core/settings.py
+++ b/avocado/core/settings.py
@@ -16,10 +16,14 @@
 Reads the avocado settings from a .ini file (from python ConfigParser).
 """
 import ast
-import ConfigParser
 import os
 import sys
 import glob
+
+try:
+    import ConfigParser
+except ImportError:
+    import configparser as ConfigParser
 
 from ..utils import path
 

--- a/avocado/core/settings.py
+++ b/avocado/core/settings.py
@@ -241,7 +241,7 @@ class Settings(object):
 
         try:
             return convert_value_type(val, key_type)
-        except Exception, details:
+        except Exception as details:
             raise SettingsValueError("Could not convert value %r to type %s "
                                      "(settings key %s, section %s): %s" %
                                      (val, key_type, key, section, details))

--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -287,11 +287,11 @@ class LogWatcher(Collectible):
             finally:
                 out_messages.close()
                 in_messages.close()
-        except ValueError, e:
+        except ValueError as e:
             log.info(e)
         except (IOError, OSError):
             log.debug("Not logging %s (lack of permissions)", self.path)
-        except Exception, e:
+        except Exception as e:
             log.error("Log file %s collection failed: %s", self.path, e)
 
 
@@ -420,7 +420,7 @@ class SysInfo(object):
         # we have to probe and find out the correct path.
         try:
             self.end_test_collectibles.add(self._get_syslog_watcher())
-        except ValueError, details:
+        except ValueError as details:
             log.info(details)
 
     def _get_collectibles(self, hook):

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -383,7 +383,7 @@ class Test(unittest.TestCase):
         stderr_check_exception = None
         try:
             self.setUp()
-        except exceptions.TestSkipError, details:
+        except exceptions.TestSkipError as details:
             stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
             raise exceptions.TestSkipError(details)
         except:  # Old-style exceptions are not inherited from Exception()
@@ -392,7 +392,7 @@ class Test(unittest.TestCase):
             raise exceptions.TestSetupFail(details)
         try:
             testMethod()
-        except exceptions.TestSkipError, details:
+        except exceptions.TestSkipError as details:
             stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
             skip_illegal_msg = ('Calling skip() in places other than '
                                 'setUp() is not allowed in avocado, you '
@@ -408,7 +408,7 @@ class Test(unittest.TestCase):
         finally:
             try:
                 self.tearDown()
-            except exceptions.TestSkipError, details:
+            except exceptions.TestSkipError as details:
                 stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
                 skip_illegal_msg = ('Calling skip() in places other than '
                                     'setUp() is not allowed in avocado, '
@@ -437,13 +437,13 @@ class Test(unittest.TestCase):
                 if not disable_output_check:
                     try:
                         self._check_reference_stdout()
-                    except Exception, details:
+                    except Exception as details:
                         stacktrace.log_exc_info(sys.exc_info(),
                                                 logger='avocado.test')
                         stdout_check_exception = details
                     try:
                         self._check_reference_stderr()
-                    except Exception, details:
+                    except Exception as details:
                         stacktrace.log_exc_info(sys.exc_info(),
                                                 logger='avocado.test')
                         stderr_check_exception = details
@@ -493,17 +493,17 @@ class Test(unittest.TestCase):
         try:
             self._tag_start()
             self._run_avocado()
-        except exceptions.TestBaseException, detail:
+        except exceptions.TestBaseException as detail:
             self.status = detail.status
             self.fail_class = detail.__class__.__name__
             self.fail_reason = detail
             self.traceback = stacktrace.prepare_exc_info(sys.exc_info())
-        except AssertionError, detail:
+        except AssertionError as detail:
             self.status = 'FAIL'
             self.fail_class = detail.__class__.__name__
             self.fail_reason = detail
             self.traceback = stacktrace.prepare_exc_info(sys.exc_info())
-        except Exception, detail:
+        except Exception as detail:
             self.status = 'ERROR'
             tb_info = stacktrace.tb_info(sys.exc_info())
             self.traceback = stacktrace.prepare_exc_info(sys.exc_info())
@@ -623,7 +623,7 @@ class SimpleTest(Test):
                                  env=test_params)
 
             self._log_detailed_cmd_info(result)
-        except process.CmdError, details:
+        except process.CmdError as details:
             self._log_detailed_cmd_info(details.result)
             raise exceptions.TestFail(details)
 

--- a/avocado/core/version.py
+++ b/avocado/core/version.py
@@ -24,4 +24,4 @@ RELEASE = 0
 VERSION = "%s.%s.%s" % (MAJOR, MINOR, RELEASE)
 
 if __name__ == '__main__':
-    print VERSION
+    print(VERSION)

--- a/avocado/plugins/list.py
+++ b/avocado/plugins/list.py
@@ -34,7 +34,7 @@ class TestLister(object):
         self.term_support = output.TermSupport()
         try:
             loader.loader.load_plugins(args)
-        except loader.LoaderError, details:
+        except loader.LoaderError as details:
             sys.stderr.write(str(details))
             sys.stderr.write('\n')
             sys.exit(exit_codes.AVOCADO_FAIL)
@@ -48,7 +48,7 @@ class TestLister(object):
         try:
             return loader.loader.discover(paths,
                                           which_tests=which_tests)
-        except loader.LoaderUnhandledUrlError, details:
+        except loader.LoaderUnhandledUrlError as details:
             self.view.notify(event="error", msg=str(details))
             self.view.cleanup()
             sys.exit(exit_codes.AVOCADO_FAIL)

--- a/avocado/plugins/multiplex.py
+++ b/avocado/plugins/multiplex.py
@@ -97,7 +97,7 @@ class Multiplex(CLICmd):
             mux_tree = multiplexer.yaml2tree(args.multiplex_files,
                                              args.filter_only, args.filter_out,
                                              args.debug)
-        except IOError, details:
+        except IOError as details:
             view.notify(event='error',
                         msg=details.strerror)
             sys.exit(exit_codes.AVOCADO_JOB_FAIL)

--- a/avocado/utils/aurl.py
+++ b/avocado/utils/aurl.py
@@ -18,7 +18,10 @@ URL related functions.
 The strange name is to avoid accidental naming colisions in code.
 """
 
-import urlparse
+try:
+    import urlparse
+except ImportError:
+    import urllib.parse as urlparse
 
 
 def is_url(path):

--- a/avocado/utils/data_factory.py
+++ b/avocado/utils/data_factory.py
@@ -79,7 +79,7 @@ def make_dir_and_populate(basedir='/tmp'):
             for _ in xrange(n_lines):
                 os.write(fd, generate_random_string(str_length))
             os.close(fd)
-    except OSError, details:
+    except OSError as details:
         log.error("Failed to generate dir in '%s' and populate: %s" %
                   (basedir, details))
         return None

--- a/avocado/utils/data_factory.py
+++ b/avocado/utils/data_factory.py
@@ -42,7 +42,7 @@ def generate_random_string(length, ignore=string.punctuation,
     :return: The generated random string.
     """
     result = ""
-    chars = string.letters + string.digits + string.punctuation
+    chars = string.ascii_letters + string.digits + string.punctuation
     if not ignore:
         ignore = ""
     for i in ignore:

--- a/avocado/utils/distro.py
+++ b/avocado/utils/distro.py
@@ -199,7 +199,7 @@ class Probe(object):
         version = UNKNOWN_DISTRO_VERSION
         match = self._get_version_match()
         if match is not None:
-            if match.groups() > 0:
+            if len(match.groups()) > 0:
                 version = match.groups()[0]
         return version
 

--- a/avocado/utils/external/gdbmi_parser.py
+++ b/avocado/utils/external/gdbmi_parser.py
@@ -27,7 +27,7 @@
 import re
 import pprint
 
-import spark
+from . import spark
 
 
 def __private():
@@ -173,10 +173,10 @@ def __private():
 
         def error(self, token, i=0, tokens=None):
             if i > 2:
-                print '%s %s %s %s' % (tokens[i - 3],
+                print('%s %s %s %s' % (tokens[i - 3],
                                        tokens[i - 2],
                                        tokens[i - 1],
-                                       tokens[i])
+                                       tokens[i]))
             raise Exception("Syntax error at or near %d:'%s' token" % (i, token))
 
     class GdbMiInterpreter(spark.GenericASTTraversal):

--- a/avocado/utils/gdb.py
+++ b/avocado/utils/gdb.py
@@ -345,7 +345,7 @@ class GDB(object):
                                             stdout=subprocess.PIPE,
                                             stderr=subprocess.PIPE,
                                             close_fds=True)
-        except OSError, details:
+        except OSError as details:
             if details.errno == 2:
                 exc = OSError("File '%s' not found" % args[0])
                 exc.errno = 2
@@ -663,7 +663,7 @@ class GDBServer(object):
                                             stdout=self.stdout,
                                             stderr=self.stderr,
                                             close_fds=True)
-        except OSError, details:
+        except OSError as details:
             if details.errno == 2:
                 exc = OSError("File '%s' not found" % args[0])
                 exc.errno = 2

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -19,7 +19,6 @@ Functions dedicated to find and run external commands.
 import logging
 import os
 import re
-import StringIO
 import signal
 import time
 import stat
@@ -34,6 +33,11 @@ try:
 except ImportError:
     import subprocess
     SUBPROCESS32_SUPPORT = False
+
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 from . import gdb
 from . import runtime
@@ -344,8 +348,8 @@ class SubProcess(object):
                     raise
 
             self.start_time = time.time()
-            self.stdout_file = StringIO.StringIO()
-            self.stderr_file = StringIO.StringIO()
+            self.stdout_file = StringIO()
+            self.stderr_file = StringIO()
             self.stdout_lock = threading.Lock()
             self.stdout_thread = threading.Thread(target=self._fd_drainer,
                                                   name="%s-stdout" % self.cmd,

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -309,7 +309,7 @@ class SubProcess(object):
         if sudo and os.getuid() != 0:
             try:
                 sudo_cmd = '%s -n' % path.find_command('sudo')
-            except path.CmdNotFoundError, details:
+            except path.CmdNotFoundError as details:
                 log.error(details)
                 log.error('Parameter sudo=True provided, but sudo was '
                           'not found. Please consider adding sudo to '
@@ -335,7 +335,7 @@ class SubProcess(object):
                                                stderr=subprocess.PIPE,
                                                shell=self.shell,
                                                env=self.env)
-            except OSError, details:
+            except OSError as details:
                 if details.errno == 2:
                     exc = OSError("File '%s' not found" % self.cmd.split()[0])
                     exc.errno = 2

--- a/avocado/utils/script.py
+++ b/avocado/utils/script.py
@@ -17,10 +17,17 @@ Module to handle scripts creation.
 """
 
 import os
-import tempfile
+import stat
 import shutil
+import tempfile
 
 from . import path as utils_path
+
+
+#: What is commonly known as "0775" or "u=rwx,g=rwx,o=rx"
+DEFAULT_MODE = (stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR |
+                stat.S_IRGRP | stat.S_IWGRP | stat.S_IXGRP |
+                stat.S_IROTH | stat.S_IXOTH)
 
 
 class Script(object):
@@ -29,7 +36,7 @@ class Script(object):
     Class that represents a script.
     """
 
-    def __init__(self, path, content, mode=0775):
+    def __init__(self, path, content, mode=DEFAULT_MODE):
         """
         Creates an instance of :class:`Script`.
 
@@ -38,7 +45,7 @@ class Script(object):
 
         :param path: the script file name.
         :param content: the script content.
-        :param mode: set file mode, default to 0775.
+        :param mode: set file mode, defaults what is commonly known as 0775.
         """
         self.path = path
         self.content = content
@@ -94,7 +101,7 @@ class TemporaryScript(Script):
     Class that represents a temporary script.
     """
 
-    def __init__(self, name, content, prefix='avocado_script', mode=0775):
+    def __init__(self, name, content, prefix='avocado_script', mode=DEFAULT_MODE):
         """
         Creates an instance of :class:`TemporaryScript`.
 
@@ -124,7 +131,7 @@ class TemporaryScript(Script):
             self.stored = False
 
 
-def make_script(path, content, mode=0775):
+def make_script(path, content, mode=DEFAULT_MODE):
     """
     Creates a new script stored in the file system.
 
@@ -138,7 +145,7 @@ def make_script(path, content, mode=0775):
     return scpt.path
 
 
-def make_temp_script(name, content, prefix='avocado_script', mode=0775):
+def make_temp_script(name, content, prefix='avocado_script', mode=DEFAULT_MODE):
     """
     Creates a new temporary script stored in the file system.
 

--- a/avocado/utils/software_manager.py
+++ b/avocado/utils/software_manager.py
@@ -39,7 +39,6 @@ implement the given backend class.
 import os
 import re
 import logging
-import ConfigParser
 import optparse
 import tempfile
 
@@ -49,6 +48,11 @@ except ImportError:
     HAS_YUM_MODULE = False
 else:
     HAS_YUM_MODULE = True
+
+try:
+    import ConfigParser
+except ImportError:
+    import configparser as ConfigParser
 
 from . import process
 from . import data_factory

--- a/avocado/utils/software_manager.py
+++ b/avocado/utils/software_manager.py
@@ -442,7 +442,7 @@ class YumBackend(RpmBackend):
                                % (tmp_file.name, self.repo_file_path),
                                sudo=True)
             return True
-        except (OSError, process.CmdError), details:
+        except (OSError, process.CmdError) as details:
             log.error(details)
             return False
 
@@ -465,7 +465,7 @@ class YumBackend(RpmBackend):
                                % (tmp_file.name, self.repo_file_path),
                                sudo=True)
                 return True
-        except (OSError, process.CmdError), details:
+        except (OSError, process.CmdError) as details:
             log.error(details)
             return False
 
@@ -501,7 +501,7 @@ class YumBackend(RpmBackend):
             return None
         try:
             d_provides = self.yum_base.searchPackageProvides(args=[name])
-        except Exception, exc:
+        except Exception as exc:
             log.error("Error searching for package that "
                       "provides %s: %s", name, exc)
             d_provides = []
@@ -767,7 +767,7 @@ class AptBackend(DpkgBackend):
                 process.system('cp %s %s'
                                % (tmp_file.name, self.repo_file_path),
                                sudo=True)
-        except (OSError, process.CmdError), details:
+        except (OSError, process.CmdError) as details:
             log.error(details)
             return False
 

--- a/scripts/avocado
+++ b/scripts/avocado
@@ -47,7 +47,7 @@ def handle_exception(*exc_info):
     except:
         pass
     tmp, name = tempfile.mkstemp(".log", prefix, crash_dir)
-    os.write(tmp, msg)
+    os.write(tmp, msg.encode('utf-8'))
     os.close(tmp)
     # Print friendly message in console-like output
     msg = ("Avocado crashed unexpectedly: %s\nYou can find details in %s"

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -687,7 +687,7 @@ class PluginsXunitTest(AbsPluginsTest, unittest.TestCase):
                          (e_rc, result))
         try:
             xunit_doc = xml.dom.minidom.parseString(xml_output)
-        except Exception, detail:
+        except Exception as detail:
             raise ParseXMLError("Failed to parse content: %s\n%s" %
                                 (detail, xml_output))
 
@@ -762,7 +762,7 @@ class PluginsJSONTest(AbsPluginsTest, unittest.TestCase):
                          (e_rc, result))
         try:
             json_data = json.loads(json_output)
-        except Exception, detail:
+        except Exception as detail:
             raise ParseJSONError("Failed to parse content: %s\n%s" %
                                  (detail, json_output))
         self.assertTrue(json_data, "Empty JSON result:\n%s" % json_output)

--- a/selftests/functional/test_interrupt.py
+++ b/selftests/functional/test_interrupt.py
@@ -3,6 +3,7 @@ import sys
 import tempfile
 import time
 import shutil
+import stat
 
 import aexpect
 import psutil
@@ -20,6 +21,11 @@ from avocado.utils import data_factory
 basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..')
 basedir = os.path.abspath(basedir)
 
+
+# What is commonly known as "0755" or "u=rwx,g=rx,o=rx"
+DEFAULT_MODE = (stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR |
+                stat.S_IRGRP | stat.S_IXGRP |
+                stat.S_IROTH | stat.S_IXOTH)
 
 BAD_TEST = """#!/usr/bin/env python
 import signal
@@ -60,7 +66,8 @@ class InterruptTest(unittest.TestCase):
                              data_factory.generate_random_string(5))
         bad_test = script.TemporaryScript(bad_test_basename, BAD_TEST,
                                           'avocado_interrupt_test',
-                                          mode=0755)
+                                          mode=DEFAULT_MODE)
+
         bad_test.save()
 
         os.chdir(basedir)
@@ -121,7 +128,7 @@ class InterruptTest(unittest.TestCase):
                               data_factory.generate_random_string(5))
         good_test = script.TemporaryScript(good_test_basename, GOOD_TEST,
                                            'avocado_interrupt_test',
-                                           mode=0755)
+                                           mode=DEFAULT_MODE)
         good_test.save()
 
         os.chdir(basedir)

--- a/selftests/functional/test_job_timeout.py
+++ b/selftests/functional/test_job_timeout.py
@@ -66,7 +66,7 @@ class JobTimeOutTest(unittest.TestCase):
                          (e_rc, result))
         try:
             xunit_doc = xml.dom.minidom.parseString(xml_output)
-        except Exception, detail:
+        except Exception as detail:
             raise ParseXMLError("Failed to parse content: %s\n%s" %
                                 (detail, xml_output))
 

--- a/selftests/functional/test_utils.py
+++ b/selftests/functional/test_utils.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import stat
 import time
 import tempfile
 import shutil
@@ -10,6 +11,12 @@ else:
     import unittest
 
 from avocado.utils import process
+
+
+# What is commonly known as "0775" or "u=rwx,g=rwx,o=rx"
+DEFAULT_MODE = (stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR |
+                stat.S_IRGRP | stat.S_IWGRP | stat.S_IXGRP |
+                stat.S_IROTH | stat.S_IXOTH)
 
 FAKE_VMSTAT_CONTENTS = """#!/usr/bin/env python
 import time
@@ -122,12 +129,12 @@ class ProcessTest(unittest.TestCase):
         self.fake_vmstat = os.path.join(self.base_logdir, 'vmstat')
         with open(self.fake_vmstat, 'w') as fake_vmstat_obj:
             fake_vmstat_obj.write(FAKE_VMSTAT_CONTENTS)
-        os.chmod(self.fake_vmstat, 0775)
+        os.chmod(self.fake_vmstat, DEFAULT_MODE)
 
         self.fake_uptime = os.path.join(self.base_logdir, 'uptime')
         with open(self.fake_uptime, 'w') as fake_uptime_obj:
             fake_uptime_obj.write(FAKE_UPTIME_CONTENTS)
-        os.chmod(self.fake_uptime, 0775)
+        os.chmod(self.fake_uptime, DEFAULT_MODE)
 
     def test_process_start(self):
         proc = process.SubProcess('%s 1' % self.fake_vmstat)

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -1,3 +1,4 @@
+import stat
 import sys
 import multiprocessing
 
@@ -12,6 +13,12 @@ from avocado.core import loader
 from avocado.utils import script
 
 # We need to access protected members pylint: disable=W0212
+
+#: What is commonly known as "0664" or "u=rw,g=rw,o=r"
+DEFAULT_NON_EXEC_MODE = (stat.S_IRUSR | stat.S_IWUSR |
+                         stat.S_IRGRP | stat.S_IWGRP |
+                         stat.S_IROTH)
+
 
 AVOCADO_TEST_OK = """#!/usr/bin/env python
 from avocado import Test
@@ -153,7 +160,7 @@ class LoaderTest(unittest.TestCase):
     def test_load_simple_not_exec(self):
         simple_test = script.TemporaryScript('simpletest.sh', SIMPLE_TEST,
                                              'avocado_loader_unittest',
-                                             mode=0664)
+                                             mode=DEFAULT_NON_EXEC_MODE)
         simple_test.save()
         test_class, test_parameters = (
             self.loader.discover(simple_test.path, True)[0])
@@ -176,7 +183,7 @@ class LoaderTest(unittest.TestCase):
         avocado_not_a_test = script.TemporaryScript('notatest.py',
                                                     NOT_A_TEST,
                                                     'avocado_loader_unittest',
-                                                    mode=0664)
+                                                    mode=DEFAULT_NON_EXEC_MODE)
         avocado_not_a_test.save()
         test_class, test_parameters = (
             self.loader.discover(avocado_not_a_test.path, True)[0])
@@ -214,7 +221,7 @@ class LoaderTest(unittest.TestCase):
         avocado_simple_test = script.TemporaryScript('simpletest.py',
                                                      PY_SIMPLE_TEST,
                                                      'avocado_loader_unittest',
-                                                     mode=0664)
+                                                     mode=DEFAULT_NON_EXEC_MODE)
         avocado_simple_test.save()
         test_class, test_parameters = (
             self.loader.discover(avocado_simple_test.path, True)[0])
@@ -227,7 +234,7 @@ class LoaderTest(unittest.TestCase):
         avocado_multiple_tests = script.TemporaryScript('multipletests.py',
                                                         AVOCADO_MULTIPLE_TESTS,
                                                         'avocado_multiple_tests_unittest',
-                                                        mode=0664)
+                                                        mode=DEFAULT_NON_EXEC_MODE)
         avocado_multiple_tests.save()
         suite = self.loader.discover(avocado_multiple_tests.path, True)
         self.assertEqual(len(suite), 2)
@@ -254,7 +261,7 @@ class LoaderTest(unittest.TestCase):
         avocado_multiple_tests = script.TemporaryScript('multipletests.py',
                                                         AVOCADO_MULTIPLE_TESTS_SAME_NAME,
                                                         'avocado_multiple_tests_unittest',
-                                                        mode=0664)
+                                                        mode=DEFAULT_NON_EXEC_MODE)
         avocado_multiple_tests.save()
         suite = self.loader.discover(avocado_multiple_tests.path, True)
         self.assertEqual(len(suite), 1)
@@ -279,7 +286,7 @@ class LoaderTest(unittest.TestCase):
         avocado_pass_test = script.TemporaryScript('disable.py',
                                                    AVOCADO_TEST_OK_DISABLED,
                                                    'avocado_loader_unittest',
-                                                   0664)
+                                                   DEFAULT_NON_EXEC_MODE)
         avocado_pass_test.save()
         test_class, test_parameters = (
             self.loader.discover(avocado_pass_test.path, True)[0])
@@ -290,7 +297,7 @@ class LoaderTest(unittest.TestCase):
         avocado_nested_test = script.TemporaryScript('nested.py',
                                                      AVOCADO_TEST_NESTED_TAGGED,
                                                      'avocado_loader_unittest',
-                                                     0664)
+                                                     DEFAULT_NON_EXEC_MODE)
         avocado_nested_test.save()
         test_class, test_parameters = (
             self.loader.discover(avocado_nested_test.path, True)[0])

--- a/selftests/unit/test_xunit.py
+++ b/selftests/unit/test_xunit.py
@@ -68,7 +68,7 @@ class xUnitSucceedTest(unittest.TestCase):
             xml = fp.read()
         try:
             dom = minidom.parseString(xml)
-        except Exception, details:
+        except Exception as details:
             raise ParseXMLError("Error parsing XML: '%s'.\nXML Contents:\n%s" % (details, xml))
         self.assertTrue(dom)
         els = dom.getElementsByTagName('testcase')

--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,7 @@ if __name__ == '__main__':
           author='Avocado Developers',
           author_email='avocado-devel@redhat.com',
           url='http://avocado-framework.github.io/',
+          use_2to3=True,
           packages=['avocado',
                     'avocado.core',
                     'avocado.utils',


### PR DESCRIPTION
Whenever Avocado is used to run tests written in Python (so called INSTRUMENTED) that also uses the API that Avocado makes available, it interfaces much more closely with the test code. Now, if the test code itself interfaces with a Python 3 based library, its users are out of luck.

For this, and various other reasons including better portability and avoiding bit rot, this PR introduces partial support for Python 3.

At this stage, the Avocado test runner is able to run some commands and most of the tests run pass when run on Python 3. Please note that some dependencies do not even exist on Python 3, and will most probably never be ported (fabric, I'm talking about you), so further isolation of features will be needed to have clean test runs on a Python 3 environment.

The good part about this PR is that it should not bring any breakage to Python 2 environments, including keeping Python 2.6 systems happy.

Now, let's see what CI thinks of it.