### PR TITLE
Process and sysinfo

### DIFF
--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -18,12 +18,8 @@ import logging
 import os
 import shlex
 import shutil
+import subprocess
 import time
-
-try:
-    import subprocess32 as subprocess
-except ImportError:
-    import subprocess
 
 from . import output
 from .settings import settings

--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -249,7 +249,7 @@ class JournalctlWatcher(Collectible):
                 cmd = 'journalctl --quiet --after-cursor %s' % self.cursor
                 log_diff = process.system_output(cmd, verbose=False)
                 dstpath = os.path.join(logdir, self.logf)
-                with gzip.GzipFile(dstpath, "w")as out_journalctl:
+                with gzip.GzipFile(dstpath, "w") as out_journalctl:
                     out_journalctl.write(log_diff)
             except IOError:
                 log.debug("Not logging journalctl (lack of permissions): %s",

--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -19,7 +19,6 @@ import os
 import shlex
 import shutil
 import time
-import threading
 
 try:
     import subprocess32 as subprocess
@@ -33,7 +32,6 @@ from ..utils import genio
 from ..utils import process
 from ..utils import software_manager
 from ..utils import path as utils_path
-from ..utils import wait
 
 log = logging.getLogger("avocado.sysinfo")
 
@@ -155,48 +153,32 @@ class Command(Collectible):
 
         :param logdir: Path to a log directory.
         """
-        def destroy(proc, cmd, timeout):
-            log.error("sysinfo: Interrupting cmd '%s' which took longer "
-                      "than %ss to finish", cmd, timeout)
-            try:
-                proc.terminate()
-                if wait.wait_for(lambda: proc.poll() is None, timeout=1,
-                                 step=0.01) is None:
-                    proc.kill()
-            except OSError:
-                pass    # Ignore errors when the process already finished
         env = os.environ.copy()
         if "PATH" not in env:
             env["PATH"] = "/usr/bin:/bin"
         locale = settings.get_value("sysinfo.collect", "locale", str, None)
         if locale:
             env["LC_ALL"] = locale
+        timeout = settings.get_value("sysinfo.collect", "commands_timeout",
+                                     int, -1)
+        # the sysinfo configuration supports negative or zero integer values
+        # but the avocado.utils.process APIs define no timeouts as "None"
+        if int(timeout) <= 0:
+            timeout = None
+        result = process.run(self.cmd,
+                             timeout=timeout,
+                             verbose=False,
+                             ignore_status=True,
+                             allow_output_check='combined',
+                             shell=True,
+                             env=env)
         logf_path = os.path.join(logdir, self.logf)
-        stdin = open(os.devnull, "r")
-        stdout = open(logf_path, "w")
-        try:
-            proc = subprocess.Popen(self.cmd, stdin=stdin, stdout=stdout,
-                                    stderr=subprocess.STDOUT, shell=True,
-                                    env=env)
-            timeout = settings.get_value("sysinfo.collect", "commands_timeout",
-                                         int, -1)
-            if timeout <= 0:
-                proc.wait()
-                return
-            timer = threading.Timer(timeout, destroy, (proc, self.cmd,
-                                                       timeout))
-            try:
-                timer.start()
-                proc.wait()
-            finally:
-                timer.cancel()
-        finally:
-            for f in (stdin, stdout):
-                f.close()
-            if self._compress_log and os.path.exists(logf_path):
-                process.run('gzip -9 "%s"' % logf_path,
-                            ignore_status=True,
-                            verbose=False)
+        if self._compress_log:
+            with gzip.GzipFile(logf_path, 'w') as logf:
+                logf.write(result.stdout)
+        else:
+            with open(logf_path, 'w') as logf:
+                logf.write(result.stdout)
 
 
 class Daemon(Command):

--- a/avocado/utils/gdb.py
+++ b/avocado/utils/gdb.py
@@ -23,12 +23,8 @@ import os
 import time
 import fcntl
 import socket
+import subprocess
 import tempfile
-
-try:
-    import subprocess32 as subprocess
-except ImportError:
-    import subprocess
 
 from . import network
 from .external import gdbmi_parser

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -435,6 +435,7 @@ class SubProcess(object):
                      has a sudo configuration such that a password won't be
                      prompted. If that's not the case, the command will
                      straight out fail.
+        :type sudo: bool
         :param ignore_bg_processes: When True the process does not wait for
                     child processes which keep opened stdout/stderr streams
                     after the main process finishes (eg. forked daemon which
@@ -444,8 +445,10 @@ class SubProcess(object):
                     to be running after the process finishes.
         :raises: ValueError if incorrect values are given to parameters
         """
-        # Now assemble the final command considering the need for sudo
-        self.cmd = self._prepend_sudo(cmd, sudo, shell)
+        if sudo:
+            self.cmd = self._prepend_sudo(cmd, shell)
+        else:
+            self.cmd = cmd
         self.verbose = verbose
         if allow_output_check is None:
             allow_output_check = OUTPUT_CHECK_RECORD_MODE
@@ -493,8 +496,8 @@ class SubProcess(object):
         return '%s %s' % (self.cmd, rc)
 
     @staticmethod
-    def _prepend_sudo(cmd, sudo, shell):
-        if sudo and os.getuid() != 0:
+    def _prepend_sudo(cmd, shell):
+        if os.getuid() != 0:
             try:
                 sudo_cmd = '%s -n' % path.find_command('sudo')
             except path.CmdNotFoundError as details:

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -307,6 +307,9 @@ class FDDrainer(object):
         :type result: a :class:`CmdResult` instance
         :param name: a descriptive name that will be passed to the Thread name
         :type name: str
+        :param logger: the logger that will be used to (interactively) write
+                       the content from the file descriptor
+        :type logger: :class:`logging.Logger`
         :param logger_prefix: the prefix used when logging the data
         :type logger_prefix: str with one %-style string formatter
         :param ignore_bg_processes: When True the process does not wait for


### PR DESCRIPTION
This PR includes a number of cleanups and fixes related to `avocado.utils.process` library, including dropping some custom code from the sysinfo implementation and relying on that library.