### PR TITLE
Travis-CI: remove sudo configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,6 @@ cache:
     directories:
         - $HOME/.cache/pip
 
-sudo: false
-
 addons:
   apt:
     packages:


### PR DESCRIPTION
According to the references given below, Travis workers now run
on VMs that are sudo capable, and the sudo configuration should
now be removed.

Reference: https://docs.travis-ci.com/user/reference/overview/
Reference: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration
Signed-off-by: Cleber Rosa <crosa@redhat.com>