### PR TITLE
Result cleanups [v2]

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -249,7 +249,7 @@ class Job(object):
             test_runner_class = runner.TestRunner
 
         self.test_runner = test_runner_class(job=self,
-                                             test_result=self.result_proxy)
+                                             result_proxy=self.result_proxy)
 
     def _make_old_style_test_result(self):
         """

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -251,31 +251,32 @@ class Job(object):
         self.test_runner = test_runner_class(job=self,
                                              test_result=self.result_proxy)
 
-    def _set_output_plugins(self):
-        if getattr(self.args, 'test_result_classes', None) is not None:
-            for klass in self.args.test_result_classes:
-                test_result_instance = klass(self)
-                self.result_proxy.add_output_plugin(test_result_instance)
-        else:
-            self.result_proxy.add_output_plugin(result.Result(self))
-
-    def _make_test_result(self):
+    def _make_old_style_test_result(self):
         """
-        Set up output plugins.
+        Old style result output plugins setup.
 
-        The basic idea behind the output plugins is:
+        This supports the activation of old style result classes which are
+        registered with :func:`avocado.core.result.register_test_result_class`.
 
-        * If there are any active output plugins, use them
-        * If at the end we only have 2 output plugins (Xunit and JSON), we can
-          add the human output plugin.
+        Then, if no plugin has claimed the STDOUT, activate a HumanResult
+        instance.
+
+        Finally, if no old style result plugin is given, activate a bare
+        bones Result instance, as they serve result information (only)
+        to the new style result plugins.
         """
         if self.args:
-            # If there are any active output plugins, let's use them
-            self._set_output_plugins()
+            if getattr(self.args, 'test_result_classes', None) is not None:
+                for klass in self.args.test_result_classes:
+                    test_result_instance = klass(self)
+                    self.result_proxy.add_output_plugin(test_result_instance)
 
         if not getattr(self.args, 'stdout_claimed_by', False) or self.standalone:
             human_plugin = result.HumanResult(self)
             self.result_proxy.add_output_plugin(human_plugin)
+
+        if not self.result_proxy.output_plugins:
+            self.result_proxy.add_output_plugin(result.Result(self))
 
     def _make_test_suite(self, urls=None):
         """
@@ -457,7 +458,7 @@ class Job(object):
                                                        "%s" % details)
         self.args.test_result_total = mux.get_number_of_tests(self.test_suite)
 
-        self._make_test_result()
+        self._make_old_style_test_result()
         if not (self.standalone or getattr(self.args, "dry_run", False)):
             self._update_latest_link()
         self._make_test_runner()

--- a/avocado/core/remote/result.py
+++ b/avocado/core/remote/result.py
@@ -34,7 +34,7 @@ class RemoteResult(HumanResult):
         HumanResult.__init__(self, job)
         self.test_dir = os.getcwd()
         self.remote_test_dir = '~/avocado/tests'
-        self.urls = self.args.url
+        self.urls = job.args.url
         self.remote = None      # Remote runner initialized during setup
         self.output = '-'
 

--- a/avocado/core/remote/result.py
+++ b/avocado/core/remote/result.py
@@ -36,7 +36,6 @@ class RemoteResult(HumanResult):
         self.remote_test_dir = '~/avocado/tests'
         self.urls = job.args.url
         self.remote = None      # Remote runner initialized during setup
-        self.output = '-'
 
     def tear_down(self):
         """ Cleanup after test execution """

--- a/avocado/core/remote/runner.py
+++ b/avocado/core/remote/runner.py
@@ -45,8 +45,8 @@ class RemoteTestRunner(TestRunner):
     remote_version_re = re.compile(r'^Avocado (\d+)\.(\d+)\r?$',
                                    re.MULTILINE)
 
-    def __init__(self, job, test_result):
-        super(RemoteTestRunner, self).__init__(job, test_result)
+    def __init__(self, job, result_proxy):
+        super(RemoteTestRunner, self).__init__(job, result_proxy)
         #: remoter connection to the remote machine
         self.remote = None
 
@@ -270,7 +270,7 @@ class RemoteTestRunner(TestRunner):
                 raise exceptions.JobError(details)
             results = self.run_test(self.job.urls, timeout)
             remote_log_dir = os.path.dirname(results['debuglog'])
-            self.result.start_tests()
+            self.result_proxy.start_tests()
             for tst in results['tests']:
                 name = tst['test'].split('-', 1)
                 name = [name[0]] + name[1].split(';')
@@ -284,8 +284,8 @@ class RemoteTestRunner(TestRunner):
                                   logfile=tst['logfile'],
                                   fail_reason=tst['fail_reason'])
                 state = test.get_state()
-                self.result.start_test(state)
-                self.result.check_test(state)
+                self.result_proxy.start_test(state)
+                self.result_proxy.check_test(state)
                 if state['status'] == "INTERRUPTED":
                     summary.add("INTERRUPTED")
                 elif not status.mapping[state['status']]:
@@ -297,7 +297,7 @@ class RemoteTestRunner(TestRunner):
             self.remote.receive_files(local_log_dir, zip_filename)
             archive.uncompress(zip_path_filename, local_log_dir)
             os.remove(zip_path_filename)
-            self.result.end_tests()
+            self.result_proxy.end_tests()
         finally:
             try:
                 self.tear_down()
