### PR TITLE
avocado.pugins.replay record/replay loader options [v2]

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -398,8 +398,8 @@ def add_loader_options(parser):
                   'where those files are located, use "test" here and '
                   'specify the test directory with the option '
                   '"--external-runner-testdir". Defaults to "%(default)s"')
-    arggrp.add_argument('--external-runner-chdir', default='off',
-                        choices=('runner', 'test', 'off'),
+    arggrp.add_argument('--external-runner-chdir', default=None,
+                        choices=('runner', 'test'),
                         help=chdir_help)
 
     arggrp.add_argument('--external-runner-testdir', metavar='DIRECTORY',
@@ -751,7 +751,7 @@ class ExternalLoader(TestLoader):
     @staticmethod
     def _process_external_runner(args, runner):
         """ Enables the external_runner when asked for """
-        chdir = getattr(args, 'external_runner_chdir', 'off')
+        chdir = getattr(args, 'external_runner_chdir', None)
         test_dir = getattr(args, 'external_runner_testdir', None)
 
         if runner:
@@ -778,7 +778,7 @@ class ExternalLoader(TestLoader):
                                                          ['runner', 'chdir',
                                                           'test_dir'])
             return cls_external_runner(runner, chdir, test_dir)
-        elif chdir != "off":
+        elif chdir:
             msg = ('Option "--external-runner-chdir" requires '
                    '"--external-runner" to be set.')
             raise LoaderError(msg)

--- a/avocado/core/replay.py
+++ b/avocado/core/replay.py
@@ -37,6 +37,7 @@ def record(args, logdir, mux, urls=None):
     path_urls = os.path.join(replay_dir, 'urls')
     path_mux = os.path.join(replay_dir, 'multiplex')
     path_pwd = os.path.join(replay_dir, 'pwd')
+    path_args = os.path.join(replay_dir, 'args')
 
     if urls:
         with open(path_urls, 'w') as f:
@@ -50,6 +51,9 @@ def record(args, logdir, mux, urls=None):
 
     with open(path_pwd, 'w') as f:
         f.write('%s' % os.getcwd())
+
+    with open(path_args, 'w') as f:
+        pickle.dump(args.__dict__, f, pickle.HIGHEST_PROTOCOL)
 
 
 def retrieve_pwd(resultsdir):
@@ -98,6 +102,15 @@ def retrieve_replay_map(resultsdir, replay_filter):
             replay_map.append(None)
 
     return replay_map
+
+
+def retrieve_args(resultsdir):
+    pkl_path = os.path.join(resultsdir, 'replay', 'args')
+    if not os.path.exists(pkl_path):
+        return None
+
+    with open(pkl_path, 'r') as f:
+        return pickle.load(f)
 
 
 def get_resultsdir(logdir, jobid):

--- a/selftests/functional/test_replay.py
+++ b/selftests/functional/test_replay.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import ast
 import glob
 import os
 import sys
@@ -23,17 +24,17 @@ class ReplayTests(unittest.TestCase):
 
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
-        cmd_line = ('./scripts/avocado run passtest --multiplex '
+        cmd_line = ('./scripts/avocado run examples/tests/passtest.py '
+                    '--multiplex '
                     'examples/tests/sleeptest.py.data/sleeptest.yaml '
-                    '--job-results-dir %s --sysinfo=off' %
+                    '--external-runner "/usr/bin/env python" '
+                    '--job-results-dir %s --sysinfo=off --json -' %
                     self.tmpdir)
         expected_rc = exit_codes.AVOCADO_ALL_OK
-        self.run_and_check(cmd_line, expected_rc)
-
-        self.jobdir = ''.join(glob.glob(os.path.join(self.tmpdir, 'job-*')))
-        idfile = ''.join(os.path.join(self.jobdir, 'id'))
-        with open(idfile, 'r') as f:
-            self.jobid = f.read().strip('\n')
+        result = self.run_and_check(cmd_line, expected_rc)
+        out = ast.literal_eval(result.stdout)
+        self.jobid = out['job_id']
+        self.jobdir = os.path.dirname(out['debuglog'])
 
     def run_and_check(self, cmd_line, expected_rc):
         os.chdir(basedir)
@@ -51,7 +52,7 @@ class ReplayTests(unittest.TestCase):
         self.run_and_check(cmd_line, expected_rc)
 
     def test_run_replay_data(self):
-        file_list = ['multiplex', 'config', 'urls', 'pwd']
+        file_list = ['multiplex', 'config', 'urls', 'pwd', 'args']
         for filename in file_list:
             path = os.path.join(self.jobdir, 'replay', filename)
             self.assertTrue(glob.glob(path))
@@ -106,10 +107,10 @@ class ReplayTests(unittest.TestCase):
                     '--sysinfo=off' % (self.jobid, self.tmpdir, self.jobdir))
         expected_rc = exit_codes.AVOCADO_ALL_OK
         result = self.run_and_check(cmd_line, expected_rc)
-        msg = '(1/4) passtest.py:PassTest.test.variant1:  SKIP\n ' \
-              '(2/4) passtest.py:PassTest.test.variant2:  SKIP\n ' \
-              '(3/4) passtest.py:PassTest.test.variant3:  SKIP\n ' \
-              '(4/4) passtest.py:PassTest.test.variant4:  SKIP'
+        msg = '(1/4) examples/tests/passtest.py:PassTest.test.variant1:  SKIP\n '\
+              '(2/4) examples/tests/passtest.py:PassTest.test.variant2:  SKIP\n '\
+              '(3/4) examples/tests/passtest.py:PassTest.test.variant3:  SKIP\n ' \
+              '(4/4) examples/tests/passtest.py:PassTest.test.variant4:  SKIP'
         self.assertIn(msg, result.stdout)
 
     def test_run_replay_remotefail(self):
@@ -142,6 +143,24 @@ class ReplayTests(unittest.TestCase):
         msg = "Option --replay-test-status is incompatible with "\
               "test URLs given on the command line."
         self.assertIn(msg, result.stderr)
+
+    def test_run_replay_external_runner(self):
+        cmd_line = ('./scripts/avocado run --replay %s '
+                    '--job-results-dir %s --replay-data-dir %s --sysinfo=off' %
+                    (self.jobid, self.tmpdir, self.jobdir))
+        expected_rc = exit_codes.AVOCADO_ALL_OK
+        result = self.run_and_check(cmd_line, expected_rc)
+
+    def test_run_replay_external_runner(self):
+        cmd_line = ('./scripts/avocado run --replay %s '
+                    '--external-runner /bin/bash '
+                    '--job-results-dir %s --replay-data-dir %s --sysinfo=off' %
+                    (self.jobid, self.tmpdir, self.jobdir))
+        expected_rc = exit_codes.AVOCADO_TESTS_FAIL
+        result = self.run_and_check(cmd_line, expected_rc)
+        msg = "Overriding the replay external-runner with the "\
+              "--external-runner value given on the command line."
+        self.assertIn(msg, result.stdout)
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir)


### PR DESCRIPTION
v2:
 - Whitelist with args options to replay.
 - external-runner-chdir defaults to None.

v1: #1046 
 - Record the loader options and reload them on job replay.