### PR TITLE
Provide "__str__" for "CmdError" [v3]

### DIFF
--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -82,6 +82,10 @@ class CmdError(Exception):
         self.result = result
         self.additional_text = additional_text
 
+    def __str__(self):
+        return ("Command '%s' failed.\nstdout: %r\nstderr: %r\nadditional_info: %s" %
+                (self.command, self.result.stdout, self.result.stderr, self.additional_text))
+
 
 def can_sudo(cmd=None):
     """

--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -281,6 +281,20 @@ class MiscProcessTests(unittest.TestCase):
 
 class CmdResultTests(unittest.TestCase):
 
+    def test_nasty_str(self):
+        result = process.CmdResult("ls", b"unicode_follows: \xc5\xa1",
+                                   b"cp1250 follows: \xfd", 1, 2, 3,
+                                   "wrong_encoding")
+        if PY2:
+            prefix = ''
+        else:
+            prefix = 'b'
+        self.assertEqual(str(result), "command: 'ls'\nexit_status: 1"
+                         "\nduration: 2\ninterrupted: False\npid: "
+                         "3\nencoding: 'wrong_encoding'\nstdout: "
+                         "%s'unicode_follows: \\xc5\\xa1'\nstderr: "
+                         "%s'cp1250 follows: \\xfd'" % (prefix, prefix))
+
     def test_cmd_result_stdout_stderr_bytes(self):
         result = process.CmdResult()
         self.assertTrue(isinstance(result.stdout, bytes))

--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -15,7 +15,7 @@ from avocado.utils import gdb
 from avocado.utils import process
 from avocado.utils import path
 
-from six import string_types
+from six import string_types, PY2
 
 
 def probe_binary(binary):
@@ -304,6 +304,23 @@ class CmdResultTests(unittest.TestCase):
         result.stderr = None
         self.assertRaises(TypeError, lambda x: result.stdout_text)
         self.assertRaises(TypeError, lambda x: result.stderr_text)
+
+
+class CmdErrorTests(unittest.TestCase):
+
+    def test_nasty_str(self):
+        result = process.CmdResult("ls", b"unicode_follows: \xc5\xa1",
+                                   b"cp1250 follows: \xfd", 1, 2, 3,
+                                   "wrong_encoding")
+        err = process.CmdError("ls", result, "please don't crash")
+        if PY2:
+            prefix = ''
+        else:
+            prefix = 'b'
+        self.assertEqual(str(err), "Command 'ls' failed.\nstdout: "
+                         "%s'unicode_follows: \\xc5\\xa1'\nstderr: "
+                         "%s'cp1250 follows: \\xfd'\nadditional_info: "
+                         "please don't crash" % (prefix, prefix))
 
 
 class FDDrainerTests(unittest.TestCase):


### PR DESCRIPTION
Let's provide the "__str__" method for "CmdError" to be able to see the
actual content on print(error).

v1: https://github.com/avocado-framework/avocado/pull/2678
v2: https://github.com/avocado-framework/avocado/pull/2840

Changes:

```yaml
v2: Use `%r` rather than decoding the outputs
v2: Slightly simplified output and commit message
v3: Add selftests
```