### PR TITLE
Test directories: favor explicitly configured test directories

### DIFF
--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -108,10 +108,27 @@ def get_test_dir():
     Get the most appropriate test location.
 
     The test location is where we store tests written with the avocado API.
+
+    The heuristics used to determine the test dir are:
+    1) If an explicit test dir is set in the configuration system, it
+    is used.
+    2) If user is running Avocado out of the source tree, the example
+    test dir is used
+    3) System wide test dir is used
+    4) User default test dir (~/avocado/tests) is used
     """
+    configured = _get_settings_dir('test_dir')
+    if utils_path.usable_ro_dir(configured):
+        return configured
+
     if settings.settings.intree:
         return _IN_TREE_TESTS_DIR
-    return _get_ro_dir(_get_settings_dir('test_dir'), SYSTEM_TEST_DIR, USER_TEST_DIR)
+
+    if utils_path.usable_ro_dir(SYSTEM_TEST_DIR):
+        return SYSTEM_TEST_DIR
+
+    if utils_path.usable_ro_dir(USER_TEST_DIR):
+        return USER_TEST_DIR
 
 
 def get_data_dir():


### PR DESCRIPTION
Up until now, if users are running Avocado out of the source trees,
the in tree example test directories are favored.  This suits most
development use cases, but it fails to respect regular users settings
when they're running out of the source checkouts.

This changes the respected order, only using the in source tree
examples directory if a different configuration is not set.  Then the
usual system wide and user default directories are used.

Reference: https://trello.com/c/VKWgvm2E
Signed-off-by: Cleber Rosa <crosa@redhat.com>