### PR TITLE
Adds unit tests for utils.memory.get_buddy_info v3

### DIFF
--- a/selftests/unit/test_utils_memory.py
+++ b/selftests/unit/test_utils_memory.py
@@ -20,5 +20,80 @@ class UtilsMemoryTest(unittest.TestCase):
                     self.assertEqual(memory.numa_nodes_with_memory(), exp)
 
 
+BUDDY_INFO_RESPONSE = '\n'.join([
+    'Node 0, zone      DMA      1      1      0      0      1      1',
+    'Node 0, zone    DMA32    987    679   1004   3068   2795   1432',
+    'Node 1, zone   Normal   5430   9759   9044   9751  16482   8924',
+])
+
+
+@mock.patch('avocado.utils.memory._get_buddy_info_content', return_value=BUDDY_INFO_RESPONSE)
+class UtilsMemoryTestGetBuddyInfo(unittest.TestCase):
+
+    def test_get_buddy_info_simple_chunk_size(self, buddy_info_content_mocked):
+        chunk_size = '0'
+        result = memory.get_buddy_info(chunk_size)
+        self.assertEqual(result[chunk_size], 6418)
+
+    def test_get_buddy_info_less_than_chunk_size(self, buddy_info_content_mocked):
+        chunk_size = '<2'
+        result = memory.get_buddy_info(chunk_size)
+        self.assertEqual(result['0'], 6418)
+        self.assertEqual(result['1'], 10439)
+
+    def test_get_buddy_info_less_than_equal_chunk_size(self, buddy_info_content_mocked):
+        chunk_size = '<=2'
+        result = memory.get_buddy_info(chunk_size)
+        self.assertEqual(result['0'], 6418)
+        self.assertEqual(result['1'], 10439)
+        self.assertEqual(result['2'], 10048)
+
+    def test_get_buddy_info_greater_than_chunk_size(self, buddy_info_content_mocked):
+        chunk_size = '>3'
+        result = memory.get_buddy_info(chunk_size)
+        self.assertEqual(result['4'], 19278)
+        self.assertEqual(result['5'], 10357)
+
+    def test_get_buddy_info_greater_than_equal_chunk_size(self, buddy_info_content_mocked):
+        chunk_size = '>=3'
+        result = memory.get_buddy_info(chunk_size)
+        self.assertEqual(result['3'], 12819)
+        self.assertEqual(result['4'], 19278)
+        self.assertEqual(result['5'], 10357)
+
+    def test_get_buddy_info_multiple_chunk_size(self, buddy_info_content_mocked):
+        chunk_size = '2 4'
+        result = memory.get_buddy_info(chunk_size)
+        self.assertEqual(result['2'], 10048)
+        self.assertEqual(result['4'], 19278)
+
+    def test_get_buddy_info_multiple_chunk_size_filtering_simple(self, buddy_info_content_mocked):
+        chunk_size = '>2 <4'
+        result = memory.get_buddy_info(chunk_size)
+        self.assertEqual(result['3'], 12819)
+
+    def test_get_buddy_info_multiple_chunk_size_filtering(self, buddy_info_content_mocked):
+        chunk_size = '>=2 <=4'
+        result = memory.get_buddy_info(chunk_size)
+        self.assertEqual(result['2'], 10048)
+        self.assertEqual(result['3'], 12819)
+        self.assertEqual(result['4'], 19278)
+
+    def test_get_buddy_info_multiple_chunk_size_filtering_invalid(self, buddy_info_content_mocked):
+        chunk_size = '>2 <2'
+        result = memory.get_buddy_info(chunk_size)
+        self.assertEqual(result, {})
+
+    def test_get_buddy_info_filtering_node(self, buddy_info_content_mocked):
+        chunk_size = '0'
+        result = memory.get_buddy_info(chunk_size, nodes='1')
+        self.assertEqual(result[chunk_size], 5430)
+
+    def test_get_buddy_info_filtering_zone(self, buddy_info_content_mocked):
+        chunk_size = '0'
+        result = memory.get_buddy_info(chunk_size, zones='DMA32')
+        self.assertEqual(result[chunk_size], 987)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
There is a pylint issue in the current utils.memory module. The
function get_buddy_info() makes use of eval()[1] what is
discouraged. In order to enable more pylint checkers, this eval()
call will be removed in a next PR. However, to minimize potential
problems considering that the change needed is not too small, this
current PR adds unit tests for the function.

It was also considered this change is valuable for the project as it is.

The tests was done mocking the real output of `/proc/buddyinfo`. To make
it easier the process to get the buddy info content was extracted for a
specific function that actually only wraps the open call. This way we
can mock this function return only instead of try mock the builtin open
function.

[1] - https://github.com/avocado-framework/avocado/blob/master/avocado/utils/memory.py#L407

Signed-off-by: Caio Carrara <ccarrara@redhat.com>

---
Changes from v2 (#2777)
* Improve mocking `_get_buddy_info_content()`