### PR TITLE
Fix job status on timeout

### DIFF
--- a/avocado/core/exceptions.py
+++ b/avocado/core/exceptions.py
@@ -133,12 +133,20 @@ class TestNotFoundError(TestBaseException):
     status = "ERROR"
 
 
-class TestTimeoutError(TestBaseException):
+class TestTimeoutInterrupted(TestBaseException):
 
     """
     Indicates that the test did not finish before the timeout specified.
     """
-    status = "ERROR"
+    status = "INTERRUPTED"
+
+
+class TestTimeoutSkip(TestBaseException):
+
+    """
+    Indicates that the test is skipped due to a job timeout.
+    """
+    status = "SKIP"
 
 
 class TestInterruptedError(TestBaseException):

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -46,6 +46,7 @@ from . import jsonresult
 from . import replay
 from .output import STD_OUTPUT
 from .settings import settings
+from .status import mapping
 from ..utils import archive
 from ..utils import astring
 from ..utils import path
@@ -492,9 +493,9 @@ class Job(object):
         self._log_job_debug_info(mux)
         replay.record(self.args, self.logdir, mux, self.urls)
         replay_map = getattr(self.args, 'replay_map', None)
-        failures = self.test_runner.run_suite(test_suite, mux,
-                                              timeout=self.timeout,
-                                              replay_map=replay_map)
+        summary = self.test_runner.run_suite(test_suite, mux,
+                                             timeout=self.timeout,
+                                             replay_map=replay_map)
         self.__stop_job_logging()
         # If it's all good so far, set job status to 'PASS'
         if self.status == 'RUNNING':
@@ -505,11 +506,18 @@ class Job(object):
             archive.create(filename, self.logdir)
         _TEST_LOGGER.info('Test results available in %s', self.logdir)
 
-        tests_status = not bool(failures)
-        if tests_status:
-            return exit_codes.AVOCADO_ALL_OK
-        else:
-            return exit_codes.AVOCADO_TESTS_FAIL
+        exit_status = exit_codes.AVOCADO_ALL_OK
+        for test_status, fail_class in summary.iteritems():
+            if not mapping[test_status]:
+                exit_status = max(exit_codes.AVOCADO_TESTS_FAIL, exit_status)
+            if fail_class == 'TestTimeoutInterrupted':
+                exit_status = max(exit_codes.AVOCADO_JOB_INTERRUPTED,
+                                  exit_status)
+            elif fail_class == 'TestTimeoutSkip':
+                exit_status = max(exit_codes.AVOCADO_JOB_INTERRUPTED,
+                                  exit_status)
+
+        return exit_status
 
     def run(self):
         """

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -369,6 +369,9 @@ class Test(unittest.TestCase):
         except exceptions.TestSkipError as details:
             stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
             raise exceptions.TestSkipError(details)
+        except exceptions.TestTimeoutSkip as details:
+            stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
+            raise exceptions.TestTimeoutSkip(details)
         except:  # Old-style exceptions are not inherited from Exception()
             stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
             details = sys.exc_info()[1]
@@ -750,6 +753,9 @@ class TimeOutSkipTest(SkipTest):
     """
 
     _skip_reason = "Test skipped due a job timeout!"
+
+    def setUp(self):
+        raise exceptions.TestTimeoutSkip(self._skip_reason)
 
 
 class DryRunTest(SkipTest):

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -197,13 +197,13 @@ class RunnerOperationTest(unittest.TestCase):
         cmd_line = './scripts/avocado run --sysinfo=off --job-results-dir %s --xunit - timeouttest' % self.tmpdir
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout
-        expected_rc = exit_codes.AVOCADO_TESTS_FAIL
+        expected_rc = exit_codes.AVOCADO_JOB_INTERRUPTED
         unexpected_rc = exit_codes.AVOCADO_FAIL
         self.assertNotEqual(result.exit_status, unexpected_rc,
                             "Avocado crashed (rc %d):\n%s" % (unexpected_rc, result))
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %d:\n%s" % (expected_rc, result))
-        self.assertIn("TestTimeoutError: Timeout reached waiting for", output,
+        self.assertIn("TestTimeoutInterrupted: Timeout reached waiting for", output,
                       "Test did not fail with timeout exception:\n%s" % output)
         # Ensure no test aborted error messages show up
         self.assertNotIn("TestAbortedError: Test aborted unexpectedly", output)

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -731,7 +731,7 @@ class PluginsXunitTest(AbsPluginsTest, unittest.TestCase):
         super(PluginsXunitTest, self).setUp()
 
     def run_and_check(self, testname, e_rc, e_ntests, e_nerrors,
-                      e_nnotfound, e_nfailures, e_nskip):
+                      e_nnotfound, e_nfailures, e_nskip, e_ninterrupted):
         os.chdir(basedir)
         cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off'
                     ' --xunit - %s' % (self.tmpdir, testname))
