### PR TITLE
yaml_to_mux: Use custom yaml.Loader [v2]

### DIFF
--- a/avocado/plugins/yaml_to_mux.py
+++ b/avocado/plugins/yaml_to_mux.py
@@ -13,6 +13,7 @@
 # Author: Lukas Doktor <ldoktor@redhat.com>
 """Multiplexer plugin to parse yaml files to params"""
 
+import copy
 import logging
 import os
 import re
@@ -43,6 +44,20 @@ YAML_MUX = 102
 
 __RE_FILE_SPLIT = re.compile(r'(?<!\\):')   # split by ':' but not '\\:'
 __RE_FILE_SUBS = re.compile(r'(?<!\\)\\:')  # substitute '\\:' but not '\\\\:'
+
+
+class _BaseLoader(Loader):
+    """
+    YAML loader with additional features related to mux
+    """
+    Loader.add_constructor(u'!include', lambda loader,
+                           node: mux.Control(YAML_INCLUDE))
+    Loader.add_constructor(u'!using',
+                           lambda loader, node: mux.Control(YAML_USING))
+    Loader.add_constructor(u'!remove_node',
+                           lambda loader, node: mux.Control(YAML_REMOVE_NODE))
+    Loader.add_constructor(u'!remove_value',
+                           lambda loader, node: mux.Control(YAML_REMOVE_VALUE))
 
 
 class Value(tuple):     # Few methods pylint: disable=R0903
@@ -143,16 +158,11 @@ def _create_from_yaml(path, cls_node=mux.MuxTreeNode):
         objects.append((mux.Control(YAML_MUX), None))
         return objects
 
-    Loader.add_constructor(u'!include',
-                           lambda loader, node: mux.Control(YAML_INCLUDE))
-    Loader.add_constructor(u'!using',
-                           lambda loader, node: mux.Control(YAML_USING))
-    Loader.add_constructor(u'!remove_node',
-                           lambda loader, node: mux.Control(YAML_REMOVE_NODE))
-    Loader.add_constructor(u'!remove_value',
-                           lambda loader, node: mux.Control(YAML_REMOVE_VALUE))
-    Loader.add_constructor(u'!mux', mux_loader)
-    Loader.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    # For each instance we need different `cls_node`, therefor different
+    # !mux and default mapping loader constructors
+    loader = copy.copy(_BaseLoader)
+    loader.add_constructor(u'!mux', mux_loader)
+    loader.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
                            mapping_to_tree_loader)
 
     # Parse file name ([$using:]$path)
@@ -169,7 +179,7 @@ def _create_from_yaml(path, cls_node=mux.MuxTreeNode):
 
     # Load the tree
     with open(path) as stream:
-        loaded_tree = yaml.load(stream, Loader)
+        loaded_tree = yaml.load(stream, loader)
         if loaded_tree is None:
             return
         loaded_tree = tree_node_from_values('', loaded_tree)

--- a/selftests/unit/test_mux.py
+++ b/selftests/unit/test_mux.py
@@ -2,6 +2,7 @@ import copy
 import itertools
 import pickle
 import unittest
+import yaml
 
 from avocado.core import mux, tree, varianter
 from avocado.plugins import yaml_to_mux
@@ -380,6 +381,29 @@ class TestAvocadoParams(unittest.TestCase):
         # params2 is sliced the other way around so it returns before the clash
         self.assertEqual(self.params2.get('clash3', default='nnn'),
                          'also equal')
+
+
+class TestMultipleLoaders(unittest.TestCase):
+
+    def test_multiple_loaders(self):
+        """
+        Verifies that `create_from_yaml` does not affects the main yaml.Loader
+        """
+        nondebug = yaml_to_mux.create_from_yaml(['/:' + PATH_PREFIX +
+                                                 'examples/mux-selftest.'
+                                                 'yaml'])
+        self.assertEqual(type(nondebug), mux.MuxTreeNode)
+        self.assertEqual(type(nondebug.children[0]), mux.MuxTreeNode)
+        debug = yaml_to_mux.create_from_yaml(['/:' + PATH_PREFIX +
+                                              'examples/mux-selftest.'
+                                              'yaml'],
+                                             debug=True)
+        self.assertEqual(type(debug), mux.MuxTreeNodeDebug)
+        # Debug nodes are of generated "NamedTreeNodeDebug" type
+        self.assertEqual("<class 'avocado.core.tree.NamedTreeNodeDebug'>",
+                         str(type(debug.children[0])))
+        plain = yaml.load("foo: bar")
+        self.assertEqual(type(plain), dict)
 
 
 class TestPathParent(unittest.TestCase):


### PR DESCRIPTION
Previously we were directly using the yaml.Loader, which is shared
across all `yaml` instances. This patch creates a `_BaseLoader` with the
basic set of constructors. That one is copied and updated of the
run-time data (debug/non-debug) during the `_create_from_yaml` to allow
loading debug and non-debug files in a single execution without
overriding the same loader.

v1: https://github.com/avocado-framework/avocado/pull/1787

Changes
```yaml
v2: Move `add_constructor` to the class-scope
```