### PR TITLE
Test References: mass rename of URL into the proper term

### DIFF
--- a/avocado/core/jobdata.py
+++ b/avocado/core/jobdata.py
@@ -28,28 +28,31 @@ from ..utils.path import init_dir
 JOB_DATA_DIR = 'jobdata'
 JOB_DATA_FALLBACK_DIR = 'replay'
 CONFIG_FILENAME = 'config'
-URLS_FILENAME = 'urls'
+TEST_REFERENCES_FILENAME = 'test_references'
+TEST_REFERENCES_FILENAME_LEGACY = 'urls'
 MUX_FILENAME = 'multiplex'
 PWD_FILENAME = 'pwd'
 ARGS_FILENAME = 'args'
 CMDLINE_FILENAME = 'cmdline'
 
 
-def record(args, logdir, mux, urls=None, cmdline=None):
+def record(args, logdir, mux, references=None, cmdline=None):
     """
     Records all required job information.
     """
     base_dir = init_dir(logdir, JOB_DATA_DIR)
     path_cfg = os.path.join(base_dir, CONFIG_FILENAME)
-    path_urls = os.path.join(base_dir, URLS_FILENAME)
+    path_references = os.path.join(base_dir, TEST_REFERENCES_FILENAME)
+    path_references_legacy = os.path.join(base_dir,
+                                          TEST_REFERENCES_FILENAME_LEGACY)
     path_mux = os.path.join(base_dir, MUX_FILENAME)
     path_pwd = os.path.join(base_dir, PWD_FILENAME)
     path_args = os.path.join(base_dir, ARGS_FILENAME)
     path_cmdline = os.path.join(base_dir, CMDLINE_FILENAME)
 
-    if urls:
-        with open(path_urls, 'w') as urls_file:
-            urls_file.write('%s' % urls)
+    if references:
+        with open(path_references, 'w') as references_file:
+            references_file.write('%s' % references)
 
     with open(path_cfg, 'w') as config_file:
         settings.config.write(config_file)
@@ -87,15 +90,18 @@ def retrieve_pwd(resultsdir):
         return pwd_file.read()
 
 
-def retrieve_urls(resultsdir):
+def retrieve_references(resultsdir):
     """
-    Retrieves the job urls from the results directory.
+    Retrieves the job test references from the results directory.
     """
-    recorded_urls = _retrieve(resultsdir, URLS_FILENAME)
-    if recorded_urls is None:
+    recorded_references = _retrieve(resultsdir, TEST_REFERENCES_FILENAME)
+    if recorded_references is None:
+        recorded_references = _retrieve(resultsdir,
+                                        TEST_REFERENCES_FILENAME_LEGACY)
+    if recorded_references is None:
         return None
-    with open(recorded_urls, 'r') as urls_file:
-        return ast.literal_eval(urls_file.read())
+    with open(recorded_references, 'r') as references_file:
+        return ast.literal_eval(references_file.read())
 
 
 def retrieve_mux(resultsdir):

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -55,21 +55,21 @@ class InvalidLoaderPlugin(LoaderError):
     pass
 
 
-class LoaderUnhandledUrlError(LoaderError):
+class LoaderUnhandledReferenceError(LoaderError):
 
-    """ Urls not handled by any loader """
+    """ Test References not handled by any resolver """
 
-    def __init__(self, unhandled_urls, plugins):
-        super(LoaderUnhandledUrlError, self).__init__()
-        self.unhandled_urls = unhandled_urls
+    def __init__(self, unhandled_references, plugins):
+        super(LoaderUnhandledReferenceError, self).__init__()
+        self.unhandled_references = unhandled_references
         self.plugins = [_.name for _ in plugins]
 
     def __str__(self):
-        return ("Unable to discover url(s) '%s' with loader plugins(s) '%s', "
+        return ("Unable to resolve reference(s) '%s' with plugins(s) '%s', "
                 "try running 'avocado list -V %s' to see the details."
-                % ("', '" .join(self.unhandled_urls),
+                % ("', '" .join(self.unhandled_references),
                    "', '".join(self.plugins),
-                   " ".join(self.unhandled_urls)))
+                   " ".join(self.unhandled_references)))
 
 
 class TestLoaderProxy(object):
