### PR TITLE
avocado/plugins/journal.py: make the goal of this plugin more clear

### DIFF
--- a/avocado/plugins/journal.py
+++ b/avocado/plugins/journal.py
@@ -126,8 +126,11 @@ class Journal(CLI):
             return
 
         self.parser = parser
-        run_subcommand_parser.output.add_argument('--journal', action='store_true',
-                                                  help='Records test status changes')
+        help_msg = ('Records test status changes (for use with '
+                    'avocado-journal-replay and avocado-server)')
+        run_subcommand_parser.output.add_argument('--journal',
+                                                  action='store_true',
+                                                  help=help_msg)
 
     def run(self, args):
         if 'journal' in args and args.journal is True:


### PR DESCRIPTION
We found some users of this plugin, and we're unsure they actually use
this as intended.  Even if they don't use it as intended, it may be a
good thing, *but* we should make it clear what was the original goal
of this feature.

Signed-off-by: Cleber Rosa <crosa@redhat.com>