### PR TITLE
Python3 port: default to bytes instead of text

### DIFF
--- a/avocado/utils/iso9660.py
+++ b/avocado/utils/iso9660.py
@@ -223,11 +223,11 @@ class Iso9660IsoInfo(MixInMntDirMount, BaseIso9660):
         cmd = 'isoinfo -i %s -d' % path
         output = process.system_output(cmd)
 
-        if re.findall("\nJoliet", output):
+        if b"\nJoliet" in output:
             self.joliet = True
-        if re.findall("\nRock Ridge signatures", output):
+        if b"\nRock Ridge signatures" in output:
             self.rock_ridge = True
-        if re.findall("\nEl Torito", output):
+        if b"\nEl Torito" in output:
             self.el_torito = True
 
     @staticmethod
@@ -287,8 +287,8 @@ class Iso9660IsoRead(MixInMntDirMount, BaseIso9660):
         temp_path = os.path.join(self.temp_dir, path)
         cmd = 'iso-read -i %s -e %s -o %s' % (self.path, path, temp_path)
         process.run(cmd)
-        with open(temp_path) as temp_file:
-            return temp_file.read()
+        with open(temp_path, 'rb') as temp_file:
+            return bytes(temp_file.read())
 
     def copy(self, src, dst):
         cmd = 'iso-read -i %s -e %s -o %s' % (self.path, src, dst)
@@ -331,8 +331,8 @@ class Iso9660Mount(BaseIso9660):
         :rtype: str
         """
         full_path = os.path.join(self.mnt_dir, path)
-        with open(full_path) as file_to_read:
-            return file_to_read.read()
+        with open(full_path, 'rb') as file_to_read:
+            return bytes(file_to_read.read())
 
     def copy(self, src, dst):
         """

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -269,17 +269,34 @@ class CmdResult(object):
     :type duration: float
     :param pid: ID of the process
     :type pid: int
+    :param encoding: the encoding to use for the text version
+                     of stdout and stderr
+    :type encoding: str
     """
 
     def __init__(self, command="", stdout="", stderr="",
-                 exit_status=None, duration=0, pid=None):
+                 exit_status=None, duration=0, pid=None,
+                 encoding=None):
         self.command = command
         self.exit_status = exit_status
+        #: The raw stdout (bytes)
         self.stdout = stdout
+        #: The raw stderr (bytes)
         self.stderr = stderr
         self.duration = duration
         self.interrupted = False
         self.pid = pid
+        if encoding is None:
+            encoding = os.environ.get("PYTHONENCODING", "utf-8")
+        self.encoding = encoding
+
+    @property
+    def stdout_text(self):
+        return self.stdout.decode(self.encoding)
+
+    @property
+    def stderr_text(self):
+        return self.stderr.decode(self.encoding)
 
     def __repr__(self):
         cmd_rep = ("Command: %s\n"
@@ -1312,12 +1329,12 @@ def system_output(cmd, timeout=None, verbose=True, ignore_status=False,
     :type strip_trail_nl: bool
 
     :return: Command output.
-    :rtype: str
+    :rtype: bytes
     :raise: :class:`CmdError`, if ``ignore_status=False``.
     """
     cmd_result = run(cmd=cmd, timeout=timeout, verbose=verbose, ignore_status=ignore_status,
                      allow_output_check=allow_output_check, shell=shell, env=env,
                      sudo=sudo, ignore_bg_processes=ignore_bg_processes)
     if strip_trail_nl:
-        return cmd_result.stdout.rstrip('\n\r')
+        return cmd_result.stdout.rstrip(b'\n\r')
     return cmd_result.stdout

--- a/optional_plugins/varianter_yaml_to_mux/tests/test_multiplex.py
+++ b/optional_plugins/varianter_yaml_to_mux/tests/test_multiplex.py
@@ -38,7 +38,7 @@ class MultiplexTests(unittest.TestCase):
         if tests:
             exp = ("PASS %s | ERROR 0 | FAIL %s | SKIP 0 | WARN 0 | "
                    "INTERRUPT 0" % tests)
