### PR TITLE
Python 3 port: enable Avocado to run tests

### DIFF
--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -403,7 +403,7 @@ class TestRunner(object):
         timeout = float(timeout or self.DEFAULT_TIMEOUT)
 
         test_deadline = time_started + timeout
-        if job_deadline > 0:
+        if job_deadline is not None and job_deadline > 0:
             deadline = min(test_deadline, job_deadline)
         else:
             deadline = test_deadline

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -570,7 +570,13 @@ class TestRunner(object):
         summary = set()
         if self.job.sysinfo is not None:
             self.job.sysinfo.start_job_hook()
-        queue = queues.SimpleQueue()
+
+        # Python 3 requires a context for a queue
+        if hasattr(multiprocessing, 'get_context'):
+            ctx = multiprocessing.get_context('spawn')
+            queue = queues.SimpleQueue(ctx=ctx)     # pylint: disable=E1123
+        else:
+            queue = queues.SimpleQueue()
 
         if timeout > 0:
             deadline = time.time() + timeout

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -1051,7 +1051,7 @@ class SimpleTest(Test):
         """
         try:
             test_params = dict([(str(key), str(val)) for _, key, val in
-                                iteritems(self.params)])
+                                self.params.iteritems()])
 
             # process.run uses shlex.split(), the self.path needs to be escaped
             result = process.run(self._command, verbose=True,

--- a/avocado/core/varianter.py
+++ b/avocado/core/varianter.py
@@ -232,11 +232,11 @@ class AvocadoParams(object):
         """
         env = []
         for param in self._rel_paths:
-            for path, key, value in iteritems(param):
+            for path, key, value in param.iteritems():
                 if (path, key) not in env:
                     env.append((path, key))
                     yield (path, key, value)
-        for path, key, value in iteritems(self._abs_path):
+        for path, key, value in self._abs_path.iteritems():
             if (path, key) not in env:
                 env.append((path, key))
                 yield (path, key, value)

--- a/optional_plugins/html/avocado_result_html/__init__.py
+++ b/optional_plugins/html/avocado_result_html/__init__.py
@@ -26,8 +26,6 @@ import time
 import pkg_resources
 import pystache
 
-from six import iteritems
-
 from avocado.core import exit_codes
 from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLI, Result
@@ -127,7 +125,7 @@ class ReportModel(object):
             params = ''
             try:
                 parameters = 'Params:\n'
-                for path, key, value in iteritems(tst['params']):
+                for path, key, value in tst['params'].iteritems():
                     parameters += '  %s:%s => %s\n' % (path, key, value)
             except KeyError:
                 pass

--- a/setup.py
+++ b/setup.py
@@ -151,7 +151,6 @@ if __name__ == '__main__':
               "Topic :: Software Development :: Quality Assurance",
               "Topic :: Software Development :: Testing",
               ],
-          use_2to3=True,
           packages=find_packages(exclude=('selftests*',)),
           data_files=get_data_files(),
           scripts=['scripts/avocado',


### PR DESCRIPTION
The previous batch of Python port work allowed the Avocado test runner to list tests.  This PR enables it to actually run tests.

This was tested with all the default plugins, plus the HTML optional plugin enabled.

There are still issues with Avocado itself, and also with many of the optional plugins.  One of the most visible issues, an `avocado.utils.process` that procues a traceback and a `TypeError: string argument expected, got 'bytes'` error that pollutes the UI, will be handled by a re-spin of PR #2151, which is coming next.