### PR TITLE
Test filtering by tags [v0]

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -275,6 +275,9 @@ class Job(object):
         loader.loader.load_plugins(self.args)
         try:
             suite = loader.loader.discover(references)
+            if getattr(self.args, 'filter_by_tags', False):
+                suite = loader.filter_test_tags(suite,
+                                                self.args.filter_by_tags)
         except loader.LoaderUnhandledReferenceError as details:
             raise exceptions.OptionValidationError(details)
         except KeyboardInterrupt:

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -237,6 +237,8 @@ class TestLoaderProxy(object):
         test_class, test_parameters = test_factory
         if 'modulePath' in test_parameters:
             test_path = test_parameters.pop('modulePath')
+        if 'tags' in test_parameters:
+            tags = test_parameters.pop('tags')
         else:
             test_path = None
         if isinstance(test_class, str):
@@ -535,7 +537,8 @@ class FileLoader(TestLoader):
 
         :param path: path to a Python source code file
         :type path: str
-        :returns: dictionary with class name and method names
+        :returns: dict with class name and additional info such as method names
+                  and tags
         :rtype: dict
         """
         # If only the Test class was imported from the avocado namespace
@@ -583,11 +586,13 @@ class FileLoader(TestLoader):
                 if safeloader.is_docstring_tag_disable(docstring):
                     continue
                 elif safeloader.is_docstring_tag_enable(docstring):
-                    functions = [st.name for st in statement.body if
-                                 isinstance(st, ast.FunctionDef) and
-                                 st.name.startswith('test')]
-                    functions = data_structures.ordered_list_unique(functions)
-                    result[statement.name] = functions
+                    methods = [st.name for st in statement.body if
+                               isinstance(st, ast.FunctionDef) and
+                               st.name.startswith('test')]
+                    methods = data_structures.ordered_list_unique(methods)
+                    tags = safeloader.get_docstring_test_tags(docstring)
+                    result[statement.name] = {'methods': methods,
+                                              'tags': tags}
                     continue
 
                 if test_import:
@@ -595,11 +600,13 @@ class FileLoader(TestLoader):
                                 if hasattr(base, 'id')]
                     # Looking for a 'class FooTest(Test):'
                     if test_import_name in base_ids:
-                        functions = [st.name for st in statement.body if
-                                     isinstance(st, ast.FunctionDef) and
-                                     st.name.startswith('test')]
-                        functions = data_structures.ordered_list_unique(functions)
-                        result[statement.name] = functions
+                        methods = [st.name for st in statement.body if
+                                   isinstance(st, ast.FunctionDef) and
+                                   st.name.startswith('test')]
+                        methods = data_structures.ordered_list_unique(methods)
+                        tags = safeloader.get_docstring_test_tags(docstring)
+                        result[statement.name] = {'methods': methods,
+                                                  'tags': tags}
                         continue
 
                 # Looking for a 'class FooTest(avocado.Test):'
@@ -608,11 +615,13 @@ class FileLoader(TestLoader):
                         module = base.value.id
                         klass = base.attr
                         if module == mod_import_name and klass == 'Test':
-                            functions = [st.name for st in statement.body if
-                                         isinstance(st, ast.FunctionDef) and
-                                         st.name.startswith('test')]
-                            functions = data_structures.ordered_list_unique(functions)
-                            result[statement.name] = functions
+                            methods = [st.name for st in statement.body if
+                                       isinstance(st, ast.FunctionDef) and
+                                       st.name.startswith('test')]
+                            methods = data_structures.ordered_list_unique(methods)
+                            tags = safeloader.get_docstring_test_tags(docstring)
+                            result[statement.name] = {'methods': methods,
+                                                      'tags': tags}
 
         return result
 
@@ -624,9 +633,9 @@ class FileLoader(TestLoader):
             tests = self._find_avocado_tests(test_path)
             if tests:
                 test_factories = []
-                for test_class, test_methods in tests.items():
+                for test_class, info in tests.items():
                     if isinstance(test_class, str):
-                        for test_method in test_methods:
+                        for test_method in info['methods']:
                             name = test_name + \
                                 ':%s.%s' % (test_class, test_method)
                             if (subtests_filter and
@@ -634,7 +643,8 @@ class FileLoader(TestLoader):
                                 continue
                             tst = (test_class, {'name': name,
                                                 'modulePath': test_path,
-                                                'methodName': test_method})
+                                                'methodName': test_method,
+                                                'tags': info['tags']})
                             test_factories.append(tst)
                 return test_factories
             else:

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -44,6 +44,41 @@ AVAILABLE = None
 ALL = True
 
 
+def filter_test_tags(test_suite, filter_by_tags):
+    '''
+    The filtering mechanism is limited to instrumented tests with tags set
+    '''
+    filtered = []
+    for klass, info in test_suite:
+        if not isinstance(klass, str):  # not instrumented: no filtering
+            filtered.append((klass, info))
+            continue
+
+        test_tags = info['tags']
+        if not test_tags:       # not tagged: no filtering
+            filtered.append((klass, info))
+            continue
+
+        for raw_tags in filter_by_tags:
+            required_tags = raw_tags.split(',')
+            must_not_have_tags = set([_[1:] for _ in required_tags
+                                      if _.startswith('-')])
+            if must_not_have_tags:
+                if must_not_have_tags.issubset(test_tags):
+                    continue
+
+            must_have_tags = set([_ for _ in required_tags
+                                  if not _.startswith('-')])
+            if must_have_tags:
+                if not must_have_tags.issubset(test_tags):
+                    continue
+
+            filtered.append((klass, info))
+            break
+
+    return filtered
+
+
 class LoaderError(Exception):
 
     """ Loader exception """

--- a/avocado/core/safeloader.py
+++ b/avocado/core/safeloader.py
@@ -101,6 +101,33 @@ def is_docstring_tag_disable(docstring):
     return result == 'disable'
 
 
+def is_docstring_test_tags(docstring):
+    """
+    Checks if there's an avocado tag that tags a test in a certain categories
+
+    :rtype: bool
+    """
+    result = get_docstring_tag(docstring)
+    if result is not None:
+        return result.startswith('tags=')
+    return False
+
+
+def get_docstring_test_tags(docstring):
+    """
+    Returns the test categories based on a `:avocado: tags=category` docstring
+
+    :rtype: set
+    """
+    if not is_docstring_test_tags(docstring):
+        return []
+
+    raw_tag = get_docstring_tag(docstring)
+    if raw_tag is not None:
+        _, comma_tags = raw_tag.split('tags=', 1)
+        return set([tag for tag in comma_tags.split(',') if tag])
+
+
 def find_class_and_methods(path, method_pattern=None, base_class=None):
     """
     Attempts to find methods names from a given Python source file

