### PR TITLE
docs: Add note about args vs. positional args [v2]

### DIFF
--- a/docs/source/GetStartedGuide.rst
+++ b/docs/source/GetStartedGuide.rst
@@ -138,6 +138,13 @@ expectations, it passed! These are known as `simple tests`, but there is also an
 type of test, which we call `instrumented tests`. See more at :ref:`test-types` or just
 keep reading.
 
+.. note:: Although in most cases running ``avocado run $test1 $test3 ...` is
+          fine, it can lead to argument vs. test name clashes. The safest
+          way to execute tests is ``avocado run --$argument1 --$argument2
+          -- $test1 $test2``. Everything after `--` will be considered
+          positional arguments, therefore test names (in case of
+          ``avocado run``)
+
 Listing tests
 -------------
 


### PR DESCRIPTION
The python's argparse is quite clever and usually evaluates the
positionals and arguments correctly. But with subparsers or weird test
names it might falsely evaluate test name as argument, for example:

    avocado run --my_test
    avocado run passtest.py --show-job-log failtest.py

those will fail as --my_test looks like an invalid option and
--show-job-log is subparser's option not known to the main parser but as
the main parser already filled positionals it evaluates the
`failtest.py` as extra argument.

The most appropriate way to distinguish between args and positional args
is the `--` separator:

    avocado run -- --my_test
    avocado run --show-job-log -- passtest.py failtest.py

v1: https://github.com/avocado-framework/avocado/pull/1479

Changes:

```
v2: Fixed typo therefore
v2: Use plural for args and test names
```