### PR TITLE
selftests: Replace custom can_sudo check with process.can_sudo

### DIFF
--- a/selftests/functional/test_lv_utils.py
+++ b/selftests/functional/test_lv_utils.py
@@ -26,11 +26,9 @@ class LVUtilsTest(unittest.TestCase):
 
     @unittest.skipIf(process.system("which vgs", ignore_status=True),
                      "LVM utils not installed (command vgs is missing)")
+    @unittest.skipIf(not process.can_sudo(), "This test requires root or "
+                     "passwordless sudo configured.")
     def setUp(self):
-        try:
-            process.system("/bin/true", sudo=True)
-        except process.CmdError as details:
-            self.skipTest("Sudo not available: %s" % details)
         self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
         self.vgs = []
 

--- a/selftests/unit/test_utils_partition.py
+++ b/selftests/unit/test_utils_partition.py
@@ -29,14 +29,6 @@ def missing_binary(binary):
         return True
 
 
-def cannot_sudo(command):
-    try:
-        process.run(command, sudo=True)
-        False
-    except (process.CmdError, OSError):
-        return True
-
-
 class TestPartition(unittest.TestCase):
 
     """
@@ -45,12 +37,8 @@ class TestPartition(unittest.TestCase):
 
     @unittest.skipIf(missing_binary('mkfs.ext2'),
                      "mkfs.ext2 is required for these tests to run.")
-    @unittest.skipIf(missing_binary('sudo'),
+    @unittest.skipIf(not process.can_sudo(),
                      "sudo is required for these tests to run.")
-    @unittest.skipIf(cannot_sudo('mount'),
-                     'current user must be allowed to run "mount" under sudo')
-    @unittest.skipIf(cannot_sudo('mkfs.ext2 -V'),
-                     'current user must be allowed to run "mkfs.ext2" under sudo')
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp(prefix="avocado_" + __name__)
         self.mountpoint = os.path.join(self.tmpdir, "disk")


### PR DESCRIPTION
There were several implementations of can_sudo methods in selftests,
most of them broken as eg. "mount" can run without sudo, which is what
happens if sudo is not available.

This patch replaces those custom methods with the one recently
introduced in `avocado.utils.process`.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>