### PR TITLE
HTML report: remove legacy symlink

### DIFF
--- a/optional_plugins/html/avocado_result_html/__init__.py
+++ b/optional_plugins/html/avocado_result_html/__init__.py
@@ -267,15 +267,8 @@ class HTMLResult(Result):
 
         open_browser = getattr(job.args, 'open_browser', False)
         if getattr(job.args, 'html_job_result', 'off') == 'on':
-            # FIXME: remove html legacy dir after 52.0 LTS release
-            html_legacy_dir = os.path.join(job.logdir, 'html')
-            if os.path.exists(html_legacy_dir):    # update the html result if exists
-                shutil.rmtree(html_legacy_dir)
             html_path = os.path.join(job.logdir, 'results.html')
             self._render(result, html_path)
-            os.makedirs(html_legacy_dir)
-            os.symlink(os.path.join(os.path.pardir, 'results.html'),
-                       os.path.join(html_legacy_dir, 'results.html'))
             if getattr(job.args, 'stdout_claimed_by', None) is None:
                 LOG_UI.info("JOB HTML   : %s", html_path)
             if open_browser:


### PR DESCRIPTION
The location of the HTML report was moved from
`$RESULTS/html/results.html` to `$RESULTS/results.html`, while a link
was left on the first location.

We don't have to carry that compatibility link anymore.

Signed-off-by: Cleber Rosa <crosa@redhat.com>