### PR TITLE
utils/memory: Memory hotplug and hotunplug functions [v3]

### DIFF
--- a/avocado/utils/memory.py
+++ b/avocado/utils/memory.py
@@ -25,9 +25,86 @@ import logging
 
 from . import process
 from . import genio
+from . import wait
 
 
-# Returns total memory in kb
+class MemoryError(Exception):
+
+    """
+    called when memory operations fails
+    """
+    pass
+
+
+def _check_memory_state(block):
+    """
+    Check the given memory block is online or offline
+
+    :param block: memory block id.
+    :type string: like 198
+    :return: 'True' if online or 'False' if offline
+    :rtype: bool
+    """
+    def _is_online():
+        with open('/sys/devices/system/memory/memory%s/state' % block, 'r') as state_file:
+            if state_file.read() == 'online\n':
+                return True
+            return False
+
+    return wait.wait_for(_is_online, timeout=120, step=1) or False
+
+
+def check_hotplug():
+    """
+    Check kernel support for memory hotplug
+
+    :return: True if hotplug supported,  else False
+    :rtype: 'bool'
+    """
+    if glob.glob('/sys/devices/system/memory/memory*'):
+        return True
+    return False
+
+
+def is_hot_pluggable(block):
+    """
+    Check if the given memory block is hotpluggable
+
+    :param block: memory block id.
+    :type string: like 198
+    :retrun: True if hotpluggable, else False
+    :rtype: 'bool'
+    """
+    with open('/sys/devices/system/memory/memory%s/removable' % block, 'r') as file_obj:
+        return bool(int(file_obj.read()))
+
+
+def hotplug(block):
+    """
+    Online the memory for the given block id.
+
+    :param block: memory block id.
+    :type string: like 198
+    """
+    with open('/sys/devices/system/memory/memory%s/state' % block, 'w') as state_file:
+        state_file.write('online')
+    if not _check_memory_state(block):
+        raise MemoryError(
+            "unable to hot-plug memory%s block, not supported ?" % block)
+
+
+def hotunplug(block):
+    """
+    Offline the memory for the given block id.
+
+    :param block: memory block id.
+    :type string: like 198
+    """
+    with open('/sys/devices/system/memory/memory%s/state' % block, 'w') as state_file:
+        state_file.write('offline')
+    if _check_memory_state(block):
+        raise MemoryError(
+            "unable to hot-unplug memory%s block. Device busy?" % block)
 
 
 def read_from_meminfo(key):


### PR DESCRIPTION
New functions added for memory offline and online, check if memory is
hotpluggable, check if kernel supports memory hotplug.

These functions will be used more often by memory testcases in avocado-misc-tests

Implemented review comments from #2114, #2116

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>