### PR TITLE
avocado/utils/partition.py: do not blow up on systems with no lsof [v4]

### DIFF
--- a/avocado/utils/partition.py
+++ b/avocado/utils/partition.py
@@ -242,6 +242,31 @@ class Partition(object):
         # Update the fstype as the mount command passed
         self.fstype = fstype
 
+    def _get_pids_on_mountpoint(self, mnt):
+        """
+        Returns a list of processes using a given mountpoint
+        """
+        try:
+            FileNotFoundError
+        except NameError:
+            FileNotFoundError = IOError   # pylint: disable=W0622
+        try:
+            cmd = "lsof " + mnt
+            out = process.system_output(cmd)
+            return [int(line.split()[1]) for line in out.splitlines()[1:]]
+        except FileNotFoundError as details:
+            msg = 'Could not find lsof executable'
+            LOG.error(msg)
+            raise PartitionError(self, msg, details)
+        except OSError as details:
+            msg = 'Could not run lsof to identify processes using "%s"' % mnt
+            LOG.error(msg)
+            raise PartitionError(self, msg, details)
+        except process.CmdError as details:
+            msg = 'Failure executing "%s"' % cmd
+            LOG.error(msg)
+            raise PartitionError(self, msg, details)
+
     def _unmount_force(self, mountpoint):
         """
         Kill all other jobs accessing this partition and force unmount it.
@@ -249,15 +274,11 @@ class Partition(object):
         :return: None
         :raise PartitionError: On critical failure
         """
-        # Human readable list of processes
-        out = process.system_output("lsof " + mountpoint, ignore_status=True)
-        # Try to kill all pids
-        for pid in (line.split()[1] for line in out.splitlines()[1:]):
+        for pid in self._get_pids_on_mountpoint(mountpoint):
             try:
-                process.system("kill -9 %d" % int(pid), ignore_status=True,
-                               sudo=True)
-            except OSError:
-                pass
+                process.system("kill -9 %d" % pid, ignore_status=True, sudo=True)
+            except process.CmdError as details:
+                raise PartitionError(self, "Failed to kill processes", details)
         # Unmount
         try:
             process.run("umount -f %s" % mountpoint, sudo=True)

--- a/selftests/unit/test_utils_partition.py
+++ b/selftests/unit/test_utils_partition.py
@@ -25,10 +25,10 @@ def missing_binary(binary):
         return True
 
 
