### PR TITLE
Job Phases [v3]

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -423,16 +423,7 @@ class Job(object):
         self._setup_job_results()
         self.__start_job_logging()
 
-        if (getattr(self.args, 'remote_hostname', False) and
-           getattr(self.args, 'remote_no_copy', False)):
-            self.test_suite = [(None, {})]
-        else:
-            try:
-                self.test_suite = self._make_test_suite(self.urls)
-            except loader.LoaderError as details:
-                stacktrace.log_exc_info(sys.exc_info(), 'avocado.app.debug')
-                self._remove_job_results()
-                raise exceptions.OptionValidationError(details)
+        self.create_test_suite()
 
         self.job_pre_post_dispatcher.map_method('pre', self)
 
@@ -489,6 +480,23 @@ class Job(object):
             self.exitcode |= exit_codes.AVOCADO_TESTS_FAIL
 
         return self.exitcode
+
+    def create_test_suite(self):
+        """
+        Creates the test suite for this Job
+
+        This is a public Job API as part of the documented Job phases
+        """
+        if (getattr(self.args, 'remote_hostname', False) and
+           getattr(self.args, 'remote_no_copy', False)):
+            self.test_suite = [(None, {})]
+        else:
+            try:
+                self.test_suite = self._make_test_suite(self.urls)
+            except loader.LoaderError as details:
+                stacktrace.log_exc_info(sys.exc_info(), 'avocado.app.debug')
+                self._remove_job_results()
+                raise exceptions.OptionValidationError(details)
 
     def run(self):
         """

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -416,20 +416,6 @@ class Job(object):
         self._log_mux_variants(mux)
         self._log_job_id()
 
-    def _run(self):
-        """
-        Unhandled job method. Runs a list of test URLs to its completion.
-
-        :return: Integer with overall job status. See
-                 :mod:`avocado.core.exit_codes` for more information.
-        :raise: Any exception (avocado crashed), or
-                :class:`avocado.core.exceptions.JobBaseException` errors,
-                that configure a job failure.
-        """
-        self.create_test_suite()
-        self.pre_tests()
-        return self.run_tests()
-
     def create_test_suite(self):
         """
         Creates the test suite for this Job
@@ -523,17 +509,19 @@ class Job(object):
 
     def run(self):
         """
-        Handled main job method. Runs a list of test URLs to its completion.
+        Runs all job phases, returning the test execution results.
 
-        The test runner figures out which tests need to be run on an empty urls
-        list by assuming the first component of the shortname is the test url.
+        This method is supposed to be the simplified interface for
+        jobs, that is, they run all phases of a job.
 
         :return: Integer with overall job status. See
                  :mod:`avocado.core.exit_codes` for more information.
         """
         runtime.CURRENT_JOB = self
         try:
-            return self._run()
+            self.create_test_suite()
+            self.pre_tests()
+            return self.run_tests()
         except exceptions.JobBaseException as details:
             self.status = details.status
             fail_class = details.__class__.__name__

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -149,8 +149,8 @@ class Job(object):
         if not (self.standalone or getattr(self.args, "dry_run", False)):
             self._update_latest_link()
         self.logfile = os.path.join(self.logdir, "job.log")
-        self.idfile = os.path.join(self.logdir, "id")
-        with open(self.idfile, 'w') as id_file_obj:
+        idfile = os.path.join(self.logdir, "id")
+        with open(idfile, 'w') as id_file_obj:
             id_file_obj.write("%s\n" % self.unique_id)
 
     def __start_job_logging(self):

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -106,8 +106,6 @@ class Job(object):
         else:
             self.loglevel = logging.DEBUG
 
-        self.test_dir = data_dir.get_test_dir()
-        self.test_index = 1
         self.status = "RUNNING"
         self.result_proxy = result.ResultProxy()
         self.sysinfo = None

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -120,8 +120,9 @@ class Job(object):
         #: has not been attempted.  If set to an empty list, it means that no
         #: test was found during resolution.
         self.test_suite = None
-        self.job_pre_post_dispatcher = dispatcher.JobPrePostDispatcher()
-        output.log_plugin_failures(self.job_pre_post_dispatcher.load_failures)
+
+        # A job may not have a dispatcher for pre/post tests execution plugins
+        self._job_pre_post_dispatcher = None
 
     def _setup_job_results(self):
         logdir = getattr(self.args, 'logdir', None)
