### PR TITLE
runner: Allow to specify suite order

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -445,10 +445,12 @@ class Job(object):
         jobdata.record(self.args, self.logdir, variant, self.references,
                        sys.argv)
         replay_map = getattr(self.args, 'replay_map', None)
+        suite_order = getattr(self.args, "suite_order", None)
         summary = self.test_runner.run_suite(self.test_suite,
                                              variant,
                                              self.timeout,
-                                             replay_map)
+                                             replay_map,
+                                             suite_order)
         # If it's all good so far, set job status to 'PASS'
         if self.status == 'RUNNING':
             self.status = 'PASS'

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -99,6 +99,12 @@ class Run(CLICmd):
                             "system information (hardware details, profilers, "
                             "etc.). Current:  %(default)s")
 
+        parser.add_argument("--suite-order", default="variants-per-test",
+                            choices=("tests-per-variant",
+                                     "variants-per-test"),
+                            help="How to iterate through test suite and "
+                            "variants")
+
         parser.output = parser.add_argument_group('output and result format')
 
         parser.output.add_argument('-s', '--silent', action="store_true",

--- a/docs/source/TestParameters.rst
+++ b/docs/source/TestParameters.rst
@@ -31,8 +31,8 @@ Overall picture of how the params handling works is:
              |  // single variant is passed to Test
              |
        +-----------+
-       |  Runner   |  // iterates through tests and runs each test with
-       +-----^-----+  // all variants supplied by Varianter
+       |  Runner   |  // iterates through tests and variants to run all
+       +-----^-----+  // desired combinations specified by "--suite-order"
              |
              |
    +-------------------+ provide variants +-----------------------+

--- a/man/avocado.rst
+++ b/man/avocado.rst
@@ -90,6 +90,8 @@ Options for subcommand `run` (`avocado run --help`)::
                             debugging). Defaults to off.
       --sysinfo {on,off}    Enable or disable system information (hardware
                             details, profilers, etc.). Current: on
+      --suite-order {tests-per-variant,variants-per-test}
+                            How to iterate through test suite and variants
 
     output and result format:
       -s, --silent          Silence stdout

--- a/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
+++ b/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
@@ -448,7 +448,8 @@ class RemoteTestRunner(TestRunner):
 
         return json_result
 
-    def run_suite(self, test_suite, variants, timeout=0, replay_map=None):
+    def run_suite(self, test_suite, variants, timeout=0, replay_map=None,
+                  suite_order="variants-per-test"):
         """
         Run one or more tests and report with test result.
 
@@ -459,6 +460,10 @@ class RemoteTestRunner(TestRunner):
         """
         del test_suite     # using self.job.references instead
         del variants            # we're not using multiplexation here
+        if suite_order != "variants-per-test" and suite_order is not None:
+            raise exceptions.JobError("suite-order %s is not supported for"
+                                      " remote execution." % suite_order)
+        del suite_order     # suite_order is ignored for now
         if not timeout:     # avoid timeout = 0
             timeout = None
         summary = set()

--- a/selftests/functional/test_multiplex.py
+++ b/selftests/functional/test_multiplex.py
@@ -92,7 +92,24 @@ class MultiplexTests(unittest.TestCase):
                     'examples/tests/sleeptest.py.data/sleeptest.yaml'
                     % (AVOCADO, self.tmpdir))
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
-        self.run_and_check(cmd_line, expected_rc, (4, 4))
+        result = self.run_and_check(cmd_line, expected_rc, (4, 4))
+        self.assertIn("(1/8) passtest.py:PassTest.test;short", result.stdout)
+        self.assertIn("(2/8) passtest.py:PassTest.test;medium", result.stdout)
+        self.assertIn("(8/8) failtest.py:FailTest.test;longest",
+                      result.stdout)
+
+    def test_run_mplex_failtest_tests_per_variant(self):
+        cmd_line = ("%s run --job-results-dir %s --sysinfo=off "
+                    "passtest.py failtest.py -m "
+                    "examples/tests/sleeptest.py.data/sleeptest.yaml "
+                    "--suite-order tests-per-variant"
+                    % (AVOCADO, self.tmpdir))
+        expected_rc = exit_codes.AVOCADO_TESTS_FAIL
+        result = self.run_and_check(cmd_line, expected_rc, (4, 4))
+        self.assertIn("(1/8) passtest.py:PassTest.test;short", result.stdout)
+        self.assertIn("(2/8) failtest.py:FailTest.test;short", result.stdout)
+        self.assertIn("(8/8) failtest.py:FailTest.test;longest",
+                      result.stdout)
 
     def test_run_double_mplex(self):
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off '


### PR DESCRIPTION
The suite order means the order in which the variants will be applied to
tests. Right now we run all variants of first test, then the same for
the second, third, ... tests. The new option "--suite-order" allows to
alternatively specify "tests-per-variant" mode where we run first
variant of all tests, then second variant, third, ...

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>