### PR TITLE
HTML report: make sysinfo section aware of pre/post/profile

### DIFF
--- a/avocado/core/html.py
+++ b/avocado/core/html.py
@@ -115,7 +115,7 @@ class ReportModel(object):
         return sysinfo_contents
 
     def hostname(self):
-        return self._get_sysinfo('hostname')
+        return self._get_sysinfo('hostname').strip()
 
     @property
     def tests(self):

--- a/avocado/core/html.py
+++ b/avocado/core/html.py
@@ -153,10 +153,14 @@ class ReportModel(object):
                                      t['fail_reason'][:exhibition_limit]))
         return test_info
 
-    def sysinfo(self):
+    def _sysinfo_phase(self, phase):
+        """
+        Returns a list of system information for a given sysinfo phase
+
+        :param section: a valid sysinfo phase, such as pre, post or profile
+        """
         sysinfo_list = []
-        base_path = os.path.join(self.results_dir(False),
-                                 'sysinfo', 'pre')
+        base_path = os.path.join(self.results_dir(False), 'sysinfo', phase)
         try:
             sysinfo_files = os.listdir(base_path)
         except OSError:
@@ -170,14 +174,23 @@ class ReportModel(object):
                 with codecs.open(sysinfo_path, 'r', encoding="utf-8") as sysinfo_file:
                     sysinfo_dict['file'] = " ".join(s_f.split("_"))
                     sysinfo_dict['contents'] = sysinfo_file.read()
-                    sysinfo_dict['element_id'] = 'heading_%s' % s_id
-                    sysinfo_dict['collapse_id'] = 'collapse_%s' % s_id
+                    sysinfo_dict['element_id'] = '%s_heading_%s' % (phase, s_id)
+                    sysinfo_dict['collapse_id'] = '%s_collapse_%s' % (phase, s_id)
             except OSError:
                 sysinfo_dict[s_f] = ('Error reading sysinfo file %s' %
                                      sysinfo_path)
             sysinfo_list.append(sysinfo_dict)
             s_id += 1
         return sysinfo_list
+
+    def sysinfo_pre(self):
+        return self._sysinfo_phase('pre')
+
+    def sysinfo_profile(self):
+        return self._sysinfo_phase('profile')
+
+    def sysinfo_post(self):
+        return self._sysinfo_phase('post')
 
 
 class HTMLTestResult(TestResult):

--- a/avocado/core/resources/htmlresult/templates/report.mustache
+++ b/avocado/core/resources/htmlresult/templates/report.mustache
@@ -77,31 +77,101 @@
             {{/tests}}
             </table>
 
