### PR TITLE
loader: Add support to discover individual python unittests and some style fixes [v3]

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -42,6 +42,10 @@ AVAILABLE = None
 ALL = True
 
 
+# Regexp to find python unittests
+_RE_UNIT_TEST = re.compile(r'test.*')
+
+
 class MissingTest(object):
     """
     Class representing reference which failed to be discovered
@@ -510,7 +514,8 @@ class FileLoader(TestLoader):
                 MissingTest: 'MISSING',
                 BrokenSymlink: 'BROKEN_SYMLINK',
                 AccessDeniedPath: 'ACCESS_DENIED',
-                test.Test: 'INSTRUMENTED'}
+                test.Test: 'INSTRUMENTED',
+                test.PythonUnittest: 'PyUNITTEST'}
 
     @staticmethod
     def get_decorator_mapping():
@@ -519,7 +524,8 @@ class FileLoader(TestLoader):
                 MissingTest: output.TERM_SUPPORT.fail_header_str,
                 BrokenSymlink: output.TERM_SUPPORT.fail_header_str,
                 AccessDeniedPath: output.TERM_SUPPORT.fail_header_str,
-                test.Test: output.TERM_SUPPORT.healthy_str}
+                test.Test: output.TERM_SUPPORT.healthy_str,
+                test.PythonUnittest: output.TERM_SUPPORT.healthy_str}
 
     def discover(self, reference, which_tests=DEFAULT):
         """
@@ -619,9 +625,11 @@ class FileLoader(TestLoader):
         :type path: str
         :param class_name: the specific class to be found
         :type path: str
-        :returns: dict with class name and additional info such as method names
-                  and tags
-        :rtype: dict
+        :returns: tuple where first item is dict with class name and additional
+                  info such as method names and tags; the second item is
+                  set of class names which look like avocado tests but are
+                  force-disabled.
+        :rtype: tuple
         """
         # If only the Test class was imported from the avocado namespace
         test_import = False
@@ -633,6 +641,7 @@ class FileLoader(TestLoader):
         mod_import_name = None
         # The resulting test classes
         result = {}
+        disabled = set()
 
         if os.path.isdir(path):
             path = os.path.join(path, "__init__.py")
@@ -678,6 +687,7 @@ class FileLoader(TestLoader):
                 has_disable = safeloader.check_docstring_directive(docstring,
                                                                    'disable')
                 if (has_disable and class_name is None):
+                    disabled.add(statement.name)
                     continue
 
                 cl_tags = safeloader.get_docstring_directives_tags(docstring)
@@ -708,12 +718,12 @@ class FileLoader(TestLoader):
                         # Looking for a 'class FooTest(Parent)'
                         else:
                             parent_class = parent.id
-
-                        res = self._find_avocado_tests(path, parent_class)
+                        res, dis = self._find_avocado_tests(path, parent_class)
                         if res:
                             parents.remove(parent)
                             for cls in res:
                                 info.extend(res[cls])
+                        disabled.update(dis)
 
                     # If there are parents left to be discovered, they
                     # might be in a different module.
@@ -755,11 +765,12 @@ class FileLoader(TestLoader):
                                         parent_module = node.module
                                     _, ppath, _ = imp.find_module(parent_module,
                                                                   modules_paths)
-                                    res = self._find_avocado_tests(ppath,
-                                                                   parent_class)
+                                    res, dis = self._find_avocado_tests(ppath,
+                                                                        parent_class)
                                     if res:
                                         for cls in res:
                                             info.extend(res[cls])
+                                    disabled.update(dis)
 
                     continue
 
@@ -784,7 +795,7 @@ class FileLoader(TestLoader):
                             result[statement.name] = info
                             continue
 
-        return result
+        return result, disabled
 
     @staticmethod
     def _get_methods_info(statement_body, class_tags):
@@ -802,13 +813,32 @@ class FileLoader(TestLoader):
 
         return methods_info
 
+    def _find_python_unittests(self, test_path, disabled, subtests_filter):
+        result = []
+        class_methods = safeloader.find_class_and_methods(test_path,
+                                                          _RE_UNIT_TEST)
+        for klass, methods in class_methods.iteritems():
+            if klass in disabled:
+                continue
+            if test_path.endswith(".py"):
+                test_path = test_path[:-3]
+            test_module_name = os.path.relpath(test_path)
+            test_module_name = test_module_name.replace(os.path.sep, ".")
+            candidates = ["%s.%s.%s" % (test_module_name, klass, method)
+                          for method in methods]
+            if subtests_filter:
+                result += [_ for _ in candidates if subtests_filter.search(_)]
+            else:
+                result += candidates
+        return result
+
     def _make_existing_file_tests(self, test_path, make_broken,
                                   subtests_filter, test_name=None):
         if test_name is None:
             test_name = test_path
         try:
             # Avocado tests
-            avocado_tests = self._find_avocado_tests(test_path)
+            avocado_tests, disabled = self._find_avocado_tests(test_path)
             if avocado_tests:
                 test_factories = []
                 for test_class, info in avocado_tests.items():
@@ -825,6 +855,21 @@ class FileLoader(TestLoader):
                                                 'tags': tags})
                             test_factories.append(tst)
                 return test_factories
+            # Python unittests
+            old_dir = os.getcwd()
+            try:
+                py_test_dir = os.path.abspath(os.path.dirname(test_path))
+                py_test_name = os.path.basename(test_path)
+                os.chdir(py_test_dir)
+                python_unittests = self._find_python_unittests(py_test_name,
+                                                               disabled,
+                                                               subtests_filter)
+            finally:
+                os.chdir(old_dir)
+            if python_unittests:
+                return [(test.PythonUnittest, {"name": name,
+                                               "test_dir": py_test_dir})
+                        for name in python_unittests]
             else:
                 if os.access(test_path, os.X_OK):
                     # Module does not have an avocado test class inside but

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -18,7 +18,6 @@ Test loader module.
 """
 
 import ast
