### PR TITLE
Drop flexmock requirement

### DIFF
--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -154,40 +154,40 @@ def get_logs_dir():
                        SYSTEM_LOG_DIR, USER_LOG_DIR)
 
 
-def create_job_logs_dir(logdir=None, unique_id=None):
+def create_job_logs_dir(base_dir=None, unique_id=None):
     """
     Create a log directory for a job, or a stand alone execution of a test.
 
-    :param logdir: Base log directory, if `None`, use value from configuration.
+    :param base_dir: Base log directory, if `None`, use value from configuration.
     :param unique_id: The unique identification. If `None`, create one.
     :rtype: basestring
     """
     start_time = time.strftime('%Y-%m-%dT%H.%M')
-    if logdir is None:
-        logdir = get_logs_dir()
-    if not os.path.exists(logdir):
-        utils_path.init_dir(logdir)
+    if base_dir is None:
+        base_dir = get_logs_dir()
+    if not os.path.exists(base_dir):
+        utils_path.init_dir(base_dir)
     # Stand alone tests handling
     if unique_id is None:
         unique_id = job_id.create_unique_job_id()
 
-    debugdir = os.path.join(logdir, 'job-%s-%s' % (start_time, unique_id[:7]))
+    logdir = os.path.join(base_dir, 'job-%s-%s' % (start_time, unique_id[:7]))
     for i in xrange(7, len(unique_id)):
         try:
-            os.mkdir(debugdir)
+            os.mkdir(logdir)
         except OSError:
-            debugdir += unique_id[i]
+            logdir += unique_id[i]
             continue
-        return debugdir
-    debugdir += "."
+        return logdir
+    logdir += "."
     for i in xrange(1000):
         try:
-            os.mkdir(debugdir + str(i))
+            os.mkdir(logdir + str(i))
         except OSError:
             continue
-        return debugdir + str(i)
+        return logdir + str(i)
     raise IOError("Unable to create unique logdir in 1000 iterations: %s"
-                  % (debugdir))
+                  % (logdir))
 
 
 class _TmpDirTracker(Borg):

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -82,7 +82,8 @@ class Job(object):
             if unique_id is None:
                 self.args.unique_job_id = "0" * 40
             self.args.sysinfo = False
-            if self.args.base_logdir is None:
+            base_logdir = getattr(self.args, "base_logdir", None)
+            if base_logdir is None:
                 self.args.base_logdir = tempfile.mkdtemp(prefix="avocado-dry-run-")
 
         unique_id = getattr(self.args, 'unique_job_id', None)

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -81,8 +81,8 @@ class Job(object):
             if not self.args.unique_job_id:
                 self.args.unique_job_id = "0" * 40
             self.args.sysinfo = False
-            if self.args.logdir is None:
-                self.args.logdir = tempfile.mkdtemp(prefix="avocado-dry-run-")
+            if self.args.base_logdir is None:
+                self.args.base_logdir = tempfile.mkdtemp(prefix="avocado-dry-run-")
 
         unique_id = getattr(self.args, 'unique_job_id', None)
         if unique_id is None:
@@ -153,20 +153,20 @@ class Job(object):
         """
         Prepares a job result directory, also known as logdir, for this job
         """
-        logdir = getattr(self.args, 'logdir', None)
+        base_logdir = getattr(self.args, 'base_logdir', None)
         if self.standalone:
-            if logdir is not None:
-                logdir = os.path.abspath(logdir)
-                self.logdir = data_dir.create_job_logs_dir(logdir=logdir,
+            if base_logdir is not None:
+                base_logdir = os.path.abspath(base_logdir)
+                self.logdir = data_dir.create_job_logs_dir(base_dir=base_logdir,
                                                            unique_id=self.unique_id)
             else:
                 self.logdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
         else:
-            if logdir is None:
+            if base_logdir is None:
                 self.logdir = data_dir.create_job_logs_dir(unique_id=self.unique_id)
             else:
-                logdir = os.path.abspath(logdir)
-                self.logdir = data_dir.create_job_logs_dir(logdir=logdir,
+                base_logdir = os.path.abspath(base_logdir)
+                self.logdir = data_dir.create_job_logs_dir(base_dir=base_logdir,
                                                            unique_id=self.unique_id)
         if not (self.standalone or getattr(self.args, "dry_run", False)):
             self._update_latest_link()
@@ -558,7 +558,7 @@ class TestProgram(object):
         self.parser = argparse.ArgumentParser(prog=self.progName)
         self.parser.add_argument('-r', '--remove-test-results', action='store_true',
                                  help='remove all test results files after test execution')
-        self.parser.add_argument('-d', '--test-results-dir', dest='logdir', default=None,
+        self.parser.add_argument('-d', '--test-results-dir', dest='base_logdir', default=None,
                                  metavar='TEST_RESULTS_DIR',
                                  help='use an alternative test results directory')
         self.args = self.parser.parse_args(argv)

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -78,7 +78,8 @@ class Job(object):
         self.log = LOG_UI
         self.standalone = getattr(self.args, 'standalone', False)
         if getattr(self.args, "dry_run", False):  # Modify args for dry-run
-            if not self.args.unique_job_id:
+            unique_id = getattr(self.args, 'unique_job_id', None)
+            if unique_id is None:
                 self.args.unique_job_id = "0" * 40
             self.args.sysinfo = False
             if self.args.base_logdir is None:

--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -178,20 +178,19 @@ class Replay(CLI):
             LOG_UI.error(err)
             sys.exit(exit_codes.AVOCADO_FAIL)
 
-        if getattr(args, 'logdir', None) is not None:
-            logdir = args.logdir
-        else:
-            logdir = settings.get_value(section='datadir.paths',
-                                        key='logs_dir', key_type='path',
-                                        default=None)
+        base_logdir = getattr(args, 'base_logdir', None)
+        if base_logdir is None:
+            base_logdir = settings.get_value(section='datadir.paths',
+                                             key='logs_dir', key_type='path',
+                                             default=None)
         try:
-            resultsdir = jobdata.get_resultsdir(logdir, args.replay_jobid)
+            resultsdir = jobdata.get_resultsdir(base_logdir, args.replay_jobid)
         except ValueError as exception:
             LOG_UI.error(exception.message)
             sys.exit(exit_codes.AVOCADO_FAIL)
 
         if resultsdir is None:
-            LOG_UI.error("Can't find job results directory in '%s'", logdir)
+            LOG_UI.error("Can't find job results directory in '%s'", base_logdir)
             sys.exit(exit_codes.AVOCADO_FAIL)
 
         sourcejob = jobdata.get_id(os.path.join(resultsdir, 'id'),

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -65,7 +65,7 @@ class Run(CLICmd):
                             'unless you know exactly what you\'re doing')
 
         parser.add_argument('--job-results-dir', action='store',
-                            dest='logdir', default=None, metavar='DIRECTORY',
+                            dest='base_logdir', default=None, metavar='DIRECTORY',
                             help=('Forces to use of an alternate job '
                                   'results directory.'))
 

--- a/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
+++ b/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
@@ -317,7 +317,7 @@ class RemoteTestRunner(TestRunner):
         self.remote = None
 
     def setup(self):
-        """ Setup remote environment and copy test directories """
+        """ Setup remote environment """
         stdout_claimed_by = getattr(self.job.args, 'stdout_claimed_by', None)
         if not stdout_claimed_by:
             self.job.log.info("LOGIN      : %s@%s:%d (TIMEOUT: %s seconds)",

--- a/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/__init__.py
+++ b/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/__init__.py
@@ -413,12 +413,12 @@ class YamlToMux(mux.MuxPlugin, Varianter):
                 args.mux_filter_out = mux_filter_out + out
             else:
                 args.mux_filter_out = out
-        if args.avocado_variants.debug:
+
+        debug = getattr(args, "mux_debug", False)
+        if debug:
             data = mux.MuxTreeNodeDebug()
         else:
             data = mux.MuxTreeNode()
-
-        debug = getattr(args, "mux_debug", False)
 
         # Merge the multiplex
         multiplex_files = getattr(args, "mux_yaml", None)

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -29,7 +29,7 @@
 Summary: Framework with tools and libraries for Automated Testing
 Name: python-%{srcname}
 Version: 54.1
-Release: 0%{?gitrel}%{?dist}
+Release: 1%{?gitrel}%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.github.io/
@@ -43,7 +43,6 @@ BuildRequires: fabric
 BuildRequires: procps-ng
 BuildRequires: pystache
 BuildRequires: python-docutils
-BuildRequires: python-flexmock
 BuildRequires: python-lxml
 BuildRequires: python-mock
 BuildRequires: python-psutil
@@ -369,6 +368,9 @@ examples of how to write tests on your own.
 %{_datadir}/avocado/yaml_to_mux_loader
 
 %changelog
+* Tue Sep 26 2017 Cleber Rosa <cleber@redhat.com> - 54.1-1
+- Remove python-flexmock requirement
+
 * Wed Sep 20 2017 Cleber Rosa <cleber@redhat.com> - 54.1-0
 - New minor upstream release
 

--- a/requirements-selftests.txt
+++ b/requirements-selftests.txt
@@ -3,8 +3,6 @@
 setuptools>=18.0.0
 # sphinx (doc build test)
 Sphinx>=1.3b1
-# flexmock (some unittests use it)
-flexmock>=0.9.7
 # inspektor (static and style checks)
 inspektor>=0.4.5
 # mock (some unittests use it)

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,7 +1,6 @@
 # All pip installable requirements pinned for Travis CI
 fabric==1.11.1
 Sphinx==1.3b1
-flexmock==0.9.7
 inspektor==0.4.5
 pep8==1.6.2
 requests==1.2.3

--- a/selftests/unit/test_datadir.py
+++ b/selftests/unit/test_datadir.py
@@ -63,20 +63,21 @@ class DataDirTest(unittest.TestCase):
         unique results.
         """
         from avocado.core import data_dir
-        flexmock(data_dir.time).should_receive('strftime').and_return("date")
-        logdir = os.path.join(self.mapping['base_dir'], "foor", "bar", "baz")
-        path_prefix = os.path.join(logdir, "job-date-")
-        uid = "1234567890"*4
-        for i in xrange(7, 40):
+        with mock.patch('avocado.core.data_dir.time.strftime',
+                        return_value="date_would_go_here"):
+            logdir = os.path.join(self.mapping['base_dir'], "foor", "bar", "baz")
+            path_prefix = os.path.join(logdir, "job-date_would_go_here-")
+            uid = "1234567890"*4
+            for i in xrange(7, 40):
+                path = data_dir.create_job_logs_dir(logdir, uid)
+                self.assertEqual(path, path_prefix + uid[:i])
+                self.assertTrue(os.path.exists(path))
             path = data_dir.create_job_logs_dir(logdir, uid)
-            self.assertEqual(path, path_prefix + uid[:i])
+            self.assertEqual(path, path_prefix + uid + ".0")
             self.assertTrue(os.path.exists(path))
-        path = data_dir.create_job_logs_dir(logdir, uid)
-        self.assertEqual(path, path_prefix + uid + ".0")
-        self.assertTrue(os.path.exists(path))
-        path = data_dir.create_job_logs_dir(logdir, uid)
-        self.assertEqual(path, path_prefix + uid + ".1")
-        self.assertTrue(os.path.exists(path))
+            path = data_dir.create_job_logs_dir(logdir, uid)
+            self.assertEqual(path, path_prefix + uid + ".1")
+            self.assertTrue(os.path.exists(path))
 
     def test_settings_dir_alternate_dynamic(self):
         """

--- a/selftests/unit/test_datadir.py
+++ b/selftests/unit/test_datadir.py
@@ -7,7 +7,6 @@ try:
     from unittest import mock
 except ImportError:
     import mock
-from flexmock import flexmock
 
 from avocado.core import settings
 
@@ -90,17 +89,15 @@ class DataDirTest(unittest.TestCase):
         No data_dir module reload should be necessary to get the new locations
         from data_dir APIs.
         """
-        stg_orig = settings.settings
-        from avocado.core import data_dir
         (self.alt_mapping,
          self.alt_config_file_path) = self._get_temporary_dirs_mapping_and_config()
         stg = settings.Settings(self.alt_config_file_path)
-        flexmock(settings, settings=stg)
-        for key in self.alt_mapping.keys():
-            data_dir_func = getattr(data_dir, 'get_%s' % key)
-            self.assertEqual(data_dir_func(), self.alt_mapping[key])
-        flexmock(settings, settings=stg_orig)
-        del data_dir
+        with mock.patch('avocado.core.data_dir.settings.settings', stg):
+            from avocado.core import data_dir
+            for key in self.alt_mapping.keys():
+                data_dir_func = getattr(data_dir, 'get_%s' % key)
+                self.assertEqual(data_dir_func(), self.alt_mapping[key])
+            del data_dir
 
     def tearDown(self):
         os.unlink(self.config_file_path)

--- a/selftests/unit/test_distro.py
+++ b/selftests/unit/test_distro.py
@@ -1,8 +1,10 @@
-import os
 import re
 import unittest
 
-from flexmock import flexmock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from avocado.utils import distro
 
@@ -64,10 +66,11 @@ class ProbeTest(unittest.TestCase):
             CHECK_FILE = distro_file
             CHECK_FILE_DISTRO_NAME = distro_name
 
-        flexmock(os.path)
-        os.path.should_receive('exists').and_return(True)
         my_probe = MyProbe()
-        probed_distro_name = my_probe.name_for_file()
+        with mock.patch('avocado.utils.distro.os.path.exists',
+                        return_value=True) as mocked:
+            probed_distro_name = my_probe.name_for_file()
+            mocked.assert_called_once_with(distro_file)
         self.assertEqual(distro_name, probed_distro_name)
 
 

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -4,6 +4,11 @@ import shutil
 import tempfile
 import unittest
 
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
 from avocado.core import data_dir
 from avocado.core import exceptions
 from avocado.core import exit_codes
@@ -156,6 +161,15 @@ class JobTest(unittest.TestCase):
         args = argparse.Namespace(dry_run=True, base_logdir=self.tmpdir)
         empty_job = job.Job(args)
         self.assertIsNotNone(empty_job.args.unique_job_id)
+
+    def test_job_no_base_logdir(self):
+        args = argparse.Namespace()
+        with mock.patch('avocado.core.job.data_dir.get_logs_dir',
+                        return_value=self.tmpdir):
+            empty_job = job.Job(args)
+        self.assertTrue(os.path.isdir(empty_job.logdir))
+        self.assertEqual(os.path.dirname(empty_job.logdir), self.tmpdir)
+        self.assertTrue(os.path.isfile(os.path.join(empty_job.logdir, 'id')))
 
     def tearDown(self):
         data_dir._tmp_tracker.unittest_refresh_dir_tracker()

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -29,22 +29,22 @@ class JobTest(unittest.TestCase):
         return found
 
     def test_job_empty_suite(self):
-        args = argparse.Namespace(logdir=self.tmpdir)
+        args = argparse.Namespace(base_logdir=self.tmpdir)
         empty_job = job.Job(args)
         self.assertIsNone(empty_job.test_suite)
 
     def test_job_empty_has_id(self):
-        args = argparse.Namespace(logdir=self.tmpdir)
+        args = argparse.Namespace(base_logdir=self.tmpdir)
         empty_job = job.Job(args)
         self.assertIsNotNone(empty_job.unique_id)
 
     def test_job_test_suite_not_created(self):
-        args = argparse.Namespace(logdir=self.tmpdir)
+        args = argparse.Namespace(base_logdir=self.tmpdir)
         myjob = job.Job(args)
         self.assertIsNone(myjob.test_suite)
 
     def test_job_create_test_suite_empty(self):
-        args = argparse.Namespace(logdir=self.tmpdir)
+        args = argparse.Namespace(base_logdir=self.tmpdir)
         myjob = job.Job(args)
         self.assertRaises(exceptions.OptionValidationError,
                           myjob.create_test_suite)
@@ -52,7 +52,7 @@ class JobTest(unittest.TestCase):
     def test_job_create_test_suite_simple(self):
         simple_tests_found = self._find_simple_test_candidates()
         args = argparse.Namespace(reference=simple_tests_found,
-                                  logdir=self.tmpdir)
+                                  base_logdir=self.tmpdir)
         myjob = job.Job(args)
         myjob.create_test_suite()
         self.assertEqual(len(simple_tests_found), len(myjob.test_suite))
@@ -69,7 +69,7 @@ class JobTest(unittest.TestCase):
                 super(JobFilterTime, self).pre_tests()
         simple_tests_found = self._find_simple_test_candidates()
         args = argparse.Namespace(reference=simple_tests_found,
-                                  logdir=self.tmpdir)
+                                  base_logdir=self.tmpdir)
         myjob = JobFilterTime(args)
         myjob.create_test_suite()
         try:
@@ -81,7 +81,7 @@ class JobTest(unittest.TestCase):
     def test_job_run_tests(self):
         simple_tests_found = self._find_simple_test_candidates(['true'])
         args = argparse.Namespace(reference=simple_tests_found,
-                                  logdir=self.tmpdir)
+                                  base_logdir=self.tmpdir)
         myjob = job.Job(args)
         myjob.create_test_suite()
         self.assertEqual(myjob.run_tests(),
@@ -95,7 +95,7 @@ class JobTest(unittest.TestCase):
                 super(JobLogPost, self).post_tests()
         simple_tests_found = self._find_simple_test_candidates()
         args = argparse.Namespace(reference=simple_tests_found,
-                                  logdir=self.tmpdir)
+                                  base_logdir=self.tmpdir)
         myjob = JobLogPost(args)
         myjob.create_test_suite()
         try:
@@ -123,7 +123,7 @@ class JobTest(unittest.TestCase):
                 super(JobFilterLog, self).post_tests()
         simple_tests_found = self._find_simple_test_candidates()
         args = argparse.Namespace(reference=simple_tests_found,
-                                  logdir=self.tmpdir)
+                                  base_logdir=self.tmpdir)
         myjob = JobFilterLog(args)
         self.assertEqual(myjob.run(),
                          exit_codes.AVOCADO_ALL_OK)
@@ -132,7 +132,7 @@ class JobTest(unittest.TestCase):
                          open(os.path.join(myjob.logdir, "reversed_id")).read())
 
     def test_job_run_account_time(self):
-        args = argparse.Namespace(logdir=self.tmpdir)
+        args = argparse.Namespace(base_logdir=self.tmpdir)
         myjob = job.Job(args)
         myjob.run()
         self.assertNotEqual(myjob.time_start, -1)
@@ -140,7 +140,7 @@ class JobTest(unittest.TestCase):
         self.assertNotEqual(myjob.time_elapsed, -1)
 
     def test_job_self_account_time(self):
-        args = argparse.Namespace(logdir=self.tmpdir)
+        args = argparse.Namespace(base_logdir=self.tmpdir)
         myjob = job.Job(args)
         myjob.time_start = 10.0
         myjob.run()

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -171,6 +171,13 @@ class JobTest(unittest.TestCase):
         self.assertEqual(os.path.dirname(empty_job.logdir), self.tmpdir)
         self.assertTrue(os.path.isfile(os.path.join(empty_job.logdir, 'id')))
 
+    def test_job_dryrun_no_base_logdir(self):
+        args = argparse.Namespace(dry_run=True)
+        empty_job = job.Job(args)
+        self.assertTrue(os.path.isdir(empty_job.logdir))
+        self.assertTrue(os.path.isfile(os.path.join(empty_job.logdir, 'id')))
+        shutil.rmtree(empty_job.args.base_logdir)
+
     def tearDown(self):
         data_dir._tmp_tracker.unittest_refresh_dir_tracker()
         shutil.rmtree(self.tmpdir)

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -152,6 +152,11 @@ class JobTest(unittest.TestCase):
         self.assertEqual(myjob.time_end, 20.0)
         self.assertEqual(myjob.time_elapsed, 100.0)
 
+    def test_job_dryrun_no_unique_job_id(self):
+        args = argparse.Namespace(dry_run=True, base_logdir=self.tmpdir)
+        empty_job = job.Job(args)
+        self.assertIsNotNone(empty_job.args.unique_job_id)
+
     def tearDown(self):
         data_dir._tmp_tracker.unittest_refresh_dir_tracker()
         shutil.rmtree(self.tmpdir)

--- a/selftests/unit/test_jsonresult.py
+++ b/selftests/unit/test_jsonresult.py
@@ -30,7 +30,7 @@ class JSONResultTest(unittest.TestCase):
         self.tmpfile = tempfile.mkstemp()
         self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
         args = argparse.Namespace(json_output=self.tmpfile[1],
-                                  logdir=self.tmpdir)
+                                  base_logdir=self.tmpdir)
         self.job = job.Job(args)
         self.test_result = Result(FakeJob(args))
         self.test_result.filename = self.tmpfile[1]

--- a/selftests/unit/test_remote.py
+++ b/selftests/unit/test_remote.py
@@ -1,10 +1,15 @@
-import logging
-import os
+import argparse
+import shutil
 import unittest
 
-from flexmock import flexmock, flexmock_teardown
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
-from avocado.utils import archive
+from avocado.core.job import Job
+from avocado.core import version
+from avocado.utils import process
 import avocado_runner_remote
 
 
@@ -25,154 +30,71 @@ class RemoteTestRunnerTest(unittest.TestCase):
 
     """ Tests RemoteTestRunner """
 
-    def setUp(self):
-        Args = flexmock(test_result_total=1,
-                        remote_username='username',
-                        remote_hostname='hostname',
-                        remote_port=22,
-                        remote_password='password',
-                        remote_key_file=None,
-                        remote_timeout=60,
-                        show_job_log=False,
-                        mux_yaml=['~/avocado/tests/foo.yaml',
-                                  '~/avocado/tests/bar/baz.yaml'],
-                        dry_run=True,
-                        env_keep=None)
-        log = flexmock()
-        log.should_receive("info")
-        result_dispatcher = flexmock()
-        result_dispatcher.should_receive("map_method")
-        job = flexmock(args=Args, log=log,
-                       references=['/tests/sleeptest', '/tests/other/test',
-                                   'passtest'], unique_id='1-sleeptest;0',
-                       logdir="/local/path",
-                       _result_events_dispatcher=result_dispatcher)
-
-        flexmock(avocado_runner_remote.RemoteTestRunner).should_receive('__init__')
-        self.runner = avocado_runner_remote.RemoteTestRunner(job, None)
-        self.runner.job = job
-
-        filehandler = logging.StreamHandler()
-        flexmock(logging).should_receive("FileHandler").and_return(filehandler)
-
-        test_results = flexmock(stdout=JSON_RESULTS, exit_status=0)
-        stream = flexmock(job_unique_id='1-sleeptest;0',
-                          debuglog='/local/path/dirname')
-        Remote = flexmock()
-        Remoter = flexmock(avocado_runner_remote.Remote)
-        Remoter.new_instances(Remote)
-        args_version = 'avocado -v'
-        version_result = flexmock(stderr='Avocado 1.2', exit_status=0)
-        args_env = 'env'
-        env_result = flexmock(stdout='''XDG_SESSION_ID=20
-HOSTNAME=rhel7.0
-SELINUX_ROLE_REQUESTED=
-SHELL=/bin/bash
-TERM=vt100
-HISTSIZE=1000
-SSH_CLIENT=192.168.124.1 52948 22
-SELINUX_USE_CURRENT_RANGE=
-SSH_TTY=/dev/pts/0
-USER=root
-PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin
-MAIL=/var/spool/mail/root
-PWD=/root
-LANG=en_US.UTF-8
-SELINUX_LEVEL_REQUESTED=
-HISTCONTROL=ignoredups
-HOME=/root
-SHLVL=2
-LOGNAME=root
-SSH_CONNECTION=192.168.124.1 52948 192.168.124.65 22
-LESSOPEN=||/usr/bin/lesspipe.sh %s
-XDG_RUNTIME_DIR=/run/user/0
-_=/usr/bin/env''', exit_status=0)
-        (Remote.should_receive('run')
-         .with_args(args_env, ignore_status=True, timeout=60)
-         .once().and_return(env_result))
-
-        (Remote.should_receive('run')
-         .with_args(args_version, ignore_status=True, timeout=60)
-         .once().and_return(version_result))
-
-        args = ("avocado run --force-job-id 1-sleeptest;0 "
-                "--json - --archive /tests/sleeptest /tests/other/test "
-                "passtest -m ~/avocado/tests/foo.yaml "
-                "~/avocado/tests/bar/baz.yaml --dry-run")
-        (Remote.should_receive('run')
-         .with_args(args, timeout=61, ignore_status=True)
-         .once().and_return(test_results))
-        Result = flexmock(remote=Remote, references=['sleeptest'],
-                          stream=stream, timeout=None,
-                          args=flexmock(show_job_log=False,
-                                        mux_yaml=['foo.yaml', 'bar/baz.yaml'],
-                                        dry_run=True))
-        args = {'name': '1-sleeptest;0', 'time_end': 1.23,
-                'status': u'PASS', 'time_start': 0,
-                'time_elapsed': 1.23, 'job_unique_id': '',
-                'fail_reason': u'None',
-                'logdir': u'/local/path/test-results/1-sleeptest;0',
-                'logfile': u'/local/path/test-results/1-sleeptest;0/debug.log',
-                'job_logdir': u'/local/path'}
-        Result.should_receive('start_test').once().with_args(args).ordered()
-        Result.should_receive('check_test').once().with_args(args).ordered()
-        (Remote.should_receive('receive_files')
-         .with_args('/local/path', '/home/user/avocado/logs/run-2014-05-26-'
-                    '15.45.37.zip')).once().ordered()
-        (flexmock(archive).should_receive('uncompress')
-         .with_args('/local/path/run-2014-05-26-15.45.37.zip', '/local/path')
-         .once().ordered())
-        (flexmock(os).should_receive('remove')
-         .with_args('/local/path/run-2014-05-26-15.45.37.zip').once()
-         .ordered())
-        Result.should_receive('end_tests').once().ordered()
-        self.runner.result = Result
-
-    def tearDown(self):
-        flexmock_teardown()
-
     def test_run_suite(self):
-        """ Test RemoteTestRunner.run_suite() """
-        self.runner.run_suite(None, None, 61)
-        flexmock_teardown()  # Checks the expectations
+        """
+        Test RemoteTestRunner.run_suite()
 
+        The general idea of this test is to:
 
-class RemoteTestRunnerSetup(unittest.TestCase):
+        1) Create the machinery necessary to get a RemoteTestRunner
+           setup inside a job, or looking at it the other way around, to
+           have a runner that is created with a valid job.
 
-    """ Tests the RemoteTestRunner setup() method"""
+        2) Mock the interactions with a remote host.  This is done here
+           basically by mocking 'Remote' and 'fabric' usage.
 
-    def setUp(self):
-        Remote = flexmock()
-        remote_remote = flexmock(avocado_runner_remote)
-        (remote_remote.should_receive('Remote')
-         .with_args(hostname='hostname', username='username',
-                    password='password', key_filename=None, port=22,
-                    timeout=60, env_keep=None)
-         .once().ordered()
-         .and_return(Remote))
-        Args = flexmock(test_result_total=1,
-                        reference=['/tests/sleeptest', '/tests/other/test',
-                                   'passtest'],
-                        remote_username='username',
-                        remote_hostname='hostname',
-                        remote_port=22,
-                        remote_password='password',
-                        remote_key_file=None,
-                        remote_timeout=60,
-                        show_job_log=False,
-                        env_keep=None)
-        log = flexmock()
-        log.should_receive("info")
-        job = flexmock(args=Args, log=log)
-        self.runner = avocado_runner_remote.RemoteTestRunner(job, None)
+        3) Provide a polluted JSON to be parsed by the RemoteTestRunner
 
-    def tearDown(self):
-        flexmock_teardown()
+        4) Assert that those results are properly parsed into the
+           job's result
+        """
+        job_args = argparse.Namespace(test_result_total=1,
+                                      remote_username='username',
+                                      remote_hostname='hostname',
+                                      remote_port=22,
+                                      remote_password='password',
+                                      remote_key_file=None,
+                                      remote_timeout=60,
+                                      show_job_log=False,
+                                      mux_yaml=['~/avocado/tests/foo.yaml',
+                                                '~/avocado/tests/bar/baz.yaml'],
+                                      dry_run=True,
+                                      env_keep=None,
+                                      reference=['/tests/sleeptest.py',
+                                                 '/tests/other/test',
+                                                 'passtest.py'])
 
-    def test_setup(self):
-        """ Tests RemoteResult.test_setup() """
-        self.runner.setup()
-        flexmock_teardown()
+        job = Job(job_args)
+        runner = avocado_runner_remote.RemoteTestRunner(job, job.result)
+        runner.check_remote_avocado = mock.Mock(return_value=(True,
+                                                              (version.MAJOR,
+                                                               version.MINOR)))
+
+        # These are mocked at their source, and will prevent fabric from
+        # trying to contact remote hosts
+        with mock.patch('avocado_runner_remote.Remote'):
+            with mock.patch('avocado_runner_remote.fabric'):
+                runner.remote = avocado_runner_remote.Remote(job_args.remote_hostname)
+
+            # This is the result that the run_suite() will get from remote.run
+            remote_run_result = process.CmdResult()
+            remote_run_result.stdout = JSON_RESULTS
+            remote_run_result.exit_status = 0
+            runner.remote.run = mock.Mock(return_value=remote_run_result)
+
+            # We have to fake the uncompressing and removal of the zip
+            # archive that was never generated on the "remote" end
+            # This test could be expand by mocking creating an actual
+            # zip file instead, but it's really overkill
+            with mock.patch('avocado_runner_remote.archive.uncompress'):
+                with mock.patch('avocado_runner_remote.os.remove'):
+                    runner.run_suite(None, None, 61)
+
+        # The job was created with dry_run so it should have a zeroed id
+        self.assertEqual(job.result.job_unique_id, '0' * 40)
+        self.assertEqual(job.result.tests_run, 1)
+        self.assertEqual(job.result.passed, 1)
+        shutil.rmtree(job.args.base_logdir)
 
 
 if __name__ == '__main__':

--- a/selftests/unit/test_test.py
+++ b/selftests/unit/test_test.py
@@ -2,8 +2,10 @@ import os
 import shutil
 import tempfile
 import unittest
-
-from flexmock import flexmock, flexmock_teardown
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from avocado.core import test, exceptions
 from avocado.utils import script
@@ -40,7 +42,6 @@ class TestClassTestUnit(unittest.TestCase):
         return FakeFilename("test", tst_id, base_logdir=self.tmpdir)
 
     def tearDown(self):
-        flexmock_teardown()
         shutil.rmtree(self.tmpdir)
 
     def test_ugly_name(self):
@@ -117,10 +118,9 @@ class TestClassTestUnit(unittest.TestCase):
         tst._record_reference_stderr()
 
     def test_all_dirs_exists_no_hang(self):
-        flexmock(os.path)
-        os.path.should_receive('exists').and_return(True)
-        self.assertRaises(exceptions.TestSetupFail, self.DummyTest, "test",
-                          test.TestID(1, "name"), base_logdir=self.tmpdir)
+        with mock.patch('os.path.exists', return_value=True):
+            self.assertRaises(exceptions.TestSetupFail, self.DummyTest, "test",
+                              test.TestID(1, "name"), base_logdir=self.tmpdir)
 
     def test_try_override_test_variable(self):
         test = self.DummyTest(base_logdir=self.tmpdir)

--- a/selftests/unit/test_test.py
+++ b/selftests/unit/test_test.py
@@ -26,6 +26,19 @@ class TestClassTestUnit(unittest.TestCase):
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp(prefix="avocado_" + __name__)
 
+    def _get_fake_filename_test(self, name):
+
+        class FakeFilename(test.Test):
+            @property
+            def filename(self):
+                return name
+
+            def test(self):
+                pass
+
+        tst_id = test.TestID("test", name=name)
+        return FakeFilename("test", tst_id, base_logdir=self.tmpdir)
+
     def tearDown(self):
         flexmock_teardown()
         shutil.rmtree(self.tmpdir)
@@ -81,12 +94,22 @@ class TestClassTestUnit(unittest.TestCase):
 
         self.assertEqual(os.path.basename(tst.workdir),
                          os.path.basename(tst.logdir))
-        flexmock(tst)
-        tst.should_receive('filename').and_return(os.path.join(self.tmpdir,
-                                                               "a"*250))
-        self.assertEqual(os.path.join(self.tmpdir, "a"*250 + ".data"),
+
+    def test_data_dir(self):
+        """
+        Tests that that a valid datadir exists follwowing the test filename
+        """
+        max_length_name = os.path.join(self.tmpdir, "a" * 250)
+        tst = self._get_fake_filename_test(max_length_name)
+        self.assertEqual(os.path.join(self.tmpdir, max_length_name + ".data"),
                          tst.datadir)
-        tst.should_receive('filename').and_return("a"*251)
+
+    def test_no_data_dir(self):
+        """
+        Tests that with a filename too long, no datadir is possible
+        """
+        above_limit_name = os.path.join(self.tmpdir, "a" * 251)
+        tst = self._get_fake_filename_test(above_limit_name)
         self.assertFalse(tst.datadir)
         tst._record_reference_stdout       # Should does nothing
         tst._record_reference_stderr       # Should does nothing

--- a/selftests/unit/test_utils_partition.py
+++ b/selftests/unit/test_utils_partition.py
@@ -7,10 +7,11 @@ avocado.utils.partition unittests
 import os
 import shutil
 import tempfile
-import time
 import unittest     # pylint: disable=C0411
-
-from flexmock import flexmock, flexmock_teardown
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from avocado.utils import partition, process
 from avocado.utils import path as utils_path
@@ -109,12 +110,10 @@ class TestMtabLock(unittest.TestCase):
     def test_lock(self):
         """ Check double-lock raises exception after 60s (in 0.1s) """
         with partition.MtabLock():
-            # speedup the process a bit
-            (flexmock(time).should_receive("time").and_return(1)
-             .and_return(2).and_return(62))
-            self.assertRaises(partition.PartitionError,
-                              partition.MtabLock().__enter__)
-            flexmock_teardown()
+            with mock.patch('avocado.utils.partition.time.time',
+                            mock.MagicMock(side_effect=[1, 2, 62])):
+                self.assertRaises(partition.PartitionError,
+                                  partition.MtabLock().__enter__)
 
 
 if __name__ == '__main__':

--- a/selftests/unit/test_vm.py
+++ b/selftests/unit/test_vm.py
@@ -1,71 +1,66 @@
+import argparse
+import shutil
 import unittest
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
-from flexmock import flexmock, flexmock_teardown
-
+from avocado.core.job import Job
 import avocado_runner_vm
-
-
-JSON_RESULTS = ('Something other than json\n'
-                '{"tests": [{"test": "sleeptest.1", "url": "sleeptest", '
-                '"status": "PASS", "time": 1.23, "start": 0, "end": 1.23}],'
-                '"debuglog": "/home/user/avocado/logs/run-2014-05-26-15.45.'
-                '37/debug.log", "errors": 0, "skip": 0, "time": 1.4, '
-                '"start": 0, "end": 1.4, "pass": 1, "failures": 0, "total": '
-                '1}\nAdditional stuff other than json')
 
 
 class _FakeVM(avocado_runner_vm.VM):
 
     """
