### PR TITLE
avocado.spec: add python-lxml to build dependencies

### DIFF
--- a/avocado.spec
+++ b/avocado.spec
@@ -14,7 +14,7 @@ URL: http://avocado-framework.github.io/
 Source0: https://github.com/avocado-framework/%{name}/archive/%{commit}/%{name}-%{version}-%{shortcommit}.tar.gz
 BuildArch: noarch
 Requires: python, python-requests, fabric, pyliblzma, libvirt-python, pystache, gdb, gdb-gdbserver, python-stevedore
-BuildRequires: python2-devel, python-setuptools, python-docutils, python-mock, python-psutil, python-sphinx, python-requests, aexpect, pystache, yum, python-stevedore
+BuildRequires: python2-devel, python-setuptools, python-docutils, python-mock, python-psutil, python-sphinx, python-requests, aexpect, pystache, yum, python-stevedore, python-lxml
 
 %if 0%{?el6}
 Requires: PyYAML


### PR DESCRIPTION
Commit 8dad284 introduced a requirement on python-lxml. Let's reflect
that on the SPEC file.

Signed-off-by: Cleber Rosa <crosa@redhat.com>