### PR TITLE
Test filtering by tags [v1]

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -285,6 +285,11 @@ class Job(object):
         loader.loader.load_plugins(self.args)
         try:
             suite = loader.loader.discover(references)
+            if getattr(self.args, 'filter_by_tags', False):
+                suite = loader.filter_test_tags(
+                    suite,
+                    self.args.filter_by_tags,
+                    self.args.filter_by_tags_ignore_empty)
         except loader.LoaderUnhandledReferenceError as details:
             raise exceptions.OptionValidationError(details)
         except KeyboardInterrupt:

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -354,13 +354,6 @@ class AccessDeniedPath(object):
     pass
 
 
-class FilteredOut(object):
-
-    """ Dummy object to represent test filtered out by the optional mask """
-
-    pass
-
-
 def add_loader_options(parser):
     arggrp = parser.add_argument_group('loader options')
     arggrp.add_argument('--loaders', nargs='*', help="Overrides the priority "
@@ -420,8 +413,7 @@ class FileLoader(TestLoader):
                 test.MissingTest: 'MISSING',
                 BrokenSymlink: 'BROKEN_SYMLINK',
                 AccessDeniedPath: 'ACCESS_DENIED',
-                test.Test: 'INSTRUMENTED',
-                FilteredOut: 'FILTERED'}
+                test.Test: 'INSTRUMENTED'}
 
     @staticmethod
     def get_decorator_mapping():
@@ -430,8 +422,7 @@ class FileLoader(TestLoader):
                 test.MissingTest: output.TERM_SUPPORT.fail_header_str,
                 BrokenSymlink: output.TERM_SUPPORT.fail_header_str,
                 AccessDeniedPath: output.TERM_SUPPORT.fail_header_str,
-                test.Test: output.TERM_SUPPORT.healthy_str,
-                FilteredOut: output.TERM_SUPPORT.warn_header_str}
+                test.Test: output.TERM_SUPPORT.healthy_str}
 
     def discover(self, reference, which_tests=DEFAULT):
         """

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -235,6 +235,10 @@ class TestLoaderProxy(object):
         :return: an instance of :class:`avocado.core.test.Test`.
         """
         test_class, test_parameters = test_factory
+        # discard tags, as they are *not* intented to be parameters
+        # for the test, but used previously during filtering
+        if 'tags' in test_parameters:
+            del(test_parameters['tags'])
         if 'modulePath' in test_parameters:
             test_path = test_parameters.pop('modulePath')
         else:
@@ -526,7 +530,8 @@ class FileLoader(TestLoader):
 
         :param path: path to a Python source code file
         :type path: str
