### PR TITLE
[V2] Remote improvements

### DIFF
--- a/avocado/core/remote/runner.py
+++ b/avocado/core/remote/runner.py
@@ -83,11 +83,12 @@ class RemoteTestRunner(TestRunner):
                           self.job.args.remote_hostname,
                           self.job.args.remote_port,
                           self.job.args.remote_timeout)
-        self.remote = remoter.Remote(self.job.args.remote_hostname,
-                                     self.job.args.remote_username,
-                                     self.job.args.remote_password,
-                                     self.job.args.remote_port,
-                                     self.job.args.remote_timeout)
+        self.remote = remoter.Remote(hostname=self.job.args.remote_hostname,
+                                     username=self.job.args.remote_username,
+                                     password=self.job.args.remote_password,
+                                     key_filename=self.job.args.remote_key_file,
+                                     port=self.job.args.remote_port,
+                                     timeout=self.job.args.remote_timeout)
 
     def check_remote_avocado(self):
         """
@@ -296,6 +297,7 @@ class VMTestRunner(RemoteTestRunner):
             self.job.args.remote_port = self.job.args.vm_port
             self.job.args.remote_username = self.job.args.vm_username
             self.job.args.remote_password = self.job.args.vm_password
+            self.job.args.remote_key_file = self.job.args.vm_key_file
             self.job.args.remote_no_copy = self.job.args.vm_no_copy
             self.job.args.remote_timeout = self.job.args.vm_timeout
             super(VMTestRunner, self).setup()

--- a/avocado/core/remoter.py
+++ b/avocado/core/remoter.py
@@ -109,6 +109,11 @@ class Remote(object):
         :rtype: :class:`avocado.utils.process.CmdResult`.
         :raise fabric.exceptions.CommandTimeout: When timeout exhausted.
         """
+        return_dict = fabric.tasks.execute(self._run, command, ignore_status,
+                                           timeout, hosts=[self.hostname])
+        return return_dict[self.hostname]
+
+    def _run(self, command, ignore_status=False, timeout=60):
         result = process.CmdResult()
         start_time = time.time()
         end_time = time.time() + (timeout or 0)   # Support timeout=None
@@ -173,6 +178,12 @@ class Remote(object):
         self.run('mkdir -p %s' % remote_path)
 
     def send_files(self, local_path, remote_path):
+        result_dict = fabric.tasks.execute(self._send_files, local_path,
+                                           remote_path, hosts=[self.hostname])
+        return result_dict[self.hostname]
+
+    @staticmethod
+    def _send_files(local_path, remote_path):
         """
         Send files to remote.
 
@@ -187,6 +198,12 @@ class Remote(object):
         return True
 
     def receive_files(self, local_path, remote_path):
+        result_dict = fabric.tasks.execute(self._receive_files, local_path,
+                                           remote_path, hosts=[self.hostname])
+        return result_dict[self.hostname]
+
+    @staticmethod
+    def _receive_files(self, local_path, remote_path):
         """
         receive remote files.
 

--- a/avocado/core/remoter.py
+++ b/avocado/core/remoter.py
@@ -29,6 +29,7 @@ try:
     import fabric.api
     import fabric.network
     import fabric.operations
+    import fabric.tasks
 except ImportError:
     REMOTE_CAPABLE = False
     LOG.info('Remote module is disabled: could not import fabric')
@@ -43,6 +44,102 @@ class RemoterError(Exception):
 
 class ConnectionError(RemoterError):
     pass
