### PR TITLE
avocado/utils/download.py: log retrieved URL information

### DIFF
--- a/avocado/utils/download.py
+++ b/avocado/utils/download.py
@@ -48,7 +48,14 @@ def url_open(url, data=None, timeout=5):
     old_timeout = socket.getdefaulttimeout()
     socket.setdefaulttimeout(timeout)
     try:
-        return urlopen(url, data=data)
+        result = urlopen(url, data=data)
+        msg = ('Retrieved URL "%s": content-length %s, date: "%s", '
+               'last-modified: "%s"')
+        logging.debug(msg, url,
+                      result.headers.get('Content-Length', 'UNKNOWN'),
+                      result.headers.get('Date', 'UNKNOWN'),
+                      result.headers.get('Last-Modified', 'UNKNOWN'))
+        return result
     finally:
         socket.setdefaulttimeout(old_timeout)
 


### PR DESCRIPTION
Sometimes the URL used is a link to the content that gets updated
between jobs.  When comparing jobs, it's unclear if we're downloading
the same file or another one.

Let's print the available information we have, such as the content
length, and the creation/modification dates.

Reference: https://trello.com/c/wQ8ir7xA
Signed-off-by: Cleber Rosa <crosa@redhat.com>