### PR TITLE
Travis fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ script:
             echo
             echo
             git checkout $COMMIT || ERR=$(echo -e "$ERR\nUnable to checkout $(git log -1 --oneline $COMMIT)")
-            AVOCADO_PARALLEL_CHECK=yes AVOCADO_LOG_DEBUG=yes AVOCADO_RESULTSDIR_CHECK=y SELF_CHECK_CONTINUOUS=y AVOCADO_CHECK_LEVEL=1 make check || ERR=$(echo -e "$ERR\nmake check of $(git log -1 --oneline) failed")
+            AVOCADO_LOG_DEBUG=yes AVOCADO_RESULTSDIR_CHECK=y SELF_CHECK_CONTINUOUS=y AVOCADO_CHECK_LEVEL=1 make check || ERR=$(echo -e "$ERR\nmake check of $(git log -1 --oneline) failed")
             make clean
         done
         if [ "$ERR" ]; then

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -293,7 +293,7 @@ class CmdResult(object):
 
 class FDDrainer(object):
 
-    def __init__(self, fd, result, name=None, logger=None, logger_prefix='',
+    def __init__(self, fd, result, name=None, logger=None, logger_prefix='%s',
                  stream_logger=None, ignore_bg_processes=False, verbose=False):
         """
         Reads data from a file descriptor in a thread, storing locally in
@@ -308,7 +308,7 @@ class FDDrainer(object):
         :param name: a descriptive name that will be passed to the Thread name
         :type name: str
         :param logger_prefix: the prefix used when logging the data
-        :type logger_prefix: str
+        :type logger_prefix: str with one %-style string formatter
         :param ignore_bg_processes: When True the process does not wait for
                     child processes which keep opened stdout/stderr streams
                     after the main process finishes (eg. forked daemon which


### PR DESCRIPTION
- Revert "travis: Use parallel check in travis"

    This reverts commit 4b29699.

    Parallel check was enabled in Travis, but it's overloading the system
    and making the time sensitive tests to FAIL.

- avocado.utils.process: fix default prefix

    Log prefix needs at least the %-style string formatter. Let's include
    that as the default so we don't break under 'no prefix'.