### PR TITLE
avocado.plugins.xml: Use pretty xml to make output human readable

### DIFF
--- a/avocado/plugins/xunit.py
+++ b/avocado/plugins/xunit.py
@@ -89,7 +89,7 @@ class XUnitResult(Result):
                 element = self._create_failure_or_error(document, test, 'error')
                 testcase.appendChild(element)
             testsuite.appendChild(testcase)
-        return document.toxml(encoding='UTF-8')
+        return document.toprettyxml(encoding='UTF-8')
 
     def render(self, result, job):
         if not (hasattr(job.args, 'xunit_job_result') or


### PR DESCRIPTION
The overhead of prettyxml is quite minimal, while the readability is
huge. Let's enable prettyxml by default to be able to read the results
manually.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>