### PR TITLE
examples: fix doublefree test

### DIFF
--- a/examples/tests/doublefree.py
+++ b/examples/tests/doublefree.py
@@ -2,8 +2,6 @@
 
 import os
 import shutil
-import signal
-import sys
 
 from avocado import Test
 from avocado import main
@@ -41,18 +39,12 @@ class DoubleFreeTest(Test):
         Execute 'doublefree'.
         """
         cmd = os.path.join(self.srcdir, 'doublefree')
-        cmd_result = process.run(cmd, ignore_status=True)
+        cmd_result = process.run(cmd, ignore_status=True,
+                                 env={'MALLOC_CHECK_': '1'})
         self.log.info(cmd_result)
-        expected_exit_status = -signal.SIGABRT
-        output = cmd_result.stdout + cmd_result.stderr
-        self.assertEqual(cmd_result.exit_status, expected_exit_status)
-        if sys.platform.startswith('darwin'):
-            pattern = 'pointer being freed was not allocated'
-        else:
-            pattern = 'double free or corruption'
-        self.assertTrue(pattern in output,
-                        msg='Could not find pattern %s in output %s' %
-                            (pattern, output))
+        pattern = 'free(): invalid pointer'
+        self.assertTrue(pattern in cmd_result.stderr,
+                        msg='Could not find pattern %s in stderr' % pattern)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Double free errors are silent in Fedora 27, making the test
doublefree.py to fail.

Using `MALLOC_CHECK_=1` is guaranteed to expose the double free
errors, regardless the OS double free handling. This patch updates
the doublefree.py test to use the `MALLOC_CHECK_=1` approach.

Signed-off-by: Amador Pahim <apahim@redhat.com>