### PR TITLE
Allow an interrupted test 60s to clean up

### DIFF
--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -41,7 +41,7 @@ from .output import LOG_UI as APP_LOG
 from .output import LOG_JOB as TEST_LOG
 
 #: when test was interrupted (ctrl+c/timeout)
-TIMEOUT_TEST_INTERRUPTED = 1
+TIMEOUT_TEST_INTERRUPTED = 60
 #: when the process died but the status was not yet delivered
 TIMEOUT_PROCESS_DIED = 10
 #: when test reported status but the process did not finish


### PR DESCRIPTION
When a test is interrupted, there is no reason it should get only 1 second to do it's
cleanup when we otherwise give a test 10 seconds to clean up if it just dies.

Fixes: 2908

Signed-off-by: Brian J. Murrell <brian@interlinx.bc.ca>