### PR TITLE
Added base_utils.py which has two generic methods

### DIFF
--- a/avocado/utils/kernel.py
+++ b/avocado/utils/kernel.py
@@ -13,11 +13,13 @@
 #
 # Copyright: Red Hat Inc. 2014
 # Author: Ruda Moura <rmoura@redhat.com>
+# Author: Santhosh G <santhog4@linux.vnet.ibm.com>
 
 import os
 import shutil
 import logging
 import tempfile
+from distutils.version import LooseVersion
 
 from . import download, archive, build
 
@@ -100,3 +102,15 @@ class KernelBuild(object):
 
     def __del__(self):
         shutil.rmtree(self.work_dir)
+
+
+def check_version(version):
+    """
+    This utility function compares the current kernel version with
+    the version parameter and gives assertion error if the version
+    parameter is greater.
+
+    :type version: string
+    :param version: version to be compared with current kernel version
+    """
+    assert LooseVersion(os.uname()[2]) > LooseVersion(version), "Old kernel"

--- a/examples/tests/linuxbuild.py
+++ b/examples/tests/linuxbuild.py
@@ -2,7 +2,7 @@
 
 from avocado import Test
 from avocado import main
-from avocado.utils import kernel_build
+from avocado.utils import kernel
 
 
 class LinuxBuildTest(Test):
@@ -20,9 +20,9 @@ class LinuxBuildTest(Test):
         if linux_config is not None:
             linux_config = os.path.join(self.datadir, linux_config)
 
-        self.linux_build = kernel_build.KernelBuild(kernel_version,
-                                                    linux_config,
-                                                    self.srcdir)
+        self.linux_build = kernel.KernelBuild(kernel_version,
+                                              linux_config,
+                                              self.srcdir)
         self.linux_build.download()
         self.linux_build.uncompress()
         self.linux_build.configure()


### PR DESCRIPTION
I Have added two methods in the file in utils/base_utils.py.
These two methods are generic and can be used by the upcoming tests as well. Currently, these methods are required for me to implement libhugetlbfs tests as mentioned in the issue - 'https://github.com/avocado-framework/avocado-misc-tests/issues/11'