@@ -424,8 +425,7 @@ class Job(object):
         self.__start_job_logging()
 
         self.create_test_suite()
-
-        self.job_pre_post_dispatcher.map_method('pre', self)
+        self.pre_tests()
 
         if not self.test_suite:
             self._remove_job_results()
@@ -498,6 +498,17 @@ class Job(object):
                 self._remove_job_results()
                 raise exceptions.OptionValidationError(details)
 
+    def pre_tests(self):
+        """
+        Run the pre tests execution hooks
+
+        By default this runs the plugins that implement the
+        :class:`avocado.core.plugin_interfaces.JobPre` interface.
+        """
+        self._job_pre_post_dispatcher = dispatcher.JobPrePostDispatcher()
+        output.log_plugin_failures(self._job_pre_post_dispatcher.load_failures)
+        self._job_pre_post_dispatcher.map_method('pre', self)
+
     def run(self):
         """
         Handled main job method. Runs a list of test URLs to its completion.
@@ -537,7 +548,8 @@ class Job(object):
             self.exitcode |= exit_codes.AVOCADO_FAIL
             return self.exitcode
         finally:
-            self.job_pre_post_dispatcher.map_method('post', self)
+            if self._job_pre_post_dispatcher is not None:
+                self._job_pre_post_dispatcher.map_method('post', self)
             if not settings.get_value('runner.behavior', 'keep_tmp_files',
                                       key_type=bool, default=False):
                 data_dir.clean_tmp_files()

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -428,7 +428,36 @@ class Job(object):
         """
         self.create_test_suite()
         self.pre_tests()
+        return self.run_tests()
 
