### PR TITLE
`avocado list`: show tags in verbose mode

### DIFF
--- a/avocado/plugins/list.py
+++ b/avocado/plugins/list.py
@@ -57,6 +57,7 @@ class TestLister(object):
         decorator_mapping = loader.loader.get_decorator_mapping()
 
         stats = {}
+        tag_stats = {}
         for value in type_label_mapping.values():
             stats[value.lower()] = 0
 
@@ -83,14 +84,19 @@ class TestLister(object):
                     tags = params['tags']
                 else:
                     tags = set()
+                for tag in tags:
+                    if tag not in tag_stats:
+                        tag_stats[tag] = 1
+                    else:
+                        tag_stats[tag] += 1
                 tags = ",".join(tags)
                 test_matrix.append((type_label, id_label, tags))
             else:
                 test_matrix.append((type_label, id_label))
 
-        return test_matrix, stats
+        return test_matrix, stats, tag_stats
 
-    def _display(self, test_matrix, stats):
+    def _display(self, test_matrix, stats, tag_stats):
         header = None
         if self.args.verbose:
             header = (output.TERM_SUPPORT.header_str('Type'),
@@ -101,9 +107,18 @@ class TestLister(object):
             LOG_UI.debug(line)
 
         if self.args.verbose:
-            LOG_UI.debug("")
+            LOG_UI.info("")
+            LOG_UI.info("TEST TYPES SUMMARY")
+            LOG_UI.info("==================")
             for key in sorted(stats):
                 LOG_UI.info("%s: %s", key.upper(), stats[key])
+
+            if tag_stats:
+                LOG_UI.info("")
+                LOG_UI.info("TEST TAGS SUMMARY")
+                LOG_UI.info("=================")
+                for key in sorted(tag_stats):
+                    LOG_UI.info("%s: %s", key, tag_stats[key])
 
     def _list(self):
         self._extra_listing()
@@ -113,8 +128,8 @@ class TestLister(object):
                 test_suite,
                 self.args.filter_by_tags,
                 self.args.filter_by_tags_include_empty)
-        test_matrix, stats = self._get_test_matrix(test_suite)
-        self._display(test_matrix, stats)
+        test_matrix, stats, tag_stats = self._get_test_matrix(test_suite)
+        self._display(test_matrix, stats, tag_stats)
 
     def list(self):
         try:

--- a/avocado/plugins/list.py
+++ b/avocado/plugins/list.py
@@ -78,7 +78,15 @@ class TestLister(object):
             stats[type_label.lower()] += 1
             type_label = decorator(type_label)
 
-            test_matrix.append((type_label, id_label))
+            if self.args.verbose:
+                if 'tags' in params:
+                    tags = params['tags']
+                else:
+                    tags = set()
+                tags = ",".join(tags)
+                test_matrix.append((type_label, id_label, tags))
+            else:
+                test_matrix.append((type_label, id_label))
 
         return test_matrix, stats
 
@@ -86,7 +94,8 @@ class TestLister(object):
         header = None
         if self.args.verbose:
             header = (output.TERM_SUPPORT.header_str('Type'),
-                      output.TERM_SUPPORT.header_str('Test'))
+                      output.TERM_SUPPORT.header_str('Test'),
+                      output.TERM_SUPPORT.header_str('Tag(s)'))
 
         for line in astring.iter_tabular_output(test_matrix, header=header):
             LOG_UI.debug(line)

--- a/docs/source/GetStartedGuide.rst
+++ b/docs/source/GetStartedGuide.rst
@@ -264,7 +264,7 @@ treated as simple tests. You can also give the ``--verbose`` or ``-V`` flag to
 display files that were found by Avocado, but are not considered Avocado tests::
 
     $ avocado list examples/gdb-prerun-scripts/ -V
-    Type       file
+    Type       Test                                     Tag(s)
     NOT_A_TEST examples/gdb-prerun-scripts/README
     NOT_A_TEST examples/gdb-prerun-scripts/pass-sigusr1
 

