### PR TITLE
[WiP] avocado: Define Mux API and turn --multiplex into a proper plugin

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -524,9 +524,9 @@ class Job(object):
 
         * If urls is provided alone, just make a simple list with no specific
           params (all tests use default params).
-        * If urls and multiplex_files are provided, multiplex provides params
+        * If urls and multiplex are provided, multiplex provides params
           and variants to all tests it can.
-        * If multiplex_files are provided alone, just use the matrix produced
+        * If multiplex are provided alone, just use the matrix produced
           by the file
 
         The test runner figures out which tests need to be run on an empty urls

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -520,15 +520,6 @@ class Job(object):
         """
         Handled main job method. Runs a list of test URLs to its completion.
 
-        Note that the behavior is as follows:
-
-        * If urls is provided alone, just make a simple list with no specific
-          params (all tests use default params).
-        * If urls and multiplex are provided, multiplex provides params
-          and variants to all tests it can.
-        * If multiplex are provided alone, just use the matrix produced
-          by the file
-
         The test runner figures out which tests need to be run on an empty urls
         list by assuming the first component of the shortname is the test url.
 

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -474,12 +474,12 @@ class Job(object):
                          "command.")
             raise exceptions.OptionValidationError(e_msg)
 
-        if isinstance(getattr(self.args, 'multiplex_files', None),
-                      multiplexer.Mux):
-            mux = self.args.multiplex_files     # pylint: disable=E1101
-        else:
+        mux = getattr(self.args, "mux", None)
+        if mux is None:
+            mux = multiplexer.Mux()
+        if not mux.is_parsed:   # Mux not yet parsed, apply args
             try:
-                mux = multiplexer.Mux(self.args)
+                mux.parse(self.args)
             except (IOError, ValueError) as details:
                 raise exceptions.OptionValidationError(details)
         self.args.test_result_total = mux.get_number_of_tests(self.test_suite)

--- a/avocado/core/jobdata.py
+++ b/avocado/core/jobdata.py
@@ -100,7 +100,7 @@ def retrieve_urls(resultsdir):
 
 def retrieve_mux(resultsdir):
     """
-    Retrieves the job multiplex from the results directory.
+    Retrieves the job Mux object from the results directory.
     """
     recorded_mux = _retrieve(resultsdir, MUX_FILENAME)
     if recorded_mux is None:

--- a/avocado/core/multiplexer.py
+++ b/avocado/core/multiplexer.py
@@ -391,10 +391,10 @@ class Mux(object):
     This is a multiplex object which multiplexes the test_suite.
     """
 
-    def __init__(self):
+    def __init__(self, debug=False):
         self._has_multiple_variants = None
         self.variants = None
-        self.data = tree.TreeNode()
+        self.data = tree.TreeNodeDebug() if debug else tree.TreeNode()
         self._mux_path = None
 
     def parse(self, args):

--- a/avocado/core/multiplexer.py
+++ b/avocado/core/multiplexer.py
@@ -26,8 +26,6 @@ import re
 
 from . import tree
 
-MULTIPLEX_CAPABLE = tree.MULTIPLEX_CAPABLE
-
 
 class MuxTree(object):
 
@@ -78,18 +76,6 @@ class MuxTree(object):
             # TODO: Implement 2nd level filters here
             # TODO: This part takes most of the time, optimize it
             yield list(itertools.chain(*pools.next()))
-
-
-def yaml2tree(input_yamls, filter_only=None, filter_out=None,
-              debug=False):
-    if filter_only is None:
-        filter_only = []
-    if filter_out is None:
-        filter_out = []
-    input_tree = tree.create_from_yaml(input_yamls, debug)
-    # TODO: Process filters and multiplex simultaneously
-    final_tree = tree.apply_filters(input_tree, filter_only, filter_out)
-    return final_tree
 
 
 # TODO: Create multiplexer plugin and split these functions into multiple files

--- a/avocado/core/multiplexer.py
+++ b/avocado/core/multiplexer.py
@@ -389,11 +389,12 @@ class Mux(object):
         filter_only = getattr(args, 'filter_only', None)
         filter_out = getattr(args, 'filter_out', None)
         if mux_files:
-            mux_tree = yaml2tree(mux_files, filter_only, filter_out)
+            mux_tree = yaml2tree(mux_files)
         else:   # no variants
             mux_tree = tree.TreeNode()
         if getattr(args, 'default_avocado_params', None):
             mux_tree.merge(args.default_avocado_params)
+        mux_tree = tree.apply_filters(mux_tree, filter_only, filter_out)
         self.variants = MuxTree(mux_tree)
         self._mux_path = getattr(args, 'mux_path', None)
         if self._mux_path is None:

--- a/avocado/core/parser.py
+++ b/avocado/core/parser.py
@@ -12,7 +12,6 @@
 # Copyright: Red Hat Inc. 2013-2014
 # Author: Ruda Moura <rmoura@redhat.com>
 
-
 """
 Avocado application command line parsing.
 """
@@ -21,7 +20,7 @@ import argparse
 import logging
 
 from . import exit_codes
-from . import tree
+from . import multiplexer
 from . import settings
 from .output import BUILTIN_STREAMS, BUILTIN_STREAM_SETS
 from .version import VERSION
@@ -125,7 +124,7 @@ class Parser(object):
             dest='subcommand')
 
         # Allow overriding default params by plugins
