### PR TITLE
multiplexer: Separate the mux and improve the variant-ids [v0.2]

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -373,6 +373,8 @@ class Job(object):
         job_log.info('')
 
     def _log_mux_tree(self, mux):
+        if not mux.variants:
+            return
         job_log = _TEST_LOGGER
         tree_repr = tree.tree_view(mux.variants.root, verbose=True,
                                    use_utf8=False)
@@ -388,6 +390,8 @@ class Job(object):
         job_log.info('')
 
     def _log_mux_variants(self, mux):
+        if not mux.variants:
+            return
         job_log = _TEST_LOGGER
 
         for (index, tpl) in enumerate(mux.variants):

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -372,34 +372,16 @@ class Job(object):
         job_log.info('logs     ' + data_dir.get_logs_dir())
         job_log.info('')
 
-    def _log_mux_tree(self, mux):
-        if not mux.variants:
-            return
-        job_log = _TEST_LOGGER
-        tree_repr = tree.tree_view(mux.variants.root, verbose=True,
-                                   use_utf8=False)
-        if tree_repr:
-            job_log.info('Multiplex tree representation:')
-            for line in tree_repr.splitlines():
-                job_log.info(line)
-            job_log.info('')
-
     def _log_tmp_dir(self):
         job_log = _TEST_LOGGER
         job_log.info('Temporary dir: %s', data_dir.get_tmp_dir())
         job_log.info('')
 
     def _log_mux_variants(self, mux):
-        if not mux.variants:
-            return
-        job_log = _TEST_LOGGER
-
-        for (index, tpl) in enumerate(mux.variants):
-            paths = ', '.join([x.path for x in tpl])
-            job_log.info('Variant %s:    %s', index + 1, paths)
-
-        if mux.variants:
-            job_log.info('')
+        out = mux.str_variants()
+        if out:
+            _TEST_LOGGER.info(out)
+            _TEST_LOGGER.info('')
 
     def _log_job_debug_info(self, mux):
         """
@@ -409,7 +391,6 @@ class Job(object):
         self._log_avocado_version()
         self._log_avocado_config()
         self._log_avocado_datadir()
-        self._log_mux_tree(mux)
         self._log_tmp_dir()
         self._log_mux_variants(mux)
         self._log_job_id()

--- a/avocado/core/multiplexer.py
+++ b/avocado/core/multiplexer.py
@@ -20,66 +20,12 @@ Multiplex and create variants.
 """
 
 import copy
-import collections
-import itertools
 import logging
 import re
 
 from . import tree
 
 
-class MuxTree(object):
-
-    """
-    Object representing part of the tree from the root to leaves or another
-    multiplex domain. Recursively it creates multiplexed variants of the full
-    tree.
-    """
-
-    def __init__(self, root):
-        """
-        :param root: Root of this tree slice
-        """
-        self.root = root
-        self.pools = []
-        for node in self._iter_mux_leaves(root):
-            if node.is_leaf:
-                self.pools.append(node)
-            else:
-                self.pools.append([MuxTree(child) for child in node.children])
-
-    @staticmethod
-    def _iter_mux_leaves(node):
-        """ yield leaves or muxes of the tree """
-        queue = collections.deque()
-        while node is not None:
-            if node.is_leaf or getattr(node, "multiplex", False):
-                yield node
-            else:
-                queue.extendleft(reversed(node.children))
-            try:
-                node = queue.popleft()
-            except IndexError:
-                raise StopIteration
-
-    def __iter__(self):
-        """
-        Iterates through variants
-        """
-        pools = []
-        for pool in self.pools:
-            if isinstance(pool, list):
-                pools.append(itertools.chain(*pool))
-            else:
-                pools.append(pool)
-        pools = itertools.product(*pools)
-        while True:
-            # TODO: Implement 2nd level filters here
-            # TODO: This part takes most of the time, optimize it
-            yield list(itertools.chain(*pools.next()))
-
-
-# TODO: Create multiplexer plugin and split these functions into multiple files
 class NoMatchError(KeyError):
     pass
 
