### PR TITLE
avocado/core/test.py: remove support for string test names and tags [v2]

### DIFF
--- a/avocado/core/multiplexer.py
+++ b/avocado/core/multiplexer.py
@@ -117,11 +117,10 @@ class AvocadoParams(object):
 
     # TODO: Use "test" to log params.get()
 
-    def __init__(self, leaves, test_id, tag, mux_path, default_params):
+    def __init__(self, leaves, test_id, mux_path, default_params):
         """
         :param leaves: List of TreeNode leaves defining current variant
         :param test_id: test id
-        :param tag: test tag
         :param mux_path: list of entry points
         :param default_params: dict of params used when no matches found
         """
@@ -135,7 +134,6 @@ class AvocadoParams(object):
         path_leaves = self._get_matching_leaves('/*', leaves)
         self._abs_path = AvocadoParam(path_leaves, '*: *')
         self.id = test_id
-        self.tag = tag
         self._log = logging.getLogger("avocado.test").debug
         self._cache = {}     # TODO: Implement something more efficient
         # TODO: Get rid of this and prepare something better

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -916,9 +916,9 @@ putting it in ``mylibrary.py``::
 
     class MyOwnDerivedTest(Test):
         def __init__(self, methodName='test', name=None, params=None,
-                     base_logdir=None, tag=None, job=None, runner_queue=None):
+                     base_logdir=None, job=None, runner_queue=None):
             super(MyOwnDerivedTest, self).__init__(methodName, name, params,
-                                                   base_logdir, tag, job,
+                                                   base_logdir, job,
                                                    runner_queue)
             self.log('Derived class example')
 

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -228,27 +228,27 @@ clear stages on a single test::
             # Preparing soil
             for row in range(rows):
                 progress_log.info("%s: preparing soil on row %s",
-                                  self.tagged_name, row)
+                                  self.name, row)
 
             # Letting soil rest
             progress_log.info("%s: letting soil rest before throwing seeds",
-                              self.tagged_name)
+                              self.name)
             time.sleep(2)
 
             # Throwing seeds
             for row in range(rows):
                 progress_log.info("%s: throwing seeds on row %s",
-                                  self.tagged_name, row)
+                                  self.name, row)
 
             # Let them grow
             progress_log.info("%s: waiting for Avocados to grow",
-                              self.tagged_name)
+                              self.name)
             time.sleep(5)
 
             # Harvest them
             for row in range(rows):
                 progress_log.info("%s: harvesting organic avocados on row %s",
-                                  self.tagged_name, row)
+                                  self.name, row)
 
 
 From this point on, you can ask Avocado to show your logging stream, either
@@ -261,18 +261,18 @@ The outcome should be similar to::
     JOB ID     : af786f86db530bff26cd6a92c36e99bedcdca95b
     JOB LOG    : /home/cleber/avocado/job-results/job-2016-03-18T10.29-af786f8/job.log
     TESTS      : 1
-     (1/1) plant.py:Plant.test_plant_organic:  progress: plant.py:Plant.test_plant_organic: preparing soil on row 0
-    progress: plant.py:Plant.test_plant_organic: preparing soil on row 1
-    progress: plant.py:Plant.test_plant_organic: preparing soil on row 2
-    progress: plant.py:Plant.test_plant_organic: letting soil rest before throwing seeds
-    -progress: plant.py:Plant.test_plant_organic: throwing seeds on row 0
-    progress: plant.py:Plant.test_plant_organic: throwing seeds on row 1
-    progress: plant.py:Plant.test_plant_organic: throwing seeds on row 2
-    progress: plant.py:Plant.test_plant_organic: waiting for Avocados to grow
-    \progress: plant.py:Plant.test_plant_organic: harvesting organic avocados on row 0
-    progress: plant.py:Plant.test_plant_organic: harvesting organic avocados on row 1
-    progress: plant.py:Plant.test_plant_organic: harvesting organic avocados on row 2
-    PASS
+     (1/1) plant.py:Plant.test_plant_organic: progress: 1-plant.py:Plant.test_plant_organic: preparing soil on row 0
+    progress: 1-plant.py:Plant.test_plant_organic: preparing soil on row 1
+    progress: 1-plant.py:Plant.test_plant_organic: preparing soil on row 2
+    progress: 1-plant.py:Plant.test_plant_organic: letting soil rest before throwing seeds
+    -progress: 1-plant.py:Plant.test_plant_organic: throwing seeds on row 0
+    progress: 1-plant.py:Plant.test_plant_organic: throwing seeds on row 1
+    progress: 1-plant.py:Plant.test_plant_organic: throwing seeds on row 2
+    progress: 1-plant.py:Plant.test_plant_organic: waiting for Avocados to grow
+    \progress: 1-plant.py:Plant.test_plant_organic: harvesting organic avocados on row 0
+    progress: 1-plant.py:Plant.test_plant_organic: harvesting organic avocados on row 1
+    progress: 1-plant.py:Plant.test_plant_organic: harvesting organic avocados on row 2
+    PASS (7.01 s)
     RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0
     JOB HTML   : /home/cleber/avocado/job-results/job-2016-03-18T10.29-af786f8/html/results.html
     TESTS TIME : 7.01 s
@@ -289,21 +289,21 @@ will be another log file named ``progress.INFO`` at the job results
 dir. During the test run, one could watch the progress with::
 
     $ tail -f ~/avocado/job-results/latest/progress.INFO
