### PR TITLE
avocado.utils.process: attempt first to decode bytes into text [v2]

### DIFF
--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -322,18 +322,18 @@ class CmdResult(object):
 
     @property
     def stdout_text(self):
-        if isinstance(self.stdout, string_types):
-            return self.stdout
         if hasattr(self.stdout, 'decode'):
             return self.stdout.decode(self.encoding)
+        if isinstance(self.stdout, string_types):
+            return self.stdout
         raise TypeError("Unable to decode stdout into a string-like type")
 
     @property
     def stderr_text(self):
-        if isinstance(self.stderr, string_types):
-            return self.stderr
         if hasattr(self.stderr, 'decode'):
             return self.stderr.decode(self.encoding)
+        if isinstance(self.stderr, string_types):
+            return self.stderr
         raise TypeError("Unable to decode stderr into a string-like type")
 
     def __repr__(self):

--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -258,9 +258,16 @@ class TestProcessRun(unittest.TestCase):
         # but the behavior is exactly the same as if shell binary
         # produced unicode
         text = u"Avok\xe1do"
-        result = process.run("%s %s" % (ECHO_CMD, text), encoding='utf-8')
-        self.assertEqual(result.stdout, text.encode('utf-8') + b'\n')
-        self.assertEqual(result.stdout_text, text + '\n')
+        # Even though code point used is "LATIN SMALL LETTER A WITH ACUTE"
+        # (http://unicode.scarfboy.com/?s=u%2B00e1) when encoded to proper
+        # utf-8, it becomes two bytes because it is >= 0x80
+        # See https://en.wikipedia.org/wiki/UTF-8
+        encoded_text = b'Avok\xc3\xa1do'
+        self.assertEqual(text.encode('utf-8'), encoded_text)
+        self.assertEqual(encoded_text.decode('utf-8'), text)
+        result = process.run("%s -n %s" % (ECHO_CMD, text), encoding='utf-8')
+        self.assertEqual(result.stdout, encoded_text)
+        self.assertEqual(result.stdout_text, text)
 
 
 class MiscProcessTests(unittest.TestCase):


### PR DESCRIPTION
And only if the method is not available, attempt to fallback to
the stdout itself if it is a string.

Before 30617c1, the following kind of check was done:

   >>> type(bytes('foo')) in string_types
   False

And after it, the check was changed to:

   >>> isinstance(bytes('foo'), string_types)
   True

That made the bytes decoding not to be performed at times.  While the
new check is correct, we should favor the attempt to decode, and
only if not available, fallback to the original stdout if it looks
like a string.

Signed-off-by: Cleber Rosa <crosa@redhat.com>

---

Changes from v1 (#2549):
 * Refer to the correct commit