### PR TITLE
test: flag that test is being skipped

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -588,6 +588,7 @@ class Test(unittest.TestCase):
             if skip_test is False:
                 self.setUp()
         except (exceptions.TestSetupSkip, exceptions.TestSkipError) as details:
+            skip_test = True
             stacktrace.log_exc_info(sys.exc_info(), logger=LOG_JOB)
             raise exceptions.TestSkipError(details)
         except exceptions.TestCancel as details:

--- a/selftests/functional/test_statuses.py
+++ b/selftests/functional/test_statuses.py
@@ -25,8 +25,6 @@ ALL_MESSAGES = ['setup pre',
 #                     [msg_in, ...])
 EXPECTED_RESULTS = {'skip-setup-d304': ('SKIP',
                                         ['setup pre',
-                                         'teardown pre',
-                                         'teardown post',
                                          "[WARNING: self.skip() will be "
                                          "deprecated. Use 'self.cancel()' "
                                          "or the skip decorators]"]),


### PR DESCRIPTION
Now that the teardown() is always called, we have to explicitly flag
when it should be skipped. That's the case when someone decorates the
setUp() with a skip decorator or when someone calls self.skip() in
setUp().

Reference: https://trello.com/c/B6DJe0JS
Signed-off-by: Amador Pahim <apahim@redhat.com>