### PR TITLE
Avoid the usage of Windows-unfriendly filenames [v3]

### DIFF
--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -28,6 +28,7 @@ except ImportError:
 
 from . import output
 from .settings import settings
+from ..utils import astring
 from ..utils import genio
 from ..utils import process
 from ..utils import software_manager
@@ -44,7 +45,7 @@ class Collectible(object):
     """
 
     def __init__(self, logf):
-        self.logf = logf
+        self.logf = astring.string_to_safe_path(logf)
 
     def readline(self, logdir):
         """
@@ -122,7 +123,7 @@ class Command(Collectible):
 
     def __init__(self, cmd, logf=None, compress_log=False):
         if not logf:
-            logf = cmd.replace(" ", "_")
+            logf = cmd
         super(Command, self).__init__(logf)
         self.cmd = cmd
         self._compress_log = compress_log

--- a/optional_plugins/html/avocado_result_html/__init__.py
+++ b/optional_plugins/html/avocado_result_html/__init__.py
@@ -179,7 +179,7 @@ class ReportModel(object):
         for s_f in sysinfo_files:
             sysinfo_dict = {}
             sysinfo_path = os.path.join(base_path, s_f)
-            sysinfo_dict['file'] = " ".join(s_f.split("_"))
+            sysinfo_dict['file'] = s_f
             sysinfo_dict['element_id'] = '%s_heading_%s' % (phase, s_id)
             sysinfo_dict['collapse_id'] = '%s_collapse_%s' % (phase, s_id)
             try:

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -1035,9 +1035,9 @@ class PluginsTest(AbsPluginsTest, unittest.TestCase):
         result_plugins = ["json", "xunit", "zip_archive"]
         result_outputs = ["results.json", "results.xml"]
         try:
-            pkg_resources.require('avocado_result_html')
+            pkg_resources.require('avocado-framework-plugin-result-html')
             result_plugins.append("html")
-            result_outputs.append("html/results.html")
+            result_outputs.append("results.html")
         except pkg_resources.DistributionNotFound:
             pass
 

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -134,6 +134,14 @@ READ_BINARY = probe_binary('read')
 SLEEP_BINARY = probe_binary('sleep')
 
 
+def html_capable():
+    try:
+        pkg_resources.require('avocado-framework-plugin-result-html')
+        return True
+    except pkg_resources.DistributionNotFound:
+        return False
+
+
 class RunnerOperationTest(unittest.TestCase):
 
     def setUp(self):
@@ -631,7 +639,7 @@ class RunnerHumanOutputTest(unittest.TestCase):
                          " test-results dir, but only one test was executed: "
                          "%s" % (test_dirs))
         self.assertEqual(os.path.basename(test_dirs[0]),
-                         '1-foo\\\\n\\\'\\"\\\\nbar_baz')
+                         "1-foo__n_'____nbar_baz")
 
     def test_replay_skip_skipped(self):
         cmd = ("%s run --job-results-dir %s --json - "
@@ -746,6 +754,36 @@ class RunnerSimpleTest(unittest.TestCase):
                       'finish with warning)', result.stdout, result)
         self.assertIn('ERROR| Error message (ordinary message not changing '
                       'the results)', result.stdout, result)
+
+    @unittest.skipIf(not GNU_ECHO_BINARY, "Uses echo as test")
+    def test_fs_unfriendly_run(self):
+        os.chdir(basedir)
+        commands_path = os.path.join(self.tmpdir, "commands")
+        script.make_script(commands_path, "echo '\"\\/|?*<>'")
+        config_path = os.path.join(self.tmpdir, "config.conf")
+        script.make_script(config_path,
+                           "[sysinfo.collectibles]\ncommands = %s"
+                           % commands_path)
+        cmd_line = ("%s --show all --config %s run --job-results-dir %s "
+                    "--sysinfo=on --external-runner %s -- \"'\\\"\\/|?*<>'\""
+                    % (AVOCADO, config_path, self.tmpdir, GNU_ECHO_BINARY))
+        result = process.run(cmd_line)
+        self.assertTrue(os.path.exists(os.path.join(self.tmpdir, "latest",
+                                                    "test-results",
+                                                    "1-\'________\'/")))
+        self.assertTrue(os.path.exists(os.path.join(self.tmpdir, "latest",
+                                                    "sysinfo", "pre",
+                                                    "echo \'________\'")))
+
+        if html_capable():
+            with open(os.path.join(self.tmpdir, "latest",
+                                   "results.html")) as html_res:
+                html_results = html_res.read()
+            # test results should replace odd chars with "_"
+            self.assertIn(os.path.join("test-results", "1-'________'"),
+                          html_results)
+            # sysinfo replaces "_" with " "
+            self.assertIn("echo '________'", html_results)
 
     def test_non_absolute_path(self):
         avocado_path = os.path.join(basedir, 'scripts', 'avocado')
@@ -1034,12 +1072,9 @@ class PluginsTest(AbsPluginsTest, unittest.TestCase):
 
         result_plugins = ["json", "xunit", "zip_archive"]
         result_outputs = ["results.json", "results.xml"]
-        try:
-            pkg_resources.require('avocado-framework-plugin-result-html')
+        if html_capable():
             result_plugins.append("html")
             result_outputs.append("results.html")
-        except pkg_resources.DistributionNotFound:
-            pass
 
         cmd_line = '%s plugins' % AVOCADO
         result = process.run(cmd_line, ignore_status=True)
