### PR TITLE
Revert "enable travis build for 36lts branch"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ python:
 branches:
     only:
         - master
-        - 36lts
 
 cache:
     directories:


### PR DESCRIPTION
This reverts commit a42eaf40a9f10dc22ba2cdc0ac697fefe9eac22a.
Seems like each branch needs a different .travis.yaml file.