### PR TITLE
avocado.core.job: Provide per-job tmpdir

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -25,6 +25,7 @@ import pipes
 import re
 import shutil
 import sys
+import tempfile
 import time
 import unittest
 
@@ -395,8 +396,11 @@ class Test(unittest.TestCase, TestData):
 
         basename = (os.path.basename(self.logdir).replace(':', '_')
                     .replace(';', '_'))
-        self.__workdir = utils_path.init_dir(data_dir.get_tmp_dir(),
-                                             basename)
+        base_tmpdir = getattr(job, "tmpdir", None)
+        # When tmpdir not specified by job, use logdir to preserve all data
+        if base_tmpdir is None:
+            base_tmpdir = tempfile.mkdtemp(prefix="tmp_dir", dir=self.logdir)
+        self.__workdir = utils_path.init_dir(base_tmpdir, basename)
         self.__srcdir = utils_path.init_dir(self.workdir, 'src')
 
         if self.filename:

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -19,6 +19,7 @@ Base Test Runner Plugins.
 import argparse
 import sys
 
+from avocado.core import data_dir
 from avocado.core import exit_codes
 from avocado.core import job
 from avocado.core import loader
@@ -207,7 +208,8 @@ class Run(CLICmd):
         except ValueError as e:
             LOG_UI.error(e.message)
             sys.exit(exit_codes.AVOCADO_FAIL)
-        job_instance = job.Job(args)
+        tmpdir = data_dir.get_tmp_dir()
+        job_instance = job.Job(args, base_tmpdir=tmpdir)
         pre_post_dispatcher = JobPrePostDispatcher()
         try:
             # Run JobPre plugins


### PR DESCRIPTION
Currently we use global "avocado.core.data"dir.get_tmp_dir" temporary
directory for Job execution, which does not allow coexistence of
multiple jobs. Let's still keep the main "data"dir.get_tmp_dir" (for
now) but use it per-application and use it as base_tmpdir for all
the possible (usually just one) jobs.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>