### PR TITLE
docs: include link for the version documentation

### DIFF
--- a/docs/source/release_notes/36_0.rst
+++ b/docs/source/release_notes/36_0.rst
@@ -5,6 +5,9 @@
 This is a very proud announcement: Avocado release 36.0lts, our very
 first "Long Term Stability" release, is now out!
 
+Release documentation: `Avocado 36.0
+<http://avocado-framework.readthedocs.io/en/36lts/>`_
+
 LTS in a nutshell
 -----------------
 

--- a/docs/source/release_notes/37_0.rst
+++ b/docs/source/release_notes/37_0.rst
@@ -5,6 +5,9 @@
 This is another proud announcement: Avocado release 37.0, aka "Trabant
 vs. South America", is now out!
 
+Release documentation: `Avocado 37.0
+<http://avocado-framework.readthedocs.io/en/37.0/>`_
+
 This release is yet another collection of bug fixes and some new
 features.  Along with the same changes that made the 36.0lts
 release[1], this brings the following additional changes:

--- a/docs/source/release_notes/38_0.rst
+++ b/docs/source/release_notes/38_0.rst
@@ -5,6 +5,9 @@
 You guessed it right: this is another Avocado release announcement:
 release 38.0, aka "Love, Ken", is now out!
 
+Release documentation: `Avocado 38.0
+<http://avocado-framework.readthedocs.io/en/38.0/>`_
+
 Another development cycle has just finished, and our community will
 receive this new release containing a nice assortment of bug fixes and
 new features.

--- a/docs/source/release_notes/39_0.rst
+++ b/docs/source/release_notes/39_0.rst
@@ -5,6 +5,9 @@
 The Avocado team is proud to present another incremental release:
 version 39.0, aka, "The Hateful Eight", is now available!
 
+Release documentation: `Avocado 39.0
+<http://avocado-framework.readthedocs.io/en/39.0/>`_
+
 The major changes introduced on this version are listed below.
 
 * Support for running tests in Docker container.  Now, in addition to

--- a/docs/source/release_notes/40_0.rst
+++ b/docs/source/release_notes/40_0.rst
@@ -5,6 +5,9 @@
 The Avocado team is proud to present another release:
 Avocado version 40.0, aka, "Dr Who", is now available!
 
+Release documentation: `Avocado 40.0
+<http://avocado-framework.readthedocs.io/en/40.0/>`_
+
 The major changes introduced on this version are listed below.
 
 * The introduction of a tool that generated a diff-like report of two

--- a/docs/source/release_notes/41_0.rst
+++ b/docs/source/release_notes/41_0.rst
@@ -5,6 +5,9 @@
 The Avocado team is proud to present another release:
 Avocado version 41.0, aka, "Outlander", is now available!
 
+Release documentation: `Avocado 41.0
+<http://avocado-framework.readthedocs.io/en/41.0/>`_
+
 The major changes introduced on this version are listed below,
 roughly categorized into major topics and intended audience:
 

--- a/docs/source/release_notes/42_0.rst
+++ b/docs/source/release_notes/42_0.rst
@@ -5,6 +5,9 @@
 The Avocado team is proud to present another release: Avocado version
 42.0, aka, "Stranger Things", is now available!
 
+Release documentation: `Avocado 42.0
+<http://avocado-framework.readthedocs.io/en/42.0/>`_
+
 The major changes introduced on this version are listed below,
 roughly categorized into major topics and intended audience:
 


### PR DESCRIPTION
We have docs available on Red The Docs for all versions from 36.0
onwards. Let's include in each release notes the link for the version
documentation so users can easily see the docs for that version.

Signed-off-by: Amador Pahim <apahim@redhat.com>