### PR TITLE
avocado/core/settings.py: allow settings to use the home dir notation [v4]

### DIFF
--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -59,7 +59,7 @@ def _get_settings_dir(dir_name):
     """
     Returns a given "datadir" directory as set by the configuration system
     """
-    return os.path.expanduser(settings.settings.get_value('datadir.paths', dir_name))
+    return settings.settings.get_value('datadir.paths', dir_name, 'path')
 
 
 def _get_rw_dir(settings_location, system_location, user_location):

--- a/avocado/core/settings.py
+++ b/avocado/core/settings.py
@@ -107,6 +107,8 @@ def convert_value_type(value, value_type):
             value_type = float
         elif value_type == 'list':
             value_type = list
+        elif value_type == 'path':
+            value_type = os.path.expanduser
 
     if value_type is None:
         value_type = str
@@ -114,6 +116,8 @@ def convert_value_type(value, value_type):
     # if length of string is zero then return None
     if len(sval) == 0:
         if value_type == str:
+            return ""
+        elif value_type == os.path.expanduser:
             return ""
         elif value_type == bool:
             return False
@@ -225,16 +229,24 @@ class Settings(object):
         Get value from key in a given config file section.
 
         :param section: Config file section.
+        :type section: str
         :param key: Config file key, relative to section.
+        :type key: str
         :param key_type: Type of key.
-                It can be either of: str, int, float, bool, list
+        :type key_type: either string based names representing types,
+                        including `str`, `int`, `float`, `bool`,
+                        `list` and `path`, or the types themselves
+                        limited to :class:`str`, :class:`int`,
+                        :class:`float`, :class:`bool` and
+                        :class:`list`.
         :param default: Default value for the key, if none found.
         :param allow_blank: Whether an empty value for the key is allowed.
 
         :returns: value, if one available in the config.
                 default value, if one provided.
 
