### PR TITLE
Python 3: Add RPM package support

### DIFF
--- a/avocado/plugins/exec_path.py
+++ b/avocado/plugins/exec_path.py
@@ -14,6 +14,8 @@
 Libexec PATHs modifier
 """
 
+import os
+
 from pkg_resources import resource_filename
 from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLICmd
@@ -34,4 +36,8 @@ class ExecPath(CLICmd):
 
         :param args: Command line args received from the run subparser.
         """
-        LOG_UI.debug(resource_filename("avocado", "libexec"))
+        system_wide = '/usr/libexec/avocado'
+        if os.path.isdir(system_wide):
+            LOG_UI.debug(system_wide)
+        else:
+            LOG_UI.debug(resource_filename("avocado", "libexec"))

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -26,6 +26,12 @@
 # enabled by default.
 %global with_tests 1
 
+%if 0%{?rhel}
+%global with_python3 0
+%else
+%global with_python3 1
+%endif
+
 Summary: Framework with tools and libraries for Automated Testing
 Name: python-%{srcname}
 Version: 59.0
@@ -73,6 +79,20 @@ BuildRequires: python2-sphinx
 BuildRequires: python2-stevedore
 %endif
 
+%if %{with_python3}
+BuildRequires: python3-pystache
+BuildRequires: python3-aexpect
+BuildRequires: python3-devel
+BuildRequires: python3-docutils
+BuildRequires: python3-lxml
+BuildRequires: python3-psutil
+BuildRequires: python3-requests
+BuildRequires: python3-setuptools
+BuildRequires: python3-six
+BuildRequires: python3-sphinx
+BuildRequires: python3-stevedore
+%endif
+
 %if %{with_tests}
 BuildRequires: libvirt-python
 BuildRequires: perl-Test-Harness
@@ -80,6 +100,9 @@ BuildRequires: perl-Test-Harness
 BuildRequires: PyYAML
 %else
 BuildRequires: python2-yaml
+%endif
+%if %{with_python3}
+BuildRequires: python3-yaml
 %endif
 %endif
 
@@ -112,6 +135,18 @@ Summary: %{summary}
 Avocado is a set of tools and libraries (what people call
 these days a framework) to perform automated testing.
 
+%package -n python3-%{srcname}
+Summary: %{summary}
+Requires: python3
+Requires: python3-requests
+Requires: python3-setuptools
+Requires: python3-six
+Requires: python3-stevedore
+
+%description -n python3-%{srcname}
+Avocado is a set of tools and libraries (what people call
+these days a framework) to perform automated testing.
+
 %prep
 %if 0%{?rel_build}
 %setup -q -n %{srcname}-%{version}
@@ -128,38 +163,66 @@ sed -e "s/'libvirt-python'//" -i optional_plugins/runner_vm/setup.py
 sed -e "s/'six>=1.10.0'/'six>=1.9.0'/" -i setup.py
 %endif
 %py2_build
+%if %{with_python3}
+%py3_build
+%endif
 pushd optional_plugins/html
 %py2_build
+%if %{with_python3}
+%py3_build
+%endif
 popd
+# no runner_remote plugin on Python 3 due to missing Fabric package
 pushd optional_plugins/runner_remote
 %py2_build
 popd
+# no runner_vm plugin on Python 3 due to missing Fabric package
 pushd optional_plugins/runner_vm
 %py2_build
 popd
+# no runner_docker plugin on Python 3 due to missing Fabric package
 pushd optional_plugins/runner_docker
 %py2_build
 popd
+# no resultsdb plugin on Python 3 due to missing resultsdb_api package
 pushd optional_plugins/resultsdb
 %py2_build
 popd
 pushd optional_plugins/varianter_yaml_to_mux
 %py2_build
+%if %{with_python3}
+%py3_build
+%endif
 popd
 pushd optional_plugins/loader_yaml
 %py2_build
+%if %{with_python3}
+%py3_build
+%endif
 popd
 pushd optional_plugins/golang
 %py2_build
+%if %{with_python3}
+%py3_build
+%endif
 popd
 pushd optional_plugins/varianter_pict
 %py2_build
+%if %{with_python3}
+%py3_build
+%endif
 popd
 pushd optional_plugins/result_upload
 %py2_build
+%if %{with_python3}
+%py3_build
+%endif
 popd
 pushd optional_plugins/glib
 %py2_build
+%if %{with_python3}
+%py3_build
+%endif
 popd
 %{__make} man
 
@@ -168,42 +231,75 @@ popd
 %{__mv} %{buildroot}%{python2_sitelib}/avocado/etc %{buildroot}
 mv %{buildroot}%{_bindir}/avocado %{buildroot}%{_bindir}/avocado-%{python2_version}
 ln -s avocado-%{python2_version} %{buildroot}%{_bindir}/avocado-2
+%if %{with_python3}
+%py3_install
+mv %{buildroot}%{_bindir}/avocado %{buildroot}%{_bindir}/avocado-%{python3_version}
+ln -s avocado-%{python3_version} %{buildroot}%{_bindir}/avocado-3
+# configuration is held at /etc/avocado only and part of the
+# python-avocado-common package
+%{__rm} -rf %{buildroot}%{python3_sitelib}/avocado/etc
+# ditto for libexec files
+%{__rm} -rf %{buildroot}%{python3_sitelib}/avocado/libexec
+%endif
 ln -s avocado-%{python2_version} %{buildroot}%{_bindir}/avocado
 pushd optional_plugins/html
 %py2_install
+%if %{with_python3}
+%py3_install
+%endif
 popd
+# no runner_remote plugin on Python 3 due to missing Fabric package
 pushd optional_plugins/runner_remote
 %py2_install
 popd
+# no runner_vm plugin on Python 3 due to missing Fabric package
 pushd optional_plugins/runner_vm
 %py2_install
 popd
+# no runner_docker plugin on Python 3 due to missing Fabric package
 pushd optional_plugins/runner_docker
 %py2_install
 popd
+# no resultsdb plugin on Python 3 due to missing resultsdb_api package
 pushd optional_plugins/resultsdb
 %py2_install
 popd
 pushd optional_plugins/varianter_yaml_to_mux
 %py2_install
