### PR TITLE
utils.memory: create a meminfo object [v2]

### DIFF
--- a/avocado/utils/memory.py
+++ b/avocado/utils/memory.py
@@ -320,3 +320,56 @@ def get_thp_value(feature):
         return (re.search(r"\[(\w+)\]", value)).group(1)
     else:
         return value
+
+
+class MemInfo(object):
+    """
+    Representation of /proc/meminfo
+    """
+
+    class MemInfoItem(object):
+        """
+        Representation of one item from /proc/meminfo
+        """
+        def __init__(self, name):
+            self.name = name
+            self.__multipliers = {'b': 1,  # 2**0
+                                  'kb': 1024,  # 2**10
+                                  'mb': 1048576,  # 2**20
+                                  'gb': 1073741824,  # 2**30
+                                  'tb': 1099511627776}  # 2**40
+
+        def __getattr__(self, attr):
+            """
+            Creates one extra attribute per available conversion unit,
+            which will return the converted value.
+            """
+            if attr not in self.__multipliers:
+                raise AttributeError('Attribute %s does not exist.' % attr)
+            return self.value * 1024 / self.__multipliers[attr]
+
+        def __dir__(self):
+            """
+            Makes the extra attributes visible when calling dir().
+            """
+            listing = dir(type(self)) + list(self.__dict__.keys())
+            listing.extend(['%s' % item for item in self.__multipliers])
+            return listing
+
+        @property
+        def value(self):
+            return read_from_meminfo(self.name)
+
+    def __init__(self):
+        with open('/proc/meminfo', 'r') as meminfo_file:
+            for line in meminfo_file.readlines():
+                name = line.strip().split()[0].strip(':')
+                safe_name = name.replace('(', '_').replace(')', '_')
+                setattr(self, safe_name, self.MemInfoItem(name))
+
+    def __iter__(self):
+        for _, item in self.__dict__.iteritems():
+            yield item
+
+
+meminfo = MemInfo()


### PR DESCRIPTION
This module has a number of functions aiming to retrieve and/or
convert values from /proc/meminfo. It's time to create a more robust
representation of /proc/meminfo. This commit creates a MemInfo class,
instantiated in a meminfo object.

The MemInfo class carries one attribute for each item in /proc/meminfo.
Each attribute is in fact an instance of a MemInfoItem class, which
contains attributes to expose the item value. The basic 'value'
attribute will show the value as is. The additional attributes will
show the converted value, according to the selected unit.

Usage:

    >>> from avocado.utils import memory

    >>> memory.meminfo
    <avocado.utils.memory.MemInfo object at 0x7fe8e737f250>

    >>> dir(memory.meminfo)
    ['Active', 'Active_anon_', 'Active_file_', 'AnonHugePages',
    'AnonPages', 'Bounce', 'Buffers', 'Cached', 'CmaFree', 'CmaTotal',
    'CommitLimit', 'Committed_AS', 'DirectMap1G', 'DirectMap2M',
    'DirectMap4k', 'Dirty', 'HardwareCorrupted', 'HugePages_Free',
    'HugePages_Rsvd', 'HugePages_Surp', 'HugePages_Total', 'Hugepagesize',
    'Inactive', 'Inactive_anon_', 'Inactive_file_', 'KernelStack',
    'Mapped', 'MemAvailable', 'MemFree', 'MemInfoObject', 'MemTotal',
    'Mlocked', 'NFS_Unstable', 'PageTables', 'SReclaimable', 'SUnreclaim',
    'Shmem', 'ShmemHugePages', 'ShmemPmdMapped', 'Slab', 'SwapCached',
    'SwapFree', 'SwapTotal', 'Unevictable', 'VmallocChunk', 'VmallocTotal',
    'VmallocUsed', 'Writeback', 'WritebackTmp', '_MemInfo__meminfo',
    '__class__', '__delattr__', '__dict__', '__dir__', '__doc__',
    '__format__', '__getattr__', '__getattribute__', '__hash__',
    '__init__', '__iter__', '__module__', '__new__', '__reduce__',
    '__reduce_ex__', '__repr__', '__setattr__', '__sizeof__', '__str__',
    '__subclasshook__', '__weakref__']

    >>> memory.meminfo.MemTotal
    <avocado.utils.memory.MemInfoItem object at 0x7fe8f6ff8750>

    >>> dir(memory.meminfo.MemTotal)
    ['_MemInfoObject__units', '__call__', '__class__', '__delattr__',
    '__dict__', '__dir__', '__doc__', '__format__', '__getattr__',
    '__getattribute__', '__hash__', '__init__', '__module__', '__new__',
    '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__sizeof__',
    '__str__', '__subclasshook__', '__weakref__', '_convert', 'name',
    'safe_name', 'value', 'b', 'gb', 'kb', 'mb', 'tb']

    >>> memory.meminfo.MemTotal.value
    15853856

    >>> memory.meminfo.MemTotal.mb
    15482

    >>> for item in memory.meminfo:
    ...     print item.name, item.mb
    ...
    WritebackTmp 0
    SwapTotal 7744
    SwapFree 7744
    DirectMap4k 384
    KernelStack 5
    MemFree 10785
    HugePages_Rsvd 0
    Committed_AS 2108
    SUnreclaim 197
    NFS_Unstable 0
    VmallocChunk 0
    CmaFree 0
    Writeback 0
    MemTotal 15482
    VmallocUsed 0
    DirectMap1G 6144
    HugePages_Free 0
    AnonHugePages 0
    Active_file_ 1259
    AnonPages 440
    Inactive_anon_ 67
    Active 1719
    CommitLimit 15486
    Hugepagesize 2
    Active_anon_ 459
    Cached 2969
    SwapCached 0
    VmallocTotal 33554431
    CmaTotal 0
    Shmem 87
    Mapped 242
    ShmemPmdMapped 0
    Unevictable 0
    SReclaimable 536
    MemAvailable 13874
    Mlocked 0
    DirectMap2M 10310
    HugePages_Surp 0
    Bounce 0
    Inactive 1691
    PageTables 19
    HardwareCorrupted 0
    ShmemHugePages 0
    HugePages_Total 0
    Slab 734
    Inactive_file_ 1623
    Buffers 2
    Dirty 0

Signed-off-by: Amador Pahim <apahim@redhat.com>