### PR TITLE
Docker plugin fixes

### DIFF
--- a/avocado/core/remote/runner.py
+++ b/avocado/core/remote/runner.py
@@ -37,7 +37,6 @@ from ...utils import stacktrace
 class RemoteTestRunner(TestRunner):
 
     """ Tooled TestRunner to run on remote machine using ssh """
-    remote_test_dir = '~/avocado/tests'
 
     # Let's use re.MULTILINE because sometimes servers might have MOTD
     # that will introduce a line break on output.
@@ -151,9 +150,8 @@ class RemoteTestRunner(TestRunner):
             extra_params.append("--dry-run")
         urls_str = " ".join(urls)
 
-        avocado_cmd = ('cd %s; avocado run --force-job-id %s --json - '
-                       '--archive %s %s' % (self.remote_test_dir,
-                                            self.job.unique_id,
+        avocado_cmd = ('avocado run --force-job-id %s --json - '
+                       '--archive %s %s' % (self.job.unique_id,
                                             urls_str, " ".join(extra_params)))
         try:
             result = self.remote.run(avocado_cmd, ignore_status=True,

--- a/avocado/plugins/docker.py
+++ b/avocado/plugins/docker.py
@@ -109,8 +109,8 @@ class DockerTestRunner(RemoteTestRunner):
     Test runner which runs the job inside a docker container
     """
 
-    def __init__(self, job, test_result):
-        super(DockerTestRunner, self).__init__(job, test_result)
+    def __init__(self, job, result_proxy):
+        super(DockerTestRunner, self).__init__(job, result_proxy)
         self.remote = None      # Will be set in `setup`
 
     def setup(self):

--- a/selftests/unit/test_remote.py
+++ b/selftests/unit/test_remote.py
@@ -95,7 +95,7 @@ _=/usr/bin/env''', exit_status=0)
          .with_args(args_version, ignore_status=True, timeout=60)
          .once().and_return(version_result))
 
-        args = ("cd ~/avocado/tests; avocado run --force-job-id 1-sleeptest;0 "
+        args = ("avocado run --force-job-id 1-sleeptest;0 "
                 "--json - --archive /tests/sleeptest /tests/other/test "
                 "passtest -m ~/avocado/tests/foo.yaml "
                 "~/avocado/tests/bar/baz.yaml --dry-run")


### PR DESCRIPTION
- Fix attribute leftover after commit 295b8f6.
- Drop directory change for remote executions, not needed anymore after commit  9d483a360 and doomed to break remote avocado in machines that does not have the directory already created.