### PR TITLE
 Add expire time for asset fetcher

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -37,6 +37,7 @@ from ..utils import genio
 from ..utils import path as utils_path
 from ..utils import process
 from ..utils import stacktrace
+from ..utils import unit_converter
 from .settings import settings
 from .version import VERSION
 
@@ -625,7 +626,7 @@ class Test(unittest.TestCase):
         raise exceptions.TestSkipError(message)
 
     def fetch_asset(self, name, asset_hash=None, algorithm='sha1',
-                    locations=None):
+                    locations=None, expire=None):
         """
         Method o call the utils.asset in order to fetch and asset file
         supporting hash check, caching and multiple locations.
@@ -635,10 +636,13 @@ class Test(unittest.TestCase):
         :param algorithm: hash algorithm (optional, defaults to sha1)
         :param locations: list of URLs from where the asset can be
                           fetched (optional)
+        :param expire: time for the asset to expire
         :returns: asset file local path
         """
+        if expire is not None:
+            expire = unit_converter.time_to_seconds(str(expire))
         return asset.Asset(name, asset_hash, algorithm, locations,
-                           self.cache_dirs).fetch()
+                           self.cache_dirs, expire).fetch()
 
 
 class SimpleTest(Test):

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -25,6 +25,7 @@ from avocado.core import job
 from avocado.core import loader
 from avocado.core import multiplexer
 from avocado.core.settings import settings
+from avocado.utils import unit_converter
 
 from .base import CLICmd
 
@@ -160,28 +161,6 @@ class Run(CLICmd):
                 node = args.default_avocado_params.get_node(value[0], True)
                 node.value[value[1]] = value[2]
 
-    def _validate_job_timeout(self, raw_timeout):
-        units = {'s': 1, 'm': 60, 'h': 3600, 'd': 86400}
-        mult = 1
-        if raw_timeout is not None:
-            try:
-                unit = raw_timeout[-1].lower()
-                if unit in units:
-                    mult = units[unit]
-                    timeout = int(raw_timeout[:-1]) * mult
-                else:
-                    timeout = int(raw_timeout)
-                if timeout < 1:
-                    raise ValueError()
-            except (ValueError, TypeError):
-                log = logging.getLogger("avocado.app")
-                log.error("Invalid number '%s' for job timeout. Use an "
-                          "integer number greater than 0", raw_timeout)
-                sys.exit(exit_codes.AVOCADO_FAIL)
-        else:
-            timeout = 0
-        return timeout
-
     def run(self, args):
         """
         Run test modules or simple tests.
@@ -198,6 +177,8 @@ class Run(CLICmd):
                 log = logging.getLogger("avocado.app")
                 log.error('Unique Job ID needs to be a 40 digit hex number')
                 sys.exit(exit_codes.AVOCADO_FAIL)
-        args.job_timeout = self._validate_job_timeout(args.job_timeout)
+        args.job_timeout = unit_converter.time_to_seconds(args.job_timeout)
+        if args.job_timeout is None:
+            sys.exit(exit_codes.AVOCADO_FAIL)
         job_instance = job.Job(args)
         return job_instance.run()

--- a/avocado/utils/unit_converter.py
+++ b/avocado/utils/unit_converter.py
@@ -1,0 +1,46 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2016
+
+"""
+Unit Convertion related functions.
+"""
+
+import logging
+
+
+def time_to_seconds(time):
+    """
+    Convert time in minutes, hours and days to seconds.
+    :param time: Time including the unit (i.e. '10d')
+    """
+    units = {'s': 1, 'm': 60, 'h': 3600, 'd': 86400}
+    mult = 1
+    if time is not None:
+        try:
+            unit = time[-1].lower()
+            if unit in units:
+                mult = units[unit]
+                seconds = int(time[:-1]) * mult
+            else:
+                seconds = int(time)
+            if seconds < 1:
+                raise ValueError()
+        except (ValueError, TypeError):
+            log = logging.getLogger("avocado.app")
+            log.error("Invalid value '%s' for time. Use an integer number "
+                      "greater than 0 or a string with the number and "
+                      "the time unit (s, m, h or d).", time)
+            return None
+    else:
+        seconds = 0
+    return seconds

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -538,6 +538,11 @@ Detailing the ``fetch_asset()`` attributes:
   file, including the file name. The first success will skip the next
   locations. Notice that for ``file://`` we just create a symbolic link in the
   cache directory, pointing to the file original location.
+* ``expire:`` (optional) time period that the cached file will be considered
+  valid. After that period, the file will be dowloaded again. iThe value can
+  be an integer greater than 0 or a string containig the time and the unit.
+  Example: 10d (ten days). Valid units are s (second), m (minute), h (hour)
+  and d (day).
 
 The expected ``return`` is the asset file path or an exception.
 

--- a/selftests/functional/test_job_timeout.py
+++ b/selftests/functional/test_job_timeout.py
@@ -138,12 +138,12 @@ class JobTimeOutTest(unittest.TestCase):
                     '--job-timeout=0 examples/tests/passtest.py' % self.tmpdir)
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_FAIL)
-        self.assertIn('Invalid number', result.stderr)
+        self.assertIn('Invalid value', result.stderr)
         cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '
                     '--job-timeout=123x examples/tests/passtest.py' % self.tmpdir)
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_FAIL)
-        self.assertIn('Invalid number', result.stderr)
+        self.assertIn('Invalid value', result.stderr)
 
     def test_valid_values(self):
         cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '

--- a/selftests/unit/test_utils_asset.py
+++ b/selftests/unit/test_utils_asset.py
@@ -18,13 +18,15 @@ class TestAsset(unittest.TestCase):
             f.write('Test!')
         self.url = 'file://%s' % self.localpath
         self.cache_dir = tempfile.mkdtemp(dir=self.basedir)
+        self.expire = 0
 
     def testFetch_urlname(self):
         foo_tarball = asset.Asset(self.url,
                                   asset_hash=self.assethash,
                                   algorithm='sha1',
                                   locations=None,
-                                  cache_dirs=[self.cache_dir]).fetch()
+                                  cache_dirs=[self.cache_dir],
+                                  expire=self.expire).fetch()
         expected_tarball = os.path.join(self.cache_dir, self.assetname)
         self.assertEqual(foo_tarball, expected_tarball)
         hashfile = '.'.join([expected_tarball, 'sha1'])
@@ -39,7 +41,8 @@ class TestAsset(unittest.TestCase):
                                   asset_hash=self.assethash,
                                   algorithm='sha1',
                                   locations=[self.url],
-                                  cache_dirs=[self.cache_dir]).fetch()
+                                  cache_dirs=[self.cache_dir],
+                                  expire=self.expire).fetch()
         expected_tarball = os.path.join(self.cache_dir, self.assetname)
         self.assertEqual(foo_tarball, expected_tarball)
         hashfile = '.'.join([expected_tarball, 'sha1'])
@@ -51,7 +54,8 @@ class TestAsset(unittest.TestCase):
 
     def testException(self):
         a = asset.Asset(name='bar.tgz', asset_hash=None, algorithm=None,
-                        locations=None, cache_dirs=[self.cache_dir])
+                        locations=None, cache_dirs=[self.cache_dir],
+                        expire=self.expire)
         self.assertRaises(EnvironmentError, a.fetch)
 
     def tearDown(self):


### PR DESCRIPTION
Now users can invalidate (download again) a local copy of the asset file if
it has more than a given time since created.

Reference: https://trello.com/c/JLk01wOl