### PR TITLE
Parameters: variants, not mux [v4]

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -400,7 +400,7 @@ class Job(object):
         LOG_JOB.info('Temporary dir: %s', data_dir.get_tmp_dir())
         LOG_JOB.info('')
 
-    def _log_job_debug_info(self, mux):
+    def _log_job_debug_info(self, variants):
         """
         Log relevant debug information to the job log.
         """
@@ -408,7 +408,7 @@ class Job(object):
         self._log_avocado_version()
         self._log_avocado_config()
         self._log_avocado_datadir()
-        self._log_variants(mux)
+        self._log_variants(variants)
         self._log_tmp_dir()
         self._log_job_id()
 

--- a/avocado/core/jobdata.py
+++ b/avocado/core/jobdata.py
@@ -36,18 +36,18 @@ ARGS_FILENAME = 'args.json'
 CMDLINE_FILENAME = 'cmdline'
 
 
-def record(args, logdir, mux, references=None, cmdline=None):
+def record(args, logdir, variants, references=None, cmdline=None):
     """
     Records all required job information.
     """
-    def json_bad_mux_obj(item):
+    def json_bad_variants_obj(item):
         for log in [LOG_UI, LOG_JOB]:
             log.warning("jobdata.variants: Unable to serialize '%s'", item)
         return str(item)
     base_dir = init_dir(logdir, JOB_DATA_DIR)
     path_cfg = os.path.join(base_dir, CONFIG_FILENAME)
     path_references = os.path.join(base_dir, TEST_REFERENCES_FILENAME)
-    path_mux = os.path.join(base_dir, VARIANTS_FILENAME)
+    path_variants = os.path.join(base_dir, VARIANTS_FILENAME)
     path_pwd = os.path.join(base_dir, PWD_FILENAME)
     path_args = os.path.join(base_dir, ARGS_FILENAME)
     path_cmdline = os.path.join(base_dir, CMDLINE_FILENAME)
@@ -63,10 +63,10 @@ def record(args, logdir, mux, references=None, cmdline=None):
         config_file.flush()
         os.fsync(config_file)
 
-    with open(path_mux, 'w') as mux_file:
-        json.dump(mux.dump(), mux_file, default=json_bad_mux_obj)
-        mux_file.flush()
-        os.fsync(mux_file)
+    with open(path_variants, 'w') as variants_file:
+        json.dump(variants.dump(), variants_file, default=json_bad_variants_obj)
+        variants_file.flush()
+        os.fsync(variants_file)
 
     with open(path_pwd, 'w') as pwd_file:
         pwd_file.write('%s' % os.getcwd())
@@ -115,12 +115,12 @@ def retrieve_references(resultsdir):
 
 def retrieve_variants(resultsdir):
     """
-    Retrieves the job Mux object from the results directory.
+    Retrieves the job variants object from the results directory.
     """
-    recorded_mux = _retrieve(resultsdir, VARIANTS_FILENAME)
-    if recorded_mux:
-        with open(recorded_mux, 'r') as mux_file:
-            return varianter.Varianter(state=json.load(mux_file))
+    recorded_variants = _retrieve(resultsdir, VARIANTS_FILENAME)
+    if recorded_variants:
+        with open(recorded_variants, 'r') as variants_file:
+            return varianter.Varianter(state=json.load(variants_file))
 
 
 def retrieve_args(resultsdir):

--- a/avocado/core/parameters.py
+++ b/avocado/core/parameters.py
@@ -41,18 +41,18 @@ class AvocadoParams(object):
     false values, though.
     """
 
-    def __init__(self, leaves, test_id, mux_path, logger_name=None):
+    def __init__(self, leaves, test_id, paths, logger_name=None):
         """
         :param leaves: List of TreeNode leaves defining current variant
         :param test_id: test id
-        :param mux_path: list of entry points
+        :param paths: list of entry points
         :param logger_name: the name of a logger to use to record attempts
                             to get parameters
         :type logger_name: str
         """
         self._rel_paths = []
         leaves = list(leaves)
-        for i, path in enumerate(mux_path):
+        for i, path in enumerate(paths):
             path_leaves = self._get_matching_leaves(path, leaves)
             self._rel_paths.append(AvocadoParam(path_leaves,
                                                 '%d: %s' % (i, path)))

--- a/avocado/core/parameters.py
+++ b/avocado/core/parameters.py
@@ -15,12 +15,11 @@
 Module related to test parameters
 """
 
