### PR TITLE
In-line code block format fix

### DIFF
--- a/docs/source/GetStartedGuide.rst
+++ b/docs/source/GetStartedGuide.rst
@@ -163,7 +163,7 @@ expectations, it passed! These are known as `simple tests`, but there is also an
 type of test, which we call `instrumented tests`. See more at :ref:`test-types` or just
 keep reading.
 
-.. note:: Although in most cases running ``avocado run $test1 $test3 ...` is
+.. note:: Although in most cases running ``avocado run $test1 $test3 ...`` is
           fine, it can lead to argument vs. test name clashes. The safest
           way to execute tests is ``avocado run --$argument1 --$argument2
           -- $test1 $test2``. Everything after `--` will be considered


### PR DESCRIPTION
There is a "`" missing of the in-line code and break the layout of the document.

![screenshot from 2016-10-24 15-38-38](https://cloud.githubusercontent.com/assets/1506238/19637126/ff1331bc-99ff-11e6-808a-8e7ac3a6d066.png)
