### PR TITLE
Pre/Post Job changes and Job Time Accounting (aka "Job time should be wall clock time")

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -25,6 +25,7 @@ import re
 import shutil
 import sys
 import tempfile
+import time
 import traceback
 
 from . import version
@@ -109,6 +110,15 @@ class Job(object):
         self.result = result.Result(self)
         self.sysinfo = None
         self.timeout = getattr(self.args, 'job_timeout', 0)
+        #: The time at which the job has started or `-1` if it has not been
+        #: started by means of the `run()` method.
+        self.time_start = -1
+        #: The time at which the job has finished or `-1` if it has not been
+        #: started by means of the `run()` method.
+        self.time_end = -1
+        #: The total amount of time the job took from start to finish,
+        #: or `-1` if it has not been started by means of the `run()` method
+        self.time_elapsed = -1
         self.__logging_handlers = {}
         self.__start_job_logging()
         self.funcatexit = data_structures.CallbackRegister("JobExit %s"
@@ -480,6 +490,8 @@ class Job(object):
         :return: Integer with overall job status. See
                  :mod:`avocado.core.exit_codes` for more information.
         """
+        if self.time_start == -1:
+            self.time_start = time.time()
         runtime.CURRENT_JOB = self
         try:
             self.create_test_suite()
@@ -515,6 +527,9 @@ class Job(object):
             if not settings.get_value('runner.behavior', 'keep_tmp_files',
                                       key_type=bool, default=False):
                 data_dir.clean_tmp_files()
+            if self.time_end == -1:
+                self.time_end = time.time()
+                self.time_elapsed = self.time_end - self.time_start
             self.__stop_job_logging()
 
 

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -123,9 +123,6 @@ class Job(object):
         #: test was found during resolution.
         self.test_suite = None
 
-        # A job may not have a dispatcher for pre/post tests execution plugins
-        self._job_pre_post_dispatcher = None
-
         # The result events dispatcher is shared with the test runner.
         # Because of our goal to support using the phases of a job
         # freely, let's get the result events dispatcher ready early.
@@ -423,11 +420,8 @@ class Job(object):
         Run the pre tests execution hooks
 
         By default this runs the plugins that implement the
-        :class:`avocado.core.plugin_interfaces.JobPre` interface.
+        :class:`avocado.core.plugin_interfaces.JobPreTests` interface.
         """
-        self._job_pre_post_dispatcher = dispatcher.JobPrePostDispatcher()
-        output.log_plugin_failures(self._job_pre_post_dispatcher.load_failures)
-        self._job_pre_post_dispatcher.map_method('pre', self)
         self._result_events_dispatcher.map_method('pre_tests', self)
 
     def run_tests(self):
@@ -472,12 +466,9 @@ class Job(object):
         Run the post tests execution hooks
 
         By default this runs the plugins that implement the
-        :class:`avocado.core.plugin_interfaces.JobPost` interface.
+        :class:`avocado.core.plugin_interfaces.JobPostTests` interface.
         """
-        if self._job_pre_post_dispatcher is None:
-            self._job_pre_post_dispatcher = dispatcher.JobPrePostDispatcher()
-            output.log_plugin_failures(self._job_pre_post_dispatcher.load_failures)
-        self._job_pre_post_dispatcher.map_method('post', self)
+        self._result_events_dispatcher.map_method('post_tests', self)
 
     def run(self):
         """

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -557,7 +557,6 @@ class TestRunner(object):
         if self.job.sysinfo is not None:
             self.job.sysinfo.end_job_hook()
         self.result.end_tests()
-        self.job._result_events_dispatcher.map_method('post_tests', self.job)
         self.job.funcatexit.run()
         signal.signal(signal.SIGTSTP, signal.SIG_IGN)
         return summary

--- a/avocado/plugins/human.py
+++ b/avocado/plugins/human.py
@@ -18,6 +18,7 @@ Human result UI
 import logging
 
 from avocado.core.plugin_interfaces import ResultEvents
+from avocado.core.plugin_interfaces import JobPre, JobPost
 from avocado.core import output
 
 
@@ -98,3 +99,22 @@ class Human(ResultEvents):
                       job.result.errors, job.result.failed, job.result.skipped,
                       job.result.warned, job.result.interrupted)
         self.log.info("TESTS TIME : %.2f s", job.result.tests_total_time)
+
+
+class HumanJob(JobPre, JobPost):
+
+    """
+    Human result UI
+    """
+
+    name = 'human'
+    description = "Human Interface UI"
+
+    def pre(self, job):
+        pass
+
+    def post(self, job):
+        if job.time_elapsed != -1:
+            if not getattr(job.args, 'stdout_claimed_by', None):
+                log = logging.getLogger("avocado.app")
+                log.info("JOB TIME   : %.2f s", job.time_elapsed)

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -23,8 +23,10 @@ import sys
 from avocado.core import exit_codes
 from avocado.core import job
 from avocado.core import loader
+from avocado.core import output
 from avocado.core.plugin_interfaces import CLICmd
 from avocado.core.dispatcher import ResultDispatcher
+from avocado.core.dispatcher import JobPrePostDispatcher
 from avocado.core.settings import settings
 from avocado.utils.data_structures import time_to_seconds
 
@@ -161,7 +163,17 @@ class Run(CLICmd):
             log.error(e.message)
             sys.exit(exit_codes.AVOCADO_FAIL)
         job_instance = job.Job(args)
+
+        # Run JobPre plugins
+        pre_post_dispatcher = JobPrePostDispatcher()
+        output.log_plugin_failures(pre_post_dispatcher.load_failures)
+        pre_post_dispatcher.map_method('pre', job_instance)
+
         job_run = job_instance.run()
+
+        # Run JobPost plugins
+        pre_post_dispatcher.map_method('post', job_instance)
+
         result_dispatcher = ResultDispatcher()
         if result_dispatcher.extensions:
             result_dispatcher.map_method('render',

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -119,6 +119,25 @@ class JobTest(unittest.TestCase):
         self.assertEqual(myjob.unique_id[::-1],
                          open(os.path.join(myjob.logdir, "reversed_id")).read())
 
+    @unittest.skip("Issue described at https://trello.com/c/qgSTIK0Y")
+    def test_job_run_account_time(self):
+        myjob = job.Job()
+        myjob.run()
+        self.assertNotEqual(myjob.time_start, -1)
+        self.assertNotEqual(myjob.time_end, -1)
+        self.assertNotEqual(myjob.time_elapsed, -1)
+
+    @unittest.skip("Issue described at https://trello.com/c/qgSTIK0Y")
+    def test_job_self_account_time(self):
+        myjob = job.Job()
+        myjob.time_start = 10.0
+        myjob.run()
+        myjob.time_end = 20.0
+        myjob.time_elapsed = myjob.time_end - myjob.time_start
+        self.assertEqual(myjob.time_start, 10.0)
+        self.assertEqual(myjob.time_end, 20.0)
+        self.assertEqual(myjob.time_elapsed, 10.0)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -155,6 +155,7 @@ if __name__ == '__main__':
                   ],
               'avocado.plugins.job.prepost': [
                   'jobscripts = avocado.plugins.jobscripts:JobScripts',
+                  'human = avocado.plugins.human:HumanJob',
                   ],
               'avocado.plugins.result': [
                   'xunit = avocado.plugins.xunit:XUnitResult',


### PR DESCRIPTION
This is the last changes to deliver the so called "Job time should be wall clock time".

It introduces necessary fixes to the location of Pre/Post Job plugins execution, followed by Job time accounting, and the human interface addition itself. 