### PR TITLE
Include Fedora 24 screen terminal

### DIFF
--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -83,7 +83,7 @@ class TermSupport(object):
         self.LOWLIGHT = self.COLOR_DARKGREY
         self.enabled = True
         allowed_terms = ['linux', 'xterm', 'xterm-256color', 'vt100', 'screen',
-                         'screen-256color']
+                         'screen-256color', 'screen.xterm-256color']
         term = os.environ.get("TERM")
         colored = settings.get_value('runner.output', 'colored',
                                      key_type='bool')


### PR DESCRIPTION
Fedora 24 using screen has TERM=screen.xterm-256color. This patch adds
that terminal option in the list of valid options to be colorized.

Signed-off-by: Amador Pahim <apahim@redhat.com>