### PR TITLE
Remote improvements

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -456,7 +456,6 @@ class Job(object):
             except (IOError, ValueError) as details:
                 raise exceptions.OptionValidationError("Unable to parse mux: "
                                                        "%s" % details)
-        self.args.test_result_total = mux.get_number_of_tests(self.test_suite)
 
         self._make_old_style_test_result()
         if not (self.standalone or getattr(self.args, "dry_run", False)):
@@ -467,9 +466,10 @@ class Job(object):
         self._log_job_debug_info(mux)
         jobdata.record(self.args, self.logdir, mux, self.urls, sys.argv)
         replay_map = getattr(self.args, 'replay_map', None)
-        summary = self.test_runner.run_suite(self.test_suite, mux, self.timeout,
-                                             replay_map,
-                                             self.args.test_result_total)
+        summary = self.test_runner.run_suite(self.test_suite,
+                                             mux,
+                                             self.timeout,
+                                             replay_map)
         # If it's all good so far, set job status to 'PASS'
         if self.status == 'RUNNING':
             self.status = 'PASS'

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -423,16 +423,12 @@ class Job(object):
         self._setup_job_results()
         self.__start_job_logging()
 
-        if (getattr(self.args, 'remote_hostname', False) and
-           getattr(self.args, 'remote_no_copy', False)):
-            self.test_suite = [(None, {})]
-        else:
-            try:
-                self.test_suite = self._make_test_suite(self.urls)
-            except loader.LoaderError as details:
-                stacktrace.log_exc_info(sys.exc_info(), 'avocado.app.debug')
-                self._remove_job_results()
-                raise exceptions.OptionValidationError(details)
+        try:
+            self.test_suite = self._make_test_suite(self.urls)
+        except loader.LoaderError as details:
+            stacktrace.log_exc_info(sys.exc_info(), 'avocado.app.debug')
+            self._remove_job_results()
+            raise exceptions.OptionValidationError(details)
 
         self.job_pre_post_dispatcher.map_method('pre', self)
 

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -116,6 +116,8 @@ class TestLoaderProxy(object):
             self.register_plugin(FileLoader)
         if ExternalLoader not in self.registered_plugins:
             self.register_plugin(ExternalLoader)
+        if RemoteLoader not in self.registered_plugins:
+            self.register_plugin(RemoteLoader)
         # Register external runner when --external-runner is used
         if getattr(args, "external_runner", None):
             self.register_plugin(ExternalLoader)
@@ -793,6 +795,36 @@ class ExternalLoader(TestLoader):
     @staticmethod
     def get_decorator_mapping():
         return {test.ExternalRunnerTest: output.TERM_SUPPORT.healthy_str}
+
+
+class RemoteLoader(TestLoader):
+
+    """
+    Remote-runner loader class
+    """
+    name = 'remote'
+
+    def __init__(self, args, extra_params):
+        super(RemoteLoader, self).__init__(args, extra_params)
+        loaders = getattr(args, 'loaders', None)
+        if loaders is not None and 'remote' in loaders:
+            self.remote = True
+        else:
+            self.remote = False
+
+    def discover(self, url, which_tests=DEFAULT):
+        if self.remote:
+            return [(test.UnknownTest, {'name': url})]
+        else:
+            return []
+
+    @staticmethod
+    def get_type_label_mapping():
+        return {test.UnknownTest: 'REMOTE'}
+
+    @staticmethod
+    def get_decorator_mapping():
+        return {test.UnknownTest: output.TERM_SUPPORT.healthy_str}
 
 
 loader = TestLoaderProxy()

--- a/avocado/core/remote/runner.py
+++ b/avocado/core/remote/runner.py
@@ -22,7 +22,6 @@ import logging
 from fabric.exceptions import CommandTimeout
 
 from .test import RemoteTest
-from .. import data_dir
 from .. import output
 from .. import remoter
 from .. import virt
@@ -49,41 +48,6 @@ class RemoteTestRunner(TestRunner):
         super(RemoteTestRunner, self).__init__(job, result_proxy)
         #: remoter connection to the remote machine
         self.remote = None
