### PR TITLE
avocado.core.output: Adjust the streams and improve UI

### DIFF
--- a/avocado/core/app.py
+++ b/avocado/core/app.py
@@ -61,7 +61,8 @@ class AvocadoApp(object):
                 if self.parser.args is None:     # Early failure
                     import argparse
                     self.parser.args = argparse.Namespace()
-                output.enable_stderr()
+                output.STD_OUTPUT.enable_outputs()
+                output.STD_OUTPUT.print_records()
                 self.parser.args.show = ["app"]
             output.reconfigure(self.parser.args)
 

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -183,11 +183,12 @@ class Job(object):
                 'early' not in enabled_logs):
             self.stdout_stderr = sys.stdout, sys.stderr
             # Enable std{out,err} but redirect booth to stderr
-            sys.stdout = output.STD_OUTPUT.stderr
-            sys.stderr = output.STD_OUTPUT.stderr
+            _gray = output.TERM_SUPPORT.COLOR_DARKGREY
+            _gray_stderr = output.STD_OUTPUT.get_colored_output(_gray, False)
+            sys.stdout = sys.stderr = _gray_stderr
             test_handler = output.add_log_handler("avocado.test",
                                                   logging.StreamHandler,
-                                                  output.STD_OUTPUT.stderr,
+                                                  _gray_stderr,
                                                   logging.DEBUG,
                                                   fmt="%(message)s")
             root_logger.addHandler(test_handler)

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -183,11 +183,11 @@ class Job(object):
                 'early' not in enabled_logs):
             self.stdout_stderr = sys.stdout, sys.stderr
             # Enable std{out,err} but redirect booth to stderr
-            sys.stdout = output.STDERR
-            sys.stderr = output.STDERR
+            sys.stdout = output.STD_OUTPUT.stderr
+            sys.stderr = output.STD_OUTPUT.stderr
             test_handler = output.add_log_handler("avocado.test",
                                                   logging.StreamHandler,
-                                                  output.STDERR,
+                                                  output.STD_OUTPUT.stderr,
                                                   logging.DEBUG,
                                                   fmt="%(message)s")
             root_logger.addHandler(test_handler)

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -98,7 +98,7 @@ class TestLoaderProxy(object):
             name = plugin.name
             mapping = plugin.get_type_label_mapping()
             # Using __func__ to avoid problem with different term_supp instances
-            healthy_func = getattr(output.term_support.healthy_str, '__func__')
+            healthy_func = getattr(output.TERM_SUPPORT.healthy_str, '__func__')
             types = [mapping[_[0]]
                      for _ in plugin.get_decorator_mapping().iteritems()
                      if _[1].__func__ is healthy_func]
@@ -416,13 +416,13 @@ class FileLoader(TestLoader):
 
     @staticmethod
     def get_decorator_mapping():
