### PR TITLE
avocado.core.runner: optimize sleep times in waiting loops

### DIFF
--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -142,6 +142,7 @@ class TestStatus(object):
         :param timeout: timeout for early_state
         :raise exceptions.TestError: On timeout/error
         """
+        step = 0.01
         end = time.time() + timeout
         while not self.early_status:
             if not proc.is_alive():
@@ -154,7 +155,7 @@ class TestStatus(object):
                        "avocado framework." % timeout)
                 os.kill(proc.pid, signal.SIGKILL)
                 raise exceptions.TestError(msg)
-            time.sleep(0)
+            time.sleep(step)
 
     def _tick(self):
         """

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -379,7 +379,7 @@ class TestRunner(object):
         stage_1_msg_displayed = False
         stage_2_msg_displayed = False
         first = 0.01
-        step = 0.1
+        step = 0.01
         abort_reason = None
 
         while True:


### PR DESCRIPTION
Avocado is running slowly on my machine and the reason are the sleep() calls in the test run loops. This PR optimizes a couple of sleep() calls to make Avocado more responsive and consuming less CPU.