### PR TITLE
add a function that returns the online cpu indexes [3]

### DIFF
--- a/avocado/utils/cpu.py
+++ b/avocado/utils/cpu.py
@@ -115,3 +115,14 @@ def get_cpu_arch():
         return 'x86_64'
     else:
         return 'i386'
+
+
+def cpu_online_list():
+    """
+    Reports a list of indexes of the online cpus
+    """
+    cpus = []
+    for line in open('/proc/cpuinfo', 'r'):
+        if line.startswith('processor'):
+            cpus.append(int(line.split()[2]))  # grab cpu number
+    return cpus

--- a/avocado/utils/cpu.py
+++ b/avocado/utils/cpu.py
@@ -71,7 +71,8 @@ def get_cpu_vendor_name():
     """
     Get the current cpu vendor name
 
-    :returns: string 'intel' or 'amd' or 'power7' depending on the current CPU architecture.
+    :returns: string 'intel' or 'amd' or 'power7' depending on the
+         current CPU architecture.
     :rtype: `string`
     """
     vendors_map = {


### PR DESCRIPTION
Signed-off-by: Praveen K Pandey praveen@linux.vnet.ibm.com

v1: #1370 
v2: https://github.com/avocado-framework/avocado/pull/1373

```
v2: style-fix for pep8
v2: added a function that return list of on -line cpu number
v3: Improve the cpu_online_list docstring
```