### PR TITLE
selftests: remove python shebangs

### DIFF
--- a/selftests/functional/test_multiplex.py
+++ b/selftests/functional/test_multiplex.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import os
 import tempfile
 import shutil

--- a/selftests/functional/test_plugin_diff.py
+++ b/selftests/functional/test_plugin_diff.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import glob
 import os
 import tempfile

--- a/selftests/functional/test_replay_basic.py
+++ b/selftests/functional/test_replay_basic.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import glob
 import os
 import tempfile

--- a/selftests/functional/test_replay_external_runner.py
+++ b/selftests/functional/test_replay_external_runner.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import glob
 import os
 import tempfile

--- a/selftests/functional/test_replay_failfast.py
+++ b/selftests/functional/test_replay_failfast.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import glob
 import os
 import tempfile

--- a/selftests/functional/test_teststmpdir.py
+++ b/selftests/functional/test_teststmpdir.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import os
 import tempfile
 import shutil

--- a/selftests/unit/test_remote.py
+++ b/selftests/unit/test_remote.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import logging
 import os
 import unittest

--- a/selftests/unit/test_utils_stacktrace.py
+++ b/selftests/unit/test_utils_stacktrace.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or

--- a/selftests/unit/test_vm.py
+++ b/selftests/unit/test_vm.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import unittest
 
 from flexmock import flexmock, flexmock_teardown


### PR DESCRIPTION
Previous commit d5fd51c attempted to remove all shebangs, as a result
of 143b574 that remove the executable bit of all tests.

There are still a few left, so this let's clean them up.

Signed-off-by: Cleber Rosa <crosa@redhat.com>