### PR TITLE
avocado.utils.network: introduce get_free_port()

### DIFF
--- a/avocado/utils/network.py
+++ b/avocado/utils/network.py
@@ -92,6 +92,22 @@ def find_free_ports(start_port, end_port, count, address="localhost", sequent=Tr
     return ports
 
 
+def get_free_port(address="localhost"):
+    """
+    Returns a free port
+
+    This selects a port from the maximum range of high ports (from
+    1024 to 65535), and should be used when the user is not interested
+    in specifying the range.
+
+    :param address: Socket address to bind or connect
+    :type address: str
+    :returns: the free port number
+    :rtype: int
+    """
+    return find_free_port(1024, 65535, address)
+
+
 class PortTracker(Borg):
 
     """


### PR DESCRIPTION
On many situations, users just need a port, there's no need to pick
from a defined range.  Let's introduce a simpler utility function,
that can be called without any arguments for that use case.

Signed-off-by: Cleber Rosa <crosa@redhat.com>