### PR TITLE
Remove skip from teststmpdir functional test

### DIFF
--- a/selftests/functional/test_teststmpdir.py
+++ b/selftests/functional/test_teststmpdir.py
@@ -57,8 +57,6 @@ class TestsTmpDirTests(unittest.TestCase):
                          "%d:\n%s" % (cmd_line, expected_rc, result))
         return result
 
-    @unittest.skipIf(os.environ.get("AVOCADO_CHECK_FULL") != "1",
-                     "Temporary skip because of errors on Travis-CI")
     @unittest.skipIf(test.COMMON_TMPDIR_NAME in os.environ,
                      "%s already set in os.environ"
                      % test.COMMON_TMPDIR_NAME)


### PR DESCRIPTION
The tests seems to be stable after the series of improvements applied to
our selftests procedures. Time to restore this check in travis.