### PR TITLE
avocado.core.remoter remote actions should fail on prompt

### DIFF
--- a/avocado/core/remoter.py
+++ b/avocado/core/remoter.py
@@ -68,7 +68,9 @@ class Remote(object):
                                 port=port,
                                 timeout=timeout / attempts,
                                 connection_attempts=attempts,
-                                linewise=True)
+                                linewise=True,
+                                abort_on_prompts=True,
+                                abort_exception=FabricException)
 
     @staticmethod
     def _setup_environment(**kwargs):
@@ -173,3 +175,12 @@ class Remote(object):
         except ValueError:
             return False
         return True
+
+
+class FabricException(Exception):
+
+    def __init__(self, msg):
+        self.fabric_msg = msg
+
+    def __str__(self):
+        return self.fabric_msg


### PR DESCRIPTION
Avocado is not interactive. Remote can prompt for interaction for
a number of reasons: unknown host key, password request and so on.

This patch makes Avocado to fail when interaction for remote access is
needed, forwarding the correspondent Fabric's message for the user.

Reference: https://trello.com/c/GEa8BY2j
Reference: https://trello.com/c/oqyAvZBq
Signed-off-by: Amador Pahim <apahim@redhat.com>