### PR TITLE
fix output on unknown tests

### DIFF
--- a/avocado/plugins/jsonresult.py
+++ b/avocado/plugins/jsonresult.py
@@ -74,6 +74,9 @@ class JSONResult(Result):
                 hasattr(job.args, 'json_output')):
             return
 
+        if not result.tests_total:
+            return
+
         content = self._render(result)
         if getattr(job.args, 'json_job_result', 'off') == 'on':
             json_path = os.path.join(job.logdir, 'results.json')

--- a/avocado/plugins/xunit.py
+++ b/avocado/plugins/xunit.py
@@ -111,6 +111,9 @@ class XUnitResult(Result):
                 hasattr(job.args, 'xunit_output')):
             return
 
+        if not result.tests_total:
+            return
+
         content = self._render(result)
         if getattr(job.args, 'xunit_job_result', 'off') == 'on':
             xunit_path = os.path.join(job.logdir, 'results.xml')

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -459,6 +459,15 @@ class OutputPluginTest(unittest.TestCase):
         self.assertIn("not found", result.stderr)
         self.assertNotIn("Avocado crashed", result.stderr)
 
+    def test_results_plugins_no_tests(self):
+        os.chdir(basedir)
+        for output in ['json', 'xunit', 'tap']:
+            cmd_line = ("%s run UNEXISTING --job-results-dir %s --%s -"
+                        % (AVOCADO, self.tmpdir, output))
+            result = process.run(cmd_line, ignore_status=True)
+            self.assertIs('', result.stdout)
+            self.assertEqual(exit_codes.AVOCADO_JOB_FAIL, result.exit_status)
+
     def tearDown(self):
         shutil.rmtree(self.tmpdir)
 


### PR DESCRIPTION
When the tests references cannot be resolved to a test_suite, the
results plugins should not output anything.

Reference: https://trello.com/c/oMQsQHC6
Signed-off-by: Amador Pahim <apahim@redhat.com>