### PR TITLE
Use asset fetcher for KernelBuild download() [v4]

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -281,6 +281,18 @@ class Test(unittest.TestCase):
     def srcdir(self):
         return utils_path.init_dir(self.workdir, 'src')
 
+    @data_structures.LazyProperty
+    def cache_dirs(self):
+        """
+        Returns a list of cache directories as set in config file.
+        """
+        cache_dirs = settings.get_value('datadir.paths', 'cache_dirs',
+                                        key_type=list, default=[])
+        datadir_cache = os.path.join(data_dir.get_data_dir(), 'cache')
+        if datadir_cache not in cache_dirs:
+            cache_dirs.append(datadir_cache)
+        return cache_dirs
+
     def __str__(self):
         return str(self.name)
 
@@ -625,11 +637,8 @@ class Test(unittest.TestCase):
                           fetched (optional)
         :returns: asset file local path
         """
-        cache_dirs = settings.get_value('datadir.paths', 'cache_dirs',
-                                        key_type=list, default=[])
-        cache_dirs.append(os.path.join(data_dir.get_data_dir(), 'cache'))
         return asset.Asset(name, asset_hash, algorithm, locations,
-                           cache_dirs).fetch()
+                           self.cache_dirs).fetch()
 
 
 class SimpleTest(Test):

--- a/examples/tests/linuxbuild.py
+++ b/examples/tests/linuxbuild.py
@@ -24,7 +24,8 @@ class LinuxBuildTest(Test):
 
         self.linux_build = kernel.KernelBuild(kernel_version,
                                               linux_config,
-                                              self.srcdir)
+                                              self.srcdir,
+                                              self.cache_dirs)
         self.linux_build.download()
         self.linux_build.uncompress()
         self.linux_build.configure()


### PR DESCRIPTION
v4:
 - Make `cache_dirs` available in `Test()` API.
 - Use `cache_dirs` from `Test()` API in the linuxbuild example test.

v3: #1248 
 - data_dirs as a list of paths.
 - add data_dirs in linuxbuild example test.

v2: #1242 
 - Introduce `data_dir` option to `KernelBuild()` so we can take advantage of the cache mechanism from the asset fetcher.

v1: #1233 
Using asset fetcher for KernelBuild download() so we can take
advantage of the cache mechanism.
Reference: https://trello.com/c/d6qeRbJD