@@ -376,11 +322,11 @@ class Mux(object):
         :note: people need to check whether mux uses debug and reflect that
                in order to provide the right results.
         """
-        self.default_params = {}
-        self.variants = None
+        # self.default_params = {}
+        self.default_params = {"example": tree.TreeNode(value={"FOO": "BAR"})}
+        self.variant_plugins = []
         self.debug = debug
-        self.data = tree.TreeNodeDebug() if debug else tree.TreeNode()
-        self._mux_path = None
+        self._parsed = False
         self.ignore_new_data = False   # Used to ignore new data on parsed Mux
 
     def parse(self, args):
@@ -389,19 +335,10 @@ class Mux(object):
 
         :param args: Parsed cmdline arguments
         """
-        root = copy.deepcopy(self._process_default_params(args))
-        # Only produce variants if there are any
-        if self.data != tree.TreeNode():
-            # TODO: Do this per-variant-plugin
-            root.merge(self.data)
-            self.variants = MuxTree(root)
-        self._mux_path = getattr(args, 'mux_path', None)
-        if self._mux_path is None:
-            self._mux_path = ['/run/*']
-        # disable data alteration (and remove data as they are not useful)
-        self.data = None
-        self.data_inject = _report_mux_already_parsed
-        self.data_merge = _report_mux_already_parsed
+        defaults = self._process_default_params(args)
+        for plugin in self.variant_plugins:
+            plugin.update_defaults(copy.deepcopy(defaults))
+        self._parsed = True
 
     def _process_default_params(self, args):
         """
@@ -424,7 +361,8 @@ class Mux(object):
         """
         Reports whether the tree was already multiplexed
         """
-        return self.variants is not None
+        return self._parsed
+
     def _skip_new_data_check(self, fction, args):
         """
         Check whether we can inject the data
@@ -434,14 +372,14 @@ class Mux(object):
         :raise RuntimeError: When data injection is restricted
         :return: True if new data should be ignored
         """
-        if self.is_parsed():
+        if self._parsed:
             if self.ignore_new_data:
                 return
             raise RuntimeError("Mux already parsed, unable to execute "
                                "%s%s"
                                % (fction, args))
 
-    def data_inject(self, name, key, value, path=None):
+    def add_default_params(self, name, key, value, path=None):
         """
         Inject entry to the mux tree (params database)
 
@@ -450,7 +388,8 @@ class Mux(object):
         :param path: Optional path to the node to which we assign the value,
                      by default '/'.
         """
-        if self._skip_new_data_check("data_inject", (name, key, value, path)):
+        if self._skip_new_data_check("add_default_params",
+                                     (name, key, value, path)):
             return
         if path is None:
             path = "/"
@@ -458,38 +397,35 @@ class Mux(object):
             self.default_params[name] = tree.TreeNode()
         self.default_params[name].get_node(path, True).value[key] = value
 
-    def data_merge(self, tree):
+    def add_variants_plugin(self, plugin):
         """
         Merge tree into the mux tree (params database)
 
         :param tree: Tree to be merged into this database.
         :type tree: :class:`avocado.core.tree.TreeNode`
         """
-        if self._skip_new_data_check("data_merge", (tree,)):
+        if self._skip_new_data_check("add_variants_plugin", (plugin,)):
             return
-        self.data.merge(tree)
+        self.variant_plugins.append(plugin)
 
     def get_number_of_tests(self, test_suite):
         """
         :return: overall number of tests * multiplex variants
         """
         # Currently number of tests is symmetrical
-        if self.variants:
-            no_variants = sum(1 for _ in self.variants)
-            return (len(test_suite) * no_variants)
+        if self.variant_plugins:
+            no_variants = sum(1 for plugin in self.variant_plugins
+                              for _ in plugin)
+            return len(test_suite) * no_variants
         else:
             return len(test_suite)
 
-    def _merge_defaults(self, variant):
+    def str_variants(self):
         """
-        Copy the default params tree, merge the individual leaves of the
-        variant and return the combination's leaves (variant with defaults)
+        Returns graphical representation of the variants
         """
-        data = copy.deepcopy(self.default_params)
-        for leaf in variant:
-            data.get_node(leaf.path, True).merge(leaf)
-        data.set_environment_dirty()
-        return data.get_leaves()
+        return "\n\n".join(plugin.str_variants()
+                           for plugin in self.variant_plugins)
 
     def itertests(self):
         """
