### PR TITLE
Asset fetcher: allow assets with same file names to be fetched and cached

### DIFF
--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -199,6 +199,18 @@ def create_job_logs_dir(base_dir=None, unique_id=None):
                   % (logdir))
 
 
+def get_cache_dirs():
+    """
+    Returns the list of cache dirs, according to configuration and convention
+    """
+    cache_dirs = settings.settings.get_value('datadir.paths', 'cache_dirs',
+                                             key_type=list, default=[])
+    datadir_cache = os.path.join(get_data_dir(), 'cache')
+    if datadir_cache not in cache_dirs:
+        cache_dirs.append(datadir_cache)
+    return cache_dirs
+
+
 class _TmpDirTracker(Borg):
 
     def __init__(self):

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -1073,7 +1073,7 @@ class Test(unittest.TestCase, TestData):
         """
         raise exceptions.TestCancel(message)
 
-    def fetch_asset(self, name, asset_hash=None, algorithm='sha1',
+    def fetch_asset(self, name, asset_hash=None, algorithm=None,
                     locations=None, expire=None):
         """
         Method o call the utils.asset in order to fetch and asset file
@@ -1081,7 +1081,8 @@ class Test(unittest.TestCase, TestData):
 
         :param name: the asset filename or URL
         :param asset_hash: asset hash (optional)
-        :param algorithm: hash algorithm (optional, defaults to sha1)
+        :param algorithm: hash algorithm (optional, defaults to
+                          :data:`avocado.utils.asset.DEFAULT_HASH_ALGORITHM`)
         :param locations: list of URLs from where the asset can be
                           fetched (optional)
         :param expire: time for the asset to expire

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -567,12 +567,7 @@ class Test(unittest.TestCase, TestData):
         Returns a list of cache directories as set in config file.
         """
         if self.__cache_dirs is None:
-            cache_dirs = settings.get_value('datadir.paths', 'cache_dirs',
-                                            key_type=list, default=[])
-            datadir_cache = os.path.join(data_dir.get_data_dir(), 'cache')
-            if datadir_cache not in cache_dirs:
-                cache_dirs.append(datadir_cache)
-            self.__cache_dirs = cache_dirs
+            self.__cache_dirs = data_dir.get_cache_dirs()
         return self.__cache_dirs
 
     @property

--- a/avocado/plugins/config.py
+++ b/avocado/plugins/config.py
@@ -70,3 +70,4 @@ class Config(CLICmd):
             LOG_UI.debug('    tests    ' + data_dir.get_test_dir())
             LOG_UI.debug('    data     ' + data_dir.get_data_dir())
             LOG_UI.debug('    logs     ' + data_dir.get_logs_dir())
+            LOG_UI.debug('    cache    ' + ", ".join(data_dir.get_cache_dirs()))

--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -189,8 +189,8 @@ class Asset(object):
         if not os.path.isfile(self.hashfile):
             self._compute_hash()
 
-        with open(self.hashfile, 'r') as asset_file:
-            for line in asset_file:
+        with open(self.hashfile, 'r') as hash_file:
+            for line in hash_file:
                 # md5 is 32 chars big and sha512 is 128 chars big.
                 # others supported algorithms are between those.
                 pattern = '%s [a-f0-9]{32,128}' % self.algorithm

--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -84,7 +84,7 @@ class Asset(object):
         if self.nameobj.scheme:
             urls.append(self.nameobj.geturl())
 
-        # First let's find for the file in all cache locations
+        # First let's search for the file in each one of the cache locations
         for cache_dir in self.cache_dirs:
             cache_dir = os.path.expanduser(cache_dir)
             self.asset_file = os.path.join(cache_dir, self.basename)

--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -40,6 +40,10 @@ from .filelock import FileLock
 log = logging.getLogger('avocado.test')
 
 
+#: The default hash algorithm to use on asset cache operations
+DEFAULT_HASH_ALGORITHM = 'sha256'
+
+
 class UnsupportProtocolError(EnvironmentError):
     """
     Signals that the protocol of the asset URL is not supported
