### PR TITLE
loader: defaults to recursive

### DIFF
--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -1197,174 +1197,70 @@ or not, please refer to our section on :ref:`docstring-directive-rules`.
 
 Now let's follow with some docstring directives examples.
 
-.. _docstring-directive-enable-disable:
+.. _docstring-directive-recursive:
 
-Explicitly enabling or disabling tests
---------------------------------------
+Test Inheritance
+----------------
 
 If your test is a method in a class that directly inherits from
 :class:`avocado.Test`, then Avocado will find it as one would expect.
 
-Now, the need may arise for more complex tests, to use more advanced
-Python features such as inheritance.  For those tests that are written
-in a class not directly inherting from :class:`avocado.Test`, Avocado
-may need your help, because Avocado uses only static analysis to examine
-the files.
+For more complex tests, using more advanced Python features such as
+inheritance, written in a class not directly inheriting from
+:class:`avocado.Test`, Avocado will evaluate all the ancestors of the class
+until the base class, the one derived from from ``avocado.Test``.
 
 For example, suppose that you define a new test class that inherits
 from the Avocado base test class, that is, :class:`avocado.Test`, and
-put it in ``mylibrary.py``::
+put it in ``test_base.py``::
 
     from avocado import Test
 
+    class TestBase(Test):
 
-    class MyOwnDerivedTest(Test):
-        def __init__(self, methodName='test', name=None, params=None,
-                     base_logdir=None, job=None, runner_queue=None):
-            super(MyOwnDerivedTest, self).__init__(methodName, name, params,
-                                                   base_logdir, job,
-                                                   runner_queue)
-            self.log('Derived class example')
-
-
-Then you implement your actual test using that derived class, in
-``mytest.py``::
-
-    import mylibrary
-
-
-    class MyTest(mylibrary.MyOwnDerivedTest):
-
-        def test1(self):
-            self.log('Testing something important')
-
-        def test2(self):
-            self.log('Testing something even more important')
-
-
-If you try to list the tests in that file, this is what you'll get::
-
-    scripts/avocado list mytest.py -V
-    Type       Test      Tag(s)
-    NOT_A_TEST mytest.py
-
-    TEST TYPES SUMMARY
-    ==================
-    ACCESS_DENIED: 0
-    BROKEN_SYMLINK: 0
-    EXTERNAL: 0
-    FILTERED: 0
-    INSTRUMENTED: 0
-    MISSING: 0
-    NOT_A_TEST: 1
-    SIMPLE: 0
-    VT: 0
-
-You need to give avocado a little help by adding a docstring
-directive. That docstring directive is ``:avocado: enable``. It tells
-the Avocado safe test detection code to consider it as an avocado
-test, regardless of what the (admittedly simple) detection code thinks
-of it. Let's see how that works out. Add the docstring, as you can see
-the example below::
-
-    import mylibrary
-
-
-    class MyTest(mylibrary.MyOwnDerivedTest):
-        """
-        :avocado: enable
-        """
-        def test1(self):
-            self.log('Testing something important')
-
-        def test2(self):
-            self.log('Testing something even more important')
-
-
-Now, trying to list the tests on the ``mytest.py`` file again::
-
-    scripts/avocado list mytest.py -V
-    Type         Test                   Tag(s)
-    INSTRUMENTED mytest.py:MyTest.test1
-    INSTRUMENTED mytest.py:MyTest.test2
-
-    TEST TYPES SUMMARY
-    ==================
-    ACCESS_DENIED: 0
-    BROKEN_SYMLINK: 0
-    EXTERNAL: 0
-    FILTERED: 0
-    INSTRUMENTED: 2
-    MISSING: 0
-    NOT_A_TEST: 0
-    SIMPLE: 0
-    VT: 0
-
-You can also use the ``:avocado: disable`` docstring directive, that
-works the opposite way: something that would be considered an Avocado
-test, but we force it to not be listed as one.
-
-The docstring ``:avocado: disable`` is evaluated first by Avocado,
-meaning that if both ``:avocado: disable`` and ``:avocado: enable`` are
-present in the same docstring, the test will not be listed.
-
-.. _docstring-directive-recursive:
-
-Recursively Discovering Tests
------------------------------
-
-In addition to the ``:avocado: enable`` and ``:avocado: disable``
-docstring directives, Avocado has support for the ``:avocado: recursive``
-directive. It is intended to be used in inherited classes when you want
-to tell Avocado to also discover the ancestor classes.
-
-The ``:avocado: recursive`` directive will direct Avocado to evaluate all
-the ancestors of the class until the base class, the one derived from
-from ``avocado.Test``.
-
-Example:
-
-File `/usr/share/avocado/tests/test_base_class.py`::
-
-    from avocado import Test
-
-
-    class BaseClass(Test):
-
-        def test_basic(self):
+        def test_base_01(self):
             pass
 
