### PR TITLE
fix crash on broken pipe

### DIFF
--- a/avocado/core/app.py
+++ b/avocado/core/app.py
@@ -38,6 +38,7 @@ class AvocadoApp(object):
         os.environ['LIBC_FATAL_STDERR_'] = '1'
 
         signal.signal(signal.SIGTSTP, signal.SIG_IGN)   # ignore ctrl+z
+        signal.signal(signal.SIGPIPE, signal.SIG_DFL)
         self.parser = Parser()
         output.early_start()
         initialized = False


### PR DESCRIPTION
Python ignores SIGPIPE on startup, because it prefers to check every
write and raise an IOError exception rather than taking the signal.

This patch changes SIGPIPE back to its default action in order to
behave correctly.

Reference: https://trello.com/c/ysKxcHEa
Signed-off-by: Amador Pahim <apahim@redhat.com>