### PR TITLE
python 3: fix avocado-vt bootstrap issue due to 'NoneType' object is …

### DIFF
--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -231,7 +231,8 @@ class _TmpDirTracker(Borg):
             try:
                 if os.path.isdir(tmp_dir):
                     shutil.rmtree(tmp_dir)
-            except AttributeError:
+            # Need catch AttributeError and TypeError.
+            except (AttributeError, TypeError):
                 pass
 
 


### PR DESCRIPTION
…not callable

in avocado/core/data_dir.py, line 232, in __del__

Signed-off-by: chunfuwen <chwen@redhat.com>