### PR TITLE
configure travis to the branch independent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,11 +34,10 @@ script:
         for FILE in scripts/*; do
             rm $BINDIR/$(basename $FILE)
         done
-        # Run the "make check" per each commit origin..HEAD
+        # Run the "make check" per each commit in PR (TRAVIS_COMMIT_RANGE)
         ERR=""
-        MASTER=$(git rev-parse origin/master)
-        echo Master is $MASTER
-        for COMMIT in $(git rev-list origin..HEAD | tail -n+2); do
+        echo Branch is $TRAVIS_BRANCH
+        for COMMIT in $(git rev-list $TRAVIS_COMMIT_RANGE); do
             echo
             echo "--------------------< $(git log -1 --oneline $COMMIT) >--------------------"
             echo


### PR DESCRIPTION
Currently we have a travis script to run make check with every
commit on the PR. But the script is hard coded to get the commit
list using the branch master as reference.

This commit uses travis env variables to make the script branch
independent, so we can have the same .travis.yaml file for every
branch we create (LTS branches for instance).

Signed-off-by: Amador Pahim <apahim@redhat.com>