### PR TITLE
Support SUSE and openSUSE

### DIFF
--- a/avocado/utils/software_manager.py
+++ b/avocado/utils/software_manager.py
@@ -107,6 +107,9 @@ class SystemInspector(object):
             elif ('yum' in list_supported and
                   self.distro in ('redhat', 'fedora')):
                 pm_supported = 'yum'
+            elif ('zypper' in list_supported and
+                  self.distro == 'SuSE'):
+                pm_supported = 'zypper'
             else:
                 pm_supported = list_supported[0]
 


### PR DESCRIPTION
The package manager for both is zypper. Both have an /etc/os-release
file, but the content of it is quite different.

Some examples:

NAME="openSUSE Leap"
VERSION="42.2"
ID=opensuse

NAME="SLES"
VERSION="12-SP2"
VERSION_ID="12.2"

NAME="openSUSE Tumbleweed"
ID=opensuse
VERSION_ID="20161125"

So I took the easy path - what they all have in common is the SUSE
string. And as no other probe looks at /etc/os-release, this is very
safe for now.