### PR TITLE
resultsdb: include information about variants

### DIFF
--- a/optional_plugins/resultsdb/avocado_resultsdb/__init__.py
+++ b/optional_plugins/resultsdb/avocado_resultsdb/__init__.py
@@ -77,6 +77,8 @@ class ResultsdbResult(ResultEvents):
 
         outcome = self._status_map(state['status'])
         name = state['name'].name
+        if state['name'].variant is not None:
+            name += ';%s' % state['name'].variant
         group = [self.job_id]
 
         note = None
@@ -101,6 +103,12 @@ class ResultsdbResult(ResultEvents):
                 'logfile': state['logfile'],
                 'whiteboard': state['whiteboard'],
                 'status': state['status']}
+
+        params = {}
+        for param in state['params'].iteritems():
+            params['param %s' % param[1]] = '%s (path: %s)' % (param[2],
+                                                               param[0])
+        data.update(params)
 
         self.rdbapi.create_result(outcome, name, group, note, ref_url, **data)
 


### PR DESCRIPTION
The ResultsDB expects the Testcase, not the Test ID. Even so, the
Testcase can be considered the combination of the test name plus the
variant.

While on this, this patch adds the parameters information to the
ResultsDB 'data' section.

Signed-off-by: Amador Pahim <apahim@redhat.com>