### PR TITLE
Update exception raise style to not brake lint

### DIFF
--- a/avocado/core/decorators.py
+++ b/avocado/core/decorators.py
@@ -45,8 +45,8 @@ def fail_on(exceptions=None):
             """ Function wrapper """
             try:
                 return func(*args, **kwargs)
-            except core_exceptions.TestBaseException:
-                raise
+            except core_exceptions.TestBaseException as exc:
+                raise exc
             except exceptions as details:
                 raise core_exceptions.TestFail(str(details))
         return wrap


### PR DESCRIPTION
There's a case where PyLint cannot deal well with raise without explicit
exception.  This change update one of this kind of occurence in Avocado
code base so lint can run successfully again.

Worth to mention there's other cases of this kind of raise in Avocado.
However seems the case of this PR is unique. Perhaps due it's in a decorator,
I don't know exactly.

Signed-off-by: Caio Carrara <ccarrara@redhat.com>