### PR TITLE
Test Loader: use enums from from Python 3.4 [v2]

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -26,6 +26,7 @@ import re
 import shlex
 import sys
 
+from enum import Enum
 from six import string_types, iteritems
 
 from . import data_dir
@@ -36,12 +37,14 @@ from ..utils import stacktrace
 from .settings import settings
 from .output import LOG_UI
 
-#: Show default tests (for execution)
-DEFAULT = False
-#: Available tests (for listing purposes)
-AVAILABLE = None
-#: All tests (including broken ones)
-ALL = True
+
+class DiscoverMode(Enum):
+    #: Show default tests (for execution)
+    DEFAULT = object()
+    #: Available tests (for listing purposes)
+    AVAILABLE = object()
+    #: All tests (including broken ones)
+    ALL = object()
 
 
 # Regexp to find python unittests
@@ -249,14 +252,14 @@ class TestLoaderProxy(object):
                                "LoaderProxy.get_decorator_mapping")
         return self._decorator_mapping
 
-    def discover(self, references, which_tests=DEFAULT, force=None):
+    def discover(self, references, which_tests=DiscoverMode.DEFAULT, force=None):
         """
         Discover (possible) tests from test references.
 
         :param references: a list of tests references; if [] use plugin defaults
         :type references: builtin.list
-        :param which_tests: Limit tests to be displayed (ALL, AVAILABLE or
-                            DEFAULT)
+        :param which_tests: Limit tests to be displayed
+        :type which_tests: :class:`DiscoverMode`
         :param force: don't raise an exception when some test references
                       are not resolved to tests.
         :return: A list of test factories (tuples (TestClass, test_params))
@@ -285,14 +288,14 @@ class TestLoaderProxy(object):
                         if _test:
                             tests.extend(_test)
                             handled = True
-                            if not which_tests:
+                            if which_tests != DiscoverMode.ALL:
                                 break  # Don't process other plugins
                     except Exception as details:
                         handle_exception(loader_plugin, details)
                 if not handled:
                     unhandled_references.append(reference)
         if unhandled_references:
-            if which_tests:
+            if which_tests == DiscoverMode.ALL:
                 tests.extend([(MissingTest, {'name': reference})
                               for reference in unhandled_references])
             else:
@@ -422,14 +425,14 @@ class TestLoader(object):
         """
         return self.get_decorator_mapping()
 
-    def discover(self, reference, which_tests=DEFAULT):
+    def discover(self, reference, which_tests=DiscoverMode.DEFAULT):
         """
         Discover (possible) tests from an reference.
 
         :param reference: the reference to be inspected.
         :type reference: str
-        :param which_tests: Limit tests to be displayed (ALL, AVAILABLE or
-                            DEFAULT)
+        :param which_tests: Limit tests to be displayed
+        :type which_tests: :class:`DiscoverMode`
         :return: a list of test matching the reference as params.
         """
         raise NotImplementedError
@@ -529,7 +532,7 @@ class FileLoader(TestLoader):
                 test.Test: output.TERM_SUPPORT.healthy_str,
                 test.PythonUnittest: output.TERM_SUPPORT.healthy_str}
 
-    def discover(self, reference, which_tests=DEFAULT):
+    def discover(self, reference, which_tests=DiscoverMode.DEFAULT):
         """
         Discover (possible) tests from a directory.
 
@@ -541,8 +544,8 @@ class FileLoader(TestLoader):
         partial match).
 
         :param reference: the directory path to inspect.
-        :param which_tests: Limit tests to be displayed (ALL, AVAILABLE or
-                            DEFAULT)
+        :param which_tests: Limit tests to be displayed
+        :type which_tests: :class:`DiscoverMode`
         :return: list of matching tests
         """
         tests = self._discover(reference, which_tests)
@@ -563,18 +566,18 @@ class FileLoader(TestLoader):
                         return None
         return tests
 
-    def _discover(self, reference, which_tests=DEFAULT):
+    def _discover(self, reference, which_tests=DiscoverMode.DEFAULT):
         """
         Recursively walk in a directory and find tests params.
         The tests are returned in alphabetic order.
 
         :param reference: the directory path to inspect.
-        :param which_tests: Limit tests to be displayed (ALL, AVAILABLE or
-                            DEFAULT)
+        :param which_tests: Limit tests to be displayed
+        :type which_tests: :class:`DiscoverMode`
         :return: list of matching tests
         """
         if reference is None:
