### PR TITLE
Job pre and post plugins [v2]

### DIFF
--- a/avocado.spec
+++ b/avocado.spec
@@ -7,7 +7,7 @@
 Summary: Avocado Test Framework
 Name: avocado
 Version: 0.34.0
-Release: 0%{?dist}
+Release: 1%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.github.io/
@@ -61,12 +61,15 @@ selftests/run
 %dir /etc/avocado
 %dir /etc/avocado/conf.d
 %dir /etc/avocado/sysinfo
+%dir /etc/avocado/scripts/job/pre.d
+%dir /etc/avocado/scripts/job/post.d
 %config(noreplace)/etc/avocado/avocado.conf
 %config(noreplace)/etc/avocado/conf.d/README
 %config(noreplace)/etc/avocado/conf.d/gdb.conf
 %config(noreplace)/etc/avocado/sysinfo/commands
 %config(noreplace)/etc/avocado/sysinfo/files
-%config(noreplace)/etc/avocado/sysinfo/profilers
+%config(noreplace)/etc/avocado/scripts/job/pre.d/README
+%config(noreplace)/etc/avocado/scripts/job/post.d/README
 %{python_sitelib}/avocado*
 %{_bindir}/avocado
 %{_bindir}/avocado-rest-client
@@ -110,6 +113,9 @@ examples of how to write tests on your own.
 %{_datadir}/avocado/wrappers
 
 %changelog
+* Thu Apr 14 2016 Cleber Rosa <cleber@redhat.com> - 0.34.0-1
+- Added job pre/post scripts directories
+
 * Mon Mar 21 2016 Cleber Rosa <cleber@redhat.com> - 0.34.0-0
 - New upstream release 0.34.0
 

--- a/avocado/core/dispatcher.py
+++ b/avocado/core/dispatcher.py
@@ -59,3 +59,16 @@ class CLICmdDispatcher(Dispatcher):
 
     def __init__(self):
         super(CLICmdDispatcher, self).__init__('avocado.plugins.cli.cmd')
+
+
+class JobPrePostDispatcher(Dispatcher):
+
+    """
+    Calls extensions before Job execution
+
+    Automatically adds all the extension with entry points registered under
+    'avocado.plugins.job.prepost'
+    """
+
+    def __init__(self):
+        super(JobPrePostDispatcher, self).__init__('avocado.plugins.job.prepost')

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -30,6 +30,7 @@ import fnmatch
 
 from . import version
 from . import data_dir
+from . import dispatcher
 from . import runner
 from . import loader
 from . import sysinfo
@@ -123,6 +124,8 @@ class Job(object):
                                                            _TEST_LOGGER)
         self.stdout_stderr = None
         self.replay_sourcejob = getattr(self.args, 'replay_sourcejob', None)
+        self.job_pre_post_dispatcher = dispatcher.JobPrePostDispatcher()
+        output.log_plugin_failures(self.job_pre_post_dispatcher.load_failures)
 
     def _setup_job_results(self):
         logdir = getattr(self.args, 'logdir', None)
