### PR TITLE
Introduce the CANCEL status and the self.cancel()

### DIFF
--- a/avocado/core/exceptions.py
+++ b/avocado/core/exceptions.py
@@ -177,3 +177,12 @@ class TestWarn(TestBaseException):
     failure.
     """
     status = "WARN"
+
+
+class TestCancel(TestBaseException):
+    """
+    Indicates that a test was cancelled.
+
+    Should be thrown when cancel() is used in the test method.
+    """
+    status = "CANCEL"

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -78,6 +78,7 @@ class TermSupport(object):
         self.INTERRUPT = self.COLOR_RED
         self.ERROR = self.COLOR_RED
         self.WARN = self.COLOR_YELLOW
+        self.CANCEL = self.COLOR_YELLOW
         self.PARTIAL = self.COLOR_YELLOW
         self.ENDC = self.CONTROL_END
         self.LOWLIGHT = self.COLOR_DARKGREY

--- a/avocado/core/result.py
+++ b/avocado/core/result.py
@@ -41,6 +41,7 @@ class Result(object):
         self.skipped = 0
         self.warned = 0
         self.interrupted = 0
+        self.cancelled = 0
         self.tests = []
 
     def _reconcile(self):
@@ -53,7 +54,8 @@ class Result(object):
         """
         valid_results_count = (self.passed + self.errors +
                                self.failed + self.warned +
-                               self.skipped + self.interrupted)
+                               self.skipped + self.interrupted +
+                               self.cancelled)
         other_skipped_count = self.tests_total - valid_results_count
         if other_skipped_count > 0:
             self.skipped += other_skipped_count
@@ -103,6 +105,8 @@ class Result(object):
             self.warned += 1
         elif status == "INTERRUPTED":
             self.interrupted += 1
+        elif status == "CANCEL":
+            self.cancelled += 1
         else:
             self.errors += 1
         self.end_test(state)

--- a/avocado/core/status.py
+++ b/avocado/core/status.py
@@ -26,14 +26,16 @@ mapping = {"SKIP": True,
            "ALERT": False,
            "RUNNING": False,
            "NOSTATUS": False,
-           "INTERRUPTED": False}
+           "INTERRUPTED": False,
+           "CANCEL": True}
 
 user_facing_status = ["SKIP",
                       "ERROR",
                       "FAIL",
                       "WARN",
                       "PASS",
-                      "INTERRUPTED"]
+                      "INTERRUPTED",
+                      "CANCEL"]
 
 feedback = {
     # Test did not advertise current status, but process running the test is

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -567,6 +567,13 @@ class Test(unittest.TestCase):
                 exceptions.TestSkipError) as details:
             stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
             raise exceptions.TestSkipError(details)
+        except exceptions.TestCancel as details:
+            stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
+            skip_illegal_msg = ('Calling cancel() in setUp() '
+                                'is not allowed in avocado, you '
+                                'must fix your test. Original cancel exception: '
+                                '%s' % details)
+            raise exceptions.TestError(skip_illegal_msg)
         except:  # Old-style exceptions are not inherited from Exception()
             stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
             details = sys.exc_info()[1]
@@ -583,6 +590,9 @@ class Test(unittest.TestCase):
         except exceptions.TestDecoratorSkip as details:
             stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
             raise exceptions.TestSkipError(details)
+        except exceptions.TestCancel as details:
+            stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
+            raise exceptions.TestCancel(details)
         except:  # Old-style exceptions are not inherited from Exception()
             stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
             details = sys.exc_info()[1]
