### PR TITLE
selftests: suppress missing directory message

### DIFF
--- a/selftests/checkall
+++ b/selftests/checkall
@@ -78,7 +78,7 @@ results_dir_content() {
     fi
 }
 
-[ "$SKIP_RESULTSDIR_CHECK" ] || RESULTS_DIR_CONTENT="$(ls $RESULTS_DIR)"
+[ "$SKIP_RESULTSDIR_CHECK" ] || RESULTS_DIR_CONTENT="$(ls $RESULTS_DIR 2> /dev/null)"
 run_rc lint 'inspekt --exclude=.git lint'
 run_rc indent 'inspekt --exclude=.git indent'
 run_rc style 'inspekt --exclude=.git style --disable E501,E265,W601,E402,E722'


### PR DESCRIPTION
checkall runs `ls` twice in the job-results dir. Once before the
selftests and once again after the tests, comparing the outputs to make
sure there's no new results there after the selftests.

When the job-results does not exist in advance (the case in travis
environments), the message 'ls: cannot access /home/travis/avocado/job-results:
No such file or directory' is shown in the logs. The message is harmless
and does not affect the check. Let's just suppress the stderr from the
`ls` command in that check.

Reference: https://trello.com/c/IBoLAJjf
Signed-off-by: Amador Pahim <apahim@redhat.com>