### PR TITLE
Python 3 port: unittests

### DIFF
--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -30,6 +30,8 @@ import shutil
 import time
 import tempfile
 
+from six.moves import xrange
+
 from . import job_id
 from . import settings
 from .output import LOG_JOB

--- a/avocado/utils/archive.py
+++ b/avocado/utils/archive.py
@@ -22,6 +22,8 @@ import stat
 import tarfile
 import zipfile
 
+from six import iteritems
+
 
 LOG = logging.getLogger(__name__)
 
@@ -172,7 +174,7 @@ class ArchiveFile(object):
             LOG.warn("Attr handling in zip files only supported on Linux.")
             return
         # Walk all files and re-create files as symlinks
-        for path, info in self._engine.NameToInfo.iteritems():
+        for path, info in iteritems(self._engine.NameToInfo):
             dst = os.path.join(dst_dir, path)
             if not os.path.exists(dst):
                 LOG.warn("One or more files in the ZIP archive '%s' could "

--- a/avocado/utils/data_structures.py
+++ b/avocado/utils/data_structures.py
@@ -24,7 +24,8 @@ avocado core code or plugins.
 
 import sys
 import math
-from itertools import izip
+
+from six.moves import zip
 
 
 def ordered_list_unique(object_list):
@@ -72,18 +73,18 @@ def compare_matrices(matrix1, matrix2, threshold=0.05):
     same = 0
     new_matrix = []
 
-    for line1, line2 in izip(matrix1, matrix2):
+    for line1, line2 in zip(matrix1, matrix2):
         new_line = []
-        elements = izip(line1, line2)
+        elements = zip(line1, line2)
         try:
-            element1, element2 = elements.next()
+            element1, element2 = next(elements)
         except StopIteration:             # no data in this row
             new_matrix.append(new_line)
             continue
         if element1 == element2:          # this column contains header
             new_line.append(element1)
             try:
-                element1, element2 = elements.next()
+                element1, element2 = next(elements)
             except StopIteration:
                 new_matrix.append(new_line)
                 continue
@@ -98,7 +99,7 @@ def compare_matrices(matrix1, matrix2, threshold=0.05):
                     new_line.append("error_%s/%s" % (element2, element1))
                     improvements += 1
                 try:
-                    element1, element2 = elements.next()
+                    element1, element2 = next(elements)
                 except StopIteration:
                     break
                 continue
@@ -112,7 +113,7 @@ def compare_matrices(matrix1, matrix2, threshold=0.05):
                 same += 1
                 new_line.append(".")
             try:
-                element1, element2 = elements.next()
+                element1, element2 = next(elements)
             except StopIteration:
                 break
         new_matrix.append(new_line)

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -29,7 +29,7 @@
 Summary: Framework with tools and libraries for Automated Testing
 Name: python-%{srcname}
 Version: 54.1
-Release: 0%{?gitrel}%{?dist}
+Release: 1%{?gitrel}%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.github.io/
@@ -51,6 +51,7 @@ BuildRequires: python-requests
 BuildRequires: python-resultsdb_api
 BuildRequires: python-setuptools
 BuildRequires: python-sphinx
+BuildRequires: python-six
 BuildRequires: python-stevedore
 BuildRequires: python2-devel
 BuildRequires: yum
@@ -369,6 +370,9 @@ examples of how to write tests on your own.
 %{_datadir}/avocado/yaml_to_mux_loader
 
 %changelog
+* Wed Oct  4 2017 Cleber Rosa <cleber@redhat.com> - 54.1-1
+- Add explicit BuildRequires for python-six
+
 * Wed Sep 20 2017 Cleber Rosa <cleber@redhat.com> - 54.1-0
 - New minor upstream release
 

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -4,5 +4,7 @@ requests==1.2.3
 PyYAML==3.11
 Pillow==2.6.1
 aexpect==1.0.0
+# six is a stevedore depedency, but we also use it directly
+six==1.9.0
 # stevedore for loading "new style" plugins
 stevedore==1.20.0

--- a/requirements-selftests.txt
+++ b/requirements-selftests.txt
@@ -22,6 +22,8 @@ pygraphviz>=1.3rc2
 pydot>=1.2.3
 aexpect>=1.0.0
 psutil>=3.1.1
+# six is a stevedore depedency, but we also use it directly
+six>=1.9.0
 # stevedore for loading "new style" plugins
 stevedore>=0.14
 lxml>=3.4.4

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -13,6 +13,8 @@ pygraphviz==1.3rc2
 mock==1.2.0
 aexpect==1.0.0
 psutil==3.1.1
+# six is a stevedore depedency, but we also use it directly
+six==1.9.0
 # stevedore for loading "new style" plugins
 stevedore==1.20.0
 lxml>=3.4.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,7 @@
 pyliblzma>=0.5.3
 # REST client (avocado.core.restclient)
 requests>=1.2.3
+# six is a stevedore depedency, but we also use it directly
+six>=1.9.0
 # stevedore for loading "new style" plugins
 stevedore>=0.14

--- a/selftests/unit/test_archive.py
+++ b/selftests/unit/test_archive.py
@@ -5,6 +5,8 @@ import shutil
 import sys
 import random
 
+from six.moves import xrange
+
 from avocado.utils import archive
 from avocado.utils import crypto
 from avocado.utils import data_factory

--- a/selftests/unit/test_data_structures.py
+++ b/selftests/unit/test_data_structures.py
@@ -1,5 +1,7 @@
 import unittest
 
+from six.moves import xrange
+
 from avocado.utils import data_structures
 
 

--- a/selftests/unit/test_datadir.py
+++ b/selftests/unit/test_datadir.py
@@ -5,6 +5,8 @@ import tempfile
 
 from flexmock import flexmock
 
+from six.moves import xrange
+
 from avocado.core import settings
 
 

--- a/selftests/unit/test_jobdata.py
+++ b/selftests/unit/test_jobdata.py
@@ -2,6 +2,8 @@ import glob
 import os
 import unittest
 
+from six import PY3
+
 from avocado.core import jobdata
 
 
@@ -87,6 +89,7 @@ class JobdataTest(unittest.TestCase):
             errs.append("cmdline: Invalid cmdline '%s' (%s)" % (act, exp))
         return errs
 
+    @unittest.skipIf(PY3, "Skipping tests with data pickled on Python 2")
     def test_versions(self):
         os.chdir(BASEDIR)
         errs = []

--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -81,126 +81,126 @@ def mock_fail_find_cmd(cmd, default=None):
 class TestProcessRun(unittest.TestCase):
 
     @mock.patch.object(path, 'find_command',
-                       mock.MagicMock(return_value=TRUE_CMD))
+                       mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid',
-                       mock.MagicMock(return_value=1000))
+                       mock.Mock(return_value=1000))
     def test_subprocess_nosudo(self):
         expected_command = 'ls -l'
         p = process.SubProcess(cmd='ls -l')
         self.assertEqual(p.cmd, expected_command)
 
     @mock.patch.object(path, 'find_command',
-                       mock.MagicMock(return_value=TRUE_CMD))
-    @mock.patch.object(os, 'getuid', mock.MagicMock(return_value=0))
+                       mock.Mock(return_value=TRUE_CMD))
+    @mock.patch.object(os, 'getuid', mock.Mock(return_value=0))
     def test_subprocess_nosudo_uid_0(self):
         expected_command = 'ls -l'
         p = process.SubProcess(cmd='ls -l')
         self.assertEqual(p.cmd, expected_command)
 
     @mock.patch.object(path, 'find_command',
-                       mock.MagicMock(return_value=TRUE_CMD))
+                       mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid',
-                       mock.MagicMock(return_value=1000))
+                       mock.Mock(return_value=1000))
     def test_subprocess_sudo(self):
         expected_command = '%s -n ls -l' % TRUE_CMD
         p = process.SubProcess(cmd='ls -l', sudo=True)
         self.assertEqual(p.cmd, expected_command)
 
     @mock.patch.object(path, 'find_command', mock_fail_find_cmd)
