### PR TITLE
Process encoding cherry-pick

### DIFF
--- a/avocado/utils/astring.py
+++ b/avocado/utils/astring.py
@@ -320,7 +320,7 @@ def is_text(data):
     return isinstance(data, str)
 
 
-def to_text(data, encoding=ENCODING):
+def to_text(data, encoding=ENCODING, errors='strict'):
     """
     Convert anything to text decoded text
 
@@ -329,15 +329,17 @@ def to_text(data, encoding=ENCODING):
     it's returned unchanged.
 
     :param data: data to be transformed into text
-    :param encoding: encoding of the data (only used when decoding
-                     is necessary)
     :type data: either bytes or other data that will be returned
                 unchanged
+    :param encoding: encoding of the data (only used when decoding
+                     is necessary)
+    :param errors: how to handle encode/decode errors, see:
+            https://docs.python.org/3/library/codecs.html#error-handlers
     """
     if is_bytes(data):
         if encoding is None:
             encoding = ENCODING
-        return data.decode(encoding)
+        return data.decode(encoding, errors=errors)
     elif not isinstance(data, string_types):
         if sys.version_info[0] < 3:
             return unicode(data)    # pylint: disable=E0602

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -274,8 +274,8 @@ class CmdResult(object):
     :param pid: ID of the process
     :type pid: int
     :param encoding: the encoding to use for the text version
-                     of stdout and stderr, with the default being
-                     Python's own (:func:`sys.getdefaultencoding`).
+                     of stdout and stderr, by default
+                     :data:`avocado.utils.astring.ENCODING`
     :type encoding: str
     """
 
@@ -292,7 +292,7 @@ class CmdResult(object):
         self.interrupted = False
         self.pid = pid
         if encoding is None:
-            encoding = sys.getdefaultencoding()
+            encoding = astring.ENCODING
         self.encoding = encoding
 
     @property
@@ -473,14 +473,13 @@ class SubProcess(object):
                     main thread finishes and also it allows those daemons
                     to be running after the process finishes.
         :param encoding: the encoding to use for the text representation
-                         of the command result stdout and stderr, with the
-                         default being Python's own, that is,
-                         (:func:`sys.getdefaultencoding`).
+                         of the command result stdout and stderr, by default
+                         :mod:`avocado.utils.astring.ENCODING`
         :type encoding: str
         :raises: ValueError if incorrect values are given to parameters
         """
         if encoding is None:
-            encoding = sys.getdefaultencoding()
+            encoding = astring.ENCODING
         if sudo:
             self.cmd = self._prepend_sudo(cmd, shell)
         else:
@@ -862,9 +861,13 @@ class GDBSubProcess(object):
         :param ignore_bg_processes: This param will be ignored in this
                      implementation, since the GDB wrapping code does not have
                      support to run commands in that way.
+        :param encoding: the encoding to use for the text representation
+                         of the command result stdout and stderr, by default
+                         :mod:`avocado.utils.astring.ENCODING`
+        :type encoding: str
         """
         if encoding is None:
-            encoding = sys.getdefaultencoding()
+            encoding = astring.ENCODING
         self.cmd = cmd
 
         self.args = cmd_split(cmd)
@@ -1254,16 +1257,15 @@ def run(cmd, timeout=None, verbose=True, ignore_status=False,
                  prompted. If that's not the case, the command will
                  straight out fail.
     :param encoding: the encoding to use for the text representation
-                     of the command result stdout and stderr, with the
-                     default being Python's own, that is,
-                     (:func:`sys.getdefaultencoding`).
+                     of the command result stdout and stderr, by default
+                     :mod:`avocado.utils.astring.ENCODING`
     :type encoding: str
 
     :return: An :class:`CmdResult` object.
     :raise: :class:`CmdError`, if ``ignore_status=False``.
     """
     if encoding is None:
