### PR TITLE
EPEL 7: RPM build release 57.0-1

### DIFF
--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -29,7 +29,7 @@
 Summary: Framework with tools and libraries for Automated Testing
 Name: python-%{srcname}
 Version: 57.0
-Release: 1%{?gitrel}%{?dist}
+Release: 2%{?gitrel}%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.github.io/
@@ -38,7 +38,6 @@ Source0: https://github.com/avocado-framework/%{srcname}/archive/%{version}.tar.
 %else
 Source0: https://github.com/avocado-framework/%{srcname}/archive/%{commit}.tar.gz#/%{gittar}
 %endif
-Patch0: 0001-selftests-unit-test_utils_cpu.py-skip-tests-on-older.patch
 BuildArch: noarch
 BuildRequires: fabric
 BuildRequires: procps-ng
@@ -111,7 +110,6 @@ these days a framework) to perform automated testing.
 %else
 %setup -q -n %{srcname}-%{commit}
 %endif
-%patch0 -p1
 # package plugins-runner-vm requires libvirt-python, but the RPM
 # version of libvirt-python does not publish the egg info and this
 # causes that dep to be attempted to be installed by pip
@@ -442,6 +440,9 @@ examples of how to write tests on your own.
 %{_datadir}/avocado/varianter_pict
 
 %changelog
+* Tue Dec 19 2017 Cleber Rosa <cleber@redhat.com> - 57.0-2
+- Removed patch added on release 1, considering it's upstream
+
 * Tue Dec 19 2017 Cleber Rosa <cleber@redhat.com> - 57.0-1
 - Add patch to skip tests on EPEL 7 due to mock version
 

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -29,7 +29,7 @@
 Summary: Framework with tools and libraries for Automated Testing
 Name: python-%{srcname}
 Version: 57.0
-Release: 0%{?gitrel}%{?dist}
+Release: 1%{?gitrel}%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.github.io/
@@ -38,6 +38,7 @@ Source0: https://github.com/avocado-framework/%{srcname}/archive/%{version}.tar.
 %else
 Source0: https://github.com/avocado-framework/%{srcname}/archive/%{commit}.tar.gz#/%{gittar}
 %endif
+Patch0: 0001-selftests-unit-test_utils_cpu.py-skip-tests-on-older.patch
 BuildArch: noarch
 BuildRequires: fabric
 BuildRequires: procps-ng
@@ -110,6 +111,7 @@ these days a framework) to perform automated testing.
 %else
 %setup -q -n %{srcname}-%{commit}
 %endif
+%patch0 -p1
 # package plugins-runner-vm requires libvirt-python, but the RPM
 # version of libvirt-python does not publish the egg info and this
 # causes that dep to be attempted to be installed by pip
@@ -440,6 +442,9 @@ examples of how to write tests on your own.
 %{_datadir}/avocado/varianter_pict
 
 %changelog
+* Tue Dec 19 2017 Cleber Rosa <cleber@redhat.com> - 57.0-1
+- Add patch to skip tests on EPEL 7 due to mock version
+
 * Tue Dec 19 2017 Cleber Rosa <cleber@redhat.com> - 57.0-0
 - New upstream release
 

--- a/selftests/unit/test_utils_cpu.py
+++ b/selftests/unit/test_utils_cpu.py
@@ -10,6 +10,11 @@ except ImportError:
 from avocado.utils import cpu
 
 
+def recent_mock():
+    major = int(mock.__version__.split('.')[0])
+    return major >= 2
+
+
 class Cpu(unittest.TestCase):
 
     @staticmethod
@@ -19,6 +24,8 @@ class Cpu(unittest.TestCase):
         file_mock.__exit__ = mock.Mock()
         return file_mock
 
+    @unittest.skipUnless(recent_mock(),
+                         "mock library version cannot (easily) patch open()")
     def test_s390x(self):
         s390x = u"""vendor_id       : IBM/S390
 # processors    : 2
@@ -87,6 +94,8 @@ cpu MHz static  : 5504
                             return_value=self._get_file_mock(s390x_2)):
                 self.assertEqual(len(cpu.cpu_online_list()), 4)
 
+    @unittest.skipUnless(recent_mock(),
+                         "mock library version cannot (easily) patch open()")
     def test_x86_64(self):
         x86_64 = u"""processor	: 0
 vendor_id	: GenuineIntel


### PR DESCRIPTION
After the tagging of 57.0, I noticed that the building of packages on EPEL 7 would fail because of older `mock` packages.

These changes reflect what was added to packages 57.0-1 for EPEL 7:

http://avocado-project.org/data/repos/epel-7-noarch/python-avocado-57.0-1.el7.centos.src.rpm

Whose contents are:

 * `0001-selftests-unit-test_utils_cpu.py-skip-tests-on-older.patch`
 * `avocado-57.0.tar.gz`
 * `python-avocado.spec`

And, after that, to keep RPM history consistent, the patches are removed and the release version incremented again.