### PR TITLE
Test: deprecate srcdir [v2]

### DIFF
--- a/docs/source/DebuggingWithGDB.rst
+++ b/docs/source/DebuggingWithGDB.rst
@@ -165,7 +165,7 @@ Take a look at ``examples/tests/modify_variable.py`` test::
         """
         Execute 'print_variable'.
         """
-        path = os.path.join(self.srcdir, 'print_variable')
+        path = os.path.join(self.workdir, 'print_variable')
         app = gdb.GDB()
         app.set_file(path)
         app.set_break(6)

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -621,15 +621,15 @@ an example that does that::
             # Build the synctest suite
             self.cwd = os.getcwd()
             tarball_path = self.get_data(sync_tarball)
-            archive.extract(tarball_path, self.srcdir)
-            self.srcdir = os.path.join(self.srcdir, 'synctest')
-            build.make(self.srcdir)
+            archive.extract(tarball_path, self.workdir)
+            self.workdir = os.path.join(self.workdir, 'synctest')
+            build.make(self.workdir)
 
         def test(self):
             """
             Execute synctest with the appropriate params.
             """
-            os.chdir(self.srcdir)
+            os.chdir(self.workdir)
             cmd = ('./synctest %s %s' %
                    (self.sync_length, self.sync_loop))
             process.system(cmd)
@@ -677,7 +677,7 @@ inside the avocado ``data_dir`` location to put the fetched files in.
         def setUp(self):
             stress = 'http://people.seas.harvard.edu/~apw/stress/stress-1.0.4.tar.gz'
             tarball = self.fetch_asset(stress)
-            archive.extract(tarball, self.srcdir)
+            archive.extract(tarball, self.workdir)
     ...
 
   In this case, ``fetch_asset()`` will download the file from the url provided,
@@ -690,7 +690,7 @@ inside the avocado ``data_dir`` location to put the fetched files in.
         def setUp(self):
             stress = 'http://people.seas.harvard.edu/~apw/stress/stress-1.0.4.tar.gz'
             tarball = self.fetch_asset(stress)
-            archive.extract(tarball, self.srcdir)
+            archive.extract(tarball, self.workdir)
     ...
 
   In this case, we try to find ``stress-1.0.4.tar.gz`` file in ``/mnt/files``
@@ -708,7 +708,7 @@ inside the avocado ``data_dir`` location to put the fetched files in.
                       'ftp://foo.bar/stress-1.0.4.tar.gz']
             tarball = self.fetch_asset(st_name, asset_hash=st_hash,
                                        locations=st_loc)
-            archive.extract(tarball, self.srcdir)
+            archive.extract(tarball, self.workdir)
     ...
 
   In this case, we try to download ``stress-1.0.4.tar.gz`` from the provided
@@ -1669,8 +1669,6 @@ tests:
 +-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
 | AVOCADO_TEST_WORKDIR        | Work directory for the test           | /var/tmp/avocado_Bjr_rd/my_test.sh                                                                  |
 +-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
-| AVOCADO_TEST_SRCDIR         | Source directory for the test         | /var/tmp/avocado_Bjr_rd/my-test.sh/src                                                              |
-+-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
 | AVOCADO_TESTS_COMMON_TMPDIR | Temporary directory created by the    | /var/tmp/avocado_XhEdo/                                                                             |
 |                             | `teststmpdir` plugin. The directory   |                                                                                                     |
 |                             | is persistent throughout the tests    |                                                                                                     |
@@ -1686,6 +1684,11 @@ tests:
 +-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
 | `***`                       | All variables from --mux-yaml         | TIMEOUT=60; IO_WORKERS=10; VM_BYTES=512M; ...                                                       |
 +-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
+| AVOCADO_TEST_SRCDIR         | Source directory for the test         | /var/tmp/avocado_Bjr_rd/my-test.sh/src                                                              |
++-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
+
+.. warning:: ``AVOCADO_TEST_SRCDIR`` is deprecated and will be removed
+             soon.  Please use ``AVOCADO_TEST_WORKDIR`` instead.
 
 
 SIMPLE Tests BASH extensions

--- a/examples/tests/cabort.py
+++ b/examples/tests/cabort.py
@@ -26,9 +26,9 @@ class CAbort(Test):
         if c_file is None:
             self.cancel('Test is missing data file %s' % source)
         c_file_name = os.path.basename(c_file)
