### PR TITLE
avocado.utils.data_structures: Adjust compare_matrices

### DIFF
--- a/avocado/utils/data_structures.py
+++ b/avocado/utils/data_structures.py
@@ -71,7 +71,7 @@ def compare_matrices(matrix1, matrix2, threshold=0.05):
     same = 0
     new_matrix = []
 
-    for line1, line2 in zip(matrix1, matrix2):
+    for line1, line2 in izip(matrix1, matrix2):
         new_line = []
         elements = izip(line1, line2)
         try:
@@ -94,7 +94,7 @@ def compare_matrices(matrix1, matrix2, threshold=0.05):
                     new_line.append(".")
                     same += 1
                 else:
-                    new_line.append("Error %s/%s" % (element2, element1))
+                    new_line.append("error_%s/%s" % (element2, element1))
                     improvements += 1
                 try:
                     element1, element2 = elements.next()

--- a/selftests/unit/test_data_structures.py
+++ b/selftests/unit/test_data_structures.py
@@ -39,7 +39,7 @@ class TestDataStructures(unittest.TestCase):
         matrix2 = [["header", 57.2, 54], [2, 51, 0]]
         self.assertEqual(data_structures.compare_matrices(matrix1, matrix2),
                          ([["header", '+10.6382978723', -10.0], ['+100.0',
-                          'Error 51/0', '.']], 3, 1, 5))
+                          'error_51/0', '.']], 3, 1, 5))
 
     def test_lazy_property(self):
         """


### PR DESCRIPTION
This patch changes the error message on ZeroDivisionError to not split
by `.split()` method to allow loading the matrix by simple split.

Additionally this changes the zip method to izip in for loop.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>