### PR TITLE
log the raw output on stdout/stderr

### DIFF
--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -478,7 +478,7 @@ class SubProcess(object):
                         for line in bfr.splitlines():
                             log.debug(prefix, line)
                             if stream_logger is not None:
-                                stream_logger.debug(stream_prefix, line)
+                                stream_logger.debug(stream_prefix, '%s\n' % line)
                         bfr = ''
             finally:
                 lock.release()

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -145,11 +145,11 @@ class OutputTest(unittest.TestCase):
                 "[stderr] test_stderr", "[stdout] test_process"]
         _check_output(joblog, exps, "job.log")
         testdir = res["tests"][0]["logdir"]
-        self.assertEqual("test_print\ntest_stdout\ntest_process\n",
+        self.assertEqual("test_printtest_stdouttest_process\n",
                          open(os.path.join(testdir, "stdout")).read())
-        self.assertEqual("test_stderr\n",
+        self.assertEqual("test_stderr",
                          open(os.path.join(testdir, "stderr")).read())
-        self.assertEqual("test_print\ntest_stdout\ntest_stderr\n"
+        self.assertEqual("test_printtest_stdouttest_stderr"
                          "test_process\n",
                          open(os.path.join(testdir, "output")).read())
 


### PR DESCRIPTION
Avocado process module has a routine to drain the std* buffer with a
per-line basis loop. This loop makes the new-line character to be
dropped.

On the other hand, the Python logging system is hard-coded to add a new-line
character at the end of the msg string.

The problem takes place when `process` writes a line which originally
had new-line character at the end but the logging system still adds the
new-line character to that line.

In this patch:
- avocado.utils.process to include the new-line character in the lines
  that originally had one.
- avocado.core.test to use for raw outputs a custom logging FileHandler
  that does not add a new-line character at the end of each line.

Verified with (checking `.../test-results/1-.../[stdout|stderr|output]`):

    $ avocado run --external-runner '/bin/echo' 'foo'

    $ avocado run --external-runner '/bin/echo -n' 'foo'

    $ avocado run --external-runner '/bin/ls' '.'

    $ avocado run --external-runner '/bin/ls' 'nonexistingfile VERSION'

----
v2:
- `output` file to also use the `RawFileLogger`.
- `avocado.utils.process` to re-include the dropped new-line character to the lines where it applies.

v1: #2234 