### PR TITLE
sysinfo improvements

### DIFF
--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -102,6 +102,8 @@ class Logfile(Collectible):
                 shutil.copyfile(self.path, os.path.join(logdir, self.logf))
             except IOError:
                 log.debug("Not logging %s (lack of permissions)", self.path)
+        else:
+            log.debug("Not logging %s (file does not exist)", self.path)
 
 
 class Command(Collectible):

--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -13,6 +13,7 @@
 # Author: John Admanski <jadmanski@google.com>
 
 import gzip
+import json
 import logging
 import os
 import shutil
@@ -211,6 +212,45 @@ class Daemon(Command):
             log.error("Daemon process '%s' (pid %d) terminated abnormally (code %d)",
                       self.cmd, self.pipe.pid, retcode)
         return retcode
+
+
+class JournalctlWatcher(Collectible):
+
+    """
+    Track the content of systemd journal into a compressed file.
+
+    :param logf: Basename of the file where output is logged (optional).
+    """
+
+    def __init__(self, logf=None):
+        if not logf:
+            logf = 'journalctl.gz'
+
+        super(JournalctlWatcher, self).__init__(logf)
+        self.cursor = self._get_cursor()
+
+    def _get_cursor(self):
+        try:
+            cmd = 'journalctl --lines 1 --output json'
+            result = process.system_output(cmd, verbose=False)
+            last_record = json.loads(result)
+            return last_record['__CURSOR']
+        except Exception as e:
+            log.debug("Journalctl collection failed: %s", e)
+
+    def run(self, logdir):
+        if self.cursor:
+            try:
+                cmd = 'journalctl --quiet --after-cursor %s' % self.cursor
+                log_diff = process.system_output(cmd, verbose=False)
+                dstpath = os.path.join(logdir, self.logf)
+                with gzip.GzipFile(dstpath, "w")as out_journalctl:
+                    out_journalctl.write(log_diff)
+            except IOError:
+                log.debug("Not logging journalctl (lack of permissions)",
+                          dstpath)
+            except Exception as e:
+                log.debug("Journalctl collection failed: %s", e)
 
 
 class LogWatcher(Collectible):
@@ -441,6 +481,8 @@ class SysInfo(object):
             self.end_test_collectibles.add(self._get_syslog_watcher())
         except ValueError as details:
             log.info(details)
+
+        self.end_test_collectibles.add(JournalctlWatcher())
 
     def _get_collectibles(self, hook):
         collectibles = self.hook_mapping.get(hook)

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -188,8 +188,10 @@ class Test(unittest.TestCase):
         self._stderr_file = os.path.join(self.logdir, 'stderr')
 
         self.outputdir = utils_path.init_dir(self.logdir, 'data')
-        self.sysinfodir = utils_path.init_dir(self.logdir, 'sysinfo')
-        self.sysinfo_logger = sysinfo.SysInfo(basedir=self.sysinfodir)
+        self.sysinfo_enabled = getattr(self.job, 'sysinfo', False)
+        if self.sysinfo_enabled:
+            self.sysinfodir = utils_path.init_dir(self.logdir, 'sysinfo')
+            self.sysinfo_logger = sysinfo.SysInfo(basedir=self.sysinfodir)
 
         self.log = logging.getLogger("avocado.test")
         original_log_warn = self.log.warning
@@ -418,7 +420,8 @@ class Test(unittest.TestCase):
         """
         testMethod = getattr(self, self._testMethodName)
         self._start_logging()
-        self.sysinfo_logger.start_test_hook()
+        if self.sysinfo_enabled:
+            self.sysinfo_logger.start_test_hook()
         test_exception = None
         cleanup_exception = None
         stdout_check_exception = None
@@ -513,7 +516,8 @@ class Test(unittest.TestCase):
                                       "details.")
 
         self.status = 'PASS'
-        self.sysinfo_logger.end_test_hook()
+        if self.sysinfo_enabled:
+            self.sysinfo_logger.end_test_hook()
 
     def _setup_environment_variables(self):
         os.environ['AVOCADO_VERSION'] = VERSION
@@ -526,7 +530,8 @@ class Test(unittest.TestCase):
         os.environ['AVOCADO_TEST_LOGDIR'] = self.logdir
         os.environ['AVOCADO_TEST_LOGFILE'] = self.logfile
         os.environ['AVOCADO_TEST_OUTPUTDIR'] = self.outputdir
-        os.environ['AVOCADO_TEST_SYSINFODIR'] = self.sysinfodir
+        if self.sysinfo_enabled:
+            os.environ['AVOCADO_TEST_SYSINFODIR'] = self.sysinfodir
 
     def run_avocado(self):
         """

--- a/examples/tests/env_variables.sh
+++ b/examples/tests/env_variables.sh
@@ -9,7 +9,6 @@ echo "Avocado Test srcdir: $AVOCADO_TEST_SRCDIR"
 echo "Avocado Test logdir: $AVOCADO_TEST_LOGDIR"
 echo "Avocado Test logfile: $AVOCADO_TEST_LOGFILE"
 echo "Avocado Test outputdir: $AVOCADO_TEST_OUTPUTDIR"
-echo "Avocado Test sysinfodir: $AVOCADO_TEST_SYSINFODIR"
 echo "Custom variable: $CUSTOM_VARIABLE"
 
 test -d "$AVOCADO_TEST_BASEDIR" -a \
@@ -17,5 +16,4 @@ test -d "$AVOCADO_TEST_BASEDIR" -a \
      -d "$AVOCADO_TEST_SRCDIR" -a \
      -d "$AVOCADO_TEST_LOGDIR" -a \
      -f "$AVOCADO_TEST_LOGFILE" -a \
-     -d "$AVOCADO_TEST_OUTPUTDIR" -a \
-     -d "$AVOCADO_TEST_SYSINFODIR"
+     -d "$AVOCADO_TEST_OUTPUTDIR"

--- a/selftests/functional/test_export_variables.py
+++ b/selftests/functional/test_export_variables.py
@@ -51,7 +51,7 @@ class EnvironmentVariablesTest(unittest.TestCase):
 
     def test_environment_vars(self):
         os.chdir(basedir)
-        cmd_line = './scripts/avocado run --job-results-dir %s --sysinfo=off %s' % (self.tmpdir, self.script.path)
+        cmd_line = './scripts/avocado run --job-results-dir %s --sysinfo=on %s' % (self.tmpdir, self.script.path)
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,

--- a/selftests/unit/test_sysinfo.py
+++ b/selftests/unit/test_sysinfo.py
@@ -85,8 +85,8 @@ class SysinfoTest(unittest.TestCase):
         job_postdir = os.path.join(testdir, 'post')
         self.assertTrue(os.path.isdir(job_postdir))
         # By default, there are no post test files
-        self.assertLess(len(os.listdir(job_postdir)), 2,
-                        "Post dir can contain 0-1 files depending on whether "
+        self.assertLess(len(os.listdir(job_postdir)), 3,
+                        "Post dir can contain 0-2 files depending on whether "
                         "sys messages are obtainable or not:\n%s"
                         % os.listdir(job_postdir))
 


### PR DESCRIPTION
- Print debug information on missing `files`.
- Include a journalctl diff in tests sysinfo results.
- Make tests to respect sysinfo enable/disabled configuration.