### PR TITLE
[36lts] avocado: Avoid custom handling of SIGINT and SIGUSR

### DIFF
--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -37,6 +37,7 @@ from ..utils import runtime
 from ..utils import process
 
 TEST_LOG = logging.getLogger("avocado.test")
+APP_LOG = logging.getLogger("avocado.app")
 
 
 class TestStatus(object):
@@ -68,9 +69,8 @@ class TestStatus(object):
         # Let's catch all exceptions, since errors here mean a
         # crash in avocado.
         except Exception as details:
-            log = logging.getLogger("avocado.app")
-            log.error("\nError receiving message from test: %s -> %s",
-                      details.__class__, details)
+            APP_LOG.error("\nError receiving message from test: %s -> %s",
+                          details.__class__, details)
             stacktrace.log_exc_info(sys.exc_info(),
                                     'avocado.app.tracebacks')
             return None
@@ -222,10 +222,10 @@ class TestRunner(object):
         """
         signal.signal(signal.SIGTSTP, signal.SIG_IGN)
         logger_list_stdout = [logging.getLogger('avocado.test.stdout'),
-                              logging.getLogger('avocado.test'),
+                              TEST_LOG,
                               logging.getLogger('paramiko')]
         logger_list_stderr = [logging.getLogger('avocado.test.stderr'),
-                              logging.getLogger('avocado.test'),
+                              TEST_LOG,
                               logging.getLogger('paramiko')]
         sys.stdout = output.LoggingFile(logger=logger_list_stdout)
         sys.stderr = output.LoggingFile(logger=logger_list_stderr)
@@ -290,15 +290,13 @@ class TestRunner(object):
             with sigtstp:
                 msg = "ctrl+z pressed, %%s test (%s)" % proc.pid
                 if self.sigstopped:
-                    logging.getLogger("avocado.app").info("\n" + msg,
-                                                          "resumming")
-                    logging.getLogger("avocado.test").info(msg, "resumming")
+                    APP_LOG.info("\n" + msg, "resumming")
+                    TEST_LOG.info(msg, "resumming")
                     process.kill_process_tree(proc.pid, signal.SIGCONT, False)
                     self.sigstopped = False
                 else:
-                    logging.getLogger("avocado.app").info("\n" + msg,
-                                                          "stopping")
-                    logging.getLogger("avocado.test").info(msg, "stopping")
+                    APP_LOG.info("\n" + msg, "stopping")
+                    TEST_LOG.info(msg, "stopping")
                     process.kill_process_tree(proc.pid, signal.SIGSTOP, False)
                     self.sigstopped = True
 

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -242,8 +242,8 @@ class RunnerOperationTest(unittest.TestCase):
                             "Avocado crashed (rc %d):\n%s" % (unexpected_rc, result))
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %d:\n%s" % (expected_rc, result))
-        self.assertIn("TestTimeoutInterrupted: Timeout reached waiting for", output,
-                      "Test did not fail with timeout exception:\n%s" % output)
+        self.assertIn("RUNNER: Timeout reached", output,
+                      "Timeout reached message not found in the output:\n%s" % output)
         # Ensure no test aborted error messages show up
         self.assertNotIn("TestAbortedError: Test aborted unexpectedly", output)
 
@@ -607,8 +607,17 @@ class RunnerSimpleTest(unittest.TestCase):
                       "stopped.")
         self.assertIn("TIME", output, "TIME not in the output, avocado "
                       "probably died unexpectadly")
-        self.assertEqual(proc.get_status(), 1, "Avocado did not finish with "
+        self.assertEqual(proc.get_status(), 8, "Avocado did not finish with "
                          "1.")
+        debug_log = os.path.join(self.tmpdir, "latest", "test-results",
+                                 "1-_bin_sleep 60", "debug.log")
+        debug_log = open(debug_log).read()
+        self.assertIn("RUNNER: Timeout reached", debug_log, "RUNNER: Timeout "
+                      "reached message not in the test's debug.log:\n%s"
+                      % debug_log)
+        self.assertNotIn("Traceback", debug_log, "Traceback present in the "
+                         "test's debug.log file, but it was suppose to be "
+                         "stopped and unable to produce it.\n%s" % debug_log)
 
     def tearDown(self):
         self.pass_script.remove()


### PR DESCRIPTION
Currently avocado adds custom handlers of SIGINT and SIGUSR1 in order to
produce traceback and notify about user interaction or timeout. This
could be missleading in case the test uses those signals and potentially
dangerous as some tests assume default behavior.

This patch removes the custom handling of SIGINT and SIGUSR1 and
reports the failure in `job.log`. Additionally it tries to inject the
error message in the test output, if status.logfile available.

In order to keep the useful traceback in case of interruption, this
patch overrides the default SIGTERM handler. The default behavior of
SIGTERM is to die, our custom handler raises SystemExit with info saying
the test was interrupted by sigterm, which should generate traceback and
finish. The runner then changes the result to INTERRUPTED, so even
when the test modifies the SIGTERM handler, we get the correct status.

Worth mentioning that in case test ignores SIGTERM, SIGKILL is emitted
by the runner, so this should be safe approach.

trello: https://trello.com/c/iYRNmjrg/571-bug-avocado-custom-signal-handling-interferes-with-tests
master: https://github.com/avocado-framework/avocado/pull/1192