### PR TITLE
Fix issue "RuntimeError: maximum recursion depth exceeded" [V4]

### DIFF
--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -652,6 +652,9 @@ class LoggingFile(object):
     def isatty(self):
         return False
 
+    def add_logger(self, logger):
+        self._logger.append(logger)
+
 
 class Throbber(object):
 

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -283,11 +283,9 @@ class TestRunner(object):
         :type queue: :class:`multiprocessing.Queue` instance.
         """
         signal.signal(signal.SIGTSTP, signal.SIG_IGN)
-        logger_list_stdout = [logging.getLogger('avocado.test.stdout'),
-                              TEST_LOG,
+        logger_list_stdout = [TEST_LOG,
                               logging.getLogger('paramiko')]
-        logger_list_stderr = [logging.getLogger('avocado.test.stderr'),
-                              TEST_LOG,
+        logger_list_stderr = [TEST_LOG,
                               logging.getLogger('paramiko')]
         sys.stdout = output.LoggingFile(logger=logger_list_stdout)
         sys.stderr = output.LoggingFile(logger=logger_list_stderr)


### PR DESCRIPTION
v4:
- Adjust the `_stop_logging()` sequence.

v3:  #1647 
- Drop the commit with the protection to the `LoggingFile`
- Remove the handlers in `_stop_logging()`.

v2: #1644 
- Use `continue` to skip the logger instead of appending a `NULL_HANDLER()` to the logger.

v1: #1631 
- Check if all loggers in `output.LoggingFile()` instance contains a handler and, if not, add the `NullHandler`.
- Add loggers `avocado.core.stdout` and `avocado.core.stdout` to the `sys.stdout` / `sys.stderr` (which are `output.LoggingFile()` instances) only when we have a handlers for them.