-    @mock.patch.object(os, 'getuid', mock.MagicMock(return_value=1000))
+    @mock.patch.object(os, 'getuid', mock.Mock(return_value=1000))
     def test_subprocess_sudo_no_sudo_installed(self):
         expected_command = 'ls -l'
         p = process.SubProcess(cmd='ls -l', sudo=True)
         self.assertEqual(p.cmd, expected_command)
 
     @mock.patch.object(path, 'find_command',
-                       mock.MagicMock(return_value=TRUE_CMD))
-    @mock.patch.object(os, 'getuid', mock.MagicMock(return_value=0))
+                       mock.Mock(return_value=TRUE_CMD))
+    @mock.patch.object(os, 'getuid', mock.Mock(return_value=0))
     def test_subprocess_sudo_uid_0(self):
         expected_command = 'ls -l'
         p = process.SubProcess(cmd='ls -l', sudo=True)
         self.assertEqual(p.cmd, expected_command)
 
     @mock.patch.object(path, 'find_command',
-                       mock.MagicMock(return_value=TRUE_CMD))
-    @mock.patch.object(os, 'getuid', mock.MagicMock(return_value=1000))
+                       mock.Mock(return_value=TRUE_CMD))
+    @mock.patch.object(os, 'getuid', mock.Mock(return_value=1000))
     def test_subprocess_sudo_shell(self):
         expected_command = '%s -n -s ls -l' % TRUE_CMD
         p = process.SubProcess(cmd='ls -l', sudo=True, shell=True)
         self.assertEqual(p.cmd, expected_command)
 
     @mock.patch.object(path, 'find_command', mock_fail_find_cmd)
