### PR TITLE
Fix W0622 pylint error in python 3.7

### DIFF
--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -877,10 +877,10 @@ class GDBSubProcess(object):
     def _get_breakpoints(self):
         breakpoints = []
         for expr in gdb.GDB_RUN_BINARY_NAMES_EXPR:
-            expr_binary_name, breakpoint = split_gdb_expr(expr)
+            expr_binary_name, break_point = split_gdb_expr(expr)
             binary_name = os.path.basename(self.binary)
             if expr_binary_name == binary_name:
-                breakpoints.append(breakpoint)
+                breakpoints.append(break_point)
 
         if not breakpoints:
             breakpoints.append(gdb.GDB.DEFAULT_BREAK)

--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -81,15 +81,15 @@ class TestGDBProcess(unittest.TestCase):
                       process.SubProcess)
 
     def test_split_gdb_expr(self):
-        binary, breakpoint = process.split_gdb_expr('foo:debug_print')
+        binary, break_point = process.split_gdb_expr('foo:debug_print')
         self.assertEqual(binary, 'foo')
-        self.assertEqual(breakpoint, 'debug_print')
-        binary, breakpoint = process.split_gdb_expr('bar')
+        self.assertEqual(break_point, 'debug_print')
+        binary, break_point = process.split_gdb_expr('bar')
         self.assertEqual(binary, 'bar')
-        self.assertEqual(breakpoint, 'main')
-        binary, breakpoint = process.split_gdb_expr('baz:main.c:57')
+        self.assertEqual(break_point, 'main')
+        binary, break_point = process.split_gdb_expr('baz:main.c:57')
         self.assertEqual(binary, 'baz')
-        self.assertEqual(breakpoint, 'main.c:57')
+        self.assertEqual(break_point, 'main.c:57')
         self.assertIsInstance(process.split_gdb_expr('foo'), tuple)
         self.assertIsInstance(process.split_gdb_expr('foo:debug_print'), tuple)
 


### PR DESCRIPTION
Python 3.7 introduced a new way to add breakpoint on the code. It was
added the built-in breackpoint function. There was couple of places
where the word breakpoint was being redefined making pylint execution
fail with W0622 error (Redefining built-in). This commit replaces
'breakpoint' with 'break_point' in these places.