### PR TITLE
GitHub/ external runners friendly v2

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -483,7 +483,7 @@ class Job(object):
 
         if 'INTERRUPTED' in summary:
             self.exitcode |= exit_codes.AVOCADO_JOB_INTERRUPTED
-        if 'FAIL' in summary:
+        if 'FAIL' in summary and not getattr(self.args, 'relax_exit_code', False):
             self.exitcode |= exit_codes.AVOCADO_TESTS_FAIL
 
         return self.exitcode

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -63,7 +63,7 @@ class TestName(object):
     Test name representation
     """
 
-    def __init__(self, uid, name, variant=None, no_digits=None):
+    def __init__(self, uid, name, variant=None, no_digits=None, variant_name=None):
         """
         Test name according to avocado specification
 
@@ -79,7 +79,10 @@ class TestName(object):
             self.str_uid = str(uid)
         self.name = name or "<unknown>"
         self.variant = variant
+        self.variant_name = variant_name
         self.str_variant = "" if variant is None else ";" + str(variant)
+        if self.variant_name is not None and self.variant_name != "":
+            self.str_variant += '-' + self.variant_name
 
     def __str__(self):
         return "%s-%s%s" % (self.str_uid, self.name, self.str_variant)

--- a/avocado/plugins/multiplex.py
+++ b/avocado/plugins/multiplex.py
@@ -59,6 +59,9 @@ class Multiplex(CLICmd):
         parser.add_argument('--list-variant-id', action='store_true',
                             default=False, help="Append variant id to list")
 
+        parser.add_argument('--get-count', action='store_true',
+                            default=False, help="Return number of variants")
+
         parser.add_argument('--mux-inject', default=[], nargs='*',
                             help="Inject [path:]key:node values into "
                             "the final multiplex tree.")
@@ -120,6 +123,10 @@ class Multiplex(CLICmd):
             sys.exit(exit_codes.AVOCADO_ALL_OK)
 
         variants = multiplexer.MuxTree(mux_tree)
+        if args.get_count:
+            log.info("%d" % len(list(enumerate(variants))))
+            sys.exit(exit_codes.AVOCADO_ALL_OK)
+
         if args.list:
             prefix = '  '
             for (index, tpl) in enumerate(variants):

--- a/avocado/plugins/multiplex.py
+++ b/avocado/plugins/multiplex.py
@@ -54,6 +54,11 @@ class Multiplex(CLICmd):
         parser.add_argument('-c', '--contents', action='store_true',
                             default=False, help="Shows the node content "
                             "(variables)")
+        parser.add_argument('-l', '--list', action='store_true',
+                            default=False, help="Dump variants as yaml list")
+        parser.add_argument('--list-variant-id', action='store_true',
+                            default=False, help="Append variant id to list")
+
         parser.add_argument('--mux-inject', default=[], nargs='*',
                             help="Inject [path:]key:node values into "
                             "the final multiplex tree.")
@@ -115,6 +120,40 @@ class Multiplex(CLICmd):
             sys.exit(exit_codes.AVOCADO_ALL_OK)
 
         variants = multiplexer.MuxTree(mux_tree)
+        if args.list:
+            prefix = '  '
+            for (index, tpl) in enumerate(variants):
+                level = 0
+                if args.list_variant_id:
+                    log.info("variant: !mux")
+                    level += 1
+
+                lname = ''
+                for x in tpl:
+                    path = x.path[len('/run'):]
+                    lname += path.replace('/', '-')
+                # trim first '-'
+                lname = lname[1:]
+                if args.list_variant_id:
+                    log.info('%s%d:' % (prefix * level, index))
+                    level += 1
+                log.info('%s%s:' % (prefix * level, lname))
+                level += 1
+                env = set()
+                for node in tpl:
+                    for key, value in node.environment.iteritems():
+                        origin = node.environment_origin[key].path
+                        env.add(("%s" % key, str(value)))
+                if not env:
+                    continue
+                fmt = '%s  %%-%ds: %%s' % (prefix * level,
+                                           max([len(_[0]) for _ in env]))
+                for record in sorted(env):
+                    log.info(fmt, *record)
+                log.info("")
+
+            sys.exit(exit_codes.AVOCADO_ALL_OK)
+
         log.info('Variants generated:')
         for (index, tpl) in enumerate(variants):
             if not args.debug:

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -82,6 +82,9 @@ class Run(CLICmd):
                             help='Enable or disable the job interruption on '
                                  'first failed test.')
 
+        parser.add_argument('--relax-exit-code', action='store_true', default=False,
+                            help='Test failures not affects exit code')
+
         sysinfo_default = settings.get_value('sysinfo.collect',
                                              'enabled',
                                              key_type='bool',

--- a/etc/avocado/avocado.conf
+++ b/etc/avocado/avocado.conf
@@ -35,6 +35,8 @@ profilers = /etc/avocado/sysinfo/profilers
 colored = True
 # Use utf8 encoding (True, False, None=autodetect)
 utf8 =
+# Append mux tree nodes name to test name
+variant_name = True
 
 [runner.behavior]
 # Keep job temporary files after jobs (useful for avocado debugging)


### PR DESCRIPTION
Hi,
This patch-set is my attempt to makes avocado mode Jenkins friendly (which will be valuable for any external runner). 
Jenkins pipeline performs test run and test result collection on different stages like follows:
!#groovy
stage 'run tests'
sh 'avocado run --job-results-dir . --xunit-job-result on /bin/true /bin/false '
sh 'avocado run --job-results-dir . --xunit-job-result on /bin/uname'
stage 'collect results'
JUnitResultArchiver', testResults: 'job-logs//results.xml'

Shell executed with '-e' so Jenkins will interpret non zero error code as error an abort whole job w/o executing other tests and w/o archiving results. So it is reasonable add mode where test failure not affect exit code.

Second thing I've done is to make Mux-tries mode more friendly for external runners.
Let's allow 'avocado multiplex' cmd to dump plain yaml tree so one can divide it and run in parallel

avocado multiplex -l --list-variant-id my-mux_tree.yaml > variants.yaml
for ((i=0;i<variants;i++);
avocado run --remote-hostname node$i my_test.py -m variants.yaml --filter-only /run/variant/$i &
done
