### PR TITLE
avocado.plugins.multiplex: Change the `system-wide` shortcut

### DIFF
--- a/avocado/plugins/multiplex.py
+++ b/avocado/plugins/multiplex.py
@@ -48,7 +48,7 @@ class Multiplex(CLICmd):
 
         parser.add_argument('--filter-out', nargs='*', default=[],
                             help='Filter out path(s) from multiplexing')
-        parser.add_argument('-s', '--system-wide', action='store_true',
+        parser.add_argument('-sw', '--system-wide', action='store_true',
                             help="Combine the files with the default "
                             "tree.")
         parser.add_argument('-c', '--contents', action='store_true',


### PR DESCRIPTION
The shortcut `-s` used for `--system-wide` clashes with `--silent|-s`
from the main apps arguments, disabling the output. This is the argparse
limitation and the only way to avoid it I found is to change the
shortcut to `-sw` which does not clashes with the main app args.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>