### PR TITLE
Fix job status on timeout [v4]

### DIFF
--- a/avocado/core/exceptions.py
+++ b/avocado/core/exceptions.py
@@ -133,12 +133,20 @@ class TestNotFoundError(TestBaseException):
     status = "ERROR"
 
 
-class TestTimeoutError(TestBaseException):
+class TestTimeoutInterrupted(TestBaseException):
 
     """
     Indicates that the test did not finish before the timeout specified.
     """
-    status = "ERROR"
+    status = "INTERRUPTED"
+
+
+class TestTimeoutSkip(TestBaseException):
+
+    """
+    Indicates that the test is skipped due to a job timeout.
+    """
+    status = "SKIP"
 
 
 class TestInterruptedError(TestBaseException):

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -46,6 +46,7 @@ from . import jsonresult
 from . import replay
 from .output import STD_OUTPUT
 from .settings import settings
+from .status import mapping
 from ..utils import archive
 from ..utils import astring
 from ..utils import path
@@ -492,9 +493,9 @@ class Job(object):
         self._log_job_debug_info(mux)
         replay.record(self.args, self.logdir, mux, self.urls)
         replay_map = getattr(self.args, 'replay_map', None)
-        failures = self.test_runner.run_suite(test_suite, mux,
-                                              timeout=self.timeout,
-                                              replay_map=replay_map)
+        summary = self.test_runner.run_suite(test_suite, mux,
+                                             timeout=self.timeout,
+                                             replay_map=replay_map)
         self.__stop_job_logging()
         # If it's all good so far, set job status to 'PASS'
         if self.status == 'RUNNING':
@@ -505,11 +506,15 @@ class Job(object):
             archive.create(filename, self.logdir)
         _TEST_LOGGER.info('Test results available in %s', self.logdir)
 
-        tests_status = not bool(failures)
-        if tests_status:
-            return exit_codes.AVOCADO_ALL_OK
-        else:
-            return exit_codes.AVOCADO_TESTS_FAIL
+        exit_status = exit_codes.AVOCADO_ALL_OK
+        for test_status in summary:
+            if not(mapping[test_status]):
+                exit_status = max(exit_codes.AVOCADO_TESTS_FAIL, exit_status)
+            if test_status == 'INTERRUPTED':
+                exit_status = max(exit_codes.AVOCADO_JOB_INTERRUPTED,
+                                  exit_status)
+
+        return exit_status
 
     def run(self):
         """

--- a/avocado/core/remote/runner.py
+++ b/avocado/core/remote/runner.py
@@ -27,7 +27,6 @@ from .. import output
 from .. import remoter
 from .. import virt
 from .. import exceptions
-from .. import status
 from ..runner import TestRunner
 from ...utils import astring
 from ...utils import archive
@@ -186,13 +185,13 @@ class RemoteTestRunner(TestRunner):
         :param params_list: a list of param dicts.
         :param mux: A multiplex iterator (unused here)
 
-        :return: a list of test failures.
+        :return: a list with all tests status.
         """
         del test_suite     # using self.job.urls instead
         del mux            # we're not using multiplexation here
         if not timeout:     # avoid timeout = 0
             timeout = None
-        failures = []
+        summary = []
 
         stdout_backup = sys.stdout
         stderr_backup = sys.stderr
@@ -239,8 +238,7 @@ class RemoteTestRunner(TestRunner):
                 state = test.get_state()
                 self.result.start_test(state)
                 self.result.check_test(state)
