### PR TITLE
Enhance provides package feature in softwaremanager

### DIFF
--- a/avocado/utils/software_manager.py
+++ b/avocado/utils/software_manager.py
@@ -546,7 +546,9 @@ class YumBackend(RpmBackend):
                       "yum module is required for this operation")
             return None
         try:
-            d_provides = self.yum_base.searchPackageProvides(args=[name])
+            #Python API need to be passed globs along with name for searching
+            #all possible occurrences of pattern 'name'
+            d_provides = self.yum_base.searchPackageProvides(args=['*/' + name])
         except Exception as exc:
             log.error("Error searching for package that "
                       "provides %s: %s", name, exc)


### PR DESCRIPTION
Currently on rhel based systems, if the name given for provides is
not part of package name itself, provides method return none.
We would have to handle situations where name is present in
filenames, this commit adds functionality of searching packages
based on filenames as well.

Signed-off-by: Srikanth Aithal <sraithal@linux.vnet.ibm.com>