--- a/avocado/plugins/list.py
+++ b/avocado/plugins/list.py
@@ -118,6 +118,9 @@ class TestLister(object):
     def _list(self):
         self._extra_listing()
         test_suite = self._get_test_suite(self.args.keywords)
+        if getattr(self.args, 'filter_by_tags', False):
+            test_suite = loader.filter_test_tags(test_suite,
+                                                 self.args.filter_by_tags)
         test_matrix, stats = self._get_test_matrix(test_suite)
         self._display(test_matrix, stats)
 
@@ -164,6 +167,10 @@ class List(CLICmd):
                             help='Turn the paginator on/off. '
                             'Current: %(default)s')
         loader.add_loader_options(parser)
+
+        filtering = parser.add_argument_group('filtering parameters')
+        filtering.add_argument('--filter-by-tags', metavar='TAGS',
+                               action='append')
 
     def run(self, args):
         test_lister = TestLister(args)

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -140,6 +140,10 @@ class Run(CLICmd):
                          help="Inject [path:]key:node values into the "
                          "final multiplex tree.")
 
+        filtering = parser.add_argument_group('filtering parameters')
+        filtering.add_argument('--filter-by-tags', metavar='TAGS',
+                               action='append')
+
     def run(self, args):
         """
         Run test modules or simple tests.

--- a/examples/tests/fast_and_slow.py
+++ b/examples/tests/fast_and_slow.py
@@ -1,0 +1,26 @@
+import time
+
+from avocado import Test
+
+
+class FastTest(Test):
+
+    """
+    Fastest possible test
+
+    :avocado: tags=fast,network
+    """
+
+    def test(self):
+        pass
+
+
+class SlowTest(Test):
+
+    """
+    Slow test
+
+    :avocado: tags=slow,disk,unsafe
+    """
+    def test(self):
+        time.sleep(3)

--- a/selftests/unit/test_safeloader.py
+++ b/selftests/unit/test_safeloader.py
@@ -47,6 +47,21 @@ class ModuleImportedAs(unittest.TestCase):
 
 class DocstringTag(unittest.TestCase):
 
+    NO_TAGS = [":AVOCADO: TAGS:FAST",
+               ":AVOCADO: TAGS=FAST",
+               ":avocado: mytags=fast",
+               ":avocado: tags",
+               ":avocado: tag",
+               ":avocado: tag="]
+
+    VALID_TAGS = {":avocado: tags=fast": set(["fast"]),
+                  ":avocado: tags=fast,network": set(["fast", "network"]),
+                  ":avocado: tags=fast,,network": set(["fast", "network"]),
+                  ":avocado: tags=slow,DISK": set(["slow", "DISK"]),
+                  ":avocado: tags=SLOW,disk,disk": set(["SLOW", "disk"]),
+                  ":avocado:\ttags=FAST": set(["FAST"]),
+                  ":avocado: tags=": set([])}
+
     def test_longline(self):
         docstring = ("This is a very long docstring in a single line. "
                      "Since we have nothing useful to put in here let's just "
@@ -72,6 +87,20 @@ class DocstringTag(unittest.TestCase):
         self.assertFalse(safeloader.is_docstring_tag_disable(":AVOCADO: DISABLE"))
         self.assertFalse(safeloader.is_docstring_tag_disable(":avocado: disabled"))
 
+    def test_is_tags(self):
+        for tag in self.VALID_TAGS:
+            self.assertTrue(safeloader.is_docstring_test_tags(tag))
+        for tag in self.NO_TAGS:
+            self.assertFalse(safeloader.is_docstring_test_tags(tag))
+
+    def test_get_tags_empty(self):
+        for tag in self.NO_TAGS:
+            self.assertEqual([], safeloader.get_docstring_test_tags(tag))
+
+    def test_get_tags(self):
+        for raw, tags in self.VALID_TAGS.items():
+            self.assertEqual(safeloader.get_docstring_test_tags(raw), tags)
+
 
 class UnlimitedDiff(unittest.TestCase):
 
@@ -96,7 +125,10 @@ class FindClassAndMethods(UnlimitedDiff):
             'DocstringTag': ['test_longline',
                              'test_newlines',
                              'test_enabled',
-                             'test_disabled'],
+                             'test_disabled',
+                             'test_is_tags',
+                             'test_get_tags_empty',
+                             'test_get_tags'],
             'FindClassAndMethods': ['test_self',
                                     'test_with_pattern',
                                     'test_with_base_class',
@@ -115,7 +147,10 @@ class FindClassAndMethods(UnlimitedDiff):
             'DocstringTag': ['test_longline',
                              'test_newlines',
                              'test_enabled',
-                             'test_disabled'],
+                             'test_disabled',
+                             'test_is_tags',
+                             'test_get_tags_empty',
+                             'test_get_tags'],
             'FindClassAndMethods': ['test_self',
                                     'test_with_pattern',
                                     'test_with_base_class',


### PR DESCRIPTION
This adds support for test tags (to choose categorized tests) to the safeloader, loader, and also to the list and run commands.

It should be fully functional, but there is one point which wasn't discussed in #1368  and I'd like to get feedback, which is how to deal with instrumented tests (that can receive tags) but that have not been tagged when a `--filter-by-tags` paramter is given.

Example of behavior 1 (current):

```    
     $ avocado list /bin/true passtest.py fast_and_slow.py --filter-by-tags=fast
     SIMPLE       /bin/true
     INSTRUMENTED passtest.py:PassTest.test
     INSTRUMENTED fast_and_slow.py:FastTest.test
```

Example of behavior 2 (alternative):

```    
     $ avocado list passtest.py fast_and_slow.py --filter-by-tags=fast
     SIMPLE       /bin/true
     INSTRUMENTED fast_and_slow.py:FastTest.test
```

Please chip in your comment/suggestion.