### PR TITLE
Add expire time for asset fetcher [v3]

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -625,7 +625,7 @@ class Test(unittest.TestCase):
         raise exceptions.TestSkipError(message)
 
     def fetch_asset(self, name, asset_hash=None, algorithm='sha1',
-                    locations=None):
+                    locations=None, expire=None):
         """
         Method o call the utils.asset in order to fetch and asset file
         supporting hash check, caching and multiple locations.
@@ -635,10 +635,13 @@ class Test(unittest.TestCase):
         :param algorithm: hash algorithm (optional, defaults to sha1)
         :param locations: list of URLs from where the asset can be
                           fetched (optional)
+        :param expire: time for the asset to expire
         :returns: asset file local path
         """
+        if expire is not None:
+            expire = data_structures.time_to_seconds(str(expire))
         return asset.Asset(name, asset_hash, algorithm, locations,
-                           self.cache_dirs).fetch()
+                           self.cache_dirs, expire).fetch()
 
 
 class SimpleTest(Test):

--- a/avocado/utils/data_structures.py
+++ b/avocado/utils/data_structures.py
@@ -218,3 +218,26 @@ class CallbackRegister(object):
                   to be executed!
         """
         self.run()
+
+
+def time_to_seconds(time):
+    """
+    Convert time in minutes, hours and days to seconds.
+    :param time: Time including the unit (i.e. '10d')
+    """
+    units = {'s': 1, 'm': 60, 'h': 3600, 'd': 86400}
+    if time is not None:
+        try:
+            unit = time[-1].lower()
+            if unit in units:
+                mult = units[unit]
+                seconds = int(time[:-1]) * mult
+            else:
+                seconds = int(time)
+        except (ValueError, TypeError) as e:
+            raise ValueError("Invalid value '%s' for time. Use an integer "
+                             "number or a string with the number and the time "
+                             "unit (s, m, h or d)." % time)
+    else:
+        seconds = 0
+    return seconds

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -538,6 +538,11 @@ Detailing the ``fetch_asset()`` attributes:
   file, including the file name. The first success will skip the next
   locations. Notice that for ``file://`` we just create a symbolic link in the
   cache directory, pointing to the file original location.
+* ``expire:`` (optional) time period that the cached file will be considered
+  valid. After that period, the file will be dowloaded again. The value can
+  be an integer or a string containig the time and the unit. Example: '10d'
+  (ten days). Valid units are ``s`` (second), ``m`` (minute), ``h`` (hour) and
+  ``d`` (day).
 
 The expected ``return`` is the asset file path or an exception.
 

--- a/selftests/functional/test_job_timeout.py
+++ b/selftests/functional/test_job_timeout.py
@@ -135,15 +135,15 @@ class JobTimeOutTest(unittest.TestCase):
 
     def test_invalid_values(self):
         cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '
-                    '--job-timeout=0 examples/tests/passtest.py' % self.tmpdir)
+                    '--job-timeout=1,5 examples/tests/passtest.py' % self.tmpdir)
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_FAIL)
-        self.assertIn('Invalid number', result.stderr)
+        self.assertIn('Invalid value', result.stderr)
         cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '
                     '--job-timeout=123x examples/tests/passtest.py' % self.tmpdir)
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_FAIL)
-        self.assertIn('Invalid number', result.stderr)
+        self.assertIn('Invalid value', result.stderr)
 
     def test_valid_values(self):
         cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '


### PR DESCRIPTION
v3:
- Use specific class in `except` when calling `time_to_seconds()` in `run.py`.
- Improved unittest.
- Improved docs.
- Don't hard code behavior for `0` and negative values in `expire`.

v2: #1275 
 - Move `time_to_seconds()` to `data_structures`.
 - Accept zero and negative values.
 - Unittest.

v1: #1266 
Now users can invalidate (download again) a local copy of the asset file if
it has more than a given time since created.

Reference: https://trello.com/c/JLk01wOl