### PR TITLE
mux: show total number of variants

### DIFF
--- a/avocado/core/mux.py
+++ b/avocado/core/mux.py
@@ -219,7 +219,7 @@ class MuxPlugin(object):
         if variants:
             # variants == 0 means disable, but in plugin it's brief
             contents = variants - 1
-            out.append("Multiplex variants:")
+            out.append("Multiplex variants (%s):" % len(self))
             for variant in self:
                 if not self.debug:
                     paths = ', '.join([x.path for x in variant["variant"]])


### PR DESCRIPTION
Now that the variant IDs are not a sequential number, we need this extra
information so users can easily know how many variants were generated.

Reference: https://trello.com/c/N7pB9E4O
Signed-off-by: Amador Pahim <apahim@redhat.com>