### PR TITLE
Makefile: remove 'egg' directories on make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,7 @@ clean:
 	rm -rf /var/tmp/avocado*
 	rm -rf /tmp/avocado*
 	find . -name '*.pyc' -delete
+	find $(AVOCADO_OPTIONAL_PLUGINS) -name '*.egg-info' -exec rm -r {} +
 
 pip:
 	$(PYTHON) -m pip --version || $(PYTHON) -c "import os; import sys; import urllib; f = urllib.urlretrieve('https://bootstrap.pypa.io/get-pip.py')[0]; os.system('%s %s' % (sys.executable, f))"


### PR DESCRIPTION
Make clean is missing the egg directories. This patch includes in make
clean a command to remove them.

Reference: https://trello.com/c/VgF0fkEa
Signed-off-by: Amador Pahim <apahim@redhat.com>