### PR TITLE
Initial set of deployment "tests"

### DIFF
--- a/selftests/deployment/README
+++ b/selftests/deployment/README
@@ -1,0 +1,21 @@
+This is a set of ansible playbooks and supporting code to test the
+deployment of Avocado in a number of different environments, and
+installed via a number of different methods.  These are intended to be
+used as regular playbooks, so roughly the following steps should be
+followed:
+
+ 1) Install ansible.  If you need help, refer to
+    https://docs.ansible.com/ansible/latest/installation_guide
+
+ 2) Adjust your inventory, that is, the hosts that will be used on the
+    playbook execution.  The simplest way is to edit the inventory
+    file this directory.
+
+ 3) (OPTIONAL) adjust your configuration on vars.yml
+
+ 4) Run a playbook with: ansible-playbook <PLAYBOOK_FILE_NAME>
+
+The following playbooks Ansible are available here:
+
+ - pip-git.yml: deployment Avocado using pip, from a GIT repository,
+   on a Python virtual environment.

--- a/selftests/deployment/ansible.cfg
+++ b/selftests/deployment/ansible.cfg
@@ -1,0 +1,5 @@
+[defaults]
+inventory = ./inventory
+
+[privilege_escalation]
+become = false

--- a/selftests/deployment/inventory
+++ b/selftests/deployment/inventory
@@ -1,0 +1,2 @@
+[avocado-test-deployment]
+localhost

--- a/selftests/deployment/pip-git.yml
+++ b/selftests/deployment/pip-git.yml
@@ -1,0 +1,66 @@
+---
+- name: Installs Avocado using pip, directly from GIT repo
+  hosts: avocado-test-deployment
+  vars:
+    avocado_git_url: https://github.com/avocado-framework/avocado.git
+    avocado_git_branch: master
+    avocado_egg_name: avocado-framework
+    avocado_python_rpm_packages:
+      - python-pip
+      # pip install "git+https://" quite obviously requires git
+      - git
+      - python-virtualenv
+    avocado_virtualenv_command: virtualenv-2.7
+  tasks:
+    - include_vars: vars.yml
+    - include_tasks: tasks/epel.yml
+    - include_tasks: tasks/python_rpm_pkgs.yml
+    - name: Temporary dir for Avocado venv
+      tempfile:
+        state: directory
+      register: temporary_dir
+    - name: Avocado installation via pip
+      pip:
+        name: "git+{{ avocado_git_url}}@{{ avocado_git_branch }}#egg={{ avocado_egg_name }}"
+        virtualenv_command: "{{ avocado_virtualenv_command }}"
+        virtualenv: "{{ temporary_dir.path }}"
+    - name: Avocado version
+      shell: "{{ temporary_dir.path }}/bin/avocado --version"
+      register: avocado_version_result
+      changed_when: false
+    - name: Avocado HTML report plugin installation via pip
+      pip:
+        name: "git+{{ avocado_git_url}}@{{ avocado_git_branch }}#egg=avocado-framework-plugin-result-html&subdirectory=optional_plugins/html"
+        virtualenv: "{{ temporary_dir.path }}"
+    - name: Avocado resultsdb plugin installation via pip
+      pip:
+        name: "git+{{ avocado_git_url}}@{{ avocado_git_branch }}#egg=avocado-framework-plugin-resultsdb&subdirectory=optional_plugins/resultsdb"
+        virtualenv: "{{ temporary_dir.path }}"
+    - name: Avocado result_upload plugin installation via pip
+      pip:
+        name: "git+{{ avocado_git_url}}@{{ avocado_git_branch }}#egg=avocado-framework-plugin-result-upload&subdirectory=optional_plugins/result_upload"
+        virtualenv: "{{ temporary_dir.path }}"
+    - name: Avocado Varianter YAML-to-Mux plugin installation via pip
+      pip:
+        name: "git+{{ avocado_git_url}}@{{ avocado_git_branch }}#egg=avocado-framework-plugin-varianter-yaml-to-mux&subdirectory=optional_plugins/varianter_yaml_to_mux"
+        virtualenv: "{{ temporary_dir.path }}"
+    - name: Avocado Varianter CIT plugin installation via pip
+      pip:
+        name: "git+{{ avocado_git_url}}@{{ avocado_git_branch }}#egg=avocado-framework-plugin-varianter-cit&subdirectory=optional_plugins/varianter_cit"
+        virtualenv: "{{ temporary_dir.path }}"
+    - name: Avocado Varianter PICT plugin installation via pip
+      pip:
+        name: "git+{{ avocado_git_url}}@{{ avocado_git_branch }}#egg=avocado-framework-plugin-varianter-pict&subdirectory=optional_plugins/varianter_pict"
+        virtualenv: "{{ temporary_dir.path }}"
+    - name: Avocado glib loader plugin installation via pip
+      pip:
+        name: "git+{{ avocado_git_url}}@{{ avocado_git_branch }}#egg=avocado-framework-plugin-glib&subdirectory=optional_plugins/glib"
+        virtualenv: "{{ temporary_dir.path }}"
+    - name: Avocado golang loader plugin installation via pip
+      pip:
+        name: "git+{{ avocado_git_url}}@{{ avocado_git_branch }}#egg=avocado-framework-plugin-golang&subdirectory=optional_plugins/golang"
+        virtualenv: "{{ temporary_dir.path }}"
+    - name: Avocado YAML loader plugin installation via pip
+      pip:
+        name: "git+{{ avocado_git_url}}@{{ avocado_git_branch }}#egg=avocado-framework-plugin-loader-yaml&subdirectory=optional_plugins/loader_yaml"
+        virtualenv: "{{ temporary_dir.path }}"

--- a/selftests/deployment/tasks/epel.yml
+++ b/selftests/deployment/tasks/epel.yml
@@ -1,0 +1,8 @@
+---
+  - name: Install EPEL on Red Hat systems
+    yum:
+      name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
+    when:
+      # This should work on both RHEL, CentOS, Scientific Linux, etc
+      - ansible_distribution_file_variety == "RedHat"
+      - ansible_distribution_major_version == "7"

--- a/selftests/deployment/tasks/python_rpm_pkgs.yml
+++ b/selftests/deployment/tasks/python_rpm_pkgs.yml
@@ -1,0 +1,7 @@
+---
+  - name: Install Python Depedencies on Red Hat (like) systems
+    package:
+      name: "{{ item }}"
+      state: latest
+    with_items: "{{ avocado_python_rpm_packages }}"
+    when: ansible_distribution_file_variety == "RedHat"

--- a/selftests/deployment/vars.yml
+++ b/selftests/deployment/vars.yml
@@ -1,0 +1,4 @@
+---
+# You own variables here.  Examples include:
+# avocado_git_url: https://github.com/$YOUR_GITHUB_USERNAME/avocado.git
+# avocado_git_branch: $YOUR_DEVELOPMENT_BRANCH


### PR DESCRIPTION
While abusing the term tests, this is an initial set of files that are
intended to test how Avocado can be deployed on various platforms,
using different installation methods.

At this point, a single combination of installation method (pip) and
destination (virtual environment).

Signed-off-by: Cleber Rosa <crosa@redhat.com>