### PR TITLE
Adds egg-info directories to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ build
 sysinfo-*
 MANIFEST
 dist
+*.egg-info*


### PR DESCRIPTION
When `make develop` is run egg-info directories are created. We
shouldn't add them to version control, so this commit adds the proper
entry to gitignore file.