@@ -66,7 +70,7 @@ class Asset(object):
         self.name = name
         self.asset_hash = asset_hash
         if algorithm is None:
-            self.algorithm = 'sha1'
+            self.algorithm = DEFAULT_HASH_ALGORITHM
         else:
             self.algorithm = algorithm
         self.locations = locations

--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -40,6 +40,12 @@ from .filelock import FileLock
 log = logging.getLogger('avocado.test')
 
 
+class UnsupportProtocolError(EnvironmentError):
+    """
+    Signals that the protocol of the asset URL is not supported
+    """
+
+
 class Asset(object):
     """
     Try to fetch/verify an asset file from multiple locations.
@@ -142,6 +148,9 @@ class Asset(object):
                 fetch = self._download
             elif urlobj.scheme == 'file':
                 fetch = self._get_local_file
+            else:
+                raise UnsupportProtocolError("Unsupported protocol"
+                                             ": %s" % urlobj.scheme)
             try:
                 if fetch(urlobj):
                     return self.asset_file

--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -139,35 +139,24 @@ class Asset(object):
         for url in urls:
             urlobj = urlparse.urlparse(url)
             if urlobj.scheme in ['http', 'https', 'ftp']:
-                try:
-                    if self._download(url):
-                        return self.asset_file
-                except:
-                    exc_type, exc_value = sys.exc_info()[:2]
-                    log.error('%s: %s' % (exc_type.__name__, exc_value))
-
+                fetch = self._download
             elif urlobj.scheme == 'file':
-                # Being flexible with the urlparse result
-                if os.path.isdir(urlobj.path):
-                    path = os.path.join(urlobj.path, self.name)
-                else:
-                    path = urlobj.path
-
-                try:
-                    if self._get_local_file(path):
-                        return self.asset_file
-                except:
-                    exc_type, exc_value = sys.exc_info()[:2]
-                    log.error('%s: %s' % (exc_type.__name__, exc_value))
+                fetch = self._get_local_file
+            try:
+                if fetch(urlobj):
+                    return self.asset_file
+            except:
+                exc_type, exc_value = sys.exc_info()[:2]
+                log.error('%s: %s' % (exc_type.__name__, exc_value))
 
         raise EnvironmentError("Failed to fetch %s." % self.basename)
 
-    def _download(self, url):
+    def _download(self, url_obj):
         try:
             # Temporary unique name to use while downloading
             temp = '%s.%s' % (self.asset_file,
                               next(tempfile._get_candidate_names()))
-            url_download(url, temp)
+            url_download(url_obj.geturl(), temp)
 
             # Acquire lock only after download the file
             with FileLock(self.asset_file, 1):
@@ -205,7 +194,12 @@ class Asset(object):
         else:
             return False
 
-    def _get_local_file(self, path):
+    def _get_local_file(self, url_obj):
+        if os.path.isdir(url_obj.path):
+            path = os.path.join(url_obj.path, self.name)
+        else:
+            path = url_obj.path
+
         try:
             with FileLock(self.asset_file, 1):
                 try:

--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -69,6 +69,22 @@ class Asset(object):
         self.basename = os.path.basename(self.nameobj.path)
         self.expire = expire
 
+    def _get_writable_cache_dir(self):
+        """
+        Returns the first available writable cache directory
+
+        When a asset has to be downloaded, a writable cache directory
+        is then needed. The first available writable cache directory
+        will be used.
+        """
+        result = None
+        for cache_dir in self.cache_dirs:
+            cache_dir = os.path.expanduser(cache_dir)
+            if utils_path.usable_rw_dir(cache_dir):
+                result = cache_dir
+                break
+        return result
+
     def fetch(self):
         """
         Fetches the asset. First tries to find the asset on the provided
@@ -107,45 +123,44 @@ class Asset(object):
         # If we get to this point, we have to download it from a location.
         # A writable cache directory is then needed. The first available
         # writable cache directory will be used.