@@ -497,8 +433,10 @@ class Mux(object):
 
         :yield (variant-id, (list of leaves, list of multiplex paths))
         """
-        if self.variants:  # Copy template and modify it's params
-            for i, variant in enumerate(self.variants, 1):
-                yield i, (variant, self._mux_path)
+        if self.variant_plugins:  # Copy template and modify it's params
+            iter_variants = (variant for plugin in self.variant_plugins
+                             for variant in plugin)
+            for variant in iter_variants:
+                yield variant
         else:   # No variants, use template
-            yield None, (self.default_params.get_leaves(), self._mux_path)
+            yield None, (self.default_params.get_leaves(), "/run")

--- a/avocado/core/multiplexer.py
+++ b/avocado/core/multiplexer.py
@@ -441,4 +441,5 @@ class Mux(object):
         else:   # No variants, use template
             yield {"variant": self.default_params.get_leaves(),
                    "variant_id": None,
+                   "variant_id_short": None,
                    "mux_path": "/run"}

--- a/avocado/core/multiplexer.py
+++ b/avocado/core/multiplexer.py
@@ -52,7 +52,7 @@ class MuxTree(object):
         """ yield leaves or muxes of the tree """
         queue = collections.deque()
         while node is not None:
-            if node.is_leaf or node.multiplex:
+            if node.is_leaf or getattr(node, "multiplex", False):
                 yield node
             else:
                 queue.extendleft(reversed(node.children))

--- a/avocado/core/multiplexer.py
+++ b/avocado/core/multiplexer.py
@@ -19,6 +19,7 @@
 Multiplex and create variants.
 """
 
+import copy
 import collections
 import itertools
 import logging
@@ -383,7 +384,7 @@ class Mux(object):
         :note: people need to check whether mux uses debug and reflect that
                in order to provide the right results.
         """
-        self._has_multiple_variants = None
+        self.default_params = {}
         self.variants = None
         self.debug = debug
         self.data = tree.TreeNodeDebug() if debug else tree.TreeNode()
@@ -395,8 +396,12 @@ class Mux(object):
 
         :param args: Parsed cmdline arguments
         """
-        self._parse_basic_injects(args)
-        self.variants = MuxTree(self.data)
+        root = copy.deepcopy(self._process_default_params(args))
+        # Only produce variants if there are any
+        if self.data != tree.TreeNode():
+            # TODO: Do this per-variant-plugin
+            root.merge(self.data)
+            self.variants = MuxTree(root)
         self._mux_path = getattr(args, 'mux_path', None)
         if self._mux_path is None:
             self._mux_path = ['/run/*']
@@ -405,17 +410,22 @@ class Mux(object):
         self.data_inject = _report_mux_already_parsed
         self.data_merge = _report_mux_already_parsed
 
-    def _parse_basic_injects(self, args):
+    def _process_default_params(self, args):
         """
-        Inject data from the basic injects defined by Mux
+        Process the default params
 
         :param args: Parsed cmdline arguments
         """
+        default_params = tree.TreeNode()
+        for default_param in self.default_params.itervalues():
+            default_params.merge(default_param)
+        self.default_params = default_params
         # FIXME: Backward compatibility params, to be removed when 36 LTS is
         # discontinued
         if (not getattr(args, "mux_skip_defaults", False) and
                 hasattr(args, "default_avocado_params")):
-            self.data_merge(args.default_avocado_params)
+            self.default_params.merge(args.default_avocado_params)
+        return self.default_params
 
     def is_parsed(self):
         """
@@ -423,7 +433,7 @@ class Mux(object):
         """
         return self.variants is not None
 
-    def data_inject(self, key, value, path=None):
+    def data_inject(self, name, key, value, path=None):
         """
         Inject entry to the mux tree (params database)
 
@@ -432,11 +442,11 @@ class Mux(object):
         :param path: Optional path to the node to which we assign the value,
                      by default '/'.
         """
