### PR TITLE
selftests/unit/test_remote.py: port from flexmock to mock

### DIFF
--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -154,40 +154,40 @@ def get_logs_dir():
                        SYSTEM_LOG_DIR, USER_LOG_DIR)
 
 
-def create_job_logs_dir(logdir=None, unique_id=None):
+def create_job_logs_dir(base_dir=None, unique_id=None):
     """
     Create a log directory for a job, or a stand alone execution of a test.
 
-    :param logdir: Base log directory, if `None`, use value from configuration.
+    :param base_dir: Base log directory, if `None`, use value from configuration.
     :param unique_id: The unique identification. If `None`, create one.
     :rtype: basestring
     """
     start_time = time.strftime('%Y-%m-%dT%H.%M')
-    if logdir is None:
-        logdir = get_logs_dir()
-    if not os.path.exists(logdir):
-        utils_path.init_dir(logdir)
+    if base_dir is None:
+        base_dir = get_logs_dir()
+    if not os.path.exists(base_dir):
+        utils_path.init_dir(base_dir)
     # Stand alone tests handling
     if unique_id is None:
         unique_id = job_id.create_unique_job_id()
 
-    debugdir = os.path.join(logdir, 'job-%s-%s' % (start_time, unique_id[:7]))
+    logdir = os.path.join(base_dir, 'job-%s-%s' % (start_time, unique_id[:7]))
     for i in xrange(7, len(unique_id)):
         try:
-            os.mkdir(debugdir)
+            os.mkdir(logdir)
         except OSError:
-            debugdir += unique_id[i]
+            logdir += unique_id[i]
             continue
-        return debugdir
-    debugdir += "."
+        return logdir
+    logdir += "."
     for i in xrange(1000):
         try:
-            os.mkdir(debugdir + str(i))
+            os.mkdir(logdir + str(i))
         except OSError:
             continue
-        return debugdir + str(i)
+        return logdir + str(i)
     raise IOError("Unable to create unique logdir in 1000 iterations: %s"
-                  % (debugdir))
+                  % (logdir))
 
 
 class _TmpDirTracker(Borg):

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -82,7 +82,8 @@ class Job(object):
             if unique_id is None:
                 self.args.unique_job_id = "0" * 40
             self.args.sysinfo = False
-            if self.args.base_logdir is None:
+            base_logdir = getattr(self.args, "base_logdir", None)
+            if base_logdir is None:
                 self.args.base_logdir = tempfile.mkdtemp(prefix="avocado-dry-run-")
 
         unique_id = getattr(self.args, 'unique_job_id', None)

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -81,8 +81,8 @@ class Job(object):
             if not self.args.unique_job_id:
                 self.args.unique_job_id = "0" * 40
             self.args.sysinfo = False
-            if self.args.logdir is None:
-                self.args.logdir = tempfile.mkdtemp(prefix="avocado-dry-run-")
+            if self.args.base_logdir is None:
+                self.args.base_logdir = tempfile.mkdtemp(prefix="avocado-dry-run-")
 
         unique_id = getattr(self.args, 'unique_job_id', None)
         if unique_id is None:
@@ -153,20 +153,20 @@ class Job(object):
         """
         Prepares a job result directory, also known as logdir, for this job
         """
-        logdir = getattr(self.args, 'logdir', None)
+        base_logdir = getattr(self.args, 'base_logdir', None)
         if self.standalone:
-            if logdir is not None:
-                logdir = os.path.abspath(logdir)
-                self.logdir = data_dir.create_job_logs_dir(logdir=logdir,
+            if base_logdir is not None:
+                base_logdir = os.path.abspath(base_logdir)
+                self.logdir = data_dir.create_job_logs_dir(base_dir=base_logdir,
                                                            unique_id=self.unique_id)
             else:
                 self.logdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
         else:
-            if logdir is None:
+            if base_logdir is None:
                 self.logdir = data_dir.create_job_logs_dir(unique_id=self.unique_id)
             else:
-                logdir = os.path.abspath(logdir)
-                self.logdir = data_dir.create_job_logs_dir(logdir=logdir,
+                base_logdir = os.path.abspath(base_logdir)
+                self.logdir = data_dir.create_job_logs_dir(base_dir=base_logdir,
                                                            unique_id=self.unique_id)
         if not (self.standalone or getattr(self.args, "dry_run", False)):
             self._update_latest_link()
@@ -558,7 +558,7 @@ class TestProgram(object):
         self.parser = argparse.ArgumentParser(prog=self.progName)
         self.parser.add_argument('-r', '--remove-test-results', action='store_true',
                                  help='remove all test results files after test execution')
-        self.parser.add_argument('-d', '--test-results-dir', dest='logdir', default=None,
+        self.parser.add_argument('-d', '--test-results-dir', dest='base_logdir', default=None,
                                  metavar='TEST_RESULTS_DIR',
                                  help='use an alternative test results directory')
         self.args = self.parser.parse_args(argv)

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -78,7 +78,8 @@ class Job(object):
         self.log = LOG_UI
         self.standalone = getattr(self.args, 'standalone', False)
         if getattr(self.args, "dry_run", False):  # Modify args for dry-run
-            if not self.args.unique_job_id:
+            unique_id = getattr(self.args, 'unique_job_id', None)
+            if unique_id is None:
                 self.args.unique_job_id = "0" * 40
             self.args.sysinfo = False
             if self.args.base_logdir is None:

--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -178,20 +178,19 @@ class Replay(CLI):
             LOG_UI.error(err)
             sys.exit(exit_codes.AVOCADO_FAIL)
 
-        if getattr(args, 'logdir', None) is not None:
-            logdir = args.logdir
-        else:
-            logdir = settings.get_value(section='datadir.paths',
-                                        key='logs_dir', key_type='path',
-                                        default=None)
+        base_logdir = getattr(args, 'base_logdir', None)
+        if base_logdir is None:
+            base_logdir = settings.get_value(section='datadir.paths',
+                                             key='logs_dir', key_type='path',
+                                             default=None)
         try:
-            resultsdir = jobdata.get_resultsdir(logdir, args.replay_jobid)
+            resultsdir = jobdata.get_resultsdir(base_logdir, args.replay_jobid)
         except ValueError as exception:
             LOG_UI.error(exception.message)
             sys.exit(exit_codes.AVOCADO_FAIL)
 
         if resultsdir is None:
-            LOG_UI.error("Can't find job results directory in '%s'", logdir)
+            LOG_UI.error("Can't find job results directory in '%s'", base_logdir)
             sys.exit(exit_codes.AVOCADO_FAIL)
 
         sourcejob = jobdata.get_id(os.path.join(resultsdir, 'id'),

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -65,7 +65,7 @@ class Run(CLICmd):
                             'unless you know exactly what you\'re doing')
 
         parser.add_argument('--job-results-dir', action='store',
-                            dest='logdir', default=None, metavar='DIRECTORY',
+                            dest='base_logdir', default=None, metavar='DIRECTORY',
                             help=('Forces to use of an alternate job '
                                   'results directory.'))
 

--- a/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/__init__.py
+++ b/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/__init__.py
@@ -413,12 +413,12 @@ class YamlToMux(mux.MuxPlugin, Varianter):
                 args.mux_filter_out = mux_filter_out + out
             else:
                 args.mux_filter_out = out
-        if args.avocado_variants.debug:
+
+        debug = getattr(args, "mux_debug", False)
+        if debug:
             data = mux.MuxTreeNodeDebug()
         else:
             data = mux.MuxTreeNode()
-
-        debug = getattr(args, "mux_debug", False)
 
         # Merge the multiplex
         multiplex_files = getattr(args, "mux_yaml", None)

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -4,6 +4,11 @@ import shutil
 import tempfile
 import unittest
 
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
 from avocado.core import data_dir
 from avocado.core import exceptions
 from avocado.core import exit_codes
@@ -156,6 +161,15 @@ class JobTest(unittest.TestCase):
         args = argparse.Namespace(dry_run=True, base_logdir=self.tmpdir)
         empty_job = job.Job(args)
         self.assertIsNotNone(empty_job.args.unique_job_id)
+
+    def test_job_no_base_logdir(self):
+        args = argparse.Namespace()
+        with mock.patch('avocado.core.job.data_dir.get_logs_dir',
+                        return_value=self.tmpdir):
+            empty_job = job.Job(args)
+        self.assertTrue(os.path.isdir(empty_job.logdir))
+        self.assertEqual(os.path.dirname(empty_job.logdir), self.tmpdir)
+        self.assertTrue(os.path.isfile(os.path.join(empty_job.logdir, 'id')))
 
     def tearDown(self):
         data_dir._tmp_tracker.unittest_refresh_dir_tracker()

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -29,22 +29,22 @@ class JobTest(unittest.TestCase):
         return found
 
     def test_job_empty_suite(self):
-        args = argparse.Namespace(logdir=self.tmpdir)
+        args = argparse.Namespace(base_logdir=self.tmpdir)
         empty_job = job.Job(args)
         self.assertIsNone(empty_job.test_suite)
 
     def test_job_empty_has_id(self):
-        args = argparse.Namespace(logdir=self.tmpdir)
+        args = argparse.Namespace(base_logdir=self.tmpdir)
         empty_job = job.Job(args)
         self.assertIsNotNone(empty_job.unique_id)
 
     def test_job_test_suite_not_created(self):
-        args = argparse.Namespace(logdir=self.tmpdir)
+        args = argparse.Namespace(base_logdir=self.tmpdir)
         myjob = job.Job(args)
         self.assertIsNone(myjob.test_suite)
 
     def test_job_create_test_suite_empty(self):
-        args = argparse.Namespace(logdir=self.tmpdir)
+        args = argparse.Namespace(base_logdir=self.tmpdir)
         myjob = job.Job(args)
         self.assertRaises(exceptions.OptionValidationError,
                           myjob.create_test_suite)
@@ -52,7 +52,7 @@ class JobTest(unittest.TestCase):
     def test_job_create_test_suite_simple(self):
         simple_tests_found = self._find_simple_test_candidates()
         args = argparse.Namespace(reference=simple_tests_found,
-                                  logdir=self.tmpdir)
+                                  base_logdir=self.tmpdir)
         myjob = job.Job(args)
         myjob.create_test_suite()
         self.assertEqual(len(simple_tests_found), len(myjob.test_suite))
@@ -69,7 +69,7 @@ class JobTest(unittest.TestCase):
                 super(JobFilterTime, self).pre_tests()
         simple_tests_found = self._find_simple_test_candidates()
         args = argparse.Namespace(reference=simple_tests_found,
-                                  logdir=self.tmpdir)
+                                  base_logdir=self.tmpdir)
         myjob = JobFilterTime(args)
         myjob.create_test_suite()
         try:
@@ -81,7 +81,7 @@ class JobTest(unittest.TestCase):
     def test_job_run_tests(self):
         simple_tests_found = self._find_simple_test_candidates(['true'])
         args = argparse.Namespace(reference=simple_tests_found,
-                                  logdir=self.tmpdir)
+                                  base_logdir=self.tmpdir)
         myjob = job.Job(args)
         myjob.create_test_suite()
         self.assertEqual(myjob.run_tests(),
@@ -95,7 +95,7 @@ class JobTest(unittest.TestCase):
                 super(JobLogPost, self).post_tests()
         simple_tests_found = self._find_simple_test_candidates()
         args = argparse.Namespace(reference=simple_tests_found,
-                                  logdir=self.tmpdir)
+                                  base_logdir=self.tmpdir)
         myjob = JobLogPost(args)
         myjob.create_test_suite()
         try:
@@ -123,7 +123,7 @@ class JobTest(unittest.TestCase):
                 super(JobFilterLog, self).post_tests()
         simple_tests_found = self._find_simple_test_candidates()
         args = argparse.Namespace(reference=simple_tests_found,
-                                  logdir=self.tmpdir)
+                                  base_logdir=self.tmpdir)
         myjob = JobFilterLog(args)
         self.assertEqual(myjob.run(),
                          exit_codes.AVOCADO_ALL_OK)
@@ -132,7 +132,7 @@ class JobTest(unittest.TestCase):
                          open(os.path.join(myjob.logdir, "reversed_id")).read())
 
     def test_job_run_account_time(self):
-        args = argparse.Namespace(logdir=self.tmpdir)
+        args = argparse.Namespace(base_logdir=self.tmpdir)
         myjob = job.Job(args)
         myjob.run()
         self.assertNotEqual(myjob.time_start, -1)
@@ -140,7 +140,7 @@ class JobTest(unittest.TestCase):
         self.assertNotEqual(myjob.time_elapsed, -1)
 
     def test_job_self_account_time(self):
-        args = argparse.Namespace(logdir=self.tmpdir)
+        args = argparse.Namespace(base_logdir=self.tmpdir)
         myjob = job.Job(args)
         myjob.time_start = 10.0
         myjob.run()

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -171,6 +171,13 @@ class JobTest(unittest.TestCase):
         self.assertEqual(os.path.dirname(empty_job.logdir), self.tmpdir)
         self.assertTrue(os.path.isfile(os.path.join(empty_job.logdir, 'id')))
 
