### PR TITLE
avocado.core.loader sort files alphabetically

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -512,7 +512,7 @@ class FileLoader(TestLoader):
             onerror = skip_non_test
 
         for dirpath, _, filenames in os.walk(url, onerror=onerror):
-            for file_name in filenames:
+            for file_name in sorted(filenames):
                 if not file_name.startswith('.'):
                     for suffix in ignore_suffix:
                         if file_name.endswith(suffix):


### PR DESCRIPTION
This was requested on avocado-devel mail list. Now the test files are
sorted alphabetically by the test loader.

Reference: https://trello.com/c/whLgcvtO
Signed-off-by: Amador Pahim <apahim@redhat.com>