-                <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
-                    <div class="panel panel-default">
-                        <div class="panel-heading" role="tab" id="headingOne">
-                            <h4 class="panel-title"><a data-toggle="collapse" data-parent="#accordion" href="#collapseOne" aria-expanded="false" aria-controls="collapseOne"> Sysinfo (pre job, click to expand) </a></h4>
-                        </div>
-                        <div id="collapseOne" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingOne">
-                            <div class="panel-body">
-                                <div class="panel-group" id="accordion2" role="tablist" aria-multiselectable="true">
-                                {{#sysinfo}}
-                                    <div class="panel panel-default">
-                                        <div class="panel-heading" role="tab" id="{{element_id}}">
-                                            <h4 class="panel-title"><a data-toggle="collapse" data-parent="#accordion2" href="#{{collapse_id}}" aria-expanded="false" aria-controls="{{collapse_id}}"><tt>{{file}}</tt></a></h4>
-                                        </div>
-                                        <div id="{{collapse_id}}" class="panel-collapse collapse" role="tabpanel" aria-labelledby="{{element_id}}">
-                                            <div class="panel-body">
-                                                <pre>{{contents}}</pre>
+            <!-- Sysinfo start -->
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <h3 class="panel-title">Sysinfo</h3>
+                </div>
+                <div class="panel-body">
+
+                    <!-- Pre-Tests start -->
+                    <div class="panel-group" id="accordionPre" role="tablist" aria-multiselectable="true">
+                        <div class="panel panel-default">
+                            <div class="panel-heading" role="tab" id="headingPre">
+                                <h4 class="panel-title"><a data-toggle="collapse" data-parent="#accordionPre" href="#collapsePre" aria-expanded="false" aria-controls="collapsePre"> Pre-Tests </a></h4>
+                            </div>
+                            <div id="collapsePre" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingPre">
+                                <div class="panel-body">
+                                    <div class="panel-group" id="accordionPre2" role="tablist" aria-multiselectable="true">
+                                        {{#sysinfo_pre}}
+                                        <div class="panel panel-default">
+                                            <div class="panel-heading" role="tab" id="{{element_id}}">
+                                                <h4 class="panel-title"><a data-toggle="collapse" data-parent="#accordionPre2" href="#{{collapse_id}}" aria-expanded="false" aria-controls="{{collapse_id}}"><tt>{{file}}</tt></a></h4>
+                                            </div>
+                                            <div id="{{collapse_id}}" class="panel-collapse collapse" role="tabpanel" aria-labelledby="{{element_id}}">
+                                                <div class="panel-body">
+                                                    <pre>{{contents}}</pre>
+                                                </div>
                                             </div>
                                         </div>
+                                        {{/sysinfo_pre}}
                                     </div>
-                                {{/sysinfo}}
                                 </div>
                             </div>
                         </div>
                     </div>
+                    <!-- Pre-Tests end -->
+
+                    <!-- Post-Tests start -->
+                    <div class="panel-group" id="accordionPost" role="tablist" aria-multiselectable="true">
+                        <div class="panel panel-default">
+                            <div class="panel-heading" role="tab" id="headingPost">
+                                <h4 class="panel-title"><a data-toggle="collapse" data-parent="#accordionPost" href="#collapsePost" aria-expanded="false" aria-controls="collapsePost"> Post-Tests </a></h4>
+                            </div>
+                            <div id="collapsePost" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingPost">
+                                <div class="panel-body">
+                                    <div class="panel-group" id="accordionPost2" role="tablist" aria-multiselectable="true">
+                                        {{#sysinfo_post}}
+                                        <div class="panel panel-default">
+                                            <div class="panel-heading" role="tab" id="{{element_id}}">
+                                                <h4 class="panel-title"><a data-toggle="collapse" data-parent="#accordionPost2" href="#{{collapse_id}}" aria-expanded="false" aria-controls="{{collapse_id}}"><tt>{{file}}</tt></a></h4>
+                                            </div>
+                                            <div id="{{collapse_id}}" class="panel-collapse collapse" role="tabpanel" aria-labelledby="{{element_id}}">
+                                                <div class="panel-body">
+                                                    <pre>{{contents}}</pre>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        {{/sysinfo_post}}
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <!-- Post-Tests end -->
+
+                    <!-- Profilers start -->
+                    <div class="panel-group" id="accordionProfile" role="tablist" aria-multiselectable="true">
+                        <div class="panel panel-default">
+                            <div class="panel-heading" role="tab" id="headingProfile">
+                                <h4 class="panel-title"><a data-toggle="collapse" data-parent="#accordionProfile" href="#collapseProfile" aria-expanded="false" aria-controls="collapseProfile"> Profilers </a></h4>
+                            </div>
+                            <div id="collapseProfile" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingProfile">
+                                <div class="panel-body">
+                                    <div class="panel-group" id="accordionProfile2" role="tablist" aria-multiselectable="true">
+                                        {{#sysinfo_profile}}
+                                        <div class="panel panel-default">
+                                            <div class="panel-heading" role="tab" id="{{element_id}}">
+                                                <h4 class="panel-title"><a data-toggle="collapse" data-parent="#accordionProfile2" href="#{{collapse_id}}" aria-expanded="false" aria-controls="{{collapse_id}}"><tt>{{file}}</tt></a></h4>
+                                            </div>
+                                            <div id="{{collapse_id}}" class="panel-collapse collapse" role="tabpanel" aria-labelledby="{{element_id}}">
+                                                <div class="panel-body">
+                                                    <pre>{{contents}}</pre>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        {{/sysinfo_profile}}
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <!-- Profilers end -->
+
                 </div>
+            </div>
+            <!-- Sysinfo end -->
+
         </div>
         <script type="text/javascript">
             $('#results')

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -466,9 +466,9 @@ class TestRunner(object):
             TEST_LOG.error('Job interrupted by ctrl+c.')
             summary.add('INTERRUPTED')
 
-        self.result.end_tests()
-        self.job.funcatexit.run()
         if self.job.sysinfo is not None:
             self.job.sysinfo.end_job_hook()
+        self.result.end_tests()
+        self.job.funcatexit.run()
         signal.signal(signal.SIGTSTP, signal.SIG_IGN)
         return summary


### PR DESCRIPTION
Currently the sysinfo info on the HTML report only shows the pre-testp hase of sysinfo.  It should really include all three phases.
    
Reference: https://trello.com/c/sXZQTfta