### PR TITLE
Python 3 port: collection of fixes [v2]

### DIFF
--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -584,7 +584,7 @@ class TestRunner(object):
             ctx = multiprocessing.get_context('spawn')
             queue = queues.SimpleQueue(ctx=ctx)     # pylint: disable=E1123
         else:
-            queue = queues.SimpleQueue()
+            queue = queues.SimpleQueue()     # pylint: disable=E1125
 
         if timeout > 0:
             deadline = time.time() + timeout

--- a/avocado/utils/external/gdbmi_parser.py
+++ b/avocado/utils/external/gdbmi_parser.py
@@ -30,6 +30,10 @@ import pprint
 from . import spark
 
 
+def compare(a, b):
+    return (a > b) - (a < b)
+
+
 def __private():
     class Token:
 
@@ -38,7 +42,7 @@ def __private():
             self.value = value
 
         def __cmp__(self, o):
-            return cmp(self.type, o)
+            return compare(self.type, o)
 
         def __repr__(self):
             return self.value or self.type
@@ -59,7 +63,7 @@ def __private():
             self._kids[low:high] = seq
 
         def __cmp__(self, o):
-            return cmp(self.type, o)
+            return compare(self.type, o)
 
     class GdbMiScannerBase(spark.GenericScanner):
 

--- a/avocado/utils/genio.py
+++ b/avocado/utils/genio.py
@@ -20,6 +20,8 @@ import logging
 import os
 import time
 
+from six.moves import input
+
 from . import path as utils_path
 
 log = logging.getLogger('avocado.test')
@@ -99,7 +101,7 @@ def ask(question, auto=False):
     if auto:
         log.info("%s (y/n) y" % question)
         return "y"
-    return raw_input("%s (y/n) " % question)
+    return input("%s (y/n) " % question)
 
 
 def read_file(filename):

--- a/avocado/utils/software_manager.py
+++ b/avocado/utils/software_manager.py
@@ -301,7 +301,7 @@ class RpmBackend(BaseBackend):
         try:
             process.system(cmd)
             return True
-        except process.CmdError, details:
+        except process.CmdError as details:
             log.error(details)
             return False
 
@@ -569,7 +569,7 @@ class YumBackend(RpmBackend):
         try:
             process.system('yum-builddep -y --tolerant %s' % name, sudo=True)
             return True
-        except process.CmdError, details:
+        except process.CmdError as details:
             log.error(details)
             return False
 
@@ -610,7 +610,7 @@ class YumBackend(RpmBackend):
             else:
                 log.error("Installing source rpm failed")
                 return ""
-        except process.CmdError, details:
+        except process.CmdError as details:
             log.error(details)
             return ""
 
@@ -798,7 +798,7 @@ class ZypperBackend(RpmBackend):
             else:
                 log.error("Source not installed properly")
                 return ""
-        except process.CmdError, details:
+        except process.CmdError as details:
             log.error(details)
             return ""
 
@@ -1015,7 +1015,7 @@ class AptBackend(DpkgBackend):
                 for subdir in os.listdir(path):
                     if subdir.startswith(name) and os.path.isdir(subdir):
                         return os.path.join(path, subdir)
-        except process.CmdError, details:
+        except process.CmdError as details:
             log.error("Apt package source failed %s", details)
             return ""
 
@@ -1037,7 +1037,7 @@ class AptBackend(DpkgBackend):
         try:
             process.system_output(src_cmd)
             return True
-        except process.CmdError, details:
+        except process.CmdError as details:
             log.error("Apt package build-dep failed %s", details)
             return False
 

--- a/examples/tests/failtest_ugly.py
+++ b/examples/tests/failtest_ugly.py
@@ -6,7 +6,7 @@ import sys
 
 sys.stdout.write("Direct output to stdout\n")
 sys.stderr.write("Direct output to stderr\n")
-raw_input("I really want some input on each import")
+input("I really want some input on each import")
 sys.stdin = 'This is my __COOL__ stdin'
 sys.stdout = 'my stdout'
 sys.stderr = 'my stderr'

--- a/examples/tests/gdbtest.py
+++ b/examples/tests/gdbtest.py
@@ -196,7 +196,7 @@ class GdbTest(Test):
         g = gdb.GDB()
 
         # Do 100 cycle of target (kind of connects) and disconnects
-        for i in xrange(0, 100):
+        for i in range(0, 100):
             cmd = '-target-select extended-remote :%s' % s.port
             r = g.cmd(cmd)
             self.assertEqual(r.result.class_, 'connected')

--- a/scripts/avocado-run-testplan
+++ b/scripts/avocado-run-testplan
@@ -23,6 +23,8 @@ import sys
 
 import argparse
 
+from six.moves import input
+
 
 class Parser(argparse.ArgumentParser):
 
@@ -89,9 +91,9 @@ class App(object):
 
             result = None
             while True:
-                result = raw_input("Result ([P]ass, [F]ail, [S]kip): ")
+                result = input("Result ([P]ass, [F]ail, [S]kip): ")
                 if result in RESULT_MAP.keys():
-                    notes = raw_input("Additional Notes: ")
+                    notes = input("Additional Notes: ")
                     break
             print("")
 
@@ -99,7 +101,7 @@ class App(object):
                                  "result": RESULT_MAP.get(result),
                                  "notes": notes.strip()})
 
-        user = raw_input("Your identification [%s]: " % getpass.getuser())
+        user = input("Your identification [%s]: " % getpass.getuser())
         if not user:
             user = getpass.getuser()
         self.user_identification = user


### PR DESCRIPTION
A collection of miscellaneous fixes for the Python 3 port.

---

Changes from v1 (#2379):
 * Use `six.moves.input()` to adapt to differences in `input()` on Python 2 and 3