### PR TITLE
travis: Enforce signed-off-by message in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,14 +19,6 @@ install:
     - pip install -r requirements-travis.txt
 
 script:
-    - inspekt lint
-    - inspekt indent
-    - inspekt style
-    - ./selftests/cyclical_deps avocado
-    - ./selftests/modules_boundaries
-    - make link
-    - ./selftests/run
-    - ./selftests/check_tmp_dirs
     - |
         # First cleanup the previously installed files
         python setup.py develop --uninstall
@@ -37,7 +29,7 @@ script:
         # Run the "make check" per each commit in PR (TRAVIS_COMMIT_RANGE)
         ERR=""
         echo Branch is $TRAVIS_BRANCH
-        for COMMIT in $(git rev-list $TRAVIS_COMMIT_RANGE~1); do
+        for COMMIT in $(git rev-list $TRAVIS_COMMIT_RANGE); do
             echo
             echo "--------------------< $(git log -1 --oneline $COMMIT) >--------------------"
             echo

--- a/selftests/checkall
+++ b/selftests/checkall
@@ -49,10 +49,20 @@ parallel_selftests() {
 }
 
 
+signed_off_check() {
+    AUTHOR="$(git log -1 --pretty='format:%aN <%aE>')"
+    git log -1 --pretty=format:%B | grep "Signed-off-by: $AUTHOR"
+    if [ $? != 0 ]; then
+        echo "The commit message does not contain author's signature (Signed-off-by: $AUTHOR)"
+        return 1
+    fi
+}
+
 run_rc lint 'inspekt --exclude=.git lint'
 run_rc indent 'inspekt --exclude=.git indent'
 run_rc style 'inspekt --exclude=.git style'
 run_rc boundaries 'selftests/modules_boundaries'
+run_rc signed-off-by signed_off_check
 if [ "$AVOCADO_PARALLEL_CHECK" ]; then
     run_rc selftests parallel_selftests
 elif [ -z "$AVOCADO_SELF_CHECK" ]; then


### PR DESCRIPTION
Let's make sure code without correct "Signed-off-by" message is not accepted. In order to avoid having multiple implementations or spoiling Makefile with yet another check I implemented it in "selftests/checkall", which used to be executed per all commit except of the first one and I also changed the travis script to use the same check for all commits, so now the "checkall" script checks all commits.