### PR TITLE
avocado: Refactor logging initialization [7]

### DIFF
--- a/avocado/core/app.py
+++ b/avocado/core/app.py
@@ -11,19 +11,19 @@
 #
 # Copyright: Red Hat Inc. 2013-2014
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
-
 """
 The core Avocado application.
 """
 
+import logging
 import os
 import signal
 
-from .parser import Parser
 from . import output
-from .settings import settings
-from .dispatcher import CLIDispatcher
 from .dispatcher import CLICmdDispatcher
+from .dispatcher import CLIDispatcher
+from .parser import Parser
+from .settings import settings
 
 
 class AvocadoApp(object):
@@ -51,21 +51,20 @@ class AvocadoApp(object):
             if self.cli_dispatcher.extensions:
                 self.cli_dispatcher.map_method('configure', self.parser)
             self.parser.finish()
+            initialized = True
             if self.cli_dispatcher.extensions:
                 self.cli_dispatcher.map_method('run', self.parser.args)
-            initialized = True
         finally:
-            if (not initialized and
-                    getattr(self.parser.args, "silent", False) is False):
+            if not initialized:
                 output.enable_stderr()
-                self.parser.args.log = ["app"]
+                self.parser.args.show = ["app"]
             output.reconfigure(self.parser.args)
 
     def _print_plugin_failures(self):
         failures = (self.cli_dispatcher.load_failures +
                     self.cli_cmd_dispatcher.load_failures)
         if failures:
-            view = output.View(self.parser.args)
+            log = logging.getLogger("avocado.app")
             msg_fmt = 'Failed to load plugin from module "%s": %s'
             silenced = settings.get_value('plugins',
                                           'skip_broken_plugin_notification',
@@ -73,14 +72,19 @@ class AvocadoApp(object):
             for failure in failures:
                 if failure[0].module_name in silenced:
                     continue
-                msg = msg_fmt % (failure[0].module_name,
-                                 failure[1].__repr__())
-                view.notify(event='error', msg=msg)
+                log.error(msg_fmt, failure[0].module_name,
+                          failure[1].__repr__())
 
     def run(self):
         try:
-            extension = self.cli_cmd_dispatcher[self.parser.args.subcommand]
-        except KeyError:
-            return
-        method = extension.obj.run
-        return method(self.parser.args)
+            try:
+                subcmd = self.parser.args.subcommand
+                extension = self.cli_cmd_dispatcher[subcmd]
+            except KeyError:
+                return
+            method = extension.obj.run
+            return method(self.parser.args)
+        finally:
+            # XXX: This makes sure we cleanup the console (stty echo). The only
+            # way to avoid cleaning it is to kill the less (paginator) directly
+            output.stop_logging()

--- a/avocado/core/html.py
+++ b/avocado/core/html.py
@@ -14,20 +14,21 @@
 """
 HTML output module.
 """
+
 import codecs
+import logging
 import os
 import shutil
+import subprocess
 import sys
 import time
-import subprocess
 import urllib
 
 import pystache
 
-from . import output
-from .result import TestResult
 from ..utils import path as utils_path
 from ..utils import runtime
+from .result import TestResult
 
 
 def check_resource_requirements():
@@ -188,12 +189,26 @@ class HTMLTestResult(TestResult):
     """
 
     command_line_arg_name = '--html'
+    compatible_output_plugins = ["--remote-hostname", "--vm-domain"]
 
-    def __init__(self, stream=None, args=None):
-        TestResult.__init__(self, stream, args)
-        self.output = getattr(self.args, 'html_output')
-        self.args = args
-        self.view = output.View(app_args=args)
+    def __init__(self, job, force_html_file=None, stdout_cmd=None):
+        """
+        :param job: Job which defines this result
+        :param force_html_file: Override the output html file location
+        :param stdout_cmd: List of enabled options that produce stdout
+        """
+        TestResult.__init__(self, job)
+        if force_html_file:
+            self.output = force_html_file
+        else:
+            self.output = self.args.html_output
+        self.log = logging.getLogger("avocado.app")
+        # TODO: Find out how to avoid the R0102 on next line
+        if stdout_cmd is None or [_ for _ in stdout_cmd
+                                  if _ in self.compatible_output_plugins]:
+            self.enable_output = True
+        else:
+            self.enable_output = False
         self.json = None
 
     def start_tests(self):
@@ -201,7 +216,7 @@ class HTMLTestResult(TestResult):
         Called once before any tests are executed.
         """
         TestResult.start_tests(self)
-        self.json = {'debuglog': self.stream.logfile,
+        self.json = {'debuglog': self.logfile,
                      'job_id': runtime.CURRENT_JOB.unique_id,
                      'tests': []}
 
@@ -244,6 +259,8 @@ class HTMLTestResult(TestResult):
             'time': self.total_time
         })
         self._render_report()
+        if self.enable_output:
+            self.log.info("JOB HTML   : %s", self.output)
 
     def _render_report(self):
         context = ReportModel(json_input=self.json, html_output=self.output)
@@ -288,7 +305,7 @@ class HTMLTestResult(TestResult):
             report_file.write(report_contents)
 
         if self.args is not None:
-            if getattr(self.args, 'open_browser'):
+            if getattr(self.args, 'open_browser', False):
                 # if possible, put browser in separate process group, so
                 # keyboard interrupts don't affect browser as well as Python
                 setsid = getattr(os, 'setsid', None)

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -83,6 +83,7 @@ class Job(object):
             args = argparse.Namespace()
         self.args = args
         self.urls = getattr(args, "url", [])
+        self.log = logging.getLogger("avocado.app")
         self.standalone = getattr(self.args, 'standalone', False)
         if getattr(self.args, "dry_run", False):  # Modify args for dry-run
             if not self.args.unique_job_id:
@@ -95,7 +96,6 @@ class Job(object):
         if unique_id is None:
             unique_id = job_id.create_unique_job_id()
         self.unique_id = unique_id
-        self.view = output.View(app_args=self.args)
         self.logdir = None
         raw_log_level = settings.get_value('job.output', 'loglevel',
                                            default='debug')
@@ -115,9 +115,12 @@ class Job(object):
         self.result_proxy = result.TestResultProxy()
         self.sysinfo = None
         self.timeout = getattr(self.args, 'job_timeout', 0)
+        self.__logging_file_handler = None
+        self.__logging_stream_handler = None
         self.funcatexit = data_structures.CallbackRegister("JobExit %s"
                                                            % self.unique_id,
                                                            _TEST_LOGGER)
+        self.stdout_stderr = None
         self.replay_sourcejob = getattr(self.args, 'replay_sourcejob', None)
 
     def _setup_job_results(self):
@@ -140,6 +143,47 @@ class Job(object):
         self.idfile = os.path.join(self.logdir, "id")
         with open(self.idfile, 'w') as id_file_obj:
             id_file_obj.write("%s\n" % self.unique_id)
+
+    def __start_job_logging(self):
+        # Enable file loggers
+        self.__logging_file_handler = logging.FileHandler(filename=self.logfile)
+        self.__logging_file_handler.setLevel(self.loglevel)
+
+        fmt = ('%(asctime)s %(module)-16.16s L%(lineno)-.4d %('
+               'levelname)-5.5s| %(message)s')
+        formatter = logging.Formatter(fmt=fmt, datefmt='%H:%M:%S')
+
+        self.__logging_file_handler.setFormatter(formatter)
+        test_logger = logging.getLogger('avocado.test')
+        test_logger.addHandler(self.__logging_file_handler)
+        test_logger.setLevel(self.loglevel)
+        root_logger = logging.getLogger()
+        root_logger.addHandler(self.__logging_file_handler)
+        root_logger.setLevel(self.loglevel)
+        # Enable console loggers
+        enabled_logs = getattr(self.args, "show", [])
+        if ('test' in enabled_logs and
+                'early' not in enabled_logs):
+            self.stdout_stderr = sys.stdout, sys.stderr
+            sys.stdout = output.STDOUT
+            sys.stderr = output.STDERR
+            self.__logging_stream_handler = logging.StreamHandler()
+            test_logger.addHandler(self.__logging_stream_handler)
+            root_logger.addHandler(self.__logging_stream_handler)
+
+    def __stop_job_logging(self):
+        if self.stdout_stderr:
+            sys.stdout, sys.stderr = self.stdout_stderr
+        test_logger = logging.getLogger('avocado.test')
+        root_logger = logging.getLogger()
+        if self.__logging_file_handler:
+            test_logger.removeHandler(self.__logging_file_handler)
+            root_logger.removeHandler(self.__logging_file_handler)
+            self.__logging_file_handler.close()
+        # Console loggers
+        if self.__logging_stream_handler:
+            test_logger.removeHandler(self.__logging_stream_handler)
+            root_logger.removeHandler(self.__logging_stream_handler)
 
     def _update_latest_link(self):
         """
@@ -167,7 +211,7 @@ class Job(object):
 
     def _make_test_runner(self):
         if hasattr(self.args, 'test_runner'):
-            test_runner_class = self.args.test_runner
+            test_runner_class = self.args.test_runner   # pylint: disable=E1101
         else:
             test_runner_class = runner.TestRunner
 
@@ -177,7 +221,7 @@ class Job(object):
     def _set_output_plugins(self):
         if getattr(self.args, 'test_result_classes', None) is not None:
             for klass in self.args.test_result_classes:
-                test_result_instance = klass(self.view, self.args)
+                test_result_instance = klass(self)
                 self.result_proxy.add_output_plugin(test_result_instance)
 
     def _make_test_result(self):
@@ -198,40 +242,30 @@ class Job(object):
 
         # Setup the xunit plugin to output to the debug directory
         xunit_file = os.path.join(self.logdir, 'results.xml')
-        args = argparse.Namespace()
-        args.xunit_output = xunit_file
-        xunit_plugin = xunit.xUnitTestResult(self.view, args)
+        xunit_plugin = xunit.xUnitTestResult(self, xunit_file)
         self.result_proxy.add_output_plugin(xunit_plugin)
 
         # Setup the json plugin to output to the debug directory
         json_file = os.path.join(self.logdir, 'results.json')
-        args = argparse.Namespace()
-        args.json_output = json_file
-        json_plugin = jsonresult.JSONTestResult(self.view, args)
+        json_plugin = jsonresult.JSONTestResult(self, json_file)
         self.result_proxy.add_output_plugin(json_plugin)
+
+        op_set_stdout = self.result_proxy.output_plugins_using_stdout()
+        if len(op_set_stdout) > 1:
+            self.log.error("Options %s are trying to use stdout "
+                           "simultaneously", " ".join(op_set_stdout))
+            self.log.error("Please set at least one of them to a file to avoid"
+                           " conflicts")
+            sys.exit(exit_codes.AVOCADO_JOB_FAIL)
 
         # Setup the html output to the results directory
         if HTML_REPORT_SUPPORT:
             html_file = os.path.join(self.logdir, 'html', 'results.html')
-            args = argparse.Namespace()
-            args.html_output = html_file
-            args.open_browser = getattr(self.args, 'open_browser', False)
-            args.relative_links = True
-            html_plugin = html.HTMLTestResult(self.view, args)
+            html_plugin = html.HTMLTestResult(self, html_file, op_set_stdout)
             self.result_proxy.add_output_plugin(html_plugin)
 
-        op_set_stdout = self.result_proxy.output_plugins_using_stdout()
-        if len(op_set_stdout) > 1:
-            msg = ('Options %s are trying to use stdout simultaneously' %
-                   " ".join(op_set_stdout))
-            self.view.notify(event='error', msg=msg)
-            msg = ('Please set at least one of them to a file to avoid '
-                   'conflicts')
-            self.view.notify(event='error', msg=msg)
-            sys.exit(exit_codes.AVOCADO_JOB_FAIL)
-
         if not op_set_stdout and not self.standalone:
-            human_plugin = result.HumanTestResult(self.view, self.args)
+            human_plugin = result.HumanTestResult(self)
             self.result_proxy.add_output_plugin(human_plugin)
 
     def _make_test_suite(self, urls=None):
@@ -391,10 +425,8 @@ class Job(object):
                 that configure a job failure.
         """
         self._setup_job_results()
