### PR TITLE
Sysinfo: fix post collection on non-PASS tests

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -917,6 +917,9 @@ class Test(unittest.TestCase, TestData):
                                                 logger=LOG_JOB)
                         stderr_check_exception = details
 
+        if self.__sysinfo_enabled:
+            self.__sysinfo_logger.end_test_hook()
+
         # pylint: disable=E0702
         if test_exception is not None:
             raise test_exception
@@ -934,8 +937,6 @@ class Test(unittest.TestCase, TestData):
                                       "details.")
 
         self.__status = 'PASS'
-        if self.__sysinfo_enabled:
-            self.__sysinfo_logger.end_test_hook()
 
     def _setup_environment_variables(self):
         os.environ['AVOCADO_VERSION'] = VERSION


### PR DESCRIPTION
The current sysinfo end_test() hook is badly positioned, in a way that
it only gets called if no exception is raised (that is, tests end with
PASS).

Signed-off-by: Cleber Rosa <crosa@redhat.com>