### PR TITLE
avocado.utils: Add "partition" utility [v3]

### DIFF
--- a/avocado/utils/partition.py
+++ b/avocado/utils/partition.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or
@@ -13,22 +12,69 @@
 #
 # Copyright: 2016 IBM.
 # Author: Rajashree Rajendran<rajashr7@linux.vnet.ibm.com>
+# Copyright: 2016 Red Hat, Inc.
+# Author: Lukas Doktor <ldoktor@redhat.com>
 #
-# Based on the code by
-# Author: Martin Bligh (mbligh@google.com)
-# Copyright: Google 2006-2008
+# Based on code by: Martin Bligh (mbligh@google.com)
+#     Copyright: Google 2006-2008
+#     https://github.com/autotest/autotest/blob/master/client/partition.py
 
 """
-Utility for handling creation, formatting of partitions.
+Utility for handling partitions.
 """
 
-import fcntl
 import logging
 import os
-import re
-import sys
+import time
+
+import fcntl
 
 from . import process
+
+
+LOG = logging.getLogger(__name__)
+
+
+class PartitionError(Exception):
+
+    """
+    Generic PartitionError
+    """
+
+    def __init__(self, partition, reason, details=None):
+        msg = reason + ": " + str(details) if details else reason
+        super(PartitionError, self).__init__(msg)
+        self.partition = partition
+
+    def __str__(self):
+        return "Partition(%s): %s" % (self.partition.device,
+                                      super(PartitionError, self).__str__())
+
+
+class MtabLock(object):
+    mtab = None
+
+    def __enter__(self):
+        self.mtab = open("/etc/mtab")
+        end_time = time.time() + 60
+        while time.time() < end_time:
+            try:
+                fcntl.flock(self.mtab.fileno(),
+                            fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break
+            except IOError as details:
+                if details.errno == 11:
+                    time.sleep(0.1)
+                else:
+                    raise
+        else:
+            raise PartitionError(self, "Unable to obtain '/etc/mtab' lock "
+                                 "in 60s")
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        if self.mtab:
+            self.mtab.close()
 
 
 class Partition(object):
@@ -42,17 +88,17 @@ class Partition(object):
         :param device: The device in question (e.g."/dev/hda2"). If device is a
                 file it will be mounted as loopback.
         :param loop_size: Size of loopback device (in MB). Defaults to 0.
-        :param mountpoint: The partition to be mounted.
+        :param mountpoint: Where the partition to be mounted to.
         """
         self.device = device
         self.loop = loop_size
         self.fstype = None
         self.mountpoint = mountpoint
-        self.mkfs_flags = None
+        self.mkfs_flags = ''
         self.mount_options = None
         if self.loop:
-            cmd = 'dd if=/dev/zero of=%s bs=1M count=%d' % (device, self.loop)
-            process.run(cmd)
+            process.run('dd if=/dev/zero of=%s bs=1M count=%d'
+                        % (device, self.loop))
 
     def __repr__(self):
         return '<Partition: %s>' % self.device
@@ -60,16 +106,15 @@ class Partition(object):
     @staticmethod
     def list_mount_devices():
         """
-        Lists mounted filesystems and swap on devices.
+        Lists mounted file systems and swap on devices.
         """
-        devices = []
-        # list mounted filesystems
-        for line in process.system_output('mount').splitlines():
-            devices.append(line.split()[0])
+        # list mounted file systems
+        devices = [line.split()[0]
+                   for line in process.system_output('mount').splitlines()]
         # list mounted swap devices
-        for line in process.system_output('swapon -s').splitlines():
-            if line.startswith('/'):    # skip header line
-                devices.append(line.split()[0])
+        swaps = process.system_output('swapon -s').splitlines()
+        devices.extend([line.split()[0] for line in swaps
+                        if line.startswith('/')])
         return devices
 
     @staticmethod
@@ -77,10 +122,8 @@ class Partition(object):
         """
         Lists the mount points.
         """
-        mountpoints = []
-        for line in process.system_output('mount').splitlines():
-            mountpoints.append(line.split()[2])
-        return mountpoints
+        return [line.split()[2]
+                for line in process.system_output('mount').splitlines()]
 
     def get_mountpoint(self, filename=None):
         """
@@ -93,9 +136,9 @@ class Partition(object):
         :return: a string with the mount point of the partition or None if not
                 mounted
         """
-
+        # Try to match this device/mountpoint
         if filename:
-            for line in open(filename).readlines():
+            for line in open(filename):
                 parts = line.split()
                 if parts[0] == self.device or parts[1] == self.mountpoint:
                     return parts[1]    # The mountpoint where it's mounted
@@ -112,21 +155,6 @@ class Partition(object):
                 res = None
         return res
 
-    @staticmethod
-    def mkfs_exec(fstype):
-        """
-        Return the proper mkfs executable based on fs
-        """
-
-        if fstype == 'ext4':
-            if os.path.exists('/sbin/mkfs.ext4'):
-                return 'mkfs'
-        else:
-            return 'mkfs'
-
-        raise NameError('Error creating partition for filesystem type %s' %
-                        fstype)
-
     def mkfs(self, fstype=None, args=''):
         """
         Format a partition to filesystem type
@@ -135,9 +163,8 @@ class Partition(object):
         :param args: arguments to be passed to mkfs command.
         """
 
-        if self.list_mount_devices().count(self.device):
-            raise NameError('Attempted to format mounted device %s' %
-                            self.device)
+        if self.device in self.list_mount_devices():
+            raise PartitionError(self, 'Unable to format mounted device')
 
         if not fstype:
             if self.fstype:
@@ -162,13 +189,12 @@ class Partition(object):
 
         args = args.strip()
 
-        mkfs_cmd = "%s %s %s" % (self.mkfs_exec(fstype), args, self.device)
+        mkfs_cmd = "mkfs %s %s" % (args, self.device)
 
-        sys.stdout.flush()
         try:
             process.system_output("yes | %s" % mkfs_cmd, shell=True)
-        except process.CmdError, error:
-            logging.error(error)
+        except process.CmdError as error:
+            raise PartitionError(self, "Failed to mkfs", error)
         else:
             self.fstype = fstype
 
@@ -182,105 +208,92 @@ class Partition(object):
                 will be used.
         :param args: Arguments to be passed to "mount" command.
         """
-
+        if not mountpoint:
+            mountpoint = self.mountpoint
+        if not mountpoint:
+            raise PartitionError(self, "No mountpoint specified and no "
+                                 "default provided to this partition object")
         if fstype is None:
             fstype = self.fstype
         else:
             self.fstype = fstype
 
         if self.mount_options:
-            args += ' -o  ' + self.mount_options
+            args += ' -o ' + self.mount_options
         if fstype:
             args += ' -t ' + fstype
         if self.loop:
             args += ' -o loop'
         args = args.lstrip()
 
-        if not mountpoint and not self.mountpoint:
-            raise ValueError("No mountpoint specified and no default "
-                             "provided to this partition object")
-        if not mountpoint:
-            mountpoint = self.mountpoint
+        with MtabLock():
+            if self.device in self.list_mount_devices():
+                raise PartitionError(self, "Attempted to mount mounted device")
+            if mountpoint in self.list_mount_points():
+                raise PartitionError(self, "Attempted to mount busy mountpoint")
+            if not os.path.isdir(mountpoint):
+                os.makedirs(mountpoint)
+            try:
+                process.system("mount %s %s %s"
+                               % (args, self.device, mountpoint), sudo=True)
+            except process.CmdError as details:
+                raise PartitionError(self, "Mount failed", details)
+        # Update the fstype as the mount command passed
+        self.fstype = fstype
 
-        mount_cmd = "mount %s %s %s" % (args, self.device, mountpoint)
-
-        if self.list_mount_devices().count(self.device):
-            raise NameError('Attempted to mount mounted device')
-        if self.list_mount_points().count(mountpoint):
-            raise NameError('Attempted to mount busy mountpoint')
-
-        mtab = open('/etc/mtab')
-        fcntl.flock(mtab.fileno(), fcntl.LOCK_EX)
-        sys.stdout.flush()
-        if not os.path.isdir(mountpoint):
-            os.makedirs(mountpoint)
-        try:
-            process.run(mount_cmd)
-            mtab.close()
-        except process.CmdError:
-            mtab.close()
-        else:
-            self.fstype = fstype
-
-    def unmount_force(self):
+    def _unmount_force(self, mountpoint):
         """
-        Kill all other jobs accessing this partition. Use fuser and ps to find
-        all mounts on this mountpoint and unmount them.
+        Kill all other jobs accessing this partition and force unmount it.
 
-        :return: true for success or false for any errors
+        :return: None
+        :raise PartitionError: On critical failure
         """
-
-        logging.debug("Standard umount failed, will try forcing. Users:")
+        # Human readable list of processes
+        out = process.system_output("lsof " + mountpoint, ignore_status=True)
+        # Try to kill all pids
+        for pid in (line.split()[1] for line in out.splitlines()[1:]):
+            try:
+                process.system("kill -9 %s" % pid, ignore_status=True,
+                               sudo=True)
+            except OSError:
+                pass
+        # Unmount
         try:
-            cmd = 'fuser ' + self.get_mountpoint()
-            logging.debug(cmd)
-            fuser = process.system_output(cmd)
-            logging.debug(fuser)
-            users = re.sub('.*:', '', fuser).split()
-            for user in users:
-                match = re.match(r'(\d+)(.*)', user)
-                (pid, usage) = (match.group(1), match.group(2))
-                try:
-                    proc_stat = process.system_output('ps -p %s | '
-                                                      'sed 1d' % pid)
-                    logging.debug(usage, pid, proc_stat)
-                except process.CmdError:
-                    pass
-                process.run('ls -l ' + self.device)
-                umount_cmd = "umount -f " + self.device
-                process.run(umount_cmd)
-                return True
-        except process.CmdError:
-            logging.debug('Umount_force failed for %s', self.device)
-            return False
+            process.run("umount -f %s" % mountpoint, sudo=True)
+        except process.CmdError as details:
+            try:
+                process.run("umount -l %s" % mountpoint, sudo=True)
+            except process.CmdError as details:
+                raise PartitionError(self, "Force unmount failed", details)
 
-    def unmount(self):
+    def unmount(self, force=True):
         """
         Umount this partition.
 
         It's easier said than done to umount a partition.
         We need to lock the mtab file to make sure we don't have any
-        locking problems if we are umounting in paralllel.
+        locking problems if we are umounting in parallel.
 
-        If there turns out to be a problem with the simple umount we
-        end up calling umount_force to get more  aggressive.
+        When the unmount fails and force==True we unmount the partition
+        ungracefully.
+
+        :return: 1 on success, 2 on force umount success
+        :raise PartitionError: On failure
         """
-        mountpoint = self.get_mountpoint()
-        if not mountpoint:
-            logging.error('umount for dev %s has no mountpoint', self.device)
-            return
-
-        umount_cmd = "umount " + mountpoint
-        mtab = open('/etc/mtab')
-
-        fcntl.flock(mtab.fileno(), fcntl.LOCK_EX)
-        sys.stdout.flush()
-        try:
-            process.run(umount_cmd)
-            mtab.close()
-        except (process.CmdError, IOError):
-            mtab.close()
-
-            # Try the forceful umount
-            if self.unmount_force():
-                return
+        with MtabLock():
+            mountpoint = self.get_mountpoint()
+            if not mountpoint:
+                LOG.debug('%s not mounted', self.device)
+                return 1
+            try:
+                process.run("umount " + mountpoint, sudo=True)
+                return 1
+            except process.CmdError as details:
+                if force:
+                    LOG.debug("Standard umount failed on %s, forcing",
+                              mountpoint)
+                    self._unmount_force(mountpoint)
+                    return 2
+                else:
+                    raise PartitionError(self, "Unable to unmount gracefully",
+                                         details)

--- a/avocado/utils/partition.py
+++ b/avocado/utils/partition.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: 2016 IBM.
+# Author: Rajashree Rajendran<rajashr7@linux.vnet.ibm.com>
+#
+# Based on the code by
+# Author: Martin Bligh (mbligh@google.com)
+# Copyright: Google 2006-2008
+
+"""
+Utility for handling creation, formatting of partitions.
+"""
+
+import fcntl
+import logging
+import os
+import re
+import sys
+
+from . import process
+
+
+class Partition(object):
+
+    """
+    Class for handling partitions and filesystems
+    """
+
+    def __init__(self, device, loop_size=0, mountpoint=None):
+        """
+        :param device: The device in question (e.g."/dev/hda2"). If device is a
+                file it will be mounted as loopback.
+        :param loop_size: Size of loopback device (in MB). Defaults to 0.
+        :param mountpoint: The partition to be mounted.
+        """
+        self.device = device
+        self.loop = loop_size
+        self.fstype = None
+        self.mountpoint = mountpoint
+        self.mkfs_flags = None
+        self.mount_options = None
+        if self.loop:
+            cmd = 'dd if=/dev/zero of=%s bs=1M count=%d' % (device, self.loop)
+            process.run(cmd)
+
+    def __repr__(self):
+        return '<Partition: %s>' % self.device
+
+    @staticmethod
+    def list_mount_devices():
+        """
+        Lists mounted filesystems and swap on devices.
+        """
+        devices = []
+        # list mounted filesystems
+        for line in process.system_output('mount').splitlines():
+            devices.append(line.split()[0])
+        # list mounted swap devices
+        for line in process.system_output('swapon -s').splitlines():
+            if line.startswith('/'):    # skip header line
+                devices.append(line.split()[0])
+        return devices
+
+    @staticmethod
+    def list_mount_points():
+        """
+        Lists the mount points.
+        """
+        mountpoints = []
+        for line in process.system_output('mount').splitlines():
+            mountpoints.append(line.split()[2])
+        return mountpoints
+
+    def get_mountpoint(self, filename=None):
+        """
+        Find the mount point of this partition object.
+
+        :param filename: where to look for the mounted partitions information
+                (default None which means it will search /proc/mounts and/or
+                /etc/mtab)
+
+        :return: a string with the mount point of the partition or None if not
+                mounted
+        """
+
+        if filename:
+            for line in open(filename).readlines():
+                parts = line.split()
+                if parts[0] == self.device or parts[1] == self.mountpoint:
+                    return parts[1]    # The mountpoint where it's mounted
+            return None
+
+        # no specific file given, look in /proc/mounts
+        res = self.get_mountpoint(filename='/proc/mounts')
+        if not res:
+            # sometimes the root partition is reported as /dev/root in
+            # /proc/mounts in this case, try /etc/mtab
+            res = self.get_mountpoint(filename='/etc/mtab')
+
+            if res != '/':
+                res = None
+        return res
+
+    @staticmethod
+    def mkfs_exec(fstype):
+        """
+        Return the proper mkfs executable based on fs
+        """
+
+        if fstype == 'ext4':
+            if os.path.exists('/sbin/mkfs.ext4'):
+                return 'mkfs'
+        else:
+            return 'mkfs'
+
+        raise NameError('Error creating partition for filesystem type %s' %
+                        fstype)
+
+    def mkfs(self, fstype=None, args=''):
+        """
+        Format a partition to filesystem type
+
+        :param fstype: the filesystem type, e.g.. "ext3", "ext2"
+        :param args: arguments to be passed to mkfs command.
+        """
+
+        if self.list_mount_devices().count(self.device):
+            raise NameError('Attempted to format mounted device %s' %
+                            self.device)
+
+        if not fstype:
+            if self.fstype:
+                fstype = self.fstype
+            else:
+                fstype = 'ext2'
+
+        if self.mkfs_flags:
+            args += ' ' + self.mkfs_flags
+        if fstype == 'xfs':
+            args += ' -f'
+
+        if self.loop:
+            if fstype.startswith('ext'):
+                args += ' -F'
+            elif fstype == 'reiserfs':
+                args += ' -f'
+
+        # If there isn't already a '-t <type>' argument, add one.
+        if "-t" not in args:
+            args = "-t %s %s" % (fstype, args)
+
+        args = args.strip()
+
+        mkfs_cmd = "%s %s %s" % (self.mkfs_exec(fstype), args, self.device)
+
+        sys.stdout.flush()
+        try:
+            process.system_output("yes | %s" % mkfs_cmd, shell=True)
+        except process.CmdError, error:
+            logging.error(error)
+        else:
+            self.fstype = fstype
+
+    def mount(self, mountpoint=None, fstype=None, args=''):
+        """
+        Mount this partition to a mount point
+
+        :param mountpoint: If you have not provided a mountpoint to partition
+                object or want to use a different one, you may specify it here.
+        :param fstype: Filesystem type. If not provided partition object value
+                will be used.
+        :param args: Arguments to be passed to "mount" command.
+        """
+
+        if fstype is None:
+            fstype = self.fstype
+        else:
+            self.fstype = fstype
+
+        if self.mount_options:
+            args += ' -o  ' + self.mount_options
+        if fstype:
+            args += ' -t ' + fstype
+        if self.loop:
+            args += ' -o loop'
+        args = args.lstrip()
+
+        if not mountpoint and not self.mountpoint:
+            raise ValueError("No mountpoint specified and no default "
+                             "provided to this partition object")
+        if not mountpoint:
+            mountpoint = self.mountpoint
+
+        mount_cmd = "mount %s %s %s" % (args, self.device, mountpoint)
+
+        if self.list_mount_devices().count(self.device):
+            raise NameError('Attempted to mount mounted device')
+        if self.list_mount_points().count(mountpoint):
+            raise NameError('Attempted to mount busy mountpoint')
+
+        mtab = open('/etc/mtab')
+        fcntl.flock(mtab.fileno(), fcntl.LOCK_EX)
+        sys.stdout.flush()
+        if not os.path.isdir(mountpoint):
+            os.makedirs(mountpoint)
+        try:
+            process.run(mount_cmd)
+            mtab.close()
+        except process.CmdError:
+            mtab.close()
+        else:
+            self.fstype = fstype
+
+    def unmount_force(self):
+        """
+        Kill all other jobs accessing this partition. Use fuser and ps to find
+        all mounts on this mountpoint and unmount them.
+
+        :return: true for success or false for any errors
+        """
+
+        logging.debug("Standard umount failed, will try forcing. Users:")
+        try:
+            cmd = 'fuser ' + self.get_mountpoint()
+            logging.debug(cmd)
+            fuser = process.system_output(cmd)
+            logging.debug(fuser)
+            users = re.sub('.*:', '', fuser).split()
+            for user in users:
+                match = re.match(r'(\d+)(.*)', user)
+                (pid, usage) = (match.group(1), match.group(2))
+                try:
+                    proc_stat = process.system_output('ps -p %s | '
+                                                      'sed 1d' % pid)
+                    logging.debug(usage, pid, proc_stat)
+                except process.CmdError:
+                    pass
+                process.run('ls -l ' + self.device)
+                umount_cmd = "umount -f " + self.device
+                process.run(umount_cmd)
+                return True
+        except process.CmdError:
+            logging.debug('Umount_force failed for %s', self.device)
+            return False
+
+    def unmount(self):
+        """
+        Umount this partition.
+
+        It's easier said than done to umount a partition.
+        We need to lock the mtab file to make sure we don't have any
+        locking problems if we are umounting in paralllel.
+
+        If there turns out to be a problem with the simple umount we
+        end up calling umount_force to get more  aggressive.
+        """
+        mountpoint = self.get_mountpoint()
+        if not mountpoint:
+            logging.error('umount for dev %s has no mountpoint', self.device)
+            return
+
+        umount_cmd = "umount " + mountpoint
+        mtab = open('/etc/mtab')
+
+        fcntl.flock(mtab.fileno(), fcntl.LOCK_EX)
+        sys.stdout.flush()
+        try:
+            process.run(umount_cmd)
+            mtab.close()
+        except (process.CmdError, IOError):
+            mtab.close()
+
+            # Try the forceful umount
+            if self.unmount_force():
+                return

--- a/selftests/unit/test_utils_partition.py
+++ b/selftests/unit/test_utils_partition.py
@@ -1,0 +1,110 @@
+"""
+avocado.utils.partition unittests
+:author: Lukas Doktor <ldoktor@redhat.com>
+:copyright: 2016 Red Hat, Inc
+"""
+
+import os
+import shutil
+import sys
+import tempfile
+import time
+
+from flexmock import flexmock, flexmock_teardown
+
+from avocado.utils import partition, process
+
+if sys.version_info[:2] == (2, 6):
+    import unittest2 as unittest    # pylint: disable=E0401
+else:
+    import unittest     # pylint: disable=C0411
+
+
+class TestPartition(unittest.TestCase):
+
+    """
+    Unit tests for avocado.utils.partition
+    """
+
+    def setUp(self):
+        try:
+            process.system("/bin/true", sudo=True)
+        except process.CmdError:
+            self.skipTest("Sudo not available")
+        self.tmpdir = tempfile.mkdtemp(prefix="avocado_" + __name__)
+        self.mountpoint = os.path.join(self.tmpdir, "disk")
+        os.mkdir(self.mountpoint)
+        self.disk = partition.Partition(os.path.join(self.tmpdir, "block"), 1,
+                                        self.mountpoint)
+
+    def test_basic(self):
+        """ Test the basic workflow """
+        self.assertEqual(None, self.disk.get_mountpoint())
+        self.disk.mkfs()
+        self.disk.mount()
+        self.assertIn(self.mountpoint, open("/proc/mounts").read())
+        self.assertEqual(self.mountpoint, self.disk.get_mountpoint())
+        self.disk.unmount()
+        self.assertNotIn(self.mountpoint, open("/proc/mounts").read())
+
+    def test_force_unmount(self):
+        """ Test force-unmount feature """
+        self.disk.mkfs()
+        self.disk.mount()
+        self.assertIn(self.mountpoint, open("/proc/mounts").read())
+        proc = process.SubProcess("cd %s; while :; do echo a > a; rm a; done"
+                                  % self.mountpoint, shell=True)
+        proc.start()
+        self.assertTrue(self.disk.unmount())
+        self.assertEqual(proc.poll(), -9)   # Process should be killed -9
+        self.assertNotIn(self.mountpoint, open("/proc/mounts").read())
+
+    def test_double_mount(self):
+        """ Check the attempt for second mount fails """
+        self.disk.mkfs("ext2")
+        self.disk.mount()
+        self.assertIn(self.mountpoint, open("/proc/mounts").read())
+        self.assertRaises(partition.PartitionError, self.disk.mount)
+        self.assertIn(self.mountpoint, open("/proc/mounts").read())
+
+    def test_double_umount(self):
+        """ Check double unmount works well """
+        self.disk.mkfs()
+        self.disk.mount()
+        self.assertIn(self.mountpoint, open("/proc/mounts").read())
+        self.disk.unmount()
+        self.assertNotIn(self.mountpoint, open("/proc/mounts").read())
+        self.disk.unmount()
+        self.assertNotIn(self.mountpoint, open("/proc/mounts").read())
+
+    def test_format_mounted(self):
+        """ Check format on mounted device fails """
+        self.disk.mkfs()
+        self.disk.mount()
+        self.assertIn(self.mountpoint, open("/proc/mounts").read())
+        self.assertRaises(partition.PartitionError, self.disk.mkfs)
+
+    def tearDown(self):
+        self.disk.unmount()
+        shutil.rmtree(self.tmpdir)
+
+
+class TestMtabLock(unittest.TestCase):
+
+    """
+    Unit tests for avocado.utils.partition
+    """
+
+    def test_lock(self):
+        """ Check double-lock raises exception after 60s (in 0.1s) """
+        with partition.MtabLock():
+            # speedup the process a bit
+            (flexmock(time).should_receive("time").and_return(1)
+             .and_return(2).and_return(62))
+            self.assertRaises(partition.PartitionError,
+                              partition.MtabLock().__enter__)
+            flexmock_teardown()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This utility comes from `autotest` and will be used by `parallel_dd` test.

v1: https://github.com/avocado-framework/avocado/pull/1240
v2: https://github.com/avocado-framework/avocado/pull/1251

Changes:
```yaml
v2: Added commit which fixes autotest's issues and brings selftest
v3: Fixed `tmpfile` `prefix` in unittest
```