-        self.view.start_job_logging(self.logfile,
-                                    self.loglevel,
-                                    self.unique_id,
-                                    self.replay_sourcejob)
+        self.__start_job_logging()
+
         try:
             test_suite = self._make_test_suite(self.urls)
         except loader.LoaderError as details:
@@ -425,13 +457,11 @@ class Job(object):
 
         self._log_job_debug_info(mux)
         replay.record(self.args, self.logdir, mux, self.urls)
-
-        self.view.logfile = self.logfile
         replay_map = getattr(self.args, 'replay_map', None)
         failures = self.test_runner.run_suite(test_suite, mux,
                                               timeout=self.timeout,
                                               replay_map=replay_map)
-        self.view.stop_job_logging()
+        self.__stop_job_logging()
         # If it's all good so far, set job status to 'PASS'
         if self.status == 'RUNNING':
             self.status = 'PASS'
@@ -472,28 +502,24 @@ class Job(object):
         except exceptions.JobBaseException as details:
             self.status = details.status
             fail_class = details.__class__.__name__
-            self.view.notify(event='error', msg=('\nAvocado job failed: %s: %s'
-                                                 % (fail_class, details)))
+            self.log.error('\nAvocado job failed: %s: %s', fail_class, details)
             return exit_codes.AVOCADO_JOB_FAIL
         except exceptions.OptionValidationError as details:
-            self.view.notify(event='error', msg='\n' + str(details))
+            self.log.error('\n' + str(details))
             return exit_codes.AVOCADO_JOB_FAIL
 
-        except Exception as details:
+        except Exception, details:
             self.status = "ERROR"
             exc_type, exc_value, exc_traceback = sys.exc_info()
             tb_info = traceback.format_exception(exc_type, exc_value,
                                                  exc_traceback.tb_next)
             fail_class = details.__class__.__name__
-            self.view.notify(event='error', msg=('\nAvocado crashed: %s: %s' %
-                                                 (fail_class, details)))
+            self.log.error('\nAvocado crashed: %s: %s', fail_class, details)
             for line in tb_info:
-                self.view.notify(event='minor', msg=line)
-            self.view.notify(event='error', msg=('Please include the traceback '
-                                                 'info and command line used on '
-                                                 'your bug report'))
-            self.view.notify(event='error', msg=('Report bugs visiting %s' %
-                                                 _NEW_ISSUE_LINK))
+                self.log.debug(line)
+            self.log.error("Please include the traceback info and command line"
+                           " used on your bug report")
+            self.log.error('Report bugs visiting %s', _NEW_ISSUE_LINK)
             return exit_codes.AVOCADO_FAIL
         finally:
             if not settings.get_value('runner.behavior', 'keep_tmp_files',
@@ -536,7 +562,7 @@ class TestProgram(object):
 
     def runTests(self):
         self.args.standalone = True
-        self.args.log = ["test"]
+        self.args.show = ["test"]
         output.reconfigure(self.args)
         self.job = Job(self.args)
         exit_status = self.job.run()

--- a/avocado/core/jsonresult.py
+++ b/avocado/core/jsonresult.py
@@ -11,14 +11,13 @@
 #
 # Copyright: Red Hat Inc. 2014
 # Author: Ruda Moura <rmoura@redhat.com>
-
 """
 JSON output module.
 """
 
 import json
+import logging
 
-from . import output
 from .result import TestResult
 
 
@@ -30,17 +29,21 @@ class JSONTestResult(TestResult):
 
     command_line_arg_name = '--json'
 
-    def __init__(self, stream=None, args=None):
-        TestResult.__init__(self, stream, args)
-        self.output = getattr(self.args, 'json_output', '-')
-        self.view = output.View(app_args=args)
+    def __init__(self, job, force_json_file=None):
+        TestResult.__init__(self, job)
+        if force_json_file:
+            self.output = force_json_file
+        else:
+            self.output = getattr(self.args, 'json_output', '-')
+        self.json = None
+        self.log = logging.getLogger("avocado.app")
 
     def start_tests(self):
         """
         Called once before any tests are executed.
         """
         TestResult.start_tests(self)
-        self.json = {'debuglog': self.stream.logfile,
+        self.json = {'debuglog': self.logfile,
                      'tests': []}
 
     def end_test(self, state):
@@ -67,7 +70,7 @@ class JSONTestResult(TestResult):
         self.json['tests'].append(t)
 
     def _save_json(self):
-        with open(self.args.json_output, 'w') as j:
+        with open(self.output, 'w') as j:
             j.write(self.json)
 
     def end_tests(self):
@@ -84,7 +87,7 @@ class JSONTestResult(TestResult):
             'time': self.total_time
         })
         self.json = json.dumps(self.json)
-        if self.args.json_output == '-':
-            self.view.notify(event='minor', msg=self.json)
+        if self.output == '-':
+            self.log.debug(self.json)
         else:
             self._save_json()

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -88,7 +88,11 @@ def reconfigure(args):
         del enabled[:]
         enabled.append("test")
     if getattr(args, "silent", False):
+        sys.stdout = open(os.devnull, 'w')
+        sys.stderr = sys.stdout
+        logging.disable(logging.CRITICAL)
         del enabled[:]
+        return
     if "app" in enabled:
         app_logger = logging.getLogger("avocado.app")
         app_handler = ProgressStreamHandler()

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -15,7 +15,6 @@
 """
 Manages output and logging in avocado applications.
 """
-from StringIO import StringIO
 import logging
 import os
 import sys
@@ -23,6 +22,10 @@ import sys
 from ..utils import path as utils_path
 from .settings import settings
 
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 if hasattr(logging, 'NullHandler'):
     NULL_HANDLER = logging.NullHandler
@@ -31,8 +34,8 @@ else:
     NULL_HANDLER = logutils.NullHandler
 
 
-STDOUT = sys.stdout
-STDERR = sys.stderr
+STDOUT = _STDOUT = sys.stdout
+STDERR = _STDERR = sys.stderr
 
 
 def early_start():
@@ -58,7 +61,7 @@ def enable_stderr():
     Enable direct stdout/stderr (useful for handling errors)
     """
     if hasattr(sys.stdout, 'getvalue'):
-        STDERR.write(sys.stdout.getvalue())
+        STDERR.write(sys.stdout.getvalue())  # pylint: disable=E1101
     sys.stdout = STDOUT
     sys.stderr = STDERR
 
@@ -68,31 +71,36 @@ def reconfigure(args):
     Adjust logging handlers accordingly to app args and re-log messages.
     """
     # Reconfigure stream loggers
-    enabled = getattr(args, "log", ["app", "early", "debug"])
+    global STDOUT
+    global STDERR
+    if getattr(args, "paginator", False) == "on" and is_colored_term():
+        STDOUT = Paginator()
+        STDERR = STDOUT
+    enabled = getattr(args, "show", None)
+    if not isinstance(enabled, list):
+        enabled = ["app"]
+        args.show = enabled
     if os.environ.get("AVOCADO_LOG_EARLY") and "early" not in enabled:
-        args.log.append("early")
         enabled.append("early")
     if os.environ.get("AVOCADO_LOG_DEBUG") and "debug" not in enabled:
-        args.log.append("debug")
         enabled.append("debug")
     if getattr(args, "show_job_log", False):
-        args.log = ["test"]
-        enabled = ["test"]
+        del enabled[:]
+        enabled.append("test")
     if getattr(args, "silent", False):
-        del args.log[:]
         del enabled[:]
     if "app" in enabled:
         app_logger = logging.getLogger("avocado.app")
         app_handler = ProgressStreamHandler()
         app_handler.setFormatter(logging.Formatter("%(message)s"))
-        app_handler.addFilter(FilterInfo())
+        app_handler.addFilter(FilterInfoAndLess())
         app_handler.stream = STDOUT
         app_logger.addHandler(app_handler)
         app_logger.propagate = False
-        app_logger.level = logging.INFO
-        app_err_handler = logging.StreamHandler()
+        app_logger.level = logging.DEBUG
+        app_err_handler = ProgressStreamHandler()
         app_err_handler.setFormatter(logging.Formatter("%(message)s"))
-        app_err_handler.addFilter(FilterError())
+        app_err_handler.addFilter(FilterWarnAndMore())
         app_err_handler.stream = STDERR
         app_logger.addHandler(app_err_handler)
         app_logger.propagate = False
@@ -119,13 +127,16 @@ def reconfigure(args):
     else:
         disable_log_handler("avocado.fabric")
         disable_log_handler("paramiko")
-    if not os.environ.get('AVOCADO_LOG_DEBUG'):    # Not already enabled by env
+    # Not already enabled by env
+    if not os.environ.get('AVOCADO_LOG_DEBUG'):
         if "debug" in enabled:
             add_log_handler("avocado.app.debug", stream=STDERR)
         else:
             disable_log_handler("avocado.app.debug")
 
-    enable_stderr()
+    for name in [_ for _ in enabled if _ not in ["app", "test", "debug",
+                                                 "remote", "early"]]:
+        add_log_handler(name, None, STDERR, logging.DEBUG)
     # Remove the in-memory handlers
     for handler in logging.root.handlers:
         if isinstance(handler, MemStreamHandler):
@@ -136,16 +147,23 @@ def reconfigure(args):
         logging.getLogger(record.name).handle(record)
 
 
-class FilterError(logging.Filter):
+def stop_logging():
+    if isinstance(STDOUT, Paginator):
+        sys.stdout = _STDOUT
+        sys.stderr = _STDERR
+        STDOUT.close()
+
+
+class FilterWarnAndMore(logging.Filter):
 
     def filter(self, record):
-        return record.levelno >= logging.ERROR
+        return record.levelno >= logging.WARN
 
 
-class FilterInfo(logging.Filter):
+class FilterInfoAndLess(logging.Filter):
 
     def filter(self, record):
