### PR TITLE
Two little improvements to TAP plugin [v2]

### DIFF
--- a/avocado/plugins/tap.py
+++ b/avocado/plugins/tap.py
@@ -65,6 +65,7 @@ class TAPResult(ResultEvents):
             log = open(output, "w", 1)
             self.__open_files.append(log)
             self.__logs.append(file_log_factory(log))
+        self.__include_logs = getattr(args, 'tap_include_logs', False)
         self.is_header_printed = False
 
     def __write(self, msg, *writeargs):
@@ -104,13 +105,15 @@ class TAPResult(ResultEvents):
             name.replace('#', '_')  # Name must not contain #
             if name[0].isdigit():   # Name must not start with digit
                 name = "_" + name
+
         # First log the system output
-        self.__write("# debug.log of %s:", name)
+        if self.__include_logs:
+            self.__write("# debug.log of %s:", name)
+            with open(state.get("logfile"), "r") as logfile_obj:
+                for line in logfile_obj:
+                    self.__write("#   %s", line.rstrip())
 
-        with open(state.get("logfile"), "r") as logfile_obj:
-            for line in logfile_obj:
-                self.__write("#   %s", line.rstrip())
-
+        # Then the status
         if status == "PASS":
             self.__write("ok %s %s", result.tests_run, name)
         elif status == "WARN":
@@ -155,6 +158,11 @@ class TAP(CLI):
                                        "default TAP result in the job results"
                                        " directory. File will be named "
                                        "\"results.tap\".")
+
+        cmd_parser.output.add_argument('--tap-include-logs',
+                                       action='store_true', help='Include '
+                                       'test logs as comments in TAP output.'
+                                       ' Defaults to %(default)s')
 
     def run(self, args):
         pass

--- a/docs/source/release_notes/lts/next.rst
+++ b/docs/source/release_notes/lts/next.rst
@@ -271,6 +271,9 @@ introduced by the next LTS version are:
   "columns".  This is also reflected in the (tabular) output of
   commands such as ``avocado list -v``.
 
+* Including test logs in TAP plugin is disabled by default and can
+  be enabled using ``--tap-include-logs``.
+
 Complete list of changes
 ========================
 

--- a/man/avocado.rst
+++ b/man/avocado.rst
@@ -126,6 +126,8 @@ Options for subcommand `run` (`avocado run --help`)::
       --tap-job-result {on,off}
                             Enables default TAP result in the job results
                             directory. File will be named "results.tap".
+      --tap-include-logs    Include test logs as comments in TAP output. Defaults
+                            to False
       --xunit FILE          Enable xUnit result format and write it to FILE. Use
                             '-' to redirect to the standard output.
       --xunit-job-result {on,off}

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -358,8 +358,8 @@ class OutputPluginTest(unittest.TestCase):
     def test_output_compatible_setup_2(self):
         tmpfile = tempfile.mktemp()
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
-                    '--xunit - --json %s passtest.py' %
-                    (AVOCADO, self.tmpdir, tmpfile))
+                    '--xunit - --json %s --tap-include-logs passtest.py'
+                    % (AVOCADO, self.tmpdir, tmpfile))
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout + result.stderr
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -387,8 +387,9 @@ class OutputPluginTest(unittest.TestCase):
         tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
         tmpfile3 = os.path.join(tmpdir, "result.html")
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
-                    '--xunit %s --json %s --html %s passtest.py'
-                    % (AVOCADO, self.tmpdir, tmpfile, tmpfile2, tmpfile3))
+                    '--xunit %s --json %s --html %s --tap-include-logs '
+                    'passtest.py' % (AVOCADO, self.tmpdir, tmpfile, tmpfile2,
+                                     tmpfile3))
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout + result.stderr
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -420,8 +421,8 @@ class OutputPluginTest(unittest.TestCase):
         tmpfile2 = tempfile.mktemp()
         # Verify --silent can be supplied as app argument
         cmd_line = ('%s --silent run --job-results-dir %s '
-                    '--sysinfo=off --xunit %s --json %s passtest.py'
-                    % (AVOCADO, self.tmpdir, tmpfile, tmpfile2))
+                    '--sysinfo=off --xunit %s --json %s --tap-include-logs '
+                    'passtest.py' % (AVOCADO, self.tmpdir, tmpfile, tmpfile2))
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout + result.stderr
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -446,7 +447,7 @@ class OutputPluginTest(unittest.TestCase):
     def test_nonprintable_chars(self):
         cmd_line = ("%s run --external-runner /bin/ls "
                     "'NON_EXISTING_FILE_WITH_NONPRINTABLE_CHARS_IN_HERE\x1b' "
-                    "--job-results-dir %s --sysinfo=off"
+                    "--job-results-dir %s --sysinfo=off --tap-include-logs"
                     % (AVOCADO, self.tmpdir))
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout_text + result.stderr_text
@@ -493,7 +494,8 @@ class OutputPluginTest(unittest.TestCase):
 
     def test_default_enabled_plugins(self):
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
-                    'passtest.py' % (AVOCADO, self.tmpdir))
+                    '--tap-include-logs passtest.py'
+                    % (AVOCADO, self.tmpdir))
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout_text + result.stderr_text
         expected_rc = exit_codes.AVOCADO_ALL_OK


### PR DESCRIPTION
For a while we want to decrease the default verbosity https://trello.com/c/90Zvwccm/1303-allow-to-tweak-verbosity-of-tap-plugin and recently we got feedback that it even slows-down test execution https://github.com/avocado-framework/avocado/issues/2647 Let's address both and disable default verbosity while improving the performance by decreasing the number of fsync.

v1: https://github.com/avocado-framework/avocado/pull/2679

Changes:
```yaml
v2: Fixed selftests
v2: Use 'Defaults to ...' instead of '((default)'
v2: Rebased
```

PS: Even on "errortest.py" the difference is `0.2s`