### PR TITLE
Asset improvements v5

### DIFF
--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -20,13 +20,17 @@ import errno
 import logging
 import os
 import re
+import shutil
 import stat
+import sys
 import time
+import tempfile
 import urlparse
 
 from . import crypto
 from . import path as utils_path
 from .download import url_download
+from .filelock import FileLock
 
 
 log = logging.getLogger('avocado.test')
@@ -40,8 +44,7 @@ class Asset(object):
     def __init__(self, name, asset_hash, algorithm, locations, cache_dirs,
                  expire):
         """
-        Initialize the Asset() and fetches the asset file. The path for
-        the fetched file can be reached using the self.path attribute.
+        Initialize the Asset() class.
 
         :param name: the asset filename. url is also supported
         :param asset_hash: asset hash
@@ -52,7 +55,10 @@ class Asset(object):
         """
         self.name = name
         self.asset_hash = asset_hash
-        self.algorithm = algorithm
+        if algorithm is None:
+            self.algorithm = 'sha1'
+        else:
+            self.algorithm = algorithm
         self.locations = locations
         self.cache_dirs = cache_dirs
         self.nameobj = urlparse.urlparse(self.name)
@@ -60,6 +66,13 @@ class Asset(object):
         self.expire = expire
 
     def fetch(self):
+        """
+        Fetches the asset. First tries to find the asset on the provided
+        cache_dirs list. Then tries to download the asset from the locations
+        list provided.
+
+        :returns: The path for the file on the cache directory.
+        """
         urls = []
 
         # If name is actually an url, it has to be included in urls list
@@ -70,128 +83,128 @@ class Asset(object):
         for cache_dir in self.cache_dirs:
             cache_dir = os.path.expanduser(cache_dir)
             self.asset_file = os.path.join(cache_dir, self.basename)
-            if (self._check_file(self.asset_file,
-               self.asset_hash, self.algorithm) and not
-               self._is_expired(self.asset_file, self.expire)):
-                return self.asset_file
+            self.hashfile = '%s-CHECKSUM' % self.asset_file
 
-        # If we get to this point, file is not in any cache directory
-        # and we have to download it from a location. A rw cache
-        # directory is then needed. The first rw cache directory will be
-        # used.
-        log.debug("Looking for a writable cache dir.")
+            # To use a cached file, it must:
+            # - Exists.
+            # - Be valid (not expired).
+            # - Be verified (hash check).
+            if (os.path.isfile(self.asset_file) and
+               not self._is_expired(self.asset_file, self.expire)):
+                try:
+                    with FileLock(self.asset_file, 1):
+                        if self._verify():
+                            return self.asset_file
+                except:
+                    exc_type, exc_value = sys.exc_info()[:2]
+                    log.error('%s: %s' % (exc_type.__name__, exc_value))
+
+        # If we get to this point, we have to download it from a location.
+        # A writable cache directory is then needed. The first available
+        # writable cache directory will be used.
         for cache_dir in self.cache_dirs:
             cache_dir = os.path.expanduser(cache_dir)
             self.asset_file = os.path.join(cache_dir, self.basename)
             if not utils_path.usable_rw_dir(cache_dir):
-                log.debug("Read-only cache dir '%s'. Skiping." %
-                          cache_dir)
                 continue
-            log.debug("Using %s as cache dir." % cache_dir)
 
-            # Adding the user defined locations to the urls list
+            # Now we have a writable cache_dir. Let's get the asset.
+            # Adding the user defined locations to the urls list:
             if self.locations is not None:
                 for item in self.locations:
                     urls.append(item)
 
             for url in urls:
                 urlobj = urlparse.urlparse(url)
-                if urlobj.scheme == 'http' or urlobj.scheme == 'https':
-                    log.debug('Downloading from %s.' % url)
+                if urlobj.scheme in ['http', 'https', 'ftp']:
                     try:
-                        url_download(url, self.asset_file)
-                    except Exception as e:
-                        log.error(e)
-                        continue
-                    if self._check_file(self.asset_file, self.asset_hash,
-                                        self.algorithm):
-                        return self.asset_file
-
-                elif urlobj.scheme == 'ftp':
-                    log.debug('Downloading from %s.' % url)
-                    try:
-                        url_download(url, self.asset_file)
-                    except Exception as e:
-                        log.error(e)
-                        continue
-                    if self._check_file(self.asset_file, self.asset_hash,
-                                        self.algorithm):
-                        return self.asset_file
+                        if self._download(url):
+                            return self.asset_file
+                    except:
+                        exc_type, exc_value = sys.exc_info()[:2]
+                        log.error('%s: %s' % (exc_type.__name__, exc_value))
 
                 elif urlobj.scheme == 'file':
+                    # Being flexible with the urlparse result
                     if os.path.isdir(urlobj.path):
                         path = os.path.join(urlobj.path, self.name)
                     else:
                         path = urlobj.path
-                    log.debug('Looking for file on %s.' % path)
-                    if self._check_file(path):
-                        try:
-                            os.symlink(path, self.asset_file)
-                        except OSError as e:
-                            if e.errno == errno.EEXIST:
-                                os.remove(self.asset_file)
-                                os.symlink(path, self.asset_file)
-                        log.debug('Symlink created %s -> %s.' %
-                                  (self.asset_file, path))
 
