### PR TITLE
fix issues with new mux-yaml option

### DIFF
--- a/avocado/core/remote/runner.py
+++ b/avocado/core/remote/runner.py
@@ -80,7 +80,7 @@ class RemoteTestRunner(TestRunner):
             test_data = path + '.data'
             if os.path.isdir(test_data):
                 self.remote.send_files(test_data, os.path.dirname(rpath))
-        for mux_file in getattr(self.job.args, 'multiplex') or []:
+        for mux_file in getattr(self.job.args, 'mux_yaml') or []:
             rpath = os.path.join(self.remote_test_dir, mux_file)
             self.remote.makedir(os.path.dirname(rpath))
             self.remote.send_files(mux_file, rpath)
@@ -181,7 +181,7 @@ class RemoteTestRunner(TestRunner):
         extra_params = []
         mux_files = [os.path.join(self.remote_test_dir, mux_file)
                      for mux_file in getattr(self.job.args,
-                                             'multiplex') or []]
+                                             'mux_yaml') or []]
         if mux_files:
             extra_params.append("-m %s" % " ".join(mux_files))
 

--- a/avocado/plugins/yaml_to_mux.py
+++ b/avocado/plugins/yaml_to_mux.py
@@ -270,7 +270,7 @@ class YamlToMux(CLI):
         if multiplex_files:
             msg = ("The use of `--multiplex` is deprecated, use `--mux-yaml` "
                    "instead.")
-            logging.getLogger("avocado.test").warning(msg)
+            logging.getLogger("avocado.app").warning(msg)
             debug = getattr(args, "mux_debug", False)
             try:
                 args.mux.data_merge(create_from_yaml(multiplex_files, debug))

--- a/selftests/unit/test_remote.py
+++ b/selftests/unit/test_remote.py
@@ -38,7 +38,7 @@ class RemoteTestRunnerTest(unittest.TestCase):
                         remote_no_copy=False,
                         remote_timeout=60,
                         show_job_log=False,
-                        multiplex=['foo.yaml', 'bar/baz.yaml'],
+                        mux_yaml=['foo.yaml', 'bar/baz.yaml'],
                         dry_run=True,
                         env_keep=None)
         log = flexmock()
@@ -113,7 +113,7 @@ _=/usr/bin/env''', exit_status=0)
         Results = flexmock(remote=Remote, urls=['sleeptest'],
                            stream=stream, timeout=None,
                            args=flexmock(show_job_log=False,
-                                         multiplex=['foo.yaml', 'bar/baz.yaml'],
+                                         mux_yaml=['foo.yaml', 'bar/baz.yaml'],
                                          dry_run=True))
         Results.should_receive('start_tests').once().ordered()
         args = {'status': u'PASS', 'whiteboard': '', 'time_start': 0,


### PR DESCRIPTION
- Rename `multiplex` to `mux_yaml` in remote runner and related selftests.
- Since `avocado.test` is not available when plugins are in action, use `avocado.app` logger to warn users about the deprecated option.