### PR TITLE
avocado.core.remoter: Update the password argument on env update

### DIFF
--- a/avocado/core/remoter.py
+++ b/avocado/core/remoter.py
@@ -153,6 +153,7 @@ def _update_fabric_env(method):
         fabric.api.env.update(host_string=args[0].hostname,
                               user=args[0].username,
                               key_filename=args[0].key_filename,
+                              password=args[0].password,
                               port=args[0].port)
         return method(*args, **kwargs)
     return wrapper


### PR DESCRIPTION
The function _update_fabric_env updates only hostname, username,
key_file and port, but some users might use password. Let's update it as
well.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>