### PR TITLE
examples.wrappers.rr: Bugfix and docs improvement

### DIFF
--- a/examples/wrappers/rr.sh
+++ b/examples/wrappers/rr.sh
@@ -3,7 +3,7 @@
 # Record deterministic execution using rr (http://rr-project.org)
 #
 
-export _RR_TRACE_DIR=$AVOCADO_TEST_OUTPUTDIR/rr
-mkdir -p $_RR_TRACE_DIR
+export _RR_TRACE_DIR="$AVOCADO_TEST_OUTPUTDIR/rr"
+mkdir -p "$_RR_TRACE_DIR"
 exec rr record -n "$@"
 


### PR DESCRIPTION
I tried to re-run the execution and found out that it's not really possible due to https://trello.com/c/6Pd0vAVB/793-add-support-for-persistent-temp-directories So I tried to run different binary and discovered there is yet another issue, which is fixed by the first commit. With that I said it might be useful to write the example into documentation.