### PR TITLE
BUG: optional_plugins.loader_yaml: Avoid corrupting of extra_params

### DIFF
--- a/optional_plugins/loader_yaml/avocado_loader_yaml/__init__.py
+++ b/optional_plugins/loader_yaml/avocado_loader_yaml/__init__.py
@@ -89,6 +89,8 @@ class YamlTestsuiteLoader(loader.TestLoader):
             for key, value in iteritems(_args):
                 setattr(args, key, value)
         extra_params = params.get("test_reference_resolver_extra", default={})
+        if extra_params:
+            extra_params = copy.deepcopy(extra_params)
         return loader_class(args, extra_params)
 
     def discover(self, reference, which_tests=loader.DEFAULT):


### PR DESCRIPTION
The `extra_params` is a mutable object and can be modified by loader.
This happens eg. in external_runner loader which removes the optional
key. This patch uses `copy.deepcopy` to avoid such issues.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>