### PR TITLE
selftests/functional/test_basic.py: prevent unversioned Python

### DIFF
--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -730,7 +730,9 @@ class RunnerSimpleTest(unittest.TestCase):
         simplewarning.sh uses the avocado-bash-utils
         """
         # simplewarning.sh calls "avocado" without specifying a path
-        os.environ['PATH'] += ":" + os.path.join(basedir, 'scripts')
+        # let's add the path that was defined at the global module
+        # scope here
+        os.environ['PATH'] += ":" + os.path.dirname(AVOCADO)
         # simplewarning.sh calls "avocado exec-path" which hasn't
         # access to an installed location for the libexec scripts
         os.environ['PATH'] += ":" + os.path.join(basedir, 'libexec')


### PR DESCRIPTION
`examples/tests/simplewarning.sh` calls a generic avocado command,
which gets added to the path by the test code. That generic avocado
command is `scripts/avocado`, from the source repository, which
contains the unversioned `/usr/bin/env python`.

Under some environments, such as Fedora >= 29, there may be no
unversioned Python binary.  Let's respect the UNITTEST_AVOCADO_CMD
environment variable, and add the the directory containting that
binary to the PATH.

Signed-off-by: Cleber Rosa <crosa@redhat.com>