### PR TITLE
Python 3: enable functional tests and temporary skips to broken tests [v2]

### DIFF
--- a/optional_plugins/varianter_yaml_to_mux/tests/test_multiplex.py
+++ b/optional_plugins/varianter_yaml_to_mux/tests/test_multiplex.py
@@ -2,6 +2,7 @@ import os
 import tempfile
 import shutil
 import unittest
+import sys
 
 from avocado.core import exit_codes
 from avocado.utils import process
@@ -54,6 +55,8 @@ class MultiplexTests(unittest.TestCase):
         result = self.run_and_check(cmd_line, expected_rc)
         self.assertIn('No such file or directory', result.stderr_text)
 
+    @unittest.skipIf(sys.version_info[0] == 3,
+                     "Test currently broken on Python 3")
     def test_mplex_debug(self):
         cmd_line = ('%s variants -c -d -m '
                     '/:optional_plugins/varianter_yaml_to_mux/tests/.data/mux-selftest.yaml '
@@ -139,6 +142,8 @@ class MultiplexTests(unittest.TestCase):
                     "passtest.py" % (AVOCADO, self.tmpdir))
         self.run_and_check(cmd_line, exit_codes.AVOCADO_ALL_OK, (1, 0))
 
+    @unittest.skipIf(sys.version_info[0] == 3,
+                     "Test currently broken on Python 3")
     def test_run_mplex_params(self):
         for variant_msg in (('/run/short', 'A'),
                             ('/run/medium', 'ASDFASDF'),

--- a/selftests/checkall
+++ b/selftests/checkall
@@ -24,19 +24,14 @@ parallel_selftests() {
     local ERR=0
     local FIND_UNITTESTS=$(readlink -f ./contrib/scripts/avocado-find-unittests)
     local NO_WORKERS=$(($(cat /proc/cpuinfo | grep -c processor) * 2))
-    local PY3=$(python --version 2>&1 | grep -q "$Python 3\.")$?
 
     # The directories that may contain files with tests, from the Avocado core
     # and from all optional plugins
     declare -A DIR_GLOB_MAP
-    if [ $PY3 -eq 1 ]; then
-        DIR_GLOB_MAP[selftests]="selftests/unit/test_*.py selftests/functional/test_*.py selftests/doc/test_*.py"
-        for PLUGIN in $(find optional_plugins -mindepth 1 -maxdepth 1 -type d); do
-            DIR_GLOB_MAP[$PLUGIN]="tests/test_*.py"
-        done;
-    else
-        DIR_GLOB_MAP[selftests]="selftests/unit/test_*.py selftests/doc/test_*.py"
-    fi
+    DIR_GLOB_MAP[selftests]="selftests/unit/test_*.py selftests/functional/test_*.py selftests/doc/test_*.py"
+    for PLUGIN in $(find optional_plugins -mindepth 1 -maxdepth 1 -type d); do
+        DIR_GLOB_MAP[$PLUGIN]="tests/test_*.py"
+    done;
 
     declare -A TESTS
     for TEST_DIR in "${!DIR_GLOB_MAP[@]}"; do

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -603,6 +603,8 @@ class RunnerHumanOutputTest(unittest.TestCase):
                       b'INTERRUPT 0 | CANCEL 1',
                       result.stdout)
 
+    @unittest.skipIf(sys.version_info[0] == 3,
+                     "Test currently broken on Python 3")
     @unittest.skipIf(not GNU_ECHO_BINARY,
                      'GNU style echo binary not available')
     def test_ugly_echo_cmd(self):

--- a/selftests/functional/test_loader.py
+++ b/selftests/functional/test_loader.py
@@ -6,6 +6,7 @@ import stat
 import tempfile
 import shutil
 import signal
+import sys
 import unittest
 
 from avocado.core import exit_codes
@@ -268,6 +269,8 @@ class LoaderTestFunctional(unittest.TestCase):
                     % (AVOCADO, self.tmpdir, mytest))
         self._run_with_timeout(cmd_line, 5)
 
