### PR TITLE
utils.cpu: Update cpu info pattern for aarch64

### DIFF
--- a/avocado/utils/cpu.py
+++ b/avocado/utils/cpu.py
@@ -129,6 +129,8 @@ def get_cpu_arch():
     for (pattern, arch) in cpu_table:
         if _list_matches(cpuinfo, pattern):
             return arch
+    if "CPU architecture" in cpuinfo:
+        return platform.machine()
     return 'i386'
 
 


### PR DESCRIPTION
arm64 or aarch64 pattern is not easy to identify in the
cpuinfo. For v7 there is model name in the cpuinfo and it
could be regonize as arm for 32 bit. But in v8 only could
found 'CPU architecture' in the cpuinfo and current code
will fail to match and return i386 which is wrong.

For fix this, if 'CPU architecture' found in cpuinfo, use
platform.machine to return the arch name.

Signed-off-by: Wayne Sun <gsun@redhat.com>