### PR TITLE
Remote/VM/Docker Runners: check if it's OK to use STDOUT

### DIFF
--- a/avocado/core/remote/runner.py
+++ b/avocado/core/remote/runner.py
@@ -50,11 +50,13 @@ class RemoteTestRunner(TestRunner):
 
     def setup(self):
         """ Setup remote environment and copy test directories """
-        self.job.log.info("LOGIN      : %s@%s:%d (TIMEOUT: %s seconds)",
-                          self.job.args.remote_username,
-                          self.job.args.remote_hostname,
-                          self.job.args.remote_port,
-                          self.job.args.remote_timeout)
+        stdout_claimed_by = getattr(self.job.args, 'stdout_claimed_by', None)
+        if not stdout_claimed_by:
+            self.job.log.info("LOGIN      : %s@%s:%d (TIMEOUT: %s seconds)",
+                              self.job.args.remote_username,
+                              self.job.args.remote_hostname,
+                              self.job.args.remote_port,
+                              self.job.args.remote_timeout)
         self.remote = remoter.Remote(
             hostname=self.job.args.remote_hostname,
             username=self.job.args.remote_username,
@@ -299,7 +301,9 @@ class VMTestRunner(RemoteTestRunner):
         Initialize VM and establish connection
         """
         # Super called after VM is found and initialized
-        self.job.log.info("DOMAIN     : %s", self.job.args.vm_domain)
+        stdout_claimed_by = getattr(self.job.args, 'stdout_claimed_by', None)
+        if not stdout_claimed_by:
+            self.job.log.info("DOMAIN     : %s", self.job.args.vm_domain)
         try:
             self.vm = virt.vm_connect(self.job.args.vm_domain,
                                       self.job.args.vm_hypervisor_uri)

--- a/avocado/plugins/docker.py
+++ b/avocado/plugins/docker.py
@@ -125,9 +125,11 @@ class DockerTestRunner(RemoteTestRunner):
         dkr_opt = self.job.args.docker_options
         dkr_name = os.path.basename(self.job.logdir) + '.' + 'avocado'
         self.remote = DockerRemoter(dkrcmd, self.job.args.docker, dkr_opt, dkr_name)
-        self.job.log.info("DOCKER     : Container id '%s'"
-                          % self.remote.get_cid())
-        self.job.log.info("DOCKER     : Container name '%s'" % dkr_name)
+        stdout_claimed_by = getattr(self.job.args, 'stdout_claimed_by', None)
+        if not stdout_claimed_by:
+            self.job.log.info("DOCKER     : Container id '%s'"
+                              % self.remote.get_cid())
+            self.job.log.info("DOCKER     : Container name '%s'" % dkr_name)
 
     def tear_down(self):
         try:
@@ -136,7 +138,9 @@ class DockerTestRunner(RemoteTestRunner):
                 if not self.job.args.docker_no_cleanup:
                     self.remote.cleanup()
         except Exception as details:
-            self.job.log.warn("DOCKER     : Fail to cleanup: %s" % details)
+            stdout_claimed_by = getattr(self.job.args, 'stdout_claimed_by', None)
+            if not stdout_claimed_by:
+                self.job.log.warn("DOCKER     : Fail to cleanup: %s" % details)
 
 
 class Docker(CLI):


### PR DESCRIPTION
We're not checking if the there's an owner for the STDOUT when
displaying the runner connection information.  This makes
command lines that output, say, xunit to the STDOUT, to become
corrupted with a "LOGIN: " (or similar) line.

Signed-off-by: Cleber Rosa <crosa@redhat.com>

---

Changes from v1 (#1724):
* Added similar check to VM and Docker plugins