### PR TITLE
Accomodating more types of slot names in pci utils

### DIFF
--- a/avocado/utils/pci.py
+++ b/avocado/utils/pci.py
@@ -182,7 +182,7 @@ def get_slot_from_sysfs(full_pci_address):
     if not os.path.isfile("/proc/device-tree/%s/ibm,loc-code" % devspec):
         return
     slot = genio.read_file("/proc/device-tree/%s/ibm,loc-code" % devspec)
-    slot = re.match(r'((\w+)[.])+(\w+)-P(\d+)-C(\d+)|Slot(\d+)', slot).group()
+    slot = re.match(r'((\w+)[.])+(\w+)-P(\d+)-C(\d+)|S(\w+)', slot).group()
     return slot
 
 

--- a/avocado/utils/pci.py
+++ b/avocado/utils/pci.py
@@ -52,7 +52,7 @@ def get_pci_addresses():
     addresses = []
     cmd = "lspci -D"
     for line in process.system_output(cmd).splitlines():
-        if "PCI bridge" not in line and "System peripheral" not in line:
+        if '06' not in get_pci_prop(line.split()[0], 'Class'):
             addresses.append(line.split()[0])
     if addresses:
         return addresses


### PR DESCRIPTION
**Commit 1:**

Slot names are of different types:
* S0001
* Slot1
* SLOT1

So, this patch accomodating all of them.

**Commit 2:**

PCI Bridges can be represented in lspci output in different ways.
But they are all of Class 06.
So, handling using class id instead, which is a better way.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>