### PR TITLE
Travis CI: add Python 3.6 jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: python
 
-virtualenv:
-  system_site_packages: true
-
 python:
     - "2.7"
     - "3.4"
+    - "3.6"
 
 branches:
     only:
@@ -17,11 +15,6 @@ cache:
         - $HOME/.cache/pip
 
 sudo: false
-
-addons:
-  apt:
-    packages:
-    - libvirt-dev
 
 install:
     - pip install -r requirements-travis.txt


### PR DESCRIPTION
There are subtle differences on some libraries between Python 3.4
and 3.6.  Most modern systems use Python 3.6, such as yours truly's
development environment, so it's quite useful to cache differences
between 3.4 (our mininum 3.x supported version) and more modern
versions.

Signed-off-by: Cleber Rosa <crosa@redhat.com>