-    10:36:59 INFO | plant.py:Plant.test_plant_organic: preparing soil on row 0
-    10:36:59 INFO | plant.py:Plant.test_plant_organic: preparing soil on row 1
-    10:36:59 INFO | plant.py:Plant.test_plant_organic: preparing soil on row 2
-    10:36:59 INFO | plant.py:Plant.test_plant_organic: letting soil rest before throwing seeds
-    10:37:01 INFO | plant.py:Plant.test_plant_organic: throwing seeds on row 0
-    10:37:01 INFO | plant.py:Plant.test_plant_organic: throwing seeds on row 1
-    10:37:01 INFO | plant.py:Plant.test_plant_organic: throwing seeds on row 2
-    10:37:01 INFO | plant.py:Plant.test_plant_organic: waiting for Avocados to grow
-    10:37:06 INFO | plant.py:Plant.test_plant_organic: harvesting organic avocados on row 0
-    10:37:06 INFO | plant.py:Plant.test_plant_organic: harvesting organic avocados on row 1
-    10:37:06 INFO | plant.py:Plant.test_plant_organic: harvesting organic avocados on row 2
+    10:36:59 INFO | 1-plant.py:Plant.test_plant_organic: preparing soil on row 0
+    10:36:59 INFO | 1-plant.py:Plant.test_plant_organic: preparing soil on row 1
+    10:36:59 INFO | 1-plant.py:Plant.test_plant_organic: preparing soil on row 2
+    10:36:59 INFO | 1-plant.py:Plant.test_plant_organic: letting soil rest before throwing seeds
+    10:37:01 INFO | 1-plant.py:Plant.test_plant_organic: throwing seeds on row 0
+    10:37:01 INFO | 1-plant.py:Plant.test_plant_organic: throwing seeds on row 1
+    10:37:01 INFO | 1-plant.py:Plant.test_plant_organic: throwing seeds on row 2
+    10:37:01 INFO | 1-plant.py:Plant.test_plant_organic: waiting for Avocados to grow
+    10:37:06 INFO | 1-plant.py:Plant.test_plant_organic: harvesting organic avocados on row 0
+    10:37:06 INFO | 1-plant.py:Plant.test_plant_organic: harvesting organic avocados on row 1
+    10:37:06 INFO | 1-plant.py:Plant.test_plant_organic: harvesting organic avocados on row 2
 
 The very same ``progress`` logger, could be used across multiple test methods
-and across multiple test modules.  In the example given, the tagged test name
-is used to give extra context.
+and across multiple test modules.  In the example given, the test name is used
+to give extra context.
 
 :class:`unittest.TestCase` heritage
 ===================================

--- a/selftests/unit/test_multiplexer.py
+++ b/selftests/unit/test_multiplexer.py
@@ -88,11 +88,11 @@ class TestAvocadoParams(unittest.TestCase):
         yamls = multiplexer.yaml2tree(["/:" + PATH_PREFIX +
                                        'examples/mux-selftest-params.yaml'])
         self.yamls = iter(multiplexer.MuxTree(yamls))
-        self.params1 = multiplexer.AvocadoParams(self.yamls.next(), 'Unittest1', 1,
+        self.params1 = multiplexer.AvocadoParams(self.yamls.next(), 'Unittest1',
                                                  ['/ch0/*', '/ch1/*'], {})
         self.yamls.next()    # Skip 2nd
         self.yamls.next()    # and 3rd
-        self.params2 = multiplexer.AvocadoParams(self.yamls.next(), 'Unittest2', 1,
+        self.params2 = multiplexer.AvocadoParams(self.yamls.next(), 'Unittest2',
                                                  ['/ch1/*', '/ch0/*'], {})
 
     @unittest.skipIf(not tree.MULTIPLEX_CAPABLE, "Not multiplex capable")
@@ -107,7 +107,7 @@ class TestAvocadoParams(unittest.TestCase):
         self.assertNotEqual(self.params1, self.params2)
         repr(self.params1)
         str(self.params1)
-        str(multiplexer.AvocadoParams([], 'Unittest', None, [], {}))
+        str(multiplexer.AvocadoParams([], 'Unittest', [], {}))
         self.assertEqual(15, sum([1 for _ in self.params1.iteritems()]))
 
     @unittest.skipIf(not tree.MULTIPLEX_CAPABLE, "Not multiplex capable")

--- a/selftests/unit/test_test.py
+++ b/selftests/unit/test_test.py
@@ -127,9 +127,6 @@ class TestClassTest(unittest.TestCase):
     def testClassAttributesTimeElapsed(self):
         self.assertIsInstance(self.tst_instance_pass.time_elapsed, float)
 
-    def testClassAttributesTag(self):
-        self.assertEqual(self.tst_instance_pass.tag, None)
-
     def testWhiteboardSave(self):
         whiteboard_file = os.path.join(
             self.tst_instance_pass.logdir, 'whiteboard')
@@ -146,6 +143,10 @@ class TestClassTest(unittest.TestCase):
 
         self.assertRaises(exceptions.TestSetupFail, AvocadoPass,
                           base_logdir=self.base_logdir)
+
+    def testNotTestName(self):
+        self.assertRaises(test.NameNotTestNameError,
+                          test.Test, name='mytest')
 
     def tearDown(self):
         shutil.rmtree(self.base_logdir)


### PR DESCRIPTION
When the support for Test IDs was introduced, support for string based
test names and tags was kept in deprecated mode, scheduled to be
removed on an upcoming release.

This planned upcoming release for removal has already passed, so let's
remove them now.

--

Changes from v1 (#1303):
 * Updated docs