+import logging
 import re
 
 from six import iterkeys, iteritems
 from six.moves import xrange as range
-
-from . import output
 
 
 class NoMatchError(KeyError):
@@ -40,18 +39,16 @@ class AvocadoParams(object):
     You can also iterate through all keys, but this can generate quite a lot
     of duplicate entries inherited from ancestor nodes.  It shouldn't produce
     false values, though.
-
-    In this version each new "get()" call is logged into avocado.LOG_JOB.
-    This is subject of change (separate file, perhaps)
     """
 
-    # TODO: Use "test" to log params.get()
-
-    def __init__(self, leaves, test_id, mux_path):
+    def __init__(self, leaves, test_id, mux_path, logger_name=None):
         """
         :param leaves: List of TreeNode leaves defining current variant
         :param test_id: test id
         :param mux_path: list of entry points
+        :param logger_name: the name of a logger to use to record attempts
+                            to get parameters
+        :type logger_name: str
         """
         self._rel_paths = []
         leaves = list(leaves)
@@ -64,6 +61,7 @@ class AvocadoParams(object):
         self._abs_path = AvocadoParam(path_leaves, '*: *')
         self.id = test_id
         self._cache = {}     # TODO: Implement something more efficient
+        self._logger_name = logger_name
 
     def __eq__(self, other):
         if set(iterkeys(self.__dict__)) != set(iterkeys(other.__dict__)):
@@ -75,15 +73,6 @@ class AvocadoParams(object):
 
     def __ne__(self, other):
         return not (self == other)
-
-    def __getstate__(self):
-        """ log can't be pickled """
-        copy = self.__dict__.copy()
-        return copy
-
-    def __setstate__(self, orig):
-        """ refresh log """
-        self.__dict__.update(orig)
 
     def __repr__(self):
         return "<AvocadoParams %s>" % self._str()
@@ -97,11 +86,6 @@ class AvocadoParams(object):
             return self._abs_path.str_leaves_variant + ',' + out
         else:
             return self._abs_path.str_leaves_variant
-
-    def log(self, key, path, default, value):
-        """ Predefined format for displaying params query """
-        output.LOG_JOB.debug("PARAMS (key=%s, path=%s, default=%s) => %r", key,
-                             path, default, value)
 
     def _get_matching_leaves(self, path, leaves):
         """
@@ -160,7 +144,10 @@ class AvocadoParams(object):
             # KeyError - first query
             # TypeError - unable to hash
             value = self._get(key, path, default)
-            self.log(key, path, default, value)
+            if self._logger_name is not None:
+                logger = logging.getLogger(self._logger_name)
+                logger.debug("PARAMS (key=%s, path=%s, default=%s) => %r",
+                             key, path, default, value)
             try:
                 self._cache[(key, path, default)] = value
             except TypeError:

--- a/avocado/core/parameters.py
+++ b/avocado/core/parameters.py
@@ -41,10 +41,9 @@ class AvocadoParams(object):
     false values, though.
     """
 
-    def __init__(self, leaves, test_id, paths, logger_name=None):
+    def __init__(self, leaves, paths, logger_name=None):
         """
         :param leaves: List of TreeNode leaves defining current variant
-        :param test_id: test id
         :param paths: list of entry points
         :param logger_name: the name of a logger to use to record attempts
                             to get parameters
@@ -59,7 +58,6 @@ class AvocadoParams(object):
         # Don't use non-mux-path params for relative paths
         path_leaves = self._get_matching_leaves('/*', leaves)
         self._abs_path = AvocadoParam(path_leaves, '*: *')
-        self.id = test_id
         self._cache = {}     # TODO: Implement something more efficient
         self._logger_name = logger_name
 

--- a/avocado/core/parser.py
+++ b/avocado/core/parser.py
@@ -133,7 +133,7 @@ class Parser(object):
         self.subcommands.required = True
 
         # Allow overriding default params by plugins
-        variants = varianter.Varianter(getattr(self.args, "mux-debug", False))
+        variants = varianter.Varianter(getattr(self.args, "debug", False))
         self.args.avocado_variants = variants
         # FIXME: Backward compatibility params, to be removed when 36 LTS is
         # discontinued

--- a/avocado/core/plugin_interfaces.py
+++ b/avocado/core/plugin_interfaces.py
@@ -218,7 +218,7 @@ class Varianter(Plugin):
         The variant is defined as dictionary with at least:
          * variant_id - name of the current variant
          * variant - AvocadoParams-compatible variant (usually a list)
-         * mux_path - default path(s)
+         * paths - default path(s)
 
         :yield variant
         """

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -187,10 +187,9 @@ class TestStatus(object):
                 self.status = msg
                 self.job._result_events_dispatcher.map_method('test_progress',
                                                               False)
