### PR TITLE
RFC: Job Phases

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -422,16 +422,7 @@ class Job(object):
         self._setup_job_results()
         self.__start_job_logging()
 
-        if (getattr(self.args, 'remote_hostname', False) and
-           getattr(self.args, 'remote_no_copy', False)):
-            self.test_suite = [(None, {})]
-        else:
-            try:
-                self.test_suite = self._make_test_suite(self.urls)
-            except loader.LoaderError as details:
-                stacktrace.log_exc_info(sys.exc_info(), 'avocado.app.debug')
-                self._remove_job_results()
-                raise exceptions.OptionValidationError(details)
+        self.create_test_suite()
 
         self.job_pre_post_dispatcher.map_methods('pre', self)
 
@@ -487,6 +478,23 @@ class Job(object):
             self.exitcode |= exit_codes.AVOCADO_TESTS_FAIL
 
         return self.exitcode
+
+    def create_test_suite(self):
+        """
+        Creates the test suite for this Job
+
+        This is a public Job API as part of the documented Job phases
+        """
+        if (getattr(self.args, 'remote_hostname', False) and
+           getattr(self.args, 'remote_no_copy', False)):
+            self.test_suite = [(None, {})]
+        else:
+            try:
+                self.test_suite = self._make_test_suite(self.urls)
+            except loader.LoaderError as details:
+                stacktrace.log_exc_info(sys.exc_info(), 'avocado.app.debug')
+                self._remove_job_results()
+                raise exceptions.OptionValidationError(details)
 
     def run(self):
         """

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -410,23 +410,6 @@ class Job(object):
         self._log_mux_variants(mux)
         self._log_job_id()
 
-    def _run(self):
-        """
-        Unhandled job method. Runs a list of test URLs to its completion.
-
-        :return: Integer with overall job status. See
-                 :mod:`avocado.core.exit_codes` for more information.
-        :raise: Any exception (avocado crashed), or
-                :class:`avocado.core.exceptions.JobBaseException` errors,
-                that configure a job failure.
-        """
-        self._setup_job_results()
-        self.__start_job_logging()
-
-        self.create_test_suite()
-        self.pre_tests()
-        return self.run_tests()
-
     def create_test_suite(self):
         """
         Creates the test suite for this Job
@@ -533,7 +516,12 @@ class Job(object):
         """
         runtime.CURRENT_JOB = self
         try:
-            return self._run()
+            self._setup_job_results()
+            self.__start_job_logging()
+
+            self.create_test_suite()
+            self.pre_tests()
+            return self.run_tests()
         except exceptions.JobBaseException as details:
             self.status = details.status
             fail_class = details.__class__.__name__

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -509,6 +509,18 @@ class Job(object):
 
         return self.exitcode
 
+    def post_tests(self):
+        """
+        Run the post tests execution hooks
+
+        By default this runs the plugins that implement the
+        :class:`avocado.core.plugin_interfaces.JobPost` interface.
+        """
+        if self.job_pre_post_dispatcher is None:
+            self.job_pre_post_dispatcher = dispatcher.JobPrePostDispatcher()
+            output.log_plugin_failures(self.job_pre_post_dispatcher.load_failures)
+        self.job_pre_post_dispatcher.map_methods('post', self)
+
     def run(self):
         """
         Handled main job method. Runs a list of test URLs to its completion.
@@ -548,8 +560,7 @@ class Job(object):
             self.exitcode |= exit_codes.AVOCADO_FAIL
             return self.exitcode
         finally:
-            if self.job_pre_post_dispatcher is not None:
-                self.job_pre_post_dispatcher.map_methods('post', self)
+            self.post_tests()
             if not settings.get_value('runner.behavior', 'keep_tmp_files',
                                       key_type=bool, default=False):
                 data_dir.clean_tmp_files()

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -1,0 +1,21 @@
+import argparse
+import sys
+if sys.version_info[:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
+
+from avocado.core import job
+
+
+class JobTest(unittest.TestCase):
+
+    def test_job_empty_suite(self):
+        args = argparse.Namespace()
+        empty_job = job.Job(args)
+        self.assertIsNone(empty_job.test_suite)
+
+    def test_job_empty_has_id(self):
+        args = argparse.Namespace()
+        empty_job = job.Job(args)
+        self.assertIsNotNone(empty_job.unique_id)


### PR DESCRIPTION
This is a code based version of the proposal presented earlier on the mailing list:

https://www.redhat.com/archives/avocado-devel/2016-September/msg00044.html

There are still boundaries being crossed, and the final implementation of the Job Phases proposal should contain tests that run only some of the phases and produce expected results. Still, it makes it quite clear how Avocado Jobs could be used programmatically and improve our own understanding of the job phases. 