### PR TITLE
avocado.core.remoter: Correct the timeout condition

### DIFF
--- a/avocado/core/remoter.py
+++ b/avocado/core/remoter.py
@@ -102,7 +102,7 @@ class Remote(object):
             except fabric.network.NetworkError as details:
                 fabric_exception = details
                 timeout = end_time - time.time()
-            if time.time() < end_time:
+            if time.time() > end_time:
                 break
         if fabric_result is None:
             if fabric_exception is not None:


### PR DESCRIPTION
We need to finish when the time.time() is greater than the timeout, not
lower.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>