### PR TITLE
avocado.core.multiplexer: Allow unhashable arguments

### DIFF
--- a/avocado/core/multiplexer.py
+++ b/avocado/core/multiplexer.py
@@ -250,10 +250,15 @@ class AvocadoParams(object):
             path = '*'
         try:
             return self._cache[(key, path, default)]
-        except KeyError:
+        except (KeyError, TypeError):
+            # KeyError - first query
+            # TypeError - unable to hash
             value = self._get(key, path, default)
             self.log(key, path, default, value)
-            self._cache[(key, path, default)] = value
+            try:
+                self._cache[(key, path, default)] = value
+            except TypeError:
+                pass
             return value
 
     def _get(self, key, path, default):

--- a/selftests/unit/test_multiplexer.py
+++ b/selftests/unit/test_multiplexer.py
@@ -111,6 +111,14 @@ class TestAvocadoParams(unittest.TestCase):
         self.assertEqual(15, sum([1 for _ in self.params1.iteritems()]))
 
     @unittest.skipIf(not tree.MULTIPLEX_CAPABLE, "Not multiplex capable")
+    def test_unhashable(self):
+        """ Verifies that unhashable arguments can be passed to params.get """
+        self.assertEqual(self.params1.get("root", "/ch0/", ["foo"]), ["foo"])
+        self.assertEqual(self.params1.get('unique1',
+                                          '/ch0/ch0.1/ch0.1.1/ch0.1.1.1/',
+                                          ['bar']), 'unique1')
+
+    @unittest.skipIf(not tree.MULTIPLEX_CAPABLE, "Not multiplex capable")
     def test_get_abs_path(self):
         # /ch0/ is not leaf thus it's not queryable
         self.assertEqual(self.params1.get('root', '/ch0/', 'bbb'), 'bbb')


### PR DESCRIPTION
When unhashable argument is passed to the `params.get`, it crashes while
trying to obtain value from cache. This patch fallbacks to new query on
such exception.

Trello: https://trello.com/c/hjipQN0L/729-bug-multiplexer-does-not-accept-unhashable-objects-as-default
Related to: https://github.com/avocado-framework/avocado-misc-tests/pull/60