### PR TITLE
Python 3: provide a predictive FilterSet.__repr__() implementation

### DIFF
--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -57,6 +57,9 @@ class FilterSet(set):
         return super(FilterSet, self).update([self.__normalize(item)
                                               for item in items])
 
+    def __str__(self):
+        return 'FilterSet([%s])' % ', '.join(["'%s'" % i for i in self])
+
 
 class TreeEnvironment(dict):
 


### PR DESCRIPTION
There's a difference on how Python 2 and 3 represents a set(), which is true
for the set derived FilterSet.  It just happens the a tree fingerprint
depends on its environment, which depends on the FilterSet representation.

Let's provide a predictive __repr__ implementation, and consequently, a
predictive fingerprint for Trees across Python versions.

This fixes the following unittest failure on Python 3:

   FAIL: test_fingerprint (selftests.unit.test_tree.TreeNode)
   ----------------------------------------------------------------------
   Traceback (most recent call last):
     File "/home/cleber/src/avocado/avocado/selftests/unit/test_tree.py", line 63, in test_fingerprint
       "/foo{},{},FilterSet([]),FilterSet([])")
   AssertionError: '/foo{},{},FilterSet(),FilterSet()' != '/foo{},{},FilterSet([]),FilterSet([])'
   - /foo{},{},FilterSet(),FilterSet()
   + /foo{},{},FilterSet([]),FilterSet([])
   ?                     ++            ++

Signed-off-by: Cleber Rosa <crosa@redhat.com>