### PR TITLE
xunit: fix system-out level in xunit output

### DIFF
--- a/avocado/plugins/xunit.py
+++ b/avocado/plugins/xunit.py
@@ -69,8 +69,7 @@ class XUnitResult(Result):
         system_out_cdata_content = self._escape_cdata(text_output)
         system_out_cdata = document.createCDATASection(system_out_cdata_content)
         system_out.appendChild(system_out_cdata)
-        element.appendChild(system_out)
-        return element
+        return element, system_out
 
     def _render(self, result):
         document = Document()
@@ -91,13 +90,19 @@ class XUnitResult(Result):
             elif status == 'SKIP':
                 testcase.appendChild(Element('skipped'))
             elif status == 'FAIL':
-                element = self._create_failure_or_error(document, test, 'failure')
+                element, system_out = self._create_failure_or_error(document,
+                                                                    test,
+                                                                    'failure')
                 testcase.appendChild(element)
+                testcase.appendChild(system_out)
             elif status == 'CANCEL':
                 testcase.appendChild(Element('skipped'))
             else:
-                element = self._create_failure_or_error(document, test, 'error')
+                element, system_out = self._create_failure_or_error(document,
+                                                                    test,
+                                                                    'error')
                 testcase.appendChild(element)
+                testcase.appendChild(system_out)
             testsuite.appendChild(testcase)
         return document.toprettyxml(encoding='UTF-8')
 

--- a/selftests/functional/junit-4.xsd
+++ b/selftests/functional/junit-4.xsd
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+    <xs:element name="failure">
+        <xs:complexType mixed="true">
+            <xs:attribute name="type" type="xs:string" use="optional"/>
+            <xs:attribute name="message" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="error">
+        <xs:complexType mixed="true">
+            <xs:attribute name="type" type="xs:string" use="optional"/>
+            <xs:attribute name="message" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="properties">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="property" maxOccurs="unbounded"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="property">
+        <xs:complexType>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="value" type="xs:string" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="skipped" type="xs:string"/>
+    <xs:element name="system-err" type="xs:string"/>
+    <xs:element name="system-out" type="xs:string"/>
+
+    <xs:element name="testcase">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="skipped" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="error" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="failure" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="system-out" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="system-err" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="assertions" type="xs:string" use="optional"/>
+            <xs:attribute name="time" type="xs:string" use="optional"/>
+            <xs:attribute name="classname" type="xs:string" use="optional"/>
+            <xs:attribute name="status" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="testsuite">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="properties" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="testcase" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="system-out" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="system-err" minOccurs="0" maxOccurs="1"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="tests" type="xs:string" use="required"/>
+            <xs:attribute name="failures" type="xs:string" use="optional"/>
+            <xs:attribute name="errors" type="xs:string" use="optional"/>
+            <xs:attribute name="time" type="xs:string" use="optional"/>
+            <xs:attribute name="disabled" type="xs:string" use="optional"/>
+            <xs:attribute name="skipped" type="xs:string" use="optional"/>
+            <xs:attribute name="timestamp" type="xs:string" use="optional"/>
+            <xs:attribute name="hostname" type="xs:string" use="optional"/>
+            <xs:attribute name="id" type="xs:string" use="optional"/>
+            <xs:attribute name="package" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="testsuites">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="testsuite" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="optional"/>
+            <xs:attribute name="time" type="xs:string" use="optional"/>
+            <xs:attribute name="tests" type="xs:string" use="optional"/>
+            <xs:attribute name="failures" type="xs:string" use="optional"/>
+            <xs:attribute name="disabled" type="xs:string" use="optional"/>
+            <xs:attribute name="errors" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+
+</xs:schema>

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -13,8 +13,10 @@ import xml.dom.minidom
 import zipfile
 import unittest
 import psutil
-
 import pkg_resources
+
+from lxml import etree
+from StringIO import StringIO
 
 from avocado.core import exit_codes
 from avocado.utils import astring
@@ -1013,6 +1015,8 @@ class PluginsXunitTest(AbsPluginsTest, unittest.TestCase):
 
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        tests_dir = os.path.dirname(os.path.abspath(__file__))
+        self.junit_schema_path = os.path.join(tests_dir, 'junit-4.xsd')
         super(PluginsXunitTest, self).setUp()
 
     def run_and_check(self, testname, e_rc, e_ntests, e_nerrors,
@@ -1030,6 +1034,14 @@ class PluginsXunitTest(AbsPluginsTest, unittest.TestCase):
         except Exception as detail:
             raise ParseXMLError("Failed to parse content: %s\n%s" %
                                 (detail, xml_output))
+
+        with open(self.junit_schema_path, 'r') as f:
+            xmlschema = etree.XMLSchema(etree.parse(f))
+
+        self.assertTrue(xmlschema.validate(etree.parse(StringIO(xml_output))),
+                        "Failed to validate against %s, message:\n%s" %
+                        (self.junit_schema_path,
+                         xmlschema.error_log.filter_from_errors()))
 
         testsuite_list = xunit_doc.getElementsByTagName('testsuite')
         self.assertEqual(len(testsuite_list), 1, 'More than one testsuite tag')


### PR DESCRIPTION
`system-out` should be in the same level as `failure`, but we are
creating it as a `failure` child.

This patch puts system-out in the same level as `failure` and adds the
functional test to validate all the xunit outputs against the
junit-4.xsd schema.

Fixes: https://github.com/avocado-framework/avocado/issues/1905
Signed-off-by: Amador Pahim <apahim@redhat.com>