-    @mock.patch.object(os, 'getuid', mock.MagicMock(return_value=1000))
+    @mock.patch.object(os, 'getuid', mock.Mock(return_value=1000))
     def test_subprocess_sudo_shell_no_sudo_installed(self):
         expected_command = 'ls -l'
         p = process.SubProcess(cmd='ls -l', sudo=True, shell=True)
         self.assertEqual(p.cmd, expected_command)
 
     @mock.patch.object(path, 'find_command',
-                       mock.MagicMock(return_value=TRUE_CMD))
-    @mock.patch.object(os, 'getuid', mock.MagicMock(return_value=0))
+                       mock.Mock(return_value=TRUE_CMD))
+    @mock.patch.object(os, 'getuid', mock.Mock(return_value=0))
     def test_subprocess_sudo_shell_uid_0(self):
         expected_command = 'ls -l'
         p = process.SubProcess(cmd='ls -l', sudo=True, shell=True)
         self.assertEqual(p.cmd, expected_command)
 
     @mock.patch.object(path, 'find_command',
-                       mock.MagicMock(return_value=TRUE_CMD))
-    @mock.patch.object(os, 'getuid', mock.MagicMock(return_value=1000))
+                       mock.Mock(return_value=TRUE_CMD))
+    @mock.patch.object(os, 'getuid', mock.Mock(return_value=1000))
     def test_run_nosudo(self):
         expected_command = 'ls -l'
         p = process.run(cmd='ls -l', ignore_status=True)
         self.assertEqual(p.command, expected_command)
 
     @mock.patch.object(path, 'find_command',
-                       mock.MagicMock(return_value=TRUE_CMD))
-    @mock.patch.object(os, 'getuid', mock.MagicMock(return_value=0))
+                       mock.Mock(return_value=TRUE_CMD))
+    @mock.patch.object(os, 'getuid', mock.Mock(return_value=0))
     def test_run_nosudo_uid_0(self):
         expected_command = 'ls -l'
         p = process.run(cmd='ls -l', ignore_status=True)
         self.assertEqual(p.command, expected_command)
 
     @mock.patch.object(path, 'find_command',
-                       mock.MagicMock(return_value=TRUE_CMD))
-    @mock.patch.object(os, 'getuid', mock.MagicMock(return_value=1000))
+                       mock.Mock(return_value=TRUE_CMD))
+    @mock.patch.object(os, 'getuid', mock.Mock(return_value=1000))
     def test_run_sudo(self):
         expected_command = '%s -n ls -l' % TRUE_CMD
         p = process.run(cmd='ls -l', sudo=True, ignore_status=True)
         self.assertEqual(p.command, expected_command)
 
     @mock.patch.object(path, 'find_command', mock_fail_find_cmd)
