### PR TITLE
Use python from env instead of absolute pyton path

### DIFF
--- a/selftests/checkall
+++ b/selftests/checkall
@@ -19,6 +19,6 @@ if [ -z "$AVOCADO_SELF_CHECK" ]; then
     run_rc selftests/run
 else
     run_rc 'python setup.py develop --user'
-    run_rc 'scripts/avocado run `./contrib/scripts/avocado-find-unittests selftests/{unit,functional,doc}/*.py | xargs` --external-runner="/usr/bin/python -m unittest"'
+    run_rc 'scripts/avocado run `./contrib/scripts/avocado-find-unittests selftests/{unit,functional,doc}/*.py | xargs` --external-runner="/usr/bin/env python -m unittest"'
 fi
 exit ${GR}


### PR DESCRIPTION
This allows `AVOCADO_SELF_CHECK=1 ./selftests/checkall` to run
inside virtualenv environemnts.

Signed-off-by: Amador Pahim <apahim@redhat.com>