### PR TITLE
selftests/checkall: skip `.git` directory on inspekt based checks

### DIFF
--- a/selftests/checkall
+++ b/selftests/checkall
@@ -7,11 +7,11 @@ run_rc() {
         GR=1
     fi
 }
-run_rc 'inspekt lint'
+run_rc 'inspekt --exclude=.git lint'
 echo ""
-run_rc 'inspekt indent'
+run_rc 'inspekt --exclude=.git indent'
 echo ""
-run_rc 'inspekt style'
+run_rc 'inspekt --exclude=.git style'
 echo ""
 run_rc 'selftests/modules_boundaries'
 echo ""


### PR DESCRIPTION
`.git` may hold content that ends up being checked by inspektor, such
as the `git-rerere` cache.  This may cause false positives, so let's
skip `.git` completetly from those checks.

Signed-off-by: Cleber Rosa <crosa@redhat.com>