### PR TITLE
selftests: Add /bin/read selftest

### DIFF
--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -488,6 +488,18 @@ class RunnerOperationTest(unittest.TestCase):
         self.assertIn('1-%s:MyTest.test_my_name -> TestError' % test,
                       result.stdout)
 
+    @unittest.skipIf(missing_binary("read"),
+                     "read binary not available.")
+    def test_read(self):
+        cmd = utils_path.find_command("read")
+        os.chdir(basedir)
+        result = process.run("./scripts/avocado run %s" % cmd, timeout=10,
+                             ignore_status=True)
+        self.assertLess(result.duration, 8, "Duration longer than expected."
+                        "\n%s" % result)
+        self.assertEqual(result.exit_status, 1, "Expected exit status is 1\n%s"
+                         % result)
+
     def tearDown(self):
         shutil.rmtree(self.tmpdir)
 


### PR DESCRIPTION
Recently I fixed a bug where test which asks for input hangs for
infinity but I forgot to add unittest for it. Let's add it now.

v1: https://github.com/avocado-framework/avocado/pull/1520
v2: https://github.com/avocado-framework/avocado/pull/1528

Changes:

```
v2: Fix typo reada => read
v3: Skip test in decorator, rather then in test
```