### PR TITLE
Revert `kernel.py` commit and use different approach to fix the issue

### DIFF
--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -42,7 +42,7 @@ class Asset(object):
     """
 
     def __init__(self, name, asset_hash, algorithm, locations, cache_dirs,
-                 expire):
+                 expire=None):
         """
         Initialize the Asset() class.
 

--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -50,8 +50,8 @@ class Asset(object):
         :param asset_hash: asset hash
         :param algorithm: hash algorithm
         :param locations: list of locations fetch asset from
-        :params cache_dirs: list of cache directories
-        :params expire: time in seconds for the asset to expire
+        :param cache_dirs: list of cache directories
+        :param expire: time in seconds for the asset to expire
         """
         self.name = name
         self.asset_hash = asset_hash

--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -50,8 +50,8 @@ class Asset(object):
         :param asset_hash: asset hash
         :param algorithm: hash algorithm
         :param locations: list of locations fetch asset from
-        :param cache_dirs: list of cache directories
-        :param expire: time in seconds for the asset to expire
+        :params cache_dirs: list of cache directories
+        :params expire: time in seconds for the asset to expire
         """
         self.name = name
         self.asset_hash = asset_hash

--- a/avocado/utils/kernel.py
+++ b/avocado/utils/kernel.py
@@ -72,8 +72,7 @@ class KernelBuild(object):
         full_url = self.URL + self.SOURCE.format(version=self.version)
         self.asset_path = asset.Asset(full_url, asset_hash=None,
                                       algorithm=None, locations=None,
-                                      cache_dirs=[self.work_dir],
-                                      expire=None).fetch()
+                                      cache_dirs=self.data_dirs).fetch()
 
     def uncompress(self):
         """


### PR DESCRIPTION
The `kernel.py` fix breaks the `data_dirs` feature. Let's revert that commit and instead of fixing the `kernel` utility, make the `expire` argument optional while keeping the default behavior. This should suit all existing code depending on `asset` to work without the need to adjust it.