### PR TITLE
avocado.utils.git: Don't produce check output

### DIFF
--- a/avocado/utils/git.py
+++ b/avocado/utils/git.py
@@ -103,7 +103,8 @@ class GitRepoHelper(object):
         """
         os.chdir(self.destination_dir)
         return process.run(r"%s %s" % (self.cmd, astring.shell_escape(cmd)),
-                           ignore_status=ignore_status)
+                           ignore_status=ignore_status,
+                           allow_output_check='none')
 
     def fetch(self, uri):
         """


### PR DESCRIPTION
The usual use of the git library is to get latest (or some) version,
quite frequently into a unique tmp dir. Let's disable recording it's
output for --output-check.

Signed-off-by: Philipp Wagner <imphil@philipp-wagner.com>
Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>

Issue: https://github.com/avocado-framework/avocado/issues/1505

Reproducer:

```diff
diff --git a/examples/tests/passtest.py b/examples/tests/passtest.py
index 4f6e25c..c5a5459 100755
--- a/examples/tests/passtest.py
+++ b/examples/tests/passtest.py
@@ -14,6 +14,8 @@ class PassTest(Test):
         """
         A test simply doesn't have to fail in order to pass
         """
+        from avocado.utils import git
+        git.get_repo("https://github.com/ldoktor/my_git")
         pass

```
```
avocado run passtest.py --output-check-record all
cat examples/tests/passtest.py.data/stdout.expected
```