### PR TITLE
avocado.utils.lv_utils: Two bugfixes

### DIFF
--- a/avocado/utils/lv_utils.py
+++ b/avocado/utils/lv_utils.py
@@ -153,7 +153,7 @@ def vg_ramdisk_cleanup(ramdisk_filename=None, vg_ramdisk_dir=None,
     """
     errs = []
     if vg_name is not None:
-        loop_device = re.search(r"([/\w]+) %s lvm2" % vg_name,
+        loop_device = re.search(r"([/\w]+) +%s +lvm2" % vg_name,
                                 process.run("pvs", sudo=True).stdout)
         if loop_device is not None:
             loop_device = loop_device.group(1)

--- a/avocado/utils/lv_utils.py
+++ b/avocado/utils/lv_utils.py
@@ -157,7 +157,7 @@ def vg_ramdisk_cleanup(ramdisk_filename=None, vg_ramdisk_dir=None,
                                 process.run("pvs", sudo=True).stdout)
         if loop_device is not None:
             loop_device = loop_device.group(1)
-        process.run("vgremove %s" %
+        process.run("vgremove -f %s" %
                     vg_name, ignore_status=True, sudo=True)
 
     if loop_device is not None:


### PR DESCRIPTION
Hello @apahim, @clebergnu, there are two issues preventing `vg_ramdisk_cleanup` to work properly. Would you please review this preferably? It leaves uncleaned partitions/mounts after cleanup...