### PR TITLE
Fix output check recorder encoding

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -83,7 +83,8 @@ class RawFileHandler(logging.FileHandler):
         try:
             msg = self.format(record)
             stream = self.stream
-            stream.write('%s' % msg)
+            stream.write(astring.to_text(msg, self.encoding,
+                                         'xmlcharrefreplace'))
             self.flush()
         except Exception:
             self.handleError(record)
@@ -636,7 +637,8 @@ class Test(unittest.TestCase, TestData):
     def _register_log_file_handler(self, logger, formatter, filename,
                                    log_level=logging.DEBUG, raw=False):
         if raw:
-            file_handler = RawFileHandler(filename=filename)
+            file_handler = RawFileHandler(filename=filename,
+                                          encoding=astring.ENCODING)
         else:
             file_handler = logging.FileHandler(filename=filename)
         file_handler.setLevel(log_level)

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -72,9 +72,6 @@ class RawFileHandler(logging.FileHandler):
     logged stream but still respects the formatter.
     """
 
-    def __init__(self, *args, **kwargs):
-        logging.FileHandler.__init__(self, *args, **kwargs)
-
     def emit(self, record):
         """
         Modifying the original emit() to avoid including a new line

--- a/avocado/utils/script.py
+++ b/avocado/utils/script.py
@@ -39,7 +39,7 @@ class Script(object):
     Class that represents a script.
     """
 
-    def __init__(self, path, content, mode=DEFAULT_MODE):
+    def __init__(self, path, content, mode=DEFAULT_MODE, open_mode='w'):
         """
         Creates an instance of :class:`Script`.
 
@@ -54,6 +54,7 @@ class Script(object):
         self.content = content
         self.mode = mode
         self.stored = False
+        self.open_mode = open_mode
 
     def __repr__(self):
         return '%s(path="%s", stored=%s)' % (self.__class__.__name__,
@@ -78,7 +79,7 @@ class Script(object):
         """
         dirname = os.path.dirname(self.path)
         utils_path.init_dir(dirname)
-        with open(self.path, 'w') as fd:
+        with open(self.path, self.open_mode) as fd:
             fd.write(self.content)
             os.chmod(self.path, self.mode)
             self.stored = True
@@ -104,7 +105,7 @@ class TemporaryScript(Script):
     Class that represents a temporary script.
     """
 
-    def __init__(self, name, content, prefix='avocado_script', mode=DEFAULT_MODE):
+    def __init__(self, name, content, prefix='avocado_script', mode=DEFAULT_MODE, open_mode='w'):
         """
         Creates an instance of :class:`TemporaryScript`.
 
@@ -124,6 +125,7 @@ class TemporaryScript(Script):
         self.content = content
         self.mode = mode
         self.stored = False
+        self.open_mode = open_mode
 
     def __del__(self):
         self.remove()

--- a/avocado/utils/script.py
+++ b/avocado/utils/script.py
@@ -121,11 +121,8 @@ class TemporaryScript(Script):
         :param mode: set file mode, default to 0775.
         """
         tmpdir = tempfile.mkdtemp(prefix=prefix)
-        self.path = os.path.join(tmpdir, name)
-        self.content = content
-        self.mode = mode
-        self.stored = False
-        self.open_mode = open_mode
+        super(TemporaryScript, self).__init__(os.path.join(tmpdir, name),
+                                              content, mode, open_mode)
 
     def __del__(self):
         self.remove()

--- a/selftests/functional/test_output_check.py
+++ b/selftests/functional/test_output_check.py
@@ -14,8 +14,8 @@ basedir = os.path.abspath(basedir)
 
 
 AVOCADO = os.environ.get("UNITTEST_AVOCADO_CMD", "./scripts/avocado")
-OUTPUT_SCRIPT_CONTENTS = """#!/bin/sh
-echo "Hello, avocado!"
+OUTPUT_SCRIPT_CONTENTS = b"""#!/bin/sh
+echo "Hello, \xc4\x9b\xc5\xa1\xc4\x8d\xc5\x99\xc5\xbe\xc3\xbd\xc3\xa1\xc3\xad\xc3\xa9!"
 echo "Hello, stderr!" >&2
 """
 
@@ -27,7 +27,8 @@ class RunnerSimpleTest(unittest.TestCase):
         self.output_script = script.TemporaryScript(
             'output_check.sh',
             OUTPUT_SCRIPT_CONTENTS,
-            'avocado_output_check_functional')
+            'avocado_output_check_functional',
+            open_mode='wb')
         self.output_script.save()
 
     def _check_output_record_all(self):
@@ -170,7 +171,8 @@ class RunnerSimpleTest(unittest.TestCase):
             stdout_diff_content = stdout_diff_obj.read()
         self.assertIn(b'-I PITY THE FOOL THAT STANDS ON STDOUT!',
                       stdout_diff_content)
-        self.assertIn(b'+Hello, avocado!', stdout_diff_content)
+        self.assertIn(b'+Hello, \xc4\x9b\xc5\xa1\xc4\x8d\xc5\x99\xc5\xbe\xc3'
+                      b'\xbd\xc3\xa1\xc3\xad\xc3\xa9!', stdout_diff_content)
 
         with open(stderr_diff, 'rb') as stderr_diff_obj:
             stderr_diff_content = stderr_diff_obj.read()
@@ -182,7 +184,8 @@ class RunnerSimpleTest(unittest.TestCase):
             job_log_content = job_log_obj.read()
         self.assertIn(b'Stdout Diff:', job_log_content)
         self.assertIn(b'-I PITY THE FOOL THAT STANDS ON STDOUT!', job_log_content)
-        self.assertIn(b'+Hello, avocado!', job_log_content)
+        self.assertIn(b'+Hello, \xc4\x9b\xc5\xa1\xc4\x8d\xc5\x99\xc5\xbe\xc3'
+                      b'\xbd\xc3\xa1\xc3\xad\xc3\xa9!', job_log_content)
         self.assertIn(b'Stdout Diff:', job_log_content)
         self.assertIn(b'-I PITY THE FOOL THAT STANDS ON STDERR!', job_log_content)
         self.assertIn(b'+Hello, stderr!', job_log_content)

--- a/selftests/functional/test_output_check.py
+++ b/selftests/functional/test_output_check.py
@@ -14,10 +14,12 @@ basedir = os.path.abspath(basedir)
 
 
 AVOCADO = os.environ.get("UNITTEST_AVOCADO_CMD", "./scripts/avocado")
+STDOUT = b"Hello, \xc4\x9b\xc5\xa1\xc4\x8d\xc5\x99\xc5\xbe\xc3\xbd\xc3\xa1\xc3\xad\xc3\xa9!"
+STDERR = b"Hello, stderr!"
 OUTPUT_SCRIPT_CONTENTS = b"""#!/bin/sh
-echo "Hello, \xc4\x9b\xc5\xa1\xc4\x8d\xc5\x99\xc5\xbe\xc3\xbd\xc3\xa1\xc3\xad\xc3\xa9!"
-echo "Hello, stderr!" >&2
-"""
+echo "%s"
+echo "%s" >&2
+""" % (STDOUT, STDERR)
 
 
 class RunnerSimpleTest(unittest.TestCase):
@@ -43,8 +45,10 @@ class RunnerSimpleTest(unittest.TestCase):
                          (expected_rc, result))
         stdout_file = os.path.join("%s.data/stdout.expected" % self.output_script)
         stderr_file = os.path.join("%s.data/stderr.expected" % self.output_script)
