### PR TITLE
avocado.core.remoter remote actions should fail on prompt [v3]

### DIFF
--- a/avocado/core/remoter.py
+++ b/avocado/core/remoter.py
@@ -36,6 +36,14 @@ else:
     REMOTE_CAPABLE = True
 
 
+class RemoterError(Exception):
+    pass
+
+
+class ConnectionError(RemoterError):
+    pass
+
+
 class Remote(object):
 
     """
@@ -68,7 +76,9 @@ class Remote(object):
                                 port=port,
                                 timeout=timeout / attempts,
                                 connection_attempts=attempts,
-                                linewise=True)
+                                linewise=True,
+                                abort_on_prompts=True,
+                                abort_exception=ConnectionError)
 
     @staticmethod
     def _setup_environment(**kwargs):


### PR DESCRIPTION
v1: #1128 

Avocado is not interactive. Remote can prompt for interaction for
a number of reasons: unknown host key, password request and so on.
This patch makes Avocado to fail when interaction for remote access is
needed, forwarding the correspondent Fabric's message for the user.

v2:
 - Exception class in the beginning of the module.
 - Keep just the `pass` in the exception class.

v3:
 - Rename exception class.