### PR TITLE
avocado.utils.process: minimize the use of external commands [v2]

### DIFF
--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -135,6 +135,22 @@ def safe_kill(pid, signal):  # pylint: disable=W0621
         return False
 
 
+def get_parent_pid(pid):
+    """
+    Returns the parent PID for the given process
+
+    TODO: this is currently Linux specific, and needs to implement
+    similar features for other platforms.
+
+    :param pid: The PID of child process
+    :returns: The parent PID
+    :rtype: int
+    """
+    with open('/proc/%d/stat' % pid, 'rb') as proc_stat:
+        parent_pid = proc_stat.read().split(b' ')[3]
+        return int(parent_pid)
+
+
 def kill_process_tree(pid, sig=signal.SIGKILL, send_sigcont=True):
     """
     Signal a process and all of its children.

--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -278,6 +278,12 @@ class MiscProcessTests(unittest.TestCase):
                          [u"avok\xe1do_test_runner",
                           u"arguments"])
 
+    def test_get_parent_pid(self):
+        stat = b'18405 (bash) S 24139 18405 18405 34818 8056 4210688 9792 170102 0 7 11 4 257 84 20 0 1 0 44336493 235409408 4281 18446744073709551615 94723230367744 94723231442728 140723100226000 0 0 0 65536 3670020 1266777851 0 0 0 17 1 0 0 0 0 0 94723233541456 94723233588580 94723248717824 140723100229613 140723100229623 140723100229623 140723100233710 0'
+        with mock.patch('avocado.utils.process.open',
+                        return_value=io.BytesIO(stat)):
+            self.assertTrue(process.get_parent_pid(0), 24139)
+
 
 class CmdResultTests(unittest.TestCase):
 

--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -3,6 +3,7 @@ import logging
 import os
 import shlex
 import unittest
+import sys
 
 try:
     from unittest import mock
@@ -283,6 +284,14 @@ class MiscProcessTests(unittest.TestCase):
         with mock.patch('avocado.utils.process.open',
                         return_value=io.BytesIO(stat)):
             self.assertTrue(process.get_parent_pid(0), 24139)
+
+    @unittest.skipUnless(sys.platform.startswith('linux'),
+                         'Linux specific feature and test')
+    def test_get_children_pids(self):
+        '''
+        Gets the list of children process.  Linux only.
+        '''
+        self.assertGreaterEqual(len(process.get_children_pids(1)), 1)
 
 
 class CmdResultTests(unittest.TestCase):


### PR DESCRIPTION
A large number of information being acquired by running external commands can be retrieved just as easily by reading files in `/proc`.

Let's use that approach instead.

---

Changes from v1 (#2844):
 * Open `/proc/*/stat` files explicitly in binary mode
 * Added a test for `get_children_pids()`
 * Rebased and removed commits not associated with this PR 