### PR TITLE
Removing the deprecated AVOCADO_TEST_DATADIR

### DIFF
--- a/examples/tests/env_variables.sh
+++ b/examples/tests/env_variables.sh
@@ -3,7 +3,6 @@
 # information, exported through environment variables.
 echo "Avocado Version: $AVOCADO_VERSION"
 echo "Avocado Test basedir: $AVOCADO_TEST_BASEDIR"
-echo "Avocado Test datadir: $AVOCADO_TEST_DATADIR"
 echo "Avocado Test workdir: $AVOCADO_TEST_WORKDIR"
 echo "Avocado Test logdir: $AVOCADO_TEST_LOGDIR"
 echo "Avocado Test logfile: $AVOCADO_TEST_LOGFILE"

--- a/selftests/functional/test_export_variables.py
+++ b/selftests/functional/test_export_variables.py
@@ -17,7 +17,6 @@ AVOCADO = os.environ.get("UNITTEST_AVOCADO_CMD", "./scripts/avocado")
 SCRIPT_CONTENT = """#!/bin/sh
 echo "Avocado Version: $AVOCADO_VERSION"
 echo "Avocado Test basedir: $AVOCADO_TEST_BASEDIR"
-echo "Avocado Test datadir: $AVOCADO_TEST_DATADIR"
 echo "Avocado Test workdir: $AVOCADO_TEST_WORKDIR"
 echo "Avocado Test logdir: $AVOCADO_TEST_LOGDIR"
 echo "Avocado Test logfile: $AVOCADO_TEST_LOGFILE"


### PR DESCRIPTION
AVOCADO_TEST_DATADIR is deprecated.
Removing them from the examples and selftests.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>