### PR TITLE
Mux: Improve the generation of Variant-IDs

### DIFF
--- a/avocado/core/mux.py
+++ b/avocado/core/mux.py
@@ -269,6 +269,9 @@ class MuxTreeNode(tree.TreeNode):
     def __repr__(self):
         return '%s(name=%r)' % (self.__class__.__name__, self.name)
 
+    def fingerprint(self):
+        return "%s%s" % (super(MuxTreeNode, self).fingerprint(), self.ctrl)
+
     def merge(self, other):
         """
         Merges `other` node into this one without checking the name of the

--- a/avocado/core/mux.py
+++ b/avocado/core/mux.py
@@ -24,6 +24,7 @@ a custom Varianter plugin.
 import collections
 import itertools
 import re
+import sha
 
 from . import output
 from . import tree
@@ -163,6 +164,16 @@ class MuxPlugin(object):
         self.root = root
         self.mux_path = mux_path
         self.debug = debug
+        self.variant_ids = self._get_variant_ids()
+
+    def _get_variant_ids(self):
+        variant_ids = []
+        for variant in MuxTree(self.root):
+            variant.sort(key=lambda x: x.path)
+            fingerprint = "-".join(_.fingerprint() for _ in variant)
+            variant_ids.append("-".join(node.name for node in variant) + '-' +
+                               sha.sha(fingerprint).hexdigest()[:4])
+        return variant_ids
 
     def __iter__(self):
         """
@@ -170,8 +181,8 @@ class MuxPlugin(object):
         """
         if self.root is None:
             return
-        for i, variant in enumerate(self.variants, 1):
-            yield {"variant_id": i,
+        for vid, variant in itertools.izip(self.variant_ids, self.variants):
+            yield {"variant_id": vid,
                    "variant": variant,
                    "mux_path": self.mux_path}
 

--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -133,6 +133,12 @@ class TreeNode(object):
         """ Inverted eq """
         return not self == other
 
+    def fingerprint(self):
+        """
+        Reports string which represents the value of this node.
+        """
+        return "%s%s" % (self.path, self.environment)
+
     def add_child(self, node):
         """
         Append node as child. Nodes with the same name gets merged into the

--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -78,8 +78,17 @@ class TreeEnvironment(dict):
         return cpy
 
     def __str__(self):
