### PR TITLE
selftests/functional/test_teststmpdir.py: use .sh extension for simpl…

### DIFF
--- a/selftests/functional/test_teststmpdir.py
+++ b/selftests/functional/test_teststmpdir.py
@@ -46,7 +46,7 @@ class TestsTmpDirTests(unittest.TestCase):
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
         self.simple_test = script.TemporaryScript(
-            'test_simple.py',
+            'test_simple.sh',
             SIMPLE_SCRIPT)
         self.simple_test.save()
         self.instrumented_test = script.TemporaryScript(


### PR DESCRIPTION
…e test

The SIMPLE test used here contains SHELL code, so it doesn't make sense
to name with a .py extension.

Signed-off-by: Cleber Rosa <crosa@redhat.com>