### PR TITLE
 Support tags in test methods [v2]

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -32,7 +32,6 @@ from . import test
 from . import safeloader
 from ..utils import path
 from ..utils import stacktrace
-from ..utils import data_structures
 from .settings import settings
 
 #: Show default tests (for execution)
@@ -629,12 +628,12 @@ class FileLoader(TestLoader):
                 if safeloader.check_docstring_directive(docstring, 'disable'):
                     continue
 
-                tags = safeloader.get_docstring_directives_tags(docstring)
+                cl_tags = safeloader.get_docstring_directives_tags(docstring)
 
                 if safeloader.check_docstring_directive(docstring, 'enable'):
-                    methods = self._get_methods(statement.body)
-                    result[statement.name] = {'methods': methods,
-                                              'tags': tags}
+                    info = self._get_methods_info(statement.body,
+                                                  cl_tags)
+                    result[statement.name] = info
                     continue
 
                 if test_import:
@@ -642,9 +641,9 @@ class FileLoader(TestLoader):
                                 if hasattr(base, 'id')]
                     # Looking for a 'class FooTest(Test):'
                     if test_import_name in base_ids:
-                        methods = self._get_methods(statement.body)
-                        result[statement.name] = {'methods': methods,
-                                                  'tags': tags}
+                        info = self._get_methods_info(statement.body,
+                                                      cl_tags)
+                        result[statement.name] = info
                         continue
 
                 # Looking for a 'class FooTest(avocado.Test):'
@@ -653,19 +652,27 @@ class FileLoader(TestLoader):
                         module = base.value.id
                         klass = base.attr
                         if module == mod_import_name and klass == 'Test':
-                            methods = self._get_methods(statement.body)
-                            result[statement.name] = {'methods': methods,
-                                                      'tags': tags}
+                            info = self._get_methods_info(statement.body,
+                                                          cl_tags)
+                            result[statement.name] = info
 
         return result
 
     @staticmethod
-    def _get_methods(statement_body):
-        methods = [st.name for st in statement_body if
-                   isinstance(st, ast.FunctionDef) and
-                   st.name.startswith('test')]
-        methods = data_structures.ordered_list_unique(methods)
-        return methods
+    def _get_methods_info(statement_body, class_tags):
+        methods_info = []
+        for st in statement_body:
+            if (isinstance(st, ast.FunctionDef) and
+                    st.name.startswith('test')):
+                docstring = ast.get_docstring(st)
+                mt_tags = safeloader.get_docstring_directives_tags(docstring)
+                mt_tags.update(class_tags)
+
+                methods = [method for method, tags in methods_info]
+                if st.name not in methods:
+                    methods_info.append((st.name, mt_tags))
+
+        return methods_info
 
     def _make_avocado_tests(self, test_path, make_broken, subtests_filter,
                             test_name=None):
@@ -677,7 +684,7 @@ class FileLoader(TestLoader):
                 test_factories = []
                 for test_class, info in tests.items():
                     if isinstance(test_class, str):
-                        for test_method in info['methods']:
+                        for test_method, tags in info:
                             name = test_name + \
                                 ':%s.%s' % (test_class, test_method)
                             if (subtests_filter and
@@ -686,7 +693,7 @@ class FileLoader(TestLoader):
                             tst = (test_class, {'name': name,
                                                 'modulePath': test_path,
                                                 'methodName': test_method,
-                                                'tags': info['tags']})
+                                                'tags': tags})
                             test_factories.append(tst)
                 return test_factories
             else:

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -1356,6 +1356,40 @@ parameter, no test will be included::
   $ avocado list perf.py --filter-by-tags=disk,slow,superuser,safe | wc -l
   0
 
+Test tags can be applied to test classes and to test methods. Tags are
+evaluated per method, meaning that the class tags will be inherited by
+all methods, being merged with method local tags. Example::
+
+    from avocado import Test
+
+    class MyClass(Test):
+        """
+        :avocado: tags=furious
+        """
+
+        def test1(self):
+            """
+            :avocado: tags=fast
+            """
+            pass
+
+        def test2(self):
+            """
+            :avocado: tags=slow
+            """
+            pass
+
+If you use the tag ``furious``, all tests will be included::
+
+    $ avocado list furious_tests.py --filter-by-tags=furious
+    INSTRUMENTED test_tags.py:MyClass.test1
+    INSTRUMENTED test_tags.py:MyClass.test2
+
+But using ``fast`` and ``furious`` will include only ``test1``::
+
+    $ avocado list furious_tests.py --filter-by-tags=fast,furious
+    INSTRUMENTED test_tags.py:MyClass.test1
+
 Multiple `--filter-by-tags`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -61,12 +61,18 @@ class DisabledTest(Test):
 
 class FastTest(Test):
     '''
-    :avocado: tags=fast,net
+    :avocado: tags=fast
     '''
     def test_fast(self):
+        '''
+        :avocado: tags=net
+        '''
         pass
 
     def test_fast_other(self):
+        '''
+        :avocado: tags=net
+        '''
         pass
 
 class SlowTest(Test):
@@ -179,6 +185,26 @@ class Second(avocado.Test):
     def test_1(self):
         pass
 """
+
+KEEP_METHODS_ORDER = '''
+from avocado import Test
+
+class MyClass(Test):
+    def test2(self):
+        pass
+
+    def testA(self):
+        pass
+
+    def test1(self):
+        pass
+
+    def testZZZ(self):
+        pass
+
+    def test(self):
+        pass
+'''
 
 
 class LoaderTest(unittest.TestCase):
@@ -462,6 +488,17 @@ class LoaderTest(unittest.TestCase):
                                                ['-fast,-slow,-safe',
                                                 'does,not,exist'])
             self.assertEqual(len(filtered), 0)
+
+    def test_methods_order(self):
+        avocado_keep_methods_order = script.TemporaryScript(
+            'keepmethodsorder.py',
+            KEEP_METHODS_ORDER)
+        avocado_keep_methods_order.save()
+        expected_order = ['test2', 'testA', 'test1', 'testZZZ', 'test']
+        tests = self.loader._find_avocado_tests(avocado_keep_methods_order.path)
+        methods = [method[0] for method in tests['MyClass']]
+        self.assertEqual(expected_order, methods)
+        avocado_keep_methods_order.remove()
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir)


### PR DESCRIPTION
V1: #1972
- Refactor `loader._find_avocado_tests()` to reduce code repetition.
- Add support for tags in test methods:
  - Tags are now related to the method and not to the class.
  - Methods will inherit the tags from the class.

V2:
- Use an ordered structure to keep the methods in the order that they are discovered in.
- Include a selftest to make sure the order is maintained.