### PR TITLE
selftests: Avoid uncleaned dirs on xunit cleanup error

### DIFF
--- a/selftests/unit/test_xunit.py
+++ b/selftests/unit/test_xunit.py
@@ -57,9 +57,17 @@ class xUnitSucceedTest(unittest.TestCase):
         self.junit = os.path.abspath(junit_xsd)
 
     def tearDown(self):
-        os.close(self.tmpfile[0])
-        os.remove(self.tmpfile[1])
-        shutil.rmtree(self.tmpdir)
+        errs = []
+        cleanups = (lambda: os.close(self.tmpfile[0]),
+                    lambda: os.remove(self.tmpfile[1]),
+                    lambda: shutil.rmtree(self.tmpdir))
+        for cleanup in cleanups:
+            try:
+                cleanup()
+            except Exception as exc:
+                errs.append(str(exc))
+        self.assertFalse(errs, "Failures occurred during cleanup:\n%s"
+                         % "\n".join(errs))
 
     @unittest.skipUnless(SCHEMA_CAPABLE,
                          'Unable to validate schema due to missing lxml.etree library')


### PR DESCRIPTION
In case on of the first cleanups fails the following ones are not
performed, leaving uncleaned files. Lets perform always all steps and
then check for occurred errors.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>