### PR TITLE
runner: Prefix sys.stdout|err output in test log with [stdout|stderr]

### DIFF
--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -608,19 +608,23 @@ class LoggingFile(object):
     """
 
     def __init__(self, prefix='', level=logging.DEBUG,
-                 logger=[logging.getLogger()]):
+                 loggers=None):
         """
-        Constructor. Sets prefixes and which logger is going to be used.
+        Constructor. Sets prefixes and which loggers is going to be used.
 
         :param prefix - The prefix for each line logged by this object.
+        :param level: Log level to be used when writing messages.
+        :param loggers: Loggers into which write should be issued.
         """
 
         self._prefix = prefix
+        if not loggers:
+            loggers = [logging.getLogger()]
         self._level = level
         self._buffer = []
-        if not isinstance(logger, list):
-            logger = [logger]
-        self._logger = logger
+        if not isinstance(loggers, list):
+            loggers = [loggers]
+        self._loggers = loggers
 
     def write(self, data):
         """"
@@ -651,7 +655,7 @@ class LoggingFile(object):
         """
         Passes lines of output to the logging module.
         """
-        for lg in self._logger:
+        for lg in self._loggers:
             lg.log(self._level, self._prefix + line)
 
     def _flush_buffer(self):
@@ -666,10 +670,10 @@ class LoggingFile(object):
         return False
 
     def add_logger(self, logger):
-        self._logger.append(logger)
+        self._loggers.append(logger)
 
     def rm_logger(self, logger):
-        self._logger.remove(logger)
+        self._loggers.remove(logger)
 
 
 class Throbber(object):

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -607,17 +607,15 @@ class LoggingFile(object):
     File-like object that will receive messages pass them to logging.
     """
 
-    def __init__(self, prefix='', level=logging.DEBUG,
+    def __init__(self, prefixes=None, level=logging.DEBUG,
                  loggers=None):
         """
         Constructor. Sets prefixes and which loggers is going to be used.
 
-        :param prefix - The prefix for each line logged by this object.
+        :param prefixes: Prefix per logger to be prefixed to each line.
         :param level: Log level to be used when writing messages.
         :param loggers: Loggers into which write should be issued.
         """
-
-        self._prefix = prefix
         if not loggers:
             loggers = [logging.getLogger()]
         self._level = level
@@ -625,6 +623,9 @@ class LoggingFile(object):
         if not isinstance(loggers, list):
             loggers = [loggers]
         self._loggers = loggers
+        if prefixes is None:
+            prefixes = [""] * len(loggers)
+        self._prefixes = prefixes
 
     def write(self, data):
         """"
@@ -655,8 +656,8 @@ class LoggingFile(object):
         """
         Passes lines of output to the logging module.
         """
-        for lg in self._loggers:
-            lg.log(self._level, self._prefix + line)
+        for i in xrange(len(self._loggers)):
+            self._loggers[i].log(self._level, self._prefixes[i] + line)
 
     def _flush_buffer(self):
         if self._buffer:
@@ -669,11 +670,14 @@ class LoggingFile(object):
     def isatty(self):
         return False
 
-    def add_logger(self, logger):
+    def add_logger(self, logger, prefix=""):
         self._loggers.append(logger)
+        self._prefixes.append(prefix)
 
     def rm_logger(self, logger):
+        idx = self._loggers.index(logger)
         self._loggers.remove(logger)
+        self._prefixes = self._prefixes[:idx] + self._prefixes[idx+1:]
 
 
 class Throbber(object):

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -17,7 +17,6 @@
 Test runner module.
 """
 
-import logging
 import multiprocessing
 from multiprocessing import queues
 import os
@@ -300,12 +299,8 @@ class TestRunner(object):
         :type queue: :class:`multiprocessing.Queue` instance.
         """
         signal.signal(signal.SIGTSTP, signal.SIG_IGN)
