### PR TITLE
vmimage: adjust the 64bits arch on Debian/Ubuntu

### DIFF
--- a/avocado/utils/vmimage.py
+++ b/avocado/utils/vmimage.py
@@ -193,6 +193,10 @@ class UbuntuImageProvider(ImageProviderBase):
 
     def __init__(self, version='[0-9]+.[0-9]+', build=None,
                  arch=os.uname()[4]):
+        # Ubuntu uses 'amd64' instead of 'x86_64'
+        if arch == 'x86_64':
+            arch = 'amd64'
+
         super(UbuntuImageProvider, self).__init__(version, build, arch)
         self.url_versions = 'http://cloud-images.ubuntu.com/releases/'
         self.url_images = self.url_versions + 'releases/{version}/release/'
@@ -208,6 +212,10 @@ class DebianImageProvider(ImageProviderBase):
 
     def __init__(self, version='[0-9]+.[0-9]+.[0-9]+-.*', build=None,
                  arch=os.uname()[4]):
+        # Debian uses 'amd64' instead of 'x86_64'
+        if arch == 'x86_64':
+            arch = 'amd64'
+
         super(DebianImageProvider, self).__init__(version, build, arch)
         self.url_versions = 'https://cdimage.debian.org/cdimage/openstack/'
         self.url_images = self.url_versions + '{version}/'


### PR DESCRIPTION
Debian and Ubuntu use 'amd64' to refer to 64bits arch. Let's use 'amd64'
when the specified arch (auto-discovered or not) is 'x86_64'.

Signed-off-by: Amador Pahim <apahim@redhat.com>