### PR TITLE
utils.process: Fix can_sudo on broken systems

### DIFF
--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -111,11 +111,14 @@ def can_sudo(cmd=None):
     except path.CmdNotFoundError:
         return False
 
-    if cmd:     # Am I able to run the cmd or plain sudo id?
-        return not system(cmd, ignore_status=True, sudo=True)
-    elif system_output("id -u", ignore_status=True, sudo=True).strip() == "0":
-        return True
-    else:
+    try:
+        if cmd:     # Am I able to run the cmd or plain sudo id?
+            return not system(cmd, ignore_status=True, sudo=True)
+        elif system_output("id -u", ignore_status=True, sudo=True).strip() == "0":
+            return True
+        else:
+            return False
+    except OSError:     # Broken sudo binary
         return False
 
 


### PR DESCRIPTION
When the "sudo" is present in the PATH but is broken, the
"process.system" raises OSError. Let's address this issue and report
False in such case (as sudo is unusable)

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>