### PR TITLE
use python-systemd for sysinfo journalctl

### DIFF
--- a/avocado.spec
+++ b/avocado.spec
@@ -7,13 +7,13 @@
 Summary: Avocado Test Framework
 Name: avocado
 Version: 41.0
-Release: 0%{?dist}
+Release: 1%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.github.io/
 Source0: https://github.com/avocado-framework/%{name}/archive/%{commit}/%{name}-%{version}-%{shortcommit}.tar.gz
 BuildArch: noarch
-Requires: python, python-requests, fabric, pyliblzma, libvirt-python, pystache, gdb, gdb-gdbserver, python-stevedore, aexpect
+Requires: python, python-requests, fabric, pyliblzma, libvirt-python, pystache, gdb, gdb-gdbserver, python-stevedore, aexpect, python-systemd
 BuildRequires: python2-devel, python-setuptools, python-docutils, python-mock, python-psutil, python-sphinx, python-requests, aexpect, pystache, yum, python-stevedore, python-lxml, perl-Test-Harness
 
 %if 0%{?el6}
@@ -117,6 +117,9 @@ examples of how to write tests on your own.
 %{_datadir}/avocado/wrappers
 
 %changelog
+* Mon Sep 29 2016 Amador Pahim <apahim@redhat.com> - 41.0-1
+- Added python-systemd requirement
+
 * Mon Sep 12 2016 Cleber Rosa <cleber@redhat.com> - 41.0-0
 - New upstream release
 

--- a/requirements-selftests.txt
+++ b/requirements-selftests.txt
@@ -22,6 +22,7 @@ pygraphviz>=1.3rc2
 pydot>=1.0.2
 aexpect>=1.0.0
 psutil>=3.1.1
+systemd-python>=232
 # stevedore for loading "new style" plugins
 stevedore>=1.8.0
 lxml>=3.4.4

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -13,6 +13,7 @@ pygraphviz==1.3rc2
 mock==1.2.0
 aexpect==1.0.0
 psutil==3.1.1
+systemd-python>=232
 # stevedore for loading "new style" plugins
 stevedore==1.8.0
 lxml>=3.4.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,5 @@ importlib>=1.0.3; python_version < '2.7'
 unittest2>=1.0.0; python_version < '2.7'
 # Aexpect is now used on Docker plugin
 aexpect>=1.2.0
+# Systemd is now required by sysinfo
+systemd-python>=232


### PR DESCRIPTION
Currently we use the journalctl command to collect the logs created
during a given test. This approach makes the KeyboardInterrupt to be
ignored by the test runner so the test ends with PASS instead of
INTERRUPTED.

This patch makes the sysinfo to use the python-systemd module, to
collect the messages, avoiding the issue and making the code less
dependent on external commands.

Reference: https://trello.com/c/dNgrjMOJhttps://trello.com/c/dNgrjMOJ
Signed-off-by: Amador Pahim <apahim@redhat.com>