### PR TITLE
JSON Result Plugin: remove legacy (duplicated) fields [v2]

### DIFF
--- a/avocado/plugins/diff.py
+++ b/avocado/plugins/diff.py
@@ -146,12 +146,12 @@ class Diff(CLICmd):
         if 'results' in args.diff_filter:
             results1 = []
             for test in job1_data['tests']:
-                test_result = '%s: %s\n' % (str(test['url']),
+                test_result = '%s: %s\n' % (str(test['id']),
                                             str(test['status']))
                 results1.append(test_result)
             results2 = []
             for test in job2_data['tests']:
-                test_result = '%s: %s\n' % (str(test['url']),
+                test_result = '%s: %s\n' % (str(test['id']),
                                             str(test['status']))
                 results2.append(test_result)
 

--- a/avocado/plugins/jsonresult.py
+++ b/avocado/plugins/jsonresult.py
@@ -44,16 +44,7 @@ class JSONResult(Result):
                           'whiteboard': test.get('whiteboard', UNKNOWN),
                           'logdir': test.get('logdir', UNKNOWN),
                           'logfile': test.get('logfile', UNKNOWN),
-                          'fail_reason': str(test.get('fail_reason', UNKNOWN)),
-                          # COMPATIBILITY: `test` and `url` are backward
-                          # compatibility key names for the test ID,
-                          # as defined by the test name RFC.  `url` is
-                          # not a test reference, as it's recorded
-                          # after it has been processed by the test resolver
-                          # (currently called test loader in the code).
-                          # Expect them to be removed in the future.
-                          'test': str(test.get('name', UNKNOWN)),
-                          'url': str(test.get('name', UNKNOWN))})
+                          'fail_reason': str(test.get('fail_reason', UNKNOWN))})
         content = {'job_id': result.job_unique_id,
                    'debuglog': result.logfile,
                    'tests': tests,

--- a/docs/source/ResultFormats.rst
+++ b/docs/source/ResultFormats.rst
@@ -113,9 +113,8 @@ plugin::
                 "logfile": "/home/cleber/avocado/job-results/job-2016-08-09T13.53-10715c4/test-results/1-sleeptest.py:SleepTest.test/debug.log",
                 "start": 1470761622.174918,
                 "status": "PASS",
-                "test": "1-sleeptest.py:SleepTest.test",
+                "id": "1-sleeptest.py:SleepTest.test",
                 "time": 1.0020360946655273,
-                "url": "1-sleeptest.py:SleepTest.test",
                 "whiteboard": ""
             },
             {
@@ -125,9 +124,8 @@ plugin::
                 "logfile": "/home/cleber/avocado/job-results/job-2016-08-09T13.53-10715c4/test-results/2-failtest.py:FailTest.test/debug.log",
                 "start": 1470761623.192334,
                 "status": "FAIL",
-                "test": "2-failtest.py:FailTest.test",
+                "id": "2-failtest.py:FailTest.test",
                 "time": 0.0011379718780517578,
-                "url": "2-failtest.py:FailTest.test",
                 "whiteboard": ""
             },
             {
@@ -137,9 +135,8 @@ plugin::
                 "logfile": "/home/cleber/avocado/job-results/job-2016-08-09T13.53-10715c4/test-results/3-synctest.py:SyncTest.test/debug.log",
                 "start": 1470761623.208165,
                 "status": "PASS",
-                "test": "3-synctest.py:SyncTest.test",
+                "id": "3-synctest.py:SyncTest.test",
                 "time": 2.4478960037231445,
-                "url": "3-synctest.py:SyncTest.test",
                 "whiteboard": ""
             }
         ],

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -1297,7 +1297,7 @@ class PluginsJSONTest(AbsPluginsTest, unittest.TestCase):
                                   'nbar/baz"', exit_codes.AVOCADO_ALL_OK, 1, 0,
                                   0, 0, external_runner=GNU_ECHO_BINARY)
         # The executed test should be this
-        self.assertEqual(data['tests'][0]['url'],
+        self.assertEqual(data['tests'][0]['id'],
                          '1--ne foo\\\\n\\\'\\"\\\\nbar/baz')
         # logdir name should escape special chars (/)
         self.assertEqual(os.path.basename(data['tests'][0]['logdir']),

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -554,9 +554,9 @@ class OutputPluginTest(unittest.TestCase):
                 bsod_dir = None
                 json_dir = None
                 for test in json_results['tests']:
-                    if "test_bsod" in test['url']:
+                    if "test_bsod" in test['id']:
                         bsod_dir = test['logfile']
-                    elif "test_json" in test['url']:
+                    elif "test_json" in test['id']:
                         json_dir = test['logfile']
                 self.assertTrue(bsod_dir, "Failed to get test_bsod output "
                                 "directory")


### PR DESCRIPTION
The "url" and "test" fields are just legacy and duplicated fields
that carry the same data as the "id" field.  Let's remove those.

Signed-off-by: Cleber Rosa <crosa@redhat.com>

---

Changes from v1 (#2461):
 * Removed mentions for the fields in the documentation