### PR TITLE
Test: Cleanup and protect the avocado.Test public values, stage2

### DIFF
--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -302,7 +302,7 @@ class TestRunner(object):
 
         instance = loader.load_test(test_factory)
         if instance.runner_queue is None:
-            instance.runner_queue = queue
+            instance.set_runner_queue(queue)
         runtime.CURRENT_TEST = instance
         early_state = instance.get_state()
         early_state['early_status'] = True

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -443,8 +443,8 @@ class Test(unittest.TestCase):
         """
         if self.running and self.time_start:
             self._update_time_elapsed()
-        preserve_attr = ['basedir', 'debugdir', 'depsdir', 'fail_reason',
-                         'logdir', 'logfile', 'name', 'resultsdir', 'srcdir',
+        preserve_attr = ['basedir', 'fail_reason',
+                         'logdir', 'logfile', 'name', 'srcdir',
                          'status', 'time_elapsed',
                          'traceback', 'workdir', 'whiteboard', 'time_start',
                          'time_end', 'running', 'paused', 'paused_msg',

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -243,7 +243,7 @@ class Test(unittest.TestCase):
         self.paused = False
         self.paused_msg = ''
 
-        self.runner_queue = runner_queue
+        self.__runner_queue = runner_queue
 
         unittest.TestCase.__init__(self, methodName=methodName)
 
@@ -364,6 +364,22 @@ class Test(unittest.TestCase):
         if datadir_cache not in cache_dirs:
             cache_dirs.append(datadir_cache)
         return cache_dirs
+
+    @property
+    def runner_queue(self):
+        """
+        The communication channel between test and test runner
+        """
+        return self.__runner_queue
+
+    def set_runner_queue(self, runner_queue):
+        """
+        Override the runner_queue
+        """
+        self.assertTrue(self.__runner_queue is None, "Overriding of runner_"
+                        "queue multiple times is not allowed -> old=%s new=%s"
+                        % (self.__runner_queue, runner_queue))
+        self.__runner_queue = runner_queue
 
     @property
     def status(self):

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -233,7 +233,6 @@ class Test(unittest.TestCase):
 
         self.log.info('START %s', self.name)
 
-        self.text_output = None
         self.__status = None
         self.__fail_reason = None
         self.__fail_class = None
@@ -446,7 +445,7 @@ class Test(unittest.TestCase):
             self._update_time_elapsed()
         preserve_attr = ['basedir', 'debugdir', 'depsdir', 'fail_reason',
                          'logdir', 'logfile', 'name', 'resultsdir', 'srcdir',
-                         'status', 'text_output', 'time_elapsed',
+                         'status', 'time_elapsed',
                          'traceback', 'workdir', 'whiteboard', 'time_start',
                          'time_end', 'running', 'paused', 'paused_msg',
                          'fail_class', 'params', "timeout"]
@@ -707,8 +706,6 @@ class Test(unittest.TestCase):
             self._tag_end()
             self._report()
             self.log.info("")
-            with open(self.logfile, 'r') as log_file_obj:
-                self.text_output = log_file_obj.read()
             self._stop_logging()
 
     def _report(self):

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -225,9 +225,9 @@ class Test(unittest.TestCase):
             params = []
         elif isinstance(params, tuple):
             params, mux_path = params[0], params[1]
-        self.params = varianter.AvocadoParams(params, self.name,
-                                              mux_path,
-                                              self.default_params)
+        self.__params = varianter.AvocadoParams(params, self.name,
+                                                mux_path,
+                                                self.default_params)
         default_timeout = getattr(self, "timeout", None)
         self.timeout = self.params.get("timeout", default=default_timeout)
 
@@ -287,6 +287,13 @@ class Test(unittest.TestCase):
         Directory available to test writers to attach files to the results
         """
         return self.__outputdir
+
+    @property
+    def params(self):
+        """
+        Parameters of this test (AvocadoParam instance)
+        """
+        return self.__params
 
     @property
     def basedir(self):

--- a/avocado/plugins/xunit.py
+++ b/avocado/plugins/xunit.py
@@ -61,7 +61,12 @@ class XUnitResult(Result):
         traceback = document.createCDATASection(traceback_content)
         element.appendChild(traceback)
         system_out = Element('system-out')
-        system_out_cdata_content = self._escape_cdata(test.get('text_output', self.UNKNOWN))
+        try:
+            with open(test.get("logfile"), "r") as logfile_obj:
+                text_output = logfile_obj.read()
+        except (TypeError, IOError):
+            text_output = self.UNKNOWN
+        system_out_cdata_content = self._escape_cdata(text_output)
         system_out_cdata = document.createCDATASection(system_out_cdata_content)
         system_out.appendChild(system_out_cdata)
         element.appendChild(system_out)


### PR DESCRIPTION
This is a stage2 of the https://github.com/avocado-framework/avocado/pull/1817 which includes some deeper changes to avocado.Test to cover all of the publicly available variables.

This version doesn't need any updates to Avocado-vt, but it won't work with older Avocado-vt versions (prior to https://github.com/avocado-framework/avocado-vt/pull/900 )