### PR TITLE
examples/tests/gdbtest.py: use teststmpdir for compiled binaries

### DIFF
--- a/examples/tests/gdbtest.py
+++ b/examples/tests/gdbtest.py
@@ -32,20 +32,21 @@ class GdbTest(Test):
                     "-auto-debug-it"]
 
     def setUp(self):
-        return99_source_path = self.get_data('return99.c')
-        if return99_source_path is None:
-            self.cancel('Test is missing data file "return99.c"')
+        self.return99_binary_path = os.path.join(self.teststmpdir, 'return99')
+        if not os.path.exists(self.return99_binary_path):
+            return99_source_path = self.get_data('return99.c')
+            if return99_source_path is None:
+                self.cancel('Test is missing data file "return99.c"')
+            process.system('gcc -O0 -g %s -o %s' % (return99_source_path,
+                                                    self.return99_binary_path))
 
-        segfault_source_path = self.get_data('segfault.c')
-        if segfault_source_path is None:
-            self.cancel('Test is missing data file "segfault.c"')
-
-        self.return99_binary_path = os.path.join(self.outputdir, 'return99')
-        process.system('gcc -O0 -g %s -o %s' % (return99_source_path,
-                                                self.return99_binary_path))
-        self.segfault_binary_path = os.path.join(self.outputdir, 'segfault')
-        process.system('gcc -O0 -g %s -o %s' % (segfault_source_path,
-                                                self.segfault_binary_path))
+        self.segfault_binary_path = os.path.join(self.teststmpdir, 'segfault')
+        if not os.path.exists(self.segfault_binary_path):
+            segfault_source_path = self.get_data('segfault.c')
+            if segfault_source_path is None:
+                self.cancel('Test is missing data file "segfault.c"')
+            process.system('gcc -O0 -g %s -o %s' % (segfault_source_path,
+                                                    self.segfault_binary_path))
 
     @staticmethod
     def is_process_alive(process):


### PR DESCRIPTION
When this test was initially written, the concept of a shared
directory available across tests did not exist.  Let's optimize the
execution by avoid compilation of the same binary on every single
test.

Signed-off-by: Cleber Rosa <crosa@redhat.com>