### PR TITLE
avocado/utils/partition.py: do not blow up on systems with no lsof

### DIFF
--- a/avocado/utils/partition.py
+++ b/avocado/utils/partition.py
@@ -250,14 +250,17 @@ class Partition(object):
         :raise PartitionError: On critical failure
         """
         # Human readable list of processes
-        out = process.system_output("lsof " + mountpoint, ignore_status=True)
-        # Try to kill all pids
-        for pid in (line.split()[1] for line in out.splitlines()[1:]):
-            try:
-                process.system("kill -9 %d" % int(pid), ignore_status=True,
-                               sudo=True)
-            except OSError:
-                pass
+        try:
+            out = process.system_output("lsof " + mountpoint, ignore_status=True)
+            # Try to kill all pids
+            for pid in (line.split()[1] for line in out.splitlines()[1:]):
+                try:
+                    process.system("kill -9 %d" % int(pid), ignore_status=True,
+                                   sudo=True)
+                except OSError:
+                    pass
+        except OSError:
+            pass
         # Unmount
         try:
             process.run("umount -f %s" % mountpoint, sudo=True)

--- a/selftests/unit/test_utils_partition.py
+++ b/selftests/unit/test_utils_partition.py
@@ -59,6 +59,7 @@ class TestPartition(unittest.TestCase):
             proc_mounts = proc_mounts_file.read()
             self.assertNotIn(self.mountpoint, proc_mounts)
 
+    @unittest.skipIf(missing_binary('lsof'), "requires running lsof")
     @unittest.skipIf(not process.can_sudo('kill -l'),
                      "requires running kill as a privileged user")
     def test_force_unmount(self):


### PR DESCRIPTION
lsof is not an Avocado dependency, and is much harder to find on
base systems than mount, kill, etc.  Since this module pretty
much revolves around those utilities, I'm not going to propose
major changes, trying to adapt to the lack of mount, kill, etc.

This simply does *not* attempt to run kill, if we can not get
the PIDs using lsof.  Then, the forceful unmount will probably
fail just the same, but the right way.

To be completely honest, there are still a broken expectation here:
when cannot assume that by sending a signal the process will be
killed.  The real is a lot more complex, though.

https://trello.com/c/DDUNPCBx
Signed-off-by: Cleber Rosa <crosa@redhat.com>