+
+
+def run(command, ignore_status=False, quiet=True, timeout=60):
+    """
+    Executes a command on the defined fabric hosts.
+
+    This is basically a wrapper to fabric.operations.run, encapsulating
+    the result on an avocado process.CmdResult object. This also assumes
+    the fabric environment was previously (and properly) initialized.
+
+    :param command: the command string to execute.
+    :param ignore_status: Whether to not raise exceptions in case the
+        command's return code is different than zero.
+    :param timeout: Maximum time allowed for the command to return.
+    :param quiet: Whether to not log command stdout/err. Default: True.
+
+    :return: the result of the remote program's execution.
+    :rtype: :class:`avocado.utils.process.CmdResult`.
+    :raise fabric.exceptions.CommandTimeout: When timeout exhausted.
+    """
+
+    result = process.CmdResult()
+    start_time = time.time()
+    end_time = time.time() + (timeout or 0)   # Support timeout=None
+    # Fabric sometimes returns NetworkError even when timeout not reached
+    fabric_result = None
+    fabric_exception = None
+    while True:
+        try:
+            fabric_result = fabric.operations.run(command=command,
+                                                  quiet=quiet,
+                                                  warn_only=True,
+                                                  timeout=timeout)
+            break
+        except fabric.network.NetworkError, details:
+            fabric_exception = details
+            timeout = end_time - time.time()
+        if time.time() < end_time:
+            break
+    if fabric_result is None:
+        if fabric_exception is not None:
+            raise fabric_exception  # it's not None pylint: disable=E0702
+        else:
+            raise fabric.network.NetworkError("Remote execution of '%s'"
+                                              "failed without any "
+                                              "exception. This should not "
+                                              "happen." % command)
+    end_time = time.time()
+    duration = end_time - start_time
+    result.command = command
+    result.stdout = str(fabric_result)
+    result.stderr = fabric_result.stderr
+    result.duration = duration
+    result.exit_status = fabric_result.return_code
+    result.failed = fabric_result.failed
+    result.succeeded = fabric_result.succeeded
+    if not ignore_status:
+        if result.failed:
+            raise process.CmdError(command=command, result=result)
+    return result
+
+
+def send_files(local_path, remote_path):
+    """
+    Send files to the defined fabric host.
+
+    This assumes the fabric environment was previously (and properly)
+    initialized.
+
+    :param local_path: the local path.
+    :param remote_path: the remote path.
+    """
+    try:
+        fabric.operations.put(local_path, remote_path,
+                              mirror_local_mode=True)
+    except ValueError:
+        return False
+    return True
+
+
+def receive_files(local_path, remote_path):
+    """
+    Receive files from the defined fabric host.
+
+    This assumes the fabric environment was previously (and properly)
+    initialized.
+
+    :param local_path: the local path.
+    :param remote_path: the remote path.
+    """
+    try:
+        fabric.operations.get(remote_path,
+                              local_path)
+    except ValueError:
+        return False
+    return True
 
 
 class Remote(object):
@@ -95,7 +192,7 @@ class Remote(object):
 
     def run(self, command, ignore_status=False, quiet=True, timeout=60):
         """
-        Run a remote command.
+        Run a command on the remote host.
 
         :param command: the command string to execute.
         :param ignore_status: Whether to not raise exceptions in case the
@@ -107,7 +204,7 @@ class Remote(object):
         :rtype: :class:`avocado.utils.process.CmdResult`.
         :raise fabric.exceptions.CommandTimeout: When timeout exhausted.
         """
