### PR TITLE
replay: Add support to resume interrupted/crashed job [v4] 

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -167,6 +167,8 @@ class Job(object):
         idfile = os.path.join(self.logdir, "id")
         with open(idfile, 'w') as id_file_obj:
             id_file_obj.write("%s\n" % self.unique_id)
+            id_file_obj.flush()
+            os.fsync(id_file_obj)
 
     def __start_job_logging(self):
         # Enable test logger

--- a/avocado/core/jobdata.py
+++ b/avocado/core/jobdata.py
@@ -53,22 +53,34 @@ def record(args, logdir, mux, references=None, cmdline=None):
     if references:
         with open(path_references, 'w') as references_file:
             references_file.write('%s' % references)
+            references_file.flush()
+            os.fsync(references_file)
         os.symlink(TEST_REFERENCES_FILENAME, path_references_legacy)
 
     with open(path_cfg, 'w') as config_file:
         settings.config.write(config_file)
+        config_file.flush()
+        os.fsync(config_file)
 
     with open(path_mux, 'w') as mux_file:
         pickle.dump(mux, mux_file, pickle.HIGHEST_PROTOCOL)
+        mux_file.flush()
+        os.fsync(mux_file)
 
     with open(path_pwd, 'w') as pwd_file:
         pwd_file.write('%s' % os.getcwd())
+        pwd_file.flush()
+        os.fsync(pwd_file)
 
     with open(path_args, 'w') as args_file:
         pickle.dump(args.__dict__, args_file, pickle.HIGHEST_PROTOCOL)
+        args_file.flush()
+        os.fsync(args_file)
 
     with open(path_cmdline, 'w') as cmdline_file:
         cmdline_file.write('%s' % cmdline)
+        cmdline_file.flush()
+        os.fsync(cmdline_file)
 
 
 def _retrieve(resultsdir, resource):

--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -16,6 +16,7 @@ import argparse
 import json
 import logging
 import os
+import re
 import sys
 
 from avocado.core import exit_codes
@@ -61,6 +62,8 @@ class Replay(CLI):
                                    help='Ignore variants (variants) and/or '
                                    'configuration (config) from the '
                                    'source job')
+        replay_parser.add_argument("--replay-resume", action="store_true",
+                                   help="Resume an interrupted job")
 
     def _valid_status(self, string):
         status_list = string.split(',')
@@ -90,6 +93,44 @@ class Replay(CLI):
         if config is not None:
             settings.process_config_path(config)
 
+    def _get_tests_from_tap(self, path):
+        if not os.path.exists(path):
+            return None
+        re_result = re.compile(r"(not )?ok (\d+) ([^#]*)(# (\w+).*)?")
+        re_no_tests = re.compile(r"1..(\d+)")
+        max_index = 0
+        no_tests = 0
+        _tests = {}
+        for line in open(path):
+            line = line.strip()
+            if line.startswith("#"):
+                continue
+            result = re_result.match(line)
+            if result:
+                if result.group(1) is None:
+                    res = result.group(5)
+                    if res is None:
+                        res = "PASS"
+                else:
+                    res = "ERROR"
+                index = int(result.group(2))
+                _tests[index] = {"status": res,
+                                 "test": result.group(3).rstrip()}
+                max_index = max(max_index, index)
+                continue
+            _no_tests = re_no_tests.match(line)
+            if _no_tests:
+                no_tests = int(_no_tests.group(1))
+                continue
+
+        if not (no_tests or max_index):
+            return None
+
+        # Now add _tests that were not executed
+        skipped_test = {"test": "UNKNOWN", "status": "INTERRUPTED"}
+        return [_tests[i] if i in _tests else skipped_test
+                for i in xrange(1, max(max_index, no_tests) + 1)]
+
     def _create_replay_map(self, resultsdir, replay_filter):
         """
         Creates a mapping to be used as filter for the replay. Given
@@ -98,14 +139,18 @@ class Replay(CLI):
         be replayed will have a correspondent None in the map.
         """
         json_results = os.path.join(resultsdir, "results.json")
