### PR TITLE
[36lts] enable travis build for 36lts branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
 branches:
     only:
         - master
+        - 36lts
 
 cache:
     directories:
@@ -35,9 +36,8 @@ script:
         done
         # Run the "make check" per each commit origin..HEAD
         ERR=""
-        MASTER=$(git rev-parse origin/master)
-        echo Master is $MASTER
-        for COMMIT in $(git rev-list origin..HEAD | tail -n+2); do
+        echo Branch is $TRAVIS_BRANCH
+        for COMMIT in $TRAVIS_COMMIT_RANGE; do
             echo
             echo "--------------------< $(git log -1 --oneline $COMMIT) >--------------------"
             echo


### PR DESCRIPTION
Travis will clone the repo and then fetch the pull-request, regardless
the branch it's coming from. That's why a PR has to contain the correct
parenting. But the build will happen only if the PR is proposed to an
enabled branch. This patch enables travis for 36lts branch.