### PR TITLE
avocado.core.tree: Disable automatic conversion for node names [v2]

### DIFF
--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -712,7 +712,7 @@ def tree_view(root, verbose=None, use_utf8=None):
             else:
                 val_prefix = '  '
             for key, value in values:
-                out.extend(prefixed_write(val_prefix, val + key + ': ',
+                out.extend(prefixed_write(val_prefix, "%s%s: " % (val, key),
                                           value))
         if node.children:
             for child in node.children[:-1]:

--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -373,7 +373,14 @@ def _create_from_yaml(path, cls_node=TreeNode):
 
     def mapping_to_tree_loader(loader, node):
         """ Maps yaml mapping tag to TreeNode structure """
-        _value = loader.construct_pairs(node)
+        _value = []
+        for key_node, value_node in node.value:
+            if key_node.tag.startswith('!'):    # reflect tags everywhere
+                key = loader.construct_object(key_node)
+            else:
+                key = loader.construct_python_str(key_node)
+            value = loader.construct_object(value_node)
+            _value.append((key, value))
         objects = ListOfNodeObjects()
         for name, values in _value:
             if isinstance(values, ListOfNodeObjects):   # New node from list

--- a/docs/source/MultiplexConfig.rst
+++ b/docs/source/MultiplexConfig.rst
@@ -54,6 +54,10 @@ They define context of the key=>value pairs allowing us to easily identify
 for what this values might be used for and also it makes possible to define
 multiple values of the same keys with different scope.
 
+Due to their purpose the YAML automatic type conversion for nodes names
+is disabled, so the value of node name is always as written in the yaml
+file (unlike values, where `yes` converts to `True` and such).
+
 Nodes are organized in parent-child relationship and together they create
 a tree. To view this structure use ``avocado multiplex --tree <file>``::
 
@@ -117,6 +121,10 @@ The environment created for the nodes ``fedora`` and ``osx`` are:
 - Node ``//devtools/fedora`` environment ``compiler: 'gcc'``, ``flags: ['-O2', '-Wall']``
 - Node ``//devtools/osx`` environment ``compiler: 'clang'``, ``flags: ['-O2', '-arch i386', '-arch x86_64']``
 
+Note that due to different usage of key and values in environment we disabled
+the automatic value conversion for keys while keeping it enabled for values.
+This means that the value can be of any YAML supported value, eg. bool, None,
+list or custom type, while the key is always string.
 
 Variants
 ========

--- a/examples/mux-selftest-advanced.yaml
+++ b/examples/mux-selftest-advanced.yaml
@@ -28,3 +28,8 @@ new_node:
     # not even planned)
     !using : /absolutely/fresh/
     new_value: "something"
+# Check that mapping keys are not converted to values, while values are
+# while value between quotes stays as string.
+on:
+    on: on
+    true: "true"

--- a/selftests/unit/test_tree.py
+++ b/selftests/unit/test_tree.py
@@ -163,7 +163,7 @@ class TestTree(unittest.TestCase):
         tree2 = tree.create_from_yaml(['/:' + PATH_PREFIX + 'examples/mux-'
                                        'selftest-advanced.yaml'])
         exp = ['intel', 'amd', 'arm', 'scsi', 'virtio', 'fedora', '6',
-               '7', 'gentoo', 'mint', 'prod', 'new_node']
+               '7', 'gentoo', 'mint', 'prod', 'new_node', 'on']
         act = tree2.get_leaves()
         oldroot = tree2.children[0]
         self.assertEqual(exp, act)
@@ -176,6 +176,9 @@ class TestTree(unittest.TestCase):
                          oldroot.children[1].children[2].value)
         self.assertEqual({'new_value': 'something'},
                          oldroot.children[3].children[0].children[0].value)
+        # Convert values, but not keys
+        self.assertEqual({'on': True, "true": "true"},
+                         oldroot.children[4].value)
         # multiplex root (always True)
         self.assertEqual(tree2.multiplex, None)
         # multiplex /virt/


### PR DESCRIPTION
The PyYAML by default replaces any value with object. This could be
confusing as:

```
on:
    true: true
```

becomes:

```
    /True/True:True
```

This patch modifies the constructor so only values and tags are
converted.

Trello: https://trello.com/c/BCC1Tg28/813-multiplexer-disable-automatic-conversion-for-everything-but-values
v1: https://github.com/avocado-framework/avocado/pull/1409#discussion_r76632932

Changes:

```yaml
v2: Added documentation
```