@@ -77,7 +77,7 @@ class TestLoaderProxy(object):
     def __init__(self):
         self._initialized_plugins = []
         self.registered_plugins = []
-        self.url_plugin_mapping = {}
+        self.reference_plugin_mapping = {}
 
     def register_plugin(self, plugin):
         try:
@@ -174,12 +174,12 @@ class TestLoaderProxy(object):
             mapping.update(loader_plugin.get_decorator_mapping())
         return mapping
 
-    def discover(self, urls, which_tests=DEFAULT):
+    def discover(self, references, which_tests=DEFAULT):
         """
-        Discover (possible) tests from test urls.
+        Discover (possible) tests from test references.
 
-        :param urls: a list of tests urls; if [] use plugin defaults
-        :type urls: builtin.list
+        :param references: a list of tests references; if [] use plugin defaults
+        :type references: builtin.list
         :param which_tests: Limit tests to be displayed (ALL, AVAILABLE or
                             DEFAULT)
         :return: A list of test factories (tuples (TestClass, test_params))
@@ -192,19 +192,19 @@ class TestLoaderProxy(object):
             # FIXME: Introduce avocado.traceback logger and use here
             stacktrace.log_exc_info(sys.exc_info(), 'avocado.app.debug')
         tests = []
-        unhandled_urls = []
-        if not urls:
+        unhandled_references = []
+        if not references:
             for loader_plugin in self._initialized_plugins:
                 try:
                     tests.extend(loader_plugin.discover(None, which_tests))
                 except Exception as details:
                     handle_exception(loader_plugin, details)
         else:
-            for url in urls:
+            for reference in references:
                 handled = False
                 for loader_plugin in self._initialized_plugins:
                     try:
-                        _test = loader_plugin.discover(url, which_tests)
+                        _test = loader_plugin.discover(reference, which_tests)
                         if _test:
                             tests.extend(_test)
                             handled = True
@@ -213,14 +213,14 @@ class TestLoaderProxy(object):
                     except Exception as details:
                         handle_exception(loader_plugin, details)
                 if not handled:
-                    unhandled_urls.append(url)
-        if unhandled_urls:
+                    unhandled_references.append(reference)
+        if unhandled_references:
             if which_tests:
-                tests.extend([(test.MissingTest, {'name': url})
-                              for url in unhandled_urls])
+                tests.extend([(test.MissingTest, {'name': reference})
+                              for reference in unhandled_references])
             else:
-                raise LoaderUnhandledUrlError(unhandled_urls,
-                                              self._initialized_plugins)
+                raise LoaderUnhandledReferenceError(unhandled_references,
+                                                    self._initialized_plugins)
         return tests
 
     def load_test(self, test_factory):
@@ -321,29 +321,29 @@ class TestLoader(object):
         """
         raise NotImplementedError
 
-    def discover(self, url, which_tests=DEFAULT):
+    def discover(self, reference, which_tests=DEFAULT):
         """
-        Discover (possible) tests from an url.
+        Discover (possible) tests from an reference.
 
-        :param url: the url to be inspected.
-        :type url: str
+        :param reference: the reference to be inspected.
+        :type reference: str
         :param which_tests: Limit tests to be displayed (ALL, AVAILABLE or
                             DEFAULT)
-        :return: a list of test matching the url as params.
+        :return: a list of test matching the reference as params.
         """
         raise NotImplementedError
 
 
 class BrokenSymlink(object):
 
-    """ Dummy object to represent url pointing to a BrokenSymlink path """
+    """ Dummy object to represent reference pointing to a BrokenSymlink path """
 
     pass
 
 
 class AccessDeniedPath(object):
 
-    """ Dummy object to represent url pointing to a inaccessible path """
+    """ Dummy object to represent reference pointing to a inaccessible path """
 
     pass
 
