### PR TITLE
Result: plugins and job changes

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -108,6 +108,7 @@ class Job(object):
         self.test_index = 1
         self.status = "RUNNING"
         self.result_proxy = result.ResultProxy()
+        self.result = result.Result(self)
         self.sysinfo = None
         self.timeout = getattr(self.args, 'job_timeout', 0)
         self.__logging_handlers = {}
@@ -248,7 +249,8 @@ class Job(object):
             test_runner_class = runner.TestRunner
 
         self.test_runner = test_runner_class(job=self,
-                                             result_proxy=self.result_proxy)
+                                             result_proxy=self.result_proxy,
+                                             result=self.result)
 
     def _make_old_style_test_result(self):
         """

--- a/avocado/core/remote/runner.py
+++ b/avocado/core/remote/runner.py
@@ -45,8 +45,8 @@ class RemoteTestRunner(TestRunner):
     remote_version_re = re.compile(r'^Avocado (\d+)\.(\d+)\r?$',
                                    re.MULTILINE)
 
-    def __init__(self, job, result_proxy):
-        super(RemoteTestRunner, self).__init__(job, result_proxy)
+    def __init__(self, job, result_proxy, result):
+        super(RemoteTestRunner, self).__init__(job, result_proxy, result)
         #: remoter connection to the remote machine
         self.remote = None
 
@@ -271,6 +271,7 @@ class RemoteTestRunner(TestRunner):
             results = self.run_test(self.job.urls, timeout)
             remote_log_dir = os.path.dirname(results['debuglog'])
             self.result_proxy.start_tests()
+            self.result.start_tests()
             for tst in results['tests']:
                 name = tst['test'].split('-', 1)
                 name = [name[0]] + name[1].split(';')
@@ -285,7 +286,9 @@ class RemoteTestRunner(TestRunner):
                                   fail_reason=tst['fail_reason'])
                 state = test.get_state()
                 self.result_proxy.start_test(state)
+                self.result.start_test(state)
                 self.result_proxy.check_test(state)
+                self.result.check_test(state)
                 if state['status'] == "INTERRUPTED":
                     summary.add("INTERRUPTED")
                 elif not status.mapping[state['status']]:
@@ -298,6 +301,7 @@ class RemoteTestRunner(TestRunner):
             archive.uncompress(zip_path_filename, local_log_dir)
             os.remove(zip_path_filename)
             self.result_proxy.end_tests()
+            self.result.end_tests()
         finally:
             try:
                 self.tear_down()
@@ -325,8 +329,8 @@ class VMTestRunner(RemoteTestRunner):
     Test runner to run tests using libvirt domain
     """
 
-    def __init__(self, job, result_proxy):
-        super(VMTestRunner, self).__init__(job, result_proxy)
+    def __init__(self, job, result_proxy, result):
+        super(VMTestRunner, self).__init__(job, result_proxy, result)
         #: VM used during testing
         self.vm = None
 

--- a/avocado/core/result.py
+++ b/avocado/core/result.py
@@ -94,7 +94,7 @@ class Result(object):
 
         :param job: an instance of :class:`avocado.core.job.Job`.
         """
-        self.job_unique_id = getattr(job, "unique_id", None)
+        self.job_unique_id = getattr(job, "unique_id")
         self.logfile = getattr(job, "logfile", None)
         self.tests_total = getattr(job.args, 'test_result_total', 0)
         self.tests_run = 0

--- a/avocado/core/result.py
+++ b/avocado/core/result.py
@@ -96,7 +96,7 @@ class Result(object):
         """
         self.job_unique_id = getattr(job, "unique_id", None)
         self.logfile = getattr(job, "logfile", None)
-        self.tests_total = getattr(job.args, 'test_result_total', 1)
+        self.tests_total = getattr(job.args, 'test_result_total', 0)
         self.tests_run = 0
         self.tests_total_time = 0.0
         self.passed = 0

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -252,16 +252,18 @@ class TestRunner(object):
     """
     DEFAULT_TIMEOUT = 86400
 
-    def __init__(self, job, result_proxy):
+    def __init__(self, job, result_proxy, result):
         """
         Creates an instance of TestRunner class.
 
         :param job: an instance of :class:`avocado.core.job.Job`.
         :param result_proxy: an instance of
                             :class:`avocado.core.result.ResultProxy`.
