### PR TITLE
Fixed issue : address issue #2873 (kernel library)  as when url

### DIFF
--- a/avocado/utils/kernel.py
+++ b/avocado/utils/kernel.py
@@ -71,9 +71,15 @@ class KernelBuild(object):
                     source tarball
         :type url: str or None
         """
+
         kernel_file = self.SOURCE.format(version=self.version)
-        if url is not None:
+        # if there's no url to override, the default is the one
+        # specified in the class
+        if url is None:
             base_url = self.URL.format(major=self.version.split('.', 1)[0])
+
+        # however, if there's a url informed as a parameter, this one
+        # should be used as the base url.
         else:
             base_url = url
         full_url = base_url + kernel_file
@@ -94,7 +100,8 @@ class KernelBuild(object):
         Configure/prepare kernel source to build.
         """
         self.linux_dir = os.path.join(self.work_dir, 'linux-%s' % self.version)
-        build.make(self.linux_dir, extra_args='-C %s mrproper' % self.linux_dir)
+        build.make(self.linux_dir, extra_args='-C %s mrproper' %
+                   self.linux_dir)
         if self.config_path is not None:
             dotconfig = os.path.join(self.linux_dir, '.config')
             shutil.copy(self.config_path, dotconfig)
@@ -114,10 +121,13 @@ class KernelBuild(object):
             if self.distro.name == "Ubuntu":
                 build_output_format = "deb-pkg"
         if self.config_path is None:
-            build.make(self.linux_dir, extra_args='-C %s defconfig' % self.linux_dir)
+            build.make(self.linux_dir, extra_args='-C %s defconfig' %
+                       self.linux_dir)
         else:
-            build.make(self.linux_dir, extra_args='-C %s olddefconfig' % self.linux_dir)
-        build.make(self.linux_dir, extra_args='-C %s %s' % (self.linux_dir, build_output_format))
+            build.make(self.linux_dir, extra_args='-C %s olddefconfig' %
+                       self.linux_dir)
+        build.make(self.linux_dir, extra_args='-C %s %s' %
+                   (self.linux_dir, build_output_format))
 
     def install(self):
         """
@@ -125,7 +135,8 @@ class KernelBuild(object):
         """
         log.info("Starting kernel install")
         if self.distro.name == "Ubuntu":
-            process.run('dpkg -i %s/*.deb' % self.work_dir, shell=True, sudo=True)
+            process.run('dpkg -i %s/*.deb' %
+                        self.work_dir, shell=True, sudo=True)
         else:
             log.info("Skipping kernel install")
 


### PR DESCRIPTION
not passed while kernel download avocado error out as

TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'

when url not passed it uses default  else try to download url

after this patch

KernelBuild('4.4.133, None, /tmp/avocado_avocado.utils.kerneloVPgOZ')
>>> k = kernel.KernelBuild('4.4.133')
>>> k.download()
>>>
[praveen@localhost avocado]$ python
Python 2.7.14 (default, Mar 14 2018, 16:45:33)
[GCC 8.0.1 20180222 (Red Hat 8.0.1-0.16)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> from avocado.utils import kernel
>>> k = kernel.KernelBuild('4.4.133')
>>> k.download(url='https://git.kernel.org/torvalds/t/linux-4.19-rc6.tar.gz')
>>>

Reported-by:  lolyu <lolyu@redhat.com>
Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>