### PR TITLE
docs: tearDown() on test skip

### DIFF
--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -987,6 +987,9 @@ Will produce the following result::
     TESTS TIME : 0.00 s
     JOB HTML   : $HOME/avocado/job-results/job-2017-02-03T17.16-1bd8642/html/results.html
 
+Notice that the `tearDown()` will not be executed when `skip()` is used.
+Any cleanup treatment has to be handled by the `setUp()`, before the
+call to `skip()`.
 
 Avocado Skip Decorators
 -----------------------
@@ -1032,6 +1035,9 @@ Will produce the following result::
 
 Notice the ``test3`` was not skipped because the provided condition was
 not ``False``.
+
+Using the skip decorators, since the `setUp()` was already executed, the
+`tearDown()` will be also executed.
 
 
 Docstring Directives


### PR DESCRIPTION
Mention the behaviour of different skip forms regarding the tearDown().

Reference: https://trello.com/c/gsdBAmMY
Signed-off-by: Amador Pahim <apahim@redhat.com>