### PR TITLE
avocado: Avoid Test.filename change on os.chdir

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -149,6 +149,19 @@ class Test(unittest.TestCase):
         else:
             self.name = TestName(0, self.__class__.__name__)
 
+        # Initialize filename
+        if not hasattr(self, 'filename'):
+            possibly_compiled = inspect.getfile(self.__class__)
+            if (possibly_compiled.endswith('.pyc') or
+                    possibly_compiled.endswith('.pyo')):
+                source = possibly_compiled[:-1]
+            else:
+                source = possibly_compiled
+            if os.path.exists(source):
+                self.filename = source
+            else:
+                self.filename = None
+
         self.tag = tag
         self.job = job
 
@@ -252,22 +265,6 @@ class Test(unittest.TestCase):
         if (self.filename is not None and
                 len(os.path.basename(self.filename)) < 251):
             return self.filename + '.data'
-        else:
-            return None
-
-    @property
-    def filename(self):
-        """
-        Returns the name of the file (path) that holds the current test
-        """
-        possibly_compiled = inspect.getfile(self.__class__)
-        if possibly_compiled.endswith('.pyc') or possibly_compiled.endswith('.pyo'):
-            source = possibly_compiled[:-1]
-        else:
-            source = possibly_compiled
-
-        if os.path.exists(source):
-            return source
         else:
             return None
 
@@ -641,16 +638,11 @@ class SimpleTest(Test):
                                 r' \d\d:\d\d:\d\d WARN \|')
 
     def __init__(self, name, params=None, base_logdir=None, tag=None, job=None):
+        if not hasattr(self, 'filename'):
+            self.filename = os.path.abspath(name.name)
         super(SimpleTest, self).__init__(name=name, params=params,
                                          base_logdir=base_logdir, tag=tag, job=job)
         self._command = self.filename
-
-    @property
-    def filename(self):
-        """
-        Returns the name of the file (path) that holds the current test
-        """
-        return os.path.abspath(self.name.name)
 
     def _log_detailed_cmd_info(self, result):
         """
@@ -694,13 +686,11 @@ class ExternalRunnerTest(SimpleTest):
         self.assertIsNotNone(external_runner, "External runner test requires "
                              "external_runner parameter, got None instead.")
         self.external_runner = external_runner
+        if not hasattr(self, 'filename'):
+            self.filename = None
         super(ExternalRunnerTest, self).__init__(name, params, base_logdir,
                                                  tag, job)
         self._command = external_runner.runner + " " + self.name.name
-
-    @property
-    def filename(self):
-        return None
 
     def test(self):
         pre_cwd = os.getcwd()


### PR DESCRIPTION
Changing the directory inside the test makes filename property to None
results in reseting basedir and datadir to None. This patch stores the
filename on init time to avoid such problems.

Fixes: avocado-framework/avocado-misc-tests#9
v1: https://github.com/avocado-framework/avocado/pull/1142

Changes:

    v2: Reordered the logic to avoid overriding the filename from different classes
    v2: Add fixes for the remaining Test classes

__WARNING: This requires change into avocado_vt (replace the filename property with a variable)__