### PR TITLE
avocado.utils.service: Check stderr when service do not exists

### DIFF
--- a/avocado/utils/service.py
+++ b/avocado/utils/service.py
@@ -117,11 +117,11 @@ def sys_v_init_result_parser(command):
             """
             # If service is stopped, exit_status is also not zero.
             # So, we can't use exit_status to check result.
-            output = cmd_result.stdout.lower()
             # Returns None if XXX is unrecognized.
-            if re.search(r"unrecognized", output):
+            if re.search(r"unrecognized", cmd_result.stderr.lower()):
                 return None
             # Returns False if XXX is stopped.
+            output = cmd_result.stdout.lower()
             dead_flags = [r"stopped", r"not running", r"dead"]
             for flag in dead_flags:
                 if re.search(flag, output):


### PR DESCRIPTION
When using a system V init service manager to check an unavailable
package, the error messages are sent via stderr, not stdout.

Signed-off-by: Hao Liu <hliu@redhat.com>