### PR TITLE
[PoC] ISO9660: add create/write capabilities

### DIFF
--- a/avocado/utils/iso9660.py
+++ b/avocado/utils/iso9660.py
@@ -415,6 +415,11 @@ class ISO9660PyCDLib(BaseIso9660):
     def create(self):
         self._open_for_create()
 
+    def write(self, path, content):
+        self._open_for_create()
+        self._iso.add_fp(io.BytesIO(content), len(content),
+                         iso_path=path, joliet_path=path)
+
     def read(self, path):
         self._open_for_read()
         if not os.path.isabs(path):
@@ -459,7 +464,7 @@ def iso9660(path, capabilities=None):
     common_capabilities = ["read", "copy", "mnt_dir"]
 
     implementations = [('pycdlib', has_pycdlib, ISO9660PyCDLib,
-                        common_capabilities + ["create"]),
+                        common_capabilities + ["create", "write"]),
 
                        ('isoinfo', has_isoinfo, Iso9660IsoInfo,
                         common_capabilities),

--- a/avocado/utils/iso9660.py
+++ b/avocado/utils/iso9660.py
@@ -416,7 +416,7 @@ class ISO9660PyCDLib(BaseIso9660):
         self._iso_closed = True
 
 
-def iso9660(path):
+def iso9660(path, capabilities=None):
     """
     Checks the available tools on a system and chooses class accordingly
 
@@ -425,16 +425,32 @@ def iso9660(path):
 
     :param path: path to an iso9660 image file
     :type path: str
+    :param capabilities: list of specific capabilities that
+                         are required for the picked implementation,
+                         such as "read", "copy", "mnt_dir".
+    :type capabilities: list
     :return: an instance of any iso9660 capable tool
     :rtype: :class:`Iso9660IsoInfo`, :class:`Iso9660IsoRead`,
             :class:`Iso9660Mount` or None
     """
-    implementations = [('pycdlib', has_pycdlib, ISO9660PyCDLib),
-                       ('isoinfo', has_isoinfo, Iso9660IsoInfo),
-                       ('iso-read', has_isoread, Iso9660IsoRead),
-                       ('mount', can_mount, Iso9660Mount)]
+    # all implementations so far have these base capabilities
+    common_capabilities = ["read", "copy", "mnt_dir"]
 
-    for (name, check, klass) in implementations:
+    implementations = [('pycdlib', has_pycdlib, ISO9660PyCDLib,
+                        common_capabilities),
+
+                       ('isoinfo', has_isoinfo, Iso9660IsoInfo,
+                        common_capabilities),
+
+                       ('iso-read', has_isoread, Iso9660IsoRead,
+                        common_capabilities),
+
+                       ('mount', can_mount, Iso9660Mount,
+                        common_capabilities)]
+
+    for (name, check, klass, cap) in implementations:
+        if capabilities is not None and not set(capabilities).issubset(cap):
+            continue
         if check():
             logging.debug('Automatically chosen class for iso9660: %s', name)
             return klass(path)

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -24,3 +24,4 @@ lxml>=3.4.4
 # pkg_resources.packaging, let's pin the version
 setuptools==25.1.1
 libvirt-python==3.6.0
+pycdlib==1.6.0

--- a/selftests/unit/test_utils_iso9660.py
+++ b/selftests/unit/test_utils_iso9660.py
@@ -160,11 +160,16 @@ class PyCDLib(BaseIso9660):
         """Call the basic workflow"""
         self.basic_workflow()
 
-    def test_create(self):
+    def test_create_write(self):
         new_iso_path = os.path.join(self.tmpdir, 'new.iso')
         new_iso = iso9660.ISO9660PyCDLib(new_iso_path)
         new_iso.create()
+        path = "/README"
+        content = b"AVOCADO"
+        new_iso.write(path, content)
         new_iso.close()
+        read_iso = iso9660.ISO9660PyCDLib(new_iso_path)
+        self.assertEqual(read_iso.read(path), content)
         self.assertTrue(os.path.isfile(new_iso_path))
 
 

--- a/selftests/unit/test_utils_iso9660.py
+++ b/selftests/unit/test_utils_iso9660.py
@@ -127,5 +127,21 @@ class IsoMount(BaseIso9660):
         self.mnt_dir_workflow()
 
 
+class PyCDLib(BaseIso9660):
+
+    """
+    PyCDLib-based check
+    """
+
+    @unittest.skipUnless(iso9660.has_pycdlib(), "pycdlib not installed")
+    def setUp(self):
+        super(PyCDLib, self).setUp()
+        self.iso = iso9660.ISO9660PyCDLib(self.iso_path)
+
+    def test_basic_workflow(self):
+        """Call the basic workflow"""
+        self.basic_workflow()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/selftests/unit/test_utils_iso9660.py
+++ b/selftests/unit/test_utils_iso9660.py
@@ -9,6 +9,24 @@ import unittest
 from avocado.utils import iso9660, process
 
 
+class Capabilities(unittest.TestCase):
+
+    def setUp(self):
+        self.iso_path = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                                     os.path.pardir, ".data",
+                                                     "sample.iso"))
+
+    def test_common_capabilities(self):
+        none_cap = iso9660.iso9660(self.iso_path)
+        read_cap = iso9660.iso9660(self.iso_path, ['read'])
+        if not (none_cap is None and read_cap is None):
+            self.assertEqual(none_cap.__class__, read_cap.__class__)
+
+    def test_non_existing_capabilities(self):
+        self.assertIsNone(iso9660.iso9660(self.iso_path,
+                                          ['non-existing', 'capabilities']))
+
+
 class BaseIso9660(unittest.TestCase):
 
     """

--- a/selftests/unit/test_utils_iso9660.py
+++ b/selftests/unit/test_utils_iso9660.py
@@ -160,6 +160,13 @@ class PyCDLib(BaseIso9660):
         """Call the basic workflow"""
         self.basic_workflow()
 
+    def test_create(self):
+        new_iso_path = os.path.join(self.tmpdir, 'new.iso')
+        new_iso = iso9660.ISO9660PyCDLib(new_iso_path)
+        new_iso.create()
+        new_iso.close()
+        self.assertTrue(os.path.isfile(new_iso_path))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The `avocado.utils.iso9660` module has helped, so far, with reading files from ISO archives.  But, it's also pretty common to also have to create ISO archives, and for those, users are left with figuring out the tools available on the system and running `mkisofs`, `genisoimage` and similar tools.

Let's add APIs to allow the creation of ISO images, and a capabilities mechanism to find appropriate implementations.

Note: this is sent as a PoC because it depends on #2738