### PR TITLE
avocado/utils/process.py: avoid false positives on pid_exists()

### DIFF
--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -16,16 +16,17 @@
 Functions dedicated to find and run external commands.
 """
 
+import errno
+import fnmatch
 import logging
 import os
 import re
-import signal
-import time
-import stat
 import shlex
 import shutil
+import signal
+import stat
 import threading
-import fnmatch
+import time
 
 try:
     import subprocess32 as subprocess
@@ -104,9 +105,10 @@ def pid_exists(pid):
     """
     try:
         os.kill(pid, 0)
-        return True
-    except Exception:
-        return False
+    except OSError as detail:
+        if detail.errno == errno.ESRCH:
+            return False
+    return True
 
 
 def safe_kill(pid, signal):


### PR DESCRIPTION
The current implementation of pid_exists() is such that, if any error
condition is obtained from sending a signal to a given process, than
it means that it doesn't exist.

But that is not true, and the same OSError exception raised when the
process doesn't exist, can be raised when there's no permission to
send a signal to a process (such as someone else's process).  So,
let's be very specific and check for ESRCH, which means "no such
process".

Signed-off-by: Cleber Rosa <crosa@redhat.com>