### PR TITLE
avocado: Some fixes related to user-config

### DIFF
--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -27,6 +27,7 @@ The general reasoning to find paths is:
 """
 import os
 import shutil
+import sys
 import time
 import tempfile
 
@@ -34,7 +35,8 @@ from six.moves import xrange as range
 
 from . import job_id
 from . import settings
-from .output import LOG_JOB
+from . import exit_codes
+from .output import LOG_JOB, LOG_UI
 from ..utils import path as utils_path
 from ..utils.data_structures import Borg
 
@@ -167,6 +169,11 @@ def create_job_logs_dir(base_dir=None, unique_id=None):
     start_time = time.strftime('%Y-%m-%dT%H.%M')
     if base_dir is None:
         base_dir = get_logs_dir()
+        if not base_dir:
+            LOG_UI.error("No writable location for logs found, use "
+                         "'avocado config --datadir' to get the "
+                         "locations and check system permissions.")
+            sys.exit(exit_codes.AVOCADO_FAIL)
     if not os.path.exists(base_dir):
         utils_path.init_dir(base_dir)
     # Stand alone tests handling

--- a/avocado/core/settings.py
+++ b/avocado/core/settings.py
@@ -198,10 +198,16 @@ class Settings(object):
                         for extra_file in glob.glob(os.path.join(_config_dir_system_extra, '*.conf')):
                             self.process_config_path(extra_file)
             if not config_local:
-                path.init_dir(_config_dir_local)
-                with open(config_path_local, 'w') as config_local_fileobj:
-                    config_local_fileobj.write('# You can use this file to override configuration values from '
-                                               '%s and %s\n' % (config_path_system, _config_dir_system_extra))
+                try:
+                    path.init_dir(_config_dir_local)
+                    with open(config_path_local, 'w') as config_local_fileobj:
+                        content = ("# You can use this file to override "
+                                   "configuration values from '%s and %s\n"
+                                   % (config_path_system,
+                                      _config_dir_system_extra))
+                        config_local_fileobj.write(content)
+                except IOError:     # Some users can't write it (docker)
+                    pass
             else:
                 self.process_config_path(config_path_local)
         else:


### PR DESCRIPTION
One user is using Avocado in container as a user without home-dir. That leads to some issues given to our wrong assumptions that there are always some writable locations.