### PR TITLE
skip/cancel: internal improvements [v2]

### DIFF
--- a/avocado/core/decorators.py
+++ b/avocado/core/decorators.py
@@ -63,7 +63,7 @@ def skip(message=None):
         if not isinstance(function, type):
             @wraps(function)
             def wrapper(*args, **kwargs):
-                raise core_exceptions.TestDecoratorSkip(message)
+                raise core_exceptions.TestSkip(message)
             function = wrapper
         function.__skip_test_decorator__ = True
         return function

--- a/avocado/core/exceptions.py
+++ b/avocado/core/exceptions.py
@@ -102,14 +102,6 @@ class TestTimeoutInterrupted(TestBaseException):
     status = "INTERRUPTED"
 
 
-class TestTimeoutSkip(TestBaseException):
-
-    """
-    Indicates that the test is skipped due to a job timeout.
-    """
-    status = "SKIP"
-
-
 class TestInterruptedError(TestBaseException):
 
     """
@@ -126,7 +118,7 @@ class TestAbortError(TestBaseException):
     status = "ERROR"
 
 
-class TestSkipError(TestBaseException):
+class TestSkip(TestBaseException):
 
     """
     Indictates that the test is skipped.
@@ -144,16 +136,6 @@ class TestSetupSkip(TestBaseException):
     Indictates that the test is skipped in setUp().
 
     Should be thrown when skip() is used in setUp().
-    """
-    status = "SKIP"
-
-
-class TestDecoratorSkip(TestBaseException):
-
-    """
-    Indictates that the test is skipped by a decorator.
-
-    Should be thrown when the skip decorators are used.
     """
     status = "SKIP"
 

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -862,15 +862,15 @@ class DummyLoader(TestLoader):
         super(DummyLoader, self).__init__(args, extra_params)
 
     def discover(self, url, which_tests=DEFAULT):
-        return [(test.SkipTest, {'name': url})]
+        return [(test.MockingTest, {'name': url})]
 
     @staticmethod
     def get_type_label_mapping():
-        return {test.SkipTest: 'DUMMY'}
+        return {test.MockingTest: 'DUMMY'}
 
     @staticmethod
     def get_decorator_mapping():
-        return {test.SkipTest: output.TERM_SUPPORT.healthy_str}
+        return {test.MockingTest: output.TERM_SUPPORT.healthy_str}
 
 
 loader = TestLoaderProxy()

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -40,6 +40,7 @@ from ..utils import genio
 from ..utils import path as utils_path
 from ..utils import process
 from ..utils import stacktrace
+from .decorators import skip
 from .settings import settings
 from .version import VERSION
 
@@ -564,14 +565,9 @@ class Test(unittest.TestCase):
         try:
             if skip_test is False:
                 self.setUp()
-        except (exceptions.TestSetupSkip,
-                exceptions.TestTimeoutSkip,
-                exceptions.TestSkipError) as details:
+        except (exceptions.TestSetupSkip, exceptions.TestSkip) as details:
             stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
-            raise exceptions.TestSkipError(details)
-        except exceptions.TestDecoratorSkip as details:
-            stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
-            raise exceptions.TestSkipError(details)
+            raise exceptions.TestSkip(details)
         except exceptions.TestCancel as details:
             cancel_test = details
         except:  # Old-style exceptions are not inherited from Exception()
@@ -590,9 +586,9 @@ class Test(unittest.TestCase):
                                 'must fix your test. Original skip exception: '
                                 '%s' % details)
             raise exceptions.TestError(skip_illegal_msg)
-        except exceptions.TestDecoratorSkip as details:
+        except exceptions.TestSkip as details:
             stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
-            raise exceptions.TestSkipError(details)
+            raise
         except exceptions.TestCancel as details:
             stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
             raise
@@ -617,7 +613,7 @@ class Test(unittest.TestCase):
                                     'you must fix your test. Original skip '
                                     'exception: %s' % details)
                 raise exceptions.TestError(skip_illegal_msg)
-            except exceptions.TestDecoratorSkip as details:
+            except exceptions.TestSkip as details:
                 stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
                 skip_illegal_msg = ('Using skip decorators in tearDown() '
                                     'is not allowed in '
@@ -961,14 +957,13 @@ class NotATest(Test):
         raise exceptions.NotATestError(e_msg)
 
 
-class SkipTest(Test):
+class MockingTest(Test):
 
     """
