### PR TITLE
Use asset fetcher for KernelBuild download() [v3]

### DIFF
--- a/examples/tests/linuxbuild.py
+++ b/examples/tests/linuxbuild.py
@@ -24,7 +24,8 @@ class LinuxBuildTest(Test):
 
         self.linux_build = kernel.KernelBuild(kernel_version,
                                               linux_config,
-                                              self.srcdir)
+                                              self.srcdir,
+                                              ['/var/tmp'])
         self.linux_build.download()
         self.linux_build.uncompress()
         self.linux_build.configure()


### PR DESCRIPTION
v3:
 - data_dirs as a list of paths.
 - add data_dirs in linuxbuild example test.

v2: #1242 
 - Introduce `data_dir` option to `KernelBuild()` so we can take advantage of the cache mechanism from the asset fetcher.

v1: #1233 
Using asset fetcher for KernelBuild download() so we can take
advantage of the cache mechanism.
Reference: https://trello.com/c/d6qeRbJD