-                if not status.mapping[state['status']]:
-                    failures.append(state['tagged_name'])
+                summary.append(state['status'])
             local_log_dir = self.job.logdir
             zip_filename = remote_log_dir + '.zip'
             zip_path_filename = os.path.join(local_log_dir,
@@ -257,7 +255,7 @@ class RemoteTestRunner(TestRunner):
         finally:
             sys.stdout = stdout_backup
             sys.stderr = stderr_backup
-        return failures
+        return summary
 
 
 class VMTestRunner(RemoteTestRunner):

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -28,7 +28,6 @@ import time
 from . import test
 from . import exceptions
 from . import output
-from . import status
 from .loader import loader
 from ..utils import wait
 from ..utils import stacktrace
@@ -251,7 +250,7 @@ class TestRunner(object):
 
         def timeout_handler(signum, frame):
             e_msg = "Timeout reached waiting for %s to end" % instance
-            raise exceptions.TestTimeoutError(e_msg)
+            raise exceptions.TestTimeoutInterrupted(e_msg)
 
         def interrupt_handler(signum, frame):
             e_msg = "Test %s interrupted by user" % instance
@@ -278,7 +277,7 @@ class TestRunner(object):
         """
         pass
 
-    def run_test(self, test_factory, queue, failures, job_deadline=0):
+    def run_test(self, test_factory, queue, summary, job_deadline=0):
         """
         Run a test instance inside a subprocess.
 
@@ -286,8 +285,8 @@ class TestRunner(object):
         :type test_factory: tuple of :class:`avocado.core.test.Test` and dict.
         :param queue: Multiprocess queue.
         :type queue: :class`multiprocessing.Queue` instance.
-        :param failures: Store tests failed.
-        :type failures: list.
+        :param summary: Store tests status.
+        :type summary: list.
         :param job_deadline: Maximum time to execute.
         :type job_deadline: int.
         """
@@ -395,8 +394,12 @@ class TestRunner(object):
             self.job.log.debug('')
 
         self.result.check_test(test_state)
-        if not status.mapping[test_state['status']]:
-            failures.append(test_state['name'])
+        if test_state['fail_class'] == 'TestTimeoutSkip':
+            # The test was skipped but the job was interrupted due
+            # to the timeout.
+            summary.append('INTERRUPTED')
+        else:
+            summary.append(test_state['status'])
 
         if ctrl_c_count > 0:
             return False
@@ -409,9 +412,9 @@ class TestRunner(object):
         :param test_suite: a list of tests to run.
         :param mux: the multiplexer.
         :param timeout: maximum amount of time (in seconds) to execute.
-        :return: a list of test failures.
+        :return: a list of tests status.
         """
-        failures = []
+        summary = []
         if self.job.sysinfo is not None:
             self.job.sysinfo.start_job_hook()
         self.result.start_tests()
@@ -435,7 +438,7 @@ class TestRunner(object):
                         del test_parameters['methodName']
                     test_factory = (test.TimeOutSkipTest, test_parameters)
                     break_loop = not self.run_test(test_factory, queue,
-                                                   failures)
+                                                   summary)
                     if break_loop:
                         break
                 else:
@@ -445,7 +448,7 @@ class TestRunner(object):
                         test_factory = (replay_map[index], test_parameters)
 
                     break_loop = not self.run_test(test_factory, queue,
-                                                   failures, deadline)
+                                                   summary, deadline)
                     if break_loop:
                         break
             runtime.CURRENT_TEST = None
@@ -456,4 +459,4 @@ class TestRunner(object):
         if self.job.sysinfo is not None:
             self.job.sysinfo.end_job_hook()
         signal.signal(signal.SIGTSTP, signal.SIG_IGN)
-        return failures
+        return summary

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -369,6 +369,9 @@ class Test(unittest.TestCase):
         except exceptions.TestSkipError as details:
             stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
             raise exceptions.TestSkipError(details)
+        except exceptions.TestTimeoutSkip as details:
+            stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
+            raise exceptions.TestTimeoutSkip(details)
         except:  # Old-style exceptions are not inherited from Exception()
             stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
             details = sys.exc_info()[1]
@@ -750,6 +753,9 @@ class TimeOutSkipTest(SkipTest):
     """
 
     _skip_reason = "Test skipped due a job timeout!"
+
+    def setUp(self):
+        raise exceptions.TestTimeoutSkip(self._skip_reason)
 
 
 class DryRunTest(SkipTest):

--- a/avocado/core/xunit.py
+++ b/avocado/core/xunit.py
@@ -54,10 +54,10 @@ class XmlResult(object):
 
         :param timestamp: Timestamp string in date/time format.
         """
-        self.testsuite = '<testsuite name="avocado" tests="{tests}" errors="{errors}" failures="{failures}" skip="{skip}" time="{total_time}" timestamp="%s">' % timestamp
+        self.testsuite = '<testsuite name="avocado" tests="{tests}" errors="{errors}" failures="{failures}" skip="{skip}" interrupted="{interrupted}" time="{total_time}" timestamp="%s">' % timestamp
         self.testcases = []
 
-    def end_testsuite(self, tests, errors, failures, skip, total_time):
+    def end_testsuite(self, tests, errors, failures, skip, interrupted, total_time):
         """
         End of testsuite node.
 
@@ -71,6 +71,7 @@ class XmlResult(object):
                   'errors': errors,
                   'failures': failures,
                   'skip': skip,
+                  'interrupted': interrupted,
                   'total_time': total_time}
         self.xml.append(self.testsuite.format(**values))
         for tc in self.testcases:
@@ -198,6 +199,8 @@ class xUnitTestResult(TestResult):
             self.xml.add_failure(state)
         elif state['status'] == 'ERROR':
             self.xml.add_error(state)
+        elif state['status'] == 'INTERRUPTED':
+            self.xml.add_error(state)
 
     def end_tests(self):
         """
