### PR TITLE
test_runner_simple_python_like_multiple_files: mark it as a resource …

### DIFF
--- a/selftests/functional/test_loader.py
+++ b/selftests/functional/test_loader.py
@@ -215,6 +215,9 @@ class LoaderTestFunctional(unittest.TestCase):
     def test_load_not_a_test_not_exec(self):
         self._test('notatest.py', NOT_A_TEST, 'NOT_A_TEST')
 
+    @unittest.skipIf(os.environ.get("AVOCADO_CHECK_FULL") != "1",
+                     "Skipping test that take a long time to run, are "
+                     "resource intensive or time sensitve")
     def test_runner_simple_python_like_multiple_files(self):
         mylib = script.TemporaryScript(
             'test2.py',


### PR DESCRIPTION
…sensitive test

As it has already been done to some other tests,
test_runner_simple_python_like_multiple_files can be sensitive to
limited resources and produce false positives.  This has been observed
recently in package builds in build farms.

Let's run that one only when `make check-full` is called, which is
usually done at dedicated machines with plenty of resources.

Reference: https://kojipkgs.fedoraproject.org/work/tasks/9189/19059189/build.log
Signed-off-by: Cleber Rosa <crosa@redhat.com>