### PR TITLE
Remote runner: provide fabric version for Python 3 on non-Fedora

### DIFF
--- a/optional_plugins/runner_remote/setup.py
+++ b/optional_plugins/runner_remote/setup.py
@@ -20,11 +20,13 @@ from avocado.utils import distro
 
 from setuptools import setup, find_packages
 
-detected_distro = distro.detect()
-if detected_distro.name == 'fedora' and int(detected_distro.version) >= 29:
-    fabric = 'Fabric3>=1.5.4,<2.0.0'
+if sys.version_info[0] == 3:
+    fabric = 'Fabric3'
 else:
     fabric = 'fabric>=1.5.4,<2.0.0'
+detected_distro = distro.detect()
+if detected_distro.name == 'fedora' and int(detected_distro.version) >= 29:
+    fabric = 'Fabric3>=1.1.4,<2.0.0'
 
 
 setup(name='avocado-framework-plugin-runner-remote',


### PR DESCRIPTION
Fedora 29 (currently rawhide) has a python2-fabric3 package, so it can
use that (Fabric3) as a requirement on both Python 2.7 and 3.4+.  But
we have not switched to Fabric3 on other environments, so let's keep
the fabric (1.x) series there.

Signed-off-by: Cleber Rosa <crosa@redhat.com>