-        self.assertTrue(os.path.isfile(stdout_file))
-        self.assertTrue(os.path.isfile(stderr_file))
+        with open(stdout_file, 'rb') as fd_stdout:
+            self.assertEqual(fd_stdout.read(), STDOUT)
+        with open(stderr_file, 'rb') as fd_stderr:
+            self.assertEqual(fd_stderr.read(), STDERR)
 
     def _check_output_record_combined(self):
         os.chdir(basedir)
@@ -57,7 +61,8 @@ class RunnerSimpleTest(unittest.TestCase):
                          "Avocado did not return rc %d:\n%s" %
                          (expected_rc, result))
         output_file = os.path.join("%s.data/output.expected" % self.output_script)
-        self.assertTrue(os.path.isfile(output_file))
+        with open(output_file, 'rb') as fd_output:
+            self.assertEqual(fd_output.read(), STDOUT + STDERR)
 
     def test_output_record_none(self):
         os.chdir(basedir)
@@ -86,7 +91,8 @@ class RunnerSimpleTest(unittest.TestCase):
                          (expected_rc, result))
         stdout_file = os.path.join("%s.data/stdout.expected" % self.output_script)
         stderr_file = os.path.join("%s.data/stderr.expected" % self.output_script)
-        self.assertTrue(os.path.isfile(stdout_file))
+        with open(stdout_file, 'rb') as fd_stdout:
+            self.assertEqual(fd_stdout.read(), STDOUT)
         self.assertFalse(os.path.isfile(stderr_file))
 
     def test_output_record_and_check(self):
@@ -171,8 +177,7 @@ class RunnerSimpleTest(unittest.TestCase):
             stdout_diff_content = stdout_diff_obj.read()
         self.assertIn(b'-I PITY THE FOOL THAT STANDS ON STDOUT!',
                       stdout_diff_content)
-        self.assertIn(b'+Hello, \xc4\x9b\xc5\xa1\xc4\x8d\xc5\x99\xc5\xbe\xc3'
-                      b'\xbd\xc3\xa1\xc3\xad\xc3\xa9!', stdout_diff_content)
+        self.assertIn(b'+%s' % STDOUT, stdout_diff_content)
 
         with open(stderr_diff, 'rb') as stderr_diff_obj:
             stderr_diff_content = stderr_diff_obj.read()
@@ -184,8 +189,7 @@ class RunnerSimpleTest(unittest.TestCase):
             job_log_content = job_log_obj.read()
         self.assertIn(b'Stdout Diff:', job_log_content)
         self.assertIn(b'-I PITY THE FOOL THAT STANDS ON STDOUT!', job_log_content)
-        self.assertIn(b'+Hello, \xc4\x9b\xc5\xa1\xc4\x8d\xc5\x99\xc5\xbe\xc3'
-                      b'\xbd\xc3\xa1\xc3\xad\xc3\xa9!', job_log_content)
+        self.assertIn(b'+%s' % STDOUT, job_log_content)
         self.assertIn(b'Stdout Diff:', job_log_content)
         self.assertIn(b'-I PITY THE FOOL THAT STANDS ON STDERR!', job_log_content)
         self.assertIn(b'+Hello, stderr!', job_log_content)


### PR DESCRIPTION
We addressed the process encoding almost everywhere, only the RawFileHandler stayed unchanged resulting in non-ascii output not being recorded. Let's use `astring.ENCODING` and just to be sure 'xmlcharrefreplace' to store the output as much as possible (we already mention in documentation that we want to keep this one in text-mode).

The rest of the commits are minor tweaks and fixes needed for selftest purposes.

Fixes: https://github.com/avocado-framework/avocado/pull/2638