### PR TITLE
Docs: installation/deployment improvements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -226,33 +226,5 @@ and the test runner man-page, accessible via ``man avocado``.
 Documentation
 =============
 
-Avocado comes with in tree documentation about the most advanced features and
-its API. It can be built with ``sphinx``, but a publicly available build of
-the latest master branch documentation and releases can be seen on `read the
-docs <https://readthedocs.org/>`__:
-
-http://avocado-framework.readthedocs.org/
-
-If you want to build the documentation yourself:
-
-1) Make sure you have the package ``python-sphinx`` installed. For Fedora::
-
-    $ sudo yum install python-sphinx
-
-2) For Mint/Ubuntu/Debian::
-
-    $ sudo apt-get install python-sphinx
-
-3) Optionally, you can install the read the docs theme, that will make your
-   in-tree documentation look just like the online version::
-
-    $ sudo pip install sphinx_rtd_theme
-
-4) Build the docs::
-
-    $ make -C docs html
-
-5) Once done, point your browser to::
-
-    $ [your-browser] docs/build/html/index.html
-
+Avocado's latest documentation build can be found at
+https://avocado-framework.readthedocs.io/.

--- a/README.rst
+++ b/README.rst
@@ -220,8 +220,9 @@ To run a test, call the ``run`` command::
   RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
   JOB TIME   : 0.14 s
 
-To continue exploring Avocado, check out the output of ``avocado --help``
-and the test runner man-page, accessible via ``man avocado``.
+To continue exploring Avocado, check out the output of ``avocado --help``.  When
+running Avocado out of package-based installs, its man page should also be
+accessible via ``man avocado``.
 
 Documentation
 =============

--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,48 @@ shortcomings.
 Installing Avocado
 ==================
 
+Avocado is primarily written in Python, so a standard Python installation
+is possible and often preferable.
+
+Installing with standard Python tools
+-------------------------------------
+
+The simplest installation method is through ``pip``.  On most POSIX
+systems with Python 2.7 and ``pip`` available, installation can be
+performed with a single command::
+
+  pip install --user avocado-framework
+
+This will fetch the Avocado package (and possibly some of its
+dependecies) from the PyPI repository, and will attempt to install it
+in the user's home directory (usually under ``~/.local``).
+
+Tip: If you want to perform a system-wide installation, drop the
+``--user`` switch.
+
+If you want even more isolation, Avocado can also be installed in a
+Python virtual environment. with no additional steps besides creating
+and activating the "venv" itself::
+
+  python -m virtualenv /path/to/new/virtual_environment
+  . /path/to/new/virtual_environment/bin/activate
+  pip install avocado-framework
+
+Please note that this installs the Avocado core functionality.  Many
+Avocado features are distributed as non-core plugins, also available
+as additional packages on PyPI.  You should be able to find them via
+``pip search avocado-framework-plugin | grep
+avocado-framework-plugin``. Some of them are listed below:
+
+* ``avocado-framework-plugin-result-html``: HTML Report for Jobs
+* ``avocado-framework-plugin-resultsdb``: Propagate Job results to Resultsdb
+* ``avocado-framework-plugin-runner-remote``: Runner for Remote Execution
+* ``avocado-framework-plugin-runner-vm``: Runner for libvirt VM Execution
+* ``avocado-framework-plugin-runner-docker``: Runner for Execution on Docker Containers
+* ``avocado-framework-plugin-loader-yaml``: Loads tests from YAML files
+* ``avocado-framework-plugin-robot``: Execution of Robot Framework tests
+* ``avocado-framework-plugin-varianter-yaml-to-mux``: Parse YAML file into variants
+
 Installing from Packages
 ------------------------
 

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -1,0 +1,25 @@
+Avocado Documentation
+=====================
+
+If you want to build the documentation yourself:
+
+1) Make sure you have the package ``python-sphinx`` installed. For Fedora::
+
+    $ sudo yum install python-sphinx
+
+2) For Mint/Ubuntu/Debian::
+
+    $ sudo apt-get install python-sphinx
+
+3) Optionally, you can install the read the docs theme, that will make your
+   in-tree documentation look just like the online version::
+
+    $ sudo pip install sphinx_rtd_theme
+
+4) Build the docs::
+
+    $ make html
+
+5) Once done, point your browser to::
+
+    $ [your-browser] build/html/index.html

--- a/docs/source/GetStartedGuide.rst
+++ b/docs/source/GetStartedGuide.rst
@@ -17,6 +17,48 @@ The first step towards using Avocado is, quite obviously, installing it.
 Installing Avocado
 ==================
 
