### PR TITLE
Result Events

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -107,6 +107,7 @@ class Job(object):
 
         self.status = "RUNNING"
         self.result_proxy = result.ResultProxy()
+        self.result = result.Result(self)
         self.sysinfo = None
         self.timeout = getattr(self.args, 'job_timeout', 0)
         self.__logging_handlers = {}
@@ -254,7 +255,8 @@ class Job(object):
             test_runner_class = runner.TestRunner
 
         self.test_runner = test_runner_class(job=self,
-                                             result_proxy=self.result_proxy)
+                                             result_proxy=self.result_proxy,
+                                             result=self.result)
 
     def _make_old_style_test_result(self):
         """
@@ -422,6 +424,7 @@ class Job(object):
         """
         try:
             self.test_suite = self._make_test_suite(self.references)
+            self.result.tests_total = len(self.test_suite)
         except loader.LoaderError as details:
             stacktrace.log_exc_info(sys.exc_info(), 'avocado.app.debug')
             raise exceptions.OptionValidationError(details)

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -285,10 +285,6 @@ class Job(object):
                     test_result_instance = klass(self)
                     self.result_proxy.add_output_plugin(test_result_instance)
 
-        if not getattr(self.args, 'stdout_claimed_by', False) or self.standalone:
-            human_plugin = result.HumanResult(self)
-            self.result_proxy.add_output_plugin(human_plugin)
-
         if not self.result_proxy.output_plugins:
             self.result_proxy.add_output_plugin(result.Result(self))
 

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -127,6 +127,13 @@ class Job(object):
         # A job may not have a dispatcher for pre/post tests execution plugins
         self._job_pre_post_dispatcher = None
 
+        # The result events dispatcher is shared with the test runner.
+        # Because of our goal to support using the phases of a job
+        # freely, let's get the result events dispatcher ready early.
+        # A future optimization may load it on demand.
+        self._result_events_dispatcher = dispatcher.ResultEventsDispatcher(self.args)
+        output.log_plugin_failures(self._result_events_dispatcher.load_failures)
+
     def _setup_job_results(self):
         """
         Prepares a job result directory, also known as logdir, for this job
@@ -439,6 +446,7 @@ class Job(object):
         self._job_pre_post_dispatcher = dispatcher.JobPrePostDispatcher()
         output.log_plugin_failures(self._job_pre_post_dispatcher.load_failures)
         self._job_pre_post_dispatcher.map_method('pre', self)
+        self._result_events_dispatcher.map_method('pre_tests', self)
 
     def run_tests(self):
         if not self.test_suite:

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -106,7 +106,6 @@ class Job(object):
             self.loglevel = logging.DEBUG
 
         self.status = "RUNNING"
-        self.result_proxy = result.ResultProxy()
         self.result = result.Result(self)
         self.sysinfo = None
         self.timeout = getattr(self.args, 'job_timeout', 0)
@@ -262,31 +261,7 @@ class Job(object):
             test_runner_class = runner.TestRunner
 
         self.test_runner = test_runner_class(job=self,
-                                             result_proxy=self.result_proxy,
                                              result=self.result)
-
-    def _make_old_style_test_result(self):
-        """
-        Old style result output plugins setup.
-
-        This supports the activation of old style result classes which are
-        registered with :func:`avocado.core.result.register_test_result_class`.
-
-        Then, if no plugin has claimed the STDOUT, activate a HumanResult
-        instance.
-
-        Finally, if no old style result plugin is given, activate a bare
-        bones Result instance, as they serve result information (only)
-        to the new style result plugins.
-        """
-        if self.args:
-            if getattr(self.args, 'test_result_classes', None) is not None:
-                for klass in self.args.test_result_classes:
-                    test_result_instance = klass(self)
-                    self.result_proxy.add_output_plugin(test_result_instance)
-
-        if not self.result_proxy.output_plugins:
-            self.result_proxy.add_output_plugin(result.Result(self))
 
     def _make_test_suite(self, references=None):
         """
@@ -466,7 +441,6 @@ class Job(object):
                 raise exceptions.OptionValidationError("Unable to parse mux: "
                                                        "%s" % details)
 
-        self._make_old_style_test_result()
         self._make_test_runner()
         self._start_sysinfo()
 

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -407,6 +407,17 @@ class Job(object):
             stacktrace.log_exc_info(sys.exc_info(), 'avocado.app.debug')
             raise exceptions.OptionValidationError(details)
 
