### PR TITLE
Varianter: drop "plugin" from interface name

### DIFF
--- a/avocado/core/mux.py
+++ b/avocado/core/mux.py
@@ -90,7 +90,7 @@ class MuxPlugin(object):
     """
     Base implementation of Mux-like Varianter plugin. It should be used as
     a base class in conjunction with
-    :class:`avocado.core.plugin_interfaces.VarianterPlugin`.
+    :class:`avocado.core.plugin_interfaces.Varianter`.
     """
     root = None
     variants = None
@@ -111,7 +111,7 @@ class MuxPlugin(object):
 
     def __iter__(self):
         """
-        See :meth:`avocado.core.plugin_interfaces.VarianterPlugin.__iter__`
+        See :meth:`avocado.core.plugin_interfaces.Varianter.__iter__`
         """
         if self.root is None:
             return
@@ -123,7 +123,7 @@ class MuxPlugin(object):
     def update_defaults(self, defaults):
         """
         See
-        :meth:`avocado.core.plugin_interfaces.VarianterPlugin.update_defaults`
+        :meth:`avocado.core.plugin_interfaces.Varianter.update_defaults`
         """
         if self.root is None:
             return
@@ -136,7 +136,7 @@ class MuxPlugin(object):
 
     def to_str(self, summary, variants, **kwargs):
         """
-        See :meth:`avocado.core.plugin_interfaces.VarianterPlugin.to_str`
+        See :meth:`avocado.core.plugin_interfaces.Varianter.to_str`
         """
         if not self.variants:
             return ""
@@ -183,7 +183,7 @@ class MuxPlugin(object):
 
     def __len__(self):
         """
-        See :meth:`avocado.core.plugin_interfaces.VarianterPlugin.__len__`
+        See :meth:`avocado.core.plugin_interfaces.Varianter.__len__`
         """
         if self.root is None:
             return 0

--- a/avocado/core/plugin_interfaces.py
+++ b/avocado/core/plugin_interfaces.py
@@ -203,7 +203,7 @@ class ResultEvents(JobPreTests, JobPostTests):
         """
 
 
-class VarianterPlugin(Plugin):
+class Varianter(Plugin):
 
     """
     Base plugin interface for producing test variants usually from cmd line

--- a/avocado/plugins/yaml_to_mux.py
+++ b/avocado/plugins/yaml_to_mux.py
@@ -20,7 +20,7 @@ import re
 import sys
 
 from avocado.core import tree, exit_codes, mux
-from avocado.core.plugin_interfaces import CLI, VarianterPlugin
+from avocado.core.plugin_interfaces import CLI, Varianter
 
 
 try:
@@ -288,7 +288,7 @@ class YamlToMuxCLI(CLI):
         """
 
 
-class YamlToMux(mux.MuxPlugin, VarianterPlugin):
+class YamlToMux(mux.MuxPlugin, Varianter):
 
     """
     Processes the mux options into varianter plugin

--- a/docs/source/TestParameters.rst
+++ b/docs/source/TestParameters.rst
@@ -146,7 +146,7 @@ More practical overview of mux path is in `yaml_to_mux plugin`_ in
 Variant
 ~~~~~~~
 
-Variant is a set of params produced by `VarianterPlugin`_s and passed to
+Variant is a set of params produced by `Varianter`_s and passed to
 the test by the test runner as ``params`` argument. The simplest variant
 is ``None``, which still produces `AvocadoParams`_ with only the
 `Test's default params`_. If dict is used as a `Variant`_, it (safely)
@@ -245,7 +245,7 @@ Where:
 Varianter plugins
 ~~~~~~~~~~~~~~~~~
 
-:class:`avocado.core.plugin_interfaces.VarianterPlugin`
+:class:`avocado.core.plugin_interfaces.Varianter`
 
 A plugin interface that can be used to build custom plugins which
 are used by `Varianter`_ to get test variants. For inspiration see
@@ -413,8 +413,8 @@ MuxPlugin
 :class:`avocado.core.mux.MuxPlugin`
 
 Defines the full interface required by
-:class:`avocado.core.plugin_interfaces.VarianterPlugin`. The plugin writer
-should inherit from this ``MuxPlugin``, then from the ``VarianterPlugin``
+:class:`avocado.core.plugin_interfaces.Varianter`. The plugin writer
+should inherit from this ``MuxPlugin``, then from the ``Varianter``
 and call the::
 
    self.initialize_mux(root, mux_path, debug)


### PR DESCRIPTION
All the plugin interfaces defined in `avocado.core.plugin_interfaces`
ommit the "plugin" term, simply because this is already qualified in
the module name.

Let's also standardize the Varianter interface to "plugin-less" name.

Signed-off-by: Cleber Rosa <crosa@redhat.com>

---

Changes from v1 (#1841):
 * Removed "plugin" suffix from docstring and docs references