-            if which_tests is DEFAULT:
+            if which_tests == DiscoverMode.DEFAULT:
                 return []  # Return empty set when not listing details
             else:
                 reference = data_dir.get_test_dir()
@@ -590,19 +593,21 @@ class FileLoader(TestLoader):
                 subtests_filter = re.compile(_subtests_filter)
 
         if not os.path.isdir(reference):  # Single file
-            return self._make_tests(reference, which_tests, subtests_filter)
+            return self._make_tests(reference, which_tests == DiscoverMode.ALL,
+                                    subtests_filter)
 
         tests = []
 
         def add_test_from_exception(exception):
             """ If the exc.filename is valid test it's added to tests """
-            tests.extend(self._make_tests(exception.filename, which_tests))
+            tests.extend(self._make_tests(exception.filename,
+                                          which_tests == DiscoverMode.ALL))
 
         def skip_non_test(exception):
             """ Always return None """
             return None
 
-        if which_tests is ALL:
+        if which_tests == DiscoverMode.ALL:
             onerror = add_test_from_exception
         else:  # DEFAULT, AVAILABLE => skip missing tests
             onerror = skip_non_test
@@ -616,7 +621,8 @@ class FileLoader(TestLoader):
                             break
                     else:
                         pth = os.path.join(dirpath, file_name)
