### PR TITLE
Filename handling bugfixes

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -174,7 +174,8 @@ class Test(unittest.TestCase):
         Returns the path to the directory that contains test data files
         """
         # Maximal allowed file name length is 255
-        if self.filename is not None and len(self.filename) < 251:
+        if (self.filename is not None and
+                len(os.path.basename(self.filename)) < 251):
             return self.filename + '.data'
         else:
             return None

--- a/selftests/unit/test_test.py
+++ b/selftests/unit/test_test.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import sys
 import tempfile
-from flexmock import flexmock
+from flexmock import flexmock, flexmock_teardown
 
 if sys.version_info[:2] == (2, 6):
     import unittest2 as unittest
@@ -32,6 +32,7 @@ class TestClassTestUnit(unittest.TestCase):
         self.tmpdir = tempfile.mkdtemp(prefix="avocado_" + __name__)
 
     def tearDown(self):
+        flexmock_teardown()
         shutil.rmtree(self.tmpdir)
 
     def testUglyName(self):

--- a/selftests/unit/test_test.py
+++ b/selftests/unit/test_test.py
@@ -67,12 +67,14 @@ class TestClassTestUnit(unittest.TestCase):
         self.assertEqual(os.path.basename(test.workdir),
                          os.path.basename(test.logdir))
         flexmock(test)
-        test.should_receive('filename').and_return("a"*250)
-        self.assertEqual("a"*250 + ".data", test.datadir)
-        self.assertRaises(IOError, test._record_reference_stdout)
-        self.assertRaises(IOError, test._record_reference_stderr)
+        test.should_receive('filename').and_return(os.path.join(self.tmpdir,
+                                                                "a"*250))
+        self.assertEqual(os.path.join(self.tmpdir, "a"*250 + ".data"),
+                         test.datadir)
         test.should_receive('filename').and_return("a"*251)
         self.assertFalse(test.datadir)
+        test._record_reference_stdout       # Should does nothing
+        test._record_reference_stderr       # Should does nothing
         test._record_reference_stdout()
         test._record_reference_stderr()
 


### PR DESCRIPTION
Hello guys, I'm sorry I forgot to cleanup the flexmock in one of the selftests and there was also a hidden bug in the filename length check.

@clebergnu thanks for the report.