### PR TITLE
Extended vendors_map dict for Power8

### DIFF
--- a/avocado/utils/cpu.py
+++ b/avocado/utils/cpu.py
@@ -78,7 +78,8 @@ def get_cpu_vendor_name():
     vendors_map = {
         'intel': ("GenuineIntel", ),
         'amd': ("AMD", ),
-        'power7': ("POWER7", )
+        'power7': ("POWER7", ),
+        'power8': ("POWER8", )
     }
 
     cpu_info = _get_cpu_info()


### PR DESCRIPTION
Added a new item for vendors_map dic to def get_cpu_vendor_name():

Signed-off-by: Venkat R B <vrbagal1@linux.vnet.ibm.com>