### PR TITLE
vmimage: make the list of providers expandable

### DIFF
--- a/avocado/utils/vmimage.py
+++ b/avocado/utils/vmimage.py
@@ -322,7 +322,6 @@ def get(name=None, version=None, build=None, arch=None, checksum=None,
     if cache_dir is None:
         cache_dir = tempfile.gettempdir()
 
-    providers_list = list_providers()
     provider_args = {}
     if version is not None:
         provider_args['version'] = version
@@ -331,7 +330,7 @@ def get(name=None, version=None, build=None, arch=None, checksum=None,
     if arch is not None:
         provider_args['arch'] = arch
 
-    for provider in providers_list:
+    for provider in IMAGE_PROVIDERS:
         if name is None or name == provider.name.lower():
             cls = provider(**provider_args)
             try:
@@ -356,3 +355,6 @@ def list_providers():
             if (_ != ImageProviderBase and
                 isinstance(_, type) and
                 issubclass(_, ImageProviderBase))]
+
+
+IMAGE_PROVIDERS = list_providers()


### PR DESCRIPTION
Creating a public interface to append custom providers to the list will
help users with private/internal image repositories not to edit the
source code in order to create their own providers.

Signed-off-by: Amador Pahim <apahim@redhat.com>