@@ -208,6 +211,7 @@ class xUnitTestResult(TestResult):
                   'errors': len(self.errors),
                   'failures': len(self.failed),
                   'skip': len(self.skipped),
+                  'interrupted': len(self.interrupted),
                   'total_time': self.total_time}
         self.xml.end_testsuite(**values)
         contents = self.xml.get_contents()

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -197,13 +197,13 @@ class RunnerOperationTest(unittest.TestCase):
         cmd_line = './scripts/avocado run --sysinfo=off --job-results-dir %s --xunit - timeouttest' % self.tmpdir
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout
-        expected_rc = exit_codes.AVOCADO_TESTS_FAIL
+        expected_rc = exit_codes.AVOCADO_JOB_INTERRUPTED
         unexpected_rc = exit_codes.AVOCADO_FAIL
         self.assertNotEqual(result.exit_status, unexpected_rc,
                             "Avocado crashed (rc %d):\n%s" % (unexpected_rc, result))
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %d:\n%s" % (expected_rc, result))
-        self.assertIn("TestTimeoutError: Timeout reached waiting for", output,
+        self.assertIn("TestTimeoutInterrupted: Timeout reached waiting for", output,
                       "Test did not fail with timeout exception:\n%s" % output)
         # Ensure no test aborted error messages show up
         self.assertNotIn("TestAbortedError: Test aborted unexpectedly", output)

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -731,7 +731,7 @@ class PluginsXunitTest(AbsPluginsTest, unittest.TestCase):
         super(PluginsXunitTest, self).setUp()
 
     def run_and_check(self, testname, e_rc, e_ntests, e_nerrors,
-                      e_nnotfound, e_nfailures, e_nskip):
+                      e_nnotfound, e_nfailures, e_nskip, e_ninterrupted):
         os.chdir(basedir)
         cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off'
                     ' --xunit - %s' % (self.tmpdir, testname))
@@ -750,8 +750,8 @@ class PluginsXunitTest(AbsPluginsTest, unittest.TestCase):
         self.assertEqual(len(testsuite_list), 1, 'More than one testsuite tag')
 
         testsuite_tag = testsuite_list[0]
-        self.assertEqual(len(testsuite_tag.attributes), 7,
-                         'The testsuite tag does not have 7 attributes. '
+        self.assertEqual(len(testsuite_tag.attributes), 8,
+                         'The testsuite tag does not have 8 attributes. '
                          'XML:\n%s' % xml_output)
 
         n_tests = int(testsuite_tag.attributes['tests'].value)
@@ -774,21 +774,26 @@ class PluginsXunitTest(AbsPluginsTest, unittest.TestCase):
                          "Unexpected number of test skips, "
                          "XML:\n%s" % xml_output)
 
+        n_interrupted = int(testsuite_tag.attributes['interrupted'].value)
+        self.assertEqual(n_interrupted, e_ninterrupted,
+                         "Unexpected number of test interrupted, "
+                         "XML:\n%s" % xml_output)
+
     def test_xunit_plugin_passtest(self):
         self.run_and_check('passtest', exit_codes.AVOCADO_ALL_OK,
-                           1, 0, 0, 0, 0)
+                           1, 0, 0, 0, 0, 0)
 
     def test_xunit_plugin_failtest(self):
         self.run_and_check('failtest', exit_codes.AVOCADO_TESTS_FAIL,
-                           1, 0, 0, 1, 0)
+                           1, 0, 0, 1, 0, 0)
 
     def test_xunit_plugin_skiponsetuptest(self):
         self.run_and_check('skiponsetup', exit_codes.AVOCADO_ALL_OK,
-                           1, 0, 0, 0, 1)
+                           1, 0, 0, 0, 1, 0)
 
     def test_xunit_plugin_errortest(self):
         self.run_and_check('errortest', exit_codes.AVOCADO_TESTS_FAIL,
-                           1, 1, 0, 0, 0)
+                           1, 1, 0, 0, 0, 0)
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir)

