### PR TITLE
Process encoding2

### DIFF
--- a/avocado/plugins/gdb.py
+++ b/avocado/plugins/gdb.py
@@ -17,6 +17,7 @@
 from avocado.core import exceptions
 from avocado.core.plugin_interfaces import CLI
 from avocado.core.settings import settings
+from avocado.utils import astring
 from avocado.utils import gdb
 from avocado.utils import process
 from avocado.utils import path as utils_path
@@ -63,7 +64,8 @@ class GDB(CLI):
     def run(self, args):
         if 'gdb_run_bin' in args:
             for binary in args.gdb_run_bin:
-                gdb.GDB_RUN_BINARY_NAMES_EXPR.append(binary)
+                b_binary = binary.encode(astring.ENCODING)
+                gdb.GDB_RUN_BINARY_NAMES_EXPR.append(b_binary)
 
         if 'gdb_prerun_commands' in args:
             for commands in args.gdb_prerun_commands:

--- a/avocado/plugins/wrapper.py
+++ b/avocado/plugins/wrapper.py
@@ -18,6 +18,7 @@ import sys
 from avocado.core import exit_codes
 from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLI
+from avocado.utils import astring
 from avocado.utils import process
 
 
@@ -58,15 +59,16 @@ class Wrapper(CLI):
             for wrap in args.wrapper:
                 if ':' not in wrap:
                     if process.WRAP_PROCESS is None:
-                        script = os.path.abspath(wrap)
-                        process.WRAP_PROCESS = os.path.abspath(script)
+                        script = os.path.abspath(wrap).encode(astring.ENCODING)
+                        process.WRAP_PROCESS = script
                     else:
                         LOG_UI.error("You can't have multiple global "
                                      "wrappers at once.")
                         sys.exit(exit_codes.AVOCADO_FAIL)
                 else:
                     script, cmd = wrap.split(':', 1)
-                    script = os.path.abspath(script)
+                    script = os.path.abspath(script).encode(astring.ENCODING)
+                    cmd = cmd.encode(astring.ENCODING)
                     process.WRAP_PROCESS_NAMES_EXPR.append((script, cmd))
                 if not os.path.exists(script):
                     LOG_UI.error("Wrapper '%s' not found!", script)

--- a/avocado/utils/astring.py
+++ b/avocado/utils/astring.py
@@ -320,7 +320,7 @@ def is_text(data):
     return isinstance(data, str)
 
 
-def to_text(data, encoding=ENCODING):
+def to_text(data, encoding=ENCODING, errors='strict'):
     """
     Convert anything to text decoded text
 
@@ -329,15 +329,17 @@ def to_text(data, encoding=ENCODING):
     it's returned unchanged.
 
     :param data: data to be transformed into text
-    :param encoding: encoding of the data (only used when decoding
-                     is necessary)
     :type data: either bytes or other data that will be returned
                 unchanged
+    :param encoding: encoding of the data (only used when decoding
+                     is necessary)
+    :param errors: how to handle encode/decode errors, see:
+            https://docs.python.org/3/library/codecs.html#error-handlers
     """
     if is_bytes(data):
         if encoding is None:
             encoding = ENCODING
-        return data.decode(encoding)
+        return data.decode(encoding, errors=errors)
     elif not isinstance(data, string_types):
         if sys.version_info[0] < 3:
             return unicode(data)    # pylint: disable=E0602

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -274,8 +274,8 @@ class CmdResult(object):
     :param pid: ID of the process
     :type pid: int
     :param encoding: the encoding to use for the text version
-                     of stdout and stderr, with the default being
-                     Python's own (:func:`sys.getdefaultencoding`).
+                     of stdout and stderr, by default
+                     :data:`avocado.utils.astring.ENCODING`
     :type encoding: str
     """
 
@@ -292,7 +292,7 @@ class CmdResult(object):
         self.interrupted = False
         self.pid = pid
         if encoding is None:
-            encoding = sys.getdefaultencoding()
+            encoding = astring.ENCODING
         self.encoding = encoding
 
     @property
@@ -473,14 +473,13 @@ class SubProcess(object):
                     main thread finishes and also it allows those daemons
                     to be running after the process finishes.
         :param encoding: the encoding to use for the text representation
-                         of the command result stdout and stderr, with the
-                         default being Python's own, that is,
-                         (:func:`sys.getdefaultencoding`).
+                         of the command result stdout and stderr, by default
+                         :mod:`avocado.utils.astring.ENCODING`
         :type encoding: str
         :raises: ValueError if incorrect values are given to parameters
         """
         if encoding is None:
-            encoding = sys.getdefaultencoding()
+            encoding = astring.ENCODING
         if sudo:
             self.cmd = self._prepend_sudo(cmd, shell)
         else:
@@ -862,9 +861,13 @@ class GDBSubProcess(object):
         :param ignore_bg_processes: This param will be ignored in this
                      implementation, since the GDB wrapping code does not have
                      support to run commands in that way.
