### PR TITLE
avocado: Improve the mux variant-id [v0]

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -389,9 +389,9 @@ class Job(object):
     def _log_mux_variants(self, mux):
         job_log = _TEST_LOGGER
 
-        for (index, tpl) in enumerate(mux.variants):
-            paths = ', '.join([x.path for x in tpl])
-            job_log.info('Variant %s:    %s', index + 1, paths)
+        for variant in mux.itertests():
+            paths = ', '.join([x.path for x in variant["variant"]])
+            job_log.info('Variant %s:    %s', variant["variant_id"], paths)
 
         if mux.variants:
             job_log.info('')

--- a/avocado/core/result.py
+++ b/avocado/core/result.py
@@ -222,7 +222,7 @@ class HumanResult(Result):
         if "name" in state:
             name = state["name"]
             uid = name.str_uid
-            name = name.name + name.str_variant
+            name = name.name + name.str_variant_short
         else:
             name = "<unknown>"
             uid = '?'

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -467,15 +467,15 @@ class TestRunner(object):
         :return: Yields tuple(test_factory including params, variant id)
         :raises ValueError: When variant and template declare params.
         """
-        for variant, params in mux.itertests():
-            if params:
+        for variant in mux.itertests():
+            if variant:
                 if "params" in template[1]:
                     msg = ("Unable to multiplex test %s, params are already "
                            "present in test factory: %s"
                            % (template[0], template[1]))
                     raise ValueError(msg)
                 factory = [template[0], template[1].copy()]
-                factory[1]["params"] = params
+                factory[1]["params"] = variant["variant"]
             else:
                 factory = template
             yield factory, variant

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -78,8 +78,15 @@ class TestName(object):
         else:
             self.str_uid = str(uid)
         self.name = name or "<unknown>"
-        self.variant = variant
-        self.str_variant = "" if variant is None else ";" + str(variant)
+        self.variant = variant["variant_id"] if variant else None
+        if variant is None:
+            self.str_variant = ""
+            self.str_variant_short = ""
+        else:
+            self.str_variant = (";" + variant["variant_id"]
+                                if variant["variant_id"] else "")
+            self.str_variant_short = (";" + variant["variant_id_short"]
+                                      if variant["variant_id_short"] else "")
 
     def __str__(self):
         return "%s-%s%s" % (self.str_uid, self.name, self.str_variant)

--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -78,6 +78,10 @@ class TreeNode(object):
         for child in children:
             self.add_child(child)
 
+    def fingerprint(self):
+        return (str(self.path) + str(self.environment) + str(self.ctrl) +
+                str(self.multiplex))
+
     def __repr__(self):
         return 'TreeNode(name=%r)' % self.name
 


### PR DESCRIPTION
Currently the variant-id is only an id. This patch adds the possibility
to specify the variant-id as well as variant-id-short, which is intended
for human-readable audience.

To demonstrate the feature this patch also implements a better
variant-id for the avocado multiplexer, which takes the variant node
names and joins them by '-'. After that it appends hash of the nodes
fingerprints in order to represent the value of the current node.

The fingerprint is not just pickle of the tree object as that'd include
the parent and all the structures, which would be unrepeatable. Instead
it calculates something which represents the important values of the
node so this value is the same when the value of that node is the same.

Overall this should allow to produce almost unique mapping for each
variant, which could be used to map data directories, repeated tests and
job diffs. The name also represents the variant, which might help humans
to find the variant they are looking for.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>