### PR TITLE
selftests.checkall: Adjust the behavior and add parallel check [v2]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ script:
             echo
             echo
             git checkout $COMMIT || ERR=$(echo -e "$ERR\nUnable to checkout $(git log -1 --oneline $COMMIT)")
-            make check || ERR=$(echo -e "$ERR\nmake check of $(git log -1 --oneline) failed")
+            SELF_CHECK_CONTINUOUS=y make check || ERR=$(echo -e "$ERR\nmake check of $(git log -1 --oneline) failed")
             make clean
         done
         if [ "$ERR" ]; then

--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ check-long: clean develop check_cyclical modules_boundaries
 	AVOCADO_CHECK_LONG=1 selftests/checkall
 	selftests/check_tmp_dirs
 
-selfcheck: clean check_cyclical modules_boundaries
+selfcheck: clean check_cyclical modules_boundaries develop
 	AVOCADO_SELF_CHECK=1 selftests/checkall
 	selftests/check_tmp_dirs
 

--- a/selftests/checkall
+++ b/selftests/checkall
@@ -1,24 +1,39 @@
 #!/bin/bash
-GR=0
+ERR=()
 run_rc() {
-    echo "Running '$1'"
+    CHECK=$1
+    shift
+    echo -e "\n\e[32mRunning '$1'\e[0m"
     eval $1
     if [ $? != 0 ]; then
-        GR=1
+        echo -e "\e[31m$CHECK FAILED\e[0m"
+        ERR+=("$CHECK")
         [ ! "$SELF_CHECK_CONTINUOUS" ] && exit 1
+    else
+        echo -e "\e[32m$CHECK PASSED\e[0m\n"
     fi
 }
-run_rc 'inspekt --exclude=.git lint'
-echo ""
-run_rc 'inspekt --exclude=.git indent'
-echo ""
-run_rc 'inspekt --exclude=.git style'
-echo ""
-run_rc 'selftests/modules_boundaries'
-echo ""
+run_rc lint 'inspekt --exclude=.git lint'
+run_rc indent 'inspekt --exclude=.git indent'
+run_rc style 'inspekt --exclude=.git style'
+run_rc boundatires 'selftests/modules_boundaries'
 if [ -z "$AVOCADO_SELF_CHECK" ]; then
-    run_rc selftests/run
+    run_rc selftests selftests/run
 else
-    run_rc 'scripts/avocado run `./contrib/scripts/avocado-find-unittests selftests/{unit,functional,doc}/*.py | xargs` --external-runner="/usr/bin/env python -m unittest"'
+    run_rc selftests 'scripts/avocado run `./contrib/scripts/avocado-find-unittests selftests/{unit,functional,doc}/*.py | xargs` --external-runner="/usr/bin/env python -m unittest"'
 fi
-exit ${GR}
+
+if [ "$ERR" ]; then
+    echo -e "\e[31m"
+    echo "Checks:"
+    for CHECK in "${ERR[@]}"; do
+        echo -e " * $CHECK FAILED"
+    done
+    echo -ne "\e[0m"
+else
+    echo -e "\e[32mAll checks PASSED\e[0m"
+fi
+if [ "$ERR" ]; then
+    exit 1
+fi
+exit 0

--- a/selftests/checkall
+++ b/selftests/checkall
@@ -57,7 +57,9 @@ if [ "$AVOCADO_PARALLEL_CHECK" ]; then
 elif [ -z "$AVOCADO_SELF_CHECK" ]; then
     run_rc selftests selftests/run
 else
-    run_rc selftests 'scripts/avocado run `./contrib/scripts/avocado-find-unittests selftests/{unit,functional,doc}/*.py | xargs` --external-runner="/usr/bin/env python -m unittest"'
+    CMD='scripts/avocado run `./contrib/scripts/avocado-find-unittests selftests/{unit,functional,doc}/*.py | xargs` --external-runner="/usr/bin/env python -m unittest"'
+    [ ! $SELF_CHECK_CONTINUOUS ] && CMD+=" --failfast on"
+    run_rc selftests "$CMD"
 fi
 
 if [ "$ERR" ]; then

