### PR TITLE
support to find free port randomly [v2]

### DIFF
--- a/avocado/utils/network.py
+++ b/avocado/utils/network.py
@@ -61,9 +61,9 @@ def find_free_ports(start_port, end_port, count, address="localhost"):
     """
     Return count of host free ports in the range [start_port, end_port].
 
-    :param count: Initial number of ports known to be free in the range.
     :param start_port: First port that will be checked.
     :param end_port: Port immediately after the last one that will be checked.
+    :param count: Initial number of ports known to be free in the range.
     """
     ports = []
     i = start_port

--- a/avocado/utils/network.py
+++ b/avocado/utils/network.py
@@ -17,6 +17,9 @@ Module with network related utility functions
 """
 
 import socket
+import random
+
+from six.moves import xrange as range
 
 from .data_structures import Borg
 
@@ -45,36 +48,47 @@ def is_port_free(port, address):
     return free
 
 
-def find_free_port(start_port, end_port, address="localhost"):
+def find_free_port(start_port, end_port, address="localhost", sequent=True):
     """
     Return a host free port in the range [start_port, end_port].
 
-    :param start_port: First port that will be checked.
-    :param end_port: Port immediately after the last one that will be checked.
+    :param start_port: header of candidate port range
+    :param end_port: ender of candidate port range
+    :param sequent: Find port sequently, random order if it's False
     :param address: Socket address to bind or connect
     """
-    for i in range(start_port, end_port):
+    port_range = range(start_port, end_port)
+    if not sequent:
+        port_range = list(port_range)
+        random.shuffle(port_range)
+    for i in port_range:
         if is_port_free(i, address):
             return i
     return None
 
 
-def find_free_ports(start_port, end_port, count, address="localhost"):
+def find_free_ports(start_port, end_port, count, address="localhost", sequent=True):
     """
     Return count of host free ports in the range [start_port, end_port].
 
-    :param start_port: First port that will be checked.
-    :param end_port: Port immediately after the last one that will be checked.
+    :param start_port: header of candidate port range
+    :param end_port: ender of candidate port range
     :param count: Initial number of ports known to be free in the range.
     :param address: Socket address to bind or connect
+    :param sequent: Find port sequently, random order if it's False
     """
     ports = []
-    i = start_port
-    while i < end_port and count > 0:
+
+    port_range = range(start_port, end_port)
+    if not sequent:
+        port_range = list(port_range)
+        random.shuffle(port_range)
+    for i in port_range:
         if is_port_free(i, address):
             ports.append(i)
-            count -= 1
-        i += 1
+        if len(ports) >= count:
+            break
+
     return ports
 
 

--- a/avocado/utils/network.py
+++ b/avocado/utils/network.py
@@ -26,6 +26,7 @@ def is_port_free(port, address):
     Return True if the given port is available for use.
 
     :param port: Port number
+    :param address: Socket address to bind or connect
     """
     try:
         s = socket.socket()
@@ -50,6 +51,7 @@ def find_free_port(start_port, end_port, address="localhost"):
 
     :param start_port: First port that will be checked.
     :param end_port: Port immediately after the last one that will be checked.
+    :param address: Socket address to bind or connect
     """
     for i in range(start_port, end_port):
         if is_port_free(i, address):
@@ -64,6 +66,7 @@ def find_free_ports(start_port, end_port, count, address="localhost"):
     :param start_port: First port that will be checked.
     :param end_port: Port immediately after the last one that will be checked.
     :param count: Initial number of ports known to be free in the range.
+    :param address: Socket address to bind or connect
     """
     ports = []
     i = start_port


### PR DESCRIPTION
Current code will try to find available from the start of range one by one, sometimes we want to randomly choose to reduce the chance to conflict.

---

Changes from v1 (#2359):
 - Indentation fix
 - Use range from six (iterator)
 - Convert to list before (and only when) shuffling port range