### PR TITLE
PoC: Redirect 1 and 2 to test's stdout

### DIFF
--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -608,19 +608,23 @@ class LoggingFile(object):
     """
 
     def __init__(self, prefix='', level=logging.DEBUG,
-                 logger=[logging.getLogger()]):
+                 loggers=None):
         """
-        Constructor. Sets prefixes and which logger is going to be used.
+        Constructor. Sets prefixes and which loggers is going to be used.
 
         :param prefix - The prefix for each line logged by this object.
+        :param level: Log level to be used when writing messages.
+        :param loggers: Loggers into which write should be issued.
         """
 
         self._prefix = prefix
+        if not loggers:
+            loggers = [logging.getLogger()]
         self._level = level
         self._buffer = []
-        if not isinstance(logger, list):
-            logger = [logger]
-        self._logger = logger
+        if not isinstance(loggers, list):
+            loggers = [loggers]
+        self._loggers = loggers
 
     def write(self, data):
         """"
@@ -651,7 +655,7 @@ class LoggingFile(object):
         """
         Passes lines of output to the logging module.
         """
-        for lg in self._logger:
+        for lg in self._loggers:
             lg.log(self._level, self._prefix + line)
 
     def _flush_buffer(self):
@@ -666,10 +670,10 @@ class LoggingFile(object):
         return False
 
     def add_logger(self, logger):
-        self._logger.append(logger)
+        self._loggers.append(logger)
 
     def rm_logger(self, logger):
-        self._logger.remove(logger)
+        self._loggers.remove(logger)
 
 
 class Throbber(object):

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -607,17 +607,15 @@ class LoggingFile(object):
     File-like object that will receive messages pass them to logging.
     """
 
-    def __init__(self, prefix='', level=logging.DEBUG,
+    def __init__(self, prefixes=None, level=logging.DEBUG,
                  loggers=None):
         """
         Constructor. Sets prefixes and which loggers is going to be used.
 
-        :param prefix - The prefix for each line logged by this object.
+        :param prefixes: Prefix per logger to be prefixed to each line.
         :param level: Log level to be used when writing messages.
         :param loggers: Loggers into which write should be issued.
         """
-
-        self._prefix = prefix
         if not loggers:
             loggers = [logging.getLogger()]
         self._level = level
@@ -625,6 +623,9 @@ class LoggingFile(object):
         if not isinstance(loggers, list):
             loggers = [loggers]
         self._loggers = loggers
+        if prefixes is None:
+            prefixes = [""] * len(loggers)
+        self._prefixes = prefixes
 
     def write(self, data):
         """"
@@ -655,8 +656,8 @@ class LoggingFile(object):
         """
         Passes lines of output to the logging module.
         """
-        for lg in self._loggers:
-            lg.log(self._level, self._prefix + line)
+        for i in xrange(len(self._loggers)):
+            self._loggers[i].log(self._level, self._prefixes[i] + line)
 
     def _flush_buffer(self):
         if self._buffer:
@@ -669,11 +670,14 @@ class LoggingFile(object):
     def isatty(self):
         return False
 
-    def add_logger(self, logger):
+    def add_logger(self, logger, prefix=""):
         self._loggers.append(logger)
+        self._prefixes.append(prefix)
 
     def rm_logger(self, logger):
+        idx = self._loggers.index(logger)
         self._loggers.remove(logger)
+        self._prefixes = self._prefixes[:idx] + self._prefixes[idx+1:]
 
 
 class Throbber(object):

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -472,6 +472,21 @@ class FilterInfoAndLess(logging.Filter):
         return record.levelno <= logging.INFO
 
 
+class FilenoHandler(logging.StreamHandler):
+    def __init__(self, fileno):
+        super(FilenoHandler, self).__init__()
+        self.fileno = fileno
+
+    def emit(self, record):
+        try:
+            msg = self.format(record)
+            os.write(self.fileno, msg + "\n")
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except Exception:
+            self.handleError(record)
+
+
 class ProgressStreamHandler(logging.StreamHandler):
 
     """

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -17,7 +17,6 @@
 Test runner module.
 """
 
-import logging
 import multiprocessing
 from multiprocessing import queues
 import os
