### PR TITLE
avocado.utils.process: minimize the use of external commands

### DIFF
--- a/avocado/utils/linux_modules.py
+++ b/avocado/utils/linux_modules.py
@@ -105,7 +105,8 @@ def loaded_module_info(module_name):
     """
     l_raw = process.system_output('/sbin/lsmod').decode('utf-8')
     modinfo_dic = parse_lsmod_for_module(l_raw, module_name)
-    output = process.system_output("/sbin/modinfo %s" % module_name).decode('utf-8')
+    output = process.system_output(
+        "/sbin/modinfo %s" % module_name).decode('utf-8')
     if output:
         param_list = []
         for line in output.splitlines():
@@ -237,3 +238,15 @@ def check_kernel_config(config_name):
                 else:
                     return BUILTIN
     return NOT_SET
+
+
+def get_modules_dir():
+    """
+    Return the modules dir for the running kernel version
+
+    :return: path of module directory
+    :rtype: String
+    """
+    kernel_version = platform.uname()[2]
+
+    return '/lib/modules/%s/kernel' % kernel_version

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -135,6 +135,22 @@ def safe_kill(pid, signal):  # pylint: disable=W0621
         return False
 
 
+def get_parent_pid(pid):
+    """
+    Returns the parent PID for the given process
+
+    TODO: this is currently Linux specific, and needs to implement
+    similar features for other platforms.
+
+    :param pid: The PID of child process
+    :returns: The parent PID
+    :rtype: int
+    """
+    with open('/proc/%d/stat' % pid) as proc_stat:
+        parent_pid = proc_stat.read().split(b' ')[3]
+        return int(parent_pid)
+
+
 def kill_process_tree(pid, sig=signal.SIGKILL, send_sigcont=True):
     """
     Signal a process and all of its children.

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -18,6 +18,7 @@ Functions dedicated to find and run external commands.
 
 import errno
 import fnmatch
+import glob
 import logging
 import os
 import re
@@ -151,6 +152,41 @@ def get_parent_pid(pid):
         return int(parent_pid)
 
 
+def _get_pid_from_proc_pid_stat(proc_path):
+    match = re.match(r'\/proc\/([0-9]+)\/.*', proc_path)
+    if match is not None:
+        return int(match.group(1))
+
+
+def get_children_pids(parent_pid, recursive=False):
+    """
+    Returns the children PIDs for the given process
+
+    TODO: this is currently Linux specific, and needs to implement
+    similar features for other platforms.
+
+    :param parent_pid: The PID of parent child process
+    :returns: The PIDs for the children processes
+    :rtype: list of int
+    """
+    proc_stats = glob.glob('/proc/[123456789]*/stat')
+    children = []
+    for proc_stat in proc_stats:
+        try:
+            with open(proc_stat) as proc_stat_fp:
+                this_parent_pid = int(proc_stat_fp.read().split(b' ')[3])
+        except IOError:
+            continue
+
+        if this_parent_pid == parent_pid:
+            children.append(_get_pid_from_proc_pid_stat(proc_stat))
+
+    if recursive:
+        for child in children:
+            children.extend(get_children_pids(child))
+    return children
+
+
 def kill_process_tree(pid, sig=signal.SIGKILL, send_sigcont=True):
     """
     Signal a process and all of its children.
@@ -160,12 +196,9 @@ def kill_process_tree(pid, sig=signal.SIGKILL, send_sigcont=True):
     :param pid: The pid of the process to signal.
     :param sig: The signal to send to the processes.
     """
-    # TODO: This relies on the GNU version of ps (need to fix MacOS support)
     if not safe_kill(pid, signal.SIGSTOP):
         return
-    children = system_output("ps --ppid=%d -o pid=" % pid, ignore_status=True,
-                             verbose=False).split()
-    for child in children:
+    for child in get_children_pids(pid):
         kill_process_tree(int(child), sig)
     safe_kill(pid, sig)
     if send_sigcont:
@@ -208,31 +241,6 @@ def process_in_ptree_is_defunct(ppid):
             defunct = True
             break
     return defunct
-
-
-def get_children_pids(ppid, recursive=False):
-    """
-    Get all PIDs of children/threads of parent ppid
-    param ppid: parent PID
-    param recursive: True to return all levels of sub-processes
-    return: list of PIDs of all children/threads of ppid
-    """
-    # TODO: This relies on the GNU version of ps (need to fix MacOS support)
-
-    cmd = "ps -L --ppid=%d -o lwp"
-
-    # Getting first level of sub-processes
-    children = system_output(cmd % ppid, verbose=False).split(b'\n')[1:]
-    if not recursive:
-        return children
-
-    # Recursion to get all levels of sub-processes
-    for child in children:
-        children.extend(system_output(cmd % int(child),
-                                      verbose=False,
-                                      ignore_status=True).split(b'\n')[1:])
-
-    return children
 
 
 def binary_from_shell_cmd(cmd):

--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -278,6 +278,12 @@ class MiscProcessTests(unittest.TestCase):
                          [u"avok\xe1do_test_runner",
                           u"arguments"])
 
+    def test_get_parent_pid(self):
+        stat = b'18405 (bash) S 24139 18405 18405 34818 8056 4210688 9792 170102 0 7 11 4 257 84 20 0 1 0 44336493 235409408 4281 18446744073709551615 94723230367744 94723231442728 140723100226000 0 0 0 65536 3670020 1266777851 0 0 0 17 1 0 0 0 0 0 94723233541456 94723233588580 94723248717824 140723100229613 140723100229623 140723100229623 140723100233710 0'
+        with mock.patch('avocado.utils.process.open',
+                        return_value=io.BytesIO(stat)):
+            self.assertTrue(process.get_parent_pid(0), 24139)
+
 
 class CmdResultTests(unittest.TestCase):
 


### PR DESCRIPTION
A large number of information being acquired by running external commands can be retrieved just as easily by reading files in `/proc`.

Let's use that approach instead.