### PR TITLE
docs: add information on LTS repositories

### DIFF
--- a/docs/source/GetStartedGuide.rst
+++ b/docs/source/GetStartedGuide.rst
@@ -22,9 +22,27 @@ are being made to support other GNU/Linux based platforms.
 Fedora
 ------
 
-You can install the RPM packages by running the following commands::
+First, get the package repositories configuration file by running the following command::
 
     sudo curl https://repos-avocadoproject.rhcloud.com/static/avocado-fedora.repo -o /etc/yum.repos.d/avocado.repo
+
+Now check if you have the ``avocado`` and ``avocado-lts`` repositories configured by running::
+
+    sudo dnf repolist avocado avocado-lts
+    ...
+    repo id      repo name                          status
+    avocado      Avocado                            50
+    avocado-lts  Avocado LTS (Long Term Stability)  disabled
+
+Regular users of Avocado will want to use the standard ``avocado``
+repository, which tracks the latest Avocado releases.  For more
+information about the LTS releases, please refer to the `Avocado Long
+Term Supportability`_ thread and to your package management docs on
+how to switch to the ``avocado-lts`` repo.
+
+Finally, after deciding between regular Avocado releases or LTS, you
+can install the RPM packages by running the following commands::
+
     sudo dnf install avocado
 
 Enterprise Linux
@@ -38,6 +56,11 @@ such as CentOS, just adapt to the following URL and commands::
     # Add avocado repository and install avocado
     sudo curl https://repos-avocadoproject.rhcloud.com/static/avocado-el.repo -o /etc/yum.repos.d/avocado.repo
     sudo yum install avocado
+
+The LTS (Long Term Supportability) repositories are also available for
+Enterprise Linux.  Please refer to the `Avocado Long Term
+Supportability`_ thread and to your package management docs on how to
+switch to the ``avocado-lts`` repo.
 
 Generic installation from a GIT repository
 ------------------------------------------
@@ -281,3 +304,5 @@ In order to do that, you can use ``avocado --show test run ...`` or
 
 As you can see, the UI output is suppressed and only the job log is shown,
 making this a useful feature for test development and debugging.
+
+.. _Avocado Long Term Supportability: https://www.redhat.com/archives/avocado-devel/2016-April/msg00038.html


### PR DESCRIPTION
Avocado now has both the regular and LTS package repositories. Let's
give some background on them, and let users know that they can choose
between the two.

Signed-off-by: Cleber Rosa <crosa@redhat.com>