### PR TITLE
utils.partition: rewrite with filelock

### DIFF
--- a/selftests/unit/test_utils_partition.py
+++ b/selftests/unit/test_utils_partition.py
@@ -166,7 +166,7 @@ class TestMtabLock(unittest.TestCase):
     def test_lock(self):
         """ Check double-lock raises exception after 60s (in 0.1s) """
         with partition.MtabLock():
-            with mock.patch('avocado.utils.partition.time.time',
+            with mock.patch('avocado.utils.filelock.time.time',
                             mock.MagicMock(side_effect=[1, 2, 62])):
                 self.assertRaises(partition.PartitionError,
                                   partition.MtabLock().__enter__)


### PR DESCRIPTION
1. rewrite MtabLock, as a proxy class for filelock.FileLock.
2. update related unit test.

Signed-off-by: lolyu <lolyu@redhat.com>