### PR TITLE
add -j option to make

### DIFF
--- a/avocado/utils/build.py
+++ b/avocado/utils/build.py
@@ -12,6 +12,7 @@
 # Copyright: Red Hat Inc. 2013-2014
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
+import multiprocessing
 import os
 
 from . import process
@@ -41,6 +42,15 @@ def make(path, make='make', env=None, extra_args='', ignore_status=False, allow_
     cwd = os.getcwd()
     os.chdir(path)
     cmd = make
+
+    # Set default number of jobs as ncpus + 1
+    if "-j" not in os.environ.get("MAKEFLAGS", ""):
+        jobs = multiprocessing.cpu_count() + 1
+        if not env:
+            env = {"MAKEFLAGS": "-j%s" % jobs}
+        elif "-j" not in env:
+            env["MAKEFLAGS"] = "-j%s" % jobs
+
     makeopts = os.environ.get('MAKEOPTS', '')
     if makeopts:
         cmd += ' %s' % makeopts


### PR DESCRIPTION
v2:
 - Set `-j` defaults on MAKEFLAGS env variable.

v1: #1234 
Parallelism is usually a good thing when it comes to build source codes.
This patch adds the -j option to make utils using ncpus+1 when -j is not
provided by the user.

Reference: https://trello.com/c/H4e7SuOC
Signed-off-by: Amador Pahim <apahim@redhat.com>