### PR TITLE
Distro Detection: use "rhel" for Red Hat Enterprise Linux

### DIFF
--- a/avocado/utils/distro.py
+++ b/avocado/utils/distro.py
@@ -304,7 +304,7 @@ class RedHatProbe(Probe):
     CHECK_FILE_CONTAINS = 'Red Hat'
     CHECK_FILE_DISTRO_NAME = 'redhat'
     CHECK_VERSION_REGEX = re.compile(
-        r'Red Hat Enterprise Linux Server release (\d{1,2})\.(\d{1,2}).*')
+        r'Red Hat Enterprise Linux \w+ release (\d{1,2})\.(\d{1,2}).*')
 
 
 class CentosProbe(RedHatProbe):

--- a/avocado/utils/distro.py
+++ b/avocado/utils/distro.py
@@ -302,7 +302,7 @@ class RedHatProbe(Probe):
     """
     CHECK_FILE = '/etc/redhat-release'
     CHECK_FILE_CONTAINS = 'Red Hat Enterprise Linux'
-    CHECK_FILE_DISTRO_NAME = 'redhat'
+    CHECK_FILE_DISTRO_NAME = 'rhel'
     CHECK_VERSION_REGEX = re.compile(
         r'Red Hat Enterprise Linux \w+ release (\d{1,2})\.(\d{1,2}).*')
 

--- a/avocado/utils/distro.py
+++ b/avocado/utils/distro.py
@@ -301,7 +301,7 @@ class RedHatProbe(Probe):
     Probe with version checks for Red Hat Enterprise Linux systems
     """
     CHECK_FILE = '/etc/redhat-release'
-    CHECK_FILE_CONTAINS = 'Red Hat'
+    CHECK_FILE_CONTAINS = 'Red Hat Enterprise Linux'
     CHECK_FILE_DISTRO_NAME = 'redhat'
     CHECK_VERSION_REGEX = re.compile(
         r'Red Hat Enterprise Linux \w+ release (\d{1,2})\.(\d{1,2}).*')

--- a/avocado/utils/software_manager.py
+++ b/avocado/utils/software_manager.py
@@ -102,10 +102,10 @@ class SystemInspector(object):
                     self.distro in ('debian', 'ubuntu')):
                 pm_supported = 'apt-get'
             elif ('dnf' in list_supported and
-                  self.distro in ('redhat', 'fedora')):
+                  self.distro in ('rhel', 'fedora')):
                 pm_supported = 'dnf'
             elif ('yum' in list_supported and
-                  self.distro in ('redhat', 'fedora')):
+                  self.distro in ('rhel', 'fedora')):
                 pm_supported = 'yum'
             elif ('zypper' in list_supported and
                   self.distro == 'SuSE'):


### PR DESCRIPTION
This is essentially a name change for the Red Hat Enteprise Linux probe, with a few fixes.  This is the foundation of a proposal for Avocado-VT that will create a `host-os.cfg` at `avocado vt-bootstrap` execution time.

This change may cause disruption for tests that rely on the `redhat` name.  A separate PR for avocado-mist-tests, our largest source of tests, accompany this one:

https://github.com/avocado-framework-tests/avocado-misc-tests/pull/468