### PR TITLE
Python 3: load JSON as supported on 3.4 (and earlier)

### DIFF
--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -269,7 +269,7 @@ class RunnerOperationTest(unittest.TestCase):
                               " --json -" % (AVOCADO, self.tmpdir, tst),
                               ignore_status=True)
             self.assertEqual(res.exit_status, exit_codes.AVOCADO_TESTS_FAIL)
-            results = json.loads(res.stdout)
+            results = json.loads(res.stdout_text)
             self.assertEqual(results["tests"][0]["status"], "ERROR",
                              "%s != %s\n%s" % (results["tests"][0]["status"],
                                                "ERROR", res))
@@ -288,7 +288,7 @@ class RunnerOperationTest(unittest.TestCase):
                               "--json - --job-timeout 1" % (AVOCADO, self.tmpdir, tst),
                               ignore_status=True)
             self.assertEqual(res.exit_status, exit_codes.AVOCADO_TESTS_FAIL)
-            results = json.loads(res.stdout)
+            results = json.loads(res.stdout_text)
             self.assertEqual(results["tests"][0]["status"], "ERROR",
                              "%s != %s\n%s" % (results["tests"][0]["status"],
                                                "ERROR", res))
@@ -310,7 +310,7 @@ class RunnerOperationTest(unittest.TestCase):
                               "--json -" % (AVOCADO, self.tmpdir, tst),
                               ignore_status=True)
             self.assertEqual(res.exit_status, exit_codes.AVOCADO_TESTS_FAIL)
-            results = json.loads(res.stdout)
+            results = json.loads(res.stdout_text)
             self.assertEqual(results["tests"][0]["status"], "ERROR",
                              "%s != %s\n%s" % (results["tests"][0]["status"],
                                                "ERROR", res))
@@ -477,7 +477,7 @@ class RunnerOperationTest(unittest.TestCase):
                     'passtest.py --json -' % (AVOCADO, self.tmpdir))
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
-        r = json.loads(result.stdout)
+        r = json.loads(result.stdout_text)
         int(r['job_id'], 16)  # it's an hex number
         self.assertEqual(len(r['job_id']), 40)
 
@@ -505,7 +505,7 @@ class RunnerOperationTest(unittest.TestCase):
         cmd = ("%s run --sysinfo=off passtest.py failtest.py "
                "gendata.py --json - --mux-inject foo:1 bar:2 baz:3 foo:foo:a"
                " foo:bar:b foo:baz:c bar:bar:bar --dry-run" % AVOCADO)
-        result = json.loads(process.run(cmd).stdout)
+        result = json.loads(process.run(cmd).stdout_text)
         debuglog = result['debuglog']
         log = genio.read_file(debuglog)
         # Remove the result dir
@@ -633,7 +633,7 @@ class RunnerHumanOutputTest(unittest.TestCase):
         cmd = ("%s run --job-results-dir %s --json - "
                "cancelonsetup.py" % (AVOCADO, self.tmpdir))
         result = process.run(cmd)
-        result = json.loads(result.stdout)
+        result = json.loads(result.stdout_text)
         jobid = str(result["job_id"])
         cmd = ("%s run --job-results-dir %s --replay %s "
                "--replay-test-status PASS" % (AVOCADO, self.tmpdir, jobid))
@@ -866,8 +866,8 @@ class RunnerSimpleTestStatus(unittest.TestCase):
         cmd_line = ('%s --config %s run --job-results-dir %s --sysinfo=off'
                     ' %s --json -' % (AVOCADO, self.config_file.path,
                                       self.tmpdir, warn_script.path))
-        result = process.system_output(cmd_line, ignore_status=True)
-        json_results = json.loads(result)
+        result = process.run(cmd_line, ignore_status=True)
+        json_results = json.loads(result.stdout_text)
         self.assertEquals(json_results['tests'][0]['status'], 'WARN')
         warn_script.remove()
 
