### PR TITLE
test: expose local variables on test error

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -453,6 +453,11 @@ class Test(unittest.TestCase):
             if not isinstance(details, Exception):  # Avoid passing nasty exc
                 details = exceptions.TestError("%r: %s" % (details, details))
             test_exception = details
+            stacktrace.log_message('Local variables:', logger='avocado.test')
+            local_vars = inspect.trace()[1][0].f_locals
+            for key, value in local_vars.iteritems():
+                stacktrace.log_message(' -> %s: %s' % (key, value),
+                                       logger='avocado.test')
         finally:
             try:
                 self.tearDown()


### PR DESCRIPTION
When the test fails, it is useful to expose the local variables of the
test function.

Reference: https://trello.com/c/yvhobkqO