### PR TITLE
fix selftests/cyclical_deps

### DIFF
--- a/requirements-selftests.txt
+++ b/requirements-selftests.txt
@@ -19,7 +19,7 @@ Pillow>=2.2.1
 snakefood>=1.4
 networkx>=1.9.1
 pygraphviz>=1.3rc2
-pydot>=1.0.2
+pydot>=1.2.3
 aexpect>=1.0.0
 psutil>=3.1.1
 # stevedore for loading "new style" plugins

--- a/selftests/cyclical_deps
+++ b/selftests/cyclical_deps
@@ -57,7 +57,8 @@ def generate_dot_file(path):
 
 
 def cyclical_deps(path_dot):
-    graph = nx.DiGraph(nx.read_dot(path_dot))
+    graph = nx.DiGraph(nx.nx_agraph.read_dot(path_dot))
+
     cycles = list(nx.simple_cycles(graph))
     if cycles:
         print('Found cyclical dependencies in module(s):')


### PR DESCRIPTION
graphviz drawing tools are no longer imported into the top
level namespace of networkx (networkx >= 1.11). This patch
changes the read_dot(), using it from the actual module.

Also, let's update the required version for pydot to make sure it works with latest networkx.