### PR TITLE
fix output on unknown tests [V2]

### DIFF
--- a/avocado/plugins/jsonresult.py
+++ b/avocado/plugins/jsonresult.py
@@ -74,6 +74,9 @@ class JSONResult(Result):
                 hasattr(job.args, 'json_output')):
             return
 
+        if not result.tests_total:
+            return
+
         content = self._render(result)
         if getattr(job.args, 'json_job_result', 'off') == 'on':
             json_path = os.path.join(job.logdir, 'results.json')

--- a/avocado/plugins/xunit.py
+++ b/avocado/plugins/xunit.py
@@ -111,6 +111,9 @@ class XUnitResult(Result):
                 hasattr(job.args, 'xunit_output')):
             return
 
+        if not result.tests_total:
+            return
+
         content = self._render(result)
         if getattr(job.args, 'xunit_job_result', 'off') == 'on':
             xunit_path = os.path.join(job.logdir, 'results.xml')

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -459,6 +459,22 @@ class OutputPluginTest(unittest.TestCase):
         self.assertIn("not found", result.stderr)
         self.assertNotIn("Avocado crashed", result.stderr)
 
+    def test_results_plugins_no_tests(self):
+        os.chdir(basedir)
+        cmd_line = ("%s run UNEXISTING --job-results-dir %s"
+                    % (AVOCADO, self.tmpdir))
+        exit_code = process.system(cmd_line, ignore_status=True)
+        self.assertEqual(exit_code, exit_codes.AVOCADO_JOB_FAIL)
+
+        xunit_results = os.path.join(self.tmpdir, 'latest', 'results.xml')
+        self.assertFalse(os.path.exists(xunit_results))
+
+        json_results = os.path.join(self.tmpdir, 'latest', 'results.json')
+        self.assertFalse(os.path.exists(json_results))
+
+        tap_results = os.path.join(self.tmpdir, 'latest', 'results.tap')
+        self.assertFalse(os.path.exists(tap_results))
+
     def tearDown(self):
         shutil.rmtree(self.tmpdir)
 


### PR DESCRIPTION
v2:
- Test results files (non)creation instead of the avocado command (non)stdout.

v1: #1923 