### PR TITLE
avocado: Remote and html bugfixes

### DIFF
--- a/avocado/core/html.py
+++ b/avocado/core/html.py
@@ -182,9 +182,9 @@ class ReportModel(object):
                     sysinfo_dict['contents'] = sysinfo_file.read()
                     sysinfo_dict['element_id'] = '%s_heading_%s' % (phase, s_id)
                     sysinfo_dict['collapse_id'] = '%s_collapse_%s' % (phase, s_id)
-            except OSError:
-                sysinfo_dict[s_f] = ('Error reading sysinfo file %s' %
-                                     sysinfo_path)
+            except (OSError, UnicodeDecodeError) as details:
+                sysinfo_dict[s_f] = ('Error reading sysinfo file %s: %s' %
+                                     (sysinfo_path, details))
             sysinfo_list.append(sysinfo_dict)
             s_id += 1
         return sysinfo_list

--- a/avocado/core/remote/runner.py
+++ b/avocado/core/remote/runner.py
@@ -42,7 +42,7 @@ class RemoteTestRunner(TestRunner):
 
     # Let's use re.MULTILINE because sometimes servers might have MOTD
     # that will introduce a line break on output.
-    remote_version_re = re.compile(r'^Avocado (\d+)\.(\d+)$',
+    remote_version_re = re.compile(r'^Avocado (\d+)\.(\d+)\r?$',
                                    re.MULTILINE)
 
     def __init__(self, job, test_result):


### PR DESCRIPTION
A user reported a crash in html plugin in sysinfo reporting when running as root due to UnicodeDecodeError. This series fixes the remote to avoid running with broken plugins and the second patch skips files which it fails to read and replaces the content with a note instead.

This series is only a workaround, I'll investigate and try to find a better solution. So far I was only able to reproduce the same with non-utf-8 encoding (which is known limitation of avocado as python2 does not provide much opportunity to get the system encoding).

__This needs to be backported to 36.3__