### PR TITLE
README.rst: mention make develop (fixes #1496)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,11 @@ If you want to `develop` avocado, or run it directly from the git repository,
 you have a couple of options:
 
 1) The avocado test runner was designed to run in tree, for rapid development
-   prototypes. Just use::
+   prototypes. After running::
+
+    $ make develop
+
+   Just use::
 
     $ scripts/avocado --help
 


### PR DESCRIPTION
Before you can run the script straight out of the run tree you need to
run a make develop step so let's make it clear.

Signed-off-by: Alex Bennée <alex.bennee@linaro.org>