### PR TITLE
Added new disk utility in  avcoado lib

### DIFF
--- a/avocado/utils/disk.py
+++ b/avocado/utils/disk.py
@@ -12,15 +12,33 @@
 # This code was inspired in the autotest project,
 #
 # client/base_utils.py
+#
+# Copyright: 2018 IBM
+# Authors : Praveen K Pandey <praveen@linux.vnet.ibm.com>
 
 
 """
 Disk utilities
 """
 
+
 import os
+import json
+from . import process
 
 
 def freespace(path):
     fs_stats = os.statvfs(path)
     return fs_stats.f_bsize * fs_stats.f_bavail
+
+
+def get_disk_blocksize(path):
+    """Return the disk block size, in bytes"""
+    fs_stats = os.statvfs(path)
+    return fs_stats.f_bsize
+
+
+def get_disks():
+    json_result = process.run('lsblk --json')
+    json_data = json.loads(json_result.stdout_text)
+    return ['/dev/%s' % str(disk['name']) for disk in json_data['blockdevices']]


### PR DESCRIPTION
added disk utility
1- get_disk_blocksize -- this function return block size of given disk(path)
2- get_disks -- this function return all disk present in system

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>