### PR TITLE
avocado/utils/partition.py: do not blow up on systems with no lsof [v2]

### DIFF
--- a/selftests/unit/test_utils_partition.py
+++ b/selftests/unit/test_utils_partition.py
@@ -25,10 +25,10 @@ def missing_binary(binary):
         return True
 
 
-class TestPartition(unittest.TestCase):
+class Base(unittest.TestCase):
 
     """
-    Unit tests for avocado.utils.partition
+    Common setUp/tearDown for partition tests
     """
 
     @unittest.skipIf(not os.path.isfile('/proc/mounts'),
@@ -45,6 +45,13 @@ class TestPartition(unittest.TestCase):
         self.disk = partition.Partition(os.path.join(self.tmpdir, "block"), 1,
                                         self.mountpoint)
 
+    def tearDown(self):
+        self.disk.unmount()
+        shutil.rmtree(self.tmpdir)
+
+
+class TestPartition(Base):
+
     def test_basic(self):
         """ Test the basic workflow """
         self.assertIsNone(self.disk.get_mountpoint())
@@ -59,12 +66,22 @@ class TestPartition(unittest.TestCase):
             proc_mounts = proc_mounts_file.read()
             self.assertNotIn(self.mountpoint, proc_mounts)
 
+
+class TestPartitionMkfsMount(Base):
+
+    """
+    Tests that assume a filesystem and mounted partition
+    """
+
+    def setUp(self):
+        super(TestPartitionMkfsMount, self).setUp()
+        self.disk.mkfs()
+        self.disk.mount()
+
     @unittest.skipIf(not process.can_sudo('kill -l'),
                      "requires running kill as a privileged user")
     def test_force_unmount(self):
         """ Test force-unmount feature """
-        self.disk.mkfs()
-        self.disk.mount()
         with open("/proc/mounts") as proc_mounts_file:
             proc_mounts = proc_mounts_file.read()
             self.assertIn(self.mountpoint, proc_mounts)
@@ -79,8 +96,6 @@ class TestPartition(unittest.TestCase):
 
     def test_double_mount(self):
         """ Check the attempt for second mount fails """
-        self.disk.mkfs()
-        self.disk.mount()
         with open("/proc/mounts") as proc_mounts_file:
             proc_mounts = proc_mounts_file.read()
             self.assertIn(self.mountpoint, proc_mounts)
@@ -89,8 +104,6 @@ class TestPartition(unittest.TestCase):
 
     def test_double_umount(self):
         """ Check double unmount works well """
-        self.disk.mkfs()
-        self.disk.mount()
         with open("/proc/mounts") as proc_mounts_file:
             proc_mounts = proc_mounts_file.read()
             self.assertIn(self.mountpoint, proc_mounts)
@@ -105,16 +118,10 @@ class TestPartition(unittest.TestCase):
 
     def test_format_mounted(self):
         """ Check format on mounted device fails """
-        self.disk.mkfs()
-        self.disk.mount()
         with open("/proc/mounts") as proc_mounts_file:
             proc_mounts = proc_mounts_file.read()
             self.assertIn(self.mountpoint, proc_mounts)
         self.assertRaises(partition.PartitionError, self.disk.mkfs)
-
-    def tearDown(self):
-        self.disk.unmount()
-        shutil.rmtree(self.tmpdir)
 
 
 @unittest.skipIf(not os.path.isfile('/etc/mtab'),

--- a/selftests/unit/test_utils_partition.py
+++ b/selftests/unit/test_utils_partition.py
@@ -47,7 +47,7 @@ class TestPartition(unittest.TestCase):
 
     def test_basic(self):
         """ Test the basic workflow """
-        self.assertEqual(None, self.disk.get_mountpoint())
+        self.assertIsNone(self.disk.get_mountpoint())
         self.disk.mkfs()
         self.disk.mount()
         with open("/proc/mounts") as proc_mounts_file:

--- a/selftests/unit/test_utils_partition.py
+++ b/selftests/unit/test_utils_partition.py
@@ -78,6 +78,7 @@ class TestPartitionMkfsMount(Base):
         self.disk.mkfs()
         self.disk.mount()
 
+    @unittest.skipIf(missing_binary('lsof'), "requires running lsof")
     @unittest.skipIf(not process.can_sudo('kill -l'),
                      "requires running kill as a privileged user")
     def test_force_unmount(self):


### PR DESCRIPTION
Better deal with situations where `lsof` is not available, or `kill` fails.

Changes from v1 (#2769):
 * Added unittest style change
 * Added unittest classes refactor
 * Refactor method to get pids
 * Added error logging and exception raising on error conditions