### PR TITLE
Job scripts: add core dump handling set of scripts

### DIFF
--- a/contrib/job-scripts/coreudmp-handling/README
+++ b/contrib/job-scripts/coreudmp-handling/README
@@ -1,0 +1,30 @@
+These are a set of scripts that will:
+
+* Setup the core pattern to the "coredumps" sub directory of the
+  current job
+* Restore the original settings once the job finishes running tests
+* Links the core files (if any) on the job level "coredumps" subdir
+  into the test result specific "coredumps" dir based on the PID and
+  log file pattern matching.  Other conditions could be added.
+
+One setting that has to be done by yourself, either in your session or
+as a systemwide configuration is setting the core file size limits, or
+more exactly.  Just run:
+
+ $ ulimit -c unlimited
+
+Or set it permanently with an entry in /etc/security/limits.conf, or
+add a file to /etc/security/limits.d.
+
+To enable those during a development session, set the following configuration
+content:
+
+[plugins.jobscripts]
+pre = <THIS_FOLDER_PATH>/pre.d/
+post = <THIS_FOLDER_PATH>/post.d/
+warn_non_existing_dir = True
+warn_non_zero_status = True
+
+WARNING: Since the core pattern is a system wide setting, if you run
+multiple parallel jobs with these scripts, the result is pretty much
+unpredictable and prone to errors.

--- a/contrib/job-scripts/coreudmp-handling/post.d/001-restore-core-pattern
+++ b/contrib/job-scripts/coreudmp-handling/post.d/001-restore-core-pattern
@@ -1,0 +1,11 @@
+#!/bin/sh -e
+
+if [ -z $AVOCADO_JOB_LOGDIR ]; then
+   exit 1
+fi
+
+BACKUP_CORE_PATTERN="$AVOCADO_JOB_LOGDIR/crash-dumps/.backup_core_pattern"
+if [ -f $BACKUP_CORE_PATTERN ]; then
+    cat $BACKUP_CORE_PATTERN > /proc/sys/kernel/core_pattern
+    rm $BACKUP_CORE_PATTERN
+fi

--- a/contrib/job-scripts/coreudmp-handling/post.d/002-link-core-to-tests
+++ b/contrib/job-scripts/coreudmp-handling/post.d/002-link-core-to-tests
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+
+import errno
+import glob
+import os
+import re
+import sys
+
+if 'AVOCADO_JOB_LOGDIR' not in os.environ:
+    sys.exit(1)
+
+AVOCADO_JOB_LOGDIR = os.environ['AVOCADO_JOB_LOGDIR']
+if not os.path.isdir(AVOCADO_JOB_LOGDIR):
+    sys.exit(2)
+
+COREDUMPS_DIR = os.path.join(AVOCADO_JOB_LOGDIR, 'coredumps')
+if not os.path.isdir(COREDUMPS_DIR):
+    sys.exit(0)
+
+COREDUMPS = glob.glob(os.path.join(COREDUMPS_DIR, 'core.*'))
+if not COREDUMPS:
+    sys.exit(0)
+
+# If we reached this far, there are core dumps, so let's attempt to
+# link them to the test results directories.
+#
+# This pattern list can be expanded, and if a match occurs, it should
+# return as the first group member the PID (an unsigned integer) of
+# the process which may have an associated coredump file.
+PATTERNS = [r'.*\sPID\s(\d+)']
+
+regexes = map(re.compile, PATTERNS)
+test_id_regex = re.compile(r'^\d+-.*')
+tests_dir = os.path.join(AVOCADO_JOB_LOGDIR, 'test-results')
+test_dirs = os.listdir(tests_dir)
+test_dirs = [os.path.join(tests_dir, t) for t in test_dirs
+             if test_id_regex.match(t)]
+
+for test_dir in test_dirs:
+    log = os.path.join(test_dir, 'debug.log')
+    for line in open(log).readlines():
+        for regex in regexes:
+            match = regex.match(line)
+            if match is not None:
+                pid = match.groups()[0]
+                src = os.path.join(COREDUMPS_DIR, 'core.%s' % pid)
+                if os.path.isfile(src):
+                    dst_dir = os.path.join(test_dir, 'coredumps')
+                    try:
+                        os.makedirs(dst_dir)
+                    except OSError as e:
+                        if e.errno != errno.EEXIST:
+                            sys.exit(3)
+                    dst = os.path.join(dst_dir, os.path.basename(src))
+                    os.symlink(os.path.relpath(src, dst_dir),
+                               os.path.join(test_dir, dst))

--- a/contrib/job-scripts/coreudmp-handling/pre.d/001-set-core-pattern
+++ b/contrib/job-scripts/coreudmp-handling/pre.d/001-set-core-pattern
@@ -1,0 +1,14 @@
+#!/bin/sh -e
+
+if [ -z $AVOCADO_JOB_LOGDIR ]; then
+   exit 1
+fi
+
+COREDUMPS_DIR="$AVOCADO_JOB_LOGDIR/coredumps"
+mkdir $COREDUMPS_DIR
+
+# Save a backup of the core pattern setting
+cat /proc/sys/kernel/core_pattern > $COREDUMPS_DIR/.backup_core_pattern
+
+# Set core pattern
+echo "$COREDUMPS_DIR/core.%p" > /proc/sys/kernel/core_pattern


### PR DESCRIPTION
This adds a "contrib" level set of scripts that will put coredump
files in the job result directory.  Additionally, the system core
pattern, changed to achieve that result will be restore after the job
finishes running tests.

Finally, coredump files are attempted to be associated with individual
tests so users can quickly deal with the coredumps of possibly failed
tests.

Signed-off-by: Cleber Rosa <crosa@redhat.com>