### PR TITLE
selftests.checkall: Print the unittest cmd which failed

### DIFF
--- a/selftests/checkall
+++ b/selftests/checkall
@@ -37,6 +37,7 @@ parallel_selftests() {
         RET=$?
         if [ $RET -ne 0 ]; then
             ERR=1
+            echo python -m unittest ${ALL[@]:$(($I * $PER_SLICE)):$PER_SLICE}
             cat ${TMPS[$I]}
         fi
         rm ${TMPS[$I]}


### PR DESCRIPTION
It might be useful to also list the command which failed to run in
parallel selfcheck.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>