### PR TITLE
Fix replay `--execution-order`

### DIFF
--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -209,7 +209,8 @@ class Replay(CLI):
                      'external_runner_testdir',
                      'external_runner_chdir',
                      'failfast',
-                     'ignore_missing_references']
+                     'ignore_missing_references',
+                     'execution_order']
         if replay_args is None:
             LOG_UI.warn('Source job args data not found. These options will '
                         'not be loaded in this replay job: %s',

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -99,7 +99,7 @@ class Run(CLICmd):
                             "system information (hardware details, profilers, "
                             "etc.). Current:  %(default)s")
 
-        parser.add_argument("--execution-order", default="variants-per-test",
+        parser.add_argument("--execution-order",
                             choices=("tests-per-variant",
                                      "variants-per-test"),
                             help="Defines the order of iterating through test "


### PR DESCRIPTION
Some adjusts are needed in order to have `--execution-order` properly working with `replay`.

The commits here were cherry-picked from PR #2099.