### PR TITLE
sysinfo: couple of daemon treatment fixes

### DIFF
--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -232,7 +232,7 @@ class Daemon(Command):
         """
         retcode = self.pipe.poll()
         if retcode is None:
-            self.pipe.terminate()
+            process.kill_process_tree(self.pipe.pid)
             retcode = self.pipe.wait()
         else:
             log.error("Daemon process '%s' (pid %d) terminated abnormally (code %d)",

--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -16,6 +16,7 @@ import gzip
 import json
 import logging
 import os
+import shlex
 import shutil
 import time
 import threading
@@ -222,8 +223,8 @@ class Daemon(Command):
         logf_path = os.path.join(logdir, self.logf)
         stdin = open(os.devnull, "r")
         stdout = open(logf_path, "w")
-        self.pipe = subprocess.Popen(self.cmd, stdin=stdin, stdout=stdout,
-                                     stderr=subprocess.STDOUT, shell=True, env=env)
+        self.pipe = subprocess.Popen(shlex.split(self.cmd), stdin=stdin, stdout=stdout,
+                                     stderr=subprocess.STDOUT, shell=False, env=env)
 
     def stop(self):
         """

--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -611,6 +611,10 @@ class SysInfo(object):
         """
         for log in self.end_test_collectibles:
             log.run(self.post_dir)
+        # Stop daemon(s) started previously
+        for log in self.start_test_collectibles:
+            if isinstance(log, Daemon):
+                log.stop()
 
         if self.log_packages:
             self._log_modified_packages(self.post_dir)


### PR DESCRIPTION
The sysinfo collection allows to use daemons to collect information while the tests are running, but as issue https://github.com/avocado-framework/avocado/issues/2135 showed us the daemons might not be cleaned properly afterwards. This PR adds some protections to decrease the probability we leave processes behind.

Fixes issue: https://github.com/avocado-framework/avocado/issues/2135