### PR TITLE
Close STD_OUTPUT on app exception [v2]

### DIFF
--- a/avocado/core/app.py
+++ b/avocado/core/app.py
@@ -18,6 +18,7 @@ The core Avocado application.
 
 import os
 import signal
+import sys
 
 from .parser import Parser
 from . import output
@@ -54,7 +55,19 @@ class AvocadoApp(object):
             self.parser.finish()
             if self.cli_dispatcher.extensions:
                 self.cli_dispatcher.map_method('run', self.parser.args)
-        finally:
+        except SystemExit as e:
+            # If someonte tries to exit Avocado, we should first close the
+            # STD_OUTPUT and only then exit.
+            output.reconfigure(self.parser.args)
+            STD_OUTPUT.close()
+            sys.exit(e.code)
+        except:
+            # For any other exception we also need to close the STD_OUTPUT.
+            output.reconfigure(self.parser.args)
+            STD_OUTPUT.close()
+            raise
+        else:
+            # In case of no exceptions, we just reconfigure the output.
             output.reconfigure(self.parser.args)
 
     def run(self):

--- a/avocado/core/parser.py
+++ b/avocado/core/parser.py
@@ -116,6 +116,7 @@ class Parser(object):
         """
         self.args, extra = self.application.parse_known_args(namespace=self.args)
         if extra:
+            setattr(self.args, 'paginator', 'off')
             msg = 'unrecognized arguments: %s' % ' '.join(extra)
             for sub in self.application._subparsers._actions:
                 if sub.dest == 'subcommand':


### PR DESCRIPTION
v2:
 - Close `STD_OUTPUT` in app `init()` instead of just turning paginator off (as in the previous version).

v1: #1268 
 - Disables the paginator on argparse error