### PR TITLE
avocado_loader_yaml: Allow to set test name prefix

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -879,7 +879,8 @@ class FileLoader(TestLoader):
                     # Module does not have an avocado test class inside but
                     # it's executable, let's execute it.
                     return self._make_test(test.SimpleTest, test_path,
-                                           subtests_filter=subtests_filter)
+                                           subtests_filter=subtests_filter,
+                                           executable=test_path)
                 else:
                     # Module does not have an avocado test class inside, and
                     # it's not executable. Not a Test.
@@ -896,25 +897,29 @@ class FileLoader(TestLoader):
                 # Module can't be imported, and it's executable. Let's try to
                 # execute it.
                 return self._make_test(test.SimpleTest, test_path,
-                                       subtests_filter=subtests_filter)
+                                       subtests_filter=subtests_filter,
+                                       executable=test_path)
             else:
                 return make_broken(NotATest, test_path, self.__not_test_str)
 
     @staticmethod
-    def _make_test(klass, uid, description=None, subtests_filter=None):
+    def _make_test(klass, uid, description=None, subtests_filter=None,
+                   **test_arguments):
         """
         Create test template
         :param klass: test class
         :param uid: test uid (by default used as id and name)
         :param description: Description appended to "uid" (for listing purpose)
         :param subtests_filter: optional filter of methods for avocado tests
+        :param test_arguments: arguments to be passed to the klass(test_arguments)
         """
         if subtests_filter and not subtests_filter.search(uid):
             return []
 
         if description:
             uid = "%s: %s" % (uid, description)
-        return [(klass, {'name': uid})]
+        test_arguments["name"] = uid
+        return [(klass, test_arguments)]
 
     def _make_tests(self, test_path, list_non_tests, subtests_filter=None):
         """
@@ -942,7 +947,8 @@ class FileLoader(TestLoader):
             else:
                 if os.access(test_path, os.X_OK):
                     return self._make_test(test.SimpleTest, test_path,
-                                           subtests_filter=subtests_filter)
+                                           subtests_filter=subtests_filter,
+                                           executable=test_path)
                 else:
                     return make_broken(NotATest, test_path,
                                        self.__not_test_str)

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -1044,7 +1044,9 @@ class ExternalLoader(TestLoader):
         if (not self._external_runner) or (reference is None):
             return []
         return [(test.ExternalRunnerTest, {'name': reference, 'external_runner':
-                                           self._external_runner})]
+                                           self._external_runner,
+                                           'external_runner_argument':
+                                           reference})]
 
     @staticmethod
     def get_type_label_mapping():

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -1101,7 +1101,11 @@ class SimpleTest(Test):
 
     DATA_SOURCES = ["variant", "file"]
 
-    def __init__(self, name, params=None, base_logdir=None, job=None):
+    def __init__(self, name, params=None, base_logdir=None, job=None,
+                 executable=None):
+        if executable is None:
+            executable = name.name
+        self._filename = executable
         super(SimpleTest, self).__init__(name=name, params=params,
                                          base_logdir=base_logdir, job=job)
         self._data_sources_mapping = {"variant": [lambda: self.datadir,
@@ -1116,7 +1120,7 @@ class SimpleTest(Test):
         """
         Returns the name of the file (path) that holds the current test
         """
-        return os.path.abspath(self.name.name)
+        return os.path.abspath(self._filename)
 
     def _log_detailed_cmd_info(self, result):
         """

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -1213,13 +1213,16 @@ class ExternalRunnerSpec(object):
 class ExternalRunnerTest(SimpleTest):
 
     def __init__(self, name, params=None, base_logdir=None, job=None,
-                 external_runner=None):
+                 external_runner=None, external_runner_argument=None):
+        if external_runner_argument is None:
+            external_runner_argument = name.name
         self.assertIsNotNone(external_runner, "External runner test requires "
                              "external_runner parameter, got None instead.")
         self.external_runner = external_runner
         super(ExternalRunnerTest, self).__init__(name, params, base_logdir,
                                                  job)
