### PR TITLE
scripts/avocado: use a more standard behavior on import failure

### DIFF
--- a/scripts/avocado
+++ b/scripts/avocado
@@ -15,16 +15,16 @@
 
 
 import sys
-try:
-    import os
-    import time
-    import tempfile
-    import traceback
+import os
+import time
+import tempfile
+import traceback
 
+try:
     from avocado.core import data_dir
 except ImportError:
-    sys.stderr.write("Unable to import basic python libraries, please "
-                     "reinstall avocado and dependencies.\n")
+    sys.stderr.write("Unable to import Avocado libraries, please verify "
+                     "your installation, and if necessary reinstall it.\n")
     # This exit code is replicated from avocado/core/exit_codes.py and not
     # imported because we are dealing with import failures
     sys.exit(-1)


### PR DESCRIPTION
I tend to favor more predictable and standard behavior, and the
currently used approach to "protect" the import of Python standard
libraries seems to me to be far from standard.

With this change, if the system's Python interpreter is broken, or if
Python standard libraries can not be imported/loaded, the default
behavior will be executed.  If it seems to be an Avocado problem, then
we try to print a line describing that.

Signed-off-by: Cleber Rosa <crosa@redhat.com>