### PR TITLE
avocado.core.test: Replace `;` in workdir too

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -273,8 +273,9 @@ class Test(unittest.TestCase):
 
     @data_structures.LazyProperty
     def workdir(self):
-        basename = os.path.basename(self.logdir)
-        return utils_path.init_dir(data_dir.get_tmp_dir(), basename.replace(':', '_'))
+        basename = (os.path.basename(self.logdir).replace(':', '_')
+                    .replace(';', '_'))
+        return utils_path.init_dir(data_dir.get_tmp_dir(), basename)
 
     @data_structures.LazyProperty
     def srcdir(self):


### PR DESCRIPTION
The `;` character is problematic for some makefiles, let's replace it
with `_` the same way we did for `:`. The result should still be
readable enough by human, it's guaranteed to be still unique which
concludes all requirements for machines regarding workdir.


Issue: https://github.com/avocado-framework/avocado-misc-tests/issues/36
Reference: https://github.com/avocado-framework/avocado/pull/756 (similar issue)