-        return_dict = fabric.tasks.execute(self._run, command, ignore_status,
+        return_dict = fabric.tasks.execute(run, command, ignore_status,
                                            quiet, timeout,
                                            hosts=[self.hostname])
         return return_dict[self.hostname]
@@ -178,41 +275,23 @@ class Remote(object):
         self.run('mkdir -p %s' % remote_path)
 
     def send_files(self, local_path, remote_path):
-        result_dict = fabric.tasks.execute(self._send_files, local_path,
-                                           remote_path, hosts=[self.hostname])
-        return result_dict[self.hostname]
-
-    @staticmethod
-    def _send_files(local_path, remote_path):
         """
-        Send files to remote.
+        Send files to remote host.
 
         :param local_path: the local path.
         :param remote_path: the remote path.
         """
-        try:
-            fabric.operations.put(local_path, remote_path,
-                                  mirror_local_mode=True)
-        except ValueError:
-            return False
-        return True
+        result_dict = fabric.tasks.execute(send_files, local_path,
+                                           remote_path, hosts=[self.hostname])
+        return result_dict[self.hostname]
 
     def receive_files(self, local_path, remote_path):
-        result_dict = fabric.tasks.execute(self._receive_files, local_path,
-                                           remote_path, hosts=[self.hostname])
-        return result_dict[self.hostname]
-
-    @staticmethod
-    def _receive_files(self, local_path, remote_path):
         """
-        receive remote files.
+        Receive files from the remote host.
 
         :param local_path: the local path.
         :param remote_path: the remote path.
         """
-        try:
-            fabric.operations.get(remote_path,
-                                  local_path)
-        except ValueError:
-            return False
-        return True
+        result_dict = fabric.tasks.execute(receive_files, local_path,
+                                           remote_path, hosts=[self.hostname])
+        return result_dict[self.hostname]

--- a/avocado/core/remoter.py
+++ b/avocado/core/remoter.py
@@ -46,6 +46,16 @@ class ConnectionError(RemoterError):
     pass
 
 
+class AuthenticationError(ConnectionError):
+
+    def __init__(self, msg):
+        self.fabric_msg = msg
+
+    def __str__(self):
+        return ('Auth error (wrong credentials, '
+                'or paramiko bug): {}'.format(self.fabric_msg))
+
+
 def run(command, ignore_status=False, quiet=True, timeout=60):
     """
     Executes a command on the defined fabric hosts.
@@ -78,7 +88,7 @@ def run(command, ignore_status=False, quiet=True, timeout=60):
                                                   warn_only=True,
                                                   timeout=timeout)
             break
-        except fabric.network.NetworkError, details:
+        except (fabric.network.NetworkError, AuthenticationError), details:
             fabric_exception = details
             timeout = end_time - time.time()
         if time.time() < end_time:
@@ -119,7 +129,7 @@ def send_files(local_path, remote_path):
     try:
         fabric.operations.put(local_path, remote_path,
                               mirror_local_mode=True)
-    except ValueError:
+    except (ValueError, AuthenticationError):
         return False
     return True
 
@@ -137,7 +147,7 @@ def receive_files(local_path, remote_path):
     try:
         fabric.operations.get(remote_path,
                               local_path)
-    except ValueError:
+    except (ValueError, AuthenticationError):
         return False
     return True
 

--- a/avocado/core/remoter.py
+++ b/avocado/core/remoter.py
@@ -83,23 +83,18 @@ class Remote(object):
                                                  'disable_known_hosts',
                                                  key_type=bool,
                                                  default=False)
-        self._setup_environment(host_string=hostname,
-                                user=username,
-                                password=password,
-                                key_filename=key_filename,
-                                port=port,
-                                timeout=timeout / attempts,
-                                connection_attempts=attempts,
-                                linewise=True,
-                                abort_on_prompts=True,
-                                abort_exception=ConnectionError,
-                                reject_unknown_hosts=reject_unknown_hosts,
-                                disable_known_hosts=disable_known_hosts)
-
-    @staticmethod
-    def _setup_environment(**kwargs):
-        """ Setup fabric environemnt """
-        fabric.api.env.update(kwargs)
+        fabric.api.env.update(host_string=hostname,
+                              user=username,
+                              password=password,
+                              key_filename=key_filename,
+                              port=port,
+                              timeout=timeout / attempts,
+                              connection_attempts=attempts,
+                              linewise=True,
+                              abort_on_prompts=True,
+                              abort_exception=ConnectionError,
+                              reject_unknown_hosts=reject_unknown_hosts,
+                              disable_known_hosts=disable_known_hosts)
 
     def run(self, command, ignore_status=False, timeout=60):
         """

--- a/avocado/core/remoter.py
+++ b/avocado/core/remoter.py
@@ -52,8 +52,7 @@ class Remote(object):
     """
 
     def __init__(self, hostname, username=None, password=None,
-                 key_filename=None, port=22, timeout=60, attempts=10,
-                 quiet=False):
+                 key_filename=None, port=22, timeout=60, attempts=10):
         """
         Creates an instance of :class:`Remote`.
 
@@ -64,7 +63,6 @@ class Remote(object):
             from Amazon EC2).
         :param timeout: remote command timeout, in seconds. Default: 60.
         :param attempts: number of attempts to connect. Default: 10.
-        :param quiet: performs quiet operations. Default: True.
         """
         self.hostname = hostname
         if username is None:
@@ -74,7 +72,6 @@ class Remote(object):
         # None = use public key
         self.password = password
         self.port = port
-        self.quiet = quiet
         reject_unknown_hosts = settings.get_value('remoter.behavior',
                                                   'reject_unknown_hosts',
                                                   key_type=bool,
@@ -96,7 +93,7 @@ class Remote(object):
                               reject_unknown_hosts=reject_unknown_hosts,
                               disable_known_hosts=disable_known_hosts)
 
-    def run(self, command, ignore_status=False, timeout=60):
+    def run(self, command, ignore_status=False, quiet=True, timeout=60):
         """
         Run a remote command.
 
