### PR TITLE
test: Don't fail on getting state with non-standard params

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -642,9 +642,12 @@ class Test(unittest.TestCase, TestData):
         state['class_name'] = self.__class__.__name__
         state['job_logdir'] = self.job.logdir
         state['job_unique_id'] = self.job.unique_id
-        state['params'] = [(path, key, value)
-                           for path, key, value
-                           in self.params.iteritems()]
+        try:
+            state['params'] = [(path, key, value)
+                               for path, key, value
+                               in self.params.iteritems()]
+        except StandardError:
+            state['params'] = None
         return state
 
     def _register_log_file_handler(self, logger, formatter, filename,

--- a/optional_plugins/html/avocado_result_html/__init__.py
+++ b/optional_plugins/html/avocado_result_html/__init__.py
@@ -129,8 +129,9 @@ class ReportModel(object):
             params = ''
             try:
                 parameters = 'Params:\n'
-                for path, key, value in tst['params']:
-                    parameters += '  %s:%s => %s\n' % (path, key, value)
+                if tst['params']:
+                    for path, key, value in tst['params']:
+                        parameters += '  %s:%s => %s\n' % (path, key, value)
             except KeyError:
                 pass
             else:

--- a/optional_plugins/resultsdb/avocado_resultsdb/__init__.py
+++ b/optional_plugins/resultsdb/avocado_resultsdb/__init__.py
@@ -114,9 +114,10 @@ class ResultsdbResultEvent(ResultEvents):
                 'status': state['status']}
 
         params = {}
-        for path, key, value in state['params']:
-            params['param %s' % key] = '%s (path: %s)' % (value, path)
-        data.update(params)
+        if state['params']:
+            for path, key, value in state['params']:
+                params['param %s' % key] = '%s (path: %s)' % (value, path)
+            data.update(params)
 
         self.rdbapi.create_result(outcome, name, group, note, ref_url, **data)
 


### PR DESCRIPTION
The "self.params" should be Avocado params, but tests might override
them (and Avocado-vt does). Let's be lenient to failures and simply
report None.

Without this patch all `avocado-vt` tests are failing, because they use their own `self.params`.

Note I have in-progress version that uses `test.name.variant` to get variant from varianter, but it'll probably take some time so let's first fix the new issue brought by https://github.com/avocado-framework/avocado/commit/d5076fac4891ed886095a27bc884815700224e3c and improve later.