### PR TITLE
etc: Correct plugin names in avocado.conf

### DIFF
--- a/etc/avocado/avocado.conf
+++ b/etc/avocado/avocado.conf
@@ -69,12 +69,11 @@ password =
 [plugins]
 # Disable listed plugins completely.  Use the fully qualified plugin
 # name, as described in the Avocado documentation "Plugins" section.
+# (e.g. "results.html")
 disable = []
 # Suppress notification about broken plugins in the app standard error.
 # Add the name of each broken plugin you want to suppress the notification
-# in the list. The names can be easily seen from the stderr messages. Example:
-# avocado.plugins.htmlresult  ImportError No module named pystache
-# add 'avocado.plugins.htmlresult' as an element of the list below.
+# in the list. (e.g. "avocado_result_html")
 skip_broken_plugin_notification = []
 # Optionally you can specify the priority of test loaders (file) or test
 # types (file.SIMPLE). Some of the plugins even support extra params


### PR DESCRIPTION
Currently there are two types of plugin names, one is the fully
qualified plugin name, which is the namespace used by stevedore and the
other is the module name, which is the module which handles the code.
It's probably too late to adjust the behavior, but let's at least
provide correct examples to simplify the usage.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>