### PR TITLE
avocado.core.replay accept empty strings to disable whitelist items

### DIFF
--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -142,7 +142,7 @@ class Replay(CLI):
         else:
             for option in whitelist:
                 optvalue = getattr(args, option, None)
-                if optvalue:
+                if optvalue is not None:
                     log.warn("Overriding the replay %s with the --%s value "
                              "given on the command line.",
                              option.replace('_', '-'),


### PR DESCRIPTION
Currently in a replay job we only skip the recorded values if in
command line user provides a non emty string. Example:

 avocaro run --replay --external-runner ''

With the command above avocado will consider --external-runner as not
provided in command line and will use the value from the original job.

This patch makes avocado accept the empty string as a valid value so users
can overwrite the recorded values with empty strings (aka disabling the replay
for that option).

Signed-off-by: Amador Pahim <apahim@redhat.com>