### PR TITLE
setup.py: fix the virtualenv detection

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,12 +15,13 @@
 
 import glob
 import os
+import sys
 # pylint: disable=E0611
 
 from setuptools import setup, find_packages
 
 
-VIRTUAL_ENV = 'VIRTUAL_ENV' in os.environ
+VIRTUAL_ENV = hasattr(sys, 'real_prefix')
 
 
 def get_dir(system_path=None, virtual_path=None):


### PR DESCRIPTION
`VIRTUAL_ENV` variable might not be always present. That's the
case for _ReadTheDocs_. On the other hand, `sys.real_prefix` seems to
be a more reliable way to detect we are under a _virtualenv_.

Reference: https://trello.com/c/PRTvrTOH

You can check the result here: http://apahim-avocado.readthedocs.io/en/fix_rtd_version/