### PR TITLE
runner: Prefix sys.stdout|err output in test log with [stdout|stderr]

### DIFF
--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -608,19 +608,21 @@ class LoggingFile(object):
     """
 
     def __init__(self, prefix='', level=logging.DEBUG,
-                 logger=[logging.getLogger()]):
+                 loggers=None):
         """
-        Constructor. Sets prefixes and which logger is going to be used.
+        Constructor. Sets prefixes and which loggers are going to be used.
 
         :param prefix - The prefix for each line logged by this object.
+        :param level: Log level to be used when writing messages.
+        :param loggers: Loggers into which write should be issued. (list)
         """
 
         self._prefix = prefix
+        if not loggers:
+            loggers = [logging.getLogger()]
         self._level = level
         self._buffer = []
-        if not isinstance(logger, list):
-            logger = [logger]
-        self._logger = logger
+        self._loggers = loggers
 
     def write(self, data):
         """"
@@ -651,7 +653,7 @@ class LoggingFile(object):
         """
         Passes lines of output to the logging module.
         """
-        for lg in self._logger:
+        for lg in self._loggers:
             lg.log(self._level, self._prefix + line)
 
     def _flush_buffer(self):
@@ -666,10 +668,10 @@ class LoggingFile(object):
         return False
 
     def add_logger(self, logger):
-        self._logger.append(logger)
+        self._loggers.append(logger)
 
     def rm_logger(self, logger):
-        self._logger.remove(logger)
+        self._loggers.remove(logger)
 
 
 class Throbber(object):

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -300,8 +300,8 @@ class TestRunner(object):
         :type queue: :class:`multiprocessing.Queue` instance.
         """
         signal.signal(signal.SIGTSTP, signal.SIG_IGN)
-        sys.stdout = output.LoggingFile(loggers=[TEST_LOG])
-        sys.stderr = output.LoggingFile(loggers=[TEST_LOG])
+        sys.stdout = output.LoggingFile(["[stdout] "], loggers=[TEST_LOG])
+        sys.stderr = output.LoggingFile(["[stderr] "], loggers=[TEST_LOG])
 
         def sigterm_handler(signum, frame):     # pylint: disable=W0613
             """ Produce traceback on SIGTERM """

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -17,7 +17,6 @@
 Test runner module.
 """
 
-import logging
 import multiprocessing
 from multiprocessing import queues
 import os
@@ -301,12 +300,8 @@ class TestRunner(object):
         :type queue: :class:`multiprocessing.Queue` instance.
         """
         signal.signal(signal.SIGTSTP, signal.SIG_IGN)
-        logger_list_stdout = [TEST_LOG,
-                              logging.getLogger('paramiko')]
-        logger_list_stderr = [TEST_LOG,
-                              logging.getLogger('paramiko')]
-        sys.stdout = output.LoggingFile(loggers=logger_list_stdout)
-        sys.stderr = output.LoggingFile(loggers=logger_list_stderr)
+        sys.stdout = output.LoggingFile(loggers=[TEST_LOG])
+        sys.stderr = output.LoggingFile(loggers=[TEST_LOG])
 
         def sigterm_handler(signum, frame):     # pylint: disable=W0613
             """ Produce traceback on SIGTERM """

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -305,8 +305,8 @@ class TestRunner(object):
                               logging.getLogger('paramiko')]
         logger_list_stderr = [TEST_LOG,
                               logging.getLogger('paramiko')]
-        sys.stdout = output.LoggingFile(logger=logger_list_stdout)
-        sys.stderr = output.LoggingFile(logger=logger_list_stderr)
+        sys.stdout = output.LoggingFile(loggers=logger_list_stdout)
+        sys.stderr = output.LoggingFile(loggers=logger_list_stderr)
 
         def sigterm_handler(signum, frame):     # pylint: disable=W0613
             """ Produce traceback on SIGTERM """

--- a/optional_plugins/robot/avocado_robot/__init__.py
+++ b/optional_plugins/robot/avocado_robot/__init__.py
@@ -54,8 +54,8 @@ class RobotTest(test.SimpleTest):
         Create the Robot command and execute it.
         """
         suite_name, test_name = self.name.name.split(':')[1].split('.')
