### PR TITLE
Revert "selftests: Few pre-release unittest fixes"

### DIFF
--- a/selftests/unit/test_archive.py
+++ b/selftests/unit/test_archive.py
@@ -125,15 +125,12 @@ class ArchiveTest(unittest.TestCase):
         self.assertEqual(os.path.realpath(get_path("link_to_dir")),
                          get_path("dir"))
         # File permissions
-        # TODO: Handle permission correctly for all users
-        # Default perm by user is 0o664 and by root 0o644
-        default_perm = 0o664 if os.getuid() else 0o644
         self.assertEqual(os.stat(get_path("dir", "file2")).st_mode & 0o777,
-                         default_perm)
+                         0o664)
         self.assertEqual(os.stat(get_path("file")).st_mode & 0o777, 0o753)
         self.assertEqual(os.stat(get_path("dir")).st_mode & 0o777, 0o775)
         self.assertEqual(os.stat(get_path("link_to_file2")).st_mode & 0o777,
-                         default_perm)
+                         0o664)
         self.assertEqual(os.stat(get_path("link_to_dir")).st_mode & 0o777,
                          0o775)
         self.assertEqual(os.stat(get_path("link_to_file")).st_mode & 0o777,

--- a/selftests/unit/test_utils_partition.py
+++ b/selftests/unit/test_utils_partition.py
@@ -26,8 +26,6 @@ class TestPartition(unittest.TestCase):
     Unit tests for avocado.utils.partition
     """
 
-    @unittest.skipIf(process.system("which mkfs", ignore_status=True),
-                     "mkfs is required for these tests to run.")
     def setUp(self):
         try:
             process.system("/bin/true", sudo=True)


### PR DESCRIPTION
Reverts avocado-framework/avocado#1284

Reverting since neither of the commits are actually fixing the make rpm.