### PR TITLE
[LTS] Deal with IOError due to EPIPE

### DIFF
--- a/avocado/core/app.py
+++ b/avocado/core/app.py
@@ -38,7 +38,6 @@ class AvocadoApp(object):
         os.environ['LIBC_FATAL_STDERR_'] = '1'
 
         signal.signal(signal.SIGTSTP, signal.SIG_IGN)   # ignore ctrl+z
-        signal.signal(signal.SIGPIPE, signal.SIG_DFL)
         self.parser = Parser()
         output.early_start()
         initialized = False

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -15,6 +15,7 @@
 """
 Manages output and logging in avocado applications.
 """
+import errno
 import logging
 import os
 import re
@@ -277,12 +278,21 @@ class StdOutput(object):
         Prints all stored messages as they occured into streams they were
         produced for.
         """
-        for stream, msg in self.records:
-            if stream:
-                sys.stdout.write(msg)
-            else:
-                sys.stderr.write(msg)
-        del self.records[:]
+        try:
+            for stream, msg in self.records:
+                if stream:
+                    sys.stdout.write(msg)
+                else:
+                    sys.stderr.write(msg)
+            del self.records[:]
+        # IOError due to EPIPE is ignored.  That is to avoid having to
+        # handle all IOErrors at the main application loop
+        # indiscriminately.  By handling them here, we can be sure
+        # that the failure was due to stdout or stderr not being
+        # connected to an open PIPE.
+        except IOError as e:
+            if not e.errno == errno.EPIPE:
+                raise
 
     def fake_outputs(self):
         """

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -371,6 +371,19 @@ class OutputPluginTest(unittest.TestCase):
             except OSError:
                 pass
 
+    def test_broken_pipe(self):
+        os.chdir(basedir)
+        cmd_line = "(./scripts/avocado run --help | whacky-unknown-command)"
+        result = process.run(cmd_line, shell=True, ignore_status=True)
+        expected_rc = 127
+        self.assertEqual(result.exit_status, expected_rc,
+                         ("avocado run to broken pipe did not return "
+                          "rc %d:\n%s" % (expected_rc, result)))
+        self.assertEqual(len(result.stderr.splitlines()), 1)
+        self.assertIn("whacky-unknown-command", result.stderr)
+        self.assertIn("not found", result.stderr)
+        self.assertNotIn("Avocado crashed", result.stderr)
+
     def tearDown(self):
         shutil.rmtree(self.tmpdir)
 


### PR DESCRIPTION
This reverts the previously introduced change in SIGPIPE handling, and adds a more specific handling of the IOError (due to EPIPE) that caused Avocado to crash.