### PR TITLE
[RFC] Remote improvements

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -455,7 +455,6 @@ class Job(object):
             except (IOError, ValueError) as details:
                 raise exceptions.OptionValidationError("Unable to parse mux: "
                                                        "%s" % details)
-        self.args.test_result_total = mux.get_number_of_tests(self.test_suite)
 
         self._make_test_result()
         if not (self.standalone or getattr(self.args, "dry_run", False)):
@@ -466,9 +465,10 @@ class Job(object):
         self._log_job_debug_info(mux)
         jobdata.record(self.args, self.logdir, mux, self.urls, sys.argv)
         replay_map = getattr(self.args, 'replay_map', None)
-        summary = self.test_runner.run_suite(self.test_suite, mux, self.timeout,
-                                             replay_map,
-                                             self.args.test_result_total)
+        summary = self.test_runner.run_suite(self.test_suite,
+                                             mux,
+                                             self.timeout,
+                                             replay_map)
         # If it's all good so far, set job status to 'PASS'
         if self.status == 'RUNNING':
             self.status = 'PASS'

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -422,8 +422,7 @@ class Job(object):
         self._setup_job_results()
         self.__start_job_logging()
 
-        if (getattr(self.args, 'remote_hostname', False) and
-           getattr(self.args, 'remote_no_copy', False)):
+        if getattr(self.args, 'remote_execution', False):
             self.test_suite = [(None, {})]
         else:
             try:

--- a/avocado/core/remote/runner.py
+++ b/avocado/core/remote/runner.py
@@ -27,6 +27,7 @@ from .. import output
 from .. import remoter
 from .. import virt
 from .. import exceptions
+from .. import exit_codes
 from .. import status
 from ..runner import TestRunner
 from ..test import TestName
@@ -208,6 +209,9 @@ class RemoteTestRunner(TestRunner):
             raise exceptions.JobError("Remote execution took longer than "
                                       "specified timeout (%s). Interrupting."
                                       % (timeout))
+
+        if result.exit_status & exit_codes.AVOCADO_JOB_FAIL:
+            raise exceptions.JobError(result.stdout)
 
         json_result = self._parse_json_response(result.stdout)
         for t_dict in json_result['tests']:

--- a/avocado/core/remote/runner.py
+++ b/avocado/core/remote/runner.py
@@ -22,7 +22,6 @@ import logging
 from fabric.exceptions import CommandTimeout
 
 from .test import RemoteTest
-from .. import data_dir
 from .. import output
 from .. import remoter
 from .. import virt
@@ -39,8 +38,6 @@ from ...utils import stacktrace
 class RemoteTestRunner(TestRunner):
 
     """ Tooled TestRunner to run on remote machine using ssh """