-        self.args.default_avocado_params = tree.TreeNode()
+        self.args.mux = multiplexer.Mux()
 
     def finish(self):
         """

--- a/avocado/core/parser.py
+++ b/avocado/core/parser.py
@@ -124,7 +124,7 @@ class Parser(object):
             dest='subcommand')
 
         # Allow overriding default params by plugins
-        self.args.mux = multiplexer.Mux()
+        self.args.mux = multiplexer.Mux(getattr(self.args, "mux-debug", False))
 
     def finish(self):
         """

--- a/avocado/core/remote/runner.py
+++ b/avocado/core/remote/runner.py
@@ -80,7 +80,7 @@ class RemoteTestRunner(TestRunner):
             test_data = path + '.data'
             if os.path.isdir(test_data):
                 self.remote.send_files(test_data, os.path.dirname(rpath))
-        for mux_file in getattr(self.job.args, 'multiplex_files') or []:
+        for mux_file in getattr(self.job.args, 'multiplex') or []:
             rpath = os.path.join(self.remote_test_dir, mux_file)
             self.remote.makedir(os.path.dirname(rpath))
             self.remote.send_files(mux_file, rpath)
@@ -181,7 +181,7 @@ class RemoteTestRunner(TestRunner):
         extra_params = []
         mux_files = [os.path.join(self.remote_test_dir, mux_file)
                      for mux_file in getattr(self.job.args,
-                                             'multiplex_files') or []]
+                                             'multiplex') or []]
         if mux_files:
             extra_params.append("--multiplex %s" % " ".join(mux_files))
 

--- a/avocado/plugins/multiplex.py
+++ b/avocado/plugins/multiplex.py
@@ -69,17 +69,16 @@ class Multiplex(CLICmd):
                                  help="Show the inherited values")
 
     def _activate(self, args):
-        # Extend default multiplex tree of --env values
+        # Extend default multiplex tree of --mux-inject values
         for value in getattr(args, "mux_inject", []):
-            value = value.split(':', 2)
+            value = value.split(':', 3)
             if len(value) < 2:
                 raise ValueError("key:value pairs required, found only %s"
                                  % (value))
-            elif len(value) == 2:
-                self._from_args_tree.value[value[0]] = value[1]
-            else:
-                node = self._from_args_tree.get_node(value[0], True)
-                node.value[value[1]] = value[2]
+            elif len(value) == 2:   # key, value
+                args.mux.data_inject(*value)
+            else:                   # path, key, value
+                args.mux.data_inject(value[1], value[2], value[0])
 
     def run(self, args):
         self._activate(args)
@@ -100,7 +99,7 @@ class Multiplex(CLICmd):
             log.error(details.strerror)
             sys.exit(exit_codes.AVOCADO_JOB_FAIL)
         if args.system_wide:
-            mux_tree.merge(args.default_avocado_params)
+            mux_tree.merge(args.mux)
         mux_tree.merge(self._from_args_tree)
         if args.tree:
             if args.contents:

--- a/avocado/plugins/multiplex.py
+++ b/avocado/plugins/multiplex.py
@@ -40,7 +40,7 @@ class Multiplex(CLICmd):
             return
 
         parser = super(Multiplex, self).configure(parser)
