### PR TITLE
Selftests: deal with resource/time sensitive tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,8 +138,8 @@ check: clean develop check_cyclical modules_boundaries
 	selftests/checkall
 	selftests/check_tmp_dirs
 
-check-long: clean develop check_cyclical modules_boundaries
-	AVOCADO_CHECK_LONG=1 selftests/checkall
+check-full: clean develop check_cyclical modules_boundaries
+	AVOCADO_CHECK_FULL=1 selftests/checkall
 	selftests/check_tmp_dirs
 
 selfcheck: clean check_cyclical modules_boundaries develop

--- a/examples/testplans/release.json
+++ b/examples/testplans/release.json
@@ -4,7 +4,7 @@
 
     "tests": [
 	{"name": "Avocado source is sound",
-	 "description": "On your development machine, on a freshen Avocado source to be released, run `$ make check`. Expected result: Make command should say OK."},
+	 "description": "On your development machine, on a freshen Avocado source to be released, run `$ make check-full`. Expected result: Make command should say OK."},
 
 	{"name": "Avocado source does not contain spelling errors",
 	 "description": "On your development machine, on a freshen Avocado source to be released, run `$ make spell`. Expected result: Make command should say OK."},

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -350,6 +350,9 @@ class RunnerOperationTest(unittest.TestCase):
         # Ensure no test aborted error messages show up
         self.assertNotIn("TestAbortedError: Test aborted unexpectedly", output)
 
+    @unittest.skipIf(os.environ.get("AVOCADO_CHECK_FULL") != "1",
+                     "Skipping test that take a long time to run, are "
+                     "resource intensive or time sensitve")
     def test_runner_abort(self):
         os.chdir(basedir)
         cmd_line = ('./scripts/avocado run --sysinfo=off --job-results-dir %s '

--- a/selftests/functional/test_interrupt.py
+++ b/selftests/functional/test_interrupt.py
@@ -58,6 +58,9 @@ class InterruptTest(unittest.TestCase):
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
 
+    @unittest.skipIf(os.environ.get("AVOCADO_CHECK_FULL") != "1",
+                     "Skipping test that take a long time to run, are "
+                     "resource intensive or time sensitve")
     def test_badly_behaved(self):
         """
         Make sure avocado can cleanly get out of a loop of badly behaved tests.

--- a/selftests/functional/test_utils.py
+++ b/selftests/functional/test_utils.py
@@ -176,8 +176,9 @@ class FileLockTest(unittest.TestCase):
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
 
-    @unittest.skipIf(os.environ.get("AVOCADO_CHECK_LONG") != "1",
-                     "Skipping test that takes a long time to run")
+    @unittest.skipIf(os.environ.get("AVOCADO_CHECK_FULL") != "1",
+                     "Skipping test that take a long time to run, are "
+                     "resource intensive or time sensitve")
     def test_filelock(self):
         players = 1000
         pool = multiprocessing.Pool(players)


### PR DESCRIPTION
We've been getting failures on both Travis CI and RPM build servers.  Let's run these tests only on environments where resources are plentiful.

This addresses #1619.