### PR TITLE
avocado.utils.process: minimize the use of external commands [v3]

### DIFF
--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -135,6 +135,22 @@ def safe_kill(pid, signal):  # pylint: disable=W0621
         return False
 
 
+def get_parent_pid(pid):
+    """
+    Returns the parent PID for the given process
+
+    TODO: this is currently Linux specific, and needs to implement
+    similar features for other platforms.
+
+    :param pid: The PID of child process
+    :returns: The parent PID
+    :rtype: int
+    """
+    with open('/proc/%d/stat' % pid, 'rb') as proc_stat:
+        parent_pid = proc_stat.read().split(b' ')[3]
+        return int(parent_pid)
+
+
 def kill_process_tree(pid, sig=signal.SIGKILL, send_sigcont=True):
     """
     Signal a process and all of its children.

--- a/selftests/__init__.py
+++ b/selftests/__init__.py
@@ -2,9 +2,34 @@ import os
 import sys
 import unittest
 
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+
 #: The base directory for the avocado source tree
 BASEDIR = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
 
 #: The name of the avocado test runner entry point
 AVOCADO = os.environ.get("UNITTEST_AVOCADO_CMD",
                          "%s ./scripts/avocado" % sys.executable)
+
+
+def recent_mock():
+    '''
+    Checks if a recent and capable enough mock library is available
+
+    On Python 2.7, it requires at least mock version 2.0.  On Python 3,
+    mock from the standard library is used, but Python 3.6 or later is
+    required.
+
+    Also, it assumes that on a future Python major version, functionality
+    won't regress.
+    '''
+    if sys.version_info[0] < 3:
+        major = int(mock.__version__.split('.')[0])
+        return major >= 2
+    elif sys.version_info[0] == 3:
+        return sys.version_info[1] >= 6
+    return True

--- a/selftests/unit/test_utils_cpu.py
+++ b/selftests/unit/test_utils_cpu.py
@@ -1,5 +1,4 @@
 import io
-import sys
 import unittest
 
 try:
@@ -7,27 +6,8 @@ try:
 except ImportError:
     import mock
 
-
+from .. import recent_mock
 from avocado.utils import cpu
-
-
-def recent_mock():
-    '''
-    Checks if a recent and capable enough mock library is available
-
-    On Python 2.7, it requires at least mock version 2.0.  On Python 3,
-    mock from the standard library is used, but Python 3.6 or later is
-    required.
-
-    Also, it assumes that on a future Python major version, functionality
-    won't regress.
-    '''
-    if sys.version_info[0] < 3:
-        major = int(mock.__version__.split('.')[0])
-        return major >= 2
-    elif sys.version_info[0] == 3:
-        return sys.version_info[1] >= 6
-    return True
 
 
 class Cpu(unittest.TestCase):

--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -3,6 +3,7 @@ import logging
 import os
 import shlex
 import unittest
+import sys
 
 try:
     from unittest import mock
@@ -286,6 +287,14 @@ class MiscProcessTests(unittest.TestCase):
         with mock.patch('avocado.utils.process.open',
                         return_value=io.BytesIO(stat)):
             self.assertTrue(process.get_parent_pid(0), 24139)
+
+    @unittest.skipUnless(sys.platform.startswith('linux'),
+                         'Linux specific feature and test')
+    def test_get_children_pids(self):
+        '''
+        Gets the list of children process.  Linux only.
+        '''
+        self.assertGreaterEqual(len(process.get_children_pids(1)), 1)
 
 
 class CmdResultTests(unittest.TestCase):

--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -10,6 +10,7 @@ except ImportError:
     import mock
 
 
+from .. import recent_mock
 from avocado.utils import astring
 from avocado.utils import gdb
 from avocado.utils import process
@@ -277,6 +278,14 @@ class MiscProcessTests(unittest.TestCase):
         self.assertEqual(process.cmd_split(unicode_command),
                          [u"avok\xe1do_test_runner",
                           u"arguments"])
+
+    @unittest.skipUnless(recent_mock(),
+                         "mock library version cannot (easily) patch open()")
+    def test_get_parent_pid(self):
+        stat = b'18405 (bash) S 24139 18405 18405 34818 8056 4210688 9792 170102 0 7 11 4 257 84 20 0 1 0 44336493 235409408 4281 18446744073709551615 94723230367744 94723231442728 140723100226000 0 0 0 65536 3670020 1266777851 0 0 0 17 1 0 0 0 0 0 94723233541456 94723233588580 94723248717824 140723100229613 140723100229623 140723100229623 140723100233710 0'
+        with mock.patch('avocado.utils.process.open',
+                        return_value=io.BytesIO(stat)):
+            self.assertTrue(process.get_parent_pid(0), 24139)
 
 
 class CmdResultTests(unittest.TestCase):


### PR DESCRIPTION
A large number of information being acquired by running external commands can be retrieved just as easily by reading files in `/proc`.

Let's use that approach instead.

---

Changes from v2 (#2845):
 * Make `recent_mock()` utility common to selftests (new commit)
 * Skipped `get_parent_pid()` test on old mock 

Changes from v1 (#2844):
 * Open `/proc/*/stat` files explicitly in binary mode
 * Added a test for `get_children_pids()`
 * Rebased and removed commits not associated with this PR 