### PR TITLE
[NOT_TO_BE_MERGED] avocado: Refactor logging initialization

### DIFF
--- a/avocado/core/app.py
+++ b/avocado/core/app.py
@@ -19,7 +19,7 @@ The core Avocado application.
 import os
 import signal
 
-from .log import configure as configure_log
+from . import log
 from .parser import Parser
 from .output import View
 from .settings import settings
@@ -38,20 +38,28 @@ class AvocadoApp(object):
         # Catch all libc runtime errors to STDERR
         os.environ['LIBC_FATAL_STDERR_'] = '1'
 
-        configure_log()
         signal.signal(signal.SIGTSTP, signal.SIG_IGN)   # ignore ctrl+z
         self.parser = Parser()
-        self.cli_dispatcher = CLIDispatcher()
-        self.cli_cmd_dispatcher = CLICmdDispatcher()
-        self._print_plugin_failures()
-        self.parser.start()
-        if self.cli_cmd_dispatcher.extensions:
-            self.cli_cmd_dispatcher.map_method('configure', self.parser)
-        if self.cli_dispatcher.extensions:
-            self.cli_dispatcher.map_method('configure', self.parser)
-        self.parser.finish()
-        if self.cli_dispatcher.extensions:
-            self.cli_dispatcher.map_method('run', self.parser.args)
+        log.early_start()
+        initialized = False
+        try:
+            self.cli_dispatcher = CLIDispatcher()
+            self.cli_cmd_dispatcher = CLICmdDispatcher()
+            self._print_plugin_failures()
+            self.parser.start()
+            if self.cli_cmd_dispatcher.extensions:
+                self.cli_cmd_dispatcher.map_method('configure', self.parser)
+            if self.cli_dispatcher.extensions:
+                self.cli_dispatcher.map_method('configure', self.parser)
+            self.parser.finish()
+            initialized = True
+            if self.cli_dispatcher.extensions:
+                self.cli_dispatcher.map_method('run', self.parser.args)
+        finally:
+            if not initialized:
+                log.enable_stderr()
+                self.parser.args = ["app"]
+            log.reconfigure(self.parser.args)
 
     def _print_plugin_failures(self):
         failures = (self.cli_dispatcher.load_failures +

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -108,20 +108,6 @@ class Job(object):
             self.loglevel = mapping[raw_log_level]
         else:
             self.loglevel = logging.DEBUG
-        self.show_job_log = getattr(self.args, 'show_job_log', False)
-        self.silent = getattr(self.args, 'silent', False)
-
-        if self.standalone:
-            self.show_job_log = True
-            if self.args is not None:
-                setattr(self.args, 'show_job_log', True)
-
-        if self.show_job_log:
-            if not self.silent:
-                output.add_log_handler(_TEST_LOGGER.name, level=logging.DEBUG)
-                output.add_log_handler('', level=logging.DEBUG)
-                _TEST_LOGGER.setLevel(self.loglevel)
-                _TEST_LOGGER.propagate = False
 
         self.test_dir = data_dir.get_test_dir()
         self.test_index = 1

--- a/avocado/core/log.py
+++ b/avocado/core/log.py
@@ -13,125 +13,120 @@
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
 
-__all__ = ['configure', 'DEFAULT_LOGGING']
-
-
+from StringIO import StringIO
 import logging
 import os
+import sys
+
+from . import output
+
+
+__all__ = ["early_start", "enable_stderr", "reconfigure"]
+
 
 if hasattr(logging, 'NullHandler'):
-    NULL_HANDLER = 'logging.NullHandler'
+    NULL_HANDLER = logging.NullHandler
 else:
-    NULL_HANDLER = 'logutils.NullHandler'
-
-DEFAULT_LOGGING = {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'formatters': {
-        'brief': {
-            'format': '%(message)s',
-        },
-    },
-    'filters': {
-        'error': {
-            '()': 'avocado.core.output.FilterError',
-        },
-        'info': {
-            '()': 'avocado.core.output.FilterInfo',
-        },
-    },
-    'handlers': {
-        'null': {
-            'level': 'INFO',
-            'class': NULL_HANDLER,
-        },
-        'console': {
-            'level': 'INFO',
-            'class': 'logging.StreamHandler',
-            'formatter': 'brief',
-        },
-        'app': {
-            'level': 'INFO',
-            'class': 'avocado.core.output.ProgressStreamHandler',
-            'formatter': 'brief',
-            'filters': ['info'],
-            'stream': 'ext://sys.stdout',
-        },
-        'error': {
-            'level': 'ERROR',
-            'class': 'logging.StreamHandler',
-            'formatter': 'brief',
-            'filters': ['error'],
-        },
-        'debug': {
-            'level': 'DEBUG',
-            'class': 'avocado.core.output.ProgressStreamHandler',
-            'formatter': 'brief',
-            'stream': 'ext://sys.stdout',
-        },
-    },
-    'loggers': {
-        '': {
-            'handlers': ['null']
-        },
-        'avocado': {
-            'handlers': ['console'],
-        },
-        'avocado.app': {
-            'handlers': ['app', 'error'],
-            'level': 'INFO',
-            'propagate': False,
-        },
-        'avocado.app.tracebacks': {
-            # Set DEBUG=true to enable debugs
-            'handlers': ['error' if os.environ.get('DEBUG') else 'null'],
-            'level': 'ERROR',
-            'propagate': False,
-        },
-        'avocado.test': {
-            'handlers': ['null'],
-            'level': 'DEBUG',
-            'propagate': False,
-        },
-        'avocado.fabric': {
-            'handlers': ['null'],
-            'level': 'DEBUG',
-            'propagate': False,
-        },
-        'paramiko': {
-            'handlers': ['null'],
-            'level': 'DEBUG',
-            'propagate': False,
-        },
-        'avocado.test.stdout': {
-            'handlers': ['null'],
-            'level': 'DEBUG',
-            'propagate': False,
-        },
-        'avocado.test.stderr': {
-            'handlers': ['null'],
-            'level': 'DEBUG',
-            'propagate': False,
-        },
-        'avocado.sysinfo': {
-            'handlers': ['error'],
-            'level': 'DEBUG',
-            'propagate': False,
-        },
-        'avocado.debug': {
-            'handlers': ['debug'],
-            'level': 'DEBUG',
-            'propagate': False,
-        },
-    }
-}
+    import logutils
+    NULL_HANDLER = logutils.NullHandler
 
 
-def configure(logging_config=DEFAULT_LOGGING):
-    from logging import config
-    if not hasattr(config, 'dictConfig'):
-        from logutils import dictconfig
-        cfg_func = dictconfig.dictConfig
+STDOUT = sys.stdout
+STDERR = sys.stderr
+
+
+def early_start():
+    """
+    Replace all outputs with in-memory handlers
+    """
+    if os.environ.get('AVOCADO_LOG_DEBUG'):
+        output.add_log_handler("avocado.app.debug", None, STDERR,
+                               logging.DEBUG)
+    if os.environ.get('AVOCADO_LOG_EARLY'):
+        output.add_log_handler("", None, STDERR, logging.DEBUG)
+        output.add_log_handler("avocado.test", None, STDERR, logging.DEBUG)
     else:
-        cfg_func = config.dictConfig
-    cfg_func(logging_config)
+        sys.stdout = StringIO()
+        sys.stderr = sys.stdout
+        output.add_log_handler("", output.MemStreamHandler, None,
+                               logging.DEBUG)
+    logging.root.level = logging.DEBUG
+
+
+def enable_stderr():
+    """
+    Enable direct stdout/stderr (useful for handling errors)
+    """
+    if hasattr(sys.stdout, 'getvalue'):
+        STDERR.write(sys.stdout.getvalue())
+    sys.stdout = STDOUT
+    sys.stderr = STDERR
+
+
+def reconfigure(args):
+    """
+    Adjust logging handlers accordingly to app args and re-log messages.
+    """
+    # Reconfigure stream loggers
+    enabled = getattr(args, "log", ["app,early,debug"])
+    if os.environ.get("AVOCADO_LOG_EARLY") and "early" not in enabled:
+        enabled.append("early")
+    if os.environ.get("AVOCADO_LOG_DEBUG") and "debug" not in enabled:
+        enabled.append("debug")
+    if getattr(args, "show_job_log", False) and "test" not in enabled:
+        enabled.append("test")
+    if getattr(args, "silent", False):
+        del enabled[:]
+    if "app" in enabled:
+        app_logger = logging.getLogger("avocado.app")
+        app_handler = output.ProgressStreamHandler()
+        app_handler.setFormatter(logging.Formatter("%(message)s"))
+        app_handler.addFilter(output.FilterInfo())
+        app_handler.stream = STDOUT
+        app_logger.addHandler(app_handler)
+        app_logger.propagate = False
+        app_logger.level = logging.INFO
+        app_err_handler = output.logging.StreamHandler()
+        app_err_handler.setFormatter(logging.Formatter("%(message)s"))
+        app_err_handler.addFilter(output.FilterError())
+        app_err_handler.stream = STDERR
+        app_logger.addHandler(app_err_handler)
+        app_logger.propagate = False
+    else:
+        output.disable_log_handler("avocado.app")
+    if not os.environ.get("AVOCADO_LOG_EARLY"):
+        logging.getLogger("avocado.test.stdout").propagate = False
+        logging.getLogger("avocado.test.stderr").propagate = False
+        if "early" in enabled:
+            enable_stderr()
+            output.add_log_handler("", None, STDERR, logging.DEBUG)
+            output.add_log_handler("avocado.test", None, STDERR,
+                                   logging.DEBUG)
+        else:
+            # FIXME: When log and output are merged, to this in
+            # start_job_logging
+            # Don't relog old messages!
+            sys.stdout = STDOUT
+            sys.stderr = STDERR
+            output.disable_log_handler("")
+            output.disable_log_handler("avocado.test")
+    if "remote" in enabled:
+        output.add_log_handler("avocado.fabric", stream=STDERR)
+        output.add_log_handler("paramiko", stream=STDERR)
+    else:
+        output.disable_log_handler("avocado.fabric")
+        output.disable_log_handler("paramiko")
+    if not os.environ.get('AVOCADO_LOG_DEBUG'):     # Not already enabled by env
+        if "debug" in enabled:
+            output.add_log_handler("avocado.app.debug", stream=STDERR)
+        else:
+            output.disable_log_handler("avocado.app.debug")
+
+    # Remove the in-memory handlers
+    for handler in logging.root.handlers:
+        if isinstance(handler, output.MemStreamHandler):
+            logging.root.handlers.remove(handler)
+
+    # Log early_messages
+    for record in output.MemStreamHandler.log:
+        logging.getLogger(record.name).handle(record)

--- a/avocado/core/parser.py
+++ b/avocado/core/parser.py
@@ -29,6 +29,28 @@ PROG = 'avocado'
 DESCRIPTION = 'Avocado Test Runner'
 
 
+def log_type(value):
+    valid_streams = ["app", "test", "debug", "remote", "early", "all", "none"]
+    value = value.split(',')
+    if any(_ not in valid_streams for _ in value):
+        missing = [_ for _ in value if _ not in valid_streams]
+        sys.stderr.write("Invalid logging stream(s): %s\nSupported logging "
+                         "streams are:\n app - application output\n "
+                         "test - test output\n debug - tracebacks and other "
+                         "debugging info\n remote - fabric/paramiko debug\n "
+                         "early - early logging of other streams (very "
+                         "verbose)\n all - everything\n none - disable "
+                         "everything\n" % ", ".join(missing))
+        sys.exit(-1)
+
+    if 'all' in value:
+        return ["app", "test", "debug", "remote", "early"]
+    elif 'none' in value:
+        return []
+    else:
+        return value
+
+
 class ArgumentParser(argparse.ArgumentParser):
 
     """
@@ -57,6 +79,12 @@ class Parser(object):
                                       version='Avocado %s' % VERSION)
         self.application.add_argument('--config', metavar='CONFIG_FILE',
                                       help='Use custom configuration from a file')
+        self.application.add_argument('--log', action="store",
+                                      type=log_type,
+                                      metavar='STREAMS', default=['app'],
+                                      help="Comma separated list of logging "
+                                      "streams to be enabled (app,test,debug,"
+                                      "remote,early); By default 'app'")
 
     def start(self):
         """

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -355,11 +355,11 @@ class RunnerHumanOutputTest(unittest.TestCase):
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %s:\n%s" %
                          (expected_rc, result))
