### PR TITLE
fix loader selftest

### DIFF
--- a/selftests/functional/test_loader.py
+++ b/selftests/functional/test_loader.py
@@ -137,6 +137,10 @@ if __name__ == "__main__":
 
 class LoaderTestFunctional(unittest.TestCase):
 
+    MODE_0644 = (stat.S_IRUSR | stat.S_IWUSR |
+                 stat.S_IRGRP |
+                 stat.S_IROTH)
+
     MODE_0664 = (stat.S_IRUSR | stat.S_IWUSR |
                  stat.S_IRGRP | stat.S_IWGRP |
                  stat.S_IROTH)


### PR DESCRIPTION
This patch adds the missing definition of `MODE_0644` in
`LoaderTestFunctional` class.

Signed-off-by: Amador Pahim <apahim@redhat.com>