-                        tests.extend(self._make_tests(pth, which_tests,
+                        tests.extend(self._make_tests(pth,
+                                                      which_tests == DiscoverMode.ALL,
                                                       subtests_filter))
         return tests
 
@@ -1034,11 +1040,11 @@ class ExternalLoader(TestLoader):
             raise LoaderError(msg)
         return None  # Skip external runner
 
-    def discover(self, reference, which_tests=DEFAULT):
+    def discover(self, reference, which_tests=DiscoverMode.DEFAULT):
         """
         :param reference: arguments passed to the external_runner
-        :param which_tests: Limit tests to be displayed (ALL, AVAILABLE or
-                            DEFAULT)
+        :param which_tests: Limit tests to be displayed
+        :type which_tests: :class:`DiscoverMode`
         :return: list of matching tests
         """
         if (not self._external_runner) or (reference is None):

--- a/avocado/plugins/list.py
+++ b/avocado/plugins/list.py
@@ -43,7 +43,10 @@ class TestLister(object):
         loader.loader.get_extra_listing()
 
     def _get_test_suite(self, paths):
-        which_tests = loader.ALL if self.args.verbose else loader.AVAILABLE
+        if self.args.verbose:
+            which_tests = loader.DiscoverMode.ALL
+        else:
+            which_tests = loader.DiscoverMode.AVAILABLE
         try:
             return loader.loader.discover(paths,
                                           which_tests=which_tests)

--- a/optional_plugins/glib/avocado_glib/__init__.py
+++ b/optional_plugins/glib/avocado_glib/__init__.py
@@ -74,7 +74,7 @@ class GLibLoader(loader.TestLoader):
     def __init__(self, args, extra_params):
         super(GLibLoader, self).__init__(args, extra_params)
 
-    def discover(self, reference, which_tests=loader.DEFAULT):
+    def discover(self, reference, which_tests=loader.DiscoverMode.DEFAULT):
         avocado_suite = []
         subtests_filter = None
 
@@ -91,7 +91,7 @@ class GLibLoader(loader.TestLoader):
                 cmd = '%s -l' % (reference)
                 result = process.run(cmd)
             except Exception as details:
-                if which_tests == loader.ALL:
+                if which_tests == loader.DiscoverMode.ALL:
                     return [(NotGLibTest,
                              {"name": "%s: %s" % (reference, details)})]
                 return []
@@ -103,7 +103,7 @@ class GLibLoader(loader.TestLoader):
                 avocado_suite.append((GLibTest, {'name': test_name,
                                                  'executable': test_name}))
 
-        if which_tests is loader.ALL and not avocado_suite:
+        if which_tests == loader.DiscoverMode.ALL and not avocado_suite:
             return [(NotGLibTest,
                      {"name": "%s: No GLib-like tests found" % reference})]
         return avocado_suite

--- a/optional_plugins/golang/avocado_golang/__init__.py
+++ b/optional_plugins/golang/avocado_golang/__init__.py
@@ -90,7 +90,7 @@ class GolangLoader(loader.TestLoader):
     def __init__(self, args, extra_params):
         super(GolangLoader, self).__init__(args, extra_params)
 
-    def discover(self, url, which_tests=loader.DEFAULT):
+    def discover(self, url, which_tests=loader.DiscoverMode.DEFAULT):
         if _GO_BIN is None:
             return self._no_tests(which_tests, url, 'Go binary not found.')
 
@@ -182,7 +182,7 @@ class GolangLoader(loader.TestLoader):
 
     @staticmethod
     def _no_tests(which_tests, url, msg):
-        if which_tests == loader.ALL:
+        if which_tests == loader.DiscoverMode.ALL:
             return [(NotGolangTest, {"name": "%s: %s" % (url, msg)})]
         return []
 

--- a/optional_plugins/loader_yaml/avocado_loader_yaml/__init__.py
+++ b/optional_plugins/loader_yaml/avocado_loader_yaml/__init__.py
@@ -93,7 +93,7 @@ class YamlTestsuiteLoader(loader.TestLoader):
             extra_params = copy.deepcopy(extra_params)
         return loader_class(args, extra_params)
 
-    def discover(self, reference, which_tests=loader.DEFAULT):
+    def discover(self, reference, which_tests=loader.DiscoverMode.DEFAULT):
         tests = []
         try:
             root = mux.apply_filters(create_from_yaml([reference], False),

--- a/optional_plugins/robot/avocado_robot/__init__.py
+++ b/optional_plugins/robot/avocado_robot/__init__.py
@@ -85,7 +85,7 @@ class RobotLoader(loader.TestLoader):
     def __init__(self, args, extra_params):
         super(RobotLoader, self).__init__(args, extra_params)
 
-    def discover(self, url, which_tests=loader.DEFAULT):
+    def discover(self, url, which_tests=loader.DiscoverMode.DEFAULT):
         avocado_suite = []
         subtests_filter = None
 
@@ -101,7 +101,7 @@ class RobotLoader(loader.TestLoader):
                                  include_suites=SuiteNamePatterns())
             robot_suite = self._find_tests(test_data, test_suite={})
         except Exception as data:
-            if which_tests == loader.ALL:
+            if which_tests == loader.DiscoverMode.ALL:
                 return [(NotRobotTest, {"name": "%s: %s" % (url, data)})]
             return []
 
@@ -114,7 +114,7 @@ class RobotLoader(loader.TestLoader):
                     continue
                 avocado_suite.append((RobotTest, {'name': test_name,
                                                   'executable': test_name}))
-        if which_tests is loader.ALL and not avocado_suite:
+        if which_tests == loader.DiscoverMode.ALL and not avocado_suite:
             return [(NotRobotTest, {"name": "%s: No robot-like tests found"
                                     % url})]
         return avocado_suite

--- a/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
+++ b/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
@@ -192,7 +192,7 @@ class DummyLoader(loader.TestLoader):
     def __init__(self, args, extra_params):
         super(DummyLoader, self).__init__(args, extra_params)
 
-    def discover(self, url, which_tests=loader.DEFAULT):
+    def discover(self, url, which_tests=loader.DiscoverMode.DEFAULT):
         return [(MockingTest, {'name': url})]
 
     @staticmethod

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -40,7 +40,7 @@
 Summary: Framework with tools and libraries for Automated Testing
 Name: python-%{srcname}
 Version: 62.0
-Release: 0%{?gitrel}%{?dist}
+Release: 1%{?gitrel}%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.github.io/
@@ -58,6 +58,7 @@ BuildRequires: pystache
 BuildRequires: python-lxml
 BuildRequires: python-setuptools
 BuildRequires: python-stevedore
+BuildRequires: python-enum34
 BuildRequires: python2-aexpect
 BuildRequires: python2-devel
 BuildRequires: python2-docutils
@@ -73,6 +74,7 @@ BuildRequires: pystache
 BuildRequires: python2-aexpect
 BuildRequires: python2-devel
 BuildRequires: python2-docutils
+BuildRequires: python2-enum34
 BuildRequires: python2-lxml
 BuildRequires: python2-mock
 BuildRequires: python2-psutil
@@ -124,12 +126,14 @@ Requires: procps-ng
 Requires: pyliblzma
 %if 0%{?rhel} == 7
 Requires: python
+Requires: python-enum34
 Requires: python-setuptools
 Requires: python-six
 Requires: python-stevedore
 Requires: python2-requests
 %else
 Requires: python2
+Requires: python2-enum34
 Requires: python2-requests
 Requires: python2-setuptools
 Requires: python2-six
@@ -778,6 +782,9 @@ Again Shell code (and possibly other similar shells).
 %{_libexecdir}/avocado*
 
 %changelog
+* Wed Jun 20 2018 Cleber Rosa <cleber@redhat.com> - 62.0-1
+- Added new python[2]-enum34 requirement
+
 * Tue Jun 12 2018 Cleber Rosa <cleber@redhat.com> - 62.0-0
 - New release
 

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -259,13 +259,13 @@ class LoaderTest(unittest.TestCase):
                                              'avocado_loader_unittest')
         simple_test.save()
         test_class, test_parameters = (
-            self.loader.discover(simple_test.path, loader.ALL)[0])
+            self.loader.discover(simple_test.path, loader.DiscoverMode.ALL)[0])
         self.assertTrue(test_class == test.SimpleTest, test_class)
         test_parameters['name'] = test.TestID(0, test_parameters['name'])
         test_parameters['base_logdir'] = self.tmpdir
         tc = test_class(**test_parameters)
         tc.run_avocado()
