### PR TITLE
avocado/core/job.py: fix Avocado version info output to log [v2]

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -323,22 +323,17 @@ class Job(object):
 
     @staticmethod
     def _log_avocado_version():
-        LOG_JOB.info('Avocado version: %s', version.VERSION)
-        if os.path.exists('.git') and os.path.exists('avocado.spec'):
+        version_log = version.VERSION
+        git_root = process.run('git rev-parse --show-toplevel',
+                               ignore_status=True, verbose=False)
+        if git_root.exit_status == 0 and os.path.exists(os.path.join(
+                git_root.stdout.strip(), 'python-avocado.spec')):
             cmd = "git show --summary --pretty='%H'"
-            result = process.run(cmd, ignore_status=True)
-            status = result.exit_status
-            top_commit = result.stdout.splitlines()[0]
-            cmd2 = "git rev-parse --abbrev-ref HEAD"
-            result2 = process.run(cmd2)
-            status2 = result2.exit_status
-            branch = result2.stdout
-            # Let's display information only if git is installed
-            # (commands succeed).
-            if status == 0 and status2 == 0:
-                LOG_JOB.info('Avocado git repo info')
-                LOG_JOB.info("Top commit: %s", top_commit)
-                LOG_JOB.info("Branch: %s", branch)
+            result = process.run(cmd, ignore_status=True, verbose=False)
+            if result.exit_status == 0:
+                top_commit = result.stdout.splitlines()[0][:8]
+                version_log += " (GIT commit %s)" % top_commit
+        LOG_JOB.info('Avocado version: %s', version_log)
         LOG_JOB.info('')
 
     @staticmethod


### PR DESCRIPTION
The recording of Avocado version, when running from a GIT repo has
been broken for a long time (since the SPEC file was renamed).  This
could be a simple fix to just match the new SPEC file named, but I
think we can do better.  Besides this fix, the changes here include:

 - Print a short commit instead (8 chars)
 - Omit branch name, commit is authoritative enough and developers can
   tell the name of a branch if it's really necessary

But, let me say that this is still broken.  The GIT version
information is only printed if the current work directory is inside
the GIT repo directory.  A better (and way more complex) fix would be
one that looks where the avocado script and Python libraries were
loaded from, and check if that location is a GIT repo.  Instead of
doing that, though, it'd make more sense to use a semantic version
approach (and possibly a library).

Signed-off-by: Cleber Rosa <crosa@redhat.com>

---

Changes from v1 (#2168):
 * Used `git rev-parse --show-toplevel` for an improved check for an Avocado GIT repo