@@ -300,12 +299,8 @@ class TestRunner(object):
         :type queue: :class:`multiprocessing.Queue` instance.
         """
         signal.signal(signal.SIGTSTP, signal.SIG_IGN)
-        logger_list_stdout = [TEST_LOG,
-                              logging.getLogger('paramiko')]
-        logger_list_stderr = [TEST_LOG,
-                              logging.getLogger('paramiko')]
-        sys.stdout = output.LoggingFile(loggers=logger_list_stdout)
-        sys.stderr = output.LoggingFile(loggers=logger_list_stderr)
+        sys.stdout = output.LoggingFile(loggers=[TEST_LOG])
+        sys.stderr = output.LoggingFile(loggers=[TEST_LOG])
 
         def sigterm_handler(signum, frame):     # pylint: disable=W0613
             """ Produce traceback on SIGTERM """

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -299,8 +299,8 @@ class TestRunner(object):
         :type queue: :class:`multiprocessing.Queue` instance.
         """
         signal.signal(signal.SIGTSTP, signal.SIG_IGN)
-        sys.stdout = output.LoggingFile(loggers=[TEST_LOG])
-        sys.stderr = output.LoggingFile(loggers=[TEST_LOG])
+        sys.stdout = output.LoggingFile(["[stdout] "], loggers=[TEST_LOG])
+        sys.stderr = output.LoggingFile(["[stderr] "], loggers=[TEST_LOG])
 
         def sigterm_handler(signum, frame):     # pylint: disable=W0613
             """ Produce traceback on SIGTERM """

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -17,11 +17,14 @@
 Test runner module.
 """
 
+import logging
 import multiprocessing
 from multiprocessing import queues
 import os
+import select
 import signal
 import sys
+import threading
 import time
 
 from . import test
@@ -284,6 +287,20 @@ class TestRunner(object):
         self.result = result
         self.sigstopped = False
 
+    def _pipe_to_file(self, pipe, target, finish):
+        while True:
+            # finish, nor select should be necessary, I just forgot to close
+            # the pipe somewhere...
+            if finish:
+                break
+            if select.select([pipe], [], [], 0.1)[0]:
+                data = os.read(pipe, 1024)
+                if data:
+                    target.write(data)
+                else:
+                    break
+        os.close(pipe)
+
     def _run_test(self, test_factory, queue):
         """
         Run a test instance.
