### PR TITLE
avocado.utils.asset raise exception when not able to fetch asset

### DIFF
--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -138,13 +138,8 @@ class Asset(object):
                         exc_type, exc_value = sys.exc_info()[:2]
                         log.error('%s: %s' % (exc_type.__name__, exc_value))
 
-            # Despite our effort, we could not provide a healthy file. Sorry.
-            log.error("Failed to fetch %s." % self.basename)
-            return None
-
-        # Cannot find a writable cache_dir. Bye.
-        log.error("Can't find a writable cache dir.")
-        return None
+            raise EnvironmentError("Failed to fetch %s." % self.basename)
+        raise EnvironmentError("Can't find a writable cache directory.")
 
     def _download(self, url):
         try:

--- a/selftests/unit/test_utils_asset.py
+++ b/selftests/unit/test_utils_asset.py
@@ -81,32 +81,21 @@ class TestAsset(unittest.TestCase):
             content2 = f.read()
         self.assertNotEqual(content1, content2)
 
-    def testFetch_error(self):
-        foo_tarball = asset.Asset('bar.tgz',
-                                  asset_hash=self.assethash,
-                                  algorithm='sha1',
-                                  locations=None,
-                                  cache_dirs=[self.cache_dir],
-                                  expire=None).fetch()
-        self.assertEqual(foo_tarball, None)
+    def testException(self):
+        a = asset.Asset(name='bar.tgz', asset_hash=None, algorithm=None,
+                        locations=None, cache_dirs=[self.cache_dir],
+                        expire=None)
+        self.assertRaises(EnvironmentError, a.fetch)
 
     def testFetch_lockerror(self):
         with FileLock(os.path.join(self.cache_dir, self.assetname)):
-            foo_tarball = asset.Asset(self.url,
-                                      asset_hash=self.assethash,
-                                      algorithm='sha1',
-                                      locations=None,
-                                      cache_dirs=[self.cache_dir],
-                                      expire=None).fetch()
-            self.assertEqual(foo_tarball, None)
-
-        foo_tarball = asset.Asset(self.url,
-                                  asset_hash=self.assethash,
-                                  algorithm='sha1',
-                                  locations=None,
-                                  cache_dirs=[self.cache_dir],
-                                  expire=None).fetch()
-        self.assertNotEqual(foo_tarball, None)
+            a = asset.Asset(self.url,
+                            asset_hash=self.assethash,
+                            algorithm='sha1',
+                            locations=None,
+                            cache_dirs=[self.cache_dir],
+                            expire=None)
+            self.assertRaises(EnvironmentError, a.fetch)
 
     def tearDown(self):
         shutil.rmtree(self.basedir)


### PR DESCRIPTION
Currently asset fetcher returns path to the asset file or None
when it fails to fetch it. This patch makes it o raise an exception
in such cases.

Reference: https://trello.com/c/CXhCbFAr
Signed-off-by: Amador Pahim <apahim@redhat.com>