### PR TITLE
Revert "Improve documentation index"

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,11 +1,11 @@
-Avocado Testing Framework
-=========================
+====================
+Avocado User's Guide
+====================
 
-.. _users-guide:
+Contents:
 
 .. toctree::
    :maxdepth: 2
-   :caption: Avocado User's Guide
 
    Introduction
    GetStartedGuide
@@ -21,36 +21,38 @@ Avocado Testing Framework
    WrapProcess
    Plugins
 
-
-.. _adv-topics:
+===============================
+Advanced Topics and Maintenance
+===============================
 
 .. toctree::
    :maxdepth: 2
-   :caption: Advanced Topics and Maintenance
 
    ReferenceGuide
    ContributionGuide
    DevelopmentTips
    MaintenanceGuide
 
+.. _api-reference:
 
-.. _api-ref:
+=============
+API Reference
+=============
 
 .. toctree::
    :maxdepth: 1
-   :caption: API Reference
 
    api/test/avocado.rst
    api/utils/avocado.utils.rst
    api/core/avocado.core.rst
    api/plugins/avocado.plugins.rst
 
-
-.. _rel-notes:
+=====================
+Avocado Release Notes
+=====================
 
 .. toctree::
    :maxdepth: 1
-   :caption: Avocado Release Notes
 
    release_notes/index
 

--- a/requirements-selftests.txt
+++ b/requirements-selftests.txt
@@ -2,7 +2,7 @@
 # Setuptools
 setuptools>=18.0.0
 # sphinx (doc build test)
-Sphinx>=1.3
+Sphinx>=1.3b1
 # flexmock (some unittests use it)
 flexmock>=0.9.7
 # inspektor (static and style checks)

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -2,7 +2,7 @@
 fabric==1.11.1
 pystache==0.4.1; python_version < '2.7'
 pystache==0.5.4; python_version >= '2.7'
-Sphinx>=1.3
+Sphinx==1.3b1
 flexmock==0.9.7
 inspektor==0.2.0
 pep8==1.6.2


### PR DESCRIPTION
This reverts commit 00e9aa461983d5f10c9bd42fa8874aa73b40fc5d.

python-sphinx 1.3 is not available for fedora 23 so the rpm build is doomed to fail with this patch. Let's revert this change and reconsider it when required python-sphinx version is available.