### PR TITLE
mux: Add support for internal filters [v3]

### DIFF
--- a/avocado/core/dispatcher.py
+++ b/avocado/core/dispatcher.py
@@ -21,6 +21,7 @@ import sys
 from stevedore import EnabledExtensionManager
 
 from .settings import settings
+from ..utils import stacktrace
 
 
 class Dispatcher(EnabledExtensionManager):
@@ -242,6 +243,7 @@ class VarianterDispatcher(Dispatcher):
             except KeyboardInterrupt:
                 raise
             except:     # catch any exception pylint: disable=W0702
+                stacktrace.log_exc_info(sys.exc_info(), logger='avocado.debug')
                 log = logging.getLogger("avocado.app")
                 log.error('Error running method "%s" of plugin "%s": %s',
                           method_name, ext.name, sys.exc_info()[1])

--- a/avocado/core/mux.py
+++ b/avocado/core/mux.py
@@ -172,7 +172,7 @@ class MuxPlugin(object):
                     env = set()
                     for node in variant["variant"]:
                         for key, value in node.environment.iteritems():
-                            origin = node.environment_origin[key].path
+                            origin = node.environment.origin[key].path
                             env.add(("%s:%s" % (origin, key), str(value)))
                     if not env:
                         continue

--- a/avocado/core/mux.py
+++ b/avocado/core/mux.py
@@ -71,19 +71,74 @@ class MuxTree(object):
 
     def __iter__(self):
         """
-        Iterates through variants
+        Iterates through variants and process the internal filters
+
+        :yield valid variants
+        """
+        for variant in self.iter_variants():
+            if self._valid_variant(variant):
+                yield variant
+
+    def iter_variants(self):
+        """
+        Iterates through variants without verifying the internal filters
+
+        :yield all existing variants
         """
         pools = []
         for pool in self.pools:
             if isinstance(pool, list):
-                pools.append(itertools.chain(*pool))
+                # Don't process 2nd level filters in non-root pools
+                pools.append(itertools.chain(*(_.iter_variants()
+                                               for _ in pool)))
             else:
-                pools.append(pool)
-        pools = itertools.product(*pools)
+                pools.append([pool])
+        variants = itertools.product(*pools)
         while True:
-            # TODO: Implement 2nd level filters here
-            # TODO: This part takes most of the time, optimize it
-            yield list(itertools.chain(*pools.next()))
+            yield list(itertools.chain(*variants.next()))
+
+    @staticmethod
+    def _valid_variant(variant):
+        """
+        Check the variant for validity of internal filters
+
+        :return: whether the variant is valid or should be ignored/filtered
+        """
+        _filter_out = set()
+        _filter_only = set()
+        for node in variant:
+            _filter_only.update(node.environment.filter_only)
+            _filter_out.update(node.environment.filter_out)
+        if not (_filter_only or _filter_out):
+            return True
+        filter_only = tuple(_filter_only)
+        filter_out = tuple(_filter_out)
+        filter_only_parents = [str(_).rsplit('/', 2)[0] + '/'
+                               for _ in filter_only
+                               if _]
+
+        for out in filter_out:
+            for node in variant:
+                path = node.path + '/'
+                if path.startswith(out):
+                    return False
+        for node in variant:
+            keep = 0
+            remove = 0
+            path = node.path + '/'
+            ppath = path.rsplit('/', 2)[0] + '/'
+            for i in xrange(len(filter_only)):
+                level = filter_only[i].count('/')
+                if level < max(keep, remove):
+                    continue
+                if ppath.startswith(filter_only_parents[i]):
+                    if path.startswith(filter_only[i]):
+                        keep = level
+                    else:
+                        remove = level
+            if remove > keep:
+                return False
+        return True
 
 
 class MuxPlugin(object):

--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -41,6 +41,21 @@ import os
 from . import output
 
 
