### PR TITLE
Fix golang loader

### DIFF
--- a/optional_plugins/golang/avocado_golang/__init__.py
+++ b/optional_plugins/golang/avocado_golang/__init__.py
@@ -93,6 +93,9 @@ class GolangLoader(loader.TestLoader):
         super(GolangLoader, self).__init__(args, extra_params)
 
     def discover(self, url, which_tests=loader.DEFAULT):
+        if _GO_BIN is None:
+            return self._no_tests(which_tests, url, 'Go binary not found.')
+
         if url is None:
             return []
 

--- a/optional_plugins/golang/avocado_golang/__init__.py
+++ b/optional_plugins/golang/avocado_golang/__init__.py
@@ -119,7 +119,9 @@ class GolangLoader(loader.TestLoader):
                 avocado_suite.append((GolangTest, {'name': test_name,
                                                    'subtest': subtest}))
 
-            return avocado_suite or self._no_tests(which_tests, url)
+            return avocado_suite or self._no_tests(which_tests, url,
+                                                   'No test matching this '
+                                                   'reference.')
 
         # When a directory is provided
         if os.path.isdir(url):
@@ -131,7 +133,9 @@ class GolangLoader(loader.TestLoader):
                     avocado_suite.append((GolangTest, {'name': test_name,
                                                        'subtest': subtest}))
 
-            return avocado_suite or self._no_tests(which_tests, url)
+            return avocado_suite or self._no_tests(which_tests, url,
+                                                   'No test matching this '
+                                                   'reference.')
 
         # When a package is provided
         go_root = os.environ.get('GOROOT')
@@ -168,12 +172,13 @@ class GolangLoader(loader.TestLoader):
                                           {'name': test_name,
                                            'subtest': subtest}))
 
-        return avocado_suite or self._no_tests(which_tests, url)
+        return avocado_suite or self._no_tests(which_tests, url,
+                                               'No test matching this '
+                                               'reference.')
 
     @staticmethod
-    def _no_tests(which_tests, url):
+    def _no_tests(which_tests, url, msg):
         if which_tests == loader.ALL:
-            msg = ('No test matching this reference.')
             return [(NotGolangTest, {"name": "%s: %s" % (url, msg)})]
         return []
 


### PR DESCRIPTION
We should not discover the golang tests when we are not able to run them. This PR makes the golang plugin to skip the discovery process when the `go` bin is not present on the system.