-        encoding = sys.getdefaultencoding()
+        encoding = astring.ENCODING
     klass = get_sub_process_klass(cmd)
     sp = klass(cmd=cmd, verbose=verbose,
                allow_output_check=allow_output_check, shell=shell, env=env,
@@ -1324,9 +1326,8 @@ def system(cmd, timeout=None, verbose=True, ignore_status=False,
                  prompted. If that's not the case, the command will
                  straight out fail.
     :param encoding: the encoding to use for the text representation
-                     of the command result stdout and stderr, with the
-                     default being Python's own, that is,
-                     (:func:`sys.getdefaultencoding`).
+                     of the command result stdout and stderr, by default
+                     :mod:`avocado.utils.astring.ENCODING`
     :type encoding: str
 
     :return: Exit code.
@@ -1392,9 +1393,8 @@ def system_output(cmd, timeout=None, verbose=True, ignore_status=False,
     :param strip_trail_nl: Whether to strip the trailing newline
     :type strip_trail_nl: bool
     :param encoding: the encoding to use for the text representation
-                     of the command result stdout and stderr, with the
-                     default being Python's own, that is,
-                     (:func:`sys.getdefaultencoding`).
+                     of the command result stdout and stderr, by default
+                     :mod:`avocado.utils.astring.ENCODING`
     :type encoding: str
 
     :return: Command output.

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -380,7 +380,8 @@ class FDDrainer(object):
                 bfr += tmp
                 if tmp.endswith(b'\n'):
                     for line in bfr.splitlines():
-                        line = astring.to_text(line, self._result.encoding)
+                        line = astring.to_text(line, self._result.encoding,
+                                               'replace')
                         if self._logger is not None:
                             self._logger.debug(self._logger_prefix, line)
                         if self._stream_logger is not None:
@@ -389,11 +390,11 @@ class FDDrainer(object):
         # Write the rest of the bfr unfinished by \n
         if self._verbose and bfr:
             for line in bfr.splitlines():
-                line = astring.to_text(line, self._result.encoding)
+                line = astring.to_text(line, self._result.encoding, 'replace')
                 if self._logger is not None:
                     self._logger.debug(self._logger_prefix, line)
                 if self._stream_logger is not None:
-                    self._stream_logger.debug(astring.to_text(line))
+                    self._stream_logger.debug(line)
 
     def start(self):
         self._thread = threading.Thread(target=self._drainer, name=self.name)

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -842,25 +842,12 @@ class GDBSubProcess(object):
 
         :param cmd: Command line to run.
         :type cmd: str
-        :param verbose: Whether to log the command run and stdout/stderr.
-                        Currently unused and provided for compatibility only.
-        :type verbose: bool
-        :param allow_output_check: Whether to log the command stream outputs
-                                   (stdout and stderr) in the test stream
-                                   files. Valid values: 'stdout', for
-                                   allowing only standard output, 'stderr',
-                                   to allow only standard error, 'all',
-                                   to allow both standard output and error
-                                   (default), and 'none', to allow
-                                   none to be recorded. Currently unused and
-                                   provided for compatibility only.
-        :type allow_output_check: str
-        :param sudo: This param will be ignored in this implementation,
-                     since the GDB wrapping code does not have support to run
-                     commands under sudo just yet.
-        :param ignore_bg_processes: This param will be ignored in this
-                     implementation, since the GDB wrapping code does not have
-                     support to run commands in that way.
+        :params verbose: Currently ignored in GDBSubProcess
+        :param allow_output_check: Currently ignored in GDBSubProcess
+        :param shell: Currently ignored in GDBSubProcess
+        :param env: Currently ignored in GDBSubProcess
+        :param sudo: Currently ignored in GDBSubProcess
+        :param ignore_bg_processes: Currently ignored in GDBSubProcess
         :param encoding: the encoding to use for the text representation
                          of the command result stdout and stderr, by default
                          :mod:`avocado.utils.astring.ENCODING`

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -918,6 +918,12 @@ unified diff was logged. The unified diffs are also present in the files
 	-Hello, Avocado!
 	+Hello, world!
 
+
+.. note:: Currently the `stdout` and `stderr` is being stored in `text` mode,
+          using `replace` in case of incorect characters (usually binary
+          data).
+
+
 Test log, stdout and stderr in native Avocado modules
 =====================================================
 


### PR DESCRIPTION
This is a cherry-pick of https://github.com/avocado-framework/avocado/pull/2650 with only the non-controversial commits.

Changes:
```yaml
v1: Removed the controversial "Support for non-default encoding"
v1: Added note to documentation about "replace" in stdout checker
v1: Use "replace" for the remaining chars without \n as well (forgot in the original series)
v1: Added selftest for "replace" ignoring chars
```