### PR TITLE
avocado.core.job: Stop logging after the jobpost hook

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -513,7 +513,6 @@ class Job(object):
         summary = self.test_runner.run_suite(self.test_suite, mux, self.timeout,
                                              replay_map,
                                              self.args.test_result_total)
-        self.__stop_job_logging()
         # If it's all good so far, set job status to 'PASS'
         if self.status == 'RUNNING':
             self.status = 'PASS'
@@ -586,6 +585,7 @@ class Job(object):
             if not settings.get_value('runner.behavior', 'keep_tmp_files',
                                       key_type=bool, default=False):
                 data_dir.clean_tmp_files()
+            self.__stop_job_logging()
 
 
 class TestProgram(object):


### PR DESCRIPTION
Currently avocado executes the job-post hook after disabling the test
logging, which, as a matter of fact, is also the job logging. That means
the output produced by job-post plugins is not stored. This patch moves
disabling of the test log into the finally part after the job post hooks
were executed.

Note: I'm not talking about the "app" error messages, but about the
stdout/stderr and avocado.test outputs.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>