### PR TITLE
Handle long filenames in avocado and fix unknown test status

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -203,7 +203,7 @@ class Test(unittest.TestCase):
 
     @data_structures.LazyProperty
     def workdir(self):
-        basename = os.path.basename(self.name)
+        basename = os.path.basename(self.logdir)
         return utils_path.init_dir(data_dir.get_tmp_dir(), basename.replace(':', '_'))
 
     @data_structures.LazyProperty

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -329,12 +329,14 @@ class Test(unittest.TestCase):
         return tagged_name
 
     def _record_reference_stdout(self):
-        utils_path.init_dir(self.datadir)
-        shutil.copyfile(self._stdout_file, self._expected_stdout_file)
+        if self.datadir is not None:
+            utils_path.init_dir(self.datadir)
+            shutil.copyfile(self._stdout_file, self._expected_stdout_file)
 
     def _record_reference_stderr(self):
-        utils_path.init_dir(self.datadir)
-        shutil.copyfile(self._stderr_file, self._expected_stderr_file)
+        if self.datadir is not None:
+            utils_path.init_dir(self.datadir)
+            shutil.copyfile(self._stderr_file, self._expected_stderr_file)
 
     def _check_reference_stdout(self):
         if (self._expected_stdout_file is not None and

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -180,7 +180,8 @@ class Test(unittest.TestCase):
         """
         Returns the path to the directory that contains test data files
         """
-        if self.filename is not None:
+        # Maximal allowed file name length is 255
+        if self.filename is not None and len(self.filename) < 251:
             return self.filename + '.data'
         else:
             return None

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -139,7 +139,7 @@ class Test(unittest.TestCase):
 
         self.debugdir = None
         self.resultsdir = None
-        self.status = None
+        self.status = "ERROR"
         self.fail_reason = None
         self.fail_class = None
         self.traceback = None

--- a/avocado/utils/astring.py
+++ b/avocado/utils/astring.py
@@ -201,4 +201,4 @@ def string_to_safe_path(string):
     :param string: String to be converted
     :return: String which is safe to pass as a file/dir name (on recent fs)
     """
-    return string.replace(os.path.sep, '_')
+    return string.replace(os.path.sep, '_')[:255]


### PR DESCRIPTION
This patchset fixes the issue https://trello.com/c/6LBKIUtN/591-bug-long-filenames-crash-avocado and avoids crash on https://trello.com/c/BdC56G6X/542-bug-avocado-can-t-handle-exceptions-raised-while-reading-the-test-queue

Basically it modifies the way `Test.logdir` is created and reuses the `Test.logdir` for other file name related variables.

Last but not least it adds commit to fix missing test status on early failure.