### PR TITLE
Simpletest decode error2

### DIFF
--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -32,7 +32,7 @@ import threading
 import time
 
 from io import BytesIO, UnsupportedOperation
-from six import string_types
+from six import PY2, string_types
 
 from . import gdb
 from . import runtime
@@ -99,10 +99,28 @@ class CmdError(Exception):
             return "CmdError"
 
 
+def normalize_cmd(cmd):
+    """
+    Normalize cmd to be safe for ``shlex.split``
+    """
+    # FIXME: Use https://trello.com/c/wsd2z7WS/
+    # 1265-unify-py3-py2-default-encoding-handling when becomes
+    # available. For now hardcode "utf-8" as most suitable
+    # alternative.
+    if PY2:
+        if not isinstance(cmd, str):
+            cmd = cmd.encode("utf-8")
+    else:
+        if isinstance(cmd, bytes):
+            cmd = cmd.decode("utf-8")
+    return cmd
+
+
 def can_sudo(cmd=None):
     """
     Check whether sudo is available (or running as root)
     """
+    cmd = normalize_cmd(cmd)
     if os.getuid() == 0:    # Root
         return True
 
@@ -242,6 +260,7 @@ def binary_from_shell_cmd(cmd):
     :param cmd: simple shell-like binary
     :return: first found binary from the cmd
     """
+    cmd = normalize_cmd(cmd)
     try:
         cmds = shlex.split(cmd)
     except ValueError:
@@ -483,6 +502,7 @@ class SubProcess(object):
                     to be running after the process finishes.
         :raises: ValueError if incorrect values are given to parameters
         """
+        cmd = normalize_cmd(cmd)
         if sudo:
             self.cmd = self._prepend_sudo(cmd, shell)
         else:
@@ -859,7 +879,7 @@ class GDBSubProcess(object):
                      implementation, since the GDB wrapping code does not have
                      support to run commands in that way.
         """
-
+        cmd = normalize_cmd(cmd)
         self.cmd = cmd
 
         self.args = shlex.split(cmd)
@@ -1193,6 +1213,7 @@ def get_sub_process_klass(cmd):
 
     :param cmd: the command arguments, from where we extract the binary name
     """
+    cmd = normalize_cmd(cmd)
     if should_run_inside_gdb(cmd):
         return GDBSubProcess
     elif should_run_inside_wrapper(cmd):

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -291,8 +291,10 @@ class CmdResult(object):
     :param pid: ID of the process
     :type pid: int
     :param encoding: the encoding to use for the text version
