### PR TITLE
Test: allow for avocado.core.test.Test tests without a hosting file

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -263,11 +263,14 @@ class Test(unittest.TestCase):
         """
         Returns the name of the file (path) that holds the current test
         """
-        possibly_compiled = inspect.getfile(self.__class__)
-        if possibly_compiled.endswith('.pyc') or possibly_compiled.endswith('.pyo'):
-            source = possibly_compiled[:-1]
-        else:
-            source = possibly_compiled
+        try:
+            possibly_compiled = inspect.getfile(self.__class__)
+            if possibly_compiled.endswith('.pyc') or possibly_compiled.endswith('.pyo'):
+                source = possibly_compiled[:-1]
+            else:
+                source = possibly_compiled
+        except TypeError:
+            return None
 
         if os.path.exists(source):
             return source


### PR DESCRIPTION
Creating a test interactively is not entirely a use case we have
thought about, AFAICT, but it shouldn't fail because of an
implementation detail.

The implementation detail, in detail, is that the `filename` property
uses inspect to try to locate the file that backs
`avocado.core.test.Test` based tests.  The proposed change is that,
if inspect fails to find the file that backs the test, the tests'
`filename` property should resolve to None.

In practice, this allows the following snippets to be tried on the
Python interpreter:

```
  >>> import avocado
  >>> class Test(avocado.Test):
  ...     def test(self):
  ...         pass
  >>> t = Test()
```

Signed-off-by: Cleber Rosa <crosa@redhat.com>