### PR TITLE
 runner: Try to interrupt test gently first

### DIFF
--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -305,7 +305,7 @@ class TestRunner(object):
 
         def sigterm_handler(signum, frame):     # pylint: disable=W0613
             """ Produce traceback on SIGTERM """
-            raise SystemExit("Test interrupted by SIGTERM")
+            raise RuntimeError("Test interrupted by SIGTERM")
 
         signal.signal(signal.SIGTERM, sigterm_handler)
 


### PR DESCRIPTION
When the test does not produces the early_status in 60s or when the test
pushes the final status and not exits we SIGKILL the test, leaving us
with no trace on where it might hang. Let's use SIGTERM first and wait
for 1s to see whether the process won't be able to give us traceback,
otherwise nuke it with SIGKILL as before.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>