### PR TITLE
avocado/core/data_dir: initialize with basedir configurable

### DIFF
--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -201,9 +201,9 @@ def create_job_logs_dir(base_dir=None, unique_id=None):
 
 class _TmpDirTracker(Borg):
 
-    def __init__(self):
+    def __init__(self, basedir=None):
         Borg.__init__(self)
-        self.basedir = None
+        self.basedir = basedir
 
     def get(self, basedir):
         if not hasattr(self, 'tmp_dir'):


### PR DESCRIPTION
using get_tmp_dir() with basedir param have no effect as it always initialized
to None, allow basedir to be initialized as configurable param

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>