### PR TITLE
[RFC] Apache JUnit schema support

### DIFF
--- a/avocado/plugins/xunit.py
+++ b/avocado/plugins/xunit.py
@@ -96,7 +96,11 @@ class XUnitResult(Result):
         testsuite.setAttribute('failures', self._escape_attr(result.failed))
         testsuite.setAttribute('skipped', self._escape_attr(result.skipped + result.cancelled))
         testsuite.setAttribute('time', self._escape_attr(result.tests_total_time))
-        testsuite.setAttribute('timestamp', self._escape_attr(datetime.datetime.now().isoformat()))
+        # this is a slightly adapted iso8601 format, which limits the
+        # the precision to seconds only
+        iso8601_format = '%Y-%m-%dT%H:%M:%S'
+        timestamp = datetime.datetime.now().strftime(iso8601_format)
+        testsuite.setAttribute('timestamp', self._escape_attr(timestamp))
         document.appendChild(testsuite)
         for test in result.tests:
             testcase = self._create_testcase_element(document, test)

--- a/selftests/.data/jenkins-junit.xsd
+++ b/selftests/.data/jenkins-junit.xsd
@@ -1,4 +1,31 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!--
+ Source: https://svn.jenkins-ci.org/trunk/hudson/dtkit/dtkit-format/dtkit-junit-model/src/main/resources/com/thalesgroup/dtkit/junit/model/xsd/junit-4.xsd
+ 
+ This file available under the terms of the MIT License as follows:
+ 
+ *******************************************************************************
+ * Copyright (c) 2010 Thales Corporate Services SAS                             *
+ *                                                                              *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy *
+ * of this software and associated documentation files (the "Software"), to deal*
+ * in the Software without restriction, including without limitation the rights *
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell    *
+ * copies of the Software, and to permit persons to whom the Software is        *
+ * furnished to do so, subject to the following conditions:                     *
+ *                                                                              *
+ * The above copyright notice and this permission notice shall be included in   *
+ * all copies or substantial portions of the Software.                          *
+ *                                                                              *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR   *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE  *
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER       *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,*
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN    *
+ * THE SOFTWARE.                                                                *
+ ********************************************************************************
+ -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
     <xs:element name="failure">

