### PR TITLE
utils.cpu: improve get_cpu_arch()

### DIFF
--- a/avocado/utils/cpu.py
+++ b/avocado/utils/cpu.py
@@ -123,15 +123,18 @@ def get_cpu_arch():
                  ('^cpu.*POWER8', 'power8'),
                  ('^cpu.*POWER9', 'power9'),
                  ('^cpu.*PPC970', 'power970'),
-                 ('ARM', 'arm'),
-                 ('^flags.*:.* lm .*', 'x86_64')]
+                 ('(ARM|^CPU implementer|^CPU part|^CPU variant'
+                  '|^Features|^BogoMIPS|^CPU revision)', 'arm'),
+                 ('(^cpu MHz dynamic|^cpu MHz static|^features'
+                  '|^bogomips per cpu|^max thread id)', 's390'),
+                 ('^type', 'sparc64'),
+                 ('^flags.*:.* lm .*', 'x86_64'),
+                 ('^flags', 'i386')]
     cpuinfo = _get_cpu_info()
     for (pattern, arch) in cpu_table:
         if _list_matches(cpuinfo, pattern):
             return arch
-    if "CPU architecture" in cpuinfo:
-        return platform.machine()
-    return 'i386'
+    return platform.machine()
 
 
 def cpu_online_list():


### PR DESCRIPTION
- try harder to detect arm.
- detect more archs (s390, sparc64 and i386).
- fallback to plataform.machine() (instead of returning i386).

Reference: https://trello.com/c/WbbZw5wq/1213-obsolete-getcpuarch-and-add-2-functions-instead-with-consistent-returns