### PR TITLE
avocado.core.test: fix syntax

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -434,7 +434,7 @@ class Test(unittest.TestCase):
                          'traceback', 'workdir', 'whiteboard', 'time_start',
                          'time_end', 'running', 'paused', 'paused_msg',
                          'fail_class', 'params', "timeout"]
-        state = {key: getattr(self, key, None) for (key) in preserve_attr}
+        state = dict([(key, getattr(self, key, None)) for key in preserve_attr])
         state['class_name'] = self.__class__.__name__
         state['job_logdir'] = self.job.logdir
         state['job_unique_id'] = self.job.unique_id


### PR DESCRIPTION
this patch fix syntax issue on python2.6 

Signed-off-by: Xu Tian <xutian@redhat.com>