### PR TITLE
sysinfo: Per test collectibles [v3]

### DIFF
--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -601,7 +601,10 @@ class SysInfo(object):
         Logging hook called before a test starts.
         """
         for log in self.start_test_collectibles:
-            log.run(self.pre_dir)
+            if isinstance(log, Daemon):  # log daemons in profile directory
+                log.run(self.profile_dir)
+            else:
+                log.run(self.pre_dir)
 
         if self.log_packages:
             self._log_installed_packages(self.pre_dir)

--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -484,17 +484,27 @@ class SysInfo(object):
                          logpaths)
 
     def _set_collectibles(self):
+        add_per_test = settings.get_value("sysinfo.collect", "per_test",
+                                          bool, None)
         if self.profiler:
             for cmd in self.profilers:
                 self.start_job_collectibles.add(Daemon(cmd))
+                if add_per_test:
+                    self.start_test_collectibles.add(Daemon(cmd))
 
         for cmd in self.commands:
             self.start_job_collectibles.add(Command(cmd))
             self.end_job_collectibles.add(Command(cmd))
+            if add_per_test:
+                self.start_test_collectibles.add(Command(cmd))
+                self.end_test_collectibles.add(Command(cmd))
 
         for filename in self.files:
             self.start_job_collectibles.add(Logfile(filename))
             self.end_job_collectibles.add(Logfile(filename))
+            if add_per_test:
+                self.start_test_collectibles.add(Logfile(filename))
+                self.end_test_collectibles.add(Logfile(filename))
 
         # As the system log path is not standardized between distros,
         # we have to probe and find out the correct path.

--- a/docs/source/Sysinfo.rst
+++ b/docs/source/Sysinfo.rst
@@ -26,6 +26,9 @@ the sysinfo collection. Avocado supports three types of tasks:
 Additionally this plugin tries to follow the system log via ``journalctl``
 if available.
 
+By default these are collected per-job but you can also run them per-test by
+setting ``per_test = True`` in the ``sysinfo.collect`` section.
+
 The sysinfo can also be enabled/disabled on the cmdline if needed by
 ``--sysinfo on|off``.
 

--- a/etc/avocado/avocado.conf
+++ b/etc/avocado/avocado.conf
@@ -23,6 +23,8 @@ installed_packages = False
 profiler = False
 # Force LANG for sysinfo collection
 locale = C
+# Enable sysinfo collection per-test
+per_test = False
 
 [sysinfo.collectibles]
 # File with list of commands that will be executed and have their output collected


### PR DESCRIPTION
We have the support for it every since the beginning, let's allow it's usage as users asked for it https://github.com/avocado-framework/avocado/issues/2169

v1: https://github.com/avocado-framework/avocado/pull/2254
v2: https://github.com/avocado-framework/avocado/pull/2267

Changes:
```yaml
v2: setting renamed from "collectibles_per_test" to "per_test"
v2: fixed typo in commit message
v3: Fixed cfg section in documentation
```