### PR TITLE
robot: fix issue on missing test references

### DIFF
--- a/optional_plugins/robot/avocado_robot/__init__.py
+++ b/optional_plugins/robot/avocado_robot/__init__.py
@@ -82,6 +82,10 @@ class RobotLoader(loader.TestLoader):
     def discover(self, url, which_tests=False):
         avocado_suite = []
         subtests_filter = None
+
+        if url is None:
+            return []
+
         if ':' in url:
             url, _subtests_filter = url.split(':', 1)
             subtests_filter = re.compile(_subtests_filter)


### PR DESCRIPTION
We have to consider that `avocado list` may be executed without the test
references.

Signed-off-by: Amador Pahim <apahim@redhat.com>