### PR TITLE
avocado.core.result: Couple of bugfixes and cleanups [v2]

### DIFF
--- a/avocado/core/html.py
+++ b/avocado/core/html.py
@@ -217,20 +217,16 @@ class HTMLTestResult(TestResult):
         :type state: dict
         """
         TestResult.end_test(self, state)
-        if state['fail_reason'] is None:
-            state['fail_reason'] = ''
-        else:
-            state['fail_reason'] = str(state['fail_reason'])
-        t = {'test': state['tagged_name'],
-             'url': state['name'],
-             'time_start': state['time_start'],
-             'time_end': state['time_end'],
-             'time': state['time_elapsed'],
-             'status': state['status'],
-             'fail_reason': state['fail_reason'],
-             'whiteboard': state['whiteboard'],
-             'logdir': urllib.quote(state['logdir']),
-             'logfile': urllib.quote(state['logfile'])
+        t = {'test': state.get('tagged_name', "<unknown>"),
+             'url': state.get('name', "<unknown>"),
+             'time_start': state.get('time_start', -1),
+             'time_end': state.get('time_end', -1),
+             'time': state.get('time_elapsed', -1),
+             'status': state.get('status', "ERROR"),
+             'fail_reason': str(state.get('fail_reason', "<unknown>")),
+             'whiteboard': state.get('whiteboard', "<unknown>"),
+             'logdir': urllib.quote(state.get('logdir', "<unknown>")),
+             'logfile': urllib.quote(state.get('logfile', "<unknown>"))
              }
         self.json['tests'].append(t)
 

--- a/avocado/core/html.py
+++ b/avocado/core/html.py
@@ -241,10 +241,10 @@ class HTMLTestResult(TestResult):
         TestResult.end_tests(self)
         self.json.update({
             'total': len(self.json['tests']),
-            'pass': len(self.passed),
-            'errors': len(self.errors),
-            'failures': len(self.failed),
-            'skip': len(self.skipped),
+            'pass': self.passed,
+            'errors': self.errors,
+            'failures': self.failed,
+            'skip': self.skipped,
             'time': self.total_time
         })
         self._render_report()

--- a/avocado/core/jsonresult.py
+++ b/avocado/core/jsonresult.py
@@ -85,10 +85,10 @@ class JSONTestResult(TestResult):
         TestResult.end_tests(self)
         self.json.update({
             'total': self.tests_total,
-            'pass': len(self.passed),
-            'errors': len(self.errors),
-            'failures': len(self.failed),
-            'skip': len(self.skipped),
+            'pass': self.passed,
+            'errors': self.errors,
+            'failures': self.failed,
+            'skip': self.skipped,
             'time': self.total_time
         })
         self.json = json.dumps(self.json)

--- a/avocado/core/jsonresult.py
+++ b/avocado/core/jsonresult.py
@@ -60,17 +60,17 @@ class JSONTestResult(TestResult):
         """
         TestResult.end_test(self, state)
         if 'job_id' not in self.json:
-            self.json['job_id'] = state['job_unique_id']
-        t = {'test': state['tagged_name'],
-             'url': state['name'],
-             'start': state['time_start'],
-             'end': state['time_end'],
-             'time': state['time_elapsed'],
-             'status': state['status'],
-             'whiteboard': state['whiteboard'],
-             'logdir': state['logdir'],
-             'logfile': state['logfile'],
-             'fail_reason': str(state['fail_reason'])
+            self.json['job_id'] = state.get('job_unique_id', "<unknown>")
+        t = {'test': state.get('tagged_name', "<unknown>"),
+             'url': state.get('name', "<unknown>"),
+             'start': state.get('time_start', -1),
+             'end': state.get('time_end', -1),
+             'time': state.get('time_elapsed', -1),
+             'status': state.get('status', {}),
+             'whiteboard': state.get('whiteboard', "<unknown>"),
+             'logdir': state.get('logdir', "<unknown>"),
+             'logfile': state.get('logfile', "<unknown>"),
+             'fail_reason': str(state.get('fail_reason', "<unknown>"))
              }
         self.json['tests'].append(t)
 

--- a/avocado/core/result.py
+++ b/avocado/core/result.py
@@ -188,7 +188,7 @@ class TestResult(object):
         :type state: dict
         """
         self.tests_run += 1
-        self.total_time += state['time_elapsed']
+        self.total_time += state.get('time_elapsed', -1)
 
     def add_pass(self, state):  # Unused variable pylint: disable=W0613
         """
@@ -255,7 +255,7 @@ class TestResult(object):
                       'SKIP': self.add_skip,
                       'WARN': self.add_warn,
                       'INTERRUPTED': self.add_interrupt}
