### PR TITLE
Misc Fixes (originally part of "Support for test/variant data files")

### DIFF
--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -26,7 +26,6 @@ The general reasoning to find paths is:
 * The next best location is the default user specific one.
 """
 import os
-import sys
 import shutil
 import time
 import tempfile
@@ -36,10 +35,6 @@ from . import settings
 from .output import LOG_JOB
 from ..utils import path as utils_path
 from ..utils.data_structures import Borg
-
-_BASE_DIR = os.path.join(sys.modules[__name__].__file__, "..", "..", "..")
-_BASE_DIR = os.path.abspath(_BASE_DIR)
-_IN_TREE_TESTS_DIR = os.path.join(_BASE_DIR, 'examples', 'tests')
 
 SYSTEM_BASE_DIR = '/var/lib/avocado'
 if 'VIRTUAL_ENV' in os.environ:
@@ -109,7 +104,8 @@ def get_test_dir():
         return configured
 
     if settings.settings.intree:
-        return _IN_TREE_TESTS_DIR
+        base_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+        return os.path.join(base_dir, 'examples', 'tests')
 
     if utils_path.usable_ro_dir(SYSTEM_TEST_DIR):
         return SYSTEM_TEST_DIR

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -580,9 +580,9 @@ class TestRunner(object):
                 index += 1
                 test_parameters = test_factory[1]
                 name = test_parameters.get("name")
-                test_parameters["name"] = test.TestName(index + 1, name,
-                                                        variant,
-                                                        no_digits)
+                test_parameters["name"] = test.TestID(index + 1, name,
+                                                      variant,
+                                                      no_digits)
                 if deadline is not None and time.time() > deadline:
                     summary.add('INTERRUPTED')
                     if 'methodName' in test_parameters:

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -52,17 +52,6 @@ from .output import LOG_JOB
 COMMON_TMPDIR_NAME = 'AVOCADO_TESTS_COMMON_TMPDIR'
 
 
-class NameNotTestNameError(Exception):
-
-    """
-    The given test name is not a TestName instance
-
-    With the introduction of :class:`avocado.core.test.TestName`, it's
-    not allowed to use other types as the ``name`` parameter to a test
-    instance.  This exception is raised when this is attempted.
-    """
-
-
 class TestName(object):
 
     """
@@ -166,7 +155,6 @@ class Test(unittest.TestCase):
                             provided, it'll use
                             :func:`avocado.data_dir.create_job_logs_dir`.
         :param job: The job that this test is part of.
-        :raises: :class:`avocado.core.test.NameNotTestNameError`
         """
         def record_and_warn(*args, **kwargs):
             """ Record call to this function and log warning """
@@ -175,8 +163,6 @@ class Test(unittest.TestCase):
             return original_log_warn(*args, **kwargs)
 
         if name is not None:
-            if not isinstance(name, TestName):
-                raise NameNotTestNameError(name)
             self.__name = name
         else:
             self.__name = TestName(0, self.__class__.__name__)

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -73,12 +73,12 @@ class TestName(object):
         else:
             self.str_uid = str(uid)
         self.name = name or "<unknown>"
-        self.variant = variant["variant_id"] if variant else None
-        if variant is None:
+        if variant is None or variant["variant_id"] is None:
+            self.variant = None
             self.str_variant = ""
         else:
-            self.str_variant = (";" + str(variant["variant_id"])
-                                if variant["variant_id"] else "")
+            self.variant = variant["variant_id"]
+            self.str_variant = ";%s" % self.variant
 
     def __str__(self):
         return "%s-%s%s" % (self.str_uid, self.name, self.str_variant)

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -865,7 +865,7 @@ class SimpleTest(Test):
         self.log.info("Exit status: %s", result.exit_status)
         self.log.info("Duration: %s", result.duration)
 
-    def execute_cmd(self):
+    def _execute_cmd(self):
         """
         Run the executable, and log its detailed execution.
         """
@@ -891,7 +891,7 @@ class SimpleTest(Test):
         """
         Run the test and postprocess the results
         """
-        self.execute_cmd()
+        self._execute_cmd()
 
 
 class ExternalRunnerTest(SimpleTest):
@@ -929,7 +929,7 @@ class ExternalRunnerTest(SimpleTest):
                                new_cwd)
                 os.chdir(new_cwd)
 
-            self.execute_cmd()
+            self._execute_cmd()
 
         finally:
             if new_cwd is not None:

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -307,7 +307,15 @@ class Test(unittest.TestCase):
     @property
     def datadir(self):
         """
