### PR TITLE
Travis-CI: configuration updates [v2]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: python
 
+virtualenv:
+  system_site_packages: true
+
 python:
-    - "2.7_with_system_site_packages"
+    - "2.7"
 
 branches:
     only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ virtualenv:
 
 python:
     - "2.7"
+    - "3.4"
+
+matrix:
+  allow_failures:
+    - python: "3.4"
 
 branches:
     only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ branches:
     only:
         - master
         - 36lts
+        - 52lts
 
 cache:
     directories:

--- a/requirements-selftests.txt
+++ b/requirements-selftests.txt
@@ -6,7 +6,7 @@ Sphinx>=1.3b1
 # inspektor (static and style checks)
 inspektor>=0.4.5
 # mock (some unittests use it)
-mock>=1.0.0
+mock>=1.0.0; python_version <= '2.7'
 # six
 six>=1.9.0
 # funcsigs
@@ -14,10 +14,10 @@ funcsigs>=0.4
 # To run make check
 pep8>=1.6.2
 Pillow>=2.2.1
-snakefood>=1.4
-networkx>=1.9.1
-pygraphviz>=1.3rc2
-pydot>=1.2.3
+snakefood>=1.4; python_version <= '2.7'
+networkx>=1.9.1; python_version <= '2.7'
+pygraphviz>=1.3rc2; python_version <= '2.7'
+pydot>=1.2.3; python_version <= '2.7'
 aexpect>=1.0.0
 psutil>=3.1.1
 # six is a stevedore depedency, but we also use it directly

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -6,10 +6,10 @@ pep8==1.6.2
 requests==1.2.3
 PyYAML==3.11
 Pillow==2.8.1
-snakefood==1.4
-networkx==1.9.1
-pygraphviz==1.3rc2
-mock==1.2.0
+snakefood==1.4; python_version <= '2.7'
+networkx==1.9.1; python_version <= '2.7'
+pygraphviz==1.3rc2; python_version <= '2.7'
+mock==1.2.0; python_version <= '2.7'
 aexpect==1.0.0
 psutil==3.1.1
 # six is a stevedore depedency, but we also use it directly


### PR DESCRIPTION
This is a collection of configuration updates for the Travis-CI system.

---

Changes from v1 (#2368):
 - Removed commit `Travis-CI: reduce the git clone depth`