+        :param result: an instance of :class:`avocado.core.result.Result`
         """
         self.job = job
         self.result_proxy = result_proxy
+        self.result = result
         self.sigstopped = False
 
     def _run_test(self, test_factory, queue):
@@ -309,6 +311,7 @@ class TestRunner(object):
             instance.error(stacktrace.str_unpickable_object(early_state))
 
         self.result_proxy.start_test(early_state)
+        self.result.start_test(early_state)
         try:
             instance.run_avocado()
         finally:
@@ -444,6 +447,7 @@ class TestRunner(object):
                                             " unsupported test status.")
 
         self.result_proxy.check_test(test_state)
+        self.result.check_test(test_state)
         if test_state['status'] == "INTERRUPTED":
             summary.add("INTERRUPTED")
         elif not mapping[test_state['status']]:
@@ -495,6 +499,7 @@ class TestRunner(object):
         if self.job.sysinfo is not None:
             self.job.sysinfo.start_job_hook()
         self.result_proxy.start_tests()
+        self.result.start_tests()
         queue = queues.SimpleQueue()
 
         if timeout > 0:
@@ -547,6 +552,7 @@ class TestRunner(object):
         if self.job.sysinfo is not None:
             self.job.sysinfo.end_job_hook()
         self.result_proxy.end_tests()
+        self.result.end_tests()
         self.job.funcatexit.run()
         signal.signal(signal.SIGTSTP, signal.SIG_IGN)
         return summary

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -168,10 +168,7 @@ class Run(CLICmd):
         job_run = job_instance.run()
         result_dispatcher = ResultDispatcher()
         if result_dispatcher.extensions:
-            # At this point job_instance doesn't have a single results
-            # attribute which is the end goal.  For now, we pick any of the
-            # plugin classes added to the result proxy.
-            if len(job_instance.result_proxy.output_plugins) > 0:
-                result = job_instance.result_proxy.output_plugins[0]
-                result_dispatcher.map_method('render', result, job_instance)
+            result_dispatcher.map_method('render',
+                                         job_instance.result,
+                                         job_instance)
         return job_run

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -166,9 +166,10 @@ class Run(CLICmd):
             sys.exit(exit_codes.AVOCADO_FAIL)
         job_instance = job.Job(args)
         job_run = job_instance.run()
-        result_dispatcher = ResultDispatcher()
-        if result_dispatcher.extensions:
-            result_dispatcher.map_method('render',
-                                         job_instance.result,
-                                         job_instance)
+        if job_instance.result.tests_total > 0:
+            result_dispatcher = ResultDispatcher()
+            if result_dispatcher.extensions:
+                result_dispatcher.map_method('render',
+                                             job_instance.result,
+                                             job_instance)
         return job_run

--- a/selftests/functional/test_argument_parsing.py
+++ b/selftests/functional/test_argument_parsing.py
@@ -72,9 +72,5 @@ class ArgumentParsingErrorEarlyTest(unittest.TestCase):
         self.run_but_fail_before_create_job_dir('--whacky-option passtest',
                                                 exit_codes.AVOCADO_FAIL)
 
-    def test_empty_option(self):
-        self.run_but_fail_before_create_job_dir('',
-                                                exit_codes.AVOCADO_JOB_FAIL)
-
 if __name__ == '__main__':
     unittest.main()

--- a/selftests/unit/test_jsonresult.py
+++ b/selftests/unit/test_jsonresult.py
@@ -15,6 +15,7 @@ class FakeJob(object):
 
     def __init__(self, args):
         self.args = args
+        self.unique_id = '0000000000000000000000000000000000000000'
 
 
 class JSONResultTest(unittest.TestCase):

--- a/selftests/unit/test_remote.py
+++ b/selftests/unit/test_remote.py
@@ -115,7 +115,13 @@ _=/usr/bin/env''', exit_status=0)
                            args=flexmock(show_job_log=False,
                                          mux_yaml=['foo.yaml', 'bar/baz.yaml'],
                                          dry_run=True))
+        Result = flexmock(remote=Remote, urls=['sleeptest'],
+                          stream=stream, timeout=None,
+                          args=flexmock(show_job_log=False,
+                                        mux_yaml=['foo.yaml', 'bar/baz.yaml'],
+                                        dry_run=True))
         Results.should_receive('start_tests').once().ordered()
+        Result.should_receive('start_tests').once().ordered()
         args = {'status': u'PASS', 'whiteboard': '', 'time_start': 0,
                 'name': '1-sleeptest;0', 'class_name': 'RemoteTest',
                 'traceback': 'Not supported yet',
@@ -126,7 +132,9 @@ _=/usr/bin/env''', exit_status=0)
                 'logdir': u'/local/path/test-results/1-sleeptest;0',
                 'logfile': u'/local/path/test-results/1-sleeptest;0/debug.log'}
         Results.should_receive('start_test').once().with_args(args).ordered()
+        Result.should_receive('start_test').once().with_args(args).ordered()
         Results.should_receive('check_test').once().with_args(args).ordered()
+        Result.should_receive('check_test').once().with_args(args).ordered()
         (Remote.should_receive('receive_files')
          .with_args('/local/path', '/home/user/avocado/logs/run-2014-05-26-'
                     '15.45.37.zip')).once().ordered()
@@ -137,7 +145,9 @@ _=/usr/bin/env''', exit_status=0)
          .with_args('/local/path/run-2014-05-26-15.45.37.zip').once()
          .ordered())
         Results.should_receive('end_tests').once().ordered()
+        Result.should_receive('end_tests').once().ordered()
         self.runner.result_proxy = Results
+        self.runner.result = Result
 
     def tearDown(self):
         flexmock_teardown()
@@ -176,7 +186,7 @@ class RemoteTestRunnerSetup(unittest.TestCase):
         log = flexmock()
         log.should_receive("info")
         job = flexmock(args=Args, log=log)
-        self.runner = remote.RemoteTestRunner(job, None)
+        self.runner = remote.RemoteTestRunner(job, None, None)
 
     def tearDown(self):
         flexmock_teardown()

--- a/selftests/unit/test_result.py
+++ b/selftests/unit/test_result.py
@@ -1,0 +1,33 @@
+import sys
+import argparse
+if sys.version_info[:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
+
+from avocado.core.result import Result
+
+
+class FakeNonUniqueIdJob(object):
+
+    def __init__(self, args):
+        self.args = args
+
+
+class FakeJob(object):
+
+    def __init__(self, args):
+        self.args = args
+        self.unique_id = '0000000000000000000000000000000000000000'
+
+
+class ResultTest(unittest.TestCase):
+
+    def test_result_job_without_id(self):
+        args = argparse.Namespace()
+        result = Result(FakeJob(args))
+        self.assertRaises(AttributeError, Result, FakeNonUniqueIdJob(args))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/selftests/unit/test_vm.py
+++ b/selftests/unit/test_vm.py
@@ -54,7 +54,7 @@ class VMTestRunnerSetup(unittest.TestCase):
         log = flexmock()
         log.should_receive("info")
         job = flexmock(args=Args, log=log)
-        self.runner = VMTestRunner(job, None)
+        self.runner = VMTestRunner(job, None, None)
         mock_vm.should_receive('stop').once().ordered()
         mock_vm.should_receive('restore_snapshot').once().ordered()
 

--- a/selftests/unit/test_xunit.py
+++ b/selftests/unit/test_xunit.py
@@ -21,6 +21,7 @@ class FakeJob(object):
 
     def __init__(self, args):
         self.args = args
+        self.unique_id = '0000000000000000000000000000000000000000'
 
 
 class xUnitSucceedTest(unittest.TestCase):


### PR DESCRIPTION
This is another incremental set of changes to the handling of results wrt Jobs and the result plugins conversion.

The biggest proposal here is that a Job can indeed be a valid one without any resolved test, that is, an empty test suite. The Job Phase proposal, and at least one card on Trello, describe this situation as valid/desirable.