### PR TITLE
Add 'latest' option to replay feature [v2]

### DIFF
--- a/avocado/core/replay.py
+++ b/avocado/core/replay.py
@@ -113,6 +113,13 @@ def retrieve_args(resultsdir):
 
 
 def get_resultsdir(logdir, jobid):
+    if jobid == 'latest':
+        try:
+            actual_dir = os.readlink(os.path.join(logdir, 'latest'))
+            return os.path.join(logdir, actual_dir)
+        except:
+            return None
+
     matches = 0
     short_jobid = jobid[:7]
     if len(short_jobid) < 7:
@@ -135,6 +142,9 @@ def get_resultsdir(logdir, jobid):
 
 
 def get_id(path, jobid):
+    if jobid == 'latest':
+        jobid = os.path.basename(os.path.dirname(path))[-7:]
+
     if not os.path.exists(path):
         return None
 

--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -43,7 +43,8 @@ class Replay(CLI):
         replay_parser.add_argument('--replay', dest='replay_jobid',
                                    default=None,
                                    help='Replay a job identified by its '
-                                   '(partial) hash id')
+                                   '(partial) hash id. Use "--replay latest" '
+                                   'to replay the latest job.')
         replay_parser.add_argument('--replay-test-status',
                                    dest='replay_teststatus',
                                    type=self._valid_status,

--- a/docs/source/Replay.rst
+++ b/docs/source/Replay.rst
@@ -7,8 +7,9 @@ Job Replay
 In order to reproduce a given job using the same data, one can use the
 ``--replay`` option for the ``run`` command, informing the hash id from
 the original job to be replayed. The hash id can be partial, as long as
-the provided part corresponds to the inital characters of the original
-job id and it is also unique enough.
+the provided part corresponds to the initial characters of the original
+job id and it is also unique enough. Or, instead of the job id, you can
+use the string ``latest`` and avocado will replay the latest job executed.
 
 Let's see an example. First, running a simple job with two urls::
 
@@ -95,7 +96,7 @@ multiplex file::
      JOB HTML   : $HOME/avocado/job-results/job-2016-01-11T21.56-bd6aa3b/html/results.html
      TESTS TIME : 0.29 s
 
-We can replay the job as is, using ``$ avocado run --replay bd6aa3b``,
+We can replay the job as is, using ``$ avocado run --replay latest``,
 or replay the job ignoring the multiplex file, as below::
 
      $ avocado run --replay bd6aa3b --replay-ignore mux
@@ -111,8 +112,7 @@ or replay the job ignoring the multiplex file, as below::
      TESTS TIME : 0.02 s
 
 Also, it is possible to replay only the variants that faced a given
-result, using the option ``--replay-test-status``. Using the same job
-``bd6aa3b``, see the example below::
+result, using the option ``--replay-test-status``. See the example below::
 
     $ avocado run --replay bd6aa3b --replay-test-status FAIL
     JOB ID     : 2e1dc41af6ed64895f3bb45e3820c5cc62a9b6eb
@@ -191,7 +191,7 @@ Trying to replay the job, it fails::
      $ avocado run --replay f1b1
      can't find job results directory in '$HOME/avocado/job-results'
 
-In this case, we have to inform where the job results dir is located::
+In this case, we have to inform where the job results directory is located::
 
      $ avocado run --replay f1b1 --replay-data-dir /tmp/avocado_results
      JOB ID     : 19c76abb29f29fe410a9a3f4f4b66387570edffa

--- a/selftests/functional/test_replay_basic.py
+++ b/selftests/functional/test_replay_basic.py
@@ -44,10 +44,17 @@ class ReplayTests(unittest.TestCase):
         return result
 
     def test_run_replay_noid(self):
-        cmd_line = ('./scripts/avocado run --replay %s'
+        cmd_line = ('./scripts/avocado run --replay %s '
                     '--job-results-dir %s --replay-data-dir %s --sysinfo=off' %
                     ('foo', self.tmpdir, self.jobdir))
         expected_rc = exit_codes.AVOCADO_JOB_FAIL
+        self.run_and_check(cmd_line, expected_rc)
+
+    def test_run_replay_latest(self):
+        cmd_line = ('./scripts/avocado run --replay latest '
+                    '--job-results-dir %s --replay-data-dir %s --sysinfo=off' %
+                    (self.tmpdir, self.jobdir))
+        expected_rc = exit_codes.AVOCADO_ALL_OK
         self.run_and_check(cmd_line, expected_rc)
 
     def test_run_replay_data(self):


### PR DESCRIPTION
v2:
 - Added help message.
 - Added documentation.

v1: #1305 
Now users can execute 'avocado run --replay latest' to have the latest
job replayed. No need to remember the job id.

Reference: https://trello.com/c/C0YCTT6d
Signed-off-by: Amador Pahim <apahim@redhat.com>