### PR TITLE
avocado.pugins.replay record/replay loader options [v3]

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -378,8 +378,8 @@ def add_loader_options(parser):
                   'where those files are located, use "test" here and '
                   'specify the test directory with the option '
                   '"--external-runner-testdir". Defaults to "%(default)s"')
-    arggrp.add_argument('--external-runner-chdir', default='off',
-                        choices=('runner', 'test', 'off'),
+    arggrp.add_argument('--external-runner-chdir', default=None,
+                        choices=('runner', 'test'),
                         help=chdir_help)
 
     arggrp.add_argument('--external-runner-testdir', metavar='DIRECTORY',
@@ -725,7 +725,7 @@ class ExternalLoader(TestLoader):
     @staticmethod
     def _process_external_runner(args, runner):
         """ Enables the external_runner when asked for """
-        chdir = getattr(args, 'external_runner_chdir', 'off')
+        chdir = getattr(args, 'external_runner_chdir', None)
         test_dir = getattr(args, 'external_runner_testdir', None)
 
         if runner:
@@ -752,7 +752,7 @@ class ExternalLoader(TestLoader):
                                                          ['runner', 'chdir',
                                                           'test_dir'])
             return cls_external_runner(runner, chdir, test_dir)
-        elif chdir != "off":
+        elif chdir:
             msg = ('Option "--external-runner-chdir" requires '
                    '"--external-runner" to be set.')
             raise LoaderError(msg)

--- a/avocado/core/replay.py
+++ b/avocado/core/replay.py
@@ -36,6 +36,7 @@ def record(args, logdir, mux, urls=None):
     path_urls = os.path.join(replay_dir, 'urls')
     path_mux = os.path.join(replay_dir, 'multiplex')
     path_pwd = os.path.join(replay_dir, 'pwd')
+    path_args = os.path.join(replay_dir, 'args')
 
     if urls:
         with open(path_urls, 'w') as f:
@@ -49,6 +50,9 @@ def record(args, logdir, mux, urls=None):
 
     with open(path_pwd, 'w') as f:
         f.write('%s' % os.getcwd())
+
+    with open(path_args, 'w') as f:
+        pickle.dump(args.__dict__, f, pickle.HIGHEST_PROTOCOL)
 
 
 def retrieve_pwd(resultsdir):
@@ -97,6 +101,15 @@ def retrieve_replay_map(resultsdir, replay_filter):
             replay_map.append(None)
 
     return replay_map
+
+
+def retrieve_args(resultsdir):
+    pkl_path = os.path.join(resultsdir, 'replay', 'args')
+    if not os.path.exists(pkl_path):
+        return None
+
+    with open(pkl_path, 'r') as f:
+        return pickle.load(f)
 
 
 def get_resultsdir(logdir, jobid):

--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -129,9 +129,29 @@ class Replay(CLI):
                    % (args.replay_jobid, resultsdir))
             log.error(msg)
             sys.exit(exit_codes.AVOCADO_JOB_FAIL)
-
         setattr(args, 'replay_sourcejob', sourcejob)
 
+        replay_args = replay.retrieve_args(resultsdir)
+        whitelist = ['loaders',
+                     'external_runner',
+                     'external_runner_testdir',
+                     'external_runner_chdir']
+        if replay_args is None:
+            log.warn('Source job args data not found. These options will not '
+                     'be loaded in this replay job: %s', ', '.join(whitelist))
+        else:
+            for option in whitelist:
+                optvalue = getattr(args, option, None)
+                if optvalue:
+                    log.warn("Overriding the replay %s with the --%s value "
+                             "given on the command line.",
+                             option.replace('_', '-'),
+                             option.replace('_', '-'))
+                else:
+                    setattr(args, option, replay_args[option])
+
+        # Keeping this for compatibility.
+        # TODO: Use replay_args['url'] at some point in the future.
         if getattr(args, 'url', None):
             log.warn('Overriding the replay urls with urls provided in '
                      'command line.')


### PR DESCRIPTION
v3:
 - Rebased to use the new logging.

v2: #1056 
 - Whitelist with args options to replay.
 - external-runner-chdir defaults to None.

v1: #1046 
 - Record the loader options and reload them on job replay.