### PR TITLE
output: Define LOG_UI and LOG_JOB [v2]

### DIFF
--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -25,7 +25,6 @@ The general reasoning to find paths is:
 * The next best location is the default system wide one.
 * The next best location is the default user specific one.
 """
-import logging
 import os
 import sys
 import shutil
@@ -34,6 +33,7 @@ import tempfile
 
 from . import job_id
 from . import settings
+from .output import LOG_JOB
 from ..utils import path as utils_path
 from ..utils.data_structures import Borg
 
@@ -52,8 +52,6 @@ USER_BASE_DIR = os.path.expanduser('~/avocado')
 USER_TEST_DIR = os.path.join(USER_BASE_DIR, 'tests')
 USER_DATA_DIR = os.path.join(USER_BASE_DIR, 'data')
 USER_LOG_DIR = os.path.join(USER_BASE_DIR, 'job-results')
-
-LOG = logging.getLogger('avocado.test')
 
 
 def _get_settings_dir(dir_name):
@@ -206,8 +204,8 @@ class _TmpDirTracker(Borg):
             self.tmp_dir = tempfile.mkdtemp(prefix='avocado_',
                                             dir=self.basedir)
         elif basedir is not None and basedir != self.basedir:
-            LOG.error("The tmp_dir was already created. The new basedir "
-                      "you're trying to provide will have no effect.")
+            LOG_JOB.error("The tmp_dir was already created. The new basedir "
+                          "you're trying to provide will have no effect.")
         return self.tmp_dir
 
     def unittest_refresh_dir_tracker(self):

--- a/avocado/core/dispatcher.py
+++ b/avocado/core/dispatcher.py
@@ -15,12 +15,12 @@
 """Extensions/plugins dispatchers."""
 
 import copy
-import logging
 import sys
 
 from stevedore import EnabledExtensionManager
 
 from .settings import settings
+from .output import LOG_UI
 from ..utils import stacktrace
 
 
@@ -183,7 +183,6 @@ class ResultEventsDispatcher(Dispatcher):
         super(ResultEventsDispatcher, self).__init__(
             'avocado.plugins.result_events',
             invoke_kwds={'args': args})
-        self.log = logging.getLogger("avocado.app")
 
     def map_method(self, method_name, *args):
         for ext in self.extensions:
@@ -196,8 +195,8 @@ class ResultEventsDispatcher(Dispatcher):
             except KeyboardInterrupt:
                 raise
             except:
-                self.log.error('Error running method "%s" of plugin "%s": %s',
-                               method_name, ext.name, sys.exc_info()[1])
+                LOG_UI.error('Error running method "%s" of plugin "%s": %s',
+                             method_name, ext.name, sys.exc_info()[1])
 
 
 class VarianterDispatcher(Dispatcher):
@@ -244,9 +243,8 @@ class VarianterDispatcher(Dispatcher):
                 raise
             except:     # catch any exception pylint: disable=W0702
                 stacktrace.log_exc_info(sys.exc_info(), logger='avocado.debug')
-                log = logging.getLogger("avocado.app")
-                log.error('Error running method "%s" of plugin "%s": %s',
-                          method_name, ext.name, sys.exc_info()[1])
+                LOG_UI.error('Error running method "%s" of plugin "%s": %s',
+                             method_name, ext.name, sys.exc_info()[1])
         return ret
 
     def map_method(self, method_name, *args, **kwargs):

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -48,11 +48,11 @@ from ..utils import runtime
 from ..utils import stacktrace
 from ..utils import data_structures
 from ..utils import process
+from .output import LOG_JOB
+from .output import LOG_UI
 
 
 _NEW_ISSUE_LINK = 'https://github.com/avocado-framework/avocado/issues/new'
-
-_TEST_LOGGER = logging.getLogger('avocado.test')
 
 
 class Job(object):
@@ -74,7 +74,7 @@ class Job(object):
             args = argparse.Namespace()
         self.args = args
         self.references = getattr(args, "reference", [])
-        self.log = logging.getLogger("avocado.app")
+        self.log = LOG_UI
         self.standalone = getattr(self.args, 'standalone', False)
         if getattr(self.args, "dry_run", False):  # Modify args for dry-run
             if not self.args.unique_job_id:
@@ -112,7 +112,7 @@ class Job(object):
         self.__start_job_logging()
         self.funcatexit = data_structures.CallbackRegister("JobExit %s"
                                                            % self.unique_id,
-                                                           _TEST_LOGGER)
+                                                           LOG_JOB)
         self._stdout_stderr = None
         self.replay_sourcejob = getattr(self.args, 'replay_sourcejob', None)
         self.exitcode = exit_codes.AVOCADO_ALL_OK
@@ -174,13 +174,13 @@ class Job(object):
         # Enable test logger
         fmt = ('%(asctime)s %(module)-16.16s L%(lineno)-.4d %('
                'levelname)-5.5s| %(message)s')
-        test_handler = output.add_log_handler("avocado.test",
+        test_handler = output.add_log_handler(LOG_JOB,
                                               logging.FileHandler,
                                               self.logfile, self.loglevel, fmt)
         root_logger = logging.getLogger()
         root_logger.addHandler(test_handler)
         root_logger.setLevel(self.loglevel)
-        self.__logging_handlers[test_handler] = ["avocado.test", ""]
+        self.__logging_handlers[test_handler] = [LOG_JOB.name, ""]
         # Add --store-logging-streams
         fmt = '%(asctime)s %(levelname)-5.5s| %(message)s'
         formatter = logging.Formatter(fmt=fmt, datefmt='%H:%M:%S')
@@ -211,13 +211,13 @@ class Job(object):
             # Enable std{out,err} but redirect booth to stderr
             sys.stdout = STD_OUTPUT.stdout
             sys.stderr = STD_OUTPUT.stdout
-            test_handler = output.add_log_handler("avocado.test",
+            test_handler = output.add_log_handler(LOG_JOB,
                                                   logging.StreamHandler,
                                                   STD_OUTPUT.stdout,
                                                   logging.DEBUG,
                                                   fmt="%(message)s")
             root_logger.addHandler(test_handler)
-            self.__logging_handlers[test_handler] = ["avocado.test", ""]
+            self.__logging_handlers[test_handler] = [LOG_JOB.name, ""]
 
     def __stop_job_logging(self):
         if self._stdout_stderr:
@@ -232,8 +232,7 @@ class Job(object):
         """
         def soft_abort(msg):
             """ Only log the problem """
-            logging.getLogger("avocado.test").warning("Unable to update the "
-                                                      "latest link: %s" % msg)
+            LOG_JOB.warning("Unable to update the latest link: %s" % msg)
         basedir = os.path.dirname(self.logdir)
         basename = os.path.basename(self.logdir)
         proc_latest = os.path.join(basedir, "latest.%s" % os.getpid())
@@ -303,23 +302,20 @@ class Job(object):
         return suite
 
     def _log_job_id(self):
-        job_log = _TEST_LOGGER
-        job_log.info('Job ID: %s', self.unique_id)
+        LOG_JOB.info('Job ID: %s', self.unique_id)
         if self.replay_sourcejob is not None:
-            job_log.info('Replay of Job ID: %s', self.replay_sourcejob)
-        job_log.info('')
+            LOG_JOB.info('Replay of Job ID: %s', self.replay_sourcejob)
+        LOG_JOB.info('')
 
     @staticmethod
     def _log_cmdline():
-        job_log = _TEST_LOGGER
         cmdline = " ".join(sys.argv)
