### PR TITLE
utils.wait: docstring typo

### DIFF
--- a/avocado/utils/wait.py
+++ b/avocado/utils/wait.py
@@ -13,7 +13,7 @@ def wait_for(func, timeout, first=0.0, step=1.0, text=None):
 
     :param timeout: Timeout in seconds
     :param first: Time to sleep before first attempt
-    :param steps: Time to sleep between attempts in seconds
+    :param step: Time to sleep between attempts in seconds
     :param text: Text to print while waiting, for debug purposes
     """
     start_time = time.time()


### PR DESCRIPTION
Parameter is `step`, docstring says `steps`. Fixing.

Signed-off-by: Amador Pahim <apahim@redhat.com>