### PR TITLE
Fix travis

### DIFF
--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -2,6 +2,7 @@
 fabric==1.11.1; python_version <= '2.7'
 Fabric3==1.13.1.post1; python_version >= '3.4'
 Sphinx==1.3b1
+pylint==1.8.1
 inspektor==0.4.5
 pep8==1.6.2
 requests==1.2.3


### PR DESCRIPTION
New pylint 1.8.3 is making travis to break. Let's pin the pylint for a version proven to work.