+class TreeEnvironment(dict):
+
+    """ TreeNode environment with values, origins and filters """
+
+    def __init__(self):
+        super(TreeEnvironment, self).__init__()     # values
+        self.origin = {}    # origins of the values
+
+    def copy(self):
+        cpy = TreeEnvironment()
+        cpy.update(self)
+        cpy.origin = self.origin.copy()
+        return cpy
+
+
 class TreeNode(object):
 
     """
@@ -57,7 +72,6 @@ class TreeNode(object):
         self.parent = parent
         self.children = []
         self._environment = None
-        self.environment_origin = {}
         for child in children:
             self.add_child(child)
 
@@ -175,9 +189,7 @@ class TreeNode(object):
         """ Get node environment (values + preceding envs) """
         if self._environment is None:
             self._environment = (self.parent.environment.copy()
-                                 if self.parent else {})
-            self.environment_origin = (self.parent.environment_origin.copy()
-                                       if self.parent else {})
+                                 if self.parent else TreeEnvironment())
             for key, value in self.value.iteritems():
                 if isinstance(value, list):
                     if (key in self._environment and
@@ -187,7 +199,7 @@ class TreeNode(object):
                         self._environment[key] = value
                 else:
                     self._environment[key] = value
-                self.environment_origin[key] = self
+                self._environment.origin[key] = self
         return self._environment
 
     def set_environment_dirty(self):

--- a/avocado/core/varianter.py
+++ b/avocado/core/varianter.py
@@ -289,7 +289,7 @@ class AvocadoParam(object):
         :raise KeyError: When value is not certain (multiple matches)
         """
         leaves = self._get_leaves(path)
