### PR TITLE
[RFC] custom SimpleQueue get() and put()

### DIFF
--- a/avocado/core/queues.py
+++ b/avocado/core/queues.py
@@ -1,0 +1,63 @@
+import os
+import sys
+
+from multiprocessing import queues
+
+
+class SimpleQueue(queues.SimpleQueue):
+
+    # There's no get/put methods in multiprocessing.SimpleQueue
+    # Instead, the _make_methods is in charge to create the self.put()
+    # and self.get(), containing the corresponding functions.
+    # Let's override _make_methods so we can make some tricks.
+    def _make_methods(self):
+        super(SimpleQueue, self)._make_methods()
+
+        # Create a queue to send the module_path from put() to be used
+        # in get()
+        internal_queue = queues.SimpleQueue()
+
+        # Hold on ;)
+        _put = self.put
+
+        # Custom put()
+        def put(value):
+            module_dir = None
+            # If we are to put 'func_at_exit', let's discover the
+            # module_dir for the injected function
+            if 'func_at_exit' in value:
+                path = sys.modules.get(value['func_at_exit'].__module__).__file__
+                module_dir = os.path.abspath(os.path.dirname(path))
+            # Informing the module_dir to be consumed by get()
+            internal_queue.put(module_dir)
+            # Finally putting the msg in the actual queue
+            _put(value)
+
+        # Here is our put() with steroids.
+        self.put = put
+
+        # hold on
+        _get = self.get
+
+        # Custom get()
+        def get():
+            internal_msg = internal_queue.get()
+            # Is there anything in the internal queue?
+            if internal_msg:
+                # If yes, it's a module_path, so let's include it in the
+                # sys.path to be able to load in in the actual get()
+                _syspath = sys.path[:]
+                sys.path.insert(1, internal_msg)
+            # Actual get()
+            msg = _get()
+
+            # Restoring the sys.path
+            if internal_msg:
+                sys.path = _syspath
+
+            # Returning the msg, possibly with a func_at_exit nicely
+            # loaded
+            return msg
+
+        # And here is our customized get()
+        self.get = get

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -19,7 +19,6 @@ Test runner module.
 
 import logging
 import multiprocessing
-from multiprocessing import queues
 import os
 import signal
 import sys
@@ -28,6 +27,7 @@ import time
 from . import test
 from . import exceptions
 from . import output
+from . import queues
 from . import status
 from .loader import loader
 from .status import mapping


### PR DESCRIPTION
The main issue with the `func_at_exit` is that we can `put()` a function that is loadable in the `test` context into the queue but the `get()` from the queue happens only in the `runner` context, where python does not have the reference for the function defined as `func_at_exit`.
The idea here is to override the `get()` and `put()` from the `multiprocessing.SimpleQueue`, creating an internal queue shared by the custom `get()`/`put()`. This queue will be used by `put()` to inform the module_path to the `get()`, which will include it in the `sys.path` before getting the `func_at_exit` from the main queue.
This is a functional first experiment.

To test it:

```python
import os
from avocado import Test
import time


def cleanup(path):
    if os.path.exists(path):
        os.unlink(path)

class MyTest(Test):

    path = "/tmp/foo"

    def setUp(self):
        open(self.path, 'w')
        self.runner_queue.put({"func_at_exit": cleanup,
                              "args": (self.path,),
                              "once": True})

    def test(self):
        self.assertTrue(os.path.exists(self.path))
```

```
$ ls /tmp/foo; avocado run ~/avocado/tests/test_func_at_exit.py; ls /tmp/foo
ls: cannot access '/tmp/foo': No such file or directory
JOB ID     : 8b622748bf479fb3c80eb2c91cc184ea5c346df4
JOB LOG    : /home/apahim/avocado/job-results/job-2017-02-10T21.34-8b62274/job.log
TESTS      : 1
 (1/1) /home/apahim/avocado/tests/test_func_at_exit.py:MyTest.test: PASS (0.02 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0
TESTS TIME : 0.02 s
JOB HTML   : /home/apahim/avocado/job-results/job-2017-02-10T21.34-8b62274/html/results.html
ls: cannot access '/tmp/foo': No such file or directory
```