### PR TITLE
enable travis build for 36lts branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
 branches:
     only:
         - master
+        - 36lts
 
 cache:
     directories:


### PR DESCRIPTION
Travis will clone the repo and then fetch the pull-request, regardless
the branch it's coming from. That's why a PR has to contain the correct
parenting. But the build will happen only if the PR is proposed to an
enabled branch. That's what this PR enables.