### PR TITLE
plugins.xunit: Use job-dir-name as name

### DIFF
--- a/avocado/plugins/xunit.py
+++ b/avocado/plugins/xunit.py
@@ -90,7 +90,7 @@ class XUnitResult(Result):
     def _render(self, result, max_test_log_size):
         document = Document()
         testsuite = document.createElement('testsuite')
-        testsuite.setAttribute('name', 'avocado')
+        testsuite.setAttribute('name', os.path.basename(os.path.dirname(result.logfile)))
         testsuite.setAttribute('tests', self._escape_attr(result.tests_total))
         testsuite.setAttribute('errors', self._escape_attr(result.errors + result.interrupted))
         testsuite.setAttribute('failures', self._escape_attr(result.failed))

--- a/selftests/unit/test_xunit.py
+++ b/selftests/unit/test_xunit.py
@@ -49,6 +49,8 @@ class xUnitSucceedTest(unittest.TestCase):
         self.job = job.Job(args)
         self.test_result = Result(FakeJob(args))
         self.test_result.tests_total = 1
+        self.test_result.logfile = ("/.../avocado/job-results/"
+                                    "job-2018-11-28T16.27-8fef221/job.log")
         self.test1 = SimpleTest(job=self.job, base_logdir=self.tmpdir)
         self.test1._Test__status = 'PASS'
         self.test1.time_elapsed = 1.23


### PR DESCRIPTION
Currently we use "avocado" as a suite name, let's use job-dir which is
quite useful when matching xml results to output directories.

Note I considered using uid, which is available directly in `results`, but the job-dir seems better.

@brianjmurrell any suggestions?