### PR TITLE
Spell check fixes for sprint #60 [v2]

### DIFF
--- a/examples/tests/doublefree.py
+++ b/examples/tests/doublefree.py
@@ -17,7 +17,7 @@ class DoubleFreeTest(Test):
 
     :avocado: tags=requires_c_compiler
 
-    :param source: name of the source file located in deps path
+    :param source: name of the source file located in a data directory
     """
 
     def setUp(self):

--- a/examples/tests/doublefree_nasty.py
+++ b/examples/tests/doublefree_nasty.py
@@ -16,7 +16,7 @@ class DoubleFreeTest(Test):
 
     :avocado: tags=failure_expected,requires_c_compiler
 
-    :param source: name of the source file located in deps path
+    :param source: name of the source file located in a data directory
     """
 
     __binary = None     # filename of the compiled program

--- a/examples/tests/modify_variable.py
+++ b/examples/tests/modify_variable.py
@@ -19,7 +19,7 @@ class PrintVariableTest(Test):
 
     :avocado: tags=requires_c_compiler
 
-    :param source: path to the source file relative to deps dir.
+    :param source: name of the source file located in a data directory
     """
 
     __binary = None    # filename of the compiled program

--- a/examples/tests/multiple_tests.py
+++ b/examples/tests/multiple_tests.py
@@ -6,10 +6,9 @@ from avocado import main
 class MultipleTests(Test):
 
     """
-    Following the idea of unittest module,
-    every test method starts with a 'test' prefix,
-    so that 'test_foo' and 'testFoo' are test methods,
-    but 'division_by_zero' and 'action' are not.
+    Following the unittest module pattern, every test method starts
+    with a literal 'test' prefix, so that 'test_foo' and 'testFoo' are
+    test methods, but 'division_by_zero' and 'action' are not.
     """
 
     def setUp(self):

--- a/examples/tests/synctest.py
+++ b/examples/tests/synctest.py
@@ -14,7 +14,7 @@ class SyncTest(Test):
     """
     Execute the synctest test suite.
 
-    :param sync_tarball: path to the tarball relative to deps dir.
+    :param sync_tarball: path to the tarball relative to a data directory
     :param default_symbols: whether to build with debug symbols (bool)
     :param sync_length: how many data should by used in sync test
     :param sync_loop: how many writes should be executed in sync test

--- a/spell.ignore
+++ b/spell.ignore
@@ -564,3 +564,17 @@ virtuozzo
 pict
 golang
 virdomain
+tmpdir
+tmpdirs
+logdir
+logdirs
+workdir
+datasize
+getoutput
+doublefree
+synctest
+getstatusoutput
+rtd
+testfoo
+commandtimeout
+uids


### PR DESCRIPTION
Signed-off-by: Cleber Rosa <crosa@redhat.com>

---

Changes from v1 (#2551):

* `s/a the/a/` on docstrings