### PR TITLE
CPU Utils: support both Python 2 and 3 [v2]

### DIFF
--- a/avocado/utils/astring.py
+++ b/avocado/utils/astring.py
@@ -346,3 +346,23 @@ def to_text(data, encoding=ENCODING, errors='strict'):
         else:
             return str(data)
     return data
+
+
+def to_bytes(data, encoding=ENCODING, errors='strict'):
+    """
+    Converts anything to encoded bytes
+
+    When data is bytes, it's returned. When it's not of string types,
+    it's turned into string and then encoded using encoding. Otherwise
+    it's simply encoded.
+
+    :param data: data to be transformed into bytes
+    :param encoding: encoding of the data (used to encode)
+    :param errors: how to handle encode/decode errors, see:
+            https://docs.python.org/3/library/codecs.html#error-handlers
+    """
+    if is_bytes(data):
+        return data
+    elif not isinstance(data, string_types):
+        data = to_text(data, encoding, errors)
+    return data.encode(encoding, errors)

--- a/avocado/utils/cpu.py
+++ b/avocado/utils/cpu.py
@@ -26,6 +26,8 @@ import platform
 import glob
 import logging
 
+from . import astring
+
 
 def _list_matches(content_list, pattern):
     """
@@ -46,9 +48,9 @@ def _get_cpu_info():
     :rtype: `list`
     """
     cpuinfo = []
-    with open('/proc/cpuinfo') as proc_cpuinfo:
+    with open('/proc/cpuinfo', 'rb') as proc_cpuinfo:
         for line in proc_cpuinfo:
-            if line == '\n':
+            if line == b'\n':
                 break
             cpuinfo.append(line)
     return cpuinfo
@@ -63,8 +65,8 @@ def _get_cpu_status(cpu):
     :returns: `bool` True if online or False if not
     :rtype: 'bool'
     """
-    with open('/sys/devices/system/cpu/cpu%s/online' % cpu) as online:
-        if '1' in online.read():
+    with open('/sys/devices/system/cpu/cpu%s/online' % cpu, 'rb') as online:
+        if b'1' in online.read():
             return True
     return False
 
@@ -116,22 +118,22 @@ def get_cpu_arch():
     """
     Work out which CPU architecture we're running on
     """
-    cpu_table = [('^cpu.*(RS64|POWER3|Broadband Engine)', 'power'),
-                 ('^cpu.*POWER4', 'power4'),
-                 ('^cpu.*POWER5', 'power5'),
-                 ('^cpu.*POWER6', 'power6'),
-                 ('^cpu.*POWER7', 'power7'),
-                 ('^cpu.*POWER8', 'power8'),
-                 ('^cpu.*POWER9', 'power9'),
-                 ('^cpu.*PPC970', 'power970'),
-                 ('(ARM|^CPU implementer|^CPU part|^CPU variant'
-                  '|^Features|^BogoMIPS|^CPU revision)', 'arm'),
-                 ('(^cpu MHz dynamic|^cpu MHz static|^features'
-                  '|^bogomips per cpu|^max thread id)', 's390'),
-                 ('^type', 'sparc64'),
-                 ('^flags.*:.* lm .*', 'x86_64'),
-                 ('^flags', 'i386'),
-                 ('^hart\\s*: 1$', 'riscv')]
+    cpu_table = [(b'^cpu.*(RS64|POWER3|Broadband Engine)', 'power'),
+                 (b'^cpu.*POWER4', 'power4'),
+                 (b'^cpu.*POWER5', 'power5'),
+                 (b'^cpu.*POWER6', 'power6'),
+                 (b'^cpu.*POWER7', 'power7'),
+                 (b'^cpu.*POWER8', 'power8'),
+                 (b'^cpu.*POWER9', 'power9'),
+                 (b'^cpu.*PPC970', 'power970'),
+                 (b'(ARM|^CPU implementer|^CPU part|^CPU variant'
+                  b'|^Features|^BogoMIPS|^CPU revision)', 'arm'),
+                 (b'(^cpu MHz dynamic|^cpu MHz static|^features'
+                  b'|^bogomips per cpu|^max thread id)', 's390'),
+                 (b'^type', 'sparc64'),
+                 (b'^flags.*:.* lm .*', 'x86_64'),
+                 (b'^flags', 'i386'),
+                 (b'^hart\\s*: 1$', 'riscv')]
     cpuinfo = _get_cpu_info()
     for (pattern, arch) in cpu_table:
         if _list_matches(cpuinfo, pattern):
@@ -150,12 +152,12 @@ def cpu_online_list():
     Reports a list of indexes of the online cpus
     """
     cpus = []
