### PR TITLE
[V2] avocado.core.runner: add test directory to sys.path

### DIFF
--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -339,6 +339,10 @@ class TestRunner(object):
         """
         proc = None
         sigtstp = multiprocessing.Lock()
+        if 'modulePath' in test_factory[1]:
+            test_path = test_factory[1]['modulePath']
+            test_module_dir = os.path.abspath(os.path.dirname(test_path))
+            sys.path.insert(0, test_module_dir)
 
         def sigtstp_handler(signum, frame):     # pylint: disable=W0613
             """ SIGSTOP all test processes on SIGTSTP """

--- a/selftests/functional/test_runner_queue.py
+++ b/selftests/functional/test_runner_queue.py
@@ -1,0 +1,75 @@
+import os
+import sys
+import shutil
+import tempfile
+
+if sys.version_info[:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
+
+from avocado.core import exit_codes
+from avocado.utils import script
+from avocado.utils import process
+
+basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..')
+basedir = os.path.abspath(basedir)
+
+AVOCADO_EXTERNAL_LIB = """
+def cleanup_function(arg1):
+    print('Bogus cleanup function. arg1: %s' % arg1)
+"""
+
+AVOCADO_TEST_RUNNER_QUEUE_EXTERNAL_LIB = """#!/usr/bin/env python
+from avocado import Test
+from avocado.utils import runtime as avocado_runtime
+from avocado_queue_testlib import cleanup_function
+
+
+class AvocadoQueueTests(Test):
+    def test_stuff_add_cleanup(self):
+        avocado_runtime.CURRENT_TEST.runner_queue.put({'func_at_exit': cleanup_function,
+                                                       'args': ('Hello Avocado Test Queue!',),
+                                                       'once': True})
+        self.assertEqual(1, 1)
+"""
+
+
+class TestRunnerQueue(unittest.TestCase):
+    def setUp(self):
+        os.chdir(basedir)
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+
+    def test_runner_queue_external_lib(self):
+        mylib = script.TemporaryScript(
+            'avocado_queue_testlib.py',
+            AVOCADO_EXTERNAL_LIB,
+            'avocado_runner_queue_functional',
+            0644)
+        mylib.save()
+        mytest = script.Script(
+            os.path.join(os.path.dirname(mylib.path), 'test.py'),
+            AVOCADO_TEST_RUNNER_QUEUE_EXTERNAL_LIB)
+        os.chdir(basedir)
+        mytest.save()
+        # job should be able to finish under 5 seconds. If this fails, it's
+        # possible that we hit the "simple test fork bomb" bug
+        cmd_line = ['./scripts/avocado',
+                    'run',
+                    '--sysinfo=off',
+                    '--job-results-dir',
+                    "%s" % self.tmpdir,
+                    "%s" % mytest]
+        result = process.run(' '.join(cmd_line))
+        self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
+        self.assertIn('Bogus cleanup function. arg1: Hello Avocado Test Queue!',
+                      result.stdout,
+                      'Cleanup function message not found in stdout:\n%s' %
+                      result.stdout)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
If user try to inject a function from the test itself in self.runner_queue,
the runner will raise an exception because the test module is not
available in sys.path.

This patch adds the test directory to the sys.path so Avocado can load
the test module when needed.

Reference: https://trello.com/c/5JtoH2qW

Changelog:
V1 - V2: Add a functional test