### PR TITLE
Fix `--open-browser` on Py2k

### DIFF
--- a/optional_plugins/html/avocado_result_html/__init__.py
+++ b/optional_plugins/html/avocado_result_html/__init__.py
@@ -222,7 +222,7 @@ class HTMLResult(Result):
         setsid = getattr(os, 'setsid', None)
         if not setsid:
             setsid = getattr(os, 'setpgrp', None)
-        inout = file(os.devnull, "r+")
+        inout = open(os.devnull, "r+")
         cmd = ['xdg-open', html_path]
         subprocess.Popen(cmd, close_fds=True, stdin=inout,
                          stdout=inout, stderr=inout,

--- a/optional_plugins/html/avocado_result_html/__init__.py
+++ b/optional_plugins/html/avocado_result_html/__init__.py
@@ -222,9 +222,10 @@ class HTMLResult(Result):
         setsid = getattr(os, 'setsid', None)
         if not setsid:
             setsid = getattr(os, 'setpgrp', None)
+        inout = file(os.devnull, "r+")
         cmd = ['xdg-open', html_path]
-        subprocess.Popen(cmd, close_fds=True, stdin=subprocess.DEVNULL,
-                         stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        subprocess.Popen(cmd, close_fds=True, stdin=inout,
+                         stdout=inout, stderr=inout,
                          preexec_fn=setsid)
 
     def _render(self, result, output_path):


### PR DESCRIPTION
The https://github.com/avocado-framework/avocado/pull/2385/commits/e51acbfad23feb0b0bf4fa0c51c51d4602a10945 broke "--open-browser" on python2 systems. Let's revert that commit and use different approach.