### PR TITLE
Some changes towards working on Python 3

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -79,7 +79,7 @@ class TestName(object):
         :param no_digits: number of digits of the test uid
         """
         self.uid = uid
-        if no_digits >= 0:
+        if no_digits is not None and no_digits >= 0:
             self.str_uid = str(uid).zfill(no_digits if no_digits else 3)
         else:
             self.str_uid = str(uid)

--- a/avocado/plugins/diff.py
+++ b/avocado/plugins/diff.py
@@ -201,14 +201,16 @@ class Diff(CLICmd):
         if getattr(args, 'create_reports', False):
             self.std_diff_output = False
             prefix = 'avocado_diff_%s_' % job1_id[:7]
-            tmp_file1 = tempfile.NamedTemporaryFile(prefix=prefix,
+            tmp_file1 = tempfile.NamedTemporaryFile(mode='w',
+                                                    prefix=prefix,
                                                     suffix='.txt',
                                                     delete=False)
             tmp_file1.writelines(job1_results)
             tmp_file1.close()
 
             prefix = 'avocado_diff_%s_' % job2_id[:7]
-            tmp_file2 = tempfile.NamedTemporaryFile(prefix=prefix,
+            tmp_file2 = tempfile.NamedTemporaryFile(mode='w',
+                                                    prefix=prefix,
                                                     suffix='.txt',
                                                     delete=False)
             tmp_file2.writelines(job2_results)
@@ -220,7 +222,8 @@ class Diff(CLICmd):
                 getattr(args, 'html', None) is None):
 
             prefix = 'avocado_diff_%s_%s_' % (job1_id[:7], job2_id[:7])
-            tmp_file = tempfile.NamedTemporaryFile(prefix=prefix,
+            tmp_file = tempfile.NamedTemporaryFile(mode='w',
+                                                   prefix=prefix,
                                                    suffix='.html',
                                                    delete=False)
 

--- a/avocado/plugins/xunit.py
+++ b/avocado/plugins/xunit.py
@@ -117,7 +117,7 @@ class XUnitResult(Result):
         content = self._render(result)
         if getattr(job.args, 'xunit_job_result', 'off') == 'on':
             xunit_path = os.path.join(job.logdir, 'results.xml')
-            with open(xunit_path, 'w') as xunit_file:
+            with open(xunit_path, 'wb') as xunit_file:
                 xunit_file.write(content)
 
         xunit_path = getattr(job.args, 'xunit_output', 'None')
@@ -125,7 +125,7 @@ class XUnitResult(Result):
             if xunit_path == '-':
                 LOG_UI.debug(content)
             else:
-                with open(xunit_path, 'w') as xunit_file:
+                with open(xunit_path, 'wb') as xunit_file:
                     xunit_file.write(content)
 
 

--- a/avocado/utils/data_structures.py
+++ b/avocado/utils/data_structures.py
@@ -107,7 +107,7 @@ def compare_matrices(matrix1, matrix2, threshold=0.05):
                 new_line.append(100 * ratio - 100)
             elif ratio > (1 + threshold):   # handling improvements
                 improvements += 1
-                new_line.append("+" + str(100 * ratio - 100))
+                new_line.append("+%.6g" % (100 * ratio - 100))
             else:
                 same += 1
                 new_line.append(".")

--- a/avocado/utils/filelock.py
+++ b/avocado/utils/filelock.py
@@ -42,7 +42,7 @@ class FileLock(object):
 
     def __init__(self, filename, timeout=0):
         self.filename = '%s.lock' % filename
-        self.pid = str(os.getpid())
+        self.pid = b'%r' % os.getpid()
         self.locked = False
         self.timeout = timeout
 

--- a/examples/tests/gdbtest.py
+++ b/examples/tests/gdbtest.py
@@ -329,7 +329,7 @@ class GdbTest(Test):
         """
         self.log.info('Testing GDB interactivity with arguments')
         result = process.run("%s 0" % self.return99_binary_path)
