### PR TITLE
Docs: describe test statuses and improve libraries heading [v2]

### DIFF
--- a/docs/source/api_utils_heading
+++ b/docs/source/api_utils_heading
@@ -1,0 +1,9 @@
+This is a set of utility APIs that Avocado provides as added value to
+test writers.
+
+It's suppose to be generic, without any knowledge of Avocado and reusable
+in different projects.
+
+.. note:: In the current version there is a hidden knowledge of avocado
+   logging streams. More about this issue can be found here
+   https://trello.com/c/4QyUgWsW/720-get-rid-of-avocado-test-loggers-from-avocado-utils

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -39,8 +39,7 @@ API_SECTIONS = {"Test APIs": (None,
                               ("modules.rst", )),
 
                 "Utilities APIs": ("utils",
-                                   "This is a set of utility APIs that Avocado "
-                                   "provides as added value to test writers.",
+                                   open("api_utils_heading", "r").read(),
                                    "utils",
                                    ("core", "plugins"),
                                    ("avocado.rst", "modules.rst"),),


### PR DESCRIPTION
While reviewing some of new utils I saw repeated improper patterns. This attempts to set the goals for avocado.utils writing and improves the test writing documentation to describe how to handle libraries exceptions from tests properly.

v1: https://github.com/avocado-framework/avocado/pull/1789

Changes

```yaml
v2: Add all improvements mentioned by cleber except of the signal
```