### PR TITLE
Makefile: boostrap pip installation automatically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,10 @@ clean:
 	rm -rf /tmp/avocado*
 	find . -name '*.pyc' -delete
 
-requirements:
+pip:
+	$(PYTHON) -m pip --version || $(PYTHON) -c "import os; import sys; import urllib; f = urllib.urlretrieve('https://bootstrap.pypa.io/get-pip.py')[0]; os.system('%s %s' % (sys.executable, f))"
+
+requirements: pip
 	- pip install "pip>=6.0.1"
 	- pip install -r requirements.txt
 


### PR DESCRIPTION
While testing `make requirements*` on a fresh machine, I found that
we rely on pip itself, which may not be available.  Its bootstrap
process is pretty simple, atomic and well documented, so it seems
like a good idea to add it as a convenience.

Signed-off-by: Cleber Rosa <crosa@redhat.com>