-        self.assertEquals(result.exit_status, 0)
+        self.assertEqual(result.exit_status, 0)
 
     def test_exit_status(self):
         """
@@ -343,7 +343,7 @@ class GdbTest(Test):
             self.log.info('Expecting exit status "%s"', exp)
             cmd = "%s %s" % (self.return99_binary_path, arg)
             result = process.run(cmd, ignore_status=True)
-            self.assertEquals(result.exit_status, exp)
+            self.assertEqual(result.exit_status, exp)
 
     def test_server_stderr(self):
         self.log.info('Testing server stderr collection')

--- a/selftests/functional/test_argument_parsing.py
+++ b/selftests/functional/test_argument_parsing.py
@@ -63,7 +63,7 @@ class ArgumentParsingErrorEarlyTest(unittest.TestCase):
         self.assertEqual(result.exit_status, expected_rc,
                          'Avocado did not return rc %d:\n%s' % (expected_rc, result))
         path_job_glob = os.path.join(log_dir, "job-*-%s" % job[0:7])
-        self.assertEquals(glob.glob(path_job_glob), [])
+        self.assertEqual(glob.glob(path_job_glob), [])
 
     def test_whacky_option(self):
         self.run_but_fail_before_create_job_dir('--whacky-option passtest',

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -990,12 +990,12 @@ class PluginsTest(AbsPluginsTest, unittest.TestCase):
         stdout_lines = result.stdout.splitlines()
         self.assertIn("Tag(s)", stdout_lines[0])
         full_test_name = "%s:MyTest.test" % test
-        self.assertEquals("INSTRUMENTED %s BIG_TAG_NAME" % full_test_name,
-                          stdout_lines[1])
+        self.assertEqual("INSTRUMENTED %s BIG_TAG_NAME" % full_test_name,
+                         stdout_lines[1])
         self.assertIn("TEST TYPES SUMMARY", stdout_lines)
         self.assertIn("INSTRUMENTED: 1", stdout_lines)
         self.assertIn("TEST TAGS SUMMARY", stdout_lines)
-        self.assertEquals("BIG_TAG_NAME: 1", stdout_lines[-1])
+        self.assertEqual("BIG_TAG_NAME: 1", stdout_lines[-1])
 
     def test_plugin_list(self):
         os.chdir(basedir)

--- a/selftests/functional/test_loader.py
+++ b/selftests/functional/test_loader.py
@@ -173,7 +173,7 @@ class LoaderTestFunctional(unittest.TestCase):
                 os.killpg(os.getpgid(test_process.pid), signal.SIGKILL)
                 self.fail("Failed to run test under %s seconds" % timeout)
             time.sleep(0.05)
-        self.assertEquals(test_process.returncode, exit_codes.AVOCADO_TESTS_FAIL)
+        self.assertEqual(test_process.returncode, exit_codes.AVOCADO_TESTS_FAIL)
 
     def test_simple(self):
         self._test('simpletest.sh', SIMPLE_TEST, 'SIMPLE', self.MODE_0775)

--- a/selftests/functional/test_skiptests.py
+++ b/selftests/functional/test_skiptests.py
@@ -118,7 +118,7 @@ class TestSkipDecorators(unittest.TestCase):
         debuglog = json_results['debuglog']
 
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
-        self.assertEquals(json_results['skip'], 3)
+        self.assertEqual(json_results['skip'], 3)
         self.assertFalse('setup executed' in open(debuglog, 'r').read())
         self.assertFalse('test executed' in open(debuglog, 'r').read())
         self.assertFalse('teardown executed' in open(debuglog, 'r').read())
@@ -135,7 +135,7 @@ class TestSkipDecorators(unittest.TestCase):
         result = process.run(' '.join(cmd_line), ignore_status=True)
         json_results = json.loads(result.stdout)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
-        self.assertEquals(json_results['skip'], 1)
+        self.assertEqual(json_results['skip'], 1)
 
     def test_skip_teardown(self):
         os.chdir(basedir)
@@ -149,7 +149,7 @@ class TestSkipDecorators(unittest.TestCase):
         result = process.run(' '.join(cmd_line), ignore_status=True)
         json_results = json.loads(result.stdout)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_TESTS_FAIL)
-        self.assertEquals(json_results['errors'], 1)
+        self.assertEqual(json_results['errors'], 1)
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir)

--- a/selftests/unit/test_data_structures.py
+++ b/selftests/unit/test_data_structures.py
@@ -34,7 +34,7 @@ class TestDataStructures(unittest.TestCase):
         matrix1 = [["header", 51.7, 60], [1, 0, 0]]
         matrix2 = [["header", 57.2, 54], [2, 51, 0]]
         self.assertEqual(data_structures.compare_matrices(matrix1, matrix2),
-                         ([["header", '+10.6382978723', -10.0], ['+100.0',
+                         ([["header", '+10.6383', -10.0], ['+100',
                           'error_51/0', '.']], 3, 1, 5))
 
     def test_lazy_property(self):

--- a/selftests/unit/test_datadir.py
+++ b/selftests/unit/test_datadir.py
@@ -28,7 +28,7 @@ class DataDirTest(unittest.TestCase):
                          'test_dir = %(test_dir)s\n'
                          'data_dir = %(data_dir)s\n'
                          'logs_dir = %(logs_dir)s\n') % mapping
-        config_file = tempfile.NamedTemporaryFile(delete=False)
+        config_file = tempfile.NamedTemporaryFile('w', delete=False)
         config_file.write(temp_settings)
         config_file.close()
         return (mapping, config_file.name)

--- a/selftests/unit/test_restclient_response.py
+++ b/selftests/unit/test_restclient_response.py
@@ -23,7 +23,7 @@ class ResultResponseTest(unittest.TestCase):
 
     def test_good_data(self):
         r = response.ResultResponse(self.GOOD_DATA)
-        self.assertEquals(r.count, 1)
+        self.assertEqual(r.count, 1)
 
     def test_bad_data_json(self):
         self.assertRaises(response.InvalidJSONError,

--- a/selftests/unit/test_settings.py
+++ b/selftests/unit/test_settings.py
@@ -19,7 +19,7 @@ home_path = ~
 class SettingsTest(unittest.TestCase):
 
     def setUp(self):
-        self.config_file = tempfile.NamedTemporaryFile(delete=False)
+        self.config_file = tempfile.NamedTemporaryFile('w', delete=False)
         self.config_file.write(example_1)
         self.config_file.close()
         self.settings = settings.Settings(self.config_file.name)

--- a/selftests/unit/test_xunit.py
+++ b/selftests/unit/test_xunit.py
@@ -4,8 +4,12 @@ import shutil
 import tempfile
 import unittest
 from lxml import etree
-from StringIO import StringIO
 from xml.dom import minidom
+
+try:
+    from io import BytesIO
+except:
+    from BytesIO import BytesIO
 
 from avocado import Test
 from avocado.core import job
@@ -57,7 +61,7 @@ class xUnitSucceedTest(unittest.TestCase):
         self.test_result.end_tests()
         xunit_result = xunit.XUnitResult()
         xunit_result.render(self.test_result, self.job)
-        with open(self.job.args.xunit_output) as fp:
+        with open(self.job.args.xunit_output, 'rb') as fp:
             xml = fp.read()
         try:
             dom = minidom.parseString(xml)
@@ -69,7 +73,7 @@ class xUnitSucceedTest(unittest.TestCase):
 
         with open(self.junit, 'r') as f:
             xmlschema = etree.XMLSchema(etree.parse(f))
-        self.assertTrue(xmlschema.validate(etree.parse(StringIO(xml))),
+        self.assertTrue(xmlschema.validate(etree.parse(BytesIO(xml))),
                         "Failed to validate against %s, content:\n%s" %
                         (self.junit, xml))
 


### PR DESCRIPTION
These include: avoiding deprecated or now-invalid idioms, specifying text or binary modes when appropriate, and a simple-minded conversion of Process to use BytesIO.

_edit_: removed the Process part because it seems to break Python2.