### PR TITLE
avocado.core.job: Provide per-job tmpdir [v4]

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -97,6 +97,7 @@ class Job(object):
         #: directory.  If it's set to None, it means that the job results
         #: directory has not yet been created.
         self.logdir = None
+        self.logfile = None
         self._setup_job_results()
         raw_log_level = settings.get_value('job.output', 'loglevel',
                                            default='debug')

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -145,15 +145,15 @@ class Job(object):
         self._result_events_dispatcher = dispatcher.ResultEventsDispatcher(self.args)
         output.log_plugin_failures(self._result_events_dispatcher.load_failures)
 
-        # Checking whether we will keep the Job tmp_dir or not.
-        # If yes, we set the basedir for a stable location.
-        basedir = None
-        keep_tmp = getattr(self.args, "keep_tmp", None)
-        if keep_tmp == 'on':
-            basedir = self.logdir
-        # Calling get_tmp_dir() early as the basedir will be set
-        # in the first call.
-        data_dir.get_tmp_dir(basedir)
+        # Use "logdir" in case "keep_tmp" is set enabled
+        if getattr(self.args, "keep_tmp", None) == "on":
+            base_tmpdir = self.logdir
+            self.__remove_tmpdir = False
+        else:
+            base_tmpdir = data_dir.get_tmp_dir()
+            self.__remove_tmpdir = True
+        self.tmpdir = tempfile.mkdtemp(prefix="avocado_job_",
+                                       dir=base_tmpdir)
 
     def _setup_job_results(self):
         """
@@ -400,9 +400,8 @@ class Job(object):
         for line in lines.splitlines():
             LOG_JOB.info(line)
 
-    @staticmethod
-    def _log_tmp_dir():
-        LOG_JOB.info('Temporary dir: %s', data_dir.get_tmp_dir())
+    def _log_tmp_dir(self):
+        LOG_JOB.info('Temporary dir: %s', self.tmpdir)
         LOG_JOB.info('')
 
     def _log_job_debug_info(self, variants):
@@ -550,6 +549,13 @@ class Job(object):
                 self.time_end = time.time()
                 self.time_elapsed = self.time_end - self.time_start
             self.__stop_job_logging()
+
+    def cleanup(self):
+        """
+        Cleanup the not-persistent environment created by this job
+        """
+        if self.__remove_tmpdir and os.path.exists(self.tmpdir):
+            shutil.rmtree(self.tmpdir)
 
 
 class TestProgram(object):

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -85,9 +85,6 @@ class Job(object):
             if unique_id is None:
                 self.args.unique_job_id = "0" * 40
             self.args.sysinfo = False
-            base_logdir = getattr(self.args, "base_logdir", None)
-            if base_logdir is None:
-                self.args.base_logdir = tempfile.mkdtemp(prefix="avocado-dry-run-")
 
         unique_id = getattr(self.args, 'unique_job_id', None)
         if unique_id is None:
@@ -98,7 +95,8 @@ class Job(object):
         #: directory has not yet been created.
         self.logdir = None
         self.logfile = None
-        self._setup_job_results()
+        self.tmpdir = None
+        self.__remove_tmpdir = False
         raw_log_level = settings.get_value('job.output', 'loglevel',
                                            default='debug')
         mapping = {'info': logging.INFO,
@@ -112,7 +110,7 @@ class Job(object):
             self.loglevel = logging.DEBUG
 
         self.status = "RUNNING"
-        self.result = result.Result(self)
+        self.result = None
         self.sysinfo = None
         self.timeout = getattr(self.args, 'job_timeout', 0)
         #: The time at which the job has started or `-1` if it has not been
@@ -125,7 +123,6 @@ class Job(object):
         #: or `-1` if it has not been started by means of the `run()` method
         self.time_elapsed = -1
         self.__logging_handlers = {}
-        self.__start_job_logging()
         self.funcatexit = data_structures.CallbackRegister("JobExit %s"
                                                            % self.unique_id,
                                                            LOG_JOB)
@@ -146,10 +143,28 @@ class Job(object):
         self._result_events_dispatcher = dispatcher.ResultEventsDispatcher(self.args)
         output.log_plugin_failures(self._result_events_dispatcher.load_failures)
 
+    def __enter__(self):
+        self.setup()
+        return self
+
+    def __exit__(self, _exc_type, _exc_value, _traceback):
+        self.cleanup()
+
+    def setup(self):
+        """
+        Setup the temporary job handlers (dirs, global setting, ...)
+        """
+        assert self.tmpdir is None, "Job.setup() already called"
+        if getattr(self.args, "dry_run", False):  # Create the dry-run dirs
+            base_logdir = getattr(self.args, "base_logdir", None)
+            if base_logdir is None:
+                self.args.base_logdir = tempfile.mkdtemp(prefix="avocado-dry-run-")
+        self._setup_job_results()
+        self.result = result.Result(self)
+        self.__start_job_logging()
         # Use "logdir" in case "keep_tmp" is set enabled
         if getattr(self.args, "keep_tmp", None) == "on":
             base_tmpdir = self.logdir
-            self.__remove_tmpdir = False
         else:
             base_tmpdir = data_dir.get_tmp_dir()
             self.__remove_tmpdir = True
@@ -512,6 +527,7 @@ class Job(object):
         :return: Integer with overall job status. See
                  :mod:`avocado.core.exit_codes` for more information.
         """
