### PR TITLE
Python 3 port: address use of dictionary iterators

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -27,6 +27,8 @@ import tempfile
 import time
 import traceback
 
+from six import iteritems
+
 from . import version
 from . import data_dir
 from . import dispatcher
@@ -232,7 +234,7 @@ class Job(object):
     def __stop_job_logging(self):
         if self._stdout_stderr:
             sys.stdout, sys.stderr = self._stdout_stderr
-        for handler, loggers in self.__logging_handlers.iteritems():
+        for handler, loggers in iteritems(self.__logging_handlers):
             for logger in loggers:
                 logging.getLogger(logger).removeHandler(handler)
 

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -25,6 +25,8 @@ import re
 import shlex
 import sys
 
+from six import iteritems
+
 from . import data_dir
 from . import output
 from . import test
@@ -155,7 +157,7 @@ class TestLoaderProxy(object):
             # Using __func__ to avoid problem with different term_supp instances
             healthy_func = getattr(output.TERM_SUPPORT.healthy_str, '__func__')
             types = [mapping[_[0]]
-                     for _ in plugin.get_decorator_mapping().iteritems()
+                     for _ in iteritems(plugin.get_decorator_mapping())
                      if _[1].__func__ is healthy_func]
             return [name + '.' + _ for _ in types]
 
@@ -553,7 +555,7 @@ class FileLoader(TestLoader):
                     if not isinstance(tst[0], str):
                         return None
             else:
