### PR TITLE
FD Drainer: always use bytes

### DIFF
--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -331,7 +331,6 @@ class FDDrainer(object):
         # automatically close.  This may be used as the detection
         # instead.
         self._result = result
-        self._lock = threading.Lock()
         self._thread = None
         self._logger = logger
         self._logger_prefix = logger_prefix
@@ -356,17 +355,16 @@ class FDDrainer(object):
             tmp = os.read(self.fd, 8192)
             if tmp == '':
                 break
-            with self._lock:
-                self.data.write(tmp)
-                if self._verbose:
-                    bfr += tmp
-                    if tmp.endswith('\n'):
-                        for line in bfr.splitlines():
-                            if self._logger is not None:
-                                self._logger.debug(self._logger_prefix, line)
-                            if self._stream_logger is not None:
-                                self._stream_logger.debug('%s\n', line)
-                        bfr = ''
+            self.data.write(tmp)
+            if self._verbose:
+                bfr += tmp
+                if tmp.endswith('\n'):
+                    for line in bfr.splitlines():
+                        if self._logger is not None:
+                            self._logger.debug(self._logger_prefix, line)
+                        if self._stream_logger is not None:
+                            self._stream_logger.debug('%s\n', line)
+                    bfr = ''
         # Write the rest of the bfr unfinished by \n
         if self._verbose and bfr:
             for line in bfr.splitlines():

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -30,10 +30,7 @@ import subprocess
 import threading
 import time
 
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
+from io import BytesIO
 
 from . import gdb
 from . import runtime
@@ -326,7 +323,7 @@ class FDDrainer(object):
         """
         self.fd = fd
         self.name = name
-        self.data = StringIO()
+        self.data = BytesIO()
         # TODO: check if, when the process finishes, the FD doesn't
         # automatically close.  This may be used as the detection
         # instead.
@@ -342,7 +339,7 @@ class FDDrainer(object):
         """
         Read from fd, storing and optionally logging the output
         """
-        bfr = ''
+        bfr = b''
         while True:
             if self._ignore_bg_processes:
                 has_io = select.select([self.fd], [], [], 1)[0]
@@ -353,18 +350,18 @@ class FDDrainer(object):
                     # Don't read unless there are new data available
                     continue
             tmp = os.read(self.fd, 8192)
-            if tmp == '':
+            if not tmp:
                 break
             self.data.write(tmp)
             if self._verbose:
                 bfr += tmp
-                if tmp.endswith('\n'):
+                if tmp.endswith(b'\n'):
                     for line in bfr.splitlines():
                         if self._logger is not None:
                             self._logger.debug(self._logger_prefix, line)
                         if self._stream_logger is not None:
                             self._stream_logger.debug('%s\n', line)
-                    bfr = ''
+                    bfr = b''
         # Write the rest of the bfr unfinished by \n
         if self._verbose and bfr:
             for line in bfr.splitlines():

--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -238,13 +238,13 @@ class FDDrainerTests(unittest.TestCase):
         result = process.CmdResult()
         fd_drainer = process.FDDrainer(read_fd, result, "test")
         fd_drainer.start()
-        for content in ("foo", "bar", "baz", "foo\nbar\nbaz\n\n"):
+        for content in (b"foo", b"bar", b"baz", b"foo\nbar\nbaz\n\n"):
             os.write(write_fd, content)
-        os.write(write_fd, "finish")
+        os.write(write_fd, b"finish")
         os.close(write_fd)
         fd_drainer.flush()
         self.assertEqual(fd_drainer.data.getvalue(),
-                         "foobarbazfoo\nbar\nbaz\n\nfinish")
+                         b"foobarbazfoo\nbar\nbaz\n\nfinish")
 
     def test_log(self):
         class CatchHandler(logging.NullHandler):
@@ -268,11 +268,11 @@ class FDDrainerTests(unittest.TestCase):
         fd_drainer = process.FDDrainer(read_fd, result, "test",
                                        logger=logger, verbose=True)
         fd_drainer.start()
-        os.write(write_fd, "should go to the log\n")
+        os.write(write_fd, b"should go to the log\n")
         os.close(write_fd)
         fd_drainer.flush()
         self.assertEqual(fd_drainer.data.getvalue(),
-                         "should go to the log\n")
+                         b"should go to the log\n")
         self.assertTrue(handler.caught_record)
 
 


### PR DESCRIPTION
This seems like a small change, but it's a big way in the way towards Python 3.  Basically, it changes the behavior to always use bytes when reading and writing from the file descriptor (usually a PIPE) and also providing bytes instead of strings on its `data` attribute.