### PR TITLE
Tags: add short command line option for `--filter-by-tags`

### DIFF
--- a/avocado/plugins/list.py
+++ b/avocado/plugins/list.py
@@ -175,7 +175,7 @@ class List(CLICmd):
         loader.add_loader_options(parser)
 
         filtering = parser.add_argument_group('filtering parameters')
-        filtering.add_argument('--filter-by-tags', metavar='TAGS',
+        filtering.add_argument('-t', '--filter-by-tags', metavar='TAGS',
                                action='append',
                                help='Filter INSTRUMENTED tests based on '
                                '":avocado: tags=tag1,tag2" notation in '

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -145,7 +145,7 @@ class Run(CLICmd):
         loader.add_loader_options(parser)
 
         filtering = parser.add_argument_group('filtering parameters')
-        filtering.add_argument('--filter-by-tags', metavar='TAGS',
+        filtering.add_argument('-t', '--filter-by-tags', metavar='TAGS',
                                action='append',
                                help='Filter INSTRUMENTED tests based on '
                                '":avocado: tags=tag1,tag2" notation in '


### PR DESCRIPTION
It looks like the tags mechanism has a lot of potential to be used
very often, so a long command line option seems to much typing.

Let's add `-t` (for *t*ags), to allow users to run commands which
are much nicer to type, such as:

 $ avocado run . -t BZ12345678

Signed-off-by: Cleber Rosa <crosa@redhat.com>