### PR TITLE
added a function which uses "process.run"[v3] 

### DIFF
--- a/avocado/utils/build.py
+++ b/avocado/utils/build.py
@@ -18,7 +18,9 @@ import os
 from . import process
 
 
-def make(path, make='make', env=None, extra_args='', ignore_status=False, allow_output_check='none'):
+def make(path, make='make', env=None, extra_args='', ignore_status=False,
+         allow_output_check='none'):
+
     """
     Run make, adding MAKEOPTS to the list of options.
 

--- a/avocado/utils/build.py
+++ b/avocado/utils/build.py
@@ -18,9 +18,8 @@ import os
 from . import process
 
 
-def make(path, make='make', env=None, extra_args='', ignore_status=False,
-         allow_output_check='none'):
-
+def run_make(path, make='make', env=None, extra_args='', ignore_status=False,
+             allow_output_check='none'):
     """
     Run make, adding MAKEOPTS to the list of options.
 
@@ -40,6 +39,7 @@ def make(path, make='make', env=None, extra_args='', ignore_status=False,
                                to use the compilation output as a reference
                                in tests.
     :type allow_output_check: str
+    :returns: result of the make process
     """
     cwd = os.getcwd()
     os.chdir(path)
@@ -58,9 +58,39 @@ def make(path, make='make', env=None, extra_args='', ignore_status=False,
         cmd += ' %s' % makeopts
     if extra_args:
         cmd += ' %s' % extra_args
-    make_process = process.system(cmd,
-                                  env=env,
-                                  ignore_status=ignore_status,
-                                  allow_output_check=allow_output_check)
+    make_process = process.run(cmd,
+                               env=env,
+                               ignore_status=ignore_status,
+                               allow_output_check=allow_output_check)
     os.chdir(cwd)
     return make_process
+
+
+def make(path, make='make', env=None, extra_args='', ignore_status=False,
+         allow_output_check='none'):
+    """
+    Run make, adding MAKEOPTS to the list of options.
+
+    :param make: what make command name to use.
+    :param env: dictionary with environment variables to be set before
+                calling make (e.g.: CFLAGS).
+    :param extra: extra command line arguments to pass to make.
+    :param allow_output_check: Whether to log the command stream outputs
+                               (stdout and stderr) of the make process in
+                               the test stream files. Valid values: 'stdout',
+                               for allowing only standard output, 'stderr',
+                               to allow only standard error, 'all',
+                               to allow both standard output and error,
+                               and 'none', to allow none to be
+                               recorded (default). The default here is
+                               'none', because usually we don't want
+                               to use the compilation output as a reference
+                               in tests.
+    :type allow_output_check: str
+    :returns: exit status of the make process
+    """
+
+    result = run_make(path, make, env, extra_args, ignore_status,
+                      allow_out_check)
+
+    return result.exit_status


### PR DESCRIPTION
1- fix style compatible to pep8 standard
2- rename make to run_make which using process.run