### PR TITLE
Python 2.6: Drop support for it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 python:
     - "2.7_with_system_site_packages"
-    - "2.6"
 
 branches:
     only:

--- a/avocado.spec
+++ b/avocado.spec
@@ -7,24 +7,14 @@
 Summary: Framework with tools and libraries for Automated Testing
 Name: avocado
 Version: 45.0
-Release: 0%{?dist}
+Release: 1%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.github.io/
 Source0: https://github.com/avocado-framework/%{name}/archive/%{commit}/%{name}-%{version}-%{shortcommit}.tar.gz
 BuildArch: noarch
-Requires: python, python-requests, fabric, pyliblzma, libvirt-python, gdb, gdb-gdbserver, python-stevedore, aexpect
-BuildRequires: python2-devel, python-setuptools, python-docutils, python-mock, python-psutil, python-sphinx, python-requests, aexpect, pystache, yum, python-stevedore, python-lxml, perl-Test-Harness, fabric, python-flexmock
-
-%if 0%{?el6}
-Requires: PyYAML
-Requires: python-argparse, python-importlib, python-logutils, python-unittest2, procps
-BuildRequires: PyYAML
-BuildRequires: python-argparse, python-importlib, python-logutils, python-unittest2, procps
-%else
-Requires: python-yaml, procps-ng
-BuildRequires: python-yaml, procps-ng
-%endif
+Requires: python, python-requests, fabric, pyliblzma, libvirt-python, gdb, gdb-gdbserver, python-stevedore, python-yaml, procps-ng, aexpect
+BuildRequires: python2-devel, python-setuptools, python-docutils, python-mock, python-psutil, python-sphinx, python-requests, aexpect, pystache, yum, python-stevedore, python-lxml, perl-Test-Harness, fabric, python-flexmock, python-yaml, procps-ng
 
 %if 0%{?fedora} >= 25
 BuildRequires: kmod
@@ -115,6 +105,9 @@ examples of how to write tests on your own.
 %{_datadir}/avocado/wrappers
 
 %changelog
+* Fri Feb  3 2017 Cleber Rosa <cleber@redhat.com> - 45.0-1
+- Removed support for EL6 requirements
+
 * Tue Jan 17 2017 Cleber Rosa <cleber@redhat.com> - 45.0-0
 - New upstream release
 

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -26,6 +26,7 @@ import re
 import shutil
 import sys
 import time
+import unittest
 
 from . import data_dir
 from . import exceptions
@@ -41,11 +42,6 @@ from ..utils import process
 from ..utils import stacktrace
 from .settings import settings
 from .version import VERSION
-
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
 
 
 #: Environment variable used to store the location of a temporary

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -16,8 +16,3 @@ psutil==3.1.1
 # stevedore for loading "new style" plugins
 stevedore==1.8.0
 lxml>=3.4.4
-# All python 2.6 specific requirements (backports)
-argparse==1.3.0; python_version < '2.7'
-logutils==0.3.3; python_version < '2.7'
-importlib==1.0.3; python_version < '2.7'
-unittest2==1.0.0; python_version < '2.7'

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,13 +10,6 @@ pyliblzma>=0.5.3
 # REST client (avocado.core.restclient)
 requests>=1.2.3
 # stevedore for loading "new style" plugins
-stevedore>=1.8.0; python_version >= '2.7'
-# stevedore-1.11.0 won't support python2.6 anymore
-stevedore>=1.8.0,<=1.10.0; python_version < '2.7'
-# Additional python 2.6 specific requirements for avocado and unittests (backports)
-argparse>=1.3.0; python_version < '2.7'
-logutils>=0.3.3; python_version < '2.7'
-importlib>=1.0.3; python_version < '2.7'
-unittest2>=1.0.0; python_version < '2.7'
+stevedore>=1.8.0
 # Aexpect is now used on Docker plugin
 aexpect>=1.2.0

