### PR TITLE
Plugins list: add result events

### DIFF
--- a/avocado/plugins/journal.py
+++ b/avocado/plugins/journal.py
@@ -41,6 +41,9 @@ class JournalResult(ResultEvents):
     feedback to users from a central place.
     """
 
+    name = 'journal'
+    description = "Journal event based results implementation"
+
     def __init__(self, args):
         """
         Creates an instance of ResultJournal.

--- a/avocado/plugins/plugins.py
+++ b/avocado/plugins/plugins.py
@@ -48,7 +48,9 @@ class Plugins(CLICmd):
             (dispatcher.JobPrePostDispatcher(),
              'Plugins that run before/after the execution of jobs (job.prepost):'),
             (dispatcher.ResultDispatcher(),
-             'Plugins that generate job result in different formats (result):')
+             'Plugins that generate job result in different formats (result):'),
+            (dispatcher.ResultEventsDispatcher(args),
+             'Plugins that generate job result based on job/test events (result_events):')
         ]
         for plugins_active, msg in plugin_types:
             log.info(msg)

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -36,7 +36,7 @@ class Run(CLICmd):
     """
 
     name = 'run'
-    description = ("Runs one or more tests (native test, test alias, binary"
+    description = ("Runs one or more tests (native test, test alias, binary "
                    "or script)")
 
     def configure(self, parser):


### PR DESCRIPTION
This PR adds "result events" plugins to the output given when running `avocado plugins`.