### PR TITLE
runner: install the SIGTSTP handler on the runner only [v2]

### DIFF
--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -299,7 +299,6 @@ class TestRunner(object):
         :param queue: Multiprocess queue.
         :type queue: :class:`multiprocessing.Queue` instance.
         """
-        signal.signal(signal.SIGTSTP, signal.SIG_IGN)
         sys.stdout = output.LoggingFile(["[stdout] "], loggers=[TEST_LOG])
         sys.stderr = output.LoggingFile(["[stderr] "], loggers=[TEST_LOG])
 
@@ -375,16 +374,15 @@ class TestRunner(object):
                     process.kill_process_tree(proc.pid, signal.SIGSTOP, False)
                     self.sigstopped = True
 
-        signal.signal(signal.SIGTSTP, sigtstp_handler)
-
         proc = multiprocessing.Process(target=self._run_test,
                                        args=(test_factory, queue,))
         test_status = TestStatus(self.job, queue)
 
         cycle_timeout = 1
         time_started = time.time()
+        signal.signal(signal.SIGTSTP, signal.SIG_IGN)
         proc.start()
-
+        signal.signal(signal.SIGTSTP, sigtstp_handler)
         test_status.wait_for_early_status(proc, 60)
 
         # At this point, the test is already initialized and we know


### PR DESCRIPTION
Currently, the signal handler for SIGTSTP (which implements the test
pause/resume) is installed before the test process is created, and
thus, is inherited by it.

There's a clean up of the signal handler in the test process, but this
clean up can be prevented by installing the signal handler on the test
runner alone (after the test process is created).

The ramifications of this proposal are such that, in the chance that a
SIGTSTP is received after the test process is created and before the
signal handler is installed in the test runner process, nothing will
happen.  In contrast, the current approach may have the signal handler
action being executed, and attempting to send SIGSTOP or SIGCONT to
the test process, but not doing so because there's no test process
yet.

In the end, it seems that the two approaches are pretty safe, and the
biggest benefit here is that the test process never has the handler
installed.

Signed-off-by: Cleber Rosa <crosa@redhat.com>

---

Changes from v1 (#2091):
 * Added a clearing of the signal before the test process is started.  The reason is that, if the runner has the signal installed as part of a previous test execution, it won't be passed to the new (second, third, etc) test processes.