-        Returns the path to the directory that contains test data files
+        Returns the path to the directory that may contain test data files
+
+        For test a test file hosted at /usr/share/avocado/tests/sleeptest.py
+        the datadir is /usr/share/avocado/tests/sleeptest.py.data.
+
+        Note that this directory has no specific relation to the test
+        name, only to the file that contains the test.  It can be used to
+        host data files that are generic enough to be used for all tests
+        contained in a given test file.
         """
         # Maximal allowed file name length is 255
         if (self.filename is not None and

--- a/avocado/utils/astring.py
+++ b/avocado/utils/astring.py
@@ -209,25 +209,30 @@ def tabular_output(matrix, header=None):
     return "\n".join(iter_tabular_output(matrix, header))
 
 
-def string_safe_encode(string):
+def string_safe_encode(input_str):
     """
     People tend to mix unicode streams with encoded strings. This function
     tries to replace any input with a valid utf-8 encoded ascii stream.
+
+    :param input_str: possibly unsafe string or other object that can
+                      be turned into a string
+    :returns: a utf-8 encoded ascii stream
     """
-    if not isinstance(string, basestring):
-        string = str(string)
+    if not isinstance(input_str, basestring):
+        input_str = str(input_str)
     try:
-        return string.encode("utf-8")
+        return input_str.encode("utf-8")
     except UnicodeDecodeError:
-        return string.decode("utf-8", "replace").encode("utf-8")
+        return input_str.decode("utf-8", "replace").encode("utf-8")
 
 
-def string_to_safe_path(string):
+def string_to_safe_path(input_str):
     """
     Convert string to a valid file/dir name.
