### PR TITLE
Test References: mass rename of URL into the proper term [v5]

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -74,7 +74,7 @@ class Job(object):
         if args is None:
             args = argparse.Namespace()
         self.args = args
-        self.urls = getattr(args, "url", [])
+        self.references = getattr(args, "reference", [])
         self.log = logging.getLogger("avocado.app")
         self.standalone = getattr(self.args, 'standalone', False)
         if getattr(self.args, "dry_run", False):  # Modify args for dry-run
@@ -283,18 +283,19 @@ class Job(object):
         if not self.result_proxy.output_plugins:
             self.result_proxy.add_output_plugin(result.Result(self))
 
-    def _make_test_suite(self, urls=None):
+    def _make_test_suite(self, references=None):
         """
         Prepares a test suite to be used for running tests
 
-        :param urls: String with tests to run, separated by whitespace.
-                     Optionally, a list of tests (each test a string).
+        :param references: String with tests references to be resolved, and then
+                           run, separated by whitespace. Optionally, a
+                           list of tests (each test a string).
         :returns: a test suite (a list of test factories)
         """
         loader.loader.load_plugins(self.args)
         try:
-            suite = loader.loader.discover(urls)
-        except loader.LoaderUnhandledUrlError as details:
+            suite = loader.loader.discover(references)
+        except loader.LoaderUnhandledReferenceError as details:
             raise exceptions.OptionValidationError(details)
         except KeyboardInterrupt:
             raise exceptions.JobError('Command interrupted by user...')
@@ -420,7 +421,7 @@ class Job(object):
         This is a public Job API as part of the documented Job phases
         """
         try:
-            self.test_suite = self._make_test_suite(self.urls)
+            self.test_suite = self._make_test_suite(self.references)
         except loader.LoaderError as details:
             stacktrace.log_exc_info(sys.exc_info(), 'avocado.app.debug')
             raise exceptions.OptionValidationError(details)
@@ -438,13 +439,14 @@ class Job(object):
 
     def run_tests(self):
         if not self.test_suite:
-            if self.urls:
-                e_msg = ("No tests found for given urls, try 'avocado list -V "
-                         "%s' for details" % " ".join(self.urls))
+            if self.references:
+                references = " ".join(self.references)
+                e_msg = ("No tests found for given test references, try "
+                         "'avocado list -V %s' for details" % references)
             else:
-                e_msg = ("No urls provided nor any arguments produced "
-                         "runable tests. Please double check the executed "
-                         "command.")
+                e_msg = ("No test references provided nor any other arguments "
+                         "resolved into tests. Please double check the executed"
+                         " command.")
             raise exceptions.OptionValidationError(e_msg)
 
         mux = getattr(self.args, "mux", None)
@@ -462,7 +464,7 @@ class Job(object):
         self._start_sysinfo()
 
         self._log_job_debug_info(mux)
-        jobdata.record(self.args, self.logdir, mux, self.urls, sys.argv)
+        jobdata.record(self.args, self.logdir, mux, self.references, sys.argv)
         replay_map = getattr(self.args, 'replay_map', None)
         summary = self.test_runner.run_suite(self.test_suite,
                                              mux,
@@ -565,7 +567,7 @@ class TestProgram(object):
         output.add_log_handler("", output.ProgressStreamHandler,
                                fmt="%(message)s")
         self.parseArgs(sys.argv[1:])
-        self.args.url = [sys.argv[0]]
+        self.args.reference = [sys.argv[0]]
         self.runTests()
 
     def parseArgs(self, argv):

--- a/avocado/core/jobdata.py
+++ b/avocado/core/jobdata.py
@@ -28,28 +28,32 @@ from ..utils.path import init_dir
 JOB_DATA_DIR = 'jobdata'
 JOB_DATA_FALLBACK_DIR = 'replay'
 CONFIG_FILENAME = 'config'
-URLS_FILENAME = 'urls'
+TEST_REFERENCES_FILENAME = 'test_references'
+TEST_REFERENCES_FILENAME_LEGACY = 'urls'
 MUX_FILENAME = 'multiplex'
 PWD_FILENAME = 'pwd'
 ARGS_FILENAME = 'args'
 CMDLINE_FILENAME = 'cmdline'
 
 
-def record(args, logdir, mux, urls=None, cmdline=None):
+def record(args, logdir, mux, references=None, cmdline=None):
     """
     Records all required job information.
     """
     base_dir = init_dir(logdir, JOB_DATA_DIR)
     path_cfg = os.path.join(base_dir, CONFIG_FILENAME)
-    path_urls = os.path.join(base_dir, URLS_FILENAME)
+    path_references = os.path.join(base_dir, TEST_REFERENCES_FILENAME)
+    path_references_legacy = os.path.join(base_dir,
+                                          TEST_REFERENCES_FILENAME_LEGACY)
     path_mux = os.path.join(base_dir, MUX_FILENAME)
     path_pwd = os.path.join(base_dir, PWD_FILENAME)
     path_args = os.path.join(base_dir, ARGS_FILENAME)
     path_cmdline = os.path.join(base_dir, CMDLINE_FILENAME)
 
-    if urls:
-        with open(path_urls, 'w') as urls_file:
-            urls_file.write('%s' % urls)
+    if references:
+        with open(path_references, 'w') as references_file:
+            references_file.write('%s' % references)
+        os.symlink(TEST_REFERENCES_FILENAME, path_references_legacy)
 
     with open(path_cfg, 'w') as config_file:
         settings.config.write(config_file)
@@ -87,15 +91,18 @@ def retrieve_pwd(resultsdir):
         return pwd_file.read()
 
 
-def retrieve_urls(resultsdir):
+def retrieve_references(resultsdir):
     """