+        assert self.tmpdir is not None, "Job.setup() not called"
         if self.time_start == -1:
             self.time_start = time.time()
         runtime.CURRENT_JOB = self
@@ -549,12 +565,12 @@ class Job(object):
             if self.time_end == -1:
                 self.time_end = time.time()
                 self.time_elapsed = self.time_end - self.time_start
-            self.__stop_job_logging()
 
     def cleanup(self):
         """
-        Cleanup the not-persistent environment created by this job
+        Cleanup the temporary job handlers (dirs, global setting, ...)
         """
+        self.__stop_job_logging()
         if self.__remove_tmpdir and os.path.exists(self.tmpdir):
             shutil.rmtree(self.tmpdir)
 
@@ -598,10 +614,10 @@ class TestProgram(object):
         self.args.standalone = True
         self.args.show = ["test"]
         output.reconfigure(self.args)
-        self.job = Job(self.args)
-        exit_status = self.job.run()
-        if self.args.remove_test_results is True:
-            shutil.rmtree(self.job.logdir)
+        with Job(self.args) as self.job:
+            exit_status = self.job.run()
+            if self.args.remove_test_results is True:
+                shutil.rmtree(self.job.logdir)
         sys.exit(exit_status)
 
     def __del__(self):

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -396,9 +396,8 @@ class Test(unittest.TestCase, TestData):
 
         self.__workdir = os.path.join(data_dir.get_tmp_dir(),
                                       self.name.str_filesystem)
-        self.__srcdir_internal_access = False
         self.__srcdir_warning_logged = False
-        self.__srcdir = None
+        self.__srcdir = utils_path.init_dir(self.workdir, 'src')
 
         self.log.debug("Test metadata:")
         if self.filename:
@@ -540,14 +539,12 @@ class Test(unittest.TestCase, TestData):
         This property is deprecated and will be removed in the future.
         The :meth:`workdir` function should be used instead.
         """
-        if not (self.__srcdir_internal_access or self.__srcdir_warning_logged):
+        if not self.__srcdir_warning_logged:
             LOG_JOB.warn("DEPRECATION NOTICE: the test's \"srcdir\" property "
                          "is deprecated and is planned to be removed no later "
                          "than May 11 2018. Please use the \"workdir\" "
                          "property instead.")
             self.__srcdir_warning_logged = True
-        if self.__srcdir is None:
-            self.__srcdir = utils_path.init_dir(self.workdir, 'src')
         return self.__srcdir
 
     @property
@@ -971,14 +968,7 @@ class Test(unittest.TestCase, TestData):
         os.environ['AVOCADO_TEST_OUTPUTDIR'] = self.outputdir
         if self.__sysinfo_enabled:
             os.environ['AVOCADO_TEST_SYSINFODIR'] = self.__sysinfodir
-        # srcdir is deprecated and will cause a test warning when
-        # accessed.  It seems unfair to return a warning for all
-        # tests because Avocado itself will access that property.
-        # this is a hack to be removed when srcdir is also removed
-        # for good.
-        self.__srcdir_internal_access = True
-        os.environ['AVOCADO_TEST_SRCDIR'] = self.srcdir
-        self.__srcdir_internal_access = False
+        os.environ['AVOCADO_TEST_SRCDIR'] = self.__srcdir
 
     def run_avocado(self):
         """

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -25,6 +25,7 @@ import pipes
 import re
 import shutil
 import sys
+import tempfile
 import time
 import unittest
 
@@ -394,7 +395,11 @@ class Test(unittest.TestCase, TestData):
 
         self.__runner_queue = runner_queue
 
