### PR TITLE
Result plugins: also list them on "plugins" command

### DIFF
--- a/avocado/plugins/jsonresult.py
+++ b/avocado/plugins/jsonresult.py
@@ -30,6 +30,9 @@ UNKNOWN = '<unknown>'
 
 class JSONResult(Result):
 
+    name = 'json'
+    description = 'JSON result support'
+
     def _render(self, result):
         tests = []
         for test in result.tests:

--- a/avocado/plugins/plugins.py
+++ b/avocado/plugins/plugins.py
@@ -46,7 +46,9 @@ class Plugins(CLICmd):
             (dispatcher.CLIDispatcher(),
              'Plugins that add new options to commands (avocado.plugins.cli):'),
             (dispatcher.JobPrePostDispatcher(),
-             'Plugins that run before/after the execution of jobs (avocado.plugins.job.prepost):')
+             'Plugins that run before/after the execution of jobs (avocado.plugins.job.prepost):'),
+            (dispatcher.ResultDispatcher(),
+             'Plugins that generate job result in different formats (avocado.plugins.result):')
         ]
         for plugins_active, msg in plugin_types:
             log.info(msg)

--- a/avocado/plugins/xunit.py
+++ b/avocado/plugins/xunit.py
@@ -27,6 +27,9 @@ from avocado.core.plugin_interfaces import CLI, Result
 
 class XUnitResult(Result):
 
+    name = 'xunit'
+    description = 'XUnit result support'
+
     UNKNOWN = '<unknown>'
     PRINTABLE = string.ascii_letters + string.digits + string.punctuation + '\n\r '
 

--- a/optional_plugins/html/avocado_result_html/__init__.py
+++ b/optional_plugins/html/avocado_result_html/__init__.py
@@ -197,6 +197,9 @@ class HTMLResult(Result):
     HTML Test Result class.
     """
 
+    name = 'html'
+    description = 'HTML result support'
+
     @staticmethod
     def _copy_static_resources(html_path):
         module = 'avocado_result_html'


### PR DESCRIPTION
The "Result" plugin interface was defined a while ago, and we now have
three implementations (JSON, XUnit, HTML).

Let's include them in the plugin listing, that is, when a user calls
`avocado plugins`.

Signed-off-by: Cleber Rosa <crosa@redhat.com>