### PR TITLE
utils.service: enforce uniform string type

### DIFF
--- a/avocado/utils/service.py
+++ b/avocado/utils/service.py
@@ -153,7 +153,7 @@ def sys_v_init_result_parser(command):
             status_per_target_dict = {}
             # Dict to store the status for service based on xinetd.
             xinet_services_dict = {}
-            lines = cmd_result.stdout.strip().splitlines()
+            lines = cmd_result.stdout_text.strip().splitlines()
             for line in lines:
                 sublines = line.strip().split()
                 if len(sublines) == 8:
@@ -231,7 +231,7 @@ def systemd_result_parser(command):
                 raise process.CmdError(cmd_result.command, cmd_result)
             # Dict to store service name to status.
             _service2status_dict = {}
-            lines = cmd_result.stdout.strip().splitlines()
+            lines = cmd_result.stdout_text.strip().splitlines()
             for line in lines:
                 sublines = line.strip().split()
                 if ((not len(sublines) == 2) or

--- a/selftests/unit/test_utils_service.py
+++ b/selftests/unit/test_utils_service.py
@@ -190,7 +190,7 @@ class TestSystemdServiceManager(TestServiceManager):
 
     def test_list(self):
         list_result_mock = mock.Mock(exit_status=0,
-                                     stdout="sshd.service enabled\n"
+                                     stdout_text="sshd.service enabled\n"
                                      "vsftpd.service disabled\n"
                                      "systemd-sysctl.service static\n")
         run_mock = mock.Mock(return_value=list_result_mock)
@@ -254,7 +254,7 @@ class TestSysVInitServiceManager(TestServiceManager):
     def test_list(self):
         list_result_mock = mock.Mock(
             exit_status=0,
-            stdout="sshd             0:off   1:off   "
+            stdout_text="sshd             0:off   1:off   "
             "2:off   3:off   4:off   5:off   6:off\n"
             "vsftpd           0:off   1:off   2:off "
             "  3:off   4:off   5:on   6:off\n"


### PR DESCRIPTION
for result parser functions, enforce all strings to be of bytes.

Signed-off-by: lolyu <lolyu@redhat.com>