-
-    def _copy_files(self):
-        """
-        Gather test directories and copy them recursively to
-        $remote_test_dir + $test_absolute_path.
-        :note: Default tests execution is translated into absolute paths too
-        """
-        if self.job.args.remote_no_copy:    # Leave everything as is
-            return
-
-        # TODO: Use `avocado.core.loader.TestLoader` instead
-        self.remote.makedir(self.remote_test_dir)
-        paths = set()
-        for i in xrange(len(self.job.urls)):
-            url = self.job.urls[i]
-            if not os.path.exists(url):     # use test_dir path + py
-                url = os.path.join(data_dir.get_test_dir(), url)
-            if not os.path.exists(url):
-                raise exceptions.JobError("Unable to map test id '%s' to file"
-                                          % self.job.urls[i])
-            url = os.path.abspath(url)  # always use abspath; avoid clashes
-            # modify url to remote_path + abspath
-            paths.add(url)
-            self.job.urls[i] = self.remote_test_dir + url
-        for path in sorted(paths):
-            rpath = self.remote_test_dir + path
-            self.remote.makedir(os.path.dirname(rpath))
-            self.remote.send_files(path, os.path.dirname(rpath))
-            test_data = path + '.data'
-            if os.path.isdir(test_data):
-                self.remote.send_files(test_data, os.path.dirname(rpath))
-        for mux_file in getattr(self.job.args, 'mux_yaml') or []:
-            rpath = os.path.join(self.remote_test_dir, mux_file)
-            self.remote.makedir(os.path.dirname(rpath))
-            self.remote.send_files(mux_file, rpath)
 
     def setup(self):
         """ Setup remote environment and copy test directories """
@@ -179,23 +143,13 @@ class RemoteTestRunner(TestRunner):
         :return: a dictionary with test results.
         """
         extra_params = []
-        mux_files = [os.path.join(self.remote_test_dir, mux_file)
-                     for mux_file in getattr(self.job.args,
-                                             'mux_yaml') or []]
+        mux_files = getattr(self.job.args, 'mux_yaml') or []
         if mux_files:
             extra_params.append("-m %s" % " ".join(mux_files))
 
         if getattr(self.job.args, "dry_run", False):
             extra_params.append("--dry-run")
         urls_str = " ".join(urls)
-        avocado_check_urls_cmd = ('cd %s; avocado list %s '
-                                  '--paginator=off' % (self.remote_test_dir,
-                                                       urls_str))
-        check_urls_result = self.remote.run(avocado_check_urls_cmd,
-                                            ignore_status=True,
-                                            timeout=60)
-        if check_urls_result.exit_status != 0:
-            raise exceptions.JobError(check_urls_result.stdout)
 
         avocado_cmd = ('cd %s; avocado run --force-job-id %s --json - '
                        '--archive %s %s' % (self.remote_test_dir,
@@ -266,7 +220,6 @@ class RemoteTestRunner(TestRunner):
                 if not avocado_installed:
                     raise exceptions.JobError('Remote machine does not seem to'
                                               ' have avocado installed')
-                self._copy_files()
             except Exception as details:
                 stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
                 raise exceptions.JobError(details)
@@ -368,7 +321,6 @@ class VMTestRunner(RemoteTestRunner):
         self.job.args.remote_username = self.job.args.vm_username
         self.job.args.remote_password = self.job.args.vm_password
         self.job.args.remote_key_file = self.job.args.vm_key_file
-        self.job.args.remote_no_copy = self.job.args.vm_no_copy
         self.job.args.remote_timeout = self.job.args.vm_timeout
         super(VMTestRunner, self).setup()
 

--- a/avocado/core/remote/runner.py
+++ b/avocado/core/remote/runner.py
@@ -209,7 +209,11 @@ class RemoteTestRunner(TestRunner):
                                       "specified timeout (%s). Interrupting."
                                       % (timeout))
 
-        json_result = self._parse_json_response(result.stdout)
+        try:
+            json_result = self._parse_json_response(result.stdout)
+        except:
+            raise exceptions.JobError(result.stdout)
+
         for t_dict in json_result['tests']:
             logdir = os.path.join(self.job.logdir, 'test-results')
             relative_path = astring.string_to_safe_path(t_dict['test'])

--- a/avocado/core/remote/runner.py
+++ b/avocado/core/remote/runner.py
@@ -219,8 +219,7 @@ class RemoteTestRunner(TestRunner):
 
         return json_result
 
-    def run_suite(self, test_suite, mux, timeout=0, replay_map=None,
-                  test_result_total=0):
+    def run_suite(self, test_suite, mux, timeout=0, replay_map=None):
         """
         Run one or more tests and report with test result.
 
