### PR TITLE
avocado.core.runner: add test directory to sys.path

### DIFF
--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -359,6 +359,10 @@ class TestRunner(object):
 
         signal.signal(signal.SIGTSTP, sigtstp_handler)
 
+        filename = loader.load_test(test_factory).filename
+        if filename is not None:
+            sys.path.insert(0, os.path.dirname(filename))
+
         proc = multiprocessing.Process(target=self._run_test,
                                        args=(test_factory, queue,))
         test_status = TestStatus(self.job, queue)


### PR DESCRIPTION
If user try to inject a function from the test itself in self.runner_queue,
the runner will raise an exception because the test module is not
available in sys.path.

This patch adds the test directory to the sys.path so Avocado can load
the test module when needed.

Reference: https://trello.com/c/5JtoH2qW
Signed-off-by: Amador Pahim <apahim@redhat.com>