### PR TITLE
Remote improvements

### DIFF
--- a/avocado/core/remote/runner.py
+++ b/avocado/core/remote/runner.py
@@ -56,7 +56,7 @@ class RemoteTestRunner(TestRunner):
         $remote_test_dir + $test_absolute_path.
         :note: Default tests execution is translated into absolute paths too
         """
-        if self.job.args.remote_no_copy:    # Leave everything as is
+        if not self.job.args.remote_copy:    # Leave everything as is
             return
 
         # TODO: Use `avocado.core.loader.TestLoader` instead
@@ -367,7 +367,7 @@ class VMTestRunner(RemoteTestRunner):
         self.job.args.remote_username = self.job.args.vm_username
         self.job.args.remote_password = self.job.args.vm_password
         self.job.args.remote_key_file = self.job.args.vm_key_file
-        self.job.args.remote_no_copy = self.job.args.vm_no_copy
+        self.job.args.remote_copy = self.job.args.vm_copy
         self.job.args.remote_timeout = self.job.args.vm_timeout
         super(VMTestRunner, self).setup()
 

--- a/avocado/core/remote/runner.py
+++ b/avocado/core/remote/runner.py
@@ -64,6 +64,8 @@ class RemoteTestRunner(TestRunner):
         paths = set()
         for i in xrange(len(self.job.urls)):
             url = self.job.urls[i]
+            if ':' in url:
+                url = url.split(':')[0]
             if not os.path.exists(url):     # use test_dir path + py
                 url = os.path.join(data_dir.get_test_dir(), url)
             if not os.path.exists(url):

--- a/avocado/plugins/docker.py
+++ b/avocado/plugins/docker.py
@@ -138,7 +138,7 @@ class DockerTestRunner(RemoteTestRunner):
         self.remote.makedir(self.remote_test_dir)
         self.job.log.info("DOCKER     : Container id '%s'"
                           % self.remote.get_cid())
-        self.job.args.remote_no_copy = self.job.args.docker_no_copy
+        self.job.args.remote_copy = self.job.args.docker_copy
 
     def tear_down(self):
         try:
@@ -173,9 +173,8 @@ class Docker(CLI):
                                 "docker' or other base docker options like "
                                 "hypervisor. Default: '%(default)s'",
                                 metavar="CMD")
-        cmd_parser.add_argument("--docker-no-copy", action="store_true",
-                                help="Assume tests are already in the "
-                                "container")
+        cmd_parser.add_argument("--docker-copy", action="store_true",
+                                help="Copy tests to the container")
         cmd_parser.add_argument("--docker-no-cleanup", action="store_true",
                                 help="Preserve container after test")
 

--- a/avocado/plugins/remote.py
+++ b/avocado/plugins/remote.py
@@ -68,10 +68,10 @@ class Remote(CLI):
                                         help='Specify an identity file with '
                                         'a private key instead of a password '
                                         '(Example: .pem files from Amazon EC2)')
-        self.remote_parser.add_argument('--remote-no-copy',
-                                        dest='remote_no_copy',
+        self.remote_parser.add_argument('--remote-copy',
+                                        dest='remote_copy',
                                         action='store_true',
-                                        help="Don't copy tests and use the "
+                                        help="Copy tests and use the "
                                         "exact uri on guest machine.")
         self.remote_parser.add_argument('--remote-timeout', metavar='SECONDS',
                                         help=("Amount of time (in seconds) to "

--- a/avocado/plugins/vm.py
+++ b/avocado/plugins/vm.py
@@ -74,8 +74,8 @@ class VM(CLI):
                                     action='store_true', default=False,
                                     help='Restore VM to a previous state, '
                                     'before running tests')
-        self.vm_parser.add_argument('--vm-no-copy', action='store_true',
-                                    help="Don't copy tests and use the "
+        self.vm_parser.add_argument('--vm-copy', action='store_true',
+                                    help="Copy tests and use the "
                                     "exact uri on VM machine.")
         self.vm_parser.add_argument('--vm-timeout', metavar='SECONDS',
                                     help=("Amount of time (in seconds) to "

--- a/docs/source/RunningTestsRemotely.rst
+++ b/docs/source/RunningTestsRemotely.rst
@@ -62,8 +62,10 @@ Once the remote machine is properly setup, you may run your test. Example::
     RESULTS    : PASS 1 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0
     TESTS TIME : 1.01 s
 
-As you can see, Avocado will copy the tests you have to your remote machine and
-execute them. A bit of extra logging information is added to your job summary,
+Notice that Avocado will not copy the tests to the remote machine. If you want
+that, use the option `--remote-copy`.
+
+A bit of extra logging information is added to your job summary,
 mainly to distinguish the regular execution from the remote one. Note here that
 we did not need `--remote-password` because an SSH key was already setup.
 
@@ -141,10 +143,11 @@ Once the virtual machine is properly setup, you may run your test. Example::
     RESULTS    : PASS 1 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0
     TESTS TIME : 1.01 s
 
-As you can see, Avocado will copy the tests you have to your libvirt domain and
-execute them. A bit of extra logging information is added to your job summary,
-mainly to distinguish the regular execution from the remote one. Note here that
-we did not need `--vm-password` because the SSH key is already setup.
+Notice that Avocado will not copy the tests to your libvirt domain. If you want
+that, use the option `--vm-copy`. A bit of extra logging information is added
+to your job summary, mainly to distinguish the regular execution from the
+remote one. Note here that we did not need `--vm-password` because the SSH key
+is already setup.
 
 Running Tests on a Docker container
 ===================================

--- a/selftests/unit/test_vm.py
+++ b/selftests/unit/test_vm.py
@@ -47,7 +47,7 @@ class VMTestRunnerSetup(unittest.TestCase):
                         vm_password='password',
                         vm_key_file=None,
                         vm_cleanup=True,
-                        vm_no_copy=False,
+                        vm_copy=False,
                         vm_timeout=120,
                         vm_hypervisor_uri='my_hypervisor_uri',
                         env_keep=None)


### PR DESCRIPTION
- Job: make test suite before the loader so the loader can know when it's a remoter execution to skip the discover.
- Remote: don't break on urls with test references.
- Invert the logics of `--remote-no-copy`, renaming it to `--remote-copy` and don't copy tests by default. 