### PR TITLE
utils.astring: add `;` to the FS_UNSAFE_CHARS

### DIFF
--- a/avocado/utils/astring.py
+++ b/avocado/utils/astring.py
@@ -35,14 +35,14 @@ from six.moves import xrange as range
 
 
 #: String containing all fs-unfriendly chars (Windows-fat/Linux-ext3)
-FS_UNSAFE_CHARS = '<>:"/\\|?*'
+FS_UNSAFE_CHARS = '<>:"/\\|?*;'
 
 # Translate table to replace fs-unfriendly chars
 if PY3:
     _FS_TRANSLATE = bytes.maketrans(bytes(FS_UNSAFE_CHARS, "ascii"),
-                                    b'_________')
+                                    b'__________')
 else:
-    _FS_TRANSLATE = string.maketrans(FS_UNSAFE_CHARS, '_________')
+    _FS_TRANSLATE = string.maketrans(FS_UNSAFE_CHARS, '__________')
 
 
 def bitlist_to_string(data):

--- a/selftests/unit/test_test.py
+++ b/selftests/unit/test_test.py
@@ -79,13 +79,13 @@ class TestClassTestUnit(unittest.TestCase):
 
         # Everything fits
         check(1, "a" * 253, None, "1-" + ("a" * 253))
-        check(2, "a" * 251, {"variant_id": 1}, "2-" + ("a" * 251) + ";1")
-        check(99, "a" * 249, {"variant_id": 88}, "99-" + ("a" * 249) + ";88")
+        check(2, "a" * 251, {"variant_id": 1}, "2-" + ("a" * 251) + "_1")
+        check(99, "a" * 249, {"variant_id": 88}, "99-" + ("a" * 249) + "_88")
         # Shrink name
-        check(3, "a" * 252, {"variant_id": 1}, "3-" + ('a' * 251) + ";1")
+        check(3, "a" * 252, {"variant_id": 1}, "3-" + ('a' * 251) + "_1")
         # Shrink variant
-        check("a" * 253, "whatever", {"variant_id": 99}, "a" * 253 + ";9")
-        check("a" * 254, "whatever", {"variant_id": 99}, "a" * 254 + ";")
+        check("a" * 253, "whatever", {"variant_id": 99}, "a" * 253 + "_9")
+        check("a" * 254, "whatever", {"variant_id": 99}, "a" * 254 + "_")
         # No variant
         tst = check("a" * 255, "whatever", {"variant_id": "whatever-else"},
                     "a" * 255)
@@ -375,7 +375,7 @@ class TestID(unittest.TestCase):
         variant = {'variant_id': variant_id}
         test_id = test.TestID(uid, name, variant=variant)
         self.assertEqual(test_id.uid, 1)
-        self.assertEqual(test_id.str_filesystem, '%s;%s' % (uid, variant_id[:253]))
+        self.assertEqual(test_id.str_filesystem, '%s_%s' % (uid, variant_id[:253]))
         self.assertIs(test_id.variant, variant_id)
         self.assertEqual(test_id.str_variant, ";%s" % variant_id)
 


### PR DESCRIPTION
We are using `;` in the test name, before the Variant ID. That character
is unsafe to be used as a fs path and, as such, need to be replaced for
a `_`.

Fixes: #2567 