### PR TITLE
CI: enable Python 3 unittests [v2]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ python:
     - "2.7"
     - "3.4"
 
-matrix:
-  allow_failures:
-    - python: "3.4"
-
 branches:
     only:
         - master

--- a/selftests/checkall
+++ b/selftests/checkall
@@ -24,14 +24,19 @@ parallel_selftests() {
     local ERR=0
     local FIND_UNITTESTS=$(readlink -f ./contrib/scripts/avocado-find-unittests)
     local NO_WORKERS=$(($(cat /proc/cpuinfo | grep -c processor) * 2))
+    local PY3=$(python --version 2>&1 | grep -q "$Python 3\.")$?
 
     # The directories that may contain files with tests, from the Avocado core
     # and from all optional plugins
     declare -A DIR_GLOB_MAP
-    DIR_GLOB_MAP[selftests]="selftests/unit/test_*.py selftests/functional/test_*.py selftests/doc/test_*.py"
-    for PLUGIN in $(find optional_plugins -mindepth 1 -maxdepth 1 -type d); do
-        DIR_GLOB_MAP[$PLUGIN]="tests/test_*.py"
-    done;
+    if [ $PY3 -eq 1 ]; then
+        DIR_GLOB_MAP[selftests]="selftests/unit/test_*.py selftests/functional/test_*.py selftests/doc/test_*.py"
+        for PLUGIN in $(find optional_plugins -mindepth 1 -maxdepth 1 -type d); do
+            DIR_GLOB_MAP[$PLUGIN]="tests/test_*.py"
+        done;
+    else
+        DIR_GLOB_MAP[selftests]="selftests/unit/test_*.py selftests/doc/test_*.py"
+    fi
 
     declare -A TESTS
     for TEST_DIR in "${!DIR_GLOB_MAP[@]}"; do

--- a/selftests/run
+++ b/selftests/run
@@ -30,9 +30,15 @@ def test_suite():
     loader = unittest.TestLoader()
     selftests_dir = os.path.dirname(os.path.abspath(__file__))
     basedir = os.path.dirname(selftests_dir)
-    for section in ('unit', 'functional', 'doc'):
+    if sys.version_info[0] == 3:
+        sections = ('unit', 'doc')
+    else:
+        sections = ('unit', 'functional', 'doc')
+    for section in sections:
         suite.addTests(loader.discover(start_dir=os.path.join(selftests_dir, section),
                                        top_level_dir=basedir))
+    if sys.version_info[0] == 3:
+        return suite
     plugins = (('avocado-framework-plugin-varianter-yaml-to-mux',
                 'varianter_yaml_to_mux'),
                ('avocado-framework-plugin-runner-remote',

--- a/selftests/unit/test_runner_queue.py
+++ b/selftests/unit/test_runner_queue.py
@@ -4,6 +4,7 @@ import tempfile
 import unittest
 import multiprocessing
 import multiprocessing.queues
+import os
 
 from avocado.core.job import Job
 from avocado.core.result import Result
@@ -42,12 +43,15 @@ class TestRunnerQueue(unittest.TestCase):
         """
         Tests if the whiteboard content is the expected one
         """
+        this = os.path.abspath(__file__)
+        base = os.path.dirname(os.path.dirname(os.path.dirname(this)))
+        module = os.path.join(base, 'examples', 'tests', 'whiteboard.py')
         factory = ['WhiteBoard',
                    {'methodName': 'test',
                     'tags': set([]),
                     'params': ([TreeNode(name='')], ['/run/*']),
                     'job': self.job,
-                    'modulePath': 'examples/tests/whiteboard.py',
+                    'modulePath': module,
                     'base_logdir': self.tmpdir}]
         msg = self._run_test(factory)
 


### PR DESCRIPTION
This is a another milestone in the Python 3 port, in which failures to Python 3 will no longer be ignored on Travis-CI.  But, given that functional tests and optional plugin tests are still not 100% ported, this only runs unittests on Python 3.

---

Changes from v1 (#2464):
 * Changed the order of commits, an attempt to tweak Travis wrt "allow failures" on Python 3
 * Rebased