### PR TITLE
Avocado list tabular out [v5]

### DIFF
--- a/avocado/plugins/list.py
+++ b/avocado/plugins/list.py
@@ -94,7 +94,8 @@ class TestLister(object):
                       output.TERM_SUPPORT.header_str('Test'),
                       output.TERM_SUPPORT.header_str('Tag(s)'))
 
-        for line in astring.iter_tabular_output(test_matrix, header=header):
+        for line in astring.iter_tabular_output(test_matrix, header=header,
+                                                strip=True):
             LOG_UI.debug(line)
 
         if self.args.verbose:

--- a/avocado/utils/astring.py
+++ b/avocado/utils/astring.py
@@ -153,7 +153,7 @@ def strip_console_codes(output, custom_codes=None):
     return return_str
 
 
-def iter_tabular_output(matrix, header=None):
+def iter_tabular_output(matrix, header=None, strip=False):
     """
     Generator for a pretty, aligned string representation of a nxm matrix.
 
@@ -163,6 +163,7 @@ def iter_tabular_output(matrix, header=None):
 
     :param matrix: Matrix representation (list with n rows of m elements).
     :param header: Optional tuple or list with header elements to be displayed.
+    :param strip:  Optionally remove trailing whitespace from each row.
     """
     def _get_matrix_with_header():
         return itertools.chain([header], matrix)
@@ -198,6 +199,11 @@ def iter_tabular_output(matrix, header=None):
         # but later in `yield` we don't want it in `len_matrix`
         len_matrix[-1] = len_matrix[-1][:-1]
 
+    if strip:
+        def str_out(x): return " ".join(x).rstrip()
+    else:
+        def str_out(x): return " ".join(x)
+
     for row, row_lens in zip(str_matrix, len_matrix):
         out = []
         padding = [" " * (lengths[i] - row_lens[i])
@@ -207,10 +213,10 @@ def iter_tabular_output(matrix, header=None):
             out.append(row[-1])
         except IndexError:
             continue    # Skip empty rows
-        yield " ".join(out)
+        yield str_out(out)
 
 
-def tabular_output(matrix, header=None):
+def tabular_output(matrix, header=None, strip=False):
     """
     Pretty, aligned string representation of a nxm matrix.
 
@@ -220,10 +226,11 @@ def tabular_output(matrix, header=None):
 
     :param matrix: Matrix representation (list with n rows of m elements).
     :param header: Optional tuple or list with header elements to be displayed.
+    :param strip:  Optionally remove trailing whitespace from each row.
     :return: String with the tabular output, lines separated by unix line feeds.
     :rtype: str
     """
-    return "\n".join(iter_tabular_output(matrix, header))
+    return "\n".join(iter_tabular_output(matrix, header, strip))
 
 
 def string_safe_encode(input_str):

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -1028,7 +1028,7 @@ class PluginsTest(AbsPluginsTest, unittest.TestCase):
                          "Avocado did not return rc %d:\n%s"
                          % (exit_codes.AVOCADO_ALL_OK, result))
         exp = (b"Type    Test                 Tag(s)\n"
-               b"MISSING this-wont-be-matched \n\n"
+               b"MISSING this-wont-be-matched\n\n"
                b"TEST TYPES SUMMARY\n"
                b"==================\n"
                b"EXTERNAL: 0\n"

--- a/selftests/unit/test_utils_astring.py
+++ b/selftests/unit/test_utils_astring.py
@@ -1,0 +1,47 @@
+import unittest
+
+from avocado.utils import astring
+
+
+class AstringUtilsTest(unittest.TestCase):
+
+    def test_tabular_output(self):
+
+        self.assertEqual(astring.tabular_output([]), "")
+        self.assertEqual(astring.tabular_output([],
+                                                header=('C1', 'C2', 'C3')),
+                         "C1 C2 C3")
+        self.assertEqual(astring.tabular_output([['v11', 'v12', 'v13']]),
+                         "v11 v12 v13")
+        self.assertEqual(astring.tabular_output([['v11', 'v12', 'v13'],
+                                                 ['v21', 'v22', 'v23']],
+                                                header=('C1', 'C2', 'C3')),
+                         "C1  C2  C3" + "\n" +
+                         "v11 v12 v13" + "\n" +
+                         "v21 v22 v23")
+        self.assertEqual(astring.tabular_output([['v11', 'v12', ''],
+                                                 ['v21', 'v22', 'v23']],
+                                                header=('C1', 'C2', 'C3')),
+                         "C1  C2  C3" + "\n" +
+                         "v11 v12 " + "\n" +
+                         "v21 v22 v23")
+        self.assertEqual(astring.tabular_output([['v11', 'v12', ''],
+                                                 ['v21', 'v22', 'v23']],
+                                                header=('C1', 'C2', 'C3'),
+                                                strip=True),
+                         "C1  C2  C3" + "\n" +
+                         "v11 v12" + "\n" +
+                         "v21 v22 v23")
+
+        self.assertEqual(astring.tabular_output([['v11', 'v12', ''],
+                                                 ['v2100', 'v22', 'v23'],
+                                                 ['v31', 'v320', 'v33']],
+                                                header=('C1', 'C02', 'COL3')),
+                         "C1    C02  COL3" + "\n" +
+                         "v11   v12  " + "\n" +
+                         "v2100 v22  v23" + "\n" +
+                         "v31   v320 v33")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The first patch improves iter_tabular_output() and tabular_output() by allowing to strip trailing whitespace on rows. It is a pre-req for next patch that solves https://trello.com/c/JWeay87z/1045-strip-tabularoutput-lines

Changes since v4 (#2610):
- Adjusted the PluginsTest.test_list_no_file_loader() test due lack of whitespace on outputs to be compared.