### PR TITLE
Makefile: add requirements-plugins target [v4]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,9 +150,15 @@ requirements-selftests: requirements
 	- pip install -r requirements-selftests.txt
 
 requirements-plugins: requirements
-	for MAKEFILE in $(AVOCADO_PLUGINS);\
-		do AVOCADO_DIRNAME=$(AVOCADO_DIRNAME) make -C $$MAKEFILE requirements &>/dev/null && echo ">> DONE $$MAKEFILE" || echo ">> SKIP $$MAKEFILE";\
-	done
+	for MAKEFILE in $(AVOCADO_PLUGINS);do\
+		if test -f $$MAKEFILE/Makefile; then echo ">> REQUIREMENTS (Makefile) $$MAKEFILE";\
+                         if test -f $$MAKEFILE/Makefile; then AVOCADO_DIRNAME=$(AVOCADO_DIRNAME) make -C $$MAKEFILE requirement &>/dev/null; fi;\
+		elif test -f $$MAKEFILE/setup.py -o -f $$MAKEFILE/requirements.txt; then echo ">> REQUIREMENTS (setup.py/requirements.txt) $$MAKEFILE";\
+			if test -f $$MAKEFILE/setup.py; then cd $$MAKEFILE; $(PYTHON) setup.py develop $(PYTHON_DEVELOP_ARGS); cd -; fi;\
+			if test -f $$MAKEFILE/requirements.txt; then pip install $(PYTHON_DEVELOP_ARGS) -r $$MAKEFILE/requirements.txt; fi;\
+		else echo ">> SKIP $$MAKEFILE";\
+                fi;\
+	done;
 
 smokecheck: clean develop
 	./scripts/avocado run passtest.py


### PR DESCRIPTION
Similar to make link, the requirements-plugins target walks through
the plugins and install dependencies.

It checks if the plugin has either:

 * A Makefile
 * A setup.py and/or a requirements.txt file

https://trello.com/c/R9rxte6o/608-add-make-requirements-plugins

Signed-off-by: Greeshma Gopinath <ggopinat@redhat.com>
Signed-off-by: Cleber Rosa <crosa@redhat.com>

---

Changes from v3 (#1866):
 * Fixed pip invocation (was calling with an additional dir)
 * Broke into Makefile *or* setup.py+requirements.txt conditional