-                     of stdout and stderr, with the default being
-                     Python's own (:func:`sys.getdefaultencoding`).
+                     of stdout and stderr. Usually
+                     :func:`sys.getdefaultencoding` is used but on python2
+                     we override "ascii" for "utf-8" as standard py2 does
+                     not report encoding properly and "utf-8" usually fits.
     :type encoding: str
     """
 
@@ -310,6 +312,12 @@ class CmdResult(object):
         self.pid = pid
         if encoding is None:
             encoding = sys.getdefaultencoding()
+            if PY2 and encoding == "ascii":
+                # FIXME: Use https://trello.com/c/wsd2z7WS/
+                # 1265-unify-py3-py2-default-encoding-handling when becomes
+                # available. For now hardcode "utf-8" as most suitable
+                # alternative.
+                encoding = "utf-8"
         self.encoding = encoding
 
     @property

--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -24,6 +24,7 @@ def probe_binary(binary):
 
 
 TRUE_CMD = probe_binary('true')
+ECHO_CMD = probe_binary('echo')
 
 
 class TestSubProcess(unittest.TestCase):
@@ -250,6 +251,16 @@ class TestProcessRun(unittest.TestCase):
         expected_command = 'ls -l'
         p = process.run(cmd='ls -l', sudo=True, shell=True, ignore_status=True)
         self.assertEqual(p.command, expected_command)
+
+    @unittest.skipUnless(ECHO_CMD, "Echo command not available in system")
+    def test_run_unicode_output(self):
+        # Using encoded string as shlex does not support decoding
+        # but the behavior is exactly the same as if shell binary
+        # produced unicode
+        text = u"Avok\xe1do"
+        result = process.run("%s %s" % (ECHO_CMD, text))
+        self.assertEqual(result.stdout, text.encode('utf-8') + b'\n')
+        self.assertEqual(result.stdout_text, text + '\n')
 
 
 class MiscProcessTests(unittest.TestCase):

--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -16,7 +16,14 @@ from avocado.utils import path
 from six import string_types
 
 
-TRUE_CMD = path.find_command('true')
+def probe_binary(binary):
+    try:
+        return path.find_command(binary)
+    except path.CmdNotFoundError:
+        return None
+
+
+TRUE_CMD = probe_binary('true')
 
 
 class TestSubProcess(unittest.TestCase):
@@ -57,6 +64,8 @@ class TestGDBProcess(unittest.TestCase):
         self.assertFalse(process.should_run_inside_gdb("foo bar baz"))
         self.assertFalse(process.should_run_inside_gdb("foo ' "))
 
+    @unittest.skipUnless(TRUE_CMD,
+                         '"true" binary not available')
     def test_get_sub_process_klass(self):
         gdb.GDB_RUN_BINARY_NAMES_EXPR = []
         self.assertIs(process.get_sub_process_klass(TRUE_CMD),
@@ -92,6 +101,8 @@ def mock_fail_find_cmd(cmd, default=None):
 
 class TestProcessRun(unittest.TestCase):
 
+    @unittest.skipUnless(TRUE_CMD,
+                         '"true" binary not available')
     @mock.patch.object(path, 'find_command',
                        mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid',
@@ -101,6 +112,8 @@ class TestProcessRun(unittest.TestCase):
         p = process.SubProcess(cmd='ls -l')
         self.assertEqual(p.cmd, expected_command)
 
+    @unittest.skipUnless(TRUE_CMD,
+                         '"true" binary not available')
     @mock.patch.object(path, 'find_command',
                        mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid', mock.Mock(return_value=0))
@@ -109,6 +122,8 @@ class TestProcessRun(unittest.TestCase):
         p = process.SubProcess(cmd='ls -l')
         self.assertEqual(p.cmd, expected_command)
 
+    @unittest.skipUnless(TRUE_CMD,
+                         '"true" binary not available')
     @mock.patch.object(path, 'find_command',
                        mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid',
@@ -125,6 +140,8 @@ class TestProcessRun(unittest.TestCase):
         p = process.SubProcess(cmd='ls -l', sudo=True)
         self.assertEqual(p.cmd, expected_command)
 
+    @unittest.skipUnless(TRUE_CMD,
+                         '"true" binary not available')
     @mock.patch.object(path, 'find_command',
                        mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid', mock.Mock(return_value=0))
@@ -133,6 +150,8 @@ class TestProcessRun(unittest.TestCase):
         p = process.SubProcess(cmd='ls -l', sudo=True)
         self.assertEqual(p.cmd, expected_command)
 
+    @unittest.skipUnless(TRUE_CMD,
+                         '"true" binary not available')
     @mock.patch.object(path, 'find_command',
                        mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid', mock.Mock(return_value=1000))
@@ -148,6 +167,8 @@ class TestProcessRun(unittest.TestCase):
         p = process.SubProcess(cmd='ls -l', sudo=True, shell=True)
         self.assertEqual(p.cmd, expected_command)
 
+    @unittest.skipUnless(TRUE_CMD,
+                         '"true" binary not available')
     @mock.patch.object(path, 'find_command',
                        mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid', mock.Mock(return_value=0))
@@ -156,6 +177,8 @@ class TestProcessRun(unittest.TestCase):
         p = process.SubProcess(cmd='ls -l', sudo=True, shell=True)
         self.assertEqual(p.cmd, expected_command)
 
+    @unittest.skipUnless(TRUE_CMD,
+                         '"true" binary not available')
     @mock.patch.object(path, 'find_command',
                        mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid', mock.Mock(return_value=1000))
@@ -164,6 +187,8 @@ class TestProcessRun(unittest.TestCase):
         p = process.run(cmd='ls -l', ignore_status=True)
         self.assertEqual(p.command, expected_command)
 
+    @unittest.skipUnless(TRUE_CMD,
+                         '"true" binary not available')
     @mock.patch.object(path, 'find_command',
                        mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid', mock.Mock(return_value=0))
@@ -172,6 +197,8 @@ class TestProcessRun(unittest.TestCase):
         p = process.run(cmd='ls -l', ignore_status=True)
         self.assertEqual(p.command, expected_command)
 
+    @unittest.skipUnless(TRUE_CMD,
+                         '"true" binary not available')
     @mock.patch.object(path, 'find_command',
                        mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid', mock.Mock(return_value=1000))
@@ -187,6 +214,8 @@ class TestProcessRun(unittest.TestCase):
         p = process.run(cmd='ls -l', sudo=True, ignore_status=True)
         self.assertEqual(p.command, expected_command)
 
+    @unittest.skipUnless(TRUE_CMD,
+                         '"true" binary not available')
     @mock.patch.object(path, 'find_command',
                        mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid', mock.Mock(return_value=0))
@@ -195,6 +224,8 @@ class TestProcessRun(unittest.TestCase):
         p = process.run(cmd='ls -l', sudo=True, ignore_status=True)
         self.assertEqual(p.command, expected_command)
 
+    @unittest.skipUnless(TRUE_CMD,
+                         '"true" binary not available')
     @mock.patch.object(path, 'find_command',
                        mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid', mock.Mock(return_value=1000))
@@ -210,6 +241,8 @@ class TestProcessRun(unittest.TestCase):
         p = process.run(cmd='ls -l', sudo=True, shell=True, ignore_status=True)
         self.assertEqual(p.command, expected_command)
 
+    @unittest.skipUnless(TRUE_CMD,
+                         '"true" binary not available')
     @mock.patch.object(path, 'find_command',
                        mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid', mock.Mock(return_value=0))


### PR DESCRIPTION
Avocado crashes when SimpleTest produces non-ascii characters. Simple reproducer is:

```
$ echo "#!/bin/sh" > a.sh
$ echo "echo ěčřž" >> a.sh
$ chmod +x a.sh
$ avocado run a.sh
```

Additionally I had to add a commit to "normalize" cmd format because PY2 shlex does not support unicode and PY3 shlex can't read bytes. Alternative would be https://pypi.python.org/pypi/ushlex/ but I wanted to avoid yet another dependency...

v1: https://trello.com/c/wsd2z7WS/1265-unify-py3-py2-default-encoding-handling

Changes:
```yaml
v2: fixed messages in TRUE_CMD selftest probe
v2: added TODOs to use https://trello.com/c/wsd2z7WS/1265-unify-py3-py2-default-encoding-handling
v2: fixed docstring in the last commit
```