### PR TITLE
avocado.core.output: Wrap the lines in paginator

### DIFF
--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -529,7 +529,7 @@ class Paginator(object):
 
     def __init__(self):
         try:
-            paginator = "%s -FRSX" % utils_path.find_command('less')
+            paginator = "%s -FRX" % utils_path.find_command('less')
         except utils_path.CmdNotFoundError:
             paginator = None
 


### PR DESCRIPTION
Currently we keep the long lines and let people to scroll left+right to
see the content. This patch changes the paginator to wrap the lines (by
default, it can be tweaked by environment variables).

For my workflows this works better as you see the full output on one
screen and you can easily copy&paste it without the need to scroll left
and right.

trello: https://trello.com/c/haciTU69/663-avocado-list-using-paginator-even-when-not-listing-results