### PR TITLE
Job pre and post plugins [v4]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ script:
             echo
             git checkout $COMMIT || ERR=$(echo -e "$ERR\nUnable to checkout $(git log -1 --oneline $COMMIT)")
             make check || ERR=$(echo -e "$ERR\nmake check of $(git log -1 --oneline) failed")
+            make clean
         done
         if [ "$ERR" ]; then
             echo

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ all:
 	@echo
 	@echo "Development related targets:"
 	@echo "check:      Runs tree static check, unittests and functional tests"
+	@echo "develop:    Runs 'python setup.py --develop on this tree alone"
 	@echo "link:       Runs 'python setup.py --develop' in all subprojects and links the needed resources"
 	@echo "clean:      Get rid of scratch, byte files and removes the links to other subprojects"
 	@echo "selfcheck:  Runs tree static check, unittests and functional tests using Avocado itself"
@@ -114,6 +115,7 @@ clean:
 		do AVOCADO_DIRNAME=$(AVOCADO_DIRNAME) make -C $$MAKEFILE unlink &>/dev/null && echo ">> UNLINK $$MAKEFILE" || echo ">> SKIP $$MAKEFILE";\
 	done
 	$(PYTHON) setup.py develop --uninstall $(shell $(PYTHON26) || echo --user)
+	rm -rf avocado.egg-info
 	rm -rf /var/tmp/avocado*
 	rm -rf /tmp/avocado*
 	find . -name '*.pyc' -delete
@@ -128,7 +130,7 @@ requirements-selftests: requirements
 smokecheck:
 	./scripts/avocado run passtest
 
-check: clean check_cyclical modules_boundaries
+check: clean develop check_cyclical modules_boundaries
 	selftests/checkall
 	selftests/check_tmp_dirs
 
@@ -142,8 +144,10 @@ check_cyclical:
 modules_boundaries:
 	selftests/modules_boundaries
 
-link:
+develop:
 	$(PYTHON) setup.py develop $(shell $(PYTHON26) || echo --user)
+
+link: develop
 	for MAKEFILE in $(AVOCADO_PLUGINS);\
 		do AVOCADO_DIRNAME=$(AVOCADO_DIRNAME) make -C $$MAKEFILE link &>/dev/null && echo ">> LINK $$MAKEFILE" || echo ">> SKIP $$MAKEFILE";\
 	done

--- a/avocado.spec
+++ b/avocado.spec
@@ -7,7 +7,7 @@
 Summary: Avocado Test Framework
 Name: avocado
 Version: 0.34.0
-Release: 0%{?dist}
+Release: 1%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.github.io/
@@ -61,12 +61,16 @@ selftests/run
 %dir /etc/avocado
 %dir /etc/avocado/conf.d
 %dir /etc/avocado/sysinfo
+%dir /etc/avocado/scripts/job/pre.d
+%dir /etc/avocado/scripts/job/post.d
 %config(noreplace)/etc/avocado/avocado.conf
 %config(noreplace)/etc/avocado/conf.d/README
 %config(noreplace)/etc/avocado/conf.d/gdb.conf
 %config(noreplace)/etc/avocado/sysinfo/commands
 %config(noreplace)/etc/avocado/sysinfo/files
 %config(noreplace)/etc/avocado/sysinfo/profilers
+%config(noreplace)/etc/avocado/scripts/job/pre.d/README
+%config(noreplace)/etc/avocado/scripts/job/post.d/README
 %{python_sitelib}/avocado*
 %{_bindir}/avocado
 %{_bindir}/avocado-rest-client
@@ -110,6 +114,9 @@ examples of how to write tests on your own.
 %{_datadir}/avocado/wrappers
 
 %changelog
+* Thu Apr 14 2016 Cleber Rosa <cleber@redhat.com> - 0.34.0-1
+- Added job pre/post scripts directories
+
 * Mon Mar 21 2016 Cleber Rosa <cleber@redhat.com> - 0.34.0-0
 - New upstream release 0.34.0
 

--- a/avocado/core/dispatcher.py
+++ b/avocado/core/dispatcher.py
@@ -59,3 +59,26 @@ class CLICmdDispatcher(Dispatcher):
 
     def __init__(self):
         super(CLICmdDispatcher, self).__init__('avocado.plugins.cli.cmd')
