### PR TITLE
fixed build.py 

### DIFF
--- a/avocado/utils/build.py
+++ b/avocado/utils/build.py
@@ -57,7 +57,7 @@ def run_make(path, make='make', extra_args='', process_kwargs=None):
 
 
 def make(path, make='make', env=None, extra_args='', ignore_status=None,
-         allow_output_check=None, process_kwargs=None):
+         allow_output_check=None, process_kwargs=None, encoding=None):
     """
     Run make, adding MAKEOPTS to the list of options.
 
@@ -82,7 +82,7 @@ def make(path, make='make', env=None, extra_args='', ignore_status=None,
 
     kwargs = dict(env=env,
                   ignore_status=ignore_status,
-                  allow_output_check=allow_output_check)
+                  allow_output_check=allow_output_check, encoding=encoding)
     if process_kwargs is not None:
         kwargs.update(process_kwargs)
     result = run_make(path, make, extra_args, kwargs)


### PR DESCRIPTION
make output  string not converted to unicode on python2.7 so make is failing as

UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 44: ordinal not in range(128)
this patch address above  issue

LOG:

[stdout] gcc -o pgms/fstime -Wall -pedantic -O3 -ffast-math -mcpu=native -mtune=native -I ./src -DTIME src/fstime.c
[stderr]   File "/usr/lib64/python2.7/threading.py", line 812, in __bootstrap_inner

[stderr]     self.run()

[stderr]   File "/usr/lib64/python2.7/threading.py", line 765, in run

[stderr]     self.__target(*self.__args, **self.__kwargs)

[stdout] make[1]: Leaving directory `/var/tmp/avocado_qTVBay/avocado_job_EduLt2/1-perf_unixbench.py_Unixbench.test/byte-unixbench-master/UnixBench'
[stderr]   File "/usr/lib/python2.7/site-packages/avocado_framework-61.0-py2.7.egg/avocado/utils/process.py", line 383, in _drainer

Command 'make' finished with 2 after 0.0370879173279s
[stderr]     line = astring.to_text(line, self._result.encoding)

[stderr]   File "/usr/lib/python2.7/site-packages/avocado_framework-61.0-py2.7.egg/avocado/utils/astring.py", line 340, in to_text

[stderr]     return data.decode(encoding)

[stderr] UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 44: ordinal not in range(128)

[stderr]

Reproduced traceback from: /usr/lib/python2.7/site-packages/avocado_framework-61.0-py2.7.egg/avocado/core/test.py:854
Traceback (most recent call last):
  File "/var/lib/libvirt/images/workspace/runAvocadoFVTTest/avocado-fvt-wrapper/tests/avocado-misc-tests/perf/unixbench.py", line 49, in setUp
    build.make(self.sourcedir)
  File "/usr/lib/python2.7/site-packages/avocado_framework-61.0-py2.7.egg/avocado/utils/build.py", line 88, in make
    result = run_make(path, make, extra_args, kwargs)
  File "/usr/lib/python2.7/site-packages/avocado_framework-61.0-py2.7.egg/avocado/utils/build.py", line 54, in run_make
    make_process = process.run(cmd,**process_kwargs)
  File "/usr/lib/python2.7/site-packages/avocado_framework-61.0-py2.7.egg/avocado/utils/process.py", line 1275, in run
    raise CmdError(cmd, sp.result)
CmdError

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>