-        add = status_map[state['status']]
+        add = status_map[state.get('status', 'ERROR')]
         add(state)
         self.end_test(state)
 
@@ -301,11 +301,12 @@ class HumanTestResult(TestResult):
     def start_test(self, state):
         super(HumanTestResult, self).start_test(state)
         self.log.debug(' (%s/%s) %s:  ', self.tests_run, self.tests_total,
-                       state["tagged_name"], extra={"skip_newline": True})
+                       state.get("tagged_name", "<missing>"),
+                       extra={"skip_newline": True})
 
     def end_test(self, state):
         super(HumanTestResult, self).end_test(state)
-        status = state["status"]
+        status = state.get("status", "ERROR")
         if status == "TEST_NA":
             status = "SKIP"
         mapping = {'PASS': output.TERM_SUPPORT.PASS,

--- a/avocado/core/result.py
+++ b/avocado/core/result.py
@@ -85,26 +85,6 @@ class TestResultProxy(object):
         for output_plugin in self.output_plugins:
             output_plugin.end_test(state)
 
-    def add_pass(self, state):
-        for output_plugin in self.output_plugins:
-            output_plugin.add_pass(state)
-
-    def add_error(self, state):
-        for output_plugin in self.output_plugins:
-            output_plugin.add_error(state)
-
-    def add_fail(self, state):
-        for output_plugin in self.output_plugins:
-            output_plugin.add_fail(state)
-
-    def add_skip(self, state):
-        for output_plugin in self.output_plugins:
-            output_plugin.add_skip(state)
-
-    def add_warn(self, state):
-        for output_plugin in self.output_plugins:
-            output_plugin.add_warn(state)
-
     def check_test(self, state):
         for output_plugin in self.output_plugins:
             output_plugin.check_test(state)
@@ -190,73 +170,25 @@ class TestResult(object):
         self.tests_run += 1
         self.total_time += state.get('time_elapsed', -1)
 
-    def add_pass(self, state):  # Unused variable pylint: disable=W0613
-        """
-        Called when a test succeeded.
-
-        :param state: result of :class:`avocado.core.test.Test.get_state`.
-        :type state: dict
-        """
-        self.passed += 1
-
-    def add_error(self, state):  # Unused variable pylint: disable=W0613
-        """
-        Called when a test had a setup error.
-
-        :param state: result of :class:`avocado.core.test.Test.get_state`.
-        :type state: dict
-        """
-        self.errors += 1
-
-    def add_fail(self, state):  # Unused variable pylint: disable=W0613
-        """
-        Called when a test fails.
-
-        :param state: result of :class:`avocado.core.test.Test.get_state`.
-        :type state: dict
-        """
-        self.failed += 1
-
-    def add_skip(self, state):  # Unused variable pylint: disable=W0613
-        """
-        Called when a test is skipped.
-
-        :param test: an instance of :class:`avocado.core.test.Test`.
-        """
-        self.skipped += 1
-
-    def add_warn(self, state):  # Unused variable pylint: disable=W0613
-        """
-        Called when a test had a warning.
-
-        :param state: result of :class:`avocado.core.test.Test.get_state`.
-        :type state: dict
-        """
-        self.warned += 1
-
-    def add_interrupt(self, state):  # Unused variable pylint: disable=W0613
-        """
-        Called when a test is interrupted by the user.
-
-        :param state: result of :class:`avocado.core.test.Test.get_state`.
-        :type state: dict
-        """
-        self.interrupted += 1
-
     def check_test(self, state):
         """
         Called once for a test to check status and report.
 
         :param test: A dict with test internal state
         """
-        status_map = {'PASS': self.add_pass,
-                      'ERROR': self.add_error,
-                      'FAIL': self.add_fail,
-                      'SKIP': self.add_skip,
-                      'WARN': self.add_warn,
-                      'INTERRUPTED': self.add_interrupt}
-        add = status_map[state.get('status', 'ERROR')]
-        add(state)
+        status = state.get('status')
+        if status == "PASS":
+            self.passed += 1
+        elif status == "SKIP":
+            self.skipped += 1
+        elif status == "FAIL":
+            self.failed += 1
+        elif status == "WARN":
+            self.warned += 1
+        elif status == "INTERRUPTED":
+            self.interrupted += 1
+        else:
+            self.errors += 1
         self.end_test(state)
 
 

--- a/avocado/core/result.py
+++ b/avocado/core/result.py
@@ -133,12 +133,12 @@ class TestResult(object):
         self.tests_total = getattr(self.args, 'test_result_total', 1)
         self.tests_run = 0
         self.total_time = 0.0
-        self.passed = []
-        self.errors = []
-        self.failed = []
-        self.skipped = []
-        self.warned = []
-        self.interrupted = []
+        self.passed = 0
+        self.errors = 0
+        self.failed = 0
+        self.skipped = 0
+        self.warned = 0
+        self.interrupted = 0
 
         # Where this results intends to write to. Convention is that a dash (-)
         # means stdout, and stdout is a special output that can be exclusively
@@ -153,12 +153,11 @@ class TestResult(object):
         missing, but this is no excuse for giving wrong summaries of test
         results.
         """
-        valid_results_count = (len(self.passed) + len(self.errors) +
-                               len(self.failed) + len(self.warned) +
-                               len(self.skipped) + len(self.interrupted))
+        valid_results_count = (self.passed + self.errors +
+                               self.failed + self.warned +
+                               self.skipped + self.interrupted)
         other_skipped_count = self.tests_total - valid_results_count
-        for i in xrange(other_skipped_count):
-            self.skipped.append({})
+        self.skipped += other_skipped_count
 
     def start_tests(self):
         """
@@ -191,58 +190,58 @@ class TestResult(object):
         self.tests_run += 1
         self.total_time += state['time_elapsed']
 
-    def add_pass(self, state):
+    def add_pass(self, state):  # Unused variable pylint: disable=W0613
         """
         Called when a test succeeded.
 
         :param state: result of :class:`avocado.core.test.Test.get_state`.
         :type state: dict
         """
-        self.passed.append(state)
+        self.passed += 1
 
-    def add_error(self, state):
+    def add_error(self, state):  # Unused variable pylint: disable=W0613
         """
         Called when a test had a setup error.
 
         :param state: result of :class:`avocado.core.test.Test.get_state`.
         :type state: dict
         """
-        self.errors.append(state)
+        self.errors += 1
 
-    def add_fail(self, state):
+    def add_fail(self, state):  # Unused variable pylint: disable=W0613
         """
         Called when a test fails.
 
         :param state: result of :class:`avocado.core.test.Test.get_state`.
         :type state: dict
         """
-        self.failed.append(state)
+        self.failed += 1
 
-    def add_skip(self, state):
+    def add_skip(self, state):  # Unused variable pylint: disable=W0613
         """
         Called when a test is skipped.
 
         :param test: an instance of :class:`avocado.core.test.Test`.
         """
-        self.skipped.append(state)
+        self.skipped += 1
 
-    def add_warn(self, state):
+    def add_warn(self, state):  # Unused variable pylint: disable=W0613
         """
         Called when a test had a warning.
 
         :param state: result of :class:`avocado.core.test.Test.get_state`.
         :type state: dict
         """
-        self.warned.append(state)
+        self.warned += 1
 
-    def add_interrupt(self, state):
+    def add_interrupt(self, state):  # Unused variable pylint: disable=W0613
         """
         Called when a test is interrupted by the user.
 
         :param state: result of :class:`avocado.core.test.Test.get_state`.
         :type state: dict
         """
-        self.interrupted.append(state)
+        self.interrupted += 1
 
     def check_test(self, state):
         """
@@ -289,9 +288,9 @@ class HumanTestResult(TestResult):
         """
         super(HumanTestResult, self).end_tests()
         self.log.info("RESULTS    : PASS %d | ERROR %d | FAIL %d | SKIP %d | "
-                      "WARN %d | INTERRUPT %s", len(self.passed),
-                      len(self.errors), len(self.failed), len(self.skipped),
-                      len(self.warned), len(self.interrupted))
+                      "WARN %d | INTERRUPT %s", self.passed,
+                      self.errors, self.failed, self.skipped,
+                      self.warned, self.interrupted)
         if self.args is not None:
             if 'html_output' in self.args:
                 logdir = os.path.dirname(self.logfile)

