### PR TITLE
jobdata selftests: split into individual test cases

### DIFF
--- a/selftests/unit/test_jobdata.py
+++ b/selftests/unit/test_jobdata.py
@@ -14,78 +14,65 @@ class JobdataTest(unittest.TestCase):
 
     def _check_results(self, dirname):
         pth = os.path.join(BASEDIR, "selftests", ".data", dirname)
-        errs = []
+
         # pwd
-        exp = "/home/medic/Work/Projekty/avocado/avocado"
-        act = jobdata.retrieve_pwd(pth)
-        if act != exp:
-            errs.append("pwd: '%s' '%s'" % (exp, act))
+        self.assertEqual(jobdata.retrieve_pwd(pth),
+                         "/home/medic/Work/Projekty/avocado/avocado",
+                         "pwd mismatch")
 
         # references
-        exp = ["yes", "no"]
-        act = jobdata.retrieve_references(pth)
-        if act != exp:
-            errs.append("references: '%s' '%s'" % (exp, act))
+        self.assertEqual(jobdata.retrieve_references(pth),
+                         ["yes", "no"], "references mismatch")
 
         # variants
         try:
             variants = jobdata.retrieve_variants(pth)
-            act = variants.to_str(0, 99)
         except Exception as details:
-            errs.append("variants: Unable to retrieve: %s" % details)
-        else:
-            exp = ("\nVariant variant1-6ec4:    /run/variant1\n"
-                   "    /run/variant1:foo => bar\n\n"
-                   "Variant variant2-a6fe:    /run/variant2\n"
-                   "    /run/variant2:foo => baz")
-            if not act or exp not in act:
-                errs.append("variants:\n%s\n\n%s" % (exp, act))
+            self.fail("variants: Unable to retrieve: %s" % details)
+        act = variants.to_str(0, 99)
+        self.assertTrue(act)
+        exp = ("\nVariant variant1-6ec4:    /run/variant1\n"
+               "    /run/variant1:foo => bar\n\n"
+               "Variant variant2-a6fe:    /run/variant2\n"
+               "    /run/variant2:foo => baz")
+        self.assertIn(exp, act, "variants mismatch")
 
         # args
         try:
             args = jobdata.retrieve_args(pth)
         except Exception as details:
-            errs.append("args: Unable to retrieve: %s" % details)
-        else:
-            if isinstance(args, dict):
-                for scenario in [["loaders", [u"external:/bin/echo"]],
-                                 ["external_runner", u"/bin/echo"],
-                                 ["failfast", False, None],
-                                 ["ignore_missing_references", False, None],
-                                 ["execution_order", "variants-per-test",
-                                  None]]:
-                    act = args.get(scenario[0])
-                    for exp in scenario[1:]:
-                        if act == exp:
-                            break
-                    else:
-                        errs.append("args: Invalid value '%s' of key '%s' "
-                                    "%s" % (act, scenario[0],
-                                            scenario[1:]))
-            else:
-                errs.append("args: Invalid args: %s" % args)
+            self.fail("args: Unable to retrieve: %s" % details)
+        self.assertTrue(isinstance(args, dict),
+                        "args: Invalid args: %s" % args)
+        for scenario in [["loaders", [u"external:/bin/echo"]],
+                         ["external_runner", u"/bin/echo"],
+                         ["failfast", False, None],
+                         ["ignore_missing_references", False, None],
+                         ["execution_order", "variants-per-test",
+                          None]]:
+            act = args.get(scenario[0])
+            self.assertIn(act, scenario[1:],
+                          "args: Invalid value '%s' of key '%s' '%s'" % (
+                              act, scenario[0], scenario[1:]))
 
         # config
         conf_path = jobdata.retrieve_config(pth)
