### PR TITLE
[V2] Make selftests to work with macOS

### DIFF
--- a/avocado/utils/iso9660.py
+++ b/avocado/utils/iso9660.py
@@ -27,6 +27,7 @@ import os
 import logging
 import tempfile
 import shutil
+import sys
 import re
 
 from . import process
@@ -311,8 +312,11 @@ class Iso9660Mount(BaseIso9660):
         """
         super(Iso9660Mount, self).__init__(path)
         self._mnt_dir = tempfile.mkdtemp(prefix='avocado_' + __name__)
-        process.run('mount -t iso9660 -v -o loop,ro %s %s' %
-                    (path, self.mnt_dir), sudo=True)
+        fs_type = 'iso9660'
+        if sys.platform.startswith('darwin'):
+            fs_type = 'cd9660'
+        process.run('mount -t %s -v -o loop,ro %s %s' %
+                    (fs_type, path, self.mnt_dir), sudo=True)
 
     def read(self, path):
         """

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -155,6 +155,7 @@ def kill_process_tree(pid, sig=signal.SIGKILL, send_sigcont=True):
     :param pid: The pid of the process to signal.
     :param sig: The signal to send to the processes.
     """
+    # TODO: This relies on the GNU version of ps (need to fix MacOS support)
     if not safe_kill(pid, signal.SIGSTOP):
         return
     children = system_output("ps --ppid=%d -o pid=" % pid, ignore_status=True,
@@ -189,6 +190,7 @@ def process_in_ptree_is_defunct(ppid):
 
     :param ppid: The parent PID of the process to verify.
     """
+    # TODO: This relies on the GNU version of ps (need to fix MacOS support)
     defunct = False
     try:
         pids = get_children_pids(ppid)
@@ -210,6 +212,7 @@ def get_children_pids(ppid, recursive=False):
     param recursive: True to return all levels of subprocesses
     return: list of PIDs of all children/threads of ppid
     """
+    # TODO: This relies on the GNU version of ps (need to fix MacOS support)
 
     cmd = "ps -L --ppid=%d -o lwp"
 

--- a/examples/tests/doublefree.py
+++ b/examples/tests/doublefree.py
@@ -3,6 +3,7 @@
 import os
 import shutil
 import signal
+import sys
 
 from avocado import Test
 from avocado import main
@@ -19,6 +20,8 @@ class DoubleFreeTest(Test):
 
     :param source: name of the source file located in deps path
     """
+    GLIBC_MSG = 'double free or corruption'
+    MAC_LIBC_MSG = 'pointer being freed was not allocated'
 
     def setUp(self):
         """
@@ -43,7 +46,13 @@ class DoubleFreeTest(Test):
         expected_exit_status = -signal.SIGABRT
         output = cmd_result.stdout + cmd_result.stderr
         self.assertEqual(cmd_result.exit_status, expected_exit_status)
-        self.assertIn('double free or corruption', output)
+        if sys.platform.startswith('darwin'):
+            pattern = self.MAC_LIBC_MSG
+        else:
+            pattern = self.GLIBC_MSG
+        self.assertTrue(pattern in output,
+                        msg='Could not find pattern %s in output %s' %
+                            (pattern, output))
 
 
 if __name__ == "__main__":

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -12,6 +12,7 @@ import time
 import xml.dom.minidom
 import zipfile
 import unittest
+import psutil
 
 import pkg_resources
 
@@ -24,6 +25,7 @@ from avocado.utils import path as utils_path
 basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..')
 basedir = os.path.abspath(basedir)
 
+TRUE_CMD = utils_path.find_command('true')
 
 PASS_SCRIPT_CONTENTS = """#!/bin/sh
 true
@@ -106,7 +108,11 @@ def probe_binary(binary):
 
 
 CC_BINARY = probe_binary('cc')
+# On macOS, the default coreutils installation (brew)
+# installs the gnu utility versions with a g prefix.
 ECHO_BINARY = probe_binary('echo')
+if ECHO_BINARY is not None:
+    ECHO_BINARY = probe_binary('gecho')
 READ_BINARY = probe_binary('read')
 SLEEP_BINARY = probe_binary('sleep')
 
@@ -470,7 +476,7 @@ class RunnerOperationTest(unittest.TestCase):
         log = open(debuglog, 'r').read()
         # Remove the result dir
         shutil.rmtree(os.path.dirname(os.path.dirname(debuglog)))
-        self.assertIn('/tmp', debuglog)   # Use tmp dir, not default location
+        self.assertIn(tempfile.gettempdir(), debuglog)   # Use tmp dir, not default location
         self.assertEqual(result['job_id'], u'0' * 40)
         # Check if all tests were skipped
         self.assertEqual(result['skip'], 4)
