### PR TITLE
variants: Introduce "avocado variants" command [v2]

### DIFF
--- a/avocado/plugins/multiplex.py
+++ b/avocado/plugins/multiplex.py
@@ -13,107 +13,22 @@
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
 import logging
-import sys
 
-from avocado.core import exit_codes
-from avocado.core.plugin_interfaces import CLICmd
-from avocado.core.settings import settings
+from .variants import Variants
 
 
-_VERBOSITY_LEVELS = {"none": 0, "brief": 1, "normal": 2, "verbose": 3,
-                     "full": 4, "max": 99}
-
-
-def map_verbosity_level(level):
-    if level.isdigit():
-        return int(level)
-    level = level.lower()
-    if level in _VERBOSITY_LEVELS:
-        return _VERBOSITY_LEVELS[level]
-    else:
-        raise ValueError
-
-
-class Multiplex(CLICmd):
+class Multiplex(Variants):
 
     """
-    Implements the avocado 'multiplex' subcommand
+    DEPRECATED version of the "avocado multiplex" command which is replaced
+    by "avocado variants" one.
     """
 
-    name = 'multiplex'
-    description = "Tool to analyze and visualize test variants and params"
-
-    def __init__(self, *args, **kwargs):
-        super(Multiplex, self).__init__(*args, **kwargs)
-
-    def configure(self, parser):
-        parser = super(Multiplex, self).configure(parser)
-        verbosity_levels = ("(positive integer - 0, 1, ... - or %s)"
-                            % ", ".join(sorted(_VERBOSITY_LEVELS,
-                                        key=lambda _: _VERBOSITY_LEVELS[_])))
-        parser.add_argument("--summary", type=map_verbosity_level,
-                            help="Verbosity of the variants summary. " +
-                            verbosity_levels)
-        parser.add_argument("--variants", type=map_verbosity_level,
-                            help="Verbosity of the list of variants. " +
-                            verbosity_levels, default=1)
-        parser.add_argument('--system-wide', action='store_false',
-                            default=True, dest="variants-skip-defaults",
-                            help="Combine the files with the default "
-                            "tree.")
-        parser.add_argument('-c', '--contents', action='store_true',
-                            default=False, help="[obsoleted by --variants] "
-                            "Shows the node content (variables)")
-        env_parser = parser.add_argument_group("environment view options")
-        env_parser.add_argument('-d', '--debug', action='store_true',
-                                dest="mux_debug", default=False,
-                                help="Debug the multiplex tree.")
-        tree_parser = parser.add_argument_group("tree view options")
-        tree_parser.add_argument('-t', '--tree', action='store_true',
-                                 default=False, help='[obsoleted by --summary]'
-                                 ' Shows the multiplex tree structure')
-        tree_parser.add_argument('-i', '--inherit', action="store_true",
-                                 help="[obsoleted by --summary] Show the "
-                                 "inherited values")
+    name = "multiplex"
 
     def run(self, args):
         log = logging.getLogger("avocado.app")
-        err = None
-        if args.tree and args.mux_debug:
-            err = "Option --tree is incompatible with --debug."
-        elif not args.tree and args.inherit:
-            err = "Option --inherit can be only used with --tree"
-        if err:
-            log.error(err)
-            sys.exit(exit_codes.AVOCADO_FAIL)
-        varianter = args.avocado_variants
-        try:
-            varianter.parse(args)
-        except (IOError, ValueError) as details:
-            log.error("Unable to parse varianter: %s", details)
-            sys.exit(exit_codes.AVOCADO_FAIL)
-        use_utf8 = settings.get_value("runner.output", "utf8",
-                                      key_type=bool, default=None)
-        summary = args.summary or 0
-        variants = args.variants or 0
-
-        # Parse obsolete options (unsafe to combine them with new args)
-        if args.tree:
-            variants = 0
-            summary += 1
-            if args.contents:
-                summary += 1
-            if args.inherit:
-                summary += 2
-        else:
-            if args.contents:
-                variants += 2
-
-        # Produce the output
-        lines = args.avocado_variants.to_str(summary=summary,
-                                             variants=variants,
-                                             use_utf8=use_utf8)
-        for line in lines.splitlines():
-            log.debug(line)
-
-        sys.exit(exit_codes.AVOCADO_ALL_OK)
+        log.warning("The 'avocado multiplex' command is deprecated by the "
+                    "'avocado variants' one. Please start using that one "
+                    "instead as this will be removed in Avocado 52.0.")
+        super(Multiplex, self).run(args)

