### PR TITLE
utils.astring: Be really lenient towards incorrect strings

### DIFF
--- a/avocado/utils/astring.py
+++ b/avocado/utils/astring.py
@@ -219,7 +219,7 @@ def string_safe_encode(string):
     try:
         return string.encode("utf-8")
     except UnicodeDecodeError:
-        return string.decode("utf-8").encode("utf-8")
+        return string.decode("utf-8", "ignore").encode("utf-8")
 
 
 def string_to_safe_path(string):


### PR DESCRIPTION
The "astring.string_safe_encode" is a method, which tries to encode the
string no-matter how wrong it is. Let's also allow broken corrupted
strings by using "ignore" to skip the corrupted chars.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>