### PR TITLE
selftests/functional/test_output.py: simplify temporary dir/file usage

### DIFF
--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -335,56 +335,45 @@ class OutputPluginTest(unittest.TestCase):
                       "Missing excerpt error message from output:\n%s" % output)
 
     def test_output_compatible_setup(self):
-        tmpfile = tempfile.mktemp()
+        tmpfile = tempfile.mktemp(dir=self.tmpdir)
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
                     '--journal --xunit %s --json - passtest.py' %
                     (AVOCADO, self.tmpdir, tmpfile))
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout_text + result.stderr_text
         expected_rc = exit_codes.AVOCADO_ALL_OK
-        try:
-            self.assertEqual(result.exit_status, expected_rc,
-                             "Avocado did not return rc %d:\n%s" %
-                             (expected_rc, result))
-            # Check if we are producing valid outputs
-            json.loads(output)
-            minidom.parse(tmpfile)
-        finally:
-            try:
-                os.remove(tmpfile)
-            except OSError:
-                pass
+        self.assertEqual(result.exit_status, expected_rc,
+                         "Avocado did not return rc %d:\n%s" %
+                         (expected_rc, result))
+        # Check if we are producing valid outputs
+        json.loads(output)
+        minidom.parse(tmpfile)
 
     def test_output_compatible_setup_2(self):
-        tmpfile = tempfile.mktemp()
+        tmpfile = tempfile.mktemp(dir=self.tmpdir)
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
                     '--xunit - --json %s --tap-include-logs passtest.py'
                     % (AVOCADO, self.tmpdir, tmpfile))
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout + result.stderr
         expected_rc = exit_codes.AVOCADO_ALL_OK
-        try:
-            self.assertEqual(result.exit_status, expected_rc,
-                             "Avocado did not return rc %d:\n%s" %
-                             (expected_rc, result))
-            # Check if we are producing valid outputs
-            with open(tmpfile, 'r') as fp:
-                json_results = json.load(fp)
-                debug_log = json_results['debuglog']
-                self.check_output_files(debug_log)
-            minidom.parseString(output)
-        finally:
-            try:
-                os.remove(tmpfile)
-            except OSError:
-                pass
+        self.assertEqual(result.exit_status, expected_rc,
+                         "Avocado did not return rc %d:\n%s" %
+                         (expected_rc, result))
+        # Check if we are producing valid outputs
+        with open(tmpfile, 'r') as fp:
+            json_results = json.load(fp)
+            debug_log = json_results['debuglog']
+            self.check_output_files(debug_log)
+        minidom.parseString(output)
 
     @unittest.skipIf(html_uncapable(),
                      "Uncapable of Avocado Result HTML plugin")
     def test_output_compatible_setup_3(self):
-        tmpfile = tempfile.mktemp(prefix='avocado_' + __name__)
-        tmpfile2 = tempfile.mktemp(prefix='avocado_' + __name__)
-        tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        prefix = 'avocado_' + __name__
+        tmpfile = tempfile.mktemp(prefix=prefix, dir=self.tmpdir)
+        tmpfile2 = tempfile.mktemp(prefix=prefix, dir=self.tmpdir)
+        tmpdir = tempfile.mkdtemp(prefix=prefix, dir=self.tmpdir)
         tmpfile3 = os.path.join(tmpdir, "result.html")
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
                     '--xunit %s --json %s --html %s --tap-include-logs '
@@ -397,28 +386,20 @@ class OutputPluginTest(unittest.TestCase):
         self.assertEqual(len(tmpdir_contents), 1, "Html plugin generated "
                          "extra files in the result dir: %s"
                          % tmpdir_contents)
-        try:
-            self.assertEqual(result.exit_status, expected_rc,
-                             "Avocado did not return rc %d:\n%s" %
-                             (expected_rc, result))
-            self.assertNotEqual(output, "", "Output is empty")
-            # Check if we are producing valid outputs
-            with open(tmpfile2, 'r') as fp:
-                json_results = json.load(fp)
-                debug_log = json_results['debuglog']
-                self.check_output_files(debug_log)
-            minidom.parse(tmpfile)
-        finally:
-            try:
-                os.remove(tmpfile)
-                os.remove(tmpfile2)
-                shutil.rmtree(tmpdir)
-            except OSError:
-                pass
+        self.assertEqual(result.exit_status, expected_rc,
+                         "Avocado did not return rc %d:\n%s" %
+                         (expected_rc, result))
+        self.assertNotEqual(output, "", "Output is empty")
+        # Check if we are producing valid outputs
+        with open(tmpfile2, 'r') as fp:
+            json_results = json.load(fp)
+            debug_log = json_results['debuglog']
+            self.check_output_files(debug_log)
+        minidom.parse(tmpfile)
 
     def test_output_compatible_setup_nooutput(self):
