### PR TITLE
parser: Suggest installing plugins on missing command

### DIFF
--- a/avocado/core/parser.py
+++ b/avocado/core/parser.py
@@ -39,6 +39,9 @@ class ArgumentParser(argparse.ArgumentParser):
     def error(self, message):
         LOG_UI.debug(self.format_help())
         LOG_UI.error("%s: error: %s", self.prog, message)
+        if "unrecognized arguments" in message:
+            LOG_UI.warning("Perhaps a plugin is missing; run 'avocado"
+                           " plugins' to list the installed ones")
         self.exit(exit_codes.AVOCADO_FAIL)
 
     def _get_option_tuples(self, option_string):

--- a/selftests/functional/test_argument_parsing.py
+++ b/selftests/functional/test_argument_parsing.py
@@ -42,6 +42,7 @@ class ArgumentParsingTest(unittest.TestCase):
         subcommand_error_msg = (b'avocado run: error: unrecognized arguments: '
                                 b'--whacky-argument')
         self.assertIn(subcommand_error_msg, result.stderr)
+        self.assertIn(b"run 'avocado plugins'", result.stderr)
 
 
 class ArgumentParsingErrorEarlyTest(unittest.TestCase):


### PR DESCRIPTION
Many arguments are provided by plugins, let's suggest checking the
installed plugins on unrecognized argument to raise awareness of the
need to install additional plugins which might help people that see
Avocado for the first time.

v1: https://github.com/avocado-framework/avocado/pull/2644

Changes
```yaml
v2: Improved error message
```