### PR TITLE
utils/cpu: Check cpu list for s390x [v4]

### DIFF
--- a/avocado/utils/cpu.py
+++ b/avocado/utils/cpu.py
@@ -22,6 +22,7 @@ Get information from the current's machine CPU.
 
 import re
 import os
+import platform
 
 
 def _list_matches(lst, pattern):
@@ -136,10 +137,15 @@ def cpu_online_list():
     Reports a list of indexes of the online cpus
     """
     cpus = []
+    search_str = 'processor'
+    index = 2
+    if platform.machine() == 's390x':
+        search_str = 'cpu number'
+        index = 3
     with open('/proc/cpuinfo', 'r') as proc_cpuinfo:
         for line in proc_cpuinfo:
-            if line.startswith('processor'):
-                cpus.append(int(line.split()[2]))  # grab cpu number
+            if line.startswith(search_str):
+                cpus.append(int(line.split()[index]))  # grab cpu number
     return cpus
 
 

--- a/selftests/checkall
+++ b/selftests/checkall
@@ -115,7 +115,8 @@ if [ "$TRAVIS" == "true" ]; then
 else
     run_rc lint 'inspekt lint --exclude=.git --enable W0102,W0611'
 fi
-run_rc indent 'inspekt indent --exclude=.git'
+# Skip checking test_utils_cpu.py due to inspektor bug
+run_rc indent 'inspekt indent --exclude=.git,selftests/unit/test_utils_cpu.py'
 run_rc style 'inspekt style --exclude=.git --disable E501,E265,W601,E402,E722'
 run_rc boundaries 'selftests/modules_boundaries'
 run_rc signed-off-by signed_off_check

--- a/selftests/unit/test_utils_cpu.py
+++ b/selftests/unit/test_utils_cpu.py
@@ -87,6 +87,229 @@ cpu MHz static  : 5504
                             return_value=self._get_file_mock(s390x_2)):
                 self.assertEqual(len(cpu.cpu_online_list()), 4)
 
+    def test_x86_64(self):
+        x86_64 = u"""processor	: 0
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 60
+model name	: Intel(R) Core(TM) i7-4710MQ CPU @ 2.50GHz
+stepping	: 3
+microcode	: 0x22
+cpu MHz		: 2494.301
+cache size	: 6144 KB
+physical id	: 0
+siblings	: 8
+core id		: 0
+cpu cores	: 4
+apicid		: 0
+initial apicid	: 0
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm cpuid_fault epb tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt dtherm ida arat pln pts
+bugs		:
+bogomips	: 4988.60
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 39 bits physical, 48 bits virtual
+power management:
+
+processor	: 1
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 60
+model name	: Intel(R) Core(TM) i7-4710MQ CPU @ 2.50GHz
+stepping	: 3
+microcode	: 0x22
+cpu MHz		: 2494.301
+cache size	: 6144 KB
+physical id	: 0
+siblings	: 8
+core id		: 0
+cpu cores	: 4
+apicid		: 1
+initial apicid	: 1
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm cpuid_fault epb tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt dtherm ida arat pln pts
+bugs		:
+bogomips	: 4988.60
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 39 bits physical, 48 bits virtual
+power management:
+
+processor	: 2
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 60
+model name	: Intel(R) Core(TM) i7-4710MQ CPU @ 2.50GHz
+stepping	: 3
+microcode	: 0x22
+cpu MHz		: 2494.301
+cache size	: 6144 KB
+physical id	: 0
+siblings	: 8
+core id		: 1
+cpu cores	: 4
+apicid		: 2
+initial apicid	: 2
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm cpuid_fault epb tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt dtherm ida arat pln pts
+bugs		:
+bogomips	: 4988.60
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 39 bits physical, 48 bits virtual
+power management:
+
+processor	: 3
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 60
+model name	: Intel(R) Core(TM) i7-4710MQ CPU @ 2.50GHz
+stepping	: 3
+microcode	: 0x22
+cpu MHz		: 2494.301
+cache size	: 6144 KB
+physical id	: 0
+siblings	: 8
+core id		: 1
+cpu cores	: 4
+apicid		: 3
+initial apicid	: 3
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm cpuid_fault epb tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt dtherm ida arat pln pts
+bugs		:
+bogomips	: 4988.60
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 39 bits physical, 48 bits virtual
+power management:
+
+processor	: 4
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 60
+model name	: Intel(R) Core(TM) i7-4710MQ CPU @ 2.50GHz
+stepping	: 3
+microcode	: 0x22
+cpu MHz		: 2494.301
+cache size	: 6144 KB
+physical id	: 0
+siblings	: 8
+core id		: 2
+cpu cores	: 4
+apicid		: 4
+initial apicid	: 4
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm cpuid_fault epb tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt dtherm ida arat pln pts
+bugs		:
+bogomips	: 4988.60
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 39 bits physical, 48 bits virtual
+power management:
+
+processor	: 5
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 60
+model name	: Intel(R) Core(TM) i7-4710MQ CPU @ 2.50GHz
+stepping	: 3
+microcode	: 0x22
+cpu MHz		: 2494.301
+cache size	: 6144 KB
+physical id	: 0
+siblings	: 8
+core id		: 2
+cpu cores	: 4
+apicid		: 5
+initial apicid	: 5
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm cpuid_fault epb tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt dtherm ida arat pln pts
+bugs		:
+bogomips	: 4988.60
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 39 bits physical, 48 bits virtual
+power management:
+
+processor	: 6
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 60
+model name	: Intel(R) Core(TM) i7-4710MQ CPU @ 2.50GHz
+stepping	: 3
+microcode	: 0x22
+cpu MHz		: 2494.301
+cache size	: 6144 KB
+physical id	: 0
+siblings	: 8
+core id		: 3
+cpu cores	: 4
+apicid		: 6
+initial apicid	: 6
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm cpuid_fault epb tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt dtherm ida arat pln pts
+bugs		:
+bogomips	: 4988.60
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 39 bits physical, 48 bits virtual
+power management:
+
+processor	: 7
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 60
+model name	: Intel(R) Core(TM) i7-4710MQ CPU @ 2.50GHz
+stepping	: 3
+microcode	: 0x22
+cpu MHz		: 2494.301
+cache size	: 6144 KB
+physical id	: 0
+siblings	: 8
+core id		: 3
+cpu cores	: 4
+apicid		: 7
+initial apicid	: 7
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm cpuid_fault epb tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt dtherm ida arat pln pts
+bugs		:
+bogomips	: 4988.60
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 39 bits physical, 48 bits virtual
+power management:
+
+"""
+        with mock.patch('avocado.utils.cpu.platform.machine', return_value='x86_64'):
+            with mock.patch('avocado.utils.cpu.open',
+                            return_value=self._get_file_mock(x86_64)):
+                self.assertEqual(len(cpu.cpu_online_list()), 8)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/selftests/unit/test_utils_cpu.py
+++ b/selftests/unit/test_utils_cpu.py
@@ -1,0 +1,92 @@
+import io
+import unittest
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+
+from avocado.utils import cpu
+
+
+class Cpu(unittest.TestCase):
+
+    @staticmethod
+    def _get_file_mock(content):
+        file_mock = mock.Mock()
+        file_mock.__enter__ = mock.Mock(return_value=io.StringIO(content))
+        file_mock.__exit__ = mock.Mock()
+        return file_mock
+
+    def test_s390x(self):
+        s390x = u"""vendor_id       : IBM/S390
+# processors    : 2
+bogomips per cpu: 2913.00
+max thread id   : 0
+features        : esan3 zarch stfle msa ldisp eimm dfp edat etf3eh highgprs te sie
+facilities      : 0 1 2 3 4 6 7 8 9 10 12 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 30 31 32 33 34 35 36 37 40 41 42 43 44 45 46 47 48 49 50 51 52 57 73 74 75 76 77
+cache0          : level=1 type=Data scope=Private size=96K line_size=256 associativity=6
+cache1          : level=1 type=Instruction scope=Private size=64K line_size=256 associativity=4
+cache2          : level=2 type=Data scope=Private size=1024K line_size=256 associativity=8
+cache3          : level=2 type=Instruction scope=Private size=1024K line_size=256 associativity=8
+cache4          : level=3 type=Unified scope=Shared size=49152K line_size=256 associativity=12
+cache5          : level=4 type=Unified scope=Shared size=393216K line_size=256 associativity=24
+processor 0: version = FF,  identification = 32C047,  machine = 2827
+processor 1: version = FF,  identification = 32C047,  machine = 2827
+
+cpu number      : 0
+cpu MHz dynamic : 5504
+cpu MHz static  : 5504
+
+cpu number      : 1
+cpu MHz dynamic : 5504
+cpu MHz static  : 5504
+
+"""
+
+        s390x_2 = u"""vendor_id       : IBM/S390
+# processors    : 4
+bogomips per cpu: 2913.00
+max thread id   : 0
+features        : esan3 zarch stfle msa ldisp eimm dfp edat etf3eh highgprs te sie
+facilities      : 0 1 2 3 4 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 30 31 32 33 34 35 36 37 40 41 42 43 44 45 46 47 48 49 50 51 52 57 64 65 66 67 68 69 70 71 72 73 75 76 77 78 131 132
+cache0          : level=1 type=Data scope=Private size=96K line_size=256 associativity=6
+cache1          : level=1 type=Instruction scope=Private size=64K line_size=256 associativity=4
+cache2          : level=2 type=Data scope=Private size=1024K line_size=256 associativity=8
+cache3          : level=2 type=Instruction scope=Private size=1024K line_size=256 associativity=8
+cache4          : level=3 type=Unified scope=Shared size=49152K line_size=256 associativity=12
+cache5          : level=4 type=Unified scope=Shared size=393216K line_size=256 associativity=24
+processor 0: version = 00,  identification = 3FC047,  machine = 2827
+processor 1: version = 00,  identification = 3FC047,  machine = 2827
+processor 2: version = 00,  identification = 3FC047,  machine = 2827
+processor 3: version = 00,  identification = 3FC047,  machine = 2827
+
+cpu number      : 0
+cpu MHz dynamic : 5504
+cpu MHz static  : 5504
+
+cpu number      : 1
+cpu MHz dynamic : 5504
+cpu MHz static  : 5504
+
+cpu number      : 2
+cpu MHz dynamic : 5504
+cpu MHz static  : 5504
+
+cpu number      : 3
+cpu MHz dynamic : 5504
+cpu MHz static  : 5504
+"""
+
+        with mock.patch('avocado.utils.cpu.platform.machine', return_value='s390x'):
+            with mock.patch('avocado.utils.cpu.open',
+                            return_value=self._get_file_mock(s390x)):
+                self.assertEqual(len(cpu.cpu_online_list()), 2)
+            with mock.patch('avocado.utils.cpu.open',
+                            return_value=self._get_file_mock(s390x_2)):
+                self.assertEqual(len(cpu.cpu_online_list()), 4)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The output in /proc/cpuinfo is different between s390x and other archs.
This is to support to parse the output on s390x.

Signed-off-by: Dan Zheng <dzheng@redhat.com>
Signed-off-by: Cleber Rosa <crosa@redhat.com>

---
Changes from v3 (#2353):
 * Skip the unittest from the indentation check due to inspektor issue ( https://github.com/avocado-framework/inspektor/issues/31 )

Changes from v2 (#2351):
 * Added x86_64 test

Changes from v1 (#2300):
 * Added unittests considering a real and slightly faked output from `/proc/cpuinfo` on s390x