-        ret = [(leaf.environment[key], leaf.environment_origin[key])
+        ret = [(leaf.environment[key], leaf.environment.origin[key])
                for leaf in leaves
                if key in leaf.environment]
         if not ret:
@@ -310,7 +310,7 @@ class AvocadoParam(object):
         """
         for leaf in self._leaves:
             for key, value in leaf.environment.iteritems():
-                yield (leaf.environment_origin[key].path, key, value)
+                yield (leaf.environment.origin[key].path, key, value)
 
 
 class Varianter(object):

--- a/avocado/plugins/yaml_to_mux.py
+++ b/avocado/plugins/yaml_to_mux.py
@@ -78,38 +78,48 @@ def _create_from_yaml(path, cls_node=mux.MuxTreeNode):
     """ Create tree structure from yaml stream """
     def tree_node_from_values(name, values):
         """ Create `name` node and add values  """
+        def handle_control_tag(node, value):
+            """ Handling of YAML tags (except of !using) """
+            if value[0].code == YAML_INCLUDE:
+                # Include file
+                ypath = value[1]
+                if not os.path.isabs(ypath):
+                    ypath = os.path.join(os.path.dirname(path), ypath)
+                if not os.path.exists(ypath):
+                    raise ValueError("File '%s' included from '%s' does not "
+                                     "exist." % (ypath, path))
+                node.merge(_create_from_yaml('/:' + ypath, cls_node))
+            elif value[0].code == YAML_REMOVE_NODE:
+                value[0].value = value[1]   # set the name
+                node.ctrl.append(value[0])    # add "blue pill" of death
+            elif value[0].code == YAML_REMOVE_VALUE:
+                value[0].value = value[1]   # set the name
+                node.ctrl.append(value[0])
+            elif value[0].code == YAML_MUX:
+                node.multiplex = True
+
+        def handle_control_tag_using(name, using, value):
+            """ Handling of the !using tag """
+            if using:
+                raise ValueError("!using can be used only once per "
+                                 "node! (%s:%s)" % (path, name))
+            using = value[1]
+            if using[0] == '/':
+                using = using[1:]
+            if using[-1] == '/':
+                using = using[:-1]
+            return using
+
         node = cls_node(str(name))
         using = ''
         for value in values:
             if isinstance(value, cls_node):
                 node.add_child(value)
             elif isinstance(value[0], mux.Control):
-                if value[0].code == YAML_INCLUDE:
-                    # Include file
-                    ypath = value[1]
-                    if not os.path.isabs(ypath):
-                        ypath = os.path.join(os.path.dirname(path), ypath)
-                    if not os.path.exists(ypath):
-                        raise ValueError("File '%s' included from '%s' does not "
-                                         "exist." % (ypath, path))
-                    node.merge(_create_from_yaml('/:' + ypath, cls_node))
-                elif value[0].code == YAML_USING:
-                    if using:
-                        raise ValueError("!using can be used only once per "
-                                         "node! (%s:%s)" % (path, name))
-                    using = value[1]
-                    if using[0] == '/':
-                        using = using[1:]
-                    if using[-1] == '/':
-                        using = using[:-1]
-                elif value[0].code == YAML_REMOVE_NODE:
-                    value[0].value = value[1]   # set the name
-                    node.ctrl.append(value[0])    # add "blue pill" of death
-                elif value[0].code == YAML_REMOVE_VALUE:
-                    value[0].value = value[1]   # set the name
-                    node.ctrl.append(value[0])
-                elif value[0].code == YAML_MUX:
-                    node.multiplex = True
+                if value[0].code == YAML_USING:
+                    using = handle_control_tag_using(name, using, value)
+                else:
+                    handle_control_tag(node, value)
             else:
                 node.value[value[0]] = value[1]
         if using:

--- a/docs/source/TestParameters.rst
+++ b/docs/source/TestParameters.rst
@@ -867,6 +867,45 @@ Children of this node will be multiplexed. This means that in first variant
 it'll return leaves of the first child, in second the leaves of the second
 child, etc. Example is in section `Variants`_
 
+!filter-only
+------------
+
+Defines internal filters. They are inherited by children and evaluated
+during multiplexation. It allows one to specify the only compatible branch
+of the tree with the current variant, for example::
+
+    cpu:
+        arm:
+            !filter-only : /disk/virtio
+    disk:
+        virtio:
+        scsi:
+
+will skip the ``[arm, scsi]`` variant and result only in ``[arm, virtio]``
+
+_Note: It's possible to use ``!filter-only`` multiple times with the same
+parent and all allowed variants will be included (unless they are
+filtered-out by ``!filter-out``)_
+
+_Note2: The evaluation order is 1. filter-out, 2. filter-only. This means when
+you booth filter-out and filter-only a branch it won't take part in the
+multiplexed variants._
+
+!filter-out
+-----------
+
+Similarly to `!filter-only`_ only it skips the specified branches and leaves
+the remaining ones. (in the same example the use of
+``!filter-out : /disk/scsi`` results in the same behavior). The difference
+is when a new disk type is introduced, ``!filter-only`` still allows just
+the specified variants, while ``!filter-out`` only removes the specified
+ones.
+
+As for the speed optimization, currently Avocado is strongly optimized
+towards fast ``!filter-out`` so it's highly recommended using them
+rather than ``!filter-only``, which takes significantly longer to
+process.
+
 Complete example
 ----------------
 

--- a/examples/mux-selftest.yaml
+++ b/examples/mux-selftest.yaml
@@ -7,16 +7,32 @@
 #          multiple files and checks that the node ordering works fine.
 # /env/opt_CFLAGS: Should be present in merged node
 # /env/prod/opt_CFLAGS: value should be overridden by latter node
+# The internal filters are designed to be used for this file injected into
+# /virt (use -m /virt:examples/mux-selftest.py). When it's injected into
+# a different location those filters should not affect the result (produces
+# all variants.
+# !filter-only: All root childern are specified in different levels. They
+#               should be combined and together enable all variants. On the
+#               other hand they should not enable other-level filter-only
+#               filters like /hw/disk/virtio.
+
 hw:
+    # This filter has no effect, it's here to test filter inheritance
+    !filter-out : /this/does/not/exists
     cpu: !mux
+        # This filter has no effect, it's here to test filter inheritance
+        !filter-out : /non/existing/node
         joinlist:
             - first_item
         intel:
+            !filter-only : "/virt/hw/disk/virtio"
+            !filter-only : "/virt/hw/disk/scsi"
             cpu_CFLAGS: '-march=core2'
         amd:
             joinlist: ['second', 'third']
             cpu_CFLAGS: '-march=athlon64'
         arm:
+            !filter-only : "/virt/hw/disk/virtio"
             cpu_CFLAGS: '-mabi=apcs-gnu -march=armv8-a -mtune=arm8'
     disk: !mux
         disk_type: 'virtio'
@@ -28,15 +44,16 @@ hw:
     corruptlist: ['upper_node_list']
 distro: !mux     # This node is set as !multiplex below
     fedora:
+        !filter-out : "/virt/hw/disk/scsi"
         init: 'systemd'
 env: !mux
     opt_CFLAGS: '-Os'
     prod:
         opt_CFLAGS: 'THIS SHOULD GET OVERWRITTEN'
 env: !mux
+    !filter-out : "/yet/another/nonexisting/node"  # let's see if filters are updated when merging
     prod:
         opt_CFLAGS: '-O2'
 distro: !mux
     mint:
         init: 'systemv'
-


### PR DESCRIPTION
This PR adds the support for the internal filters to the Mux. The basic idea is to define relations ({could be only used | could not be used} with other branch), which makes it a bit different from what we know from `--mux-filter-{only|out}`:

1. They are applied per complete variant (because the filters are compound of per-leaf-filters)
2. They don't remove/keep the nodes, but they only evaluate whether this resulting variant makes sense (whether it passes the filters)

Details are in the updated documentation.

v2: https://github.com/avocado-framework/avocado/pull/1885

Changes:

v3: Improved documentation
v3: Rebased