### PR TITLE
Lint: add w0101 and w0404 checks [v2]

### DIFF
--- a/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
+++ b/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
@@ -48,7 +48,7 @@ class RemoterError(Exception):
     pass
 
 
-class ConnectionError(RemoterError):
+class ConnectError(RemoterError):
     pass
 
 
@@ -253,7 +253,7 @@ class Remote(object):
                               connection_attempts=attempts,
                               linewise=True,
                               abort_on_prompts=True,
-                              abort_exception=ConnectionError,
+                              abort_exception=ConnectError,
                               reject_unknown_hosts=reject_unknown_hosts,
                               disable_known_hosts=disable_known_hosts)
 

--- a/optional_plugins/varianter_yaml_to_mux/tests/test_mux.py
+++ b/optional_plugins/varianter_yaml_to_mux/tests/test_mux.py
@@ -127,10 +127,10 @@ class TestMuxTree(unittest.TestCase):
                   'prod']
         self.assertEqual(leaves, self.tree.get_leaves())
         # ascii contain all leaves and doesn't raise any exceptions
-        ascii = tree.tree_view(self.tree, 0, False).decode('ascii')
+        tree_view = tree.tree_view(self.tree, 0, False).decode('ascii')
         for leaf in leaves:
-            self.assertIn(leaf, ascii, "Leaf %s not in ascii:\n%s"
-                          % (leaf, ascii))
+            self.assertIn(leaf, tree_view, "Leaf %s not in ascii:\n%s"
+                          % (leaf, tree_view))
 
     def test_filters(self):
         tree2 = copy.deepcopy(self.tree)

--- a/selftests/.data/test_statuses.py
+++ b/selftests/.data/test_statuses.py
@@ -249,6 +249,7 @@ class ExceptionSetup(Test):
     def setUp(self):
         self.log.info('setup pre')
         raise ValueError
+        # pylint: disable=W0101
         self.log.info('setup post')
 
     def test(self):
@@ -269,6 +270,7 @@ class ExceptionTest(Test):
     def test(self):
         self.log.info('test pre')
         raise ValueError
+        # pylint: disable=W0101
         self.log.info('test post')
 
     def tearDown(self):
@@ -289,6 +291,7 @@ class ExceptionTeardown(Test):
     def tearDown(self):
         self.log.info('teardown pre')
         raise ValueError
+        # pylint: disable=W0101
         self.log.info('teardown post')
 
 

--- a/selftests/checkall
+++ b/selftests/checkall
@@ -161,7 +161,7 @@ results_dir_content() {
 
 [ "$SKIP_RESULTSDIR_CHECK" ] || RESULTS_DIR_CONTENT="$(ls $RESULTS_DIR 2> /dev/null)"
 if [ "$TRAVIS" == "true" ]; then
-    run_rc lint 'RESULT=$(mktemp); inspekt lint --exclude=.git --enable W0102,W0611 &>$RESULT || { cat $RESULT; rm $RESULT; exit -1; }; rm $RESULT'
+    run_rc lint 'RESULT=$(mktemp); inspekt lint --exclude=.git --enable W0102,W0611,W0612,W0622 &>$RESULT || { cat $RESULT; rm $RESULT; exit -1; }; rm $RESULT'
 else
     run_rc lint 'inspekt lint --exclude=.git --enable W0102,W0611,W0612,W0622'
 fi

--- a/selftests/checkall
+++ b/selftests/checkall
@@ -161,9 +161,9 @@ results_dir_content() {
 
 [ "$SKIP_RESULTSDIR_CHECK" ] || RESULTS_DIR_CONTENT="$(ls $RESULTS_DIR 2> /dev/null)"
 if [ "$TRAVIS" == "true" ]; then
-    run_rc lint 'RESULT=$(mktemp); inspekt lint --exclude=.git --enable W0102,W0404,W0611,W0612,W0622 &>$RESULT || { cat $RESULT; rm $RESULT; exit -1; }; rm $RESULT'
+    run_rc lint 'RESULT=$(mktemp); inspekt lint --exclude=.git --enable W0101,W0102,W0404,W0611,W0612,W0622 &>$RESULT || { cat $RESULT; rm $RESULT; exit -1; }; rm $RESULT'
 else
-    run_rc lint 'inspekt lint --exclude=.git --enable W0102,W0404,W0611,W0612,W0622'
+    run_rc lint 'inspekt lint --exclude=.git --enable W0101,W0102,W0404,W0611,W0612,W0622'
 fi
 # Skip checking test_utils_cpu.py due to inspektor bug
 run_rc indent 'inspekt indent --exclude=.git,selftests/unit/test_utils_cpu.py'

--- a/selftests/checkall
+++ b/selftests/checkall
@@ -161,9 +161,9 @@ results_dir_content() {
 
 [ "$SKIP_RESULTSDIR_CHECK" ] || RESULTS_DIR_CONTENT="$(ls $RESULTS_DIR 2> /dev/null)"
 if [ "$TRAVIS" == "true" ]; then
-    run_rc lint 'RESULT=$(mktemp); inspekt lint --exclude=.git --enable W0102,W0611,W0612,W0622 &>$RESULT || { cat $RESULT; rm $RESULT; exit -1; }; rm $RESULT'
+    run_rc lint 'RESULT=$(mktemp); inspekt lint --exclude=.git --enable W0102,W0404,W0611,W0612,W0622 &>$RESULT || { cat $RESULT; rm $RESULT; exit -1; }; rm $RESULT'
 else
-    run_rc lint 'inspekt lint --exclude=.git --enable W0102,W0611,W0612,W0622'
+    run_rc lint 'inspekt lint --exclude=.git --enable W0102,W0404,W0611,W0612,W0622'
 fi
 # Skip checking test_utils_cpu.py due to inspektor bug
 run_rc indent 'inspekt indent --exclude=.git,selftests/unit/test_utils_cpu.py'

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -8,7 +8,6 @@ import unittest
 
 from avocado.core import test
 from avocado.core import loader
-from avocado.core import test
 from avocado.utils import script
 
 # We need to access protected members pylint: disable=W0212


### PR DESCRIPTION
Enabling an additional couple of warnings to our lint check. 

---

Changes from v1 (#2546):
 * Renamed variable `ascii_` to `tree_view`