### PR TITLE
Makefile: Don't fail when "make unlink" fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ clean:
 	find docs/source/api/ -name '*.rst' -delete
 	for MAKEFILE in $(AVOCADO_PLUGINS); do\
 		if test -f $$MAKEFILE/Makefile -o -f $$MAKEFILE/setup.py; then echo ">> UNLINK $$MAKEFILE";\
-			if test -f $$MAKEFILE/Makefile; then AVOCADO_DIRNAME=$(AVOCADO_DIRNAME) make -C $$MAKEFILE unlink &>/dev/null;\
+			if test -f $$MAKEFILE/Makefile; then AVOCADO_DIRNAME=$(AVOCADO_DIRNAME) make -C $$MAKEFILE unlink &>/dev/null || echo ">> FAIL $$MAKEFILE";\
 			elif test -f $$MAKEFILE/setup.py; then cd $$MAKEFILE; $(PYTHON) setup.py develop --uninstall $(PYTHON_DEVELOP_ARGS); cd -; fi;\
 		else echo ">> SKIP $$MAKEFILE"; fi;\
 	done


### PR DESCRIPTION
We already tweaked the "make link" to not fail when "make link" fails
but I forgot about unlink, which is now failing. Let's allow the "make
link" failure as there might be non-related modules not implementing the
"make unlink" functionality.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>