-    search_str = 'processor'
+    search_str = b'processor'
     index = 2
     if platform.machine() == 's390x':
-        search_str = 'cpu number'
+        search_str = b'cpu number'
         index = 3
-    with open('/proc/cpuinfo', 'r') as proc_cpuinfo:
+    with open('/proc/cpuinfo', 'rb') as proc_cpuinfo:
         for line in proc_cpuinfo:
             if line.startswith(search_str):
                 cpus.append(int(line.split()[index]))  # grab cpu number
@@ -180,8 +182,8 @@ def online(cpu):
     """
     Online given CPU
     """
-    with open("/sys/devices/system/cpu/cpu%s/online" % cpu, "w") as fd:
-        fd.write('1')
+    with open("/sys/devices/system/cpu/cpu%s/online" % cpu, "wb") as fd:
+        fd.write(b'1')
     if _get_cpu_status(cpu):
         return 0
     return 1
@@ -191,8 +193,8 @@ def offline(cpu):
     """
     Offline given CPU
     """
-    with open("/sys/devices/system/cpu/cpu%s/online" % cpu, "w") as fd:
-        fd.write('0')
+    with open("/sys/devices/system/cpu/cpu%s/online" % cpu, "wb") as fd:
+        fd.write(b'0')
     if _get_cpu_status(cpu):
         return 1
     return 0
@@ -213,7 +215,7 @@ def get_cpuidle_state():
         for state_no in states:
             state_file = "/sys/devices/system/cpu/cpu%s/cpuidle/state%s/disable" % (cpu, state_no)
             try:
-                cpu_idlestate[cpu][state_no] = int(open(state_file).read())
+                cpu_idlestate[cpu][state_no] = int(open(state_file, 'rb').read())
             except IOError as err:
                 logging.warning("Failed to read idle state on cpu %s "
                                 "for state %s:\n%s", cpu, state_no, err)
@@ -239,7 +241,7 @@ def set_cpuidle_state(state_number="all", disable=1, setstate=None):
             for state_no in states:
                 state_file = "/sys/devices/system/cpu/cpu%s/cpuidle/state%s/disable" % (cpu, state_no)
                 try:
-                    open(state_file, "w").write(str(disable))
+                    open(state_file, "wb").write(astring.to_bytes(disable))
                 except IOError as err:
                     logging.warning("Failed to set idle state on cpu %s "
                                     "for state %s:\n%s", cpu, state_no, err)
@@ -248,7 +250,7 @@ def set_cpuidle_state(state_number="all", disable=1, setstate=None):
             for state_no, value in stateval.items():
                 state_file = "/sys/devices/system/cpu/cpu%s/cpuidle/state%s/disable" % (cpu, state_no)
                 try:
-                    open(state_file, "w").write(str(value))
+                    open(state_file, "wb").write(astring.to_bytes(value))
                 except IOError as err:
                     logging.warning("Failed to set idle state on cpu %s "
                                     "for state %s:\n%s", cpu, state_no, err)

--- a/avocado/utils/cpu.py
+++ b/avocado/utils/cpu.py
@@ -27,16 +27,15 @@ import glob
 import logging
 
 
-def _list_matches(lst, pattern):
+def _list_matches(content_list, pattern):
     """
-    True if any item in list matches the specified pattern.
+    Checks if any item in list matches the specified pattern
     """
