### PR TITLE
selftests: Add /bin/read selftest

### DIFF
--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -476,6 +476,17 @@ class RunnerOperationTest(unittest.TestCase):
         self.assertIn('1-%s:MyTest.test_my_name -> TestError' % test,
                       result.stdout)
 
+    @unittest.skipIf(process.system("which /bin/read", ignore_status=True),
+                     "/bin/read not available.")
+    def test_read(self):
+        os.chdir(basedir)
+        result = process.run("./scripts/avocado run /bin/read", timeout=10,
+                             ignore_status=True)
+        self.assertLess(result.duration, 8, "Duration longer than expected."
+                        "\n%s" % result)
+        self.assertEqual(result.exit_status, 1, "Expected exit status is 1\n%s"
+                         % result)
+
     def tearDown(self):
         shutil.rmtree(self.tmpdir)
 


### PR DESCRIPTION
Recently I fixed a bug where test which asks for input hangs for
infinity but I forgot to add unittest for it. Let's add it now.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>