--- a/avocado/core/result.py
+++ b/avocado/core/result.py
@@ -137,7 +137,10 @@ class TestResult(object):
                                self.failed + self.warned +
                                self.skipped + self.interrupted)
         other_skipped_count = self.tests_total - valid_results_count
-        self.skipped += other_skipped_count
+        if other_skipped_count > 0:
+            self.skipped += other_skipped_count
+        else:
+            self.tests_total -= other_skipped_count
 
     def start_tests(self):
         """

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -148,14 +148,14 @@ class Test(unittest.TestCase):
         self.whiteboard = ''
 
         self.running = False
-        self.time_start = None
-        self.time_end = None
+        self.time_start = -1
+        self.time_end = -1
         self.paused = False
         self.paused_msg = ''
 
         self.runner_queue = runner_queue
 
-        self.time_elapsed = None
+        self.time_elapsed = -1
         unittest.TestCase.__init__(self, methodName=methodName)
 
     @property

--- a/avocado/core/xunit.py
+++ b/avocado/core/xunit.py
@@ -209,9 +209,9 @@ class xUnitTestResult(TestResult):
         """
         TestResult.end_tests(self)
         values = {'tests': self.tests_total,
-                  'errors': len(self.errors) + len(self.interrupted),
-                  'failures': len(self.failed),
-                  'skip': len(self.skipped),
+                  'errors': self.errors + self.interrupted,
+                  'failures': self.failed,
+                  'skip': self.skipped,
                   'total_time': self.total_time}
         self.xml.end_testsuite(**values)
         contents = self.xml.get_contents()

