### PR TITLE
plugins.human: Avoid signaling too long fail-reasons in UI

### DIFF
--- a/avocado/plugins/human.py
+++ b/avocado/plugins/human.py
@@ -79,6 +79,9 @@ class Human(ResultEvents):
         out = (output.TERM_SUPPORT.MOVE_BACK + self.output_mapping[status] +
                status)
         if extra:
+            if len(extra) > 255:
+                extra = extra[:255] + '...'
+            extra = extra.replace('\n', '\\n')
             out += ": " + extra
         out += output.TERM_SUPPORT.ENDC
         return out


### PR DESCRIPTION
The 984424989c9f2fd229f8d589a40240a70dcc873e added fail-reason to UI,
but for some tests this could be multiple lines of explanation, which
does not really fit in the UI purpose. Let's limit the maximum size to
255 chars (this number is not important, it just have to be sensible)
and avoid '\n' in the output.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>