### PR TITLE
runner: fix _iter_variants()

### DIFF
--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -478,7 +478,7 @@ class TestRunner(object):
         :raises ValueError: When variant and template declare params.
         """
         for variant in variants.itertests():
-            params = variant.get("variant")
+            params = (variant.get("variant"), variant.get("mux_path"))
             if params:
                 if "params" in template[1]:
                     msg = ("Unable to use test variants %s, params are already"


### PR DESCRIPTION
variants.itertests() changed the format of each variant from a tuple to
a dictionary. After that change, the runner was not updated to provide
the mux_path considering the new format.

This patch adds the mux_path to the factory params in _iter_variants(),
fixing the Test.self.__params resolution.

Fixes: #1839 
Signed-off-by: Amador Pahim <apahim@redhat.com>