### PR TITLE
avocado.utils.iso9660: add capabilities and create/write

### DIFF
--- a/selftests/unit/test_utils_iso9660.py
+++ b/selftests/unit/test_utils_iso9660.py
@@ -9,6 +9,24 @@ import unittest
 from avocado.utils import iso9660, process
 
 
+class Capabilities(unittest.TestCase):
+
+    def setUp(self):
+        self.iso_path = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                                     os.path.pardir, ".data",
+                                                     "sample.iso"))
+
+    def test_common_capabilities(self):
+        none_cap = iso9660.iso9660(self.iso_path)
+        read_cap = iso9660.iso9660(self.iso_path, ['read'])
+        if not (none_cap is None and read_cap is None):
+            self.assertEqual(none_cap.__class__, read_cap.__class__)
+
+    def test_non_existing_capabilities(self):
+        self.assertIsNone(iso9660.iso9660(self.iso_path,
+                                          ['non-existing', 'capabilities']))
+
+
 class BaseIso9660(unittest.TestCase):
 
     """

--- a/selftests/unit/test_utils_iso9660.py
+++ b/selftests/unit/test_utils_iso9660.py
@@ -160,12 +160,17 @@ class PyCDLib(BaseIso9660):
         """Call the basic workflow"""
         self.basic_workflow()
 
-    def test_create(self):
+    def test_create_write(self):
         new_iso_path = os.path.join(self.tmpdir, 'new.iso')
         new_iso = iso9660.ISO9660PyCDLib(new_iso_path)
         new_iso.create()
-        new_iso.close()
-        self.assertTrue(os.path.isfile(new_iso_path))
+        for path in ("README", "/readme", "readme.txt", "quite-long-readme.txt"):
+            content = b"AVOCADO"
+            new_iso.write(path, content)
+            new_iso.close()
+            read_iso = iso9660.ISO9660PyCDLib(new_iso_path)
+            self.assertEqual(read_iso.read(path), content)
+            self.assertTrue(os.path.isfile(new_iso_path))
 
 
 if __name__ == "__main__":

--- a/selftests/unit/test_utils_iso9660.py
+++ b/selftests/unit/test_utils_iso9660.py
@@ -160,6 +160,13 @@ class PyCDLib(BaseIso9660):
         """Call the basic workflow"""
         self.basic_workflow()
 
+    def test_create(self):
+        new_iso_path = os.path.join(self.tmpdir, 'new.iso')
+        new_iso = iso9660.ISO9660PyCDLib(new_iso_path)
+        new_iso.create()
+        new_iso.close()
+        self.assertTrue(os.path.isfile(new_iso_path))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This adds a capabilities selection mechanism for users of `avocado.utils.iso9660.iso9660` and ISO image creation support for the ISO9660PyCDLib backend.  More backends may add the same capabilities later.