-        suite = self.loader.discover(simple_test.path, loader.ALL)
+        suite = self.loader.discover(simple_test.path, loader.DiscoverMode.ALL)
         self.assertEqual(len(suite), 1)
         self.assertEqual(suite[0][1]["name"], simple_test.path)
         simple_test.remove()
@@ -275,7 +275,7 @@ class LoaderTest(unittest.TestCase):
                                              'avocado_loader_unittest',
                                              mode=DEFAULT_NON_EXEC_MODE)
         simple_test.save()
-        test_class, _ = self.loader.discover(simple_test.path, loader.ALL)[0]
+        test_class, _ = self.loader.discover(simple_test.path, loader.DiscoverMode.ALL)[0]
         self.assertTrue(test_class == loader.NotATest, test_class)
         simple_test.remove()
 
@@ -285,7 +285,7 @@ class LoaderTest(unittest.TestCase):
                                                    'avocado_loader_unittest')
         avocado_pass_test.save()
         test_class, _ = self.loader.discover(avocado_pass_test.path,
-                                             loader.ALL)[0]
+                                             loader.DiscoverMode.ALL)[0]
         self.assertTrue(test_class == 'PassTest', test_class)
         avocado_pass_test.remove()
 
@@ -296,7 +296,7 @@ class LoaderTest(unittest.TestCase):
                                                     mode=DEFAULT_NON_EXEC_MODE)
         avocado_not_a_test.save()
         test_class, _ = self.loader.discover(avocado_not_a_test.path,
-                                             loader.ALL)[0]
+                                             loader.DiscoverMode.ALL)[0]
         self.assertTrue(test_class == loader.NotATest, test_class)
         avocado_not_a_test.remove()
 
@@ -305,7 +305,7 @@ class LoaderTest(unittest.TestCase):
                                                     'avocado_loader_unittest')
         avocado_not_a_test.save()
         test_class, test_parameters = (
-            self.loader.discover(avocado_not_a_test.path, loader.ALL)[0])
+            self.loader.discover(avocado_not_a_test.path, loader.DiscoverMode.ALL)[0])
         self.assertTrue(test_class == test.SimpleTest, test_class)
         test_parameters['name'] = test.TestID(0, test_parameters['name'])
         test_parameters['base_logdir'] = self.tmpdir