-        return record.levelno == logging.INFO
+        return record.levelno <= logging.INFO
 
 
 class ProgressStreamHandler(logging.StreamHandler):
@@ -157,6 +175,14 @@ class ProgressStreamHandler(logging.StreamHandler):
     def emit(self, record):
         try:
             msg = self.format(record)
+            if record.levelno < logging.INFO:   # Most messages are INFO
+                pass
+            elif record.levelno < logging.WARNING:
+                msg = term_support.header_str(msg)
+            elif record.levelno < logging.ERROR:
+                msg = term_support.warn_header_str(msg)
+            else:
+                msg = term_support.fail_header_str(msg)
             stream = self.stream
             skip_newline = False
             if hasattr(record, 'skip_newline'):
@@ -230,18 +256,6 @@ class Paginator(object):
             pass
 
 
-def get_paginator():
-    """
-    Get a paginator.
-
-    The paginator is whatever the user sets as $PAGER, or 'less', or if all
-    else fails, sys.stdout. It is a useful feature inspired in programs such
-    as git, since it lets you scroll up and down large buffers of text,
-    increasing the program's usability.
-    """
-    return Paginator()
-
-
 def add_log_handler(logger, klass=logging.StreamHandler, stream=sys.stdout,
                     level=logging.INFO, fmt='%(name)s: %(message)s'):
     """
@@ -274,6 +288,18 @@ def disable_log_handler(logger):
     logger.propagate = False
 
 
+def is_colored_term():
+    allowed_terms = ['linux', 'xterm', 'xterm-256color', 'vt100', 'screen',
+                     'screen-256color']
+    term = os.environ.get("TERM")
+    colored = settings.get_value('runner.output', 'colored',
+                                 key_type='bool')
+    if ((not colored) or (not os.isatty(1)) or (term not in allowed_terms)):
+        return False
+    else:
+        return True
+
+
 class TermSupport(object):
 
     COLOR_BLUE = '\033[94m'
@@ -297,9 +323,6 @@ class TermSupport(object):
     stdout is in a tty or the terminal type is recognized.
     """
 
-    allowed_terms = ['linux', 'xterm', 'xterm-256color', 'vt100', 'screen',
-                     'screen-256color']
-
     def __init__(self):
         self.HEADER = self.COLOR_BLUE
         self.PASS = self.COLOR_GREEN
@@ -312,11 +335,7 @@ class TermSupport(object):
         self.ENDC = self.CONTROL_END
         self.LOWLIGHT = self.COLOR_DARKGREY
         self.enabled = True
-        term = os.environ.get("TERM")
-        colored = settings.get_value('runner.output', 'colored',
-                                     key_type='bool')
-        if ((not colored) or (not os.isatty(1)) or
-                (term not in self.allowed_terms)):
+        if not is_colored_term():
             self.disable()
 
     def disable(self):
@@ -522,221 +541,3 @@ class Throbber(object):
         result = self.MOVES[self.position]
         self._update_position()
         return result
-
-
-class View(object):
-
-    """
-    Takes care of both disk logs and stdout/err logs.
-    """
-
-    def __init__(self, app_args=None, console_logger='avocado.app',
-                 use_paginator=False):
-        """
-        Set up the console logger and the paginator mode.
-
-        :param console_logger: logging.Logger identifier for the main app
-                               logger.
-        :type console_logger: str
-        :param use_paginator: Whether to use paginator mode. Set it to True if
-                              the program is supposed to output a large list of
-                              lines to the user and you want the user to be able
-                              to scroll through them at will (think git log).
-        """
-        self.app_args = app_args
-        self.use_paginator = use_paginator
-        self.console_log = logging.getLogger(console_logger)
-        if self.use_paginator:
-            self.paginator = get_paginator()
-        else:
-            self.paginator = None
-        self.throbber = Throbber()
-        self.tests_info = {}
-        self.file_handler = None
-        self.stream_handler = None
-
-    def cleanup(self):
-        if self.use_paginator:
-            self.paginator.close()
-
-    def notify(self, event='message', msg=None, skip_newline=False):
-        mapping = {'message': self._log_ui_header,
-                   'minor': self._log_ui_minor,
-                   'error': self._log_ui_error,
-                   'warning': self._log_ui_warning,
-                   'partial': self._log_ui_partial}
-        if msg is not None:
-            mapping[event](msg=msg, skip_newline=skip_newline)
-
-    def notify_progress(self, progress):
-        """
-        Give an interactive indicator of the test progress
-
-        :param progress: if indication of progress came explicitly from the
-                         test. If false, it means the test process is running,
-                         but not communicating test specific progress.
-        :type progress: bool
-        :rtype: None
-        """
-        if progress:
-            self._log_ui_healthy(self.throbber.render(), True)
-        else:
-            self._log_ui_partial(self.throbber.render(), True)
-
-    def add_test(self, state):
-        self._log(msg=self._get_test_tag(state['tagged_name']),
-                  skip_newline=True)
-
-    def set_test_status(self, status, state):
-        """
-        Log a test status message
-        :param status: the test status
-        :param state: test state (used to get 'time_elapsed')
-        """
-        mapping = {'PASS': term_support.pass_str,
-                   'ERROR': term_support.error_str,
-                   'FAIL': term_support.fail_str,
-                   'SKIP': term_support.skip_str,
-                   'WARN': term_support.warn_str,
-                   'INTERRUPTED': term_support.interrupt_str}
-        if status == 'SKIP':
-            msg = mapping[status]()
-        else:
-            msg = mapping[status]() + " (%.2f s)" % state['time_elapsed']
-        self._log_ui_info(msg)
-
-    def set_tests_info(self, info):
-        self.tests_info.update(info)
-
-    def _get_test_tag(self, test_name):
-        return (' (%s/%s) %s:  ' %
-                (self.tests_info['tests_run'],
-                 self.tests_info['tests_total'], test_name))
-
-    def _log(self, msg, level=logging.INFO, skip_newline=False):
-        """
-        Write a message to the avocado.app logger or the paginator.
-
-        :param msg: Message to write
-        :type msg: string
-        """
-        enabled = getattr(self.app_args, "log", [])
-        if "app" in enabled and self.use_paginator and level < logging.ERROR:
-            if not skip_newline:
-                msg += '\n'
-            self.paginator.write(msg)
-        else:
-            extra = {'skip_newline': skip_newline}
-            self.console_log.log(level=level, msg=msg, extra=extra)
-
-    def _log_ui_info(self, msg, skip_newline=False):
-        """
-        Log a :mod:`logging.INFO` message to the UI.
-
-        :param msg: Message to write.
-        """
-        self._log(msg, level=logging.INFO, skip_newline=skip_newline)
-
-    def _log_ui_error_base(self, msg, skip_newline=False):
-        """
-        Log a :mod:`logging.ERROR` message to the UI.
-
-        :param msg: Message to write.
-        """
-        self._log(msg, level=logging.ERROR, skip_newline=skip_newline)
-
-    def _log_ui_healthy(self, msg, skip_newline=False):
-        """
-        Log a message that indicates that things are going as expected.
-
-        :param msg: Message to write.
-        """
-        self._log_ui_info(term_support.healthy_str(msg), skip_newline)
-
-    def _log_ui_partial(self, msg, skip_newline=False):
-        """
-        Log a message that indicates something (at least) partially OK
-
-        :param msg: Message to write.
-        """
-        self._log_ui_info(term_support.partial_str(msg), skip_newline)
-
-    def _log_ui_header(self, msg, skip_newline=False):
-        """
-        Log a header message.
-
-        :param msg: Message to write.
-        """
-        self._log_ui_info(term_support.header_str(msg), skip_newline)
-
-    def _log_ui_minor(self, msg, skip_newline=False):
-        """
-        Log a minor message.
-
-        :param msg: Message to write.
-        """
-        self._log_ui_info(msg, skip_newline)
-
-    def _log_ui_error(self, msg, skip_newline=False):
-        """
-        Log an error message (useful for critical errors).
-
-        :param msg: Message to write.
-        """
-        self._log_ui_error_base(term_support.fail_header_str(msg), skip_newline)
-
-    def _log_ui_warning(self, msg, skip_newline=False):
-        """
-        Log a warning message (useful for warning messages).
-
-        :param msg: Message to write.
-        """
-        self._log_ui_info(term_support.warn_header_str(msg), skip_newline)
-
-    def start_job_logging(self, logfile, loglevel, unique_id, sourcejob=None):
-        """
-        Start the main file logging.
-
-        :param logfile: Path to file that will receive logging.
-        :param loglevel: Level of the logger. Example: :mod:`logging.DEBUG`.
-        :param unique_id: job.Job() unique id attribute.
-        """
-        self.job_unique_id = unique_id
-        self.debuglog = logfile
-        # File loggers
-        self.file_handler = logging.FileHandler(filename=logfile)
-        self.file_handler.setLevel(loglevel)
-
-        fmt = ('%(asctime)s %(module)-16.16s L%(lineno)-.4d %('
-               'levelname)-5.5s| %(message)s')
-        formatter = logging.Formatter(fmt=fmt, datefmt='%H:%M:%S')
-
-        self.file_handler.setFormatter(formatter)
-        test_logger = logging.getLogger('avocado.test')
-        test_logger.addHandler(self.file_handler)
-        test_logger.setLevel(loglevel)
-        root_logger = logging.getLogger()
-        root_logger.addHandler(self.file_handler)
-        root_logger.setLevel(loglevel)
-        # Console loggers
-        if ('test' in self.app_args.log and
-                'early' not in self.app_args.log):
-            self.stream_handler = ProgressStreamHandler()
-            test_logger.addHandler(self.stream_handler)
-            root_logger.addHandler(self.stream_handler)
-        self.replay_sourcejob = sourcejob
-
-    def stop_job_logging(self):
-        """
-        Simple helper for removing a handler from the current logger.
-        """
-        # File loggers
-        test_logger = logging.getLogger('avocado.test')
-        root_logger = logging.getLogger()
-        test_logger.removeHandler(self.file_handler)
-        root_logger.removeHandler(self.file_handler)
-        self.file_handler.close()
-        # Console loggers
-        if self.stream_handler:
-            test_logger.removeHandler(self.stream_handler)
-            root_logger.removeHandler(self.stream_handler)

--- a/avocado/core/parser.py
+++ b/avocado/core/parser.py
@@ -30,19 +30,19 @@ DESCRIPTION = 'Avocado Test Runner'
 
 
 def log_type(value):
-    valid_streams = ["app", "test", "debug", "remote", "early", "all", "none"]
     value = value.split(',')
