### PR TITLE
SPEC file: relocate examples to doc directory

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -485,8 +485,8 @@ class Test(unittest.TestCase, TestData):
         """
         Returns the path to the directory that may contain test data files
 
-        For test a test file hosted at /usr/share/avocado/tests/sleeptest.py
-        the datadir is /usr/share/avocado/tests/sleeptest.py.data.
+        For test a test file hosted at /usr/share/doc/avocado/tests/sleeptest.py
+        the datadir is /usr/share/doc/avocado/tests/sleeptest.py.data.
 
         Note that this directory has no specific relation to the test
         name, only to the file that contains the test.  It can be used to

--- a/avocado/etc/avocado/avocado.conf
+++ b/avocado/etc/avocado/avocado.conf
@@ -2,7 +2,7 @@
 # Avocado data dir (holds tests and test auxiliary data, such as ISO files).
 base_dir = /var/lib/avocado
 # You may override the specific test directory with test_dir
-test_dir = /usr/share/avocado/tests
+test_dir = /usr/share/doc/avocado/tests
 # You may override the specific test auxiliary data directory with data_dir
 data_dir = /var/lib/avocado/data
 # You may override the specific job results directory with logs_dir

--- a/docs/source/Configuration.rst
+++ b/docs/source/Configuration.rst
@@ -15,7 +15,7 @@ that contain a number of `keys` and `values`. Take for example a basic Avocado c
 
     [datadir.paths]
     base_dir = /var/lib/avocado
-    test_dir = /usr/share/avocado/tests
+    test_dir = /usr/share/doc/avocado/tests
     data_dir = /var/lib/avocado/data
     logs_dir = ~/avocado/job-results
 
@@ -106,7 +106,7 @@ configuration, after all the files are parsed in their correct resolution order.
 
         Section.Key     Value
         runner.base_dir /var/lib/avocado
-        runner.test_dir /usr/share/avocado/tests
+        runner.test_dir /usr/share/doc/avocado/tests
         runner.data_dir /var/lib/avocado/data
         runner.logs_dir ~/avocado/job-results
 

--- a/docs/source/GetStartedGuide.rst
+++ b/docs/source/GetStartedGuide.rst
@@ -254,24 +254,24 @@ If no arguments provided, Avocado lists "default" tests per each plugin.
 The output might look like this::
 
     $ avocado list
-    INSTRUMENTED /usr/share/avocado/tests/abort.py
-    INSTRUMENTED /usr/share/avocado/tests/datadir.py
-    INSTRUMENTED /usr/share/avocado/tests/doublefail.py
-    INSTRUMENTED /usr/share/avocado/tests/doublefree.py
-    INSTRUMENTED /usr/share/avocado/tests/errortest.py
-    INSTRUMENTED /usr/share/avocado/tests/failtest.py
-    INSTRUMENTED /usr/share/avocado/tests/fiotest.py
-    INSTRUMENTED /usr/share/avocado/tests/gdbtest.py
-    INSTRUMENTED /usr/share/avocado/tests/gendata.py
-    INSTRUMENTED /usr/share/avocado/tests/linuxbuild.py
-    INSTRUMENTED /usr/share/avocado/tests/multiplextest.py
-    INSTRUMENTED /usr/share/avocado/tests/passtest.py
-    INSTRUMENTED /usr/share/avocado/tests/sleeptenmin.py
-    INSTRUMENTED /usr/share/avocado/tests/sleeptest.py
-    INSTRUMENTED /usr/share/avocado/tests/synctest.py
-    INSTRUMENTED /usr/share/avocado/tests/timeouttest.py
-    INSTRUMENTED /usr/share/avocado/tests/warntest.py
-    INSTRUMENTED /usr/share/avocado/tests/whiteboard.py
+    INSTRUMENTED /usr/share/doc/avocado/tests/abort.py
+    INSTRUMENTED /usr/share/doc/avocado/tests/datadir.py
+    INSTRUMENTED /usr/share/doc/avocado/tests/doublefail.py
+    INSTRUMENTED /usr/share/doc/avocado/tests/doublefree.py
+    INSTRUMENTED /usr/share/doc/avocado/tests/errortest.py
+    INSTRUMENTED /usr/share/doc/avocado/tests/failtest.py
+    INSTRUMENTED /usr/share/doc/avocado/tests/fiotest.py
+    INSTRUMENTED /usr/share/doc/avocado/tests/gdbtest.py
+    INSTRUMENTED /usr/share/doc/avocado/tests/gendata.py
+    INSTRUMENTED /usr/share/doc/avocado/tests/linuxbuild.py
+    INSTRUMENTED /usr/share/doc/avocado/tests/multiplextest.py
+    INSTRUMENTED /usr/share/doc/avocado/tests/passtest.py
+    INSTRUMENTED /usr/share/doc/avocado/tests/sleeptenmin.py
+    INSTRUMENTED /usr/share/doc/avocado/tests/sleeptest.py
+    INSTRUMENTED /usr/share/doc/avocado/tests/synctest.py
+    INSTRUMENTED /usr/share/doc/avocado/tests/timeouttest.py
+    INSTRUMENTED /usr/share/doc/avocado/tests/warntest.py
+    INSTRUMENTED /usr/share/doc/avocado/tests/whiteboard.py
     ...
 
 These Python files are considered by Avocado to contain ``INSTRUMENTED``
@@ -280,11 +280,11 @@ tests.
 Let's now list only the executable shell scripts::
 
     $ avocado list | grep ^SIMPLE
-    SIMPLE       /usr/share/avocado/tests/env_variables.sh
-    SIMPLE       /usr/share/avocado/tests/output_check.sh
-    SIMPLE       /usr/share/avocado/tests/simplewarning.sh
-    SIMPLE       /usr/share/avocado/tests/failtest.sh
-    SIMPLE       /usr/share/avocado/tests/passtest.sh
+    SIMPLE       /usr/share/doc/avocado/tests/env_variables.sh
+    SIMPLE       /usr/share/doc/avocado/tests/output_check.sh
+    SIMPLE       /usr/share/doc/avocado/tests/simplewarning.sh
+    SIMPLE       /usr/share/doc/avocado/tests/failtest.sh
+    SIMPLE       /usr/share/doc/avocado/tests/passtest.sh
 
 Here, as mentioned before, ``SIMPLE`` means that those files are executables
 treated as simple tests. You can also give the ``--verbose`` or ``-V`` flag to

--- a/docs/source/Loaders.rst
+++ b/docs/source/Loaders.rst
@@ -114,60 +114,60 @@ expression.
 For instance, if you want to list all tests that are present in the
 ``gdbtest.py`` file, you can use the list command below::
 
-    $ avocado list /usr/share/avocado/tests/gdbtest.py
-    INSTRUMENTED /usr/share/avocado/tests/gdbtest.py:GdbTest.test_start_exit
-    INSTRUMENTED /usr/share/avocado/tests/gdbtest.py:GdbTest.test_existing_commands_raw
-    INSTRUMENTED /usr/share/avocado/tests/gdbtest.py:GdbTest.test_existing_commands
-    INSTRUMENTED /usr/share/avocado/tests/gdbtest.py:GdbTest.test_load_set_breakpoint_run_exit_raw
-    INSTRUMENTED /usr/share/avocado/tests/gdbtest.py:GdbTest.test_load_set_breakpoint_run_exit
-    INSTRUMENTED /usr/share/avocado/tests/gdbtest.py:GdbTest.test_generate_core
-    INSTRUMENTED /usr/share/avocado/tests/gdbtest.py:GdbTest.test_set_multiple_break
-    INSTRUMENTED /usr/share/avocado/tests/gdbtest.py:GdbTest.test_disconnect_raw
-    INSTRUMENTED /usr/share/avocado/tests/gdbtest.py:GdbTest.test_disconnect
-    INSTRUMENTED /usr/share/avocado/tests/gdbtest.py:GdbTest.test_remote_exec
-    INSTRUMENTED /usr/share/avocado/tests/gdbtest.py:GdbTest.test_stream_messages
-    INSTRUMENTED /usr/share/avocado/tests/gdbtest.py:GdbTest.test_connect_multiple_clients
-    INSTRUMENTED /usr/share/avocado/tests/gdbtest.py:GdbTest.test_server_exit
-    INSTRUMENTED /usr/share/avocado/tests/gdbtest.py:GdbTest.test_multiple_servers
-    INSTRUMENTED /usr/share/avocado/tests/gdbtest.py:GdbTest.test_interactive
-    INSTRUMENTED /usr/share/avocado/tests/gdbtest.py:GdbTest.test_interactive_args
-    INSTRUMENTED /usr/share/avocado/tests/gdbtest.py:GdbTest.test_exit_status
-    INSTRUMENTED /usr/share/avocado/tests/gdbtest.py:GdbTest.test_server_stderr
-    INSTRUMENTED /usr/share/avocado/tests/gdbtest.py:GdbTest.test_server_stdout
-    INSTRUMENTED /usr/share/avocado/tests/gdbtest.py:GdbTest.test_interactive_stdout
-    INSTRUMENTED /usr/share/avocado/tests/gdbtest.py:GdbTest.test_remote
+    $ avocado list /usr/share/doc/avocado/tests/gdbtest.py
+    INSTRUMENTED /usr/share/doc/avocado/tests/gdbtest.py:GdbTest.test_start_exit
+    INSTRUMENTED /usr/share/doc/avocado/tests/gdbtest.py:GdbTest.test_existing_commands_raw
+    INSTRUMENTED /usr/share/doc/avocado/tests/gdbtest.py:GdbTest.test_existing_commands
+    INSTRUMENTED /usr/share/doc/avocado/tests/gdbtest.py:GdbTest.test_load_set_breakpoint_run_exit_raw
+    INSTRUMENTED /usr/share/doc/avocado/tests/gdbtest.py:GdbTest.test_load_set_breakpoint_run_exit
+    INSTRUMENTED /usr/share/doc/avocado/tests/gdbtest.py:GdbTest.test_generate_core
+    INSTRUMENTED /usr/share/doc/avocado/tests/gdbtest.py:GdbTest.test_set_multiple_break
+    INSTRUMENTED /usr/share/doc/avocado/tests/gdbtest.py:GdbTest.test_disconnect_raw
+    INSTRUMENTED /usr/share/doc/avocado/tests/gdbtest.py:GdbTest.test_disconnect
+    INSTRUMENTED /usr/share/doc/avocado/tests/gdbtest.py:GdbTest.test_remote_exec
+    INSTRUMENTED /usr/share/doc/avocado/tests/gdbtest.py:GdbTest.test_stream_messages
+    INSTRUMENTED /usr/share/doc/avocado/tests/gdbtest.py:GdbTest.test_connect_multiple_clients
+    INSTRUMENTED /usr/share/doc/avocado/tests/gdbtest.py:GdbTest.test_server_exit
+    INSTRUMENTED /usr/share/doc/avocado/tests/gdbtest.py:GdbTest.test_multiple_servers
+    INSTRUMENTED /usr/share/doc/avocado/tests/gdbtest.py:GdbTest.test_interactive
+    INSTRUMENTED /usr/share/doc/avocado/tests/gdbtest.py:GdbTest.test_interactive_args
+    INSTRUMENTED /usr/share/doc/avocado/tests/gdbtest.py:GdbTest.test_exit_status
+    INSTRUMENTED /usr/share/doc/avocado/tests/gdbtest.py:GdbTest.test_server_stderr
+    INSTRUMENTED /usr/share/doc/avocado/tests/gdbtest.py:GdbTest.test_server_stdout
+    INSTRUMENTED /usr/share/doc/avocado/tests/gdbtest.py:GdbTest.test_interactive_stdout
+    INSTRUMENTED /usr/share/doc/avocado/tests/gdbtest.py:GdbTest.test_remote
 
 To filter the results, listing only the tests that have
 ``test_interactive`` in their test method names, you can execute::
 
-    $ avocado list /usr/share/avocado/tests/gdbtest.py:test_interactive
-    INSTRUMENTED /usr/share/avocado/tests/gdbtest.py:GdbTest.test_interactive
-    INSTRUMENTED /usr/share/avocado/tests/gdbtest.py:GdbTest.test_interactive_args
-    INSTRUMENTED /usr/share/avocado/tests/gdbtest.py:GdbTest.test_interactive_stdout
+    $ avocado list /usr/share/doc/avocado/tests/gdbtest.py:test_interactive
+    INSTRUMENTED /usr/share/doc/avocado/tests/gdbtest.py:GdbTest.test_interactive
+    INSTRUMENTED /usr/share/doc/avocado/tests/gdbtest.py:GdbTest.test_interactive_args
+    INSTRUMENTED /usr/share/doc/avocado/tests/gdbtest.py:GdbTest.test_interactive_stdout
 
 As the string after the ``:`` is a regular expression, three tests were
 filtered in. You can manipulate the regular expression to have only the
 test with that exact name::
 
-    $ avocado list /usr/share/avocado/tests/gdbtest.py:test_interactive$
-    INSTRUMENTED /usr/share/avocado/tests/gdbtest.py:GdbTest.test_interactive
+    $ avocado list /usr/share/doc/avocado/tests/gdbtest.py:test_interactive$
+    INSTRUMENTED /usr/share/doc/avocado/tests/gdbtest.py:GdbTest.test_interactive
 
 The regular expression enables you to have more complex filters.
 Example::
 
-    $ avocado list /usr/share/avocado/tests/gdbtest.py:GdbTest.test_[le].*raw
-    INSTRUMENTED /usr/share/avocado/tests/gdbtest.py:GdbTest.test_existing_commands_raw
-    INSTRUMENTED /usr/share/avocado/tests/gdbtest.py:GdbTest.test_load_set_breakpoint_run_exit_raw
+    $ avocado list /usr/share/doc/avocado/tests/gdbtest.py:GdbTest.test_[le].*raw
+    INSTRUMENTED /usr/share/doc/avocado/tests/gdbtest.py:GdbTest.test_existing_commands_raw
+    INSTRUMENTED /usr/share/doc/avocado/tests/gdbtest.py:GdbTest.test_load_set_breakpoint_run_exit_raw
 
 Once the test reference is providing you the expected outcome, you can
 replace the ``list`` subcommand with the ``run`` subcommand to execute your
 tests::
 
-    $ avocado run /usr/share/avocado/tests/gdbtest.py:GdbTest.test_[le].*raw
+    $ avocado run /usr/share/doc/avocado/tests/gdbtest.py:GdbTest.test_[le].*raw
     JOB ID     : 333912fb02698ed5339a400b832795a80757b8af
     JOB LOG    : $HOME/avocado/job-results/job-2017-06-14T14.54-333912f/job.log
-     (1/2) /usr/share/avocado/tests/gdbtest.py:GdbTest.test_existing_commands_raw: PASS (0.59 s)
-     (2/2) /usr/share/avocado/tests/gdbtest.py:GdbTest.test_load_set_breakpoint_run_exit_raw: PASS (0.42 s)
+     (1/2) /usr/share/doc/avocado/tests/gdbtest.py:GdbTest.test_existing_commands_raw: PASS (0.59 s)
+     (2/2) /usr/share/doc/avocado/tests/gdbtest.py:GdbTest.test_load_set_breakpoint_run_exit_raw: PASS (0.42 s)
     RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
     JOB TIME   : 1.15 s
     JOB HTML   : $HOME/avocado/job-results/job-2017-06-14T14.54-333912f/html/results.html
@@ -176,7 +176,7 @@ tests::
    to individually enclose your Test References in quotes to avoid bash
    of corrupting them. In that case, the command from the example above
    would be:
-   ``avocado run "/usr/share/avocado/tests/gdbtest.py:GdbTest.test_[le].*raw"``
+   ``avocado run "/usr/share/doc/avocado/tests/gdbtest.py:GdbTest.test_[le].*raw"``
 
 External Loader
 ---------------

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -1029,7 +1029,7 @@ the test parameters, as shown below.
 	2016-11-02 11:13:04,411 stacktrace       L0038 ERROR| 
 	2016-11-02 11:13:04,412 stacktrace       L0041 ERROR| Reproduced traceback from: $HOME/src/avocado/avocado/core/test.py:454
 	2016-11-02 11:13:04,412 stacktrace       L0044 ERROR| Traceback (most recent call last):
-	2016-11-02 11:13:04,413 stacktrace       L0044 ERROR|   File "/usr/share/avocado/tests/sleeptest.py", line 23, in test
+	2016-11-02 11:13:04,413 stacktrace       L0044 ERROR|   File "/usr/share/doc/avocado/tests/sleeptest.py", line 23, in test
 	2016-11-02 11:13:04,413 stacktrace       L0044 ERROR|     time.sleep(sleep_length)
 	2016-11-02 11:13:04,413 stacktrace       L0044 ERROR|   File "$HOME/src/avocado/avocado/core/runner.py", line 293, in sigterm_handler
 	2016-11-02 11:13:04,413 stacktrace       L0044 ERROR|     raise SystemExit("Test interrupted by SIGTERM")
@@ -1324,7 +1324,7 @@ from ``avocado.Test``.
 
 Example:
 
-File `/usr/share/avocado/tests/test_base_class.py`::
+File `/usr/share/doc/avocado/tests/test_base_class.py`::
 
     from avocado import Test
 
@@ -1335,7 +1335,7 @@ File `/usr/share/avocado/tests/test_base_class.py`::
             pass
 
 
-File `/usr/share/avocado/tests/test_first_child.py`::
+File `/usr/share/doc/avocado/tests/test_first_child.py`::
 
     from test_base_class import BaseClass
 
@@ -1346,7 +1346,7 @@ File `/usr/share/avocado/tests/test_first_child.py`::
             pass
 
 
-File `/usr/share/avocado/tests/test_second_child.py`::
+File `/usr/share/doc/avocado/tests/test_second_child.py`::
 
     from test_first_child import FirstChild
 

--- a/man/avocado.rst
+++ b/man/avocado.rst
@@ -545,25 +545,25 @@ doubt about which one is that, you may use `avocado config --datadir`).
 The output looks like::
 
     $ avocado list
-    INSTRUMENTED /usr/share/avocado/tests/abort.py
-    INSTRUMENTED /usr/share/avocado/tests/datadir.py
-    INSTRUMENTED /usr/share/avocado/tests/doublefail.py
-    INSTRUMENTED /usr/share/avocado/tests/doublefree.py
-    INSTRUMENTED /usr/share/avocado/tests/errortest.py
-    INSTRUMENTED /usr/share/avocado/tests/failtest.py
-    INSTRUMENTED /usr/share/avocado/tests/fiotest.py
-    INSTRUMENTED /usr/share/avocado/tests/gdbtest.py
-    INSTRUMENTED /usr/share/avocado/tests/gendata.py
-    INSTRUMENTED /usr/share/avocado/tests/linuxbuild.py
-    INSTRUMENTED /usr/share/avocado/tests/multiplextest.py
-    INSTRUMENTED /usr/share/avocado/tests/passtest.py
-    INSTRUMENTED /usr/share/avocado/tests/skiptest.py
-    INSTRUMENTED /usr/share/avocado/tests/sleeptenmin.py
-    INSTRUMENTED /usr/share/avocado/tests/sleeptest.py
-    INSTRUMENTED /usr/share/avocado/tests/synctest.py
-    INSTRUMENTED /usr/share/avocado/tests/timeouttest.py
-    INSTRUMENTED /usr/share/avocado/tests/warntest.py
-    INSTRUMENTED /usr/share/avocado/tests/whiteboard.py
+    INSTRUMENTED /usr/share/doc/avocado/tests/abort.py
+    INSTRUMENTED /usr/share/doc/avocado/tests/datadir.py
+    INSTRUMENTED /usr/share/doc/avocado/tests/doublefail.py
+    INSTRUMENTED /usr/share/doc/avocado/tests/doublefree.py
+    INSTRUMENTED /usr/share/doc/avocado/tests/errortest.py
+    INSTRUMENTED /usr/share/doc/avocado/tests/failtest.py
+    INSTRUMENTED /usr/share/doc/avocado/tests/fiotest.py
+    INSTRUMENTED /usr/share/doc/avocado/tests/gdbtest.py
+    INSTRUMENTED /usr/share/doc/avocado/tests/gendata.py
+    INSTRUMENTED /usr/share/doc/avocado/tests/linuxbuild.py
+    INSTRUMENTED /usr/share/doc/avocado/tests/multiplextest.py
+    INSTRUMENTED /usr/share/doc/avocado/tests/passtest.py
+    INSTRUMENTED /usr/share/doc/avocado/tests/skiptest.py
+    INSTRUMENTED /usr/share/doc/avocado/tests/sleeptenmin.py
+    INSTRUMENTED /usr/share/doc/avocado/tests/sleeptest.py
+    INSTRUMENTED /usr/share/doc/avocado/tests/synctest.py
+    INSTRUMENTED /usr/share/doc/avocado/tests/timeouttest.py
+    INSTRUMENTED /usr/share/doc/avocado/tests/warntest.py
+    INSTRUMENTED /usr/share/doc/avocado/tests/whiteboard.py
 
 Here, `INSTRUMENTED` means that the files there are python files with an
 avocado test class in them, therefore, that they are what we call

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -323,14 +323,14 @@ popd
 %{__install} -m 0644 man/avocado.1 %{buildroot}%{_mandir}/man1/avocado.1
 %{__install} -m 0644 man/avocado-rest-client.1 %{buildroot}%{_mandir}/man1/avocado-rest-client.1
 %{__install} -d -m 0755 %{buildroot}%{_sharedstatedir}/avocado/data
-%{__install} -d -m 0755 %{buildroot}%{_datadir}/avocado
-%{__cp} -r examples/gdb-prerun-scripts %{buildroot}%{_datadir}/avocado
-%{__cp} -r examples/plugins %{buildroot}%{_datadir}/avocado
-%{__cp} -r examples/tests %{buildroot}%{_datadir}/avocado
-%{__cp} -r examples/wrappers %{buildroot}%{_datadir}/avocado
-%{__cp} -r examples/yaml_to_mux %{buildroot}%{_datadir}/avocado
-%{__cp} -r examples/yaml_to_mux_loader %{buildroot}%{_datadir}/avocado
-%{__cp} -r examples/varianter_pict %{buildroot}%{_datadir}/avocado
+%{__install} -d -m 0755 %{buildroot}%{_docdir}/avocado
+%{__cp} -r examples/gdb-prerun-scripts %{buildroot}%{_docdir}/avocado
+%{__cp} -r examples/plugins %{buildroot}%{_docdir}/avocado
+%{__cp} -r examples/tests %{buildroot}%{_docdir}/avocado
+%{__cp} -r examples/wrappers %{buildroot}%{_docdir}/avocado
+%{__cp} -r examples/yaml_to_mux %{buildroot}%{_docdir}/avocado
+%{__cp} -r examples/yaml_to_mux_loader %{buildroot}%{_docdir}/avocado
+%{__cp} -r examples/varianter_pict %{buildroot}%{_docdir}/avocado
 %{__mkdir} -p %{buildroot}%{_libexecdir}/avocado
 %{__mv} %{buildroot}%{python2_sitelib}/avocado/libexec/* %{buildroot}%{_libexecdir}/avocado
 
@@ -757,14 +757,14 @@ Some of them are used as functional tests of the framework, others serve as
 examples of how to write tests on your own.
 
 %files examples
-%dir %{_datadir}/avocado
-%{_datadir}/avocado/gdb-prerun-scripts
-%{_datadir}/avocado/plugins
-%{_datadir}/avocado/tests
-%{_datadir}/avocado/wrappers
-%{_datadir}/avocado/yaml_to_mux
-%{_datadir}/avocado/yaml_to_mux_loader
-%{_datadir}/avocado/varianter_pict
+%dir %{_docdir}/avocado
+%{_docdir}/avocado/gdb-prerun-scripts
+%{_docdir}/avocado/plugins
+%{_docdir}/avocado/tests
+%{_docdir}/avocado/wrappers
+%{_docdir}/avocado/yaml_to_mux
+%{_docdir}/avocado/yaml_to_mux_loader
+%{_docdir}/avocado/varianter_pict
 
 %package bash
 Summary: Avocado Test Framework Bash Utilities


### PR DESCRIPTION
Following up on an open question from PR #2625:

The supposedly version-agnostic `python-avocado-examples` package currently contains byte-compiled `.pyc` and `.pyo` files for python2 (which is the system default python) which get installed in `/usr/share/avocado`. Due to that choice of installation directory, the RPM build process automatically byte-compiles all `.py` files it finds.

Since the examples are technically documentation, the ideal way to fix that problem is to install the examples to `/usr/share/doc/avocado` instead--which is ignored by the automatic byte-compilation.

Signed-off-by: Merlin Mathesius <mmathesi@redhat.com>