### PR TITLE
Test: Cleanup and protect the avocado.Test public values

### DIFF
--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -302,7 +302,7 @@ class TestRunner(object):
 
         instance = loader.load_test(test_factory)
         if instance.runner_queue is None:
-            instance.runner_queue = queue
+            instance.set_runner_queue(queue)
         runtime.CURRENT_TEST = instance
         early_state = instance.get_state()
         early_state['early_status'] = True

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -361,7 +361,7 @@ class Test(unittest.TestCase):
                          'traceback', 'workdir', 'whiteboard', 'time_start',
                          'time_end', 'running', 'paused', 'paused_msg',
                          'fail_class', 'params', "timeout"]
-        state = dict([(key, self.__dict__.get(key)) for key in preserve_attr])
+        state = {key: getattr(self, key, None) for (key) in preserve_attr}
         state['class_name'] = self.__class__.__name__
         state['job_logdir'] = self.job.logdir
         state['job_unique_id'] = self.job.unique_id

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -233,7 +233,6 @@ class Test(unittest.TestCase):
 
         self.log.info('START %s', self.name)
 
-        self.text_output = None
         self.__status = None
         self.__fail_reason = None
         self.__fail_class = None
@@ -449,7 +448,7 @@ class Test(unittest.TestCase):
             self._update_time_elapsed()
         preserve_attr = ['basedir', 'debugdir', 'depsdir', 'fail_reason',
                          'logdir', 'logfile', 'name', 'resultsdir', 'srcdir',
-                         'status', 'text_output', 'time_elapsed',
+                         'status', 'time_elapsed',
                          'traceback', 'workdir', 'whiteboard', 'time_start',
                          'time_end', 'running', 'paused', 'paused_msg',
                          'fail_class', 'params', "timeout"]
@@ -710,8 +709,6 @@ class Test(unittest.TestCase):
             self._tag_end()
             self._report()
             self.log.info("")
-            with open(self.logfile, 'r') as log_file_obj:
-                self.text_output = log_file_obj.read()
             self._stop_logging()
 
     def _report(self):

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -130,6 +130,18 @@ class Test(unittest.TestCase):
     """
     #: `default_params` will be deprecated by the end of 2017.
     default_params = {}
+    #: Arbitrary string which will be stored in `$logdir/whiteboard` location
+    #: when the test finishes.
+    whiteboard = ''
+    #: (unix) time when the test started (could be forced from test)
+    time_start = -1
+    #: (unix) time when the test finished (could be forced from test)
+    time_end = -1
+    #: duration of the test execution (always recalculated from time_end -
+    #: time_start
+    time_elapsed = -1
+    #: Test timeout (the timeout from params takes precedence)
+    timeout = None
 
     def __init__(self, methodName='test', name=None, params=None,
                  base_logdir=None, job=None, runner_queue=None):
@@ -229,19 +241,15 @@ class Test(unittest.TestCase):
         self.traceback = None
         self.text_output = None
 
-        self.whiteboard = ''
         # Avoid sharing mutable default params
         self.default_params = self.default_params.copy()
 
         self.running = False
-        self.time_start = -1
-        self.time_end = -1
         self.paused = False
         self.paused_msg = ''
 
         self.runner_queue = runner_queue
 
-        self.time_elapsed = -1
         unittest.TestCase.__init__(self, methodName=methodName)
 
     @property

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -446,8 +446,8 @@ class Test(unittest.TestCase):
         """
         if self.running and self.time_start:
             self._update_time_elapsed()
