### PR TITLE
xunit: simple schema usage and source improvements

### DIFF
--- a/selftests/.data/jenkins-junit.xsd
+++ b/selftests/.data/jenkins-junit.xsd
@@ -1,4 +1,31 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!--
+ Source: https://svn.jenkins-ci.org/trunk/hudson/dtkit/dtkit-format/dtkit-junit-model/src/main/resources/com/thalesgroup/dtkit/junit/model/xsd/junit-4.xsd
+
+ This file available under the terms of the MIT License as follows:
+
+ *******************************************************************************
+ * Copyright (c) 2010 Thales Corporate Services SAS                             *
+ *                                                                              *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy *
+ * of this software and associated documentation files (the "Software"), to deal*
+ * in the Software without restriction, including without limitation the rights *
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell    *
+ * copies of the Software, and to permit persons to whom the Software is        *
+ * furnished to do so, subject to the following conditions:                     *
+ *                                                                              *
+ * The above copyright notice and this permission notice shall be included in   *
+ * all copies or substantial portions of the Software.                          *
+ *                                                                              *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR   *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE  *
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER       *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,*
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN    *
+ * THE SOFTWARE.                                                                *
+ ********************************************************************************
+ -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
     <xs:element name="failure">

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -1192,7 +1192,7 @@ class PluginsXunitTest(AbsPluginsTest, unittest.TestCase):
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
         junit_xsd = os.path.join(os.path.dirname(__file__),
-                                 os.path.pardir, ".data", 'junit-4.xsd')
+                                 os.path.pardir, ".data", 'jenkins-junit.xsd')
         self.junit = os.path.abspath(junit_xsd)
         super(PluginsXunitTest, self).setUp()
 

--- a/selftests/unit/test_xunit.py
+++ b/selftests/unit/test_xunit.py
@@ -85,7 +85,8 @@ class xUnitSucceedTest(unittest.TestCase):
         self.assertEqual(len(els), 1)
 
         junit_xsd = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                                                 os.path.pardir, ".data", 'junit-4.xsd'))
+                                                 os.path.pardir, ".data",
+                                                 'jenkins-junit.xsd'))
         with open(junit_xsd, 'r') as f:
             xmlschema = etree.XMLSchema(etree.parse(f))   # pylint: disable=I1101
         # pylint: disable=I1101

--- a/selftests/unit/test_xunit.py
+++ b/selftests/unit/test_xunit.py
@@ -52,9 +52,6 @@ class xUnitSucceedTest(unittest.TestCase):
         self.test1 = SimpleTest(job=self.job, base_logdir=self.tmpdir)
         self.test1._Test__status = 'PASS'
         self.test1.time_elapsed = 1.23
-        junit_xsd = os.path.join(os.path.dirname(__file__),
-                                 os.path.pardir, ".data", 'junit-4.xsd')
-        self.junit = os.path.abspath(junit_xsd)
 
     def tearDown(self):
         errs = []
@@ -87,12 +84,14 @@ class xUnitSucceedTest(unittest.TestCase):
         els = dom.getElementsByTagName('testcase')
         self.assertEqual(len(els), 1)
 
-        with open(self.junit, 'r') as f:
+        junit_xsd = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                                 os.path.pardir, ".data", 'junit-4.xsd'))
+        with open(junit_xsd, 'r') as f:
             xmlschema = etree.XMLSchema(etree.parse(f))   # pylint: disable=I1101
         # pylint: disable=I1101
         self.assertTrue(xmlschema.validate(etree.parse(BytesIO(xml))),
                         "Failed to validate against %s, content:\n%s\nerror log:\n%s" %
-                        (self.junit, xml, xmlschema.error_log))
+                        (junit_xsd, xml, xmlschema.error_log))
 
     def test_max_test_log_size(self):
         log = tempfile.NamedTemporaryFile(dir=self.tmpdir, delete=False)

--- a/selftests/unit/test_xunit.py
+++ b/selftests/unit/test_xunit.py
@@ -91,8 +91,8 @@ class xUnitSucceedTest(unittest.TestCase):
             xmlschema = etree.XMLSchema(etree.parse(f))   # pylint: disable=I1101
         # pylint: disable=I1101
         self.assertTrue(xmlschema.validate(etree.parse(BytesIO(xml))),
-                        "Failed to validate against %s, content:\n%s" %
-                        (self.junit, xml))
+                        "Failed to validate against %s, content:\n%s\nerror log:\n%s" %
+                        (self.junit, xml, xmlschema.error_log))
 
     def test_max_test_log_size(self):
         log = tempfile.NamedTemporaryFile(dir=self.tmpdir, delete=False)


### PR DESCRIPTION
It's hard to define the "right" source for the xunit/junit schemas, but this attempts to use a source that's active (junit.org) and the give schema a better name based on what it targets (Jenkins compatibility).