--- a/selftests/doc/test_doc_build.py
+++ b/selftests/doc/test_doc_build.py
@@ -4,13 +4,8 @@ Build documentation and report whether we had warning/error messages.
 This is geared towards documentation build regression testing.
 """
 import os
-import sys
 import urllib
-
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 from avocado.utils import process
 

--- a/selftests/functional/test_argument_parsing.py
+++ b/selftests/functional/test_argument_parsing.py
@@ -1,11 +1,6 @@
 import os
-import sys
 import glob
-
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 from avocado.core import data_dir
 from avocado.core import job_id

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -11,13 +11,9 @@ import tempfile
 import time
 import xml.dom.minidom
 import zipfile
+import unittest
 
 import pkg_resources
-
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
 
 from avocado.core import exit_codes
 from avocado.utils import astring

--- a/selftests/functional/test_export_variables.py
+++ b/selftests/functional/test_export_variables.py
@@ -1,12 +1,7 @@
 import os
-import sys
 import tempfile
 import shutil
-
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 from avocado import VERSION
 from avocado.core import exit_codes

--- a/selftests/functional/test_gdb.py
+++ b/selftests/functional/test_gdb.py
@@ -1,12 +1,7 @@
 import os
-import sys
 import shutil
 import tempfile
-
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 from avocado.utils import process
 

--- a/selftests/functional/test_interrupt.py
+++ b/selftests/functional/test_interrupt.py
@@ -1,17 +1,12 @@
 import os
-import sys
 import tempfile
 import time
 import shutil
 import stat
+import unittest
 
 import aexpect
 import psutil
-
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
 
 from avocado.utils import wait
 from avocado.utils import script

--- a/selftests/functional/test_job_timeout.py
+++ b/selftests/functional/test_job_timeout.py
@@ -1,14 +1,9 @@
 import glob
 import os
-import sys
 import tempfile
 import shutil
 import xml.dom.minidom
-
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 from avocado.core import exit_codes
 from avocado.utils import process

--- a/selftests/functional/test_journal.py
+++ b/selftests/functional/test_journal.py
@@ -1,14 +1,9 @@
 import os
-import sys
 import json
 import sqlite3
 import tempfile
 import shutil
-
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 from avocado.core import exit_codes
 from avocado.utils import process

--- a/selftests/functional/test_loader.py
+++ b/selftests/functional/test_loader.py
@@ -1,16 +1,11 @@
 import os
-import sys
 import subprocess
 import time
 import stat
 import tempfile
 import shutil
 import signal
-
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 from avocado.core import exit_codes
 from avocado.utils import script

--- a/selftests/functional/test_lv_utils.py
+++ b/selftests/functional/test_lv_utils.py
@@ -7,15 +7,8 @@ from avocado.utils import process, lv_utils
 import glob
 import os
 import shutil
-import sys
 import tempfile
 import unittest
-
-
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
 
 
 class LVUtilsTest(unittest.TestCase):

--- a/selftests/functional/test_multiplex.py
+++ b/selftests/functional/test_multiplex.py
@@ -1,14 +1,9 @@
 #!/usr/bin/env python
 
 import os
-import sys
 import tempfile
 import shutil
-
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 from avocado.core import exit_codes
 from avocado.utils import process

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -2,16 +2,11 @@ import json
 import tempfile
 import os
 import re
-import sys
 import shutil
+import unittest
 from xml.dom import minidom
 
 import pkg_resources
-
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
 
 from avocado.core import exit_codes
 from avocado.core.output import TermSupport

--- a/selftests/functional/test_output_check.py
+++ b/selftests/functional/test_output_check.py
@@ -1,12 +1,7 @@
 import os
-import sys
 import tempfile
 import shutil
-
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 from avocado.core import exit_codes
 from avocado.utils import process

--- a/selftests/functional/test_plugin_diff.py
+++ b/selftests/functional/test_plugin_diff.py
@@ -2,14 +2,9 @@
 
 import glob
 import os
-import sys
 import tempfile
 import shutil
-
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 from avocado.core import exit_codes
 from avocado.utils import process

--- a/selftests/functional/test_plugin_jobscripts.py
+++ b/selftests/functional/test_plugin_jobscripts.py
@@ -1,12 +1,7 @@
 import os
 import shutil
-import sys
 import tempfile
-
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 from avocado.core import exit_codes
 from avocado.utils import process

--- a/selftests/functional/test_replay_basic.py
+++ b/selftests/functional/test_replay_basic.py
@@ -2,14 +2,9 @@
 
 import glob
 import os
-import sys
 import tempfile
 import shutil
-
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 from avocado.core import exit_codes
 from avocado.utils import process

--- a/selftests/functional/test_replay_external_runner.py
+++ b/selftests/functional/test_replay_external_runner.py
@@ -2,14 +2,9 @@
 
 import glob
 import os
-import sys
 import tempfile
 import shutil
-
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 from avocado.core import exit_codes
 from avocado.utils import process

--- a/selftests/functional/test_replay_failfast.py
+++ b/selftests/functional/test_replay_failfast.py
@@ -2,14 +2,9 @@
 
 import glob
 import os
-import sys
 import tempfile
 import shutil
-
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 from avocado.core import exit_codes
 from avocado.utils import process

--- a/selftests/functional/test_standalone.py
+++ b/selftests/functional/test_standalone.py
@@ -1,10 +1,5 @@
 import os
-import sys
-
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 from avocado.core import exit_codes
 from avocado.utils import process

--- a/selftests/functional/test_streams.py
+++ b/selftests/functional/test_streams.py
@@ -1,12 +1,7 @@
 import os
 import shutil
-import sys
 import tempfile
-
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 from avocado.core import exit_codes
 from avocado.utils import process

--- a/selftests/functional/test_sysinfo.py
+++ b/selftests/functional/test_sysinfo.py
@@ -1,12 +1,7 @@
 import os
-import sys
 import shutil
 import tempfile
-
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 from avocado.core import exit_codes
 from avocado.utils import process

--- a/selftests/functional/test_teststmpdir.py
+++ b/selftests/functional/test_teststmpdir.py
@@ -1,14 +1,9 @@
 #!/usr/bin/env python
 
 import os
-import sys
 import tempfile
 import shutil
-
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 from avocado.core import exit_codes
 from avocado.core import test

--- a/selftests/functional/test_thirdparty_bugs.py
+++ b/selftests/functional/test_thirdparty_bugs.py
@@ -1,11 +1,8 @@
 import json
-import sys
-from avocado.utils import download
+import unittest
+import urllib2
 
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
+from avocado.utils import download
 
 
 class TestThirdPartyBugs(unittest.TestCase):
@@ -25,7 +22,7 @@ class TestThirdPartyBugs(unittest.TestCase):
                              'change the avocado.conf option '
                              '"reject_unknown_hosts" defaults to True.' %
                              'https://github.com/paramiko/paramiko/issues/243')
-        except download.urllib2.URLError as details:
+        except urllib2.URLError as details:
             raise unittest.SkipTest(details)
 
 

--- a/selftests/functional/test_unittest_compat.py
+++ b/selftests/functional/test_unittest_compat.py
@@ -2,11 +2,7 @@ import os
 import sys
 import shutil
 import tempfile
-
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 from avocado.utils import script
 from avocado.utils import process

--- a/selftests/functional/test_utils.py
+++ b/selftests/functional/test_utils.py
@@ -6,16 +6,10 @@ import stat
 import sys
 import tempfile
 import time
+import unittest
 
 from avocado.utils.filelock import FileLock
 from avocado.utils.stacktrace import prepare_exc_info
-
-
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
-
 from avocado.utils import process
 
 

--- a/selftests/functional/test_wrapper.py
+++ b/selftests/functional/test_wrapper.py
@@ -1,17 +1,13 @@
 import os
-import sys
 import tempfile
 import shutil
-
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 from avocado.core import exit_codes
 from avocado.utils import process
 from avocado.utils import script
 from avocado.utils import path as utils_path
+
 
 basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..')
 basedir = os.path.abspath(basedir)

--- a/selftests/run
+++ b/selftests/run
@@ -6,12 +6,7 @@ __author__ = 'Lucas Meneghel Rodrigues <lmr@redhat.com>'
 import os
 import sys
 import logging
-
-
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 logger = logging.getLogger(__name__)
 

--- a/selftests/unit/test_data_structures.py
+++ b/selftests/unit/test_data_structures.py
@@ -1,8 +1,4 @@
-import sys
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 from avocado.utils import data_structures
 

--- a/selftests/unit/test_dispatcher.py
+++ b/selftests/unit/test_dispatcher.py
@@ -1,9 +1,4 @@
-import sys
-
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 from avocado.core import dispatcher
 

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -1,12 +1,8 @@
 import argparse
 import os
 import shutil
-import sys
 import tempfile
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 from avocado.core import exceptions
 from avocado.core import test

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -1,13 +1,8 @@
 import shutil
 import stat
-import sys
 import multiprocessing
 import tempfile
-
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 from avocado.core import test
 from avocado.core import exceptions

--- a/selftests/unit/test_mux.py
+++ b/selftests/unit/test_mux.py
@@ -1,16 +1,12 @@
 import copy
 import itertools
 import pickle
-import sys
+import unittest
 
 from avocado.core import mux, tree, varianter
 from avocado.plugins import yaml_to_mux
 
 
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
 if __name__ == "__main__":
     PATH_PREFIX = "../../../../"
 else:

--- a/selftests/unit/test_parser.py
+++ b/selftests/unit/test_parser.py
@@ -1,10 +1,5 @@
 import argparse
-import sys
-
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 from avocado.core import parser
 

--- a/selftests/unit/test_result.py
+++ b/selftests/unit/test_result.py
@@ -1,9 +1,5 @@
-import sys
 import argparse
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 from avocado.core.result import Result
 

--- a/selftests/unit/test_safeloader.py
+++ b/selftests/unit/test_safeloader.py
@@ -1,11 +1,6 @@
 import ast
 import re
-import sys
-
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 from avocado.core import safeloader
 from avocado.utils import script

--- a/selftests/unit/test_settings.py
+++ b/selftests/unit/test_settings.py
@@ -1,11 +1,6 @@
 import os
-import sys
 import tempfile
-
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 from avocado.core import settings
 

--- a/selftests/unit/test_sysinfo.py
+++ b/selftests/unit/test_sysinfo.py
@@ -1,12 +1,7 @@
 import os
-import sys
 import tempfile
 import shutil
-
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 from avocado.core import sysinfo
 

--- a/selftests/unit/test_test.py
+++ b/selftests/unit/test_test.py
@@ -1,13 +1,9 @@
 import os
 import shutil
-import sys
 import tempfile
-from flexmock import flexmock, flexmock_teardown
+import unittest
 
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
+from flexmock import flexmock, flexmock_teardown
 
 from avocado.core import test, exceptions
 from avocado.utils import script

--- a/selftests/unit/test_utils_iso9660.py
+++ b/selftests/unit/test_utils_iso9660.py
@@ -3,16 +3,10 @@ Verifies the avocado.utils.iso9660 functionality
 """
 import os
 import shutil