-                test_class = (key for key, value in mapping.iteritems()
+                test_class = (key for key, value in iteritems(mapping)
                               if value == self.test_type).next()
                 for tst in tests:
                     if (isinstance(tst[0], str) or
@@ -817,7 +819,7 @@ class FileLoader(TestLoader):
         result = []
         class_methods = safeloader.find_class_and_methods(test_path,
                                                           _RE_UNIT_TEST)
-        for klass, methods in class_methods.iteritems():
+        for klass, methods in iteritems(class_methods):
             if klass in disabled:
                 continue
             if test_path.endswith(".py"):

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -21,7 +21,7 @@ import os
 import re
 import sys
 
-from six import string_types
+from six import string_types, iterkeys
 
 from . import exit_codes
 from ..utils import path as utils_path
@@ -437,7 +437,7 @@ def reconfigure(args):
             disable_log_handler(LOG_UI.getChild("debug"))
 
     # Add custom loggers
-    for name in [_ for _ in enabled if _ not in BUILTIN_STREAMS.iterkeys()]:
+    for name in [_ for _ in enabled if _ not in iterkeys(BUILTIN_STREAMS)]:
         stream_level = re.split(r'(?<!\\):', name, maxsplit=1)
         name = stream_level[0]
         if len(stream_level) == 1:

--- a/avocado/core/parser.py
+++ b/avocado/core/parser.py
@@ -18,6 +18,8 @@ Avocado application command line parsing.
 
 import argparse
 
+from six import iteritems
+
 from . import exit_codes
 from . import varianter
 from . import settings
@@ -80,8 +82,8 @@ class Parser(object):
         self.application.add_argument('--config', metavar='CONFIG_FILE',
                                       nargs='?',
                                       help='Use custom configuration from a file')
-        streams = (['"%s": %s' % _ for _ in BUILTIN_STREAMS.iteritems()] +
-                   ['"%s": %s' % _ for _ in BUILTIN_STREAM_SETS.iteritems()])
+        streams = (['"%s": %s' % _ for _ in iteritems(BUILTIN_STREAMS)] +
+                   ['"%s": %s' % _ for _ in iteritems(BUILTIN_STREAM_SETS)])
         streams = "; ".join(streams)
         self.application.add_argument('--show', action="store",
                                       type=lambda value: value.split(","),

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -28,7 +28,7 @@ import sys
 import time
 import unittest
 
-from six import string_types
+from six import string_types, iteritems
 
 from . import data_dir
 from . import exceptions
@@ -588,7 +588,7 @@ class Test(unittest.TestCase):
             sys.stderr.rm_logger(LOG_JOB.getChild("stderr"))
         if isinstance(sys.stdout, output.LoggingFile):
             sys.stdout.rm_logger(LOG_JOB.getChild("stdout"))
-        for name, handler in self._logging_handlers.iteritems():
+        for name, handler in iteritems(self._logging_handlers):
             logging.getLogger(name).removeHandler(handler)
 
     def _record_reference_stdout(self):
@@ -670,7 +670,7 @@ class Test(unittest.TestCase):
                 test_exception = details
                 self.log.debug("Local variables:")
                 local_vars = inspect.trace()[1][0].f_locals
-                for key, value in local_vars.iteritems():
+                for key, value in iteritems(local_vars):
                     self.log.debug(' -> %s %s: %s', key, type(value), value)
         finally:
             try:
@@ -934,7 +934,7 @@ class SimpleTest(Test):
         """
         try:
             test_params = dict([(str(key), str(val)) for _, key, val in
-                                self.params.iteritems()])
+                                iteritems(self.params)])
 
             # process.run uses shlex.split(), the self.path needs to be escaped
             result = process.run(self._command, verbose=True,
@@ -1099,7 +1099,7 @@ class DryRunTest(MockingTest):
 
     def setUp(self):
         self.log.info("Test params:")
-        for path, key, value in self.params.iteritems():
+        for path, key, value in iteritems(self.params):
             self.log.info("%s:%s ==> %s", path, key, value)
         self.cancel('Test cancelled due to --dry-run')
 

--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -38,6 +38,8 @@ import itertools
 import locale
 import os
 
+from six import iterkeys, iteritems
+
 from . import output
 
 
@@ -80,10 +82,10 @@ class TreeEnvironment(dict):
     def __str__(self):
         # Use __str__ instead of __repr__ to improve readability
         if self:
-            _values = ["%s: %s" % _ for _ in self.iteritems()]
+            _values = ["%s: %s" % _ for _ in iteritems(self)]
             values = "{%s}" % ", ".join(_values)
             _origin = ["%s: %s" % (key, node.path)
-                       for key, node in self.origin.iteritems()]
+                       for key, node in iteritems(self.origin)]
             origin = "{%s}" % ", ".join(_origin)
         else:
             values = "{}"
@@ -276,7 +278,7 @@ class TreeNode(object):
         if self._environment is None:
             self._environment = (self.parent.environment.copy()
                                  if self.parent else TreeEnvironment())
-            for key, value in self.value.iteritems():
+            for key, value in iteritems(self.value):
                 if isinstance(value, list):
                     if (key in self._environment and
                             isinstance(self._environment[key], list)):
@@ -408,7 +410,7 @@ class ValueDict(dict):  # only container pylint: disable=R0903
         self.yaml = srcyaml
         self.node = node
         self.yaml_per_key = {}
-        for key, value in values.iteritems():
+        for key, value in iteritems(values):
             self[key] = value
 
     def __setitem__(self, key, value):
@@ -434,7 +436,7 @@ class ValueDict(dict):  # only container pylint: disable=R0903
 
     def iteritems(self):
         """ Slower implementation with the use of __getitem__ """
-        for key in self.iterkeys():
+        for key in iterkeys(self):
             yield key, self[key]
         raise StopIteration
 
@@ -525,13 +527,13 @@ def tree_view(root, verbose=None, use_utf8=None):
             right = charset['Right']
         out = [node.name]
         if verbose >= 2 and node.is_leaf:
-            values = itertools.chain(node.environment.iteritems(),
+            values = itertools.chain(iteritems(node.environment),
                                      [("filter-only", _)
                                       for _ in node.environment.filter_only],
                                      [("filter-out", _)
                                       for _ in node.environment.filter_out])
         elif verbose in (1, 3):
-            values = itertools.chain(node.value.iteritems(),
+            values = itertools.chain(iteritems(node.value),
                                      [("filter-only", _)
                                       for _ in node.filters[0]],
                                      [("filter-out", _)
@@ -586,9 +588,9 @@ def tree_view(root, verbose=None, use_utf8=None):
         right = charset['Right']
     out = []
     if (verbose >= 2) and root.is_leaf:
-        values = root.environment.iteritems()
+        values = iteritems(root.environment)
     elif verbose in (1, 3):
-        values = root.value.iteritems()
+        values = iteritems(root.value)
     else:
         values = None
     if values:

--- a/avocado/core/varianter.py
+++ b/avocado/core/varianter.py
@@ -22,6 +22,8 @@ Multiplex and create variants.
 import hashlib
 import re
 
+from six import iterkeys, iteritems, itervalues
+
 from . import tree
 from . import dispatcher
 from . import output
@@ -75,9 +77,9 @@ class AvocadoParams(object):
         self._default_params = default_params
 
     def __eq__(self, other):
-        if set(self.__dict__.iterkeys()) != set(other.__dict__.iterkeys()):
+        if set(iterkeys(self.__dict__)) != set(iterkeys(other.__dict__)):
             return False
-        for attr in self.__dict__.iterkeys():
+        for attr in iterkeys(self.__dict__):
             if (getattr(self, attr) != getattr(other, attr)):
                 return False
         return True
@@ -229,11 +231,11 @@ class AvocadoParams(object):
         """
         env = []
         for param in self._rel_paths:
-            for path, key, value in param.iteritems():
+            for path, key, value in iteritems(param):
                 if (path, key) not in env:
                     env.append((path, key))
                     yield (path, key, value)
-        for path, key, value in self._abs_path.iteritems():
+        for path, key, value in iteritems(self._abs_path):
             if (path, key) not in env:
                 env.append((path, key))
                 yield (path, key, value)
@@ -306,7 +308,7 @@ class AvocadoParam(object):
         which generates lots of duplicate entries due to inherited values.
         """
         for leaf in self._leaves:
-            for key, value in leaf.environment.iteritems():
+            for key, value in iteritems(leaf.environment):
                 yield (leaf.environment.origin[key].path, key, value)
 
 
@@ -362,7 +364,7 @@ def variant_to_str(variant, verbosity, out_args=None, debug=False):
     if verbosity:
         env = set()
         for node in variant["variant"]:
-            for key, value in node.environment.iteritems():
+            for key, value in iteritems(node.environment):
                 origin = node.environment.origin[key].path
                 env.add(("%s:%s" % (origin, key), str(value)))
         if not env:
@@ -383,7 +385,7 @@ def dump_ivariants(ivariants):
         """
         return (str(node.path),
                 [(str(node.environment.origin[key].path), str(key), value)
-                 for key, value in node.environment.iteritems()])
+                 for key, value in iteritems(node.environment)])
 
     variants = []
     for variant in ivariants():
@@ -429,7 +431,7 @@ class FakeVariantDispatcher(object):
                                                 paths))
             env = set()
             for node in variant["variant"]:
