### PR TITLE
Travis CI: pin pylint version

### DIFF
--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,5 +1,6 @@
 # All pip installable requirements pinned for Travis CI
 pycodestyle==2.4.0
+pylint==1.9.2
 fabric==1.11.1; python_version <= '2.7'
 Fabric3==1.13.1.post1; python_version >= '3.4'
 Sphinx==1.3b1


### PR DESCRIPTION
Avocado uses inspekt, which in turn uses pylint.  On Travis-CI under
Python 2.7, pylint 1.9.2 is being used, while on Python 3.4 it's
installing 2.0.0.

The pylint 2.0.0 API is different, and produces the following error:

   Running 'inspekt lint --exclude=.git --enable W0101,W0102,W0404,W0611,W0612,W0622'
   Pylint disabled: W,R,C,E1002,E1101,E1103,E1120,F0401,I0011
   Pylint enabled : W0101,W0102,W0404,W0611,W0612,W0622
   __init__() got an unexpected keyword argument 'exit'
   lint FAILED

Let's pin the pylint version for predictable results, as we do with
pycodestyle.

Reference: https://trello.com/c/LDbYJFeR/1374-lint-failed-on-python-3
Signed-off-by: Cleber Rosa <crosa@redhat.com>