### PR TITLE
selftests: Remove skip test [v2]

### DIFF
--- a/selftests/functional/test_lv_utils.py
+++ b/selftests/functional/test_lv_utils.py
@@ -29,10 +29,6 @@ class LVUtilsTest(unittest.TestCase):
     @unittest.skipIf(not process.can_sudo(), "This test requires root or "
                      "passwordless sudo configured.")
     def setUp(self):
-        try:
-            process.system("/bin/true", sudo=True)
-        except process.CmdError as details:
-            self.skipTest("Sudo not available: %s" % details)
         self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
         self.vgs = []
 


### PR DESCRIPTION
v2:
Probe the binary only once and use if throughout the skip tests and the tests themselves.

v1: #1555 
Let's separate the check for requirements and the test code according to
the project's understanding of setup/test phases.