### PR TITLE
jobdata: Store only data, not data+code [v2]

### DIFF
--- a/avocado/core/jobdata.py
+++ b/avocado/core/jobdata.py
@@ -30,7 +30,9 @@ JOB_DATA_FALLBACK_DIR = 'replay'
 CONFIG_FILENAME = 'config'
 TEST_REFERENCES_FILENAME = 'test_references'
 TEST_REFERENCES_FILENAME_LEGACY = 'urls'
-VARIANTS_FILENAME = 'multiplex'
+VARIANTS_FILENAME = 'variants'
+# TODO: Remove when 36lts is discontinued
+VARIANTS_FILENAME_LEGACY = 'multiplex'
 PWD_FILENAME = 'pwd'
 ARGS_FILENAME = 'args'
 CMDLINE_FILENAME = 'cmdline'
@@ -122,6 +124,8 @@ def retrieve_variants(resultsdir):
     Retrieves the job Mux object from the results directory.
     """
     recorded_mux = _retrieve(resultsdir, VARIANTS_FILENAME)
+    if recorded_mux is None:
+        recorded_mux = _retrieve(resultsdir, VARIANTS_FILENAME_LEGACY)
     if recorded_mux is None:
         return None
     with open(recorded_mux, 'r') as mux_file:

--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -92,6 +92,37 @@ class TreeEnvironment(dict):
                          str(self.filter_out)))
 
 
+class TreeNodeEnvOnly(object):
+
+    """
+    Minimal TreeNode-like class providing interface for AvocadoParams
+    """
+    def __init__(self, path, environment=None):
+        """
+        :param path: Path of this node (must not end with '/')
+        :param environment: List of pair/key/value items
+        """
+        self.name = path.rsplit("/")[-1]
+        self.path = path
+        self.environment = TreeEnvironment()
+        if environment:
+            self.__load_environment(environment)
+
+    def __load_environment(self, environment):
+        nodes = {}
+        for path, key, value in environment:
+            self.environment[key] = value
+            if path not in nodes:
+                nodes[path] = TreeNodeEnvOnly(path)
+            self.environment.origin[key] = nodes[path]
+
+    def get_environment(self):
+        return self.environment
+
+    def get_path(self):
+        return self.path
+
+
 class TreeNode(object):
 
     """

--- a/avocado/core/varianter.py
+++ b/avocado/core/varianter.py
@@ -26,7 +26,6 @@ from . import dispatcher
 from .output import LOG_JOB
 
 
-# TODO: Create multiplexer plugin and split these functions into multiple files
 class NoMatchError(KeyError):
     pass
 

--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -254,14 +254,9 @@ class Replay(CLI):
                 LOG_UI.error('Source job variants data not found. Aborting.')
                 sys.exit(exit_codes.AVOCADO_FAIL)
             else:
-                # Ignore data manipulation. This is necessary, because
-                # we replaced the unparsed object with parsed one. There
-                # are other plugins running before/after this which might
-                # want to alter the variants object.
-                if args.avocado_variants.is_parsed():
-                    LOG_UI.warning("Using src job Mux data only, use "
-                                   "`--replay-ignore variants` to override "
-                                   "them.")
+                LOG_UI.warning("Using src job Mux data only, use "
+                               "`--replay-ignore variants` to override "
+                               "them.")
                 setattr(args, "avocado_variants", variants)
 
         # Extend "replay_test_status" of "INTERRUPTED" when --replay-resume

--- a/selftests/functional/test_replay_basic.py
+++ b/selftests/functional/test_replay_basic.py
@@ -60,7 +60,7 @@ class ReplayTests(unittest.TestCase):
         """
         Checks if all expected files are there.
         """
-        file_list = ['variants', 'config', 'test_references', 'pwd',
+        file_list = ['variants.json', 'config', 'test_references', 'pwd',
                      'args.json', 'cmdline']
         for filename in file_list:
             path = os.path.join(self.jobdir, 'jobdata', filename)

--- a/selftests/functional/test_replay_basic.py
+++ b/selftests/functional/test_replay_basic.py
@@ -60,8 +60,8 @@ class ReplayTests(unittest.TestCase):
         """
         Checks if all expected files are there.
         """
-        file_list = ['variants', 'config', 'test_references', 'pwd', 'args',
-                     'cmdline']
+        file_list = ['variants', 'config', 'test_references', 'pwd',
+                     'args.json', 'cmdline']
         for filename in file_list:
             path = os.path.join(self.jobdir, 'jobdata', filename)
             self.assertTrue(glob.glob(path))

--- a/selftests/functional/test_replay_basic.py
+++ b/selftests/functional/test_replay_basic.py
@@ -60,7 +60,7 @@ class ReplayTests(unittest.TestCase):
         """
         Checks if all expected files are there.
         """
-        file_list = ['multiplex', 'config', 'test_references', 'pwd', 'args',
+        file_list = ['variants', 'config', 'test_references', 'pwd', 'args',
                      'cmdline']
         for filename in file_list:
             path = os.path.join(self.jobdir, 'jobdata', filename)


### PR DESCRIPTION
Currently we use pickle to store args and variants, which does not scale between versions and is also insecure as one can sneak-in malicious code. In this PR I'm using json to serialize the data while using None to store insecure content in args and I added a method to safely serialize variants and again using json to store them. For variants there is potential loss of information as it can contain insecure objects which are turned to strings and also I'm not storing the full state, only simplified produced variants representation which is safe and from AvocadoParams point of view represents the status.

Note: as a consequence it's now possible to re-run/diff jobs without the varianter plugins (or with different ones as they are not used to produce the variants anyway).

v1: https://github.com/avocado-framework/avocado/pull/2058

Changes:

```yaml
v2: Renamed variable VARIANTS_FILENAME_OLD => VARIANTS_FILENAME_LEGACY
v2: Always show the `--replay-ignore variants` message as there is no easy way
    of discovering, whether varianter is used and it almost always is anyway...
```