### PR TITLE
Add .gitattributes, marking some files as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.min.css binary
+*.min.js binary
+*.svg binary


### PR DESCRIPTION
*.svg, .min.js and .min.css are text files, but they're not
intended to be edited by hand.

Worst of all, they keep poluting the output of git grep.