### PR TITLE
Selftests and misc fixes (9th batch) [v2]

### DIFF
--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -200,6 +200,21 @@ class TreeNode(object):
         """ Inverted eq """
         return not self == other
 
+    def __hash__(self):
+        values = []
+        for item in self.value:
+            try:
+                values.append(hash(item))
+            except TypeError:
+                values.append(hash(str(item)))
+        children = []
+        for item in self.children:
+            try:
+                children.append(hash(item))
+            except TypeError:
+                children.append(hash(str(item)))
+        return hash((self.name, ) + tuple(values) + tuple(children))
+
     def fingerprint(self):
         """
         Reports string which represents the value of this node.

--- a/optional_plugins/varianter_yaml_to_mux/tests/test_mux.py
+++ b/optional_plugins/varianter_yaml_to_mux/tests/test_mux.py
@@ -228,9 +228,18 @@ class TestMuxTree(unittest.TestCase):
         variant1 = next(iter(mux1))
         variant2 = next(iter(mux2))
         self.assertNotEqual(variant1, variant2)
-        self.assertEqual(str(variant1), "{'paths': '', 'variant': "
-                         "[TreeNode(name='child1'), TreeNode(name="
-                         "'child2')], 'variant_id': 'child1-child2-9154'}")
+        str_variant = str(variant1)
+        variant_list = []
+        for item in variant1:
+            variant_list.append("'%s': '%s'" % (item, variant1[item]))
+        expected_items = ["'paths': ''",
+                          "'variant': '[TreeNode(name='child1'), "
+                          "TreeNode(name='child2')]'",
+                          "'variant_id': 'child1-child2-9154'"]
+        for item in expected_items:
+            self.assertIn(item, variant_list)
+            variant_list.remove(item)
+        self.assertFalse(variant_list)
 
 
 class TestMultiplex(unittest.TestCase):

--- a/selftests/functional/test_json_variants.py
+++ b/selftests/functional/test_json_variants.py
@@ -21,14 +21,16 @@ class VariantsDumpLoadTests(unittest.TestCase):
         os.chdir(basedir)
 
     def test_variants_dump(self):
-        content = ('[{"paths": ["/run/*"], '
-                   '"variant": [["/", []]], '
-                   '"variant_id": null}]')
         cmd_line = ('%s variants --json-variants-dump %s' %
                     (AVOCADO, self.variants_file))
         process.run(cmd_line)
         with open(self.variants_file, 'r') as file_obj:
-            self.assertEqual(file_obj.read(), content)
+            file_content = file_obj.read()
+            self.assertEqual(file_content[0:2], '[{')
+            self.assertIn('"paths": ["/run/*"]', file_content)
+            self.assertIn('"variant": [["/", []]]', file_content)
+            self.assertIn('"variant_id": null', file_content)
+            self.assertEqual(file_content[-2:], '}]')
 
     def test_run_load(self):
         content = ('[{"paths": ["/run/*"],'


### PR DESCRIPTION
This is the ninth batch (not a v9) of miscellaneous test (and other) fixes, mostly necessary for the Python 3 port.

---

Changes from v1 (#2484):
 * Changed `test_fingerprint_order` to also detect no extra content exists (suggested by @apahim )