### PR TITLE
Remote runner: use fabric >= 2.0.0 on non-Fedora systems

### DIFF
--- a/optional_plugins/runner_remote/setup.py
+++ b/optional_plugins/runner_remote/setup.py
@@ -20,11 +20,13 @@ from avocado.utils import distro
 
 from setuptools import setup, find_packages
 
+fabric = 'fabric>=2.0.0'
 detected_distro = distro.detect()
-if detected_distro.name == 'fedora' and int(detected_distro.version) >= 29:
-    fabric = 'Fabric3>=1.5.4,<2.0.0'
-else:
-    fabric = 'fabric>=1.5.4,<2.0.0'
+if detected_distro.name == 'fedora':
+    if int(detected_distro.version) >= 29:
+        fabric = 'Fabric3>=1.5.4,<2.0.0'
+    else:
+        fabric = 'fabric>=1.5.4,<2.0.0'
 
 
 setup(name='avocado-framework-plugin-runner-remote',

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,7 +1,6 @@
 # All pip installable requirements pinned for Travis CI
 pycodestyle==2.4.0
-fabric==1.11.1; python_version <= '2.7'
-Fabric3==1.13.1.post1; python_version >= '3.4'
+fabric>=2.0.0
 Sphinx==1.3b1
 inspektor==0.5.1
 pep8==1.6.2


### PR DESCRIPTION
The packaging of fabric on Fedora is a beast, but on other
platforms, when using pip to fulfill the deps, we should start
with fabric 2.0.0, which supports both Python 2.7 and 3.4+.

Reference: https://trello.com/c/Em5AMtfg/1373-wrong-fabric-version-on-python-3
Signed-off-by: Cleber Rosa <crosa@redhat.com>