+
+
+class JobPrePostDispatcher(Dispatcher):
+
+    """
+    Calls extensions before Job execution
+
+    Automatically adds all the extension with entry points registered under
+    'avocado.plugins.job.prepost'
+    """
+
+    def __init__(self):
+        super(JobPrePostDispatcher, self).__init__('avocado.plugins.job.prepost')
+
+    def map_methods(self, method_name, job):
+        for ext in self.extensions:
+            try:
+                if hasattr(ext.obj, method_name):
+                    method = getattr(ext.obj, method_name)
+                    method(job)
+            except Exception as e:
+                job.log.error('Error running method "%s" of plugin "%s": %s',
+                              method_name, ext.name, e)

--- a/avocado/plugins/base.py
+++ b/avocado/plugins/base.py
@@ -84,3 +84,37 @@ class CLICmd(Plugin):
         """
         Entry point for actually running the command
         """
+
+
+class JobPre(Plugin):
+
+    """
+    Base plugin interface for adding actions before a job runs
+
+    Plugins that want to add actions to be run before a job runs,
+    should use the 'avocado.plugins.job.prepost' namespace and
+    implement the defined interface.
+    """
+
+    @abc.abstractmethod
+    def pre(self, job):
+        """
+        Entry point for actually running the pre job action
+        """
+
+
+class JobPost(Plugin):
+
+    """
+    Base plugin interface for adding actions after a job runs
+
+    Plugins that want to add actions to be run after a job runs,
+    should use the 'avocado.plugins.job.prepost' namespace and
+    implement the defined interface.
+    """
+
+    @abc.abstractmethod
+    def post(self, job):
+        """
+        Entry point for actually running the post job action
+        """

--- a/avocado/plugins/jobscripts.py
+++ b/avocado/plugins/jobscripts.py
@@ -1,0 +1,69 @@
+import os
+import logging
+
+from avocado.utils import process
+from avocado.core.settings import settings
+from avocado.plugins.base import JobPre, JobPost
+
+
+CONFIG_SECTION = 'avocado.plugins.jobscripts'
+
+
+class JobScripts(JobPre, JobPost):
+
+    name = 'jobscripts'
+    description = 'Runs scripts before/after the job is run'
+
+    def __init__(self):
+        self.log = logging.getLogger("avocado.app")
+        self.warn_non_existing_dir = settings.get_value(section=CONFIG_SECTION,
+                                                        key="warn_non_existing_dir",
+                                                        key_type=bool,
+                                                        default=False)
+        self.warn_non_zero_status = settings.get_value(section=CONFIG_SECTION,
+                                                       key="warn_non_zero_status",
+                                                       key_type=bool,
+                                                       default=False)
+
+    def _run_scripts(self, kind, scripts_dir, job):
+        if not os.path.isdir(scripts_dir):
+            if self.warn_non_existing_dir:
+                self.log.error("Directory configured to hold %s-job scripts "
+                               "has not been found: %s", kind, scripts_dir)
+            return
+
+        dir_list = os.listdir(scripts_dir)
+        scripts = [os.path.join(scripts_dir, f) for f in dir_list]
+        scripts = [f for f in scripts
+                   if os.access(f, os.R_OK | os.X_OK)]
+        scripts.sort()
+        if not scripts:
+            return
+
+        env = self._job_to_environment_variables(job)
+        for script in scripts:
+            result = process.run(script, ignore_status=True, env=env)
+            if (result.exit_status != 0) and self.warn_non_zero_status:
+                self.log.error('Script "%s" exited with status "%i"',
+                               script, result.exit_status)
+
+    @staticmethod
+    def _job_to_environment_variables(job):
+        env = {}
+        env['AVOCADO_JOB_UNIQUE_ID'] = job.unique_id
+        env['AVOCADO_JOB_STATUS'] = job.status
+        if job.logdir is not None:
+            env['AVOCADO_JOB_LOGDIR'] = job.logdir
+        return env
+
+    def pre(self, job):
+        path = settings.get_value(section=CONFIG_SECTION,
+                                  key="pre", key_type=str,
+                                  default="/etc/avocado/scripts/job/pre.d/")
+        self._run_scripts('pre', path, job)
+
+    def post(self, job):
+        path = settings.get_value(section=CONFIG_SECTION,
+                                  key="post", key_type=str,
+                                  default="/etc/avocado/scripts/job/post.d/")
+        self._run_scripts('post', path, job)

