### PR TITLE
 Avoid crash in case paginator tries to use not available "less" [v2]

### DIFF
--- a/avocado/core/dispatcher.py
+++ b/avocado/core/dispatcher.py
@@ -144,7 +144,8 @@ class Dispatcher(EnabledExtensionManager):
             except KeyboardInterrupt:
                 raise
             except:     # catch any exception pylint: disable=W0702
-                stacktrace.log_exc_info(sys.exc_info(), logger='avocado.debug')
+                stacktrace.log_exc_info(sys.exc_info(),
+                                        logger='avocado.app.debug')
                 LOG_UI.error('Error running method "%s" of plugin "%s": %s',
                              method_name, ext.name, sys.exc_info()[1])
         return ret
@@ -166,7 +167,8 @@ class Dispatcher(EnabledExtensionManager):
             except KeyboardInterrupt:
                 raise
             except:     # catch any exception pylint: disable=W0702
-                stacktrace.log_exc_info(sys.exc_info(), logger='avocado.debug')
+                stacktrace.log_exc_info(sys.exc_info(),
+                                        logger='avocado.app.debug')
                 LOG_UI.error('Error running method "%s" of plugin "%s": %s',
                              method_name, ext.name, sys.exc_info()[1])
 

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -321,7 +321,15 @@ class StdOutput(object):
         """
         Enable paginator
         """
-        self.stdout = self.stderr = Paginator()
+        try:
+            paginator = Paginator()
+        except RuntimeError as details:
+            # Paginator not available
+            logging.getLogger('avocado.app.debug').error("Failed to enable "
+                                                         "paginator: %s"
+                                                         % details)
+            return
+        self.stdout = self.stderr = paginator
 
     def enable_stderr(self):
         """
@@ -536,17 +544,14 @@ class Paginator(object):
     """
 
     def __init__(self):
-        try:
-            paginator = "%s -FRX" % utils_path.find_command('less')
-        except utils_path.CmdNotFoundError:
-            paginator = None
+        paginator = os.environ.get('PAGER')
+        if not paginator:
+            try:
+                paginator = "%s -FRX" % utils_path.find_command('less')
+            except utils_path.CmdNotFoundError as details:
+                raise RuntimeError("Unable to enable pagination: %s" % details)
 
-        paginator = os.environ.get('PAGER', paginator)
-
-        if paginator is None:
-            self.pipe = sys.stdout
-        else:
-            self.pipe = os.popen(paginator, 'w')
+        self.pipe = os.popen(paginator, 'w')
 
     def __del__(self):
         self.close()

--- a/avocado/utils/debug.py
+++ b/avocado/utils/debug.py
@@ -23,7 +23,7 @@ from six import iteritems
 
 
 # Use this for debug logging
-LOGGER = logging.getLogger("avocado.debug")
+LOGGER = logging.getLogger("avocado.app.debug")
 
 # measure_duration global storage
 __MEASURE_DURATION = {}

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -295,6 +295,12 @@ class CmdResult(object):
             encoding = astring.ENCODING
         self.encoding = encoding
 
+    def __str__(self):
+        return '\n'.join("%s: %r" % (key, getattr(self, key, "MISSING"))
+                         for key in ('command', 'exit_status', 'duration',
+                                     'interrupted', 'pid', 'encoding',
+                                     'stdout', 'stderr'))
+
     @property
     def stdout_text(self):
         if hasattr(self.stdout, 'decode'):

--- a/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
+++ b/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
@@ -458,7 +458,8 @@ class RemoteTestRunner(TestRunner):
         try:
             json_result = self._parse_json_response(result.stdout)
         except:
-            stacktrace.log_exc_info(sys.exc_info(), logger='avocado.debug')
+            stacktrace.log_exc_info(sys.exc_info(),
+                                    logger='avocado.app.debug')
             raise exceptions.JobError(result.stdout)
 
         for t_dict in json_result['tests']:

--- a/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/mux.py
+++ b/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/mux.py
@@ -211,7 +211,8 @@ class MuxPlugin(object):
             # summary == 0 means disable, but in plugin it's brief
             tree_repr = tree.tree_view(self.root, verbose=summary - 1,
                                        use_utf8=kwargs.get("use_utf8", None))
-            out.append(tree_repr)
+            # ascii is a subset of UTF-8, let's use always UTF-8 to decode here
+            out.append(tree_repr.decode('utf-8'))
             out.append("")
 
         if variants:

--- a/selftests/unit/test_output.py
+++ b/selftests/unit/test_output.py
@@ -1,0 +1,35 @@
+import sys
+import unittest
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+from avocado.utils import path as utils_path
+from avocado.core import output
+
+
+class TestStdOutput(unittest.TestCase):
+
+    def setUp(self):
+        """Preserve sys.std{out,err} so we can restore them in tearDown"""
+        self.stdout = sys.stdout
+        self.stderr = sys.stderr
+
+    def tearDown(self):
+        sys.stdout = self.stdout
+        sys.stderr = self.stderr
+
+    def test_paginator_not_available(self):
+        """Check that without paginator command we proceed without changes"""
+        std = output.StdOutput()
+        with mock.patch('avocado.utils.path.find_command',
+                        side_effect=utils_path.CmdNotFoundError('just',
+                                                                ['mocking'])):
+            std.enable_paginator()
+        self.assertEqual(self.stdout, sys.stdout)
+        self.assertEqual(self.stderr, sys.stderr)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This  slightly diverged so it started as "less", but there are several fixes  found while working on it and in travis. See the actual commit messages  for details.


v1: https://github.com/avocado-framework/avocado/pull/2676

changes:

```yaml
v2: Addressed a untreated logger name change in "optional_plugins"
v2: Improved messages/docstrings
v2: Use list instead of string in raised exception
```