-import collections
 import imp
 import inspect
 import os
@@ -964,10 +963,7 @@ class ExternalLoader(TestLoader):
                        '"--external-runner-chdir=test".')
                 raise LoaderError(msg)
 
-            cls_external_runner = collections.namedtuple('ExternalLoader',
-                                                         ['runner', 'chdir',
-                                                          'test_dir'])
-            return cls_external_runner(runner, chdir, test_dir)
+            return test.ExternalRunnerSpec(runner, chdir, test_dir)
         elif chdir:
             msg = ('Option "--external-runner-chdir" requires '
                    '"--external-runner" to be set.')

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -803,15 +803,16 @@ class FileLoader(TestLoader):
 
         return methods_info
 
-    def _make_avocado_tests(self, test_path, make_broken, subtests_filter,
-                            test_name=None):
+    def _make_existing_file_tests(self, test_path, make_broken,
+                                  subtests_filter, test_name=None):
         if test_name is None:
             test_name = test_path
         try:
-            tests = self._find_avocado_tests(test_path)
-            if tests:
+            # Avocado tests
+            avocado_tests = self._find_avocado_tests(test_path)
+            if avocado_tests:
                 test_factories = []
-                for test_class, info in tests.items():
+                for test_class, info in avocado_tests.items():
                     if isinstance(test_class, str):
                         for test_method, tags in info:
                             name = test_name + \
@@ -883,8 +884,8 @@ class FileLoader(TestLoader):
                                    "readable")
             path_analyzer = path.PathInspector(test_path)
             if path_analyzer.is_python():
-                return self._make_avocado_tests(test_path, make_broken,
-                                                subtests_filter)
+                return self._make_existing_file_tests(test_path, make_broken,
+                                                      subtests_filter)
             else:
                 if os.access(test_path, os.X_OK):
                     return self._make_test(test.SimpleTest,
@@ -905,8 +906,9 @@ class FileLoader(TestLoader):
             # Try to resolve test ID (keep compatibility)
             test_path = os.path.join(data_dir.get_test_dir(), test_name)
             if os.path.exists(test_path):
-                return self._make_avocado_tests(test_path, make_broken,
-                                                subtests_filter, test_name)
+                return self._make_existing_file_tests(test_path, make_broken,
+                                                      subtests_filter,
+                                                      test_name)
             else:
                 if not subtests_filter and ':' in test_name:
                     test_name, subtests_filter = test_name.split(':', 1)
@@ -914,9 +916,10 @@ class FileLoader(TestLoader):
                                              test_name)
                     if os.path.exists(test_path):
                         subtests_filter = re.compile(subtests_filter)
-                        return self._make_avocado_tests(test_path, make_broken,
-                                                        subtests_filter,
-                                                        test_name)
+                        return self._make_existing_file_tests(test_path,
+                                                              make_broken,
+                                                              subtests_filter,
+                                                              test_name)
                 return make_broken(NotATest, test_name, "File not found "
                                    "('%s'; '%s')" % (test_name, test_path))
         return make_broken(NotATest, test_name, self.__not_test_str)

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -973,6 +973,18 @@ class ExternalRunnerTest(SimpleTest):
                 os.chdir(pre_cwd)
 
 
