### PR TITLE
fix odd message for '--show' inside 'run' without argument

### DIFF
--- a/avocado/core/parser.py
+++ b/avocado/core/parser.py
@@ -68,6 +68,7 @@ class Parser(object):
         self.application.add_argument('--show', action="store",
                                       type=lambda value: value.split(","),
                                       metavar="STREAM[:LVL]",
+                                      nargs='?',
                                       default=['app'], help="List of comma "
                                       "separated builtin logs, or logging "
                                       "streams optionally followed by LEVEL "


### PR DESCRIPTION
v1:
 - Use [`nargs='?'`](https://docs.python.org/2.7/library/argparse.html#nargs) for `--show` option.