### PR TITLE
[rfc]  environment variables configuration on remote machines

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -503,6 +503,12 @@ class Test(unittest.TestCase):
         self.sysinfo_logger.end_test_hook()
 
     def _setup_environment_variables(self):
+        if self.job is not None:
+            test_env_vars = getattr(self.job.args, 'test_env', None)
+            if test_env_vars is not None:
+                for key, value in test_env_vars.items():
+                    os.environ[key] = value
+
         os.environ['AVOCADO_VERSION'] = VERSION
         if self.basedir is not None:
             os.environ['AVOCADO_TEST_BASEDIR'] = self.basedir

--- a/avocado/plugins/envvars.py
+++ b/avocado/plugins/envvars.py
@@ -1,0 +1,73 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2016
+# Author: Amador Pahim <apahim@redhat.com>
+
+import argparse
+import os
+from .base import CLI
+from avocado.core.settings import settings
+
+
+class EnvVars(CLI):
+
+    """
+    Set environment variables
+    """
+
+    name = 'envvars'
+    description = "Set variables in tests processes environemnt"
+
+    def configure(self, parser):
+        run_subcommand_parser = parser.subcommands.choices.get('run', None)
+        if run_subcommand_parser is None:
+            return
+
+        msg = 'environemnt variables'
+        replay_parser = run_subcommand_parser.add_argument_group(msg)
+        replay_parser.add_argument('--test-env', dest='test_env',
+                                   default=None,
+                                   type=self._parse_test_env_vars,
+                                   help='Set environemnt variables for tests')
+
+    def _parse_test_env_vars(self, string):
+        # Convert this:
+        #  'key=value,key2=value2,key3=value3'
+        # into this:
+        #  {'key': 'value', 'key2': 'value2', 'key3': 'value3'}
+        try:
+            env_dict = {}
+            env_list = string.split(',')
+            for item in env_list:
+                key, value = item.split('=', 1)
+                env_dict.update({key: value})
+            return env_dict
+        except:
+            raise argparse.ArgumentTypeError('Invalid format.')
+
+    def run(self, args):
+        if getattr(args, 'test_env', None) is None:
+            return
+
+        env_vars = settings.get_value('test.environment', 'env_vars',
+                                      key_type=list, default=None)
+        if env_vars is not None:
+            for item in env_vars:
+                args.test_env.update(self._parse_test_env_vars(item))
+
+        env_keep = settings.get_value('test.environment', 'env_keep',
+                                      key_type=list, default=None)
+        if env_keep is not None:
+            for key in env_keep:
+                value = os.environ.get(key)
+                if value is not None:
+                    args.test_env.update({key: value})

--- a/etc/avocado/avocado.conf
+++ b/etc/avocado/avocado.conf
@@ -80,3 +80,11 @@ skip_broken_plugin_notification = []
 # options or test types).
 # The keyword "@DEFAULT" will be replaced with all available unused loaders.
 loaders = ['file', '@DEFAULT']
+
+[test.environment]
+# List of environment variables and its value that will be set on test
+# process environemnt
+# env_vars = ['FOO=BAR', 'FOO2=BAR2']
+# List of environemnt variables that will be copied (if present) from
+# the Avocado main process to the test process environemnt
+# env_keep = ['VAR1', 'VAR2']

--- a/setup.py
+++ b/setup.py
@@ -128,6 +128,7 @@ if __name__ == '__main__':
                    'scripts/avocado-rest-client'],
           entry_points={
               'avocado.plugins.cli': [
+                  'envvars = avocado.plugins.envvars:EnvVars',
                   'gdb = avocado.plugins.gdb:GDB',
                   'wrapper = avocado.plugins.wrapper:Wrapper',
                   'xunit = avocado.plugins.xunit:XUnit',


### PR DESCRIPTION
Ir order to allow users to configure environment variables for the tests
in remote machines, this patch adds:

- The --test-env option to run command, so users can set environment
variables for the tests using the command line.
- The config setting 'env_vars', so users can set environment variables
for the tests using the config file.
- The config setting 'env_keep', so users can set what environment
variables will be copied from the Avocado main process environment to
the test environment.

Signed-off-by: Amador Pahim <apahim@redhat.com>