-    @mock.patch.object(os, 'getuid', mock.MagicMock(return_value=1000))
+    @mock.patch.object(os, 'getuid', mock.Mock(return_value=1000))
     def test_run_sudo_no_sudo_installed(self):
         expected_command = 'ls -l'
         p = process.run(cmd='ls -l', sudo=True, ignore_status=True)
         self.assertEqual(p.command, expected_command)
 
     @mock.patch.object(path, 'find_command',
-                       mock.MagicMock(return_value=TRUE_CMD))
-    @mock.patch.object(os, 'getuid', mock.MagicMock(return_value=0))
+                       mock.Mock(return_value=TRUE_CMD))
+    @mock.patch.object(os, 'getuid', mock.Mock(return_value=0))
     def test_run_sudo_uid_0(self):
         expected_command = 'ls -l'
         p = process.run(cmd='ls -l', sudo=True, ignore_status=True)
         self.assertEqual(p.command, expected_command)
 
     @mock.patch.object(path, 'find_command',
-                       mock.MagicMock(return_value=TRUE_CMD))
-    @mock.patch.object(os, 'getuid', mock.MagicMock(return_value=1000))
+                       mock.Mock(return_value=TRUE_CMD))
+    @mock.patch.object(os, 'getuid', mock.Mock(return_value=1000))
     def test_run_sudo_shell(self):
         expected_command = '%s -n -s ls -l' % TRUE_CMD
         p = process.run(cmd='ls -l', sudo=True, shell=True, ignore_status=True)
         self.assertEqual(p.command, expected_command)
 
     @mock.patch.object(path, 'find_command', mock_fail_find_cmd)
-    @mock.patch.object(os, 'getuid', mock.MagicMock(return_value=1000))
+    @mock.patch.object(os, 'getuid', mock.Mock(return_value=1000))
     def test_run_sudo_shell_no_sudo_installed(self):
         expected_command = 'ls -l'
         p = process.run(cmd='ls -l', sudo=True, shell=True, ignore_status=True)
         self.assertEqual(p.command, expected_command)
 
     @mock.patch.object(path, 'find_command',
-                       mock.MagicMock(return_value=TRUE_CMD))
-    @mock.patch.object(os, 'getuid', mock.MagicMock(return_value=0))
+                       mock.Mock(return_value=TRUE_CMD))
+    @mock.patch.object(os, 'getuid', mock.Mock(return_value=0))
     def test_run_sudo_shell_uid_0(self):
         expected_command = 'ls -l'
         p = process.run(cmd='ls -l', sudo=True, shell=True, ignore_status=True)

--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -1,6 +1,11 @@
 import os
 import unittest
-from mock import MagicMock, patch
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
 
 from avocado.utils import gdb
 from avocado.utils import process
@@ -75,125 +80,127 @@ def mock_fail_find_cmd(cmd, default=None):
 
 class TestProcessRun(unittest.TestCase):
 
-    @patch.object(path, 'find_command',
-                  MagicMock(return_value=TRUE_CMD))
-    @patch.object(os, 'getuid', MagicMock(return_value=1000))
+    @mock.patch.object(path, 'find_command',
+                       mock.MagicMock(return_value=TRUE_CMD))
+    @mock.patch.object(os, 'getuid',
+                       mock.MagicMock(return_value=1000))
     def test_subprocess_nosudo(self):
         expected_command = 'ls -l'
         p = process.SubProcess(cmd='ls -l')
         self.assertEqual(p.cmd, expected_command)
 
-    @patch.object(path, 'find_command',
-                  MagicMock(return_value=TRUE_CMD))
-    @patch.object(os, 'getuid', MagicMock(return_value=0))
+    @mock.patch.object(path, 'find_command',
+                       mock.MagicMock(return_value=TRUE_CMD))
+    @mock.patch.object(os, 'getuid', mock.MagicMock(return_value=0))
     def test_subprocess_nosudo_uid_0(self):
         expected_command = 'ls -l'
         p = process.SubProcess(cmd='ls -l')
         self.assertEqual(p.cmd, expected_command)
 
-    @patch.object(path, 'find_command',
-                  MagicMock(return_value=TRUE_CMD))
-    @patch.object(os, 'getuid', MagicMock(return_value=1000))
+    @mock.patch.object(path, 'find_command',
+                       mock.MagicMock(return_value=TRUE_CMD))
+    @mock.patch.object(os, 'getuid',
+                       mock.MagicMock(return_value=1000))
     def test_subprocess_sudo(self):
         expected_command = '%s -n ls -l' % TRUE_CMD
         p = process.SubProcess(cmd='ls -l', sudo=True)
         self.assertEqual(p.cmd, expected_command)
 