@@ -1244,7 +1279,7 @@ class PluginsJSONTest(AbsPluginsTest, unittest.TestCase):
                          '1--ne foo\\\\n\\\'\\"\\\\nbar/baz')
         # logdir name should escape special chars (/)
         self.assertEqual(os.path.basename(data['tests'][0]['logdir']),
-                         '1--ne foo\\\\n\\\'\\"\\\\nbar_baz')
+                         "1--ne foo__n_'____nbar_baz")
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir)

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -77,7 +77,7 @@ def image_output_uncapable():
 
 def html_uncapable():
     try:
-        pkg_resources.require('avocado_result_html')
+        pkg_resources.require('avocado-framework-plugin-result-html')
         return False
     except pkg_resources.DistributionNotFound:
         return True
@@ -264,7 +264,7 @@ class OutputPluginTest(unittest.TestCase):
         tmpfile = tempfile.mktemp(prefix='avocado_' + __name__)
         tmpfile2 = tempfile.mktemp(prefix='avocado_' + __name__)
         tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
-        tmpfile3 = tempfile.mktemp(dir=tmpdir)
+        tmpfile3 = os.path.join(tmpdir, "result.html")
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
                     '--xunit %s --json %s --html %s passtest.py'
                     % (AVOCADO, self.tmpdir, tmpfile, tmpfile2, tmpfile3))
@@ -272,8 +272,9 @@ class OutputPluginTest(unittest.TestCase):
         output = result.stdout + result.stderr
         expected_rc = exit_codes.AVOCADO_ALL_OK
         tmpdir_contents = os.listdir(tmpdir)
-        self.assertEqual(len(tmpdir_contents), 4,
-                         'Not all resources dir were created: %s' % tmpdir_contents)
+        self.assertEqual(len(tmpdir_contents), 1, "Html plugin generated "
+                         "extra files in the result dir: %s"
+                         % tmpdir_contents)
         try:
             self.assertEqual(result.exit_status, expected_rc,
                              "Avocado did not return rc %d:\n%s" %

--- a/selftests/functional/test_sysinfo.py
+++ b/selftests/functional/test_sysinfo.py
@@ -104,7 +104,7 @@ class SysInfoTest(unittest.TestCase):
                          'Avocado did not return rc %d:\n%s'
                          % (expected_rc, result))
         sleep_log = os.path.join(self.tmpdir, "latest", "sysinfo", "pre",
-                                 "sleep_%s" % sleep)
+                                 "sleep %s" % sleep)
         if not os.path.exists(sleep_log):
             path = os.path.abspath(sleep_log)
             while not os.path.exists(path):

--- a/selftests/unit/test_astring.py
+++ b/selftests/unit/test_astring.py
@@ -62,6 +62,12 @@ class AstringTest(unittest.TestCase):
                       "a\u0430 123")
         self.assertEqual(astring.tabular_output(matrix), str_matrix)
 
+    def test_safe_path(self):
+        self.assertEqual(astring.string_to_safe_path('a<>:"/\\|\?*b'),
+                         "a__________b")
+        self.assertEqual(astring.string_to_safe_path('..'), "_.")
+        self.assertEqual(len(astring.string_to_safe_path(" " * 300)), 255)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/selftests/unit/test_test.py
+++ b/selftests/unit/test_test.py
@@ -6,7 +6,7 @@ import unittest
 from flexmock import flexmock, flexmock_teardown
 
 from avocado.core import test, exceptions
-from avocado.utils import script
+from avocado.utils import astring, script
 
 PASS_SCRIPT_CONTENTS = """#!/bin/sh
 true
@@ -253,7 +253,8 @@ class TestID(unittest.TestCase):
         test_id = test.TestID(uid, name)
         self.assertEqual(test_id.uid, 1)
         self.assertEqual(test_id.str_uid, '1')
-        self.assertEqual(test_id.str_filesystem, '%s-%s' % (uid, name))
+        self.assertEqual(test_id.str_filesystem,
+                         astring.string_to_safe_path('%s-%s' % (uid, name)))
         self.assertIs(test_id.variant, None)
         self.assertIs(test_id.str_variant, '')
 
@@ -263,7 +264,8 @@ class TestID(unittest.TestCase):
         test_id = test.TestID(uid, name, no_digits=2)
         self.assertEqual(test_id.uid, 1)
         self.assertEqual(test_id.str_uid, '01')
-        self.assertEqual(test_id.str_filesystem, '%s-%s' % ('01', name))
+        self.assertEqual(test_id.str_filesystem,
+                         astring.string_to_safe_path('%s-%s' % ('01', name)))
         self.assertIs(test_id.variant, None)
         self.assertIs(test_id.str_variant, '')
 


### PR DESCRIPTION
As we realized in https://github.com/avocado-framework/avocado/issues/2189 there are some windows-unfriendly characters in our generated output. This PR first fixes our selftests, then makes sure we use `astring.string_to_safe_path` in all files generated in results and the last commit improves the `astring.string_to_safe_path` to be windows friendly.

Note the `string` approach in that function is very fast, but fails on unicode strings, that's why there is a fallback to slower, but unicode-friendly implementation.

v1: https://github.com/avocado-framework/avocado/pull/2224
v2: https://github.com/avocado-framework/avocado/pull/2227

Changes:

```yaml
v2: Revert to `pkg_resources` but use the correct name this time (1st commit)
v2: Use the FS_UNSAFE_CHARS variable correctly in astring (3rd commit)
v3: Change the `html_uncapable` to `html_capable` function in `test_basic`
v3: Improved the message in `test_output` assert (as well as filename)
```