-        job_log.info("Command line: %s", cmdline)
-        job_log.info('')
+        LOG_JOB.info("Command line: %s", cmdline)
+        LOG_JOB.info('')
 
     @staticmethod
     def _log_avocado_version():
-        job_log = _TEST_LOGGER
-        job_log.info('Avocado version: %s', version.VERSION)
+        LOG_JOB.info('Avocado version: %s', version.VERSION)
         if os.path.exists('.git') and os.path.exists('avocado.spec'):
             cmd = "git show --summary --pretty='%H'"
             result = process.run(cmd, ignore_status=True)
@@ -332,24 +328,23 @@ class Job(object):
             # Let's display information only if git is installed
             # (commands succeed).
             if status == 0 and status2 == 0:
-                job_log.info('Avocado git repo info')
-                job_log.info("Top commit: %s", top_commit)
-                job_log.info("Branch: %s", branch)
-        job_log.info('')
+                LOG_JOB.info('Avocado git repo info')
+                LOG_JOB.info("Top commit: %s", top_commit)
+                LOG_JOB.info("Branch: %s", branch)
+        LOG_JOB.info('')
 
     @staticmethod
     def _log_avocado_config():
-        job_log = _TEST_LOGGER
-        job_log.info('Config files read (in order):')
+        LOG_JOB.info('Config files read (in order):')
         for cfg_path in settings.config_paths:
-            job_log.info(cfg_path)
+            LOG_JOB.info(cfg_path)
         if settings.config_paths_failed:
-            job_log.info('Config files failed to read (in order):')
+            LOG_JOB.info('Config files failed to read (in order):')
             for cfg_path in settings.config_paths_failed:
-                job_log.info(cfg_path)
-        job_log.info('')
+                LOG_JOB.info(cfg_path)
+        LOG_JOB.info('')
 
-        job_log.info('Avocado config:')
+        LOG_JOB.info('Avocado config:')
         header = ('Section.Key', 'Value')
         config_matrix = []
         for section in settings.config.sections():
@@ -358,28 +353,26 @@ class Job(object):
                 config_matrix.append([config_key, value[1]])
 
         for line in astring.iter_tabular_output(config_matrix, header):
-            job_log.info(line)
-        job_log.info('')
+            LOG_JOB.info(line)
+        LOG_JOB.info('')
 
     def _log_avocado_datadir(self):
-        job_log = _TEST_LOGGER
-        job_log.info('Avocado Data Directories:')
-        job_log.info('')
-        job_log.info('base     ' + data_dir.get_base_dir())
-        job_log.info('tests    ' + data_dir.get_test_dir())
-        job_log.info('data     ' + data_dir.get_data_dir())
-        job_log.info('logs     ' + self.logdir)
-        job_log.info('')
+        LOG_JOB.info('Avocado Data Directories:')
+        LOG_JOB.info('')
+        LOG_JOB.info('base     ' + data_dir.get_base_dir())
+        LOG_JOB.info('tests    ' + data_dir.get_test_dir())
+        LOG_JOB.info('data     ' + data_dir.get_data_dir())
+        LOG_JOB.info('logs     ' + self.logdir)
+        LOG_JOB.info('')
 
     def _log_variants(self, variants):
         lines = variants.to_str(summary=1, variants=1, use_utf8=False)
         for line in lines.splitlines():
-            _TEST_LOGGER.info(line)
+            LOG_JOB.info(line)
 
     def _log_tmp_dir(self):
-        job_log = _TEST_LOGGER
-        job_log.info('Temporary dir: %s', data_dir.get_tmp_dir())
-        job_log.info('')
+        LOG_JOB.info('Temporary dir: %s', data_dir.get_tmp_dir())
+        LOG_JOB.info('')
 
     def _log_job_debug_info(self, mux):
         """
@@ -403,7 +396,7 @@ class Job(object):
             self.test_suite = self._make_test_suite(self.references)
             self.result.tests_total = len(self.test_suite)
         except loader.LoaderError as details:
-            stacktrace.log_exc_info(sys.exc_info(), 'avocado.app.debug')
+            stacktrace.log_exc_info(sys.exc_info(), LOG_UI.getChild("debug"))
             raise exceptions.OptionValidationError(details)
 
         if not self.test_suite:
@@ -454,7 +447,7 @@ class Job(object):
         # If it's all good so far, set job status to 'PASS'
         if self.status == 'RUNNING':
             self.status = 'PASS'
-        _TEST_LOGGER.info('Test results available in %s', self.logdir)
+        LOG_JOB.info('Test results available in %s', self.logdir)
 
         if summary is None:
             self.exitcode |= exit_codes.AVOCADO_JOB_FAIL

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -33,6 +33,7 @@ from . import safeloader
 from ..utils import path
 from ..utils import stacktrace
 from .settings import settings
+from .output import LOG_UI
 
 #: Show default tests (for execution)
 DEFAULT = False
@@ -246,9 +247,9 @@ class TestLoaderProxy(object):
             # FIXME: Introduce avocado.exceptions logger and use here
             stacktrace.log_message("Test discovery plugin %s failed: "
                                    "%s" % (plugin, details),
-                                   'avocado.app.exceptions')
+                                   LOG_UI.getChild("exceptions"))
             # FIXME: Introduce avocado.traceback logger and use here
-            stacktrace.log_exc_info(sys.exc_info(), 'avocado.app.debug')
+            stacktrace.log_exc_info(sys.exc_info(), LOG_UI.getChild("debug"))
         tests = []
         unhandled_references = []
         if not references:

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -32,6 +32,11 @@ else:
     NULL_HANDLER = logutils.NullHandler
 
 
+#: Pre-defined Avocado human UI logger
+LOG_UI = logging.getLogger("avocado.app")
+#: Pre-defined Avocado job/test logger
+LOG_JOB = logging.getLogger("avocado.test")
+
 #: Builtin special keywords to enable set of logging streams
 BUILTIN_STREAMS = {'app': 'application output',
                    'test': 'test output',

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -348,11 +348,11 @@ def early_start():
     Replace all outputs with in-memory handlers
     """
     if os.environ.get('AVOCADO_LOG_DEBUG'):
-        add_log_handler("avocado.app.debug", logging.StreamHandler, sys.stdout,
-                        logging.DEBUG)
+        add_log_handler(LOG_UI.getChild("debug"), logging.StreamHandler,
+                        sys.stdout, logging.DEBUG)
     if os.environ.get('AVOCADO_LOG_EARLY'):
         add_log_handler("", logging.StreamHandler, sys.stdout, logging.DEBUG)
