### PR TITLE
requirements: use latest stevedore

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -5,4 +5,4 @@ PyYAML==3.11
 Pillow==2.6.1
 aexpect==1.0.0
 # stevedore for loading "new style" plugins
-stevedore==1.8.0
+stevedore>=1.8.0

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -14,7 +14,7 @@ mock==1.2.0
 aexpect==1.0.0
 psutil==3.1.1
 # stevedore for loading "new style" plugins
-stevedore==1.8.0
+stevedore>=1.8.0
 lxml>=3.4.4
 # some setuptools versions can fail accessing
 # pkg_resources.packaging, let's pin the version


### PR DESCRIPTION
With the last pbr update, stevedore 1.8.0 dependencies are broken.

This patch adjusts the requirements for travis and for docs to install
the latest stevedore.

Signed-off-by: Amador Pahim <apahim@redhat.com>