-        if not os.path.exists(json_results):
-            return None
-
-        with open(json_results, 'r') as json_file:
-            results = json.loads(json_file.read())
-        tests = results["tests"]
-        for _ in xrange(results["total"] + 1 - len(tests)):
-            tests.append({"test": "UNKNOWN", "status": "INTERRUPTED"})
+        if os.path.exists(json_results):
+            with open(json_results, 'r') as json_file:
+                results = json.loads(json_file.read())
+                tests = results["tests"]
+                for _ in xrange(results["total"] + 1 - len(tests)):
+                    tests.append({"test": "UNKNOWN", "status": "INTERRUPTED"})
+        else:
+            # get partial results from tap
+            tests = self._get_tests_from_tap(os.path.join(resultsdir,
+                                                          "results.tap"))
+            if not tests:   # tests not available, ignore replay map
+                return None
 
         replay_map = []
         for test in tests:
@@ -217,6 +262,13 @@ class Replay(CLI):
                                 "ignore variants` to override them.")
                 setattr(args, "avocado_variants", variants)
 
+        # Extend "replay_test_status" of "INTERRUPTED" when --replay-resume
+        # supplied.
+        if args.replay_resume:
+            if not args.replay_teststatus:
+                args.replay_teststatus = ["INTERRUPTED"]
+            elif "INTERRUPTED" not in args.replay_teststatus:
+                args.replay_teststatus.append("INTERRUPTED")
         if args.replay_teststatus:
             replay_map = self._create_replay_map(resultsdir,
                                                  args.replay_teststatus)

--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -103,9 +103,12 @@ class Replay(CLI):
 
         with open(json_results, 'r') as json_file:
             results = json.loads(json_file.read())
+        tests = results["tests"]
+        for _ in xrange(results["total"] + 1 - len(tests)):
+            tests.append({"test": "UNKNOWN", "status": "INTERRUPTED"})
 
         replay_map = []
-        for test in results['tests']:
+        for test in tests:
             if test['status'] not in replay_filter:
                 replay_map.append(ReplaySkipTest)
             else:

--- a/avocado/plugins/tap.py
+++ b/avocado/plugins/tap.py
@@ -38,7 +38,10 @@ def file_log_factory(log_file):
             except TypeError as details:
                 raise TypeError("%s: msg='%s' args='%s'" %
                                 (details, msg, writeargs))
-        return log_file.write(msg + "\n")
+        ret = log_file.write(msg + "\n")
+        log_file.flush()
+        os.fsync(log_file)
+        return ret
     return writeln
 
 

--- a/docs/source/Replay.rst
+++ b/docs/source/Replay.rst
@@ -166,6 +166,12 @@ result, using the option ``--replay-test-status``. See the example below::
     TESTS TIME : 0.19 s
     JOB HTML   : $HOME/avocado/job-results/job-2016-01-12T00.38-2e1dc41/html/results.html
 
+Of which one special example is ``--replay-test-status INTERRUPTED``
+or simply ``--replay-resume``, which SKIPs the executed
+tests and only executes the ones which were CANCELED or not executed
+after a CANCELED test. This feature should work even on hard interruptions
+like system crash.
+
 When replaying jobs that were executed with the ``--failfast on`` option, you
 can disable the ``failfast`` option using ``--failfast off`` in the replay job.
 

--- a/selftests/unit/test_replay.py
+++ b/selftests/unit/test_replay.py
@@ -28,11 +28,48 @@ class Replay(unittest.TestCase):
                       '"PASS"}], "total": 4}')
         rep = replay.Replay()
         act = rep._create_replay_map(self.tmpdir, ["PASS"])
-        exp = [None, test.ReplaySkipTest, test.ReplaySkipTest, test.ReplaySkipTest, test.ReplaySkipTest]
+        exp = [None, test.ReplaySkipTest, test.ReplaySkipTest,
+               test.ReplaySkipTest, test.ReplaySkipTest]
         self.assertEqual(act, exp)
         act = rep._create_replay_map(self.tmpdir, ["INTERRUPTED"])
         exp = [test.ReplaySkipTest, None, None, None, None]
         self.assertEqual(act, exp)
