### PR TITLE
docs: cross-reference for test tags in 'Test discovery'

### DIFF
--- a/docs/source/Loaders.rst
+++ b/docs/source/Loaders.rst
@@ -52,3 +52,11 @@ as some of them result in error)::
         > EXTERNAL     this_does_not_exist
         > SIMPLE       /bin/echo
 
+Categorizing tests with tags
+============================
+
+Avocado allows tests to be given tags, which can be used to create
+test categories. With tags set, users can select a subset of the
+tests found by the test resolver (also known as test loader). For
+more information about the test tags, visit
+`<WritingTests.html#categorizing-tests>`__


### PR DESCRIPTION
From test writer perspective, we need the information about test tags in
the Writing Tests section. But from the users executing tests
perspective, the information about test tags should be present in Test
Discovery section. Let's fix that creating this cross-reference.

Signed-off-by: Amador Pahim <apahim@redhat.com>