### PR TITLE
Makefile: also clean PYPI_UPLOAD dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ rpm-release: srpm-release
 clean:
 	$(PYTHON) setup.py clean
 	$(MAKE) -f $(CURDIR)/debian/rules clean || true
-	rm -rf build/ MANIFEST BUILD BUILDROOT SPECS RPMS SRPMS SOURCES
+	rm -rf build/ MANIFEST BUILD BUILDROOT SPECS RPMS SRPMS SOURCES PYPI_UPLOAD
 	rm -f man/avocado.1
 	rm -f man/avocado-rest-client.1
 	rm -rf docs/build


### PR DESCRIPTION
On commit dfd3742, a backport for the pypi target, I missed the clean
up of the PYPI_UPLOAD dir.  Let's include it here.

Signed-off-by: Cleber Rosa <crosa@redhat.com>