### PR TITLE
skip/cancel: internal improvements

### DIFF
--- a/avocado/core/decorators.py
+++ b/avocado/core/decorators.py
@@ -63,7 +63,7 @@ def skip(message=None):
         if not isinstance(function, type):
             @wraps(function)
             def wrapper(*args, **kwargs):
-                raise core_exceptions.TestDecoratorSkip(message)
+                raise core_exceptions.TestSkip(message)
             function = wrapper
         function.__skip_test_decorator__ = True
         return function

--- a/avocado/core/exceptions.py
+++ b/avocado/core/exceptions.py
@@ -102,14 +102,6 @@ class TestTimeoutInterrupted(TestBaseException):
     status = "INTERRUPTED"
 
 
-class TestTimeoutSkip(TestBaseException):
-
-    """
-    Indicates that the test is skipped due to a job timeout.
-    """
-    status = "SKIP"
-
-
 class TestInterruptedError(TestBaseException):
 
     """
@@ -126,7 +118,7 @@ class TestAbortError(TestBaseException):
     status = "ERROR"
 
 
-class TestSkipError(TestBaseException):
+class TestSkip(TestBaseException):
 
     """
     Indictates that the test is skipped.
@@ -144,16 +136,6 @@ class TestSetupSkip(TestBaseException):
     Indictates that the test is skipped in setUp().
 
     Should be thrown when skip() is used in setUp().
-    """
-    status = "SKIP"
-
-
-class TestDecoratorSkip(TestBaseException):
-
-    """
-    Indictates that the test is skipped by a decorator.
-
-    Should be thrown when the skip decorators are used.
     """
     status = "SKIP"
 

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -862,15 +862,15 @@ class DummyLoader(TestLoader):
         super(DummyLoader, self).__init__(args, extra_params)
 
     def discover(self, url, which_tests=DEFAULT):
-        return [(test.SkipTest, {'name': url})]
+        return [(test.FakeTest, {'name': url})]
 
     @staticmethod
     def get_type_label_mapping():
-        return {test.SkipTest: 'DUMMY'}
+        return {test.FakeTest: 'DUMMY'}
 
     @staticmethod
     def get_decorator_mapping():
-        return {test.SkipTest: output.TERM_SUPPORT.healthy_str}
+        return {test.FakeTest: output.TERM_SUPPORT.healthy_str}
 
 
 loader = TestLoaderProxy()

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -479,11 +479,11 @@ class RunnerOperationTest(unittest.TestCase):
         self.assertIn(tempfile.gettempdir(), debuglog)   # Use tmp dir, not default location
         self.assertEqual(result['job_id'], u'0' * 40)
         # Check if all tests were skipped
-        self.assertEqual(result['skip'], 4)
+        self.assertEqual(result['cancel'], 4)
         for i in xrange(4):
             test = result['tests'][i]
             self.assertEqual(test['fail_reason'],
-                             u'Test skipped due to --dry-run')
+                             u'Test cancelled due to --dry-run')
         # Check if all params are listed
         # The "/:bar ==> 2 is in the tree, but not in any leave so inaccessible
         # from test.

--- a/selftests/unit/test_test.py
+++ b/selftests/unit/test_test.py
@@ -191,24 +191,22 @@ class SimpleTestClassTest(unittest.TestCase):
         shutil.rmtree(self.tmpdir)
 
 
-class SkipTest(unittest.TestCase):
+class FakeTest(unittest.TestCase):
 
     def setUp(self):
         self.tests = []
 
     def test_init(self):
         # No params
-        self.tests.append(test.SkipTest())
-        self.assertRaises(exceptions.TestSkipError, self.tests[-1].setUp)
-        self.assertRaises(RuntimeError, self.tests[-1].test)
+        self.tests.append(test.FakeTest())
         # Positional
-        self.tests.append(test.SkipTest("test", test.TestName(1, "my_name"),
+        self.tests.append(test.FakeTest("test", test.TestName(1, "my_name"),
                                         {}, None, "1",
                                         None, None, "extra_param1",
                                         "extra_param2"))
         self.assertEqual(self.tests[-1].name, "1-my_name")
         # Kwargs
-        self.tests.append(test.SkipTest(methodName="test",
+        self.tests.append(test.FakeTest(methodName="test",
                                         name=test.TestName(1, "my_name2"),
                                         params={}, base_logdir=None,
                                         tag="a", job=None, runner_queue=None,
@@ -217,7 +215,7 @@ class SkipTest(unittest.TestCase):
         self.assertEqual(self.tests[-1].name, "1-my_name2")
         # both (theoretically impossible in python, but valid for nasty tests)
         # keyword args are used as they explicitly represent what they mean
-        self.tests.append(test.SkipTest("not used", "who cares", {}, None, "0",
+        self.tests.append(test.FakeTest("not used", "who cares", {}, None, "0",
                                         None, None, "extra_param1",
                                         "extra_param2",
                                         methodName="test",
@@ -228,7 +226,7 @@ class SkipTest(unittest.TestCase):
                                         extra2="extra_param4"))
         self.assertEqual(self.tests[-1].name, "1-my_name3")
         # combination
-        self.tests.append(test.SkipTest("test", test.TestName(1, "my_name4"),
+        self.tests.append(test.FakeTest("test", test.TestName(1, "my_name4"),
                                         tag="321",
                                         other_param="Whatever"))
         self.assertEqual(self.tests[-1].name, "1-my_name4")
@@ -238,7 +236,7 @@ class SkipTest(unittest.TestCase):
         # ones.
         name = "positional_method_name_becomes_test_name"
         tag = "positional_base_logdir_becomes_tag"
-        self.tests.append(test.SkipTest(test.TestName(1, name), None, None, tag,
+        self.tests.append(test.FakeTest(test.TestName(1, name), None, None, tag,
                                         methodName="test",
                                         other_param="Whatever"))
         self.assertEqual(self.tests[-1].name, "1-" + name)


### PR DESCRIPTION
Due to the deprecation of the self.skip(), the availability of the skip
decorators and the new CANCEL status, some internal improvements are
important to keep our behaviour sane and our own code sound and clean.

- The test.SkipTest class was renamed to test.FakeTest to be even more
  generic, intending to be overridden by subclasses that make the test
  to end both with SKIP or CANCEL status. To keep it generic,
  test.FakeTest class will not SKIP the test if used directly anymore.

- The test.TimeOutSkipTest and test.ReplaySkipTest classes now are using
  the skip decorators instead of raising an exception in setUp(), since
  'skipping' the test means 'don't execute anything', not even the
  setUp().

- The test.DryRunTest class, which is expected to log itself in setUp()
  and then abort the test execution, is now using self.cancel() (instead
  of raising a SKIP exception), being now compliant with the concept
  that a SKIP test cannot execute anything.

- The skip exceptions were simplified and the only missing piece is to
  remove the exceptions.TestSetupSkip, when the time to drop the
  self.skip() comes.

- Selftests were adjusted accordingly.

Signed-off-by: Amador Pahim <apahim@redhat.com>