### PR TITLE
meminfo: attributes should return current values

### DIFF
--- a/avocado/utils/memory.py
+++ b/avocado/utils/memory.py
@@ -420,8 +420,11 @@ class _MemInfoItem(DataSize):
     Representation of one item from /proc/meminfo
     """
     def __init__(self, name):
-        super(_MemInfoItem, self).__init__('%sk' % read_from_meminfo(name))
         self.name = name
+
+    def __getattr__(self, attr):
+        datasize = DataSize('%sk' % read_from_meminfo(self.name))
+        return getattr(datasize, attr)
 
 
 class MemInfo(object):


### PR DESCRIPTION
The last change in meminfo object to use the new DataSize object
introduced a wrong behaviour. Currently meminfo is not returning updated
values. This patch fixes it.

Signed-off-by: Amador Pahim <apahim@redhat.com>