-        preserve_attr = ['basedir', 'debugdir', 'depsdir', 'fail_reason',
-                         'logdir', 'logfile', 'name', 'resultsdir', 'srcdir',
+        preserve_attr = ['basedir', 'fail_reason',
+                         'logdir', 'logfile', 'name', 'srcdir',
                          'status', 'time_elapsed',
                          'traceback', 'workdir', 'whiteboard', 'time_start',
                          'time_end', 'running', 'paused', 'paused_msg',

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -171,11 +171,11 @@ class Test(unittest.TestCase):
         if name is not None:
             if not isinstance(name, TestName):
                 raise NameNotTestNameError(name)
-            self.name = name
+            self.__name = name
         else:
-            self.name = TestName(0, self.__class__.__name__)
+            self.__name = TestName(0, self.__class__.__name__)
 
-        self.job = job
+        self.__job = job
 
         if self.datadir is None:
             self._expected_stdout_file = None
@@ -194,24 +194,24 @@ class Test(unittest.TestCase):
             raise exceptions.TestSetupFail("Log dir already exists, this "
                                            "should never happen: %s"
                                            % logdir)
-        self.logdir = utils_path.init_dir(logdir)
+        self.__logdir = utils_path.init_dir(logdir)
 
         # Replace '/' with '_' to avoid splitting name into multiple dirs
         genio.set_log_file_dir(self.logdir)
-        self.logfile = os.path.join(self.logdir, 'debug.log')
+        self.__logfile = os.path.join(self.logdir, 'debug.log')
         self._ssh_logfile = os.path.join(self.logdir, 'remote.log')
 
         self._stdout_file = os.path.join(self.logdir, 'stdout')
         self._stderr_file = os.path.join(self.logdir, 'stderr')
         self._logging_handlers = {}
 
-        self.outputdir = utils_path.init_dir(self.logdir, 'data')
+        self.__outputdir = utils_path.init_dir(self.logdir, 'data')
         self.sysinfo_enabled = getattr(self.job, 'sysinfo', False)
         if self.sysinfo_enabled:
             self.sysinfodir = utils_path.init_dir(self.logdir, 'sysinfo')
             self.sysinfo_logger = sysinfo.SysInfo(basedir=self.sysinfodir)
 
-        self.log = logging.getLogger("avocado.test")
+        self.__log = logging.getLogger("avocado.test")
         original_log_warn = self.log.warning
         self.__log_warn_used = False
         self.log.warn = self.log.warning = record_and_warn
@@ -244,13 +244,55 @@ class Test(unittest.TestCase):
         # Avoid sharing mutable default params
         self.default_params = self.default_params.copy()
 
-        self.running = False
+        self.__running = False
         self.paused = False
         self.paused_msg = ''
 
         self.runner_queue = runner_queue
 
         unittest.TestCase.__init__(self, methodName=methodName)
+
+    @property
+    def name(self):
+        """
+        The test name (TestName instance)
+        """
+        return self.__name
+
+    @property
+    def job(self):
+        """
+        The job this test is associated with
+        """
+        return self.__job
+
+    @property
+    def log(self):
+        """
+        The enhanced test log
+        """
+        return self.__log
+
+    @property
+    def logdir(self):
+        """
+        Path to this test's logging dir
+        """
+        return self.__logdir
+
+    @property
+    def logfile(self):
+        """
+        Path to this test's main `debug.log` file
+        """
+        return self.__logfile
+
+    @property
+    def outputdir(self):
+        """
+        Directory available to test writers to attach files to the results
+        """
+        return self.__outputdir
 
     @property
     def basedir(self):
@@ -328,6 +370,13 @@ class Test(unittest.TestCase):
             cache_dirs.append(datadir_cache)
         return cache_dirs
 
+    @property
+    def running(self):
+        """
+        Whether this test is currently being executed
+        """
+        return self.__running
+
     def __str__(self):
         return str(self.name)
 
@@ -335,11 +384,11 @@ class Test(unittest.TestCase):
         return "Test(%r)" % self.name
 
     def _tag_start(self):
-        self.running = True
+        self.__running = True
         self.time_start = time.time()
 
     def _tag_end(self):
-        self.running = False
+        self.__running = False
         self.time_end = time.time()
         # for consistency sake, always use the same stupid method
         self._update_time_elapsed(self.time_end)

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -206,10 +206,10 @@ class Test(unittest.TestCase):
         self._logging_handlers = {}
 
         self.__outputdir = utils_path.init_dir(self.logdir, 'data')
-        self.sysinfo_enabled = getattr(self.job, 'sysinfo', False)
-        if self.sysinfo_enabled:
-            self.sysinfodir = utils_path.init_dir(self.logdir, 'sysinfo')
-            self.sysinfo_logger = sysinfo.SysInfo(basedir=self.sysinfodir)
+        self.__sysinfo_enabled = getattr(self.job, 'sysinfo', False)
+        if self.__sysinfo_enabled:
+            self.__sysinfodir = utils_path.init_dir(self.logdir, 'sysinfo')
+            self.__sysinfo_logger = sysinfo.SysInfo(basedir=self.__sysinfodir)
 
         self.__log = logging.getLogger("avocado.test")
         original_log_warn = self.log.warning
@@ -416,7 +416,7 @@ class Test(unittest.TestCase):
             self._update_time_elapsed()
         preserve_attr = ['basedir', 'debugdir', 'depsdir', 'fail_reason',
                          'logdir', 'logfile', 'name', 'resultsdir', 'srcdir',
-                         'status', 'sysinfodir', 'text_output', 'time_elapsed',
+                         'status', 'text_output', 'time_elapsed',
                          'traceback', 'workdir', 'whiteboard', 'time_start',
                          'time_end', 'running', 'paused', 'paused_msg',
                          'fail_class', 'params', "timeout"]
@@ -513,8 +513,8 @@ class Test(unittest.TestCase):
         """
         testMethod = getattr(self, self._testMethodName)
         self._start_logging()
-        if self.sysinfo_enabled:
-            self.sysinfo_logger.start_test_hook()
+        if self.__sysinfo_enabled:
+            self.__sysinfo_logger.start_test_hook()
         test_exception = None
         cleanup_exception = None
         stdout_check_exception = None
@@ -623,8 +623,8 @@ class Test(unittest.TestCase):
                                       "details.")
 
         self.status = 'PASS'
-        if self.sysinfo_enabled:
-            self.sysinfo_logger.end_test_hook()
+        if self.__sysinfo_enabled:
+            self.__sysinfo_logger.end_test_hook()
 
     def _setup_environment_variables(self):
         os.environ['AVOCADO_VERSION'] = VERSION
@@ -637,8 +637,8 @@ class Test(unittest.TestCase):
         os.environ['AVOCADO_TEST_LOGDIR'] = self.logdir
         os.environ['AVOCADO_TEST_LOGFILE'] = self.logfile
         os.environ['AVOCADO_TEST_OUTPUTDIR'] = self.outputdir
-        if self.sysinfo_enabled:
-            os.environ['AVOCADO_TEST_SYSINFODIR'] = self.sysinfodir
+        if self.__sysinfo_enabled:
+            os.environ['AVOCADO_TEST_SYSINFODIR'] = self.__sysinfodir
 
     def run_avocado(self):
         """

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -233,8 +233,6 @@ class Test(unittest.TestCase):
 
         self.log.info('START %s', self.name)
 
-        self.debugdir = None
-        self.resultsdir = None
         self.status = None
         self.fail_reason = None
         self.fail_class = None

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -230,6 +230,8 @@ class Test(unittest.TestCase):
         self.text_output = None
 
         self.whiteboard = ''
+        # Avoid sharing mutable default params
+        self.default_params = self.default_params.copy()
 
         self.running = False
         self.time_start = -1

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -233,11 +233,11 @@ class Test(unittest.TestCase):
 
         self.log.info('START %s', self.name)
 
-        self.status = None
         self.fail_reason = None
         self.fail_class = None
         self.traceback = None
         self.text_output = None
+        self.__status = None
 
         # Avoid sharing mutable default params
         self.default_params = self.default_params.copy()
@@ -367,6 +367,13 @@ class Test(unittest.TestCase):
         if datadir_cache not in cache_dirs:
             cache_dirs.append(datadir_cache)
         return cache_dirs
+
+    @property
+    def status(self):
+        """
+        The result status of this test
+        """
+        return self.__status
 
     @property
     def running(self):
@@ -620,7 +627,7 @@ class Test(unittest.TestCase):
                                       "during execution. Check the log for "
                                       "details.")
 
-        self.status = 'PASS'
+        self.__status = 'PASS'
         if self.__sysinfo_enabled:
             self.__sysinfo_logger.end_test_hook()
 
@@ -691,7 +698,7 @@ class Test(unittest.TestCase):
 
         else:
             if self.status is None:
-                self.status = 'INTERRUPTED'
+                self.__status = 'INTERRUPTED'
             self.log.info("%s %s", self.status,
                           self.name)
 

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -233,11 +233,11 @@ class Test(unittest.TestCase):
 
         self.log.info('START %s', self.name)
 
-        self.fail_reason = None
-        self.fail_class = None
-        self.traceback = None
         self.text_output = None
         self.__status = None
+        self.__fail_reason = None
+        self.__fail_class = None
+        self.__traceback = None
 
         # Avoid sharing mutable default params
         self.default_params = self.default_params.copy()
@@ -381,6 +381,18 @@ class Test(unittest.TestCase):
         Whether this test is currently being executed
         """
         return self.__running
+
+    @property
+    def fail_reason(self):
+        return self.__fail_reason
+
+    @property
+    def fail_class(self):
+        return self.__fail_class
+
+    @property
+    def traceback(self):
+        return self.__traceback
 
     def __str__(self):
         return str(self.name)
@@ -656,26 +668,26 @@ class Test(unittest.TestCase):
             self._tag_start()
             self._run_avocado()
         except exceptions.TestBaseException as detail:
-            self.status = detail.status
-            self.fail_class = detail.__class__.__name__
-            self.fail_reason = detail
-            self.traceback = stacktrace.prepare_exc_info(sys.exc_info())
+            self.__status = detail.status
+            self.__fail_class = detail.__class__.__name__
+            self.__fail_reason = detail
+            self.__traceback = stacktrace.prepare_exc_info(sys.exc_info())
         except AssertionError as detail:
-            self.status = 'FAIL'
-            self.fail_class = detail.__class__.__name__
-            self.fail_reason = detail
-            self.traceback = stacktrace.prepare_exc_info(sys.exc_info())
+            self.__status = 'FAIL'
+            self.__fail_class = detail.__class__.__name__
+            self.__fail_reason = detail
+            self.__traceback = stacktrace.prepare_exc_info(sys.exc_info())
         except Exception as detail:
-            self.status = 'ERROR'
+            self.__status = 'ERROR'
             tb_info = stacktrace.tb_info(sys.exc_info())
-            self.traceback = stacktrace.prepare_exc_info(sys.exc_info())
+            self.__traceback = stacktrace.prepare_exc_info(sys.exc_info())
             try:
-                self.fail_class = str(detail.__class__.__name__)
-                self.fail_reason = str(detail)
+                self.__fail_class = str(detail.__class__.__name__)
+                self.__fail_reason = str(detail)
             except TypeError:
-                self.fail_class = "Exception"
-                self.fail_reason = ("Unable to get exception, check the "
-                                    "traceback for details.")
+                self.__fail_class = "Exception"
+                self.__fail_reason = ("Unable to get exception, check the "
+                                      "traceback for details.")
             for e_line in tb_info:
                 self.log.error(e_line)
         finally:

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -225,9 +225,9 @@ class Test(unittest.TestCase):
             params = []
         elif isinstance(params, tuple):
             params, mux_path = params[0], params[1]
-        self.params = varianter.AvocadoParams(params, self.name,
-                                              mux_path,
-                                              self.default_params)
+        self.__params = varianter.AvocadoParams(params, self.name,
+                                                mux_path,
+                                                self.default_params)
         default_timeout = getattr(self, "timeout", None)
         self.timeout = self.params.get("timeout", default=default_timeout)
 
@@ -290,6 +290,13 @@ class Test(unittest.TestCase):
         Directory available to test writers to attach files to the results
         """
         return self.__outputdir
+
+    @property
+    def params(self):
+        """
+        Parameters of this test (AvocadoParam instance)
+        """
+        return self.__params
 
     @property
     def basedir(self):

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -246,7 +246,7 @@ class Test(unittest.TestCase):
         self.paused = False
         self.paused_msg = ''
 
-        self.runner_queue = runner_queue
+        self.__runner_queue = runner_queue
 
         unittest.TestCase.__init__(self, methodName=methodName)
 
@@ -367,6 +367,22 @@ class Test(unittest.TestCase):
         if datadir_cache not in cache_dirs:
             cache_dirs.append(datadir_cache)
         return cache_dirs
+
+    @property
+    def runner_queue(self):
+        """
+        The communication channel between test and test runner
+        """
+        return self.__runner_queue
+
+    def set_runner_queue(self, runner_queue):
+        """
+        Override the runner_queue
+        """
+        self.assertTrue(self.__runner_queue is None, "Overriding of runner_"
+                        "queue is not allowed old=%s new=%s"
+                        % (self.__runner_queue, runner_queue))
+        self.__runner_queue = runner_queue
 
     @property
     def status(self):

--- a/avocado/plugins/xunit.py
+++ b/avocado/plugins/xunit.py
@@ -61,7 +61,12 @@ class XUnitResult(Result):
         traceback = document.createCDATASection(traceback_content)
         element.appendChild(traceback)
         system_out = Element('system-out')
-        system_out_cdata_content = self._escape_cdata(test.get('text_output', self.UNKNOWN))
+        try:
+            with open(test.get("logfile"), "r") as logfile_obj:
+                text_output = logfile_obj.read()
+        except (TypeError, IOError):
+            text_output = self.UNKNOWN
+        system_out_cdata_content = self._escape_cdata(text_output)
         system_out_cdata = document.createCDATASection(system_out_cdata_content)
         system_out.appendChild(system_out_cdata)
         element.appendChild(system_out)

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -57,7 +57,8 @@ from avocado import Test
 class FakeStatusTest(Test):
     def run_avocado(self):
         super(FakeStatusTest, self).run_avocado()
-        self.status = 'not supported'
+        # Please do NOT use this, ever...
+        self._Test__status = 'not supported'
 
     def test(self):
         pass

--- a/selftests/unit/test_jsonresult.py
+++ b/selftests/unit/test_jsonresult.py
@@ -36,7 +36,7 @@ class JSONResultTest(unittest.TestCase):
         self.test_result.filename = self.tmpfile[1]
         self.test_result.tests_total = 1
         self.test1 = SimpleTest(job=self.job, base_logdir=self.tmpdir)
-        self.test1.status = 'PASS'
+        self.test1._Test__status = 'PASS'
         self.test1.time_elapsed = 1.23
 
     def tearDown(self):

--- a/selftests/unit/test_xunit.py
+++ b/selftests/unit/test_xunit.py
@@ -41,7 +41,7 @@ class xUnitSucceedTest(unittest.TestCase):
         self.test_result = Result(FakeJob(args))
         self.test_result.tests_total = 1
         self.test1 = SimpleTest(job=self.job, base_logdir=self.tmpdir)
-        self.test1.status = 'PASS'
+        self.test1._Test__status = 'PASS'
         self.test1.time_elapsed = 1.23
         unittests_path = os.path.dirname(os.path.abspath(__file__))
         self.junit_schema_path = os.path.join(unittests_path, 'junit-4.xsd')


### PR DESCRIPTION
There are several `avocado.test` values which are public but restricted to Avocado usage. Lately we had some nasty user failures which turned out to be related to users overriding those variables. The purpose of this PR is to lower the probability of those clashes usually by turning the internal only variables to internal variables (`__`), then turning the read-only variables to properties without setter. Later there are some RFC-like commits, which turn even read-write variables into properties and the last commit treats params, which result in Avocado-vt breakage, which is addressed in this tree: https://github.com/ldoktor/avocado-vt/tree/avocado-test-variables