### PR TITLE
GLib loader: use text instead of bytes for the test names

### DIFF
--- a/optional_plugins/glib/avocado_glib/__init__.py
+++ b/optional_plugins/glib/avocado_glib/__init__.py
@@ -96,7 +96,7 @@ class GLibLoader(loader.TestLoader):
                              {"name": "%s: %s" % (reference, details)})]
                 return []
 
-            for test_item in result.stdout.splitlines():
+            for test_item in result.stdout_text.splitlines():
                 test_name = "%s:%s" % (reference, test_item)
                 if subtests_filter and not subtests_filter.search(test_name):
                     continue


### PR DESCRIPTION
The test names are based on the executable output with '-l', but
it should be treated as text, and not as bytes.

This fixes issue #2927.

Reference: https://github.com/avocado-framework/avocado/issues/2927
Signed-off-by: Cleber Rosa <crosa@redhat.com>