### PR TITLE
Test filtering by tags [v3]

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -285,6 +285,11 @@ class Job(object):
         loader.loader.load_plugins(self.args)
         try:
             suite = loader.loader.discover(references)
+            if getattr(self.args, 'filter_by_tags', False):
+                suite = loader.filter_test_tags(
+                    suite,
+                    self.args.filter_by_tags,
+                    self.args.filter_by_tags_include_empty)
         except loader.LoaderUnhandledReferenceError as details:
             raise exceptions.OptionValidationError(details)
         except KeyboardInterrupt:

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -571,9 +571,9 @@ class FileLoader(TestLoader):
                 docstring = ast.get_docstring(statement)
                 # Looking for a class that has in the docstring either
                 # ":avocado: enable" or ":avocado: disable
-                if safeloader.is_docstring_tag_disable(docstring):
+                if safeloader.is_docstring_directive_disable(docstring):
                     continue
-                elif safeloader.is_docstring_tag_enable(docstring):
+                elif safeloader.is_docstring_directive_enable(docstring):
                     functions = [st.name for st in statement.body if
                                  isinstance(st, ast.FunctionDef) and
                                  st.name.startswith('test')]

--- a/avocado/core/safeloader.py
+++ b/avocado/core/safeloader.py
@@ -63,41 +63,42 @@ def modules_imported_as(module):
     return result
 
 
-#: Gets the tag value from a string. Used to tag a test class in various ways
-AVOCADO_DOCSTRING_TAG_RE = re.compile(r'\s*:avocado:\s*(\S+)\s*')
+#: Gets the docstring directive value from a string. Used to tweak
+#: test class behavior in various ways
+AVOCADO_DOCSTRING_DIRECTIVE_RE = re.compile(r'\s*:avocado:\s*(\S+)\s*')
 
 
-def get_docstring_tag(docstring):
+def get_docstring_directive(docstring):
     """
-    Returns the value of the avocado custom tag inside a docstring
+    Returns the value of the avocado docstring directive
 
     :param docstring: the complete text used as documentation
     :type docstring: str
     """
     if docstring is None:
         return None
-    result = AVOCADO_DOCSTRING_TAG_RE.search(docstring)
+    result = AVOCADO_DOCSTRING_DIRECTIVE_RE.search(docstring)
     if result is not None:
         return result.groups()[0]
 
 
-def is_docstring_tag_enable(docstring):
+def is_docstring_directive_enable(docstring):
     """
-    Checks if there's an avocado tag that enables its class as a Test class
+    Checks if there's a docstring directive that enables a Test class
 
     :rtype: bool
     """
-    result = get_docstring_tag(docstring)
+    result = get_docstring_directive(docstring)
     return result == 'enable'
 
 
-def is_docstring_tag_disable(docstring):
+def is_docstring_directive_disable(docstring):
     """
-    Checks if there's an avocado tag that disables its class as a Test class
+    Checks if there's a docstring directive that disables a Test class
 
     :rtype: bool
     """
-    result = get_docstring_tag(docstring)
+    result = get_docstring_directive(docstring)
     return result == 'disable'
 
 

--- a/avocado/core/safeloader.py
+++ b/avocado/core/safeloader.py
@@ -102,6 +102,33 @@ def is_docstring_directive_disable(docstring):
     return result == 'disable'
 
 
