### PR TITLE
[RFC] tests temporary directory

### DIFF
--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -31,6 +31,7 @@ from . import output
 from . import status
 from .loader import loader
 from .status import mapping
+from .teststmpdir import teststmpdir
 from ..utils import wait
 from ..utils import runtime
 from ..utils import process
@@ -513,11 +514,13 @@ class TestRunner(object):
         no_digits = len(str(test_result_total))
         self.result.tests_total = test_result_total
         self.result.start_tests()
+        tests_tmpdir = teststmpdir.create()
         index = -1
         try:
             for test_template in test_suite:
                 test_template[1]['base_logdir'] = self.job.logdir
                 test_template[1]['job'] = self.job
+                test_template[1]['tests_tmpdir'] = tests_tmpdir
                 break_loop = False
                 for test_factory, variant in self._iter_variants(test_template,
                                                                  mux):
@@ -556,6 +559,7 @@ class TestRunner(object):
         if self.job.sysinfo is not None:
             self.job.sysinfo.end_job_hook()
         self.result.end_tests()
+        teststmpdir.destroy()
         self.job._result_events_dispatcher.map_method('post_tests', self.job)
         self.job.funcatexit.run()
         signal.signal(signal.SIGTSTP, signal.SIG_IGN)

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -129,7 +129,8 @@ class Test(unittest.TestCase):
     default_params = {}
 
     def __init__(self, methodName='test', name=None, params=None,
-                 base_logdir=None, job=None, runner_queue=None):
+                 base_logdir=None, job=None, runner_queue=None,
+                 tests_tmpdir=None):
         """
         Initializes the test.
 
@@ -145,6 +146,8 @@ class Test(unittest.TestCase):
                             provided, it'll use
                             :func:`avocado.data_dir.create_job_logs_dir`.
         :param job: The job that this test is part of.
+        :param tests_tmpdir: Temporary directory created to share resources
+                             among tests.
         :raises: :class:`avocado.core.test.NameNotTestNameError`
         """
         def record_and_warn(*args, **kwargs):
@@ -238,6 +241,10 @@ class Test(unittest.TestCase):
 
         self.time_elapsed = -1
         unittest.TestCase.__init__(self, methodName=methodName)
+
+        self.teststmpdir = None
+        if tests_tmpdir is not None:
+            self.teststmpdir = tests_tmpdir
 
     @property
     def basedir(self):

--- a/avocado/core/teststmpdir.py
+++ b/avocado/core/teststmpdir.py
@@ -1,0 +1,31 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+
+
+import os
+import shutil
+import tempfile
+
+
+class TestsTmpDir(object):
+
+    def __init__(self, varname='XXX_TESTS_COMMON_TMPDIR'):
+        self._varname = varname
+
+    def create(self):
+        tmpdir = tempfile.mkdtemp(prefix='avocado_')
+        os.environ[self._varname] = tmpdir
+        return tmpdir
+
+    def destroy(self):
+        if os.environ.get(self._varname) is not None:
+            shutil.rmtree(os.environ.get(self._varname))
+
+teststmpdir = TestsTmpDir()


### PR DESCRIPTION
This docstring-less prototype is intended for discussion.

I don't think the job is the correct place to create such resource, since we can break the expectations when the multi-host is in place.

On the other hand, the test runner is always expected to be executed entirely in the same host. In this POC, I'm creating the temporary directory in the `run_suite()` and exposing it via both Test API and environment variable.

Btw, I first implemented it as a job pre/post plugin, but from the feedback on list, that approach can "bring inconsistencies or clashes in the very near future".

https://www.redhat.com/archives/avocado-devel/2016-October/msg00015.html

Once we agree in the architecture, the documentation will follow.
