### PR TITLE
Loader: be clear about the meaning of NOT_A_TEST [v2]

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -496,8 +496,8 @@ class FileLoader(TestLoader):
     """
 
     name = 'file'
-    __not_test_str = ("Does not look like an INSTRUMENTED test, nor is it "
-                      "executable")
+    __not_test_str = ("Not an INSTRUMENTED (avocado.Test based), PyUNITTEST ("
+                      "unittest.TestCase based) or SIMPLE (executable) test")
 
     def __init__(self, args, extra_params):
         test_type = extra_params.pop('allowed_test_types', None)


### PR DESCRIPTION
NOT_A_TEST is a test resolution result that currently only applies to
INSTRUMENTED, PyUNITTEST and SIMPLE tests.  The message given on the
command line, though, doesn't make that completely clear because it
omits the PyUNITTEST and SIMPLE test types.

Signed-off-by: Cleber Rosa <crosa@redhat.com>

---

Changes from v1 (#2191):
 * Added newly introduced PyUNITTEST to the message