-    :param string: String to be converted
+
+    :param input_str: String to be converted
     :return: String which is safe to pass as a file/dir name (on recent fs)
     """
-    if string.startswith("."):
-        string = "_" + string[1:]
-    return string.replace(os.path.sep, '_')[:255]
+    if input_str.startswith("."):
+        input_str = "_" + input_str[1:]
+    return input_str.replace(os.path.sep, '_')[:255]

--- a/docs/source/ReferenceGuide.rst
+++ b/docs/source/ReferenceGuide.rst
@@ -111,7 +111,6 @@ Syntax::
 Examples of test-names::
 
    '/bin/true'
-   '/bin/grep foobar /etc/passwd'
    'passtest.py:Passtest.test'
    'file:///tmp/passtest.py:Passtest.test'
    'multiple_tests.py:MultipleTests.test_hello'

--- a/docs/source/ReferenceGuide.rst
+++ b/docs/source/ReferenceGuide.rst
@@ -66,6 +66,14 @@ By definition, a Test Name is a Test Reference, but the
 reciprocal is not necessarily true, as the latter can represent
 more than one test.
 
+Examples of Test Names::
+
+   '/bin/true'
+   'passtest.py:Passtest.test'
+   'file:///tmp/passtest.py:Passtest.test'
+   'multiple_tests.py:MultipleTests.test_hello'
+   'type_specific.io-github-autotest-qemu.systemtap_tracing.qemu.qemu_free'
+
 
 Variant IDs
 -----------
@@ -108,14 +116,13 @@ Syntax::
 
    <unique-id>-<test-name>[;<variant-id>]
 
-Examples of test-names::
+Example of Test IDs::
 
-   '/bin/true'
-   'passtest.py:Passtest.test'
-   'file:///tmp/passtest.py:Passtest.test'
-   'multiple_tests.py:MultipleTests.test_hello'
-   'type_specific.io-github-autotest-qemu.systemtap_tracing.qemu.qemu_free'
-
+   '1-/bin/true'
+   '2-passtest.py:Passtest.test;quiet-'
+   '3-file:///tmp/passtest.py:Passtest.test'
+   '4-multiple_tests.py:MultipleTests.test_hello;maximum_debug-df2f'
+   '5-type_specific.io-github-autotest-qemu.systemtap_tracing.qemu.qemu_free'
 
 .. _test-types:
 

--- a/docs/source/TestParameters.rst
+++ b/docs/source/TestParameters.rst
@@ -102,7 +102,7 @@ AvocadoParams
 Is a "database" of params present in every (instrumented) avocado test.
 It's produced during :class:`avocado.core.test.Test`'s ``__init__``
 from a `variant`_. It accepts a list of `TreeNode`_ objects; test name
-:class:`avocado.core.test.TestName` (for logging purposes); list of
+:class:`avocado.core.test.TestID` (for logging purposes); list of
 default paths (`Mux path`_) and the `Test's default params`_.
 
 In test it allows querying for data by using::

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -266,69 +266,69 @@ as an example:
 
 Which produces following structure and parameters::
 
-      $ avocado variants -m examples/tests/sleeptenmin.py.data/sleeptenmin.yaml --summary 2 --variants 2
-      Multiplex tree representation:
-       ┗━━ run
-            ┣━━ sleeptenmin
-            ┃    ╠══ builtin
-            ┃    ║     → sleep_method: builtin
-            ┃    ╚══ shell
-            ┃          → sleep_method: shell
-            ┗━━ variants
-                 ╠══ one_cycle
-                 ║     → sleep_length: 600
-                 ║     → sleep_cycles: 1
-                 ╠══ six_cycles
-                 ║     → sleep_length: 100
-                 ║     → sleep_cycles: 6
-                 ╠══ one_hundred_cycles
-                 ║     → sleep_length: 6
-                 ║     → sleep_cycles: 100
-                 ╚══ six_hundred_cycles
-                       → sleep_length: 1
-                       → sleep_cycles: 600
+  $ avocado variants -m examples/tests/sleeptenmin.py.data/sleeptenmin.yaml --summary 2 --variants 2
+  Multiplex tree representation:
+   ┗━━ run
+        ┣━━ sleeptenmin
+        ┃    ╠══ builtin
+        ┃    ║     → sleep_method: builtin
+        ┃    ╚══ shell
+        ┃          → sleep_method: shell
+        ┗━━ variants
+             ╠══ one_cycle
+             ║     → sleep_length: 600
+             ║     → sleep_cycles: 1
+             ╠══ six_cycles
+             ║     → sleep_length: 100
+             ║     → sleep_cycles: 6
+             ╠══ one_hundred_cycles
+             ║     → sleep_length: 6
+             ║     → sleep_cycles: 100
+             ╚══ six_hundred_cycles
+                   → sleep_length: 1
+                   → sleep_cycles: 600
 
-      Multiplex variants:
+  Multiplex variants (8):
 
-      Variant 1:    /run/sleeptenmin/builtin, /run/variants/one_cycle
-          /run/sleeptenmin/builtin:sleep_method => builtin
-          /run/variants/one_cycle:sleep_cycles  => 1
-          /run/variants/one_cycle:sleep_length  => 600
+  Variant builtin-one_cycle-f659:    /run/sleeptenmin/builtin, /run/variants/one_cycle
+      /run/sleeptenmin/builtin:sleep_method => builtin
+      /run/variants/one_cycle:sleep_cycles  => 1
+      /run/variants/one_cycle:sleep_length  => 600
 
-      Variant 2:    /run/sleeptenmin/builtin, /run/variants/six_cycles
-          /run/sleeptenmin/builtin:sleep_method => builtin
-          /run/variants/six_cycles:sleep_cycles => 6
-          /run/variants/six_cycles:sleep_length => 100
+  Variant builtin-six_cycles-723b:    /run/sleeptenmin/builtin, /run/variants/six_cycles
+      /run/sleeptenmin/builtin:sleep_method => builtin
+      /run/variants/six_cycles:sleep_cycles => 6
+      /run/variants/six_cycles:sleep_length => 100
 
-      Variant 3:    /run/sleeptenmin/builtin, /run/variants/one_hundred_cycles
-          /run/sleeptenmin/builtin:sleep_method         => builtin
-          /run/variants/one_hundred_cycles:sleep_cycles => 100
-          /run/variants/one_hundred_cycles:sleep_length => 6
+  Variant builtin-one_hundred_cycles-633a:    /run/sleeptenmin/builtin, /run/variants/one_hundred_cycles
+      /run/sleeptenmin/builtin:sleep_method         => builtin
+      /run/variants/one_hundred_cycles:sleep_cycles => 100
+      /run/variants/one_hundred_cycles:sleep_length => 6
 
-      Variant 4:    /run/sleeptenmin/builtin, /run/variants/six_hundred_cycles
-          /run/sleeptenmin/builtin:sleep_method         => builtin
-          /run/variants/six_hundred_cycles:sleep_cycles => 600
-          /run/variants/six_hundred_cycles:sleep_length => 1
+  Variant builtin-six_hundred_cycles-a570:    /run/sleeptenmin/builtin, /run/variants/six_hundred_cycles
+      /run/sleeptenmin/builtin:sleep_method         => builtin
+      /run/variants/six_hundred_cycles:sleep_cycles => 600
+      /run/variants/six_hundred_cycles:sleep_length => 1
 
-      Variant 5:    /run/sleeptenmin/shell, /run/variants/one_cycle
-          /run/sleeptenmin/shell:sleep_method  => shell
-          /run/variants/one_cycle:sleep_cycles => 1
-          /run/variants/one_cycle:sleep_length => 600
+  Variant shell-one_cycle-55f5:    /run/sleeptenmin/shell, /run/variants/one_cycle
+      /run/sleeptenmin/shell:sleep_method  => shell
+      /run/variants/one_cycle:sleep_cycles => 1
+      /run/variants/one_cycle:sleep_length => 600
 
-      Variant 6:    /run/sleeptenmin/shell, /run/variants/six_cycles
-          /run/sleeptenmin/shell:sleep_method   => shell
-          /run/variants/six_cycles:sleep_cycles => 6
-          /run/variants/six_cycles:sleep_length => 100
+  Variant shell-six_cycles-9e23:    /run/sleeptenmin/shell, /run/variants/six_cycles
+      /run/sleeptenmin/shell:sleep_method   => shell
+      /run/variants/six_cycles:sleep_cycles => 6
+      /run/variants/six_cycles:sleep_length => 100
 
-      Variant 7:    /run/sleeptenmin/shell, /run/variants/one_hundred_cycles
-          /run/sleeptenmin/shell:sleep_method           => shell
-          /run/variants/one_hundred_cycles:sleep_cycles => 100
-          /run/variants/one_hundred_cycles:sleep_length => 6
+  Variant shell-one_hundred_cycles-586f:    /run/sleeptenmin/shell, /run/variants/one_hundred_cycles
+      /run/sleeptenmin/shell:sleep_method           => shell
+      /run/variants/one_hundred_cycles:sleep_cycles => 100
+      /run/variants/one_hundred_cycles:sleep_length => 6
 
-      Variant 8:    /run/sleeptenmin/shell, /run/variants/six_hundred_cycles
-          /run/sleeptenmin/shell:sleep_method           => shell
-          /run/variants/six_hundred_cycles:sleep_cycles => 600
-          /run/variants/six_hundred_cycles:sleep_length => 1
+  Variant shell-six_hundred_cycles-1e84:    /run/sleeptenmin/shell, /run/variants/six_hundred_cycles
+      /run/sleeptenmin/shell:sleep_method           => shell
+      /run/variants/six_hundred_cycles:sleep_cycles => 600
+      /run/variants/six_hundred_cycles:sleep_length => 1
 
 You can see that it creates all possible variants of each ``multiplex domain``,
 which are defined by ``!mux`` tag in the YAML file and displayed as single
@@ -338,14 +338,14 @@ values). In total it'll produce 8 variants of each test::
       $ avocado run --mux-yaml examples/tests/sleeptenmin.py.data/sleeptenmin.yaml -- passtest.py
       JOB ID     : cc7ef22654c683b73174af6f97bc385da5a0f02f
       JOB LOG    : /home/medic/avocado/job-results/job-2017-01-22T11.26-cc7ef22/job.log
-       (1/8) passtest.py:PassTest.test;1: PASS (0.01 s)
-       (2/8) passtest.py:PassTest.test;2: PASS (0.01 s)
-       (3/8) passtest.py:PassTest.test;3: PASS (0.01 s)
-       (4/8) passtest.py:PassTest.test;4: PASS (0.01 s)
-       (5/8) passtest.py:PassTest.test;5: PASS (0.01 s)
-       (6/8) passtest.py:PassTest.test;6: PASS (0.01 s)
-       (7/8) passtest.py:PassTest.test;7: PASS (0.01 s)
-       (8/8) passtest.py:PassTest.test;8: PASS (0.01 s)
+       (1/8) passtest.py:PassTest.test;builtin-one_cycle-f659: PASS (0.01 s)
+       (2/8) passtest.py:PassTest.test;builtin-six_cycles-723b: PASS (0.01 s)
+       (3/8) passtest.py:PassTest.test;builtin-one_hundred_cycles-633a: PASS (0.01 s)
+       (4/8) passtest.py:PassTest.test;builtin-six_hundred_cycles-a570: PASS (0.01 s)
+       (5/8) passtest.py:PassTest.test;shell-one_cycle-55f5: PASS (0.01 s)
+       (6/8) passtest.py:PassTest.test;shell-six_cycles-9e23: PASS (0.01 s)
+       (7/8) passtest.py:PassTest.test;shell-one_hundred_cycles-586f: PASS (0.01 s)
+       (8/8) passtest.py:PassTest.test;shell-six_hundred_cycles-1e84: PASS (0.01 s)
       RESULTS    : PASS 8 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0
       JOB TIME   : 0.16 s
 

--- a/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
+++ b/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
@@ -37,7 +37,7 @@ from avocado.core.output import LOG_JOB, LOG_UI
 from avocado.core.plugin_interfaces import CLI
 from avocado.core.runner import TestRunner
 from avocado.core.settings import settings
-from avocado.core.test import TestName
+from avocado.core.test import TestID
 from avocado.utils import archive
 from avocado.utils import astring
 from avocado.utils import process
@@ -507,7 +507,7 @@ class RemoteTestRunner(TestRunner):
                 name = [name[0]] + name[1].split(';')
                 if len(name) == 3:
                     name[2] = {"variant_id": name[2]}
-                name = TestName(*name, no_digits=-1)
+                name = TestID(*name, no_digits=-1)
                 state = dict(name=name,
                              time_elapsed=tst['time'],
                              time_start=tst['start'],

--- a/selftests/unit/test_astring.py
+++ b/selftests/unit/test_astring.py
@@ -5,7 +5,7 @@ from avocado.utils import astring
 
 class AstringTest(unittest.TestCase):
 
-    def testTabularOutput(self):
+    def test_tabular_output(self):
         matrix = [('foo', 'bar'), ('/bin/bar/sbrubles',
                                    '/home/myuser/sbrubles')]
         self.assertEqual(astring.tabular_output(matrix),
@@ -17,7 +17,7 @@ class AstringTest(unittest.TestCase):
                           'foo               bar\n'
                           '/bin/bar/sbrubles /home/myuser/sbrubles'))
 
-    def testTabularWithConsoleCodes(self):
+    def test_tabular_with_console_codes(self):
         matrix = [("a", "an", "dog", "word", "last"),
                   ("\x1b[94ma",             # {BLUE}a
                    "\033[0man",             # {END}an
@@ -32,7 +32,7 @@ class AstringTest(unittest.TestCase):
                          "[94ma [0man cc[91mc "
                          "[91md[92md[94md[90md[0m last")
 
-    def testTabularOutputDifferentNOCols(self):
+    def test_tabular_output_different_no_cols(self):
         matrix = [[], [1], [2, 2], [333, 333, 333], [4, 4, 4, 4444]]
         self.assertEqual(astring.tabular_output(matrix),
                          "1\n"
@@ -40,7 +40,7 @@ class AstringTest(unittest.TestCase):
                          "333 333 333\n"
                          "4   4   4   4444")
 
-    def testUnicodeTabular(self):
+    def test_unicode_tabular(self):
         """
         Verifies tabular can handle utf-8 chars properly
 

