### PR TITLE
selftests: Replace custom can_sudo check with process.can_sudo [v2]

### DIFF
--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -98,12 +98,20 @@ class CmdError(Exception):
             return "CmdError"
 
 
-def can_sudo():
+def can_sudo(cmd=None):
     """
-    :return: True when sudo is available (or is root)
+    Check whether sudo is available (or running as root)
     """
-    if os.getuid() == 0:
+    if os.getuid() == 0:    # Root
         return True
+
+    try:    # Does sudo binary exists?
+        path.find_command('sudo')
+    except path.CmdNotFoundError:
+        return False
+
+    if cmd:     # Am I able to run the cmd or plain sudo id?
+        return not system(cmd, ignore_status=True, sudo=True)
     elif system_output("id -u", ignore_status=True, sudo=True).strip() == "0":
         return True
     else:

--- a/selftests/functional/test_lv_utils.py
+++ b/selftests/functional/test_lv_utils.py
@@ -26,6 +26,8 @@ class LVUtilsTest(unittest.TestCase):
 
     @unittest.skipIf(process.system("which vgs", ignore_status=True),
                      "LVM utils not installed (command vgs is missing)")
+    @unittest.skipIf(not process.can_sudo(), "This test requires root or "
+                     "passwordless sudo configured.")
     def setUp(self):
         try:
             process.system("/bin/true", sudo=True)

--- a/selftests/unit/test_utils_iso9660.py
+++ b/selftests/unit/test_utils_iso9660.py
@@ -43,8 +43,8 @@ class BaseIso9660(unittest.TestCase):
         self.iso.close()
         self.iso.close()    # check that double-close won't fail
 
-    @unittest.skipIf(not process.can_sudo(),
-                     "This test requires sudo or root")
+    @unittest.skipIf(not process.can_sudo("mount"),
+                     "This test requires mount to run under sudo or root")
     def mnt_dir_workflow(self):
         """
         Check the mnt_dir functionality

--- a/selftests/unit/test_utils_partition.py
+++ b/selftests/unit/test_utils_partition.py
@@ -29,14 +29,6 @@ def missing_binary(binary):
         return True
 
 
-def cannot_sudo(command):
-    try:
-        process.run(command, sudo=True)
-        False
-    except (process.CmdError, OSError):
-        return True
-
-
 class TestPartition(unittest.TestCase):
 
     """
@@ -45,12 +37,11 @@ class TestPartition(unittest.TestCase):
 
     @unittest.skipIf(missing_binary('mkfs.ext2'),
                      "mkfs.ext2 is required for these tests to run.")
-    @unittest.skipIf(missing_binary('sudo'),
-                     "sudo is required for these tests to run.")
-    @unittest.skipIf(cannot_sudo('mount'),
+    @unittest.skipIf(not process.can_sudo('mount'),
                      'current user must be allowed to run "mount" under sudo')
-    @unittest.skipIf(cannot_sudo('mkfs.ext2 -V'),
-                     'current user must be allowed to run "mkfs.ext2" under sudo')
+    @unittest.skipIf(not process.can_sudo('mkfs.ext2 -V'),
+                     'current user must be allowed to run "mkfs.ext2" under '
+                     'sudo')
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp(prefix="avocado_" + __name__)
         self.mountpoint = os.path.join(self.tmpdir, "disk")


### PR DESCRIPTION
There were several implementations of can_sudo methods in selftests,
most of them broken as eg. "mount" can run without sudo, which is what
happens if sudo is not available.

This patch replaces those custom methods with the one recently
introduced in `avocado.utils.process`.

v1: https://github.com/avocado-framework/avocado/pull/1533

Changes:
```
v2: New commit to support custom command for can_sudo
v2: Use the custom commands (where it makes sense) in selftests
```