### PR TITLE
Fixes for "install from source" [v2]

### DIFF
--- a/docs/source/GetStartedGuide.rst
+++ b/docs/source/GetStartedGuide.rst
@@ -134,7 +134,7 @@ First make sure you have a basic set of packages installed. The
 following applies to Fedora based distributions, please adapt to
 your platform::
 
-    sudo yum install -y git gcc python-devel python-pip libvirt-devel libyaml-devel redhat-rpm-config xz-devel
+    sudo dnf install -y python2 git gcc python-devel python-pip libvirt-devel libffi-devel openssl-devel libyaml-devel redhat-rpm-config xz-devel
 
 Then to install Avocado from the git repository run::
 


### PR DESCRIPTION
We need some updates in the installation process when performing a Generic installation from a GIT repository:
- Move from `yum` to `dnf` in our docs.
- Update the list of packages to be installed via package manager in our docs. 

v2:
- Drop the commit adding `libvirt-python` to requirements.txt.

v1: #2195 