-        parser.add_argument('multiplex_files', nargs='+',
+        parser.add_argument('multiplex', nargs='+',
                             help='Path(s) to a multiplex file(s)')
 
         parser.add_argument('--filter-only', nargs='*', default=[],
@@ -92,7 +92,7 @@ class Multiplex(CLICmd):
             log.error(err)
             sys.exit(exit_codes.AVOCADO_FAIL)
         try:
-            mux_tree = multiplexer.yaml2tree(args.multiplex_files,
+            mux_tree = multiplexer.yaml2tree(args.multiplex,
                                              args.filter_only, args.filter_out,
                                              args.debug)
         except IOError as details:

--- a/avocado/plugins/multiplex.py
+++ b/avocado/plugins/multiplex.py
@@ -53,8 +53,8 @@ class Multiplex(CLICmd):
                             "the final multiplex tree.")
         env_parser = parser.add_argument_group("environment view options")
         env_parser.add_argument('-d', '--debug', action='store_true',
-                                default=False, help="Debug multiplexed "
-                                "files.")
+                                dest="mux_debug", default=False,
+                                help="Debug the multiplex tree.")
         tree_parser = parser.add_argument_group("tree view options")
         tree_parser.add_argument('-t', '--tree', action='store_true',
                                  default=False, help='Shows the multiplex '
@@ -78,7 +78,7 @@ class Multiplex(CLICmd):
         self._activate(args)
         log = logging.getLogger("avocado.app")
         err = None
-        if args.tree and args.debug:
+        if args.tree and args.mux_debug:
             err = "Option --tree is incompatible with --debug."
         elif not args.tree and args.inherit:
             err = "Option --inherit can be only used with --tree"
@@ -88,7 +88,7 @@ class Multiplex(CLICmd):
         try:
             mux_tree = multiplexer.yaml2tree(args.multiplex,
                                              args.filter_only, args.filter_out,
-                                             args.debug)
+                                             args.mux_debug)
         except IOError as details:
             log.error(details.strerror)
             sys.exit(exit_codes.AVOCADO_JOB_FAIL)
@@ -107,7 +107,7 @@ class Multiplex(CLICmd):
         variants = multiplexer.MuxTree(mux_tree)
         log.info('Variants generated:')
         for (index, tpl) in enumerate(variants):
-            if not args.debug:
+            if not args.mux_debug:
                 paths = ', '.join([x.path for x in tpl])
             else:
                 color = output.TERM_SUPPORT.LOWLIGHT

--- a/avocado/plugins/multiplex.py
+++ b/avocado/plugins/multiplex.py
@@ -35,12 +35,10 @@ class Multiplex(CLICmd):
         super(Multiplex, self).__init__(*args, **kwargs)
 
     def configure(self, parser):
-        if multiplexer.MULTIPLEX_CAPABLE is False:
-            return
-
         parser = super(Multiplex, self).configure(parser)
-        parser.add_argument('multiplex', nargs='+',
-                            help='Path(s) to a multiplex file(s)')
+        if multiplexer.MULTIPLEX_CAPABLE:
+            parser.add_argument("-m", '--multiplex', nargs='*',
+                                help='Path(s) to a multiplex file(s)')
 
         parser.add_argument('--filter-only', nargs='*', default=[],
                             help='Filter only path(s) from multiplexing')

--- a/avocado/plugins/multiplex.py
+++ b/avocado/plugins/multiplex.py
@@ -36,9 +36,6 @@ class Multiplex(CLICmd):
 
     def configure(self, parser):
         parser = super(Multiplex, self).configure(parser)
-        if multiplexer.MULTIPLEX_CAPABLE:
-            parser.add_argument("-m", '--multiplex', nargs='*',
-                                help='Path(s) to a multiplex file(s)')
 
         parser.add_argument('--filter-only', nargs='*', default=[],
                             help='Filter only path(s) from multiplexing')
@@ -85,13 +82,8 @@ class Multiplex(CLICmd):
         if err:
             log.error(err)
             sys.exit(exit_codes.AVOCADO_FAIL)
-        try:
-            mux_tree = multiplexer.yaml2tree(args.multiplex,
-                                             args.filter_only, args.filter_out,
-                                             args.mux_debug)
-        except IOError as details:
-            log.error(details.strerror)
-            sys.exit(exit_codes.AVOCADO_JOB_FAIL)
+        mux = args.mux
+        mux.parse(args)
         if args.tree:
             if args.contents:
                 verbose = 1
@@ -101,12 +93,11 @@ class Multiplex(CLICmd):
                 verbose += 2
             use_utf8 = settings.get_value("runner.output", "utf8",
                                           key_type=bool, default=None)
-            log.debug(tree.tree_view(mux_tree, verbose, use_utf8))
+            log.debug(tree.tree_view(mux.variants.root, verbose, use_utf8))
             sys.exit(exit_codes.AVOCADO_ALL_OK)
 
-        variants = multiplexer.MuxTree(mux_tree)
         log.info('Variants generated:')
-        for (index, tpl) in enumerate(variants):
+        for (index, tpl) in enumerate(mux.variants):
             if not args.mux_debug:
                 paths = ', '.join([x.path for x in tpl])
             else:

--- a/avocado/plugins/multiplex.py
+++ b/avocado/plugins/multiplex.py
@@ -33,7 +33,6 @@ class Multiplex(CLICmd):
 
     def __init__(self, *args, **kwargs):
         super(Multiplex, self).__init__(*args, **kwargs)
-        self._from_args_tree = tree.TreeNode()
 
     def configure(self, parser):
         if multiplexer.MULTIPLEX_CAPABLE is False:
@@ -48,9 +47,6 @@ class Multiplex(CLICmd):
 
         parser.add_argument('--filter-out', nargs='*', default=[],
                             help='Filter out path(s) from multiplexing')
-        parser.add_argument('--system-wide', action='store_true',
-                            help="Combine the files with the default "
-                            "tree.")
         parser.add_argument('-c', '--contents', action='store_true',
                             default=False, help="Shows the node content "
                             "(variables)")
@@ -98,9 +94,6 @@ class Multiplex(CLICmd):
         except IOError as details:
             log.error(details.strerror)
             sys.exit(exit_codes.AVOCADO_JOB_FAIL)
-        if args.system_wide:
-            mux_tree.merge(args.mux)
-        mux_tree.merge(self._from_args_tree)
         if args.tree:
             if args.contents:
                 verbose = 1

--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -213,11 +213,12 @@ class Replay(CLI):
                                         for _ in args.multiplex_files]
             else:
                 mux = jobdata.retrieve_mux(resultsdir)
-                if mux is None:
-                    log.error('Source job multiplex data not found. Aborting.')
+                if mux is None:     # Fallback to multiplex_files
+                    log.error("Source job multiplex data not found. "
+                              "Aborting.")
                     sys.exit(exit_codes.AVOCADO_JOB_FAIL)
                 else:
