### PR TITLE
[do not merge - demonstration] fix html pass rate

### DIFF
--- a/optional_plugins/html/avocado_result_html/__init__.py
+++ b/optional_plugins/html/avocado_result_html/__init__.py
@@ -75,14 +75,15 @@ class ReportModel(object):
     def tests_total(self):
         return self.result.tests_total
 
-    def passed(self):
-        return self.result.passed
+    def succeeded(self):
+        return self.result.passed + self.result.warned
 
-    def pass_rate(self):
+    def success_rate(self):
         total = float(self.result.tests_total)
-        passed = float(self.result.passed)
+        succeded = float(self.result.passed)
+        succeded += float(self.result.warned)
         if total > 0:
-            pr = 100 * (passed / total)
+            pr = 100 * (succeded / total)
         else:
             pr = 0
         return "%.2f" % pr

--- a/optional_plugins/html/avocado_result_html/resources/templates/report.mustache
+++ b/optional_plugins/html/avocado_result_html/resources/templates/report.mustache
@@ -736,7 +736,7 @@
                             <td>Cumulative test time</td><td>{{tests_total_time}} s</td>
                         </tr>
                         <tr>
-                            <td>Stats</td><td>From {{tests_total}} tests executed, {{passed}} passed (pass rate of {{pass_rate}}%)</td>
+                            <td>Stats</td><td>From {{tests_total}} tests executed, {{succeeded}} succeeded (success rate of {{success_rate}}%)</td>
                         </tr>
                     </table>
                 </div>


### PR DESCRIPTION
[PLEASE, DO NOT REVIEW]

Instead of "pass rate", let's use the naming "success rate" and include
the warned tests into the stat.

Signed-off-by: Amador Pahim <apahim@redhat.com>