### PR TITLE
avocado.core.output: Adjust the streams and improve UI [v4]

### DIFF
--- a/avocado/core/app.py
+++ b/avocado/core/app.py
@@ -22,6 +22,7 @@ import signal
 
 from .parser import Parser
 from . import output
+from .output import STD_OUTPUT
 from .settings import settings
 from .dispatcher import CLIDispatcher
 from .dispatcher import CLICmdDispatcher
@@ -61,8 +62,8 @@ class AvocadoApp(object):
                 if self.parser.args is None:     # Early failure
                     import argparse
                     self.parser.args = argparse.Namespace()
-                output.STD_OUTPUT.enable_outputs()
-                output.STD_OUTPUT.print_records()
+                STD_OUTPUT.enable_outputs()
+                STD_OUTPUT.print_records()
                 self.parser.args.show = ["app"]
             output.reconfigure(self.parser.args)
 
@@ -93,4 +94,4 @@ class AvocadoApp(object):
         finally:
             # This makes sure we cleanup the console (stty echo). The only way
             # to avoid cleaning it is to kill the less (paginator) directly
-            output.stop_logging()
+            STD_OUTPUT.close()

--- a/avocado/core/app.py
+++ b/avocado/core/app.py
@@ -57,14 +57,6 @@ class AvocadoApp(object):
                 self.cli_dispatcher.map_method('run', self.parser.args)
             initialized = True
         finally:
-            if (not initialized and
-                    getattr(self.parser.args, "silent", False) is False):
-                if self.parser.args is None:     # Early failure
-                    import argparse
-                    self.parser.args = argparse.Namespace()
-                STD_OUTPUT.enable_outputs()
-                STD_OUTPUT.print_records()
-                self.parser.args.show = ["app"]
             output.reconfigure(self.parser.args)
 
     def _print_plugin_failures(self):

--- a/avocado/core/app.py
+++ b/avocado/core/app.py
@@ -61,7 +61,8 @@ class AvocadoApp(object):
                 if self.parser.args is None:     # Early failure
                     import argparse
                     self.parser.args = argparse.Namespace()
-                output.enable_stderr()
+                output.STD_OUTPUT.enable_outputs()
+                output.STD_OUTPUT.print_records()
                 self.parser.args.show = ["app"]
             output.reconfigure(self.parser.args)
 

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -183,11 +183,11 @@ class Job(object):
                 'early' not in enabled_logs):
             self.stdout_stderr = sys.stdout, sys.stderr
             # Enable std{out,err} but redirect booth to stderr
-            sys.stdout = output.STD_OUTPUT.stderr
-            sys.stderr = output.STD_OUTPUT.stderr
+            sys.stdout = output.STD_OUTPUT.stdout
+            sys.stderr = output.STD_OUTPUT.stdout
             test_handler = output.add_log_handler("avocado.test",
                                                   logging.StreamHandler,
-                                                  output.STD_OUTPUT.stderr,
+                                                  output.STD_OUTPUT.stdout,
                                                   logging.DEBUG,
                                                   fmt="%(message)s")
             root_logger.addHandler(test_handler)

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -44,6 +44,7 @@ from . import test
 from . import xunit
 from . import jsonresult
 from . import replay
+from .output import STD_OUTPUT
 from .settings import settings
 from ..utils import archive
 from ..utils import astring
@@ -183,11 +184,11 @@ class Job(object):
                 'early' not in enabled_logs):
             self.stdout_stderr = sys.stdout, sys.stderr
             # Enable std{out,err} but redirect booth to stderr
-            sys.stdout = output.STD_OUTPUT.stdout
-            sys.stderr = output.STD_OUTPUT.stdout
+            sys.stdout = STD_OUTPUT.stdout
+            sys.stderr = STD_OUTPUT.stdout
             test_handler = output.add_log_handler("avocado.test",
                                                   logging.StreamHandler,
-                                                  output.STD_OUTPUT.stdout,
+                                                  STD_OUTPUT.stdout,
                                                   logging.DEBUG,
                                                   fmt="%(message)s")
             root_logger.addHandler(test_handler)

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -183,11 +183,11 @@ class Job(object):
                 'early' not in enabled_logs):
             self.stdout_stderr = sys.stdout, sys.stderr
             # Enable std{out,err} but redirect booth to stderr
-            sys.stdout = output.STDERR
-            sys.stderr = output.STDERR
+            sys.stdout = output.STD_OUTPUT.stderr
+            sys.stderr = output.STD_OUTPUT.stderr
             test_handler = output.add_log_handler("avocado.test",
                                                   logging.StreamHandler,
-                                                  output.STDERR,
+                                                  output.STD_OUTPUT.stderr,
                                                   logging.DEBUG,
                                                   fmt="%(message)s")
             root_logger.addHandler(test_handler)

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -98,7 +98,7 @@ class TestLoaderProxy(object):
             name = plugin.name
             mapping = plugin.get_type_label_mapping()
             # Using __func__ to avoid problem with different term_supp instances
-            healthy_func = getattr(output.term_support.healthy_str, '__func__')
+            healthy_func = getattr(output.TERM_SUPPORT.healthy_str, '__func__')
             types = [mapping[_[0]]
                      for _ in plugin.get_decorator_mapping().iteritems()
                      if _[1].__func__ is healthy_func]
@@ -416,13 +416,13 @@ class FileLoader(TestLoader):
 
     @staticmethod
     def get_decorator_mapping():