-    compiled = re.compile(pattern)
-    for element in lst:
-        match = compiled.search(element)
+    for content in content_list:
+        match = re.search(pattern, content)
         if match:
-            return 1
-    return 0
+            return True
+    return False
 
 
 def _get_cpu_info():

--- a/selftests/unit/test_utils_astring.py
+++ b/selftests/unit/test_utils_astring.py
@@ -42,6 +42,15 @@ class AstringUtilsTest(unittest.TestCase):
                          "v2100 v22  v23" + "\n" +
                          "v31   v320 v33")
 
+    def test_to_bytes(self):
+        self.assertEqual(astring.to_bytes(b'\x00\x80\xff'), b'\x00\x80\xff')
+        self.assertEqual(astring.to_bytes(u'avok\xe1do', 'utf-8'),
+                         b'avok\xc3\xa1do')
+        self.assertEqual(astring.to_bytes(b'avok\xe1do', 'ISO-8859-15'),
+                         b'avok\xe1do')
+        data = Exception(b'avok\xc3\xa1do'.decode('utf-8'))
+        self.assertEqual(astring.to_bytes(data, 'utf-8'), b'avok\xc3\xa1do')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/selftests/unit/test_utils_cpu.py
+++ b/selftests/unit/test_utils_cpu.py
@@ -1,6 +1,5 @@
 import io
 import unittest
-import StringIO
 
 try:
     from unittest import mock
@@ -21,14 +20,14 @@ class Cpu(unittest.TestCase):
     @staticmethod
     def _get_file_mock(content):
         file_mock = mock.Mock()
-        file_mock.__enter__ = mock.Mock(return_value=io.StringIO(content))
+        file_mock.__enter__ = mock.Mock(return_value=io.BytesIO(content))
         file_mock.__exit__ = mock.Mock()
         return file_mock
 
     @unittest.skipUnless(recent_mock(),
                          "mock library version cannot (easily) patch open()")
     def test_s390x_cpu_online(self):
-        s390x = u"""vendor_id       : IBM/S390
+        s390x = b"""vendor_id       : IBM/S390
 # processors    : 2
 bogomips per cpu: 2913.00
 max thread id   : 0