+%if %{with_python3}
+%py3_install
+%endif
 popd
 pushd optional_plugins/loader_yaml
 %py2_install
+%if %{with_python3}
+%py3_install
+%endif
 popd
 pushd optional_plugins/golang
 %py2_install
+%if %{with_python3}
+%py3_install
+%endif
 popd
 pushd optional_plugins/varianter_pict
 %py2_install
+%if %{with_python3}
+%py3_install
+%endif
 popd
 pushd optional_plugins/result_upload
 %py2_install
+%if %{with_python3}
+%py3_install
+%endif
 popd
 pushd optional_plugins/glib
 %py2_install
+%if %{with_python3}
+%py3_install
+%endif
 popd
-ln -rs %{buildroot}%{_bindir}/avocado %{buildroot}%{_bindir}/avocado-%{python2_version}
-ln -rs %{buildroot}%{_bindir}/avocado %{buildroot}%{_bindir}/avocado-2
 %{__mkdir} -p %{buildroot}%{_mandir}/man1
 %{__install} -m 0644 man/avocado.1 %{buildroot}%{_mandir}/man1/avocado.1
 %{__install} -m 0644 man/avocado-rest-client.1 %{buildroot}%{_mandir}/man1/avocado-rest-client.1
@@ -234,6 +330,7 @@ popd
 pushd optional_plugins/runner_docker
 %{__python2} setup.py develop --user
 popd
+# no resultsdb plugin on Python 3 due to missing resultsdb_api package
 pushd optional_plugins/resultsdb
 %{__python2} setup.py develop --user
 popd
@@ -259,6 +356,34 @@ popd
 # we have observed so far.  Let's avoid tests that require too
 # much resources or are time sensitive
 AVOCADO_CHECK_LEVEL=0 %{__python2} selftests/run
+%if %{with_python3}
+%{__python3} setup.py develop --user
+pushd optional_plugins/html
+%{__python3} setup.py develop --user
+popd
+pushd optional_plugins/varianter_yaml_to_mux
+%{__python3} setup.py develop --user
+popd
+pushd optional_plugins/loader_yaml
+%{__python3} setup.py develop --user
+popd
+pushd optional_plugins/golang
+%{__python3} setup.py develop --user
+popd
+pushd optional_plugins/varianter_pict
+%{__python3} setup.py develop --user
+popd
+pushd optional_plugins/result_upload
+%{__python3} setup.py develop --user
+popd
+pushd optional_plugins/glib
+%{__python3} setup.py develop --user
+popd
+# Package build environments have the least amount of resources
+# we have observed so far.  Let's avoid tests that require too
+# much resources or are time sensitive
+AVOCADO_CHECK_LEVEL=0 %{__python3} selftests/run
+%endif
 %endif
 
 %files -n python2-%{srcname}
@@ -295,6 +420,27 @@ AVOCADO_CHECK_LEVEL=0 %{__python2} selftests/run
 %exclude %{python2_sitelib}/avocado_framework_plugin_glib*
 %exclude %{python2_sitelib}/avocado/libexec*
 
+%files -n python3-%{srcname}
+%defattr(-,root,root,-)
+%doc README.rst LICENSE
+%{_bindir}/avocado-3
+%{_bindir}/avocado-%{python3_version}
+%{python3_sitelib}/avocado*
+%exclude %{python3_sitelib}/avocado_result_html*
+%exclude %{python3_sitelib}/avocado_loader_yaml*
+%exclude %{python3_sitelib}/avocado_golang*
+%exclude %{python3_sitelib}/avocado_varianter_yaml_to_mux*
+%exclude %{python3_sitelib}/avocado_varianter_pict*
+%exclude %{python3_sitelib}/avocado_result_upload*
+%exclude %{python3_sitelib}/avocado_glib*
+%exclude %{python3_sitelib}/avocado_framework_plugin_result_html*
+%exclude %{python3_sitelib}/avocado_framework_plugin_varianter_yaml_to_mux*
+%exclude %{python3_sitelib}/avocado_framework_plugin_varianter_pict*
+%exclude %{python3_sitelib}/avocado_framework_plugin_loader_yaml*
+%exclude %{python3_sitelib}/avocado_framework_plugin_golang*
+%exclude %{python3_sitelib}/avocado_framework_plugin_result_upload*
+%exclude %{python3_sitelib}/avocado_framework_plugin_glib*
+
 %package common
 Summary: Avocado common files
 
@@ -330,6 +476,19 @@ arbitrary filesystem location.
 %files -n python2-%{srcname}-plugins-output-html
 %{python2_sitelib}/avocado_result_html*
 %{python2_sitelib}/avocado_framework_plugin_result_html*
+
+%package -n python3-%{srcname}-plugins-output-html
+Summary: Avocado HTML report plugin
+Requires: python3-%{srcname} == %{version}, python3-pystache
+
+%description -n python3-%{srcname}-plugins-output-html
+Adds to avocado the ability to generate an HTML report at every job results
+directory. It also gives the user the ability to write a report on an
+arbitrary filesystem location.
+
+%files -n python3-%{srcname}-plugins-output-html
+%{python3_sitelib}/avocado_result_html*
+%{python3_sitelib}/avocado_framework_plugin_result_html*
 
 %package -n python2-%{srcname}-plugins-runner-remote
 Summary: Avocado Runner for Remote Execution
@@ -405,6 +564,18 @@ defined in a yaml file(s).
 %{python2_sitelib}/avocado_varianter_yaml_to_mux*
 %{python2_sitelib}/avocado_framework_plugin_varianter_yaml_to_mux*
 
+%package -n python3-%{srcname}-plugins-varianter-yaml-to-mux
+Summary: Avocado plugin to generate variants out of yaml files
+Requires: python3-%{srcname} == %{version}
+
+%description -n python3-%{srcname}-plugins-varianter-yaml-to-mux
+Can be used to produce multiple test variants with test parameters
+defined in a yaml file(s).
+
+%files -n python3-%{srcname}-plugins-varianter-yaml-to-mux
+%{python3_sitelib}/avocado_varianter_yaml_to_mux*
+%{python3_sitelib}/avocado_framework_plugin_varianter_yaml_to_mux*
+
 %package -n python2-%{srcname}-plugins-loader-yaml
 Summary: Avocado Plugin that loads tests from YAML files
 Requires: %{name}-plugins-varianter-yaml-to-mux == %{version}
