### PR TITLE
html report: include params and split Test ID

### DIFF
--- a/optional_plugins/html/avocado_result_html/__init__.py
+++ b/optional_plugins/html/avocado_result_html/__init__.py
@@ -120,6 +120,10 @@ class ReportModel(object):
         for tst in self.result.tests:
             formatted = {}
             formatted['name'] = tst['name']
+            params = 'Params:\n'
+            for path, key, value in tst['params'].iteritems():
+                params += '  %s:%s => %s\n' % (path, key, value)
+            formatted['params'] = params
             formatted['status'] = tst['status']
             logdir = os.path.join(results_dir, 'test-results', tst['logdir'])
             formatted['logdir'] = os.path.relpath(logdir, self.html_output_dir)

--- a/optional_plugins/html/avocado_result_html/__init__.py
+++ b/optional_plugins/html/avocado_result_html/__init__.py
@@ -119,11 +119,13 @@ class ReportModel(object):
         results_dir = self.results_dir(False)
         for tst in self.result.tests:
             formatted = {}
-            formatted['name'] = tst['name']
+            formatted['uid'] = tst['name'].uid
+            formatted['name'] = tst['name'].name
             params = 'Params:\n'
             for path, key, value in tst['params'].iteritems():
                 params += '  %s:%s => %s\n' % (path, key, value)
             formatted['params'] = params
+            formatted['variant'] = tst['name'].variant or ''
             formatted['status'] = tst['status']
             logdir = os.path.join(results_dir, 'test-results', tst['logdir'])
             formatted['logdir'] = os.path.relpath(logdir, self.html_output_dir)

--- a/optional_plugins/html/avocado_result_html/resources/templates/report.mustache
+++ b/optional_plugins/html/avocado_result_html/resources/templates/report.mustache
@@ -58,7 +58,9 @@
             <table id="results" class="display" cellspacing="0" width="100%"><thead>
             <tr>
                 <th>Start Time</th>
-                <th>Test ID</th>
+                <th>UID</th>
+                <th>Test Name</th>
+                <th>Variant</th>
                 <th>Status</th>
                 <th>Time (sec)</th>
                 <th>Info</th>
@@ -68,7 +70,9 @@
             {{#tests}}
                 <tr class="{{row_class}}">
                     <td>{{time_start}}</td>
+                    <td>{{uid}}</td>
                     <td><a href="{{logdir}}" title="{{params}}">{{name}}</a></td>
+                    <td>{{variant}}</td>
                     <td>{{status}}</td>
                     <td>{{time}}</td>
                     <td>{{& fail_reason}}</td>

--- a/optional_plugins/html/avocado_result_html/resources/templates/report.mustache
+++ b/optional_plugins/html/avocado_result_html/resources/templates/report.mustache
@@ -68,7 +68,7 @@
             {{#tests}}
                 <tr class="{{row_class}}">
                     <td>{{time_start}}</td>
-                    <td><a href="{{logdir}}">{{name}}</a></td>
+                    <td><a href="{{logdir}}" title="{{params}}">{{name}}</a></td>
                     <td>{{status}}</td>
                     <td>{{time}}</td>
                     <td>{{& fail_reason}}</td>


### PR DESCRIPTION
- Include `Params` as a test name tooltip.
- Split Test ID in UID, Test Name and Variant, so users can order by any of them individually.