### PR TITLE
test: Remove unnecessary LazyProperty from Test class

### DIFF
--- a/examples/tests/synctest.py
+++ b/examples/tests/synctest.py
@@ -28,19 +28,19 @@ class SyncTest(Test):
         sync_tarball = self.params.get('sync_tarball', '*', 'synctest.tar.bz2')
         tarball_path = os.path.join(self.datadir, sync_tarball)
         archive.extract(tarball_path, self.srcdir)
-        self.srcdir = os.path.join(self.srcdir, 'synctest')
+        srcdir = os.path.join(self.srcdir, 'synctest')
+        os.chdir(srcdir)
         if self.params.get('debug_symbols', default=True):
-            build.make(self.srcdir,
+            build.make(srcdir,
                        env={'CFLAGS': '-g -O0'},
                        extra_args='synctest')
         else:
-            build.make(self.srcdir)
+            build.make(srcdir)
 
     def test(self):
         """
         Execute synctest with the appropriate params.
         """
-        os.chdir(self.srcdir)
         path = os.path.join(os.getcwd(), 'synctest')
         cmd = ('%s %s %s' %
                (path, self.params.get('sync_length', default=100),

--- a/examples/tests/trinity.py
+++ b/examples/tests/trinity.py
@@ -31,10 +31,10 @@ class TrinityTest(Test):
         tarball = self.params.get('tarball', default='trinity-1.5.tar.bz2')
         tarball_path = os.path.join(self.datadir, tarball)
         archive.extract(tarball_path, self.srcdir)
-        self.srcdir = os.path.join(self.srcdir, 'trinity-1.5')
-        os.chdir(self.srcdir)
+        srcdir = os.path.join(self.srcdir, 'trinity-1.5')
+        os.chdir(srcdir)
         process.run('./configure.sh')
-        build.make(self.srcdir)
+        build.make(srcdir)
         self.victims_path = data_factory.make_dir_and_populate(self.workdir)
 
     def test(self):


### PR DESCRIPTION
Most of the LazyProperty variables in Test are actually always read on
"get_state" and other occasions so it does not make sense to set it
Lazily.

Also protect the remaining lazily initialized property from overriding
by using @property instead of our custom LazyProperty, which is not
really a property.

This commit requires some adjustments to nasty example tests which used
to override self.srcdir, which is not allowed (and restricted since this
commit).

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>