### PR TITLE
selftests: Easy a bit the OutputPluginTest.test_broken_pipe test

### DIFF
--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -633,8 +633,6 @@ class OutputPluginTest(unittest.TestCase):
         self.assertEqual(result.exit_status, expected_rc,
                          ("avocado run to broken pipe did not return "
                           "rc %d:\n%s" % (expected_rc, result)))
-        self.assertEqual(len(result.stderr.splitlines()), 1,
-                         "stderr line count is not 1:\n%s" % result.stderr)
         self.assertIn(b"whacky-unknown-command", result.stderr)
         self.assertIn(b"not found", result.stderr)
         self.assertNotIn(b"Avocado crashed", result.stderr)


### PR DESCRIPTION
It has been reported that on some occasions python can report extra
lines when the pipe is broken:

    python2 -c 'print("Hello, World!")' | no-such-command
    -bash: no-such-command: command not found
    close failed in file object destructor:
    sys.excepthook is missing
    lost sys.stderr

Let's remove the check for the number of lines and only keep the check
for unexpected words.

Fixes: https://github.com/avocado-framework/avocado/issues/2671