+def is_docstring_directive_tags(docstring):
+    """
+    Checks if there's a docstring directive that tags a test
+
+    :rtype: bool
+    """
+    result = get_docstring_directive(docstring)
+    if result is not None:
+        return result.startswith('tags=')
+    return False
+
+
+def get_docstring_directive_tags(docstring):
+    """
+    Returns the test categories based on a `:avocado: tags=category` docstring
+
+    :rtype: set
+    """
+    if not is_docstring_directive_tags(docstring):
+        return []
+
+    raw_tag = get_docstring_directive(docstring)
+    if raw_tag is not None:
+        _, comma_tags = raw_tag.split('tags=', 1)
+        return set([tag for tag in comma_tags.split(',') if tag])
+
+
 def find_class_and_methods(path, method_pattern=None, base_class=None):
     """
     Attempts to find methods names from a given Python source file

--- a/avocado/plugins/list.py
+++ b/avocado/plugins/list.py
@@ -100,6 +100,11 @@ class TestLister(object):
     def _list(self):
         self._extra_listing()
         test_suite = self._get_test_suite(self.args.reference)
+        if getattr(self.args, 'filter_by_tags', False):
+            test_suite = loader.filter_test_tags(
+                test_suite,
+                self.args.filter_by_tags,
+                self.args.filter_by_tags_include_empty)
         test_matrix, stats = self._get_test_matrix(test_suite)
         self._display(test_matrix, stats)
 
@@ -145,6 +150,19 @@ class List(CLICmd):
                             help='Turn the paginator on/off. '
                             'Current: %(default)s')
         loader.add_loader_options(parser)
+
+        filtering = parser.add_argument_group('filtering parameters')
+        filtering.add_argument('--filter-by-tags', metavar='TAGS',
+                               action='append',
+                               help='Filter INSTRUMENTED tests based on '
+                               '":avocado: tags=tag1,tag2" notation in '
+                               'their class docstring')
+        filtering.add_argument('--filter-by-tags-include-empty',
+                               action='store_true', default=False,
+                               help=('Include all tests without tags during '
+                                     'filtering. This effectively means they '
+                                     'will be kept in the test suite found '
+                                     'previously to filtering.'))
 
     def run(self, args):
         test_lister = TestLister(args)

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -144,6 +144,19 @@ class Run(CLICmd):
                          help="Inject [path:]key:node values into the "
                          "final multiplex tree.")
 
+        filtering = parser.add_argument_group('filtering parameters')
+        filtering.add_argument('--filter-by-tags', metavar='TAGS',
+                               action='append',
+                               help='Filter INSTRUMENTED tests based on '
+                               '":avocado: tags=tag1,tag2" notation in '
+                               'their class docstring')
+        filtering.add_argument('--filter-by-tags-include-empty',
+                               action='store_true', default=False,
+                               help=('Include all tests without tags during '
+                                     'filtering. This effectively means they '
+                                     'will be kept in the test suite found '
+                                     'previously to filtering.'))
+
     def run(self, args):
         """
         Run test modules or simple tests.

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -945,6 +945,148 @@ You can also use the ``:avocado: disable`` docstring directive, that
 works the opposite way: something that would be considered an Avocado
 test, but we force it to not be listed as one.
 
