### PR TITLE
avocado/core/settings.py: allow any settings to use the home dir nota…

### DIFF
--- a/avocado/core/settings.py
+++ b/avocado/core/settings.py
@@ -244,6 +244,11 @@ class Settings(object):
         if not val.strip() and not allow_blank:
             return self._handle_no_value(section, key, default)
 
+        # if the value looks like a user directory, let's expand it
+        if key_type == str:
+            if isinstance(val, str):
+                val = os.path.expanduser(val)
+
         try:
             return convert_value_type(val, key_type)
         except Exception as details:

--- a/selftests/unit/test_settings.py
+++ b/selftests/unit/test_settings.py
@@ -16,6 +16,8 @@ float_key = 1.25
 bool_key = True
 list_key = ['I', 'love', 'settings']
 empty_key =
+path = ~/path/at/home
+home_path = ~
 """
 
 
@@ -40,6 +42,18 @@ class SettingsTest(unittest.TestCase):
 
     def testBoolConversion(self):
         self.assertTrue(self.settings.get_value('foo', 'bool_key', bool))
+
+    def testPathHomeDir(self):
+        raw_from_settings = '~/path/at/home'
+        path_from_settings = self.settings.get_value('foo', 'path', str)
+        self.assertEqual(path_from_settings[-13:],
+                         raw_from_settings[-13:])
+        self.assertGreaterEqual(len(path_from_settings),
+                                len(raw_from_settings))
+        home_from_environ = os.environ.get('HOME', None)
+        if home_from_environ is not None:
+            self.assertEqual(home_from_environ,
+                             self.settings.get_value('foo', 'home_path', str))
 
     def testListConversion(self):
         self.assertEqual(self.settings.get_value('foo', 'list_key', list),


### PR DESCRIPTION
…tion

It's common to use the tilde notation (`~/foo`) to refer to locations
inside the user directory.  Let's support this transparently in the
configuration files.

Signed-off-by: Cleber Rosa <crosa@redhat.com>