### PR TITLE
docstring directives: define more formal and strict format

### DIFF
--- a/avocado/core/safeloader.py
+++ b/avocado/core/safeloader.py
@@ -64,8 +64,9 @@ def modules_imported_as(module):
 
 
 #: Gets the docstring directive value from a string. Used to tweak
-#: test class behavior in various ways
-AVOCADO_DOCSTRING_DIRECTIVE_RE = re.compile(r'\s*:avocado:\s*(\S+)\s*')
+#: test behavior in various ways
+DOCSTRING_DIRECTIVE_RE_RAW = r'\s*:avocado:[ \t]+([a-zA-Z0-9]+?[a-zA-Z0-9_:,\=]*)\s*$'
+DOCSTRING_DIRECTIVE_RE = re.compile(DOCSTRING_DIRECTIVE_RE_RAW)
 
 
 def get_docstring_directives(docstring):
@@ -77,10 +78,17 @@ def get_docstring_directives(docstring):
 
     :rtype: builtin.list
     """
-    try:
-        return AVOCADO_DOCSTRING_DIRECTIVE_RE.findall(docstring)
-    except TypeError:
-        return []
+    result = []
+    if docstring is None:
+        return result
+    for line in docstring.splitlines():
+        try:
+            match = DOCSTRING_DIRECTIVE_RE.match(line)
+            if match:
+                result.append(match.groups()[0])
+        except TypeError:
+            pass
+    return result
 
 
 def check_docstring_directive(docstring, directive):

--- a/docs/source/ReferenceGuide.rst
+++ b/docs/source/ReferenceGuide.rst
@@ -485,3 +485,41 @@ function, positional arguments and keyword arguments will be
 registered, not matter how many times they're attempted to be
 registered. For more information check
 :meth:`avocado.utils.data_structures.CallbackRegister.register`.
+
+.. _docstring-directive-rules:
+
+Docstring Directives Rules
+==========================
+
+Avocado INSTRUMENTED tests, those written in Python and using the
+:class:`avocado.Test` API, can make use of special directives
+specified as docstrings.
+
+To be considered valid, the docstring must match this pattern:
+:data:`avocado.core.safeloader.DOCSTRING_DIRECTIVE_RE_RAW`.
+
+An Avocado docstring directive has two parts:
+
+ 1) The marker, which is the literal string ``:avocado:``.
+
+ 2) The content, a string that follows the marker, separated by at
+    least one white space or tab.
+
+The following is a list of rules that makes a docstring directive
+be a valid one:
+
+ * It should start with ``:avocado:``, which is the docstring
+   directive "marker"
+
+ * At least one whitespace or tab must follow the marker and preceed
+   the docstring directive "content"
+
+ * The "content", which follows the marker and the space, must begin
+   with an alphanumeric character, that is, characters within "a-z",
+   "A-Z" or "0-9".
+
+ * After at least one alphanumeric character, the content may contain
+   the following special symbols too: ``_``, ``,``, ``=`` and ``:``.
+
+ * An end of string (or end of line) must immediately follow the
+   content.

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -1123,9 +1123,9 @@ Docstring Directives
 ====================
 
 Some Avocado features, usually only available to instrumented tests,
-depend on setting directives on the test's class docstring.  The
-standard prefix used is ``:avocado:`` followed by the directive
-itself, such as ``:avocado: directive``.
+depend on setting directives on the test's class docstring.  A
+docstring directive is composed of a marker (a literal ``:avocado:`` string),
+followed by the custom content itself, such as ``:avocado: directive``.
 
 This is similar to docstring directives such as ``:param my_param:
 description`` and shouldn't be a surprise to most Python developers.
@@ -1133,6 +1133,9 @@ description`` and shouldn't be a surprise to most Python developers.
 The reason Avocado uses those docstring directives (instead of real
 Python code) is that the inspection done while looking for tests does
 not involve any execution of code.
+
+For a detailed explanation about what makes a docstring format valid
+or not, please refer to our section on :ref:`docstring-directive-rules`.
 
 Now let's follow with some docstring directives examples.
 


### PR DESCRIPTION
The format of the docstring directives has not been formally described
so far.  Because at least two different features are built on that,
and possibly more will come, it's a good idea to define a format.

This introduces a stricter format, basically adding a number of
requirements or rules.  To make the following description more
consistent let's call the ":avocado:" part of the docstring directive
"the marker" and what follows it the "content".

1) One or more spaces are required between the ":avocado:" marker and
   the content.  The following is a valid docstring directive:

   ":avocado: enable"

   While this is invalid:

   ":avocado:enable"

2) A more limited set of characters are now allowed in the content,
   namely one from the following set: [a-zA-Z0-9_:,=].  The following
   is a valid docstring directive:

   ":avocado: foo=bar,foz=baz:extra"

   While the following is invalid:

   ":avocado: foo=bar!"

3) The first character of the content must be alphanumeric, so the
   following is a valid docstring directive:

   ":avocado: foo=bar"

   While the following is invalid:

   ":avocado: =bar"

4) An end of string (or end of line) is now required after the content
   (which itself may not contain white spaces).  The following is a
   valid docstring directive:

   ":avocado: enable"

   While the following is invalid:

   ":avocado: enable FOO"

Signed-off-by: Cleber Rosa <crosa@redhat.com>