### PR TITLE
avocado.utils.distro: remove dependency on deprecated platform.dist

### DIFF
--- a/avocado/utils/distro.py
+++ b/avocado/utils/distro.py
@@ -19,7 +19,6 @@ it's running under.
 
 import os
 import re
-import platform
 
 
 __all__ = ['LinuxDistro',
@@ -261,41 +260,6 @@ class Probe(object):
         return distro
 
 
-class StdLibProbe(Probe):
-
-    """
-    Probe that uses the Python standard library builtin detection
-
-    This Probe has a lower score on purpose, serving as a fallback
-    if no explicit (and hopefully more accurate) probe exists.
-    """
-
-    def get_distro(self):
-        name = None
-        version = UNKNOWN_DISTRO_VERSION
-        release = UNKNOWN_DISTRO_RELEASE
-
-        d_name, d_version_release, _ = platform.dist()
-        if d_name:
-            name = d_name
-
-        if '.' in d_version_release:
-            d_version, d_release = d_version_release.split('.', 1)
-            version = d_version
-            release = d_release
-        else:
-            version = d_version_release
-
-        arch = os.uname()[4]
-
-        if name is not None:
-            distro = LinuxDistro(name, version, release, arch)
-        else:
-            distro = UNKNOWN_DISTRO
-
-        return distro
-
-
 class RedHatProbe(Probe):
 
     """
@@ -446,7 +410,6 @@ register_probe(FedoraProbe)
 register_probe(AmazonLinuxProbe)
 register_probe(DebianProbe)
 register_probe(SUSEProbe)
-register_probe(StdLibProbe)
 
 
 def detect():


### PR DESCRIPTION
The standard library platform.dist function has been deprecated since
2.6, and has now been removed in 3.8.  Since we used as mostly a
fallback probe (other more specific ones are present), it seems safe
to remove this one, and probably wiser to remove it "sooner" than
"even later".

Reference: https://trello.com/c/f2g8BUSt
Reference: https://docs.python.org/2/library/platform.html#platform.dist
Signed-off-by: Cleber Rosa <crosa@redhat.com>