### PR TITLE
avocado/core/test.py: remove support for string test names and tags

### DIFF
--- a/avocado/core/multiplexer.py
+++ b/avocado/core/multiplexer.py
@@ -117,11 +117,10 @@ class AvocadoParams(object):
 
     # TODO: Use "test" to log params.get()
 
-    def __init__(self, leaves, test_id, tag, mux_path, default_params):
+    def __init__(self, leaves, test_id, mux_path, default_params):
         """
         :param leaves: List of TreeNode leaves defining current variant
         :param test_id: test id
-        :param tag: test tag
         :param mux_path: list of entry points
         :param default_params: dict of params used when no matches found
         """
@@ -135,7 +134,6 @@ class AvocadoParams(object):
         path_leaves = self._get_matching_leaves('/*', leaves)
         self._abs_path = AvocadoParam(path_leaves, '*: *')
         self.id = test_id
-        self.tag = tag
         self._log = logging.getLogger("avocado.test").debug
         self._cache = {}     # TODO: Implement something more efficient
         # TODO: Get rid of this and prepare something better

--- a/selftests/unit/test_multiplexer.py
+++ b/selftests/unit/test_multiplexer.py
@@ -88,11 +88,11 @@ class TestAvocadoParams(unittest.TestCase):
         yamls = multiplexer.yaml2tree(["/:" + PATH_PREFIX +
                                        'examples/mux-selftest-params.yaml'])
         self.yamls = iter(multiplexer.MuxTree(yamls))
-        self.params1 = multiplexer.AvocadoParams(self.yamls.next(), 'Unittest1', 1,
+        self.params1 = multiplexer.AvocadoParams(self.yamls.next(), 'Unittest1',
                                                  ['/ch0/*', '/ch1/*'], {})
         self.yamls.next()    # Skip 2nd
         self.yamls.next()    # and 3rd
-        self.params2 = multiplexer.AvocadoParams(self.yamls.next(), 'Unittest2', 1,
+        self.params2 = multiplexer.AvocadoParams(self.yamls.next(), 'Unittest2',
                                                  ['/ch1/*', '/ch0/*'], {})
 
     @unittest.skipIf(not tree.MULTIPLEX_CAPABLE, "Not multiplex capable")
@@ -107,7 +107,7 @@ class TestAvocadoParams(unittest.TestCase):
         self.assertNotEqual(self.params1, self.params2)
         repr(self.params1)
         str(self.params1)
-        str(multiplexer.AvocadoParams([], 'Unittest', None, [], {}))
+        str(multiplexer.AvocadoParams([], 'Unittest', [], {}))
         self.assertEqual(15, sum([1 for _ in self.params1.iteritems()]))
 
     @unittest.skipIf(not tree.MULTIPLEX_CAPABLE, "Not multiplex capable")

--- a/selftests/unit/test_test.py
+++ b/selftests/unit/test_test.py
@@ -127,9 +127,6 @@ class TestClassTest(unittest.TestCase):
     def testClassAttributesTimeElapsed(self):
         self.assertIsInstance(self.tst_instance_pass.time_elapsed, float)
 
-    def testClassAttributesTag(self):
-        self.assertEqual(self.tst_instance_pass.tag, None)
-
     def testWhiteboardSave(self):
         whiteboard_file = os.path.join(
             self.tst_instance_pass.logdir, 'whiteboard')
@@ -146,6 +143,10 @@ class TestClassTest(unittest.TestCase):
 
         self.assertRaises(exceptions.TestSetupFail, AvocadoPass,
                           base_logdir=self.base_logdir)
+
+    def testNotTestName(self):
+        self.assertRaises(test.NameNotTestNameError,
+                          test.Test, name='mytest')
 
     def tearDown(self):
         shutil.rmtree(self.base_logdir)


### PR DESCRIPTION
When the support for Test IDs was introduced, support for string based
test names and tags was kept in deprecated mode, scheduled to be
removed on an upcoming release.

This planned upcoming release for removal has already passed, so let's
remove them now.

Reference: https://trello.com/c/QqZmfkYt
Signed-off-by: Cleber Rosa <crosa@redhat.com>

--

This has been tested with the following combination of versions:

* Avocado 36lts (ab66fba) + Avocado-VT "test_name_remove_deprecated" (b82c0ac) = OK
* Avocado master (c0ebd3f) + Avocado-VT "test_name_remove_deprecated" (b82c0ac) = OK
* Avocado "test_name_remove_deprecated" (6baeeed) + Avocado-VT "test_name_remove_deprecated" (b82c0ac) = OK

The combination of Avocado "test_name_remove_deprecated" branch
(6baeeed) + Avocado-VT master branch (1af13fd) does *not* work, as
Avocado-VT users avocado.core.test.Test parameters that do not exist
anymore.  But this is OK because Avocado-VT users are expected to
either use Avocado from master or a LTS release.
