### PR TITLE
External Runner: deal with empty test URL

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -769,7 +769,7 @@ class ExternalLoader(TestLoader):
                             DEFAULT)
         :return: list of matching tests
         """
-        if not self._external_runner:
+        if (not self._external_runner) or (url is None):
             return []
         return [(test.ExternalRunnerTest, {'name': url, 'external_runner':
                                            self._external_runner})]

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -612,6 +612,18 @@ class ExternalRunnerTest(unittest.TestCase):
                          "Avocado did not return rc %d:\n%s" %
                          (expected_rc, result))
 
+    def test_externalrunner_no_url(self):
+        os.chdir(basedir)
+        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '
+                    '--external-runner=/bin/true' % self.tmpdir)
+        result = process.run(cmd_line, ignore_status=True)
+        expected_output = ('No tests found for given urls')
+        self.assertIn(expected_output, result.stderr)
+        expected_rc = exit_codes.AVOCADO_JOB_FAIL
+        self.assertEqual(result.exit_status, expected_rc,
+                         "Avocado did not return rc %d:\n%s" %
+                         (expected_rc, result))
+
     def tearDown(self):
         self.pass_script.remove()
         self.fail_script.remove()


### PR DESCRIPTION
A test base on the external runner feature depends on both the
external runner and the test URL. These two are always combined to
generate the complete command that will be executed by Avocado.

But, the Avocado command line application does not require URLs to be
given on the command line, because these may come from other sources
on loaders other than the basic FileLoader.

So, let's also explicitly require a URL to be given to to the External
Runner loader to return a test factory (class and parameters).

Signed-off-by: Cleber Rosa <crosa@redhat.com>