### PR TITLE
avocado.utils.archive: improve docstring for extract()

### DIFF
--- a/avocado/utils/archive.py
+++ b/avocado/utils/archive.py
@@ -168,7 +168,8 @@ class ArchiveFile(object):
         Extract all files from the archive.
 
         :param path: destination path.
-        :return: extracted folder name
+        :return: the first member of the archive, a file or directory or None
+                 if the archive is empty
         """
         self._engine.extractall(path)
         if self.is_zip:


### PR DESCRIPTION
Which will return the first member of the archive, either a file or
directory.  If the archive is empty, it'll return None.

Signed-off-by: Cleber Rosa <crosa@redhat.com>