### PR TITLE
Add 'latest' option to replay feature

### DIFF
--- a/avocado/core/replay.py
+++ b/avocado/core/replay.py
@@ -113,6 +113,13 @@ def retrieve_args(resultsdir):
 
 
 def get_resultsdir(logdir, jobid):
+    if jobid == 'latest':
+        try:
+            actual_dir = os.readlink(os.path.join(logdir, 'latest'))
+            return os.path.join(logdir, actual_dir)
+        except:
+            return None
+
     matches = 0
     short_jobid = jobid[:7]
     if len(short_jobid) < 7:
@@ -135,6 +142,9 @@ def get_resultsdir(logdir, jobid):
 
 
 def get_id(path, jobid):
+    if jobid == 'latest':
+        jobid = os.path.basename(os.path.dirname(path))[-7:]
+
     if not os.path.exists(path):
         return None
 

--- a/selftests/functional/test_replay_basic.py
+++ b/selftests/functional/test_replay_basic.py
@@ -44,10 +44,17 @@ class ReplayTests(unittest.TestCase):
         return result
 
     def test_run_replay_noid(self):
-        cmd_line = ('./scripts/avocado run --replay %s'
+        cmd_line = ('./scripts/avocado run --replay %s '
                     '--job-results-dir %s --replay-data-dir %s --sysinfo=off' %
                     ('foo', self.tmpdir, self.jobdir))
         expected_rc = exit_codes.AVOCADO_JOB_FAIL
+        self.run_and_check(cmd_line, expected_rc)
+
+    def test_run_replay_latest(self):
+        cmd_line = ('./scripts/avocado run --replay latest '
+                    '--job-results-dir %s --replay-data-dir %s --sysinfo=off' %
+                    (self.tmpdir, self.jobdir))
+        expected_rc = exit_codes.AVOCADO_ALL_OK
         self.run_and_check(cmd_line, expected_rc)
 
     def test_run_replay_data(self):


### PR DESCRIPTION
Now users can execute 'avocado run --replay latest' to have the latest
job replayed (no need to remember the job id).

Reference: https://trello.com/c/C0YCTT6d
Signed-off-by: Amador Pahim <apahim@redhat.com>