### PR TITLE
golang: error test execution when "go" binary was not found [v2]

### DIFF
--- a/optional_plugins/golang/avocado_golang/__init__.py
+++ b/optional_plugins/golang/avocado_golang/__init__.py
@@ -21,6 +21,7 @@ import glob
 import os
 import re
 
+from avocado.core import exceptions
 from avocado.core import loader
 from avocado.core import output
 from avocado.core import test
@@ -29,7 +30,10 @@ from avocado.utils import path as utils_path
 from avocado.utils import process
 
 
-_GO_BIN = utils_path.find_command('go')
+try:
+    _GO_BIN = utils_path.find_command('go')
+except utils_path.CmdNotFoundError:
+    _GO_BIN = None
 
 
 class GolangTest(test.SimpleTest):
@@ -57,6 +61,9 @@ class GolangTest(test.SimpleTest):
         """
         Create the Golang command and execute it.
         """
+        if _GO_BIN is None:
+            raise exceptions.TestError("go binary not found")
+
         test_name = '%s$' % self.name.name.split(':')[1]
         if self.subtest is not None:
             test_name += '/%s' % self.subtest


### PR DESCRIPTION
This prevents an error when the avocado golang plugin is installed,
but "go" itself is not.

This still allows tests to be listed without "go" because:
 * it is not a requirement for that
 * there's value in listing tests even when your system is (still?)
   not completely setup to run them
 * Avocado hasn't promised symmetry between listing and guaranteeing
   that tests will be able to run
 * There may be situations in which we can *not* predict if tests
   that we can list can be executed

Signed-off-by: Cleber Rosa <crosa@redhat.com>

---

Changes from v1:

* Improved commit message, with reasons for allowing listing
* Fixed the error message (`s/be//`)