### PR TITLE
data_dir: make settings dynamic

### DIFF
--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -34,18 +34,13 @@ import time
 import tempfile
 
 from . import job_id
-from .settings import settings
+from . import settings
 from ..utils import path as utils_path
 from ..utils.data_structures import Borg
 
 _BASE_DIR = os.path.join(sys.modules[__name__].__file__, "..", "..", "..")
 _BASE_DIR = os.path.abspath(_BASE_DIR)
 _IN_TREE_TESTS_DIR = os.path.join(_BASE_DIR, 'examples', 'tests')
-
-SETTINGS_BASE_DIR = os.path.expanduser(settings.get_value('datadir.paths', 'base_dir'))
-SETTINGS_TEST_DIR = os.path.expanduser(settings.get_value('datadir.paths', 'test_dir'))
-SETTINGS_DATA_DIR = os.path.expanduser(settings.get_value('datadir.paths', 'data_dir'))
-SETTINGS_LOG_DIR = os.path.expanduser(settings.get_value('datadir.paths', 'logs_dir'))
 
 SYSTEM_BASE_DIR = '/var/lib/avocado'
 if 'VIRTUAL_ENV' in os.environ:
@@ -58,6 +53,13 @@ USER_BASE_DIR = os.path.expanduser('~/avocado')
 USER_TEST_DIR = os.path.join(USER_BASE_DIR, 'tests')
 USER_DATA_DIR = os.path.join(USER_BASE_DIR, 'data')
 USER_LOG_DIR = os.path.join(USER_BASE_DIR, 'job-results')
+
+
+def _get_settings_dir(dir_name):
+    """
+    Returns a given "datadir" directory as set by the configuration system
+    """
+    return os.path.expanduser(settings.settings.get_value('datadir.paths', dir_name))
 
 
 def _get_rw_dir(settings_location, system_location, user_location):
@@ -73,7 +75,7 @@ def _get_rw_dir(settings_location, system_location, user_location):
 
 
 def _get_ro_dir(settings_location, system_location, user_location):
-    if not settings.intree:
+    if not settings.settings.intree:
         if utils_path.usable_ro_dir(settings_location):
             return settings_location
 
@@ -97,7 +99,8 @@ def get_base_dir():
         * Data directory
         * Tests directory
     """
-    return _get_rw_dir(SETTINGS_BASE_DIR, SYSTEM_BASE_DIR, USER_BASE_DIR)
+    return _get_rw_dir(_get_settings_dir('base_dir'),
+                       SYSTEM_BASE_DIR, USER_BASE_DIR)
 
 
 def get_test_dir():
@@ -106,9 +109,9 @@ def get_test_dir():
 
     The test location is where we store tests written with the avocado API.
     """
-    if settings.intree:
+    if settings.settings.intree:
         return _IN_TREE_TESTS_DIR
-    return _get_ro_dir(SETTINGS_TEST_DIR, SYSTEM_TEST_DIR, USER_TEST_DIR)
+    return _get_ro_dir(_get_settings_dir('test_dir'), SYSTEM_TEST_DIR, USER_TEST_DIR)
 
 
 def get_data_dir():
@@ -124,7 +127,8 @@ def get_data_dir():
         * VM images
         * Reference bitmaps
     """
-    return _get_rw_dir(SETTINGS_DATA_DIR, SYSTEM_DATA_DIR, USER_DATA_DIR)
+    return _get_rw_dir(_get_settings_dir('data_dir'),
+                       SYSTEM_DATA_DIR, USER_DATA_DIR)
 
 
 def get_datafile_path(*args):
@@ -143,7 +147,8 @@ def get_logs_dir():
 
     The log dir is where we store job/test logs in general.
     """
-    return _get_rw_dir(SETTINGS_LOG_DIR, SYSTEM_LOG_DIR, USER_LOG_DIR)
+    return _get_rw_dir(_get_settings_dir('logs_dir'),
+                       SYSTEM_LOG_DIR, USER_LOG_DIR)
 
 
 def create_job_logs_dir(logdir=None, unique_id=None):

--- a/selftests/unit/test_datadir.py
+++ b/selftests/unit/test_datadir.py
@@ -8,33 +8,41 @@ from flexmock import flexmock
 from avocado.core import settings
 
 
-def _get_bogus_settings(args):
-    return ('[datadir.paths]\n'
-            'base_dir = %(base_dir)s\n'
-            'test_dir = %(test_dir)s\n'
-            'data_dir = %(data_dir)s\n'
-            'logs_dir = %(logs_dir)s\n') % args
-
-
 class DataDirTest(unittest.TestCase):
 
+    @staticmethod
+    def _get_temporary_dirs_mapping_and_config():
+        """
+        Creates a temporary bogus base data dir
+
+        And returns a dictionary containing the temporary data dir paths and
+        a the path to a configuration file contain those same settings
+        """
+        base_dir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        mapping = {'base_dir': base_dir,
+                   'test_dir': os.path.join(base_dir, 'tests'),
+                   'data_dir': os.path.join(base_dir, 'data'),
+                   'logs_dir': os.path.join(base_dir, 'logs')}
+        temp_settings = ('[datadir.paths]\n'
+                         'base_dir = %(base_dir)s\n'
+                         'test_dir = %(test_dir)s\n'
+                         'data_dir = %(data_dir)s\n'
+                         'logs_dir = %(logs_dir)s\n') % mapping
+        config_file = tempfile.NamedTemporaryFile(delete=False)
+        config_file.write(temp_settings)
+        config_file.close()
+        return (mapping, config_file.name)
+
     def setUp(self):
-        tbase = tempfile.mkdtemp(prefix='avocado_' + __name__)
-        tdir = os.path.join(tbase, 'tests')
-        tdata = os.path.join(tbase, 'data')
-        tlogs = os.path.join(tbase, 'logs')
-        self.mapping = {'base_dir': tbase, 'test_dir': tdir, 'data_dir': tdata,
-                        'logs_dir': tlogs}
-        self.config_file = tempfile.NamedTemporaryFile(delete=False)
-        self.config_file.write(_get_bogus_settings(self.mapping))
-        self.config_file.close()
+        (self.mapping,
+         self.config_file_path) = self._get_temporary_dirs_mapping_and_config()
 
     def testDataDirFromConfig(self):
         """
         When avocado.conf is present, honor the values coming from it.
         """
         stg_orig = settings.settings
-        stg = settings.Settings(self.config_file.name)
+        stg = settings.Settings(self.config_file_path)
         try:
             # Trick the module to think we're on a system wide install
             stg.intree = False
@@ -73,7 +81,7 @@ class DataDirTest(unittest.TestCase):
         self.assertTrue(os.path.exists(path))
 
     def tearDown(self):
-        os.unlink(self.config_file.name)
+        os.unlink(self.config_file_path)
         shutil.rmtree(self.mapping['base_dir'])
 
 if __name__ == '__main__':


### PR DESCRIPTION
The configurations related to the "data_dir" are currently read at module load time. This means that changes in the configuration between module load time and changes to the settings (such as parsing an additional config file) is never seen.

This fixes this issue, making every lookup of the data_dir settings dynamic.

Reference:

https://trello.com/c/QSNlIbP6/574-bug-data-dir-module-ignores-settings