### PR TITLE
 Avoid zombie invasion [v3]

### DIFF
--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -209,6 +209,7 @@ def kill_process_tree(pid, sig=signal.SIGKILL, send_sigcont=True,
 
     :param pid: The pid of the process to signal.
     :param sig: The signal to send to the processes.
+    :param send_sigcont: Send SIGCONT to allow killing stopped processes
     :param timeout: How long to wait for the pid(s) to die
                     (negative=infinity, 0=don't wait,
                     positive=number_of_seconds)


### PR DESCRIPTION
Actually I already found out the https://github.com/avocado-framework/avocado/pull/2945 implementation is broken and can lead to zombie invasion...

v1: https://github.com/avocado-framework/avocado/pull/2954
v2: https://github.com/avocado-framework/avocado/pull/2956

Changes:

```yaml
v2: Add selftest for return value and check for it in existing tests
v3: Reorganized killed_pids list
v3: Improved docstring
```