### PR TITLE
Test namespace cleanup [4th round]

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -187,7 +187,12 @@ class Test(unittest.TestCase):
         """
         Returns the name of the file (path) that holds the current test
         """
-        return inspect.getfile(self.__class__).rstrip('co')
+        possibly_compiled = inspect.getfile(self.__class__)
+        if possibly_compiled.endswith('.pyc') or possibly_compiled.endswith('.pyo'):
+            source = possibly_compiled[:-1]
+        else:
+            source = possibly_compiled
+        return source
 
     @data_structures.LazyProperty
     def workdir(self):

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -333,26 +333,6 @@ class Test(unittest.TestCase):
 
         return tagged_name
 
-    def setUp(self):
-        """
-        Setup stage that the test needs before passing to the actual test*.
-
-        Must be implemented by tests if they want such an stage. Commonly we'll
-        download/compile test suites, create files needed for a test, among
-        other possibilities.
-        """
-        pass
-
-    def tearDown(self):
-        """
-        Cleanup stage after the test* is done.
-
-        Examples of cleanup are deleting temporary files, restoring
-        firewall configurations or other system settings that were changed
-        in setup.
-        """
-        pass
-
     def _record_reference_stdout(self):
         utils_path.init_dir(self.datadir)
         shutil.copyfile(self._stdout_file, self._expected_stdout_file)

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -120,9 +120,6 @@ class Test(unittest.TestCase):
         self.__log_warn_used = False
         self.log.warn = self.log.warning = record_and_warn
 
-        self.stdout_log = logging.getLogger("avocado.test.stdout")
-        self.stderr_log = logging.getLogger("avocado.test.stderr")
-
         mux_path = ['/test/*']
         if isinstance(params, dict):
             self.default_params = self.default_params.copy()
@@ -293,10 +290,12 @@ class Test(unittest.TestCase):
         stream_fmt = '%(message)s'
         stream_formatter = logging.Formatter(fmt=stream_fmt)
 
-        self._stdout_file_handler = self._register_log_file_handler(self.stdout_log, stream_formatter,
-                                                                    self._stdout_file)
-        self._stderr_file_handler = self._register_log_file_handler(self.stderr_log, stream_formatter,
-                                                                    self._stderr_file)
+        self._register_log_file_handler(logging.getLogger("avocado.test.stdout"),
+                                        stream_formatter,
+                                        self._stdout_file)
+        self._register_log_file_handler(logging.getLogger("avocado.test.stderr"),
+                                        stream_formatter,
+                                        self._stderr_file)
         self._ssh_fh = self._register_log_file_handler(logging.getLogger('paramiko'),
                                                        formatter,
                                                        self._ssh_logfile)

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -192,7 +192,11 @@ class Test(unittest.TestCase):
             source = possibly_compiled[:-1]
         else:
             source = possibly_compiled
-        return source
+
+        if os.path.exists(source):
+            return source
+        else:
+            return None
 
     @data_structures.LazyProperty
     def workdir(self):

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -99,7 +99,7 @@ class Test(unittest.TestCase):
         if base_logdir is None:
             base_logdir = data_dir.create_job_logs_dir()
         base_logdir = os.path.join(base_logdir, 'test-results')
-        self.tagged_name = self.get_tagged_name(base_logdir)
+        self.tagged_name = self._get_tagged_name(base_logdir)
 
         # Replace '/' with '_' to avoid splitting name into multiple dirs
         safe_tagged_name = astring.string_to_safe_path(self.tagged_name)
@@ -307,7 +307,7 @@ class Test(unittest.TestCase):
         self.log.removeHandler(self.file_handler)
         logging.getLogger('paramiko').removeHandler(self._ssh_fh)
 
