### PR TITLE
avocado.utils.vmimage: differentiate against base and concrete classes [v2]

### DIFF
--- a/avocado/utils/vmimage.py
+++ b/avocado/utils/vmimage.py
@@ -386,9 +386,9 @@ def list_providers():
     List the available Image Providers
     """
     return set(_ for _ in itervalues(globals())
-               if (_ != ImageProviderBase and
-                   isinstance(_, type) and
-                   issubclass(_, ImageProviderBase)))
+               if (isinstance(_, type) and
+                   issubclass(_, ImageProviderBase) and
+                   hasattr(_, 'name')))
 
 
 #: List of available providers classes

--- a/selftests/unit/test_utils_vmimage.py
+++ b/selftests/unit/test_utils_vmimage.py
@@ -8,6 +8,10 @@ class VMImage(unittest.TestCase):
     def test_list_providers(self):
         self.assertIsNotNone(vmimage.list_providers())
 
+    def test_concrete_providers_have_name(self):
+        for provider in vmimage.list_providers():
+            self.assertTrue(hasattr(provider, 'name'))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
First of all, a disclaimer: this is hackish.  But, it's the simplest
and thus best fix I could think of.

What happens here is that this module makes no distintcion between
what is a base class "abstract" class, and a concrete class.  With the
goal of reducing code duplication, a goal that will remain valid here
and in other modules, it made sense to create a common Fedora class.

Now, because only being a ImageProviderBase suffices, the
FedoraImageProviderBase class, which is not intended to be used as a
concrete (final) class, is being carried along and its "name" is
checked, causing crashes.

This introduces the ad-hoc, hackish, notion, that a concrete
ImageProvider is one that contains a name.

Signed-off-by: Cleber Rosa <crosa@redhat.com>

---

Changes from v1 (#2816):
 * Removed one now unnecessary check (`_ != ImageProviderBase`)