### PR TITLE
Adds function to return owner id of a process

### DIFF
--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -1553,3 +1553,15 @@ def getstatusoutput(cmd, timeout=None, verbose=False, ignore_status=True,
     if text[-1:] == '\n':
         text = text[:-1]
     return (sts, text)
+
+
+def get_owner_id(pid):
+    """
+    Get the owner's user id of a process
+    param pid: process id
+    return: user id of the process owner
+    """
+    try:
+        return os.stat('/proc/%d/' % pid).st_uid
+    except OSError:
+        return None

--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -296,6 +296,27 @@ class MiscProcessTests(unittest.TestCase):
         '''
         self.assertGreaterEqual(len(process.get_children_pids(1)), 1)
 
+    @mock.patch('avocado.utils.process.os.stat')
+    def test_process_get_owner_id(self, stat_mock):
+        process_id = 123
+        owner_user_id = 13
+        stat_mock.return_value = mock.Mock(st_uid=owner_user_id)
+
+        returned_owner_id = process.get_owner_id(process_id)
+
+        self.assertEqual(returned_owner_id, owner_user_id)
+        stat_mock.assert_called_with('/proc/%d/' % process_id)
+
+    @mock.patch('avocado.utils.process.os.stat')
+    def test_process_get_owner_id_with_pid_not_found(self, stat_mock):
+        process_id = 123
+        stat_mock.side_effect = OSError()
+
+        returned_owner_id = process.get_owner_id(process_id)
+
+        self.assertIsNone(returned_owner_id)
+        stat_mock.assert_called_with('/proc/%d/' % process_id)
+
 
 class CmdResultTests(unittest.TestCase):
 


### PR DESCRIPTION
Seems that is important have a default way to get a process owner id in
process utils module. This function will be useful soon when we have to
deal with timeout of sudo enabled processes (explained in reference link).

This change is being added as suggested here: [#2854](https://github.com/avocado-framework/avocado/pull/2854/files#r219902574)

Reference: https://trello.com/c/ROPWdFFr
Signed-off-by: Caio Carrara <ccarrara@redhat.com>