@@ -104,16 +101,19 @@ class Remote(object):
         :param ignore_status: Whether to not raise exceptions in case the
             command's return code is different than zero.
         :param timeout: Maximum time allowed for the command to return.
+        :param quiet: Whether to not log command stdout/err. Default: True.
 
         :return: the result of the remote program's execution.
         :rtype: :class:`avocado.utils.process.CmdResult`.
         :raise fabric.exceptions.CommandTimeout: When timeout exhausted.
         """
         return_dict = fabric.tasks.execute(self._run, command, ignore_status,
-                                           timeout, hosts=[self.hostname])
+                                           quiet, timeout,
+                                           hosts=[self.hostname])
         return return_dict[self.hostname]
 
-    def _run(self, command, ignore_status=False, timeout=60):
+    @staticmethod
+    def _run(command, ignore_status=False, quiet=True, timeout=60):
         result = process.CmdResult()
         start_time = time.time()
         end_time = time.time() + (timeout or 0)   # Support timeout=None
@@ -123,7 +123,7 @@ class Remote(object):
         while True:
             try:
                 fabric_result = fabric.operations.run(command=command,
-                                                      quiet=self.quiet,
+                                                      quiet=quiet,
                                                       warn_only=True,
                                                       timeout=timeout,
                                                       pty=False)

--- a/avocado/core/remoter.py
+++ b/avocado/core/remoter.py
@@ -142,6 +142,22 @@ def receive_files(local_path, remote_path):
     return True
 
 
+def _update_fabric_env(method):
+    """
+    Update fabric env with the appropriate parameters.
+
+    :param method: Remote method to wrap.
+    :return: Wrapped method.
+    """
+    def wrapper(*args, **kwargs):
+        fabric.api.env.update(host_string=args[0].hostname,
+                              user=args[0].username,
+                              key_filename=args[0].key_filename,
+                              port=args[0].port)
+        return method(*args, **kwargs)
+    return wrapper
+
+
 class Remote(object):
 
     """
@@ -190,6 +206,7 @@ class Remote(object):
                               reject_unknown_hosts=reject_unknown_hosts,
                               disable_known_hosts=disable_known_hosts)
 
+    @_update_fabric_env
     def run(self, command, ignore_status=False, quiet=True, timeout=60):
         """
         Run a command on the remote host.
@@ -274,6 +291,7 @@ class Remote(object):
         """
         self.run('mkdir -p %s' % remote_path)
 
+    @_update_fabric_env
     def send_files(self, local_path, remote_path):
         """
         Send files to remote host.
@@ -285,6 +303,7 @@ class Remote(object):
                                            remote_path, hosts=[self.hostname])
         return result_dict[self.hostname]
 
+    @_update_fabric_env
     def receive_files(self, local_path, remote_path):
         """
         Receive files from the remote host.

--- a/avocado/core/remoter.py
+++ b/avocado/core/remoter.py
@@ -52,13 +52,16 @@ class Remote(object):
     """
 
     def __init__(self, hostname, username=None, password=None,
-                 port=22, timeout=60, attempts=10, quiet=False):
+                 key_filename=None, port=22, timeout=60, attempts=10,
+                 quiet=False):
         """
         Creates an instance of :class:`Remote`.
 
         :param hostname: the hostname.
         :param username: the username. Default: autodetect.
         :param password: the password. Default: try to use public key.
+        :param key_filename: path to an identity file (Example: .pem files
+            from Amazon EC2).
         :param timeout: remote command timeout, in seconds. Default: 60.
         :param attempts: number of attempts to connect. Default: 10.
         :param quiet: performs quiet operations. Default: True.
@@ -67,6 +70,7 @@ class Remote(object):
         if username is None:
             username = getpass.getuser()
         self.username = username
+        self.key_filename = key_filename
         # None = use public key
         self.password = password
         self.port = port
