### PR TITLE
Bring back some of the `utils.astring` features

### DIFF
--- a/avocado/utils/astring.py
+++ b/avocado/utils/astring.py
@@ -271,4 +271,10 @@ def string_to_safe_path(input_str):
     elif len(input_str) > 255:
         input_str = input_str[:255]
 
-    return input_str.translate(_FS_TRANSLATE)
+    try:
+        return input_str.translate(_FS_TRANSLATE)
+    except TypeError:
+        # Deal with incorrect encodings
+        for bad_chr in FS_UNSAFE_CHARS:
+            input_str = input_str.replace(bad_chr, "_")
+        return input_str

--- a/avocado/utils/astring.py
+++ b/avocado/utils/astring.py
@@ -34,6 +34,17 @@ from six.moves import zip
 from six.moves import xrange as range
 
 
+#: String containing all fs-unfriendly chars (Windows-fat/Linux-ext3)
+FS_UNSAFE_CHARS = '<>:"/\\|?*'
+
+# Translate table to replace fs-unfriendly chars
+if PY3:
+    _FS_TRANSLATE = bytes.maketrans(bytes(FS_UNSAFE_CHARS, "ascii"),
+                                    b'_________')
+else:
+    _FS_TRANSLATE = string.maketrans(FS_UNSAFE_CHARS, '_________')
+
+
 def bitlist_to_string(data):
     """
     Transform from bit list to ASCII string.
@@ -260,8 +271,4 @@ def string_to_safe_path(input_str):
     elif len(input_str) > 255:
         input_str = input_str[:255]
 
-    if PY3:
-        maketrans = bytes.maketrans
-    else:
-        maketrans = string.maketrans
-    return input_str.translate(maketrans(b'<>:"/\|?*', b'_________'))
+    return input_str.translate(_FS_TRANSLATE)

--- a/selftests/unit/test_astring.py
+++ b/selftests/unit/test_astring.py
@@ -1,8 +1,6 @@
 import sys
 import unittest
 
-from six import PY2
-
 from avocado.utils import astring
 
 
@@ -75,10 +73,9 @@ class AstringTest(unittest.TestCase):
                          "a__________b")
         self.assertEqual(astring.string_to_safe_path('..'), "_.")
         self.assertEqual(len(astring.string_to_safe_path(" " * 300)), 255)
-        if PY2:
-            self.assertRaises(TypeError,
-                              astring.string_to_safe_path,
-                              unicode("foo"))
+        avocado = u'\u0430\u0432\u043e\u043a\u0430\u0434\xff<>'
+        self.assertEqual(astring.string_to_safe_path(avocado),
+                         "%s__" % avocado[:-2])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR reverts some old behavior changed in https://github.com/avocado-framework/avocado/pull/2249 while it keeps the py3 compatibility.

Basically the first commit brings back the `FS_UNSAFE_CHARS` as it might be a useful variable to be exported and the second commit brings back the support to treat unicode in py2 mode as we do that in all of the remaining astring methods.