### PR TITLE
Makefile: also check for Python 2 explicitly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 ifndef PYTHON
-PYTHON=$(shell which python3 2>/dev/null || which python 2>/dev/null)
+PYTHON=$(shell which python3 2>/dev/null || which python2 2>/dev/null || which python 2>/dev/null)
 endif
 VERSION=$(shell $(PYTHON) setup.py --version 2>/dev/null)
 PYTHON_DEVELOP_ARGS=$(shell if ($(PYTHON) setup.py develop --help 2>/dev/null | grep -q '\-\-user'); then echo "--user"; else echo ""; fi)


### PR DESCRIPTION
Some distros don't create `/bin/python` and only ship with
`/bin/python2` or `/bin/python3`.  As we are already detecting
`python3` let's also look for `python2` explicitly.

Also, let's fallback to unversioned `python` if no other is found, as
unlikely as it may be.

Signed-off-by: Cleber Rosa <crosa@redhat.com>