### PR TITLE
Add skip, skipIf and skipUnless decorators [V2]

### DIFF
--- a/avocado/__init__.py
+++ b/avocado/__init__.py
@@ -13,10 +13,19 @@
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
 
-__all__ = ['main', 'Test', 'VERSION', 'fail_on']
+__all__ = ['main',
+           'Test',
+           'VERSION',
+           'fail_on',
+           'skip',
+           'skipIf',
+           'skipUnless']
 
 
 from avocado.core.job import main
 from avocado.core.test import Test
 from avocado.core.version import VERSION
 from avocado.core.exceptions import fail_on
+from avocado.core.decorators import skip
+from avocado.core.decorators import skipIf
+from avocado.core.decorators import skipUnless

--- a/avocado/core/decorators.py
+++ b/avocado/core/decorators.py
@@ -1,0 +1,53 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2017
+# Author: Amador Pahim <apahim@redhat.com>
+
+from functools import wraps
+
+from . import exceptions
+
+
+def skip(message=None):
+    """
+    Decorator to skip a test.
+    """
+    def decorator(function):
+        if not isinstance(function, type):
+            @wraps(function)
+            def wrapper(*args, **kwargs):
+                raise exceptions.TestDecoratorSkip(message)
+            function = wrapper
+        return function
+    return decorator
+
+
+def skipIf(condition, message=None):
+    """
+    Decorator to skip a test if a condition is True.
+    """
+    if condition:
+        return skip(message)
+    return _itself
+
+
+def skipUnless(condition, message=None):
+    """
+    Decorator to skip a test if a condition is False.
+    """
+    if not condition:
+        return skip(message)
+    return _itself
+
+
+def _itself(obj):
+    return obj

--- a/avocado/core/exceptions.py
+++ b/avocado/core/exceptions.py
@@ -177,6 +177,26 @@ class TestSkipError(TestBaseException):
     status = "SKIP"
 
 
+class TestSetupSkip(TestBaseException):
+
+    """
+    Indictates that the test is skipped in setUp().
+
+    Should be thrown when skip() is used in setUp().
+    """
+    status = "SKIP"
+
+
+class TestDecoratorSkip(TestBaseException):
+
+    """
+    Indictates that the test is skipped by a decorator.
+
+    Should be thrown when the skip decorators are used.
+    """
+    status = "SKIP"
+
+
 class TestFail(TestBaseException, AssertionError):
 
     """

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -466,25 +466,28 @@ class Test(unittest.TestCase):
         stderr_check_exception = None
         try:
             self.setUp()
-        except exceptions.TestSkipError as details:
+        except (exceptions.TestSetupSkip,
+                exceptions.TestDecoratorSkip,
+                exceptions.TestTimeoutSkip,
+                exceptions.TestSkipError) as details:
             stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
             raise exceptions.TestSkipError(details)
-        except exceptions.TestTimeoutSkip as details:
-            stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
-            raise exceptions.TestTimeoutSkip(details)
         except:  # Old-style exceptions are not inherited from Exception()
             stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
             details = sys.exc_info()[1]
             raise exceptions.TestSetupFail(details)
         try:
             testMethod()
-        except exceptions.TestSkipError as details:
+        except exceptions.TestSetupSkip as details:
             stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
             skip_illegal_msg = ('Calling skip() in places other than '
                                 'setUp() is not allowed in avocado, you '
                                 'must fix your test. Original skip exception: '
                                 '%s' % details)
             raise exceptions.TestError(skip_illegal_msg)
+        except exceptions.TestDecoratorSkip as details:
+            stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
+            raise exceptions.TestSkipError(details)
         except:  # Old-style exceptions are not inherited from Exception()
             stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
             details = sys.exc_info()[1]
@@ -498,12 +501,19 @@ class Test(unittest.TestCase):
         finally:
             try:
                 self.tearDown()
-            except exceptions.TestSkipError as details:
+            except exceptions.TestSetupSkip as details:
                 stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
                 skip_illegal_msg = ('Calling skip() in places other than '
                                     'setUp() is not allowed in avocado, '
                                     'you must fix your test. Original skip '
                                     'exception: %s' % details)
+                raise exceptions.TestError(skip_illegal_msg)
+            except exceptions.TestDecoratorSkip as details:
+                stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
+                skip_illegal_msg = ('Using skip decorators after the test '
+                                    'will have no effect, you must fix your '
+                                    'test. Original skip exception: %s' %
+                                    details)
                 raise exceptions.TestError(skip_illegal_msg)
             except:  # avoid old-style exception failures
                 stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
@@ -669,7 +679,7 @@ class Test(unittest.TestCase):
         :param message: an optional message that will be recorded in the logs
         :type message: str
         """
-        raise exceptions.TestSkipError(message)
+        raise exceptions.TestSetupSkip(message)
 
     def fetch_asset(self, name, asset_hash=None, algorithm='sha1',
                     locations=None, expire=None):

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -827,6 +827,93 @@ a timeout of 3 seconds before Avocado ends the test forcefully by sending a
 :class:`avocado.core.exceptions.TestTimeoutError`.
 
 
