### PR TITLE
Selftests: introduce multiple test levels [v2]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ script:
             echo
             echo
             git checkout $COMMIT || ERR=$(echo -e "$ERR\nUnable to checkout $(git log -1 --oneline $COMMIT)")
-            AVOCADO_RESULTSDIR_CHECK=y SELF_CHECK_CONTINUOUS=y make check || ERR=$(echo -e "$ERR\nmake check of $(git log -1 --oneline) failed")
+            AVOCADO_RESULTSDIR_CHECK=y SELF_CHECK_CONTINUOUS=y make check-extended || ERR=$(echo -e "$ERR\nmake check of $(git log -1 --oneline) failed")
             make clean
         done
         if [ "$ERR" ]; then

--- a/Makefile
+++ b/Makefile
@@ -35,13 +35,14 @@ MOCK_CONFIG=default
 all:
 	@echo
 	@echo "Development related targets:"
-	@echo "check:      Runs tree static check, unittests and fast functional tests"
-	@echo "check-full: Runs tree static check, unittests and all functional tests"
-	@echo "develop:    Runs 'python setup.py --develop on this tree alone"
-	@echo "link:       Runs 'python setup.py --develop' in all subprojects and links the needed resources"
-	@echo "clean:      Get rid of scratch, byte files and removes the links to other subprojects"
-	@echo "selfcheck:  Runs tree static check, unittests and functional tests using Avocado itself"
-	@echo "spell:      Runs spell checker on comments and docstrings (requires python-enchant)"
+	@echo "check:          Runs tree static check, unittests and fast functional tests"
+	@echo "check-extended: Runs tree static check, unittests and most functional tests"
+	@echo "check-full:     Runs tree static check, and all unittests and functional tests"
+	@echo "develop:        Runs 'python setup.py --develop on this tree alone"
+	@echo "link:           Runs 'python setup.py --develop' in all subprojects and links the needed resources"
+	@echo "clean:          Get rid of scratch, byte files and removes the links to other subprojects"
+	@echo "selfcheck:      Runs tree static check, unittests and functional tests using Avocado itself"
+	@echo "spell:          Runs spell checker on comments and docstrings (requires python-enchant)"
 	@echo
 	@echo "Package requirements related targets"
 	@echo "requirements:            Install runtime requirements"
@@ -158,11 +159,16 @@ smokecheck: clean develop
 	./scripts/avocado run passtest.py
 
 check: clean develop check_cyclical modules_boundaries
+	# Unless manually set, this is equivalent to AVOCADO_CHECK_LEVEL=0
 	selftests/checkall
 	selftests/check_tmp_dirs
 
+check-extended:	clean develop check_cyclical modules_boundaries
+	AVOCADO_CHECK_LEVEL=1 selftests/checkall
+	selftests/check_tmp_dirs
+
 check-full: clean develop check_cyclical modules_boundaries
-	AVOCADO_CHECK_FULL=1 selftests/checkall
+	AVOCADO_CHECK_LEVEL=2 selftests/checkall
 	selftests/check_tmp_dirs
 
 selfcheck: clean check_cyclical modules_boundaries develop

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -175,7 +175,10 @@ popd
 pushd optional_plugins/resultsdb
 %{__python} setup.py develop --user
 popd
-selftests/run
+# Package build environments have the least amount of resources
+# we have observed so far.  Let's avoid tests that require too
+# much resources or are time sensitive
+AVOCADO_CHECK_LEVEL=0 selftests/run
 %endif
 
 %files
@@ -320,6 +323,7 @@ examples of how to write tests on your own.
 %changelog
 * Thu Apr 27 2017 Cleber Rosa <cleber@redhat.com> - 49.0-2
 - Also setup resultsdb plugin on check
+- Be explicit about selftest level run on check
 
 * Tue Apr 25 2017 Cleber Rosa <cleber@redhat.com> - 49.0-1
 - Added missing runner-docker directory

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -189,7 +189,7 @@ AVOCADO_CHECK_LEVEL=0 selftests/run
 %dir /etc/avocado/sysinfo
 %dir /etc/avocado/scripts/job/pre.d
 %dir /etc/avocado/scripts/job/post.d
-%dir %{_sharedstatedir}/avocado/data
+%dir %{_sharedstatedir}/avocado
 %config(noreplace)/etc/avocado/avocado.conf
 %config(noreplace)/etc/avocado/conf.d/README
 %config(noreplace)/etc/avocado/conf.d/gdb.conf
@@ -324,6 +324,7 @@ examples of how to write tests on your own.
 * Thu Apr 27 2017 Cleber Rosa <cleber@redhat.com> - 49.0-2
 - Also setup resultsdb plugin on check
 - Be explicit about selftest level run on check
+- Take ownership of base avocado data dir (/var/lib/avocado)
 
 * Tue Apr 25 2017 Cleber Rosa <cleber@redhat.com> - 49.0-1
 - Added missing runner-docker directory

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -29,7 +29,7 @@
 Summary: Framework with tools and libraries for Automated Testing
 Name: python-%{srcname}
 Version: 49.0
