### PR TITLE
Multiplex doc: try to be clearer about mandatory space and colon

### DIFF
--- a/docs/source/MultiplexConfig.rst
+++ b/docs/source/MultiplexConfig.rst
@@ -300,13 +300,13 @@ file. This is done by the `!include : $path` directive::
         gentoo:
             !include : gentoo.yaml
 
-.. warning:: Due to YAML nature, it's __mandatory__ to put space between
-             `!include` and `:`!
+.. warning:: Due to YAML nature, it's **mandatory** to put space between
+             `!include` and the colon (`:`) that must follow it.
 
 The file location can be either absolute path or relative path to the YAML
 file where the `!include` is called (even when it's nested).
 
-Whole file is __merged__ into the node where it's defined.
+Whole file is **merged** into the node where it's defined.
 
 
 Advanced YAML tags


### PR DESCRIPTION
We have a warning about the mandatory space when using
the `!include :` construct.  Since the warning has an exclamation mark (for
punctuation purposes) it can make it a bit confusing since the
example given begins with an exclamation mark (for syntactic
purposes).

Also, in reStructured Text markup, double underscores do not add
emphasis, as it seems to be the original intention.

Signed-off-by: Cleber Rosa <crosa@redhat.com>