### PR TITLE
Wrappers: add support for rr [v2]

### DIFF
--- a/docs/source/DebuggingWithGDB.rst
+++ b/docs/source/DebuggingWithGDB.rst
@@ -15,6 +15,13 @@ other:
   other types of commands. This requires a test written with that
   approach and API in mind.
 
+.. tip:: Even though this section describes the use of the Avocado GDB
+   features, which allow live debugging of binaries inside Avocado
+   tests, it's also possible to debug some application offline by
+   using tools such as `rr <http://rr-project.org>`_.  Avocado ships
+   with an example wrapper script (to be used with ``--wrapper``) for
+   that purpose.
+
 
 Transparent Execution of Executables
 ------------------------------------

--- a/examples/wrappers/rr.sh
+++ b/examples/wrappers/rr.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# Record deterministic execution using rr (http://rr-project.org)
+#
+
+export _RR_TRACE_DIR=$AVOCADO_TEST_OUTPUTDIR/rr
+mkdir -p $_RR_TRACE_DIR
+exec rr record -n "$@"
+


### PR DESCRIPTION
This example wrapper script runs binaries inside rr (record), which
saves the execution environment, allowing to deterministically debug
possible failures later.

The usage instructions to run tests with this wrapper are no different
than other wrappers.  The effect of the wrapper, though, deserves notice:
it creates an "rr" directory inside the test results, which rr uses
to save its data files.

Replays should be executed like this:

 $ rr replay $JOB-RESULTS/test-results/$TEST/data/rr/$BINARY_NUMBER

Where $BINARY_NUMBER is the "Nth" execution of "binary" by your
test.

Signed-off-by: Cleber Rosa <crosa@redhat.com>

--

Changes from v1 (#1338):
* Added references to the rr web site
* Added documentation
* Changed output directory to `$AVOCADO_TEST_OUTPUTDIR/rr`
* Added `-n` so that it works on most (all?) setups