-    if any(_ not in valid_streams for _ in value):
-        missing = [_ for _ in value if _ not in valid_streams]
-        msg = ("Invalid logging stream(s): %s\n"
-               "Supported logging streams are:\n"
+    if '?' in value:
+        msg = ("Enable stdout/stderr console streams. Special values are:\n"
                " app - application output\n"
                " test - test output\n"
                " debug - tracebacks and other debugging info\n"
                " remote - fabric/paramiko debug\n"
                " early - early logging of other streams (very verbose)\n"
-               " all - everything\n"
-               " none - disable everything\n" % ", ".join(missing))
+               " all - all of the above\n"
+               " none - disable console logging\n"
+               " ? - this help\n"
+               " Additionally you can specify any (non-colliding) stream, "
+               "eg. 'my.stream'.\n" % ", ".join(missing))
         sys.stderr.write(msg)
         sys.exit(-1)
 
@@ -73,7 +73,7 @@ class Parser(object):
     """
 
     def __init__(self):
-        self.args = None
+        self.args = argparse.Namespace()
         self.subcommands = None
         self.application = ArgumentParser(prog=PROG,
                                           add_help=False,  # see parent parsing
@@ -82,12 +82,12 @@ class Parser(object):
                                       version='Avocado %s' % VERSION)
         self.application.add_argument('--config', metavar='CONFIG_FILE',
                                       help='Use custom configuration from a file')
-        self.application.add_argument('--log', action="store",
+        self.application.add_argument('--show', action="store",
                                       type=log_type,
                                       metavar='STREAMS', default=['app'],
                                       help="Comma separated list of logging "
-                                      "streams to be enabled (app,test,debug,"
-                                      "remote,early); By default 'app'")
+                                      "streams to be enabled. Use '?' to get "
+                                      "additional info; By default 'app'")
 
     def start(self):
         """

--- a/avocado/core/parser.py
+++ b/avocado/core/parser.py
@@ -84,10 +84,12 @@ class Parser(object):
                                       help='Use custom configuration from a file')
         self.application.add_argument('--show', action="store",
                                       type=log_type,
-                                      metavar='STREAMS', default=['app'],
-                                      help="Comma separated list of logging "
-                                      "streams to be enabled. Use '?' to get "
-                                      "additional info; By default 'app'")
+                                      metavar="STREAM[:LVL]",
+                                      default=['app'], help="Comma separated "
+                                      "list of logging streams to be enabled "
+                                      "optionally followed by LEVEL. "
+                                      "Use '?' to get additional info; "
+                                      "By default 'app:DEBUG'")
 
     def start(self):
         """

--- a/avocado/core/parser.py
+++ b/avocado/core/parser.py
@@ -90,6 +90,8 @@ class Parser(object):
                                       "optionally followed by LEVEL. "
                                       "Use '?' to get additional info; "
                                       "By default 'app:DEBUG'")
+        self.application.add_argument('-s', '--silent', action='store_true',
+                                      default=False, help='Silence stdout')
 
     def start(self):
         """

--- a/avocado/core/remote/result.py
+++ b/avocado/core/remote/result.py
@@ -27,14 +27,13 @@ class RemoteTestResult(HumanTestResult):
 
     command_line_arg_name = '--remote-hostname'
 
-    def __init__(self, stream, args):
+    def __init__(self, job):
         """
         Creates an instance of RemoteTestResult.
 
-        :param stream: an instance of :class:`avocado.core.output.View`.
-        :param args: an instance of :class:`argparse.Namespace`.
+        :param job: an instance of :class:`avocado.core.job.Job`.
         """
-        HumanTestResult.__init__(self, stream, args)
+        HumanTestResult.__init__(self, job)
         self.test_dir = os.getcwd()
         self.remote_test_dir = '~/avocado/tests'
         self.urls = self.args.url
@@ -54,6 +53,6 @@ class VMTestResult(RemoteTestResult):
 
     command_line_arg_name = '--vm-domain'
 
-    def __init__(self, stream, args):
-        super(VMTestResult, self).__init__(stream, args)
+    def __init__(self, job):
+        super(VMTestResult, self).__init__(job)
         self.vm = None

--- a/avocado/core/remote/runner.py
+++ b/avocado/core/remote/runner.py
@@ -78,12 +78,11 @@ class RemoteTestRunner(TestRunner):
 
     def setup(self):
         """ Setup remote environment and copy test directories """