--- a/selftests/checkall
+++ b/selftests/checkall
@@ -5,6 +5,7 @@ run_rc() {
     eval $1
     if [ $? != 0 ]; then
         GR=1
+        [ ! "$SELF_CHECK_CONTINUOUS" ] && exit 1
     fi
 }
 run_rc 'inspekt --exclude=.git lint'

--- a/selftests/checkall
+++ b/selftests/checkall
@@ -13,11 +13,48 @@ run_rc() {
         echo -e "\e[32m$CHECK PASSED\e[0m\n"
     fi
 }
+
+
+parallel_selftests() {
+    local START=$(date +%s)
+    local ERR=0
+    # Use sort -R to randomize the order as longer tests seems to be likely in the same file
+    local ALL=($(./contrib/scripts/avocado-find-unittests selftests/*/*.py | sort -R))
+    [ ${#ALL[@]} -eq 0 ] && return 0
+    local NO_WORKERS=$(($(cat /proc/cpuinfo | grep -c processor) * 2))
+    local PER_SLICE=$((${#ALL[@]} / $NO_WORKERS))
+    [ $PER_SLICE -eq 0 ] && PER_SLICE=1
+    local PIDS=()
+    local TMPS=()
+    for I in $(seq 0 $PER_SLICE $((${#ALL[@]} - 1))); do
+        TMP=$(mktemp /tmp/avocado_parallel_unittest_output_XXXXXX)
+        TMPS+=("$TMP")
+        python -m unittest ${ALL[@]:$I:$PER_SLICE} &> $TMP &
+        PIDS+=("$!")
+    done
+    for I in $(seq 0 $((${#PIDS[@]} - 1))); do
+        wait ${PIDS[$I]}
+        RET=$?
+        if [ $RET -ne 0 ]; then
+            ERR=1
+            cat ${TMPS[$I]}
+        fi
+        rm ${TMPS[$I]}
+    done
+    echo
+    echo ----------------------------------------------------------------------
+    echo Ran ${#ALL[@]} tests in $(($(date +%s) - START))s
+    return $ERR
+}
+
+
 run_rc lint 'inspekt --exclude=.git lint'
 run_rc indent 'inspekt --exclude=.git indent'
 run_rc style 'inspekt --exclude=.git style'
 run_rc boundatires 'selftests/modules_boundaries'
-if [ -z "$AVOCADO_SELF_CHECK" ]; then
+if [ "$AVOCADO_PARALLEL_CHECK" ]; then
+    run_rc selftests parallel_selftests
+elif [ -z "$AVOCADO_SELF_CHECK" ]; then
     run_rc selftests selftests/run
 else
     run_rc selftests 'scripts/avocado run `./contrib/scripts/avocado-find-unittests selftests/{unit,functional,doc}/*.py | xargs` --external-runner="/usr/bin/env python -m unittest"'

--- a/selftests/checkall
+++ b/selftests/checkall
@@ -19,7 +19,6 @@ echo ""
 if [ -z "$AVOCADO_SELF_CHECK" ]; then
     run_rc selftests/run
 else
-    run_rc 'python setup.py develop --user'
     run_rc 'scripts/avocado run `./contrib/scripts/avocado-find-unittests selftests/{unit,functional,doc}/*.py | xargs` --external-runner="/usr/bin/env python -m unittest"'
 fi
 exit ${GR}

--- a/selftests/run
+++ b/selftests/run
@@ -27,7 +27,7 @@ def test_suite():
     return suite
 
 if __name__ == '__main__':
-    runner = unittest.TextTestRunner()
+    runner = unittest.TextTestRunner(failfast=not os.environ.get("SELF_CHECK_CONTINUOUS"))
     result = runner.run(test_suite())
     if result.failures or result.errors:
         sys.exit(1)


### PR DESCRIPTION
This PR makes the `checkall` fail with the first error, unless `SELF_CHECK_CONTINUOUS` is set, which suits better to `git bisect` usage. While on it I went ahead and add colors and results to the output and last but not least finally the parallel execution support, which I wanted to add for ages (and already deleted my branch, so it's freshly developed today).

Trello: https://trello.com/c/6QAdqKeE/582-make-check-could-fail-fast
v1: https://github.com/avocado-framework/avocado/pull/1485

Changes:

```
v2: New commit to enable fail fast per unittest (and not just per-module)
v2: Rebased
```