### PR TITLE
resultsdb: print IU message only when using default TUI

### DIFF
--- a/optional_plugins/resultsdb/avocado_resultsdb/__init__.py
+++ b/optional_plugins/resultsdb/avocado_resultsdb/__init__.py
@@ -160,7 +160,8 @@ class ResultsdbResult(Result):
     description = 'Resultsdb result support'
 
     def render(self, result, job):
-        if getattr(job.args, 'resultsdb_logs', None) is not None:
+        if (getattr(job.args, 'resultsdb_logs', None) is not None and
+                getattr(job.args, 'stdout_claimed_by', None) is None):
             LOG_UI.info("JOB URL    : %s/%s" % (job.args.resultsdb_logs,
                                                 os.path.basename(job.logdir)))
 


### PR DESCRIPTION
The message is being printed even woth different result formats (json,
tap, ...). This patch makes it to be printed only when using default
TUI.

Signed-off-by: Amador Pahim <apahim@redhat.com>