-        tmpfile = tempfile.mktemp()
-        tmpfile2 = tempfile.mktemp()
+        tmpfile = tempfile.mktemp(dir=self.tmpdir)
+        tmpfile2 = tempfile.mktemp(dir=self.tmpdir)
         # Verify --silent can be supplied as app argument
         cmd_line = ('%s --silent run --job-results-dir %s '
                     '--sysinfo=off --xunit %s --json %s --tap-include-logs '
@@ -426,23 +407,16 @@ class OutputPluginTest(unittest.TestCase):
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout + result.stderr
         expected_rc = exit_codes.AVOCADO_ALL_OK
-        try:
-            self.assertEqual(result.exit_status, expected_rc,
-                             "Avocado did not return rc %d:\n%s" %
-                             (expected_rc, result))
-            self.assertEqual(output, b"", "Output is not empty:\n%s" % output)
-            # Check if we are producing valid outputs
-            with open(tmpfile2, 'r') as fp:
-                json_results = json.load(fp)
-                debug_log = json_results['debuglog']
-                self.check_output_files(debug_log)
-            minidom.parse(tmpfile)
-        finally:
-            try:
-                os.remove(tmpfile)
-                os.remove(tmpfile2)
-            except OSError:
-                pass
+        self.assertEqual(result.exit_status, expected_rc,
+                         "Avocado did not return rc %d:\n%s" %
+                         (expected_rc, result))
+        self.assertEqual(output, b"", "Output is not empty:\n%s" % output)
+        # Check if we are producing valid outputs
+        with open(tmpfile2, 'r') as fp:
+            json_results = json.load(fp)
+            debug_log = json_results['debuglog']
+            self.check_output_files(debug_log)
+        minidom.parse(tmpfile)
 
     def test_nonprintable_chars(self):
         cmd_line = ("%s run --external-runner /bin/ls "
@@ -513,98 +487,80 @@ class OutputPluginTest(unittest.TestCase):
         self.check_output_files(debug_log)
 
     def test_verify_whiteboard_save(self):
-        tmpfile = tempfile.mktemp()
-        try:
-            config = os.path.join(self.tmpdir, "conf.ini")
-            content = ("[datadir.paths]\nlogs_dir = %s"
-                       % os.path.relpath(self.tmpdir, "."))
-            script.Script(config, content).save()
-            cmd_line = ('%s --config %s --show all run '
-                        '--sysinfo=off whiteboard.py --json %s'
-                        % (AVOCADO, config, tmpfile))
-            result = process.run(cmd_line, ignore_status=True)
-            expected_rc = exit_codes.AVOCADO_ALL_OK
-            self.assertEqual(result.exit_status, expected_rc,
-                             "Avocado did not return rc %d:\n%s" %
-                             (expected_rc, result))
-            with open(tmpfile, 'r') as fp:
-                json_results = json.load(fp)
-                logfile = json_results['tests'][0]['logfile']
-                debug_dir = os.path.dirname(logfile)
-                whiteboard_path = os.path.join(debug_dir, 'whiteboard')
-                self.assertTrue(os.path.exists(whiteboard_path),
-                                'Missing whiteboard file %s' % whiteboard_path)
-        finally:
-            try:
-                os.remove(tmpfile)
-            except OSError:
-                pass
+        tmpfile = tempfile.mktemp(dir=self.tmpdir)
+        config = os.path.join(self.tmpdir, "conf.ini")
+        content = ("[datadir.paths]\nlogs_dir = %s"
+                   % os.path.relpath(self.tmpdir, "."))
+        script.Script(config, content).save()
+        cmd_line = ('%s --config %s --show all run '
+                    '--sysinfo=off whiteboard.py --json %s'
+                    % (AVOCADO, config, tmpfile))
+        result = process.run(cmd_line, ignore_status=True)
+        expected_rc = exit_codes.AVOCADO_ALL_OK
+        self.assertEqual(result.exit_status, expected_rc,
+                         "Avocado did not return rc %d:\n%s" %
+                         (expected_rc, result))
+        with open(tmpfile, 'r') as fp:
+            json_results = json.load(fp)
+            logfile = json_results['tests'][0]['logfile']
+            debug_dir = os.path.dirname(logfile)
+            whiteboard_path = os.path.join(debug_dir, 'whiteboard')
+            self.assertTrue(os.path.exists(whiteboard_path),
+                            'Missing whiteboard file %s' % whiteboard_path)
 
     @unittest.skipIf(image_output_uncapable(),
                      "Uncapable of generating images with PIL library")
     def test_gendata(self):
-        tmpfile = tempfile.mktemp()
-        try:
-            cmd_line = ("%s run --job-results-dir %s "
-                        "--sysinfo=off gendata.py --json %s" %
-                        (AVOCADO, self.tmpdir, tmpfile))
-            result = process.run(cmd_line, ignore_status=True)
-            expected_rc = exit_codes.AVOCADO_ALL_OK
-            self.assertEqual(result.exit_status, expected_rc,
-                             "Avocado did not return rc %d:\n%s" %
-                             (expected_rc, result))
-            with open(tmpfile, 'r') as fp:
-                json_results = json.load(fp)
-                bsod_dir = None
-                json_dir = None
-                for test in json_results['tests']:
-                    if "test_bsod" in test['id']:
-                        bsod_dir = test['logfile']
-                    elif "test_json" in test['id']:
-                        json_dir = test['logfile']
-                self.assertTrue(bsod_dir, "Failed to get test_bsod output "
-                                "directory")
-                self.assertTrue(json_dir, "Failed to get test_json output "
-                                "directory")
-                bsod_dir = os.path.join(os.path.dirname(bsod_dir), "data",
-                                        "bsod.png")
-                json_dir = os.path.join(os.path.dirname(json_dir), "data",
-                                        "test.json")
-                self.assertTrue(os.path.exists(bsod_dir), "File %s produced by"
-                                "test does not exist" % bsod_dir)
-                self.assertTrue(os.path.exists(json_dir), "File %s produced by"
-                                "test does not exist" % json_dir)
-        finally:
-            try:
-                os.remove(tmpfile)
-            except OSError:
-                pass
+        tmpfile = tempfile.mktemp(dir=self.tmpdir)
+        cmd_line = ("%s run --job-results-dir %s "
+                    "--sysinfo=off gendata.py --json %s" %
+                    (AVOCADO, self.tmpdir, tmpfile))
+        result = process.run(cmd_line, ignore_status=True)
+        expected_rc = exit_codes.AVOCADO_ALL_OK
+        self.assertEqual(result.exit_status, expected_rc,
+                         "Avocado did not return rc %d:\n%s" %
+                         (expected_rc, result))
+        with open(tmpfile, 'r') as fp:
+            json_results = json.load(fp)
+            bsod_dir = None
+            json_dir = None
+            for test in json_results['tests']:
+                if "test_bsod" in test['id']:
+                    bsod_dir = test['logfile']
+                elif "test_json" in test['id']:
+                    json_dir = test['logfile']
+            self.assertTrue(bsod_dir, "Failed to get test_bsod output "
+                            "directory")
+            self.assertTrue(json_dir, "Failed to get test_json output "
+                            "directory")
+            bsod_dir = os.path.join(os.path.dirname(bsod_dir), "data",
+                                    "bsod.png")
+            json_dir = os.path.join(os.path.dirname(json_dir), "data",
+                                    "test.json")
+            self.assertTrue(os.path.exists(bsod_dir), "File %s produced by"
+                            "test does not exist" % bsod_dir)
+            self.assertTrue(os.path.exists(json_dir), "File %s produced by"
+                            "test does not exist" % json_dir)
 
     def test_redirect_output(self):
-        redirected_output_path = tempfile.mktemp()
-        try:
-            cmd_line = ('%s run --job-results-dir %s '
-                        '--sysinfo=off passtest.py > %s'
-                        % (AVOCADO, self.tmpdir, redirected_output_path))
-            result = process.run(cmd_line, ignore_status=True, shell=True)
-            output = result.stdout + result.stderr
-            expected_rc = exit_codes.AVOCADO_ALL_OK
-            self.assertEqual(result.exit_status, expected_rc,
-                             "Avocado did not return rc %d:\n%s" %
-                             (expected_rc, result))
-            self.assertEqual(output, b'',
-                             'After redirecting to file, output is not empty: %s' % output)
-            with open(redirected_output_path, 'r') as redirected_output_file_obj:
-                redirected_output = redirected_output_file_obj.read()
-                for code in TermSupport.ESCAPE_CODES:
-                    self.assertNotIn(code, redirected_output,
-                                     'Found terminal support code %s in redirected output\n%s' %
-                                     (code, redirected_output))
-        finally:
-            try:
-                os.remove(redirected_output_path)
-            except OSError:
-                pass
+        redirected_output_path = tempfile.mktemp(dir=self.tmpdir)
+        cmd_line = ('%s run --job-results-dir %s '
+                    '--sysinfo=off passtest.py > %s'
+                    % (AVOCADO, self.tmpdir, redirected_output_path))
+        result = process.run(cmd_line, ignore_status=True, shell=True)
+        output = result.stdout + result.stderr
+        expected_rc = exit_codes.AVOCADO_ALL_OK
+        self.assertEqual(result.exit_status, expected_rc,
+                         "Avocado did not return rc %d:\n%s" %
+                         (expected_rc, result))
+        self.assertEqual(output, b'',
+                         'After redirecting to file, output is not empty: %s' % output)
+        with open(redirected_output_path, 'r') as redirected_output_file_obj:
+            redirected_output = redirected_output_file_obj.read()
+            for code in TermSupport.ESCAPE_CODES:
+                self.assertNotIn(code, redirected_output,
+                                 'Found terminal support code %s in redirected output\n%s' %
+                                 (code, redirected_output))
 
     @unittest.skipIf(perl_tap_parser_uncapable(),
                      "Uncapable of using Perl TAP::Parser library")


### PR DESCRIPTION
Instead of creating new temporary dirs and files, and handling their
removal in each test, let's just create additional dirs/files in the
already provided tmpdir, which will be removed by the test tearDown
method.

Signed-off-by: Cleber Rosa <crosa@redhat.com>