### PR TITLE
External Runner: support relative paths given on the command line

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -823,7 +823,8 @@ class ExternalLoader(TestLoader):
 
         if runner:
             external_runner_and_args = shlex.split(runner)
-            executable = external_runner_and_args[0]
+            executable = os.path.abspath(external_runner_and_args[0])
+            runner = " ".join([executable] + external_runner_and_args[1:])
             if not os.path.exists(executable):
                 msg = ('Could not find the external runner executable "%s"'
                        % executable)

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -962,6 +962,19 @@ class ExternalRunnerTest(unittest.TestCase):
                          "Avocado did not return rc %d:\n%s" %
                          (expected_rc, result))
 
+    def test_externalrunner_chdir_runner_relative(self):
+        avocado_abs = " ".join([os.path.abspath(_) for _ in AVOCADO.split(" ")])
+        pass_abs = os.path.abspath(self.pass_script.path)
+        os.chdir('/')
+        cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
+                    '--external-runner=bin/sh --external-runner-chdir=runner -- %s'
+                    % (avocado_abs, self.tmpdir, pass_abs))
+        result = process.run(cmd_line, ignore_status=True)
+        expected_rc = exit_codes.AVOCADO_ALL_OK
+        self.assertEqual(result.exit_status, expected_rc,
+                         "Avocado did not return rc %d:\n%s" %
+                         (expected_rc, result))
+
     def test_externalrunner_no_url(self):
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
                     '--external-runner=%s' % (AVOCADO, self.tmpdir, TRUE_CMD))


### PR DESCRIPTION
I was trying to use the external runner, in a reasonably simple way:
from within a project (QEMU) build dir, I'd run:

```
 $ avocado run --external-runner=tests/qemu-iotests/check \
   --external-runner-chdir=runner -- 001 002
```

But, what should work, did not.  The problem is with the non-absolute
path to the external runner, that is needed because we're changing
directories.

Absolute paths won't hurt otherwise (when no chdir is done), so it's
always done here.

Signed-off-by: Cleber Rosa <crosa@redhat.com>