### PR TITLE
avocado.core.test: Always use "test" as methodName in dry-run

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -805,6 +805,8 @@ class SkipTest(Test):
                 super_kwargs[arg] = kwargs[arg]
             elif args:
                 super_kwargs[arg] = args.pop()
+        # The methodName might not exist in SkipTest, make sure it's self.test
+        super_kwargs["methodName"] = "test"
         super(SkipTest, self).__init__(**super_kwargs)
 
     def setUp(self):

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -440,7 +440,7 @@ class RunnerOperationTest(unittest.TestCase):
     def test_dry_run(self):
         os.chdir(basedir)
         cmd = ("./scripts/avocado run --sysinfo=off passtest.py failtest.py "
-               "errortest.py --json - --mux-inject foo:1 bar:2 baz:3 foo:foo:a"
+               "gendata.py --json - --mux-inject foo:1 bar:2 baz:3 foo:foo:a"
                " foo:bar:b foo:baz:c bar:bar:bar --dry-run")
         result = json.loads(process.run(cmd).stdout)
         debuglog = result['debuglog']
@@ -450,8 +450,8 @@ class RunnerOperationTest(unittest.TestCase):
         self.assertIn('/tmp', debuglog)   # Use tmp dir, not default location
         self.assertEqual(result['job_id'], u'0' * 40)
         # Check if all tests were skipped
-        self.assertEqual(result['skip'], 3)
-        for i in xrange(3):
+        self.assertEqual(result['skip'], 4)
+        for i in xrange(4):
             test = result['tests'][i]
             self.assertEqual(test['fail_reason'],
                              u'Test skipped due to --dry-run')
@@ -460,7 +460,7 @@ class RunnerOperationTest(unittest.TestCase):
         # from test.
         for line in ("/:foo ==> 1", "/:baz ==> 3", "/foo:foo ==> a",
                      "/foo:bar ==> b", "/foo:baz ==> c", "/bar:bar ==> bar"):
-            self.assertEqual(log.count(line), 3)
+            self.assertEqual(log.count(line), 4)
 
     def test_invalid_python(self):
         os.chdir(basedir)


### PR DESCRIPTION
The --dry-run replaces the test class with a special one instead. When
the original class used a different but "test" methodName this fails
during __init__ as unittest requires the methodName attribute to exists.
This patch always changes the methodName to "test", which is defined in
the fake dry-run class.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>