-        if path:
-            node = self.data.get_node(path, True)
-        else:
-            node = self.data
-        node.value[key] = value
+        if path is None:
+            path = "/"
+        if name not in self.default_params:
+            self.default_params[name] = tree.TreeNode()
+        self.default_params[name].get_node(path, True).value[key] = value
 
     def data_merge(self, tree):
         """
@@ -454,11 +464,20 @@ class Mux(object):
         # Currently number of tests is symmetrical
         if self.variants:
             no_variants = sum(1 for _ in self.variants)
-            if no_variants > 1:
-                self._has_multiple_variants = True
             return (len(test_suite) * no_variants)
         else:
             return len(test_suite)
+
+    def _merge_defaults(self, variant):
+        """
+        Copy the default params tree, merge the individual leaves of the
+        variant and return the combination's leaves (variant with defaults)
+        """
+        data = copy.deepcopy(self.default_params)
+        for leaf in variant:
+            data.get_node(leaf.path, True).merge(leaf)
+        data.set_environment_dirty()
+        return data.get_leaves()
 
     def itertests(self):
         """
@@ -467,10 +486,7 @@ class Mux(object):
         :yield (variant-id, (list of leaves, list of multiplex paths))
         """
         if self.variants:  # Copy template and modify it's params
-            if self._has_multiple_variants:
-                for i, variant in enumerate(self.variants, 1):
-                    yield i, (variant, self._mux_path)
-            else:
-                yield None, (iter(self.variants).next(), self._mux_path)
+            for i, variant in enumerate(self.variants, 1):
+                yield i, (variant, self._mux_path)
         else:   # No variants, use template
-            yield None, None
+            yield None, (self.default_params.get_leaves(), self._mux_path)

--- a/avocado/core/multiplexer.py
+++ b/avocado/core/multiplexer.py
@@ -417,17 +417,6 @@ class Mux(object):
                 hasattr(args, "default_avocado_params")):
             self.data_merge(args.default_avocado_params)
 
-        # Extend default multiplex tree of --mux-inject values
-        for inject in getattr(args, "mux_inject", []):
-            entry = inject.split(':', 3)
-            if len(entry) < 2:
-                raise ValueError("key:entry pairs required, found only %s"
-                                 % (entry))
-            elif len(entry) == 2:   # key, entry
-                self.data_inject(*entry)
-            else:                   # path, key, entry
-                self.data_inject(key=entry[1], value=entry[2], path=entry[0])
-
     def is_parsed(self):
         """
         Reports whether the tree was already multiplexed

--- a/avocado/core/multiplexer.py
+++ b/avocado/core/multiplexer.py
@@ -439,4 +439,6 @@ class Mux(object):
             for variant in iter_variants:
                 yield variant
         else:   # No variants, use template
-            yield None, (self.default_params.get_leaves(), "/run")
+            yield {"variant": self.default_params.get_leaves(),
+                   "variant_id": None,
+                   "mux_path": "/run"}

--- a/avocado/core/multiplexer.py
+++ b/avocado/core/multiplexer.py
@@ -395,11 +395,8 @@ class Mux(object):
 
         :param args: Parsed cmdline arguments
         """
-        filter_only = getattr(args, 'filter_only', None)
-        filter_out = getattr(args, 'filter_out', None)
         self._parse_basic_injects(args)
-        mux_tree = tree.apply_filters(self.data, filter_only, filter_out)
-        self.variants = MuxTree(mux_tree)
+        self.variants = MuxTree(self.data)
         self._mux_path = getattr(args, 'mux_path', None)
         if self._mux_path is None:
             self._mux_path = ['/run/*']

--- a/avocado/core/result.py
+++ b/avocado/core/result.py
@@ -217,7 +217,7 @@ class HumanResult(Result):
         if "name" in state:
             name = state["name"]
             uid = name.str_uid
-            name = name.name + name.str_variant
+            name = name.name + name.str_variant_short
         else:
             name = "<unknown>"
             uid = '?'

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -467,7 +467,8 @@ class TestRunner(object):
         :return: Yields tuple(test_factory including params, variant id)
         :raises ValueError: When variant and template declare params.
         """
