### PR TITLE
[Docs] Change the order of two paragraphs in plugin document

### DIFF
--- a/docs/source/Plugins.rst
+++ b/docs/source/Plugins.rst
@@ -138,6 +138,10 @@ In many situations, such as result generation, not one, but all of the
 enabled plugin types will be executed.  The order in which the plugins
 are executed follows the lexical order of the entry point name.
 
+If it sounds too complicated, it isn't.  It just means that for
+plugins of the same type, a plugin named ``automated`` will be
+executed before the plugin named ``uploader``.
+
 For example, for the JSON result plugin, whose fully qualified name
 is ``result.json``, has an entry point name of ``json``, as can be seen
 on its registration code in ``setup.py``::
@@ -147,10 +151,6 @@ on its registration code in ``setup.py``::
       'avocado.plugins.result': [
          'json = avocado.plugins.jsonresult:JSONResult',
    ...
-
-If it sounds too complicated, it isn't.  It just means that for
-plugins of the same type, a plugin named ``automated`` will be
-executed before the plugin named ``uploader``.
 
 In the default Avocado set of result plugins, it means that the JSON
 plugin (``json``) will be executed before the XUnit plugin (``xunit``).


### PR DESCRIPTION
I'm not good at English writing, but I think place the `json` plugin example between the plugin order definition and the more detail explanation is a little bit odd.

So I changed the place of two paragraphs and it looks more reasonable now.

If you guys think this change is incorrect, just go ahead closing this PR.

Thanks.