### PR TITLE
Fix Travis check 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ sudo: false
 addons:
   apt:
     packages:
-    - python-libvirt
+    - libvirt-dev
 
 install:
     - pip install -r requirements-travis.txt

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -6,7 +6,7 @@ inspektor==0.4.5
 pep8==1.6.2
 requests==1.2.3
 PyYAML==3.11
-Pillow==2.2.1
+Pillow==2.8.1
 snakefood==1.4
 networkx==1.9.1
 pygraphviz==1.3rc2
@@ -19,3 +19,4 @@ lxml>=3.4.4
 # some setuptools versions can fail accessing
 # pkg_resources.packaging, let's pin the version
 setuptools==25.1.1
+libvirt-python==3.6.0


### PR DESCRIPTION
With the EOL of Ubuntu 12.04, Travis CI is now running our tests using
Ubuntu 14.04. With this change, our check started to fail.

Even though I'm not sure about the reasons, I could make it work by
using a newer version of `pillow` and also installing `libvirt-python` with
`pip` (`import libvirt` is not working in the `virtualenv` with libvirt-python
installed with apt).