### PR TITLE
vmimage: add JeOS Image Provider

### DIFF
--- a/avocado/utils/vmimage.py
+++ b/avocado/utils/vmimage.py
@@ -222,6 +222,25 @@ class DebianImageProvider(ImageProviderBase):
         self.image_pattern = 'debian-{version}-openstack-{arch}.qcow2$'
 
 
+class JeosImageProvider(ImageProviderBase):
+    """
+    JeOS Image Provider
+    """
+
+    name = 'JeOS'
+
+    def __init__(self, version='[0-9]+', build=None,
+                 arch=os.uname()[4]):
+        # JeOS uses '64' instead of 'x86_64'
+        if arch == 'x86_64':
+            arch = '64'
+
+        super(JeosImageProvider, self).__init__(version, build, arch)
+        self.url_versions = 'http://avocado-project.org/data/assets/jeos/'
+        self.url_images = self.url_versions + '{version}/'
+        self.image_pattern = 'jeos-{version}-{arch}.qcow2.xz$'
+
+
 class Image(object):
     def __init__(self, name, url, version, arch, checksum, algorithm,
                  cache_dir):


### PR DESCRIPTION
WIth the new repository, now it is possible to add our own JeOS Image
Provider to the vmimage module.

Signed-off-by: Amador Pahim <apahim@redhat.com>