### PR TITLE
Adds warning to UI & job.log if remote avocado version mismatch

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -467,6 +467,19 @@ class Job(object):
                                              variant,
                                              self.timeout,
                                              replay_map)
+        # if the length of summary is 2, check if it came from remote/runner.py
+        # the summary set holds both versions of avocado local and remote
+        # if the values are not from remote/runner.py add them back to the set and continue code execution
+        if len(summary) == 2:
+            local_version = summary.pop()
+            remote_version = summary.pop()
+            if (local_version.isdigit() and remote_version.isdigit()) and (remote_version != local_version):
+                _TEST_LOGGER.warn("WARNING: avocado version on the remote system is %s, local is %s",
+                                  remote_version, local_version)
+            else:
+                summary.add(local_version)
+                summary.add(remote_version)
+
         # If it's all good so far, set job status to 'PASS'
         if self.status == 'RUNNING':
             self.status = 'PASS'

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -467,19 +467,6 @@ class Job(object):
                                              variant,
                                              self.timeout,
                                              replay_map)
-        # if the length of summary is 2, check if it came from remote/runner.py
-        # the summary set holds both versions of avocado local and remote
-        # if the values are not from remote/runner.py add them back to the set and continue code execution
-        if len(summary) == 2:
-            local_version = summary.pop()
-            remote_version = summary.pop()
-            if (local_version.isdigit() and remote_version.isdigit()) and (remote_version != local_version):
-                _TEST_LOGGER.warn("WARNING: avocado version on the remote system is %s, local is %s",
-                                  remote_version, local_version)
-            else:
-                summary.add(local_version)
-                summary.add(remote_version)
-
         # If it's all good so far, set job status to 'PASS'
         if self.status == 'RUNNING':
             self.status = 'PASS'

--- a/avocado/core/remote/runner.py
+++ b/avocado/core/remote/runner.py
@@ -48,16 +48,16 @@ class RemoteTestRunner(TestRunner):
         super(RemoteTestRunner, self).__init__(job, result)
         #: remoter connection to the remote machine
         self.remote = None
-        self.remote_version = ""
-        self.local_version = ""
 
     def setup(self):
         """ Setup remote environment and copy test directories """