-        for cache_dir in self.cache_dirs:
-            cache_dir = os.path.expanduser(cache_dir)
-            self.asset_file = os.path.join(cache_dir, self.basename)
-            self.hashfile = '%s-CHECKSUM' % self.asset_file
-            if not utils_path.usable_rw_dir(cache_dir):
-                continue
+        cache_dir = self._get_writable_cache_dir()
+        if cache_dir is None:
+            raise EnvironmentError("Can't find a writable cache directory.")
 
-            # Now we have a writable cache_dir. Let's get the asset.
-            # Adding the user defined locations to the urls list:
-            if self.locations is not None:
-                for item in self.locations:
-                    urls.append(item)
+        self.asset_file = os.path.join(cache_dir, self.basename)
+        self.hashfile = '%s-CHECKSUM' % self.asset_file
 
-            for url in urls:
-                urlobj = urlparse.urlparse(url)
-                if urlobj.scheme in ['http', 'https', 'ftp']:
-                    try:
-                        if self._download(url):
-                            return self.asset_file
-                    except:
-                        exc_type, exc_value = sys.exc_info()[:2]
-                        log.error('%s: %s' % (exc_type.__name__, exc_value))
+        # Now we have a writable cache_dir. Let's get the asset.
+        # Adding the user defined locations to the urls list:
+        if self.locations is not None:
+            for item in self.locations:
+                urls.append(item)
 
-                elif urlobj.scheme == 'file':
-                    # Being flexible with the urlparse result
-                    if os.path.isdir(urlobj.path):
-                        path = os.path.join(urlobj.path, self.name)
-                    else:
-                        path = urlobj.path
+        for url in urls:
+            urlobj = urlparse.urlparse(url)
+            if urlobj.scheme in ['http', 'https', 'ftp']:
+                try:
+                    if self._download(url):
+                        return self.asset_file
+                except:
+                    exc_type, exc_value = sys.exc_info()[:2]
+                    log.error('%s: %s' % (exc_type.__name__, exc_value))
 
-                    try:
-                        if self._get_local_file(path):
-                            return self.asset_file
-                    except:
-                        exc_type, exc_value = sys.exc_info()[:2]
-                        log.error('%s: %s' % (exc_type.__name__, exc_value))
+            elif urlobj.scheme == 'file':
+                # Being flexible with the urlparse result
+                if os.path.isdir(urlobj.path):
+                    path = os.path.join(urlobj.path, self.name)
+                else:
+                    path = urlobj.path
 
-            raise EnvironmentError("Failed to fetch %s." % self.basename)
-        raise EnvironmentError("Can't find a writable cache directory.")
+                try:
+                    if self._get_local_file(path):
+                        return self.asset_file
+                except:
+                    exc_type, exc_value = sys.exc_info()[:2]
+                    log.error('%s: %s' % (exc_type.__name__, exc_value))
+
+        raise EnvironmentError("Failed to fetch %s." % self.basename)
 
     def _download(self, url):
         try:

--- a/avocado/utils/crypto.py
+++ b/avocado/utils/crypto.py
@@ -17,23 +17,6 @@ import logging
 import hashlib
 
 
