### PR TITLE
utils.service: add systemd options, make service calls safer

### DIFF
--- a/avocado/utils/service.py
+++ b/avocado/utils/service.py
@@ -277,6 +277,11 @@ def sys_v_init_command_generator(command):
             target = convert_systemd_target_to_runlevel(target)
             return ["telinit", target]
         return set_target_command
+    # Do not need reset failed, mask and unmask in sys_v style system.
+    elif command in ["reset_failed", "mask", "unmask"]:
+        def true_command(service_name):
+            return ["true"]
+        return true_command
 
     def method(service_name):
         return [command_name, service_name, command]
@@ -316,6 +321,8 @@ def systemd_command_generator(command):
         def set_target_command(target):
             return [command_name, "isolate", target]
         return set_target_command
+    elif command == "reset_failed":
+        command = "reset-failed"
 
     def method(service_name):
         return [command_name, command, "%s.service" % service_name]
@@ -335,6 +342,9 @@ COMMANDS = (
     ("is_enabled", False),
     ("list", False),
     ("set_target", True),
+    ("reset_failed", True),
+    ("mask", True),
+    ("unmask", True)
 )
 
 

--- a/avocado/utils/service.py
+++ b/avocado/utils/service.py
@@ -395,7 +395,7 @@ class _ServiceCommandGenerator(object):
             setattr(self, command, command_generator(command))
 
 
-def _get_name_of_init(run=process.run):
+def get_name_of_init(run=process.run):
     """
     Internal function to determine what executable is PID 1
 
@@ -421,25 +421,6 @@ def _get_name_of_init(run=process.run):
     else:
         output = run("readlink /proc/1/exe").stdout.strip()
         return os.path.basename(output)
-
-
-def get_name_of_init(run=process.run):
-    """
-    Determine what executable is PID 1, aka init by checking /proc/1/exe
-    This init detection will only run once and cache the return value.
-
-    :return: executable name for PID 1, aka init
-    :rtype:  str
-    """
-    # _init_name is explicitly undefined so that we get the NameError on
-    # first access
-    # pylint: disable=W0601
-    global _init_name
-    try:
-        return _init_name
-    except (NameError, AttributeError):
-        _init_name = _get_name_of_init(run)
-        return _init_name
 
 
 class _SpecificServiceManager(object):
@@ -709,44 +690,6 @@ _service_managers = {"init": _SysVInitServiceManager,
                      "systemd": _SystemdServiceManager}
 
 
-def _get_service_result_parser(run=process.run):
-    """
-    Get the ServiceResultParser using the auto-detect init command.
-
-    :return: ServiceResultParser fro the current init command.
-    :rtype: _ServiceResultParser
-    """
-    # pylint: disable=W0601
-    global _service_result_parser
-    try:
-        return _service_result_parser
-    except NameError:
-        result_parser = _result_parsers[get_name_of_init(run)]
-        _service_result_parser = _ServiceResultParser(result_parser)
-        return _service_result_parser
-
-
-def _get_service_command_generator(run=process.run):
-    """
-    Lazy initializer for ServiceCommandGenerator using the auto-detect init
-    command.
-
-    :return: ServiceCommandGenerator for the current init command.
-    :rtype: _ServiceCommandGenerator
-    """
-    # service_command_generator is explicitly undefined so that we get the
-    # NameError on first access
-    # pylint: disable=W0601
-    global _service_command_generator
-    try:
-        return _service_command_generator
-    except NameError:
-        command_generator = _command_generators[get_name_of_init(run)]
-        _service_command_generator = _ServiceCommandGenerator(
-            command_generator)
-        return _service_command_generator
-
-
 def service_manager(run=process.run):
     """
     Detect which init program is being used, init or systemd and return a
@@ -771,20 +714,16 @@ def service_manager(run=process.run):
     :return: SysVInitServiceManager or SystemdServiceManager
     :rtype: _GenericServiceManager
     """
-    internal_service_manager = _service_managers[get_name_of_init(run)]
-    # service_command_generator is explicitly undefined so that we get the
-    # NameError on first access
-    # pylint: disable=W0601
-    global _service_manager
-    try:
-        return _service_manager
-    except NameError:
-        internal_generator = _get_service_command_generator
-        internal_parser = _get_service_result_parser
-        _service_manager = internal_service_manager(internal_generator(run),
-                                                    internal_parser(run),
-                                                    run=run)
-        return _service_manager
+    init = get_name_of_init(run)
+    internal_service_manager = _service_managers[init]
+    internal_command_generator = _command_generators[init]
+    internal_result_parser = _result_parsers[init]
+
+    internal_generator = _ServiceCommandGenerator(internal_command_generator)
+    internal_parser = _ServiceResultParser(internal_result_parser)
+    _service_manager = internal_service_manager(internal_generator,
+                                                internal_parser, run=run)
+    return _service_manager
 
 
 ServiceManager = service_manager
@@ -844,10 +783,12 @@ def specific_service_manager(service_name, run=process.run):
     :return: SpecificServiceManager that has start/stop methods
     :rtype: _SpecificServiceManager
     """
