### PR TITLE
[RFC] Test: add skipIf and skipUnless decorators

### DIFF
--- a/avocado/core/exceptions.py
+++ b/avocado/core/exceptions.py
@@ -177,6 +177,28 @@ class TestSkipError(TestBaseException):
     status = "SKIP"
 
 
+class TestSkipIfError(TestBaseException):
+
+    """
+    Indictates that the test is skipped due to a given True condition.
+
+    Should be thrown by the Test.skipIf decorator when a given condition
+    is True.
+    """
+    status = "SKIP"
+
+
+class TestSkipUnlessError(TestBaseException):
+
+    """
+    Indictates that the test is skipped due to a given False condition.
+
+    Should be thrown by the Test.skipUnless decorator when a given
+    condition False.
+    """
+    status = "SKIP"
+
+
 class TestFail(TestBaseException, AssertionError):
 
     """

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -478,6 +478,9 @@ class Test(unittest.TestCase):
             raise exceptions.TestSetupFail(details)
         try:
             testMethod()
+        except exceptions.TestSkipIfError as details:
+            stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
+            raise exceptions.TestSkipError(details)
         except exceptions.TestSkipError as details:
             stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
             skip_illegal_msg = ('Calling skip() in places other than '
@@ -690,6 +693,30 @@ class Test(unittest.TestCase):
             expire = data_structures.time_to_seconds(str(expire))
         return asset.Asset(name, asset_hash, algorithm, locations,
                            self.cache_dirs, expire).fetch()
+
+    @staticmethod
+    def skipIf(condition, reason):
+        """
+        Decorator to skip a test if a condition is True.
+        """
+        def decorator(function):
+            def wrapper(*args, **kwargs):
+                if condition:
+                    raise exceptions.TestSkipIfError(reason)
+            return wrapper
+        return decorator
+
+    @staticmethod
+    def skipUnless(condition, reason):
+        """
+        Decorator to skip a test if a condition is False.
+        """
+        def decorator(function):
+            def wrapper(*args, **kwargs):
+                if not condition:
+                    raise exceptions.TestSkipUnlessError(reason)
+            return wrapper
+        return decorator
 
 
 class SimpleTest(Test):

--- a/selftests/functional/test_skiptests.py
+++ b/selftests/functional/test_skiptests.py
@@ -1,0 +1,64 @@
+import json
+import os
+import shutil
+import sys
+import tempfile
+
+if sys.version_info[:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
+
+from avocado.core import exit_codes
+from avocado.utils import script
+from avocado.utils import process
+
+basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..')
+basedir = os.path.abspath(basedir)
+
+
+AVOCADO_TEST_SKIP_DECORATORS = """#!/usr/bin/env python
+from avocado import Test
+
+class AvocadoSkipTests(Test):
+
+    @Test.skipIf(True, 'Skipped due to the True condition')
+    def test1(self):
+        pass
+
+    @Test.skipUnless(False, 'Skipped due to the False condition')
+    def test2(self):
+        pass
+"""
+
+
+class TestSkipDecorators(unittest.TestCase):
+
+    def setUp(self):
+        os.chdir(basedir)
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+
+    def test_skip_decorators(self):
+        test_decorators = script.TemporaryScript(
+            'avocado_test_skip_decorators.py',
+            AVOCADO_TEST_SKIP_DECORATORS)
+        test_decorators.save()
+        os.chdir(basedir)
+        cmd_line = ['./scripts/avocado',
+                    'run',
+                    '--sysinfo=off',
+                    '--job-results-dir',
+                    '%s' % self.tmpdir,
+                    '%s' % test_decorators,
+                    '--json -']
+        result = process.run(' '.join(cmd_line))
+        json_results = json.loads(result.stdout)
+        self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
+        self.assertEquals(json_results['skip'], 2)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Avocado does not support self.skip() to be called from inside a test.
This is a design decision that users have to comply with. On the other
hand, users keep requesting ways to skip tests.

This patch creates the decorators Test.skipIf and Test.skipUnless to be
used in test functions. Corresponding exceptions will be raised in those
cases.

Reference: https://trello.com/c/JK5Z5dql
Signed-off-by: Amador Pahim <apahim@redhat.com>