### PR TITLE
Python 3: add universal_newlines parameter for process.run

### DIFF
--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -1178,6 +1178,8 @@ class PluginsXunitTest(AbsPluginsTest, unittest.TestCase):
                     ' --xunit - %s' % (AVOCADO, self.tmpdir, testname))
         result = process.run(cmd_line, ignore_status=True)
         xml_output = result.stdout
+        if hasattr(xml_output, 'encode'):
+            xml_output = xml_output.encode('utf-8')
         self.assertEqual(result.exit_status, e_rc,
                          "Avocado did not return rc %d:\n%s" %
                          (e_rc, result))


### PR DESCRIPTION
For python3, if universal_newlines is true, process.run return text
result output, if false, process.run return bytes result output.
In this patch, also set universal_newlines default to True.

Signed-off-by: cuzhang <cuzhang@redhat.com>