### PR TITLE
virt: improve error messages

### DIFF
--- a/avocado/core/remote/runner.py
+++ b/avocado/core/remote/runner.py
@@ -336,11 +336,11 @@ class VMTestRunner(RemoteTestRunner):
         """
         # Super called after VM is found and initialized
         self.job.log.info("DOMAIN     : %s", self.job.args.vm_domain)
-        self.vm = virt.vm_connect(self.job.args.vm_domain,
-                                  self.job.args.vm_hypervisor_uri)
-        if self.vm is None:
-            e_msg = "Could not connect to VM '%s'" % self.job.args.vm_domain
-            raise exceptions.JobError(e_msg)
+        try:
+            self.vm = virt.vm_connect(self.job.args.vm_domain,
+                                      self.job.args.vm_hypervisor_uri)
+        except virt.VirtError as exception:
+            raise exceptions.JobError(exception.message)
         if self.vm.start() is False:
             e_msg = "Could not start VM '%s'" % self.job.args.vm_domain
             raise exceptions.JobError(e_msg)

--- a/avocado/core/virt.py
+++ b/avocado/core/virt.py
@@ -38,6 +38,10 @@ if remoter.REMOTE_CAPABLE is False:
     LOG.info('Virt module is disabled: remote module is disabled')
 
 
+class VirtError(Exception):
+    pass
+
+
 class Hypervisor(object):
 
     """
@@ -351,7 +355,11 @@ def vm_connect(domain_name, hypervisor_uri='qemu:///system'):
     :return: an instance of :class:`VM`
     """
     hyper = Hypervisor(hypervisor_uri)
-    hyper.connect()
+    if hyper.connect() is None:
+        raise VirtError('VirtError: Cannot connect to libvirt.')
+
     dom = hyper.find_domain_by_name(domain_name)
-    vm = VM(hyper, dom)
-    return vm
+    if dom is None:
+        raise VirtError('VirtError: Domain not found.')
+
+    return VM(hyper, dom)


### PR DESCRIPTION
Improve virt module exceptions/messages when it is not able to connect
to libvirt and when the domain is not available.

Reference: https://trello.com/c/Ni1LvaMQ
Signed-off-by: Amador Pahim <apahim@redhat.com>