### PR TITLE
Selftests: respect pylint 2.2.0 checks

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -106,17 +106,11 @@ def filter_test_tags(test_suite, filter_by_tags, include_empty=False):
 
 
 class LoaderError(Exception):
-
     """ Loader exception """
-
-    pass
 
 
 class InvalidLoaderPlugin(LoaderError):
-
     """ Invalid loader plugin """
-
-    pass
 
 
 class LoaderUnhandledReferenceError(LoaderError):
@@ -445,17 +439,11 @@ class TestLoader(object):
 
 
 class BrokenSymlink(object):
-
     """ Dummy object to represent reference pointing to a BrokenSymlink path """
-
-    pass
 
 
 class AccessDeniedPath(object):
-
     """ Dummy object to represent reference pointing to a inaccessible path """
-
-    pass
 
 
 def add_loader_options(parser):

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -238,11 +238,9 @@ class _StdOutputFile(object):
 
     def close(self):
         """ File-object methods """
-        pass
 
     def flush(self):
         """ File-object methods """
-        pass
 
     def isatty(self):
         """ File-object methods """
@@ -250,11 +248,9 @@ class _StdOutputFile(object):
 
     def seek(self):
         """ File-object methods """
-        pass
 
     def tell(self):
         """ File-object methods """
-        pass
 
     def getvalue(self):
         """
@@ -527,7 +523,6 @@ class MemStreamHandler(logging.StreamHandler):
         """
         This is in-mem object, it does not require flushing
         """
-        pass
 
 
 class PagerNotFoundError(Exception):

--- a/avocado/core/restclient/connection.py
+++ b/avocado/core/restclient/connection.py
@@ -32,19 +32,15 @@ MIN_REQUIRED_VERSION = (0, 2, 0)
 
 
 class InvalidConnectionError(Exception):
-
     """
     Invalid connection for selected server
     """
-    pass
 
 
 class InvalidServerVersionError(Exception):
-
     """
     The server version does not satisfy the minimum required version
     """
-    pass
 
 
 class UnexpectedHttpStatusCode(Exception):

--- a/avocado/core/restclient/response.py
+++ b/avocado/core/restclient/response.py
@@ -20,22 +20,18 @@ import json
 
 
 class InvalidJSONError(Exception):
-
     """
     Data given to a loader/decoder is not valid JSON
     """
-    pass
 
 
 class InvalidResultResponseError(Exception):
-
     """
     Returned result response does not conform to expectation
 
     Even though the result may be a valid json, it may not have the required
     or expected information that would normally be sent by avocado-server.
     """
-    pass
 
 
 class BaseResponse(object):

--- a/avocado/core/result.py
+++ b/avocado/core/result.py
@@ -75,7 +75,6 @@ class Result(object):
         :param state: result of :class:`avocado.core.test.Test.get_state`.
         :type state: dict
         """
-        pass
 
     def end_test(self, state):
         """

--- a/avocado/core/settings.py
+++ b/avocado/core/settings.py
@@ -32,19 +32,15 @@ from ..utils import path
 
 
 class SettingsError(Exception):
-
     """
     Base settings error.
     """
-    pass
 
 
 class SettingsValueError(SettingsError):
-
     """
     Error thrown when we could not convert successfully a key to a value.
     """
-    pass
 
 
 class ConfigFileNotFound(SettingsError):

--- a/avocado/utils/archive.py
+++ b/avocado/utils/archive.py
@@ -40,11 +40,9 @@ except ImportError:
 
 
 class ArchiveException(Exception):
-
     """
     Base exception for all archive errors.
     """
-    pass
 
 
 class _WrapLZMA(object):

--- a/avocado/utils/external/gdbmi_parser.py
+++ b/avocado/utils/external/gdbmi_parser.py
@@ -78,7 +78,6 @@ def __private():
 
         def t_whitespace(self, s):
             r'[ \t\f\v]+'
-            pass
 
         def t_symbol(self, s):
             r',|\{|\}|\[|\]|\='
@@ -158,7 +157,6 @@ def __private():
             list ::= { value }
             list ::= { value value_list }
             """
-            pass
 
         def terminal(self, token):
             #  Homogeneous AST.

--- a/avocado/utils/gdb.py
+++ b/avocado/utils/gdb.py
@@ -72,43 +72,33 @@ REMOTE_MAX_PACKET_SIZE = 1024
 
 
 class UnexpectedResponseError(Exception):
-
     """
     A response different from the one expected was received from GDB
     """
-    pass
 
 
 class ServerInitTimeoutError(Exception):
-
     """
     Server took longer than expected to initialize itself properly
     """
-    pass
 
 
 class InvalidPacketError(Exception):
-
     """
     Packet received has invalid format
     """
-    pass
 
 
 class NotConnectedError(Exception):
