### PR TITLE
Python 2.6 / EL6 fixes [v2]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 #
 
 PYTHON=$(shell which python)
-PYTHON26=$(shell $(PYTHON) -V 2>&1 | grep 2.6 -q && echo true || echo false)
+PYTHON_DEVELOP_ARGS=$(shell if ($(PYTHON) setup.py develop --help 2>/dev/null | grep -q '\-\-user'); then echo "--user"; else echo ""; fi)
 VERSION=$(shell $(PYTHON) setup.py --version 2>/dev/null)
 DESTDIR=/
 AVOCADO_DIRNAME=$(shell echo $${PWD\#\#*/})
@@ -107,10 +107,10 @@ clean:
 	for MAKEFILE in $(AVOCADO_PLUGINS); do\
 		if test -f $$MAKEFILE/Makefile -o -f $$MAKEFILE/setup.py; then echo ">> UNLINK $$MAKEFILE";\
 			if test -f $$MAKEFILE/Makefile; then AVOCADO_DIRNAME=$(AVOCADO_DIRNAME) make -C $$MAKEFILE unlink &>/dev/null;\
-			elif test -f $$MAKEFILE/setup.py; then cd $$MAKEFILE; $(PYTHON) setup.py develop --uninstall $(shell $(PYTHON26) || echo --user); cd -; fi;\
+			elif test -f $$MAKEFILE/setup.py; then cd $$MAKEFILE; $(PYTHON) setup.py develop --uninstall $(PYTHON_DEVELOP_ARGS); cd -; fi;\
 		else echo ">> SKIP $$MAKEFILE"; fi;\
 	done
-	$(PYTHON) setup.py develop --uninstall $(shell $(PYTHON26) || echo --user)
+	$(PYTHON) setup.py develop --uninstall $(PYTHON_DEVELOP_ARGS)
 	rm -rf avocado_framework.egg-info
 	rm -rf /var/tmp/avocado*
 	rm -rf /tmp/avocado*
@@ -153,11 +153,11 @@ modules_boundaries:
 	selftests/modules_boundaries
 
 develop:
-	$(PYTHON) setup.py develop $(shell $(PYTHON26) || echo --user)
+	$(PYTHON) setup.py develop $(PYTHON_DEVELOP_ARGS)
 	for MAKEFILE in $(AVOCADO_OPTIONAL_PLUGINS); do\
 		if test -f $$MAKEFILE/Makefile -o -f $$MAKEFILE/setup.py; then echo ">> LINK $$MAKEFILE";\
 			if test -f $$MAKEFILE/Makefile; then AVOCADO_DIRNAME=$(AVOCADO_DIRNAME) make -C $$MAKEFILE link &>/dev/null;\
-			elif test -f $$MAKEFILE/setup.py; then cd $$MAKEFILE; $(PYTHON) setup.py develop $(shell $(PYTHON26) || echo --user); cd -; fi;\
+			elif test -f $$MAKEFILE/setup.py; then cd $$MAKEFILE; $(PYTHON) setup.py develop $(PYTHON_DEVELOP_ARGS); cd -; fi;\
 		else echo ">> SKIP $$MAKEFILE"; fi;\
 	done
 
@@ -165,7 +165,7 @@ link: develop
 	for MAKEFILE in $(AVOCADO_EXTERNAL_PLUGINS); do\
 		if test -f $$MAKEFILE/Makefile -o -f $$MAKEFILE/setup.py; then echo ">> LINK $$MAKEFILE";\
 			if test -f $$MAKEFILE/Makefile; then AVOCADO_DIRNAME=$(AVOCADO_DIRNAME) make -C $$MAKEFILE link &>/dev/null;\
-			elif test -f $$MAKEFILE/setup.py; then cd $$MAKEFILE; $(PYTHON) setup.py develop $(shell $(PYTHON26) || echo --user); cd -; fi;\
+			elif test -f $$MAKEFILE/setup.py; then cd $$MAKEFILE; $(PYTHON) setup.py develop $(PYTHON_DEVELOP_ARGS); cd -; fi;\
 		else echo ">> SKIP $$MAKEFILE"; fi;\
 	done
 
@@ -176,7 +176,6 @@ man: man/avocado.1 man/avocado-rest-client.1
 
 variables:
 	@echo "PYTHON: $(PYTHON)"
-	@echo "PYTHON26: $(PYTHON26)"
 	@echo "VERSION: $(VERSION)"
 	@echo "DESTDIR: $(DESTDIR)"
 	@echo "AVOCADO_DIRNAME: $(AVOCADO_DIRNAME)"
@@ -186,6 +185,7 @@ variables:
 	@echo "COMMIT: $(COMMIT)"
 	@echo "SHORT_COMMIT: $(SHORT_COMMIT)"
 	@echo "MOCK_CONFIG: $(MOCK_CONFIG)"
+	@echo "PYTHON_DEVELOP_ARGS: $(PYTHON_DEVELOP_ARGS)"
 
 .PHONY: source install clean check link variables
 

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,10 @@ PYTHON26=$(shell $(PYTHON) -V 2>&1 | grep 2.6 -q && echo true || echo false)
 VERSION=$(shell $(PYTHON) setup.py --version 2>/dev/null)
 DESTDIR=/
 AVOCADO_DIRNAME=$(shell echo $${PWD\#\#*/})
-AVOCADO_PLUGINS=$(filter-out ../$(AVOCADO_DIRNAME), $(shell find ../ -maxdepth 1 -mindepth 1 -type d))
-AVOCADO_PLUGINS+=$(shell find ./optional_plugins -maxdepth 1 -mindepth 1 -type d)
+AVOCADO_EXTERNAL_PLUGINS=$(filter-out ../$(AVOCADO_DIRNAME), $(shell find ../ -maxdepth 1 -mindepth 1 -type d))
+AVOCADO_OPTIONAL_PLUGINS=$(shell find ./optional_plugins -maxdepth 1 -mindepth 1 -type d)
+AVOCADO_PLUGINS=$(AVOCADO_EXTERNAL_PLUGINS)
+AVOCADO_PLUGINS+=$(AVOCADO_OPTIONAL_PLUGINS)
 RELEASE_COMMIT=$(shell git log --pretty=format:'%H' -n 1 $(VERSION))
 RELEASE_SHORT_COMMIT=$(shell git log --pretty=format:'%h' -n 1 $(VERSION))
 COMMIT=$(shell git log --pretty=format:'%H' -n 1)
@@ -152,9 +154,15 @@ modules_boundaries:
 
 develop:
 	$(PYTHON) setup.py develop $(shell $(PYTHON26) || echo --user)
+	for MAKEFILE in $(AVOCADO_OPTIONAL_PLUGINS); do\
+		if test -f $$MAKEFILE/Makefile -o -f $$MAKEFILE/setup.py; then echo ">> LINK $$MAKEFILE";\
+			if test -f $$MAKEFILE/Makefile; then AVOCADO_DIRNAME=$(AVOCADO_DIRNAME) make -C $$MAKEFILE link &>/dev/null;\
+			elif test -f $$MAKEFILE/setup.py; then cd $$MAKEFILE; $(PYTHON) setup.py develop $(shell $(PYTHON26) || echo --user); cd -; fi;\
+		else echo ">> SKIP $$MAKEFILE"; fi;\
+	done
 
 link: develop
-	for MAKEFILE in $(AVOCADO_PLUGINS); do\
+	for MAKEFILE in $(AVOCADO_EXTERNAL_PLUGINS); do\
 		if test -f $$MAKEFILE/Makefile -o -f $$MAKEFILE/setup.py; then echo ">> LINK $$MAKEFILE";\
 			if test -f $$MAKEFILE/Makefile; then AVOCADO_DIRNAME=$(AVOCADO_DIRNAME) make -C $$MAKEFILE link &>/dev/null;\
 			elif test -f $$MAKEFILE/setup.py; then cd $$MAKEFILE; $(PYTHON) setup.py develop $(shell $(PYTHON26) || echo --user); cd -; fi;\

--- a/avocado.spec
+++ b/avocado.spec
@@ -7,14 +7,14 @@
 Summary: Avocado Test Framework
 Name: avocado
 Version: 41.0
-Release: 0%{?dist}
+Release: 1%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.github.io/
 Source0: https://github.com/avocado-framework/%{name}/archive/%{commit}/%{name}-%{version}-%{shortcommit}.tar.gz
 BuildArch: noarch
 Requires: python, python-requests, fabric, pyliblzma, libvirt-python, pystache, gdb, gdb-gdbserver, python-stevedore, aexpect
-BuildRequires: python2-devel, python-setuptools, python-docutils, python-mock, python-psutil, python-sphinx, python-requests, aexpect, pystache, yum, python-stevedore, python-lxml, perl-Test-Harness
+BuildRequires: python2-devel, python-setuptools, python-docutils, python-mock, python-psutil, python-sphinx, python-requests, aexpect, pystache, yum, python-stevedore, python-lxml, perl-Test-Harness, fabric, python-flexmock
 
 %if 0%{?el6}
 Requires: PyYAML
@@ -23,11 +23,7 @@ BuildRequires: PyYAML
 BuildRequires: python-argparse, python-importlib, python-logutils, python-unittest2, procps
 %else
 Requires: python-yaml, procps-ng
-BuildRequires: python-yaml, fabric, procps-ng
-%endif
-
-%if !0%{?el7}
-BuildRequires: python-flexmock
+BuildRequires: python-yaml, procps-ng
 %endif
 
 %description
@@ -53,12 +49,11 @@ cd ../../
 %{__install} -m 0644 man/avocado.1 %{buildroot}%{_mandir}/man1/avocado.1
 %{__install} -m 0644 man/avocado-rest-client.1 %{buildroot}%{_mandir}/man1/avocado-rest-client.1
 
-# Running the unittests is currently disabled on EL6 because fabric is
-# missing on EPEL 6 and also on EL7 because python-flexmock is missing
-# on EPEL7.
-%if !0%{?rhel}
+# Running selftests on EL7 is currently disabled because of a few
+# broken tests
+%if !0%{?el7}
 %check
-selftests/run
+ selftests/run
 %endif
 
 %files
@@ -117,6 +112,10 @@ examples of how to write tests on your own.
 %{_datadir}/avocado/wrappers
 
 %changelog
+* Fri Sep 16 2016 Cleber Rosa <cleber@redhat.com> - 41.0-1
+- Consolidated build requires common to all targets
+- Enabled check on EL6
+
 * Mon Sep 12 2016 Cleber Rosa <cleber@redhat.com> - 41.0-0
 - New upstream release
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 
-import sys
+import errno
 import os
+import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -18,10 +19,13 @@ ON_RTD = os.environ.get('READTHEDOCS', None) == 'True'
 #
 # Auto generate API documentation
 #
-apidoc = path.find_command('sphinx-apidoc')
 api_source_dir = os.path.join(root_path, 'avocado')
-apidoc_template = apidoc + " -o %(output_dir)s " + api_source_dir + " %(exclude_dirs)s"
 base_api_output_dir = os.path.join(root_path, 'docs', 'source', 'api')
+try:
+    apidoc = path.find_command('sphinx-apidoc')
+    apidoc_template = apidoc + " -o %(output_dir)s " + api_source_dir + " %(exclude_dirs)s"
+except path.CmdNotFoundError:
+    apidoc = False
 
 # Documentation sections. Key is the name of the section, followed by:
 # Second level module name (after avocado), Module description,
@@ -66,11 +70,13 @@ for (section, params) in API_SECTIONS.iteritems():
     files_to_remove = [os.path.join(base_api_output_dir, output_dir, d)
                        for d in params[4]]
     # generate all rst files
-    cmd = apidoc_template % locals()
-    process.run(cmd)
-    # remove unnecessary ones
-    for f in files_to_remove:
-        os.unlink(f)
+    if apidoc:
+        cmd = apidoc_template % locals()
+        process.run(cmd)
+        # remove unnecessary ones
+        for f in files_to_remove:
+            os.unlink(f)
+
     # rewrite first lines of main rst file for this section
     second_level_module_name = params[0]
     if second_level_module_name is None:
@@ -79,7 +85,16 @@ for (section, params) in API_SECTIONS.iteritems():
     else:
         main_rst = os.path.join(output_dir,
                                 "avocado.%s.rst" % second_level_module_name)
-    main_rst_content = open(main_rst).readlines()
+    if not apidoc:
+        main_rst_content = []
+        try:
+            os.makedirs(os.path.dirname(main_rst))
+        except OSError as details:
+            if not details.errno == errno.EEXIST:
+                raise
+    else:
+        main_rst_content = open(main_rst).readlines()
+
     new_main_rst_content = [section, "=" * len(section), "",
                             params[1], ""]
     new_main_rst = open(main_rst, "w")

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -142,7 +142,13 @@ texinfo_documents = [
      'Miscellaneous'),
 ]
 
-# Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'http://docs.python.org/': None}
+# Older python-sphinx cannot handle newer inventory files (objects.inv)
+# this is not failproof, as there can be newer python-sphinx on older
+# Python, but it seems to be good enough.
+if sys.version_info[0] == 2 and sys.version_info[1] == 6:
+    intersphinx_python_url = 'http://docs.python.org/2.6/'
+else:
+    intersphinx_python_url = 'http://docs.python.org/'
+intersphinx_mapping = {intersphinx_python_url: None}
 
 autoclass_content = 'both'

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -19,7 +19,7 @@ from avocado.core import exit_codes
 from avocado.utils import astring
 from avocado.utils import process
 from avocado.utils import script
-
+from avocado.utils import path as utils_path
 
 basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..')
 basedir = os.path.abspath(basedir)
@@ -96,6 +96,14 @@ class MyTest(Test):
 '''
 
 
+def missing_binary(binary):
+    try:
+        utils_path.find_command(binary)
+        return False
+    except utils_path.CmdNotFoundError:
+        return True
+
+
 class RunnerOperationTest(unittest.TestCase):
 
     def setUp(self):
@@ -160,6 +168,8 @@ class RunnerOperationTest(unittest.TestCase):
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %d:\n%s" % (expected_rc, result))
 
+    @unittest.skipIf(missing_binary('cc'),
+                     "C compiler is required by the underlying datadir.py test")
     def test_datadir_alias(self):
         os.chdir(basedir)
         cmd_line = ('./scripts/avocado run --sysinfo=off --job-results-dir %s '
@@ -173,6 +183,8 @@ class RunnerOperationTest(unittest.TestCase):
                     'env_variables.sh' % self.tmpdir)
         process.run(cmd_line)
 
+    @unittest.skipIf(missing_binary('cc'),
+                     "C compiler is required by the underlying datadir.py test")
     def test_datadir_noalias(self):
         os.chdir(basedir)
         cmd_line = ('./scripts/avocado run --sysinfo=off --job-results-dir %s examples/tests/datadir.py '

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -17,6 +17,7 @@ from avocado.core import exit_codes
 from avocado.core.output import TermSupport
 from avocado.utils import process
 from avocado.utils import script
+from avocado.utils import path as utils_path
 
 basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..')
 basedir = os.path.abspath(basedir)
@@ -56,11 +57,21 @@ def perl_tap_parser_uncapable():
     return os.system("perl -e 'use TAP::Parser;'") != 0
 
 
+def missing_binary(binary):
+    try:
+        utils_path.find_command(binary)
+        return False
+    except utils_path.CmdNotFoundError:
+        return True
+
+
 class OutputTest(unittest.TestCase):
 
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
 
+    @unittest.skipIf(missing_binary('cc'),
+                     "C compiler is required by the underlying doublefree.py test")
     def test_output_doublefree(self):
         os.chdir(basedir)
         cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '

--- a/selftests/functional/test_wrapper.py
+++ b/selftests/functional/test_wrapper.py
@@ -11,6 +11,7 @@ else:
 from avocado.core import exit_codes
 from avocado.utils import process
 from avocado.utils import script
+from avocado.utils import path as utils_path
 
 basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..')
 basedir = os.path.abspath(basedir)
@@ -24,6 +25,14 @@ exec -- $@
 DUMMY_CONTENT = """#!/bin/bash
 exec -- $@
 """
+
+
+def missing_binary(binary):
+    try:
+        utils_path.find_command(binary)
+        return False
+    except utils_path.CmdNotFoundError:
+        return True
 
 
 class WrapperTest(unittest.TestCase):
@@ -42,6 +51,8 @@ class WrapperTest(unittest.TestCase):
             'avocado_wrapper_functional')
         self.dummy.save()
 
+    @unittest.skipIf(missing_binary('cc'),
+                     "C compiler is required by the underlying datadir.py test")
     def test_global_wrapper(self):
         os.chdir(basedir)
         cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off --wrapper %s '
@@ -56,6 +67,8 @@ class WrapperTest(unittest.TestCase):
                         "%s\nCmdline: %s" %
                         (self.tmpfile, result.stdout, cmd_line))
 
+    @unittest.skipIf(missing_binary('cc'),
+                     "C compiler is required by the underlying datadir.py test")
     def test_process_wrapper(self):
         os.chdir(basedir)
         cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off --wrapper %s:*/datadir '
@@ -70,6 +83,8 @@ class WrapperTest(unittest.TestCase):
                         "%s\nStdout: %s" %
                         (self.tmpfile, cmd_line, result.stdout))
 
+    @unittest.skipIf(missing_binary('cc'),
+                     "C compiler is required by the underlying datadir.py test")
     def test_both_wrappers(self):
         os.chdir(basedir)
         cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off --wrapper %s --wrapper %s:*/datadir '


### PR DESCRIPTION
This contains a number of fixes and small improvements that I found necessary to have `make check` passing on a EL6 host.

--

Changes from v1 (#1474):
 * Moved HTML bugfix to separate PR
 * Use symbolic `errno.EEXIST` instead of literal value
 * Use `AVOCADO_OPTIONAL_PLUGINS` in `develop` target and `AVOCADO_EXTERNAL_PLUGINS` in `link` target