### PR TITLE
test: Store fail_reason only as string

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -707,12 +707,12 @@ class Test(unittest.TestCase):
         except exceptions.TestBaseException as detail:
             self.__status = detail.status
             self.__fail_class = detail.__class__.__name__
-            self.__fail_reason = detail
+            self.__fail_reason = str(detail)
             self.__traceback = stacktrace.prepare_exc_info(sys.exc_info())
         except AssertionError as detail:
             self.__status = 'FAIL'
             self.__fail_class = detail.__class__.__name__
-            self.__fail_reason = detail
+            self.__fail_reason = str(detail)
             self.__traceback = stacktrace.prepare_exc_info(sys.exc_info())
         except Exception as detail:
             self.__status = 'ERROR'


### PR DESCRIPTION
The fail_reason is the instance of the actual exception. We do store it
only as string in case of old-type exception, but even new style
exceptions might be not available when sys.path is different causing
unpickle on runner part impossible.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>