### PR TITLE
Two little improvements to TAP plugin

### DIFF
--- a/docs/source/release_notes/lts/next.rst
+++ b/docs/source/release_notes/lts/next.rst
@@ -271,6 +271,9 @@ introduced by the next LTS version are:
   "columns".  This is also reflected in the (tabular) output of
   commands such as ``avocado list -v``.
 
+* Including test logs in TAP plugin is disabled by default and can
+  be enabled using ``--tap-include-logs``.
+
 Complete list of changes
 ========================
 

--- a/man/avocado.rst
+++ b/man/avocado.rst
@@ -126,6 +126,7 @@ Options for subcommand `run` (`avocado run --help`)::
       --tap-job-result {on,off}
                             Enables default TAP result in the job results
                             directory. File will be named "results.tap".
+      --tap-include-logs    Include test logs as comments in TAP output ((False)
       --xunit FILE          Enable xUnit result format and write it to FILE. Use
                             '-' to redirect to the standard output.
       --xunit-job-result {on,off}


### PR DESCRIPTION
For a while we want to decrease the default verbosity https://trello.com/c/90Zvwccm/1303-allow-to-tweak-verbosity-of-tap-plugin and recently we got feedback that it even slows-down test execution https://github.com/avocado-framework/avocado/issues/2647 Let's address both and disable default verbosity while improving the performance by decreasing the number of fsync.

PS: Even on "errortest.py" the difference is `0.2s`