-        :returns: dictionary with class name and method names
+        :returns: dict with class name and additional info such as method names
+                  and tags
         :rtype: dict
         """
         # If only the Test class was imported from the avocado namespace
@@ -574,11 +579,13 @@ class FileLoader(TestLoader):
                 if safeloader.is_docstring_tag_disable(docstring):
                     continue
                 elif safeloader.is_docstring_tag_enable(docstring):
-                    functions = [st.name for st in statement.body if
-                                 isinstance(st, ast.FunctionDef) and
-                                 st.name.startswith('test')]
-                    functions = data_structures.ordered_list_unique(functions)
-                    result[statement.name] = functions
+                    methods = [st.name for st in statement.body if
+                               isinstance(st, ast.FunctionDef) and
+                               st.name.startswith('test')]
+                    methods = data_structures.ordered_list_unique(methods)
+                    tags = safeloader.get_docstring_test_tags(docstring)
+                    result[statement.name] = {'methods': methods,
+                                              'tags': tags}
                     continue
 
                 if test_import:
@@ -586,11 +593,13 @@ class FileLoader(TestLoader):
                                 if hasattr(base, 'id')]
                     # Looking for a 'class FooTest(Test):'
                     if test_import_name in base_ids:
-                        functions = [st.name for st in statement.body if
-                                     isinstance(st, ast.FunctionDef) and
-                                     st.name.startswith('test')]
-                        functions = data_structures.ordered_list_unique(functions)
-                        result[statement.name] = functions
+                        methods = [st.name for st in statement.body if
+                                   isinstance(st, ast.FunctionDef) and
+                                   st.name.startswith('test')]
+                        methods = data_structures.ordered_list_unique(methods)
+                        tags = safeloader.get_docstring_test_tags(docstring)
+                        result[statement.name] = {'methods': methods,
+                                                  'tags': tags}
                         continue
 
                 # Looking for a 'class FooTest(avocado.Test):'
@@ -599,11 +608,13 @@ class FileLoader(TestLoader):
                         module = base.value.id
                         klass = base.attr
                         if module == mod_import_name and klass == 'Test':
-                            functions = [st.name for st in statement.body if
-                                         isinstance(st, ast.FunctionDef) and
-                                         st.name.startswith('test')]
-                            functions = data_structures.ordered_list_unique(functions)
-                            result[statement.name] = functions
+                            methods = [st.name for st in statement.body if
+                                       isinstance(st, ast.FunctionDef) and
+                                       st.name.startswith('test')]
+                            methods = data_structures.ordered_list_unique(methods)
+                            tags = safeloader.get_docstring_test_tags(docstring)
+                            result[statement.name] = {'methods': methods,
+                                                      'tags': tags}
 
         return result
 
@@ -615,9 +626,9 @@ class FileLoader(TestLoader):
             tests = self._find_avocado_tests(test_path)
             if tests:
                 test_factories = []
-                for test_class, test_methods in tests.items():
+                for test_class, info in tests.items():
                     if isinstance(test_class, str):
-                        for test_method in test_methods:
+                        for test_method in info['methods']:
                             name = test_name + \
                                 ':%s.%s' % (test_class, test_method)
                             if (subtests_filter and
@@ -625,7 +636,8 @@ class FileLoader(TestLoader):
                                 continue
                             tst = (test_class, {'name': name,
                                                 'modulePath': test_path,
-                                                'methodName': test_method})
+                                                'methodName': test_method,
+                                                'tags': info['tags']})
                             test_factories.append(tst)
                 return test_factories
             else:

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -44,6 +44,52 @@ AVAILABLE = None
 ALL = True
 
 
+def filter_test_tags(test_suite, filter_by_tags, ignore_empty=False):
+    """
+    Filter the existing (unfiltered) test suite based on tags
+
+    The filtering mechanism is limited to INSTRUMENTED tests, that is it does
+    not apply to SIMPLE tests or any other test type.  It mean non-INSTRUMENTED
+    tests are *always* included.
+
+    :param test_suite: the unfiltered test suite
+    :type test_suite: dict
+    :param filter_by_tags: the list of tag sets to use as filters
+    :type filter_by_tags: list of comma separated tags (['foo,bar', 'fast'])
+    :param ignore_empty: if instrumented tests without tags should not be
+                         filtered out
+    :param ignore_empty: bool
+    """
+    filtered = []
+    for klass, info in test_suite:
+        if not isinstance(klass, str):  # not instrumented: no filtering
+            filtered.append((klass, info))
+            continue
+
+        test_tags = info['tags']
+        if not test_tags and ignore_empty:       # not tagged: no filtering
+            filtered.append((klass, info))
+            continue
+
+        for raw_tags in filter_by_tags:
+            required_tags = raw_tags.split(',')
+            must_not_have_tags = set([_[1:] for _ in required_tags
+                                      if _.startswith('-')])
+            if must_not_have_tags.intersection(test_tags):
+                continue
+
+            must_have_tags = set([_ for _ in required_tags
+                                  if not _.startswith('-')])
+            if must_have_tags:
+                if not must_have_tags.issubset(test_tags):
+                    continue
+
+            filtered.append((klass, info))
+            break
+
+    return filtered
+
+
 class LoaderError(Exception):
 
     """ Loader exception """

--- a/avocado/core/safeloader.py
+++ b/avocado/core/safeloader.py
@@ -101,6 +101,33 @@ def is_docstring_tag_disable(docstring):
     return result == 'disable'
 
 
+def is_docstring_test_tags(docstring):
+    """
+    Checks if there's an avocado tag that tags a test in a certain categories
+
+    :rtype: bool
+    """
+    result = get_docstring_tag(docstring)
+    if result is not None:
+        return result.startswith('tags=')
+    return False
+
+
+def get_docstring_test_tags(docstring):
+    """
+    Returns the test categories based on a `:avocado: tags=category` docstring
+
+    :rtype: set
+    """
+    if not is_docstring_test_tags(docstring):
+        return []
+
+    raw_tag = get_docstring_tag(docstring)
+    if raw_tag is not None:
+        _, comma_tags = raw_tag.split('tags=', 1)
+        return set([tag for tag in comma_tags.split(',') if tag])
+
+
 def find_class_and_methods(path, method_pattern=None, base_class=None):
     """
     Attempts to find methods names from a given Python source file

