### PR TITLE
Add checkpoint plugin and allow resuming tests when replaying

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -275,7 +275,7 @@ class TestLoaderProxy(object):
         :type test_factory: tuple
         :return: an instance of :class:`avocado.core.test.Test`.
         """
-        test_class, test_parameters = test_factory
+        test_class, test_parameters, test_decorator = test_factory
         # discard tags, as they are *not* intended to be parameters
         # for the test, but used previously during filtering
         if 'tags' in test_parameters:
@@ -308,7 +308,14 @@ class TestLoaderProxy(object):
                     if issubclass(obj, test.Test):
                         test_class = obj
                         break
-        test_instance = test_class(**test_parameters)
+        if test_decorator is not None:
+            if isinstance(test_decorator, tuple):
+                test_instance = test_decorator[0](test_class, test_parameters,
+                                                  test_decorator[1])
+            else:
+                test_instance = test_decorator(test_class, test_parameters)
+        else:
+            test_instance = test_class(**test_parameters)
 
         return test_instance
 

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -484,10 +484,10 @@ class TestRunner(object):
                            " present in test factory: %s"
                            % (template[0], template[1]))
                     raise ValueError(msg)
-                factory = [template[0], template[1].copy()]
+                factory = [template[0], template[1].copy(), None]
                 factory[1]["params"] = params
             else:
-                factory = template
+                factory = tuple(template[0], template[1].copy(), None)
             yield factory, variant
 
     def run_suite(self, test_suite, variants, timeout=0, replay_map=None):
@@ -530,16 +530,16 @@ class TestRunner(object):
                         summary.add('INTERRUPTED')
                         if 'methodName' in test_parameters:
                             del test_parameters['methodName']
-                        test_factory = (test.TimeOutSkipTest, test_parameters)
+                        test_factory = (test.TimeOutSkipTest, test_parameters,
+                                        None)
                         break_loop = not self.run_test(test_factory, queue,
                                                        summary)
                         if break_loop:
                             break
                     else:
-                        if (replay_map is not None and
-                                replay_map[index] is not None):
-                            test_parameters["methodName"] = "test"
-                            test_factory = (replay_map[index], test_parameters)
+                        if (replay_map is not None and index < len(replay_map)):
+                            test_factory = (test_factory[0], test_factory[1],
+                                            replay_map[index])
 
                         break_loop = not self.run_test(test_factory, queue,
                                                        summary, deadline)

--- a/avocado/plugins/checkpoint.py
+++ b/avocado/plugins/checkpoint.py
@@ -1,0 +1,90 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2014, 2017
+# Author: Cleber Rosa <cleber@redhat.com>
+# Author: Benjamin Berg <bberg@redhat.com>
+
+"""Checkpoint Plugin"""
+
+import os
+import sqlite3
+import datetime
+import logging
+
+from avocado.core.plugin_interfaces import ResultEvents
+from avocado.core.dispatcher import ResultDispatcher
+
+class Checkpoint(ResultEvents):
+
+    """
+    Checkpoint Results class.
+
+    This class writes out the results at the start of a/each test to ensure
+    that the result set is in a sane state in case avocado or even the whole
+    system crashes.
+    """
+
+    name = 'checkpoint'
+    description = "Checkpoint results before running each test"
+
+    def __init__(self, args):
+        """
+        Creates an instance of CheckpointJournal.
+
+        :param job: an instance of :class:`avocado.core.job.Job`.
+        """
+        self.log = logging.getLogger("avocado.app")
+        self._result_dispatcher = ResultDispatcher()
+
+    def pre_tests(self, job):
+        self._job = job
+        pass
+
+    def start_test(self, result, state):
+        # NOTE: During local execution this function is called from inside
+        #       a forked subprocess.
+
+        # Copy the state, put it into an INTERRUPTED state and append it
+        incomplete_state = dict(state)
+        incomplete_state['status'] = 'INTERRUPTED'
+        result.tests.append(incomplete_state)
+
+        if self._result_dispatcher:
+            self._result_dispatcher.map_method('render',
+                                               self._job.result,
+                                               self._job)
+
+        del result.tests[-1]
+
+        # Try to sync everything to disk
+        try:
+            fd, fd_dir = -1, -1
+            fd = os.open(os.path.join(self._job.logdir, 'results.json'), os.O_RDONLY)
+            fd_dir = os.open(self._job.logdir, os.O_RDONLY)
+        except Exception, e:
+            self.log.error("Could not sync (json) output for checkpointing, recovery might not work! %s" % str(e))
+        finally:
+            if fd >= 0:
+                os.close(fd)
+            if fd_dir >= 0:
+                os.close(fd_dir)
+
+
+    def test_progress(self, progress=False):
+        pass
+
+    def end_test(self, result, state):
+        pass
+
+    def post_tests(self, job):
+        pass
+

--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -24,7 +24,24 @@ from avocado.core import status
 
 from avocado.core.plugin_interfaces import CLI
 from avocado.core.settings import settings
-from avocado.core.test import ReplaySkipTest
+from avocado.core.test import ReplaySkipTest, TestError, ReplayResultCopier
+
+def _require_recover(test_cls, args, previous):
+    args['recovery_required'] = True
+    return test_cls(previous_run=previous, **args)
+
+def _replay_skip(test_cls, args):
+    args["methodName"] = "test"
+    return ReplaySkipTest(**args)
+
+def _replay_copy(test_cls, args, previous):
+    args["methodName"] = "test"
+    return ReplayResultCopier(previous_run=previous, **args)
+
+def _fail_interrupted(test_cls, args):
+    args["methodName"] = "test"
+    args['exception'] = 'Test was interrupted on last run!'
+    return TestError(**args)
 
 
 class Replay(CLI):
@@ -54,6 +71,26 @@ class Replay(CLI):
                                    default=None,
                                    help='Filter tests to replay by '
                                    'test status')
+        replay_parser.add_argument('--resume',
+                                   dest='resume',
+                                   action='store_true',
+                                   default=False,
+                                   help='Replay all tests that were '
+                                   'interrupted or do not have a result set '
+                                   'yet.')
+        replay_parser.add_argument('--replay-results',
+                                   dest='replay_results',
+                                   action='store_true',
+                                   default=False,
+                                   help='During replay copy result sets from '
+                                   'the previous run instead of marking the '
+                                   'tests as skipped.')
+        replay_parser.add_argument('--fail-interrupted',
+                                   dest='fail_interrupted',
+                                   action='store_true',
+                                   default=False,
+                                   help='Do not try to rerun an interrupted '
+                                   'test.')
         replay_parser.add_argument('--replay-ignore',
                                    dest='replay_ignore',
                                    type=self._valid_ignore,
@@ -90,7 +127,8 @@ class Replay(CLI):
         if config is not None:
             settings.process_config_path(config)
 
-    def _create_replay_map(self, resultsdir, replay_filter):
+    def _create_replay_map(self, resultsdir, replay_filter, fail_interrupted,
+                           replay_results):
         """
         Creates a mapping to be used as filter for the replay. Given
         the replay_filter, tests that should be filtered out will have a
