### PR TITLE
Safe Loader: a second, more abstract and reusable implementation [v2]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,10 @@ SHORT_COMMIT=$(shell git log --pretty=format:'%h' -n 1)
 all:
 	@echo
 	@echo "Development related targets:"
-	@echo "check:  Runs tree static check, unittests and functional tests"
-	@echo "link:   Runs 'python setup.py --develop' in all subprojects and links the needed resources"
-	@echo "clean:  Get rid of scratch, byte files and removes the links to other subprojects"
+	@echo "check:      Runs tree static check, unittests and functional tests"
+	@echo "link:       Runs 'python setup.py --develop' in all subprojects and links the needed resources"
+	@echo "clean:      Get rid of scratch, byte files and removes the links to other subprojects"
+	@echo "selfcheck:  Runs tree static check, unittests and functional tests using Avocado itself"
 	@echo
 	@echo "Package requirements related targets"
 	@echo "requirements:            Install runtime requirements"
@@ -127,6 +128,10 @@ smokecheck:
 
 check: clean check_cyclical modules_boundaries
 	selftests/checkall
+	selftests/check_tmp_dirs
+
+selfcheck: clean check_cyclical modules_boundaries
+	AVOCADO_SELF_CHECK=1 selftests/checkall
 	selftests/check_tmp_dirs
 
 check_cyclical:

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -30,6 +30,7 @@ import sys
 from . import data_dir
 from . import output
 from . import test
+from . import safeloader
 from ..utils import path
 from ..utils import stacktrace
 from .settings import settings
@@ -37,28 +38,6 @@ from .settings import settings
 DEFAULT = False  # Show default tests (for execution)
 AVAILABLE = None  # Available tests (for listing purposes)
 ALL = True  # All tests (including broken ones)
-
-
-#: Gets the tag value from a string. Used to tag a test class in various ways
-AVOCADO_DOCSTRING_TAG_RE = re.compile(r'\s*:avocado:\s*(\S+)\s*')
-
-
-def get_docstring_tag(docstring):
-    if docstring is None:
-        return None
-    result = AVOCADO_DOCSTRING_TAG_RE.search(docstring)
-    if result is not None:
-        return result.groups()[0]
-
-
-def is_docstring_tag_enable(docstring):
-    result = get_docstring_tag(docstring)
-    return result == 'enable'
-
-
-def is_docstring_tag_disable(docstring):
-    result = get_docstring_tag(docstring)
-    return result == 'disable'
 
 
 class LoaderError(Exception):
@@ -597,9 +576,9 @@ class FileLoader(TestLoader):
                 docstring = ast.get_docstring(statement)
                 # Looking for a class that has in the docstring either
                 # ":avocado: enable" or ":avocado: disable
-                if is_docstring_tag_disable(docstring):
+                if safeloader.is_docstring_tag_disable(docstring):
                     continue
-                elif is_docstring_tag_enable(docstring):
+                elif safeloader.is_docstring_tag_enable(docstring):
                     functions = [st.name for st in statement.body if
                                  isinstance(st, ast.FunctionDef) and
                                  st.name.startswith('test')]

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -33,6 +33,7 @@ from . import test
 from . import safeloader
 from ..utils import path
 from ..utils import stacktrace
+from ..utils import data_structures
 from .settings import settings
 
 DEFAULT = False  # Show default tests (for execution)
@@ -519,12 +520,6 @@ class FileLoader(TestLoader):
                         tests.extend(self._make_tests(pth, which_tests))
         return tests
 
