### PR TITLE
Lower stevedore version requirement

### DIFF
--- a/requirements-selftests.txt
+++ b/requirements-selftests.txt
@@ -23,5 +23,5 @@ pydot>=1.2.3
 aexpect>=1.0.0
 psutil>=3.1.1
 # stevedore for loading "new style" plugins
-stevedore>=1.8.0
+stevedore>=0.14
 lxml>=3.4.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ pyliblzma>=0.5.3
 # REST client (avocado.core.restclient)
 requests>=1.2.3
 # stevedore for loading "new style" plugins
-stevedore>=1.8.0
+stevedore>=0.14

--- a/setup.py
+++ b/setup.py
@@ -173,4 +173,4 @@ if __name__ == '__main__':
           zip_safe=False,
           test_suite='selftests',
           python_requires='>=2.7',
-          install_requires=['stevedore>=1.8.0'])
+          install_requires=['stevedore>=0.14'])


### PR DESCRIPTION
The current requirement set for the stevedore library doing build/use
of Avocado doesn't actually reflect the minimum version needed.

The proof is that Avocado on EL7, when installed from packages, will
run just fine with 0.14, the version that ships on that distro.

Without this change, package builds on EL7 attempt to download a newer
(Python) module:

    Processing dependencies for avocado-framework==50.0
    Searching for stevedore>=1.8.0
    Reading https://pypi.python.org/simple/stevedore/
    Best match: stevedore 1.21.0
    Downloading  https://pypi.python.org/[...]/stevedore-1.21.0.tar.gz[...]

With this change, no download is attempted:

    Processing dependencies for avocado-framework==50.0
    Searching for stevedore==0.14
    Best match: stevedore 0.14
    Adding stevedore 0.14 to easy-install.pth file
    Using /usr/lib/python2.7/site-packages
    Finished processing dependencies for avocado-framework==50.0

A couple of stevedore requirement mentions were preserved. Explanation:

 * requirements-docs.txt: it's used on readthedocs.org only
 * requirements-travis.txt: it's used Travis-CI only

Signed-off-by: Cleber Rosa <crosa@redhat.com>