### PR TITLE
Runner: fix typo in exception name

### DIFF
--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -249,7 +249,7 @@ class TestStatus(object):
                 test_state['text_output'] = log_file_obj.read()
         except IOError:
             test_state["text_output"] = "Not available, file not created yet"
-        TEST_LOG.error('ERROR %s -> TestAbortedError: %s.', err,
+        TEST_LOG.error('ERROR %s -> TestAbortError: %s.', err,
                        test_state['name'])
         if proc.is_alive():
             TEST_LOG.warning("Killing hanged test process %s" % proc.pid)

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -403,7 +403,7 @@ class RunnerOperationTest(unittest.TestCase):
         self.assertIn(b"Runner error occurred: Timeout reached", output,
                       "Timeout reached message not found in the output:\n%s" % output)
         # Ensure no test aborted error messages show up
-        self.assertNotIn(b"TestAbortedError: Test aborted unexpectedly", output)
+        self.assertNotIn(b"TestAbortError: Test aborted unexpectedly", output)
 
     @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 2,
                      "Skipping test that take a long time to run, are "


### PR DESCRIPTION
The correct name of the exception is TestAbortError, and not
TestAbortedError.

Signed-off-by: Cleber Rosa <crosa@redhat.com>