### PR TITLE
selftests: Two little adjustments

### DIFF
--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -969,7 +969,8 @@ class PluginsTest(AbsPluginsTest, unittest.TestCase):
             os.unlink(archives[0])
 
         config_content_zip_last = ("[plugins.result]\norder=['html', 'json',"
-                                   "'xunit', 'zip_archive']")
+                                   "'xunit', 'non_existing_plugin_is_ignored'"
+                                   ",'zip_archive']")
         config_zip_last = script.TemporaryScript("zip_last.conf",
                                                  config_content_zip_last)
         with config_zip_last:
@@ -980,14 +981,6 @@ class PluginsTest(AbsPluginsTest, unittest.TestCase):
             zip_file_list = zip_file.namelist()
             for result_output in result_outputs:
                 self.assertIn(result_output, zip_file_list)
-
-        config_content_missing = ("[plugins.result]\norder=['foo', "
-                                  "'html', 'json', 'xunit', "
-                                  "'zip_archive', 'bar']")
-        config_missing = script.TemporaryScript("missing.conf",
-                                                config_content_missing)
-        with config_missing:
-            run_config(config_missing)
 
     def test_Namespace_object_has_no_attribute(self):
         os.chdir(basedir)

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -928,7 +928,8 @@ class PluginsTest(AbsPluginsTest, unittest.TestCase):
         """
         def run_config(config_path):
             cmd = ('./scripts/avocado --config %s run passtest.py --archive '
-                   '--job-results-dir %s') % (config_path, self.base_outputdir)
+                   '--job-results-dir %s --sysinfo=off'
+                   % (config_path, self.base_outputdir))
             result = process.run(cmd, ignore_status=True)
             expected_rc = exit_codes.AVOCADO_ALL_OK
             self.assertEqual(result.exit_status, expected_rc,

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -26,7 +26,7 @@ basedir = os.path.abspath(basedir)
 PERL_TAP_PARSER_SNIPPET = """#!/bin/env perl
 use TAP::Parser;
 
-my $parser = TAP::Parser->new( { exec => ['./scripts/avocado', 'run', 'passtest.py', 'errortest.py', 'warntest.py', '--tap', '-'] } );
+my $parser = TAP::Parser->new( { exec => ['./scripts/avocado', 'run', 'passtest.py', 'errortest.py', 'warntest.py', '--tap', '-', '--sysinfo', 'off', '--job-results-dir', '%s'] } );
 
 while ( my $result = $parser->next ) {
         $result->is_unknown && die "Unknown line \\"" . $result->as_string . "\\" in the TAP output!\n";
@@ -421,7 +421,8 @@ class OutputPluginTest(unittest.TestCase):
                      "Uncapable of using Perl TAP::Parser library")
     def test_tap_parser(self):
         perl_script = script.TemporaryScript("tap_parser.pl",
-                                             PERL_TAP_PARSER_SNIPPET)
+                                             PERL_TAP_PARSER_SNIPPET
+                                             % self.tmpdir)
         perl_script.save()
         os.chdir(basedir)
         process.run("perl %s" % perl_script)


### PR DESCRIPTION
The first one disables the `sysinfo` collection and adds `job-restuls-dir` where it's not defined, the second merges two checks into the same one (0.812s vs. 1.123s and we don't expect this to fail frequently - or at all).