+    init = get_name_of_init(run)
+    result_parser = _result_parsers[init]
     specific_generator = _auto_create_specific_service_command_generator
     return _SpecificServiceManager(service_name,
                                    specific_generator(run),
-                                   _get_service_result_parser(run), run)
+                                   _ServiceResultParser(result_parser), run)
 
 
 SpecificServiceManager = specific_service_manager

--- a/avocado/utils/service.py
+++ b/avocado/utils/service.py
@@ -782,7 +782,8 @@ def service_manager(run=process.run):
         internal_generator = _get_service_command_generator
         internal_parser = _get_service_result_parser
         _service_manager = internal_service_manager(internal_generator(run),
-                                                    internal_parser(run))
+                                                    internal_parser(run),
+                                                    run=run)
         return _service_manager
 
 

--- a/selftests/unit/test_utils_service.py
+++ b/selftests/unit/test_utils_service.py
@@ -67,6 +67,8 @@ class TestSystemd(unittest.TestCase):
                 self.service_command_generator, cmd)(self.service_name)
             if cmd == "is_enabled":
                 cmd = "is-enabled"
+            if cmd == "reset_failed":
+                cmd = "reset-failed"
             self.assertEqual(ret, ["systemctl", cmd, "%s.service" % self.service_name])
 
     def test_set_target(self):
@@ -88,7 +90,8 @@ class TestSysVInit(unittest.TestCase):
         command_name = "service"
         for cmd, _ in ((c, r) for (c, r) in
                        self.service_command_generator.commands if
-                       c not in ["list", "set_target"]):
+                       c not in ["list", "set_target", "reset_failed", "mask",
+                                 "unmask"]):
             ret = getattr(
                 self.service_command_generator, cmd)(self.service_name)
             if cmd == "is_enabled":

--- a/selftests/unit/test_utils_service.py
+++ b/selftests/unit/test_utils_service.py
@@ -26,6 +26,30 @@ except ImportError:
 from avocado.utils import service
 
 
+class TestRunCalls(unittest.TestCase):
+
+    def setUp(self):
+        self.run_param1 = ["foo_target", "set_target", mock.Mock()]
+        self.run_param2 = ["foo_service", "start", mock.Mock()]
+        self.run_param1[-1].return_value.stdout = "systemd"
+        self.run_param2[-1].return_value.stdout = "init"
+        self.results = ["systemctl isolate foo_target",
+                        "service foo_service start"]
+
+    def test_run_calls(self):
+
+        def run_call(run_params):
+            run_mock = run_params[-1]
+            serv = service.service_manager(run=run_mock)
+            self.assertTrue(run_mock.called)
+            getattr(serv, run_params[1])(run_params[0])
+
+        for test_params, test_results in zip([self.run_param1, self.run_param2],
+                                             self.results):
+            run_call(test_params)
+            self.assertEqual(test_params[-1].call_args[0][0], test_results)
+
+
 class TestSystemd(unittest.TestCase):
 
     def setUp(self):

--- a/selftests/unit/test_utils_service.py
+++ b/selftests/unit/test_utils_service.py
@@ -69,7 +69,8 @@ class TestSystemd(unittest.TestCase):
                 cmd = "is-enabled"
             if cmd == "reset_failed":
                 cmd = "reset-failed"
-            self.assertEqual(ret, ["systemctl", cmd, "%s.service" % self.service_name])
+            self.assertEqual(ret, ["systemctl", cmd, "%s.service" %
+                                   self.service_name])
 
     def test_set_target(self):
         ret = getattr(
@@ -160,7 +161,8 @@ class TestServiceManager(unittest.TestCase):
         service_command_generator = service._ServiceCommandGenerator(
             command_generator)
         service_result_parser = service._ServiceResultParser(result_parser)
-        return service_manager(service_command_generator, service_result_parser, run_mock)
+        return service_manager(service_command_generator, service_result_parser,
+                               run_mock)
 
 
 class TestSystemdServiceManager(TestServiceManager):
@@ -168,9 +170,10 @@ class TestSystemdServiceManager(TestServiceManager):
     def setUp(self):
         self.run_mock = mock.Mock()
         self.init_name = "systemd"
-        self.service_manager = super(TestSystemdServiceManager,
-                                     self).get_service_manager_from_init_and_run(self.init_name,
-                                                                                 self.run_mock)
+        self.service_manager = \
+            (super(TestSystemdServiceManager, self)
+             .get_service_manager_from_init_and_run(self.init_name,
+                                                    self.run_mock))
 
     def test_start(self):
         srv = "lldpad"
@@ -184,12 +187,13 @@ class TestSystemdServiceManager(TestServiceManager):
                                      "vsftpd.service disabled\n"
                                      "systemd-sysctl.service static\n")
         run_mock = mock.Mock(return_value=list_result_mock)
