### PR TITLE
test: include 'whiteboard' in preserved parameters

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -60,7 +60,7 @@ TEST_STATE_ATTRIBUTES = ('name', 'logdir', 'logfile',
                          'status', 'running', 'paused',
                          'time_start', 'time_elapsed', 'time_end',
                          'fail_reason', 'fail_class', 'traceback',
-                         'params', 'timeout')
+                         'params', 'timeout', 'whiteboard')
 
 
 class RawFileHandler(logging.FileHandler):


### PR DESCRIPTION
Whiteboard was (probably accidentally) removed from the test attributes.
This patch recreates the whiteboard.

Signed-off-by: Amador Pahim <apahim@redhat.com>