### PR TITLE
utils/memory : use block string instead of block id

### DIFF
--- a/avocado/utils/memory.py
+++ b/avocado/utils/memory.py
@@ -41,17 +41,17 @@ def _check_memory_state(block):
     Check the given memory block is online or offline
 
     :param block: memory block id.
-    :type string: like 198
+    :type string: like memory198
     :return: 'True' if online or 'False' if offline
     :rtype: bool
     """
     def _is_online():
-        with open('/sys/devices/system/memory/memory%s/state' % block, 'r') as state_file:
+        with open('/sys/devices/system/memory/%s/state' % block, 'r') as state_file:
             if state_file.read() == 'online\n':
                 return True
             return False
 
-    return wait.wait_for(_is_online, timeout=120, step=1) or False
+    return wait.wait_for(_is_online, timeout=2, step=1) or False
 
 
 def check_hotplug():
@@ -71,11 +71,11 @@ def is_hot_pluggable(block):
     Check if the given memory block is hotpluggable
 
     :param block: memory block id.
-    :type string: like 198
+    :type string: like memory198
     :retrun: True if hotpluggable, else False
     :rtype: 'bool'
     """
-    with open('/sys/devices/system/memory/memory%s/removable' % block, 'r') as file_obj:
+    with open('/sys/devices/system/memory/%s/removable' % block, 'r') as file_obj:
         return bool(int(file_obj.read()))
 
 
@@ -84,13 +84,13 @@ def hotplug(block):
     Online the memory for the given block id.
 
     :param block: memory block id.
-    :type string: like 198
+    :type string: like memory198
     """
-    with open('/sys/devices/system/memory/memory%s/state' % block, 'w') as state_file:
+    with open('/sys/devices/system/memory/%s/state' % block, 'w') as state_file:
         state_file.write('online')
     if not _check_memory_state(block):
         raise MemoryError(
-            "unable to hot-plug memory%s block, not supported ?" % block)
+            "unable to hot-plug %s block, not supported ?" % block)
 
 
 def hotunplug(block):
@@ -98,13 +98,13 @@ def hotunplug(block):
     Offline the memory for the given block id.
 
     :param block: memory block id.
-    :type string: like 198
+    :type string: like memory198
     """
-    with open('/sys/devices/system/memory/memory%s/state' % block, 'w') as state_file:
+    with open('/sys/devices/system/memory/%s/state' % block, 'w') as state_file:
         state_file.write('offline')
     if _check_memory_state(block):
         raise MemoryError(
-            "unable to hot-unplug memory%s block. Device busy?" % block)
+            "unable to hot-unplug %s block. Device busy?" % block)
 
 
 def read_from_meminfo(key):
@@ -141,7 +141,7 @@ def memtotal_sys():
     block_size = int(open(os.path.join(sys_mempath,
                                        'block_size_bytes'),
                           "r").read().strip(), 16)
-    return (no_memblocks * block_size)/1024.0
+    return (no_memblocks * block_size) / 1024.0
 
 
 def freememtotal():
@@ -419,9 +419,11 @@ def get_thp_value(feature):
 
 
 class _MemInfoItem(object):
+
     """
     Representation of one item from /proc/meminfo
     """
+
     def __init__(self, name):
         self.name = name
         self.__multipliers = {'b': 1,  # 2**0
@@ -453,6 +455,7 @@ class _MemInfoItem(object):
 
 
 class MemInfo(object):
+
     """
     Representation of /proc/meminfo
     """


### PR DESCRIPTION
It is easier for the user to pass full string of block id
like 'memory234' instead of just '234', it saves few steps of the
user to find the memory blocks and call this functions to hotplug/unplug

fix: in _check_memory_state() no try for 120 times to check for state. So
2 retries is enough for the state to change from 'going-online' to 'online'

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>