### PR TITLE
Add LockFile (avocado.utils.lockfile) test [v2]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ all:
 	@echo
 	@echo "Development related targets:"
 	@echo "check:      Runs tree static check, unittests and functional tests"
+	@echo "check-long: Runs tree static check, unittests and long functional tests"
 	@echo "develop:    Runs 'python setup.py --develop on this tree alone"
 	@echo "link:       Runs 'python setup.py --develop' in all subprojects and links the needed resources"
 	@echo "clean:      Get rid of scratch, byte files and removes the links to other subprojects"
@@ -154,6 +155,10 @@ smokecheck:
 
 check: clean develop check_cyclical modules_boundaries
 	selftests/checkall
+	selftests/check_tmp_dirs
+
+check-long: clean develop check_cyclical modules_boundaries
+	AVOCADO_CHECK_LONG=1 selftests/checkall
 	selftests/check_tmp_dirs
 
 selfcheck: clean check_cyclical modules_boundaries

--- a/selftests/functional/test_utils.py
+++ b/selftests/functional/test_utils.py
@@ -1,9 +1,14 @@
+import multiprocessing
 import os
-import sys
-import stat
-import time
-import tempfile
+import random
 import shutil
+import stat
+import sys
+import tempfile
+import time
+
+from avocado.utils.filelock import FileLock
+
 
 if sys.version_info[:2] == (2, 6):
     import unittest2 as unittest
@@ -154,6 +159,36 @@ class ProcessTest(unittest.TestCase):
 
     def tearDown(self):
         shutil.rmtree(self.base_logdir)
+
+
+def file_lock_action(args):
+    path, players = args
+    max_individual_timeout = 0.021
+    max_timeout = max_individual_timeout * players
+    with FileLock(path, max_timeout):
+        sleeptime = random.random() / 100
+        time.sleep(sleeptime)
+
+
+class FileLockTest(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+
+    @unittest.skipIf(os.environ.get("AVOCADO_CHECK_LONG") != "1",
+                     "Skipping test that takes a long time to run")
+    def test_filelock(self):
+        players = 1000
+        pool = multiprocessing.Pool(players)
+        args = [(self.tmpdir, players)] * players
+        try:
+            pool.map(file_lock_action, args)
+        except:
+            self.fail('Failed to run FileLock with %s players' % players)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
We used a functional test during the development of the lockfile module, but didn't include because really useful tests would take too long to run.

This adds a `Makefile` target for longer tests, which include this one. 

--
Changes from v1 ( #1378):
 * Changed test tunables to more agressive behavior: 1000 players, 100 times smaller timeouts
 * Removed `as lock` from `with FileLock` as it was not being used