### PR TITLE
Job pre and post plugins

### DIFF
--- a/avocado/core/dispatcher.py
+++ b/avocado/core/dispatcher.py
@@ -59,3 +59,29 @@ class CLICmdDispatcher(Dispatcher):
 
     def __init__(self):
         super(CLICmdDispatcher, self).__init__('avocado.plugins.cli.cmd')
+
+
+class JobPreDispatcher(Dispatcher):
+
+    """
+    Calls extensions before Job execution
+
+    Automatically adds all the extension with entry points registered under
+    'avocado.plugins.job.pre'
+    """
+
+    def __init__(self):
+        super(JobPreDispatcher, self).__init__('avocado.plugins.job.pre')
+
+
+class JobPostDispatcher(Dispatcher):
+
+    """
+    Calls extensions after Job execution
+
+    Automatically adds all the extension with entry points registered under
+    'avocado.plugins.job.post'
+    """
+
+    def __init__(self):
+        super(JobPostDispatcher, self).__init__('avocado.plugins.job.post')

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -30,6 +30,7 @@ import fnmatch
 
 from . import version
 from . import data_dir
+from . import dispatcher
 from . import runner
 from . import loader
 from . import sysinfo
@@ -123,6 +124,10 @@ class Job(object):
                                                            _TEST_LOGGER)
         self.stdout_stderr = None
         self.replay_sourcejob = getattr(self.args, 'replay_sourcejob', None)
+        self.job_pre_dispatcher = dispatcher.JobPreDispatcher()
+        self.job_post_dispatcher = dispatcher.JobPostDispatcher()
+        output.log_plugin_failures(self.job_pre_dispatcher.load_failures +
+                                   self.job_post_dispatcher.load_failures)
 
     def _setup_job_results(self):
         logdir = getattr(self.args, 'logdir', None)
