### PR TITLE
Python 3: make the subcommands sub parser a required option

### DIFF
--- a/avocado/core/parser.py
+++ b/avocado/core/parser.py
@@ -121,6 +121,14 @@ class Parser(object):
             description='valid subcommands',
             help='subcommand help',
             dest='subcommand')
+        # On Python 2, required doesn't make a difference because a
+        # subparser is considered an unconsumed positional arguments,
+        # and not providing one will error with a "too few arguments"
+        # message.  On Python 3, required arguments are used instead.
+        # Unfortunately, there's no way to pass this as an option when
+        # constructing the sub parsers, but it is possible to set that
+        # option afterwards.
+        self.subcommands.required = True
 
         # Allow overriding default params by plugins
         variants = varianter.Varianter(getattr(self.args, "mux-debug", False))


### PR DESCRIPTION
The goal of this change is to make the behavior of the Avocado command
line application as similar as possible to the behavior when running
under Python 2.  This bit is about what happens when the simplest
possible Avocado command line is run:

 $ avocado

On Python 2, it prints the complete usage, along with the error
message "too few arguments".  While we could go employ extreme changes
to make the very same error message be given on Python 3, this seems
wrong.  The reason is that the message is generated by the Python 2
standard library.  The Python 3 standard library relies on "required"
arguments instead.  When settings the subcommand sub parser as a
required option, the behavior is exactly the same, minus the error
message which becomes "the following arguments are required:
subcommand".

Signed-off-by: Cleber Rosa <crosa@redhat.com>