### PR TITLE
Travis: bump PyYAML pinned version to 3.13

### DIFF
--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -8,7 +8,7 @@ Sphinx==1.3b1
 inspektor==0.5.2
 pep8==1.7.1
 requests==1.2.3
-PyYAML==3.11
+PyYAML==3.13
 Pillow==2.8.1
 mock==1.2.0; python_version <= '2.7'
 aexpect==1.4.0


### PR DESCRIPTION
PyYAML is the first failure on Travis' Python Nightly jobs.  The
version we're using is ancient, dating from Mar 27, 2014.  Let's
update that and see how the nightly job goes.

Signed-off-by: Cleber Rosa <crosa@redhat.com>