### PR TITLE
Better naming for internal varianter debug argument

### DIFF
--- a/avocado/core/parser.py
+++ b/avocado/core/parser.py
@@ -133,7 +133,7 @@ class Parser(object):
         self.subcommands.required = True
 
         # Allow overriding default params by plugins
-        variants = varianter.Varianter(getattr(self.args, "debug", False))
+        variants = varianter.Varianter(getattr(self.args, "varianter_debug", False))
         self.args.avocado_variants = variants
         # FIXME: Backward compatibility params, to be removed when 36 LTS is
         # discontinued

--- a/avocado/plugins/variants.py
+++ b/avocado/plugins/variants.py
@@ -67,7 +67,7 @@ class Variants(CLICmd):
                             "Shows the node content (variables)")
         env_parser = parser.add_argument_group("environment view options")
         env_parser.add_argument('-d', '--debug', action='store_true',
-                                dest="debug", default=False,
+                                dest="varianter_debug", default=False,
                                 help="Use debug implementation to gather more"
                                 " information.")
         tree_parser = parser.add_argument_group("tree view options")
@@ -80,7 +80,7 @@ class Variants(CLICmd):
 
     def run(self, args):
         err = None
-        if args.tree and args.debug:
+        if args.tree and args.varianter_debug:
             err = "Option --tree is incompatible with --debug."
         elif not args.tree and args.inherit:
             err = "Option --inherit can be only used with --tree"

--- a/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/__init__.py
+++ b/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/__init__.py
@@ -419,7 +419,7 @@ class YamlToMux(mux.MuxPlugin, Varianter):
             else:
                 args.mux_filter_out = out
 
-        debug = getattr(args, "debug", False)
+        debug = getattr(args, "varianter_debug", False)
         if debug:
             data = mux.MuxTreeNodeDebug()
         else:


### PR DESCRIPTION
Commit 51e46987af536048b55853ffdbfbde62b62cb822 changed it from
`mux_debug` to `debug`, but using `debug` is actually dangerous if some
higher level plugin creates the same option, since it can make the
varianter plugin to use TreeNodeDebug instead of TreeNode.

Let's use a more exclusive naming, while still in line with the actual
implementation.

Signed-off-by: Amador Pahim <apahim@redhat.com>