### PR TITLE
selftests: Replace custom can_sudo check with process.can_sudo [v4]

### DIFF
--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -99,12 +99,20 @@ class CmdError(Exception):
             return "CmdError"
 
 
-def can_sudo():
+def can_sudo(cmd=None):
     """
-    :return: True when sudo is available (or is root)
+    Check whether sudo is available (or running as root)
     """
-    if os.getuid() == 0:
+    if os.getuid() == 0:    # Root
         return True
+
+    try:    # Does sudo binary exists?
+        path.find_command('sudo')
+    except path.CmdNotFoundError:
+        return False
+
+    if cmd:     # Am I able to run the cmd or plain sudo id?
+        return not system(cmd, ignore_status=True, sudo=True)
     elif system_output("id -u", ignore_status=True, sudo=True).strip() == "0":
         return True
     else:

--- a/selftests/functional/test_lv_utils.py
+++ b/selftests/functional/test_lv_utils.py
@@ -26,6 +26,8 @@ class LVUtilsTest(unittest.TestCase):
 
     @unittest.skipIf(process.system("which vgs", ignore_status=True),
                      "LVM utils not installed (command vgs is missing)")
+    @unittest.skipIf(not process.can_sudo(), "This test requires root or "
+                     "passwordless sudo configured.")
     def setUp(self):
         try:
             process.system("/bin/true", sudo=True)

--- a/selftests/unit/test_utils_iso9660.py
+++ b/selftests/unit/test_utils_iso9660.py
@@ -43,8 +43,8 @@ class BaseIso9660(unittest.TestCase):
         self.iso.close()
         self.iso.close()    # check that double-close won't fail
 
-    @unittest.skipIf(not process.can_sudo(),
-                     "This test requires sudo or root")
+    @unittest.skipIf(not process.can_sudo("mount"),
+                     "This test requires mount to run under sudo or root")
     def mnt_dir_workflow(self):
         """
         Check the mnt_dir functionality
@@ -116,7 +116,7 @@ class IsoMount(BaseIso9660):
     Mount-based check
     """
 
-    @unittest.skipIf(not process.can_sudo(),
+    @unittest.skipIf(not process.can_sudo("mount"),
                      "This test requires sudo or root")
     def setUp(self):
         super(IsoMount, self).setUp()


### PR DESCRIPTION
There were several implementations of can_sudo methods in selftests,
most of them broken as eg. "mount" can run without sudo, which is what
happens if sudo is not available.

This patch replaces those custom methods with the one recently
introduced in `avocado.utils.process`.

v1: https://github.com/avocado-framework/avocado/pull/1533
v2: https://github.com/avocado-framework/avocado/pull/1541
v3: https://github.com/avocado-framework/avocado/pull/1542

Changes:
```
v2: New commit to support custom command for can_sudo
v2: Use the custom commands (where it makes sense) in selftests
v3: Change one plain sudo check for "mount" one in iso9660
v3: Add "kill" sudo check in one partition test
v4: Use `kill -l`
v4: Remove the `missing_binary(mkfs.ext2)` which is handled by `can_sudo(mkfs...`
```