### PR TITLE
changes in avocado:utils:cpu utility

### DIFF
--- a/avocado/utils/cpu.py
+++ b/avocado/utils/cpu.py
@@ -212,14 +212,17 @@ def get_cpuidle_state():
     :rtype: Dict of dicts
     """
     cpus_list = cpu_online_list()
-    states = range(len(glob.glob("/sys/devices/system/cpu/cpu0/cpuidle/state*")))
+    states = range(
+        len(glob.glob("/sys/devices/system/cpu/cpu0/cpuidle/state*")))
     cpu_idlestate = {}
     for cpu in cpus_list:
         cpu_idlestate[cpu] = {}
         for state_no in states:
-            state_file = "/sys/devices/system/cpu/cpu%s/cpuidle/state%s/disable" % (cpu, state_no)
+            state_file = "/sys/devices/system/cpu/cpu%s/cpuidle/state%s/disable" % (
+                cpu, state_no)
             try:
-                cpu_idlestate[cpu][state_no] = int(open(state_file, 'rb').read())
+                cpu_idlestate[cpu][state_no] = int(
+                    open(state_file, 'rb').read())
             except IOError as err:
                 logging.warning("Failed to read idle state on cpu %s "
                                 "for state %s:\n%s", cpu, state_no, err)
@@ -265,13 +268,15 @@ def set_cpuidle_state(state_number="all", disable=True, setstate=None):
     if not setstate:
         states = []
         if state_number == 'all':
-            states = range(0, len(glob.glob("/sys/devices/system/cpu/cpu0/cpuidle/state*")))
+            states = range(
+                0, len(glob.glob("/sys/devices/system/cpu/cpu0/cpuidle/state*")))
         else:
             states.append(state_number)
         disable = _legacy_disable(disable)
         for cpu in cpus_list:
             for state_no in states:
-                state_file = "/sys/devices/system/cpu/cpu%s/cpuidle/state%s/disable" % (cpu, state_no)
+                state_file = "/sys/devices/system/cpu/cpu%s/cpuidle/state%s/disable" % (
+                    cpu, state_no)
                 try:
                     open(state_file, "wb").write(disable)
                 except IOError as err:
@@ -280,7 +285,8 @@ def set_cpuidle_state(state_number="all", disable=True, setstate=None):
     else:
         for cpu, stateval in setstate.items():
             for state_no, value in stateval.items():
-                state_file = "/sys/devices/system/cpu/cpu%s/cpuidle/state%s/disable" % (cpu, state_no)
+                state_file = "/sys/devices/system/cpu/cpu%s/cpuidle/state%s/disable" % (
+                    cpu, state_no)
                 disable = _legacy_disable(value)
                 try:
                     open(state_file, "wb").write(disable)

--- a/avocado/utils/cpu.py
+++ b/avocado/utils/cpu.py
@@ -27,6 +27,8 @@ import glob
 import logging
 import random
 
+from . import process
+
 
 def _list_matches(content_list, pattern):
     """
@@ -346,3 +348,24 @@ def get_cpufreq_governor():
     except IOError as err:
         logging.error("Unable to get the current governor\n %s", err)
         return ""
+
+
+def get_pid_cpu(pid):
+    """
+    Get the process used cpus.
+    :param pid: process id
+    :type pid: string
+    :return: A list include all cpus the process used
+    :rtype: list
+    """
+    cmd = "ps -o cpuid -L -p %s" % pid
+    cpu_pid = ''
+    try:
+        cpu_pid = process.run(cmd)
+    except Exception:
+        pass
+    if not cpu_pid:
+        return []
+    lst = set([_.strip() for _ in cpu_pid.stdout_text.splitlines()])
+    lst.remove("CPUID")
+    return list(lst)


### PR DESCRIPTION
1-Fixed style issue in avocado:utils:cpu utility
fixed pep8 issue in multiple places
2-enhance avocado:utils:cpu as a new utility 
added utility which return a list include all cpus the process
used

after this patch

>>> from avocado.utils import cpu
>>> cpu.get_pid_cpu("22207")
['1']
>>> cpu.get_pid_cpu("")
[]
>>>

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>