### PR TITLE
Added a sleep time after starting multipath services in multipath.py

### DIFF
--- a/avocado/utils/multipath.py
+++ b/avocado/utils/multipath.py
@@ -58,6 +58,7 @@ def form_conf_mpath_file(blacklist="", defaults_extra=""):
     # multipath.conf file to take effect.
     time.sleep(5)
     service.SpecificServiceManager(get_svc_name()).restart()
+    time.sleep(4)
 
 
 def device_exists(path):


### PR DESCRIPTION
Test which are using this utility are failing as they start using
multipath as soon as services are re-satrted. But multipath need
some time to load the services completely. So to load the
multipaths properly we need to give some sleep time which resolve
the issue

Signed-off-by: Naresh Bannoth <nbannoth@in.ibm.com>