### PR TITLE
BUG: Avoid crash when SimpleTest produces utf-8 characters

### DIFF
--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -307,6 +307,9 @@ class CmdResult(object):
         self.pid = pid
         if encoding is None:
             encoding = sys.getdefaultencoding()
+            if PY2 and encoding == "ascii":
+                # python2 fails to getdefaultencoding, let's assume utf-8
+                encoding = "utf-8"
         self.encoding = encoding
 
     @property

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -32,6 +32,7 @@ import threading
 import time
 
 from io import BytesIO
+from six import PY2
 from six import string_types
 
 from . import gdb
@@ -99,10 +100,24 @@ class CmdError(Exception):
             return "CmdError"
 
 
+def normalize_cmd(cmd):
+    """
+    Normalize cmd to be safe for ``shlex.split``
+    """
+    if PY2:
+        if not isinstance(cmd, str):
+            cmd = cmd.encode("utf-8")
+    else:
+        if isinstance(cmd, bytes):
+            cmd = cmd.decode("utf-8")
+    return cmd
+
+
 def can_sudo(cmd=None):
     """
     Check whether sudo is available (or running as root)
     """
+    cmd = normalize_cmd(cmd)
     if os.getuid() == 0:    # Root
         return True
 
@@ -242,6 +257,7 @@ def binary_from_shell_cmd(cmd):
     :param cmd: simple shell-like binary
     :return: first found binary from the cmd
     """
+    cmd = normalize_cmd(cmd)
     try:
         cmds = shlex.split(cmd)
     except ValueError:
@@ -478,6 +494,7 @@ class SubProcess(object):
                     to be running after the process finishes.
         :raises: ValueError if incorrect values are given to parameters
         """
+        cmd = normalize_cmd(cmd)
         if sudo:
             self.cmd = self._prepend_sudo(cmd, shell)
         else:
@@ -854,7 +871,7 @@ class GDBSubProcess(object):
                      implementation, since the GDB wrapping code does not have
                      support to run commands in that way.
         """
-
+        cmd = normalize_cmd(cmd)
         self.cmd = cmd
 
         self.args = shlex.split(cmd)
@@ -1188,6 +1205,7 @@ def get_sub_process_klass(cmd):
 
     :param cmd: the command arguments, from where we extract the binary name
     """
+    cmd = normalize_cmd(cmd)
     if should_run_inside_gdb(cmd):
         return GDBSubProcess
     elif should_run_inside_wrapper(cmd):

--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -23,6 +23,7 @@ def probe_binary(binary):
 
 
 TRUE_CMD = probe_binary('true')
+ECHO_CMD = probe_binary('echo')
 
 
 class TestSubProcess(unittest.TestCase):
@@ -249,6 +250,16 @@ class TestProcessRun(unittest.TestCase):
         expected_command = 'ls -l'
         p = process.run(cmd='ls -l', sudo=True, shell=True, ignore_status=True)
         self.assertEqual(p.command, expected_command)
+
+    @unittest.skipUnless(ECHO_CMD, "Echo command not available in system")
+    def test_run_unicode_output(self):
+        # Using encoded string as shlex does not support decoding
+        # but the behavior is exactly the same as if shell binary
+        # produced unicode
+        text = u"Avok\xe1do"
+        result = process.run("%s %s" % (ECHO_CMD, text))
+        self.assertEqual(result.stdout, text.encode('utf-8') + b'\n')
+        self.assertEqual(result.stdout_text, text + '\n')
 
 
 class MiscProcessTests(unittest.TestCase):

--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -15,7 +15,14 @@ from avocado.utils import path
 from six import string_types
 
 
-TRUE_CMD = path.find_command('true')
+def probe_binary(binary):
+    try:
+        return path.find_command(binary)
+    except path.CmdNotFoundError:
+        return None
+
+
+TRUE_CMD = probe_binary('true')
 
 
 class TestSubProcess(unittest.TestCase):
@@ -56,6 +63,8 @@ class TestGDBProcess(unittest.TestCase):
         self.assertFalse(process.should_run_inside_gdb("foo bar baz"))
         self.assertFalse(process.should_run_inside_gdb("foo ' "))
 
