### PR TITLE
Enable pylint exception related checks and more

### DIFF
--- a/avocado/plugins/diff.py
+++ b/avocado/plugins/diff.py
@@ -356,7 +356,7 @@ class Diff(CLICmd):
             try:
                 resultsdir = jobdata.get_resultsdir(logdir, job_id)
             except ValueError as exception:
-                LOG_UI.error(exception.message)
+                LOG_UI.error(exception)
                 sys.exit(exit_codes.AVOCADO_FAIL)
 
         if resultsdir is None:

--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -189,7 +189,7 @@ class Replay(CLI):
         try:
             resultsdir = jobdata.get_resultsdir(base_logdir, args.replay_jobid)
         except ValueError as exception:
-            LOG_UI.error(exception.message)
+            LOG_UI.error(exception)
             sys.exit(exit_codes.AVOCADO_FAIL)
 
         if resultsdir is None:

--- a/avocado/utils/filelock.py
+++ b/avocado/utils/filelock.py
@@ -63,7 +63,7 @@ class FileLock(object):
                         try:
                             content = f.read()
                         except Exception as detail:
-                            raise LockFailed(detail.message)
+                            raise LockFailed(detail)
 
                     # If file is empty, I guess someone created it with 'touch'
                     # to manually lock the file.

--- a/avocado/utils/memory.py
+++ b/avocado/utils/memory.py
@@ -410,8 +410,8 @@ def get_buddy_info(chunk_sizes, nodes="all", zones="all"):
 
     if re.findall("[<>=]", chunk_sizes) and buddy_list:
         size_list = range(len(buddy_list[-1][-1].strip().split()))
-        chunk_sizes = [str(_) for _ in size_list if eval("%s %s" % (_,
-                                                                    chunk_sizes))]
+        chunk_sizes = [str(_) for _ in size_list
+                       if eval("%s %s" % (_, chunk_sizes))]  # pylint: disable=W0123
 
         chunk_sizes = ' '.join(chunk_sizes)
 

--- a/contrib/scripts/avocado-find-unittests
+++ b/contrib/scripts/avocado-find-unittests
@@ -34,7 +34,7 @@ if __name__ == '__main__':
         try:
             test_class_methods = find_class_and_methods(test_module_path,
                                                         re.compile(r'test.*'))
-        except:
+        except IOError as error:
             continue
         for klass, methods in test_class_methods.items():
             if test_module_path.endswith(".py"):

--- a/contrib/scripts/avocado-get-job-results-dir.py
+++ b/contrib/scripts/avocado-get-job-results-dir.py
@@ -41,7 +41,7 @@ if __name__ == '__main__':
     try:
         resultsdir = jobdata.get_resultsdir(logdir, sys.argv[1])
     except ValueError as exception:
-        sys.stderr.write('%s\n' % exception.message)
+        sys.stderr.write('%s\n' % exception)
         sys.exit(-1)
     else:
         if resultsdir is None:

--- a/optional_plugins/runner_vm/avocado_runner_vm/__init__.py
+++ b/optional_plugins/runner_vm/avocado_runner_vm/__init__.py
@@ -385,7 +385,7 @@ class VMTestRunner(RemoteTestRunner):
             self.vm = vm_connect(self.job.args.vm_domain,
                                  self.job.args.vm_hypervisor_uri)
         except VirtError as exception:
-            raise exceptions.JobError(exception.message)
+            raise exceptions.JobError(exception)
         if self.vm.start() is False:
             e_msg = "Could not start VM '%s'" % self.job.args.vm_domain
             raise exceptions.JobError(e_msg)

--- a/selftests/checkall
+++ b/selftests/checkall
@@ -167,7 +167,7 @@ results_dir_content() {
 }
 
 [ "$SKIP_RESULTSDIR_CHECK" ] || RESULTS_DIR_CONTENT="$(ls $RESULTS_DIR 2> /dev/null)"
-run_rc lint 'inspekt lint --exclude=.git --enable R0401,W0101,W0102,W0104,W0105,W0106,W0107,W0108,W0109,W0110,W0111,W0120,W0404,W0611,W0612,W0622'
+run_rc lint 'inspekt lint --exclude=.git --enable R0401,W0101,W0102,W0104,W0105,W0106,W0107,W0108,W0109,W0110,W0111,W0120,W0122,W0123,W0124,W0125,W0150,W0404,W0611,W0612,W0622,W1645'
 # Skip checking test_utils_cpu.py due to inspektor bug
 run_rc indent 'inspekt indent --exclude=.git,selftests/unit/test_utils_cpu.py'
 run_rc style 'inspekt style --exclude=.git --disable E501,E265,W601,E402,E722'


### PR DESCRIPTION
This change enables W0150 (lost-exception) and W1645 (Exception.message
removed in Python 3) related to exception heandling.

This change also enables other checks that didn't require code changes
W0122, W0123, W0124, W0125.

Reference: https://trello.com/c/Ohh7Q6qj
Signed-off-by: Caio Carrara <ccarrara@redhat.com>