### PR TITLE
avocado.core.test: Fix SimpleTest

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -661,7 +661,7 @@ class SimpleTest(Test):
         self.log.info("Exit status: %s", result.exit_status)
         self.log.info("Duration: %s", result.duration)
 
-    def test(self):
+    def execute_cmd(self):
         """
         Run the executable, and log its detailed execution.
         """
@@ -678,8 +678,11 @@ class SimpleTest(Test):
             self._log_detailed_cmd_info(details.result)
             raise exceptions.TestFail(details)
 
-    def run(self, result=None):
-        super(SimpleTest, self).run(result)
+    def test(self):
+        """
+        Run the test and postprocess the results
+        """
+        self.execute_cmd()
         for line in open(self.logfile):
             if self.re_avocado_log.match(line):
                 raise exceptions.TestWarn("Test passed but there were warnings"
@@ -722,7 +725,7 @@ class ExternalRunnerTest(SimpleTest):
                                new_cwd)
                 os.chdir(new_cwd)
 
-            super(ExternalRunnerTest, self).test()
+            self.execute_cmd()
 
         finally:
             if new_cwd is not None:

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -640,9 +640,11 @@ class SimpleTest(Test):
     re_avocado_log = re.compile(r'^\d\d:\d\d:\d\d DEBUG\| \[stdout\]'
                                 r' \d\d:\d\d:\d\d WARN \|')
 
-    def __init__(self, name, params=None, base_logdir=None, tag=None, job=None):
+    def __init__(self, name, params=None, base_logdir=None, tag=None,
+                 job=None):
         super(SimpleTest, self).__init__(name=name, params=params,
-                                         base_logdir=base_logdir, tag=tag, job=job)
+                                         base_logdir=base_logdir, tag=tag,
+                                         job=job)
         self._command = self.filename
 
     @property
@@ -666,7 +668,7 @@ class SimpleTest(Test):
         Run the executable, and log its detailed execution.
         """
         try:
-            test_params = dict([(str(key), str(val)) for path, key, val in
+            test_params = dict([(str(key), str(val)) for _, key, val in
                                 self.params.iteritems()])
 
             # process.run uses shlex.split(), the self.path needs to be escaped

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -154,7 +154,7 @@ class LoaderTest(unittest.TestCase):
         test_parameters['name'] = test.TestName(0, test_parameters['name'])
         test_parameters['base_logdir'] = self.tmpdir
         tc = test_class(**test_parameters)
-        tc.test()
+        tc.run_avocado()
         # Load with params
         simple_with_params = simple_test.path + " 'foo bar' --baz"
         suite = self.loader.discover(simple_with_params, True)
@@ -227,7 +227,7 @@ class LoaderTest(unittest.TestCase):
         test_parameters['name'] = test.TestName(0, test_parameters['name'])
         test_parameters['base_logdir'] = self.tmpdir
         tc = test_class(**test_parameters)
-        tc.test()
+        tc.run_avocado()
         avocado_simple_test.remove()
 
     def test_py_simple_test_notexec(self):

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -1,6 +1,8 @@
+import shutil
 import stat
 import sys
 import multiprocessing
+import tempfile
 
 if sys.version_info[:2] == (2, 6):
     import unittest2 as unittest
@@ -140,6 +142,7 @@ class LoaderTest(unittest.TestCase):
     def setUp(self):
         self.loader = loader.FileLoader(None, {})
         self.queue = multiprocessing.Queue()
+        self.tmpdir = tempfile.mkdtemp(prefix="avocado-test-loader")
 
     def test_load_simple(self):
         simple_test = script.TemporaryScript('simpletest.sh', SIMPLE_TEST,
@@ -149,6 +152,7 @@ class LoaderTest(unittest.TestCase):
             self.loader.discover(simple_test.path, True)[0])
         self.assertTrue(test_class == test.SimpleTest, test_class)
         test_parameters['name'] = test.TestName(0, test_parameters['name'])
+        test_parameters['base_logdir'] = self.tmpdir
         tc = test_class(**test_parameters)
         tc.test()
         # Load with params
@@ -167,6 +171,7 @@ class LoaderTest(unittest.TestCase):
             self.loader.discover(simple_test.path, True)[0])
         self.assertTrue(test_class == test.NotATest, test_class)
         test_parameters['name'] = test.TestName(0, test_parameters['name'])
+        test_parameters['base_logdir'] = self.tmpdir
         tc = test_class(**test_parameters)
         self.assertRaises(exceptions.NotATestError, tc.test)
         simple_test.remove()
@@ -191,6 +196,7 @@ class LoaderTest(unittest.TestCase):
             self.loader.discover(avocado_not_a_test.path, True)[0])
         self.assertTrue(test_class == test.NotATest, test_class)
         test_parameters['name'] = test.TestName(0, test_parameters['name'])
+        test_parameters['base_logdir'] = self.tmpdir
         tc = test_class(**test_parameters)
         self.assertRaises(exceptions.NotATestError, tc.test)
         avocado_not_a_test.remove()
@@ -203,6 +209,7 @@ class LoaderTest(unittest.TestCase):
             self.loader.discover(avocado_not_a_test.path, True)[0])
         self.assertTrue(test_class == test.SimpleTest, test_class)
         test_parameters['name'] = test.TestName(0, test_parameters['name'])
+        test_parameters['base_logdir'] = self.tmpdir
         tc = test_class(**test_parameters)
         # The test can't be executed (no shebang), raising an OSError
         # (OSError: [Errno 8] Exec format error)
@@ -218,6 +225,7 @@ class LoaderTest(unittest.TestCase):
             self.loader.discover(avocado_simple_test.path, True)[0])
         self.assertTrue(test_class == test.SimpleTest)
         test_parameters['name'] = test.TestName(0, test_parameters['name'])
+        test_parameters['base_logdir'] = self.tmpdir
         tc = test_class(**test_parameters)
         tc.test()
         avocado_simple_test.remove()
@@ -232,6 +240,7 @@ class LoaderTest(unittest.TestCase):
             self.loader.discover(avocado_simple_test.path, True)[0])
         self.assertTrue(test_class == test.NotATest)
         test_parameters['name'] = test.TestName(0, test_parameters['name'])
+        test_parameters['base_logdir'] = self.tmpdir
         tc = test_class(**test_parameters)
         self.assertRaises(exceptions.NotATestError, tc.test)
         avocado_simple_test.remove()
@@ -321,6 +330,9 @@ class LoaderTest(unittest.TestCase):
             self.loader.discover(avocado_multiple_imp_test.path, True)[0])
         self.assertTrue(test_class == 'Second', test_class)
         avocado_multiple_imp_test.remove()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
With the d6abdcd `Test` methods changed
but for SimpleTest the wrong method was chosed and only the test
execution is performed now, the post-process class is completelly
ignored. This changes the method to the correct one and adjusts
ExternalRunner to not run this postprocess.

This fixes issue found by @clebergnu while looking at issue https://github.com/avocado-framework/avocado/issues/1244