### PR TITLE
 [Do Not Merge] Create the option to reject unknown hosts 

### DIFF
--- a/avocado/core/remoter.py
+++ b/avocado/core/remoter.py
@@ -20,6 +20,7 @@ import getpass
 import logging
 import time
 
+from .settings import settings
 from ..utils import process
 
 LOG = logging.getLogger('avocado.test')
@@ -62,13 +63,20 @@ class Remote(object):
         self.password = password
         self.port = port
         self.quiet = quiet
+        reject_unknown_hosts = settings.get_value('runner.behavior',
+                                                  'reject_unknown_hosts',
+                                                  key_type=bool,
+                                                  default=True)
         self._setup_environment(host_string=hostname,
                                 user=username,
                                 password=password,
                                 port=port,
                                 timeout=timeout / attempts,
                                 connection_attempts=attempts,
-                                linewise=True)
+                                linewise=True,
+                                reject_unknown_hosts=reject_unknown_hosts,
+                                abort_on_prompts=True,
+                                abort_exception=UnknownHostException)
 
     @staticmethod
     def _setup_environment(**kwargs):
@@ -173,3 +181,12 @@ class Remote(object):
         except ValueError:
             return False
         return True
+
+
+class UnknownHostException(Exception):
+
+    def __init__(self, msg):
+        self.fabric_msg = msg
+
+    def __str__(self):
+        return "The authenticity of remote can't be established."

--- a/etc/avocado/avocado.conf
+++ b/etc/avocado/avocado.conf
@@ -37,6 +37,9 @@ utf8 =
 [runner.behavior]
 # Keep job temporary files after jobs (useful for avocado debugging)
 keep_tmp_files = False
+# Remote runner to reject unknown SSH host keys
+# warning: 'False' will leave you wide open to man-in-the-middle attacks!
+reject_unknown_hosts = True
 
 [job.output]
 # Base log level for --show-job-log.


### PR DESCRIPTION
When Avocado runs tests on remote machines, based on SSH, it always
accepts the host SSH key. This could allow credentials to be stolen
if the remote host name or address is spoofed.

This patch adds to Avocado the configuration option to enable/disable
the `reject_unknown_hosts` option, so user can choose between safe or
flexible.

  **WARNING**
  There is an issue with Paramiko that makes the fabric `reject_unknown_hosts`
  option to fail: https://github.com/fabric/fabric/issues/85

  This PR aims to prepare Avocado so we can merge it when Paramiko/Fabric get
  fixed.