### PR TITLE
avocado.utils.iso9660: add capabilities and create/write [v2]

### DIFF
--- a/selftests/unit/test_utils_iso9660.py
+++ b/selftests/unit/test_utils_iso9660.py
@@ -6,7 +6,38 @@ import shutil
 import tempfile
 import unittest
 
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+
 from avocado.utils import iso9660, process
+
+
+class Capabilities(unittest.TestCase):
+
+    def setUp(self):
+        self.iso_path = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                                     os.path.pardir, ".data",
+                                                     "sample.iso"))
+
+    @mock.patch('avocado.utils.iso9660.has_pycdlib', return_value=True)
+    def test_capabilities_pycdlib(self, has_pycdlib_mocked):
+        instance = iso9660.iso9660(self.iso_path, ['read'])
+        self.assertIsInstance(instance, iso9660.ISO9660PyCDLib)
+
+    @mock.patch('avocado.utils.iso9660.has_pycdlib', return_value=False)
+    @mock.patch('avocado.utils.iso9660.has_isoinfo', return_value=False)
+    @mock.patch('avocado.utils.iso9660.has_isoread', return_value=False)
+    @mock.patch('avocado.utils.iso9660.can_mount', return_value=False)
+    def test_capabilities_nobackend(self, has_pycdlib_mocked, has_isoinfo_mocked,
+                                    has_isoread_mocked, can_mount_mocked):
+        self.assertIsNone(iso9660.iso9660(self.iso_path, ['read']))
+
+    def test_non_existing_capabilities(self):
+        self.assertIsNone(iso9660.iso9660(self.iso_path,
+                                          ['non-existing', 'capabilities']))
 
 
 class BaseIso9660(unittest.TestCase):

--- a/selftests/unit/test_utils_iso9660.py
+++ b/selftests/unit/test_utils_iso9660.py
@@ -24,7 +24,7 @@ class Capabilities(unittest.TestCase):
 
     @mock.patch('avocado.utils.iso9660.has_pycdlib', return_value=True)
     def test_capabilities_pycdlib(self, has_pycdlib_mocked):
-        instance = iso9660.iso9660(self.iso_path, ['read'])
+        instance = iso9660.iso9660(self.iso_path, ['read', 'create'])
         self.assertIsInstance(instance, iso9660.ISO9660PyCDLib)
 
     @mock.patch('avocado.utils.iso9660.has_pycdlib', return_value=False)
@@ -172,6 +172,13 @@ class PyCDLib(BaseIso9660):
     def test_basic_workflow(self):
         """Call the basic workflow"""
         self.basic_workflow()
+
+    def test_create(self):
+        new_iso_path = os.path.join(self.tmpdir, 'new.iso')
+        new_iso = iso9660.ISO9660PyCDLib(new_iso_path)
+        new_iso.create()
+        new_iso.close()
+        self.assertTrue(os.path.isfile(new_iso_path))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This adds a capabilities selection mechanism for users of `avocado.utils.iso9660.iso9660` and ISO image creation support for the ISO9660PyCDLib backend.  More backends may add the same capabilities later.

---

Changes from v1 (#2756):
 * Moved `content` variable outside of the for loop on `test_create_write`
 * Rewritten capabilities tests, mocking the checks for external tools for better predictability 