### PR TITLE
selftests/checkall: check load failures [v2]

### DIFF
--- a/selftests/checkall
+++ b/selftests/checkall
@@ -85,6 +85,18 @@ parallel_selftests() {
                 for FAILURE in $(cat "${TMPS[$I]}" | sed -n 's/\(ERROR\|FAIL\): \([^ ]*\) (\([^)]*\)).*/\3.\2/p'); do
                     FAILED_ONCE+=("$FAILURE")
                 done
+                # On Python 3.4, load errors are not treated as test failures, and we can
+                # not easily tell which test failed to be loaded.  Let's return immediately.
+                grep -q "AttributeError: 'module' object has no attribute" "${TMPS[$I]}"
+                if [ $? == 0 ]; then
+                    echo
+                    echo ----------------------------------------------------------------------
+                    echo "ERROR: failed to load at least 1 test"
+                    echo "Check the following log output for more information:"
+                    cat "${TMPS[$I]}"
+                    echo ----------------------------------------------------------------------
+                    return 1;
+                fi
             else
                 rm ${TMPS[$I]}
             fi


### PR DESCRIPTION
During the parallel execution of unittests, only conditions for FAIL
and ERROR are checked.  Under Python > 3.4, that's fine because load
failures are treated as FAILures:

```
   $ python3.6
   Python 3.6.5 (default, Mar 29 2018, 18:20:46)
   [GCC 8.0.1 20180317 (Red Hat 8.0.1-0.19)] on linux
   Type "help", "copyright", "credits" or "license" for more information.
   >>> import unittest.loader
   >>> l = unittest.loader.TestLoader()
   >>> l.loadTestsFromName('selftests.unit.test_utils_cpu.Cpu.test_cpu_arch_ppc64_power8')
   <unittest.suite.TestSuite tests=[<unittest.loader._FailedTest testMethod=test_utils_cpu>]>
```

But, under Python 3.4, no such treatment is done:

```
   $ python3.4
   Python 3.4.3 (default, Jan 13 2018, 13:06:46)
   [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)] on linux
   Type "help", "copyright", "credits" or "license" for more information.
   >>> import unittest.loader
   >>> l = unittest.loader.TestLoader()
   >>> l.loadTestsFromName('selftests.unit.test_utils_cpu.Cpu.test_cpu_arch_ppc64_power8')
   Traceback (most recent call last):
     File "<stdin>", line 1, in <module>
     File "/home/cleber/.local/lib/python3.4/unittest/loader.py", line 114, in loadTestsFromName
       parent, obj = obj, getattr(obj, part)
   AttributeError: 'module' object has no attribute 'test_utils_cpu'
```

This implements a simple check for load failures, which is not
perfect, but better than none.

Signed-off-by: Cleber Rosa <crosa@redhat.com>

---

Changes from v1 (#2674 ):
 * Print better message and log