### PR TITLE
Add 'failfast' support in 'replay'

### DIFF
--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -136,14 +136,15 @@ class Replay(CLI):
         whitelist = ['loaders',
                      'external_runner',
                      'external_runner_testdir',
-                     'external_runner_chdir']
+                     'external_runner_chdir',
+                     'failfast']
         if replay_args is None:
             log.warn('Source job args data not found. These options will not '
                      'be loaded in this replay job: %s', ', '.join(whitelist))
         else:
             for option in whitelist:
                 optvalue = getattr(args, option, None)
-                if optvalue:
+                if optvalue is not None:
                     log.warn("Overriding the replay %s with the --%s value "
                              "given on the command line.",
                              option.replace('_', '-'),

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -77,7 +77,10 @@ class Run(CLICmd):
                                   'You can also use suffixes, like: '
                                   ' s (seconds), m (minutes), h (hours). '))
 
-        parser.add_argument('--failfast', action='store_true',
+        parser.add_argument('--failfast',
+                            nargs='?',
+                            const=True,
+                            type=self._failfast,
                             help='Interrupt job on first failed test.')
 
         sysinfo_default = settings.get_value('sysinfo.collect',
@@ -149,6 +152,15 @@ class Run(CLICmd):
             mux.add_argument('--mux-inject', default=[], nargs='*',
                              help="Inject [path:]key:node values into the "
                              "final multiplex tree.")
+
+    def _failfast(self, string):
+        if string == 'off':
+            return False
+        elif string == 'on':
+            return True
+        msg = ('Invalid --failfast option. Valid '
+               'options are: on, off (Defaults to on)')
+        raise argparse.ArgumentTypeError(msg)
 
     def _activate(self, args):
         # Extend default multiplex tree of --mux_inject values

--- a/docs/source/Replay.rst
+++ b/docs/source/Replay.rst
@@ -171,6 +171,9 @@ result, using the option ``--replay-test-status``. See the example below::
     JOB HTML   : $HOME/avocado/job-results/job-2016-01-12T00.38-2e1dc41/html/results.html
     TESTS TIME : 0.19 s
 
+When replaying jobs that were executed with the ``--failfast`` option, you can
+disable the ``failfast`` option using ``--failfast off`` in the replay job.
+
 To be able to replay a job, avocado records the job data in the same
 job results directory, inside a subdirectory named ``replay``. If a
 given job has a non-default path to record the logs, when the replay

--- a/selftests/functional/test_replay_failfast.py
+++ b/selftests/functional/test_replay_failfast.py
@@ -13,25 +13,20 @@ else:
 
 from avocado.core import exit_codes
 from avocado.utils import process
-from avocado.utils import script
 
 
 basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..')
 basedir = os.path.abspath(basedir)
 
 
-class ReplayExtRunnerTests(unittest.TestCase):
+class ReplayFailfastTests(unittest.TestCase):
 
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
-        test = script.make_script(os.path.join(self.tmpdir, 'test'), 'exit 0')
-        cmd_line = ('./scripts/avocado run %s '
-                    '--multiplex '
-                    'examples/tests/sleeptest.py.data/sleeptest.yaml '
-                    '--external-runner /bin/bash '
-                    '--job-results-dir %s --sysinfo=off --json -' %
-                    (test, self.tmpdir))
-        expected_rc = exit_codes.AVOCADO_ALL_OK
+        cmd_line = ('./scripts/avocado run passtest.py failtest.py passtest.py '
+                    '--failfast --job-results-dir %s --sysinfo=off --json -' %
+                    self.tmpdir)
+        expected_rc = exit_codes.AVOCADO_TESTS_FAIL | exit_codes.AVOCADO_JOB_INTERRUPTED
         self.run_and_check(cmd_line, expected_rc)
         self.jobdir = ''.join(glob.glob(os.path.join(self.tmpdir, 'job-*')))
         idfile = ''.join(os.path.join(self.jobdir, 'id'))
@@ -46,15 +41,20 @@ class ReplayExtRunnerTests(unittest.TestCase):
                          "%d:\n%s" % (cmd_line, expected_rc, result))
         return result
 
-    def test_run_replay_external_runner(self):
+    def test_run_replay_failfast(self):
         cmd_line = ('./scripts/avocado run --replay %s '
-                    '--external-runner /bin/sh '
-                    '--job-results-dir %s --replay-data-dir %s --sysinfo=off' %
-                    (self.jobid, self.tmpdir, self.jobdir))
-        expected_rc = exit_codes.AVOCADO_ALL_OK
+                    '--job-results-dir %s --replay-data-dir %s --sysinfo=off'
+                    % (self.jobid, self.tmpdir, self.jobdir))
+        expected_rc = exit_codes.AVOCADO_TESTS_FAIL | exit_codes.AVOCADO_JOB_INTERRUPTED
         result = self.run_and_check(cmd_line, expected_rc)
-        msg = "Overriding the replay external-runner with the "\
-              "--external-runner value given on the command line."
+
+    def test_run_replay_disable_failfast(self):
+        cmd_line = ('./scripts/avocado run --replay %s --failfast off '
+                    '--job-results-dir %s --replay-data-dir %s --sysinfo=off'
+                    % (self.jobid, self.tmpdir, self.jobdir))
+        expected_rc = exit_codes.AVOCADO_TESTS_FAIL
+        result = self.run_and_check(cmd_line, expected_rc)
+        msg = 'Overriding the replay failfast with the --failfast value given on the command line.'
         self.assertIn(msg, result.stderr)
 
     def tearDown(self):


### PR DESCRIPTION
Now replay jobs will respect the original job failfast option, when used. Also,
it is possible to disable failfast option on replay jobs with `--failfast off`.

Signed-off-by: Amador Pahim <apahim@redhat.com>