-class TestPartition(unittest.TestCase):
+class Base(unittest.TestCase):
 
     """
-    Unit tests for avocado.utils.partition
+    Common setUp/tearDown for partition tests
     """
 
     @unittest.skipIf(not os.path.isfile('/proc/mounts'),
@@ -45,6 +45,13 @@ class TestPartition(unittest.TestCase):
         self.disk = partition.Partition(os.path.join(self.tmpdir, "block"), 1,
                                         self.mountpoint)
 
+    def tearDown(self):
+        self.disk.unmount()
+        shutil.rmtree(self.tmpdir)
+
+
+class TestPartition(Base):
+
     def test_basic(self):
         """ Test the basic workflow """
         self.assertIsNone(self.disk.get_mountpoint())
@@ -59,12 +66,22 @@ class TestPartition(unittest.TestCase):
             proc_mounts = proc_mounts_file.read()
             self.assertNotIn(self.mountpoint, proc_mounts)
 
+
+class TestPartitionMkfsMount(Base):
+
+    """
+    Tests that assume a filesystem and mounted partition
+    """
+
+    def setUp(self):
+        super(TestPartitionMkfsMount, self).setUp()
+        self.disk.mkfs()
+        self.disk.mount()
+
     @unittest.skipIf(not process.can_sudo('kill -l'),
                      "requires running kill as a privileged user")
     def test_force_unmount(self):
         """ Test force-unmount feature """
-        self.disk.mkfs()
-        self.disk.mount()
         with open("/proc/mounts") as proc_mounts_file:
             proc_mounts = proc_mounts_file.read()
             self.assertIn(self.mountpoint, proc_mounts)
@@ -79,8 +96,6 @@ class TestPartition(unittest.TestCase):
 
     def test_double_mount(self):
         """ Check the attempt for second mount fails """
-        self.disk.mkfs()
-        self.disk.mount()
         with open("/proc/mounts") as proc_mounts_file:
             proc_mounts = proc_mounts_file.read()
             self.assertIn(self.mountpoint, proc_mounts)
@@ -89,8 +104,6 @@ class TestPartition(unittest.TestCase):
 
     def test_double_umount(self):
         """ Check double unmount works well """
-        self.disk.mkfs()
-        self.disk.mount()
         with open("/proc/mounts") as proc_mounts_file:
             proc_mounts = proc_mounts_file.read()
             self.assertIn(self.mountpoint, proc_mounts)
@@ -105,16 +118,10 @@ class TestPartition(unittest.TestCase):
 
     def test_format_mounted(self):
         """ Check format on mounted device fails """
-        self.disk.mkfs()
-        self.disk.mount()
         with open("/proc/mounts") as proc_mounts_file:
             proc_mounts = proc_mounts_file.read()
             self.assertIn(self.mountpoint, proc_mounts)
         self.assertRaises(partition.PartitionError, self.disk.mkfs)
-
-    def tearDown(self):
-        self.disk.unmount()
-        shutil.rmtree(self.tmpdir)
 
 
 @unittest.skipIf(not os.path.isfile('/etc/mtab'),

--- a/selftests/unit/test_utils_partition.py
+++ b/selftests/unit/test_utils_partition.py
@@ -47,7 +47,7 @@ class TestPartition(unittest.TestCase):
 
     def test_basic(self):
         """ Test the basic workflow """
-        self.assertEqual(None, self.disk.get_mountpoint())
+        self.assertIsNone(self.disk.get_mountpoint())
         self.disk.mkfs()
         self.disk.mount()
         with open("/proc/mounts") as proc_mounts_file:

--- a/selftests/unit/test_utils_partition.py
+++ b/selftests/unit/test_utils_partition.py
@@ -78,6 +78,7 @@ class TestPartitionMkfsMount(Base):
         self.disk.mkfs()
         self.disk.mount()
 
+    @unittest.skipIf(missing_binary('lsof'), "requires running lsof")
     @unittest.skipIf(not process.can_sudo('kill -l'),
                      "requires running kill as a privileged user")
     def test_force_unmount(self):
@@ -93,6 +94,36 @@ class TestPartitionMkfsMount(Base):
         with open("/proc/mounts") as proc_mounts_file:
             proc_mounts = proc_mounts_file.read()
             self.assertNotIn(self.mountpoint, proc_mounts)
+
+    @unittest.skipUnless(missing_binary('lsof'), "requires not having lsof")
+    def test_force_unmount_no_lsof(self):
+        """ Checks that a force-unmount will fail on systems without lsof """
+        with open("/proc/mounts") as proc_mounts_file:
+            proc_mounts = proc_mounts_file.read()
+            self.assertIn(self.mountpoint, proc_mounts)
+            proc = process.SubProcess("cd %s; while :; do echo a > a; rm a; done"
+                                      % self.mountpoint, shell=True)
+            proc.start()
+            self.assertRaises(partition.PartitionError, self.disk.unmount)
+            proc.terminate()
+            proc.wait()
+
+    def test_force_unmount_get_pids_fail(self):
+        """ Checks PartitionError is raised if there's no lsof to get pids """
+        with open("/proc/mounts") as proc_mounts_file:
+            proc_mounts = proc_mounts_file.read()
+            self.assertIn(self.mountpoint, proc_mounts)
+            proc = process.SubProcess("cd %s; while :; do echo a > a; rm a; done"
+                                      % self.mountpoint, shell=True)
+            proc.start()
+            with mock.patch('avocado.utils.partition.process.run',
+                            side_effect=process.CmdError):
+                with mock.patch('avocado.utils.partition.process.system_output',
+                                side_effect=OSError) as mocked_system_output:
+                    self.assertRaises(partition.PartitionError, self.disk.unmount)
+                    mocked_system_output.assert_called_with('lsof ' + self.mountpoint)
+            proc.terminate()
+            proc.wait()
 
     def test_double_mount(self):
         """ Check the attempt for second mount fails """


### PR DESCRIPTION
This deals better with situations where `lsof` is not available, or `kill` fails.

Changes from v3 (#2792):
 * Added a `pylint: disable=W0622` do ignore the "redefinition" of `FileNotFoundError`

Changes from v2 (#2789):
 * Fixed string formatting
 * Treated `FileNotFoundError` exception and added alias on Python 2
 * Added test for real behavior on systems without `lsof`
 * Added test with mocked behavior for getting PIDs using mountpoint

Changes from v1 (#2769):
 * Added unittest style change
 * Added unittest classes refactor
 * Refactor method to get pids
 * Added error logging and exception raising on error conditions