@@ -716,8 +722,10 @@ class RunnerSimpleTest(unittest.TestCase):
                               % (self.tmpdir, SLEEP_BINARY))
         proc.read_until_output_matches(["\(1/1\)"], timeout=3,
                                        internal_timeout=0.01)
-        # We need pid of the avocado, not the shell executing it
-        pid = int(process.get_children_pids(proc.get_pid())[0])
+        # We need pid of the avocado process, not the shell executing it
+        avocado_shell = psutil.Process(proc.get_pid())
+        avocado_proc = avocado_shell.children()[0]
+        pid = avocado_proc.pid
         os.kill(pid, signal.SIGTSTP)   # This freezes the process
         deadline = time.time() + 9
         while time.time() < deadline:
@@ -807,7 +815,7 @@ class ExternalRunnerTest(unittest.TestCase):
     def test_externalrunner_no_url(self):
         os.chdir(basedir)
         cmd_line = ('./scripts/avocado run --job-results-dir %s --sysinfo=off '
-                    '--external-runner=/bin/true' % self.tmpdir)
+                    '--external-runner=%s' % (self.tmpdir, TRUE_CMD))
         result = process.run(cmd_line, ignore_status=True)
         expected_output = ('No test references provided nor any other '
                            'arguments resolved into tests')

--- a/selftests/functional/test_interrupt.py
+++ b/selftests/functional/test_interrupt.py
@@ -104,7 +104,10 @@ class InterruptTest(unittest.TestCase):
                         if old_psutil:
                             cmdline_list = psutil.Process(p).cmdline
                         else:
-                            cmdline_list = psutil.Process(p).cmdline()
+                            try:
+                                cmdline_list = psutil.Process(p).cmdline()
+                            except psutil.AccessDenied:
+                                continue
                         if bad_test.path in " ".join(cmdline_list):
                             bad_test_processes.append(p_obj)
                 # psutil.NoSuchProcess happens when the original
@@ -159,7 +162,10 @@ class InterruptTest(unittest.TestCase):
                         if old_psutil:
                             cmdline_list = psutil.Process(p).cmdline
                         else:
-                            cmdline_list = psutil.Process(p).cmdline()
+                            try:
+                                cmdline_list = psutil.Process(p).cmdline()
+                            except psutil.AccessDenied:
+                                cmdline_list = []
                         if good_test.path in " ".join(cmdline_list):
                             good_test_processes.append(p_obj)
                 # psutil.NoSuchProcess happens when the original

--- a/selftests/functional/test_lv_utils.py
+++ b/selftests/functional/test_lv_utils.py
@@ -6,6 +6,7 @@ avocado.utils.lv_utils selftests
 from avocado.utils import process, lv_utils
 import glob
 import os
+import sys
 import shutil
 import tempfile
 import unittest
@@ -17,6 +18,8 @@ class LVUtilsTest(unittest.TestCase):
     Check the LVM related utilities
     """
 
+    @unittest.skipIf(sys.platform.startswith('darwin'),
+                     'macOS does not support LVM')
     @unittest.skipIf(process.system("which vgs", ignore_status=True),
                      "LVM utils not installed (command vgs is missing)")
     @unittest.skipIf(not process.can_sudo(), "This test requires root or "
@@ -30,7 +33,10 @@ class LVUtilsTest(unittest.TestCase):
         for vg_name in self.vgs:
             lv_utils.vg_remove(vg_name)
 
-    @unittest.skipIf(process.system("modinfo scsi_debug", ignore_status=True),
+    @unittest.skipIf(sys.platform.startswith('darwin'),
+                     'macOS does not support LVM')
+    @unittest.skipIf(process.system("modinfo scsi_debug", shell=True,
+                                    ignore_status=True),
                      "Kernel mod 'scsi_debug' not available.")
     @unittest.skipIf(process.system("lsmod | grep -q scsi_debug; [ $? -ne 0 ]",
                                     shell=True, ignore_status=True),
@@ -64,6 +70,8 @@ class LVUtilsTest(unittest.TestCase):
         else:
             self.fail("Fail to remove scsi_debug after testing: %s" % res)
 
+    @unittest.skipIf(sys.platform.startswith('darwin'),
+                     'macOS does not support LVM')
     @unittest.skipIf(process.system("vgs --all | grep -q avocado_testing_vg_"
                                     "e5kj3erv11a; [ $? -ne 0 ]", sudo=True,
                                     shell=True, ignore_status=True),

--- a/selftests/unit/test_archive.py
+++ b/selftests/unit/test_archive.py
@@ -2,6 +2,7 @@ import unittest
 import tempfile
 import os
 import shutil
+import sys
 import random
 
 from avocado.utils import archive
@@ -93,6 +94,8 @@ class ArchiveTest(unittest.TestCase):
     def test_tbz2_2_file(self):
         self.compress_and_check_file('.tbz2')
 
+    @unittest.skipIf(sys.platform.startswith('darwin'),
+                     'macOS does not support archive extra attributes')
     def test_zip_extra_attrs(self):
         """
         Check that utils.archive reflects extra attrs of file like symlinks

