### PR TITLE
Wait 10s for the memory state to change

### DIFF
--- a/avocado/utils/memory.py
+++ b/avocado/utils/memory.py
@@ -52,7 +52,7 @@ def _check_memory_state(block):
             return True
         return False
 
-    return wait.wait_for(_is_online, timeout=120, step=1) or False
+    return wait.wait_for(_is_online, timeout=10, step=0.2) or False
 
 
 def check_hotplug():


### PR DESCRIPTION
Waiting 120s is not appropriate as the system takes less time for
memory state to change from 'going-online' to 'online' so changed
it to 10s and with freq of 0.2s

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>