### PR TITLE
avocado/plugins/replay.py: remove misleading TODO comment

### DIFF
--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -226,8 +226,6 @@ class Replay(CLI):
                 elif option in replay_args:
                     setattr(args, option, replay_args[option])
 
-        # Keeping this for compatibility.
-        # TODO: Use replay_args['reference'] at some point in the future.
         if getattr(args, 'reference', None):
             LOG_UI.warn('Overriding the replay test references with test '
                         'references given in the command line.')


### PR DESCRIPTION
The current state of this comment is the result of a mechanical change
replacing `urls` with `references`.

The source for references given on the command line is working as
intended, that is, if test references are given on the command line
they are taken and will override the ones on the replay args.

Signed-off-by: Cleber Rosa <crosa@redhat.com>