+    @unittest.skipIf(sys.version_info[0] == 3,
+                     "Test currently broken on Python 3")
     @unittest.skipUnless(os.path.exists("/bin/true"), "/bin/true not "
                          "available")
     @unittest.skipUnless(os.path.exists("/bin/echo"), "/bin/echo not "
@@ -326,6 +329,8 @@ class LoaderTestFunctional(unittest.TestCase):
         self.assertEqual(test, 11, "Number of tests is not 12 (%s):\n%s"
                          % (test, result))
 
+    @unittest.skipIf(sys.version_info[0] == 3,
+                     "Test currently broken on Python 3")
     def test_python_unittest(self):
         test_path = os.path.join(basedir, "selftests", ".data", "unittests.py")
         cmd = ("%s run --sysinfo=off --job-results-dir %s --json - -- %s"

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -1,8 +1,9 @@
 import json
-import tempfile
 import os
 import re
 import shutil
+import sys
+import tempfile
 import unittest
 from xml.dom import minidom
 
@@ -162,6 +163,8 @@ class OutputTest(unittest.TestCase):
                          "Libc double free can be seen in avocado "
                          "doublefree output:\n%s" % output)
 
+    @unittest.skipIf(sys.version_info[0] == 3,
+                     "Test currently broken on Python 3")
     def test_print_to_std(self):
         def _check_output(path, exps, name):
             i = 0
@@ -246,6 +249,8 @@ class OutputTest(unittest.TestCase):
                 with open(output_file_path, 'r') as output:
                     self.assertEqual(output.read(), '')
 
+    @unittest.skipIf(sys.version_info[0] == 3,
+                     "Test currently broken on Python 3")
     def test_check_on_off(self):
         """
         Checks that output will always be kept, but it will only make into

--- a/selftests/functional/test_output_check.py
+++ b/selftests/functional/test_output_check.py
@@ -1,7 +1,8 @@
 import json
 import os
-import tempfile
 import shutil
+import sys
+import tempfile
 import unittest
 
 from avocado.core import exit_codes
@@ -138,6 +139,8 @@ class RunnerSimpleTest(unittest.TestCase):
                          (expected_rc, result))
         self.assertIn(tampered_msg, result.stdout)
 
+    @unittest.skipIf(sys.version_info[0] == 3,
+                     "Test currently broken on Python 3")
     def test_output_diff(self):
         self._check_output_record_all()
         tampered_msg_stdout = b"I PITY THE FOOL THAT STANDS ON STDOUT!"

--- a/selftests/run
+++ b/selftests/run
@@ -30,15 +30,9 @@ def test_suite():
     loader = unittest.TestLoader()
     selftests_dir = os.path.dirname(os.path.abspath(__file__))
     basedir = os.path.dirname(selftests_dir)
-    if sys.version_info[0] == 3:
-        sections = ('unit', 'doc')
-    else:
-        sections = ('unit', 'functional', 'doc')
-    for section in sections:
+    for section in ('unit', 'functional', 'doc'):
         suite.addTests(loader.discover(start_dir=os.path.join(selftests_dir, section),
                                        top_level_dir=basedir))
-    if sys.version_info[0] == 3:
-        return suite
     plugins = (('avocado-framework-plugin-varianter-yaml-to-mux',
                 'varianter_yaml_to_mux'),
                ('avocado-framework-plugin-runner-remote',


### PR DESCRIPTION
There are few issues (3 to my count) which affect a number of tests
on Python 3.  Instead of not executing any of the functional tests,
let's skip the broken ones.

This is important because it will prevent new issues from making
its way into the Avocado code.

The list of tests being skipped is being tracked on our planning board,
so that they are accounted for, and enabled when fixed.

Reference: https://trello.com/c/eFY9Vw1R/1282-python-3-functional-tests-checklist

---

Changes from v1 (#2518):
 * Added commit to fix loading of JSON on Python 3.4 (which runs on Travis-CI)
 * Rebased