+
+    def test_replay_map_after_crash(self):
+        """
+        Tests the fallback to TAP as the source of executed tests when
+        JSON was not generated
+        """
+        with open(os.path.join(self.tmpdir, "results.tap"), "w") as res:
+            res.write("\n# 1..10\nok 3 test3\nnot ok 2 test2\n1..5")
+        rep = replay.Replay()
+        act = rep._create_replay_map(self.tmpdir, ["PASS"])
+        exp = [test.ReplaySkipTest, test.ReplaySkipTest, None,
+               test.ReplaySkipTest, test.ReplaySkipTest]
+        self.assertEqual(act, exp)
+        act = rep._create_replay_map(self.tmpdir, ["INTERRUPTED"])
+        exp = [None, test.ReplaySkipTest, test.ReplaySkipTest, None, None]
+        self.assertEqual(act, exp)
+
+    def test_tap_parsing(self):
+        """
+        Check various ugly tap results
+        """
+        rep = replay.Replay()
+        res_path = os.path.join(self.tmpdir, "results.tap")
+        self.assertEqual(rep._get_tests_from_tap(res_path), None)
+        with open(res_path, "w") as res:
+            res.write("\n# 1..5\n")
+        self.assertEqual(rep._get_tests_from_tap(res_path), None)
+        with open(res_path, "w") as res:
+            res.write("\n1..5\n")
+        exp = [{"test": "UNKNOWN", "status": "INTERRUPTED"}] * 5
+        self.assertEqual(rep._get_tests_from_tap(res_path), exp)
+        with open(res_path, "w") as res:
+            res.write("ok 5 fdfafdsfa  # SKIP for no reason")
+        exp = ([{"test": "UNKNOWN", "status": "INTERRUPTED"}] * 4 +
+               [{"test": "fdfafdsfa", "status": "SKIP"}])
+        self.assertEqual(rep._get_tests_from_tap(res_path), exp)
 
 
 if __name__ == '__main__':

--- a/selftests/unit/test_replay.py
+++ b/selftests/unit/test_replay.py
@@ -1,0 +1,39 @@
+import os
+import shutil
+import tempfile
+import unittest
+
+from avocado.core import test
+from avocado.plugins import replay
+
+
+class Replay(unittest.TestCase):
+
+    """
+    avocado.plugins.Replay unittests
+    """
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+    def test_replay_map_interrupted_json(self):
+        """
+        Make sure unexecuted tests are appended
+        """
+        with open(os.path.join(self.tmpdir, "results.json"), "w") as res:
+            res.write('{"skip": 3, "tests": [{"test": "executed", "status":'
+                      '"PASS"}], "total": 4}')
+        rep = replay.Replay()
+        act = rep._create_replay_map(self.tmpdir, ["PASS"])
+        exp = [None, test.ReplaySkipTest, test.ReplaySkipTest, test.ReplaySkipTest, test.ReplaySkipTest]
+        self.assertEqual(act, exp)
+        act = rep._create_replay_map(self.tmpdir, ["INTERRUPTED"])
+        exp = [test.ReplaySkipTest, None, None, None, None]
+        self.assertEqual(act, exp)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR fixes the way we get info about not-executed-tests from "results.json" and then adds support to resume job by using `--replay-resume` argument. This is basically just a symlink to `--replay-test-status INTERRUPTED` and it can be also combined with other statuses. The only drawback could be when the "results.json" is not yet available (host crash, kill -9, ...) the "results.tap" is used and it does not support all test statuses and for the replay purpose it maps all failures to ERRORs.

v1: https://github.com/avocado-framework/avocado/pull/1942
v2: https://github.com/avocado-framework/avocado/pull/1958
v3: https://github.com/avocado-framework/avocado/pull/1976

Changes:
```yaml
v2: Add documentation
v2: Add commit to always sync basic job-related data on disk
v3: Remove shebang from unittest
v4: Fix a docstring of one selftest
v4: Fix the commit message of the first commit
```