### PR TITLE
Fix job status on timeout [v6]

### DIFF
--- a/avocado/core/exceptions.py
+++ b/avocado/core/exceptions.py
@@ -133,12 +133,20 @@ class TestNotFoundError(TestBaseException):
     status = "ERROR"
 
 
-class TestTimeoutError(TestBaseException):
+class TestTimeoutInterrupted(TestBaseException):
 
     """
     Indicates that the test did not finish before the timeout specified.
     """
-    status = "ERROR"
+    status = "INTERRUPTED"
+
+
+class TestTimeoutSkip(TestBaseException):
+
+    """
+    Indicates that the test is skipped due to a job timeout.
+    """
+    status = "SKIP"
 
 
 class TestInterruptedError(TestBaseException):

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -28,8 +28,8 @@ import time
 from . import test
 from . import exceptions
 from . import output
-from . import status
 from .loader import loader
+from .status import mapping
 from ..utils import wait
 from ..utils import stacktrace
 from ..utils import runtime
@@ -251,7 +251,7 @@ class TestRunner(object):
 
         def timeout_handler(signum, frame):
             e_msg = "Timeout reached waiting for %s to end" % instance
-            raise exceptions.TestTimeoutError(e_msg)
+            raise exceptions.TestTimeoutInterrupted(e_msg)
 
         def interrupt_handler(signum, frame):
             e_msg = "Test %s interrupted by user" % instance
@@ -278,7 +278,7 @@ class TestRunner(object):
         """
         pass
 
-    def run_test(self, test_factory, queue, failures, job_deadline=0):
+    def run_test(self, test_factory, queue, summary, job_deadline=0):
         """
         Run a test instance inside a subprocess.
 
@@ -286,8 +286,8 @@ class TestRunner(object):
         :type test_factory: tuple of :class:`avocado.core.test.Test` and dict.
         :param queue: Multiprocess queue.
         :type queue: :class`multiprocessing.Queue` instance.
-        :param failures: Store tests failed.
-        :type failures: list.
+        :param summary: Contains types of test failures.
+        :type summary: set.
         :param job_deadline: Maximum time to execute.
         :type job_deadline: int.
         """
@@ -395,8 +395,10 @@ class TestRunner(object):
             self.job.log.debug('')
 
         self.result.check_test(test_state)
-        if not status.mapping[test_state['status']]:
-            failures.append(test_state['name'])
+        if test_state['status'] == "INTERRUPTED":
+            summary.add("INTERRUPTED")
+        elif not mapping[test_state['status']]:
+            summary.add("FAIL")
 
         if ctrl_c_count > 0:
             return False
@@ -409,9 +411,9 @@ class TestRunner(object):
         :param test_suite: a list of tests to run.
         :param mux: the multiplexer.
         :param timeout: maximum amount of time (in seconds) to execute.
-        :return: a list of test failures.
+        :return: a set with types of test failures.
         """
-        failures = []
+        summary = set()
         if self.job.sysinfo is not None:
             self.job.sysinfo.start_job_hook()
         self.result.start_tests()
@@ -431,11 +433,12 @@ class TestRunner(object):
                 index += 1
                 test_parameters = test_factory[1]
                 if deadline is not None and time.time() > deadline:
+                    summary.add('INTERRUPTED')
                     if 'methodName' in test_parameters:
                         del test_parameters['methodName']
                     test_factory = (test.TimeOutSkipTest, test_parameters)
                     break_loop = not self.run_test(test_factory, queue,
-                                                   failures)
+                                                   summary)
                     if break_loop:
                         break
                 else:
@@ -445,7 +448,7 @@ class TestRunner(object):
                         test_factory = (replay_map[index], test_parameters)
 
                     break_loop = not self.run_test(test_factory, queue,
-                                                   failures, deadline)
+                                                   summary, deadline)
                     if break_loop:
                         break
             runtime.CURRENT_TEST = None
@@ -456,4 +459,4 @@ class TestRunner(object):
         if self.job.sysinfo is not None:
             self.job.sysinfo.end_job_hook()
         signal.signal(signal.SIGTSTP, signal.SIG_IGN)
-        return failures
+        return summary

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -369,6 +369,9 @@ class Test(unittest.TestCase):
         except exceptions.TestSkipError as details:
             stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
             raise exceptions.TestSkipError(details)