--- a/avocado/plugins/list.py
+++ b/avocado/plugins/list.py
@@ -76,26 +76,13 @@ class TestLister(object):
                 elif 'path' in params:
                     id_label = params['path']
 
-            try:
-                type_label = type_label_mapping[cls]
-                decorator = decorator_mapping[cls]
-                stats[type_label.lower()] += 1
-                type_label = decorator(type_label)
-            except KeyError:
-                if isinstance(cls, str):
-                    cls = test.Test
-                    type_label = type_label_mapping[cls]
-                    decorator = decorator_mapping[cls]
-                    stats[type_label.lower()] += 1
-                    type_label = decorator(type_label)
-                    id_label = params['name']
-                elif issubclass(cls, test.Test):
-                    cls = test.Test
-                    type_label = type_label_mapping[cls]
-                    decorator = decorator_mapping[cls]
-                    stats[type_label.lower()] += 1
-                    type_label = decorator(type_label)
-                    id_label = params['name']
+            if isinstance(cls, str):
+                cls = test.Test
+                id_label = params['name']
+            type_label = type_label_mapping[cls]
+            decorator = decorator_mapping[cls]
+            stats[type_label.lower()] += 1
+            type_label = decorator(type_label)
 
             test_matrix.append((type_label, id_label))
 

--- a/avocado/plugins/list.py
+++ b/avocado/plugins/list.py
@@ -104,7 +104,7 @@ class TestLister(object):
 
     def _list(self):
         self._extra_listing()
-        test_suite = self._get_test_suite(self.args.keywords)
+        test_suite = self._get_test_suite(self.args.reference)
         test_matrix, stats = self._get_test_matrix(test_suite)
         self._display(test_matrix, stats)
 
