### PR TITLE
avocado/core/status.py: feedback definition was never used

### DIFF
--- a/avocado/core/status.py
+++ b/avocado/core/status.py
@@ -36,25 +36,3 @@ user_facing_status = ["SKIP",
                       "PASS",
                       "INTERRUPTED",
                       "CANCEL"]
-
-feedback = {
-    # Test did not advertise current status, but process running the test is
-    # known to be still running
-    '.': 'Process Running',
-
-    # Test advertised its current status explicitly (by means of a formal test
-    # API, so user can be sure his test not only has a process running, but
-    # is performing its intended tasks
-    'T': 'Test Running',
-
-    # The process is paused because a binary was run under a debugger and hit
-    # a breakpoint. The breakpoint may be a breakpoint explicitly set by the
-    # user or a signal that is automatically caught, such as a SIGSEGV
-    'D': 'Paused for debugging',
-
-    # The test has ended and either passed or failed. After this message, a
-    # proper test result should be passed so that it is presented to the
-    # user and passed along other result plugins.
-    'P': 'Passed (ended)',
-    'F': 'Failed (ended)'
-}


### PR DESCRIPTION
These were introduced when the throbber feedback was implemented,
and probably the idea was to give extra information in the UI.

This was never implemented, and no other internal component relies
on it, so let's remove it to avoid bitrot.

Signed-off-by: Cleber Rosa <crosa@redhat.com>