### PR TITLE
avocado.core.loader sort directories/files alphabetically [v2]

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -511,8 +511,9 @@ class FileLoader(TestLoader):
         else:  # DEFAULT, AVAILABLE => skip missing tests
             onerror = skip_non_test
 
-        for dirpath, _, filenames in os.walk(url, onerror=onerror):
-            for file_name in filenames:
+        for dirpath, dirs, filenames in os.walk(url, onerror=onerror):
+            dirs.sort()
+            for file_name in sorted(filenames):
                 if not file_name.startswith('.'):
                     for suffix in ignore_suffix:
                         if file_name.endswith(suffix):


### PR DESCRIPTION
v2:
Sort the directories as well.

v1: #1554 
This was requested on avocado-devel mail list. Now the test directories
and the test files are sorted alphabetically by the test loader.

Reference: https://trello.com/c/whLgcvtO
Signed-off-by: Amador Pahim <apahim@redhat.com>