@@ -879,8 +879,8 @@ class RunnerSimpleTestStatus(unittest.TestCase):
         cmd_line = ('%s --config %s run --job-results-dir %s --sysinfo=off'
                     ' %s --json -' % (AVOCADO, self.config_file.path,
                                       self.tmpdir, skip_script.path))
-        result = process.system_output(cmd_line, ignore_status=True)
-        json_results = json.loads(result)
+        result = process.run(cmd_line, ignore_status=True)
+        json_results = json.loads(result.stdout_text)
         self.assertEquals(json_results['tests'][0]['status'], 'SKIP')
         skip_script.remove()
 
@@ -1261,7 +1261,7 @@ class PluginsJSONTest(AbsPluginsTest, unittest.TestCase):
         if external_runner is not None:
             cmd_line += " --external-runner '%s'" % external_runner
         result = process.run(cmd_line, ignore_status=True)
-        json_output = result.stdout
+        json_output = result.stdout_text
         self.assertEqual(result.exit_status, e_rc,
                          "Avocado did not return rc %d:\n%s" %
                          (e_rc, result))

--- a/selftests/functional/test_journal.py
+++ b/selftests/functional/test_journal.py
@@ -23,7 +23,7 @@ class JournalPluginTests(unittest.TestCase):
                          '--journal examples/tests/passtest.py'
                          % (AVOCADO, self.tmpdir))
         self.result = process.run(self.cmd_line, ignore_status=True)
-        data = json.loads(self.result.stdout)
+        data = json.loads(self.result.stdout_text)
         self.job_id = data['job_id']
         jfile = os.path.join(os.path.dirname(data['debuglog']), '.journal.sqlite')
         self.db = sqlite3.connect(jfile)

--- a/selftests/functional/test_json_variants.py
+++ b/selftests/functional/test_json_variants.py
@@ -49,7 +49,7 @@ class VariantsDumpLoadTests(unittest.TestCase):
                     '--job-results-dir %s --json -' %
                     (AVOCADO, self.variants_file, self.tmpdir))
         result = process.run(cmd_line)
-        json_result = json.loads(result.stdout)
+        json_result = json.loads(result.stdout_text)
         self.assertEqual(json_result["pass"], 2)
         self.assertEqual(json_result["tests"][0]["id"],
                          "1-passtest.py:PassTest.test;foo-0ead")

--- a/selftests/functional/test_loader.py
+++ b/selftests/functional/test_loader.py
@@ -331,7 +331,7 @@ class LoaderTestFunctional(unittest.TestCase):
         cmd = ("%s run --sysinfo=off --job-results-dir %s --json - -- %s"
                % (AVOCADO, self.tmpdir, test_path))
         result = process.run(cmd, ignore_status=True)
