### PR TITLE
Added -y to pvcreate in lv_utils

### DIFF
--- a/avocado/utils/lv_utils.py
+++ b/avocado/utils/lv_utils.py
@@ -125,7 +125,7 @@ def vg_ramdisk(disk, vg_name, ramdisk_vg_size,
             process.run("losetup %s %s" %
                         (loop_device, ramdisk_filename), sudo=True)
         LOGGER.debug("Creating physical volume %s", loop_device)
-        process.run("pvcreate %s" % loop_device, sudo=True)
+        process.run("pvcreate -y %s" % loop_device, sudo=True)
         LOGGER.debug("Creating volume group %s", vg_name)
         process.run("vgcreate %s %s" %
                     (vg_name, loop_device), sudo=True)


### PR DESCRIPTION
Added '-y' to pvcreate since pvcreate asks for confirmation
if previous filesystem signature exists.

```
# pvcreate /dev/sdb
WARNING: ext4 signature detected on /dev/sdb at offset 1080. Wipe it? [y/n]: n
  Aborted wiping of ext4.
  1 existing signature left on the device.
# pvcreate -y /dev/sdb
  Wiping ext4 signature on /dev/sdb.
  Physical volume "/dev/sdb" successfully created.

```
Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>