### PR TITLE
[DONT_MERGE] ISO9660: add a pycdlib backend

### DIFF
--- a/avocado/utils/iso9660.py
+++ b/avocado/utils/iso9660.py
@@ -23,14 +23,21 @@ either in userspace tools or on the Linux kernel itself (via mount).
 
 __all__ = ['iso9660', 'Iso9660IsoInfo', 'Iso9660IsoRead', 'Iso9660Mount']
 
-import os
+import io
 import logging
-import tempfile
+import os
+import re
 import shutil
 import sys
-import re
+import tempfile
 
 from . import process
+
+
+try:
+    import pycdlib              # pylint: disable=W0612
+except ImportError:
+    pass
 
 
 def has_userland_tool(executable):
@@ -72,6 +79,19 @@ def has_isoread():
     :rtype: bool
     """
     return has_userland_tool('iso-read')
+
+
+def has_pycdlib():
+    """
+    Returns whether the system has the Python "pycdlib" library
+
+    :rtype: bool
+    """
+    try:
+        import pycdlib          # pylint: disable=W0612
+    except ImportError:
+        return False
+    return True
 
 
 def can_mount():
@@ -366,6 +386,39 @@ class Iso9660Mount(BaseIso9660):
         return self._mnt_dir
 
 
+class ISO9660PyCDLib(BaseIso9660):
+
+    """
+    Represents a ISO9660 filesystem
+
+    This implementation is based on the pycdlib library
+    """
+
+    def __init__(self, path):
+        if not has_pycdlib():
+            raise RuntimeError('This class requires the pycdlib library')
+        self._iso = pycdlib.PyCdlib()
+        self._iso.open(path)
+        self._iso_closed = False
+
+    def read(self, path):
+        if not os.path.isabs(path):
+            path = '/' + path
+        data = io.BytesIO()
+        self._iso.get_file_from_iso_fp(data, joliet_path=path)
+        return data.getvalue()
+
+    def copy(self, src, dst):
+        if not os.path.isabs(src):
+            src = '/' + src
+        self._iso.get_file_from_iso(dst, joliet_path=src)
+
+    def close(self):
+        if not self._iso_closed:
+            self._iso.close()
+        self._iso_closed = True
+
+
 def iso9660(path):
     """
     Checks the available tools on a system and chooses class accordingly
@@ -379,7 +432,8 @@ def iso9660(path):
     :rtype: :class:`Iso9660IsoInfo`, :class:`Iso9660IsoRead`,
             :class:`Iso9660Mount` or None
     """
-    implementations = [('isoinfo', has_isoinfo, Iso9660IsoInfo),
+    implementations = [('pycdlib', has_pycdlib, ISO9660PyCDLib),
+                       ('isoinfo', has_isoinfo, Iso9660IsoInfo),
                        ('iso-read', has_isoread, Iso9660IsoRead),
                        ('mount', can_mount, Iso9660Mount)]
 

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -24,3 +24,4 @@ lxml>=3.4.4
 # pkg_resources.packaging, let's pin the version
 setuptools==25.1.1
 libvirt-python==3.6.0
+-e git+https://github.com/clalancette/pycdlib#egg=pycdlib

--- a/selftests/unit/test_utils_iso9660.py
+++ b/selftests/unit/test_utils_iso9660.py
@@ -127,5 +127,21 @@ class IsoMount(BaseIso9660):
         self.mnt_dir_workflow()
 
 
+class PyCDLib(BaseIso9660):
+
+    """
+    PyCDLib-based check
+    """
+
+    @unittest.skipUnless(iso9660.has_pycdlib(), "pycdlib not installed")
+    def setUp(self):
+        super(PyCDLib, self).setUp()
+        self.iso = iso9660.ISO9660PyCDLib(self.iso_path)
+
+    def test_basic_workflow(self):
+        """Call the basic workflow"""
+        self.basic_workflow()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This implements another backend for the avocado.utils.iso9660 library,
based on the pure Python pycdlib.

The library, as it's the case with all other ISO9660 utilities, is
optional and should only attempted to be be used if they are available
in the system.

In theory, we're well equipped with backends, but this brings the
interesting possibility of running on non-UNIX platforms.

Signed-off-by: Cleber Rosa <crosa@redhat.com>