-        log_stdout = output.LoggingFile(logger=[self.log], level=logging.INFO)
-        log_stderr = output.LoggingFile(logger=[self.log], level=logging.ERROR)
+        log_stdout = output.LoggingFile(loggers=[self.log], level=logging.INFO)
+        log_stderr = output.LoggingFile(loggers=[self.log], level=logging.ERROR)
         result = run(self.filename,
                      suite=suite_name,
                      test=test_name,

--- a/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
+++ b/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
@@ -487,8 +487,8 @@ class RemoteTestRunner(TestRunner):
         if self.job.args.show_job_log:
             logger_list.append(app_logger)
             output.add_log_handler(paramiko_logger.name)
-        sys.stdout = output.LoggingFile(logger=logger_list)
-        sys.stderr = output.LoggingFile(logger=logger_list)
+        sys.stdout = output.LoggingFile(loggers=logger_list)
+        sys.stderr = output.LoggingFile(loggers=logger_list)
         try:
             try:
                 self.setup()

--- a/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
+++ b/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
@@ -483,10 +483,9 @@ class RemoteTestRunner(TestRunner):
         fabric_logger.addHandler(file_handler)
         paramiko_logger.addHandler(file_handler)
         remote_logger.addHandler(file_handler)
-        logger_list = [fabric_logger]
         if self.job.args.show_job_log:
-            logger_list.append(app_logger)
             output.add_log_handler(paramiko_logger.name)
+        logger_list = [output.LOG_JOB]
         sys.stdout = output.LoggingFile(loggers=logger_list)
         sys.stderr = output.LoggingFile(loggers=logger_list)
         try:

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -34,6 +34,39 @@ $parser->plan eq '1..3' || die "Plan does not match what was expected!\n";
 """ % AVOCADO
 
 
+OUTPUT_TEST_CONTENT = """#!/bin/env python
+import sys
+
+from avocado import Test
+from avocado.utils import process
+
+print "top_print"
+sys.stdout.write("top_stdout\\n")
+sys.stderr.write("top_stderr\\n")
+process.run("/bin/echo top_process")
+
+class OutputTest(Test):
+    def __init__(self, *args, **kwargs):
+        super(OutputTest, self).__init__(*args, **kwargs)
+        print "init_print"
+        sys.stdout.write("init_stdout\\n")
+        sys.stderr.write("init_stderr\\n")
+        process.run("/bin/echo init_process")
+
+    def test(self):
+        print "test_print"
+        sys.stdout.write("test_stdout\\n")
+        sys.stderr.write("test_stderr\\n")
+        process.run("/bin/echo test_process")
+
+    def __del__(self):
+        print "del_print"
+        sys.stdout.write("del_stdout\\n")
+        sys.stderr.write("del_stderr\\n")
+        process.run("/bin/echo del_process")
+"""
+
+
 def image_output_uncapable():
     try:
         import PIL
@@ -83,6 +116,40 @@ class OutputTest(unittest.TestCase):
         self.assertNotIn(bad_string, output,
                          "Libc double free can be seen in avocado "
                          "doublefree output:\n%s" % output)
+
+    def test_print_to_std(self):
+        def _check_output(path, exps, name):
+            i = 0
+            end = len(exps)
+            for line in open(path):
+                if exps[i] in line:
+                    i += 1
+                    if i == end:
+                        break
+            self.assertEqual(i, end, "Failed to find %sth message from\n%s\n"
+                             "\nin the %s. Either it's missing or in wrong "
+                             "order.\n%s" % (i, "\n".join(exps), name,
+                                             open(path).read()))
+        test = script.Script(os.path.join(self.tmpdir, "output_test.py"),
+                             OUTPUT_TEST_CONTENT)
+        test.save()
+        os.chdir(basedir)
+        result = process.run("%s run --job-results-dir %s --sysinfo=off "
+                             "--json - -- %s" % (AVOCADO, self.tmpdir, test))
+        res = json.loads(result.stdout)
+        joblog = res["debuglog"]
+        exps = ["[stdout] top_print", "[stdout] top_stdout",
+                "[stderr] top_stderr", "[stdout] top_process",
+                "[stdout] init_print", "[stdout] init_stdout",
+                "[stderr] init_stderr", "[stdout] init_process",
+                "[stdout] test_print", "[stdout] test_stdout",
+                "[stderr] test_stderr", "[stdout] test_process"]
+        _check_output(joblog, exps, "job.log")
+        testdir = res["tests"][0]["logdir"]
+        self.assertEqual("test_print\ntest_stdout\ntest_process\n",
+                         open(os.path.join(testdir, "stdout")).read())
+        self.assertEqual("test_stderr\n",
+                         open(os.path.join(testdir, "stderr")).read())
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir)


### PR DESCRIPTION
This patch set fixes a bit the test's (runner's) logging setup and makes sure `sys.stdout` calls are properly forwarded with "[stdout] " prefix to `avocado.test` (job.log) and without any prefix to `avocado.test.stdout` (`test_result/stdout`).

v1: https://github.com/avocado-framework/avocado/pull/2132

Changes:
```yaml
v2: Fixed typos/language
v2: Remove the possibility to add single log name (instead of list)
```