### PR TITLE
Several "settings" fixes and plugin to allow setting/modifying config file paths

### DIFF
--- a/avocado/core/dispatcher.py
+++ b/avocado/core/dispatcher.py
@@ -21,8 +21,14 @@ from stevedore import EnabledExtensionManager
 
 from .settings import settings
 from .settings import SettingsError
+from .settings import SettingsDispatcher
 from .output import LOG_UI
 from ..utils import stacktrace
+
+
+#: Settings dispatcher is simplified and has to be available before the
+#: settings object. Let's include it here for consistency
+SettingsDispatcher = SettingsDispatcher
 
 
 class Dispatcher(EnabledExtensionManager):

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -381,10 +381,6 @@ class Job(object):
         LOG_JOB.info('Config files read (in order):')
         for cfg_path in settings.config_paths:
             LOG_JOB.info(cfg_path)
-        if settings.config_paths_failed:
-            LOG_JOB.info('Config files failed to read (in order):')
-            for cfg_path in settings.config_paths_failed:
-                LOG_JOB.info(cfg_path)
         LOG_JOB.info('')
 
         LOG_JOB.info('Avocado config:')

--- a/avocado/core/plugin_interfaces.py
+++ b/avocado/core/plugin_interfaces.py
@@ -25,6 +25,22 @@ class Plugin(object):
     """
 
 
+class Settings(Plugin):
+
+    """
+    Base plugin to allow modifying settings.
+
+    Currently it only supports to extend/modify the default list of
+    paths to config files.
+    """
+
+    @abc.abstractmethod
+    def adjust_settings_paths(self, paths):
+        """
+        Entry point where plugin can modify the list of configuration paths
+        """
+
+
 class CLI(Plugin):
 
     """

--- a/avocado/core/settings.py
+++ b/avocado/core/settings.py
@@ -219,7 +219,6 @@ class Settings(object):
             else:
                 self.process_config_path(config_path_local)
         else:
-            # Unittests
             self.process_config_path(config_path)
 
     def process_config_path(self, pth):
@@ -228,6 +227,7 @@ class Settings(object):
             self.config_paths += read_configs
         else:
             self.config_paths_failed.append(pth)
+            # Only used by unittests (the --config parses the file later)
 
     def _handle_no_value(self, section, key, default):
         """

--- a/avocado/core/settings.py
+++ b/avocado/core/settings.py
@@ -144,9 +144,15 @@ class Settings(object):
         :param config_path: Path to a config file. Useful for unittesting.
         """
         self.config = ConfigParser.ConfigParser()
-        self.intree = False
         self.config_paths = []
         self.config_paths_failed = []
+        _source_tree_root = os.path.dirname(os.path.dirname(os.path.dirname(
+            sys.modules[__name__].__file__)))
+        # In case "examples" file exists in root, we are running from tree
+        if os.path.exists(os.path.join(_source_tree_root, 'examples')):
+            self.intree = True
+        else:
+            self.intree = False
         if config_path is None:
             if 'VIRTUAL_ENV' in os.environ:
                 cfg_dir = os.path.join(os.environ['VIRTUAL_ENV'], 'etc')
@@ -158,7 +164,6 @@ class Settings(object):
             _config_dir_system = os.path.join(cfg_dir, 'avocado')
             _config_dir_system_extra = os.path.join(cfg_dir, 'avocado', 'conf.d')
             _config_dir_local = os.path.join(user_dir, '.config', 'avocado')
-            _source_tree_root = os.path.join(sys.modules[__name__].__file__, "..", "..", "..")
             _config_path_intree = os.path.join(os.path.abspath(_source_tree_root),
                                                'avocado', 'etc', 'avocado')
             _config_path_intree_extra = os.path.join(_config_path_intree, 'conf.d')
@@ -188,7 +193,6 @@ class Settings(object):
                 if config_intree_extra:
                     for extra_file in glob.glob(os.path.join(_config_path_intree_extra, '*.conf')):
                         self.process_config_path(extra_file)
-                self.intree = True
             # Override with system config
             if config_system:
                 self.process_config_path(config_path_system)

--- a/avocado/core/settings.py
+++ b/avocado/core/settings.py
@@ -25,7 +25,10 @@ try:
 except ImportError:
     import configparser as ConfigParser
 
