### PR TITLE
avocado.core.remoter keep environment variables

### DIFF
--- a/avocado/core/remote/runner.py
+++ b/avocado/core/remote/runner.py
@@ -89,7 +89,8 @@ class RemoteTestRunner(TestRunner):
                                      password=self.job.args.remote_password,
                                      key_filename=self.job.args.remote_key_file,
                                      port=self.job.args.remote_port,
-                                     timeout=self.job.args.remote_timeout)
+                                     timeout=self.job.args.remote_timeout,
+                                     env_keep=self.job.args.env_keep)
 
     def check_remote_avocado(self):
         """

--- a/avocado/plugins/envkeep.py
+++ b/avocado/plugins/envkeep.py
@@ -1,0 +1,49 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2016
+# Author: Amador Pahim <apahim@redhat.com>
+
+import argparse
+from .base import CLI
+
+
+class EnvKeep(CLI):
+
+    """
+    Keep environment variables on remote executions
+    """
+
+    name = 'envkeep'
+    description = "Keep variables in remote environment"
+
+    def configure(self, parser):
+        run_subcommand_parser = parser.subcommands.choices.get('run', None)
+        if run_subcommand_parser is None:
+            return
+
+        msg = 'keep environment variables'
+        replay_parser = run_subcommand_parser.add_argument_group(msg)
+        replay_parser.add_argument('--env-keep', dest='env_keep',
+                                   default=None,
+                                   type=self._parse_env_keep,
+                                   help='Keep environment variables in remote '
+                                   'executions')
+
+    def _parse_env_keep(self, string):
+        try:
+            return string.split(',')
+        except:
+            raise argparse.ArgumentTypeError('Invalid format.')
+
+    def run(self, args):
+        if getattr(args, 'env_keep', None) is None:
+            return

--- a/docs/source/RunningTestsRemotely.rst
+++ b/docs/source/RunningTestsRemotely.rst
@@ -146,3 +146,18 @@ As you can see, Avocado will copy the tests you have to your libvirt domain and
 execute them. A bit of extra logging information is added to your job summary,
 mainly to distinguish the regular execution from the remote one. Note here that
 we did not need `--vm-password` because the SSH key is already setup.
+
+Environment Variables
+=====================
+
+Running remote instances os Avocado, for example using `remote` or `vm`
+plugins, the remote environment has a diferent set of environment variables. If
+you want to make available remotely variables that are available in the local
+environment, you can use the `run` option `--env-keep`. See the example below::
+
+    $ export MYVAR1=foobar
+    $ env MYVAR2=foobar2 avocado run passtest.py --env-keep MYVAR1,MYVAR2 --remote-hostname 192.168.122.30 --remote-username fedora
+
+By doing that, both `MYVAR1` and `MYVAR2` will be available in remote
+environment.
+

--- a/selftests/unit/test_remote.py
+++ b/selftests/unit/test_remote.py
@@ -39,7 +39,8 @@ class RemoteTestRunnerTest(unittest.TestCase):
                         remote_timeout=60,
                         show_job_log=False,
                         multiplex_files=['foo.yaml', 'bar/baz.yaml'],
-                        dry_run=True)
+                        dry_run=True,
+                        env_keep=None)
         log = flexmock()
         log.should_receive("info")
         job = flexmock(args=Args, log=log,
@@ -156,7 +157,8 @@ class RemoteTestRunnerSetup(unittest.TestCase):
         remote_remote = flexmock(remoter)
         (remote_remote.should_receive('Remote')
          .with_args(hostname='hostname', username='username',
-                    password='password', key_filename=None, port=22, timeout=60)
+                    password='password', key_filename=None, port=22,
+                    timeout=60, env_keep=None)
          .once().ordered()
          .and_return(Remote))
         Args = flexmock(test_result_total=1,
@@ -169,7 +171,8 @@ class RemoteTestRunnerSetup(unittest.TestCase):
                         remote_key_file=None,
                         remote_no_copy=False,
                         remote_timeout=60,
-                        show_job_log=False)
+                        show_job_log=False,
+                        env_keep=None)
         log = flexmock()
         log.should_receive("info")
         job = flexmock(args=Args, log=log)

--- a/selftests/unit/test_vm.py
+++ b/selftests/unit/test_vm.py
@@ -39,7 +39,8 @@ class VMTestRunnerSetup(unittest.TestCase):
                         vm_cleanup=True,
                         vm_no_copy=False,
                         vm_timeout=120,
-                        vm_hypervisor_uri='my_hypervisor_uri')
+                        vm_hypervisor_uri='my_hypervisor_uri',
+                        env_keep=None)
         log = flexmock()
         log.should_receive("info")
         job = flexmock(args=Args, log=log)

--- a/setup.py
+++ b/setup.py
@@ -128,6 +128,7 @@ if __name__ == '__main__':
                    'scripts/avocado-rest-client'],
           entry_points={
               'avocado.plugins.cli': [
+                  'envkeep = avocado.plugins.envkeep:EnvKeep',
                   'gdb = avocado.plugins.gdb:GDB',
                   'wrapper = avocado.plugins.wrapper:Wrapper',
                   'xunit = avocado.plugins.xunit:XUnit',


### PR DESCRIPTION
Add options --env-keep to run command so users can make
available in remote executions of Avocado some environment
variables that are available locally.

Reference: https://trello.com/c/Ddcly0oG
Signed-off-by: Amador Pahim <apahim@redhat.com>