### PR TITLE
Turn fabric pty off

### DIFF
--- a/avocado/core/remoter.py
+++ b/avocado/core/remoter.py
@@ -96,7 +96,8 @@ class Remote(object):
                 fabric_result = fabric.operations.run(command=command,
                                                       quiet=self.quiet,
                                                       warn_only=True,
-                                                      timeout=timeout)
+                                                      timeout=timeout,
+                                                      pty=False)
                 break
             except fabric.network.NetworkError as details:
                 fabric_exception = details


### PR DESCRIPTION
Fabric automatically echoes all text typed into the terminal back
out to the user. This makes avocado treat the echoed strings as
fabric return.

This patch disables terminal echo in fabric.

Reference: https://trello.com/c/xqN7bq6N
Signed-off-by: Amador Pahim <apahim@redhat.com>