### PR TITLE
avocado.core.output: Two bugfixes

### DIFF
--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -404,8 +404,10 @@ def reconfigure(args):
             disable_log_handler("")
             disable_log_handler("avocado.test")
     if "remote" in enabled:
-        add_log_handler("avocado.fabric", stream=STD_OUTPUT.stdout)
-        add_log_handler("paramiko", stream=STD_OUTPUT.stdout)
+        add_log_handler("avocado.fabric", stream=STD_OUTPUT.stdout,
+                        level=logging.DEBUG)
+        add_log_handler("paramiko", stream=STD_OUTPUT.stdout,
+                        level=logging.DEBUG)
     else:
         disable_log_handler("avocado.fabric")
         disable_log_handler("paramiko")

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -423,8 +423,8 @@ def reconfigure(args):
         if len(stream_level) == 1:
             level = logging.DEBUG
         else:
-            level = (int(name[1]) if name[1].isdigit()
-                     else logging.getLevelName(name[1].upper()))
+            level = (int(stream_level[1]) if stream_level[1].isdigit()
+                     else logging.getLevelName(stream_level[1].upper()))
         try:
             add_log_handler(name, logging.StreamHandler, STD_OUTPUT.stdout,
                             level)

--- a/selftests/functional/test_streams.py
+++ b/selftests/functional/test_streams.py
@@ -114,6 +114,29 @@ class StreamsTest(unittest.TestCase):
             self.assertEqual('', result.stdout)
             self.assertNotEqual('', result.stderr)
 
+    def test_custom_stream_and_level(self):
+        """
+        Checks if "--show stream:level" works for non-built-in-streams
+        """
+        def run(show, no_lines):
+            result = process.run("./scripts/avocado --show %s config" % show)
+            out = (result.stdout + result.stderr).splitlines()
+            if no_lines == "more_than_one":
+                self.assertGreater(len(out), 1, "Output of %s should contain "
+                                   "more than 1 line, contains only %s\n%s"
+                                   % (result.command, len(out), result))
+            else:
+                self.assertEqual(len(out), no_lines, "Output of %s should "
+                                 "contain %s lines, contains %s instead\n%s"
+                                 % (result.command, no_lines, len(out),
+                                    result))
+        run("avocado.app:dEbUg", "more_than_one")
+        run("avocado.app:0", "more_than_one")
+        run("avocado.app:InFo", 1)
+        run("avocado.app:20", 1)
+        run("avocado.app:wARn", 0)
+        run("avocado.app:30", 0)
+
     def tearDown(self):
         shutil.rmtree(self.tmpdir)
 


### PR DESCRIPTION
Hello guys, the `--show $stream:$level` currently does not work as there is an incorrect variable used to parse the level from. Additionally I found out we log only INFO level for "remote" builtin stream, which is different from the "remote.log" people are used to. There is also no way to tweak the level for builtin streams so I hardcoded "DEBUG" for now and added card to allow overriding it: https://trello.com/c/FnZaz8ml/631-support-log-level-specification-for-built-in-streams