### PR TITLE
docker: Return the receive_files and improve UI

### DIFF
--- a/avocado/plugins/docker.py
+++ b/avocado/plugins/docker.py
@@ -127,7 +127,7 @@ class DockerTestRunner(RemoteTestRunner):
         self.remote = DockerRemoter(dkrcmd, self.job.args.docker, dkr_opt, dkr_name)
         self.job.log.info("DOCKER     : Container id '%s'"
                           % self.remote.get_cid())
-        self.job.log.debug("DOCKER     : Container name '%s'" % dkr_name)
+        self.job.log.info("DOCKER     : Container name '%s'" % dkr_name)
 
     def tear_down(self):
         try:

--- a/avocado/plugins/docker.py
+++ b/avocado/plugins/docker.py
@@ -61,6 +61,13 @@ class DockerRemoter(object):
         """ Return this remoter's container ID """
         return self._docker_id
 
+    def receive_files(self, local_path, remote_path):
+        """
+        Receive files from the container
+        """
+        process.run("%s cp %s:%s %s" % (self._dkrcmd, self._docker_id,
+                                        remote_path, local_path))
+
     def run(self, command, ignore_status=False, quiet=None, timeout=60):
         """
         Run command inside the container


### PR DESCRIPTION
In the https://github.com/avocado-framework/avocado/pull/1569 we removed the `receive_files` from docker, which is still necessary in order to receive results of the avocado job. Let's bring it back.

Also note that without the plugins order it might happen that the `html` plugin runs before the `archive`, which results in:

```
DOCKER     : Container id 'db60234eeafabc131fbd63a5c427b60268557f92b8ae4062613613fcfb59c431'
DOCKER     : Container name 'job-2016-10-27T09.42-c0eb3e2.avocado'
JOB ID     : c0eb3e28165c3bb3bf4f613af78422377a381989
JOB LOG    : /home/medic/avocado/job-results/job-2016-10-27T09.42-c0eb3e2/job.log
TESTS      : 1
 (1/1) /bin/true: PASS (0.00 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0
TESTS TIME : 0.00 s
Error running method "render" of plugin "html": [Errno 17] File exists: '/home/medic/avocado/job-results/job-2016-10-27T09.42-c0eb3e2/html'
```

We should define the order to avoid such exception. As we don't have plugin priority yet, lets just cope with the occasional error message (not influencing the exit code)