-        if os.path.exists(conf_path):
-            exp = "[avocado.selftest]\njobdata = yes"
-            with open(conf_path, "r") as conf:
-                act = conf.read()
-                if exp not in act:
-                    errs.append("config: Expected string\n%s\n\nNot in:\n%s"
-                                % (exp, act))
-
-        else:
-            errs.append("config: Retrieved path '%s' does not exists"
-                        % conf_path)
+        self.assertTrue(os.path.exists(conf_path),
+                        "config: Retrieved path '%s' does not exists" %
+                        conf_path)
+        exp = "[avocado.selftest]\njobdata = yes"
+        with open(conf_path, "r") as conf:
+            act = conf.read()
+            self.assertIn(exp, act,
+                          "config: Expected string\n%s\n\nNot in:\n%s" % (
+                              exp, act))
 
         # cmdline
         act = jobdata.retrieve_cmdline(pth)
         exp = ['/usr/local/bin/avocado', 'run', '--external-runner',
                '/bin/echo', '-m', 'examples/mux-0.yaml', '--', 'yes', 'no']
-        if exp != act:
-            errs.append("cmdline: Invalid cmdline '%s' (%s)" % (act, exp))
-        self.assertFalse(errs, "Errors: %s" % "\n  ".join(errs))
+        self.assertEqual(exp, act,
+                         "cmdline: Invalid cmdline '%s' (%s)" % (act, exp))
 
     @unittest.skipIf(PY3, "Skipping tests with data pickled on Python 2")
     def setUp(self):

--- a/selftests/unit/test_jobdata.py
+++ b/selftests/unit/test_jobdata.py
@@ -1,4 +1,3 @@
-import glob
 import os
 import unittest
 
@@ -13,8 +12,8 @@ BASEDIR = os.path.abspath(BASEDIR)
 
 class JobdataTest(unittest.TestCase):
 
-    @staticmethod
-    def _check_results(pth):
+    def _check_results(self, dirname):
+        pth = os.path.join(BASEDIR, "selftests", ".data", dirname)
         errs = []
         # pwd
         exp = "/home/medic/Work/Projekty/avocado/avocado"
@@ -86,21 +85,35 @@ class JobdataTest(unittest.TestCase):
                '/bin/echo', '-m', 'examples/mux-0.yaml', '--', 'yes', 'no']
         if exp != act:
             errs.append("cmdline: Invalid cmdline '%s' (%s)" % (act, exp))
-        return errs
+        self.assertFalse(errs, "Errors: %s" % "\n  ".join(errs))
 
     @unittest.skipIf(PY3, "Skipping tests with data pickled on Python 2")
-    def test_versions(self):
+    def setUp(self):
         os.chdir(BASEDIR)
-        errs = []
-        for pth in sorted(glob.glob(os.path.join(BASEDIR, "selftests",
-                                                 ".data", "results-*"))):
-            res = self._check_results(pth)
-            if res:
-                name = os.path.basename(pth)
-                errs.append("%s\n%s\n\n  %s\n\n" % (name, "-" * len(name),
-                                                    "\n  ".join(res)))
-        self.assertFalse(errs, "Some results were not loaded properly:\n%s"
-                         % "\n * ".join(errs))
+
+    def test_36_0_lts(self):
+        self._check_results("results-36.0lts")
+
+    def test_36_4(self):
+        self._check_results("results-36.4")
+
+    def test_37_0(self):
+        self._check_results("results-37.0")
+
+    def test_38_0(self):
+        self._check_results("results-38.0")
+
+    def test_39_0(self):
+        self._check_results("results-39.0")
+
+    def test_40_0(self):
+        self._check_results("results-40.0")
+
+    def test_41_0(self):
+        self._check_results("results-41.0")
+
+    def test_51_0(self):
+        self._check_results("results-51.0")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
And switch to an more "unittest.TestCase" like approach.

Besides the style and result visibility values in itself, with a Python 3 port, this will allow us to selectively test some of the more recent versions and skip others depending on the environment we're running (Python 2 or Python 3).