### PR TITLE
avocado: Rename the `args.default_multiplex_tree`

### DIFF
--- a/avocado/core/multiplexer.py
+++ b/avocado/core/multiplexer.py
@@ -389,8 +389,8 @@ class Mux(object):
             mux_tree = yaml2tree(mux_files, filter_only, filter_out)
         else:   # no variants
             mux_tree = tree.TreeNode()
-        if getattr(args, 'default_multiplex_tree', None):
-            mux_tree.merge(args.default_multiplex_tree)
+        if getattr(args, 'default_avocado_params', None):
+            mux_tree.merge(args.default_avocado_params)
         self.variants = MuxTree(mux_tree)
         self._mux_path = getattr(args, 'mux_path', None)
         if self._mux_path is None:

--- a/avocado/core/parser.py
+++ b/avocado/core/parser.py
@@ -105,9 +105,8 @@ class Parser(object):
             help='subcommand help',
             dest='subcommand')
 
-        if tree.MULTIPLEX_CAPABLE:
-            # Allow overriding multiplex variants by plugins args
-            self.args.default_multiplex_tree = tree.TreeNode()
+        # Allow overriding default params by plugins
+        self.args.default_avocado_params = tree.TreeNode()
 
     def finish(self):
         """

--- a/avocado/plugins/multiplex.py
+++ b/avocado/plugins/multiplex.py
@@ -101,7 +101,7 @@ class Multiplex(CLICmd):
             log.error(details.strerror)
             sys.exit(exit_codes.AVOCADO_JOB_FAIL)
         if args.system_wide:
-            mux_tree.merge(args.default_multiplex_tree)
+            mux_tree.merge(args.default_avocado_params)
         mux_tree.merge(self._from_args_tree)
         if args.tree:
             if args.contents:

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -154,9 +154,9 @@ class Run(CLICmd):
                 raise ValueError("key:value pairs required, found only %s"
                                  % (value))
             elif len(value) == 2:
-                args.default_multiplex_tree.value[value[0]] = value[1]
+                args.default_avocado_params.value[value[0]] = value[1]
             else:
-                node = args.default_multiplex_tree.get_node(value[0], True)
+                node = args.default_avocado_params.get_node(value[0], True)
                 node.value[value[1]] = value[2]
 
     def _validate_job_timeout(self, raw_timeout):


### PR DESCRIPTION
The `args.default_multiplex_tree` stands for default avocado params,
which currently supports only `multiplexer` implementation. This might
change in the future, but this variable could be used by other backends
too. So let's rename it now to `default_avocado_params`.

Additionally it's only set when the system is multiplexer-enabled, but
it has nothing to do with the multiplexer (directly). Multiplexer is
only one of the sources of params. So let's initialize it always. This
avoids a bug in `avocado-virt`, which uses this default params to set
it's params and it does that via this generic API (not dependent on the
multiplexer at all).

__This has to be merged together with https://github.com/avocado-framework/avocado-virt/pull/78 PR__