--- a/selftests/unit/test_datadir.py
+++ b/selftests/unit/test_datadir.py
@@ -37,7 +37,7 @@ class DataDirTest(unittest.TestCase):
         (self.mapping,
          self.config_file_path) = self._get_temporary_dirs_mapping_and_config()
 
-    def testDataDirFromConfig(self):
+    def test_datadir_from_config(self):
         """
         When avocado.conf is present, honor the values coming from it.
         """
@@ -57,7 +57,7 @@ class DataDirTest(unittest.TestCase):
             flexmock(settings, settings=stg_orig)
         del data_dir
 
-    def testUniqueLogDir(self):
+    def test_unique_log_dir(self):
         """
         Tests that multiple queries for a logdir at the same time provides
         unique results.
@@ -78,7 +78,7 @@ class DataDirTest(unittest.TestCase):
         self.assertEqual(path, path_prefix + uid + ".1")
         self.assertTrue(os.path.exists(path))
 
-    def testSettingsDirAlternateDynamic(self):
+    def test_settings_dir_alternate_dynamic(self):
         """
         Tests that changes to the data_dir settings are applied dynamically
 

--- a/selftests/unit/test_jsonresult.py
+++ b/selftests/unit/test_jsonresult.py
@@ -44,7 +44,7 @@ class JSONResultTest(unittest.TestCase):
         os.remove(self.tmpfile[1])
         shutil.rmtree(self.tmpdir)
 
