### PR TITLE
RPM build fixes for release 53.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,19 +105,19 @@ install:
 
 srpm: source
 	if test ! -d BUILD/SRPM; then mkdir -p BUILD/SRPM; fi
-	mock -r $(MOCK_CONFIG) --resultdir BUILD/SRPM -D "rel_build 0" -D "commit $(COMMIT)" -D "commit_date $(COMMIT_DATE)" --buildsrpm --spec python-avocado.spec --sources SOURCES
+	mock --old-chroot -r $(MOCK_CONFIG) --resultdir BUILD/SRPM -D "rel_build 0" -D "commit $(COMMIT)" -D "commit_date $(COMMIT_DATE)" --buildsrpm --spec python-avocado.spec --sources SOURCES
 
 rpm: srpm
 	if test ! -d BUILD/RPM; then mkdir -p BUILD/RPM; fi
-	mock -r $(MOCK_CONFIG) --resultdir BUILD/RPM -D "rel_build 0" -D "commit $(COMMIT)" -D "commit_date $(COMMIT_DATE)" --rebuild BUILD/SRPM/python-avocado-$(VERSION)-*.src.rpm
+	mock --old-chroot -r $(MOCK_CONFIG) --resultdir BUILD/RPM -D "rel_build 0" -D "commit $(COMMIT)" -D "commit_date $(COMMIT_DATE)" --rebuild BUILD/SRPM/python-avocado-$(VERSION)-*.src.rpm
 
 srpm-release: source-release
 	if test ! -d BUILD/SRPM; then mkdir -p BUILD/SRPM; fi
-	mock -r $(MOCK_CONFIG) --resultdir BUILD/SRPM -D "rel_build 1" --buildsrpm --spec python-avocado.spec --sources SOURCES
+	mock --old-chroot -r $(MOCK_CONFIG) --resultdir BUILD/SRPM -D "rel_build 1" --buildsrpm --spec python-avocado.spec --sources SOURCES
 
 rpm-release: srpm-release
 	if test ! -d BUILD/RPM; then mkdir -p BUILD/RPM; fi
-	mock -r $(MOCK_CONFIG) --resultdir BUILD/RPM -D "rel_build 1" --rebuild BUILD/SRPM/python-avocado-$(VERSION)-*.src.rpm
+	mock --old-chroot -r $(MOCK_CONFIG) --resultdir BUILD/RPM -D "rel_build 1" --rebuild BUILD/SRPM/python-avocado-$(VERSION)-*.src.rpm
 
 clean:
 	$(PYTHON) setup.py clean

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,3 @@
-#
-# NOTE: to build Avocado RPM packages extra deps not present out of the box
-# are necessary. These packages are currently hosted at:
-#
-# https://repos-avocadoproject.rhcloud.com/static/avocado-fedora.repo
-# or
-# https://repos-avocadoproject.rhcloud.com/static/avocado-el.repo
-#
-# Since the RPM build steps are based on mock, edit your chroot config
-# file (/etc/mock/<your-config>.cnf) and add the corresponding repo
-# configuration there.
-#
-
 PYTHON=$(shell which python)
 PYTHON_DEVELOP_ARGS=$(shell if ($(PYTHON) setup.py develop --help 2>/dev/null | grep -q '\-\-user'); then echo "--user"; else echo ""; fi)
 VERSION=$(shell $(PYTHON) setup.py --version 2>/dev/null)

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -29,7 +29,7 @@
 Summary: Framework with tools and libraries for Automated Testing
 Name: python-%{srcname}
 Version: 52.0
-Release: 1%{?gitrel}%{?dist}
+Release: 2%{?gitrel}%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.github.io/
@@ -59,6 +59,11 @@ BuildRequires: python-aexpect
 %if %{with_tests}
 BuildRequires: libvirt-python
 BuildRequires: perl-Test-Harness
+%if 0%{?rhel}
+BuildRequires: python-yaml
+%else
+BuildRequires: python2-yaml
+%endif
 %endif
 
 Requires: gdb
@@ -310,7 +315,11 @@ server.
 %package plugins-varianter-yaml-to-mux
 Summary: Avocado plugin to generate variants out of yaml files
 Requires: %{name} == %{version}
+%if 0%{?rhel}
 Requires: python-yaml
+%else
+Requires: python2-yaml
+%endif
 
 %description plugins-varianter-yaml-to-mux
 Can be used to produce multiple test variants with test parameters
@@ -334,6 +343,9 @@ examples of how to write tests on your own.
 %{_datadir}/avocado/wrappers
 
 %changelog
+* Mon Aug 14 2017 Cleber Rosa <cleber@redhat.com> - 52.0-2
+- Add python[2]-yaml requirements
+
 * Tue Jun 27 2017 Cleber Rosa <cleber@redhat.com> - 52.0-1
 - Fix python-aexpect depedency on EL7
 


### PR DESCRIPTION
`make rpm` is not working out of the box, and although `mock` (and previously `git`) changes were to blame, let's make it work it.