-        for variant, params in mux.itertests():
+        for variant in mux.itertests():
+            params = variant.get("variant")
             if params:
                 if "params" in template[1]:
                     msg = ("Unable to multiplex test %s, params are already "

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -81,9 +81,12 @@ class TestName(object):
         self.variant = variant["variant_id"] if variant else None
         if variant is None:
             self.str_variant = ""
+            self.str_variant_short = ""
         else:
             self.str_variant = (";" + str(variant["variant_id"])
                                 if variant["variant_id"] else "")
+            self.str_variant_short = (";" + str(variant["variant_id_short"])
+                                      if variant["variant_id_short"] else "")
 
     def __str__(self):
         return "%s-%s%s" % (self.str_uid, self.name, self.str_variant)

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -78,8 +78,12 @@ class TestName(object):
         else:
             self.str_uid = str(uid)
         self.name = name or "<unknown>"
-        self.variant = variant
-        self.str_variant = "" if variant is None else ";" + str(variant)
+        self.variant = variant["variant_id"] if variant else None
+        if variant is None:
+            self.str_variant = ""
+        else:
+            self.str_variant = (";" + str(variant["variant_id"])
+                                if variant["variant_id"] else "")
 
     def __str__(self):
         return "%s-%s%s" % (self.str_uid, self.name, self.str_variant)

--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -103,6 +103,10 @@ class TreeNode(object):
                     return False
             return True
 
+    def __ne__(self, other):
+        """ Inverted eq """
+        return not self == other
+
     def add_child(self, node):
         """
         Append node as child. Nodes with the same name gets merged into the

--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -107,6 +107,12 @@ class TreeNode(object):
         """ Inverted eq """
         return not self == other
 
+    def fingerprint(self):
+        """
+        Reports string which represents the value of this node.
+        """
+        return str(self.path) + str(self.environment) + str(self.ctrl)
+
     def add_child(self, node):
         """
         Append node as child. Nodes with the same name gets merged into the

--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -71,15 +71,14 @@ class TreeNode(object):
         self.value = value
         self.parent = parent
         self.children = []
+        self.ctrl = []
         self._environment = None
         self.environment_origin = {}
-        self.ctrl = []
-        self.multiplex = None
         for child in children:
             self.add_child(child)
 
     def __repr__(self):
-        return 'TreeNode(name=%r)' % self.name
+        return 'SimpleTreeNode(name=%r)' % self.name
 
     def __str__(self):
         variables = ['%s=%s' % (k, v) for k, v in self.environment.items()]
@@ -144,10 +143,6 @@ class TreeNode(object):
                             remove.append(key)
                     for key in remove:
                         self.value.pop(key, None)
-        if other.multiplex is True:
-            self.multiplex = True
-        elif other.multiplex is False:
-            self.multiplex = False
         self.value.update(other.value)
         for child in other.children:
             self.add_child(child)
@@ -465,9 +460,9 @@ class TreeNodeDebug(TreeNode):  # only container pylint: disable=R0903
         return super(TreeNodeDebug, self).merge(other)
 
 
-def get_named_tree_cls(path):
+def get_named_tree_cls(path, klass=TreeNodeDebug):
     """ Return TreeNodeDebug class with hardcoded yaml path """
-    class NamedTreeNodeDebug(TreeNodeDebug):    # pylint: disable=R0903
+    class NamedTreeNodeDebug(klass):    # pylint: disable=R0903
 
         """ Fake class with hardcoded yaml path """
 
@@ -559,7 +554,7 @@ def tree_view(root, verbose=None, use_utf8=None):
                    'DoubleDownRight': ' #== ',
                    'DoubleRight': ' #== ',
                    'Value': ' -> '}
-    if root.multiplex:
+    if getattr(root, "multiplex", False):
         down = charset['DoubleDown']
         down_right = charset['DoubleDownRight']
         right = charset['DoubleRight']

