### PR TITLE
utils.service: Few style-fixes

### DIFF
--- a/avocado/utils/service.py
+++ b/avocado/utils/service.py
@@ -661,13 +661,13 @@ class _SystemdServiceManager(_GenericServiceManager):
         os.rename(tmp_symlink, "/etc/systemd/system/default.target")
 
 
-_command_generators = {"init": sys_v_init_command_generator,
+_COMMAND_GENERATORS = {"init": sys_v_init_command_generator,
                        "systemd": systemd_command_generator}
 
-_result_parsers = {"init": sys_v_init_result_parser,
+_RESULT_PARSERS = {"init": sys_v_init_result_parser,
                    "systemd": systemd_result_parser}
 
-_service_managers = {"init": _SysVInitServiceManager,
+_SERVICE_MANAGERS = {"init": _SysVInitServiceManager,
                      "systemd": _SystemdServiceManager}
 
 
@@ -696,9 +696,9 @@ def service_manager(run=process.run):
     :rtype: _GenericServiceManager
     """
     init = get_name_of_init(run)
-    internal_service_manager = _service_managers[init]
-    internal_command_generator = _command_generators[init]
-    internal_result_parser = _result_parsers[init]
+    internal_service_manager = _SERVICE_MANAGERS[init]
+    internal_command_generator = _COMMAND_GENERATORS[init]
+    internal_result_parser = _RESULT_PARSERS[init]
 
     internal_generator = _ServiceCommandGenerator(internal_command_generator)
     internal_parser = _ServiceResultParser(internal_result_parser)
@@ -718,7 +718,7 @@ def _auto_create_specific_service_result_parser(run=process.run):
     :return: A ServiceResultParser for the auto-detected init command.
     :rtype: _ServiceResultParser
     """
-    result_parser = _result_parsers[get_name_of_init(run)]
+    result_parser = _RESULT_PARSERS[get_name_of_init(run)]
     # remove list _method
     command_list = [(c, r) for (c, r) in COMMANDS if
                     c not in ["list", "set_target"]]
@@ -738,7 +738,7 @@ def _auto_create_specific_service_command_generator(run=process.run):
     :return: A ServiceCommandGenerator for the auto-detected init command.
     :rtype: _ServiceCommandGenerator
     """
-    command_generator = _command_generators[get_name_of_init(run)]
+    command_generator = _COMMAND_GENERATORS[get_name_of_init(run)]
     # remove list _method
     command_list = [(c, r) for (c, r) in COMMANDS if
                     c not in ["list", "set_target"]]
@@ -765,7 +765,7 @@ def specific_service_manager(service_name, run=process.run):
     :rtype: _SpecificServiceManager
     """
     init = get_name_of_init(run)
-    result_parser = _result_parsers[init]
+    result_parser = _RESULT_PARSERS[init]
     specific_generator = _auto_create_specific_service_command_generator
     return _SpecificServiceManager(service_name,
                                    specific_generator(run),

--- a/selftests/unit/test_utils_service.py
+++ b/selftests/unit/test_utils_service.py
@@ -50,7 +50,7 @@ class TestSystemd(unittest.TestCase):
     def setUp(self):
         self.service_name = "fake_service"
         init_name = "systemd"
-        command_generator = service._command_generators[init_name]
+        command_generator = service._COMMAND_GENERATORS[init_name]
         self.service_command_generator = service._ServiceCommandGenerator(
             command_generator)
 
@@ -84,7 +84,7 @@ class TestSysVInit(unittest.TestCase):
     def setUp(self):
         self.service_name = "fake_service"
         init_name = "init"
-        command_generator = service._command_generators[init_name]
+        command_generator = service._COMMAND_GENERATORS[init_name]
         self.service_command_generator = service._ServiceCommandGenerator(
             command_generator)
 
@@ -162,9 +162,9 @@ class TestServiceManager(unittest.TestCase):
 
     @staticmethod
     def get_service_manager_from_init_and_run(init_name, run_mock):
-        command_generator = service._command_generators[init_name]
-        result_parser = service._result_parsers[init_name]
-        service_manager = service._service_managers[init_name]
+        command_generator = service._COMMAND_GENERATORS[init_name]
+        result_parser = service._RESULT_PARSERS[init_name]
+        service_manager = service._SERVICE_MANAGERS[init_name]
         service_command_generator = service._ServiceCommandGenerator(
             command_generator)
         service_result_parser = service._ServiceResultParser(result_parser)


### PR DESCRIPTION
There are few style-fixes and improved selftests related to `avocado.utils.service`. The last commit might be problematic as it changes variable-names, but I only addressed the private ones so hopefully no-one is using them.