### PR TITLE
Fix travis build for python2.6

### DIFF
--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,5 +1,5 @@
 # All pip installable requirements pinned for Travis CI
-fabric==1.10.0
+fabric==1.11.1
 pystache==0.4.1; python_version < '2.7'
 pystache==0.5.4; python_version >= '2.7'
 Sphinx==1.3b1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Avocado functional requirements
 # SSH lib (avocado.utils.remote)
-fabric>=1.7.0
+fabric>=1.11.0
 # multiplexer (avocado.core.tree)
 PyYAML>=3.11
 # vm plugin (avocado.core.plugins.vm)


### PR DESCRIPTION
Fabric 1.10.0 has a dependency issue. This patch changes
the fabric version to the highest available
version right now.