-from pkg_resources import resource_exists, resource_filename
+from pkg_resources import resource_exists
+from pkg_resources import resource_filename
+from pkg_resources import resource_isdir
+from pkg_resources import resource_listdir
 from six import string_types
 
 from ..utils import path
@@ -164,34 +167,36 @@ class Settings(object):
             _config_dir_system = os.path.join(cfg_dir, 'avocado')
             _config_dir_system_extra = os.path.join(cfg_dir, 'avocado', 'conf.d')
             _config_dir_local = os.path.join(user_dir, '.config', 'avocado')
-            _config_path_intree = os.path.join(os.path.abspath(_source_tree_root),
-                                               'avocado', 'etc', 'avocado')
-            _config_path_intree_extra = os.path.join(_config_path_intree, 'conf.d')
 
             config_filename = 'avocado.conf'
             config_path_system = os.path.join(_config_dir_system, config_filename)
             config_path_local = os.path.join(_config_dir_local, config_filename)
-            config_path_intree = os.path.join(_config_path_intree, config_filename)
 
             config_system = os.path.exists(config_path_system)
             config_system_extra = os.path.exists(_config_dir_system_extra)
             config_local = os.path.exists(config_path_local)
-            config_intree = os.path.exists(config_path_intree)
-            config_intree_extra = os.path.exists(_config_path_intree_extra)
-            config_pkg_base = os.path.join('etc', config_filename)
+            config_pkg_base = os.path.join('etc', 'avocado', config_filename)
             config_pkg = resource_exists('avocado', config_pkg_base)
             config_path_pkg = resource_filename('avocado', config_pkg_base)
+            _config_pkg_extra = os.path.join('etc', 'avocado', 'conf.d')
+            if resource_isdir('avocado', _config_pkg_extra):
+                config_pkg_extra = resource_listdir('avocado',
+                                                    _config_pkg_extra)
+                _config_pkg_extra = resource_filename('avocado', _config_pkg_extra)
+            else:
+                config_pkg_extra = None
             if not (config_system or config_local or
-                    config_intree or config_pkg):
+                    config_pkg):
                 raise ConfigFileNotFound([config_path_system,
                                           config_path_local,
-                                          config_path_intree,
                                           config_path_pkg])
-            # First try in-tree config
-            if config_intree:
-                self.process_config_path(config_path_intree)
-                if config_intree_extra:
-                    for extra_file in glob.glob(os.path.join(_config_path_intree_extra, '*.conf')):
+            # First try pkg/in-tree config
+            if config_pkg:
+                self.process_config_path(config_path_pkg)
+                if config_pkg_extra:
+                    for extra_file in (os.path.join(_config_pkg_extra, _)
+                                       for _ in config_pkg_extra
+                                       if _.endswith('.conf')):
                         self.process_config_path(extra_file)
             # Override with system config
             if config_system:

--- a/avocado/plugins/config.py
+++ b/avocado/plugins/config.py
@@ -37,13 +37,13 @@ class Config(CLICmd):
                             'Current: %(default)s')
 
     def run(self, args):
-        LOG_UI.info('Config files read (in order):')
-        for cfg_path in settings.config_paths:
-            LOG_UI.debug('    %s', cfg_path)
-        if settings.config_paths_failed:
-            LOG_UI.error('\nConfig files that failed to read:')
-            for cfg_path in settings.config_paths_failed:
-                LOG_UI.error('    %s', cfg_path)
+        LOG_UI.info("Config files read (in order, '*' means the file exists "
+                    "and had been read):")
+        for cfg_path in settings.all_config_paths:
+            if cfg_path in settings.config_paths:
+                LOG_UI.debug('    * %s', cfg_path)
+            else:
+                LOG_UI.debug('      %s', cfg_path)
         LOG_UI.debug("")
         if not args.datadir:
             blength = 0


### PR DESCRIPTION
I'm leaving on vacation, so let me share the WiP for https://trello.com/c/NxqPTjh2/1118-avocadovt-add-avocado-and-other-requirements

This PR fixes several issues in "avocado.core.settings" and on top adds plugin to allow to extend/modify the list of config-file locations to be parsed into settings. This plugin is to be used by Avocado-vt (and hopefully other plugins will follow) to clearly define their config files.