### PR TITLE
linuxbuild: fix NameError that 'os' is not defined

### DIFF
--- a/examples/tests/linuxbuild.py
+++ b/examples/tests/linuxbuild.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+import os
+
 from avocado import Test
 from avocado import main
 from avocado.utils import kernel


### PR DESCRIPTION
Signed-off-by: Wei Jiangang <weijg.fnst@cn.fujitsu.com>