@@ -531,6 +536,8 @@ class Job(object):
                  :mod:`avocado.core.exit_codes` for more information.
         """
         runtime.CURRENT_JOB = self
+        if self.job_pre_dispatcher.extensions:
+            self.job_pre_dispatcher.map_method('run', self)
         try:
             return self._run()
         except exceptions.JobBaseException as details:
@@ -556,6 +563,8 @@ class Job(object):
             self.log.error('Report bugs visiting %s', _NEW_ISSUE_LINK)
             return exit_codes.AVOCADO_FAIL
         finally:
+            if self.job_post_dispatcher.extensions:
+                self.job_post_dispatcher.map_method('run', self)
             if not settings.get_value('runner.behavior', 'keep_tmp_files',
                                       key_type=bool, default=False):
                 data_dir.clean_tmp_files()

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -669,3 +669,23 @@ class Throbber(object):
         result = self.MOVES[self.position]
         self._update_position()
         return result
+
+
+def log_plugin_failures(failures):
+    """
+    Log in the application UI failures to load a set of plugins
+
+    :param failures: a list of load failures, usually comming from a
+                     :class:`avocado.core.dispatcher.Dispatcher`
+                     attribute `load_failures`
+    """
+    log = logging.getLogger("avocado.app")
+    msg_fmt = 'Failed to load plugin from module "%s": %s'
+    silenced = settings.get_value('plugins',
+                                  'skip_broken_plugin_notification',
+                                  list, [])
+    for failure in failures:
+        if failure[0].module_name in silenced:
+            continue
+        log.error(msg_fmt, failure[0].module_name,
+                  failure[1].__repr__())

--- a/avocado/plugins/base.py
+++ b/avocado/plugins/base.py
@@ -90,3 +90,26 @@ class CLICmd(Plugin):
         """
         Entry point for actually running the command
         """
+
+
+class JobPrePost(Plugin):
+
+    """
+    Base plugin interface for adding actions before or after a job
+
+    Plugins that want to add actions to be run before a job runs,
+    should use the 'avocado.plugins.job.pre' namespace.
+
+    Plugins that want to add actions to be run after a job runs,
+    should use the 'avocado.plugins.job.post' namespace.
+    """
+    __metaclass__ = abc.ABCMeta
+
+    def __init__(self):
+        super(JobPrePost, self).__init__()
+
+    @abc.abstractmethod
+    def run(self, job):
+        """
+        Entry point for actually running the pre or post job action
+        """

--- a/avocado/plugins/plugins.py
+++ b/avocado/plugins/plugins.py
@@ -41,22 +41,17 @@ class Plugins(CLICmd):
 
     def run(self, args):
         log = logging.getLogger("avocado.app")
-        cli_cmds = dispatcher.CLICmdDispatcher()
-        msg = 'Plugins that add new commands (avocado.plugins.cli.cmd):'
-        log.info(msg)
-        plugin_matrix = []
-        for plugin in sorted(cli_cmds):
-            plugin_matrix.append((plugin.name, plugin.obj.description))
+        plugin_types = [
+            (dispatcher.CLICmdDispatcher(),
+             'Plugins that add new commands (avocado.plugins.cli.cmd):'),
+            (dispatcher.CLIDispatcher(),
+             'Plugins that add new options to commands (avocado.plugins.cli):')
+        ]
+        for plugins_active, msg in plugin_types:
+            log.info(msg)
+            plugin_matrix = []
+            for plugin in sorted(plugins_active):
+                plugin_matrix.append((plugin.name, plugin.obj.description))
 
-        for line in astring.iter_tabular_output(plugin_matrix):
-            log.debug(line)
-
-        msg = 'Plugins that add new options to commands (avocado.plugins.cli):'
-        cli = dispatcher.CLIDispatcher()
-        log.info(msg)
-        plugin_matrix = []
-        for plugin in sorted(cli):
-            plugin_matrix.append((plugin.name, plugin.obj.description))
-
-        for line in astring.iter_tabular_output(plugin_matrix):
-            log.debug(line)
+            for line in astring.iter_tabular_output(plugin_matrix):
+                log.debug(line)

--- a/avocado/plugins/plugins.py
+++ b/avocado/plugins/plugins.py
@@ -53,5 +53,8 @@ class Plugins(CLICmd):
             for plugin in sorted(plugins_active):
                 plugin_matrix.append((plugin.name, plugin.obj.description))
 
-            for line in astring.iter_tabular_output(plugin_matrix):
-                log.debug(line)
+            if not plugin_matrix:
+                log.debug("(No active plugin)")
+            else:
+                for line in astring.iter_tabular_output(plugin_matrix):
+                    log.debug(line)

--- a/avocado/plugins/plugins.py
+++ b/avocado/plugins/plugins.py
@@ -45,7 +45,11 @@ class Plugins(CLICmd):
             (dispatcher.CLICmdDispatcher(),
              'Plugins that add new commands (avocado.plugins.cli.cmd):'),
             (dispatcher.CLIDispatcher(),
-             'Plugins that add new options to commands (avocado.plugins.cli):')
+             'Plugins that add new options to commands (avocado.plugins.cli):'),
+            (dispatcher.JobPreDispatcher(),
+             'Plugins that run before the execution of jobs (avocado.plugins.job.pre):'),
+            (dispatcher.JobPostDispatcher(),
+             'Plugins that run after the execution of jobs (avocado.plugins.job.post):')
         ]
         for plugins_active, msg in plugin_types:
             log.info(msg)

--- a/docs/source/Plugins.rst
+++ b/docs/source/Plugins.rst
@@ -88,6 +88,8 @@ We have briefly discussed the making of Avocado plugins. We recommend
 the `Stevedore documentation`_ and also a look at the
 :mod:`avocado.plugins.base` module for the various plugin interface definitions.
 
+Some plugins examples are available in the `Avocado source tree_`, under ``examples/plugins``.
+
 Finally, exploring the real plugins shipped with Avocado in :mod:`avocado.plugins`
 is the final "documentation" source.
 
@@ -96,3 +98,4 @@ is the final "documentation" source.
 .. _Stevedore documentation: http://docs.openstack.org/developer/stevedore/index.html
 .. _setuptools: https://pythonhosted.org/setuptools/
 .. _entry points: https://pythonhosted.org/setuptools/pkg_resources.html#entry-points
+.. _Avocado source tree: https://github.com/avocado-framework/avocado/tree/master/examples/plugins

--- a/examples/plugins/job-pre-post/mail/avocado_job_mail.py
+++ b/examples/plugins/job-pre-post/mail/avocado_job_mail.py
@@ -1,0 +1,48 @@
+import logging
+import smtplib
+from email.mime.text import MIMEText
+
+from avocado.core.settings import settings
+from avocado.plugins.base import JobPrePost
+
+
+class Mail(JobPrePost):
+
+    name = 'mail'
+    description = 'Sends mail to notify on job start/end'
+
+    def run(self, job):
+        log = logging.getLogger("avocado.app")
+        rcpt = settings.get_value(section="plugins.job.mail",
+                                  key="recipient",
+                                  key_type=str,
+                                  default='root@localhost.localdomain')
+        subject = settings.get_value(section="plugins.job.mail",
+                                     key="subject",
+                                     key_type=str,
+                                     default='[AVOCADO JOB NOTIFICATION]')
+        sender = settings.get_value(section="plugins.job.mail",
+                                    key="sender",
+                                    key_type=str,
+                                    default='avocado@localhost.localdomain')
+        server = settings.get_value(section="plugins.job.mail",
+                                    key="server",
+                                    key_type=str,
+                                    default='localhost')
+
+        # build proper subject based on job status
+        subject += '- Job %s - Status: %s' % (job.unique_id,
+                                              job.status)
+        msg = MIMEText(subject)
+        msg['Subject'] = subject
+        msg['From'] = sender
+        msg['To'] = rcpt
+
+        # So many possible failures, let's just tell the user about it
+        try:
+            smtp = smtplib.SMTP(server)
+            smtp.sendmail(sender, [rcpt], msg.as_string())
+            smtp.quit()
+        except:
+            log.error("Failure to send email notification: "
+                      "please check your mail configuration")

--- a/examples/plugins/job-pre-post/mail/setup.py
+++ b/examples/plugins/job-pre-post/mail/setup.py
@@ -1,0 +1,16 @@
+from setuptools import setup
+
+name = 'avocado_job_mail'
+klass = 'Mail'
+entry_point = '%s = %s:%s' % (name, name, klass)
+
+if __name__ == '__main__':
+    setup(name=name,
+          version='1.0',
+          description='Avocado Pre/Post Job Mail Notification',
+          py_modules=[name],
+          entry_points={
+              'avocado.plugins.job.pre': [entry_point],
+              'avocado.plugins.job.post': [entry_point],
+              }
+          )

--- a/examples/plugins/job-pre-post/sleep/avocado_job_sleep.py
+++ b/examples/plugins/job-pre-post/sleep/avocado_job_sleep.py
@@ -1,0 +1,21 @@
+import time
+import logging
+
+from avocado.core.settings import settings
+from avocado.plugins.base import JobPrePost
+
+
+class Sleep(JobPrePost):
+
+    name = 'sleep'
+    description = 'Sleeps for a number of seconds'
+
+    def run(self, job):
+        log = logging.getLogger("avocado.app")
+        seconds = settings.get_value(section="plugins.job.sleep",
+                                     key="seconds",
+                                     key_type=int,
+                                     default=3)
+        for i in range(seconds):
+            log.info("Sleeping %2i/%s", i+1, seconds)
+            time.sleep(1)

--- a/examples/plugins/job-pre-post/sleep/setup.py
+++ b/examples/plugins/job-pre-post/sleep/setup.py
@@ -1,0 +1,16 @@
+from setuptools import setup
+
+name = 'avocado_job_sleep'
+klass = 'Sleep'
+entry_point = '%s = %s:%s' % (name, name, klass)
+
+if __name__ == '__main__':
+    setup(name=name,
+          version='1.0',
+          description='Avocado Pre/Post Job Sleep',
+          py_modules=[name],
+          entry_points={
+              'avocado.plugins.job.pre': [entry_point],
+              'avocado.plugins.job.post': [entry_point],
+              }
+          )


### PR DESCRIPTION
This introduces a new Plugin interface, and allows plugin writers to execute custom actions before and after the jobs are run.

The plugin interface gives the `avocado.core.job.Job` instance to plugin writers, who can collect information from it.

Also, two examples are given, including a "real world" mail notification plugin.