### PR TITLE
Remove the deprecated Test.srcdir and Test.datadir attributes [v2]

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -402,8 +402,7 @@ class Test(unittest.TestCase, TestData):
             base_tmpdir = tempfile.mkdtemp(prefix="tmp_dir", dir=self.logdir)
         self.__workdir = os.path.join(base_tmpdir,
                                       self.name.str_filesystem)
-        self.__srcdir_warning_logged = False
-        self.__srcdir = utils_path.init_dir(self.__workdir, 'src')
+        utils_path.init_dir(self.__workdir)
 
         self.log.debug("Test metadata:")
         if self.filename:
@@ -546,20 +545,6 @@ class Test(unittest.TestCase, TestData):
         building software, etc.
         """
         return self.__workdir
-
-    @property
-    def srcdir(self):
-        """
-        This property is deprecated and will be removed in the future.
-        The :meth:`workdir` property should be used instead.
-        """
-        if not self.__srcdir_warning_logged:
-            LOG_JOB.warn("DEPRECATION NOTICE: the test's \"srcdir\" property "
-                         "is deprecated and is planned to be removed no later "
-                         "than May 11 2018. Please use the \"workdir\" "
-                         "property instead.")
-            self.__srcdir_warning_logged = True
-        return self.__srcdir
 
     @property
     def cache_dirs(self):
@@ -977,7 +962,6 @@ class Test(unittest.TestCase, TestData):
         os.environ['AVOCADO_TEST_OUTPUTDIR'] = self.outputdir
         if self.__sysinfo_enabled:
             os.environ['AVOCADO_TEST_SYSINFODIR'] = self.__sysinfodir
-        os.environ['AVOCADO_TEST_SRCDIR'] = self.__srcdir
 
     def run_avocado(self):
         """

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -1691,11 +1691,11 @@ tests:
 +-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
 | `***`                       | All variables from --mux-yaml         | TIMEOUT=60; IO_WORKERS=10; VM_BYTES=512M; ...                                                       |
 +-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
-| AVOCADO_TEST_SRCDIR         | Source directory for the test         | /var/tmp/avocado_Bjr_rd/my-test.sh/src                                                              |
-+-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
 
-.. warning:: ``AVOCADO_TEST_SRCDIR`` is deprecated and will be removed
-             soon.  Please use ``AVOCADO_TEST_WORKDIR`` instead.
+.. warning:: ``AVOCADO_TEST_SRCDIR`` was present in earlier versions,
+             but has been deprecated on version 60.0, and removed on
+             version 62.0.  Please use ``AVOCADO_TEST_WORKDIR``
+             instead.
 
 
 SIMPLE Tests BASH extensions

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -227,10 +227,12 @@ you intend to create it.
          for that specific test and execution conditions (such as with or
          without variants).  Look for "Test data directories" in the test logs.
 
-.. note:: An older API, :attr:`avocado.core.test.Test.datadir`, allows access
-          to the data directory based on the test file location only.  This API
-          is limited, deprecated and will be removed.  All new users should rely
-          on ``get_data()`` instead.
+.. note:: The previously existing API ``avocado.core.test.Test.datadir``,
+          used to allow access to the data directory based on the test file
+          location only.  This API has been removed.  If, for whatever reason
+          you still need to access the data directory based on the test file
+          location only, you can use
+          ``get_data(filename='', source='file', must_exist=False)`` instead.
 
 .. _accessing-test-parameters:
 
@@ -1672,8 +1674,6 @@ tests:
 +-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
 | AVOCADO_TEST_BASEDIR        | Base directory of Avocado tests       | $HOME/Downloads/avocado-source/avocado                                                              |
 +-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
-| AVOCADO_TEST_DATADIR        | Data directory for the test           | $AVOCADO_TEST_BASEDIR/my_test.sh.data                                                               |
-+-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
 | AVOCADO_TEST_WORKDIR        | Work directory for the test           | /var/tmp/avocado_Bjr_rd/my_test.sh                                                                  |
 +-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
 | AVOCADO_TESTS_COMMON_TMPDIR | Temporary directory created by the    | /var/tmp/avocado_XhEdo/                                                                             |
@@ -1697,6 +1697,11 @@ tests:
              version 62.0.  Please use ``AVOCADO_TEST_WORKDIR``
              instead.
 
+.. warning:: ``AVOCADO_TEST_DATADIR`` was present in earlier versions,
+             but has been deprecated on version 60.0, and removed on
+             version 62.0.  The test data files (and directories) are
+             now dynamically evaluated and are not available as
+             environment variables
 
 SIMPLE Tests BASH extensions
 ============================

