### PR TITLE
Fix variants output

### DIFF
--- a/avocado/core/varianter.py
+++ b/avocado/core/varianter.py
@@ -264,9 +264,14 @@ class Varianter(object):
                 out.append("\n".join(variant_to_str(variant, variants - 1,
                                                     kwargs, self.debug)))
             return "\n\n".join(out)
-        return "\n\n".join(self._variant_plugins.map_method("to_str", summary,
-                                                            variants,
-                                                            **kwargs))
+
+        out = [item for item in self._variant_plugins.map_method("to_str",
+                                                                 summary,
+                                                                 variants,
+                                                                 **kwargs)
+               if item]
+
+        return "\n\n".join(out)
 
     def get_number_of_tests(self, test_suite):
         """

--- a/optional_plugins/varianter_pict/avocado_varianter_pict/__init__.py
+++ b/optional_plugins/varianter_pict/avocado_varianter_pict/__init__.py
@@ -170,10 +170,12 @@ class VarianterPict(Varianter):
         :param kwargs: Other free-form arguments
         :rtype: str
         """
+        if not self.variants:
+            return ""
+
         out = []
-        if variants:
-            out.append("Pict Variants (%i):" % len(self))
-            for variant in self:
-                out.append('Variant %s:    %s' % (variant["variant_id"],
-                                                  self.parameter_path))
+        out.append("Pict Variants (%i):" % len(self))
+        for variant in self:
+            out.append('Variant %s:    %s' % (variant["variant_id"],
+                                              self.parameter_path))
         return "\n".join(out)


### PR DESCRIPTION
With the introduction of our first extra varianter plugin (PICT), I noticed that the UI is not handling multiple plugins properly. This PR fixes that by:
- Making sure the varianter will not include line breaks for plugins with no variants.
- Making sure the varianter_pict plugin will return an empty string on no-variants. 