### PR TITLE
selftests/unit/test_utils_kernel.py: make sure temp work dir is clean…

### DIFF
--- a/selftests/unit/test_utils_kernel.py
+++ b/selftests/unit/test_utils_kernel.py
@@ -16,3 +16,7 @@ class TestKernelBuild(unittest.TestCase):
         base_url = 'https://mykernel.com/'
         expected_url = '{}linux-4.4.133.tar.gz'.format(base_url)
         self.assertEqual(self.kernel._build_kernel_url(base_url=base_url), expected_url)
+
+    def tearDown(self):
+        # To make sure that the temporary workdir is cleaned up
+        del(self.kernel)


### PR DESCRIPTION
…ed up

On some environments, we can not count on the reference count and
automatic cleanup of that instance, and consequently, the left over
temporary directory constitutes a failure.

Signed-off-by: Cleber Rosa <crosa@redhat.com>