### PR TITLE
Fix issue "RuntimeError: maximum recursion depth exceeded"

### DIFF
--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -639,6 +639,8 @@ class LoggingFile(object):
         Passes lines of output to the logging module.
         """
         for lg in self._logger:
+            if not lg.handlers:
+                lg.handlers.append(NULL_HANDLER())
             lg.log(self._level, self._prefix + line)
 
     def _flush_buffer(self):

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -654,6 +654,9 @@ class LoggingFile(object):
     def isatty(self):
         return False
 
+    def add_logger(self, logger):
+        self._logger.append(logger)
+
 
 class Throbber(object):
 

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -283,11 +283,9 @@ class TestRunner(object):
         :type queue: :class:`multiprocessing.Queue` instance.
         """
         signal.signal(signal.SIGTSTP, signal.SIG_IGN)
-        logger_list_stdout = [logging.getLogger('avocado.test.stdout'),
-                              TEST_LOG,
+        logger_list_stdout = [TEST_LOG,
                               logging.getLogger('paramiko')]
-        logger_list_stderr = [logging.getLogger('avocado.test.stderr'),
-                              TEST_LOG,
+        logger_list_stderr = [TEST_LOG,
                               logging.getLogger('paramiko')]
         sys.stdout = output.LoggingFile(logger=logger_list_stdout)
         sys.stderr = output.LoggingFile(logger=logger_list_stderr)

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -30,6 +30,7 @@ from . import data_dir
 from . import exceptions
 from . import multiplexer
 from . import sysinfo
+from . import output
 from ..utils import asset
 from ..utils import astring
 from ..utils import data_structures
@@ -382,6 +383,11 @@ class Test(unittest.TestCase):
         self._ssh_fh = self._register_log_file_handler(logging.getLogger('paramiko'),
                                                        formatter,
                                                        self._ssh_logfile)
+
+        if isinstance(sys.stdout, output.LoggingFile):
+            sys.stdout.add_logger(logging.getLogger("avocado.test.stdout"))
+        if isinstance(sys.stderr, output.LoggingFile):
+            sys.stderr.add_logger(logging.getLogger("avocado.test.stderr"))
 
     def _stop_logging(self):
         """


### PR DESCRIPTION
- Check if all loggers in `output.LoggingFile()` instance contains a handler and, if not, add the `NullHandler`.
- Add loggers `avocado.core.stdout` and `avocado.core.stdout` to the `sys.stdout` / `sys.stderr` (which are `output.LoggingFile()` instances) only when we have a handlers for them.