### PR TITLE
PEP479: do not raise StopIteration

### DIFF
--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -274,7 +274,7 @@ class TreeNode(object):
         node = self.parent
         while True:
             if node is None:
-                raise StopIteration
+                return
             yield node
             node = node.parent
 

--- a/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/mux.py
+++ b/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/mux.py
@@ -73,7 +73,7 @@ class MuxTree(object):
             try:
                 node = queue.popleft()
             except IndexError:
-                raise StopIteration
+                return
 
     def __iter__(self):
         """
@@ -101,7 +101,10 @@ class MuxTree(object):
                 pools.append([pool])
         variants = itertools.product(*pools)
         while True:
-            yield list(itertools.chain(*next(variants)))
+            try:
+                yield list(itertools.chain(*next(variants)))
+            except StopIteration:
+                return
 
     @staticmethod
     def _valid_variant(variant):
@@ -310,7 +313,6 @@ class ValueDict(dict):  # only container pylint: disable=R0903
         """ Slower implementation with the use of __getitem__ """
         for key in iterkeys(self):
             yield key, self[key]
-        raise StopIteration
 
 
 class Control(object):  # Few methods pylint: disable=R0903


### PR DESCRIPTION
Raising StopIteration gets translated to a RuntimeError in Python 3.7.
The same behavior can be achieved by 'return' from generators.

Reference: https://github.com/avocado-framework/avocado/issues/2721
Signed-off-by: Cleber Rosa <crosa@redhat.com>