-        self.job.view.notify(event='message',
-                             msg=("LOGIN      : %s@%s:%d (TIMEOUT: %s seconds)"
-                                  % (self.job.args.remote_username,
-                                     self.job.args.remote_hostname,
-                                     self.job.args.remote_port,
-                                     self.job.args.remote_timeout)))
+        self.job.log.info("LOGIN      : %s@%s:%d (TIMEOUT: %s seconds)",
+                          self.job.args.remote_username,
+                          self.job.args.remote_hostname,
+                          self.job.args.remote_port,
+                          self.job.args.remote_timeout)
         self.remote = remoter.Remote(self.job.args.remote_hostname,
                                      self.job.args.remote_username,
                                      self.job.args.remote_password,
@@ -265,8 +264,7 @@ class VMTestRunner(RemoteTestRunner):
 
     def setup(self):
         # Super called after VM is found and initialized
-        self.job.view.notify(event='message', msg="DOMAIN     : %s"
-                             % self.job.args.vm_domain)
+        self.job.log.info("DOMAIN     : %s", self.job.args.vm_domain)
         self.vm = virt.vm_connect(self.job.args.vm_domain,
                                   self.job.args.vm_hypervisor_uri)
         if self.vm is None:

--- a/avocado/core/replay.py
+++ b/avocado/core/replay.py
@@ -20,7 +20,6 @@ import pickle
 import sys
 
 from . import exit_codes
-from . import output
 from .test import ReplaySkipTest
 
 from .settings import settings
@@ -101,7 +100,6 @@ def retrieve_replay_map(resultsdir, replay_filter):
 
 
 def get_resultsdir(logdir, jobid):
-    view = output.View()
     matches = 0
     short_jobid = jobid[:7]
     if len(short_jobid) < 7:
@@ -112,8 +110,9 @@ def get_resultsdir(logdir, jobid):
             match_file = id_file
             matches += 1
             if matches > 1:
-                msg = "hash '%s' is not unique enough" % jobid
-                view.notify(event='error', msg=(msg))
+                from logging import getLogger
+                getLogger("avocado.app").error("hash '%s' is not unique "
+                                               "enough", jobid)
                 sys.exit(exit_codes.AVOCADO_JOB_FAIL)
 
     if matches == 1:

--- a/avocado/core/restclient/cli/actions/server.py
+++ b/avocado/core/restclient/cli/actions/server.py
@@ -6,8 +6,13 @@ Module that implements the actions for the CLI App when the job toplevel
 command is used
 """
 
+import logging
+
 from . import base
 from ... import connection
+
+
+log = logging.getLogger("avocado.app")
 
 
 @base.action
@@ -16,8 +21,7 @@ def status(app):
     Shows the server status
     """
     data = app.connection.request("version/")
-    app.view.notify(event="message",
-                    msg="Server version: %s" % data.get('version'))
+    log.info("Server version: %s", data.get('version'))
 
 
 @base.action
@@ -29,12 +33,9 @@ def list_brief(app):
         data = app.connection.get_api_list()
     except connection.UnexpectedHttpStatusCode as e:
         if e.received == 403:
-            app.view.notify(event="error",
-                            msg="Error: Access Forbidden")
+            log.error("Error: Access Forbidden")
             return False
 
-    app.view.notify(event="message",
-                    msg="Available APIs:")
+    log.info("Available APIs:")
     for name in data:
-        app.view.notify(event="message",
-                        msg=" * %s" % name)
+        log.info(" * %s", name)

--- a/avocado/core/restclient/cli/app.py
+++ b/avocado/core/restclient/cli/app.py
@@ -11,19 +11,19 @@
 #
 # Copyright: Red Hat Inc. 2015
 # Author: Cleber Rosa <cleber@redhat.com>
-
 """
 This is the main entry point for the rest client cli application
 """
 
+import importlib
+import logging
 import sys
 import types
-import importlib
 
 from . import parser
 from .. import connection
-from ... import output
 from ... import exit_codes
+
 
 __all__ = ['App']
 
@@ -48,7 +48,7 @@ class App(object):
         self.connection = None
         self.parser = parser.Parser()
         self.parser.add_arguments_on_all_modules()
-        self.view = output.View()
+        self.log = logging.getLogger("avocado.app")
 
     def initialize_connection(self):
         """
@@ -61,16 +61,13 @@ class App(object):
                 username=self.args.username,
                 password=self.args.password)
         except connection.InvalidConnectionError:
-            self.view.notify(event="error",
-                             msg="Error: could not connect to the server")
+            self.log.error("Error: could not connect to the server")
             sys.exit(exit_codes.AVOCADO_JOB_FAIL)
         except connection.InvalidServerVersionError:
-            self.view.notify(event="error",
-                             msg=("REST server version is higher than "
-                                  "than this client can support."))
-            self.view.notify(event="error",
-                             msg=("Please use a more recent version "
-                                  "of the REST client application."))
+            self.log.error("REST server version is higher than "
+                           "than this client can support.")
+            self.log.error("Please use a more recent version "
+                           "of the REST client application.")
             sys.exit(exit_codes.AVOCADO_JOB_FAIL)
 
     def dispatch_action(self):
@@ -108,8 +105,7 @@ class App(object):
             self.initialize_connection()
             return kallable(self)
         else:
-            self.view.notify(event="error",
-                             msg="Action specified is not implemented")
+            self.log.error("Action specified is not implemented")
 
     def run(self):
         """

--- a/avocado/core/result.py
+++ b/avocado/core/result.py
@@ -12,7 +12,6 @@
 # Copyright: Red Hat Inc. 2013-2014
 # Authors: Lucas Meneghel Rodrigues <lmr@redhat.com>
 #          Ruda Moura <rmoura@redhat.com>
-
 """
 Contains the definition of the TestResult class, used for output in avocado.
 
@@ -20,7 +19,9 @@ It also contains the most basic test result class, HumanTestResult,
 used by the test runner.
 """
 
-import os
+import logging
+
+from . import output
 
 
 class InvalidOutputPlugin(Exception):
@@ -118,16 +119,16 @@ class TestResult(object):
     #: inconsistencies come from.
     command_line_arg_name = None
 
-    def __init__(self, stream, args):
+    def __init__(self, job):
         """
         Creates an instance of TestResult.
 
-        :param stream: an instance of :class:`avocado.core.output.View`.
-        :param args: an instance of :class:`argparse.Namespace`.
+        :param job: an instance of :class:`avocado.core.job.Job`.
         """
-        self.stream = stream
-        self.args = args
-        self.tests_total = getattr(args, 'test_result_total', 1)
+        self.job_unique_id = getattr(job, "unique_id", None)
+        self.logfile = getattr(job, "logfile", None)
+        self.args = getattr(job, "args", None)
+        self.tests_total = getattr(self.args, 'test_result_total', 1)
         self.tests_run = 0
         self.total_time = 0.0
         self.passed = []
@@ -162,7 +163,6 @@ class TestResult(object):
         Called once before any tests are executed.
         """
         self.tests_run += 1
-        self.stream.set_tests_info({'tests_run': self.tests_run})
 
     def end_tests(self):
         """
@@ -188,7 +188,6 @@ class TestResult(object):
         """
         self.tests_run += 1
         self.total_time += state['time_elapsed']
-        self.stream.set_tests_info({'tests_run': self.tests_run})
 
     def add_pass(self, state):
         """
@@ -265,107 +264,57 @@ class HumanTestResult(TestResult):
     """
     Human output Test result class.
     """
+    def __init__(self, job):
+        super(HumanTestResult, self).__init__(job)
+        self.log = logging.getLogger("avocado.app")
+        self.__throbber = output.Throbber()
 
     def start_tests(self):
         """
         Called once before any tests are executed.
         """
-        TestResult.start_tests(self)
-        self.stream.notify(event="message", msg="JOB ID     : %s" % self.stream.job_unique_id)
-        if self.stream.replay_sourcejob is not None:
-            self.stream.notify(event="message", msg="SRC JOB ID : %s" %
-                               self.stream.replay_sourcejob)
-        self.stream.notify(event="message", msg="JOB LOG    : %s" % self.stream.logfile)
-        self.stream.notify(event="message", msg="TESTS      : %s" % self.tests_total)
-        self.stream.set_tests_info({'tests_total': self.tests_total})
+        super(HumanTestResult, self).start_tests()
+        self.log.info("JOB ID     : %s", self.job_unique_id)
+        if getattr(self.args, "replay_sourcejob", None):
+            self.log.info("SRC JOB ID : %s", self.args.replay_sourcejob)
+        self.log.info("JOB LOG    : %s", self.logfile)
+        self.log.info("TESTS      : %s", self.tests_total)
 
     def end_tests(self):
         """
         Called once after all tests are executed.
         """
+        super(HumanTestResult, self).end_tests()
         self._reconcile()
-        self.stream.notify(event="message",
-                           msg="RESULTS    : PASS %d | ERROR %d | FAIL %d | "
-                               "SKIP %d | WARN %d | INTERRUPT %s" %
-                               (len(self.passed), len(self.errors),
-                                len(self.failed), len(self.skipped),
-                                len(self.warned), len(self.interrupted)))
-        if self.args is not None:
-            if 'html_output' in self.args:
-                logdir = os.path.dirname(self.stream.logfile)
-                html_file = os.path.join(logdir, 'html', 'results.html')
-                self.stream.notify(event="message", msg=("JOB HTML   : %s" %
-                                                         html_file))
-        self.stream.notify(event="message",
-                           msg="TIME       : %.2f s" % self.total_time)
+        self.log.info("RESULTS    : PASS %d | ERROR %d | FAIL %d | SKIP %d | "
+                      "WARN %d | INTERRUPT %s", len(self.passed),
+                      len(self.errors), len(self.failed), len(self.skipped),
+                      len(self.warned), len(self.interrupted))
+        self.log.info("TIME       : %.2f s", self.total_time)
 
     def start_test(self, state):
-        """
-        Called when the given test is about to run.
-
-        :param state: result of :class:`avocado.core.test.Test.get_state`.
-        :type state: dict
-        """
-        self.stream.add_test(state)
+        super(HumanTestResult, self).start_test(state)
+        self.log.debug(' (%s/%s) %s:  ', self.tests_run, self.tests_total,
+                       state["tagged_name"], extra={"skip_newline": True})
 
     def end_test(self, state):
-        """
-        Called when the given test has been run.
+        super(HumanTestResult, self).end_test(state)
+        status = state["status"]
+        if status == "TEST_NA":
+            status = "SKIP"
+        mapping = {'PASS': output.term_support.PASS,
+                   'ERROR': output.term_support.ERROR,
+                   'FAIL': output.term_support.FAIL,
+                   'SKIP': output.term_support.SKIP,
+                   'WARN': output.term_support.WARN,
+                   'INTERRUPTED': output.term_support.INTERRUPT}
+        self.log.debug(output.term_support.MOVE_BACK + mapping[status] +
+                       status + output.term_support.ENDC)
 
-        :param state: result of :class:`avocado.core.test.Test.get_state`.
-        :type state: dict
-        """
-        TestResult.end_test(self, state)
-
-    def add_pass(self, state):
-        """
-        Called when a test succeeded.
-
-        :param state: result of :class:`avocado.core.test.Test.get_state`.
-        :type state: dict
-        """
-        TestResult.add_pass(self, state)
-        self.stream.set_test_status(status='PASS', state=state)
-
-    def add_error(self, state):
-        """
-        Called when a test had a setup error.
-
-        :param state: result of :class:`avocado.core.test.Test.get_state`.
-        :type state: dict
-        """
-        TestResult.add_error(self, state)
-        self.stream.set_test_status(status='ERROR', state=state)
-
-    def add_fail(self, state):
-        """
-        Called when a test fails.
-
-        :param state: result of :class:`avocado.core.test.Test.get_state`.
-        :type state: dict
-        """
-        TestResult.add_fail(self, state)
-        self.stream.set_test_status(status='FAIL', state=state)
-
-    def add_skip(self, state):
-        """
-        Called when a test is skipped.
-
-        :param state: result of :class:`avocado.core.test.Test.get_state`.
-        :type state: dict
-        """
-        TestResult.add_skip(self, state)
-        self.stream.set_test_status(status='SKIP', state=state)
-
-    def add_warn(self, state):
-        """
-        Called when a test had a warning.
-
-        :param state: result of :class:`avocado.core.test.Test.get_state`.
-        :type state: dict
-        """
-        TestResult.add_warn(self, state)
-        self.stream.set_test_status(status='WARN', state=state)
-
-    def notify_progress(self, progress_from_test=False):
-        self.stream.notify_progress(progress_from_test)
+    def notify_progress(self, progress=False):
+        if progress:
+            color = output.term_support.PASS
+        else:
+            color = output.term_support.PARTIAL
+        self.log.debug(color + self.__throbber.render() +
+                       output.term_support.ENDC, extra={"skip_newline": True})

--- a/avocado/core/xunit.py
+++ b/avocado/core/xunit.py
@@ -11,13 +11,12 @@
 #
 # Copyright: Red Hat Inc. 2014
 # Author: Ruda Moura <rmoura@redhat.com>
-
 """xUnit module."""
 
 import datetime
+import logging
 from xml.sax.saxutils import quoteattr
 
-from . import output
 from .result import TestResult
 
 
@@ -154,16 +153,19 @@ class xUnitTestResult(TestResult):
 
     command_line_arg_name = '--xunit'
 
-    def __init__(self, stream=None, args=None):
+    def __init__(self, job, force_xunit_file=None):
         """
         Creates an instance of xUnitTestResult.
 
-        :param stream: an instance of :class:`avocado.core.output.View`.
-        :param args: an instance of :class:`argparse.Namespace`.
+        :param job: an instance of :class:`avocado.core.job.Job`.
+        :param force_xunit_file: Override the output file defined in job.args
         """
-        TestResult.__init__(self, stream, args)
-        self.output = getattr(self.args, 'xunit_output', '-')
-        self.stream = output.View(app_args=args)
+        TestResult.__init__(self, job)
+        if force_xunit_file:
+            self.output = force_xunit_file
+        else:
+            self.output = getattr(self.args, 'xunit_output', '-')
+        self.log = logging.getLogger("avocado.app")
         self.xml = XmlResult()
 
     def start_tests(self):
@@ -209,7 +211,7 @@ class xUnitTestResult(TestResult):
         self.xml.end_testsuite(**values)
         contents = self.xml.get_contents()
         if self.output == '-':
-            self.stream.notify(event='minor', msg=contents)
+            self.log.debug(contents)
         else:
             with open(self.output, 'w') as xunit_output:
                 xunit_output.write(contents)

--- a/avocado/plugins/config.py
+++ b/avocado/plugins/config.py
@@ -12,10 +12,12 @@
 # Copyright: Red Hat Inc. 2013-2014
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
-from .base import CLICmd
-from avocado.core import output
+import logging
+
 from avocado.core import data_dir
 from avocado.core.settings import settings
+
+from .base import CLICmd
 
 
 class Config(CLICmd):
@@ -37,41 +39,37 @@ class Config(CLICmd):
                             'Current: %(default)s')
 
     def run(self, args):
-        view = output.View(use_paginator=(args.paginator == 'on'))
-        try:
-            view.notify(event="message", msg='Config files read (in order):')
-            for cfg_path in settings.config_paths:
-                view.notify(event="message", msg='    %s' % cfg_path)
-            if settings.config_paths_failed:
-                view.notify(event="minor", msg='')
-                view.notify(event="error", msg='Config files that failed to read:')
-                for cfg_path in settings.config_paths_failed:
-                    view.notify(event="error", msg='    %s' % cfg_path)
-            view.notify(event="minor", msg='')
-            if not args.datadir:
-                blength = 0
-                for section in settings.config.sections():
-                    for value in settings.config.items(section):
-                        clength = len('%s.%s' % (section, value[0]))
-                        if clength > blength:
-                            blength = clength
+        log = logging.getLogger("avocado.app")
+        log.info('Config files read (in order):')
+        for cfg_path in settings.config_paths:
+            log.debug('    %s' % cfg_path)
+        if settings.config_paths_failed:
+            log.error('\nConfig files that failed to read:')
+            for cfg_path in settings.config_paths_failed:
+                log.error('    %s' % cfg_path)
+        log.debug("")
+        if not args.datadir:
+            blength = 0
+            for section in settings.config.sections():
+                for value in settings.config.items(section):
+                    clength = len('%s.%s' % (section, value[0]))
+                    if clength > blength:
+                        blength = clength
 
-                format_str = "    %-" + str(blength) + "s %s"
+            format_str = "    %-" + str(blength) + "s %s"
 
-                view.notify(event="minor", msg=format_str % ('Section.Key', 'Value'))
-                for section in settings.config.sections():
-                    for value in settings.config.items(section):
-                        config_key = ".".join((section, value[0]))
-                        view.notify(event="minor", msg=format_str % (config_key, value[1]))
-            else:
-                view.notify(event="minor", msg="Avocado replaces config dirs that can't be accessed")
-                view.notify(event="minor", msg="with sensible defaults. Please edit your local config")
-                view.notify(event="minor", msg="file to customize values")
-                view.notify(event="message", msg='')
-                view.notify(event="message", msg='Avocado Data Directories:')
-                view.notify(event="minor", msg='    base     ' + data_dir.get_base_dir())
-                view.notify(event="minor", msg='    tests    ' + data_dir.get_test_dir())
-                view.notify(event="minor", msg='    data     ' + data_dir.get_data_dir())
-                view.notify(event="minor", msg='    logs     ' + data_dir.get_logs_dir())
-        finally:
-            view.cleanup()
+            log.debug(format_str, 'Section.Key', 'Value')
+            for section in settings.config.sections():
+                for value in settings.config.items(section):
+                    config_key = ".".join((section, value[0]))
+                    log.debug(format_str, config_key, value[1])
+        else:
+            log.debug("Avocado replaces config dirs that can't be accessed")
+            log.debug("with sensible defaults. Please edit your local config")
+            log.debug("file to customize values")
+            log.debug('')
+            log.info('Avocado Data Directories:')
+            log.debug('    base     ' + data_dir.get_base_dir())
+            log.debug('    tests    ' + data_dir.get_test_dir())
+            log.debug('    data     ' + data_dir.get_data_dir())
+            log.debug('    logs     ' + data_dir.get_logs_dir())

