### PR TITLE
Added -f argument for formating a disk with btrfs file system

### DIFF
--- a/avocado/utils/partition.py
+++ b/avocado/utils/partition.py
@@ -174,7 +174,7 @@ class Partition(object):
 
         if self.mkfs_flags:
             args += ' ' + self.mkfs_flags
-        if fstype == 'xfs':
+        if fstype in ['xfs', 'btrfs']:
             args += ' -f'
 
         if self.loop:


### PR DESCRIPTION
mkfs function in partition.py is failing to create a btrfs file
system when already a file system exists on the given disk.
adding -f option will resolve the issue. So added the same and
it is working fine now.

Signed-off-by: Naresh Bannoth <nbannoth@in.ibm.com>