### PR TITLE
Remove argument support for SIMPLE tests

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -23,7 +23,6 @@ import imp
 import inspect
 import os
 import re
-import pipes
 import shlex
 import sys
 
@@ -531,12 +530,6 @@ class FileLoader(TestLoader):
                 subtests_filter = re.compile(_subtests_filter)
 
         if not os.path.isdir(reference):  # Single file
-            if (not self._make_tests(reference, DEFAULT, subtests_filter) and
-                    not subtests_filter):
-                split_reference = shlex.split(reference)
-                if (os.access(split_reference[0], os.X_OK) and
-                        not os.path.isdir(split_reference[0])):
-                    return self._make_test(test.SimpleTest, reference)
             return self._make_tests(reference, which_tests, subtests_filter)
 
         tests = []
@@ -740,7 +733,7 @@ class FileLoader(TestLoader):
             else:
                 if os.access(test_path, os.X_OK):
                     return self._make_test(test.SimpleTest,
-                                           pipes.quote(test_path))
+                                           test_path)
                 else:
                     return make_broken(test.NotATest, test_path)
         else:

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -21,6 +21,7 @@ framework tests.
 import inspect
 import logging
 import os
+import pipes
 import re
 import shutil
 import sys
@@ -702,7 +703,9 @@ class SimpleTest(Test):
     def __init__(self, name, params=None, base_logdir=None, job=None):
         super(SimpleTest, self).__init__(name=name, params=params,
                                          base_logdir=base_logdir, job=job)
-        self._command = self.filename
+        self._command = None
+        if self.filename is not None:
+            self._command = pipes.quote(self.filename)
 
     @property
     def filename(self):

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -261,8 +261,8 @@ class OutputPluginTest(unittest.TestCase):
                 pass
 
     def test_nonprintable_chars(self):
-        cmd_line = ("./scripts/avocado run '/bin/ls "
-                    "NON_EXISTING_FILE_WITH_NONPRINTABLE_CHARS_IN_HERE\x1b' "
+        cmd_line = ("./scripts/avocado run --external-runner /bin/ls "
+                    "'NON_EXISTING_FILE_WITH_NONPRINTABLE_CHARS_IN_HERE\x1b' "
                     "--job-results-dir %s --sysinfo=off" % self.tmpdir)
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout + result.stderr

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -204,11 +204,9 @@ class LoaderTest(unittest.TestCase):
         test_parameters['base_logdir'] = self.tmpdir
         tc = test_class(**test_parameters)
         tc.run_avocado()
-        # Load with params
-        simple_with_params = simple_test.path + " 'foo bar' --baz"
-        suite = self.loader.discover(simple_with_params, loader.ALL)
+        suite = self.loader.discover(simple_test.path, loader.ALL)
         self.assertEqual(len(suite), 1)
-        self.assertEqual(suite[0][1]["name"], simple_with_params)
+        self.assertEqual(suite[0][1]["name"], simple_test.path)
         simple_test.remove()
 
     def test_load_simple_not_exec(self):


### PR DESCRIPTION
To provide support for passing arguments for simple tests in command
line, we were creating some cases where the test reference could not be
properly handled. Also, for test references with white-spaces, we have
an inconsistent behavior. See reference.

This patch removes the support for arguments in test references,
restoring the proper behavior, which is expected to be shell-like.

As consequence, we now handle correctly white-spaces in tests references
as well as Unicode characters.

Reference: https://www.redhat.com/archives/avocado-devel/2016-November/msg00011.html
Reference: https://trello.com/c/bfE9NBbl
Signed-off-by: Amador Pahim <apahim@redhat.com>