### PR TITLE
optional_plugins.remote_runner: Respect ~/.ssh/config

### DIFF
--- a/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
+++ b/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
@@ -177,7 +177,8 @@ def _update_fabric_env(method):
                               user=args[0].username,
                               key_filename=args[0].key_filename,
                               password=args[0].password,
-                              port=args[0].port)
+                              port=args[0].port,
+                              use_ssh_config=True)
         return method(*args, **kwargs)
     return wrapper
 

--- a/optional_plugins/runner_remote/setup.py
+++ b/optional_plugins/runner_remote/setup.py
@@ -22,9 +22,9 @@ from setuptools import setup, find_packages
 
 detected_distro = distro.detect()
 if detected_distro.name == 'fedora' and int(detected_distro.version) >= 29:
-    fabric = 'Fabric3<2.0.0'
+    fabric = 'Fabric3>=1.5.4,<2.0.0'
 else:
-    fabric = 'fabric<2.0.0'
+    fabric = 'fabric>=1.5.4,<2.0.0'
 
 
 setup(name='avocado-framework-plugin-runner-remote',


### PR DESCRIPTION
Respect the "~/.ssh/config" files when using remote runner to allow
users to configure their connection details.

Fixes: https://github.com/avocado-framework/avocado/issues/2141