### PR TITLE
runner_remote: do not assume varianter mux_to_yaml plugin is available

### DIFF
--- a/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
+++ b/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
@@ -411,7 +411,7 @@ class RemoteTestRunner(TestRunner):
         :return: a dictionary with test results.
         """
         extra_params = []
-        mux_files = getattr(self.job.args, 'mux_yaml') or []
+        mux_files = getattr(self.job.args, 'mux_yaml', [])
         if mux_files:
             extra_params.append("-m %s" % " ".join(mux_files))
 


### PR DESCRIPTION
The remote runner is currently assuming not only about the existence
of mux_to_yaml plugin, which is bad enough, but relying on it to be
installed and active.

Let's default to no "mux files" if the plugin is not available.

Signed-off-by: Cleber Rosa <crosa@redhat.com>