### PR TITLE
Minorfix: Fix the install requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -107,5 +107,5 @@ if __name__ == '__main__':
               },
           zip_safe=False,
           test_suite='selftests',
-          python_requires='>=2.7, >=3.4',
+          python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
           install_requires=['stevedore>=0.14', 'six>=1.10.0', 'setuptools'])


### PR DESCRIPTION
To fix the pip 9.0.1 install python requirements with ">=2.7, >=3.4" failure,
">=2.7, >=3.4" means ">=2.7" and ">=3.4", so the result is ">=3.4"
for reference: https://stackoverflow.com/questions/44660448/

Signed-off-by: Junxiang Li <junli@redhat.com>