### PR TITLE
avocado/utils/partition.py: test related improvements

### DIFF
--- a/avocado/utils/partition.py
+++ b/avocado/utils/partition.py
@@ -159,7 +159,8 @@ class Partition(object):
         """
         Format a partition to filesystem type
 
-        :param fstype: the filesystem type, e.g.. "ext3", "ext2"
+        :param fstype: the filesystem type, such as "ext3", "ext2". Defaults
+                       to previously set type or "ext2" if none has set.
         :param args: arguments to be passed to mkfs command.
         """
 

--- a/selftests/unit/test_utils_partition.py
+++ b/selftests/unit/test_utils_partition.py
@@ -26,8 +26,8 @@ class TestPartition(unittest.TestCase):
     Unit tests for avocado.utils.partition
     """
 
-    @unittest.skipIf(process.system("which mkfs.ext3", ignore_status=True),
-                     "mkfs.ext3 is required for these tests to run.")
+    @unittest.skipIf(process.system("which mkfs.ext2", ignore_status=True),
+                     "mkfs.ext2 is required for these tests to run.")
     def setUp(self):
         try:
             process.system("/bin/true", sudo=True)
@@ -63,7 +63,7 @@ class TestPartition(unittest.TestCase):
 
     def test_double_mount(self):
         """ Check the attempt for second mount fails """
-        self.disk.mkfs("ext2")
+        self.disk.mkfs()
         self.disk.mount()
         self.assertIn(self.mountpoint, open("/proc/mounts").read())
         self.assertRaises(partition.PartitionError, self.disk.mount)

--- a/selftests/unit/test_utils_partition.py
+++ b/selftests/unit/test_utils_partition.py
@@ -13,11 +13,28 @@ import time
 from flexmock import flexmock, flexmock_teardown
 
 from avocado.utils import partition, process
+from avocado.utils import path as utils_path
 
 if sys.version_info[:2] == (2, 6):
     import unittest2 as unittest    # pylint: disable=E0401
 else:
     import unittest     # pylint: disable=C0411
+
+
+def missing_binary(binary):
+    try:
+        utils_path.find_command(binary)
+        return False
+    except utils_path.CmdNotFoundError:
+        return True
+
+
+def cannot_sudo(command):
+    try:
+        process.run(command, sudo=True)
+        False
+    except process.CmdError:
+        return True
 
 
 class TestPartition(unittest.TestCase):
@@ -26,13 +43,15 @@ class TestPartition(unittest.TestCase):
     Unit tests for avocado.utils.partition
     """
 
-    @unittest.skipIf(process.system("which mkfs.ext2", ignore_status=True),
+    @unittest.skipIf(missing_binary('mkfs.ext2'),
                      "mkfs.ext2 is required for these tests to run.")
+    @unittest.skipIf(missing_binary('sudo'),
+                     "sudo is required for these tests to run.")
+    @unittest.skipIf(cannot_sudo('mount'),
+                     'current user must be allowed to run "mount" under sudo')
+    @unittest.skipIf(cannot_sudo('mkfs.ext2 -V'),
+                     'current user must be allowed to run "mkfs.ext2" under sudo')
     def setUp(self):
-        try:
-            process.system("/bin/true", sudo=True)
-        except process.CmdError:
-            self.skipTest("Sudo not available")
         self.tmpdir = tempfile.mkdtemp(prefix="avocado_" + __name__)
         self.mountpoint = os.path.join(self.tmpdir, "disk")
         os.mkdir(self.mountpoint)


### PR DESCRIPTION
After spending a couple of time looking at this test, I noticed that it could use a couple of improvements.  Among them is the use of our own `find_command` utility function instead of running `which` (kind of shell approach) and the use of more specific checks for skipping the partition related tests.