### PR TITLE
docs: fix the version (release) number used by sphinx

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -98,7 +98,7 @@ project = u'Avocado'
 copyright = u'2014-2015, Red Hat'
 
 version = VERSION
-release = '0'
+release = VERSION
 
 if not ON_RTD:  # only import and set the theme if we're building docs locally
     try:


### PR DESCRIPTION
Sphinx actually use the contents of the `release` variable as the
user visible version number, so release here is very different from,
say, a RPM release number.

Let's set the release number to the very same version number.

Signed-off-by: Cleber Rosa <crosa@redhat.com>