### PR TITLE
travis: Run the per-commit check only for ascendant commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script:
         # Run the "make check" per each commit in PR (TRAVIS_COMMIT_RANGE)
         ERR=""
         echo Branch is $TRAVIS_BRANCH
-        for COMMIT in $(git rev-list $TRAVIS_COMMIT_RANGE); do
+        for COMMIT in $(git rev-list $TRAVIS_COMMIT_RANGE~1); do
             echo
             echo "--------------------< $(git log -1 --oneline $COMMIT) >--------------------"
             echo


### PR DESCRIPTION
The first commit is checked by the main check, don't re-check it with
the per-commit check.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>