### PR TITLE
avocado: Force clean_tmp_files on exit

### DIFF
--- a/avocado/core/app.py
+++ b/avocado/core/app.py
@@ -20,6 +20,7 @@ import os
 import signal
 import sys
 
+from . import data_dir
 from . import output
 from .dispatcher import CLICmdDispatcher
 from .dispatcher import CLIDispatcher
@@ -92,3 +93,5 @@ class AvocadoApp(object):
             # This makes sure we cleanup the console (stty echo). The only way
             # to avoid cleaning it is to kill the less (paginator) directly
             STD_OUTPUT.close()
+            # Force-close tmpdir
+            data_dir.clean_tmp_files()


### PR DESCRIPTION
Hello guys, recently I'm getting more and more `/var/tmp/avocado_*` dirs being left behind. Not sure whether something changed in our sources, or the python version I use (python-2.7.13-2.fc25.x86_64) does not run `__del__` but this addresses the issue and should not generate new problems.