### PR TITLE
scripts/avocado-journal-replay: Fix usage message

### DIFF
--- a/scripts/avocado-journal-replay
+++ b/scripts/avocado-journal-replay
@@ -29,7 +29,7 @@ class ArgumentParser(argparse.ArgumentParser):
     def __init__(self):
         super(ArgumentParser, self).__init__(
             prog='avocado-journal-replay',
-            description=('Avocado Test Journal Replay. Sends test journal data'
+            description=('Avocado Test Journal Replay. Sends test journal data '
                          'to an Avocado Server'))
 
         self.add_argument('-s', '--server-uri',


### PR DESCRIPTION
There's a missing space at the end of the line, that is, let's
replace "datato" with "data to".

Signed-off-by: Wei Jiangang <weijg.fnst@cn.fujitsu.com>