### PR TITLE
Functional tests: prevent the persistence of temporary job results

### DIFF
--- a/selftests/functional/test_multiplex.py
+++ b/selftests/functional/test_multiplex.py
@@ -107,8 +107,8 @@ class MultiplexTests(unittest.TestCase):
         self.run_and_check(cmd_line, expected_rc, (4, 0))
 
     def test_empty_file(self):
-        cmd_line = ("./scripts/avocado run -m selftests/.data/empty_file "
-                    "-- passtest.py")
+        cmd_line = ("./scripts/avocado run --job-results-dir %s -m "
+                    "selftests/.data/empty_file -- passtest.py" % self.tmpdir)
         result = self.run_and_check(cmd_line, exit_codes.AVOCADO_ALL_OK,
                                     (1, 0))
 

--- a/selftests/functional/test_plugin_jobscripts.py
+++ b/selftests/functional/test_plugin_jobscripts.py
@@ -71,8 +71,8 @@ class JobScriptsTest(unittest.TestCase):
                                         SCRIPT_PRE_POST_CFG % (self.pre_dir,
                                                                self.post_dir))
         with config:
-            cmd = './scripts/avocado --config %s run --sysinfo=off %s' % (config,
-                                                                          test_check_touch)
+            cmd = ('./scripts/avocado --config %s run --job-results-dir %s '
+                   '--sysinfo=off %s' % (config, self.tmpdir, test_check_touch))
             result = process.run(cmd)
 
         # Pre/Post scripts failures do not (currently?) alter the exit status
@@ -93,7 +93,8 @@ class JobScriptsTest(unittest.TestCase):
         config = script.TemporaryScript("non_zero.conf",
                                         SCRIPT_NON_ZERO_CFG % self.pre_dir)
         with config:
-            cmd = './scripts/avocado --config %s run --sysinfo=off passtest.py' % config
+            cmd = ('./scripts/avocado --config %s run --job-results-dir %s '
+                   '--sysinfo=off passtest.py' % (config, self.tmpdir))
             result = process.run(cmd)
 
         # Pre/Post scripts failures do not (currently?) alter the exit status
@@ -114,7 +115,8 @@ class JobScriptsTest(unittest.TestCase):
         config = script.TemporaryScript("non_existing_dir.conf",
                                         SCRIPT_NON_EXISTING_DIR_CFG % self.pre_dir)
         with config:
-            cmd = './scripts/avocado --config %s run --sysinfo=off passtest.py' % config
+            cmd = ('./scripts/avocado --config %s run --job-results-dir %s '
+                   '--sysinfo=off passtest.py' % (config, self.tmpdir))
             result = process.run(cmd)
 
         # Pre/Post scripts failures do not (currently?) alter the exit status


### PR DESCRIPTION
Some functional tests, most of which execute a full avocado command,
were missing the `--job-results-dir`, pointing to a directory that
would be removed after the tests.  This has led to the pollution of
the standard job results directory (usually `~/avocado/job-results`)
when selftests are run.

This proposal fixes all but one set of functional tests, which has
to be fixed with a different set of changes (see reference).

Besides the functional tests, some unittests are also creating
job results that should be discarded.  It's believed that at least
some of this is caused by the relationship between tests and jobs,
but this is speculation and it's not attepted to be fixed on this
patch.

Reference: https://trello.com/c/I2ieqhR5
Signed-off-by: Cleber Rosa crosa@redhat.com