--- a/avocado/plugins/plugins.py
+++ b/avocado/plugins/plugins.py
@@ -45,7 +45,9 @@ class Plugins(CLICmd):
             (dispatcher.CLICmdDispatcher(),
              'Plugins that add new commands (avocado.plugins.cli.cmd):'),
             (dispatcher.CLIDispatcher(),
-             'Plugins that add new options to commands (avocado.plugins.cli):')
+             'Plugins that add new options to commands (avocado.plugins.cli):'),
+            (dispatcher.JobPrePostDispatcher(),
+             'Plugins that run before/after the execution of jobs (avocado.plugins.job.prepost):')
         ]
         for plugins_active, msg in plugin_types:
             log.info(msg)

--- a/docs/source/Plugins.rst
+++ b/docs/source/Plugins.rst
@@ -88,6 +88,8 @@ We have briefly discussed the making of Avocado plugins. We recommend
 the `Stevedore documentation`_ and also a look at the
 :mod:`avocado.plugins.base` module for the various plugin interface definitions.
 
+Some plugins examples are available in the `Avocado source tree_`, under ``examples/plugins``.
+
 Finally, exploring the real plugins shipped with Avocado in :mod:`avocado.plugins`
 is the final "documentation" source.
 
@@ -96,3 +98,4 @@ is the final "documentation" source.
 .. _Stevedore documentation: http://docs.openstack.org/developer/stevedore/index.html
 .. _setuptools: https://pythonhosted.org/setuptools/
 .. _entry points: https://pythonhosted.org/setuptools/pkg_resources.html#entry-points
+.. _Avocado source tree: https://github.com/avocado-framework/avocado/tree/master/examples/plugins

