### PR TITLE
Command line argument parser: disable abbreviations [v2]

### DIFF
--- a/avocado/core/parser.py
+++ b/avocado/core/parser.py
@@ -42,6 +42,9 @@ class ArgumentParser(argparse.ArgumentParser):
         log.error("%s: error: %s", self.prog, message)
         self.exit(exit_codes.AVOCADO_FAIL)
 
+    def _get_option_tuples(self, option_string):
+        return []
+
 
 class Parser(object):
 

--- a/avocado/core/remote/runner.py
+++ b/avocado/core/remote/runner.py
@@ -132,7 +132,7 @@ class RemoteTestRunner(TestRunner):
                      for mux_file in getattr(self.job.args,
                                              'multiplex_files') or []]
         if mux_files:
-            extra_params.append("--multiplex-files %s" % " ".join(mux_files))
+            extra_params.append("--multiplex %s" % " ".join(mux_files))
 
         if getattr(self.job.args, "dry_run", False):
             extra_params.append("--dry-run")

--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -100,7 +100,7 @@ class Replay(CLI):
         err = None
         if args.replay_teststatus and args.multiplex_files:
             err = ("Option --replay-test-status is incompatible with "
-                   "--multiplex-files.")
+                   "--multiplex.")
         elif args.replay_teststatus and args.url:
             err = ("Option --replay-test-status is incompatible with "
                    "test URLs given on the command line.")

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -128,10 +128,13 @@ class Run(CLICmd):
 
         if multiplexer.MULTIPLEX_CAPABLE:
             mux = parser.add_argument_group('multiplexer use on test execution')
-            mux.add_argument('-m', '--multiplex-files', nargs='*',
+            mux.add_argument('-m', '--multiplex', nargs='*', dest='multiplex_files',
                              default=None, metavar='FILE',
                              help='Location of one or more Avocado multiplex (.yaml) '
                              'FILE(s) (order dependent)')
+            mux.add_argument('--multiplex-files', nargs='*',
+                             default=None, metavar='FILE',
+                             help='DEPRECATED: please use --multiplex instead')
             mux.add_argument('--filter-only', nargs='*', default=[],
                              help='Filter only path(s) from multiplexing')
             mux.add_argument('--filter-out', nargs='*', default=[],

--- a/docs/source/Replay.rst
+++ b/docs/source/Replay.rst
@@ -39,7 +39,7 @@ The replay feature will retrieve the original job urls, the multiplex
 tree and the configuration. Let's see another example, now using
 multiplex file::
 
-  $ avocado run /bin/true /bin/false --multiplex-files mux-environment.yaml
+  $ avocado run /bin/true /bin/false --multiplex mux-environment.yaml
   JOB ID     : bd6aa3b852d4290637b5e771b371537541043d1d
   JOB LOG    : $HOME/avocado/job-results/job-2016-01-11T21.56-bd6aa3b/job.log
   TESTS      : 48

--- a/man/avocado.rst
+++ b/man/avocado.rst
@@ -286,7 +286,7 @@ file (multiplex file) that produced the output above is::
 
 You can execute `sleeptest` in all variations exposed above with:
 
- $ avocado run sleeptest --multiplex-files examples/tests/sleeptest.py.data/sleeptest.yaml
+ $ avocado run sleeptest --multiplex examples/tests/sleeptest.py.data/sleeptest.yaml
 
 And the output should look like::
 
@@ -313,13 +313,13 @@ the `filter-out` removes one or more paths from being processed.
 From the previous example, if we are interested to use the variants `/run/medium`
 and `/run/longest`, we do the following command line::
 
- $ avocado run sleeptest --multiplex-files examples/tests/sleeptest.py.data/sleeptest.yaml \
+ $ avocado run sleeptest --multiplex examples/tests/sleeptest.py.data/sleeptest.yaml \
        --filter-only /run/medium /run/longest
 
 And if you want to remove `/small` from the variants created,
 we do the following::
 
- $ avocado run sleeptest --multiplex-files examples/tests/sleeptest.py.data/sleeptest.yaml \
+ $ avocado run sleeptest --multiplex examples/tests/sleeptest.py.data/sleeptest.yaml \
        --filter-out /run/medium
 
 Note that both `--filter-only` and `--filter-out` filters can be arranged in

--- a/selftests/functional/test_replay_basic.py
+++ b/selftests/functional/test_replay_basic.py
@@ -126,7 +126,7 @@ class ReplayTests(unittest.TestCase):
         expected_rc = exit_codes.AVOCADO_FAIL
         result = self.run_and_check(cmd_line, expected_rc)
         msg = "Option --replay-test-status is incompatible with "\
-              "--multiplex-files."
+              "--multiplex."
         self.assertIn(msg, result.stderr)
 
     def test_run_replay_status_and_urls(self):

--- a/selftests/unit/test_remote.py
+++ b/selftests/unit/test_remote.py
@@ -103,7 +103,7 @@ _=/usr/bin/env''', exit_status=0)
 
         args = ("cd ~/avocado/tests; avocado run --force-job-id sleeptest.1 "
                 "--json - --archive /tests/sleeptest /tests/other/test "
-                "passtest --multiplex-files ~/avocado/tests/foo.yaml "
+                "passtest --multiplex ~/avocado/tests/foo.yaml "
                 "~/avocado/tests/bar/baz.yaml --dry-run")
         (Remote.should_receive('run')
          .with_args(args, timeout=61, ignore_status=True)


### PR DESCRIPTION
Let's formally use `--multiplex` as an option on `run` and deprecate `--multiplex-files`.

Also, to avoid ambiguity and allow for precise argument names and this
command line examples, let's disable abbreviations. One example where
this led to confusion:

```
 $ avocado run --show test passtest
```

Instead of

```
 $ avocado --show test run passtest
```

With this change, the first command line would result in:

```
 avocado run: error: unrecognized arguments: --show
```

Which is much more precise than:

```
 Unable to discover url(s) 'test' with loader plugins(s) 'file',
 'external', try running 'avocado list -V test' to see the details.
```

Disabling the arguments abbreviation without depending on the fix
applied to Python itself is suggested here:

 http://bugs.python.org/msg204678

---

Changes from v1:
 * Use `--multiplex` and deprecate `--multiplex-files`