### PR TITLE
Handle result plugin failures / HTML result fix with older pystache

### DIFF
--- a/avocado/core/dispatcher.py
+++ b/avocado/core/dispatcher.py
@@ -94,3 +94,17 @@ class ResultDispatcher(Dispatcher):
 
     def __init__(self):
         super(ResultDispatcher, self).__init__('avocado.plugins.result')
+
+    def map_method(self, method_name, result, job):
+        for ext in self.extensions:
+            try:
+                if hasattr(ext.obj, method_name):
+                    method = getattr(ext.obj, method_name)
+                    method(result, job)
+            except SystemExit:
+                raise
+            except KeyboardInterrupt:
+                raise
+            except:
+                job.log.error('Error running method "%s" of plugin "%s": %s',
+                              method_name, ext.name, sys.exc_info()[1])

--- a/avocado/core/dispatcher.py
+++ b/avocado/core/dispatcher.py
@@ -75,7 +75,7 @@ class JobPrePostDispatcher(Dispatcher):
     def __init__(self):
         super(JobPrePostDispatcher, self).__init__('avocado.plugins.job.prepost')
 
-    def map_methods(self, method_name, job):
+    def map_method(self, method_name, job):
         for ext in self.extensions:
             try:
                 if hasattr(ext.obj, method_name):

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -433,7 +433,7 @@ class Job(object):
                 self._remove_job_results()
                 raise exceptions.OptionValidationError(details)
 
-        self.job_pre_post_dispatcher.map_methods('pre', self)
+        self.job_pre_post_dispatcher.map_method('pre', self)
 
         if not self.test_suite:
             self._remove_job_results()
@@ -527,7 +527,7 @@ class Job(object):
             self.exitcode |= exit_codes.AVOCADO_FAIL
             return self.exitcode
         finally:
-            self.job_pre_post_dispatcher.map_methods('post', self)
+            self.job_pre_post_dispatcher.map_method('post', self)
             if not settings.get_value('runner.behavior', 'keep_tmp_files',
                                       key_type=bool, default=False):
                 data_dir.clean_tmp_files()

--- a/optional_plugins/html/avocado_result_html/__init__.py
+++ b/optional_plugins/html/avocado_result_html/__init__.py
@@ -248,8 +248,7 @@ class HTMLResult(Result):
             else:
                 from pystache import view
                 v = view.View(template, context)
-                report_contents = v.render('utf8')  # encodes into ascii
-                report_contents = codecs.decode("utf8")  # decode to unicode
+                report_contents = v.render('utf8')
         except UnicodeDecodeError as details:
             # FIXME: Remove me when UnicodeDecodeError problem is fixed
             import logging


### PR DESCRIPTION
Previously, a crash in one result plugin could abort the execution of other plugins and consequently the last parts of the avocado command line application execution.

Let's handle exceptions that could be raised there, as it's already being done with Job Pre/Post plugins.

Additionally, this bundles the HTML result fix with older pystache versions, since one of the review requests was to improve the handling when unicode conversions occur so that Avocado doesn't crash.