### PR TITLE
Fix issue in journalctl log watcher

### DIFF
--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -232,7 +232,7 @@ class JournalctlWatcher(Collectible):
     def _get_cursor(self):
         try:
             cmd = 'journalctl --lines 1 --output json'
-            result = process.system_output(cmd, verbose=False)
+            result = subprocess.check_output(cmd.split())
             last_record = json.loads(result)
             return last_record['__CURSOR']
         except Exception as e:
@@ -242,7 +242,7 @@ class JournalctlWatcher(Collectible):
         if self.cursor:
             try:
                 cmd = 'journalctl --quiet --after-cursor %s' % self.cursor
-                log_diff = process.system_output(cmd, verbose=False)
+                log_diff = subprocess.check_output(cmd.split())
                 dstpath = os.path.join(logdir, self.logf)
                 with gzip.GzipFile(dstpath, "w")as out_journalctl:
                     out_journalctl.write(log_diff)


### PR DESCRIPTION
Using avocado.utils.process to run the journalctl commands makes avocado
to ignore the KeyboardInterrupt signal and consider the test as PASS due
to the later (sysinfo post) command executed successfully.

This patch changes the method to run the journalctl commands to
subprocess.check_output. Now Avocado seems to handle KeyboardInterrupt
nicely.

Reference: https://trello.com/c/dNgrjMOJ
Signed-off-by: Amador Pahim <apahim@redhat.com>