### PR TITLE
Loader: Move MissingTest mapping to TestLoaderProxy [v2]

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -122,6 +122,8 @@ class TestLoaderProxy(object):
         self._initialized_plugins = []
         self.registered_plugins = []
         self.reference_plugin_mapping = {}
+        self._label_mapping = None
+        self._decorator_mapping = None
 
     def register_plugin(self, plugin):
         try:
@@ -155,6 +157,8 @@ class TestLoaderProxy(object):
             return ", ".join(sorted(supported_types + supported_loaders))
 
         self._initialized_plugins = []
+        self._label_mapping = None
+        self._decorator_mapping = None
         # Add (default) file loader if not already registered
         if FileLoader not in self.registered_plugins:
             self.register_plugin(FileLoader)
@@ -207,13 +211,17 @@ class TestLoaderProxy(object):
         return base_path
 
     def get_type_label_mapping(self):
-        mapping = {}
+        if self._label_mapping is not None:
+            return self._label_mapping
+        mapping = {test.MissingTest: "MISSING"}
         for loader_plugin in self._initialized_plugins:
             mapping.update(loader_plugin.get_type_label_mapping())
         return mapping
 
     def get_decorator_mapping(self):
-        mapping = {}
+        if self._decorator_mapping is not None:
+            return self._decorator_mapping
+        mapping = {test.MissingTest: output.TERM_SUPPORT.fail_header_str}
         for loader_plugin in self._initialized_plugins:
             mapping.update(loader_plugin.get_decorator_mapping())
         return mapping


### PR DESCRIPTION
The MissingTest is yielded by TestLoaderProxy, but it was implemented
and described in FileLoader, which caused troubles when FileLoader was
not being used. This simple fix allows TestLoaderProxy to define basic
mappings and adds MissingTest to it.

v1: https://github.com/avocado-framework/avocado/pull/1920

Changes:
```yaml
v2: Use different approach as this is a bugfix and the correct fix will be introduced later
```