### PR TITLE
setup: Add "setuptools" dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,4 +99,4 @@ if __name__ == '__main__':
           zip_safe=False,
           test_suite='selftests',
           python_requires='>=2.7',
-          install_requires=['stevedore>=0.14', 'six>=1.10.0'])
+          install_requires=['stevedore>=0.14', 'six>=1.10.0', 'setuptools'])


### PR DESCRIPTION
We heavily depend on setuptools, let's add it to "install_requires".

Addresses: https://github.com/avocado-framework/avocado/issues/1798
Note: it's already required in RPM spec file.