### PR TITLE
scripts: Fixing os.write() excpetion TypeError when using Python 3 [v2].

### DIFF
--- a/scripts/avocado
+++ b/scripts/avocado
@@ -31,7 +31,7 @@ def handle_exception(*exc_info):
     # Print traceback if AVOCADO_LOG_DEBUG environment variable is set
     msg = "Avocado crashed:\n" + "".join(traceback.format_exception(*exc_info))
     if os.environ.get("AVOCADO_LOG_DEBUG"):
-        os.write(2, msg + '\n')
+        os.write(2, (msg + '\n').encode('utf-8'))
     # Store traceback in data_dir or TMPDIR
     crash_dir = None
     prefix = "avocado-traceback-"
@@ -50,7 +50,7 @@ def handle_exception(*exc_info):
     # Print friendly message in console-like output
     msg = ("Avocado crashed unexpectedly: %s\nYou can find details in %s"
            % (exc_info[1], name))
-    os.write(2, msg + '\n')
+    os.write(2, (msg + '\n').encode('utf-8'))
     # This exit code is replicated from avocado/core/exit_codes.py and not
     # imported because we are dealing with import failures
     sys.exit(-1)


### PR DESCRIPTION
The function os.write() is throwing an error when using Python 3.

    Traceback (most recent call last):

      File "/home/travis/virtualenv/python3.3.6/bin/avocado", line 53,
in handle_exception
        os.write(2, msg + '\n')
    TypeError: 'str' does not support the buffer interface

This error was checked using Python:
- 3.3.6
- 3.4.5

Obs: this error is happening while I try to run my own plugin. As it is failing, avocado
fails too. Instead of show (after patching):

    Avocado crashed unexpectedly: 'dict' object has no attribute 'iteritems'
    You can find details in /var/tmp/avocado-traceback-2017-12-10_09:50:11-r40x7rsp.log

Avocado shows the traceback.

Signed-off-by: Julio Faracco <jfaracco@br.ibm.com>