-                if msg['paused']:
-                    reason = msg['paused_msg']
-                    if reason:
-                        self.job.log.warning(reason)
+                paused_msg = msg['paused']
+                if paused_msg:
+                    self.job.log.warning(paused_msg)
             else:       # test_status
                 self.status = msg
 

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -185,7 +185,6 @@ class TestStatus(object):
                 self.interrupt = True
             elif "paused" in msg:
                 self.status = msg
-                self.job.result_proxy.notify_progress(False)
                 self.job._result_events_dispatcher.map_method('test_progress',
                                                               False)
                 if msg['paused']:

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -513,12 +513,12 @@ class TestRunner(object):
                          followed by parameters to the class
         :type template: tuple
         :param variant: variant to be applied, usually containing
-                        the keys: mux_path, variant and variant_id
+                        the keys: paths, variant and variant_id
         :type variant: dict
         :return: tuple(new_test_factory, applied_variant)
         """
         var = variant.get("variant")
-        mux_path = variant.get("mux_path")
+        paths = variant.get("paths")
         klass, klass_parameters = template
         if "params" in klass_parameters:
             if not varianter.is_empty_variant(var):
@@ -533,10 +533,10 @@ class TestRunner(object):
             variant_id = varianter.generate_variant_id(var)
             return template, {"variant": var,
                               "variant_id": variant_id,
-                              "mux_path": mux_path}
+                              "paths": paths}
         else:
             factory = [klass, klass_parameters.copy()]
-            factory[1]["params"] = (var, mux_path)
+            factory[1]["params"] = (var, paths)
             return factory, variant
 
     def _iter_suite(self, test_suite, variants, execution_order):

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -54,6 +54,14 @@ from .output import LOG_JOB
 #: one job)
 COMMON_TMPDIR_NAME = 'AVOCADO_TESTS_COMMON_TMPDIR'
 
+#: The list of test attributes that are used as the test state, which
+#: is given to the test runner via the queue they share
+TEST_STATE_ATTRIBUTES = ('name', 'logdir', 'logfile',
+                         'status', 'running', 'paused',
+                         'time_start', 'time_elapsed', 'time_end',
+                         'fail_reason', 'fail_class', 'traceback',
+                         'params', 'timeout')
+
 
 class RawFileHandler(logging.FileHandler):
 
@@ -614,13 +622,7 @@ class Test(unittest.TestCase, TestData):
         """
         if self.running and self.time_start:
             self._update_time_elapsed()
-        preserve_attr = ['basedir', 'fail_reason',
-                         'logdir', 'logfile', 'name', 'srcdir',
-                         'status', 'time_elapsed',
-                         'traceback', 'workdir', 'whiteboard', 'time_start',
-                         'time_end', 'running', 'paused', 'paused_msg',
-                         'fail_class', 'params', "timeout"]
-        state = {key: getattr(self, key, None) for (key) in preserve_attr}
+        state = {key: getattr(self, key, None) for (key) in TEST_STATE_ATTRIBUTES}
         state['class_name'] = self.__class__.__name__
         state['job_logdir'] = self.job.logdir
         state['job_unique_id'] = self.job.unique_id

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -367,7 +367,7 @@ class Test(unittest.TestCase, TestData):
         elif isinstance(params, tuple):
             params, mux_path = params[0], params[1]
         self.__params = parameters.AvocadoParams(params, self.name,
-                                                 mux_path)
+                                                 mux_path, self.__log.name)
         default_timeout = getattr(self, "timeout", None)
         self.timeout = self.params.get("timeout", default=default_timeout)
 

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -369,13 +369,13 @@ class Test(unittest.TestCase, TestData):
         self.__log_warn_used = False
         self.log.warn = self.log.warning = record_and_warn
 
