### PR TITLE
Output record: also record the combined stdout+stderr output

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -213,6 +213,7 @@ class Test(unittest.TestCase):
 
         self._stdout_file = os.path.join(self.logdir, 'stdout')
         self._stderr_file = os.path.join(self.logdir, 'stderr')
+        self._output_file = os.path.join(self.logdir, 'output')
         self._logging_handlers = {}
 
         self.__outputdir = utils_path.init_dir(self.logdir, 'data')
@@ -525,6 +526,14 @@ class Test(unittest.TestCase):
         self._register_log_file_handler(logging.getLogger('paramiko'),
                                         formatter,
                                         self._ssh_logfile)
+
+        # combined output logging
+        self._register_log_file_handler(log_test_stdout,
+                                        stream_formatter,
+                                        self._output_file)
+        self._register_log_file_handler(log_test_stderr,
+                                        stream_formatter,
+                                        self._output_file)
 
         if isinstance(sys.stdout, output.LoggingFile):
             sys.stdout.add_logger(log_test_stdout)

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -150,6 +150,9 @@ class OutputTest(unittest.TestCase):
                          open(os.path.join(testdir, "stdout")).read())
         self.assertEqual("test_stderr\n",
                          open(os.path.join(testdir, "stderr")).read())
+        self.assertEqual("test_print\ntest_stdout\ntest_stderr\n"
+                         "test_process\n",
+                         open(os.path.join(testdir, "output")).read())
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir)


### PR DESCRIPTION
Some tests that rely on output check may also rely on the combined
generated output (stdout+stderr).  The first step is to record that
in the same order it was generated.

Signed-off-by: Cleber Rosa <crosa@redhat.com>