### PR TITLE
venv: Avoid using home dirs when using virtual_env

### DIFF
--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -36,14 +36,17 @@ from .output import LOG_JOB
 from ..utils import path as utils_path
 from ..utils.data_structures import Borg
 
-SYSTEM_BASE_DIR = '/var/lib/avocado'
 if 'VIRTUAL_ENV' in os.environ:
     SYSTEM_BASE_DIR = os.environ['VIRTUAL_ENV']
+    USER_BASE_DIR = SYSTEM_BASE_DIR
+else:
+    SYSTEM_BASE_DIR = '/var/lib/avocado'
+    USER_BASE_DIR = os.path.expanduser('~/avocado')
+
 SYSTEM_TEST_DIR = os.path.join(SYSTEM_BASE_DIR, 'tests')
 SYSTEM_DATA_DIR = os.path.join(SYSTEM_BASE_DIR, 'data')
 SYSTEM_LOG_DIR = os.path.join(SYSTEM_BASE_DIR, 'job-results')
 
-USER_BASE_DIR = os.path.expanduser('~/avocado')
 USER_TEST_DIR = os.path.join(USER_BASE_DIR, 'tests')
 USER_DATA_DIR = os.path.join(USER_BASE_DIR, 'data')
 USER_LOG_DIR = os.path.join(USER_BASE_DIR, 'job-results')

--- a/avocado/core/settings.py
+++ b/avocado/core/settings.py
@@ -29,12 +29,14 @@ from ..utils import path
 
 if 'VIRTUAL_ENV' in os.environ:
     CFG_DIR = os.path.join(os.environ['VIRTUAL_ENV'], 'etc')
+    USER_DIR = os.environ['VIRTUAL_ENV']
 else:
     CFG_DIR = '/etc'
+    USER_DIR = os.path.expanduser("~")
 
 _config_dir_system = os.path.join(CFG_DIR, 'avocado')
 _config_dir_system_extra = os.path.join(CFG_DIR, 'avocado', 'conf.d')
-_config_dir_local = os.path.join(os.path.expanduser("~"), '.config', 'avocado')
+_config_dir_local = os.path.join(USER_DIR, '.config', 'avocado')
 _source_tree_root = os.path.join(sys.modules[__name__].__file__, "..", "..", "..")
 _config_path_intree = os.path.join(os.path.abspath(_source_tree_root), 'etc', 'avocado')
 _config_path_intree_extra = os.path.join(_config_path_intree, 'conf.d')


### PR DESCRIPTION
This patch prevents the use of `~` for data and settings purposes to
avoid polluting of the main system while we are in python virtual
environment.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>