@@ -539,6 +542,9 @@ class Job(object):
                  :mod:`avocado.core.exit_codes` for more information.
         """
         runtime.CURRENT_JOB = self
+        for ext in self.job_pre_post_dispatcher.extensions:
+            if hasattr(ext.obj, 'pre'):
+                ext.obj.pre(self)
         try:
             return self._run()
         except exceptions.JobBaseException as details:
@@ -564,6 +570,9 @@ class Job(object):
             self.log.error('Report bugs visiting %s', _NEW_ISSUE_LINK)
             return exit_codes.AVOCADO_FAIL
         finally:
+            for ext in self.job_pre_post_dispatcher.extensions:
+                if hasattr(ext.obj, 'post'):
+                    ext.obj.post(self)
             if not settings.get_value('runner.behavior', 'keep_tmp_files',
                                       key_type=bool, default=False):
                 data_dir.clean_tmp_files()

--- a/avocado/plugins/base.py
+++ b/avocado/plugins/base.py
@@ -84,3 +84,35 @@ class CLICmd(Plugin):
         """
         Entry point for actually running the command
         """
+
+
+class JobPre(Plugin):
+
+    """
+    Base plugin interface for adding actions before a job runs
+
+    Plugins that want to add actions to be run before a job runs,
+    should use the 'avocado.plugins.job.pre' namespace.
+    """
+
+    @abc.abstractmethod
+    def pre(self, job):
+        """
+        Entry point for actually running the pre job action
+        """
+
+
+class JobPost(Plugin):
+
+    """
+    Base plugin interface for adding actions after a job runs
+
+    Plugins that want to add actions to be run after a job runs,
+    should use the 'avocado.plugins.job.post' namespace.
+    """
+
+    @abc.abstractmethod
+    def post(self, job):
+        """
+        Entry point for actually running the post job action
+        """

--- a/avocado/plugins/jobscripts.py
+++ b/avocado/plugins/jobscripts.py
@@ -1,0 +1,56 @@
+import os
+import logging
+
+from avocado.utils import process
+from avocado.core.settings import settings
+from avocado.plugins.base import JobPre, JobPost
+
+
+CONFIG_SECTION = 'avocado.plugins.jobscripts'
+
+
+class JobScripts(JobPre, JobPost):
+
+    name = 'jobscripts'
+    description = 'Runs scripts before/after the job is run'
+
+    def __init__(self):
+        self.log = logging.getLogger("avocado.app")
+        self.warn_non_existing_dir = settings.get_value(section=CONFIG_SECTION,
+                                                        key="warn_non_existing_dir",
+                                                        key_type=bool,
+                                                        default=False)
+        self.warn_non_zero_status = settings.get_value(section=CONFIG_SECTION,
+                                                       key="warn_non_zero_status",
+                                                       key_type=bool,
+                                                       default=False)
+
+    def run_scripts(self, kind, scripts_dir):
+        if not os.path.isdir(scripts_dir):
+            if self.warn_non_existing_dir:
+                self.log.error("Directory configured to hold %s-job scripts "
+                               "has not been found: %s", kind, scripts_dir)
+            return
+
+        dir_list = os.listdir(scripts_dir)
+        scripts = [os.path.join(scripts_dir, f) for f in dir_list]
+        scripts = [f for f in scripts
+                   if os.access(f, os.R_OK | os.X_OK)]
+        scripts.sort()
+        for script in scripts:
+            result = process.run(script, ignore_status=True)
+            if (result.exit_status != 0) and self.warn_non_zero_status:
+                self.log.error('Script "%s" exited with status "%i"',
+                               script, result.exit_status)
+
+    def pre(self, job):
+        d = settings.get_value(section=CONFIG_SECTION,
+                               key="pre", key_type=str,
+                               default="/etc/avocado/scripts/job/pre.d/")
+        self.run_scripts('pre', d)
+
+    def post(self, job):
+        d = settings.get_value(section=CONFIG_SECTION,
+                               key="post", key_type=str,
+                               default="/etc/avocado/scripts/job/post.d/")
+        self.run_scripts('post', d)

--- a/avocado/plugins/plugins.py
+++ b/avocado/plugins/plugins.py
@@ -45,7 +45,9 @@ class Plugins(CLICmd):
             (dispatcher.CLICmdDispatcher(),
              'Plugins that add new commands (avocado.plugins.cli.cmd):'),
             (dispatcher.CLIDispatcher(),
-             'Plugins that add new options to commands (avocado.plugins.cli):')
+             'Plugins that add new options to commands (avocado.plugins.cli):'),
+            (dispatcher.JobPrePostDispatcher(),
+             'Plugins that run before/after the execution of jobs (avocado.plugins.job.prepost):')
         ]
         for plugins_active, msg in plugin_types:
             log.info(msg)

--- a/docs/source/Plugins.rst
+++ b/docs/source/Plugins.rst
@@ -88,6 +88,8 @@ We have briefly discussed the making of Avocado plugins. We recommend
 the `Stevedore documentation`_ and also a look at the
 :mod:`avocado.plugins.base` module for the various plugin interface definitions.
 
+Some plugins examples are available in the `Avocado source tree_`, under ``examples/plugins``.
+
 Finally, exploring the real plugins shipped with Avocado in :mod:`avocado.plugins`
 is the final "documentation" source.
 
@@ -96,3 +98,4 @@ is the final "documentation" source.
 .. _Stevedore documentation: http://docs.openstack.org/developer/stevedore/index.html
 .. _setuptools: https://pythonhosted.org/setuptools/
 .. _entry points: https://pythonhosted.org/setuptools/pkg_resources.html#entry-points
+.. _Avocado source tree: https://github.com/avocado-framework/avocado/tree/master/examples/plugins

--- a/etc/avocado/conf.d/jobscripts.conf
+++ b/etc/avocado/conf.d/jobscripts.conf
@@ -1,0 +1,9 @@
+[avocado.plugins.jobscripts]
+# Directory with scripts to be executed before a job is run
+pre = /etc/avocado/scripts/job/pre.d/
+# Directory with scripts to be executed after a job is run
+post = /etc/avocado/scripts/job/post.d/
+# Warn if configured (or default) directory does not exist
+warn_non_existing_dir = False
+# Warn if any script run return non-zero status
+warn_non_zero_status = False

--- a/etc/avocado/scripts/job/post.d/README
+++ b/etc/avocado/scripts/job/post.d/README
@@ -1,0 +1,4 @@
+Put your post-job scripts here. They need to be readable and executable by
+the Avocado user running the jobs. The order of execution is based on their
+file names. If order is important, use a prefix, such as 001-myscript,
+002-otherscript, etc.

--- a/etc/avocado/scripts/job/pre.d/README
+++ b/etc/avocado/scripts/job/pre.d/README
@@ -1,0 +1,4 @@
+Put your pre-job scripts here. They need to be readable and executable by
+the Avocado user running the jobs. The order of execution is based on their
+file names. If order is important, use a prefix, such as 001-myscript,
+002-otherscript, etc.

--- a/examples/plugins/README.rst
+++ b/examples/plugins/README.rst
@@ -1,0 +1,16 @@
+=================
+ Plugin Examples
+=================
+
+Here you can find a collection of example code for the various Avocado
+Plugin interfaces.
+
+To try them out on a development environment, you may run::
+
+ $ cd <plugin-type>/<plugin-example>
+ $ python setup.py develop --user
+
+And to remove them on a development environment, you may run, at the
+same directory::
+
+ $ python setup.py develop --uninstall --user

--- a/examples/plugins/job-pre-post/mail/avocado_job_mail.py
+++ b/examples/plugins/job-pre-post/mail/avocado_job_mail.py
@@ -1,0 +1,52 @@
+import logging
+import smtplib
+from email.mime.text import MIMEText
+
+from avocado.core.settings import settings
+from avocado.plugins.base import JobPre, JobPost
+
+
+class Mail(JobPre, JobPost):
+
+    name = 'mail'
+    description = 'Sends mail to notify on job start/end'
+
+    def __init__(self):
+        self.log = logging.getLogger("avocado.app")
+        self.rcpt = settings.get_value(section="plugins.job.mail",
+                                       key="recipient",
+                                       key_type=str,
+                                       default='root@localhost.localdomain')
+        self.subject = settings.get_value(section="plugins.job.mail",
+                                          key="subject",
+                                          key_type=str,
+                                          default='[AVOCADO JOB NOTIFICATION]')
+        self.sender = settings.get_value(section="plugins.job.mail",
+                                         key="sender",
+                                         key_type=str,
+                                         default='avocado@localhost.localdomain')
+        self.server = settings.get_value(section="plugins.job.mail",
+                                         key="server",
+                                         key_type=str,
+                                         default='localhost')
+
+    def mail(self, job):
+        # build proper subject based on job status
+        subject = '%s Job %s - Status: %s' % (self.subject,
+                                              job.unique_id,
+                                              job.status)
+        msg = MIMEText(subject)
+        msg['Subject'] = self.subject
+        msg['From'] = self.sender
+        msg['To'] = self.rcpt
+
+        # So many possible failures, let's just tell the user about it
+        try:
+            smtp = smtplib.SMTP(self.server)
+            smtp.sendmail(self.sender, [self.rcpt], msg.as_string())
+            smtp.quit()
+        except:
+            self.log.error("Failure to send email notification: "
+                           "please check your mail configuration")
+
+    pre = post = mail

--- a/examples/plugins/job-pre-post/mail/setup.py
+++ b/examples/plugins/job-pre-post/mail/setup.py
@@ -1,0 +1,15 @@
+from setuptools import setup
+
+name = 'avocado_job_mail'
+klass = 'Mail'
+entry_point = '%s = %s:%s' % (name, name, klass)
+
+if __name__ == '__main__':
+    setup(name=name,
+          version='1.0',
+          description='Avocado Pre/Post Job Mail Notification',
+          py_modules=[name],
+          entry_points={
+              'avocado.plugins.job.prepost': [entry_point]
+              }
+          )

--- a/examples/plugins/job-pre-post/sleep/avocado_job_sleep.py
+++ b/examples/plugins/job-pre-post/sleep/avocado_job_sleep.py
@@ -1,0 +1,25 @@
+import time
+import logging
+
+from avocado.core.settings import settings
+from avocado.plugins.base import JobPre, JobPost
+
+
+class Sleep(JobPre, JobPost):
+
+    name = 'sleep'
+    description = 'Sleeps for a number of seconds'
+
+    def __init__(self):
+        self.log = logging.getLogger("avocado.app")
+        self.seconds = settings.get_value(section="plugins.job.sleep",
+                                          key="seconds",
+                                          key_type=int,
+                                          default=3)
+
+    def sleep(self, job):
+        for i in xrange(1, self.seconds + 1):
+            self.log.info("Sleeping %2i/%s", i, self.seconds)
+            time.sleep(1)
+
+    pre = post = sleep

--- a/examples/plugins/job-pre-post/sleep/setup.py
+++ b/examples/plugins/job-pre-post/sleep/setup.py
@@ -1,0 +1,15 @@
+from setuptools import setup
+
+name = 'avocado_job_sleep'
+klass = 'Sleep'
+entry_point = '%s = %s:%s' % (name, name, klass)
+
+if __name__ == '__main__':
+    setup(name=name,
+          version='1.0',
+          description='Avocado Pre/Post Job Sleep',
+          py_modules=[name],
+          entry_points={
+              'avocado.plugins.job.prepost': [entry_point],
+              }
+          )

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,10 @@ def get_data_files():
     data_files += [(get_dir(['etc', 'avocado', 'sysinfo']),
                     ['etc/avocado/sysinfo/commands', 'etc/avocado/sysinfo/files',
                      'etc/avocado/sysinfo/profilers'])]
+    data_files += [(get_dir(['etc', 'avocado', 'scripts', 'job', 'pre.d']),
+                    ['etc/avocado/scripts/job/pre.d/README'])]
+    data_files += [(get_dir(['etc', 'avocado', 'scripts', 'job', 'post.d']),
+                    ['etc/avocado/scripts/job/post.d/README'])]
     data_files += [(get_tests_dir(), glob.glob('examples/tests/*.py'))]
     for data_dir in glob.glob('examples/tests/*.data'):
         fmt_str = '%s/*' % data_dir
@@ -146,7 +150,10 @@ if __name__ == '__main__':
                   'run = avocado.plugins.run:Run',
                   'sysinfo = avocado.plugins.sysinfo:SysInfo',
                   'plugins = avocado.plugins.plugins:Plugins',
-                  ]
+                  ],
+              'avocado.plugins.job.prepost': [
+                  'jobscripts = avocado.plugins.jobscripts:JobScripts',
+                  ],
               },
           zip_safe=False,
           test_suite='selftests')


### PR DESCRIPTION
This introduces a new Plugin interface, and allows plugin writers to execute custom actions before and after the jobs are run.

The plugin interface gives the avocado.core.job.Job instance to plugin writers, who can collect information from it.

Also, two examples are given, including a "real world" mail notification plugin.

--

Changes from v1 (#1106):
 * Broke down the interface specification into JobPre and JobPost
 * Added "jobscripts" plugin, that allows user's scripts to be run before and after the job