### PR TITLE
correction of typo error in multipath.py

### DIFF
--- a/avocado/utils/multipath.py
+++ b/avocado/utils/multipath.py
@@ -122,7 +122,7 @@ def get_multipath_details():
 
     :return: Dictionary of multipath output in json format.
     """
-    mpath_op = process.system_output("multipathd show maps jsons", sudo=True)
+    mpath_op = process.system_output("multipathd show maps json", sudo=True)
     if 'multipath-tools v' in mpath_op:
         return ''
     mpath_op = ast.literal_eval(mpath_op.replace("\n", '').replace(' ', ''))


### PR DESCRIPTION
There is a typo error in command execution in multipath.py in
get_path_status() method. so corrected it and it is working fine now.

Signed-off-by: Naresh Bannoth <nbannoth@linux.vnet.ibm.com>