-    Retrieves the job urls from the results directory.
+    Retrieves the job test references from the results directory.
     """
-    recorded_urls = _retrieve(resultsdir, URLS_FILENAME)
-    if recorded_urls is None:
+    recorded_references = _retrieve(resultsdir, TEST_REFERENCES_FILENAME)
+    if recorded_references is None:
+        recorded_references = _retrieve(resultsdir,
+                                        TEST_REFERENCES_FILENAME_LEGACY)
+    if recorded_references is None:
         return None
-    with open(recorded_urls, 'r') as urls_file:
-        return ast.literal_eval(urls_file.read())
+    with open(recorded_references, 'r') as references_file:
+        return ast.literal_eval(references_file.read())
 
 
 def retrieve_mux(resultsdir):

--- a/avocado/core/remote/runner.py
+++ b/avocado/core/remote/runner.py
@@ -134,11 +134,11 @@ class RemoteTestRunner(TestRunner):
                              "output:\n%s" % output)
         return response
 
-    def run_test(self, urls, timeout):
+    def run_test(self, references, timeout):
         """
         Run tests.
 
-        :param urls: a string with test URLs.
+        :param references: a string with test references.
         :return: a dictionary with test results.
         """
         extra_params = []
@@ -148,11 +148,11 @@ class RemoteTestRunner(TestRunner):
 
         if getattr(self.job.args, "dry_run", False):
             extra_params.append("--dry-run")
-        urls_str = " ".join(urls)
+        references_str = " ".join(references)
 
         avocado_cmd = ('avocado run --force-job-id %s --json - '
                        '--archive %s %s' % (self.job.unique_id,
-                                            urls_str, " ".join(extra_params)))
+                                            references_str, " ".join(extra_params)))
         try:
             result = self.remote.run(avocado_cmd, ignore_status=True,
                                      timeout=timeout)
@@ -185,7 +185,7 @@ class RemoteTestRunner(TestRunner):
 
         :return: a set with types of test failures.
         """
-        del test_suite     # using self.job.urls instead
+        del test_suite     # using self.job.references instead
         del mux            # we're not using multiplexation here
         if not timeout:     # avoid timeout = 0
             timeout = None
