### PR TITLE
Makefile: keep using Python 2, but fallback to Python 3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PYTHON=$(shell which python)
+PYTHON=$(shell which python 2>/dev/null || which python3 2>/dev/null)
 PYTHON_DEVELOP_ARGS=$(shell if ($(PYTHON) setup.py develop --help 2>/dev/null | grep -q '\-\-user'); then echo "--user"; else echo ""; fi)
 VERSION=$(shell $(PYTHON) setup.py --version 2>/dev/null)
 DESTDIR=/


### PR DESCRIPTION
This shouldn't change the experience for current users, but it
makes Makefile work on environments with Python 3 only.

Signed-off-by: Cleber Rosa <crosa@redhat.com>