### PR TITLE
avocado/core/dispatcher.py: function `sorted()` is the one being used

### DIFF
--- a/avocado/core/dispatcher.py
+++ b/avocado/core/dispatcher.py
@@ -79,7 +79,7 @@ class Dispatcher(EnabledExtensionManager):
 
         This differs from :func:`stevedore.extension.ExtensionManager.names`
         in that it returns names in a predictable order, by using standard
-        :func:`order`.
+        :func:`sorted`.
         """
         return sorted(super(Dispatcher, self).names())
 


### PR DESCRIPTION
And not `order()` as mentioned in the docstring.

Signed-off-by: Cleber Rosa <crosa@redhat.com>