### PR TITLE
F30 spec fixes

### DIFF
--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -393,6 +393,7 @@ popd
 %{__cp} -r examples/yaml_to_mux_loader %{buildroot}%{_docdir}/avocado
 %{__cp} -r examples/varianter_pict %{buildroot}%{_docdir}/avocado
 %{__cp} -r examples/varianter_cit %{buildroot}%{_docdir}/avocado
+find %{buildroot}%{_docdir}/avocado -type f -name '*.py' -exec %{__chmod} -c -x {} ';'
 %{__mkdir} -p %{buildroot}%{_libexecdir}/avocado
 %{__mv} %{buildroot}%{python2_sitelib}/avocado/libexec/* %{buildroot}%{_libexecdir}/avocado
 

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -99,6 +99,10 @@ BuildRequires: python2-setuptools
 BuildRequires: python2-six
 BuildRequires: python2-sphinx
 BuildRequires: python2-stevedore
+%endif
+%if 0%{?fedora} && 0%{?fedora} <= 29
+# Python2 binary packages are being removed
+# See https://fedoraproject.org/wiki/Changes/Mass_Python_2_Package_Removal
 BuildRequires: python2-pycdlib
 %endif
 
@@ -157,6 +161,10 @@ Requires: python2-requests
 Requires: python2-setuptools
 Requires: python2-six
 Requires: python2-stevedore
+%endif
+%if 0%{?fedora} && 0%{?fedora} <= 29
+# Python2 binary packages are being removed
+# See https://fedoraproject.org/wiki/Changes/Mass_Python_2_Package_Removal
 Requires: python2-pycdlib
 %endif
 %{?python_provide:%python_provide python2-%{srcname}}


### PR DESCRIPTION
This PR fixes two separate issues in the avocado SPEC file preventing avocado from building for Fedora 30 using `make MOCK_CONFIG=fedora-30-x86_64 rpm`.

The first build problem occurs because the `python2-pycdlib` package has been removed in Fedora 30 as part of the https://fedoraproject.org/wiki/Changes/Mass_Python_2_Package_Removal effort. The first commit simply conditionalizes the Requires/BuildRequires for `python2-pycdlib`, and avocado automatically disables runtime support for the features provided by the retired package.

After fixing the first problem, a second problem appears. The BuildRoot Policy Script `/usr/lib/rpm/redhat/brp-mangle-shebangs` detects the use of `#!/usr/bin/env python` shebang lines in avocado documentation example python scripts and fails the build with "ambiguous python shebang" errors. The second commit adds a line to to the %build stanza that disables execute permission on the example scripts--which is appropriate for documentation files--which makes the errors go away. Background information about the shebang errors can be found at https://fedoraproject.org/wiki/Changes/Make_ambiguous_python_shebangs_error and https://fedoraproject.org/wiki/Packaging:Guidelines#Shebang_lines.

With these commits, `make MOCK_CONFIG=fedora-30-x86_64 rpm` now completes successfully.