### PR TITLE
optional_plugins: Fail yaml_testsuite_loader on missing variant

### DIFF
--- a/examples/yaml_to_mux_loader/loaders.yaml
+++ b/examples/yaml_to_mux_loader/loaders.yaml
@@ -18,12 +18,6 @@ tests: !mux
         # Make sure only SIMPLE test types will be detected
         test_reference_resolver_extra: !!python/dict
             allowed_test_types: SIMPLE
-    silently_skipped_test:
-        test_reference: passtest.sh
-        # This test will be skipped as it won't be discovered because of type-mismatch
-        test_reference_resolver_class: "avocado.core.loader.FileLoader"
-        test_reference_resolver_extra: !!python/dict
-            allowed_test_types: INSTRUMENTED
     external_echo:
         test_reference: "external_echo"
         # Use ExternalLoader


### PR DESCRIPTION
Currently yaml_testsuite_loader silently ignored variants with no tests
assigned. This patch makes yaml_testsuite_loader to fail on such
occasions (reports []) and in case of verbose also notify which variants
are actually causing the issue so people can use "avocado variants" to
see the values.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>