@@ -132,9 +132,8 @@ class List(CLICmd):
         :param parser: Main test runner parser.
         """
         parser = super(List, self).configure(parser)
-        parser.add_argument('keywords', type=str, default=[], nargs='*',
-                            help="List of paths, aliases or other "
-                            "keywords used to locate tests. "
+        parser.add_argument('reference', type=str, default=[], nargs='*',
+                            help="List of test references (aliases or paths). "
                             "If empty, avocado will list tests on "
                             "the configured test source, "
                             "(see 'avocado config --datadir') Also, "

--- a/avocado/plugins/list.py
+++ b/avocado/plugins/list.py
@@ -105,6 +105,11 @@ class TestLister(object):
     def _list(self):
         self._extra_listing()
         test_suite = self._get_test_suite(self.args.reference)
+        if getattr(self.args, 'filter_by_tags', False):
+            test_suite = loader.filter_test_tags(
+                test_suite,
+                self.args.filter_by_tags,
+                self.args.filter_by_tags_ignore_empty)
         test_matrix, stats = self._get_test_matrix(test_suite)
         self._display(test_matrix, stats)
 
@@ -150,6 +155,19 @@ class List(CLICmd):
                             help='Turn the paginator on/off. '
                             'Current: %(default)s')
         loader.add_loader_options(parser)
+
+        filtering = parser.add_argument_group('filtering parameters')
+        filtering.add_argument('--filter-by-tags', metavar='TAGS',
+                               action='append',
+                               help='Filter INSTRUMENTED tests based on '
+                               '":avocado: tags=tag1,tag2" notation in '
+                               'their class docstring')
+        filtering.add_argument('--filter-by-tags-ignore-empty',
+                               action='store_true', default=False,
+                               help=('Ignore INSTRUMENTED tests without tags '
+                                     'during filtering.  This effectively '
+                                     'means they will be kept in the test '
+                                     'suite found previously to filtering.'))
 
     def run(self, args):
         test_lister = TestLister(args)

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -144,6 +144,19 @@ class Run(CLICmd):
                          help="Inject [path:]key:node values into the "
                          "final multiplex tree.")
 
+        filtering = parser.add_argument_group('filtering parameters')
+        filtering.add_argument('--filter-by-tags', metavar='TAGS',
+                               action='append',
+                               help='Filter INSTRUMENTED tests based on '
+                               '":avocado: tags=tag1,tag2" notation in '
+                               'their class docstring')
+        filtering.add_argument('--filter-by-tags-ignore-empty',
+                               action='store_true', default=False,
+                               help=('Ignore INSTRUMENTED tests without tags '
+                                     'during filtering.  This effectively '
+                                     'means they will be kept in the test '
+                                     'suite found previously to filtering.'))
+
     def run(self, args):
         """
         Run test modules or simple tests.

--- a/examples/tests/abort.py
+++ b/examples/tests/abort.py
@@ -10,6 +10,8 @@ class AbortTest(Test):
 
     """
     A test that just calls abort() (and abort).
+
+    :avocado: tags=failure_expected
     """
 
     default_params = {'timeout': 2.0}

--- a/examples/tests/cabort.py
+++ b/examples/tests/cabort.py
@@ -14,6 +14,8 @@ class CAbort(Test):
     """
     A test that calls C standard lib function abort().
 
+    :avocado: tags=requires_c_compiler
+
     params:
     :param tarball: Path to the c-source file relative to deps dir.
     """

--- a/examples/tests/datadir.py
+++ b/examples/tests/datadir.py
@@ -14,6 +14,8 @@ class DataDirTest(Test):
     """
     Test that uses resources from the data dir.
 
+    :avocado: tags=requires_c_compiler
+
     :param tarball: Path to the c-source file relative to deps dir.
     """
 

--- a/examples/tests/doublefail.py
+++ b/examples/tests/doublefail.py
@@ -8,6 +8,9 @@ class DoubleFail(Test):
 
     """
     Functional test for avocado. Straight up fail the test.
+
+    :avocado: tags=failure_expected
+
     """
 
     def test(self):

--- a/examples/tests/doublefree.py
+++ b/examples/tests/doublefree.py
@@ -15,6 +15,8 @@ class DoubleFreeTest(Test):
     """
     Double free test case.
 
+    :avocado: tags=requires_c_compiler
+
     :param source: name of the source file located in deps path
     """
 

--- a/examples/tests/doublefree_nasty.py
+++ b/examples/tests/doublefree_nasty.py
@@ -14,6 +14,8 @@ class DoubleFreeTest(Test):
     """
     10% chance to execute double free exception.
 
+    :avocado: tags=failure_expected,requires_c_compiler
+
     :param source: name of the source file located in deps path
     """
 

--- a/examples/tests/errortest.py
+++ b/examples/tests/errortest.py
@@ -8,6 +8,8 @@ class ErrorTest(Test):
 
     """
     Example test that ends with ERROR.
+
+    :avocado: tags=failure_expected
     """
 
     def test(self):

--- a/examples/tests/errortest_nasty.py
+++ b/examples/tests/errortest_nasty.py
@@ -19,6 +19,8 @@ class FailTest(Test):
 
     """
     Very nasty exception test
+
+    :avocado: tags=failure_expected
     """
 
     def test(self):

