### PR TITLE
[52LTS] avocado.settings: Don't fail when user can't write user-config

### DIFF
--- a/avocado/core/settings.py
+++ b/avocado/core/settings.py
@@ -187,10 +187,16 @@ class Settings(object):
                         for extra_file in glob.glob(os.path.join(_config_dir_system_extra, '*.conf')):
                             self.process_config_path(extra_file)
             if not config_local:
-                path.init_dir(_config_dir_local)
-                with open(config_path_local, 'w') as config_local_fileobj:
-                    config_local_fileobj.write('# You can use this file to override configuration values from '
-                                               '%s and %s\n' % (config_path_system, _config_dir_system_extra))
+                try:
+                    path.init_dir(_config_dir_local)
+                    with open(config_path_local, 'w') as config_local_fileobj:
+                        content = ("# You can use this file to override "
+                                   "configuration values from '%s and %s\n"
+                                   % (config_path_system,
+                                      _config_dir_system_extra))
+                        config_local_fileobj.write(content)
+                except (OSError, IOError):     # Some users can't write it
+                    pass
             else:
                 self.process_config_path(config_path_local)
         else:


### PR DESCRIPTION
The user-config location ("~/.config/avocado.conf") might not be
writable by users (usually when executing in docker without user
home-dir). Let's use the file if available, but don't fail in case we
fail to produce it.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>