### PR TITLE
Broken plugin notification: fix behavior with additional config files

### DIFF
--- a/avocado/core/app.py
+++ b/avocado/core/app.py
@@ -50,11 +50,11 @@ class AvocadoApp(object):
         self.parser = Parser()
         output.early_start()
         try:
+            self.parser.start()
             self.cli_dispatcher = CLIDispatcher()
             self.cli_cmd_dispatcher = CLICmdDispatcher()
             output.log_plugin_failures(self.cli_dispatcher.load_failures +
                                        self.cli_cmd_dispatcher.load_failures)
-            self.parser.start()
             if self.cli_cmd_dispatcher.extensions:
                 self.cli_cmd_dispatcher.map_method('configure', self.parser)
             if self.cli_dispatcher.extensions:


### PR DESCRIPTION
When trying out Avocado installations, I wanted to silence the plugin
errors that I knew would fail to load.  I chose to do that by running
a command such as:

 $ avocado --config=silent_plugins.conf run passtest.py

But it did not behave as expected.  The reason is that plugins are
loaded first, and then the parsing of command line (with additional
parsing of config files) is done.  Let's parse the command line
earlier then.

Signed-off-by: Cleber Rosa <crosa@redhat.com>