### PR TITLE
examples: Minor fixes in sleeptenmin test

### DIFF
--- a/examples/tests/sleeptenmin.py
+++ b/examples/tests/sleeptenmin.py
@@ -25,13 +25,12 @@ class SleepTenMin(Test):
         length = int(self.params.get('sleep_length', default=600))
         method = self.params.get('sleep_method', default='builtin')
 
-        for cycle in xrange(0, cycles):
+        for _ in xrange(0, cycles):
             self.log.debug("Sleeping for %.2f seconds", length)
             if method == 'builtin':
                 time.sleep(length)
             elif method == 'shell':
                 os.system("sleep %s" % length)
-            self.report_state()
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
The sleeptenmin example test contains `self.report_state` which should
not be called directly and it defines variable which is not used.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>