### PR TITLE
docs: use ResultEvents interface

### DIFF
--- a/docs/source/ResultFormats.rst
+++ b/docs/source/ResultFormats.rst
@@ -272,7 +272,7 @@ Implementing other result formats
 ---------------------------------
 
 If you are looking to implement a new machine or human readable output
-format, you can refer to :mod:`avocado.core.plugins.xunit` and use it as a
+format, you can refer to :mod:`avocado.plugins.xunit` and use it as a
 starting point.
 
 If your result is something that is produced at once, based on the
@@ -281,10 +281,11 @@ complete job outcome, you should create a new class that inherits from
 :meth:`avocado.core.plugin_interfaces.Result.render` method.
 
 But, if your result implementation is something that outputs
-information live before/after each test, have to implement the
-old-style interface.  Create a class that inherits from
-:class:`avocado.core.result.Result` and implements all public methods,
-that perform actions (write to a file/stream) for each test states.
+information live before/during/after tests, then the
+:class:`avocado.core.plugin_interfaces.ResultEvents` interface is to
+one to look at.  It will require you to implement the methods that
+will perform actions (write to a file/stream) for each of the defined
+events on a Job and test execution.
 
 You can take a look at :doc:`Plugins` for more information on how to
 write a plugin that will activate and execute the new result format.


### PR DESCRIPTION
Instead of the `Result` (old-style plugin) approach.

Also, the example `xunit` module was incorrect and it's fixed here.

Signed-off-by: Cleber Rosa <crosa@redhat.com>