### PR TITLE
Avocado: set default encoding

### DIFF
--- a/avocado/core/defaults.py
+++ b/avocado/core/defaults.py
@@ -1,0 +1,20 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2018
+# Author: Cleber Rosa <crosa@redhat.com>
+
+"""
+The Avocado core defaults
+"""
+
+#: The encoding used by default on all data input
+ENCODING = 'utf-8'

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -32,6 +32,7 @@ from difflib import unified_diff
 from six import string_types, iteritems
 
 from . import data_dir
+from . import defaults
 from . import exceptions
 from . import output
 from . import parameters
@@ -1133,7 +1134,7 @@ class SimpleTest(Test):
 
             # process.run uses shlex.split(), the self.path needs to be escaped
             result = process.run(self._command, verbose=True,
-                                 env=test_params)
+                                 env=test_params, encoding=defaults.ENCODING)
 
             self._log_detailed_cmd_info(result)
         except process.CmdError as details:

--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -16,7 +16,14 @@ from avocado.utils import path
 from six import string_types
 
 
-TRUE_CMD = path.find_command('true')
+def probe_binary(binary):
+    try:
+        return path.find_command(binary)
+    except path.CmdNotFoundError:
+        return None
+
+
+TRUE_CMD = probe_binary('true')
 
 
 class TestSubProcess(unittest.TestCase):
@@ -57,6 +64,8 @@ class TestGDBProcess(unittest.TestCase):
         self.assertFalse(process.should_run_inside_gdb("foo bar baz"))
         self.assertFalse(process.should_run_inside_gdb("foo ' "))
 
