### PR TITLE
Loader: Move MissingTest mapping to TestLoaderProxy [v3]

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -122,6 +122,8 @@ class TestLoaderProxy(object):
         self._initialized_plugins = []
         self.registered_plugins = []
         self.reference_plugin_mapping = {}
+        self._label_mapping = None
+        self._decorator_mapping = None
 
     def register_plugin(self, plugin):
         try:
@@ -195,6 +197,14 @@ class TestLoaderProxy(object):
                 extra_params['loader_options'] = loaders[i][1]
             plugin = self.registered_plugins[supported_loaders.index(name)]
             self._initialized_plugins.append(plugin(args, extra_params))
+        # Plugins are initialized, let's update mappings
+        self._label_mapping = {test.MissingTest: "MISSING"}
+        for plugin in self._initialized_plugins:
+            self._label_mapping.update(plugin.get_type_label_mapping())
+        self._decorator_mapping = {test.MissingTest:
+                              output.TERM_SUPPORT.fail_header_str}
+        for plugin in self._initialized_plugins:
+            self._decorator_mapping.update(plugin.get_decorator_mapping())
 
     def get_extra_listing(self):
         for loader_plugin in self._initialized_plugins:
@@ -207,16 +217,10 @@ class TestLoaderProxy(object):
         return base_path
 
     def get_type_label_mapping(self):
-        mapping = {}
-        for loader_plugin in self._initialized_plugins:
-            mapping.update(loader_plugin.get_type_label_mapping())
-        return mapping
+        return self._label_mapping
 
     def get_decorator_mapping(self):
-        mapping = {}
-        for loader_plugin in self._initialized_plugins:
-            mapping.update(loader_plugin.get_decorator_mapping())
-        return mapping
+        return self._decorator_mapping
 
     def discover(self, references, which_tests=DEFAULT):
         """

--- a/avocado/plugins/list.py
+++ b/avocado/plugins/list.py
@@ -53,7 +53,6 @@ class TestLister(object):
 
     def _get_test_matrix(self, test_suite):
         test_matrix = []
-
         type_label_mapping = loader.loader.get_type_label_mapping()
         decorator_mapping = loader.loader.get_decorator_mapping()
 

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -880,6 +880,19 @@ class PluginsTest(AbsPluginsTest, unittest.TestCase):
                          (expected_rc, result))
         self.assertIn("Unable to resolve reference", output)
 
+    def test_list_no_file_loader(self):
+        os.chdir(basedir)
+        cmd_line = ("%s list --loaders external --verbose -- "
+                    "this-wont-be-matched" % AVOCADO)
+        result = process.run(cmd_line, ignore_status=True)
+        self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK,
+                         "Avocado did not return rc %d:\n%s"
+                         % (exit_codes.AVOCADO_ALL_OK, result))
+        exp = ("Type    Test\nMISSING this-wont-be-matched\n\nEXTERNAL: 0\n"
+               "MISSING: 1\n")
+        self.assertEqual(exp, result.stdout, "Stdout mismatch:\n%s\n\n%s"
+                         % (exp, result))
+
     def test_plugin_list(self):
         os.chdir(basedir)
         cmd_line = '%s plugins' % AVOCADO


### PR DESCRIPTION
The MissingTest is yielded by TestLoaderProxy, but it was implemented
and described in FileLoader, which caused troubles when FileLoader was
not being used. This simple fix allows TestLoaderProxy to define basic
mappings and adds MissingTest to it.

v1: https://github.com/avocado-framework/avocado/pull/1920
v2: https://github.com/avocado-framework/avocado/pull/1926

Changes:
```yaml
v2: Use different approach as this is a bugfix and the correct fix will be introduced later
v3: Rework the lazy-init to normal init on `load_plugins`
v3: Add selftest
```