### PR TITLE
Fixes for "install from source"

### DIFF
--- a/docs/source/GetStartedGuide.rst
+++ b/docs/source/GetStartedGuide.rst
@@ -134,7 +134,7 @@ First make sure you have a basic set of packages installed. The
 following applies to Fedora based distributions, please adapt to
 your platform::
 
-    sudo yum install -y git gcc python-devel python-pip libvirt-devel libyaml-devel redhat-rpm-config xz-devel
+    sudo dnf install -y python2 git gcc python-devel python-pip libvirt-devel libffi-devel openssl-devel libyaml-devel redhat-rpm-config xz-devel
 
 Then to install Avocado from the git repository run::
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ pyliblzma>=0.5.3
 requests>=1.2.3
 # stevedore for loading "new style" plugins
 stevedore>=0.14
+# Python bindings for libvirt
+libvirt-python>=3.7.0


### PR DESCRIPTION
We need some updates in the installation process when performing a Generic installation from a GIT repository:
- `libvirt-python` added to requirements.txt
- Move from `yum` to `dnf` in our docs.
- Update the list of packages to be installed via package manager in our docs. 