### PR TITLE
Command line argument parser: disable abbreviations

### DIFF
--- a/avocado/core/parser.py
+++ b/avocado/core/parser.py
@@ -42,6 +42,9 @@ class ArgumentParser(argparse.ArgumentParser):
         log.error("%s: error: %s", self.prog, message)
         self.exit(exit_codes.AVOCADO_FAIL)
 
+    def _get_option_tuples(self, option_string):
+        return []
+
 
 class Parser(object):
 

--- a/docs/source/DebuggingWithGDB.rst
+++ b/docs/source/DebuggingWithGDB.rst
@@ -62,7 +62,7 @@ place, the test notifies you and you can investigate the problem. This is
 demonstrated in ``examples/tests/doublefree_nasty.py`` test. To unveil the
 power of Avocado, run this test using::
 
-    avocado run --gdb-run-bin=doublefree: examples/tests/doublefree_nasty.py --gdb-prerun-commands examples/tests/doublefree_nasty.py.data/gdb_pre --multiplex examples/tests/doublefree_nasty.py.data/iterations.yaml
+    avocado run --gdb-run-bin=doublefree: examples/tests/doublefree_nasty.py --gdb-prerun-commands examples/tests/doublefree_nasty.py.data/gdb_pre --multiplex-files examples/tests/doublefree_nasty.py.data/iterations.yaml
 
 which executes 100 iterations of this test while setting all breakpoints from
 the ``examples/tests/doublefree_nasty.py.data/gdb_pre`` file (you can specify

--- a/docs/source/MultiplexConfig.rst
+++ b/docs/source/MultiplexConfig.rst
@@ -221,7 +221,7 @@ Injecting files
 
 You can run any test with any YAML file by::
 
-    avocado run sleeptest --multiplex file.yaml
+    avocado run sleeptest --multiplex-files file.yaml
 
 This puts the content of ``file.yaml`` into ``/run``
 location, which as mentioned in previous section, is the default ``mux-path``
@@ -233,7 +233,7 @@ when you have two files and you don't want the content to be merged into
 a single place becomming effectively a single blob, you can do that by
 giving a name to your yaml file::
 
-    avocado run sleeptest --multiplex duration:duration.yaml
+    avocado run sleeptest --multiplex-files duration:duration.yaml
 
 The content of ``duration.yaml`` is injected into ``/run/duration``. Still when
 keys from other files don't clash, you can use ``params.get(key)`` and retrieve
@@ -245,7 +245,7 @@ multiple files by using the same or different name, or even a complex
 Last but not least, advanced users can inject the file into whatever location
 they prefer by::
 
-    avocado run sleeptest --multiplex /my/variants/duration:duration.yaml
+    avocado run sleeptest --multiplex-files /my/variants/duration:duration.yaml
 
 Simple ``params.get(key)`` won't look in this location, which might be the
 intention of the test writer. There are several ways to access the values:

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -100,7 +100,7 @@ the following multiplex file for sleeptest::
         long:
             sleep_length: 5
 
-When running this example by ``avocado run $test --multiplex $file.yaml``
+When running this example by ``avocado run $test --multiplex-files $file.yaml``
 three variants are executed and the content is injected into ``/run`` namespace
 (see :doc:`MultiplexConfig` for details). Every variant contains variables
 "type" and "sleep_length". To obtain the current value, you need the name
@@ -153,7 +153,7 @@ Using a multiplex file
 You may use the Avocado runner with a multiplex file to provide params and matrix
 generation for sleeptest just like::
 
-    $ avocado run sleeptest --multiplex examples/tests/sleeptest.py.data/sleeptest.yaml
+    $ avocado run sleeptest --multiplex-files examples/tests/sleeptest.py.data/sleeptest.yaml
     JOB ID    : d565e8dec576d6040f894841f32a836c751f968f
     JOB LOG   : $HOME/avocado/job-results/job-2014-08-12T15.44-d565e8de/job.log
     TESTS     : 3
@@ -164,7 +164,7 @@ generation for sleeptest just like::
     JOB HTML  : $HOME/avocado/job-results/job-2014-08-12T15.44-d565e8de/html/results.html
     TIME : 6.52 s
 
-The ``--multiplex`` accepts either only ``$FILE_LOCATION`` or ``$INJECT_TO:$FILE_LOCATION``.
+The ``--multiplex-files`` accepts either only ``$FILE_LOCATION`` or ``$INJECT_TO:$FILE_LOCATION``.
 As explained in :doc:`MultiplexConfig` without any path the content gets
 injected into ``/run`` in order to be in the default relative path location.
 The ``$INJECT_TO`` can be either relative path, then it's injected into
@@ -180,12 +180,12 @@ developer to get the value from this location (using path or adding the path to
 Note that, as your multiplex file specifies all parameters for sleeptest, you
 can't leave the test ID empty::
 
-    $ scripts/avocado run --multiplex examples/tests/sleeptest/sleeptest.yaml
+    $ scripts/avocado run --multiplex-files examples/tests/sleeptest/sleeptest.yaml
     Empty test ID. A test path or alias must be provided
 
 You can also execute multiple tests with the same multiplex file::
 
-    ./scripts/avocado run sleeptest synctest --multiplex examples/tests/sleeptest.py.data/sleeptest.yaml
+    ./scripts/avocado run sleeptest synctest --multiplex-files examples/tests/sleeptest.py.data/sleeptest.yaml
     JOB ID     : 72166988c13fec26fcc9c2e504beec8edaad4761
     JOB LOG    : /home/medic/avocado/job-results/job-2015-05-15T11.02-7216698/job.log
     TESTS      : 8
@@ -665,7 +665,7 @@ impact your test grid. You can account for that possibility and set up a
 
 ::
 
-    $ avocado run sleeptest --multiplex /tmp/sleeptest-example.yaml
+    $ avocado run sleeptest --multiplex-files /tmp/sleeptest-example.yaml
     JOB ID    : 6d5a2ff16bb92395100fbc3945b8d253308728c9
     JOB LOG   : $HOME/avocado/job-results/job-2014-08-12T15.52-6d5a2ff1/job.log
     JOB HTML  : $HOME/avocado/job-results/job-2014-08-12T15.52-6d5a2ff1/html/results.html
@@ -914,7 +914,7 @@ Here are the current variables that Avocado exports to the tests:
 +-------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
 | AVOCADO_TEST_SYSINFODIR | The system information directory      | $HOME/logs/job-results/job-2014-09-16T14.38-ac332e6/test-results/$HOME/my_test.sh.1/sysinfo         |
 +-------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
-| *                       | All variables from --multiplex-file   | TIMEOUT=60; IO_WORKERS=10; VM_BYTES=512M; ...                                                       |
+| *                       | All variables from --multiplex-files  | TIMEOUT=60; IO_WORKERS=10; VM_BYTES=512M; ...                                                       |
 +-------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
 
 

--- a/selftests/functional/test_multiplex.py
+++ b/selftests/functional/test_multiplex.py
@@ -65,29 +65,29 @@ class MultiplexTests(unittest.TestCase):
 
     def test_run_mplex_noid(self):
         cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '
-                    '--multiplex examples/tests/sleeptest.py.data/sleeptest.yaml' % self.tmpdir)
+                    '--multiplex-files examples/tests/sleeptest.py.data/sleeptest.yaml' % self.tmpdir)
         expected_rc = exit_codes.AVOCADO_JOB_FAIL
         self.run_and_check(cmd_line, expected_rc)
 
     def test_run_mplex_passtest(self):
         cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off passtest '
