### PR TITLE
[52LTS] selftests/functional/test_plugin_diff.py: use the detected avocado script

### DIFF
--- a/selftests/functional/test_plugin_diff.py
+++ b/selftests/functional/test_plugin_diff.py
@@ -52,9 +52,9 @@ class DiffTests(unittest.TestCase):
         result = self.run_and_check(cmd_line, expected_rc)
         msg = "# COMMAND LINE"
         self.assertIn(msg, result.stdout)
-        msg = "-./scripts/avocado run"
+        msg = "-%s run" % AVOCADO
         self.assertIn(msg, result.stdout)
-        msg = "+./scripts/avocado run"
+        msg = "+%s run" % AVOCADO
         self.assertIn(msg, result.stdout)
 
     def test_diff_nocmdline(self):


### PR DESCRIPTION
And not the hardcoded path "./scripts/avocado".

Signed-off-by: Merlin Mathesius <mmathesi@redhat.com>
Signed-off-by: Cleber Rosa <crosa@redhat.com>