### PR TITLE
docs/source/Introduction.rst: remove broken link to slides

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,11 +14,6 @@ automated testing and continuous integration. Among them, we can highlight:
 - A database for results, with a web interface;
 - A scheduler for setting up a test grid.
 
-An `extensive set of slides about avocado
-<https://docs.google.com/presentation/d/1PLyOcmoYooWGAe-rS2gtjmrZ0B9J22FbfpNlQY8fIUE>`__,
-including details about its architecture, main features and status is available
-in google-drive.
-
 Using avocado
 -------------
 

--- a/docs/source/Introduction.rst
+++ b/docs/source/Introduction.rst
@@ -30,8 +30,5 @@ providing an assortment of system and logging facilities, with no effort,
 and if you want more features, then you can start using the API features
 progressively.
 
-An `extensive set of slides about Avocado
-<https://docs.google.com/presentation/d/1PLyOcmoYooWGAe-rS2gtjmrZ0B9J22FbfpNlQY8fIUE>`__,
-including details about its architecture, main features and status is available
-in google-drive. Mindmap from workshop (2015) demonstrating features on
-examples available `here <https://www.mindmeister.com/504616310>`__.
+Mindmap from workshop (2015) demonstrating features on examples
+available `here <https://www.mindmeister.com/504616310>`__.


### PR DESCRIPTION
The slides links are broken.  Let's remove them, and eventually re-add
them when they are put back in place.

Signed-off-by: Cleber Rosa <crosa@redhat.com>