### PR TITLE
loader: Add support to discover individual python unittests and some style fixes [v2]

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -18,7 +18,6 @@ Test loader module.
 """
 
 import ast
-import collections
 import imp
 import inspect
 import os
@@ -964,10 +963,7 @@ class ExternalLoader(TestLoader):
                        '"--external-runner-chdir=test".')
                 raise LoaderError(msg)
 
-            cls_external_runner = collections.namedtuple('ExternalLoader',
-                                                         ['runner', 'chdir',
-                                                          'test_dir'])
-            return cls_external_runner(runner, chdir, test_dir)
+            return test.ExternalRunnerSpec(runner, chdir, test_dir)
         elif chdir:
             msg = ('Option "--external-runner-chdir" requires '
                    '"--external-runner" to be set.')

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -803,15 +803,16 @@ class FileLoader(TestLoader):
 
         return methods_info
 
-    def _make_avocado_tests(self, test_path, make_broken, subtests_filter,
-                            test_name=None):
+    def _make_existing_file_tests(self, test_path, make_broken,
+                                  subtests_filter, test_name=None):
         if test_name is None:
             test_name = test_path
         try:
-            tests = self._find_avocado_tests(test_path)
-            if tests:
+            # Avocado tests
+            avocado_tests = self._find_avocado_tests(test_path)
+            if avocado_tests:
                 test_factories = []
-                for test_class, info in tests.items():
+                for test_class, info in avocado_tests.items():
                     if isinstance(test_class, str):
                         for test_method, tags in info:
                             name = test_name + \
@@ -883,8 +884,8 @@ class FileLoader(TestLoader):
                                    "readable")
             path_analyzer = path.PathInspector(test_path)
             if path_analyzer.is_python():
-                return self._make_avocado_tests(test_path, make_broken,
-                                                subtests_filter)
+                return self._make_existing_file_tests(test_path, make_broken,
+                                                      subtests_filter)
             else:
                 if os.access(test_path, os.X_OK):
                     return self._make_test(test.SimpleTest,
@@ -905,8 +906,9 @@ class FileLoader(TestLoader):
             # Try to resolve test ID (keep compatibility)
             test_path = os.path.join(data_dir.get_test_dir(), test_name)
             if os.path.exists(test_path):
-                return self._make_avocado_tests(test_path, make_broken,
-                                                subtests_filter, test_name)
+                return self._make_existing_file_tests(test_path, make_broken,
+                                                      subtests_filter,
+                                                      test_name)
             else:
                 if not subtests_filter and ':' in test_name:
                     test_name, subtests_filter = test_name.split(':', 1)
@@ -914,9 +916,10 @@ class FileLoader(TestLoader):
                                              test_name)
                     if os.path.exists(test_path):
                         subtests_filter = re.compile(subtests_filter)
-                        return self._make_avocado_tests(test_path, make_broken,
-                                                        subtests_filter,
-                                                        test_name)
+                        return self._make_existing_file_tests(test_path,
+                                                              make_broken,
+                                                              subtests_filter,
+                                                              test_name)
                 return make_broken(NotATest, test_name, "File not found "
                                    "('%s'; '%s')" % (test_name, test_path))
         return make_broken(NotATest, test_name, self.__not_test_str)

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -973,6 +973,18 @@ class ExternalRunnerTest(SimpleTest):
                 os.chdir(pre_cwd)
 
 
+class PythonUnittest(ExternalRunnerTest):
+    """
+    Python unittest test
+    """
+    def __init__(self, name, params=None, base_logdir=None, job=None,
+                 test_dir=None):
+        runner = "%s -m unittest -q -c" % sys.executable
+        external_runner = ExternalRunnerSpec(runner, "test", test_dir)
+        super(PythonUnittest, self).__init__(name, params, base_logdir, job,
+                                             external_runner=external_runner)
+
+
 class MockingTest(Test):
 
     """

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -921,6 +921,16 @@ class SimpleTest(Test):
         self._execute_cmd()
 
 
