### PR TITLE
yaml_to_mux: Construct tree as OrderedDict [v2]

### DIFF
--- a/docs/source/optional_plugins/varianter_yaml_to_mux.rst
+++ b/docs/source/optional_plugins/varianter_yaml_to_mux.rst
@@ -311,6 +311,16 @@ keys so:
 Won't become ``True: True``, but the key will be preserved as string
 ``on: True``.
 
+You might also want to use dict as values in your params. This is also
+supported but as we can't easily distinguish whether that value is
+a value or a node (structure), you have to either embed it into another
+object (list, ..) or you have to clearly state the type (yaml tag
+``!!python/dict``). Even then the value won't be a standard dictionary,
+but it'll be ``collections.OrderedDict`` and similarly to nodes
+structure all keys are preserved as strings and no smart type detection
+is used. Apart from that it should behave similarly as dict, only you
+get the values ordered by the order they appear in the file.
+
 Multiple files
 --------------
 

--- a/docs/source/optional_plugins/varianter_yaml_to_mux.rst
+++ b/docs/source/optional_plugins/varianter_yaml_to_mux.rst
@@ -297,6 +297,20 @@ example parameters for your plugin, which you need to separate from the test
 parameters.
 
 
+Special values
+--------------
+
+As you might have noticed, we are using mapping/dicts to define the structure
+of the params. To avoid surprises we disallowed the smart typing of mapping
+keys so:
+
+.. code-block:: yaml
+
+   on: on
+
+Won't become ``True: True``, but the key will be preserved as string
+``on: True``.
+
 Multiple files
 --------------
 

--- a/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/__init__.py
+++ b/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/__init__.py
@@ -11,8 +11,10 @@
 #
 # Copyright: Red Hat Inc. 2016-2017
 # Author: Lukas Doktor <ldoktor@redhat.com>
+
 """Varianter plugin to parse yaml files to params"""
 
+import collections
 import copy
 import os
 import re
@@ -80,6 +82,11 @@ class ListOfNodeObjects(list):     # Few methods pylint: disable=R0903
     pass
 
 
+class MappingDict(dict):
+
+    """Object representing mapping"""
+
+
 def _create_from_yaml(path, cls_node=mux.MuxTreeNode):
     """ Create tree structure from yaml stream """
     def tree_node_from_values(name, values):
@@ -125,7 +132,7 @@ def _create_from_yaml(path, cls_node=mux.MuxTreeNode):
             if using:
                 raise ValueError("!using can be used only once per "
                                  "node! (%s:%s)" % (path, name))
-            using = value[1]
+            using = value
             if using[0] == '/':
                 using = using[1:]
             if using[-1] == '/':
@@ -133,17 +140,37 @@ def _create_from_yaml(path, cls_node=mux.MuxTreeNode):
             return using
 
         node = cls_node(str(name))
+        if not values:
+            return node
         using = ''
-        for value in values:
-            if isinstance(value, cls_node):
-                node.add_child(value)
-            elif isinstance(value[0], mux.Control):
-                if value[0].code == YAML_USING:
-                    using = handle_control_tag_using(name, using, value)
+
+        if isinstance(values, dict):    # didn't looked like a node
+            for key, value in values.iteritems():
+                if isinstance(key, mux.Control):
+                    if key.code == YAML_USING:
+                        using = handle_control_tag_using(name, using, value)
+                    else:
+                        handle_control_tag(node, [key, value])
+                elif (isinstance(value, collections.OrderedDict) or
+                      value is None):
+                    node.add_child(tree_node_from_values(key, value))
                 else:
-                    handle_control_tag(node, value)
-            else:
-                node.value[value[0]] = value[1]
+                    node.value[key] = value
+        else:       # already looked like a dict
+            for value in values:
+                if isinstance(value, cls_node):
+                    node.add_child(value)
+                elif isinstance(value[0], mux.Control):
+                    if value[0].code == YAML_USING:
+                        using = handle_control_tag_using(name, using, value[1])
+                    else:
+                        handle_control_tag(node, value)
+                elif isinstance(value[1], collections.OrderedDict):
+                    node.add_child(tree_node_from_values(str(value[0]),
+                                                         value[1]))
+                else:
+                    node.value[value[0]] = value[1]
+
         if using:
             if name is not '':
                 for name in using.split('/')[::-1]:
@@ -159,17 +186,30 @@ def _create_from_yaml(path, cls_node=mux.MuxTreeNode):
                 node = cls_node('', children=[node])
         return node
 
-    def mapping_to_tree_loader(loader, node):
+    def mapping_to_tree_loader(loader, node, looks_like_node=False):
         """ Maps yaml mapping tag to TreeNode structure """
         _value = []
         for key_node, value_node in node.value:
+            # Allow only strings as dict keys
             if key_node.tag.startswith('!'):    # reflect tags everywhere
                 key = loader.construct_object(key_node)
             else:
                 key = loader.construct_python_str(key_node)
+            # If we are to keep them, use following, but we lose the control
+            # for both, nodes and dicts
+            # key = loader.construct_object(key_node)
+            if isinstance(key, mux.Control):
+                looks_like_node = True
             value = loader.construct_object(value_node)
+            if isinstance(value, ListOfNodeObjects):
+                looks_like_node = True
             _value.append((key, value))
+
+        if not looks_like_node:
+            return collections.OrderedDict(_value)
+
         objects = ListOfNodeObjects()
+        looks_like_node = False
         for name, values in _value:
             if isinstance(values, ListOfNodeObjects):   # New node from list
                 objects.append(tree_node_from_values(name, values))
@@ -184,7 +224,7 @@ def _create_from_yaml(path, cls_node=mux.MuxTreeNode):
         Special !mux loader which allows to tag node as 'multiplex = True'.
         """
         if not isinstance(obj, yaml.ScalarNode):
-            objects = mapping_to_tree_loader(loader, obj)
+            objects = mapping_to_tree_loader(loader, obj, looks_like_node=True)
         else:   # This means it's empty node. Don't call mapping_to_tree_loader
             objects = ListOfNodeObjects()
         objects.append((mux.Control(YAML_MUX), None))
@@ -214,6 +254,7 @@ def _create_from_yaml(path, cls_node=mux.MuxTreeNode):
         loaded_tree = yaml.load(stream, loader)
         if loaded_tree is None:
             return
+
         loaded_tree = tree_node_from_values('', loaded_tree)
 
     # Add prefix

--- a/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/__init__.py
+++ b/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/__init__.py
@@ -55,23 +55,22 @@ class _BaseLoader(Loader):
     YAML loader with additional features related to mux
     """
     Loader.add_constructor(u'!include',
-                           lambda loader, node: mux.Control(YAML_INCLUDE))
+                           lambda *_: mux.Control(YAML_INCLUDE))
     Loader.add_constructor(u'!using',
-                           lambda loader, node: mux.Control(YAML_USING))
+                           lambda *_: mux.Control(YAML_USING))
     Loader.add_constructor(u'!remove_node',
-                           lambda loader, node: mux.Control(YAML_REMOVE_NODE))
+                           lambda *_: mux.Control(YAML_REMOVE_NODE))
     Loader.add_constructor(u'!remove_value',
-                           lambda loader, node: mux.Control(YAML_REMOVE_VALUE))
+                           lambda *_: mux.Control(YAML_REMOVE_VALUE))
     Loader.add_constructor(u'!filter-only',
-                           lambda loader, node: mux.Control(YAML_FILTER_ONLY))
+                           lambda *_: mux.Control(YAML_FILTER_ONLY))
     Loader.add_constructor(u'!filter-out',
-                           lambda loader, node: mux.Control(YAML_FILTER_OUT))
+                           lambda *_: mux.Control(YAML_FILTER_OUT))
 
 
 class Value(tuple):     # Few methods pylint: disable=R0903
 
-    """ Used to mark values to simplify checking for node vs. value """
-    pass
+    """Used to mark values to simplify checking for node vs. value"""
 
 
 class ListOfNodeObjects(list):     # Few methods pylint: disable=R0903
@@ -79,7 +78,6 @@ class ListOfNodeObjects(list):     # Few methods pylint: disable=R0903
     """
     Used to mark list as list of objects from whose node is going to be created
     """
-    pass
 
 
 class MappingDict(dict):
