### PR TITLE
Increase failed_once threshold and enable parallel check in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ script:
             echo
             echo
             git checkout $COMMIT || ERR=$(echo -e "$ERR\nUnable to checkout $(git log -1 --oneline $COMMIT)")
-            AVOCADO_LOG_DEBUG=yes AVOCADO_RESULTSDIR_CHECK=y SELF_CHECK_CONTINUOUS=y AVOCADO_CHECK_LEVEL=1 make check || ERR=$(echo -e "$ERR\nmake check of $(git log -1 --oneline) failed")
+            AVOCADO_PARALLEL_CHECK=yes AVOCADO_LOG_DEBUG=yes AVOCADO_RESULTSDIR_CHECK=y SELF_CHECK_CONTINUOUS=y AVOCADO_CHECK_LEVEL=1 make check || ERR=$(echo -e "$ERR\nmake check of $(git log -1 --oneline) failed")
             make clean
         done
         if [ "$ERR" ]; then

--- a/selftests/checkall
+++ b/selftests/checkall
@@ -90,7 +90,7 @@ parallel_selftests() {
             fi
         done
         if [ ${#FAILED_ONCE[@]} -gt 0 ]; then
-            if [ ${#FAILED_ONCE[@]} -le 10 ]; then
+            if [ ${#FAILED_ONCE[@]} -le 24 ]; then
                 echo ${#FAILED_ONCE[@]} failed during parallel execution, trying them in series
                 echo "python -m unittest --failfast ${FAILED_ONCE[@]}"
                 if python -m unittest --failfast ${FAILED_ONCE[@]}; then

--- a/selftests/checkall
+++ b/selftests/checkall
@@ -22,7 +22,7 @@ run_rc() {
 parallel_selftests() {
     local START=$(date +%s)
     local ERR=0
-    local FIND_UNITTESTS=$(realpath ./contrib/scripts/avocado-find-unittests)
+    local FIND_UNITTESTS=$(readlink -f ./contrib/scripts/avocado-find-unittests)
     local NO_WORKERS=$(($(cat /proc/cpuinfo | grep -c processor) * 2))
 
     # The directories that may contain files with tests, from the Avocado core


### PR DESCRIPTION
Increases the failed_once threshold to 24 and enables the parallel check in Travis.