--- a/avocado/plugins/exec_path.py
+++ b/avocado/plugins/exec_path.py
@@ -14,11 +14,13 @@
 Libexec PATHs modifier
 """
 
+import logging
 import os
 import sys
 
+from avocado.core import exit_codes
+
 from .base import CLICmd
-from avocado.core import exit_codes, output
 
 
 class ExecPath(CLICmd):
@@ -36,24 +38,21 @@ class ExecPath(CLICmd):
 
         :param args: Command line args received from the run subparser.
         """
-        self.view = output.View(app_args=args, use_paginator=False)
+        log = logging.getLogger("avocado.app")
         if 'VIRTUAL_ENV' in os.environ:
-            self.view.notify(event='minor', msg='libexec')
+            log.debug('libexec')
         elif os.path.exists('/usr/libexec/avocado'):
-            self.view.notify(event='minor', msg='/usr/libexec/avocado')
+            log.debug('/usr/libexec/avocado')
         elif os.path.exists('/usr/lib/avocado'):
-            self.view.notify(event='minor', msg='/usr/lib/avocado')
+            log.debug('/usr/lib/avocado')
         else:
             for path in os.environ.get('PATH').split(':'):
                 if (os.path.exists(os.path.join(path, 'avocado')) and
                     os.path.exists(os.path.join(os.path.dirname(path),
                                                 'libexec'))):
-                    self.view.notify(event='minor',
-                                     msg=os.path.join(os.path.dirname(path),
-                                                      'libexec'))
+                    log.debug(os.path.join(os.path.dirname(path), 'libexec'))
                     break
             else:
-                self.view.notify(event='error',
-                                 msg="Can't locate avocado libexec path")
+                log.error("Can't locate avocado libexec path")
                 sys.exit(exit_codes.AVOCADO_FAIL)
         return sys.exit(exit_codes.AVOCADO_ALL_OK)

--- a/avocado/plugins/html.py
+++ b/avocado/plugins/html.py
@@ -14,10 +14,11 @@
 """
 HTML output module.
 """
+
+import logging
 import sys
 
 from avocado.core import exit_codes
-from avocado.core import output
 from avocado.core.html import HTMLTestResult
 from avocado.core.result import register_test_result_class
 
@@ -58,11 +59,9 @@ class HTML(CLI):
 
     def run(self, args):
         if 'html_output' in args and args.html_output == '-':
-            view = output.View(app_args=args)
-            view.notify(event='error',
-                        msg='HTML to stdout not supported '
-                        '(not all HTML resources can be embedded '
-                        'on a single file)')
+            log = logging.getLogger("avocado.app")
+            log.error('HTML to stdout not supported (not all HTML resources '
+                      'can be embedded on a single file)')
             sys.exit(exit_codes.AVOCADO_JOB_FAIL)
 
         if 'html_output' in args and args.html_output is not None:

--- a/avocado/plugins/journal.py
+++ b/avocado/plugins/journal.py
@@ -45,14 +45,13 @@ class TestResultJournal(TestResult):
 
     command_line_arg_name = '--journal'
 
-    def __init__(self, stream=None, args=None):
+    def __init__(self, args=None):
         """
         Creates an instance of TestResultJournal.
 
-        :param stream: an instance of :class:`avocado.core.output.View`.
         :param args: an instance of :class:`argparse.Namespace`.
         """
-        TestResult.__init__(self, stream, args)
+        TestResult.__init__(self, args)
         self.journal_initialized = False
 
     def _init_journal(self, logdir):

--- a/avocado/plugins/multiplex.py
+++ b/avocado/plugins/multiplex.py
@@ -12,14 +12,15 @@
 # Copyright: Red Hat Inc. 2013-2014
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
+import logging
 import sys
 
-from .base import CLICmd
+from avocado.core import exit_codes, output
 from avocado.core import multiplexer
-from avocado.core import exit_codes
-from avocado.core import output
 from avocado.core import tree
 from avocado.core.settings import settings
+
+from .base import CLICmd
 
 
 class Multiplex(CLICmd):
@@ -83,22 +84,21 @@ class Multiplex(CLICmd):
 
     def run(self, args):
         self._activate(args)
-        view = output.View(app_args=args)
+        log = logging.getLogger("avocado.app")
         err = None
         if args.tree and args.debug:
             err = "Option --tree is incompatible with --debug."
         elif not args.tree and args.inherit:
             err = "Option --inherit can be only used with --tree"
         if err:
-            view.notify(event="error", msg=err)
+            log.error(err)
             sys.exit(exit_codes.AVOCADO_FAIL)
         try:
             mux_tree = multiplexer.yaml2tree(args.multiplex_files,
                                              args.filter_only, args.filter_out,
                                              args.debug)
         except IOError as details:
-            view.notify(event='error',
-                        msg=details.strerror)
+            log.error(details.strerror)
             sys.exit(exit_codes.AVOCADO_JOB_FAIL)
         if args.system_wide:
             mux_tree.merge(args.default_multiplex_tree)
@@ -112,12 +112,11 @@ class Multiplex(CLICmd):
                 verbose += 2
             use_utf8 = settings.get_value("runner.output", "utf8",
                                           key_type=bool, default=None)
-            view.notify(event='minor', msg=tree.tree_view(mux_tree, verbose,
-                                                          use_utf8))
+            log.debug(tree.tree_view(mux_tree, verbose, use_utf8))
             sys.exit(exit_codes.AVOCADO_ALL_OK)
 
         variants = multiplexer.MuxTree(mux_tree)
-        view.notify(event='message', msg='Variants generated:')
+        log.info('Variants generated:')
         for (index, tpl) in enumerate(variants):
             if not args.debug:
                 paths = ', '.join([x.path for x in tpl])
@@ -129,8 +128,8 @@ class Multiplex(CLICmd):
                                                           "Unknown"),
                                                   cend)
                                    for _ in tpl])
-            view.notify(event='minor', msg='%sVariant %s:    %s' %
-                        (('\n' if args.contents else ''), index + 1, paths))
+            log.debug('%sVariant %s:    %s' %
+                      (('\n' if args.contents else ''), index + 1, paths))
             if args.contents:
                 env = set()
                 for node in tpl:
@@ -141,6 +140,6 @@ class Multiplex(CLICmd):
                     continue
                 fmt = '    %%-%ds => %%s' % max([len(_[0]) for _ in env])
                 for record in sorted(env):
-                    view.notify(event='minor', msg=fmt % record)
+                    log.debug(fmt % record)
 
         sys.exit(exit_codes.AVOCADO_ALL_OK)