+    def test_job_dryrun_no_base_logdir(self):
+        args = argparse.Namespace(dry_run=True)
+        empty_job = job.Job(args)
+        self.assertTrue(os.path.isdir(empty_job.logdir))
+        self.assertTrue(os.path.isfile(os.path.join(empty_job.logdir, 'id')))
+        shutil.rmtree(empty_job.args.base_logdir)
+
     def tearDown(self):
         data_dir._tmp_tracker.unittest_refresh_dir_tracker()
         shutil.rmtree(self.tmpdir)

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -152,6 +152,11 @@ class JobTest(unittest.TestCase):
         self.assertEqual(myjob.time_end, 20.0)
         self.assertEqual(myjob.time_elapsed, 100.0)
 
+    def test_job_dryrun_no_unique_job_id(self):
+        args = argparse.Namespace(dry_run=True, base_logdir=self.tmpdir)
+        empty_job = job.Job(args)
+        self.assertIsNotNone(empty_job.args.unique_job_id)
+
     def tearDown(self):
         data_dir._tmp_tracker.unittest_refresh_dir_tracker()
         shutil.rmtree(self.tmpdir)

--- a/selftests/unit/test_jsonresult.py
+++ b/selftests/unit/test_jsonresult.py
@@ -30,7 +30,7 @@ class JSONResultTest(unittest.TestCase):
         self.tmpfile = tempfile.mkstemp()
         self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
         args = argparse.Namespace(json_output=self.tmpfile[1],
-                                  logdir=self.tmpdir)
+                                  base_logdir=self.tmpdir)
         self.job = job.Job(args)
         self.test_result = Result(FakeJob(args))
         self.test_result.filename = self.tmpfile[1]

--- a/selftests/unit/test_remote.py
+++ b/selftests/unit/test_remote.py
@@ -1,10 +1,15 @@
-import logging
-import os
+import argparse
+import shutil
 import unittest
 
-from flexmock import flexmock, flexmock_teardown
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
-from avocado.utils import archive
+from avocado.core.job import Job
+from avocado.core import version
+from avocado.utils import process
 import avocado_runner_remote
 
 
@@ -25,154 +30,71 @@ class RemoteTestRunnerTest(unittest.TestCase):
 
     """ Tests RemoteTestRunner """
 
