### PR TITLE
Support variants dump/load

### DIFF
--- a/avocado/plugins/variants.py
+++ b/avocado/plugins/variants.py
@@ -13,6 +13,7 @@
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 # Author: Lukas Doktor <ldoktor@redhat.com>
 
+import json
 import sys
 
 from avocado.core import exit_codes
@@ -65,6 +66,8 @@ class Variants(CLICmd):
         parser.add_argument('-c', '--contents', action='store_true',
                             default=False, help="[obsoleted by --variants] "
                             "Shows the node content (variables)")
+        parser.add_argument('--dump-variants', default=None,
+                            help="Dump the Variants to a JSON file")
         env_parser = parser.add_argument_group("environment view options")
         env_parser.add_argument('-d', '--debug', action='store_true',
                                 dest="varianter_debug", default=False,
@@ -109,6 +112,15 @@ class Variants(CLICmd):
         else:
             if args.contents:
                 variants += 2
+
+        # Export the serialized avocado_variants
+        if args.dump_variants is not None:
+            try:
+                with open(args.dump_variants, 'w') as variants_file:
+                    json.dump(args.avocado_variants.dump(), variants_file)
+            except IOError:
+                LOG_UI.error("Cannot write %s", args.dump_variants)
+                sys.exit(exit_codes.AVOCADO_FAIL)
 
         # Produce the output
         lines = args.avocado_variants.to_str(summary=summary,

--- a/docs/source/TestParameters.rst
+++ b/docs/source/TestParameters.rst
@@ -137,6 +137,46 @@ is ``None``, which still produces an empty `AvocadoParams`_. Also, the
 `Variant`_ can also be a ``tuple(list, paths)`` or just the
 ``list`` of :class:`avocado.core.tree.TreeNode` with the params.
 
+Dumping/Loading Variants
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Depending on the number of parameters, generating the Variants can be very
+compute intensive. And since the Variants are generated as part of the Job
+execution, that compute intensive task will be executed by the systems under
+test, causing an unwanted cpu load on those systems.
+
+To avoid such situation, you can export (dump) the variants to a JSON file and
+use that file (load) on the system where the Job will be executed. Example:
+
+On `system 01`::
+
+   $ avocado variants --mux-yaml examples/yaml_to_mux/hw/hw.yaml --dump-variants variants.json
+   Multiplex variants (6):
+   Variant intel-scsi-56d0:    /run/cpu/intel, /run/disk/scsi
+   Variant intel-virtio-3d4e:    /run/cpu/intel, /run/disk/virtio
+   Variant amd-scsi-fa43:    /run/cpu/amd, /run/disk/scsi
+   Variant amd-virtio-a59a:    /run/cpu/amd, /run/disk/virtio
+   Variant arm-scsi-1c14:    /run/cpu/arm, /run/disk/scsi
+   Variant arm-virtio-5ce1:    /run/cpu/arm, /run/disk/virtio
+
+.. note:: The option ``--dump-variants`` is available for both ``avocado run``
+   and ``avocado variants`` commands.
+
+Copy the file over and, on `system 02`::
+
+   $ avocado run passtest.py --load-variants variants.json
+   JOB ID     : f2022736b5b89d7f4cf62353d3fb4d7e3a06f075
+   JOB LOG    : $HOME/avocado/job-results/job-2018-02-09T14.39-f202273/job.log
+    (1/6) passtest.py:PassTest.test;intel-scsi-56d0: PASS (0.04 s)
+    (2/6) passtest.py:PassTest.test;intel-virtio-3d4e: PASS (0.02 s)
+    (3/6) passtest.py:PassTest.test;amd-scsi-fa43: PASS (0.02 s)
+    (4/6) passtest.py:PassTest.test;amd-virtio-a59a: PASS (0.02 s)
+    (5/6) passtest.py:PassTest.test;arm-scsi-1c14: PASS (0.03 s)
+    (6/6) passtest.py:PassTest.test;arm-virtio-5ce1: PASS (0.04 s)
+   RESULTS    : PASS 6 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
+   JOB TIME   : 0.51 s
+   JOB HTML   : $HOME/avocado/job-results/job-2018-02-09T14.39-f202273/results.html
+
 Varianter
 ~~~~~~~~~
 

--- a/selftests/functional/test_variants.py
+++ b/selftests/functional/test_variants.py
@@ -1,0 +1,75 @@
+import json
+import os
+import tempfile
+import shutil
+import unittest
+
+from avocado.utils import process
+
+
+basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..')
+basedir = os.path.abspath(basedir)
+
+AVOCADO = os.environ.get("UNITTEST_AVOCADO_CMD", "./scripts/avocado")
+
+
+class VariantsDumpLoadTests(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        self.variants_file = os.path.join(self.tmpdir, 'variants.json')
+
+    def test_variants_dump(self):
+        content = ('[{"paths": ["/run/*"], '
+                   '"variant": [["/", []]], '
+                   '"variant_id": null}]')
+
+        cmd_line = ('%s variants --dump-variants %s' %
+                    (AVOCADO, self.variants_file))
+        process.run(cmd_line)
+        with open(self.variants_file, 'r') as file_obj:
+            self.assertEqual(file_obj.read(), content)
+
+    def test_run_dump(self):
+        content = ('[{"paths": ["/run/*"], '
+                   '"variant": [["/", []]], '
+                   '"variant_id": null}]')
+
+        cmd_line = ('%s run passtest.py --dump-variants %s '
+                    '--job-results-dir %s' %
+                    (AVOCADO, self.variants_file, self.tmpdir))
+        process.run(cmd_line)
+        with open(self.variants_file, 'r') as file_obj:
+            self.assertEqual(file_obj.read(), content)
+
+    def test_run_load(self):
+        content = ('[{"paths": ["/run/*"],'
+                   '  "variant": [["/run/params/foo",'
+                   '             [["/run/params/foo", "p2", "foo2"],'
+                   '              ["/run/params/foo", "p1", "foo1"]]]], '
+                   '  "variant_id": "foo-0ead"}, '
+                   ' {"paths": ["/run/*"],'
+                   '  "variant": [["/run/params/bar",'
+                   '             [["/run/params/bar", "p2", "bar2"],'
+                   '              ["/run/params/bar", "p1", "bar1"]]]],'
+                   '  "variant_id": "bar-d06d"}]')
+
+        with open(self.variants_file, 'w') as file_obj:
+            file_obj.write(content)
+        cmd_line = ('%s run passtest.py --load-variants %s '
+                    '--job-results-dir %s --json -' %
+                    (AVOCADO, self.variants_file, self.tmpdir))
+        result = process.run(cmd_line)
+        json_result = json.loads(result.stdout)
+        self.assertEqual(json_result["pass"], 2)
+        self.assertEqual(json_result["tests"][0]["id"],
+                         "1-passtest.py:PassTest.test;foo-0ead")
+        self.assertEqual(json_result["tests"][1]["id"],
+                         "2-passtest.py:PassTest.test;bar-d06d")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Depending on the number of parameters, generating the Variants can be
compute intensive. This patch adds the ability to dump/load the variants
to/from a JSON file so the Variants generation can be offloaded from the
machine under test.

Reference: https://trello.com/c/llZJKBdi
Signed-off-by: Amador Pahim <apahim@redhat.com>