-                    '--multiplex examples/tests/sleeptest.py.data/sleeptest.yaml' % self.tmpdir)
+                    '--multiplex-files examples/tests/sleeptest.py.data/sleeptest.yaml' % self.tmpdir)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.run_and_check(cmd_line, expected_rc)
 
     def test_run_mplex_doublepass(self):
         cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off passtest passtest '
-                    '--multiplex examples/tests/sleeptest.py.data/sleeptest.yaml' % self.tmpdir)
+                    '--multiplex-files examples/tests/sleeptest.py.data/sleeptest.yaml' % self.tmpdir)
         self.run_and_check(cmd_line, expected_rc=0)
 
     def test_run_mplex_failtest(self):
         cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off passtest failtest '
-                    '--multiplex examples/tests/sleeptest.py.data/sleeptest.yaml' % self.tmpdir)
+                    '--multiplex-files examples/tests/sleeptest.py.data/sleeptest.yaml' % self.tmpdir)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         self.run_and_check(cmd_line, expected_rc)
 
     def test_run_double_mplex(self):
-        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off passtest --multiplex '
+        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off passtest --multiplex-files '
                     'examples/tests/sleeptest.py.data/sleeptest.yaml '
                     'examples/tests/sleeptest.py.data/sleeptest.yaml' % self.tmpdir)
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -99,7 +99,7 @@ class MultiplexTests(unittest.TestCase):
                             ('/run/long', 'This is very long\nmultiline\ntext.')):
             variant, msg = variant_msg
             cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off examples/tests/env_variables.sh '
