### PR TITLE
Improve is_port_free

### DIFF
--- a/avocado/utils/network.py
+++ b/avocado/utils/network.py
@@ -38,13 +38,17 @@ def is_port_free(port, address):
     :param port: Port number
     :param address: Socket address to bind or connect
     """
+    if address == "localhost" or not address:
+        localhost = True
+    else:
+        localhost = False
     sock = None
     try:
         for family in FAMILIES:
             for protocol in PROTOCOLS:
                 try:
                     sock = socket.socket(family, protocol)
-                    if address == "localhost":
+                    if localhost:
                         sock.bind(("", port))
                     else:
                         sock.connect((address, port))
@@ -52,7 +56,7 @@ def is_port_free(port, address):
                 except socket.error as exc:
                     if exc.errno in (93, 94):   # Unsupported combinations
                         continue
-                    if address == "localhost":
+                    if localhost:
                         return False
                 sock.close()
         return True

--- a/avocado/utils/network.py
+++ b/avocado/utils/network.py
@@ -45,7 +45,7 @@ def is_port_free(port, address):
                 try:
                     s = socket.socket(family, protocol)
                     if address == "localhost":
-                        s.bind((address, port))
+                        s.bind(("", port))
                     else:
                         s.connect((address, port))
                         return False

--- a/avocado/utils/network.py
+++ b/avocado/utils/network.py
@@ -38,27 +38,27 @@ def is_port_free(port, address):
     :param port: Port number
     :param address: Socket address to bind or connect
     """
-    s = None
+    sock = None
     try:
         for family in FAMILIES:
             for protocol in PROTOCOLS:
                 try:
-                    s = socket.socket(family, protocol)
+                    sock = socket.socket(family, protocol)
                     if address == "localhost":
-                        s.bind(("", port))
+                        sock.bind(("", port))
                     else:
-                        s.connect((address, port))
+                        sock.connect((address, port))
                         return False
                 except socket.error as exc:
                     if exc.errno in (93, 94):   # Unsupported combinations
                         continue
                     if address == "localhost":
                         return False
-                s.close()
+                sock.close()
         return True
     finally:
-        if s is not None:
-            s.close()
+        if sock is not None:
+            sock.close()
 
 
 def find_free_port(start_port=1024, end_port=65535, address="localhost", sequent=True):

--- a/avocado/utils/network.py
+++ b/avocado/utils/network.py
@@ -23,29 +23,37 @@ from six.moves import xrange as range
 
 from .data_structures import Borg
 
+#: Families taken into account in this class
+FAMILIES = (socket.AF_INET, socket.AF_INET6)
+
 
 def is_port_free(port, address):
     """
     Return True if the given port is available for use.
 
+    Currently we only check for TCP connections on ipv4/6
+
     :param port: Port number
     :param address: Socket address to bind or connect
     """
+    s = None
     try:
-        s = socket.socket()
-        if address == "localhost":
-            s.bind((address, port))
-            free = True
-        else:
-            s.connect((address, port))
-            free = False
-    except socket.error:
-        if address == "localhost":
-            free = False
-        else:
-            free = True
-    s.close()
-    return free
+        for family in FAMILIES:
+            try:
+                s = socket.socket(family, socket.SOCK_STREAM)
+                if address == "localhost":
+                    s.bind((address, port))
+                else:
+                    s.connect((address, port))
+                    return False
+            except socket.error:
+                if address == "localhost":
+                    return False
+            s.close()
+        return True
+    finally:
+        if s is not None:
+            s.close()
 
 
 def find_free_port(start_port=1024, end_port=65535, address="localhost", sequent=True):

--- a/requirements-selftests.txt
+++ b/requirements-selftests.txt
@@ -34,3 +34,6 @@ lxml==4.2.4
 # in make develop. The proper solution would be migrate
 # our make develop process to use pip
 libvirt-python==4.6.0
+
+# For avocado.utils.network selftests
+netifaces