-    def setUp(self):
-        Args = flexmock(test_result_total=1,
-                        remote_username='username',
-                        remote_hostname='hostname',
-                        remote_port=22,
-                        remote_password='password',
-                        remote_key_file=None,
-                        remote_timeout=60,
-                        show_job_log=False,
-                        mux_yaml=['~/avocado/tests/foo.yaml',
-                                  '~/avocado/tests/bar/baz.yaml'],
-                        dry_run=True,
-                        env_keep=None)
-        log = flexmock()
-        log.should_receive("info")
-        result_dispatcher = flexmock()
-        result_dispatcher.should_receive("map_method")
-        job = flexmock(args=Args, log=log,
-                       references=['/tests/sleeptest', '/tests/other/test',
-                                   'passtest'], unique_id='1-sleeptest;0',
-                       logdir="/local/path",
-                       _result_events_dispatcher=result_dispatcher)
-
-        flexmock(avocado_runner_remote.RemoteTestRunner).should_receive('__init__')
-        self.runner = avocado_runner_remote.RemoteTestRunner(job, None)
-        self.runner.job = job
-
-        filehandler = logging.StreamHandler()
-        flexmock(logging).should_receive("FileHandler").and_return(filehandler)
-
-        test_results = flexmock(stdout=JSON_RESULTS, exit_status=0)
-        stream = flexmock(job_unique_id='1-sleeptest;0',
-                          debuglog='/local/path/dirname')
-        Remote = flexmock()
-        Remoter = flexmock(avocado_runner_remote.Remote)
-        Remoter.new_instances(Remote)
-        args_version = 'avocado -v'
-        version_result = flexmock(stderr='Avocado 1.2', exit_status=0)
-        args_env = 'env'
-        env_result = flexmock(stdout='''XDG_SESSION_ID=20
-HOSTNAME=rhel7.0
-SELINUX_ROLE_REQUESTED=
-SHELL=/bin/bash
-TERM=vt100
-HISTSIZE=1000
-SSH_CLIENT=192.168.124.1 52948 22
-SELINUX_USE_CURRENT_RANGE=
-SSH_TTY=/dev/pts/0
-USER=root
-PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin
-MAIL=/var/spool/mail/root
-PWD=/root
-LANG=en_US.UTF-8
-SELINUX_LEVEL_REQUESTED=
-HISTCONTROL=ignoredups
-HOME=/root
-SHLVL=2
-LOGNAME=root
-SSH_CONNECTION=192.168.124.1 52948 192.168.124.65 22
-LESSOPEN=||/usr/bin/lesspipe.sh %s
-XDG_RUNTIME_DIR=/run/user/0
-_=/usr/bin/env''', exit_status=0)
-        (Remote.should_receive('run')
-         .with_args(args_env, ignore_status=True, timeout=60)
-         .once().and_return(env_result))
-
-        (Remote.should_receive('run')
-         .with_args(args_version, ignore_status=True, timeout=60)
-         .once().and_return(version_result))
-
-        args = ("avocado run --force-job-id 1-sleeptest;0 "
-                "--json - --archive /tests/sleeptest /tests/other/test "
-                "passtest -m ~/avocado/tests/foo.yaml "
-                "~/avocado/tests/bar/baz.yaml --dry-run")
-        (Remote.should_receive('run')
-         .with_args(args, timeout=61, ignore_status=True)
-         .once().and_return(test_results))
-        Result = flexmock(remote=Remote, references=['sleeptest'],
-                          stream=stream, timeout=None,
-                          args=flexmock(show_job_log=False,
-                                        mux_yaml=['foo.yaml', 'bar/baz.yaml'],
-                                        dry_run=True))
-        args = {'name': '1-sleeptest;0', 'time_end': 1.23,
-                'status': u'PASS', 'time_start': 0,
-                'time_elapsed': 1.23, 'job_unique_id': '',
-                'fail_reason': u'None',
-                'logdir': u'/local/path/test-results/1-sleeptest;0',
-                'logfile': u'/local/path/test-results/1-sleeptest;0/debug.log',
-                'job_logdir': u'/local/path'}
-        Result.should_receive('start_test').once().with_args(args).ordered()
-        Result.should_receive('check_test').once().with_args(args).ordered()
-        (Remote.should_receive('receive_files')
-         .with_args('/local/path', '/home/user/avocado/logs/run-2014-05-26-'
-                    '15.45.37.zip')).once().ordered()
-        (flexmock(archive).should_receive('uncompress')
-         .with_args('/local/path/run-2014-05-26-15.45.37.zip', '/local/path')
-         .once().ordered())
-        (flexmock(os).should_receive('remove')
-         .with_args('/local/path/run-2014-05-26-15.45.37.zip').once()
-         .ordered())
-        Result.should_receive('end_tests').once().ordered()
-        self.runner.result = Result
-
-    def tearDown(self):
-        flexmock_teardown()
-
     def test_run_suite(self):
