### PR TITLE
Making requirements-plugins to install dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,8 +140,12 @@ requirements-selftests: requirements
 	- pip install -r requirements-selftests.txt
 
 requirements-plugins: requirements
-	for MAKEFILE in $(AVOCADO_PLUGINS);\
-		do AVOCADO_DIRNAME=$(AVOCADO_DIRNAME) make -C $$MAKEFILE requirements &>/dev/null && echo ">> DONE $$MAKEFILE" || echo ">> SKIP $$MAKEFILE";\
+	for MAKEFILE in $(AVOCADO_PLUGINS);do\
+		if test -f $$MAKEFILE/Makefile -o -f $$MAKEFILE/setup.py -o -f $$MAKEFILE/requirements.txt; then echo ">> REQUIREMENTS $$MAKEFILE";\
+			if test -f $$MAKEFILE/Makefile; then AVOCADO_DIRNAME=$(AVOCADO_DIRNAME) make -C $$MAKEFILE requirement &>/dev/null;\
+			elif test -f $$MAKEFILE/setup.py; then cd $$MAKEFILE; $(PYTHON) setup.py develop $(PYTHON_DEVELOP_ARGS); cd -;\
+			elif test -f $$MAKEFILE/requirements.txt; then cd $$MAKEFILE; pip install -r $$MAKEFILE/requirements.txt; cd -; fi;\
+		else echo ">> SKIP $$MAKEFILE"; fi;\
 	done
 
 smokecheck: clean develop


### PR DESCRIPTION
Similar to make link the Makefile now walks throught the plugins
and install dependencies depending on the makefile type.

https://trello.com/c/R9rxte6o/608-add-make-requirements-plugins

Signed-off-by: Greeshma Gopinath <ggopinat@redhat.com>