### PR TITLE
Misc avocado.Test improvements [v2]

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -394,7 +394,8 @@ class Test(unittest.TestCase, TestData):
 
         self.__runner_queue = runner_queue
 
-        self.__workdir = None
+        self.__workdir = os.path.join(data_dir.get_tmp_dir(),
+                                      self.name.str_filesystem)
         self.__srcdir_internal_access = False
         self.__srcdir_warning_logged = False
         self.__srcdir = None
@@ -531,9 +532,6 @@ class Test(unittest.TestCase, TestData):
 
     @property
     def workdir(self):
-        if self.__workdir is None:
-            self.__workdir = os.path.join(data_dir.get_tmp_dir(),
-                                          self.name.str_filesystem)
         return self.__workdir
 
     @property

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -399,9 +399,17 @@ class Test(unittest.TestCase, TestData):
         self.__srcdir_warning_logged = False
         self.__srcdir = None
 
+        self.log.debug("Test metadata:")
         if self.filename:
-            self.log.debug("Test metadata:")
             self.log.debug("  filename: %s", self.filename)
+        try:
+            teststmpdir = self.teststmpdir
+        except EnvironmentError:
+            pass
+        else:
+            self.log.debug("  teststmpdir: %s", self.teststmpdir)
+        self.log.debug("  workdir: %s", self.workdir)
+
         unittest.TestCase.__init__(self, methodName=methodName)
         TestData.__init__(self)
 

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -369,6 +369,8 @@ class Test(unittest.TestCase, TestData):
         self.__log_warn_used = False
         self.log.warn = self.log.warning = record_and_warn
 
+        self.log.info('INIT %s', self.name)
+
         paths = ['/test/*']
         if params is None:
             params = []
@@ -378,8 +380,6 @@ class Test(unittest.TestCase, TestData):
                                                  self.__log.name)
         default_timeout = getattr(self, "timeout", None)
         self.timeout = self.params.get("timeout", default=default_timeout)
-
-        self.log.info('START %s', self.name)
 
         self.__status = None
         self.__fail_reason = None
@@ -608,6 +608,7 @@ class Test(unittest.TestCase, TestData):
         return "Test(%r)" % self.name
 
     def _tag_start(self):
+        self.log.info('START %s', self.name)
         self.__running = True
         self.time_start = time.time()
 

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -532,10 +532,8 @@ class Test(unittest.TestCase, TestData):
     @property
     def workdir(self):
         if self.__workdir is None:
-            base_logdir = os.path.basename(self.logdir)
-            safe_base_logdir = base_logdir.replace(':', '_').replace(';', '_')
             self.__workdir = os.path.join(data_dir.get_tmp_dir(),
-                                          safe_base_logdir)
+                                          self.name.str_filesystem)
         return self.__workdir
 
     @property

--- a/selftests/unit/test_test.py
+++ b/selftests/unit/test_test.py
@@ -90,7 +90,7 @@ class TestClassTestUnit(unittest.TestCase):
         tst = check("a" * 255, "whatever", {"variant_id": "whatever-else"},
                     "a" * 255)
         # Impossible to store (uid does not fit
-        self.assertRaises(AssertionError, check, "a" * 256, "whatever",
+        self.assertRaises(RuntimeError, check, "a" * 256, "whatever",
                           {"variant_id": "else"}, None)
 
         self.assertEqual(os.path.basename(tst.workdir),
@@ -347,7 +347,7 @@ class TestID(unittest.TestCase):
         raised.
         """
         test_id = test.TestID(1, 'test', no_digits=256)
-        self.assertRaises(AssertionError, lambda: test_id.str_filesystem)
+        self.assertRaises(RuntimeError, lambda: test_id.str_filesystem)
 
     def test_uid_large_name(self):
         """


### PR DESCRIPTION
A small collection of miscellaneous `avocado.Test` improvements.

---

Changes from v1 (#2506):
 * Use `RuntimeError` instead of `ValueError`
 * New commits:
   * `Test: rely on TestId.str_filesystem for the workdir`
   * `Test: initialize workdir early in non-lazy mode`
 * Some properties have **not** being converted to non-lazy mode, according to the issues described at: https://trello.com/c/SNIYpFS7/1278-avocadotest-optimize-some-properties