-                    else:
-                        continue
-                    if self._check_file(self.asset_file, self.asset_hash,
-                                        self.algorithm):
-                        return self.asset_file
+                    try:
+                        if self._get_local_file(path):
+                            return self.asset_file
+                    except:
+                        exc_type, exc_value = sys.exc_info()[:2]
+                        log.error('%s: %s' % (exc_type.__name__, exc_value))
 
-            raise EnvironmentError("Failed to fetch %s." % self.basename)
-        raise EnvironmentError("Can't find a writable cache dir.")
+            # Despite our effort, we could not provide a healthy file. Sorry.
+            log.error("Failed to fetch %s." % self.basename)
+            return None
 
-    @staticmethod
-    def _check_file(path, filehash=None, algorithm=None):
-        """
-        Checks if file exists and verifies the hash, when the hash is
-        provided. We try first to find a hash file to verify the hash
-        against and only if the hash file is not present we compute the
-        hash.
-        """
-        if not os.path.isfile(path):
-            log.debug('Asset %s not found.' % path)
-            return False
+        # Cannot find a writable cache_dir. Bye.
+        log.error("Can't find a writable cache dir.")
+        return None
 
-        if filehash is None:
+    def _download(self, url):
+        try:
+            # Temporary unique name to use while downloading
+            temp = '%s.%s' % (self.asset_file,
+                              next(tempfile._get_candidate_names()))
+            url_download(url, temp)
+
+            # Acquire lock only after download the file
+            with FileLock(self.asset_file, 1):
+                shutil.copy(temp, self.asset_file)
+                self._compute_hash()
+                return self._verify()
+        finally:
+            os.remove(temp)
+
+    def _compute_hash(self):
+        result = crypto.hash_file(self.asset_file, algorithm=self.algorithm)
+        basename = os.path.basename(self.asset_file)
+        with open(self.hashfile, 'w') as f:
+            f.write('%s %s\n' % (self.algorithm, result))
+
+    def _get_hash_from_file(self):
+        discovered = None
+        if not os.path.isfile(self.hashfile):
+            self._compute_hash()
+
+        with open(self.hashfile, 'r') as f:
+            for line in f.readlines():
+                # md5 is 32 chars big and sha512 is 128 chars big.
+                # others supported algorithms are between those.
+                pattern = '%s [a-f0-9]{32,128}' % self.algorithm
+                if re.match(pattern, line):
+                    discovered = line.split()[1]
+                    break
+        return discovered
+
+    def _verify(self):
+        if not self.asset_hash:
             return True
-
-        basename = os.path.basename(path)
-        discovered_hash = None
-        # Try to find a hashfile for the asset file
-        hashfile = '%s.%s' % (path, algorithm)
-        if os.path.isfile(hashfile):
-            with open(hashfile, 'r') as f:
-                for line in f.readlines():
-                    # md5 is 32 chars big and sha512 is 128 chars big.
-                    # others supported algorithms are between those.
-                    pattern = '[a-f0-9]{32,128} %s' % basename
-                    if re.match(pattern, line):
-                        log.debug('Hashfile found for %s.' % path)
-                        discovered_hash = line.split()[0]
-                        break
-
-        # If no hashfile, lets calculate the hash by ourselves
-        if discovered_hash is None:
-            log.debug('No hashfile found for %s. Computing hash.' %
-                      path)
-            discovered_hash = crypto.hash_file(path, algorithm=algorithm)
-
-            # Creating the hashfile for further usage.
-            log.debug('Creating hashfile %s.' % hashfile)
-            with open(hashfile, 'w') as f:
-                content = '%s %s\n' % (discovered_hash, basename)
-                f.write(content)
-
-        if filehash == discovered_hash:
-            log.debug('Asset %s verified.' % path)
+        if self._get_hash_from_file() == self.asset_hash:
             return True
         else:
-            log.error('Asset %s corrupted (hash expected:%s, hash found:%s).' %
-                      (path, filehash, discovered_hash))
             return False
+
+    def _get_local_file(self, path):
+        try:
+            with FileLock(self.asset_file, 1):
+                try:
+                    os.symlink(path, self.asset_file)
+                    self._compute_hash()
+                    return self._verify()
+                except OSError as e:
+                    if e.errno == errno.EEXIST:
+                        os.remove(self.asset_file)
+                        os.symlink(path, self.asset_file)
+                        self._compute_hash()
+                        return self._verify()
+        except:
+            raise
 
     @staticmethod
     def _is_expired(path, expire):

