### PR TITLE
Fix Rawhide build failure due to fabric package rename

### DIFF
--- a/optional_plugins/runner_remote/setup.py
+++ b/optional_plugins/runner_remote/setup.py
@@ -13,12 +13,15 @@
 # Copyright: Red Hat Inc. 2017
 # Author: Cleber Rosa <crosa@redhat.com>
 
+import os
 import sys
+sys.path.append(os.path.join('..', '..'))
+from avocado.utils import distro
 
 from setuptools import setup, find_packages
 
-
-if sys.version_info[0] == 3:
+detected_distro = distro.detect()
+if detected_distro.name == 'fedora' and int(detected_distro.version) >= 29:
     fabric = 'Fabric3<2.0.0'
 else:
     fabric = 'fabric<2.0.0'

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -50,9 +50,14 @@ Source0: https://github.com/avocado-framework/%{srcname}/archive/%{version}.tar.
 Source0: https://github.com/avocado-framework/%{srcname}/archive/%{commit}.tar.gz#/%{gittar}
 %endif
 BuildArch: noarch
-BuildRequires: fabric
 BuildRequires: procps-ng
 BuildRequires: kmod
+%if 0%{?fedora} >= 29
+BuildRequires: python2-fabric3
+%else
+BuildRequires: fabric
+%endif
+
 %if 0%{?rhel} == 7
 BuildRequires: pystache
 BuildRequires: python-lxml
@@ -527,7 +532,11 @@ arbitrary filesystem location.
 %package -n python2-%{srcname}-plugins-runner-remote
 Summary: Avocado Runner for Remote Execution
 Requires: python2-%{srcname} == %{version}
+%if 0%{?fedora} >= 29
+Requires: python2-fabric3
+%else
 Requires: fabric
+%endif
 
 %description -n python2-%{srcname}-plugins-runner-remote
 Allows Avocado to run jobs on a remote machine, by means of an SSH


### PR DESCRIPTION
Avocado 62.0 fails to build in Fedora Rawhide because the old `fabric` package was renamed to `fabric3`, and there is a new `fabric` package.

It appears that `optional_plugins/runner_remote/setup.py` tried to accommodate this renaming, but did so based on checking the Python version rather than the Fedora release. This PR corrects that.

The SPEC file also needs to require the renamed `fabric` package starting with the current Fedora Rawhide release. It also needs to require the Python `distro` package so the previously mentioned `setup.py` script update can detect the Fedora release. This PR makes those changes as well.

Also note: the renamed `fabric` package now also includes a Python3 version--which should help make several plugins available for Python3.