### PR TITLE
Python 3: avoid leaking temporary files

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -597,5 +597,8 @@ class TestProgram(object):
             shutil.rmtree(self.job.logdir)
         sys.exit(exit_status)
 
+    def __del__(self):
+        data_dir.clean_tmp_files()
+
 
 main = TestProgram

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -393,11 +393,8 @@ class Test(unittest.TestCase, TestData):
 
         self.__runner_queue = runner_queue
 
-        basename = (os.path.basename(self.logdir).replace(':', '_')
-                    .replace(';', '_'))
-        self.__workdir = utils_path.init_dir(data_dir.get_tmp_dir(),
-                                             basename)
-        self.__srcdir = utils_path.init_dir(self.workdir, 'src')
+        self.__workdir = None
+        self.__srcdir = None
 
         if self.filename:
             self.log.debug("Test metadata:")
@@ -523,10 +520,17 @@ class Test(unittest.TestCase, TestData):
 
     @property
     def workdir(self):
+        if self.__workdir is None:
+            base_logdir = os.path.basename(self.logdir)
+            safe_base_logdir = base_logdir.replace(':', '_').replace(';', '_')
+            self.__workdir = os.path.join(data_dir.get_tmp_dir(),
+                                          safe_base_logdir)
         return self.__workdir
 
     @property
     def srcdir(self):
+        if self.__srcdir is None:
+            self.__srcdir = utils_path.init_dir(self.workdir, 'src')
         return self.__srcdir
 
     @property


### PR DESCRIPTION
It was noticed that when running the full set of functional tests on Python 3 that 10 directories where leaked (some with extra files):

10 directories get left out:

```
$ inotifywatch -e create,delete /tmp 
Establishing watches...
Finished establishing watches, now collecting statistics.
^Ctotal  create  delete  filename
566    288     278     /tmp/

$ ls -1d avocado_*
avocado_0wkvc511
avocado_4_b5c3t7
avocado_8ll0n0me
avocado_9apb4zwz
avocado_9zg8jv_l
avocado_bq749f_t
avocado_ieli0ydf
avocado_o3i810ri
avocado_xfj81asc
avocado_z6tgawwk
```

The two fixes here avoid this leakage.