### PR TITLE
Selftests: converge execution to the same tests

### DIFF
--- a/selftests/__init__.py
+++ b/selftests/__init__.py
@@ -50,3 +50,36 @@ def python_module_available(module_name):
         return True
     except pkg_resources.DistributionNotFound:
         return False
+
+
+def test_suite():
+    '''
+    Returns a test suite with all selftests found
+
+    This includes tests on available optional plugins directories
+
+    :rtype: unittest.TestSuite
+    '''
+    suite = unittest.TestSuite()
+    loader = unittest.TestLoader()
+    selftests_dir = os.path.dirname(os.path.abspath(__file__))
+    basedir = os.path.dirname(selftests_dir)
+    for section in ('unit', 'functional', 'doc'):
+        suite.addTests(loader.discover(start_dir=os.path.join(selftests_dir, section),
+                                       top_level_dir=basedir))
+    plugins = (('avocado-framework-plugin-varianter-yaml-to-mux',
+                'varianter_yaml_to_mux'),
+               ('avocado-framework-plugin-runner-remote',
+                'runner_remote'),
+               ('avocado-framework-plugin-runner-vm',
+                'runner_vm'),
+               ('avocado-framework-plugin-varianter-cit',
+                'varianter_cit'),
+               ('avocado-framework-plugin-result-html',
+                'html'))
+    for plugin_name, plugin_dir in plugins:
+        if python_module_available(plugin_name):
+            path = os.path.join(basedir, 'optional_plugins',
+                                plugin_dir, 'tests')
+            suite.addTests(loader.discover(start_dir=path, top_level_dir=path))
+    return suite

--- a/selftests/__init__.py
+++ b/selftests/__init__.py
@@ -1,4 +1,5 @@
 import os
+import pkg_resources
 import sys
 import unittest
 
@@ -33,3 +34,19 @@ def recent_mock():
     elif sys.version_info[0] == 3:
         return sys.version_info[1] >= 6
     return True
+
+
+def python_module_available(module_name):
+    '''
+    Checks if a given Python module is available
+
+    :param module_name: the name of the module
+    :type module_name: str
+    :returns: if the Python module is available in the system
+    :rtype: bool
+    '''
+    try:
+        pkg_resources.require(module_name)
+        return True
+    except pkg_resources.DistributionNotFound:
+        return False

--- a/selftests/__init__.py
+++ b/selftests/__init__.py
@@ -52,32 +52,40 @@ def python_module_available(module_name):
         return False
 
 
-def test_suite():
+#: The plugin module names and directories under optional_plugins
+PLUGINS = {'varianter_yaml_to_mux': 'avocado-framework-plugin-varianter-yaml-to-mux',
+           'runner_remote': 'avocado-framework-plugin-runner-remote',
+           'runner_vm': 'avocado-framework-plugin-runner-vm',
+           'varianter_cit': 'avocado-framework-plugin-varianter-cit',
+           'html': 'avocado-framework-plugin-result-html'}
+
+
+def test_suite(base_selftests=True, plugin_selftests=None):
     '''
     Returns a test suite with all selftests found
 
     This includes tests on available optional plugins directories
 
+    :param base_selftests: if the base selftests directory should be included
+    :type base_selftests: bool
+    :param plugin_selftests: the list optional plugin directories to include
+                             or None to include all
+    :type plugin_selftests: list or None
     :rtype: unittest.TestSuite
     '''
     suite = unittest.TestSuite()
     loader = unittest.TestLoader()
     selftests_dir = os.path.dirname(os.path.abspath(__file__))
     basedir = os.path.dirname(selftests_dir)
-    for section in ('unit', 'functional', 'doc'):
-        suite.addTests(loader.discover(start_dir=os.path.join(selftests_dir, section),
-                                       top_level_dir=basedir))
-    plugins = (('avocado-framework-plugin-varianter-yaml-to-mux',
-                'varianter_yaml_to_mux'),
-               ('avocado-framework-plugin-runner-remote',
-                'runner_remote'),
-               ('avocado-framework-plugin-runner-vm',
-                'runner_vm'),
-               ('avocado-framework-plugin-varianter-cit',
-                'varianter_cit'),
-               ('avocado-framework-plugin-result-html',
-                'html'))
-    for plugin_name, plugin_dir in plugins:
+    if base_selftests:
+        for section in ('unit', 'functional', 'doc'):
+            start_dir = os.path.join(selftests_dir, section)
+            suite.addTests(loader.discover(start_dir=start_dir,
+                                           top_level_dir=basedir))
+    if plugin_selftests is None:
+        plugin_selftests = PLUGINS.keys()
+    for plugin_dir in plugin_selftests:
+        plugin_name = PLUGINS.get(plugin_dir, None)
         if python_module_available(plugin_name):
             path = os.path.join(basedir, 'optional_plugins',
                                 plugin_dir, 'tests')

