### PR TITLE
avocado.utils.partition selftests fixes

### DIFF
--- a/selftests/unit/test_utils_partition.py
+++ b/selftests/unit/test_utils_partition.py
@@ -130,6 +130,10 @@ class TestPartitionMkfsMount(Base):
                             side_effect=OSError) as mocked_system_output:
                 self.assertRaises(partition.PartitionError, self.disk.unmount)
                 mocked_system_output.assert_called_with('lsof ' + self.mountpoint)
+        # TODO: process.terminate() should be enough, but currently isn't.
+        # debug the root cause of why the process fails to terminate and the
+        # test hangs on wait()
+        self.disk.unmount()
         proc.terminate()
         proc.wait()
 

--- a/selftests/unit/test_utils_partition.py
+++ b/selftests/unit/test_utils_partition.py
@@ -59,12 +59,12 @@ class TestPartition(Base):
         self.disk.mount()
         with open("/proc/mounts") as proc_mounts_file:
             proc_mounts = proc_mounts_file.read()
-            self.assertIn(self.mountpoint, proc_mounts)
-            self.assertEqual(self.mountpoint, self.disk.get_mountpoint())
-            self.disk.unmount()
+        self.assertIn(self.mountpoint, proc_mounts)
+        self.assertEqual(self.mountpoint, self.disk.get_mountpoint())
+        self.disk.unmount()
         with open("/proc/mounts") as proc_mounts_file:
             proc_mounts = proc_mounts_file.read()
-            self.assertNotIn(self.mountpoint, proc_mounts)
+        self.assertNotIn(self.mountpoint, proc_mounts)
 
 
 class TestPartitionMkfsMount(Base):
@@ -85,73 +85,73 @@ class TestPartitionMkfsMount(Base):
         """ Test force-unmount feature """
         with open("/proc/mounts") as proc_mounts_file:
             proc_mounts = proc_mounts_file.read()
-            self.assertIn(self.mountpoint, proc_mounts)
-            proc = process.SubProcess("cd %s; while :; do echo a > a; rm a; done"
-                                      % self.mountpoint, shell=True)
-            proc.start()
-            self.assertTrue(self.disk.unmount())
-            self.assertEqual(proc.poll(), -9)   # Process should be killed -9
+        self.assertIn(self.mountpoint, proc_mounts)
+        proc = process.SubProcess("cd %s; while :; do echo a > a; rm a; done"
+                                  % self.mountpoint, shell=True)
+        proc.start()
+        self.assertTrue(self.disk.unmount())
+        self.assertEqual(proc.poll(), -9)   # Process should be killed -9
         with open("/proc/mounts") as proc_mounts_file:
             proc_mounts = proc_mounts_file.read()
-            self.assertNotIn(self.mountpoint, proc_mounts)
+        self.assertNotIn(self.mountpoint, proc_mounts)
 
     @unittest.skipUnless(missing_binary('lsof'), "requires not having lsof")
     def test_force_unmount_no_lsof(self):
         """ Checks that a force-unmount will fail on systems without lsof """
         with open("/proc/mounts") as proc_mounts_file:
             proc_mounts = proc_mounts_file.read()
-            self.assertIn(self.mountpoint, proc_mounts)
-            proc = process.SubProcess("cd %s; while :; do echo a > a; rm a; done"
-                                      % self.mountpoint, shell=True)
-            proc.start()
-            self.assertRaises(partition.PartitionError, self.disk.unmount)
-            proc.terminate()
-            proc.wait()
+        self.assertIn(self.mountpoint, proc_mounts)
+        proc = process.SubProcess("cd %s; while :; do echo a > a; rm a; done"
+                                  % self.mountpoint, shell=True)
+        proc.start()
+        self.assertRaises(partition.PartitionError, self.disk.unmount)
+        proc.terminate()
+        proc.wait()
 
     def test_force_unmount_get_pids_fail(self):
         """ Checks PartitionError is raised if there's no lsof to get pids """
         with open("/proc/mounts") as proc_mounts_file:
             proc_mounts = proc_mounts_file.read()
-            self.assertIn(self.mountpoint, proc_mounts)
-            proc = process.SubProcess("cd %s; while :; do echo a > a; rm a; done"
-                                      % self.mountpoint, shell=True)
-            proc.start()
-            with mock.patch('avocado.utils.partition.process.run',
-                            side_effect=process.CmdError):
-                with mock.patch('avocado.utils.partition.process.system_output',
-                                side_effect=OSError) as mocked_system_output:
-                    self.assertRaises(partition.PartitionError, self.disk.unmount)
-                    mocked_system_output.assert_called_with('lsof ' + self.mountpoint)
-            proc.terminate()
-            proc.wait()
+        self.assertIn(self.mountpoint, proc_mounts)
+        proc = process.SubProcess("cd %s; while :; do echo a > a; rm a; done"
+                                  % self.mountpoint, shell=True)
+        proc.start()
+        with mock.patch('avocado.utils.partition.process.run',
+                        side_effect=process.CmdError):
+            with mock.patch('avocado.utils.partition.process.system_output',
+                            side_effect=OSError) as mocked_system_output:
+                self.assertRaises(partition.PartitionError, self.disk.unmount)
+                mocked_system_output.assert_called_with('lsof ' + self.mountpoint)
+        proc.terminate()
+        proc.wait()
 
     def test_double_mount(self):
         """ Check the attempt for second mount fails """
         with open("/proc/mounts") as proc_mounts_file:
             proc_mounts = proc_mounts_file.read()
-            self.assertIn(self.mountpoint, proc_mounts)
-            self.assertRaises(partition.PartitionError, self.disk.mount)
-            self.assertIn(self.mountpoint, proc_mounts)
+        self.assertIn(self.mountpoint, proc_mounts)
+        self.assertRaises(partition.PartitionError, self.disk.mount)
+        self.assertIn(self.mountpoint, proc_mounts)
 
     def test_double_umount(self):
         """ Check double unmount works well """
         with open("/proc/mounts") as proc_mounts_file:
             proc_mounts = proc_mounts_file.read()
-            self.assertIn(self.mountpoint, proc_mounts)
+        self.assertIn(self.mountpoint, proc_mounts)
         self.disk.unmount()
         with open("/proc/mounts") as proc_mounts_file:
             proc_mounts = proc_mounts_file.read()
-            self.assertNotIn(self.mountpoint, proc_mounts)
+        self.assertNotIn(self.mountpoint, proc_mounts)
         self.disk.unmount()
         with open("/proc/mounts") as proc_mounts_file:
             proc_mounts = proc_mounts_file.read()
-            self.assertNotIn(self.mountpoint, proc_mounts)
+        self.assertNotIn(self.mountpoint, proc_mounts)
 
     def test_format_mounted(self):
         """ Check format on mounted device fails """
         with open("/proc/mounts") as proc_mounts_file:
             proc_mounts = proc_mounts_file.read()
-            self.assertIn(self.mountpoint, proc_mounts)
+        self.assertIn(self.mountpoint, proc_mounts)
         self.assertRaises(partition.PartitionError, self.disk.mkfs)
 
 


### PR DESCRIPTION
The "avocado.util.partition" selftests will only run when the right environment is preset, that is, you run them as privileged users that can do partition and filesystem operations.  For this reason, they're not always executed on developer environments (that's true for my own).

When trying to run them in suitable environment, I found some issues described and fixed in the individual commits.