### PR TITLE
[DONT_MERGE] this is a collection of commits

### DIFF
--- a/avocado/utils/astring.py
+++ b/avocado/utils/astring.py
@@ -302,7 +302,7 @@ def is_text(data):
     each character.
     """
     if sys.version_info[0] < 3:
-        return isinstance(data, unicode)
+        return isinstance(data, unicode)   # pylint: disable=E0602
     return isinstance(data, str)
 
 

--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -172,6 +172,7 @@ class TestProcessRun(unittest.TestCase):
         p = process.run(cmd='ls -l', ignore_status=True)
         self.assertEqual(p.command, expected_command)
 
+    @unittest.skipUnless(os.path.exists('/bin/sudo'))
     @mock.patch.object(path, 'find_command',
                        mock.Mock(return_value='/bin/sudo'))
     @mock.patch.object(os, 'getuid', mock.Mock(return_value=1000))


### PR DESCRIPTION
avocado.utils.astring: ignore "undefined" unicode

Depending on the Python version stack being used *by inspekt*, it
can produce this error:

   Syntax check FAIL
   ************* Module avocado.utils.astring
   E0602:305,32: is_text: Undefined variable 'unicode'

Let's disable that check, since that variable is a reserved word
that should always exist in Python 2.7, for which a conditional
exists.

Signed-off-by: Cleber Rosa <crosa@redhat.com>

selftests/unit/test_utils_process.py: skip test if sudo is not available

test_run_sudo() actually needs sudo, because it attempts to run it.
Let's check for the file at the usual location, and skip the test
unless it exists.

   ERROR: test_run_sudo (selftests.unit.test_utils_process.TestProcessRun)
   ----------------------------------------------------------------------
   Traceback (most recent call last):
     File "/home/travis/virtualenv/python2.7_with_system_site_packages/local/lib/python2.7/site-packages/mock/mock.py", line 1305, in patched
       return func(*args, **keywargs)
     File "selftests/unit/test_utils_process.py", line 180, in test_run_sudo
       p = process.run(cmd='ls -l', sudo=True, ignore_status=True)
     File "avocado/utils/process.py", line 1272, in run
       cmd_result = sp.run(timeout=timeout)
     File "avocado/utils/process.py", line 781, in run
       self._init_subprocess()
     File "avocado/utils/process.py", line 571, in _init_subprocess
       raise details
   OSError: [Errno 2] No such file or directory (/bin/sudo -n ls -l)

Signed-off-by: Cleber Rosa <crosa@redhat.com>