### PR TITLE
Adds warning to UI & job.log if remote avocado version mismatch

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -467,6 +467,19 @@ class Job(object):
                                              variant,
                                              self.timeout,
                                              replay_map)
+        # if the length of summary is 2, check if it came from remote/runner.py
+        # the summary set holds both versions of avocado local and remote
+        # if the values are not from remote/runner.py add them back to the set and continue code execution
+        if len(summary) == 2:
+            local_version = summary.pop()
+            remote_version = summary.pop()
+            if (local_version.isdigit() and remote_version.isdigit()) and (remote_version != local_version):
+                _TEST_LOGGER.warn("WARNING: avocado version on the remote system is %s, local is %s",
+                                  remote_version, local_version)
+            else:
+                summary.add(local_version)
+                summary.add(remote_version)
+
         # If it's all good so far, set job status to 'PASS'
         if self.status == 'RUNNING':
             self.status = 'PASS'

--- a/avocado/core/remote/runner.py
+++ b/avocado/core/remote/runner.py
@@ -22,6 +22,7 @@ import logging
 from fabric.exceptions import CommandTimeout
 
 from .test import RemoteTest
+from .. import version
 from .. import output
 from .. import remoter
 from .. import virt
@@ -47,6 +48,8 @@ class RemoteTestRunner(TestRunner):
         super(RemoteTestRunner, self).__init__(job, result)
         #: remoter connection to the remote machine
         self.remote = None
+        self.remote_version = ""
+        self.local_version = ""
 
     def setup(self):
         """ Setup remote environment and copy test directories """
@@ -86,7 +89,13 @@ class RemoteTestRunner(TestRunner):
         if result.exit_status == 127:
             return (False, None)
 
+        # Get the remote and local versions of avocado, and compare the major versions only
         match = self.remote_version_re.findall(result.stdout)
+        self.remote_version = '.'.join(list(match[0]))
+        self.local_version = version.VERSION
+        if self.remote_version.split('.')[0] != self.local_version.split('.')[0]:
+            self.job.log.info("WARNING    : avocado version on the remote system is %s, local is %s",
+                              self.remote_version, self.local_version)
         if match is None:
             return (False, None)
 
@@ -270,6 +279,9 @@ class RemoteTestRunner(TestRunner):
                 raise exceptions.JobError(details)
             sys.stdout = stdout_backup
             sys.stderr = stderr_backup
+        # returning the remote and local avocado version to be added to job.log as a possible warning
+        summary.add(self.remote_version.split('.')[0])
+        summary.add(self.local_version.split('.')[0])
         return summary
 
     def tear_down(self):


### PR DESCRIPTION
For debugging purposes it's nice to know if the remote version is
different from the local version of avocado. Code has been added to
job.py and remote/runner.py to support this functionality.
remote/runner.py will gather the remote and local versions, and print a
warning to the UI if they are different. remote/runner.py also adds the
version variables to the summary set. job.py checks the length of the
summary set variable if it equals exactly two, it'll compare the
versions and add a warning to job.log. The versions are popped from
summary returning summary to it's previous state, and code execution
continues as before.

Reference: https://trello.com/c/ZcV36ncd

Signed-off-by: Maurice Saldivar <maurice.a.saldivar@hpe.com>