### PR TITLE
output: Adjust LoggingFile to work with raw output

### DIFF
--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -57,13 +57,13 @@ class OutputTest(Test):
         print "test_print"
         sys.stdout.write("test_stdout\\n")
         sys.stderr.write("test_stderr\\n")
-        process.run("/bin/echo test_process")
+        process.run("/bin/echo -n test_process")
 
     def __del__(self):
         print "del_print"
         sys.stdout.write("del_stdout\\n")
         sys.stderr.write("del_stderr\\n")
-        process.run("/bin/echo del_process")
+        process.run("/bin/echo -n del_process")
 """
 
 
@@ -145,12 +145,12 @@ class OutputTest(unittest.TestCase):
                 "[stderr] test_stderr", "[stdout] test_process"]
         _check_output(joblog, exps, "job.log")
         testdir = res["tests"][0]["logdir"]
-        self.assertEqual("test_printtest_stdouttest_process\n",
+        self.assertEqual("test_print\ntest_stdout\ntest_process",
                          open(os.path.join(testdir, "stdout")).read())
-        self.assertEqual("test_stderr",
+        self.assertEqual("test_stderr\n",
                          open(os.path.join(testdir, "stderr")).read())
-        self.assertEqual("test_printtest_stdouttest_stderr"
-                         "test_process\n",
+        self.assertEqual("test_print\ntest_stdout\ntest_stderr\n"
+                         "test_process",
                          open(os.path.join(testdir, "output")).read())
 
     def tearDown(self):


### PR DESCRIPTION
The 4235b3299210c24f91539754312c8ad09053cf32 changed the
stdout/stderr/output logging handlers to not to add tailing '\n's, but
these are processed by LoggingFile, which is designed to remove the
'\n's and to logged them per line. As a result the unittest was
incorrectly changed as the first outputs actually add the '\n' which was
removed in the expected output.

This patch keeps the raw approach as it is necessary for the last
buffered line and instead of buffering puts all lines including the
tailing '\n' and not '\n' for the remaining last line (if it's
available). Consequently this should improve the situation where output
is being produced by stderr and stdout concurrently as no buffering of
the non-tailing-newline output is done on LoggingFile level.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>