### PR TITLE
Travis-CI: whitelist style check errors

### DIFF
--- a/examples/tests/raise.py
+++ b/examples/tests/raise.py
@@ -45,7 +45,7 @@ class Raise(Test):
             expected_result = 0
             self.assertIn("I'm alive!", cmd_result.stdout)
         elif 0 < signum < 65:
-            expected_result = -signum
+            expected_result = -signum   # pylint: disable=E1130
         else:
             expected_result = 255
             self.assertIn("raise: Invalid argument", cmd_result.stderr)

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -1188,8 +1188,9 @@ class PluginsXunitTest(AbsPluginsTest, unittest.TestCase):
                                 (detail, xml_output))
 
         with open(self.junit, 'rb') as f:
-            xmlschema = etree.XMLSchema(etree.parse(f))
+            xmlschema = etree.XMLSchema(etree.parse(f))   # pylint: disable=I1101
 
+        # pylint: disable=I1101
         self.assertTrue(xmlschema.validate(etree.parse(BytesIO(xml_output))),
                         "Failed to validate against %s, message:\n%s" %
                         (self.junit,

--- a/selftests/unit/test_xunit.py
+++ b/selftests/unit/test_xunit.py
@@ -88,7 +88,8 @@ class xUnitSucceedTest(unittest.TestCase):
         self.assertEqual(len(els), 1)
 
         with open(self.junit, 'r') as f:
-            xmlschema = etree.XMLSchema(etree.parse(f))
+            xmlschema = etree.XMLSchema(etree.parse(f))   # pylint: disable=I1101
+        # pylint: disable=I1101
         self.assertTrue(xmlschema.validate(etree.parse(BytesIO(xml))),
                         "Failed to validate against %s, content:\n%s" %
                         (self.junit, xml))


### PR DESCRIPTION
The latest jobs have been failing because of the following issues:

```
    ************* Module raise
    E1130: 48,30: Raise.test: bad operand type for unary -: NoneType
    ************* Module selftests.functional.test_basic
    I1101:1191,24: PluginsXunitTest.run_and_check: Module 'lxml.etree'
    has not 'XMLSchema' member, but source is unavailable. Consider
    adding this module to extension-pkg-whitelist if you want to
    perform analysis based on run-time introspection of living
    objects.
    I1101:1191,40: PluginsXunitTest.run_and_check: Module 'lxml.etree'
    has not 'parse' member, but source is unavailable. Consider adding
    this module to extension-pkg-whitelist if you want to perform
    analysis based on run-time introspection of living objects.
    I1101:1193,43: PluginsXunitTest.run_and_check: Module 'lxml.etree'
    has not 'parse' member, but source is unavailable. Consider adding
    this module to extension-pkg-whitelist if you want to perform
    analysis based on run-time introspection of living objects.
    ************* Module selftests.unit.test_xunit
    I1101: 91,24: xUnitSucceedTest.test_add_success: Module
    'lxml.etree' has not 'XMLSchema' member, but source is
    unavailable. Consider adding this module to
    extension-pkg-whitelist if you want to perform analysis based on
    run-time introspection of living objects.
    I1101: 91,40: xUnitSucceedTest.test_add_success: Module
    'lxml.etree' has not 'parse' member, but source is
    unavailable. Consider adding this module to
    extension-pkg-whitelist if you want to perform analysis based on
    run-time introspection of living objects.
    I1101: 92,43: xUnitSucceedTest.test_add_success: Module
    'lxml.etree' has not 'parse' member, but source is
    unavailable. Consider adding this module to
    extension-pkg-whitelist if you want to perform analysis based on
    run-time introspection of living objects.
```

We can't whitelist the `lxml.etree` module at this time (inspekt doesn't
have such an option) and the raise failure is a false positive.  Let's
ignore those issues then.

Signed-off-by: Cleber Rosa <crosa@redhat.com>