@@ -773,6 +783,9 @@ class Test(unittest.TestCase):
         :type message: str
         """
         raise exceptions.TestSetupSkip(message)
+
+    def cancel(self, message=None):
+        raise exceptions.TestCancel(message)
 
     def fetch_asset(self, name, asset_hash=None, algorithm='sha1',
                     locations=None, expire=None):

--- a/avocado/plugins/human.py
+++ b/avocado/plugins/human.py
@@ -35,7 +35,8 @@ class Human(ResultEvents):
                       'FAIL': output.TERM_SUPPORT.FAIL,
                       'SKIP': output.TERM_SUPPORT.SKIP,
                       'WARN': output.TERM_SUPPORT.WARN,
-                      'INTERRUPTED': output.TERM_SUPPORT.INTERRUPT}
+                      'INTERRUPTED': output.TERM_SUPPORT.INTERRUPT,
+                      'CANCEL': output.TERM_SUPPORT.CANCEL}
 
     def __init__(self, args):
         self.log = logging.getLogger("avocado.app")
@@ -93,7 +94,8 @@ class Human(ResultEvents):
         if not self.owns_stdout:
             return
         self.log.info("RESULTS    : PASS %d | ERROR %d | FAIL %d | SKIP %d | "
-                      "WARN %d | INTERRUPT %s", job.result.passed,
+                      "WARN %d | INTERRUPT %s | CANCEL %s", job.result.passed,
                       job.result.errors, job.result.failed, job.result.skipped,
-                      job.result.warned, job.result.interrupted)
+                      job.result.warned, job.result.interrupted,
+                      job.result.cancelled)
         self.log.info("TESTS TIME : %.2f s", job.result.tests_total_time)

--- a/avocado/plugins/jsonresult.py
+++ b/avocado/plugins/jsonresult.py
@@ -62,6 +62,7 @@ class JSONResult(Result):
                    'errors': result.errors,
                    'failures': result.failed,
                    'skip': result.skipped,
+                   'cancel': result.cancelled,
                    'time': result.tests_total_time}
         return json.dumps(content,
                           sort_keys=True,

--- a/avocado/plugins/tap.py
+++ b/avocado/plugins/tap.py
@@ -114,6 +114,9 @@ class TAPResult(ResultEvents):
             self.__write("ok %s %s", result.tests_run, name)
         elif status == "SKIP":
             self.__write("ok %s %s  # SKIP %s", result.tests_run, name, state.get("fail_reason"))
+        elif status == "CANCEL":
+            self.__write("ok %s %s  # CANCEL %s",
+                         result.tests_run, name, state.get("fail_reason"))
         else:
             self.__write("not ok %s %s", result.tests_run, name)
 

--- a/avocado/plugins/xunit.py
+++ b/avocado/plugins/xunit.py
@@ -79,7 +79,7 @@ class XUnitResult(Result):
         testsuite.setAttribute('tests', self._escape_attr(result.tests_total))
         testsuite.setAttribute('errors', self._escape_attr(result.errors + result.interrupted))
         testsuite.setAttribute('failures', self._escape_attr(result.failed))
-        testsuite.setAttribute('skipped', self._escape_attr(result.skipped))
+        testsuite.setAttribute('skipped', self._escape_attr(result.skipped + result.cancelled))
         testsuite.setAttribute('time', self._escape_attr(result.tests_total_time))
         testsuite.setAttribute('timestamp', self._escape_attr(datetime.datetime.now()))
         document.appendChild(testsuite)
@@ -90,6 +90,8 @@ class XUnitResult(Result):
                 pass
             elif status == 'SKIP':
                 testcase.appendChild(Element('skipped'))
+            elif status == 'CANCEL':
+                testcase.appendChild(Element('cancelled'))
             elif status == 'FAIL':
                 element = self._create_failure_or_error(document, test, 'failure')
                 testcase.appendChild(element)

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -1034,6 +1034,48 @@ Notice the ``test3`` was not skipped because the provided condition was
 not ``False``.
 
 
+Cancelling Tests
+================
+
+The only supported way to cancel a test and not negatively impact the
+job exit status (unlike using `self.fail` or `self.error`) is by using
+the `self.cancel()` method. The `self.cancel()` can be called only
+from your test methods. Example::
+
+    #!/usr/bin/env python
+
+    from avocado import Test
+    from avocado import main
+
+
+    class CancelTest(Test):
+
+        """
+        Example test that cancels the current test from inside the test.
+        """
+
+        def test(self):
+            self.cancel("This should end with CANCEL.")
+
+    if __name__ == "__main__":
+        main()
+
+The test above will result in::
+
+    $ avocado run canceltest.py
+    JOB ID     : e6e17fdbe3ced70a63ae1f2bdc1242b7339d1347
+    JOB LOG    : $HOME/avocado/job-results/job-2017-03-08T16.56-e6e17fd/job.log
+     (1/1) canceltest.py:CancelTest.test: CANCEL (0.00 s)
+    RESULTS    : PASS 0 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 1
+    TESTS TIME : 0.00 s
+
+    $ echo $?
+    0
+
+Notice that, since the `setUp()` was already executed, calling the
+`self.cancel()` will cancel the rest of the test from that point on, but
+the `tearDown()` will still be executed.
+
 Docstring Directives
 ====================
 

--- a/examples/tests/canceltest.py
+++ b/examples/tests/canceltest.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+
+from avocado import Test
+from avocado import main
+
+
+class CancelTest(Test):
+
+    """
+    Example test that cancels the current test from inside the test.
+    """
+
+    def test(self):
+        self.cancel("This should end with CANCEL.")
+
+
+if __name__ == "__main__":
+    main()

--- a/optional_plugins/html/avocado_result_html/__init__.py
+++ b/optional_plugins/html/avocado_result_html/__init__.py
@@ -113,7 +113,8 @@ class ReportModel(object):
                    "ALERT": "danger",
                    "RUNNING": "info",
                    "NOSTATUS": "info",
-                   "INTERRUPTED": "danger"}
+                   "INTERRUPTED": "danger",
+                   "CANCEL": "warning"}
         test_info = []
         results_dir = self.results_dir(False)
         for tst in self.result.tests:


### PR DESCRIPTION
We have received many requests to support skip tests from inside the
test method. As we can do that without breaking our own concepts, we
decided to introduce the CANCEL status and the corresponding
self.cancel() method to the Test class.

Reference: https://trello.com/c/viBJIEwI
Signed-off-by: Amador Pahim <apahim@redhat.com>