### PR TITLE
avocado.utils.process: require unicode input for command to be executed

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -1120,6 +1120,10 @@ class SimpleTest(Test):
         self._command = None
         if self.filename is not None:
             self._command = pipes.quote(self.filename)
+            # process.run expects unicode as the command, but pipes.quote
+            # turns it into a "bytes" array in Python 2
+            if not astring.is_text(self._command):
+                self._command = astring.to_text(self._command, defaults.ENCODING)
 
     @property
     def filename(self):
@@ -1145,7 +1149,6 @@ class SimpleTest(Test):
             test_params = dict([(str(key), str(val)) for _, key, val in
                                 self.params.iteritems()])
 
-            # process.run uses shlex.split(), the self.path needs to be escaped
             result = process.run(self._command, verbose=True,
                                  env=test_params, encoding=defaults.ENCODING)
 

--- a/avocado/utils/astring.py
+++ b/avocado/utils/astring.py
@@ -27,6 +27,7 @@ And not notice until their code starts failing.
 
 import itertools
 import re
+import sys
 import string
 
 from six import string_types, PY3
@@ -278,3 +279,28 @@ def string_to_safe_path(input_str):
         for bad_chr in FS_UNSAFE_CHARS:
             input_str = input_str.replace(bad_chr, "_")
         return input_str
+
+
+def is_bytes(data):
+    """
+    Checks if the data given is a sequence of bytes
+
+    And not a "text" type, that can be of multi-byte characters.
+    Also, this does NOT mean a bytearray type.
+
+    :param data: the instance to be checked if it falls under the definition
+                 of an array of bytes.
+    """
+    return isinstance(data, bytes)
+
+
+def is_text(data):
+    """
+    Checks if the data given is a suitable for holding text
+
+    That is, if it can hold text that requires more than one byte for
+    each character.
+    """
+    if sys.version_info[0] < 3:
+        return isinstance(data, unicode)
+    return isinstance(data, str)

--- a/avocado/utils/astring.py
+++ b/avocado/utils/astring.py
@@ -304,3 +304,23 @@ def is_text(data):
     if sys.version_info[0] < 3:
         return isinstance(data, unicode)
     return isinstance(data, str)
+
+
+def to_text(data, encoding=None):
+    """
+    Convert data to text
+
+    Action is only taken if data is "bytes", in which case it's
+    decoded into the given encoding and should produce a type that
+    passes the is_text() check.
+
+    :param data: data to be transformed into text
+    :type data: either bytes or other data that will be returned
+                unchanged
+    """
+    if is_bytes(data):
+        if encoding is None:
+            return data.decode()
+        else:
+            return data.decode(encoding)
+    return data

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -82,23 +82,6 @@ class CmdError(Exception):
         self.result = result
         self.additional_text = additional_text
 
