### PR TITLE
avocado.plugins.run: Fix job-timeout documentation

### DIFF
--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -73,7 +73,7 @@ class Run(CLICmd):
                             default=None, metavar='SECONDS',
                             help=('Set the maximum amount of time (in SECONDS) that '
                                   'tests are allowed to execute. '
-                                  'Note that zero means "no timeout". '
+                                  'Values <= zero means "no timeout". '
                                   'You can also use suffixes, like: '
                                   ' s (seconds), m (minutes), h (hours). '))
 


### PR DESCRIPTION
The --job-timeout now accepts values <= zero and treats them as no
timeout, let's reflect that in help msg.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>