### PR TITLE
Sysinfo: do not force package collection

### DIFF
--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -549,7 +549,7 @@ def collect_sysinfo(args):
         timestamp = time.strftime('%Y-%m-%d-%H.%M.%S')
         basedir = os.path.join(cwd, 'sysinfo-%s' % timestamp)
 
-    sysinfo_logger = SysInfo(basedir=basedir, log_packages=True)
+    sysinfo_logger = SysInfo(basedir=basedir)
     sysinfo_logger.start_job_hook()
     sysinfo_logger.end_job_hook()
     log.info("Logged system information to %s", basedir)


### PR DESCRIPTION
I noticed during a `make check` that my system was collecting the list
of installed packages.  Initially, I thought it was some explicit
check performed by a sysinfo related test, but it turned out that,
whenever avocado is run with the `sysinfo` command, it forces the
package collection.

That behavior is wrong, because it disregards the configuration key
`installed_packages` under `sysinfo.collect` that defaults to False.
If users intend to collect installed packages, than they should change
the appropriate configuration key.

Signed-off-by: Cleber Rosa <crosa@redhat.com>