@@ -88,13 +86,13 @@ class MappingDict(dict):
 
 
 def _create_from_yaml(path, cls_node=mux.MuxTreeNode):
-    """ Create tree structure from yaml stream """
+    """Create tree structure from yaml stream"""
     def tree_node_from_values(name, values):
-        """ Create `name` node and add values  """
+        """Create `name` node and add values"""
         def handle_control_tag(node, value):
-            """ Handling of YAML tags (except of !using) """
+            """Handling of YAML tags (except of !using)"""
             def normalize_path(path):
-                """ End the path with single '/', None when empty path """
+                """End the path with single '/', None when empty path"""
                 if not path:
                     return
                 if path[-1] != '/':
@@ -128,7 +126,7 @@ def _create_from_yaml(path, cls_node=mux.MuxTreeNode):
                     node.filters[1].append(new_value)
 
         def handle_control_tag_using(name, using, value):
-            """ Handling of the !using tag """
+            """Handling of the !using tag"""
             if using:
                 raise ValueError("!using can be used only once per "
                                  "node! (%s:%s)" % (path, name))
@@ -187,7 +185,7 @@ def _create_from_yaml(path, cls_node=mux.MuxTreeNode):
         return node
 
     def mapping_to_tree_loader(loader, node, looks_like_node=False):
-        """ Maps yaml mapping tag to TreeNode structure """
+        """Maps yaml mapping tag to TreeNode structure"""
         _value = []
         for key_node, value_node in node.value:
             # Allow only strings as dict keys
@@ -276,13 +274,13 @@ def create_from_yaml(paths, debug=False):
     :return: Root of the created tree structure
     """
     def _merge(data, path):
-        """ Normal run """
+        """Normal run"""
         tmp = _create_from_yaml(path)
         if tmp:
             data.merge(tmp)
 
     def _merge_debug(data, path):
-        """ Use NamedTreeNodeDebug magic """
+        """Use NamedTreeNodeDebug magic"""
         node_cls = tree.get_named_tree_cls(path, mux.MuxTreeNodeDebug)
         tmp = _create_from_yaml(path, node_cls)
         if tmp:
@@ -328,32 +326,33 @@ class YamlToMuxCLI(CLI):
             subparser = parser.subcommands.choices.get(name, None)
             if subparser is None:
                 continue
-            mux = subparser.add_argument_group("yaml to mux options")
-            mux.add_argument("-m", "--mux-yaml", nargs='*', metavar="FILE",
-                             help="Location of one or more Avocado"
-                             " multiplex (.yaml) FILE(s) (order dependent)")
-            mux.add_argument('--mux-filter-only', nargs='*', default=[],
-                             help='Filter only path(s) from multiplexing')
-            mux.add_argument('--mux-filter-out', nargs='*', default=[],
-                             help='Filter out path(s) from multiplexing')
-            mux.add_argument('--mux-path', nargs='*', default=None,
-                             help="List of default paths used to determine "
-                             "path priority when querying for parameters")
-            mux.add_argument('--mux-inject', default=[], nargs='*',
-                             help="Inject [path:]key:node values into the "
-                             "final multiplex tree.")
-            mux = subparser.add_argument_group("yaml to mux options "
-                                               "[deprecated]")
-            mux.add_argument("--multiplex", nargs='*',
-                             default=None, metavar="FILE",
-                             help="DEPRECATED: Location of one or more Avocado"
-                             " multiplex (.yaml) FILE(s) (order dependent)")
-            mux.add_argument("--filter-only", nargs='*', default=[],
-                             help="DEPRECATED: Filter only path(s) from "
-                             "multiplexing (use --mux-filter-only instead)")
-            mux.add_argument("--filter-out", nargs='*', default=[],
-                             help="DEPRECATED: Filter out path(s) from "
-                             "multiplexing (use --mux-filter-out instead)")
+            agroup = subparser.add_argument_group("yaml to mux options")
+            agroup.add_argument("-m", "--mux-yaml", nargs='*', metavar="FILE",
+                                help="Location of one or more Avocado"
+                                " multiplex (.yaml) FILE(s) (order dependent)")
+            agroup.add_argument('--mux-filter-only', nargs='*', default=[],
+                                help='Filter only path(s) from multiplexing')
+            agroup.add_argument('--mux-filter-out', nargs='*', default=[],
+                                help='Filter out path(s) from multiplexing')
+            agroup.add_argument('--mux-path', nargs='*', default=None,
+                                help="List of default paths used to determine "
+                                "path priority when querying for parameters")
+            agroup.add_argument('--mux-inject', default=[], nargs='*',
+                                help="Inject [path:]key:node values into the "
+                                "final multiplex tree.")
+            agroup = subparser.add_argument_group("yaml to mux options "
+                                                  "[deprecated]")
+            agroup.add_argument("--multiplex", nargs='*',
+                                default=None, metavar="FILE",
+                                help="DEPRECATED: Location of one or more "
+                                "Avocado multiplex (.yaml) FILE(s) (order "
+                                "dependent)")
+            agroup.add_argument("--filter-only", nargs='*', default=[],
+                                help="DEPRECATED: Filter only path(s) from "
+                                "multiplexing (use --mux-filter-only instead)")
+            agroup.add_argument("--filter-out", nargs='*', default=[],
+                                help="DEPRECATED: Filter out path(s) from "
+                                "multiplexing (use --mux-filter-out instead)")
 
     def run(self, args):
         """

