### PR TITLE
 Preserve test environment for post-mortem debug [v2]

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -133,6 +133,28 @@ class Job(object):
         self._result_events_dispatcher = dispatcher.ResultEventsDispatcher(self.args)
         output.log_plugin_failures(self._result_events_dispatcher.load_failures)
 
+        # Checking whether we will keep the Job tmp_dir or not.
+        basedir = None
+        keep_tmp = False
+        keep_tmp_arg = getattr(self.args, "keep_tmp", None)
+        keep_tmp_setting = settings.get_value('runner.behavior',
+                                              'keep_tmp_files',
+                                              key_type=bool,
+                                              default=False)
+        # '--kepp-tmp on' makes the Job to keep the tmp_dir
+        if keep_tmp_arg == 'on':
+            keep_tmp = True
+        # 'keep_tmp_files = True' in config file makes the Job to keep
+        # the tmp_dir, but only if '--keep-tmp' is not set to 'off'.
+        elif keep_tmp_setting and keep_tmp_arg != 'off':
+            keep_tmp = True
+        # As we are keeping the tmp_dir, let's create it in a stable
+        # location.
+        if keep_tmp:
+            basedir = self.logdir
+
+        data_dir.get_tmp_dir(basedir, keep_tmp)
+
     def _setup_job_results(self):
         """
         Prepares a job result directory, also known as logdir, for this job
@@ -521,9 +543,6 @@ class Job(object):
             return self.exitcode
         finally:
             self.post_tests()
-            if not settings.get_value('runner.behavior', 'keep_tmp_files',
-                                      key_type=bool, default=False):
-                data_dir.clean_tmp_files()
             self.__stop_job_logging()
 
 

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -79,6 +79,10 @@ class Run(CLICmd):
                             help='Enable or disable the job interruption on '
                             'first failed test.')
 
+        parser.add_argument('--keep-tmp', choices=('on', 'off'),
+                            default='off', help='Keep job temporary files '
+                            'after jobs (useful for avocado debugging.')
+
         sysinfo_default = settings.get_value('sysinfo.collect',
                                              'enabled',
                                              key_type='bool',


### PR DESCRIPTION
v1: #1615 

Changes from v1:
- New option `--keep-tmp (on|off)` for Avocado run command with precedence over the `keep_tmp_files` config option.