--- a/selftests/unit/test_utils_partition.py
+++ b/selftests/unit/test_utils_partition.py
@@ -30,6 +30,8 @@ class TestPartition(unittest.TestCase):
     Unit tests for avocado.utils.partition
     """
 
+    @unittest.skipIf(not os.path.isdir('/proc/mounts'),
+                     'system does not have /proc/mounts')
     @unittest.skipIf(not process.can_sudo('mount'),
                      'current user must be allowed to run "mount" under sudo')
     @unittest.skipIf(not process.can_sudo('mkfs.ext2 -V'),
@@ -96,6 +98,8 @@ class TestPartition(unittest.TestCase):
         shutil.rmtree(self.tmpdir)
 
 
+@unittest.skipIf(not os.path.isfile('/etc/mtab'),
+                 'macOS does not have /etc/mtab')
 class TestMtabLock(unittest.TestCase):
 
     """

--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -6,6 +6,8 @@ from avocado.utils import gdb
 from avocado.utils import process
 from avocado.utils import path
 
+TRUE_CMD = path.find_command('true')
+
 
 class TestGDBProcess(unittest.TestCase):
 
@@ -40,7 +42,7 @@ class TestGDBProcess(unittest.TestCase):
 
     def test_get_sub_process_klass(self):
         gdb.GDB_RUN_BINARY_NAMES_EXPR = []
-        self.assertIs(process.get_sub_process_klass('/bin/true'),
+        self.assertIs(process.get_sub_process_klass(TRUE_CMD),
                       process.SubProcess)
 
         gdb.GDB_RUN_BINARY_NAMES_EXPR.append('/bin/false')
@@ -74,7 +76,7 @@ def mock_fail_find_cmd(cmd, default=None):
 class TestProcessRun(unittest.TestCase):
 
     @patch.object(path, 'find_command',
-                  MagicMock(return_value='/bin/true'))
+                  MagicMock(return_value=TRUE_CMD))
     @patch.object(os, 'getuid', MagicMock(return_value=1000))
     def test_subprocess_nosudo(self):
         expected_command = 'ls -l'
@@ -82,7 +84,7 @@ class TestProcessRun(unittest.TestCase):
         self.assertEqual(p.cmd, expected_command)
 
     @patch.object(path, 'find_command',
-                  MagicMock(return_value='/bin/true'))
+                  MagicMock(return_value=TRUE_CMD))
     @patch.object(os, 'getuid', MagicMock(return_value=0))
     def test_subprocess_nosudo_uid_0(self):
         expected_command = 'ls -l'
@@ -90,10 +92,10 @@ class TestProcessRun(unittest.TestCase):
         self.assertEqual(p.cmd, expected_command)
 
     @patch.object(path, 'find_command',
-                  MagicMock(return_value='/bin/true'))
+                  MagicMock(return_value=TRUE_CMD))
     @patch.object(os, 'getuid', MagicMock(return_value=1000))
     def test_subprocess_sudo(self):
-        expected_command = '/bin/true -n ls -l'
+        expected_command = '%s -n ls -l' % TRUE_CMD
         p = process.SubProcess(cmd='ls -l', sudo=True)
         self.assertEqual(p.cmd, expected_command)
 
@@ -105,7 +107,7 @@ class TestProcessRun(unittest.TestCase):
         self.assertEqual(p.cmd, expected_command)
 
     @patch.object(path, 'find_command',
-                  MagicMock(return_value='/bin/true'))
+                  MagicMock(return_value=TRUE_CMD))
     @patch.object(os, 'getuid', MagicMock(return_value=0))
     def test_subprocess_sudo_uid_0(self):
         expected_command = 'ls -l'
@@ -113,10 +115,10 @@ class TestProcessRun(unittest.TestCase):
         self.assertEqual(p.cmd, expected_command)
 
     @patch.object(path, 'find_command',
-                  MagicMock(return_value='/bin/true'))
+                  MagicMock(return_value=TRUE_CMD))
     @patch.object(os, 'getuid', MagicMock(return_value=1000))
     def test_subprocess_sudo_shell(self):
