### PR TITLE
Makefile improvements [v2]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 
 PYTHON=$(shell which python)
 PYTHON26=$(shell $(PYTHON) -V 2>&1 | grep 2.6 -q && echo true || echo false)
-VERSION=$(shell $(PYTHON) setup.py --version)
+VERSION=$(shell $(PYTHON) setup.py --version 2>/dev/null)
 DESTDIR=/
 BUILDIR=$(CURDIR)/debian/avocado
 PROJECT=avocado

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@
 # https://repos-avocadoproject.rhcloud.com/static/avocado-el.repo
 #
 # Since the RPM build steps are based on mock, edit your chroot config
-# file (/etc/mock/<your-config>.cnf) and add the COPR repo configuration there.
+# file (/etc/mock/<your-config>.cnf) and add the corresponding repo
+# configuration there.
 #
 
 PYTHON=$(shell which python)

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ PYTHON26=$(shell $(PYTHON) -V 2>&1 | grep 2.6 -q && echo true || echo false)
 VERSION=$(shell $(PYTHON) setup.py --version 2>/dev/null)
 DESTDIR=/
 AVOCADO_DIRNAME=$(shell echo $${PWD\#\#*/})
-AVOCADO_PLUGINS=$(filter-out ../$(AVOCADO_DIRNAME), $(wildcard ../*))
+AVOCADO_PLUGINS=$(filter-out ../$(AVOCADO_DIRNAME), $(shell find ../ -maxdepth 1 -mindepth 1 -type d))
 RELEASE_COMMIT=$(shell git log --pretty=format:'%H' -n 1 $(VERSION))
 RELEASE_SHORT_COMMIT=$(shell git log --pretty=format:'%h' -n 1 $(VERSION))
 COMMIT=$(shell git log --pretty=format:'%H' -n 1)
@@ -101,8 +101,8 @@ clean:
 	rm -f man/avocado-rest-client.1
 	rm -rf docs/build
 	find docs/source/api/ -name '*.rst' -delete
-	for MAKEFILE in $(AVOCADO_PLUGINS);\
-		do AVOCADO_DIRNAME=$(AVOCADO_DIRNAME) make -C $$MAKEFILE unlink &>/dev/null && echo ">> UNLINK $$MAKEFILE" || echo ">> SKIP $$MAKEFILE";\
+	for MAKEFILE in $(AVOCADO_PLUGINS); do\
+		if test -f $$MAKEFILE/Makefile; then AVOCADO_DIRNAME=$(AVOCADO_DIRNAME) make -C $$MAKEFILE unlink &>/dev/null && echo ">> UNLINK $$MAKEFILE" || echo ">> SKIP $$MAKEFILE"; fi;\
 	done
 	$(PYTHON) setup.py develop --uninstall $(shell $(PYTHON26) || echo --user)
 	rm -rf avocado.egg-info
@@ -150,8 +150,8 @@ develop:
 	$(PYTHON) setup.py develop $(shell $(PYTHON26) || echo --user)
 
 link: develop
-	for MAKEFILE in $(AVOCADO_PLUGINS);\
-		do AVOCADO_DIRNAME=$(AVOCADO_DIRNAME) make -C $$MAKEFILE link &>/dev/null && echo ">> LINK $$MAKEFILE" || echo ">> SKIP $$MAKEFILE";\
+	for MAKEFILE in $(AVOCADO_PLUGINS); do\
+		if test -f $$MAKEFILE/Makefile; then AVOCADO_DIRNAME=$(AVOCADO_DIRNAME) make -C $$MAKEFILE link &>/dev/null && echo ">> LINK $$MAKEFILE" || echo ">> SKIP $$MAKEFILE"; fi;\
 	done
 
 spell:

--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,10 @@ PYTHON=$(shell which python)
 PYTHON26=$(shell $(PYTHON) -V 2>&1 | grep 2.6 -q && echo true || echo false)
 VERSION=$(shell $(PYTHON) setup.py --version 2>/dev/null)
 DESTDIR=/
-BUILDIR=$(CURDIR)/debian/avocado
-PROJECT=avocado
 AVOCADO_DIRNAME=$(shell echo $${PWD\#\#*/})
 AVOCADO_PLUGINS=$(filter-out ../$(AVOCADO_DIRNAME), $(wildcard ../*))
 RELEASE_COMMIT=$(shell git log --pretty=format:'%H' -n 1 $(VERSION))
 RELEASE_SHORT_COMMIT=$(shell git log --pretty=format:'%h' -n 1 $(VERSION))
-
 COMMIT=$(shell git log --pretty=format:'%H' -n 1)
 SHORT_COMMIT=$(shell git log --pretty=format:'%h' -n 1)
 
@@ -48,11 +45,6 @@ all:
 	@echo "RPM related targets:"
 	@echo "srpm:  Generate a source RPM package (.srpm)"
 	@echo "rpm:   Generate binary RPMs"
-	@echo
-	@echo "Debian related targets:"
-	@echo "deb:      Generate both source and binary debian packages"
-	@echo "deb-src:  Generate a source debian package"
-	@echo "deb-bin:  Generate a binary debian package"
 	@echo
 	@echo "Release related targets:"
 	@echo "source-release:  Create source package for the latest tagged release"
@@ -82,25 +74,6 @@ pypi: source-pypi develop
 
 install:
 	$(PYTHON) setup.py install --root $(DESTDIR) $(COMPILE)
-
-deb-prepare-source:
-	# build the source package in the parent directory
-	# then rename it to project_version.orig.tar.gz
-	dch -D "vivid" -M -v "$(VERSION)" "Automated (make builddeb) build."
-	$(PYTHON) setup.py sdist $(COMPILE) --dist-dir=../
-	rename -f 's/$(PROJECT)-(.*)\.tar\.gz/$(PROJECT)_$$1\.orig\.tar\.gz/' ../*
-
-deb-src: deb-prepare-source
-	# build the source package
-	dpkg-buildpackage -S -elookkas@gmail.com -rfakeroot
-
-deb-bin: deb-prepare-source
-	# build binary package
-	dpkg-buildpackage -b -rfakeroot
-
-deb: deb-prepare-source
-	# build both source and binary packages
-	dpkg-buildpackage -i -I -rfakeroot
 
 srpm: source
 	if test ! -d BUILD/SRPM; then mkdir -p BUILD/SRPM; fi

--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,19 @@ spell:
 
 man: man/avocado.1 man/avocado-rest-client.1
 
-.PHONY: source install clean check link
+variables:
+	@echo "PYTHON: $(PYTHON)"
+	@echo "PYTHON26: $(PYTHON26)"
+	@echo "VERSION: $(VERSION)"
+	@echo "DESTDIR: $(DESTDIR)"
+	@echo "AVOCADO_DIRNAME: $(AVOCADO_DIRNAME)"
+	@echo "AVOCADO_PLUGINS: $(AVOCADO_PLUGINS)"
+	@echo "RELEASE_COMMIT: $(RELEASE_COMMIT)"
+	@echo "RELEASE_SHORT_COMMIT: $(RELEASE_SHORT_COMMIT)"
+	@echo "COMMIT: $(COMMIT)"
+	@echo "SHORT_COMMIT: $(SHORT_COMMIT)"
+
+.PHONY: source install clean check link variables
 
 # implicit rule/recipe for man page creation
 %.1: %.rst

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ RELEASE_COMMIT=$(shell git log --pretty=format:'%H' -n 1 $(VERSION))
 RELEASE_SHORT_COMMIT=$(shell git log --pretty=format:'%h' -n 1 $(VERSION))
 COMMIT=$(shell git log --pretty=format:'%H' -n 1)
 SHORT_COMMIT=$(shell git log --pretty=format:'%h' -n 1)
+MOCK_CONFIG=default
 
 all:
 	@echo
@@ -78,19 +79,19 @@ install:
 
 srpm: source
 	if test ! -d BUILD/SRPM; then mkdir -p BUILD/SRPM; fi
-	mock --resultdir BUILD/SRPM -D "commit $(COMMIT)" --buildsrpm --spec avocado.spec --sources SOURCES
+	mock -r $(MOCK_CONFIG) --resultdir BUILD/SRPM -D "commit $(COMMIT)" --buildsrpm --spec avocado.spec --sources SOURCES
 
 rpm: srpm
 	if test ! -d BUILD/RPM; then mkdir -p BUILD/RPM; fi
-	mock --resultdir BUILD/RPM -D "commit $(COMMIT)" --rebuild BUILD/SRPM/avocado-$(VERSION)-*.src.rpm
+	mock -r $(MOCK_CONFIG) --resultdir BUILD/RPM -D "commit $(COMMIT)" --rebuild BUILD/SRPM/avocado-$(VERSION)-*.src.rpm
 
 srpm-release: source-release
 	if test ! -d BUILD/SRPM; then mkdir -p BUILD/SRPM; fi
-	mock --resultdir BUILD/SRPM -D "commit $(RELEASE_COMMIT)" --buildsrpm --spec avocado.spec --sources SOURCES
+	mock -r $(MOCK_CONFIG) --resultdir BUILD/SRPM -D "commit $(RELEASE_COMMIT)" --buildsrpm --spec avocado.spec --sources SOURCES
 
 rpm-release: srpm-release
 	if test ! -d BUILD/RPM; then mkdir -p BUILD/RPM; fi
-	mock --resultdir BUILD/RPM -D "commit $(RELEASE_COMMIT)" --rebuild BUILD/SRPM/avocado-$(VERSION)-*.src.rpm
+	mock -r $(MOCK_CONFIG) --resultdir BUILD/RPM -D "commit $(RELEASE_COMMIT)" --rebuild BUILD/SRPM/avocado-$(VERSION)-*.src.rpm
 
 clean:
 	$(PYTHON) setup.py clean
@@ -169,6 +170,7 @@ variables:
 	@echo "RELEASE_SHORT_COMMIT: $(RELEASE_SHORT_COMMIT)"
 	@echo "COMMIT: $(COMMIT)"
 	@echo "SHORT_COMMIT: $(SHORT_COMMIT)"
+	@echo "MOCK_CONFIG: $(MOCK_CONFIG)"
 
 .PHONY: source install clean check link variables
 

--- a/contrib/packages/debian/Makefile
+++ b/contrib/packages/debian/Makefile
@@ -1,0 +1,29 @@
+BUILDIR=$(CURDIR)/debian/avocado
+PROJECT=avocado
+
+all:
+	@echo
+	@echo "Debian related targets:"
+	@echo "deb:      Generate both source and binary debian packages"
+	@echo "deb-src:  Generate a source debian package"
+	@echo "deb-bin:  Generate a binary debian package"
+	@echo
+
+deb-prepare-source:
+	# build the source package in the parent directory
+	# then rename it to project_version.orig.tar.gz
+	dch -D "vivid" -M -v "$(VERSION)" "Automated (make builddeb) build."
+	$(PYTHON) setup.py sdist $(COMPILE) --dist-dir=../
+	rename -f 's/$(PROJECT)-(.*)\.tar\.gz/$(PROJECT)_$$1\.orig\.tar\.gz/' ../*
+
+deb-src: deb-prepare-source
+	# build the source package
+	dpkg-buildpackage -S -elookkas@gmail.com -rfakeroot
+
+deb-bin: deb-prepare-source
+	# build binary package
+	dpkg-buildpackage -b -rfakeroot
+
+deb: deb-prepare-source
+	# build both source and binary packages
+	dpkg-buildpackage -i -I -rfakeroot

--- a/contrib/packages/debian/README
+++ b/contrib/packages/debian/README
@@ -1,0 +1,10 @@
+This is a collection of files that are useful to generate packages for
+Debian(-like) systems.  Their "contrib" status mean that they should
+work, but there's no support for them.
+
+If there are users out there interested in keeping Debian(-like)
+packages update, please step up.
+
+The basic usage is to run the various targets defined in the Makefile,
+such as running `make deb` to have both source and binary packages
+generated.

--- a/selftests/unit/test_utils_partition.py
+++ b/selftests/unit/test_utils_partition.py
@@ -33,7 +33,7 @@ def cannot_sudo(command):
     try:
         process.run(command, sudo=True)
         False
-    except process.CmdError:
+    except (process.CmdError, OSError):
         return True
 
 


### PR DESCRIPTION
This is a small collection of Makefile related cleanups and improvements.

--
Changes from v1 (#1430):
 * Added missing `contrib/packaging/debian/Makefile` file
 * Added a Debian package contrib README file
 * Changed the name of the target from `show` to `variables`
 * Removed mention of COPR in the Makefile embedded documentaiton
 * Added option that controls mock (RPM build related) config
 * Added unittest fix for breakage that usually manifests itself in the mock build environment
 * Limit attempts to run clean/link to directories containing Makefiles