-        self.__workdir = os.path.join(data_dir.get_tmp_dir(),
+        base_tmpdir = getattr(job, "tmpdir", None)
+        # When tmpdir not specified by job, use logdir to preserve all data
+        if base_tmpdir is None:
+            base_tmpdir = tempfile.mkdtemp(prefix="tmp_dir", dir=self.logdir)
+        self.__workdir = os.path.join(base_tmpdir,
                                       self.name.str_filesystem)
         self.__srcdir_warning_logged = False
         self.__srcdir = utils_path.init_dir(self.workdir, 'src')

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -218,6 +218,7 @@ class Run(CLICmd):
         finally:
             # Run JobPost plugins
             pre_post_dispatcher.map_method('post', job_instance)
+            job_instance.cleanup()
 
         result_dispatcher = ResultDispatcher()
         if result_dispatcher.extensions:

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -207,18 +207,17 @@ class Run(CLICmd):
         except ValueError as e:
             LOG_UI.error(e.args[0])
             sys.exit(exit_codes.AVOCADO_FAIL)
-        job_instance = job.Job(args)
-        pre_post_dispatcher = JobPrePostDispatcher()
-        try:
-            # Run JobPre plugins
-            output.log_plugin_failures(pre_post_dispatcher.load_failures)
-            pre_post_dispatcher.map_method('pre', job_instance)
+        with job.Job(args) as job_instance:
+            pre_post_dispatcher = JobPrePostDispatcher()
+            try:
+                # Run JobPre plugins
+                output.log_plugin_failures(pre_post_dispatcher.load_failures)
+                pre_post_dispatcher.map_method('pre', job_instance)
 
-            job_run = job_instance.run()
-        finally:
-            # Run JobPost plugins
-            pre_post_dispatcher.map_method('post', job_instance)
-            job_instance.cleanup()
+                job_run = job_instance.run()
+            finally:
+                # Run JobPost plugins
+                pre_post_dispatcher.map_method('post', job_instance)
 
         result_dispatcher = ResultDispatcher()
         if result_dispatcher.extensions:

--- a/optional_plugins/runner_remote/tests/test_remote.py
+++ b/optional_plugins/runner_remote/tests/test_remote.py
@@ -64,8 +64,10 @@ class RemoteTestRunnerTest(unittest.TestCase):
                                                  '/tests/other/test',
                                                  'passtest.py'])
 
+        job = None
         try:
             job = Job(job_args)
+            job.setup()
             runner = avocado_runner_remote.RemoteTestRunner(job, job.result)
             return_value = (True, (version.MAJOR, version.MINOR))
             runner.check_remote_avocado = mock.Mock(return_value=return_value)
@@ -102,7 +104,8 @@ class RemoteTestRunnerTest(unittest.TestCase):
                                                  ignore_status=True,
                                                  timeout=61)
         finally:
-            shutil.rmtree(job.args.base_logdir)
+            if job:
+                shutil.rmtree(job.args.base_logdir)
 
 
 if __name__ == '__main__':

--- a/optional_plugins/runner_vm/tests/test_vm.py
+++ b/optional_plugins/runner_vm/tests/test_vm.py
@@ -50,8 +50,10 @@ class VMTestRunnerSetup(unittest.TestCase):
                                                  'passtest.py'],
                                       dry_run=True,
                                       env_keep=None)
+        job = None
         try:
             job = Job(job_args)
+            job.setup()
             with mock.patch('avocado_runner_vm.vm_connect',
                             return_value=mock_vm):
                 # VMTestRunner()
@@ -63,7 +65,8 @@ class VMTestRunnerSetup(unittest.TestCase):
                 mock_vm.stop.assert_called_once_with()
                 mock_vm.restore_snapshot.assert_called_once_with()
         finally:
-            shutil.rmtree(job.args.base_logdir)
+            if job:
+                shutil.rmtree(job.args.base_logdir)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Historically the `avocado.core.job.Job` uses `datadir.get_tmp_dir` to get the job tmpdir, which (together with tmpdir cleanup and check) disallows the use of multiple jobs within one python interpreter. Let's create a job tmpdir there instead to allow that.

This unveiled how much handlers and temporary settings Job produces so there is an extra commit to require `Job.setup` and `Job.cleanup` calls manually to explicitly define where those handlers are in use.

v1: https://github.com/avocado-framework/avocado/pull/2436
v2: https://github.com/avocado-framework/avocado/pull/2465
v3: https://github.com/avocado-framework/avocado/pull/2520

Changes:

```yaml
v2: Use `datadir.get_tmp_dir` directly in Job instead of optional argument
v2: Added commit to require to call setup/cleanup manually
v2: Added extra commit to remove unnecessary srcdir hack
v3: Extracted unrelated remove-lazy-init, combined with internal_access_srcdir
    hack and put it as first commit
v3: Put `sys.exit` outside the `with Job` to run the cleanup first
v3: Changed style in one selftest
v3: Improved selftest
v3: New commit to initialize "logfile" on "__init__"
v4: Added "test_two_jobs" selftest (2nd and 4th commits)
```