--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -445,7 +445,7 @@ def tree_view(root, verbose=None, use_utf8=None):
         Generate this node's tree-view
         :return: list of lines
         """
-        if node.multiplex:
+        if getattr(root, "multiplex", False):
             down = charset['DoubleDown']
             down_right = charset['DoubleDownRight']
             right = charset['DoubleRight']

--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -283,62 +283,6 @@ class TreeNode(object):
         return self
 
 
-def path_parent(path):
-    """
-    From a given path, return its parent path.
-
-    :param path: the node path as string.
-    :return: the parent path as string.
-    """
-    parent = path.rpartition('/')[0]
-    if not parent:
-        return '/'
-    return parent
-
-
-def apply_filters(tree, filter_only=None, filter_out=None):
-    """
-    Apply a set of filters to the tree.
-
-    The basic filtering is filter only, which includes nodes,
-    and the filter out rules, that exclude nodes.
-
-    Note that filter_out is stronger than filter_only, so if you filter out
-    something, you could not bypass some nodes by using a filter_only rule.
-
-    :param filter_only: the list of paths which will include nodes.
-    :param filter_out: the list of paths which will exclude nodes.
-    :return: the original tree minus the nodes filtered by the rules.
-    """
-    if filter_only is None:
-        filter_only = []
-    else:
-        filter_only = [_.rstrip('/') for _ in filter_only if _]
-    if filter_out is None:
-        filter_out = []
-    else:
-        filter_out = [_.rstrip('/') for _ in filter_out if _]
-    for node in tree.iter_children_preorder():
-        keep_node = True
-        for path in filter_only:
-            if path == '':
-                continue
-            if node.path == path:
-                keep_node = True
-                break
-            if node.parent and node.parent.path == path_parent(path):
-                keep_node = False
-                continue
-        for path in filter_out:
-            if path == '':
-                continue
-            if node.path == path:
-                keep_node = False
-                break
-        if not keep_node:
-            node.detach()
-    return tree
-
 #
 # Debug version of TreeNode with additional utilities.
 #

--- a/avocado/plugins/multiplex.py
+++ b/avocado/plugins/multiplex.py
@@ -36,11 +36,6 @@ class Multiplex(CLICmd):
     def configure(self, parser):
         parser = super(Multiplex, self).configure(parser)
 
-        parser.add_argument('--filter-only', nargs='*', default=[],
-                            help='Filter only path(s) from multiplexing')
-
-        parser.add_argument('--filter-out', nargs='*', default=[],
-                            help='Filter out path(s) from multiplexing')
         parser.add_argument('--system-wide', action='store_false',
                             default=True, dest="mux-skip-defaults",
                             help="Combine the files with the default "
@@ -48,9 +43,6 @@ class Multiplex(CLICmd):
         parser.add_argument('-c', '--contents', action='store_true',
                             default=False, help="Shows the node content "
                             "(variables)")
-        parser.add_argument('--mux-inject', default=[], nargs='*',
-                            help="Inject [path:]key:node values into "
-                            "the final multiplex tree.")
         env_parser = parser.add_argument_group("environment view options")
         env_parser.add_argument('-d', '--debug', action='store_true',
                                 dest="mux_debug", default=False,

--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -27,12 +27,6 @@ from avocado.core.settings import settings
 from avocado.core.test import ReplaySkipTest
 
 
-def ignore_call(*args, **kwargs):
-    """
-    Accepts anything and does nothing
-    """
-
-
 class Replay(CLI):
 
     """
@@ -224,8 +218,7 @@ class Replay(CLI):
                     log.warning("Using src job Mux data only, use `--replay-"
                                 "ignore mux` to override them.")
                 setattr(args, "mux", mux)