--- a/avocado/core/xunit.py
+++ b/avocado/core/xunit.py
@@ -199,9 +199,7 @@ class xUnitTestResult(TestResult):
             self.xml.add_skip(state)
         elif status == 'FAIL':
             self.xml.add_failure(state)
-        elif status == 'ERROR':
-            self.xml.add_error(state)
-        elif status == 'INTERRUPTED':
+        else:   # ERROR, INTERRUPTED, ...
             self.xml.add_error(state)
 
     def end_tests(self):

--- a/avocado/core/xunit.py
+++ b/avocado/core/xunit.py
@@ -87,9 +87,9 @@ class XmlResult(object):
         :type state: dict
         """
         tc = '\t<testcase classname={class} name={name} time="{time}"/>'
-        values = {'class': self._escape_attr(state['class_name']),
-                  'name': self._escape_attr(state['tagged_name']),
-                  'time': state['time_elapsed']}
+        values = {'class': self._escape_attr(state.get('class_name', "<unknown>")),
+                  'name': self._escape_attr(state.get('tagged_name', "<unknown>")),
+                  'time': state.get('time_elapsed', -1)}
         self.testcases.append(tc.format(**values))
 
     def add_skip(self, state):
@@ -102,9 +102,9 @@ class XmlResult(object):
         tc = '''\t<testcase classname={class} name={name} time="{time}">
 \t\t<skipped />
 \t</testcase>'''
-        values = {'class': self._escape_attr(state['class_name']),
-                  'name': self._escape_attr(state['tagged_name']),
-                  'time': state['time_elapsed']}
+        values = {'class': self._escape_attr(state.get('class_name', "<unknown>")),
+                  'name': self._escape_attr(state.get('tagged_name', "<unknown>")),
+                  'time': state.get('time_elapsed', -1)}
         self.testcases.append(tc.format(**values))
 
     def add_failure(self, state):
@@ -118,13 +118,13 @@ class XmlResult(object):
 \t\t<failure type={type} message={reason}><![CDATA[{traceback}]]></failure>
 \t\t<system-out><![CDATA[{systemout}]]></system-out>
 \t</testcase>'''
-        values = {'class': self._escape_attr(state['class_name']),
-                  'name': self._escape_attr(state['tagged_name']),
-                  'time': state['time_elapsed'],
-                  'type': self._escape_attr(state['fail_class']),
-                  'traceback': self._escape_cdata(state['traceback']),
-                  'systemout': self._escape_cdata(state['text_output']),
-                  'reason': self._escape_attr(str(state['fail_reason']))}
+        values = {'class': self._escape_attr(state.get('class_name', "<unknown>")),
+                  'name': self._escape_attr(state.get('tagged_name', "<unknown>")),
+                  'time': state.get('time_elapsed', -1),
+                  'type': self._escape_attr(state.get('fail_class', "<unknown>")),
+                  'traceback': self._escape_cdata(state.get('traceback', "<unknown>")),
+                  'systemout': self._escape_cdata(state.get('text_output', "<unknown>")),
+                  'reason': self._escape_attr(str(state.get('fail_reason', "<unknown>")))}
         self.testcases.append(tc.format(**values))
 
     def add_error(self, state):
@@ -138,13 +138,13 @@ class XmlResult(object):
 \t\t<error type={type} message={reason}><![CDATA[{traceback}]]></error>
 \t\t<system-out><![CDATA[{systemout}]]></system-out>
 \t</testcase>'''
-        values = {'class': self._escape_attr(state['class_name']),
-                  'name': self._escape_attr(state['tagged_name']),
-                  'time': state['time_elapsed'],
-                  'type': self._escape_attr(state['fail_class']),
-                  'traceback': self._escape_cdata(state['traceback']),
-                  'systemout': self._escape_cdata(state['text_output']),
-                  'reason': self._escape_attr(str(state['fail_reason']))}
+        values = {'class': self._escape_attr(state.get('class_name', "<unknown>")),
+                  'name': self._escape_attr(state.get('tagged_name', "<unknown>")),
+                  'time': state.get('time_elapsed', -1),
+                  'type': self._escape_attr(state.get('fail_class', "<unknown>")),
+                  'traceback': self._escape_cdata(state.get('traceback', "<unknown>")),
+                  'systemout': self._escape_cdata(state.get('text_output', "<unknown>")),
+                  'reason': self._escape_attr(str(state.get('fail_reason', "<unknown>")))}
         self.testcases.append(tc.format(**values))
 
 
@@ -192,15 +192,16 @@ class xUnitTestResult(TestResult):
         :type state: dict
         """
         TestResult.end_test(self, state)
