### PR TITLE
jobdata: Store only data, not data+code

### DIFF
--- a/avocado/core/jobdata.py
+++ b/avocado/core/jobdata.py
@@ -30,7 +30,9 @@ JOB_DATA_FALLBACK_DIR = 'replay'
 CONFIG_FILENAME = 'config'
 TEST_REFERENCES_FILENAME = 'test_references'
 TEST_REFERENCES_FILENAME_LEGACY = 'urls'
-VARIANTS_FILENAME = 'multiplex'
+VARIANTS_FILENAME = 'variants'
+# TODO: Remove when 36lts is discontinued
+VARIANTS_FILENAME_OLD = 'multiplex'
 PWD_FILENAME = 'pwd'
 ARGS_FILENAME = 'args'
 CMDLINE_FILENAME = 'cmdline'
@@ -122,6 +124,8 @@ def retrieve_variants(resultsdir):
     Retrieves the job Mux object from the results directory.
     """
     recorded_mux = _retrieve(resultsdir, VARIANTS_FILENAME)
+    if recorded_mux is None:
+        recorded_mux = _retrieve(resultsdir, VARIANTS_FILENAME_OLD)
     if recorded_mux is None:
         return None
     with open(recorded_mux, 'r') as mux_file:

--- a/avocado/core/jobdata.py
+++ b/avocado/core/jobdata.py
@@ -22,6 +22,8 @@ import json
 import os
 import pickle
 
+from . import varianter
+from .output import LOG_UI, LOG_JOB
 from .settings import settings
 from ..utils.path import init_dir
 
@@ -43,12 +45,16 @@ def record(args, logdir, mux, references=None, cmdline=None):
     """
     Records all required job information.
     """
+    def json_bad_mux_obj(item):
+        for log in [LOG_UI, LOG_JOB]:
+            log.warning("jobdata.variants: Unable to serialize '%s'", item)
+        return str(item)
     base_dir = init_dir(logdir, JOB_DATA_DIR)
     path_cfg = os.path.join(base_dir, CONFIG_FILENAME)
     path_references = os.path.join(base_dir, TEST_REFERENCES_FILENAME)
     path_references_legacy = os.path.join(base_dir,
                                           TEST_REFERENCES_FILENAME_LEGACY)
-    path_mux = os.path.join(base_dir, VARIANTS_FILENAME)
+    path_mux = os.path.join(base_dir, VARIANTS_FILENAME + ".json")
     path_pwd = os.path.join(base_dir, PWD_FILENAME)
     path_args = os.path.join(base_dir, ARGS_FILENAME + ".json")
     path_cmdline = os.path.join(base_dir, CMDLINE_FILENAME)
@@ -66,7 +72,7 @@ def record(args, logdir, mux, references=None, cmdline=None):
         os.fsync(config_file)
 
     with open(path_mux, 'w') as mux_file:
-        pickle.dump(mux, mux_file, pickle.HIGHEST_PROTOCOL)
+        json.dump(mux.dump(), mux_file, default=json_bad_mux_obj)
         mux_file.flush()
         os.fsync(mux_file)
 
@@ -124,11 +130,17 @@ def retrieve_variants(resultsdir):
     """
     Retrieves the job Mux object from the results directory.
     """
+    recorded_mux = _retrieve(resultsdir, VARIANTS_FILENAME + ".json")
+    if recorded_mux:    # new json-based dump
+        with open(recorded_mux, 'r') as mux_file:
+            return varianter.Varianter(state=json.load(mux_file))
     recorded_mux = _retrieve(resultsdir, VARIANTS_FILENAME)
     if recorded_mux is None:
         recorded_mux = _retrieve(resultsdir, VARIANTS_FILENAME_OLD)
     if recorded_mux is None:
         return None
+    # old pickle-based dump
+    # TODO: Remove when 36lts is discontinued
     with open(recorded_mux, 'r') as mux_file:
         return pickle.load(mux_file)
 

--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -92,6 +92,37 @@ class TreeEnvironment(dict):
                          str(self.filter_out)))
 
 
+class TreeNodeEnvOnly(object):
+
+    """
+    Minimal TreeNode-like class providing interface for AvocadoParams
+    """
+    def __init__(self, path, environment=None):
+        """
+        :param path: Path of this node (must not end with '/')
+        :param environment: List of pair/key/value items
+        """
+        self.name = path.rsplit("/")[-1]
+        self.path = path
+        self.environment = TreeEnvironment()
+        if environment:
+            self.__load_environment(environment)
+
+    def __load_environment(self, environment):
+        nodes = {}
+        for path, key, value in environment:
+            self.environment[key] = value
+            if path not in nodes:
+                nodes[path] = TreeNodeEnvOnly(path)
+            self.environment.origin[key] = nodes[path]
+
+    def get_environment(self):
+        return self.environment
+
+    def get_path(self):
+        return self.path
+
+
 class TreeNode(object):
 
     """

--- a/avocado/core/varianter.py
+++ b/avocado/core/varianter.py
@@ -26,7 +26,6 @@ from . import dispatcher
 from .output import LOG_JOB
 
 
-# TODO: Create multiplexer plugin and split these functions into multiple files
 class NoMatchError(KeyError):
     pass
 

--- a/selftests/functional/test_replay_basic.py
+++ b/selftests/functional/test_replay_basic.py
@@ -60,7 +60,7 @@ class ReplayTests(unittest.TestCase):
         """
         Checks if all expected files are there.
         """
-        file_list = ['variants', 'config', 'test_references', 'pwd',
+        file_list = ['variants.json', 'config', 'test_references', 'pwd',
                      'args.json', 'cmdline']
         for filename in file_list:
             path = os.path.join(self.jobdir, 'jobdata', filename)

--- a/selftests/functional/test_replay_basic.py
+++ b/selftests/functional/test_replay_basic.py
@@ -60,8 +60,8 @@ class ReplayTests(unittest.TestCase):
         """
         Checks if all expected files are there.
         """
-        file_list = ['variants', 'config', 'test_references', 'pwd', 'args',
-                     'cmdline']
+        file_list = ['variants', 'config', 'test_references', 'pwd',
+                     'args.json', 'cmdline']
         for filename in file_list:
             path = os.path.join(self.jobdir, 'jobdata', filename)
             self.assertTrue(glob.glob(path))

--- a/selftests/functional/test_replay_basic.py
+++ b/selftests/functional/test_replay_basic.py
@@ -60,7 +60,7 @@ class ReplayTests(unittest.TestCase):
         """
         Checks if all expected files are there.
         """
-        file_list = ['multiplex', 'config', 'test_references', 'pwd', 'args',
+        file_list = ['variants', 'config', 'test_references', 'pwd', 'args',
                      'cmdline']
         for filename in file_list:
             path = os.path.join(self.jobdir, 'jobdata', filename)


### PR DESCRIPTION
Currently we use pickle to store args and variants, which does not scale between versions and is also insecure as one can sneak-in malicious code. In this PR I'm using json to serialize the data while using None to store insecure content in args and I added a method to safely serialize variants and again using json to store them. For variants there is potential loss of information as it can contain insecure objects which are turned to strings and also I'm not storing the full state, only simplified produced variants representation which is safe and from AvocadoParams point of view represents the status.

Note: as a consequence it's now possible to re-run/diff jobs without the varianter plugins (or with different ones as they are not used to produce the variants anyway).