@@ -106,8 +144,16 @@ class Replay(CLI):
 
         replay_map = []
         for test in results['tests']:
-            if test['status'] not in replay_filter:
-                replay_map.append(ReplaySkipTest)
+            if test['status'] == 'INTERRUPTED':
+                if fail_interrupted:
+                    replay_map.append(_fail_interrupted)
+                else:
+                    replay_map.append((_require_recover, test))
+            elif test['status'] not in replay_filter:
+                if replay_results:
+                    replay_map.append((_replay_copy, test))
+                else:
+                    replay_map.append(_replay_skip)
             else:
                 replay_map.append(None)
 
@@ -120,13 +166,16 @@ class Replay(CLI):
         log = logging.getLogger("avocado.app")
 
         err = None
-        if args.replay_teststatus and 'variants' in args.replay_ignore:
+        if args.resume and args.replay_teststatus:
+            err = ("Option `--replay-test-status` is mutually exclusive with "
+                   "`--resume`.")
+        elif args.replay_teststatus and 'variants' in args.replay_ignore:
             err = ("Option `--replay-test-status` is incompatible with "
                    "`--replay-ignore variants`.")
         elif args.replay_teststatus and args.reference:
             err = ("Option --replay-test-status is incompatible with "
                    "test references given on the command line.")
-        elif args.remote_hostname:
+        elif hasattr(args, 'remote_hostname') and args.remote_hostname:
             err = "Currently we don't replay jobs in remote hosts."
         if err is not None:
             log.error(err)
@@ -216,9 +265,14 @@ class Replay(CLI):
                 setattr(args, "avocado_variants", variants)
                 variants.ignore_new_data = True
 
