### PR TITLE
Travis: add pypy2.7 coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: python
 
-virtualenv:
-  system_site_packages: true
+matrix:
+  allow_failures:
+    - python: "pypy"
 
 python:
     - "2.7"
     - "3.4"
+    - "pypy"
 
 branches:
     only:


### PR DESCRIPTION
I was positively surprised at how Avocado runs under pypy2.7.  Based
on my brief experience, it can help uncover issues that won't be
aparent under CPython.

Let's add a pypy2.7 job, allowing for failures at this point.

Signed-off-by: Cleber Rosa <crosa@redhat.com>