-
-File `/usr/share/avocado/tests/test_first_child.py`::
-
-    from test_base_class import BaseClass
-
-
-    class FirstChild(BaseClass):
-
-        def test_first_child(self):
+        def test_base_02(self):
             pass
 
+Running ``avocado list test_base.py`` will return::
 
-File `/usr/share/avocado/tests/test_second_child.py`::
+    INSTRUMENTED test_base.py:TestBase.test_base_01
+    INSTRUMENTED test_base.py:TestBase.test_base_02
 
-    from test_first_child import FirstChild
+If you create another test class inheriting from :class:`TestBase`, for example
+in ``test_specific.py``::
 
+    from test_base import TestBase
 
-    class SecondChild(FirstChild):
-        """
-        :avocado: recursive
-        """
+    class TestSpecific(TestBase):
 
-        def test_second_child(self):
+        def test_specific_A(self):
             pass
 
-Using only `test_second_child.py` as a test reference will result in::
+        def test_specific_B(self):
+            pass
 
-    $ avocado list test_second_child.py
-    INSTRUMENTED test_second_child.py:SecondChild.test_second_child
-    INSTRUMENTED test_second_child.py:SecondChild.test_first_child
-    INSTRUMENTED test_second_child.py:SecondChild.test_basic
+Running ``avocado list test_specific.py`` will return::
+
+    INSTRUMENTED test_specific.py:TestSpecific.test_specific_A
+    INSTRUMENTED test_specific.py:TestSpecific.test_specific_B
+    INSTRUMENTED test_specific.py:TestSpecific.test_base_01
+    INSTRUMENTED test_specific.py:TestSpecific.test_base_02
+
+What proves that, even though Avocado uses static analysis to examine
+the files, it's capable of discover the chain of inheritance and execute
+the parent classes tests.
+
+.. _docstring-directive-enable-disable:
+
+Explicitly disabling tests
+--------------------------
+
+You can use the ``:avocado: disable`` docstring directive to mark something
+that would be considered an Avocado test, but we force it to not be listed
+as one.
 
 Notice that the ``:avocado: disable`` docstring will be ignored in
 ancestors during the recursive discovery. What means that even if an

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -141,21 +141,6 @@ class MultipleMethods(Test):
         pass
 """
 
-AVOCADO_FOREIGN_TAGGED_ENABLE = """from foreignlib import Base
-
-class First(Base):
-    '''
-    First actual test based on library base class
-
-    This Base class happens to, fictionally, inherit from avocado.Test. Because
-    Avocado can't tell that, a tag is necessary to signal that.
-
-    :avocado: enable
-    '''
-    def test(self):
-        pass
-"""
-
 AVOCADO_TEST_NESTED_TAGGED = """from avocado import Test
 import avocado
 import fmaslkfdsaf
@@ -232,9 +217,6 @@ from avocado import Test
 from recursive_discovery_test1 import SecondChild
 
 class ThirdChild(Test, SecondChild):
-    '''
-    :avocado: recursive
-    '''
     def test_third_child(self):
         pass
 """
@@ -382,16 +364,6 @@ class LoaderTest(unittest.TestCase):
         self.assertEqual(len(suite), 1)
         self.assertEqual(suite[0][1]["methodName"], 'test')
         avocado_multiple_tests.remove()
-
-    def test_load_foreign(self):
-        avocado_pass_test = script.TemporaryScript('foreign.py',
-                                                   AVOCADO_FOREIGN_TAGGED_ENABLE,
-                                                   'avocado_loader_unittest')
-        avocado_pass_test.save()
-        test_class, test_parameters = (
-            self.loader.discover(avocado_pass_test.path, loader.ALL)[0])
-        self.assertTrue(test_class == 'First', test_class)
-        avocado_pass_test.remove()
 
     def test_load_pass_disable(self):
         avocado_pass_test = script.TemporaryScript('disable.py',


### PR DESCRIPTION
We currently have to tag a sub-class from a class inheriting from
avocado.Test to make sure it will be considered an Avocado test class.
The recursive behaviour is proven to work by now, so it's time to make it
the default behaviour.

This patch removes the need of a "recursive" docstring, making the
recursive discovery the default behaviour. The "enable" docstring
was also removed for the same reason.

Signed-off-by: Amador Pahim <apahim@redhat.com>