### PR TITLE
avocado/core/loader.py: always use absolute module path at import time

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -238,7 +238,7 @@ class TestLoaderProxy(object):
             test_path = None
         if isinstance(test_class, str):
             module_name = os.path.basename(test_path).split('.')[0]
-            test_module_dir = os.path.dirname(test_path)
+            test_module_dir = os.path.abspath(os.path.dirname(test_path))
             # Tests with local dir imports need this
             try:
                 sys.path.insert(0, test_module_dir)


### PR DESCRIPTION
The path of the module to be imported/loaded is reflected later at run
time.  Non-absolute paths can refer to the wrong locations if the
current working directory changes.  Absolute paths are always
absolutes, so, let's use them.

Signed-off-by: Cleber Rosa <crosa@redhat.com>