### PR TITLE
support multiple docstring directives

### DIFF
--- a/avocado/core/safeloader.py
+++ b/avocado/core/safeloader.py
@@ -76,10 +76,10 @@ def get_docstring_directive(docstring):
     :type docstring: str
     """
     if docstring is None:
-        return None
-    result = AVOCADO_DOCSTRING_DIRECTIVE_RE.search(docstring)
+        return []
+    result = AVOCADO_DOCSTRING_DIRECTIVE_RE.findall(docstring)
     if result is not None:
-        return result.groups()[0]
+        return result
 
 
 def is_docstring_directive_enable(docstring):
@@ -89,7 +89,10 @@ def is_docstring_directive_enable(docstring):
     :rtype: bool
     """
     result = get_docstring_directive(docstring)
-    return result == 'enable'
+    if 'enable' in result:
+        return True
+
+    return False
 
 
 def is_docstring_directive_disable(docstring):
@@ -99,7 +102,10 @@ def is_docstring_directive_disable(docstring):
     :rtype: bool
     """
     result = get_docstring_directive(docstring)
-    return result == 'disable'
+    if 'disable' in result:
+        return True
+
+    return False
 
 
 def is_docstring_directive_tags(docstring):
@@ -109,8 +115,11 @@ def is_docstring_directive_tags(docstring):
     :rtype: bool
     """
     result = get_docstring_directive(docstring)
-    if result is not None:
-        return result.startswith('tags=')
+
+    for item in result:
+        if item.startswith('tags='):
+            return True
+
     return False
 
 
@@ -123,10 +132,11 @@ def get_docstring_directive_tags(docstring):
     if not is_docstring_directive_tags(docstring):
         return []
 
-    raw_tag = get_docstring_directive(docstring)
-    if raw_tag is not None:
-        _, comma_tags = raw_tag.split('tags=', 1)
-        return set([tag for tag in comma_tags.split(',') if tag])
+    result = get_docstring_directive(docstring)
+    for item in result:
+        if item.startswith('tags='):
+            _, comma_tags = item.split('tags=', 1)
+            return set([tag for tag in comma_tags.split(',') if tag])
 
 
 def find_class_and_methods(path, method_pattern=None, base_class=None):

--- a/selftests/unit/test_safeloader.py
+++ b/selftests/unit/test_safeloader.py
@@ -61,7 +61,9 @@ class DocstringDirectives(unittest.TestCase):
                   ":avocado: tags=SLOW,disk, invalid": set(["SLOW", "disk"]),
                   ":avocado: tags=SLOW,disk , invalid": set(["SLOW", "disk"]),
                   ":avocado:\ttags=FAST": set(["FAST"]),
-                  ":avocado: tags=": set([])}
+                  ":avocado: tags=": set([]),
+                  ":avocado: enable\n:avocado: tags=fast": set(["fast"]),
+                  ":avocado: tags=fast,slow\n:avocado: enable": set(["fast", "slow"])}
 
     def test_longline(self):
         docstring = ("This is a very long docstring in a single line. "
@@ -80,6 +82,7 @@ class DocstringDirectives(unittest.TestCase):
     def test_enabled(self):
         self.assertTrue(safeloader.is_docstring_directive_enable(":avocado: enable"))
         self.assertTrue(safeloader.is_docstring_directive_enable(":avocado:\tenable"))
+        self.assertTrue(safeloader.is_docstring_directive_enable(":avocado: enable\n:avocado: tags=fast"))
         self.assertFalse(safeloader.is_docstring_directive_enable(":AVOCADO: ENABLE"))
         self.assertFalse(safeloader.is_docstring_directive_enable(":avocado: enabled"))
 


### PR DESCRIPTION
Using more than one docstrig directive makes Avocado to use only the
first one. This patch makes the safeloader to handle multiple docstring
directives (i.e. `:avocado: enable` and `:avocado: tags=foo`).

Reference: https://trello.com/c/6FpySXuC
Signed-off-by: Amador Pahim <apahim@redhat.com>