### PR TITLE
tree: Provide fingerprint for TreeNodeEnvOnly

### DIFF
--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -129,6 +129,9 @@ class TreeNodeEnvOnly(object):
             return False
         return True
 
+    def fingerprint(self):
+        return "%s%s" % (self.path, self.environment)
+
     def get_environment(self):
         return self.environment
 

--- a/optional_plugins/loader_yaml/tests/.data/two_tests.yaml
+++ b/optional_plugins/loader_yaml/tests/.data/two_tests.yaml
@@ -1,0 +1,5 @@
+!mux
+instrumented:
+    test_reference: passtest.py
+simple:
+    test_reference: passtest.sh

--- a/optional_plugins/loader_yaml/tests/test_yaml_loader.py
+++ b/optional_plugins/loader_yaml/tests/test_yaml_loader.py
@@ -1,0 +1,56 @@
+import os
+import tempfile
+import shutil
+import unittest
+
+from avocado.core import exit_codes
+from avocado.utils import process
+
+
+BASEDIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..', '..')
+BASEDIR = os.path.abspath(BASEDIR)
+
+AVOCADO = os.environ.get("UNITTEST_AVOCADO_CMD", "./scripts/avocado")
+
+
+class YamlLoaderTests(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+
+    def run_and_check(self, cmd_line, expected_rc, stdout_strings=None):
+        os.chdir(BASEDIR)
+        result = process.run(cmd_line, ignore_status=True)
+        self.assertEqual(result.exit_status, expected_rc,
+                         "Command %s did not return rc "
+                         "%d:\n%s" % (cmd_line, expected_rc, result))
+        if stdout_strings is not None:
+            for exp in stdout_strings:
+                self.assertIn(exp, result.stdout, b"'%s' not in stdout:"
+                              b"\n%s" % (exp, result))
+        return result
+
+    def test_replay(self):
+        # Run source job
+        tests = ["passtest.py:PassTest.test", "passtest.sh"]
+        cmd = ('%s run --sysinfo=off --job-results-dir %s -- '
+               'optional_plugins/loader_yaml/tests/.data/two_tests.yaml'
+               % (AVOCADO, self.tmpdir))
+        res = self.run_and_check(cmd, exit_codes.AVOCADO_ALL_OK, tests)
+        # Run replay job
+        for line in res.stdout.splitlines():
+            if line.startswith(b"JOB LOG"):
+                srcjob = line[13:]
+                break
+        else:
+            self.fail("Unable to find 'JOB LOG' in:\n%s" % res)
+        cmd = ('%s run --sysinfo=off --job-results-dir %s '
+               '--replay %s' % (AVOCADO, self.tmpdir, srcjob))
+        self.run_and_check(cmd, exit_codes.AVOCADO_ALL_OK, tests)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The fingerprint is used when replaying jobs causing "yaml_loader" test
not being replayable.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>