### PR TITLE
Ordered process output

### DIFF
--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -29,6 +29,7 @@ from avocado.core.dispatcher import ResultDispatcher
 from avocado.core.dispatcher import JobPrePostDispatcher
 from avocado.core.settings import settings
 from avocado.utils.data_structures import time_to_seconds
+from avocado.utils import process
 
 
 class Run(CLICmd):
@@ -133,7 +134,8 @@ class Run(CLICmd):
         out_check = parser.add_argument_group('output check arguments')
 
         out_check.add_argument('--output-check-record',
-                               choices=('none', 'all', 'stdout', 'stderr'),
+                               choices=('none', 'all', 'stdout', 'stderr',
+                                        'both', 'combined'),
                                default='none',
                                help="Record output streams of your tests "
                                "to reference files (valid options: none (do "
@@ -171,6 +173,9 @@ class Run(CLICmd):
 
         :param args: Command line args received from the run subparser.
         """
+        if 'output_check_record' in args:
+            process.OUTPUT_CHECK_RECORD_MODE = getattr(args, 'output_check_record')
+
         if args.unique_job_id is not None:
             try:
                 int(args.unique_job_id, 16)

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -488,8 +488,7 @@ class SubProcess(object):
             tmp = os.read(fileno, 8192)
             if tmp == '':
                 break
-            lock.acquire()
-            try:
+            with lock:
                 output_file.write(tmp)
                 if self.verbose:
                     bfr += tmp
@@ -499,8 +498,6 @@ class SubProcess(object):
                             if stream_logger is not None:
                                 stream_logger.debug(stream_prefix, '%s\n' % line)
                         bfr = ''
-            finally:
-                lock.release()
         # Write the rest of the bfr unfinished by \n
         if self.verbose and bfr:
             for line in bfr.splitlines():
@@ -553,9 +550,8 @@ class SubProcess(object):
         :rtype: str
         """
         self._init_subprocess()
-        self._output_stdout_lock.acquire()
-        stdout = self.stdout_file.getvalue()
-        self._output_stdout_lock.release()
+        with self._output_stdout_lock:
+            stdout = self.stdout_file.getvalue()
         return stdout
 
     def get_stderr(self):
@@ -566,9 +562,8 @@ class SubProcess(object):
         :rtype: str
         """
         self._init_subprocess()
-        self._output_stderr_lock.acquire()
-        stderr = self.stderr_file.getvalue()
-        self._output_stderr_lock.release()
+        with self._output_stderr_lock:
+            stderr = self.stderr_file.getvalue()
         return stderr
 
     def terminate(self):

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -410,17 +410,14 @@ class SubProcess(object):
             self.stdout_file = StringIO()
             self.stderr_file = StringIO()
             self.stdout_lock = threading.Lock()
-            ignore_bg_processes = self._ignore_bg_processes
             self.stdout_thread = threading.Thread(target=self._fd_drainer,
                                                   name="%s-stdout" % self.cmd,
-                                                  args=[self._popen.stdout,
-                                                        ignore_bg_processes])
+                                                  args=[self._popen.stdout])
             self.stdout_thread.daemon = True
             self.stderr_lock = threading.Lock()
             self.stderr_thread = threading.Thread(target=self._fd_drainer,
                                                   name="%s-stderr" % self.cmd,
-                                                  args=[self._popen.stderr,
-                                                        ignore_bg_processes])
+                                                  args=[self._popen.stderr])
             self.stderr_thread.daemon = True
             self.stdout_thread.start()
             self.stderr_thread.start()
@@ -435,7 +432,7 @@ class SubProcess(object):
                 if self.verbose:
                     log.info("Command %s running on a thread", self.cmd)
 
-    def _fd_drainer(self, input_pipe, ignore_bg_processes=False):
+    def _fd_drainer(self, input_pipe):
         """
         Read from input_pipe, storing and logging output.
 
@@ -463,7 +460,7 @@ class SubProcess(object):
 
         bfr = ''
         while True:
-            if ignore_bg_processes:
+            if self._ignore_bg_processes:
                 # Exit if there are no new data and the main process finished
                 if (not select.select([fileno], [], [], 1)[0] and
                         self.result.exit_status is not None):

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -333,10 +333,15 @@ class SubProcess(object):
                     in missing output produced by those daemons after the
                     main thread finishes and also it allows those daemons
                     to be running after the process finishes.
+        :raises: ValueError if incorrect values are given to parameters
         """
         # Now assemble the final command considering the need for sudo
         self.cmd = self._prepend_sudo(cmd, sudo, shell)
         self.verbose = verbose
+        if allow_output_check not in ('none', 'stderr', 'stdout', 'all'):
+            msg = ("Invalid value (%s) set in allow_output_check" %
+                   allow_output_check)
+            raise ValueError(msg)
         self.allow_output_check = allow_output_check
         self.result = CmdResult(self.cmd)
         self.shell = shell

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -461,12 +461,12 @@ class SubProcess(object):
         bfr = ''
         while True:
             if self._ignore_bg_processes:
-                # Exit if there are no new data and the main process finished
-                if (not select.select([fileno], [], [], 1)[0] and
-                        self.result.exit_status is not None):
+                has_io = select.select([fileno], [], [], 1)[0]
+                if (not has_io and self.result.exit_status is not None):
+                    # Exit if no new data and main process has finished
                     break
-                # Don't read unless there are new data available:
-                if not select.select([fileno], [], [], 1)[0]:
+                if not has_io:
+                    # Don't read unless there are new data available
                     continue
             tmp = os.read(fileno, 8192)
             if tmp == '':

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -26,15 +26,9 @@ import shlex
 import shutil
 import signal
 import stat
+import subprocess
 import threading
 import time
-
-try:
-    import subprocess32 as subprocess
-    SUBPROCESS32_SUPPORT = True
-except ImportError:
-    import subprocess
-    SUBPROCESS32_SUPPORT = False
 
 try:
     from StringIO import StringIO

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -455,7 +455,6 @@ class SubProcess(object):
 
         :param input_pipe: File like object to the stream.
         """
-        stream_prefix = "%s"
         if input_pipe == self._popen.stdout:
             prefix = '[stdout] %s'
             if self.allow_output_check in ['none', 'stderr']:
@@ -496,14 +495,14 @@ class SubProcess(object):
                         for line in bfr.splitlines():
                             log.debug(prefix, line)
                             if stream_logger is not None:
-                                stream_logger.debug(stream_prefix, '%s\n' % line)
+                                stream_logger.debug('%s\n', line)
                         bfr = ''
         # Write the rest of the bfr unfinished by \n
         if self.verbose and bfr:
             for line in bfr.splitlines():
                 log.debug(prefix, line)
                 if stream_logger is not None:
-                    stream_logger.debug(stream_prefix, line)
+                    stream_logger.debug(line)
 
     def _fill_results(self, rc):
         self._init_subprocess()

--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -14,6 +14,13 @@ from avocado.utils import path
 TRUE_CMD = path.find_command('true')
 
 
+class TestSubProcess(unittest.TestCase):
+
+    def test_allow_output_check_parameter(self):
+        self.assertRaises(ValueError, process.SubProcess,
+                          TRUE_CMD, False, "invalid")
+
+
 class TestGDBProcess(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
Avocado currently will run processes and split the STDOUT and STDERR streams.  This makes it impossible to have ordered (combined) output.

Some tests will record the combined output, and to play good with them,  Avocado must support a combined **and ordered** stdout+stderr mode.