### PR TITLE
Fix "avocado variants" with no variants and the "--system-wide" argument

### DIFF
--- a/avocado/core/mux.py
+++ b/avocado/core/mux.py
@@ -26,8 +26,8 @@ import hashlib
 import itertools
 import re
 
-from . import output
 from . import tree
+from . import varianter
 
 
 #
@@ -218,33 +218,10 @@ class MuxPlugin(object):
 
         if variants:
             # variants == 0 means disable, but in plugin it's brief
-            contents = variants - 1
             out.append("Multiplex variants (%s):" % len(self))
             for variant in self:
-                if not self.debug:
-                    paths = ', '.join([x.path for x in variant["variant"]])
-                else:
-                    color = output.TERM_SUPPORT.LOWLIGHT
-                    cend = output.TERM_SUPPORT.ENDC
-                    paths = ', '.join(["%s%s@%s%s" % (_.name, color,
-                                                      getattr(_, 'yaml',
-                                                              "Unknown"),
-                                                      cend)
-                                       for _ in variant["variant"]])
-                out.append('%sVariant %s:    %s' % ('\n' if contents else '',
-                                                    variant["variant_id"],
-                                                    paths))
-                if contents:
-                    env = set()
-                    for node in variant["variant"]:
-                        for key, value in node.environment.iteritems():
-                            origin = node.environment.origin[key].path
-                            env.add(("%s:%s" % (origin, key), str(value)))
-                    if not env:
-                        continue
-                    fmt = '    %%-%ds => %%s' % max([len(_[0]) for _ in env])
-                    for record in sorted(env):
-                        out.append(fmt % record)
+                out.extend(varianter.variant_to_str(variant, variants - 1,
+                                                    kwargs, self.debug))
         return "\n".join(out)
 
     def __len__(self):

--- a/avocado/core/varianter.py
+++ b/avocado/core/varianter.py
@@ -385,7 +385,7 @@ class Varianter(object):
         self.default_params.clear()     # We don't need these anymore
         # FIXME: Backward compatibility params, to be removed when 36 LTS is
         # discontinued
-        if (not getattr(args, "variants_skip_defaults", False) and
+        if (not getattr(args, "variants-skip-defaults", False) and
                 hasattr(args, "default_avocado_params")):
             self._default_params.merge(args.default_avocado_params)
         return self._default_params

--- a/avocado/core/varianter.py
+++ b/avocado/core/varianter.py
@@ -467,6 +467,15 @@ class Varianter(object):
         :param kwargs: Other free-form arguments
         :rtype: str
         """
+        if self._no_variants == 0:  # No variants, only defaults:
+            out = []
+            if summary:
+                out.append("No variants available, using defaults only")
+            if variants:
+                out.append("\n".join(variant_to_str(next(self.itertests()),
+                                                    variants - 1, kwargs,
+                                                    self.debug)))
+            return "\n\n".join(out)
         return "\n\n".join(self._variant_plugins.map_method("to_str", summary,
                                                             variants,
                                                             **kwargs))


### PR DESCRIPTION
The `avocado variants` without any variants reports nothing at all, which is not actually what it looks like during `avocado run`. On `avocado run` default params are supplied as a `None` variant. Let's duplicate this behavior on `avocado variants` as well.

While on it I noticed that the `--system-wide` is broken, because of a wrong variable name. Fix is included in this PR.