### PR TITLE
 avocado.core.loader: Fix the test alias resolver [v1]

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -700,13 +700,22 @@ class FileLoader(TestLoader):
                     return make_broken(AccessDeniedPath, test_path)
 
             # Try to resolve test ID (keep compatibility)
-            rel_path = '%s.py' % test_name
-            test_path = os.path.join(data_dir.get_test_dir(), rel_path)
+            test_path = os.path.join(data_dir.get_test_dir(), test_name)
             if os.path.exists(test_path):
                 return self._make_avocado_tests(test_path, make_broken,
-                                                subtests_filter, rel_path)
+                                                subtests_filter, test_name)
             else:
-                return make_broken(test.MissingTest, test_name)
+                if not subtests_filter and ':' in test_name:
+                    test_name, subtests_filter = test_name.split(':', 1)
+                    test_path = os.path.join(data_dir.get_test_dir(),
+                                             test_name)
+                    if os.path.exists(test_path):
+                        subtests_filter = re.compile(subtests_filter)
+                        return self._make_avocado_tests(test_path, make_broken,
+                                                        subtests_filter,
+                                                        test_name)
+                    else:
+                        return make_broken(test.MissingTest, test_name)
 
 
 class ExternalLoader(TestLoader):

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -122,12 +122,21 @@ class RunnerOperationTest(unittest.TestCase):
 
     def test_runner_all_ok(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --sysinfo=off --job-results-dir %s passtest passtest' % self.tmpdir
+        cmd_line = ('./scripts/avocado run --sysinfo=off --job-results-dir %s '
+                    'passtest.py passtest.py' % self.tmpdir)
         process.run(cmd_line)
 
     def test_datadir_alias(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --sysinfo=off --job-results-dir %s datadir' % self.tmpdir
+        cmd_line = ('./scripts/avocado run --sysinfo=off --job-results-dir %s '
+                    'datadir.py' % self.tmpdir)
+        process.run(cmd_line)
+
+    def test_shell_alias(self):
+        """ Tests that .sh files are also executable via alias """
+        os.chdir(basedir)
+        cmd_line = ('./scripts/avocado run --sysinfo=off --job-results-dir %s '
+                    'env_variables.sh' % self.tmpdir)
         process.run(cmd_line)
 
     def test_datadir_noalias(self):
@@ -175,7 +184,8 @@ class RunnerOperationTest(unittest.TestCase):
 
     def test_runner_tests_fail(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --sysinfo=off --job-results-dir %s passtest failtest passtest' % self.tmpdir
+        cmd_line = ('./scripts/avocado run --sysinfo=off --job-results-dir %s '
+                    'passtest.py failtest.py passtest.py' % self.tmpdir)
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         self.assertEqual(result.exit_status, expected_rc,
@@ -183,7 +193,8 @@ class RunnerOperationTest(unittest.TestCase):
 
     def test_runner_nonexistent_test(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --sysinfo=off --job-results-dir %s bogustest' % self.tmpdir
+        cmd_line = ('./scripts/avocado run --sysinfo=off --job-results-dir '
+                    '%s bogustest' % self.tmpdir)
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_JOB_FAIL
         unexpected_rc = exit_codes.AVOCADO_FAIL
@@ -194,7 +205,8 @@ class RunnerOperationTest(unittest.TestCase):
 
     def test_runner_doublefail(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --sysinfo=off --job-results-dir %s --xunit - doublefail' % self.tmpdir
+        cmd_line = ('./scripts/avocado run --sysinfo=off --job-results-dir %s '
+                    '--xunit - doublefail.py' % self.tmpdir)
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
@@ -212,7 +224,7 @@ class RunnerOperationTest(unittest.TestCase):
     def test_uncaught_exception(self):
         os.chdir(basedir)
         cmd_line = ("./scripts/avocado run --sysinfo=off --job-results-dir %s "
-                    "--json - uncaught_exception" % self.tmpdir)
+                    "--json - uncaught_exception.py" % self.tmpdir)
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         self.assertEqual(result.exit_status, expected_rc,
@@ -223,7 +235,7 @@ class RunnerOperationTest(unittest.TestCase):
     def test_fail_on_exception(self):
         os.chdir(basedir)
         cmd_line = ("./scripts/avocado run --sysinfo=off --job-results-dir %s "
-                    "--json - fail_on_exception" % self.tmpdir)
+                    "--json - fail_on_exception.py" % self.tmpdir)
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         self.assertEqual(result.exit_status, expected_rc,
@@ -233,7 +245,8 @@ class RunnerOperationTest(unittest.TestCase):
 
     def test_runner_timeout(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --sysinfo=off --job-results-dir %s --xunit - timeouttest' % self.tmpdir
+        cmd_line = ('./scripts/avocado run --sysinfo=off --job-results-dir %s '
+                    '--xunit - timeouttest.py' % self.tmpdir)
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout
         expected_rc = exit_codes.AVOCADO_JOB_INTERRUPTED
@@ -249,7 +262,8 @@ class RunnerOperationTest(unittest.TestCase):
 
     def test_runner_abort(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --sysinfo=off --job-results-dir %s --xunit - abort' % self.tmpdir
+        cmd_line = ('./scripts/avocado run --sysinfo=off --job-results-dir %s '
+                    '--xunit - abort.py' % self.tmpdir)
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout
         excerpt = 'Test process aborted'
@@ -263,7 +277,8 @@ class RunnerOperationTest(unittest.TestCase):
 
     def test_silent_output(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado --silent run --sysinfo=off --job-results-dir %s passtest' % self.tmpdir
+        cmd_line = ('./scripts/avocado --silent run --sysinfo=off '
+                    '--job-results-dir %s passtest.py' % self.tmpdir)
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         expected_output = ''
@@ -298,7 +313,8 @@ class RunnerOperationTest(unittest.TestCase):
         self.assertNotIn('Unable to discover url', result.stdout)
 
     def test_invalid_unique_id(self):
-        cmd_line = './scripts/avocado run --sysinfo=off --force-job-id foobar passtest'
+        cmd_line = ('./scripts/avocado run --sysinfo=off --force-job-id foobar'
+                    ' passtest.py')
         result = process.run(cmd_line, ignore_status=True)
         self.assertNotEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
         self.assertIn('needs to be a 40 digit hex', result.stderr)
@@ -306,14 +322,16 @@ class RunnerOperationTest(unittest.TestCase):
 
     def test_valid_unique_id(self):
         cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '
-                    '--force-job-id 975de258ac05ce5e490648dec4753657b7ccc7d1 passtest' % self.tmpdir)
+                    '--force-job-id 975de258ac05ce5e490648dec4753657b7ccc7d1 '
+                    'passtest.py' % self.tmpdir)
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
         self.assertNotIn('needs to be a 40 digit hex', result.stderr)
         self.assertIn('PASS', result.stdout)
 
     def test_automatic_unique_id(self):
-        cmd_line = './scripts/avocado run --job-results-dir %s --sysinfo=off passtest --json -' % self.tmpdir
+        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '
+                    'passtest.py --json -' % self.tmpdir)
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
         r = json.loads(result.stdout)
@@ -323,7 +341,7 @@ class RunnerOperationTest(unittest.TestCase):
     def test_skip_outside_setup(self):
         os.chdir(basedir)
         cmd_line = ("./scripts/avocado run --sysinfo=off --job-results-dir %s "
-                    "--json - skip_outside_setup" % self.tmpdir)
+                    "--json - skip_outside_setup.py" % self.tmpdir)
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         self.assertEqual(result.exit_status, expected_rc,
@@ -351,9 +369,9 @@ class RunnerOperationTest(unittest.TestCase):
 
     def test_dry_run(self):
         os.chdir(basedir)
-        cmd = ("./scripts/avocado run --sysinfo=off passtest failtest "
-               "errortest --json - --mux-inject foo:1 bar:2 baz:3 foo:foo:a "
-               "foo:bar:b foo:baz:c bar:bar:bar --dry-run")
+        cmd = ("./scripts/avocado run --sysinfo=off passtest.py failtest.py "
+               "errortest.py --json - --mux-inject foo:1 bar:2 baz:3 foo:foo:a"
+               " foo:bar:b foo:baz:c bar:bar:bar --dry-run")
         result = json.loads(process.run(cmd).stdout)
         debuglog = result['debuglog']
         log = open(debuglog, 'r').read()
@@ -399,7 +417,8 @@ class RunnerHumanOutputTest(unittest.TestCase):
 
     def test_output_pass(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --sysinfo=off --job-results-dir %s passtest' % self.tmpdir
+        cmd_line = ('./scripts/avocado run --sysinfo=off --job-results-dir %s '
+                    'passtest.py' % self.tmpdir)
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
@@ -409,7 +428,8 @@ class RunnerHumanOutputTest(unittest.TestCase):
 
     def test_output_fail(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --sysinfo=off --job-results-dir %s failtest' % self.tmpdir
+        cmd_line = ('./scripts/avocado run --sysinfo=off --job-results-dir %s '
+                    'failtest.py' % self.tmpdir)
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         self.assertEqual(result.exit_status, expected_rc,
@@ -419,7 +439,8 @@ class RunnerHumanOutputTest(unittest.TestCase):
 
     def test_output_error(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --sysinfo=off --job-results-dir %s errortest' % self.tmpdir
+        cmd_line = ('./scripts/avocado run --sysinfo=off --job-results-dir %s '
+                    'errortest.py' % self.tmpdir)
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         self.assertEqual(result.exit_status, expected_rc,
@@ -429,7 +450,8 @@ class RunnerHumanOutputTest(unittest.TestCase):
 
     def test_output_skip(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --sysinfo=off --job-results-dir %s skiponsetup' % self.tmpdir
+        cmd_line = ('./scripts/avocado run --sysinfo=off --job-results-dir %s '
+                    'skiponsetup.py' % self.tmpdir)
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
@@ -465,7 +487,7 @@ class RunnerHumanOutputTest(unittest.TestCase):
                          '1-_bin_echo -ne foo\\\\n\\\'\\"\\\\nbar_baz')
 
     def test_replay_skip_skipped(self):
-        result = process.run("./scripts/avocado run skiponsetup --json -")
+        result = process.run("./scripts/avocado run skiponsetup.py --json -")
         result = json.loads(result.stdout)
         jobid = result["job_id"]
         process.run(str("./scripts/avocado run --replay %s "
@@ -519,7 +541,7 @@ class RunnerSimpleTest(unittest.TestCase):
         considered to be pretty safe here.
         """
         os.chdir(basedir)
-        one_hundred = 'failtest ' * 100
+        one_hundred = 'failtest.py ' * 100
         cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off'
                     ' %s' % (self.tmpdir, one_hundred))
         initial_time = time.time()
@@ -536,7 +558,8 @@ class RunnerSimpleTest(unittest.TestCase):
         100 failtests and check the test runner timing.
         """
         os.chdir(basedir)
-        sleep_fail_sleep = 'sleeptest ' + 'failtest ' * 100 + 'sleeptest'
+        sleep_fail_sleep = ('sleeptest.py ' + 'failtest.py ' * 100 +
+                            'sleeptest.py')
         cmd_line = './scripts/avocado run --job-results-dir %s --sysinfo=off %s' % (
             self.tmpdir, sleep_fail_sleep)
         initial_time = time.time()
@@ -828,19 +851,19 @@ class PluginsXunitTest(AbsPluginsTest, unittest.TestCase):
                          "XML:\n%s" % xml_output)
 
     def test_xunit_plugin_passtest(self):
-        self.run_and_check('passtest', exit_codes.AVOCADO_ALL_OK,
+        self.run_and_check('passtest.py', exit_codes.AVOCADO_ALL_OK,
                            1, 0, 0, 0, 0)
 
     def test_xunit_plugin_failtest(self):
-        self.run_and_check('failtest', exit_codes.AVOCADO_TESTS_FAIL,
+        self.run_and_check('failtest.py', exit_codes.AVOCADO_TESTS_FAIL,
                            1, 0, 0, 1, 0)
 
     def test_xunit_plugin_skiponsetuptest(self):
-        self.run_and_check('skiponsetup', exit_codes.AVOCADO_ALL_OK,
+        self.run_and_check('skiponsetup.py', exit_codes.AVOCADO_ALL_OK,
                            1, 0, 0, 0, 1)
 
     def test_xunit_plugin_errortest(self):
-        self.run_and_check('errortest', exit_codes.AVOCADO_TESTS_FAIL,
+        self.run_and_check('errortest.py', exit_codes.AVOCADO_TESTS_FAIL,
                            1, 1, 0, 0, 0)
 
     def tearDown(self):
@@ -891,19 +914,19 @@ class PluginsJSONTest(AbsPluginsTest, unittest.TestCase):
         return json_data
 
     def test_json_plugin_passtest(self):
-        self.run_and_check('passtest', exit_codes.AVOCADO_ALL_OK,
+        self.run_and_check('passtest.py', exit_codes.AVOCADO_ALL_OK,
                            1, 0, 0, 0)
 
     def test_json_plugin_failtest(self):
-        self.run_and_check('failtest', exit_codes.AVOCADO_TESTS_FAIL,
+        self.run_and_check('failtest.py', exit_codes.AVOCADO_TESTS_FAIL,
                            1, 0, 1, 0)
 
     def test_json_plugin_skiponsetuptest(self):
-        self.run_and_check('skiponsetup', exit_codes.AVOCADO_ALL_OK,
+        self.run_and_check('skiponsetup.py', exit_codes.AVOCADO_ALL_OK,
                            1, 0, 0, 1)
 
     def test_json_plugin_errortest(self):
-        self.run_and_check('errortest', exit_codes.AVOCADO_TESTS_FAIL,
+        self.run_and_check('errortest.py', exit_codes.AVOCADO_TESTS_FAIL,
                            1, 1, 0, 0)
 
     def test_ugly_echo_cmd(self):

--- a/selftests/functional/test_gdb.py
+++ b/selftests/functional/test_gdb.py
@@ -22,13 +22,15 @@ class GDBPluginTest(unittest.TestCase):
     def test_gdb_prerun_commands(self):
         os.chdir(basedir)
         cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '
-                    '--gdb-prerun-commands=/dev/null passtest' % self.tmpdir)
+                    '--gdb-prerun-commands=/dev/null passtest.py' % self.tmpdir)
         process.run(cmd_line)
 
     def test_gdb_multiple_prerun_commands(self):
         os.chdir(basedir)
-        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off --gdb-prerun-commands=/dev/null '
-                    '--gdb-prerun-commands=foo:/dev/null passtest' % self.tmpdir)
+        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '
+                    '--gdb-prerun-commands=/dev/null '
+                    '--gdb-prerun-commands=foo:/dev/null passtest.py'
+                    % self.tmpdir)
         process.run(cmd_line)
 
     def tearDown(self):

--- a/selftests/functional/test_multiplex.py
+++ b/selftests/functional/test_multiplex.py
@@ -70,26 +70,34 @@ class MultiplexTests(unittest.TestCase):
         self.run_and_check(cmd_line, expected_rc)
 
     def test_run_mplex_passtest(self):
-        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off passtest '
-                    '--multiplex examples/tests/sleeptest.py.data/sleeptest.yaml' % self.tmpdir)
+        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '
+                    'passtest.py --multiplex '
+                    'examples/tests/sleeptest.py.data/sleeptest.yaml'
+                    % self.tmpdir)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.run_and_check(cmd_line, expected_rc)
 
     def test_run_mplex_doublepass(self):
-        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off passtest passtest '
-                    '--multiplex examples/tests/sleeptest.py.data/sleeptest.yaml' % self.tmpdir)
+        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '
+                    'passtest.py passtest.py --multiplex '
+                    'examples/tests/sleeptest.py.data/sleeptest.yaml'
+                    % self.tmpdir)
         self.run_and_check(cmd_line, expected_rc=0)
 
     def test_run_mplex_failtest(self):
-        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off passtest failtest '
-                    '--multiplex examples/tests/sleeptest.py.data/sleeptest.yaml' % self.tmpdir)
+        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '
+                    'passtest.py failtest.py --multiplex '
+                    'examples/tests/sleeptest.py.data/sleeptest.yaml'
+                    % self.tmpdir)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         self.run_and_check(cmd_line, expected_rc)
 
     def test_run_double_mplex(self):
-        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off passtest --multiplex '
+        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '
+                    'passtest.py --multiplex '
                     'examples/tests/sleeptest.py.data/sleeptest.yaml '
-                    'examples/tests/sleeptest.py.data/sleeptest.yaml' % self.tmpdir)
+                    'examples/tests/sleeptest.py.data/sleeptest.yaml'
+                    % self.tmpdir)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.run_and_check(cmd_line, expected_rc)
 

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -34,7 +34,8 @@ class OutputTest(unittest.TestCase):
 
     def test_output_doublefree(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --job-results-dir %s --sysinfo=off doublefree' % self.tmpdir
+        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '
+                    'doublefree.py' % self.tmpdir)
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         output = result.stdout + result.stderr
@@ -71,7 +72,8 @@ class OutputPluginTest(unittest.TestCase):
 
     def test_output_incompatible_setup(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --job-results-dir %s --sysinfo=off --xunit - --json - passtest' % self.tmpdir
+        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '
+                    '--xunit - --json - passtest.py' % self.tmpdir)
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_JOB_FAIL
         output = result.stdout + result.stderr
@@ -85,7 +87,8 @@ class OutputPluginTest(unittest.TestCase):
 
     def test_output_incompatible_setup_2(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --job-results-dir %s --sysinfo=off --html - passtest' % self.tmpdir
+        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '
+                    '--html - passtest.py' % self.tmpdir)
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_JOB_FAIL
         output = result.stdout + result.stderr
@@ -99,7 +102,8 @@ class OutputPluginTest(unittest.TestCase):
     def test_output_compatible_setup(self):
         tmpfile = tempfile.mktemp()
         os.chdir(basedir)
-        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off --journal --xunit %s --json - passtest' %
+        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '
+                    '--journal --xunit %s --json - passtest.py' %
                     (self.tmpdir, tmpfile))
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout + result.stderr
@@ -120,7 +124,8 @@ class OutputPluginTest(unittest.TestCase):
     def test_output_compatible_setup_2(self):
         tmpfile = tempfile.mktemp()
         os.chdir(basedir)
-        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off --xunit - --json %s passtest' %
+        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '
+                    '--xunit - --json %s passtest.py' %
                     (self.tmpdir, tmpfile))
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout + result.stderr
@@ -147,7 +152,8 @@ class OutputPluginTest(unittest.TestCase):
         tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
         tmpfile3 = tempfile.mktemp(dir=tmpdir)
         os.chdir(basedir)
-        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off --xunit %s --json %s --html %s passtest' %
+        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '
+                    '--xunit %s --json %s --html %s passtest.py' %
                     (self.tmpdir, tmpfile, tmpfile2, tmpfile3))
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout + result.stderr
@@ -179,7 +185,8 @@ class OutputPluginTest(unittest.TestCase):
         tmpfile2 = tempfile.mktemp()
         os.chdir(basedir)
         # Verify --silent can be supplied as app argument
-        cmd_line = ('./scripts/avocado --silent run --job-results-dir %s --sysinfo=off --xunit %s --json %s passtest' %
+        cmd_line = ('./scripts/avocado --silent run --job-results-dir %s '
+                    '--sysinfo=off --xunit %s --json %s passtest.py' %
                     (self.tmpdir, tmpfile, tmpfile2))
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout + result.stderr
@@ -223,7 +230,8 @@ class OutputPluginTest(unittest.TestCase):
 
     def test_show_job_log(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --job-results-dir %s --sysinfo=off passtest --show-job-log' % self.tmpdir
+        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '
+                    'passtest.py --show-job-log' % self.tmpdir)
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
@@ -239,7 +247,8 @@ class OutputPluginTest(unittest.TestCase):
     def test_silent_trumps_show_job_log(self):
         os.chdir(basedir)
         # Also verify --silent can be supplied as run option
-        cmd_line = ('./scripts/avocado run --silent --job-results-dir %s --sysinfo=off passtest --show-job-log' %
+        cmd_line = ('./scripts/avocado run --silent --job-results-dir %s '
+                    '--sysinfo=off passtest.py --show-job-log' %
                     self.tmpdir)
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout + result.stderr
@@ -251,7 +260,8 @@ class OutputPluginTest(unittest.TestCase):
 
     def test_default_enabled_plugins(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --job-results-dir %s --sysinfo=off passtest' % self.tmpdir
+        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '
+                    'passtest.py' % self.tmpdir)
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout + result.stderr
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -272,7 +282,8 @@ class OutputPluginTest(unittest.TestCase):
         tmpfile = tempfile.mktemp()
         try:
             os.chdir(basedir)
-            cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off whiteboard --json %s' %
+            cmd_line = ('./scripts/avocado run --job-results-dir %s '
+                        '--sysinfo=off whiteboard.py --json %s' %
                         (self.tmpdir, tmpfile))
             result = process.run(cmd_line, ignore_status=True)
             expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -299,7 +310,7 @@ class OutputPluginTest(unittest.TestCase):
         try:
             os.chdir(basedir)
             cmd_line = ("./scripts/avocado run --job-results-dir %s "
-                        "--sysinfo=off gendata --json %s" %
+                        "--sysinfo=off gendata.py --json %s" %
                         (self.tmpdir, tmpfile))
             result = process.run(cmd_line, ignore_status=True)
             expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -337,7 +348,8 @@ class OutputPluginTest(unittest.TestCase):
         redirected_output_path = tempfile.mktemp()
         try:
             os.chdir(basedir)
-            cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off passtest > %s' %
+            cmd_line = ('./scripts/avocado run --job-results-dir %s '
+                        '--sysinfo=off passtest.py > %s' %
                         (self.tmpdir, redirected_output_path))
             result = process.run(cmd_line, ignore_status=True, shell=True)
             output = result.stdout + result.stderr

--- a/selftests/functional/test_plugin_jobscripts.py
+++ b/selftests/functional/test_plugin_jobscripts.py
@@ -93,7 +93,7 @@ class JobScriptsTest(unittest.TestCase):
         config = script.TemporaryScript("non_zero.conf",
                                         SCRIPT_NON_ZERO_CFG % self.pre_dir)
         with config:
-            cmd = './scripts/avocado --config %s run passtest' % config
+            cmd = './scripts/avocado --config %s run passtest.py' % config
             result = process.run(cmd)
 
         # Pre/Post scripts failures do not (currently?) alter the exit status
@@ -114,7 +114,7 @@ class JobScriptsTest(unittest.TestCase):
         config = script.TemporaryScript("non_existing_dir.conf",
                                         SCRIPT_NON_EXISTING_DIR_CFG % self.pre_dir)
         with config:
-            cmd = './scripts/avocado --config %s run passtest' % config
+            cmd = './scripts/avocado --config %s run passtest.py' % config
             result = process.run(cmd)
 
         # Pre/Post scripts failures do not (currently?) alter the exit status

--- a/selftests/functional/test_replay_basic.py
+++ b/selftests/functional/test_replay_basic.py
@@ -23,7 +23,7 @@ class ReplayTests(unittest.TestCase):
 
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
-        cmd_line = ('./scripts/avocado run passtest '
+        cmd_line = ('./scripts/avocado run passtest.py '
                     '--multiplex '
                     'examples/tests/sleeptest.py.data/sleeptest.yaml '
                     '--job-results-dir %s --sysinfo=off --json -' %

--- a/selftests/functional/test_streams.py
+++ b/selftests/functional/test_streams.py
@@ -52,9 +52,9 @@ class StreamsTest(unittest.TestCase):
         variable `AVOCADO_LOG_EARLY` being set.
         """
         cmds = (('./scripts/avocado --show early run --sysinfo=off '
-                 '--job-results-dir %s passtest' % self.tmpdir, {}),
+                 '--job-results-dir %s passtest.py' % self.tmpdir, {}),
                 ('./scripts/avocado run --sysinfo=off --job-results-dir'
-                 ' %s passtest' % self.tmpdir, {'AVOCADO_LOG_EARLY': 'y'}))
+                 ' %s passtest.py' % self.tmpdir, {'AVOCADO_LOG_EARLY': 'y'}))
         for cmd, env in cmds:
             result = process.run(cmd, env=env, shell=True)
             self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
@@ -71,9 +71,9 @@ class StreamsTest(unittest.TestCase):
         Also checks the symmetry between `--show test` and `--show-job-log`
         """
         for cmd in (('./scripts/avocado --show test run --sysinfo=off '
-                     '--job-results-dir %s passtest' % self.tmpdir),
+                     '--job-results-dir %s passtest.py' % self.tmpdir),
                     ('./scripts/avocado run --show-job-log --sysinfo=off '
-                     '--job-results-dir %s passtest' % self.tmpdir)):
+                     '--job-results-dir %s passtest.py' % self.tmpdir)):
             result = process.run(cmd)
             self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
             self.assertNotIn("stevedore.extension: found extension EntryPoint.parse",
@@ -94,9 +94,9 @@ class StreamsTest(unittest.TestCase):
         Also checks the symmetry between `--show none` and `--silent`
         """
         for cmd in (('./scripts/avocado --show none run --sysinfo=off '
-                     '--job-results-dir %s passtest' % self.tmpdir),
+                     '--job-results-dir %s passtest.py' % self.tmpdir),
                     ('./scripts/avocado --silent run --sysinfo=off '
-                     '--job-results-dir %s passtest' % self.tmpdir)):
+                     '--job-results-dir %s passtest.py' % self.tmpdir)):
             result = process.run(cmd)
             self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
             self.assertEqual('', result.stdout)

--- a/selftests/functional/test_sysinfo.py
+++ b/selftests/functional/test_sysinfo.py
@@ -23,7 +23,8 @@ class SysInfoTest(unittest.TestCase):
 
     def test_sysinfo_enabled(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --job-results-dir %s --sysinfo=on passtest' % self.tmpdir
+        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=on '
+                    'passtest.py' % self.tmpdir)
         result = process.run(cmd_line)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
@@ -48,7 +49,8 @@ class SysInfoTest(unittest.TestCase):
 
     def test_sysinfo_disabled(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --job-results-dir %s --sysinfo=off passtest' % self.tmpdir
+        cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '
+                    'passtest.py' % self.tmpdir)
         result = process.run(cmd_line)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,


### PR DESCRIPTION
This patch fixes and improves resolving of the test aliases (paths
relative to `data_dir.get_tests_dir`).

1. It removes the magic `.py` suffix, which prevented non-python files
   from being resolved (simple.sh was resolved to $tests/simple.sh.py)
2. It adds the feature to filter the class/method from the test
   reference by parsing $test_reference:$class.$method for implicit
   resolver. (previously this worked only for absolute path resolver)

Visible changes are:

* `avocado run passtest` => fails (used to work)
* `avocado run passtest.py` => works (did not work)
* `avocado run env_variables.sh` => works (did not work)
* `avocado run passtest.py:PassTest.test` => works (did not work)

Trello: https://trello.com/c/jPpRVdBG/644-remove-the-py-detection-in-loaders