@@ -53,7 +52,7 @@ cpu MHz static  : 5504
 
 """
 
-        s390x_2 = u"""vendor_id       : IBM/S390
+        s390x_2 = b"""vendor_id       : IBM/S390
 # processors    : 4
 bogomips per cpu: 2913.00
 max thread id   : 0
@@ -98,7 +97,7 @@ cpu MHz static  : 5504
     @unittest.skipUnless(recent_mock(),
                          "mock library version cannot (easily) patch open()")
     def test_x86_64_cpu_online(self):
-        x86_64 = u"""processor	: 0
+        x86_64 = b"""processor	: 0
 vendor_id	: GenuineIntel
 cpu family	: 6
 model		: 60
@@ -323,7 +322,7 @@ power management:
     @unittest.skipUnless(recent_mock(),
                          "mock library version cannot (easily) patch open()")
     def test_cpu_arch_i386(self):
-        cpu_output = u"""processor       : 0
+        cpu_output = b"""processor       : 0
 vendor_id       : GenuineIntel
 cpu family      : 6
 model           : 13
@@ -360,7 +359,7 @@ power management:
     @unittest.skipUnless(recent_mock(),
                          "mock library version cannot (easily) patch open()")
     def test_cpu_arch_x86_64(self):
-        cpu_output = u"""processor       : 0
+        cpu_output = b"""processor       : 0
 vendor_id       : GenuineIntel
 cpu family      : 6
 model           : 60
@@ -394,7 +393,7 @@ power management:
     @unittest.skipUnless(recent_mock(),
                          "mock library version cannot (easily) patch open()")
     def test_cpu_arch_ppc64_power8(self):
-        cpu_output = u"""processor       : 88
+        cpu_output = b"""processor       : 88
 cpu             : POWER8E (raw), altivec supported
 clock           : 3325.000000MHz
 revision        : 2.1 (pvr 004b 0201)
@@ -412,7 +411,7 @@ firmware        : OPAL v3
     @unittest.skipUnless(recent_mock(),
                          "mock library version cannot (easily) patch open()")
     def test_cpu_arch_ppc64_le_power8(self):
-        cpu_output = u"""processor       : 88
+        cpu_output = b"""processor       : 88
 cpu             : POWER8E (raw), altivec supported
 clock           : 3325.000000MHz
 revision        : 2.1 (pvr 004b 0201)
@@ -430,7 +429,7 @@ firmware        : OPAL v3
     @unittest.skipUnless(recent_mock(),
                          "mock library version cannot (easily) patch open()")
     def test_cpu_arch_ppc64_le_power9(self):
-        cpu_output = u"""processor	: 20
+        cpu_output = b"""processor	: 20
 cpu		: POWER9 (raw), altivec supported
 clock		: 2050.000000MHz
 revision	: 1.0 (pvr 004e 0100)
@@ -448,7 +447,7 @@ firmware	: OPAL
     @unittest.skipUnless(recent_mock(),
                          "mock library version cannot (easily) patch open()")
     def test_cpu_arch_s390(self):
-        cpu_output = u"""vendor_id       : IBM/S390
+        cpu_output = b"""vendor_id       : IBM/S390
 # processors    : 2
 bogomips per cpu: 2913.00
 max thread id   : 0
@@ -478,7 +477,7 @@ cpu MHz static  : 5504
     @unittest.skipUnless(recent_mock(),
                          "mock library version cannot (easily) patch open()")
     def test_cpu_arch_arm_v7(self):
-        cpu_output = u"""Processor       : ARMv7 Processor rev 2 (v7l)
+        cpu_output = b"""Processor       : ARMv7 Processor rev 2 (v7l)
 BogoMIPS        : 994.65
 Features        : swp half thumb fastmult vfp edsp thumbee neon vfpv3
 CPU implementer : 0x41
@@ -498,7 +497,7 @@ Serial          : 3534268a5e0700ec
     @unittest.skipUnless(recent_mock(),
                          "mock library version cannot (easily) patch open()")
     def test_cpu_arch_arm_v8(self):
-        cpu_output = u"""processor       : 0
+        cpu_output = b"""processor       : 0
 BogoMIPS        : 200.00
 Features        : fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid
 CPU implementer : 0x43
@@ -515,7 +514,7 @@ CPU revision    : 1
     @unittest.skipUnless(recent_mock(),
                          "mock library version cannot (easily) patch open()")
     def test_cpu_arch_risc_v(self):
-        cpu_output = u"""hart	: 1
+        cpu_output = b"""hart	: 1
 isa	: rv64imafdc
 mmu	: sv39
 uarch	: sifive,rocket0
@@ -530,7 +529,7 @@ uarch	: sifive,rocket0
         retval = {0: {0: 0}}
         with mock.patch('avocado.utils.cpu.cpu_online_list', return_value=[0]):
             with mock.patch('glob.glob', return_value=['/sys/devices/system/cpu/cpu0/cpuidle/state1']):
-                with mock.patch('avocado.utils.cpu.open', return_value=StringIO.StringIO('0')):
+                with mock.patch('avocado.utils.cpu.open', return_value=io.BytesIO(b'0')):
                     self.assertEqual(cpu.get_cpuidle_state(), retval)
 
     @unittest.skipUnless(recent_mock(),
@@ -539,38 +538,38 @@ uarch	: sifive,rocket0
         retval = {0: {0: 1}}
         with mock.patch('avocado.utils.cpu.cpu_online_list', return_value=[0]):
             with mock.patch('glob.glob', return_value=['/sys/devices/system/cpu/cpu0/cpuidle/state1']):
-                with mock.patch('avocado.utils.cpu.open', return_value=StringIO.StringIO('1')):
+                with mock.patch('avocado.utils.cpu.open', return_value=io.BytesIO(b'1')):
                     self.assertEqual(cpu.get_cpuidle_state(), retval)
 
     @unittest.skipUnless(recent_mock(),
                          "mock library version cannot (easily) patch open()")
     def test_set_cpuidle_state_default(self):
-        output = StringIO.StringIO()
+        output = io.BytesIO()
         with mock.patch('avocado.utils.cpu.cpu_online_list', return_value=[0]):
             with mock.patch('glob.glob', return_value=['/sys/devices/system/cpu/cpu0/cpuidle/state1']):
                 with mock.patch('avocado.utils.cpu.open', return_value=output):
                     cpu.set_cpuidle_state()
-                    self.assertEqual(output.getvalue(), "1")
+                    self.assertEqual(output.getvalue(), b"1")
 
     @unittest.skipUnless(recent_mock(),
                          "mock library version cannot (easily) patch open()")
     def test_set_cpuidle_state_withstateno(self):
-        output = StringIO.StringIO()
+        output = io.BytesIO()
         with mock.patch('avocado.utils.cpu.cpu_online_list', return_value=[0]):
             with mock.patch('glob.glob', return_value=['/sys/devices/system/cpu/cpu0/cpuidle/state2']):
                 with mock.patch('avocado.utils.cpu.open', return_value=output):
                     cpu.set_cpuidle_state(disable='0', state_number='2')
-                    self.assertEqual(output.getvalue(), "0")
+                    self.assertEqual(output.getvalue(), b"0")
 
     @unittest.skipUnless(recent_mock(),
                          "mock library version cannot (easily) patch open()")
     def test_set_cpuidle_state_withsetstate(self):
-        output = StringIO.StringIO()
+        output = io.BytesIO()
         with mock.patch('avocado.utils.cpu.cpu_online_list', return_value=[0, 2]):
             with mock.patch('glob.glob', return_value=['/sys/devices/system/cpu/cpu0/cpuidle/state1']):
                 with mock.patch('avocado.utils.cpu.open', return_value=output):
                     cpu.set_cpuidle_state(setstate={0: {0: 1}, 2: {0: 0}})
-                    self.assertEqual(output.getvalue(), "10")
+                    self.assertEqual(output.getvalue(), b"10")
 
 
 if __name__ == "__main__":

--- a/selftests/unit/test_utils_cpu.py
+++ b/selftests/unit/test_utils_cpu.py
@@ -1,4 +1,5 @@
 import io
+import sys
 import unittest
 
 try:
@@ -11,8 +12,22 @@ from avocado.utils import cpu
 
 
 def recent_mock():
-    major = int(mock.__version__.split('.')[0])
-    return major >= 2
+    '''
+    Checks if a recent and capable enough mock library is available
+
+    On Python 2.7, it requires at least mock version 2.0.  On Python 3,
+    mock from the standard library is used, but Python 3.6 or later is
+    required.
+
+    Also, it assumes that on a future Python major version, functionality
+    won't regress.
+    '''
+    if sys.version_info[0] < 3:
+        major = int(mock.__version__.split('.')[0])
+        return major >= 2
+    elif sys.version_info[0] == 3:
+        return sys.version_info[1] >= 6
+    return True
 
 
 class Cpu(unittest.TestCase):


### PR DESCRIPTION
This PR fixes a number of issues with the CPU utility libraries.  Basically, it moves to using bytes, since it interacts with `/proc/*` and `/sys/*` files which are produced by the Kernel and won't follow any kind of userspace locale/encoding.

v1: https://github.com/avocado-framework/avocado/pull/2664

Changes:

```yaml
v2: Removed commit to use True/False in "cpu" module as the module
    is strongly oriented to /sys and usually allows writing the actual values (1,2,3,...)
v2: Added commit that implements "to_bytes" in "astring"
v2: Use the "to_bytes" in the "CPU utils: handle /proc/* and /sys/* as binary commit to
    properly turn string/int/bytes into bytes.
v2: Rebased
```