+        except exceptions.TestTimeoutSkip as details:
+            stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
+            raise exceptions.TestTimeoutSkip(details)
         except:  # Old-style exceptions are not inherited from Exception()
             stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
             details = sys.exc_info()[1]
@@ -750,6 +753,9 @@ class TimeOutSkipTest(SkipTest):
     """
 
     _skip_reason = "Test skipped due a job timeout!"
+
+    def setUp(self):
+        raise exceptions.TestTimeoutSkip(self._skip_reason)
 
 
 class DryRunTest(SkipTest):

--- a/avocado/core/xunit.py
+++ b/avocado/core/xunit.py
@@ -198,6 +198,8 @@ class xUnitTestResult(TestResult):
             self.xml.add_failure(state)
         elif state['status'] == 'ERROR':
             self.xml.add_error(state)
+        elif state['status'] == 'INTERRUPTED':
+            self.xml.add_error(state)
 
     def end_tests(self):
         """
@@ -205,7 +207,7 @@ class xUnitTestResult(TestResult):
         """
         TestResult.end_tests(self)
         values = {'tests': self.tests_total,
-                  'errors': len(self.errors),
+                  'errors': len(self.errors) + len(self.interrupted),
                   'failures': len(self.failed),
                   'skip': len(self.skipped),
                   'total_time': self.total_time}

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -197,13 +197,13 @@ class RunnerOperationTest(unittest.TestCase):
         cmd_line = './scripts/avocado run --sysinfo=off --job-results-dir %s --xunit - timeouttest' % self.tmpdir
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout
-        expected_rc = exit_codes.AVOCADO_TESTS_FAIL
+        expected_rc = exit_codes.AVOCADO_JOB_INTERRUPTED
         unexpected_rc = exit_codes.AVOCADO_FAIL
         self.assertNotEqual(result.exit_status, unexpected_rc,
                             "Avocado crashed (rc %d):\n%s" % (unexpected_rc, result))
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %d:\n%s" % (expected_rc, result))
-        self.assertIn("TestTimeoutError: Timeout reached waiting for", output,
+        self.assertIn("TestTimeoutInterrupted: Timeout reached waiting for", output,
                       "Test did not fail with timeout exception:\n%s" % output)
         # Ensure no test aborted error messages show up
         self.assertNotIn("TestAbortedError: Test aborted unexpectedly", output)

--- a/selftests/functional/test_job_timeout.py
+++ b/selftests/functional/test_job_timeout.py
@@ -108,13 +108,13 @@ class JobTimeOutTest(unittest.TestCase):
         cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '
                     '--xunit - --job-timeout=1 %s examples/tests/passtest.py' %
                     (self.tmpdir, self.script.path))
-        self.run_and_check(cmd_line, exit_codes.AVOCADO_TESTS_FAIL, 2, 1, 0, 1)
+        self.run_and_check(cmd_line, exit_codes.AVOCADO_JOB_INTERRUPTED, 2, 1, 0, 1)
 
     def test_sleep_short_timeout_with_test_methods(self):
         cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '
                     '--xunit - --job-timeout=1 %s' %
                     (self.tmpdir, self.py.path))
-        self.run_and_check(cmd_line, exit_codes.AVOCADO_TESTS_FAIL, 3, 1, 0, 2)
+        self.run_and_check(cmd_line, exit_codes.AVOCADO_JOB_INTERRUPTED, 3, 1, 0, 2)
 
     def test_invalid_values(self):
         cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '


### PR DESCRIPTION
v1 #1101:

 - Include interrupted tetsts in xunit results.
 - Fix return code for timed out jobs.

v2: #1102 

 - Make the exit code OR'able.
 - Put job return code in line with OR'able exit code.
 - Adjust tests.

v3: #1105 

 - Restore v1 (#1101).
 - Remove `add_interrupted()` from `xunit` and reuse `add_error()` for `INTERRUPTED` status.

v4: #1108 

 - Return only a list with all tests status from `runner` to `job`.
 - Adjust `remote.runner` to aslo return the new `summary` list.
 - When the test is skipped due to a job timeout, overwrite its `SKIP` status on `summary` with `INTERRUPTED` so `job` can set the right status.

v5: #1111 

 - `summary` is now a `set()` containing `INTERRUPTED` when the job is timed out or `FAIL` if any test finishes with a bad status (`not status.mapping(test-status)`). Empty `summary` means all tests finished well.

v6:

 - Adjust xunit to match the template in use.
 - Minor fix to avoid crash in job when `summary` is `None`.
 - Improved docstrings.