### PR TITLE
Makefile: Don't fail when "make link" fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ develop:
 link: develop
 	for MAKEFILE in $(AVOCADO_EXTERNAL_PLUGINS); do\
 		if test -f $$MAKEFILE/Makefile -o -f $$MAKEFILE/setup.py; then echo ">> LINK $$MAKEFILE";\
-			if test -f $$MAKEFILE/Makefile; then AVOCADO_DIRNAME=$(AVOCADO_DIRNAME) make -C $$MAKEFILE link &>/dev/null;\
+			if test -f $$MAKEFILE/Makefile; then AVOCADO_DIRNAME=$(AVOCADO_DIRNAME) make -C $$MAKEFILE link &>/dev/null || echo ">> FAIL $$MAKEFILE";\
 			elif test -f $$MAKEFILE/setup.py; then cd $$MAKEFILE; $(PYTHON) setup.py develop $(PYTHON_DEVELOP_ARGS); cd -; fi;\
 		else echo ">> SKIP $$MAKEFILE"; fi;\
 	done


### PR DESCRIPTION
The "make link" feature goes through subdirs trying to either use
`setup.py` or `Makefile` to install all plugins. The problem is that
even when `Makefile` is present it might not support `make link` target
which results in failure. This patch instead of failure in this case
just lists "FAIL" followed by the module name.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>