### PR TITLE
[wip] Asset fetcher improvements

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -625,7 +625,7 @@ class Test(unittest.TestCase):
         raise exceptions.TestSkipError(message)
 
     def fetch_asset(self, name, asset_hash=None, algorithm='sha1',
-                    locations=None, expire=None):
+                    locations=None, expire=None, lock_timeout=None):
         """
         Method o call the utils.asset in order to fetch and asset file
         supporting hash check, caching and multiple locations.
@@ -641,7 +641,7 @@ class Test(unittest.TestCase):
         if expire is not None:
             expire = data_structures.time_to_seconds(str(expire))
         return asset.Asset(name, asset_hash, algorithm, locations,
-                           self.cache_dirs, expire).fetch()
+                           self.cache_dirs, expire, lock_timeout).fetch()
 
 
 class SimpleTest(Test):

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -543,6 +543,10 @@ Detailing the ``fetch_asset()`` attributes:
   be an integer or a string containig the time and the unit. Example: '10d'
   (ten days). Valid units are ``s`` (second), ``m`` (minute), ``h`` (hour) and
   ``d`` (day).
+* ``lock_timeout:`` (optional) To avoid race conditions, files not present in
+  cache or expired files will be locked when we have to (re)download them. The
+  first user will have the lock and additional users will wait up to the 
+  ``lock_timeout`` number of seconds for the lock to be released.
 
 The expected ``return`` is the asset file path or an exception.
 

--- a/selftests/unit/test_utils_asset.py
+++ b/selftests/unit/test_utils_asset.py
@@ -25,15 +25,10 @@ class TestAsset(unittest.TestCase):
                                   algorithm='sha1',
                                   locations=None,
                                   cache_dirs=[self.cache_dir],
-                                  expire=None).fetch()
+                                  expire=None,
+                                  lock_timeout=None).fetch()
         expected_tarball = os.path.join(self.cache_dir, self.assetname)
         self.assertEqual(foo_tarball, expected_tarball)
-        hashfile = '.'.join([expected_tarball, 'sha1'])
-        self.assertTrue(os.path.isfile(hashfile))
-        expected_content = '%s %s\n' % (self.assethash, self.assetname)
-        with open(hashfile, 'r') as f:
-            content = f.read()
-        self.assertEqual(content, expected_content)
 
     def testFetch_location(self):
         foo_tarball = asset.Asset(self.assetname,
@@ -41,15 +36,10 @@ class TestAsset(unittest.TestCase):
                                   algorithm='sha1',
                                   locations=[self.url],
                                   cache_dirs=[self.cache_dir],
-                                  expire=None).fetch()
+                                  expire=None,
+                                  lock_timeout=None).fetch()
         expected_tarball = os.path.join(self.cache_dir, self.assetname)
         self.assertEqual(foo_tarball, expected_tarball)
-        hashfile = '.'.join([expected_tarball, 'sha1'])
-        self.assertTrue(os.path.isfile(hashfile))
-        expected_content = '%s %s\n' % (self.assethash, self.assetname)
-        with open(hashfile, 'r') as f:
-            content = f.read()
-        self.assertEqual(content, expected_content)
 
     def testFecth_expire(self):
         foo_tarball = asset.Asset(self.assetname,
@@ -57,7 +47,8 @@ class TestAsset(unittest.TestCase):
                                   algorithm='sha1',
                                   locations=[self.url],
                                   cache_dirs=[self.cache_dir],
-                                  expire=None).fetch()
+                                  expire=None,
+                                  lock_timeout=None).fetch()
         with open(foo_tarball, 'r') as f:
             content1 = f.read()
 
@@ -74,7 +65,8 @@ class TestAsset(unittest.TestCase):
                     algorithm='sha1',
                     locations=[new_url],
                     cache_dirs=[self.cache_dir],
-                    expire=None).fetch()
+                    expire=None,
+                    lock_timeout=None).fetch()
         with open(foo_tarball, 'r') as f:
             content2 = f.read()
         self.assertEqual(content1, content2)
@@ -85,16 +77,31 @@ class TestAsset(unittest.TestCase):
                     algorithm='sha1',
                     locations=[new_url],
                     cache_dirs=[self.cache_dir],
-                    expire=-1).fetch()
+                    expire=-1,
+                    lock_timeout=None).fetch()
         with open(foo_tarball, 'r') as f:
             content2 = f.read()
         self.assertNotEqual(content1, content2)
 
-    def testException(self):
-        a = asset.Asset(name='bar.tgz', asset_hash=None, algorithm=None,
-                        locations=None, cache_dirs=[self.cache_dir],
-                        expire=None)
-        self.assertRaises(EnvironmentError, a.fetch)
+    def testFetch_error(self):
+        foo_tarball = asset.Asset('bar.tgz',
+                                  asset_hash=self.assethash,
+                                  algorithm='sha1',
+                                  locations=None,
+                                  cache_dirs=[self.cache_dir],
+                                  expire=None,
+                                  lock_timeout=None).fetch()
+        self.assertEqual(foo_tarball, None)
+
+    def testFetch_lockerror(self):
+        foo_tarball = asset.Asset(self.url,
+                                  asset_hash=self.assethash,
+                                  algorithm='sha1',
+                                  locations=None,
+                                  cache_dirs=[self.cache_dir],
+                                  expire=None,
+                                  lock_timeout=-1).fetch()
+        self.assertEqual(foo_tarball, None)
 
     def tearDown(self):
         shutil.rmtree(self.basedir)


### PR DESCRIPTION
The new expire feature in asset fetcher made we re-think the logics behind
the fetcher.

In this patch, we:
 - Drop the hashfile support: if user expires a file and do not provide a hash (or
   provide a hash in a diferent algorithm), the existing hashfile can easily become
   outdated. Let's drop the hashfile support and calculate the hash every time user
   provides a hash to be compared to.
 - Create a file lock: as we are going to expire files and re-download them, we now
   lock the file while downloading.
 - Drop EnviromentError exceptions: let's be nice with our tests and do not raise
   an exception when we are not able to provide an asset. Instead, now we just log
   and error and return None.
 - Clean debug messages: now the feature is more mature, we can drop the debug
   messages.

With those changes, asset fetcher is now expected to avoid race conditions and also
to properly verify the files it provides to our tests.

Reference: https://trello.com/c/NeFPMkZY
Reference: https://trello.com/c/OWCprQpd
Signed-off-by: Amador Pahim <apahim@redhat.com>