@@ -231,7 +230,6 @@ class RemoteTestRunner(TestRunner):
         """
         del test_suite     # using self.job.urls instead
         del mux            # we're not using multiplexation here
-        del test_result_total  # evaluated by the remote avocado
         if not timeout:     # avoid timeout = 0
             timeout = None
         summary = set()
@@ -270,6 +268,7 @@ class RemoteTestRunner(TestRunner):
                 raise exceptions.JobError(details)
             results = self.run_test(self.job.urls, timeout)
             remote_log_dir = os.path.dirname(results['debuglog'])
+            self.result_proxy.tests_total(results['total'])
             self.result_proxy.start_tests()
             for tst in results['tests']:
                 name = tst['test'].split('-', 1)

--- a/avocado/core/result.py
+++ b/avocado/core/result.py
@@ -81,6 +81,10 @@ class ResultProxy(object):
         for output_plugin in self.output_plugins:
             output_plugin.check_test(state)
 
+    def tests_total(self, tests_total):
+        for output_plugin in self.output_plugins:
+            output_plugin.tests_total = tests_total
+
 
 class Result(object):
 
@@ -96,7 +100,7 @@ class Result(object):
         """
         self.job_unique_id = getattr(job, "unique_id", None)
         self.logfile = getattr(job, "logfile", None)
-        self.tests_total = getattr(job.args, 'test_result_total', 1)
+        self.tests_total = 0
         self.tests_run = 0
         self.tests_total_time = 0.0
         self.passed = 0

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -481,8 +481,7 @@ class TestRunner(object):
                 factory = template
             yield factory, variant
 
