### PR TITLE
optional_plugins: Blacklist unsupported versions of PyYAML

### DIFF
--- a/optional_plugins/varianter_yaml_to_mux/setup.py
+++ b/optional_plugins/varianter_yaml_to_mux/setup.py
@@ -24,7 +24,8 @@ setup(name='avocado-framework-plugin-varianter-yaml-to-mux',
       url='http://avocado-framework.github.io/',
       packages=find_packages(exclude=('tests*',)),
       include_package_data=True,
-      install_requires=['avocado-framework', 'PyYAML'],
+      install_requires=['avocado-framework',
+                        'PyYAML>=3.10,!=4.0,!=4.1,!=4.2b1'],
       test_suite='tests',
       entry_points={
           "avocado.plugins.cli": [


### PR DESCRIPTION
The PyYAML-4.0 to PyYAML-4.2b1 lack "construct_python_str" which is used
in varianter_yaml_to_mux. Note that 4.0 nor 4.1 were ever released on
pip but they exist in some distributions, therefor it makes sense to
include them here.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>