### PR TITLE
Add failfast support for replay [v2]

### DIFF
--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -445,7 +445,7 @@ class TestRunner(object):
         elif not mapping[test_state['status']]:
             summary.add("FAIL")
 
-            if getattr(self.job.args, 'failfast', False):
+            if getattr(self.job.args, 'failfast', 'off') == 'on':
                 summary.add("INTERRUPTED")
                 self.job.log.debug("Interrupting job (failfast).")
                 return False

--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -136,14 +136,15 @@ class Replay(CLI):
         whitelist = ['loaders',
                      'external_runner',
                      'external_runner_testdir',
-                     'external_runner_chdir']
+                     'external_runner_chdir',
+                     'failfast']
         if replay_args is None:
             log.warn('Source job args data not found. These options will not '
                      'be loaded in this replay job: %s', ', '.join(whitelist))
         else:
             for option in whitelist:
                 optvalue = getattr(args, option, None)
-                if optvalue:
+                if optvalue is not None:
                     log.warn("Overriding the replay %s with the --%s value "
                              "given on the command line.",
                              option.replace('_', '-'),

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -77,8 +77,9 @@ class Run(CLICmd):
                                   'You can also use suffixes, like: '
                                   ' s (seconds), m (minutes), h (hours). '))
 
-        parser.add_argument('--failfast', action='store_true',
-                            help='Interrupt job on first failed test.')
+        parser.add_argument('--failfast', choices=('on', 'off'),
+                            help='Enable or disable the job interruption on '
+                                 'first failed test.')
 
         sysinfo_default = settings.get_value('sysinfo.collect',
                                              'enabled',

--- a/docs/source/GetStartedGuide.rst
+++ b/docs/source/GetStartedGuide.rst
@@ -219,10 +219,10 @@ instrumented and simple tests::
 Interrupting The Job On First Failed Test (failfast)
 ====================================================
 
-The Avocado ``run`` command has the option ``--failfast`` to exit the job on
-first failed test::
+The Avocado ``run`` command has the option ``--failfast on`` to exit the job
+on first failed test::
 
-    $ avocado run --failfast /bin/true /bin/false /bin/true /bin/true
+    $ avocado run --failfast on /bin/true /bin/false /bin/true /bin/true
     JOB ID     : eaf51b8c7d6be966bdf5562c9611b1ec2db3f68a
     JOB LOG    : $HOME/avocado/job-results/job-2016-07-19T09.43-eaf51b8/job.log
     TESTS      : 4
@@ -232,6 +232,10 @@ first failed test::
     RESULTS    : PASS 1 | ERROR 0 | FAIL 1 | SKIP 2 | WARN 0 | INTERRUPT 0
     JOB HTML   : /home/apahim/avocado/job-results/job-2016-07-19T09.43-eaf51b8/html/results.html
     TESTS TIME : 0.02 s
+
+The ``--failfast`` option accepts the argument ``off``. Since it's disabled
+by default, the ``off`` argument only makes sense in replay jobs, when the
+original job was executed with ``--failfast on``.
 
 .. _running-external-runner:
 

--- a/docs/source/Replay.rst
+++ b/docs/source/Replay.rst
@@ -171,6 +171,9 @@ result, using the option ``--replay-test-status``. See the example below::
     JOB HTML   : $HOME/avocado/job-results/job-2016-01-12T00.38-2e1dc41/html/results.html
     TESTS TIME : 0.19 s
 
+When replaying jobs that were executed with the ``--failfast on`` option, you
+can disable the ``failfast`` option using ``--failfast off`` in the replay job.
+
 To be able to replay a job, avocado records the job data in the same
 job results directory, inside a subdirectory named ``replay``. If a
 given job has a non-default path to record the logs, when the replay

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -151,7 +151,8 @@ class RunnerOperationTest(unittest.TestCase):
     def test_runner_failfast(self):
         os.chdir(basedir)
         cmd_line = ('./scripts/avocado run --sysinfo=off --job-results-dir %s '
-                    'passtest.py failtest.py passtest.py --failfast' % self.tmpdir)
+                    'passtest.py failtest.py passtest.py --failfast on' %
+                    self.tmpdir)
         result = process.run(cmd_line, ignore_status=True)
         self.assertIn('Interrupting job (failfast).', result.stdout)
         self.assertIn('PASS 1 | ERROR 0 | FAIL 1 | SKIP 1', result.stdout)