-        self.assertIn('[stdout] foo', result.stdout, result)
-        self.assertIn('[stdout] \'"', result.stdout, result)
-        self.assertIn('[stdout] bar/baz', result.stdout, result)
+        self.assertIn('[stdout] foo', result.stderr, result)
+        self.assertIn('[stdout] \'"', result.stderr, result)
+        self.assertIn('[stdout] bar/baz', result.stderr, result)
         self.assertIn('PASS /bin/echo -ne foo\\\\n\\\'\\"\\\\nbar/baz',
-                      result.stdout, result)
+                      result.stderr, result)
         # logdir name should escape special chars (/)
         test_dirs = glob.glob(os.path.join(self.tmpdir, 'latest',
                                            'test-results', '*'))
@@ -464,12 +464,12 @@ class RunnerSimpleTest(unittest.TestCase):
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %s:\n%s" %
                          (expected_rc, result))
-        self.assertIn('DEBUG| Debug message', result.stdout, result)
-        self.assertIn('INFO | Info message', result.stdout, result)
+        self.assertIn('DEBUG| Debug message', result.stderr, result)
+        self.assertIn('INFO | Info message', result.stderr, result)
         self.assertIn('WARN | Warning message (should cause this test to '
-                      'finish with warning)', result.stdout, result)
+                      'finish with warning)', result.stderr, result)
         self.assertIn('ERROR| Error message (ordinary message not changing '
-                      'the results)', result.stdout, result)
+                      'the results)', result.stderr, result)
 
     def test_non_absolute_path(self):
         avocado_path = os.path.join(basedir, 'scripts', 'avocado')

