### PR TITLE
avocado.plugins: Add plugin to run job in docker container

### DIFF
--- a/avocado/core/remote/runner.py
+++ b/avocado/core/remote/runner.py
@@ -203,6 +203,7 @@ class RemoteTestRunner(TestRunner):
         fabric_debugfile = os.path.join(self.job.logdir, 'remote.log')
         paramiko_logger = logging.getLogger('paramiko')
         fabric_logger = logging.getLogger('avocado.fabric')
+        remote_logger = logging.getLogger('avocado.remote')
         app_logger = logging.getLogger('avocado.debug')
         fmt = ('%(asctime)s %(module)-10.10s L%(lineno)-.4d %('
                'levelname)-5.5s| %(message)s')
@@ -211,6 +212,7 @@ class RemoteTestRunner(TestRunner):
         file_handler.setFormatter(formatter)
         fabric_logger.addHandler(file_handler)
         paramiko_logger.addHandler(file_handler)
+        remote_logger.addHandler(file_handler)
         logger_list = [fabric_logger]
         if self.job.args.show_job_log:
             logger_list.append(app_logger)

--- a/avocado/plugins/docker.py
+++ b/avocado/plugins/docker.py
@@ -1,0 +1,170 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: 2016 Red Hat, Inc.
+# Author: Lukas Doktor <ldoktor@redhat.com>
+"""Run the job inside a docker container."""
+
+import logging
+import time
+
+import aexpect
+from avocado.core.plugin_interfaces import CLI
+from avocado.core.remote.runner import RemoteTestRunner
+from avocado.utils import process
+from avocado.utils.wait import wait_for
+
+
+LOG = logging.getLogger('avocado.remote')
+
+
+class DockerRemoter(object):
+
+    """
+    Remoter object similar to `avocado.core.remoter` which implements subset
+    of the commands on docker container.
+    """
+
+    def __init__(self, dkrcmd):
+        """
+        Executes docker container and attaches it.
+
+        :param dkrcmd: The desired docker cmd, it has to use `-d` in order
+                       to output the cid and finish and the executed command
+                       has to be some kind of shell. Remoter will then use
+                       `docker attach` to attach the container (this is to
+                       prevent uninitialized container being inquired)
+        """
+        self._docker_id = process.system_output(dkrcmd, 10).strip()
+        self._docker = aexpect.ShellSession("docker attach %s"
+                                            % self._docker_id)
+        # Disable echo to avoid duplicate output
+        self._docker.cmd("stty -echo")
+
+    def get_cid(self):
+        """ Return this remoter's container ID """
+        return self._docker_id
+
+    def makedir(self, remote_path):
+        """
+        Create a directory on the container
+
+        :warning: No other process must be running on foreground
+        :param remote_path: the remote path to create.
+        """
+        self._docker.cmd("mkdir -p %s" % remote_path)
+
+    def send_files(self, local_path, remote_path):
+        """
+        Send files to the container
+        """
+        process.run("docker cp %s %s:%s" % (local_path, self._docker_id,
+                                            remote_path))
+
+    def receive_files(self, local_path, remote_path):
+        """
+        Receive files from the container
+        """
+        process.run("docker cp %s:%s %s" % (self._docker_id, remote_path,
+                                            local_path))
+
+    def run(self, command, ignore_status=False, quiet=None, timeout=60):
+        """
+        Run command inside the container
+        """
+        def print_func(*args, **kwargs):    # pylint: disable=W0613
+            """ Accept anything and does nothing """
+            pass
+        if timeout is None:
+            timeout = 31536000  # aexpect does not support None, use one year
+        start = time.time()
+        if quiet is not False:
+            print_func = LOG.debug
+        status, output = self._docker.cmd_status_output(command,
+                                                        timeout=timeout,
+                                                        print_func=print_func)
+        result = process.CmdResult(command, output, '', status,
+                                   time.time() - start)
+        if status and not ignore_status:
+            raise process.CmdError(command, result, "in container %s"
+                                   % self._docker_id)
+        return result
+
+    def close(self):
+        """
+        Safely postprocess the container
+
+        :note: It won't remove the container, you need to do it manually
+        """
+        self._docker.sendline("exit")
+        # Leave the process up to 10s to finish, then nuke it
+        wait_for(lambda: not self._docker.is_alive(), 10)
+        self._docker.close()
+
+
+class DockerTestRunner(RemoteTestRunner):
+
+    """
+    Test runner which runs the job inside a docker container
+    """
+
+    def __init__(self, job, test_result):
+        super(DockerTestRunner, self).__init__(job, test_result)
+        self.remote = None      # Will be set in `setup`
+        self.remote_test_dir = "/avocado_remote_test_dir"  # Absolute path only
+
+    def setup(self):
+        dkrcmd = ("docker %s run -t -i -d '%s' bash"
+                  % (self.job.args.docker_hypervisor_uri,
+                     self.job.args.docker))
+        self.remote = DockerRemoter(dkrcmd)
+        # We need to create the base dir, otherwise docker creates it as root
+        self.remote.makedir(self.remote_test_dir)
+        self.job.log.info("DOCKER     : Using docker cmd '%s'" % dkrcmd)
+        self.job.log.info("DOCKER     : Container id '%s'"
+                          % self.remote.get_cid())
+        self.job.args.remote_no_copy = self.job.args.remote_no_copy
+
+    def tear_down(self):
+        self.remote.close()
+        if not self.job.args.docker_no_cleanup:
+            process.system("docker rm %s" % self.remote.get_cid())
+
+
+class Docker(CLI):
+
+    """
+    Run the job inside a docker container
+    """
+
+    name = 'docker'
+    description = "Run tests inside docker container"
+
+    def configure(self, parser):
+        run_subcommand_parser = parser.subcommands.choices.get('run', None)
+        if run_subcommand_parser is None:
+            return
+
+        msg = 'test execution inside docker container'
+        cmd_parser = run_subcommand_parser.add_argument_group(msg)
+        cmd_parser.add_argument("--docker", help="Name of the docker image to"
+                                "run tests on.", metavar="IMAGE")
+        cmd_parser.add_argument("--docker-hypervisor-uri", default="",
+                                help="Specify hypervisor connection URI")
+        cmd_parser.add_argument("--docker-no-copy", action="store_true",
+                                help="Assume tests are already in the "
+                                "container")
+        cmd_parser.add_argument("--docker-no-cleanup", action="store_true",
+                                help="Preserve container after test")
+
+    def run(self, args):
+        if getattr(args, "docker", None):
+            args.test_runner = DockerTestRunner

--- a/setup.py
+++ b/setup.py
@@ -139,6 +139,7 @@ if __name__ == '__main__':
                   'replay = avocado.plugins.replay:Replay',
                   'tap = avocado.plugins.tap:TAP',
                   'vm = avocado.plugins.vm:VM',
+                  'docker = avocado.plugins.docker:Docker',
                   ],
               'avocado.plugins.cli.cmd': [
                   'config = avocado.plugins.config:Config',


### PR DESCRIPTION
Similarly to --remote or --vm plugins this plugin allows one to run the
job inside a docker container by specifying the docker image. It
executes a new container, then attaches it and uses it similarly as
--remote plugin uses remote machine.

To check it out you can use "ldoktor/fedora-avocado" image which is
available on (the default) hub.docker.com

Trello: https://trello.com/c/FOxIriF3/616-support-running-tests-in-a-docker-container-based-on-the-remote-plugin