-    @patch.object(path, 'find_command', mock_fail_find_cmd)
-    @patch.object(os, 'getuid', MagicMock(return_value=1000))
+    @mock.patch.object(path, 'find_command', mock_fail_find_cmd)
+    @mock.patch.object(os, 'getuid', mock.MagicMock(return_value=1000))
     def test_subprocess_sudo_no_sudo_installed(self):
         expected_command = 'ls -l'
         p = process.SubProcess(cmd='ls -l', sudo=True)
         self.assertEqual(p.cmd, expected_command)
 
-    @patch.object(path, 'find_command',
-                  MagicMock(return_value=TRUE_CMD))
-    @patch.object(os, 'getuid', MagicMock(return_value=0))
+    @mock.patch.object(path, 'find_command',
+                       mock.MagicMock(return_value=TRUE_CMD))
+    @mock.patch.object(os, 'getuid', mock.MagicMock(return_value=0))
     def test_subprocess_sudo_uid_0(self):
         expected_command = 'ls -l'
         p = process.SubProcess(cmd='ls -l', sudo=True)
         self.assertEqual(p.cmd, expected_command)
 
-    @patch.object(path, 'find_command',
-                  MagicMock(return_value=TRUE_CMD))
-    @patch.object(os, 'getuid', MagicMock(return_value=1000))
+    @mock.patch.object(path, 'find_command',
+                       mock.MagicMock(return_value=TRUE_CMD))
+    @mock.patch.object(os, 'getuid', mock.MagicMock(return_value=1000))
     def test_subprocess_sudo_shell(self):
         expected_command = '%s -n -s ls -l' % TRUE_CMD
         p = process.SubProcess(cmd='ls -l', sudo=True, shell=True)
         self.assertEqual(p.cmd, expected_command)
 
-    @patch.object(path, 'find_command', mock_fail_find_cmd)
-    @patch.object(os, 'getuid', MagicMock(return_value=1000))
+    @mock.patch.object(path, 'find_command', mock_fail_find_cmd)
+    @mock.patch.object(os, 'getuid', mock.MagicMock(return_value=1000))
     def test_subprocess_sudo_shell_no_sudo_installed(self):
         expected_command = 'ls -l'
         p = process.SubProcess(cmd='ls -l', sudo=True, shell=True)
         self.assertEqual(p.cmd, expected_command)
 
-    @patch.object(path, 'find_command',
-                  MagicMock(return_value=TRUE_CMD))
-    @patch.object(os, 'getuid', MagicMock(return_value=0))
+    @mock.patch.object(path, 'find_command',
+                       mock.MagicMock(return_value=TRUE_CMD))
+    @mock.patch.object(os, 'getuid', mock.MagicMock(return_value=0))
     def test_subprocess_sudo_shell_uid_0(self):
         expected_command = 'ls -l'
         p = process.SubProcess(cmd='ls -l', sudo=True, shell=True)
         self.assertEqual(p.cmd, expected_command)
 
-    @patch.object(path, 'find_command',
-                  MagicMock(return_value=TRUE_CMD))
-    @patch.object(os, 'getuid', MagicMock(return_value=1000))
+    @mock.patch.object(path, 'find_command',
+                       mock.MagicMock(return_value=TRUE_CMD))
+    @mock.patch.object(os, 'getuid', mock.MagicMock(return_value=1000))
     def test_run_nosudo(self):
         expected_command = 'ls -l'
         p = process.run(cmd='ls -l', ignore_status=True)
         self.assertEqual(p.command, expected_command)
 
-    @patch.object(path, 'find_command',
-                  MagicMock(return_value=TRUE_CMD))
-    @patch.object(os, 'getuid', MagicMock(return_value=0))
+    @mock.patch.object(path, 'find_command',
+                       mock.MagicMock(return_value=TRUE_CMD))
+    @mock.patch.object(os, 'getuid', mock.MagicMock(return_value=0))
     def test_run_nosudo_uid_0(self):
         expected_command = 'ls -l'
         p = process.run(cmd='ls -l', ignore_status=True)
         self.assertEqual(p.command, expected_command)
 
