### PR TITLE
[RFC] loader improvements

### DIFF
--- a/avocado/plugins/list.py
+++ b/avocado/plugins/list.py
@@ -54,13 +54,6 @@ class TestLister(object):
     def _get_test_matrix(self, test_suite):
         test_matrix = []
 
-        type_label_mapping = loader.loader.get_type_label_mapping()
-        decorator_mapping = loader.loader.get_decorator_mapping()
-
-        stats = {}
-        for value in type_label_mapping.values():
-            stats[value.lower()] = 0
-
         for cls, params in test_suite:
             id_label = ''
             if 'params' in params:
@@ -74,28 +67,23 @@ class TestLister(object):
             if isinstance(cls, basestring):
                 cls = test.Test
                 id_label = params['name']
-            type_label = type_label_mapping[cls]
-            decorator = decorator_mapping[cls]
-            stats[type_label.lower()] += 1
+            type_label = cls.label
+            decorator = cls.decorator
             type_label = decorator(type_label)
 
-            test_matrix.append((type_label, id_label))
+            test_matrix.append((params['loader'], type_label, id_label))
 
-        return test_matrix, stats
+        return test_matrix
 
-    def _display(self, test_matrix, stats):
+    def _display(self, test_matrix):
         header = None
         if self.args.verbose:
-            header = (output.TERM_SUPPORT.header_str('Type'),
+            header = (output.TERM_SUPPORT.header_str('Plugin'),
+                      output.TERM_SUPPORT.header_str('Type'),
                       output.TERM_SUPPORT.header_str('Test'))
 
         for line in astring.iter_tabular_output(test_matrix, header=header):
             self.log.debug(line)
-
-        if self.args.verbose:
-            self.log.debug("")
-            for key in sorted(stats):
-                self.log.info("%s: %s", key.upper(), stats[key])
 
     def _list(self):
         self._extra_listing()
@@ -105,8 +93,8 @@ class TestLister(object):
                 test_suite,
                 self.args.filter_by_tags,
                 self.args.filter_by_tags_include_empty)
-        test_matrix, stats = self._get_test_matrix(test_suite)
-        self._display(test_matrix, stats)
+        test_matrix = self._get_test_matrix(test_suite)
+        self._display(test_matrix)
 
     def list(self):
         try:

--- a/selftests/functional/test_loader.py
+++ b/selftests/functional/test_loader.py
@@ -149,14 +149,14 @@ class LoaderTestFunctional(unittest.TestCase):
         os.chdir(basedir)
         self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
 
-    def _test(self, name, content, exp_str, mode=MODE_0664, count=1):
+    def _test(self, name, content, exp_str, mode=MODE_0664):
         test_script = script.TemporaryScript(name, content,
                                              'avocado_loader_test',
                                              mode=mode)
         test_script.save()
         cmd_line = ('%s list -V %s' % (AVOCADO, test_script.path))
         result = process.run(cmd_line)
-        self.assertIn('%s: %s' % (exp_str, count), result.stdout)
+        self.assertIn('%s' % exp_str, result.stdout)
         test_script.remove()
 
     def _run_with_timeout(self, cmd_line, timeout):
@@ -199,15 +199,15 @@ class LoaderTestFunctional(unittest.TestCase):
                         ("Took more than 3 seconds to list tests. Loader "
                          "probably loaded/executed Python code and slept for "
                          "eleven seconds."))
-        self.assertIn('INSTRUMENTED: 2', result.stdout)
+        self.assertIn('INSTRUMENTED', result.stdout)
 
     def test_multiple_class(self):
         self._test('multipleclasses.py', AVOCADO_TEST_MULTIPLE_CLASSES,
-                   'INSTRUMENTED', self.MODE_0664, 2)
+                   'INSTRUMENTED', self.MODE_0664)
 
     def test_multiple_methods_same_name(self):
         self._test('multiplemethods.py', AVOCADO_TEST_MULTIPLE_METHODS_SAME_NAME,
-                   'INSTRUMENTED', 0664, 1)
+                   'INSTRUMENTED', 0664)
 
     def test_load_not_a_test(self):
         self._test('notatest.py', NOT_A_TEST, 'SIMPLE', self.MODE_0775)
@@ -229,7 +229,7 @@ class LoaderTestFunctional(unittest.TestCase):
         mytest.save()
         cmd_line = "%s list -V %s" % (AVOCADO, mytest)
         result = process.run(cmd_line)
-        self.assertIn('SIMPLE: 1', result.stdout)
+        self.assertIn('SIMPLE', result.stdout)
         # job should be able to finish under 5 seconds. If this fails, it's
         # possible that we hit the "simple test fork bomb" bug
         cmd_line = ("%s run --sysinfo=off --job-results-dir '%s' -- '%s'"


### PR DESCRIPTION
Currently the loaders plugins are keeping the mapping of the test labels and (color)decorators to be used in `list`. This has a problem because the core loader can resolv a test reference as `test.MissingTest` and if the available loaders don't have that mapping, avocado will crash (see https://trello.com/c/r4DLYomE/982-bug-the-avocado-list-is-broken-when-file-loader-is-not-enabled).

This PR is a proposal for moving the label/decorator knowledge to the tests classes so each class keeps the information about itself. The loaders will then only keep the list of supported test classes.

As consequence, the list `command` can now show the results per plugin when used in verbose mode.

Selftests have to be improved, but please allow me to discuss the design in first place with this PR .