### PR TITLE
Loader recursive rework partial rebase 

### DIFF
--- a/avocado/core/safeloader.py
+++ b/avocado/core/safeloader.py
@@ -193,14 +193,10 @@ def find_avocado_tests(path, class_name=None):
               force-disabled.
     :rtype: tuple
     """
-    # If only the Test class was imported from the avocado namespace
-    test_import = False
     # The name used, in case of 'from avocado import Test as AvocadoTest'
-    test_import_name = None
-    # If the "avocado" module itself was imported
-    mod_import = False
+    test_import = ""
     # The name used, in case of 'import avocado as avocadolib'
-    mod_import_name = None
+    mod_import = ""
     # The resulting test classes
     result = collections.OrderedDict()
     disabled = set()
@@ -218,22 +214,20 @@ def find_avocado_tests(path, class_name=None):
 
             for name in statement.names:
                 if name.name == 'Test':
-                    test_import = True
                     if name.asname is not None:
-                        test_import_name = name.asname
+                        test_import = name.asname
                     else:
-                        test_import_name = name.name
+                        test_import = name.name
                     break
 
         # Looking for a 'import avocado'
         elif isinstance(statement, ast.Import):
             for name in statement.names:
                 if name.name == 'avocado':
-                    mod_import = True
                     if name.asname is not None:
-                        mod_import_name = name.nasname
+                        mod_import = name.nasname
                     else:
-                        mod_import_name = name.name
+                        mod_import = name.name
 
         # Looking for a 'class Anything(anything):'
         elif isinstance(statement, ast.ClassDef):
@@ -338,7 +332,7 @@ def find_avocado_tests(path, class_name=None):
                 base_ids = [base.id for base in statement.bases
                             if hasattr(base, 'id')]
                 # Looking for a 'class FooTest(Test):'
-                if test_import_name in base_ids:
+                if test_import in base_ids:
                     info = get_methods_info(statement.body,
                                             cl_tags)
                     result[statement.name] = info
@@ -349,7 +343,7 @@ def find_avocado_tests(path, class_name=None):
                 for base in statement.bases:
                     module = base.value.id
                     klass = base.attr
-                    if module == mod_import_name and klass == 'Test':
+                    if module == mod_import and klass == 'Test':
                         info = get_methods_info(statement.body,
                                                 cl_tags)
                         result[statement.name] = info

--- a/avocado/core/safeloader.py
+++ b/avocado/core/safeloader.py
@@ -266,12 +266,11 @@ def find_avocado_tests(path, class_name=None):
 
                 # Searching the parents in the same module
                 for parent in parents[:]:
-                    # Looking for a 'class FooTest(module.Parent)'
-                    if isinstance(parent, ast.Attribute):
-                        parent_class = parent.attr
                     # Looking for a 'class FooTest(Parent)'
-                    else:
-                        parent_class = parent.id
+                    if not isinstance(parent, ast.Name):
+                        # 'class FooTest(bar.Bar)' not supported within a module
+                        continue
+                    parent_class = parent.id
                     res, dis = find_avocado_tests(path, parent_class)
                     if res:
                         parents.remove(parent)
@@ -328,9 +327,10 @@ def find_avocado_tests(path, class_name=None):
 
                 continue
 
+            # Looking for a 'class FooTest(Test):'
             if test_import:
                 base_ids = [base.id for base in statement.bases
-                            if hasattr(base, 'id')]
+                            if isinstance(base, ast.Name)]
                 # Looking for a 'class FooTest(Test):'
                 if test_import in base_ids:
                     info = get_methods_info(statement.body,
@@ -341,6 +341,9 @@ def find_avocado_tests(path, class_name=None):
             # Looking for a 'class FooTest(avocado.Test):'
             if mod_import:
                 for base in statement.bases:
+                    if not isinstance(base, ast.Attribute):
+                        # Check only 'module.Class' bases
+                        continue
                     module = base.value.id
                     klass = base.attr
                     if module == mod_import and klass == 'Test':

--- a/avocado/core/safeloader.py
+++ b/avocado/core/safeloader.py
@@ -225,7 +225,7 @@ def find_avocado_tests(path, class_name=None):
             for name in statement.names:
                 if name.name == 'avocado':
                     if name.asname is not None:
-                        mod_import = name.nasname
+                        mod_import = name.asname
                     else:
                         mod_import = name.name
 

--- a/selftests/.data/loader_instrumented/dont_crash.py
+++ b/selftests/.data/loader_instrumented/dont_crash.py
@@ -1,0 +1,60 @@
+# Having 2 imports forces both paths
+import avocado
+
+
+# Should not be discovered as "Test" import did not happened yet
+class DontCrash0(Test):
+    def test(self):
+        pass
+
+
+from avocado import Test
+
+
+# on "import avocado" this requires some skipping
+class DontCrash1(object):
+    pass
+
+
+# This one should be discovered no matter how other
+# classes break
+class DiscoverMe(avocado.Test):
+    def test(self):
+        pass
+
+
+# The same as "DontCrash1" only this one should be discovered
+class DiscoverMe2(object, avocado.Test, main):  # pylint: disable=E0240,E0602
+    def test(self):
+        pass
+
+
+# The same as "DontCrash1" only this one should be discovered
+class DiscoverMe3(object, Test, main):  # pylint: disable=E0240,E0602
+    def test(self):
+        pass
+
+
+class DontCrash2p(object):
+    class Bar(avocado.Test):
+        def test(self):
+            pass
+
+
+# Only top-level-namespace classes are allowed for
+# in-module-class definitions
+class DontCrash2(DontCrash2p.Bar):
+    """:avocado: recursive"""
+
+
+# Class DiscoverMe4p is defined after this one
+class DiscoverMe4(DiscoverMe4p):    # pylint: disable=E0601
+    """:avocado: recursive"""
+
+
+class DiscoverMe4p(object):
+    def test(self):
+        pass
+
+
+dont_crash3_on_broken_syntax    # pylint: disable=E0602

--- a/selftests/.data/loader_instrumented/double_import.py
+++ b/selftests/.data/loader_instrumented/double_import.py
@@ -1,0 +1,26 @@
+# This currently only discovers 2 tests in avocado due to bug
+import avocado as foo
+import avocado as bar   # pylint: disable=W0404
+
+from avocado import Test as Foo
+from avocado import Test as Bar     # pylint: disable=W0404
+
+
+class Test1(foo.Test):
+    def test1(self):
+        pass
+
+
+class Test2(bar.Test):
+    def test2(self):
+        pass
+
+
+class Test3(Foo):
+    def test3(self):
+        pass
+
+
+class Test4(Bar):
+    def test4(self):
+        pass

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -490,6 +490,17 @@ class LoaderTest(unittest.TestCase):
                 ('DiscoverMe4', 'selftests/.data/loader_instrumented/dont_crash.py:DiscoverMe4.test')]
         self.assertEqual(names, exps)
 
+    def test_double_import(self):
+        # This is currently broken in Avocado, so let's just document the
+        # current behavior.
+        path = os.path.relpath(os.path.join(os.path.dirname(os.path.dirname(__file__)),
+                                            '.data', 'loader_instrumented', 'double_import.py'))
+        tests = self.loader.discover(path)
+        names = [(_[0], _[1]['name']) for _ in tests]
+        exps = [('Test2', 'selftests/.data/loader_instrumented/double_import.py:Test2.test2'),
+                ('Test4', 'selftests/.data/loader_instrumented/double_import.py:Test4.test4')]
+        self.assertEqual(names, exps, tests)
+
     def tearDown(self):
         shutil.rmtree(self.tmpdir)
 

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -479,6 +479,17 @@ class LoaderTest(unittest.TestCase):
                  "test_dir": os.path.dirname(python_unittest.path)})]
         self.assertEqual(tests, exp)
 
+    def test_mod_import_and_classes(self):
+        path = os.path.relpath(os.path.join(os.path.dirname(os.path.dirname(__file__)),
+                                            '.data', 'loader_instrumented', 'dont_crash.py'))
+        tests = self.loader.discover(path)
+        names = [(_[0], _[1]['name']) for _ in tests]
+        exps = [('DiscoverMe', 'selftests/.data/loader_instrumented/dont_crash.py:DiscoverMe.test'),
+                ('DiscoverMe2', 'selftests/.data/loader_instrumented/dont_crash.py:DiscoverMe2.test'),
+                ('DiscoverMe3', 'selftests/.data/loader_instrumented/dont_crash.py:DiscoverMe3.test'),
+                ('DiscoverMe4', 'selftests/.data/loader_instrumented/dont_crash.py:DiscoverMe4.test')]
+        self.assertEqual(names, exps)
+
     def tearDown(self):
         shutil.rmtree(self.tmpdir)
 


### PR DESCRIPTION
This is a partial rebase of the PR #2687.  My goal and intentions in sending those are:

* Add the obvious improvements and fixes on those changes
* Help with the enablement of the "recursive by default" feature in the mentioned PR

The code is basically all of the authorship of @ldoktor, applied to the different location.  The only change is the addition of `os.path.relpath()` in the unittests to adjust for Python 2 and 3 behavioral differences.