--- a/avocado/plugins/plugins.py
+++ b/avocado/plugins/plugins.py
@@ -15,10 +15,12 @@
 Plugins information plugin
 """
 
-from .base import CLICmd
-from avocado.core import output
+import logging
+
 from avocado.core import dispatcher
 from avocado.utils import astring
+
+from .base import CLICmd
 
 
 class Plugins(CLICmd):
@@ -38,25 +40,23 @@ class Plugins(CLICmd):
                             'Current: %(default)s')
 
     def run(self, args):
-        view = output.View(app_args=args,
-                           use_paginator=args.paginator == 'on')
-
+        log = logging.getLogger("avocado.app")
         cli_cmds = dispatcher.CLICmdDispatcher()
         msg = 'Plugins that add new commands (avocado.plugins.cli.cmd):'
-        view.notify(event='message', msg=msg)
+        log.info(msg)
         plugin_matrix = []
         for plugin in sorted(cli_cmds):
             plugin_matrix.append((plugin.name, plugin.obj.description))
 
         for line in astring.iter_tabular_output(plugin_matrix):
-            view.notify(event='minor', msg=line)
+            log.debug(line)
 
         msg = 'Plugins that add new options to commands (avocado.plugins.cli):'
         cli = dispatcher.CLIDispatcher()
-        view.notify(event='message', msg=msg)
+        log.info(msg)
         plugin_matrix = []
         for plugin in sorted(cli):
             plugin_matrix.append((plugin.name, plugin.obj.description))
 
         for line in astring.iter_tabular_output(plugin_matrix):
-            view.notify(event='minor', msg=line)
+            log.debug(line)

--- a/avocado/plugins/remote.py
+++ b/avocado/plugins/remote.py
@@ -15,15 +15,14 @@
 """Run tests on a remote machine."""
 
 import getpass
+import logging
 import sys
 
 from avocado.core import exit_codes
-from avocado.core import output
 from avocado.core import remoter
 from avocado.core.remote import RemoteTestResult
 from avocado.core.remote import RemoteTestRunner
 from avocado.core.result import register_test_result_class
-
 from .base import CLI
 
 
@@ -91,12 +90,11 @@ class Remote(CLI):
             if not getattr(args, arg):
                 missing.append(arg)
         if missing:
-            view = output.View(app_args=args)
-            e_msg = ('Use of %s requires %s arguments to be set. Please set %s'
-                     '.' % (enable_arg, ', '.join(required_args),
-                            ', '.join(missing)))
+            log = logging.getLogger("avocado.app")
+            log.error("Use of %s requires %s arguments to be set. Please set "
+                      "%s.", enable_arg, ', '.join(required_args),
+                      ', '.join(missing))
 
-            view.notify(event='error', msg=e_msg)
             return sys.exit(exit_codes.AVOCADO_FAIL)
         return True
 

--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -13,6 +13,7 @@
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
 import argparse
+import logging
 import os
 import sys
 
@@ -20,7 +21,6 @@ from .base import CLI
 from avocado.core import replay
 from avocado.core import status
 from avocado.core import exit_codes
-from avocado.core import output
 from avocado.core.settings import settings
 
 
@@ -79,9 +79,9 @@ class Replay(CLI):
         ignore_list = string.split(',')
         for item in ignore_list:
             if item not in options:
-                msg = 'Invalid --replay-ignore option. Valid ' \
-                       'options are (more than one allowed): %s' % \
-                       ','.join(options)
+                msg = ('Invalid --replay-ignore option. Valid '
+                       'options are (more than one allowed): %s'
+                       % ','.join(options))
                 raise argparse.ArgumentTypeError(msg)
 
         return ignore_list
@@ -95,7 +95,7 @@ class Replay(CLI):
         if getattr(args, 'replay_jobid', None) is None:
             return
 
-        view = output.View()
+        log = logging.getLogger("avocado.app")
 
         err = None
         if args.replay_teststatus and args.multiplex_files:
@@ -107,7 +107,7 @@ class Replay(CLI):
         elif args.remote_hostname:
             err = "Currently we don't replay jobs in remote hosts."
         if err is not None:
-            view.notify(event="error", msg=err)
+            log.error(err)
             sys.exit(exit_codes.AVOCADO_FAIL)
 
         if args.replay_datadir is not None:
@@ -115,12 +115,11 @@ class Replay(CLI):
         else:
             logs_dir = settings.get_value('datadir.paths', 'logs_dir',
                                           default=None)
-            self.logdir = os.path.expanduser(logs_dir)
-            resultsdir = replay.get_resultsdir(self.logdir, args.replay_jobid)
+            logdir = os.path.expanduser(logs_dir)
+            resultsdir = replay.get_resultsdir(logdir, args.replay_jobid)
 
         if resultsdir is None:
-            msg = "Can't find job results directory in '%s'" % self.logdir
-            view.notify(event='error', msg=(msg))
+            log.error("Can't find job results directory in '%s'", logdir)
             sys.exit(exit_codes.AVOCADO_JOB_FAIL)
 
         sourcejob = replay.get_id(os.path.join(resultsdir, 'id'),
@@ -128,47 +127,42 @@ class Replay(CLI):
         if sourcejob is None:
             msg = "Can't find matching job id '%s' in '%s' directory." % \
                   (args.replay_jobid, resultsdir)
-            view.notify(event='error', msg=(msg))
+            log.error(msg)
             sys.exit(exit_codes.AVOCADO_JOB_FAIL)
 
         setattr(args, 'replay_sourcejob', sourcejob)
 
         if getattr(args, 'url', None):
-            msg = 'Overriding the replay urls with urls provided in '\
-                  'command line.'
-            view.notify(event='warning', msg=(msg))
+            log.warn('Overriding the replay urls with urls provided in '
+                     'command line.')
         else:
             urls = replay.retrieve_urls(resultsdir)
             if urls is None:
-                msg = 'Source job urls data not found. Aborting.'
-                view.notify(event='error', msg=(msg))
+                log.error('Source job urls data not found. Aborting.')
                 sys.exit(exit_codes.AVOCADO_JOB_FAIL)
             else:
                 setattr(args, 'url', urls)
 
         if args.replay_ignore and 'config' in args.replay_ignore:
-            msg = "Ignoring configuration from source job with " \
-                  "--replay-ignore."
-            view.notify(event='warning', msg=(msg))
+            log.warn("Ignoring configuration from source job with "
+                     "--replay-ignore.")
         else:
             self.load_config(resultsdir)
 
         if args.replay_ignore and 'mux' in args.replay_ignore:
-            msg = "Ignoring multiplex from source job with --replay-ignore."
-            view.notify(event='warning', msg=(msg))
+            log.warn("Ignoring multiplex from source job with "
+                     "--replay-ignore.")
         else:
             if getattr(args, 'multiplex_files', None) is not None:
-                msg = 'Overriding the replay multiplex with '\
-                      '--multiplex-files.'
-                view.notify(event='warning', msg=(msg))
+                log.warn('Overriding the replay multiplex with '
+                         '--multiplex-file.')
                 # Use absolute paths to avoid problems with os.chdir
                 args.multiplex_files = [os.path.abspath(_)
                                         for _ in args.multiplex_files]
             else:
                 mux = replay.retrieve_mux(resultsdir)
                 if mux is None:
-                    msg = 'Source job multiplex data not found. Aborting.'
-                    view.notify(event='error', msg=(msg))
+                    log.error('Source job multiplex data not found. Aborting.')
                     sys.exit(exit_codes.AVOCADO_JOB_FAIL)
                 else:
                     setattr(args, "multiplex_files", mux)
@@ -184,6 +178,5 @@ class Replay(CLI):
             if os.path.exists(pwd):
                 os.chdir(pwd)
             else:
-                view.notify(event="warning", msg="Directory used in the replay"
-                            " source job '%s' does not exist, using '.' "
-                            "instead" % pwd)
+                log.warn("Directory used in the replay source job '%s' does "
+                         "not exist, using '.' instead", pwd)

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -73,6 +73,10 @@ class Run(CLICmd):
                                   'Note that zero means "no timeout". '
                                   'You can also use suffixes, like: '
                                   ' s (seconds), m (minutes), h (hours). '))
+        parser.add_argument("--store-logging-stream", nargs="*", default=[],
+                            metavar="STREAM[:LEVEL]", help="Store given "
+                            "logging streams in $JOB_RESULTS_DIR/$STREAM_NAME."
+                            "$LEVEL.")
 
         sysinfo_default = settings.get_value('sysinfo.collect',
                                              'enabled',

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -91,10 +91,6 @@ class Run(CLICmd):
         parser.output = parser.add_argument_group('output and result format')
 
         parser.output.add_argument(
-            '-s', '--silent', action='store_true', default=False,
-            help='Silence stdout')
-
-        parser.output.add_argument(
             '--show-job-log', action='store_true', default=False,
             help=('Display only the job log on stdout. Useful '
                   'for test debugging purposes. No output will '

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -11,20 +11,20 @@
 #
 # Copyright: Red Hat Inc. 2013-2014
 # Author: Ruda Moura <rmoura@redhat.com>
-
 """
 Base Test Runner Plugins.
 """
 
+import logging
 import sys
 
-from .base import CLICmd
 from avocado.core import exit_codes
-from avocado.core import output
 from avocado.core import job
 from avocado.core import loader
 from avocado.core import multiplexer
 from avocado.core.settings import settings
+
+from .base import CLICmd
 
 
 class Run(CLICmd):
@@ -163,10 +163,9 @@ class Run(CLICmd):
                 if timeout < 1:
                     raise ValueError()
             except (ValueError, TypeError):
-                self.view.notify(
-                    event='error',
-                    msg=("Invalid number '%s' for job timeout. "
-                         "Use an integer number greater than 0") % raw_timeout)
+                log = logging.getLogger("avocado.app")
+                log.error("Invalid number '%s' for job timeout. Use an "
+                          "integer number greater than 0", raw_timeout)
                 sys.exit(exit_codes.AVOCADO_FAIL)
         else:
             timeout = 0
@@ -179,14 +178,15 @@ class Run(CLICmd):
         :param args: Command line args received from the run subparser.
         """
         self._activate(args)
-        self.view = output.View(app_args=args)
+        self.log = logging.getLogger("avocado.app")
         if args.unique_job_id is not None:
             try:
                 int(args.unique_job_id, 16)
                 if len(args.unique_job_id) != 40:
                     raise ValueError
             except ValueError:
-                self.view.notify(event='error', msg='Unique Job ID needs to be a 40 digit hex number')
+                log = logging.getLogger("avocado.app")
+                log.error('Unique Job ID needs to be a 40 digit hex number')
                 sys.exit(exit_codes.AVOCADO_FAIL)
         args.job_timeout = self._validate_job_timeout(args.job_timeout)
         job_instance = job.Job(args)

--- a/avocado/plugins/vm.py
+++ b/avocado/plugins/vm.py
@@ -15,15 +15,14 @@
 """Run tests on Virtual Machine."""
 
 import getpass
+import logging
 import sys
 
 from avocado.core import exit_codes
-from avocado.core import output
 from avocado.core import virt
 from avocado.core.remote import VMTestResult
 from avocado.core.remote import VMTestRunner
 from avocado.core.result import register_test_result_class
-
 from .base import CLI
 
 
@@ -95,12 +94,11 @@ class VM(CLI):
             if not getattr(args, arg):
                 missing.append(arg)
         if missing:
-            view = output.View(app_args=args)
-            e_msg = ('Use of %s requires %s arguments to be set. Please set %s'
-                     '.' % (enable_arg, ', '.join(required_args),
-                            ', '.join(missing)))
+            log = logging.getLogger("avocado.app")
+            log.error("Use of %s requires %s arguments to be set. Please set "
+                      "%s.", enable_arg, ', '.join(required_args),
+                      ', '.join(missing))
 
-            view.notify(event='error', msg=e_msg)
             return sys.exit(exit_codes.AVOCADO_FAIL)
         return True
 

--- a/avocado/plugins/wrapper.py
+++ b/avocado/plugins/wrapper.py
@@ -12,11 +12,11 @@
 # Copyright: Red Hat Inc. 2014
 # Author: Ruda Moura <rmoura@redhat.com>
 
+import logging
 import os
 import sys
 
 from avocado.core import exit_codes
-from avocado.core import output
 from avocado.utils import process
 
 from .base import CLI
@@ -51,11 +51,10 @@ class Wrapper(CLI):
     def run(self, args):
         wraps = getattr(args, "wrapper", None)
         if wraps:
-            view = output.View(app_args=args)
+            log = logging.getLogger("avocado.app")
             if getattr(args, 'gdb_run_bin', None):
-                view.notify(event='error',
-                            msg='Command line option --wrapper is incompatible'
-                                ' with option --gdb-run-bin.')
+                log.error('Command line option --wrapper is incompatible'
+                          ' with option --gdb-run-bin.\n%s', args.wrapper)
                 sys.exit(exit_codes.AVOCADO_FAIL)
 
             for wrap in args.wrapper:
@@ -64,15 +63,13 @@ class Wrapper(CLI):
                         script = os.path.abspath(wrap)
                         process.WRAP_PROCESS = os.path.abspath(script)
                     else:
-                        view.notify(event='error',
-                                    msg="You can't have multiple global"
-                                        " wrappers at once.")
+                        log.error("You can't have multiple global "
+                                  "wrappers at once.")
                         sys.exit(exit_codes.AVOCADO_FAIL)
                 else:
                     script, cmd = wrap.split(':', 1)
                     script = os.path.abspath(script)
                     process.WRAP_PROCESS_NAMES_EXPR.append((script, cmd))
                 if not os.path.exists(script):
