### PR TITLE
spell: fix spelling for v44 release

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -277,7 +277,7 @@ class TestLoaderProxy(object):
         :return: an instance of :class:`avocado.core.test.Test`.
         """
         test_class, test_parameters = test_factory
-        # discard tags, as they are *not* intented to be parameters
+        # discard tags, as they are *not* intended to be parameters
         # for the test, but used previously during filtering
         if 'tags' in test_parameters:
             del(test_parameters['tags'])

--- a/spell.ignore
+++ b/spell.ignore
@@ -412,3 +412,4 @@ unparsed
 browsable
 rfc
 bfr
+eq


### PR DESCRIPTION
Only two occurrences. One is a typo and another is an exception.