+    @unittest.skipUnless(TRUE_CMD,
+                         '"echo" binary not available')
     def test_get_sub_process_klass(self):
         gdb.GDB_RUN_BINARY_NAMES_EXPR = []
         self.assertIs(process.get_sub_process_klass(TRUE_CMD),
@@ -91,6 +100,8 @@ def mock_fail_find_cmd(cmd, default=None):
 
 class TestProcessRun(unittest.TestCase):
 
+    @unittest.skipUnless(TRUE_CMD,
+                         '"echo" binary not available')
     @mock.patch.object(path, 'find_command',
                        mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid',
@@ -100,6 +111,8 @@ class TestProcessRun(unittest.TestCase):
         p = process.SubProcess(cmd='ls -l')
         self.assertEqual(p.cmd, expected_command)
 
+    @unittest.skipUnless(TRUE_CMD,
+                         '"echo" binary not available')
     @mock.patch.object(path, 'find_command',
                        mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid', mock.Mock(return_value=0))
@@ -108,6 +121,8 @@ class TestProcessRun(unittest.TestCase):
         p = process.SubProcess(cmd='ls -l')
         self.assertEqual(p.cmd, expected_command)
 
+    @unittest.skipUnless(TRUE_CMD,
+                         '"echo" binary not available')
     @mock.patch.object(path, 'find_command',
                        mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid',
@@ -124,6 +139,8 @@ class TestProcessRun(unittest.TestCase):
         p = process.SubProcess(cmd='ls -l', sudo=True)
         self.assertEqual(p.cmd, expected_command)
 
+    @unittest.skipUnless(TRUE_CMD,
+                         '"echo" binary not available')
     @mock.patch.object(path, 'find_command',
                        mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid', mock.Mock(return_value=0))
@@ -132,6 +149,8 @@ class TestProcessRun(unittest.TestCase):
         p = process.SubProcess(cmd='ls -l', sudo=True)
         self.assertEqual(p.cmd, expected_command)
 
+    @unittest.skipUnless(TRUE_CMD,
+                         '"echo" binary not available')
     @mock.patch.object(path, 'find_command',
                        mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid', mock.Mock(return_value=1000))
@@ -147,6 +166,8 @@ class TestProcessRun(unittest.TestCase):
         p = process.SubProcess(cmd='ls -l', sudo=True, shell=True)
         self.assertEqual(p.cmd, expected_command)
 
+    @unittest.skipUnless(TRUE_CMD,
+                         '"echo" binary not available')
     @mock.patch.object(path, 'find_command',
                        mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid', mock.Mock(return_value=0))
@@ -155,6 +176,8 @@ class TestProcessRun(unittest.TestCase):
         p = process.SubProcess(cmd='ls -l', sudo=True, shell=True)
         self.assertEqual(p.cmd, expected_command)
 
+    @unittest.skipUnless(TRUE_CMD,
+                         '"echo" binary not available')
     @mock.patch.object(path, 'find_command',
                        mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid', mock.Mock(return_value=1000))
@@ -163,6 +186,8 @@ class TestProcessRun(unittest.TestCase):
         p = process.run(cmd='ls -l', ignore_status=True)
         self.assertEqual(p.command, expected_command)
 
+    @unittest.skipUnless(TRUE_CMD,
+                         '"echo" binary not available')
     @mock.patch.object(path, 'find_command',
                        mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid', mock.Mock(return_value=0))
@@ -171,6 +196,8 @@ class TestProcessRun(unittest.TestCase):
         p = process.run(cmd='ls -l', ignore_status=True)
         self.assertEqual(p.command, expected_command)
 
+    @unittest.skipUnless(TRUE_CMD,
+                         '"echo" binary not available')
     @mock.patch.object(path, 'find_command',
                        mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid', mock.Mock(return_value=1000))
@@ -186,6 +213,8 @@ class TestProcessRun(unittest.TestCase):
         p = process.run(cmd='ls -l', sudo=True, ignore_status=True)
         self.assertEqual(p.command, expected_command)
 
+    @unittest.skipUnless(TRUE_CMD,
+                         '"echo" binary not available')
     @mock.patch.object(path, 'find_command',
                        mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid', mock.Mock(return_value=0))
@@ -194,6 +223,8 @@ class TestProcessRun(unittest.TestCase):
         p = process.run(cmd='ls -l', sudo=True, ignore_status=True)
         self.assertEqual(p.command, expected_command)
 
+    @unittest.skipUnless(TRUE_CMD,
+                         '"echo" binary not available')
     @mock.patch.object(path, 'find_command',
                        mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid', mock.Mock(return_value=1000))
@@ -209,6 +240,8 @@ class TestProcessRun(unittest.TestCase):
         p = process.run(cmd='ls -l', sudo=True, shell=True, ignore_status=True)
         self.assertEqual(p.command, expected_command)
 
+    @unittest.skipUnless(TRUE_CMD,
+                         '"echo" binary not available')
     @mock.patch.object(path, 'find_command',
                        mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid', mock.Mock(return_value=0))


### PR DESCRIPTION
Avocado crashes when SimpleTest produces non-ascii characters. Simple reproducer is:

```
$ echo "#!/bin/sh" > a.sh
$ echo "echo ěčřž" >> a.sh
$ chmod +x a.sh
$ avocado run a.sh
```

Additionally I had to add a commit to "normalize" cmd format because PY2 shlex does not support unicode and PY3 shlex can't read bytes. Alternative would be https://pypi.python.org/pypi/ushlex/ but I wanted to avoid yet another dependency...