-def hash_wrapper(algorithm='md5', data=None):
-    """
-    Returns an hash object of data using either md5 or sha1 only.
-
-    :param input: Optional input string that will be used to update the hash.
-    :returns: Hash object.
-    """
-    if algorithm not in ['md5', 'sha1']:
-        raise ValueError("Unsupported hash algorithm: %s" % algorithm)
-
-    hash_obj = hashlib.new(algorithm)
-    if data:
-        hash_obj.update(data)
-
-    return hash_obj
-
-
 def hash_file(filename, size=None, algorithm="md5"):
     """
     Calculate the hash value of filename.
@@ -57,9 +40,10 @@ def hash_file(filename, size=None, algorithm="md5"):
         size = fsize
 
     try:
-        hash_obj = hash_wrapper(algorithm=algorithm)
-    except ValueError:
-        logging.error("Unknown hash algorithm %s, returning None", algorithm)
+        hash_obj = hashlib.new(algorithm)
+    except ValueError as e:
+        logging.error('Returning "None" due to inability to create hash '
+                      'object: "%s"', e)
         return None
 
     with open(filename, 'rb') as file_to_hash:

--- a/avocado/utils/crypto.py
+++ b/avocado/utils/crypto.py
@@ -45,9 +45,8 @@ def hash_file(filename, size=None, algorithm="md5"):
         dd if=filename bs=1024 count=size/1024 | sha1sum -
 
     :param filename: Path of the file that will have its hash calculated.
-    :param method: Method used to calculate the hash. Supported methods:
-                   * md5
-                   * sha1
+    :param algorithm: Method used to calculate the hash. Supported methods are
+                      md5 (default) or sha1
     :param size: If provided, hash only the first size bytes of the file.
     :return: Hash of the file, if something goes wrong, return None.
     """

--- a/selftests/unit/test_utils_asset.py
+++ b/selftests/unit/test_utils_asset.py
@@ -102,6 +102,32 @@ class TestAsset(unittest.TestCase):
                               None, None, None, [self.cache_dir], None)
         self.assertRaises(asset.UnsupportProtocolError, invalid.fetch)
 
+    def test_fetch_two_files_same_name_no_hash(self):
+        """
+        Checks that when two different assets which happen to have
+        the same *filename*, are properly stored in the cache
+        directory and that the right one will be given to the user,
+        no matter if a hash is used or not.
+        """
+        second_assetname = self.assetname
+        second_asset_origin_dir = tempfile.mkdtemp(dir=self.basedir)
+        second_asset_local_path = os.path.join(second_asset_origin_dir,
+                                               second_assetname)
+        second_asset_content = 'This is not your first asset content!'
+        with open(second_asset_local_path, 'w') as f:
+            f.write(second_asset_content)
+        second_asset_origin_url = 'file://%s' % second_asset_local_path
+
+        a1 = asset.Asset(self.url, self.assethash, 'sha1', None,
+                         [self.cache_dir], None)
+        a1.fetch()
+        a2 = asset.Asset(second_asset_origin_url, None, None,
+                         [second_asset_origin_dir], [self.cache_dir],
+                         None)
+        a2_path = a2.fetch()
+        with open(a2_path, 'r') as a2_file:
+            self.assertEqual(a2_file.read(), second_asset_content)
+
     def tearDown(self):
         shutil.rmtree(self.basedir)
 

--- a/selftests/unit/test_utils_asset.py
+++ b/selftests/unit/test_utils_asset.py
@@ -40,7 +40,7 @@ class TestAsset(unittest.TestCase):
         expected_tarball = os.path.join(self.cache_dir, self.assetname)
         self.assertEqual(foo_tarball, expected_tarball)
 
-    def test_fecth_expire(self):
+    def test_fetch_expire(self):
         foo_tarball = asset.Asset(self.assetname,
                                   asset_hash=self.assethash,
                                   algorithm='sha1',

--- a/selftests/unit/test_utils_asset.py
+++ b/selftests/unit/test_utils_asset.py
@@ -97,6 +97,11 @@ class TestAsset(unittest.TestCase):
                             expire=None)
             self.assertRaises(EnvironmentError, a.fetch)
 
+    def test_unknown_scheme(self):
+        invalid = asset.Asset("weird-protocol://location/?params=foo",
+                              None, None, None, [self.cache_dir], None)
+        self.assertRaises(asset.UnsupportProtocolError, invalid.fetch)
+
     def tearDown(self):
         shutil.rmtree(self.basedir)
 


### PR DESCRIPTION
The current implementation fails to cache multiple files if their name is the same.  The filename *only* will be considered when looking at the cached directories, and if hashes are not given, users will end up with the wrong files, even when they give unique URLs to different files.

Other than fixing this issue, there are a number of refactors and fixes on related code.