### PR TITLE
test: Don't fail on getting state with non-standard params

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -642,9 +642,12 @@ class Test(unittest.TestCase, TestData):
         state['class_name'] = self.__class__.__name__
         state['job_logdir'] = self.job.logdir
         state['job_unique_id'] = self.job.unique_id
-        state['params'] = [(path, key, value)
-                           for path, key, value
-                           in self.params.iteritems()]
+        try:
+            state['params'] = [(path, key, value)
+                               for path, key, value
+                               in self.params.iteritems()]
+        except StandardError:
+            state['params'] = None
         return state
 
     def _register_log_file_handler(self, logger, formatter, filename,

--- a/optional_plugins/html/avocado_result_html/__init__.py
+++ b/optional_plugins/html/avocado_result_html/__init__.py
@@ -126,15 +126,18 @@ class ReportModel(object):
             formatted = {}
             formatted['uid'] = tst['name'].uid
             formatted['name'] = tst['name'].name
-            params = ''
-            try:
-                parameters = 'Params:\n'
-                for path, key, value in tst['params']:
-                    parameters += '  %s:%s => %s\n' % (path, key, value)
-            except KeyError:
-                pass
+            if tst['params']:
+                params = ''
+                try:
+                    parameters = 'Params:\n'
+                    for path, key, value in tst['params']:
+                        parameters += '  %s:%s => %s\n' % (path, key, value)
+                except KeyError:
+                    pass
+                else:
+                    params = parameters
             else:
-                params = parameters
+                params = "No params"
             formatted['params'] = params
             formatted['variant'] = tst['name'].variant or ''
             formatted['status'] = tst['status']

--- a/optional_plugins/resultsdb/avocado_resultsdb/__init__.py
+++ b/optional_plugins/resultsdb/avocado_resultsdb/__init__.py
@@ -114,9 +114,10 @@ class ResultsdbResultEvent(ResultEvents):
                 'status': state['status']}
 
         params = {}
-        for path, key, value in state['params']:
-            params['param %s' % key] = '%s (path: %s)' % (value, path)
-        data.update(params)
+        if state['params']:
+            for path, key, value in state['params']:
+                params['param %s' % key] = '%s (path: %s)' % (value, path)
+            data.update(params)
 
         self.rdbapi.create_result(outcome, name, group, note, ref_url, **data)
 


### PR DESCRIPTION
The "self.params" should be Avocado params, but tests might override
them (and Avocado-vt does). Let's be lenient to failures and simply
report None.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>