### PR TITLE
Fix SIGINT/SIGTERM [V2]

### DIFF
--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -447,6 +447,7 @@ class TestRunner(object):
                                            ignore_window)
                         stage_1_msg_displayed = True
                     ignore_time_started = time.time()
+                    os.kill(proc.pid, signal.SIGINT)
                 if (ctrl_c_count > 1) and (time_elapsed > ignore_window):
                     if not stage_2_msg_displayed:
                         abort_reason = ("Interrupted by signal/SIGINT "

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -359,6 +359,7 @@ class TestRunner(object):
         :param job_deadline: Maximum time to execute.
         :type job_deadline: int.
         """
+        self.abort_reason = None
         proc = None
         sigtstp = multiprocessing.Lock()
 
@@ -379,6 +380,10 @@ class TestRunner(object):
                     process.kill_process_tree(proc.pid, signal.SIGSTOP, False)
                     self.sigstopped = True
 
+        def sigterm_handler(signum, frame):
+            self.abort_reason = "Interrupted by signal/SIGTERM"
+            os.kill(proc.pid, signal.SIGTERM)
+
         signal.signal(signal.SIGTSTP, sigtstp_handler)
 
         proc = multiprocessing.Process(target=self._run_test,
@@ -389,6 +394,7 @@ class TestRunner(object):
         time_started = time.time()
         proc.start()
 
+        signal.signal(signal.SIGTERM, sigterm_handler)
         test_status.wait_for_early_status(proc, 60)
 
         # At this point, the test is already initialized and we know
@@ -409,13 +415,12 @@ class TestRunner(object):
         stage_2_msg_displayed = False
         first = 0.01
         step = 0.01
-        abort_reason = None
         result_dispatcher = self.job._result_events_dispatcher
 
         while True:
             try:
                 if time.time() >= deadline:
-                    abort_reason = "Timeout reached"
+                    self.abort_reason = "Timeout reached"
                     try:
                         os.kill(proc.pid, signal.SIGTERM)
                     except OSError:
@@ -440,7 +445,7 @@ class TestRunner(object):
                 ctrl_c_count += 1
                 if ctrl_c_count == 1:
                     if not stage_1_msg_displayed:
-                        abort_reason = "Interrupted by signal/SIGINT"
+                        self.abort_reason = "Interrupted by signal/SIGINT"
                         self.job.log.debug("\nInterrupt requested. Waiting %d "
                                            "seconds for test to finish "
                                            "(ignoring new SIGINT until then)",
@@ -450,15 +455,15 @@ class TestRunner(object):
                     os.kill(proc.pid, signal.SIGINT)
                 if (ctrl_c_count > 1) and (time_elapsed > ignore_window):
                     if not stage_2_msg_displayed:
-                        abort_reason = ("Interrupted by signal/SIGINT "
-                                        "(multiple-times)")
+                        self.abort_reason = ("Interrupted by signal/SIGINT "
+                                             "(multiple-times)")
                         self.job.log.debug("Killing test subprocess %s",
                                            proc.pid)
                         stage_2_msg_displayed = True
-                    os.kill(proc.pid, signal.SIGKILL)
+                    os.kill(proc.pid, signal.SIGTERM)
 
         # Get/update the test status (decrease timeout on abort)
-        if abort_reason:
+        if self.abort_reason:
             finish_deadline = TIMEOUT_TEST_INTERRUPTED
         else:
             finish_deadline = deadline
@@ -467,9 +472,9 @@ class TestRunner(object):
                                         result_dispatcher)
 
         # Try to log the timeout reason to test's results and update test_state
-        if abort_reason:
+        if self.abort_reason:
             test_state = add_runner_failure(test_state, "INTERRUPTED",
-                                            abort_reason)
+                                            self.abort_reason)
 
         # don't process other tests from the list
         if ctrl_c_count > 0:

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -440,16 +440,17 @@ class TestRunner(object):
                 ctrl_c_count += 1
                 if ctrl_c_count == 1:
                     if not stage_1_msg_displayed:
-                        abort_reason = "Interrupted by ctrl+c"
+                        abort_reason = "Interrupted by signal/SIGINT"
                         self.job.log.debug("\nInterrupt requested. Waiting %d "
                                            "seconds for test to finish "
-                                           "(ignoring new Ctrl+C until then)",
+                                           "(ignoring new SIGINT until then)",
                                            ignore_window)
                         stage_1_msg_displayed = True
                     ignore_time_started = time.time()
                 if (ctrl_c_count > 1) and (time_elapsed > ignore_window):
                     if not stage_2_msg_displayed:
-                        abort_reason = "Interrupted by ctrl+c (multiple-times)"
+                        abort_reason = ("Interrupted by signal/SIGINT "
+                                        "(multiple-times)")
                         self.job.log.debug("Killing test subprocess %s",
                                            proc.pid)
                         stage_2_msg_displayed = True

--- a/selftests/functional/test_interrupt.py
+++ b/selftests/functional/test_interrupt.py
@@ -79,7 +79,7 @@ class InterruptTest(unittest.TestCase):
         proc.sendline('\x03')
         proc.read_until_last_line_matches('Interrupt requested. Waiting 2 '
                                           'seconds for test to finish '
-                                          '(ignoring new Ctrl+C until then)')
+                                          '(ignoring new SIGINT until then)')
         # We have to actually wait 2 seconds until the ignore window is over
         time.sleep(2.5)
         proc.sendline('\x03')
@@ -181,7 +181,7 @@ class InterruptTest(unittest.TestCase):
         self.assertNotIn('Killing test subprocess', proc.get_output())
         # Make sure the Interrupted requested sentence is there
         self.assertIn('Interrupt requested. Waiting 2 seconds for test to '
-                      'finish (ignoring new Ctrl+C until then)',
+                      'finish (ignoring new SIGINT until then)',
                       proc.get_output())
 
     def tearDown(self):

--- a/selftests/functional/test_interrupt.py
+++ b/selftests/functional/test_interrupt.py
@@ -7,7 +7,6 @@ import stat
 import subprocess
 import unittest
 
-import aexpect
 import psutil
 
 from avocado.utils import process
@@ -61,7 +60,7 @@ class InterruptTest(unittest.TestCase):
     @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 2,
                      "Skipping test that take a long time to run, are "
                      "resource intensive or time sensitve")
-    def test_badly_behaved(self):
+    def test_badly_behaved_sigint(self):
         """
         Make sure avocado can cleanly get out of a loop of badly behaved tests.
         """
@@ -70,24 +69,31 @@ class InterruptTest(unittest.TestCase):
         bad_test = script.TemporaryScript(bad_test_basename, BAD_TEST,
                                           'avocado_interrupt_test',
                                           mode=DEFAULT_MODE)
-
         bad_test.save()
-
         os.chdir(basedir)
-        cmd_line = ('%s run --sysinfo=off --job-results-dir %s '
-                    '%s %s %s' % (AVOCADO, self.tmpdir, bad_test.path,
-                                  bad_test.path, bad_test.path))
-        proc = aexpect.Expect(command=cmd_line, linesep='')
-        proc.read_until_last_line_matches(os.path.basename(bad_test.path))
-        proc.sendline('\x03')
-        proc.read_until_last_line_matches('Interrupt requested. Waiting 2 '
-                                          'seconds for test to finish '
-                                          '(ignoring new SIGINT until then)')
-        # We have to actually wait 2 seconds until the ignore window is over
+        cmd = ('%s run %s --sysinfo=off --job-results-dir %s ' %
+               (AVOCADO, bad_test.path, self.tmpdir))
+        proc = subprocess.Popen(cmd.split(),
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE)
+
+        def has_children():
+            return len(psutil.Process(proc.pid).children()) > 0
+        wait.wait_for(has_children, timeout=5)
+
+        os.kill(proc.pid, signal.SIGINT)
         time.sleep(2.5)
-        proc.sendline('\x03')
-        proc.read_until_last_line_matches('JOB TIME   : %d s')
-        wait.wait_for(lambda: not proc.is_alive(), timeout=1)
+        # We have to actually wait 2+ seconds until
+        # the ignore window is over
+        os.kill(proc.pid, signal.SIGINT)
+
+        def is_finished():
+            return proc.poll() is not None
+        finished = wait.wait_for(is_finished, timeout=5)
+        if not finished:
+            process.kill_process_tree(proc.pid)
+            self.fail('Avocado was still running after receiving SIGINT '
+                      'twice.')
 
         # Make sure the bad test will be really gone from the process table
         def wait_until_no_badtest():
@@ -120,14 +126,20 @@ class InterruptTest(unittest.TestCase):
 
             return len(bad_test_processes) == 0
 
-        wait.wait_for(wait_until_no_badtest, timeout=2)
+        if not wait.wait_for(wait_until_no_badtest, timeout=2):
+            self.fail('Avocado left processes behind.')
+
+        output = proc.communicate()[0]
+        # Make sure the Interrupted requested sentence is there
+        self.assertIn('Interrupt requested. Waiting 2 seconds for test to '
+                      'finish (ignoring new SIGINT until then)', output)
         # Make sure the Killing test subprocess message did appear
-        self.assertIn('Killing test subprocess', proc.get_output())
+        self.assertIn('Killing test subprocess', output)
 
     @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 1,
                      "Skipping test that take a long time to run, are "
                      "resource intensive or time sensitve")
-    def test_well_behaved(self):
+    def test_well_behaved_sigint(self):
         """
         Make sure avocado can cleanly get out of a loop of well behaved tests.
         """
@@ -139,14 +151,24 @@ class InterruptTest(unittest.TestCase):
         good_test.save()
 
         os.chdir(basedir)
-        cmd_line = ('%s run --sysinfo=off --job-results-dir %s '
-                    '%s %s %s' % (AVOCADO, self.tmpdir, good_test.path,
-                                  good_test.path, good_test.path))
-        proc = aexpect.Expect(command=cmd_line, linesep='')
-        proc.read_until_last_line_matches(os.path.basename(good_test.path))
-        proc.sendline('\x03')
-        proc.read_until_last_line_matches('JOB TIME   : %d s')
-        wait.wait_for(lambda: not proc.is_alive(), timeout=1)
+        cmd = ('%s run %s --sysinfo=off --job-results-dir %s ' %
+               (AVOCADO, good_test.path, self.tmpdir))
+        proc = subprocess.Popen(cmd.split(),
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE)
+
+        def has_children():
+            return len(psutil.Process(proc.pid).children()) > 0
+        wait.wait_for(has_children, timeout=5)
+
+        os.kill(proc.pid, signal.SIGINT)
+
+        def is_finished():
+            return proc.poll() is not None
+        finished = wait.wait_for(is_finished, timeout=5)
+        if not finished:
+            process.kill_process_tree(proc.pid)
+            self.fail('Avocado was still running after receiving SIGINT.')
 
         # Make sure the good test will be really gone from the process table
         def wait_until_no_goodtest():
@@ -179,21 +201,94 @@ class InterruptTest(unittest.TestCase):
 
             return len(good_test_processes) == 0
 
-        wait.wait_for(wait_until_no_goodtest, timeout=2)
+        if not wait.wait_for(wait_until_no_goodtest, timeout=2):
+            self.fail('Avocado left processes behind.')
+
+        output = proc.communicate()[0]
         # Make sure the Killing test subprocess message is not there
-        self.assertNotIn('Killing test subprocess', proc.get_output())
+        self.assertNotIn('Killing test subprocess', output)
         # Make sure the Interrupted requested sentence is there
         self.assertIn('Interrupt requested. Waiting 2 seconds for test to '
-                      'finish (ignoring new SIGINT until then)',
-                      proc.get_output())
+                      'finish (ignoring new SIGINT until then)', output)
+
+    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 2,
+                     "Skipping test that take a long time to run, are "
+                     "resource intensive or time sensitve")
+    def test_badly_behaved_sigterm(self):
+        """
+        Make sure avocado can cleanly get out of a loop of badly behaved tests.
+        """
+        bad_test_basename = ('wontquit-%s' %
+                             data_factory.generate_random_string(5))
+        bad_test = script.TemporaryScript(bad_test_basename, BAD_TEST,
+                                          'avocado_interrupt_test',
+                                          mode=DEFAULT_MODE)
+        bad_test.save()
+        os.chdir(basedir)
+        cmd = ('%s run %s --sysinfo=off --job-results-dir %s ' %
+               (AVOCADO, bad_test.path, self.tmpdir))
+        proc = subprocess.Popen(cmd.split(),
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE)
+
+        def has_children():
+            return len(psutil.Process(proc.pid).children()) > 0
+        wait.wait_for(has_children, timeout=5)
+
+        os.kill(proc.pid, signal.SIGTERM)
+
+        def is_finished():
+            return proc.poll() is not None
+        finished = wait.wait_for(is_finished, timeout=5)
+        if not finished:
+            process.kill_process_tree(proc.pid)
+            self.fail('Avocado was still running after receiving SIGINT '
+                      'twice.')
+
+        # Make sure the bad test will be really gone from the process table
+        def wait_until_no_badtest():
+            bad_test_processes = []
+
+            old_psutil = False
+            try:
+                process_list = psutil.pids()
+            except AttributeError:
+                process_list = psutil.get_pid_list()
+                old_psutil = True
+
+            for p in process_list:
+                try:
+                    p_obj = psutil.Process(p)
+                    if p_obj is not None:
+                        if old_psutil:
+                            cmdline_list = psutil.Process(p).cmdline
+                        else:
+                            try:
+                                cmdline_list = psutil.Process(p).cmdline()
+                            except psutil.AccessDenied:
+                                cmdline_list = []
+                        if bad_test.path in " ".join(cmdline_list):
+                            bad_test_processes.append(p_obj)
+                # psutil.NoSuchProcess happens when the original
+                # process already ended and left the process table
+                except psutil.NoSuchProcess:
+                    pass
+
+            return len(bad_test_processes) == 0
+
+        if not wait.wait_for(wait_until_no_badtest, timeout=2):
+            self.fail('Avocado left processes behind.')
+
+        output = proc.communicate()[0]
+        # Make sure the Interrupted test sentence is there
+        self.assertIn('INTERRUPTED', output)
 
     @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 1,
                      "Skipping test that take a long time to run, are "
                      "resource intensive or time sensitve")
-    def test_main_process_sigint(self):
+    def test_well_behaved_sigterm(self):
         """
-        Make sure Avocado finishes after the main process receives
-        a SIGINT.
+        Make sure avocado can cleanly get out of a loop of well behaved tests.
         """
         good_test_basename = ('goodtest-%s.py' %
                               data_factory.generate_random_string(5))
@@ -201,17 +296,19 @@ class InterruptTest(unittest.TestCase):
                                            'avocado_interrupt_test',
                                            mode=DEFAULT_MODE)
         good_test.save()
+
         os.chdir(basedir)
         cmd = ('%s run %s --sysinfo=off --job-results-dir %s ' %
                (AVOCADO, good_test.path, self.tmpdir))
-        proc = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE,
+        proc = subprocess.Popen(cmd.split(),
+                                stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE)
 
         def has_children():
             return len(psutil.Process(proc.pid).children()) > 0
         wait.wait_for(has_children, timeout=5)
 
-        os.kill(proc.pid, signal.SIGINT)
+        os.kill(proc.pid, signal.SIGTERM)
 
         def is_finished():
             return proc.poll() is not None
@@ -220,11 +317,43 @@ class InterruptTest(unittest.TestCase):
             process.kill_process_tree(proc.pid)
             self.fail('Avocado was still running after receiving SIGINT.')
 
+        # Make sure the good test will be really gone from the process table
+        def wait_until_no_goodtest():
+            good_test_processes = []
+
+            old_psutil = False
+            try:
+                process_list = psutil.pids()
+            except AttributeError:
+                process_list = psutil.get_pid_list()
+                old_psutil = True
+
+            for p in process_list:
+                try:
+                    p_obj = psutil.Process(p)
+                    if p_obj is not None:
+                        if old_psutil:
+                            cmdline_list = psutil.Process(p).cmdline
+                        else:
+                            try:
+                                cmdline_list = psutil.Process(p).cmdline()
+                            except psutil.AccessDenied:
+                                cmdline_list = []
+                        if good_test.path in " ".join(cmdline_list):
+                            good_test_processes.append(p_obj)
+                # psutil.NoSuchProcess happens when the original
+                # process already ended and left the process table
+                except psutil.NoSuchProcess:
+                    pass
+
+            return len(good_test_processes) == 0
+
+        if not wait.wait_for(wait_until_no_goodtest, timeout=2):
+            self.fail('Avocado left processes behind.')
+
         output = proc.communicate()[0]
-        self.assertNotIn('Killing test subprocess', output)
-        self.assertIn('Interrupt requested. Waiting 2 seconds for test to '
-                      'finish (ignoring new SIGINT until then)',
-                      output)
+        # Make sure the Interrupted test sentence is there
+        self.assertIn('INTERRUPTED', output)
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir)


### PR DESCRIPTION
v2:
- Fix message on SIGINT (new commit)
- Improve SIGINT selftest.
- New commit to fix SIGINT/SIGTERM behavior on avocado.runner and process.Subprocess. See commit message for details.

v1: #2130 
