### PR TITLE
linux_modules: eliminate duplicates in submodules

### DIFF
--- a/avocado/utils/linux_modules.py
+++ b/avocado/utils/linux_modules.py
@@ -29,6 +29,7 @@ from enum import Enum
 
 from . import astring
 from . import process
+from . import data_structures
 
 LOG = logging.getLogger('avocado.test')
 
@@ -163,7 +164,7 @@ def get_submodules(module_name):
         module_list = submodules
         for module in submodules:
             module_list += get_submodules(module)
-    return module_list
+    return data_structures.ordered_list_unique(module_list)
 
 
 def unload_module(module_name):


### PR DESCRIPTION
The result in `get_submodules` contains duplicates, which result
from no check of visited in DFS.
Solved by using `ordered_list_unique` from `data_structures` to
del duplicates before returning from each recursion.

Signed-off-by: lolyu <lolyu@redhat.com>