### PR TITLE
Remove the TESTS line from the UI

### DIFF
--- a/avocado/plugins/human.py
+++ b/avocado/plugins/human.py
@@ -51,7 +51,6 @@ class Human(ResultEvents):
         if replay_source_job:
             self.log.info("SRC JOB ID : %s", replay_source_job)
         self.log.info("JOB LOG    : %s", job.logfile)
-        self.log.info("TESTS      : %s", len(job.test_suite))
 
     def start_test(self, result, state):
         if not self.owns_stdout:


### PR DESCRIPTION
This information is not accurate since it does not consider the number
of variants. Also, if it was accurate, it would be redundant.

Let's just remove it.  

Reference: https://trello.com/c/62I3ABZ0
Signed-off-by: Amador Pahim <apahim@redhat.com>