-        mux_path = ['/test/*']
+        paths = ['/test/*']
         if params is None:
             params = []
         elif isinstance(params, tuple):
-            params, mux_path = params[0], params[1]
+            params, paths = params[0], params[1]
         self.__params = parameters.AvocadoParams(params, self.name,
-                                                 mux_path, self.__log.name)
+                                                 paths, self.__log.name)
         default_timeout = getattr(self, "timeout", None)
         self.timeout = self.params.get("timeout", default=default_timeout)
 

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -374,8 +374,8 @@ class Test(unittest.TestCase, TestData):
             params = []
         elif isinstance(params, tuple):
             params, paths = params[0], params[1]
-        self.__params = parameters.AvocadoParams(params, self.name,
-                                                 paths, self.__log.name)
+        self.__params = parameters.AvocadoParams(params, paths,
+                                                 self.__log.name)
         default_timeout = getattr(self, "timeout", None)
         self.timeout = self.params.get("timeout", default=default_timeout)
 

--- a/avocado/core/varianter.py
+++ b/avocado/core/varianter.py
@@ -106,8 +106,8 @@ def dump_ivariants(ivariants):
     variants = []
     for variant in ivariants():
         safe_variant = {}
-        safe_variant["mux_path"] = [str(pth)
-                                    for pth in variant.get("mux_path")]
+        safe_variant["paths"] = [str(pth)
+                                 for pth in variant.get("paths")]
         safe_variant["variant_id"] = variant.get("variant_id")
         safe_variant["variant"] = [dump_tree_node(_)
                                    for _ in variant.get("variant", [])]
@@ -172,9 +172,9 @@ class Varianter(object):
 
     def __init__(self, debug=False, state=None):
         """
-        :param debug: Store whether this instance should debug the mux
+        :param debug: Store whether this instance should debug varianter
         :param state: Force-varianter state
-        :note: people need to check whether mux uses debug and reflect that
+        :note: it's necessary to check whether variants debug is enable
                in order to provide the right results.
         """
         self.default_params = {}
@@ -290,13 +290,13 @@ class Varianter(object):
         This is lossy representation which takes all yielded variants and
         replaces the list of nodes with TreeNodeEnvOnly representations::
 
