### PR TITLE
optional_plugins: Use stdout&stderr to get version

### DIFF
--- a/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
+++ b/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
@@ -355,7 +355,7 @@ class RemoteTestRunner(TestRunner):
         if result.exit_status == 127:
             return (False, None)
 
-        match = self.remote_version_re.findall(result.stderr)
+        match = self.remote_version_re.findall(result.stderr + result.stdout)
         if match is None:
             return (False, None)
 


### PR DESCRIPTION
Recent changes to remote runner use only stderr to get Avocado version,
but the docker plugin does not return separate stream for stdout and
stderr, therefor it always fails to get the version string. This patch
uses combination of stdeerr + stdout, which should be safe as we only
care about the first occurrence (so in case both stderr and stdout
produce version string, the stderr one will be used, anyway such
question is only hypothetical)

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>