### PR TITLE
Plugins: add support for optional plugins dir and related Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,10 @@ clean:
 	rm -rf docs/build
 	find docs/source/api/ -name '*.rst' -delete
 	for MAKEFILE in $(AVOCADO_PLUGINS); do\
-		if test -f $$MAKEFILE/Makefile; then AVOCADO_DIRNAME=$(AVOCADO_DIRNAME) make -C $$MAKEFILE unlink &>/dev/null && echo ">> UNLINK $$MAKEFILE" || echo ">> SKIP $$MAKEFILE"; fi;\
+		if test -f $$MAKEFILE/Makefile -o -f $$MAKEFILE/setup.py; then echo ">> UNLINK $$MAKEFILE";\
+			if test -f $$MAKEFILE/Makefile; then AVOCADO_DIRNAME=$(AVOCADO_DIRNAME) make -C $$MAKEFILE unlink &>/dev/null;\
+			elif test -f $$MAKEFILE/setup.py; then cd $$MAKEFILE; $(PYTHON) setup.py develop --uninstall $(shell $(PYTHON26) || echo --user); cd -; fi;\
+		else echo ">> SKIP $$MAKEFILE"; fi;\
 	done
 	$(PYTHON) setup.py develop --uninstall $(shell $(PYTHON26) || echo --user)
 	rm -rf avocado.egg-info
@@ -152,7 +155,10 @@ develop:
 
 link: develop
 	for MAKEFILE in $(AVOCADO_PLUGINS); do\
-		if test -f $$MAKEFILE/Makefile; then AVOCADO_DIRNAME=$(AVOCADO_DIRNAME) make -C $$MAKEFILE link &>/dev/null && echo ">> LINK $$MAKEFILE" || echo ">> SKIP $$MAKEFILE"; fi;\
+		if test -f $$MAKEFILE/Makefile -o -f $$MAKEFILE/setup.py; then echo ">> LINK $$MAKEFILE";\
+			if test -f $$MAKEFILE/Makefile; then AVOCADO_DIRNAME=$(AVOCADO_DIRNAME) make -C $$MAKEFILE link &>/dev/null;\
+			elif test -f $$MAKEFILE/setup.py; then cd $$MAKEFILE; $(PYTHON) setup.py develop $(shell $(PYTHON26) || echo --user); cd -; fi;\
+		else echo ">> SKIP $$MAKEFILE"; fi;\
 	done
 
 spell:

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ VERSION=$(shell $(PYTHON) setup.py --version 2>/dev/null)
 DESTDIR=/
 AVOCADO_DIRNAME=$(shell echo $${PWD\#\#*/})
 AVOCADO_PLUGINS=$(filter-out ../$(AVOCADO_DIRNAME), $(shell find ../ -maxdepth 1 -mindepth 1 -type d))
+AVOCADO_PLUGINS+=$(shell find ./optional_plugins -maxdepth 1 -mindepth 1 -type d)
 RELEASE_COMMIT=$(shell git log --pretty=format:'%H' -n 1 $(VERSION))
 RELEASE_SHORT_COMMIT=$(shell git log --pretty=format:'%h' -n 1 $(VERSION))
 COMMIT=$(shell git log --pretty=format:'%H' -n 1)

--- a/examples/plugins/job-pre-post/mail/avocado_job_mail.py
+++ b/examples/plugins/job-pre-post/mail/avocado_job_mail.py
@@ -3,7 +3,7 @@ import smtplib
 from email.mime.text import MIMEText
 
 from avocado.core.settings import settings
-from avocado.plugins.base import JobPre, JobPost
+from avocado.core.plugin_interfaces import JobPre, JobPost
 
 
 class Mail(JobPre, JobPost):

--- a/examples/plugins/job-pre-post/sleep/avocado_job_sleep.py
+++ b/examples/plugins/job-pre-post/sleep/avocado_job_sleep.py
@@ -2,7 +2,7 @@ import time
 import logging
 
 from avocado.core.settings import settings
-from avocado.plugins.base import JobPre, JobPost
+from avocado.core.plugin_interfaces import JobPre, JobPost
 
 
 class Sleep(JobPre, JobPost):

--- a/optional_plugins/README.rst
+++ b/optional_plugins/README.rst
@@ -1,0 +1,26 @@
+==================
+ Optional Plugins
+==================
+
+This is where plugins shipped with Avocado, but not considered core
+functionality can be found.
+
+To try them out on a development environment, you may run::
+
+ $ cd <plugin-dir>/
+ $ python setup.py develop --user
+
+And to remove them on a development environment, you may run, at the
+same directory::
+
+ $ python setup.py develop --uninstall --user
+
+Also, on a development environment, the following command on the
+topmost Avocado source code directory will enable all optional
+plugins::
+
+ $ make link
+
+And this will disable all optional plugins::
+
+ $ make unlink


### PR DESCRIPTION
This adds support for optional plugins dir and related Makefile targets.  The first candidate for this `optional_plugins` dir is the HTML result plugin, but I decided to send this separately so that it can be more easily reviewed and tested.

To test it, I suggest to copy `examples/plugins/job-pre-post/sleep` to the `optional_plugins` dir and run `make link`.  After that, running any job should have the plugin activated.

To clean up, run `make clean` (and then remove the copied `sleep` dir).