-        return ",".join((super(TreeEnvironment, self).__str__(),
-                         str(self.origin), str(self.filter_only),
+        # Use __str__ instead of __repr__ to improve readability
+        if self:
+            _values = ["%s: %s" % _ for _ in self.iteritems()]
+            values = "{%s}" % ", ".join(_values)
+            _origin = ["%s: %s" % (key, node.path)
+                       for key, node in self.origin.iteritems()]
+            origin = "{%s}" % ", ".join(_origin)
+        else:
+            values = "{}"
+            origin = "{}"
+        return ",".join((values, origin, str(self.filter_only),
                          str(self.filter_out)))
 
 

--- a/selftests/functional/test_multiplex.py
+++ b/selftests/functional/test_multiplex.py
@@ -15,7 +15,7 @@ basedir = os.path.abspath(basedir)
 AVOCADO = os.environ.get("UNITTEST_AVOCADO_CMD", "./scripts/avocado")
 
 
-DEBUG_OUT = """Variant 16:    amd@examples/mux-environment.yaml, virtio@examples/mux-environment.yaml, mint@examples/mux-environment.yaml, debug@examples/mux-environment.yaml
+DEBUG_OUT = """Variant mint-debug-amd-virtio-5e02:    amd@examples/mux-environment.yaml, virtio@examples/mux-environment.yaml, mint@examples/mux-environment.yaml, debug@examples/mux-environment.yaml
     /distro/mint:init         => systemv@examples/mux-environment.yaml:/distro/mint
     /env/debug:opt_CFLAGS     => -O0 -g@examples/mux-environment.yaml:/env/debug
     /hw/cpu/amd:cpu_CFLAGS    => -march=athlon64@examples/mux-environment.yaml:/hw/cpu/amd

--- a/selftests/unit/test_mux.py
+++ b/selftests/unit/test_mux.py
@@ -493,5 +493,45 @@ class TestPathParent(unittest.TestCase):
         self.assertNotEqual(mux.path_parent('/os/linux'), '/')
 
 
+class TestFingerprint(unittest.TestCase):
+
+    def test_fingerprint(self):
+        """
+        Verifies the fingerprint is correctly evaluated
+        """
+        node1 = tree.TreeNode("node1", {"foo": "bar"})
+        node1_fingerprint = node1.fingerprint()
+        node1duplicate = tree.TreeNode("node1", {"foo": "bar"})
+        self.assertEqual(node1_fingerprint, node1duplicate.fingerprint())
+        node1b_value = tree.TreeNode("node1", {"foo": "baz"})
+        self.assertNotEqual(node1_fingerprint, node1b_value.fingerprint())
+        node1b_name = tree.TreeNode("node2", {"foo": "bar"})
+        self.assertNotEqual(node1_fingerprint, node1b_name)
+        node1b_path = tree.TreeNode("node1", {"foo": "bar"})
+        tree.TreeNode("root", children=(node1b_path,))
+        self.assertNotEqual(node1_fingerprint, node1b_path.fingerprint())
+        node1b_env_orig = tree.TreeNode("node1", {"foo": "bar"})
+        tree.TreeNode("root", {"bar": "baz"}, children=(node1b_env_orig))
+        node1b_env_origb = tree.TreeNode("node1",
+                                         {"foo": "bar", "bar": "baz"})
+        tree.TreeNode("root", children=(node1b_env_origb,))
+        self.assertNotEqual(node1b_env_orig.fingerprint(),
+                            node1b_env_origb.fingerprint())
+
+    def test_tree_mux_node(self):
+        """
+        Check the extension of fingerprint in MuxTreeNode
+        """
+        node1 = tree.TreeNode("node1", {"foo": "bar"})
+        node1m = mux.MuxTreeNode("node1", {"foo": "bar"})
+        node1m_fingerprint = node1m.fingerprint()
+        self.assertNotEqual(node1.fingerprint(), node1m_fingerprint)
+        node1mduplicate = mux.MuxTreeNode("node1", {"foo": "bar"})
+        self.assertEqual(node1m_fingerprint, node1mduplicate.fingerprint())
+        node1mb_ctrl = mux.MuxTreeNode("node1", {"foo": "bar"})
+        node1mb_ctrl.ctrl = [mux.Control(0, 0)]
+        self.assertNotEqual(node1m_fingerprint, node1mb_ctrl.fingerprint())
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/selftests/unit/test_mux.py
+++ b/selftests/unit/test_mux.py
@@ -204,6 +204,27 @@ class TestMuxTree(unittest.TestCase):
         self.assertRaises(ValueError,
                           self.tree.get_node, '/non-existing-node')
 
+    def test_fingerprint_order(self):
+        """
+        Checks whether different order changes the fingerprint
+        """
+        children1 = (tree.TreeNode("child1"), tree.TreeNode("child2"))
+        tree1 = tree.TreeNode("root", children=children1)
+        children2 = (tree.TreeNode("child2"), tree.TreeNode("child1"))
+        tree2 = tree.TreeNode("root", children=children2)
+        mux1 = mux.MuxPlugin()
+        mux2 = mux.MuxPlugin()
+        mux1.initialize_mux(tree1, "", False)
+        mux2.initialize_mux(tree2, "", False)
+        mux1.update_defaults(tree.TreeNode())
+        mux2.update_defaults(tree.TreeNode())
+        variant1 = iter(mux1).next()
+        variant2 = iter(mux2).next()
+        self.assertNotEqual(variant1, variant2)
+        self.assertEqual(str(variant1), "{'mux_path': '', 'variant': "
+                         "[TreeNode(name='child1'), TreeNode(name="
+                         "'child2')], 'variant_id': 'child1-child2-9154'}")
+
 
 class TestMultiplex(unittest.TestCase):
 


### PR DESCRIPTION
This PR changes the serial-id-based variant_ids with id based on leaf names and hash of their contents. This is a reworked (and improved) version of https://github.com/avocado-framework/avocado/pull/1591 which also supports the debug mode.

Sample output is:

```
$ avocado run passtest.py -m examples/mux-environment.yaml 
JOB ID     : 1a68bf76137bde5f64fe3f8fc9d0b0b502edc7a8
JOB LOG    : /home/medic/avocado/job-results/job-2017-04-12T11.30-1a68bf7/job.log
 (01/24) passtest.py:PassTest.test;fedora-debug-intel-scsi-88ab: PASS (0.01 s)
 (02/24) passtest.py:PassTest.test;fedora-prod-intel-scsi-2d69: PASS (0.01 s)
...
```

compare to the old:

```
$ avocado run passtest.py -m examples/mux-environment.yaml 
JOB ID     : 140e93e43a595ee8e7681891bd2cbc101b92d77a
JOB LOG    : /home/medic/avocado/job-results/job-2017-04-12T11.31-140e93e/job.log
 (01/24) passtest.py:PassTest.test;1: PASS (0.01 s)
 (02/24) passtest.py:PassTest.test;2: PASS (0.01 s)
```