-                        '--multiplex examples/tests/env_variables.sh.data/env_variables.yaml '
+                        '--multiplex-files examples/tests/env_variables.sh.data/env_variables.yaml '
                         '--filter-only %s --show-job-log' % (self.tmpdir, variant))
             expected_rc = exit_codes.AVOCADO_ALL_OK
             result = self.run_and_check(cmd_line, expected_rc)

--- a/selftests/functional/test_replay_basic.py
+++ b/selftests/functional/test_replay_basic.py
@@ -24,7 +24,7 @@ class ReplayTests(unittest.TestCase):
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
         cmd_line = ('./scripts/avocado run passtest '
-                    '--multiplex '
+                    '--multiplex-files '
                     'examples/tests/sleeptest.py.data/sleeptest.yaml '
                     '--job-results-dir %s --sysinfo=off --json -' %
                     self.tmpdir)
@@ -119,7 +119,7 @@ class ReplayTests(unittest.TestCase):
         self.assertIn(msg, result.stderr)
 
     def test_run_replay_status_and_mux(self):
-        cmd_line = ('./scripts/avocado run --replay %s --multiplex '
+        cmd_line = ('./scripts/avocado run --replay %s --multiplex-files '
                     'examples/mux-environment.yaml --replay-test-status FAIL '
                     '--job-results-dir %s --replay-data-dir %s '
                     '--sysinfo=off' % (self.jobid, self.tmpdir, self.jobdir))

--- a/selftests/functional/test_replay_external_runner.py
+++ b/selftests/functional/test_replay_external_runner.py
@@ -26,7 +26,7 @@ class ReplayTests(unittest.TestCase):
         self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
         test = script.make_script(os.path.join(self.tmpdir, 'test'), 'exit 0')
         cmd_line = ('./scripts/avocado run %s '
-                    '--multiplex '
+                    '--multiplex-files '
                     'examples/tests/sleeptest.py.data/sleeptest.yaml '
                     '--external-runner /bin/bash '
                     '--job-results-dir %s --sysinfo=off --json -' %


### PR DESCRIPTION
To avoid ambiguity, and allow for precise argument names and this
command line examples, let's disable abbreviations. One example where
this led to confusion:

```
 $ avocado run --show test passtest
```

Instead of

```
 $ avocado --show test run passtest
```

With this change, the first command line would result in:

```
 avocado run: error: unrecognized arguments: --show
```

Which is much more precise than:

```
 Unable to discover url(s) 'test' with loader plugins(s) 'file',
 'external', try running 'avocado list -V test' to see the details.
```

Disabling the arguments abbreviation without depending on the fix
applied to Python itself is suggested here:

 http://bugs.python.org/msg204678

Reference: https://trello.com/c/Z3lWiJp0
Signed-off-by: Cleber Rosa <crosa@redhat.com>