### PR TITLE
recursive by default: picks from the complete PR [v2]

### DIFF
--- a/selftests/.data/loader_instrumented/dont_detect_non_avocado.py
+++ b/selftests/.data/loader_instrumented/dont_detect_non_avocado.py
@@ -1,0 +1,23 @@
+from avocado.core.test import Test  # pylint: disable=W0404
+
+
+# On load this will be avocado.Test, but in static analysis
+# it's avocado.core.test.Test and should not match
+# (only as a unittest)
+class StaticallyNotAvocadoTest(Test):
+    def test(self):
+        pass
+
+
+# This import should not make the previous import to be
+# internally evaluated as "avocado.Test", because it happens
+# after the previous class definition
+from avocado import Test    # pylint: disable=W0404
+
+
+# On recursive discovery this should be imported from
+# avocado.core.test and not avocado.Test, therefor it should
+# not be detected (only as a unittest)
+class NotTest(StaticallyNotAvocadoTest):
+    def test2(self):
+        pass

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -505,6 +505,14 @@ class LoaderTest(unittest.TestCase):
                 ('DiscoverMe4', 'selftests/.data/loader_instrumented/dont_crash.py:DiscoverMe4.test')]
         self._check_discovery(exps, tests)
 
+    def test_dont_detect_non_avocado(self):
+        path = os.path.join(os.path.dirname(os.path.dirname(__file__)),
+                            '.data', 'loader_instrumented', 'dont_detect_non_avocado.py')
+        tests = self.loader.discover(path)
+        exps = [(test.PythonUnittest, 'dont_detect_non_avocado.StaticallyNotAvocadoTest.test'),
+                (test.PythonUnittest, 'dont_detect_non_avocado.NotTest.test2')]
+        self._check_discovery(exps, tests)
+
     def test_double_import(self):
         path = os.path.join(os.path.dirname(os.path.dirname(__file__)),
                             '.data', 'loader_instrumented', 'double_import.py')

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -503,12 +503,7 @@ class LoaderTest(unittest.TestCase):
                 ('DiscoverMe2', 'selftests/.data/loader_instrumented/dont_crash.py:DiscoverMe2.test'),
                 ('DiscoverMe3', 'selftests/.data/loader_instrumented/dont_crash.py:DiscoverMe3.test'),
                 ('DiscoverMe4', 'selftests/.data/loader_instrumented/dont_crash.py:DiscoverMe4.test')]
-        for exp, tst in zip(exps, tests):
-            # Test class
-            self.assertEqual(tst[0], exp[0])
-            # Test name (path)
-            # py2 reports relpath, py3 abspath
-            self.assertEqual(os.path.abspath(tst[1]['name']), os.path.abspath(exp[1]))
+        self._check_discovery(exps, tests)
 
     def test_double_import(self):
         path = os.path.join(os.path.dirname(os.path.dirname(__file__)),


### PR DESCRIPTION
This is an attempt to reduce the size and (my perceived) complexity of #2839, and consequently enable me to do a better review.  Because of the hotfixes that were already applied (PRs #2874, #2868), the amount of code that is really devoted to enabling recursive behavior by default is dropping - and this is another small step into that direction.

Also, the author @ldoktor recognizes that the those PR introduces some code duplication.  There's one commit here that attempts to do the opposite and be useful (verbatim or as inspiration) to the original PR. 

---

Changes from v1 (#2875):
 * Fixed docstring on `statement_import_as()`