### PR TITLE
test: always execute tearDown()

### DIFF
--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -520,6 +520,11 @@ If you need to perform setup actions before/after your test, you may do so
 in the ``setUp`` and ``tearDown`` methods, respectively. We'll give examples
 in the following section.
 
+The ``teadDown`` method is always executed (unless the test is skipped).
+Even if something goes wrong in ``setUp``, generating an exception, the
+``tearDown`` will be called to make sure your environment is properly
+cleaned up.
+
 Running third party test suites
 ===============================
 

--- a/selftests/functional/test_test.py
+++ b/selftests/functional/test_test.py
@@ -1,0 +1,69 @@
+import json
+import os
+import shutil
+import tempfile
+import unittest
+
+from avocado.core import exit_codes
+from avocado.utils import process
+from avocado.utils import script
+
+basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..')
+basedir = os.path.abspath(basedir)
+
+AVOCADO = os.environ.get("UNITTEST_AVOCADO_CMD", "./scripts/avocado")
+
+TEST_SETUP_EXCEPTION = """
+import avocado
+
+class AvocadoTest(avocado.Test):
+
+    def setUp(self):
+        self.log.info('setup code before')
+        raise
+        self.log.info('setup code after')
+
+    def test(self):
+        self.log.info('test code')
+
+    def tearDown(self):
+        self.log.info('teardown code')
+"""
+
+
+class TestTest(unittest.TestCase):
+
+    def setUp(self):
+        os.chdir(basedir)
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+
+        test_path = os.path.join(self.tmpdir, 'test_setup_exception.py')
+        self.test_setup_exception = script.Script(test_path,
+                                                  TEST_SETUP_EXCEPTION)
+        self.test_setup_exception.save()
+
+    def test_setup_exception(self):
+        os.chdir(basedir)
+        cmd_line = [AVOCADO,
+                    'run',
+                    '--sysinfo=off',
+                    '--job-results-dir',
+                    '%s' % self.tmpdir,
+                    '%s' % self.test_setup_exception,
+                    '--json -']
+        result = process.run(' '.join(cmd_line), ignore_status=True)
+        json_results = json.loads(result.stdout)
+        debuglog = json_results['debuglog']
+        self.assertEqual(result.exit_status, exit_codes.AVOCADO_TESTS_FAIL)
+        self.assertEqual(json_results['errors'], 1)
+        self.assertIn('setup code before', open(debuglog, 'r').read())
+        self.assertNotIn('setup code after', open(debuglog, 'r').read())
+        self.assertNotIn('test code', open(debuglog, 'r').read())
+        self.assertIn('teardown code', open(debuglog, 'r').read())
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Currently, when something goes wrong in setUp(), tearDown() is not
executed. This patch changes the behaviour of our Test class, making the
tearDown() to be always executed, regardless what happens in setUp().

Reference: https://trello.com/c/zSZ4xFwp
Signed-off-by: Amador Pahim <apahim@redhat.com>