### PR TITLE
Better handling of PCI bridges in pci utils

### DIFF
--- a/avocado/utils/pci.py
+++ b/avocado/utils/pci.py
@@ -52,7 +52,7 @@ def get_pci_addresses():
     addresses = []
     cmd = "lspci -D"
     for line in process.system_output(cmd).splitlines():
-        if "PCI bridge" not in line and "System peripheral" not in line:
+        if not get_pci_prop(line.split()[0], 'Class').startswith('06'):
             addresses.append(line.split()[0])
     if addresses:
         return addresses


### PR DESCRIPTION
PCI Bridges can be represented in lspci output in different ways.
But they are all of Class 06.
So, handling using class id instead, which is a better way.

Changes from V1 (https://github.com/avocado-framework/avocado/pull/2380/commits/e80c4478c07e0292daf65c74dfe8dd3e7b4b423) : used `startswith()` as per suggestion from @apahim 

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>