--- a/avocado/plugins/variants.py
+++ b/avocado/plugins/variants.py
@@ -1,0 +1,121 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2013-2014,2016
+# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+# Author: Lukas Doktor <ldoktor@redhat.com>
+
+import logging
+import sys
+
+from avocado.core import exit_codes
+from avocado.core.plugin_interfaces import CLICmd
+from avocado.core.settings import settings
+
+
+_VERBOSITY_LEVELS = {"none": 0, "brief": 1, "normal": 2, "verbose": 3,
+                     "full": 4, "max": 99}
+
+
+def map_verbosity_level(level):
+    if level.isdigit():
+        return int(level)
+    level = level.lower()
+    if level in _VERBOSITY_LEVELS:
+        return _VERBOSITY_LEVELS[level]
+    else:
+        raise ValueError
+
+
+class Variants(CLICmd):
+
+    """
+    Implements "variants" command to visualize/debug test variants and params
+    """
+
+    name = 'variants'
+    description = "Tool to analyze and visualize test variants and params"
+
+    def __init__(self, *args, **kwargs):
+        super(Variants, self).__init__(*args, **kwargs)
+
+    def configure(self, parser):
+        parser = super(Variants, self).configure(parser)
+        verbosity_levels = ("(positive integer - 0, 1, ... - or %s)"
+                            % ", ".join(sorted(_VERBOSITY_LEVELS,
+                                        key=lambda _: _VERBOSITY_LEVELS[_])))
+        parser.add_argument("--summary", type=map_verbosity_level,
+                            help="Verbosity of the variants summary. " +
+                            verbosity_levels)
+        parser.add_argument("--variants", type=map_verbosity_level,
+                            help="Verbosity of the list of variants. " +
+                            verbosity_levels, default=1)
+        parser.add_argument('--system-wide', action='store_false',
+                            default=True, dest="variants-skip-defaults",
+                            help="Combine the files with the default "
+                            "tree.")
+        parser.add_argument('-c', '--contents', action='store_true',
+                            default=False, help="[obsoleted by --variants] "
+                            "Shows the node content (variables)")
+        env_parser = parser.add_argument_group("environment view options")
+        env_parser.add_argument('-d', '--debug', action='store_true',
+                                dest="mux_debug", default=False,
+                                help="Use debug implementation to gather more"
+                                " information.")
+        tree_parser = parser.add_argument_group("tree view options")
+        tree_parser.add_argument('-t', '--tree', action='store_true',
+                                 default=False, help='[obsoleted by --summary]'
+                                 ' Shows the multiplex tree structure')
+        tree_parser.add_argument('-i', '--inherit', action="store_true",
+                                 help="[obsoleted by --summary] Show the "
+                                 "inherited values")
+
+    def run(self, args):
+        log = logging.getLogger("avocado.app")
+        err = None
+        if args.tree and args.mux_debug:
+            err = "Option --tree is incompatible with --debug."
+        elif not args.tree and args.inherit:
+            err = "Option --inherit can be only used with --tree"
+        if err:
+            log.error(err)
+            sys.exit(exit_codes.AVOCADO_FAIL)
+        varianter = args.avocado_variants
+        try:
+            varianter.parse(args)
+        except (IOError, ValueError) as details:
+            log.error("Unable to parse varianter: %s", details)
+            sys.exit(exit_codes.AVOCADO_FAIL)
+        use_utf8 = settings.get_value("runner.output", "utf8",
+                                      key_type=bool, default=None)
+        summary = args.summary or 0
+        variants = args.variants or 0
+
+        # Parse obsolete options (unsafe to combine them with new args)
+        if args.tree:
+            variants = 0
+            summary += 1
+            if args.contents:
+                summary += 1
+            if args.inherit:
+                summary += 2
+        else:
+            if args.contents:
+                variants += 2
+
+        # Produce the output
+        lines = args.avocado_variants.to_str(summary=summary,
+                                             variants=variants,
+                                             use_utf8=use_utf8)
+        for line in lines.splitlines():
+            log.debug(line)
+
+        sys.exit(exit_codes.AVOCADO_ALL_OK)