-        return {test.SimpleTest: output.term_support.healthy_str,
-                test.NotATest: output.term_support.warn_header_str,
-                test.MissingTest: output.term_support.fail_header_str,
-                BrokenSymlink: output.term_support.fail_header_str,
-                AccessDeniedPath: output.term_support.fail_header_str,
-                test.Test: output.term_support.healthy_str,
-                FilteredOut: output.term_support.warn_header_str}
+        return {test.SimpleTest: output.TERM_SUPPORT.healthy_str,
+                test.NotATest: output.TERM_SUPPORT.warn_header_str,
+                test.MissingTest: output.TERM_SUPPORT.fail_header_str,
+                BrokenSymlink: output.TERM_SUPPORT.fail_header_str,
+                AccessDeniedPath: output.TERM_SUPPORT.fail_header_str,
+                test.Test: output.TERM_SUPPORT.healthy_str,
+                FilteredOut: output.TERM_SUPPORT.warn_header_str}
 
     def discover(self, url, which_tests=DEFAULT):
         """
@@ -780,7 +780,7 @@ class ExternalLoader(TestLoader):
 
     @staticmethod
     def get_decorator_mapping():
-        return {test.ExternalRunnerTest: output.term_support.healthy_str}
+        return {test.ExternalRunnerTest: output.TERM_SUPPORT.healthy_str}
 
 
 loader = TestLoaderProxy()

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -331,11 +331,11 @@ def early_start():
     Replace all outputs with in-memory handlers
     """
     if os.environ.get('AVOCADO_LOG_DEBUG'):
