### PR TITLE
Plugin listing: improve readability

### DIFF
--- a/avocado/plugins/plugins.py
+++ b/avocado/plugins/plugins.py
@@ -64,3 +64,4 @@ class Plugins(CLICmd):
             else:
                 for line in astring.iter_tabular_output(plugin_matrix):
                     LOG_UI.debug(line)
+                LOG_UI.debug("")


### PR DESCRIPTION
Let's include an empty line between the plugin categories, so it's
easier to distinguish between different plugin types.

Signed-off-by: Cleber Rosa <crosa@redhat.com>