### PR TITLE
avocado.utils.astring: Couple of tabular_output related fixes

### DIFF
--- a/avocado/utils/astring.py
+++ b/avocado/utils/astring.py
@@ -160,10 +160,14 @@ def iter_tabular_output(matrix, header=None):
     if type(header) is list:
         header = tuple(header)
     lengths = []
-    if header:
-        for column in header:
-            lengths.append(len(strip_console_codes(column, allow_move=True)))
     str_matrix = []
+    if header:
+        str_matrix.append([])
+        for column in header:
+            column = string_safe_encode(column)
+            str_matrix[-1].append(column)
+            lengths.append(len(strip_console_codes(column.decode("utf-8"),
+                                                   allow_move=True)))
     for row in matrix:
         str_matrix.append([])
         for i, column in enumerate(row):
@@ -184,9 +188,6 @@ def iter_tabular_output(matrix, header=None):
                               for leng in lengths[:-1]] +
                              ["%s"])
 
-    if header:
-        out_line = format_string % header
-        yield out_line
     for row in str_matrix:
         out_line = format_string % tuple(row)
         yield out_line

--- a/avocado/utils/astring.py
+++ b/avocado/utils/astring.py
@@ -162,14 +162,15 @@ def iter_tabular_output(matrix, header=None):
     lengths = []
     if header:
         for column in header:
-            lengths.append(len(column))
+            lengths.append(len(strip_console_codes(column, allow_move=True)))
     str_matrix = []
     for row in matrix:
         str_matrix.append([])
         for i, column in enumerate(row):
             column = string_safe_encode(column)
             str_matrix[-1].append(column)
-            col_len = len(column.decode("utf-8"))
+            col_len = len(strip_console_codes(column.decode("utf-8"),
+                                              allow_move=True))
             try:
                 max_len = lengths[i]
                 if col_len > max_len:

--- a/avocado/utils/astring.py
+++ b/avocado/utils/astring.py
@@ -86,7 +86,7 @@ def shell_escape(command):
     return command
 
 
-def strip_console_codes(output, custom_codes=None):
+def strip_console_codes(output, custom_codes=None, allow_move=False):
     """
     Remove the Linux console escape and control sequences from the console
     output. Make the output readable and can be used for result check. Now
@@ -96,7 +96,9 @@ def strip_console_codes(output, custom_codes=None):
     :type output: string
     :param custom_codes: The codes added to the console codes which is not
                          covered in the default codes
-    :type output: string
+    :type custom_codes: string
+    :param allow_move: Whether to emulate move (left, right only for now)
+    :type allow_move: bool
     :return: the string without any special codes
     :rtype: string
     """
@@ -126,6 +128,13 @@ def strip_console_codes(output, custom_codes=None):
         try:
             special_code = re.findall(console_codes, tmp_word)[0]
         except IndexError:
+            if allow_move:
+                if tmp_word == "[1D":
+                    return_str = return_str[:-1]
+                    continue
+                elif tmp_word == "[1C":
+                    return_str += " "
+                    continue
             if index + tmp_index < len(output):
                 raise ValueError("%s is not included in the known console "
                                  "codes list %s" % (tmp_word, console_codes))

--- a/selftests/unit/test_astring.py
+++ b/selftests/unit/test_astring.py
@@ -17,6 +17,19 @@ class AstringTest(unittest.TestCase):
                           'foo               bar\n'
                           '/bin/bar/sbrubles /home/myuser/sbrubles'))
 
+    def testTabularWithConsoleCodes(self):
+        matrix = [("a", "bb", "ccc", "dddd", "last"),
+                  ("\x1b[94ma",             # {BLUE}a
+                   "\033[0mbb",             # {END}bb
+                   "ccc\033[1D\033[1Dcc",   # ccc{MOVE_LEFT}{MOVE_LEFT}cc
+                   "d\033[1C\033[1Cd",      # d{MOVE_RIGHT}{MOVE_RIGHT}d
+                   "last")]
+        header = ['0', '1', '2', '3', '4']
+        self.assertEqual(astring.tabular_output(matrix, header),
+                         "0 1  2   3    4\n"
+                         "a bb ccc dddd last\n"
+                         "\x1b[94ma \x1b[0mbb ccc\x1b[1D\x1b[1Dcc d\x1b[1C\x1b[1Cd last")
+
     def testUnicodeTabular(self):
         """
         Verifies tabular can handle utf-8 chars properly

--- a/selftests/unit/test_astring.py
+++ b/selftests/unit/test_astring.py
@@ -51,6 +51,7 @@ class AstringTest(unittest.TestCase):
                       "avok\xc3\xa1do 123\n"
                       "avocado 123")
         self.assertEqual(astring.tabular_output(matrix), str_matrix)
+        self.assertEqual(astring.tabular_output(matrix[1:], matrix[0]), str_matrix)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This patch set adds support for terminal characters used in tabular_output input and fixes the support for unicode in tabular_output headers.