### PR TITLE
adds warning to UI & job.log if remote avocado version mismatch

### DIFF
--- a/avocado/core/remote/runner.py
+++ b/avocado/core/remote/runner.py
@@ -22,6 +22,7 @@ import logging
 from fabric.exceptions import CommandTimeout
 
 from .test import RemoteTest
+from .. import version
 from .. import output
 from .. import remoter
 from .. import virt
@@ -217,7 +218,7 @@ class RemoteTestRunner(TestRunner):
         try:
             try:
                 self.setup()
-                avocado_installed, _ = self.check_remote_avocado()
+                avocado_installed, remote_version = self.check_remote_avocado()
                 if not avocado_installed:
                     raise exceptions.JobError('Remote machine does not seem to'
                                               ' have avocado installed')
@@ -264,6 +265,13 @@ class RemoteTestRunner(TestRunner):
             self.result.end_tests()
             self.job._result_events_dispatcher.map_method('post_tests',
                                                           self.job)
+            # compare the major version of remote and local version of avocado. If different write to UI and job.log
+            if str(remote_version[0]) != version.MAJOR:
+                log = logging.getLogger("avocado.job")
+                self.job.log.info("WARNING    : avocado version on the remote system is %s, local is %s",
+                                  '.'.join(map(str, remote_version)), version.VERSION)
+                log.warn("WARNING    : avocado version on the remote system is %s, local is %s",
+                         '.'.join(map(str, remote_version)), version.VERSION)
         finally:
             try:
                 self.tear_down()


### PR DESCRIPTION
Fixed indent error that travis-ci picked up. The error was produced
by switching between vim and pycharm. Code has been refactored, and
all logic is self contained inside remote/runner.py. The warning appears in both
the UI and job.log

Previous pull requests: #1750 & #1752 

Reference: https://trello.com/c/ZcV36ncd

Signed-off-by: Maurice Saldivar <maurice.a.saldivar@hpe.com>