-    Class intended as generic substitute for avocado tests which fails during
-    setUp phase using "self._skip_reason" message.
+    Class intended as generic substitute for avocado tests which will
+    not be executed for some reason. This class is expected to be
+    overridden by specific reason-oriented sub-classes.
     """
-
-    _skip_reason = "Generic skip test reason"
 
     def __init__(self, *args, **kwargs):
         """
@@ -983,19 +978,15 @@ class SkipTest(Test):
                 super_kwargs[arg] = kwargs[arg]
             elif args:
                 super_kwargs[arg] = args.pop()
-        # The methodName might not exist in SkipTest, make sure it's self.test
+        # The methodName might not exist, make sure it's self.test
         super_kwargs["methodName"] = "test"
-        super(SkipTest, self).__init__(**super_kwargs)
-
-    def setUp(self):
-        raise exceptions.TestSkipError(self._skip_reason)
+        super(MockingTest, self).__init__(**super_kwargs)
 
     def test(self):
-        """ Should not be executed """
-        raise RuntimeError("This should never be executed!")
+        pass
 
 
-class TimeOutSkipTest(SkipTest):
+class TimeOutSkipTest(MockingTest):
 
     """
     Skip test due job timeout.
@@ -1004,28 +995,25 @@ class TimeOutSkipTest(SkipTest):
     It will never have a chance to execute.
     """
 
-    _skip_reason = "Test skipped due a job timeout!"
+    @skip('Test skipped due a job timeout!')
+    def test(self):
+        pass
 
-    def setUp(self):
-        raise exceptions.TestTimeoutSkip(self._skip_reason)
 
-
-class DryRunTest(SkipTest):
+class DryRunTest(MockingTest):
 
     """
-    Fake test which logs itself and reports as SKIP
+    Fake test which logs itself and reports as CANCEL
     """
-
-    _skip_reason = "Test skipped due to --dry-run"
 
     def setUp(self):
         self.log.info("Test params:")
         for path, key, value in self.params.iteritems():
             self.log.info("%s:%s ==> %s", path, key, value)
-        super(DryRunTest, self).setUp()
+        self.cancel('Test cancelled due to --dry-run')
 
 
-class ReplaySkipTest(SkipTest):
+class ReplaySkipTest(MockingTest):
 
     """
     Skip test due to job replay filter.
@@ -1034,7 +1022,9 @@ class ReplaySkipTest(SkipTest):
     It will never have a chance to execute.
     """
 
-    _skip_reason = "Test skipped due to a job replay filter!"
+    @skip('Test skipped due to a job replay filter!')
+    def test(self):
+        pass
 
 
 class TestError(Test):

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -479,11 +479,11 @@ class RunnerOperationTest(unittest.TestCase):
         self.assertIn(tempfile.gettempdir(), debuglog)   # Use tmp dir, not default location
         self.assertEqual(result['job_id'], u'0' * 40)
         # Check if all tests were skipped
-        self.assertEqual(result['skip'], 4)
+        self.assertEqual(result['cancel'], 4)
         for i in xrange(4):
             test = result['tests'][i]
             self.assertEqual(test['fail_reason'],
-                             u'Test skipped due to --dry-run')
+                             u'Test cancelled due to --dry-run')
         # Check if all params are listed
         # The "/:bar ==> 2 is in the tree, but not in any leave so inaccessible
         # from test.

--- a/selftests/unit/test_test.py
+++ b/selftests/unit/test_test.py
@@ -191,46 +191,44 @@ class SimpleTestClassTest(unittest.TestCase):
         shutil.rmtree(self.tmpdir)
 
 
-class SkipTest(unittest.TestCase):
+class MockingTest(unittest.TestCase):
 
     def setUp(self):
         self.tests = []
 
     def test_init(self):
         # No params
-        self.tests.append(test.SkipTest())
-        self.assertRaises(exceptions.TestSkipError, self.tests[-1].setUp)
-        self.assertRaises(RuntimeError, self.tests[-1].test)
+        self.tests.append(test.MockingTest())
         # Positional
