### PR TITLE
recursive by default: picks from the complete PR [v3]

### DIFF
--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -503,12 +503,7 @@ class LoaderTest(unittest.TestCase):
                 ('DiscoverMe2', 'selftests/.data/loader_instrumented/dont_crash.py:DiscoverMe2.test'),
                 ('DiscoverMe3', 'selftests/.data/loader_instrumented/dont_crash.py:DiscoverMe3.test'),
                 ('DiscoverMe4', 'selftests/.data/loader_instrumented/dont_crash.py:DiscoverMe4.test')]
-        for exp, tst in zip(exps, tests):
-            # Test class
-            self.assertEqual(tst[0], exp[0])
-            # Test name (path)
-            # py2 reports relpath, py3 abspath
-            self.assertEqual(os.path.abspath(tst[1]['name']), os.path.abspath(exp[1]))
+        self._check_discovery(exps, tests)
 
     def test_double_import(self):
         path = os.path.join(os.path.dirname(os.path.dirname(__file__)),


### PR DESCRIPTION
This is an attempt to reduce the size and (my perceived) complexity of #2839, and consequently enable me to do a better review.  Because of the hotfixes that were already applied (PRs #2874, #2868), the amount of code that is really devoted to enabling recursive behavior by default is dropping - and this is another small step into that direction.

Also, the author @ldoktor recognizes that the those PR introduces some code duplication.  There's one commit here that attempts to do the opposite and be useful (verbatim or as inspiration) to the original PR. 

---
Changes from v2 (#2886):
 * Removed commit `safeloader: add tests where INSTRUMENTED tests should not be found`, so now the title of this PR becomes misleading, because there are no picks from the original PR

Changes from v1 (#2875):
 * Fixed docstring on `statement_import_as()`