### PR TITLE
Add skip, skipIf and skipUnless decorators

### DIFF
--- a/avocado/__init__.py
+++ b/avocado/__init__.py
@@ -13,10 +13,19 @@
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
 
-__all__ = ['main', 'Test', 'VERSION', 'fail_on']
+__all__ = ['main',
+           'Test',
+           'VERSION',
+           'fail_on',
+           'skip',
+           'skipIf',
+           'skipUnless']
 
 
 from avocado.core.job import main
 from avocado.core.test import Test
 from avocado.core.version import VERSION
 from avocado.core.exceptions import fail_on
+from avocado.core.decorators import skip
+from avocado.core.decorators import skipIf
+from avocado.core.decorators import skipUnless

--- a/avocado/core/decorators.py
+++ b/avocado/core/decorators.py
@@ -1,0 +1,53 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2017
+# Author: Amador Pahim <apahim@redhat.com>
+
+from functools import wraps
+
+from . import exceptions
+
+
+def skip(message=None):
+    """
+    Decorator to skip a test.
+    """
+    def decorator(function):
+        if not isinstance(function, type):
+            @wraps(function)
+            def wrapper(*args, **kwargs):
+                raise exceptions.TestSkip(message)
+            function = wrapper
+        return function
+    return decorator
+
+
+def skipIf(condition, message=None):
+    """
+    Decorator to skip a test if a condition is True.
+    """
+    if condition:
+        return skip(message)
+    return _itself
+
+
+def skipUnless(condition, message=None):
+    """
+    Decorator to skip a test if a condition is False.
+    """
+    if not condition:
+        return skip(message)
+    return _itself
+
+
+def _itself(obj):
+    return obj

--- a/avocado/core/exceptions.py
+++ b/avocado/core/exceptions.py
@@ -177,6 +177,16 @@ class TestSkipError(TestBaseException):
     status = "SKIP"
 
 
+class TestSkip(TestBaseException):
+
+    """
+    Indictates that the test is skipped by a decorator.
+
+    Should be thrown when the skip decorators are used.
+    """
+    status = "SKIP"
+
+
 class TestFail(TestBaseException, AssertionError):
 
     """

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -469,6 +469,9 @@ class Test(unittest.TestCase):
         except exceptions.TestSkipError as details:
             stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
             raise exceptions.TestSkipError(details)
+        except exceptions.TestSkip as details:
+            stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
+            raise exceptions.TestSkip(details)
         except exceptions.TestTimeoutSkip as details:
             stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
             raise exceptions.TestTimeoutSkip(details)
@@ -478,6 +481,9 @@ class Test(unittest.TestCase):
             raise exceptions.TestSetupFail(details)
         try:
             testMethod()
+        except exceptions.TestSkip as details:
+            stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
+            raise exceptions.TestSkip(details)
         except exceptions.TestSkipError as details:
             stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
             skip_illegal_msg = ('Calling skip() in places other than '

--- a/selftests/functional/test_skiptests.py
+++ b/selftests/functional/test_skiptests.py
@@ -1,0 +1,97 @@
+import json
+import os
+import shutil
+import sys
+import tempfile
+
+if sys.version_info[:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
+
+from avocado.core import exit_codes
+from avocado.utils import process
+
+basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..')
+basedir = os.path.abspath(basedir)
+
+
+AVOCADO_TEST_SKIP_DECORATORS = """#!/usr/bin/env python
+import avocado
+from avocado_test_skip_lib import check_condition
+
+class AvocadoSkipTests(avocado.Test):
+
+
+    @avocado.skip('Test skipped')
+    def test1(self):
+        pass
+
+    @avocado.skipIf(check_condition(True),
+                    'Skipped due to the True condition')
+    def test2(self):
+        pass
+
+    @avocado.skipUnless(check_condition(False),
+                        'Skipped due to the False condition')
+    def test3(self):
+        pass
+
+    @avocado.skipIf(False)
+    def test4(self):
+        pass
+
+    @avocado.skipUnless(True)
+    def test5(self):
+        pass
+
+    @avocado.skip()
+    def test6(self):
+        pass
+"""
+
+
+AVOCADO_TEST_SKIP_LIB = """#!/usr/bin/env python
+
+def check_condition(condition):
+    if condition:
+        return True
+    return False
+"""
+
+
+class TestSkipDecorators(unittest.TestCase):
+
+    def setUp(self):
+        os.chdir(basedir)
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        self.test_module = os.path.join(self.tmpdir,
+                                        'avocado_test_skip_decorators.py')
+        with open(self.test_module, 'w') as f_test_module:
+            f_test_module.write(AVOCADO_TEST_SKIP_DECORATORS)
+        self.test_lib = os.path.join(self.tmpdir,
+                                     'avocado_test_skip_lib.py')
+        with open(self.test_lib, 'w') as f_test_lib:
+            f_test_lib.write(AVOCADO_TEST_SKIP_LIB)
+
+    def test_skip_decorators(self):
+        os.chdir(basedir)
+        cmd_line = ['./scripts/avocado',
+                    'run',
+                    '--sysinfo=off',
+                    '--job-results-dir',
+                    '%s' % self.tmpdir,
+                    '%s' % self.test_module,
+                    '--json -']
+        result = process.run(' '.join(cmd_line), ignore_status=True)
+        json_results = json.loads(result.stdout)
+        self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
+        self.assertEquals(json_results['pass'], 2)
+        self.assertEquals(json_results['skip'], 4)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Avocado does not support self.skip() to be called from inside a test.
This is a design decision that users have to comply with. On the other
hand, users keep requesting alternative ways to skip tests.

This patch creates the decorators skip, skipIf and skipUnless to be
used in test functions. Corresponding exceptions will be raised in
those cases.

Reference: https://trello.com/c/JK5Z5dql
Signed-off-by: Amador Pahim <apahim@redhat.com>

---
RFC: #1718 