### PR TITLE
DataSize: force values to be integers on Python 3

### DIFF
--- a/avocado/utils/data_structures.py
+++ b/avocado/utils/data_structures.py
@@ -297,8 +297,8 @@ class DataSize(object):
         """
         if attr not in self.MULTIPLIERS:
             raise AttributeError('Attribute %s does not exist.' % attr)
-        return (self.value * self.MULTIPLIERS[self.unit] /
-                self.MULTIPLIERS[attr])
+        return int(self.value * self.MULTIPLIERS[self.unit] /
+                   self.MULTIPLIERS[attr])
 
     def __dir__(self):
         """

--- a/selftests/unit/test_data_structures.py
+++ b/selftests/unit/test_data_structures.py
@@ -105,9 +105,11 @@ class TestDataSize(unittest.TestCase):
         self.assertRaises(data_structures.InvalidDataSize,
                           data_structures.DataSize, '10Mb')
 
+    def test_value_and_type(self):
+        self.assertIs(data_structures.DataSize('0b').b, 0)
+        self.assertIs(data_structures.DataSize('0t').b, 0)
+
     def test_values(self):
-        self.assertEqual(data_structures.DataSize('0b').b, 0)
-        self.assertEqual(data_structures.DataSize('0t').b, 0)
         self.assertEqual(data_structures.DataSize('10m').b, 10485760)
         self.assertEqual(data_structures.DataSize('10M').b, 10485760)
 


### PR DESCRIPTION
On Python 3, the calculation of a value for a unit will return
a float.  Let's make things predictable accross Python 2 and 3
and force an integer instead.

Reference: https://github.com/avocado-framework/avocado/pull/2498
Signed-off-by: Cleber Rosa <crosa@redhat.com>