-                    setattr(args, "multiplex_files", mux)
+                    setattr(args, "mux", mux)
 
         if args.replay_teststatus:
             replay_map = self._create_replay_map(resultsdir,

--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -125,7 +125,7 @@ class Replay(CLI):
         log = logging.getLogger("avocado.app")
 
         err = None
-        if args.replay_teststatus and args.multiplex_files:
+        if args.replay_teststatus and args.multiplex:
             err = ("Option --replay-test-status is incompatible with "
                    "--multiplex.")
         elif args.replay_teststatus and args.url:
@@ -205,12 +205,12 @@ class Replay(CLI):
             log.warn("Ignoring multiplex from source job with "
                      "--replay-ignore.")
         else:
-            if getattr(args, 'multiplex_files', None) is not None:
+            if getattr(args, 'multiplex', None) is not None:
                 log.warn('Overriding the replay multiplex with '
                          '--multiplex-file.')
                 # Use absolute paths to avoid problems with os.chdir
-                args.multiplex_files = [os.path.abspath(_)
-                                        for _ in args.multiplex_files]
+                args.multiplex = [os.path.abspath(_)
+                                        for _ in args.multiplex]
             else:
                 mux = jobdata.retrieve_mux(resultsdir)
                 if mux is None:     # Fallback to multiplex_files

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -135,7 +135,6 @@ class Run(CLICmd):
         mux = parser.add_argument_group('test parameters')
         if multiplexer.MULTIPLEX_CAPABLE:
             mux.add_argument('-m', '--multiplex', nargs='*',
-                             dest='multiplex_files',
                              default=None, metavar='FILE',
                              help='Location of one or more Avocado multiplex '
                              '(.yaml) FILE(s) (order dependent)')
@@ -151,8 +150,8 @@ class Run(CLICmd):
                          "final multiplex tree.")
 
     def _activate(self, args):
-        # Merge the multiplex_files
-        multiplex_files = getattr(args, "multiplex_files", None)
+        # Merge the multiplex
+        multiplex_files = getattr(args, "multiplex", None)
         if multiplex_files:
             args.mux.data_merge(multiplexer.yaml2tree(multiplex_files))
 

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -138,9 +138,6 @@ class Run(CLICmd):
                              default=None, metavar='FILE',
                              help='Location of one or more Avocado multiplex (.yaml) '
                              'FILE(s) (order dependent)')
