### PR TITLE
avocado.utils.asset: put hashfile next to asset file

### DIFF
--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -106,6 +106,7 @@ class Asset(object):
         for cache_dir in self.cache_dirs:
             cache_dir = os.path.expanduser(cache_dir)
             self.asset_file = os.path.join(cache_dir, self.basename)
+            self.hashfile = '%s-CHECKSUM' % self.asset_file
             if not utils_path.usable_rw_dir(cache_dir):
                 continue
 


### PR DESCRIPTION
Hash files (%s-CHECKSUM) were always written into the last cache
directory specified in `datadir.paths.cache_dirs`. This failed if that
directory does not exist or is not writable.

Fix this by setting self.hash_file again when deciding were to download
the asset to.