### PR TITLE
Resolution of RPM package warnings and errors spotted by rpmlint 

### DIFF
--- a/avocado.spec
+++ b/avocado.spec
@@ -4,7 +4,7 @@
 %endif
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
-Summary: Avocado Test Framework
+Summary: Framework with tools and libraries for Automated Testing
 Name: avocado
 Version: 42.0
 Release: 0%{?dist}

--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or

--- a/avocado/core/version.py
+++ b/avocado/core/version.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or
@@ -24,6 +22,3 @@ except pkg_resources.DistributionNotFound:
     VERSION = "unknown.unknown"
 
 MAJOR, MINOR = VERSION.split('.')
-
-if __name__ == '__main__':
-    print(VERSION)

--- a/avocado/utils/kernel.py
+++ b/avocado/utils/kernel.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or

--- a/avocado/utils/partition.py
+++ b/avocado/utils/partition.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or

--- a/avocado/utils/software_manager.py
+++ b/avocado/utils/software_manager.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or
@@ -922,7 +920,7 @@ def install_distro_packages(distro_pkg_map, interactive=False):
     return result
 
 
-if __name__ == '__main__':
+def main():
     parser = optparse.OptionParser(
         "usage: %prog [install|remove|check-installed|list-all|list-files|add-repo|"
         "remove-repo| upgrade|what-provides|install-what-provides] arguments")
@@ -991,3 +989,7 @@ if __name__ == '__main__':
 
     elif action == 'show-help':
         parser.print_help()
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/testplans/release.json
+++ b/examples/testplans/release.json
@@ -12,6 +12,9 @@
 	{"name": "Avocado RPM build",
 	 "description": "On your development machine, build the Avocado RPM packages using: `$ make rpm`. Expected result: SRPM and RPM files at `BUILD/RPM/avocado-x.y.z-r.distro.{src,noarch}.rpm`"},
 
+	{"name": "Avocado RPM lint",
+	 "description": "With the built RPMs, check if there are no packaging errors or warnings by running: `$ rpmlint BUILD/RPM/avocado-x.y.z-r.distro.noarch.rpm`.  Expected result: 1 packages and 0 specfiles checked; 0 errors, 0 warnings."},
+
 	{"name": "Avocado RPM install",
 	 "description": "On a fresh virtual machine, perform the installation of Avocado using the packages built on test 'Avocado RPM build' and the aexpect package from src or avocado repo. Also install and start the qemu-guest-agent."},
 


### PR DESCRIPTION
As a preparation for proposing official Avocado packages to Fedora, let's make sure our packages are free or warnings/errors (as detected by rpmlint).