-
     """
     GDBRemote is not connected to a remote GDB server
     """
-    pass
 
 
 class RetransmissionRequestedError(Exception):
-
     """
     Message integrity was not validated and retransmission is being requested
     """
-    pass
 
 
 def parse_mi(line):

--- a/avocado/utils/genio.py
+++ b/avocado/utils/genio.py
@@ -35,7 +35,6 @@ class GenIOError(Exception):
     """
     Base Exception Class for all IO exceptions
     """
-    pass
 
 
 def log_line(filename, line):

--- a/avocado/utils/iso9660.py
+++ b/avocado/utils/iso9660.py
@@ -185,7 +185,6 @@ class BaseIso9660(object):
 
         :rtype: None
         """
-        pass
 
 
 class MixInMntDirMount(object):

--- a/avocado/utils/lv_utils.py
+++ b/avocado/utils/lv_utils.py
@@ -38,7 +38,6 @@ class LVException(Exception):
     """
     Base Exception Class for all exceptions
     """
-    pass
 
 
 def get_diskspace(disk):

--- a/avocado/utils/memory.py
+++ b/avocado/utils/memory.py
@@ -31,11 +31,9 @@ from .data_structures import DataSize
 
 
 class MemError(Exception):
-
     """
     called when memory operations fails
     """
-    pass
 
 
 def get_blk_string(block):

--- a/examples/tests/cancelonsetup.py
+++ b/examples/tests/cancelonsetup.py
@@ -17,7 +17,6 @@ class CancelOnSetupTest(Test):
         """
         This won't get to be executed, given that setUp calls .cancel().
         """
-        pass
 
 
 if __name__ == "__main__":

--- a/examples/tests/passtest.py
+++ b/examples/tests/passtest.py
@@ -16,7 +16,6 @@ class PassTest(Test):
         """
         A test simply doesn't have to fail in order to pass
         """
-        pass
 
 
 if __name__ == "__main__":

--- a/optional_plugins/html/avocado_result_html/__init__.py
+++ b/optional_plugins/html/avocado_result_html/__init__.py
@@ -47,7 +47,6 @@ class ReportModel(object):
         """
         Hook for updates not supported
         """
-        pass
 
     def get(self, key, default):
         value = getattr(self, key, default)

--- a/optional_plugins/runner_docker/avocado_runner_docker/__init__.py
+++ b/optional_plugins/runner_docker/avocado_runner_docker/__init__.py
@@ -73,7 +73,7 @@ class DockerRemoter(object):
         """
         def print_func(*args, **kwargs):    # pylint: disable=W0613
             """ Accept anything and does nothing """
-            pass
+
         if timeout is None:
             timeout = 31536000  # aexpect does not support None, use one year
         start = time.time()

--- a/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
+++ b/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
@@ -595,7 +595,6 @@ class RemoteTestRunner(TestRunner):
         :warning: It might be called on `setup` exceptions, so things
                   initialized during `setup` might not yet be initialized.
         """
-        pass
 
 
 class RemoteCLI(CLI):

--- a/optional_plugins/runner_vm/avocado_runner_vm/__init__.py
+++ b/optional_plugins/runner_vm/avocado_runner_vm/__init__.py
@@ -34,7 +34,6 @@ class VirtError(Exception):
     Generic exception class to propagate underling
     errors to the caller.
     """
-    pass
 
 
 class Hypervisor(object):
@@ -100,7 +99,6 @@ class Hypervisor(object):
         avoid unwanted messages from libvirt exceptions to be sent for
         stdout.
         """
-        pass
 
 
 class VM(object):

--- a/requirements-selftests.txt
+++ b/requirements-selftests.txt
@@ -3,6 +3,8 @@
 Sphinx==1.7.8
 
 # inspektor (static and style checks)
+pylint==1.9.3; python_version <= '2.7'
+pylint==2.2.0; python_version >= '3.4'
 inspektor==0.5.2
 
 # mock (some unittests use it)

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -112,7 +112,7 @@ class OutputCheckOnOff(Test):
 
 def image_output_uncapable():
     try:
-        import PIL              # pylint: disable=W0612
+        import PIL              # pylint: disable=W0611,W0612
         return False
     except ImportError:
         return True


### PR DESCRIPTION
The newly released pylint version 2.2.0, changed its default behavior
(enabled) the following checks:

 * :unnecessary-pass (W0107): *Unnecessary pass statement*
   Used when a "pass" statement that can be avoided is encountered.

 * :unused-import (W0611): *Unused %s*
   Used when an imported module or variable is not used.

Let's apply fixes to those checks, and at the same time, pin the
pylint version so that our CI environment is more stable (code that
test our code -- pylint -- doesn't change, while our code changes).

Signed-off-by: Cleber Rosa <crosa@redhat.com>