@@ -416,6 +587,18 @@ similar to the one used in the yaml_to_mux varianter plugin.
 %files -n python2-%{srcname}-plugins-loader-yaml
 %{python2_sitelib}/avocado_loader_yaml*
 %{python2_sitelib}/avocado_framework_plugin_loader_yaml*
+
+%package -n python3-%{srcname}-plugins-loader-yaml
+Summary: Avocado Plugin that loads tests from YAML files
+Requires: python3-%{srcname}-plugins-varianter-yaml-to-mux == %{version}
+
+%description -n python3-%{srcname}-plugins-loader-yaml
+Can be used to produce a test suite from definitions in a YAML file,
+similar to the one used in the yaml_to_mux varianter plugin.
+
+%files -n python3-%{srcname}-plugins-loader-yaml
+%{python3_sitelib}/avocado_loader_yaml*
+%{python3_sitelib}/avocado_framework_plugin_loader_yaml*
 
 %package -n python2-%{srcname}-plugins-golang
 Summary: Avocado Plugin for Execution of golang tests
@@ -430,6 +613,19 @@ also run them.
 %{python2_sitelib}/avocado_golang*
 %{python2_sitelib}/avocado_framework_plugin_golang*
 
+%package -n python3-%{srcname}-plugins-golang
+Summary: Avocado Plugin for Execution of golang tests
+Requires: python3-%{srcname} == %{version}
+Requires: golang
+
+%description -n python3-%{srcname}-plugins-golang
+Allows Avocado to list golang tests, and if golang is installed,
+also run them.
+
+%files -n python3-%{srcname}-plugins-golang
+%{python3_sitelib}/avocado_golang*
+%{python3_sitelib}/avocado_framework_plugin_golang*
+
 %package -n python2-%{srcname}-plugins-varianter-pict
 Summary: Varianter with combinatorial capabilities by PICT
 Requires: python2-%{srcname} == %{version}
@@ -441,6 +637,18 @@ Pair-Wise algorithms, also known as Combinatorial Independent Testing.
 %files -n python2-%{srcname}-plugins-varianter-pict
 %{python2_sitelib}/avocado_varianter_pict*
 %{python2_sitelib}/avocado_framework_plugin_varianter_pict*
+
+%package -n python3-%{srcname}-plugins-varianter-pict
+Summary: Varianter with combinatorial capabilities by PICT
+Requires: python3-%{srcname} == %{version}
+
+%description -n python3-%{srcname}-plugins-varianter-pict
+This plugin uses a third-party tool to provide variants created by
+Pair-Wise algorithms, also known as Combinatorial Independent Testing.
+
+%files -n python3-%{srcname}-plugins-varianter-pict
+%{python3_sitelib}/avocado_varianter_pict*
+%{python3_sitelib}/avocado_framework_plugin_varianter_pict*
 
 %package -n python2-%{srcname}-plugins-result-upload
 Summary: Avocado Plugin to propagate Job results to a remote host
@@ -455,6 +663,19 @@ a dedicated sever.
 %{python2_sitelib}/avocado_framework_plugin_result_upload*
 %config(noreplace)%{_sysconfdir}/avocado/conf.d/result_upload.conf
 
+%package -n python3-%{srcname}-plugins-result-upload
+Summary: Avocado Plugin to propagate Job results to a remote host
+Requires: python3-%{srcname} == %{version}
+
+%description -n python3-%{srcname}-plugins-result-upload
+This optional plugin is intended to upload the Avocado Job results to
+a dedicated sever.
+
+%files -n python3-%{srcname}-plugins-result-upload
+%{python3_sitelib}/avocado_result_upload*
+%{python3_sitelib}/avocado_framework_plugin_result_upload*
+%config(noreplace)%{_sysconfdir}/avocado/conf.d/result_upload.conf
+
 %package -n python2-%{srcname}-plugins-glib
 Summary: Avocado Plugin for Execution of GLib Test Framework tests
 Requires: %{name} == %{version}
@@ -466,6 +687,18 @@ GLib Test Framework.
 %files -n python2-%{srcname}-plugins-glib
 %{python2_sitelib}/avocado_glib*
 %{python2_sitelib}/avocado_framework_plugin_glib*
+
+%package -n python3-%{srcname}-plugins-glib
+Summary: Avocado Plugin for Execution of GLib Test Framework tests
+Requires: %{name} == %{version}
+
+%description -n python3-%{srcname}-plugins-glib
+This optional plugin is intended to list and run tests written in the
+GLib Test Framework.
+
+%files -n python3-%{srcname}-plugins-glib
+%{python3_sitelib}/avocado_glib*
+%{python3_sitelib}/avocado_framework_plugin_glib*
 
 %package examples
 Summary: Avocado Test Framework Example Tests
@@ -504,6 +737,7 @@ Again Shell code (and possibly other similar shells).
 - Added new common sub-package
 - Make bash package independent of Python version
 - Set supported Python major version explicitly to 2
+- Added Python 3 packages
 
 * Thu Mar  8 2018 Cleber Rosa <cleber@redhat.com> - 59.0-1
 - Remove backward compatibility with name avocado

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -104,6 +104,14 @@ Requires: python2-stevedore
 Avocado is a set of tools and libraries (what people call
 these days a framework) to perform automated testing.
 
+%package -n python2-%{srcname}
+Summary: %{summary}
+%{?python_provide:%python_provide python2-%{srcname}}
+
+%description -n python2-%{srcname}
+Avocado is a set of tools and libraries (what people call
+these days a framework) to perform automated testing.
+
 %prep
 %if 0%{?rel_build}
 %setup -q -n %{srcname}-%{version}
