### PR TITLE
Avocado version and setup improvements

### DIFF
--- a/avocado/core/version.py
+++ b/avocado/core/version.py
@@ -16,11 +16,14 @@
 
 __all__ = ['MAJOR', 'MINOR', 'VERSION']
 
+import pkg_resources
 
-MAJOR = 39
-MINOR = 0
+try:
+    VERSION = pkg_resources.get_distribution("avocado").version
+except pkg_resources.DistributionNotFound:
+    VERSION = "0.0"
 
-VERSION = "%s.%s" % (MAJOR, MINOR)
+MAJOR, MINOR = VERSION.split('.')
 
 if __name__ == '__main__':
     print(VERSION)

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,6 @@ import os
 
 from setuptools import setup
 
-from avocado import VERSION
-
 
 VIRTUAL_ENV = 'VIRTUAL_ENV' in os.environ
 
@@ -104,7 +102,7 @@ def get_long_description():
 
 if __name__ == '__main__':
     setup(name='avocado',
-          version=VERSION,
+          version='39.0',
           description='Avocado Test Framework',
           long_description=get_long_description(),
           author='Avocado Developers',

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ import glob
 import os
 # pylint: disable=E0611
 
-from setuptools import setup
+from setuptools import setup, find_packages
 
 
 VIRTUAL_ENV = 'VIRTUAL_ENV' in os.environ
@@ -109,16 +109,7 @@ if __name__ == '__main__':
           author_email='avocado-devel@redhat.com',
           url='http://avocado-framework.github.io/',
           use_2to3=True,
-          packages=['avocado',
-                    'avocado.core',
-                    'avocado.utils',
-                    'avocado.utils.external',
-                    'avocado.core.remote',
-                    'avocado.core.restclient',
-                    'avocado.core.restclient.cli',
-                    'avocado.core.restclient.cli.args',
-                    'avocado.core.restclient.cli.actions',
-                    'avocado.plugins'],
+          packages=find_packages(exclude=('selftests*',)),
           package_data={'avocado.core': _get_resource_files(
               'avocado/core/resources')},
           data_files=get_data_files(),

--- a/setup.py
+++ b/setup.py
@@ -145,4 +145,5 @@ if __name__ == '__main__':
                   ],
               },
           zip_safe=False,
-          test_suite='selftests')
+          test_suite='selftests',
+          python_requires='>=2.6')


### PR DESCRIPTION
This changes how Avocado queries for its version numbers, moving the authoritative setting to the setup script.  This avoid loading a lot of modules from `setup.py`, and even fixes crashes we'd have on systems without most Avocado requirements.

Also, two additional improvements to our `setup.py`.