### PR TITLE
spec: requires stevedore for python2

### DIFF
--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -128,6 +128,7 @@ these days a framework) to perform automated testing.
 
 %package -n python2-%{srcname}
 Summary: %{summary}
+Requires: python2-stevedore
 Requires: %{name}-common == %{version}
 %{?python_provide:%python_provide python2-%{srcname}}
 


### PR DESCRIPTION
We someway missed that and the current v60 rpm is broken to the point
it doesn't require stevedore.
Reference: https://trello.com/c/TRHACAcr/1294-bug-v600-dnf-install-is-not-requiring-stevedore