+Categorizing tests
+------------------
+
+Avocado allows tests to be given tags, which can be used to create
+test categories.  With tags set, users can select a subset of the
+tests found by the test resolver (also known as test loader).
+
+To make this feature easier to grasp, let's work with an example: a
+single Python source code file, named ``perf.py``, that contains both
+disk and network performance tests::
+
+  from avocado import Test
+
+  class Disk(Test):
+
+      """
+      Disk performance tests
+
+      :avocado: tags=disk,slow,superuser,unsafe
+      """
+
+      def test_device(self):
+          device = self.params.get('device', default='/dev/vdb')
+          self.whiteboard = measure_write_to_disk(device)
+
+
+  class Network(Test):
+
+      """
+      Network performance tests
+
+      :avocado: tags=net,fast,safe
+      """
+
+      def test_latency(self):
+          self.whiteboard = measure_latency()
+
+      def test_throughput(self):
+          self.whiteboard = measure_throughput()
+
+
+  class Idle(Test):
+
+      """
+      Idle tests
+      """
+
+      def test_idle(self):
+          self.whiteboard = "test achieved nothing"
+
+
+Usually, listing and executing tests with the Avocado test runner
+would reveal all three tests::
+
+  $ avocado list perf.py
+  INSTRUMENTED perf.py:Disk.test_device
+  INSTRUMENTED perf.py:Network.test_latency
+  INSTRUMENTED perf.py:Network.test_throughput
+  INSTRUMENTED perf.py:Idle.test_idle
+
+If you want to list or run only the network based tests, you can do so
+by requesting only tests that are tagged with ``net``::
+
+  $ avocado list perf.py --filter-by-tags=net
+  INSTRUMENTED perf.py:Network.test_latency
+  INSTRUMENTED perf.py:Network.test_throughput
+
+Now, suppose you're not in an environment where you're confortable
+running a test that will write to your raw disk devices (such as your
+development workstation).  You know that some tests are tagged
+with ``safe`` while others are tagged with ``unsafe``.  To only
+select the "safe" tests you can run::
+
+  $ avocado list perf.py --filter-by-tags=safe
+  INSTRUMENTED perf.py:Network.test_latency
+  INSTRUMENTED perf.py:Network.test_throughput
+
+But you could also say that you do **not** want the "unsafe" tests
+(note the *minus* sign before the tag)::
+
+  $ avocado list perf.py --filter-by-tags=-unsafe
+  INSTRUMENTED perf.py:Network.test_latency
+  INSTRUMENTED perf.py:Network.test_throughput
+
+
+.. tip:: The ``-`` sign may cause issues with some shells.  One know
+   error condition is to use spaces between ``--filter-by-tags`` and
+   the negated tag, that is, ``--filter-by-tags -unsafe`` will most
+   likely not work.  To be on the safe side, use
+   ``--filter-by-tags=-tag``.
+
+
+If you require tests to be tagged with **multiple** tags, just add
+them separate by commas.  Example::
+
+  $ avocado list perf.py --filter-by-tags=disk,slow,superuser,unsafe
+  INSTRUMENTED perf.py:Disk.test_device
+
+If no test contains all tags given on a single `--filter-by-tags`
+parameter, no test will be included::
+
+  $ avocado list perf.py --filter-by-tags=disk,slow,superuser,safe | wc -l
+  0
+
+Multiple `--filter-by-tags`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+While multiple tags in a single option will require tests with all the
+given tags (effectively a logical AND operation), it's also possible
+to use multiple ``--filter-by-tags`` (effectively a logical OR
+operation).
+
+For instance To include all tests that have the `disk` tag and all
+tests that have the `net` tag, you can run::
+
+  $ avocado list perf.py --filter-by-tags=disk --filter-by-tags=net
+  INSTRUMENTED perf.py:Disk.test_device
+  INSTRUMENTED perf.py:Network.test_latency
+  INSTRUMENTED perf.py:Network.test_throughput
+
+Including tests without tags
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The normal behavior when using `--filter-by-tags` is to require the
+given tags on all tests.  In some situations, though, it may be
+desirable to include tests that have no tags set.
+
+For instance, you may want to include tests of certain types that do
+not have support for tags (such as SIMPLE tests) or tests that have
+not (yet) received tags.  Consider this command::
+
+  $ avocado list perf.py /bin/true --filter-by-tags=disk
+  INSTRUMENTED perf.py:Disk.test_device
+
+Since it requires the `disk` tag, only one test was returned.  By
+using the `--filter-by-tags-include-empty` option, you can force the
+inclusion of tests without tags::
+
+  $ avocado list perf.py /bin/true --filter-by-tags=disk --filter-by-tags-include-empty
+  SIMPLE       /bin/true
+  INSTRUMENTED perf.py:Idle.test_idle
+  INSTRUMENTED perf.py:Disk.test_device
+
 Python :mod:`unittest` Compatibility Limitations And Caveats
 ============================================================
 

--- a/examples/tests/abort.py
+++ b/examples/tests/abort.py
@@ -10,6 +10,8 @@ class AbortTest(Test):
 
     """
     A test that just calls abort() (and abort).
+
+    :avocado: tags=failure_expected
     """
 
     default_params = {'timeout': 2.0}

--- a/examples/tests/cabort.py
+++ b/examples/tests/cabort.py
@@ -14,6 +14,8 @@ class CAbort(Test):
     """
     A test that calls C standard lib function abort().
 
+    :avocado: tags=requires_c_compiler
+
     params:
     :param tarball: Path to the c-source file relative to deps dir.
     """

--- a/examples/tests/datadir.py
+++ b/examples/tests/datadir.py
@@ -14,6 +14,8 @@ class DataDirTest(Test):
     """
     Test that uses resources from the data dir.
 
+    :avocado: tags=requires_c_compiler
+
     :param tarball: Path to the c-source file relative to deps dir.
     """
 

--- a/examples/tests/doublefail.py
+++ b/examples/tests/doublefail.py
@@ -8,6 +8,9 @@ class DoubleFail(Test):
 
     """
     Functional test for avocado. Straight up fail the test.
+
+    :avocado: tags=failure_expected
+
     """
 
     def test(self):

--- a/examples/tests/doublefree.py
+++ b/examples/tests/doublefree.py
@@ -15,6 +15,8 @@ class DoubleFreeTest(Test):
     """
     Double free test case.
 
+    :avocado: tags=requires_c_compiler
+
     :param source: name of the source file located in deps path
     """
 

