### PR TITLE
docs: add robot plugin information

### DIFF
--- a/docs/source/optional_plugins/index.rst
+++ b/docs/source/optional_plugins/index.rst
@@ -10,3 +10,4 @@ The following pages are the documentation for the optical plugins:
    :maxdepth: 1
 
    resultsdb
+   robot

--- a/docs/source/optional_plugins/robot.rst
+++ b/docs/source/optional_plugins/robot.rst
@@ -1,0 +1,21 @@
+============
+Robot Plugin
+============
+
+This optional plugin enables Avocado to work with tests originally
+written using the `Robot Framework <http://robotframework.org/>`_ API.
+
+To install the Robot plugin from pip, use::
+
+    $ sudo pip install avocado-framework-plugin-robot
+
+After installed, you can list/run Robot tests the same way you do with
+other types of tests.
+
+To list the tests, execute::
+
+    $ avocado list ~/path/to/robot/tests/test.robot
+
+Directories are also accepted. To run the tests, execute::
+
+    $ avocado run ~/path/to/robot/tests/test.robot


### PR DESCRIPTION
Robot plugin was introduced without documentation. This PR adds the
basic information about the Robot plugin.

Signed-off-by: Amador Pahim <apahim@redhat.com>