@@ -82,6 +86,7 @@ class Remote(object):
         self._setup_environment(host_string=hostname,
                                 user=username,
                                 password=password,
+                                key_filename=key_filename,
                                 port=port,
                                 timeout=timeout / attempts,
                                 connection_attempts=attempts,

--- a/avocado/core/remoter.py
+++ b/avocado/core/remoter.py
@@ -101,8 +101,11 @@ class Remote(object):
         Run a remote command.
 
         :param command: the command string to execute.
+        :param ignore_status: Whether to not raise exceptions in case the
+            command's return code is different than zero.
+        :param timeout: Maximum time allowed for the command to return.
 
-        :return: the result of the remote program's output.
+        :return: the result of the remote program's execution.
         :rtype: :class:`avocado.utils.process.CmdResult`.
         :raise fabric.exceptions.CommandTimeout: When timeout exhausted.
         """

--- a/avocado/plugins/remote.py
+++ b/avocado/plugins/remote.py
@@ -64,6 +64,11 @@ class Remote(CLI):
                                         dest='remote_password', default=None,
                                         help='Specify the password to login on'
                                         ' remote machine')
+        self.remote_parser.add_argument('--remote-key-file',
+                                        dest='remote_key_file', default=None,
+                                        help='Specify an identity file with '
+                                        'a private key instead of a password '
+                                        '(Example: .pem files from Amazon EC2)')
         self.remote_parser.add_argument('--remote-no-copy',
                                         dest='remote_no_copy',
                                         action='store_true',

--- a/avocado/plugins/vm.py
+++ b/avocado/plugins/vm.py
@@ -66,6 +66,11 @@ class VM(CLI):
         self.vm_parser.add_argument('--vm-password',
                                     default=None,
                                     help='Specify the password to login on VM')
+        self.vm_parser.add_argument('--vm-key-file',
+                                    dest='vm_key_file', default=None,
+                                    help='Specify an identity file with '
+                                    'a private key instead of a password '
+                                    '(Example: .pem files from Amazon EC2)')
         self.vm_parser.add_argument('--vm-cleanup',
                                     action='store_true', default=False,
                                     help='Restore VM to a previous state, '

--- a/selftests/unit/test_remote.py
+++ b/selftests/unit/test_remote.py
@@ -34,6 +34,7 @@ class RemoteTestRunnerTest(unittest.TestCase):
                         remote_hostname='hostname',
                         remote_port=22,
                         remote_password='password',
+                        remote_key_file=None,
                         remote_no_copy=False,
                         remote_timeout=60,
                         show_job_log=False,
@@ -154,7 +155,8 @@ class RemoteTestRunnerSetup(unittest.TestCase):
         Remote = flexmock()
         remote_remote = flexmock(remoter)
         (remote_remote.should_receive('Remote')
-         .with_args('hostname', 'username', 'password', 22, 60)
+         .with_args(hostname='hostname', username='username',
+                    password='password', key_filename=None, port=22, timeout=60)
          .once().ordered()
          .and_return(Remote))
         Args = flexmock(test_result_total=1,
@@ -164,6 +166,7 @@ class RemoteTestRunnerSetup(unittest.TestCase):
                         remote_hostname='hostname',
                         remote_port=22,
                         remote_password='password',
+                        remote_key_file=None,
                         remote_no_copy=False,
                         remote_timeout=60,
                         show_job_log=False)

--- a/selftests/unit/test_vm.py
+++ b/selftests/unit/test_vm.py
@@ -35,6 +35,7 @@ class VMTestRunnerSetup(unittest.TestCase):
                         vm_hostname='hostname',
                         vm_port=22,
                         vm_password='password',
+                        vm_key_file=None,
                         vm_cleanup=True,
                         vm_no_copy=False,
                         vm_timeout=120,


### PR DESCRIPTION
This contains a number of changes made to support my AWS cluster tests.

Those changes basically refactor a number of things in the remote class, enable multiple instances to be executed on the same test, and work around a Paramiko bug [2].

This is a rebase against the latest master. I have a new SSH library, but I imagine that will take more time to get in. Meanwhile, I have other tests, and a plugin that depend on those changes.

[1] Possibly Paramiko as well (the keys handling bug is specially annoying). I'm seriously thinking about reusing the autotest SSH host classes and have something that works with raw ssh and paramiko interchangeably.
[2] https://github.com/paramiko/paramiko/issues/387