### PR TITLE
avocado: Avoid custom handling of SIGINT and SIGUSR

### DIFF
--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -37,6 +37,7 @@ from ..utils import runtime
 from ..utils import process
 
 TEST_LOG = logging.getLogger("avocado.test")
+APP_LOG = logging.getLogger("avocado.app")
 
 
 class TestStatus(object):
@@ -68,9 +69,8 @@ class TestStatus(object):
         # Let's catch all exceptions, since errors here mean a
         # crash in avocado.
         except Exception as details:
-            log = logging.getLogger("avocado.app")
-            log.error("\nError receiving message from test: %s -> %s",
-                      details.__class__, details)
+            APP_LOG.error("\nError receiving message from test: %s -> %s",
+                          details.__class__, details)
             stacktrace.log_exc_info(sys.exc_info(),
                                     'avocado.app.tracebacks')
             return None
@@ -222,10 +222,10 @@ class TestRunner(object):
         """
         signal.signal(signal.SIGTSTP, signal.SIG_IGN)
         logger_list_stdout = [logging.getLogger('avocado.test.stdout'),
-                              logging.getLogger('avocado.test'),
+                              TEST_LOG,
                               logging.getLogger('paramiko')]
         logger_list_stderr = [logging.getLogger('avocado.test.stderr'),
-                              logging.getLogger('avocado.test'),
+                              TEST_LOG,
                               logging.getLogger('paramiko')]
         sys.stdout = output.LoggingFile(logger=logger_list_stdout)
         sys.stderr = output.LoggingFile(logger=logger_list_stderr)
@@ -290,15 +290,13 @@ class TestRunner(object):
             with sigtstp:
                 msg = "ctrl+z pressed, %%s test (%s)" % proc.pid
                 if self.sigstopped:
-                    logging.getLogger("avocado.app").info("\n" + msg,
-                                                          "resumming")
-                    logging.getLogger("avocado.test").info(msg, "resumming")
+                    APP_LOG.info("\n" + msg, "resumming")
+                    TEST_LOG.info(msg, "resumming")
                     process.kill_process_tree(proc.pid, signal.SIGCONT, False)
                     self.sigstopped = False
                 else:
-                    logging.getLogger("avocado.app").info("\n" + msg,
-                                                          "stopping")
-                    logging.getLogger("avocado.test").info(msg, "stopping")
+                    APP_LOG.info("\n" + msg, "stopping")
+                    TEST_LOG.info(msg, "stopping")
                     process.kill_process_tree(proc.pid, signal.SIGSTOP, False)
                     self.sigstopped = True
 

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -238,17 +238,6 @@ class TestRunner(object):
         early_state['early_status'] = True
         queue.put(early_state)
 
-        def timeout_handler(signum, frame):
-            e_msg = "Timeout reached waiting for %s to end" % instance
-            raise exceptions.TestTimeoutInterrupted(e_msg)
-
-        def interrupt_handler(signum, frame):
-            e_msg = "Test %s interrupted by user" % instance
-            raise exceptions.TestInterruptedError(e_msg)
-
-        signal.signal(signal.SIGUSR1, timeout_handler)
-        signal.signal(signal.SIGINT, interrupt_handler)
-
         self.result.start_test(early_state)
         try:
             instance.run_avocado()
@@ -300,7 +289,12 @@ class TestRunner(object):
                     process.kill_process_tree(proc.pid, signal.SIGSTOP, False)
                     self.sigstopped = True
 
+        def sigterm_handler(signum, frame):     # pylint: disable=W0613
+            """ Produce traceback on SIGTERM """
+            raise SystemExit("Test interrupted by SIGTERM")
+
         signal.signal(signal.SIGTSTP, sigtstp_handler)
+        signal.signal(signal.SIGTERM, sigterm_handler)
 
         proc = multiprocessing.Process(target=self._run_test,
                                        args=(test_factory, queue,))
@@ -330,12 +324,14 @@ class TestRunner(object):
         stage_2_msg_displayed = False
         first = 0.01
         step = 0.1
+        abort_reason = None
 
         while True:
             try:
                 if time.time() >= deadline:
+                    abort_reason = "Timeout reached"
                     try:
-                        os.kill(proc.pid, signal.SIGUSR1)
+                        os.kill(proc.pid, signal.SIGTERM)
                     except OSError:
                         pass
                     break
@@ -357,6 +353,7 @@ class TestRunner(object):
                 ctrl_c_count += 1
                 if ctrl_c_count == 1:
                     if not stage_1_msg_displayed:
+                        abort_reason = "Interrupted by ctrl+c"
                         self.job.log.debug("\nInterrupt requested. Waiting %d "
                                            "seconds for test to finish "
                                            "(ignoring new Ctrl+C until then)",
@@ -365,6 +362,7 @@ class TestRunner(object):
                     ignore_time_started = time.time()
                 if (ctrl_c_count > 1) and (time_elapsed > ignore_window):
                     if not stage_2_msg_displayed:
+                        abort_reason = "Interrupted by ctrl+c (multiple-times)"
                         self.job.log.debug("Killing test subprocess %s",
                                            proc.pid)
                         stage_2_msg_displayed = True
@@ -376,6 +374,20 @@ class TestRunner(object):
         else:
             test_state = test_status.abort(proc, time_started, cycle_timeout,
                                            first, step)
+
+        # Try to log the timeout reason to test's results and update test_state
+        if abort_reason:
+            TEST_LOG.error(abort_reason)
+            test_log = test_state.get("logfile")
+            if test_log:
+                open(test_log, "a").write("\nRUNNER: " + abort_reason + "\n")
+            if test_state.get("text_output"):
+                test_state["text_output"] += "\nRUNNER: " + abort_reason + "\n"
+            else:
+                test_state["text_output"] = abort_reason
+            test_state["status"] = "INTERRUPTED"
+            test_state["fail_reason"] = abort_reason
+            test_state["fail_class"] = "RUNNER"
 
         # don't process other tests from the list
         if ctrl_c_count > 0:

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -242,8 +242,8 @@ class RunnerOperationTest(unittest.TestCase):
                             "Avocado crashed (rc %d):\n%s" % (unexpected_rc, result))
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %d:\n%s" % (expected_rc, result))
-        self.assertIn("TestTimeoutInterrupted: Timeout reached waiting for", output,
-                      "Test did not fail with timeout exception:\n%s" % output)
+        self.assertIn("RUNNER: Timeout reached", output,
+                      "Timeout reached message not found in the output:\n%s" % output)
         # Ensure no test aborted error messages show up
         self.assertNotIn("TestAbortedError: Test aborted unexpectedly", output)
 
@@ -607,7 +607,7 @@ class RunnerSimpleTest(unittest.TestCase):
                       "stopped.")
         self.assertIn("TIME", output, "TIME not in the output, avocado "
                       "probably died unexpectadly")
-        self.assertEqual(proc.get_status(), 1, "Avocado did not finish with "
+        self.assertEqual(proc.get_status(), 8, "Avocado did not finish with "
                          "1.")
 
     def tearDown(self):


### PR DESCRIPTION
Currently avocado adds custom handlers of SIGINT and SIGUSR1 in order to
produce traceback and notify about user interaction or timeout. This
could be missleading in case the test uses those signals and potentially
dangerous as some tests assume default behavior.

This patch removes the custom handling of SIGINT and SIGUSR1 and
reports the failure in `job.log`. Additionally it tries to inject the
error message in the test output, if status.logfile available.

In order to keep the useful traceback in case of interruption, this
patch overrides the default SIGTERM handler. The default behavior of
SIGTERM is to die, our custom handler raises SystemExit with info saying
the test was interrupted by sigterm, which should generate traceback and
finish. The runner then changes the result to INTERRUPTED, so even
when the test modifies the SIGTERM handler, we get the correct status.

Worth mentioning that in case test ignores SIGTERM, SIGKILL is emitted
by the runner, so this should be safe approach.

trello: https://trello.com/c/iYRNmjrg/571-bug-avocado-custom-signal-handling-interferes-with-tests