### PR TITLE
selftests: selfcheck with results in a tempdir

### DIFF
--- a/selftests/checkall
+++ b/selftests/checkall
@@ -89,7 +89,7 @@ if [ "$AVOCADO_PARALLEL_CHECK" ]; then
 elif [ -z "$AVOCADO_SELF_CHECK" ]; then
     run_rc selftests selftests/run
 else
-    CMD='scripts/avocado run `./contrib/scripts/avocado-find-unittests selftests/{unit,functional,doc}/*.py | xargs` --external-runner="/usr/bin/env python -m unittest"'
+    CMD='scripts/avocado run --job-results-dir=$(mktemp -d) `./contrib/scripts/avocado-find-unittests selftests/{unit,functional,doc}/*.py | xargs` --external-runner="/usr/bin/env python -m unittest"'
     [ ! $SELF_CHECK_CONTINUOUS ] && CMD+=" --failfast on"
     run_rc selftests "$CMD"
 fi


### PR DESCRIPTION
To make sure the seltests does not leave job results behind,
we introduced a check which compares the job-results directory
content from before the selftets with the content after the
selftests. But using `AVOCADO_SELF_CHECK=1 make check`, we
expect at least one extra result in the job-results directory,
making the content of the job-results to not be the same after
the tests.

This patch changes the avocado command used for self check
in `make check`, pointing the results to a temporary directory.

Reference: https://trello.com/c/y57xZSUS
Signed-off-by: Amador Pahim <apahim@redhat.com>