### PR TITLE
avocado.core.runner: Disable stdin for tests

### DIFF
--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -293,6 +293,9 @@ class TestRunner(object):
 
         signal.signal(signal.SIGTERM, sigterm_handler)
 
+        # Replace STDIN (0) with the /dev/null's fd
+        os.dup2(sys.stdin.fileno(), 0)
+
         instance = loader.load_test(test_factory)
         if instance.runner_queue is None:
             instance.runner_queue = queue


### PR DESCRIPTION
We already disable stdin by setting sys.stdin for tests, but there is
still way to access it via `os.read(0, ...)`. This patch replaces the
`0` (STDIN) file descriptor with the `/dev/null` file descriptor.

Simple check is:

    avocado run /bin/read

which hangs until data are provided and fails with this patch.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>