--- a/examples/tests/doublefree_nasty.py
+++ b/examples/tests/doublefree_nasty.py
@@ -14,6 +14,8 @@ class DoubleFreeTest(Test):
     """
     10% chance to execute double free exception.
 
+    :avocado: tags=failure_expected,requires_c_compiler
+
     :param source: name of the source file located in deps path
     """
 

--- a/examples/tests/errortest.py
+++ b/examples/tests/errortest.py
@@ -8,6 +8,8 @@ class ErrorTest(Test):
 
     """
     Example test that ends with ERROR.
+
+    :avocado: tags=failure_expected
     """
 
     def test(self):

--- a/examples/tests/errortest_nasty.py
+++ b/examples/tests/errortest_nasty.py
@@ -19,6 +19,8 @@ class FailTest(Test):
 
     """
     Very nasty exception test
+
+    :avocado: tags=failure_expected
     """
 
     def test(self):

--- a/examples/tests/errortest_nasty2.py
+++ b/examples/tests/errortest_nasty2.py
@@ -19,6 +19,8 @@ class FailTest(Test):
 
     """
     Very nasty exception test
+
+    :avocado: tags=failure_expected
     """
 
     def test(self):

--- a/examples/tests/errortest_nasty3.py
+++ b/examples/tests/errortest_nasty3.py
@@ -19,6 +19,8 @@ class FailTest(Test):
 
     """
     This test raises old-style-class exception
+
+    :avocado: tags=failure_expected
     """
 
     def test(self):

--- a/examples/tests/fail_on_exception.py
+++ b/examples/tests/fail_on_exception.py
@@ -7,6 +7,8 @@ class FailOnException(avocado.Test):
 
     """
     Test illustrating the behavior of the fail_on decorator.
+
+    :avocado: tags=failure_expected
     """
 
     # @avocado.fail_on(ValueError) also possible

--- a/examples/tests/failtest.py
+++ b/examples/tests/failtest.py
@@ -8,6 +8,8 @@ class FailTest(Test):
 
     """
     Example test for avocado. Straight up fail the test.
+
+    :avocado: tags=failure_expected
     """
 
     def test(self):

--- a/examples/tests/gdbtest.py
+++ b/examples/tests/gdbtest.py
@@ -12,6 +12,8 @@ class GdbTest(Test):
 
     """
     Execute the gdb test
+
+    :avocado: tags=requires_c_compiler
     """
 
     VALID_CMDS = ["-list-target-features",

--- a/examples/tests/linuxbuild.py
+++ b/examples/tests/linuxbuild.py
@@ -12,6 +12,8 @@ class LinuxBuildTest(Test):
     """
     Execute the Linux Build test.
 
+    :avocado: tags=requires_c_compiler
+
     :param linux_version: kernel version to be built
     :param linux_config: name of the config file located in deps path
     """

--- a/examples/tests/modify_variable.py
+++ b/examples/tests/modify_variable.py
@@ -17,6 +17,8 @@ class PrintVariableTest(Test):
     2) using GDB it modifies the variable to ff
     3) checks the output
 
+    :avocado: tags=requires_c_compiler
+
     :param source: path to the source file relative to deps dir.
     """
 

--- a/examples/tests/passtest.py
+++ b/examples/tests/passtest.py
@@ -8,6 +8,8 @@ class PassTest(Test):
 
     """
     Example test that passes.
+
+    :avocado: tags=fast
     """
 
     def test(self):

--- a/examples/tests/sleeptenmin.py
+++ b/examples/tests/sleeptenmin.py
@@ -12,6 +12,8 @@ class SleepTenMin(Test):
     """
     Sleeps for 10 minutes
 
+    :avocado: tags=slow
+
     :param sleep_cycles: How many iterations should be executed
     :param sleep_length: single sleep duration
     :param sleep_method: what method of sleep should be used (builtin|shell)

--- a/examples/tests/uncaught_exception.py
+++ b/examples/tests/uncaught_exception.py
@@ -8,6 +8,8 @@ class ErrorTest(Test):
 
     """
     Example test that raises generic exception
+
+    :avocado: tags=failure_expected
     """
 
     def test(self):

--- a/selftests/unit/test_safeloader.py
+++ b/selftests/unit/test_safeloader.py
@@ -47,6 +47,27 @@ class ModuleImportedAs(unittest.TestCase):
 
 class DocstringDirectives(unittest.TestCase):
 
