### PR TITLE
avocado.core.test: Ignore unknown arguments in TimeOutSkipTest

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -717,6 +717,21 @@ class TimeOutSkipTest(Test):
 
     _skip_reason = "Test skipped due a job timeout!"
 
+    def __init__(self, *args, **kwargs):
+        """
+        This class substitutes other classes. Let's just ignore the remaining
+        arguments and only set the ones supported by avocado.Test
+        """
+        super_kwargs = dict()
+        args = list(reversed(args))
+        for arg in ["methodName", "name", "params", "base_logdir", "tag",
+                    "job", "runner_queue"]:
+            if args:
+                super_kwargs[arg] = args.pop()
+            elif arg in kwargs:
+                super_kwargs[arg] = kwargs[arg]
+        super(TimeOutSkipTest, self).__init__(**super_kwargs)
+
     def setUp(self):
         raise exceptions.TestSkipError(self._skip_reason)
 


### PR DESCRIPTION
The TimeOutSkipTest (and heirs) are used to substitute other test
classes. Custom classes might supply additional arguments, which
TimeOutSkipTest does not handle.

This patch simply picks the supported arguments and ignores the
remaining ones.

Note that positional arguments are also used. When the order is kept, it
will work fine. But if the custom class reorders the positional
arguments things are going to be messy.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>