### PR TITLE
Packaging and installation improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ source-pypi: clean
 	git archive --prefix="avocado-framework/" -o "PYPI_UPLOAD/avocado-framework-$(VERSION).tar.gz" $(VERSION)
 
 pypi: source-pypi develop
-	sed -e 's/Name: avocado/Name: avocado-framework/' avocado.egg-info/PKG-INFO > PYPI_UPLOAD/PKG-INFO
+	cp avocado_framework.egg-info/PKG-INFO PYPI_UPLOAD/PKG-INFO
 	@echo
 	@echo "Please use the files on PYPI_UPLOAD dir to upload a new version to PyPI"
 	@echo "The URL to do that may be a bit tricky to find, so here it is:"

--- a/avocado/core/version.py
+++ b/avocado/core/version.py
@@ -19,7 +19,7 @@ __all__ = ['MAJOR', 'MINOR', 'VERSION']
 import pkg_resources
 
 try:
-    VERSION = pkg_resources.get_distribution("avocado").version
+    VERSION = pkg_resources.get_distribution("avocado-framework").version
 except pkg_resources.DistributionNotFound:
     VERSION = "unknown.unknown"
 

--- a/optional_plugins/html/setup.py
+++ b/optional_plugins/html/setup.py
@@ -23,7 +23,7 @@ setup(name='avocado_result_html',
       url='http://avocado-framework.github.io/',
       packages=find_packages(),
       include_package_data=True,
-      install_requires=['pystache'],
+      install_requires=['avocado-framework', 'pystache'],
       entry_points={
           'avocado.plugins.cli': [
               'html = avocado_result_html:HTML',

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,6 +1,5 @@
 # All pip installable requirements pinned for readthedocs.org
 fabric==1.10.0
-pystache==0.5.4
 requests==1.2.3
 PyYAML==3.11
 Pillow==2.6.1

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,7 +1,5 @@
 # All pip installable requirements pinned for Travis CI
 fabric==1.11.1
-pystache==0.4.1; python_version < '2.7'
-pystache==0.5.4; python_version >= '2.7'
 Sphinx==1.3b1
 flexmock==0.9.7
 inspektor==0.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,6 @@ PyYAML>=3.11
 libvirt-python>=1.2.9
 # .tar.xz support (avocado.utils.archive)
 pyliblzma>=0.5.3
-# HTML report plugin (avocado.core.plugins.htmlresult)
-pystache>=0.5.3
 # REST client (avocado.core.restclient)
 requests>=1.2.3
 # stevedore for loading "new style" plugins

--- a/setup.py
+++ b/setup.py
@@ -149,4 +149,5 @@ if __name__ == '__main__':
               },
           zip_safe=False,
           test_suite='selftests',
-          python_requires='>=2.6')
+          python_requires='>=2.6',
+          install_requires=['stevedore'])

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ def get_long_description():
     return req_contents
 
 if __name__ == '__main__':
-    setup(name='avocado',
+    setup(name='avocado-framework',
           version='40.0',
           description='Avocado Test Framework',
           long_description=get_long_description(),


### PR DESCRIPTION
This collection of patches tries to streamline the installation experience that users will get with the standard Python tools.

In short, we rename the *package* to `avocado-framework`, adjust some optional packages from `requires*.txt` and finally add core requirements to `setup.py` itself.

This should allow any user to install avocado using `pip install avocado-framework` after this is incorporated and a new package is pushed to PyPI.  Until then, the same experience can be tested by running:

```
pip install -e git://github.com/clebergnu/avocado.git@requirements#egg=avocado-framework
```

This can be done, say, in a virtual environment, and the basic avocado functionality should be up and running with this single command.