### PR TITLE
Adjusts in SKIP and CANCEL [v2]

### DIFF
--- a/avocado/core/decorators.py
+++ b/avocado/core/decorators.py
@@ -65,6 +65,7 @@ def skip(message=None):
             def wrapper(*args, **kwargs):
                 raise core_exceptions.TestDecoratorSkip(message)
             function = wrapper
+        function.__skip__ = True
         return function
     return decorator
 

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -560,7 +560,8 @@ class Test(unittest.TestCase):
         stdout_check_exception = None
         stderr_check_exception = None
         try:
-            self.setUp()
+            if not getattr(testMethod, "__skip__", False):
+                self.setUp()
         except (exceptions.TestSetupSkip,
                 exceptions.TestDecoratorSkip,
                 exceptions.TestTimeoutSkip,
@@ -605,7 +606,8 @@ class Test(unittest.TestCase):
                 self.log.debug(' -> %s %s: %s', key, type(value), value)
         finally:
             try:
-                self.tearDown()
+                if not getattr(testMethod, "__skip__", False):
+                    self.tearDown()
             except exceptions.TestSetupSkip as details:
                 stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
                 skip_illegal_msg = ('Calling skip() in places other than '

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -569,11 +569,7 @@ class Test(unittest.TestCase):
             raise exceptions.TestSkipError(details)
         except exceptions.TestCancel as details:
             stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
-            skip_illegal_msg = ('Calling cancel() in setUp() '
-                                'is not allowed in avocado, you '
-                                'must fix your test. Original cancel exception: '
-                                '%s' % details)
-            raise exceptions.TestError(skip_illegal_msg)
+            raise
         except exceptions.TestDecoratorSkip as details:
             stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
             skip_illegal_msg = ('Using skip decorators in places other than '
@@ -628,6 +624,9 @@ class Test(unittest.TestCase):
                                     'you must fix your test. Original skip '
                                     'exception: %s' % details)
                 raise exceptions.TestError(skip_illegal_msg)
+            except exceptions.TestCancel as details:
+                stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
+                raise
             except:  # avoid old-style exception failures
                 stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
                 details = sys.exc_info()[1]

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -563,7 +563,6 @@ class Test(unittest.TestCase):
             if not getattr(testMethod, "__skip__", False):
                 self.setUp()
         except (exceptions.TestSetupSkip,
-                exceptions.TestDecoratorSkip,
                 exceptions.TestTimeoutSkip,
                 exceptions.TestSkipError) as details:
             stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
@@ -574,6 +573,13 @@ class Test(unittest.TestCase):
                                 'is not allowed in avocado, you '
                                 'must fix your test. Original cancel exception: '
                                 '%s' % details)
+            raise exceptions.TestError(skip_illegal_msg)
+        except exceptions.TestDecoratorSkip as details:
+            stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
+            skip_illegal_msg = ('Using skip decorators in places other than '
+                                'the test method is not allowed in avocado, '
+                                'you must fix your test. Original skip '
+                                'exception: %s' % details)
             raise exceptions.TestError(skip_illegal_msg)
         except:  # Old-style exceptions are not inherited from Exception()
             stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
@@ -617,10 +623,10 @@ class Test(unittest.TestCase):
                 raise exceptions.TestError(skip_illegal_msg)
             except exceptions.TestDecoratorSkip as details:
                 stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
-                skip_illegal_msg = ('Using skip decorators after the test '
-                                    'will have no effect, you must fix your '
-                                    'test. Original skip exception: %s' %
-                                    details)
+                skip_illegal_msg = ('Using skip decorators in places other than '
+                                    'the test method is not allowed in avocado, '
+                                    'you must fix your test. Original skip '
+                                    'exception: %s' % details)
                 raise exceptions.TestError(skip_illegal_msg)
             except:  # avoid old-style exception failures
                 stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -782,7 +782,11 @@ class Test(unittest.TestCase):
         :param message: an optional message that will be recorded in the logs
         :type message: str
         """
-        raise exceptions.TestSetupSkip(message)
+        dep_msg = '[WARNING: self.skip() will be deprecated, please ' \
+                  'use self.cancel()] '
+        if message is not None:
+            dep_msg += message
+        raise exceptions.TestSetupSkip(dep_msg)
 
     def cancel(self, message=None):
         """

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -77,6 +77,9 @@ Avocado supports the most common exit statuses:
   ``PASS`` instead)
 * ``SKIP`` - the test's pre-requisites were not satisfied and the test's
   body was not executed (nor its ``setUp()`` and ``tearDown``).
+* ``CANCEL`` - the test was canceled somewhere during the `setUp()`, the
+  test method or the `tearDown()`. The ``setUp()`` and ``tearDown``
+  methods are executed.
 * ``FAIL`` - test did not result in the expected outcome. A failure points
   at a (possible) bug in the tested subject, and not in the test itself.
   When the test (and its) execution breaks, an ``ERROR`` and not a ``FAIL``
@@ -1046,10 +1049,9 @@ the  `setUp()` method, the test method and the `tearDown()` method.
 Cancelling Tests
 ================
 
