### PR TITLE
Exit codes: review AVOCADO_JOB_FAIL and AVOCADO_FAIL usage

### DIFF
--- a/avocado/core/exit_codes.py
+++ b/avocado/core/exit_codes.py
@@ -26,8 +26,8 @@ AVOCADO_ALL_OK = 0x0000
 #: Job went fine, but some tests FAILed or ERRORed
 AVOCADO_TESTS_FAIL = 0x0001
 
-#: Something went wrong with the Job itself, by explicit
-#: :class:`avocado.core.exceptions.JobError` exception.
+#: Something went wrong with an Avocado Job execution, usually by
+#: an explicit :class:`avocado.core.exceptions.JobError` exception.
 AVOCADO_JOB_FAIL = 0x0002
 
 #: Something else went wrong and avocado failed (or crashed). Commonly

--- a/avocado/core/restclient/cli/app.py
+++ b/avocado/core/restclient/cli/app.py
@@ -62,13 +62,13 @@ class App(object):
                 password=self.args.password)
         except connection.InvalidConnectionError:
             self.log.error("Error: could not connect to the server")
-            sys.exit(exit_codes.AVOCADO_JOB_FAIL)
+            sys.exit(exit_codes.AVOCADO_FAIL)
         except connection.InvalidServerVersionError:
             self.log.error("REST server version is higher than "
                            "than this client can support.")
             self.log.error("Please use a more recent version "
                            "of the REST client application.")