@@ -325,8 +325,8 @@ class VMTestRunner(RemoteTestRunner):
     Test runner to run tests using libvirt domain
     """
 
-    def __init__(self, job, test_result):
-        super(VMTestRunner, self).__init__(job, test_result)
+    def __init__(self, job, result_proxy):
+        super(VMTestRunner, self).__init__(job, result_proxy)
         #: VM used during testing
         self.vm = None
 

--- a/avocado/core/result.py
+++ b/avocado/core/result.py
@@ -96,8 +96,7 @@ class Result(object):
         """
         self.job_unique_id = getattr(job, "unique_id", None)
         self.logfile = getattr(job, "logfile", None)
-        self.args = getattr(job, "args", None)
-        self.tests_total = getattr(self.args, 'test_result_total', 1)
+        self.tests_total = getattr(job.args, 'test_result_total', 1)
         self.tests_run = 0
         self.tests_total_time = 0.0
         self.passed = 0
@@ -194,6 +193,7 @@ class HumanResult(Result):
         super(HumanResult, self).__init__(job)
         self.log = logging.getLogger("avocado.app")
         self.__throbber = output.Throbber()
+        self._replay_source_job = getattr(job.args, "replay_sourcejob", None)
 
     def start_tests(self):
         """
@@ -201,8 +201,8 @@ class HumanResult(Result):
         """
         super(HumanResult, self).start_tests()
         self.log.info("JOB ID     : %s", self.job_unique_id)
-        if getattr(self.args, "replay_sourcejob", None):
-            self.log.info("SRC JOB ID : %s", self.args.replay_sourcejob)
+        if self._replay_source_job is not None:
+            self.log.info("SRC JOB ID : %s", self._replay_source_job)
         self.log.info("JOB LOG    : %s", self.logfile)
         self.log.info("TESTS      : %s", self.tests_total)
 

--- a/avocado/core/result.py
+++ b/avocado/core/result.py
@@ -107,11 +107,6 @@ class Result(object):
         self.interrupted = 0
         self.tests = []
 
-        # Where this results intends to write to. Convention is that a dash (-)
-        # means stdout, and stdout is a special output that can be exclusively
-        # claimed by a result class.
-        self.output = None
-
     def _reconcile(self):
         """
         Make sure job results are reconciled

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -251,16 +251,16 @@ class TestRunner(object):
     """
     DEFAULT_TIMEOUT = 86400
 
-    def __init__(self, job, test_result):
+    def __init__(self, job, result_proxy):
         """
         Creates an instance of TestRunner class.
 
         :param job: an instance of :class:`avocado.core.job.Job`.
-        :param test_result: an instance of
+        :param result_proxy: an instance of
                             :class:`avocado.core.result.ResultProxy`.
         """
         self.job = job
-        self.result = test_result
+        self.result_proxy = result_proxy
         self.sigstopped = False
 
     def _run_test(self, test_factory, queue):
@@ -307,7 +307,7 @@ class TestRunner(object):
         except Exception:
             instance.error(stacktrace.str_unpickable_object(early_state))
 
-        self.result.start_test(early_state)
+        self.result_proxy.start_test(early_state)
         try:
             instance.run_avocado()
         finally:
@@ -442,7 +442,7 @@ class TestRunner(object):
             test_state = add_runner_failure(test_state, "ERROR", "Test reports"
                                             " unsupported test status.")
 
-        self.result.check_test(test_state)
+        self.result_proxy.check_test(test_state)
         if test_state['status'] == "INTERRUPTED":
             summary.add("INTERRUPTED")
         elif not mapping[test_state['status']]:
@@ -493,7 +493,7 @@ class TestRunner(object):
         summary = set()
         if self.job.sysinfo is not None:
             self.job.sysinfo.start_job_hook()
-        self.result.start_tests()
+        self.result_proxy.start_tests()
         queue = queues.SimpleQueue()
 
         if timeout > 0:
@@ -545,7 +545,7 @@ class TestRunner(object):
 
         if self.job.sysinfo is not None:
             self.job.sysinfo.end_job_hook()
-        self.result.end_tests()
+        self.result_proxy.end_tests()
         self.job.funcatexit.run()
         signal.signal(signal.SIGTSTP, signal.SIG_IGN)
         return summary

--- a/avocado/plugins/tap.py
+++ b/avocado/plugins/tap.py
@@ -34,7 +34,7 @@ class TAPResult(Result):
             """
             return self.output.write(msg % args + "\n")
         super(TAPResult, self).__init__(job)
-        self.output = force_output_file or getattr(self.args, 'tap', '-')
+        self.output = force_output_file or getattr(job.args, 'tap', '-')
         if self.output != '-':
             self.output = open(self.output, "w", 1)
             self.__write = writeln

--- a/selftests/unit/test_remote.py
+++ b/selftests/unit/test_remote.py
@@ -137,7 +137,7 @@ _=/usr/bin/env''', exit_status=0)
          .with_args('/local/path/run-2014-05-26-15.45.37.zip').once()
          .ordered())
         Results.should_receive('end_tests').once().ordered()
-        self.runner.result = Results
+        self.runner.result_proxy = Results
 
     def tearDown(self):
         flexmock_teardown()


### PR DESCRIPTION
This is collection of cleanups on the result module, that sets some of the stage for the conversion of the Result class to a pure result (data) holder.

Since these changes do not (or should not) introduce behavior change, I felt like sending them earlier.

--

Changes from v1 (#1537):
 * Removed `output` attribute from RemoteResult
 * Removed `self.args` access on RemoteResult (using `job.args` instead)