### PR TITLE
Job: dry run usage fix

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -78,7 +78,8 @@ class Job(object):
         self.log = LOG_UI
         self.standalone = getattr(self.args, 'standalone', False)
         if getattr(self.args, "dry_run", False):  # Modify args for dry-run
-            if not self.args.unique_job_id:
+            unique_id = getattr(self.args, 'unique_job_id', None)
+            if unique_id is None:
                 self.args.unique_job_id = "0" * 40
             self.args.sysinfo = False
             if self.args.logdir is None:

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -152,6 +152,11 @@ class JobTest(unittest.TestCase):
         self.assertEqual(myjob.time_end, 20.0)
         self.assertEqual(myjob.time_elapsed, 100.0)
 
+    def test_job_dryrun_no_unique_job_id(self):
+        args = argparse.Namespace(dry_run=True, logdir=self.tmpdir)
+        empty_job = job.Job(args)
+        self.assertIsNotNone(empty_job.args.unique_job_id)
+
     def tearDown(self):
         data_dir._tmp_tracker.unittest_refresh_dir_tracker()
         shutil.rmtree(self.tmpdir)

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -4,6 +4,11 @@ import shutil
 import tempfile
 import unittest
 
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
 from avocado.core import data_dir
 from avocado.core import exceptions
 from avocado.core import exit_codes
@@ -156,6 +161,13 @@ class JobTest(unittest.TestCase):
         args = argparse.Namespace(dry_run=True, logdir=self.tmpdir)
         empty_job = job.Job(args)
         self.assertIsNotNone(empty_job.args.unique_job_id)
+
+    def test_job_no_logdir(self):
+        args = argparse.Namespace()
+        with mock.patch('avocado.core.job.data_dir.create_job_logs_dir',
+                        return_value=self.tmpdir):
+            empty_job = job.Job(args)
+            self.assertEqual(empty_job.logdir, self.tmpdir)
 
     def tearDown(self):
         data_dir._tmp_tracker.unittest_refresh_dir_tracker()


### PR DESCRIPTION
We already handle the lack of a unique_job_id in a job, but when using dry run, the check is not being done in a way that waives that requirement.

Also in this PR, an extra test for creating a job without an explicit `logdir`.