-            sys.exit(exit_codes.AVOCADO_JOB_FAIL)
+            sys.exit(exit_codes.AVOCADO_FAIL)
 
     def dispatch_action(self):
         """

--- a/avocado/plugins/diff.py
+++ b/avocado/plugins/diff.py
@@ -343,7 +343,7 @@ class Diff(CLICmd):
                 resultsdir = jobdata.get_resultsdir(logdir, job_id)
             except ValueError as exception:
                 LOG.error(exception.message)
-                sys.exit(exit_codes.AVOCADO_JOB_FAIL)
+                sys.exit(exit_codes.AVOCADO_FAIL)
 
         if resultsdir is None:
             LOG.error("Can't find job results directory for '%s' in '%s'",

--- a/avocado/plugins/multiplex.py
+++ b/avocado/plugins/multiplex.py
@@ -91,7 +91,7 @@ class Multiplex(CLICmd):
             varianter.parse(args)
         except (IOError, ValueError) as details:
             log.error("Unable to parse varianter: %s", details)
-            sys.exit(exit_codes.AVOCADO_JOB_FAIL)
+            sys.exit(exit_codes.AVOCADO_FAIL)
         use_utf8 = settings.get_value("runner.output", "utf8",
                                       key_type=bool, default=None)
         summary = args.summary or 0

--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -142,11 +142,11 @@ class Replay(CLI):
             resultsdir = jobdata.get_resultsdir(logdir, args.replay_jobid)
         except ValueError as exception:
             log.error(exception.message)
-            sys.exit(exit_codes.AVOCADO_JOB_FAIL)
+            sys.exit(exit_codes.AVOCADO_FAIL)
 
         if resultsdir is None:
             log.error("Can't find job results directory in '%s'", logdir)
-            sys.exit(exit_codes.AVOCADO_JOB_FAIL)
+            sys.exit(exit_codes.AVOCADO_FAIL)
 
         sourcejob = jobdata.get_id(os.path.join(resultsdir, 'id'),
                                    args.replay_jobid)
@@ -154,7 +154,7 @@ class Replay(CLI):
             msg = ("Can't find matching job id '%s' in '%s' directory."
                    % (args.replay_jobid, resultsdir))
             log.error(msg)
-            sys.exit(exit_codes.AVOCADO_JOB_FAIL)
+            sys.exit(exit_codes.AVOCADO_FAIL)
         setattr(args, 'replay_sourcejob', sourcejob)
 
         replay_args = jobdata.retrieve_args(resultsdir)
@@ -186,7 +186,7 @@ class Replay(CLI):
             references = jobdata.retrieve_references(resultsdir)
             if references is None:
                 log.error('Source job test references data not found. Aborting.')
-                sys.exit(exit_codes.AVOCADO_JOB_FAIL)
+                sys.exit(exit_codes.AVOCADO_FAIL)
             else:
                 setattr(args, 'reference', references)
 
@@ -203,7 +203,7 @@ class Replay(CLI):
             variants = jobdata.retrieve_variants(resultsdir)
             if variants is None:
                 log.error('Source job variants data not found. Aborting.')
-                sys.exit(exit_codes.AVOCADO_JOB_FAIL)
+                sys.exit(exit_codes.AVOCADO_FAIL)
             else:
                 # Ignore data manipulation. This is necessary, because
                 # we replaced the unparsed object with parsed one. There

--- a/avocado/plugins/yaml_to_mux.py
+++ b/avocado/plugins/yaml_to_mux.py
@@ -335,7 +335,10 @@ class YamlToMux(mux.MuxPlugin, Varianter):
             except IOError as details:
                 error_msg = "%s : %s" % (details.strerror, details.filename)
                 logging.getLogger("avocado.app").error(error_msg)
-                sys.exit(exit_codes.AVOCADO_JOB_FAIL)
+                if args.subcommand == 'run':
+                    sys.exit(exit_codes.AVOCADO_JOB_FAIL)
+                else:
+                    sys.exit(exit_codes.AVOCADO_FAIL)
 
         # Deprecated --multiplex option
         multiplex_files = getattr(args, "multiplex", None)
@@ -348,7 +351,10 @@ class YamlToMux(mux.MuxPlugin, Varianter):
             except IOError as details:
                 error_msg = "%s : %s" % (details.strerror, details.filename)
                 logging.getLogger("avocado.app").error(error_msg)
-                sys.exit(exit_codes.AVOCADO_JOB_FAIL)
+                if args.subcommand == 'run':
+                    sys.exit(exit_codes.AVOCADO_JOB_FAIL)
+                else:
+                    sys.exit(exit_codes.AVOCADO_FAIL)
 
         # Extend default multiplex tree of --mux-inject values
         for inject in getattr(args, "mux_inject", []):

--- a/selftests/functional/test_multiplex.py
+++ b/selftests/functional/test_multiplex.py
@@ -49,7 +49,7 @@ class MultiplexTests(unittest.TestCase):
 
     def test_mplex_plugin_nonexistent(self):
         cmd_line = './scripts/avocado multiplex -m nonexist'
-        expected_rc = exit_codes.AVOCADO_JOB_FAIL
+        expected_rc = exit_codes.AVOCADO_FAIL
         result = self.run_and_check(cmd_line, expected_rc)
         self.assertIn('No such file or directory', result.stderr)
 

--- a/selftests/functional/test_replay_basic.py
+++ b/selftests/functional/test_replay_basic.py
@@ -44,7 +44,7 @@ class ReplayTests(unittest.TestCase):
         cmd_line = ('./scripts/avocado run --replay %s '
                     '--job-results-dir %s --sysinfo=off' %
                     ('foo', self.tmpdir))
-        expected_rc = exit_codes.AVOCADO_JOB_FAIL
+        expected_rc = exit_codes.AVOCADO_FAIL
         self.run_and_check(cmd_line, expected_rc)
 
     def test_run_replay_latest(self):


### PR DESCRIPTION
The definition of AVOCADO_JOB_FAIL was "Something went wrong with the
Job itself, by explicit avocado.core.exceptions.JobError exception",
while AVOCADO_FAIL is defined as "Something else went wrong and
avocado failed (or crashed). Commonly used on command line validation
errors".

With those in mind, I support that AVOCADO_JOB_FAIL should be slightly
adjusted (see changes in the diff), to include other types of
failures, but limited to job *execution* failures.  AVOCADO_FAIL is
already generic enough, so there's no need to change its definition.
This is important, IMHO, because users could quickly understand if a
job was executed, and failed, or if some earlier type of failure (such
as command line validation) happened.

With this updated definition, I spotted a few places where AVOCADO_FAIL
and AVOCADO_JOB_FAIL usage should be changed.  Examples:

 * In `avocado.plugins.diff` the resultsdir is attempted to be read, but
   in my book that still doesn't qualify as a job failure, because a job
   is not being executed.

 * In `avocado.plugins.replay` while there's functionality to run a
   (replayed) job, many of the occurrences of AVOCADO_JOB_FAIL are
   similar to the `avocado.plugins.diff` and happen while trying to load
   jobdata from the previous job resultsdir.

 * In `avocado.plugins.multiplex` the situation is a bit more tricky.  The
   same code is executed when multiple avocado subcommands are executed.
   If the currently executed command is `run`, it would mean that a job is
   being attempted to be executed.  In fact, a job *is* already executing
   at this point, so a AVOCADO_JOB_FAIL is appropriate.  In other scenarios,
   such as when running `$ avocado multiplex`, these failures have nothing
   to do with jobs, so AVOCADO_FAIL is appropriate.

Signed-off-by: Cleber Rosa <crosa@redhat.com>