### PR TITLE
Turn paginator off on argparse error

### DIFF
--- a/avocado/core/parser.py
+++ b/avocado/core/parser.py
@@ -116,6 +116,7 @@ class Parser(object):
         """
         self.args, extra = self.application.parse_known_args(namespace=self.args)
         if extra:
+            setattr(self.args, 'paginator', 'off')
             msg = 'unrecognized arguments: %s' % ' '.join(extra)
             for sub in self.application._subparsers._actions:
                 if sub.dest == 'subcommand':


### PR DESCRIPTION
Paginator is default on for list command. When an unrecognized argument
in provided to list, the argparser error results in disabled echo on bash.

This patch disables the paginator on argparse error.

Referece: https://trello.com/c/F1x0ZUye
Signed-off-by: Amador Pahim <apahim@redhat.com>