-            mux.add_argument('--multiplex-files', nargs='*',
-                             default=None, metavar='FILE',
-                             help='DEPRECATED: please use --multiplex instead')
             mux.add_argument('--filter-only', nargs='*', default=[],
                              help='Filter only path(s) from multiplexing')
             mux.add_argument('--filter-out', nargs='*', default=[],

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -133,7 +133,7 @@ class Run(CLICmd):
         loader.add_loader_options(parser)
 
         if multiplexer.MULTIPLEX_CAPABLE:
-            mux = parser.add_argument_group('multiplexer use on test execution')
+            mux = parser.add_argument_group('test parameters')
             mux.add_argument('-m', '--multiplex', nargs='*', dest='multiplex_files',
                              default=None, metavar='FILE',
                              help='Location of one or more Avocado multiplex (.yaml) '

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -151,17 +151,21 @@ class Run(CLICmd):
                          "final multiplex tree.")
 
     def _activate(self, args):
-        # Extend default multiplex tree of --mux_inject values
+        # Merge the multiplex_files
+        multiplex_files = getattr(args, "multiplex_files", None)
+        if multiplex_files:
+            args.mux.data_merge(multiplexer.yaml2tree(multiplex_files))
+
+        # Extend default multiplex tree of --mux-inject values
         for value in getattr(args, "mux_inject", []):
-            value = value.split(':', 2)
+            value = value.split(':', 3)
             if len(value) < 2:
                 raise ValueError("key:value pairs required, found only %s"
                                  % (value))
-            elif len(value) == 2:
-                args.default_avocado_params.value[value[0]] = value[1]
-            else:
-                node = args.default_avocado_params.get_node(value[0], True)
-                node.value[value[1]] = value[2]
+            elif len(value) == 2:   # key, value
+                args.mux.data_inject(*value)
+            else:                   # path, key, value
+                args.mux.data_inject(value[1], value[2], value[0])
 
     def run(self, args):
         """

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -23,7 +23,6 @@ import sys
 from avocado.core import exit_codes
 from avocado.core import job
 from avocado.core import loader
-from avocado.core import multiplexer
 from avocado.core.plugin_interfaces import CLICmd
 from avocado.core.dispatcher import ResultDispatcher
 from avocado.core.settings import settings
@@ -133,11 +132,6 @@ class Run(CLICmd):
         loader.add_loader_options(parser)
 
         mux = parser.add_argument_group('test parameters')
-        if multiplexer.MULTIPLEX_CAPABLE:
-            mux.add_argument('-m', '--multiplex', nargs='*',
-                             default=None, metavar='FILE',
-                             help='Location of one or more Avocado multiplex '
-                             '(.yaml) FILE(s) (order dependent)')
         mux.add_argument('--filter-only', nargs='*', default=[],
                          help='Filter only path(s) from multiplexing')
         mux.add_argument('--filter-out', nargs='*', default=[],
@@ -150,11 +144,6 @@ class Run(CLICmd):
                          "final multiplex tree.")
 
     def _activate(self, args):
-        # Merge the multiplex
-        multiplex_files = getattr(args, "multiplex", None)
-        if multiplex_files:
-            args.mux.data_merge(multiplexer.yaml2tree(multiplex_files))
-
         # Extend default multiplex tree of --mux-inject values
         for value in getattr(args, "mux_inject", []):
             value = value.split(':', 3)

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -132,22 +132,23 @@ class Run(CLICmd):
 
         loader.add_loader_options(parser)
 
+        mux = parser.add_argument_group('test parameters')
         if multiplexer.MULTIPLEX_CAPABLE:
-            mux = parser.add_argument_group('test parameters')
-            mux.add_argument('-m', '--multiplex', nargs='*', dest='multiplex_files',
+            mux.add_argument('-m', '--multiplex', nargs='*',
+                             dest='multiplex_files',
                              default=None, metavar='FILE',
-                             help='Location of one or more Avocado multiplex (.yaml) '
-                             'FILE(s) (order dependent)')
-            mux.add_argument('--filter-only', nargs='*', default=[],
-                             help='Filter only path(s) from multiplexing')
-            mux.add_argument('--filter-out', nargs='*', default=[],
-                             help='Filter out path(s) from multiplexing')
-            mux.add_argument('--mux-path', nargs='*', default=None,
-                             help="List of paths used to determine path "
-                             "priority when querying for parameters")
-            mux.add_argument('--mux-inject', default=[], nargs='*',
-                             help="Inject [path:]key:node values into the "
-                             "final multiplex tree.")
+                             help='Location of one or more Avocado multiplex '
+                             '(.yaml) FILE(s) (order dependent)')
+        mux.add_argument('--filter-only', nargs='*', default=[],
+                         help='Filter only path(s) from multiplexing')
+        mux.add_argument('--filter-out', nargs='*', default=[],
+                         help='Filter out path(s) from multiplexing')
+        mux.add_argument('--mux-path', nargs='*', default=None,
+                         help="List of paths used to determine path "
+                         "priority when querying for parameters")
+        mux.add_argument('--mux-inject', default=[], nargs='*',
+                         help="Inject [path:]key:node values into the "
+                         "final multiplex tree.")
 
     def _activate(self, args):
         # Extend default multiplex tree of --mux_inject values

--- a/avocado/plugins/yaml_to_mux.py
+++ b/avocado/plugins/yaml_to_mux.py
@@ -1,0 +1,250 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2016
+# Author: Lukas Doktor <ldoktor@redhat.com>
+"""Multiplexer plugin to parse yaml files to params"""
+
+from avocado.core import tree, exit_codes
+from avocado.core.plugin_interfaces import CLI
+import os
+import re
+import sys
+
+
+try:
+    import yaml
+except ImportError:
+    MULTIPLEX_CAPABLE = False
+else:
+    MULTIPLEX_CAPABLE = True
+    try:
+        from yaml import CLoader as Loader
+    except ImportError:
+        from yaml import Loader
+
+
+# Mapping for yaml flags
+YAML_INCLUDE = 100
+YAML_USING = 101
+YAML_REMOVE_NODE = tree.REMOVE_NODE
+YAML_REMOVE_VALUE = tree.REMOVE_VALUE
+YAML_MUX = 102
+
+__RE_FILE_SPLIT = re.compile(r'(?<!\\):')   # split by ':' but not '\\:'
+__RE_FILE_SUBS = re.compile(r'(?<!\\)\\:')  # substitute '\\:' but not '\\\\:'
+
+
+class Value(tuple):     # Few methods pylint: disable=R0903
+
+    """ Used to mark values to simplify checking for node vs. value """
+    pass
+
+
+class ListOfNodeObjects(list):     # Few methods pylint: disable=R0903
+
+    """
+    Used to mark list as list of objects from whose node is going to be created
+    """
+    pass
+
+
+def _create_from_yaml(path, cls_node=tree.TreeNode):
+    """ Create tree structure from yaml stream """
+    def tree_node_from_values(name, values):
+        """ Create `name` node and add values  """
+        node = cls_node(str(name))
+        using = ''
+        for value in values:
+            if isinstance(value, tree.TreeNode):
+                node.add_child(value)
+            elif isinstance(value[0], tree.Control):
+                if value[0].code == YAML_INCLUDE:
+                    # Include file
+                    ypath = value[1]
+                    if not os.path.isabs(ypath):
+                        ypath = os.path.join(os.path.dirname(path), ypath)
+                    if not os.path.exists(ypath):
+                        raise ValueError("File '%s' included from '%s' does not "
+                                         "exist." % (ypath, path))
+                    node.merge(_create_from_yaml('/:' + ypath, cls_node))
+                elif value[0].code == YAML_USING:
+                    if using:
+                        raise ValueError("!using can be used only once per "
+                                         "node! (%s:%s)" % (path, name))
+                    using = value[1]
+                    if using[0] == '/':
+                        using = using[1:]
+                    if using[-1] == '/':
+                        using = using[:-1]
+                elif value[0].code == YAML_REMOVE_NODE:
+                    value[0].value = value[1]   # set the name
+                    node.ctrl.append(value[0])    # add "blue pill" of death
+                elif value[0].code == YAML_REMOVE_VALUE:
+                    value[0].value = value[1]   # set the name
+                    node.ctrl.append(value[0])
+                elif value[0].code == YAML_MUX:
+                    node.multiplex = True
+            else:
+                node.value[value[0]] = value[1]
+        if using:
+            if name is not '':
+                for name in using.split('/')[::-1]:
+                    node = cls_node(name, children=[node])
+            else:
+                using = using.split('/')[::-1]
+                node.name = using.pop()
+                while True:
+                    if not using:
+                        break
+                    name = using.pop()  # 'using' is list pylint: disable=E1101
+                    node = cls_node(name, children=[node])
+                node = cls_node('', children=[node])
+        return node
+
+    def mapping_to_tree_loader(loader, node):
+        """ Maps yaml mapping tag to TreeNode structure """
+        _value = loader.construct_pairs(node)
+        objects = ListOfNodeObjects()
+        for name, values in _value:
+            if isinstance(values, ListOfNodeObjects):   # New node from list
+                objects.append(tree_node_from_values(name, values))
+            elif values is None:            # Empty node
+                objects.append(cls_node(str(name)))
+            else:                           # Values
+                objects.append(Value((name, values)))
+        return objects
+
+    def mux_loader(loader, obj):
+        """
+        Special !mux loader which allows to tag node as 'multiplex = True'.
+        """
+        if not isinstance(obj, yaml.ScalarNode):
+            objects = mapping_to_tree_loader(loader, obj)
+        else:   # This means it's empty node. Don't call mapping_to_tree_loader
+            objects = ListOfNodeObjects()
+        objects.append((tree.Control(YAML_MUX), None))
+        return objects
+
+    Loader.add_constructor(u'!include',
+                           lambda loader, node: tree.Control(YAML_INCLUDE))
+    Loader.add_constructor(u'!using',
+                           lambda loader, node: tree.Control(YAML_USING))
+    Loader.add_constructor(u'!remove_node',
+                           lambda loader, node: tree.Control(YAML_REMOVE_NODE))
+    Loader.add_constructor(u'!remove_value',
+                           lambda loader, node: tree.Control(YAML_REMOVE_VALUE))
+    Loader.add_constructor(u'!mux', mux_loader)
+    Loader.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+                           mapping_to_tree_loader)
+
+    # Parse file name ([$using:]$path)
+    path = __RE_FILE_SPLIT.split(path, 1)
+    if len(path) == 1:
+        path = __RE_FILE_SUBS.sub(':', path[0])
+        using = ["run"]
+    else:
+        nodes = __RE_FILE_SUBS.sub(':', path[0]).strip('/').split('/')
+        using = [node for node in nodes if node]
+        if not path[0].startswith('/'):  # relative path, put into /run
+            using.insert(0, 'run')
+        path = __RE_FILE_SUBS.sub(':', path[1])
+
+    # Load the tree
+    with open(path) as stream:
+        loaded_tree = yaml.load(stream, Loader)
+        loaded_tree = tree_node_from_values('', loaded_tree)
+
+    # Add prefix
+    if using:
+        loaded_tree.name = using.pop()
+        while True:
+            if not using:
+                break
+            loaded_tree = cls_node(using.pop(), children=[loaded_tree])
+        loaded_tree = cls_node('', children=[loaded_tree])
+    return loaded_tree
+
+
+def create_from_yaml(paths, debug=False):
+    """
+    Create tree structure from yaml-like file
+    :param fileobj: File object to be processed
+    :raise SyntaxError: When yaml-file is corrupted
+    :return: Root of the created tree structure
+    """
+    def _merge(data, path):
+        """ Normal run """
+        data.merge(_create_from_yaml(path))
+
+    def _merge_debug(data, path):
+        """ Use NamedTreeNodeDebug magic """
+        node_cls = tree.get_named_tree_cls(path)
+        data.merge(_create_from_yaml(path, node_cls))
+
+    if not debug:
+        data = tree.TreeNode()
+        merge = _merge
+    else:
+        data = tree.TreeNodeDebug()
+        merge = _merge_debug
+
+    path = None
+    try:
+        for path in paths:
+            merge(data, path)
+    # Yaml can raise IndexError on some files
+    except (yaml.YAMLError, IndexError) as details:
+        if 'mapping values are not allowed in this context' in str(details):
+            details = ("%s\nMake sure !tags and colons are separated by a "
+                       "space (eg. !include :)" % details)
+        msg = "Invalid multiplex file '%s': %s" % (path, details)
+        raise IOError(2, msg, path)
+    return data
+
+
+class YamlToMux(CLI):
+
+    """
+    Registers callback to inject params from yaml file to the
+    default_avocado_params
+    """
+
+    name = 'yaml_to_mux'
+    description = "YamlToMux options for the 'run' subcommand"
+
+    def configure(self, parser):
+        """
+        Configures "run" and "multiplex" subparsers
+        """
+        if not MULTIPLEX_CAPABLE:
+            return
+        for name in ("run", "multiplex"):
+            subparser = parser.subcommands.choices.get(name, None)
+            if subparser is None:
+                continue
+            mux = subparser.add_argument_group("yaml to mux options")
+            mux.add_argument("-m", "--multiplex", nargs='*', dest="multiplex",
+                             default=None, metavar="FILE",
+                             help="Location of one or more Avocado multiplex "
+                             "(.yaml) FILE(s) (order dependent)")
+
+    def run(self, args):
+        # Merge the multiplex
+        multiplex_files = getattr(args, "multiplex", None)
+        if multiplex_files:
+            debug = getattr(args, "mux_debug", False)
+            try:
+                args.mux.data_merge(create_from_yaml(multiplex_files, debug))
+            except IOError as details:
+                import logging
+                logging.getLogger("avocado.app").error(details.strerror)
+                sys.exit(exit_codes.AVOCADO_JOB_FAIL)

--- a/selftests/functional/test_multiplex.py
+++ b/selftests/functional/test_multiplex.py
@@ -43,18 +43,18 @@ class MultiplexTests(unittest.TestCase):
         return result
 
     def test_mplex_plugin(self):
-        cmd_line = './scripts/avocado multiplex examples/tests/sleeptest.py.data/sleeptest.yaml'
+        cmd_line = './scripts/avocado multiplex -m examples/tests/sleeptest.py.data/sleeptest.yaml'
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.run_and_check(cmd_line, expected_rc)
 
     def test_mplex_plugin_nonexistent(self):
-        cmd_line = './scripts/avocado multiplex nonexist'
+        cmd_line = './scripts/avocado multiplex -m nonexist'
         expected_rc = exit_codes.AVOCADO_JOB_FAIL
         result = self.run_and_check(cmd_line, expected_rc)
         self.assertIn('No such file or directory', result.stderr)
 
     def test_mplex_debug(self):
-        cmd_line = ('./scripts/avocado multiplex -c -d '
+        cmd_line = ('./scripts/avocado multiplex -c -d -m '
                     '/:examples/mux-selftest.yaml '
                     '/:examples/mux-environment.yaml '
                     '/:examples/mux-selftest.yaml '

--- a/selftests/unit/test_multiplexer.py
+++ b/selftests/unit/test_multiplexer.py
@@ -4,6 +4,7 @@ import sys
 
 from avocado.core import multiplexer
 from avocado.core import tree
+from avocado.plugins import yaml_to_mux
 
 if sys.version_info[:2] == (2, 6):
     import unittest2 as unittest
@@ -29,23 +30,19 @@ class TestMultiplex(unittest.TestCase):
                                                'examples/mux-selftest.yaml'])
         self.mux_full = tuple(multiplexer.MuxTree(self.mux_tree))
 
-    @unittest.skipIf(not tree.MULTIPLEX_CAPABLE, "Not multiplex capable")
     def test_empty(self):
         act = tuple(multiplexer.MuxTree(tree.TreeNode()))
         self.assertEqual(act, (['', ],))
 
-    @unittest.skipIf(not tree.MULTIPLEX_CAPABLE, "Not multiplex capable")
     def test_partial(self):
         exp = (['intel', 'scsi'], ['intel', 'virtio'], ['amd', 'scsi'],
                ['amd', 'virtio'], ['arm', 'scsi'], ['arm', 'virtio'])
         act = tuple(multiplexer.MuxTree(self.mux_tree.children[0]))
         self.assertEqual(act, exp)
 
-    @unittest.skipIf(not tree.MULTIPLEX_CAPABLE, "Not multiplex capable")
     def test_full(self):
         self.assertEqual(len(self.mux_full), 12)
 
-    @unittest.skipIf(not tree.MULTIPLEX_CAPABLE, "Not multiplex capable")
     def test_create_variants(self):
         from_file = multiplexer.yaml2tree(
             ["/:" + PATH_PREFIX + 'examples/mux-selftest.yaml'])
@@ -53,7 +50,7 @@ class TestMultiplex(unittest.TestCase):
         self.assertEqual(self.mux_full, tuple(from_file))
 
     # Filters are tested in tree_unittests, only verify `multiplex_yamls` calls
-    @unittest.skipIf(not tree.MULTIPLEX_CAPABLE, "Not multiplex capable")
+    @unittest.skipIf(not yaml_to_mux.MULTIPLEX_CAPABLE, "Not multiplex capable")
     def test_filter_only(self):
         exp = (['intel', 'scsi'], ['intel', 'virtio'])
         act = multiplexer.yaml2tree(["/:" + PATH_PREFIX +
@@ -64,7 +61,7 @@ class TestMultiplex(unittest.TestCase):
         act = tuple(multiplexer.MuxTree(act))
         self.assertEqual(act, exp)
 
-    @unittest.skipIf(not tree.MULTIPLEX_CAPABLE, "Not multiplex capable")
+    @unittest.skipIf(not yaml_to_mux.MULTIPLEX_CAPABLE, "Not multiplex capable")
     def test_filter_out(self):
         act = multiplexer.yaml2tree(["/:" + PATH_PREFIX +
                                      'examples/mux-selftest.yaml'],
@@ -95,13 +92,13 @@ class TestAvocadoParams(unittest.TestCase):
         self.params2 = multiplexer.AvocadoParams(self.yamls.next(), 'Unittest2',
                                                  ['/ch1/*', '/ch0/*'], {})
 
-    @unittest.skipIf(not tree.MULTIPLEX_CAPABLE, "Not multiplex capable")
+    @unittest.skipIf(not yaml_to_mux.MULTIPLEX_CAPABLE, "Not multiplex capable")
     def test_pickle(self):
         params = pickle.dumps(self.params1, 2)  # protocol == 2
         params = pickle.loads(params)
         self.assertEqual(self.params1, params)
 
-    @unittest.skipIf(not tree.MULTIPLEX_CAPABLE, "Not multiplex capable")
+    @unittest.skipIf(not yaml_to_mux.MULTIPLEX_CAPABLE, "Not multiplex capable")
     def test_basic(self):
         self.assertEqual(self.params1, self.params1)
         self.assertNotEqual(self.params1, self.params2)
@@ -110,7 +107,7 @@ class TestAvocadoParams(unittest.TestCase):
         str(multiplexer.AvocadoParams([], 'Unittest', [], {}))
         self.assertEqual(15, sum([1 for _ in self.params1.iteritems()]))
 
-    @unittest.skipIf(not tree.MULTIPLEX_CAPABLE, "Not multiplex capable")
+    @unittest.skipIf(not yaml_to_mux.MULTIPLEX_CAPABLE, "Not multiplex capable")
     def test_unhashable(self):
         """ Verifies that unhashable arguments can be passed to params.get """
         self.assertEqual(self.params1.get("root", "/ch0/", ["foo"]), ["foo"])
@@ -118,7 +115,7 @@ class TestAvocadoParams(unittest.TestCase):
                                           '/ch0/ch0.1/ch0.1.1/ch0.1.1.1/',
                                           ['bar']), 'unique1')
 
-    @unittest.skipIf(not tree.MULTIPLEX_CAPABLE, "Not multiplex capable")
+    @unittest.skipIf(not yaml_to_mux.MULTIPLEX_CAPABLE, "Not multiplex capable")
     def test_get_abs_path(self):
         # /ch0/ is not leaf thus it's not queryable
         self.assertEqual(self.params1.get('root', '/ch0/', 'bbb'), 'bbb')
@@ -140,7 +137,7 @@ class TestAvocadoParams(unittest.TestCase):
                                           '/ch0/ch0.1/ch0.1.1/ch0.1.1.1/',
                                           'hhh'), 'hhh')
 
-    @unittest.skipIf(not tree.MULTIPLEX_CAPABLE, "Not multiplex capable")
+    @unittest.skipIf(not yaml_to_mux.MULTIPLEX_CAPABLE, "Not multiplex capable")
     def test_get_greedy_path(self):
         self.assertEqual(self.params1.get('unique1', '/*/*/*/ch0.1.1.1/',
                                           111), 'unique1')
@@ -164,7 +161,7 @@ class TestAvocadoParams(unittest.TestCase):
         # path matches nothing
         self.assertEqual(self.params1.get('root', '', 999), 999)
 
-    @unittest.skipIf(not tree.MULTIPLEX_CAPABLE, "Not multiplex capable")
+    @unittest.skipIf(not yaml_to_mux.MULTIPLEX_CAPABLE, "Not multiplex capable")
     def test_get_rel_path(self):
         self.assertEqual(self.params1.get('root', default='iii'), 'root')
         self.assertEqual(self.params1.get('unique1', '*', 'jjj'), 'unique1')
@@ -179,7 +176,7 @@ class TestAvocadoParams(unittest.TestCase):
         self.assertEqual(self.params2.get('unique1', '*/ch0.1.1.1/', 'ooo'),
                          'ooo')
 
-    @unittest.skipIf(not tree.MULTIPLEX_CAPABLE, "Not multiplex capable")
+    @unittest.skipIf(not yaml_to_mux.MULTIPLEX_CAPABLE, "Not multiplex capable")
     def test_get_clashes(self):
         # One inherited, the other is new
         self.assertRaisesRegexp(ValueError, r"'clash1'.* \['/ch0/ch0.1/ch0.1.1"

--- a/selftests/unit/test_remote.py
+++ b/selftests/unit/test_remote.py
@@ -38,7 +38,7 @@ class RemoteTestRunnerTest(unittest.TestCase):
                         remote_no_copy=False,
                         remote_timeout=60,
                         show_job_log=False,
-                        multiplex_files=['foo.yaml', 'bar/baz.yaml'],
+                        multiplex=['foo.yaml', 'bar/baz.yaml'],
                         dry_run=True,
                         env_keep=None)
         log = flexmock()
@@ -113,7 +113,7 @@ _=/usr/bin/env''', exit_status=0)
         Results = flexmock(remote=Remote, urls=['sleeptest'],
                            stream=stream, timeout=None,
                            args=flexmock(show_job_log=False,
-                                         multiplex_files=['foo.yaml', 'bar/baz.yaml'],
+                                         multiplex=['foo.yaml', 'bar/baz.yaml'],
                                          dry_run=True))
         Results.should_receive('start_tests').once().ordered()
         args = {'status': u'PASS', 'whiteboard': '', 'time_start': 0,

--- a/setup.py
+++ b/setup.py
@@ -129,6 +129,7 @@ if __name__ == '__main__':
                   'tap = avocado.plugins.tap:TAP',
                   'vm = avocado.plugins.vm:VM',
                   'docker = avocado.plugins.docker:Docker',
+                  'yaml_to_mux = avocado.plugins.yaml_to_mux:YamlToMux',
                   ],
               'avocado.plugins.cli.cmd': [
                   'config = avocado.plugins.config:Config',


### PR DESCRIPTION
This rather complex pull request defines public `Mux` API, which should be accessible to plugins to allow extending of the avocado params. Basically avocado now contains `args.mux` object, which is an instance of `avocado.core.multiplexer.Mux` class. This class allows several interaction like `data_inject` or `data_merge` (for plugin writers) and `parse`, `itertests` and `get_number_of_tests` (to allow variants generation).

Currently this is still work in progress. I think the `multiplexer` should be renamed to `mux` to distinguish between the parametrisation API vs. yaml parser. Also the selftests need polishing and there might be some issues I did not addressed yet.

Tomorrow I'm on a vacation so the purpose of this PR is to let you know what I'd been working on and to see your brief opinion about the direction (no need for proper reviews, but feel free to comment about the basic approach).