### PR TITLE
selftests/unit/test_utils_partition.py: improve assertion error message

### DIFF
--- a/selftests/unit/test_utils_partition.py
+++ b/selftests/unit/test_utils_partition.py
@@ -89,7 +89,12 @@ class TestPartitionMkfsMount(Base):
         proc.start()
         self.assertTrue(wait.wait_for(lambda: os.path.exists(self.use_mnt_file),
                                       timeout=1, first=0.1, step=0.1),
-                        "File was not created within mountpoint")
+                        "File was not created within mountpoint. "
+                        "\nCommand line: %s"
+                        "\nCommand output: %s"
+                        "\nCommand error: %s" % (self.use_mnt_cmd,
+                                                 proc.get_stdout(),
+                                                 proc.get_stderr()))
         return proc
 
     @unittest.skipIf(missing_binary('lsof'), "requires running lsof")

--- a/selftests/unit/test_utils_partition.py
+++ b/selftests/unit/test_utils_partition.py
@@ -85,7 +85,7 @@ class TestPartitionMkfsMount(Base):
                                                  self.use_mnt_file))
 
     def run_process_to_use_mnt(self):
-        proc = process.SubProcess(self.use_mnt_cmd)
+        proc = process.SubProcess(self.use_mnt_cmd, sudo=True)
         proc.start()
         self.assertTrue(wait.wait_for(lambda: os.path.exists(self.use_mnt_file),
                                       timeout=1, first=0.1, step=0.1),
@@ -93,6 +93,8 @@ class TestPartitionMkfsMount(Base):
         return proc
 
     @unittest.skipIf(missing_binary('lsof'), "requires running lsof")
+    @unittest.skipIf(not process.can_sudo(sys.executable),
+                     "requires running Python as a privileged user")
     @unittest.skipIf(not process.can_sudo('kill -l'),
                      "requires running kill as a privileged user")
     def test_force_unmount(self):
@@ -107,6 +109,8 @@ class TestPartitionMkfsMount(Base):
             proc_mounts = proc_mounts_file.read()
         self.assertNotIn(self.mountpoint, proc_mounts)
 
+    @unittest.skipIf(not process.can_sudo(sys.executable),
+                     "requires running Python as a privileged user")
     @unittest.skipUnless(missing_binary('lsof'), "requires not having lsof")
     def test_force_unmount_no_lsof(self):
         """ Checks that a force-unmount will fail on systems without lsof """
@@ -118,6 +122,8 @@ class TestPartitionMkfsMount(Base):
         proc.terminate()
         proc.wait()
 
+    @unittest.skipIf(not process.can_sudo(sys.executable),
+                     "requires running Python as a privileged user")
     def test_force_unmount_get_pids_fail(self):
         """ Checks PartitionError is raised if there's no lsof to get pids """
         with open("/proc/mounts") as proc_mounts_file:


### PR DESCRIPTION
Because the failures can happen on places hard to reproduce, it's
helpful to understand the situation of the process that's supposed
to create a file within the mountpoint.

Signed-off-by: Cleber Rosa <crosa@redhat.com>