### PR TITLE
avocado.core.job: Make update_latest_link parallel-execution-safe

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -154,7 +154,10 @@ class Job(object):
             os.unlink(latest)
         except OSError:
             pass
-        os.symlink(basename, latest)
+        try:
+            os.symlink(basename, latest)
+        except OSError:
+            pass
 
     def _start_sysinfo(self):
         if hasattr(self.args, 'sysinfo'):


### PR DESCRIPTION
When running avocado in parallel, one of them crash because the
_update_latest_link is not parallel-process-safe:

    1. avocado1 removes the symlink
    2. avocado2 removes the symlink
    3. avocado2 creates the symlink
    4. avocado1 crashes as the symlink already exists

When the symlink already exists it means we either don't have
permissions to remove it, or it was created by another process. This
should not prevent the avocado execution as when we don't have
permissions to change it, we don't change it. And when other process
already created it, it means we are not the latest result anymore.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>