--- a/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/__init__.py
+++ b/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/__init__.py
@@ -20,7 +20,7 @@ import os
 import re
 import sys
 
-from avocado.core import tree, exit_codes, mux, varianter, loader
+from avocado.core import tree, exit_codes, mux, varianter
 from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLI, Varianter
 

--- a/selftests/.data/mux-selftest-advanced.yaml
+++ b/selftests/.data/mux-selftest-advanced.yaml
@@ -33,3 +33,14 @@ new_node:
 on:
     on: on
     true: "true"
+# We do also support ordinary dicts as values if they are either marked
+# as dicts or when they are stored inside another object.
+# note: They will be turned into OrderedDict(s), but the behavior
+#       should be similar.
+dict:
+    explicit: !!python/dict
+        foo: bar
+        bar: baz
+    in_list:
+        - foo: bar
+          bar: baz

--- a/selftests/unit/test_mux.py
+++ b/selftests/unit/test_mux.py
@@ -169,7 +169,7 @@ class TestMuxTree(unittest.TestCase):
                                               'selftests/.data/mux-selftest-advanced.'
                                               'yaml'])
         exp = ['intel', 'amd', 'arm', 'scsi', 'virtio', 'fedora', '6',
-               '7', 'gentoo', 'mint', 'prod', 'new_node', 'on']
+               '7', 'gentoo', 'mint', 'prod', 'new_node', 'on', 'dict']
         act = tree2.get_leaves()
         oldroot = tree2.children[0]
         self.assertEqual(exp, act)
@@ -185,6 +185,10 @@ class TestMuxTree(unittest.TestCase):
         # Convert values, but not keys
         self.assertEqual({'on': True, "true": "true"},
                          oldroot.children[4].value)
+        # Dicts as values
+        self.assertEqual({"explicit": {"foo": "bar", "bar": "baz"},
+                          "in_list": [{"foo": "bar", "bar": "baz"}]},
+                         oldroot.children[5].value)
         # multiplex root (always True)
         self.assertEqual(tree2.multiplex, None)
         # multiplex /virt/


### PR DESCRIPTION
This PR changes the way we parse the yaml file. Instead of treating all mappings as tree-node-structure it first attempts to create ordered dicts instead and only when advanced features (like our tags) are used or when the potential node is connected to root, the content is conversed into a tree. This way dicts inside another object, or explicitly defined dicts stay as dicts and will be available (almost) unmodified in test params.

The almost stands for the essential changes that are needed due to yaml parser nature, where we parse the objects from inside out, therefor we can't tell in advanced whether they are dicts or nodes and for nodes we require the correct order they appear in (`collection.OrderedDict`) and we don't want to convert keys into arbitrary types (`on` should stay as `on` and not as `bool(True)`).

Fixes issue: https://github.com/avocado-framework/avocado/issues/2123
v1: https://github.com/avocado-framework/avocado/pull/2156

Changes:
```yaml
v2: Several new commits with minor fixes
v2: One new commit to describe things we (don't) do while parsing yaml file
v2: Add selftest
v2: Add documentation
```