### PR TITLE
plugins/xunit.py: use ISO8601_DATETIME_PATTERN as timestamp format

### DIFF
--- a/avocado/plugins/xunit.py
+++ b/avocado/plugins/xunit.py
@@ -80,7 +80,7 @@ class XUnitResult(Result):
         testsuite.setAttribute('failures', self._escape_attr(result.failed))
         testsuite.setAttribute('skipped', self._escape_attr(result.skipped + result.cancelled))
         testsuite.setAttribute('time', self._escape_attr(result.tests_total_time))
-        testsuite.setAttribute('timestamp', self._escape_attr(datetime.datetime.now()))
+        testsuite.setAttribute('timestamp', self._escape_attr(datetime.datetime.now().isoformat()))
         document.appendChild(testsuite)
         for test in result.tests:
             testcase = self._create_testcase_element(document, test)


### PR DESCRIPTION
Following the common JUnit XSD description, covert the timestamp to iso 8601.
I also hit parsing fail while importing avocado xunit result to other system
as timestap format.

Signed-off-by: Xiao Liang <xiliang@redhat.com>