### PR TITLE
test: check-output to record diffs

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -28,6 +28,7 @@ import sys
 import time
 import unittest
 
+from difflib import unified_diff
 from six import string_types, iteritems
 
 from . import data_dir
@@ -243,6 +244,10 @@ class Test(unittest.TestCase):
         self._stdout_file = os.path.join(self.logdir, 'stdout')
         self._stderr_file = os.path.join(self.logdir, 'stderr')
         self._output_file = os.path.join(self.logdir, 'output')
+        self._stdout_diff_file = os.path.join(self.logdir,
+                                              'stdout_expected.diff')
+        self._stderr_diff_file = os.path.join(self.logdir,
+                                              'stderr_expected.diff')
         self._logging_handlers = {}
 
         self.__outputdir = utils_path.init_dir(self.logdir, 'data')
@@ -606,6 +611,14 @@ class Test(unittest.TestCase):
                 os.path.isfile(self._expected_stdout_file)):
             expected = genio.read_file(self._expected_stdout_file)
             actual = genio.read_file(self._stdout_file)
+
+            diff = unified_diff(expected.splitlines(), actual.splitlines(),
+                                fromfile=self._expected_stdout_file,
+                                tofile=self._stdout_file)
+            with open(self._stdout_diff_file, 'w') as file_obj:
+                for line in diff:
+                    file_obj.write(line.strip()+'\n')
+
             msg = ('Actual test sdtout differs from expected one:\n'
                    'Actual:\n%s\nExpected:\n%s' % (actual, expected))
             self.assertEqual(expected, actual, msg)
@@ -615,6 +628,14 @@ class Test(unittest.TestCase):
                 os.path.isfile(self._expected_stderr_file)):
             expected = genio.read_file(self._expected_stderr_file)
             actual = genio.read_file(self._stderr_file)
+
+            diff = unified_diff(expected.splitlines(), actual.splitlines(),
+                                fromfile=self._expected_stderr_file,
+                                tofile=self._stderr_file)
+            with open(self._stderr_diff_file, 'w') as file_obj:
+                for line in diff:
+                    file_obj.write(line.strip()+'\n')
+
             msg = ('Actual test sdterr differs from expected one:\n'
                    'Actual:\n%s\nExpected:\n%s' % (actual, expected))
             self.assertEqual(expected, actual, msg)

--- a/selftests/functional/test_output_check.py
+++ b/selftests/functional/test_output_check.py
@@ -1,3 +1,4 @@
+import json
 import os
 import tempfile
 import shutil
@@ -15,6 +16,7 @@ basedir = os.path.abspath(basedir)
 AVOCADO = os.environ.get("UNITTEST_AVOCADO_CMD", "./scripts/avocado")
 OUTPUT_SCRIPT_CONTENTS = """#!/bin/sh
 echo "Hello, avocado!"
+echo "Hello, stderr!" >&2
 """
 
 
@@ -97,6 +99,47 @@ class RunnerSimpleTest(unittest.TestCase):
                          "Avocado did not return rc %d:\n%s" %
                          (expected_rc, result))
         self.assertIn(tampered_msg, result.stdout)
+
+    def test_output_diff(self):
+        self.test_output_record_all()
+        tampered_msg_stdout = "I PITY THE FOOL THAT STANDS ON STDOUT!"
+        tampered_msg_stderr = "I PITY THE FOOL THAT STANDS ON STDERR!"
+
+        stdout_file = os.path.join("%s.data/stdout.expected" %
+                                   self.output_script.path)
+        with open(stdout_file, 'w') as stdout_file_obj:
+            stdout_file_obj.write(tampered_msg_stdout)
+
+        stderr_file = os.path.join("%s.data/stderr.expected" %
+                                   self.output_script.path)
+        with open(stderr_file, 'w') as stderr_file_obj:
+            stderr_file_obj.write(tampered_msg_stderr)
+
+        cmd_line = ('%s run --job-results-dir %s --sysinfo=off %s --json -'
+                    % (AVOCADO, self.tmpdir, self.output_script.path))
+        result = process.run(cmd_line, ignore_status=True)
+        expected_rc = exit_codes.AVOCADO_TESTS_FAIL
+        self.assertEqual(result.exit_status, expected_rc,
+                         "Avocado did not return rc %d:\n%s" %
+                         (expected_rc, result))
+
+        json_result = json.loads(result.stdout)
+        stdout_diff = os.path.join(json_result['tests'][0]['logdir'],
+                                   'stdout_expected.diff')
+        stderr_diff = os.path.join(json_result['tests'][0]['logdir'],
+                                   'stderr_expected.diff')
+
+        with open(stdout_diff, 'r') as stdout_diff_obj:
+            stdout_diff_content = stdout_diff_obj.read()
+        self.assertIn('-I PITY THE FOOL THAT STANDS ON STDOUT!',
+                      stdout_diff_content)
+        self.assertIn('+Hello, avocado!', stdout_diff_content)
+
+        with open(stderr_diff, 'r') as stderr_diff_obj:
+            stderr_diff_content = stderr_diff_obj.read()
+        self.assertIn('-I PITY THE FOOL THAT STANDS ON STDERR!',
+                      stderr_diff_content)
+        self.assertIn('+Hello, stderr!', stderr_diff_content)
 
     def test_disable_output_check(self):
         self.test_output_record_all()


### PR DESCRIPTION
The output check functionality logs, on failures, the complete contents
of the both the actual output, and the expected one. Most often than not,
the most relevant information is the difference between both.

This patch records diff files (`stdout_expected.diff` and
`stderr_expected.diff`) containing the unified diff between the expected
outputs and the actual outputs.

Reference: https://trello.com/c/CXDP1khV
Signed-off-by: Amador Pahim <apahim@redhat.com>