### PR TITLE
Selftests:  miscellaneous fixes (2nd batch) [v2]

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -1225,8 +1225,8 @@ class ExternalRunnerTest(SimpleTest):
         pre_cwd = os.getcwd()
         new_cwd = None
         try:
-            self.log.info('Running test with the external level test '
-                          'runner: "%s"', self.external_runner.runner)
+            self.log.info('Running test with the external test runner: "%s"',
+                          self.external_runner.runner)
 
             # Change work directory if needed by the external runner
             if self.external_runner.chdir == 'runner':

--- a/examples/tests/whiteboard.py
+++ b/examples/tests/whiteboard.py
@@ -38,7 +38,7 @@ class WhiteBoard(Test):
         result = ''
         for _ in range(0, iterations):
             result += data
-        self.whiteboard = base64.encodestring(result)
+        self.whiteboard = base64.encodestring(result.encode()).decode('ascii')
 
 
 if __name__ == "__main__":

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -20,7 +20,12 @@ try:
 except:
     from BytesIO import BytesIO
 
-from lxml import etree
+try:
+    from lxml import etree
+    SCHEMA_CAPABLE = True
+except ImportError:
+    SCHEMA_CAPABLE = False
+
 from six import iteritems
 from six.moves import xrange as range
 
@@ -1144,6 +1149,8 @@ class ParseXMLError(Exception):
 
 class PluginsXunitTest(AbsPluginsTest, unittest.TestCase):
 
