### PR TITLE
Fix avocado crash

### DIFF
--- a/avocado/core/version.py
+++ b/avocado/core/version.py
@@ -14,7 +14,7 @@
 # Copyright: Red Hat Inc. 2013-2014
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
-__all__ = ['MAJOR', 'MINOR', 'VERSION']
+__all__ = ['MAJOR', 'MINOR', 'BUILD', 'VERSION']
 
 import pkg_resources
 
@@ -23,7 +23,11 @@ try:
 except pkg_resources.DistributionNotFound:
     VERSION = "unknown.unknown"
 
-MAJOR, MINOR = VERSION.split('.')
+if len(VERSION) > 3:
+    MAJOR, MINOR, BUILD = VERSION.split('.')
+else:
+    MAJOR, MINOR = VERSION.split('.')
+    BUILD = None
 
 if __name__ == '__main__':
     print(VERSION)


### PR DESCRIPTION
Install latest version of avocado rpm on Fedora [I have 23]:

1. sudo curl https://repos-avocadoproject.rhcloud.com/static/avocado-fedora.repo -o /etc/yum.repos.d/avocado.repo

2. sudo dnf install avocado

3. Check RPM version:
[srikanth@bssrikanth-tp ~]$ rpm -qa | grep avocado
avocado-40.0-0.fc23.noarch

4. Later running any avocado commands crash:

$ avocado config
Avocado crashed unexpectedly: too many values to unpack
You can find details in /tmp/avocado-traceback-2016-08-26_15:25:32-Xs3_eq.log

Below is the issue:

$ python
Python 2.7.11 (default, Aug  9 2016, 15:45:42)
[GCC 5.3.1 20160406 (Red Hat 5.3.1-6)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import pkg_resources
>>> VERSION = pkg_resources.get_distribution("avocado").version
>>> VERSION
'2.4.1'
>>> MAJOR, MINOR = VERSION.split('.')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: too many values to unpack

After fix:

[srikanth@bssrikanth-tp upstream_avocado_fix]$ avocado --version
Avocado 2.4.1