-        """ Test RemoteTestRunner.run_suite() """
-        self.runner.run_suite(None, None, 61)
-        flexmock_teardown()  # Checks the expectations
+        """
+        Test RemoteTestRunner.run_suite()
 
+        The general idea of this test is to:
 
-class RemoteTestRunnerSetup(unittest.TestCase):
+        1) Create the machinery necessary to get a RemoteTestRunner
+           setup inside a job, or looking at it the other way around, to
+           have a runner that is created with a valid job.
 
-    """ Tests the RemoteTestRunner setup() method"""
+        2) Mock the interactions with a remote host.  This is done here
+           basically by mocking 'Remote' and 'fabric' usage.
 
-    def setUp(self):
-        Remote = flexmock()
-        remote_remote = flexmock(avocado_runner_remote)
-        (remote_remote.should_receive('Remote')
-         .with_args(hostname='hostname', username='username',
-                    password='password', key_filename=None, port=22,
-                    timeout=60, env_keep=None)
-         .once().ordered()
-         .and_return(Remote))
-        Args = flexmock(test_result_total=1,
-                        reference=['/tests/sleeptest', '/tests/other/test',
-                                   'passtest'],
-                        remote_username='username',
-                        remote_hostname='hostname',
-                        remote_port=22,
-                        remote_password='password',
-                        remote_key_file=None,
-                        remote_timeout=60,
-                        show_job_log=False,
-                        env_keep=None)
-        log = flexmock()
-        log.should_receive("info")
-        job = flexmock(args=Args, log=log)
-        self.runner = avocado_runner_remote.RemoteTestRunner(job, None)
+        3) Provide a polluted JSON to be parsed by the RemoteTestRunner
 
-    def tearDown(self):
-        flexmock_teardown()
+        4) Assert that those results are properly parsed into the
+           job's result
+        """
+        job_args = argparse.Namespace(test_result_total=1,
+                                      remote_username='username',
+                                      remote_hostname='hostname',
+                                      remote_port=22,
+                                      remote_password='password',
+                                      remote_key_file=None,
+                                      remote_timeout=60,
+                                      show_job_log=False,
+                                      mux_yaml=['~/avocado/tests/foo.yaml',
+                                                '~/avocado/tests/bar/baz.yaml'],
+                                      dry_run=True,
+                                      env_keep=None,
+                                      reference=['/tests/sleeptest.py',
+                                                 '/tests/other/test',
+                                                 'passtest.py'])
 
-    def test_setup(self):
-        """ Tests RemoteResult.test_setup() """
-        self.runner.setup()
-        flexmock_teardown()
+        job = Job(job_args)
+        runner = avocado_runner_remote.RemoteTestRunner(job, job.result)
+        runner.check_remote_avocado = mock.Mock(return_value=(True,
+                                                              (version.MAJOR,
+                                                               version.MINOR)))
+
+        # These are mocked at their source, and will prevent fabric from
+        # trying to contact remote hosts
+        with mock.patch('avocado_runner_remote.Remote'):
+            with mock.patch('avocado_runner_remote.fabric'):
+                runner.remote = avocado_runner_remote.Remote(job_args.remote_hostname)
+
+            # This is the result that the run_suite() will get from remote.run
+            remote_run_result = process.CmdResult()
+            remote_run_result.stdout = JSON_RESULTS
+            remote_run_result.exit_status = 0
+            runner.remote.run = mock.Mock(return_value=remote_run_result)
+
+            # We have to fake the uncompressing and removal of the zip
+            # archive that was never generated on the "remote" end
+            # This test could be expand by mocking creating an actual
+            # zip file instead, but it's really overkill
+            with mock.patch('avocado_runner_remote.archive.uncompress'):
+                with mock.patch('avocado_runner_remote.os.remove'):
+                    runner.run_suite(None, None, 61)
+
+        # The job was created with dry_run so it should have a zeroed id
+        self.assertEqual(job.result.job_unique_id, '0' * 40)
+        self.assertEqual(job.result.tests_run, 1)
+        self.assertEqual(job.result.passed, 1)
+        shutil.rmtree(job.args.base_logdir)
 
 
 if __name__ == '__main__':

--- a/selftests/unit/test_xunit.py
+++ b/selftests/unit/test_xunit.py
@@ -39,7 +39,7 @@ class xUnitSucceedTest(unittest.TestCase):
 
         self.tmpfile = tempfile.mkstemp()
         self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
-        args = argparse.Namespace(logdir=self.tmpdir)
+        args = argparse.Namespace(base_logdir=self.tmpdir)
         args.xunit_output = self.tmpfile[1]
         self.job = job.Job(args)
         self.test_result = Result(FakeJob(args))


### PR DESCRIPTION
This is a port to the mock library that is in the standard in Python 3, and it's available in Python 2, and already a requirement for Avocado.

The approach used on this port is to avoid excessive mocking, and use the real code, unless when insteracting with dynamic and non-existing components (such as a remote system).

**IMPORTANT**: this PR is based on top of `job_base_logdir`, which are independent fixes (and should be reviewed in PR #2222), but that are also required here.