### PR TITLE
avocado.core.sysinfo: Force LANG for sysinfo collection

### DIFF
--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -151,6 +151,9 @@ class Command(Collectible):
         env = os.environ.copy()
         if "PATH" not in env:
             env["PATH"] = "/usr/bin:/bin"
+        lang = settings.get_value("sysinfo.collect", "lang", str, None)
+        if lang:
+            env["LANG"] = lang
         logf_path = os.path.join(logdir, self.logf)
         stdin = open(os.devnull, "r")
         stdout = open(logf_path, "w")
@@ -185,6 +188,9 @@ class Daemon(Command):
         env = os.environ.copy()
         if "PATH" not in env:
             env["PATH"] = "/usr/bin:/bin"
+        lang = settings.get_value("sysinfo.collect", "lang", str, None)
+        if lang:
+            env["LANG"] = lang
         logf_path = os.path.join(logdir, self.logf)
         stdin = open(os.devnull, "r")
         stdout = open(logf_path, "w")

--- a/etc/avocado/avocado.conf
+++ b/etc/avocado/avocado.conf
@@ -19,6 +19,8 @@ enabled = True
 installed_packages = False
 # Whether to run certain commands in bg to give extra job debug information
 profiler = False
+# Force LANG for sysinfo collection
+lang = C
 
 [sysinfo.collectibles]
 # File with list of commands that will be executed and have their output collected


### PR DESCRIPTION
This commit allows setting custom LANG for sysinfo collection to
simplify `avocado diff` comparison between different machines. One can
disable this by setting no/empty value.

Trello: https://trello.com/c/3uE5GTq9/800-use-lc-all-c-for-sysinfo-gathering-by-default