+    @unittest.skipUnless(TRUE_CMD,
+                         '"true" binary not available')
     def test_get_sub_process_klass(self):
         gdb.GDB_RUN_BINARY_NAMES_EXPR = []
         self.assertIs(process.get_sub_process_klass(TRUE_CMD),
@@ -92,6 +101,8 @@ def mock_fail_find_cmd(cmd, default=None):
 
 class TestProcessRun(unittest.TestCase):
 
+    @unittest.skipUnless(TRUE_CMD,
+                         '"true" binary not available')
     @mock.patch.object(path, 'find_command',
                        mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid',
@@ -101,6 +112,8 @@ class TestProcessRun(unittest.TestCase):
         p = process.SubProcess(cmd='ls -l')
         self.assertEqual(p.cmd, expected_command)
 
+    @unittest.skipUnless(TRUE_CMD,
+                         '"true" binary not available')
     @mock.patch.object(path, 'find_command',
                        mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid', mock.Mock(return_value=0))
@@ -109,6 +122,8 @@ class TestProcessRun(unittest.TestCase):
         p = process.SubProcess(cmd='ls -l')
         self.assertEqual(p.cmd, expected_command)
 
+    @unittest.skipUnless(TRUE_CMD,
+                         '"true" binary not available')
     @mock.patch.object(path, 'find_command',
                        mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid',
@@ -125,6 +140,8 @@ class TestProcessRun(unittest.TestCase):
         p = process.SubProcess(cmd='ls -l', sudo=True)
         self.assertEqual(p.cmd, expected_command)
 
+    @unittest.skipUnless(TRUE_CMD,
+                         '"true" binary not available')
     @mock.patch.object(path, 'find_command',
                        mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid', mock.Mock(return_value=0))
@@ -133,6 +150,8 @@ class TestProcessRun(unittest.TestCase):
         p = process.SubProcess(cmd='ls -l', sudo=True)
         self.assertEqual(p.cmd, expected_command)
 
+    @unittest.skipUnless(TRUE_CMD,
+                         '"true" binary not available')
     @mock.patch.object(path, 'find_command',
                        mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid', mock.Mock(return_value=1000))
@@ -148,6 +167,8 @@ class TestProcessRun(unittest.TestCase):
         p = process.SubProcess(cmd='ls -l', sudo=True, shell=True)
         self.assertEqual(p.cmd, expected_command)
 
+    @unittest.skipUnless(TRUE_CMD,
+                         '"true" binary not available')
     @mock.patch.object(path, 'find_command',
                        mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid', mock.Mock(return_value=0))
@@ -156,6 +177,8 @@ class TestProcessRun(unittest.TestCase):
         p = process.SubProcess(cmd='ls -l', sudo=True, shell=True)
         self.assertEqual(p.cmd, expected_command)
 
+    @unittest.skipUnless(TRUE_CMD,
+                         '"true" binary not available')
     @mock.patch.object(path, 'find_command',
                        mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid', mock.Mock(return_value=1000))
@@ -164,6 +187,8 @@ class TestProcessRun(unittest.TestCase):
         p = process.run(cmd='ls -l', ignore_status=True)
         self.assertEqual(p.command, expected_command)
 
+    @unittest.skipUnless(TRUE_CMD,
+                         '"true" binary not available')
     @mock.patch.object(path, 'find_command',
                        mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid', mock.Mock(return_value=0))
@@ -172,6 +197,8 @@ class TestProcessRun(unittest.TestCase):
         p = process.run(cmd='ls -l', ignore_status=True)
         self.assertEqual(p.command, expected_command)
 
+    @unittest.skipUnless(TRUE_CMD,
+                         '"true" binary not available')
     @mock.patch.object(path, 'find_command',
                        mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid', mock.Mock(return_value=1000))
@@ -187,6 +214,8 @@ class TestProcessRun(unittest.TestCase):
         p = process.run(cmd='ls -l', sudo=True, ignore_status=True)
         self.assertEqual(p.command, expected_command)
 
+    @unittest.skipUnless(TRUE_CMD,
+                         '"true" binary not available')
     @mock.patch.object(path, 'find_command',
                        mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid', mock.Mock(return_value=0))
@@ -195,6 +224,8 @@ class TestProcessRun(unittest.TestCase):
         p = process.run(cmd='ls -l', sudo=True, ignore_status=True)
         self.assertEqual(p.command, expected_command)
 
+    @unittest.skipUnless(TRUE_CMD,
+                         '"true" binary not available')
     @mock.patch.object(path, 'find_command',
                        mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid', mock.Mock(return_value=1000))
@@ -210,6 +241,8 @@ class TestProcessRun(unittest.TestCase):
         p = process.run(cmd='ls -l', sudo=True, shell=True, ignore_status=True)
         self.assertEqual(p.command, expected_command)
 
+    @unittest.skipUnless(TRUE_CMD,
+                         '"true" binary not available')
     @mock.patch.object(path, 'find_command',
                        mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid', mock.Mock(return_value=0))

--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -24,6 +24,7 @@ def probe_binary(binary):
 
 
 TRUE_CMD = probe_binary('true')
+ECHO_CMD = probe_binary('echo')
 
 
 class TestSubProcess(unittest.TestCase):
@@ -250,6 +251,16 @@ class TestProcessRun(unittest.TestCase):
         expected_command = 'ls -l'
         p = process.run(cmd='ls -l', sudo=True, shell=True, ignore_status=True)
         self.assertEqual(p.command, expected_command)
+
+    @unittest.skipUnless(ECHO_CMD, "Echo command not available in system")
+    def test_run_unicode_output(self):
+        # Using encoded string as shlex does not support decoding
+        # but the behavior is exactly the same as if shell binary
+        # produced unicode
+        text = u"Avok\xe1do"
+        result = process.run("%s %s" % (ECHO_CMD, text), encoding='utf-8')
+        self.assertEqual(result.stdout, text.encode('utf-8') + b'\n')
+        self.assertEqual(result.stdout_text, text + '\n')
 
 
 class MiscProcessTests(unittest.TestCase):


### PR DESCRIPTION
And allow that setting to be used on `avocado.uttils` APIs such as `process.run()`.  This fixes the crash reported, and fixed with a different implementation on PR #2538.

@ldoktor for your appreciation and review.