### PR TITLE
WiP: loader: Discover tests as "recursive" by default

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -678,126 +678,126 @@ class FileLoader(TestLoader):
 
             # Looking for a 'class Anything(anything):'
             elif isinstance(statement, ast.ClassDef):
-
                 # class_name will exist only under recursion. In that
                 # case, we will only process the class if it has the
                 # expected class_name.
-                if class_name is not None and class_name != statement.name:
-                    continue
+                if class_name is not None:
+                    if class_name != statement.name:
+                        continue
 
                 docstring = ast.get_docstring(statement)
-                # Looking for a class that has in the docstring either
-                # ":avocado: enable" or ":avocado: disable
-                has_disable = safeloader.check_docstring_directive(docstring,
-                                                                   'disable')
-                if (has_disable and class_name is None):
-                    disabled.add(statement.name)
-                    continue
-
+                # Check whether class is not force-disabled `:avocado: disable`
                 cl_tags = safeloader.get_docstring_directives_tags(docstring)
 
-                has_enable = safeloader.check_docstring_directive(docstring,
-                                                                  'enable')
-                if (has_enable and class_name is None):
+                info = None
+                # Already recursing or the user forced recursion by
+                # ":avocado: recursive"
+                if (class_name is not None or
+                        safeloader.check_docstring_directive(docstring,
+                                                             'recursive')):
+                    info = self._get_methods_info(statement.body, cl_tags)
+                # User force disabled this class by ":avocado: disable"
+                elif safeloader.check_docstring_directive(docstring,
+                                                          'disable'):
+                    disabled.add(statement.name)
+                    continue
+                # User force enabled this class by ":avocado: enable"
+                elif safeloader.check_docstring_directive(docstring, 'enable'):
+                    # Stop the recursion and only add this class
                     info = self._get_methods_info(statement.body, cl_tags)
                     result[statement.name] = info
                     continue
-
-                # Looking for the 'recursive' docstring or a 'class_name'
-                # (meaning we are under recursion)
-                has_recurse = safeloader.check_docstring_directive(docstring,
-                                                                   'recursive')
-                if (has_recurse or class_name is not None):
-                    info = self._get_methods_info(statement.body, cl_tags)
-                    result[statement.name] = info
-
-                    # Getting the list of parents of the current class
-                    parents = statement.bases
-
-                    # Searching the parents in the same module
-                    for parent in parents[:]:
-                        # Looking for a 'class FooTest(module.Parent)'
-                        if isinstance(parent, ast.Attribute):
-                            parent_class = parent.attr
-                        # Looking for a 'class FooTest(Parent)'
-                        else:
-                            parent_class = parent.id
-                        res, dis = self._find_avocado_tests(path, parent_class)
-                        if res:
-                            parents.remove(parent)
-                            for cls in res:
-                                info.extend(res[cls])
-                        disabled.update(dis)
-
-                    # If there are parents left to be discovered, they
-                    # might be in a different module.
-                    for parent in parents:
-                        if isinstance(parent, ast.Attribute):
-                            # Looking for a 'class FooTest(module.Parent)'
-                            parent_module = parent.value.id
-                            parent_class = parent.attr
-                        else:
-                            # Looking for a 'class FooTest(Parent)'
-                            parent_module = None
-                            parent_class = parent.id
-
-                        for node in mod.body:
-                            reference = None
-                            # Looking for 'from parent import class'
-                            if isinstance(node, ast.ImportFrom):
-                                reference = parent_class
-                            # Looking for 'import parent'
-                            elif isinstance(node, ast.Import):
-                                reference = parent_module
-
-                            if reference is None:
-                                continue
-
-                            for artifact in node.names:
-                                # Looking for a class alias
-                                # ('from parent import class as alias')
-                                if artifact.asname is not None:
-                                    parent_class = reference = artifact.name
-                                # If the parent class or the parent module
-                                # is found in the imports, discover the
-                                # parent module path and find the parent
-                                # class there
-                                if artifact.name == reference:
-                                    modules_paths = [os.path.dirname(path)]
-                                    modules_paths.extend(sys.path)
-                                    if parent_module is None:
-                                        parent_module = node.module
-                                    _, ppath, _ = imp.find_module(parent_module,
-                                                                  modules_paths)
-                                    res, dis = self._find_avocado_tests(ppath,
-                                                                        parent_class)
-                                    if res:
-                                        for cls in res:
-                                            info.extend(res[cls])
-                                    disabled.update(dis)
-
-                    continue
-
-                if test_import:
+                # If not decided check whether it's inherited from Test
+                if info is None and test_import:
                     base_ids = [base.id for base in statement.bases
                                 if hasattr(base, 'id')]
                     # Looking for a 'class FooTest(Test):'
                     if test_import_name in base_ids:
                         info = self._get_methods_info(statement.body,
                                                       cl_tags)
