### PR TITLE
Fix issue "RuntimeError: maximum recursion depth exceeded" [V3]

### DIFF
--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -652,6 +652,9 @@ class LoggingFile(object):
     def isatty(self):
         return False
 
+    def add_logger(self, logger):
+        self._logger.append(logger)
+
 
 class Throbber(object):
 

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -283,11 +283,9 @@ class TestRunner(object):
         :type queue: :class:`multiprocessing.Queue` instance.
         """
         signal.signal(signal.SIGTSTP, signal.SIG_IGN)
-        logger_list_stdout = [logging.getLogger('avocado.test.stdout'),
-                              TEST_LOG,
+        logger_list_stdout = [TEST_LOG,
                               logging.getLogger('paramiko')]
-        logger_list_stderr = [logging.getLogger('avocado.test.stderr'),
-                              TEST_LOG,
+        logger_list_stderr = [TEST_LOG,
                               logging.getLogger('paramiko')]
         sys.stdout = output.LoggingFile(logger=logger_list_stdout)
         sys.stderr = output.LoggingFile(logger=logger_list_stderr)

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -30,6 +30,7 @@ from . import data_dir
 from . import exceptions
 from . import multiplexer
 from . import sysinfo
+from . import output
 from ..utils import asset
 from ..utils import astring
 from ..utils import data_structures
@@ -373,21 +374,31 @@ class Test(unittest.TestCase):
         stream_fmt = '%(message)s'
         stream_formatter = logging.Formatter(fmt=stream_fmt)
 
-        self._register_log_file_handler(logging.getLogger("avocado.test.stdout"),
-                                        stream_formatter,
-                                        self._stdout_file)
-        self._register_log_file_handler(logging.getLogger("avocado.test.stderr"),
-                                        stream_formatter,
-                                        self._stderr_file)
-        self._ssh_fh = self._register_log_file_handler(logging.getLogger('paramiko'),
-                                                       formatter,
-                                                       self._ssh_logfile)
+        self._stdout_fh = self._register_log_file_handler(
+                                      logging.getLogger("avocado.test.stdout"),
+                                      stream_formatter,
+                                      self._stdout_file)
+        self._stderr_fh = self._register_log_file_handler(
+                                      logging.getLogger("avocado.test.stderr"),
+                                      stream_formatter,
+                                      self._stderr_file)
+        self._ssh_fh = self._register_log_file_handler(
+                                                 logging.getLogger('paramiko'),
+                                                 formatter,
+                                                 self._ssh_logfile)
+
+        if isinstance(sys.stdout, output.LoggingFile):
+            sys.stdout.add_logger(logging.getLogger("avocado.test.stdout"))
+        if isinstance(sys.stderr, output.LoggingFile):
+            sys.stderr.add_logger(logging.getLogger("avocado.test.stderr"))
 
     def _stop_logging(self):
         """
         Stop the logging activity of the test by cleaning the logger handlers.
         """
         self.log.removeHandler(self.file_handler)
+        logging.getLogger('avocado.test.stdout').removeHandler(self._stdout_fh)
+        logging.getLogger('avocado.test.stderr').removeHandler(self._stderr_fh)
         logging.getLogger('paramiko').removeHandler(self._ssh_fh)
 
     def _record_reference_stdout(self):


### PR DESCRIPTION
v3: 
- Drop the commit with the protection to the `LoggingFile`
- Remove the handlers in `_stop_logging()`.

v2: #1644 
- Use `continue` to skip the logger instead of appending a `NULL_HANDLER()` to the logger.

v1: #1631 
- Check if all loggers in `output.LoggingFile()` instance contains a handler and, if not, add the `NullHandler`.
- Add loggers `avocado.core.stdout` and `avocado.core.stdout` to the `sys.stdout` / `sys.stderr` (which are `output.LoggingFile()` instances) only when we have a handlers for them.