### PR TITLE
[DO NOT MERGE] avocado.utils.astring: undefined unicode

### DIFF
--- a/avocado/utils/astring.py
+++ b/avocado/utils/astring.py
@@ -302,7 +302,7 @@ def is_text(data):
     each character.
     """
     if sys.version_info[0] < 3:
-        return isinstance(data, unicode)
+        return isinstance(data, unicode)   # pylint: disable=E0602
     return isinstance(data, str)
 
 

--- a/selftests/checkall
+++ b/selftests/checkall
@@ -156,6 +156,10 @@ results_dir_content() {
 
 [ "$SKIP_RESULTSDIR_CHECK" ] || RESULTS_DIR_CONTENT="$(ls $RESULTS_DIR 2> /dev/null)"
 if [ "$TRAVIS" == "true" ]; then
+    which inspekt
+    echo "=== INSPEKTOR ==="
+    cat $(which inspekt)
+    echo "=== END INSPEKTOR ==="
     run_rc lint 'RESULT=$(mktemp); inspekt lint --exclude=.git --enable W0101,W0102,W0404,W0611,W0612,W0622 &>$RESULT || { cat $RESULT; rm $RESULT; exit -1; }; rm $RESULT'
 else
     run_rc lint 'inspekt lint --exclude=.git --enable W0101,W0102,W0404,W0611,W0612,W0622'


### PR DESCRIPTION
This is an attempt to understand the behavior on Travis, on Python 3
jobs, that cause the following inspekt lint failure:

   Syntax check FAIL
   ************* Module avocado.utils.astring
   E0602:305,32: is_text: Undefined variable 'unicode'

Signed-off-by: Cleber Rosa <crosa@redhat.com>