### PR TITLE
Preserve test environment for post-mortem debug [v3]

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -521,9 +521,6 @@ class Job(object):
             return self.exitcode
         finally:
             self.post_tests()
-            if not settings.get_value('runner.behavior', 'keep_tmp_files',
-                                      key_type=bool, default=False):
-                data_dir.clean_tmp_files()
             self.__stop_job_logging()
 
 

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -133,6 +133,16 @@ class Job(object):
         self._result_events_dispatcher = dispatcher.ResultEventsDispatcher(self.args)
         output.log_plugin_failures(self._result_events_dispatcher.load_failures)
 
+        # Checking whether we will keep the Job tmp_dir or not.
+        # If yes, we set the basedir for a stable location.
+        basedir = None
+        keep_tmp = getattr(self.args, "keep_tmp", None)
+        if keep_tmp == 'on':
+            basedir = self.logdir
+        # Calling get_tmp_dir() early as the basedir will be set
+        # in the first call.
+        data_dir.get_tmp_dir(basedir)
+
     def _setup_job_results(self):
         """
         Prepares a job result directory, also known as logdir, for this job

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -79,6 +79,10 @@ class Run(CLICmd):
                             help='Enable or disable the job interruption on '
                             'first failed test.')
 
+        parser.add_argument('--keep-tmp', choices=('on', 'off'),
+                            default='off', help='Keep job temporary files '
+                            '(useful for avocado debugging). Defaults to off.')
+
         sysinfo_default = settings.get_value('sysinfo.collect',
                                              'enabled',
                                              key_type='bool',

--- a/etc/avocado/avocado.conf
+++ b/etc/avocado/avocado.conf
@@ -36,10 +36,6 @@ colored = True
 # Use utf8 encoding (True, False, None=autodetect)
 utf8 =
 
-[runner.behavior]
-# Keep job temporary files after jobs (useful for avocado debugging)
-keep_tmp_files = False
-
 [remoter.behavior]
 # __Insecure__, reject unknown SSH host keys.
 # 'False' will leave you wide open to man-in-the-middle attacks!


### PR DESCRIPTION
v1: #1615 

v2: #1620 
- New option `--keep-tmp (on|off)` for Avocado run command with precedence over the `keep_tmp_files` config option.

v3:
- Drop non-working config option `keep_tmp_files`.
- Decide whether we will keep the tmp dir or not based on the `basedir`. If it's not `None`, then we create the tmp_dir in the `basedir` location and don't remove it when the job finishes.