+        if not self.test_suite:
+            if self.references:
+                references = " ".join(self.references)
+                e_msg = ("No tests found for given test references, try "
+                         "'avocado list -V %s' for details" % references)
+            else:
+                e_msg = ("No test references provided nor any other arguments "
+                         "resolved into tests. Please double check the executed"
+                         " command.")
+            raise exceptions.OptionValidationError(e_msg)
+
     def pre_tests(self):
         """
         Run the pre tests execution hooks
@@ -420,17 +431,6 @@ class Job(object):
         self._result_events_dispatcher.map_method('pre_tests', self)
 
     def run_tests(self):
-        if not self.test_suite:
-            if self.references:
-                references = " ".join(self.references)
-                e_msg = ("No tests found for given test references, try "
-                         "'avocado list -V %s' for details" % references)
-            else:
-                e_msg = ("No test references provided nor any other arguments "
-                         "resolved into tests. Please double check the executed"
-                         " command.")
-            raise exceptions.OptionValidationError(e_msg)
-
         mux = getattr(self.args, "mux", None)
         if mux is None:
             mux = multiplexer.Mux()

--- a/avocado/core/plugin_interfaces.py
+++ b/avocado/core/plugin_interfaces.py
@@ -134,3 +134,70 @@ class Result(Plugin):
         :param job: the finished job for which a result will be written
         :type job: :class:`avocado.core.job.Job`
         """
+
+
+class JobPreTests(Plugin):
+
+    """
+    Base plugin interface for adding actions before a job runs tests
+
+    This interface looks similar to :class:`JobPre`, but it's inteded
+    to be called at a very specific place, that is, between
+    :meth:`avocado.core.job.Job.create_test_suite` and
+    :meth:`avocado.core.job.Job.run_tests`.
+    """
+
+    @abc.abstractmethod
+    def pre_tests(self, job):
+        """
+        Entry point for job running actions before tests execution
+        """
+
+
+class JobPostTests(Plugin):
+
+    """
+    Base plugin interface for adding actions after a job runs tests
+
+    Plugins using this interface will run at the a time equivalent to
+    plugins using the :class:`JobPost` interface, that is, at
+    :meth:`avocado.core.job.Job.post_tests`.  This is because
+    :class:`JobPost` based plugins will eventually be modified to
+    really run after the job has finished, and not after it has run
+    tests.
+    """
+
+    @abc.abstractmethod
+    def post_tests(self, job):
+        """
+        Entry point for job running actions after the tests execution
+        """
+
+
+class ResultEvents(JobPreTests, JobPostTests):
+
+    """
+    Base plugin interface for event based (streameable) results
+
+    Plugins that want to add actions to be run after a job runs,
+    should use the 'avocado.plugins.result_events' namespace and
+    implement the defined interface.
+    """
+
+    @abc.abstractmethod
+    def start_test(self, result, state):
+        """
+        Event triggered when a test starts running
+        """
+
+    @abc.abstractmethod
+    def test_progress(self, progress=False):
+        """
+        Interface to notify progress (or not) of the running test
+        """
+
+    @abc.abstractmethod
+    def end_test(self, result, state):
+        """
+        Event triggered when a test finishes running
+        """

--- a/avocado/core/remote/runner.py
+++ b/avocado/core/remote/runner.py
@@ -43,8 +43,8 @@ class RemoteTestRunner(TestRunner):
     remote_version_re = re.compile(r'^Avocado (\d+)\.(\d+)\r?$',
                                    re.MULTILINE)
 
-    def __init__(self, job, result_proxy, result):
-        super(RemoteTestRunner, self).__init__(job, result_proxy, result)
+    def __init__(self, job, result):
+        super(RemoteTestRunner, self).__init__(job, result)
         #: remoter connection to the remote machine
         self.remote = None
 
@@ -224,8 +224,6 @@ class RemoteTestRunner(TestRunner):
                 raise exceptions.JobError(details)
             results = self.run_test(self.job.references, timeout)
             remote_log_dir = os.path.dirname(results['debuglog'])
-            self.result_proxy.set_tests_total(results['total'])
-            self.result_proxy.start_tests()
             self.result.tests_total = results['total']
             self.result.start_tests()
             for tst in results['tests']:
@@ -241,9 +239,7 @@ class RemoteTestRunner(TestRunner):
                                   logfile=tst['logfile'],
                                   fail_reason=tst['fail_reason'])
                 state = test.get_state()
-                self.result_proxy.start_test(state)
                 self.result.start_test(state)
-                self.result_proxy.check_test(state)
                 self.result.check_test(state)
                 if state['status'] == "INTERRUPTED":
                     summary.add("INTERRUPTED")
@@ -256,7 +252,6 @@ class RemoteTestRunner(TestRunner):
             self.remote.receive_files(local_log_dir, zip_filename)
             archive.uncompress(zip_path_filename, local_log_dir)
             os.remove(zip_path_filename)
-            self.result_proxy.end_tests()
             self.result.end_tests()
         finally:
             try:
@@ -285,8 +280,8 @@ class VMTestRunner(RemoteTestRunner):
     Test runner to run tests using libvirt domain
     """
 
-    def __init__(self, job, result_proxy, result):
-        super(VMTestRunner, self).__init__(job, result_proxy, result)
+    def __init__(self, job, result):
+        super(VMTestRunner, self).__init__(job, result)
         #: VM used during testing
         self.vm = None
 

--- a/avocado/core/remote/runner.py
+++ b/avocado/core/remote/runner.py
@@ -43,8 +43,8 @@ class RemoteTestRunner(TestRunner):
     remote_version_re = re.compile(r'^Avocado (\d+)\.(\d+)\r?$',
                                    re.MULTILINE)
 
-    def __init__(self, job, result_proxy):
-        super(RemoteTestRunner, self).__init__(job, result_proxy)
+    def __init__(self, job, result_proxy, result):
+        super(RemoteTestRunner, self).__init__(job, result_proxy, result)
         #: remoter connection to the remote machine
         self.remote = None
 
@@ -226,6 +226,8 @@ class RemoteTestRunner(TestRunner):
             remote_log_dir = os.path.dirname(results['debuglog'])
             self.result_proxy.set_tests_total(results['total'])
             self.result_proxy.start_tests()
+            self.result.tests_total = results['total']
+            self.result.start_tests()
             for tst in results['tests']:
                 name = tst['test'].split('-', 1)
                 name = [name[0]] + name[1].split(';')
@@ -240,7 +242,9 @@ class RemoteTestRunner(TestRunner):
                                   fail_reason=tst['fail_reason'])
                 state = test.get_state()
                 self.result_proxy.start_test(state)
+                self.result.start_test(state)
                 self.result_proxy.check_test(state)
+                self.result.check_test(state)
                 if state['status'] == "INTERRUPTED":
                     summary.add("INTERRUPTED")
                 elif not status.mapping[state['status']]:
@@ -253,6 +257,7 @@ class RemoteTestRunner(TestRunner):
             archive.uncompress(zip_path_filename, local_log_dir)
             os.remove(zip_path_filename)
             self.result_proxy.end_tests()
+            self.result.end_tests()
         finally:
             try:
                 self.tear_down()
@@ -280,8 +285,8 @@ class VMTestRunner(RemoteTestRunner):
     Test runner to run tests using libvirt domain
     """
 
-    def __init__(self, job, result_proxy):
-        super(VMTestRunner, self).__init__(job, result_proxy)
+    def __init__(self, job, result_proxy, result):
+        super(VMTestRunner, self).__init__(job, result_proxy, result)
         #: VM used during testing
         self.vm = None
 

--- a/avocado/core/result.py
+++ b/avocado/core/result.py
@@ -14,69 +14,8 @@
 #          Ruda Moura <rmoura@redhat.com>
 
 """
-Contains the definition of the Result class, used for output in avocado.
+Contains the Result class, used for result accounting.
 """
-
-
-class InvalidOutputPlugin(Exception):
-    pass
-
-
-def register_test_result_class(application_args, klass):
-    """
-    Register the given test result class to be loaded and enabled by the job
-
-    :param application_args: the parsed application command line arguments.
-                             This is currently being abused to hold various job
-                             settings and feature choices, such as the runner.
-    :type application_args: :class:`argparse.Namespace`
-    :param klass: the test result class to enable
-    :type klass: a subclass of :class:`Result`
-    """
-    if not hasattr(application_args, 'test_result_classes'):
-        application_args.test_result_classes = set()
-    application_args.test_result_classes.add(klass)
-
-
-class ResultProxy(object):
-
-    def __init__(self):
-        self.output_plugins = []
-
-    def notify_progress(self, progress_from_test=False):
-        for output_plugin in self.output_plugins:
-            if hasattr(output_plugin, 'notify_progress'):
-                output_plugin.notify_progress(progress_from_test)
-
-    def add_output_plugin(self, plugin):
-        if not isinstance(plugin, Result):
-            raise InvalidOutputPlugin("Object %s is not an instance of "
-                                      "Result" % plugin)
-        self.output_plugins.append(plugin)
-
-    def start_tests(self):
-        for output_plugin in self.output_plugins:
-            output_plugin.start_tests()
-
-    def end_tests(self):
-        for output_plugin in self.output_plugins:
-            output_plugin.end_tests()
-
-    def start_test(self, state):
-        for output_plugin in self.output_plugins:
-            output_plugin.start_test(state)
-
-    def end_test(self, state):
-        for output_plugin in self.output_plugins:
-            output_plugin.end_test(state)
-
-    def check_test(self, state):
-        for output_plugin in self.output_plugins:
-            output_plugin.check_test(state)
-
-    def set_tests_total(self, tests_total):
-        for output_plugin in self.output_plugins:
-            output_plugin.tests_total = tests_total
 
 
 class Result(object):

--- a/avocado/core/result.py
+++ b/avocado/core/result.py
@@ -15,14 +15,7 @@
 
 """
 Contains the definition of the Result class, used for output in avocado.
-
-It also contains the most basic result class, HumanResult, used by the
-test runner.
 """
