### PR TITLE
loader: Improve message when file does not exists

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -809,6 +809,8 @@ class FileLoader(TestLoader):
                         return self._make_avocado_tests(test_path, make_broken,
                                                         subtests_filter,
                                                         test_name)
+                return make_broken(NotATest, test_name, "File not found "
+                                   "('%s'; '%s')" % (test_name, test_path))
         return make_broken(NotATest, test_name, self.__not_test_str)
 
 

--- a/etc/avocado/avocado.conf
+++ b/etc/avocado/avocado.conf
@@ -4,7 +4,8 @@ base_dir = /var/lib/avocado
 # You may override the specific test directory with test_dir
 test_dir = /usr/share/avocado/tests
 # You may override the specific test auxiliary data directory with data_dir
-data_dir = /var/lib/avocado/data
+#data_dir = /var/lib/avocado/data
+data_dir = /home/medic/avocado/data
 # You may override the specific job results directory with logs_dir
 logs_dir = ~/avocado/job-results
 # You can set a list of cache directories to be used by the avocado test

--- a/etc/avocado/avocado.conf
+++ b/etc/avocado/avocado.conf
@@ -4,8 +4,7 @@ base_dir = /var/lib/avocado
 # You may override the specific test directory with test_dir
 test_dir = /usr/share/avocado/tests
 # You may override the specific test auxiliary data directory with data_dir
-#data_dir = /var/lib/avocado/data
-data_dir = /home/medic/avocado/data
+data_dir = /var/lib/avocado/data
 # You may override the specific job results directory with logs_dir
 logs_dir = ~/avocado/job-results
 # You can set a list of cache directories to be used by the avocado test


### PR DESCRIPTION
Currently when the target file does not exists the FileLoader reports:
"Does not look like an INSTRUMENTED test, nor is it executable" which
can be a bit misleading. Let's change it to: "File not found
($locations)".

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>