-    def get_tagged_name(self, logdir):
+    def _get_tagged_name(self, logdir):
         """
         Get a test tagged name.
 

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -253,19 +253,6 @@ class Test(unittest.TestCase):
         state['job_unique_id'] = self.job.unique_id
         return state
 
-    def get_data_path(self, basename):
-        """
-        Find a test dependency path inside the test data dir.
-
-        This is a short hand for an operation that will be commonly
-        used on avocado tests, so we feel it deserves its own API.
-
-        :param basename: Basename of the dep file. Ex: ``testsuite.tar.bz2``.
-
-        :return: Path where dependency is supposed to be found.
-        """
-        return os.path.join(self.datadir, basename)
-
     def _register_log_file_handler(self, logger, formatter, filename,
                                    log_level=logging.DEBUG):
         file_handler = logging.FileHandler(filename=filename)

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -84,8 +84,7 @@ class Test(unittest.TestCase):
         else:
             self.name = self.__class__.__name__
 
-        self.tag = tag or None
-
+        self.tag = tag
         self.job = job
 
         if self.datadir is None:

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -519,23 +519,32 @@ You may log something into the test logs using the methods in
                            'won't do that for you.')
             self.log.debug('Everybody look, I had a good lunch today...')
 
-If you need to write directly to the test stdout and stderr streams, there
-are another 2 class attributes for that, :mod:`avocado.Test.stdout_log`
-and :mod:`avocado.Test.stderr_log`, that have the exact same methods
-of the log object. So if you want to add stuff to your expected stdout and
-stderr streams, you can do something like::
+If you need to write directly to the test stdout and stderr streams,
+Avocado makes two preconfigured loggers available for that purpose,
+named ``avocado.test.stdout`` and ``avocado.test.stderr``. You can use
+Python's standard logging API to write to them. Example::
+
+    import logging
 
     class output_test(Test):
 
         def test(self):
-            self.log.info('This goes to the log and it is only informational')
-            self.stdout_log.info('This goes to the test stdout (will be recorded)')
-            self.stderr_log.info('This goes to the test stderr (will be recorded)')
+            stdout = logging.getLogger('avocado.test.stdout')
+            stdout.info('Informational line that will go to stdout')
+            ...
+            stderr = logging.getLogger('avocado.test.stderr')
+            stderr.info('Informational line that will go to stderr')
 
-Each one of the last 2 statements will go to the ``stdout.expected`` and
-``stderr.expected``, should you choose ``--output-check-record all``, and
-will be output to the files ``stderr`` and ``stdout`` of the job results dir
-every time that test is executed.
+Avocado will automatically save anything a test generates on STDOUT
+into a ``stdout`` file, to be found at the test results directory. The same
+applies to anything a test generates on STDERR, that is, it will be saved
+into a ``stderr`` file at the same location.
+
+Additionally, when using the runner's output recording features,
+namely the ``--output-check-record`` argument with values ``stdout``,
+``stderr`` or ``all``, everything given to those loggers will be saved
+to the files ``stdout.expected`` and ``stderr.expected`` at the test's
+data directory (which is different from the job/test results directory).
 
 Avocado Tests run on a separate process
 =======================================

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -308,7 +308,7 @@ an example that does that::
             """
             # Build the synctest suite
             self.cwd = os.getcwd()
-            tarball_path = self.get_data_path(self.params.sync_tarball)
+            tarball_path = os.path.join(self.datadir, self.params.sync_tarball)
             archive.extract(tarball_path, self.srcdir)
             self.srcdir = os.path.join(self.srcdir, 'synctest')
             build.make(self.srcdir)
@@ -329,7 +329,7 @@ an example that does that::
 
 Here we have an example of the ``setUp`` method in action: Here we get the
 location of the test suite code (tarball) through
-:func:`avocado.Test.get_data_path`, then uncompress the tarball through
+:meth:`avocado.Test.datadir`, then uncompress the tarball through
 :func:`avocado.utils.archive.extract`, an API that will
 decompress the suite tarball, followed by :func:`avocado.utils.build.make`, that will build
 the suite.

--- a/examples/tests/cabort.py
+++ b/examples/tests/cabort.py
@@ -22,7 +22,8 @@ class CAbort(Test):
         """
         Build 'abort'.
         """
-        c_file = self.get_data_path(self.params.get('source', default='abort.c'))
+        source = self.params.get('source', default='abort.c')
+        c_file = os.path.join(self.datadir, source)
         c_file_name = os.path.basename(c_file)
         dest_c_file = os.path.join(self.srcdir, c_file_name)
         shutil.copy(c_file, dest_c_file)

--- a/examples/tests/datadir.py
+++ b/examples/tests/datadir.py
@@ -21,8 +21,8 @@ class DataDirTest(Test):
         """
         Build 'datadir'.
         """
-        c_file = self.get_data_path(self.params.get('source',
-                                                    default='datadir.c'))
+        source = self.params.get('source', default='datadir.c')
+        c_file = os.path.join(self.datadir, source)
         c_file_name = os.path.basename(c_file)
         dest_c_file = os.path.join(self.srcdir, c_file_name)
         shutil.copy(c_file, dest_c_file)

--- a/examples/tests/doublefree.py
+++ b/examples/tests/doublefree.py
@@ -22,8 +22,8 @@ class DoubleFreeTest(Test):
         """
         Build 'doublefree'.
         """
-        c_file = self.get_data_path(self.params.get('source',
-                                                    default='doublefree.c'))
+        source = self.params.get('source', default='doublefree.c')
+        c_file = os.path.join(self.datadir, source)
         c_file_name = os.path.basename(c_file)
         dest_c_file = os.path.join(self.srcdir, c_file_name)
         shutil.copy(c_file, dest_c_file)

