### PR TITLE
Wrappers: add support for rr

### DIFF
--- a/examples/wrappers/rr.sh
+++ b/examples/wrappers/rr.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# Record deterministic execution using rr
+#
+
+export _RR_TRACE_DIR=$AVOCADO_TEST_LOGDIR/rr
+mkdir -p $_RR_TRACE_DIR
+exec rr record "$@"
+


### PR DESCRIPTION
This example wrapper script runs binaries inside rr (record), which
saves the execution environment, allowing to deterministically debug
possible failures later.

The usage instructions to run tests with this wrapper are no different
than other wrappers.  The effect of the wrapper, though, deserves notice:
it creates an "rr" directory inside the test results, which rr uses
to save its data files.

Replays should be executed like this:

 $ rr replay <job-results>/test-results/<test>/rr/<binary-number>

Where <binary-number> is the "Nth" execution of "binary" by your
test.

Signed-off-by: Cleber Rosa <crosa@redhat.com>