### PR TITLE
MANIFEST.in: there are no longer YAML files under examples

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,4 @@
 include README.rst
 include LICENSE
 include Makefile
-include examples/*.yaml
 recursive-include selftests *


### PR DESCRIPTION
This fixes the warning "warning: no files found matching
'examples/*.yaml'" while running "make develop".

Signed-off-by: Cleber Rosa <crosa@redhat.com>