### PR TITLE
Handle long filenames in avocado and fix unknown test status [v2]

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -203,7 +203,7 @@ class Test(unittest.TestCase):
 
     @data_structures.LazyProperty
     def workdir(self):
-        basename = os.path.basename(self.name)
+        basename = os.path.basename(self.logdir)
         return utils_path.init_dir(data_dir.get_tmp_dir(), basename.replace(':', '_'))
 
     @data_structures.LazyProperty

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -329,12 +329,14 @@ class Test(unittest.TestCase):
         return tagged_name
 
     def _record_reference_stdout(self):
-        utils_path.init_dir(self.datadir)
-        shutil.copyfile(self._stdout_file, self._expected_stdout_file)
+        if self.datadir is not None:
+            utils_path.init_dir(self.datadir)
+            shutil.copyfile(self._stdout_file, self._expected_stdout_file)
 
     def _record_reference_stderr(self):
-        utils_path.init_dir(self.datadir)
-        shutil.copyfile(self._stderr_file, self._expected_stderr_file)
+        if self.datadir is not None:
+            utils_path.init_dir(self.datadir)
+            shutil.copyfile(self._stderr_file, self._expected_stderr_file)
 
     def _check_reference_stdout(self):
         if (self._expected_stdout_file is not None and

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -180,7 +180,8 @@ class Test(unittest.TestCase):
         """
         Returns the path to the directory that contains test data files
         """
-        if self.filename is not None:
+        # Maximal allowed file name length is 255
+        if self.filename is not None and len(self.filename) < 251:
             return self.filename + '.data'
         else:
             return None

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -139,7 +139,7 @@ class Test(unittest.TestCase):
 
         self.debugdir = None
         self.resultsdir = None
-        self.status = None
+        self.status = "ERROR"
         self.fail_reason = None
         self.fail_class = None
         self.traceback = None

--- a/avocado/utils/astring.py
+++ b/avocado/utils/astring.py
@@ -201,4 +201,4 @@ def string_to_safe_path(string):
     :param string: String to be converted
     :return: String which is safe to pass as a file/dir name (on recent fs)
     """
-    return string.replace(os.path.sep, '_')
+    return string.replace(os.path.sep, '_')[:255]

--- a/avocado/utils/astring.py
+++ b/avocado/utils/astring.py
@@ -201,4 +201,6 @@ def string_to_safe_path(string):
     :param string: String to be converted
     :return: String which is safe to pass as a file/dir name (on recent fs)
     """
+    if string.startswith("."):
+        string = "_" + string[1:]
     return string.replace(os.path.sep, '_')[:255]

--- a/selftests/unit/test_test.py
+++ b/selftests/unit/test_test.py
@@ -34,6 +34,31 @@ class TestClassTestUnit(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.tmpdir)
 
+    def testUglyName(self):
+        def run(name, path_name):
+            """ Initialize test and check the dirs were created """
+            test = DummyTest("test", name, base_logdir=self.tmpdir)
+            self.assertEqual(os.path.basename(test.logdir), path_name)
+            self.assertTrue(os.path.exists(test.logdir))
+            self.assertEqual(os.path.dirname(os.path.dirname(test.logdir)),
+                             self.tmpdir)
+
+        run("/absolute/path", "_absolute_path")
+        run("./relative/path", "__relative_path")
+        run("../../multi_level/relative/path",
+            "_._.._multi_level_relative_path")
+        # Greek word 'kosme'
+        run("\xce\xba\xe1\xbd\xb9\xcf\x83\xce\xbc\xce\xb5",
+            "\xce\xba\xe1\xbd\xb9\xcf\x83\xce\xbc\xce\xb5")
+        # Particularly problematic noncharacters in 16-bit applications
+        name = ("\xb7\x95\xef\xb7\x96\xef\xb7\x97\xef\xb7\x98\xef\xb7\x99"
+                "\xef\xb7\x9a\xef\xb7\x9b\xef\xb7\x9c\xef\xb7\x9d\xef\xb7"
+                "\x9e\xef\xb7\x9f\xef\xb7\xa0\xef\xb7\xa1\xef\xb7\xa2\xef"
+                "\xb7\xa3\xef\xb7\xa4\xef\xb7\xa5\xef\xb7\xa6\xef\xb7\xa7"
+                "\xef\xb7\xa8\xef\xb7\xa9\xef\xb7\xaa\xef\xb7\xab\xef\xb7"
+                "\xac\xef\xb7\xad\xef\xb7\xae\xef\xb7\xaf")
+        run(name, name)
+
     def testLongName(self):
         test = DummyTest("test", "a" * 256, base_logdir=self.tmpdir)
         self.assertEqual(os.path.basename(test.logdir), "a" * 240)


### PR DESCRIPTION
This patchset fixes the issue https://trello.com/c/6LBKIUtN/591-bug-long-filenames-crash-avocado and avoids crash on https://trello.com/c/BdC56G6X/542-bug-avocado-can-t-handle-exceptions-raised-while-reading-the-test-queue and https://trello.com/c/JhfMuJkW/623-bug-regression-no-test-result-for-some-relative-pathnames

Basically it modifies the way `Test.logdir` is created and reuses the `Test.logdir` for other file name related variables.

Last but not least it adds commit to fix missing test status on early failure.

v1: https://github.com/avocado-framework/avocado/pull/1090

Changes:

    v2: New commit to fix the names with leading '.'