### PR TITLE
Pylint enable w01xx checks

### DIFF
--- a/avocado/plugins/diff.py
+++ b/avocado/plugins/diff.py
@@ -162,8 +162,6 @@ class Diff(CLICmd):
             for test in job1_data['tests']:
                 test_result = '%s: %s\n' % (get_name(test),
                                             str(test['status']))
-                if args.diff_strip_id:
-                    test
                 results1.append(test_result)
             results2 = []
             for test in job2_data['tests']:

--- a/selftests/checkall
+++ b/selftests/checkall
@@ -167,7 +167,7 @@ results_dir_content() {
 }
 
 [ "$SKIP_RESULTSDIR_CHECK" ] || RESULTS_DIR_CONTENT="$(ls $RESULTS_DIR 2> /dev/null)"
-run_rc lint 'inspekt lint --exclude=.git --enable R0401,W0101,W0102,W0404,W0611,W0612,W0622'
+run_rc lint 'inspekt lint --exclude=.git --enable R0401,W0101,W0102,W0104,W0105,W0106,W0107,W0108,W0109,W0110,W0111,W0404,W0611,W0612,W0622'
 # Skip checking test_utils_cpu.py due to inspektor bug
 run_rc indent 'inspekt indent --exclude=.git,selftests/unit/test_utils_cpu.py'
 run_rc style 'inspekt style --exclude=.git --disable E501,E265,W601,E402,E722'

--- a/selftests/unit/test_test.py
+++ b/selftests/unit/test_test.py
@@ -112,7 +112,6 @@ class TestClassTestUnit(unittest.TestCase):
         above_limit_name = os.path.join(self.tmpdir, "a" * 251)
         tst = self._get_fake_filename_test(above_limit_name)
         self.assertFalse(tst.get_data('', 'file', False))
-        tst._record_reference       # Should do nothing
         tst._record_reference('stdout', 'stdout.expected')
         tst._record_reference('stderr', 'stderr.expected')
         tst._record_reference('output', 'output.expected')


### PR DESCRIPTION
In order to enable all pylint W01xx checks, this change removes some
pointless statements that already was in the code base and enable proper
checks in checkall script.

Reference: https://trello.com/c/Ohh7Q6qj
Signed-off-by: Caio Carrara <ccarrara@redhat.com>