### PR TITLE
Revert Test ID change

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -83,7 +83,7 @@ class TestID(object):
             self.str_variant = ""
         else:
             self.variant = variant["variant_id"]
-            self.str_variant = "+%s" % self.variant
+            self.str_variant = ";%s" % self.variant
 
     def __str__(self):
         return "%s-%s%s" % (self.str_uid, self.name, self.str_variant)
@@ -112,8 +112,8 @@ class TestID(object):
         value of this method.  If the filesystem can not even
         represent the "uid", than an exception will be raised.
 
-        For Test ID "001-mytest+foo", examples of shortened file
-        system versions include "001-mytest+f" or "001-myte+foo".
+        For Test ID "001-mytest;foo", examples of shortened file
+        system versions include "001-mytest;f" or "001-myte;foo".
 
         :raises: AssertionError
         """

--- a/docs/source/ReferenceGuide.rst
+++ b/docs/source/ReferenceGuide.rst
@@ -114,14 +114,14 @@ sets of Test IDs.
 
 Syntax::
 
-   <unique-id>-<test-name>[+<variant-id>]
+   <unique-id>-<test-name>[;<variant-id>]
 
 Example of Test IDs::
 
    '1-/bin/true'
-   '2-passtest.py:Passtest.test+quiet-'
+   '2-passtest.py:Passtest.test;quiet-'
    '3-file:///tmp/passtest.py:Passtest.test'
-   '4-multiple_tests.py:MultipleTests.test_hello+maximum_debug-df2f'
+   '4-multiple_tests.py:MultipleTests.test_hello;maximum_debug-df2f'
    '5-type_specific.io-github-autotest-qemu.systemtap_tracing.qemu.qemu_free'
 
 .. _test-types:

--- a/docs/source/Replay.rst
+++ b/docs/source/Replay.rst
@@ -41,10 +41,10 @@ mux YAML file::
      $ avocado run /bin/true /bin/false --mux-yaml mux-environment.yaml
      JOB ID     : bd6aa3b852d4290637b5e771b371537541043d1d
      JOB LOG    : $HOME/avocado/job-results/job-2016-01-11T21.56-bd6aa3b/job.log
-      (1/4) /bin/true+first-c49a: PASS (0.01 s)
-      (2/4) /bin/true+second-f05f: PASS (0.01 s)
-      (3/4) /bin/false+first-c49a: FAIL (0.04 s)
-      (4/4) /bin/false+second-f05f: FAIL (0.04 s)
+      (1/4) /bin/true;first-c49a: PASS (0.01 s)
+      (2/4) /bin/true;second-f05f: PASS (0.01 s)
+      (3/4) /bin/false;first-c49a: FAIL (0.04 s)
+      (4/4) /bin/false;second-f05f: FAIL (0.04 s)
      RESULTS    : PASS 2 | ERROR 0 | FAIL 2 | SKIP 0 | WARN 0 | INTERRUPT 0
      JOB TIME   : 0.19 s
      JOB HTML   : $HOME/avocado/job-results/job-2016-01-11T21.56-bd6aa3b/html/results.html
@@ -70,10 +70,10 @@ result, using the option ``--replay-test-status``. See the example below::
     JOB ID     : 2e1dc41af6ed64895f3bb45e3820c5cc62a9b6eb
     SRC JOB ID : bd6aa3b852d4290637b5e771b371537541043d1d
     JOB LOG    : $HOME/avocado/job-results/job-2016-01-12T00.38-2e1dc41/job.log
-     (1/4) /bin/true+first-c49a: SKIP
-     (2/4) /bin/true+second-f05f: SKIP
-     (3/4) /bin/false+first-c49a: FAIL (0.03 s)
-     (4/4) /bin/false+second-f05f: FAIL (0.04 s)
+     (1/4) /bin/true;first-c49a: SKIP
+     (2/4) /bin/true;second-f05f: SKIP
+     (3/4) /bin/false;first-c49a: FAIL (0.03 s)
+     (4/4) /bin/false;second-f05f: FAIL (0.04 s)
     RESULTS    : PASS 0 | ERROR 0 | FAIL 24 | SKIP 24 | WARN 0 | INTERRUPT 0
     JOB TIME   : 0.29 s
     JOB HTML   : $HOME/avocado/job-results/job-2016-01-12T00.38-2e1dc41/html/results.html

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -338,14 +338,14 @@ values). In total it'll produce 8 variants of each test::
       $ avocado run --mux-yaml examples/tests/sleeptenmin.py.data/sleeptenmin.yaml -- passtest.py
       JOB ID     : cc7ef22654c683b73174af6f97bc385da5a0f02f
       JOB LOG    : /home/medic/avocado/job-results/job-2017-01-22T11.26-cc7ef22/job.log
-       (1/8) passtest.py:PassTest.test+builtin-one_cycle-f659: PASS (0.01 s)
-       (2/8) passtest.py:PassTest.test+builtin-six_cycles-723b: PASS (0.01 s)
-       (3/8) passtest.py:PassTest.test+builtin-one_hundred_cycles-633a: PASS (0.01 s)
-       (4/8) passtest.py:PassTest.test+builtin-six_hundred_cycles-a570: PASS (0.01 s)
-       (5/8) passtest.py:PassTest.test+shell-one_cycle-55f5: PASS (0.01 s)
-       (6/8) passtest.py:PassTest.test+shell-six_cycles-9e23: PASS (0.01 s)
-       (7/8) passtest.py:PassTest.test+shell-one_hundred_cycles-586f: PASS (0.01 s)
-       (8/8) passtest.py:PassTest.test+shell-six_hundred_cycles-1e84: PASS (0.01 s)
+       (1/8) passtest.py:PassTest.test;builtin-one_cycle-f659: PASS (0.01 s)
+       (2/8) passtest.py:PassTest.test;builtin-six_cycles-723b: PASS (0.01 s)
+       (3/8) passtest.py:PassTest.test;builtin-one_hundred_cycles-633a: PASS (0.01 s)
+       (4/8) passtest.py:PassTest.test;builtin-six_hundred_cycles-a570: PASS (0.01 s)
+       (5/8) passtest.py:PassTest.test;shell-one_cycle-55f5: PASS (0.01 s)
+       (6/8) passtest.py:PassTest.test;shell-six_cycles-9e23: PASS (0.01 s)
+       (7/8) passtest.py:PassTest.test;shell-one_hundred_cycles-586f: PASS (0.01 s)
+       (8/8) passtest.py:PassTest.test;shell-six_hundred_cycles-1e84: PASS (0.01 s)
       RESULTS    : PASS 8 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0
       JOB TIME   : 0.16 s
 

--- a/docs/source/release_notes/54_0.rst
+++ b/docs/source/release_notes/54_0.rst
@@ -21,14 +21,6 @@ Users/Test Writers
   :mod:`unittest` users were waiting for to start running them with
   Avocado.
 
-* The Test ID format Avocado has been using for a while received a
-  minor tweak, to allow for better serialization into some filesystem
-  types, such as Microsoft Windows' ones.  Basically, the character
-  that precedes the variant name, a separator, used to be ``;``, which
-  is not allowed on some filesystems.  Now, a ``+`` character is used.
-  A Test ID ``sleeptest.py:SleepTest.test;short-beaf`` on a previous
-  Avocado version is now ``sleeptest.py:SleepTest.test+short-beaf``.
-
 * The full path of the filename that holds the currently running test
   is now output is the test log, under the heading ``Test metadata:``.
 

--- a/selftests/functional/test_multiplex.py
+++ b/selftests/functional/test_multiplex.py
@@ -105,9 +105,9 @@ class MultiplexTests(unittest.TestCase):
                     % (AVOCADO, self.tmpdir))
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         result = self.run_and_check(cmd_line, expected_rc, (4, 4))
-        self.assertIn("(1/8) passtest.py:PassTest.test+short", result.stdout)
-        self.assertIn("(2/8) passtest.py:PassTest.test+medium", result.stdout)
-        self.assertIn("(8/8) failtest.py:FailTest.test+longest",
+        self.assertIn("(1/8) passtest.py:PassTest.test;short", result.stdout)
+        self.assertIn("(2/8) passtest.py:PassTest.test;medium", result.stdout)
+        self.assertIn("(8/8) failtest.py:FailTest.test;longest",
                       result.stdout)
 
     def test_run_mplex_failtest_tests_per_variant(self):
@@ -118,9 +118,9 @@ class MultiplexTests(unittest.TestCase):
                     % (AVOCADO, self.tmpdir))
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         result = self.run_and_check(cmd_line, expected_rc, (4, 4))
-        self.assertIn("(1/8) passtest.py:PassTest.test+short", result.stdout)
-        self.assertIn("(2/8) failtest.py:FailTest.test+short", result.stdout)
-        self.assertIn("(8/8) failtest.py:FailTest.test+longest",
+        self.assertIn("(1/8) passtest.py:PassTest.test;short", result.stdout)
+        self.assertIn("(2/8) failtest.py:FailTest.test;short", result.stdout)
+        self.assertIn("(8/8) failtest.py:FailTest.test;longest",
                       result.stdout)
 
     def test_run_double_mplex(self):

--- a/selftests/functional/test_statuses.py
+++ b/selftests/functional/test_statuses.py
@@ -165,7 +165,7 @@ class TestStatuses(unittest.TestCase):
 
         # Testing each individual test results
         for test in self.results['tests']:
-            variant = test['id'].split('+')[1]
+            variant = test['id'].split(';')[1]
             expected = EXPECTED_RESULTS.get(variant, False)
             if not expected:
                 missing_tests.append(variant)
@@ -179,7 +179,7 @@ class TestStatuses(unittest.TestCase):
                          missing_msg)
 
     def _check_test(self, test, expected):
-        variant = test['id'].split('+')[1]
+        variant = test['id'].split(';')[1]
         self.assertEqual(expected[0], test['status'],
                          "Status error: '%s' != '%s' (%s)" %
                          (expected[0], test['status'], variant))

--- a/selftests/unit/test_remote.py
+++ b/selftests/unit/test_remote.py
@@ -9,7 +9,7 @@ import avocado_runner_remote
 
 
 JSON_RESULTS = ('Something other than json\n'
-                '{"tests": [{"test": "1-sleeptest+0",'
+                '{"tests": [{"test": "1-sleeptest;0",'
                 '"reference": "sleeptest", '
                 '"fail_reason": "None", '
                 '"status": "PASS", "time": 1.23, "start": 0, "end": 1.23}],'
@@ -44,7 +44,7 @@ class RemoteTestRunnerTest(unittest.TestCase):
         result_dispatcher.should_receive("map_method")
         job = flexmock(args=Args, log=log,
                        references=['/tests/sleeptest', '/tests/other/test',
-                                   'passtest'], unique_id='1-sleeptest+0',
+                                   'passtest'], unique_id='1-sleeptest;0',
                        logdir="/local/path",
                        _result_events_dispatcher=result_dispatcher)
 
@@ -56,7 +56,7 @@ class RemoteTestRunnerTest(unittest.TestCase):
         flexmock(logging).should_receive("FileHandler").and_return(filehandler)
 
         test_results = flexmock(stdout=JSON_RESULTS, exit_status=0)
-        stream = flexmock(job_unique_id='1-sleeptest+0',
+        stream = flexmock(job_unique_id='1-sleeptest;0',
                           debuglog='/local/path/dirname')
         Remote = flexmock()
         Remoter = flexmock(avocado_runner_remote.Remote)
@@ -95,7 +95,7 @@ _=/usr/bin/env''', exit_status=0)
          .with_args(args_version, ignore_status=True, timeout=60)
          .once().and_return(version_result))
 
-        args = ("avocado run --force-job-id 1-sleeptest+0 "
+        args = ("avocado run --force-job-id 1-sleeptest;0 "
                 "--json - --archive /tests/sleeptest /tests/other/test "
                 "passtest -m ~/avocado/tests/foo.yaml "
                 "~/avocado/tests/bar/baz.yaml --dry-run")
@@ -107,12 +107,12 @@ _=/usr/bin/env''', exit_status=0)
                           args=flexmock(show_job_log=False,
                                         mux_yaml=['foo.yaml', 'bar/baz.yaml'],
                                         dry_run=True))
-        args = {'name': '1-sleeptest+0', 'time_end': 1.23,
+        args = {'name': '1-sleeptest;0', 'time_end': 1.23,
                 'status': u'PASS', 'time_start': 0,
                 'time_elapsed': 1.23, 'job_unique_id': '',
                 'fail_reason': u'None',
-                'logdir': u'/local/path/test-results/1-sleeptest+0',
-                'logfile': u'/local/path/test-results/1-sleeptest+0/debug.log',
+                'logdir': u'/local/path/test-results/1-sleeptest;0',
+                'logfile': u'/local/path/test-results/1-sleeptest;0/debug.log',
                 'job_logdir': u'/local/path'}
         Result.should_receive('start_test').once().with_args(args).ordered()
         Result.should_receive('check_test').once().with_args(args).ordered()

--- a/selftests/unit/test_test.py
+++ b/selftests/unit/test_test.py
@@ -65,13 +65,13 @@ class TestClassTestUnit(unittest.TestCase):
 
         # Everything fits
         check(1, "a" * 253, None, "1-" + ("a" * 253))
-        check(2, "a" * 251, {"variant_id": 1}, "2-" + ("a" * 251) + "+1")
-        check(99, "a" * 249, {"variant_id": 88}, "99-" + ("a" * 249) + "+88")
+        check(2, "a" * 251, {"variant_id": 1}, "2-" + ("a" * 251) + ";1")
+        check(99, "a" * 249, {"variant_id": 88}, "99-" + ("a" * 249) + ";88")
         # Shrink name
-        check(3, "a" * 252, {"variant_id": 1}, "3-" + ('a' * 251) + "+1")
+        check(3, "a" * 252, {"variant_id": 1}, "3-" + ('a' * 251) + ";1")
         # Shrink variant
-        check("a" * 253, "whatever", {"variant_id": 99}, "a" * 253 + "+9")
-        check("a" * 254, "whatever", {"variant_id": 99}, "a" * 254 + "+")
+        check("a" * 253, "whatever", {"variant_id": 99}, "a" * 253 + ";9")
+        check("a" * 254, "whatever", {"variant_id": 99}, "a" * 254 + ";")
         # No variant
         tst = check("a" * 255, "whatever", {"variant_id": "whatever-else"},
                     "a" * 255)
@@ -316,9 +316,9 @@ class TestID(unittest.TestCase):
         variant = {'variant_id': variant_id}
         test_id = test.TestID(uid, name, variant=variant)
         self.assertEqual(test_id.uid, 1)
-        self.assertEqual(test_id.str_filesystem, '%s+%s' % (uid, variant_id[:253]))
+        self.assertEqual(test_id.str_filesystem, '%s;%s' % (uid, variant_id[:253]))
         self.assertIs(test_id.variant, variant_id)
-        self.assertEqual(test_id.str_variant, "+%s" % variant_id)
+        self.assertEqual(test_id.str_variant, ";%s" % variant_id)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
We changed the wrong character. We should have changed the colon (`:`), but we ended up changing the semi-colon (`;`).