-        jres = json.loads(result.stdout)
+        jres = json.loads(result.stdout_text)
         self.assertEqual(result.exit_status, 1, result)
         exps = [("unittests.Second.test_fail", "FAIL"),
                 ("unittests.Second.test_error", "ERROR"),

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -185,7 +185,7 @@ class OutputTest(unittest.TestCase):
         test.save()
         result = process.run("%s run --job-results-dir %s --sysinfo=off "
                              "--json - -- %s" % (AVOCADO, self.tmpdir, test))
-        res = json.loads(result.stdout)
+        res = json.loads(result.stdout_text)
         joblog = res["debuglog"]
         exps = [b"[stdout] top_print", b"[stdout] top_stdout",
                 b"[stderr] top_stderr", b"[stdout] top_process",
@@ -211,7 +211,7 @@ class OutputTest(unittest.TestCase):
         result = process.run("%s run --job-results-dir %s --sysinfo=off "
                              "--output-check-record=combined "
                              "--json - -- %s" % (AVOCADO, self.tmpdir, test))
-        res = json.loads(result.stdout)
+        res = json.loads(result.stdout_text)
         testdir = res["tests"][0]["logdir"]
         with open(os.path.join(testdir, "output")) as output_file:
             self.assertEqual("test_process__test_stderr____test_stdout__",
@@ -238,7 +238,7 @@ class OutputTest(unittest.TestCase):
                                                                    self.tmpdir,
                                                                    test.path)
             result = process.run(cmd)
-            res = json.loads(result.stdout)
+            res = json.loads(result.stdout_text)
             testdir = res["tests"][0]["logdir"]
             for output_file in ('stdout', 'stderr', 'output'):
                 output_file_path = os.path.join(testdir, output_file)
@@ -260,7 +260,7 @@ class OutputTest(unittest.TestCase):
             cmd = ("%s run --job-results-dir %s --sysinfo=off "
                    "--json - -- %s") % (AVOCADO, self.tmpdir, test.path)
             result = process.run(cmd)
-            res = json.loads(result.stdout)
+            res = json.loads(result.stdout_text)
             testdir = res["tests"][0]["logdir"]
             stdout_path = os.path.join(testdir, 'stdout')
             self.assertTrue(os.path.exists(stdout_path))
@@ -340,7 +340,7 @@ class OutputPluginTest(unittest.TestCase):
                     '--journal --xunit %s --json - passtest.py' %
                     (AVOCADO, self.tmpdir, tmpfile))
         result = process.run(cmd_line, ignore_status=True)
-        output = result.stdout + result.stderr
+        output = result.stdout_text + result.stderr_text
         expected_rc = exit_codes.AVOCADO_ALL_OK
         try:
             self.assertEqual(result.exit_status, expected_rc,

--- a/selftests/functional/test_output_check.py
+++ b/selftests/functional/test_output_check.py
@@ -159,7 +159,7 @@ class RunnerSimpleTest(unittest.TestCase):
                          "Avocado did not return rc %d:\n%s" %
                          (expected_rc, result))
 
-        json_result = json.loads(result.stdout)
+        json_result = json.loads(result.stdout_text)
         job_log = json_result['debuglog']
         stdout_diff = os.path.join(json_result['tests'][0]['logdir'],
                                    'stdout.diff')

--- a/selftests/functional/test_skiptests.py
+++ b/selftests/functional/test_skiptests.py
@@ -115,7 +115,7 @@ class TestSkipDecorators(unittest.TestCase):
                     '%s' % self.test_module,
                     '--json -']
         result = process.run(' '.join(cmd_line), ignore_status=True)
-        json_results = json.loads(result.stdout)
+        json_results = json.loads(result.stdout_text)
         debuglog = json_results['debuglog']
 
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
@@ -135,7 +135,7 @@ class TestSkipDecorators(unittest.TestCase):
                     '%s' % self.skip_setup,
                     '--json -']
         result = process.run(' '.join(cmd_line), ignore_status=True)
-        json_results = json.loads(result.stdout)
+        json_results = json.loads(result.stdout_text)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
         self.assertEqual(json_results['skip'], 1)
 
@@ -149,7 +149,7 @@ class TestSkipDecorators(unittest.TestCase):
                     '%s' % self.bad_teardown,
                     '--json -']
         result = process.run(' '.join(cmd_line), ignore_status=True)
-        json_results = json.loads(result.stdout)
+        json_results = json.loads(result.stdout_text)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_TESTS_FAIL)
         self.assertEqual(json_results['errors'], 1)
 

--- a/selftests/functional/test_statuses.py
+++ b/selftests/functional/test_statuses.py
@@ -144,7 +144,7 @@ class TestStatuses(unittest.TestCase):
                (AVOCADO, test_file, self.tmpdir))
 
         results = process.run(cmd, ignore_status=True)
-        self.results = json.loads(results.stdout)
+        self.results = json.loads(results.stdout_text)
 
     def test(self):
         missing_tests = []


### PR DESCRIPTION
Under Python 3.4, which runs on our CI and is our lowest supported
version, json.loads() requires a string, while newer versions also
allows bytes.

    >>> json.loads(b'{}')
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "/home/cleber/.local/lib/python3.4/json/__init__.py", line 312, in loads s.__class__.__name__))
    TypeError: the JSON object must be str, not 'bytes'

Let's make that code compatible with Python 3.4.

Signed-off-by: Cleber Rosa <crosa@redhat.com>