### PR TITLE
avocado.pugins.replay record/replay loader options [v5]

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -378,8 +378,8 @@ def add_loader_options(parser):
                   'where those files are located, use "test" here and '
                   'specify the test directory with the option '
                   '"--external-runner-testdir". Defaults to "%(default)s"')
-    arggrp.add_argument('--external-runner-chdir', default='off',
-                        choices=('runner', 'test', 'off'),
+    arggrp.add_argument('--external-runner-chdir', default=None,
+                        choices=('runner', 'test'),
                         help=chdir_help)
 
     arggrp.add_argument('--external-runner-testdir', metavar='DIRECTORY',
@@ -725,7 +725,7 @@ class ExternalLoader(TestLoader):
     @staticmethod
     def _process_external_runner(args, runner):
         """ Enables the external_runner when asked for """
-        chdir = getattr(args, 'external_runner_chdir', 'off')
+        chdir = getattr(args, 'external_runner_chdir', None)
         test_dir = getattr(args, 'external_runner_testdir', None)
 
         if runner:
@@ -752,7 +752,7 @@ class ExternalLoader(TestLoader):
                                                          ['runner', 'chdir',
                                                           'test_dir'])
             return cls_external_runner(runner, chdir, test_dir)
-        elif chdir != "off":
+        elif chdir:
             msg = ('Option "--external-runner-chdir" requires '
                    '"--external-runner" to be set.')
             raise LoaderError(msg)

--- a/avocado/core/replay.py
+++ b/avocado/core/replay.py
@@ -36,6 +36,7 @@ def record(args, logdir, mux, urls=None):
     path_urls = os.path.join(replay_dir, 'urls')
     path_mux = os.path.join(replay_dir, 'multiplex')
     path_pwd = os.path.join(replay_dir, 'pwd')
+    path_args = os.path.join(replay_dir, 'args')
 
     if urls:
         with open(path_urls, 'w') as f:
@@ -49,6 +50,9 @@ def record(args, logdir, mux, urls=None):
 
     with open(path_pwd, 'w') as f:
         f.write('%s' % os.getcwd())
+
+    with open(path_args, 'w') as f:
+        pickle.dump(args.__dict__, f, pickle.HIGHEST_PROTOCOL)
 
 
 def retrieve_pwd(resultsdir):
@@ -97,6 +101,15 @@ def retrieve_replay_map(resultsdir, replay_filter):
             replay_map.append(None)
 
     return replay_map
+
+
+def retrieve_args(resultsdir):
+    pkl_path = os.path.join(resultsdir, 'replay', 'args')
+    if not os.path.exists(pkl_path):
+        return None
+
+    with open(pkl_path, 'r') as f:
+        return pickle.load(f)
 
 
 def get_resultsdir(logdir, jobid):

--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -129,9 +129,29 @@ class Replay(CLI):
                    % (args.replay_jobid, resultsdir))
             log.error(msg)
             sys.exit(exit_codes.AVOCADO_JOB_FAIL)
-
         setattr(args, 'replay_sourcejob', sourcejob)
 
+        replay_args = replay.retrieve_args(resultsdir)
+        whitelist = ['loaders',
+                     'external_runner',
+                     'external_runner_testdir',
+                     'external_runner_chdir']
+        if replay_args is None:
+            log.warn('Source job args data not found. These options will not '
+                     'be loaded in this replay job: %s', ', '.join(whitelist))
+        else:
+            for option in whitelist:
+                optvalue = getattr(args, option, None)
+                if optvalue:
+                    log.warn("Overriding the replay %s with the --%s value "
+                             "given on the command line.",
+                             option.replace('_', '-'),
+                             option.replace('_', '-'))
+                else:
+                    setattr(args, option, replay_args[option])
+
+        # Keeping this for compatibility.
+        # TODO: Use replay_args['url'] at some point in the future.
         if getattr(args, 'url', None):
             log.warn('Overriding the replay urls with urls provided in '
                      'command line.')

