### PR TITLE
Docs: update location for RPM repo location

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ Term Stability) releases available from its own package repository.
 To use it, first get the package repositories configuration file by
 running the following command::
 
-    sudo curl https://repos-avocadoproject.rhcloud.com/static/avocado-fedora.repo -o /etc/yum.repos.d/avocado.repo
+    sudo curl http://avocado-project.org/data/repos/avocado-fedora.repo -o /etc/yum.repos.d/avocado.repo
 
 Now check if you have the ``avocado`` and ``avocado-lts`` repositories configured by running::
 
@@ -107,11 +107,11 @@ following command should do it::
     yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
 Then you must use the Avocado project RHEL repo
-(https://repos-avocadoproject.rhcloud.com/static/avocado-el.repo).
+(http://avocado-project.org/data/repos/avocado-el.repo).
 Running the following command should give you the basic Avocado
 installation ready::
 
-    curl https://repos-avocadoproject.rhcloud.com/static/avocado-el.repo -o /etc/yum.repos.d/avocado.repo
+    curl http://avocado-project.org/data/repos/avocado-el.repo -o /etc/yum.repos.d/avocado.repo
     yum install python-avocado
 
 Other available packages (depending on the Avocado version) may include:

--- a/docs/source/GetStartedGuide.rst
+++ b/docs/source/GetStartedGuide.rst
@@ -49,7 +49,7 @@ Term Stability) releases available from its own package repository.
 To use it, first get the package repositories configuration file by
 running the following command::
 
-    sudo curl https://repos-avocadoproject.rhcloud.com/static/avocado-fedora.repo -o /etc/yum.repos.d/avocado.repo
+    sudo curl http://avocado-project.org/data/repos/avocado-fedora.repo -o /etc/yum.repos.d/avocado.repo
 
 Now check if you have the ``avocado`` and ``avocado-lts`` repositories configured by running::
 
@@ -92,11 +92,11 @@ following command should do it::
     yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
 Then you must use the Avocado project RHEL repo
-(https://repos-avocadoproject.rhcloud.com/static/avocado-el.repo).
+(http://avocado-project.org/data/repos/avocado-el.repo).
 Running the following command should give you the basic Avocado
 installation ready::
 
-    curl https://repos-avocadoproject.rhcloud.com/static/avocado-el.repo -o /etc/yum.repos.d/avocado.repo
+    curl http://avocado-project.org/data/repos/avocado-el.repo -o /etc/yum.repos.d/avocado.repo
     yum install python-avocado
 
 Other available packages (depending on the Avocado version) may include:


### PR DESCRIPTION
We've got a new server, and the RPM repo is already there.  Let's use
that new server in the documentation.

Signed-off-by: Cleber Rosa <crosa@redhat.com>