### PR TITLE
Fixup: format strings for tap output

### DIFF
--- a/avocado/plugins/tap.py
+++ b/avocado/plugins/tap.py
@@ -63,17 +63,16 @@ class TAPResult(Result):
             if name[0].isdigit():   # Name must not start with digit
                 name = "_" + name
         # First log the system output
-        self.__write("# debug.log of %s:" % name)
+        self.__write("# debug.log of %s:", name)
         if state.get('text_output'):
             for line in state['text_output'].splitlines():
-                self.__write("#   " + line)
+                self.__write("#   %s", line)
         if status in ("PASS", "WARN"):
-            self.__write("ok %s %s" % (self.tests_run, name))
+            self.__write("ok %s %s", self.tests_run, name)
         elif status == "SKIP":
-            self.__write("ok %s %s  # SKIP %s" % (self.tests_run, name,
-                                                  state.get("fail_reason")))
+            self.__write("ok %s %s  # SKIP %s", self.tests_run, name, state.get("fail_reason"))
         else:
-            self.__write("not ok %s %s" % (self.tests_run, name))
+            self.__write("not ok %s %s", self.tests_run, name)
         super(TAPResult, self).end_test(state)
 
     def end_tests(self):


### PR DESCRIPTION
Before this patch
  File "/usr/lib/python2.7/site-packages/avocado_framework-42.0-py2.7.egg/avocado/core/result.py", line 178, in check_test
    self.end_test(state)

  File "/usr/lib/python2.7/site-packages/avocado_framework-42.0-py2.7.egg/avocado/plugins/tap.py", line 69, in end_test
    self.__write("#   " + line)

  File "/usr/lib/python2.7/site-packages/avocado_framework-42.0-py2.7.egg/avocado/plugins/tap.py", line 35, in writeln
    return self.output.write(msg % args + "\n")

TypeError: not enough arguments for format string

This patch addresses above issue while giving file for
tap output