-    @patch.object(path, 'find_command',
-                  MagicMock(return_value=TRUE_CMD))
-    @patch.object(os, 'getuid', MagicMock(return_value=1000))
+    @mock.patch.object(path, 'find_command',
+                       mock.MagicMock(return_value=TRUE_CMD))
+    @mock.patch.object(os, 'getuid', mock.MagicMock(return_value=1000))
     def test_run_sudo(self):
         expected_command = '%s -n ls -l' % TRUE_CMD
         p = process.run(cmd='ls -l', sudo=True, ignore_status=True)
         self.assertEqual(p.command, expected_command)
 
-    @patch.object(path, 'find_command', mock_fail_find_cmd)
-    @patch.object(os, 'getuid', MagicMock(return_value=1000))
+    @mock.patch.object(path, 'find_command', mock_fail_find_cmd)
+    @mock.patch.object(os, 'getuid', mock.MagicMock(return_value=1000))
     def test_run_sudo_no_sudo_installed(self):
         expected_command = 'ls -l'
         p = process.run(cmd='ls -l', sudo=True, ignore_status=True)
         self.assertEqual(p.command, expected_command)
 
-    @patch.object(path, 'find_command',
-                  MagicMock(return_value=TRUE_CMD))
-    @patch.object(os, 'getuid', MagicMock(return_value=0))
+    @mock.patch.object(path, 'find_command',
+                       mock.MagicMock(return_value=TRUE_CMD))
+    @mock.patch.object(os, 'getuid', mock.MagicMock(return_value=0))
     def test_run_sudo_uid_0(self):
         expected_command = 'ls -l'
         p = process.run(cmd='ls -l', sudo=True, ignore_status=True)
         self.assertEqual(p.command, expected_command)
 
-    @patch.object(path, 'find_command',
-                  MagicMock(return_value=TRUE_CMD))
-    @patch.object(os, 'getuid', MagicMock(return_value=1000))
+    @mock.patch.object(path, 'find_command',
+                       mock.MagicMock(return_value=TRUE_CMD))
+    @mock.patch.object(os, 'getuid', mock.MagicMock(return_value=1000))
     def test_run_sudo_shell(self):
         expected_command = '%s -n -s ls -l' % TRUE_CMD
         p = process.run(cmd='ls -l', sudo=True, shell=True, ignore_status=True)
         self.assertEqual(p.command, expected_command)
 
-    @patch.object(path, 'find_command', mock_fail_find_cmd)
-    @patch.object(os, 'getuid', MagicMock(return_value=1000))
+    @mock.patch.object(path, 'find_command', mock_fail_find_cmd)
+    @mock.patch.object(os, 'getuid', mock.MagicMock(return_value=1000))
     def test_run_sudo_shell_no_sudo_installed(self):
         expected_command = 'ls -l'
         p = process.run(cmd='ls -l', sudo=True, shell=True, ignore_status=True)
         self.assertEqual(p.command, expected_command)
 
-    @patch.object(path, 'find_command',
-                  MagicMock(return_value=TRUE_CMD))
-    @patch.object(os, 'getuid', MagicMock(return_value=0))
+    @mock.patch.object(path, 'find_command',
+                       mock.MagicMock(return_value=TRUE_CMD))
+    @mock.patch.object(os, 'getuid', mock.MagicMock(return_value=0))
     def test_run_sudo_shell_uid_0(self):
         expected_command = 'ls -l'
         p = process.run(cmd='ls -l', sudo=True, shell=True, ignore_status=True)

--- a/selftests/unit/test_utils_service.py
+++ b/selftests/unit/test_utils_service.py
@@ -18,7 +18,10 @@
 
 import unittest
 
-from mock import MagicMock, patch
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from avocado.utils import service
 
@@ -84,15 +87,15 @@ class TestSysVInit(unittest.TestCase):
 class TestSpecificServiceManager(unittest.TestCase):
 
     def setUp(self):
-        self.run_mock = MagicMock()
+        self.run_mock = mock.MagicMock()
         self.init_name = "init"
-        get_name_of_init_mock = MagicMock(return_value="init")
+        get_name_of_init_mock = mock.MagicMock(return_value="init")
 
-        @patch.object(service, "get_name_of_init", get_name_of_init_mock)
+        @mock.patch.object(service, "get_name_of_init", get_name_of_init_mock)
         def patch_service_command_generator():
             return service._auto_create_specific_service_command_generator()
 
