### PR TITLE
avocado.spec: do not require pystache on base avocado package [v2]

### DIFF
--- a/avocado.spec
+++ b/avocado.spec
@@ -13,7 +13,7 @@ Group: Development/Tools
 URL: http://avocado-framework.github.io/
 Source0: https://github.com/avocado-framework/%{name}/archive/%{commit}/%{name}-%{version}-%{shortcommit}.tar.gz
 BuildArch: noarch
-Requires: python, python-requests, fabric, pyliblzma, libvirt-python, pystache, gdb, gdb-gdbserver, python-stevedore, aexpect
+Requires: python, python-requests, fabric, pyliblzma, libvirt-python, gdb, gdb-gdbserver, python-stevedore, aexpect
 BuildRequires: python2-devel, python-setuptools, python-docutils, python-mock, python-psutil, python-sphinx, python-requests, aexpect, pystache, yum, python-stevedore, python-lxml, perl-Test-Harness, fabric, python-flexmock
 
 %if 0%{?el6}


### PR DESCRIPTION
The pystache package should only be a requirement for the HTML
result plugin, not for the base avocado package.

Signed-off-by: Cleber Rosa <crosa@redhat.com>

---

Changes from v1:
 * Rebased because of PEP8 erros (skipping them is already on master)