-    def testAddSuccess(self):
+    def test_add_success(self):
         self.test_result.start_test(self.test1)
         self.test_result.end_test(self.test1.get_state())
         self.test_result.end_tests()
@@ -56,7 +56,7 @@ class JSONResultTest(unittest.TestCase):
         self.assertTrue(obj)
         self.assertEqual(len(obj['tests']), 1)
 
-    def testAddSeveralStatuses(self):
+    def test_add_several_statuses(self):
         def run_fake_status(status):
             self.test_result.start_test(self.test1)
             self.test_result.check_test(status)
@@ -92,7 +92,7 @@ class JSONResultTest(unittest.TestCase):
         check_item("[skip]", res["skip"], 4)
         check_item("[total]", res["total"], 13)
 
-    def testNegativeStatus(self):
+    def test_negative_status(self):
         def check_item(name, value, exp):
             self.assertEqual(value, exp, "Result%s is %s and not %s\n%s"
                              % (name, value, exp, res))

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -253,7 +253,7 @@ class LoaderTest(unittest.TestCase):
         test_class, test_parameters = (
             self.loader.discover(simple_test.path, loader.ALL)[0])
         self.assertTrue(test_class == test.SimpleTest, test_class)
-        test_parameters['name'] = test.TestName(0, test_parameters['name'])
+        test_parameters['name'] = test.TestID(0, test_parameters['name'])
         test_parameters['base_logdir'] = self.tmpdir
         tc = test_class(**test_parameters)
         tc.run_avocado()
@@ -299,7 +299,7 @@ class LoaderTest(unittest.TestCase):
         test_class, test_parameters = (
             self.loader.discover(avocado_not_a_test.path, loader.ALL)[0])
         self.assertTrue(test_class == test.SimpleTest, test_class)
-        test_parameters['name'] = test.TestName(0, test_parameters['name'])
+        test_parameters['name'] = test.TestID(0, test_parameters['name'])
         test_parameters['base_logdir'] = self.tmpdir
         tc = test_class(**test_parameters)
         # The test can't be executed (no shebang), raising an OSError
