### PR TITLE
aexpect: add it to source and package installation requirements

### DIFF
--- a/avocado.spec
+++ b/avocado.spec
@@ -7,13 +7,13 @@
 Summary: Avocado Test Framework
 Name: avocado
 Version: 39.0
-Release: 0%{?dist}
+Release: 1%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.github.io/
 Source0: https://github.com/avocado-framework/%{name}/archive/%{commit}/%{name}-%{version}-%{shortcommit}.tar.gz
 BuildArch: noarch
-Requires: python, python-requests, fabric, pyliblzma, libvirt-python, pystache, gdb, gdb-gdbserver, python-stevedore
+Requires: python, python-requests, fabric, pyliblzma, libvirt-python, pystache, gdb, gdb-gdbserver, python-stevedore, aexpect
 BuildRequires: python2-devel, python-setuptools, python-docutils, python-mock, python-psutil, python-sphinx, python-requests, aexpect, pystache, yum, python-stevedore, python-lxml
 
 %if 0%{?el6}
@@ -113,6 +113,9 @@ examples of how to write tests on your own.
 %{_datadir}/avocado/wrappers
 
 %changelog
+* Tue Aug  2 2016 Cleber Rosa <cleber@redhat.com> - 39.0-1
+- Added expect requirement (for Docker plugin)
+
 * Tue Jul 26 2016 Cleber Rosa <cleber@redhat.com> - 39.0-0
 - New upstream release
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,5 @@ argparse>=1.3.0; python_version < '2.7'
 logutils>=0.3.3; python_version < '2.7'
 importlib>=1.0.3; python_version < '2.7'
 unittest2>=1.0.0; python_version < '2.7'
+# Aexpect is now used on Docker plugin
+aexpect>=1.2.0


### PR DESCRIPTION
The aexpect module is used by the Docker plugin.  Since we do not
package those separately, let's add it as a global Avocado dependency.

Signed-off-by: Cleber Rosa <crosa@redhat.com>