### PR TITLE
Memutils: Added full memory string support, increased wait time and style fixes 

### DIFF
--- a/avocado/utils/memory.py
+++ b/avocado/utils/memory.py
@@ -41,12 +41,14 @@ def _check_memory_state(block):
     Check the given memory block is online or offline
 
     :param block: memory block id.
-    :type string: like 198
+    :type string: like 198 or memory198
     :return: 'True' if online or 'False' if offline
     :rtype: bool
     """
+    if not block.startswith("memory"):
+        block = "memory%s" % block
     def _is_online():
-        with open('/sys/devices/system/memory/memory%s/state' % block, 'r') as state_file:
+        with open('/sys/devices/system/memory/%s/state' % block, 'r') as state_file:
             if state_file.read() == 'online\n':
                 return True
             return False
@@ -71,11 +73,13 @@ def is_hot_pluggable(block):
     Check if the given memory block is hotpluggable
 
     :param block: memory block id.
-    :type string: like 198
+    :type string: like 198 or memory198
     :retrun: True if hotpluggable, else False
     :rtype: 'bool'
     """
-    with open('/sys/devices/system/memory/memory%s/removable' % block, 'r') as file_obj:
+    if not block.startswith("memory"):
+        block = "memory%s" % block
+    with open('/sys/devices/system/memory/%s/removable' % block, 'r') as file_obj:
         return bool(int(file_obj.read()))
 
 
@@ -84,9 +88,11 @@ def hotplug(block):
     Online the memory for the given block id.
 
     :param block: memory block id.
-    :type string: like 198
+    :type string: like 198 or memory198
     """
-    with open('/sys/devices/system/memory/memory%s/state' % block, 'w') as state_file:
+    if not block.startswith("memory"):
+        block = "memory%s" % block
+    with open('/sys/devices/system/memory/%s/state' % block, 'w') as state_file:
         state_file.write('online')
     if not _check_memory_state(block):
         raise MemoryError(
@@ -98,9 +104,11 @@ def hotunplug(block):
     Offline the memory for the given block id.
 
     :param block: memory block id.
-    :type string: like 198
+    :type string: like 198 or memory198
     """
-    with open('/sys/devices/system/memory/memory%s/state' % block, 'w') as state_file:
+    if not block.startswith("memory"):
+        block = "memory%s" % block
+    with open('/sys/devices/system/memory/%s/state' % block, 'w') as state_file:
         state_file.write('offline')
     if _check_memory_state(block):
         raise MemoryError(

--- a/avocado/utils/memory.py
+++ b/avocado/utils/memory.py
@@ -51,7 +51,7 @@ def _check_memory_state(block):
                 return True
             return False
 
-    return wait.wait_for(_is_online, timeout=120, step=1) or False
+    return wait.wait_for(_is_online, timeout=10, step=1) or False
 
 
 def check_hotplug():

--- a/avocado/utils/memory.py
+++ b/avocado/utils/memory.py
@@ -47,6 +47,7 @@ def _check_memory_state(block):
     """
     if not block.startswith("memory"):
         block = "memory%s" % block
+
     def _is_online():
         with open('/sys/devices/system/memory/%s/state' % block, 'r') as state_file:
             if state_file.read() == 'online\n':
@@ -149,7 +150,7 @@ def memtotal_sys():
     block_size = int(open(os.path.join(sys_mempath,
                                        'block_size_bytes'),
                           "r").read().strip(), 16)
-    return (no_memblocks * block_size)/1024.0
+    return (no_memblocks * block_size) / 1024.0
 
 
 def freememtotal():
@@ -427,9 +428,11 @@ def get_thp_value(feature):
 
 
 class _MemInfoItem(object):
+
     """
     Representation of one item from /proc/meminfo
     """
+
     def __init__(self, name):
         self.name = name
         self.__multipliers = {'b': 1,  # 2**0
@@ -461,6 +464,7 @@ class _MemInfoItem(object):
 
 
 class MemInfo(object):
+
     """
     Representation of /proc/meminfo
     """


### PR DESCRIPTION
Memutils: Added full memory string support, increased wait time and style fixes 
    utils/memory.py : ran autopep8 for style fixes
    Use complete string for the block id to hotplug
    Wait 10s for the memory state to change

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>