### PR TITLE
utils.archive: Properly close the opened file

### DIFF
--- a/avocado/utils/archive.py
+++ b/avocado/utils/archive.py
@@ -186,7 +186,8 @@ class ArchiveFile(object):
                 dst = os.path.join(dst_dir, path)
                 if not os.path.islink(dst):
                     # Link created as an ordinary file containing the dst path
-                    src = open(dst, 'r').read()
+                    with open(dst, 'r') as dst_path:
+                        src = dst_path.read()
                 else:
                     # Link is already there and could be outdated. Let's read
                     # the original destination from the zip file.


### PR DESCRIPTION
On python3 this naked open reports ResourceWarning. Let's properly close
it:

```
python3 unit/test_archive.py 
.........../home/medic/Work/Projekty/avocado/avocado/build/lib/avocado/utils/archive.py:191: ResourceWarning: unclosed file <_io.TextIOWrapper name='/tmp/avocado___main__rv2ihor0/tmp0drzyrsb/dir/link_to_link_to_file2' mode='r' encoding='UTF-8'>
  src = open(dst, 'r').read()
/home/medic/Work/Projekty/avocado/avocado/build/lib/avocado/utils/archive.py:191: ResourceWarning: unclosed file <_io.TextIOWrapper name='/tmp/avocado___main__rv2ihor0/tmp0drzyrsb/dir/2nd_link_to_file' mode='r' encoding='UTF-8'>
  src = open(dst, 'r').read()
/home/medic/Work/Projekty/avocado/avocado/build/lib/avocado/utils/archive.py:191: ResourceWarning: unclosed file <_io.TextIOWrapper name='/tmp/avocado___main__rv2ihor0/tmp0drzyrsb/link_to_file' mode='r' encoding='UTF-8'>
  src = open(dst, 'r').read()
/home/medic/Work/Projekty/avocado/avocado/build/lib/avocado/utils/archive.py:191: ResourceWarning: unclosed file <_io.TextIOWrapper name='/tmp/avocado___main__rv2ihor0/tmp0drzyrsb/link_to_dir' mode='r' encoding='UTF-8'>
  src = open(dst, 'r').read()
/home/medic/Work/Projekty/avocado/avocado/build/lib/avocado/utils/archive.py:191: ResourceWarning: unclosed file <_io.TextIOWrapper name='/tmp/avocado___main__rv2ihor0/tmp0drzyrsb/link_to_file2' mode='r' encoding='UTF-8'>
  src = open(dst, 'r').read()
..
----------------------------------------------------------------------
Ran 13 tests in 0.059s

OK
```