### PR TITLE
avocado/utils/kernel.py: fix the use of the asset library

### DIFF
--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -50,8 +50,8 @@ class Asset(object):
         :param asset_hash: asset hash
         :param algorithm: hash algorithm
         :param locations: list of locations fetch asset from
-        :params cache_dirs: list of cache directories
-        :params expire: time in seconds for the asset to expire
+        :param cache_dirs: list of cache directories
+        :param expire: time in seconds for the asset to expire
         """
         self.name = name
         self.asset_hash = asset_hash

--- a/avocado/utils/kernel.py
+++ b/avocado/utils/kernel.py
@@ -72,7 +72,8 @@ class KernelBuild(object):
         full_url = self.URL + self.SOURCE.format(version=self.version)
         self.asset_path = asset.Asset(full_url, asset_hash=None,
                                       algorithm=None, locations=None,
-                                      cache_dirs=self.data_dirs).fetch()
+                                      cache_dirs=[self.work_dir], expire=0).fetch()
+
 
     def uncompress(self):
         """


### PR DESCRIPTION
And the docstring of the asset library itself.

Signed-off-by: Cleber Rosa <crosa@redhat.com>