@@ -427,7 +427,7 @@ class FileLoader(TestLoader):
                 test.Test: output.TERM_SUPPORT.healthy_str,
                 FilteredOut: output.TERM_SUPPORT.warn_header_str}
 
-    def discover(self, url, which_tests=DEFAULT):
+    def discover(self, reference, which_tests=DEFAULT):
         """
         Discover (possible) tests from a directory.
 
@@ -438,12 +438,12 @@ class FileLoader(TestLoader):
         found tests are of the allowed type. If not return None (even on
         partial match).
 
-        :param url: the directory path to inspect.
+        :param reference: the directory path to inspect.
         :param which_tests: Limit tests to be displayed (ALL, AVAILABLE or
                             DEFAULT)
         :return: list of matching tests
         """
-        tests = self._discover(url, which_tests)
+        tests = self._discover(reference, which_tests)
         if self.test_type:
             mapping = self.get_type_label_mapping()
             if self.test_type == 'INSTRUMENTED':
@@ -461,40 +461,40 @@ class FileLoader(TestLoader):
                         return None
         return tests
 
-    def _discover(self, url, which_tests=DEFAULT):
+    def _discover(self, reference, which_tests=DEFAULT):
         """
         Recursively walk in a directory and find tests params.
         The tests are returned in alphabetic order.
 
-        :param url: the directory path to inspect.
+        :param reference: the directory path to inspect.
         :param which_tests: Limit tests to be displayed (ALL, AVAILABLE or
                             DEFAULT)
         :return: list of matching tests
         """
-        if url is None:
+        if reference is None:
             if which_tests is DEFAULT:
                 return []  # Return empty set when not listing details
             else:
-                url = data_dir.get_test_dir()
+                reference = data_dir.get_test_dir()
         ignore_suffix = ('.data', '.pyc', '.pyo', '__init__.py',
                          '__main__.py')
 
         # Look for filename:test_method pattern
         subtests_filter = None
-        if ':' in url:
-            _url, _subtests_filter = url.split(':', 1)
-            if os.path.exists(_url):  # otherwise it's ':' in the file name
-                url = _url
+        if ':' in reference:
+            _reference, _subtests_filter = reference.split(':', 1)
+            if os.path.exists(_reference):  # otherwise it's ':' in the file name
+                reference = _reference
                 subtests_filter = re.compile(_subtests_filter)
 
