### PR TITLE
setup: Add "six" as install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,4 +99,4 @@ if __name__ == '__main__':
           zip_safe=False,
           test_suite='selftests',
           python_requires='>=2.7',
-          install_requires=['stevedore>=0.14'])
+          install_requires=['stevedore>=0.14', 'six>=1.10.0'])


### PR DESCRIPTION
With the python3 patches we have another core dependency on six. Let's
include it in setup.py as without it Avocado is unusable.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>