### PR TITLE
Revert "process.py: Add subprocess stdin.write() method"

### DIFF
--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -531,7 +531,6 @@ class SubProcess(object):
                 else:
                     stderr = subprocess.PIPE
                 self._popen = subprocess.Popen(cmd,
-                                               stdin=subprocess.PIPE,
                                                stdout=subprocess.PIPE,
                                                stderr=stderr,
                                                shell=self.shell,
@@ -701,16 +700,6 @@ class SubProcess(object):
         if rc is not None:
             self._fill_results(rc)
         return rc
-
-    def stdin_write(self, value, flush=False):
-        """
-        Call the subprocess stdin.write() method for any input to subprocess
-        Optionally flush the input buffer
-        """
-        self._init_subprocess()
-        self._popen.stdin.write(value)
-        if flush:
-            self._popen.stdin.flush()
 
     def stop(self):
         """


### PR DESCRIPTION
 Revert "process.py: Add subprocess stdin.write() method"

The commit 3a66bcb is causing the
"selftests.functional.test_basic.RunnerOperationTest.test_read" selftest
to fail.

@apahim @clebergnu please take a look at this first and rebase all outstanding PRs after this is merged, otherwise the `incremental_check` fails (and if merged without it we'll have even more commits with malfunctioning `make check`).