--- a/selftests/.data/junit-apache.xsd
+++ b/selftests/.data/junit-apache.xsd
@@ -1,0 +1,206 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	 elementFormDefault="qualified"
+	 attributeFormDefault="unqualified">
+	<xs:annotation>
+		<xs:documentation xml:lang="en">JUnit test result schema for the Apache Ant JUnit and JUnitReport tasks
+Copyright © 2011, Windy Road Technology Pty. Limited
+The Apache Ant JUnit XML Schema is distributed under the terms of the Apache License Version 2.0 http://www.apache.org/licenses/
+Permission to waive conditions of this license may be requested from Windy Road Support (http://windyroad.org/support).</xs:documentation>
+	</xs:annotation>
+	<xs:element name="testsuite" type="testsuite"/>
+	<xs:simpleType name="ISO8601_DATETIME_PATTERN">
+		<xs:restriction base="xs:dateTime">
+			<xs:pattern value="[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:element name="testsuites">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Contains an aggregation of testsuite results</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="testsuite" minOccurs="0" maxOccurs="unbounded">
+					<xs:complexType>
+						<xs:complexContent>
+							<xs:extension base="testsuite">
+								<xs:attribute name="package" type="xs:token" use="required">
+									<xs:annotation>
+										<xs:documentation xml:lang="en">Derived from testsuite/@name in the non-aggregated documents</xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
+								<xs:attribute name="id" type="xs:int" use="required">
+									<xs:annotation>
+										<xs:documentation xml:lang="en">Starts at '0' for the first testsuite and is incremented by 1 for each following testsuite</xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
+							</xs:extension>
+						</xs:complexContent>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:complexType name="testsuite">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Contains the results of exexuting a testsuite</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="properties">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">Properties (e.g., environment settings) set during test execution</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="property" minOccurs="0" maxOccurs="unbounded">
+							<xs:complexType>
+								<xs:attribute name="name" use="required">
+									<xs:simpleType>
+										<xs:restriction base="xs:token">
+											<xs:minLength value="1"/>
+										</xs:restriction>
+									</xs:simpleType>
+								</xs:attribute>
+								<xs:attribute name="value" type="xs:string" use="required"/>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="testcase" minOccurs="0" maxOccurs="unbounded">
+				<xs:complexType>
+					<xs:choice minOccurs="0">
+						<xs:element name="error">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">Indicates that the test errored.  An errored test is one that had an unanticipated problem. e.g., an unchecked throwable; or a problem with the implementation of the test. Contains as a text node relevant data for the error, e.g., a stack trace</xs:documentation>
+			</xs:annotation>
+							<xs:complexType>
+								<xs:simpleContent>
+									<xs:extension base="pre-string">
+										<xs:attribute name="message" type="xs:string">
+											<xs:annotation>
+												<xs:documentation xml:lang="en">The error message. e.g., if a java exception is thrown, the return value of getMessage()</xs:documentation>
+											</xs:annotation>
+										</xs:attribute>
+										<xs:attribute name="type" type="xs:string" use="required">
+											<xs:annotation>
+												<xs:documentation xml:lang="en">The type of error that occured. e.g., if a java execption is thrown the full class name of the exception.</xs:documentation>
+											</xs:annotation>
+										</xs:attribute>
+									</xs:extension>
+								</xs:simpleContent>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="failure">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">Indicates that the test failed. A failure is a test which the code has explicitly failed by using the mechanisms for that purpose. e.g., via an assertEquals. Contains as a text node relevant data for the failure, e.g., a stack trace</xs:documentation>
+			</xs:annotation>
+							<xs:complexType>
+								<xs:simpleContent>
+									<xs:extension base="pre-string">
+										<xs:attribute name="message" type="xs:string">
+											<xs:annotation>
+												<xs:documentation xml:lang="en">The message specified in the assert</xs:documentation>
+											</xs:annotation>
+										</xs:attribute>
+										<xs:attribute name="type" type="xs:string" use="required">
+											<xs:annotation>
+												<xs:documentation xml:lang="en">The type of the assert.</xs:documentation>
+											</xs:annotation>
+										</xs:attribute>
+									</xs:extension>
+								</xs:simpleContent>
+							</xs:complexType>
+						</xs:element>
+					</xs:choice>
+					<xs:attribute name="name" type="xs:token" use="required">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">Name of the test method</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="classname" type="xs:token" use="required">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">Full class name for the class the test method is in.</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="time" type="xs:decimal" use="required">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">Time taken (in seconds) to execute the test</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="system-out">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">Data that was written to standard out while the test was executed</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="pre-string">
+						<xs:whiteSpace value="preserve"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="system-err">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">Data that was written to standard error while the test was executed</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="pre-string">
+						<xs:whiteSpace value="preserve"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="name" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">Full class name of the test for non-aggregated testsuite documents. Class name without the package for aggregated testsuites documents</xs:documentation>
+			</xs:annotation>
+			<xs:simpleType>
+				<xs:restriction base="xs:token">
+					<xs:minLength value="1"/>
+				</xs:restriction>
+			</xs:simpleType>
+		</xs:attribute>
+		<xs:attribute name="timestamp" type="ISO8601_DATETIME_PATTERN" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">when the test was executed. Timezone may not be specified.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="hostname" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">Host on which the tests were executed. 'localhost' should be used if the hostname cannot be determined.</xs:documentation>
+			</xs:annotation>
+			<xs:simpleType>
+				<xs:restriction base="xs:token">
+					<xs:minLength value="1"/>
+				</xs:restriction>
+			</xs:simpleType>
+		</xs:attribute>
+		<xs:attribute name="tests" type="xs:int" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">The total number of tests in the suite</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="failures" type="xs:int" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">The total number of tests in the suite that failed. A failure is a test which the code has explicitly failed by using the mechanisms for that purpose. e.g., via an assertEquals</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="errors" type="xs:int" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">The total number of tests in the suite that errored. An errored test is one that had an unanticipated problem. e.g., an unchecked throwable; or a problem with the implementation of the test.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="time" type="xs:decimal" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">Time taken (in seconds) to execute the tests in the suite</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:simpleType name="pre-string">
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -1192,7 +1192,7 @@ class PluginsXunitTest(AbsPluginsTest, unittest.TestCase):
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
         junit_xsd = os.path.join(os.path.dirname(__file__),
-                                 os.path.pardir, ".data", 'junit-4.xsd')
+                                 os.path.pardir, ".data", 'jenkins-junit.xsd')
         self.junit = os.path.abspath(junit_xsd)
         super(PluginsXunitTest, self).setUp()
 

--- a/selftests/unit/test_xunit.py
+++ b/selftests/unit/test_xunit.py
@@ -85,7 +85,8 @@ class xUnitSucceedTest(unittest.TestCase):
         self.assertEqual(len(els), 1)
 
         junit_xsd = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                                                 os.path.pardir, ".data", 'junit-4.xsd'))
