### PR TITLE
pylint: Fix W605 issues

### DIFF
--- a/avocado/utils/astring.py
+++ b/avocado/utils/astring.py
@@ -123,8 +123,8 @@ def strip_console_codes(output, custom_codes=None):
     return_str = ""
     index = 0
     output = "\x1b[m%s" % output
-    console_codes = "%[G@8]|\[[@A-HJ-MPXa-hl-nqrsu\`]"
-    console_codes += "|\[[\d;]+[HJKgqnrm]|#8|\([B0UK]|\)"
+    console_codes = "%[G@8]|\\[[@A-HJ-MPXa-hl-nqrsu\\`]"
+    console_codes += "|\\[[\\d;]+[HJKgqnrm]|#8|\\([B0UK]|\\)"
     if custom_codes is not None and custom_codes not in console_codes:
         console_codes += "|%s" % custom_codes
     while index < len(output):

--- a/avocado/utils/external/spark.py
+++ b/avocado/utils/external/spark.py
@@ -125,7 +125,7 @@ class GenericParser:
         self.augment(start)
         self.ruleschanged = 1
 
-    _NULLABLE = '\e_'
+    _NULLABLE = '\\e_'
     _START = 'START'
     _BOF = '|-'
 

--- a/avocado/utils/linux_modules.py
+++ b/avocado/utils/linux_modules.py
@@ -76,7 +76,7 @@ def parse_lsmod_for_module(l_raw, module_name, escape=True):
     # having to splitlines use named matches so we can extract the dictionary
     # with groupdict
     pattern = (r"^(?P<name>%s)\s+(?P<size>\d+)\s+(?P<used>\d+)"
-               "\s*(?P<submodules>\S+)?$")
+               r"\s*(?P<submodules>\S+)?$")
     lsmod = re.search(pattern % module_search, l_raw, re.M)
     if lsmod:
         # default to empty list if no submodules

--- a/avocado/utils/memory.py
+++ b/avocado/utils/memory.py
@@ -270,7 +270,7 @@ def read_from_vmstat(key):
     """
     with open("/proc/vmstat") as vmstat:
         vmstat_info = vmstat.read()
-        return int(re.findall("%s\s+(\d+)" % key, vmstat_info)[0])
+        return int(re.findall(r"%s\s+(\d+)" % key, vmstat_info)[0])
 
 
 def read_from_smaps(pid, key):
@@ -288,7 +288,7 @@ def read_from_smaps(pid, key):
         smaps_info = smaps.read()
 
         memory_size = 0
-        for each_number in re.findall("%s:\s+(\d+)" % key, smaps_info):
+        for each_number in re.findall(r"%s:\s+(\d+)" % key, smaps_info):
             memory_size += int(each_number)
 
         return memory_size
@@ -348,24 +348,24 @@ def get_buddy_info(chunk_sizes, nodes="all", zones="all"):
     with open("/proc/buddyinfo") as buddy_info:
         buddy_info_content = buddy_info.read()
 
-        re_buddyinfo = "Node\s+"
+        re_buddyinfo = r"Node\s+"
         if nodes == "all":
-            re_buddyinfo += "(\d+)"
+            re_buddyinfo += r"(\d+)"
         else:
             re_buddyinfo += "(%s)" % "|".join(nodes.split())
 
         if not re.findall(re_buddyinfo, buddy_info_content):
             logging.warn("Can not find Nodes %s" % nodes)
             return None
-        re_buddyinfo += ".*?zone\s+"
+        re_buddyinfo += r".*?zone\s+"
         if zones == "all":
-            re_buddyinfo += "(\w+)"
+            re_buddyinfo += r"(\w+)"
         else:
             re_buddyinfo += "(%s)" % "|".join(zones.split())
         if not re.findall(re_buddyinfo, buddy_info_content):
             logging.warn("Can not find zones %s" % zones)
             return None
-        re_buddyinfo += "\s+([\s\d]+)"
+        re_buddyinfo += r"\s+([\s\d]+)"
 
         buddy_list = re.findall(re_buddyinfo, buddy_info_content)
 

--- a/avocado/utils/software_manager.py
+++ b/avocado/utils/software_manager.py
@@ -658,7 +658,7 @@ class ZypperBackend(RpmBackend):
                                  verbose=False)
         out = cmd_result.stdout.strip()
         try:
-            ver = re.findall('\d.\d*.\d*', out)[0]
+            ver = re.findall(r'\d.\d*.\d*', out)[0]
         except IndexError:
             ver = out
         self.pm_version = ver

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -803,7 +803,7 @@ class RunnerSimpleTest(unittest.TestCase):
                               "--external-runner %s --sysinfo=off "
                               "--job-timeout 3"
                               % (AVOCADO, self.tmpdir, SLEEP_BINARY))
-        proc.read_until_output_matches(["\(1/1\)"], timeout=3,
+        proc.read_until_output_matches([r"\(1/1\)"], timeout=3,
                                        internal_timeout=0.01)
         # We need pid of the avocado process, not the shell executing it
         avocado_shell = psutil.Process(proc.get_pid())

--- a/selftests/unit/test_astring.py
+++ b/selftests/unit/test_astring.py
@@ -69,7 +69,7 @@ class AstringTest(unittest.TestCase):
         self.assertEqual(astring.tabular_output(matrix), str_matrix)
 
     def test_safe_path(self):
-        self.assertEqual(astring.string_to_safe_path('a<>:"/\\|\?*b'),
+        self.assertEqual(astring.string_to_safe_path('a<>:"/\\|\\?*b'),
                          "a__________b")
         self.assertEqual(astring.string_to_safe_path('..'), "_.")
         self.assertEqual(len(astring.string_to_safe_path(" " * 300)), 255)


### PR DESCRIPTION
The newly W605 warning is caused by incorrect escaped chars, that are
automatically translated to '\\' but future versions should treat it as
SyntaxError.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>