### PR TITLE
Fix selftests on EL7 and enable checks on package build

### DIFF
--- a/avocado.spec
+++ b/avocado.spec
@@ -26,6 +26,13 @@ Requires: python-yaml, procps-ng
 BuildRequires: python-yaml, procps-ng
 %endif
 
+%if 0%{?fedora} >= 25
+BuildRequires: kmod
+%endif
+%if 0%{?rhel} >= 7
+BuildRequires: kmod
+%endif
+
 %description
 Avocado is a set of tools and libraries (what people call
 these days a framework) to perform automated testing.
@@ -49,12 +56,8 @@ cd ../../
 %{__install} -m 0644 man/avocado.1 %{buildroot}%{_mandir}/man1/avocado.1
 %{__install} -m 0644 man/avocado-rest-client.1 %{buildroot}%{_mandir}/man1/avocado-rest-client.1
 
-# Running selftests on EL7 is currently disabled because of a few
-# broken tests
-%if !0%{?el7}
 %check
- selftests/run
-%endif
+selftests/run
 
 %files
 %defattr(-,root,root,-)

--- a/selftests/doc/test_doc_build.py
+++ b/selftests/doc/test_doc_build.py
@@ -49,6 +49,14 @@ class DocBuildTest(unittest.TestCase):
         """
         ignore_list = []
         failure_lines = []
+        # Disregard bogus warnings due to a bug in older versions of
+        # python-sphinx.
+        ignore_list.append('WARNING: toctree contains reference to ' +
+                           'nonexisting document u\'api/test/avocado.core\'')
+        ignore_list.append('WARNING: toctree contains reference to ' +
+                           'nonexisting document u\'api/test/avocado.plugins\'')
+        ignore_list.append('WARNING: toctree contains reference to ' +
+                           'nonexisting document u\'api/test/avocado.utils\'')
         doc_dir = os.path.join(basedir, 'docs')
         process.run('make -C %s clean' % doc_dir)
         result = process.run('make -C %s html' % doc_dir)


### PR DESCRIPTION
1. Added explicit build dependencies upon kmod to prevent test_lv_utils check
   failures.
2. Modified test_build_docs to explicitly ignore bogus warnings due to a bug
   in older versions of python-sphinx package causing checks to fail.
3. Enabled EL7 checks during package build.

Signed-off-by: Merlin Mathesius <mmathesi@redhat.com>