--- a/selftests/functional/test_job_timeout.py
+++ b/selftests/functional/test_job_timeout.py
@@ -57,7 +57,7 @@ class JobTimeOutTest(unittest.TestCase):
         os.chdir(basedir)
 
     def run_and_check(self, cmd_line, e_rc, e_ntests, e_nerrors, e_nfailures,
-                      e_nskip):
+                      e_nskip, e_ninterrupted):
         os.chdir(basedir)
         result = process.run(cmd_line, ignore_status=True)
         xml_output = result.stdout
@@ -74,8 +74,8 @@ class JobTimeOutTest(unittest.TestCase):
         self.assertEqual(len(testsuite_list), 1, 'More than one testsuite tag')
 
         testsuite_tag = testsuite_list[0]
-        self.assertEqual(len(testsuite_tag.attributes), 7,
-                         'The testsuite tag does not have 7 attributes. '
+        self.assertEqual(len(testsuite_tag.attributes), 8,
+                         'The testsuite tag does not have 8 attributes. '
                          'XML:\n%s' % xml_output)
 
         n_tests = int(testsuite_tag.attributes['tests'].value)
@@ -98,23 +98,28 @@ class JobTimeOutTest(unittest.TestCase):
                          "Unexpected number of test skips, "
                          "XML:\n%s" % xml_output)
 
+        n_interrupted = int(testsuite_tag.attributes['interrupted'].value)
+        self.assertEqual(n_interrupted, e_ninterrupted,
+                         "Unexpected number of test interrupted, "
+                         "XML:\n%s" % xml_output)
+
     def test_sleep_longer_timeout(self):
         cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '
                     '--xunit - --job-timeout=5 %s examples/tests/passtest.py' %
                     (self.tmpdir, self.script.path))
-        self.run_and_check(cmd_line, 0, 2, 0, 0, 0)
+        self.run_and_check(cmd_line, 0, 2, 0, 0, 0, 0)
 
     def test_sleep_short_timeout(self):
         cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '
                     '--xunit - --job-timeout=1 %s examples/tests/passtest.py' %
                     (self.tmpdir, self.script.path))
-        self.run_and_check(cmd_line, exit_codes.AVOCADO_TESTS_FAIL, 2, 1, 0, 1)
+        self.run_and_check(cmd_line, exit_codes.AVOCADO_TESTS_FAIL, 2, 1, 0, 1, 0)
 
     def test_sleep_short_timeout_with_test_methods(self):
         cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '
                     '--xunit - --job-timeout=1 %s' %
                     (self.tmpdir, self.py.path))
-        self.run_and_check(cmd_line, exit_codes.AVOCADO_TESTS_FAIL, 3, 1, 0, 2)
+        self.run_and_check(cmd_line, exit_codes.AVOCADO_TESTS_FAIL, 3, 1, 0, 2, 0)
 
     def test_invalid_values(self):
         cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '

--- a/selftests/functional/test_job_timeout.py
+++ b/selftests/functional/test_job_timeout.py
@@ -113,13 +113,13 @@ class JobTimeOutTest(unittest.TestCase):
         cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '
                     '--xunit - --job-timeout=1 %s examples/tests/passtest.py' %
                     (self.tmpdir, self.script.path))
-        self.run_and_check(cmd_line, exit_codes.AVOCADO_TESTS_FAIL, 2, 1, 0, 1, 0)
+        self.run_and_check(cmd_line, exit_codes.AVOCADO_JOB_INTERRUPTED, 2, 0, 0, 1, 1)
 
     def test_sleep_short_timeout_with_test_methods(self):
         cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '
                     '--xunit - --job-timeout=1 %s' %
                     (self.tmpdir, self.py.path))
-        self.run_and_check(cmd_line, exit_codes.AVOCADO_TESTS_FAIL, 3, 1, 0, 2, 0)
+        self.run_and_check(cmd_line, exit_codes.AVOCADO_JOB_INTERRUPTED, 3, 0, 0, 2, 1)
 
     def test_invalid_values(self):
         cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '


### PR DESCRIPTION
v1 #1101:

 - Include interrupted tetsts in xunit results.
 - Fix return code for timed out jobs.

v2: #1102 

 - Make the exit code OR'able.
 - Put job return code in line with OR'able exit code.
 - Adjust tests.

v3: #1105 

 - Restore v1 (#1101).
 - Remove `add_interrupted()` from `xunit` and reuse `add_error()` for `INTERRUPTED` status.

v4:

 - Return only a list with all tests status from `runner` to `job`.
 - Adjust `remote.runner` to aslo return the new `summary` list.
 - When the test is skipped due to a job timeout, overwrite its `SKIP` status on `summary` with `INTERRUPTED` so `job` can set the right status.