### PR TITLE
Increase avocado timeouts

### DIFF
--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -239,7 +239,8 @@ class TestStatus(object):
                        test_state['name'])
         if proc.is_alive():
             TEST_LOG.warning("Killing hanged test process %s" % proc.pid)
-            for _ in xrange(5):     # I really want to destroy it
+            end_time = time.time() + 60
+            while time.time() < end_time:
                 os.kill(proc.pid, signal.SIGKILL)
                 if not proc.is_alive():
                     break
@@ -366,7 +367,7 @@ class TestRunner(object):
         time_started = time.time()
         proc.start()
 
-        test_status.wait_for_early_status(proc, 10)
+        test_status.wait_for_early_status(proc, 60)
 
         # At this point, the test is already initialized and we know
         # for sure if there's a timeout set.

--- a/avocado/utils/gdb.py
+++ b/avocado/utils/gdb.py
@@ -623,7 +623,7 @@ class GDBServer(object):
 
     #: The time to optionally wait for the server to initialize itself and be
     #: ready to accept new connections
-    INIT_TIMEOUT = 2.0
+    INIT_TIMEOUT = 5.0
 
     def __init__(self, path='/usr/bin/gdbserver', port=None,
                  wait_until_running=True, *extra_args):
@@ -675,10 +675,10 @@ class GDBServer(object):
             self._wait_until_running()
 
     def _wait_until_running(self):
-        init_time = time.time()
         connection_ok = False
         c = GDB()
-        while time.time() - init_time < self.INIT_TIMEOUT:
+        end_time = time.time() + self.INIT_TIMEOUT
+        while time.time() < end_time:
             try:
                 c.connect(self.port)
                 connection_ok = True


### PR DESCRIPTION
This patch set increases some runner timeouts, gdb init timeout and improves the loop condition.