### PR TITLE
yaml_to_mux: Use custom yaml.Loader

### DIFF
--- a/selftests/unit/test_mux.py
+++ b/selftests/unit/test_mux.py
@@ -2,6 +2,7 @@ import copy
 import itertools
 import pickle
 import unittest
+import yaml
 
 from avocado.core import mux, tree, varianter
 from avocado.plugins import yaml_to_mux
@@ -380,6 +381,29 @@ class TestAvocadoParams(unittest.TestCase):
         # params2 is sliced the other way around so it returns before the clash
         self.assertEqual(self.params2.get('clash3', default='nnn'),
                          'also equal')
+
+
+class TestMultipleLoaders(unittest.TestCase):
+
+    def test_multiple_loaders(self):
+        """
+        Verifies that `create_from_yaml` does not affects the main yaml.Loader
+        """
+        nondebug = yaml_to_mux.create_from_yaml(['/:' + PATH_PREFIX +
+                                                 'examples/mux-selftest.'
+                                                 'yaml'])
+        self.assertEqual(type(nondebug), mux.MuxTreeNode)
+        self.assertEqual(type(nondebug.children[0]), mux.MuxTreeNode)
+        debug = yaml_to_mux.create_from_yaml(['/:' + PATH_PREFIX +
+                                              'examples/mux-selftest.'
+                                              'yaml'],
+                                             debug=True)
+        self.assertEqual(type(debug), mux.MuxTreeNodeDebug)
+        # Debug nodes are of generated "NamedTreeNodeDebug" type
+        self.assertEqual("<class 'avocado.core.tree.NamedTreeNodeDebug'>",
+                         str(type(debug.children[0])))
+        plain = yaml.load("foo: bar")
+        self.assertEqual(type(plain), dict)
 
 
 class TestPathParent(unittest.TestCase):


### PR DESCRIPTION
Previously we were directly using the yaml.Loader, which is shared
across all `yaml` instances. This patch creates a `_BaseLoader` with the
basic set of constructors. That one is copied and updated of the
run-time data (debug/non-debug) during the `_create_from_yaml` to allow
loading debug and non-debug files in a single execution without
overriding the same loader.

This fixes the issue found by Vincent Matossian and reported on mailinglist.