### PR TITLE
avocado.core: Cleanup runner->multiplexer API

### DIFF
--- a/avocado/core/multiplexer.py
+++ b/avocado/core/multiplexer.py
@@ -414,22 +414,15 @@ class Mux(object):
         else:
             return len(test_suite)
 
-    def itertests(self, template):
+    def itertests(self):
         """
-        Processes the template and yields test definition with proper params
+        Yield variant-id and test params
         """
         if self.variants:  # Copy template and modify it's params
             i = None
             for i, variant in enumerate(self.variants, 1):
-                test_factory = [template[0], template[1].copy()]
-                if "params" in test_factory[1]:
-                    msg = ("Unable to multiplex test %s, params are already "
-                           "present in test factory: %s"
-                           % (test_factory[0], test_factory[1]))
-                    raise ValueError(msg)
-                test_factory[1]['params'] = (variant, self._mux_path)
-                yield test_factory, i if self._has_multiple_variants else None
+                yield i if self._has_multiple_variants else None, variant
             if i is None:   # No variants, use template
-                yield template, None
+                yield None, None
         else:   # No variants, use template
-            yield template, None
+            yield None, None

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -461,6 +461,29 @@ class TestRunner(object):
             return False
         return True
 
+    @staticmethod
+    def _iter_variants(template, mux):
+        """
+        Iterate through variants and set the params/variants accordingly.
+
+        :param template: test template
+        :param mux: the Mux object containing the variants
+        :return: Yields tuple(test_factory including params, variant id)
+        :raises ValueError: When variant and template declare params.
+        """
+        for variant, params in mux.itertests():
+            if params:
+                if "params" in template[1]:
+                    msg = ("Unable to multiplex test %s, params are already "
+                           "present in test factory: %s"
+                           % (template[0], template[1]))
+                    raise ValueError(msg)
+                factory = [template[0], template[1].copy()]
+                factory[1]["params"] = params
+            else:
+                factory = template
+            yield factory, variant
+
     def run_suite(self, test_suite, mux, timeout=0, replay_map=None,
                   test_result_total=0):
         """
@@ -490,7 +513,8 @@ class TestRunner(object):
                 test_template[1]['base_logdir'] = self.job.logdir
                 test_template[1]['job'] = self.job
                 break_loop = False
-                for test_factory, variant in mux.itertests(test_template):
+                for test_factory, variant in self._iter_variants(test_template,
+                                                                 mux):
                     index += 1
                     test_parameters = test_factory[1]
                     name = test_parameters.get("name")


### PR DESCRIPTION
The runner uses multiplexer to modify the test-template, which is not
really clean. It should only as for variants and the runner itself
should be responsible for adjusting the template which is exactly what
this patch does.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>