### PR TITLE
avocado.core.runner: add test directory to sys.path

### DIFF
--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -339,6 +339,10 @@ class TestRunner(object):
         """
         proc = None
         sigtstp = multiprocessing.Lock()
+        if 'modulePath' in test_factory[1]:
+            test_path = test_factory[1]['modulePath']
+            test_module_dir = os.path.abspath(os.path.dirname(test_path))
+            sys.path.insert(0, test_module_dir)
 
         def sigtstp_handler(signum, frame):     # pylint: disable=W0613
             """ SIGSTOP all test processes on SIGTSTP """


### PR DESCRIPTION
If user try to inject a function from the test itself in self.runner_queue,
the runner will raise an exception because the test module is not
available in sys.path.

This patch adds the test directory to the sys.path so Avocado can load
the test module when needed.

Reference: https://trello.com/c/5JtoH2qW
Signed-off-by: Amador Pahim <apahim@redhat.com>