### PR TITLE
Drop flexmock requirement [v3]

### DIFF
--- a/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
+++ b/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
@@ -317,7 +317,7 @@ class RemoteTestRunner(TestRunner):
         self.remote = None
 
     def setup(self):
-        """ Setup remote environment and copy test directories """
+        """ Setup remote environment """
         stdout_claimed_by = getattr(self.job.args, 'stdout_claimed_by', None)
         if not stdout_claimed_by:
             self.job.log.info("LOGIN      : %s@%s:%d (TIMEOUT: %s seconds)",

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -29,7 +29,7 @@
 Summary: Framework with tools and libraries for Automated Testing
 Name: python-%{srcname}
 Version: 54.1
-Release: 1%{?gitrel}%{?dist}
+Release: 2%{?gitrel}%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.github.io/
@@ -43,7 +43,6 @@ BuildRequires: fabric
 BuildRequires: procps-ng
 BuildRequires: pystache
 BuildRequires: python-docutils
-BuildRequires: python-flexmock
 BuildRequires: python-lxml
 BuildRequires: python-mock
 BuildRequires: python-psutil
@@ -370,6 +369,10 @@ examples of how to write tests on your own.
 %{_datadir}/avocado/yaml_to_mux_loader
 
 %changelog
+
+* Wed Oct  4 2017 Cleber Rosa <cleber@redhat.com> - 54.1-2
+- Remove python-flexmock requirement
+
 * Wed Oct  4 2017 Cleber Rosa <cleber@redhat.com> - 54.1-1
 - Add explicit BuildRequires for python-six
 

--- a/requirements-selftests.txt
+++ b/requirements-selftests.txt
@@ -3,8 +3,6 @@
 setuptools>=18.0.0
 # sphinx (doc build test)
 Sphinx>=1.3b1
-# flexmock (some unittests use it)
-flexmock>=0.9.7
 # inspektor (static and style checks)
 inspektor>=0.4.5
 # mock (some unittests use it)

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,7 +1,6 @@
 # All pip installable requirements pinned for Travis CI
 fabric==1.11.1
 Sphinx==1.3b1
-flexmock==0.9.7
 inspektor==0.4.5
 pep8==1.6.2
 requests==1.2.3

--- a/selftests/unit/test_datadir.py
+++ b/selftests/unit/test_datadir.py
@@ -7,7 +7,6 @@ try:
     from unittest import mock
 except ImportError:
     import mock
-from flexmock import flexmock
 
 from six.moves import xrange as range
 
@@ -92,17 +91,15 @@ class DataDirTest(unittest.TestCase):
         No data_dir module reload should be necessary to get the new locations
         from data_dir APIs.
         """
-        stg_orig = settings.settings
-        from avocado.core import data_dir
         (self.alt_mapping,
          self.alt_config_file_path) = self._get_temporary_dirs_mapping_and_config()
         stg = settings.Settings(self.alt_config_file_path)
-        flexmock(settings, settings=stg)
-        for key in self.alt_mapping.keys():
-            data_dir_func = getattr(data_dir, 'get_%s' % key)
-            self.assertEqual(data_dir_func(), self.alt_mapping[key])
-        flexmock(settings, settings=stg_orig)
-        del data_dir
+        with mock.patch('avocado.core.data_dir.settings.settings', stg):
+            from avocado.core import data_dir
+            for key in self.alt_mapping.keys():
+                data_dir_func = getattr(data_dir, 'get_%s' % key)
+                self.assertEqual(data_dir_func(), self.alt_mapping[key])
+            del data_dir
 
     def tearDown(self):
         os.unlink(self.config_file_path)

--- a/selftests/unit/test_datadir.py
+++ b/selftests/unit/test_datadir.py
@@ -3,6 +3,10 @@ import os
 import shutil
 import tempfile
 
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 from flexmock import flexmock
 
 from six.moves import xrange as range
@@ -43,21 +47,17 @@ class DataDirTest(unittest.TestCase):
         """
         When avocado.conf is present, honor the values coming from it.
         """
-        stg_orig = settings.settings
         stg = settings.Settings(self.config_file_path)
-        try:
-            # Trick the module to think we're on a system wide install
-            stg.intree = False
-            flexmock(settings, settings=stg)
+        # Trick the module to think we're on a system wide install
+        stg.intree = False
+        with mock.patch('avocado.core.data_dir.settings.settings', stg):
             from avocado.core import data_dir
-            flexmock(data_dir.settings, settings=stg)
             self.assertFalse(data_dir.settings.settings.intree)
             for key in self.mapping.keys():
                 data_dir_func = getattr(data_dir, 'get_%s' % key)
                 self.assertEqual(data_dir_func(), stg.get_value('datadir.paths', key))
-        finally:
-            flexmock(settings, settings=stg_orig)
-        del data_dir
+        # make sure that without the patch, we have a different value here
+        self.assertTrue(data_dir.settings.settings.intree)
 
     def test_unique_log_dir(self):
         """

--- a/selftests/unit/test_datadir.py
+++ b/selftests/unit/test_datadir.py
@@ -65,20 +65,21 @@ class DataDirTest(unittest.TestCase):
         unique results.
         """
         from avocado.core import data_dir
-        flexmock(data_dir.time).should_receive('strftime').and_return("date")
-        logdir = os.path.join(self.mapping['base_dir'], "foor", "bar", "baz")
-        path_prefix = os.path.join(logdir, "job-date-")
-        uid = "1234567890"*4
-        for i in range(7, 40):
+        with mock.patch('avocado.core.data_dir.time.strftime',
+                        return_value="date_would_go_here"):
+            logdir = os.path.join(self.mapping['base_dir'], "foor", "bar", "baz")
+            path_prefix = os.path.join(logdir, "job-date_would_go_here-")
+            uid = "1234567890"*4
+            for i in range(7, 40):
+                path = data_dir.create_job_logs_dir(logdir, uid)
+                self.assertEqual(path, path_prefix + uid[:i])
+                self.assertTrue(os.path.exists(path))
             path = data_dir.create_job_logs_dir(logdir, uid)
-            self.assertEqual(path, path_prefix + uid[:i])
+            self.assertEqual(path, path_prefix + uid + ".0")
             self.assertTrue(os.path.exists(path))
-        path = data_dir.create_job_logs_dir(logdir, uid)
-        self.assertEqual(path, path_prefix + uid + ".0")
-        self.assertTrue(os.path.exists(path))
-        path = data_dir.create_job_logs_dir(logdir, uid)
-        self.assertEqual(path, path_prefix + uid + ".1")
-        self.assertTrue(os.path.exists(path))
+            path = data_dir.create_job_logs_dir(logdir, uid)
+            self.assertEqual(path, path_prefix + uid + ".1")
+            self.assertTrue(os.path.exists(path))
 
     def test_settings_dir_alternate_dynamic(self):
         """

--- a/selftests/unit/test_distro.py
+++ b/selftests/unit/test_distro.py
@@ -1,8 +1,10 @@
-import os
 import re
 import unittest
 
-from flexmock import flexmock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from avocado.utils import distro
 
@@ -64,10 +66,11 @@ class ProbeTest(unittest.TestCase):
             CHECK_FILE = distro_file
             CHECK_FILE_DISTRO_NAME = distro_name
 
-        flexmock(os.path)
-        os.path.should_receive('exists').and_return(True)
         my_probe = MyProbe()
-        probed_distro_name = my_probe.name_for_file()
+        with mock.patch('avocado.utils.distro.os.path.exists',
+                        return_value=True) as mocked:
+            probed_distro_name = my_probe.name_for_file()
+            mocked.assert_called_once_with(distro_file)
         self.assertEqual(distro_name, probed_distro_name)
 
 

--- a/selftests/unit/test_remote.py
+++ b/selftests/unit/test_remote.py
@@ -1,10 +1,15 @@
-import logging
-import os
+import argparse
+import shutil
 import unittest
 
-from flexmock import flexmock, flexmock_teardown
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
-from avocado.utils import archive
+from avocado.core.job import Job
+from avocado.core import version
+from avocado.utils import process
 import avocado_runner_remote
 
 
@@ -25,154 +30,80 @@ class RemoteTestRunnerTest(unittest.TestCase):
 
     """ Tests RemoteTestRunner """
 
-    def setUp(self):
-        Args = flexmock(test_result_total=1,
-                        remote_username='username',
-                        remote_hostname='hostname',
-                        remote_port=22,
-                        remote_password='password',
-                        remote_key_file=None,
-                        remote_timeout=60,
-                        show_job_log=False,
-                        mux_yaml=['~/avocado/tests/foo.yaml',
-                                  '~/avocado/tests/bar/baz.yaml'],
-                        dry_run=True,
-                        env_keep=None)
-        log = flexmock()
-        log.should_receive("info")
-        result_dispatcher = flexmock()
-        result_dispatcher.should_receive("map_method")
-        job = flexmock(args=Args, log=log,
-                       references=['/tests/sleeptest', '/tests/other/test',
-                                   'passtest'], unique_id='1-sleeptest;0',
-                       logdir="/local/path",
-                       _result_events_dispatcher=result_dispatcher)
-
-        flexmock(avocado_runner_remote.RemoteTestRunner).should_receive('__init__')
-        self.runner = avocado_runner_remote.RemoteTestRunner(job, None)
-        self.runner.job = job
-
-        filehandler = logging.StreamHandler()
-        flexmock(logging).should_receive("FileHandler").and_return(filehandler)
-
-        test_results = flexmock(stdout=JSON_RESULTS, exit_status=0)
-        stream = flexmock(job_unique_id='1-sleeptest;0',
-                          debuglog='/local/path/dirname')
-        Remote = flexmock()
-        Remoter = flexmock(avocado_runner_remote.Remote)
-        Remoter.new_instances(Remote)
-        args_version = 'avocado -v'
-        version_result = flexmock(stderr='Avocado 1.2', exit_status=0)
-        args_env = 'env'
-        env_result = flexmock(stdout='''XDG_SESSION_ID=20
-HOSTNAME=rhel7.0
-SELINUX_ROLE_REQUESTED=
-SHELL=/bin/bash
-TERM=vt100
-HISTSIZE=1000
-SSH_CLIENT=192.168.124.1 52948 22
-SELINUX_USE_CURRENT_RANGE=
-SSH_TTY=/dev/pts/0
-USER=root
-PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin
-MAIL=/var/spool/mail/root
-PWD=/root
-LANG=en_US.UTF-8
-SELINUX_LEVEL_REQUESTED=
-HISTCONTROL=ignoredups
-HOME=/root
-SHLVL=2
-LOGNAME=root
-SSH_CONNECTION=192.168.124.1 52948 192.168.124.65 22
-LESSOPEN=||/usr/bin/lesspipe.sh %s
-XDG_RUNTIME_DIR=/run/user/0
-_=/usr/bin/env''', exit_status=0)
-        (Remote.should_receive('run')
-         .with_args(args_env, ignore_status=True, timeout=60)
-         .once().and_return(env_result))
-
-        (Remote.should_receive('run')
-         .with_args(args_version, ignore_status=True, timeout=60)
-         .once().and_return(version_result))
-
-        args = ("avocado run --force-job-id 1-sleeptest;0 "
-                "--json - --archive /tests/sleeptest /tests/other/test "
-                "passtest -m ~/avocado/tests/foo.yaml "
-                "~/avocado/tests/bar/baz.yaml --dry-run")
-        (Remote.should_receive('run')
-         .with_args(args, timeout=61, ignore_status=True)
-         .once().and_return(test_results))
-        Result = flexmock(remote=Remote, references=['sleeptest'],
-                          stream=stream, timeout=None,
-                          args=flexmock(show_job_log=False,
-                                        mux_yaml=['foo.yaml', 'bar/baz.yaml'],
-                                        dry_run=True))
-        args = {'name': '1-sleeptest;0', 'time_end': 1.23,
-                'status': u'PASS', 'time_start': 0,
-                'time_elapsed': 1.23, 'job_unique_id': '',
-                'fail_reason': u'None',
-                'logdir': u'/local/path/test-results/1-sleeptest;0',
-                'logfile': u'/local/path/test-results/1-sleeptest;0/debug.log',
-                'job_logdir': u'/local/path'}
-        Result.should_receive('start_test').once().with_args(args).ordered()
-        Result.should_receive('check_test').once().with_args(args).ordered()
-        (Remote.should_receive('receive_files')
-         .with_args('/local/path', '/home/user/avocado/logs/run-2014-05-26-'
-                    '15.45.37.zip')).once().ordered()
-        (flexmock(archive).should_receive('uncompress')
-         .with_args('/local/path/run-2014-05-26-15.45.37.zip', '/local/path')
-         .once().ordered())
-        (flexmock(os).should_receive('remove')
-         .with_args('/local/path/run-2014-05-26-15.45.37.zip').once()
-         .ordered())
-        Result.should_receive('end_tests').once().ordered()
-        self.runner.result = Result
-
-    def tearDown(self):
-        flexmock_teardown()
-
     def test_run_suite(self):
-        """ Test RemoteTestRunner.run_suite() """
-        self.runner.run_suite(None, None, 61)
-        flexmock_teardown()  # Checks the expectations
+        """
+        Test RemoteTestRunner.run_suite()
 
+        The general idea of this test is to:
 
-class RemoteTestRunnerSetup(unittest.TestCase):
+        1) Create the machinery necessary to get a RemoteTestRunner
+           setup inside a job, or looking at it the other way around, to
+           have a runner that is created with a valid job.
 
-    """ Tests the RemoteTestRunner setup() method"""
+        2) Mock the interactions with a remote host.  This is done here
+           basically by mocking 'Remote' and 'fabric' usage.
 
-    def setUp(self):
-        Remote = flexmock()
-        remote_remote = flexmock(avocado_runner_remote)
-        (remote_remote.should_receive('Remote')
-         .with_args(hostname='hostname', username='username',
-                    password='password', key_filename=None, port=22,
-                    timeout=60, env_keep=None)
-         .once().ordered()
-         .and_return(Remote))
-        Args = flexmock(test_result_total=1,
-                        reference=['/tests/sleeptest', '/tests/other/test',
-                                   'passtest'],
-                        remote_username='username',
-                        remote_hostname='hostname',
-                        remote_port=22,
-                        remote_password='password',
-                        remote_key_file=None,
-                        remote_timeout=60,
-                        show_job_log=False,
-                        env_keep=None)
-        log = flexmock()
-        log.should_receive("info")
-        job = flexmock(args=Args, log=log)
-        self.runner = avocado_runner_remote.RemoteTestRunner(job, None)
+        3) Provide a polluted JSON to be parsed by the RemoteTestRunner
 
-    def tearDown(self):
-        flexmock_teardown()
+        4) Assert that those results are properly parsed into the
+           job's result
+        """
+        job_args = argparse.Namespace(test_result_total=1,
+                                      remote_username='username',
+                                      remote_hostname='hostname',
+                                      remote_port=22,
+                                      remote_password='password',
+                                      remote_key_file=None,
+                                      remote_timeout=60,
+                                      show_job_log=False,
+                                      mux_yaml=['~/avocado/tests/foo.yaml',
+                                                '~/avocado/tests/bar/baz.yaml'],
+                                      dry_run=True,
+                                      env_keep=None,
+                                      reference=['/tests/sleeptest.py',
+                                                 '/tests/other/test',
+                                                 'passtest.py'])
 
-    def test_setup(self):
-        """ Tests RemoteResult.test_setup() """
-        self.runner.setup()
-        flexmock_teardown()
+        try:
+            job = Job(job_args)
+            runner = avocado_runner_remote.RemoteTestRunner(job, job.result)
+            return_value = (True, (version.MAJOR, version.MINOR))
+            runner.check_remote_avocado = mock.Mock(return_value=return_value)
+
+            # These are mocked at their source, and will prevent fabric from
+            # trying to contact remote hosts
+            with mock.patch('avocado_runner_remote.Remote'):
+                with mock.patch('avocado_runner_remote.fabric'):
+                    runner.remote = avocado_runner_remote.Remote(job_args.remote_hostname)
+
+                # This is the result that the run_suite() will get from remote.run
+                remote_run_result = process.CmdResult()
+                remote_run_result.stdout = JSON_RESULTS
+                remote_run_result.exit_status = 0
+                runner.remote.run = mock.Mock(return_value=remote_run_result)
+
+                # We have to fake the uncompressing and removal of the zip
+                # archive that was never generated on the "remote" end
+                # This test could be expand by mocking creating an actual
+                # zip file instead, but it's really overkill
+                with mock.patch('avocado_runner_remote.archive.uncompress'):
+                    with mock.patch('avocado_runner_remote.os.remove'):
+                        runner.run_suite(None, None, 61)
+
+            # The job was created with dry_run so it should have a zeroed id
+            self.assertEqual(job.result.job_unique_id, '0' * 40)
+            self.assertEqual(job.result.tests_run, 1)
+            self.assertEqual(job.result.passed, 1)
+            cmd_line = ('avocado run --force-job-id '
+                        '0000000000000000000000000000000000000000 --json - '
+                        '--archive /tests/sleeptest.py /tests/other/test '
+                        'passtest.py -m ~/avocado/tests/foo.yaml '
+                        '~/avocado/tests/bar/baz.yaml --dry-run')
+            runner.remote.run.assert_called_with(cmd_line,
+                                                 ignore_status=True,
+                                                 timeout=61)
+        finally:
+            shutil.rmtree(job.args.base_logdir)
 
 
 if __name__ == '__main__':

--- a/selftests/unit/test_test.py
+++ b/selftests/unit/test_test.py
@@ -26,6 +26,19 @@ class TestClassTestUnit(unittest.TestCase):
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp(prefix="avocado_" + __name__)
 
+    def _get_fake_filename_test(self, name):
+
+        class FakeFilename(test.Test):
+            @property
+            def filename(self):
+                return name
+
+            def test(self):
+                pass
+
+        tst_id = test.TestID("test", name=name)
+        return FakeFilename("test", tst_id, base_logdir=self.tmpdir)
+
     def tearDown(self):
         flexmock_teardown()
         shutil.rmtree(self.tmpdir)
@@ -81,12 +94,22 @@ class TestClassTestUnit(unittest.TestCase):
 
         self.assertEqual(os.path.basename(tst.workdir),
                          os.path.basename(tst.logdir))
-        flexmock(tst)
-        tst.should_receive('filename').and_return(os.path.join(self.tmpdir,
-                                                               "a"*250))
-        self.assertEqual(os.path.join(self.tmpdir, "a"*250 + ".data"),
+
+    def test_data_dir(self):
+        """
+        Tests that that a valid datadir exists follwowing the test filename
+        """
+        max_length_name = os.path.join(self.tmpdir, "a" * 250)
+        tst = self._get_fake_filename_test(max_length_name)
+        self.assertEqual(os.path.join(self.tmpdir, max_length_name + ".data"),
                          tst.datadir)
-        tst.should_receive('filename').and_return("a"*251)
+
+    def test_no_data_dir(self):
+        """
+        Tests that with a filename too long, no datadir is possible
+        """
+        above_limit_name = os.path.join(self.tmpdir, "a" * 251)
+        tst = self._get_fake_filename_test(above_limit_name)
         self.assertFalse(tst.datadir)
         tst._record_reference_stdout       # Should does nothing
         tst._record_reference_stderr       # Should does nothing

--- a/selftests/unit/test_test.py
+++ b/selftests/unit/test_test.py
@@ -2,8 +2,10 @@ import os
 import shutil
 import tempfile
 import unittest
-
-from flexmock import flexmock, flexmock_teardown
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from avocado.core import test, exceptions
 from avocado.utils import astring, script
@@ -40,7 +42,6 @@ class TestClassTestUnit(unittest.TestCase):
         return FakeFilename("test", tst_id, base_logdir=self.tmpdir)
 
     def tearDown(self):
-        flexmock_teardown()
         shutil.rmtree(self.tmpdir)
 
     def test_ugly_name(self):
@@ -117,10 +118,9 @@ class TestClassTestUnit(unittest.TestCase):
         tst._record_reference_stderr()
 
     def test_all_dirs_exists_no_hang(self):
-        flexmock(os.path)
-        os.path.should_receive('exists').and_return(True)
-        self.assertRaises(exceptions.TestSetupFail, self.DummyTest, "test",
-                          test.TestID(1, "name"), base_logdir=self.tmpdir)
+        with mock.patch('os.path.exists', return_value=True):
+            self.assertRaises(exceptions.TestSetupFail, self.DummyTest, "test",
+                              test.TestID(1, "name"), base_logdir=self.tmpdir)
 
     def test_try_override_test_variable(self):
         test = self.DummyTest(base_logdir=self.tmpdir)

--- a/selftests/unit/test_utils_partition.py
+++ b/selftests/unit/test_utils_partition.py
@@ -7,10 +7,11 @@ avocado.utils.partition unittests
 import os
 import shutil
 import tempfile
-import time
 import unittest     # pylint: disable=C0411
-
-from flexmock import flexmock, flexmock_teardown
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from avocado.utils import partition, process
 from avocado.utils import path as utils_path
@@ -109,12 +110,10 @@ class TestMtabLock(unittest.TestCase):
     def test_lock(self):
         """ Check double-lock raises exception after 60s (in 0.1s) """
         with partition.MtabLock():
-            # speedup the process a bit
-            (flexmock(time).should_receive("time").and_return(1)
-             .and_return(2).and_return(62))
-            self.assertRaises(partition.PartitionError,
-                              partition.MtabLock().__enter__)
-            flexmock_teardown()
+            with mock.patch('avocado.utils.partition.time.time',
+                            mock.MagicMock(side_effect=[1, 2, 62])):
+                self.assertRaises(partition.PartitionError,
+                                  partition.MtabLock().__enter__)
 
 
 if __name__ == '__main__':

--- a/selftests/unit/test_vm.py
+++ b/selftests/unit/test_vm.py
@@ -1,71 +1,69 @@
+import argparse
+import shutil
 import unittest
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
-from flexmock import flexmock, flexmock_teardown
-
+from avocado.core.job import Job
 import avocado_runner_vm
-
-
-JSON_RESULTS = ('Something other than json\n'
-                '{"tests": [{"test": "sleeptest.1", "url": "sleeptest", '
-                '"status": "PASS", "time": 1.23, "start": 0, "end": 1.23}],'
-                '"debuglog": "/home/user/avocado/logs/run-2014-05-26-15.45.'
-                '37/debug.log", "errors": 0, "skip": 0, "time": 1.4, '
-                '"start": 0, "end": 1.4, "pass": 1, "failures": 0, "total": '
-                '1}\nAdditional stuff other than json')
 
 
 class _FakeVM(avocado_runner_vm.VM):
 
     """
-    Fake VM-inherited object (it's better to inherit it, than to flexmock the
+    Fake VM-inherited object (it's better to inherit it, than to mock the
     isinstance)
     """
 
     def __init__(self):  # pylint: disable=W0231
         # don't call avocado_runner_vm.VM.__init__
         self.snapshot = True
-        self.domain = flexmock(isActive=lambda: True)
+        self.domain = mock.Mock()
+        self.domain.isActive = mock.Mock(return_value=True)
 
 
 class VMTestRunnerSetup(unittest.TestCase):
 
     """ Tests the VMTestRunner setup() method """
 
-    def setUp(self):
-        mock_vm = flexmock(_FakeVM())
-        flexmock(avocado_runner_vm).should_receive('vm_connect').and_return(mock_vm).once().ordered()
-        mock_vm.should_receive('start').and_return(True).once().ordered()
-        mock_vm.should_receive('create_snapshot').once().ordered()
-        # VMTestRunner()
-        Args = flexmock(test_result_total=1,
-                        url=['/tests/sleeptest', '/tests/other/test',
-                             'passtest'],
-                        vm_domain='domain',
-                        vm_username='username',
-                        vm_hostname='hostname',
-                        vm_port=22,
-                        vm_password='password',
-                        vm_key_file=None,
-                        vm_cleanup=True,
-                        vm_no_copy=False,
-                        vm_timeout=120,
-                        vm_hypervisor_uri='my_hypervisor_uri',
-                        env_keep=None)
-        log = flexmock()
-        log.should_receive("info")
-        job = flexmock(args=Args, log=log)
-        self.runner = avocado_runner_vm.VMTestRunner(job, None)
-        mock_vm.should_receive('stop').once().ordered()
-        mock_vm.should_receive('restore_snapshot').once().ordered()
-
-    def tearDown(self):
-        flexmock_teardown()
-
     def test_setup(self):
-        """ Tests VMTestRunner.setup() """
-        self.runner.setup()
-        self.runner.tear_down()
-        flexmock_teardown()
+        mock_vm = _FakeVM()
+        mock_vm.start = mock.Mock(return_value=True)
+        mock_vm.create_snapshot = mock.Mock()
+        mock_vm.stop = mock.Mock()
+        mock_vm.restore_snapshot = mock.Mock()
+        job_args = argparse.Namespace(test_result_total=1,
+                                      vm_domain='domain',
+                                      vm_username='username',
+                                      vm_hostname='hostname',
+                                      vm_port=22,
+                                      vm_password='password',
+                                      vm_key_file=None,
+                                      vm_cleanup=True,
+                                      vm_no_copy=False,
+                                      vm_timeout=120,
+                                      vm_hypervisor_uri='my_hypervisor_uri',
+                                      reference=['/tests/sleeptest.py',
+                                                 '/tests/other/test',
+                                                 'passtest.py'],
+                                      dry_run=True,
+                                      env_keep=None)
+        try:
+            job = Job(job_args)
+            with mock.patch('avocado_runner_vm.vm_connect',
+                            return_value=mock_vm):
+                # VMTestRunner()
+                runner = avocado_runner_vm.VMTestRunner(job, None)
+                runner.setup()
+                runner.tear_down()
+                mock_vm.start.assert_called_once_with()
+                mock_vm.create_snapshot.assert_called_once_with()
+                mock_vm.stop.assert_called_once_with()
+                mock_vm.restore_snapshot.assert_called_once_with()
+        finally:
+            shutil.rmtree(job.args.base_logdir)
 
 
 if __name__ == '__main__':

--- a/spell.ignore
+++ b/spell.ignore
@@ -393,7 +393,6 @@ aexpect
 remoter's
 isinstance
 dkrcmd
-flexmock
 lockfile
 urlparse
 cpus


### PR DESCRIPTION
This is a port to the mock library that is in the standard in Python 3, and it's available in Python 2, and already a requirement for Avocado.

The approach used on this port is to avoid excessive mocking, and use the real code, unless when interacting with dynamic and non-existing components (such as a remote system).

---

Changes from v2 (#2232):
 * Rebased and resolved conflicts
 * Bumped the release number on the SPEC file and updated the ChangeLog entry

Changes from v1 (#2226):
 * Dropped Job related commits from PR #2222, now merged on master
 * Added a try/finally block on `test_remote.py` to ensure temp dir is removed
 * Added a mock assert for `runner.remote.run` on `test_remote.py` to ensure that it got called
 * Switch to mock method `assert_called_once_with` instead of `assert_called_once`, because it's available on mock >= 1.0.0
 * Added a try/finally block on `test_vm.py` to ensure temp dir is removed
 