### PR TITLE
Provide diagnostic information with assertion failure in in test_broken_pipe()

### DIFF
--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -631,7 +631,8 @@ class OutputPluginTest(unittest.TestCase):
         self.assertEqual(result.exit_status, expected_rc,
                          ("avocado run to broken pipe did not return "
                           "rc %d:\n%s" % (expected_rc, result)))
-        self.assertEqual(len(result.stderr.splitlines()), 1)
+        self.assertEqual(len(result.stderr.splitlines()), 1,
+                         "stderr line count is not 1:\n%s" % result.stderr)
         self.assertIn(b"whacky-unknown-command", result.stderr)
         self.assertIn(b"not found", result.stderr)
         self.assertNotIn(b"Avocado crashed", result.stderr)


### PR DESCRIPTION
Numerous times in the past several weeks I have diagnosed mysterious selftest failures from test_broken_pipe() such as the following:

    FAIL: test_broken_pipe (selftests.functional.test_output.OutputPluginTest)
    ----------------------------------------------------------------------
    Traceback (most recent call last):
    File "/builddir/build/BUILD/avocado-85175f00b61257964ec1542dfb5470a80809b05c/selftests/functional/test_output.py", line 634, in test_broken_pipe
    self.assertEqual(len(result.stderr.splitlines()), 1)
    AssertionError: 3 != 1
    ----------------------------------------------------------------------

This small patch makes that assertion failure less mysterious by reporting useful information about what actually went wrong!