--- a/docs/source/ReferenceGuide.rst
+++ b/docs/source/ReferenceGuide.rst
@@ -258,6 +258,72 @@ The instances should have:
 
 .. [#f1] Avocado plugins can introduce additional test types.
 
+Job Pre and Post Scripts
+========================
+
+Avocado ships by default with a plugin that allows running scripts
+before and after the actual execution of Jobs.  A user can be sure
+that, when a given "pre" script is run, no test in that job has been
+run, and when the "post" scripts are run, all the tests in a given job
+have already finished running.
+
+Configuration
+-------------
+
+By default, the script directory location is::
+
+  /etc/avocado/scripts/job
+
+Inside that directory, that is a directory for pre-job scripts::
+
+  /etc/avocado/scripts/job/pre.d
+
+And for post-job scripts::
+
+  /etc/avocado/scripts/job/post.d
+
+All the configuration about the Pre/Post Job Scripts are placed under
+the ``avocado.plugins.jobscripts`` config section.  To change the
+location for the pre-job scripts, your configuration should look
+something like this::
+
+  [avocado.plugins.jobscripts]
+  pre = /my/custom/directory/for/pre/job/scripts/
+
+Accordingly, to change the location for the post-job scripts, your
+configuration should look something like this::
+
+  [avocado.plugins.jobscripts]
+  post = /my/custom/directory/for/post/scripts/
+
+A couple of other configuration options are available under the same
+section:
+
+* ``warn_non_existing_dir``: gives warnings if the configured (or
+  default) directory set for either pre or post scripts do not exist
+* ``warn_non_zero_status``: gives warnings if a given script (either
+  pre or post) exits with non-zero status
+
+Script Execution Environment
+----------------------------
+
+All scripts are run in separate process with some environment
+variables set.  These can be used in your scripts in any way you wish:
+
+* ``AVOCADO_JOB_UNIQUE_ID``: the unique `job-id`_.
+* ``AVOCADO_JOB_STATUS``: the current status of the job.
+* ``AVOCADO_JOB_LOGDIR``: the filesystem location that holds the logs
+  and various other files for a given job run.
+
+Note: Even though these variables should all be set, it's a good
+practice for scripts to check if they're set before using their
+values.  This may prevent unintended actions such as writing to the
+current working directory instead of to the ``AVOCADO_JOB_LOGDIR`` if
+this is not set.
+
+Finally, any failures in the Pre/Post scripts will not alter the
+status of the corresponding jobs.
+
 Job Cleanup
 ===========
 

--- a/etc/avocado/conf.d/jobscripts.conf
+++ b/etc/avocado/conf.d/jobscripts.conf
@@ -1,0 +1,9 @@
+[avocado.plugins.jobscripts]
+# Directory with scripts to be executed before a job is run
+pre = /etc/avocado/scripts/job/pre.d/
+# Directory with scripts to be executed after a job is run
+post = /etc/avocado/scripts/job/post.d/
+# Warn if configured (or default) directory does not exist
+warn_non_existing_dir = False
+# Warn if any script run return non-zero status
+warn_non_zero_status = False

--- a/etc/avocado/scripts/job/post.d/README
+++ b/etc/avocado/scripts/job/post.d/README
@@ -1,0 +1,4 @@
+Put your post-job scripts here. They need to be readable and executable by
+the Avocado user running the jobs. The order of execution is based on their
+file names. If order is important, use a prefix, such as 001-myscript,
+002-otherscript, etc.

--- a/etc/avocado/scripts/job/pre.d/README
+++ b/etc/avocado/scripts/job/pre.d/README
@@ -1,0 +1,4 @@
+Put your pre-job scripts here. They need to be readable and executable by
+the Avocado user running the jobs. The order of execution is based on their
+file names. If order is important, use a prefix, such as 001-myscript,
+002-otherscript, etc.

--- a/examples/plugins/README.rst
+++ b/examples/plugins/README.rst
@@ -1,0 +1,16 @@
+=================
+ Plugin Examples
+=================
+
+Here you can find a collection of example code for the various Avocado
+Plugin interfaces.
+
+To try them out on a development environment, you may run::
+
+ $ cd <plugin-type>/<plugin-example>
+ $ python setup.py develop --user
+
+And to remove them on a development environment, you may run, at the
+same directory::
+
+ $ python setup.py develop --uninstall --user

--- a/examples/plugins/job-pre-post/mail/avocado_job_mail.py
+++ b/examples/plugins/job-pre-post/mail/avocado_job_mail.py
@@ -1,0 +1,52 @@
+import logging
+import smtplib
+from email.mime.text import MIMEText
+
+from avocado.core.settings import settings
+from avocado.plugins.base import JobPre, JobPost
+
+
+class Mail(JobPre, JobPost):
+
+    name = 'mail'
+    description = 'Sends mail to notify on job start/end'
+
+    def __init__(self):
+        self.log = logging.getLogger("avocado.app")
+        self.rcpt = settings.get_value(section="plugins.job.mail",
+                                       key="recipient",
+                                       key_type=str,
+                                       default='root@localhost.localdomain')
+        self.subject = settings.get_value(section="plugins.job.mail",
+                                          key="subject",
+                                          key_type=str,
+                                          default='[AVOCADO JOB NOTIFICATION]')
+        self.sender = settings.get_value(section="plugins.job.mail",
+                                         key="sender",
+                                         key_type=str,
+                                         default='avocado@localhost.localdomain')
+        self.server = settings.get_value(section="plugins.job.mail",
+                                         key="server",
+                                         key_type=str,
+                                         default='localhost')
+
+    def mail(self, job):
+        # build proper subject based on job status
+        subject = '%s Job %s - Status: %s' % (self.subject,
+                                              job.unique_id,
+                                              job.status)
+        msg = MIMEText(subject)
+        msg['Subject'] = self.subject
+        msg['From'] = self.sender
+        msg['To'] = self.rcpt
+
+        # So many possible failures, let's just tell the user about it
+        try:
+            smtp = smtplib.SMTP(self.server)
+            smtp.sendmail(self.sender, [self.rcpt], msg.as_string())
+            smtp.quit()
+        except:
+            self.log.error("Failure to send email notification: "
+                           "please check your mail configuration")
+
+    pre = post = mail

--- a/examples/plugins/job-pre-post/mail/setup.py
+++ b/examples/plugins/job-pre-post/mail/setup.py
@@ -1,0 +1,15 @@
+from setuptools import setup
+
+name = 'avocado_job_mail'
+klass = 'Mail'
+entry_point = '%s = %s:%s' % (name, name, klass)
+
+if __name__ == '__main__':
+    setup(name=name,
+          version='1.0',
+          description='Avocado Pre/Post Job Mail Notification',
+          py_modules=[name],
+          entry_points={
+              'avocado.plugins.job.prepost': [entry_point]
+              }
+          )

--- a/examples/plugins/job-pre-post/sleep/avocado_job_sleep.py
+++ b/examples/plugins/job-pre-post/sleep/avocado_job_sleep.py
@@ -1,0 +1,25 @@
+import time
+import logging
+
+from avocado.core.settings import settings
+from avocado.plugins.base import JobPre, JobPost
+
+
+class Sleep(JobPre, JobPost):
+
+    name = 'sleep'
+    description = 'Sleeps for a number of seconds'
+
+    def __init__(self):
+        self.log = logging.getLogger("avocado.app")
+        self.seconds = settings.get_value(section="plugins.job.sleep",
+                                          key="seconds",
+                                          key_type=int,
+                                          default=3)
+
+    def sleep(self, job):
+        for i in xrange(1, self.seconds + 1):
+            self.log.info("Sleeping %2i/%s", i, self.seconds)
+            time.sleep(1)
+
+    pre = post = sleep

--- a/examples/plugins/job-pre-post/sleep/setup.py
+++ b/examples/plugins/job-pre-post/sleep/setup.py
@@ -1,0 +1,15 @@
+from setuptools import setup
+
+name = 'avocado_job_sleep'
+klass = 'Sleep'
+entry_point = '%s = %s:%s' % (name, name, klass)
+
+if __name__ == '__main__':
+    setup(name=name,
+          version='1.0',
+          description='Avocado Pre/Post Job Sleep',
+          py_modules=[name],
+          entry_points={
+              'avocado.plugins.job.prepost': [entry_point],
+              }
+          )

--- a/selftests/functional/test_plugin_jobscripts.py
+++ b/selftests/functional/test_plugin_jobscripts.py
@@ -1,0 +1,131 @@
+import os
+import shutil
+import sys
+import tempfile
+
+if sys.version_info[:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
+
+from avocado.core import exit_codes
+from avocado.utils import process
+from avocado.utils import script
+
+
+SCRIPT_PRE_TOUCH = """#!/bin/sh -e
+touch %s"""
+
+TEST_CHECK_TOUCH = """#!/bin/sh -e
+test -f %s"""
+
+SCRIPT_POST_RM = """#!/bin/sh -e
+rm %s"""
+
+SCRIPT_PRE_POST_CFG = """[avocado.plugins.jobscripts]
+pre = %s
+post = %s
+warn_non_existing_dir = True
+warn_non_zero_status = True"""
+
+SCRIPT_NON_EXISTING_DIR_CFG = """[avocado.plugins.jobscripts]
+pre = %s
+warn_non_existing_dir = True
+warn_non_zero_status = False"""
+
+SCRIPT_NON_ZERO_STATUS = """#!/bin/sh
+exit 1"""
+
+SCRIPT_NON_ZERO_CFG = """[avocado.plugins.jobscripts]
+pre = %s
+warn_non_existing_dir = False
+warn_non_zero_status = True"""
+
+
+class JobScriptsTest(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        self.pre_dir = os.path.join(self.tmpdir, 'pre.d')
+        os.mkdir(self.pre_dir)
+        self.post_dir = os.path.join(self.tmpdir, 'post.d')
+        os.mkdir(self.post_dir)
+
+    def test_pre_post(self):
+        """
+        Runs both pre and post scripts and makes sure both execute properly
+        """
+        touch_script = script.Script(os.path.join(self.pre_dir,
+                                                  'touch.sh'),
+                                     SCRIPT_PRE_TOUCH)
+        touch_script.save()
+        test_check_touch = script.Script(os.path.join(self.tmpdir,
+                                                      'check_touch.sh'),
+                                         TEST_CHECK_TOUCH)
+        test_check_touch.save()
+        rm_script = script.Script(os.path.join(self.post_dir,
+                                               'rm.sh'),
+                                  SCRIPT_POST_RM)
+        rm_script.save()
+        config = script.TemporaryScript("pre_post.conf",
+                                        SCRIPT_PRE_POST_CFG % (self.pre_dir,
+                                                               self.post_dir))
+        with config:
+            cmd = './scripts/avocado --config %s run %s' % (config,
+                                                            test_check_touch)
+            result = process.run(cmd)
+
+        # Pre/Post scripts failures do not (currently?) alter the exit status
+        self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
+        self.assertNotIn('Script "%s" exited with status "1"' % touch_script,
+                         result.stderr)
+        self.assertNotIn('Script "%s" exited with status "1"' % rm_script,
+                         result.stderr)
+
+    def test_status_non_zero(self):
+        """
+        Checks warning when script returns non-zero status
+        """
+        non_zero_script = script.Script(os.path.join(self.pre_dir,
+                                                     'non_zero.sh'),
+                                        SCRIPT_NON_ZERO_STATUS)
+        non_zero_script.save()
+        config = script.TemporaryScript("non_zero.conf",
+                                        SCRIPT_NON_ZERO_CFG % self.pre_dir)
+        with config:
+            cmd = './scripts/avocado --config %s run passtest' % config
+            result = process.run(cmd)
+
+        # Pre/Post scripts failures do not (currently?) alter the exit status
+        self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
+        self.assertEqual('Script "%s" exited with status "1"\n' % non_zero_script,
+                         result.stderr)
+
+    def test_non_existing_dir(self):
+        """
+        Checks warning with non existing pre dir
+        """
+        non_zero_script = script.Script(os.path.join(self.pre_dir,
+                                                     'non_zero.sh'),
+                                        SCRIPT_NON_ZERO_STATUS)
+        non_zero_script.save()
+
+        self.pre_dir = '/non/existing/dir'
+        config = script.TemporaryScript("non_existing_dir.conf",
+                                        SCRIPT_NON_EXISTING_DIR_CFG % self.pre_dir)
+        with config:
+            cmd = './scripts/avocado --config %s run passtest' % config
+            result = process.run(cmd)
+
+        # Pre/Post scripts failures do not (currently?) alter the exit status
+        self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
+        self.assertIn('-job scripts has not been found', result.stderr)
+        self.assertNotIn('Script "%s" exited with status "1"' % non_zero_script,
+                         result.stderr)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,10 @@ def get_data_files():
     data_files += [(get_dir(['etc', 'avocado', 'sysinfo']),
                     ['etc/avocado/sysinfo/commands', 'etc/avocado/sysinfo/files',
                      'etc/avocado/sysinfo/profilers'])]
+    data_files += [(get_dir(['etc', 'avocado', 'scripts', 'job', 'pre.d']),
+                    ['etc/avocado/scripts/job/pre.d/README'])]
+    data_files += [(get_dir(['etc', 'avocado', 'scripts', 'job', 'post.d']),
+                    ['etc/avocado/scripts/job/post.d/README'])]
     data_files += [(get_tests_dir(), glob.glob('examples/tests/*.py'))]
     for data_dir in glob.glob('examples/tests/*.data'):
         fmt_str = '%s/*' % data_dir
@@ -146,7 +150,10 @@ if __name__ == '__main__':
                   'run = avocado.plugins.run:Run',
                   'sysinfo = avocado.plugins.sysinfo:SysInfo',
                   'plugins = avocado.plugins.plugins:Plugins',
-                  ]
+                  ],
+              'avocado.plugins.job.prepost': [
+                  'jobscripts = avocado.plugins.jobscripts:JobScripts',
+                  ],
               },
           zip_safe=False,
           test_suite='selftests')


### PR DESCRIPTION
This introduces a new Plugin interface, and allows plugin writers to execute custom actions before and after the jobs are run.

The plugin interface gives the avocado.core.job.Job instance to plugin writers, who can collect information from it.

Also, two examples are given, including a "real world" mail notification plugin.

--

Changes from v3 (#1134):
 * Added Makefile help message for "develop" target
 * Removed duplicate removal of "avocado.egg-info" on "clean" target
 * Wrapped plugin pre/post method execution into the dispatcher, producing error messages when exceptions occur in the plugin code
 * Change of conditional flow on jobscripts plugin (`if not scripts: return`)
 * Change of location where pre job hook is called, to a bit later into the execution of the job. At this point the job results dir is initialized, but test suite is not created and tests have not run.

Changes from v2 (#1126):
 * Added functional tests
 * Added documentation
 * Added better cleanup for Travis CI per-commit checks

Changes from v1 (#1106):
 * Broke down the interface specification into JobPre and JobPost
 * Added "jobscripts" plugin, that allows user's scripts to be run before and after the job