### PR TITLE
Handle long filenames in avocado and fix unknown test status [v4]

### DIFF
--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -28,6 +28,7 @@ import time
 from . import test
 from . import exceptions
 from . import output
+from . import status
 from .loader import loader
 from .status import mapping
 from ..utils import wait
@@ -393,6 +394,17 @@ class TestRunner(object):
         # don't process other tests from the list
         if ctrl_c_count > 0:
             self.job.log.debug('')
+
+        # Make sure the test status is correct
+        if test_state.get('status') not in status.user_facing_status:
+            test_state['fail_reason'] = ("Test reports unsupported test "
+                                         "status %s.\nOriginal fail_reason: %s"
+                                         "\nOriginal fail_class: %s"
+                                         % (test_state.get('status'),
+                                            test_state.get('fail_reason'),
+                                            test_state.get('fail_class')))
+            test_state['fail_class'] = "RUNNER"
+            test_state['status'] = 'ERROR'
 
         self.result.check_test(test_state)
         if test_state['status'] == "INTERRUPTED":

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -313,14 +313,14 @@ class Test(unittest.TestCase):
         tag = 0
         tagged_name = name
         # The maximal length on ext4+python2.7 is 255 chars.
-        safe_tagged_name = astring.string_to_safe_path(tagged_name[:251])
+        safe_tagged_name = astring.string_to_safe_path(tagged_name[:250])
         for i in xrange(9999):
             if not os.path.isdir(os.path.join(logdir, safe_tagged_name)):
                 break
             tag += 1
             tagged_name = "%s.%s" % (name, tag)
             safe_tagged_name = astring.string_to_safe_path("%s.%s"
-                                                           % (name[:251], tag))
+                                                           % (name[:250], tag))
         else:
             raise exceptions.TestSetupFail("Unable to find unique name in %s "
                                            "iterations (%s).", i,

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -203,7 +203,7 @@ class Test(unittest.TestCase):
 
     @data_structures.LazyProperty
     def workdir(self):
-        basename = os.path.basename(self.name)
+        basename = os.path.basename(self.logdir)
         return utils_path.init_dir(data_dir.get_tmp_dir(), basename.replace(':', '_'))
 
     @data_structures.LazyProperty

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -101,16 +101,9 @@ class Test(unittest.TestCase):
         if base_logdir is None:
             base_logdir = data_dir.create_job_logs_dir()
         base_logdir = os.path.join(base_logdir, 'test-results')
-        self.tagged_name = self._get_tagged_name(base_logdir)
+        self.tagged_name, self.logdir = self._init_logdir(base_logdir)
 
         # Replace '/' with '_' to avoid splitting name into multiple dirs
-        safe_tagged_name = astring.string_to_safe_path(self.tagged_name)
-        test_log_dir = os.path.join(base_logdir, safe_tagged_name)
-        if os.path.isdir(test_log_dir):
-            msg = ('Test log dir "%s" exists prior to Avocado creating '
-                   'it' % test_log_dir)
-            raise exceptions.TestSetupFail(msg)
-        self.logdir = utils_path.init_dir(base_logdir, safe_tagged_name)
         genio.set_log_file_dir(self.logdir)
         self.logfile = os.path.join(self.logdir, 'debug.log')
         self._ssh_logfile = os.path.join(self.logdir, 'remote.log')
@@ -302,9 +295,9 @@ class Test(unittest.TestCase):
         self.log.removeHandler(self.file_handler)
         logging.getLogger('paramiko').removeHandler(self._ssh_fh)
 
-    def _get_tagged_name(self, logdir):
+    def _init_logdir(self, logdir):
         """
-        Get a test tagged name.
+        Initialize log dir
 
         Combines name + tag (if present) to obtain unique name. When associated
         directory already exists, appends ".$number" until unused name
@@ -312,21 +305,28 @@ class Test(unittest.TestCase):
 
         :param logdir: Log directory being in use for result storage.
 
-        :return: Unique test name
+        :return: Unique test name and the logdir
         """
         name = self.name
         if self.tag is not None:
             name += ".%s" % self.tag
         tag = 0
         tagged_name = name
-        safe_tagged_name = astring.string_to_safe_path(tagged_name)
-        while os.path.isdir(os.path.join(logdir, safe_tagged_name)):
+        # The maximal length on ext4+python2.7 is 255 chars.
+        safe_tagged_name = astring.string_to_safe_path(tagged_name[:251])
+        for i in xrange(9999):
+            if not os.path.isdir(os.path.join(logdir, safe_tagged_name)):
+                break
             tag += 1
             tagged_name = "%s.%s" % (name, tag)
-            safe_tagged_name = astring.string_to_safe_path(tagged_name)
-
+            safe_tagged_name = astring.string_to_safe_path("%s.%s"
+                                                           % (name[:251], tag))
+        else:
+            raise exceptions.TestSetupFail("Unable to find unique name in %s "
+                                           "iterations (%s).", i,
+                                           safe_tagged_name)
         self.tag = "%s.%s" % (self.tag, tag) if self.tag else str(tag)
-        return tagged_name
+        return tagged_name, utils_path.init_dir(logdir, safe_tagged_name)
 
     def _record_reference_stdout(self):
         if self.datadir is not None:

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -329,12 +329,14 @@ class Test(unittest.TestCase):
         return tagged_name
 
     def _record_reference_stdout(self):
-        utils_path.init_dir(self.datadir)
-        shutil.copyfile(self._stdout_file, self._expected_stdout_file)
+        if self.datadir is not None:
+            utils_path.init_dir(self.datadir)
+            shutil.copyfile(self._stdout_file, self._expected_stdout_file)
 
     def _record_reference_stderr(self):
-        utils_path.init_dir(self.datadir)
-        shutil.copyfile(self._stderr_file, self._expected_stderr_file)
+        if self.datadir is not None:
+            utils_path.init_dir(self.datadir)
+            shutil.copyfile(self._stderr_file, self._expected_stderr_file)
 
     def _check_reference_stdout(self):
         if (self._expected_stdout_file is not None and

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -180,7 +180,8 @@ class Test(unittest.TestCase):
         """
         Returns the path to the directory that contains test data files
         """
-        if self.filename is not None:
+        # Maximal allowed file name length is 255
+        if self.filename is not None and len(self.filename) < 251:
             return self.filename + '.data'
         else:
             return None

--- a/avocado/utils/astring.py
+++ b/avocado/utils/astring.py
@@ -217,4 +217,4 @@ def string_to_safe_path(string):
     :param string: String to be converted
     :return: String which is safe to pass as a file/dir name (on recent fs)
     """
-    return string.replace(os.path.sep, '_')
+    return string.replace(os.path.sep, '_')[:255]

--- a/avocado/utils/astring.py
+++ b/avocado/utils/astring.py
@@ -217,4 +217,6 @@ def string_to_safe_path(string):
     :param string: String to be converted
     :return: String which is safe to pass as a file/dir name (on recent fs)
     """
+    if string.startswith("."):
+        string = "_" + string[1:]
     return string.replace(os.path.sep, '_')[:255]

--- a/selftests/unit/test_test.py
+++ b/selftests/unit/test_test.py
@@ -34,6 +34,31 @@ class TestClassTestUnit(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.tmpdir)
 
+    def testUglyName(self):
+        def run(name, path_name):
+            """ Initialize test and check the dirs were created """
+            test = DummyTest("test", name, base_logdir=self.tmpdir)
+            self.assertEqual(os.path.basename(test.logdir), path_name)
+            self.assertTrue(os.path.exists(test.logdir))
+            self.assertEqual(os.path.dirname(os.path.dirname(test.logdir)),
+                             self.tmpdir)
+
+        run("/absolute/path", "_absolute_path")
+        run("./relative/path", "__relative_path")
+        run("../../multi_level/relative/path",
+            "_._.._multi_level_relative_path")
+        # Greek word 'kosme'
+        run("\xce\xba\xe1\xbd\xb9\xcf\x83\xce\xbc\xce\xb5",
+            "\xce\xba\xe1\xbd\xb9\xcf\x83\xce\xbc\xce\xb5")
+        # Particularly problematic noncharacters in 16-bit applications
+        name = ("\xb7\x95\xef\xb7\x96\xef\xb7\x97\xef\xb7\x98\xef\xb7\x99"
+                "\xef\xb7\x9a\xef\xb7\x9b\xef\xb7\x9c\xef\xb7\x9d\xef\xb7"
+                "\x9e\xef\xb7\x9f\xef\xb7\xa0\xef\xb7\xa1\xef\xb7\xa2\xef"
+                "\xb7\xa3\xef\xb7\xa4\xef\xb7\xa5\xef\xb7\xa6\xef\xb7\xa7"
+                "\xef\xb7\xa8\xef\xb7\xa9\xef\xb7\xaa\xef\xb7\xab\xef\xb7"
+                "\xac\xef\xb7\xad\xef\xb7\xae\xef\xb7\xaf")
+        run(name, name)
+
     def testLongName(self):
         test = DummyTest("test", "a" * 256, base_logdir=self.tmpdir)
         self.assertEqual(os.path.basename(test.logdir), "a" * 250)

--- a/selftests/unit/test_test.py
+++ b/selftests/unit/test_test.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import sys
 import tempfile
+from flexmock import flexmock
 
 if sys.version_info[:2] == (2, 6):
     import unittest2 as unittest
@@ -18,6 +19,42 @@ true
 FAIL_SCRIPT_CONTENTS = """#!/bin/sh
 false
 """
+
+
+class DummyTest(test.Test):
+    def test(self):
+        pass
+
+
+class TestClassTestUnit(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix="avocado_" + __name__)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+    def testLongName(self):
+        test = DummyTest("test", "a" * 256, base_logdir=self.tmpdir)
+        self.assertEqual(os.path.basename(test.logdir), "a" * 250)
+        test = DummyTest("test", "a" * 256, base_logdir=self.tmpdir)
+        self.assertEqual(os.path.basename(test.logdir), "a" * 250 + ".1")
+        self.assertEqual(os.path.basename(test.workdir),
+                         os.path.basename(test.logdir))
+        flexmock(test)
+        test.should_receive('filename').and_return("a"*250)
+        self.assertEqual("a"*250 + ".data", test.datadir)
+        self.assertRaises(IOError, test._record_reference_stdout)
+        self.assertRaises(IOError, test._record_reference_stderr)
+        test.should_receive('filename').and_return("a"*251)
+        self.assertFalse(test.datadir)
+        test._record_reference_stdout()
+        test._record_reference_stderr()
+
+    def testAllDirsExistsNoHang(self):
+        flexmock(os.path)
+        os.path.should_receive('isdir').and_return(True)
+        self.assertRaises(exceptions.TestSetupFail, DummyTest, "test", "name")
 
 
 class TestClassTest(unittest.TestCase):


### PR DESCRIPTION
This patchset fixes the issue https://trello.com/c/6LBKIUtN/591-bug-long-filenames-crash-avocado and avoids crash on https://trello.com/c/BdC56G6X/542-bug-avocado-can-t-handle-exceptions-raised-while-reading-the-test-queue and https://trello.com/c/JhfMuJkW/623-bug-regression-no-test-result-for-some-relative-pathnames

Basically it modifies the way `Test.logdir` is created and reuses the `Test.logdir` for other file name related variables.

Last but not least it adds commit to fix missing test status on early failure.

v1: https://github.com/avocado-framework/avocado/pull/1090
v2: https://github.com/avocado-framework/avocado/pull/1098
v3: https://github.com/avocado-framework/avocado/pull/1109

Changes:

    v2: New commit to fix the names with leading '.'
    v3: Different approach to uninitialized test status + selftest
    v3: Increased the filename limit to the max allowed length on ext4
    v4: Correct the test name length limit (255 instead of 256)
    v4: Improve the check for ".data" file (require name match)