--- a/selftests/unit/test_utils_network.py
+++ b/selftests/unit/test_utils_network.py
@@ -50,19 +50,22 @@ class FreePort(unittest.TestCase):
             else:
                 addrs = ipv6_addrs
             for addr in addrs:
-                try:
-                    sock = socket.socket(family, socket.SOCK_STREAM)
-                    sock.bind((addr, port))
-                    if network.is_port_free(port, "localhost"):
-                        bad.append("%s, %s: reports free" % (family, addr))
-                    else:
-                        good.append("%s, %s" % (family, addr))
-                except Exception as exc:
-                    bad.append("%s, %s: Failed to bind: %s"
-                               % (family, addr, exc))
-                finally:
-                    if sock is not None:
-                        sock.close()
+                for protocol in network.PROTOCOLS:
+                    try:
+                        sock = socket.socket(family, socket.SOCK_STREAM)
+                        sock.bind((addr, port))
+                        if network.is_port_free(port, "localhost"):
+                            bad.append("%s, %s, %s: reports free"
+                                       % (family, protocol, addr))
+                        else:
+                            good.append("%s, %s, %s" % (family, protocol,
+                                                        addr))
+                    except Exception as exc:
+                        bad.append("%s, %s, %s: Failed to bind: %s"
+                                   % (family, protocol, addr, exc))
+                    finally:
+                        if sock is not None:
+                            sock.close()
         self.assertFalse(bad, "Following combinations failed:\n%s\n\n"
                          "Following combinations passed:\n%s"
                          % ("\n".join(bad), "\n".join(good)))

--- a/selftests/unit/test_utils_network.py
+++ b/selftests/unit/test_utils_network.py
@@ -1,3 +1,4 @@
+import socket
 import unittest
 
 try:
@@ -31,6 +32,40 @@ class PortTrackerTest(unittest.TestCase):
         tracker.retained_ports = [22]
         tracker.release_port(22)
         self.assertNotIn(22, tracker.retained_ports)
+
+
+class FreePort(unittest.TestCase):
+
+    def test_is_port_free(self):
+        port = network.find_free_port()
+        self.assertTrue(network.is_port_free(port, "localhost"))
+        ipv4_addrs = ["localhost", "127.0.0.1"]
+        ipv6_addrs = ["localhost", "::1"]
+        good = []
+        bad = []
+        sock = None
+        for family in network.FAMILIES:
+            if family == socket.AF_INET:
+                addrs = ipv4_addrs
+            else:
+                addrs = ipv6_addrs
+            for addr in addrs:
+                try:
+                    sock = socket.socket(family, socket.SOCK_STREAM)
+                    sock.bind((addr, port))
+                    if network.is_port_free(port, "localhost"):
+                        bad.append("%s, %s: reports free" % (family, addr))
+                    else:
+                        good.append("%s, %s" % (family, addr))
+                except Exception as exc:
+                    bad.append("%s, %s: Failed to bind: %s"
+                               % (family, addr, exc))
+                finally:
+                    if sock is not None:
+                        sock.close()
+        self.assertFalse(bad, "Following combinations failed:\n%s\n\n"
+                         "Following combinations passed:\n%s"
+                         % ("\n".join(bad), "\n".join(good)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hello guys, it took me quite long to find out our is_port_free function is seriously insufficient (first I blamed qemu, but it's us). The first commit fixes the issue where ipv4 address is already freed, but ipv6 address is still occupied, the second commit makes sure we don't allow using port that is already used by UDP (not sure why but at least on my system it allows that without complaint). Third replaces "localhost" with "", because on "localhost" python binds only to 127.0.0.1/::1 but on "" it binds to all localhost interfaces (like 192.168.122.1, ...), which is commonly used by programs and we were not detectin these. After that follows fixes and optimization.

PS: This (hopefully) fixes (or at least decreases probability) very rare Avocado-vt migration issue where ports are not free even though we claim they are.