### PR TITLE
utils.astring: Be really lenient towards incorrect strings [v2]

### DIFF
--- a/avocado/utils/astring.py
+++ b/avocado/utils/astring.py
@@ -219,7 +219,7 @@ def string_safe_encode(string):
     try:
         return string.encode("utf-8")
     except UnicodeDecodeError:
-        return string.decode("utf-8").encode("utf-8")
+        return string.decode("utf-8", "replace").encode("utf-8")
 
 
 def string_to_safe_path(string):

--- a/selftests/unit/test_astring.py
+++ b/selftests/unit/test_astring.py
@@ -49,17 +49,17 @@ class AstringTest(unittest.TestCase):
         the correct results. (the string_safe_encode function is in use here)
         """
 
-        matrix = [("\xd0\xb0\xd0\xb2\xd0\xbe\xd0\xba\xd0\xb0\xd0\xb4\xd0\xbe",
+        matrix = [("\xd0\xb0\xd0\xb2\xd0\xbe\xd0\xba\xd0\xb0\xd0\xb4\xff",
                    123),
-                  (u'\u0430\u0432\u043e\u043a\u0430\u0434\u043e', 123),
+                  (u'\u0430\u0432\u043e\u043a\u0430\u0434\xff', 123),
                   ("avok\xc3\xa1do", 123),
-                  ("avocado", 123)]
+                  ("a\u0430", 123)]
         str_matrix = ("\xd0\xb0\xd0\xb2\xd0\xbe\xd0\xba\xd0\xb0\xd0\xb4"
-                      "\xd0\xbe 123\n"
+                      "\xef\xbf\xbd 123\n"
                       "\xd0\xb0\xd0\xb2\xd0\xbe\xd0\xba\xd0\xb0\xd0\xb4"
-                      "\xd0\xbe 123\n"
+                      "\xc3\xbf 123\n"
                       "avok\xc3\xa1do 123\n"
-                      "avocado 123")
+                      "a\u0430 123")
         self.assertEqual(astring.tabular_output(matrix), str_matrix)
 
 


### PR DESCRIPTION
The "astring.string_safe_encode" is a method, which tries to encode the
string no-matter how wrong it is. Let's also allow broken corrupted
strings by using "ignore" to skip the corrupted chars.

v1: https://github.com/avocado-framework/avocado/pull/1901

Changes:
```yaml
v2: Improved selftest to contain incorrect characters
v2: Use "replace" rather than "ignore" to emphasize there was something ugly
```