### PR TITLE
Revert "optional_plugins.robot: Report failures on verbose list"

### DIFF
--- a/optional_plugins/robot/avocado_robot/__init__.py
+++ b/optional_plugins/robot/avocado_robot/__init__.py
@@ -67,13 +67,6 @@ class RobotTest(test.SimpleTest):
                       'non-0 exit code (%s)' % result)
 
 
-class NotRobotTest(object):
-
-    """
-    Not a robot test (for reporting purposes)
-    """
-
-
 class RobotLoader(loader.TestLoader):
     """
     Robot loader class
@@ -98,9 +91,7 @@ class RobotLoader(loader.TestLoader):
                                  source=url,
                                  include_suites=SuiteNamePatterns())
             robot_suite = self._find_tests(test_data, test_suite={})
-        except Exception as data:
-            if which_tests == loader.ALL:
-                return [(NotRobotTest, {"name": "%s: %s" % (url, data)})]
+        except DataError:
             return []
 
         for item in robot_suite:
@@ -111,9 +102,6 @@ class RobotLoader(loader.TestLoader):
                 if subtests_filter and not subtests_filter.search(test_name):
                     continue
                 avocado_suite.append((RobotTest, {'name': test_name}))
-        if which_tests is loader.ALL and not avocado_suite:
-            return [(NotRobotTest, {"name": "%s: No robot-like tests found"
-                                    % url})]
         return avocado_suite
 
     def _find_tests(self, data, test_suite):
@@ -127,13 +115,11 @@ class RobotLoader(loader.TestLoader):
 
     @staticmethod
     def get_type_label_mapping():
-        return {RobotTest: 'ROBOT',
-                NotRobotTest: "!ROBOT"}
+        return {RobotTest: 'ROBOT'}
 
     @staticmethod
     def get_decorator_mapping():
-        return {RobotTest: output.TERM_SUPPORT.healthy_str,
-                NotRobotTest: output.TERM_SUPPORT.fail_header_str}
+        return {RobotTest: output.TERM_SUPPORT.healthy_str}
 
 
 class RobotCLI(CLI):


### PR DESCRIPTION
I honestly missed the fact that no other loader reports failures
when it doesn't find resolve a test for a given test reference.
This brings experience that is really inconsistent.

Since the real fix may not be so simple to come up with, I propose we
revert this commit at this point.

This reverts commit 2b52631a4d51a7e7a84f66cb7c05d2b186c4edd9.

Signed-off-by: Cleber Rosa <crosa@redhat.com>