### PR TITLE
TAP: fix number of test to be run (tests * variants)

### DIFF
--- a/avocado/core/result.py
+++ b/avocado/core/result.py
@@ -60,12 +60,6 @@ class Result(object):
         else:
             self.tests_total -= other_skipped_count
 
-    def start_tests(self):
-        """
-        Called once before any tests are executed.
-        """
-        pass
-
     def end_tests(self):
         """
         Called once after all tests are executed.

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -512,7 +512,6 @@ class TestRunner(object):
         test_result_total = variants.get_number_of_tests(test_suite)
         no_digits = len(str(test_result_total))
         self.result.tests_total = test_result_total
-        self.result.start_tests()
         index = -1
         try:
             for test_template in test_suite:

--- a/avocado/plugins/tap.py
+++ b/avocado/plugins/tap.py
@@ -66,6 +66,7 @@ class TAPResult(ResultEvents):
             log = open(output, "w", 1)
             self.__open_files.append(log)
             self.__logs.append(file_log_factory(log))
+        self.is_header_printed = False
 
     def __write(self, msg, *writeargs):
         """
@@ -84,11 +85,6 @@ class TAPResult(ResultEvents):
             self.__open_files.append(log)
             self.__logs.append(file_log_factory(log))
 
-        # Start writing the tap to all streams
-        tests = len(job.test_suite)
-        if tests > 0:
-            self.__write("1..%d", tests)
-
     def start_test(self, result, state):
         pass
 
@@ -96,6 +92,10 @@ class TAPResult(ResultEvents):
         """
         Log the test status and details
         """
+        if not self.is_header_printed:
+            self.__write("1..%d", result.tests_total)
+            self.is_header_printed = True
+
         status = state.get("status", "ERROR")
         name = state.get("name")
         if not name:

--- a/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
+++ b/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
@@ -536,7 +536,6 @@ class RemoteTestRunner(TestRunner):
             results = self.run_test(self.job.references, timeout)
             remote_log_dir = os.path.dirname(results['debuglog'])
             self.result.tests_total = results['total']
-            self.result.start_tests()
             local_log_dir = self.job.logdir
             for tst in results['tests']:
                 name = tst['test'].split('-', 1)

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -427,6 +427,17 @@ class OutputPluginTest(unittest.TestCase):
         os.chdir(basedir)
         process.run("perl %s" % perl_script)
 
+    def test_tap_totaltests(self):
+        os.chdir(basedir)
+        cmd_line = ("./scripts/avocado run passtest.py "
+                    "-m examples/tests/sleeptest.py.data/sleeptest.yaml "
+                    "--job-results-dir %s "
+                    "--tap -" % self.tmpdir)
+        result = process.run(cmd_line)
+        expr = '1..4'
+        self.assertIn(expr, result.stdout, "'%s' not found in:\n%s"
+                      % (expr, result.stdout))
+
     def test_broken_pipe(self):
         os.chdir(basedir)
         cmd_line = "(./scripts/avocado run --help | whacky-unknown-command)"

--- a/selftests/unit/test_jsonresult.py
+++ b/selftests/unit/test_jsonresult.py
@@ -35,7 +35,6 @@ class JSONResultTest(unittest.TestCase):
         self.test_result = Result(FakeJob(args))
         self.test_result.filename = self.tmpfile[1]
         self.test_result.tests_total = 1
-        self.test_result.start_tests()
         self.test1 = SimpleTest(job=self.job, base_logdir=self.tmpdir)
         self.test1.status = 'PASS'
         self.test1.time_elapsed = 1.23

--- a/selftests/unit/test_remote.py
+++ b/selftests/unit/test_remote.py
@@ -109,7 +109,6 @@ _=/usr/bin/env''', exit_status=0)
                           args=flexmock(show_job_log=False,
                                         mux_yaml=['foo.yaml', 'bar/baz.yaml'],
                                         dry_run=True))
-        Result.should_receive('start_tests').once().ordered()
         args = {'name': '1-sleeptest;0', 'time_end': 1.23,
                 'status': u'PASS', 'time_start': 0,
                 'time_elapsed': 1.23, 'job_unique_id': '',

--- a/selftests/unit/test_xunit.py
+++ b/selftests/unit/test_xunit.py
@@ -40,7 +40,6 @@ class xUnitSucceedTest(unittest.TestCase):
         self.job = job.Job(args)
         self.test_result = Result(FakeJob(args))
         self.test_result.tests_total = 1
-        self.test_result.start_tests()
         self.test1 = SimpleTest(job=self.job, base_logdir=self.tmpdir)
         self.test1.status = 'PASS'
         self.test1.time_elapsed = 1.23


### PR DESCRIPTION
The number of tests to be run in TAP output.  The current implementation uses the number of tests but do not take into account the number of variants. 