-        if state['status'] in ('PASS', 'WARN'):
+        status = state.get('status', "ERROR")
+        if status in ('PASS', 'WARN'):
             self.xml.add_success(state)
-        elif state['status'] == 'SKIP':
+        elif status == 'SKIP':
             self.xml.add_skip(state)
-        elif state['status'] == 'FAIL':
+        elif status == 'FAIL':
             self.xml.add_failure(state)
-        elif state['status'] == 'ERROR':
+        elif status == 'ERROR':
             self.xml.add_error(state)
-        elif state['status'] == 'INTERRUPTED':
+        elif status == 'INTERRUPTED':
             self.xml.add_error(state)
 
     def end_tests(self):

--- a/selftests/unit/test_jsonresult.py
+++ b/selftests/unit/test_jsonresult.py
@@ -51,6 +51,39 @@ class JSONResultTest(unittest.TestCase):
         self.assertTrue(obj)
         self.assertEqual(len(obj['tests']), 1)
 
+    def testAddSeveralStatuses(self):
+        def run_fake_status(status):
+            self.test_result.start_test(self.test1)
+            self.test_result.check_test(status)
+
+        def check_item(name, value, exp):
+            self.assertEqual(value, exp, "Result%s is %s and not %s\n%s"
+                             % (name, value, exp, res))
+
+        # Set the number of tests to all tests + 3
+        self.test_result.tests_total = 13
+        # Full PASS status
+        self.test_result.start_test(self.test1)
+        self.test_result.check_test(self.test1.get_state())
+        # Only status - valid statuses
+        run_fake_status({"status": "PASS"})
+        run_fake_status({"status": "SKIP"})
+        run_fake_status({"status": "FAIL"})
+        run_fake_status({"status": "ERROR"})
+        run_fake_status({"status": "WARN"})
+        run_fake_status({"status": "INTERRUPTED"})
+        # Only status - invalid statuses
+        run_fake_status({"status": "INVALID"})
+        run_fake_status({"status": None})
+        run_fake_status({"status": ""})
+        # Postprocess
+        self.test_result.end_tests()
+        res = json.loads(self.test_result.json)
+        check_item("[pass]", res["pass"], 2)
+        check_item("[errors]", res["errors"], 4)
+        check_item("[failures]", res["failures"], 1)
+        check_item("[skip]", res["skip"], 4)
+        check_item("[total]", res["total"], 13)
 
 if __name__ == '__main__':
     unittest.main()

--- a/selftests/unit/test_jsonresult.py
+++ b/selftests/unit/test_jsonresult.py
@@ -85,5 +85,20 @@ class JSONResultTest(unittest.TestCase):
         check_item("[skip]", res["skip"], 4)
         check_item("[total]", res["total"], 13)
 
+    def testNegativeStatus(self):
+        def check_item(name, value, exp):
+            self.assertEqual(value, exp, "Result%s is %s and not %s\n%s"
+                             % (name, value, exp, res))
+
+        self.test_result.tests_total = 0
+        self.test_result.start_test(self.test1)
+        self.test_result.check_test(self.test1.get_state())
+        self.test_result.end_tests()
+        res = json.loads(self.test_result.json)
+        check_item("[total]", res["total"], 1)
+        check_item("[skip]", res["skip"], 0)
+        check_item("[pass]", res["pass"], 1)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Hello guys,

while reviewing the jsonresult PR I noticed that the results are quite broken. This PR tries to fix the most pressing issues and removing possible problems by removing unused API (which has a minor speedup effect).

Please see the commits for details.

v1: https://github.com/avocado-framework/avocado/pull/1121

Changes:

    v2: Removed the unused API also from TestResultProxy
    v2: Always use -1 for undefined time/duration references
    v2: Squash commits which were suppose to be squashed
    v2: Remove accidentally committed remnant from debugging