### PR TITLE
Avoid zombie invasion [v2]

### DIFF
--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -212,33 +212,37 @@ def kill_process_tree(pid, sig=signal.SIGKILL, send_sigcont=True,
     :param timeout: How long to wait for the pid(s) to die
                     (negative=infinity, 0=don't wait,
                     positive=number_of_seconds)
+    :return: killed_pids that were destroyed
     """
-    if timeout <= 0:
-        def remaining_time():
-            return timeout
-    else:
+    def _all_pids_dead(killed_pids):
+        for pid in killed_pids:
+            if pid_exists(pid):
+                return False
+        return True
+
+    killed_pids = [pid]
+    if timeout > 0:
         start = time.time()
 
-        def remaining_time():
-            return timeout - time.time() + start
-
     if not safe_kill(pid, signal.SIGSTOP):
-        return
+        return killed_pids
     for child in get_children_pids(pid):
-        kill_process_tree(int(child), sig, timeout=remaining_time())
+        killed_pids.extend(kill_process_tree(int(child), sig, False))
     safe_kill(pid, sig)
     if send_sigcont:
-        safe_kill(pid, signal.SIGCONT)
+        for pid in killed_pids:
+            safe_kill(pid, signal.SIGCONT)
     if timeout == 0:
-        return
+        return killed_pids
     elif timeout > 0:
-        if not wait_for(lambda: not pid_exists(pid), remaining_time(),
-                        step=0.01):
+        if not wait_for(_all_pids_dead, timeout + start - time.time(),
+                        step=0.01, args=(killed_pids[::-1],)):
             raise RuntimeError("Timeout reached when waiting for pid %s "
                                "and children to die (%s)" % (pid, timeout))
     else:
-        while pid_exists(pid):
+        while not _all_pids_dead(killed_pids[::-1]):
             time.sleep(0.01)
+    return killed_pids
 
 
 def kill_process_by_pattern(pattern):

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -209,6 +209,7 @@ def kill_process_tree(pid, sig=signal.SIGKILL, send_sigcont=True,
 
     :param pid: The pid of the process to signal.
     :param sig: The signal to send to the processes.
+    :param send_sigcont: Send SIGCONT to allow killing stopped processes
     :param timeout: How long to wait for the pid(s) to die
                     (negative=infinity, 0=don't wait,
                     positive=number_of_seconds)


### PR DESCRIPTION
Actually I already found out the https://github.com/avocado-framework/avocado/pull/2945 implementation is broken and can lead to zombie invasion...

v1: https://github.com/avocado-framework/avocado/pull/2954

Changes:

```yaml
v2: Add selftest for return value and check for it in existing tests
```