### PR TITLE
glib: remove legacy check

### DIFF
--- a/optional_plugins/glib/avocado_glib/__init__.py
+++ b/optional_plugins/glib/avocado_glib/__init__.py
@@ -90,10 +90,6 @@ class GLibLoader(loader.TestLoader):
 
         for test in result.stdout.splitlines():
             test_name = "%s:%s" % (reference, test)
-            for item in avocado_suite:
-                if item[1]['name'] == test_name:
-                    raise ValueError
-
             if subtests_filter and not subtests_filter.search(test_name):
                 continue
             avocado_suite.append((GLibTest, {'name': test_name}))


### PR DESCRIPTION
This check was introduced in the previous draft of this plugin, when it
was using gtester, and left over. Dropping.

Signed-off-by: Amador Pahim <apahim@redhat.com>