-        logger_list_stdout = [TEST_LOG,
-                              logging.getLogger('paramiko')]
-        logger_list_stderr = [TEST_LOG,
-                              logging.getLogger('paramiko')]
-        sys.stdout = output.LoggingFile(loggers=logger_list_stdout)
-        sys.stderr = output.LoggingFile(loggers=logger_list_stderr)
+        sys.stdout = output.LoggingFile(loggers=[TEST_LOG])
+        sys.stderr = output.LoggingFile(loggers=[TEST_LOG])
 
         def sigterm_handler(signum, frame):     # pylint: disable=W0613
             """ Produce traceback on SIGTERM """

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -299,8 +299,8 @@ class TestRunner(object):
         :type queue: :class:`multiprocessing.Queue` instance.
         """
         signal.signal(signal.SIGTSTP, signal.SIG_IGN)
-        sys.stdout = output.LoggingFile(loggers=[TEST_LOG])
-        sys.stderr = output.LoggingFile(loggers=[TEST_LOG])
+        sys.stdout = output.LoggingFile(["[stdout] "], loggers=[TEST_LOG])
+        sys.stderr = output.LoggingFile(["[stderr] "], loggers=[TEST_LOG])
 
         def sigterm_handler(signum, frame):     # pylint: disable=W0613
             """ Produce traceback on SIGTERM """

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -304,8 +304,8 @@ class TestRunner(object):
                               logging.getLogger('paramiko')]
         logger_list_stderr = [TEST_LOG,
                               logging.getLogger('paramiko')]
-        sys.stdout = output.LoggingFile(logger=logger_list_stdout)
-        sys.stderr = output.LoggingFile(logger=logger_list_stderr)
+        sys.stdout = output.LoggingFile(loggers=logger_list_stdout)
+        sys.stderr = output.LoggingFile(loggers=logger_list_stderr)
 
         def sigterm_handler(signum, frame):     # pylint: disable=W0613
             """ Produce traceback on SIGTERM """

--- a/optional_plugins/robot/avocado_robot/__init__.py
+++ b/optional_plugins/robot/avocado_robot/__init__.py
@@ -54,8 +54,8 @@ class RobotTest(test.SimpleTest):
         Create the Robot command and execute it.
         """
         suite_name, test_name = self.name.name.split(':')[1].split('.')
-        log_stdout = output.LoggingFile(logger=[self.log], level=logging.INFO)
-        log_stderr = output.LoggingFile(logger=[self.log], level=logging.ERROR)
+        log_stdout = output.LoggingFile(loggers=[self.log], level=logging.INFO)
+        log_stderr = output.LoggingFile(loggers=[self.log], level=logging.ERROR)
         result = run(self.filename,
                      suite=suite_name,
                      test=test_name,

--- a/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
+++ b/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
@@ -487,8 +487,8 @@ class RemoteTestRunner(TestRunner):
         if self.job.args.show_job_log:
             logger_list.append(app_logger)
             output.add_log_handler(paramiko_logger.name)
-        sys.stdout = output.LoggingFile(logger=logger_list)
-        sys.stderr = output.LoggingFile(logger=logger_list)
+        sys.stdout = output.LoggingFile(loggers=logger_list)
+        sys.stderr = output.LoggingFile(loggers=logger_list)
         try:
             try:
                 self.setup()

--- a/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
+++ b/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
@@ -483,10 +483,9 @@ class RemoteTestRunner(TestRunner):
         fabric_logger.addHandler(file_handler)
         paramiko_logger.addHandler(file_handler)
         remote_logger.addHandler(file_handler)
-        logger_list = [fabric_logger]
         if self.job.args.show_job_log:
-            logger_list.append(app_logger)
             output.add_log_handler(paramiko_logger.name)
+        logger_list = [output.LOG_JOB]
         sys.stdout = output.LoggingFile(loggers=logger_list)
         sys.stderr = output.LoggingFile(loggers=logger_list)
         try:


### PR DESCRIPTION
This patch set fixes a bit the test's (runner's) logging setup and makes sure `sys.stdout` calls are properly forwarded with "[stdout] " prefix to `avocado.test` (job.log) and without any prefix to `avocado.test.stdout` (`test_result/stdout`).