### PR TITLE
 Fix result generation order

### DIFF
--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -196,4 +196,5 @@ class Run(CLICmd):
             if len(job_instance.result_proxy.output_plugins) > 0:
                 result = job_instance.result_proxy.output_plugins[0]
                 result_dispatcher.map_method('render', result, job_instance)
+        job_instance.post_run()
         return job_run


### PR DESCRIPTION
Commit d60991f moved result generation to run plugings,
this change have side effect. After this commit resutls plugins
(xunit,html and most important results.json) are generated
at very last state.  This means that job-results directory was
archived w/o resutls.json also post scripts do not have access
to output generated by resutls plugin


This patch add post_job() function which can be should be called
by Run plugin.

https://github.com/avocado-framework/avocado/issues/1403