### PR TITLE
Python 3: port avocado.utils.astring

### DIFF
--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -162,7 +162,7 @@ def create_job_logs_dir(base_dir=None, unique_id=None):
 
     :param base_dir: Base log directory, if `None`, use value from configuration.
     :param unique_id: The unique identification. If `None`, create one.
-    :rtype: basestring
+    :rtype: str
     """
     start_time = time.strftime('%Y-%m-%dT%H.%M')
     if base_dir is None:

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -21,6 +21,8 @@ import os
 import re
 import sys
 
+from six import string_types
+
 from . import exit_codes
 from ..utils import path as utils_path
 from .settings import settings
@@ -579,7 +581,7 @@ def add_log_handler(logger, klass=logging.StreamHandler, stream=sys.stdout,
     :param level: Log level (defaults to `INFO``)
     :param fmt: Logging format (defaults to ``%(name)s: %(message)s``)
     """
-    if isinstance(logger, basestring):
+    if isinstance(logger, string_types):
         logger = logging.getLogger(logger)
     handler = klass(stream)
     handler.setLevel(level)
@@ -592,7 +594,7 @@ def add_log_handler(logger, klass=logging.StreamHandler, stream=sys.stdout,
 
 
 def disable_log_handler(logger):
-    if isinstance(logger, basestring):
+    if isinstance(logger, string_types):
         logger = logging.getLogger(logger)
     # Handlers might be reused elsewhere, can't delete them
     while logger.handlers:

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -28,6 +28,8 @@ import sys
 import time
 import unittest
 
+from six import string_types
+
 from . import data_dir
 from . import exceptions
 from . import varianter
@@ -119,7 +121,7 @@ class TestID(object):
         return repr(str(self))
 
     def __eq__(self, other):
-        if isinstance(other, basestring):
+        if isinstance(other, string_types):
             return str(self) == other
         else:
             return self.__dict__ == other.__dict__

--- a/avocado/plugins/list.py
+++ b/avocado/plugins/list.py
@@ -14,6 +14,7 @@
 
 import sys
 
+from six import string_types
 
 from avocado.core import exit_codes, output
 from avocado.core import loader
@@ -62,7 +63,7 @@ class TestLister(object):
             stats[value.lower()] = 0
 
         for cls, params in test_suite:
-            if isinstance(cls, basestring):
+            if isinstance(cls, string_types):
                 cls = test.Test
             type_label = type_label_mapping[cls]
             decorator = decorator_mapping[cls]

--- a/avocado/utils/astring.py
+++ b/avocado/utils/astring.py
@@ -29,6 +29,8 @@ import itertools
 import re
 import string
 
+from six import string_types
+
 
 #: String containing all fs-unfriendly chars (Windows-fat/Linux-ext3)
 FS_UNSAFE_CHARS = '<>:"/\\|?*'
@@ -224,7 +226,7 @@ def string_safe_encode(input_str):
                       be turned into a string
     :returns: a utf-8 encoded ascii stream
     """
-    if not isinstance(input_str, basestring):
+    if not isinstance(input_str, string_types):
         input_str = str(input_str)
     try:
         return input_str.encode("utf-8")

--- a/avocado/utils/stacktrace.py
+++ b/avocado/utils/stacktrace.py
@@ -7,6 +7,8 @@ import inspect
 import pickle
 from pprint import pformat
 
+from six import string_types
+
 
 def tb_info(exc_info):
     """
@@ -34,7 +36,7 @@ def log_exc_info(exc_info, logger=''):
     :param exc_info: Exception info produced by sys.exc_info()
     :param logger: Name or logger instance (defaults to '')
     """
-    if isinstance(logger, basestring):
+    if isinstance(logger, string_types):
         logger = logging.getLogger(logger)
     logger.error('')
     called_from = inspect.currentframe().f_back
@@ -53,7 +55,7 @@ def log_message(message, logger=''):
     :param message: Message
     :param logger: Name or logger instance (defaults to '')
     """
-    if isinstance(logger, basestring):
+    if isinstance(logger, string_types):
         logger = logging.getLogger(logger)
     for line in message.splitlines():
         logger.error(line)

--- a/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
+++ b/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
@@ -441,7 +441,7 @@ class RemoteTestRunner(TestRunner):
 
         for t_dict in json_result['tests']:
             logdir = os.path.join(self.job.logdir, 'test-results')
-            relative_path = astring.string_to_safe_path(t_dict['test'])
+            relative_path = astring.string_to_safe_path(str(t_dict['test']))
             logdir = os.path.join(logdir, relative_path)
             t_dict['logdir'] = logdir
             t_dict['logfile'] = os.path.join(logdir, 'debug.log')

--- a/selftests/unit/test_astring.py
+++ b/selftests/unit/test_astring.py
@@ -1,3 +1,4 @@
+import sys
 import unittest
 
 from avocado.utils import astring
@@ -40,6 +41,11 @@ class AstringTest(unittest.TestCase):
                          "333 333 333\n"
                          "4   4   4   4444")
 
+    # This could be a skip based on the Python version, but this is more
+    # specific to the exact reason why it does/doesn't make sense to run it
+    @unittest.skipUnless(sys.getdefaultencoding() == 'ascii',
+                         "Test verifies conversion behavior of between ascii "
+                         "and utf-8 only")
     def test_unicode_tabular(self):
         """
         Verifies tabular can handle utf-8 chars properly

--- a/selftests/unit/test_astring.py
+++ b/selftests/unit/test_astring.py
@@ -1,6 +1,8 @@
 import sys
 import unittest
 
+from six import PY2
+
 from avocado.utils import astring
 
 
@@ -73,6 +75,10 @@ class AstringTest(unittest.TestCase):
                          "a__________b")
         self.assertEqual(astring.string_to_safe_path('..'), "_.")
         self.assertEqual(len(astring.string_to_safe_path(" " * 300)), 255)
+        if PY2:
+            self.assertRaises(TypeError,
+                              astring.string_to_safe_path,
+                              unicode("foo"))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
A port of `avocado.utils.astring` and related test to Python 3.

Given the nature of the subject, strings, and the big differences between Python 2 and 3 on that matter, it was impossible to not have conditionals on version on even skips on some of the unittests.