### PR TITLE
Temporary directory for tests

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -280,6 +280,15 @@ class Test(unittest.TestCase):
         else:
             return None
 
+    @property
+    def teststmpdir(self):
+        env_var = 'XXX_TESTS_COMMON_TMPDIR'
+        path = os.environ.get(env_var)
+        if path is None:
+            msg = 'Environment Variable %s is not set.' % env_var
+            raise EnvironmentError(msg)
+        return path
+
     @data_structures.LazyProperty
     def workdir(self):
         basename = (os.path.basename(self.logdir).replace(':', '_')

--- a/avocado/plugins/teststmpdir.py
+++ b/avocado/plugins/teststmpdir.py
@@ -1,0 +1,26 @@
+import os
+import shutil
+import tempfile
+
+from avocado.core.plugin_interfaces import JobPre, JobPost
+
+
+class TestsTmpDir(JobPre, JobPost):
+
+    name = 'teststmpdir'
+    description = 'Creates a temporary directory for tests consumption'
+
+    def __init__(self):
+        self._varname = 'XXX_TESTS_COMMON_TMPDIR'
+        self._dirname = None
+
+    def pre(self, job):
+        if os.environ.get(self._varname) is None:
+            self._dirname = tempfile.mkdtemp(prefix='avocado_')
+            os.environ[self._varname] = self._dirname
+
+    def post(self, job):
+        if (self._dirname is not None and
+                os.environ.get(self._varname) == self._dirname and
+                os.path.exists(self._dirname)):
+            shutil.rmtree(self._dirname)

--- a/selftests/functional/test_teststmpdir.py
+++ b/selftests/functional/test_teststmpdir.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import tempfile
+import shutil
+
+if sys.version_info[:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
+
+from avocado.core import exit_codes
+from avocado.utils import process
+from avocado.utils import script
+
+
+basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..')
+basedir = os.path.abspath(basedir)
+
+
+SIMPLE_SCRIPT = """#!/bin/bash
+: ${XXX_TESTS_COMMON_TMPDIR:?}
+"""
+
+
+class TestsTmpDirTests(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+
+    def run_and_check(self, cmd_line, expected_rc):
+        os.chdir(basedir)
+        result = process.run(cmd_line, ignore_status=True)
+        self.assertEqual(result.exit_status, expected_rc,
+                         "Command %s did not return rc "
+                         "%d:\n%s" % (cmd_line, expected_rc, result))
+        return result
+
+    def test_simple(self):
+        simple_test = script.TemporaryScript(
+            'test_simple.py',
+            SIMPLE_SCRIPT)
+        simple_test.save()
+        cmd_line = ("./scripts/avocado run --sysinfo=off --job-results-dir %s "
+                    "%s" % (self.tmpdir, simple_test))
+        self.run_and_check(cmd_line, exit_codes.AVOCADO_ALL_OK)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/selftests/functional/test_teststmpdir.py
+++ b/selftests/functional/test_teststmpdir.py
@@ -18,6 +18,11 @@ from avocado.utils import script
 basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..')
 basedir = os.path.abspath(basedir)
 
+INSTRUMENTED_SCRIPT = """from avocado import Test
+class MyTest(Test):
+    def test(self):
+        self.teststmpdir
+"""
 
 SIMPLE_SCRIPT = """#!/bin/bash
 : ${XXX_TESTS_COMMON_TMPDIR:?}
@@ -36,6 +41,15 @@ class TestsTmpDirTests(unittest.TestCase):
                          "Command %s did not return rc "
                          "%d:\n%s" % (cmd_line, expected_rc, result))
         return result
+
+    def test_instrumented(self):
+        instrumented_test = script.TemporaryScript(
+            'test_instrumented.py',
+            INSTRUMENTED_SCRIPT)
+        instrumented_test.save()
+        cmd_line = ("./scripts/avocado run --sysinfo=off --job-results-dir %s "
+                    "%s" % (self.tmpdir, instrumented_test))
+        self.run_and_check(cmd_line, exit_codes.AVOCADO_ALL_OK)
 
     def test_simple(self):
         simple_test = script.TemporaryScript(

--- a/setup.py
+++ b/setup.py
@@ -160,6 +160,7 @@ if __name__ == '__main__':
                   ],
               'avocado.plugins.job.prepost': [
                   'jobscripts = avocado.plugins.jobscripts:JobScripts',
+                  'teststmpdir = avocado.plugins.teststmpdir:TestsTmpDir',
                   ],
               'avocado.plugins.result': [
                   'xunit = avocado.plugins.xunit:XUnitResult',


### PR DESCRIPTION
- Job pre/post plugin to create/destroy the directory and expose its path via environment variable.
- Make the directory available via `Test()` API.