@@ -321,7 +321,7 @@ class LoaderTest(unittest.TestCase):
                                                      'avocado_loader_unittest')
         avocado_simple_test.save()
         test_class, test_parameters = (
-            self.loader.discover(avocado_simple_test.path, loader.ALL)[0])
+            self.loader.discover(avocado_simple_test.path, loader.DiscoverMode.ALL)[0])
         self.assertTrue(test_class == test.SimpleTest)
         test_parameters['name'] = test.TestID(0, test_parameters['name'])
         test_parameters['base_logdir'] = self.tmpdir
@@ -336,7 +336,7 @@ class LoaderTest(unittest.TestCase):
                                                      mode=DEFAULT_NON_EXEC_MODE)
         avocado_simple_test.save()
         test_class, _ = self.loader.discover(avocado_simple_test.path,
-                                             loader.ALL)[0]
+                                             loader.DiscoverMode.ALL)[0]
         self.assertTrue(test_class == loader.NotATest)
         avocado_simple_test.remove()
 
@@ -346,25 +346,25 @@ class LoaderTest(unittest.TestCase):
                                                         'avocado_multiple_tests_unittest',
                                                         mode=DEFAULT_NON_EXEC_MODE)
         avocado_multiple_tests.save()
-        suite = self.loader.discover(avocado_multiple_tests.path, loader.ALL)
+        suite = self.loader.discover(avocado_multiple_tests.path, loader.DiscoverMode.ALL)
         self.assertEqual(len(suite), 2)
         # Try to load only some of the tests
         suite = self.loader.discover(avocado_multiple_tests.path +
-                                     ':MultipleMethods.testTwo', loader.ALL)
+                                     ':MultipleMethods.testTwo', loader.DiscoverMode.ALL)
         self.assertEqual(len(suite), 1)
         self.assertEqual(suite[0][1]["methodName"], 'testTwo')
         # Load using regexp
         suite = self.loader.discover(avocado_multiple_tests.path +
-                                     ':.*_one', loader.ALL)
+                                     ':.*_one', loader.DiscoverMode.ALL)
         self.assertEqual(len(suite), 1)
         self.assertEqual(suite[0][1]["methodName"], 'test_one')
         # Load booth
         suite = self.loader.discover(avocado_multiple_tests.path +
-                                     ':test.*', loader.ALL)
+                                     ':test.*', loader.DiscoverMode.ALL)
         self.assertEqual(len(suite), 2)
         # Load none should return no tests
         self.assertTrue(not self.loader.discover(avocado_multiple_tests.path +
-                                                 ":no_match", loader.ALL))
+                                                 ":no_match", loader.DiscoverMode.ALL))
         avocado_multiple_tests.remove()
 
     def test_multiple_methods_same_name(self):
@@ -373,11 +373,11 @@ class LoaderTest(unittest.TestCase):
                                                         'avocado_multiple_tests_unittest',
                                                         mode=DEFAULT_NON_EXEC_MODE)
         avocado_multiple_tests.save()
-        suite = self.loader.discover(avocado_multiple_tests.path, loader.ALL)
+        suite = self.loader.discover(avocado_multiple_tests.path, loader.DiscoverMode.ALL)
         self.assertEqual(len(suite), 1)
         # Try to load only some of the tests
         suite = self.loader.discover(avocado_multiple_tests.path +
-                                     ':MultipleMethods.test', loader.ALL)
+                                     ':MultipleMethods.test', loader.DiscoverMode.ALL)
         self.assertEqual(len(suite), 1)
         self.assertEqual(suite[0][1]["methodName"], 'test')
         avocado_multiple_tests.remove()
@@ -388,7 +388,7 @@ class LoaderTest(unittest.TestCase):
                                                    'avocado_loader_unittest')
         avocado_pass_test.save()
         test_class, _ = (
-            self.loader.discover(avocado_pass_test.path, loader.ALL)[0])
+            self.loader.discover(avocado_pass_test.path, loader.DiscoverMode.ALL)[0])
         self.assertTrue(test_class == 'First', test_class)
         avocado_pass_test.remove()
 
@@ -399,7 +399,7 @@ class LoaderTest(unittest.TestCase):
                                                    DEFAULT_NON_EXEC_MODE)
         avocado_pass_test.save()
         test_class, _ = (
-            self.loader.discover(avocado_pass_test.path, loader.ALL)[0])
+            self.loader.discover(avocado_pass_test.path, loader.DiscoverMode.ALL)[0])
         self.assertTrue(test_class == loader.NotATest)
         avocado_pass_test.remove()
 
