### PR TITLE
python-avocado.spec: fix excluded files for optional plugin packages

### DIFF
--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -29,7 +29,7 @@
 Summary: Framework with tools and libraries for Automated Testing
 Name: python-%{srcname}
 Version: 48.0
-Release: 2%{?gitrel}%{?dist}
+Release: 3%{?gitrel}%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.github.io/
@@ -190,6 +190,10 @@ selftests/run
 %{_mandir}/man1/avocado-rest-client.1.gz
 %{_docdir}/avocado/avocado.rst
 %{_docdir}/avocado/avocado-rest-client.rst
+%exclude %{python_sitelib}/avocado_result_html*
+%exclude %{python_sitelib}/avocado_runner_remote*
+%exclude %{python_sitelib}/avocado_runner_vm*
+%exclude %{python_sitelib}/avocado_runner_docker*
 %exclude %{python_sitelib}/avocado_framework_plugin_result_html*
 %exclude %{python_sitelib}/avocado_framework_plugin_runner_remote*
 %exclude %{python_sitelib}/avocado_framework_plugin_runner_vm*
@@ -212,6 +216,7 @@ directory. It also gives the user the ability to write a report on an
 arbitrary filesystem location.
 
 %files plugins-output-html
+%{python_sitelib}/avocado_result_html*
 %{python_sitelib}/avocado_framework_plugin_result_html*
 
 %package plugins-runner-remote
@@ -230,6 +235,7 @@ Allows Avocado to run jobs on a remote machine, by means of an SSH
 connection.  Avocado must be previously installed on the remote machine.
 
 %files plugins-runner-remote
+%{python_sitelib}/avocado_runner_remote*
 %{python_sitelib}/avocado_framework_plugin_runner_remote*
 
 %package plugins-runner-vm
@@ -246,6 +252,7 @@ interaction with a libvirt daemon and an SSH connection to the VM
 itself.  Avocado must be previously installed on the VM.
 
 %files plugins-runner-vm
+%{python_sitelib}/avocado_runner_vm*
 %{python_sitelib}/avocado_framework_plugin_runner_vm*
 
 %package plugins-runner-docker
@@ -266,6 +273,7 @@ Docker daemon and attaching to the container itself.  Avocado must
 be previously installed on the container.
 
 %files plugins-runner-docker
+%{python_sitelib}/avocado_runner_docker*
 %{python_sitelib}/avocado_framework_plugin_runner_docker*
 
 
@@ -283,6 +291,9 @@ examples of how to write tests on your own.
 %{_datadir}/avocado/wrappers
 
 %changelog
+* Wed Apr 19 2017 Cleber Rosa <cleber@redhat.com> - 48.0-3
+- Fix exclusion of optional plugins files done on 48.0-1
+
 * Mon Apr 10 2017 Cleber Rosa <cleber@redhat.com> - 48.0-2
 - Update how release and snapshot packages are built
 


### PR DESCRIPTION
Commit 7a249b7 removed files that were intended to be packaged in the
optional plugin packages.  By doing so, they ended up in the main
package.

This fixes that issue, and puts both the directories with the
package and module name (which differ) into each optional plugin
package file listing.

Signed-off-by: Cleber Rosa <crosa@redhat.com>