-The only supported way to cancel a test and not negatively impact the
-job exit status (unlike using `self.fail` or `self.error`) is by using
-the `self.cancel()` method. The `self.cancel()` can be called only
-from your test methods. Example::
+You can cancel a test calling `self.cancel()` at any phase of the test
+(`setUp()`, test method or `tearDown()`). Test will finish with `CANCEL`
+status and will not make the Job to exit with a non-0 status. Example::
 
     #!/usr/bin/env python
 
@@ -1096,11 +1098,10 @@ the correct version, the result will be::
     TESTS TIME : 2.28 s
     JOB HTML   : $HOME/avocado/job-results/job-2017-03-10T16.22-39c1f12/html/results.html
 
-Notice that, since the `setUp()` was already executed, calling the
-`self.cancel()` will cancel the rest of the test from that point on, but
-the `tearDown()` will still be executed.
+Notice that using the `self.cancel()` will cancel the rest of the test
+from that point on, but the `tearDown()` will still be executed.
 
-Depending on the result format you're refering to, the `CANCEL` status
+Depending on the result format you're referring to, the `CANCEL` status
 is mapped to a corresponding valid status in that format. See the table
 below:
 

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -957,6 +957,9 @@ Avocado offers some options for the test writers to skip a test:
 Test ``skip()`` Method
 ----------------------
 
+.. warning:: `self.skip()` is under deprecation process. Please adjust
+   your tests to use the `self.cancel()` or the skip decorators instead.
+
 Using the ``skip()`` method available in the Test API is only allowed
 inside the ``setUp()`` method. Calling ``skip()`` from inside the test is not
 allowed as, by concept, you cannot skip a test after it's already initiated.

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -1005,8 +1005,9 @@ Another way to skip tests is by using the Avocado skip decorators:
 - ``@avocado.skipUnless(condition, reason)``: Skips a test if the condition is
   ``False``
 
-Those decorators can be used with both ``setUp()`` method and/or and in the
-``test*()`` methods. The test below::
+Those decorators can be used only in the ``test*()`` methods. Decorating
+`setUp()` or `tearDown()` will make the test to finish with `ERROR`.
+The test below::
 
     import avocado
 

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -76,7 +76,7 @@ Avocado supports the most common exit statuses:
   be nice to review. (some result plugins does not support this and report
   ``PASS`` instead)
 * ``SKIP`` - the test's pre-requisites were not satisfied and the test's
-  body was not executed (nor its ``tearDown``)
+  body was not executed (nor its ``setUp()`` and ``tearDown``).
 * ``FAIL`` - test did not result in the expected outcome. A failure points
   at a (possible) bug in the tested subject, and not in the test itself.
   When the test (and its) execution breaks, an ``ERROR`` and not a ``FAIL``
@@ -1039,9 +1039,8 @@ Will produce the following result::
 Notice the ``test3`` was not skipped because the provided condition was
 not ``False``.
 
-Using the skip decorators, since the `setUp()` was already executed, the
-`tearDown()` will be also executed.
-
+Using the skip decorators, nothing is actually executed. We will skip
+the  `setUp()` method, the test method and the `tearDown()` method.
 
 Cancelling Tests
 ================

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -993,9 +993,10 @@ Will produce the following result::
     TESTS TIME : 0.00 s
     JOB HTML   : $HOME/avocado/job-results/job-2017-02-03T17.16-1bd8642/html/results.html
 
-Notice that the `tearDown()` will not be executed when `skip()` is used.
-Any cleanup treatment has to be handled by the `setUp()`, before the
-call to `skip()`.
+Calling `self.skip()`, nothing else will be executed after the call.
+We will skip the rest of the `setUp()` method, the test method and the
+`tearDown()` method. Any cleanup treatment has to be handled by the
+`setUp()`, before the call to `self.skip()`.
 
 Avocado Skip Decorators
 -----------------------

--- a/selftests/functional/test_canceltests.py
+++ b/selftests/functional/test_canceltests.py
@@ -74,9 +74,8 @@ class TestCancel(unittest.TestCase):
                     '--json -']
         result = process.run(' '.join(cmd_line), ignore_status=True)
         json_results = json.loads(result.stdout)
-        self.assertEqual(result.exit_status, exit_codes.AVOCADO_TESTS_FAIL)
-        self.assertEqual(json_results['cancel'], 0)
-        self.assertEqual(json_results['errors'], 1)
+        self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
+        self.assertEqual(json_results['cancel'], 1)
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir)


### PR DESCRIPTION
**Goals**:

SKIP

- Will never run `setUp()`/`tearDown()`.
- Can be triggered using skip decorators.
- Skip decorators can decorate only test methods (not `setUp()`/`tearDown()`).
- Can be triggered using `self.skip()`.
- `self.skip()` can be used only in `setUp()`
- Start deprecating `self.skip()`

CANCEL:

- Will run `setUp()` and `tearDown()`.
- Can be triggered using `self.cancel()`.
- `self.cancel()` can be called anywhere, including in `setUp()` and `tearDown()`.

DOCS:
- Update documentation to consider the new CANCEL status.

---

v2:
- Improve deprecation message to self.skip()
- Don't accept skip decorators in setUp() and tearDown()
- Accept self.cancel() in setUp() and tearDown()
- Rebase commits, putting the corresponding docs along with the code.

v1: #1872 
- Start the deprecation process for `self.skip()`.
- Don't execute `setUp()` and `tearDown()` when using skip decorators.
- Docs adjustments.