@@ -750,8 +750,8 @@ class PluginsXunitTest(AbsPluginsTest, unittest.TestCase):
         self.assertEqual(len(testsuite_list), 1, 'More than one testsuite tag')
 
         testsuite_tag = testsuite_list[0]
-        self.assertEqual(len(testsuite_tag.attributes), 7,
-                         'The testsuite tag does not have 7 attributes. '
+        self.assertEqual(len(testsuite_tag.attributes), 8,
+                         'The testsuite tag does not have 8 attributes. '
                          'XML:\n%s' % xml_output)
 
         n_tests = int(testsuite_tag.attributes['tests'].value)
@@ -774,21 +774,26 @@ class PluginsXunitTest(AbsPluginsTest, unittest.TestCase):
                          "Unexpected number of test skips, "
                          "XML:\n%s" % xml_output)
 
+        n_interrupted = int(testsuite_tag.attributes['interrupted'].value)
+        self.assertEqual(n_interrupted, e_ninterrupted,
+                         "Unexpected number of test interrupted, "
+                         "XML:\n%s" % xml_output)
+
     def test_xunit_plugin_passtest(self):
         self.run_and_check('passtest', exit_codes.AVOCADO_ALL_OK,
-                           1, 0, 0, 0, 0)
+                           1, 0, 0, 0, 0, 0)
 
     def test_xunit_plugin_failtest(self):
         self.run_and_check('failtest', exit_codes.AVOCADO_TESTS_FAIL,
-                           1, 0, 0, 1, 0)
+                           1, 0, 0, 1, 0, 0)
 
     def test_xunit_plugin_skiponsetuptest(self):
         self.run_and_check('skiponsetup', exit_codes.AVOCADO_ALL_OK,
-                           1, 0, 0, 0, 1)
+                           1, 0, 0, 0, 1, 0)
 
     def test_xunit_plugin_errortest(self):
         self.run_and_check('errortest', exit_codes.AVOCADO_TESTS_FAIL,
-                           1, 1, 0, 0, 0)
+                           1, 1, 0, 0, 0, 0)
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir)

--- a/selftests/functional/test_job_timeout.py
+++ b/selftests/functional/test_job_timeout.py
@@ -57,7 +57,7 @@ class JobTimeOutTest(unittest.TestCase):
         os.chdir(basedir)
 
     def run_and_check(self, cmd_line, e_rc, e_ntests, e_nerrors, e_nfailures,
-                      e_nskip):
+                      e_nskip, e_ninterrupted):
         os.chdir(basedir)
         result = process.run(cmd_line, ignore_status=True)
         xml_output = result.stdout
@@ -74,8 +74,8 @@ class JobTimeOutTest(unittest.TestCase):
         self.assertEqual(len(testsuite_list), 1, 'More than one testsuite tag')
 
         testsuite_tag = testsuite_list[0]
-        self.assertEqual(len(testsuite_tag.attributes), 7,
-                         'The testsuite tag does not have 7 attributes. '
+        self.assertEqual(len(testsuite_tag.attributes), 8,
+                         'The testsuite tag does not have 8 attributes. '
                          'XML:\n%s' % xml_output)
 
         n_tests = int(testsuite_tag.attributes['tests'].value)
@@ -98,23 +98,28 @@ class JobTimeOutTest(unittest.TestCase):
                          "Unexpected number of test skips, "
                          "XML:\n%s" % xml_output)
 
+        n_interrupted = int(testsuite_tag.attributes['interrupted'].value)
+        self.assertEqual(n_interrupted, e_ninterrupted,
+                         "Unexpected number of test interrupted, "
+                         "XML:\n%s" % xml_output)
+
     def test_sleep_longer_timeout(self):
         cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '
                     '--xunit - --job-timeout=5 %s examples/tests/passtest.py' %
                     (self.tmpdir, self.script.path))
