### PR TITLE
test: Log full path to the test source

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -261,7 +261,18 @@ class Test(unittest.TestCase):
                                              basename)
         self.__srcdir = utils_path.init_dir(self.workdir, 'src')
 
+        test_metadata = self._get_metadata()
+        if test_metadata:
+            self.log.debug("Test metadata:")
+            for key, value in test_metadata.iteritems():
+                self.log.debug("  %s: %s", key, value)
         unittest.TestCase.__init__(self, methodName=methodName)
+
+    def _get_metadata(self):
+        """
+        Returns a dictionary containing various metadata about this test
+        """
+        return {"test_src": inspect.getfile(self.__class__)}
 
     @property
     def name(self):


### PR DESCRIPTION
Currently it might not be easy to determine what version of the test
source was executed (eg. when test-repo is used). Let's log the test_src
entry which is the location of the source file of the test class.

In the future we or users should be able to extend the concept of test
metadata of other useful details like mentioned in

    https://trello.com/c/XvaiS4UV/1063-introduce-test-repo-concept-to-
    make-test-names-more-relevant

for example "test_tainted, test_version (sha), etc, this is why I chose
generic approach by using `self._get_metadata`.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>