### PR TITLE
avocado.code.result fix results.json on job interruption

### DIFF
--- a/avocado/core/result.py
+++ b/avocado/core/result.py
@@ -170,7 +170,7 @@ class TestResult(object):
         """
         Called once after all tests are executed.
         """
-        pass
+        self._reconcile()
 
     def start_test(self, state):
         """
@@ -288,7 +288,6 @@ class HumanTestResult(TestResult):
         Called once after all tests are executed.
         """
         super(HumanTestResult, self).end_tests()
-        self._reconcile()
         self.log.info("RESULTS    : PASS %d | ERROR %d | FAIL %d | SKIP %d | "
                       "WARN %d | INTERRUPT %s", len(self.passed),
                       len(self.errors), len(self.failed), len(self.skipped),


### PR DESCRIPTION
Currently UI shows coherent results, reporting tests that where not
executed due to an interruption as SKIP. This information is not in
line with results.json, which does not account un-executed tests.

This patch changes the _reconcile() call from HumanTestResult() class
to its parent class, TestResult(). That way all classes inheriting from
TestResult() will have proper results to report.

Reference: https://trello.com/c/8CXFl13M
Signed-off-by: Amador Pahim <apahim@redhat.com>