### PR TITLE
varianter: Fix mux_path on no-variants

### DIFF
--- a/avocado/core/varianter.py
+++ b/avocado/core/varianter.py
@@ -606,4 +606,4 @@ class Varianter(object):
         else:   # No variants, use template
             yield {"variant": self._default_params.get_leaves(),
                    "variant_id": None,
-                   "mux_path": "/run"}
+                   "mux_path": ["/run/*"]}

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -189,6 +189,11 @@ class RunnerOperationTest(unittest.TestCase):
         cmd_line = ('%s run --sysinfo=off --job-results-dir %s '
                     'passtest.py passtest.py' % (AVOCADO, self.tmpdir))
         process.run(cmd_line)
+        # Also check whether jobdata contains correct mux_path
+        variants = open(os.path.join(self.tmpdir, "latest", "jobdata",
+                        "variants.json")).read()
+        self.assertIn('["/run/*"]', variants, "mux_path stored in jobdata "
+                      "does not contains [\"/run/*\"]\n%s" % variants)
 
     def test_runner_failfast(self):
         os.chdir(basedir)

--- a/selftests/functional/test_multiplex.py
+++ b/selftests/functional/test_multiplex.py
@@ -78,13 +78,25 @@ class MultiplexTests(unittest.TestCase):
                     % (AVOCADO, self.tmpdir))
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.run_and_check(cmd_line, expected_rc, (4, 0))
+        # Also check whether jobdata contains correct mux_path
+        variants = open(os.path.join(self.tmpdir, "latest", "jobdata",
+                        "variants.json")).read()
+        self.assertIn('["/run/*"]', variants, "mux_path stored in jobdata "
+                      "does not contains [\"/run/*\"]\n%s" % variants)
 
     def test_run_mplex_doublepass(self):
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
                     'passtest.py passtest.py -m '
-                    'examples/tests/sleeptest.py.data/sleeptest.yaml'
+                    'examples/tests/sleeptest.py.data/sleeptest.yaml '
+                    '--mux-path /foo/\\* /bar/\\* /baz/\\*'
                     % (AVOCADO, self.tmpdir))
         self.run_and_check(cmd_line, exit_codes.AVOCADO_ALL_OK, (8, 0))
+        # Also check whether jobdata contains correct mux_path
+        variants = open(os.path.join(self.tmpdir, "latest", "jobdata",
+                        "variants.json")).read()
+        exp = '["/foo/*", "/bar/*", "/baz/*"]'
+        self.assertIn(exp, variants, "mux_path stored in jobdata "
+                      "does not contains %s\n%s" % (exp, variants))
 
     def test_run_mplex_failtest(self):
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off '


### PR DESCRIPTION
When no variants are provided Avocado sets the default variant, but
instead of list of mux paths it created just string "/run", which
processed into ["/", "r", "u", "n"]. Let's fix this by setting list.

Also the proper mux_path should be `/run/*` in order to include all
children nodes of the "/run".

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>