### PR TITLE
Travis-CI: skip tests that are time/resource sensitive

### DIFF
--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -481,6 +481,9 @@ class RunnerOperationTest(unittest.TestCase):
         int(r['job_id'], 16)  # it's an hex number
         self.assertEqual(len(r['job_id']), 40)
 
+    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 2,
+                     "Skipping test that take a long time to run, are "
+                     "resource intensive or time sensitve")
     def test_early_latest_result(self):
         """
         Tests that the `latest` link to the latest job results is created early
@@ -795,7 +798,7 @@ class RunnerSimpleTest(unittest.TestCase):
                          (expected_rc, result))
 
     @unittest.skipIf(not SLEEP_BINARY, 'sleep binary not available')
-    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 1,
+    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 2,
                      "Skipping test that take a long time to run, are "
                      "resource intensive or time sensitve")
     def test_kill_stopped_sleep(self):

--- a/selftests/functional/test_interrupt.py
+++ b/selftests/functional/test_interrupt.py
@@ -193,7 +193,7 @@ class InterruptTest(unittest.TestCase):
         # Make sure the Interrupted test sentence is there
         self.assertIn(b'Terminated\n', self.proc.stdout.read())
 
-    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 1,
+    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 2,
                      "Skipping test that take a long time to run, are "
                      "resource intensive or time sensitve")
     def test_well_behaved_sigint(self):
@@ -237,7 +237,7 @@ class InterruptTest(unittest.TestCase):
         # Make sure the Killing test subprocess message is not there
         self.assertNotIn(b'Killing test subprocess', output)
 
-    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 1,
+    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 2,
                      "Skipping test that take a long time to run, are "
                      "resource intensive or time sensitve")
     def test_well_behaved_sigterm(self):

--- a/selftests/functional/test_loader.py
+++ b/selftests/functional/test_loader.py
@@ -191,7 +191,7 @@ class LoaderTestFunctional(unittest.TestCase):
     def test_not_python_module(self):
         self._test('passtest', AVOCADO_TEST_OK, 'NOT_A_TEST')
 
-    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 1,
+    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 2,
                      "Skipping test that take a long time to run, are "
                      "resource intensive or time sensitve")
     def test_sleep_a_lot(self):
@@ -253,7 +253,7 @@ class LoaderTestFunctional(unittest.TestCase):
                     % (AVOCADO, self.tmpdir, mytest))
         self._run_with_timeout(cmd_line, 5)
 
-    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 1,
+    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 2,
                      "Skipping test that take a long time to run, are "
                      "resource intensive or time sensitve")
     def test_simple_using_main(self):


### PR DESCRIPTION
And that have been causing failures on Travis jobs, due to limited
on unreliable amount of resources present.

This is the full list of tests that won't be run anymore on Travis,
only on `make check-full`:

  selftests.functional.test_basic.RunnerOperationTest.test_early_latest_result
  selftests.functional.test_basic.RunnerSimpleTest.test_kill_stopped_sleep
  selftests.functional.test_interrupt.InterruptTest.test_well_behaved_sigint
  selftests.functional.test_interrupt.InterruptTest.test_well_behaved_sigterm
  selftests.functional.test_loader.LoaderTestFunctional.test_simple_using_main
  selftests.functional.test_loader.LoaderTestFunctional.test_sleep_a_lot

Signed-off-by: Cleber Rosa <crosa@redhat.com>