### PR TITLE
utils.vmimage: Use set to store providers

### DIFF
--- a/avocado/utils/vmimage.py
+++ b/avocado/utils/vmimage.py
@@ -351,10 +351,10 @@ def list_providers():
     """
     List the available Image Providers
     """
-    return [_ for _ in globals().itervalues()
-            if (_ != ImageProviderBase and
-                isinstance(_, type) and
-                issubclass(_, ImageProviderBase))]
+    return set(_ for _ in globals().itervalues()
+               if (_ != ImageProviderBase and
+                   isinstance(_, type) and
+                   issubclass(_, ImageProviderBase)))
 
 
 #: List of available providers classes

--- a/docs/source/utils/vmimage.rst
+++ b/docs/source/utils/vmimage.rst
@@ -97,7 +97,7 @@ with::
     class MyTest(Test):
 
         def setUp(self):
-            vmimage.IMAGE_PROVIDERS.append(MyProvider)
+            vmimage.IMAGE_PROVIDERS.add(MyProvider)
             image = vmimage.get('MyDistro')
             ...
 


### PR DESCRIPTION
The IMAGE_PROVIDERS stores possible classes to provide images, let's
avoid unnecessary multiple occurrences.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>