-                mux.data_merge = ignore_call
-                mux.data_inject = ignore_call
+                mux.ignore_new_data = True
 
         if args.replay_teststatus:
             replay_map = self._create_replay_map(resultsdir,

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -132,18 +132,6 @@ class Run(CLICmd):
 
         loader.add_loader_options(parser)
 
-        mux = parser.add_argument_group('test parameters')
-        mux.add_argument('--filter-only', nargs='*', default=[],
-                         help='Filter only path(s) from multiplexing')
-        mux.add_argument('--filter-out', nargs='*', default=[],
-                         help='Filter out path(s) from multiplexing')
-        mux.add_argument('--mux-path', nargs='*', default=None,
-                         help="List of paths used to determine path "
-                         "priority when querying for parameters")
-        mux.add_argument('--mux-inject', default=[], nargs='*',
-                         help="Inject [path:]key:node values into the "
-                         "final multiplex tree.")
-
     def run(self, args):
         """
         Run test modules or simple tests.

--- a/avocado/plugins/yaml_to_mux.py
+++ b/avocado/plugins/yaml_to_mux.py
@@ -398,6 +398,7 @@ class MuxPlugin(object):
                 data.set_environment_dirty()
             yield {"variant_id": i,
                    "variant": data.get_leaves(),
+                   "variant_id_short": i,
                    "mux_path": self.mux_path}
 
     def update_defaults(self, defaults):

--- a/avocado/plugins/yaml_to_mux.py
+++ b/avocado/plugins/yaml_to_mux.py
@@ -543,4 +543,5 @@ class YamlToMux(CLI):
 
         data = apply_filters(data, getattr(args, 'mux_only', None),
                              getattr(args, 'mux_out', None))
-        args.mux.add_variants_plugin(MuxPlugin(data, mux_path))
+        if data != MuxTreeNode():   # Only include it when there are any data
+            args.mux.add_variants_plugin(MuxPlugin(data, mux_path))

--- a/avocado/plugins/yaml_to_mux.py
+++ b/avocado/plugins/yaml_to_mux.py
@@ -298,6 +298,14 @@ class YamlToMux(CLI):
                              help="DEPRECATED: Location of one or more Avocado"
                              " multiplex (.yaml) FILE(s) (order dependent)")
 
+    @staticmethod
+    def _log_deprecation_msg(deprecated, current):
+        """
+        Log a message into the "avocado.app" warning log
+        """
+        msg = "The use of '%s' is deprecated, please use '%s' instead"
+        logging.getLogger("avocado.app").warning(msg, deprecated, current)
+
     def run(self, args):
         # Merge the multiplex
         multiplex_files = getattr(args, "mux_yaml", None)
@@ -312,9 +320,7 @@ class YamlToMux(CLI):
         # Deprecated --multiplex option
         multiplex_files = getattr(args, "multiplex", None)
         if multiplex_files:
-            msg = ("The use of `--multiplex` is deprecated, use `--mux-yaml` "
-                   "instead.")
-            logging.getLogger("avocado.app").warning(msg)
+            self._log_deprecation_msg("--multiplex", "--mux-yaml")
             debug = getattr(args, "mux_debug", False)
             try:
                 args.mux.data_merge(create_from_yaml(multiplex_files, debug))

--- a/avocado/plugins/yaml_to_mux.py
+++ b/avocado/plugins/yaml_to_mux.py
@@ -396,7 +396,9 @@ class MuxPlugin(object):
             for leaf in variant:
                 data.get_node(leaf.path, True).merge(leaf)
                 data.set_environment_dirty()
-            yield i, (data.get_leaves(), self.mux_path)
+            yield {"variant_id": i,
+                   "variant": data.get_leaves(),
+                   "mux_path": self.mux_path}
 
     def update_defaults(self, defaults):
         self.default_params = defaults
@@ -413,9 +415,9 @@ class MuxPlugin(object):
         out += tree_repr
         out += "\n\n"
 
-        for variant_id, tpl in self:
-            paths = ', '.join([x.path for x in tpl[0]])
-            out += 'Variant %s:    %s\n' % (variant_id, paths)
+        for variant in self:
+            paths = ', '.join([x.path for x in variant["variant"]])
+            out += 'Variant %s:    %s\n' % (variant["variant_id"], paths)
 
         if not out.endswith("\n"):
             out += "\n"


### PR DESCRIPTION
This proof-of-concept PR addresses the discussion from https://github.com/avocado-framework/avocado/pull/1535 and extends that PR. The main goal is to completely separate the yaml_to_mux parser, create multiplexer API without hardcoded dependency on mux and then improve the variant IDs.

The quality is rather poor, because I'd like to ask whether it's aligned with what we discussed in the previous PR. I have to say I like this separation more, even though it does not offer such flexibility as previous approach.

v0: https://github.com/avocado-framework/avocado/pull/1535

Changes:

```
v0.2: Everything except of the concept of variant-ids (which uses order-by-path instead
      of order by position in yaml file and the patches are split.
```
