### PR TITLE
[DO NOT MERGE] Travis CI tests

### DIFF
--- a/optional_plugins/runner_remote/setup.py
+++ b/optional_plugins/runner_remote/setup.py
@@ -20,11 +20,13 @@ from avocado.utils import distro
 
 from setuptools import setup, find_packages
 
-detected_distro = distro.detect()
-if detected_distro.name == 'fedora' and int(detected_distro.version) >= 29:
-    fabric = 'Fabric3>=1.5.4,<2.0.0'
+if sys.version_info[0] == 3:
+    fabric = 'Fabric3'
 else:
     fabric = 'fabric>=1.5.4,<2.0.0'
+detected_distro = distro.detect()
+if detected_distro.name == 'fedora' and int(detected_distro.version) >= 29:
+    fabric = 'Fabric3>=1.1.4,<2.0.0'
 
 
 setup(name='avocado-framework-plugin-runner-remote',

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,5 +1,6 @@
 # All pip installable requirements pinned for Travis CI
 pycodestyle==2.4.0
+pylint==1.9.2
 fabric==1.11.1; python_version <= '2.7'
 Fabric3==1.13.1.post1; python_version >= '3.4'
 Sphinx==1.3b1

--- a/selftests/functional/test_output_check.py
+++ b/selftests/functional/test_output_check.py
@@ -16,19 +16,17 @@ basedir = os.path.abspath(basedir)
 AVOCADO = os.environ.get("UNITTEST_AVOCADO_CMD", "./scripts/avocado")
 STDOUT = b"Hello, \xc4\x9b\xc5\xa1\xc4\x8d\xc5\x99\xc5\xbe\xc3\xbd\xc3\xa1\xc3\xad\xc3\xa9!"
 STDERR = b"Hello, stderr!"
-OUTPUT_SCRIPT_CONTENTS = b"""#!/bin/sh
-echo "%s"
-echo "%s" >&2
-""" % (STDOUT, STDERR)
-
 
 class RunnerSimpleTest(unittest.TestCase):
 
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        content = b"#!/bin/sh\n"
+        content += b"echo \"" + STDOUT + b"\"\n"
+        content += b"echo \"" + STDERR + b"\" >&2\n"
         self.output_script = script.TemporaryScript(
             'output_check.sh',
-            OUTPUT_SCRIPT_CONTENTS,
+            content,
             'avocado_output_check_functional',
             open_mode='wb')
         self.output_script.save()
@@ -177,7 +175,7 @@ class RunnerSimpleTest(unittest.TestCase):
             stdout_diff_content = stdout_diff_obj.read()
         self.assertIn(b'-I PITY THE FOOL THAT STANDS ON STDOUT!',
                       stdout_diff_content)
-        self.assertIn(b'+%s' % STDOUT, stdout_diff_content)
+        self.assertIn(b'+' + STDOUT, stdout_diff_content)
 
         with open(stderr_diff, 'rb') as stderr_diff_obj:
             stderr_diff_content = stderr_diff_obj.read()
@@ -189,10 +187,10 @@ class RunnerSimpleTest(unittest.TestCase):
             job_log_content = job_log_obj.read()
         self.assertIn(b'Stdout Diff:', job_log_content)
         self.assertIn(b'-I PITY THE FOOL THAT STANDS ON STDOUT!', job_log_content)
-        self.assertIn(b'+%s' % STDOUT, job_log_content)
+        self.assertIn(b'+' + STDOUT, job_log_content)
         self.assertIn(b'Stdout Diff:', job_log_content)
         self.assertIn(b'-I PITY THE FOOL THAT STANDS ON STDERR!', job_log_content)
-        self.assertIn(b'+Hello, stderr!', job_log_content)
+        self.assertIn(b'+' + STDERR, job_log_content)
 
     def test_disable_output_check(self):
         self._check_output_record_all()


### PR DESCRIPTION
This is a collection of commits:

------------------------------------------------------------------------------

Remote runner: provide fabric version for Python 3 on non-Fedora

Fedora 29 (currently rawhide) has a python2-fabric3 package, so it can
use that (Fabric3) as a requirement on both Python 2.7 and 3.4+.  But
we have not switched to Fabric3 on other environments, so let's keep
the fabric (1.x) series there.

Signed-off-by: Cleber Rosa <crosa@redhat.com>

------------------------------------------------------------------------------

Travis CI: pin pylint version

Avocado uses inspekt, which in turn uses pylint.  On Travis-CI under
Python 2.7, pylint 1.9.2 is being used, while on Python 3.4 it's
installing 2.0.0.

The pylint 2.0.0 API is different, and produces the following error:

   Running 'inspekt lint --exclude=.git --enable W0101,W0102,W0404,W0611,W0612,W0622'
   Pylint disabled: W,R,C,E1002,E1101,E1103,E1120,F0401,I0011
   Pylint enabled : W0101,W0102,W0404,W0611,W0612,W0622
   __init__() got an unexpected keyword argument 'exit'
   lint FAILED

Let's pin the pylint version for predictable results, as we do with
pycodestyle.

Reference: https://trello.com/c/LDbYJFeR/1374-lint-failed-on-python-3
Signed-off-by: Cleber Rosa <crosa@redhat.com>