### PR TITLE
test: log the raw output on stdout/stderr

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -52,6 +52,33 @@ from .output import LOG_JOB
 COMMON_TMPDIR_NAME = 'AVOCADO_TESTS_COMMON_TMPDIR'
 
 
+class RawFileHandler(logging.FileHandler):
+
+    """
+    File Handler that doesn't include arbitrary characters to the
+    logged stream but still respects the formatter.
+    """
+
+    def __init__(self, *args, **kwargs):
+        logging.FileHandler.__init__(self, *args, **kwargs)
+
+    def emit(self, record):
+        """
+        Modifying the original emit() to avoid including a new line
+        in streams that should be logged in its purest form, like in
+        stdout/stderr recordings.
+        """
+        if self.stream is None:
+            self.stream = self._open()
+        try:
+            msg = self.format(record)
+            stream = self.stream
+            stream.write(msg)
+            self.flush()
+        except Exception:
+            self.handleError(record)
+
+
 class TestID(object):
 
     """
@@ -494,8 +521,11 @@ class Test(unittest.TestCase):
         return state
 
     def _register_log_file_handler(self, logger, formatter, filename,
-                                   log_level=logging.DEBUG):
-        file_handler = logging.FileHandler(filename=filename)
+                                   log_level=logging.DEBUG, raw=False):
+        if raw:
+            file_handler = RawFileHandler(filename=filename)
+        else:
+            file_handler = logging.FileHandler(filename=filename)
         file_handler.setLevel(log_level)
         file_handler.setFormatter(formatter)
         logger.addHandler(file_handler)
@@ -522,10 +552,12 @@ class Test(unittest.TestCase):
 
         self._register_log_file_handler(log_test_stdout,
                                         stream_formatter,
-                                        self._stdout_file)
+                                        self._stdout_file,
+                                        raw=True)
         self._register_log_file_handler(log_test_stderr,
                                         stream_formatter,
-                                        self._stderr_file)
+                                        self._stderr_file,
+                                        raw=True)
         self._register_log_file_handler(logging.getLogger('paramiko'),
                                         formatter,
                                         self._ssh_logfile)

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -145,9 +145,9 @@ class OutputTest(unittest.TestCase):
                 "[stderr] test_stderr", "[stdout] test_process"]
         _check_output(joblog, exps, "job.log")
         testdir = res["tests"][0]["logdir"]
-        self.assertEqual("test_print\ntest_stdout\ntest_process\n",
+        self.assertEqual("test_printtest_stdouttest_process",
                          open(os.path.join(testdir, "stdout")).read())
-        self.assertEqual("test_stderr\n",
+        self.assertEqual("test_stderr",
                          open(os.path.join(testdir, "stderr")).read())
         self.assertEqual("test_print\ntest_stdout\ntest_stderr\n"
                          "test_process\n",


### PR DESCRIPTION
Python logging system is hard-coded to add a new line character at the
end of each call to emit(). Since the Avocado recording to test
stdout/stderr uses the logging system, this patch creates/uses a custom
FileHandler to be used in the cases where we need the raw output to
be recorded to the files.

Reference: https://trello.com/c/dH7FLT75
Signed-off-by: Amador Pahim <apahim@redhat.com>