### PR TITLE
Python3 micro tasks pending

### DIFF
--- a/avocado/core/restclient/cli/app.py
+++ b/avocado/core/restclient/cli/app.py
@@ -116,7 +116,7 @@ class App(object):
             self.args = self.parser.parse_args()
             action_result = self.dispatch_action()
         except KeyboardInterrupt:
-            print 'Interrupted'
+            print('Interrupted')
 
         if isinstance(action_result, int):
             sys.exit(action_result)

--- a/contrib/scripts/avocado-find-unittests
+++ b/contrib/scripts/avocado-find-unittests
@@ -44,4 +44,4 @@ if __name__ == '__main__':
             result += ["%s.%s.%s" % (test_module_name, klass, method)
                        for method in methods]
     if result:
-        print "\n".join(result)
+        print("\n".join(result))

--- a/optional_plugins/runner_remote/setup.py
+++ b/optional_plugins/runner_remote/setup.py
@@ -13,7 +13,15 @@
 # Copyright: Red Hat Inc. 2017
 # Author: Cleber Rosa <crosa@redhat.com>
 
+import sys
+
 from setuptools import setup, find_packages
+
+
+if sys.version_info[0] == 3:
+    fabric = 'Fabric3'
+else:
+    fabric = 'fabric'
 
 
 setup(name='avocado-framework-plugin-runner-remote',
@@ -24,7 +32,7 @@ setup(name='avocado-framework-plugin-runner-remote',
       url='http://avocado-framework.github.io/',
       packages=find_packages(),
       include_package_data=True,
-      install_requires=['avocado-framework', 'fabric'],
+      install_requires=['avocado-framework', fabric],
       entry_points={
           'avocado.plugins.cli': [
               'remote = avocado_runner_remote:RemoteCLI',

--- a/selftests/cyclical_deps
+++ b/selftests/cyclical_deps
@@ -18,6 +18,14 @@ import sys
 import subprocess
 import tempfile
 
+# it doesn't make sense to go any further on Python 3 because snakefood
+# won't be available anyway.  it's not fair to say this check failed, so
+# let's exit successfully.  the check should be performend when running
+# on Python 2.
+if sys.version_info[0] == 3:
+    sys.exit(0)
+
+
 try:
     import networkx as nx
 except ImportError:

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,8 @@ import sys
 
 from setuptools import setup, find_packages
 
-
-VERSION = open('VERSION', 'r').read().strip()
+BASE_PATH = os.path.dirname(__file__)
+VERSION = open(os.path.join(BASE_PATH, 'VERSION'), 'r').read().strip()
 VIRTUAL_ENV = (hasattr(sys, 'real_prefix') or 'VIRTUAL_ENV' in os.environ)
 
 
@@ -125,7 +125,7 @@ def _get_resource_files(path, base):
 
 
 def get_long_description():
-    with open('README.rst', 'r') as req:
+    with open(os.path.join(BASE_PATH, 'README.rst'), 'r') as req:
         req_contents = req.read()
     return req_contents
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ from setuptools import setup, find_packages
 
 
 VERSION = open('VERSION', 'r').read().strip()
-VIRTUAL_ENV = hasattr(sys, 'real_prefix')
+VIRTUAL_ENV = (hasattr(sys, 'real_prefix') or 'VIRTUAL_ENV' in os.environ)
 
 
 def get_dir(system_path=None, virtual_path=None):


### PR DESCRIPTION
Another batch of changes for Python 3.  With these, Avocado can be installed and executed from a Python 3 virtual environment (venv) and `make check` on a development environment gets to the point of running tests (although some still fail) .