### PR TITLE
Add --failfast option to avocado run command [v2]

### DIFF
--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -457,6 +457,11 @@ class TestRunner(object):
         elif not mapping[test_state['status']]:
             summary.add("FAIL")
 
+            if getattr(self.job.args, 'failfast', False):
+                summary.add("INTERRUPTED")
+                self.job.log.debug("Interrupting job (failfast).")
+                return False
+
         if ctrl_c_count > 0:
             return False
         return True

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -77,6 +77,9 @@ class Run(CLICmd):
                                   'You can also use suffixes, like: '
                                   ' s (seconds), m (minutes), h (hours). '))
 
+        parser.add_argument('--failfast', action='store_true',
+                            help='Interrupt job on first failed test.')
+
         sysinfo_default = settings.get_value('sysinfo.collect',
                                              'enabled',
                                              key_type='bool',

--- a/docs/source/GetStartedGuide.rst
+++ b/docs/source/GetStartedGuide.rst
@@ -216,6 +216,23 @@ instrumented and simple tests::
     JOB HTML  : $HOME/avocado/job-results/job-2014-08-12T15.42-86911e49/html/results.html
     TESTS TIME : 5.88 s
 
+Interrupting The Job On First Failed Test (failfast)
+====================================================
+
+The Avocado ``run`` command has the option ``--failfast`` to exit the job on
+first failed test::
+
+    $ avocado run --failfast /bin/true /bin/false /bin/true /bin/true
+    JOB ID     : eaf51b8c7d6be966bdf5562c9611b1ec2db3f68a
+    JOB LOG    : $HOME/avocado/job-results/job-2016-07-19T09.43-eaf51b8/job.log
+    TESTS      : 4
+     (1/4) /bin/true: PASS (0.01 s)
+     (2/4) /bin/false: FAIL (0.01 s)
+    Interrupting job (failfast).
+    RESULTS    : PASS 1 | ERROR 0 | FAIL 1 | SKIP 2 | WARN 0 | INTERRUPT 0
+    JOB HTML   : /home/apahim/avocado/job-results/job-2016-07-19T09.43-eaf51b8/html/results.html
+    TESTS TIME : 0.02 s
+
 .. _running-external-runner:
 
 Running Tests With An External Runner

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -148,6 +148,17 @@ class RunnerOperationTest(unittest.TestCase):
                     'passtest.py passtest.py' % self.tmpdir)
         process.run(cmd_line)
 
+    def test_runner_failfast(self):
+        os.chdir(basedir)
+        cmd_line = ('./scripts/avocado run --sysinfo=off --job-results-dir %s '
+                    'passtest.py failtest.py passtest.py --failfast' % self.tmpdir)
+        result = process.run(cmd_line, ignore_status=True)
+        self.assertIn('Interrupting job (failfast).', result.stdout)
+        self.assertIn('PASS 1 | ERROR 0 | FAIL 1 | SKIP 1', result.stdout)
+        expected_rc = exit_codes.AVOCADO_TESTS_FAIL | exit_codes.AVOCADO_JOB_INTERRUPTED
+        self.assertEqual(result.exit_status, expected_rc,
+                         "Avocado did not return rc %d:\n%s" % (expected_rc, result))
+
     def test_datadir_alias(self):
         os.chdir(basedir)
         cmd_line = ('./scripts/avocado run --sysinfo=off --job-results-dir %s '


### PR DESCRIPTION
v2:
 - Access `job.args` properly.
 - Add `AVOCADO_JOB_INTERRUPTED` to exit code.
 - Use the same wording for `--help`.

v1: #1313 
With this option, a test that ends with a 'bad' status will make
the job to be interrupted.