--- a/selftests/functional/test_multiplex.py
+++ b/selftests/functional/test_multiplex.py
@@ -106,15 +106,15 @@ class MultiplexTests(unittest.TestCase):
 
             msg_lines = msg.splitlines()
             msg_header = '[stdout] Custom variable: %s' % msg_lines[0]
-            self.assertIn(msg_header, result.stdout,
+            self.assertIn(msg_header, result.stderr,
                           "Multiplexed variable should produce:"
                           "\n  %s\nwhich is not present in the output:\n  %s"
-                          % (msg_header, "\n  ".join(result.stdout.splitlines())))
+                          % (msg_header, "\n  ".join(result.stderr.splitlines())))
             for msg_remain in msg_lines[1:]:
-                self.assertIn('[stdout] %s' % msg_remain, result.stdout,
+                self.assertIn('[stdout] %s' % msg_remain, result.stderr,
                               "Multiplexed variable should produce:"
                               "\n  %s\nwhich is not present in the output:\n  %s"
-                              % (msg_remain, "\n  ".join(result.stdout.splitlines())))
+                              % (msg_remain, "\n  ".join(result.stderr.splitlines())))
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir)

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -205,10 +205,10 @@ class OutputPluginTest(unittest.TestCase):
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %d:\n%s" %
                          (expected_rc, result))
