### PR TITLE
Varianter: drop "plugin" from interface name

### DIFF
--- a/avocado/core/plugin_interfaces.py
+++ b/avocado/core/plugin_interfaces.py
@@ -203,7 +203,7 @@ class ResultEvents(JobPreTests, JobPostTests):
         """
 
 
-class VarianterPlugin(Plugin):
+class Varianter(Plugin):
 
     """
     Base plugin interface for producing test variants usually from cmd line

--- a/avocado/plugins/yaml_to_mux.py
+++ b/avocado/plugins/yaml_to_mux.py
@@ -20,7 +20,7 @@ import re
 import sys
 
 from avocado.core import tree, exit_codes, mux
-from avocado.core.plugin_interfaces import CLI, VarianterPlugin
+from avocado.core.plugin_interfaces import CLI, Varianter
 
 
 try:
@@ -288,7 +288,7 @@ class YamlToMuxCLI(CLI):
         """
 
 
-class YamlToMux(mux.MuxPlugin, VarianterPlugin):
+class YamlToMux(mux.MuxPlugin, Varianter):
 
     """
     Processes the mux options into varianter plugin


### PR DESCRIPTION
All the plugin interfaces defined in `avocado.core.plugin_interfaces`
ommit the "plugin" term, simply because this is already qualified in
the module name.

Let's also standardize the Varianter interface to "plugin-less" name.

Signed-off-by: Cleber Rosa <crosa@redhat.com>