--- a/avocado/utils/filelock.py
+++ b/avocado/utils/filelock.py
@@ -1,0 +1,115 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2016
+# Author: Amador Pahim <apahim@redhat.com>
+
+"""
+Utility for individual file access control implemented
+via PID lock files.
+"""
+
+import os
+import time
+
+from .process import pid_exists
+
+
+class AlreadyLocked(Exception):
+    pass
+
+
+class LockFailed(Exception):
+    pass
+
+
+class FileLock(object):
+
+    """
+    Creates an exclusive advisory lock for a file.
+    All processes should would use and honour the advisory
+    locking scheme, but uncooperative processes are free to
+    ignore the lock and access the file in any way they choose.
+    """
+
+    def __init__(self, filename, timeout=0):
+        self.filename = '%s.lock' % filename
+        self.pid = str(os.getpid())
+        self.locked = False
+        self.timeout = timeout
+
+    def __enter__(self):
+        flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY | os.O_SYNC
+        timelimit = time.time() + self.timeout
+        while True:
+            try:
+                fd = os.open(self.filename, flags)
+                os.write(fd, self.pid)
+                os.close(fd)
+                self.locked = True
+                return self
+            except:
+                try:
+                    # Read the file to realize what's happening.
+                    with open(self.filename, 'r') as f:
+                        try:
+                            content = f.read()
+                        except Exception as e:
+                            raise LockFailed(e.message)
+
+                    # If file is empty, I guess someone created it with 'touch'
+                    # to manually lock the file.
+                    if not content:
+                        raise AlreadyLocked('File is locked by someone else.')
+
+                    try:
+                        existing_lock_pid = int(content)
+                    except ValueError:
+                        # If the file content is not an integer, then I don't know
+                        # who created it and we better get out of here.
+                        raise AlreadyLocked('File is locked by someone else.')
+
+                    # If the PID in the lock file is not my PID, let's
+                    # handle it.
+                    if existing_lock_pid != self.pid:
+                        # If there's no process with the PID in lockfile,
+                        # let's try to remove the lockfile to acquire the
+                        # lock in the next iteration.
+                        if not pid_exists(existing_lock_pid):
+                            try:
+                                os.remove(self.filename)
+                                continue
+                            except:
+                                raise LockFailed('Not able to lock.')
+
+                except:
+                    # If we cannot read the lock file, let's just
+                    # go on. Maybe in next iteration (if we have time)
+                    # we have a better luck.
+                    pass
+
+                # If we get to this point, the lock file is there, it belongs
+                # to a running process and we are just waiting for the lock
+                # to be released.
+                if self.timeout <= 0:
+                    raise AlreadyLocked('File is already locked.')
+                elif time.time() > timelimit:
+                    raise AlreadyLocked('Timeout waiting for the lock.')
+                else:
+                    time.sleep(0.1)
+
+    def __exit__(self, *args):
+        if self.locked:
+            try:
+                os.remove(self.filename)
+                self.locked = False
+            except:
+                pass

--- a/selftests/unit/test_utils_filelock.py
+++ b/selftests/unit/test_utils_filelock.py
@@ -1,0 +1,40 @@
+import os
+import shutil
+import tempfile
+import unittest
+
+from avocado.utils.filelock import AlreadyLocked
+from avocado.utils.filelock import FileLock
+
+
+class TestFileLock(unittest.TestCase):
+
+    def setUp(self):
+        self.basedir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        self.filename = os.path.join(self.basedir, 'file.img')
+        self.content = 'Foo bar'
+        with open(self.filename, 'w') as f:
+            f.write(self.content)
+
+    def _readfile(self):
+        with FileLock(self.filename):
+            with open(self.filename, 'r') as f:
+                return f.read()
+
+    def test_readfile(self):
+        self.assertEqual(self._readfile(), self.content)
+
+    def test_locked_by_me(self):
+        with FileLock(self.filename):
+            self.assertRaises(AlreadyLocked, self._readfile)
+
+    def test_locked_by_other(self):
+        with open(self.filename+'.lock', 'w') as f:
+            f.write('1')
+        self.assertRaises(AlreadyLocked, self._readfile)
+
+    def tearDown(self):
+        shutil.rmtree(self.basedir)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/spell.ignore
+++ b/spell.ignore
@@ -394,3 +394,4 @@ remoter's
 isinstance
 dkrcmd
 flexmock
+lockfile

--- a/spell.ignore
+++ b/spell.ignore
@@ -395,3 +395,4 @@ isinstance
 dkrcmd
 flexmock
 lockfile
+urlparse


### PR DESCRIPTION
v5:
 - Avoid race condition in the filelocker.
 - Return filelocker instance to allow the syntax `with FileLock(filename) as f:`.
 - Improve filelocker docstring.
 - Use `O_SYNC` to avoid race conditions in file creation/write.

v4: #1325 
 - `FileLock` as a context manager.
 - Proper exception message when no timeout is set.
 - Use `utils.process.pid_exists()` instead of redundant code.
 - Improve tests.
 - Minor style improvements.

v3: #1309 
 - Make lock timeout configurable and set it to `1s` in asset fetcher.

v2: #1304 
-  Introduce the file locker utility.
-  Asset fetcher improvements:
 - Use the avocado.utils.filelock to avoid race conditions:
 - Drop EnviromentError exceptions on cache miss.
 - Clean excessive debug messages.
 - Unify hashfile for any algorithm.
 - Improve hashfile control.

v1: #1299 
Preliminary work, intended to collect feedback. No need to look there ;)

Reference: https://trello.com/c/NeFPMkZY
Reference: https://trello.com/c/OWCprQpd