### PR TITLE
Iso9660: selftests improvements

### DIFF
--- a/selftests/unit/test_utils_iso9660.py
+++ b/selftests/unit/test_utils_iso9660.py
@@ -45,7 +45,7 @@ class Capabilities(unittest.TestCase):
                                           ['non-existing', 'capabilities']))
 
 
-class BaseIso9660(unittest.TestCase):
+class BaseIso9660(object):
 
     """
     Base class defining setup and tests for shared Iso9660 functionality
@@ -62,8 +62,6 @@ class BaseIso9660(unittest.TestCase):
         """
         Check the basic Iso9660 workflow
         """
-        if self.iso is None:
-            self.skipTest("ISO attribute not setup for this test to work with")
         self.assertEqual(self.iso.read("file"),
                          b"file content\n")
         dst = os.path.join(self.tmpdir, "file")
@@ -78,8 +76,6 @@ class BaseIso9660(unittest.TestCase):
         """
         Check the mnt_dir functionality
         """
-        if self.iso is None:
-            self.skipTest("ISO attribute not setup for this test to work with")
         base = self.iso.mnt_dir
         dir_path = os.path.join(base, "Dir")
         self.assertTrue(os.path.isdir(dir_path))
@@ -98,7 +94,7 @@ class BaseIso9660(unittest.TestCase):
         shutil.rmtree(self.tmpdir)
 
 
-class IsoInfo(BaseIso9660):
+class IsoInfo(BaseIso9660, unittest.TestCase):
 
     """
     IsoInfo-based check
@@ -111,7 +107,7 @@ class IsoInfo(BaseIso9660):
         self.iso = iso9660.Iso9660IsoInfo(self.iso_path)
 
 
-class IsoRead(BaseIso9660):
+class IsoRead(BaseIso9660, unittest.TestCase):
 
     """
     IsoRead-based check
@@ -124,7 +120,7 @@ class IsoRead(BaseIso9660):
         self.iso = iso9660.Iso9660IsoRead(self.iso_path)
 
 
-class IsoMount(BaseIso9660):
+class IsoMount(BaseIso9660, unittest.TestCase):
 
     """
     Mount-based check
@@ -137,7 +133,7 @@ class IsoMount(BaseIso9660):
         self.iso = iso9660.Iso9660Mount(self.iso_path)
 
 
-class PyCDLib(BaseIso9660):
+class PyCDLib(BaseIso9660, unittest.TestCase):
 
     """
     PyCDLib-based check

--- a/selftests/unit/test_utils_iso9660.py
+++ b/selftests/unit/test_utils_iso9660.py
@@ -75,13 +75,12 @@ class BaseIso9660(unittest.TestCase):
 
     @unittest.skipIf(not process.can_sudo("mount"),
                      "This test requires mount to run under sudo or root")
-    def mnt_dir_workflow(self):
+    def test_mnt_dir_workflow(self):
         """
         Check the mnt_dir functionality
-
-        :warning: Make sure to include this in per-implementation tests
-                  due to ast loader we can't just define a base-class.
         """
+        if self.iso is None:
+            self.skipTest("ISO attribute not setup for this test to work with")
         base = self.iso.mnt_dir
         dir_path = os.path.join(base, "Dir")
         self.assertTrue(os.path.isdir(dir_path))
@@ -116,10 +115,6 @@ class IsoInfo(BaseIso9660):
         """Call the basic workflow"""
         self.basic_workflow()
 
-    def test_mnt_dir(self):
-        """Use the mnt_dir property"""
-        self.mnt_dir_workflow()
-
 
 class IsoRead(BaseIso9660):
 
@@ -137,10 +132,6 @@ class IsoRead(BaseIso9660):
         """Call the basic workflow"""
         self.basic_workflow()
 
-    def test_mnt_dir(self):
-        """Use the mnt_dir property"""
-        self.mnt_dir_workflow()
-
 
 class IsoMount(BaseIso9660):
 
@@ -157,10 +148,6 @@ class IsoMount(BaseIso9660):
     def test_basic_workflow(self):
         """Call the basic workflow"""
         self.basic_workflow()
-
-    def test_mnt_dir(self):
-        """Use the mnt_dir property"""
-        self.mnt_dir_workflow()
 
 
 class PyCDLib(BaseIso9660):
@@ -189,10 +176,6 @@ class PyCDLib(BaseIso9660):
             read_iso = iso9660.ISO9660PyCDLib(new_iso_path)
             self.assertEqual(read_iso.read(path), content)
             self.assertTrue(os.path.isfile(new_iso_path))
-
-    def test_mnt_dir(self):
-        """Use the mnt_dir property"""
-        self.mnt_dir_workflow()
 
 
 if __name__ == "__main__":

--- a/selftests/unit/test_utils_iso9660.py
+++ b/selftests/unit/test_utils_iso9660.py
@@ -58,13 +58,12 @@ class BaseIso9660(unittest.TestCase):
         self.iso = None
         self.tmpdir = tempfile.mkdtemp(prefix="avocado_" + __name__)
 
-    def basic_workflow(self):
+    def test_basic_workflow(self):
         """
         Check the basic Iso9660 workflow
-
-        :warning: Make sure to include this in per-implementation tests
-                  due to ast loader we can't just define a base-class.
         """
+        if self.iso is None:
+            self.skipTest("ISO attribute not setup for this test to work with")
         self.assertEqual(self.iso.read("file"),
                          b"file content\n")
         dst = os.path.join(self.tmpdir, "file")
@@ -111,10 +110,6 @@ class IsoInfo(BaseIso9660):
         super(IsoInfo, self).setUp()
         self.iso = iso9660.Iso9660IsoInfo(self.iso_path)
 
-    def test_basic_workflow(self):
-        """Call the basic workflow"""
-        self.basic_workflow()
-
 
 class IsoRead(BaseIso9660):
 
@@ -127,10 +122,6 @@ class IsoRead(BaseIso9660):
     def setUp(self):
         super(IsoRead, self).setUp()
         self.iso = iso9660.Iso9660IsoRead(self.iso_path)
-
-    def test_basic_workflow(self):
-        """Call the basic workflow"""
-        self.basic_workflow()
 
 
 class IsoMount(BaseIso9660):
@@ -145,10 +136,6 @@ class IsoMount(BaseIso9660):
         super(IsoMount, self).setUp()
         self.iso = iso9660.Iso9660Mount(self.iso_path)
 
-    def test_basic_workflow(self):
-        """Call the basic workflow"""
-        self.basic_workflow()
-
 
 class PyCDLib(BaseIso9660):
 
@@ -160,10 +147,6 @@ class PyCDLib(BaseIso9660):
     def setUp(self):
         super(PyCDLib, self).setUp()
         self.iso = iso9660.ISO9660PyCDLib(self.iso_path)
-
-    def test_basic_workflow(self):
-        """Call the basic workflow"""
-        self.basic_workflow()
 
     def test_create_write(self):
         new_iso_path = os.path.join(self.tmpdir, 'new.iso')


### PR DESCRIPTION
This is basically about the simplification of the ISO9660 selftests, removing the techniques previously used to make sure tests were found and properly run on the previous unittest execution model.