+Skipping Tests
+==============
+
+Avocado offers some options for the test writers to skip a test:
+
+Test ``skip()`` Method
+----------------------
+
+Using the ``skip()`` method available in the Test API is only allowed
+inside the ``setUp()`` method. Calling ``skip()`` from inside the test is not
+allowed as, by concept, you cannot skip a test after it's already initiated.
+
+The test below::
+
+    import avocado
+
+    class MyTestClass(avocado.Test):
+
+        def setUp(self):
+            if self.check_condition():
+                self.skip('Test skipped due to the condition.')
+
+        def test(self):
+            pass
+
+        def check_condition(self):
+            return True
+
+Will produce the following result::
+
+    $ avocado run test_skip_method.py 
+    JOB ID     : 1bd8642400e3b6c584979504cafc4318f7a5fb65
+    JOB LOG    : $HOME/avocado/job-results/job-2017-02-03T17.16-1bd8642/job.log
+    TESTS      : 1
+     (1/1) test_skip_method.py:MyTestClass.test: SKIP
+    RESULTS    : PASS 0 | ERROR 0 | FAIL 0 | SKIP 1 | WARN 0 | INTERRUPT 0
+    TESTS TIME : 0.00 s
+    JOB HTML   : $HOME/avocado/job-results/job-2017-02-03T17.16-1bd8642/html/results.html
+
+
+Avocado Skip Decorators
+-----------------------
+
+Another way to skip tests is by using the Avocado skip decorators:
+
+- ``@avocado.skip(reason)``: Skips a test.
+- ``@avocado.skipIf(condition, reason)``: Skips a test if the condition is
+  ``True``.
+- ``@avocado.skipUnless(condition, reason)``: Skips a test if the condition is
+  ``False``
+
+Those decorators can be used with both ``setUp()`` method and/or and in the
+test methods. The test below::
+
+    import avocado
+
+    class MyTest(avocado.Test):
+
+        @avocado.skipIf(1 == 1, 'Skipping on True condition.')
+        def test1(self):
+            pass
+
+        @avocado.skip("Don't want this test now.")
+        def test2(self):
+            pass
+
+        @avocado.skipUnless(1 == 1, 'Skipping on False condition.')
+        def test3(self):
+            pass
+
+Will produce the following result::
+
+    $ avocado run  test_skip_decorators.py
+    JOB ID     : 59c815f6a42269daeaf1e5b93e52269fb8a78119
+    JOB LOG    : $HOME/avocado/job-results/job-2017-02-03T17.41-59c815f/job.log
+    TESTS      : 3
+     (1/3) test_skip_decorators.py:MyTest.test1: SKIP
+     (2/3) test_skip_decorators.py:MyTest.test2: SKIP
+     (3/3) test_skip_decorators.py:MyTest.test3: PASS (0.02 s)
+    RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 2 | WARN 0 | INTERRUPT 0
+    TESTS TIME : 0.03 s
+    JOB HTML   : $HOME/avocado/job-results/job-2017-02-03T17.41-59c815f/html/results.html
+
+Notice the ``test3`` was not skipped because the provided condition was
+not ``False``.
+
+
 Docstring Directives
 ====================
 

--- a/selftests/functional/test_skiptests.py
+++ b/selftests/functional/test_skiptests.py
@@ -1,0 +1,97 @@
+import json
+import os
+import shutil
+import sys
+import tempfile
+
+if sys.version_info[:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
+
+from avocado.core import exit_codes
+from avocado.utils import process
+from avocado.utils import script
+
+basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..')
+basedir = os.path.abspath(basedir)
+
+
+AVOCADO_TEST_SKIP_DECORATORS = """
+import avocado
+from lib_skip_decorators import check_condition
+
+class AvocadoSkipTests(avocado.Test):
+
+    @avocado.skip('Test skipped')
+    def test1(self):
+        pass
+
+    @avocado.skipIf(check_condition(True),
+                    'Skipped due to the True condition')
+    def test2(self):
+        pass
+
+    @avocado.skipUnless(check_condition(False),
+                        'Skipped due to the False condition')
+    def test3(self):
+        pass
+
+    @avocado.skipIf(False)
+    def test4(self):
+        pass
+
+    @avocado.skipUnless(True)
+    def test5(self):
+        pass
+
+    @avocado.skip()
+    def test6(self):
+        pass
+"""
+
+
+AVOCADO_TEST_SKIP_LIB = """
+def check_condition(condition):
+    if condition:
+        return True
+    return False
+"""
+
+
+class TestSkipDecorators(unittest.TestCase):
+
+    def setUp(self):
+        os.chdir(basedir)
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+
+        test_path = os.path.join(self.tmpdir, 'test_skip_decorators.py')
+        self.test_module = script.Script(test_path,
+                                         AVOCADO_TEST_SKIP_DECORATORS)
+        self.test_module.save()
+
+        lib_path = os.path.join(self.tmpdir, 'lib_skip_decorators.py')
+        self.test_lib = script.Script(lib_path, AVOCADO_TEST_SKIP_LIB)
+        self.test_lib.save()
+
+    def test_skip_decorators(self):
+        os.chdir(basedir)
+        cmd_line = ['./scripts/avocado',
+                    'run',
+                    '--sysinfo=off',
+                    '--job-results-dir',
+                    '%s' % self.tmpdir,
+                    '%s' % self.test_module,
+                    '--json -']
+        result = process.run(' '.join(cmd_line), ignore_status=True)
+        json_results = json.loads(result.stdout)
+        self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
+        self.assertEquals(json_results['pass'], 2)
+        self.assertEquals(json_results['skip'], 4)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
v2:
- Use `avocado.utils.script` in selftests.
- Include doccumentation.
- Better naming and organization for skip exceptions.

v1: #1725 
- Improve selftests.
- Move decorators from `avocado.Test` to `avocado`.

RFC: #1718 