### PR TITLE
avocado.core.test: Support avocado-bash-utils in external runner

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -739,17 +739,17 @@ class SimpleTest(Test):
         except process.CmdError as details:
             self._log_detailed_cmd_info(details.result)
             raise exceptions.TestFail(details)
+        for line in open(self.logfile):
+            if self.re_avocado_log.match(line):
+                raise exceptions.TestWarn("Test passed but there were warnings"
+                                          " on stdout during execution. Check "
+                                          "the log for details.")
 
     def test(self):
         """
         Run the test and postprocess the results
         """
         self.execute_cmd()
-        for line in open(self.logfile):
-            if self.re_avocado_log.match(line):
-                raise exceptions.TestWarn("Test passed but there were warnings"
-                                          " on stdout during execution. Check "
-                                          "the log for details.")
 
 
 class ExternalRunnerTest(SimpleTest):


### PR DESCRIPTION
The external runner tests currently do not support the extended API for
simple tests. This patch moves the extended API into the
`SimpleTest.execute_cmd` in order to run this from inherited tests like
ExternalRunner.

Note this version affects all tests which share the
`SimpleTest.execute_cmd`. I think it's a good think, but I'd be also
fine with implementing it as another SimpleTest method and call this
method from inherited tests where it makes sense (like ExternalRunner).

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>