### PR TITLE
loader: Add support to discover individual python unittests and some style fixes

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -964,10 +964,7 @@ class ExternalLoader(TestLoader):
                        '"--external-runner-chdir=test".')
                 raise LoaderError(msg)
 
-            cls_external_runner = collections.namedtuple('ExternalLoader',
-                                                         ['runner', 'chdir',
-                                                          'test_dir'])
-            return cls_external_runner(runner, chdir, test_dir)
+            return test.ExternalRunnerSpec(runner, chdir, test_dir)
         elif chdir:
             msg = ('Option "--external-runner-chdir" requires '
                    '"--external-runner" to be set.')

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -803,15 +803,16 @@ class FileLoader(TestLoader):
 
         return methods_info
 
-    def _make_avocado_tests(self, test_path, make_broken, subtests_filter,
-                            test_name=None):
+    def _make_existing_file_tests(self, test_path, make_broken,
+                                  subtests_filter, test_name=None):
         if test_name is None:
             test_name = test_path
         try:
-            tests = self._find_avocado_tests(test_path)
-            if tests:
+            # Avocado tests
+            avocado_tests = self._find_avocado_tests(test_path)
+            if avocado_tests:
                 test_factories = []
-                for test_class, info in tests.items():
+                for test_class, info in avocado_tests.items():
                     if isinstance(test_class, str):
                         for test_method, tags in info:
                             name = test_name + \
@@ -883,8 +884,8 @@ class FileLoader(TestLoader):
                                    "readable")
             path_analyzer = path.PathInspector(test_path)
             if path_analyzer.is_python():
-                return self._make_avocado_tests(test_path, make_broken,
-                                                subtests_filter)
+                return self._make_existing_file_tests(test_path, make_broken,
+                                                      subtests_filter)
             else:
                 if os.access(test_path, os.X_OK):
                     return self._make_test(test.SimpleTest,
@@ -905,8 +906,9 @@ class FileLoader(TestLoader):
             # Try to resolve test ID (keep compatibility)
             test_path = os.path.join(data_dir.get_test_dir(), test_name)
             if os.path.exists(test_path):
-                return self._make_avocado_tests(test_path, make_broken,
-                                                subtests_filter, test_name)
+                return self._make_existing_file_tests(test_path, make_broken,
+                                                      subtests_filter,
+                                                      test_name)
             else:
                 if not subtests_filter and ':' in test_name:
                     test_name, subtests_filter = test_name.split(':', 1)
@@ -914,9 +916,10 @@ class FileLoader(TestLoader):
                                              test_name)
                     if os.path.exists(test_path):
                         subtests_filter = re.compile(subtests_filter)
-                        return self._make_avocado_tests(test_path, make_broken,
-                                                        subtests_filter,
-                                                        test_name)
+                        return self._make_existing_file_tests(test_path,
+                                                              make_broken,
+                                                              subtests_filter,
+                                                              test_name)
                 return make_broken(NotATest, test_name, "File not found "
                                    "('%s'; '%s')" % (test_name, test_path))
         return make_broken(NotATest, test_name, self.__not_test_str)

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -18,7 +18,6 @@ Test loader module.
 """
 
 import ast
-import collections
 import imp
 import inspect
 import os

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -908,6 +908,16 @@ class SimpleTest(Test):
         self._execute_cmd()
 
 
+class ExternalRunnerSpec(object):
+    """
+    Defines the basic options used by ExternalRunner
+    """
+    def __init__(self, runner, chdir=None, test_dir=None):
+        self.runner = runner
+        self.chdir = chdir
+        self.test_dir = test_dir
+
+
 class ExternalRunnerTest(SimpleTest):
 
     def __init__(self, name, params=None, base_logdir=None, job=None,

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -960,6 +960,18 @@ class ExternalRunnerTest(SimpleTest):
                 os.chdir(pre_cwd)
 
 
+class PythonUnittest(ExternalRunnerTest):
+    """
+    Python unittest test
+    """
+    def __init__(self, name, params=None, base_logdir=None, job=None,
+                 test_dir=None):
+        runner = "%s -m unittest -q -c" % sys.executable
+        external_runner = ExternalRunnerSpec(runner, "test", test_dir)
+        super(PythonUnittest, self).__init__(name, params, base_logdir, job,
+                                             external_runner=external_runner)
+
+
 class MockingTest(Test):
 
     """

--- a/selftests/checkall
+++ b/selftests/checkall
@@ -93,7 +93,7 @@ if [ "$AVOCADO_PARALLEL_CHECK" ]; then
 elif [ -z "$AVOCADO_SELF_CHECK" ]; then
     run_rc selftests selftests/run
 else
-    CMD='scripts/avocado run --job-results-dir=$(mktemp -d) `./contrib/scripts/avocado-find-unittests selftests/{unit,functional,doc}/*.py | xargs` --external-runner="/usr/bin/env python -m unittest"'
+    CMD='scripts/avocado run --job-results-dir=$(mktemp -d) selftests/{unit,functional,doc}'
     [ ! $SELF_CHECK_CONTINUOUS ] && CMD+=" --failfast on"
     run_rc selftests "$CMD"
 fi


### PR DESCRIPTION
This PR adds the support to execute individual python unittests directly without the need to use contrib script and external runner.

This first version makes python unittests a supported test type of the FileLoader, which means Avocado would execute them together with other Avocado tests and it also allows using absolute paths to run python unittests. The problem is it also discovers tests tagged like INSTRUMENTED-disabled as unittests even on recursive discovery (avocado run example/tests).

The last commit extracts the PyUNITTEST loader into standalone loader, which results in either INSTRUMENTED/SIMPLE tests or PyUNITTESTS are returned (on recursive discovery).

Another solution would be to explicitly skip PyUNITTEST discovery on tests discovered as INSTRUMENTED-disabled. Not sure which would be the best behavior, probably this one but I'd like to get your opinions before implementing it...