### PR TITLE
sysinfo: Revert the removed `--quiet` option to journalctl

### DIFF
--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -231,7 +231,7 @@ class JournalctlWatcher(Collectible):
 
     def _get_cursor(self):
         try:
-            cmd = 'journalctl --lines 1 --output json'
+            cmd = 'journalctl --quiet --lines 1 --output json'
             result = process.system_output(cmd, verbose=False)
             last_record = json.loads(result)
             return last_record['__CURSOR']


### PR DESCRIPTION
During revert f658f0e5d3099a7a1f896120848f644ae8e21ef7 the `--quiet` was
removed, but it is suppose to be there. Let's revert that part.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>