### PR TITLE
Improve yaml_to_mux error messages

### DIFF
--- a/avocado/plugins/yaml_to_mux.py
+++ b/avocado/plugins/yaml_to_mux.py
@@ -310,7 +310,7 @@ class YamlToMux(CLI):
             try:
                 data.merge(create_from_yaml(multiplex_files, debug))
             except IOError as details:
-                logging.getLogger("avocado.app").error(details.strerror)
+                logging.getLogger("avocado.app").error(details)
                 sys.exit(exit_codes.AVOCADO_JOB_FAIL)
 
         # Deprecated --multiplex option


### PR DESCRIPTION
When we use args:--mux-yaml and the yaml file not existing it
show more detail error messages

Reference: https://trello.com/c/hYCrS1oI/900-improve-yaml-to-mux-error-messages
Signed-off-by: mengalong <alongmeng@gmail.com>