### PR TITLE
Yaml to mux: unwind (unnest) some utility functions [v2]

### DIFF
--- a/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/__init__.py
+++ b/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/__init__.py
@@ -73,20 +73,28 @@ class ListOfNodeObjects(list):     # Few methods pylint: disable=R0903
     """
 
 
+def _normalize_path(path):
+    """
+    End the path with single '/'
+
+    :param path: original path
+    :type path: str
+    :returns: path with trailing '/', or None when empty path
+    :rtype: str or None
+    """
+    if not path:
+        return
+    if path[-1] != '/':
+        path += '/'
+    return path
+
+
 def _create_from_yaml(path, cls_node=mux.MuxTreeNode):
     """Create tree structure from yaml stream"""
     def tree_node_from_values(name, values):
         """Create `name` node and add values"""
         def handle_control_tag(node, value):
             """Handling of YAML tags (except of !using)"""
-            def normalize_path(path):
-                """End the path with single '/', None when empty path"""
-                if not path:
-                    return
-                if path[-1] != '/':
-                    path += '/'
-                return path
-
             if value[0].code == YAML_INCLUDE:
                 # Include file
                 ypath = value[1]
@@ -105,11 +113,11 @@ def _create_from_yaml(path, cls_node=mux.MuxTreeNode):
             elif value[0].code == YAML_MUX:
                 node.multiplex = True
             elif value[0].code == YAML_FILTER_ONLY:
-                new_value = normalize_path(value[1])
+                new_value = _normalize_path(value[1])
                 if new_value:
                     node.filters[0].append(new_value)
             elif value[0].code == YAML_FILTER_OUT:
-                new_value = normalize_path(value[1])
+                new_value = _normalize_path(value[1])
                 if new_value:
                     node.filters[1].append(new_value)
 

--- a/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/__init__.py
+++ b/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/__init__.py
@@ -104,12 +104,9 @@ def _create_from_yaml(path, cls_node=mux.MuxTreeNode):
                     raise ValueError("File '%s' included from '%s' does not "
                                      "exist." % (ypath, path))
                 node.merge(_create_from_yaml('/:' + ypath, cls_node))
-            elif value[0].code == YAML_REMOVE_NODE:
+            elif value[0].code in (YAML_REMOVE_NODE, YAML_REMOVE_VALUE):
                 value[0].value = value[1]   # set the name
                 node.ctrl.append(value[0])    # add "blue pill" of death
-            elif value[0].code == YAML_REMOVE_VALUE:
-                value[0].value = value[1]   # set the name
-                node.ctrl.append(value[0])
             elif value[0].code == YAML_MUX:
                 node.multiplex = True
             elif value[0].code == YAML_FILTER_ONLY:

--- a/optional_plugins/varianter_yaml_to_mux/tests/.data/mux-selftest-using.yaml
+++ b/optional_plugins/varianter_yaml_to_mux/tests/.data/mux-selftest-using.yaml
@@ -1,0 +1,3 @@
+!using : /foo
+bar:
+    !using : baz

--- a/optional_plugins/varianter_yaml_to_mux/tests/test_multiplex.py
+++ b/optional_plugins/varianter_yaml_to_mux/tests/test_multiplex.py
@@ -55,6 +55,13 @@ class MultiplexTests(unittest.TestCase):
         result = self.run_and_check(cmd_line, expected_rc)
         self.assertIn('No such file or directory', result.stderr_text)
 
+    def test_mplex_plugin_using(self):
+        cmd_line = ('%s variants -m /:optional_plugins/varianter_yaml_to_mux/'
+                    'tests/.data/mux-selftest-using.yaml' % AVOCADO)
+        expected_rc = exit_codes.AVOCADO_ALL_OK
+        result = self.run_and_check(cmd_line, expected_rc)
+        self.assertIn(b' /foo/baz/bar', result.stdout)
+
     @unittest.skipIf(sys.version_info[0] == 3,
                      "Test currently broken on Python 3")
     def test_mplex_debug(self):

--- a/optional_plugins/varianter_yaml_to_mux/tests/test_mux.py
+++ b/optional_plugins/varianter_yaml_to_mux/tests/test_mux.py
@@ -535,6 +535,13 @@ class TestPathParent(unittest.TestCase):
         self.assertNotEqual(mux.path_parent('/os/linux'), '/')
 
 
+class TestCreateFromYaml(unittest.TestCase):
+
+    def test_normalize_path(self):
+        self.assertEqual(yaml_to_mux._normalize_path(''), None)
+        self.assertEqual(yaml_to_mux._normalize_path('path'), 'path/')
+
+
 class TestFingerprint(unittest.TestCase):
 
     def test_fingerprint(self):

--- a/optional_plugins/varianter_yaml_to_mux/tests/test_mux.py
+++ b/optional_plugins/varianter_yaml_to_mux/tests/test_mux.py
@@ -572,6 +572,11 @@ class TestCreateFromYaml(unittest.TestCase):
                                                       '/using/path/')
         self.assertEqual(using, 'using/path')
 
+    def test_apply_using(self):
+        node = yaml_to_mux._apply_using('bar', mux.MuxTreeNode,
+                                        'foo', mux.MuxTreeNode())
+        self.assertEqual(node.path, '/foo')
+
 
 class TestFingerprint(unittest.TestCase):
 

--- a/optional_plugins/varianter_yaml_to_mux/tests/test_mux.py
+++ b/optional_plugins/varianter_yaml_to_mux/tests/test_mux.py
@@ -560,6 +560,18 @@ class TestCreateFromYaml(unittest.TestCase):
         self.assertEqual(control.value, to_be_removed)
         self.assertIn(control, node.ctrl)
 
+    def test_handle_control_tag_using_multiple(self):
+        with self.assertRaises(ValueError):
+            yaml_to_mux._handle_control_tag_using('original_fake_file.yaml',
+                                                  'name', True, 'using')
+
+    def test_handle_control_tag_using(self):
+        using = yaml_to_mux._handle_control_tag_using('fake_path',
+                                                      'name',
+                                                      False,
+                                                      '/using/path/')
+        self.assertEqual(using, 'using/path')
+
 
 class TestFingerprint(unittest.TestCase):
 

--- a/optional_plugins/varianter_yaml_to_mux/tests/test_mux.py
+++ b/optional_plugins/varianter_yaml_to_mux/tests/test_mux.py
@@ -541,6 +541,25 @@ class TestCreateFromYaml(unittest.TestCase):
         self.assertEqual(yaml_to_mux._normalize_path(''), None)
         self.assertEqual(yaml_to_mux._normalize_path('path'), 'path/')
 
+    def test_handle_control_path_include_file_does_not_exist(self):
+        with self.assertRaises(ValueError):
+            yaml_to_mux._handle_control_tag(
+                'original_fake_file.yaml',
+                mux.MuxTreeNode, mux.MuxTreeNode(),
+                (mux.Control(yaml_to_mux.YAML_INCLUDE),
+                 'unexisting_include.yaml'))
+
+    def test_handle_control_path_remove(self):
+        klass = mux.MuxTreeNode
+        node = klass()
+        control = mux.Control(yaml_to_mux.YAML_REMOVE_NODE)
+        to_be_removed = 'node_to_be_removed'
+        yaml_to_mux._handle_control_tag('fake_path',
+                                        klass, node,
+                                        (control, to_be_removed))
+        self.assertEqual(control.value, to_be_removed)
+        self.assertIn(control, node.ctrl)
+
 
 class TestFingerprint(unittest.TestCase):
 


### PR DESCRIPTION
With the goal of improving test coverage, documentation, and IMO, readability.

---

Changes from v1 (#2853):
 * Use context manager style on `assertRaises`