### PR TITLE
adding a line to pci.py to skip System peripheral device in output

### DIFF
--- a/avocado/utils/pci.py
+++ b/avocado/utils/pci.py
@@ -53,7 +53,7 @@ def get_pci_addresses():
     addresses = []
     cmd = "lspci -D"
     for line in process.system_output(cmd).splitlines():
-        if "PCI bridge" not in line:
+        if "PCI bridge" not in line and "System peripheral" not in line:
             addresses.append(line.split()[0])
     if addresses:
         return addresses


### PR DESCRIPTION
lspci output lists System perpheral deivece's pci address too,
like PCI Bridge, which are not much operable by end user. Hence
skipping them while parsing the pci adress to the user.
these deivce looks like as follows
*XXX:XX:XX.X System peripheral: PLX Technology, Inc. Device 87d0
example:
root@ltc-briggs3:~# lspci -D | grep -i peripheral
0001:01:00.1 System peripheral: PLX Technology, Inc. Device 87d0
0001:01:00.2 System peripheral: PLX Technology, Inc. Device 87d0
0001:01:00.3 System peripheral: PLX Technology, Inc. Device 87d0
0001:01:00.4 System peripheral: PLX Technology, Inc. Device 87d0
root@ltc-briggs3:~#

Signed-off-by: Naresh Bannoth <nbannoth@in.ibm.com>