@@ -119,78 +127,83 @@ sed -e "s/'libvirt-python'//" -i optional_plugins/runner_vm/setup.py
 %if 0%{?rhel} == 7
 sed -e "s/'six>=1.10.0'/'six>=1.9.0'/" -i setup.py
 %endif
-%{__python} setup.py build
+%py2_build
 pushd optional_plugins/html
-%{__python} setup.py build
+%py2_build
 popd
 pushd optional_plugins/runner_remote
-%{__python} setup.py build
+%py2_build
 popd
 pushd optional_plugins/runner_vm
-%{__python} setup.py build
+%py2_build
 popd
 pushd optional_plugins/runner_docker
-%{__python} setup.py build
+%py2_build
 popd
 pushd optional_plugins/resultsdb
-%{__python} setup.py build
+%py2_build
 popd
 pushd optional_plugins/varianter_yaml_to_mux
-%{__python} setup.py build
+%py2_build
 popd
 pushd optional_plugins/loader_yaml
-%{__python} setup.py build
+%py2_build
 popd
 pushd optional_plugins/golang
-%{__python} setup.py build
+%py2_build
 popd
 pushd optional_plugins/varianter_pict
-%{__python} setup.py build
+%py2_build
 popd
 pushd optional_plugins/result_upload
-%{__python} setup.py build
+%py2_build
 popd
 pushd optional_plugins/glib
-%{__python} setup.py build
+%py2_build
 popd
 %{__make} man
 
 %install
-%{__python} setup.py install --root %{buildroot} --skip-build
-%{__mv} %{buildroot}%{python_sitelib}/avocado/etc %{buildroot}
+%py2_install
+%{__mv} %{buildroot}%{python2_sitelib}/avocado/etc %{buildroot}
+mv %{buildroot}%{_bindir}/avocado %{buildroot}%{_bindir}/avocado-%{python2_version}
+ln -s avocado-%{python2_version} %{buildroot}%{_bindir}/avocado-2
+ln -s avocado-%{python2_version} %{buildroot}%{_bindir}/avocado
 pushd optional_plugins/html
-%{__python} setup.py install --root %{buildroot} --skip-build
+%py2_install
 popd
 pushd optional_plugins/runner_remote
-%{__python} setup.py install --root %{buildroot} --skip-build
+%py2_install
 popd
 pushd optional_plugins/runner_vm
-%{__python} setup.py install --root %{buildroot} --skip-build
+%py2_install
 popd
 pushd optional_plugins/runner_docker
-%{__python} setup.py install --root %{buildroot} --skip-build
+%py2_install
 popd
 pushd optional_plugins/resultsdb
-%{__python} setup.py install --root %{buildroot} --skip-build
+%py2_install
 popd
 pushd optional_plugins/varianter_yaml_to_mux
-%{__python} setup.py install --root %{buildroot} --skip-build
+%py2_install
 popd
 pushd optional_plugins/loader_yaml
-%{__python} setup.py install --root %{buildroot} --skip-build
+%py2_install
 popd
 pushd optional_plugins/golang
-%{__python} setup.py install --root %{buildroot} --skip-build
+%py2_install
 popd
 pushd optional_plugins/varianter_pict
-%{__python} setup.py install --root %{buildroot} --skip-build
+%py2_install
 popd
 pushd optional_plugins/result_upload
-%{__python} setup.py install --root %{buildroot} --skip-build
+%py2_install
 popd
 pushd optional_plugins/glib
-%{__python} setup.py install --root %{buildroot} --skip-build
+%py2_install
 popd
+ln -rs %{buildroot}%{_bindir}/avocado %{buildroot}%{_bindir}/avocado-%{python2_version}
+ln -rs %{buildroot}%{_bindir}/avocado %{buildroot}%{_bindir}/avocado-2
 %{__mkdir} -p %{buildroot}%{_mandir}/man1
 %{__install} -m 0644 man/avocado.1 %{buildroot}%{_mandir}/man1/avocado.1
 %{__install} -m 0644 man/avocado-rest-client.1 %{buildroot}%{_mandir}/man1/avocado-rest-client.1
@@ -204,81 +217,83 @@ popd
 %{__cp} -r examples/yaml_to_mux_loader %{buildroot}%{_datadir}/avocado
 %{__cp} -r examples/varianter_pict %{buildroot}%{_datadir}/avocado
 %{__mkdir} -p %{buildroot}%{_libexecdir}/avocado
