### PR TITLE
HTML: add a link to the report in the same location other results live

### DIFF
--- a/optional_plugins/html/avocado_result_html/__init__.py
+++ b/optional_plugins/html/avocado_result_html/__init__.py
@@ -273,6 +273,8 @@ class HTMLResult(Result):
             os.makedirs(html_dir)
             html_path = os.path.join(html_dir, 'results.html')
             self._render(result, html_path)
+            html_symlink_path = os.path.join(job.logdir, 'results.html')
+            os.symlink(os.path.join('html', 'results.html'), html_symlink_path)
             if getattr(job.args, 'stdout_claimed_by', None) is None:
                 LOG_UI.info("JOB HTML   : %s", html_path)
             if open_browser:


### PR DESCRIPTION
All other result plugins write (by default) to the job results dir.
The HTML plugin was different because it used to require a number of
files.  Now, it's a single file, and thus, could/should live in the
same place as other files.

To ease the transition of the location, let's add a symlink, so that
users can start to rely on the new proposed location.

Signed-off-by: Cleber Rosa <crosa@redhat.com>