### PR TITLE
avocado.utils.process: Always log the command on Popen failure

### DIFF
--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -377,12 +377,8 @@ class SubProcess(object):
                                                shell=self.shell,
                                                env=self.env)
             except OSError as details:
-                if details.errno == 2:
-                    exc = OSError("File '%s' not found" % self.cmd.split()[0])
-                    exc.errno = 2
-                    raise exc
-                else:
-                    raise
+                details.strerror += " (%s)" % self.cmd
+                raise details
 
             self.start_time = time.time()
             self.stdout_file = StringIO()


### PR DESCRIPTION
The default exception of `subprocess.Popen` does not contain any useful
info. We already replace the original exception for "File not found"
exception, this patch always modifies the exception's message to include
the executed command.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>