### PR TITLE
REMOVEME: Demonstration on how to support ugly tests for now

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -142,12 +142,16 @@ class Test(unittest.TestCase):
 
         _incorrect_name = None
         if isinstance(name, basestring):    # TODO: Remove in release 0.37
+            import random
             _incorrect_name = True
-            self.name = TestName(0, name)
+            self.name = TestName(random.randrange(9999), name)
         elif name is not None:
             self.name = name
         else:
-            self.name = TestName(0, self.__class__.__name__)
+            import random
+            _incorrect_name = True
+            self.name = TestName(random.randrange(9999),
+                                 self.__class__.__name__)
 
         self.tag = tag
         self.job = job

--- a/examples/tests/passtest.py
+++ b/examples/tests/passtest.py
@@ -9,6 +9,9 @@ class PassTest(Test):
     """
     Example test that passes.
     """
+    def __init__(self, *args, **kwargs):
+        kwargs["name"] = "ugly test name"
+        super(PassTest, self).__init__(*args, **kwargs)
 
     def test(self):
         """


### PR DESCRIPTION
Instead of hardcoding the serial id 0, we can use random number to
minimize the possible clashes. Check it out on modified passtest:

    avocado run passtest passtest passtest passtest

should execute 4 tests and in most cases it should not fail.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>