### PR TITLE
output: Disable CANCEL color on unsupported terms

### DIFF
--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -103,6 +103,7 @@ class TermSupport(object):
         self.INTERRUPT = ''
         self.ERROR = ''
         self.WARN = ''
+        self.CANCEL = ''
         self.PARTIAL = ''
         self.ENDC = ''
         self.LOWLIGHT = ''


### PR DESCRIPTION
The recently added CANCEL color is not cleaned when we disable TERM
support.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>