### PR TITLE
Introduce FileOrStdoutAction

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -19,14 +19,14 @@ Job module - describes a sequence of automated test operations.
 
 import argparse
 import commands
+import fnmatch
 import logging
 import os
 import re
-import sys
-import traceback
-import tempfile
 import shutil
-import fnmatch
+import sys
+import tempfile
+import traceback
 
 from . import version
 from . import data_dir
@@ -299,16 +299,7 @@ class Job(object):
             html_plugin = html.HTMLTestResult(self, html_file)
             self.result_proxy.add_output_plugin(html_plugin)
 
-        op_set_stdout = self.result_proxy.output_plugins_using_stdout()
-        if len(op_set_stdout) > 1:
-            self.log.error('Options %s are trying to use stdout '
-                           'simultaneously', " ".join(op_set_stdout))
-            self.log.error('Please set at least one of them to a file to '
-                           'avoid conflicts')
-            self.exitcode |= exit_codes.AVOCADO_JOB_FAIL
-            sys.exit(self.exitcode)
-
-        if not op_set_stdout and not self.standalone:
+        if not getattr(self.args, 'stdout_claimed', False) or self.standalone:
             human_plugin = result.HumanTestResult(self)
             self.result_proxy.add_output_plugin(human_plugin)
 

--- a/avocado/core/result.py
+++ b/avocado/core/result.py
@@ -62,13 +62,6 @@ class TestResultProxy(object):
                                       "TestResult" % plugin)
         self.output_plugins.append(plugin)
 
-    def output_plugins_using_stdout(self):
-        using_stdout = []
-        for op in self.output_plugins:
-            if op.output == '-':
-                using_stdout.append(op.command_line_arg_name)
-        return using_stdout
-
     def start_tests(self):
         for output_plugin in self.output_plugins:
             output_plugin.start_tests()

--- a/avocado/plugins/json.py
+++ b/avocado/plugins/json.py
@@ -19,6 +19,7 @@ JSON output module.
 from avocado.core.jsonresult import JSONTestResult
 from avocado.core.plugin_interfaces import CLI
 from avocado.core.result import register_test_result_class
+from avocado.core.parser import FileOrStdoutAction
 
 
 class JSON(CLI):
@@ -36,7 +37,7 @@ class JSON(CLI):
             return
 
         run_subcommand_parser.output.add_argument(
-            '--json', type=str,
+            '--json', type=str, action=FileOrStdoutAction,
             dest='json_output', metavar='FILE',
             help='Enable JSON result format and write it to FILE. '
                  "Use '-' to redirect to the standard output.")

--- a/avocado/plugins/tap.py
+++ b/avocado/plugins/tap.py
@@ -17,8 +17,9 @@ TAP output module.
 
 import logging
 
-from ..core.result import register_test_result_class, TestResult
+from avocado.core.parser import FileOrStdoutAction
 from avocado.core.plugin_interfaces import CLI
+from avocado.core.result import register_test_result_class, TestResult
 
 
 class TAPResult(TestResult):
@@ -95,6 +96,7 @@ class TAP(CLI):
             return
 
         cmd_parser.output.add_argument('--tap', type=str, metavar='FILE',
+                                       action=FileOrStdoutAction,
                                        help="Enable TAP result output and "
                                        "write it to FILE. Use '-' to redirect "
                                        "to the standard output.")

--- a/avocado/plugins/xunit.py
+++ b/avocado/plugins/xunit.py
@@ -17,6 +17,7 @@
 from avocado.core.plugin_interfaces import CLI
 from avocado.core.result import register_test_result_class
 from avocado.core.xunit import xUnitTestResult
+from avocado.core.parser import FileOrStdoutAction
 
 
 class XUnit(CLI):
@@ -35,7 +36,8 @@ class XUnit(CLI):
 
         self.parser = parser
         run_subcommand_parser.output.add_argument(
-            '--xunit', type=str, dest='xunit_output', metavar='FILE',
+            '--xunit', type=str, action=FileOrStdoutAction,
+            dest='xunit_output', metavar='FILE',
             help=('Enable xUnit result format and write it to FILE. '
                   "Use '-' to redirect to the standard output."))
 

--- a/selftests/unit/test_parser.py
+++ b/selftests/unit/test_parser.py
@@ -1,0 +1,37 @@
+import argparse
+import sys
+
+if sys.version_info[:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
+
+from avocado.core import parser
+from avocado.core import exceptions
+
+
+class FileOrStdoutActionTest(unittest.TestCase):
+
+    def setUp(self):
+        self.parser = argparse.ArgumentParser(prog='avocado')
+        self.parser.add_argument('--xunit',
+                                 action=parser.FileOrStdoutAction)
+        self.parser.add_argument('--json',
+                                 action=parser.FileOrStdoutAction)
+
+    def test_multiple_files(self):
+        self.parser.parse_args(['--xunit=results.xml',
+                                '--json=results.json'])
+
+    def test_one_file_and_stdout(self):
+        self.parser.parse_args(['--xunit=-',
+                                '--json=results.json'])
+
+    def test_multiple_stdout_raises(self):
+        self.assertRaises(exceptions.OptionValidationError,
+                          self.parser.parse_args,
+                          ['--xunit=-', '--json=-'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This has the goal of moving the logic of incompatible options out of the job layer. This way, plugins can try to acquire the rights to standard output, and if more than one do, the application is aborted.

This is one piece required to make the job completely unaware of result plugins, which is coming next.