-    Fake VM-inherited object (it's better to inherit it, than to flexmock the
+    Fake VM-inherited object (it's better to inherit it, than to mock the
     isinstance)
     """
 
     def __init__(self):  # pylint: disable=W0231
         # don't call avocado_runner_vm.VM.__init__
         self.snapshot = True
-        self.domain = flexmock(isActive=lambda: True)
+        self.domain = mock.Mock()
+        self.domain.isActive = mock.Mock(return_value=True)
 
 
 class VMTestRunnerSetup(unittest.TestCase):
 
     """ Tests the VMTestRunner setup() method """
 
-    def setUp(self):
-        mock_vm = flexmock(_FakeVM())
-        flexmock(avocado_runner_vm).should_receive('vm_connect').and_return(mock_vm).once().ordered()
-        mock_vm.should_receive('start').and_return(True).once().ordered()
-        mock_vm.should_receive('create_snapshot').once().ordered()
-        # VMTestRunner()
-        Args = flexmock(test_result_total=1,
-                        url=['/tests/sleeptest', '/tests/other/test',
-                             'passtest'],
-                        vm_domain='domain',
-                        vm_username='username',
-                        vm_hostname='hostname',
-                        vm_port=22,
-                        vm_password='password',
-                        vm_key_file=None,
-                        vm_cleanup=True,
-                        vm_no_copy=False,
-                        vm_timeout=120,
-                        vm_hypervisor_uri='my_hypervisor_uri',
-                        env_keep=None)
-        log = flexmock()
-        log.should_receive("info")
-        job = flexmock(args=Args, log=log)
-        self.runner = avocado_runner_vm.VMTestRunner(job, None)
-        mock_vm.should_receive('stop').once().ordered()
-        mock_vm.should_receive('restore_snapshot').once().ordered()
-
-    def tearDown(self):
-        flexmock_teardown()
-
     def test_setup(self):
-        """ Tests VMTestRunner.setup() """
-        self.runner.setup()
-        self.runner.tear_down()
-        flexmock_teardown()
+        mock_vm = _FakeVM()
+        mock_vm.start = mock.Mock(return_value=True)
+        mock_vm.create_snapshot = mock.Mock()
+        mock_vm.stop = mock.Mock()
+        mock_vm.restore_snapshot = mock.Mock()
+        job_args = argparse.Namespace(test_result_total=1,
+                                      vm_domain='domain',
+                                      vm_username='username',
+                                      vm_hostname='hostname',
+                                      vm_port=22,
+                                      vm_password='password',
+                                      vm_key_file=None,
+                                      vm_cleanup=True,
+                                      vm_no_copy=False,
+                                      vm_timeout=120,
+                                      vm_hypervisor_uri='my_hypervisor_uri',
+                                      reference=['/tests/sleeptest.py',
+                                                 '/tests/other/test',
+                                                 'passtest.py'],
+                                      dry_run=True,
+                                      env_keep=None)
+        with mock.patch('avocado_runner_vm.vm_connect', return_value=mock_vm):
+            # VMTestRunner()
+            job = Job(job_args)
+            runner = avocado_runner_vm.VMTestRunner(job, None)
+            runner.setup()
+            runner.tear_down()
+        mock_vm.start.assert_called_once()
+        mock_vm.create_snapshot.assert_called_once()
+        mock_vm.stop.assert_called_once()
+        mock_vm.restore_snapshot.assert_called_once()
+        shutil.rmtree(job.args.base_logdir)
 
 
 if __name__ == '__main__':

--- a/selftests/unit/test_xunit.py
+++ b/selftests/unit/test_xunit.py
@@ -39,7 +39,7 @@ class xUnitSucceedTest(unittest.TestCase):
 
         self.tmpfile = tempfile.mkstemp()
         self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
-        args = argparse.Namespace(logdir=self.tmpdir)
+        args = argparse.Namespace(base_logdir=self.tmpdir)
         args.xunit_output = self.tmpfile[1]
         self.job = job.Job(args)
         self.test_result = Result(FakeJob(args))

--- a/spell.ignore
+++ b/spell.ignore
@@ -393,7 +393,6 @@ aexpect
 remoter's
 isinstance
 dkrcmd
-flexmock
 lockfile
 urlparse
 cpus


### PR DESCRIPTION
This is a port to the mock library that is in the standard in Python 3, and it's available in Python 2, and already a requirement for Avocado.

The approach used on this port is to avoid excessive mocking, and use the real code, unless when interacting with dynamic and non-existing components (such as a remote system).

**IMPORTANT**: this PR is based on top of `job_base_logdir`, which are independent fixes (and should be reviewed in PR #2222), but that are also required here.