--- a/avocado/plugins/yaml_to_mux.py
+++ b/avocado/plugins/yaml_to_mux.py
@@ -283,7 +283,7 @@ class YamlToMuxCLI(CLI):
         """
         if not MULTIPLEX_CAPABLE:
             return
-        for name in ("run", "multiplex"):
+        for name in ("run", "multiplex", "variants"):
             subparser = parser.subcommands.choices.get(name, None)
             if subparser is None:
                 continue

--- a/docs/source/Configuration.rst
+++ b/docs/source/Configuration.rst
@@ -88,10 +88,10 @@ example), we established the following order of precedence for variables (from l
 * global config file
 * local (user) config file
 * command line switch
-* multiplexer
+* test parameters
 
-So the least important value comes from the library or test code default, going all the way up to the multiplexing
-system.
+So the least important value comes from the library or test code default,
+going all the way up to the test parameters system.
 
 Config plugin
 =============

--- a/docs/source/ReferenceGuide.rst
+++ b/docs/source/ReferenceGuide.rst
@@ -70,21 +70,19 @@ more than one test.
 Variant IDs
 -----------
 
-The multiplexer component creates different sets of variables
+The varianter component creates different sets of variables
 (known as "variants"), to allow tests to be run individually in
 each of them.
 
 A Variant ID is an arbitrary and abstract string created by the
-multiplexer to identify each variant. It should be unique per
-variant inside a set. In other words, the multiplexer generates a
-set of variants, identified by unique IDs.
+varianter plugin to identify each variant. It should be unique per
+variant inside a set. In other words, the varianter plugin generates
+a set of variants, identified by unique IDs.
 
-A simpler implementation of the multiplexer uses serial integers
+A simpler implementation of the varianter uses serial integers
 as Variant IDs. A more sophisticated implementation could
 generate Variant IDs with more semantic, potentially representing
 their contents.
-
-.. note:: The multiplexer supports serialized variant IDs only
 
 
 Test ID

--- a/docs/source/Replay.rst
+++ b/docs/source/Replay.rst
@@ -34,9 +34,9 @@ Now we can replay the job by running::
      TESTS TIME : 0.01 s
      JOB HTML   : $HOME/avocado/job-results/job-2016-01-11T16.18-55a0d10/html/results.html
 
-The replay feature will retrieve the original test references, the multiplex
-tree and the configuration. Let's see another example, now using
-multiplex file::
+The replay feature will retrieve the original test references, the variants
+and the configuration. Let's see another example, now using
+mux yaml file::
 
      $ avocado run /bin/true /bin/false --mux-yaml mux-environment.yaml
      JOB ID     : bd6aa3b852d4290637b5e771b371537541043d1d
@@ -94,7 +94,7 @@ multiplex file::
      JOB HTML   : $HOME/avocado/job-results/job-2016-01-11T21.56-bd6aa3b/html/results.html
 
 We can replay the job as is, using ``$ avocado run --replay latest``,
-or replay the job ignoring the multiplex file, as below::
+or replay the job ignoring the variants, as below::
 
      $ avocado run --replay bd6aa3b --replay-ignore variants
      Ignoring variants from source job with --replay-ignore.

--- a/docs/source/Replay.rst
+++ b/docs/source/Replay.rst
@@ -96,8 +96,8 @@ multiplex file::
 We can replay the job as is, using ``$ avocado run --replay latest``,
 or replay the job ignoring the multiplex file, as below::
 
-     $ avocado run --replay bd6aa3b --replay-ignore mux
-     Ignoring multiplex from source job with --replay-ignore.
+     $ avocado run --replay bd6aa3b --replay-ignore variants
+     Ignoring variants from source job with --replay-ignore.
      JOB ID     : d5a46186ee0fb4645e3f7758814003d76c980bf9
      SRC JOB ID : bd6aa3b852d4290637b5e771b371537541043d1d
      JOB LOG    : $HOME/avocado/job-results/job-2016-01-11T22.01-d5a4618/job.log

--- a/docs/source/TestParameters.rst
+++ b/docs/source/TestParameters.rst
@@ -510,7 +510,7 @@ is disabled, so the value of node name is always as written in the yaml
 file (unlike values, where `yes` converts to `True` and such).
 
 Nodes are organized in parent-child relationship and together they create
-a tree. To view this structure use ``avocado multiplex --tree -m <file>``::
+a tree. To view this structure use ``avocado variants --tree -m <file>``::
 
  ┗━━ run
       ┣━━ hw
@@ -933,7 +933,7 @@ Let's take a second look at the first example::
 After filters are applied (simply removes non-matching variants), leaves
 are gathered and all variants are generated::
 
-    $ avocado multiplex -m examples/mux-environment.yaml
+    $ avocado variants -m examples/mux-environment.yaml
     Variants generated:
     Variant 1:    /hw/cpu/intel, /hw/disk/scsi, /distro/fedora, /env/debug
     Variant 2:    /hw/cpu/intel, /hw/disk/scsi, /distro/fedora, /env/prod

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -197,7 +197,7 @@ the details.
 Let's say your test receives following params (you'll learn how to execute
 them in the following section)::
 
-    $ avocado multiplex -m examples/tests/sleeptenmin.py.data/sleeptenmin.yaml --variants 2
+    $ avocado variants -m examples/tests/sleeptenmin.py.data/sleeptenmin.yaml --variants 2
     ...
     Variant 1:    /run/sleeptenmin/builtin, /run/variants/one_cycle
         /run/sleeptenmin/builtin:sleep_method => builtin
@@ -259,7 +259,7 @@ an example:
 
 Which produces following structure and parameters::
 
-      $ avocado multiplex -m examples/tests/sleeptenmin.py.data/sleeptenmin.yaml --summary 2 --variants 2
+      $ avocado variants -m examples/tests/sleeptenmin.py.data/sleeptenmin.yaml --summary 2 --variants 2
       Multiplex tree representation:
        ┗━━ run
             ┣━━ sleeptenmin

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -887,7 +887,7 @@ Setting a Test Timeout
 Sometimes your test suite/test might get stuck forever, and this might
 impact your test grid. You can account for that possibility and set up a
 ``timeout`` parameter for your test. The test timeout can be set through
-the multiplex, as shown below.
+the test parameters, as shown below.
 
 ::
 
@@ -946,9 +946,9 @@ the multiplex, as shown below.
 	2016-11-02 11:13:04,440 test             L0592 ERROR| ERROR 1-sleeptest.py:SleepTest.test -> TestError: SystemExit('Test interrupted by SIGTERM',): Test interrupted by SIGTERM
 
 
-If you pass that multiplex file to the runner multiplexer, this will register
-a timeout of 3 seconds before Avocado ends the test forcefully by sending a
-:class:`signal.SIGTERM` to the test, making it raise a
+The ``yaml`` file defines a test parameter ``timeout`` which overrides
+the default test timeout before the runner ends the test forcefully by
+sending a class:`signal.SIGTERM` to the test, making it raise a
 :class:`avocado.core.exceptions.TestTimeoutError`.
 
 
@@ -1480,7 +1480,7 @@ the Avocado supported use cases.
 Environment Variables for Simple Tests
 ======================================
 
-Avocado exports Avocado variables and multiplexed variables as BASH environment
+Avocado exports Avocado variables and test parameters as BASH environment
 to the running test. Those variables are interesting to simple tests, because
 they can not make use of Avocado API directly with Python, like the native
 tests can do and also they can modify the test parameters.

--- a/selftests/functional/test_multiplex.py
+++ b/selftests/functional/test_multiplex.py
@@ -45,19 +45,19 @@ class MultiplexTests(unittest.TestCase):
         return result
 
     def test_mplex_plugin(self):
-        cmd_line = ('%s multiplex -m examples/tests/sleeptest.py.data/'
+        cmd_line = ('%s variants -m examples/tests/sleeptest.py.data/'
                     'sleeptest.yaml' % AVOCADO)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.run_and_check(cmd_line, expected_rc)
 
     def test_mplex_plugin_nonexistent(self):
-        cmd_line = '%s multiplex -m nonexist' % AVOCADO
+        cmd_line = '%s variants -m nonexist' % AVOCADO
         expected_rc = exit_codes.AVOCADO_FAIL
         result = self.run_and_check(cmd_line, expected_rc)
         self.assertIn('No such file or directory', result.stderr)
 
     def test_mplex_debug(self):
-        cmd_line = ('%s multiplex -c -d -m '
+        cmd_line = ('%s variants -c -d -m '
                     '/:examples/mux-selftest.yaml '
                     '/:examples/mux-environment.yaml '
                     '/:examples/mux-selftest.yaml '

--- a/setup.py
+++ b/setup.py
@@ -144,6 +144,7 @@ if __name__ == '__main__':
                   'distro = avocado.plugins.distro:Distro',
                   'exec-path = avocado.plugins.exec_path:ExecPath',
                   'multiplex = avocado.plugins.multiplex:Multiplex',
+                  'variants = avocado.plugins.variants:Variants',
                   'list = avocado.plugins.list:List',
                   'run = avocado.plugins.run:Run',
                   'sysinfo = avocado.plugins.sysinfo:SysInfo',


### PR DESCRIPTION
The "avocado multiplex" command is misleading as multiplexation is only
the generic concept used by one of our varianter plugins
implementations. Let's change the command name to "avocado variants"
which better reflects what is it used for.

As people depend on "avocado multiplex" command let's keep both of them
for now to give people time till Avocado 52.0 to migrate.

v1: https://github.com/avocado-framework/avocado/pull/1936

Changes:

```yaml
v2: Fix `avocado multiplex` mentions in documentation
v2: New commit to fix the `multiplex` word usage in documentation
v2: Fix the deprecation message
```

Not changed:

```yaml
v2: VARIANTS_FILENAME = 'multiplex' # it would break backward compatibility, we should do it once we implement a proper serialization
```