### PR TITLE
Makes avocado more  friendly to external runners

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -483,7 +483,7 @@ class Job(object):
 
         if 'INTERRUPTED' in summary:
             self.exitcode |= exit_codes.AVOCADO_JOB_INTERRUPTED
-        if 'FAIL' in summary:
+        if 'FAIL' in summary and not getattr(self.args, 'relax_exit_code', False):
             self.exitcode |= exit_codes.AVOCADO_TESTS_FAIL
 
         return self.exitcode

--- a/avocado/plugins/multiplex.py
+++ b/avocado/plugins/multiplex.py
@@ -54,6 +54,11 @@ class Multiplex(CLICmd):
         parser.add_argument('-c', '--contents', action='store_true',
                             default=False, help="Shows the node content "
                             "(variables)")
+        parser.add_argument('-l', '--list', action='store_true',
+                            default=False, help="Dump variants as yaml list")
+        parser.add_argument('--list-variant-id', action='store_true',
+                            default=False, help="Append variant id to list")
+
         parser.add_argument('--mux-inject', default=[], nargs='*',
                             help="Inject [path:]key:node values into "
                             "the final multiplex tree.")
@@ -115,6 +120,40 @@ class Multiplex(CLICmd):
             sys.exit(exit_codes.AVOCADO_ALL_OK)
 
         variants = multiplexer.MuxTree(mux_tree)
+        if args.list:
+            prefix = '  '
+            for (index, tpl) in enumerate(variants):
+                level = 0
+                if args.list_variant_id:
+                    log.info("variant: !mux")
+                    level += 1
+
+                lname = ''
+                for x in tpl:
+                    path = x.path[len('/run'):]
+                    lname += path.replace('/', '-')
+                # trim first '-'
+                lname = lname[1:]
+                if args.list_variant_id:
+                    log.info('%s%d:' % (prefix * level, index))
+                    level += 1
+                log.info('%s%s:' % (prefix * level, lname))
+                level += 1
+                env = set()
+                for node in tpl:
+                    for key, value in node.environment.iteritems():
+                        origin = node.environment_origin[key].path
+                        env.add(("%s" % key, str(value)))
+                if not env:
+                    continue
+                fmt = '%s  %%-%ds: %%s' % (prefix * level,
+                                           max([len(_[0]) for _ in env]))
+                for record in sorted(env):
+                    log.info(fmt, *record)
+                log.info("")
+
+            sys.exit(exit_codes.AVOCADO_ALL_OK)
+
         log.info('Variants generated:')
         for (index, tpl) in enumerate(variants):
             if not args.debug:

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -82,6 +82,9 @@ class Run(CLICmd):
                             help='Enable or disable the job interruption on '
                                  'first failed test.')
 
+        parser.add_argument('--relax-exit-code', action='store_true', default=False,
+                            help='Test failures not affects exit code')
+
         sysinfo_default = settings.get_value('sysinfo.collect',
                                              'enabled',
                                              key_type='bool',


### PR DESCRIPTION
Hi,
This patch-set is my attempt to makes avocado mode Jenkins friendly (which will be valuable for any external runner). 
Jenkins pipeline performs test run and test result collection on different stages like follows:
!#groovy
stage 'run tests'
sh 'avocado run --job-results-dir . --xunit-job-result on /bin/true /bin/false '
sh 'avocado run --job-results-dir . --xunit-job-result on /bin/uname'
stage 'collect results'
JUnitResultArchiver', testResults: 'job-logs/*/results*.xml'

Shell executed with '-e' so Jenkins will interpret non zero error code as error an abort whole job w/o executing other tests and w/o archiving results. So it is reasonable add mode where test failure not affect exit code.

Second thing I've done is to make Mux-tries mode more friendly for external runners.
Let's allow 'avocado multiplex' cmd to dump plain yaml tree so one can divide it and run in parallel

avocado multiplex -l --list-variant-id  my-mux_tree.yaml  > variants.yaml
for ((i=0;i<variants;i++);
   avocado run --remote-hostname node$i  my_test.py  -m variants.yaml --filter-only /run/variant/$i &
done

 