### PR TITLE
Fixup: format strings for tap output[V3]

### DIFF
--- a/avocado/plugins/tap.py
+++ b/avocado/plugins/tap.py
@@ -35,7 +35,13 @@ class TAPResult(ResultEvents):
             """
             Format msg and append '\n'
             """
-            return self.output.write(msg % writeargs + "\n")
+            if writeargs:
+                try:
+                    msg %= writeargs
+                except TypeError, details:
+                    raise TypeError("%s: msg='%s' args='%s'" %
+                                    (details, msg, writeargs))
+            return self.output.write(msg + "\n")
 
         def silent(msg, *writeargs):
             pass
@@ -75,17 +81,16 @@ class TAPResult(ResultEvents):
             if name[0].isdigit():   # Name must not start with digit
                 name = "_" + name
         # First log the system output
-        self.__write("# debug.log of %s:" % name)
+        self.__write("# debug.log of %s:", name)
         if state.get('text_output'):
             for line in state['text_output'].splitlines():
-                self.__write("#   " + line)
+                self.__write("#   %s", line)
         if status in ("PASS", "WARN"):
-            self.__write("ok %s %s" % (result.tests_run, name))
+            self.__write("ok %s %s", result.tests_run, name)
         elif status == "SKIP":
-            self.__write("ok %s %s  # SKIP %s" % (result.tests_run, name,
-                                                  state.get("fail_reason")))
+            self.__write("ok %s %s  # SKIP %s", result.tests_run, name, state.get("fail_reason"))
         else:
-            self.__write("not ok %s %s" % (result.tests_run, name))
+            self.__write("not ok %s %s", result.tests_run, name)
 
     def test_progress(self, progress=False):
         pass


### PR DESCRIPTION
Before this patch tap output to a file fails with below error

 File "/usr/lib/python2.7/site-packages/avocado_framework-42.0-py2.7.egg/avocado/core/result.py", line 178, in check_test
    self.end_test(state)

  File "/usr/lib/python2.7/site-packages/avocado_framework-42.0-py2.7.egg/avocado/plugins/tap.py", line 69, in end_test
    self.__write("#   " + line)

  File "/usr/lib/python2.7/site-packages/avocado_framework-42.0-py2.7.egg/avocado/plugins/tap.py", line 35, in writeln
    return self.output.write(msg % args + "\n")

TypeError: not enough arguments for format string

This patch addresses above issue.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>
Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>