### PR TITLE
Fix "--json-variants-load" for python3

### DIFF
--- a/avocado/core/parameters.py
+++ b/avocado/core/parameters.py
@@ -250,7 +250,8 @@ class AvocadoParam(object):
         if not ret:
             raise NoMatchError("No matches to %s => %s in %s"
                                % (path.pattern, key, self.str_leaves_variant))
-        if len(set([_[1] for _ in ret])) == 1:  # single source of results
+        # make sure all params come from the same origin
+        if len(set([_[1].path for _ in ret])) == 1:
             return ret[0][0]
         else:
             raise ValueError("Multiple %s leaves contain the key '%s'; %s"

--- a/avocado/core/varianter.py
+++ b/avocado/core/varianter.py
@@ -198,7 +198,7 @@ class Varianter(object):
             default_params.merge(default_param)
         self._default_params = default_params
         self.default_params.clear()
-        self._variant_plugins.map_method_copy("initialize", args)
+        self._variant_plugins.map_method("initialize", args)
         self._variant_plugins.map_method_copy("update_defaults", self._default_params)
         self._no_variants = sum(self._variant_plugins.map_method("__len__"))
 

--- a/selftests/unit/test_parameters.py
+++ b/selftests/unit/test_parameters.py
@@ -21,3 +21,35 @@ class Parameters(unittest.TestCase):
                          'foo/')
         self.assertEqual(params._greedy_path_to_re('/foo/*').pattern,
                          '/foo/')
+
+    def test_same_origin_of_different_nodes(self):
+        # ideally we have one tree, therefor shared key
+        # have identical origin (id of the origin env)
+        foo = tree.TreeNode().get_node("/foo", True)
+        root = foo.parent
+        root.value = {'timeout': 1}
+        bar = root.get_node("/bar", True)
+        params1 = parameters.AvocadoParams([foo, bar], '/')
+        self.assertEqual(params1.get('timeout'), 1)
+        self.assertEqual(params1.get('timeout', '/foo/'), 1)
+        self.assertEqual(params1.get('timeout', '/bar/'), 1)
+        # Sometimes we get multiple trees, but if they claim the origin
+        # is of the same path, let's trust it (even when the values
+        # differ)
+        # note: This is an artificial example which should not happen
+        # in production. Anyway in json-variants-loader we do create
+        # only leave-nodes without connecting the parents, which result
+        # in same paths with different node objects. Let's make sure
+        # they behave correctly.
+        baz = tree.TreeNode().get_node("/baz", True)
+        baz.parent.value = {'timeout': 2}
+        params2 = parameters.AvocadoParams([foo, baz], '/')
+        self.assertEqual(params2.get('timeout'), 1)
+        self.assertEqual(params2.get('timeout', '/foo/'), 1)
+        self.assertEqual(params2.get('timeout', '/baz/'), 2)
+        # Note: Different origin of the same value, which should produce
+        # a crash, are tested in yaml2mux selftest
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR modifies the "--json-variants-load" to not to crash on py3.