### PR TITLE
PoC: Yaml testsuite loader

### DIFF
--- a/avocado/core/mux.py
+++ b/avocado/core/mux.py
@@ -22,7 +22,6 @@ a custom Varianter plugin.
 #
 
 import collections
-import hashlib
 import itertools
 import re
 
@@ -167,13 +166,8 @@ class MuxPlugin(object):
         self.variant_ids = self._get_variant_ids()
 
     def _get_variant_ids(self):
-        variant_ids = []
-        for variant in MuxTree(self.root):
-            variant.sort(key=lambda x: x.path)
-            fingerprint = "-".join(_.fingerprint() for _ in variant)
-            variant_ids.append("-".join(node.name for node in variant) + '-' +
-                               hashlib.sha1(fingerprint).hexdigest()[:4])
-        return variant_ids
+        return [varianter.generate_variant_id(variant)
+                for variant in MuxTree(self.root)]
 
     def __iter__(self):
         """

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -29,6 +29,7 @@ from . import test
 from . import exceptions
 from . import output
 from . import status
+from . import varianter
 from .loader import loader
 from .status import mapping
 from ..utils import wait
@@ -506,10 +507,19 @@ class TestRunner(object):
         params = variant.get("variant"), variant.get("mux_path")
         if params:
             if "params" in template[1]:
-                msg = ("Unable to use test variants %s, params are already"
-                       " present in test factory: %s"
-                       % (template[0], template[1]))
-                raise ValueError(msg)
+                if not varianter.is_empty_variant(params[0]):
+                    msg = ("Specifying test params from test loader and "
+                           "from varianter at the same time is not yet "
+                           "supported. Please remove either variants defined"
+                           "by the varianter (%s) or make the test loader of"
+                           "test %s to not to fill variants."
+                           % (variant, template))
+                    raise NotImplementedError(msg)
+                params = template[1]["params"]
+                variant_id = varianter.generate_variant_id(params[0])
+                return template, {"variant": params[0],
+                                  "variant_id": variant_id,
+                                  "mux_path": params[1]}
             factory = [template[0], template[1].copy()]
             factory[1]["params"] = params
         else:

--- a/avocado/core/varianter.py
+++ b/avocado/core/varianter.py
@@ -310,6 +310,16 @@ class AvocadoParam(object):
                 yield (leaf.environment.origin[key].path, key, value)
 
 
+def is_empty_variant(variant):
+    """
+    Reports whether the variant contains any data
+
+    :param variant: Avocado test variant (list of TreeNode-like objects)
+    :return: True when the variant does not contain (any useful) data
+    """
+    return not variant or variant == [tree.TreeNode()] * len(variant)
+
+
 def generate_variant_id(variant):
     """
     Basic function to generate variant-id from a variant

