### PR TITLE
selftests: Don't produce results in default results dir [v2]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ script:
             echo
             echo
             git checkout $COMMIT || ERR=$(echo -e "$ERR\nUnable to checkout $(git log -1 --oneline $COMMIT)")
-            SELF_CHECK_CONTINUOUS=y make check || ERR=$(echo -e "$ERR\nmake check of $(git log -1 --oneline) failed")
+            AVOCADO_RESULTSDIR_CHECK=y SELF_CHECK_CONTINUOUS=y make check || ERR=$(echo -e "$ERR\nmake check of $(git log -1 --oneline) failed")
             make clean
         done
         if [ "$ERR" ]; then

--- a/selftests/checkall
+++ b/selftests/checkall
@@ -4,7 +4,7 @@ run_rc() {
     CHECK=$1
     shift
     echo -e "\n\e[32mRunning '$1'\e[0m"
-    eval $1
+    eval $*
     if [ $? != 0 ]; then
         echo -e "\e[31m$CHECK FAILED\e[0m"
         ERR+=("$CHECK")

--- a/selftests/checkall
+++ b/selftests/checkall
@@ -1,5 +1,7 @@
 #!/bin/bash
 ERR=()
+RESULTS_DIR=$(./scripts/avocado config | grep datadir.paths.logs_dir | awk '{print $2}')
+
 run_rc() {
     CHECK=$1
     shift
@@ -58,6 +60,23 @@ signed_off_check() {
     fi
 }
 
+
+results_dir_content() {
+    NOW="$(ls $RESULTS_DIR)"
+    if [ "$(echo $* | xargs)" != "$(echo $NOW | xargs)" ]; then
+        echo "The output of 'ls ~/avocado/job-results/' is not the same as before running the checks"
+        echo "ORIGINAL:"
+        echo "$*"
+        echo "NOW:"
+        echo "$NOW"
+        return 1
+    else:
+        echo "No extra files were created in '~/avocado/job-results/'"
+        return 0
+    fi
+}
+
+[ "$SKIP_RESULTSDIR_CHECK" ] || RESULTS_DIR_CONTENT="$(ls $RESULTS_DIR)"
 run_rc lint 'inspekt --exclude=.git lint'
 run_rc indent 'inspekt --exclude=.git indent'
 run_rc style 'inspekt --exclude=.git style --disable E501,E265,W601,E402,E722'
@@ -72,6 +91,7 @@ else
     [ ! $SELF_CHECK_CONTINUOUS ] && CMD+=" --failfast on"
     run_rc selftests "$CMD"
 fi
+[ "$SKIP_RESULTSDIR_CHECK" ] || run_rc job-results results_dir_content "$RESULTS_DIR_CONTENT"
 
 if [ "$ERR" ]; then
     echo -e "\e[31m"

--- a/selftests/functional/test_unittest_compat.py
+++ b/selftests/functional/test_unittest_compat.py
@@ -1,5 +1,7 @@
 import os
 import sys
+import shutil
+import tempfile
 
 if sys.version_info[:2] == (2, 6):
     import unittest2 as unittest
@@ -16,7 +18,14 @@ basedir = os.path.abspath(basedir)
 
 UNITTEST_GOOD = """from avocado import Test
 from unittest import main
-class AvocadoPassTest(Test):
+
+
+class CustomBaselogDirInit(Test):
+    def __init__(self, *args, **kwargs):
+        super(CustomBaselogDirInit, self).__init__(base_logdir="%s", *args,
+                                                   **kwargs)
+
+class AvocadoPassTest(CustomBaselogDirInit):
     def test(self):
         self.assertTrue(True)
 if __name__ == '__main__':
@@ -25,7 +34,14 @@ if __name__ == '__main__':
 
 UNITTEST_FAIL = """from avocado import Test
 from unittest import main
-class AvocadoFailTest(Test):
+
+
+class CustomBaselogDirInit(Test):
+    def __init__(self, *args, **kwargs):
+        super(CustomBaselogDirInit, self).__init__(base_logdir="%s", *args,
+                                                   **kwargs)
+
+class AvocadoFailTest(CustomBaselogDirInit):
     def test(self):
         self.fail('This test is supposed to fail')
 if __name__ == '__main__':
@@ -34,7 +50,14 @@ if __name__ == '__main__':
 
 UNITTEST_ERROR = """from avocado import Test
 from unittest import main
-class AvocadoErrorTest(Test):
+
+
+class CustomBaselogDirInit(Test):
+    def __init__(self, *args, **kwargs):
+        super(CustomBaselogDirInit, self).__init__(base_logdir="%s", *args,
+                                                   **kwargs)
+
+class AvocadoErrorTest(CustomBaselogDirInit):
     def test(self):
         self.error('This test is supposed to error')
 if __name__ == '__main__':
@@ -45,6 +68,7 @@ if __name__ == '__main__':
 class UnittestCompat(unittest.TestCase):
 
     def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix="avocado_" + __name__)
         self.original_pypath = os.environ.get('PYTHONPATH')
         if self.original_pypath is not None:
             os.environ['PYTHONPATH'] = '%s:%s' % (
@@ -53,17 +77,17 @@ class UnittestCompat(unittest.TestCase):
             os.environ['PYTHONPATH'] = '%s' % basedir
         self.unittest_script_good = script.TemporaryScript(
             'unittest_good.py',
-            UNITTEST_GOOD,
+            UNITTEST_GOOD % self.tmpdir,
             'avocado_as_unittest_functional')
         self.unittest_script_good.save()
         self.unittest_script_fail = script.TemporaryScript(
             'unittest_fail.py',
-            UNITTEST_FAIL,
+            UNITTEST_FAIL % self.tmpdir,
             'avocado_as_unittest_functional')
         self.unittest_script_fail.save()
         self.unittest_script_error = script.TemporaryScript(
             'unittest_error.py',
-            UNITTEST_ERROR,
+            UNITTEST_ERROR % self.tmpdir,
             'avocado_as_unittest_functional')
         self.unittest_script_error.save()
 
@@ -88,6 +112,9 @@ class UnittestCompat(unittest.TestCase):
         self.assertIn('Ran 1 test in', result.stderr)
         self.assertIn('This test is supposed to error', result.stderr)
         self.assertIn('FAILED (errors=1)', result.stderr)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
 
 
 if __name__ == '__main__':

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -1,6 +1,8 @@
 import argparse
 import os
+import shutil
 import sys
+import tempfile
 if sys.version_info[:2] == (2, 6):
     import unittest2 as unittest
 else:
@@ -15,6 +17,9 @@ from avocado.utils import path as utils_path
 
 class JobTest(unittest.TestCase):
 
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix="avocado_" + __name__)
+
     @staticmethod
     def _find_simple_test_candidates(candidates=['true', 'time', 'uptime']):
         found = []
@@ -26,29 +31,30 @@ class JobTest(unittest.TestCase):
         return found
 
     def test_job_empty_suite(self):
-        args = argparse.Namespace()
+        args = argparse.Namespace(logdir=self.tmpdir)
         empty_job = job.Job(args)
         self.assertIsNone(empty_job.test_suite)
 
     def test_job_empty_has_id(self):
-        args = argparse.Namespace()
+        args = argparse.Namespace(logdir=self.tmpdir)
         empty_job = job.Job(args)
         self.assertIsNotNone(empty_job.unique_id)
 
     def test_job_test_suite_not_created(self):
-        args = argparse.Namespace()
+        args = argparse.Namespace(logdir=self.tmpdir)
         myjob = job.Job(args)
         self.assertIsNone(myjob.test_suite)
 
     def test_job_create_test_suite_empty(self):
-        args = argparse.Namespace()
+        args = argparse.Namespace(logdir=self.tmpdir)
         myjob = job.Job(args)
         self.assertRaises(exceptions.OptionValidationError,
                           myjob.create_test_suite)
 
     def test_job_create_test_suite_simple(self):
         simple_tests_found = self._find_simple_test_candidates()
-        args = argparse.Namespace(reference=simple_tests_found)
+        args = argparse.Namespace(reference=simple_tests_found,
+                                  logdir=self.tmpdir)
         myjob = job.Job(args)
         myjob.create_test_suite()
         self.assertEqual(len(simple_tests_found), len(myjob.test_suite))
@@ -64,7 +70,8 @@ class JobTest(unittest.TestCase):
                 self.test_suite = filtered_test_suite
                 super(JobFilterTime, self).pre_tests()
         simple_tests_found = self._find_simple_test_candidates()
-        args = argparse.Namespace(reference=simple_tests_found)
+        args = argparse.Namespace(reference=simple_tests_found,
+                                  logdir=self.tmpdir)
         myjob = JobFilterTime(args)
         myjob.create_test_suite()
         myjob.pre_tests()
@@ -72,7 +79,8 @@ class JobTest(unittest.TestCase):
 
     def test_job_run_tests(self):
         simple_tests_found = self._find_simple_test_candidates(['true'])
-        args = argparse.Namespace(reference=simple_tests_found)
+        args = argparse.Namespace(reference=simple_tests_found,
+                                  logdir=self.tmpdir)
         myjob = job.Job(args)
         myjob.create_test_suite()
         self.assertEqual(myjob.run_tests(),
@@ -85,7 +93,8 @@ class JobTest(unittest.TestCase):
                     f.write(self.unique_id[::-1])
                 super(JobLogPost, self).post_tests()
         simple_tests_found = self._find_simple_test_candidates()
-        args = argparse.Namespace(reference=simple_tests_found)
+        args = argparse.Namespace(reference=simple_tests_found,
+                                  logdir=self.tmpdir)
         myjob = JobLogPost(args)
         myjob.create_test_suite()
         myjob.pre_tests()
@@ -111,13 +120,17 @@ class JobTest(unittest.TestCase):
                     f.write(self.unique_id[::-1])
                 super(JobFilterLog, self).post_tests()
         simple_tests_found = self._find_simple_test_candidates()
-        args = argparse.Namespace(reference=simple_tests_found)
+        args = argparse.Namespace(reference=simple_tests_found,
+                                  logdir=self.tmpdir)
         myjob = JobFilterLog(args)
         self.assertEqual(myjob.run(),
                          exit_codes.AVOCADO_ALL_OK)
         self.assertLessEqual(len(myjob.test_suite), 1)
         self.assertEqual(myjob.unique_id[::-1],
                          open(os.path.join(myjob.logdir, "reversed_id")).read())
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
 
 
 if __name__ == '__main__':

--- a/selftests/unit/test_jsonresult.py
+++ b/selftests/unit/test_jsonresult.py
@@ -29,7 +29,8 @@ class JSONResultTest(unittest.TestCase):
 
         self.tmpfile = tempfile.mkstemp()
         self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
-        args = argparse.Namespace(json_output=self.tmpfile[1])
+        args = argparse.Namespace(json_output=self.tmpfile[1],
+                                  logdir=self.tmpdir)
         self.job = job.Job(args)
         self.test_result = Result(FakeJob(args))
         self.test_result.filename = self.tmpfile[1]

--- a/selftests/unit/test_test.py
+++ b/selftests/unit/test_test.py
@@ -21,13 +21,11 @@ false
 """
 
 
-class DummyTest(test.Test):
-
-    def test(self):
-        pass
-
-
 class TestClassTestUnit(unittest.TestCase):
+
+    class DummyTest(test.Test):
+        def test(self):
+            pass
 
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp(prefix="avocado_" + __name__)
@@ -39,8 +37,8 @@ class TestClassTestUnit(unittest.TestCase):
     def testUglyName(self):
         def run(name, path_name):
             """ Initialize test and check the dirs were created """
-            tst = DummyTest("test", test.TestName(1, name),
-                            base_logdir=self.tmpdir)
+            tst = self.DummyTest("test", test.TestName(1, name),
+                                 base_logdir=self.tmpdir)
             self.assertEqual(os.path.basename(tst.logdir), path_name)
             self.assertTrue(os.path.exists(tst.logdir))
             self.assertEqual(os.path.dirname(os.path.dirname(tst.logdir)),
@@ -64,7 +62,8 @@ class TestClassTestUnit(unittest.TestCase):
 
     def testLongName(self):
         def check(uid, name, variant, exp_logdir):
-            tst = DummyTest("test", test.TestName(uid, name, variant))
+            tst = self.DummyTest("test", test.TestName(uid, name, variant),
+                                 base_logdir=self.tmpdir)
             self.assertEqual(os.path.basename(tst.logdir), exp_logdir)
             return tst
 
@@ -100,8 +99,8 @@ class TestClassTestUnit(unittest.TestCase):
     def testAllDirsExistsNoHang(self):
         flexmock(os.path)
         os.path.should_receive('exists').and_return(True)
-        self.assertRaises(exceptions.TestSetupFail, DummyTest, "test",
-                          test.TestName(1, "name"))
+        self.assertRaises(exceptions.TestSetupFail, self.DummyTest, "test",
+                          test.TestName(1, "name"), base_logdir=self.tmpdir)
 
 
 class TestClassTest(unittest.TestCase):
@@ -245,7 +244,7 @@ class SkipTest(unittest.TestCase):
     def tearDown(self):
         for tst in self.tests:
             try:
-                shutil.rmtree(os.path.dirname(tst.logdir))
+                shutil.rmtree(os.path.dirname(os.path.dirname(tst.logdir)))
             except Exception:
                 pass
 

--- a/selftests/unit/test_xunit.py
+++ b/selftests/unit/test_xunit.py
@@ -35,7 +35,7 @@ class xUnitSucceedTest(unittest.TestCase):
 
         self.tmpfile = tempfile.mkstemp()
         self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
-        args = argparse.Namespace()
+        args = argparse.Namespace(logdir=self.tmpdir)
         args.xunit_output = self.tmpfile[1]
         self.job = job.Job(args)
         self.test_result = Result(FakeJob(args))


### PR DESCRIPTION
This pull request fixes all places where we were producing results by running selftests and then it adds a check that no new results are produced throughout the `make check` execution.

v1: https://github.com/avocado-framework/avocado/pull/1722

Changes:
```
v2: Get the logs_dir from `avocado config`
v2: Enable resultsdir check by default (Use SKIP_RESULTSDIR_CHECK to disable it)
v2: Moved DummyTest class to class namespace rather than using get_tst method
v2: NOT moved the AvocadoPass class from setUp to class namespace because it's
    a local var and I prefer the current solution.
v2: NOT using the resultscheck for checks outside checkall as that would require Makefile
    changes and I don't see it important enough.
```