### PR TITLE
Revert "sysinfo: include journalctl diff information"

### DIFF
--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -13,7 +13,6 @@
 # Author: John Admanski <jadmanski@google.com>
 
 import gzip
-import json
 import logging
 import os
 import shutil
@@ -212,45 +211,6 @@ class Daemon(Command):
             log.error("Daemon process '%s' (pid %d) terminated abnormally (code %d)",
                       self.cmd, self.pipe.pid, retcode)
         return retcode
-
-
-class JournalctlWatcher(Collectible):
-
-    """
-    Track the content of systemd journal into a compressed file.
-
-    :param logf: Basename of the file where output is logged (optional).
-    """
-
-    def __init__(self, logf=None):
-        if not logf:
-            logf = 'journalctl.gz'
-
-        super(JournalctlWatcher, self).__init__(logf)
-        self.cursor = self._get_cursor()
-
-    def _get_cursor(self):
-        try:
-            cmd = 'journalctl --lines 1 --output json'
-            result = process.system_output(cmd, verbose=False)
-            last_record = json.loads(result)
-            return last_record['__CURSOR']
-        except Exception as e:
-            log.debug("Journalctl collection failed: %s", e)
-
-    def run(self, logdir):
-        if self.cursor:
-            try:
-                cmd = 'journalctl --quiet --after-cursor %s' % self.cursor
-                log_diff = process.system_output(cmd, verbose=False)
-                dstpath = os.path.join(logdir, self.logf)
-                with gzip.GzipFile(dstpath, "w")as out_journalctl:
-                    out_journalctl.write(log_diff)
-            except IOError:
-                log.debug("Not logging journalctl (lack of permissions)",
-                          dstpath)
-            except Exception as e:
-                log.debug("Journalctl collection failed: %s", e)
 
 
 class LogWatcher(Collectible):
@@ -475,8 +435,6 @@ class SysInfo(object):
             self.end_test_collectibles.add(self._get_syslog_watcher())
         except ValueError as details:
             log.info(details)
-
-        self.end_test_collectibles.add(JournalctlWatcher())
 
     def _get_collectibles(self, hook):
         collectibles = self.hook_mapping.get(hook)

--- a/selftests/unit/test_sysinfo.py
+++ b/selftests/unit/test_sysinfo.py
@@ -85,8 +85,8 @@ class SysinfoTest(unittest.TestCase):
         job_postdir = os.path.join(testdir, 'post')
         self.assertTrue(os.path.isdir(job_postdir))
         # By default, there are no post test files
-        self.assertLess(len(os.listdir(job_postdir)), 3,
-                        "Post dir can contain 0-2 files depending on whether "
+        self.assertLess(len(os.listdir(job_postdir)), 2,
+                        "Post dir can contain 0-1 files depending on whether "
                         "sys messages are obtainable or not:\n%s"
                         % os.listdir(job_postdir))
 


### PR DESCRIPTION
The commit 64b9478a0a220f216bd20850fb3f492f103aa08c breaks the ctrl+c
functionality, so:

    avocado run sleeptenmin.py

followed by ctrl+c passes, instead of finishing with interrupted. (not
only this test). Let's revert this patch till we find version, which
would keep the ctrl+c working.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>