### PR TITLE
avocado.core.loader fix crash on loader exception [v4]

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -244,10 +244,13 @@ class TestLoaderProxy(object):
                 sys.path.insert(0, test_module_dir)
                 f, p, d = imp.find_module(module_name, [test_module_dir])
                 test_module = imp.load_module(module_name, f, p, d)
-            except ImportError as details:
-                raise ImportError("Unable to import test's module with "
-                                  "sys.path=%s\n\n%s" % (", ".join(sys.path),
-                                                         details))
+            except:
+                # On load_module exception we fake the test class and pass
+                # the exc_info as parameter to be logged.
+                test_parameters['methodName'] = 'test'
+                exception = stacktrace.prepare_exc_info(sys.exc_info())
+                test_parameters['exception'] = exception
+                return test.TestError(**test_parameters)
             finally:
                 if test_module_dir in sys.path:
                     sys.path.remove(test_module_dir)

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -786,3 +786,17 @@ class ReplaySkipTest(SkipTest):
     """
 
     _skip_reason = "Test skipped due to a job replay filter!"
+
+
+class TestError(Test):
+    """
+    Generic test error.
+    """
+
+    def __init__(self, *args, **kwargs):
+        exception = kwargs.pop('exception')
+        Test.__init__(self, *args, **kwargs)
+        self.exception = exception
+
+    def test(self):
+        self.error(self.exception)

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -62,6 +62,17 @@ class FakeStatusTest(Test):
         pass
 '''
 
+INVALID_PYTHON_TEST = '''
+from avocado import Test
+
+class MyTest(Test):
+
+    non_existing_variable_causing_crash
+
+    def test_my_name(self):
+        pass
+'''
+
 
 class RunnerOperationTest(unittest.TestCase):
 
@@ -362,6 +373,19 @@ class RunnerOperationTest(unittest.TestCase):
         for line in ("/:foo ==> 1", "/:baz ==> 3", "/foo:foo ==> a",
                      "/foo:bar ==> b", "/foo:baz ==> c", "/bar:bar ==> bar"):
             self.assertEqual(log.count(line), 3)
+
+    def test_invalid_python(self):
+        os.chdir(basedir)
+        test = script.make_script(os.path.join(self.tmpdir, 'test.py'),
+                                  INVALID_PYTHON_TEST)
+        cmd_line = './scripts/avocado --show test run --sysinfo=off '\
+                   '--job-results-dir %s %s' % (self.tmpdir, test)
+        result = process.run(cmd_line, ignore_status=True)
+        expected_rc = exit_codes.AVOCADO_TESTS_FAIL
+        self.assertEqual(result.exit_status, expected_rc,
+                         "Avocado did not return rc %d:\n%s" %
+                         (expected_rc, result))
+        self.assertIn('MyTest.test_my_name -> TestError', result.stdout)
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir)


### PR DESCRIPTION
v1: #1107 
 - Fake the test class when the original class cannot be loaded.
 - Capture the load exception and log it.
 - Set `status` = `ERROR` to the test that failed to be loaded.

v2: #1116 
 - User `self.error()` instead of a new exception.
 - Functional test.

v3: #1117 
 - Rename the fake test class from `TestLoaderError` to `TestError`
 - Rename the fake test function from `test` to `unknown`
 - Better 'python bad code' in test.

v4:
 - Restore test name function as `test`.
 - Functional test to assert the original test class/name is in the log.