### PR TITLE
SPEC: add build requirements so that tests for iso9660 gets run [v2]

### DIFF
--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -47,7 +47,7 @@
 Summary: Framework with tools and libraries for Automated Testing
 Name: python-%{srcname}
 Version: 66.0
-Release: 0%{?gitrel}%{?dist}
+Release: 1%{?gitrel}%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.github.io/
@@ -123,8 +123,11 @@ BuildRequires: python3-pycdlib
 %endif
 
 %if %{with_tests}
+BuildRequires: genisoimage
+BuildRequires: libcdio
 BuildRequires: libvirt-python
 BuildRequires: perl-Test-Harness
+BuildRequires: psmisc
 %if 0%{?rhel}
 BuildRequires: PyYAML
 %else
@@ -970,6 +973,9 @@ Again Shell code (and possibly other similar shells).
 %{_libexecdir}/avocado*
 
 %changelog
+* Wed Dec  5 2018 Cleber Rosa <cleber@redhat.com> - 66.0-1
+- Added libcdio, genisoimage and psmisc as build deps
+
 * Tue Nov 20 2018 Cleber Rosa <cleber@redhat.com> - 66.0-0
 - New release
 


### PR DESCRIPTION
There are a number of backends and requirements for iso9660 tests
to run.  Let's add those as build requirements to that as many
as possible tests and code paths get executed during the checks
in the RPM build.  With this, two other test cases get executed:

Before:
 - (Python 2): Ran 600 tests in 198.076s OK (skipped=42)
 - (Python 3): Ran 600 tests in 196.489s OK (skipped=45)

After:
 - (Python 2): Ran 600 tests in 180.514s OK (skipped=40)
 - (Python 3): Ran 600 tests in 188.545s OK (skipped=43)

Signed-off-by: Cleber Rosa <crosa@redhat.com>

---

Changes from v1 (#2936):
 * Moved requirements to the the "with_tests" conditional block, as they're only used on tests (@mmathesius) 