--- a/examples/tests/errortest_nasty2.py
+++ b/examples/tests/errortest_nasty2.py
@@ -19,6 +19,8 @@ class FailTest(Test):
 
     """
     Very nasty exception test
+
+    :avocado: tags=failure_expected
     """
 
     def test(self):

--- a/examples/tests/errortest_nasty3.py
+++ b/examples/tests/errortest_nasty3.py
@@ -19,6 +19,8 @@ class FailTest(Test):
 
     """
     This test raises old-style-class exception
+
+    :avocado: tags=failure_expected
     """
 
     def test(self):

--- a/examples/tests/fail_on_exception.py
+++ b/examples/tests/fail_on_exception.py
@@ -7,6 +7,8 @@ class FailOnException(avocado.Test):
 
     """
     Test illustrating the behavior of the fail_on decorator.
+
+    :avocado: tags=failure_expected
     """
 
     # @avocado.fail_on(ValueError) also possible

--- a/examples/tests/failtest.py
+++ b/examples/tests/failtest.py
@@ -8,6 +8,8 @@ class FailTest(Test):
 
     """
     Example test for avocado. Straight up fail the test.
+
+    :avocado: tags=failure_expected
     """
 
     def test(self):

--- a/examples/tests/gdbtest.py
+++ b/examples/tests/gdbtest.py
@@ -12,6 +12,8 @@ class GdbTest(Test):
 
     """
     Execute the gdb test
+
+    :avocado: tags=requires_c_compiler
     """
 
     VALID_CMDS = ["-list-target-features",

--- a/examples/tests/linuxbuild.py
+++ b/examples/tests/linuxbuild.py
@@ -12,6 +12,8 @@ class LinuxBuildTest(Test):
     """
     Execute the Linux Build test.
 
+    :avocado: tags=requires_c_compiler
+
     :param linux_version: kernel version to be built
     :param linux_config: name of the config file located in deps path
     """

--- a/examples/tests/modify_variable.py
+++ b/examples/tests/modify_variable.py
@@ -17,6 +17,8 @@ class PrintVariableTest(Test):
     2) using GDB it modifies the variable to ff
     3) checks the output
 
+    :avocado: tags=requires_c_compiler
+
     :param source: path to the source file relative to deps dir.
     """
 

--- a/examples/tests/passtest.py
+++ b/examples/tests/passtest.py
@@ -8,6 +8,8 @@ class PassTest(Test):
 
     """
     Example test that passes.
+
+    :avocado: tags=fast
     """
 
     def test(self):

--- a/examples/tests/sleeptenmin.py
+++ b/examples/tests/sleeptenmin.py
@@ -12,6 +12,8 @@ class SleepTenMin(Test):
     """
     Sleeps for 10 minutes
 
+    :avocado: tags=slow
+
     :param sleep_cycles: How many iterations should be executed
     :param sleep_length: single sleep duration
     :param sleep_method: what method of sleep should be used (builtin|shell)

--- a/examples/tests/uncaught_exception.py
+++ b/examples/tests/uncaught_exception.py
@@ -8,6 +8,8 @@ class ErrorTest(Test):
 
     """
     Example test that raises generic exception
+
+    :avocado: tags=failure_expected
     """
 
     def test(self):

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -95,7 +95,6 @@ class SafeTest(Test):
     def test_safe(self):
         pass
 