@@ -410,7 +410,7 @@ class LoaderTest(unittest.TestCase):
                                                      DEFAULT_NON_EXEC_MODE)
         avocado_nested_test.save()
         test_class, _ = self.loader.discover(avocado_nested_test.path,
-                                             loader.ALL)[0]
+                                             loader.DiscoverMode.ALL)[0]
         self.assertTrue(test_class == loader.NotATest)
         avocado_nested_test.remove()
 
@@ -421,7 +421,7 @@ class LoaderTest(unittest.TestCase):
             'avocado_loader_unittest')
         avocado_multiple_imp_test.save()
         test_class, _ = (
-            self.loader.discover(avocado_multiple_imp_test.path, loader.ALL)[0])
+            self.loader.discover(avocado_multiple_imp_test.path, loader.DiscoverMode.ALL)[0])
         self.assertTrue(test_class == 'Second', test_class)
         avocado_multiple_imp_test.remove()
 
@@ -439,7 +439,7 @@ class LoaderTest(unittest.TestCase):
                     'SafeTest.test_safe': set(['safe'])}
         with avocado_test_tags:
             for _, info in self.loader.discover(avocado_test_tags.path,
-                                                loader.ALL):
+                                                loader.DiscoverMode.ALL):
                 name = info['name'].split(':', 1)[1]
                 self.assertEqual(info['tags'], tags_map[name])
                 del(tags_map[name])
@@ -451,7 +451,7 @@ class LoaderTest(unittest.TestCase):
                                                    'avocado_loader_unittest',
                                                    DEFAULT_NON_EXEC_MODE)
         with avocado_pass_test as test:
-            test_suite = self.loader.discover(test.path, loader.ALL)
+            test_suite = self.loader.discover(test.path, loader.DiscoverMode.ALL)
             self.assertEqual([], loader.filter_test_tags(test_suite, []))
             self.assertEqual(test_suite,
                              loader.filter_test_tags(test_suite, [], True))
@@ -462,7 +462,7 @@ class LoaderTest(unittest.TestCase):
                                                    'avocado_loader_unittest',
                                                    DEFAULT_NON_EXEC_MODE)
         with avocado_test_tags as test:
-            test_suite = self.loader.discover(test.path, loader.ALL)
+            test_suite = self.loader.discover(test.path, loader.DiscoverMode.ALL)
             self.assertEqual(len(test_suite), 5)
             self.assertEqual(test_suite[0][0], 'FastTest')
             self.assertEqual(test_suite[0][1]['methodName'], 'test_fast')

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,11 @@ def get_long_description():
     return req_contents
 
 
+INSTALL_REQUIREMENTS = ['stevedore>=0.14', 'six>=1.10.0', 'setuptools']
+if sys.version_info[0] == 2:
+    INSTALL_REQUIREMENTS.append('enum34')
+
+
 if __name__ == '__main__':
     # Force "make develop" inside the "readthedocs.org" environment
     if os.environ.get("READTHEDOCS") and "install" in sys.argv:
@@ -108,4 +113,4 @@ if __name__ == '__main__':
           zip_safe=False,
           test_suite='selftests',
           python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
-          install_requires=['stevedore>=0.14', 'six>=1.10.0', 'setuptools'])
+          install_requires=INSTALL_REQUIREMENTS)


### PR DESCRIPTION
This change reveleaed a couple of location in the symbolic names where
not being used, but their special values were being evaluated.  Let's
avoid using the special (and subtle) meaning of ALL (True) and
DEFAULT/AVAILABLE (which evaluate to False).

The enum library is part of the standard library, starting from 3.4
(which is the mininum version we require for Avocado).  On Python 2.7,
we can rely on the backport package.

This is of course not necessary right now, but I feel that we can
continue modernizing the code base, and not wait for 2020 and then be
liberated to use newer constructs and libraries.

Signed-off-by: Cleber Rosa <crosa@redhat.com>

---

Changes from v1 (#2613):
 * Using `object()` for values, as we don't intend them to map to any real-world constant or even being relied on
 * Changed one comparison from `if not foo == bar` to `if foo != bar`
 * Changed class name to `DiscoverMode`