### PR TITLE
Robot Plugin [V4]

### DIFF
--- a/optional_plugins/robot/avocado_robot/__init__.py
+++ b/optional_plugins/robot/avocado_robot/__init__.py
@@ -1,0 +1,133 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2017
+# Authors: Amador Pahim <apahim@redhat.com>
+
+import collections
+import logging
+import re
+import subprocess
+
+from StringIO import StringIO
+
+from avocado.core import exceptions
+from avocado.core import loader
+from avocado.core import output
+from avocado.core import test
+from avocado.core.plugin_interfaces import CLI
+from avocado.core.runner import TestRunner
+from avocado.utils import path as utils_path
+from robot import run
+from robot.parsing.model import TestData
+from robot.model import SuiteNamePatterns
+
+
+class RobotTest(test.SimpleTest):
+
+    """
+    Run a Robot command as a SIMPLE test.
+    """
+
+    def __init__(self,
+                 name,
+                 params=None,
+                 base_logdir=None,
+                 job=None,
+                 external_runner=None):
+        super(RobotTest, self).__init__(name, params, base_logdir, job)
+
+    @property
+    def filename(self):
+        """
+        Returns the path of the robot test suite.
+        """
+        return self.name.name.split(':')[0]
+
+    def test(self):
+        """
+        Create the Robot command and execute it.
+        """
+        suite_name, test_name = self.name.name.split(':')[1].split('.')
+        log_stdout = output.LoggingFile(logger=[self.log], level=logging.INFO)
+        log_stderr = output.LoggingFile(logger=[self.log], level=logging.ERROR)
+        result = run(self.filename,
+                     suite=suite_name,
+                     test=test_name,
+                     outputdir=self.outputdir,
+                     stdout=log_stdout,
+                     stderr=log_stderr)
+        if result:
+            self.fail('Robot execution returned a '
+                      'non-0 exit code (%s)' % result)
+
+
+class RobotLoader(loader.TestLoader):
+    """
+    Robot loader class
+    """
+    name = "robot"
+
+    def __init__(self, args, extra_params):
+        super(RobotLoader, self).__init__(args, extra_params)
+
+    def discover(self, url, which_tests=False):
+        avocado_suite = []
+        subtests_filter = None
+        if ':' in url:
+            url, _subtests_filter = url.split(':', 1)
+            subtests_filter = re.compile(_subtests_filter)
+        robot_suite = self._find_tests(TestData(parent=None,
+                                                source=url,
+                                                include_suites=SuiteNamePatterns()),
+                                       test_suite={})
+        for item in robot_suite:
+            for robot_test in robot_suite[item]:
+                test_name = "%s:%s.%s" % (robot_test['test_source'],
+                                          item,
+                                          robot_test['test_name'])
+                if subtests_filter and not subtests_filter.search(test_name):
+                    continue
+                avocado_suite.append((RobotTest, {'name': test_name}))
+        return avocado_suite
+
+    def _find_tests(self, data, test_suite):
+        test_suite[data.name] = []
+        for test in data.testcase_table:
+            test_suite[data.name].append({'test_name': test.name,
+                                          'test_source': test.source})
+        for child_data in data.children:
+            self._find_tests(child_data, test_suite)
+        return test_suite
+
+    @staticmethod
+    def get_type_label_mapping():
+        return {RobotTest: 'ROBOT'}
+
+    @staticmethod
+    def get_decorator_mapping():
+        return {RobotTest: output.TERM_SUPPORT.healthy_str}
+
+
+class RobotCLI(CLI):
+
+    """
+    Run Robot Framework tests
+    """
+
+    name = 'robot'
+    description = "Robot Framework options for 'run' subcommand"
+
+    def configure(self, parser):
+        pass
+
+    def run(self, args):
+        loader.loader.register_plugin(RobotLoader)

--- a/optional_plugins/robot/setup.py
+++ b/optional_plugins/robot/setup.py
@@ -1,0 +1,37 @@
+#!/bin/env python
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2017
+# Author: Amador Pahim <apahim@redhat.com>
+
+import os
+from setuptools import setup, find_packages
+
+
+root_path = os.path.abspath(os.path.join("..", ".."))
+version_file = os.path.join(root_path, 'VERSION')
+VERSION = open(version_file, 'r').read().strip()
+
+setup(name='avocado-robot',
+      description='Avocado Plugin for Execution of Robot Framework tests',
+      version=VERSION,
+      author='Avocado Developers',
+      author_email='avocado-devel@redhat.com',
+      url='http://avocado-framework.github.io/',
+      packages=find_packages(),
+      include_package_data=True,
+      install_requires=['robotframework'],
+      entry_points={
+          'avocado.plugins.cli': [
+              'robot = avocado_robot:RobotCLI',
+          ]}
+      )


### PR DESCRIPTION
v4:
- Make robot loader always registered along with default loaders.
- Fix discovery recursion.
- Fix `avocado list` results.
- Accept extra regex in the test reference the same way we accept in builtin loaders (`avocado list ~/Downloads/WebDemo/login_tests/:invalid_login.*Empty`)

v3: #1873 
- Handle `robot.run()` `stderr`.
- Handle `robot.run()` return code.

v2: #1869 
- Use `robot.run()` instead of robot command.

v1: #1868 