### PR TITLE
job: Fixup permission denied for tmpdir per Job

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -170,6 +170,7 @@ class Job(object):
             self.__remove_tmpdir = True
         self.tmpdir = tempfile.mkdtemp(prefix="avocado_job_",
                                        dir=base_tmpdir)
+        os.chmod(self.tmpdir, os.stat(base_tmpdir).st_mode)
 
     def _setup_job_results(self):
         """


### PR DESCRIPTION
The tmpdir per job now is accessible only by the creating user ID
. And this will cause permission denied sometimes when
guest try to access the dir by other user. So change the mode to
the same as basedir

Signed-off-by: Yan Li <yannli@redhat.com>