-
-import logging
-
-from . import output
 
 
 class InvalidOutputPlugin(Exception):
@@ -180,75 +173,3 @@ class Result(object):
         else:
             self.errors += 1
         self.end_test(state)
-
-
-class HumanResult(Result):
-
-    """
-    Human output Test result class.
-    """
-
-    def __init__(self, job):
-        super(HumanResult, self).__init__(job)
-        self.log = logging.getLogger("avocado.app")
-        self.__throbber = output.Throbber()
-        self._replay_source_job = getattr(job.args, "replay_sourcejob", None)
-
-    def start_tests(self):
-        """
-        Called once before any tests are executed.
-        """
-        super(HumanResult, self).start_tests()
-        self.log.info("JOB ID     : %s", self.job_unique_id)
-        if self._replay_source_job is not None:
-            self.log.info("SRC JOB ID : %s", self._replay_source_job)
-        self.log.info("JOB LOG    : %s", self.logfile)
-        self.log.info("TESTS      : %s", self.tests_total)
-
-    def end_tests(self):
-        """
-        Called once after all tests are executed.
-        """
-        super(HumanResult, self).end_tests()
-        self.log.info("RESULTS    : PASS %d | ERROR %d | FAIL %d | SKIP %d | "
-                      "WARN %d | INTERRUPT %s", self.passed,
-                      self.errors, self.failed, self.skipped,
-                      self.warned, self.interrupted)
-        self.log.info("TESTS TIME : %.2f s", self.tests_total_time)
-
-    def start_test(self, state):
-        super(HumanResult, self).start_test(state)
-        if "name" in state:
-            name = state["name"]
-            uid = name.str_uid
-            name = name.name + name.str_variant
-        else:
-            name = "<unknown>"
-            uid = '?'
-        self.log.debug(' (%s/%s) %s:  ', uid, self.tests_total, name,
-                       extra={"skip_newline": True})
-
-    def end_test(self, state):
-        super(HumanResult, self).end_test(state)
-        status = state.get("status", "ERROR")
-        if status == "TEST_NA":
-            status = "SKIP"
-        mapping = {'PASS': output.TERM_SUPPORT.PASS,
-                   'ERROR': output.TERM_SUPPORT.ERROR,
-                   'FAIL': output.TERM_SUPPORT.FAIL,
-                   'SKIP': output.TERM_SUPPORT.SKIP,
-                   'WARN': output.TERM_SUPPORT.WARN,
-                   'INTERRUPTED': output.TERM_SUPPORT.INTERRUPT}
-        duration = (" (%.2f s)" % state.get('time_elapsed', -1)
-                    if status != "SKIP"
-                    else "")
-        self.log.debug(output.TERM_SUPPORT.MOVE_BACK + mapping[status] +
-                       status + output.TERM_SUPPORT.ENDC + duration)
-
-    def notify_progress(self, progress=False):
-        if progress:
-            color = output.TERM_SUPPORT.PASS
-        else:
-            color = output.TERM_SUPPORT.PARTIAL
-        self.log.debug(color + self.__throbber.render() +
-                       output.TERM_SUPPORT.ENDC, extra={"skip_newline": True})

--- a/avocado/core/result.py
+++ b/avocado/core/result.py
@@ -98,7 +98,7 @@ class Result(object):
 
         :param job: an instance of :class:`avocado.core.job.Job`.
         """
-        self.job_unique_id = getattr(job, "unique_id", None)
+        self.job_unique_id = getattr(job, "unique_id")
         self.logfile = getattr(job, "logfile", None)
         self.tests_total = 0
         self.tests_run = 0

--- a/avocado/core/result.py
+++ b/avocado/core/result.py
@@ -125,7 +125,7 @@ class Result(object):
         """
         Called once before any tests are executed.
         """
-        self.tests_run += 1
+        pass
 
     def end_tests(self):
         """

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -175,7 +175,6 @@ class TestStatus(object):
                 self.interrupt = True
             elif "paused" in msg:
                 self.status = msg
-                self.job.result_proxy.notify_progress(False)
                 self.job._result_events_dispatcher.map_method('test_progress',
                                                               False)
                 if msg['paused']:
@@ -254,17 +253,14 @@ class TestRunner(object):
     """
     DEFAULT_TIMEOUT = 86400
 
-    def __init__(self, job, result_proxy, result):
+    def __init__(self, job, result):
         """
         Creates an instance of TestRunner class.
 
         :param job: an instance of :class:`avocado.core.job.Job`.
