### PR TITLE
avocado.core.test fix crash with replay-test-status and external-runner

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -55,7 +55,8 @@ class Test(unittest.TestCase):
     default_params = {}
 
     def __init__(self, methodName='test', name=None, params=None,
-                 base_logdir=None, tag=None, job=None, runner_queue=None):
+                 base_logdir=None, tag=None, job=None, runner_queue=None,
+                 **kargs):
         """
         Initializes the test.
 


### PR DESCRIPTION
When using --replay-test-status to filter out some variants, we do that by
using ReplaySkipTest(), which inherits from Test(). Those classes are not expecting
external_runner argument and then, using --external-runner, the crash takes place.

This patch adds **kargs to Test() so we can receive any number of named arguments.

Reference: https://trello.com/c/7XMJopli
Signed-off-by: Amador Pahim <apahim@redhat.com>