### PR TITLE
selftests: Silence `inspekt lint` unless there is an error

### DIFF
--- a/selftests/checkall
+++ b/selftests/checkall
@@ -79,7 +79,11 @@ results_dir_content() {
 }
 
 [ "$SKIP_RESULTSDIR_CHECK" ] || RESULTS_DIR_CONTENT="$(ls $RESULTS_DIR 2> /dev/null)"
-run_rc lint 'inspekt --exclude=.git lint'
+if [ "$TRAVIS" == "true" ]; then
+    run_rc lint 'RESULT=$(mktemp); inspekt --exclude=.git lint &>$RESULT || { cat $RESULT; rm $RESULT; exit -1; }; rm $RESULT'
+else
+    run_rc lint 'inspekt --exclude=.git lint'
+fi
 run_rc indent 'inspekt --exclude=.git indent'
 run_rc style 'inspekt --exclude=.git style --disable E501,E265,W601,E402,E722'
 run_rc boundaries 'selftests/modules_boundaries'


### PR DESCRIPTION
For couple of weeks the `inspekt lint` produces unwanted `Your code has
been rated at 10.00/10 (previous run: 10.00/10, +0.00)` messages
polluting the log too much for me to bear. I tried to remove those
messages, but so far I haven't found a solution, so let's just silence
it unless there is a lint failure.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>