-        :param result_proxy: an instance of
-                            :class:`avocado.core.result.ResultProxy`.
         :param result: an instance of :class:`avocado.core.result.Result`
         """
         self.job = job
-        self.result_proxy = result_proxy
         self.result = result
         self.sigstopped = False
 
@@ -312,7 +308,6 @@ class TestRunner(object):
         except Exception:
             instance.error(stacktrace.str_unpickable_object(early_state))
 
-        self.result_proxy.start_test(early_state)
         self.result.start_test(early_state)
         self.job._result_events_dispatcher.map_method('start_test',
                                                       self.result,
@@ -408,10 +403,8 @@ class TestRunner(object):
                     if ctrl_c_count == 0:
                         if (test_status.status.get('running') or
                                 self.sigstopped):
-                            self.job.result_proxy.notify_progress(False)
                             self.job._result_events_dispatcher.map_method('test_progress', False)
                         else:
-                            self.job.result_proxy.notify_progress(True)
                             self.job._result_events_dispatcher.map_method('test_progress', True)
                 else:
                     break
@@ -453,7 +446,6 @@ class TestRunner(object):
             test_state = add_runner_failure(test_state, "ERROR", "Test reports"
                                             " unsupported test status.")
 
-        self.result_proxy.check_test(test_state)
         self.result.check_test(test_state)
         self.job._result_events_dispatcher.map_method('end_test',
                                                       self.result,
@@ -516,8 +508,6 @@ class TestRunner(object):
 
         test_result_total = mux.get_number_of_tests(test_suite)
         no_digits = len(str(test_result_total))
-        self.result_proxy.set_tests_total(test_result_total)
-        self.result_proxy.start_tests()
         self.result.tests_total = test_result_total
         self.result.start_tests()
         index = -1
@@ -562,7 +552,6 @@ class TestRunner(object):
 
         if self.job.sysinfo is not None:
             self.job.sysinfo.end_job_hook()
-        self.result_proxy.end_tests()
         self.result.end_tests()
         self.job._result_events_dispatcher.map_method('post_tests', self.job)
         self.job.funcatexit.run()

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -252,16 +252,18 @@ class TestRunner(object):
     """
     DEFAULT_TIMEOUT = 86400
 
-    def __init__(self, job, result_proxy):
+    def __init__(self, job, result_proxy, result):
         """
         Creates an instance of TestRunner class.
 
         :param job: an instance of :class:`avocado.core.job.Job`.
         :param result_proxy: an instance of
                             :class:`avocado.core.result.ResultProxy`.
+        :param result: an instance of :class:`avocado.core.result.Result`
         """
         self.job = job
         self.result_proxy = result_proxy
+        self.result = result
         self.sigstopped = False
 
     def _run_test(self, test_factory, queue):
@@ -309,6 +311,7 @@ class TestRunner(object):
             instance.error(stacktrace.str_unpickable_object(early_state))
 
         self.result_proxy.start_test(early_state)
+        self.result.start_test(early_state)
         try:
             instance.run_avocado()
         finally:
@@ -444,6 +447,7 @@ class TestRunner(object):
                                             " unsupported test status.")
 
         self.result_proxy.check_test(test_state)
+        self.result.check_test(test_state)
         if test_state['status'] == "INTERRUPTED":
             summary.add("INTERRUPTED")
         elif not mapping[test_state['status']]:
@@ -504,7 +508,8 @@ class TestRunner(object):
         no_digits = len(str(test_result_total))
         self.result_proxy.set_tests_total(test_result_total)
         self.result_proxy.start_tests()
-
+        self.result.tests_total = test_result_total
+        self.result.start_tests()
         index = -1
         try:
             for test_template in test_suite:
@@ -548,6 +553,7 @@ class TestRunner(object):
         if self.job.sysinfo is not None:
             self.job.sysinfo.end_job_hook()
         self.result_proxy.end_tests()
+        self.result.end_tests()
         self.job.funcatexit.run()
         signal.signal(signal.SIGTSTP, signal.SIG_IGN)
         return summary

--- a/avocado/plugins/docker.py
+++ b/avocado/plugins/docker.py
@@ -116,8 +116,8 @@ class DockerTestRunner(RemoteTestRunner):
     Test runner which runs the job inside a docker container
     """
 
-    def __init__(self, job, result_proxy):
-        super(DockerTestRunner, self).__init__(job, result_proxy)
+    def __init__(self, job, result_proxy, result):
+        super(DockerTestRunner, self).__init__(job, result_proxy, result)
         self.remote = None      # Will be set in `setup`
 
     def setup(self):

--- a/avocado/plugins/docker.py
+++ b/avocado/plugins/docker.py
@@ -116,8 +116,8 @@ class DockerTestRunner(RemoteTestRunner):
     Test runner which runs the job inside a docker container
     """
 
-    def __init__(self, job, result_proxy, result):
-        super(DockerTestRunner, self).__init__(job, result_proxy, result)
+    def __init__(self, job, result):
+        super(DockerTestRunner, self).__init__(job, result)
         self.remote = None      # Will be set in `setup`
 
     def setup(self):