@@ -222,7 +222,7 @@ class RemoteTestRunner(TestRunner):
             except Exception as details:
                 stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
                 raise exceptions.JobError(details)
-            results = self.run_test(self.job.urls, timeout)
+            results = self.run_test(self.job.references, timeout)
             remote_log_dir = os.path.dirname(results['debuglog'])
             self.result_proxy.set_tests_total(results['total'])
             self.result_proxy.start_tests()

--- a/avocado/plugins/jsonresult.py
+++ b/avocado/plugins/jsonresult.py
@@ -36,8 +36,7 @@ class JSONResult(Result):
     def _render(self, result):
         tests = []
         for test in result.tests:
-            tests.append({'test': str(test.get('name', UNKNOWN)),
-                          'url': str(test.get('name', UNKNOWN)),
+            tests.append({'id': str(test.get('name', UNKNOWN)),
                           'start': test.get('time_start', -1),
                           'end': test.get('time_end', -1),
                           'time': test.get('time_elapsed', -1),
@@ -45,7 +44,16 @@ class JSONResult(Result):
                           'whiteboard': test.get('whiteboard', UNKNOWN),
                           'logdir': test.get('logdir', UNKNOWN),
                           'logfile': test.get('logfile', UNKNOWN),
-                          'fail_reason': str(test.get('fail_reason', UNKNOWN))})
+                          'fail_reason': str(test.get('fail_reason', UNKNOWN)),
+                          # COMPATIBILITY: `test` and `url` are backward
+                          # compatibility key names for the test ID,
+                          # as defined by the test name RFC.  `url` is
+                          # not a test reference, as it's recorded
+                          # after it has been processed by the test resolver
+                          # (currently called test loader in the code).
+                          # Expect them to be removed in the future.
+                          'test': str(test.get('name', UNKNOWN)),
+                          'url': str(test.get('name', UNKNOWN))})
         content = {'job_id': result.job_unique_id,
                    'debuglog': result.logfile,
                    'tests': tests,

--- a/avocado/plugins/list.py
+++ b/avocado/plugins/list.py
@@ -47,7 +47,7 @@ class TestLister(object):
         try:
             return loader.loader.discover(paths,
                                           which_tests=which_tests)
-        except loader.LoaderUnhandledUrlError as details:
+        except loader.LoaderUnhandledReferenceError as details:
             self.log.error(str(details))
             sys.exit(exit_codes.AVOCADO_FAIL)
 

--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -194,7 +194,7 @@ class Replay(CLI):
             log.warn('Overriding the replay test references with test '
                      'references given in the command line.')
         else:
-            references = jobdata.retrieve_urls(resultsdir)
+            references = jobdata.retrieve_references(resultsdir)
             if references is None:
                 log.error('Source job test references data not found. Aborting.')
                 sys.exit(exit_codes.AVOCADO_JOB_FAIL)

--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -134,9 +134,9 @@ class Replay(CLI):
         if args.replay_teststatus and 'mux' in args.replay_ignore:
             err = ("Option `--replay-test-status` is incompatible with "
                    "`--replay-ignore mux`.")
-        elif args.replay_teststatus and args.url:
+        elif args.replay_teststatus and args.reference:
             err = ("Option --replay-test-status is incompatible with "
-                   "test URLs given on the command line.")
+                   "test references given on the command line.")
         elif args.remote_hostname:
             err = "Currently we don't replay jobs in remote hosts."
         if err is not None:
@@ -189,17 +189,17 @@ class Replay(CLI):
                     setattr(args, option, replay_args[option])
 
         # Keeping this for compatibility.
-        # TODO: Use replay_args['url'] at some point in the future.
-        if getattr(args, 'url', None):
-            log.warn('Overriding the replay urls with urls provided in '
-                     'command line.')
+        # TODO: Use replay_args['reference'] at some point in the future.
+        if getattr(args, 'reference', None):
+            log.warn('Overriding the replay test references with test '
+                     'references given in the command line.')
         else:
-            urls = jobdata.retrieve_urls(resultsdir)
-            if urls is None:
-                log.error('Source job urls data not found. Aborting.')
+            references = jobdata.retrieve_urls(resultsdir)
+            if references is None:
+                log.error('Source job test references data not found. Aborting.')
                 sys.exit(exit_codes.AVOCADO_JOB_FAIL)
             else:
-                setattr(args, 'url', urls)
+                setattr(args, 'reference', references)
 
         if 'config' in args.replay_ignore:
             log.warn("Ignoring configuration from source job with "
@@ -232,7 +232,7 @@ class Replay(CLI):
                                                  args.replay_teststatus)
             setattr(args, 'replay_map', replay_map)
 
-        # Use the original directory to discover test urls properly
+        # Use the original directory to resolve test references properly
         pwd = jobdata.retrieve_pwd(resultsdir)
         if pwd is not None:
             if os.path.exists(pwd):

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -47,7 +47,7 @@ class Run(CLICmd):
         """
         parser = super(Run, self).configure(parser)
 
-        parser.add_argument("url", type=str, default=[], nargs='*',
+        parser.add_argument("reference", type=str, default=[], nargs='*',
                             metavar="TEST_REFERENCE",
                             help='List of test references (aliases or paths)')
 

--- a/docs/source/ReferenceGuide.rst
+++ b/docs/source/ReferenceGuide.rst
@@ -253,7 +253,7 @@ results directory structure can be seen below ::
     │   ├── config
     │   ├── multiplex
     │   ├── pwd
-    │   └── urls
+    │   └── test_references
     ├── job.log
     ├── results.json
     ├── results.xml

--- a/docs/source/Replay.rst
+++ b/docs/source/Replay.rst
@@ -11,7 +11,7 @@ the provided part corresponds to the initial characters of the original
 job id and it is also unique enough. Or, instead of the job id, you can
 use the string ``latest`` and avocado will replay the latest job executed.
 
-Let's see an example. First, running a simple job with two urls::
+Let's see an example. First, running a simple job with two test references::
 
      $ avocado run /bin/true /bin/false
      JOB ID     : 825b860b0c2f6ec48953c638432e3e323f8d7cad
@@ -36,7 +36,7 @@ Now we can replay the job by running::
      TESTS TIME : 0.01 s
      JOB HTML   : $HOME/avocado/job-results/job-2016-01-11T16.18-55a0d10/html/results.html
 
-The replay feature will retrieve the original job urls, the multiplex
+The replay feature will retrieve the original test references, the multiplex
 tree and the configuration. Let's see another example, now using
 multiplex file::
 

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -388,7 +388,8 @@ class RunnerOperationTest(unittest.TestCase):
         cmd_line = './scripts/avocado run --sysinfo=off --job-results-dir %s' % self.tmpdir
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_JOB_FAIL
-        expected_output = 'No urls provided nor any arguments produced'
+        expected_output = ('No test references provided nor any other '
+                           'arguments resolved into tests')
         self.assertEqual(result.exit_status, expected_rc)
         self.assertIn(expected_output, result.stderr)
 
@@ -398,8 +399,8 @@ class RunnerOperationTest(unittest.TestCase):
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_JOB_FAIL
         self.assertEqual(result.exit_status, expected_rc)
-        self.assertIn('Unable to discover url', result.stderr)
-        self.assertNotIn('Unable to discover url', result.stdout)
+        self.assertIn('Unable to resolve reference', result.stderr)
+        self.assertNotIn('Unable to resolve reference', result.stdout)
 
     def test_invalid_unique_id(self):
         cmd_line = ('./scripts/avocado run --sysinfo=off --job-results-dir '
@@ -809,7 +810,8 @@ class ExternalRunnerTest(unittest.TestCase):
         cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '
                     '--external-runner=/bin/true' % self.tmpdir)
         result = process.run(cmd_line, ignore_status=True)
-        expected_output = ('No urls provided nor any arguments produced')
+        expected_output = ('No test references provided nor any other '
+                           'arguments resolved into tests')
         self.assertIn(expected_output, result.stderr)
         expected_rc = exit_codes.AVOCADO_JOB_FAIL
         self.assertEqual(result.exit_status, expected_rc,
@@ -864,7 +866,7 @@ class PluginsTest(AbsPluginsTest, unittest.TestCase):
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %d:\n%s" %
                          (expected_rc, result))
-        self.assertIn("Unable to discover url", output)
+        self.assertIn("Unable to resolve reference", output)
 
     def test_plugin_list(self):
         os.chdir(basedir)

--- a/selftests/functional/test_replay_basic.py
+++ b/selftests/functional/test_replay_basic.py
@@ -77,7 +77,7 @@ class ReplayTests(unittest.TestCase):
         """
         Checks if all expected files are there.
         """
-        file_list = ['multiplex', 'config', 'urls', 'pwd', 'args',
+        file_list = ['multiplex', 'config', 'test_references', 'pwd', 'args',
                      'cmdline']
         for filename in file_list:
             path = os.path.join(self.jobdir, 'jobdata', filename)

--- a/selftests/functional/test_replay_basic.py
+++ b/selftests/functional/test_replay_basic.py
@@ -77,7 +77,8 @@ class ReplayTests(unittest.TestCase):
         """
         Checks if all expected files are there.
         """
-        file_list = ['multiplex', 'config', 'urls', 'pwd', 'args', 'cmdline']
+        file_list = ['multiplex', 'config', 'urls', 'pwd', 'args',
+                     'cmdline']
         for filename in file_list:
             path = os.path.join(self.jobdir, 'jobdata', filename)
             self.assertTrue(glob.glob(path))
@@ -179,9 +180,9 @@ class ReplayTests(unittest.TestCase):
                "`--replay-ignore mux`")
         self.assertIn(msg, result.stderr)
 
-    def test_run_replay_status_and_urls(self):
+    def test_run_replay_status_and_references(self):
         """