-        service_manager = super(TestSystemdServiceManager,
-                                self).get_service_manager_from_init_and_run(self.init_name,
-                                                                            run_mock)
+        service_manager = \
+            (super(TestSystemdServiceManager, self)
+             .get_service_manager_from_init_and_run(self.init_name, run_mock))
         list_result = service_manager.list(ignore_status=False)
         self.assertEqual(run_mock.call_args[0][0],
-                         "systemctl list-unit-files --type=service --no-pager --full")
+                         "systemctl list-unit-files --type=service "
+                         "--no-pager --full")
         self.assertEqual(list_result, {'sshd': "enabled",
                                        'vsftpd': "disabled",
                                        'systemd-sysctl': "static"})
@@ -229,28 +233,41 @@ class TestSysVInitServiceManager(TestServiceManager):
     def setUp(self):
         self.run_mock = mock.Mock()
         self.init_name = "init"
-        self.service_manager = super(TestSysVInitServiceManager,
-                                     self).get_service_manager_from_init_and_run(self.init_name,
-                                                                                 self.run_mock)
+        self.service_manager = \
+            super(TestSysVInitServiceManager,
+                  self).get_service_manager_from_init_and_run(self.init_name,
+                                                              self.run_mock)
+
+    def test_start(self):
+        srv = "lldpad"
+        self.service_manager.start(srv)
+        cmd = ("service %s start" % srv)
+        self.assertEqual(self.run_mock.call_args[0][0], cmd)
 
     def test_list(self):
         list_result_mock = mock.Mock(
             exit_status=0,
-            stdout="sshd             0:off   1:off   2:off   3:off   4:off   5:off   6:off\n"
-            "vsftpd           0:off   1:off   2:off   3:off   4:off   5:on   6:off\n"
+            stdout="sshd             0:off   1:off   "
+            "2:off   3:off   4:off   5:off   6:off\n"
+            "vsftpd           0:off   1:off   2:off "
+            "  3:off   4:off   5:on   6:off\n"
             "xinetd based services:\n"
             "        amanda:         off\n"
             "        chargen-dgram:  on\n")
 
         run_mock = mock.Mock(return_value=list_result_mock)
-        service_manager = super(TestSysVInitServiceManager,
-                                self).get_service_manager_from_init_and_run(self.init_name,
-                                                                            run_mock)
+        service_manager = \
+            super(TestSysVInitServiceManager,
+                  self).get_service_manager_from_init_and_run(self.init_name,
+                                                              run_mock)
         list_result = service_manager.list(ignore_status=False)
         self.assertEqual(run_mock.call_args[0][0], "chkconfig --list")
-        self.assertEqual(list_result, {'sshd': {0: "off", 1: "off", 2: "off", 3: "off", 4: "off", 5: "off", 6: "off"},
-                                       'vsftpd': {0: "off", 1: "off", 2: "off", 3: "off", 4: "off", 5: "on", 6: "off"},
-                                       'xinetd': {'amanda': "off", 'chargen-dgram': "on"}})
+        self.assertEqual(list_result,
+                         {'sshd': {0: "off", 1: "off", 2: "off", 3: "off",
+                                   4: "off", 5: "off", 6: "off"},
+                          'vsftpd': {0: "off", 1: "off", 2: "off", 3: "off",
+                                     4: "off", 5: "on", 6: "off"},
+                          'xinetd': {'amanda': "off", 'chargen-dgram': "on"}})
 
     def test_enable(self):
         srv = "lldpad"


### PR DESCRIPTION
- this PR solves https://trello.com/c/2kMETG2y/1327-make-avocadoutilsservice-thread-and-even-multi-access-safe?menu=filter&filter=serv
- furthermore are added `status, reset-failed, mask, unmask` options to service management (majority of which are transerred from https://github.com/avocado-framework/avocado-vt/blob/master/virttest/staging/service.py) - see https://github.com/avocado-framework/avocado-vt/pull/1565
- this is also bugfix for omission of `runner` parameter in `internal_servicemanagement`. Optional runners were then not possible.
- style correction of long lines