+    NO_TAGS = [":AVOCADO: TAGS:FAST",
+               ":AVOCADO: TAGS=FAST",
+               ":avocado: mytags=fast",
+               ":avocado: tags",
+               ":avocado: tag",
+               ":avocado: tag=",
+               ":this is not avocado: tags=foo",
+               ":neither is this :avocado: tags:foo",
+               ":tags:foo,bar",
+               "tags=foo,bar"]
+
+    VALID_TAGS = {":avocado: tags=fast": set(["fast"]),
+                  ":avocado: tags=fast,network": set(["fast", "network"]),
+                  ":avocado: tags=fast,,network": set(["fast", "network"]),
+                  ":avocado: tags=slow,DISK": set(["slow", "DISK"]),
+                  ":avocado: tags=SLOW,disk,disk": set(["SLOW", "disk"]),
+                  ":avocado: tags=SLOW,disk, invalid": set(["SLOW", "disk"]),
+                  ":avocado: tags=SLOW,disk , invalid": set(["SLOW", "disk"]),
+                  ":avocado:\ttags=FAST": set(["FAST"]),
+                  ":avocado: tags=": set([])}
+
     def test_longline(self):
         docstring = ("This is a very long docstring in a single line. "
                      "Since we have nothing useful to put in here let's just "
@@ -73,6 +94,20 @@ class DocstringDirectives(unittest.TestCase):
         self.assertFalse(safeloader.is_docstring_directive_disable(":AVOCADO: DISABLE"))
         self.assertFalse(safeloader.is_docstring_directive_disable(":avocado: disabled"))
 
+    def test_is_tags(self):
+        for tag in self.VALID_TAGS:
+            self.assertTrue(safeloader.is_docstring_directive_tags(tag))
+        for tag in self.NO_TAGS:
+            self.assertFalse(safeloader.is_docstring_directive_tags(tag))
+
+    def test_get_tags_empty(self):
+        for tag in self.NO_TAGS:
+            self.assertEqual([], safeloader.get_docstring_directive_tags(tag))
+
+    def test_get_tags(self):
+        for raw, tags in self.VALID_TAGS.items():
+            self.assertEqual(safeloader.get_docstring_directive_tags(raw), tags)
+
 
 class UnlimitedDiff(unittest.TestCase):
 
@@ -97,7 +132,10 @@ class FindClassAndMethods(UnlimitedDiff):
             'DocstringDirectives': ['test_longline',
                                     'test_newlines',
                                     'test_enabled',
-                                    'test_disabled'],
+                                    'test_disabled',
+                                    'test_is_tags',
+                                    'test_get_tags_empty',
+                                    'test_get_tags'],
             'FindClassAndMethods': ['test_self',
                                     'test_with_pattern',
                                     'test_with_base_class',
@@ -116,7 +154,10 @@ class FindClassAndMethods(UnlimitedDiff):
             'DocstringDirectives': ['test_longline',
                                     'test_newlines',
                                     'test_enabled',
-                                    'test_disabled'],
+                                    'test_disabled',
+                                    'test_is_tags',
+                                    'test_get_tags_empty',
+                                    'test_get_tags'],
             'FindClassAndMethods': ['test_self',
                                     'test_with_pattern',
                                     'test_with_base_class',

--- a/selftests/unit/test_safeloader.py
+++ b/selftests/unit/test_safeloader.py
@@ -45,32 +45,33 @@ class ModuleImportedAs(unittest.TestCase):
         self._test("class Foo(object): import foo as foo", {})
 
 
-class DocstringTag(unittest.TestCase):
+class DocstringDirectives(unittest.TestCase):
 
     def test_longline(self):
         docstring = ("This is a very long docstring in a single line. "
                      "Since we have nothing useful to put in here let's just "
-                     "mention avocado: it's awesome, but that was not a tag. "
-                     "a tag would be something line this: :avocado: enable")
-        self.assertIsNotNone(safeloader.get_docstring_tag(docstring))
+                     "mention avocado: it's awesome, but that was not a "
+                     "directive. a tag would be something line this: "
+                     ":avocado: enable")
+        self.assertIsNotNone(safeloader.get_docstring_directive(docstring))
 
     def test_newlines(self):
         docstring = ("\n\n\nThis is a docstring with many new\n\nlines "
                      "followed by an avocado tag\n"
                      "\n\n:avocado: enable\n\n")
-        self.assertIsNotNone(safeloader.get_docstring_tag(docstring))
+        self.assertIsNotNone(safeloader.get_docstring_directive(docstring))
 
     def test_enabled(self):
