### PR TITLE
WiP selftests: Force-disable "global evaluation"

### DIFF
--- a/selftests/checkall
+++ b/selftests/checkall
@@ -79,7 +79,7 @@ results_dir_content() {
 }
 
 [ "$SKIP_RESULTSDIR_CHECK" ] || RESULTS_DIR_CONTENT="$(ls $RESULTS_DIR 2> /dev/null)"
-run_rc lint 'inspekt --exclude=.git lint'
+run_rc lint 'inspekt --exclude=.git lint --disable RP0004,W,R,C,E1002,E1101,E1103,E1120,F0401,I0011 --enable W0611'
 run_rc indent 'inspekt --exclude=.git indent'
 run_rc style 'inspekt --exclude=.git style --disable E501,E265,W601,E402,E722'
 run_rc boundaries 'selftests/modules_boundaries'


### PR DESCRIPTION
__DON'T MERGE__
=========================

Recently some pylint version even on non-verbose execution started
printing "Global evaluation". Let's force-disable it to avoid
unnecessary messages.