### PR TITLE
Add tests for kernel download url building

### DIFF
--- a/avocado/utils/kernel.py
+++ b/avocado/utils/kernel.py
@@ -63,6 +63,12 @@ class KernelBuild(object):
                                               self.config_path,
                                               self.work_dir)
 
+    def _build_kernel_url(self, base_url=None):
+        kernel_file = self.SOURCE.format(version=self.version)
+        if base_url is None:
+            base_url = self.URL.format(major=self.version.split('.', 1)[0])
+        return base_url + kernel_file
+
     def download(self, url=None):
         """
         Download kernel source.
@@ -71,19 +77,7 @@ class KernelBuild(object):
                     source tarball
         :type url: str or None
         """
-
-        kernel_file = self.SOURCE.format(version=self.version)
-        # if there's no url to override, the default is the one
-        # specified in the class
-        if url is None:
-            base_url = self.URL.format(major=self.version.split('.', 1)[0])
-
-        # however, if there's a url informed as a parameter, this one
-        # should be used as the base url.
-        else:
-            base_url = url
-        full_url = base_url + kernel_file
-
+        full_url = self._build_kernel_url(base_url=url)
         self.asset_path = asset.Asset(full_url, asset_hash=None,
                                       algorithm=None, locations=None,
                                       cache_dirs=self.data_dirs).fetch()

--- a/selftests/unit/test_utils_kernel.py
+++ b/selftests/unit/test_utils_kernel.py
@@ -1,0 +1,18 @@
+import unittest
+
+from avocado.utils.kernel import KernelBuild
+
+
+class TestKernelBuild(unittest.TestCase):
+    def setUp(self):
+        self.kernel_version = '4.4.133'
+        self.kernel = KernelBuild(self.kernel_version)
+
+    def test_build_default_url(self):
+        expected_url = 'https://www.kernel.org/pub/linux/kernel/v4.x/linux-4.4.133.tar.gz'
+        self.assertEqual(self.kernel._build_kernel_url(), expected_url)
+
+    def test_build_overrided_url(self):
+        base_url = 'https://mykernel.com/'
+        expected_url = '{}linux-4.4.133.tar.gz'.format(base_url)
+        self.assertEqual(self.kernel._build_kernel_url(base_url=base_url), expected_url)


### PR DESCRIPTION
The current utils kernel module has no tests. Recently it was added a
fix[1] to the process of kernel url building. To keep this process
without future regressions, this change adds a proper test for it.

It's important to note that a new internal method was added to the
KernelBuild class to make easier to test it. Indirectly it's an
improvement of download method that now is shorter and more explicit.

[1] 
     - commit c84ac6ba5eb892a54128e42649b9beb53fc1c20e 
     - PR #2893 

Signed-off-by: Caio Carrara <ccarrara@redhat.com>