### PR TITLE
Asset fetcher: allow assets with same file names to be fetched and cached [v2]

### DIFF
--- a/avocado/core/app.py
+++ b/avocado/core/app.py
@@ -63,13 +63,13 @@ class AvocadoApp(object):
             self.parser.finish()
             if self.cli_dispatcher.extensions:
                 self.cli_dispatcher.map_method('run', self.parser.args)
-        except SystemExit as e:
+        except SystemExit as detail:
             # If someone tries to exit Avocado, we should first close the
             # STD_OUTPUT and only then exit.
             setattr(self.parser.args, 'paginator', 'off')
             output.reconfigure(self.parser.args)
             STD_OUTPUT.close()
-            sys.exit(e.code)
+            sys.exit(detail.code)
         except:
             # For any other exception we also need to close the STD_OUTPUT.
             setattr(self.parser.args, 'paginator', 'off')

--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -199,6 +199,18 @@ def create_job_logs_dir(base_dir=None, unique_id=None):
                   % (logdir))
 
 
+def get_cache_dirs():
+    """
+    Returns the list of cache dirs, according to configuration and convention
+    """
+    cache_dirs = settings.settings.get_value('datadir.paths', 'cache_dirs',
+                                             key_type=list, default=[])
+    datadir_cache = os.path.join(get_data_dir(), 'cache')
+    if datadir_cache not in cache_dirs:
+        cache_dirs.append(datadir_cache)
+    return cache_dirs
+
+
 class _TmpDirTracker(Borg):
 
     def __init__(self):

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -299,8 +299,8 @@ class StdOutput(object):
         # indiscriminately.  By handling them here, we can be sure
         # that the failure was due to stdout or stderr not being
         # connected to an open PIPE.
-        except IOError as e:
-            if not e.errno == errno.EPIPE:
+        except IOError as detail:
+            if not detail.errno == errno.EPIPE:
                 raise
 
     def fake_outputs(self):

--- a/avocado/core/restclient/cli/actions/server.py
+++ b/avocado/core/restclient/cli/actions/server.py
@@ -27,8 +27,8 @@ def list_brief(app):
     """
     try:
         data = app.connection.get_api_list()
-    except connection.UnexpectedHttpStatusCode as e:
-        if e.received == 403:
+    except connection.UnexpectedHttpStatusCode as detail:
+        if detail.received == 403:
             LOG_UI.error("Error: Access Forbidden")
             return False
 

--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -240,8 +240,8 @@ class JournalctlWatcher(Collectible):
             result = process.system_output(cmd, verbose=False)
             last_record = json.loads(astring.to_text(result, "utf-8"))
             return last_record['__CURSOR']
-        except Exception as e:
-            log.debug("Journalctl collection failed: %s", e)
+        except Exception as detail:
+            log.debug("Journalctl collection failed: %s", detail)
 
     def run(self, logdir):
         if self.cursor:
@@ -254,8 +254,8 @@ class JournalctlWatcher(Collectible):
             except IOError:
                 log.debug("Not logging journalctl (lack of permissions): %s",
                           dstpath)
-            except Exception as e:
-                log.debug("Journalctl collection failed: %s", e)
+            except Exception as detail:
+                log.debug("Journalctl collection failed: %s", detail)
 
 
 class LogWatcher(Collectible):
@@ -336,12 +336,12 @@ class LogWatcher(Collectible):
                         if not in_data:
                             break
                         out_messages.write(in_data)
-        except ValueError as e:
-            log.info(e)
+        except ValueError as detail:
+            log.info(detail)
         except (IOError, OSError):
             log.debug("Not logging %s (lack of permissions)", self.path)
-        except Exception as e:
-            log.error("Log file %s collection failed: %s", self.path, e)
+        except Exception as detail:
+            log.error("Log file %s collection failed: %s", self.path, detail)
 
 
 class SysInfo(object):

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -1073,7 +1073,7 @@ class Test(unittest.TestCase, TestData):
         """
         raise exceptions.TestCancel(message)
 
