### PR TITLE
Makefile: improve clean up of plugins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ clean:
 	for PLUGIN in $(AVOCADO_PLUGINS); do\
 		if test -f $$PLUGIN/Makefile -o -f $$PLUGIN/setup.py; then echo ">> UNLINK $$PLUGIN";\
 			if test -f $$PLUGIN/Makefile; then AVOCADO_DIRNAME=$(AVOCADO_DIRNAME) make -C $$PLUGIN unlink &>/dev/null || echo ">> FAIL $$PLUGIN";\
-			elif test -f $$PLUGIN/setup.py; then cd $$PLUGIN; $(PYTHON) setup.py develop --uninstall $(PYTHON_DEVELOP_ARGS); cd -; fi;\
+			elif test -f $$PLUGIN/setup.py; then cd $$PLUGIN; $(PYTHON) setup.py develop --uninstall $(PYTHON_DEVELOP_ARGS); $(PYTHON) setup.py clean; rm -fr build; cd -; fi;\
 		else echo ">> SKIP $$PLUGIN"; fi;\
 	done
 	$(PYTHON) setup.py develop --uninstall $(PYTHON_DEVELOP_ARGS)


### PR DESCRIPTION
The build directory of the main Avocado module is already cleaned by
the `clean` rule, but when plugins contain a build directory, they are
not currently cleaned.

Sometimes this leads to annoying `inspekt` failures, because previous
different versions of the plugin may be in the build directory, and
the error message only mentions the name of the module/class/method
violating the check, but not the exact file name.

Signed-off-by: Cleber Rosa <crosa@redhat.com>