### PR TITLE
avocado.spec: Add build dependency for TAP parser

### DIFF
--- a/avocado.spec
+++ b/avocado.spec
@@ -14,7 +14,7 @@ URL: http://avocado-framework.github.io/
 Source0: https://github.com/avocado-framework/%{name}/archive/%{commit}/%{name}-%{version}-%{shortcommit}.tar.gz
 BuildArch: noarch
 Requires: python, python-requests, fabric, pyliblzma, libvirt-python, pystache, gdb, gdb-gdbserver, python-stevedore, aexpect
-BuildRequires: python2-devel, python-setuptools, python-docutils, python-mock, python-psutil, python-sphinx, python-requests, aexpect, pystache, yum, python-stevedore, python-lxml
+BuildRequires: python2-devel, python-setuptools, python-docutils, python-mock, python-psutil, python-sphinx, python-requests, aexpect, pystache, yum, python-stevedore, python-lxml, perl-Test-Harness
 
 %if 0%{?el6}
 Requires: PyYAML


### PR DESCRIPTION
The TAP test requires the perl-Test-Harness package, let's add it to the
build dependencies. It fails silently, but there is a message just when
the selftests are executed:

    + selftests/run
    Can't locate TAP/Parser.pm in @INC (you may need to install the
    TAP::Parser module) (@INC contains: /usr/local/lib64/perl5
    /usr/local/share/perl5 /usr/lib64/perl5/vendor_perl
    /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5 .) at
    -e line 1.
    BEGIN failed--compilation aborted at -e line 1.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>