### PR TITLE
This patch fixes the TypeError due to the improper usage of Asset module

### DIFF
--- a/avocado/utils/kernel.py
+++ b/avocado/utils/kernel.py
@@ -72,7 +72,7 @@ class KernelBuild(object):
         full_url = self.URL + self.SOURCE.format(version=self.version)
         self.asset_path = asset.Asset(full_url, asset_hash=None,
                                       algorithm=None, locations=None,
-                                      cache_dirs=self.data_dirs).fetch()
+                                      cache_dirs=self.data_dirs, expire=None).fetch()
 
     def uncompress(self):
         """


### PR DESCRIPTION
This patch fixes the TypeError due to the improper usage of Asset module. ("TypeError: __init__() takes exactly 7 arguments (6 given)")