### PR TITLE
Restore start_tests() for result plugins [v2]

### DIFF
--- a/avocado/core/plugin_interfaces.py
+++ b/avocado/core/plugin_interfaces.py
@@ -185,6 +185,12 @@ class ResultEvents(JobPreTests, JobPostTests):
     """
 
     @abc.abstractmethod
+    def start_tests(self, result):
+        """
+        Event triggered when the tests are about to start
+        """
+
+    @abc.abstractmethod
     def start_test(self, result, state):
         """
         Event triggered when a test starts running

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -512,7 +512,8 @@ class TestRunner(object):
         test_result_total = variants.get_number_of_tests(test_suite)
         no_digits = len(str(test_result_total))
         self.result.tests_total = test_result_total
-        self.result.start_tests()
+        self.job._result_events_dispatcher.map_method('start_tests',
+                                                      self.result)
         index = -1
         try:
             for test_template in test_suite:

--- a/avocado/plugins/human.py
+++ b/avocado/plugins/human.py
@@ -51,7 +51,11 @@ class Human(ResultEvents):
         if replay_source_job:
             self.log.info("SRC JOB ID : %s", replay_source_job)
         self.log.info("JOB LOG    : %s", job.logfile)
-        self.log.info("TESTS      : %s", len(job.test_suite))
+
+    def start_tests(self, result):
+        if not self.owns_stdout:
+            return
+        self.log.info("TESTS      : %s", result.tests_total)
 
     def start_test(self, result, state):
         if not self.owns_stdout:

--- a/avocado/plugins/journal.py
+++ b/avocado/plugins/journal.py
@@ -98,6 +98,9 @@ class JournalResult(ResultEvents):
     def pre_tests(self, job):
         pass
 
+    def start_tests(self, result):
+        pass
+
     def start_test(self, result, state):
         self.lazy_init_journal(state)
         self._record_status(state, "STARTED")

--- a/avocado/plugins/tap.py
+++ b/avocado/plugins/tap.py
@@ -84,10 +84,10 @@ class TAPResult(ResultEvents):
             self.__open_files.append(log)
             self.__logs.append(file_log_factory(log))
 
+    def start_tests(self, result):
         # Start writing the tap to all streams
-        tests = len(job.test_suite)
-        if tests > 0:
-            self.__write("1..%d", tests)
+        if result.tests_total > 0:
+            self.__write("1..%d", result.tests_total)
 
     def start_test(self, result, state):
         pass

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -427,6 +427,17 @@ class OutputPluginTest(unittest.TestCase):
         os.chdir(basedir)
         process.run("perl %s" % perl_script)
 
+    def test_tap_totaltests(self):
+        os.chdir(basedir)
+        cmd_line = ("./scripts/avocado run passtest.py "
+                    "-m examples/tests/sleeptest.py.data/sleeptest.yaml "
+                    "--tap -")
+        result = process.run(cmd_line)
+        expr = '1..4'
+        self.assertIn(expr, result.stdout, "'%s' not found in:\n%s"
+                      % (expr, result.stdout))
+
+
     def test_broken_pipe(self):
         os.chdir(basedir)
         cmd_line = "(./scripts/avocado run --help | whacky-unknown-command)"


### PR DESCRIPTION
With commit 2e6ecce6, the start_tests() method from results was lost.
But the runner was using that method to report the number of tests to
the UI.

This patch re-creates the start_tests() method, now using the new plugin
interface, fixing the tests number information in the UI.

Reference: https://trello.com/c/62I3ABZ0
Signed-off-by: Amador Pahim <apahim@redhat.com>

---

v2:
- Fix the same issue in TAP plugin as well.

v1: #1766 