### PR TITLE
FDDrainer: flush reliably with different stream loggers

### DIFF
--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -31,7 +31,7 @@ import sys
 import threading
 import time
 
-from io import BytesIO
+from io import BytesIO, UnsupportedOperation
 from six import string_types
 
 from . import gdb
@@ -419,7 +419,12 @@ class FDDrainer(object):
                 # the same interface, so let's try to use it if available
                 stream = getattr(handler, 'stream', None)
                 if (stream is not None) and (not stream.closed):
-                    os.fsync(stream.fileno())
+                    if hasattr(stream, 'fileno'):
+                        try:
+                            fileno = stream.fileno()
+                            os.fsync(fileno)
+                        except UnsupportedOperation:
+                            pass
                 if hasattr(handler, 'close'):
                     handler.close()
 

--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -1,3 +1,4 @@
+import io
 import logging
 import os
 import unittest
@@ -304,6 +305,38 @@ class FDDrainerTests(unittest.TestCase):
         self.assertEqual(fd_drainer.data.getvalue(),
                          b"should go to the log\n")
         self.assertTrue(handler.caught_record)
+
+    def test_flush_on_closed_handler(self):
+        handler = logging.StreamHandler(io.StringIO())
+        log = logging.getLogger("test_flush_on_closed_handler")
+        log.addHandler(handler)
+        read_fd, write_fd = os.pipe()
+        result = process.CmdResult()
+        fd_drainer = process.FDDrainer(read_fd, result, name="test",
+                                       stream_logger=log)
+        fd_drainer.start()
+        os.close(write_fd)
+        if fd_drainer._stream_logger is not None:
+            for handler in fd_drainer._stream_logger.handlers:
+                stream = getattr(handler, 'stream', None)
+                if stream is not None:
+                    if hasattr(stream, 'close'):
+                        # force closing the handler's stream to check if
+                        # flush will adapt to it
+                        stream.close()
+        fd_drainer.flush()
+
+    def test_flush_on_handler_with_no_fileno(self):
+        handler = logging.StreamHandler(io.StringIO())
+        log = logging.getLogger("test_flush_on_handler_with_no_fileno")
+        log.addHandler(handler)
+        read_fd, write_fd = os.pipe()
+        result = process.CmdResult()
+        fd_drainer = process.FDDrainer(read_fd, result, name="test",
+                                       stream_logger=log)
+        fd_drainer.start()
+        os.close(write_fd)
+        fd_drainer.flush()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The FDDrainer can fail to flush due to some other conditions,
including when the stream handler is a plain StreamHandler,
and not a FileHandler.

Let's add tests that cover this situation, and another one that's
already fixed that deals with closed streams.

Reference: https://github.com/avocado-framework/avocado/pull/2512
Signed-off-by: Cleber Rosa <crosa@redhat.com>