### PR TITLE
spec: fix shortcommit

### DIFF
--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -15,7 +15,7 @@
     %if ! 0%{?commit_date:1}
         %global commit_date	20170518
     %endif
-    %global shortcommit	%(c=%{commit};echo ${c:0:7})
+    %global shortcommit	%(c=%{commit};echo ${c:0:8})
     %global gitrel		.%{commit_date}git%{shortcommit}
     %global gittar		%{srcname}-%{shortcommit}.tar.gz
 %endif


### PR DESCRIPTION
shortcommit is supposed to contain the 8 first characters instead of 7.

Signed-off-by: Amador Pahim <apahim@redhat.com>