### PR TITLE
avocado.utils.process: execute default sigint handler

### DIFF
--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -406,6 +406,7 @@ class SubProcess(object):
             def signal_handler(signum, frame):
                 self.result.interrupted = "signal/ctrl+c"
                 self.wait()
+                signal.default_int_handler()
             try:
                 signal.signal(signal.SIGINT, signal_handler)
             except ValueError:


### PR DESCRIPTION
In order to exit subprocess gracefully, our library overrides the
default SIGINT handler with a custom handler that waits for the
subprocess. Since the default SIGINT handler raises a KeyboardExeption,
which is expected by the caller, and our custom handler does not, this
patch calls the default handler from inside our custom handler, after
the steps required to exit the subprocess gracefully.

Reference: https://trello.com/c/NZPg155x
Signed-off-by: Amador Pahim <apahim@redhat.com>