+    def create_test_suite(self):
+        """
+        Creates the test suite for this Job
+
+        This is a public Job API as part of the documented Job phases
+        """
+        if (getattr(self.args, 'remote_hostname', False) and
+           getattr(self.args, 'remote_no_copy', False)):
+            self.test_suite = [(None, {})]
+        else:
+            try:
+                self.test_suite = self._make_test_suite(self.urls)
+            except loader.LoaderError as details:
+                stacktrace.log_exc_info(sys.exc_info(), 'avocado.app.debug')
+                raise exceptions.OptionValidationError(details)
+
+    def pre_tests(self):
+        """
+        Run the pre tests execution hooks
+
+        By default this runs the plugins that implement the
+        :class:`avocado.core.plugin_interfaces.JobPre` interface.
+        """
+        self._job_pre_post_dispatcher = dispatcher.JobPrePostDispatcher()
+        output.log_plugin_failures(self._job_pre_post_dispatcher.load_failures)
+        self._job_pre_post_dispatcher.map_method('pre', self)
+
+    def run_tests(self):
         if not self.test_suite:
             if self.urls:
                 e_msg = ("No tests found for given urls, try 'avocado list -V "
@@ -479,33 +508,6 @@ class Job(object):
             self.exitcode |= exit_codes.AVOCADO_TESTS_FAIL
 
         return self.exitcode
-
-    def create_test_suite(self):
-        """
-        Creates the test suite for this Job
-
-        This is a public Job API as part of the documented Job phases
-        """
-        if (getattr(self.args, 'remote_hostname', False) and
-           getattr(self.args, 'remote_no_copy', False)):
-            self.test_suite = [(None, {})]
-        else:
-            try:
-                self.test_suite = self._make_test_suite(self.urls)
-            except loader.LoaderError as details:
-                stacktrace.log_exc_info(sys.exc_info(), 'avocado.app.debug')
-                raise exceptions.OptionValidationError(details)
-
-    def pre_tests(self):
-        """
-        Run the pre tests execution hooks
-
-        By default this runs the plugins that implement the
-        :class:`avocado.core.plugin_interfaces.JobPre` interface.
-        """
-        self._job_pre_post_dispatcher = dispatcher.JobPrePostDispatcher()
-        output.log_plugin_failures(self._job_pre_post_dispatcher.load_failures)
-        self._job_pre_post_dispatcher.map_method('pre', self)
 
     def run(self):
         """

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -115,7 +115,7 @@ class Job(object):
         self.funcatexit = data_structures.CallbackRegister("JobExit %s"
                                                            % self.unique_id,
                                                            _TEST_LOGGER)
-        self.stdout_stderr = None
+        self._stdout_stderr = None
         self.replay_sourcejob = getattr(self.args, 'replay_sourcejob', None)
         self.exitcode = exit_codes.AVOCADO_ALL_OK
         #: The list of discovered/resolved tests that will be attempted to
@@ -190,7 +190,7 @@ class Job(object):
         enabled_logs = getattr(self.args, "show", [])
         if ('test' in enabled_logs and
                 'early' not in enabled_logs):
-            self.stdout_stderr = sys.stdout, sys.stderr
+            self._stdout_stderr = sys.stdout, sys.stderr
             # Enable std{out,err} but redirect booth to stderr
             sys.stdout = STD_OUTPUT.stdout
             sys.stderr = STD_OUTPUT.stdout
@@ -203,8 +203,8 @@ class Job(object):
             self.__logging_handlers[test_handler] = ["avocado.test", ""]
 
     def __stop_job_logging(self):
-        if self.stdout_stderr:
-            sys.stdout, sys.stderr = self.stdout_stderr
+        if self._stdout_stderr:
+            sys.stdout, sys.stderr = self._stdout_stderr
         for handler, loggers in self.__logging_handlers.iteritems():
             for logger in loggers:
                 logging.getLogger(logger).removeHandler(handler)

--- a/selftests/functional/test_argument_parsing.py
+++ b/selftests/functional/test_argument_parsing.py
@@ -72,9 +72,5 @@ class ArgumentParsingErrorEarlyTest(unittest.TestCase):
         self.run_but_fail_before_create_job_dir('--whacky-option passtest',
                                                 exit_codes.AVOCADO_FAIL)
 
-    def test_empty_option(self):
-        self.run_but_fail_before_create_job_dir('',
-                                                exit_codes.AVOCADO_JOB_FAIL)
-
 if __name__ == '__main__':
     unittest.main()

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -7,16 +7,16 @@ else:
 
 from avocado.core import test
 from avocado.core import job
+from avocado.core import exit_codes
 from avocado.utils import path as utils_path
 
 
 class JobTest(unittest.TestCase):
 
     @staticmethod
-    def _find_simple_test_candidates():
-        simple_test_candidates = ['true', 'time', 'uptime']
+    def _find_simple_test_candidates(candidates=['true', 'time', 'uptime']):
         found = []
-        for candidate in simple_test_candidates:
+        for candidate in candidates:
             try:
                 found.append(utils_path.find_command(candidate))
             except utils_path.CmdNotFoundError:
@@ -67,6 +67,14 @@ class JobTest(unittest.TestCase):
         myjob.create_test_suite()
         myjob.pre_tests()
         self.assertLessEqual(len(myjob.test_suite), 1)
+
+    def test_job_run_tests(self):
+        simple_tests_found = self._find_simple_test_candidates(['true'])
+        args = argparse.Namespace(url=simple_tests_found)
+        myjob = job.Job(args)
+        myjob.create_test_suite()
+        self.assertEqual(myjob.run_tests(),
+                         exit_codes.AVOCADO_ALL_OK)
 
 if __name__ == '__main__':
     unittest.main()

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -6,9 +6,21 @@ else:
     import unittest
 
 from avocado.core import job
+from avocado.utils import path as utils_path
 
 
 class JobTest(unittest.TestCase):
+
+    @staticmethod
+    def _find_simple_test_candidates():
+        simple_test_candidates = ['true', 'time', 'uptime']
+        found = []
+        for candidate in simple_test_candidates:
+            try:
+                found.append(utils_path.find_command(candidate))
+            except utils_path.CmdNotFoundError:
+                pass
+        return found
 
     def test_job_empty_suite(self):
         args = argparse.Namespace()
@@ -19,6 +31,24 @@ class JobTest(unittest.TestCase):
         args = argparse.Namespace()
         empty_job = job.Job(args)
         self.assertIsNotNone(empty_job.unique_id)
+
+    def test_job_test_suite_not_created(self):
+        args = argparse.Namespace()
+        myjob = job.Job(args)
+        self.assertIsNone(myjob.test_suite)
+
+    def test_job_create_test_suite_empty(self):
+        args = argparse.Namespace()
+        myjob = job.Job(args)
+        myjob.create_test_suite()
+        self.assertEqual(myjob.test_suite, [])
+
+    def test_job_create_test_suite_simple(self):
+        simple_tests_found = self._find_simple_test_candidates()
+        args = argparse.Namespace(url=simple_tests_found)
+        myjob = job.Job(args)
+        myjob.create_test_suite()
+        self.assertEqual(len(simple_tests_found), len(myjob.test_suite))
 
 if __name__ == '__main__':
     unittest.main()

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -1,0 +1,24 @@
+import argparse
+import sys
+if sys.version_info[:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
+
+from avocado.core import job
+
+
+class JobTest(unittest.TestCase):
+
+    def test_job_empty_suite(self):
+        args = argparse.Namespace()
+        empty_job = job.Job(args)
+        self.assertIsNone(empty_job.test_suite)
+
+    def test_job_empty_has_id(self):
+        args = argparse.Namespace()
+        empty_job = job.Job(args)
+        self.assertIsNotNone(empty_job.unique_id)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -93,5 +93,30 @@ class JobTest(unittest.TestCase):
         self.assertEqual(myjob.unique_id[::-1],
                          open(os.path.join(myjob.logdir, "reversed_id")).read())
 
+    @unittest.skip("Issue described at https://trello.com/c/qgSTIK0Y")
+    def test_job_run(self):
+        class JobFilterLog(job.Job):
+            def pre_tests(self):
+                filtered_test_suite = []
+                for test_factory in self.test_suite:
+                    if test_factory[0] is test.SimpleTest:
+                        if not test_factory[1].get('name', '').endswith('time'):
+                            filtered_test_suite.append(test_factory)
+                self.test_suite = filtered_test_suite
+                super(JobFilterLog, self).pre_tests()
+
+            def post_tests(self):
+                with open(os.path.join(self.logdir, "reversed_id"), "w") as f:
+                    f.write(self.unique_id[::-1])
+                super(JobFilterLog, self).post_tests()
+        simple_tests_found = self._find_simple_test_candidates()
+        args = argparse.Namespace(url=simple_tests_found)
+        myjob = JobFilterLog(args)
+        self.assertEqual(myjob.run(),
+                         exit_codes.AVOCADO_ALL_OK)
+        self.assertLessEqual(len(myjob.test_suite), 1)
+        self.assertEqual(myjob.unique_id[::-1],
+                         open(os.path.join(myjob.logdir, "reversed_id")).read())
+
 if __name__ == '__main__':
     unittest.main()

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 import sys
 if sys.version_info[:2] == (2, 6):
     import unittest2 as unittest
@@ -75,6 +76,22 @@ class JobTest(unittest.TestCase):
         myjob.create_test_suite()
         self.assertEqual(myjob.run_tests(),
                          exit_codes.AVOCADO_ALL_OK)
+
+    def test_job_post_tests(self):
+        class JobLogPost(job.Job):
+            def post_tests(self):
+                with open(os.path.join(self.logdir, "reversed_id"), "w") as f:
+                    f.write(self.unique_id[::-1])
+                super(JobLogPost, self).post_tests()
+        simple_tests_found = self._find_simple_test_candidates()
+        args = argparse.Namespace(url=simple_tests_found)
+        myjob = JobLogPost(args)
+        myjob.create_test_suite()
+        myjob.pre_tests()
+        myjob.run_tests()
+        myjob.post_tests()
+        self.assertEqual(myjob.unique_id[::-1],
+                         open(os.path.join(myjob.logdir, "reversed_id")).read())
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Even though the previous version was an RFC, the feedback received was positivite so it motivated a V2 (non-RFC). This is a code based version of the proposal presented earlier on the mailing list:

https://www.redhat.com/archives/avocado-devel/2016-September/msg00044.html

On this version, the distinct Job Phases can be clearly seen in the code as the only public methods on the Job class.  They're:

 * `create_test_suite()`
 * `pre_tests()`
 * `run_tests()`
 * `post_tests()`
 * `run()`

The accompanying unittest (`selftests/unit/test_job.py`) show how onw can programmatically use a job instance.

--

Changes from v2 (#1549):
 * Updated docstring on `run()`
 * Updated commit message from "Job API" to "Job Phases"
 * Added `__main__` section to `test_job.py`

Changes from RFC (#1498):
 * Added tests
 * Made many Job class attributes private
 * Added proposed solution for https://trello.com/c/hu4vxQOL/511-add-proper-status-for-test-references-that-can-not-be-resolved-loaded, which impacted the use Job instances and the Job phases