-Release: 1%{?gitrel}%{?dist}
+Release: 2%{?gitrel}%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.github.io/
@@ -170,6 +170,9 @@ pushd optional_plugins/runner_vm
 %{__python} setup.py develop --user
 popd
 pushd optional_plugins/runner_docker
+%{__python} setup.py develop --user
+popd
+pushd optional_plugins/resultsdb
 %{__python} setup.py develop --user
 popd
 selftests/run
@@ -315,6 +318,9 @@ examples of how to write tests on your own.
 %{_datadir}/avocado/wrappers
 
 %changelog
+* Thu Apr 27 2017 Cleber Rosa <cleber@redhat.com> - 49.0-2
+- Also setup resultsdb plugin on check
+
 * Tue Apr 25 2017 Cleber Rosa <cleber@redhat.com> - 49.0-1
 - Added missing runner-docker directory
 

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -368,7 +368,7 @@ class RunnerOperationTest(unittest.TestCase):
         # Ensure no test aborted error messages show up
         self.assertNotIn("TestAbortedError: Test aborted unexpectedly", output)
 
-    @unittest.skipIf(os.environ.get("AVOCADO_CHECK_FULL") != "1",
+    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 2,
                      "Skipping test that take a long time to run, are "
                      "resource intensive or time sensitve")
     def test_runner_abort(self):
@@ -650,7 +650,7 @@ class RunnerSimpleTest(unittest.TestCase):
                          "Avocado did not return rc %d:\n%s" %
                          (expected_rc, result))
 
-    @unittest.skipIf(os.environ.get("AVOCADO_CHECK_FULL") != "1",
+    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 2,
                      "Skipping test that take a long time to run, are "
                      "resource intensive or time sensitve")
     def test_runner_onehundred_fail_timing(self):

--- a/selftests/functional/test_interrupt.py
+++ b/selftests/functional/test_interrupt.py
@@ -121,6 +121,9 @@ class InterruptTest(unittest.TestCase):
         # Make sure the Killing test subprocess message did appear
         self.assertIn('Killing test subprocess', proc.get_output())
 
+    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 1,
+                     "Skipping test that take a long time to run, are "
+                     "resource intensive or time sensitve")
     def test_well_behaved(self):
         """
         Make sure avocado can cleanly get out of a loop of well behaved tests.

--- a/selftests/functional/test_interrupt.py
+++ b/selftests/functional/test_interrupt.py
@@ -55,7 +55,7 @@ class InterruptTest(unittest.TestCase):
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
 
-    @unittest.skipIf(os.environ.get("AVOCADO_CHECK_FULL") != "1",
+    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 2,
                      "Skipping test that take a long time to run, are "
                      "resource intensive or time sensitve")
     def test_badly_behaved(self):

--- a/selftests/functional/test_loader.py
+++ b/selftests/functional/test_loader.py
@@ -215,7 +215,7 @@ class LoaderTestFunctional(unittest.TestCase):
     def test_load_not_a_test_not_exec(self):
         self._test('notatest.py', NOT_A_TEST, 'NOT_A_TEST')
 
-    @unittest.skipIf(os.environ.get("AVOCADO_CHECK_FULL") != "1",
+    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 2,
                      "Skipping test that take a long time to run, are "
                      "resource intensive or time sensitve")
     def test_runner_simple_python_like_multiple_files(self):

--- a/selftests/functional/test_utils.py
+++ b/selftests/functional/test_utils.py
@@ -170,7 +170,7 @@ class FileLockTest(unittest.TestCase):
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
 
-    @unittest.skipIf(os.environ.get("AVOCADO_CHECK_FULL") != "1",
+    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 2,
                      "Skipping test that take a long time to run, are "
                      "resource intensive or time sensitve")
     def test_filelock(self):

--- a/selftests/run_coverage
+++ b/selftests/run_coverage
@@ -7,7 +7,7 @@
 
 coverage erase
 rm .coverage.*
-AVOCADO_CHECK_FULL=1 UNITTEST_AVOCADO_CMD="coverage run -p --include 'avocado/*' ./scripts/avocado" coverage run -p --include "avocado/*" ./selftests/run
+AVOCADO_CHECK_LEVEL=2 UNITTEST_AVOCADO_CMD="coverage run -p --include 'avocado/*' ./scripts/avocado" coverage run -p --include "avocado/*" ./selftests/run
 coverage combine .coverage*
 echo
 coverage report -m --include "avocado/core/*"


### PR DESCRIPTION
A finer level of granularity may help to extend our testing coverage while reducing the amount of false positives.  Also, one (somewhat related) packaging fixes was squeezed in here.

**There should be changes on tests run on current environments**, besides the explicit move into level 1 on the second-last commit.

---

Changes from v1 (#1968):
 * Made the `AVOCADO_CHECK_LEVEL=0` implicit on Makefile `check` target
 * Moved `InterruptTest.test_well_behaved` into level 1
 * Removed the trailing `*` from the avocado data dir.