-                    view.notify(event='error',
-                                msg="Wrapper '%s' not found!" % script)
+                    log.error("Wrapper '%s' not found!", script)
                     sys.exit(exit_codes.AVOCADO_FAIL)

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -182,7 +182,7 @@ class RunnerOperationTest(unittest.TestCase):
 
     def test_silent_output(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --sysinfo=off --job-results-dir %s passtest --silent' % self.tmpdir
+        cmd_line = './scripts/avocado --silent run --sysinfo=off --job-results-dir %s passtest' % self.tmpdir
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         expected_output = ''

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -8,6 +8,7 @@ import xml.dom.minidom
 import glob
 import aexpect
 import signal
+import re
 
 if sys.version_info[:2] == (2, 6):
     import unittest2 as unittest
@@ -54,6 +55,13 @@ class RunnerOperationTest(unittest.TestCase):
 
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+
+    def test_show_version(self):
+        result = process.run('./scripts/avocado -v', ignore_status=True)
+        self.assertEqual(result.exit_status, 0)
+        self.assertTrue(re.match(r"^Avocado \d+\.\d+\.\d+$", result.stderr),
+                        "Version string does not match 'Avocado \\d\\.\\d\\.\\"
+                        "d':\n%r" % (result.stderr))
 
     def test_runner_all_ok(self):
         os.chdir(basedir)

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -174,7 +174,7 @@ class OutputPluginTest(unittest.TestCase):
         tmpfile = tempfile.mktemp()
         tmpfile2 = tempfile.mktemp()
         os.chdir(basedir)
-        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off --silent --xunit %s --json %s passtest' %
+        cmd_line = ('./scripts/avocado --silent run --job-results-dir %s --sysinfo=off --xunit %s --json %s passtest' %
                     (self.tmpdir, tmpfile, tmpfile2))
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout + result.stderr
@@ -214,7 +214,7 @@ class OutputPluginTest(unittest.TestCase):
 
     def test_silent_trumps_show_job_log(self):
         os.chdir(basedir)
-        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off passtest --show-job-log --silent' %
+        cmd_line = ('./scripts/avocado --silent run --job-results-dir %s --sysinfo=off passtest --show-job-log' %
                     self.tmpdir)
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout + result.stderr

--- a/selftests/functional/test_replay.py
+++ b/selftests/functional/test_replay.py
@@ -88,7 +88,7 @@ class ReplayTests(unittest.TestCase):
         expected_rc = exit_codes.AVOCADO_ALL_OK
         result = self.run_and_check(cmd_line, expected_rc)
         msg = 'Ignoring multiplex from source job with --replay-ignore.'
-        self.assertIn(msg, result.stdout)
+        self.assertIn(msg, result.stderr)
 
     def test_run_replay_invalidstatus(self):
         cmd_line = ('./scripts/avocado run --replay %s --replay-test-status E '

--- a/selftests/unit/test_jsonresult.py
+++ b/selftests/unit/test_jsonresult.py
@@ -10,25 +10,9 @@ from avocado.core import jsonresult
 from avocado.core import job
 
 
-class _Stream(object):
-
-    def start_job_logging(self, param1, param2):
-        pass
-
-    def stop_job_logging(self):
-        pass
-
-    def set_tests_info(self, info):
-        pass
-
-    def notify(self, event, msg):
-        pass
-
-    def add_test(self, state):
-        pass
-
-    def set_test_status(self, status, state):
-        pass
+class FakeJob(object):
+    def __init__(self, args):
+        self.args = args
 
 
 class JSONResultTest(unittest.TestCase):
@@ -43,9 +27,7 @@ class JSONResultTest(unittest.TestCase):
         self.tmpfile = tempfile.mkstemp()
         self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
         args = argparse.Namespace(json_output=self.tmpfile[1])
-        stream = _Stream()
-        stream.logfile = 'debug.log'
-        self.test_result = jsonresult.JSONTestResult(stream, args)
+        self.test_result = jsonresult.JSONTestResult(FakeJob(args))
         self.test_result.filename = self.tmpfile[1]
         self.test_result.start_tests()
         self.test1 = SimpleTest(job=job.Job(), base_logdir=self.tmpdir)

--- a/selftests/unit/test_remote.py
+++ b/selftests/unit/test_remote.py
@@ -5,7 +5,6 @@ import os
 
 from flexmock import flexmock, flexmock_teardown
 
-from avocado.core import output
 from avocado.core import remoter
 from avocado.core import remote
 from avocado.utils import archive
@@ -30,9 +29,6 @@ class RemoteTestRunnerTest(unittest.TestCase):
     """ Tests RemoteTestRunner """
 
     def setUp(self):
-        View = flexmock(output.View)
-        view = output.View()
-        view.should_receive('notify')
         Args = flexmock(test_result_total=1,
                         remote_username='username',
                         remote_hostname='hostname',
@@ -43,7 +39,9 @@ class RemoteTestRunnerTest(unittest.TestCase):
                         show_job_log=False,
                         multiplex_files=['foo.yaml', 'bar/baz.yaml'],
                         dry_run=True)
-        job = flexmock(args=Args, view=view,
+        log = flexmock()
+        log.should_receive("info")
+        job = flexmock(args=Args, log=log,
                        urls=['/tests/sleeptest', '/tests/other/test',
                              'passtest'], unique_id='sleeptest.1',
                        logdir="/local/path")
@@ -154,9 +152,6 @@ class RemoteTestRunnerSetup(unittest.TestCase):
 
     def setUp(self):
         Remote = flexmock()
-        View = flexmock(output.View)
-        view = output.View()
-        view.should_receive('notify')
         remote_remote = flexmock(remoter)
         (remote_remote.should_receive('Remote')
          .with_args('hostname', 'username', 'password', 22, 60)
@@ -172,7 +167,9 @@ class RemoteTestRunnerSetup(unittest.TestCase):
                         remote_no_copy=False,
                         remote_timeout=60,
                         show_job_log=False)
-        job = flexmock(args=Args, view=view)
+        log = flexmock()
+        log.should_receive("info")
+        job = flexmock(args=Args, log=log)
         self.runner = remote.RemoteTestRunner(job, None)
 
     def tearDown(self):

--- a/selftests/unit/test_vm.py
+++ b/selftests/unit/test_vm.py
@@ -6,7 +6,6 @@ from flexmock import flexmock, flexmock_teardown
 
 from avocado.core.remote import VMTestRunner
 from avocado.core import virt
-from avocado.core import output
 
 JSON_RESULTS = ('Something other than json\n'
                 '{"tests": [{"test": "sleeptest.1", "url": "sleeptest", '
@@ -22,9 +21,6 @@ class VMTestRunnerSetup(unittest.TestCase):
     """ Tests the VMTestRunner setup() method """
 
     def setUp(self):
-        View = flexmock(output.View)
-        view = output.View()
-        view.should_receive('notify')
         mock_vm = flexmock(snapshot=True,
                            domain=flexmock(isActive=lambda: True))
         flexmock(virt).should_receive('vm_connect').and_return(mock_vm).once().ordered()
@@ -43,7 +39,9 @@ class VMTestRunnerSetup(unittest.TestCase):
                         vm_no_copy=False,
                         vm_timeout=120,
                         vm_hypervisor_uri='my_hypervisor_uri')
-        job = flexmock(args=Args, view=view)
+        log = flexmock()
+        log.should_receive("info")
+        job = flexmock(args=Args, log=log)
         self.runner = VMTestRunner(job, None)
         mock_vm.should_receive('stop').once().ordered()
         mock_vm.should_receive('restore_snapshot').once().ordered()

--- a/selftests/unit/test_xunit.py
+++ b/selftests/unit/test_xunit.py
@@ -14,25 +14,9 @@ class ParseXMLError(Exception):
     pass
 
 
-class _Stream(object):
-
-    def start_job_logging(self, param1, param2):
-        pass
-
-    def stop_job_logging(self):
-        pass
-
-    def set_tests_info(self, info):
-        pass
-
-    def notify(self, event, msg):
-        pass
-
-    def add_test(self, state):
-        pass
-
-    def set_test_status(self, status, state):
-        pass
+class FakeJob(object):
+    def __init__(self, args):
+        self.args = args
 
 
 class xUnitSucceedTest(unittest.TestCase):
@@ -48,7 +32,7 @@ class xUnitSucceedTest(unittest.TestCase):
         self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
         args = argparse.Namespace()
         args.xunit_output = self.tmpfile[1]
-        self.test_result = xunit.xUnitTestResult(stream=_Stream(), args=args)
+        self.test_result = xunit.xUnitTestResult(FakeJob(args))
         self.test_result.start_tests()
         self.test1 = SimpleTest(job=job.Job(), base_logdir=self.tmpdir)
         self.test1.status = 'PASS'


### PR DESCRIPTION
Hello guys,

this complex PR is a first step to refactor the logging. What it does is it changes the initialization of logging to by design avoid problems with --silent not ready during parser initialization.

v1: https://github.com/avocado-framework/avocado/pull/946
v2: https://github.com/avocado-framework/avocado/pull/949
v3: https://github.com/avocado-framework/avocado/pull/962
v4: https://github.com/avocado-framework/avocado/pull/980
v5: https://github.com/avocado-framework/avocado/pull/1010
v6: https://github.com/avocado-framework/avocado/pull/1040

Changes:

    v2: Renamed cryptic variable names in log (eg. appl->app_logger)
    v2: Output which streams are incorrect when incorrect streams supplied
    v2: Remove false fix for typo (excerpt is a word ...)
    v2: Squash the late python2.6 fix where it was produced
    v3: Simplifies the "scripts/avocado" fatal failure handler
    v3: Renames DEBUG env variables to "AVOCADO_LOG_..."
    v3: Fixes some docstrings
    v3: Added commit which removes "View"
    v3: The "View" commit fixes the error which prevented v2 from being applied
    v4: Rebase
    v4: Bugfixes regarding stdout/stderr handling (output._STDOUT is stdout, output.STDOUT is output)
    v4: Add support to specify level in --output
    v4: Add support to store additional job logging streams
    v4: Make silent arg always silent
    v4: Move --silent arg from "run" to core
    v4: Renamed "--log" to "--show"
    v4: Few other bugfixes squashed to the "View" commit (no changes prior to the
        '''Remove the "View" concept''' commit)
    v5: Added missing whitespaces (separate commit)
    v5: Set defaults in add_log_handler (separate commit)
    v5: Rebase
    v5: Fixed commit message (docstrings => comments)
    v5: Added empty "MemStreamHandler.flush" to avoid crashes
    v6: Rebase to the latest master
    v6: Split the "View" commit into three
    v6: Found solution to fix "avocado: Refactor logging initialization" to work properly,
        (we can merge this as stage1, fixes the bugs from Trello and doesn't break anything)
    v6: "console_handler" renamed to "handler"
    v6: Added missing renames in "Rename add_console_handler to add_log_handler"
    v7: Rebase to current master (includes stage1 and stage2 of this PR)
    v7: Avoid crash on "avocado -V" (self.args = argparse.Namespace() in avocado/core/parser.py)
    v7: Adjust the StringIO usage to the recent changes.

Next steps:

* Remove the `View` from `avocado-virt/vt`: https://github.com/avocado-framework/avocado-virt/pull/75 https://github.com/avocado-framework/avocado-vt/pull/372
* Propagate the "--store-logging-stream" to test loggers and store them also in the test's results (waits for https://trello.com/c/W58vhyHR/539-bug-some-avocado-test-methods-and-atributes-are-public )
* Simplify the "reserved" logging streams (avocado.app, avocado.test, avocado.test.stdout, ...). We should reconsider the logic, avoid multiple levels where it does not makes sense, etc.
* Consider using `avocado.app` for human output only. Create `avocado.app.xunit`, `avocado.app.json` streams and in case `-` is used disable the `avocado.app` logger instead of changing what do we write where. This way we can use `app_log.write("...")` in plugins (eg. htmloutput, replay), which would only show when user uses "avocado.app" and would be ignored when "--json -" is used. Ideally we should create a method to take-over avocado app logger, which would raise exception in case it's already taken (to simplify detection of `--json - --xunit -`).
* Expand unittests