### PR TITLE
data_dir: use a directory intended for writable content

### DIFF
--- a/etc/avocado/avocado.conf
+++ b/etc/avocado/avocado.conf
@@ -1,10 +1,10 @@
 [datadir.paths]
 # Avocado data dir (holds tests and test auxiliary data, such as ISO files).
-base_dir = /usr/share/avocado
+base_dir = /var/lib/avocado
 # You may override the specific test directory with test_dir
 test_dir = /usr/share/avocado/tests
 # You may override the specific test auxiliary data directory with data_dir
-data_dir = /usr/share/avocado/data
+data_dir = /var/lib/avocado/data
 # You may override the specific job results directory with logs_dir
 logs_dir = ~/avocado/job-results
 # You can set a list of cache directories to be used by the avocado test

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -29,7 +29,7 @@
 Summary: Framework with tools and libraries for Automated Testing
 Name: python-%{srcname}
 Version: 48.0
-Release: 3%{?gitrel}%{?dist}
+Release: 4%{?gitrel}%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.github.io/
@@ -148,6 +148,7 @@ popd
 %{__mkdir} -p %{buildroot}%{_mandir}/man1
 %{__install} -m 0644 man/avocado.1 %{buildroot}%{_mandir}/man1/avocado.1
 %{__install} -m 0644 man/avocado-rest-client.1 %{buildroot}%{_mandir}/man1/avocado-rest-client.1
+%{__install} -d -m 0755 %{buildroot}%{_sharedstatedir}/avocado/data
 
 %check
 %if %{with_tests}
@@ -175,6 +176,7 @@ selftests/run
 %dir /etc/avocado/sysinfo
 %dir /etc/avocado/scripts/job/pre.d
 %dir /etc/avocado/scripts/job/post.d
+%dir %{_sharedstatedir}/avocado/data
 %config(noreplace)/etc/avocado/avocado.conf
 %config(noreplace)/etc/avocado/conf.d/README
 %config(noreplace)/etc/avocado/conf.d/gdb.conf
@@ -291,6 +293,9 @@ examples of how to write tests on your own.
 %{_datadir}/avocado/wrappers
 
 %changelog
+* Wed Apr 19 2017 Cleber Rosa <cleber@redhat.com> - 48.0-4
+- Added "/var/lib/avocado" directory for writable content
+
 * Wed Apr 19 2017 Cleber Rosa <cleber@redhat.com> - 48.0-3
 - Fix exclusion of optional plugins files done on 48.0-1
 


### PR DESCRIPTION
Avocado's "data_dir" has always been meant for readable **and** writable
content.

Right now, this is broken because the system wide default for
"base_dir" (data_dir's parent) is set to /usr/share/avocado, and
consequently, "data_dir" is set to /usr/share/avocado/data.

Let's use "/var/lib/avocado" for the "base_dir", and
"/var/lib/avocado/data" for the "data_dir".  Content intended to be
read-only, such as example tests and wrappers, are still set to
/usr/share/avocado.

This has been tested with Avocado-VT, making the result of system
wide content, such as test providers and downloadable files be
put under "/var/lib/avocado/data/avocado-vt".

Reference: https://trello.com/c/KU1DvSAz
Signed-off-by: Cleber Rosa <crosa@redhat.com>