### PR TITLE
selftests/unit/test_utils_partition.py: use sudo

### DIFF
--- a/avocado/utils/lv_utils.py
+++ b/avocado/utils/lv_utils.py
@@ -173,7 +173,7 @@ def vg_ramdisk_cleanup(ramdisk_filename=None, vg_ramdisk_dir=None,
             errs.append("wipe pv")
             LOGGER.error("Failed to wipe pv from %s: %s", loop_device, result)
 
-        losetup_all = process.run("losetup --all").stdout_text
+        losetup_all = process.run("losetup --all", sudo=True).stdout_text
         if loop_device in losetup_all:
             ramdisk_filename = re.search(r"%s: \[\d+\]:\d+ \(([/\w]+)\)" %
                                          loop_device, losetup_all)

--- a/avocado/utils/partition.py
+++ b/avocado/utils/partition.py
@@ -252,7 +252,7 @@ class Partition(object):
             FileNotFoundError = IOError   # pylint: disable=W0622
         try:
             cmd = "lsof " + mnt
-            out = process.system_output(cmd)
+            out = process.system_output(cmd, sudo=True)
             return [int(line.split()[1]) for line in out.splitlines()[1:]]
         except OSError as details:
             msg = 'Could not run lsof to identify processes using "%s"' % mnt


### PR DESCRIPTION
Both when writing to mountpoint, using a Python interpreter, and when
trying to listing open files during a forceful unmount of the disk.

Signed-off-by: Cleber Rosa <crosa@redhat.com>