### PR TITLE
Default to Python 3 for development purposes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,8 @@ install:
 script:
     - |
         # First cleanup the previously installed files
-        python setup.py develop --uninstall
+        PYTHON=$(which python)
+        $(PYTHON) setup.py develop --uninstall
         BINDIR=$(dirname $(which python))
         for FILE in scripts/*; do
             rm $BINDIR/$(basename $FILE)
@@ -61,8 +62,8 @@ script:
             echo
             echo
             git checkout $COMMIT || ERR=$(echo -e "$ERR\nUnable to checkout $(git log -1 --oneline $COMMIT)")
-            make check || ERR=$(echo -e "$ERR\nmake check of $(git log -1 --oneline) failed")
-            make clean
+            make PYTHON=$PYTHON check || ERR=$(echo -e "$ERR\nmake check of $(git log -1 --oneline) failed")
+            make PYTHON=$PYTHON clean
         done
         if [ "$ERR" ]; then
             echo

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-PYTHON=$(shell which python 2>/dev/null || which python3 2>/dev/null)
+ifndef PYTHON
+PYTHON=$(shell which python3 2>/dev/null || which python 2>/dev/null)
+endif
 VERSION=$(shell $(PYTHON) setup.py --version 2>/dev/null)
 PYTHON_DEVELOP_ARGS=$(shell if ($(PYTHON) setup.py develop --help 2>/dev/null | grep -q '\-\-user'); then echo "--user"; else echo ""; fi)
 DESTDIR=/
@@ -130,15 +132,15 @@ smokecheck: clean develop
 
 check: clean develop modules_boundaries
 	# Unless manually set, this is equivalent to AVOCADO_CHECK_LEVEL=0
-	selftests/checkall
+	PYTHON=$(PYTHON) selftests/checkall
 	selftests/check_tmp_dirs
 
 check-full: clean develop modules_boundaries
-	AVOCADO_CHECK_LEVEL=2 selftests/checkall
+	PYTHON=$(PYTHON) AVOCADO_CHECK_LEVEL=2 selftests/checkall
 	selftests/check_tmp_dirs
 
 selfcheck: clean modules_boundaries develop
-	AVOCADO_SELF_CHECK=1 selftests/checkall
+	PYTHON=$(PYTHON) AVOCADO_SELF_CHECK=1 selftests/checkall
 	selftests/check_tmp_dirs
 
 modules_boundaries:

--- a/selftests/checkall
+++ b/selftests/checkall
@@ -1,4 +1,5 @@
 #!/bin/bash
+PYTHON=${PYTHON:-python3}
 ERR=()
 RESULTS_DIR=$(./scripts/avocado config | grep datadir.paths.logs_dir | awk '{print $2}')
 # Very basic version of expanduser
@@ -72,7 +73,7 @@ parallel_selftests() {
         for I in $(seq 0 $PER_SLICE $((${#ALL[@]} - 1))); do
             TMP=$(mktemp /tmp/avocado_parallel_unittest_output_XXXXXX)
             TMPS+=("$TMP")
-            ( python -m unittest ${ALL[@]:$I:$PER_SLICE} &> $TMP ) &
+            ( $PYTHON -m unittest ${ALL[@]:$I:$PER_SLICE} &> $TMP ) &
             PIDS+=("$!")
             sleep 0.1
         done
@@ -104,8 +105,8 @@ parallel_selftests() {
         if [ ${#FAILED_ONCE[@]} -gt 0 ]; then
             if [ ${#FAILED_ONCE[@]} -le 24 ]; then
                 echo ${#FAILED_ONCE[@]} failed during parallel execution, trying them in series
-                echo "python -m unittest --failfast ${FAILED_ONCE[@]}"
-                if python -m unittest --failfast ${FAILED_ONCE[@]}; then
+                echo "$PYTHON -m unittest --failfast ${FAILED_ONCE[@]}"
+                if $PYTHON -m unittest --failfast ${FAILED_ONCE[@]}; then
                     echo "All failed tests passed when executed in series"
                     echo
                     for I in $(seq 0 $((${#PIDS[@]} - 1))); do
@@ -126,7 +127,7 @@ parallel_selftests() {
         for I in $(seq 0 $((${#PIDS[@]} - 1))); do
             if [ -e "${TMPS[$I]}" ]; then
                 echo
-                echo python -m unittest ${ALL[@]:$(($I * $PER_SLICE)):$PER_SLICE}
+                echo $PYTHON -m unittest ${ALL[@]:$(($I * $PER_SLICE)):$PER_SLICE}
                 cat "${TMPS[$I]}"
                 rm "${TMPS[$I]}"
             fi


### PR DESCRIPTION
The Makefile is used mostly on development related work flows, and has
up to know stick to Python 2 by default.  I think it's time to flip
the switch, and look for a Python 3 binary by default.

Signed-off-by: Cleber Rosa <crosa@redhat.com>