### PR TITLE
FDDrainer: flush the file based handlers before filling results

### DIFF
--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -376,8 +376,19 @@ class FDDrainer(object):
         self._thread.daemon = True
         self._thread.start()
 
-    def join(self):
+    def flush(self):
         self._thread.join()
+        if self._stream_logger is not None:
+            for handler in self._stream_logger.handlers:
+                # FileHandler has a close() method, which we expect will
+                # flush the file on disk.  SocketHandler, MemoryHandler
+                # and other logging handlers (custom ones?) also have
+                # the same interface, so let's try to use it if available
+                stream = getattr(handler, 'stream', None)
+                if stream is not None:
+                    os.fsync(stream.fileno())
+                if hasattr(handler, 'close'):
+                    handler.close()
 
 
 class SubProcess(object):
@@ -581,9 +592,9 @@ class SubProcess(object):
         """
         # Cleaning up threads
         if self._stdout_drainer is not None:
-            self._stdout_drainer.join()
+            self._stdout_drainer.flush()
         if self._stderr_drainer is not None:
-            self._stderr_drainer.join()
+            self._stderr_drainer.flush()
         # Clean subprocess pipes and populate stdout/err
         self.result.stdout = self.get_stdout()
         self.result.stderr = self.get_stderr()

--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -242,7 +242,7 @@ class FDDrainerTests(unittest.TestCase):
             os.write(write_fd, content)
         os.write(write_fd, "finish")
         os.close(write_fd)
-        fd_drainer.join()
+        fd_drainer.flush()
         self.assertEqual(fd_drainer.data.getvalue(),
                          "foobarbazfoo\nbar\nbaz\n\nfinish")
 
@@ -270,7 +270,7 @@ class FDDrainerTests(unittest.TestCase):
         fd_drainer.start()
         os.write(write_fd, "should go to the log\n")
         os.close(write_fd)
-        fd_drainer.join()
+        fd_drainer.flush()
         self.assertEqual(fd_drainer.data.getvalue(),
                          "should go to the log\n")
         self.assertTrue(handler.caught_record)


### PR DESCRIPTION
The FDDrainer reads from the PIPEs and writes to both the internal
StringIO instances and to stream logging handlers.  There are no
guarantees that the logging handlers will flush the content before the
FDDrainer finishes.

Let's explicitly close all the handlers (which should really be
FileHandlers) associated with the stream loggers, which should flush
and sync the content on the files themselves.

This *should* fix the race conditions with content missing from the
output files that we're observing on Travis-CI.

Signed-off-by: Cleber Rosa <crosa@redhat.com>