+class ExternalRunnerSpec(object):
+    """
+    Defines the basic options used by ExternalRunner
+    """
+    def __init__(self, runner, chdir=None, test_dir=None):
+        self.runner = runner
+        self.chdir = chdir
+        self.test_dir = test_dir
+
+
 class ExternalRunnerTest(SimpleTest):
 
     def __init__(self, name, params=None, base_logdir=None, job=None,

--- a/selftests/checkall
+++ b/selftests/checkall
@@ -93,7 +93,7 @@ if [ "$AVOCADO_PARALLEL_CHECK" ]; then
 elif [ -z "$AVOCADO_SELF_CHECK" ]; then
     run_rc selftests selftests/run
 else
-    CMD='scripts/avocado run --job-results-dir=$(mktemp -d) `./contrib/scripts/avocado-find-unittests selftests/{unit,functional,doc}/*.py | xargs` --external-runner="/usr/bin/env python -m unittest"'
+    CMD='scripts/avocado run --job-results-dir=$(mktemp -d) selftests/{unit,functional,doc}'
     [ ! $SELF_CHECK_CONTINUOUS ] && CMD+=" --failfast on"
     run_rc selftests "$CMD"
 fi

--- a/selftests/functional/test_loader.py
+++ b/selftests/functional/test_loader.py
@@ -108,6 +108,9 @@ from avocado import main
 from test2 import *
 
 class BasicTestSuite(SuperTest):
+    '''
+    :avocado: disable
+    '''
 
     def test1(self):
         self.xxx()

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -8,6 +8,7 @@ import unittest
 
 from avocado.core import test
 from avocado.core import loader
+from avocado.core import test
 from avocado.utils import script
 
 # We need to access protected members pylint: disable=W0212
@@ -235,6 +236,14 @@ class ThirdChild(Test, SecondChild):
     :avocado: recursive
     '''
     def test_third_child(self):
+        pass
+"""
+
+PYTHON_UNITTEST = """#!/usr/bin/env python
+from unittest import TestCase
+
+class SampleTest(TestCase):
+    def test(self):
         pass
 """
 
@@ -513,7 +522,7 @@ class LoaderTest(unittest.TestCase):
             KEEP_METHODS_ORDER)
         avocado_keep_methods_order.save()
         expected_order = ['test2', 'testA', 'test1', 'testZZZ', 'test']
-        tests = self.loader._find_avocado_tests(avocado_keep_methods_order.path)
+        tests = self.loader._find_avocado_tests(avocado_keep_methods_order.path)[0]
         methods = [method[0] for method in tests['MyClass']]
         self.assertEqual(expected_order, methods)
         avocado_keep_methods_order.remove()
@@ -529,12 +538,28 @@ class LoaderTest(unittest.TestCase):
         avocado_recursive_discovery_test2.save()
 
         sys.path.append(os.path.dirname(avocado_recursive_discovery_test1.path))
-        tests = self.loader._find_avocado_tests(avocado_recursive_discovery_test2.path)
+        tests = self.loader._find_avocado_tests(avocado_recursive_discovery_test2.path)[0]
         expected = {'ThirdChild': [('test_third_child', set([])),
                                    ('test_second_child', set([])),
                                    ('test_first_child', set([])),
                                    ('test_basic', set([]))]}
         self.assertEqual(expected, tests)
+
+    def test_python_unittest(self):
+        disabled_test = script.TemporaryScript("disabled.py",
+                                               AVOCADO_TEST_OK_DISABLED,
+                                               mode=0o644)
+        python_unittest = script.TemporaryScript("python_unittest.py",
+                                                 PYTHON_UNITTEST)
+        disabled_test.save()
+        python_unittest.save()
+        tests = self.loader.discover(disabled_test.path)
+        self.assertEqual(tests, [])
+        tests = self.loader.discover(python_unittest.path)
+        exp = [(test.PythonUnittest,
+                {"name": "python_unittest.SampleTest.test",
+                 "test_dir": os.path.dirname(python_unittest.path)})]
+        self.assertEqual(tests, exp)
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir)


### PR DESCRIPTION
This PR adds support to discover python unittests as individual tests, which was previously supported only as contrib script + external runner.

As Avocado tests are in fact python unittests, disabled Avocado tests are excluded from the results to avoid confusion. Also to support running tests from parent locations, each unittest is executed from it's __file__ directory (eg. running `/tmp/foo.py => cd /tmp && python -m unittest foo.$class.$test`, instead of `..........tmp.foo.$class.$test` which would not work).

v1: https://github.com/avocado-framework/avocado/pull/2182

changes:
```yaml
v2: Instead of working-around the Avocado disabled tests detect them and skip them
    directly in the loader.
v2: Rebased, added selftest
```