--- a/avocado/core/varianter.py
+++ b/avocado/core/varianter.py
@@ -19,6 +19,7 @@
 Multiplex and create variants.
 """
 
+import hashlib
 import re
 
 from . import tree
@@ -307,6 +308,20 @@ class AvocadoParam(object):
         for leaf in self._leaves:
             for key, value in leaf.environment.iteritems():
                 yield (leaf.environment.origin[key].path, key, value)
+
+
+def generate_variant_id(variant):
+    """
+    Basic function to generate variant-id from a variant
+
+    :param variant: Avocado test variant (list of TreeNode-like objects)
+    :return: String compound of ordered node names and a hash of all
+             values.
+    """
+    variant = sorted(variant, key=lambda x: x.path)
+    fingerprint = "-".join(_.fingerprint() for _ in variant)
+    return ("-".join(node.name for node in variant) + '-' +
+            hashlib.sha1(fingerprint).hexdigest()[:4])
 
 
 def variant_to_str(variant, verbosity, out_args=None, debug=False):

--- a/examples/yaml_to_mux_loader/advanced.yaml
+++ b/examples/yaml_to_mux_loader/advanced.yaml
@@ -1,0 +1,20 @@
+# Notice the order of params and tests...
+
+timeout: !mux
+    short:
+        timeout: 2
+    longer:
+        timeout: 6
+    no_timeout:
+tests: !mux
+    passtest:
+        test_reference: passtest.py
+    sleeptest:
+        test_reference: sleeptest.py
+        !include : ../tests/sleeptest.py.data/sleeptest.yaml
+    failtest:
+        test_reference: failtest.py
+        some_test_variants: !mux
+            this_fails:
+            this_also_fails:
+            and_this_fails_as_well:

--- a/examples/yaml_to_mux_loader/basic.yaml
+++ b/examples/yaml_to_mux_loader/basic.yaml
@@ -1,0 +1,14 @@
+# test_reference - specifies the test reference to be loaded with the default
+#     (file) loader.
+
+!mux
+passtest:
+    test_reference: passtest.py
+sleeptest:
+    test_reference: sleeptest.py
+failtest:
+    test_reference: failtest.py
+    some_test_variants: !mux
+        this_fails:
+        this_also_fails:
+        and_this_fails_as_well:

--- a/examples/yaml_to_mux_loader/future.yaml
+++ b/examples/yaml_to_mux_loader/future.yaml
@@ -1,0 +1,51 @@
+# test_reference_resolver - should map to initialized loaders from the
+#     LoaderProxy (Not supported in this PoC)
+# test_reference_resolver_class - should be an importable loader class
+#     which receives the arguments from this loader plugin. (Not supported
+#     in this PoC)
+# test_reference_resolver_extra - extra argument to the resolver_class
+
+iterations: !mux
+    1:
+    2:
+    3:
+    4:
+    5:
+qemu-versions: !mux
+    upstream:
+        # TODO: Support relative-path internal filters
+        # or at least prefix the current location if needed
+        !filter-only : "*/machine_type/ppc64le/*"
+        qemu_compile_location: git://...
+    downstream:
+        !filter-only : "*/machine_type/ppc64le/*"
+        qemu_compile_location: git://...
+archs:
+    machine_type: !mux
+        ppc64:
+            machine_type: ppc64
+        ppc64le:
+            machine_type: ppc64le
+tests: !mux
+    install_qemu:
+        test_reference_resolver: file
+        test_reference: "install_qemu"
+    unattended_install:
+        test_reference: "unattended_install.cdrom.extra_cdrom_ks.default_install.aio_threads"
+    boot:
+        test_reference: boot
+    migrate:
+        test_reference: migrate.with_reboot.tcp
+    sleeptest:
+        test_reference_resolver: file
+        test_reference: sleeptest.py
+        variants:
+            !include : /usr/share/avocado/examples/tests/sleeptest.py.data/sleeptest.yaml
+    iotests:
+        test_reference_resolver_class: external
+        test_reference_resolver_extra: "./check"
+        !include : tests/iotests.yaml
+    kvm-unit-tests:
+        test_reference_resolver: external
+        test_reference_resolver_extra: "./run_kvm_unittest"
+        test_reference: ...


### PR DESCRIPTION
Hello guys,

this attempts to solve our long-outstanding inability of assign variants to only some of the tests in the testsuite. It adds a new loader (for demonstration purpose bundled with the optional yaml_to_mux varianter plugin, but the location might change) which goes through a YAML file, allows the same syntax as `yaml_to_mux` but instead of just producing variants it looks for `test_reference` key per each variant. If available it uses the file loader (support for other loaders is definitely expected in final version) to discover it and it associates the __current__ variant/params to that test. This is then passed to the runner and executed with the params filled by the loader (not the varianter).

You can test this by running:

    $ avocado run examples/yaml_to_mux_loader/basic.yaml

Limitations of this PoC to be tackled in final version:

1. it should allow to specify the loader including custom loader classes
2. it should allow merging variants defined by loader and varianter (currently it detects such use and reports NotImplementedError)

@clebergnu, @lmr, @jscotka, @amoskong I think you might be interested in this as you asked for such feature in history (if I'm not mistaken). Please let me know whether this would help or even solve your issues and whether you see anything which might help improving this feature.