### PR TITLE
safeloader: Support "multiple import" with different name

### DIFF
--- a/selftests/.data/loader_instrumented/double_import.py
+++ b/selftests/.data/loader_instrumented/double_import.py
@@ -1,4 +1,3 @@
-# This currently only discovers 2 tests in avocado due to bug
 import avocado as foo
 import avocado as bar   # pylint: disable=W0404
 

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -516,7 +516,9 @@ class LoaderTest(unittest.TestCase):
         path = os.path.join(os.path.dirname(os.path.dirname(__file__)),
                             '.data', 'loader_instrumented', 'double_import.py')
         tests = self.loader.discover(path)
-        exps = [('Test2', 'selftests/.data/loader_instrumented/double_import.py:Test2.test2'),
+        exps = [('Test1', 'selftests/.data/loader_instrumented/double_import.py:Test1.test1'),
+                ('Test2', 'selftests/.data/loader_instrumented/double_import.py:Test2.test2'),
+                ('Test3', 'selftests/.data/loader_instrumented/double_import.py:Test3.test3'),
                 ('Test4', 'selftests/.data/loader_instrumented/double_import.py:Test4.test4')]
         self._check_discovery(exps, tests)
 


### PR DESCRIPTION
This is a continuation (and a conclusion) of the hotfix in #2868.  I had imagined that the backport for the complete fix was not going to be easy, but it turned out to be straightforward.

---

This allows us to detect when someone imports avocado multiple times
with different names.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>
Signed-off-by: Cleber Rosa <crosa@redhat.com>
