### PR TITLE
 Added utility in disk library

### DIFF
--- a/avocado/utils/disk.py
+++ b/avocado/utils/disk.py
@@ -24,6 +24,7 @@ Disk utilities
 
 import os
 import json
+import re
 
 from . import process
 
@@ -55,3 +56,13 @@ def get_disks():
     json_result = process.run('lsblk --json')
     json_data = json.loads(json_result.stdout_text)
     return ['/dev/%s' % str(disk['name']) for disk in json_data['blockdevices']]
+
+
+def get_filesystems():
+    """
+    Return a list of all available filesystems
+
+    :returns: a list of filesystem string
+    :rtype: list of str
+    """
+    return [re.sub('(nodev)?\s*', '', fs) for fs in open('/proc/filesystems')]

--- a/avocado/utils/disk.py
+++ b/avocado/utils/disk.py
@@ -65,4 +65,14 @@ def get_filesystems():
     :returns: a list of filesystem string
     :rtype: list of str
     """
-    return [re.sub('(nodev)?\s*', '', fs) for fs in open('/proc/filesystems')]
+    return [re.sub('(nodev)?\\s*', '', fs) for fs in open('/proc/filesystems')]
+
+
+def get_rootfilesystem():
+    """
+    Return a root  filesystem
+
+    :returns: file system string
+    :rtype: str
+    """
+    return process.system_output('findmnt / -o FSTYPE -n')


### PR DESCRIPTION
1-
utility which return all supported filesystem
on running kernel

after patch

[GCC 5.3.1 20160406 (Red Hat 5.3.1-6)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from avocado.utils import disk
>>> disk.filesystems()
['sysfs', 'rootfs', 'ramfs', 'bdev', 'proc', 'cpuset', 'cgroup', 'cgroup2', 'tmpfs', 'devtmpfs', 'configfs', 'debugfs', 'tracefs', 'securityfs', 'sockfs', 'bpf', 'pipefs', 'hugetlbfs', 'devpts', 'ext3', 'ext2', 'ext4', 'autofs', 'pstore', 'mqueue', 'selinuxfs', 'binfmt_misc', 'rpc_pipefs', 'nfsd']
>>>

2-
utility which return root file system

[GCC 5.3.1 20160406 (Red Hat 5.3.1-6)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> from avocado.utils import disk
>>> disk.get_rootfilesystem()
'ext4'
>>>

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>
