### PR TITLE
added a function which uses "process.run"[v2]

### DIFF
--- a/avocado/utils/build.py
+++ b/avocado/utils/build.py
@@ -18,7 +18,9 @@ import os
 from . import process
 
 
-def make(path, make='make', env=None, extra_args='', ignore_status=False, allow_output_check='none'):
+def make(path, make='make', env=None, extra_args='', ignore_status=False,
+         allow_output_check='none'):
+
     """
     Run make, adding MAKEOPTS to the list of options.
 

--- a/avocado/utils/build.py
+++ b/avocado/utils/build.py
@@ -10,7 +10,9 @@
 # See LICENSE for more details.
 #
 # Copyright: Red Hat Inc. 2013-2014
+#          : IBM 2016
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+#       : Praveen K Pandey <praveen@linux.vnet.ibm.com>
 
 import multiprocessing
 import os
@@ -18,9 +20,8 @@ import os
 from . import process
 
 
-def make(path, make='make', env=None, extra_args='', ignore_status=False,
-         allow_output_check='none'):
-
+def run_make(path, make='make', env=None, extra_args='', ignore_status=False,
+             allow_output_check='none'):
     """
     Run make, adding MAKEOPTS to the list of options.
 
@@ -58,9 +59,37 @@ def make(path, make='make', env=None, extra_args='', ignore_status=False,
         cmd += ' %s' % makeopts
     if extra_args:
         cmd += ' %s' % extra_args
-    make_process = process.system(cmd,
-                                  env=env,
-                                  ignore_status=ignore_status,
-                                  allow_output_check=allow_output_check)
+    make_process = process.run(cmd,
+                               env=env,
+                               ignore_status=ignore_status,
+                               allow_output_check=allow_output_check)
     os.chdir(cwd)
     return make_process
+
+
+def make(path, make='make', env=None, extra_arg='', ig_status=False,
+         allow_out_check='none'):
+    """
+    Run make, adding MAKEOPTS to the list of options.
+
+    :param make: what make command name to use.
+    :param env: dictionary with environment variables to be set before
+                calling make (e.g.: CFLAGS).
+    :param extra: extra command line arguments to pass to make.
+    :param allow_out_check: Whether to log the command stream outputs
+                               (stdout and stderr) of the make process in
+                               the test stream files. Valid values: 'stdout',
+                               for allowing only standard output, 'stderr',
+                               to allow only standard error, 'all',
+                               to allow both standard output and error,
+                               and 'none', to allow none to be
+                               recorded (default). The default here is
+                               'none', because usually we don't want
+                               to use the compilation output as a reference
+                               in tests.
+    :type allow_out_check: str
+    """
+
+    status = run_make(path, make, env, extra_arg, ig_status, allow_out_check)
+
+    return status.exit_status


### PR DESCRIPTION
1- fix style compatible to pep8 standard
2-rename make to run_make which using process.run