-        job_id_list = re.findall('Job ID: (.*)', result.stdout,
+        job_id_list = re.findall('Job ID: (.*)', result.stderr,
                                  re.MULTILINE)
-        self.assertTrue(job_id_list, 'No Job ID in stdout:\n%s' %
-                        result.stdout)
+        self.assertTrue(job_id_list, 'No Job ID in stderr:\n%s' %
+                        result.stderr)
         job_id = job_id_list[0]
         self.assertEqual(len(job_id), 40)
 


### PR DESCRIPTION
This patch changes the way logging is initialized in avocado app:

1. stdout/stderr/logging is replaced with in-memory handlers
2. when arg parsing is done, logging is reconfigured accordingly to
   setting and re-logs stored messages (when streams are enabled)
3. when job starts and "test" stream is enabled, "" and "avocado.test"
   streams are enabled
4. when job finishes and "test" stream enabled the additional outputs,
   the additional outputs are disabled again.

The 3 and 4 is necessarily as the "" logger contains all logs including
avocado initialization (stevedore, PIL, ...). This way the "test" stream
still outputs everything, but only during the job-execution and not
during avocado initialization and cleanup. (one can use "early" log to
see those).

This patch keeps the old means to enable logs (--show-job-log, --silent),
but it also adds "--log STREAMS" argument, which should be used instead.
Note that "--show-job-log" keeps the enabled streams so now you get booth
"avocado.app" and "avocado.test" in the output. While testing this seemed
easier to follow as "avocado.app" output is quite short.

Last but not least it keeps "avocado.app" output in stdout (and stderr),
but it moves all other outputs to stderr instead. This is IMO better
handling as one can distinguish between debug and "additional" output.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>