+    @unittest.skipUnless(SCHEMA_CAPABLE,
+                         'Unable to validate schema due to missing lxml.etree library')
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
         junit_xsd = os.path.join(os.path.dirname(__file__),

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -15,7 +15,10 @@ import unittest
 import psutil
 import pkg_resources
 
-from StringIO import StringIO
+try:
+    from io import BytesIO
+except:
+    from BytesIO import BytesIO
 
 from lxml import etree
 from six import iteritems
@@ -1163,10 +1166,10 @@ class PluginsXunitTest(AbsPluginsTest, unittest.TestCase):
             raise ParseXMLError("Failed to parse content: %s\n%s" %
                                 (detail, xml_output))
 
-        with open(self.junit, 'r') as f:
+        with open(self.junit, 'rb') as f:
             xmlschema = etree.XMLSchema(etree.parse(f))
 
-        self.assertTrue(xmlschema.validate(etree.parse(StringIO(xml_output))),
+        self.assertTrue(xmlschema.validate(etree.parse(BytesIO(xml_output))),
                         "Failed to validate against %s, message:\n%s" %
                         (self.junit,
                          xmlschema.error_log.filter_from_errors()))

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -166,7 +166,7 @@ class OutputTest(unittest.TestCase):
         def _check_output(path, exps, name):
             i = 0
             end = len(exps)
-            with open(path) as output_file:
+            with open(path, 'rb') as output_file:
                 output_file_content = output_file.read()
                 output_file.seek(0)
                 for line in output_file:
@@ -193,11 +193,11 @@ class OutputTest(unittest.TestCase):
                 "[stderr] test_stderr", "[stdout] test_process"]
         _check_output(joblog, exps, "job.log")
         testdir = res["tests"][0]["logdir"]
-        with open(os.path.join(testdir, "stdout")) as stdout_file:
-            self.assertEqual("test_print\ntest_stdout\ntest_process__test_stdout__",
+        with open(os.path.join(testdir, "stdout"), 'rb') as stdout_file:
+            self.assertEqual(b"test_print\ntest_stdout\ntest_process__test_stdout__",
                              stdout_file.read())
-        with open(os.path.join(testdir, "stderr")) as stderr_file:
-            self.assertEqual("test_stderr\n__test_stderr__",
+        with open(os.path.join(testdir, "stderr"), 'rb') as stderr_file:
+            self.assertEqual(b"test_stderr\n__test_stderr__",
                              stderr_file.read())
 
         # Now run the same test, but with combined output

--- a/selftests/functional/test_output_check.py
+++ b/selftests/functional/test_output_check.py
@@ -110,9 +110,9 @@ class RunnerSimpleTest(unittest.TestCase):
 
     def test_output_tamper_stdout(self):
         self._check_output_record_all()
-        tampered_msg = "I PITY THE FOOL THAT STANDS ON MY WAY!"
+        tampered_msg = b"I PITY THE FOOL THAT STANDS ON MY WAY!"
         stdout_file = os.path.join("%s.data/stdout.expected" % self.output_script.path)
-        with open(stdout_file, 'w') as stdout_file_obj:
+        with open(stdout_file, 'wb') as stdout_file_obj:
             stdout_file_obj.write(tampered_msg)
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off %s --xunit -'
                     % (AVOCADO, self.tmpdir, self.output_script.path))
@@ -125,9 +125,9 @@ class RunnerSimpleTest(unittest.TestCase):
 
     def test_output_tamper_combined(self):
         self._check_output_record_combined()
-        tampered_msg = "I PITY THE FOOL THAT STANDS ON MY WAY!"
+        tampered_msg = b"I PITY THE FOOL THAT STANDS ON MY WAY!"
         output_file = os.path.join("%s.data/output.expected" % self.output_script.path)
-        with open(output_file, 'w') as output_file_obj:
+        with open(output_file, 'wb') as output_file_obj:
             output_file_obj.write(tampered_msg)
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off %s --xunit -'
                     % (AVOCADO, self.tmpdir, self.output_script.path))
@@ -140,15 +140,15 @@ class RunnerSimpleTest(unittest.TestCase):
 
     def test_output_diff(self):
         self._check_output_record_all()
-        tampered_msg_stdout = "I PITY THE FOOL THAT STANDS ON STDOUT!"
-        tampered_msg_stderr = "I PITY THE FOOL THAT STANDS ON STDERR!"
+        tampered_msg_stdout = b"I PITY THE FOOL THAT STANDS ON STDOUT!"
+        tampered_msg_stderr = b"I PITY THE FOOL THAT STANDS ON STDERR!"
 
         stdout_file = "%s.data/stdout.expected" % self.output_script.path
-        with open(stdout_file, 'w') as stdout_file_obj:
+        with open(stdout_file, 'wb') as stdout_file_obj:
             stdout_file_obj.write(tampered_msg_stdout)
 
         stderr_file = "%s.data/stderr.expected" % self.output_script.path
-        with open(stderr_file, 'w') as stderr_file_obj:
+        with open(stderr_file, 'wb') as stderr_file_obj:
             stderr_file_obj.write(tampered_msg_stderr)
 
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off %s --json -'
@@ -166,32 +166,32 @@ class RunnerSimpleTest(unittest.TestCase):
         stderr_diff = os.path.join(json_result['tests'][0]['logdir'],
                                    'stderr.diff')
 
-        with open(stdout_diff, 'r') as stdout_diff_obj:
+        with open(stdout_diff, 'rb') as stdout_diff_obj:
             stdout_diff_content = stdout_diff_obj.read()
-        self.assertIn('-I PITY THE FOOL THAT STANDS ON STDOUT!',
+        self.assertIn(b'-I PITY THE FOOL THAT STANDS ON STDOUT!',
                       stdout_diff_content)
-        self.assertIn('+Hello, avocado!', stdout_diff_content)
+        self.assertIn(b'+Hello, avocado!', stdout_diff_content)
 
-        with open(stderr_diff, 'r') as stderr_diff_obj:
+        with open(stderr_diff, 'rb') as stderr_diff_obj:
             stderr_diff_content = stderr_diff_obj.read()
-        self.assertIn('-I PITY THE FOOL THAT STANDS ON STDERR!',
+        self.assertIn(b'-I PITY THE FOOL THAT STANDS ON STDERR!',
                       stderr_diff_content)
-        self.assertIn('+Hello, stderr!', stderr_diff_content)
+        self.assertIn(b'+Hello, stderr!', stderr_diff_content)
 
-        with open(job_log, 'r') as job_log_obj:
+        with open(job_log, 'rb') as job_log_obj:
             job_log_content = job_log_obj.read()
-        self.assertIn('Stdout Diff:', job_log_content)
-        self.assertIn('-I PITY THE FOOL THAT STANDS ON STDOUT!', job_log_content)
-        self.assertIn('+Hello, avocado!', job_log_content)
-        self.assertIn('Stdout Diff:', job_log_content)
-        self.assertIn('-I PITY THE FOOL THAT STANDS ON STDERR!', job_log_content)
-        self.assertIn('+Hello, stderr!', job_log_content)
+        self.assertIn(b'Stdout Diff:', job_log_content)
+        self.assertIn(b'-I PITY THE FOOL THAT STANDS ON STDOUT!', job_log_content)
+        self.assertIn(b'+Hello, avocado!', job_log_content)
+        self.assertIn(b'Stdout Diff:', job_log_content)
+        self.assertIn(b'-I PITY THE FOOL THAT STANDS ON STDERR!', job_log_content)
+        self.assertIn(b'+Hello, stderr!', job_log_content)
 
     def test_disable_output_check(self):
         self._check_output_record_all()
-        tampered_msg = "I PITY THE FOOL THAT STANDS ON MY WAY!"
+        tampered_msg = b"I PITY THE FOOL THAT STANDS ON MY WAY!"
         stdout_file = os.path.join("%s.data/stdout.expected" % self.output_script.path)
-        with open(stdout_file, 'w') as stdout_file_obj:
+        with open(stdout_file, 'wb') as stdout_file_obj:
             stdout_file_obj.write(tampered_msg)
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off %s '
                     '--output-check=off --xunit -'

--- a/selftests/unit/test_runner_queue.py
+++ b/selftests/unit/test_runner_queue.py
@@ -2,8 +2,8 @@ import argparse
 import shutil
 import tempfile
 import unittest
-
-from multiprocessing import queues
+import multiprocessing
+import multiprocessing.queues
 
 from avocado.core.job import Job
 from avocado.core.result import Result
@@ -28,7 +28,10 @@ class TestRunnerQueue(unittest.TestCase):
         :param factory: the Avocado Test factory
         :return: the last queue message from the test
         """
-        queue = queues.SimpleQueue()
+        if hasattr(multiprocessing, 'SimpleQueue'):
+            queue = multiprocessing.SimpleQueue()
+        else:
+            queue = multiprocessing.queues.SimpleQueue()  # pylint: disable=E1125
         runner = TestRunner(job=self.job, result=self.result)
         runner._run_test(factory, queue)
         while not queue.empty():


### PR DESCRIPTION
This is a second batch (not a v2) of miscellaneous test (and other) fixes, mostly necessary for the Python 3 port.

---

Changes from v1 (#2441):
 * Let the `multiprocessing` module choose que context (when required, on Python 3) for the SimpleQueue used on the runner (as per https://github.com/avocado-framework/avocado/pull/2451)