### PR TITLE
contrib: Disable coredump support when not running as root

### DIFF
--- a/contrib/job-scripts/coredump-handling/pre.d/001-set-core-pattern
+++ b/contrib/job-scripts/coredump-handling/pre.d/001-set-core-pattern
@@ -20,6 +20,12 @@ if [ -z $AVOCADO_JOB_LOGDIR ]; then
    exit 1
 fi
 
+# Skip this when not running as root
+if [ $UID -ne 0 ]; then
+    (>&2 echo "Skipping coredump support because not running as root")
+    exit 0
+fi
+
 # Set the core ulimit for Avocado main process
 ppid=$$
 prlimit --core=unlimited --pid=$(cat /proc/$ppid/status | grep PPid | cut -f2)


### PR DESCRIPTION
The job-scripts are system-wide and always enabled when installed. Let's
skip the `coredump` one in case it's not executed as root to avoid big
fat warnings in every execution. Instead this patch adds a `stderr`
message informing user that coredump support was disabled because it's
not executed as root.

There is no need to modify the other coredump-related scripts as they
depend on files generated by this first script.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>