### PR TITLE
utils/archive: fix extracted folder name

### DIFF
--- a/avocado/utils/archive.py
+++ b/avocado/utils/archive.py
@@ -181,7 +181,7 @@ class ArchiveFile(object):
 
         files = self._engine.getnames()
         if files:
-            return files[0]
+            return files[0].split(os.sep)[0]
         return None
 
     def _update_zip_extra_attrs(self, dst_dir):


### PR DESCRIPTION
returning the extracted folder in a more stable way, the first name
might be the foldername or can be path for a file name so handle
it accordingly.

Example,
stress-ng archive have the foldername as first in the list,

>>> y = tarfile.open('./stress-ng-0.07.14.tar.gz', 'r')
>>> y.getnames()
['stress-ng-0.07.14', 'stress-ng-0.07.14/stress-numa.c',...]

where as iozone have the filename as first in the list,

>>> x = tarfile.open('./iozone3_482.tar', 'r')
>>> x.getnames()
['iozone3_482/src/current/Changes.txt', 'iozone3_482/src/current/iozone.c'...]

This Fix would return proper archive name,

>>> from avocado.utils import archive
>>> archive.uncompress('./iozone3_482.tar', '/var/tmp')
'iozone3_482'
>>> archive.uncompress('./stress-ng-0.07.14.tar.gz', '/var/tmp')
'stress-ng-0.07.14'

Reported-by: Aihua Liang <aliang@redhat.com>
Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>