-            self.assertIn(exp, result.stdout, "%s not in stdout:\n%s"
+            self.assertIn(exp, result.stdout_text, "%s not in stdout:\n%s"
                           % (exp, result))
         return result
 
@@ -52,7 +52,7 @@ class MultiplexTests(unittest.TestCase):
         cmd_line = '%s variants -m nonexist' % AVOCADO
         expected_rc = exit_codes.AVOCADO_FAIL
         result = self.run_and_check(cmd_line, expected_rc)
-        self.assertIn('No such file or directory', result.stderr)
+        self.assertIn('No such file or directory', result.stderr_text)
 
     def test_mplex_debug(self):
         cmd_line = ('%s variants -c -d -m '
@@ -63,7 +63,7 @@ class MultiplexTests(unittest.TestCase):
                     % AVOCADO)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         result = self.run_and_check(cmd_line, expected_rc)
-        self.assertIn(DEBUG_OUT, result.stdout)
+        self.assertIn(DEBUG_OUT, result.stdout_text)
 
     def test_run_mplex_noid(self):
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
@@ -106,10 +106,10 @@ class MultiplexTests(unittest.TestCase):
                     % (AVOCADO, self.tmpdir))
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         result = self.run_and_check(cmd_line, expected_rc, (4, 4))
-        self.assertIn("(1/8) passtest.py:PassTest.test;short", result.stdout)
-        self.assertIn("(2/8) passtest.py:PassTest.test;medium", result.stdout)
+        self.assertIn("(1/8) passtest.py:PassTest.test;short", result.stdout_text)
+        self.assertIn("(2/8) passtest.py:PassTest.test;medium", result.stdout_text)
         self.assertIn("(8/8) failtest.py:FailTest.test;longest",
-                      result.stdout)
+                      result.stdout_text)
 
     def test_run_mplex_failtest_tests_per_variant(self):
         cmd_line = ("%s run --job-results-dir %s --sysinfo=off "
@@ -119,10 +119,10 @@ class MultiplexTests(unittest.TestCase):
                     % (AVOCADO, self.tmpdir))
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         result = self.run_and_check(cmd_line, expected_rc, (4, 4))
-        self.assertIn("(1/8) passtest.py:PassTest.test;short", result.stdout)
-        self.assertIn("(2/8) failtest.py:FailTest.test;short", result.stdout)
+        self.assertIn("(1/8) passtest.py:PassTest.test;short", result.stdout_text)
+        self.assertIn("(2/8) failtest.py:FailTest.test;short", result.stdout_text)
         self.assertIn("(8/8) failtest.py:FailTest.test;longest",
-                      result.stdout)
+                      result.stdout_text)
 
     def test_run_double_mplex(self):
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
@@ -155,15 +155,15 @@ class MultiplexTests(unittest.TestCase):
 
             msg_lines = msg.splitlines()
             msg_header = '[stdout] Custom variable: %s' % msg_lines[0]
-            self.assertIn(msg_header, result.stdout,
+            self.assertIn(msg_header, result.stdout_text,
                           "Multiplexed variable should produce:"
                           "\n  %s\nwhich is not present in the output:\n  %s"
-                          % (msg_header, "\n  ".join(result.stdout.splitlines())))
+                          % (msg_header, "\n  ".join(result.stdout_text.splitlines())))
             for msg_remain in msg_lines[1:]:
-                self.assertIn('[stdout] %s' % msg_remain, result.stdout,
+                self.assertIn('[stdout] %s' % msg_remain, result.stdout_text,
                               "Multiplexed variable should produce:"
                               "\n  %s\nwhich is not present in the output:\n  %s"
-                              % (msg_remain, "\n  ".join(result.stdout.splitlines())))
+                              % (msg_remain, "\n  ".join(result.stdout_text.splitlines())))
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir)

--- a/selftests/unit/test_utils_iso9660.py
+++ b/selftests/unit/test_utils_iso9660.py
@@ -30,7 +30,7 @@ class BaseIso9660(unittest.TestCase):
                   due to ast loader we can't just define a base-class.
         """
         self.assertEqual(self.iso.read("file"),
-                         "file content\n")
+                         b"file content\n")
         dst = os.path.join(self.tmpdir, "file")
         self.iso.copy(os.path.join("Dir", "in_dir_file"), dst)
         self.assertEqual(open(dst).read(), "content of in-dir-file\n")
@@ -49,10 +49,11 @@ class BaseIso9660(unittest.TestCase):
         base = self.iso.mnt_dir
         dir_path = os.path.join(base, "Dir")
         self.assertTrue(os.path.isdir(dir_path))
-        self.assertEqual(open(os.path.join(base, "file")).read(),
-                         "file content\n")
-        self.assertEqual(open(os.path.join(base, "Dir", "in_dir_file")).read(),
-                         "content of in-dir-file\n")
+        self.assertEqual(bytes(open(os.path.join(base, "file"), 'rb').read()),
+                         b"file content\n")
+        in_dir_file_path = os.path.join(base, "Dir", "in_dir_file")
+        self.assertEqual(bytes(open(in_dir_file_path, 'rb').read()),
+                         b"content of in-dir-file\n")
         self.iso.close()
         self.assertFalse(os.path.exists(base), "the mnt_dir is suppose to be "
                          "destroyed after iso.close()")

--- a/selftests/unit/test_utils_iso9660.py
+++ b/selftests/unit/test_utils_iso9660.py
@@ -47,7 +47,8 @@ class BaseIso9660(unittest.TestCase):
                   due to ast loader we can't just define a base-class.
         """
         base = self.iso.mnt_dir
-        os.path.isdir(os.path.join(base, "Dir"))
+        dir_path = os.path.join(base, "Dir")
+        self.assertTrue(os.path.isdir(dir_path))
         self.assertEqual(open(os.path.join(base, "file")).read(),
                          "file content\n")
         self.assertEqual(open(os.path.join(base, "Dir", "in_dir_file")).read(),


### PR DESCRIPTION
The `avocado.utils.process` and `avocado.utils.iso9660` now default to handle content as bytes (instead of text).  This brings more uniformity across Python versions, and consequently the Python 3 port closer.