### PR TITLE
safeloader: Fix typo in 'asname' and add selftest

### DIFF
--- a/avocado/core/safeloader.py
+++ b/avocado/core/safeloader.py
@@ -65,7 +65,7 @@ class AvocadoModule(object):
                 for name in statement.names:
                     if name.name == 'avocado':
                         if name.asname is not None:
-                            self.mod_import = name.nasname
+                            self.mod_import = name.asname
                         else:
                             self.mod_import = name.name
 

--- a/selftests/.data/loader_instrumented/double_import.py
+++ b/selftests/.data/loader_instrumented/double_import.py
@@ -1,0 +1,26 @@
+# This currently only discovers 2 tests in avocado due to bug
+import avocado as foo
+import avocado as bar   # pylint: disable=W0404
+
+from avocado import Test as Foo
+from avocado import Test as Bar     # pylint: disable=W0404
+
+
+class Test1(foo.Test):
+    def test1(self):
+        pass
+
+
+class Test2(bar.Test):
+    def test2(self):
+        pass
+
+
+class Test3(Foo):
+    def test3(self):
+        pass
+
+
+class Test4(Bar):
+    def test4(self):
+        pass


### PR DESCRIPTION
Currently there is a typo and a bug. Let's fix the typo, add selftest to
document the current behavior and deal with the bug (should detect 4
classes) later.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>
Signed-off-by: Cleber Rosa <crosa@redhat.com>