-import sys
 import tempfile
+import unittest
 
 from avocado.utils import iso9660, process
-
-
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
 
 
 class BaseIso9660(unittest.TestCase):

--- a/selftests/unit/test_utils_partition.py
+++ b/selftests/unit/test_utils_partition.py
@@ -6,19 +6,14 @@ avocado.utils.partition unittests
 
 import os
 import shutil
-import sys
 import tempfile
 import time
+import unittest     # pylint: disable=C0411
 
 from flexmock import flexmock, flexmock_teardown
 
 from avocado.utils import partition, process
 from avocado.utils import path as utils_path
-
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest    # pylint: disable=E0401
-else:
-    import unittest     # pylint: disable=C0411
 
 
 def missing_binary(binary):

--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -1,11 +1,6 @@
 import os
-import sys
+import unittest
 from mock import MagicMock, patch
-
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
 
 from avocado.utils import gdb
 from avocado.utils import process

--- a/selftests/unit/test_utils_service.py
+++ b/selftests/unit/test_utils_service.py
@@ -16,12 +16,7 @@
 #  The full GNU General Public License is included in this distribution in
 #  the file called "COPYING".
 
-import sys
-
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 from mock import MagicMock, patch
 

--- a/setup.py
+++ b/setup.py
@@ -24,11 +24,6 @@ from setuptools import setup, find_packages
 VERSION = open('VERSION', 'r').read().strip()
 VIRTUAL_ENV = hasattr(sys, 'real_prefix')
 
-if sys.version_info[:2] >= (2, 7):
-    stevedore_version = 'stevedore>=1.8.0'
-else:
-    stevedore_version = 'stevedore>=1.8.0,<=1.10.0'
-
 
 def get_dir(system_path=None, virtual_path=None):
     """
@@ -175,5 +170,5 @@ if __name__ == '__main__':
               },
           zip_safe=False,
           test_suite='selftests',
-          python_requires='>=2.6',
-          install_requires=[stevedore_version])
+          python_requires='>=2.7',
+          install_requires=['stevedore>=1.8.0'])


### PR DESCRIPTION
Looking towards the future, we have decided to drop support for Python 2.6.  While this may look like bad news, it's actually something that will let us focus our energy on other things, such as Py3k compatibility.