### PR TITLE
[RFC] Add TestFail, TestError and TestCancel to the avocado namespace

### DIFF
--- a/avocado/__init__.py
+++ b/avocado/__init__.py
@@ -19,7 +19,10 @@ __all__ = ['main',
            'fail_on',
            'skip',
            'skipIf',
-           'skipUnless']
+           'skipUnless',
+           'TestError',
+           'TestFail',
+           'TestCancel']
 
 
 from avocado.core.job import main
@@ -29,3 +32,6 @@ from avocado.core.decorators import fail_on
 from avocado.core.decorators import skip
 from avocado.core.decorators import skipIf
 from avocado.core.decorators import skipUnless
+from avocado.core.exceptions import TestError
+from avocado.core.exceptions import TestFail
+from avocado.core.exceptions import TestCancel


### PR DESCRIPTION
In many cases when you are developing a test suite using
avocado libraries, you want to flag certain exceptional
conditions as real test failures, rather than something
that will be converted to an ERROR status (the current
default behavior).

Consider QEMU testing: An exception involving a QEMU core
dump should be considered a failure in pretty much every
scenario one can think of. So it makes sense to have code
similar to:

from avocado import TestFail

QEMUCoreDump(TestFail):
    pass

so that when said exception happens inside library code,
the test can be immediately flagged as a failure, without
having to introduce boilerplate code to check for error
conditions.

So at least the 3 main test related exceptions (TestFail,
TestError and TestCancel) should be directly exposed in
the test writer API. Methods such as self.fail() are
neat shortcuts for simpler cases and should be used,
but entirely isolating access to *all* avocado exceptions
is detrimental to the goal of reducing boilerplate code
in tests.

This patch adds the mentioned 3 test exceptions to the
avocado namespace, making them part of the test writer
API.

Signed-off-by: Lucas Meneghel Rodrigues <lookkas@gmail.com>