### PR TITLE
utils/cpu: Check cpu list for s390x

### DIFF
--- a/avocado/utils/cpu.py
+++ b/avocado/utils/cpu.py
@@ -22,6 +22,7 @@ Get information from the current's machine CPU.
 
 import re
 import os
+import platform
 
 
 def _list_matches(lst, pattern):
@@ -134,9 +135,14 @@ def cpu_online_list():
     Reports a list of indexes of the online cpus
     """
     cpus = []
+    search_str = 'processor'
+    index = 2
+    if platform.machine() == 's390x':
+        search_str = 'cpu number'
+        index = 3
     for line in open('/proc/cpuinfo', 'r'):
-        if line.startswith('processor'):
-            cpus.append(int(line.split()[2]))  # grab cpu number
+        if line.startswith(search_str):
+            cpus.append(int(line.split()[index]))  # grab cpu number
     return cpus
 
 


### PR DESCRIPTION
The output in /proc/cpuinfo is different between s390x and other archs.
This is to support to parse the output on s390x.

Signed-off-by: Dan Zheng <dzheng@redhat.com>