+class PythonUnittest(ExternalRunnerTest):
+    """
+    Python unittest test
+    """
+    def __init__(self, name, params=None, base_logdir=None, job=None,
+                 test_dir=None):
+        runner = "%s -m unittest -q -c" % sys.executable
+        external_runner = ExternalRunnerSpec(runner, "test", test_dir)
+        super(PythonUnittest, self).__init__(name, params, base_logdir, job,
+                                             external_runner=external_runner)
+
+
 class MockingTest(Test):
 
     """

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -921,6 +921,16 @@ class SimpleTest(Test):
         self._execute_cmd()
 
 
+class ExternalRunnerSpec(object):
+    """
+    Defines the basic options used by ExternalRunner
+    """
+    def __init__(self, runner, chdir=None, test_dir=None):
+        self.runner = runner
+        self.chdir = chdir
+        self.test_dir = test_dir
+
+
 class ExternalRunnerTest(SimpleTest):
 
     def __init__(self, name, params=None, base_logdir=None, job=None,

--- a/selftests/checkall
+++ b/selftests/checkall
@@ -93,7 +93,7 @@ if [ "$AVOCADO_PARALLEL_CHECK" ]; then
 elif [ -z "$AVOCADO_SELF_CHECK" ]; then
     run_rc selftests selftests/run
 else
-    CMD='scripts/avocado run --job-results-dir=$(mktemp -d) `./contrib/scripts/avocado-find-unittests selftests/{unit,functional,doc}/*.py | xargs` --external-runner="/usr/bin/env python -m unittest"'
+    CMD='scripts/avocado run --job-results-dir=$(mktemp -d) selftests/{unit,functional,doc}'
     [ ! $SELF_CHECK_CONTINUOUS ] && CMD+=" --failfast on"
     run_rc selftests "$CMD"
 fi

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -138,6 +138,7 @@ class RunnerOperationTest(unittest.TestCase):
 
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        os.chdir(basedir)
 
     def test_show_version(self):
         result = process.run('%s -v' % AVOCADO, ignore_status=True)
@@ -168,7 +169,6 @@ class RunnerOperationTest(unittest.TestCase):
         os.write(fd, config)
         os.close(fd)
 
-        os.chdir(basedir)
         cmd = '%s --config %s config --datadir' % (AVOCADO, config_file)
         result = process.run(cmd)
         output = result.stdout
@@ -181,7 +181,6 @@ class RunnerOperationTest(unittest.TestCase):
         self.assertIn('    logs     ' + mapping['logs_dir'], result.stdout)
 
     def test_runner_all_ok(self):
-        os.chdir(basedir)
         cmd_line = ('%s run --sysinfo=off --job-results-dir %s '
                     'passtest.py passtest.py' % (AVOCADO, self.tmpdir))
         process.run(cmd_line)
@@ -192,7 +191,6 @@ class RunnerOperationTest(unittest.TestCase):
                       "does not contains [\"/run/*\"]\n%s" % variants)
 
     def test_runner_failfast(self):
-        os.chdir(basedir)
         cmd_line = ('%s run --sysinfo=off --job-results-dir %s '
                     'passtest.py failtest.py passtest.py --failfast on'
                     % (AVOCADO, self.tmpdir))
@@ -204,7 +202,6 @@ class RunnerOperationTest(unittest.TestCase):
                          "Avocado did not return rc %d:\n%s" % (expected_rc, result))
 
     def test_runner_ignore_missing_references_one_missing(self):
-        os.chdir(basedir)
         cmd_line = ('%s run --sysinfo=off --job-results-dir %s '
                     'passtest.py badtest.py --ignore-missing-references on'
                     % (AVOCADO, self.tmpdir))
@@ -216,7 +213,6 @@ class RunnerOperationTest(unittest.TestCase):
                          "Avocado did not return rc %d:\n%s" % (expected_rc, result))
 
     def test_runner_ignore_missing_references_all_missing(self):
-        os.chdir(basedir)
         cmd_line = ('%s run --sysinfo=off --job-results-dir %s '
                     'badtest.py badtest2.py --ignore-missing-references on'
                     % (AVOCADO, self.tmpdir))
@@ -231,14 +227,12 @@ class RunnerOperationTest(unittest.TestCase):
     @unittest.skipIf(not CC_BINARY,
                      "C compiler is required by the underlying datadir.py test")
     def test_datadir_alias(self):
-        os.chdir(basedir)
         cmd_line = ('%s run --sysinfo=off --job-results-dir %s '
                     'datadir.py' % (AVOCADO, self.tmpdir))
         process.run(cmd_line)
 
     def test_shell_alias(self):
         """ Tests that .sh files are also executable via alias """
-        os.chdir(basedir)
         cmd_line = ('%s run --sysinfo=off --job-results-dir %s '
                     'env_variables.sh' % (AVOCADO, self.tmpdir))
         process.run(cmd_line)
@@ -246,13 +240,11 @@ class RunnerOperationTest(unittest.TestCase):
     @unittest.skipIf(not CC_BINARY,
                      "C compiler is required by the underlying datadir.py test")
     def test_datadir_noalias(self):
-        os.chdir(basedir)
         cmd_line = ('%s run --sysinfo=off --job-results-dir %s examples/tests/datadir.py '
                     'examples/tests/datadir.py' % (AVOCADO, self.tmpdir))
         process.run(cmd_line)
 
     def test_runner_noalias(self):
-        os.chdir(basedir)
         cmd_line = ("%s run --sysinfo=off --job-results-dir %s examples/tests/passtest.py "
                     "examples/tests/passtest.py" % (AVOCADO, self.tmpdir))
         process.run(cmd_line)
@@ -266,14 +258,12 @@ class RunnerOperationTest(unittest.TestCase):
         mytest = script.Script(
             os.path.join(os.path.dirname(mylib.path), 'test_local_imports.py'),
             LOCAL_IMPORT_TEST_CONTENTS)
-        os.chdir(basedir)
         mytest.save()
         cmd_line = ("%s run --sysinfo=off --job-results-dir %s "
                     "%s" % (AVOCADO, self.tmpdir, mytest))
         process.run(cmd_line)
 
     def test_unsupported_status(self):
-        os.chdir(basedir)
         with script.TemporaryScript("fake_status.py",
                                     UNSUPPORTED_STATUS_TEST_CONTENTS,
                                     "avocado_unsupported_status") as tst:
@@ -293,7 +283,6 @@ class RunnerOperationTest(unittest.TestCase):
                      "resource intensive or time sensitve")
     def test_hanged_test_with_status(self):
         """ Check that avocado handles hanged tests properly """
-        os.chdir(basedir)
         with script.TemporaryScript("report_status_and_hang.py",
                                     REPORTS_STATUS_AND_HANG,
                                     "hanged_test_with_status") as tst:
@@ -316,7 +305,6 @@ class RunnerOperationTest(unittest.TestCase):
                             "interrupted. Results:\n%s" % res)
 
     def test_no_status_reported(self):
-        os.chdir(basedir)
         with script.TemporaryScript("die_without_reporting_status.py",
                                     DIE_WITHOUT_REPORTING_STATUS,
                                     "no_status_reported") as tst:
@@ -332,7 +320,6 @@ class RunnerOperationTest(unittest.TestCase):
                           results["tests"][0]["fail_reason"])
 
     def test_runner_tests_fail(self):
-        os.chdir(basedir)
         cmd_line = ('%s run --sysinfo=off --job-results-dir %s passtest.py '
                     'failtest.py passtest.py' % (AVOCADO, self.tmpdir))
         result = process.run(cmd_line, ignore_status=True)
@@ -341,7 +328,6 @@ class RunnerOperationTest(unittest.TestCase):
                          "Avocado did not return rc %d:\n%s" % (expected_rc, result))
 
     def test_runner_nonexistent_test(self):
-        os.chdir(basedir)
         cmd_line = ('%s run --sysinfo=off --job-results-dir '
                     '%s bogustest' % (AVOCADO, self.tmpdir))
         result = process.run(cmd_line, ignore_status=True)
@@ -353,7 +339,6 @@ class RunnerOperationTest(unittest.TestCase):
                          "Avocado did not return rc %d:\n%s" % (expected_rc, result))
 
     def test_runner_doublefail(self):
-        os.chdir(basedir)
         cmd_line = ('%s run --sysinfo=off --job-results-dir %s '
                     '--xunit - doublefail.py' % (AVOCADO, self.tmpdir))
         result = process.run(cmd_line, ignore_status=True)
@@ -371,7 +356,6 @@ class RunnerOperationTest(unittest.TestCase):
                       "Test did not fail with action exception:\n%s" % output)
 
     def test_uncaught_exception(self):
-        os.chdir(basedir)
         cmd_line = ("%s run --sysinfo=off --job-results-dir %s "
                     "--json - uncaught_exception.py" % (AVOCADO, self.tmpdir))
         result = process.run(cmd_line, ignore_status=True)
@@ -382,7 +366,6 @@ class RunnerOperationTest(unittest.TestCase):
         self.assertIn('"status": "ERROR"', result.stdout)
 
     def test_fail_on_exception(self):
-        os.chdir(basedir)
         cmd_line = ("%s run --sysinfo=off --job-results-dir %s "
                     "--json - fail_on_exception.py" % (AVOCADO, self.tmpdir))
         result = process.run(cmd_line, ignore_status=True)
@@ -393,7 +376,6 @@ class RunnerOperationTest(unittest.TestCase):
         self.assertIn('"status": "FAIL"', result.stdout)
 
     def test_exception_not_in_path(self):
-        os.chdir(basedir)
         os.mkdir(os.path.join(self.tmpdir, "shared_lib"))
         mylib = script.Script(os.path.join(self.tmpdir, "shared_lib",
                                            "mylib.py"),
@@ -413,7 +395,6 @@ class RunnerOperationTest(unittest.TestCase):
         self.assertNotIn("Failed to read queue", result.stdout)
 
     def test_runner_timeout(self):
-        os.chdir(basedir)
         cmd_line = ('%s run --sysinfo=off --job-results-dir %s '
                     '--xunit - timeouttest.py' % (AVOCADO, self.tmpdir))
         result = process.run(cmd_line, ignore_status=True)
@@ -433,7 +414,6 @@ class RunnerOperationTest(unittest.TestCase):
                      "Skipping test that take a long time to run, are "
                      "resource intensive or time sensitve")
     def test_runner_abort(self):
-        os.chdir(basedir)
         cmd_line = ('%s run --sysinfo=off --job-results-dir %s '
                     '--xunit - abort.py' % (AVOCADO, self.tmpdir))
         result = process.run(cmd_line, ignore_status=True)
@@ -448,7 +428,6 @@ class RunnerOperationTest(unittest.TestCase):
         self.assertIn(excerpt, output)
 
     def test_silent_output(self):
-        os.chdir(basedir)
         cmd_line = ('%s --silent run --sysinfo=off --job-results-dir %s '
                     'passtest.py' % (AVOCADO, self.tmpdir))
         result = process.run(cmd_line, ignore_status=True)
@@ -458,7 +437,6 @@ class RunnerOperationTest(unittest.TestCase):
         self.assertEqual(result.stdout, expected_output)
 
     def test_empty_args_list(self):
-        os.chdir(basedir)
         cmd_line = AVOCADO
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_FAIL
@@ -467,7 +445,6 @@ class RunnerOperationTest(unittest.TestCase):
         self.assertIn(expected_output, result.stderr)
 
     def test_empty_test_list(self):
-        os.chdir(basedir)
         cmd_line = '%s run --sysinfo=off --job-results-dir %s' % (AVOCADO,
                                                                   self.tmpdir)
         result = process.run(cmd_line, ignore_status=True)
@@ -478,7 +455,6 @@ class RunnerOperationTest(unittest.TestCase):
         self.assertIn(expected_output, result.stderr)
 
     def test_not_found(self):
-        os.chdir(basedir)
         cmd_line = ('%s run --sysinfo=off --job-results-dir %s sbrubles'
                     % (AVOCADO, self.tmpdir))
         result = process.run(cmd_line, ignore_status=True)
@@ -517,7 +493,6 @@ class RunnerOperationTest(unittest.TestCase):
         """
         Tests that the `latest` link to the latest job results is created early
         """
-        os.chdir(basedir)
         cmd_line = ('%s run --sysinfo=off --job-results-dir %s '
                     'examples/tests/passtest.py' % (AVOCADO, self.tmpdir))
         avocado_process = process.SubProcess(cmd_line)
@@ -532,7 +507,6 @@ class RunnerOperationTest(unittest.TestCase):
         self.assertTrue(os.path.islink(link))
 
     def test_dry_run(self):
-        os.chdir(basedir)
         cmd = ("%s run --sysinfo=off passtest.py failtest.py "
                "gendata.py --json - --mux-inject foo:1 bar:2 baz:3 foo:foo:a"
                " foo:bar:b foo:baz:c bar:bar:bar --dry-run" % AVOCADO)
@@ -557,7 +531,6 @@ class RunnerOperationTest(unittest.TestCase):
             self.assertEqual(log.count(line), 4)
 
     def test_invalid_python(self):
-        os.chdir(basedir)
         test = script.make_script(os.path.join(self.tmpdir, 'test.py'),
                                   INVALID_PYTHON_TEST)
         cmd_line = ('%s --show test run --sysinfo=off '
@@ -575,7 +548,6 @@ class RunnerOperationTest(unittest.TestCase):
                      "Skipping test that take a long time to run, are "
                      "resource intensive or time sensitve")
     def test_read(self):
-        os.chdir(basedir)
         cmd = "%s run --sysinfo=off --job-results-dir %%s %%s" % AVOCADO
         cmd %= (self.tmpdir, READ_BINARY)
         result = process.run(cmd, timeout=10, ignore_status=True)
@@ -592,9 +564,9 @@ class RunnerHumanOutputTest(unittest.TestCase):
 
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        os.chdir(basedir)
 
     def test_output_pass(self):
-        os.chdir(basedir)
         cmd_line = ('%s run --sysinfo=off --job-results-dir %s '
                     'passtest.py' % (AVOCADO, self.tmpdir))
         result = process.run(cmd_line, ignore_status=True)
@@ -605,7 +577,6 @@ class RunnerHumanOutputTest(unittest.TestCase):
         self.assertIn('passtest.py:PassTest.test:  PASS', result.stdout)
 
     def test_output_fail(self):
-        os.chdir(basedir)
         cmd_line = ('%s run --sysinfo=off --job-results-dir %s '
                     'failtest.py' % (AVOCADO, self.tmpdir))
         result = process.run(cmd_line, ignore_status=True)
@@ -616,7 +587,6 @@ class RunnerHumanOutputTest(unittest.TestCase):
         self.assertIn('failtest.py:FailTest.test:  FAIL', result.stdout)
 
     def test_output_error(self):
-        os.chdir(basedir)
         cmd_line = ('%s run --sysinfo=off --job-results-dir %s '
                     'errortest.py' % (AVOCADO, self.tmpdir))
         result = process.run(cmd_line, ignore_status=True)
@@ -627,7 +597,6 @@ class RunnerHumanOutputTest(unittest.TestCase):
         self.assertIn('errortest.py:ErrorTest.test:  ERROR', result.stdout)
 
     def test_output_cancel(self):
-        os.chdir(basedir)
         cmd_line = ('%s run --sysinfo=off --job-results-dir %s '
                     'cancelonsetup.py' % (AVOCADO, self.tmpdir))
         result = process.run(cmd_line, ignore_status=True)
@@ -641,7 +610,6 @@ class RunnerHumanOutputTest(unittest.TestCase):
     @unittest.skipIf(not GNU_ECHO_BINARY,
                      'GNU style echo binary not available')
     def test_ugly_echo_cmd(self):
-        os.chdir(basedir)
         cmd_line = ('%s run --external-runner "%s -ne" '
                     '"foo\\\\\\n\\\'\\\\\\"\\\\\\nbar/baz" --job-results-dir %s'
                     ' --sysinfo=off  --show-job-log' %
@@ -693,9 +661,9 @@ class RunnerSimpleTest(unittest.TestCase):
                                                   'avocado_simpletest_'
                                                   'functional')
         self.fail_script.save()
+        os.chdir(basedir)
 
     def test_simpletest_pass(self):
-        os.chdir(basedir)
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off'
                     ' "%s"' % (AVOCADO, self.tmpdir, self.pass_script.path))
         result = process.run(cmd_line, ignore_status=True)
@@ -705,7 +673,6 @@ class RunnerSimpleTest(unittest.TestCase):
                          (expected_rc, result))
 
     def test_simpletest_fail(self):
-        os.chdir(basedir)
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off'
                     ' %s' % (AVOCADO, self.tmpdir, self.fail_script.path))
         result = process.run(cmd_line, ignore_status=True)
@@ -725,7 +692,6 @@ class RunnerSimpleTest(unittest.TestCase):
         Notice: on a current machine this takes about 0.12s, so 30 seconds is
         considered to be pretty safe here.
         """