+Avocado is primarily written in Python, so a standard Python installation
+is possible and often preferable.
+
+Installing with standard Python tools
+-------------------------------------
+
+The simplest installation method is through ``pip``.  On most POSIX
+systems with Python 2.7 and ``pip`` available, installation can be
+performed with a single command::
+
+  pip install --user avocado-framework
+
+This will fetch the Avocado package (and possibly some of its
+dependecies) from the PyPI repository, and will attempt to install it
+in the user's home directory (usually under ``~/.local``).
+
+.. tip:: If you want to perform a system-wide installation, drop the
+         ``--user`` switch.
+
+If you want even more isolation, Avocado can also be installed in a
+Python virtual environment. with no additional steps besides creating
+and activating the "venv" itself::
+
+  python -m virtualenv /path/to/new/virtual_environment
+  . /path/to/new/virtual_environment/bin/activate
+  pip install avocado-framework
+
+Please note that this installs the Avocado core functionality.  Many
+Avocado features are distributed as non-core plugins, also available
+as additional packages on PyPI.  You should be able to find them via
+``pip search avocado-framework-plugin | grep
+avocado-framework-plugin``. Some of them are listed below:
+
+* `avocado-framework-plugin-result-html <https://pypi.python.org/pypi/avocado-framework-plugin-result-html>`_: HTML Report for Jobs
+* `avocado-framework-plugin-resultsdb <https://pypi.python.org/pypi/avocado-framework-plugin-resultsdb>`_: Propagate Job results to Resultsdb
+* `avocado-framework-plugin-runner-remote <https://pypi.python.org/pypi/avocado-framework-plugin-runner-remote>`_: Runner for Remote Execution
+* `avocado-framework-plugin-runner-vm <https://pypi.python.org/pypi/avocado-framework-plugin-runner-vm>`_: Runner for libvirt VM Execution
+* `avocado-framework-plugin-runner-docker <https://pypi.python.org/pypi/avocado-framework-plugin-runner-docker>`_: Runner for Execution on Docker Containers
+* `avocado-framework-plugin-loader-yaml <https://pypi.python.org/pypi/avocado-framework-plugin-loader-yaml>`_: Loads tests from YAML files
+* `avocado-framework-plugin-robot <https://pypi.python.org/pypi/avocado-framework-plugin-robot>`_: Execution of Robot Framework tests
+* `avocado-framework-plugin-varianter-yaml-to-mux <https://pypi.python.org/pypi/avocado-framework-plugin-varianter-yaml-to-mux>`_: Parse YAML file into variants
+
 Installing from Packages
 ------------------------
 
@@ -157,42 +199,6 @@ optional plugins.  To install say, the HTML report plugin, run::
     sudo python setup.py install
 
 If you intend to hack on Avocado, you may want to look at :ref:`hacking-and-using`.
-
-Installing from standard Python tools
--------------------------------------
-
-Avocado can also be installed by the standard Python packaging tools,
-namely ``pip``.  On most POSIX systems with Python >= 2.7 and ``pip``
-available, installation can be performed with the following commands::
-
-  pip install avocado-framework
-
-.. note:: As a design decision, only the dependencies for the core
-          Avocado test runner will be installed.  You may notice,
-          depending on your system, that some plugins will fail to load,
-          due to those missing dependencies.
-
-If you want to install all the requirements for all plugins, you may
-attempt to do so by running::
-
-  pip install -r https://raw.githubusercontent.com/avocado-framework/avocado/master/requirements.txt
-
-which installs the python dependencies, although you might still be
-missing the non-python dependencies so the use of distribution package
-is preferred.
-
-The optional plugins are also shipped via PyPI and you should be able
-to find them via ``pip search avocado-framework``. Some of them
-are listed below:
-
-* `avocado-framework-plugin-result-html <https://pypi.python.org/pypi/avocado-framework-plugin-result-html>`_: HTML Report for Jobs
-* `avocado-framework-plugin-resultsdb <https://pypi.python.org/pypi/avocado-framework-plugin-resultsdb>`_: Propagate Job results to Resultsdb
-* `avocado-framework-plugin-runner-remote <https://pypi.python.org/pypi/avocado-framework-plugin-runner-remote>`_: Runner for Remote Execution
-* `avocado-framework-plugin-runner-vm <https://pypi.python.org/pypi/avocado-framework-plugin-runner-vm>`_: Runner for libvirt VM Execution
-* `avocado-framework-plugin-runner-docker <https://pypi.python.org/pypi/avocado-framework-plugin-runner-docker>`_: Runner for Execution on Docker Containers
-* `avocado-framework-plugin-loader-yaml <https://pypi.python.org/pypi/avocado-framework-plugin-loader-yaml>`_: Loads tests from YAML files
-* `avocado-framework-plugin-robot <https://pypi.python.org/pypi/avocado-framework-plugin-robot>`_: Execution of Robot Framework tests
-* `avocado-framework-plugin-varianter-yaml-to-mux <https://pypi.python.org/pypi/avocado-framework-plugin-varianter-yaml-to-mux>`_: Parse YAML file into variants
 
 Using Avocado
 =============


### PR DESCRIPTION
The installation instructions will now favor a simpler (and more Pythonic) deployment strategy: the use of `pip` based installs.

By favoring installations in isolated (user dir or virtual environments) it should be possible to quickly install, upgrade and remove Avocado from a system, be it a developer workstation or a system that will just run tests and be done with it. 

**IMPORTANT**:  for a proper user experience, these documentation changes depend on the packaging fixes on #2394.  Without it, a `pip install --user avocado-framework` will fail trying to install data system wide (such as into `/etc`).