### PR TITLE
selftests/functional/test_basic.py: extend timeout on test_kill_stopp…

### DIFF
--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -539,13 +539,14 @@ class RunnerSimpleTest(unittest.TestCase):
         # We need pid of the avocado, not the shell executing it
         pid = int(process.get_children_pids(proc.get_pid())[0])
         os.kill(pid, signal.SIGTSTP)   # This freezes the process
-        deadline = time.time() + 5
+        deadline = time.time() + 9
         while time.time() < deadline:
             if not proc.is_alive():
                 break
+            time.sleep(0.1)
         else:
             proc.kill(signal.SIGKILL)
-            self.fail("Avocado process still alive 1s after job-timeout:\n%s"
+            self.fail("Avocado process still alive 5s after job-timeout:\n%s"
                       % proc.get_output())
         output = proc.get_output()
         self.assertIn("ctrl+z pressed, stopping test", output, "SIGTSTP "


### PR DESCRIPTION
…ed_sleep

Given the last CI jobs, RunnerSimpleTest:test_kill_stopped_sleep() has
been failing often. The obvious reason, given the nature of the test
and the heavily shared and loaded computing resources they run on, is
the lack of resources.

One example of such as failure:

   ======================================================================
   FAIL: test_kill_stopped_sleep (selftests.functional.test_basic.RunnerSimpleTest)
   ----------------------------------------------------------------------
   Traceback (most recent call last):
     File "/home/travis/build/avocado-framework/avocado/selftests/functional/test_basic.py", line 549, in test_kill_stopped_sleep
       % proc.get_output())
   AssertionError: Avocado process still alive 1s after job-timeout:
   JOB ID     : 5c65a06b4ab15e69d6c4a1fc762368e0e99cbc1f
   JOB LOG    : /tmp/avocado_selftests.functional.test_basicHIyhV4/job-2016-03-09T15.08-5c65a06/job.log
   TESTS      : 1
    (1/1) /bin/sleep 60:
   ctrl+z pressed, stopping test (5046)
   ERROR

So, let's give 4 extra seconds for the process to be
terminated. Hopefully failures in the timeout handling will still be
revealed given the relatively small buffer.

Signed-off-by: Cleber Rosa <crosa@redhat.com>