--- a/selftests/checkall
+++ b/selftests/checkall
@@ -23,43 +23,25 @@ run_rc() {
 parallel_selftests() {
     local START=$(date +%s)
     local ERR=0
-    local FIND_UNITTESTS=$(readlink -f ./contrib/scripts/avocado-find-unittests)
+    local FIND_UNITTESTS=$(readlink -f ./selftests/list)
     local NO_WORKERS=$(($(cat /proc/cpuinfo | grep -c processor) * 2))
 
     # The directories that may contain files with tests, from the Avocado core
     # and from all optional plugins
-    declare -A DIR_GLOB_MAP
-    DIR_GLOB_MAP[selftests]="selftests/unit/test_*.py selftests/functional/test_*.py selftests/doc/test_*.py"
-    for PLUGIN in $(find optional_plugins -mindepth 1 -maxdepth 1 -type d); do
-        DIR_GLOB_MAP[$PLUGIN]="tests/test_*.py"
-    done;
-
     declare -A TESTS
-    for TEST_DIR in "${!DIR_GLOB_MAP[@]}"; do
-        # tests in core, that is "selftests" expect the regular path, while
-        # python -m unittest module.class.test_name won't work for tests on
-        # plugins without a change of directory because the full path is
-        # not a valid python module (would need __init__.py) in places where
-        # it doesn't make sense
-        if [ "x$TEST_DIR" != "xselftests" ]; then
-            OLD_PWD=$PWD
-            cd $TEST_DIR
-        fi
-        # Use sort -R to randomize the order as longer tests
-        # seems to be likely in the same file
-        THIS_DIR_TESTS=$(${FIND_UNITTESTS} ${DIR_GLOB_MAP[$TEST_DIR]} | sort -R)
+    TESTS[selftests]=$(${FIND_UNITTESTS} | sort -R)
+    for PLUGIN in $(find optional_plugins -mindepth 1 -maxdepth 1 -type d); do
+        PLUGIN_BASENAME=$(basename $PLUGIN)
+        THIS_DIR_TESTS=$(${FIND_UNITTESTS} --no-base-selftests --plugin-dirs $PLUGIN_BASENAME | sort -R)
         if [ -n "$THIS_DIR_TESTS" ]; then
-            TESTS[$TEST_DIR]=${THIS_DIR_TESTS};
-        fi
-        if [ -n $TEST_DIR ]; then
-            cd $OLD_PWD
+            TESTS[$PLUGIN]=${THIS_DIR_TESTS};
         fi
     done
 
     for TEST_DIR in "${!TESTS[@]}"; do
         if [ "x$TEST_DIR" != "xselftests" ]; then
             OLD_PWD=$PWD
-            cd $TEST_DIR
+            cd $TEST_DIR/tests
         fi
 
         declare -a ALL

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -12,7 +12,6 @@ import xml.dom.minidom
 import zipfile
 import unittest
 import psutil
-import pkg_resources
 
 try:
     from io import BytesIO
@@ -35,7 +34,7 @@ from avocado.utils import process
 from avocado.utils import script
 from avocado.utils import path as utils_path
 
-from .. import AVOCADO, BASEDIR
+from .. import AVOCADO, BASEDIR, python_module_available
 
 
 LOCAL_IMPORT_TEST_CONTENTS = '''
@@ -143,14 +142,6 @@ if GNU_ECHO_BINARY is not None:
             GNU_ECHO_BINARY = probe_binary('gecho')
 READ_BINARY = probe_binary('read')
 SLEEP_BINARY = probe_binary('sleep')
-
-
-def html_capable():
-    try:
-        pkg_resources.require('avocado-framework-plugin-result-html')
-        return True
-    except pkg_resources.DistributionNotFound:
-        return False
 
 
 class RunnerOperationTest(unittest.TestCase):
@@ -782,7 +773,7 @@ class RunnerSimpleTest(unittest.TestCase):
                                                     "sysinfo", "pre",
                                                     "echo \'________\'")))
 
-        if html_capable():
+        if python_module_available('avocado-framework-plugin-result-html'):
             with open(os.path.join(self.tmpdir, "latest",
                                    "results.html")) as html_res:
                 html_results = html_res.read()
@@ -1156,7 +1147,7 @@ class PluginsTest(AbsPluginsTest, unittest.TestCase):
 
         result_plugins = ["json", "xunit", "zip_archive"]
         result_outputs = ["results.json", "results.xml"]
-        if html_capable():
+        if python_module_available('avocado-framework-plugin-result-html'):
             result_plugins.append("html")
             result_outputs.append("results.html")
 

--- a/selftests/list
+++ b/selftests/list
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+
+import sys
+
+from selftests import test_suite
+
+
+if __name__ == '__main__':
+    def iter_or_id(arg):
+        if hasattr(arg, '__iter__'):
+            for inner in arg:
+                iter_or_id(inner)
+        else:
+            print(arg.id())
+    try:
+        iter_or_id(test_suite())
+        sys.exit(0)
+    except Exception:
+        sys.exit(1)

--- a/selftests/list
+++ b/selftests/list
@@ -1,8 +1,22 @@
 #!/usr/bin/env python
 
+import argparse
 import sys
 
-from selftests import test_suite
+from selftests import test_suite, PLUGINS
+
+
+class Parser(argparse.ArgumentParser):
+    def __init__(self):
+        super(Parser, self).__init__(
+            description='List selftests using unittest loader')
+        self.add_argument('--no-base-selftests',
+                          action='store_true', default=False,
+                          help='Do not include the base selftests')
+        self.add_argument('--plugin-dirs', nargs='+', default=[],
+                          metavar='DIR',
+                          help='Plugin directories to include. Available '
+                          'directories: %s' % " ".join(PLUGINS.keys()))
 
 
 if __name__ == '__main__':
@@ -12,8 +26,11 @@ if __name__ == '__main__':
                 iter_or_id(inner)
         else:
             print(arg.id())
+
+    args = Parser().parse_args()
     try:
-        iter_or_id(test_suite())
+        iter_or_id(test_suite(not args.no_base_selftests,
+                              args.plugin_dirs))
         sys.exit(0)
     except Exception:
         sys.exit(1)

--- a/selftests/run
+++ b/selftests/run
@@ -5,24 +5,17 @@ __author__ = 'Lucas Meneghel Rodrigues <lmr@redhat.com>'
 
 import gc
 import os
-import pkg_resources
 import subprocess
 import sys
 import unittest
 
 from avocado.core import data_dir
 
+from selftests import python_module_available
+
 
 CHECK_TMP_DIRS = os.path.abspath(os.path.join(os.path.dirname(__file__),
                                               "check_tmp_dirs"))
-
-
-def plugin_available(plugin_name):
-    try:
-        pkg_resources.require(plugin_name)
-        return True
-    except pkg_resources.DistributionNotFound:
-        return False
 
 
 def test_suite():
@@ -44,7 +37,7 @@ def test_suite():
                ('avocado-framework-plugin-result-html',
                 'html'))
     for plugin_name, plugin_dir in plugins:
-        if plugin_available(plugin_name):
+        if python_module_available(plugin_name):
             path = os.path.join(basedir, 'optional_plugins',
                                 plugin_dir, 'tests')
             suite.addTests(loader.discover(start_dir=path, top_level_dir=path))

--- a/selftests/run
+++ b/selftests/run
@@ -11,37 +11,11 @@ import unittest
 
 from avocado.core import data_dir
 
-from selftests import python_module_available
+from selftests import test_suite
 
 
 CHECK_TMP_DIRS = os.path.abspath(os.path.join(os.path.dirname(__file__),
                                               "check_tmp_dirs"))
-
-
-def test_suite():
-    suite = unittest.TestSuite()
-    loader = unittest.TestLoader()
-    selftests_dir = os.path.dirname(os.path.abspath(__file__))
-    basedir = os.path.dirname(selftests_dir)
-    for section in ('unit', 'functional', 'doc'):
-        suite.addTests(loader.discover(start_dir=os.path.join(selftests_dir, section),
-                                       top_level_dir=basedir))
-    plugins = (('avocado-framework-plugin-varianter-yaml-to-mux',
-                'varianter_yaml_to_mux'),
-               ('avocado-framework-plugin-runner-remote',
-                'runner_remote'),
-               ('avocado-framework-plugin-runner-vm',
-                'runner_vm'),
-               ('avocado-framework-plugin-varianter-cit',
-                'varianter_cit'),
-               ('avocado-framework-plugin-result-html',
-                'html'))
-    for plugin_name, plugin_dir in plugins:
-        if python_module_available(plugin_name):
-            path = os.path.join(basedir, 'optional_plugins',
-                                plugin_dir, 'tests')
-            suite.addTests(loader.discover(start_dir=path, top_level_dir=path))
-    return suite
 
 
 class MyResult(unittest.TextTestResult):


### PR DESCRIPTION
There are currently two ways of running unittests:

* Using an "almost-vanilla" unittest runner, in non-parallel mode (`selftests/run`)
* Using shell code (`parallel_selftests` in `selftests/checkall`)

But the list of tests is obtained in two different ways.

Also, because an AST based tool is being used to find unittests, other constraints are put on some of the tests.  Let's add symmetry to the test suite, no matter how it's executed.