### PR TITLE
avocado/core/tree.py: replace get_ascii() with tree_view()

### DIFF
--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -271,7 +271,7 @@ class TreeNode(object):
                     node = child
                 else:
                     raise ValueError("Path %s does not exists in this tree\n%s"
-                                     % (path, self.get_ascii()))
+                                     % (path, tree_view(self.root)))
         return node
 
     def iter_children_preorder(self):

--- a/selftests/unit/test_tree.py
+++ b/selftests/unit/test_tree.py
@@ -192,6 +192,10 @@ class TestTree(unittest.TestCase):
         self.assertEqual(tree2.children[0].children[1].children[0].multiplex,
                          None)
 
+    def test_get_node(self):
+        self.assertRaises(ValueError,
+                          self.tree.get_node, '/non-existing-node')
+
 
 class TestPathParent(unittest.TestCase):
 


### PR DESCRIPTION
Commit 19cb82c removed the `get_ascii()` method and added the utility
function `tree_view()`.  But there is a leftover using the old method.
Let's replace them.

Signed-off-by: Cleber Rosa <crosa@redhat.com>