-        @patch.object(service, "get_name_of_init", get_name_of_init_mock)
+        @mock.patch.object(service, "get_name_of_init", get_name_of_init_mock)
         def patch_service_result_parser():
             return service._auto_create_specific_service_result_parser()
         service_command_generator = patch_service_command_generator()
@@ -136,7 +139,7 @@ class TestServiceManager(unittest.TestCase):
 class TestSystemdServiceManager(TestServiceManager):
 
     def setUp(self):
-        self.run_mock = MagicMock()
+        self.run_mock = mock.MagicMock()
         self.init_name = "systemd"
         self.service_manager = super(TestSystemdServiceManager,
                                      self).get_service_manager_from_init_and_run(self.init_name,
@@ -149,10 +152,11 @@ class TestSystemdServiceManager(TestServiceManager):
         self.assertEqual(self.run_mock.call_args[0][0], cmd)
 
     def test_list(self):
-        list_result_mock = MagicMock(exit_status=0, stdout="sshd.service enabled\n"
-                                                           "vsftpd.service disabled\n"
-                                                           "systemd-sysctl.service static\n")
-        run_mock = MagicMock(return_value=list_result_mock)
+        list_result_mock = mock.MagicMock(exit_status=0,
+                                          stdout="sshd.service enabled\n"
+                                          "vsftpd.service disabled\n"
+                                          "systemd-sysctl.service static\n")
+        run_mock = mock.MagicMock(return_value=list_result_mock)
         service_manager = super(TestSystemdServiceManager,
                                 self).get_service_manager_from_init_and_run(self.init_name,
                                                                             run_mock)
@@ -165,13 +169,13 @@ class TestSystemdServiceManager(TestServiceManager):
 
     def test_set_default_runlevel(self):
         runlevel = service.convert_sysv_runlevel(3)
-        mktemp_mock = MagicMock(return_value="temp_filename")
-        symlink_mock = MagicMock()
-        rename_mock = MagicMock()
+        mktemp_mock = mock.MagicMock(return_value="temp_filename")
+        symlink_mock = mock.MagicMock()
+        rename_mock = mock.MagicMock()
 
-        @patch.object(service, "mktemp", mktemp_mock)
-        @patch("os.symlink", symlink_mock)
-        @patch("os.rename", rename_mock)
+        @mock.patch.object(service, "mktemp", mktemp_mock)
+        @mock.patch("os.symlink", symlink_mock)
+        @mock.patch("os.rename", rename_mock)
         def _():
             self.service_manager.change_default_runlevel(runlevel)
             self.assertTrue(mktemp_mock.called)
@@ -196,21 +200,22 @@ class TestSystemdServiceManager(TestServiceManager):
 class TestSysVInitServiceManager(TestServiceManager):
 
     def setUp(self):
-        self.run_mock = MagicMock()
+        self.run_mock = mock.MagicMock()
         self.init_name = "init"
         self.service_manager = super(TestSysVInitServiceManager,
                                      self).get_service_manager_from_init_and_run(self.init_name,
                                                                                  self.run_mock)
 
     def test_list(self):
-        list_result_mock = MagicMock(exit_status=0,
-                                     stdout="sshd             0:off   1:off   2:off   3:off   4:off   5:off   6:off\n"
-                                            "vsftpd           0:off   1:off   2:off   3:off   4:off   5:on   6:off\n"
-                                            "xinetd based services:\n"
-                                            "        amanda:         off\n"
-                                            "        chargen-dgram:  on\n")
+        list_result_mock = mock.MagicMock(
+            exit_status=0,
+            stdout="sshd             0:off   1:off   2:off   3:off   4:off   5:off   6:off\n"
+            "vsftpd           0:off   1:off   2:off   3:off   4:off   5:on   6:off\n"
+            "xinetd based services:\n"
+            "        amanda:         off\n"
+            "        chargen-dgram:  on\n")
 
-        run_mock = MagicMock(return_value=list_result_mock)
+        run_mock = mock.MagicMock(return_value=list_result_mock)
         service_manager = super(TestSysVInitServiceManager,
                                 self).get_service_manager_from_init_and_run(self.init_name,
                                                                             run_mock)

--- a/selftests/unit/test_utils_service.py
+++ b/selftests/unit/test_utils_service.py
@@ -87,9 +87,9 @@ class TestSysVInit(unittest.TestCase):
 class TestSpecificServiceManager(unittest.TestCase):
 
     def setUp(self):
-        self.run_mock = mock.MagicMock()
+        self.run_mock = mock.Mock()
         self.init_name = "init"
-        get_name_of_init_mock = mock.MagicMock(return_value="init")
+        get_name_of_init_mock = mock.Mock(return_value="init")
 
         @mock.patch.object(service, "get_name_of_init", get_name_of_init_mock)
         def patch_service_command_generator():
@@ -139,7 +139,7 @@ class TestServiceManager(unittest.TestCase):
 class TestSystemdServiceManager(TestServiceManager):
 
     def setUp(self):
-        self.run_mock = mock.MagicMock()
+        self.run_mock = mock.Mock()
         self.init_name = "systemd"
         self.service_manager = super(TestSystemdServiceManager,
                                      self).get_service_manager_from_init_and_run(self.init_name,
@@ -152,11 +152,11 @@ class TestSystemdServiceManager(TestServiceManager):
         self.assertEqual(self.run_mock.call_args[0][0], cmd)
 
     def test_list(self):
-        list_result_mock = mock.MagicMock(exit_status=0,
-                                          stdout="sshd.service enabled\n"
-                                          "vsftpd.service disabled\n"
-                                          "systemd-sysctl.service static\n")
-        run_mock = mock.MagicMock(return_value=list_result_mock)
+        list_result_mock = mock.Mock(exit_status=0,
+                                     stdout="sshd.service enabled\n"
+                                     "vsftpd.service disabled\n"
+                                     "systemd-sysctl.service static\n")
+        run_mock = mock.Mock(return_value=list_result_mock)
         service_manager = super(TestSystemdServiceManager,
                                 self).get_service_manager_from_init_and_run(self.init_name,
                                                                             run_mock)
@@ -169,9 +169,9 @@ class TestSystemdServiceManager(TestServiceManager):
 
     def test_set_default_runlevel(self):
         runlevel = service.convert_sysv_runlevel(3)
-        mktemp_mock = mock.MagicMock(return_value="temp_filename")
-        symlink_mock = mock.MagicMock()
-        rename_mock = mock.MagicMock()
+        mktemp_mock = mock.Mock(return_value="temp_filename")
+        symlink_mock = mock.Mock()
+        rename_mock = mock.Mock()
 
         @mock.patch.object(service, "mktemp", mktemp_mock)
         @mock.patch("os.symlink", symlink_mock)
@@ -200,14 +200,14 @@ class TestSystemdServiceManager(TestServiceManager):
 class TestSysVInitServiceManager(TestServiceManager):
 
     def setUp(self):
-        self.run_mock = mock.MagicMock()
+        self.run_mock = mock.Mock()
         self.init_name = "init"
         self.service_manager = super(TestSysVInitServiceManager,
                                      self).get_service_manager_from_init_and_run(self.init_name,
                                                                                  self.run_mock)
 
     def test_list(self):
-        list_result_mock = mock.MagicMock(
+        list_result_mock = mock.Mock(
             exit_status=0,
             stdout="sshd             0:off   1:off   2:off   3:off   4:off   5:off   6:off\n"
             "vsftpd           0:off   1:off   2:off   3:off   4:off   5:on   6:off\n"
@@ -215,7 +215,7 @@ class TestSysVInitServiceManager(TestServiceManager):
             "        amanda:         off\n"
             "        chargen-dgram:  on\n")
 
-        run_mock = mock.MagicMock(return_value=list_result_mock)
+        run_mock = mock.Mock(return_value=list_result_mock)
         service_manager = super(TestSysVInitServiceManager,
                                 self).get_service_manager_from_init_and_run(self.init_name,
                                                                             run_mock)


### PR DESCRIPTION
This is a collection of unittest adjustments to make them work properly under both Python 2 and 3.

On a single instance (IIRC, only for `test_jobdata`), I reckoned it was not worth the effort to attempt complex techniques of loading pickled data generated on Python 2 on Python 3, so that test is skipped on Python 3.

This PR introduces `six` as a direct dependency, which just makes things more explicit, since it already is a dependency of `stevedore`.  Based on my experiments, it may even be possible to drop `2to3` in the near future, allowing the code (and not the built code) to also be usable on Python 3 directly.