### PR TITLE
avocado.utils.lvutils: fix bytes/text problems

### DIFF
--- a/selftests/functional/test_lv_utils.py
+++ b/selftests/functional/test_lv_utils.py
@@ -114,8 +114,8 @@ class LVUtilsTest(unittest.TestCase):
             # Create and check LV
             lv_utils.lv_create(vg_name, lv_name, 1)
             lv_utils.lv_check(vg_name, lv_name)
-            self.assertIn(vg_name, process.system_output("lvs --all",
-                                                         sudo=True))
+            self.assertIn(vg_name, process.run("lvs --all",
+                                               sudo=True).stdout_text)
             self.assertIn(lv_name, lv_utils.lv_list())
             lv_utils.lv_mount(vg_name, lv_name, mount_loc, "ext2")
             lv_utils.lv_umount(vg_name, lv_name)


### PR DESCRIPTION
The lv_utils functional tests, which usually don't run because
they require privileged execution, revealed a number of broken
expectations when it comes to bytes and text handling.

Let's fix both the module and the test.

Signed-off-by: Cleber Rosa <crosa@redhat.com>