-        return {test.SimpleTest: output.term_support.healthy_str,
-                test.NotATest: output.term_support.warn_header_str,
-                test.MissingTest: output.term_support.fail_header_str,
-                BrokenSymlink: output.term_support.fail_header_str,
-                AccessDeniedPath: output.term_support.fail_header_str,
-                test.Test: output.term_support.healthy_str,
-                FilteredOut: output.term_support.warn_header_str}
+        return {test.SimpleTest: output.TERM_SUPPORT.healthy_str,
+                test.NotATest: output.TERM_SUPPORT.warn_header_str,
+                test.MissingTest: output.TERM_SUPPORT.fail_header_str,
+                BrokenSymlink: output.TERM_SUPPORT.fail_header_str,
+                AccessDeniedPath: output.TERM_SUPPORT.fail_header_str,
+                test.Test: output.TERM_SUPPORT.healthy_str,
+                FilteredOut: output.TERM_SUPPORT.warn_header_str}
 
     def discover(self, url, which_tests=DEFAULT):
         """
@@ -780,7 +780,7 @@ class ExternalLoader(TestLoader):
 
     @staticmethod
     def get_decorator_mapping():
-        return {test.ExternalRunnerTest: output.term_support.healthy_str}
+        return {test.ExternalRunnerTest: output.TERM_SUPPORT.healthy_str}
 
 
 loader = TestLoaderProxy()

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -348,6 +348,10 @@ def reconfigure(args):
     # "silent" is incompatible with "paginator"
     elif getattr(args, "paginator", False) == "on" and TERM_SUPPORT.enabled:
         STD_OUTPUT.enable_paginator()
+    if "none" in enabled:
+        del enabled[:]
+    elif "all" in enabled:
+        enabled.extend([_ for _ in BUILTIN_STREAMS if _ not in enabled])
     if os.environ.get("AVOCADO_LOG_EARLY") and "early" not in enabled:
         enabled.append("early")
     if os.environ.get("AVOCADO_LOG_DEBUG") and "debug" not in enabled:

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -39,28 +39,20 @@ else:
 STDOUT = _STDOUT = sys.stdout
 STDERR = _STDERR = sys.stderr
 
+#: Builtin special keywords to enable set of logging streams
 BUILTIN_STREAMS = {'app': 'application output',
                    'test': 'test output',
                    'debug': 'tracebacks and other debugging info',
                    'remote': 'fabric/paramiko debug',
                    'early':  'early logging of other streams (very verbose)'}
-
+#: Groups of builtin streams
 BUILTIN_STREAM_SETS = {'all': 'all builtin streams',
                        'none': 'disable console logging completely'}
-
-
 #: Transparently handles colored terminal, when one is used
 TERM_SUPPORT = None
 
 
 class TermSupport(object):
-
-    """
-    Class to help applications to colorize their outputs for terminals.
-
-    This will probe the current terminal and colorize ouput only if the
-    stdout is in a tty or the terminal type is recognized.
-    """
 
     COLOR_BLUE = '\033[94m'
     COLOR_GREEN = '\033[92m'
@@ -75,6 +67,13 @@ class TermSupport(object):
 
     ESCAPE_CODES = [COLOR_BLUE, COLOR_GREEN, COLOR_YELLOW, COLOR_RED,
                     COLOR_DARKGREY, CONTROL_END, MOVE_BACK, MOVE_FORWARD]
+
+    """
+    Class to help applications to colorize their outputs for terminals.
+
+    This will probe the current terminal and colorize ouput only if the
+    stdout is in a tty or the terminal type is recognized.
+    """
 
     def __init__(self):
         self.HEADER = self.COLOR_BLUE

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -369,16 +369,19 @@ def reconfigure(args):
     app_err_handler.stream = STD_OUTPUT.stderr
     app_logger.addHandler(app_err_handler)
     app_logger.propagate = False
+    gray_stderr = STD_OUTPUT.get_colored_output(TERM_SUPPORT.COLOR_DARKGREY,
+                                                False)
+
     if not os.environ.get("AVOCADO_LOG_EARLY"):
         logging.getLogger("avocado.test.stdout").propagate = False
         logging.getLogger("avocado.test.stderr").propagate = False
         if "early" in enabled:
             STD_OUTPUT.enable_outputs()
             STD_OUTPUT.print_records()
-            add_log_handler("", logging.StreamHandler, STD_OUTPUT.stderr,
+            add_log_handler("", logging.StreamHandler, gray_stderr,
                             logging.DEBUG)
             add_log_handler("avocado.test", logging.StreamHandler,
-                            STD_OUTPUT.stderr, logging.DEBUG)
+                            gray_stderr, logging.DEBUG)
         else:
             # TODO: When stdout/stderr is not used by avocado we should move
             # this to output.start_job_logging
@@ -386,15 +389,15 @@ def reconfigure(args):
             disable_log_handler("")
             disable_log_handler("avocado.test")
     if "remote" in enabled:
-        add_log_handler("avocado.fabric", stream=STD_OUTPUT.stderr)
-        add_log_handler("paramiko", stream=STD_OUTPUT.stderr)
+        add_log_handler("avocado.fabric", stream=gray_stderr)
+        add_log_handler("paramiko", stream=gray_stderr)
     else:
         disable_log_handler("avocado.fabric")
         disable_log_handler("paramiko")
     # Not enabled by env
     if not os.environ.get('AVOCADO_LOG_DEBUG'):
         if "debug" in enabled:
-            add_log_handler("avocado.app.debug", stream=STD_OUTPUT.stderr)
+            add_log_handler("avocado.app.debug", stream=gray_stderr)
         else:
             disable_log_handler("avocado.app.debug")
 
@@ -408,7 +411,7 @@ def reconfigure(args):
             level = (int(name[1]) if name[1].isdigit()
                      else logging.getLevelName(name[1].upper()))
         try:
-            add_log_handler(name, logging.StreamHandler, STD_OUTPUT.stderr,
+            add_log_handler(name, logging.StreamHandler, gray_stderr,
                             level)
         except ValueError, details:
             app_logger.error("Failed to set logger for --show %s:%s: %s.",

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -241,17 +241,10 @@ def reconfigure(args):
     # Reconfigure stream loggers
     global STDOUT
     global STDERR
-    if getattr(args, "paginator", False) == "on" and TERM_SUPPORT.enabled:
-        STDOUT = Paginator()
-        STDERR = STDOUT
     enabled = getattr(args, "show", None)
     if not isinstance(enabled, list):
         enabled = ["app"]
         args.show = enabled
-    if os.environ.get("AVOCADO_LOG_EARLY") and "early" not in enabled:
-        enabled.append("early")
-    if os.environ.get("AVOCADO_LOG_DEBUG") and "debug" not in enabled:
-        enabled.append("debug")
     if getattr(args, "show_job_log", False):
         del enabled[:]
         enabled.append("test")
@@ -260,7 +253,14 @@ def reconfigure(args):
         sys.stderr = sys.stdout
         logging.disable(logging.CRITICAL)
         del enabled[:]
-        return
+    if os.environ.get("AVOCADO_LOG_EARLY") and "early" not in enabled:
+        enabled.append("early")
+    if os.environ.get("AVOCADO_LOG_DEBUG") and "debug" not in enabled:
+        enabled.append("debug")
+    # "silent" is incompatible with "paginator"
+    elif getattr(args, "paginator", False) == "on" and TERM_SUPPORT.enabled:
+        STDOUT = Paginator()
+        STDERR = STDOUT
     if "app" in enabled:
         app_logger = logging.getLogger("avocado.app")
         app_handler = ProgressStreamHandler()

--- a/avocado/core/result.py
+++ b/avocado/core/result.py
@@ -310,19 +310,19 @@ class HumanTestResult(TestResult):
         status = state["status"]
         if status == "TEST_NA":
             status = "SKIP"
-        mapping = {'PASS': output.term_support.PASS,
-                   'ERROR': output.term_support.ERROR,
-                   'FAIL': output.term_support.FAIL,
-                   'SKIP': output.term_support.SKIP,
-                   'WARN': output.term_support.WARN,
-                   'INTERRUPTED': output.term_support.INTERRUPT}
-        self.log.debug(output.term_support.MOVE_BACK + mapping[status] +
-                       status + output.term_support.ENDC)
+        mapping = {'PASS': output.TERM_SUPPORT.PASS,
+                   'ERROR': output.TERM_SUPPORT.ERROR,
+                   'FAIL': output.TERM_SUPPORT.FAIL,
+                   'SKIP': output.TERM_SUPPORT.SKIP,
+                   'WARN': output.TERM_SUPPORT.WARN,
+                   'INTERRUPTED': output.TERM_SUPPORT.INTERRUPT}
+        self.log.debug(output.TERM_SUPPORT.MOVE_BACK + mapping[status] +
+                       status + output.TERM_SUPPORT.ENDC)
 
     def notify_progress(self, progress=False):
         if progress:
-            color = output.term_support.PASS
+            color = output.TERM_SUPPORT.PASS
         else:
-            color = output.term_support.PARTIAL
+            color = output.TERM_SUPPORT.PARTIAL
         self.log.debug(color + self.__throbber.render() +
-                       output.term_support.ENDC, extra={"skip_newline": True})
+                       output.TERM_SUPPORT.ENDC, extra={"skip_newline": True})

--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -544,9 +544,9 @@ class OutputValue(object):  # only container pylint: disable=R0903
 
     def __str__(self):
         return "%s%s@%s:%s%s" % (self.value,
-                                 output.term_support.LOWLIGHT,
+                                 output.TERM_SUPPORT.LOWLIGHT,
                                  self.yaml, self.node.path,
-                                 output.term_support.ENDC)
+                                 output.TERM_SUPPORT.ENDC)
 
 
 class OutputList(list):  # only container pylint: disable=R0903
@@ -566,8 +566,8 @@ class OutputList(list):  # only container pylint: disable=R0903
                           self.yamls + other.yamls)
 
     def __str__(self):
-        color = output.term_support.LOWLIGHT
-        cend = output.term_support.ENDC
+        color = output.TERM_SUPPORT.LOWLIGHT
+        cend = output.TERM_SUPPORT.ENDC
         return ' + '.join("%s%s@%s:%s%s"
                           % (_[0], color, _[1], _[2].path, cend)
                           for _ in itertools.izip(self, self.yamls,

--- a/avocado/plugins/list.py
+++ b/avocado/plugins/list.py
@@ -104,8 +104,8 @@ class TestLister(object):
     def _display(self, test_matrix, stats):
         header = None
         if self.args.verbose:
-            header = (output.term_support.header_str('Type'),
-                      output.term_support.header_str('Test'))
+            header = (output.TERM_SUPPORT.header_str('Type'),
+                      output.TERM_SUPPORT.header_str('Test'))
 
         for line in astring.iter_tabular_output(test_matrix, header=header):
             self.log.debug(line)

--- a/avocado/plugins/multiplex.py
+++ b/avocado/plugins/multiplex.py
@@ -121,8 +121,8 @@ class Multiplex(CLICmd):
             if not args.debug:
                 paths = ', '.join([x.path for x in tpl])
             else:
-                color = output.term_support.LOWLIGHT
-                cend = output.term_support.ENDC
+                color = output.TERM_SUPPORT.LOWLIGHT
+                cend = output.TERM_SUPPORT.ENDC
                 paths = ', '.join(["%s%s@%s%s" % (_.name, color,
                                                   getattr(_, 'yaml',
                                                           "Unknown"),


### PR DESCRIPTION
After the big logging refactoring we decided the behavior should be slightly different. This pullrequest tries to adjust the handling accordingly and adds 2 RFC to improve the UI even further.

Main changes:

* stdout messages are printed to stdout (--help)
* stdout is not disabled on `--silent`
* RFC: Always colorize stderr in red
* RFC: Always colorize non-app streams in dark-grey

Additionally I think we can consider leaving `test` stream as is (default color) and use dark-grey only for other streams (the proper debug streams)