### PR TITLE
FDDrainer: flush the file based handlers before filling results

### DIFF
--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -242,7 +242,7 @@ class FDDrainerTests(unittest.TestCase):
             os.write(write_fd, content)
         os.write(write_fd, "finish")
         os.close(write_fd)
-        fd_drainer.join()
+        fd_drainer.flush()
         self.assertEqual(fd_drainer.data.getvalue(),
                          "foobarbazfoo\nbar\nbaz\n\nfinish")
 
@@ -270,7 +270,7 @@ class FDDrainerTests(unittest.TestCase):
         fd_drainer.start()
         os.write(write_fd, "should go to the log\n")
         os.close(write_fd)
-        fd_drainer.join()
+        fd_drainer.flush()
         self.assertEqual(fd_drainer.data.getvalue(),
                          "should go to the log\n")
         self.assertTrue(handler.caught_record)


### PR DESCRIPTION
The FDDrainer reads from the PIPEs and writes to both the internal
StringIO instances and to stream logging handlers.  There are no
guarantees that the logging handlers will flush the content before the
FDDrainer finishes.

Let's explicitly close all the handlers (which should really be
FileHandlers) associated with the stream loggers, which should flush
and sync the content on the files themselves.

Additionally, the combined drainer was being missed from the flush
process, and was causing some output in that mode to be unavailable on
generated output.

Signed-off-by: Cleber Rosa <crosa@redhat.com>