### PR TITLE
robot: fix error on unknown tests

### DIFF
--- a/optional_plugins/robot/avocado_robot/__init__.py
+++ b/optional_plugins/robot/avocado_robot/__init__.py
@@ -89,10 +89,14 @@ class RobotLoader(loader.TestLoader):
         if ':' in url:
             url, _subtests_filter = url.split(':', 1)
             subtests_filter = re.compile(_subtests_filter)
-        robot_suite = self._find_tests(TestData(parent=None,
-                                                source=url,
-                                                include_suites=SuiteNamePatterns()),
-                                       test_suite={})
+        try:
+            robot_suite = self._find_tests(TestData(parent=None,
+                                           source=url,
+                                           include_suites=SuiteNamePatterns()),
+                                           test_suite={})
+        except:
+            return []
+
         for item in robot_suite:
             for robot_test in robot_suite[item]:
                 test_name = "%s:%s.%s" % (robot_test['test_source'],


### PR DESCRIPTION
When robot plugin cannot determine the tests from the test references we
should return an empty list instead of an exception.

Signed-off-by: Amador Pahim <apahim@redhat.com>