-    @staticmethod
-    def _unique_ordered_list(method_list):
-        seen = set()
-        seen_add = seen.add
-        return [x for x in method_list if not (x in seen or seen_add(x))]
-
     def _find_avocado_tests(self, path):
         """
         Attempts to find Avocado instrumented tests from Python source files
@@ -582,7 +577,7 @@ class FileLoader(TestLoader):
                     functions = [st.name for st in statement.body if
                                  isinstance(st, ast.FunctionDef) and
                                  st.name.startswith('test')]
-                    functions = self._unique_ordered_list(functions)
+                    functions = data_structures.ordered_list_unique(functions)
                     result[statement.name] = functions
                     continue
 
@@ -594,7 +589,7 @@ class FileLoader(TestLoader):
                         functions = [st.name for st in statement.body if
                                      isinstance(st, ast.FunctionDef) and
                                      st.name.startswith('test')]
-                        functions = self._unique_ordered_list(functions)
+                        functions = data_structures.ordered_list_unique(functions)
                         result[statement.name] = functions
                         continue
 
@@ -607,7 +602,7 @@ class FileLoader(TestLoader):
                             functions = [st.name for st in statement.body if
                                          isinstance(st, ast.FunctionDef) and
                                          st.name.startswith('test')]
-                            functions = self._unique_ordered_list(functions)
+                            functions = data_structures.ordered_list_unique(functions)
                             result[statement.name] = functions
 
         return result

--- a/avocado/core/safeloader.py
+++ b/avocado/core/safeloader.py
@@ -1,0 +1,60 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2014-2016
+# Authors: Cleber Rosa <crosa@redhat.com>
+
+"""
+Safe (AST based) test loader module utilities
+"""
+
+import ast
+
+
+def modules_imported_as(module):
+    """
+    Returns a mapping of imported module names wether using aliases or not
+
+    The goal of this utility function is to return the name of the import
+    as used in the rest of the module, wether an aliased import was used
+    or not.
+
+    For code such as:
+
+    >>> import foo as bar
+
+    This function should return {"foo": "bar"}
+
+    And for code such as:
+
+    >>> import foo
+
+    It should return {"foo": "foo"}
+
+    Please note that only global level imports are looked at. If there are
+    imports defined, say, inside functions or class definitions, they will
+    not be seen by this function.
+
+    :param module: module, as parsed by :func:`ast.parse`
+    :type module: :class:`_ast.Module`
+    :returns: a mapping of names {<realname>: <alias>} of modules imported
+    :rtype: dict
+    """
+    result = {}
+    for statement in module.body:
+        # Looking for a 'import <module>'
+        if isinstance(statement, ast.Import):
+            for name in statement.names:
+                if name.asname is not None:
+                    result[name.name] = name.asname
+                else:
+                    result[name.name] = name.name
+    return result

--- a/avocado/core/safeloader.py
+++ b/avocado/core/safeloader.py
@@ -17,6 +17,7 @@ Safe (AST based) test loader module utilities
 """
 
 import ast
+import re
 
 
 def modules_imported_as(module):
@@ -58,3 +59,41 @@ def modules_imported_as(module):
                 else:
                     result[name.name] = name.name
     return result
+
+
+#: Gets the tag value from a string. Used to tag a test class in various ways
+AVOCADO_DOCSTRING_TAG_RE = re.compile(r'\s*:avocado:\s*(\S+)\s*')
+
+
+def get_docstring_tag(docstring):
+    """
+    Returns the value of the avocado custom tag inside a docstring
+
+    :param docstring: the complete text used as documentation
+    :type docstring: str
+    """
+    if docstring is None:
+        return None
+    result = AVOCADO_DOCSTRING_TAG_RE.search(docstring)
+    if result is not None:
+        return result.groups()[0]
+
+
+def is_docstring_tag_enable(docstring):
+    """
+    Checks if there's an avocado tag that enables its class as a Test class
+
+    :rtype: bool
+    """
+    result = get_docstring_tag(docstring)
+    return result == 'enable'
+
+
+def is_docstring_tag_disable(docstring):
+    """
+    Checks if there's an avocado tag that disables its class as a Test class
+
+    :rtype: bool
+    """
+    result = get_docstring_tag(docstring)
+    return result == 'disable'

--- a/avocado/utils/data_structures.py
+++ b/avocado/utils/data_structures.py
@@ -24,6 +24,15 @@ avocado core code or plugins.
 import sys
 
 
