### PR TITLE
HTML: write report in the same location other results live [v2]

### DIFF
--- a/optional_plugins/html/avocado_result_html/__init__.py
+++ b/optional_plugins/html/avocado_result_html/__init__.py
@@ -267,12 +267,15 @@ class HTMLResult(Result):
 
         open_browser = getattr(job.args, 'open_browser', False)
         if getattr(job.args, 'html_job_result', 'off') == 'on':
-            html_dir = os.path.join(job.logdir, 'html')
-            if os.path.exists(html_dir):    # update the html result if exists
-                shutil.rmtree(html_dir)
-            os.makedirs(html_dir)
-            html_path = os.path.join(html_dir, 'results.html')
+            # FIXME: remove html legacy dir after 52.0 LTS release
+            html_legacy_dir = os.path.join(job.logdir, 'html')
+            if os.path.exists(html_legacy_dir):    # update the html result if exists
+                shutil.rmtree(html_legacy_dir)
+            html_path = os.path.join(job.logdir, 'results.html')
             self._render(result, html_path)
+            os.makedirs(html_legacy_dir)
+            os.symlink(os.path.join(os.path.pardir, 'results.html'),
+                       os.path.join(html_legacy_dir, 'results.html'))
             if getattr(job.args, 'stdout_claimed_by', None) is None:
                 LOG_UI.info("JOB HTML   : %s", html_path)
             if open_browser:


### PR DESCRIPTION
All other result plugins write (by default) to the job results dir.
The HTML plugin was different because it used to require a number of
files.  Now, it's a single file, and thus, could/should live in the
same place as other files.

To ease the transition of the location, let's add a symlink, so that
users can still rely on the old location.

Signed-off-by: Cleber Rosa <crosa@redhat.com>

--

Changes from v1 (#2100):
 * Write the file at `$job_resutls_dir/results.html` and link at `$job_results_dir/html/results.html`