### PR TITLE
Avoid crash in case paginator tries to use not available "less"

### DIFF
--- a/avocado/core/dispatcher.py
+++ b/avocado/core/dispatcher.py
@@ -144,7 +144,8 @@ class Dispatcher(EnabledExtensionManager):
             except KeyboardInterrupt:
                 raise
             except:     # catch any exception pylint: disable=W0702
-                stacktrace.log_exc_info(sys.exc_info(), logger='avocado.debug')
+                stacktrace.log_exc_info(sys.exc_info(),
+                                        logger='avocado.app.debug')
                 LOG_UI.error('Error running method "%s" of plugin "%s": %s',
                              method_name, ext.name, sys.exc_info()[1])
         return ret
@@ -166,7 +167,8 @@ class Dispatcher(EnabledExtensionManager):
             except KeyboardInterrupt:
                 raise
             except:     # catch any exception pylint: disable=W0702
-                stacktrace.log_exc_info(sys.exc_info(), logger='avocado.debug')
+                stacktrace.log_exc_info(sys.exc_info(),
+                                        logger='avocado.app.debug')
                 LOG_UI.error('Error running method "%s" of plugin "%s": %s',
                              method_name, ext.name, sys.exc_info()[1])
 

--- a/avocado/utils/debug.py
+++ b/avocado/utils/debug.py
@@ -23,7 +23,7 @@ from six import iteritems
 
 
 # Use this for debug logging
-LOGGER = logging.getLogger("avocado.debug")
+LOGGER = logging.getLogger("avocado.app.debug")
 
 # measure_duration global storage
 __MEASURE_DURATION = {}

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -295,6 +295,12 @@ class CmdResult(object):
             encoding = astring.ENCODING
         self.encoding = encoding
 
+    def __str__(self):
+        return '\n'.join("%s: %r" % (key, getattr(self, key, "MISSING"))
+                         for key in ('command', 'exit_status', 'duration',
+                                     'interrupted', 'pid', 'encoding',
+                                     'stdout', 'stderr'))
+
     @property
     def stdout_text(self):
         if hasattr(self.stdout, 'decode'):

--- a/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/mux.py
+++ b/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/mux.py
@@ -211,7 +211,8 @@ class MuxPlugin(object):
             # summary == 0 means disable, but in plugin it's brief
             tree_repr = tree.tree_view(self.root, verbose=summary - 1,
                                        use_utf8=kwargs.get("use_utf8", None))
-            out.append(tree_repr)
+            # ascii is a subset of UTF-8, let's use always UTF-8 to decode here
+            out.append(tree_repr.decode('utf-8'))
             out.append("")
 
         if variants:

--- a/selftests/unit/test_output.py
+++ b/selftests/unit/test_output.py
@@ -1,0 +1,35 @@
+import sys
+import unittest
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+from avocado.utils import path as utils_path
+from avocado.core import output
+
+
+class TestStdOutput(unittest.TestCase):
+
+    def setUp(self):
+        """Always restore sys.std{out,err}, just in case.."""
+        self.stdout = sys.stdout
+        self.stderr = sys.stderr
+
+    def tearDown(self):
+        sys.stdout = self.stdout
+        sys.stderr = self.stderr
+
+    def test_paginator_not_available(self):
+        """Check that without paginator command we proceed without changes"""
+        std = output.StdOutput()
+        with mock.patch('avocado.utils.path.find_command',
+                        side_effect=utils_path.CmdNotFoundError('just',
+                                                                'mocking')):
+            std.enable_paginator()
+        self.assertEqual(self.stdout, sys.stdout)
+        self.assertEqual(self.stderr, sys.stderr)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This slightly diverged so it started as "less", but there are several fixes found while working on it and in travis. See the actual commit messages for details.