-    remote_test_dir = '~/avocado/tests'
-
     # Let's use re.MULTILINE because sometimes servers might have MOTD
     # that will introduce a line break on output.
     remote_version_re = re.compile(r'^Avocado (\d+)\.(\d+)\r?$',
@@ -50,41 +47,6 @@ class RemoteTestRunner(TestRunner):
         super(RemoteTestRunner, self).__init__(job, test_result)
         #: remoter connection to the remote machine
         self.remote = None
-
-    def _copy_files(self):
-        """
-        Gather test directories and copy them recursively to
-        $remote_test_dir + $test_absolute_path.
-        :note: Default tests execution is translated into absolute paths too
-        """
-        if self.job.args.remote_no_copy:    # Leave everything as is
-            return
-
-        # TODO: Use `avocado.core.loader.TestLoader` instead
-        self.remote.makedir(self.remote_test_dir)
-        paths = set()
-        for i in xrange(len(self.job.urls)):
-            url = self.job.urls[i]
-            if not os.path.exists(url):     # use test_dir path + py
-                url = os.path.join(data_dir.get_test_dir(), url)
-            if not os.path.exists(url):
-                raise exceptions.JobError("Unable to map test id '%s' to file"
-                                          % self.job.urls[i])
-            url = os.path.abspath(url)  # always use abspath; avoid clashes
-            # modify url to remote_path + abspath
-            paths.add(url)
-            self.job.urls[i] = self.remote_test_dir + url
-        for path in sorted(paths):
-            rpath = self.remote_test_dir + path
-            self.remote.makedir(os.path.dirname(rpath))
-            self.remote.send_files(path, os.path.dirname(rpath))
-            test_data = path + '.data'
-            if os.path.isdir(test_data):
-                self.remote.send_files(test_data, os.path.dirname(rpath))
-        for mux_file in getattr(self.job.args, 'mux_yaml') or []:
-            rpath = os.path.join(self.remote_test_dir, mux_file)
-            self.remote.makedir(os.path.dirname(rpath))
-            self.remote.send_files(mux_file, rpath)
 
     def setup(self):
         """ Setup remote environment and copy test directories """
@@ -180,27 +142,16 @@ class RemoteTestRunner(TestRunner):
         :return: a dictionary with test results.
         """
         extra_params = []
-        mux_files = [os.path.join(self.remote_test_dir, mux_file)
-                     for mux_file in getattr(self.job.args,
-                                             'mux_yaml') or []]
+        mux_files = [mux_file for mux_file in getattr(self.job.args,
+                                                      'mux_yaml') or []]
         if mux_files:
             extra_params.append("-m %s" % " ".join(mux_files))
 
         if getattr(self.job.args, "dry_run", False):
             extra_params.append("--dry-run")
         urls_str = " ".join(urls)
-        avocado_check_urls_cmd = ('cd %s; avocado list %s '
-                                  '--paginator=off' % (self.remote_test_dir,
-                                                       urls_str))
-        check_urls_result = self.remote.run(avocado_check_urls_cmd,
-                                            ignore_status=True,
-                                            timeout=60)
-        if check_urls_result.exit_status != 0:
-            raise exceptions.JobError(check_urls_result.stdout)
-
-        avocado_cmd = ('cd %s; avocado run --force-job-id %s --json - '
-                       '--archive %s %s' % (self.remote_test_dir,
-                                            self.job.unique_id,
+        avocado_cmd = ('avocado run --force-job-id %s --json - '
+                       '--archive %s %s' % (self.job.unique_id,
                                             urls_str, " ".join(extra_params)))
         try:
             result = self.remote.run(avocado_cmd, ignore_status=True,
@@ -266,7 +217,6 @@ class RemoteTestRunner(TestRunner):
                 if not avocado_installed:
                     raise exceptions.JobError('Remote machine does not seem to'
                                               ' have avocado installed')
-                self._copy_files()
             except Exception as details:
                 stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
                 raise exceptions.JobError(details)
@@ -368,7 +318,6 @@ class VMTestRunner(RemoteTestRunner):
         self.job.args.remote_username = self.job.args.vm_username
         self.job.args.remote_password = self.job.args.vm_password
         self.job.args.remote_key_file = self.job.args.vm_key_file
-        self.job.args.remote_no_copy = self.job.args.vm_no_copy
         self.job.args.remote_timeout = self.job.args.vm_timeout
         super(VMTestRunner, self).setup()
 

--- a/avocado/core/remote/runner.py
+++ b/avocado/core/remote/runner.py
@@ -219,8 +219,7 @@ class RemoteTestRunner(TestRunner):
 
         return json_result
 
-    def run_suite(self, test_suite, mux, timeout=0, replay_map=None,
-                  test_result_total=0):
+    def run_suite(self, test_suite, mux, timeout=0, replay_map=None):
         """
         Run one or more tests and report with test result.
 
@@ -231,7 +230,6 @@ class RemoteTestRunner(TestRunner):
         """
         del test_suite     # using self.job.urls instead
         del mux            # we're not using multiplexation here
-        del test_result_total  # evaluated by the remote avocado
         if not timeout:     # avoid timeout = 0
             timeout = None
         summary = set()
@@ -270,7 +268,8 @@ class RemoteTestRunner(TestRunner):
                 raise exceptions.JobError(details)
             results = self.run_test(self.job.urls, timeout)
             remote_log_dir = os.path.dirname(results['debuglog'])
-            self.result.start_tests()
+            test_result_total = results['total']
+            self.result.start_tests(test_result_total)
             for tst in results['tests']:
                 name = tst['test'].split('-', 1)
                 name = [name[0]] + name[1].split(';')

--- a/avocado/core/result.py
+++ b/avocado/core/result.py
@@ -61,9 +61,9 @@ class ResultProxy(object):
                                       "Result" % plugin)
         self.output_plugins.append(plugin)
 
-    def start_tests(self):
+    def start_tests(self, tests_total):
         for output_plugin in self.output_plugins:
-            output_plugin.start_tests()
+            output_plugin.start_tests(tests_total)
 
     def end_tests(self):
         for output_plugin in self.output_plugins:
@@ -97,7 +97,6 @@ class Result(object):
         self.job_unique_id = getattr(job, "unique_id", None)
         self.logfile = getattr(job, "logfile", None)
         self.args = getattr(job, "args", None)
-        self.tests_total = getattr(self.args, 'test_result_total', 1)
         self.tests_run = 0
         self.tests_total_time = 0.0
         self.passed = 0
@@ -107,6 +106,7 @@ class Result(object):
         self.warned = 0
         self.interrupted = 0
         self.tests = []
+        self.tests_total = 0
 
         # Where this results intends to write to. Convention is that a dash (-)
         # means stdout, and stdout is a special output that can be exclusively
@@ -130,10 +130,11 @@ class Result(object):
         else:
             self.tests_total -= other_skipped_count
 
-    def start_tests(self):
+    def start_tests(self, tests_total):
         """
         Called once before any tests are executed.
         """
+        self.tests_total = tests_total
         self.tests_run += 1
 
     def end_tests(self):
@@ -195,11 +196,11 @@ class HumanResult(Result):
         self.log = logging.getLogger("avocado.app")
         self.__throbber = output.Throbber()
 
-    def start_tests(self):
+    def start_tests(self, tests_total):
         """
         Called once before any tests are executed.
         """
-        super(HumanResult, self).start_tests()
+        super(HumanResult, self).start_tests(tests_total)
         self.log.info("JOB ID     : %s", self.job_unique_id)
         if getattr(self.args, "replay_sourcejob", None):
             self.log.info("SRC JOB ID : %s", self.args.replay_sourcejob)

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -480,8 +480,7 @@ class TestRunner(object):
                 factory = template
             yield factory, variant
 
-    def run_suite(self, test_suite, mux, timeout=0, replay_map=None,
-                  test_result_total=0):
+    def run_suite(self, test_suite, mux, timeout=0, replay_map=None):
         """
         Run one or more tests and report with test result.
 
@@ -493,7 +492,6 @@ class TestRunner(object):
         summary = set()
         if self.job.sysinfo is not None:
             self.job.sysinfo.start_job_hook()
-        self.result.start_tests()
         queue = queues.SimpleQueue()
 
         if timeout > 0:
@@ -501,7 +499,9 @@ class TestRunner(object):
         else:
             deadline = None
 
+        test_result_total = mux.get_number_of_tests(test_suite)
         no_digits = len(str(test_result_total))
+        self.result.start_tests(test_result_total)
 
         index = -1
         try:

--- a/avocado/plugins/docker.py
+++ b/avocado/plugins/docker.py
@@ -195,4 +195,5 @@ class Docker(CLI):
 
     def run(self, args):
         if getattr(args, "docker", None):
+            args.remote_execution = True
             args.test_runner = DockerTestRunner

--- a/avocado/plugins/docker.py
+++ b/avocado/plugins/docker.py
@@ -148,7 +148,6 @@ class DockerTestRunner(RemoteTestRunner):
         self.job.log.info("DOCKER     : Container id '%s'"
                           % self.remote.get_cid())
         self.job.log.debug("DOCKER     : Container name '%s'" % dkr_name)
-        self.job.args.remote_no_copy = self.job.args.docker_no_copy
 
     def tear_down(self):
         try:
@@ -186,10 +185,6 @@ class Docker(CLI):
         cmd_parser.add_argument("--docker-options", default="",
                                 help="Extra options for docker run cmd."
                                 " (see: man docker-run)", metavar="OPT")
-
-        cmd_parser.add_argument("--docker-no-copy", action="store_true",
-                                help="Assume tests are already in the "
-                                "container")
         cmd_parser.add_argument("--docker-no-cleanup", action="store_true",
                                 help="Preserve container after test")
 

--- a/avocado/plugins/remote.py
+++ b/avocado/plugins/remote.py
@@ -106,6 +106,7 @@ class Remote(CLI):
     def run(self, args):
         if self._check_required_args(args, 'remote_hostname',
                                      ('remote_hostname',)):
+            args.remote_execution = True
             register_test_result_class(args, RemoteResult)
             args.test_runner = RemoteTestRunner
             setattr(args, 'stdout_claimed_by', '--remote-hostname')

--- a/avocado/plugins/remote.py
+++ b/avocado/plugins/remote.py
@@ -68,11 +68,6 @@ class Remote(CLI):
                                         help='Specify an identity file with '
                                         'a private key instead of a password '
                                         '(Example: .pem files from Amazon EC2)')
