### PR TITLE
small improvements to selftests

### DIFF
--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -528,7 +528,8 @@ class RunnerOperationTest(unittest.TestCase):
         # from test.
         for line in ("/:foo ==> 1", "/:baz ==> 3", "/foo:foo ==> a",
                      "/foo:bar ==> b", "/foo:baz ==> c", "/bar:bar ==> bar"):
-            self.assertEqual(log.count(line), 4)
+            self.assertEqual(log.count(line), 4,
+                             "Avocado log count for param '%s' not as expected:\n%s" % (line, log))
 
     def test_invalid_python(self):
         test = script.make_script(os.path.join(self.tmpdir, 'test.py'),

--- a/selftests/functional/test_skiptests.py
+++ b/selftests/functional/test_skiptests.py
@@ -127,7 +127,7 @@ class TestSkipDecorators(unittest.TestCase):
 
     def test_skip_setup(self):
         os.chdir(basedir)
-        cmd_line = ['./scripts/avocado',
+        cmd_line = [AVOCADO,
                     'run',
                     '--sysinfo=off',
                     '--job-results-dir',
@@ -141,7 +141,7 @@ class TestSkipDecorators(unittest.TestCase):
 
     def test_skip_teardown(self):
         os.chdir(basedir)
-        cmd_line = ['./scripts/avocado',
+        cmd_line = [AVOCADO,
                     'run',
                     '--sysinfo=off',
                     '--job-results-dir',

--- a/selftests/functional/test_utils.py
+++ b/selftests/functional/test_utils.py
@@ -20,7 +20,7 @@ DEFAULT_MODE = (stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR |
                 stat.S_IRGRP | stat.S_IWGRP | stat.S_IXGRP |
                 stat.S_IROTH | stat.S_IXOTH)
 
-FAKE_VMSTAT_CONTENTS = """#!/usr/bin/env python
+FAKE_VMSTAT_CONTENTS = """#!{python}
 import time
 import random
 import signal
@@ -115,13 +115,13 @@ class FakeVMStat(object):
 if __name__ == '__main__':
     vmstat = FakeVMStat(interval=float(sys.argv[1]))
     vmstat.start()
-"""
+""".format(python=sys.executable)
 
-FAKE_UPTIME_CONTENTS = """#!/usr/bin/env python
+FAKE_UPTIME_CONTENTS = """#!{python}
 if __name__ == '__main__':
     print("17:56:34 up  8:06,  7 users,  load average: 0.26, 0.20, 0.21")
 
-"""
+""".format(python=sys.executable)
 
 
 class ProcessTest(unittest.TestCase):

--- a/selftests/run
+++ b/selftests/run
@@ -59,7 +59,7 @@ class MyResult(unittest.TextTestResult):
                          stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE).communicate()
         # ... and check whether some dirs were left behind
-        dir_check = subprocess.Popen([CHECK_TMP_DIRS], stdout=subprocess.PIPE,
+        dir_check = subprocess.Popen([sys.executable, CHECK_TMP_DIRS], stdout=subprocess.PIPE,
                                      stderr=subprocess.STDOUT)
         if dir_check.wait():
             raise AssertionError("Test %s left some tmp files behind:\n%s"


### PR DESCRIPTION
This PR makes sure the currently running version of the Python interpreter is used to execute certain test scripts. This becomes absolutely necessary in Fedora Rawhide because `/usr/bin/python` no longer exists.

This PR also updates an assertion in `test_dry_run()` in `selftests/functional/test_basic.py` to report diagnostic information to help determine _why_ the assertion failed.