-%{__mv} %{buildroot}%{python_sitelib}/avocado/libexec/* %{buildroot}%{_libexecdir}/avocado
+%{__mv} %{buildroot}%{python2_sitelib}/avocado/libexec/* %{buildroot}%{_libexecdir}/avocado
 
 %check
 %if %{with_tests}
-%{__python} setup.py develop --user
+%{__python2} setup.py develop --user
 pushd optional_plugins/html
-%{__python} setup.py develop --user
+%{__python2} setup.py develop --user
 popd
 pushd optional_plugins/runner_remote
-%{__python} setup.py develop --user
+%{__python2} setup.py develop --user
 popd
 pushd optional_plugins/runner_vm
-%{__python} setup.py develop --user
+%{__python2} setup.py develop --user
 popd
 pushd optional_plugins/runner_docker
-%{__python} setup.py develop --user
+%{__python2} setup.py develop --user
 popd
 pushd optional_plugins/resultsdb
-%{__python} setup.py develop --user
+%{__python2} setup.py develop --user
 popd
 pushd optional_plugins/varianter_yaml_to_mux
-%{__python} setup.py develop --user
+%{__python2} setup.py develop --user
 popd
 pushd optional_plugins/loader_yaml
-%{__python} setup.py develop --user
+%{__python2} setup.py develop --user
 popd
 pushd optional_plugins/golang
-%{__python} setup.py develop --user
+%{__python2} setup.py develop --user
 popd
 pushd optional_plugins/varianter_pict
-%{__python} setup.py develop --user
+%{__python2} setup.py develop --user
 popd
 pushd optional_plugins/result_upload
-%{__python} setup.py develop --user
+%{__python2} setup.py develop --user
 popd
 pushd optional_plugins/glib
-%{__python} setup.py develop --user
+%{__python2} setup.py develop --user
 popd
 # Package build environments have the least amount of resources
 # we have observed so far.  Let's avoid tests that require too
 # much resources or are time sensitive
-AVOCADO_CHECK_LEVEL=0 selftests/run
+AVOCADO_CHECK_LEVEL=0 %{__python2} selftests/run
 %endif
 
-%files
+%files -n python2-%{srcname}
 %defattr(-,root,root,-)
 %doc README.rst LICENSE
-%{python_sitelib}/avocado*
+%{python2_sitelib}/avocado*
 %{_bindir}/avocado
+%{_bindir}/avocado-2
+%{_bindir}/avocado-%{python2_version}
 %{_bindir}/avocado-rest-client
 %{_mandir}/man1/avocado.1.gz
 %{_mandir}/man1/avocado-rest-client.1.gz
-%exclude %{python_sitelib}/avocado_result_html*
-%exclude %{python_sitelib}/avocado_runner_remote*
-%exclude %{python_sitelib}/avocado_runner_vm*
-%exclude %{python_sitelib}/avocado_runner_docker*
-%exclude %{python_sitelib}/avocado_resultsdb*
-%exclude %{python_sitelib}/avocado_loader_yaml*
-%exclude %{python_sitelib}/avocado_golang*
-%exclude %{python_sitelib}/avocado_varianter_yaml_to_mux*
-%exclude %{python_sitelib}/avocado_varianter_pict*
-%exclude %{python_sitelib}/avocado_result_upload*
-%exclude %{python_sitelib}/avocado_glib*
-%exclude %{python_sitelib}/avocado_framework_plugin_result_html*
-%exclude %{python_sitelib}/avocado_framework_plugin_runner_remote*
-%exclude %{python_sitelib}/avocado_framework_plugin_runner_vm*
-%exclude %{python_sitelib}/avocado_framework_plugin_runner_docker*
-%exclude %{python_sitelib}/avocado_framework_plugin_resultsdb*
-%exclude %{python_sitelib}/avocado_framework_plugin_varianter_yaml_to_mux*
-%exclude %{python_sitelib}/avocado_framework_plugin_varianter_pict*
-%exclude %{python_sitelib}/avocado_framework_plugin_loader_yaml*
-%exclude %{python_sitelib}/avocado_framework_plugin_golang*
-%exclude %{python_sitelib}/avocado_framework_plugin_result_upload*
-%exclude %{python_sitelib}/avocado_framework_plugin_glib*
-%exclude %{python_sitelib}/avocado/libexec*
+%exclude %{python2_sitelib}/avocado_result_html*
+%exclude %{python2_sitelib}/avocado_runner_remote*
+%exclude %{python2_sitelib}/avocado_runner_vm*
+%exclude %{python2_sitelib}/avocado_runner_docker*
+%exclude %{python2_sitelib}/avocado_resultsdb*
+%exclude %{python2_sitelib}/avocado_loader_yaml*
+%exclude %{python2_sitelib}/avocado_golang*
+%exclude %{python2_sitelib}/avocado_varianter_yaml_to_mux*
+%exclude %{python2_sitelib}/avocado_varianter_pict*
+%exclude %{python2_sitelib}/avocado_result_upload*
+%exclude %{python2_sitelib}/avocado_glib*
+%exclude %{python2_sitelib}/avocado_framework_plugin_result_html*
+%exclude %{python2_sitelib}/avocado_framework_plugin_runner_remote*
+%exclude %{python2_sitelib}/avocado_framework_plugin_runner_vm*
+%exclude %{python2_sitelib}/avocado_framework_plugin_runner_docker*
+%exclude %{python2_sitelib}/avocado_framework_plugin_resultsdb*
+%exclude %{python2_sitelib}/avocado_framework_plugin_varianter_yaml_to_mux*
+%exclude %{python2_sitelib}/avocado_framework_plugin_varianter_pict*
+%exclude %{python2_sitelib}/avocado_framework_plugin_loader_yaml*
+%exclude %{python2_sitelib}/avocado_framework_plugin_golang*
+%exclude %{python2_sitelib}/avocado_framework_plugin_result_upload*
+%exclude %{python2_sitelib}/avocado_framework_plugin_glib*
+%exclude %{python2_sitelib}/avocado/libexec*
 
 %package common
 Summary: Avocado common files
@@ -303,77 +318,77 @@ Common files (such as configuration) for the Avocado Testing Framework.
 %config(noreplace)%{_sysconfdir}/avocado/scripts/job/pre.d/README
 %config(noreplace)%{_sysconfdir}/avocado/scripts/job/post.d/README
 
-%package plugins-output-html
+%package -n python2-%{srcname}-plugins-output-html
 Summary: Avocado HTML report plugin
-Requires: %{name} == %{version}, pystache
+Requires: python2-%{srcname} == %{version}, pystache
 
-%description plugins-output-html
+%description -n python2-%{srcname}-plugins-output-html
 Adds to avocado the ability to generate an HTML report at every job results
 directory. It also gives the user the ability to write a report on an
 arbitrary filesystem location.
 
-%files plugins-output-html
-%{python_sitelib}/avocado_result_html*
-%{python_sitelib}/avocado_framework_plugin_result_html*
+%files -n python2-%{srcname}-plugins-output-html
+%{python2_sitelib}/avocado_result_html*
+%{python2_sitelib}/avocado_framework_plugin_result_html*
 
-%package plugins-runner-remote
+%package -n python2-%{srcname}-plugins-runner-remote
 Summary: Avocado Runner for Remote Execution
-Requires: %{name} == %{version}
+Requires: python2-%{srcname} == %{version}
 Requires: fabric
 
-%description plugins-runner-remote
+%description -n python2-%{srcname}-plugins-runner-remote
 Allows Avocado to run jobs on a remote machine, by means of an SSH
 connection.  Avocado must be previously installed on the remote machine.
 
-%files plugins-runner-remote
-%{python_sitelib}/avocado_runner_remote*
-%{python_sitelib}/avocado_framework_plugin_runner_remote*
+%files -n python2-%{srcname}-plugins-runner-remote
+%{python2_sitelib}/avocado_runner_remote*
+%{python2_sitelib}/avocado_framework_plugin_runner_remote*
 
-%package plugins-runner-vm
+%package -n python2-%{srcname}-plugins-runner-vm
 Summary: Avocado Runner for libvirt VM Execution
-Requires: %{name} == %{version}
-Requires: %{name}-plugins-runner-remote == %{version}
+Requires: python2-%{srcname} == %{version}
+Requires: python2-%{srcname}-plugins-runner-remote == %{version}
 Requires: libvirt-python
 
-%description plugins-runner-vm
+%description -n python2-%{srcname}-plugins-runner-vm
 Allows Avocado to run jobs on a libvirt based VM, by means of
 interaction with a libvirt daemon and an SSH connection to the VM
 itself.  Avocado must be previously installed on the VM.
 
-%files plugins-runner-vm
-%{python_sitelib}/avocado_runner_vm*
-%{python_sitelib}/avocado_framework_plugin_runner_vm*
+%files -n python2-%{srcname}-plugins-runner-vm
+%{python2_sitelib}/avocado_runner_vm*
+%{python2_sitelib}/avocado_framework_plugin_runner_vm*
 
-%package plugins-runner-docker
+%package -n python2-%{srcname}-plugins-runner-docker
 Summary: Avocado Runner for Execution on Docker Containers
-Requires: %{name} == %{version}
-Requires: %{name}-plugins-runner-remote == %{version}
-Requires: python-aexpect
+Requires: python2-%{srcname} == %{version}
+Requires: python2-%{srcname}-plugins-runner-remote == %{version}
+Requires: python2-aexpect
 
-%description plugins-runner-docker
+%description -n python2-%{srcname}-plugins-runner-docker
 Allows Avocado to run jobs on a Docker container by interacting with a
 Docker daemon and attaching to the container itself.  Avocado must
 be previously installed on the container.
 
-%files plugins-runner-docker
-%{python_sitelib}/avocado_runner_docker*
-%{python_sitelib}/avocado_framework_plugin_runner_docker*
+%files -n python2-%{srcname}-plugins-runner-docker
+%{python2_sitelib}/avocado_runner_docker*
+%{python2_sitelib}/avocado_framework_plugin_runner_docker*
 
-%package plugins-resultsdb
+%package -n python2-%{srcname}-plugins-resultsdb
 Summary: Avocado plugin to propagate job results to ResultsDB
-Requires: %{name} == %{version}
-Requires: python-resultsdb_api
+Requires: python2-%{srcname} == %{version}
+Requires: python2-resultsdb_api
 
-%description plugins-resultsdb
+%description -n python2-%{srcname}-plugins-resultsdb
 Allows Avocado to send job results directly to a ResultsDB
 server.
 
-%files plugins-resultsdb
-%{python_sitelib}/avocado_resultsdb*
-%{python_sitelib}/avocado_framework_plugin_resultsdb*
+%files -n python2-%{srcname}-plugins-resultsdb
+%{python2_sitelib}/avocado_resultsdb*
+%{python2_sitelib}/avocado_framework_plugin_resultsdb*
 %config(noreplace)%{_sysconfdir}/avocado/conf.d/resultsdb.conf
 
-%package plugins-varianter-yaml-to-mux
+%package -n python2-%{srcname}-plugins-varianter-yaml-to-mux
 Summary: Avocado plugin to generate variants out of yaml files
 Requires: %{name} == %{version}
 %if 0%{?rhel}
@@ -382,75 +397,75 @@ Requires: PyYAML
 Requires: python2-yaml
 %endif
 
-%description plugins-varianter-yaml-to-mux
+%description -n python2-%{srcname}-plugins-varianter-yaml-to-mux
 Can be used to produce multiple test variants with test parameters
 defined in a yaml file(s).
 
-%files plugins-varianter-yaml-to-mux
-%{python_sitelib}/avocado_varianter_yaml_to_mux*
-%{python_sitelib}/avocado_framework_plugin_varianter_yaml_to_mux*
+%files -n python2-%{srcname}-plugins-varianter-yaml-to-mux
+%{python2_sitelib}/avocado_varianter_yaml_to_mux*
+%{python2_sitelib}/avocado_framework_plugin_varianter_yaml_to_mux*
 
-%package plugins-loader-yaml
+%package -n python2-%{srcname}-plugins-loader-yaml
 Summary: Avocado Plugin that loads tests from YAML files
 Requires: %{name}-plugins-varianter-yaml-to-mux == %{version}
 
-%description plugins-loader-yaml
+%description -n python2-%{srcname}-plugins-loader-yaml
 Can be used to produce a test suite from definitions in a YAML file,
 similar to the one used in the yaml_to_mux varianter plugin.
 
-%files plugins-loader-yaml
-%{python_sitelib}/avocado_loader_yaml*
-%{python_sitelib}/avocado_framework_plugin_loader_yaml*
+%files -n python2-%{srcname}-plugins-loader-yaml
+%{python2_sitelib}/avocado_loader_yaml*
+%{python2_sitelib}/avocado_framework_plugin_loader_yaml*
 
-%package plugins-golang
+%package -n python2-%{srcname}-plugins-golang
 Summary: Avocado Plugin for Execution of golang tests
-Requires: %{name} == %{version}
+Requires: python2-%{srcname} == %{version}
 Requires: golang
 
-%description plugins-golang
+%description -n python2-%{srcname}-plugins-golang
 Allows Avocado to list golang tests, and if golang is installed,
 also run them.
 
-%files plugins-golang
-%{python_sitelib}/avocado_golang*
-%{python_sitelib}/avocado_framework_plugin_golang*
+%files -n python2-%{srcname}-plugins-golang
+%{python2_sitelib}/avocado_golang*
+%{python2_sitelib}/avocado_framework_plugin_golang*
 
-%package plugins-varianter-pict
+%package -n python2-%{srcname}-plugins-varianter-pict
 Summary: Varianter with combinatorial capabilities by PICT
-Requires: %{name} == %{version}
+Requires: python2-%{srcname} == %{version}
 
-%description plugins-varianter-pict
+%description -n python2-%{srcname}-plugins-varianter-pict
 This plugin uses a third-party tool to provide variants created by
 Pair-Wise algorithms, also known as Combinatorial Independent Testing.
 
-%files plugins-varianter-pict
-%{python_sitelib}/avocado_varianter_pict*
-%{python_sitelib}/avocado_framework_plugin_varianter_pict*
+%files -n python2-%{srcname}-plugins-varianter-pict
+%{python2_sitelib}/avocado_varianter_pict*
+%{python2_sitelib}/avocado_framework_plugin_varianter_pict*
 
-%package plugins-result-upload
+%package -n python2-%{srcname}-plugins-result-upload
 Summary: Avocado Plugin to propagate Job results to a remote host
-Requires: %{name} == %{version}
+Requires: python2-%{srcname} == %{version}
 
-%description plugins-result-upload
+%description -n python2-%{srcname}-plugins-result-upload
 This optional plugin is intended to upload the Avocado Job results to
 a dedicated sever.
 
-%files plugins-result-upload
-%{python_sitelib}/avocado_result_upload*
-%{python_sitelib}/avocado_framework_plugin_result_upload*
+%files -n python2-%{srcname}-plugins-result-upload
+%{python2_sitelib}/avocado_result_upload*
+%{python2_sitelib}/avocado_framework_plugin_result_upload*
 %config(noreplace)%{_sysconfdir}/avocado/conf.d/result_upload.conf
 
-%package plugins-glib
+%package -n python2-%{srcname}-plugins-glib
 Summary: Avocado Plugin for Execution of GLib Test Framework tests
 Requires: %{name} == %{version}
 
-%description plugins-glib
+%description -n python2-%{srcname}-plugins-glib
 This optional plugin is intended to list and run tests written in the
 GLib Test Framework.
 
-%files plugins-glib
-%{python_sitelib}/avocado_glib*
-%{python_sitelib}/avocado_framework_plugin_glib*
+%files -n python2-%{srcname}-plugins-glib
+%{python2_sitelib}/avocado_glib*
+%{python2_sitelib}/avocado_framework_plugin_glib*
 
 %package examples
 Summary: Avocado Test Framework Example Tests
@@ -488,6 +503,7 @@ Again Shell code (and possibly other similar shells).
 - Added python-avocado requirement for golang plugin
 - Added new common sub-package
 - Make bash package independent of Python version
+- Set supported Python major version explicitly to 2
 
 * Thu Mar  8 2018 Cleber Rosa <cleber@redhat.com> - 59.0-1
 - Remove backward compatibility with name avocado

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -203,8 +203,8 @@ popd
 %{__cp} -r examples/yaml_to_mux %{buildroot}%{_datadir}/avocado
 %{__cp} -r examples/yaml_to_mux_loader %{buildroot}%{_datadir}/avocado
 %{__cp} -r examples/varianter_pict %{buildroot}%{_datadir}/avocado
-%{__mkdir} -p %{buildroot}%{_libexecdir}/
-ln -s %{python_sitelib}/avocado/libexec/ %{buildroot}%{_libexecdir}/avocado
+%{__mkdir} -p %{buildroot}%{_libexecdir}/avocado
+%{__mv} %{buildroot}%{python_sitelib}/avocado/libexec/* %{buildroot}%{_libexecdir}/avocado
 
 %check
 %if %{with_tests}
@@ -479,7 +479,6 @@ A small set of utilities to interact with Avocado from the Bourne
 Again Shell code (and possibly other similar shells).
 
 %files bash
-%{python_sitelib}/avocado/libexec*
 %{_libexecdir}/avocado*
 
 %changelog
@@ -488,6 +487,7 @@ Again Shell code (and possibly other similar shells).
 - Removed extra dependencies on Fedora 24 for runner-remote
 - Added python-avocado requirement for golang plugin
 - Added new common sub-package
+- Make bash package independent of Python version
 
 * Thu Mar  8 2018 Cleber Rosa <cleber@redhat.com> - 59.0-1
 - Remove backward compatibility with name avocado

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -311,10 +311,6 @@ arbitrary filesystem location.
 Summary: Avocado Runner for Remote Execution
 Requires: %{name} == %{version}
 Requires: fabric
-%if 0%{?fedora} == 24
-Requires: python-crypto
-BuildRequires: python-crypto
-%endif
 
 %description plugins-runner-remote
 Allows Avocado to run jobs on a remote machine, by means of an SSH
@@ -479,6 +475,7 @@ Again Shell code (and possibly other similar shells).
 %changelog
 * Mon Mar 19 2018 Cleber Rosa <cleber@redhat.com> - 59.0-2
 - Removed backward compatibility with name avocado on plugins
+- Removed extra dependencies on Fedora 24 for runner-remote
 
 * Thu Mar  8 2018 Cleber Rosa <cleber@redhat.com> - 59.0-1
 - Remove backward compatibility with name avocado

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -29,7 +29,7 @@
 Summary: Framework with tools and libraries for Automated Testing
 Name: python-%{srcname}
 Version: 59.0
-Release: 1%{?gitrel}%{?dist}
+Release: 2%{?gitrel}%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.github.io/
@@ -297,8 +297,6 @@ AVOCADO_CHECK_LEVEL=0 selftests/run
 %package plugins-output-html
 Summary: Avocado HTML report plugin
 Requires: %{name} == %{version}, pystache
-Obsoletes: %{srcname}-plugins-output-html < 47.0-1
-Provides: %{srcname}-plugins-output-html = %{version}-%{release}
 
 %description plugins-output-html
 Adds to avocado the ability to generate an HTML report at every job results
@@ -317,8 +315,6 @@ Requires: fabric
 Requires: python-crypto
 BuildRequires: python-crypto
 %endif
-Obsoletes: %{srcname}-plugins-runner-remote < 47.0-1
-Provides: %{srcname}-plugins-runner-remote = %{version}-%{release}
 
 %description plugins-runner-remote
 Allows Avocado to run jobs on a remote machine, by means of an SSH
@@ -333,8 +329,6 @@ Summary: Avocado Runner for libvirt VM Execution
 Requires: %{name} == %{version}
 Requires: %{name}-plugins-runner-remote == %{version}
 Requires: libvirt-python
-Obsoletes: %{srcname}-plugins-runner-vm < 47.0-1
-Provides: %{srcname}-plugins-runner-vm = %{version}-%{release}
 
 %description plugins-runner-vm
 Allows Avocado to run jobs on a libvirt based VM, by means of
@@ -350,8 +344,6 @@ Summary: Avocado Runner for Execution on Docker Containers
 Requires: %{name} == %{version}
 Requires: %{name}-plugins-runner-remote == %{version}
 Requires: python-aexpect
-Obsoletes: %{srcname}-plugins-runner-docker < 47.0-1
-Provides: %{srcname}-plugins-runner-docker = %{version}-%{release}
 
 %description plugins-runner-docker
 Allows Avocado to run jobs on a Docker container by interacting with a
@@ -485,6 +477,9 @@ Again Shell code (and possibly other similar shells).
 %{_libexecdir}/avocado*
 
 %changelog
+* Mon Mar 19 2018 Cleber Rosa <cleber@redhat.com> - 59.0-2
+- Removed backward compatibility with name avocado on plugins
+
 * Thu Mar  8 2018 Cleber Rosa <cleber@redhat.com> - 59.0-1
 - Remove backward compatibility with name avocado
 - Remove hack to workaround fabric bugs on Fedora 24

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -83,6 +83,7 @@ BuildRequires: python2-yaml
 %endif
 %endif
 
+Requires: %{name}-common == %{version}
 Requires: gdb
 Requires: gdb-gdbserver
 Requires: procps-ng
@@ -250,21 +251,6 @@ AVOCADO_CHECK_LEVEL=0 selftests/run
 %files
 %defattr(-,root,root,-)
 %doc README.rst LICENSE
-%dir %{_sysconfdir}/avocado
-%dir %{_sysconfdir}/avocado/conf.d
-%dir %{_sysconfdir}/avocado/sysinfo
-%dir %{_sysconfdir}/avocado/scripts/job/pre.d
-%dir %{_sysconfdir}/avocado/scripts/job/post.d
-%dir %{_sharedstatedir}/avocado
-%config(noreplace)%{_sysconfdir}/avocado/avocado.conf
-%config(noreplace)%{_sysconfdir}/avocado/conf.d/README
-%config(noreplace)%{_sysconfdir}/avocado/conf.d/gdb.conf
-%config(noreplace)%{_sysconfdir}/avocado/conf.d/jobscripts.conf
-%config(noreplace)%{_sysconfdir}/avocado/sysinfo/commands
-%config(noreplace)%{_sysconfdir}/avocado/sysinfo/files
-%config(noreplace)%{_sysconfdir}/avocado/sysinfo/profilers
-%config(noreplace)%{_sysconfdir}/avocado/scripts/job/pre.d/README
-%config(noreplace)%{_sysconfdir}/avocado/scripts/job/post.d/README
 %{python_sitelib}/avocado*
 %{_bindir}/avocado
 %{_bindir}/avocado-rest-client
@@ -293,6 +279,29 @@ AVOCADO_CHECK_LEVEL=0 selftests/run
 %exclude %{python_sitelib}/avocado_framework_plugin_result_upload*
 %exclude %{python_sitelib}/avocado_framework_plugin_glib*
 %exclude %{python_sitelib}/avocado/libexec*
+
+%package common
+Summary: Avocado common files
+
+%description common
+Common files (such as configuration) for the Avocado Testing Framework.
+
+%files common
+%dir %{_sysconfdir}/avocado
+%dir %{_sysconfdir}/avocado/conf.d
+%dir %{_sysconfdir}/avocado/sysinfo
+%dir %{_sysconfdir}/avocado/scripts/job/pre.d
+%dir %{_sysconfdir}/avocado/scripts/job/post.d
+%dir %{_sharedstatedir}/avocado
+%config(noreplace)%{_sysconfdir}/avocado/avocado.conf
+%config(noreplace)%{_sysconfdir}/avocado/conf.d/README
+%config(noreplace)%{_sysconfdir}/avocado/conf.d/gdb.conf
+%config(noreplace)%{_sysconfdir}/avocado/conf.d/jobscripts.conf
+%config(noreplace)%{_sysconfdir}/avocado/sysinfo/commands
+%config(noreplace)%{_sysconfdir}/avocado/sysinfo/files
+%config(noreplace)%{_sysconfdir}/avocado/sysinfo/profilers
+%config(noreplace)%{_sysconfdir}/avocado/scripts/job/pre.d/README
+%config(noreplace)%{_sysconfdir}/avocado/scripts/job/post.d/README
 
 %package plugins-output-html
 Summary: Avocado HTML report plugin
@@ -478,6 +487,7 @@ Again Shell code (and possibly other similar shells).
 - Removed backward compatibility with name avocado on plugins
 - Removed extra dependencies on Fedora 24 for runner-remote
 - Added python-avocado requirement for golang plugin
+- Added new common sub-package
 
 * Thu Mar  8 2018 Cleber Rosa <cleber@redhat.com> - 59.0-1
 - Remove backward compatibility with name avocado

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -395,6 +395,7 @@ similar to the one used in the yaml_to_mux varianter plugin.
 
 %package plugins-golang
 Summary: Avocado Plugin for Execution of golang tests
+Requires: %{name} == %{version}
 Requires: golang
 
 %description plugins-golang
@@ -476,6 +477,7 @@ Again Shell code (and possibly other similar shells).
 * Mon Mar 19 2018 Cleber Rosa <cleber@redhat.com> - 59.0-2
 - Removed backward compatibility with name avocado on plugins
 - Removed extra dependencies on Fedora 24 for runner-remote
+- Added python-avocado requirement for golang plugin
 
 * Thu Mar  8 2018 Cleber Rosa <cleber@redhat.com> - 59.0-1
 - Remove backward compatibility with name avocado


### PR DESCRIPTION
This PR brings support for Python 3 versions of the Avocado RPM packages.