--- a/docs/source/GetStartedGuide.rst
+++ b/docs/source/GetStartedGuide.rst
@@ -268,6 +268,8 @@ display files that were found by Avocado, but are not considered Avocado tests::
     NOT_A_TEST examples/gdb-prerun-scripts/README
     NOT_A_TEST examples/gdb-prerun-scripts/pass-sigusr1
 
+    TEST TYPES SUMMARY
+    ==================
     SIMPLE: 0
     INSTRUMENTED: 0
     MISSING: 0

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -1183,7 +1183,7 @@ Then you implement your actual test using that derived class, in
 If you try to list the tests in that file, this is what you'll get::
 
     scripts/avocado list mytest.py -V
-    Type       Test
+    Type       Test      Tag(s)
     NOT_A_TEST mytest.py
 
     ACCESS_DENIED: 0
@@ -1220,7 +1220,7 @@ the example below::
 Now, trying to list the tests on the ``mytest.py`` file again::
 
     scripts/avocado list mytest.py -V
-    Type         Test
+    Type         Test                   Tag(s)
     INSTRUMENTED mytest.py:MyTest.test1
     INSTRUMENTED mytest.py:MyTest.test2
 

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -1186,6 +1186,8 @@ If you try to list the tests in that file, this is what you'll get::
     Type       Test      Tag(s)
     NOT_A_TEST mytest.py
 
+    TEST TYPES SUMMARY
+    ==================
     ACCESS_DENIED: 0
     BROKEN_SYMLINK: 0
     EXTERNAL: 0
@@ -1224,6 +1226,8 @@ Now, trying to list the tests on the ``mytest.py`` file again::
     INSTRUMENTED mytest.py:MyTest.test1
     INSTRUMENTED mytest.py:MyTest.test2
 
+    TEST TYPES SUMMARY
+    ==================
     ACCESS_DENIED: 0
     BROKEN_SYMLINK: 0
     EXTERNAL: 0

--- a/man/avocado.rst
+++ b/man/avocado.rst
@@ -608,6 +608,8 @@ are not avocado tests, along with summary information::
     NOT_A_TEST examples/gdb-prerun-scripts/README
     NOT_A_TEST examples/gdb-prerun-scripts/pass-sigusr1
 
+    TEST TYPES SUMMARY
+    ==================
     SIMPLE: 0
     INSTRUMENTED: 0
     MISSING: 0

--- a/man/avocado.rst
+++ b/man/avocado.rst
@@ -604,7 +604,7 @@ the `--verbose`, or `-V` flag to display files that were detected but
 are not avocado tests, along with summary information::
 
     $ avocado list examples/gdb-prerun-scripts/ -V
-    Type       file
+    Type       Test                                     Tag(s)
     NOT_A_TEST examples/gdb-prerun-scripts/README
     NOT_A_TEST examples/gdb-prerun-scripts/pass-sigusr1
 

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -922,6 +922,8 @@ class PluginsTest(AbsPluginsTest, unittest.TestCase):
                          % (exit_codes.AVOCADO_ALL_OK, result))
         exp = ("Type    Test                 Tag(s)\n"
                "MISSING this-wont-be-matched \n\n"
+               "TEST TYPES SUMMARY\n"
+               "==================\n"
                "EXTERNAL: 0\n"
                "MISSING: 1\n")
         self.assertEqual(exp, result.stdout, "Stdout mismatch:\n%s\n\n%s"

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -920,7 +920,9 @@ class PluginsTest(AbsPluginsTest, unittest.TestCase):
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK,
                          "Avocado did not return rc %d:\n%s"
                          % (exit_codes.AVOCADO_ALL_OK, result))
-        exp = ("Type    Test\nMISSING this-wont-be-matched\n\nEXTERNAL: 0\n"
+        exp = ("Type    Test                 Tag(s)\n"
+               "MISSING this-wont-be-matched \n\n"
+               "EXTERNAL: 0\n"
                "MISSING: 1\n")
         self.assertEqual(exp, result.stdout, "Stdout mismatch:\n%s\n\n%s"
                          % (exp, result))


### PR DESCRIPTION
This shows tags (and statistics) when `avocado list` is called with `--verbose`.