### PR TITLE
avocado.core.remoter option to reject remote unknown hosts [v2]

### DIFF
--- a/avocado/core/remoter.py
+++ b/avocado/core/remoter.py
@@ -20,6 +20,7 @@ import getpass
 import logging
 import time
 
+from .settings import settings
 from ..utils import process
 
 LOG = logging.getLogger('avocado.test')
@@ -70,6 +71,10 @@ class Remote(object):
         self.password = password
         self.port = port
         self.quiet = quiet
+        reject_unknown_hosts = settings.get_value('remoter.behavior',
+                                                  'reject_unknown_hosts',
+                                                  key_type=bool,
+                                                  default=False)
         self._setup_environment(host_string=hostname,
                                 user=username,
                                 password=password,
@@ -78,7 +83,8 @@ class Remote(object):
                                 connection_attempts=attempts,
                                 linewise=True,
                                 abort_on_prompts=True,
-                                abort_exception=ConnectionError)
+                                abort_exception=ConnectionError,
+                                reject_unknown_hosts=reject_unknown_hosts)
 
     @staticmethod
     def _setup_environment(**kwargs):

--- a/etc/avocado/avocado.conf
+++ b/etc/avocado/avocado.conf
@@ -38,6 +38,14 @@ utf8 =
 # Keep job temporary files after jobs (useful for avocado debugging)
 keep_tmp_files = False
 
+[remoter.behavior]
+# Reject unknown SSH host keys.
+# 'False' will leave you wide open to man-in-the-middle attacks!
+# 'True' will only work with RSA keys (due to a bug in Paramiko).
+# If using 'True', accept the remote host key fingerprint by using:
+#   $ ssh -oHostKeyAlgorithms='ssh-rsa' <host>
+reject_unknown_hosts = False
+
 [job.output]
 # Base log level for --show-job-log.
 # Allowed levels: debug, info, warning, error, critical


### PR DESCRIPTION
v1: #1127 
 - Create `reject_unknown_host` option.

v2: 
 - Defaults to `False` due to the Paramiko issue with `ecdsa` host key fingerprint.
 - Proper config section.