-        add_log_handler("avocado.app.debug", logging.StreamHandler, sys.stderr,
+        add_log_handler("avocado.app.debug", logging.StreamHandler, sys.stdout,
                         logging.DEBUG)
     if os.environ.get('AVOCADO_LOG_EARLY'):
-        add_log_handler("", logging.StreamHandler, sys.stderr, logging.DEBUG)
-        add_log_handler("avocado.test", logging.StreamHandler, sys.stderr,
+        add_log_handler("", logging.StreamHandler, sys.stdout, logging.DEBUG)
+        add_log_handler("avocado.test", logging.StreamHandler, sys.stdout,
                         logging.DEBUG)
     else:
         STD_OUTPUT.fake_outputs()
@@ -392,23 +392,23 @@ def reconfigure(args):
         logging.getLogger("avocado.test.stdout").propagate = False
         logging.getLogger("avocado.test.stderr").propagate = False
         if "early" in enabled:
-            add_log_handler("", logging.StreamHandler, STD_OUTPUT.stderr,
+            add_log_handler("", logging.StreamHandler, STD_OUTPUT.stdout,
                             logging.DEBUG)
             add_log_handler("avocado.test", logging.StreamHandler,
-                            STD_OUTPUT.stderr, logging.DEBUG)
+                            STD_OUTPUT.stdout, logging.DEBUG)
         else:
             disable_log_handler("")
             disable_log_handler("avocado.test")
     if "remote" in enabled:
-        add_log_handler("avocado.fabric", stream=STD_OUTPUT.stderr)
-        add_log_handler("paramiko", stream=STD_OUTPUT.stderr)
+        add_log_handler("avocado.fabric", stream=STD_OUTPUT.stdout)
+        add_log_handler("paramiko", stream=STD_OUTPUT.stdout)
     else:
         disable_log_handler("avocado.fabric")
         disable_log_handler("paramiko")
     # Not enabled by env
     if not os.environ.get('AVOCADO_LOG_DEBUG'):
         if "debug" in enabled:
-            add_log_handler("avocado.app.debug", stream=STD_OUTPUT.stderr)
+            add_log_handler("avocado.app.debug", stream=STD_OUTPUT.stdout)
         else:
             disable_log_handler("avocado.app.debug")
 
@@ -422,7 +422,7 @@ def reconfigure(args):
             level = (int(name[1]) if name[1].isdigit()
                      else logging.getLevelName(name[1].upper()))
         try:
-            add_log_handler(name, logging.StreamHandler, STD_OUTPUT.stderr,
+            add_log_handler(name, logging.StreamHandler, STD_OUTPUT.stdout,
                             level)
         except ValueError, details:
             app_logger.error("Failed to set logger for --show %s:%s: %s.",

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -360,6 +360,10 @@ def reconfigure(args):
     # "silent" is incompatible with "paginator"
     elif getattr(args, "paginator", False) == "on" and TERM_SUPPORT.enabled:
         STD_OUTPUT.enable_paginator()
+    if "none" in enabled:
+        del enabled[:]
+    elif "all" in enabled:
+        enabled.extend([_ for _ in BUILTIN_STREAMS if _ not in enabled])
     if os.environ.get("AVOCADO_LOG_EARLY") and "early" not in enabled:
         enabled.append("early")
     if os.environ.get("AVOCADO_LOG_DEBUG") and "debug" not in enabled:

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -39,28 +39,20 @@ else:
 STDOUT = _STDOUT = sys.stdout
 STDERR = _STDERR = sys.stderr
 
+#: Builtin special keywords to enable set of logging streams
 BUILTIN_STREAMS = {'app': 'application output',
                    'test': 'test output',
                    'debug': 'tracebacks and other debugging info',
                    'remote': 'fabric/paramiko debug',
                    'early':  'early logging of other streams (very verbose)'}
-
+#: Groups of builtin streams
 BUILTIN_STREAM_SETS = {'all': 'all builtin streams',
                        'none': 'disable console logging completely'}
-
-
 #: Transparently handles colored terminal, when one is used
 TERM_SUPPORT = None
 
 
 class TermSupport(object):
-
-    """
-    Class to help applications to colorize their outputs for terminals.
-
-    This will probe the current terminal and colorize ouput only if the
-    stdout is in a tty or the terminal type is recognized.
-    """
 
     COLOR_BLUE = '\033[94m'
     COLOR_GREEN = '\033[92m'
@@ -75,6 +67,13 @@ class TermSupport(object):
 
     ESCAPE_CODES = [COLOR_BLUE, COLOR_GREEN, COLOR_YELLOW, COLOR_RED,
                     COLOR_DARKGREY, CONTROL_END, MOVE_BACK, MOVE_FORWARD]
+
+    """
+    Class to help applications to colorize their outputs for terminals.
+
+    This will probe the current terminal and colorize ouput only if the
+    stdout is in a tty or the terminal type is recognized.
+    """
 
     def __init__(self):
         self.HEADER = self.COLOR_BLUE

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -241,17 +241,10 @@ def reconfigure(args):
     # Reconfigure stream loggers
     global STDOUT
     global STDERR
-    if getattr(args, "paginator", False) == "on" and TERM_SUPPORT.enabled:
-        STDOUT = Paginator()
-        STDERR = STDOUT
     enabled = getattr(args, "show", None)
     if not isinstance(enabled, list):
         enabled = ["app"]
         args.show = enabled
-    if os.environ.get("AVOCADO_LOG_EARLY") and "early" not in enabled:
-        enabled.append("early")
-    if os.environ.get("AVOCADO_LOG_DEBUG") and "debug" not in enabled:
-        enabled.append("debug")
     if getattr(args, "show_job_log", False):
         del enabled[:]
         enabled.append("test")
@@ -260,7 +253,14 @@ def reconfigure(args):
         sys.stderr = sys.stdout
         logging.disable(logging.CRITICAL)
         del enabled[:]
-        return
+    # "silent" is incompatible with "paginator"
+    elif getattr(args, "paginator", False) == "on" and TERM_SUPPORT.enabled:
+        STDOUT = Paginator()
+        STDERR = STDOUT
+    if os.environ.get("AVOCADO_LOG_EARLY") and "early" not in enabled:
+        enabled.append("early")
+    if os.environ.get("AVOCADO_LOG_DEBUG") and "debug" not in enabled:
+        enabled.append("debug")
     if "app" in enabled:
         app_logger = logging.getLogger("avocado.app")
         app_handler = ProgressStreamHandler()

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -36,7 +36,7 @@ BUILTIN_STREAMS = {'app': 'application output',
                    'test': 'test output',
                    'debug': 'tracebacks and other debugging info',
                    'remote': 'fabric/paramiko debug',
-                   'early':  'early logging of other streams (very verbose)'}
+                   'early':  'early logging of other streams, including test (very verbose)'}
 #: Groups of builtin streams
 BUILTIN_STREAM_SETS = {'all': 'all builtin streams',
                        'none': 'disable console logging completely'}

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -438,10 +438,6 @@ def reconfigure(args):
         logging.getLogger(record.name).handle(record)
 
 
-def stop_logging():
-    STD_OUTPUT.close()
-
-
 class FilterWarnAndMore(logging.Filter):
 
     def filter(self, record):

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -24,20 +24,12 @@ from . import exit_codes
 from ..utils import path as utils_path
 from .settings import settings
 
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
-
 if hasattr(logging, 'NullHandler'):
     NULL_HANDLER = logging.NullHandler
 else:
     import logutils
     NULL_HANDLER = logutils.NullHandler
 
-
-STDOUT = _STDOUT = sys.stdout
-STDERR = _STDERR = sys.stderr
 
 #: Builtin special keywords to enable set of logging streams
 BUILTIN_STREAMS = {'app': 'application output',
@@ -50,6 +42,8 @@ BUILTIN_STREAM_SETS = {'all': 'all builtin streams',
                        'none': 'disable console logging completely'}
 #: Transparently handles colored terminal, when one is used
 TERM_SUPPORT = None
+#: Allows modifying the sys.stdout/sys.stderr
+STD_OUTPUT = None
 
 
 class TermSupport(object):
@@ -205,32 +199,147 @@ class TermSupport(object):
 TERM_SUPPORT = TermSupport()
 
 
+class _StdOutputFile(object):
+
+    """
+    File-like object which stores (_is_stdout, content) into the provided list
+    """
+
+    def __init__(self, is_stdout, records):
+        """
+        :param is_stdout: Is this output stdout or stderr
+        :param records: list to store (is_stdout, written_message) records
+        """
+        self._is_stdout = is_stdout
+        self._records = records
+
+    def write(self, msg):
+        """
+        Record the message
+        """
+        self._records.append((self._is_stdout, msg))
+
+    def writelines(self, iterable):
+        """
+        Record all messages
+        """
+        for line in iterable:
+            self.write(line)
+
+    def close(self):
+        """ File-object methods """
+        pass
+
+    def flush(self):
+        """ File-object methods """
+        pass
+
+    def isatty(self):
+        """ File-object methods """
+        return False
+
+    def seek(self):
+        """ File-object methods """
+        pass
+
+    def tell(self):
+        """ File-object methods """
+        pass
+
+    def getvalue(self):
+        """
+        Get all messages written to this "file"
+        """
+        return "\n".join((_[1] for _ in self._records
+                          if _[0] == self._is_stdout))
+
+
+class StdOutput(object):
+
+    """
+    Class to modify sys.stdout/sys.stderr
+    """
+    #: List of records of stored output when stdout/stderr is disabled
+    records = []
+
+    def __init__(self):
+        self.stdout = self._stdout = sys.stdout
+        self.stderr = self._stderr = sys.stderr
+
+    def _paginator_in_use(self):
+        """
+        :return: True when we output into paginator
+        """
+        return bool(isinstance(sys.stdout, Paginator))
+
+    def print_records(self):
+        """
+        Prints all stored messages as they occured into streams they were
+        produced for.
+        """
+        for stream, msg in self.records:
+            if stream:
+                sys.stdout.write(msg)
+            else:
+                sys.stderr.write(msg)
+        del self.records[:]
+
+    def fake_outputs(self):
+        """
+        Replace sys.stdout/sys.stderr with in-memory-objects
+        """
+        sys.stdout = _StdOutputFile(True, self.records)
+        sys.stderr = _StdOutputFile(False, self.records)
+
+    def enable_outputs(self):
+        """
+        Enable sys.stdout/sys.stderr (either with 2 streams or with paginator)
+        """
+        sys.stdout = self.stdout
+        sys.stderr = self.stderr
+
+    def enable_paginator(self):
+        """
+        Enable paginator
+        """
+        self.stdout = self.stderr = Paginator()
+
+    def disable_outputs(self):
+        """
+        Disable sys.stdout/sys.stderr (including in-memory-object)
+        """
+        sys.stdout = sys.stderr = open(os.devnull, 'w')
+
+    def close(self):
+        """
+        Enable original sys.stdout/sys.stderr and cleanup
+        """
+        paginator = None
+        if self._paginator_in_use():
+            paginator = sys.stdout
+        self.enable_outputs()
+        if paginator:
+            paginator.close()
+
+
+STD_OUTPUT = StdOutput()
+
+
 def early_start():
     """
     Replace all outputs with in-memory handlers
     """
     if os.environ.get('AVOCADO_LOG_DEBUG'):
-        add_log_handler("avocado.app.debug", logging.StreamHandler, STDERR,
+        add_log_handler("avocado.app.debug", logging.StreamHandler, sys.stderr,
                         logging.DEBUG)
     if os.environ.get('AVOCADO_LOG_EARLY'):
-        add_log_handler("", logging.StreamHandler, STDERR, logging.DEBUG)
-        add_log_handler("avocado.test", logging.StreamHandler, STDERR,
+        add_log_handler("", logging.StreamHandler, sys.stderr, logging.DEBUG)
+        add_log_handler("avocado.test", logging.StreamHandler, sys.stderr,
                         logging.DEBUG)
     else:
-        sys.stdout = StringIO()
-        sys.stderr = sys.stdout
+        STD_OUTPUT.fake_outputs()
         add_log_handler("", MemStreamHandler, None, logging.DEBUG)
     logging.root.level = logging.DEBUG
-
-
-def enable_stderr():
-    """
-    Enable direct stdout/stderr (useful for handling errors)
-    """
-    if hasattr(sys.stdout, 'getvalue'):
-        STDERR.write(sys.stdout.getvalue())  # pylint: disable=E1101
-    sys.stdout = STDOUT
-    sys.stderr = STDERR
 
 
 def reconfigure(args):
@@ -238,8 +347,6 @@ def reconfigure(args):
     Adjust logging handlers accordingly to app args and re-log messages.
     """
     # Reconfigure stream loggers
-    global STDOUT
-    global STDERR
     enabled = getattr(args, "show", None)
     if not isinstance(enabled, list):
         enabled = ["app"]
@@ -248,14 +355,12 @@ def reconfigure(args):
         del enabled[:]
         enabled.append("test")
     if getattr(args, "silent", False):
-        sys.stdout = open(os.devnull, 'w')
-        sys.stderr = sys.stdout
         logging.disable(logging.CRITICAL)
+        STD_OUTPUT.disable_outputs()
         del enabled[:]
     # "silent" is incompatible with "paginator"
     elif getattr(args, "paginator", False) == "on" and TERM_SUPPORT.enabled:
-        STDOUT = Paginator()
-        STDERR = STDOUT
+        STD_OUTPUT.enable_paginator()
     if os.environ.get("AVOCADO_LOG_EARLY") and "early" not in enabled:
         enabled.append("early")
     if os.environ.get("AVOCADO_LOG_DEBUG") and "debug" not in enabled:
@@ -265,14 +370,14 @@ def reconfigure(args):
         app_handler = ProgressStreamHandler()
         app_handler.setFormatter(logging.Formatter("%(message)s"))
         app_handler.addFilter(FilterInfoAndLess())
-        app_handler.stream = STDOUT
+        app_handler.stream = STD_OUTPUT.stdout
         app_logger.addHandler(app_handler)
         app_logger.propagate = False
         app_logger.level = logging.DEBUG
         app_err_handler = ProgressStreamHandler()
         app_err_handler.setFormatter(logging.Formatter("%(message)s"))
         app_err_handler.addFilter(FilterWarnAndMore())
-        app_err_handler.stream = STDERR
+        app_err_handler.stream = STD_OUTPUT.stderr
         app_logger.addHandler(app_err_handler)
         app_logger.propagate = False
     else:
@@ -281,27 +386,28 @@ def reconfigure(args):
         logging.getLogger("avocado.test.stdout").propagate = False
         logging.getLogger("avocado.test.stderr").propagate = False
         if "early" in enabled:
-            enable_stderr()
-            add_log_handler("", logging.StreamHandler, STDERR, logging.DEBUG)
-            add_log_handler("avocado.test", logging.StreamHandler, STDERR,
+            STD_OUTPUT.enable_outputs()
+            STD_OUTPUT.print_records()
+            add_log_handler("", logging.StreamHandler, STD_OUTPUT.stderr,
                             logging.DEBUG)
+            add_log_handler("avocado.test", logging.StreamHandler,
+                            STD_OUTPUT.stderr, logging.DEBUG)
         else:
             # TODO: When stdout/stderr is not used by avocado we should move
             # this to output.start_job_logging
-            sys.stdout = STDOUT
-            sys.stderr = STDERR
+            STD_OUTPUT.enable_outputs()
             disable_log_handler("")
             disable_log_handler("avocado.test")
     if "remote" in enabled:
-        add_log_handler("avocado.fabric", stream=STDERR)
-        add_log_handler("paramiko", stream=STDERR)
+        add_log_handler("avocado.fabric", stream=STD_OUTPUT.stderr)
+        add_log_handler("paramiko", stream=STD_OUTPUT.stderr)
     else:
         disable_log_handler("avocado.fabric")
         disable_log_handler("paramiko")
     # Not enabled by env
     if not os.environ.get('AVOCADO_LOG_DEBUG'):
         if "debug" in enabled:
-            add_log_handler("avocado.app.debug", stream=STDERR)
+            add_log_handler("avocado.app.debug", stream=STD_OUTPUT.stderr)
         else:
             disable_log_handler("avocado.app.debug")
 
@@ -315,7 +421,8 @@ def reconfigure(args):
             level = (int(name[1]) if name[1].isdigit()
                      else logging.getLevelName(name[1].upper()))
         try:
-            add_log_handler(name, logging.StreamHandler, STDERR, level)
+            add_log_handler(name, logging.StreamHandler, STD_OUTPUT.stderr,
+                            level)
         except ValueError, details:
             app_logger.error("Failed to set logger for --show %s:%s: %s.",
                              name, level, details)
@@ -331,10 +438,7 @@ def reconfigure(args):
 
 
 def stop_logging():
-    if isinstance(STDOUT, Paginator):
-        sys.stdout = _STDOUT
-        sys.stderr = _STDERR
-        STDOUT.close()
+    STD_OUTPUT.close()
 
 
 class FilterWarnAndMore(logging.Filter):

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -39,7 +39,7 @@ BUILTIN_STREAMS = {'app': 'application output',
                    'early':  'early logging of other streams, including test (very verbose)'}
 #: Groups of builtin streams
 BUILTIN_STREAM_SETS = {'all': 'all builtin streams',
-                       'none': 'disable console logging completely'}
+                       'none': 'disables regular output (leaving only errors enabled)'}
 #: Transparently handles colored terminal, when one is used
 TERM_SUPPORT = None
 #: Allows modifying the sys.stdout/sys.stderr

--- a/avocado/core/parser.py
+++ b/avocado/core/parser.py
@@ -74,7 +74,7 @@ class Parser(object):
         self.application.add_argument('-s', '--silent',
                                       default=argparse.SUPPRESS,
                                       action="store_true",
-                                      help='Silence stdout')
+                                      help=BUILTIN_STREAM_SETS['none'])
 
     def start(self):
         """

--- a/avocado/core/parser.py
+++ b/avocado/core/parser.py
@@ -50,7 +50,7 @@ class Parser(object):
     """
 
     def __init__(self):
-        self.args = None
+        self.args = argparse.Namespace()
         self.subcommands = None
         self.application = ArgumentParser(prog=PROG,
                                           add_help=False,  # see parent parsing

--- a/avocado/core/parser.py
+++ b/avocado/core/parser.py
@@ -18,7 +18,7 @@ Avocado application command line parsing.
 """
 
 import argparse
-import sys
+import logging
 
 from . import exit_codes
 from . import tree
@@ -37,9 +37,10 @@ class ArgumentParser(argparse.ArgumentParser):
     """
 
     def error(self, message):
-        msg = '%s: error: %s\n' % (self.prog, message)
-        self.print_help(sys.stderr)
-        self.exit(exit_codes.AVOCADO_FAIL, msg)
+        log = logging.getLogger("avocado.app")
+        log.debug(self.format_help())
+        log.error("%s: error: %s", self.prog, message)
+        self.exit(exit_codes.AVOCADO_FAIL)
 
 
 class Parser(object):

--- a/avocado/core/result.py
+++ b/avocado/core/result.py
@@ -310,19 +310,19 @@ class HumanTestResult(TestResult):
         status = state["status"]
         if status == "TEST_NA":
             status = "SKIP"
-        mapping = {'PASS': output.term_support.PASS,
-                   'ERROR': output.term_support.ERROR,
-                   'FAIL': output.term_support.FAIL,
-                   'SKIP': output.term_support.SKIP,
-                   'WARN': output.term_support.WARN,
-                   'INTERRUPTED': output.term_support.INTERRUPT}
-        self.log.debug(output.term_support.MOVE_BACK + mapping[status] +
-                       status + output.term_support.ENDC)
+        mapping = {'PASS': output.TERM_SUPPORT.PASS,
+                   'ERROR': output.TERM_SUPPORT.ERROR,
+                   'FAIL': output.TERM_SUPPORT.FAIL,
+                   'SKIP': output.TERM_SUPPORT.SKIP,
+                   'WARN': output.TERM_SUPPORT.WARN,
+                   'INTERRUPTED': output.TERM_SUPPORT.INTERRUPT}
+        self.log.debug(output.TERM_SUPPORT.MOVE_BACK + mapping[status] +
+                       status + output.TERM_SUPPORT.ENDC)
 
     def notify_progress(self, progress=False):
         if progress:
-            color = output.term_support.PASS
+            color = output.TERM_SUPPORT.PASS
         else:
-            color = output.term_support.PARTIAL
+            color = output.TERM_SUPPORT.PARTIAL
         self.log.debug(color + self.__throbber.render() +
-                       output.term_support.ENDC, extra={"skip_newline": True})
+                       output.TERM_SUPPORT.ENDC, extra={"skip_newline": True})

--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -544,9 +544,9 @@ class OutputValue(object):  # only container pylint: disable=R0903
 
     def __str__(self):
         return "%s%s@%s:%s%s" % (self.value,
-                                 output.term_support.LOWLIGHT,
+                                 output.TERM_SUPPORT.LOWLIGHT,
                                  self.yaml, self.node.path,
-                                 output.term_support.ENDC)
+                                 output.TERM_SUPPORT.ENDC)
 
 
 class OutputList(list):  # only container pylint: disable=R0903
@@ -566,8 +566,8 @@ class OutputList(list):  # only container pylint: disable=R0903
                           self.yamls + other.yamls)
 
     def __str__(self):
-        color = output.term_support.LOWLIGHT
-        cend = output.term_support.ENDC
+        color = output.TERM_SUPPORT.LOWLIGHT
+        cend = output.TERM_SUPPORT.ENDC
         return ' + '.join("%s%s@%s:%s%s"
                           % (_[0], color, _[1], _[2].path, cend)
                           for _ in itertools.izip(self, self.yamls,

--- a/avocado/plugins/list.py
+++ b/avocado/plugins/list.py
@@ -104,8 +104,8 @@ class TestLister(object):
     def _display(self, test_matrix, stats):
         header = None
         if self.args.verbose:
-            header = (output.term_support.header_str('Type'),
-                      output.term_support.header_str('Test'))
+            header = (output.TERM_SUPPORT.header_str('Type'),
+                      output.TERM_SUPPORT.header_str('Test'))
 
         for line in astring.iter_tabular_output(test_matrix, header=header):
             self.log.debug(line)

--- a/avocado/plugins/multiplex.py
+++ b/avocado/plugins/multiplex.py
@@ -121,8 +121,8 @@ class Multiplex(CLICmd):
             if not args.debug:
                 paths = ', '.join([x.path for x in tpl])
             else:
-                color = output.term_support.LOWLIGHT
-                cend = output.term_support.ENDC
+                color = output.TERM_SUPPORT.LOWLIGHT
+                cend = output.TERM_SUPPORT.ENDC
                 paths = ', '.join(["%s%s@%s%s" % (_.name, color,
                                                   getattr(_, 'yaml',
                                                           "Unknown"),

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -75,10 +75,6 @@ class Run(CLICmd):
                                   'Note that zero means "no timeout". '
                                   'You can also use suffixes, like: '
                                   ' s (seconds), m (minutes), h (hours). '))
-        parser.add_argument("--store-logging-stream", nargs="*", default=[],
-                            metavar="STREAM[:LEVEL]", help="Store given "
-                            "logging STREAMs in $JOB_RESULTS_DIR/$STREAM."
-                            "$LEVEL.")
 
         sysinfo_default = settings.get_value('sysinfo.collect',
                                              'enabled',
@@ -101,6 +97,11 @@ class Run(CLICmd):
             help=('Display only the job log on stdout. Useful '
                   'for test debugging purposes. No output will '
                   'be displayed if you also specify --silent'))
+
+        parser.output.add_argument("--store-logging-stream", nargs="*",
+                                   default=[], metavar="STREAM[:LEVEL]",
+                                   help="Store given logging STREAMs in "
+                                   "$JOB_RESULTS_DIR/$STREAM.$LEVEL.")
 
         out_check = parser.add_argument_group('output check arguments')
 

--- a/docs/source/LoggingSystem.rst
+++ b/docs/source/LoggingSystem.rst
@@ -1,0 +1,37 @@
+==============
+Logging system
+==============
+
+This section describes the logging system used in avocado and avocado tests.
+
+
+Tweaking the UI
+===============
+
+Avocado uses python's logging system to produce UI and to store test's output. The system is quite flexible and allows you to tweak the output to your needs either by built-in stream sets, or directly by using the stream name. To tweak them you can use `avocado --show STREAM[:LEVEL][,STREAM[:LEVEL],...]`. Built-in streams with description (followed by list of associated python streams):
+
+:app: The text based UI (avocado.app)
+:test: Output of the executed tests (avocado.test, "")
+:debug: Additional messages useful to debug avocado (avocado.app.debug)
+:remote: Fabric/paramiko debug messages, useful to analyze remote execution (avocado.fabric, paramiko)
+:early: Early logging before the logging system is set. It includes the test output and lots of output produced by used libraries. ("", avocado.test)
+
+Additionally you can specify "all" or "none" to enable/disable all of pre-defined streams and you can also supply custom python logging streams and they will be passed to the standard output.
+
+.. warning:: Messages with importance greater or equal WARN in logging stream "avocado.app" are always enabled and they go to the standard error.
+
+
+Storing custom logs
+===================
+
+When you run a test, you can also store custom logging streams into the results directory by `avocado run --store-logging-stream [STREAM[:LEVEL] [STREAM[:LEVEL] ...]]`, which will produce `$STREAM.$LEVEL` files per each (unique) entry in the test results directory.
+
+.. note:: You have to specify separated logging streams. You can't use the built-in streams in this function.
+
+.. note:: Currently the custom streams are stored only per job, not per each individual test.
+
+
+Paginator
+=========
+
+Some subcommands (list, plugins, ...) support "paginator", which, on compatible terminals, basically pipes the colored output to `less` to simplify browsing of the produced output. One can disable it by `--paginator {on|off}`.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,6 +13,7 @@ Contents:
    ResultFormats
    Configuration
    Loaders
+   LoggingSystem
    MultiplexConfig
    Replay
    RunningTestsRemotely

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -229,7 +229,7 @@ class RunnerOperationTest(unittest.TestCase):
         expected_rc = exit_codes.AVOCADO_ALL_OK
         expected_output = ''
         self.assertEqual(result.exit_status, expected_rc)
-        self.assertEqual(result.stderr, expected_output)
+        self.assertEqual(result.stdout, expected_output)
 
     def test_empty_args_list(self):
         os.chdir(basedir)
@@ -397,11 +397,11 @@ class RunnerHumanOutputTest(unittest.TestCase):
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %s:\n%s" %
                          (expected_rc, result))
-        self.assertIn('[stdout] foo', result.stderr, result)
-        self.assertIn('[stdout] \'"', result.stderr, result)
-        self.assertIn('[stdout] bar/baz', result.stderr, result)
+        self.assertIn('[stdout] foo', result.stdout, result)
+        self.assertIn('[stdout] \'"', result.stdout, result)
+        self.assertIn('[stdout] bar/baz', result.stdout, result)
         self.assertIn('PASS /bin/echo -ne foo\\\\n\\\'\\"\\\\nbar/baz',
-                      result.stderr, result)
+                      result.stdout, result)
         # logdir name should escape special chars (/)
         test_dirs = glob.glob(os.path.join(self.tmpdir, 'latest',
                                            'test-results', '*'))
@@ -506,12 +506,12 @@ class RunnerSimpleTest(unittest.TestCase):
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %s:\n%s" %
                          (expected_rc, result))
-        self.assertIn('DEBUG| Debug message', result.stderr, result)
-        self.assertIn('INFO | Info message', result.stderr, result)
+        self.assertIn('DEBUG| Debug message', result.stdout, result)
+        self.assertIn('INFO | Info message', result.stdout, result)
         self.assertIn('WARN | Warning message (should cause this test to '
-                      'finish with warning)', result.stderr, result)
+                      'finish with warning)', result.stdout, result)
         self.assertIn('ERROR| Error message (ordinary message not changing '
-                      'the results)', result.stderr, result)
+                      'the results)', result.stdout, result)
 
     def test_non_absolute_path(self):
         avocado_path = os.path.join(basedir, 'scripts', 'avocado')

--- a/selftests/functional/test_multiplex.py
+++ b/selftests/functional/test_multiplex.py
@@ -106,15 +106,15 @@ class MultiplexTests(unittest.TestCase):
 
             msg_lines = msg.splitlines()
             msg_header = '[stdout] Custom variable: %s' % msg_lines[0]
-            self.assertIn(msg_header, result.stderr,
+            self.assertIn(msg_header, result.stdout,
                           "Multiplexed variable should produce:"
                           "\n  %s\nwhich is not present in the output:\n  %s"
-                          % (msg_header, "\n  ".join(result.stderr.splitlines())))
+                          % (msg_header, "\n  ".join(result.stdout.splitlines())))
             for msg_remain in msg_lines[1:]:
-                self.assertIn('[stdout] %s' % msg_remain, result.stderr,
+                self.assertIn('[stdout] %s' % msg_remain, result.stdout,
                               "Multiplexed variable should produce:"
                               "\n  %s\nwhich is not present in the output:\n  %s"
-                              % (msg_remain, "\n  ".join(result.stderr.splitlines())))
+                              % (msg_remain, "\n  ".join(result.stdout.splitlines())))
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir)

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -206,10 +206,10 @@ class OutputPluginTest(unittest.TestCase):
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %d:\n%s" %
                          (expected_rc, result))
-        job_id_list = re.findall('Job ID: (.*)', result.stderr,
+        job_id_list = re.findall('Job ID: (.*)', result.stdout,
                                  re.MULTILINE)
-        self.assertTrue(job_id_list, 'No Job ID in stderr:\n%s' %
-                        result.stderr)
+        self.assertTrue(job_id_list, 'No Job ID in stdout:\n%s' %
+                        result.stdout)
         job_id = job_id_list[0]
         self.assertEqual(len(job_id), 40)
 

--- a/selftests/functional/test_standalone.py
+++ b/selftests/functional/test_standalone.py
@@ -51,7 +51,7 @@ class StandaloneTests(unittest.TestCase):
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         result = self.run_and_check(cmd_line, expected_rc, 'errortest_nasty')
         exc = "NastyException: Nasty-string-like-exception"
-        count = result.stderr.count("\n%s" % exc)
+        count = result.stdout.count("\n%s" % exc)
         self.assertEqual(count, 2, "Exception \\n%s should be present twice in"
                          "the log (once from the log, second time when parsing"
                          "exception details." % (exc))
@@ -61,14 +61,14 @@ class StandaloneTests(unittest.TestCase):
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         result = self.run_and_check(cmd_line, expected_rc, 'errortest_nasty2')
         self.assertIn("Exception: Unable to get exception, check the traceback"
-                      " for details.", result.stderr)
+                      " for details.", result.stdout)
 
     def test_errortest_nasty3(self):
         cmd_line = './examples/tests/errortest_nasty3.py -r'
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         result = self.run_and_check(cmd_line, expected_rc, 'errortest_nasty3')
         self.assertIn("TestError: <errortest_nasty3.NastyException instance at ",
-                      result.stderr)
+                      result.stdout)
 
     def test_errortest(self):
         cmd_line = './examples/tests/errortest.py -r'

--- a/selftests/functional/test_streams.py
+++ b/selftests/functional/test_streams.py
@@ -1,0 +1,122 @@
+import os
+import shutil
+import sys
+import tempfile
+
+if sys.version_info[:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
+
+from avocado.core import exit_codes
+from avocado.utils import process
+
+
+basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..')
+basedir = os.path.abspath(basedir)
+
+
+class StreamsTest(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+
+    def test_app_info_stdout(self):
+        """
+        Checks that the application output (<= level info) goes to stdout
+        """
+        result = process.run('./scripts/avocado distro')
+        self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
+        self.assertIn('Detected distribution', result.stdout)
+        self.assertEqual('', result.stderr)
+
+    def test_app_error_stderr(self):
+        """
+        Checks that the application error (> level info) goes to stderr
+        """
+        result = process.run('./scripts/avocado unknown-whacky-command',
+                             ignore_status=True)
+        self.assertEqual(result.exit_status, exit_codes.AVOCADO_FAIL)
+        self.assertIn("invalid choice: 'unknown-whacky-command'",
+                      result.stderr)
+        self.assertNotIn("invalid choice: 'unknown-whacky-command'",
+                         result.stdout)
+        self.assertIn("Avocado Test Runner", result.stdout)
+        self.assertNotIn("Avocado Test Runner", result.stderr)
+
+    def test_other_stream_early_stdout(self):
+        """
+        Checks that other streams (early in this case) goes to stdout
+
+        Also checks the symmetry between `--show early` and the environment
+        variable `AVOCADO_LOG_EARLY` being set.
+        """
+        cmds = (('./scripts/avocado --show early run --sysinfo=off '
+                 '--job-results-dir %s passtest' % self.tmpdir, {}),
+                ('./scripts/avocado run --sysinfo=off --job-results-dir'
+                 ' %s passtest' % self.tmpdir, {'AVOCADO_LOG_EARLY': 'y'}))
+        for cmd, env in cmds:
+            result = process.run(cmd, env=env, shell=True)
+            self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
+            self.assertIn("stevedore.extension: found extension EntryPoint.parse",
+                          result.stdout)
+            self.assertIn("avocado.test: Command line: %s" % cmd,
+                          result.stdout)
+            self.assertEqual('', result.stderr)
+
+    def test_test(self):
+        """
+        Checks that the test stream (early in this case) goes to stdout
+
+        Also checks the symmetry between `--show test` and `--show-job-log`
+        """
+        for cmd in (('./scripts/avocado --show test run --sysinfo=off '
+                     '--job-results-dir %s passtest' % self.tmpdir),
+                    ('./scripts/avocado run --show-job-log --sysinfo=off '
+                     '--job-results-dir %s passtest' % self.tmpdir)):
+            result = process.run(cmd)
+            self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
+            self.assertNotIn("stevedore.extension: found extension EntryPoint.parse",
+                             result.stdout)
+            self.assertNotIn("stevedore.extension: found extension EntryPoint.parse",
+                             result.stderr)
+            self.assertIn("Command line: %s" % cmd,
+                          result.stdout)
+            self.assertIn("START passtest", result.stdout)
+            self.assertIn("PASS passtest", result.stdout)
+            self.assertEqual('', result.stderr)
+
+    def test_none_success(self):
+        """
+        Checks that only errors are output, and that they go to stderr
+
+        Also checks the symmetry between `--show none` and `--silent`
+        """
+        for cmd in (('./scripts/avocado --show none run --sysinfo=off '
+                     '--job-results-dir %s passtest' % self.tmpdir),
+                    ('./scripts/avocado --silent run --sysinfo=off '
+                     '--job-results-dir %s passtest' % self.tmpdir)):
+            result = process.run(cmd)
+            self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
+            self.assertEqual('', result.stdout)
+            self.assertEqual('', result.stderr)
+
+    def test_none_error(self):
+        """
+        Checks that only errors are output, and that they go to stderr
+
+        Also checks the symmetry between `--show none` and `--silent`
+        """
+        for cmd in ('./scripts/avocado --show none unknown-whacky-command',
+                    './scripts/avocado --silent unknown-whacky-command'):
+            result = process.run(cmd, ignore_status=True)
+            self.assertEqual(result.exit_status, exit_codes.AVOCADO_FAIL)
+            self.assertEqual('', result.stdout)
+            self.assertNotEqual('', result.stderr)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
After the big logging refactoring we decided the behavior should be slightly different. This pull request tries to adjust the handling accordingly to the discussion we had.

Main changes:

* FIX: Handle the "all" and "none" builtin streams
* stdout messages are printed to stdout (--help)
* stdout is not disabled on `--silent`
* log all streams to sys.stdout except of `avocado.app` messages with `loglevel > INFO`

v1: https://github.com/avocado-framework/avocado/pull/1072
v2: https://github.com/avocado-framework/avocado/pull/1074
v3: https://github.com/avocado-framework/avocado/pull/1080

Changes:

    v2: Commit which fixes "all"/"none" streams
    v2: Commit which imports STD_OUTPUT rather than reusing it
    v2: Commit which adjusts the stdout/stderr usage according to the new discussion
    v2: Improved docstrings, commit messages and style fixes
    v2: Removed the RFC commits, will be sent separately
    v3: [cleber] added selftests
    v3: [cleber] improved some messages
    v3: Removed hack to enable default streams on early error
    v3: Make --silent and --show none equal
    v3: Use logging on parser error (split message in stdout/stderr)
    v4: Move --store-logging-stream in different section in help
    v4: Add documentation