### PR TITLE
avocado.utils.distro: introduce UbuntuProbe

### DIFF
--- a/avocado/utils/distro.py
+++ b/avocado/utils/distro.py
@@ -349,6 +349,19 @@ class DebianProbe(Probe):
     CHECK_FILE_DISTRO_NAME = 'debian'
 
 
+class UbuntuProbe(Probe):
+
+    """
+    Simple probe for Ubunt systems in general
+    """
+
+    CHECK_FILE = '/etc/os-release'
+    CHECK_FILE_CONTAINS = 'ubuntu'
+    CHECK_FILE_DISTRO_NAME = 'Ubuntu'
+    CHECK_VERSION_REGEX = re.compile(r'.*VERSION_ID=\"(\d+)\.(\d+)\".*',
+                                     re.MULTILINE | re.DOTALL)
+
+
 class SUSEProbe(Probe):
 
     """
@@ -410,6 +423,7 @@ register_probe(FedoraProbe)
 register_probe(AmazonLinuxProbe)
 register_probe(DebianProbe)
 register_probe(SUSEProbe)
+register_probe(UbuntuProbe)
 
 
 def detect():


### PR DESCRIPTION
While running avocado in ubuntu system distro.detect().name has output
"unknown".  This is probably due to the removal of StdLibProbe.  Let's
add a proper Ubuntu probe.  Before this:

    >>> distro.detect().version and distro.detect().release
    0
    >>> from avocado.utils import distro
    >>> distro.detect().name
    unknown
    >>> distro.detect().version
    0
    >>> distro.detect().release
    0

After this patch:

    >>> from avocado.utils import distro
    >>> print distro.detect().name
    Ubuntu
    >>> print distro.detect().version
    18
    >>> print distro.detect().release
    04

Reported-by:   Kamalesh Babulal <kamalesh@linux.vnet.ibm.com>
Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>
Signed-off-by: Cleber Rosa <crosa@redhat.com>