+                                                 os.path.pardir, ".data",
+                                                 'jenkins-junit.xsd'))
         with open(junit_xsd, 'r') as f:
             xmlschema = etree.XMLSchema(etree.parse(f))   # pylint: disable=I1101
         # pylint: disable=I1101

--- a/selftests/unit/test_xunit.py
+++ b/selftests/unit/test_xunit.py
@@ -84,15 +84,16 @@ class xUnitSucceedTest(unittest.TestCase):
         els = dom.getElementsByTagName('testcase')
         self.assertEqual(len(els), 1)
 
-        junit_xsd = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                                                 os.path.pardir, ".data",
-                                                 'jenkins-junit.xsd'))
-        with open(junit_xsd, 'r') as f:
-            xmlschema = etree.XMLSchema(etree.parse(f))   # pylint: disable=I1101
-        # pylint: disable=I1101
-        self.assertTrue(xmlschema.validate(etree.parse(BytesIO(xml))),
-                        "Failed to validate against %s, content:\n%s\nerror log:\n%s" %
-                        (junit_xsd, xml, xmlschema.error_log))
+        for junit_xsd in ('jenkins-junit.xsd', 'junit-apache.xsd'):
+            junit_xsd = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                                     os.path.pardir, ".data",
+                                                     junit_xsd))
+            with open(junit_xsd, 'r') as f:
+                xmlschema = etree.XMLSchema(etree.parse(f))   # pylint: disable=I1101
+            # pylint: disable=I1101
+            self.assertTrue(xmlschema.validate(etree.parse(BytesIO(xml))),
+                            "Failed to validate against %s, content:\n%s\nerror log:\n%s" %
+                            (junit_xsd, xml, xmlschema.error_log))
 
     def test_max_test_log_size(self):
         log = tempfile.NamedTemporaryFile(dir=self.tmpdir, delete=False)

--- a/selftests/unit/test_xunit.py
+++ b/selftests/unit/test_xunit.py
@@ -52,9 +52,6 @@ class xUnitSucceedTest(unittest.TestCase):
         self.test1 = SimpleTest(job=self.job, base_logdir=self.tmpdir)
         self.test1._Test__status = 'PASS'
         self.test1.time_elapsed = 1.23
-        junit_xsd = os.path.join(os.path.dirname(__file__),
-                                 os.path.pardir, ".data", 'junit-4.xsd')
-        self.junit = os.path.abspath(junit_xsd)
 
     def tearDown(self):
         errs = []
@@ -87,12 +84,14 @@ class xUnitSucceedTest(unittest.TestCase):
         els = dom.getElementsByTagName('testcase')
         self.assertEqual(len(els), 1)
 
-        with open(self.junit, 'r') as f:
+        junit_xsd = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                                 os.path.pardir, ".data", 'junit-4.xsd'))
+        with open(junit_xsd, 'r') as f:
             xmlschema = etree.XMLSchema(etree.parse(f))   # pylint: disable=I1101
         # pylint: disable=I1101
         self.assertTrue(xmlschema.validate(etree.parse(BytesIO(xml))),
                         "Failed to validate against %s, content:\n%s\nerror log:\n%s" %
-                        (self.junit, xml, xmlschema.error_log))
+                        (junit_xsd, xml, xmlschema.error_log))
 
     def test_max_test_log_size(self):
         log = tempfile.NamedTemporaryFile(dir=self.tmpdir, delete=False)

--- a/selftests/unit/test_xunit.py
+++ b/selftests/unit/test_xunit.py
@@ -91,8 +91,8 @@ class xUnitSucceedTest(unittest.TestCase):
             xmlschema = etree.XMLSchema(etree.parse(f))   # pylint: disable=I1101
         # pylint: disable=I1101
         self.assertTrue(xmlschema.validate(etree.parse(BytesIO(xml))),
-                        "Failed to validate against %s, content:\n%s" %
-                        (self.junit, xml))
+                        "Failed to validate against %s, content:\n%s\nerror log:\n%s" %
+                        (self.junit, xml, xmlschema.error_log))
 
     def test_max_test_log_size(self):
         log = tempfile.NamedTemporaryFile(dir=self.tmpdir, delete=False)


### PR DESCRIPTION
This RFC is intended to gather feedback about other variations of the Xunit/Junit formats.  As per https://github.com/avocado-framework/avocado/commit/5bd0a72b9467f664555e75be03ca83fb863f75de it can be seen that the current schema file fails to enforce all of the necessary attribute formats.

@liangxiao1 this is specially targeted at you, since it would even change the format of the "iso8601" date introduced by you.

Maybe it'd be necessary to have support for slightly different formats, as there are some incompatibilities even among the two schemas proposed in this PR.