### PR TITLE
test: Store fail_reason only as string

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -707,12 +707,12 @@ class Test(unittest.TestCase):
         except exceptions.TestBaseException as detail:
             self.__status = detail.status
             self.__fail_class = detail.__class__.__name__
-            self.__fail_reason = detail
+            self.__fail_reason = str(detail)
             self.__traceback = stacktrace.prepare_exc_info(sys.exc_info())
         except AssertionError as detail:
             self.__status = 'FAIL'
             self.__fail_class = detail.__class__.__name__
-            self.__fail_reason = detail
+            self.__fail_reason = str(detail)
             self.__traceback = stacktrace.prepare_exc_info(sys.exc_info())
         except Exception as detail:
             self.__status = 'ERROR'

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -29,23 +29,6 @@ basedir = os.path.abspath(basedir)
 
 AVOCADO = os.environ.get("UNITTEST_AVOCADO_CMD", "./scripts/avocado")
 
-PASS_SCRIPT_CONTENTS = """#!/bin/sh
-true
-"""
-
-PASS_SHELL_CONTENTS = "exit 0"
-
-FAIL_SCRIPT_CONTENTS = """#!/bin/sh
-false
-"""
-
-FAIL_SHELL_CONTENTS = "exit 1"
-
-HELLO_LIB_CONTENTS = """
-def hello():
-    return 'Hello world'
-"""
-
 LOCAL_IMPORT_TEST_CONTENTS = '''
 from avocado import Test
 from mylib import hello
@@ -272,7 +255,7 @@ class RunnerOperationTest(unittest.TestCase):
     def test_runner_test_with_local_imports(self):
         mylib = script.TemporaryScript(
             'mylib.py',
-            HELLO_LIB_CONTENTS,
+            "def hello():\n    return 'Hello world'",
             'avocado_simpletest_functional')
         mylib.save()
         mytest = script.Script(
@@ -697,11 +680,11 @@ class RunnerSimpleTest(unittest.TestCase):
         self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
         self.pass_script = script.TemporaryScript(
             'ʊʋʉʈɑ ʅʛʌ',
-            PASS_SCRIPT_CONTENTS,
+            "#!/bin/sh\ntrue",
             'avocado_simpletest_functional')
         self.pass_script.save()
         self.fail_script = script.TemporaryScript('avocado_fail.sh',
-                                                  FAIL_SCRIPT_CONTENTS,
+                                                  "#!/bin/sh\nfalse",
                                                   'avocado_simpletest_'
                                                   'functional')
         self.fail_script.save()
@@ -861,12 +844,12 @@ class ExternalRunnerTest(unittest.TestCase):
         self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
         self.pass_script = script.TemporaryScript(
             'pass',
-            PASS_SHELL_CONTENTS,
+            "exit 0",
             'avocado_externalrunner_functional')
         self.pass_script.save()
         self.fail_script = script.TemporaryScript(
             'fail',
-            FAIL_SHELL_CONTENTS,
+            "exit 1",
             'avocado_externalrunner_functional')
         self.fail_script.save()
 


### PR DESCRIPTION
The fail_reason is the instance of the actual exception. We do store it
only as string in case of old-type exception, but even new style
exceptions might be not available when sys.path is different causing
unpickle on runner part impossible.

v1: https://github.com/avocado-framework/avocado/pull/2128

Changes
```yaml
v2: Add commit to adjust test_basic style in terms of small global variables
```