-    def run_suite(self, test_suite, mux, timeout=0, replay_map=None,
-                  test_result_total=0):
+    def run_suite(self, test_suite, mux, timeout=0, replay_map=None):
         """
         Run one or more tests and report with test result.
 
@@ -494,7 +493,6 @@ class TestRunner(object):
         summary = set()
         if self.job.sysinfo is not None:
             self.job.sysinfo.start_job_hook()
-        self.result_proxy.start_tests()
         queue = queues.SimpleQueue()
 
         if timeout > 0:
@@ -502,7 +500,10 @@ class TestRunner(object):
         else:
             deadline = None
 
+        test_result_total = mux.get_number_of_tests(test_suite)
         no_digits = len(str(test_result_total))
+        self.result_proxy.tests_total(test_result_total)
+        self.result_proxy.start_tests()
 
         index = -1
         try:

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -871,3 +871,7 @@ class TestError(Test):
 
     def test(self):
         self.error(self.exception)
+
+
+class UnknownTest(object):
+    pass

--- a/avocado/plugins/docker.py
+++ b/avocado/plugins/docker.py
@@ -148,7 +148,6 @@ class DockerTestRunner(RemoteTestRunner):
         self.job.log.info("DOCKER     : Container id '%s'"
                           % self.remote.get_cid())
         self.job.log.debug("DOCKER     : Container name '%s'" % dkr_name)
-        self.job.args.remote_no_copy = self.job.args.docker_no_copy
 
     def tear_down(self):
         try:
@@ -186,10 +185,6 @@ class Docker(CLI):
         cmd_parser.add_argument("--docker-options", default="",
                                 help="Extra options for docker run cmd."
                                 " (see: man docker-run)", metavar="OPT")
-
-        cmd_parser.add_argument("--docker-no-copy", action="store_true",
-                                help="Assume tests are already in the "
-                                "container")
         cmd_parser.add_argument("--docker-no-cleanup", action="store_true",
                                 help="Preserve container after test")
 

--- a/avocado/plugins/remote.py
+++ b/avocado/plugins/remote.py
@@ -68,11 +68,6 @@ class Remote(CLI):
                                         help='Specify an identity file with '
                                         'a private key instead of a password '
                                         '(Example: .pem files from Amazon EC2)')
-        self.remote_parser.add_argument('--remote-no-copy',
-                                        dest='remote_no_copy',
-                                        action='store_true',
-                                        help="Don't copy tests and use the "
-                                        "exact uri on guest machine.")
         self.remote_parser.add_argument('--remote-timeout', metavar='SECONDS',
                                         help=("Amount of time (in seconds) to "
                                               "wait for a successful connection"

--- a/avocado/plugins/remote.py
+++ b/avocado/plugins/remote.py
@@ -106,6 +106,7 @@ class Remote(CLI):
     def run(self, args):
         if self._check_required_args(args, 'remote_hostname',
                                      ('remote_hostname',)):
+            args.loaders = ['remote']
             register_test_result_class(args, RemoteResult)
             args.test_runner = RemoteTestRunner
             setattr(args, 'stdout_claimed_by', '--remote-hostname')

--- a/avocado/plugins/vm.py
+++ b/avocado/plugins/vm.py
@@ -74,9 +74,6 @@ class VM(CLI):
                                     action='store_true', default=False,
                                     help='Restore VM to a previous state, '
                                     'before running tests')
-        self.vm_parser.add_argument('--vm-no-copy', action='store_true',
-                                    help="Don't copy tests and use the "
-                                    "exact uri on VM machine.")
         self.vm_parser.add_argument('--vm-timeout', metavar='SECONDS',
                                     help=("Amount of time (in seconds) to "
                                           "wait for a successful connection"

--- a/avocado/plugins/yaml_to_mux.py
+++ b/avocado/plugins/yaml_to_mux.py
@@ -261,9 +261,9 @@ class YamlToMux(CLI):
             debug = getattr(args, "mux_debug", False)
             try:
                 args.mux.data_merge(create_from_yaml(multiplex_files, debug))
-            except IOError as details:
-                logging.getLogger("avocado.app").error(details.strerror)
-                sys.exit(exit_codes.AVOCADO_JOB_FAIL)
+            except IOError:
+                msg = 'Cannot access the multiplex file(s) in this host.'
+                logging.getLogger("avocado.app").warning(msg)
 
         # Deprecated --multiplex option
         multiplex_files = getattr(args, "multiplex", None)

--- a/docs/source/RunningTestsRemotely.rst
+++ b/docs/source/RunningTestsRemotely.rst
@@ -62,9 +62,8 @@ Once the remote machine is properly setup, you may run your test. Example::
     RESULTS    : PASS 1 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0
     TESTS TIME : 1.01 s
 
-As you can see, Avocado will copy the tests you have to your remote machine and
-execute them. A bit of extra logging information is added to your job summary,
-mainly to distinguish the regular execution from the remote one. Note here that
+A bit of extra logging information is added to your job summary, mainly
+to distinguish the regular execution from the remote one. Note here that
 we did not need `--remote-password` because an SSH key was already setup.
 
 Running Tests on a Virtual Machine
@@ -141,9 +140,8 @@ Once the virtual machine is properly setup, you may run your test. Example::
     RESULTS    : PASS 1 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0
     TESTS TIME : 1.01 s
 
-As you can see, Avocado will copy the tests you have to your libvirt domain and
-execute them. A bit of extra logging information is added to your job summary,
-mainly to distinguish the regular execution from the remote one. Note here that
+A bit of extra logging information is added to your job summary, mainly
+to distinguish the regular execution from the remote one. Note here that
 we did not need `--vm-password` because the SSH key is already setup.
 
 Running Tests on a Docker container

--- a/selftests/functional/test_multiplex.py
+++ b/selftests/functional/test_multiplex.py
@@ -54,9 +54,10 @@ class MultiplexTests(unittest.TestCase):
 
     def test_mplex_plugin_nonexistent(self):
         cmd_line = './scripts/avocado multiplex -m nonexist'
-        expected_rc = exit_codes.AVOCADO_JOB_FAIL
+        expected_rc = exit_codes.AVOCADO_ALL_OK
         result = self.run_and_check(cmd_line, expected_rc)
-        self.assertIn('No such file or directory', result.stderr)
+        self.assertIn('Cannot access the multiplex file(s) in this host.',
+                      result.stderr)
 
     def test_mplex_debug(self):
         cmd_line = ('./scripts/avocado multiplex -c -d -m '

--- a/selftests/unit/test_jsonresult.py
+++ b/selftests/unit/test_jsonresult.py
@@ -32,6 +32,7 @@ class JSONResultTest(unittest.TestCase):
         self.job = job.Job(args)
         self.test_result = Result(FakeJob(args))
         self.test_result.filename = self.tmpfile[1]
+        self.test_result.tests_total = 1
         self.test_result.start_tests()
         self.test1 = SimpleTest(job=self.job, base_logdir=self.tmpdir)
         self.test1.status = 'PASS'

--- a/selftests/unit/test_remote.py
+++ b/selftests/unit/test_remote.py
@@ -35,10 +35,10 @@ class RemoteTestRunnerTest(unittest.TestCase):
                         remote_port=22,
                         remote_password='password',
                         remote_key_file=None,
-                        remote_no_copy=False,
                         remote_timeout=60,
                         show_job_log=False,
-                        mux_yaml=['foo.yaml', 'bar/baz.yaml'],
+                        mux_yaml=['~/avocado/tests/foo.yaml',
+                                  '~/avocado/tests/bar/baz.yaml'],
                         dry_run=True,
                         env_keep=None)
         log = flexmock()
@@ -51,7 +51,6 @@ class RemoteTestRunnerTest(unittest.TestCase):
         flexmock(remote.RemoteTestRunner).should_receive('__init__')
         self.runner = remote.RemoteTestRunner(job, None)
         self.runner.job = job
-        self.runner._copy_files = lambda: True  # Skip _copy_files
 
         filehandler = logging.StreamHandler()
         flexmock(logging).should_receive("FileHandler").and_return(filehandler)
@@ -96,13 +95,6 @@ _=/usr/bin/env''', exit_status=0)
          .with_args(args_version, ignore_status=True, timeout=60)
          .once().and_return(version_result))
 
-        args = ('cd ~/avocado/tests; avocado list /tests/sleeptest '
-                '/tests/other/test passtest --paginator=off')
-        urls_result = flexmock(exit_status=0)
-        (Remote.should_receive('run')
-         .with_args(args, ignore_status=True, timeout=60)
-         .once().and_return(urls_result))
-
         args = ("cd ~/avocado/tests; avocado run --force-job-id 1-sleeptest;0 "
                 "--json - --archive /tests/sleeptest /tests/other/test "
                 "passtest -m ~/avocado/tests/foo.yaml "
@@ -113,7 +105,8 @@ _=/usr/bin/env''', exit_status=0)
         Results = flexmock(remote=Remote, urls=['sleeptest'],
                            stream=stream, timeout=None,
                            args=flexmock(show_job_log=False,
-                                         mux_yaml=['foo.yaml', 'bar/baz.yaml'],
+                                         mux_yaml=['~/avocado/tests/foo.yaml',
+                                                   '~/avocado/tests/bar/baz.yaml'],
                                          dry_run=True))
         Results.should_receive('tests_total').once().with_args(1).ordered()
         Results.should_receive('start_tests').once().ordered()
@@ -170,7 +163,6 @@ class RemoteTestRunnerSetup(unittest.TestCase):
                         remote_port=22,
                         remote_password='password',
                         remote_key_file=None,
-                        remote_no_copy=False,
                         remote_timeout=60,
                         show_job_log=False,
                         env_keep=None)

--- a/selftests/unit/test_remote.py
+++ b/selftests/unit/test_remote.py
@@ -115,6 +115,7 @@ _=/usr/bin/env''', exit_status=0)
                            args=flexmock(show_job_log=False,
                                          mux_yaml=['foo.yaml', 'bar/baz.yaml'],
                                          dry_run=True))
+        Results.should_receive('tests_total').once().with_args(1).ordered()
         Results.should_receive('start_tests').once().ordered()
         args = {'status': u'PASS', 'whiteboard': '', 'time_start': 0,
                 'name': '1-sleeptest;0', 'class_name': 'RemoteTest',

--- a/selftests/unit/test_xunit.py
+++ b/selftests/unit/test_xunit.py
@@ -38,6 +38,7 @@ class xUnitSucceedTest(unittest.TestCase):
         args.xunit_output = self.tmpfile[1]
         self.job = job.Job(args)
         self.test_result = Result(FakeJob(args))
+        self.test_result.tests_total = 1
         self.test_result.start_tests()
         self.test1 = SimpleTest(job=self.job, base_logdir=self.tmpdir)
         self.test1.status = 'PASS'


### PR DESCRIPTION
- Move the number of tests probe from the job to the runner.
- Create a remote loader for the remote plugin.
- Improve error handling of remote executions.
- Drop the 'copy files' support for remote executions.