### PR TITLE
Add rate to result v2

### DIFF
--- a/avocado/core/result.py
+++ b/avocado/core/result.py
@@ -114,6 +114,6 @@ class Result(object):
     def rate(self):
         total = float(self.tests_total - self.skipped - self.cancelled)
         if not total:
-            return 0
+            return 0.0
         succeeded = float(self.passed + self.warned)
         return 100 * (succeeded / total)

--- a/avocado/core/result.py
+++ b/avocado/core/result.py
@@ -109,3 +109,11 @@ class Result(object):
         else:
             self.errors += 1
         self.end_test(state)
+
+    @property
+    def rate(self):
+        total = float(self.tests_total - self.skipped - self.cancelled)
+        if not total:
+            return 0
+        succeeded = float(self.passed + self.warned)
+        return 100 * (succeeded / total)

--- a/selftests/unit/test_result.py
+++ b/selftests/unit/test_result.py
@@ -24,6 +24,46 @@ class ResultTest(unittest.TestCase):
         Result(FakeJob(args))
         self.assertRaises(AttributeError, Result, FakeJobMissingUniqueId(args))
 
+    def test_result_rate_all_succeeded(self):
+        result = Result(FakeJob([]))
+        result.check_test({'status': 'PASS'})
+        result.end_tests()
+        self.assertEquals(result.rate, 100.0)
+
+    def test_result_rate_all_succeeded_with_warns(self):
+        result = Result(FakeJob([]))
+        result.check_test({'status': 'PASS'})
+        result.check_test({'status': 'WARN'})
+        result.end_tests()
+        self.assertEquals(result.rate, 100.0)
+
+    def test_result_rate_all_succeeded_with_skips(self):
+        result = Result(FakeJob([]))
+        result.check_test({'status': 'PASS'})
+        result.check_test({'status': 'SKIP'})
+        result.end_tests()
+        self.assertEquals(result.rate, 100.0)
+
+    def test_result_rate_all_succeeded_with_cancelled(self):
+        result = Result(FakeJob([]))
+        result.check_test({'status': 'PASS'})
+        result.check_test({'status': 'CANCEL'})
+        result.end_tests()
+        self.assertEquals(result.rate, 100.0)
+
+    def test_result_rate_half_succeeded(self):
+        result = Result(FakeJob([]))
+        result.check_test({'status': 'PASS'})
+        result.check_test({'status': 'FAIL'})
+        result.end_tests()
+        self.assertEquals(result.rate, 50.0)
+
+    def test_result_rate_none_succeeded(self):
+        result = Result(FakeJob([]))
+        result.check_test({'status': 'FAIL'})
+        result.end_tests()
+        self.assertEquals(result.rate, 0.0)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Currently to generate the HTML report the success rate of a test result
is computed by the plugin itself[1]. Since this is an information about the
test result it should be calculated by the Result object and no anywhere
else.

This change adds the rate property to Result class according with the
code (method) already in place in HTML plugin. This new property will be
used soon when the new template engine be added to HTML plugin.

Signed-off-by: Caio Carrara <ccarrara@redhat.com>

[1] - https://github.com/avocado-framework/avocado/blob/master/optional_plugins/html/avocado_result_html/__init__.py#L84

---
Changes from v1 #2950 
* Normalize the new rate property to always return float type