-        self.assertTrue(safeloader.is_docstring_tag_enable(":avocado: enable"))
-        self.assertTrue(safeloader.is_docstring_tag_enable(":avocado:\tenable"))
-        self.assertFalse(safeloader.is_docstring_tag_enable(":AVOCADO: ENABLE"))
-        self.assertFalse(safeloader.is_docstring_tag_enable(":avocado: enabled"))
+        self.assertTrue(safeloader.is_docstring_directive_enable(":avocado: enable"))
+        self.assertTrue(safeloader.is_docstring_directive_enable(":avocado:\tenable"))
+        self.assertFalse(safeloader.is_docstring_directive_enable(":AVOCADO: ENABLE"))
+        self.assertFalse(safeloader.is_docstring_directive_enable(":avocado: enabled"))
 
     def test_disabled(self):
-        self.assertTrue(safeloader.is_docstring_tag_disable(":avocado: disable"))
-        self.assertTrue(safeloader.is_docstring_tag_disable(":avocado:\tdisable"))
-        self.assertFalse(safeloader.is_docstring_tag_disable(":AVOCADO: DISABLE"))
-        self.assertFalse(safeloader.is_docstring_tag_disable(":avocado: disabled"))
+        self.assertTrue(safeloader.is_docstring_directive_disable(":avocado: disable"))
+        self.assertTrue(safeloader.is_docstring_directive_disable(":avocado:\tdisable"))
+        self.assertFalse(safeloader.is_docstring_directive_disable(":AVOCADO: DISABLE"))
+        self.assertFalse(safeloader.is_docstring_directive_disable(":avocado: disabled"))
 
 
 class UnlimitedDiff(unittest.TestCase):
@@ -93,10 +94,10 @@ class FindClassAndMethods(UnlimitedDiff):
                                  'test_foo_as_bar',
                                  'test_foo_as_foo',
                                  'test_import_inside_class'],
-            'DocstringTag': ['test_longline',
-                             'test_newlines',
-                             'test_enabled',
-                             'test_disabled'],
+            'DocstringDirectives': ['test_longline',
+                                    'test_newlines',
+                                    'test_enabled',
+                                    'test_disabled'],
             'FindClassAndMethods': ['test_self',
                                     'test_with_pattern',
                                     'test_with_base_class',
@@ -112,10 +113,10 @@ class FindClassAndMethods(UnlimitedDiff):
                                  'test_foo_as_bar',
                                  'test_foo_as_foo',
                                  'test_import_inside_class'],
-            'DocstringTag': ['test_longline',
-                             'test_newlines',
-                             'test_enabled',
-                             'test_disabled'],
+            'DocstringDirectives': ['test_longline',
+                                    'test_newlines',
+                                    'test_enabled',
+                                    'test_disabled'],
             'FindClassAndMethods': ['test_self',
                                     'test_with_pattern',
                                     'test_with_base_class',


### PR DESCRIPTION
This adds support for test tags (to choose categorized tests) to the safeloader, loader, and also to the list and run commands.

---

Changes from v2 (#1637):
 * Made the filtering agnostic to test type. Although we only support getting tags from INSTRUMENTED tests, the filtering does not check that.  This was necessary to make things such as `--filter-by-tags-include-empty` work accross the board and suggested by @famz
 * Added test that checks that everything after a space on "tags=" values are ignored.  The root reason is the format for *all* docstring directives (see regex). Suggested by @ldoktor
 * Added tests for docstrings directives with spaces, as suggested by @ldoktor
 * Renamed option `--filter-by-tags-ignore-empty` to `--filter-by-tags-include-empty`, as suggested by @famz
 * Documented behavior of multiple `--filter-by-tags`
 * Documented behavior of `--filter-by-tags-include-empty

Changes from v1 (#1629):
 * Moved commits not directly related to feature to separate PR (already merged)
 * Added user documentation (includes not directly related commit, also sent in separate PR #1636) 

Other changes from v0 (#1621):
 * Docstring style changes
 * Fixed conditional block that was misplaced in another `if/else` block (about the removal of the `tags` from the test parameters)
 * Introduced many tests to the loader filter option
 * Introduced the `ignore_empty` option to `loader.filter_test_tags()`
 * Removed `FILTERED` "test type" and consequently from the `avocado list -V` output
 * [RFC] Tagged most INSTRUMENTED example tests
