### PR TITLE
Adapt optional_plugins to SimpleTest changes

### DIFF
--- a/optional_plugins/glib/avocado_glib/__init__.py
+++ b/optional_plugins/glib/avocado_glib/__init__.py
@@ -32,21 +32,23 @@ class GLibTest(test.SimpleTest):
     Run a GLib test command as a SIMPLE test.
     """
 
-    def __init__(self, name, params=None, base_logdir=None, job=None):
-        super(GLibTest, self).__init__(name, params, base_logdir, job)
+    def __init__(self, name, params=None, base_logdir=None, job=None,
+                 executable=None):
+        super(GLibTest, self).__init__(name, params, base_logdir, job,
+                                       executable)
 
     @property
     def filename(self):
         """
         Returns the path of the GLib test suite.
         """
-        return self.name.name.split(':')[0]
+        return self._filename.split(':')[0]
 
     def test(self):
         """
         Create the GLib command and execute it.
         """
-        test_name = self.name.name.split(':')[1]
+        test_name = self._filename.split(':')[1]
         cmd = '%s -p=%s' % (self.filename, test_name)
         result = process.run(cmd, ignore_status=True)
         if result.exit_status != 0:
@@ -85,7 +87,8 @@ class GLibLoader(loader.TestLoader):
             result = process.run(cmd)
         except Exception as details:
             if which_tests == loader.ALL:
-                return [(NotGLibTest, {"name": "%s: %s" % (reference, details)})]
+                return [(NotGLibTest,
+                         {"name": "%s: %s" % (reference, details)})]
             return []
 
         for test in result.stdout.splitlines():
@@ -96,7 +99,8 @@ class GLibLoader(loader.TestLoader):
 
             if subtests_filter and not subtests_filter.search(test_name):
                 continue
-            avocado_suite.append((GLibTest, {'name': test_name}))
+            avocado_suite.append((GLibTest, {'name': test_name,
+                                             'executable': test_name}))
 
         if which_tests is loader.ALL and not avocado_suite:
             return [(NotGLibTest,

--- a/optional_plugins/golang/avocado_golang/__init__.py
+++ b/optional_plugins/golang/avocado_golang/__init__.py
@@ -42,12 +42,10 @@ class GolangTest(test.SimpleTest):
     Run a Golang Test command as a SIMPLE test.
     """
 
-    def __init__(self, name,
-                 params=None,
-                 base_logdir=None,
-                 job=None,
-                 subtest=None):
-        super(GolangTest, self).__init__(name, params, base_logdir, job)
+    def __init__(self, name, params=None, base_logdir=None, job=None,
+                 subtest=None, executable=None):
+        super(GolangTest, self).__init__(name, params, base_logdir, job,
+                                         executable)
         self.subtest = subtest
 
     @property
@@ -55,7 +53,7 @@ class GolangTest(test.SimpleTest):
         """
         Returns the path of the golang test suite.
         """
-        return self.name.name.split(':')[0]
+        return self._filename.split(':')[0]
 
     def test(self):
         """
@@ -64,7 +62,7 @@ class GolangTest(test.SimpleTest):
         if _GO_BIN is None:
             raise exceptions.TestError("go binary not found")
 
-        test_name = '%s$' % self.name.name.split(':')[1]
+        test_name = '%s$' % self._filename.split(':')[1]
         if self.subtest is not None:
             test_name += '/%s' % self.subtest
 
@@ -120,7 +118,8 @@ class GolangLoader(loader.TestLoader):
                 if tests_filter and not tests_filter.search(test_name):
                     continue
                 avocado_suite.append((GolangTest, {'name': test_name,
-                                                   'subtest': subtest}))
+                                                   'subtest': subtest,
+                                                   'executable': test_name}))
 
             return avocado_suite or self._no_tests(which_tests, url,
                                                    'No test matching this '
@@ -134,7 +133,8 @@ class GolangLoader(loader.TestLoader):
                     if tests_filter and not tests_filter.search(test_name):
                         continue
                     avocado_suite.append((GolangTest, {'name': test_name,
-                                                       'subtest': subtest}))
+                                                       'subtest': subtest,
+                                                       'executable': test_name}))
 
             return avocado_suite or self._no_tests(which_tests, url,
                                                    'No test matching this '
@@ -173,7 +173,8 @@ class GolangLoader(loader.TestLoader):
                         continue
                     avocado_suite.append((GolangTest,
                                           {'name': test_name,
-                                           'subtest': subtest}))
+                                           'subtest': subtest,
+                                           'executable': test_name}))
 
         return avocado_suite or self._no_tests(which_tests, url,
                                                'No test matching this '

--- a/optional_plugins/robot/avocado_robot/__init__.py
+++ b/optional_plugins/robot/avocado_robot/__init__.py
@@ -39,21 +39,23 @@ class RobotTest(test.SimpleTest):
                  name,
                  params=None,
                  base_logdir=None,
-                 job=None):
-        super(RobotTest, self).__init__(name, params, base_logdir, job)
+                 job=None,
+                 executable=None):
+        super(RobotTest, self).__init__(name, params, base_logdir, job,
+                                        executable)
 
     @property
     def filename(self):
         """
         Returns the path of the robot test suite.
         """
-        return self.name.name.split(':')[0]
+        return self._filename.split(':')[0]
 
     def test(self):
         """
         Create the Robot command and execute it.
         """
-        suite_name, test_name = self.name.name.split(':')[1].split('.')
+        suite_name, test_name = self._filename.split(':')[1].split('.')
         log_stdout = output.LoggingFile(loggers=[self.log], level=logging.INFO)
         log_stderr = output.LoggingFile(loggers=[self.log], level=logging.ERROR)
         result = run(self.filename,
@@ -110,7 +112,8 @@ class RobotLoader(loader.TestLoader):
                                           robot_test['test_name'])
                 if subtests_filter and not subtests_filter.search(test_name):
                     continue
-                avocado_suite.append((RobotTest, {'name': test_name}))
+                avocado_suite.append((RobotTest, {'name': test_name,
+                                                  'executable': test_name}))
         if which_tests is loader.ALL and not avocado_suite:
             return [(NotRobotTest, {"name": "%s: No robot-like tests found"
                                     % url})]


### PR DESCRIPTION
Now there's a new parameter `executable` to use as the command line
information. The previous parameter, `name` can now be hijacked by
the yaml_loader, so this PR addresses that change in all the affected
optional_plugins.