### PR TITLE
selftests/unit/test_data_structures.py: identity check is unsuitable

### DIFF
--- a/selftests/unit/test_data_structures.py
+++ b/selftests/unit/test_data_structures.py
@@ -113,8 +113,8 @@ class TestDataSize(unittest.TestCase):
                           data_structures.DataSize, '10Mb')
 
     def test_value_and_type(self):
-        self.assertIs(data_structures.DataSize('0b').b, 0)
-        self.assertIs(data_structures.DataSize('0t').b, 0)
+        self.assertEqual(data_structures.DataSize('0b').b, 0)
+        self.assertEqual(data_structures.DataSize('0t').b, 0)
 
     def test_values(self):
         self.assertEqual(data_structures.DataSize('10m').b, 10485760)


### PR DESCRIPTION
On some architectures, Python will return a long on
data_structures.DataSize conversions.  That makes the identity
check assertion fail, because:

   >>> long(0) == int(0)
   True

But:
   >>> long(0) is int(0)
   False

Reference: https://kojipkgs.fedoraproject.org//work/tasks/1223/26881223/build.log
Signed-off-by: Cleber Rosa <crosa@redhat.com>