-        self.job.log.info("LOGIN      : %s@%s:%d (TIMEOUT: %s seconds)",
-                          self.job.args.remote_username,
-                          self.job.args.remote_hostname,
-                          self.job.args.remote_port,
-                          self.job.args.remote_timeout)
+        stdout_claimed_by = getattr(self.job.args, 'stdout_claimed_by', None)
+        if not stdout_claimed_by:
+            self.job.log.info("LOGIN      : %s@%s:%d (TIMEOUT: %s seconds)",
+                              self.job.args.remote_username,
+                              self.job.args.remote_hostname,
+                              self.job.args.remote_port,
+                              self.job.args.remote_timeout)
         self.remote = remoter.Remote(
             hostname=self.job.args.remote_hostname,
             username=self.job.args.remote_username,
@@ -91,11 +91,6 @@ class RemoteTestRunner(TestRunner):
 
         # Get the remote and local versions of avocado, and compare the major versions only
         match = self.remote_version_re.findall(result.stdout)
-        self.remote_version = '.'.join(list(match[0]))
-        self.local_version = version.VERSION
-        if self.remote_version.split('.')[0] != self.local_version.split('.')[0]:
-            self.job.log.info("WARNING    : avocado version on the remote system is %s, local is %s",
-                              self.remote_version, self.local_version)
         if match is None:
             return (False, None)
 
@@ -224,7 +219,7 @@ class RemoteTestRunner(TestRunner):
         try:
             try:
                 self.setup()
-                avocado_installed, _ = self.check_remote_avocado()
+                avocado_installed, remote_version = self.check_remote_avocado()
                 if not avocado_installed:
                     raise exceptions.JobError('Remote machine does not seem to'
                                               ' have avocado installed')
@@ -271,6 +266,13 @@ class RemoteTestRunner(TestRunner):
             self.result.end_tests()
             self.job._result_events_dispatcher.map_method('post_tests',
                                                           self.job)
+            # compare the major versions of remote and local version of avocado. If different write to UI and job.log
+            if str(remote_version[0]) != version.MAJOR:
+                log = logging.getLogger("avocado.job")
+                self.job.log.info("WARNING    : avocado version on the remote system is %s, local is %s",
+                                  '.'.join(map(str, remote_version)), version.VERSION)
+                log.warn("WARNING    : avocado version on the remote system is %s, local is %s",
+                         '.'.join(map(str, remote_version)), version.VERSION)
         finally:
             try:
                 self.tear_down()
@@ -279,9 +281,6 @@ class RemoteTestRunner(TestRunner):
                 raise exceptions.JobError(details)
             sys.stdout = stdout_backup
             sys.stderr = stderr_backup
-        # returning the remote and local avocado version to be added to job.log as a possible warning
-        summary.add(self.remote_version.split('.')[0])
-        summary.add(self.local_version.split('.')[0])
         return summary
 
     def tear_down(self):
@@ -311,7 +310,9 @@ class VMTestRunner(RemoteTestRunner):
         Initialize VM and establish connection
         """
         # Super called after VM is found and initialized
-        self.job.log.info("DOMAIN     : %s", self.job.args.vm_domain)
+        stdout_claimed_by = getattr(self.job.args, 'stdout_claimed_by', None)
+        if not stdout_claimed_by:
+            self.job.log.info("DOMAIN     : %s", self.job.args.vm_domain)
         try:
             self.vm = virt.vm_connect(self.job.args.vm_domain,
                                       self.job.args.vm_hypervisor_uri)

--- a/avocado/core/remote/runner.py
+++ b/avocado/core/remote/runner.py
@@ -89,7 +89,6 @@ class RemoteTestRunner(TestRunner):
         if result.exit_status == 127:
             return (False, None)
 
-        # Get the remote and local versions of avocado, and compare the major versions only
         match = self.remote_version_re.findall(result.stdout)
         if match is None:
             return (False, None)

--- a/avocado/core/remote/runner.py
+++ b/avocado/core/remote/runner.py
@@ -48,16 +48,16 @@ class RemoteTestRunner(TestRunner):
         super(RemoteTestRunner, self).__init__(job, result)
         #: remoter connection to the remote machine
         self.remote = None
+        self.remote_version = ""
+        self.local_version = ""
 
     def setup(self):
         """ Setup remote environment and copy test directories """
-        stdout_claimed_by = getattr(self.job.args, 'stdout_claimed_by', None)
-        if not stdout_claimed_by:
-            self.job.log.info("LOGIN      : %s@%s:%d (TIMEOUT: %s seconds)",
-                              self.job.args.remote_username,
-                              self.job.args.remote_hostname,
-                              self.job.args.remote_port,
-                              self.job.args.remote_timeout)
+        self.job.log.info("LOGIN      : %s@%s:%d (TIMEOUT: %s seconds)",
+                          self.job.args.remote_username,
+                          self.job.args.remote_hostname,
+                          self.job.args.remote_port,
+                          self.job.args.remote_timeout)
         self.remote = remoter.Remote(
             hostname=self.job.args.remote_hostname,
             username=self.job.args.remote_username,
@@ -91,6 +91,11 @@ class RemoteTestRunner(TestRunner):
 
         # Get the remote and local versions of avocado, and compare the major versions only
         match = self.remote_version_re.findall(result.stdout)
+        self.remote_version = '.'.join(list(match[0]))
+        self.local_version = version.VERSION
+        if self.remote_version.split('.')[0] != self.local_version.split('.')[0]:
+            self.job.log.info("WARNING    : avocado version on the remote system is %s, local is %s",
+                              self.remote_version, self.local_version)
         if match is None:
             return (False, None)
 
@@ -219,7 +224,7 @@ class RemoteTestRunner(TestRunner):
         try:
             try:
                 self.setup()
-                avocado_installed, remote_version = self.check_remote_avocado()
+                avocado_installed, _ = self.check_remote_avocado()
                 if not avocado_installed:
                     raise exceptions.JobError('Remote machine does not seem to'
                                               ' have avocado installed')
@@ -266,13 +271,6 @@ class RemoteTestRunner(TestRunner):
             self.result.end_tests()
             self.job._result_events_dispatcher.map_method('post_tests',
                                                           self.job)
-            # compare the major versions of remote and local version of avocado. If different write to UI and job.log
-            if str(remote_version[0]) != version.MAJOR:
-                log = logging.getLogger("avocado.job")
-                self.job.log.info("WARNING    : avocado version on the remote system is %s, local is %s",
-                                  '.'.join(map(str, remote_version)), version.VERSION)
-                log.warn("WARNING    : avocado version on the remote system is %s, local is %s",
-                         '.'.join(map(str, remote_version)), version.VERSION)
         finally:
             try:
                 self.tear_down()
@@ -281,6 +279,9 @@ class RemoteTestRunner(TestRunner):
                 raise exceptions.JobError(details)
             sys.stdout = stdout_backup
             sys.stderr = stderr_backup
+        # returning the remote and local avocado version to be added to job.log as a possible warning
+        summary.add(self.remote_version.split('.')[0])
+        summary.add(self.local_version.split('.')[0])
         return summary
 
     def tear_down(self):
@@ -310,9 +311,7 @@ class VMTestRunner(RemoteTestRunner):
         Initialize VM and establish connection
         """
         # Super called after VM is found and initialized
-        stdout_claimed_by = getattr(self.job.args, 'stdout_claimed_by', None)
-        if not stdout_claimed_by:
-            self.job.log.info("DOMAIN     : %s", self.job.args.vm_domain)
+        self.job.log.info("DOMAIN     : %s", self.job.args.vm_domain)
         try:
             self.vm = virt.vm_connect(self.job.args.vm_domain,
                                       self.job.args.vm_hypervisor_uri)


### PR DESCRIPTION
Refactored code, and kept everything inside remote/runner.py

Previous pull request #1750 

Reference: https://trello.com/c/ZcV36ncd

Signed-off-by: Maurice Saldivar <maurice.a.saldivar@hpe.com>