### PR TITLE
varianter: Bring back compatibility with 52.0 results

### DIFF
--- a/avocado/core/varianter.py
+++ b/avocado/core/varianter.py
@@ -326,6 +326,11 @@ class Varianter(object):
 
         :param state: loadable Varianter representation
         """
+        # TODO: Remove when 52.0 is deprecated
+        # In 52.0 the "paths" was called "mux_path"
+        for variant in state:
+            if "mux_path" in variant and "paths" not in variant:
+                variant["paths"] = variant["mux_path"]
         self.debug = False
         self.node_class = tree.TreeNode
         self._variant_plugins = FakeVariantDispatcher(state)


### PR DESCRIPTION
Recently we renamed the default varianter paths from "mux_path" to
"paths", which results in default "paths" being used when replaying
older results (including 52.0). Let's "upgrade" the results on-load.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>