### PR TITLE
avocado.core.remoter option to reject remote unknown hosts [v3]

### DIFF
--- a/avocado/core/remoter.py
+++ b/avocado/core/remoter.py
@@ -20,6 +20,7 @@ import getpass
 import logging
 import time
 
+from .settings import settings
 from ..utils import process
 
 LOG = logging.getLogger('avocado.test')
@@ -70,6 +71,14 @@ class Remote(object):
         self.password = password
         self.port = port
         self.quiet = quiet
+        reject_unknown_hosts = settings.get_value('remoter.behavior',
+                                                  'reject_unknown_hosts',
+                                                  key_type=bool,
+                                                  default=True)
+        disable_known_hosts = settings.get_value('remoter.behavior',
+                                                 'disable_known_hosts',
+                                                 key_type=bool,
+                                                 default=False)
         self._setup_environment(host_string=hostname,
                                 user=username,
                                 password=password,
@@ -78,7 +87,9 @@ class Remote(object):
                                 connection_attempts=attempts,
                                 linewise=True,
                                 abort_on_prompts=True,
-                                abort_exception=ConnectionError)
+                                abort_exception=ConnectionError,
+                                reject_unknown_hosts=reject_unknown_hosts,
+                                disable_known_hosts=disable_known_hosts)
 
     @staticmethod
     def _setup_environment(**kwargs):

--- a/etc/avocado/avocado.conf
+++ b/etc/avocado/avocado.conf
@@ -38,6 +38,18 @@ utf8 =
 # Keep job temporary files after jobs (useful for avocado debugging)
 keep_tmp_files = False
 
+[remoter.behavior]
+# Reject unknown SSH host keys.
+# 'False' will leave you wide open to man-in-the-middle attacks!
+# 'True' will only work with RSA keys (due to a bug in Paramiko).
+# If using 'True', accept the remote host key fingerprint by using:
+#   $ ssh -oHostKeyAlgorithms='ssh-rsa' <host>
+reject_unknown_hosts = False
+# SSH layer to skip loading the user’s known-hosts file. Useful for avoiding
+# exceptions in situations where a 'known host' changing its host key is
+# actually valid (e.g. cloud servers such as EC2.)
+disable_known_hosts = False
+
 [job.output]
 # Base log level for --show-job-log.
 # Allowed levels: debug, info, warning, error, critical

--- a/selftests/functional/test_thirdparty_bugs.py
+++ b/selftests/functional/test_thirdparty_bugs.py
@@ -1,0 +1,29 @@
+import json
+import sys
+from avocado.utils import download
+
+if sys.version_info[:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
+
+
+class TestThirdPartyBugs(unittest.TestCase):
+    """
+    Class created to verify third-party known issues
+    """
+
+    def test_paramiko_ecsda_bug(self):
+        # https://github.com/paramiko/paramiko/issues/243
+        # Problems with using ECDSA known_hosts keys when negotiation also
+        # accepts RSA or DSS keys
+        issue_url = 'https://api.github.com/repos/paramiko/paramiko/issues/243'
+        issue = json.load(download.url_open(issue_url))
+        self.assertEqual(issue['state'], 'open', 'The issue %s is not open '
+                         'anymore. Please double check and, if already fixed, '
+                         'change the avocado.conf option '
+                         '"reject_unknown_hosts" defaults to True.' %
+                         'https://github.com/paramiko/paramiko/issues/243')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
v1: #1127 
 - Create `reject_unknown_host` option.

v2: #1135 
 - Defaults to `False` due to the Paramiko issue with `ecdsa` host key fingerprint.
 - Proper config section.

v3:
 - Include `disable_known_hosts` option.
 - `reject_unknown_hosts` defaults to `True` internally.
 - Test to check when the issue in Paramiko gets fixed.