### PR TITLE
Subtests filter fixes [V2]

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -615,7 +615,8 @@ class FileLoader(TestLoader):
                             break
                     else:
                         pth = os.path.join(dirpath, file_name)
-                        tests.extend(self._make_tests(pth, which_tests))
+                        tests.extend(self._make_tests(pth, which_tests,
+                                                      subtests_filter))
         return tests
 
     def _find_avocado_tests(self, path, class_name=None):

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -877,7 +877,8 @@ class FileLoader(TestLoader):
                 if os.access(test_path, os.X_OK):
                     # Module does not have an avocado test class inside but
                     # it's executable, let's execute it.
-                    return self._make_test(test.SimpleTest, test_path)
+                    return self._make_test(test.SimpleTest, test_path,
+                                           subtests_filter=subtests_filter)
                 else:
                     # Module does not have an avocado test class inside, and
                     # it's not executable. Not a Test.
@@ -893,18 +894,23 @@ class FileLoader(TestLoader):
             if os.access(test_path, os.X_OK):
                 # Module can't be imported, and it's executable. Let's try to
                 # execute it.
-                return self._make_test(test.SimpleTest, test_path)
+                return self._make_test(test.SimpleTest, test_path,
+                                       subtests_filter=subtests_filter)
             else:
                 return make_broken(NotATest, test_path, self.__not_test_str)
 
     @staticmethod
-    def _make_test(klass, uid, description=None):
+    def _make_test(klass, uid, description=None, subtests_filter=None):
         """
         Create test template
         :param klass: test class
         :param uid: test uid (by default used as id and name)
         :param description: Description appended to "uid" (for listing purpose)
+        :param subtests_filter: optional filter of methods for avocado tests
         """
+        if subtests_filter and not subtests_filter.search(uid):
+            return []
+
         if description:
             uid = "%s: %s" % (uid, description)
         return [(klass, {'name': uid})]
@@ -934,8 +940,8 @@ class FileLoader(TestLoader):
                                                       subtests_filter)
             else:
                 if os.access(test_path, os.X_OK):
-                    return self._make_test(test.SimpleTest,
-                                           test_path)
+                    return self._make_test(test.SimpleTest, test_path,
+                                           subtests_filter=subtests_filter)
                 else:
                     return make_broken(NotATest, test_path,
                                        self.__not_test_str)

--- a/selftests/functional/test_loader.py
+++ b/selftests/functional/test_loader.py
@@ -350,6 +350,19 @@ class LoaderTestFunctional(unittest.TestCase):
         self.assertFalse(exps, "Some expected result not matched to actual"
                          "results:\n%s\n\nexps = %s" % (result, exps))
 
+    def test_list_subtests_filter(self):
+        """
+        Check whether the subtests filter works for both INSTRUMENTED
+        and SIMPLE in a directory list.
+        """
+        cmd = "%s list examples/tests/:fail" % AVOCADO
+        result = process.run(cmd)
+        expected = ("INSTRUMENTED examples/tests/doublefail.py:DoubleFail.test\n"
+                    "INSTRUMENTED examples/tests/fail_on_exception.py:FailOnException.test\n"
+                    "INSTRUMENTED examples/tests/failtest.py:FailTest.test\n"
+                    "SIMPLE       examples/tests/failtest.sh\n")
+        self.assertEqual(expected, result.stdout)
+
     def tearDown(self):
         shutil.rmtree(self.tmpdir)
 


### PR DESCRIPTION
v2:
- Add `:param subtests_filter:` to the `_make_test()` method docstring.
- Drop `ignore_status=True` from the selftest call to `process.run()`.
- Rebase.

v1: #2303 
- Make subtests filter to work in directory discoveries.
- Make subtests filter to work for SIMPLE tests.