-        self.run_and_check(cmd_line, 0, 2, 0, 0, 0)
+        self.run_and_check(cmd_line, 0, 2, 0, 0, 0, 0)
 
     def test_sleep_short_timeout(self):
         cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '
                     '--xunit - --job-timeout=1 %s examples/tests/passtest.py' %
                     (self.tmpdir, self.script.path))
-        self.run_and_check(cmd_line, exit_codes.AVOCADO_TESTS_FAIL, 2, 1, 0, 1)
+        self.run_and_check(cmd_line, exit_codes.AVOCADO_TESTS_FAIL, 2, 1, 0, 1, 0)
 
     def test_sleep_short_timeout_with_test_methods(self):
         cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '
                     '--xunit - --job-timeout=1 %s' %
                     (self.tmpdir, self.py.path))
-        self.run_and_check(cmd_line, exit_codes.AVOCADO_TESTS_FAIL, 3, 1, 0, 2)
+        self.run_and_check(cmd_line, exit_codes.AVOCADO_TESTS_FAIL, 3, 1, 0, 2, 0)
 
     def test_invalid_values(self):
         cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '

--- a/selftests/functional/test_job_timeout.py
+++ b/selftests/functional/test_job_timeout.py
@@ -113,13 +113,13 @@ class JobTimeOutTest(unittest.TestCase):
         cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '
                     '--xunit - --job-timeout=1 %s examples/tests/passtest.py' %
                     (self.tmpdir, self.script.path))
-        self.run_and_check(cmd_line, exit_codes.AVOCADO_TESTS_FAIL, 2, 1, 0, 1, 0)
+        self.run_and_check(cmd_line, exit_codes.AVOCADO_JOB_INTERRUPTED, 2, 0, 0, 1, 1)
 
     def test_sleep_short_timeout_with_test_methods(self):
         cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '
                     '--xunit - --job-timeout=1 %s' %
                     (self.tmpdir, self.py.path))
-        self.run_and_check(cmd_line, exit_codes.AVOCADO_TESTS_FAIL, 3, 1, 0, 2, 0)
+        self.run_and_check(cmd_line, exit_codes.AVOCADO_JOB_INTERRUPTED, 3, 0, 0, 2, 1)
 
     def test_invalid_values(self):
         cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '


### PR DESCRIPTION
When a job is timed out during a test execution, we fail the test
and put status ERROR in the test. The job then exits with the rc
AVOCADO_TESTS_FAIL. This PR fixes this, making the test status
INTERRUPTED and the job to exit with AVOCADO_JOB_INTERRUPTED.

Also, when a job is timed out before a test, the test is skipped
and the job exits with rc AVOCADO_ALL_OK. For that case, this PR
makes the job to exit with AVOCADO_JOB_INTERRUPTED instead, keeping
the test status as SKIP.

Before this change, we had the following behavior of test status
and job return code:

    Case1:
    - Test1: PASS
    - Test2: SKIP (TestSkipError)
    - Job RC: AVOCADO_ALL_OK

    Case2:
    - Test1: PASS
    - Test2: ERROR (TestTimeoutError)
    - Test3: SKIP (TestSkipError)
    - Job RC: AVOCADO_TESTS_FAIL

    Case3:
    - Test1: PASS
    - Test2: FAIL
    - Test3: ERROR (TestTimeoutError)
    - Test4: SKIP (TestSkipError)
    - Job RC: AVOCADO_TESTS_FAIL

Given this change, now we have the following behavior of test status
and job return code:

    Case1:
    - Test1: PASS
    - Test2: SKIP (TestTimeoutSkip)
    - Job RC: AVOCADO_JOB_INTERRUPTED

    Case2:
    - Test1: PASS
    - Test2: INTERRUPTED (TestTimeoutInterrupted)
    - Test3: SKIP (TestTimeoutSkip)
    - Job RC: AVOCADO_JOB_INTERRUPTED

    Case3:
    - Test1: PASS
    - Test2: FAIL
    - Test3: INTERRUPTED (TestTimeoutInterrupted)
    - Test4: SKIP (TestTimeoutSkip)
    - Job RC: AVOCADO_JOB_INTERRUPTED

Reference: https://trello.com/c/H1AxryDp
Reference: https://trello.com/c/Brd5XC8q