### PR TITLE
Tags for remote runner [v2]

### DIFF
--- a/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
+++ b/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
@@ -433,12 +433,14 @@ class RemoteTestRunner(TestRunner):
         :return: a dictionary with test results.
         """
         extra_params = []
-        mux_files = getattr(self.job.args, 'mux_yaml', [])
-        if mux_files:
-            extra_params.append("-m %s" % " ".join(mux_files))
+        for arg in ["--mux-yaml", "--dry-run"]:
+            key = arg[2:].replace('-', '_')
+            value = getattr(self.job.args, key, None)
+            if value is True:
+                extra_params.append(arg)
+            elif value:
+                extra_params.append("%s %s" % (arg, " ".join(value)))
 
-        if getattr(self.job.args, "dry_run", False):
-            extra_params.append("--dry-run")
         references_str = " ".join(references)
 
         avocado_cmd = ('avocado run --force-job-id %s --json - '

--- a/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
+++ b/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
@@ -432,14 +432,27 @@ class RemoteTestRunner(TestRunner):
         :param references: a string with test references.
         :return: a dictionary with test results.
         """
+        def arg_to_dest(arg):
+            """
+            Turns long argparse arguments into default dest
+            """
+            return arg[2:].replace('-', '_')
+
         extra_params = []
-        for arg in ["--mux-yaml", "--dry-run"]:
-            key = arg[2:].replace('-', '_')
-            value = getattr(self.job.args, key, None)
+        # bool or nargs
+        for arg in ["--mux-yaml", "--dry-run",
+                    "--filter-by-tags-include-empty"]:
+            value = getattr(self.job.args, arg_to_dest(arg), None)
             if value is True:
                 extra_params.append(arg)
             elif value:
                 extra_params.append("%s %s" % (arg, " ".join(value)))
+        # append
+        for arg in ["--filter-by-tags"]:
+            value = getattr(self.job.args, arg_to_dest(arg), None)
+            if value:
+                join = ' %s ' % arg
+                extra_params.append("%s %s" % (arg, join.join(value)))
 
         references_str = " ".join(references)
 

--- a/optional_plugins/runner_remote/tests/test_remote.py
+++ b/optional_plugins/runner_remote/tests/test_remote.py
@@ -98,7 +98,7 @@ class RemoteTestRunnerTest(unittest.TestCase):
             cmd_line = ('avocado run --force-job-id '
                         '0000000000000000000000000000000000000000 --json - '
                         '--archive /tests/sleeptest.py /tests/other/test '
-                        'passtest.py -m ~/avocado/tests/foo.yaml '
+                        'passtest.py --mux-yaml ~/avocado/tests/foo.yaml '
                         '~/avocado/tests/bar/baz.yaml --dry-run')
             runner.remote.run.assert_called_with(cmd_line,
                                                  ignore_status=True,

--- a/optional_plugins/runner_remote/tests/test_remote.py
+++ b/optional_plugins/runner_remote/tests/test_remote.py
@@ -58,6 +58,8 @@ class RemoteTestRunnerTest(unittest.TestCase):
                                       show_job_log=False,
                                       mux_yaml=['~/avocado/tests/foo.yaml',
                                                 '~/avocado/tests/bar/baz.yaml'],
+                                      filter_by_tags=["-foo", "-bar"],
+                                      filter_by_tags_include_empty=False,
                                       dry_run=True,
                                       env_keep=None,
                                       reference=['/tests/sleeptest.py',
@@ -99,7 +101,8 @@ class RemoteTestRunnerTest(unittest.TestCase):
                         '0000000000000000000000000000000000000000 --json - '
                         '--archive /tests/sleeptest.py /tests/other/test '
                         'passtest.py --mux-yaml ~/avocado/tests/foo.yaml '
-                        '~/avocado/tests/bar/baz.yaml --dry-run')
+                        '~/avocado/tests/bar/baz.yaml --dry-run --filter-'
+                        'by-tags -foo --filter-by-tags -bar')
             runner.remote.run.assert_called_with(cmd_line,
                                                  ignore_status=True,
                                                  timeout=61)


### PR DESCRIPTION
Add support for "--filter-by-tags" and automates the way arguments are whitelisted.

Fixes: https://github.com/avocado-framework/avocado/issues/2704

Changes:

```yaml
v2: Repeat `--filter-by-tags` per each item as it uses `action=store` and not `nargs+`
```