### PR TITLE
avocado.plugins: Add TAP output plugin

### DIFF
--- a/avocado/plugins/tap.py
+++ b/avocado/plugins/tap.py
@@ -1,0 +1,106 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat, Inc. 2016
+# Author: Lukas Doktor <ldoktor@redhat.com>
+"""
+TAP output module.
+"""
+
+import logging
+
+from ..core.result import register_test_result_class, TestResult
+from .base import CLI
+
+
+class TAPResult(TestResult):
+    """
+    TAP output class
+    """
+
+    def __init__(self, job, force_output_file=None):
+        def writeln(msg, *args):
+            """
+            Format msg and append '\n'
+            """
+            return self.output.write(msg % args + "\n")
+        super(TAPResult, self).__init__(job)
+        self.output = force_output_file or getattr(self.args, 'tap', '-')
+        if self.output != '-':
+            self.output = open(self.output, "w", 1)
+            self.__write = writeln
+        else:
+            self.__write = logging.getLogger(
+                "avocado.app").debug   # pylint: disable=R0204
+
+    def start_tests(self):
+        """
+        Log the test plan
+        """
+        super(TAPResult, self).start_tests()
+        self.__write("1..%s", self.tests_total)
+
+    def end_test(self, state):
+        """
+        Log the test status and details
+        """
+        status = state.get("status", "ERRPR")
+        name = state.get("name")
+        if not name:
+            name = "Unknown"
+        else:
+            name = name.name + name.str_variant
+            name.replace('#', '_')  # Name must not contain #
+            if name[0].isdigit():   # Name must not start with digit
+                name = "_" + name
+        tap_status = "ok"
+        extra = ""
+        if status == "PASS":
+            pass
+        elif status == "WARN":
+            extra = "\n# Previous test finished with warning"
+        elif status == "SKIP":
+            extra = " # SKIP %s" % state.get("fail_reason")
+        else:
+            tap_status = "not ok"
+            extra = ("\n# Previous test finished with %s, details:\n#    "
+                     % status)
+            extra += "\n#    ".join(str(state.get("fail_reason")).splitlines())
+        self.__write("%s %s - %s%s", tap_status, self.tests_run, name, extra)
+        super(TAPResult, self).end_test(state)
+
+    def end_tests(self):
+        if self.output is not '-':
+            self.output.close()
+
+
+class TAP(CLI):
+
+    """
+    TAP Test Anything Protocol output avocado plugin
+    """
+
+    name = 'TAP'
+    description = "TAP - Test Anything Protocol results"
+
+    def configure(self, parser):
+        cmd_parser = parser.subcommands.choices.get('run', None)
+        if cmd_parser is None:
+            return
+
+        cmd_parser.output.add_argument('--tap', type=str, metavar='FILE',
+                                       help="Enable TAP result output and "
+                                       "write it to FILE. Use '-' to redirect "
+                                       "to the standard output.")
+
+    def run(self, args):
+        if getattr(args, "tap", False):
+            register_test_result_class(args, TAPResult)

--- a/setup.py
+++ b/setup.py
@@ -136,6 +136,7 @@ if __name__ == '__main__':
                   'html = avocado.plugins.html:HTML',
                   'remote = avocado.plugins.remote:Remote',
                   'replay = avocado.plugins.replay:Replay',
+                  'tap = avocado.plugins.tap:TAP',
                   'vm = avocado.plugins.vm:VM',
                   ],
               'avocado.plugins.cli.cmd': [


### PR DESCRIPTION
This patch adds simple TAP (v12) results plugin. It supports stdout/file
output and is fully stream-lined (uses 1 line buffering to file).

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>