### PR TITLE
Makefile: Fix the egg cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ clean:
 		else echo ">> SKIP $$MAKEFILE"; fi;\
 	done
 	$(PYTHON) setup.py develop --uninstall $(shell $(PYTHON26) || echo --user)
-	rm -rf avocado.egg-info
+	rm -rf avocado_framework.egg-info
 	rm -rf /var/tmp/avocado*
 	rm -rf /tmp/avocado*
 	find . -name '*.pyc' -delete


### PR DESCRIPTION
The avocado package was renamed in 760d82c91ec to `avocado-framework`,
but the cleanup was left unchanged. This commit fixes it.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>