-
 if __name__ == "__main__":
     main()
 """
@@ -400,6 +399,76 @@ class LoaderTest(unittest.TestCase):
                 self.assertEqual(info['tags'], tags_map[name])
                 del(tags_map[name])
         self.assertEqual(len(tags_map), 0)
+
+    def test_filter_tags_ignore_empty(self):
+        avocado_pass_test = script.TemporaryScript('passtest.py',
+                                                   AVOCADO_TEST_OK,
+                                                   'avocado_loader_unittest',
+                                                   DEFAULT_NON_EXEC_MODE)
+        with avocado_pass_test as test:
+            test_suite = self.loader.discover(test.path, loader.ALL)
+            self.assertEqual([], loader.filter_test_tags(test_suite, []))
+            self.assertEqual(test_suite,
+                             loader.filter_test_tags(test_suite, [], True))
+
+    def test_filter_tags(self):
+        avocado_test_tags = script.TemporaryScript('tags.py',
+                                                   AVOCADO_TEST_TAGS,
+                                                   'avocado_loader_unittest',
+                                                   DEFAULT_NON_EXEC_MODE)
+        with avocado_test_tags as test:
+            test_suite = self.loader.discover(test.path, loader.ALL)
+            self.assertEqual(len(test_suite), 5)
+            self.assertEqual(test_suite[0][0], 'SafeTest')
+            self.assertEqual(test_suite[0][1]['methodName'], 'test_safe')
+            self.assertEqual(test_suite[1][0], 'FastTest')
+            self.assertEqual(test_suite[1][1]['methodName'], 'test_fast')
+            self.assertEqual(test_suite[2][0], 'FastTest')
+            self.assertEqual(test_suite[2][1]['methodName'], 'test_fast_other')
+            self.assertEqual(test_suite[3][0], 'SlowUnsafeTest')
+            self.assertEqual(test_suite[3][1]['methodName'], 'test_slow_unsafe')
+            self.assertEqual(test_suite[4][0], 'SlowTest')
+            self.assertEqual(test_suite[4][1]['methodName'], 'test_slow')
+            filtered = loader.filter_test_tags(test_suite, ['fast,net'])
+            self.assertEqual(len(filtered), 2)
+            self.assertEqual(filtered[0][0], 'FastTest')
+            self.assertEqual(filtered[0][1]['methodName'], 'test_fast')
+            self.assertEqual(filtered[1][0], 'FastTest')
+            self.assertEqual(filtered[1][1]['methodName'], 'test_fast_other')
+            filtered = loader.filter_test_tags(test_suite,
+                                               ['fast,net',
+                                                'slow,disk,unsafe'])
+            self.assertEqual(len(filtered), 3)
+            self.assertEqual(filtered[0][0], 'FastTest')
+            self.assertEqual(filtered[0][1]['methodName'], 'test_fast')
+            self.assertEqual(filtered[1][0], 'FastTest')
+            self.assertEqual(filtered[1][1]['methodName'], 'test_fast_other')
+            self.assertEqual(filtered[2][0], 'SlowUnsafeTest')
+            self.assertEqual(filtered[2][1]['methodName'], 'test_slow_unsafe')
+            filtered = loader.filter_test_tags(test_suite,
+                                               ['fast,net',
+                                                'slow,disk'])
+            self.assertEqual(len(filtered), 4)
+            self.assertEqual(filtered[0][0], 'FastTest')
+            self.assertEqual(filtered[0][1]['methodName'], 'test_fast')
+            self.assertEqual(filtered[1][0], 'FastTest')
+            self.assertEqual(filtered[1][1]['methodName'], 'test_fast_other')
+            self.assertEqual(filtered[2][0], 'SlowUnsafeTest')
+            self.assertEqual(filtered[2][1]['methodName'], 'test_slow_unsafe')
+            self.assertEqual(filtered[3][0], 'SlowTest')
+            self.assertEqual(filtered[3][1]['methodName'], 'test_slow')
+            filtered = loader.filter_test_tags(test_suite,
+                                               ['-fast,-slow'])
+            self.assertEqual(len(filtered), 1)
+            self.assertEqual(filtered[0][0], 'SafeTest')
+            self.assertEqual(filtered[0][1]['methodName'], 'test_safe')
+            filtered = loader.filter_test_tags(test_suite,
+                                               ['-fast,-slow,-safe'])
+            self.assertEqual(len(filtered), 0)
+            filtered = loader.filter_test_tags(test_suite,
+                                               ['-fast,-slow,-safe',
+                                                'does,not,exist'])
+            self.assertEqual(len(filtered), 0)
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir)

--- a/selftests/unit/test_safeloader.py
+++ b/selftests/unit/test_safeloader.py
@@ -47,6 +47,21 @@ class ModuleImportedAs(unittest.TestCase):
 
 class DocstringTag(unittest.TestCase):
 
+    NO_TAGS = [":AVOCADO: TAGS:FAST",
+               ":AVOCADO: TAGS=FAST",
+               ":avocado: mytags=fast",
+               ":avocado: tags",
+               ":avocado: tag",
+               ":avocado: tag="]
+
+    VALID_TAGS = {":avocado: tags=fast": set(["fast"]),
+                  ":avocado: tags=fast,network": set(["fast", "network"]),
+                  ":avocado: tags=fast,,network": set(["fast", "network"]),
+                  ":avocado: tags=slow,DISK": set(["slow", "DISK"]),
+                  ":avocado: tags=SLOW,disk,disk": set(["SLOW", "disk"]),
+                  ":avocado:\ttags=FAST": set(["FAST"]),
+                  ":avocado: tags=": set([])}
+
     def test_longline(self):
         docstring = ("This is a very long docstring in a single line. "
                      "Since we have nothing useful to put in here let's just "
@@ -72,6 +87,20 @@ class DocstringTag(unittest.TestCase):
         self.assertFalse(safeloader.is_docstring_tag_disable(":AVOCADO: DISABLE"))
         self.assertFalse(safeloader.is_docstring_tag_disable(":avocado: disabled"))
 
+    def test_is_tags(self):
+        for tag in self.VALID_TAGS:
+            self.assertTrue(safeloader.is_docstring_test_tags(tag))
+        for tag in self.NO_TAGS:
+            self.assertFalse(safeloader.is_docstring_test_tags(tag))
+
+    def test_get_tags_empty(self):
+        for tag in self.NO_TAGS:
+            self.assertEqual([], safeloader.get_docstring_test_tags(tag))
+
+    def test_get_tags(self):
+        for raw, tags in self.VALID_TAGS.items():
+            self.assertEqual(safeloader.get_docstring_test_tags(raw), tags)
+
 
 class UnlimitedDiff(unittest.TestCase):
 
@@ -96,7 +125,10 @@ class FindClassAndMethods(UnlimitedDiff):
             'DocstringTag': ['test_longline',
                              'test_newlines',
                              'test_enabled',
-                             'test_disabled'],
+                             'test_disabled',
+                             'test_is_tags',
+                             'test_get_tags_empty',
+                             'test_get_tags'],
             'FindClassAndMethods': ['test_self',
                                     'test_with_pattern',
                                     'test_with_base_class',
@@ -115,7 +147,10 @@ class FindClassAndMethods(UnlimitedDiff):
             'DocstringTag': ['test_longline',
                              'test_newlines',
                              'test_enabled',
-                             'test_disabled'],
+                             'test_disabled',
+                             'test_is_tags',
+                             'test_get_tags_empty',
+                             'test_get_tags'],
             'FindClassAndMethods': ['test_self',
                                     'test_with_pattern',
                                     'test_with_base_class',


### PR DESCRIPTION
This adds support for test tags (to choose categorized tests) to the safeloader, loader, and also to the list and run commands.

It should be fully functional, and based on the discussion on v0 (#1621), it includes INSTRUMENTED tags that do not have `:avocado: tags=` set in the filtering process.  To disable that behavior, the `--filter-by-tags-ignore-empty` option was added.

Still missing here is full user facing documentation.  I'll include it based on feedback on the new behavior.

---

Other changes from v0 (#1621):
 * Docstring style changes
 * Fixed conditional block that was misplaced in another `if/else` block (about the removal of the `tags` from the test parameters)
 * Introduced many tests to the loader filter option
 * Introduced the `ignore_empty` option to `loader.filter_test_tags()`
 * Removed `FILTERED` "test type" and consequently from the `avocado list -V` output
 * [RFC] Tagged most INSTRUMENTED example tests