### PR TITLE
avocado.plugins: Add list test heading

### DIFF
--- a/avocado/plugins/list.py
+++ b/avocado/plugins/list.py
@@ -119,6 +119,7 @@ class TestLister(object):
         self._extra_listing()
         test_suite = self._get_test_suite(self.args.keywords)
         test_matrix, stats = self._get_test_matrix(test_suite)
+        self.log.info("Avaliable tests:")
         self._display(test_matrix, stats)
 
     def list(self):


### PR DESCRIPTION
The `avocado list` command does not support only test listing, but also
optional per-plugin "extra_listing". When this is used no one can tell
where the extra-listing ends and the test-listing begins, therefor this
commit adds a simple "Available tests:" heading.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>