### PR TITLE
[36lts] Don't discover tests when using --remote-no-copy

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -471,12 +471,16 @@ class Job(object):
         self._setup_job_results()
         self.__start_job_logging()
 
-        try:
-            self.test_suite = self._make_test_suite(self.urls)
-        except loader.LoaderError as details:
-            stacktrace.log_exc_info(sys.exc_info(), 'avocado.app.debug')
-            self._remove_job_results()
-            raise exceptions.OptionValidationError(details)
+        if (getattr(self.args, 'remote_hostname', False) and
+           getattr(self.args, 'remote_no_copy', False)):
+            self.test_suite = [(None, {})]
+        else:
+            try:
+                self.test_suite = self._make_test_suite(self.urls)
+            except loader.LoaderError as details:
+                stacktrace.log_exc_info(sys.exc_info(), 'avocado.app.debug')
+                self._remove_job_results()
+                raise exceptions.OptionValidationError(details)
 
         self.job_pre_post_dispatcher.map_methods('pre', self)
 


### PR DESCRIPTION
Backport

When the tests are not going to be copied, there's no need to try to
discover them locally.

This patch fakes the test_suite when remote-no-copy is used.

Reference: b168855ef4b773de7ba8b8b69e6b18e0cf93db03
Signed-off-by: Amador Pahim <apahim@redhat.com>