### PR TITLE
selftests: exclude E722 from pep8 check

### DIFF
--- a/selftests/checkall
+++ b/selftests/checkall
@@ -60,7 +60,7 @@ signed_off_check() {
 
 run_rc lint 'inspekt --exclude=.git lint'
 run_rc indent 'inspekt --exclude=.git indent'
-run_rc style 'inspekt --exclude=.git style'
+run_rc style 'inspekt --exclude=.git style --disable E501,E265,W601,E402,E722'
 run_rc boundaries 'selftests/modules_boundaries'
 run_rc signed-off-by signed_off_check
 if [ "$AVOCADO_PARALLEL_CHECK" ]; then


### PR DESCRIPTION
pep8 v2.3.0 introduced the check for bare except clause (E722). Until
now, we don't explicitly disable the pep8 checks we don't want because
inspekt has a default exclude list (E501, E265, W601 and E402).

Let's make explicit the exclude list for the checks we don't want in our
selftests, adding to the list the new E722 check.

Signed-off-by: Amador Pahim <apahim@redhat.com>