### PR TITLE
don't create a shell escaped command

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -23,7 +23,6 @@ import imp
 import inspect
 import os
 import re
-import pipes
 import shlex
 import sys
 
@@ -691,8 +690,7 @@ class FileLoader(TestLoader):
                                                 subtests_filter)
             else:
                 if os.access(test_path, os.X_OK):
-                    return self._make_test(test.SimpleTest,
-                                           pipes.quote(test_path))
+                    return self._make_test(test.SimpleTest, test_path)
                 else:
                     return make_broken(test.NotATest, test_path)
         else:

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -1,3 +1,4 @@
+# This Python file uses the following encoding: utf-8
 import aexpect
 import glob
 import json
@@ -609,7 +610,7 @@ class RunnerSimpleTest(unittest.TestCase):
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
         self.pass_script = script.TemporaryScript(
-            'avocado_pass.sh',
+            'ʊʋʉʈɑʅʛʌ',
             PASS_SCRIPT_CONTENTS,
             'avocado_simpletest_functional')
         self.pass_script.save()


### PR DESCRIPTION
This is causing more problems than helping. Escaped commands can make
os.path.abspath() to misbehave since the command can be inside single
quotes. Let's remove this so we can behave correctly when some funky
characters are in the command.

Signed-off-by: Amador Pahim <apahim@redhat.com>