### PR TITLE
Travis: update versions of modules used in lint/syntax checks

### DIFF
--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,11 +1,12 @@
 # All pip installable requirements pinned for Travis CI
 pycodestyle==2.4.0
-pylint==1.9.2
+pylint==1.9.3; python_version <= '2.7'
+pylint==2.1.1; python_version >= '3.4'
 fabric==1.11.1; python_version <= '2.7'
 Fabric3==1.13.1.post1; python_version >= '3.4'
 Sphinx==1.3b1
-inspektor==0.5.1
-pep8==1.6.2
+inspektor==0.5.2
+pep8==1.7.1
 requests==1.2.3
 PyYAML==3.11
 Pillow==2.8.1


### PR DESCRIPTION
This started as a hunt for "foo" doesn't exist in module "bar" errors
in "inspekt lint" checks.  It looks like it fixes those issues, but
even if it doesn't, it's a valid change in itself.

Signed-off-by: Cleber Rosa <crosa@redhat.com>