### PR TITLE
Enable pylint w0120

### DIFF
--- a/avocado/utils/external/spark.py
+++ b/avocado/utils/external/spark.py
@@ -297,15 +297,15 @@ class GenericParser:
                                  candidate, oldrule))
                 candidate = 0
                 i += 1
+
+            if candidate:
+                lhs = self._NULLABLE + lhs
+                rule = (lhs, rhs)
+            if lhs in self.newrules:
+                self.newrules[lhs].append(rule)
             else:
-                if candidate:
-                    lhs = self._NULLABLE + lhs
-                    rule = (lhs, rhs)
-                if lhs in self.newrules:
-                    self.newrules[lhs].append(rule)
-                else:
-                    self.newrules[lhs] = [rule]
-                self.new2old[rule] = oldrule
+                self.newrules[lhs] = [rule]
+            self.new2old[rule] = oldrule
 
     def typestring(self, token):
         return None

--- a/selftests/checkall
+++ b/selftests/checkall
@@ -167,7 +167,7 @@ results_dir_content() {
 }
 
 [ "$SKIP_RESULTSDIR_CHECK" ] || RESULTS_DIR_CONTENT="$(ls $RESULTS_DIR 2> /dev/null)"
-run_rc lint 'inspekt lint --exclude=.git --enable R0401,W0101,W0102,W0104,W0105,W0106,W0107,W0108,W0109,W0110,W0111,W0404,W0611,W0612,W0622'
+run_rc lint 'inspekt lint --exclude=.git --enable R0401,W0101,W0102,W0104,W0105,W0106,W0107,W0108,W0109,W0110,W0111,W0120,W0404,W0611,W0612,W0622'
 # Skip checking test_utils_cpu.py due to inspektor bug
 run_rc indent 'inspekt indent --exclude=.git,selftests/unit/test_utils_cpu.py'
 run_rc style 'inspekt style --exclude=.git --disable E501,E265,W601,E402,E722'


### PR DESCRIPTION
There was an else on while without break. That has no meaning because
since while has no break, the else block will be always executed. This
change removes the else statement and keeps the block.

The pylint W0120 check was also enabled since now it's possible.

Reference: https://trello.com/c/Ohh7Q6qj
Signed-off-by: Caio Carrara <ccarrara@redhat.com>

ps: the change doesn't seems too clear on Github diff.