@@ -299,8 +316,65 @@ class TestRunner(object):
         :type queue: :class:`multiprocessing.Queue` instance.
         """
         signal.signal(signal.SIGTSTP, signal.SIG_IGN)
+        # backup the raw outputs
+        raw_1 = os.dup(1)
+        raw_2 = os.dup(2)
+        # replace StreamHandlers in logging with handlers that output into
+        # raw outputs (to avoid double [stdout] prefixes)
+        for log in logging.Logger.manager.loggerDict.itervalues():
+            if not hasattr(log, "handlers"):
+                continue
+            stdouts = []
+            stderrs = []
+            for handler in log.handlers:
+                stream = getattr(handler, "stream", None)
+                if not stream:
+                    continue
+                elif stream == sys.stdout:
+                    stdouts.append(handler)
+                elif stream == sys.stderr:
+                    stderrs.append(handler)
+            if stdouts:
+                for handler in stdouts:
+                    if handler in log.handlers:
+                        log.handlers.remove(handler)
+                new_handler = output.FilenoHandler(raw_1)
+                new_handler.filters = handler.filters
+                new_handler.formatter = handler.formatter
+                log.addHandler(new_handler)
+            if stderrs:
+                for handler in stderrs:
+                    if handler in log.handlers:
+                        log.handlers.remove(handler)
+                new_handler = output.FilenoHandler(raw_2)
+                new_handler.filters = handler.filters
+                new_handler.formatter = handler.formatter
+                log.addHandler(new_handler)
+        # Replace sys.stdout with logger-redirector
+        #   * here avocado.test is added with "[stdout] " prefix (job.log,
+        #     debug.log, if enabled also (raw)stdout)
+        #   * on Test._start_logging avocado.test.stdout is added without
+        #     any prefix (stdout)
         sys.stdout = output.LoggingFile(["[stdout] "], loggers=[TEST_LOG])
         sys.stderr = output.LoggingFile(["[stderr] "], loggers=[TEST_LOG])
+
+        # Create pipes to be able to replace fd1 and fd2 with a fd
+        stdout_out, stdout_in = os.pipe()
+        stderr_out, stderr_in = os.pipe()
+
+        # Start threads to read from fd1 and fd2 and forward it to the
+        # "updated" stdout/stderr (the logger-redirection)
+        # note: The finish should not be necessary, I just had no time to
+        #       debug where I forgot to close the pipe...
+        finish = []
+        th_stdout = threading.Thread(target=self._pipe_to_file,
+                                     name="1_to_stdout",
+                                     args=(stdout_out, sys.stdout, finish))
+        th_stderr = threading.Thread(target=self._pipe_to_file,
+                                     name="2_to_stderr",
+                                     args=(stderr_out, sys.stderr, finish))
+        th_stdout.start()
+        th_stderr.start()
 
         def sigterm_handler(signum, frame):     # pylint: disable=W0613
             """ Produce traceback on SIGTERM """
@@ -316,7 +390,12 @@ class TestRunner(object):
         # STDIN fd (0), with the same fd previously set by
         # `multiprocessing.Process()`
         os.dup2(sys.stdin.fileno(), 0)
-
+        # Replace the 1 and 2 with our pipe, which then forwards the output
+        # to the logger redirector, which produces raw messages in the "stdout"
+        # file as well as "[stdout] " prefixed ones in avocado.test logger.
+        os.dup2(stdout_in, 1)
+        os.dup2(stderr_in, 2)
+        # Now we are all set...
         instance = loader.load_test(test_factory)
         if instance.runner_queue is None:
             instance.set_runner_queue(queue)
@@ -335,6 +414,15 @@ class TestRunner(object):
         try:
             instance.run_avocado()
         finally:
+            # Finish the logging, theoretically we should replace the output
+            # with raw_outputs to be able to see what's going on after this
+            # point. This is why we don't see the `del_1/2` messages in the
+            # selftest.
+            finish.append(True)
+            os.close(stdout_in)
+            os.close(stderr_in)
+            th_stdout.join()
+            th_stderr.join()
             try:
                 state = instance.get_state()
                 queue.put(state)
@@ -377,7 +465,7 @@ class TestRunner(object):
         signal.signal(signal.SIGTSTP, sigtstp_handler)
 
         proc = multiprocessing.Process(target=self._run_test,
-                                       args=(test_factory, queue,))
+                                       args=(test_factory, queue))
         test_status = TestStatus(self.job, queue)
 
         cycle_timeout = 1

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -304,8 +304,8 @@ class TestRunner(object):
                               logging.getLogger('paramiko')]
         logger_list_stderr = [TEST_LOG,
                               logging.getLogger('paramiko')]
-        sys.stdout = output.LoggingFile(logger=logger_list_stdout)
-        sys.stderr = output.LoggingFile(logger=logger_list_stderr)
+        sys.stdout = output.LoggingFile(loggers=logger_list_stdout)
+        sys.stderr = output.LoggingFile(loggers=logger_list_stderr)
 
         def sigterm_handler(signum, frame):     # pylint: disable=W0613
             """ Produce traceback on SIGTERM """

--- a/optional_plugins/robot/avocado_robot/__init__.py
+++ b/optional_plugins/robot/avocado_robot/__init__.py
@@ -54,8 +54,8 @@ class RobotTest(test.SimpleTest):
         Create the Robot command and execute it.
         """
         suite_name, test_name = self.name.name.split(':')[1].split('.')
-        log_stdout = output.LoggingFile(logger=[self.log], level=logging.INFO)
-        log_stderr = output.LoggingFile(logger=[self.log], level=logging.ERROR)
+        log_stdout = output.LoggingFile(loggers=[self.log], level=logging.INFO)
+        log_stderr = output.LoggingFile(loggers=[self.log], level=logging.ERROR)
         result = run(self.filename,
                      suite=suite_name,
                      test=test_name,

--- a/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
+++ b/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
@@ -487,8 +487,8 @@ class RemoteTestRunner(TestRunner):
         if self.job.args.show_job_log:
             logger_list.append(app_logger)
             output.add_log_handler(paramiko_logger.name)
-        sys.stdout = output.LoggingFile(logger=logger_list)
-        sys.stderr = output.LoggingFile(logger=logger_list)
+        sys.stdout = output.LoggingFile(loggers=logger_list)
+        sys.stderr = output.LoggingFile(loggers=logger_list)
         try:
             try:
                 self.setup()

--- a/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
+++ b/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
@@ -483,10 +483,9 @@ class RemoteTestRunner(TestRunner):
         fabric_logger.addHandler(file_handler)
         paramiko_logger.addHandler(file_handler)
         remote_logger.addHandler(file_handler)
-        logger_list = [fabric_logger]
         if self.job.args.show_job_log:
-            logger_list.append(app_logger)
             output.add_log_handler(paramiko_logger.name)
+        logger_list = [output.LOG_JOB]
         sys.stdout = output.LoggingFile(loggers=logger_list)
         sys.stderr = output.LoggingFile(loggers=logger_list)
         try:


### PR DESCRIPTION
Only the last commit is the actual PoC, the rest is sent separately in https://github.com/avocado-framework/avocado/pull/2132 as sys.stdout handling fix. See the details in the very verbose last commit's message.