-    def fetch_asset(self, name, asset_hash=None, algorithm='sha1',
+    def fetch_asset(self, name, asset_hash=None, algorithm=None,
                     locations=None, expire=None):
         """
         Method o call the utils.asset in order to fetch and asset file
@@ -1081,7 +1081,8 @@ class Test(unittest.TestCase, TestData):
 
         :param name: the asset filename or URL
         :param asset_hash: asset hash (optional)
-        :param algorithm: hash algorithm (optional, defaults to sha1)
+        :param algorithm: hash algorithm (optional, defaults to
+                          :data:`avocado.utils.asset.DEFAULT_HASH_ALGORITHM`)
         :param locations: list of URLs from where the asset can be
                           fetched (optional)
         :param expire: time for the asset to expire

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -567,12 +567,7 @@ class Test(unittest.TestCase, TestData):
         Returns a list of cache directories as set in config file.
         """
         if self.__cache_dirs is None:
-            cache_dirs = settings.get_value('datadir.paths', 'cache_dirs',
-                                            key_type=list, default=[])
-            datadir_cache = os.path.join(data_dir.get_data_dir(), 'cache')
-            if datadir_cache not in cache_dirs:
-                cache_dirs.append(datadir_cache)
-            self.__cache_dirs = cache_dirs
+            self.__cache_dirs = data_dir.get_cache_dirs()
         return self.__cache_dirs
 
     @property

--- a/avocado/plugins/config.py
+++ b/avocado/plugins/config.py
@@ -70,3 +70,4 @@ class Config(CLICmd):
             LOG_UI.debug('    tests    ' + data_dir.get_test_dir())
             LOG_UI.debug('    data     ' + data_dir.get_data_dir())
             LOG_UI.debug('    logs     ' + data_dir.get_logs_dir())
+            LOG_UI.debug('    cache    ' + ", ".join(data_dir.get_cache_dirs()))

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -204,8 +204,8 @@ class Run(CLICmd):
                 sys.exit(exit_codes.AVOCADO_FAIL)
         try:
             args.job_timeout = time_to_seconds(args.job_timeout)
-        except ValueError as e:
-            LOG_UI.error(e.args[0])
+        except ValueError as detail:
+            LOG_UI.error(detail.args[0])
             sys.exit(exit_codes.AVOCADO_FAIL)
         with job.Job(args) as job_instance:
             pre_post_dispatcher = JobPrePostDispatcher()

--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -40,6 +40,10 @@ from .filelock import FileLock
 log = logging.getLogger('avocado.test')
 
 
+#: The default hash algorithm to use on asset cache operations
+DEFAULT_HASH_ALGORITHM = 'sha1'
+
+
 class UnsupportedProtocolError(EnvironmentError):
     """
     Signals that the protocol of the asset URL is not supported
@@ -66,7 +70,7 @@ class Asset(object):
         self.name = name
         self.asset_hash = asset_hash
         if algorithm is None:
-            self.algorithm = 'sha1'
+            self.algorithm = DEFAULT_HASH_ALGORITHM
         else:
             self.algorithm = algorithm
         self.locations = locations

--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -192,8 +192,8 @@ class Asset(object):
         if not os.path.isfile(self.hashfile):
             self._compute_hash()
 
-        with open(self.hashfile, 'r') as asset_file:
-            for line in asset_file:
+        with open(self.hashfile, 'r') as hash_file:
+            for line in hash_file:
                 # md5 is 32 chars big and sha512 is 128 chars big.
                 # others supported algorithms are between those.
                 pattern = '%s [a-f0-9]{32,128}' % self.algorithm

--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -246,8 +246,8 @@ class Asset(object):
                     os.symlink(path, self.asset_file)
                     self._compute_hash()
                     return self._verify()
-                except OSError as e:
-                    if e.errno == errno.EEXIST:
+                except OSError as detail:
+                    if detail.errno == errno.EEXIST:
                         os.remove(self.asset_file)
                         os.symlink(path, self.asset_file)
                         self._compute_hash()

--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -84,7 +84,7 @@ class Asset(object):
         if self.nameobj.scheme:
             urls.append(self.nameobj.geturl())
 
-        # First let's find for the file in all cache locations
+        # First let's search for the file in each one of the cache locations
         for cache_dir in self.cache_dirs:
             cache_dir = os.path.expanduser(cache_dir)
             self.asset_file = os.path.join(cache_dir, self.basename)

--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -17,20 +17,22 @@ Asset fetcher from multiple locations
 """
 
 import errno
+import hashlib
 import logging
 import os
 import re
 import shutil
 import stat
 import sys
-import time
 import tempfile
+import time
 
 try:
     import urlparse
 except ImportError:
     import urllib.parse as urlparse
 
+from . import astring
 from . import crypto
 from . import path as utils_path
 from .download import url_download
@@ -79,6 +81,22 @@ class Asset(object):
         self.basename = os.path.basename(self.nameobj.path)
         self.expire = expire
 
+        #: This is a directory that lives on a cache directory, that will
+        #: contain the cached files.  Its name is based on the hash of
+        #: the base URL when no asset hash is given, and is an empty string
+        #: (so no extra directory above the cache directory) when an asset
+        #: hash is given.
+        self.cache_relative_dir = None
+        if self.asset_hash is None:
+            base_url = "%s://%s/%s" % (self.nameobj.scheme,
+                                       self.nameobj.netloc,
+                                       os.path.dirname(self.nameobj.path))
+            base_url_hash = hashlib.new(DEFAULT_HASH_ALGORITHM,
+                                        base_url.encode(astring.ENCODING))
+            self.cache_relative_dir = base_url_hash.hexdigest()
+        else:
+            self.cache_relative_dir = ''
+
     def _get_writable_cache_dir(self):
         """
         Returns the first available writable cache directory
@@ -119,7 +137,8 @@ class Asset(object):
         # First let's search for the file in each one of the cache locations
         for cache_dir in self.cache_dirs:
             cache_dir = os.path.expanduser(cache_dir)
-            self.asset_file = os.path.join(cache_dir, self.basename)
+            self.asset_file = os.path.join(cache_dir, self.cache_relative_dir,
+                                           self.basename)
             self.hashfile = '%s-CHECKSUM' % self.asset_file
 
             # To use a cached file, it must:
@@ -140,7 +159,8 @@ class Asset(object):
         # A writable cache directory is then needed. The first available
         # writable cache directory will be used.
         cache_dir = self._get_writable_cache_dir()
-        self.asset_file = os.path.join(cache_dir, self.basename)
+        self.asset_file = os.path.join(cache_dir, self.cache_relative_dir,
+                                       self.basename)
         self.hashfile = '%s-CHECKSUM' % self.asset_file
 
         # Now we have a writable cache_dir. Let's get the asset.
@@ -158,6 +178,10 @@ class Asset(object):
             else:
                 raise UnsupportedProtocolError("Unsupported protocol"
                                                ": %s" % urlobj.scheme)
+
+            dirname = os.path.dirname(self.asset_file)
+            if not os.path.isdir(dirname):
+                os.mkdir(dirname)
             try:
                 if fetch(urlobj):
                     return self.asset_file

--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -40,6 +40,12 @@ from .filelock import FileLock
 log = logging.getLogger('avocado.test')
 
 
+class UnsupportedProtocolError(EnvironmentError):
+    """
+    Signals that the protocol of the asset URL is not supported
+    """
+
+
 class Asset(object):
     """
     Try to fetch/verify an asset file from multiple locations.
@@ -145,6 +151,9 @@ class Asset(object):
                 fetch = self._download
             elif urlobj.scheme == 'file':
                 fetch = self._get_local_file
+            else:
+                raise UnsupportedProtocolError("Unsupported protocol"
+                                               ": %s" % urlobj.scheme)
             try:
                 if fetch(urlobj):
                     return self.asset_file

--- a/avocado/utils/crypto.py
+++ b/avocado/utils/crypto.py
@@ -17,23 +17,6 @@ import logging
 import hashlib
 
 
-def hash_wrapper(algorithm='md5', data=None):
-    """
-    Returns an hash object of data using either md5 or sha1 only.
-
-    :param input: Optional input string that will be used to update the hash.
-    :returns: Hash object.
-    """
-    if algorithm not in ['md5', 'sha1']:
-        raise ValueError("Unsupported hash algorithm: %s" % algorithm)
-
-    hash_obj = hashlib.new(algorithm)
-    if data:
-        hash_obj.update(data)
-
-    return hash_obj
-
-
 def hash_file(filename, size=None, algorithm="md5"):
     """
     Calculate the hash value of filename.
@@ -45,8 +28,7 @@ def hash_file(filename, size=None, algorithm="md5"):
         dd if=filename bs=1024 count=size/1024 | sha1sum -
 
     :param filename: Path of the file that will have its hash calculated.
-    :param algorithm: Method used to calculate the hash. Supported methods are
-                      md5 (default) or sha1
+    :param algorithm: Method used to calculate the hash (default is md5).
     :param size: If provided, hash only the first size bytes of the file.
     :return: Hash of the file, if something goes wrong, return None.
     """
@@ -57,9 +39,10 @@ def hash_file(filename, size=None, algorithm="md5"):
         size = fsize
 
     try:
-        hash_obj = hash_wrapper(algorithm=algorithm)
-    except ValueError:
-        logging.error("Unknown hash algorithm %s, returning None", algorithm)
+        hash_obj = hashlib.new(algorithm)
+    except ValueError as e:
+        logging.error('Returning "None" due to inability to create hash '
+                      'object: "%s"', e)
         return None
 
     with open(filename, 'rb') as file_to_hash:

--- a/avocado/utils/crypto.py
+++ b/avocado/utils/crypto.py
@@ -40,9 +40,9 @@ def hash_file(filename, size=None, algorithm="md5"):
 
     try:
         hash_obj = hashlib.new(algorithm)
-    except ValueError as e:
+    except ValueError as detail:
         logging.error('Returning "None" due to inability to create hash '
-                      'object: "%s"', e)
+                      'object: "%s"', detail)
         return None
 
     with open(filename, 'rb') as file_to_hash:

--- a/avocado/utils/crypto.py
+++ b/avocado/utils/crypto.py
@@ -45,9 +45,8 @@ def hash_file(filename, size=None, algorithm="md5"):
         dd if=filename bs=1024 count=size/1024 | sha1sum -
 
     :param filename: Path of the file that will have its hash calculated.
-    :param method: Method used to calculate the hash. Supported methods:
-                   * md5
-                   * sha1
+    :param algorithm: Method used to calculate the hash. Supported methods are
+                      md5 (default) or sha1
     :param size: If provided, hash only the first size bytes of the file.
     :return: Hash of the file, if something goes wrong, return None.
     """

--- a/avocado/utils/filelock.py
+++ b/avocado/utils/filelock.py
@@ -62,8 +62,8 @@ class FileLock(object):
                     with open(self.filename, 'r') as f:
                         try:
                             content = f.read()
-                        except Exception as e:
-                            raise LockFailed(e.message)
+                        except Exception as detail:
+                            raise LockFailed(detail.message)
 
                     # If file is empty, I guess someone created it with 'touch'
                     # to manually lock the file.

--- a/selftests/cyclical_deps
+++ b/selftests/cyclical_deps
@@ -48,8 +48,8 @@ def has_snakefood():
         try:
             cmd = ['sfood', '-h']
             subprocess.call(cmd, stdout=null)
-        except Exception as e:
-            print("Could not find sfood utility: %s: %s" % (cmd, e), file=sys.stderr)
+        except Exception as detail:
+            print("Could not find sfood utility: %s: %s" % (cmd, detail), file=sys.stderr)
             print("Did you forget to 'pip install snakefood'?", file=sys.stderr)
             return False
     return True

--- a/selftests/unit/test_utils_asset.py
+++ b/selftests/unit/test_utils_asset.py
@@ -97,6 +97,11 @@ class TestAsset(unittest.TestCase):
                             expire=None)
             self.assertRaises(EnvironmentError, a.fetch)
 
+    def test_unknown_scheme(self):
+        invalid = asset.Asset("weird-protocol://location/?params=foo",
+                              None, None, None, [self.cache_dir], None)
+        self.assertRaises(asset.UnsupportedProtocolError, invalid.fetch)
+
     def tearDown(self):
         shutil.rmtree(self.basedir)
 

--- a/selftests/unit/test_utils_asset.py
+++ b/selftests/unit/test_utils_asset.py
@@ -102,6 +102,32 @@ class TestAsset(unittest.TestCase):
                               None, None, None, [self.cache_dir], None)
         self.assertRaises(asset.UnsupportedProtocolError, invalid.fetch)
 
+    def test_fetch_two_files_same_name_no_hash(self):
+        """
+        Checks that when two different assets which happen to have
+        the same *filename*, are properly stored in the cache
+        directory and that the right one will be given to the user,
+        no matter if a hash is used or not.
+        """
+        second_assetname = self.assetname
+        second_asset_origin_dir = tempfile.mkdtemp(dir=self.basedir)
+        second_asset_local_path = os.path.join(second_asset_origin_dir,
+                                               second_assetname)
+        second_asset_content = 'This is not your first asset content!'
+        with open(second_asset_local_path, 'w') as f:
+            f.write(second_asset_content)
+        second_asset_origin_url = 'file://%s' % second_asset_local_path
+
+        a1 = asset.Asset(self.url, self.assethash, 'sha1', None,
+                         [self.cache_dir], None)
+        a1.fetch()
+        a2 = asset.Asset(second_asset_origin_url, None, None,
+                         [second_asset_origin_dir], [self.cache_dir],
+                         None)
+        a2_path = a2.fetch()
+        with open(a2_path, 'r') as a2_file:
+            self.assertEqual(a2_file.read(), second_asset_content)
+
     def tearDown(self):
         shutil.rmtree(self.basedir)
 

--- a/selftests/unit/test_utils_asset.py
+++ b/selftests/unit/test_utils_asset.py
@@ -40,7 +40,7 @@ class TestAsset(unittest.TestCase):
         expected_tarball = os.path.join(self.cache_dir, self.assetname)
         self.assertEqual(foo_tarball, expected_tarball)
 
-    def test_fecth_expire(self):
+    def test_fetch_expire(self):
         foo_tarball = asset.Asset(self.assetname,
                                   asset_hash=self.assethash,
                                   algorithm='sha1',


### PR DESCRIPTION
The current implementation fails to cache multiple files if their name is the same.  The filename *only* will be considered when looking at the cached directories, and if hashes are not given, users will end up with the wrong files, even when they give unique URLs to different files.

Other than fixing this issue, there are a number of refactors and fixes on related code.

---

Changes from v1 (#2646):
 * Kept same default hash algorithm (sha1)
 * Fixed docstring on `hash_file()`, mentioning the default hash algorithm
 * Fixed `except Exception as e:` (invalid-name) pattern (new commit)
 * Renamed `UnsupportProtocolError` to `UnsupportedProtocolError`