### PR TITLE
[backport] avocado: Remote and html bugfixes

### DIFF
--- a/avocado/core/html.py
+++ b/avocado/core/html.py
@@ -170,15 +170,17 @@ class ReportModel(object):
         for s_f in sysinfo_files:
             sysinfo_dict = {}
             sysinfo_path = os.path.join(base_path, s_f)
+            sysinfo_dict['file'] = " ".join(s_f.split("_"))
+            sysinfo_dict['element_id'] = '%s_heading_%s' % (phase, s_id)
+            sysinfo_dict['collapse_id'] = '%s_collapse_%s' % (phase, s_id)
             try:
                 with codecs.open(sysinfo_path, 'r', encoding="utf-8") as sysinfo_file:
-                    sysinfo_dict['file'] = " ".join(s_f.split("_"))
                     sysinfo_dict['contents'] = sysinfo_file.read()
-                    sysinfo_dict['element_id'] = '%s_heading_%s' % (phase, s_id)
-                    sysinfo_dict['collapse_id'] = '%s_collapse_%s' % (phase, s_id)
             except (OSError, UnicodeDecodeError) as details:
-                sysinfo_dict[s_f] = ('Error reading sysinfo file %s: %s' %
-                                     (sysinfo_path, details))
+                path = os.path.relpath(sysinfo_path, self.html_output_dir)
+                sysinfo_dict['err'] = ("Error reading sysinfo file, check out"
+                                       "the file <a href=%s>%s</a>: %s"
+                                       % (path, path, details))
             sysinfo_list.append(sysinfo_dict)
             s_id += 1
         return sysinfo_list

--- a/avocado/core/html.py
+++ b/avocado/core/html.py
@@ -176,9 +176,9 @@ class ReportModel(object):
                     sysinfo_dict['contents'] = sysinfo_file.read()
                     sysinfo_dict['element_id'] = '%s_heading_%s' % (phase, s_id)
                     sysinfo_dict['collapse_id'] = '%s_collapse_%s' % (phase, s_id)
-            except OSError:
-                sysinfo_dict[s_f] = ('Error reading sysinfo file %s' %
-                                     sysinfo_path)
+            except (OSError, UnicodeDecodeError) as details:
+                sysinfo_dict[s_f] = ('Error reading sysinfo file %s: %s' %
+                                     (sysinfo_path, details))
             sysinfo_list.append(sysinfo_dict)
             s_id += 1
         return sysinfo_list

--- a/avocado/core/remote/runner.py
+++ b/avocado/core/remote/runner.py
@@ -42,7 +42,7 @@ class RemoteTestRunner(TestRunner):
 
     # Let's use re.MULTILINE because sometimes servers might have MOTD
     # that will introduce a line break on output.
-    remote_version_re = re.compile(r'^Avocado (\d+)\.(\d+lts|\d+)$',
+    remote_version_re = re.compile(r'^Avocado (\d+)\.(\d+lts|\d+)\r?$',
                                    re.MULTILINE)
 
     def _copy_files(self):

--- a/avocado/core/resources/htmlresult/templates/report.mustache
+++ b/avocado/core/resources/htmlresult/templates/report.mustache
@@ -101,6 +101,7 @@
                                             <div id="{{collapse_id}}" class="panel-collapse collapse" role="tabpanel" aria-labelledby="{{element_id}}">
                                                 <div class="panel-body">
                                                     <pre>{{contents}}</pre>
+                                                    {{& err}}
                                                 </div>
                                             </div>
                                         </div>


### PR DESCRIPTION
A user reported a crash in html plugin in sysinfo reporting when running as root due to UnicodeDecodeError. This series fixes the remote to avoid running with broken plugins and the second patch skips files which it fails to read and replaces the content with a note instead.

This series is only a workaround, I'll investigate and try to find a better solution. So far I was only able to reproduce the same with non-utf-8 encoding (which is known limitation of avocado as python2 does not provide much opportunity to get the system encoding). The last patch improves the html output in case of failure.

master: https://github.com/avocado-framework/avocado/pull/1416
master: https://github.com/avocado-framework/avocado/pull/1418