### PR TITLE
loader: Improve message when file does not exists [v2]

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -809,6 +809,8 @@ class FileLoader(TestLoader):
                         return self._make_avocado_tests(test_path, make_broken,
                                                         subtests_filter,
                                                         test_name)
+                return make_broken(NotATest, test_name, "File not found "
+                                   "('%s'; '%s')" % (test_name, test_path))
         return make_broken(NotATest, test_name, self.__not_test_str)
 
 


### PR DESCRIPTION
Currently when the target file does not exists the FileLoader reports:
"Does not look like an INSTRUMENTED test, nor is it executable" which
can be a bit misleading. Let's change it to: "File not found
($locations)".

v1: https://github.com/avocado-framework/avocado/pull/2036

Changes:

```
v2: Rebased and remove the accidental `etc` changes
```