-        dest_c_file = os.path.join(self.srcdir, c_file_name)
+        dest_c_file = os.path.join(self.workdir, c_file_name)
         shutil.copy(c_file, dest_c_file)
-        build.make(self.srcdir,
+        build.make(self.workdir,
                    env={'CFLAGS': '-g -O0'},
                    extra_args='abort')
 
@@ -36,7 +36,7 @@ class CAbort(Test):
         """
         Execute 'abort'.
         """
-        cmd = os.path.join(self.srcdir, 'abort')
+        cmd = os.path.join(self.workdir, 'abort')
         cmd_result = process.run(cmd, ignore_status=True)
         self.log.info(cmd_result)
         expected_result = -6  # SIGABRT = 6

--- a/examples/tests/datadir.py
+++ b/examples/tests/datadir.py
@@ -26,9 +26,9 @@ class DataDirTest(Test):
         if c_file is None:
             self.cancel('Test is missing data file %s' % source)
         c_file_name = os.path.basename(c_file)
-        dest_c_file = os.path.join(self.srcdir, c_file_name)
+        dest_c_file = os.path.join(self.workdir, c_file_name)
         shutil.copy(c_file, dest_c_file)
-        build.make(self.srcdir,
+        build.make(self.workdir,
                    env={'CFLAGS': '-g -O0'},
                    extra_args='datadir')
 
@@ -36,7 +36,7 @@ class DataDirTest(Test):
         """
         Execute 'datadir'.
         """
-        cmd = os.path.join(self.srcdir, 'datadir')
+        cmd = os.path.join(self.workdir, 'datadir')
         cmd_result = process.run(cmd)
         self.log.info(cmd_result)
 

--- a/examples/tests/doublefree.py
+++ b/examples/tests/doublefree.py
@@ -29,9 +29,9 @@ class DoubleFreeTest(Test):
         if c_file is None:
             self.cancel('Test is missing data file %s' % source)
         c_file_name = os.path.basename(c_file)
-        dest_c_file = os.path.join(self.srcdir, c_file_name)
+        dest_c_file = os.path.join(self.workdir, c_file_name)
         shutil.copy(c_file, dest_c_file)
-        build.make(self.srcdir,
+        build.make(self.workdir,
                    env={'CFLAGS': '-g -O0'},
                    extra_args='doublefree')
 
@@ -39,7 +39,7 @@ class DoubleFreeTest(Test):
         """
         Execute 'doublefree'.
         """
-        cmd = os.path.join(self.srcdir, 'doublefree')
+        cmd = os.path.join(self.workdir, 'doublefree')
         cmd_result = process.run(cmd, ignore_status=True,
                                  env={'MALLOC_CHECK_': '1'})
         self.log.info(cmd_result)

--- a/examples/tests/doublefree_nasty.py
+++ b/examples/tests/doublefree_nasty.py
@@ -29,9 +29,9 @@ class DoubleFreeTest(Test):
         c_file = self.get_data(source)
         if c_file is None:
             self.cancel('Test is missing data file %s' % source)
-        shutil.copy(c_file, self.srcdir)
+        shutil.copy(c_file, self.workdir)
         self.__binary = source.rsplit('.', 1)[0]
-        build.make(self.srcdir,
+        build.make(self.workdir,
                    env={'CFLAGS': '-g -O0'},
                    extra_args=self.__binary)
 
@@ -39,7 +39,7 @@ class DoubleFreeTest(Test):
         """
         Execute 'doublefree'.
         """
-        cmd = os.path.join(self.srcdir, self.__binary)
+        cmd = os.path.join(self.workdir, self.__binary)
         cmd_result = process.run(cmd)
         self.log.info(cmd_result)
 

--- a/examples/tests/env_variables.sh
+++ b/examples/tests/env_variables.sh
@@ -5,6 +5,7 @@ echo "Avocado Version: $AVOCADO_VERSION"
 echo "Avocado Test basedir: $AVOCADO_TEST_BASEDIR"
 echo "Avocado Test datadir: $AVOCADO_TEST_DATADIR"
 echo "Avocado Test workdir: $AVOCADO_TEST_WORKDIR"
+# Warning: srcdir is deprecated and will be removed soon
 echo "Avocado Test srcdir: $AVOCADO_TEST_SRCDIR"
 echo "Avocado Test logdir: $AVOCADO_TEST_LOGDIR"
 echo "Avocado Test logfile: $AVOCADO_TEST_LOGFILE"

--- a/examples/tests/linuxbuild.py
+++ b/examples/tests/linuxbuild.py
@@ -26,7 +26,7 @@ class LinuxBuildTest(Test):
 
         self.linux_build = kernel.KernelBuild(kernel_version,
                                               linux_config,
-                                              self.srcdir,
+                                              self.workdir,
                                               self.cache_dirs)
         self.linux_build.download()
         self.linux_build.uncompress()

--- a/examples/tests/modify_variable.py
+++ b/examples/tests/modify_variable.py
@@ -32,9 +32,9 @@ class PrintVariableTest(Test):
         c_file = self.get_data(source)
         if c_file is None:
             self.cancel('Test is missing data file %s' % source)
-        shutil.copy(c_file, self.srcdir)
+        shutil.copy(c_file, self.workdir)
         self.__binary = source.rsplit('.', 1)[0]
-        build.make(self.srcdir,
+        build.make(self.workdir,
                    env={'CFLAGS': '-g -O0'},
                    extra_args=self.__binary)
 
@@ -42,7 +42,7 @@ class PrintVariableTest(Test):
         """
         Execute 'print_variable'.
         """
-        path = os.path.join(self.srcdir, self.__binary)
+        path = os.path.join(self.workdir, self.__binary)
         app = gdb.GDB()
         app.set_file(path)
         app.set_break(6)

--- a/examples/tests/raise.py
+++ b/examples/tests/raise.py
@@ -27,9 +27,9 @@ class Raise(Test):
         if c_file is None:
             self.cancel('Test is missing data file %s' % source)
         c_file_name = os.path.basename(c_file)
-        dest_c_file = os.path.join(self.srcdir, c_file_name)
+        dest_c_file = os.path.join(self.workdir, c_file_name)
         shutil.copy(c_file, dest_c_file)
-        build.make(self.srcdir,
+        build.make(self.workdir,
                    env={'CFLAGS': '-g -O0'},
                    extra_args='raise')
 
@@ -38,7 +38,7 @@ class Raise(Test):
         Execute 'raise'.
         """
         signum = self.params.get('signal_number', default=15)
-        cmd = os.path.join(self.srcdir, 'raise %d' % signum)
+        cmd = os.path.join(self.workdir, 'raise %d' % signum)
         cmd_result = process.run(cmd, ignore_status=True)
         self.log.info(cmd_result)
         if signum == 0:

--- a/examples/tests/synctest.py
+++ b/examples/tests/synctest.py
@@ -29,8 +29,8 @@ class SyncTest(Test):
         tarball_path = self.get_data(sync_tarball)
         if tarball_path is None:
             self.cancel('Test is missing data file %s' % tarball_path)
-        archive.extract(tarball_path, self.srcdir)
-        srcdir = os.path.join(self.srcdir, 'synctest')
+        archive.extract(tarball_path, self.workdir)
+        srcdir = os.path.join(self.workdir, 'synctest')
         os.chdir(srcdir)
         if self.params.get('debug_symbols', default=True):
             build.make(srcdir,


### PR DESCRIPTION
After much discussion, it was decided that `srcdir` must go, and
`workdir` should be used instead.  At this time, let's deprecate
it, and in the near future, remove it.

The deprecation approach chosen is to flag tests that use `srcdir`
with warning, so users will hopefully take notice.

Reference: https://github.com/avocado-framework/avocado/issues/1924
Reference: https://trello.com/c/U1aaJjPJ/1158-deprecate-testsrcdir
Reference: https://trello.com/c/dCcxhJc2/1267-remove-testsrcdir
Signed-off-by: Cleber Rosa <crosa@redhat.com>

---

Changes from v1 (#2501):
 * Produces test warnings on `srcdir` access
 * Added estimate date on removal
 * Moved the `AVOCADO_TEST_SRCDIR` environment variable documentation to the last position in the table, close to the deprecation warning.