-    def __str__(self):
-        if self.result is not None:
-            if self.result.interrupted:
-                msg = "Command '%s' interrupted by %s"
-                msg %= (self.command, self.result.interrupted)
-            elif self.result.exit_status is None:
-                msg = "Command '%s' failed and is not responding to signals"
-                msg %= self.command
-            else:
-                msg = "Command '%s' failed (rc=%d)"
-                msg %= (self.command, self.result.exit_status)
-            if self.additional_text:
-                msg += ", " + self.additional_text
-            return msg
-        else:
-            return "CmdError"
-
 
 def normalize_cmd(cmd, encoding=None):
     """
@@ -356,19 +339,6 @@ class CmdResult(object):
         if isinstance(self.stderr, string_types):
             return self.stderr
         raise TypeError("Unable to decode stderr into a string-like type")
-
-    def __repr__(self):
-        cmd_rep = ("Command: %s\n"
-                   "Exit status: %s\n"
-                   "Duration: %s\n"
-                   "Stdout:\n%s\n"
-                   "Stderr:\n%s\n"
-                   "PID:\n%s\n" % (self.command, self.exit_status,
-                                   self.duration, self.stdout, self.stderr,
-                                   self.pid))
-        if self.interrupted:
-            cmd_rep += "Command interrupted by %s\n" % self.interrupted
-        return cmd_rep
 
 
 class FDDrainer(object):

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -34,6 +34,7 @@ import time
 from io import BytesIO, UnsupportedOperation
 from six import PY2, string_types
 
+from . import astring
 from . import gdb
 from . import runtime
 from . import path
@@ -279,6 +280,26 @@ def binary_from_shell_cmd(cmd, encoding=None):
         if not _RE_BASH_SET_VARIABLE.match(item):
             return item
     raise ValueError("Unable to parse first binary from '%s'" % cmd)
+
+
+def cmd_split(cmd):
+    """
+    Splits a command line into individual components
+
+    This is a simple wrapper around :func:`shlex.split`, which has the
+    requirement of having text (not bytes) as its argument on Python 3,
+    but bytes on Python 2.
+
+    :param cmd: text (a multi byte string) encoded as 'utf-8'
+    """
+    if sys.version_info[0] < 3:
+        data = cmd.encode('utf-8')
+        result = shlex.split(data)
+        result = [i.decode('utf-8') for i in result]
+    else:
+        data = astring.to_text(cmd, 'utf-8')
+        result = shlex.split(data)
+    return result
 
 
 class CmdResult(object):

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -1,4 +1,3 @@
-# This Python file uses the following encoding: utf-8
 import aexpect
 import glob
 import json
@@ -648,7 +647,7 @@ class RunnerSimpleTest(unittest.TestCase):
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
         self.pass_script = script.TemporaryScript(
-            'ʊʋʉʈɑ ʅʛʌ',
+            u'\u00e1 \u00e9 \u00ed \u00f3 \u00fa',
             "#!/bin/sh\ntrue",
             'avocado_simpletest_functional')
         self.pass_script.save()

--- a/selftests/unit/test_astring.py
+++ b/selftests/unit/test_astring.py
@@ -77,6 +77,35 @@ class AstringTest(unittest.TestCase):
         self.assertEqual(astring.string_to_safe_path(avocado),
                          "%s__" % avocado[:-2])
 
+    def test_is_bytes(self):
+        """
+        Verifies what bytes means, basically that they are the same
+        thing accross Python 2 and 3 and can be decoded into "text"
+        """
+        binary = b''
+        text = u''
+        self.assertTrue(astring.is_bytes(binary))
+        self.assertFalse(astring.is_bytes(text))
+        self.assertTrue(hasattr(binary, 'decode'))
+        self.assertTrue(astring.is_text(binary.decode()))
+        # on Python 2, each str member is also a single byte char
+        if sys.version_info[0] < 3:
+            self.assertTrue(astring.is_bytes(str('')))
+        else:
+            self.assertFalse(astring.is_bytes(str('')))
+
+    def test_is_text(self):
+        """
+        Verifies what text means, basically that they can represent
+        extended set of characters and can be encoded into "bytes"
+        """
+        binary = b''
+        text = u''
+        self.assertTrue(astring.is_text(text))
+        self.assertFalse(astring.is_text(binary))
+        self.assertTrue(hasattr(text, 'encode'))
+        self.assertTrue(astring.is_bytes(text.encode()))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/selftests/unit/test_astring.py
+++ b/selftests/unit/test_astring.py
@@ -106,6 +106,23 @@ class AstringTest(unittest.TestCase):
         self.assertTrue(hasattr(text, 'encode'))
         self.assertTrue(astring.is_bytes(text.encode()))
 
+    def test_to_text_is_text(self):
+        self.assertTrue(astring.is_text(astring.to_text(b'')))
+        self.assertTrue(astring.is_text(astring.to_text('')))
+        self.assertTrue(astring.is_text(astring.to_text(u'')))
+
+    def test_to_text_decode_is_text(self):
+        self.assertTrue(astring.is_text(astring.to_text(b'', 'ascii')))
+        self.assertTrue(astring.is_text(astring.to_text('', 'ascii')))
+        self.assertTrue(astring.is_text(astring.to_text(u'', 'ascii')))
+
+    def test_to_text_decode_utf_8(self):
+        text_1 = astring.to_text(b'\xc3\xa1', 'utf-8')
+        text_2 = astring.to_text(u'\u00e1', 'utf-8')
+        self.assertTrue(astring.is_text(text_1))
+        self.assertTrue(astring.is_text(text_1))
+        self.assertEqual(text_1, text_2)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -229,7 +229,8 @@ class TestProcessRun(unittest.TestCase):
         encoded_text = b'Avok\xc3\xa1do'
         self.assertEqual(text.encode('utf-8'), encoded_text)
         self.assertEqual(encoded_text.decode('utf-8'), text)
-        result = process.run("%s -n %s" % (ECHO_CMD, text), encoding='utf-8')
+        cmd = u"%s -n %s" % (ECHO_CMD, text)
+        result = process.run(cmd, encoding='utf-8')
         self.assertEqual(result.stdout, encoded_text)
         self.assertEqual(result.stdout_text, text)
 

--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -25,15 +25,15 @@ def probe_binary(binary):
         return None
 
 
-TRUE_CMD = probe_binary('true')
 ECHO_CMD = probe_binary('echo')
+FICTIONAL_CMD = '/usr/bin/fictional_cmd'
 
 
 class TestSubProcess(unittest.TestCase):
 
     def test_allow_output_check_parameter(self):
         self.assertRaises(ValueError, process.SubProcess,
-                          TRUE_CMD, False, "invalid")
+                          FICTIONAL_CMD, False, "invalid")
 
 
 class TestGDBProcess(unittest.TestCase):
@@ -67,11 +67,9 @@ class TestGDBProcess(unittest.TestCase):
         self.assertFalse(process.should_run_inside_gdb("foo bar baz"))
         self.assertFalse(process.should_run_inside_gdb("foo ' "))
 
-    @unittest.skipUnless(TRUE_CMD,
-                         '"true" binary not available')
     def test_get_sub_process_klass(self):
         gdb.GDB_RUN_BINARY_NAMES_EXPR = []
-        self.assertIs(process.get_sub_process_klass(TRUE_CMD),
+        self.assertIs(process.get_sub_process_klass(FICTIONAL_CMD),
                       process.SubProcess)
 
         gdb.GDB_RUN_BINARY_NAMES_EXPR.append('/bin/false')
@@ -79,7 +77,7 @@ class TestGDBProcess(unittest.TestCase):
                       process.GDBSubProcess)
         self.assertIs(process.get_sub_process_klass('false'),
                       process.GDBSubProcess)
-        self.assertIs(process.get_sub_process_klass('true'),
+        self.assertIs(process.get_sub_process_klass(FICTIONAL_CMD),
                       process.SubProcess)
 
     def test_split_gdb_expr(self):
@@ -104,10 +102,6 @@ def mock_fail_find_cmd(cmd, default=None):
 
 class TestProcessRun(unittest.TestCase):
 
-    @unittest.skipUnless(TRUE_CMD,
-                         '"true" binary not available')
-    @mock.patch.object(path, 'find_command',
-                       mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid',
                        mock.Mock(return_value=1000))
     def test_subprocess_nosudo(self):
@@ -115,10 +109,6 @@ class TestProcessRun(unittest.TestCase):
         p = process.SubProcess(cmd='ls -l')
         self.assertEqual(p.cmd, expected_command)
 
-    @unittest.skipUnless(TRUE_CMD,
-                         '"true" binary not available')
-    @mock.patch.object(path, 'find_command',
-                       mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid', mock.Mock(return_value=0))
     def test_subprocess_nosudo_uid_0(self):
         expected_command = 'ls -l'
@@ -142,10 +132,6 @@ class TestProcessRun(unittest.TestCase):
         p = process.SubProcess(cmd='ls -l', sudo=True)
         self.assertEqual(p.cmd, expected_command)
 
-    @unittest.skipUnless(TRUE_CMD,
-                         '"true" binary not available')
-    @mock.patch.object(path, 'find_command',
-                       mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid', mock.Mock(return_value=0))
     def test_subprocess_sudo_uid_0(self):
         expected_command = 'ls -l'
@@ -168,30 +154,18 @@ class TestProcessRun(unittest.TestCase):
         p = process.SubProcess(cmd='ls -l', sudo=True, shell=True)
         self.assertEqual(p.cmd, expected_command)
 
-    @unittest.skipUnless(TRUE_CMD,
-                         '"true" binary not available')
-    @mock.patch.object(path, 'find_command',
-                       mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid', mock.Mock(return_value=0))
     def test_subprocess_sudo_shell_uid_0(self):
         expected_command = 'ls -l'
         p = process.SubProcess(cmd='ls -l', sudo=True, shell=True)
         self.assertEqual(p.cmd, expected_command)
 
-    @unittest.skipUnless(TRUE_CMD,
-                         '"true" binary not available')
-    @mock.patch.object(path, 'find_command',
-                       mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid', mock.Mock(return_value=1000))
     def test_run_nosudo(self):
         expected_command = 'ls -l'
         p = process.run(cmd='ls -l', ignore_status=True)
         self.assertEqual(p.command, expected_command)
 
-    @unittest.skipUnless(TRUE_CMD,
-                         '"true" binary not available')
-    @mock.patch.object(path, 'find_command',
-                       mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid', mock.Mock(return_value=0))
     def test_run_nosudo_uid_0(self):
         expected_command = 'ls -l'
@@ -214,10 +188,6 @@ class TestProcessRun(unittest.TestCase):
         p = process.run(cmd='ls -l', sudo=True, ignore_status=True)
         self.assertEqual(p.command, expected_command)
 
-    @unittest.skipUnless(TRUE_CMD,
-                         '"true" binary not available')
-    @mock.patch.object(path, 'find_command',
-                       mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid', mock.Mock(return_value=0))
     def test_run_sudo_uid_0(self):
         expected_command = 'ls -l'
@@ -240,10 +210,6 @@ class TestProcessRun(unittest.TestCase):
         p = process.run(cmd='ls -l', sudo=True, shell=True, ignore_status=True)
         self.assertEqual(p.command, expected_command)
 
-    @unittest.skipUnless(TRUE_CMD,
-                         '"true" binary not available')
-    @mock.patch.object(path, 'find_command',
-                       mock.Mock(return_value=TRUE_CMD))
     @mock.patch.object(os, 'getuid', mock.Mock(return_value=0))
     def test_run_sudo_shell_uid_0(self):
         expected_command = 'ls -l'

--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -125,15 +125,14 @@ class TestProcessRun(unittest.TestCase):
         p = process.SubProcess(cmd='ls -l')
         self.assertEqual(p.cmd, expected_command)
 
-    @unittest.skipUnless(TRUE_CMD,
-                         '"true" binary not available')
     @mock.patch.object(path, 'find_command',
-                       mock.Mock(return_value=TRUE_CMD))
+                       mock.Mock(return_value='/bin/sudo'))
     @mock.patch.object(os, 'getuid',
                        mock.Mock(return_value=1000))
     def test_subprocess_sudo(self):
-        expected_command = '%s -n ls -l' % TRUE_CMD
+        expected_command = '/bin/sudo -n ls -l'
         p = process.SubProcess(cmd='ls -l', sudo=True)
+        path.find_command.assert_called_once_with('sudo')
         self.assertEqual(p.cmd, expected_command)
 
     @mock.patch.object(path, 'find_command', mock_fail_find_cmd)
@@ -153,14 +152,13 @@ class TestProcessRun(unittest.TestCase):
         p = process.SubProcess(cmd='ls -l', sudo=True)
         self.assertEqual(p.cmd, expected_command)
 
-    @unittest.skipUnless(TRUE_CMD,
-                         '"true" binary not available')
     @mock.patch.object(path, 'find_command',
-                       mock.Mock(return_value=TRUE_CMD))
+                       mock.Mock(return_value='/bin/sudo'))
     @mock.patch.object(os, 'getuid', mock.Mock(return_value=1000))
     def test_subprocess_sudo_shell(self):
-        expected_command = '%s -n -s ls -l' % TRUE_CMD
+        expected_command = '/bin/sudo -n -s ls -l'
         p = process.SubProcess(cmd='ls -l', sudo=True, shell=True)
+        path.find_command.assert_called_once_with('sudo')
         self.assertEqual(p.cmd, expected_command)
 
     @mock.patch.object(path, 'find_command', mock_fail_find_cmd)
@@ -200,14 +198,13 @@ class TestProcessRun(unittest.TestCase):
         p = process.run(cmd='ls -l', ignore_status=True)
         self.assertEqual(p.command, expected_command)
 
-    @unittest.skipUnless(TRUE_CMD,
-                         '"true" binary not available')
     @mock.patch.object(path, 'find_command',
-                       mock.Mock(return_value=TRUE_CMD))
+                       mock.Mock(return_value='/bin/sudo'))
     @mock.patch.object(os, 'getuid', mock.Mock(return_value=1000))
     def test_run_sudo(self):
-        expected_command = '%s -n ls -l' % TRUE_CMD
+        expected_command = '/bin/sudo -n ls -l'
         p = process.run(cmd='ls -l', sudo=True, ignore_status=True)
+        path.find_command.assert_called_once_with('sudo')
         self.assertEqual(p.command, expected_command)
 
     @mock.patch.object(path, 'find_command', mock_fail_find_cmd)
@@ -227,14 +224,13 @@ class TestProcessRun(unittest.TestCase):
         p = process.run(cmd='ls -l', sudo=True, ignore_status=True)
         self.assertEqual(p.command, expected_command)
 
-    @unittest.skipUnless(TRUE_CMD,
-                         '"true" binary not available')
     @mock.patch.object(path, 'find_command',
-                       mock.Mock(return_value=TRUE_CMD))
+                       mock.Mock(return_value='/bin/sudo'))
     @mock.patch.object(os, 'getuid', mock.Mock(return_value=1000))
     def test_run_sudo_shell(self):
-        expected_command = '%s -n -s ls -l' % TRUE_CMD
+        expected_command = '/bin/sudo -n -s ls -l'
         p = process.run(cmd='ls -l', sudo=True, shell=True, ignore_status=True)
+        path.find_command.assert_called_once_with('sudo')
         self.assertEqual(p.command, expected_command)
 
     @mock.patch.object(path, 'find_command', mock_fail_find_cmd)

--- a/selftests/unit/test_utils_script.py
+++ b/selftests/unit/test_utils_script.py
@@ -1,0 +1,20 @@
+import os
+import unittest
+
+
+from avocado.utils import script
+
+
+class TestTemporary(unittest.TestCase):
+
+    def test_unicode_name(self):
+        path = u'\u00e1 \u00e9 \u00ed \u00f3 \u00fa'
+        content = "a e i o u"
+        with script.TemporaryScript(path, content) as temp_script:
+            self.assertTrue(os.path.exists(temp_script.path))
+            with open(temp_script.path) as temp_script_file:
+                self.assertEqual(content, temp_script_file.read())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
With the increasing exposition to both content in extended character sets, and the Python 2 and 3 important differences, it makes sense to standardize the internal behavior and what the Avocado APIs take as input.

On this PR, the *command to be executed* by the `avocado.utils.process` functions, should now be given as unicode strings.  This removes a lot of guesswork about the encoding used, including the need to have an encoding parameter on some functions.

The output generated by the command executed, though, can still be interpreted as text on different encodings (there was no change in this area, given that the output generated by the command hasn't got to have any relation to the encoding used on the command itself).