-        os.chdir(basedir)
         one_hundred = 'failtest.py ' * 100
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off %s'
                     % (AVOCADO, self.tmpdir, one_hundred))
@@ -745,7 +711,6 @@ class RunnerSimpleTest(unittest.TestCase):
         Sleeptest is supposed to take 1 second, let's make a sandwich of
         100 failtests and check the test runner timing.
         """
-        os.chdir(basedir)
         sleep_fail_sleep = ('sleeptest.py ' + 'failtest.py ' * 100 +
                             'sleeptest.py')
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off %s'
@@ -762,7 +727,6 @@ class RunnerSimpleTest(unittest.TestCase):
         """
         simplewarning.sh uses the avocado-bash-utils
         """
-        os.chdir(basedir)
         # simplewarning.sh calls "avocado" without specifying a path
         os.environ['PATH'] += ":" + os.path.join(basedir, 'scripts')
         # simplewarning.sh calls "avocado exec-path" which hasn't
@@ -786,8 +750,8 @@ class RunnerSimpleTest(unittest.TestCase):
     def test_non_absolute_path(self):
         avocado_path = os.path.join(basedir, 'scripts', 'avocado')
         test_base_dir = os.path.dirname(self.pass_script.path)
-        test_file_name = os.path.basename(self.pass_script.path)
         os.chdir(test_base_dir)
+        test_file_name = os.path.basename(self.pass_script.path)
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off'
                     ' "%s"' % (avocado_path, self.tmpdir, test_file_name))
         result = process.run(cmd_line, ignore_status=True)
@@ -862,9 +826,9 @@ class ExternalRunnerTest(unittest.TestCase):
             "exit 1",
             'avocado_externalrunner_functional')
         self.fail_script.save()
+        os.chdir(basedir)
 
     def test_externalrunner_pass(self):
-        os.chdir(basedir)
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
                     '--external-runner=/bin/sh %s'
                     % (AVOCADO, self.tmpdir, self.pass_script.path))
@@ -875,7 +839,6 @@ class ExternalRunnerTest(unittest.TestCase):
                          (expected_rc, result))
 
     def test_externalrunner_fail(self):
-        os.chdir(basedir)
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
                     '--external-runner=/bin/sh %s'
                     % (AVOCADO, self.tmpdir, self.fail_script.path))
@@ -886,7 +849,6 @@ class ExternalRunnerTest(unittest.TestCase):
                          (expected_rc, result))
 
     def test_externalrunner_chdir_no_testdir(self):
-        os.chdir(basedir)
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
                     '--external-runner=/bin/sh --external-runner-chdir=test %s'
                     % (AVOCADO, self.tmpdir, self.pass_script.path))
@@ -900,7 +862,6 @@ class ExternalRunnerTest(unittest.TestCase):
                          (expected_rc, result))
 
     def test_externalrunner_no_url(self):
-        os.chdir(basedir)
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
                     '--external-runner=%s' % (AVOCADO, self.tmpdir, TRUE_CMD))
         result = process.run(cmd_line, ignore_status=True)
@@ -922,6 +883,7 @@ class AbsPluginsTest(object):
 
     def setUp(self):
         self.base_outputdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        os.chdir(basedir)
 
     def tearDown(self):
         shutil.rmtree(self.base_outputdir)
@@ -930,7 +892,6 @@ class AbsPluginsTest(object):
 class PluginsTest(AbsPluginsTest, unittest.TestCase):
 
     def test_sysinfo_plugin(self):
-        os.chdir(basedir)
         cmd_line = '%s sysinfo %s' % (AVOCADO, self.base_outputdir)
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -941,7 +902,6 @@ class PluginsTest(AbsPluginsTest, unittest.TestCase):
         self.assertGreater(len(sysinfo_files), 0, "Empty sysinfo files dir")
 
     def test_list_plugin(self):
-        os.chdir(basedir)
         cmd_line = '%s list' % AVOCADO
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout
@@ -952,7 +912,6 @@ class PluginsTest(AbsPluginsTest, unittest.TestCase):
         self.assertNotIn('No tests were found on current tests dir', output)
 
     def test_list_error_output(self):
-        os.chdir(basedir)
         cmd_line = '%s list sbrubles' % AVOCADO
         result = process.run(cmd_line, ignore_status=True)
         output = result.stderr
@@ -963,7 +922,6 @@ class PluginsTest(AbsPluginsTest, unittest.TestCase):
         self.assertIn("Unable to resolve reference", output)
 
     def test_list_no_file_loader(self):
-        os.chdir(basedir)
         cmd_line = ("%s list --loaders external --verbose -- "
                     "this-wont-be-matched" % AVOCADO)
         result = process.run(cmd_line, ignore_status=True)
@@ -983,7 +941,6 @@ class PluginsTest(AbsPluginsTest, unittest.TestCase):
         """
         Runs list verbosely and check for tag related output
         """
-        os.chdir(basedir)
         test = script.make_script(os.path.join(self.base_outputdir, 'test.py'),
                                   VALID_PYTHON_TEST_WITH_TAGS)
         cmd_line = ("%s list --loaders file --verbose %s" % (AVOCADO,
@@ -1003,7 +960,6 @@ class PluginsTest(AbsPluginsTest, unittest.TestCase):
         self.assertEqual("BIG_TAG_NAME: 1", stdout_lines[-1])
 
     def test_plugin_list(self):
-        os.chdir(basedir)
         cmd_line = '%s plugins' % AVOCADO
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout
@@ -1015,7 +971,6 @@ class PluginsTest(AbsPluginsTest, unittest.TestCase):
             self.assertNotIn('Disabled', output)
 
     def test_config_plugin(self):
-        os.chdir(basedir)
         cmd_line = '%s config --paginator off' % AVOCADO
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout
@@ -1026,7 +981,6 @@ class PluginsTest(AbsPluginsTest, unittest.TestCase):
         self.assertNotIn('Disabled', output)
 
     def test_config_plugin_datadir(self):
-        os.chdir(basedir)
         cmd_line = '%s config --datadir --paginator off' % AVOCADO
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout
@@ -1037,7 +991,6 @@ class PluginsTest(AbsPluginsTest, unittest.TestCase):
         self.assertNotIn('Disabled', output)
 
     def test_disable_plugin(self):
-        os.chdir(basedir)
         cmd_line = '%s plugins' % AVOCADO
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -1088,7 +1041,6 @@ class PluginsTest(AbsPluginsTest, unittest.TestCase):
         except pkg_resources.DistributionNotFound:
             pass
 
-        os.chdir(basedir)
         cmd_line = '%s plugins' % AVOCADO
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -1126,7 +1078,6 @@ class PluginsTest(AbsPluginsTest, unittest.TestCase):
                 self.assertIn(result_output, zip_file_list)
 
     def test_Namespace_object_has_no_attribute(self):
-        os.chdir(basedir)
         cmd_line = '%s plugins' % AVOCADO
         result = process.run(cmd_line, ignore_status=True)
         output = result.stderr
@@ -1152,7 +1103,6 @@ class PluginsXunitTest(AbsPluginsTest, unittest.TestCase):
 
     def run_and_check(self, testname, e_rc, e_ntests, e_nerrors,
                       e_nnotfound, e_nfailures, e_nskip):
-        os.chdir(basedir)
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off'
                     ' --xunit - %s' % (AVOCADO, self.tmpdir, testname))
         result = process.run(cmd_line, ignore_status=True)
@@ -1235,7 +1185,6 @@ class PluginsJSONTest(AbsPluginsTest, unittest.TestCase):
 
     def run_and_check(self, testname, e_rc, e_ntests, e_nerrors,
                       e_nfailures, e_nskip, e_ncancel=0, external_runner=None):
-        os.chdir(basedir)
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off --json - '
                     '--archive %s' % (AVOCADO, self.tmpdir, testname))
         if external_runner is not None:

--- a/selftests/functional/test_loader.py
+++ b/selftests/functional/test_loader.py
@@ -108,6 +108,9 @@ from avocado import main
 from test2 import *
 
 class BasicTestSuite(SuperTest):
+    '''
+    :avocado: disable
+    '''
 
     def test1(self):
         self.xxx()

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -99,11 +99,11 @@ class OutputTest(unittest.TestCase):
 
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        os.chdir(basedir)
 
     @unittest.skipIf(missing_binary('cc'),
                      "C compiler is required by the underlying doublefree.py test")
     def test_output_doublefree(self):
-        os.chdir(basedir)
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
                     'doublefree.py' % (AVOCADO, self.tmpdir))
         result = process.run(cmd_line, ignore_status=True)
@@ -133,7 +133,6 @@ class OutputTest(unittest.TestCase):
         test = script.Script(os.path.join(self.tmpdir, "output_test.py"),
                              OUTPUT_TEST_CONTENT)
         test.save()
-        os.chdir(basedir)
         result = process.run("%s run --job-results-dir %s --sysinfo=off "
                              "--json - -- %s" % (AVOCADO, self.tmpdir, test))
         res = json.loads(result.stdout)
@@ -162,6 +161,7 @@ class OutputPluginTest(unittest.TestCase):
 
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        os.chdir(basedir)
 
     def check_output_files(self, debug_log):
         base_dir = os.path.dirname(debug_log)
@@ -183,7 +183,6 @@ class OutputPluginTest(unittest.TestCase):
         self.assertIn("\n# debug.log of ", tap)
 
     def test_output_incompatible_setup(self):
-        os.chdir(basedir)
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
                     '--xunit - --json - passtest.py' % (AVOCADO, self.tmpdir))
         result = process.run(cmd_line, ignore_status=True)
@@ -202,7 +201,6 @@ class OutputPluginTest(unittest.TestCase):
     @unittest.skipIf(html_uncapable(),
                      "Uncapable of Avocado Result HTML plugin")
     def test_output_incompatible_setup_2(self):
-        os.chdir(basedir)
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
                     '--html - passtest.py' % (AVOCADO, self.tmpdir))
         result = process.run(cmd_line, ignore_status=True)
@@ -217,7 +215,6 @@ class OutputPluginTest(unittest.TestCase):
 
     def test_output_compatible_setup(self):
         tmpfile = tempfile.mktemp()
-        os.chdir(basedir)
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
                     '--journal --xunit %s --json - passtest.py' %
                     (AVOCADO, self.tmpdir, tmpfile))
@@ -239,7 +236,6 @@ class OutputPluginTest(unittest.TestCase):
 
     def test_output_compatible_setup_2(self):
         tmpfile = tempfile.mktemp()
-        os.chdir(basedir)
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
                     '--xunit - --json %s passtest.py' %
                     (AVOCADO, self.tmpdir, tmpfile))
@@ -269,7 +265,6 @@ class OutputPluginTest(unittest.TestCase):
         tmpfile2 = tempfile.mktemp(prefix='avocado_' + __name__)
         tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
         tmpfile3 = tempfile.mktemp(dir=tmpdir)
-        os.chdir(basedir)
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
                     '--xunit %s --json %s --html %s passtest.py'
                     % (AVOCADO, self.tmpdir, tmpfile, tmpfile2, tmpfile3))
@@ -301,7 +296,6 @@ class OutputPluginTest(unittest.TestCase):
     def test_output_compatible_setup_nooutput(self):
         tmpfile = tempfile.mktemp()
         tmpfile2 = tempfile.mktemp()
-        os.chdir(basedir)
         # Verify --silent can be supplied as app argument
         cmd_line = ('%s --silent run --job-results-dir %s '
                     '--sysinfo=off --xunit %s --json %s passtest.py'
@@ -348,7 +342,6 @@ class OutputPluginTest(unittest.TestCase):
         self.check_output_files(debug_log)
 
     def test_show_job_log(self):
-        os.chdir(basedir)
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
                     'passtest.py --show-job-log' % (AVOCADO, self.tmpdir))
         result = process.run(cmd_line, ignore_status=True)
@@ -364,7 +357,6 @@ class OutputPluginTest(unittest.TestCase):
         self.assertEqual(len(job_id), 40)
 
     def test_silent_trumps_show_job_log(self):
-        os.chdir(basedir)
         # Also verify --silent can be supplied as run option
         cmd_line = ('%s run --silent --job-results-dir %s '
                     '--sysinfo=off passtest.py --show-job-log'
@@ -378,7 +370,6 @@ class OutputPluginTest(unittest.TestCase):
         self.assertEqual(output, "")
 
     def test_default_enabled_plugins(self):
-        os.chdir(basedir)
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
                     'passtest.py' % (AVOCADO, self.tmpdir))
         result = process.run(cmd_line, ignore_status=True)
@@ -400,7 +391,6 @@ class OutputPluginTest(unittest.TestCase):
     def test_verify_whiteboard_save(self):
         tmpfile = tempfile.mktemp()
         try:
-            os.chdir(basedir)
             config = os.path.join(self.tmpdir, "conf.ini")
             content = ("[datadir.paths]\nlogs_dir = %s"
                        % os.path.relpath(self.tmpdir, "."))
@@ -431,7 +421,6 @@ class OutputPluginTest(unittest.TestCase):
     def test_gendata(self):
         tmpfile = tempfile.mktemp()
         try:
-            os.chdir(basedir)
             cmd_line = ("%s run --job-results-dir %s "
                         "--sysinfo=off gendata.py --json %s" %
                         (AVOCADO, self.tmpdir, tmpfile))
@@ -470,7 +459,6 @@ class OutputPluginTest(unittest.TestCase):
     def test_redirect_output(self):
         redirected_output_path = tempfile.mktemp()
         try:
-            os.chdir(basedir)
             cmd_line = ('%s run --job-results-dir %s '
                         '--sysinfo=off passtest.py > %s'
                         % (AVOCADO, self.tmpdir, redirected_output_path))
@@ -501,11 +489,9 @@ class OutputPluginTest(unittest.TestCase):
                                              PERL_TAP_PARSER_SNIPPET
                                              % self.tmpdir)
         perl_script.save()
-        os.chdir(basedir)
         process.run("perl %s" % perl_script)
 
     def test_tap_totaltests(self):
-        os.chdir(basedir)
         cmd_line = ("%s run passtest.py "
                     "-m examples/tests/sleeptest.py.data/sleeptest.yaml "
                     "--job-results-dir %s "
@@ -516,7 +502,6 @@ class OutputPluginTest(unittest.TestCase):
                       % (expr, result.stdout))
 
     def test_broken_pipe(self):
-        os.chdir(basedir)
         cmd_line = "(%s run --help | whacky-unknown-command)" % AVOCADO
         result = process.run(cmd_line, shell=True, ignore_status=True,
                              env={"LC_ALL": "C"})
@@ -530,7 +515,6 @@ class OutputPluginTest(unittest.TestCase):
         self.assertNotIn("Avocado crashed", result.stderr)
 
     def test_results_plugins_no_tests(self):
-        os.chdir(basedir)
         cmd_line = ("%s run UNEXISTING --job-results-dir %s"
                     % (AVOCADO, self.tmpdir))
         result = process.run(cmd_line, ignore_status=True)

--- a/selftests/functional/test_plugin_jobscripts.py
+++ b/selftests/functional/test_plugin_jobscripts.py
@@ -7,6 +7,8 @@ from avocado.core import exit_codes
 from avocado.utils import process
 from avocado.utils import script
 
+BASEDIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..')
+BASEDIR = os.path.abspath(BASEDIR)
 
 AVOCADO = os.environ.get("UNITTEST_AVOCADO_CMD", "./scripts/avocado")
 
@@ -47,6 +49,7 @@ class JobScriptsTest(unittest.TestCase):
         os.mkdir(self.pre_dir)
         self.post_dir = os.path.join(self.tmpdir, 'post.d')
         os.mkdir(self.post_dir)
+        os.chdir(BASEDIR)
 
     def test_pre_post(self):
         """

