### PR TITLE
Porting avocado.util.process to Python 3 (do not merge)

### DIFF
--- a/avocado/utils/iso9660.py
+++ b/avocado/utils/iso9660.py
@@ -267,7 +267,7 @@ class Iso9660IsoInfo(MixInMntDirMount, BaseIso9660):
 
         cmd.append("-x %s" % fname)
         result = process.run(" ".join(cmd), verbose=False)
-        return result.stdout
+        return result.stdout_bytes
 
 
 class Iso9660IsoRead(MixInMntDirMount, BaseIso9660):
@@ -286,7 +286,7 @@ class Iso9660IsoRead(MixInMntDirMount, BaseIso9660):
         temp_file = os.path.join(self.temp_dir, path)
         cmd = 'iso-read -i %s -e %s -o %s' % (self.path, path, temp_file)
         process.run(cmd)
-        return open(temp_file).read()
+        return open(temp_file, 'rb').read()
 
     def copy(self, src, dst):
         cmd = 'iso-read -i %s -e %s -o %s' % (self.path, src, dst)
@@ -329,7 +329,7 @@ class Iso9660Mount(BaseIso9660):
         :rtype: str
         """
         full_path = os.path.join(self.mnt_dir, path)
-        return open(full_path).read()
+        return open(full_path, 'rb').read()
 
     def copy(self, src, dst):
         """

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -16,7 +16,11 @@ import psutil
 import pkg_resources
 
 from lxml import etree
-from StringIO import StringIO
+
+try:
+    from io import BytesIO
+except:
+    from BytesIO import BytesIO
 
 from avocado.core import exit_codes
 from avocado.utils import astring
@@ -1163,7 +1167,7 @@ class PluginsXunitTest(AbsPluginsTest, unittest.TestCase):
         with open(self.junit, 'r') as f:
             xmlschema = etree.XMLSchema(etree.parse(f))
 
-        self.assertTrue(xmlschema.validate(etree.parse(StringIO(xml_output))),
+        self.assertTrue(xmlschema.validate(etree.parse(BytesIO(result.stdout_bytes))),
                         "Failed to validate against %s, message:\n%s" %
                         (self.junit,
                          xmlschema.error_log.filter_from_errors()))

--- a/selftests/functional/test_utils.py
+++ b/selftests/functional/test_utils.py
@@ -142,7 +142,7 @@ class ProcessTest(unittest.TestCase):
         time.sleep(3)
         proc.terminate()
         proc.wait()
-        stdout = proc.get_stdout()
+        stdout = proc.get_stdout().decode('utf-8')
         self.assertIn('memory', stdout, 'result: %s' % stdout)
         self.assertRegexpMatches(stdout, '[0-9]+')
 

--- a/selftests/unit/test_utils_iso9660.py
+++ b/selftests/unit/test_utils_iso9660.py
@@ -30,10 +30,10 @@ class BaseIso9660(unittest.TestCase):
                   due to ast loader we can't just define a base-class.
         """
         self.assertEqual(self.iso.read("file"),
-                         "file content\n")
+                         b"file content\n")
         dst = os.path.join(self.tmpdir, "file")
         self.iso.copy(os.path.join("Dir", "in_dir_file"), dst)
-        self.assertEqual(open(dst).read(), "content of in-dir-file\n")
+        self.assertEqual(open(dst, 'rb').read(), b"content of in-dir-file\n")
         self.iso.close()
         self.iso.close()    # check that double-close won't fail
 


### PR DESCRIPTION
This pull request adds two more properties stdout_bytes and stderr_bytes to CmdResult; the decoded stdout and stderr are computed lazily. However, this still causes a few Python 2 failures, so this pull request is only provided for convenience in analyzing those failures.