-                        result[statement.name] = info
-                        continue
-
-                # Looking for a 'class FooTest(avocado.Test):'
-                if mod_import:
+                # If not decided check whether it's inherited from avocado.Test
+                if info is None and mod_import:
                     for base in statement.bases:
                         module = base.value.id
                         klass = base.attr
                         if module == mod_import_name and klass == 'Test':
                             info = self._get_methods_info(statement.body,
                                                           cl_tags)
-                            result[statement.name] = info
+                # It's not Avocado test
+                if info is None:
+                    continue
+
+                # Add the class defined by "info"
+                result[statement.name] = info
+
+                # Getting the list of parents of the current class
+                parents = statement.bases
+
+                # Searching the parents in the same module
+                for parent in parents[:]:
+                    # Looking for a 'class FooTest(module.Parent)'
+                    if isinstance(parent, ast.Attribute):
+                        parent_class = parent.attr
+                    # Looking for a 'class FooTest(Parent)'
+                    else:
+                        parent_class = parent.id
+                    res, dis = self._find_avocado_tests(path, parent_class)
+                    if res:
+                        parents.remove(parent)
+                        for cls in res:
+                            info.extend(res[cls])
+                        disabled.update(dis)
+
+                # If there are parents left to be discovered, they
+                # might be in a different module.
+                for parent in parents:
+                    if isinstance(parent, ast.Attribute):
+                        # Looking for a 'class FooTest(module.Parent)'
+                        parent_module = parent.value.id
+                        parent_class = parent.attr
+                    else:
+                        # Looking for a 'class FooTest(Parent)'
+                        parent_module = None
+                        parent_class = parent.id
+
+                    for node in mod.body:
+                        reference = None
+                        # Looking for 'from parent import class'
+                        if isinstance(node, ast.ImportFrom):
+                            reference = parent_class
+                        # Looking for 'import parent'
+                        elif isinstance(node, ast.Import):
+                            reference = parent_module
+
+                        if reference is None:
                             continue
+
+                        for artifact in node.names:
+                            # Looking for a class alias
+                            # ('from parent import class as alias')
+                            if artifact.asname is not None:
+                                parent_class = reference = artifact.name
+                            # If the parent class or the parent module
+                            # is found in the imports, discover the
+                            # parent module path and find the parent
+                            # class there
+                            if artifact.name == reference:
+                                modules_paths = [os.path.dirname(path)]
+                                modules_paths.extend(sys.path)
+                                if parent_module is None:
+                                    parent_module = node.module
+                                try:
+                                    _, ppath, _ = imp.find_module(parent_module,
+                                                                  modules_paths)
+                                except ImportError:
+                                    # Unable to inspect this module
+                                    continue
+                                res, dis = self._find_avocado_tests(ppath,
+                                                                    parent_class)
+                                if res:
+                                    for cls in res:
+                                        info.extend(res[cls])
+                                    disabled.update(dis)
 
         return result, disabled
 


### PR DESCRIPTION
For a while we have the ":avocado: recursive" tag, which allows
recursive discovery of tests and should limit the need for ":avocado:
enable".

This is a simple version, which only changes the default and acts as if
every class was given the ":avocado: recursive" tag but we might want to
tweak the behavior of disable/enable/recursive in the near future to
improve the user experience.

**This is not meant for merging as I found many issues with "recursive" which I am working on right now. Only yesterday I spent the morning with CI slowing down my progress.**