@@ -315,7 +315,7 @@ class LoaderTest(unittest.TestCase):
         test_class, test_parameters = (
             self.loader.discover(avocado_simple_test.path, loader.ALL)[0])
         self.assertTrue(test_class == test.SimpleTest)
-        test_parameters['name'] = test.TestName(0, test_parameters['name'])
+        test_parameters['name'] = test.TestID(0, test_parameters['name'])
         test_parameters['base_logdir'] = self.tmpdir
         tc = test_class(**test_parameters)
         tc.run_avocado()

--- a/selftests/unit/test_settings.py
+++ b/selftests/unit/test_settings.py
@@ -24,21 +24,21 @@ class SettingsTest(unittest.TestCase):
         self.config_file.close()
         self.settings = settings.Settings(self.config_file.name)
 
-    def testStringConversion(self):
+    def test_string_conversion(self):
         self.assertEqual(self.settings.get_value('foo', 'str_key', str),
                          'frobnicate')
 
-    def testIntConversion(self):
+    def test_int_conversion(self):
         self.assertEqual(self.settings.get_value('foo', 'int_key', int), 1)
 
-    def testFloatConversion(self):
+    def test_float_conversion(self):
         self.assertEqual(self.settings.get_value('foo', 'float_key', float),
                          1.25)
 
-    def testBoolConversion(self):
+    def test_bool_conversion(self):
         self.assertTrue(self.settings.get_value('foo', 'bool_key', bool))
 
-    def testPathHomeDir(self):
+    def test_path_homedir(self):
         raw_from_settings = '~/path/at/home'
         path_from_settings = self.settings.get_value('foo', 'path', 'path')
         home_str_from_settings = self.settings.get_value('foo', 'home_path', str)
@@ -49,47 +49,47 @@ class SettingsTest(unittest.TestCase):
         self.assertEqual(os.path.expanduser(home_str_from_settings),
                          self.settings.get_value('foo', 'home_path', 'path'))
 
-    def testPathOnStrKey(self):
+    def test_path_on_str_key(self):
         self.assertEqual(self.settings.get_value('foo', 'path', str),
                          '~/path/at/home')
 
-    def testListConversion(self):
+    def test_list_conversion(self):
         self.assertEqual(self.settings.get_value('foo', 'list_key', list),
                          ['I', 'love', 'settings'])
 
-    def testDefault(self):
+    def test_default(self):
         self.assertEqual(self.settings.get_value('foo', 'non_existing',
                                                  str, "ohnoes"), "ohnoes")
 
-    def testNonExistingKey(self):
+    def test_non_existing_key(self):
         with self.assertRaises(settings.SettingsError):
             self.settings.get_value('foo', 'non_existing', str)
 
-    def testAllowBlankTrueStr(self):
+    def test_allow_blank_true_str(self):
         self.assertEqual(self.settings.get_value('foo', 'empty_key', str,
                                                  allow_blank=True), "")
 
-    def testAllowBlankTrueInt(self):
+    def test_allow_blank_true_int(self):
         self.assertEqual(self.settings.get_value('foo', 'empty_key', int,
                                                  allow_blank=True), 0)
 
-    def testAllowBlankTrueFloat(self):
+    def test_allow_blank_true_float(self):
         self.assertEqual(self.settings.get_value('foo', 'empty_key', float,
                                                  allow_blank=True), 0.0)
 
-    def testAllowBlankTrueList(self):
+    def test_allow_blank_true_list(self):
         self.assertEqual(self.settings.get_value('foo', 'empty_key', list,
                                                  allow_blank=True), [])
 
-    def testAllowBlankTrueBool(self):
+    def test_allow_blank_true_bool(self):
         self.assertEqual(self.settings.get_value('foo', 'empty_key', bool,
                                                  allow_blank=True), False)
 
-    def testAllowBlankTrueOther(self):
+    def test_allow_blank_true_other(self):
         self.assertEqual(self.settings.get_value('foo', 'empty_key', 'baz',
                                                  allow_blank=True), None)
 
-    def testAllowBlankFalse(self):
+    def test_allow_blank_false(self):
         with self.assertRaises(settings.SettingsError):
             self.settings.get_value('foo', 'empty_key', str)
 

--- a/selftests/unit/test_sysinfo.py
+++ b/selftests/unit/test_sysinfo.py
@@ -11,7 +11,7 @@ class SysinfoTest(unittest.TestCase):
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp(prefix="sysinfo_unittest")
 
-    def testLoggablesEqual(self):
+    def test_loggables_equal(self):
         cmd1 = sysinfo.Command("ls -l")
         cmd2 = sysinfo.Command("ls -l")
         self.assertEqual(cmd1, cmd2)
@@ -19,7 +19,7 @@ class SysinfoTest(unittest.TestCase):
         file2 = sysinfo.Logfile("/proc/cpuinfo")
         self.assertEqual(file1, file2)
 
