### PR TITLE
Makefile: implement make-requirements-plugins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ all:
 	@echo "Package requirements related targets"
 	@echo "requirements:            Install runtime requirements"
 	@echo "requirements-selftests:  Install runtime and selftests requirements"
+	@echo "requirements-plugins:    Install plugins requirements"
 	@echo
 	@echo "Platform independent distribution/installtion related targets:"
 	@echo "source:   Create source package"
@@ -126,6 +127,11 @@ requirements:
 
 requirements-selftests: requirements
 	- pip install -r requirements-selftests.txt
+
+requirements-plugins: requirements
+	for MAKEFILE in $(AVOCADO_PLUGINS);\
+		do AVOCADO_DIRNAME=$(AVOCADO_DIRNAME) make -C $$MAKEFILE requirements &>/dev/null && echo ">> DONE $$MAKEFILE" || echo ">> SKIP $$MAKEFILE";\
+	done
 
 smokecheck:
 	./scripts/avocado run passtest

--- a/docs/source/ContributionGuide.rst
+++ b/docs/source/ContributionGuide.rst
@@ -25,17 +25,17 @@ available).
 Avocado supports various plugins, which are distributed as separate projects,
 for example "avocado-vt" and "avocado-virt". These also need to be
 deployed and linked in order to work properly with the avocado from
-sources (installed version works out of the box). To simplify this
-one can use `make link` Makefile target. The prerequisite is that you need
-to put all the projects in the same parent directory. Then by running
-`make link` inside the main avocado project you link and develop the
-separated projects as well as avocado itself. The workflow could be::
+sources (installed version works out of the box). To simplify this you can
+use `make requirements-plugins` from the main avocado project to install
+requirements of the plugins and `make link` to link and develop the
+plugins. The workflow could be::
 
     $ cd $AVOCADO_PROJECTS_DIR
     $ git clone $AVOCADO_GIT
     $ git clone $AVOCADO_PROJECT2
     $ # Add more projects
     $ cd avocado    # go into the main avocado project dir
+    $ make requirements-plugins
     $ make link
 
 You should see the process and status for each directory.


### PR DESCRIPTION
Support `make requirements-plugins` to walk all sub-directories
like the same way `make link` works.

v1: https://github.com/avocado-framework/avocado/pull/1205

Changes:

    v2: Depend on "requirements" to install main avocado requirements first
    v2: Add documentation