### PR TITLE
Added support for POWER9 cpu arch identification

### DIFF
--- a/avocado/utils/cpu.py
+++ b/avocado/utils/cpu.py
@@ -104,6 +104,7 @@ def get_cpu_arch():
                  ('^cpu.*POWER6', 'power6'),
                  ('^cpu.*POWER7', 'power7'),
                  ('^cpu.*POWER8', 'power8'),
+                 ('^cpu.*POWER9', 'power9'),
                  ('^cpu.*PPC970', 'power970'),
                  ('ARM', 'arm'),
                  ('^flags.*:.* lm .*', 'x86_64')]


### PR DESCRIPTION
Added support for POWER9 cpu arch identification

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>