-        expected_command = '/bin/true -n -s ls -l'
+        expected_command = '%s -n -s ls -l' % TRUE_CMD
         p = process.SubProcess(cmd='ls -l', sudo=True, shell=True)
         self.assertEqual(p.cmd, expected_command)
 
@@ -128,7 +130,7 @@ class TestProcessRun(unittest.TestCase):
         self.assertEqual(p.cmd, expected_command)
 
     @patch.object(path, 'find_command',
-                  MagicMock(return_value='/bin/true'))
+                  MagicMock(return_value=TRUE_CMD))
     @patch.object(os, 'getuid', MagicMock(return_value=0))
     def test_subprocess_sudo_shell_uid_0(self):
         expected_command = 'ls -l'
@@ -136,7 +138,7 @@ class TestProcessRun(unittest.TestCase):
         self.assertEqual(p.cmd, expected_command)
 
     @patch.object(path, 'find_command',
-                  MagicMock(return_value='/bin/true'))
+                  MagicMock(return_value=TRUE_CMD))
     @patch.object(os, 'getuid', MagicMock(return_value=1000))
     def test_run_nosudo(self):
         expected_command = 'ls -l'
@@ -144,7 +146,7 @@ class TestProcessRun(unittest.TestCase):
         self.assertEqual(p.command, expected_command)
 
     @patch.object(path, 'find_command',
-                  MagicMock(return_value='/bin/true'))
+                  MagicMock(return_value=TRUE_CMD))
     @patch.object(os, 'getuid', MagicMock(return_value=0))
     def test_run_nosudo_uid_0(self):
         expected_command = 'ls -l'
@@ -152,10 +154,10 @@ class TestProcessRun(unittest.TestCase):
         self.assertEqual(p.command, expected_command)
 
     @patch.object(path, 'find_command',
-                  MagicMock(return_value='/bin/true'))
+                  MagicMock(return_value=TRUE_CMD))
     @patch.object(os, 'getuid', MagicMock(return_value=1000))
     def test_run_sudo(self):
-        expected_command = '/bin/true -n ls -l'
+        expected_command = '%s -n ls -l' % TRUE_CMD
         p = process.run(cmd='ls -l', sudo=True, ignore_status=True)
         self.assertEqual(p.command, expected_command)
 
@@ -167,7 +169,7 @@ class TestProcessRun(unittest.TestCase):
         self.assertEqual(p.command, expected_command)
 
     @patch.object(path, 'find_command',
-                  MagicMock(return_value='/bin/true'))
+                  MagicMock(return_value=TRUE_CMD))
     @patch.object(os, 'getuid', MagicMock(return_value=0))
     def test_run_sudo_uid_0(self):
         expected_command = 'ls -l'
@@ -175,10 +177,10 @@ class TestProcessRun(unittest.TestCase):
         self.assertEqual(p.command, expected_command)
 
     @patch.object(path, 'find_command',
-                  MagicMock(return_value='/bin/true'))
+                  MagicMock(return_value=TRUE_CMD))
     @patch.object(os, 'getuid', MagicMock(return_value=1000))
     def test_run_sudo_shell(self):
-        expected_command = '/bin/true -n -s ls -l'
+        expected_command = '%s -n -s ls -l' % TRUE_CMD
         p = process.run(cmd='ls -l', sudo=True, shell=True, ignore_status=True)
         self.assertEqual(p.command, expected_command)
 
@@ -190,7 +192,7 @@ class TestProcessRun(unittest.TestCase):
         self.assertEqual(p.command, expected_command)
 
     @patch.object(path, 'find_command',
-                  MagicMock(return_value='/bin/true'))
+                  MagicMock(return_value=TRUE_CMD))
     @patch.object(os, 'getuid', MagicMock(return_value=0))
     def test_run_sudo_shell_uid_0(self):
         expected_command = 'ls -l'


### PR DESCRIPTION
This is a follow up to #1783.

We still have ways to go before we can say that macOS is a 2nd tier supported platform on avocado, but this at least makes the avocado selftests to work under that platform. More work is necessary to  make some APIs to fully work on macOS in a way that pleases different groups that use avocado.

I've removed the commit that adds OSX as a target on Travis CI because that is going to take more time and effort. The changes proposed are not hugely controversial and touch avocado APIs where the change was trivial.

Changes from V1 (RFC):
* Implemented suggestions from @ldoktor that don't tie conditional skip unittests to the `darwin` platform.
* Removed patch adding OSX as a Travis CI target
* Added TODO items to fix some `avocado.utils.process` APIs on macOS