### PR TITLE
Makefile: Make sure to use pip of the same version as python

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -29,8 +29,8 @@ pip:
 	$(PYTHON) -m pip --version || $(PYTHON) -m ensurepip $(PYTHON_DEVELOP_ARGS) || $(PYTHON) -c "import os; import sys; import urllib; f = urllib.urlretrieve('https://bootstrap.pypa.io/get-pip.py')[0]; os.system('%s %s' % (sys.executable, f))"
 
 requirements: pip
-	- pip install "pip>=6.0.1"
-	- pip install -r requirements.txt
+	- $(PYTHON) -m pip install "pip>=6.0.1"
+	- $(PYTHON) -m pip install -r requirements.txt
 
 requirements-selftests: requirements
-	- pip install -r requirements-selftests.txt
+	- $(PYTHON) -m pip install -r requirements-selftests.txt


### PR DESCRIPTION
Some systems don't ship with "pip" binary and only provide the "pip3".
Instead of attempting to get the right one, let's just use "python -m
pip" that should work the same way plus we always use the right version
(py2/py3).

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>
Signed-off-by: Cleber Rosa <crosa@redhat.com>