### PR TITLE
Provide "__str__" for "CmdError" [v2]

### DIFF
--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -82,6 +82,10 @@ class CmdError(Exception):
         self.result = result
         self.additional_text = additional_text
 
+    def __str__(self):
+        return ("Command '%s' failed.\nstdout: %r\nstderr: %r\nadditional_info: %s" %
+                (self.command, self.result.stdout, self.result.stderr, self.additional_text))
+
 
 def can_sudo(cmd=None):
     """


### PR DESCRIPTION
Let's provide the "__str__" method for "CmdError" to be able to see the
actual content on print(error).

v1: https://github.com/avocado-framework/avocado/pull/2678

Changes:

```yaml
v2: Use `%r` rather than decoding the outputs
v2: Slightly simplified output and commit message
```