### PR TITLE
contrib: Stop using "--rawurl" in "avocado-check-pr"

### DIFF
--- a/contrib/scripts/avocado-check-pr.sh
+++ b/contrib/scripts/avocado-check-pr.sh
@@ -128,7 +128,7 @@ publish_results() {
             description="ALL PASS"
         fi
     fi
-    [ "$DRY" ] || url=$(fpaste --rawurl -x 604800 $tmp)
+    [ "$DRY" ] || url=$(fpaste -x 604800 $tmp | tail -n 1)
     set_status "$BASE_URL" "$commit" "$status" "${url%%/raw/}" "$description"
 }
 


### PR DESCRIPTION
The "--rawurl" is not supported on later "fpaste" versions as it outputs
everything else to stderr. Anyway to keep compatibility with older
fpaste let's explicitly use `tail -n 1` to get only the last line.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>