-                for key, value in node.environment.iteritems():
+                for key, value in iteritems(node.environment):
                     origin = node.environment.origin[key].path
                     env.add(("%s:%s" % (origin, key), str(value)))
             if not env:
@@ -487,7 +489,7 @@ class Varianter(object):
         :param args: Parsed cmdline arguments
         """
         default_params = self.node_class()
-        for default_param in self.default_params.itervalues():
+        for default_param in itervalues(self.default_params):
             default_params.merge(default_param)
         self._default_params = default_params
         self.default_params.clear()     # We don't need these anymore

--- a/avocado/utils/debug.py
+++ b/avocado/utils/debug.py
@@ -19,6 +19,8 @@ import logging
 import time
 import os
 
+from six import iteritems
+
 
 # Use this for debug logging
 LOGGER = logging.getLogger("avocado.debug")
@@ -52,7 +54,7 @@ def log_calls_class(length=None):
     :param length: Max message length
     """
     def wrap(orig_cls):
-        for key, attr in orig_cls.__dict__.iteritems():
+        for key, attr in iteritems(orig_cls.__dict__):
             if callable(attr):
                 setattr(orig_cls, key,
                         _log_calls(attr, length, orig_cls.__name__))
@@ -71,7 +73,7 @@ def _log_calls(func, length=None, cls_name=None):
                   cls_name, func.func_name,
                   ", ".join([str(_) for _ in args]),
                   ", ".join(["%s=%s" % (key, value)
-                             for key, value in kwargs.iteritems()])))
+                             for key, value in iteritems(kwargs)])))
         if length:
             msg = msg[:length]
         LOGGER.debug(msg)

--- a/avocado/utils/memory.py
+++ b/avocado/utils/memory.py
@@ -465,7 +465,7 @@ class MemInfo(object):
                 setattr(self, safe_name, _MemInfoItem(name))
 
     def __iter__(self):
-        for _, item in self.__dict__.iteritems():
+        for item in self.__dict__.items():
             yield item
 
 

--- a/avocado/utils/stacktrace.py
+++ b/avocado/utils/stacktrace.py
@@ -7,7 +7,7 @@ import inspect
 import pickle
 from pprint import pformat
 
-from six import string_types
+from six import string_types, iteritems
 
 
 def tb_info(exc_info):
@@ -84,7 +84,7 @@ def analyze_unpickable_item(path_prefix, obj):
             subitems = enumerate(obj.__iter__())
             path_prefix += "<%s>"
         elif hasattr(obj, "__dict__"):
-            subitems = obj.__dict__.iteritems()
+            subitems = iteritems(obj.__dict__)
             path_prefix += ".%s"
         else:
             return [(path_prefix, obj)]

--- a/optional_plugins/html/avocado_result_html/__init__.py
+++ b/optional_plugins/html/avocado_result_html/__init__.py
@@ -26,6 +26,8 @@ import time
 import pkg_resources
 import pystache
 
+from six import iteritems
+
 from avocado.core import exit_codes
 from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLI, Result
@@ -125,7 +127,7 @@ class ReportModel(object):
             params = ''
             try:
                 parameters = 'Params:\n'
-                for path, key, value in tst['params'].iteritems():
+                for path, key, value in iteritems(tst['params']):
                     parameters += '  %s:%s => %s\n' % (path, key, value)
             except KeyError:
                 pass

