### PR TITLE
Return slot direct from file output without any filter

### DIFF
--- a/avocado/utils/pci.py
+++ b/avocado/utils/pci.py
@@ -141,8 +141,7 @@ def get_slot_from_sysfs(full_pci_address):
     if not os.path.isfile("/proc/device-tree/%s/ibm,loc-code" % devspec):
         return
     slot = read_file("/proc/device-tree/%s/ibm,loc-code" % devspec)
-    return re.match(r'((\w+)[\.])+(\w+)-(\w*\d+)-(\w*\d+)|Slot(\d+)',
-                    slot).group()
+    return slot
 
 
 def get_slot_list():


### PR DESCRIPTION
Different servers returns the slot numbers in different formate.
So filtering it with regExp may not return correct value.
hence return a slot value directly from file output, and leave
upto the user for rheir usage accordingly.
following are few example of different slot values on different
systems
examples:
root@ltciofvtr-firestone1:~# lsvpd -l 0000:01:00.1 | grep -i "*YL"
*YL Slot5
root@ltciofvtr-firestone1:~#
root@ltc-briggs3:~# lsvpd -l 0004:01:00.1 | grep -i "*YL"
*YL WIO Slot3
root@ltc-briggs3:~#
root@ltcalpine-lp2:~# lsvpd -l 0028:01:00.0 | grep -i "*YL"
*YL U78C7.001.RCH0040-P1-C9-T1
root@ltcalpine-lp2:~#

Signed-off-by: Naresh Bannoth <nbannoth@in.ibm.com>