-        if args.replay_teststatus:
+        if args.resume:
+            args.replay_teststatus = []
+
+        if args.replay_teststatus is not None:
             replay_map = self._create_replay_map(resultsdir,
-                                                 args.replay_teststatus)
+                                                 args.replay_teststatus,
+                                                 args.fail_interrupted,
+                                                 args.replay_results)
             setattr(args, 'replay_map', replay_map)
 
         # Use the original directory to resolve test references properly

--- a/setup.py
+++ b/setup.py
@@ -163,6 +163,7 @@ if __name__ == '__main__':
                   'human = avocado.plugins.human:Human',
                   'tap = avocado.plugins.tap:TAPResult',
                   'journal = avocado.plugins.journal:JournalResult',
+                  'checkpoint = avocado.plugins.checkpoint:Checkpoint',
                   ],
               },
           zip_safe=False,


### PR DESCRIPTION
The idea here is to allow resuming a test in case avocado or the machine
dies (for example running a local test that might cause a kernel panic).
When a test run is recovered, the tests that were already run will be
skipped (and their old result sets copied if requested). On any test
marked as INTERRUPTED the original test will be run but the
recover_failure method will be called prior to any operation. If it is
not implemented, then the default implementation is to FAIL the test.

Example, interrupting avocado manually during Sleeptest:
$ ./scripts/avocado run ./examples/tests/sleeptest.py ./examples/tests/sleeptest.py
JOB ID     : 16e4e4e33256a6844cdbe87972031859c22c08c3
JOB LOG    : /home/benjamin/avocado/job-results/job-2017-03-03T17.10-16e4e4e/job.log
 (1/2) ./examples/tests/sleeptest.py:SleepTest.test: PASS (1.02 s)
 (2/2) ./examples/tests/sleeptest.py:SleepTest.test:  ^\Quit (core dumped)

Here SleepTest is patched to return SKIP from recover_failure.
$ ./scripts/avocado run --replay 16e4e4e --resume
Using src job Mux data only, use `--replay-ignore variants` to override them.
JOB ID     : 601a3aa20c63f59f19b207dcb75672c7a66e7d4e
SRC JOB ID : 16e4e4e33256a6844cdbe87972031859c22c08c3
JOB LOG    : /home/benjamin/avocado/job-results/job-2017-03-03T17.11-601a3aa/job.log
 (1/2) ./examples/tests/sleeptest.py:SleepTest.test: SKIP
 (2/2) ./examples/tests/sleeptest.py:SleepTest.test: SKIP
RESULTS    : PASS 0 | ERROR 0 | FAIL 0 | SKIP 2 | WARN 0 | INTERRUPT 0
TESTS TIME : 0.00 s
JOB HTML   : /home/benjamin/avocado/job-results/job-2017-03-03T17.11-601a3aa/html/results.html

With --fail-interrupted the test fails:
$ ./scripts/avocado run --replay 16e4e4e --resume --fail-interrupted
Using src job Mux data only, use `--replay-ignore variants` to override them.
JOB ID     : 030432144585754a746512806f377a3772fdc745
SRC JOB ID : 16e4e4e33256a6844cdbe87972031859c22c08c3
JOB LOG    : /home/benjamin/avocado/job-results/job-2017-03-03T17.12-0304321/job.log
 (1/2) ./examples/tests/sleeptest.py:SleepTest.test: SKIP
 (2/2) ./examples/tests/sleeptest.py:SleepTest.test: ERROR (0.02 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 1 | WARN 0 | INTERRUPT 0
TESTS TIME : 0.02 s
JOB HTML   : /home/benjamin/avocado/job-results/job-2017-03-03T17.12-0304321/html/results.html

Adding --replay-results causes the first test passes:
$ ./scripts/avocado run --replay 16e4e4e --resume --fail-interrupted --replay-results
Using src job Mux data only, use `--replay-ignore variants` to override them.
JOB ID     : 11767a55901b8fac8ea9aafcc2604047110cecad
SRC JOB ID : 16e4e4e33256a6844cdbe87972031859c22c08c3
JOB LOG    : /home/benjamin/avocado/job-results/job-2017-03-03T17.14-11767a5/job.log
 (1/2) ./examples/tests/sleeptest.py:SleepTest.test: PASS (1.02 s)
 (2/2) ./examples/tests/sleeptest.py:SleepTest.test: ERROR (0.02 s)
RESULTS    : PASS 1 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0
TESTS TIME : 1.04 s
JOB HTML   : /home/benjamin/avocado/job-results/job-2017-03-03T17.14-11767a5/html/results.html