-        add_log_handler("avocado.test", logging.StreamHandler, sys.stdout,
+        add_log_handler(LOG_JOB, logging.StreamHandler, sys.stdout,
                         logging.DEBUG)
     else:
         STD_OUTPUT.fake_outputs()
@@ -392,34 +392,33 @@ def reconfigure(args):
     else:
         STD_OUTPUT.enable_stderr()
     STD_OUTPUT.print_records()
-    app_logger = logging.getLogger("avocado.app")
     if "app" in enabled:
         app_handler = ProgressStreamHandler()
         app_handler.setFormatter(logging.Formatter("%(message)s"))
         app_handler.addFilter(FilterInfoAndLess())
         app_handler.stream = STD_OUTPUT.stdout
-        app_logger.addHandler(app_handler)
-        app_logger.propagate = False
-        app_logger.level = logging.DEBUG
+        LOG_UI.addHandler(app_handler)
+        LOG_UI.propagate = False
+        LOG_UI.level = logging.DEBUG
     else:
-        disable_log_handler("avocado.app")
+        disable_log_handler(LOG_UI)
     app_err_handler = ProgressStreamHandler()
     app_err_handler.setFormatter(logging.Formatter("%(message)s"))
     app_err_handler.addFilter(FilterWarnAndMore())
     app_err_handler.stream = STD_OUTPUT.stderr
-    app_logger.addHandler(app_err_handler)
-    app_logger.propagate = False
+    LOG_UI.addHandler(app_err_handler)
+    LOG_UI.propagate = False
     if not os.environ.get("AVOCADO_LOG_EARLY"):
-        logging.getLogger("avocado.test.stdout").propagate = False
-        logging.getLogger("avocado.test.stderr").propagate = False
+        LOG_JOB.getChild("stdout").propagate = False
+        LOG_JOB.getChild("stderr").propagate = False
         if "early" in enabled:
             add_log_handler("", logging.StreamHandler, STD_OUTPUT.stdout,
                             logging.DEBUG)
-            add_log_handler("avocado.test", logging.StreamHandler,
+            add_log_handler(LOG_JOB, logging.StreamHandler,
                             STD_OUTPUT.stdout, logging.DEBUG)
         else:
             disable_log_handler("")
-            disable_log_handler("avocado.test")
+            disable_log_handler(LOG_JOB)
     if "remote" in enabled:
         add_log_handler("avocado.fabric", stream=STD_OUTPUT.stdout,
                         level=logging.DEBUG)
@@ -431,9 +430,9 @@ def reconfigure(args):
     # Not enabled by env
     if not os.environ.get('AVOCADO_LOG_DEBUG'):
         if "debug" in enabled:
-            add_log_handler("avocado.app.debug", stream=STD_OUTPUT.stdout)
+            add_log_handler(LOG_UI.getChild("debug"), stream=STD_OUTPUT.stdout)
         else:
-            disable_log_handler("avocado.app.debug")
+            disable_log_handler(LOG_UI.getChild("debug"))
 
     # Add custom loggers
     for name in [_ for _ in enabled if _ not in BUILTIN_STREAMS.iterkeys()]:
@@ -448,8 +447,8 @@ def reconfigure(args):
             add_log_handler(name, logging.StreamHandler, STD_OUTPUT.stdout,
                             level)
         except ValueError as details:
-            app_logger.error("Failed to set logger for --show %s:%s: %s.",
-                             name, level, details)
+            LOG_UI.error("Failed to set logger for --show %s:%s: %s.",
+                         name, level, details)
             sys.exit(exit_codes.AVOCADO_FAIL)
     # Remove the in-memory handlers
     for handler in logging.root.handlers:
@@ -576,18 +575,21 @@ def add_log_handler(logger, klass=logging.StreamHandler, stream=sys.stdout,
     :param level: Log level (defaults to `INFO``)
     :param fmt: Logging format (defaults to ``%(name)s: %(message)s``)
     """
+    if isinstance(logger, basestring):
+        logger = logging.getLogger(logger)
     handler = klass(stream)
     handler.setLevel(level)
     if isinstance(fmt, str):
         fmt = logging.Formatter(fmt=fmt)
     handler.setFormatter(fmt)
-    logging.getLogger(logger).addHandler(handler)
-    logging.getLogger(logger).propagate = False
+    logger.addHandler(handler)
+    logger.propagate = False
     return handler
 
 
 def disable_log_handler(logger):
-    logger = logging.getLogger(logger)
+    if isinstance(logger, basestring):
+        logger = logging.getLogger(logger)
     # Handlers might be reused elsewhere, can't delete them
     while logger.handlers:
         logger.handlers.pop()
@@ -704,7 +706,6 @@ def log_plugin_failures(failures):
                      :class:`avocado.core.dispatcher.Dispatcher`
                      attribute `load_failures`
     """
-    log = logging.getLogger("avocado.app")
     msg_fmt = 'Failed to load plugin from module "%s": %s'
     silenced = settings.get_value('plugins',
                                   'skip_broken_plugin_notification',
@@ -712,5 +713,5 @@ def log_plugin_failures(failures):
     for failure in failures:
         if failure[0].module_name in silenced:
             continue
-        log.error(msg_fmt, failure[0].module_name,
-                  failure[1].__repr__())
+        LOG_UI.error(msg_fmt, failure[0].module_name,
+                     failure[1].__repr__())

--- a/avocado/core/parser.py
+++ b/avocado/core/parser.py
@@ -17,13 +17,12 @@ Avocado application command line parsing.
 """
 
 import argparse
-import logging
 
 from . import exit_codes
 from . import varianter
 from . import settings
 from . import tree
-from .output import BUILTIN_STREAMS, BUILTIN_STREAM_SETS
+from .output import BUILTIN_STREAMS, BUILTIN_STREAM_SETS, LOG_UI
 from .version import VERSION
 
 PROG = 'avocado'
@@ -37,9 +36,8 @@ class ArgumentParser(argparse.ArgumentParser):
     """
 
     def error(self, message):
-        log = logging.getLogger("avocado.app")
-        log.debug(self.format_help())
-        log.error("%s: error: %s", self.prog, message)
+        LOG_UI.debug(self.format_help())
+        LOG_UI.error("%s: error: %s", self.prog, message)
         self.exit(exit_codes.AVOCADO_FAIL)
 
     def _get_option_tuples(self, option_string):

--- a/avocado/core/restclient/cli/actions/server.py
+++ b/avocado/core/restclient/cli/actions/server.py
@@ -6,13 +6,9 @@ Module that implements the actions for the CLI App when the job toplevel
 command is used
 """
 
-import logging
-
 from . import base
 from ... import connection
-
-
-log = logging.getLogger("avocado.app")
+from ....output import LOG_UI
 
 
 @base.action
@@ -21,7 +17,7 @@ def status(app):
     Shows the server status
     """
     data = app.connection.request("version/")
-    log.info("Server version: %s", data.get('version'))
+    LOG_UI.info("Server version: %s", data.get('version'))
 
 
 @base.action
@@ -33,9 +29,9 @@ def list_brief(app):
         data = app.connection.get_api_list()
     except connection.UnexpectedHttpStatusCode as e:
         if e.received == 403:
-            log.error("Error: Access Forbidden")
+            LOG_UI.error("Error: Access Forbidden")
             return False
 
-    log.info("Available APIs:")
+    LOG_UI.info("Available APIs:")
     for name in data:
-        log.info(" * %s", name)
+        LOG_UI.info(" * %s", name)

--- a/avocado/core/restclient/cli/app.py
+++ b/avocado/core/restclient/cli/app.py
@@ -16,13 +16,13 @@ This is the main entry point for the rest client cli application
 """
 
 import importlib
-import logging
 import sys
 import types
 
 from . import parser
 from .. import connection
 from ... import exit_codes
+from ...output import LOG_UI
 
 
 __all__ = ['App']
@@ -48,7 +48,7 @@ class App(object):
         self.connection = None
         self.parser = parser.Parser()
         self.parser.add_arguments_on_all_modules()
-        self.log = logging.getLogger("avocado.app")
+        self.log = LOG_UI
 
     def initialize_connection(self):
         """

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -36,8 +36,8 @@ from ..utils import runtime
 from ..utils import process
 from ..utils import stacktrace
 
-TEST_LOG = logging.getLogger("avocado.test")
-APP_LOG = logging.getLogger("avocado.app")
+from .output import LOG_UI as APP_LOG
+from .output import LOG_JOB as TEST_LOG
 
 #: when test was interrupted (ctrl+c/timeout)
 TIMEOUT_TEST_INTERRUPTED = 1

--- a/avocado/core/varianter.py
+++ b/avocado/core/varianter.py
@@ -19,11 +19,11 @@
 Multiplex and create variants.
 """
 
-import logging
 import re
 
 from . import tree
 from . import dispatcher
+from .output import LOG_JOB
 
 
 # TODO: Create multiplexer plugin and split these functions into multiple files
@@ -45,7 +45,7 @@ class AvocadoParams(object):
     of duplicate entries inherited from ancestor nodes.  It shouldn't produce
     false values, though.
 
-    In this version each new "get()" call is logged into "avocado.test" log.
+    In this version each new "get()" call is logged into avocado.LOG_JOB.
     This is subject of change (separate file, perhaps)
     """
 
@@ -70,7 +70,6 @@ class AvocadoParams(object):
         path_leaves = self._get_matching_leaves('/*', leaves)
         self._abs_path = AvocadoParam(path_leaves, '*: *')
         self.id = test_id
-        self._log = logging.getLogger("avocado.test").debug
         self._cache = {}     # TODO: Implement something more efficient
         # TODO: Get rid of this and prepare something better
         self._default_params = default_params
@@ -89,13 +88,11 @@ class AvocadoParams(object):
     def __getstate__(self):
         """ log can't be pickled """
         copy = self.__dict__.copy()
-        del(copy['_log'])
         return copy
 
     def __setstate__(self, orig):
         """ refresh log """
         self.__dict__.update(orig)
-        self._log = logging.getLogger("avocado.test").debug
 
     def __repr__(self):
         return "<AvocadoParams %s>" % self._str()
@@ -112,8 +109,8 @@ class AvocadoParams(object):
 
     def log(self, key, path, default, value):
         """ Predefined format for displaying params query """
-        self._log("PARAMS (key=%s, path=%s, default=%s) => %r", key, path,
-                  default, value)
+        LOG_JOB.debug("PARAMS (key=%s, path=%s, default=%s) => %r", key, path,
+                      default, value)
 
     def _get_matching_leaves(self, path, leaves):
         """
@@ -169,7 +166,7 @@ class AvocadoParams(object):
             msg = ("You're probably retrieving param %s via attributes "
                    " (self.params.$key) which is obsoleted. Use "
                    "self.params.get($key) instead." % attr)
-            logging.getLogger("avocado.test").warn(msg)
+            LOG_JOB.warn(msg)
             return self.get(attr)
 
     def get(self, key, path=None, default=None):

--- a/avocado/plugins/config.py
+++ b/avocado/plugins/config.py
@@ -12,9 +12,8 @@
 # Copyright: Red Hat Inc. 2013-2014
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
-import logging
-
 from avocado.core import data_dir
+from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLICmd
 from avocado.core.settings import settings
 
@@ -38,15 +37,14 @@ class Config(CLICmd):
                             'Current: %(default)s')
 
     def run(self, args):
-        log = logging.getLogger("avocado.app")
-        log.info('Config files read (in order):')
+        LOG_UI.info('Config files read (in order):')
         for cfg_path in settings.config_paths:
-            log.debug('    %s' % cfg_path)
+            LOG_UI.debug('    %s' % cfg_path)
         if settings.config_paths_failed:
-            log.error('\nConfig files that failed to read:')
+            LOG_UI.error('\nConfig files that failed to read:')
             for cfg_path in settings.config_paths_failed:
-                log.error('    %s' % cfg_path)
-        log.debug("")
+                LOG_UI.error('    %s' % cfg_path)
+        LOG_UI.debug("")
         if not args.datadir:
             blength = 0
             for section in settings.config.sections():
@@ -57,18 +55,18 @@ class Config(CLICmd):
 
             format_str = "    %-" + str(blength) + "s %s"
 
-            log.debug(format_str, 'Section.Key', 'Value')
+            LOG_UI.debug(format_str, 'Section.Key', 'Value')
             for section in settings.config.sections():
                 for value in settings.config.items(section):
                     config_key = ".".join((section, value[0]))
-                    log.debug(format_str, config_key, value[1])
+                    LOG_UI.debug(format_str, config_key, value[1])
         else:
-            log.debug("Avocado replaces config dirs that can't be accessed")
-            log.debug("with sensible defaults. Please edit your local config")
-            log.debug("file to customize values")
-            log.debug('')
-            log.info('Avocado Data Directories:')
-            log.debug('    base     ' + data_dir.get_base_dir())
-            log.debug('    tests    ' + data_dir.get_test_dir())
-            log.debug('    data     ' + data_dir.get_data_dir())
-            log.debug('    logs     ' + data_dir.get_logs_dir())
+            LOG_UI.debug("Avocado replaces config dirs that can't be accessed")
+            LOG_UI.debug("with sensible defaults. Please edit your local config")
+            LOG_UI.debug("file to customize values")
+            LOG_UI.debug('')
+            LOG_UI.info('Avocado Data Directories:')
+            LOG_UI.debug('    base     ' + data_dir.get_base_dir())
+            LOG_UI.debug('    tests    ' + data_dir.get_test_dir())
+            LOG_UI.debug('    data     ' + data_dir.get_data_dir())
+            LOG_UI.debug('    logs     ' + data_dir.get_logs_dir())

--- a/avocado/plugins/diff.py
+++ b/avocado/plugins/diff.py
@@ -19,7 +19,6 @@ Job Diff
 from __future__ import absolute_import
 import argparse
 import json
-import logging
 import os
 import subprocess
 import sys
@@ -31,11 +30,9 @@ from avocado.core import exit_codes
 from avocado.core import jobdata
 from avocado.core import output
 
+from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLICmd
 from avocado.core.settings import settings
-
-
-LOG = logging.getLogger("avocado.app")
 
 
 class Diff(CLICmd):
@@ -217,7 +214,7 @@ class Diff(CLICmd):
             tmp_file2.writelines(job2_results)
             tmp_file2.close()
 
-            LOG.info('%s %s', tmp_file1.name, tmp_file2.name)
+            LOG_UI.info('%s %s', tmp_file1.name, tmp_file2.name)
 
         if (getattr(args, 'open_browser', False) and
                 getattr(args, 'html', None) is None):
@@ -259,10 +256,10 @@ class Diff(CLICmd):
                 with open(args.html, 'w') as html_file:
                     html_file.writelines(job_diff_html.encode("utf-8"))
 
-                LOG.info(args.html)
+                LOG_UI.info(args.html)
 
             except IOError as exception:
-                LOG.error(exception)
+                LOG_UI.error(exception)
                 sys.exit(exit_codes.AVOCADO_FAIL)
 
         if getattr(args, 'open_browser', False):
@@ -281,13 +278,13 @@ class Diff(CLICmd):
                                                      job2_results,
                                                      fromfile=job1_id,
                                                      tofile=job2_id)):
-                    LOG.debug(line.strip())
+                    LOG_UI.debug(line.strip())
             else:
                 for line in unified_diff(job1_results,
                                          job2_results,
                                          fromfile=job1_id,
                                          tofile=job2_id):
-                    LOG.debug(line.strip())
+                    LOG_UI.debug(line.strip())
 
     @staticmethod
     def _validate_filters(string):
@@ -342,18 +339,18 @@ class Diff(CLICmd):
             try:
                 resultsdir = jobdata.get_resultsdir(logdir, job_id)
             except ValueError as exception:
-                LOG.error(exception.message)
+                LOG_UI.error(exception.message)
                 sys.exit(exit_codes.AVOCADO_FAIL)
 
         if resultsdir is None:
-            LOG.error("Can't find job results directory for '%s' in '%s'",
-                      job_id, logdir)
+            LOG_UI.error("Can't find job results directory for '%s' in '%s'",
+                         job_id, logdir)
             sys.exit(exit_codes.AVOCADO_FAIL)
 
         sourcejob = jobdata.get_id(os.path.join(resultsdir, 'id'), job_id)
         if sourcejob is None:
-            LOG.error("Can't find matching job id '%s' in '%s' directory.",
-                      job_id, resultsdir)
+            LOG_UI.error("Can't find matching job id '%s' in '%s' directory.",
+                         job_id, resultsdir)
             sys.exit(exit_codes.AVOCADO_FAIL)
 
         return resultsdir, sourcejob

--- a/avocado/plugins/distro.py
+++ b/avocado/plugins/distro.py
@@ -14,12 +14,12 @@
 
 import bz2
 import json
-import logging
 import os
 import sys
 
 from avocado.core import exit_codes
 from avocado.core.plugin_interfaces import CLICmd
+from avocado.core.output import LOG_UI
 from avocado.utils import distro as utils_distro
 from avocado.utils import path as utils_path
 from avocado.utils import process
@@ -340,23 +340,22 @@ class Distro(CLICmd):
                                         args.distro_def_arch)
 
     def run(self, args):
-        log = logging.getLogger("avocado.app")
         if args.distro_def_create:
             if not (args.distro_def_name and args.distro_def_version and
                     args.distro_def_arch and args.distro_def_type and
                     args.distro_def_path):
-                log.error('Required arguments: name, version, arch, type '
-                          'and path')
+                LOG_UI.error('Required arguments: name, version, arch, type '
+                             'and path')
                 sys.exit(exit_codes.AVOCADO_FAIL)
 
             output_file_name = self.get_output_file_name(args)
             if os.path.exists(output_file_name):
                 error_msg = ('Output file "%s" already exists, will not '
                              'overwrite it', output_file_name)
-                log.error(error_msg)
+                LOG_UI.error(error_msg)
             else:
-                log.debug("Loading distro information from tree... "
-                          "Please wait...")
+                LOG_UI.debug("Loading distro information from tree... "
+                             "Please wait...")
                 distro = load_from_tree(args.distro_def_name,
                                         args.distro_def_version,
                                         args.distro_def_release,
@@ -364,10 +363,10 @@ class Distro(CLICmd):
                                         args.distro_def_type,
                                         args.distro_def_path)
                 save_distro(distro, output_file_name)
-                log.debug('Distro information saved to "%s"',
-                          output_file_name)
+                LOG_UI.debug('Distro information saved to "%s"',
+                             output_file_name)
         else:
             detected = utils_distro.detect()
-            log.debug('Detected distribution: %s (%s) version %s release %s',
-                      detected.name, detected.arch, detected.version,
-                      detected.release)
+            LOG_UI.debug('Detected distribution: %s (%s) version %s release '
+                         '%s', detected.name, detected.arch, detected.version,
+                         detected.release)

--- a/avocado/plugins/exec_path.py
+++ b/avocado/plugins/exec_path.py
@@ -14,11 +14,11 @@
 Libexec PATHs modifier
 """
 
-import logging
 import os
 import sys
 
 from avocado.core import exit_codes
+from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLICmd
 
 
@@ -37,21 +37,20 @@ class ExecPath(CLICmd):
 
         :param args: Command line args received from the run subparser.
         """
-        log = logging.getLogger("avocado.app")
         if 'VIRTUAL_ENV' in os.environ:
-            log.debug('libexec')
+            LOG_UI.debug('libexec')
         elif os.path.exists('/usr/libexec/avocado'):
-            log.debug('/usr/libexec/avocado')
+            LOG_UI.debug('/usr/libexec/avocado')
         elif os.path.exists('/usr/lib/avocado'):
-            log.debug('/usr/lib/avocado')
+            LOG_UI.debug('/usr/lib/avocado')
         else:
             for path in os.environ.get('PATH').split(':'):
                 if (os.path.exists(os.path.join(path, 'avocado')) and
                     os.path.exists(os.path.join(os.path.dirname(path),
                                                 'libexec'))):
-                    log.debug(os.path.join(os.path.dirname(path), 'libexec'))
+                    LOG_UI.debug(os.path.join(os.path.dirname(path), 'libexec'))
                     break
             else:
-                log.error("Can't locate avocado libexec path")
+                LOG_UI.error("Can't locate avocado libexec path")
                 sys.exit(exit_codes.AVOCADO_FAIL)
         return sys.exit(exit_codes.AVOCADO_ALL_OK)

--- a/avocado/plugins/human.py
+++ b/avocado/plugins/human.py
@@ -15,8 +15,7 @@
 Human result UI
 """
 
-import logging
-
+from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import ResultEvents
 from avocado.core import output
 
@@ -39,7 +38,7 @@ class Human(ResultEvents):
                       'CANCEL': output.TERM_SUPPORT.CANCEL}
 
     def __init__(self, args):
-        self.log = logging.getLogger("avocado.app")
+        self.log = LOG_UI
         self.__throbber = output.Throbber()
         stdout_claimed_by = getattr(args, 'stdout_claimed_by', None)
         self.owns_stdout = not stdout_claimed_by

--- a/avocado/plugins/jobscripts.py
+++ b/avocado/plugins/jobscripts.py
@@ -1,6 +1,6 @@
 import os
-import logging
 
+from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import JobPre, JobPost
 from avocado.core.settings import settings
 from avocado.utils import process
@@ -15,7 +15,7 @@ class JobScripts(JobPre, JobPost):
     description = 'Runs scripts before/after the job is run'
 
     def __init__(self):
-        self.log = logging.getLogger("avocado.app")
+        self.log = LOG_UI
         self.warn_non_existing_dir = settings.get_value(section=CONFIG_SECTION,
                                                         key="warn_non_existing_dir",
                                                         key_type=bool,

--- a/avocado/plugins/jsonresult.py
+++ b/avocado/plugins/jsonresult.py
@@ -18,9 +18,9 @@ JSON output module.
 """
 
 import json
-import logging
 import os
 
+from avocado.core.output import LOG_UI
 from avocado.core.parser import FileOrStdoutAction
 from avocado.core.plugin_interfaces import CLI, Result
 
@@ -86,8 +86,7 @@ class JSONResult(Result):
         json_path = getattr(job.args, 'json_output', 'None')
         if json_path is not None:
             if json_path == '-':
-                log = logging.getLogger("avocado.app")
-                log.debug(content)
+                LOG_UI.debug(content)
             else:
                 with open(json_path, 'w') as json_file:
                     json_file.write(content)

--- a/avocado/plugins/list.py
+++ b/avocado/plugins/list.py
@@ -12,13 +12,13 @@
 # Copyright: Red Hat Inc. 2013-2014
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
-import logging
 import sys
 
 
 from avocado.core import exit_codes, output
 from avocado.core import loader
 from avocado.core import test
+from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLICmd
 from avocado.utils import astring
 
@@ -30,7 +30,6 @@ class TestLister(object):
     """
 
     def __init__(self, args):
-        self.log = logging.getLogger("avocado.app")
         try:
             loader.loader.load_plugins(args)
         except loader.LoaderError as details:
@@ -48,7 +47,7 @@ class TestLister(object):
             return loader.loader.discover(paths,
                                           which_tests=which_tests)
         except loader.LoaderUnhandledReferenceError as details:
-            self.log.error(str(details))
+            LOG_UI.error(str(details))
             sys.exit(exit_codes.AVOCADO_FAIL)
 
     def _get_test_matrix(self, test_suite):
@@ -90,12 +89,12 @@ class TestLister(object):
                       output.TERM_SUPPORT.header_str('Test'))
 
         for line in astring.iter_tabular_output(test_matrix, header=header):
-            self.log.debug(line)
+            LOG_UI.debug(line)
 
         if self.args.verbose:
-            self.log.debug("")
+            LOG_UI.debug("")
             for key in sorted(stats):
-                self.log.info("%s: %s", key.upper(), stats[key])
+                LOG_UI.info("%s: %s", key.upper(), stats[key])
 
     def _list(self):
         self._extra_listing()
@@ -112,7 +111,7 @@ class TestLister(object):
         try:
             self._list()
         except KeyboardInterrupt:
-            self.log.error('Command interrupted by user...')
+            LOG_UI.error('Command interrupted by user...')
             return exit_codes.AVOCADO_FAIL
 
 

--- a/avocado/plugins/multiplex.py
+++ b/avocado/plugins/multiplex.py
@@ -12,7 +12,7 @@
 # Copyright: Red Hat Inc. 2013-2014
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
-import logging
+from avocado.core.output import LOG_UI
 
 from .variants import Variants
 
@@ -27,8 +27,7 @@ class Multiplex(Variants):
     name = "multiplex"
 
     def run(self, args):
-        log = logging.getLogger("avocado.app")
-        log.warning("The 'avocado multiplex' command is deprecated by the "
-                    "'avocado variants' one. Please start using that one "
-                    "instead as this will be removed in Avocado 52.0.")
+        LOG_UI.warning("The 'avocado multiplex' command is deprecated by the "
+                       "'avocado variants' one. Please start using that one "
+                       "instead as this will be removed in Avocado 52.0.")
         super(Multiplex, self).run(args)

--- a/avocado/plugins/plugins.py
+++ b/avocado/plugins/plugins.py
@@ -15,9 +15,8 @@
 Plugins information plugin
 """
 
-import logging
-
 from avocado.core import dispatcher
+from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLICmd
 from avocado.utils import astring
 
@@ -39,7 +38,6 @@ class Plugins(CLICmd):
                             'Current: %(default)s')
 
     def run(self, args):
-        log = logging.getLogger("avocado.app")
         plugin_types = [
             (dispatcher.CLICmdDispatcher(),
              'Plugins that add new commands (cli.cmd):'),
@@ -56,13 +54,13 @@ class Plugins(CLICmd):
              'Plugins that generate test variants (varianter): ')
         ]
         for plugins_active, msg in plugin_types:
-            log.info(msg)
+            LOG_UI.info(msg)
             plugin_matrix = []
             for plugin in sorted(plugins_active, key=lambda x: x.name):
                 plugin_matrix.append((plugin.name, plugin.obj.description))
 
             if not plugin_matrix:
-                log.debug("(No active plugin)")
+                LOG_UI.debug("(No active plugin)")
             else:
                 for line in astring.iter_tabular_output(plugin_matrix):
-                    log.debug(line)
+                    LOG_UI.debug(line)

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -17,12 +17,12 @@ Base Test Runner Plugins.
 """
 
 import argparse
-import logging
 import sys
 
 from avocado.core import exit_codes
 from avocado.core import job
 from avocado.core import loader
+from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLICmd
 from avocado.core.dispatcher import ResultDispatcher
 from avocado.core.settings import settings
@@ -151,19 +151,18 @@ class Run(CLICmd):
 
         :param args: Command line args received from the run subparser.
         """
-        log = logging.getLogger("avocado.app")
         if args.unique_job_id is not None:
             try:
                 int(args.unique_job_id, 16)
                 if len(args.unique_job_id) != 40:
                     raise ValueError
             except ValueError:
-                log.error('Unique Job ID needs to be a 40 digit hex number')
+                LOG_UI.error('Unique Job ID needs to be a 40 digit hex number')
                 sys.exit(exit_codes.AVOCADO_FAIL)
         try:
             args.job_timeout = time_to_seconds(args.job_timeout)
         except ValueError as e:
-            log.error(e.message)
+            LOG_UI.error(e.message)
             sys.exit(exit_codes.AVOCADO_FAIL)
         job_instance = job.Job(args)
         job_run = job_instance.run()

--- a/avocado/plugins/tap.py
+++ b/avocado/plugins/tap.py
@@ -15,9 +15,9 @@
 TAP output module.
 """
 
-import logging
 import os
 
+from avocado.core.output import LOG_UI
 from avocado.core.parser import FileOrStdoutAction
 from avocado.core.plugin_interfaces import CLI, ResultEvents
 
@@ -63,7 +63,7 @@ class TAPResult(ResultEvents):
         self.__open_files = []
         output = getattr(args, 'tap', None)
         if output == '-':
-            log = logging.getLogger("avocado.app").debug
+            log = LOG_UI.debug
             self.__logs.append(log)
         elif output is not None:
             log = open(output, "w", 1)

--- a/avocado/plugins/variants.py
+++ b/avocado/plugins/variants.py
@@ -13,10 +13,10 @@
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 # Author: Lukas Doktor <ldoktor@redhat.com>
 
-import logging
 import sys
 
 from avocado.core import exit_codes
+from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLICmd
 from avocado.core.settings import settings
 
@@ -79,20 +79,19 @@ class Variants(CLICmd):
                                  "inherited values")
 
     def run(self, args):
-        log = logging.getLogger("avocado.app")
         err = None
         if args.tree and args.mux_debug:
             err = "Option --tree is incompatible with --debug."
         elif not args.tree and args.inherit:
             err = "Option --inherit can be only used with --tree"
         if err:
-            log.error(err)
+            LOG_UI.error(err)
             sys.exit(exit_codes.AVOCADO_FAIL)
         varianter = args.avocado_variants
         try:
             varianter.parse(args)
         except (IOError, ValueError) as details:
-            log.error("Unable to parse varianter: %s", details)
+            LOG_UI.error("Unable to parse varianter: %s", details)
             sys.exit(exit_codes.AVOCADO_FAIL)
         use_utf8 = settings.get_value("runner.output", "utf8",
                                       key_type=bool, default=None)
@@ -116,6 +115,6 @@ class Variants(CLICmd):
                                              variants=variants,
                                              use_utf8=use_utf8)
         for line in lines.splitlines():
-            log.debug(line)
+            LOG_UI.debug(line)
 
         sys.exit(exit_codes.AVOCADO_ALL_OK)

--- a/avocado/plugins/wrapper.py
+++ b/avocado/plugins/wrapper.py
@@ -12,11 +12,11 @@
 # Copyright: Red Hat Inc. 2014
 # Author: Ruda Moura <rmoura@redhat.com>
 
-import logging
 import os
 import sys
 
 from avocado.core import exit_codes
+from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLI
 from avocado.utils import process
 
@@ -50,10 +50,9 @@ class Wrapper(CLI):
     def run(self, args):
         wraps = getattr(args, "wrapper", None)
         if wraps:
-            log = logging.getLogger("avocado.app")
             if getattr(args, 'gdb_run_bin', None):
-                log.error('Command line option --wrapper is incompatible'
-                          ' with option --gdb-run-bin.\n%s', args.wrapper)
+                LOG_UI.error('Command line option --wrapper is incompatible'
+                             ' with option --gdb-run-bin.\n%s', args.wrapper)
                 sys.exit(exit_codes.AVOCADO_FAIL)
 
             for wrap in args.wrapper:
@@ -62,13 +61,13 @@ class Wrapper(CLI):
                         script = os.path.abspath(wrap)
                         process.WRAP_PROCESS = os.path.abspath(script)
                     else:
-                        log.error("You can't have multiple global "
-                                  "wrappers at once.")
+                        LOG_UI.error("You can't have multiple global "
+                                     "wrappers at once.")
                         sys.exit(exit_codes.AVOCADO_FAIL)
                 else:
                     script, cmd = wrap.split(':', 1)
                     script = os.path.abspath(script)
                     process.WRAP_PROCESS_NAMES_EXPR.append((script, cmd))
                 if not os.path.exists(script):
-                    log.error("Wrapper '%s' not found!", script)
+                    LOG_UI.error("Wrapper '%s' not found!", script)
                     sys.exit(exit_codes.AVOCADO_FAIL)

--- a/avocado/plugins/xunit.py
+++ b/avocado/plugins/xunit.py
@@ -16,12 +16,12 @@
 """xUnit module."""
 
 import datetime
-import logging
 import os
 import string
 from xml.dom.minidom import Document, Element
 
 from avocado.core.parser import FileOrStdoutAction
+from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLI, Result
 
 
@@ -123,8 +123,7 @@ class XUnitResult(Result):
         xunit_path = getattr(job.args, 'xunit_output', 'None')
         if xunit_path is not None:
             if xunit_path == '-':
-                log = logging.getLogger("avocado.app")
-                log.debug(content)
+                LOG_UI.debug(content)
             else:
                 with open(xunit_path, 'w') as xunit_file:
                     xunit_file.write(content)

--- a/avocado/plugins/yaml_to_mux.py
+++ b/avocado/plugins/yaml_to_mux.py
@@ -14,12 +14,12 @@
 """Multiplexer plugin to parse yaml files to params"""
 
 import copy
-import logging
 import os
 import re
 import sys
 
 from avocado.core import tree, exit_codes, mux
+from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLI, Varianter
 
 
@@ -332,10 +332,10 @@ class YamlToMux(mux.MuxPlugin, Varianter):
     @staticmethod
     def _log_deprecation_msg(deprecated, current):
         """
-        Log a message into the "avocado.app" warning log
+        Log a message into the avocado.LOG_UI warning log
         """
         msg = "The use of '%s' is deprecated, please use '%s' instead"
-        logging.getLogger("avocado.app").warning(msg, deprecated, current)
+        LOG_UI.warning(msg, deprecated, current)
 
     def initialize(self, args):
         # Deprecated filters
@@ -369,7 +369,7 @@ class YamlToMux(mux.MuxPlugin, Varianter):
                 data.merge(create_from_yaml(multiplex_files, debug))
             except IOError as details:
                 error_msg = "%s : %s" % (details.strerror, details.filename)
-                logging.getLogger("avocado.app").error(error_msg)
+                LOG_UI.error(error_msg)
                 if args.subcommand == 'run':
                     sys.exit(exit_codes.AVOCADO_JOB_FAIL)
                 else:
@@ -385,7 +385,7 @@ class YamlToMux(mux.MuxPlugin, Varianter):
                 args.avocado_variants.data_merge(from_yaml)
             except IOError as details:
                 error_msg = "%s : %s" % (details.strerror, details.filename)
-                logging.getLogger("avocado.app").error(error_msg)
+                LOG_UI.error(error_msg)
                 if args.subcommand == 'run':
                     sys.exit(exit_codes.AVOCADO_JOB_FAIL)
                 else:

--- a/avocado/utils/stacktrace.py
+++ b/avocado/utils/stacktrace.py
@@ -34,15 +34,16 @@ def log_exc_info(exc_info, logger=''):
     :param exc_info: Exception info produced by sys.exc_info()
     :param logger: Name of the logger (defaults to root)
     """
-    log = logging.getLogger(logger)
-    log.error('')
+    if isinstance(logger, basestring):
+        logger = logging.getLogger(logger)
+    logger.error('')
     called_from = inspect.currentframe().f_back
-    log.error("Reproduced traceback from: %s:%s",
-              called_from.f_code.co_filename, called_from.f_lineno)
+    logger.error("Reproduced traceback from: %s:%s",
+                 called_from.f_code.co_filename, called_from.f_lineno)
     for line in tb_info(exc_info):
         for l in line.splitlines():
-            log.error(l)
-    log.error('')
+            logger.error(l)
+    logger.error('')
 
 
 def log_message(message, logger=''):
@@ -52,9 +53,10 @@ def log_message(message, logger=''):
     :param message: Message
     :param logger: Name of the logger (defaults to root)
     """
-    log = logging.getLogger(logger)
+    if isinstance(logger, basestring):
+        logger = logging.getLogger(logger)
     for line in message.splitlines():
-        log.error(line)
+        logger.error(line)
 
 
 def analyze_unpickable_item(path_prefix, obj):

--- a/avocado/utils/stacktrace.py
+++ b/avocado/utils/stacktrace.py
@@ -27,7 +27,7 @@ def prepare_exc_info(exc_info):
     return "".join(tb_info(exc_info))
 
 
-def log_exc_info(exc_info, logger='root'):
+def log_exc_info(exc_info, logger=''):
     """
     Log exception info to logger_name.
 
@@ -45,7 +45,7 @@ def log_exc_info(exc_info, logger='root'):
     log.error('')
 
 
-def log_message(message, logger='root'):
+def log_message(message, logger=''):
     """
     Log message to logger.
 

--- a/docs/source/Plugins.rst
+++ b/docs/source/Plugins.rst
@@ -44,6 +44,7 @@ Code example
 Let's say you want to write a plugin that adds a new subcommand to the test
 runner, ``hello``. This is how you'd do it::
 
+    from avocado.core.output import LOG_JOB
     from avocado.core.plugin_interfaces import CLICmd
 
 
@@ -53,13 +54,17 @@ runner, ``hello``. This is how you'd do it::
         description = 'The classical Hello World! plugin example.'
 
         def run(self, args):
-            print(self.description)
+            LOG_JOB.info(self.description)
 
 As you can see, this plugins inherits from :class:`avocado.core.plugin_interfaces.CLICmd`.
 This specific base class allows for the creation of new commands for the Avocado
 CLI tool. The only mandatory method to be implemented is :func:`run
 <avocado.core.plugin_interfaces.CLICmd.run>` and it's the plugin main entry point.
-In this code example it will simply print the plugin's description.
+
+This plugin uses :py:data:`avocado.core.output.LOG_JOB` to produce the hello
+world output in the Job log. One can also use
+:py:data:`avocado.core.output.LOG_UI` to produce output in the human readable
+output.
 
 Registering Plugins
 ~~~~~~~~~~~~~~~~~~~

--- a/examples/plugins/job-pre-post/mail/avocado_job_mail.py
+++ b/examples/plugins/job-pre-post/mail/avocado_job_mail.py
@@ -1,7 +1,7 @@
-import logging
 import smtplib
 from email.mime.text import MIMEText
 
+from avocado.core.output import LOG_UI
 from avocado.core.settings import settings
 from avocado.core.plugin_interfaces import JobPre, JobPost
 
@@ -12,7 +12,6 @@ class Mail(JobPre, JobPost):
     description = 'Sends mail to notify on job start/end'
 
     def __init__(self):
-        self.log = logging.getLogger("avocado.app")
         self.rcpt = settings.get_value(section="plugins.job.mail",
                                        key="recipient",
                                        key_type=str,
@@ -46,7 +45,7 @@ class Mail(JobPre, JobPost):
             smtp.sendmail(self.sender, [self.rcpt], msg.as_string())
             smtp.quit()
         except:
-            self.log.error("Failure to send email notification: "
-                           "please check your mail configuration")
+            LOG_UI.error("Failure to send email notification: "
+                         "please check your mail configuration")
 
     pre = post = mail

--- a/examples/plugins/job-pre-post/sleep/avocado_job_sleep.py
+++ b/examples/plugins/job-pre-post/sleep/avocado_job_sleep.py
@@ -1,6 +1,6 @@
 import time
-import logging
 
+from avocado.core.output import LOG_UI
 from avocado.core.settings import settings
 from avocado.core.plugin_interfaces import JobPre, JobPost
 
@@ -11,7 +11,6 @@ class Sleep(JobPre, JobPost):
     description = 'Sleeps for a number of seconds'
 
     def __init__(self):
-        self.log = logging.getLogger("avocado.app")
         self.seconds = settings.get_value(section="plugins.job.sleep",
                                           key="seconds",
                                           key_type=int,
@@ -19,7 +18,7 @@ class Sleep(JobPre, JobPost):
 
     def sleep(self, job):
         for i in xrange(1, self.seconds + 1):
-            self.log.info("Sleeping %2i/%s", i, self.seconds)
+            LOG_UI.info("Sleeping %2i/%s", i, self.seconds)
             time.sleep(1)
 
     pre = post = sleep

--- a/optional_plugins/html/avocado_result_html/__init__.py
+++ b/optional_plugins/html/avocado_result_html/__init__.py
@@ -27,6 +27,7 @@ import pkg_resources
 import pystache
 
 from avocado.core import exit_codes
+from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLI, Result
 
 
@@ -258,15 +259,14 @@ class HTMLResult(Result):
                 report_contents = v.render('utf8')
         except UnicodeDecodeError as details:
             # FIXME: Remove me when UnicodeDecodeError problem is fixed
-            import logging
-            ui = logging.getLogger("avocado.app")
-            ui.critical("\n" + ("-" * 80))
-            ui.critical("HTML failed to render the template: %s\n\n",
-                        template)
-            ui.critical("-" * 80)
-            ui.critical("%s:\n\n", details)
-            ui.critical("%r", getattr(details, "object", "object not found"))
-            ui.critical("-" * 80)
+            LOG_UI.critical("\n" + ("-" * 80))
+            LOG_UI.critical("HTML failed to render the template: %s\n\n",
+                            template)
+            LOG_UI.critical("-" * 80)
+            LOG_UI.critical("%s:\n\n", details)
+            LOG_UI.critical("%r", getattr(details, "object",
+                                          "object not found"))
+            LOG_UI.critical("-" * 80)
             raise
 
         self._copy_static_resources(output_path)
@@ -289,8 +289,7 @@ class HTMLResult(Result):
             html_path = os.path.join(html_dir, 'results.html')
             self._render(result, html_path)
             if getattr(job.args, 'stdout_claimed_by', None) is None:
-                log = logging.getLogger("avocado.app")
-                log.info("JOB HTML   : %s", html_path)
+                LOG_UI.info("JOB HTML   : %s", html_path)
             if open_browser:
                 self._open_browser(html_path)
                 open_browser = False
@@ -345,7 +344,6 @@ class HTML(CLI):
 
     def run(self, args):
         if 'html_output' in args and args.html_output == '-':
-            log = logging.getLogger("avocado.app")
-            log.error('HTML to stdout not supported (not all HTML resources '
-                      'can be embedded on a single file)')
+            LOG_UI.error('HTML to stdout not supported (not all HTML resources'
+                         ' can be embedded on a single file)')
             sys.exit(exit_codes.AVOCADO_JOB_FAIL)

--- a/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
+++ b/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
@@ -33,6 +33,7 @@ from avocado.core import exit_codes
 from avocado.core import loader
 from avocado.core import output
 from avocado.core import status
+from avocado.core.output import LOG_JOB, LOG_UI
 from avocado.core.plugin_interfaces import CLI
 from avocado.core.runner import TestRunner
 from avocado.core.settings import settings
@@ -491,7 +492,7 @@ class RemoteTestRunner(TestRunner):
                     raise exceptions.JobError('Remote machine does not seem to'
                                               ' have avocado installed')
             except Exception as details:
-                stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
+                stacktrace.log_exc_info(sys.exc_info(), logger=LOG_JOB)
                 raise exceptions.JobError(details)
             results = self.run_test(self.job.references, timeout)
             remote_log_dir = os.path.dirname(results['debuglog'])
@@ -538,7 +539,7 @@ class RemoteTestRunner(TestRunner):
             try:
                 self.tear_down()
             except Exception as details:
-                stacktrace.log_exc_info(sys.exc_info(), logger='avocado.test')
+                stacktrace.log_exc_info(sys.exc_info(), logger=LOG_JOB)
                 raise exceptions.JobError(details)
             sys.stdout = stdout_backup
             sys.stderr = stderr_backup
@@ -616,10 +617,9 @@ class RemoteCLI(CLI):
             if not getattr(args, arg):
                 missing.append(arg)
         if missing:
-            log = logging.getLogger("avocado.app")
-            log.error("Use of %s requires %s arguments to be set. Please set "
-                      "%s.", enable_arg, ', '.join(required_args),
-                      ', '.join(missing))
+            LOG_UI.error("Use of %s requires %s arguments to be set. Please "
+                         "set %s.", enable_arg, ', '.join(required_args),
+                         ', '.join(missing))
 
             return sys.exit(exit_codes.AVOCADO_FAIL)
         return True

--- a/optional_plugins/runner_vm/avocado_runner_vm/__init__.py
+++ b/optional_plugins/runner_vm/avocado_runner_vm/__init__.py
@@ -21,7 +21,7 @@ from xml.dom import minidom
 
 import libvirt
 
-from avocado.core import exit_codes
+from avocado.core import exit_codes, exceptions
 from avocado.core.plugin_interfaces import CLI
 from avocado_runner_remote import Remote, RemoteTestRunner
 

--- a/optional_plugins/runner_vm/avocado_runner_vm/__init__.py
+++ b/optional_plugins/runner_vm/avocado_runner_vm/__init__.py
@@ -22,6 +22,7 @@ from xml.dom import minidom
 import libvirt
 
 from avocado.core import exit_codes, exceptions
+from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLI
 from avocado_runner_remote import Remote, RemoteTestRunner
 
@@ -491,10 +492,9 @@ class VMCLI(CLI):
             if not getattr(args, arg):
                 missing.append(arg)
         if missing:
-            log = logging.getLogger("avocado.app")
-            log.error("Use of %s requires %s arguments to be set. Please set "
-                      "%s.", enable_arg, ', '.join(required_args),
-                      ', '.join(missing))
+            LOG_UI.error("Use of %s requires %s arguments to be set. Please "
+                         "set %s.", enable_arg, ', '.join(required_args),
+                         ', '.join(missing))
 
             return sys.exit(exit_codes.AVOCADO_FAIL)
         return True


### PR DESCRIPTION
Those two loggers are essential (not only) for plugin writers. I think we ought to make them part of the public API. While on it there are two minor bugfixes...

v1: https://github.com/avocado-framework/avocado/pull/1989

changes:
```yaml
v2: Split the main commit
v2: Don't make LOG_{UI,TEST} public yet, but only define it in `avocado.core.output`
v2: Add documentation
v2: Update the remaining occurrences from `optional_plugins` and `examples`
```