### PR TITLE
avocado/core/settings.py: do not ignore user local configuration

### DIFF
--- a/avocado/core/settings.py
+++ b/avocado/core/settings.py
@@ -182,11 +182,12 @@ class Settings(object):
                     if config_system_extra:
                         for extra_file in glob.glob(os.path.join(_config_dir_system_extra, '*.conf')):
                             self.process_config_path(extra_file)
-                if not config_local:
-                    path.init_dir(_config_dir_local)
-                    with open(config_path_local, 'w') as config_local_fileobj:
-                        config_local_fileobj.write('# You can use this file to override configuration values from '
-                                                   '%s and %s\n' % (config_path_system, _config_dir_system_extra))
+            if not config_local:
+                path.init_dir(_config_dir_local)
+                with open(config_path_local, 'w') as config_local_fileobj:
+                    config_local_fileobj.write('# You can use this file to override configuration values from '
+                                               '%s and %s\n' % (config_path_system, _config_dir_system_extra))
+            else:
                 self.process_config_path(config_path_local)
         else:
             # Unittests


### PR DESCRIPTION
When avocado is run out of the source tree, it ignores the user local
configuration (~/.config/avocado/avocado.conf).  IMHO this is both
inconsistent and bad for development sessions.

Signed-off-by: Cleber Rosa <crosa@redhat.com>