### PR TITLE
Test ids docs2

### DIFF
--- a/avocado/core/result.py
+++ b/avocado/core/result.py
@@ -256,8 +256,11 @@ class HumanTestResult(TestResult):
                    'SKIP': output.TERM_SUPPORT.SKIP,
                    'WARN': output.TERM_SUPPORT.WARN,
                    'INTERRUPTED': output.TERM_SUPPORT.INTERRUPT}
+        duration = (" (%.2f s)" % state.get('time_elapsed', -1)
+                    if status != "SKIP"
+                    else "")
         self.log.debug(output.TERM_SUPPORT.MOVE_BACK + mapping[status] +
-                       status + output.TERM_SUPPORT.ENDC)
+                       status + output.TERM_SUPPORT.ENDC + duration)
 
     def notify_progress(self, progress=False):
         if progress:

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -46,8 +46,9 @@ class Run(CLICmd):
         """
         parser = super(Run, self).configure(parser)
 
-        parser.add_argument('url', type=str, default=[], nargs='*',
-                            help='List of test IDs (aliases or paths)')
+        parser.add_argument("url", type=str, default=[], nargs='*',
+                            metavar="TEST_REFERENCE",
+                            help='List of test references (aliases or paths)')
 
         parser.add_argument("-d", "--dry-run", action="store_true",
                             help="Instead of running the test only "

--- a/docs/source/GetStartedGuide.rst
+++ b/docs/source/GetStartedGuide.rst
@@ -260,9 +260,11 @@ Debugging tests
 When developing new tests, you frequently want to look straight at the
 job log, without switching screens or having to "tail" the job log.
 
-In order to do that, you can use ``--show-job-log`` option::
+In order to do that, you can use ``avocado --show test run ...`` or
+``avocado run --show-job-log ...`` options::
 
-    $ avocado run examples/tests/sleeptest --show-job-log
+    $ avocado --show test run examples/tests/sleeptest
+    ...
     Job ID: f9ea1742134e5352dec82335af584d1f151d4b85
 
     START examples/tests/sleeptest.py

--- a/docs/source/GetStartedGuide.rst
+++ b/docs/source/GetStartedGuide.rst
@@ -70,7 +70,9 @@ line tool that will conveniently run your tests and collect their results.
 Running Tests
 -------------
 
-To do so, please run ``avocado`` with the ``run`` sub-command and the chosen test::
+To do so, please run ``avocado`` with the ``run`` sub-command followed by
+a test reference, which could be either a path to the file, or a
+recognizable name::
 
     $ avocado run /bin/true
     JOB ID    : 381b849a62784228d2fd208d929cc49f310412dc
@@ -176,19 +178,20 @@ Running A More Complex Test Job
 You can run any number of test in an arbitrary order, as well as mix and match
 instrumented and simple tests::
 
-    $ avocado run failtest sleeptest synctest failtest synctest /tmp/simple_test.sh
+    $ avocado run failtest.py sleeptest.py synctest.py failtest.py synctest.py /tmp/simple_test.sh
     JOB ID    : 86911e49b5f2c36caeea41307cee4fecdcdfa121
     JOB LOG   : $HOME/avocado/job-results/job-2014-08-12T15.42-86911e49/job.log
     TESTS     : 6
-     (1/6) failtest.1: FAIL (0.00 s)
-     (2/6) sleeptest.1: PASS (1.00 s)
-     (3/6) synctest.1: ERROR (0.01 s)
-     (4/6) failtest.2: FAIL (0.00 s)
-     (5/6) synctest.2: ERROR (0.01 s)
+     (1/6) failtest.py:FailTest.test: FAIL (0.00 s)
+     (2/6) sleeptest.py:SleepTest.test: PASS (1.00 s)
+     (3/6) synctest.py:SyncTest.test: PASS (2.43 s)
+     (4/6) failtest.py:FailTest.test: FAIL (0.00 s)
+     (5/6) synctest.py:SyncTest.test: PASS (2.44 s)
+     (6/6) /bin/true: PASS (0.00 s)
      (6/6) /tmp/simple_test.sh.1: PASS (0.02 s)
     RESULTS    : PASS 2 | ERROR 2 | FAIL 2 | SKIP 0 | WARN 0 | INTERRUPT 0
     JOB HTML  : $HOME/avocado/job-results/job-2014-08-12T15.42-86911e49/html/results.html
-    TIME      : 1.04 s
+    TIME      : 5.88 s
 
 .. _running-external-runner:
 
@@ -226,11 +229,11 @@ files with shell code could be considered tests::
     $ avocado run --external-runner=/bin/sh /tmp/pass /tmp/fail
     JOB ID     : 4a2a1d259690cc7b226e33facdde4f628ab30741
     JOB LOG    : /home/<user>/avocado/job-results/job-<date>-<shortid>/job.log
-    JOB HTML   : /home/<user>/avocado/job-results/job-<date>-<shortid>/html/results.html
     TESTS      : 2
     (1/2) /tmp/pass: PASS (0.01 s)
     (2/2) /tmp/fail: FAIL (0.01 s)
     RESULTS    : PASS 1 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0
+    JOB HTML   : /home/<user>/avocado/job-results/job-<date>-<shortid>/html/results.html
     TIME       : 0.01 s
 
 This example is pretty obvious, and could be achieved by giving
@@ -244,11 +247,11 @@ But now consider the following example::
                                            http://remote-avocado-server:9405/jobs/
     JOB ID     : 56016a1ffffaba02492fdbd5662ac0b958f51e11
     JOB LOG    : /home/<user>/avocado/job-results/job-<date>-<shortid>/job.log
-    JOB HTML   : /home/<user>/avocado/job-results/job-<date>-<shortid>/html/results.html
     TESTS      : 2
     (1/2) http://local-avocado-server:9405/jobs/: PASS (0.02 s)
     (2/2) http://remote-avocado-server:9405/jobs/: FAIL (3.02 s)
     RESULTS    : PASS 1 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0
+    JOB HTML   : /home/<user>/avocado/job-results/job-<date>-<shortid>/html/results.html
     TIME       : 3.04 s
 
 This effectively makes `/bin/curl` an "external test runner", responsible for
@@ -263,16 +266,16 @@ job log, without switching screens or having to "tail" the job log.
 In order to do that, you can use ``avocado --show test run ...`` or
 ``avocado run --show-job-log ...`` options::
 
-    $ avocado --show test run examples/tests/sleeptest
+    $ avocado --show test run examples/tests/sleeptest.py
     ...
     Job ID: f9ea1742134e5352dec82335af584d1f151d4b85
 
-    START examples/tests/sleeptest.py
+    START 1-sleeptest.py:SleepTest.test
 
     PARAMS (key=timeout, path=*, default=None) => None
     PARAMS (key=sleep_length, path=*, default=1) => 1
     Sleeping for 1.00 seconds
-    PASS examples/tests/sleeptest.py
+    PASS 1-sleeptest.py:SleepTest.test
 
     Test results available in $HOME/avocado/job-results/job-2015-06-02T10.45-f9ea174
 

--- a/docs/source/Loaders.rst
+++ b/docs/source/Loaders.rst
@@ -36,17 +36,17 @@ To get help about ``--loaders``::
 Example of how ``--loaders`` affects the produced tests (manually gathered
 as some of them result in error)::
 
-    $ avocado run passtest boot this_does_not_exist /bin/echo
+    $ avocado run passtest.py boot this_does_not_exist /bin/echo
         > INSTRUMENTED passtest.py:PassTest.test
         > VT           io-github-autotest-qemu.boot
         > MISSING      this_does_not_exist
         > SIMPLE       /bin/echo
-    $ avocado run passtest boot this_does_not_exist /bin/echo --loaders @DEFAULT "external:/bin/echo -e"
+    $ avocado run passtest.py boot this_does_not_exist /bin/echo --loaders @DEFAULT "external:/bin/echo -e"
         > INSTRUMENTED passtest.py:PassTest.test
         > VT           io-github-autotest-qemu.boot
         > EXTERNAL     this_does_not_exist
         > SIMPLE       /bin/echo
-    $ avocado run passtest boot this_does_not_exist /bin/echo --loaders file.SIMPLE file.INSTRUMENTED @DEFAULT external.EXTERNAL:/bin/echo
+    $ avocado run passtest.py boot this_does_not_exist /bin/echo --loaders file.SIMPLE file.INSTRUMENTED @DEFAULT external.EXTERNAL:/bin/echo
         > INSTRUMENTED passtest.py:PassTest.test
         > VT           io-github-autotest-qemu.boot
         > EXTERNAL     this_does_not_exist

--- a/docs/source/MultiplexConfig.rst
+++ b/docs/source/MultiplexConfig.rst
@@ -300,7 +300,8 @@ file. This is done by the `!include : $path` directive::
         gentoo:
             !include : gentoo.yaml
 
-Due to YAML nature, it's __mandatory__ to put space between `!include` and `:`!
+.. warning:: Due to YAML nature, it's __mandatory__ to put space between
+             `!include` and `:`!
 
 The file location can be either absolute path or relative path to the YAML
 file where the `!include` is called (even when it's nested).

--- a/docs/source/MultiplexConfig.rst
+++ b/docs/source/MultiplexConfig.rst
@@ -221,7 +221,7 @@ Injecting files
 
 You can run any test with any YAML file by::
 
-    avocado run sleeptest --multiplex file.yaml
+    avocado run sleeptest.py --multiplex file.yaml
 
 This puts the content of ``file.yaml`` into ``/run``
 location, which as mentioned in previous section, is the default ``mux-path``
@@ -233,7 +233,7 @@ when you have two files and you don't want the content to be merged into
 a single place becomming effectively a single blob, you can do that by
 giving a name to your yaml file::
 
-    avocado run sleeptest --multiplex duration:duration.yaml
+    avocado run sleeptest.py --multiplex duration:duration.yaml
 
 The content of ``duration.yaml`` is injected into ``/run/duration``. Still when
 keys from other files don't clash, you can use ``params.get(key)`` and retrieve
@@ -245,7 +245,7 @@ multiple files by using the same or different name, or even a complex
 Last but not least, advanced users can inject the file into whatever location
 they prefer by::
 
-    avocado run sleeptest --multiplex /my/variants/duration:duration.yaml
+    avocado run sleeptest.py --multiplex /my/variants/duration:duration.yaml
 
 Simple ``params.get(key)`` won't look in this location, which might be the
 intention of the test writer. There are several ways to access the values:
@@ -414,7 +414,7 @@ Let's take a second look at the first example::
 After filters are applied (simply removes non-matching variants), leaves
 are gathered and all variants are generated::
 
-    ./scripts/avocado multiplex examples/mux-environment.yaml 
+    $ avocado multiplex examples/mux-environment.yaml
     Variants generated:
     Variant 1:    /hw/cpu/intel, /hw/disk/scsi, /distro/fedora, /env/debug
     Variant 2:    /hw/cpu/intel, /hw/disk/scsi, /distro/fedora, /env/prod

--- a/docs/source/Plugins.rst
+++ b/docs/source/Plugins.rst
@@ -88,7 +88,7 @@ We have briefly discussed the making of Avocado plugins. We recommend
 the `Stevedore documentation`_ and also a look at the
 :mod:`avocado.plugins.base` module for the various plugin interface definitions.
 
-Some plugins examples are available in the `Avocado source tree_`, under ``examples/plugins``.
+Some plugins examples are available in the `Avocado source tree`_, under ``examples/plugins``.
 
 Finally, exploring the real plugins shipped with Avocado in :mod:`avocado.plugins`
 is the final "documentation" source.

--- a/docs/source/ReferenceGuide.rst
+++ b/docs/source/ReferenceGuide.rst
@@ -182,55 +182,56 @@ results directory structure can be seen below ::
     │   │   ├── uname_-a
     │   │   ├── uptime
     │   │   └── version
-    │   └── pre
-    │       ├── brctl_show
-    │       ├── cmdline
-    │       ├── cpuinfo
-    │       ├── current_clocksource
-    │       ├── df_-mP
-    │       ├── dmesg_-c
-    │       ├── dmidecode
-    │       ├── fdisk_-l
-    │       ├── gcc_--version
-    │       ├── hostname
-    │       ├── ifconfig_-a
-    │       ├── interrupts
-    │       ├── ip_link
-    │       ├── ld_--version
-    │       ├── lscpu
-    │       ├── lspci_-vvnn
-    │       ├── meminfo
-    │       ├── modules
-    │       ├── mount
-    │       ├── mounts
-    │       ├── numactl_--hardware_show
-    │       ├── partitions
-    │       ├── scaling_governor
-    │       ├── uname_-a
-    │       ├── uptime
-    │       └── version
+    │   ├── pre
+    │   │   ├── brctl_show
+    │   │   ├── cmdline
+    │   │   ├── cpuinfo
+    │   │   ├── current_clocksource
+    │   │   ├── df_-mP
+    │   │   ├── dmesg_-c
+    │   │   ├── dmidecode
+    │   │   ├── fdisk_-l
+    │   │   ├── gcc_--version
+    │   │   ├── hostname
+    │   │   ├── ifconfig_-a
+    │   │   ├── interrupts
+    │   │   ├── ip_link
+    │   │   ├── ld_--version
+    │   │   ├── lscpu
+    │   │   ├── lspci_-vvnn
+    │   │   ├── meminfo
+    │   │   ├── modules
+    │   │   ├── mount
+    │   │   ├── mounts
+    │   │   ├── numactl_--hardware_show
+    │   │   ├── partitions
+    │   │   ├── scaling_governor
+    │   │   ├── uname_-a
+    │   │   ├── uptime
+    │   │   └── version
+    │   └── profile
     └── test-results
         └── tests
-            ├── sleeptest.py.long
+            ├── sleeptest.py.1
             │   ├── data
             │   ├── debug.log
             │   └── sysinfo
             │       ├── post
             │       └── pre
-            ├── sleeptest.py.medium
+            ├── sleeptest.py.2
             │   ├── data
             │   ├── debug.log
             │   └── sysinfo
             │       ├── post
             │       └── pre
-            └── sleeptest.py.short
+            └── sleeptest.py.3
                 ├── data
                 ├── debug.log
                 └── sysinfo
                     ├── post
                     └── pre
     
-    20 directories, 59 files
+    21 directories, 59 files
 
 
 From what you can see, the results dir has:
@@ -238,12 +239,12 @@ From what you can see, the results dir has:
 1) A human readable ``id`` in the top level, with the job SHA1.
 2) A human readable ``job.log`` in the top level, with human readable logs of
    the task
-3) A machine readable ``results.xml`` in the top level, with a summary of the
-   job information in xUnit format.
-4) A top level ``sysinfo`` dir, with sub directories ``pre`` and ``post``, that store
-   sysinfo files pre job and post job, respectively.
+3) A machine readable ``results.xml`` and ``results.json`` in the top level,
+   with a summary of the job information in xUnit/json format.
+4) A top level ``sysinfo`` dir, with sub directories ``pre``, ``post`` and
+   ``profile``, that store sysinfo files pre/post/during job, respectively.
 5) Subdirectory ``test-results``, that contains a number of subdirectories
-   (tagged testnames). Those tagged testnames represent instances of test
+   (filesystem-friendly test ids). Those test ids represent instances of test
    execution results.
 
 Test execution instances specification
@@ -251,7 +252,7 @@ Test execution instances specification
 
 The instances should have:
 
-1) A top level human readable ``test.log``, with test debug information
+1) A top level human readable ``job.log``, with job debug information
 2) A ``sysinfo`` subdir, with sub directories ``pre`` and ``post``, that store
    sysinfo files pre test and post test, respectively.
 3) A ``data`` subdir, where the test can output a number of files if necessary.

--- a/docs/source/ReferenceGuide.rst
+++ b/docs/source/ReferenceGuide.rst
@@ -6,16 +6,19 @@ Reference Guide
 
 This guide presents information on the Avocado basic design and its internals.
 
+Job, test and identifiers
+=========================
+
 .. _job-id:
 
 Job ID
-======
+------
 
 The Job ID is a random SHA1 string that uniquely identifies a given job.
 
 The full form of the SHA1 string is used is most references to a job::
 
-  $ avocado run sleeptest
+  $ avocado run sleeptest.py
   JOB ID     : 49ec339a6cca73397be21866453985f88713ac34
   ...
 
@@ -23,6 +26,99 @@ But a shorter version is also used at some places, such as in the job
 results location::
 
   JOB LOG    : $HOME/avocado/job-results/job-2015-06-10T10.44-49ec339/job.log
+
+
+Test References
+---------------
+
+A Test Reference is a string that can be resolved into
+(interpreted as) one or more tests by the Avocado Test Resolver.
+A given resolver plugin is free to interpret a test reference,
+it is completely abstract to the other components of Avocado.
+
+.. note:: Mapping the Test References to tests can be affected
+   by command-line switches like `--external-runner`, which
+   completelly changes the meaning of the given strings.
+
+
+Test Name
+---------
+
+A test name is an arbitrarily long string that unambiguously
+points to the source of a single test. In other words the Avocado
+Test Resolver, as configured for a particular job, should return
+one and only one test as the interpretation of this name.
+
+This name can be as specific as necessary to make it unique.
+Therefore it can contain an arbitrary number of variables,
+prefixes, suffixes, tags, etc.  It all depends on user
+preferences, what is supported by Avocado via its Test Resolvers and
+the context of the job.
+
+The output of the Test Resolver when resolving Test References
+should always be a list of unambiguous Test Names (for that
+particular job).
+
+Notice that although the Test Name has to be unique, one test can
+be run more than once inside a job.
+
+By definition, a Test Name is a Test Reference, but the
+reciprocal is not necessarily true, as the latter can represent
+more than one test.
+
+
+Variant IDs
+-----------
+
+The multiplexer component creates different sets of variables
+(known as "variants"), to allow tests to be run individually in
+each of them.
+
+A Variant ID is an arbitrary and abstract string created by the
+multiplexer to identify each variant. It should be unique per
+variant inside a set. In other words, the multiplexer generates a
+set of variants, identified by unique IDs.
+
+A simpler implementation of the multiplexer uses serial integers
+as Variant IDs. A more sophisticated implementation could
+generate Variant IDs with more semantic, potentially representing
+their contents.
+
+.. note:: The multiplexer supports serialized variant IDs only
+
+
+Test ID
+--------
+
+A test ID is a string that uniquely identifies a test in the
+context of a job. When considering a single job, there are no two
+tests with the same ID.
+
+A test ID should encapsulate the Test Name and the Variant ID, to
+allow direct identification of a test. In other words, by looking
+at the test ID it should be possible to identify:
+
+  - What's the test name
+  - What's the variant used to run this test (if any)
+
+Test IDs don't necessarily keep their uniqueness properties when
+considered outside of a particular job, but two identical jobs
+run in the exact same environment should generate a identical
+sets of Test IDs.
+
+Syntax::
+
+   <unique-id>-<test-name>[;<variant-id>]
+
+Examples of test-names::
+
+   '/bin/true'
+   '/bin/grep foobar /etc/passwd'
+   'passtest.py:Passtest.test'
+   'file:///tmp/passtest.py:Passtest.test'
+   'multiple_tests.py:MultipleTests.test_hello'
+   'type_specific.io-github-autotest-qemu.systemtap_tracing.qemu.qemu_free'
+
 
 .. _test-types:
 

--- a/docs/source/Replay.rst
+++ b/docs/source/Replay.rst
@@ -39,61 +39,61 @@ The replay feature will retrieve the original job urls, the multiplex
 tree and the configuration. Let's see another example, now using
 multiplex file::
 
-  $ avocado run /bin/true /bin/false --multiplex mux-environment.yaml
-  JOB ID     : bd6aa3b852d4290637b5e771b371537541043d1d
-  JOB LOG    : $HOME/avocado/job-results/job-2016-01-11T21.56-bd6aa3b/job.log
-  TESTS      : 48
-   (1/48) /bin/true.variant1: PASS (0.01 s)
-   (2/48) /bin/true.variant2: PASS (0.01 s)
-   (3/48) /bin/true.variant3: PASS (0.01 s)
-   (4/48) /bin/true.variant4: PASS (0.01 s)
-   (5/48) /bin/true.variant5: PASS (0.01 s)
-   (6/48) /bin/true.variant6: PASS (0.01 s)
-   (7/48) /bin/true.variant7: PASS (0.01 s)
-   (8/48) /bin/true.variant8: PASS (0.01 s)
-   (9/48) /bin/true.variant9: PASS (0.01 s)
-   (10/48) /bin/true.variant10: PASS (0.01 s)
-   (11/48) /bin/true.variant11: PASS (0.01 s)
-   (12/48) /bin/true.variant12: PASS (0.01 s)
-   (13/48) /bin/true.variant13: PASS (0.01 s)
-   (14/48) /bin/true.variant14: PASS (0.01 s)
-   (15/48) /bin/true.variant15: PASS (0.01 s)
-   (16/48) /bin/true.variant16: PASS (0.01 s)
-   (17/48) /bin/true.variant17: PASS (0.01 s)
-   (18/48) /bin/true.variant18: PASS (0.01 s)
-   (19/48) /bin/true.variant19: PASS (0.01 s)
-   (20/48) /bin/true.variant20: PASS (0.01 s)
-   (21/48) /bin/true.variant21: PASS (0.01 s)
-   (22/48) /bin/true.variant22: PASS (0.01 s)
-   (23/48) /bin/true.variant23: PASS (0.01 s)
-   (24/48) /bin/true.variant24: PASS (0.01 s)
-   (25/48) /bin/false.variant1: FAIL (0.01 s)
-   (26/48) /bin/false.variant2: FAIL (0.01 s)
-   (27/48) /bin/false.variant3: FAIL (0.01 s)
-   (28/48) /bin/false.variant4: FAIL (0.01 s)
-   (29/48) /bin/false.variant5: FAIL (0.01 s)
-   (30/48) /bin/false.variant6: FAIL (0.01 s)
-   (31/48) /bin/false.variant7: FAIL (0.01 s)
-   (32/48) /bin/false.variant8: FAIL (0.01 s)
-   (33/48) /bin/false.variant9: FAIL (0.01 s)
-   (34/48) /bin/false.variant10: FAIL (0.01 s)
-   (35/48) /bin/false.variant11: FAIL (0.01 s)
-   (36/48) /bin/false.variant12: FAIL (0.01 s)
-   (37/48) /bin/false.variant13: FAIL (0.01 s)
-   (38/48) /bin/false.variant14: FAIL (0.01 s)
-   (39/48) /bin/false.variant15: FAIL (0.01 s)
-   (40/48) /bin/false.variant16: FAIL (0.01 s)
-   (41/48) /bin/false.variant17: FAIL (0.01 s)
-   (42/48) /bin/false.variant18: FAIL (0.01 s)
-   (43/48) /bin/false.variant19: FAIL (0.01 s)
-   (44/48) /bin/false.variant20: FAIL (0.01 s)
-   (45/48) /bin/false.variant21: FAIL (0.01 s)
-   (46/48) /bin/false.variant22: FAIL (0.01 s)
-   (47/48) /bin/false.variant23: FAIL (0.01 s)
-   (48/48) /bin/false.variant24: FAIL (0.01 s)
-  RESULTS    : PASS 24 | ERROR 0 | FAIL 24 | SKIP 0 | WARN 0 | INTERRUPT 0
-  JOB HTML   : $HOME/avocado/job-results/job-2016-01-11T21.56-bd6aa3b/html/results.html
-  TIME       : 0.29 s
+     $ avocado run /bin/true /bin/false --multiplex mux-environment.yaml
+     JOB ID     : bd6aa3b852d4290637b5e771b371537541043d1d
+     JOB LOG    : $HOME/avocado/job-results/job-2016-01-11T21.56-bd6aa3b/job.log
+     TESTS      : 48
+      (1/48) /bin/true;1: PASS (0.01 s)
+      (2/48) /bin/true;2: PASS (0.01 s)
+      (3/48) /bin/true;3: PASS (0.01 s)
+      (4/48) /bin/true;4: PASS (0.01 s)
+      (5/48) /bin/true;5: PASS (0.01 s)
+      (6/48) /bin/true;6: PASS (0.01 s)
+      (7/48) /bin/true;7: PASS (0.01 s)
+      (8/48) /bin/true;8: PASS (0.01 s)
+      (9/48) /bin/true;9: PASS (0.01 s)
+      (10/48) /bin/true;10: PASS (0.01 s)
+      (11/48) /bin/true;11: PASS (0.01 s)
+      (12/48) /bin/true;12: PASS (0.01 s)
+      (13/48) /bin/true;13: PASS (0.01 s)
+      (14/48) /bin/true;14: PASS (0.01 s)
+      (15/48) /bin/true;15: PASS (0.01 s)
+      (16/48) /bin/true;16: PASS (0.01 s)
+      (17/48) /bin/true;17: PASS (0.01 s)
+      (18/48) /bin/true;18: PASS (0.01 s)
+      (19/48) /bin/true;19: PASS (0.01 s)
+      (20/48) /bin/true;20: PASS (0.01 s)
+      (21/48) /bin/true;21: PASS (0.01 s)
+      (22/48) /bin/true;22: PASS (0.01 s)
+      (23/48) /bin/true;23: PASS (0.01 s)
+      (24/48) /bin/true;24: PASS (0.01 s)
+      (25/48) /bin/false;1: FAIL (0.01 s)
+      (26/48) /bin/false;2: FAIL (0.01 s)
+      (27/48) /bin/false;3: FAIL (0.01 s)
+      (28/48) /bin/false;4: FAIL (0.01 s)
+      (29/48) /bin/false;5: FAIL (0.01 s)
+      (30/48) /bin/false;6: FAIL (0.01 s)
+      (31/48) /bin/false;7: FAIL (0.01 s)
+      (32/48) /bin/false;8: FAIL (0.01 s)
+      (33/48) /bin/false;9: FAIL (0.01 s)
+      (34/48) /bin/false;10: FAIL (0.01 s)
+      (35/48) /bin/false;11: FAIL (0.01 s)
+      (36/48) /bin/false;12: FAIL (0.01 s)
+      (37/48) /bin/false;13: FAIL (0.01 s)
+      (38/48) /bin/false;14: FAIL (0.01 s)
+      (39/48) /bin/false;15: FAIL (0.01 s)
+      (40/48) /bin/false;16: FAIL (0.01 s)
+      (41/48) /bin/false;17: FAIL (0.01 s)
+      (42/48) /bin/false;18: FAIL (0.01 s)
+      (43/48) /bin/false;19: FAIL (0.01 s)
+      (44/48) /bin/false;20: FAIL (0.01 s)
+      (45/48) /bin/false;21: FAIL (0.01 s)
+      (46/48) /bin/false;22: FAIL (0.01 s)
+      (47/48) /bin/false;23: FAIL (0.01 s)
+      (48/48) /bin/false;24: FAIL (0.01 s)
+     RESULTS    : PASS 24 | ERROR 0 | FAIL 24 | SKIP 0 | WARN 0 | INTERRUPT 0
+     JOB HTML   : $HOME/avocado/job-results/job-2016-01-11T21.56-bd6aa3b/html/results.html
+     TIME       : 0.29 s
 
 We can replay the job as is, using ``$ avocado run --replay bd6aa3b``,
 or replay the job ignoring the multiplex file, as below::
@@ -119,54 +119,54 @@ result, using the option ``--replay-test-status``. Using the same job
     SRC JOB ID : bd6aa3b852d4290637b5e771b371537541043d1d
     JOB LOG    : $HOME/avocado/job-results/job-2016-01-12T00.38-2e1dc41/job.log
     TESTS      : 48
-     (1/48) /bin/true.variant1: SKIP
-     (2/48) /bin/true.variant2: SKIP
-     (3/48) /bin/true.variant3: SKIP
-     (4/48) /bin/true.variant4: SKIP
-     (5/48) /bin/true.variant5: SKIP
-     (6/48) /bin/true.variant6: SKIP
-     (7/48) /bin/true.variant7: SKIP
-     (8/48) /bin/true.variant8: SKIP
-     (9/48) /bin/true.variant9: SKIP
-     (10/48) /bin/true.variant10: SKIP
-     (11/48) /bin/true.variant11: SKIP
-     (12/48) /bin/true.variant12: SKIP
-     (13/48) /bin/true.variant13: SKIP
-     (14/48) /bin/true.variant14: SKIP
-     (15/48) /bin/true.variant15: SKIP
-     (16/48) /bin/true.variant16: SKIP
-     (17/48) /bin/true.variant17: SKIP
-     (18/48) /bin/true.variant18: SKIP
-     (19/48) /bin/true.variant19: SKIP
-     (20/48) /bin/true.variant20: SKIP
-     (21/48) /bin/true.variant21: SKIP
-     (22/48) /bin/true.variant22: SKIP
-     (23/48) /bin/true.variant23: SKIP
-     (24/48) /bin/true.variant24: SKIP
-     (25/48) /bin/false.variant1: FAIL (0.01 s)
-     (26/48) /bin/false.variant2: FAIL (0.01 s)
-     (27/48) /bin/false.variant3: FAIL (0.01 s)
-     (28/48) /bin/false.variant4: FAIL (0.01 s)
-     (29/48) /bin/false.variant5: FAIL (0.01 s)
-     (30/48) /bin/false.variant6: FAIL (0.01 s)
-     (31/48) /bin/false.variant7: FAIL (0.01 s)
-     (32/48) /bin/false.variant8: FAIL (0.01 s)
-     (33/48) /bin/false.variant9: FAIL (0.01 s)
-     (34/48) /bin/false.variant10: FAIL (0.01 s)
-     (35/48) /bin/false.variant11: FAIL (0.01 s)
-     (36/48) /bin/false.variant12: FAIL (0.01 s)
-     (37/48) /bin/false.variant13: FAIL (0.01 s)
-     (38/48) /bin/false.variant14: FAIL (0.01 s)
-     (39/48) /bin/false.variant15: FAIL (0.01 s)
-     (40/48) /bin/false.variant16: FAIL (0.01 s)
-     (41/48) /bin/false.variant17: FAIL (0.01 s)
-     (42/48) /bin/false.variant18: FAIL (0.01 s)
-     (43/48) /bin/false.variant19: FAIL (0.01 s)
-     (44/48) /bin/false.variant20: FAIL (0.01 s)
-     (45/48) /bin/false.variant21: FAIL (0.01 s)
-     (46/48) /bin/false.variant22: FAIL (0.01 s)
-     (47/48) /bin/false.variant23: FAIL (0.01 s)
-     (48/48) /bin/false.variant24: FAIL (0.01 s)
+     (1/48) /bin/true;1: SKIP
+     (2/48) /bin/true;2: SKIP
+     (3/48) /bin/true;3: SKIP
+     (4/48) /bin/true;4: SKIP
+     (5/48) /bin/true;5: SKIP
+     (6/48) /bin/true;6: SKIP
+     (7/48) /bin/true;7: SKIP
+     (8/48) /bin/true;8: SKIP
+     (9/48) /bin/true;9: SKIP
+     (10/48) /bin/true;10: SKIP
+     (11/48) /bin/true;11: SKIP
+     (12/48) /bin/true;12: SKIP
+     (13/48) /bin/true;13: SKIP
+     (14/48) /bin/true;14: SKIP
+     (15/48) /bin/true;15: SKIP
+     (16/48) /bin/true;16: SKIP
+     (17/48) /bin/true;17: SKIP
+     (18/48) /bin/true;18: SKIP
+     (19/48) /bin/true;19: SKIP
+     (20/48) /bin/true;20: SKIP
+     (21/48) /bin/true;21: SKIP
+     (22/48) /bin/true;22: SKIP
+     (23/48) /bin/true;23: SKIP
+     (24/48) /bin/true;24: SKIP
+     (25/48) /bin/false;1: FAIL (0.01 s)
+     (26/48) /bin/false;2: FAIL (0.01 s)
+     (27/48) /bin/false;3: FAIL (0.01 s)
+     (28/48) /bin/false;4: FAIL (0.01 s)
+     (29/48) /bin/false;5: FAIL (0.01 s)
+     (30/48) /bin/false;6: FAIL (0.01 s)
+     (31/48) /bin/false;7: FAIL (0.01 s)
+     (32/48) /bin/false;8: FAIL (0.01 s)
+     (33/48) /bin/false;9: FAIL (0.01 s)
+     (34/48) /bin/false;10: FAIL (0.01 s)
+     (35/48) /bin/false;11: FAIL (0.01 s)
+     (36/48) /bin/false;12: FAIL (0.01 s)
+     (37/48) /bin/false;13: FAIL (0.01 s)
+     (38/48) /bin/false;14: FAIL (0.01 s)
+     (39/48) /bin/false;15: FAIL (0.01 s)
+     (40/48) /bin/false;16: FAIL (0.01 s)
+     (41/48) /bin/false;17: FAIL (0.01 s)
+     (42/48) /bin/false;18: FAIL (0.01 s)
+     (43/48) /bin/false;19: FAIL (0.01 s)
+     (44/48) /bin/false;20: FAIL (0.01 s)
+     (45/48) /bin/false;21: FAIL (0.01 s)
+     (46/48) /bin/false;22: FAIL (0.01 s)
+     (47/48) /bin/false;23: FAIL (0.01 s)
+     (48/48) /bin/false;24: FAIL (0.01 s)
     RESULTS    : PASS 0 | ERROR 0 | FAIL 24 | SKIP 24 | WARN 0 | INTERRUPT 0
     JOB HTML   : $HOME/avocado/job-results/job-2016-01-12T00.38-2e1dc41/html/results.html
     TIME       : 0.19 s

--- a/docs/source/Replay.rst
+++ b/docs/source/Replay.rst
@@ -12,28 +12,28 @@ job id and it is also unique enough.
 
 Let's see an example. First, running a simple job with two urls::
 
-  $ avocado run /bin/true /bin/false
-  JOB ID     : 825b860b0c2f6ec48953c638432e3e323f8d7cad
-  JOB LOG    : $HOME/avocado/job-results/job-2016-01-11T16.14-825b860/job.log
-  TESTS      : 2
-   (1/2) /bin/true: PASS (0.01 s)
-   (2/2) /bin/false: FAIL (0.01 s)
-  RESULTS    : PASS 1 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0
-  JOB HTML   : $HOME/avocado/job-results/job-2016-01-11T16.14-825b860/html/results.html
-  TIME       : 0.02 s
+     $ avocado run /bin/true /bin/false
+     JOB ID     : 825b860b0c2f6ec48953c638432e3e323f8d7cad
+     JOB LOG    : $HOME/avocado/job-results/job-2016-01-11T16.14-825b860/job.log
+     TESTS      : 2
+      (1/2) /bin/true: PASS (0.01 s)
+      (2/2) /bin/false: FAIL (0.01 s)
+     RESULTS    : PASS 1 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0
+     JOB HTML   : $HOME/avocado/job-results/job-2016-01-11T16.14-825b860/html/results.html
+     TIME       : 0.02 s
 
 Now we can replay the job by running::
 
-  $ avocado run --replay 825b86
-  JOB ID     : 55a0d10132c02b8cc87deb2b480bfd8abbd956c3
-  SRC JOB ID : 825b860b0c2f6ec48953c638432e3e323f8d7cad
-  JOB LOG    : $HOME/avocado/job-results/job-2016-01-11T16.18-55a0d10/job.log
-  TESTS      : 2
-   (1/2) /bin/true: PASS (0.01 s)
-   (2/2) /bin/false: FAIL (0.01 s)
-  RESULTS    : PASS 1 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0
-  JOB HTML   : $HOME/avocado/job-results/job-2016-01-11T16.18-55a0d10/html/results.html
-  TIME       : 0.01 s
+     $ avocado run --replay 825b86
+     JOB ID     : 55a0d10132c02b8cc87deb2b480bfd8abbd956c3
+     SRC JOB ID : 825b860b0c2f6ec48953c638432e3e323f8d7cad
+     JOB LOG    : $HOME/avocado/job-results/job-2016-01-11T16.18-55a0d10/job.log
+     TESTS      : 2
+      (1/2) /bin/true: PASS (0.01 s)
+      (2/2) /bin/false: FAIL (0.01 s)
+     RESULTS    : PASS 1 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0
+     JOB HTML   : $HOME/avocado/job-results/job-2016-01-11T16.18-55a0d10/html/results.html
+     TIME       : 0.01 s
 
 The replay feature will retrieve the original job urls, the multiplex
 tree and the configuration. Let's see another example, now using
@@ -98,17 +98,17 @@ multiplex file::
 We can replay the job as is, using ``$ avocado run --replay bd6aa3b``,
 or replay the job ignoring the multiplex file, as below::
 
-  $ avocado run --replay bd6aa3b --replay-ignore mux
-  Ignoring multiplex from source job with --replay-ignore.
-  JOB ID     : d5a46186ee0fb4645e3f7758814003d76c980bf9
-  SRC JOB ID : bd6aa3b852d4290637b5e771b371537541043d1d
-  JOB LOG    : $HOME/avocado/job-results/job-2016-01-11T22.01-d5a4618/job.log
-  TESTS      : 2
-   (1/2) /bin/true: PASS (0.01 s)
-   (2/2) /bin/false: FAIL (0.01 s)
-  RESULTS    : PASS 1 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0
-  JOB HTML   : $HOME/avocado/job-results/job-2016-01-11T22.01-d5a4618/html/results.html
-  TIME       : 0.02 s
+     $ avocado run --replay bd6aa3b --replay-ignore mux
+     Ignoring multiplex from source job with --replay-ignore.
+     JOB ID     : d5a46186ee0fb4645e3f7758814003d76c980bf9
+     SRC JOB ID : bd6aa3b852d4290637b5e771b371537541043d1d
+     JOB LOG    : $HOME/avocado/job-results/job-2016-01-11T22.01-d5a4618/job.log
+     TESTS      : 2
+      (1/2) /bin/true: PASS (0.01 s)
+      (2/2) /bin/false: FAIL (0.01 s)
+     RESULTS    : PASS 1 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0
+     JOB HTML   : $HOME/avocado/job-results/job-2016-01-11T22.01-d5a4618/html/results.html
+     TIME       : 0.02 s
 
 Also, it is possible to replay only the variants that faced a given
 result, using the option ``--replay-test-status``. Using the same job
@@ -177,28 +177,28 @@ given job has a non-default path to record the logs, when the replay
 time comes, we need to inform where the logs are. See the example
 below::
 
-  $ avocado run /bin/true --job-results-dir /tmp/avocado_results/
-  JOB ID     : f1b1c870ad892eac6064a5332f1bbe38cda0aaf3
-  JOB LOG    : /tmp/avocado_results/job-2016-01-11T22.10-f1b1c87/job.log
-  TESTS      : 1
-   (1/1) /bin/true: PASS (0.01 s)
-  RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0
-  JOB HTML   : /tmp/avocado_results/job-2016-01-11T22.10-f1b1c87/html/results.html
-  TIME       : 0.01 s
+     $ avocado run /bin/true --job-results-dir /tmp/avocado_results/
+     JOB ID     : f1b1c870ad892eac6064a5332f1bbe38cda0aaf3
+     JOB LOG    : /tmp/avocado_results/job-2016-01-11T22.10-f1b1c87/job.log
+     TESTS      : 1
+      (1/1) /bin/true: PASS (0.01 s)
+     RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0
+     JOB HTML   : /tmp/avocado_results/job-2016-01-11T22.10-f1b1c87/html/results.html
+     TIME       : 0.01 s
 
 Trying to replay the job, it fails::
 
-  $ avocado run --replay f1b1
-  can't find job results directory in '$HOME/avocado/job-results'
+     $ avocado run --replay f1b1
+     can't find job results directory in '$HOME/avocado/job-results'
 
 In this case, we have to inform where the job results dir is located::
 
-  $ avocado run --replay f1b1 --replay-data-dir /tmp/avocado_results
-  JOB ID     : 19c76abb29f29fe410a9a3f4f4b66387570edffa
-  SRC JOB ID : f1b1c870ad892eac6064a5332f1bbe38cda0aaf3
-  JOB LOG    : $HOME/avocado/job-results/job-2016-01-11T22.15-19c76ab/job.log
-  TESTS      : 1
-   (1/1) /bin/true: PASS (0.01 s)
-  RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0
-  JOB HTML   : $HOME/avocado/job-results/job-2016-01-11T22.15-19c76ab/html/results.html
-  TIME       : 0.01 s
+     $ avocado run --replay f1b1 --replay-data-dir /tmp/avocado_results
+     JOB ID     : 19c76abb29f29fe410a9a3f4f4b66387570edffa
+     SRC JOB ID : f1b1c870ad892eac6064a5332f1bbe38cda0aaf3
+     JOB LOG    : $HOME/avocado/job-results/job-2016-01-11T22.15-19c76ab/job.log
+     TESTS      : 1
+      (1/1) /bin/true: PASS (0.01 s)
+     RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0
+     JOB HTML   : $HOME/avocado/job-results/job-2016-01-11T22.15-19c76ab/html/results.html
+     TIME       : 0.01 s

--- a/docs/source/ResultFormats.rst
+++ b/docs/source/ResultFormats.rst
@@ -61,7 +61,9 @@ Another type of results are those intended to be parsed by other
 applications. Several standards exist in the test community, and Avocado can
 in theory support pretty much every result standard out there.
 
-Out of the box, Avocado supports a couple of machine readable results.
+Out of the box, Avocado supports a couple of machine readable results. They
+are always generated and stored in the results directory in `results.$type`
+files, but you can ask for a different location too.
 
 xunit
 ~~~~~
@@ -83,8 +85,9 @@ output in the standard output of the runner, simply use::
         </testcase>
         <testcase classname="synctest" name="synctest.1" time="1.69329714775"/>
 
-Note the dash `-` in the option `--xunit`, it means that the xunit result
-should go to the standard output.
+
+.. note:: The dash `-` in the option `--xunit`, it means that the xunit result
+          should go to the standard output.
 
 json
 ~~~~
@@ -96,11 +99,11 @@ plugin::
     $ scripts/avocado --json - run "sleeptest failtest synctest"
     {"tests": [{"test": "sleeptest.1", "url": "sleeptest", "status": "PASS", "time": 1.4282619953155518}, {"test": "failtest.1", "url": "failtest", "status": "FAIL", "time": 0.34017300605773926}, {"test": "synctest.1", "url": "synctest", "status": "PASS", "time": 2.109131097793579}], "errors": 0, "skip": 0, "time": 3.87756609916687, "debuglog": "$HOME/avocado/logs/run-2014-06-11-01.35.15/debug.log", "pass": 2, "failures": 1, "total": 3}
 
-Note the dash `-` in the option `--json`, it means that the xunit result
-should go to the standard output.
+.. note:: The dash `-` in the option `--json`, it means that the xunit result
+          should go to the standard output.
 
 Bear in mind that there's no documented standard for the Avocado JSON result
-format. This means that it will probably grow organically to acommodate
+format. This means that it will probably grow organically to accommodate
 newer Avocado features. A reasonable effort will be made to not break
 backwards compatibility with applications that parse the current form of its
 JSON result.
@@ -125,6 +128,8 @@ Avocado and check its results::
        echo "great success!"
     elif
        ...
+
+more details regarding exit codes in `Exit Codes`_ section.
 
 Multiple results at once
 ------------------------

--- a/docs/source/ResultFormats.rst
+++ b/docs/source/ResultFormats.rst
@@ -21,13 +21,13 @@ Avocado command line UI
 A regular run of Avocado will present the test results in a live fashion,
 that is, the job and its test(s) results are constantly updated::
 
-    $ avocado run sleeptest failtest synctest
+    $ avocado run sleeptest.py failtest.py synctest.py
     JOB ID    : 5ffe479262ea9025f2e4e84c4e92055b5c79bdc9
     JOB LOG   : $HOME/avocado/job-results/job-2014-08-12T15.57-5ffe4792/job.log
     TESTS     : 3
-     (1/3) sleeptest.1: PASS (1.01 s)
-     (2/3) failtest.1: FAIL (0.00 s)
-     (3/3) synctest.1: PASS (1.98 s)
+     (1/3) sleeptest.py:SleepTest.test: PASS (1.01 s)
+     (2/3) failtest.py:FailTest.test: FAIL (0.00 s)
+     (3/3) synctest.py:SyncTest.test: PASS (1.98 s)
     RESULTS    : PASS 1 | ERROR 1 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0
     JOB HTML  : $HOME/avocado/job-results/job-2014-08-12T15.57-5ffe4792/html/results.html
     TIME      : 3.17 s
@@ -41,7 +41,7 @@ HTML report
 As can be seen in the previous example, Avocado shows the path to an HTML
 report that will be generated as soon as the job finishes running::
 
-    $ avocado run sleeptest failtest synctest
+    $ avocado run sleeptest.py failtest.py synctest.py
     ...
     JOB HTML  : $HOME/avocado/job-results/job-2014-08-12T15.57-5ffe4792/html/results.html
     ...
@@ -76,14 +76,31 @@ are used by other test automation projects, such as `jenkins
 <http://jenkins-ci.org/>`__. If you want to make Avocado to generate xunit
 output in the standard output of the runner, simply use::
 
-    $ scripts/avocado --xunit - run "sleeptest failtest synctest"
-    <?xml version="1.0" encoding="UTF-8"?>
-    <testsuite name="avocado" tests="3" errors="0" failures="1" skipped="0" time="2.88632893562" timestamp="2014-04-24 18:25:39.545588">
-        <testcase classname="sleeptest" name="sleeptest.1" time="1.10091400146"/>
-        <testcase classname="failtest" name="failtest.1" time="0.0921177864075">
-            <failure><![CDATA[This test is supposed to fail]]></failure>
-        </testcase>
-        <testcase classname="synctest" name="synctest.1" time="1.69329714775"/>
+   $ avocado run sleeptest.py failtest.py synctest.py --xunit -
+   <?xml version="1.0" encoding="UTF-8"?>
+   <testsuite name="avocado" tests="3" errors="0" failures="1" skipped="0" time="3.5769162178" timestamp="2016-05-04 14:46:52.803365">
+           <testcase classname="SleepTest" name="1-sleeptest.py:SleepTest.test" time="1.00204920769"/>
+           <testcase classname="FailTest" name="2-failtest.py:FailTest.test" time="0.00120401382446">
+                   <failure type="TestFail" message="This test is supposed to fail"><![CDATA[Traceback (most recent call last):
+     File "/home/medic/Work/Projekty/avocado/avocado/avocado/core/test.py", line 490, in _run_avocado
+       raise test_exception
+   TestFail: This test is supposed to fail
+   ]]></failure>
+                   <system-out><![CDATA[14:46:53 ERROR| 
+   14:46:53 ERROR| Reproduced traceback from: /home/medic/Work/Projekty/avocado/avocado/avocado/core/test.py:435
+   14:46:53 ERROR| Traceback (most recent call last):
+   14:46:53 ERROR|   File "/home/medic/Work/Projekty/avocado/avocado/examples/tests/failtest.py", line 17, in test
+   14:46:53 ERROR|     self.fail('This test is supposed to fail')
+   14:46:53 ERROR|   File "/home/medic/Work/Projekty/avocado/avocado/avocado/core/test.py", line 585, in fail
+   14:46:53 ERROR|     raise exceptions.TestFail(message)
+   14:46:53 ERROR| TestFail: This test is supposed to fail
+   14:46:53 ERROR| 
+   14:46:53 ERROR| FAIL 2-failtest.py:FailTest.test -> TestFail: This test is supposed to fail
+   14:46:53 INFO | 
+   ]]></system-out>
+           </testcase>
+           <testcase classname="SyncTest" name="3-synctest.py:SyncTest.test" time="2.57366299629"/>
+   </testsuite>
 
 
 .. note:: The dash `-` in the option `--xunit`, it means that the xunit result
@@ -96,8 +113,60 @@ json
 json Avocado plugin outputs job information, similarly to the xunit output
 plugin::
 
-    $ scripts/avocado --json - run "sleeptest failtest synctest"
-    {"tests": [{"test": "sleeptest.1", "url": "sleeptest", "status": "PASS", "time": 1.4282619953155518}, {"test": "failtest.1", "url": "failtest", "status": "FAIL", "time": 0.34017300605773926}, {"test": "synctest.1", "url": "synctest", "status": "PASS", "time": 2.109131097793579}], "errors": 0, "skip": 0, "time": 3.87756609916687, "debuglog": "$HOME/avocado/logs/run-2014-06-11-01.35.15/debug.log", "pass": 2, "failures": 1, "total": 3}
+    $ avocado run sleeptest.py failtest.py synctest.py --json -
+    {"tests": [{"status": "PASS", "url": "1-sleeptest.py:SleepTest.test", "logfile": "/home/medic/avocado/job-results/job-2016-05-04T14.51-74e01c8/test-results/1-sleeptest.py:SleepTest.test/debug.log", "whiteboard": "", "end": 1462366291.95844, "logdir": "/home/medic/avocado/job-results/job-2016-05-04T14.51-74e01c8/test-results/1-sleeptest.py:SleepTest.test", "start": 1462366290.957374, "test": "1-sleeptest.py:SleepTest.test", "fail_reason": "None", "time": 1.001065969467163}, {"status": "FAIL", "url": "2-failtest.py:FailTest.test", "logfile": "/home/medic/avocado/job-results/job-2016-05-04T14.51-74e01c8/test-results/2-failtest.py:FailTest.test/debug.log", "whiteboard": "", "end": 1462366291.980557, "logdir": "/home/medic/avocado/job-results/job-2016-05-04T14.51-74e01c8/test-results/2-failtest.py:FailTest.test", "start": 1462366291.977591, "test": "2-failtest.py:FailTest.test", "fail_reason": "This test is supposed to fail", "time": 0.0029659271240234375}, {"status": "PASS", "url": "3-synctest.py:SyncTest.test", "logfile": "/home/medic/avocado/job-results/job-2016-05-04T14.51-74e01c8/test-results/3-synctest.py:SyncTest.test/debug.log", "whiteboard": "", "end": 1462366294.713253, "logdir": "/home/medic/avocado/job-results/job-2016-05-04T14.51-74e01c8/test-results/3-synctest.py:SyncTest.test", "start": 1462366291.995889, "test": "3-synctest.py:SyncTest.test", "fail_reason": "None", "time": 2.7173640727996826}], "errors": 0, "job_id": "74e01c82c95009e7d126b4fd60d5e3c615aa7539", "skip": 0, "time": 3.721395969390869, "debuglog": "/home/medic/avocado/job-results/job-2016-05-04T14.51-74e01c8/job.log", "pass": 2, "failures": 1, "total": 3}
+
+Alternatively human-readable version using `json.tool`::
+
+    $ avocado run sleeptest.py failtest.py synctest.py --json - | python -m json.tool
+    {
+        "debuglog": "/home/medic/avocado/job-results/job-2016-05-04T14.51-74e01c8/job.log",
+        "errors": 0,
+        "failures": 1,
+        "job_id": "74e01c82c95009e7d126b4fd60d5e3c615aa7539",
+        "pass": 2,
+        "skip": 0,
+        "tests": [
+            {
+                "end": 1462366291.95844,
+                "fail_reason": "None",
+                "logdir": "/home/medic/avocado/job-results/job-2016-05-04T14.51-74e01c8/test-results/1-sleeptest.py:SleepTest.test",
+                "logfile": "/home/medic/avocado/job-results/job-2016-05-04T14.51-74e01c8/test-results/1-sleeptest.py:SleepTest.test/debug.log",
+                "start": 1462366290.957374,
+                "status": "PASS",
+                "test": "1-sleeptest.py:SleepTest.test",
+                "time": 1.001065969467163,
+                "url": "1-sleeptest.py:SleepTest.test",
+                "whiteboard": ""
+            },
+            {
+                "end": 1462366291.980557,
+                "fail_reason": "This test is supposed to fail",
+                "logdir": "/home/medic/avocado/job-results/job-2016-05-04T14.51-74e01c8/test-results/2-failtest.py:FailTest.test",
+                "logfile": "/home/medic/avocado/job-results/job-2016-05-04T14.51-74e01c8/test-results/2-failtest.py:FailTest.test/debug.log",
+                "start": 1462366291.977591,
+                "status": "FAIL",
+                "test": "2-failtest.py:FailTest.test",
+                "time": 0.0029659271240234375,
+                "url": "2-failtest.py:FailTest.test",
+                "whiteboard": ""
+            },
+            {
+                "end": 1462366294.713253,
+                "fail_reason": "None",
+                "logdir": "/home/medic/avocado/job-results/job-2016-05-04T14.51-74e01c8/test-results/3-synctest.py:SyncTest.test",
+                "logfile": "/home/medic/avocado/job-results/job-2016-05-04T14.51-74e01c8/test-results/3-synctest.py:SyncTest.test/debug.log",
+                "start": 1462366291.995889,
+                "status": "PASS",
+                "test": "3-synctest.py:SyncTest.test",
+                "time": 2.7173640727996826,
+                "url": "3-synctest.py:SyncTest.test",
+                "whiteboard": ""
+            }
+        ],
+        "time": 3.721395969390869,
+        "total": 3
+    }
 
 .. note:: The dash `-` in the option `--json`, it means that the xunit result
           should go to the standard output.
@@ -114,7 +183,7 @@ Silent result
 While not a very fancy result format, an application may want nothing but
 the exit status code from an Avocado test job run. Example::
 
-    $ avocado --silent run failtest
+    $ avocado --silent run failtest.py
     $ echo $?
     1
 
@@ -123,7 +192,7 @@ Avocado and check its results::
 
     #!/bin/bash
     ...
-    avocado run /path/to/my/test.py --silent
+    $ avocado --silent run /path/to/my/test.py
     if [ $? == 0 ]; then
        echo "great success!"
     elif
@@ -138,22 +207,22 @@ You can have multiple results formats at once, as long as only one of them
 uses the standard output. For example, it is fine to use the xunit result on
 stdout and the JSON result to output to a file::
 
-    $ scripts/avocado --xunit - --json /tmp/result.json run "sleeptest synctest"
-    <?xml version="1.0" encoding="UTF-8"?>
-    <testsuite name="avocado" tests="2" errors="0" failures="0" skipped="0" time="3.21392536163" timestamp="2014-06-11 01:49:35.858187">
-        <testcase classname="sleeptest" name="sleeptest.1" time="1.34533214569"/>
-        <testcase classname="synctest" name="synctest.1" time="1.86859321594"/>
-    </testsuite>
+   $ avocado run sleeptest.py synctest.py --xunit - --json /tmp/result.json
+   <?xml version="1.0" encoding="UTF-8"?>
+   <testsuite name="avocado" tests="2" errors="0" failures="0" skipped="0" time="3.64848303795" timestamp="2016-05-04 17:26:05.645665">
+           <testcase classname="SleepTest" name="1-sleeptest.py:SleepTest.test" time="1.00270605087"/>
+           <testcase classname="SyncTest" name="2-synctest.py:SyncTest.test" time="2.64577698708"/>
+   </testsuite>
 
-    $ cat /tmp/result.json
-    {"tests": [{"test": "sleeptest.1", "url": "sleeptest", "status": "PASS", "time": 1.345332145690918}, {"test": "synctest.1", "url": "synctest", "status": "PASS", "time": 1.8685932159423828}], "errors": 0, "skip": 0, "time": 3.213925361633301, "debuglog": "$HOME/avocado/logs/run-2014-06-11-01.49.35/debug.log", "pass": 2, "failures": 0, "total": 2}
+   $ cat /tmp/result.json
+   {"tests": [{"status": "PASS", "url": "1-sleeptest.py:SleepTest.test",...
 
 But you won't be able to do the same without the --json flag passed to
 the program::
 
-    $ scripts/avocado --xunit - --json - run "sleeptest synctest"
-    Avocado could not set --json and --xunit both to output to stdout.
-    Please set the output flag of one of them to a file to avoid conflicts.
+   $ avocado run sleeptest.py synctest.py --xunit - --json -
+   Options --json --xunit are trying to use stdout simultaneously
+   Please set at least one of them to a file to avoid conflicts
 
 That's basically the only rule, and a sane one, that you need to follow.
 

--- a/docs/source/RunningTestsRemotely.rst
+++ b/docs/source/RunningTestsRemotely.rst
@@ -41,7 +41,7 @@ Make sure you have:
  1) Avocado packages installed. You can see more info on how to do that in
     the :ref:`get-started` section.
  2) The remote machine IP address or fully qualified hostname and the SSH port number.
- 3) All pre-requesites for your test to run installed inside the remote machine
+ 3) All pre-requisites for your test to run installed inside the remote machine
     (gcc, make and others if you want to compile a 3rd party test suite written
     in C, for example).
 

--- a/docs/source/RunningTestsRemotely.rst
+++ b/docs/source/RunningTestsRemotely.rst
@@ -137,8 +137,8 @@ Once the virtual machine is properly setup, you may run your test. Example::
     JOB ID    : 60ddd718e7d7bb679f258920ce3c39ce73cb9779
     JOB LOG   : $HOME/avocado/job-results/job-2014-09-16T18.41-60ddd71/job.log
     TESTS     : 2
-     (1/2) examples/tests/sleeptest.py: PASS (1.00 s)
-     (2/2) examples/tests/failtest.py: FAIL (0.00 s)
+     (1/2) examples/tests/sleeptest.py:SleepTest.test: PASS (1.00 s)
+     (2/2) examples/tests/failtest.py:FailTest.test: FAIL (0.01 s)
     RESULTS    : PASS 1 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0
     TIME      : 1.01 s
 

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -154,16 +154,16 @@ Using a multiplex file
 You may use the Avocado runner with a multiplex file to provide params and matrix
 generation for sleeptest just like::
 
-    $ avocado run sleeptest --multiplex examples/tests/sleeptest.py.data/sleeptest.yaml
-    JOB ID    : d565e8dec576d6040f894841f32a836c751f968f
-    JOB LOG   : $HOME/avocado/job-results/job-2014-08-12T15.44-d565e8de/job.log
-    TESTS     : 3
-     (1/3) sleeptest: PASS (0.50 s)
-     (2/3) sleeptest.1: PASS (1.01 s)
-     (3/3) sleeptest.2: PASS (5.01 s)
+    $ avocado run sleeptest.py --multiplex examples/tests/sleeptest.py.data/sleeptest.yaml
+    JOB ID     : d565e8dec576d6040f894841f32a836c751f968f
+    JOB LOG    : $HOME/avocado/job-results/job-2014-08-12T15.44-d565e8de/job.log
+    TESTS      : 3
+     (1/3) sleeptest.py:SleepTest.test;1: PASS (0.50 s)
+     (2/3) sleeptest.py:SleepTest.test;2: PASS (1.00 s)
+     (3/3) sleeptest.py:SleepTest.test;3: PASS (5.00 s)
     RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0
-    JOB HTML  : $HOME/avocado/job-results/job-2014-08-12T15.44-d565e8de/html/results.html
-    TIME : 6.52 s
+    JOB HTML   : $HOME/avocado/job-results/job-2014-08-12T15.44-d565e8de/html/results.html
+    TIME       : 6.50 s
 
 The ``--multiplex`` accepts either only ``$FILE_LOCATION`` or ``$INJECT_TO:$FILE_LOCATION``.
 As explained in :doc:`MultiplexConfig` without any path the content gets
@@ -186,21 +186,22 @@ can't leave the test ID empty::
 
 You can also execute multiple tests with the same multiplex file::
 
-    ./scripts/avocado run sleeptest synctest --multiplex examples/tests/sleeptest.py.data/sleeptest.yaml
-    JOB ID     : 72166988c13fec26fcc9c2e504beec8edaad4761
-    JOB LOG    : /home/medic/avocado/job-results/job-2015-05-15T11.02-7216698/job.log
+    $ avocado run sleeptest.py synctest.py --multiplex examples/tests/sleeptest.py.data/sleeptest.yaml
+    JOB ID     : cd20fc8d1714da6d4791c19322374686da68c45c
+    JOB LOG    : $HOME/avocado/job-results/job-2016-05-04T09.25-cd20fc8/job.log
     TESTS      : 8
-     (1/8) sleeptest.py: PASS (1.00 s)
-     (2/8) sleeptest.py.1: PASS (1.00 s)
-     (3/8) sleeptest.py.2: PASS (1.00 s)
-     (4/8) sleeptest.py.3: PASS (1.00 s)
-     (5/8) synctest.py: PASS (1.31 s)
-     (6/8) synctest.py.1: PASS (1.48 s)
-     (7/8) synctest.py.2: PASS (3.36 s)
-     (8/8) synctest.py.3: PASS (3.59 s)
+     (1/8) sleeptest.py:SleepTest.test;1: PASS (0.50 s)
+     (2/8) sleeptest.py:SleepTest.test;2: PASS (1.00 s)
+     (3/8) sleeptest.py:SleepTest.test;3: PASS (5.01 s)
+     (4/8) sleeptest.py:SleepTest.test;4: PASS (10.00 s)
+     (5/8) synctest.py:SyncTest.test;1: PASS (2.38 s)
+     (6/8) synctest.py:SyncTest.test;2: PASS (2.47 s)
+     (7/8) synctest.py:SyncTest.test;3: PASS (2.46 s)
+     (8/8) synctest.py:SyncTest.test;4: PASS (2.45 s)
     RESULTS    : PASS 8 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0
-    JOB HTML   : /home/medic/avocado/job-results/job-2015-05-15T11.02-7216698/html/results.html
-    TIME       : 13.76 s
+    JOB HTML   : $HOME/avocado/job-results/job-2016-05-04T09.25-cd20fc8/html/results.html
+    TIME       : 26.26 s
+
 
 Advanced logging capabilities
 =============================
@@ -450,7 +451,8 @@ parameters, using :func:`avocado.utils.process.system`.
 
 Fetching asset files
 ====================
-To run third party test suites as mentioned above, or for any other pourpose,
+
+To run third party test suites as mentioned above, or for any other purpose,
 we offer an asset fetcher as a method of Avocado Test class.
 The asset method looks for a list of directories in the ``cache_dirs`` key,
 inside the ``[datadir.paths]`` section from the configuration files. Read-only
@@ -572,11 +574,11 @@ From those 2 files, only stdout.expected is non empty::
 The output files were originally obtained using the test runner and passing the
 option --output-check-record all to the test runner::
 
-    $ scripts/avocado run --output-check-record all synctest
+    $ scripts/avocado run --output-check-record all synctest.py
     JOB ID    : bcd05e4fd33e068b159045652da9eb7448802be5
     JOB LOG   : $HOME/avocado/job-results/job-2014-09-25T20.20-bcd05e4/job.log
     TESTS     : 1
-     (1/1) synctest.py: PASS (2.20 s)
+     (1/1) synctest.py:SyncTest.test: PASS (2.20 s)
     RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0
     TIME      : 2.20 s
 
@@ -605,7 +607,7 @@ Let's record the output for this one::
     JOB ID    : 25c4244dda71d0570b7f849319cd71fe1722be8b
     JOB LOG   : $HOME/avocado/job-results/job-2014-09-25T20.49-25c4244/job.log
     TESTS     : 1
-     (1/1) home/$USER/Code/avocado/output_record.sh: PASS (0.01 s)
+     (1/1) output_record.sh: PASS (0.01 s)
     RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0
     TIME      : 0.01 s
 
@@ -630,14 +632,14 @@ happens if we change the ``stdout.expected`` file contents to ``Hello, Avocado!`
     JOB ID    : f0521e524face93019d7cb99c5765aedd933cb2e
     JOB LOG   : $HOME/avocado/job-results/job-2014-09-25T20.52-f0521e5/job.log
     TESTS     : 1
-     (1/1) home/$USER/Code/avocado/output_record.sh: FAIL (0.02 s)
+     (1/1) output_record.sh: FAIL (0.02 s)
     RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0
     TIME      : 0.02 s
 
 Verifying the failure reason::
 
     $ cat $HOME/avocado/job-results/job-2014-09-25T20.52-f0521e5/job.log
-    20:52:38 test       L0163 INFO | START home/$USER/Code/avocado/output_record.sh
+    20:52:38 test       L0163 INFO | START 1-output_record.sh
     20:52:38 test       L0164 DEBUG|
     20:52:38 test       L0165 DEBUG| Test instance parameters:
     20:52:38 test       L0173 DEBUG|
@@ -671,7 +673,7 @@ Verifying the failure reason::
     20:52:38 test       L0063 ERROR| Hello, Avocado!
     20:52:38 test       L0063 ERROR|
     20:52:38 test       L0064 ERROR|
-    20:52:38 test       L0529 ERROR| FAIL home/$USER/Code/avocado/output_record.sh -> AssertionError: Actual test sdtout differs from expected one:
+    20:52:38 test       L0529 ERROR| FAIL 1-output_record.sh -> AssertionError: Actual test sdtout differs from expected one:
     Actual:
     Hello, world!
 
@@ -768,19 +770,19 @@ impact your test grid. You can account for that possibility and set up a
 
 ::
 
-    $ avocado run sleeptest --multiplex /tmp/sleeptest-example.yaml
+    $ avocado run sleeptest.py --multiplex /tmp/sleeptest-example.yaml
     JOB ID    : 6d5a2ff16bb92395100fbc3945b8d253308728c9
     JOB LOG   : $HOME/avocado/job-results/job-2014-08-12T15.52-6d5a2ff1/job.log
     JOB HTML  : $HOME/avocado/job-results/job-2014-08-12T15.52-6d5a2ff1/html/results.html
     TESTS     : 1
-     (1/1) sleeptest.1: ERROR (2.97 s)
+     (1/1) sleeptest.py:SleepTest.test: ERROR (2.97 s)
     RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0
     TIME      : 2.97 s
 
 ::
 
     $ cat $HOME/avocado/job-results/job-2014-08-12T15.52-6d5a2ff1/job.log
-    15:52:51 test       L0143 INFO | START sleeptest.1
+    15:52:51 test       L0143 INFO | START 1-sleeptest.py
     15:52:51 test       L0144 DEBUG|
     15:52:51 test       L0145 DEBUG| Test log: $HOME/avocado/job-results/job-2014-08-12T15.52-6d5a2ff1/sleeptest.1/test.log
     15:52:51 test       L0146 DEBUG| Test instance parameters:
@@ -811,7 +813,7 @@ impact your test grid. You can account for that possibility and set up a
     15:52:54 test       L0060 ERROR|     raise exceptions.TestTimeoutError(e_msg)
     15:52:54 test       L0060 ERROR| TestTimeoutError: Timeout reached waiting for sleeptest to end
     15:52:54 test       L0061 ERROR|
-    15:52:54 test       L0400 ERROR| ERROR sleeptest.1 -> TestTimeoutError: Timeout reached waiting for sleeptest to end
+    15:52:54 test       L0400 ERROR| ERROR 1-sleeptest.py -> TestTimeoutError: Timeout reached waiting for sleeptest to end
     15:52:54 test       L0387 INFO |
 
 
@@ -854,20 +856,20 @@ This accomplishes a similar effect to the multiplex setup defined in there.
 
 ::
 
-    $ avocado run timeouttest
+    $ avocado run timeouttest.py
     JOB ID    : d78498a54504b481192f2f9bca5ebb9bbb820b8a
     JOB LOG   : $HOME/avocado/job-results/job-2014-08-12T15.54-d78498a5/job.log
     JOB HTML  : $HOME/avocado/job-results/job-2014-08-12T15.54-d78498a5/html/results.html
     TESTS     : 1
-     (1/1) timeouttest.1: ERROR (2.97 s)
+     (1/1) timeouttest.py:TimeoutTest.test: INTERRUPTED (3.04 s)
     RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0
-    TIME      : 2.97 s
+    TIME      : 3.04 s
 
 
 ::
 
     $ cat $HOME/avocado/job-results/job-2014-08-12T15.54-d78498a5/job.log
-    15:54:28 test       L0143 INFO | START timeouttest.1
+    15:54:28 test       L0143 INFO | START 1-timeouttest.py:TimeoutTest.test
     15:54:28 test       L0144 DEBUG|
     15:54:28 test       L0145 DEBUG| Test log: $HOME/avocado/job-results/job-2014-08-12T15.54-d78498a5/timeouttest.1/test.log
     15:54:28 test       L0146 DEBUG| Test instance parameters:
@@ -890,7 +892,7 @@ This accomplishes a similar effect to the multiplex setup defined in there.
     15:54:31 test       L0060 ERROR|     raise exceptions.TestTimeoutError(e_msg)
     15:54:31 test       L0060 ERROR| TestTimeoutError: Timeout reached waiting for timeouttest to end
     15:54:31 test       L0061 ERROR|
-    15:54:31 test       L0400 ERROR| ERROR timeouttest.1 -> TestTimeoutError: Timeout reached waiting for timeouttest to end
+    15:54:31 test       L0400 ERROR| ERROR 1-timeouttest.py:TimeoutTest.test -> TestTimeoutError: Timeout reached waiting for timeouttest to end
     15:54:31 test       L0387 INFO |
 
 

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -60,7 +60,7 @@ Note that the test class provides you with a number of convenience attributes:
 Saving test generated (custom) data
 ===================================
 
-Each test instance provides a so called ``whiteboard``. It that can be accessed
+Each test instance provides a so called ``whiteboard``. It can be accessed
 through ``self.whiteboard``. This whiteboard is simply a string that will be
 automatically saved to test results (as long as the output format supports it).
 If you choose to save binary data to the whiteboard, it's your responsibility to

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -91,14 +91,15 @@ Avocado finds and populates ``self.params`` with all parameters you define on
 a Multiplex Config file (see :doc:`MultiplexConfig`). As an example, consider
 the following multiplex file for sleeptest::
 
-    sleeptest: !mux
+    sleeptest:
         type: "builtin"
-        short:
-            sleep_length: 0.5
-        medium:
-            sleep_length: 1
-        long:
-            sleep_length: 5
+        length: !mux
+            short:
+                sleep_length: 0.5
+            medium:
+                sleep_length: 1
+            long:
+                sleep_length: 5
 
 When running this example by ``avocado run $test --multiplex $file.yaml``
 three variants are executed and the content is injected into ``/run`` namespace
@@ -106,8 +107,8 @@ three variants are executed and the content is injected into ``/run`` namespace
 "type" and "sleep_length". To obtain the current value, you need the name
 ("sleep_length") and its path. The path differs for each variant so it's
 needed to use the most suitable portion of the path, in this example:
-"/run/sleeptest/*" or perhaps "sleeptest/*" might be enough. It depends on how
-your setup looks like.
+`/run/sleeptest/length/*` or perhaps `sleeptest/*` might be enough. It depends
+on how your setup looks like.
 
 The default value is optional, but always keep in mind to handle them nicely.
 Someone might be executing your test with different params or without any


### PR DESCRIPTION
This PR fixes a feature removed accidentally in 0.34.0, fixes couple of issues in the current documentation and finally brings the serialized-test-ids https://github.com/avocado-framework/avocado/pull/1158 and alias modification https://github.com/avocado-framework/avocado/pull/1159 documentation.

trello: https://trello.com/c/p3D97waT/647-test-ids-logs-ui-and-documentation
v1: https://github.com/avocado-framework/avocado/pull/1186

changes:

    v2: Fixed missing `sleeptest` => `sleeptest.py`
    v2: Improved the Test References/TestName description in ReferenceGuide
    v2: Use `json.tool` instead of `pprint` to humanize the results