### PR TITLE
avocado/core/app.py: remove useless initialized variable

### DIFF
--- a/avocado/core/app.py
+++ b/avocado/core/app.py
@@ -41,7 +41,6 @@ class AvocadoApp(object):
         signal.signal(signal.SIGPIPE, signal.SIG_DFL)
         self.parser = Parser()
         output.early_start()
-        initialized = False
         try:
             self.cli_dispatcher = CLIDispatcher()
             self.cli_cmd_dispatcher = CLICmdDispatcher()
@@ -55,7 +54,6 @@ class AvocadoApp(object):
             self.parser.finish()
             if self.cli_dispatcher.extensions:
                 self.cli_dispatcher.map_method('run', self.parser.args)
-            initialized = True
         finally:
             output.reconfigure(self.parser.args)
 


### PR DESCRIPTION
This variable is a leftover from the days the preceded the plugin system
overhaul.  It serves no purpose now, so, let's remove it.

Signed-off-by: Cleber Rosa <crosa@redhat.com>