### PR TITLE
examples: Add `make spell` to testplan

### DIFF
--- a/examples/testplans/release.json
+++ b/examples/testplans/release.json
@@ -6,6 +6,9 @@
 	{"name": "Avocado source is sound",
 	 "description": "On your development machine, on a freshen Avocado source to be released, run `$ make check`. Expected result: Make command should say OK."},
 
+	{"name": "Avocado source does not contain spelling errors",
+	 "description": "On your development machine, on a freshen Avocado source to be released, run `$ make spell`. Expected result: Make command should say OK."},
+
 	{"name": "Avocado RPM build",
 	 "description": "On your development machine, build the Avocado RPM packages using: `$ make rpm`. Expected result: SRPM and RPM files at `BUILD/RPM/avocado-x.y.z-r.distro.{src,noarch}.rpm`"},
 


### PR DESCRIPTION
Support for spell checking had been added to avocado recently, let's
make that mandatory step of manual testplan.

v1: https://github.com/avocado-framework/avocado/pull/1306

Changes:

    v2: indentation fixes