### PR TITLE
[RFC] Enable W1618 and W0410 warnings on lint

### DIFF
--- a/avocado/__init__.py
+++ b/avocado/__init__.py
@@ -12,6 +12,8 @@
 # Copyright: Red Hat Inc. 2013-2014
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
+from __future__ import absolute_import
+
 
 __all__ = ['main',
            'Test',

--- a/avocado/__main__.py
+++ b/avocado/__main__.py
@@ -2,6 +2,8 @@
 Main entry point when called by 'python -m'.
 """
 
+from __future__ import absolute_import
+
 import sys
 
 from avocado.core.app import AvocadoApp

--- a/avocado/core/app.py
+++ b/avocado/core/app.py
@@ -16,6 +16,8 @@
 The core Avocado application.
 """
 
+from __future__ import absolute_import
+
 import os
 import signal
 import sys

--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -25,6 +25,9 @@ The general reasoning to find paths is:
 * The next best location is the default system wide one.
 * The next best location is the default user specific one.
 """
+
+from __future__ import absolute_import
+
 import os
 import shutil
 import sys

--- a/avocado/core/decorators.py
+++ b/avocado/core/decorators.py
@@ -12,6 +12,8 @@
 # Copyright: Red Hat Inc. 2017
 # Author: Amador Pahim <apahim@redhat.com>
 
+from __future__ import absolute_import
+
 from functools import wraps
 import types
 

--- a/avocado/core/dispatcher.py
+++ b/avocado/core/dispatcher.py
@@ -14,6 +14,8 @@
 
 """Extensions/plugins dispatchers."""
 
+from __future__ import absolute_import
+
 import copy
 import sys
 

--- a/avocado/core/exceptions.py
+++ b/avocado/core/exceptions.py
@@ -16,6 +16,8 @@
 Exception classes, useful for tests, and other parts of the framework code.
 """
 
+from __future__ import absolute_import
+
 
 class JobBaseException(Exception):
 

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -17,6 +17,8 @@
 Job module - describes a sequence of automated test operations.
 """
 
+from __future__ import absolute_import
+
 import argparse
 import logging
 import os

--- a/avocado/core/job_id.py
+++ b/avocado/core/job_id.py
@@ -12,6 +12,8 @@
 # Copyright: Red Hat Inc. 2013-2014
 # Authors: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
+from __future__ import absolute_import
+
 import hashlib
 import random
 

--- a/avocado/core/jobdata.py
+++ b/avocado/core/jobdata.py
@@ -16,6 +16,8 @@
 Record/retrieve job information
 """
 
+from __future__ import absolute_import
+
 import ast
 import glob
 import json

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -17,6 +17,8 @@
 Test loader module.
 """
 
+from __future__ import absolute_import
+
 import ast
 import collections
 import imp

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -15,6 +15,9 @@
 """
 Manages output and logging in avocado applications.
 """
+
+from __future__ import absolute_import
+
 import errno
 import logging
 import os

--- a/avocado/core/parameters.py
+++ b/avocado/core/parameters.py
@@ -15,6 +15,8 @@
 Module related to test parameters
 """
 
+from __future__ import absolute_import
+
 import logging
 import re
 

--- a/avocado/core/parser.py
+++ b/avocado/core/parser.py
@@ -16,6 +16,8 @@
 Avocado application command line parsing.
 """
 
+from __future__ import absolute_import
+
 import argparse
 
 from six import iteritems

--- a/avocado/core/plugin_interfaces.py
+++ b/avocado/core/plugin_interfaces.py
@@ -12,6 +12,8 @@
 # Copyright: Red Hat Inc. 2015
 # Author: Cleber Rosa <cleber@redhat.com>
 
+from __future__ import absolute_import
+
 
 import abc
 

--- a/avocado/core/restclient/cli/actions/server.py
+++ b/avocado/core/restclient/cli/actions/server.py
@@ -6,6 +6,8 @@ Module that implements the actions for the CLI App when the job toplevel
 command is used
 """
 
+from __future__ import absolute_import
+
 from . import base
 from ... import connection
 from ....output import LOG_UI

--- a/avocado/core/restclient/cli/app.py
+++ b/avocado/core/restclient/cli/app.py
@@ -15,6 +15,8 @@
 This is the main entry point for the rest client cli application
 """
 
+from __future__ import absolute_import
+
 import importlib
 import sys
 import types

--- a/avocado/core/restclient/cli/args/base.py
+++ b/avocado/core/restclient/cli/args/base.py
@@ -19,6 +19,8 @@ These top level commands import these definitions for uniformity and
 consistency sake
 """
 
+from __future__ import absolute_import
+
 __all__ = ['ADD', 'LIST_BRIEF', 'LIST_FULL', 'DELETE', 'NAME', 'ID']
 
 

--- a/avocado/core/restclient/cli/args/server.py
+++ b/avocado/core/restclient/cli/args/server.py
@@ -16,6 +16,8 @@
 This module has actions for the server command
 """
 
+from __future__ import absolute_import
+
 from . import base
 
 

--- a/avocado/core/restclient/cli/parser.py
+++ b/avocado/core/restclient/cli/parser.py
@@ -16,6 +16,8 @@
 REST client application command line parsing
 """
 
+from __future__ import absolute_import
+
 import os
 import glob
 import argparse

--- a/avocado/core/restclient/connection.py
+++ b/avocado/core/restclient/connection.py
@@ -19,6 +19,8 @@ A connection is a simple wrapper around a HTTP request instance. It is this
 basic object that allows methods to be called on the remote server.
 """
 
+from __future__ import absolute_import
+
 import requests
 
 from ..settings import settings

--- a/avocado/core/restclient/response.py
+++ b/avocado/core/restclient/response.py
@@ -16,6 +16,8 @@
 Module with base model functions to manipulate JSON data
 """
 
+from __future__ import absolute_import
+
 import json
 
 

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -17,6 +17,8 @@
 Test runner module.
 """
 
+from __future__ import absolute_import
+
 import multiprocessing
 import multiprocessing.queues
 import os

--- a/avocado/core/safeloader.py
+++ b/avocado/core/safeloader.py
@@ -16,6 +16,8 @@
 Safe (AST based) test loader module utilities
 """
 
+from __future__ import absolute_import
+
 import ast
 import re
 

--- a/avocado/core/settings.py
+++ b/avocado/core/settings.py
@@ -15,6 +15,9 @@
 """
 Reads the avocado settings from a .ini file (from python ConfigParser).
 """
+
+from __future__ import absolute_import
+
 import ast
 import os
 import sys

--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -12,6 +12,8 @@
 # client/shared/settings.py
 # Author: John Admanski <jadmanski@google.com>
 
+from __future__ import absolute_import
+
 import gzip
 import json
 import logging

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -18,6 +18,8 @@ Contains the base test implementation, used as a base for the actual
 framework tests.
 """
 
+from __future__ import absolute_import
+
 import inspect
 import logging
 import os

--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -33,6 +33,8 @@ original base tree code and re-license under GPLv2+, given that GPLv3 and GPLv2
 (used in some avocado files) are incompatible.
 """
 
+from __future__ import absolute_import
+
 import collections
 import copy
 import itertools

--- a/avocado/core/varianter.py
+++ b/avocado/core/varianter.py
@@ -19,6 +19,8 @@
 Base classes for implementing the varianter interface
 """
 
+from __future__ import absolute_import
+
 import hashlib
 
 from six import iteritems, itervalues

--- a/avocado/core/version.py
+++ b/avocado/core/version.py
@@ -12,6 +12,8 @@
 # Copyright: Red Hat Inc. 2013-2014
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
+from __future__ import absolute_import
+
 __all__ = ['MAJOR', 'MINOR', 'VERSION']
 
 import pkg_resources

--- a/avocado/plugins/archive.py
+++ b/avocado/plugins/archive.py
@@ -14,6 +14,8 @@
 
 """Result Archive Plugin"""
 
+from __future__ import absolute_import
+
 from avocado.core.plugin_interfaces import CLI, Result
 from avocado.utils import archive
 

--- a/avocado/plugins/config.py
+++ b/avocado/plugins/config.py
@@ -12,6 +12,8 @@
 # Copyright: Red Hat Inc. 2013-2014
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
+from __future__ import absolute_import
+
 from avocado.core import data_dir
 from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLICmd

--- a/avocado/plugins/diff.py
+++ b/avocado/plugins/diff.py
@@ -17,6 +17,7 @@ Job Diff
 """
 
 from __future__ import absolute_import
+
 import argparse
 import json
 import os

--- a/avocado/plugins/distro.py
+++ b/avocado/plugins/distro.py
@@ -12,6 +12,8 @@
 # Copyright: Red Hat Inc. 2015
 # Author: Cleber Rosa <cleber@redhat.com>
 
+from __future__ import absolute_import
+
 import bz2
 import json
 import os

--- a/avocado/plugins/envkeep.py
+++ b/avocado/plugins/envkeep.py
@@ -12,6 +12,8 @@
 # Copyright: Red Hat Inc. 2016
 # Author: Amador Pahim <apahim@redhat.com>
 
+from __future__ import absolute_import
+
 from avocado.core.plugin_interfaces import CLI
 
 

--- a/avocado/plugins/exec_path.py
+++ b/avocado/plugins/exec_path.py
@@ -14,6 +14,8 @@
 Libexec PATHs modifier
 """
 
+from __future__ import absolute_import
+
 import os
 
 from pkg_resources import resource_filename

--- a/avocado/plugins/gdb.py
+++ b/avocado/plugins/gdb.py
@@ -14,6 +14,8 @@
 
 """Run tests with GDB goodies enabled."""
 
+from __future__ import absolute_import
+
 from avocado.core import exceptions
 from avocado.core.plugin_interfaces import CLI
 from avocado.core.settings import settings

--- a/avocado/plugins/human.py
+++ b/avocado/plugins/human.py
@@ -15,6 +15,8 @@
 Human result UI
 """
 
+from __future__ import absolute_import
+
 from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import ResultEvents
 from avocado.core.plugin_interfaces import JobPre, JobPost

--- a/avocado/plugins/jobscripts.py
+++ b/avocado/plugins/jobscripts.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import os
 
 from avocado.core.output import LOG_UI

--- a/avocado/plugins/journal.py
+++ b/avocado/plugins/journal.py
@@ -14,6 +14,8 @@
 
 """Journal Plugin"""
 
+from __future__ import absolute_import
+
 import os
 import sqlite3
 import datetime

--- a/avocado/plugins/json_variants.py
+++ b/avocado/plugins/json_variants.py
@@ -12,6 +12,8 @@
 # Copyright: Red Hat Inc. 2018
 # Authors: Amador Pahim <apahim@redhat.com>
 
+from __future__ import absolute_import
+
 import json
 import sys
 

--- a/avocado/plugins/jsonresult.py
+++ b/avocado/plugins/jsonresult.py
@@ -17,6 +17,8 @@
 JSON output module.
 """
 
+from __future__ import absolute_import
+
 import json
 import os
 

--- a/avocado/plugins/list.py
+++ b/avocado/plugins/list.py
@@ -12,6 +12,8 @@
 # Copyright: Red Hat Inc. 2013-2014
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
+from __future__ import absolute_import
+
 import sys
 
 from six import string_types

--- a/avocado/plugins/multiplex.py
+++ b/avocado/plugins/multiplex.py
@@ -12,6 +12,8 @@
 # Copyright: Red Hat Inc. 2013-2014
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
+from __future__ import absolute_import
+
 from avocado.core.output import LOG_UI
 
 from .variants import Variants

--- a/avocado/plugins/plugins.py
+++ b/avocado/plugins/plugins.py
@@ -15,6 +15,8 @@
 Plugins information plugin
 """
 
+from __future__ import absolute_import
+
 from avocado.core import dispatcher
 from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLICmd

--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -12,6 +12,8 @@
 # Copyright: Red Hat Inc. 2016
 # Author: Amador Pahim <apahim@redhat.com>
 
+from __future__ import absolute_import
+
 import argparse
 import json
 import os

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -16,6 +16,8 @@
 Base Test Runner Plugins.
 """
 
+from __future__ import absolute_import
+
 import argparse
 import sys
 

--- a/avocado/plugins/sysinfo.py
+++ b/avocado/plugins/sysinfo.py
@@ -15,6 +15,8 @@
 System information plugin
 """
 
+from __future__ import absolute_import
+
 from avocado.core.plugin_interfaces import CLICmd
 from avocado.core import sysinfo
 

--- a/avocado/plugins/tap.py
+++ b/avocado/plugins/tap.py
@@ -15,6 +15,8 @@
 TAP output module.
 """
 
+from __future__ import absolute_import
+
 import os
 
 from avocado.core.output import LOG_UI

--- a/avocado/plugins/teststmpdir.py
+++ b/avocado/plugins/teststmpdir.py
@@ -15,6 +15,8 @@
 Tests temporary directory plugin
 """
 
+from __future__ import absolute_import
+
 import os
 import shutil
 import tempfile

--- a/avocado/plugins/variants.py
+++ b/avocado/plugins/variants.py
@@ -13,6 +13,8 @@
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 # Author: Lukas Doktor <ldoktor@redhat.com>
 
+from __future__ import absolute_import
+
 import json
 import sys
 

--- a/avocado/plugins/wrapper.py
+++ b/avocado/plugins/wrapper.py
@@ -12,6 +12,8 @@
 # Copyright: Red Hat Inc. 2014
 # Author: Ruda Moura <rmoura@redhat.com>
 
+from __future__ import absolute_import
+
 import os
 import sys
 

--- a/avocado/plugins/xunit.py
+++ b/avocado/plugins/xunit.py
@@ -15,6 +15,8 @@
 
 """xUnit module."""
 
+from __future__ import absolute_import
+
 import datetime
 import os
 import string

--- a/avocado/utils/archive.py
+++ b/avocado/utils/archive.py
@@ -15,6 +15,8 @@
 Module to help extract and create compressed archives.
 """
 
+from __future__ import absolute_import
+
 import logging
 import os
 import platform

--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -16,6 +16,8 @@
 Asset fetcher from multiple locations
 """
 
+from __future__ import absolute_import
+
 import errno
 import logging
 import os

--- a/avocado/utils/astring.py
+++ b/avocado/utils/astring.py
@@ -25,6 +25,8 @@ string. Even with the dot notation, people may try to do things like
 And not notice until their code starts failing.
 """
 
+from __future__ import absolute_import
+
 import itertools
 import re
 import string

--- a/avocado/utils/aurl.py
+++ b/avocado/utils/aurl.py
@@ -18,6 +18,8 @@ URL related functions.
 The strange name is to avoid accidental naming collisions in code.
 """
 
+from __future__ import absolute_import
+
 try:
     import urlparse
 except ImportError:

--- a/avocado/utils/build.py
+++ b/avocado/utils/build.py
@@ -12,6 +12,8 @@
 # Copyright: Red Hat Inc. 2013-2014
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
+from __future__ import absolute_import
+
 import multiprocessing
 import os
 

--- a/avocado/utils/cpu.py
+++ b/avocado/utils/cpu.py
@@ -15,10 +15,11 @@
 # Original author: Martin J Bligh <mbligh@google.com>
 # Original author: John Admanski <jadmanski@google.com>
 
-
 """
 Get information from the current's machine CPU.
 """
+
+from __future__ import absolute_import
 
 import re
 import os

--- a/avocado/utils/crypto.py
+++ b/avocado/utils/crypto.py
@@ -12,6 +12,8 @@
 # Copyright: Red Hat Inc. 2013-2014
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
+from __future__ import absolute_import
+
 import os
 import logging
 import hashlib

--- a/avocado/utils/data_factory.py
+++ b/avocado/utils/data_factory.py
@@ -16,6 +16,8 @@
 Generate data useful for the avocado framework and tests themselves.
 """
 
+from __future__ import absolute_import
+
 import logging
 import os
 import random

--- a/avocado/utils/data_structures.py
+++ b/avocado/utils/data_structures.py
@@ -21,6 +21,7 @@ This module contains handy classes that can be used inside
 avocado core code or plugins.
 """
 
+from __future__ import absolute_import
 
 import re
 import sys

--- a/avocado/utils/debug.py
+++ b/avocado/utils/debug.py
@@ -15,6 +15,9 @@
 """
 This file contains tools for (not only) Avocado developers.
 """
+
+from __future__ import absolute_import
+
 import logging
 import time
 import os

--- a/avocado/utils/disk.py
+++ b/avocado/utils/disk.py
@@ -18,6 +18,8 @@
 Disk utilities
 """
 
+from __future__ import absolute_import
+
 import os
 
 

--- a/avocado/utils/distro.py
+++ b/avocado/utils/distro.py
@@ -17,6 +17,8 @@ This module provides the client facilities to detect the Linux Distribution
 it's running under.
 """
 
+from __future__ import absolute_import
+
 import os
 import re
 import platform

--- a/avocado/utils/download.py
+++ b/avocado/utils/download.py
@@ -17,6 +17,8 @@
 Methods to download URLs and regular files.
 """
 
+from __future__ import absolute_import
+
 import logging
 import os
 import socket

--- a/avocado/utils/external/gdbmi_parser.py
+++ b/avocado/utils/external/gdbmi_parser.py
@@ -23,6 +23,7 @@
 #   Frank Laub (frank.laub@gmail.com)
 #   Michael Eddington (mike@phed.org)
 
+from __future__ import absolute_import
 
 import re
 import pprint

--- a/avocado/utils/external/spark.py
+++ b/avocado/utils/external/spark.py
@@ -19,11 +19,14 @@
 #  TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 #  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-__version__ = 'SPARK-0.7 (pre-alpha-7)'
+from __future__ import absolute_import
 
 import re
 
 from six.moves import xrange as range
+
+
+__version__ = 'SPARK-0.7 (pre-alpha-7)'
 
 
 def _namelist(instance):

--- a/avocado/utils/filelock.py
+++ b/avocado/utils/filelock.py
@@ -17,6 +17,8 @@ Utility for individual file access control implemented
 via PID lock files.
 """
 
+from __future__ import absolute_import
+
 import os
 import time
 

--- a/avocado/utils/gdb.py
+++ b/avocado/utils/gdb.py
@@ -16,8 +16,7 @@
 Module that provides communication with GDB via its GDB/MI interpreter
 """
 
-__all__ = ['GDB', 'GDBServer', 'GDBRemote']
-
+from __future__ import absolute_import
 
 import os
 import time
@@ -28,6 +27,10 @@ import tempfile
 
 from . import network
 from .external import gdbmi_parser
+
+
+__all__ = ['GDB', 'GDBServer', 'GDBRemote']
+
 
 #: Contains a list of binary names that should be run via the GNU debugger
 #: and be stopped at a given point. That means that a breakpoint will be set

--- a/avocado/utils/genio.py
+++ b/avocado/utils/genio.py
@@ -16,6 +16,8 @@
 Avocado generic IO related functions.
 """
 
+from __future__ import absolute_import
+
 import logging
 import os
 import time

--- a/avocado/utils/git.py
+++ b/avocado/utils/git.py
@@ -16,6 +16,8 @@
 APIs to download/update git repositories from inside python scripts.
 """
 
+from __future__ import absolute_import
+
 import os
 import logging
 

--- a/avocado/utils/iso9660.py
+++ b/avocado/utils/iso9660.py
@@ -20,8 +20,7 @@ ISO9660 internal structure. Instead, it uses commonly available support
 either in userspace tools or on the Linux kernel itself (via mount).
 """
 
-
-__all__ = ['iso9660', 'Iso9660IsoInfo', 'Iso9660IsoRead', 'Iso9660Mount']
+from __future__ import absolute_import
 
 import os
 import logging
@@ -31,6 +30,9 @@ import sys
 import re
 
 from . import process
+
+
+__all__ = ['iso9660', 'Iso9660IsoInfo', 'Iso9660IsoRead', 'Iso9660Mount']
 
 
 def has_userland_tool(executable):

--- a/avocado/utils/kernel.py
+++ b/avocado/utils/kernel.py
@@ -13,6 +13,8 @@
 # Author: Ruda Moura <rmoura@redhat.com>
 # Author: Santhosh G <santhog4@linux.vnet.ibm.com>
 
+from __future__ import absolute_import
+
 import os
 import shutil
 import logging

--- a/avocado/utils/linux_modules.py
+++ b/avocado/utils/linux_modules.py
@@ -21,6 +21,8 @@
 Linux kernel modules APIs
 """
 
+from __future__ import absolute_import
+
 import re
 import logging
 import platform

--- a/avocado/utils/lv_utils.py
+++ b/avocado/utils/lv_utils.py
@@ -19,6 +19,7 @@
 #
 # Source: https://github.com/autotest/autotest/blob/master/client/lv_utils.py
 
+from __future__ import absolute_import
 
 import logging
 import os

--- a/avocado/utils/memory.py
+++ b/avocado/utils/memory.py
@@ -16,6 +16,7 @@
 # client/shared/utils.py
 # Authors: Yiqiao Pu <ypu@redhat.com>
 
+from __future__ import absolute_import
 
 import os
 import re

--- a/avocado/utils/multipath.py
+++ b/avocado/utils/multipath.py
@@ -17,6 +17,8 @@ Module with multipath related utility functions.
 It needs root access.
 """
 
+from __future__ import absolute_import
+
 import time
 import logging
 import ast

--- a/avocado/utils/network.py
+++ b/avocado/utils/network.py
@@ -16,6 +16,8 @@
 Module with network related utility functions
 """
 
+from __future__ import absolute_import
+
 import socket
 import random
 

--- a/avocado/utils/output.py
+++ b/avocado/utils/output.py
@@ -21,6 +21,8 @@
 Utility functions for user friendly display of information.
 """
 
+from __future__ import absolute_import
+
 import sys
 
 

--- a/avocado/utils/partition.py
+++ b/avocado/utils/partition.py
@@ -22,6 +22,8 @@
 Utility for handling partitions.
 """
 
+from __future__ import absolute_import
+
 import logging
 import os
 import time

--- a/avocado/utils/path.py
+++ b/avocado/utils/path.py
@@ -16,6 +16,8 @@
 Avocado path related functions.
 """
 
+from __future__ import absolute_import
+
 import os
 import stat
 import tempfile

--- a/avocado/utils/pci.py
+++ b/avocado/utils/pci.py
@@ -20,6 +20,7 @@
 Module for all PCI devices related functions.
 """
 
+from __future__ import absolute_import
 
 import re
 import os

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -16,6 +16,8 @@
 Functions dedicated to find and run external commands.
 """
 
+from __future__ import absolute_import
+
 import errno
 import fnmatch
 import logging

--- a/avocado/utils/script.py
+++ b/avocado/utils/script.py
@@ -16,6 +16,8 @@
 Module to handle scripts creation.
 """
 
+from __future__ import absolute_import
+
 import os
 import stat
 import shutil

--- a/avocado/utils/service.py
+++ b/avocado/utils/service.py
@@ -21,6 +21,8 @@
 # client/shared/service.py
 # Original author: Ross Brattain <ross.b.brattain@intel.com>
 
+from __future__ import absolute_import
+
 import os
 import re
 import logging

--- a/avocado/utils/software_manager.py
+++ b/avocado/utils/software_manager.py
@@ -34,6 +34,9 @@ implement the given backend class.
 :copyright: IBM 2008-2009
 :copyright: Red Hat 2009-2014
 """
+
+from __future__ import absolute_import
+
 import os
 import re
 import shutil

--- a/avocado/utils/stacktrace.py
+++ b/avocado/utils/stacktrace.py
@@ -1,6 +1,9 @@
 """
 Traceback standard module plus some additional APIs.
 """
+
+from __future__ import absolute_import
+
 from traceback import format_exception
 import logging
 import inspect

--- a/avocado/utils/vmimage.py
+++ b/avocado/utils/vmimage.py
@@ -16,6 +16,8 @@
 Provides VM images acquired from official repositories
 """
 
+from __future__ import absolute_import
+
 import os
 import re
 import tempfile

--- a/avocado/utils/wait.py
+++ b/avocado/utils/wait.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import logging
 import time
 

--- a/selftests/checkall
+++ b/selftests/checkall
@@ -161,9 +161,9 @@ results_dir_content() {
 
 [ "$SKIP_RESULTSDIR_CHECK" ] || RESULTS_DIR_CONTENT="$(ls $RESULTS_DIR 2> /dev/null)"
 if [ "$TRAVIS" == "true" ]; then
-    run_rc lint 'RESULT=$(mktemp); inspekt lint --exclude=.git --enable W0101,W0102,W0404,W0611,W0612,W0622 &>$RESULT || { cat $RESULT; rm $RESULT; exit -1; }; rm $RESULT'
+    run_rc lint 'RESULT=$(mktemp); inspekt lint --exclude=.git --enable W0101,W0102,W0404,W0410,W0611,W0612,W0622,W1618 &>$RESULT || { cat $RESULT; rm $RESULT; exit -1; }; rm $RESULT'
 else
-    run_rc lint 'inspekt lint --exclude=.git --enable W0101,W0102,W0404,W0611,W0612,W0622'
+    run_rc lint 'inspekt lint --exclude=.git --enable W0101,W0102,W0404,W0410,W0611,W0612,W0622,W1618'
 fi
 # Skip checking test_utils_cpu.py due to inspektor bug
 run_rc indent 'inspekt indent --exclude=.git,selftests/unit/test_utils_cpu.py'


### PR DESCRIPTION
This is sent as RFC, because I've felt that applying the
recommendations of W1618 (and related W0410) to example/tests/*, can
introduce yet another level of boilermuch code, adding noise, and
reducing their value.

Basically, a simple example like passtest.py, would start to look like:

```python

  #!/usr/bin/env python

  from __future__ import absolute_import

  from avocado import main
  from avocado import Test

  class PassTest(Test):

      """
      Example test that passes.

      :avocado: tags=fast
      """

      def test(self):
          """
          A test simply doesn't have to fail in order to pass
          """
          pass

  if __name__ == "__main__":
      main()

```

Feedback is welcome, specially on if/how this affects the readability
and purpose of the example tests.

Signed-off-by: Cleber Rosa <crosa@redhat.com>