### PR TITLE
Python 3: do not allow failures on CI, but only run unittests and doc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ python:
     - "2.7"
     - "3.4"
 
-matrix:
-  allow_failures:
-    - python: "3.4"
-
 branches:
     only:
         - master
@@ -55,7 +51,15 @@ script:
             echo
             echo
             git checkout $COMMIT || ERR=$(echo -e "$ERR\nUnable to checkout $(git log -1 --oneline $COMMIT)")
-            AVOCADO_PARALLEL_CHECK=yes AVOCADO_LOG_DEBUG=yes AVOCADO_RESULTSDIR_CHECK=y SELF_CHECK_CONTINUOUS=y AVOCADO_CHECK_LEVEL=1 make check || ERR=$(echo -e "$ERR\nmake check of $(git log -1 --oneline) failed")
+            # TODO: REMOVE ME WHEN PYTHON 3 PORT IS FINISHED.
+            # This makes the Python 3 checks *not* run in parallel, and consequently
+            # skip the functional and optional plugin's tests
+            PY_VERSION=$(python --version)
+            if [ "PY_VERSION" == "3.4.3" ]; then
+                AVOCADO_PARALLEL_CHECK=yes AVOCADO_LOG_DEBUG=yes AVOCADO_RESULTSDIR_CHECK=y SELF_CHECK_CONTINUOUS=y AVOCADO_CHECK_LEVEL=1 make check || ERR=$(echo -e "$ERR\nmake check of $(git log -1 --oneline) failed")
+            else
+                AVOCADO_LOG_DEBUG=yes AVOCADO_RESULTSDIR_CHECK=y SELF_CHECK_CONTINUOUS=y AVOCADO_CHECK_LEVEL=1 make check || ERR=$(echo -e "$ERR\nmake check of $(git log -1 --oneline) failed")
+            fi
             make clean
         done
         if [ "$ERR" ]; then

--- a/selftests/run
+++ b/selftests/run
@@ -30,9 +30,15 @@ def test_suite():
     loader = unittest.TestLoader()
     selftests_dir = os.path.dirname(os.path.abspath(__file__))
     basedir = os.path.dirname(selftests_dir)
-    for section in ('unit', 'functional', 'doc'):
+    if sys.version_info[0] == 3:
+        sections = ('unit', 'doc')
+    else:
+        sections = ('unit', 'functional', 'doc')
+    for section in sections:
         suite.addTests(loader.discover(start_dir=os.path.join(selftests_dir, section),
                                        top_level_dir=basedir))
+    if sys.version_info[0] == 3:
+        return suite
     plugins = (('avocado-framework-plugin-varianter-yaml-to-mux',
                 'varianter_yaml_to_mux'),
                ('avocado-framework-plugin-runner-remote',


### PR DESCRIPTION
This removes the exception of allowing failures on the Travis CI jobs
with Python 3, while, at the same time, temporary restricts Python 3
jobs to run only unittests and the documentation build for the Avocado
core.  That is, it excludes the functional tests, and the optional
plugin's tests.

While it may look like a step back, it's actually a step forward in the
Python 3 port, because now any regression on the unittests will be caught.
And, when the additional fixes are applied to address the functional tests
and plugin's tests, the whole set of tests will be enabled for Python 3.

Signed-off-by: Cleber Rosa <crosa@redhat.com>