--- a/selftests/functional/test_replay_basic.py
+++ b/selftests/functional/test_replay_basic.py
@@ -23,13 +23,13 @@ class ReplayTests(unittest.TestCase):
 
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
-        cmd_line = ('./scripts/avocado run passtest --multiplex '
+        cmd_line = ('./scripts/avocado run passtest '
+                    '--multiplex '
                     'examples/tests/sleeptest.py.data/sleeptest.yaml '
-                    '--job-results-dir %s --sysinfo=off' %
+                    '--job-results-dir %s --sysinfo=off --json -' %
                     self.tmpdir)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.run_and_check(cmd_line, expected_rc)
-
         self.jobdir = ''.join(glob.glob(os.path.join(self.tmpdir, 'job-*')))
         idfile = ''.join(os.path.join(self.jobdir, 'id'))
         with open(idfile, 'r') as f:
@@ -51,7 +51,7 @@ class ReplayTests(unittest.TestCase):
         self.run_and_check(cmd_line, expected_rc)
 
     def test_run_replay_data(self):
-        file_list = ['multiplex', 'config', 'urls', 'pwd']
+        file_list = ['multiplex', 'config', 'urls', 'pwd', 'args']
         for filename in file_list:
             path = os.path.join(self.jobdir, 'replay', filename)
             self.assertTrue(glob.glob(path))
@@ -106,10 +106,7 @@ class ReplayTests(unittest.TestCase):
                     '--sysinfo=off' % (self.jobid, self.tmpdir, self.jobdir))
         expected_rc = exit_codes.AVOCADO_ALL_OK
         result = self.run_and_check(cmd_line, expected_rc)
-        msg = '(1/4) passtest.py:PassTest.test.variant1:  SKIP\n ' \
-              '(2/4) passtest.py:PassTest.test.variant2:  SKIP\n ' \
-              '(3/4) passtest.py:PassTest.test.variant3:  SKIP\n ' \
-              '(4/4) passtest.py:PassTest.test.variant4:  SKIP'
+        msg = 'RESULTS    : PASS 0 | ERROR 0 | FAIL 0 | SKIP 4 | WARN 0 | INTERRUPT 0'
         self.assertIn(msg, result.stdout)
 
     def test_run_replay_remotefail(self):

--- a/selftests/functional/test_replay_external_runner.py
+++ b/selftests/functional/test_replay_external_runner.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+
+import glob
+import os
+import sys
+import tempfile
+import shutil
+
+if sys.version_info[:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
+
+from avocado.core import exit_codes
+from avocado.utils import process
+from avocado.utils import script
+
+
+basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..')
+basedir = os.path.abspath(basedir)
+
+
+class ReplayTests(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        test = script.make_script(os.path.join(self.tmpdir, 'test'), 'exit 0')
+        cmd_line = ('./scripts/avocado run %s '
+                    '--multiplex '
+                    'examples/tests/sleeptest.py.data/sleeptest.yaml '
+                    '--external-runner /bin/bash '
+                    '--job-results-dir %s --sysinfo=off --json -' %
+                    (test, self.tmpdir))
+        expected_rc = exit_codes.AVOCADO_ALL_OK
+        self.run_and_check(cmd_line, expected_rc)
+        self.jobdir = ''.join(glob.glob(os.path.join(self.tmpdir, 'job-*')))
+        idfile = ''.join(os.path.join(self.jobdir, 'id'))
+        with open(idfile, 'r') as f:
+            self.jobid = f.read().strip('\n')
+
+    def run_and_check(self, cmd_line, expected_rc):
+        os.chdir(basedir)
+        result = process.run(cmd_line, ignore_status=True)
+        self.assertEqual(result.exit_status, expected_rc,
+                         "Command %s did not return rc "
+                         "%d:\n%s" % (cmd_line, expected_rc, result))
+        return result
+
+    def test_run_replay_external_runner(self):
+        cmd_line = ('./scripts/avocado run --replay %s '
+                    '--external-runner /bin/sh '
+                    '--job-results-dir %s --replay-data-dir %s --sysinfo=off' %
+                    (self.jobid, self.tmpdir, self.jobdir))
+        expected_rc = exit_codes.AVOCADO_ALL_OK
+        result = self.run_and_check(cmd_line, expected_rc)
+        msg = "Overriding the replay external-runner with the "\
+              "--external-runner value given on the command line."
+        self.assertIn(msg, result.stderr)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
v5:
 - Testing replay with and without external-runner in original job.

v4: #1071 
 - Test with external runner in original job.
 - Use json module (instead of ast) to load job result.

v3: #1069 
 - Rebased to use the new logging.

v2: #1056 
 - Whitelist with args options to replay.
 - external-runner-chdir defaults to None.

v1: #1046 
 - Record the loader options and reload them on job replay.