-        self.tests.append(test.SkipTest("test", test.TestName(1, "my_name"),
-                                        {}, None, "1",
-                                        None, None, "extra_param1",
-                                        "extra_param2"))
+        self.tests.append(test.MockingTest("test", test.TestName(1, "my_name"),
+                                           {}, None, "1",
+                                           None, None, "extra_param1",
+                                           "extra_param2"))
         self.assertEqual(self.tests[-1].name, "1-my_name")
         # Kwargs
-        self.tests.append(test.SkipTest(methodName="test",
-                                        name=test.TestName(1, "my_name2"),
-                                        params={}, base_logdir=None,
-                                        tag="a", job=None, runner_queue=None,
-                                        extra1="extra_param1",
-                                        extra2="extra_param2"))
+        self.tests.append(test.MockingTest(methodName="test",
+                                           name=test.TestName(1, "my_name2"),
+                                           params={}, base_logdir=None,
+                                           tag="a", job=None, runner_queue=None,
+                                           extra1="extra_param1",
+                                           extra2="extra_param2"))
         self.assertEqual(self.tests[-1].name, "1-my_name2")
         # both (theoretically impossible in python, but valid for nasty tests)
         # keyword args are used as they explicitly represent what they mean
-        self.tests.append(test.SkipTest("not used", "who cares", {}, None, "0",
-                                        None, None, "extra_param1",
-                                        "extra_param2",
-                                        methodName="test",
-                                        name=test.TestName(1, "my_name3"),
-                                        params={}, base_logdir=None,
-                                        tag="3", job=None, runner_queue=None,
-                                        extra1="extra_param3",
-                                        extra2="extra_param4"))
+        self.tests.append(test.MockingTest("not used", "who cares", {}, None, "0",
+                                           None, None, "extra_param1",
+                                           "extra_param2",
+                                           methodName="test",
+                                           name=test.TestName(1, "my_name3"),
+                                           params={}, base_logdir=None,
+                                           tag="3", job=None, runner_queue=None,
+                                           extra1="extra_param3",
+                                           extra2="extra_param4"))
         self.assertEqual(self.tests[-1].name, "1-my_name3")
         # combination
-        self.tests.append(test.SkipTest("test", test.TestName(1, "my_name4"),
-                                        tag="321",
-                                        other_param="Whatever"))
+        self.tests.append(test.MockingTest("test", test.TestName(1, "my_name4"),
+                                           tag="321",
+                                           other_param="Whatever"))
         self.assertEqual(self.tests[-1].name, "1-my_name4")
         # ugly combination (positional argument overrides kwargs, this only
         # happens when the substituted class reorders the positional arguments.
@@ -238,9 +236,9 @@ class SkipTest(unittest.TestCase):
         # ones.
         name = "positional_method_name_becomes_test_name"
         tag = "positional_base_logdir_becomes_tag"
-        self.tests.append(test.SkipTest(test.TestName(1, name), None, None, tag,
-                                        methodName="test",
-                                        other_param="Whatever"))
+        self.tests.append(test.MockingTest(test.TestName(1, name), None, None, tag,
+                                           methodName="test",
+                                           other_param="Whatever"))
         self.assertEqual(self.tests[-1].name, "1-" + name)
 
     def tearDown(self):


### PR DESCRIPTION
Due to the deprecation of the self.skip(), the availability of the skip
decorators and the new CANCEL status, some internal improvements are
important to keep our behaviour sane and our own code sound and clean.

- The test.SkipTest class was renamed to test.MockingTest to be even more
  generic, intending to be overridden by sub-classes that make the test
  to end both with SKIP or CANCEL status. To keep it generic,
  test.MockingTest class will not SKIP the test if used directly anymore.

- The test.TimeOutSkipTest and test.ReplaySkipTest classes now are using
  the skip decorators instead of raising an exception in setUp(), since
  'skipping' the test means 'don't execute anything', not even the
  setUp().

- The test.DryRunTest class, which is expected to log itself in setUp()
  and then abort the test execution, is now using self.cancel() (instead
  of raising a SKIP exception), being now compliant with the concept
  that a SKIP test cannot execute anything.

- The skip exceptions were simplified and the only missing piece is to
  remove the exceptions.TestSetupSkip, when the time to drop the
  self.skip() comes.

- Selftests were adjusted accordingly.

---

v1: #1962 

v2:
- Rename `FakeTest` to `MockingTest`.