### PR TITLE
Simplifications to Avocado's executables (aka scripts) [v2]

### DIFF
--- a/scripts/avocado
+++ b/scripts/avocado
@@ -56,14 +56,6 @@ def handle_exception(*exc_info):
     sys.exit(-1)
 
 
-# simple magic for using scripts within a source tree
-basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if os.path.isdir(os.path.join(basedir, 'avocado')):
-    os.environ['PATH'] += ":" + os.path.join(basedir, 'scripts')
-    os.environ['PATH'] += ":" + os.path.join(basedir, 'libexec')
-    sys.path.append(basedir)
-
-
 if __name__ == '__main__':
     sys.excepthook = handle_exception
     from avocado.core.app import AvocadoApp

--- a/scripts/avocado
+++ b/scripts/avocado
@@ -56,10 +56,6 @@ def handle_exception(*exc_info):
     sys.exit(-1)
 
 
-if __name__ == '__main__':
-    sys.excepthook = handle_exception
-
-
 # simple magic for using scripts within a source tree
 basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if os.path.isdir(os.path.join(basedir, 'avocado')):
@@ -68,10 +64,10 @@ if os.path.isdir(os.path.join(basedir, 'avocado')):
     sys.path.append(basedir)
 
 
-from avocado.core.app import AvocadoApp
-
-
 if __name__ == '__main__':
+    sys.excepthook = handle_exception
+    from avocado.core.app import AvocadoApp
+
     # Override tmp in case it's not set in env
     for attr in ("TMP", "TEMP", "TMPDIR"):
         if attr in os.environ:

--- a/scripts/avocado-rest-client
+++ b/scripts/avocado-rest-client
@@ -14,13 +14,7 @@
 # Author: Cleber Rosa <cleber@redhat.com>
 
 
-import os
 import sys
-
-# simple magic for using scripts within a source tree
-basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if os.path.isdir(os.path.join(basedir, 'avocado')):
-    sys.path.append(basedir)
 
 from avocado.core.restclient.cli.app import App
 

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -763,6 +763,11 @@ class RunnerSimpleTest(unittest.TestCase):
         simplewarning.sh uses the avocado-bash-utils
         """
         os.chdir(basedir)
+        # simplewarning.sh calls "avocado" without specifying a path
+        os.environ['PATH'] += ":" + os.path.join(basedir, 'scripts')
+        # simplewarning.sh calls "avocado exec-path" which hasn't
+        # access to an installed location for the libexec scripts
+        os.environ['PATH'] += ":" + os.path.join(basedir, 'libexec')
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
                     'examples/tests/simplewarning.sh --show-job-log'
                     % (AVOCADO, self.tmpdir))


### PR DESCRIPTION
A couple of cleanups/simplifications for the avocado executables (aka scripts).

---

Changes from v1 (#2093):
 * Move the avocado import to after the exception hook is set