### PR TITLE
Drop 36lts code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ matrix:
 branches:
     only:
         - master
-        - 36lts
         - 52lts
 
 cache:

--- a/Makefile
+++ b/Makefile
@@ -138,8 +138,6 @@ clean:
 	rm -rf /tmp/avocado*
 	find . -name '*.pyc' -delete
 	find $(AVOCADO_OPTIONAL_PLUGINS) -name '*.egg-info' -exec rm -r {} +
-	# Remove this after 36lts is declared EOL
-	rm -rf avocado.egg-info
 
 pip:
 	$(PYTHON) -m pip --version || $(PYTHON) -c "import os; import sys; import urllib; f = urllib.urlretrieve('https://bootstrap.pypa.io/get-pip.py')[0]; os.system('%s %s' % (sys.executable, f))"

--- a/avocado/core/parser.py
+++ b/avocado/core/parser.py
@@ -23,7 +23,6 @@ from six import iteritems
 from . import exit_codes
 from . import varianter
 from . import settings
-from . import tree
 from .output import BUILTIN_STREAMS, BUILTIN_STREAM_SETS, LOG_UI
 from .version import VERSION
 
@@ -135,9 +134,6 @@ class Parser(object):
         # Allow overriding default params by plugins
         variants = varianter.Varianter(getattr(self.args, "varianter_debug", False))
         self.args.avocado_variants = variants
-        # FIXME: Backward compatibility params, to be removed when 36 LTS is
-        # discontinued
-        self.args.default_avocado_params = tree.TreeNode()
 
     def finish(self):
         """

--- a/avocado/core/varianter.py
+++ b/avocado/core/varianter.py
@@ -209,11 +209,6 @@ class Varianter(object):
             default_params.merge(default_param)
         self._default_params = default_params
         self.default_params.clear()     # We don't need these anymore
-        # FIXME: Backward compatibility params, to be removed when 36 LTS is
-        # discontinued
-        if (not getattr(args, "variants-skip-defaults", False) and
-                hasattr(args, "default_avocado_params")):
-            self._default_params.merge(args.default_avocado_params)
         return self._default_params
 
     def is_parsed(self):

--- a/avocado/utils/build.py
+++ b/avocado/utils/build.py
@@ -23,10 +23,11 @@ def run_make(path, make='make', env=None, extra_args='', ignore_status=None,
     """
     Run make, adding MAKEOPTS to the list of options.
 
+    :param path: directory from where to run make
     :param make: what make command name to use.
     :param env: dictionary with environment variables to be set before
                 calling make (e.g.: CFLAGS).
-    :param extra: extra command line arguments to pass to make.
+    :param extra_args: extra command line arguments to pass to make.
     :param allow_output_check: Whether to log the command stream outputs
                                (stdout and stderr) of the make process in
                                the test stream files. Valid values: 'stdout',

--- a/avocado/utils/build.py
+++ b/avocado/utils/build.py
@@ -18,27 +18,12 @@ import os
 from . import process
 
 
-def run_make(path, make='make', env=None, extra_args='', ignore_status=None,
-             allow_output_check=None, process_kwargs=None):
+def run_make(path, make='make', extra_args='', process_kwargs=None):
     """
     Run make, adding MAKEOPTS to the list of options.
 
     :param path: directory from where to run make
     :param make: what make command name to use.
-    :param env: dictionary with environment variables to be set before
-                calling make (e.g.: CFLAGS).
-    :param extra_args: extra command line arguments to pass to make.
-    :param allow_output_check: Whether to log the command stream outputs
-                               (stdout and stderr) of the make process in
-                               the test stream files. Valid values: 'stdout',
-                               for allowing only standard output, 'stderr',
-                               to allow only standard error, 'all',
-                               to allow both standard output and error,
-                               and 'none', to allow none to be
-                               recorded (default). The default here is
-                               'none', because usually we don't want
-                               to use the compilation output as a reference
-                               in tests.
     :param process_kwargs: Additional key word arguments to the underlying
                            process running the make.
     :type allow_output_check: str
@@ -48,13 +33,17 @@ def run_make(path, make='make', env=None, extra_args='', ignore_status=None,
     os.chdir(path)
     cmd = make
 
+    env = {}
     # Set default number of jobs as ncpus + 1
     if "-j" not in os.environ.get("MAKEFLAGS", ""):
         jobs = multiprocessing.cpu_count() + 1
+        env = process_kwargs.get('env', {})
         if not env:
             env = {"MAKEFLAGS": "-j%s" % jobs}
         elif "-j" not in env:
             env["MAKEFLAGS"] = "-j%s" % jobs
+    if env and process_kwargs['env'] is not None:
+        process_kwargs['env'].update(env)
 
     makeopts = os.environ.get('MAKEOPTS', '')
     if makeopts:
@@ -62,25 +51,7 @@ def run_make(path, make='make', env=None, extra_args='', ignore_status=None,
     if extra_args:
         cmd += ' %s' % extra_args
 
-    # Compatibility with 36LTS
-    # process_kwargs was added in 43.0 and supersedes the old way of
-    # specifying the process's arguments. When 36LTS is discontinued the
-    # ignore_status, allow_output_check and env args should be removed.
-    if process_kwargs is None:
-        process_kwargs = {}
-    if ignore_status is not None:   # Compatibility with 36LTS
-        process_kwargs["ignore_status"] = ignore_status
-    if allow_output_check is not None:  # Compatibility with 36LTS
-        process_kwargs["allow_output_check"] = allow_output_check
-    else:
-        process_kwargs["allow_output_check"] = "none"
-    if env:     # Compatibility with 36LTS
-        if process_kwargs.get("env"):
-            process_kwargs["env"].update(env)
-        else:
-            process_kwargs["env"] = env
-    make_process = process.run(cmd,
-                               **process_kwargs)
+    make_process = process.run(cmd, **process_kwargs)
     os.chdir(cwd)
     return make_process
 
@@ -109,7 +80,11 @@ def make(path, make='make', env=None, extra_args='', ignore_status=None,
     :returns: exit status of the make process
     """
 
-    result = run_make(path, make, env, extra_args, ignore_status,
-                      allow_output_check)
+    kwargs = dict(env=env,
+                  ignore_status=ignore_status,
+                  allow_output_check=allow_output_check)
+    if process_kwargs is not None:
+        kwargs.update(process_kwargs)
+    result = run_make(path, make, extra_args, kwargs)
 
     return result.exit_status

--- a/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/mux.py
+++ b/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/mux.py
@@ -181,9 +181,6 @@ class MuxPlugin(object):
         if self.root is None:
             return
 
-        # TODO: Remove when 36lts is discontinued
-        if not hasattr(self, "variant_ids"):
-            self.variant_ids = self._get_variant_ids()
         for vid, variant in itertools.izip(self.variant_ids, self.variants):
             yield {"variant_id": vid,
                    "variant": variant,


### PR DESCRIPTION
With 36lts now declared EOLed[1], let's remove code that was related to specifics of that release.

[1] - https://www.redhat.com/archives/avocado-devel/2018-February/msg00015.html