### PR TITLE
avocado.core.test: Fix SimpleTest [v2]

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -650,9 +650,11 @@ class SimpleTest(Test):
     re_avocado_log = re.compile(r'^\d\d:\d\d:\d\d DEBUG\| \[stdout\]'
                                 r' \d\d:\d\d:\d\d WARN \|')
 
-    def __init__(self, name, params=None, base_logdir=None, tag=None, job=None):
+    def __init__(self, name, params=None, base_logdir=None, tag=None,
+                 job=None):
         super(SimpleTest, self).__init__(name=name, params=params,
-                                         base_logdir=base_logdir, tag=tag, job=job)
+                                         base_logdir=base_logdir, tag=tag,
+                                         job=job)
         self._command = self.filename
 
     @property
@@ -676,7 +678,7 @@ class SimpleTest(Test):
         Run the executable, and log its detailed execution.
         """
         try:
-            test_params = dict([(str(key), str(val)) for path, key, val in
+            test_params = dict([(str(key), str(val)) for _, key, val in
                                 self.params.iteritems()])
 
             # process.run uses shlex.split(), the self.path needs to be escaped

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -671,7 +671,7 @@ class SimpleTest(Test):
         self.log.info("Exit status: %s", result.exit_status)
         self.log.info("Duration: %s", result.duration)
 
-    def test(self):
+    def execute_cmd(self):
         """
         Run the executable, and log its detailed execution.
         """
@@ -688,8 +688,11 @@ class SimpleTest(Test):
             self._log_detailed_cmd_info(details.result)
             raise exceptions.TestFail(details)
 
-    def run(self, result=None):
-        super(SimpleTest, self).run(result)
+    def test(self):
+        """
+        Run the test and postprocess the results
+        """
+        self.execute_cmd()
         for line in open(self.logfile):
             if self.re_avocado_log.match(line):
                 raise exceptions.TestWarn("Test passed but there were warnings"
@@ -732,7 +735,7 @@ class ExternalRunnerTest(SimpleTest):
                                new_cwd)
                 os.chdir(new_cwd)
 
-            super(ExternalRunnerTest, self).test()
+            self.execute_cmd()
 
         finally:
             if new_cwd is not None:

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -154,7 +154,7 @@ class LoaderTest(unittest.TestCase):
         test_parameters['name'] = test.TestName(0, test_parameters['name'])
         test_parameters['base_logdir'] = self.tmpdir
         tc = test_class(**test_parameters)
-        tc.test()
+        tc.run_avocado()
         # Load with params
         simple_with_params = simple_test.path + " 'foo bar' --baz"
         suite = self.loader.discover(simple_with_params, True)
@@ -227,7 +227,7 @@ class LoaderTest(unittest.TestCase):
         test_parameters['name'] = test.TestName(0, test_parameters['name'])
         test_parameters['base_logdir'] = self.tmpdir
         tc = test_class(**test_parameters)
-        tc.test()
+        tc.run_avocado()
         avocado_simple_test.remove()
 
     def test_py_simple_test_notexec(self):


### PR DESCRIPTION
With the d6abdcd `Test` methods changed
but for SimpleTest the wrong method was chosed and only the test
execution is performed now, the post-process class is completelly
ignored. This changes the method to the correct one and adjusts
ExternalRunner to not run this postprocess.

This fixes issue found by @clebergnu while looking at issue https://github.com/avocado-framework/avocado/issues/1244

v1: https://github.com/avocado-framework/avocado/pull/1245#discussion_r66211275

```yaml
v2: Use __file__ for tmpdir prefix
```