--- a/optional_plugins/loader_yaml/avocado_loader_yaml/__init__.py
+++ b/optional_plugins/loader_yaml/avocado_loader_yaml/__init__.py
@@ -15,6 +15,8 @@
 
 import copy
 
+from six import iteritems
+
 from avocado.core import loader
 from avocado.core import mux
 from avocado.core import varianter
@@ -83,7 +85,7 @@ class YamlTestsuiteLoader(loader.TestLoader):
             args = self.args
         else:
             args = copy.deepcopy(self.args)
-            for key, value in _args.iteritems():
+            for key, value in iteritems(_args):
                 setattr(args, key, value)
         extra_params = params.get("test_reference_resolver_extra", default={})
         return loader_class(args, extra_params)

--- a/optional_plugins/resultsdb/avocado_resultsdb/__init__.py
+++ b/optional_plugins/resultsdb/avocado_resultsdb/__init__.py
@@ -19,7 +19,9 @@ Avocado Plugin to propagate Job results to Resultsdb
 import os
 import sys
 import time
+
 import resultsdb_api
+from six import iteritems
 
 from avocado.core.plugin_interfaces import CLI, ResultEvents
 from avocado.core.settings import settings
@@ -105,7 +107,7 @@ class ResultsdbResult(ResultEvents):
                 'status': state['status']}
 
         params = {}
-        for param in state['params'].iteritems():
+        for param in iteritems(state['params']):
             params['param %s' % param[1]] = '%s (path: %s)' % (param[2],
                                                                param[0])
         data.update(params)

--- a/optional_plugins/runner_vm/avocado_runner_vm/__init__.py
+++ b/optional_plugins/runner_vm/avocado_runner_vm/__init__.py
@@ -20,6 +20,7 @@ import time
 from xml.dom import minidom
 
 import libvirt
+from six import iteritems
 
 from avocado.core import exit_codes, exceptions
 from avocado.core.output import LOG_UI
@@ -331,7 +332,7 @@ class VM(object):
         ipversion = libvirt.VIR_IP_ADDR_TYPE_IPV4
 
         ifaces = self.domain.interfaceAddresses(querytype)
-        for iface, data in ifaces.iteritems():
+        for iface, data in iteritems(ifaces):
             if data['addrs'] and data['hwaddr'] != '00:00:00:00:00:00':
                 ip_addr = data['addrs'][0]['addr']
                 ip_type = data['addrs'][0]['type']

--- a/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/__init__.py
+++ b/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/__init__.py
@@ -20,6 +20,8 @@ import os
 import re
 import sys
 
+from six import iteritems
+
 from avocado.core import tree, exit_codes, mux, varianter
 from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLI, Varianter
@@ -156,7 +158,7 @@ def _create_from_yaml(path, cls_node=mux.MuxTreeNode):
 
         def node_content_from_dict(node, values, using):
             """Processes dict values into the current node content"""
-            for key, value in values.iteritems():
+            for key, value in iteritems(values):
                 if isinstance(key, mux.Control):
                     if key.code == YAML_USING:
                         using = handle_control_tag_using(name, using, value)

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -15,8 +15,10 @@ import unittest
 import psutil
 import pkg_resources
 
-from lxml import etree
 from StringIO import StringIO
+
+from lxml import etree
+from six import iteritems
 
 from avocado.core import exit_codes
 from avocado.utils import astring
@@ -169,7 +171,7 @@ class RunnerOperationTest(unittest.TestCase):
                    'data_dir': os.path.join(base_dir, 'data'),
                    'logs_dir': os.path.join(base_dir, 'logs')}
         config = '[datadir.paths]'
-        for key, value in mapping.iteritems():
+        for key, value in iteritems(mapping):
             if not os.path.isdir(value):
                 os.mkdir(value)
             config += "%s = %s\n" % (key, value)

--- a/selftests/unit/test_mux.py
+++ b/selftests/unit/test_mux.py
@@ -5,6 +5,7 @@ import pickle
 import unittest
 import yaml
 
+from six import iteritems
 
 import avocado_varianter_yaml_to_mux as yaml_to_mux
 from avocado.core import mux, tree, varianter
@@ -311,7 +312,7 @@ class TestAvocadoParams(unittest.TestCase):
         repr(self.params1)
         str(self.params1)
         str(varianter.AvocadoParams([], 'Unittest', [], {}))
-        self.assertEqual(15, sum([1 for _ in self.params1.iteritems()]))
+        self.assertEqual(15, sum([1 for _ in iteritems(self.params1)]))
 
     @unittest.skipIf(not yaml_to_mux.MULTIPLEX_CAPABLE, "Not multiplex capable")
     def test_unhashable(self):


### PR DESCRIPTION
This changes uses the six compatibility equivalents for iterkeys,
iteritems and itervalues.

Signed-off-by: Cleber Rosa <crosa@redhat.com>