### PR TITLE
Handle sigterm [v3]

### DIFF
--- a/avocado/core/app.py
+++ b/avocado/core/app.py
@@ -25,6 +25,7 @@ from .dispatcher import CLICmdDispatcher
 from .dispatcher import CLIDispatcher
 from .output import STD_OUTPUT
 from .parser import Parser
+from ..utils import process
 
 
 class AvocadoApp(object):
@@ -38,6 +39,13 @@ class AvocadoApp(object):
         # Catch all libc runtime errors to STDERR
         os.environ['LIBC_FATAL_STDERR_'] = '1'
 
+        def sigterm_handler(signum, frame):     # pylint: disable=W0613
+            children = process.get_children_pids(os.getpid())
+            for child in children:
+                process.kill_process_tree(int(child), sig=signal.SIGTERM)
+            raise SystemExit('Terminated')
+
+        signal.signal(signal.SIGTERM, sigterm_handler)
         signal.signal(signal.SIGTSTP, signal.SIG_IGN)   # ignore ctrl+z
         self.parser = Parser()
         output.early_start()

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -203,13 +203,28 @@ def process_in_ptree_is_defunct(ppid):
     return defunct
 
 
-def get_children_pids(ppid):
+def get_children_pids(ppid, recursive=False):
     """
     Get all PIDs of children/threads of parent ppid
     param ppid: parent PID
+    param recursive: True to return all levels of subprocesses
     return: list of PIDs of all children/threads of ppid
     """
-    return system_output("ps -L --ppid=%d -o lwp" % ppid, verbose=False).split('\n')[1:]
+
+    cmd = "ps -L --ppid=%d -o lwp"
+
+    # Getting first level of subprocesses
+    children = system_output(cmd % ppid, verbose=False).split('\n')[1:]
+    if not recursive:
+        return children
+
+    # Recursion to get all levels of subprocesses
+    for child in children:
+        children.extend(system_output(cmd % int(child),
+                                      verbose=False,
+                                      ignore_status=True).split('\n')[1:])
+
+    return children
 
 
 def binary_from_shell_cmd(cmd):


### PR DESCRIPTION
v3:
- Use `process.kill_process_tree()` instead of custom routine to kill sub-processes.

v2: #1814 
- Add to `avocado.utils.process.get_children_pids()` the ability to return all levels of sub-processes (using the argument `recursive=True`).
- Use `avocado.utils.process` instead os `psutil`.

v1: #1813 