-        self._command = external_runner.runner + " " + self.name.name
+        self._command = "%s %s" % (external_runner.runner,
+                                   external_runner_argument)
 
     @property
     def filename(self):
@@ -1257,11 +1260,12 @@ class PythonUnittest(ExternalRunnerTest):
     Python unittest test
     """
     def __init__(self, name, params=None, base_logdir=None, job=None,
-                 test_dir=None):
+                 test_dir=None, python_unittest_module=None):
         runner = "%s -m unittest -q -c" % sys.executable
         external_runner = ExternalRunnerSpec(runner, "test", test_dir)
         super(PythonUnittest, self).__init__(name, params, base_logdir, job,
-                                             external_runner=external_runner)
+                                             external_runner=external_runner,
+                                             external_runner_argument=python_unittest_module)
 
     def _find_result(self, status="OK"):
         status_line = "[stderr] %s" % status

--- a/docs/source/optional_plugins/yaml_loader.rst
+++ b/docs/source/optional_plugins/yaml_loader.rst
@@ -23,6 +23,9 @@ Currently supported special keys are:
    resolver args will be modified)
  * ``test_reference_resolver_extra`` - extra_params to be passed to the
    ``test_resolver_class``.
+ * ``mux_suite_test_name_prefix`` - test name prefix to be added to each
+   discovered test (is useful to distinguish between different variants
+   of the same test)
 
 Keep in mind YAML files (in Avocado) are ordered, therefor variant name won't
 re-arrange the test order. The only exception is when you use the same variant

--- a/docs/source/optional_plugins/yaml_loader.rst
+++ b/docs/source/optional_plugins/yaml_loader.rst
@@ -13,6 +13,17 @@ or it fall-backs to `FileLoader` when not specified. Then it assigns the
 current variant's params to all of the discovered tests. This way one can
 freely assign various variants to different tests.
 
+Currently supported special keys are:
+
+ * ``test_reference`` - reference to be discovered as test
+ * ``test_reference_resolver_class`` - loadable location of a loader class
+   to be used to discover the ``test_reference``
+ * ``test_reference_resolver_args`` - those arguments will override the
+   avocado arguments passed to the ``test_resolver_class`` (only
+   resolver args will be modified)
+ * ``test_reference_resolver_extra`` - extra_params to be passed to the
+   ``test_resolver_class``.
+
 Keep in mind YAML files (in Avocado) are ordered, therefor variant name won't
 re-arrange the test order. The only exception is when you use the same variant
 name twice, then the second one will get merged into the first one.

--- a/examples/yaml_to_mux_loader/advanced.yaml
+++ b/examples/yaml_to_mux_loader/advanced.yaml
@@ -5,8 +5,10 @@
 
 timeout: !mux
     short:
+        mux_suite_test_name_prefix: "short/"
         timeout: 2
     longer:
+        mux_suite_test_name_prefix: "longer/"
         timeout: 6
     no_timeout:
 tests: !mux

--- a/optional_plugins/loader_yaml/avocado_loader_yaml/__init__.py
+++ b/optional_plugins/loader_yaml/avocado_loader_yaml/__init__.py
@@ -112,8 +112,11 @@ class YamlTestsuiteLoader(loader.TestLoader):
                 test_loader.get_full_type_label_mapping())
             self._extra_decorator_mapping.update(
                 test_loader.get_full_decorator_mapping())
+            name_prefix = params.get("mux_suite_test_name_prefix")
             if _tests:
                 for tst in _tests:
+                    if name_prefix:
+                        tst[1]["name"] = name_prefix + tst[1]["name"]
                     tst[1]["params"] = (variant, ["/run/*"])
                 tests.extend(_tests)
         return tests


### PR DESCRIPTION
This PR adds "special" key to the "yaml_loader" to prefix the test name. This would be useful for my CI as I need to run the same tests but with different setting. To support this some changes to our "Test" classes are necessary, because currently the "name" determines the to-be-executed command.