### PR TITLE
travis: enable plugins in travis ci check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ script:
     - inspekt style
     - ./selftests/cyclical_deps avocado
     - ./selftests/modules_boundaries
-    - python setup.py develop
+    - make link
     - ./selftests/run
     - ./selftests/check_tmp_dirs
     - |


### PR DESCRIPTION
This patch enables all the optional plugins in travis to increate the
test coverage.

Reference: https://trello.com/c/UHdVHzOZ
Signed-off-by: Amador Pahim <apahim@redhat.com>