--- a/avocado/plugins/human.py
+++ b/avocado/plugins/human.py
@@ -1,0 +1,100 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat, Inc. 2016
+# Author: Cleber Rosa <crosa@redhat.com>
+"""
+Human result UI
+"""
+
+import logging
+
+from avocado.core.plugin_interfaces import ResultEvents
+from avocado.core import output
+
+
+class Human(ResultEvents):
+
+    """
+    Human result UI
+    """
+
+    name = 'human'
+    description = "Human Interface UI"
+
+    output_mapping = {'PASS': output.TERM_SUPPORT.PASS,
+                      'ERROR': output.TERM_SUPPORT.ERROR,
+                      'FAIL': output.TERM_SUPPORT.FAIL,
+                      'SKIP': output.TERM_SUPPORT.SKIP,
+                      'WARN': output.TERM_SUPPORT.WARN,
+                      'INTERRUPTED': output.TERM_SUPPORT.INTERRUPT}
+
+    def __init__(self, args):
+        self.log = logging.getLogger("avocado.app")
+        self.__throbber = output.Throbber()
+        stdout_claimed_by = getattr(args, 'stdout_claimed_by', None)
+        self.owns_stdout = not stdout_claimed_by
+
+    def pre_tests(self, job):
+        if not self.owns_stdout:
+            return
+        self.log.info("JOB ID     : %s", job.unique_id)
+        replay_source_job = getattr(job.args, "replay_sourcejob", False)
+        if replay_source_job:
+            self.log.info("SRC JOB ID : %s", self.__replay_source_job)
+        self.log.info("JOB LOG    : %s", job.logfile)
+        self.log.info("TESTS      : %s", len(job.test_suite))
+
+    def start_test(self, result, state):
+        if not self.owns_stdout:
+            return
+        if "name" in state:
+            name = state["name"]
+            uid = name.str_uid
+            name = name.name + name.str_variant
+        else:
+            name = "<unknown>"
+            uid = '?'
+        self.log.debug(' (%s/%s) %s:  ', uid, result.tests_total, name,
+                       extra={"skip_newline": True})
+
+    def test_progress(self, progress=False):
+        if not self.owns_stdout:
+            return
+        if progress:
+            color = output.TERM_SUPPORT.PASS
+        else:
+            color = output.TERM_SUPPORT.PARTIAL
+        self.log.debug(color + self.__throbber.render() +
+                       output.TERM_SUPPORT.ENDC, extra={"skip_newline": True})
+
+    def end_test(self, result, state):
+        if not self.owns_stdout:
+            return
+        status = state.get("status", "ERROR")
+        if status == "TEST_NA":
+            status = "SKIP"
+        duration = (" (%.2f s)" % state.get('time_elapsed', -1)
+                    if status != "SKIP"
+                    else "")
+        self.log.debug(output.TERM_SUPPORT.MOVE_BACK +
+                       self.output_mapping[status] +
+                       status + output.TERM_SUPPORT.ENDC +
+                       duration)
+
+    def post_tests(self, job):
+        if not self.owns_stdout:
+            return
+        self.log.info("RESULTS    : PASS %d | ERROR %d | FAIL %d | SKIP %d | "
+                      "WARN %d | INTERRUPT %s", job.result.passed,
+                      job.result.errors, job.result.failed, job.result.skipped,
+                      job.result.warned, job.result.interrupted)
+        self.log.info("TESTS TIME : %.2f s", job.result.tests_total_time)

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -164,10 +164,7 @@ class Run(CLICmd):
         job_run = job_instance.run()
         result_dispatcher = ResultDispatcher()
         if result_dispatcher.extensions:
-            # At this point job_instance doesn't have a single results
-            # attribute which is the end goal.  For now, we pick any of the
-            # plugin classes added to the result proxy.
-            if len(job_instance.result_proxy.output_plugins) > 0:
-                result = job_instance.result_proxy.output_plugins[0]
-                result_dispatcher.map_method('render', result, job_instance)
+            result_dispatcher.map_method('render',
+                                         job_instance.result,
+                                         job_instance)
         return job_run

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -162,9 +162,11 @@ class Run(CLICmd):
             sys.exit(exit_codes.AVOCADO_FAIL)
         job_instance = job.Job(args)
         job_run = job_instance.run()
-        result_dispatcher = ResultDispatcher()
-        if result_dispatcher.extensions:
-            result_dispatcher.map_method('render',
-                                         job_instance.result,
-                                         job_instance)
+
+        if job_instance.status != 'RUNNING':
+            result_dispatcher = ResultDispatcher()
+            if result_dispatcher.extensions:
+                result_dispatcher.map_method('render',
+                                             job_instance.result,
+                                             job_instance)
         return job_run

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -6,6 +6,7 @@ if sys.version_info[:2] == (2, 6):
 else:
     import unittest
 
