### PR TITLE
utils.process: FDDrainer.flush() check stream is open

### DIFF
--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -418,7 +418,7 @@ class FDDrainer(object):
                 # and other logging handlers (custom ones?) also have
                 # the same interface, so let's try to use it if available
                 stream = getattr(handler, 'stream', None)
-                if stream is not None:
+                if (stream is not None) and (not stream.closed):
                     os.fsync(stream.fileno())
                 if hasattr(handler, 'close'):
                     handler.close()


### PR DESCRIPTION
The method flush() in FDDrainer does not check the stream is open
before get its file descriptor, resulting in "ValueError: I/O operation
on closed file".

Changed flush() to check the stream is open, otherwise do not
try to flush.

Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>