### PR TITLE
avocado: Improve exception in case of unpickable status

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -314,13 +314,6 @@ class Test(unittest.TestCase):
             current_time = time.time()
         self.time_elapsed = current_time - self.time_start
 
-    def report_state(self):
-        """
-        Send the current test state to the test runner process
-        """
-        if self.runner_queue is not None:
-            self.runner_queue.put(self.get_state())
-
     def get_state(self):
         """
         Serialize selected attributes representing the test state

--- a/avocado/utils/stacktrace.py
+++ b/avocado/utils/stacktrace.py
@@ -4,6 +4,8 @@ Traceback standard module plus some additional APIs.
 from traceback import format_exception
 import logging
 import inspect
+import pickle
+from pprint import pformat
 
 
 def tb_info(exc_info):
@@ -53,3 +55,64 @@ def log_message(message, logger='root'):
     log = logging.getLogger(logger)
     for line in message.splitlines():
         log.error(line)
+
+
+def analyze_unpickable_item(path_prefix, obj):
+    """
+    Recursive method to obtain unpickable objects along with location
+
+    :param path_prefix: Path to this object
+    :param obj: The sub-object under introspection
+    :return: [($path_to_the_object, $value), ...]
+    """
+    _path_prefix = path_prefix
+    try:
+        if hasattr(obj, "iteritems"):
+            subitems = obj.iteritems()
+            path_prefix += "[%s]"
+        elif hasattr(obj, "items"):
+            subitems = obj.items()
+            path_prefix += "[%s]"
+        elif isinstance(obj, list):
+            subitems = enumerate(obj)
+            path_prefix += "[%s]"
+        elif hasattr(obj, "__iter__"):
+            subitems = enumerate(obj.__iter__())
+            path_prefix += "<%s>"
+        elif hasattr(obj, "__dict__"):
+            subitems = obj.__dict__.iteritems()
+            path_prefix += ".%s"
+        else:
+            return [(path_prefix, obj)]
+    except Exception:
+        return [(path_prefix, obj)]
+    unpickables = []
+    for key, value in subitems:
+        try:
+            pickle.dumps(value)
+        except Exception:
+            ret = analyze_unpickable_item(path_prefix % key, value)
+            if ret:
+                unpickables.extend(ret)
+    if not unpickables:
+        return [(_path_prefix, obj)]
+    return unpickables
+
+
+def str_unpickable_object(obj):
+    """
+    Return human readable string identifying the unpickable objects
+
+    :param obj: The object for analysis
+    :raise ValueError: In case the object is pickable
+    """
+    try:
+        pickle.dumps(obj)
+    except Exception:
+        pass
+    else:
+        raise ValueError("This object is pickable:\n%s" % pformat(obj))
+    unpickables = analyze_unpickable_item("this", obj)
+    return ("Unpickable object in:\n  %s\nItems causing troubles:\n  "
+            % "\n  ".join(pformat(obj).splitlines()) +
+            "\n  ".join("%s => %s" % obj for obj in unpickables))

--- a/selftests/unit/test_utils_stacktrace.py
+++ b/selftests/unit/test_utils_stacktrace.py
@@ -1,0 +1,84 @@
+#! /usr/bin/env python
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: 2016 Red Hat, Inc.
+# Author: Lukas Doktor <ldoktor@redhat.com>
+"""
+avocado.utils.stacktrace unittests
+"""
+
+import re
+import unittest
+
+from avocado.utils import stacktrace
+
+
+class Unpickable(object):
+    """
+    Dummy class which does not support pickling
+    """
+
+    def __getstate__(self):
+        raise NotImplementedError()
+
+
+class InClassUnpickable(object):
+    """
+    Dummy class containing unpickable object inside itself
+    """
+
+    def __init__(self):
+        self.troublemaker = Unpickable()
+
+
+class ListWithUnpickableAttribute(list):
+    """
+    Dummy list class containing also unpickable attribute
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.__troublemaker = Unpickable()
+        super(ListWithUnpickableAttribute, self).__init__(*args, **kwargs)
+
+
+class TestUnpickableObject(unittest.TestCase):
+
+    """
+    Basic selftests for `avocado.utils.stacktrace.str_unpickable_object
+    """
+
+    def test_basic(self):
+        """ Basic usage """
+        def check(exps, obj):
+            """ Search exps in the output of str_unpickable_object(obj) """
+            act = stacktrace.str_unpickable_object(obj)
+            for exp in exps:
+                if not re.search(exp, act):
+                    self.fail("%r no match in:\n%s" % (exp, act))
+        self.assertRaises(ValueError, stacktrace.str_unpickable_object,
+                          ([{"foo": set([])}]))
+        check(["this => .*Unpickable"], Unpickable())
+        check([r"this\[0\]\[0\]\[foo\]\.troublemaker => .*Unpickable"],
+              [[{"foo": InClassUnpickable()}]])
+        check([r"this\[foo\] => \[1, 2, 3\]"],
+              {"foo": ListWithUnpickableAttribute([1, 2, 3])})
+        check([r"this\[foo\]\[3\] => .*Unpickable"],
+              {"foo": ListWithUnpickableAttribute([1, 2, 3, Unpickable()])})
+        check([r"this\[2\] => .*Unpickable",
+               r"this\[3\]\[foo\].troublemaker => .*Unpickable",
+               r"this\[4\]\[0\].troublemaker => .*Unpickable"],
+              [1, 2, Unpickable(), {"foo": InClassUnpickable(), "bar": None},
+               ListWithUnpickableAttribute(ListWithUnpickableAttribute(
+                   [InClassUnpickable()]))])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR removes an unused code from `avocado.core.test`, adds a tool to walk the unpickable object and reports the subitems causing that and uses this tool to improve errors in case state can't be sent through the queue.

Trello: https://trello.com/c/uRQkvfX8/700-improve-the-queue-exception-messages