### PR TITLE
avocado.core.job: Provide a better message when no tests found

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -469,8 +469,13 @@ class Job(object):
             raise exceptions.OptionValidationError(details)
         if not test_suite:
             self._remove_job_results()
-            e_msg = ("No tests found for given urls, try 'avocado list -V %s' "
-                     "for details" % (" ".join(self.urls) if self.urls else "\b"))
+            if self.urls:
+                e_msg = ("No tests found for given urls, try 'avocado list -V "
+                         "%s' for details" % " ".join(self.urls))
+            else:
+                e_msg = ("No urls provided nor any arguments produced "
+                         "runable tests. Please double check the executed "
+                         "command.")
             raise exceptions.OptionValidationError(e_msg)
 
         if isinstance(getattr(self.args, 'multiplex_files', None),

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -245,7 +245,7 @@ class RunnerOperationTest(unittest.TestCase):
         cmd_line = './scripts/avocado run --sysinfo=off'
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_JOB_FAIL
-        expected_output = 'No tests found for given urls'
+        expected_output = 'No urls provided nor any arguments produced'
         self.assertEqual(result.exit_status, expected_rc)
         self.assertIn(expected_output, result.stderr)
 
@@ -617,7 +617,7 @@ class ExternalRunnerTest(unittest.TestCase):
         cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '
                     '--external-runner=/bin/true' % self.tmpdir)
         result = process.run(cmd_line, ignore_status=True)
-        expected_output = ('No tests found for given urls')
+        expected_output = ('No urls provided nor any arguments produced')
         self.assertIn(expected_output, result.stderr)
         expected_rc = exit_codes.AVOCADO_JOB_FAIL
         self.assertEqual(result.exit_status, expected_rc,


### PR DESCRIPTION
In case no tests are found we advice users to run `avocado list -V`
followed by list of urls, which does not really work with no-urls given.
This patch adds second message in case the user does not provide urls
(eg. is using the `--vt-config` option).

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>