### PR TITLE
optional_plugins: Limit fabric version to <2.0.0

### DIFF
--- a/examples/testplans/release.json
+++ b/examples/testplans/release.json
@@ -3,6 +3,9 @@
     "description": "Test Plan to be performed before a release is cut",
 
     "tests": [
+	{"name": "Get the latest available requirements",
+	 "description": "Update your systems requirements to the latest pip ones to avoid new deps breakages, run `$ pip install -r requirements.txt --upgrade` inside Avocado sources"},
+
 	{"name": "Avocado source is sound",
 	 "description": "On your development machine, on a freshen Avocado source to be released, run `$ make check-full`. Expected result: Make command should say OK."},
 

--- a/optional_plugins/runner_remote/setup.py
+++ b/optional_plugins/runner_remote/setup.py
@@ -19,9 +19,9 @@ from setuptools import setup, find_packages
 
 
 if sys.version_info[0] == 3:
-    fabric = 'Fabric3'
+    fabric = 'Fabric3<2.0.0'
 else:
-    fabric = 'fabric'
+    fabric = 'fabric<2.0.0'
 
 
 setup(name='avocado-framework-plugin-runner-remote',


### PR DESCRIPTION
The recently released fabric 2.x.y is completely different. Let's limit it's version to `<2.0.0` and add a new step in release testplan to avoid such issues at least on release-time.