### PR TITLE
Respect Python versions on non-parallel selftests

### DIFF
--- a/selftests/checkall
+++ b/selftests/checkall
@@ -186,7 +186,7 @@ run_rc signed-off-by signed_off_check
 if [ "$AVOCADO_PARALLEL_CHECK" ]; then
     run_rc selftests parallel_selftests
 elif [ -z "$AVOCADO_SELF_CHECK" ]; then
-    run_rc selftests selftests/run
+    run_rc selftests "$PYTHON selftests/run"
 else
     CMD='scripts/avocado run --job-results-dir=$(mktemp -d) selftests/{unit,functional,doc}'
     [ ! $SELF_CHECK_CONTINUOUS ] && CMD+=" --failfast on"


### PR DESCRIPTION
On 03d81feada, we let the Avocado developer choose the Python version
to use by setting a PYTHON variable that gets passed to `make`
commands.

But, we missed the case when the execution of the selftests is not
done in parallel.

Signed-off-by: Cleber Rosa <crosa@redhat.com>