### PR TITLE
Support tags in test methods

### DIFF
--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -1356,6 +1356,40 @@ parameter, no test will be included::
   $ avocado list perf.py --filter-by-tags=disk,slow,superuser,safe | wc -l
   0
 
+Test tags can be applied to test classes and to test methods. Tags are
+evaluated per method, meaning that the class tags will be inherited by
+all methods, being merged with method local tags. Example::
+
+    from avocado import Test
+
+    class MyClass(Test):
+        """
+        :avocado: tags=furious
+        """
+
+        def test1(self):
+            """
+            :avocado: tags=fast
+            """
+            pass
+
+        def test2(self):
+            """
+            :avocado: tags=slow
+            """
+            pass
+
+If you use the tag ``furious``, all tests will be included::
+
+    $ avocado list furious_tests.py --filter-by-tags=furious
+    INSTRUMENTED test_tags.py:MyClass.test1
+    INSTRUMENTED test_tags.py:MyClass.test2
+
+But using ``fast`` and ``furious`` will include only ``test1``::
+
+    $ avocado list furious_tests.py --filter-by-tags=fast,furious
+    INSTRUMENTED test_tags.py:MyClass.test1
+
 Multiple `--filter-by-tags`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -61,12 +61,18 @@ class DisabledTest(Test):
 
 class FastTest(Test):
     '''
-    :avocado: tags=fast,net
+    :avocado: tags=fast
     '''
     def test_fast(self):
+        '''
+        :avocado: tags=net
+        '''
         pass
 
     def test_fast_other(self):
+        '''
+        :avocado: tags=net
+        '''
         pass
 
 class SlowTest(Test):


### PR DESCRIPTION
- Refactor `loader._find_avocado_tests()` to reduce code repetition.
- Add support for tags in test methods:
  - Tags are now related to the method and not to the class.
  - Methods will inherit the tags from the class.