### PR TITLE
utils.cpu: Custom detection of arm [v2]

### DIFF
--- a/avocado/utils/cpu.py
+++ b/avocado/utils/cpu.py
@@ -136,12 +136,17 @@ def get_cpu_arch():
     cpuinfo = _get_cpu_info()
     for (pattern, arch) in cpu_table:
         if _list_matches(cpuinfo, pattern):
-            # ARM is a special situation, which matches both 32 bits
-            # (v7) and 64 bits (v8).
             if arch == 'arm':
-                arm_v8_arch_name = 'aarch64'
-                if arm_v8_arch_name == platform.machine():
-                    return arm_v8_arch_name
+                # ARM is a special situation, which matches both 32 bits
+                # (v7) and 64 bits (v8).
+                for line in cpuinfo:
+                    if line.startswith(b"CPU architecture"):
+                        version = int(line.split(b':', 1)[1])
+                        if version >= 8:
+                            return 'aarch64'
+                        else:
+                            # For historical reasons return arm
+                            return 'arm'
             return arch
     return platform.machine()
 

--- a/selftests/unit/test_utils_cpu.py
+++ b/selftests/unit/test_utils_cpu.py
@@ -521,9 +521,8 @@ CPU variant     : 0x1
 CPU part        : 0x0a1
 CPU revision    : 1
 """
-        with mock.patch('avocado.utils.cpu.platform.machine', return_value='aarch64'):
-            with mock.patch('avocado.utils.cpu.open',
-                            return_value=self._get_file_mock(cpu_output)):
+        with mock.patch('avocado.utils.cpu.open',
+                        return_value=self._get_file_mock(cpu_output)):
                 self.assertEqual(cpu.get_cpu_arch(), "aarch64")
 
     @unittest.skipUnless(recent_mock(),


### PR DESCRIPTION
Difference between aarch32/64 is fairly simple, let's detect it
ourselves instead of relying on "machine.platform".

Fixes: https://github.com/avocado-framework/avocado/issues/2737

v1: https://github.com/avocado-framework/avocado/pull/2739

Changes:

```yaml
v2: Fixed indentation
v2: Use bytes in "startswith"
```

PS: We could either fix selftest and mock the `machine` call in `arm` case, or avoid the `machine` completely. Here I chose the later as the detection is (currently) fairly simple and we are about to rework it anyway in https://trello.com/c/WbbZw5wq/1213-obsolete-getcpuarch-and-add-2-functions-instead-with-consistent-returns