+def ordered_list_unique(object_list):
+    """
+    Returns an unique list of objects, with their original order preserved
+    """
+    seen = set()
+    seen_add = seen.add
+    return [x for x in object_list if not (x in seen or seen_add(x))]
+
+
 class Borg:
 
     """

--- a/contrib/avocado-find-unittests
+++ b/contrib/avocado-find-unittests
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2016
+# Author: Cleber Rosa <cleber@redhat.com>
+
+#
+# Simple script that, given Python file containing unittests, returns the canonical
+# location of each test, each one on its own line. The idea is to be able
+# to filter the tests you want to run by doing something like:
+#
+# $ avocado run `avocado-find-unittests <path-to-test.py> | <your-condition> | xargs`
+#
+
+import os
+import re
+import sys
+
+from avocado.core.safeloader import find_class_and_methods
+
+if __name__ == '__main__':
+    test_module_paths = sys.argv[1:]
+    result = []
+    for test_module_path in test_module_paths:
+        try:
+            test_class_methods = find_class_and_methods(test_module_path,
+                                                        re.compile(r'test.*'))
+        except:
+            continue
+        for klass, methods in test_class_methods.items():
+            if test_module_path.endswith(".py"):
+                test_module_path = test_module_path[:-3]
+            test_module_name = os.path.relpath(test_module_path)
+            test_module_name = test_module_name.replace(os.path.sep, ".")
+            result += ["%s.%s.%s" % (test_module_name, klass, method)
+                       for method in methods]
+    if result:
+        print "\n".join(result)

--- a/selftests/checkall
+++ b/selftests/checkall
@@ -2,7 +2,7 @@
 GR=0
 run_rc() {
     echo "Running '$1'"
-    $1
+    eval $1
     if [ $? != 0 ]; then
         GR=1
     fi
@@ -15,5 +15,10 @@ run_rc 'inspekt style'
 echo ""
 run_rc 'selftests/modules_boundaries'
 echo ""
-run_rc 'selftests/run'
+if [ -z "$AVOCADO_SELF_CHECK" ]; then
+    run_rc selftests/run
+else
+    run_rc 'python setup.py develop --user'
+    run_rc 'scripts/avocado run `./contrib/avocado-find-unittests selftests/{unit,functional,doc}/*.py | xargs` --external-runner="/usr/bin/python -m unittest"'
+fi
 exit ${GR}

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -320,7 +320,8 @@ class OutputPluginTest(unittest.TestCase):
             self.assertEqual(result.exit_status, expected_rc,
                              "Avocado did not return rc %d:\n%s" %
                              (expected_rc, result))
-            assert output == '', 'After redirecting to file, output is not empty: %s' % output
+            self.assertEqual(output, '',
+                             'After redirecting to file, output is not empty: %s' % output)
             with open(redirected_output_path, 'r') as redirected_output_file_obj:
                 redirected_output = redirected_output_file_obj.read()
                 for code in TermSupport.ESCAPE_CODES:

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -310,32 +310,5 @@ class LoaderTest(unittest.TestCase):
         avocado_multiple_imp_test.remove()
 
 
-class DocstringTagTests(unittest.TestCase):
-
-    def test_longline(self):
-        docstring = ("This is a very long docstring in a single line. "
-                     "Since we have nothing useful to put in here let's just "
-                     "mention avocado: it's awesome, but that was not a tag. "
-                     "a tag would be something line this: :avocado: enable")
-        self.assertIsNotNone(loader.get_docstring_tag(docstring))
-
-    def test_newlines(self):
-        docstring = ("\n\n\nThis is a docstring with many new\n\nlines "
-                     "followed by an avocado tag\n"
-                     "\n\n:avocado: enable\n\n")
-        self.assertIsNotNone(loader.get_docstring_tag(docstring))
-
-    def test_enabled(self):
-        self.assertTrue(loader.is_docstring_tag_enable(":avocado: enable"))
-        self.assertTrue(loader.is_docstring_tag_enable(":avocado:\tenable"))
-        self.assertFalse(loader.is_docstring_tag_enable(":AVOCADO: ENABLE"))
-        self.assertFalse(loader.is_docstring_tag_enable(":avocado: enabled"))
-
-    def test_disabled(self):
-        self.assertTrue(loader.is_docstring_tag_disable(":avocado: disable"))
-        self.assertTrue(loader.is_docstring_tag_disable(":avocado:\tdisable"))
-        self.assertFalse(loader.is_docstring_tag_disable(":AVOCADO: DISABLE"))
-        self.assertFalse(loader.is_docstring_tag_disable(":avocado: disabled"))
-
 if __name__ == '__main__':
     unittest.main()

--- a/selftests/unit/test_safeloader.py
+++ b/selftests/unit/test_safeloader.py
@@ -1,0 +1,36 @@
+import ast
+import sys
+
+if sys.version_info[:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
+
+from avocado.core import safeloader
+from avocado.utils import script
+
+
+class ModuleImportedAs(unittest.TestCase):
+
+    def _test(self, content, result):
+        temp_script = script.TemporaryScript('temp.py', content,
+                                             'avocado_loader_unittest')
+        temp_script.save()
+        module = ast.parse(content, temp_script.path)
+        temp_script.remove()
+        self.assertEqual(result, safeloader.modules_imported_as(module))
+
+    def test_foo(self):
+        self._test('import foo', {'foo': 'foo'})
+
+    def test_foo_as_bar(self):
+        self._test('import foo as bar', {'foo': 'bar'})
+
+    def test_foo_as_foo(self):
+        self._test('import foo as foo', {'foo': 'foo'})
+
+    def test_import_inside_class(self):
+        self._test("class Foo(object): import foo as foo", {})
+
+if __name__ == '__main__':
+    unittest.main()

--- a/selftests/unit/test_safeloader.py
+++ b/selftests/unit/test_safeloader.py
@@ -32,5 +32,34 @@ class ModuleImportedAs(unittest.TestCase):
     def test_import_inside_class(self):
         self._test("class Foo(object): import foo as foo", {})
 
+
+class DocstringTag(unittest.TestCase):
+
+    def test_longline(self):
+        docstring = ("This is a very long docstring in a single line. "
+                     "Since we have nothing useful to put in here let's just "
+                     "mention avocado: it's awesome, but that was not a tag. "
+                     "a tag would be something line this: :avocado: enable")
+        self.assertIsNotNone(safeloader.get_docstring_tag(docstring))
+
+    def test_newlines(self):
+        docstring = ("\n\n\nThis is a docstring with many new\n\nlines "
+                     "followed by an avocado tag\n"
+                     "\n\n:avocado: enable\n\n")
+        self.assertIsNotNone(safeloader.get_docstring_tag(docstring))
+
+    def test_enabled(self):
+        self.assertTrue(safeloader.is_docstring_tag_enable(":avocado: enable"))
+        self.assertTrue(safeloader.is_docstring_tag_enable(":avocado:\tenable"))
+        self.assertFalse(safeloader.is_docstring_tag_enable(":AVOCADO: ENABLE"))
+        self.assertFalse(safeloader.is_docstring_tag_enable(":avocado: enabled"))
+
+    def test_disabled(self):
+        self.assertTrue(safeloader.is_docstring_tag_disable(":avocado: disable"))
+        self.assertTrue(safeloader.is_docstring_tag_disable(":avocado:\tdisable"))
+        self.assertFalse(safeloader.is_docstring_tag_disable(":AVOCADO: DISABLE"))
+        self.assertFalse(safeloader.is_docstring_tag_disable(":avocado: disabled"))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/selftests/unit/test_utils_linux_modules.py
+++ b/selftests/unit/test_utils_linux_modules.py
@@ -32,13 +32,11 @@ ip6table_filter        12815  1
         lsmod_info = linux_modules.parse_lsmod_for_module(
             self.LSMOD_OUT, "ebtables")
         submodules = ['ebtable_broute', 'ebtable_nat', 'ebtable_filter']
-        assert lsmod_info['submodules'] == submodules
-        assert lsmod_info == {
-            'name': "ebtables",
-            'size': 30758,
-            'used': 3,
-            'submodules': submodules
-        }
+        self.assertEqual(lsmod_info['submodules'], submodules)
+        self.assertEqual(lsmod_info, {'name': "ebtables",
+                                      'size': 30758,
+                                      'used': 3,
+                                      'submodules': submodules})
 
     def test_parse_lsmod_is_empty(self):
         lsmod_info = linux_modules.parse_lsmod_for_module("", "ebtables")
@@ -47,25 +45,21 @@ ip6table_filter        12815  1
     def test_parse_lsmod_no_submodules(self):
         lsmod_info = linux_modules.parse_lsmod_for_module(self.LSMOD_OUT, "ccm")
         submodules = []
-        assert lsmod_info['submodules'] == submodules
-        assert lsmod_info == {
-            'name': "ccm",
-            'size': 17773,
-            'used': 2,
-            'submodules': submodules
-        }
+        self.assertEqual(lsmod_info['submodules'], submodules)
+        self.assertEqual(lsmod_info, {'name': "ccm",
+                                      'size': 17773,
+                                      'used': 2,
+                                      'submodules': submodules})
 
     def test_parse_lsmod_single_submodules(self):
         lsmod_info = linux_modules.parse_lsmod_for_module(
             self.LSMOD_OUT, "bridge")
         submodules = ['ebtable_broute']
-        assert lsmod_info['submodules'] == submodules
-        assert lsmod_info == {
-            'name': "bridge",
-            'size': 110862,
-            'used': 1,
-            'submodules': submodules
-        }
+        self.assertEqual(lsmod_info['submodules'], submodules)
+        self.assertEqual(lsmod_info, {'name': "bridge",
+                                      'size': 110862,
+                                      'used': 1,
+                                      'submodules': submodules})
 
 
 if __name__ == '__main__':

--- a/selftests/unit/test_utils_linux_modules.py
+++ b/selftests/unit/test_utils_linux_modules.py
@@ -40,10 +40,9 @@ ip6table_filter        12815  1
             'submodules': submodules
         }
 
-    @staticmethod
-    def test_parse_lsmod_is_empty():
+    def test_parse_lsmod_is_empty(self):
         lsmod_info = linux_modules.parse_lsmod_for_module("", "ebtables")
-        assert lsmod_info == {}
+        self.assertEqual(lsmod_info, {})
 
     def test_parse_lsmod_no_submodules(self):
         lsmod_info = linux_modules.parse_lsmod_for_module(self.LSMOD_OUT, "ccm")


### PR DESCRIPTION
When the safe(r) test loader mechanism was introduced in the `avocado.core.loader` module, it was written specifically to address Avocado's own needs (that is, `avocado.Test` based test classes).

Now, we want to:

 * Allow the safe test loader to be optional, that is, allow the user to run `$ avocado list --unsafe` or similar
 * Increase the scope of tests that can be run by Avocado, and that includes standard Python unittests

The first step is to abstract and isolate the original safe loader code, which is done and this PR in the form of the  `avocado.core.safeloader` module. Then, as a PoC, we deliver a contrib script that makes use of this new module and finds unittests on Python source code files.

This brings us to an interesting situation, where, although not without flaws or limitations, Avocado can test itself, which was one of the original goals of the project. A sample session / command line would look like this:

```    
$ cd avocado/selftests/unit
$ avocado run `../../contrib/avocado-find-unittests *.py | xargs` --external-runner '/usr/bin/python -m unittest'
```

This has been put into a developer friendly target called `selfcheck`, so a developer can run:

```
$ make selfcheck
...
JOB ID     : 4eca6695394ff7741943c6713c1ac2529845c53d
JOB LOG    : /home/cleber/avocado/job-results/job-2016-02-15T05.44-4eca669/job.log
TESTS      : 293
 (1/293) selftests.unit.test_archive.ArchiveTest.test_zip_dir: PASS (0.17 s)
 (2/293) selftests.unit.test_archive.ArchiveTest.test_zip_file: PASS (0.18 s)
...
 (292/293) selftests.functional.test_wrapper.WrapperTest.test_both_wrappers: PASS (1.38 s)
 (293/293) selftests.doc.test_doc_build.DocBuildTest.test_build_docs: PASS (0.21 s)
RESULTS    : PASS 293 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0
JOB HTML   : /home/cleber/avocado/job-results/job-2016-02-15T05.44-4eca669/html/results.html
TIME       : 249.21 s
selftests/check_tmp_dirs
No temporary avocado dirs lying around in /tmp
```

---

Changes from v1:
   * Do not switch CI to use that approach as it's been shown to be problematic on the environment given by Travis

Changes from v0:
   * Contrib script module path handling suggestions by @ldoktor 
   * Unittest fixes
   * Addition of the Makefile selfcheck target
   * Changes to Travis CI configuration