--- a/selftests/functional/test_statuses.py
+++ b/selftests/functional/test_statuses.py
@@ -153,6 +153,7 @@ class TestStatuses(unittest.TestCase):
                                                  ".data",
                                                  'test_statuses.yaml'))
 
+        os.chdir(basedir)
         cmd = ('%s run %s -m %s --sysinfo=off --job-results-dir %s --json -' %
                (AVOCADO, test_file, yaml_file, self.tmpdir))
 

--- a/selftests/functional/test_streams.py
+++ b/selftests/functional/test_streams.py
@@ -17,6 +17,7 @@ class StreamsTest(unittest.TestCase):
 
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        os.chdir(basedir)
 
     def test_app_info_stdout(self):
         """

--- a/selftests/unit/test_mux.py
+++ b/selftests/unit/test_mux.py
@@ -1,5 +1,6 @@
 import copy
 import itertools
+import os
 import pickle
 import unittest
 import yaml
@@ -8,11 +9,10 @@ import yaml
 import avocado_varianter_yaml_to_mux as yaml_to_mux
 from avocado.core import mux, tree, varianter
 
+BASEDIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..')
+BASEDIR = os.path.abspath(BASEDIR)
 
-if __name__ == "__main__":
-    PATH_PREFIX = "../../"
-else:
-    PATH_PREFIX = ""
+PATH_PREFIX = os.path.relpath(BASEDIR) + os.path.sep
 
 
 def combine(leaves_pools):


### PR DESCRIPTION
This PR adds support to discover python unittests as individual tests, which was previously supported only as contrib script + external runner.

As Avocado tests are in fact python unittests, disabled Avocado tests are excluded from the results to avoid confusion. Also to support running tests from parent locations, each unittest is executed from it's __file__ directory (eg. running `/tmp/foo.py => cd /tmp && python -m unittest foo.$class.$test`, instead of `..........tmp.foo.$class.$test` which would not work).

v1: https://github.com/avocado-framework/avocado/pull/2182
v2: https://github.com/avocado-framework/avocado/pull/2192

changes:
```yaml
v2: Instead of working-around the Avocado disabled tests detect them and skip them
    directly in the loader.
v2: Rebased, added selftest
v3: Fixed rtype in docstring
v3: renamed 2 not-well-named variables
v3: Use DEFAULT_NON_EXEC_MODE instead of 0o644
v3: Properly support to filter tests (`:..`)
v3: New commit to always set basedir correctly in selftests
```