### PR TITLE
runner: install the SIGTSTP handler on the runner only

### DIFF
--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -299,7 +299,6 @@ class TestRunner(object):
         :param queue: Multiprocess queue.
         :type queue: :class:`multiprocessing.Queue` instance.
         """
-        signal.signal(signal.SIGTSTP, signal.SIG_IGN)
         logger_list_stdout = [TEST_LOG,
                               logging.getLogger('paramiko')]
         logger_list_stderr = [TEST_LOG,
@@ -373,8 +372,6 @@ class TestRunner(object):
                     process.kill_process_tree(proc.pid, signal.SIGSTOP, False)
                     self.sigstopped = True
 
-        signal.signal(signal.SIGTSTP, sigtstp_handler)
-
         proc = multiprocessing.Process(target=self._run_test,
                                        args=(test_factory, queue,))
         test_status = TestStatus(self.job, queue)
@@ -382,7 +379,7 @@ class TestRunner(object):
         cycle_timeout = 1
         time_started = time.time()
         proc.start()
-
+        signal.signal(signal.SIGTSTP, sigtstp_handler)
         test_status.wait_for_early_status(proc, 60)
 
         # At this point, the test is already initialized and we know


### PR DESCRIPTION
Currently, the signal handler for SIGTSTP (which implements the test
pause/resume) is installed before the test process is created, and
thus, is inherited by it.

There's a clean up of the signal handler in the test process, but this
clean up can be prevented by installing the signal handler on the test
runner alone (after the test process is created).

The ramifications of this proposal are such that, in the chance that a
SIGTSTP is received after the test process is created and before the
signal handler is installed in the test runner process, nothing will
happen.  In contrast, the current approach may have the signal handler
action being executed, and attempting to send SIGSTOP or SIGCONT to
the test process, but not doing so because there's no test process
yet.

In the end, it seems that the two approaches are pretty safe, and the
biggest benefit here is one fewer line of code (and on less action) to
be performed by the test process.

Signed-off-by: Cleber Rosa <crosa@redhat.com>