-            [{'mux_path': mux_path,
+            [{'path': path,
               'variant_id': variant_id,
               'variant': dump_tree_nodes(original_variant)},
-             {'mux_path': [str, str, ...],
+             {'path': [str, str, ...],
               'variant_id': str,
               'variant': [(str, [(str, str, object), ...])],
-             {'mux_path': ['/run/*'],
+             {'path': ['/run/*'],
               'variant_id': 'cat-26c0'
               'variant': [('/pig/cat',
                            [('/pig', 'ant', 'fox'),
@@ -340,7 +340,7 @@ class Varianter(object):
          * variant - AvocadoParams-compatible variant (usually a list of
                      TreeNodes but dict or simply None are also possible
                      values)
-         * mux_path - default path(s)
+         * paths - default path(s)
 
         :yield variant
         """
@@ -354,4 +354,4 @@ class Varianter(object):
         else:   # No variants, use template
             yield {"variant": self._default_params.get_leaves(),
                    "variant_id": None,
-                   "mux_path": ["/run/*"]}
+                   "paths": ["/run/*"]}

--- a/avocado/plugins/variants.py
+++ b/avocado/plugins/variants.py
@@ -67,7 +67,7 @@ class Variants(CLICmd):
                             "Shows the node content (variables)")
         env_parser = parser.add_argument_group("environment view options")
         env_parser.add_argument('-d', '--debug', action='store_true',
-                                dest="mux_debug", default=False,
+                                dest="debug", default=False,
                                 help="Use debug implementation to gather more"
                                 " information.")
         tree_parser = parser.add_argument_group("tree view options")
@@ -80,7 +80,7 @@ class Variants(CLICmd):
 
     def run(self, args):
         err = None
-        if args.tree and args.mux_debug:
+        if args.tree and args.debug:
             err = "Option --tree is incompatible with --debug."
         elif not args.tree and args.inherit:
             err = "Option --inherit can be only used with --tree"

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -872,8 +872,8 @@ class GDBSubProcess(object):
             script_name = '%s.gdb.connect_commands' % binary_name
             path = os.path.join(current_test.outputdir, script_name)
             with open(path, 'w') as cmds_file:
-                cmds_file('file %s\n' % os.path.abspath(self.binary))
-                cmds_file('target extended-remote :%s\n' % self.gdb_server.port)
+                cmds_file.write('file %s\n' % os.path.abspath(self.binary))
+                cmds_file.write('target extended-remote :%s\n' % self.gdb_server.port)
             return path
 
     def generate_gdb_connect_sh(self):

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -918,15 +918,14 @@ class GDBSubProcess(object):
                "NOTE: please use *disconnect* command in gdb before exiting, "
                "or else the debugged process will be KILLED\n" % script_path)
 
-        runtime.CURRENT_TEST.paused = True
-        runtime.CURRENT_TEST.paused_msg = msg
+        runtime.CURRENT_TEST.paused = msg
         runtime.CURRENT_TEST.report_state()
-        runtime.CURRENT_TEST.paused_msg = ''
+        runtime.CURRENT_TEST.paused = ''
 
         ret = self.create_and_wait_on_resume_fifo(fifo_path)
-        runtime.CURRENT_TEST.paused_msg = ("\rResuming ...")
+        runtime.CURRENT_TEST.paused = ("\rResuming ...")
         runtime.CURRENT_TEST.report_state()
-        runtime.CURRENT_TEST.paused_msg = ''
+        runtime.CURRENT_TEST.paused = ''
         return ret
 
     def handle_fatal_signal(self, response):
@@ -942,15 +941,14 @@ class GDBSubProcess(object):
 
         self.gdb.disconnect()
 
-        runtime.CURRENT_TEST.paused = True
-        runtime.CURRENT_TEST.paused_msg = msg
+        runtime.CURRENT_TEST.paused = msg
         runtime.CURRENT_TEST.report_state()
-        runtime.CURRENT_TEST.paused_msg = ''
+        runtime.CURRENT_TEST.paused = ''
 
         ret = self.create_and_wait_on_resume_fifo(fifo_path)
-        runtime.CURRENT_TEST.paused_msg = ("\rResuming ...")
+        runtime.CURRENT_TEST.paused = ("\rResuming ...")
         runtime.CURRENT_TEST.report_state()
-        runtime.CURRENT_TEST.paused_msg = ''
+        runtime.CURRENT_TEST.paused = ''
         return ret
 
     def _is_thread_stopped(self):

--- a/docs/source/TestParameters.rst
+++ b/docs/source/TestParameters.rst
@@ -91,7 +91,7 @@ Is a "database" of params present in every (instrumented) avocado
 test.  It's produced during :class:`avocado.core.test.Test`'s
 ``__init__`` from a `variant`_. It accepts a list of `TreeNode`_
 objects; test name :class:`avocado.core.test.TestID` (for logging
-purposes) and a list of default paths (`Mux path`_).
+purposes) and a list of default paths (`Parameter Paths`_).
 
 In test it allows querying for data by using::
 
@@ -106,8 +106,8 @@ Where:
 Each `variant`_ defines a hierarchy, which is preserved so `AvocadoParams`_
 follows it to return the most appropriate value or raise Exception on error.
 
-Mux path
-~~~~~~~~
+Parameter Paths
+~~~~~~~~~~~~~~~
 
 As test params are organized in trees, it's possible to have the same
 variant in several locations. When they are produced from the same
@@ -121,12 +121,12 @@ For example let's say we have upstream values in ``/upstream/sleeptest``
 and our values in ``/downstream/sleeptest``. If we asked for a value using
 path ``"*"``, it'd raise an exception being unable to distinguish whether
 we want the value from ``/downstream`` or ``/upstream``. We can set the
-mux path to ``["/downstream/*", "/upstream/*"]`` to make all relative
+parameter paths to ``["/downstream/*", "/upstream/*"]`` to make all relative
 calls (path starting with ``*``) to first look in nodes in ``/downstream``
 and if not found look into ``/upstream``.
 
-More practical overview of mux path is in :ref:`yaml-to-mux-plugin` in
-:ref:`yaml-to-mux-resolution-order` section.
+More practical overview of parameter paths is in :ref:`yaml-to-mux-plugin`
+in :ref:`yaml-to-mux-resolution-order` section.
 
 Variant
 ~~~~~~~
@@ -134,7 +134,7 @@ Variant
 Variant is a set of params produced by `Varianter`_s and passed to the
 test by the test runner as ``params`` argument. The simplest variant
 is ``None``, which still produces an empty `AvocadoParams`_. Also, the
-`Variant`_ can also be a ``tuple(list, mux_path)`` or just the
+`Variant`_ can also be a ``tuple(list, paths)`` or just the
 ``list`` of :class:`avocado.core.tree.TreeNode` with the params.
 
 Varianter
@@ -401,13 +401,13 @@ Defines the full interface required by
 should inherit from this ``MuxPlugin``, then from the ``Varianter``
 and call the::
 
-   self.initialize_mux(root, mux_path, debug)
+   self.initialize_mux(root, paths, debug)
 
 Where:
 
 * root - is the root of your params tree (compound of `TreeNode`_ -like
   nodes)
-* mux_path - is the `Mux path`_ to be used in test with all variants
+* paths - is the `Parameter paths`_ to be used in test with all variants
 * debug - whether to use debug mode (requires the passed tree to be
   compound of ``TreeNodeDebug``-like nodes which stores the origin
   of the variant/value/environment as the value for listing purposes

--- a/optional_plugins/loader_yaml/avocado_loader_yaml/__init__.py
+++ b/optional_plugins/loader_yaml/avocado_loader_yaml/__init__.py
@@ -19,6 +19,7 @@ from six import iteritems
 
 from avocado.core import loader
 from avocado.core import parameters
+from avocado.core import output
 from avocado.core.plugin_interfaces import CLI
 from avocado_varianter_yaml_to_mux import create_from_yaml
 from avocado_varianter_yaml_to_mux import mux
@@ -101,7 +102,7 @@ class YamlTestsuiteLoader(loader.TestLoader):
         mux_tree = mux.MuxTree(root)
         for variant in mux_tree:
             params = parameters.AvocadoParams(variant, "YamlTestsuiteLoader",
-                                              ["/run/*"])
+                                              ["/run/*"], output.LOG_UI.name)
             reference = params.get("test_reference")
             test_loader = self._get_loader(params)
             if not test_loader:

--- a/optional_plugins/loader_yaml/avocado_loader_yaml/__init__.py
+++ b/optional_plugins/loader_yaml/avocado_loader_yaml/__init__.py
@@ -101,8 +101,8 @@ class YamlTestsuiteLoader(loader.TestLoader):
             return []
         mux_tree = mux.MuxTree(root)
         for variant in mux_tree:
-            params = parameters.AvocadoParams(variant, "YamlTestsuiteLoader",
-                                              ["/run/*"], output.LOG_UI.name)
+            params = parameters.AvocadoParams(variant, ["/run/*"],
+                                              output.LOG_UI.name)
             reference = params.get("test_reference")
             test_loader = self._get_loader(params)
             if not test_loader:

--- a/optional_plugins/varianter_pict/avocado_varianter_pict/__init__.py
+++ b/optional_plugins/varianter_pict/avocado_varianter_pict/__init__.py
@@ -152,7 +152,7 @@ class VarianterPict(Varianter):
 
             yield {"variant_id": vid,
                    "variant": variant_tree_nodes,
-                   "mux_path": self.parameter_path}
+                   "paths": self.parameter_path}
 
     def __len__(self):
         return sum(1 for _ in self)

--- a/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/__init__.py
+++ b/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/__init__.py
@@ -357,6 +357,7 @@ class YamlToMuxCLI(CLI):
             agroup.add_argument('--mux-filter-out', nargs='*', default=[],
                                 help='Filter out path(s) from multiplexing')
             agroup.add_argument('--mux-path', nargs='*', default=None,
+                                dest='mux_parameter_paths',
                                 help="List of default paths used to determine "
                                 "path priority when querying for parameters")
             agroup.add_argument('--mux-inject', default=[], nargs='*',
@@ -418,7 +419,7 @@ class YamlToMux(mux.MuxPlugin, Varianter):
             else:
                 args.mux_filter_out = out
 
-        debug = getattr(args, "mux_debug", False)
+        debug = getattr(args, "debug", False)
         if debug:
             data = mux.MuxTreeNodeDebug()
         else:
@@ -467,7 +468,7 @@ class YamlToMux(mux.MuxPlugin, Varianter):
         mux_filter_out = getattr(args, 'mux_filter_out', None)
         data = mux.apply_filters(data, mux_filter_only, mux_filter_out)
         if data != mux.MuxTreeNode():
-            mux_path = getattr(args, "mux_path", ["/run/*"])
-            if mux_path is None:
-                mux_path = ["/run/*"]
-            self.initialize_mux(data, mux_path, debug)
+            paths = getattr(args, "mux_parameter_paths", ["/run/*"])
+            if paths is None:
+                paths = ["/run/*"]
+            self.initialize_mux(data, paths, debug)

--- a/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/mux.py
+++ b/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/mux.py
@@ -152,10 +152,10 @@ class MuxPlugin(object):
     root = None
     variants = None
     default_params = None
-    mux_path = None
+    paths = None
     debug = None
 
-    def initialize_mux(self, root, mux_path, debug):
+    def initialize_mux(self, root, paths, debug):
         """
         Initialize the basic values
 
@@ -163,7 +163,7 @@ class MuxPlugin(object):
                via dispatcher with no __init__ arguments.
         """
         self.root = root
-        self.mux_path = mux_path
+        self.paths = paths
         self.debug = debug
         self.variant_ids = self._get_variant_ids()
 
@@ -184,7 +184,7 @@ class MuxPlugin(object):
         for vid, variant in itertools.izip(self.variant_ids, self.variants):
             yield {"variant_id": vid,
                    "variant": variant,
-                   "mux_path": self.mux_path}
+                   "paths": self.paths}
 
     def update_defaults(self, defaults):
         """

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -196,10 +196,10 @@ class RunnerOperationTest(unittest.TestCase):
         cmd_line = ('%s run --sysinfo=off --job-results-dir %s '
                     'passtest.py passtest.py' % (AVOCADO, self.tmpdir))
         process.run(cmd_line)
-        # Also check whether jobdata contains correct mux_path
+        # Also check whether jobdata contains correct parameter paths
         variants = open(os.path.join(self.tmpdir, "latest", "jobdata",
                         "variants.json")).read()
-        self.assertIn('["/run/*"]', variants, "mux_path stored in jobdata "
+        self.assertIn('["/run/*"]', variants, "paths stored in jobdata "
                       "does not contains [\"/run/*\"]\n%s" % variants)
 
     def test_runner_failfast(self):

--- a/selftests/functional/test_multiplex.py
+++ b/selftests/functional/test_multiplex.py
@@ -78,11 +78,11 @@ class MultiplexTests(unittest.TestCase):
                     % (AVOCADO, self.tmpdir))
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.run_and_check(cmd_line, expected_rc, (4, 0))
-        # Also check whether jobdata contains correct mux_path
+        # Also check whether jobdata contains correct parameter paths
         variants = open(os.path.join(self.tmpdir, "latest", "jobdata",
                         "variants.json")).read()
-        self.assertIn('["/run/*"]', variants, "mux_path stored in jobdata "
-                      "does not contains [\"/run/*\"]\n%s" % variants)
+        self.assertIn('["/run/*"]', variants, "parameter paths stored in "
+                      "jobdata does not contains [\"/run/*\"]\n%s" % variants)
 
     def test_run_mplex_doublepass(self):
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
@@ -91,11 +91,11 @@ class MultiplexTests(unittest.TestCase):
                     '--mux-path /foo/\\* /bar/\\* /baz/\\*'
                     % (AVOCADO, self.tmpdir))
         self.run_and_check(cmd_line, exit_codes.AVOCADO_ALL_OK, (8, 0))
-        # Also check whether jobdata contains correct mux_path
+        # Also check whether jobdata contains correct parameter paths
         variants = open(os.path.join(self.tmpdir, "latest", "jobdata",
                         "variants.json")).read()
         exp = '["/foo/*", "/bar/*", "/baz/*"]'
-        self.assertIn(exp, variants, "mux_path stored in jobdata "
+        self.assertIn(exp, variants, "parameter paths stored in jobdata "
                       "does not contains %s\n%s" % (exp, variants))
 
     def test_run_mplex_failtest(self):

--- a/selftests/unit/test_mux.py
+++ b/selftests/unit/test_mux.py
@@ -293,11 +293,11 @@ class TestAvocadoParams(unittest.TestCase):
         yamls = yaml_to_mux.create_from_yaml(["/:" + PATH_PREFIX +
                                               'selftests/.data/mux-selftest-params.yaml'])
         self.yamls = iter(mux.MuxTree(yamls))
-        self.params1 = parameters.AvocadoParams(next(self.yamls), 'Unittest1',
+        self.params1 = parameters.AvocadoParams(next(self.yamls),
                                                 ['/ch0/*', '/ch1/*'])
         next(self.yamls)    # Skip 2nd
         next(self.yamls)    # and 3rd
-        self.params2 = parameters.AvocadoParams(next(self.yamls), 'Unittest2',
+        self.params2 = parameters.AvocadoParams(next(self.yamls),
                                                 ['/ch1/*', '/ch0/*'])
 
     @unittest.skipIf(not yaml_to_mux.MULTIPLEX_CAPABLE, "Not multiplex capable")
@@ -312,7 +312,7 @@ class TestAvocadoParams(unittest.TestCase):
         self.assertNotEqual(self.params1, self.params2)
         repr(self.params1)
         str(self.params1)
-        str(parameters.AvocadoParams([], 'Unittest', []))
+        str(parameters.AvocadoParams([], []))
         self.assertEqual(15, sum([1 for _ in iteritems(self.params1)]))
 
     @unittest.skipIf(not yaml_to_mux.MULTIPLEX_CAPABLE, "Not multiplex capable")

--- a/selftests/unit/test_mux.py
+++ b/selftests/unit/test_mux.py
@@ -228,7 +228,7 @@ class TestMuxTree(unittest.TestCase):
         variant1 = next(iter(mux1))
         variant2 = next(iter(mux2))
         self.assertNotEqual(variant1, variant2)
-        self.assertEqual(str(variant1), "{'mux_path': '', 'variant': "
+        self.assertEqual(str(variant1), "{'paths': '', 'variant': "
                          "[TreeNode(name='child1'), TreeNode(name="
                          "'child2')], 'variant_id': 'child1-child2-9154'}")
 


### PR DESCRIPTION
This PR is a collection of architectural and terminology arrangements.

It starts by not using the "mux" or "multiplexer" terminology in places where the (abstract) varianter interface is meant to be.  Then, it cleans up the `AvocadoParams` interfaces.  Finally, it moves the tests that are related to the mux code to the `yaml_to_mux` optional plugin, a primer that should be followed on other optional plugins.

---
Changes from v3 (#2349):
 - Removal of the `Multiplexer: move respective tests to the yaml_to_mux plugin` to be introduced in a later PR
 - Removed `test_id` docstring from `AvocadoParams`
 - Removed `__getstate__` and `__setstate__` methods from `AvocadoParams` on commit `Parameters: remove knowledge about a specific (job) logger` because they are workarounds for the (now removed) logger instance

Changes from v2 (#2343):
 - Two new commits fixing two issues related to "paused msg":
   * `avocado/utils/process.py: fix writing of GDB "commands" file`
   * `avocado/core/runner.py: remove ResultProxy reference`
 - Fixed the use of `paused` instead of `paused_msg` from `avocado.utils.process`
 - Rebased

Changes from v1 (#2336):
 - Added a missing `__init__.py` file on tests directory
 - Adapt new location of `yaml` files used on the tests
 - Rebased