### PR TITLE
avocado.utils.distro: simplify AmazonProbe

### DIFF
--- a/avocado/utils/distro.py
+++ b/avocado/utils/distro.py
@@ -304,40 +304,8 @@ class AmazonLinuxProbe(Probe):
     CHECK_FILE = '/etc/os-release'
     CHECK_FILE_CONTAINS = 'Amazon Linux'
     CHECK_FILE_DISTRO_NAME = 'amzn'
-
-    def get_distro(self):
-        dst = Probe.get_distro(self)
-
-        if not dst.name == self.CHECK_FILE_DISTRO_NAME:
-            return dst
-
-        version_re = re.compile(r'VERSION="(.*)"')
-        version = None
-
-        with open(self.CHECK_FILE) as check_file:
-            for line in check_file:
-                match = version_re.match(line)
-                if match:
-                    version = match.group(1)
-                    break
-
-        if version:
-            version_parts = version.split()
-            if len(version_parts) == 1:
-                dst.version = 1
-                try:
-                    dst.release = re.findall(r'\d*\.\d*', version_parts[0])[0]
-                except IndexError:
-                    dst.release = UNKNOWN_DISTRO_RELEASE
-            else:
-                try:
-                    dst.version = int(version_parts[0].split('.')[0])
-                    dst.release = re.findall(r'\d*\.\d*', version_parts[1])[0]
-                except IndexError:
-                    dst.version = UNKNOWN_DISTRO_VERSION
-                    dst.release = UNKNOWN_DISTRO_RELEASE
-
-        return dst
+    CHECK_VERSION_REGEX = re.compile(r'.*VERSION=\"(\d+)\.(\d+)\".*',
+                                     re.MULTILINE | re.DOTALL)
 
 
 class DebianProbe(Probe):


### PR DESCRIPTION
Based on the distro module API, it should be possible to get the
version and release simply by providing a regex that has either one or
two groups.

Signed-off-by: Cleber Rosa <crosa@redhat.com>