### PR TITLE
utils.crypto: Fix two errors in hash_file

### DIFF
--- a/avocado/utils/crypto.py
+++ b/avocado/utils/crypto.py
@@ -66,11 +66,11 @@ def hash_file(filename, size=None, algorithm="md5"):
         while size > 0:
             if chunksize > size:
                 chunksize = size
-                data = file_to_hash.read(chunksize)
-                if len(data) == 0:
-                    logging.debug("Nothing left to read but size=%d", size)
-                    break
-                hash_obj.update(data)
-                size -= len(data)
+            data = file_to_hash.read(chunksize)
+            if len(data) == 0:
+                logging.debug("Nothing left to read but size=%d", size)
+                break
+            hash_obj.update(data)
+            size -= len(data)
 
     return hash_obj.hexdigest()

--- a/avocado/utils/crypto.py
+++ b/avocado/utils/crypto.py
@@ -61,6 +61,7 @@ def hash_file(filename, size=None, algorithm="md5"):
         hash_obj = hash_wrapper(algorithm=algorithm)
     except ValueError:
         logging.error("Unknown hash algorithm %s, returning None", algorithm)
+        return None
 
     with open(filename, 'rb') as file_to_hash:
         while size > 0:


### PR DESCRIPTION
Fix the following two errors in hash_file:

* A wrong indentation caused a dead loop
* Forgot returning `None` when the given hash algorithm is unknown

Signed-off-by: Xu Han <xuhan@redhat.com>