### PR TITLE
avocado-check-pr.sh: pin GitHub API version

### DIFF
--- a/contrib/scripts/avocado-check-pr.sh
+++ b/contrib/scripts/avocado-check-pr.sh
@@ -60,10 +60,10 @@ set_status() {
     data="\"state\": \"$status\", \"description\": \"$description\", \"context\": \"manual/$GITHUB_USER\""
     [ "$result_url" ] && data+=", \"target_url\": \"$result_url\""
     if [ "$DEBUG" ]; then
-        echo curl -u $GITHUB_USER:$GITHUB_TOKEN --data "{$data}" "$base_url/statuses/$commit"
-        [ "$DRY" ] || curl -u $GITHUB_USER:$GITHUB_TOKEN --data "{$data}" "$base_url/statuses/$commit"
+        echo curl -u $GITHUB_USER:$GITHUB_TOKEN --data "{$data}" -H "Accept: application/vnd.github.v3+json" "$base_url/statuses/$commit"
+        [ "$DRY" ] || curl -u $GITHUB_USER:$GITHUB_TOKEN --data "{$data}" -H "Accept: application/vnd.github.v3+json" "$base_url/statuses/$commit"
     else
-        [ "$DRY" ] || curl -u $GITHUB_USER:$GITHUB_TOKEN --data "{$data}" "$base_url/statuses/$commit" &>/dev/null
+        [ "$DRY" ] || curl -u $GITHUB_USER:$GITHUB_TOKEN --data "{$data}" -H "Accept: application/vnd.github.v3+json" "$base_url/statuses/$commit" &>/dev/null
     fi
 }
 


### PR DESCRIPTION
To avoid breakage when newer versions come out, let's pin to current
GitHub API version to v3.

Reference: https://developer.github.com/v3/media/#request-specific-version
Signed-off-by: Cleber Rosa <crosa@redhat.com>