--- a/selftests/functional/test_replay_failfast.py
+++ b/selftests/functional/test_replay_failfast.py
@@ -13,25 +13,20 @@ else:
 
 from avocado.core import exit_codes
 from avocado.utils import process
-from avocado.utils import script
 
 
 basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..')
 basedir = os.path.abspath(basedir)
 
 
-class ReplayExtRunnerTests(unittest.TestCase):
+class ReplayFailfastTests(unittest.TestCase):
 
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
-        test = script.make_script(os.path.join(self.tmpdir, 'test'), 'exit 0')
-        cmd_line = ('./scripts/avocado run %s '
-                    '--multiplex '
-                    'examples/tests/sleeptest.py.data/sleeptest.yaml '
-                    '--external-runner /bin/bash '
-                    '--job-results-dir %s --sysinfo=off --json -' %
-                    (test, self.tmpdir))
-        expected_rc = exit_codes.AVOCADO_ALL_OK
+        cmd_line = ('./scripts/avocado run passtest.py failtest.py passtest.py '
+                    '--failfast on --job-results-dir %s --sysinfo=off --json -'
+                    % self.tmpdir)
+        expected_rc = exit_codes.AVOCADO_TESTS_FAIL | exit_codes.AVOCADO_JOB_INTERRUPTED
         self.run_and_check(cmd_line, expected_rc)
         self.jobdir = ''.join(glob.glob(os.path.join(self.tmpdir, 'job-*')))
         idfile = ''.join(os.path.join(self.jobdir, 'id'))
@@ -46,15 +41,20 @@ class ReplayExtRunnerTests(unittest.TestCase):
                          "%d:\n%s" % (cmd_line, expected_rc, result))
         return result
 
-    def test_run_replay_external_runner(self):
+    def test_run_replay_failfast(self):
         cmd_line = ('./scripts/avocado run --replay %s '
-                    '--external-runner /bin/sh '
-                    '--job-results-dir %s --replay-data-dir %s --sysinfo=off' %
-                    (self.jobid, self.tmpdir, self.jobdir))
-        expected_rc = exit_codes.AVOCADO_ALL_OK
+                    '--job-results-dir %s --replay-data-dir %s --sysinfo=off'
+                    % (self.jobid, self.tmpdir, self.jobdir))
+        expected_rc = exit_codes.AVOCADO_TESTS_FAIL | exit_codes.AVOCADO_JOB_INTERRUPTED
         result = self.run_and_check(cmd_line, expected_rc)
-        msg = "Overriding the replay external-runner with the "\
-              "--external-runner value given on the command line."
+
+    def test_run_replay_disable_failfast(self):
+        cmd_line = ('./scripts/avocado run --replay %s --failfast off '
+                    '--job-results-dir %s --replay-data-dir %s --sysinfo=off'
+                    % (self.jobid, self.tmpdir, self.jobdir))
+        expected_rc = exit_codes.AVOCADO_TESTS_FAIL
+        result = self.run_and_check(cmd_line, expected_rc)
+        msg = 'Overriding the replay failfast with the --failfast value given on the command line.'
         self.assertIn(msg, result.stderr)
 
     def tearDown(self):


### PR DESCRIPTION
v2:
- Turn ``--failfast`` argument mandatory (on|off).

v1: #1345 
Now replay jobs will respect the original job failfast option, when used. Also,
it is possible to disable failfast option on replay jobs with `--failfast off`.