### PR TITLE
fix docs to not fail on make requirements

### DIFF
--- a/docs/source/GetStartedGuide.rst
+++ b/docs/source/GetStartedGuide.rst
@@ -55,7 +55,7 @@ First make sure you have a basic set of packages installed. The
 following applies to Fedora based distributions, please adapt to
 your platform::
 
-    sudo yum install -y git gcc python-devel python-pip libvirt-devel libyaml-devel
+    sudo yum install -y git gcc python-devel python-pip libvirt-devel libyaml-devel redhat-rpm-config xz-devel
 
 Then to install Avocado from the git repository run::
 


### PR DESCRIPTION
Trying to follow the docs to install avocado from source,
make requirements command fails doe to the missing
dependencies.

This patch adds the two missing dependencies I had to install
in addition to the ones listed in docs.

Reference: https://trello.com/c/1ryTxsXw
Signed-off-by: Amador Pahim <apahim@redhat.com>