### PR TITLE
data_dir: Alwas return abspath dir from settings

### DIFF
--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -60,7 +60,8 @@ def _get_settings_dir(dir_name):
     """
     Returns a given "datadir" directory as set by the configuration system
     """
-    return settings.settings.get_value('datadir.paths', dir_name, 'path')
+    path = settings.settings.get_value('datadir.paths', dir_name, 'path')
+    return os.path.abspath(path)
 
 
 def _get_rw_dir(settings_location, system_location, user_location):

--- a/examples/tests/whiteboard.py
+++ b/examples/tests/whiteboard.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import base64
+import os
 
 from avocado import Test
 from avocado import main
@@ -18,6 +19,7 @@ class WhiteBoard(Test):
     """
 
     def test(self):
+        os.chdir(self.datadir)    # Just to stress out Avocado
         data_file = self.params.get('whiteboard_data_file', default='')
         data_size = self.params.get('whiteboard_data_size', default='10')
         if data_file:

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -328,9 +328,13 @@ class OutputPluginTest(unittest.TestCase):
         tmpfile = tempfile.mktemp()
         try:
             os.chdir(basedir)
-            cmd_line = ('./scripts/avocado run --job-results-dir %s '
+            config = os.path.join(self.tmpdir, "conf.ini")
+            content = ("[datadir.paths]\nlogs_dir = %s"
+                       % os.path.relpath(self.tmpdir, "."))
+            script.Script(config, content).save()
+            cmd_line = ('./scripts/avocado --config %s --show all run '
                         '--sysinfo=off whiteboard.py --json %s' %
-                        (self.tmpdir, tmpfile))
+                        (config, tmpfile))
             result = process.run(cmd_line, ignore_status=True)
             expected_rc = exit_codes.AVOCADO_ALL_OK
             self.assertEqual(result.exit_status, expected_rc,


### PR DESCRIPTION
It is possible to set relative paths in settings, but once we evaluate
them we should turn them into absolute paths to avoid incorrect
representation on `os.chdir` (or so)

Addresses issue: https://github.com/avocado-framework/avocado/issues/1818