### PR TITLE
Creates env var to define parallel lint execution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ python:
     - "3.6"
     - "nightly"
 
+env:
+    - AVOCADO_PARALLEL_LINT=1
+
 branches:
     only:
         - master

--- a/selftests/checkall
+++ b/selftests/checkall
@@ -167,7 +167,15 @@ results_dir_content() {
 }
 
 [ "$SKIP_RESULTSDIR_CHECK" ] || RESULTS_DIR_CONTENT="$(ls $RESULTS_DIR 2> /dev/null)"
-run_rc lint 'inspekt lint --exclude=.git --enable R0401,W0101,W0102,W0104,W0105,W0106,W0107,W0108,W0109,W0110,W0111,W0120,W0122,W0123,W0124,W0125,W0150,W0404,W0611,W0612,W0622,W1645'
+
+LINT_CMD="inspekt lint --exclude=.git"
+PYLINT_ENABLE="--enable R0401,W0101,W0102,W0104,W0105,W0106,W0107,W0108,W0109,W0110,W0111,W0120,W0122,W0123,W0124,W0125,W0150,W0404,W0611,W0612,W0622,W1645"
+if [ "$AVOCADO_PARALLEL_LINT" ]; then
+    LINT_CMD="$LINT_CMD --parallel=$AVOCADO_PARALLEL_LINT"
+fi
+
+run_rc lint "$LINT_CMD $PYLINT_ENABLE"
+
 # Skip checking test_utils_cpu.py due to inspektor bug
 run_rc indent 'inspekt indent --exclude=.git,selftests/unit/test_utils_cpu.py'
 run_rc style 'inspekt style --exclude=.git --disable E501,E265,W601,E402,E722'


### PR DESCRIPTION
This change introduce `AVOCADO_PARALLEL_LINT` variable to
`selftest/checkall` script to make possible set the parallel lint
execution per environment.

Since currently the Travis CI is failing due lint parallel execution,
this change already sets `AVOCADO_PARALLEL_LINT=1` in Travis CI.

Reference: https://trello.com/c/LQ0szonH
Signed-off-by: Caio Carrara <ccarrara@redhat.com>