### PR TITLE
 support multiple docstring directives [v2]

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -611,14 +611,14 @@ class FileLoader(TestLoader):
                 docstring = ast.get_docstring(statement)
                 # Looking for a class that has in the docstring either
                 # ":avocado: enable" or ":avocado: disable
-                if safeloader.is_docstring_directive_disable(docstring):
+                if safeloader.check_docstring_directive(docstring, 'disable'):
                     continue
-                elif safeloader.is_docstring_directive_enable(docstring):
+                elif safeloader.check_docstring_directive(docstring, 'enable'):
                     methods = [st.name for st in statement.body if
                                isinstance(st, ast.FunctionDef) and
                                st.name.startswith('test')]
                     methods = data_structures.ordered_list_unique(methods)
-                    tags = safeloader.get_docstring_directive_tags(docstring)
+                    tags = safeloader.get_docstring_directives_tags(docstring)
                     result[statement.name] = {'methods': methods,
                                               'tags': tags}
                     continue
@@ -632,7 +632,7 @@ class FileLoader(TestLoader):
                                    isinstance(st, ast.FunctionDef) and
                                    st.name.startswith('test')]
                         methods = data_structures.ordered_list_unique(methods)
-                        tags = safeloader.get_docstring_directive_tags(docstring)
+                        tags = safeloader.get_docstring_directives_tags(docstring)
                         result[statement.name] = {'methods': methods,
                                                   'tags': tags}
                         continue
@@ -647,7 +647,7 @@ class FileLoader(TestLoader):
                                        isinstance(st, ast.FunctionDef) and
                                        st.name.startswith('test')]
                             methods = data_structures.ordered_list_unique(methods)
-                            tags = safeloader.get_docstring_directive_tags(docstring)
+                            tags = safeloader.get_docstring_directives_tags(docstring)
                             result[statement.name] = {'methods': methods,
                                                       'tags': tags}
 

--- a/avocado/core/safeloader.py
+++ b/avocado/core/safeloader.py
@@ -68,65 +68,44 @@ def modules_imported_as(module):
 AVOCADO_DOCSTRING_DIRECTIVE_RE = re.compile(r'\s*:avocado:\s*(\S+)\s*')
 
 
-def get_docstring_directive(docstring):
+def get_docstring_directives(docstring):
     """
-    Returns the value of the avocado docstring directive
+    Returns the values of the avocado docstring directives
 
     :param docstring: the complete text used as documentation
     :type docstring: str
+
+    :rtype: builtin.list
     """
-    if docstring is None:
-        return None
-    result = AVOCADO_DOCSTRING_DIRECTIVE_RE.search(docstring)
-    if result is not None:
-        return result.groups()[0]
+    try:
+        return AVOCADO_DOCSTRING_DIRECTIVE_RE.findall(docstring)
+    except TypeError:
+        return []
 
 
-def is_docstring_directive_enable(docstring):
+def check_docstring_directive(docstring, directive):
     """
-    Checks if there's a docstring directive that enables a Test class
+    Checks if there's a given directive in a given docstring
 
     :rtype: bool
     """
-    result = get_docstring_directive(docstring)
-    return result == 'enable'
+    return directive in get_docstring_directives(docstring)
 
 
-def is_docstring_directive_disable(docstring):
+def get_docstring_directives_tags(docstring):
     """
-    Checks if there's a docstring directive that disables a Test class
-
-    :rtype: bool
-    """
-    result = get_docstring_directive(docstring)
-    return result == 'disable'
-
-
-def is_docstring_directive_tags(docstring):
-    """
-    Checks if there's a docstring directive that tags a test
-
-    :rtype: bool
-    """
-    result = get_docstring_directive(docstring)
-    if result is not None:
-        return result.startswith('tags=')
-    return False
-
-
-def get_docstring_directive_tags(docstring):
-    """
-    Returns the test categories based on a `:avocado: tags=category` docstring
+    Returns the test categories based on a `:avocado: tags=category`
+    docstring
 
     :rtype: set
     """
-    if not is_docstring_directive_tags(docstring):
-        return []
+    tags = []
+    for item in get_docstring_directives(docstring):
+        if item.startswith('tags='):
+            _, comma_tags = item.split('tags=', 1)
+            tags.extend([tag for tag in comma_tags.split(',') if tag])
 
-    raw_tag = get_docstring_directive(docstring)
-    if raw_tag is not None:
-        _, comma_tags = raw_tag.split('tags=', 1)
-        return set([tag for tag in comma_tags.split(',') if tag])
+    return set(tags)
 
 
 def find_class_and_methods(path, method_pattern=None, base_class=None):

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -1238,6 +1238,10 @@ You can also use the ``:avocado: disable`` docstring directive, that
 works the opposite way: something that would be considered an Avocado
 test, but we force it to not be listed as one.
 
+The docstring ``:avocado: disable`` is evaluated first by Avocado,
+meaning that if both ``:avocado: disable`` and ``:avocado: enable`` are
+present in the same docstring, the test will not be listed.
+
 .. _categorizing-tests:
 
 Categorizing tests


### PR DESCRIPTION
v2:
- Refactor/rename to optimize the safeloader functions to handle the docstrings.
- Docs about enable and disable in the same docstring.

v1: #1913 