### PR TITLE
Add comma_separated_ranges_to_list utility

### DIFF
--- a/avocado/utils/data_structures.py
+++ b/avocado/utils/data_structures.py
@@ -128,6 +128,24 @@ def compare_matrices(matrix1, matrix2, threshold=0.05):
     return (new_matrix, improvements, regressions, total)
 
 
+def comma_separated_ranges_to_list(string):
+    """
+    Provides a list from comma sepatated ranges
+
+    :param string: string of comma seperated range
+    :retrun list: list of integer values in comma seperated range
+    """
+    values = []
+    for value in string.split(','):
+        if '-' in value:
+            start, end = value.split('-')
+            for val in range(int(start), int(end) + 1):
+                values.append(int(val))
+        else:
+            values.append(int(value))
+    return values
+
+
 class Borg:
 
     """

--- a/selftests/unit/test_data_structures.py
+++ b/selftests/unit/test_data_structures.py
@@ -39,6 +39,18 @@ class TestDataStructures(unittest.TestCase):
                          ([["header", '+10.6383', -10.0],
                            ['+100', 'error_51/0', '.']], 3, 1, 5))
 
+    def test_comma_separated_ranges_to_list(self):
+        """
+        Verify the correct value is obtained when converting a comma separated
+        range string to list
+        """
+        node_values = ["0", "1-3", "0-1,16-17", "0-1,16-20,23-25"]
+        expected_values = [[0], [1, 2, 3], [0, 1, 16, 17],
+                           [0, 1, 16, 17, 18, 19, 20, 23, 24, 25]]
+        for index, value in enumerate(node_values):
+            self.assertEqual(data_structures.comma_separated_ranges_to_list(
+                value), expected_values[index])
+
     def test_lazy_property(self):
         """
         Verify the value is initialized lazily with the correct value


### PR DESCRIPTION
Patch adds comma_separated_ranges_to_list utility to return a list of integers from comma separated range values

Signed-off-by: Harish <harish@linux.vnet.ibm.com>