-    def testLoggablesNotEqual(self):
+    def test_loggables_not_equal(self):
         cmd1 = sysinfo.Command("ls -l")
         cmd2 = sysinfo.Command("ls -la")
         self.assertNotEqual(cmd1, cmd2)
@@ -27,7 +27,7 @@ class SysinfoTest(unittest.TestCase):
         file2 = sysinfo.Logfile("/etc/fstab")
         self.assertNotEqual(file1, file2)
 
-    def testLoggablesSet(self):
+    def test_loggables_set(self):
         container = set()
         cmd1 = sysinfo.Command("ls -l")
         cmd2 = sysinfo.Command("ls -l")

--- a/selftests/unit/test_test.py
+++ b/selftests/unit/test_test.py
@@ -145,10 +145,6 @@ class TestClassTest(unittest.TestCase):
         self.assertRaises(exceptions.TestSetupFail, AvocadoPass,
                           base_logdir=self.base_logdir)
 
-    def test_not_test_name(self):
-        self.assertRaises(test.NameNotTestNameError,
-                          test.Test, name='mytest')
-
     def tearDown(self):
         shutil.rmtree(self.base_logdir)
 

--- a/selftests/unit/test_test.py
+++ b/selftests/unit/test_test.py
@@ -30,7 +30,7 @@ class TestClassTestUnit(unittest.TestCase):
         flexmock_teardown()
         shutil.rmtree(self.tmpdir)
 
-    def testUglyName(self):
+    def test_ugly_name(self):
         def run(name, path_name):
             """ Initialize test and check the dirs were created """
             tst = self.DummyTest("test", test.TestName(1, name),
@@ -56,7 +56,7 @@ class TestClassTestUnit(unittest.TestCase):
                 "\xac\xef\xb7\xad\xef\xb7\xae\xef\xb7\xaf")
         run(name, "1-" + name)
 
-    def testLongName(self):
+    def test_long_name(self):
         def check(uid, name, variant, exp_logdir):
             tst = self.DummyTest("test", test.TestName(uid, name, variant),
                                  base_logdir=self.tmpdir)
@@ -93,13 +93,13 @@ class TestClassTestUnit(unittest.TestCase):
         tst._record_reference_stdout()
         tst._record_reference_stderr()
 
-    def testAllDirsExistsNoHang(self):
+    def test_all_dirs_exists_no_hang(self):
         flexmock(os.path)
         os.path.should_receive('exists').and_return(True)
         self.assertRaises(exceptions.TestSetupFail, self.DummyTest, "test",
                           test.TestName(1, "name"), base_logdir=self.tmpdir)
 
-    def testTryOverrideTestVariable(self):
+    def test_try_override_test_variable(self):
         test = self.DummyTest(base_logdir=self.tmpdir)
         self.assertRaises(AttributeError, setattr, test, "name", "whatever")
         self.assertRaises(AttributeError, setattr, test, "status", "whatever")
@@ -119,16 +119,16 @@ class TestClassTest(unittest.TestCase):
         self.tst_instance_pass = AvocadoPass(base_logdir=self.base_logdir)
         self.tst_instance_pass.run_avocado()
 
-    def testClassAttributesName(self):
+    def test_class_attributes_name(self):
         self.assertEqual(self.tst_instance_pass.name, '0-AvocadoPass')
 
-    def testClassAttributesStatus(self):
+    def test_class_attributes_status(self):
         self.assertEqual(self.tst_instance_pass.status, 'PASS')
 
-    def testClassAttributesTimeElapsed(self):
+    def test_class_attributes_time_elapsed(self):
         self.assertIsInstance(self.tst_instance_pass.time_elapsed, float)
 
-    def testWhiteboardSave(self):
+    def test_whiteboard_save(self):
         whiteboard_file = os.path.join(
             self.tst_instance_pass.logdir, 'whiteboard')
         self.assertTrue(os.path.isfile(whiteboard_file))
@@ -136,7 +136,7 @@ class TestClassTest(unittest.TestCase):
             whiteboard_contents = whiteboard_file_obj.read().strip()
             self.assertTrue(whiteboard_contents, 'foo')
 
-    def testRunningTestTwiceWithTheSameUidFailure(self):
+    def test_running_test_twice_with_the_same_uid_failure(self):
         class AvocadoPass(test.Test):
 
             def test(self):
@@ -145,7 +145,7 @@ class TestClassTest(unittest.TestCase):
         self.assertRaises(exceptions.TestSetupFail, AvocadoPass,
                           base_logdir=self.base_logdir)
 
-    def testNotTestName(self):
+    def test_not_test_name(self):
         self.assertRaises(test.NameNotTestNameError,
                           test.Test, name='mytest')
 
@@ -179,10 +179,10 @@ class SimpleTestClassTest(unittest.TestCase):
             base_logdir=self.tmpdir)
         self.tst_instance_fail.run_avocado()
 
