### PR TITLE
FDDrainer: flush reliably with different stream loggers [v2]

### DIFF
--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -31,7 +31,7 @@ import sys
 import threading
 import time
 
-from io import BytesIO
+from io import BytesIO, UnsupportedOperation
 from six import string_types
 
 from . import gdb
@@ -419,7 +419,12 @@ class FDDrainer(object):
                 # the same interface, so let's try to use it if available
                 stream = getattr(handler, 'stream', None)
                 if (stream is not None) and (not stream.closed):
-                    os.fsync(stream.fileno())
+                    if hasattr(stream, 'fileno'):
+                        try:
+                            fileno = stream.fileno()
+                            os.fsync(fileno)
+                        except UnsupportedOperation:
+                            pass
                 if hasattr(handler, 'close'):
                     handler.close()
 


### PR DESCRIPTION
The FDDrainer can fail to flush due to some other conditions,
including when the stream handler is a plain StreamHandler,
and not a FileHandler.

Let's add tests that cover this situation, and another one that's
already fixed that deals with closed streams.

Reference: https://github.com/avocado-framework/avocado/pull/2512
Signed-off-by: Cleber Rosa <crosa@redhat.com>

---

Changes from v1 (#2513):
 * Used `self.assertIsNotNone(fd_drainer._stream_logger)` to ensure the test condition (i.e. stream is closed) is granted
 * Ensured at least one handle has its stream closed before `flush()`
