### PR TITLE
Close STD_OUTPUT on app exception [v3]

### DIFF
--- a/avocado/core/app.py
+++ b/avocado/core/app.py
@@ -18,6 +18,7 @@ The core Avocado application.
 
 import os
 import signal
+import sys
 
 from .parser import Parser
 from . import output
@@ -54,7 +55,21 @@ class AvocadoApp(object):
             self.parser.finish()
             if self.cli_dispatcher.extensions:
                 self.cli_dispatcher.map_method('run', self.parser.args)
-        finally:
+        except SystemExit as e:
+            # If someonte tries to exit Avocado, we should first close the
+            # STD_OUTPUT and only then exit.
+            setattr(self.parser.args, 'paginator', 'off')
+            output.reconfigure(self.parser.args)
+            STD_OUTPUT.close()
+            sys.exit(e.code)
+        except:
+            # For any other exception we also need to close the STD_OUTPUT.
+            setattr(self.parser.args, 'paginator', 'off')
+            output.reconfigure(self.parser.args)
+            STD_OUTPUT.close()
+            raise
+        else:
+            # In case of no exceptions, we just reconfigure the output.
             output.reconfigure(self.parser.args)
 
     def run(self):


### PR DESCRIPTION
v3:
 - Move the  'paginator off' code to the exceptions in `app` so we cover any case instead of argparse error only.

v2: #1271 
 - Close `STD_OUTPUT` in app `init()` instead of just turning paginator off (as in the previous version).
 - Turn the paginator off on argparse error.

v1: #1268 
 - Disables the paginator on argparse error