### PR TITLE
Fixup enable/disable cpuidle states

### DIFF
--- a/avocado/utils/cpu.py
+++ b/avocado/utils/cpu.py
@@ -225,9 +225,9 @@ def _bool_to_binary(value):
     Turns a boolean value (True or False) into data suitable for writing to
     /proc/* and /sys/* files.
     '''
-    if value is True:
+    if value:
         return b'1'
-    if value is False:
+    else:
         return b'0'
     raise TypeError('Value is not a boolean: %s', value)
 
@@ -256,6 +256,7 @@ def set_cpuidle_state(state_number="all", disable=True, setstate=None):
     :param setstate: cpuidle state value, output of `get_cpuidle_state()`
     """
     cpus_list = cpu_online_list()
+    disable = _legacy_disable(disable)
     if not setstate:
         states = []
         if state_number == 'all':
@@ -265,7 +266,6 @@ def set_cpuidle_state(state_number="all", disable=True, setstate=None):
         for cpu in cpus_list:
             for state_no in states:
                 state_file = "/sys/devices/system/cpu/cpu%s/cpuidle/state%s/disable" % (cpu, state_no)
-                disable = _legacy_disable(disable)
                 try:
                     open(state_file, "wb").write(disable)
                 except IOError as err:
@@ -275,9 +275,8 @@ def set_cpuidle_state(state_number="all", disable=True, setstate=None):
         for cpu, stateval in setstate.items():
             for state_no, value in stateval.items():
                 state_file = "/sys/devices/system/cpu/cpu%s/cpuidle/state%s/disable" % (cpu, state_no)
-                disable = _legacy_disable(value)
                 try:
-                    open(state_file, "wb").write(disable)
+                    open(state_file, "wb").write(value)
                 except IOError as err:
                     logging.warning("Failed to set idle state on cpu %s "
                                     "for state %s:\n%s", cpu, state_no, err)


### PR DESCRIPTION
Recent commit 2580f7e47e33324ed87b8497f03bae92f4402aad
enhances disable/enable idle states by using boolean,
which broke the set_cpuidle_state functionality, this patch
fixes it.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>