### PR TITLE
RFC: avocado: Replace custom skip* decorators with unittests ones

### DIFF
--- a/avocado/__init__.py
+++ b/avocado/__init__.py
@@ -21,11 +21,12 @@ __all__ = ['main',
            'skipIf',
            'skipUnless']
 
+# re-import some useful unittest decorators
+from unittest import skip
+from unittest import skipIf
+from unittest import skipUnless
 
 from avocado.core.job import main
 from avocado.core.test import Test
 from avocado.core.version import VERSION
 from avocado.core.decorators import fail_on
-from avocado.core.decorators import skip
-from avocado.core.decorators import skipIf
-from avocado.core.decorators import skipUnless

--- a/avocado/core/decorators.py
+++ b/avocado/core/decorators.py
@@ -53,39 +53,3 @@ def fail_on(exceptions=None):
     if func:
         return decorate(func)
     return decorate
-
-
-def skip(message=None):
-    """
-    Decorator to skip a test.
-    """
-    def decorator(function):
-        if not isinstance(function, type):
-            @wraps(function)
-            def wrapper(*args, **kwargs):
-                raise core_exceptions.TestDecoratorSkip(message)
-            function = wrapper
-        return function
-    return decorator
-
-
-def skipIf(condition, message=None):
-    """
-    Decorator to skip a test if a condition is True.
-    """
-    if condition:
-        return skip(message)
-    return _itself
-
-
-def skipUnless(condition, message=None):
-    """
-    Decorator to skip a test if a condition is False.
-    """
-    if not condition:
-        return skip(message)
-    return _itself
-
-
-def _itself(obj):
-    return obj

--- a/avocado/core/exceptions.py
+++ b/avocado/core/exceptions.py
@@ -148,16 +148,6 @@ class TestSetupSkip(TestBaseException):
     status = "SKIP"
 
 
-class TestDecoratorSkip(TestBaseException):
-
-    """
-    Indictates that the test is skipped by a decorator.
-
-    Should be thrown when the skip decorators are used.
-    """
-    status = "SKIP"
-
-
 class TestFail(TestBaseException, AssertionError):
 
     """

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -463,9 +463,9 @@ class Test(unittest.TestCase):
         try:
             self.setUp()
         except (exceptions.TestSetupSkip,
-                exceptions.TestDecoratorSkip,
                 exceptions.TestTimeoutSkip,
-                exceptions.TestSkipError) as details:
+                exceptions.TestSkipError,
+                unittest.SkipTest) as details:
             stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
             raise exceptions.TestSkipError(details)
         except:  # Old-style exceptions are not inherited from Exception()
@@ -481,7 +481,9 @@ class Test(unittest.TestCase):
                                 'must fix your test. Original skip exception: '
                                 '%s' % details)
             raise exceptions.TestError(skip_illegal_msg)
-        except exceptions.TestDecoratorSkip as details:
+        # For compatibility reasons allow unittest.SkipTest in tests as well
+        # (which allows using decorators)
+        except unittest.SkipTest as details:
             stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
             raise exceptions.TestSkipError(details)
         except:  # Old-style exceptions are not inherited from Exception()
@@ -504,7 +506,7 @@ class Test(unittest.TestCase):
                                     'you must fix your test. Original skip '
                                     'exception: %s' % details)
                 raise exceptions.TestError(skip_illegal_msg)
-            except exceptions.TestDecoratorSkip as details:
+            except unittest.SkipTest as details:
                 stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
                 skip_illegal_msg = ('Using skip decorators after the test '
                                     'will have no effect, you must fix your '

--- a/selftests/functional/test_skiptests.py
+++ b/selftests/functional/test_skiptests.py
@@ -14,6 +14,7 @@ basedir = os.path.abspath(basedir)
 
 AVOCADO_TEST_SKIP_DECORATORS = """
 import avocado
+import unittest
 from lib_skip_decorators import check_condition
 
 class AvocadoSkipTests(avocado.Test):
@@ -32,15 +33,16 @@ class AvocadoSkipTests(avocado.Test):
     def test3(self):
         pass
 
-    @avocado.skipIf(False)
+    @avocado.skipIf(False, "won't be skipped")
     def test4(self):
         pass
 
-    @avocado.skipUnless(True)
+    @avocado.skipUnless(True, "won't be skipped")
     def test5(self):
         pass
 
-    @avocado.skip()
+    @unittest.skipIf(True, "Skipped using unittest's skipIf which works"
+                     "but is not recommended.")
     def test6(self):
         pass
 """


### PR DESCRIPTION
Instead of re-implementing the wheel let's just inherit unittest's
decorators and support their privileged usage (exceptions inside test's
run) in the avocado tests. The fact that we inherit doesn't mean we
should promote this. We should still encourage people to use
`avocado.skip*` methods because at some point we might want to
improve/modify/update the decorators which could be again new
implementation or just some enhancement of the inherited ones.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>