### PR TITLE
Fix E1111 pylint error

### DIFF
--- a/selftests/run
+++ b/selftests/run
@@ -52,7 +52,7 @@ def test_suite():
 class MyResult(unittest.TextTestResult):
     def stopTest(self, test):
         # stopTest
-        ret = super(MyResult, self).stopTest(test)
+        super(MyResult, self).stopTest(test)
         # Destroy the data_dir.get_tmpdir ...
         data_dir._tmp_tracker.unittest_refresh_dir_tracker()
         # Rung garbage collection (run __del__s) and force-sync disk
@@ -66,7 +66,6 @@ class MyResult(unittest.TextTestResult):
         if dir_check.wait():
             raise AssertionError("Test %s left some tmp files behind:\n%s"
                                  % (test, dir_check.stdout.read()))
-        return ret
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
E1111 error happens when a function which doesn't return is used to
assign to something. In this particular case the `unittest.TextTestResut`
`stopTest` method doesn't return and its result is being assigned to a
variable. This behaviour makes pylint fails with E1111 error. This
commit just don't assign the result of super() call and also keeps the
super class method behavior (not returning).