+        :param encoding: the encoding to use for the text representation
+                         of the command result stdout and stderr, by default
+                         :mod:`avocado.utils.astring.ENCODING`
+        :type encoding: str
         """
         if encoding is None:
-            encoding = sys.getdefaultencoding()
+            encoding = astring.ENCODING
         self.cmd = cmd
 
         self.args = cmd_split(cmd)
@@ -1254,16 +1257,15 @@ def run(cmd, timeout=None, verbose=True, ignore_status=False,
                  prompted. If that's not the case, the command will
                  straight out fail.
     :param encoding: the encoding to use for the text representation
-                     of the command result stdout and stderr, with the
-                     default being Python's own, that is,
-                     (:func:`sys.getdefaultencoding`).
+                     of the command result stdout and stderr, by default
+                     :mod:`avocado.utils.astring.ENCODING`
     :type encoding: str
 
     :return: An :class:`CmdResult` object.
     :raise: :class:`CmdError`, if ``ignore_status=False``.
     """
     if encoding is None:
-        encoding = sys.getdefaultencoding()
+        encoding = astring.ENCODING
     klass = get_sub_process_klass(cmd)
     sp = klass(cmd=cmd, verbose=verbose,
                allow_output_check=allow_output_check, shell=shell, env=env,
@@ -1324,9 +1326,8 @@ def system(cmd, timeout=None, verbose=True, ignore_status=False,
                  prompted. If that's not the case, the command will
                  straight out fail.
     :param encoding: the encoding to use for the text representation
-                     of the command result stdout and stderr, with the
-                     default being Python's own, that is,
-                     (:func:`sys.getdefaultencoding`).
+                     of the command result stdout and stderr, by default
+                     :mod:`avocado.utils.astring.ENCODING`
     :type encoding: str
 
     :return: Exit code.
@@ -1392,9 +1393,8 @@ def system_output(cmd, timeout=None, verbose=True, ignore_status=False,
     :param strip_trail_nl: Whether to strip the trailing newline
     :type strip_trail_nl: bool
     :param encoding: the encoding to use for the text representation
-                     of the command result stdout and stderr, with the
-                     default being Python's own, that is,
-                     (:func:`sys.getdefaultencoding`).
+                     of the command result stdout and stderr, by default
+                     :mod:`avocado.utils.astring.ENCODING`
     :type encoding: str
 
     :return: Command output.

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -842,25 +842,12 @@ class GDBSubProcess(object):
 
         :param cmd: Command line to run.
         :type cmd: str
-        :param verbose: Whether to log the command run and stdout/stderr.
-                        Currently unused and provided for compatibility only.
-        :type verbose: bool
-        :param allow_output_check: Whether to log the command stream outputs
-                                   (stdout and stderr) in the test stream
-                                   files. Valid values: 'stdout', for
-                                   allowing only standard output, 'stderr',
-                                   to allow only standard error, 'all',
-                                   to allow both standard output and error
-                                   (default), and 'none', to allow
-                                   none to be recorded. Currently unused and
-                                   provided for compatibility only.
-        :type allow_output_check: str
-        :param sudo: This param will be ignored in this implementation,
-                     since the GDB wrapping code does not have support to run
-                     commands under sudo just yet.
-        :param ignore_bg_processes: This param will be ignored in this
-                     implementation, since the GDB wrapping code does not have
-                     support to run commands in that way.
+        :params verbose: Currently ignored in GDBSubProcess
+        :param allow_output_check: Currently ignored in GDBSubProcess
+        :param shell: Currently ignored in GDBSubProcess
+        :param env: Currently ignored in GDBSubProcess
+        :param sudo: Currently ignored in GDBSubProcess
+        :param ignore_bg_processes: Currently ignored in GDBSubProcess
         :param encoding: the encoding to use for the text representation
                          of the command result stdout and stderr, by default
                          :mod:`avocado.utils.astring.ENCODING`

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -387,7 +387,8 @@ class FDDrainer(object):
                 bfr += tmp
                 if tmp.endswith(b'\n'):
                     for line in bfr.splitlines():
-                        line = astring.to_text(line, self._result.encoding)
+                        line = astring.to_text(line, self._result.encoding,
+                                               'replace')
                         if self._logger is not None:
                             self._logger.debug(self._logger_prefix, line)
                         if self._stream_logger is not None:


### PR DESCRIPTION
We finally introduced quite sane default encoding in `astring.ENCODING`. Let's use it in the `process` library by default. While on it fix several issues related to encoding withing this library. There were and still are some little issues with `sudo` but I'd like to first focus on the basic workflow and deal with sudo here https://trello.com/c/x0KgbhZy/1316-investigate-encoding-handling-in-avocadoutilsprocess-library-when-using-sudo and also the wrappers/gdb handling is a bit odd https://trello.com/c/lTesLk1A/1318-overview-the-gdb-and-wrappers-handling-with-regards-to-bytes-vs-strings

v1: https://github.com/avocado-framework/avocado/pull/2626

Changes:

```yaml
v2: two docstring and one import improvements
```