### PR TITLE
avocado.core.remoter fix default for reject_unknown_hosts

### DIFF
--- a/avocado/core/remoter.py
+++ b/avocado/core/remoter.py
@@ -74,7 +74,7 @@ class Remote(object):
         reject_unknown_hosts = settings.get_value('remoter.behavior',
                                                   'reject_unknown_hosts',
                                                   key_type=bool,
-                                                  default=True)
+                                                  default=False)
         disable_known_hosts = settings.get_value('remoter.behavior',
                                                  'disable_known_hosts',
                                                  key_type=bool,


### PR DESCRIPTION
We use `False` in avocado.conf and remoter should have the same default.

Signed-off-by: Amador Pahim <apahim@redhat.com>