+from avocado.core import exceptions
 from avocado.core import test
 from avocado.core import job
 from avocado.core import exit_codes
@@ -42,8 +43,8 @@ class JobTest(unittest.TestCase):
     def test_job_create_test_suite_empty(self):
         args = argparse.Namespace()
         myjob = job.Job(args)
-        myjob.create_test_suite()
-        self.assertEqual(myjob.test_suite, [])
+        self.assertRaises(exceptions.OptionValidationError,
+                          myjob.create_test_suite)
 
     def test_job_create_test_suite_simple(self):
         simple_tests_found = self._find_simple_test_candidates()

--- a/selftests/unit/test_jsonresult.py
+++ b/selftests/unit/test_jsonresult.py
@@ -15,6 +15,7 @@ class FakeJob(object):
 
     def __init__(self, args):
         self.args = args
+        self.unique_id = '0000000000000000000000000000000000000000'
 
 
 class JSONResultTest(unittest.TestCase):

--- a/selftests/unit/test_remote.py
+++ b/selftests/unit/test_remote.py
@@ -111,6 +111,12 @@ _=/usr/bin/env''', exit_status=0)
                                          dry_run=True))
         Results.should_receive('set_tests_total').once().with_args(1).ordered()
         Results.should_receive('start_tests').once().ordered()
+        Result = flexmock(remote=Remote, urls=['sleeptest'],
+                          stream=stream, timeout=None,
+                          args=flexmock(show_job_log=False,
+                                        mux_yaml=['foo.yaml', 'bar/baz.yaml'],
+                                        dry_run=True))
+        Result.should_receive('start_tests').once().ordered()
         args = {'status': u'PASS', 'whiteboard': '', 'time_start': 0,
                 'name': '1-sleeptest;0', 'class_name': 'RemoteTest',
                 'traceback': 'Not supported yet',
@@ -121,7 +127,9 @@ _=/usr/bin/env''', exit_status=0)
                 'logdir': u'/local/path/test-results/1-sleeptest;0',
                 'logfile': u'/local/path/test-results/1-sleeptest;0/debug.log'}
         Results.should_receive('start_test').once().with_args(args).ordered()
+        Result.should_receive('start_test').once().with_args(args).ordered()
         Results.should_receive('check_test').once().with_args(args).ordered()
+        Result.should_receive('check_test').once().with_args(args).ordered()
         (Remote.should_receive('receive_files')
          .with_args('/local/path', '/home/user/avocado/logs/run-2014-05-26-'
                     '15.45.37.zip')).once().ordered()
@@ -132,7 +140,9 @@ _=/usr/bin/env''', exit_status=0)
          .with_args('/local/path/run-2014-05-26-15.45.37.zip').once()
          .ordered())
         Results.should_receive('end_tests').once().ordered()
+        Result.should_receive('end_tests').once().ordered()
         self.runner.result_proxy = Results
+        self.runner.result = Result
 
     def tearDown(self):
         flexmock_teardown()
@@ -170,7 +180,7 @@ class RemoteTestRunnerSetup(unittest.TestCase):
         log = flexmock()
         log.should_receive("info")
         job = flexmock(args=Args, log=log)
-        self.runner = remote.RemoteTestRunner(job, None)
+        self.runner = remote.RemoteTestRunner(job, None, None)
 
     def tearDown(self):
         flexmock_teardown()

--- a/selftests/unit/test_remote.py
+++ b/selftests/unit/test_remote.py
@@ -103,15 +103,7 @@ _=/usr/bin/env''', exit_status=0)
         (Remote.should_receive('run')
          .with_args(args, timeout=61, ignore_status=True)
          .once().and_return(test_results))
