### PR TITLE
Deal with IOError due to (EPIPE) [v2]

### DIFF
--- a/avocado/core/app.py
+++ b/avocado/core/app.py
@@ -39,7 +39,6 @@ class AvocadoApp(object):
         os.environ['LIBC_FATAL_STDERR_'] = '1'
 
         signal.signal(signal.SIGTSTP, signal.SIG_IGN)   # ignore ctrl+z
-        signal.signal(signal.SIGPIPE, signal.SIG_DFL)
         self.parser = Parser()
         output.early_start()
         try:

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -399,6 +399,19 @@ class OutputPluginTest(unittest.TestCase):
         os.chdir(basedir)
         process.run("perl %s" % perl_script)
 
+    def test_broken_pipe(self):
+        os.chdir(basedir)
+        cmd_line = "(./scripts/avocado run --help | whacky-unknown-command)"
+        result = process.run(cmd_line, shell=True, ignore_status=True)
+        expected_rc = 127
+        self.assertEqual(result.exit_status, expected_rc,
+                         ("avocado run to broken pipe did not return "
+                          "rc %d:\n%s" % (expected_rc, result)))
+        self.assertEqual(len(result.stderr.splitlines()), 1)
+        self.assertIn("whacky-unknown-command", result.stderr)
+        self.assertIn("not found", result.stderr)
+        self.assertNotIn("Avocado crashed", result.stderr)
+
     def tearDown(self):
         shutil.rmtree(self.tmpdir)
 


### PR DESCRIPTION
This reverts the previously introduced change in SIGPIPE handling, and adds a more specific handling of the IOError (due to EPIPE) that caused Avocado to crash.

--
Changes from v1:
 * Deal with the different shell used in travis