### PR TITLE
avocado.utils.path: fix CmdNotFoundError constructor

### DIFF
--- a/avocado/utils/path.py
+++ b/avocado/utils/path.py
@@ -35,7 +35,7 @@ class CmdNotFoundError(Exception):
     """
 
     def __init__(self, cmd, paths):
-        super(CmdNotFoundError, self)
+        super(CmdNotFoundError, self).__init__(cmd, paths)
         self.cmd = cmd
         self.paths = paths
 


### PR DESCRIPTION
calling Exception.__init__  in CmdNotFoundError's constructor.

Signed-off-by: lolyu <lolyu@redhat.com>