### PR TITLE
Fix human output for replay jobs

### DIFF
--- a/avocado/plugins/human.py
+++ b/avocado/plugins/human.py
@@ -49,7 +49,7 @@ class Human(ResultEvents):
         self.log.info("JOB ID     : %s", job.unique_id)
         replay_source_job = getattr(job.args, "replay_sourcejob", False)
         if replay_source_job:
-            self.log.info("SRC JOB ID : %s", self.__replay_source_job)
+            self.log.info("SRC JOB ID : %s", replay_source_job)
         self.log.info("JOB LOG    : %s", job.logfile)
         self.log.info("TESTS      : %s", len(job.test_suite))
 


### PR DESCRIPTION
Commit 2e6ecce6 made the human results a real plugin. But the change
broke the human results for replay jobs. This is a fix that makes the
human results to show the SRC JOB ID properly again.

Signed-off-by: Amador Pahim <apahim@redhat.com>