### PR TITLE
[36lts] setup: Fix requirements and backport the way to get avocado version [v2]

### DIFF
--- a/avocado/core/version.py
+++ b/avocado/core/version.py
@@ -16,11 +16,14 @@
 
 __all__ = ['MAJOR', 'MINOR', 'VERSION']
 
+import pkg_resources
 
-MAJOR = 36
-MINOR = 4
+try:
+    VERSION = pkg_resources.get_distribution("avocado").version
+except pkg_resources.DistributionNotFound:
+    VERSION = "unknown.unknown"
 
-VERSION = "%s.%s" % (MAJOR, MINOR)
+MAJOR, MINOR = VERSION.split('.')
 
 if __name__ == '__main__':
     print(VERSION)

--- a/requirements-selftests.txt
+++ b/requirements-selftests.txt
@@ -23,5 +23,5 @@ pydot>=1.0.2
 aexpect>=1.0.0
 psutil>=3.1.1
 # stevedore for loading "new style" plugins
-stevedore>=1.8.0
+stevedore>=0.14
 lxml>=3.4.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,9 +12,9 @@ pystache>=0.5.3
 # REST client (avocado.core.restclient)
 requests>=1.2.3
 # stevedore for loading "new style" plugins
-stevedore>=1.8.0; python_version >= '2.7'
+stevedore>=0.14; python_version >= '2.7'
 # stevedore-1.11.0 won't support python2.6 anymore
-stevedore>=1.8.0,<=1.10.0; python_version < '2.7'
+stevedore>=0.14,<=1.10.0; python_version < '2.7'
 # Additional python 2.6 specific requirements for avocado and unittests (backports)
 argparse>=1.3.0; python_version < '2.7'
 logutils>=0.3.3; python_version < '2.7'

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@
 
 import glob
 import os
+import sys
 # pylint: disable=E0611
 
 from setuptools import setup
@@ -101,6 +102,14 @@ def get_long_description():
     return req_contents
 
 if __name__ == '__main__':
+    if sys.version_info < (2, 7, 0):
+        requirements = ["pystache>=0.5.3", "stevedore>=0.14,<=1.10.0",
+                        "argparse>=1.3.0", "logutils>=0.3.3",
+                        "importlib>=1.0.3", "PyYAML>=3.11",
+                        "unittest2>=1.0.0"]
+    else:
+        requirements = ["pystache>=0.5.3", "stevedore>=0.14",
+                        "PyYAML>=3.11"]
     setup(name='avocado',
           version='36.4',
           description='Avocado Test Framework',
@@ -150,5 +159,6 @@ if __name__ == '__main__':
                   'jobscripts = avocado.plugins.jobscripts:JobScripts',
                   ],
               },
+          install_requires=requirements,
           zip_safe=False,
           test_suite='selftests')

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,6 @@ import os
 
 from setuptools import setup
 
-from avocado import VERSION
-
 
 VIRTUAL_ENV = 'VIRTUAL_ENV' in os.environ
 
@@ -104,7 +102,7 @@ def get_long_description():
 
 if __name__ == '__main__':
     setup(name='avocado',
-          version=VERSION,
+          version='36.4',
           description='Avocado Test Framework',
           long_description=get_long_description(),
           author='Avocado Developers',


### PR DESCRIPTION
This PR addresses issue https://github.com/avocado-framework/avocado/issues/2027 Basically the current 36lts is not installable from pip unless stevedore is already installed. This is addressed by the first backport of how to treat avocado version.

Still after pip installation Avocado is not really usable as it lacks the requirements specified from "requirements.txt". The second commit tries to add the basic default of dependencies directly to setup.py to make Avocado usable without the need to install additional dependencies manually. Note I did not specified the full list, see the details in the commit message.

v1: https://github.com/avocado-framework/avocado/pull/2039

Changes:

```yaml
v2: Also backport the 56f35 Lower stevedore version requirement
```