### PR TITLE
avocado.core.remoter fail early when host is not in known_hosts

### DIFF
--- a/avocado/core/remoter.py
+++ b/avocado/core/remoter.py
@@ -122,6 +122,8 @@ class Remote(object):
                 break
             except fabric.network.NetworkError as details:
                 fabric_exception = details
+                if 'not found in known_hosts' in details.message:
+                    break
                 timeout = end_time - time.time()
             if time.time() > end_time:
                 break


### PR DESCRIPTION
when the user provides --remote-password and the host is not found
in known_hosts, it raises fabric.network.NetworkError. We catch this
exception in remoter as usually it means the connection timed out
and if we have enough time we try it again.

This patch checks if 'not found in known_hosts' is present in the
exception message and breaks the loop to retry, re-raising the exception.

Signed-off-by: Amador Pahim <apahim@redhat.com>