-        Runs a replay job with custom urls and '--replay-test-status'.
+        Runs a replay job with custom test references and --replay-test-status
         """
         cmd_line = ('./scripts/avocado run sleeptest --replay %s '
                     '--replay-test-status FAIL --job-results-dir %s '
@@ -189,8 +190,8 @@ class ReplayTests(unittest.TestCase):
                     (self.jobid, self.tmpdir, self.jobdir))
         expected_rc = exit_codes.AVOCADO_FAIL
         result = self.run_and_check(cmd_line, expected_rc)
-        msg = "Option --replay-test-status is incompatible with "\
-              "test URLs given on the command line."
+        msg = ("Option --replay-test-status is incompatible with "
+               "test references given on the command line.")
         self.assertIn(msg, result.stderr)
 
     def test_run_replay_fallbackdir(self):

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -47,7 +47,7 @@ class JobTest(unittest.TestCase):
 
     def test_job_create_test_suite_simple(self):
         simple_tests_found = self._find_simple_test_candidates()
-        args = argparse.Namespace(url=simple_tests_found)
+        args = argparse.Namespace(reference=simple_tests_found)
         myjob = job.Job(args)
         myjob.create_test_suite()
         self.assertEqual(len(simple_tests_found), len(myjob.test_suite))
@@ -63,7 +63,7 @@ class JobTest(unittest.TestCase):
                 self.test_suite = filtered_test_suite
                 super(JobFilterTime, self).pre_tests()
         simple_tests_found = self._find_simple_test_candidates()
-        args = argparse.Namespace(url=simple_tests_found)
+        args = argparse.Namespace(reference=simple_tests_found)
         myjob = JobFilterTime(args)
         myjob.create_test_suite()
         myjob.pre_tests()
@@ -71,7 +71,7 @@ class JobTest(unittest.TestCase):
 
     def test_job_run_tests(self):
         simple_tests_found = self._find_simple_test_candidates(['true'])
-        args = argparse.Namespace(url=simple_tests_found)
+        args = argparse.Namespace(reference=simple_tests_found)
         myjob = job.Job(args)
         myjob.create_test_suite()
         self.assertEqual(myjob.run_tests(),
@@ -84,7 +84,7 @@ class JobTest(unittest.TestCase):
                     f.write(self.unique_id[::-1])
                 super(JobLogPost, self).post_tests()
         simple_tests_found = self._find_simple_test_candidates()
-        args = argparse.Namespace(url=simple_tests_found)
+        args = argparse.Namespace(reference=simple_tests_found)
         myjob = JobLogPost(args)
         myjob.create_test_suite()
         myjob.pre_tests()
@@ -110,7 +110,7 @@ class JobTest(unittest.TestCase):
                     f.write(self.unique_id[::-1])
                 super(JobFilterLog, self).post_tests()
         simple_tests_found = self._find_simple_test_candidates()
-        args = argparse.Namespace(url=simple_tests_found)
+        args = argparse.Namespace(reference=simple_tests_found)
         myjob = JobFilterLog(args)
         self.assertEqual(myjob.run(),
                          exit_codes.AVOCADO_ALL_OK)

--- a/selftests/unit/test_remote.py
+++ b/selftests/unit/test_remote.py
@@ -13,7 +13,8 @@ import logging
 cwd = os.getcwd()
 
 JSON_RESULTS = ('Something other than json\n'
-                '{"tests": [{"test": "1-sleeptest;0", "url": "sleeptest", '
+                '{"tests": [{"test": "1-sleeptest;0",'
+                '"reference": "sleeptest", '
                 '"fail_reason": "None", '
                 '"status": "PASS", "time": 1.23, "start": 0, "end": 1.23}],'
                 '"debuglog": "/home/user/avocado/logs/run-2014-05-26-15.45.'
@@ -44,8 +45,8 @@ class RemoteTestRunnerTest(unittest.TestCase):
         log = flexmock()
         log.should_receive("info")
         job = flexmock(args=Args, log=log,
-                       urls=['/tests/sleeptest', '/tests/other/test',
-                             'passtest'], unique_id='1-sleeptest;0',
+                       references=['/tests/sleeptest', '/tests/other/test',
+                                   'passtest'], unique_id='1-sleeptest;0',
                        logdir="/local/path")
 
         flexmock(remote.RemoteTestRunner).should_receive('__init__')
@@ -102,7 +103,7 @@ _=/usr/bin/env''', exit_status=0)
         (Remote.should_receive('run')
          .with_args(args, timeout=61, ignore_status=True)
          .once().and_return(test_results))
-        Results = flexmock(remote=Remote, urls=['sleeptest'],
+        Results = flexmock(remote=Remote, references=['sleeptest'],
                            stream=stream, timeout=None,
                            args=flexmock(show_job_log=False,
                                          mux_yaml=['~/avocado/tests/foo.yaml',
@@ -156,8 +157,8 @@ class RemoteTestRunnerSetup(unittest.TestCase):
          .once().ordered()
          .and_return(Remote))
         Args = flexmock(test_result_total=1,
-                        url=['/tests/sleeptest', '/tests/other/test',
-                             'passtest'],
+                        reference=['/tests/sleeptest', '/tests/other/test',
+                                   'passtest'],
                         remote_username='username',
                         remote_hostname='hostname',
                         remote_port=22,


### PR DESCRIPTION
It's been a while since the "Test ID RFC" came out:

https://www.redhat.com/archives/avocado-devel/2016-March/msg00024.html

Still, we've been referring to test URLs all around our code
and also on user visible strings.  This is an attempt to rename
the mentions of "URLs" that really should be "test references"
or simply "references" at this point.
---
Changes from v4 (#1575):
 - Rebased

Changes from v3 (#1571):
- Rebased

Changes from v2 (#1564):
- Rebased

Changes from v1 (#1550):
- Introduced new key `id` on JSON result, while keeping old `test` and `url` keys for compatiblity
- Added jobdata symlink from `test_references` to `urls`, for compatibility purposes, while making it a separate commit
