### PR TITLE
utils.process: Do not terminate the process

### DIFF
--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -545,7 +545,9 @@ class SubProcess(object):
 
         :param timeout: Time (seconds) we'll wait until the process is
                         finished. If it's not, we'll try to terminate it
-                        and get a status.
+                        and get a status. If time is negative, we'll directly
+                        return the result attr, instead of waiting for the
+                        process to end.
         :type timeout: float
         :param sig: Signal to send to the process in case it did not end after
                     the specified timeout.
@@ -558,6 +560,9 @@ class SubProcess(object):
 
         if timeout is None:
             self.wait()
+
+        if timeout < 0.0:
+            return self.result
 
         if timeout > 0.0:
             while time.time() - start_time < timeout:


### PR DESCRIPTION
Currently the run funtion always waits for the subprocess to end or
terminate the subprocess, then return. But there is a need to only
create the subprocess and simply return. The subprocess status can be
handled later. This will make the caller of run function continue other
processing logic, instead of being blocked.

Signed-off-by: Dan Zheng <dzheng@redhat.com>