### PR TITLE
Py3k support: `avocado` runs (no plugins) and tests run (many failures)

### DIFF
--- a/avocado/core/dispatcher.py
+++ b/avocado/core/dispatcher.py
@@ -20,6 +20,7 @@ import sys
 from stevedore import EnabledExtensionManager
 
 from .settings import settings
+from .settings import SettingsError
 from .output import LOG_UI
 from ..utils import stacktrace
 
@@ -71,8 +72,17 @@ class Dispatcher(EnabledExtensionManager):
         return "plugins.%s" % self.plugin_type()
 
     def enabled(self, extension):
-        disabled = settings.get_value('plugins', 'disable', key_type=list)
-        return self.fully_qualified_name(extension) not in disabled
+        """
+        Checks configuration for explicit mention of plugin in a disable list
+
+        If configuration section or key doesn't exist, it means no plugin
+        is disabled.
+        """
+        try:
+            disabled = settings.get_value('plugins', 'disable', key_type=list)
+            return self.fully_qualified_name(extension) not in disabled
+        except SettingsError:
+            return False
 
     def names(self):
         """

--- a/avocado/core/mux.py
+++ b/avocado/core/mux.py
@@ -22,9 +22,9 @@ a custom Varianter plugin.
 #
 
 import collections
+import hashlib
 import itertools
 import re
-import sha
 
 from . import output
 from . import tree
@@ -172,7 +172,7 @@ class MuxPlugin(object):
             variant.sort(key=lambda x: x.path)
             fingerprint = "-".join(_.fingerprint() for _ in variant)
             variant_ids.append("-".join(node.name for node in variant) + '-' +
-                               sha.sha(fingerprint).hexdigest()[:4])
+                               hashlib.sha1(fingerprint).hexdigest()[:4])
         return variant_ids
 
     def __iter__(self):

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -92,7 +92,7 @@ class TermSupport(object):
                          'screen-256color', 'screen.xterm-256color']
         term = os.environ.get("TERM")
         colored = settings.get_value('runner.output', 'colored',
-                                     key_type='bool')
+                                     key_type='bool', default=True)
         if not colored or not os.isatty(1) or term not in allowed_terms:
             self.disable()
 

--- a/avocado/core/settings.py
+++ b/avocado/core/settings.py
@@ -223,6 +223,23 @@ class Settings(object):
         else:
             return default
 
+    def _handle_no_section(self, section, default):
+        """
+        What to do if section doesn't exist.
+
+        :param section: Config file section.
+        :param default: Default value for key, in case it does not exist.
+
+        :returns: Default value, if a default value was provided.
+
+        :raises: SettingsError, in case no default was provided.
+        """
+        if default is self.no_default:
+            msg = "Section '%s' doesn't exist in configuration" % section
+            raise SettingsError(msg)
+        else:
+            return default
+
     def get_value(self, section, key, key_type=str, default=no_default,
                   allow_blank=False):
         """
@@ -250,6 +267,8 @@ class Settings(object):
         """
         try:
             val = self.config.get(section, key)
+        except ConfigParser.NoSectionError:
+            return self._handle_no_section(section, default)
         except ConfigParser.Error:
             return self._handle_no_value(section, key, default)
 

--- a/selftests/functional/test_loader.py
+++ b/selftests/functional/test_loader.py
@@ -207,7 +207,7 @@ class LoaderTestFunctional(unittest.TestCase):
 
     def test_multiple_methods_same_name(self):
         self._test('multiplemethods.py', AVOCADO_TEST_MULTIPLE_METHODS_SAME_NAME,
-                   'INSTRUMENTED', 0664, 1)
+                   'INSTRUMENTED', self.MODE_0664, 1)
 
     def test_load_not_a_test(self):
         self._test('notatest.py', NOT_A_TEST, 'SIMPLE', self.MODE_0775)
@@ -223,7 +223,7 @@ class LoaderTestFunctional(unittest.TestCase):
             'test2.py',
             AVOCADO_SIMPLE_PYTHON_LIKE_MULTIPLE_FILES_LIB,
             'avocado_simpletest_functional',
-            0644)
+            self.MODE_0644)
         mylib.save()
         mytest = script.Script(
             os.path.join(os.path.dirname(mylib.path), 'test.py'),

--- a/selftests/functional/test_lv_utils.py
+++ b/selftests/functional/test_lv_utils.py
@@ -3,6 +3,7 @@ avocado.utils.lv_utils selftests
 :author: Lukas Doktor <ldoktor@redhat.com>
 :copyright: 2016 Red Hat, Inc
 """
+from __future__ import print_function
 from avocado.utils import process, lv_utils
 import glob
 import os
@@ -58,10 +59,10 @@ class LVUtilsTest(unittest.TestCase):
                 res = process.run("rmmod scsi_debug", ignore_status=True,
                                   sudo=True)
                 if not res.exit_status:
-                    print "scsi_debug removed"
+                    print("scsi_debug removed")
                     break
             else:
-                print "Fail to remove scsi_debug: %s" % res
+                print("Fail to remove scsi_debug: %s" % res)
         for _ in xrange(10):
             res = process.run("rmmod scsi_debug", ignore_status=True,
                               sudo=True)
@@ -126,16 +127,16 @@ class LVUtilsTest(unittest.TestCase):
                 process.run("mountpoint %s && umount %s"
                             % (mount_loc, mount_loc), shell=True, sudo=True)
             except BaseException as details:
-                print "Fail to unmount LV: %s" % details
+                print("Fail to unmount LV: %s" % details)
             try:
                 lv_utils.lv_remove(vg_name, lv_name)
             except BaseException as details:
-                print "Fail to cleanup LV: %s" % details
+                print("Fail to cleanup LV: %s" % details)
             try:
                 lv_utils.vg_ramdisk_cleanup(ramdisk_filename, vg_ramdisk_dir,
                                             vg_name, loop_device)
             except BaseException as details:
-                print "Fail to cleanup vg_ramdisk: %s" % details
+                print("Fail to cleanup vg_ramdisk: %s" % details)
             raise
 
 


### PR DESCRIPTION
This is yet another round of Python 3 compatibility patches.  At this point:
 * `avocado` runs, but no plugins are loaded
* `python3 setup.py test` also runs, but of course, there are many failures.  It looks like most of the failures are related to byte/string issues

To test this, please run `python3 setup.py develop --user` before trials.