### PR TITLE
utils/memory.py : function to get the linux page size

### DIFF
--- a/avocado/utils/memory.py
+++ b/avocado/utils/memory.py
@@ -112,6 +112,16 @@ def node_size():
     return ((memtotal() * 1024) / nodes)
 
 
+def get_page_size():
+    """
+    Get linux page size for this system.
+
+    :return Kernel page size (Bytes).
+    """
+    output = process.system_output('getconf PAGESIZE')
+    return int(output)
+
+
 def get_huge_page_size():
     """
     Get size of the huge pages for this system.


### PR DESCRIPTION
Added a function to get the linux page size for the given
kernel, it returns a byte value from 'getconf PAGESIZE'
command.

systems can have 4k, 64k page sizes, accordingly decide to
start a memory tests.

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>