### PR TITLE
SIMPLE tests: improve status API

### DIFF
--- a/avocado/etc/avocado/avocado.conf
+++ b/avocado/etc/avocado/avocado.conf
@@ -84,3 +84,18 @@ skip_broken_plugin_notification = []
 # options or test types).
 # The keyword "@DEFAULT" will be replaced with all available unused loaders.
 loaders = ['file', '@DEFAULT']
+
+[simpletests.status]
+# Regular Expression that will make the test
+# status WARN when matched. Defaults to disabled.
+# warn_regex = ^WARN$
+
+# all, stdout, stderr
+# warn_location = all
+#
+# Regular Expression that will make the test
+# status SKIP when matched. Defaults to disabled.
+# skip_regex = ^SKIP$
+
+# all, stdout, stderr
+# skip_location = all

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -1753,6 +1753,41 @@ by ``avocado exec-path`` (if any).  Also, the example test
 .. tip:: These extensions may be available as a separate package.  For
          RPM packages, look for the ``bash`` sub-package.
 
+SIMPLE Tests Status
+===================
+
+With SIMPLE tests, Avocado checks the exit code of the test to determine
+whether the test PASSed or FAILed.
+
+If your test exits with exit code 0 but you still want to set a different test
+status in some conditions, Avocado can search a given regular expression in
+the test outputs and, based on that, set the status to WARN or SKIP.
+
+To use that feature, you have to set the proper keys in the configuration
+file. For instance, to set the test status to SKIP when the test outputs
+a line like this: '11:08:24 Test Skipped'::
+
+    [simpletests.output]
+    skip_regex = ^\d\d:\d\d:\d\d Test Skipped$
+
+That configuration will make avocado to search the regular expression in both
+stdout and stderr. If you want to limit the search for only one of them,
+there's another key for that configuration, resulting in::
+
+    [simpletests.output]
+    skip_regex = ^\d\d:\d\d:\d\d Test Skipped$
+    skip_location = stderr
+
+The equivalent settings can be present for the WARN status. For instance,
+if you want to set the test status to WARN when the test outputs a line
+starting with string ``WARNING:``, the configuration file will look like this::
+
+    [simpletests.output]
+    skip_regex = ^\d\d:\d\d:\d\d Test Skipped$
+    skip_location = stderr
+    warn_regex = ^WARNING:
+    warn_location = all
+
 Wrap Up
 =======
 


### PR DESCRIPTION
Currently simple tests have a limited status API, being able to set only
the WARN status by generating an output string in a very specific and
hard-coded format.

This patch, while respects the current behaviour, creates configuration
keys, allowing users to provide regular expressions to search for in the
test outputs, aiming to set the final test status to either WARN or SKIP
when the test finishes with exit code 0.

Signed-off-by: Amador Pahim <apahim@redhat.com>