-        :raises: SettingsError, in case no default was provided.
+        :raises: SettingsError, in case key is not set and no default
+                 was provided.
         """
         try:
             val = self.config.get(section, key)

--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -333,14 +333,14 @@ class SysInfo(object):
 
         commands_file = settings.get_value('sysinfo.collectibles',
                                            'commands',
-                                           key_type='str',
+                                           key_type='path',
                                            default='')
         log.info('Commands configured by file: %s', commands_file)
         self.commands = genio.read_all_lines(commands_file)
 
         files_file = settings.get_value('sysinfo.collectibles',
                                         'files',
-                                        key_type='str',
+                                        key_type='path',
                                         default='')
         log.info('Files configured by file: %s', files_file)
         self.files = genio.read_all_lines(files_file)
@@ -355,7 +355,7 @@ class SysInfo(object):
 
         profiler_file = settings.get_value('sysinfo.collectibles',
                                            'profilers',
-                                           key_type='str',
+                                           key_type='path',
                                            default='')
         self.profilers = genio.read_all_lines(profiler_file)
 

--- a/avocado/plugins/diff.py
+++ b/avocado/plugins/diff.py
@@ -336,9 +336,9 @@ class Diff(CLICmd):
             resultsdir = os.path.dirname(os.path.expanduser(job_id))
             job_id = ''
         else:
-            logs_dir = settings.get_value('datadir.paths', 'logs_dir',
-                                          default=None)
-            logdir = os.path.expanduser(logs_dir)
+            logdir = settings.get_value(section='datadir.paths',
+                                        key='logs_dir', key_type='path',
+                                        default=None)
             try:
                 resultsdir = jobdata.get_resultsdir(logdir, job_id)
             except ValueError as exception:

--- a/avocado/plugins/gdb.py
+++ b/avocado/plugins/gdb.py
@@ -77,11 +77,12 @@ class GDB(CLI):
             gdb.GDB_ENABLE_CORE = True if args.gdb_coredump == 'on' else False
 
         system_gdb_path = utils_path.find_command('gdb', '/usr/bin/gdb')
-        gdb.GDB_PATH = settings.get_value('gdb.paths', 'gdb',
+        gdb.GDB_PATH = settings.get_value('gdb.paths', 'gdb', key_type='path',
                                           default=system_gdb_path)
         system_gdbserver_path = utils_path.find_command('gdbserver',
                                                         '/usr/bin/gdbserver')
         gdb.GDBSERVER_PATH = settings.get_value('gdb.paths',
                                                 'gdbserver',
+                                                key_type='path',
                                                 default=system_gdbserver_path)
         process.UNDEFINED_BEHAVIOR_EXCEPTION = exceptions.TestError

--- a/avocado/plugins/jobscripts.py
+++ b/avocado/plugins/jobscripts.py
@@ -58,12 +58,12 @@ class JobScripts(JobPre, JobPost):
 
     def pre(self, job):
         path = settings.get_value(section=CONFIG_SECTION,
-                                  key="pre", key_type=str,
+                                  key="pre", key_type='path',
                                   default="/etc/avocado/scripts/job/pre.d/")
         self._run_scripts('pre', path, job)
 
     def post(self, job):
         path = settings.get_value(section=CONFIG_SECTION,
-                                  key="post", key_type=str,
+                                  key="post", key_type='path',
                                   default="/etc/avocado/scripts/job/post.d/")
         self._run_scripts('post', path, job)

--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -140,9 +140,9 @@ class Replay(CLI):
         if args.replay_datadir is not None:
             resultsdir = args.replay_datadir
         else:
-            logs_dir = settings.get_value('datadir.paths', 'logs_dir',
-                                          default=None)
-            logdir = os.path.expanduser(logs_dir)
+            logdir = settings.get_value(section='datadir.paths',
+                                        key='logs_dir', key_type='path',
+                                        default=None)
             try:
                 resultsdir = jobdata.get_resultsdir(logdir, args.replay_jobid)
             except ValueError as exception:

--- a/selftests/unit/test_settings.py
+++ b/selftests/unit/test_settings.py
@@ -16,6 +16,8 @@ float_key = 1.25
 bool_key = True
 list_key = ['I', 'love', 'settings']
 empty_key =
+path = ~/path/at/home
+home_path = ~
 """
 
 
@@ -40,6 +42,21 @@ class SettingsTest(unittest.TestCase):
 
     def testBoolConversion(self):
         self.assertTrue(self.settings.get_value('foo', 'bool_key', bool))
+
+    def testPathHomeDir(self):
+        raw_from_settings = '~/path/at/home'
+        path_from_settings = self.settings.get_value('foo', 'path', 'path')
+        home_str_from_settings = self.settings.get_value('foo', 'home_path', str)
+        self.assertEqual(path_from_settings[-13:],
+                         raw_from_settings[-13:])
+        self.assertGreaterEqual(len(path_from_settings),
+                                len(raw_from_settings))
+        self.assertEqual(os.path.expanduser(home_str_from_settings),
+                         self.settings.get_value('foo', 'home_path', 'path'))
+
+    def testPathOnStrKey(self):
+        self.assertEqual(self.settings.get_value('foo', 'path', str),
+                         '~/path/at/home')
 
     def testListConversion(self):
         self.assertEqual(self.settings.get_value('foo', 'list_key', list),


### PR DESCRIPTION
It's common to use the tilde notation (`~/foo`) to refer to locations
inside the user directory.  Let's introduce a new settings key type,
called `path`, that will automatically expand the tilde notation
if one is found.

--
Changes from v3 (#1428):
 * Use `os.path.expanduser` in unittest instead of `os.environ.get('HOME', ...)` approach

Changes from v2 (#1400):
 * Added missing places where key type "path" could/should be used, including replay, diff and gdb plugins.

Changes from v1 (#1377):
* Added `path` as an argument to `key_type`
* Added unittest for paths used in `str` types of key
* General docstring improvements 
* Switched key types from `str` to `path` on appropriate sections 