### PR TITLE
Preserve test environment for post-mortem debug

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -132,6 +132,14 @@ class Job(object):
         # A future optimization may load it on demand.
         self._result_events_dispatcher = dispatcher.ResultEventsDispatcher(self.args)
         output.log_plugin_failures(self._result_events_dispatcher.load_failures)
+        self.keep_tmp_files = settings.get_value('runner.behavior',
+                                                 'keep_tmp_files',
+                                                 key_type=bool,
+                                                 default=False)
+        basedir = None
+        if self.keep_tmp_files:
+            basedir = self.logdir
+        data_dir.get_tmp_dir(basedir)
 
     def _setup_job_results(self):
         """


### PR DESCRIPTION
In order to preserve test environment for post-mortem debug, let's
create the job tmp_dir inside the job logdir when keep_tmp_files is set
to True in the config file, so users can have the temporary directory
created for the job preserved in a stable location.

Reference: https://trello.com/c/Q6I65OZl
Signed-off-by: Amador Pahim <apahim@redhat.com>