### PR TITLE
get_slot_from_sysfs fails for bare-metal machine

### DIFF
--- a/avocado/utils/pci.py
+++ b/avocado/utils/pci.py
@@ -182,8 +182,12 @@ def get_slot_from_sysfs(full_pci_address):
     if not os.path.isfile("/proc/device-tree/%s/ibm,loc-code" % devspec):
         return
     slot = genio.read_file("/proc/device-tree/%s/ibm,loc-code" % devspec)
-    slot = re.match(r'((\w+)[.])+(\w+)-P(\d+)-C(\d+)|Slot(\d+)', slot).group()
-    return slot
+    slot_ibm = re.match(r'((\w+)[.])+(\w+)-[P(\d+)-]*C(\d+)', slot)
+    slot_openpower = re.match(r'(\w+)[\s]*(\w+)(\d*)', slot)
+    if slot_ibm:
+        return slot_ibm.group()
+    else:
+        return slot_openpower.group()
 
 
 def get_slot_list():

--- a/selftests/unit/test_utils_pci.py
+++ b/selftests/unit/test_utils_pci.py
@@ -1,0 +1,25 @@
+import unittest
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+from avocado.utils import pci
+
+
+class UtilsPciTest(unittest.TestCase):
+
+    def test_get_slot_from_sysfs(self):
+        pcid = '0002:01:00.1'
+        file_values = ['S0001', 'S0001[', 'Slot2', 'SLOT1', 'Backplane USB', 'U78CB.001.WZS07CU-P1-C9-T1', 'PLX Slot1', 'Onboard USB', 'U78D5.001.CSS130E-P1-P2-P2-C1-T1']
+        expected_values = ['S0001', 'S0001', 'Slot2', 'SLOT1', 'Backplane USB', 'U78CB.001.WZS07CU-P1-C9', 'PLX Slot1', 'Onboard USB', 'U78D5.001.CSS130E-P1-P2-P2-C1']
+        for value, exp in zip(file_values, expected_values):
+            with mock.patch('os.path.isfile', return_value=True):
+                with mock.patch('avocado.utils.genio.read_file',
+                                return_value=value):
+                    self.assertEqual(pci.get_slot_from_sysfs(pcid), exp)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
In case of bare-metal machine the actual string for the location code parameter
is 'PLX Slot1' but the regex was failing to parse, so extended regex to also cover
this case. also return the slot cleanly i.e only if the match is found.

that fixes this error: at pci.py", line 185,
AttributeError: 'NoneType' object has no attribute 'group'

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>