-        Results = flexmock(remote=Remote, references=['sleeptest'],
-                           stream=stream, timeout=None,
-                           args=flexmock(show_job_log=False,
-                                         mux_yaml=['~/avocado/tests/foo.yaml',
-                                                   '~/avocado/tests/bar/baz.yaml'],
-                                         dry_run=True))
-        Results.should_receive('set_tests_total').once().with_args(1).ordered()
-        Results.should_receive('start_tests').once().ordered()
-        Result = flexmock(remote=Remote, urls=['sleeptest'],
+        Result = flexmock(remote=Remote, references=['sleeptest'],
                           stream=stream, timeout=None,
                           args=flexmock(show_job_log=False,
                                         mux_yaml=['foo.yaml', 'bar/baz.yaml'],
@@ -126,9 +118,7 @@ _=/usr/bin/env''', exit_status=0)
                 'fail_reason': u'None',
                 'logdir': u'/local/path/test-results/1-sleeptest;0',
                 'logfile': u'/local/path/test-results/1-sleeptest;0/debug.log'}
-        Results.should_receive('start_test').once().with_args(args).ordered()
         Result.should_receive('start_test').once().with_args(args).ordered()
-        Results.should_receive('check_test').once().with_args(args).ordered()
         Result.should_receive('check_test').once().with_args(args).ordered()
         (Remote.should_receive('receive_files')
          .with_args('/local/path', '/home/user/avocado/logs/run-2014-05-26-'
@@ -139,9 +129,7 @@ _=/usr/bin/env''', exit_status=0)
         (flexmock(os).should_receive('remove')
          .with_args('/local/path/run-2014-05-26-15.45.37.zip').once()
          .ordered())
-        Results.should_receive('end_tests').once().ordered()
         Result.should_receive('end_tests').once().ordered()
-        self.runner.result_proxy = Results
         self.runner.result = Result
 
     def tearDown(self):
@@ -180,7 +168,7 @@ class RemoteTestRunnerSetup(unittest.TestCase):
         log = flexmock()
         log.should_receive("info")
         job = flexmock(args=Args, log=log)
-        self.runner = remote.RemoteTestRunner(job, None, None)
+        self.runner = remote.RemoteTestRunner(job, None)
 
     def tearDown(self):
         flexmock_teardown()

--- a/selftests/unit/test_result.py
+++ b/selftests/unit/test_result.py
@@ -1,0 +1,33 @@
+import sys
+import argparse
+if sys.version_info[:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
+
+from avocado.core.result import Result
+
+
+class FakeJobMissingUniqueId(object):
+
+    def __init__(self, args):
+        self.args = args
+
+
+class FakeJob(object):
+
+    def __init__(self, args):
+        self.args = args
+        self.unique_id = '0000000000000000000000000000000000000000'
+
+
+class ResultTest(unittest.TestCase):
+
+    def test_result_job_without_id(self):
+        args = argparse.Namespace()
+        result = Result(FakeJob(args))
+        self.assertRaises(AttributeError, Result, FakeJobMissingUniqueId(args))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/selftests/unit/test_vm.py
+++ b/selftests/unit/test_vm.py
@@ -54,7 +54,7 @@ class VMTestRunnerSetup(unittest.TestCase):
         log = flexmock()
         log.should_receive("info")
         job = flexmock(args=Args, log=log)
-        self.runner = VMTestRunner(job, None, None)
+        self.runner = VMTestRunner(job, None)
         mock_vm.should_receive('stop').once().ordered()
         mock_vm.should_receive('restore_snapshot').once().ordered()
 

--- a/selftests/unit/test_vm.py
+++ b/selftests/unit/test_vm.py
@@ -54,7 +54,7 @@ class VMTestRunnerSetup(unittest.TestCase):
         log = flexmock()
         log.should_receive("info")
         job = flexmock(args=Args, log=log)
-        self.runner = VMTestRunner(job, None)
+        self.runner = VMTestRunner(job, None, None)
         mock_vm.should_receive('stop').once().ordered()
         mock_vm.should_receive('restore_snapshot').once().ordered()
 

--- a/selftests/unit/test_xunit.py
+++ b/selftests/unit/test_xunit.py
@@ -21,6 +21,7 @@ class FakeJob(object):
 
     def __init__(self, args):
         self.args = args
+        self.unique_id = '0000000000000000000000000000000000000000'
 
 
 class xUnitSucceedTest(unittest.TestCase):

--- a/setup.py
+++ b/setup.py
@@ -162,6 +162,7 @@ if __name__ == '__main__':
                   ],
               'avocado.plugins.result_events': [
                   'human = avocado.plugins.human:Human',
+                  'tap = avocado.plugins.tap:TAPResult',
                   ],
               },
           zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -160,6 +160,9 @@ if __name__ == '__main__':
                   'json = avocado.plugins.jsonresult:JSONResult',
                   'zip_archive = avocado.plugins.archive:Archive',
                   ],
+              'avocado.plugins.result_events': [
+                  'human = avocado.plugins.human:Human',
+                  ],
               },
           zip_safe=False,
           test_suite='selftests',

--- a/setup.py
+++ b/setup.py
@@ -163,6 +163,7 @@ if __name__ == '__main__':
               'avocado.plugins.result_events': [
                   'human = avocado.plugins.human:Human',
                   'tap = avocado.plugins.tap:TAPResult',
+                  'journal = avocado.plugins.journal:JournalResult',
                   ],
               },
           zip_safe=False,


### PR DESCRIPTION
This is a complete implementation of the `ResultEvents` plugin interface, including the migration of the `HumanResult`, `TAP` and `Journal` plugins.  A few notes:

 * The `FileOrStdOutAction` approach was kept to lock access to STDOUT.  As suggested by @ldoktor there are fancier and cleaner approaches, but they were not attempted here.

 * Those changes expose a lot of issues about or current job/runner implementation details.  Some of the commits are controversial and inteded as a RFC.