### PR TITLE
Docs: reference Avocado-VT from Avocado's installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,11 @@ Installing Avocado
 Avocado is primarily written in Python, so a standard Python installation
 is possible and often preferable.
 
+.. tip:: If you are looking for Virtualization specific testing, also
+         consider looking at `Avocado-VT installation instructions
+         <https://avocado-vt.readthedocs.io/en/latest/GetStartedGuide.html#installing-avocado-vt>`_
+         after finishing the Avocado installation.
+
 Installing with standard Python tools
 -------------------------------------
 

--- a/docs/source/GetStartedGuide.rst
+++ b/docs/source/GetStartedGuide.rst
@@ -20,6 +20,12 @@ Installing Avocado
 Avocado is primarily written in Python, so a standard Python installation
 is possible and often preferable.
 
+.. tip:: If you are looking for Virtualization specific testing, also
+         consider looking at `Avocado-VT installation instructions
+         <https://avocado-vt.readthedocs.io/en/latest/GetStartedGuide.html#installing-avocado-vt>`_
+         after finishing the Avocado installation.
+
+
 Installing with standard Python tools
 -------------------------------------
 


### PR DESCRIPTION
Avocado is frequently used with Avocado-VT, so let's make it easier
for users to jump to Avocado-VT's documentation for a smoothier
installation experience.

This is based on real feedback from a long time user, after wasting time
attempting to find Avocado-VT references.

Signed-off-by: Cleber Rosa <crosa@redhat.com>