-        self.remote_parser.add_argument('--remote-no-copy',
-                                        dest='remote_no_copy',
-                                        action='store_true',
-                                        help="Don't copy tests and use the "
-                                        "exact uri on guest machine.")
         self.remote_parser.add_argument('--remote-timeout', metavar='SECONDS',
                                         help=("Amount of time (in seconds) to "
                                               "wait for a successful connection"

--- a/avocado/plugins/vm.py
+++ b/avocado/plugins/vm.py
@@ -74,9 +74,6 @@ class VM(CLI):
                                     action='store_true', default=False,
                                     help='Restore VM to a previous state, '
                                     'before running tests')
-        self.vm_parser.add_argument('--vm-no-copy', action='store_true',
-                                    help="Don't copy tests and use the "
-                                    "exact uri on VM machine.")
         self.vm_parser.add_argument('--vm-timeout', metavar='SECONDS',
                                     help=("Amount of time (in seconds) to "
                                           "wait for a successful connection"

--- a/avocado/plugins/vm.py
+++ b/avocado/plugins/vm.py
@@ -109,6 +109,7 @@ class VM(CLI):
 
     def run(self, args):
         if self._check_required_args(args, 'vm_domain', ('vm_domain',)):
+            args.remote_execution = True
             register_test_result_class(args, VMResult)
             args.test_runner = VMTestRunner
             setattr(args, 'stdout_claimed_by', '--vm-domain')

--- a/avocado/plugins/yaml_to_mux.py
+++ b/avocado/plugins/yaml_to_mux.py
@@ -255,6 +255,8 @@ class YamlToMux(CLI):
                              " multiplex (.yaml) FILE(s) (order dependent)")
 
     def run(self, args):
+        if getattr(args, 'remote_execution', False):
+            return
         # Merge the multiplex
         multiplex_files = getattr(args, "mux_yaml", None)
         if multiplex_files:

--- a/docs/source/RunningTestsRemotely.rst
+++ b/docs/source/RunningTestsRemotely.rst
@@ -62,9 +62,8 @@ Once the remote machine is properly setup, you may run your test. Example::
     RESULTS    : PASS 1 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0
     TESTS TIME : 1.01 s
 
-As you can see, Avocado will copy the tests you have to your remote machine and
-execute them. A bit of extra logging information is added to your job summary,
-mainly to distinguish the regular execution from the remote one. Note here that
+A bit of extra logging information is added to your job summary, mainly
+to distinguish the regular execution from the remote one. Note here that
 we did not need `--remote-password` because an SSH key was already setup.
 
 Running Tests on a Virtual Machine
@@ -141,9 +140,8 @@ Once the virtual machine is properly setup, you may run your test. Example::
     RESULTS    : PASS 1 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0
     TESTS TIME : 1.01 s
 
-As you can see, Avocado will copy the tests you have to your libvirt domain and
-execute them. A bit of extra logging information is added to your job summary,
-mainly to distinguish the regular execution from the remote one. Note here that
+A bit of extra logging information is added to your job summary, mainly
+to distinguish the regular execution from the remote one. Note here that
 we did not need `--vm-password` because the SSH key is already setup.
 
 Running Tests on a Docker container

--- a/selftests/unit/test_jsonresult.py
+++ b/selftests/unit/test_jsonresult.py
@@ -32,7 +32,7 @@ class JSONResultTest(unittest.TestCase):
         self.job = job.Job(args)
         self.test_result = Result(FakeJob(args))
         self.test_result.filename = self.tmpfile[1]
-        self.test_result.start_tests()
+        self.test_result.start_tests(1)
         self.test1 = SimpleTest(job=self.job, base_logdir=self.tmpdir)
         self.test1.status = 'PASS'
         self.test1.time_elapsed = 1.23

--- a/selftests/unit/test_xunit.py
+++ b/selftests/unit/test_xunit.py
@@ -38,7 +38,7 @@ class xUnitSucceedTest(unittest.TestCase):
         args.xunit_output = self.tmpfile[1]
         self.job = job.Job(args)
         self.test_result = Result(FakeJob(args))
-        self.test_result.start_tests()
+        self.test_result.start_tests(1)
         self.test1 = SimpleTest(job=self.job, base_logdir=self.tmpdir)
         self.test1.status = 'PASS'
         self.test1.time_elapsed = 1.23


### PR DESCRIPTION
- Move the number of tests probe from the job to the runner.
- Create a unified mechanism to identify we are in a remote execution.
- Improve error handling of remote executions.
- Drop the 'copy files' support for remote executions.