### PR TITLE
requirements.txt: Add conditional pyliblzma-req-install

### DIFF
--- a/avocado/utils/archive.py
+++ b/avocado/utils/archive.py
@@ -32,7 +32,11 @@ try:
     import lzma
     LZMA_CAPABLE = True
 except ImportError:
-    LZMA_CAPABLE = False
+    try:
+        from backports import lzma
+        LZMA_CAPABLE = True
+    except ImportError:
+        LZMA_CAPABLE = False
 
 
 class ArchiveException(Exception):

--- a/avocado/utils/vmimage.py
+++ b/avocado/utils/vmimage.py
@@ -26,7 +26,11 @@ try:
     import lzma
     LZMA_CAPABLE = True
 except ImportError:
-    LZMA_CAPABLE = False
+    try:
+        from backports import lzma
+        LZMA_CAPABLE = True
+    except ImportError:
+        LZMA_CAPABLE = False
 
 from HTMLParser import HTMLParser
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Avocado functional requirements
 # .tar.xz support (avocado.utils.archive)
-pyliblzma>=0.5.3
+backports.lzma>=0.0.10; python_version < '3.3'
 # REST client (avocado.core.restclient)
 requests>=1.2.3
 # six is a stevedore depedency, but we also use it directly


### PR DESCRIPTION
pyliblzma is not required in python >= 3.3, and backports.lzma
works for all versions prior to that one. Let's update
the requirements.txt file to only install that backport
when necessary.

Signed-off-by: Lucas Meneghel Rodrigues <lookkas@gmail.com>