--- a/examples/tests/env_variables.sh
+++ b/examples/tests/env_variables.sh
@@ -5,8 +5,6 @@ echo "Avocado Version: $AVOCADO_VERSION"
 echo "Avocado Test basedir: $AVOCADO_TEST_BASEDIR"
 echo "Avocado Test datadir: $AVOCADO_TEST_DATADIR"
 echo "Avocado Test workdir: $AVOCADO_TEST_WORKDIR"
-# Warning: srcdir is deprecated and will be removed soon
-echo "Avocado Test srcdir: $AVOCADO_TEST_SRCDIR"
 echo "Avocado Test logdir: $AVOCADO_TEST_LOGDIR"
 echo "Avocado Test logfile: $AVOCADO_TEST_LOGFILE"
 echo "Avocado Test outputdir: $AVOCADO_TEST_OUTPUTDIR"
@@ -14,7 +12,6 @@ echo "Custom variable: $CUSTOM_VARIABLE"
 
 test -d "$AVOCADO_TEST_BASEDIR" -a \
      -d "$AVOCADO_TEST_WORKDIR" -a \
-     -d "$AVOCADO_TEST_SRCDIR" -a \
      -d "$AVOCADO_TEST_LOGDIR" -a \
      -f "$AVOCADO_TEST_LOGFILE" -a \
      -d "$AVOCADO_TEST_OUTPUTDIR"

--- a/examples/tests/linuxbuild.py
+++ b/examples/tests/linuxbuild.py
@@ -28,7 +28,7 @@ class LinuxBuildTest(Test):
 
         self.linux_build = kernel.KernelBuild(kernel_version,
                                               linux_config,
-                                              self.srcdir,
+                                              self.workdir,
                                               self.cache_dirs)
         self.linux_build.download(kernel_src_url)
         self.linux_build.uncompress()

--- a/selftests/functional/test_export_variables.py
+++ b/selftests/functional/test_export_variables.py
@@ -19,7 +19,6 @@ echo "Avocado Version: $AVOCADO_VERSION"
 echo "Avocado Test basedir: $AVOCADO_TEST_BASEDIR"
 echo "Avocado Test datadir: $AVOCADO_TEST_DATADIR"
 echo "Avocado Test workdir: $AVOCADO_TEST_WORKDIR"
-echo "Avocado Test srcdir: $AVOCADO_TEST_SRCDIR"
 echo "Avocado Test logdir: $AVOCADO_TEST_LOGDIR"
 echo "Avocado Test logfile: $AVOCADO_TEST_LOGFILE"
 echo "Avocado Test outputdir: $AVOCADO_TEST_OUTPUTDIR"
@@ -28,7 +27,6 @@ echo "Avocado Test sysinfodir: $AVOCADO_TEST_SYSINFODIR"
 test "$AVOCADO_VERSION" = "{version}" -a \
      -d "$AVOCADO_TEST_BASEDIR" -a \
      -d "$AVOCADO_TEST_WORKDIR" -a \
-     -d "$AVOCADO_TEST_SRCDIR" -a \
      -d "$AVOCADO_TEST_LOGDIR" -a \
      -f "$AVOCADO_TEST_LOGFILE" -a \
      -d "$AVOCADO_TEST_OUTPUTDIR" -a \

--- a/selftests/unit/test_test.py
+++ b/selftests/unit/test_test.py
@@ -98,12 +98,12 @@ class TestClassTestUnit(unittest.TestCase):
 
     def test_data_dir(self):
         """
-        Tests that a valid datadir exists following the test filename
+        Checks `get_data()` won't report fs-unfriendly data dir name
         """
         max_length_name = os.path.join(self.tmpdir, "a" * 250)
         tst = self._get_fake_filename_test(max_length_name)
         self.assertEqual(os.path.join(self.tmpdir, max_length_name + ".data"),
-                         tst.datadir)
+                         tst.get_data('', 'file', False))
 
     def test_no_data_dir(self):
         """
@@ -111,7 +111,7 @@ class TestClassTestUnit(unittest.TestCase):
         """
         above_limit_name = os.path.join(self.tmpdir, "a" * 251)
         tst = self._get_fake_filename_test(above_limit_name)
-        self.assertFalse(tst.datadir)
+        self.assertFalse(tst.get_data('', 'file', False))
         tst._record_reference       # Should do nothing
         tst._record_reference('stdout', 'stdout.expected')
         tst._record_reference('stderr', 'stderr.expected')


### PR DESCRIPTION
These have been deprecated for a while, and are now past due their removal, so let's do it now.

---

Changes from v1 (#2653):
 * Changed wording and fixed typo on datadir removal (s/extint/previously existing)
 * Better unittest docstrings