### PR TITLE
test: Log full path to the test source

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -262,6 +262,9 @@ class Test(unittest.TestCase):
                                              basename)
         self.__srcdir = utils_path.init_dir(self.workdir, 'src')
 
+        if self.filename:
+            self.log.debug("Test metadata:")
+            self.log.debug("  filename: %s", self.filename)
         unittest.TestCase.__init__(self, methodName=methodName)
 
     @property


### PR DESCRIPTION
Currently it might not be easy to determine what version of the test
source was executed (eg. when test-repo is used). Let's log the filename
entry which is the location of the source file of the test class.

In the future we or users should be able to extend the concept of test
metadata of other useful details like mentioned in

    https://trello.com/c/XvaiS4UV/1063-introduce-test-repo-concept-to-
    make-test-names-more-relevant

for example "test_tainted, test_version (sha), etc.

v1: https://github.com/avocado-framework/avocado/pull/2178

Changes:

```yaml
v2: Simplified to only log self.filename if available
```