### PR TITLE
Varianter plugins: list them in `avocado plugins`

### DIFF
--- a/avocado/plugins/plugins.py
+++ b/avocado/plugins/plugins.py
@@ -51,7 +51,9 @@ class Plugins(CLICmd):
              'Plugins that generate job result in different formats (result):'),
             (dispatcher.ResultEventsDispatcher(args),
              ('Plugins that generate job result based on job/test events '
-              '(result_events):'))
+              '(result_events):')),
+            (dispatcher.VarianterDispatcher(),
+             'Plugins that generate test variants (varianter): ')
         ]
         for plugins_active, msg in plugin_types:
             log.info(msg)

--- a/avocado/plugins/yaml_to_mux.py
+++ b/avocado/plugins/yaml_to_mux.py
@@ -294,6 +294,9 @@ class YamlToMux(mux.MuxPlugin, Varianter):
     Processes the mux options into varianter plugin
     """
 
+    name = 'yaml_to_mux'
+    description = 'Multiplexer plugin to parse yaml files to params'
+
     @staticmethod
     def _log_deprecation_msg(deprecated, current):
         """


### PR DESCRIPTION
That includes creating a new section for them, and also adding
name and description to the `yaml_to_mux` implementation.

Signed-off-by: Cleber Rosa <crosa@redhat.com>