### PR TITLE
yaml loader: use JOB log instead of UI log

### DIFF
--- a/optional_plugins/loader_yaml/avocado_loader_yaml/__init__.py
+++ b/optional_plugins/loader_yaml/avocado_loader_yaml/__init__.py
@@ -102,7 +102,7 @@ class YamlTestsuiteLoader(loader.TestLoader):
         mux_tree = mux.MuxTree(root)
         for variant in mux_tree:
             params = parameters.AvocadoParams(variant, ["/run/*"],
-                                              output.LOG_UI.name)
+                                              output.LOG_JOB.name)
             reference = params.get("test_reference")
             test_loader = self._get_loader(params)
             if not test_loader:


### PR DESCRIPTION
The YAML Test Loader is sending the messages for the UI. They
should go to the Job Log instead.

Signed-off-by: Amador Pahim <apahim@redhat.com>