-    def testSimpleTestPassStatus(self):
+    def test_simple_test_pass_status(self):
         self.assertEqual(self.tst_instance_pass.status, 'PASS')
 
-    def testSimpleTestFailStatus(self):
+    def test_simple_test_fail_status(self):
         self.assertEqual(self.tst_instance_fail.status, 'FAIL')
 
     def tearDown(self):

--- a/selftests/unit/test_utils_asset.py
+++ b/selftests/unit/test_utils_asset.py
@@ -20,7 +20,7 @@ class TestAsset(unittest.TestCase):
         self.url = 'file://%s' % self.localpath
         self.cache_dir = tempfile.mkdtemp(dir=self.basedir)
 
-    def testFetch_urlname(self):
+    def test_fetch_urlname(self):
         foo_tarball = asset.Asset(self.url,
                                   asset_hash=self.assethash,
                                   algorithm='sha1',
@@ -30,7 +30,7 @@ class TestAsset(unittest.TestCase):
         expected_tarball = os.path.join(self.cache_dir, self.assetname)
         self.assertEqual(foo_tarball, expected_tarball)
 
-    def testFetch_location(self):
+    def test_fetch_location(self):
         foo_tarball = asset.Asset(self.assetname,
                                   asset_hash=self.assethash,
                                   algorithm='sha1',
@@ -40,7 +40,7 @@ class TestAsset(unittest.TestCase):
         expected_tarball = os.path.join(self.cache_dir, self.assetname)
         self.assertEqual(foo_tarball, expected_tarball)
 
-    def testFecth_expire(self):
+    def test_fecth_expire(self):
         foo_tarball = asset.Asset(self.assetname,
                                   asset_hash=self.assethash,
                                   algorithm='sha1',
@@ -81,13 +81,13 @@ class TestAsset(unittest.TestCase):
             content2 = f.read()
         self.assertNotEqual(content1, content2)
 
-    def testException(self):
+    def test_exception(self):
         a = asset.Asset(name='bar.tgz', asset_hash=None, algorithm=None,
                         locations=None, cache_dirs=[self.cache_dir],
                         expire=None)
         self.assertRaises(EnvironmentError, a.fetch)
 
-    def testFetch_lockerror(self):
+    def test_fetch_lockerror(self):
         with FileLock(os.path.join(self.cache_dir, self.assetname)):
             a = asset.Asset(self.url,
                             asset_hash=self.assethash,

--- a/selftests/unit/test_utils_output.py
+++ b/selftests/unit/test_utils_output.py
@@ -5,7 +5,7 @@ from avocado.utils import output
 
 class UtilsOutputTest(unittest.TestCase):
 
-    def testDisplayDataSizeFactor1024(self):
+    def test_display_data_size_factor_1024(self):
         self.assertEqual(output.display_data_size(103), '103.00 B')
         self.assertEqual(output.display_data_size(1024**1), '1.02 KB')
         self.assertEqual(output.display_data_size(1024**2), '1.05 MB')
@@ -14,7 +14,7 @@ class UtilsOutputTest(unittest.TestCase):
         self.assertEqual(output.display_data_size(1024**5), '1.13 PB')
         self.assertEqual(output.display_data_size(1024**6), '1152.92 PB')
 
-    def testDisplayDataSizeFactor1000(self):
+    def test_display_data_size_factor_1000(self):
         self.assertEqual(output.display_data_size(1000**1), '1.00 KB')
         self.assertEqual(output.display_data_size(1000**2), '1.00 MB')
         self.assertEqual(output.display_data_size(1000**3), '1.00 GB')

--- a/selftests/unit/test_xunit.py
+++ b/selftests/unit/test_xunit.py
@@ -56,7 +56,7 @@ class xUnitSucceedTest(unittest.TestCase):
         os.remove(self.tmpfile[1])
         shutil.rmtree(self.tmpdir)
 
-    def testAddSuccess(self):
+    def test_add_success(self):
         self.test_result.start_test(self.test1)
         self.test_result.end_test(self.test1.get_state())
         self.test_result.end_tests()


### PR DESCRIPTION
This contains the fixes commit originally part of PR #2164.

I decided to split it because the Travis job wouldn't pass with this number of commits, and also because the changes about test/variant data files can be better reviewed alone.

---

Changes relative to PR #2164:

On commit `Docs: give examples on both Test Names and Test IDs`:
 * Shortened test uid (that is, replaced "001-test_name" for "1-test_name")

Removal of commit `avocado/core/test.py: do not default test name to unknown`

On commit `avocado/core/test.py: do not force TestName type`:
 * Wrote a proper commit message

On commit `avocado/core/test.py: rename TestName to TestID`:
* Fixed the `__init__()` docstring parameter "variant" information
* Fixed the name property docstring about returning (removed the FIXME and gave information on the return type)


