### PR TITLE
Adjusts in SKIP and CANCEL

### DIFF
--- a/avocado/core/decorators.py
+++ b/avocado/core/decorators.py
@@ -65,6 +65,7 @@ def skip(message=None):
             def wrapper(*args, **kwargs):
                 raise core_exceptions.TestDecoratorSkip(message)
             function = wrapper
+        function.__skip__ = True
         return function
     return decorator
 

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -560,7 +560,8 @@ class Test(unittest.TestCase):
         stdout_check_exception = None
         stderr_check_exception = None
         try:
-            self.setUp()
+            if not getattr(testMethod, "__skip__", False):
+                self.setUp()
         except (exceptions.TestSetupSkip,
                 exceptions.TestDecoratorSkip,
                 exceptions.TestTimeoutSkip,
@@ -605,7 +606,8 @@ class Test(unittest.TestCase):
                 self.log.debug(' -> %s %s: %s', key, type(value), value)
         finally:
             try:
-                self.tearDown()
+                if not getattr(testMethod, "__skip__", False):
+                    self.tearDown()
             except exceptions.TestSetupSkip as details:
                 stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
                 skip_illegal_msg = ('Calling skip() in places other than '

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -782,6 +782,7 @@ class Test(unittest.TestCase):
         :param message: an optional message that will be recorded in the logs
         :type message: str
         """
+        message += '\nWARNING: self.skip() will be deprecated.'
         raise exceptions.TestSetupSkip(message)
 
     def cancel(self, message=None):

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -76,7 +76,9 @@ Avocado supports the most common exit statuses:
   be nice to review. (some result plugins does not support this and report
   ``PASS`` instead)
 * ``SKIP`` - the test's pre-requisites were not satisfied and the test's
-  body was not executed (nor its ``tearDown``)
+  body was not executed (nor its ``setUp()`` and ``tearDown``).
+* ``CANCEL`` - the test was canceled inside the test method itself. The
+  ``setUp()`` and ``tearDown`` methods are executed.
 * ``FAIL`` - test did not result in the expected outcome. A failure points
   at a (possible) bug in the tested subject, and not in the test itself.
   When the test (and its) execution breaks, an ``ERROR`` and not a ``FAIL``
@@ -990,9 +992,10 @@ Will produce the following result::
     TESTS TIME : 0.00 s
     JOB HTML   : $HOME/avocado/job-results/job-2017-02-03T17.16-1bd8642/html/results.html
 
-Notice that the `tearDown()` will not be executed when `skip()` is used.
-Any cleanup treatment has to be handled by the `setUp()`, before the
-call to `skip()`.
+Calling `self.skip()`, nothing else will be executed after the call.
+We will skip the rest of the `setUp()` method, the test method and the
+`tearDown()` method. Any cleanup treatment has to be handled by the
+`setUp()`, before the call to `self.skip()`.
 
 Avocado Skip Decorators
 -----------------------
@@ -1039,9 +1042,8 @@ Will produce the following result::
 Notice the ``test3`` was not skipped because the provided condition was
 not ``False``.
 
-Using the skip decorators, since the `setUp()` was already executed, the
-`tearDown()` will be also executed.
-
+Using the skip decorators, nothing is actually executed. We will skip
+the  `setUp()` method, the test method and the `tearDown()` method.
 
 Cancelling Tests
 ================
@@ -1049,7 +1051,7 @@ Cancelling Tests
 The only supported way to cancel a test and not negatively impact the
 job exit status (unlike using `self.fail` or `self.error`) is by using
 the `self.cancel()` method. The `self.cancel()` can be called only
-from your test methods. Example::
+from your test methods (not from `setUp()`). Example::
 
     #!/usr/bin/env python
 
@@ -1100,7 +1102,7 @@ Notice that, since the `setUp()` was already executed, calling the
 `self.cancel()` will cancel the rest of the test from that point on, but
 the `tearDown()` will still be executed.
 
-Depending on the result format you're refering to, the `CANCEL` status
+Depending on the result format you're referring to, the `CANCEL` status
 is mapped to a corresponding valid status in that format. See the table
 below:
 

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -957,6 +957,9 @@ Avocado offers some options for the test writers to skip a test:
 Test ``skip()`` Method
 ----------------------
 
+.. warning:: `self.skip()` is under deprecation process. Please adjust
+   your tests to use the skip decorators instead.
+
 Using the ``skip()`` method available in the Test API is only allowed
 inside the ``setUp()`` method. Calling ``skip()`` from inside the test is not
 allowed as, by concept, you cannot skip a test after it's already initiated.


### PR DESCRIPTION
- Start the deprecation process for `self.skip()`.
- Don't execute `setUp()` and `tearDown()` when using skip decorators.
- Docs adjustments.

Reference: https://trello.com/c/viBJIEwI