--- a/examples/tests/doublefree_nasty.py
+++ b/examples/tests/doublefree_nasty.py
@@ -24,7 +24,7 @@ class DoubleFreeTest(Test):
         Build 'doublefree'.
         """
         source = self.params.get('source', default='doublefree.c')
-        c_file = self.get_data_path(source)
+        c_file = os.path.join(self.datadir, source)
         shutil.copy(c_file, self.srcdir)
         self.__binary = source.rsplit('.', 1)[0]
         build.make(self.srcdir,

--- a/examples/tests/gdbtest.py
+++ b/examples/tests/gdbtest.py
@@ -28,12 +28,12 @@ class GdbTest(Test):
 
     def setUp(self):
         self.return99_binary_path = os.path.join(self.outputdir, 'return99')
-        return99_source_path = self.get_data_path('return99.c')
+        return99_source_path = os.path.join(self.datadir, 'return99.c')
         process.system('gcc -O0 -g %s -o %s' % (return99_source_path,
                                                 self.return99_binary_path))
 
         self.segfault_binary_path = os.path.join(self.outputdir, 'segfault')
-        segfault_source_path = self.get_data_path('segfault.c')
+        segfault_source_path = os.path.join(self.datadir, 'segfault.c')
         process.system('gcc -O0 -g %s -o %s' % (segfault_source_path,
                                                 self.segfault_binary_path))
 

--- a/examples/tests/linuxbuild.py
+++ b/examples/tests/linuxbuild.py
@@ -18,7 +18,7 @@ class LinuxBuildTest(Test):
         kernel_version = self.params.get('linux_version', default='3.19.8')
         linux_config = self.params.get('linux_config', default=None)
         if linux_config is not None:
-            linux_config = self.get_data_path(linux_config)
+            linux_config = os.path.join(self.datadir, linux_config)
 
         self.linux_build = kernel_build.KernelBuild(kernel_version,
                                                     linux_config,

--- a/examples/tests/modify_variable.py
+++ b/examples/tests/modify_variable.py
@@ -27,7 +27,7 @@ class PrintVariableTest(Test):
         Build 'print_variable'.
         """
         source = self.params.get('source', default='print_variable.c')
-        c_file = self.get_data_path(source)
+        c_file = os.path.join(self.datadir, source)
         shutil.copy(c_file, self.srcdir)
         self.__binary = source.rsplit('.', 1)[0]
         build.make(self.srcdir,

--- a/examples/tests/raise.py
+++ b/examples/tests/raise.py
@@ -22,8 +22,8 @@ class Raise(Test):
         """
         Build 'raise'.
         """
-        c_file = self.get_data_path(self.params.get('source',
-                                                    default='raise.c'))
+        source = self.params.get('source', default='raise.c')
+        c_file = os.path.join(self.datadir, source)
         c_file_name = os.path.basename(c_file)
         dest_c_file = os.path.join(self.srcdir, c_file_name)
         shutil.copy(c_file, dest_c_file)

--- a/examples/tests/synctest.py
+++ b/examples/tests/synctest.py
@@ -25,8 +25,8 @@ class SyncTest(Test):
         Build the synctest suite.
         """
         self.cwd = os.getcwd()
-        tarball_path = self.get_data_path(self.params.get('sync_tarball', '*',
-                                                          'synctest.tar.bz2'))
+        sync_tarball = self.params.get('sync_tarball', '*', 'synctest.tar.bz2')
+        tarball_path = os.path.join(self.datadir, sync_tarball)
         archive.extract(tarball_path, self.srcdir)
         self.srcdir = os.path.join(self.srcdir, 'synctest')
         if self.params.get('debug_symbols', default=True):

--- a/examples/tests/trinity.py
+++ b/examples/tests/trinity.py
@@ -29,7 +29,7 @@ class TrinityTest(Test):
         Build trinity.
         """
         tarball = self.params.get('tarball', default='trinity-1.5.tar.bz2')
-        tarball_path = self.get_data_path(tarball)
+        tarball_path = os.path.join(self.datadir, tarball)
         archive.extract(tarball_path, self.srcdir)
         self.srcdir = os.path.join(self.srcdir, 'trinity-1.5')
         os.chdir(self.srcdir)


### PR DESCRIPTION
This is a continuation of the work on the avocado.Test class. While these few patches actually don't to much cleaning, they are, as said before, a continuation of the previous work, and they also address an unrelated bug that was found during code reviews.

Reference:

https://trello.com/c/W58vhyHR/539-bug-some-avocado-test-methods-and-atributes-are-public