### PR TITLE
remote: fix timeout check

### DIFF
--- a/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
+++ b/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
@@ -104,7 +104,7 @@ def run(command, ignore_status=False, quiet=True, timeout=60):
         except fabric.network.NetworkError as details:
             fabric_exception = details
             timeout = end_time - time.time()
-        if time.time() < end_time:
+        if time.time() > end_time:
             break
     if fabric_result is None:
         if fabric_exception is not None:


### PR DESCRIPTION
The operator is inverted since the beginning of times and no one ever
noticed. Until now.

Fixes #2275