### PR TITLE
Parameters: fix wrong examples on _greedy_path

### DIFF
--- a/selftests/unit/test_parameters.py
+++ b/selftests/unit/test_parameters.py
@@ -1,0 +1,23 @@
+import unittest
+
+from avocado.core import parameters
+from avocado.core import tree
+
+
+class Parameters(unittest.TestCase):
+
+    def test_greedy_path_to_re(self):
+        params = parameters.AvocadoParams([tree.TreeNode()],
+                                          ['/run'])
+        self.assertEqual(params._greedy_path_to_re('').pattern, '^$')
+        self.assertEqual(params._greedy_path_to_re('/').pattern, '/$')
+        self.assertEqual(params._greedy_path_to_re('/foo/bar').pattern,
+                         '/foo/bar$')
+        self.assertEqual(params._greedy_path_to_re('foo/bar').pattern,
+                         'foo/bar$')
+        self.assertEqual(params._greedy_path_to_re('/*/foo').pattern,
+                         '/[^/]*/foo$')
+        self.assertEqual(params._greedy_path_to_re('foo/*').pattern,
+                         'foo/')
+        self.assertEqual(params._greedy_path_to_re('/foo/*').pattern,
+                         '/foo/')


### PR DESCRIPTION
The docstring given on `_greedy_path()` has examples that don't match
the implementation.  To prevent the implementation from deviating
(again?) let's turn those into tests.

Also, to make the purpose of that function more clear, this
changes its name to `_greedy_path_to_re()`.

Signed-off-by: Cleber Rosa <crosa@redhat.com>