### PR TITLE
Revert "avocado.core.runner: Disable stdin for tests"

### DIFF
--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -293,9 +293,6 @@ class TestRunner(object):
 
         signal.signal(signal.SIGTERM, sigterm_handler)
 
-        # Replace STDIN (0) with the /dev/null's fd
-        os.dup2(sys.stdin.fileno(), 0)
-
         instance = loader.load_test(test_factory)
         if instance.runner_queue is None:
             instance.runner_queue = queue


### PR DESCRIPTION
The commit 793a481842fb64be7477ae734f4fa3805438eec5 breaks the ctrl+c
handling as the test's process won't detect it without the 0st fd.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>