-        if not os.path.isdir(url):  # Single file
-            if (not self._make_tests(url, DEFAULT, subtests_filter) and
+        if not os.path.isdir(reference):  # Single file
+            if (not self._make_tests(reference, DEFAULT, subtests_filter) and
                     not subtests_filter):
-                split_url = shlex.split(url)
-                if (os.access(split_url[0], os.X_OK) and
-                        not os.path.isdir(split_url[0])):
-                    return self._make_test(test.SimpleTest, url)
-            return self._make_tests(url, which_tests, subtests_filter)
+                split_reference = shlex.split(reference)
+                if (os.access(split_reference[0], os.X_OK) and
+                        not os.path.isdir(split_reference[0])):
+                    return self._make_test(test.SimpleTest, reference)
+            return self._make_tests(reference, which_tests, subtests_filter)
 
         tests = []
 
@@ -511,7 +511,7 @@ class FileLoader(TestLoader):
         else:  # DEFAULT, AVAILABLE => skip missing tests
             onerror = skip_non_test
 
-        for dirpath, _, filenames in os.walk(url, onerror=onerror):
+        for dirpath, _, filenames in os.walk(reference, onerror=onerror):
             for file_name in filenames:
                 if not file_name.startswith('.'):
                     for suffix in ignore_suffix:
@@ -774,16 +774,16 @@ class ExternalLoader(TestLoader):
             raise LoaderError(msg)
         return None  # Skip external runner
 
-    def discover(self, url, which_tests=DEFAULT):
+    def discover(self, reference, which_tests=DEFAULT):
         """
-        :param url: arguments passed to the external_runner
+        :param reference: arguments passed to the external_runner
         :param which_tests: Limit tests to be displayed (ALL, AVAILABLE or
                             DEFAULT)
         :return: list of matching tests
         """
-        if (not self._external_runner) or (url is None):
+        if (not self._external_runner) or (reference is None):
             return []
-        return [(test.ExternalRunnerTest, {'name': url, 'external_runner':
+        return [(test.ExternalRunnerTest, {'name': reference, 'external_runner':
                                            self._external_runner})]
 
     @staticmethod

--- a/avocado/core/remote/result.py
+++ b/avocado/core/remote/result.py
@@ -34,7 +34,7 @@ class RemoteResult(HumanResult):
         HumanResult.__init__(self, job)
         self.test_dir = os.getcwd()
         self.remote_test_dir = '~/avocado/tests'
-        self.urls = job.args.url
+        self.references = job.args.reference
         self.remote = None      # Remote runner initialized during setup
 
     def tear_down(self):

--- a/avocado/plugins/list.py
+++ b/avocado/plugins/list.py
@@ -47,7 +47,7 @@ class TestLister(object):
         try:
             return loader.loader.discover(paths,
                                           which_tests=which_tests)
-        except loader.LoaderUnhandledUrlError as details:
+        except loader.LoaderUnhandledReferenceError as details:
             self.log.error(str(details))
             sys.exit(exit_codes.AVOCADO_FAIL)
 

--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -134,9 +134,9 @@ class Replay(CLI):
         if args.replay_teststatus and 'mux' in args.replay_ignore:
             err = ("Option `--replay-test-status` is incompatible with "
                    "`--replay-ignore mux`.")
-        elif args.replay_teststatus and args.url:
+        elif args.replay_teststatus and args.reference:
             err = ("Option --replay-test-status is incompatible with "
-                   "test URLs given on the command line.")
+                   "test references given on the command line.")
         elif args.remote_hostname:
             err = "Currently we don't replay jobs in remote hosts."
         if err is not None:
@@ -189,17 +189,17 @@ class Replay(CLI):
                     setattr(args, option, replay_args[option])
 
         # Keeping this for compatibility.
-        # TODO: Use replay_args['url'] at some point in the future.
-        if getattr(args, 'url', None):
-            log.warn('Overriding the replay urls with urls provided in '
-                     'command line.')
+        # TODO: Use replay_args['reference'] at some point in the future.
+        if getattr(args, 'reference', None):
+            log.warn('Overriding the replay test references with test '
+                     'references given in the command line.')
         else:
-            urls = jobdata.retrieve_urls(resultsdir)
-            if urls is None:
-                log.error('Source job urls data not found. Aborting.')
+            references = jobdata.retrieve_references(resultsdir)
+            if references is None:
+                log.error('Source job test references data not found. Aborting.')
                 sys.exit(exit_codes.AVOCADO_JOB_FAIL)
             else:
-                setattr(args, 'url', urls)
+                setattr(args, 'reference', references)
 
         if 'config' in args.replay_ignore:
             log.warn("Ignoring configuration from source job with "
@@ -232,7 +232,7 @@ class Replay(CLI):
                                                  args.replay_teststatus)
             setattr(args, 'replay_map', replay_map)
 
-        # Use the original directory to discover test urls properly
+        # Use the original directory to resolve test references properly
         pwd = jobdata.retrieve_pwd(resultsdir)
         if pwd is not None:
             if os.path.exists(pwd):

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -47,7 +47,7 @@ class Run(CLICmd):
         """
         parser = super(Run, self).configure(parser)
 
-        parser.add_argument("url", type=str, default=[], nargs='*',
+        parser.add_argument("reference", type=str, default=[], nargs='*',
                             metavar="TEST_REFERENCE",
                             help='List of test references (aliases or paths)')
 

--- a/docs/source/ReferenceGuide.rst
+++ b/docs/source/ReferenceGuide.rst
@@ -253,7 +253,7 @@ results directory structure can be seen below ::
     │   ├── config
     │   ├── multiplex
     │   ├── pwd
-    │   └── urls
+    │   └── test_references
     ├── job.log
     ├── results.json
     ├── results.xml

--- a/docs/source/Replay.rst
+++ b/docs/source/Replay.rst
@@ -11,7 +11,7 @@ the provided part corresponds to the initial characters of the original
 job id and it is also unique enough. Or, instead of the job id, you can
 use the string ``latest`` and avocado will replay the latest job executed.
 
-Let's see an example. First, running a simple job with two urls::
+Let's see an example. First, running a simple job with two test references::
 
      $ avocado run /bin/true /bin/false
      JOB ID     : 825b860b0c2f6ec48953c638432e3e323f8d7cad
@@ -36,7 +36,7 @@ Now we can replay the job by running::
      TESTS TIME : 0.01 s
      JOB HTML   : $HOME/avocado/job-results/job-2016-01-11T16.18-55a0d10/html/results.html
 
-The replay feature will retrieve the original job urls, the multiplex
+The replay feature will retrieve the original test references, the multiplex
 tree and the configuration. Let's see another example, now using
 multiplex file::
 

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -381,7 +381,8 @@ class RunnerOperationTest(unittest.TestCase):
         cmd_line = './scripts/avocado run --sysinfo=off'
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_JOB_FAIL
-        expected_output = 'No urls provided nor any arguments produced'
+        expected_output = ('No test references provided nor any other '
+                           'arguments resolved into tests')
         self.assertEqual(result.exit_status, expected_rc)
         self.assertIn(expected_output, result.stderr)
 
@@ -391,8 +392,8 @@ class RunnerOperationTest(unittest.TestCase):
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_JOB_FAIL
         self.assertEqual(result.exit_status, expected_rc)
-        self.assertIn('Unable to discover url', result.stderr)
-        self.assertNotIn('Unable to discover url', result.stdout)
+        self.assertIn('Unable to resolve reference', result.stderr)
+        self.assertNotIn('Unable to resolve reference', result.stdout)
 
     def test_invalid_unique_id(self):
         cmd_line = ('./scripts/avocado run --sysinfo=off --force-job-id foobar'
@@ -798,7 +799,8 @@ class ExternalRunnerTest(unittest.TestCase):
         cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '
                     '--external-runner=/bin/true' % self.tmpdir)
         result = process.run(cmd_line, ignore_status=True)
-        expected_output = ('No urls provided nor any arguments produced')
+        expected_output = ('No test references provided nor any other '
+                           'arguments resolved into tests')
         self.assertIn(expected_output, result.stderr)
         expected_rc = exit_codes.AVOCADO_JOB_FAIL
         self.assertEqual(result.exit_status, expected_rc,
@@ -853,7 +855,7 @@ class PluginsTest(AbsPluginsTest, unittest.TestCase):
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %d:\n%s" %
                          (expected_rc, result))
-        self.assertIn("Unable to discover url", output)
+        self.assertIn("Unable to resolve reference", output)
 
     def test_plugin_list(self):
         os.chdir(basedir)

--- a/selftests/functional/test_replay_basic.py
+++ b/selftests/functional/test_replay_basic.py
@@ -77,7 +77,8 @@ class ReplayTests(unittest.TestCase):
         """
         Checks if all expected files are there.
         """
-        file_list = ['multiplex', 'config', 'urls', 'pwd', 'args', 'cmdline']
+        file_list = ['multiplex', 'config', 'test_references', 'pwd', 'args',
+                     'cmdline']
         for filename in file_list:
             path = os.path.join(self.jobdir, 'jobdata', filename)
             self.assertTrue(glob.glob(path))
@@ -179,9 +180,9 @@ class ReplayTests(unittest.TestCase):
                "`--replay-ignore mux`")
         self.assertIn(msg, result.stderr)
 
-    def test_run_replay_status_and_urls(self):
+    def test_run_replay_status_and_references(self):
         """
-        Runs a replay job with custom urls and '--replay-test-status'.
+        Runs a replay job with custom test references and --replay-test-status
         """
         cmd_line = ('./scripts/avocado run sleeptest --replay %s '
                     '--replay-test-status FAIL --job-results-dir %s '
@@ -189,8 +190,8 @@ class ReplayTests(unittest.TestCase):
                     (self.jobid, self.tmpdir, self.jobdir))
         expected_rc = exit_codes.AVOCADO_FAIL
         result = self.run_and_check(cmd_line, expected_rc)
-        msg = "Option --replay-test-status is incompatible with "\
-              "test URLs given on the command line."
+        msg = ("Option --replay-test-status is incompatible with "
+               "test references given on the command line.")
         self.assertIn(msg, result.stderr)
 
     def test_run_replay_fallbackdir(self):

--- a/selftests/unit/test_remote.py
+++ b/selftests/unit/test_remote.py
@@ -13,7 +13,8 @@ import logging
 cwd = os.getcwd()
 
 JSON_RESULTS = ('Something other than json\n'
-                '{"tests": [{"test": "1-sleeptest;0", "url": "sleeptest", '
+                '{"tests": [{"test": "1-sleeptest;0",'
+                '"reference": "sleeptest", '
                 '"fail_reason": "None", '
                 '"status": "PASS", "time": 1.23, "start": 0, "end": 1.23}],'
                 '"debuglog": "/home/user/avocado/logs/run-2014-05-26-15.45.'
@@ -44,8 +45,8 @@ class RemoteTestRunnerTest(unittest.TestCase):
         log = flexmock()
         log.should_receive("info")
         job = flexmock(args=Args, log=log,
-                       urls=['/tests/sleeptest', '/tests/other/test',
-                             'passtest'], unique_id='1-sleeptest;0',
+                       references=['/tests/sleeptest', '/tests/other/test',
+                                   'passtest'], unique_id='1-sleeptest;0',
                        logdir="/local/path")
 
         flexmock(remote.RemoteTestRunner).should_receive('__init__')
@@ -98,10 +99,10 @@ _=/usr/bin/env''', exit_status=0)
 
         args = ('cd ~/avocado/tests; avocado list /tests/sleeptest '
                 '/tests/other/test passtest --paginator=off')
-        urls_result = flexmock(exit_status=0)
+        references_result = flexmock(exit_status=0)
         (Remote.should_receive('run')
          .with_args(args, ignore_status=True, timeout=60)
-         .once().and_return(urls_result))
+         .once().and_return(references_result))
 
         args = ("cd ~/avocado/tests; avocado run --force-job-id 1-sleeptest;0 "
                 "--json - --archive /tests/sleeptest /tests/other/test "
@@ -110,7 +111,7 @@ _=/usr/bin/env''', exit_status=0)
         (Remote.should_receive('run')
          .with_args(args, timeout=61, ignore_status=True)
          .once().and_return(test_results))
-        Results = flexmock(remote=Remote, urls=['sleeptest'],
+        Results = flexmock(remote=Remote, references=['sleeptest'],
                            stream=stream, timeout=None,
                            args=flexmock(show_job_log=False,
                                          mux_yaml=['foo.yaml', 'bar/baz.yaml'],
@@ -162,8 +163,8 @@ class RemoteTestRunnerSetup(unittest.TestCase):
          .once().ordered()
          .and_return(Remote))
         Args = flexmock(test_result_total=1,
-                        url=['/tests/sleeptest', '/tests/other/test',
-                             'passtest'],
+                        reference=['/tests/sleeptest', '/tests/other/test',
+                                   'passtest'],
                         remote_username='username',
                         remote_hostname='hostname',
                         remote_port=22,


### PR DESCRIPTION
It's been a while since the "Test ID RFC" came out:

https://www.redhat.com/archives/avocado-devel/2016-March/msg00024.html

Still, we've been referring to test URLs all around our code
and also on user visible strings.  This is an attempt to rename
the mentions of "URLs" that really should be "test references"
or simply "references" at this point.

Signed-off-by: Cleber Rosa <crosa@redhat.com>