### PR TITLE
avocado.plugins: Add TAP output plugin [v5]

### DIFF
--- a/avocado/plugins/tap.py
+++ b/avocado/plugins/tap.py
@@ -1,0 +1,104 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat, Inc. 2016
+# Author: Lukas Doktor <ldoktor@redhat.com>
+"""
+TAP output module.
+"""
+
+import logging
+
+from ..core.result import register_test_result_class, TestResult
+from .base import CLI
+
+
+class TAPResult(TestResult):
+    """
+    TAP output class
+    """
+
+    def __init__(self, job, force_output_file=None):
+        def writeln(msg, *args):
+            """
+            Format msg and append '\n'
+            """
+            return self.output.write(msg % args + "\n")
+        super(TAPResult, self).__init__(job)
+        self.output = force_output_file or getattr(self.args, 'tap', '-')
+        if self.output != '-':
+            self.output = open(self.output, "w", 1)
+            self.__write = writeln
+        else:
+            self.__write = logging.getLogger(
+                "avocado.app").debug   # pylint: disable=R0204
+
+    def start_tests(self):
+        """
+        Log the test plan
+        """
+        super(TAPResult, self).start_tests()
+        self.__write("1..%s", self.tests_total)
+
+    def end_test(self, state):
+        """
+        Log the test status and details
+        """
+        status = state.get("status", "ERROR")
+        name = state.get("name")
+        if not name:
+            name = "Unknown"
+        else:
+            name = name.name + name.str_variant
+            name.replace('#', '_')  # Name must not contain #
+            if name[0].isdigit():   # Name must not start with digit
+                name = "_" + name
+        # First log the system output
+        self.__write("# debug.log of %s:" % name)
+        if state.get('text_output'):
+            for line in state['text_output'].splitlines():
+                self.__write("#   " + line)
+        if status in ("PASS", "WARN"):
+            self.__write("ok %s %s" % (self.tests_run, name))
+        elif status == "SKIP":
+            self.__write("ok %s %s  # SKIP %s" % (self.tests_run, name,
+                                                  state.get("fail_reason")))
+        else:
+            self.__write("not ok %s %s" % (self.tests_run, name))
+        super(TAPResult, self).end_test(state)
+
+    def end_tests(self):
+        if self.output is not '-':
+            self.output.close()
+
+
+class TAP(CLI):
+
+    """
+    TAP Test Anything Protocol output avocado plugin
+    """
+
+    name = 'TAP'
+    description = "TAP - Test Anything Protocol results"
+
+    def configure(self, parser):
+        cmd_parser = parser.subcommands.choices.get('run', None)
+        if cmd_parser is None:
+            return
+
+        cmd_parser.output.add_argument('--tap', type=str, metavar='FILE',
+                                       help="Enable TAP result output and "
+                                       "write it to FILE. Use '-' to redirect "
+                                       "to the standard output.")
+
+    def run(self, args):
+        if getattr(args, "tap", False):
+            register_test_result_class(args, TAPResult)

--- a/docs/source/ResultFormats.rst
+++ b/docs/source/ResultFormats.rst
@@ -177,6 +177,22 @@ newer Avocado features. A reasonable effort will be made to not break
 backwards compatibility with applications that parse the current form of its
 JSON result.
 
+
+TAP
+~~~
+
+Provides the basic `TAP <http://testanything.org/>`__ (Test Anything Protocol) results, currently in v12. Unlike most existing avocado machine readable outputs this one is streamlined (per test results)::
+
+    $ avocado run sleeptest.py --tap -
+    1..1
+    # debug.log of sleeptest.py:SleepTest.test:
+    #   12:04:38 DEBUG| PARAMS (key=sleep_length, path=*, default=1) => 1
+    #   12:04:38 DEBUG| Sleeping for 1.00 seconds
+    #   12:04:39 INFO | PASS 1-sleeptest.py:SleepTest.test
+    #   12:04:39 INFO |
+    ok 1 sleeptest.py:SleepTest.test
+
+
 Silent result
 ~~~~~~~~~~~~~
 

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -14,9 +14,24 @@ else:
 from avocado.core import exit_codes
 from avocado.core.output import TermSupport
 from avocado.utils import process
+from avocado.utils import script
 
 basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..')
 basedir = os.path.abspath(basedir)
+
+
+PERL_TAP_PARSER_SNIPPET = """#!/bin/env perl
+use TAP::Parser;
+
+my $parser = TAP::Parser->new( { exec => ['./scripts/avocado', 'run', 'passtest.py', 'errortest.py', 'warntest.py', '--tap', '-'] } );
+
+while ( my $result = $parser->next ) {
+        $result->is_unknown && die "Unknown line \\"" . $result->as_string . "\\" in the TAP output!\n";
+}
+$parser->parse_errors == 0 || die "Parser errors!\n";
+$parser->is_good_plan || die "Plan is not a good plan!\n";
+$parser->plan eq '1..3' || die "Plan does not match what was expected!\n";
+"""
 
 
 def image_output_uncapable():
@@ -25,6 +40,10 @@ def image_output_uncapable():
         return False
     except ImportError:
         return True
+
+
+def perl_tap_parser_uncapable():
+    return os.system("perl -e 'use TAP::Parser;'") != 0
 
 
 class OutputTest(unittest.TestCase):
@@ -370,6 +389,15 @@ class OutputPluginTest(unittest.TestCase):
                 os.remove(redirected_output_path)
             except OSError:
                 pass
+
+    @unittest.skipIf(perl_tap_parser_uncapable(),
+                     "Uncapable of using Perl TAP::Parser library")
+    def test_tap_parser(self):
+        perl_script = script.TemporaryScript("tap_parser.pl",
+                                             PERL_TAP_PARSER_SNIPPET)
+        perl_script.save()
+        os.chdir(basedir)
+        process.run("perl %s" % perl_script)
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir)

--- a/setup.py
+++ b/setup.py
@@ -136,6 +136,7 @@ if __name__ == '__main__':
                   'html = avocado.plugins.html:HTML',
                   'remote = avocado.plugins.remote:Remote',
                   'replay = avocado.plugins.replay:Replay',
+                  'tap = avocado.plugins.tap:TAP',
                   'vm = avocado.plugins.vm:VM',
                   ],
               'avocado.plugins.cli.cmd': [


### PR DESCRIPTION
This patch adds simple TAP (v12) results plugin. It supports stdout/file
output and is fully stream-lined (uses 1 line buffering to file).

v1: https://github.com/avocado-framework/avocado/pull/1224
v2: https://github.com/avocado-framework/avocado/pull/1232
v3: https://github.com/avocado-framework/avocado/pull/1249
v4: https://github.com/avocado-framework/avocado/pull/1258

Changes:

```
v2: Add test's stdout
v2: Put test's comments before the test (to follow TAP standard)
v2: Add unittest by Cleber
v2: Strengthen and modify the unittest (next commit)
v3: Squash the unittest changes and use in-unit-test file again
    as I was not able to make travis work.
v4: Added TAP documentation
v5: Added `::` in documentation to align block properly
```