### PR TITLE
html: ignore missing params

### DIFF
--- a/optional_plugins/html/avocado_result_html/__init__.py
+++ b/optional_plugins/html/avocado_result_html/__init__.py
@@ -121,9 +121,15 @@ class ReportModel(object):
             formatted = {}
             formatted['uid'] = tst['name'].uid
             formatted['name'] = tst['name'].name
-            params = 'Params:\n'
-            for path, key, value in tst['params'].iteritems():
-                params += '  %s:%s => %s\n' % (path, key, value)
+            params = ''
+            try:
+                parameters = 'Params:\n'
+                for path, key, value in tst['params'].iteritems():
+                    parameters += '  %s:%s => %s\n' % (path, key, value)
+            except KeyError:
+                pass
+            else:
+                params = parameters
             formatted['params'] = params
             formatted['variant'] = tst['name'].variant or ''
             formatted['status'] = tst['status']


### PR DESCRIPTION
Generate the html report even if `state['params']` is not available.