### PR TITLE
avocado.utils.vmimage: move decompression to avocado.utils.archive

### DIFF
--- a/avocado/utils/archive.py
+++ b/avocado/utils/archive.py
@@ -80,6 +80,20 @@ class _WrapLZMA(object):
         return cls(filename, mode)
 
 
+if LZMA_CAPABLE:
+    def extract_lzma(path, force=False):
+        """
+        Extracts a XZ compressed file to the same directory.
+        """
+        extracted_file = os.path.splitext(path)[0]
+        if not force and os.path.exists(extracted_file):
+            return extracted_file
+        with open(path, 'r') as file_obj:
+            with open(extracted_file, 'wb') as newfile_obj:
+                newfile_obj.write(lzma.decompress(file_obj.read()))
+        return extracted_file
+
+
 class ArchiveFile(object):
 
     """

--- a/avocado/utils/vmimage.py
+++ b/avocado/utils/vmimage.py
@@ -19,8 +19,12 @@ Provides VM images acquired from official repositories
 import os
 import re
 import tempfile
-import urllib2
 import uuid
+
+from six import itervalues
+from six.moves.urllib.request import urlopen
+from six.moves.urllib.error import HTTPError
+from six.moves.html_parser import HTMLParser
 
 try:
     import lzma
@@ -31,8 +35,6 @@ except ImportError:
         LZMA_CAPABLE = True
     except ImportError:
         LZMA_CAPABLE = False
-
-from HTMLParser import HTMLParser
 
 from . import asset
 from . import path as utils_path
@@ -92,8 +94,8 @@ class ImageProviderBase(object):
         pattern = '^%s/$' % self._version
         parser = VMImageHtmlParser(pattern)
         try:
-            parser.feed(urllib2.urlopen(self.url_versions).read())
-        except urllib2.HTTPError:
+            parser.feed(urlopen(self.url_versions).read())
+        except HTTPError:
             raise ImageProviderError('Cannot open %s' % self.url_versions)
         if parser.items:
             resulting_versions = []
@@ -128,9 +130,9 @@ class ImageProviderBase(object):
                                           arch=self.arch)
         parser = VMImageHtmlParser(image)
         try:
-            content = urllib2.urlopen(url_images).read()
+            content = urlopen(url_images).read()
             parser.feed(content)
-        except urllib2.HTTPError:
+        except HTTPError:
             raise ImageProviderError('Cannot open %s' % url_images)
 
         if parser.items:
@@ -390,7 +392,7 @@ def list_providers():
     """
     List the available Image Providers
     """
-    return set(_ for _ in globals().itervalues()
+    return set(_ for _ in itervalues(globals())
                if (_ != ImageProviderBase and
                    isinstance(_, type) and
                    issubclass(_, ImageProviderBase)))

--- a/avocado/utils/vmimage.py
+++ b/avocado/utils/vmimage.py
@@ -63,7 +63,9 @@ class VMImageHtmlParser(HTMLParser):
             return
         for attr in attrs:
             if attr[0] == 'href' and re.match(self.pattern, attr[1]):
-                self.items.append(attr[1].strip('/'))
+                match = attr[1].strip('/')
+                if match not in self.items:
+                    self.items.append(match)
 
 
 class ImageProviderBase(object):

--- a/selftests/unit/test_utils_vmimage.py
+++ b/selftests/unit/test_utils_vmimage.py
@@ -1,0 +1,13 @@
+import unittest
+
+from avocado.utils import vmimage
+
+
+class VMImage(unittest.TestCase):
+
+    def test_list_providers(self):
+        self.assertIsNotNone(vmimage.list_providers())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The `avocado.util.archive` already contains code to extract files compressed with xz.  It may be that there's only support for tar+xz, but in any case, the code should be improved and live in `avocado.utils.archive`.

Plus, a couple of other `vmimage` fixes.