### PR TITLE
Makefile: also remove 36lts "egg-info" dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,8 @@ clean:
 	rm -rf /tmp/avocado*
 	find . -name '*.pyc' -delete
 	find $(AVOCADO_OPTIONAL_PLUGINS) -name '*.egg-info' -exec rm -r {} +
+	# Remove this after 36lts is declared EOL
+	rm -rf avocado.egg-info
 
 pip:
 	$(PYTHON) -m pip --version || $(PYTHON) -c "import os; import sys; import urllib; f = urllib.urlretrieve('https://bootstrap.pypa.io/get-pip.py')[0]; os.system('%s %s' % (sys.executable, f))"


### PR DESCRIPTION
When switching between 36lts and master branch, content from 36lts
(the .egg-info dir) may be kept.  The reason for that is that 36lts
used "avocado" as the module name, and thus produces
"avocado.egg-info" dir.

Signed-off-by: Cleber Rosa <crosa@redhat.com>