### PR TITLE
Tags: prep work for the support of key:val

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -88,15 +88,19 @@ def filter_test_tags(test_suite, filter_by_tags, include_empty=False):
 
         for raw_tags in filter_by_tags:
             required_tags = raw_tags.split(',')
-            must_not_have_tags = set([_[1:] for _ in required_tags
-                                      if _.startswith('-')])
-            if must_not_have_tags.intersection(test_tags):
+            must = set()
+            must_not = set()
+            for tag in required_tags:
+                if tag.startswith('-'):
+                    must_not.add(tag[1:])
+                else:
+                    must.add(tag)
+
+            if must_not.intersection(test_tags):
                 continue
 
-            must_have_tags = set([_ for _ in required_tags
-                                  if not _.startswith('-')])
-            if must_have_tags:
-                if not must_have_tags.issubset(test_tags):
+            if must:
+                if not must.issubset(test_tags):
                     continue
 
             filtered.append((klass, info))

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -81,7 +81,7 @@ def filter_test_tags(test_suite, filter_by_tags, include_empty=False):
     """
     filtered = []
     for klass, info in test_suite:
-        test_tags = info.get('tags', set([]))
+        test_tags = info.get('tags', {})
         if not test_tags and include_empty:
             filtered.append((klass, info))
             continue

--- a/avocado/core/safeloader.py
+++ b/avocado/core/safeloader.py
@@ -167,15 +167,24 @@ def get_docstring_directives_tags(docstring):
     Returns the test categories based on a `:avocado: tags=category`
     docstring
 
-    :rtype: set
+    :rtype: dict
     """
-    tags = []
+    result = {}
     for item in get_docstring_directives(docstring):
         if item.startswith('tags='):
             _, comma_tags = item.split('tags=', 1)
-            tags.extend([tag for tag in comma_tags.split(',') if tag])
-
-    return set(tags)
+            for tag in comma_tags.split(','):
+                if not tag:
+                    continue
+                if ':' in tag:
+                    key, val = tag.split(':', 1)
+                    if key in result:
+                        result[key].add(val)
+                    else:
+                        result[key] = set([val])
+                else:
+                    result[tag] = None
+    return result
 
 
 def find_class_and_methods(path, method_pattern=None, base_class=None):

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -93,6 +93,13 @@ class SafeTest(Test):
     def test_safe(self):
         pass
 
+class SafeX86Test(Test):
+    '''
+    :avocado: tags=safe,arch:x86_64
+    '''
+    def test_safe_x86(self):
+        pass
+
 if __name__ == "__main__":
     main()
 """
@@ -437,7 +444,7 @@ class TagFilter(unittest.TestCase):
                                                    loader.DiscoverMode.ALL)
 
     def test_no_tag_filter(self):
-        self.assertEqual(len(self.test_suite), 5)
+        self.assertEqual(len(self.test_suite), 6)
         self.assertEqual(self.test_suite[0][0], 'FastTest')
         self.assertEqual(self.test_suite[0][1]['methodName'], 'test_fast')
         self.assertEqual(self.test_suite[1][0], 'FastTest')
@@ -486,7 +493,7 @@ class TagFilter(unittest.TestCase):
     def test_filter_not_fast_not_slow(self):
         filtered = loader.filter_test_tags(self.test_suite,
                                            ['-fast,-slow'])
-        self.assertEqual(len(filtered), 1)
+        self.assertEqual(len(filtered), 2)
         self.assertEqual(filtered[0][0], 'SafeTest')
         self.assertEqual(filtered[0][1]['methodName'], 'test_safe')
 
@@ -502,13 +509,15 @@ class TagFilter(unittest.TestCase):
         self.assertEqual(len(filtered), 0)
 
     def test_load_tags(self):
-        tags_map = {'FastTest.test_fast': set(['fast', 'net']),
-                    'FastTest.test_fast_other': set(['fast', 'net']),
-                    'SlowTest.test_slow': set(['slow', 'disk']),
-                    'SlowUnsafeTest.test_slow_unsafe': set(['slow',
-                                                            'disk',
-                                                            'unsafe']),
-                    'SafeTest.test_safe': set(['safe'])}
+        tags_map = {'FastTest.test_fast': {'fast': None, 'net': None},
+                    'FastTest.test_fast_other': {'fast': None, 'net': None},
+                    'SlowTest.test_slow': {'slow': None, 'disk': None},
+                    'SlowUnsafeTest.test_slow_unsafe': {'slow': None,
+                                                        'disk': None,
+                                                        'unsafe': None},
+                    'SafeTest.test_safe': {'safe': None},
+                    'SafeX86Test.test_safe_x86': {'safe': None,
+                                                  'arch': set(['x86_64'])}}
 
         for _, info in self.test_suite:
             name = info['name'].split(':', 1)[1]

--- a/selftests/unit/test_safeloader.py
+++ b/selftests/unit/test_safeloader.py
@@ -133,17 +133,6 @@ class DocstringDirectives(unittest.TestCase):
                ":avocado: tags=SLOW,disk, invalid",
                ":avocado: tags=SLOW,disk , invalid"]
 
-    VALID_TAGS = {":avocado: tags=fast": set(["fast"]),
-                  ":avocado: tags=fast,network": set(["fast", "network"]),
-                  ":avocado: tags=fast,,network": set(["fast", "network"]),
-                  ":avocado: tags=slow,DISK": set(["slow", "DISK"]),
-                  ":avocado: tags=SLOW,disk,disk": set(["SLOW", "disk"]),
-                  ":avocado:\ttags=FAST": set(["FAST"]),
-                  ":avocado: tags=": set([]),
-                  ":avocado: enable\n:avocado: tags=fast": set(["fast"]),
-                  ":avocado: tags=fast,slow\n:avocado: enable": set(["fast", "slow"])
-                  }
-
     def test_longline(self):
         docstring = ("This is a very long docstring in a single line. "
                      "Since we have nothing useful to put in here let's just "
@@ -175,9 +164,50 @@ class DocstringDirectives(unittest.TestCase):
         for tag in self.NO_TAGS:
             self.assertEqual(set([]), safeloader.get_docstring_directives_tags(tag))
 
-    def test_get_tags(self):
-        for raw, tags in self.VALID_TAGS.items():
-            self.assertEqual(safeloader.get_docstring_directives_tags(raw), tags)
+    def test_tag_single(self):
+        raw = ":avocado: tags=fast"
+        exp = set(["fast"])
+        self.assertEqual(safeloader.get_docstring_directives_tags(raw), exp)
+
+    def test_tag_double(self):
+        raw = ":avocado: tags=fast,network"
+        exp = set(["fast", "network"])
+        self.assertEqual(safeloader.get_docstring_directives_tags(raw), exp)
+
+    def test_tag_double_with_empty(self):
+        raw = ":avocado: tags=fast,,network"
+        exp = set(["fast", "network"])
+        self.assertEqual(safeloader.get_docstring_directives_tags(raw), exp)
+
+    def test_tag_lowercase_uppercase(self):
+        raw = ":avocado: tags=slow,DISK"
+        exp = set(["slow", "DISK"])
+        self.assertEqual(safeloader.get_docstring_directives_tags(raw), exp)
+
+    def test_tag_duplicate(self):
+        raw = ":avocado: tags=SLOW,disk,disk"
+        exp = set(["SLOW", "disk"])
+        self.assertEqual(safeloader.get_docstring_directives_tags(raw), exp)
+
+    def test_tag_tab_separator(self):
+        raw = ":avocado:\ttags=FAST"
+        exp = set(["FAST"])
+        self.assertEqual(safeloader.get_docstring_directives_tags(raw), exp)
+
+    def test_tag_empty(self):
+        raw = ":avocado: tags="
+        exp = set([])
+        self.assertEqual(safeloader.get_docstring_directives_tags(raw), exp)
+
+    def test_tag_newline_before(self):
+        raw = ":avocado: enable\n:avocado: tags=fast"
+        exp = set(["fast"])
+        self.assertEqual(safeloader.get_docstring_directives_tags(raw), exp)
+
+    def test_tag_newline_after(self):
+        raw = ":avocado: tags=fast,slow\n:avocado: enable"
+        exp = set(["fast", "slow"])
+        self.assertEqual(safeloader.get_docstring_directives_tags(raw), exp)
 
     def test_directives_regex(self):
         """
@@ -214,7 +244,15 @@ class FindClassAndMethods(UnlimitedDiff):
                                     'test_enabled',
                                     'test_disabled',
                                     'test_get_tags_empty',
-                                    'test_get_tags',
+                                    'test_tag_single',
+                                    'test_tag_double',
+                                    'test_tag_double_with_empty',
+                                    'test_tag_lowercase_uppercase',
+                                    'test_tag_duplicate',
+                                    'test_tag_tab_separator',
+                                    'test_tag_empty',
+                                    'test_tag_newline_before',
+                                    'test_tag_newline_after',
                                     'test_directives_regex'],
             'FindClassAndMethods': ['test_self',
                                     'test_with_pattern',
@@ -238,7 +276,15 @@ class FindClassAndMethods(UnlimitedDiff):
                                     'test_enabled',
                                     'test_disabled',
                                     'test_get_tags_empty',
-                                    'test_get_tags',
+                                    'test_tag_single',
+                                    'test_tag_double',
+                                    'test_tag_double_with_empty',
+                                    'test_tag_lowercase_uppercase',
+                                    'test_tag_duplicate',
+                                    'test_tag_tab_separator',
+                                    'test_tag_empty',
+                                    'test_tag_newline_before',
+                                    'test_tag_newline_after',
                                     'test_directives_regex'],
             'FindClassAndMethods': ['test_self',
                                     'test_with_pattern',

--- a/selftests/unit/test_safeloader.py
+++ b/selftests/unit/test_safeloader.py
@@ -162,51 +162,66 @@ class DocstringDirectives(unittest.TestCase):
 
     def test_get_tags_empty(self):
         for tag in self.NO_TAGS:
-            self.assertEqual(set([]), safeloader.get_docstring_directives_tags(tag))
+            self.assertEqual({}, safeloader.get_docstring_directives_tags(tag))
 
     def test_tag_single(self):
         raw = ":avocado: tags=fast"
-        exp = set(["fast"])
+        exp = {"fast": None}
         self.assertEqual(safeloader.get_docstring_directives_tags(raw), exp)
 
     def test_tag_double(self):
         raw = ":avocado: tags=fast,network"
-        exp = set(["fast", "network"])
+        exp = {"fast": None, "network": None}
         self.assertEqual(safeloader.get_docstring_directives_tags(raw), exp)
 
     def test_tag_double_with_empty(self):
         raw = ":avocado: tags=fast,,network"
-        exp = set(["fast", "network"])
+        exp = {"fast": None, "network": None}
         self.assertEqual(safeloader.get_docstring_directives_tags(raw), exp)
 
     def test_tag_lowercase_uppercase(self):
         raw = ":avocado: tags=slow,DISK"
-        exp = set(["slow", "DISK"])
+        exp = {"slow": None, "DISK": None}
         self.assertEqual(safeloader.get_docstring_directives_tags(raw), exp)
 
     def test_tag_duplicate(self):
         raw = ":avocado: tags=SLOW,disk,disk"
-        exp = set(["SLOW", "disk"])
+        exp = {"SLOW": None, "disk": None}
         self.assertEqual(safeloader.get_docstring_directives_tags(raw), exp)
 
     def test_tag_tab_separator(self):
         raw = ":avocado:\ttags=FAST"
-        exp = set(["FAST"])
+        exp = {"FAST": None}
         self.assertEqual(safeloader.get_docstring_directives_tags(raw), exp)
 
     def test_tag_empty(self):
         raw = ":avocado: tags="
-        exp = set([])
+        exp = {}
         self.assertEqual(safeloader.get_docstring_directives_tags(raw), exp)
 
     def test_tag_newline_before(self):
         raw = ":avocado: enable\n:avocado: tags=fast"
-        exp = set(["fast"])
+        exp = {"fast": None}
         self.assertEqual(safeloader.get_docstring_directives_tags(raw), exp)
 
     def test_tag_newline_after(self):
         raw = ":avocado: tags=fast,slow\n:avocado: enable"
-        exp = set(["fast", "slow"])
+        exp = {"fast": None, "slow": None}
+        self.assertEqual(safeloader.get_docstring_directives_tags(raw), exp)
+
+    def test_tag_keyval_single(self):
+        raw = ":avocado: tags=fast,arch:x86_64"
+        exp = {"fast": None, "arch": set(["x86_64"])}
+        self.assertEqual(safeloader.get_docstring_directives_tags(raw), exp)
+
+    def test_tag_keyval_double(self):
+        raw = ":avocado: tags=fast,arch:x86_64,arch:ppc64"
+        exp = {"fast": None, "arch": set(["x86_64", "ppc64"])}
+        self.assertEqual(safeloader.get_docstring_directives_tags(raw), exp)
+
+    def test_tag_keyval_duplicate(self):
+        raw = ":avocado: tags=fast,arch:x86_64,arch:ppc64,arch:x86_64"
+        exp = {"fast": None, "arch": set(["x86_64", "ppc64"])}
         self.assertEqual(safeloader.get_docstring_directives_tags(raw), exp)
 
     def test_directives_regex(self):
@@ -253,6 +268,9 @@ class FindClassAndMethods(UnlimitedDiff):
                                     'test_tag_empty',
                                     'test_tag_newline_before',
                                     'test_tag_newline_after',
+                                    'test_tag_keyval_single',
+                                    'test_tag_keyval_double',
+                                    'test_tag_keyval_duplicate',
                                     'test_directives_regex'],
             'FindClassAndMethods': ['test_self',
                                     'test_with_pattern',
@@ -285,6 +303,9 @@ class FindClassAndMethods(UnlimitedDiff):
                                     'test_tag_empty',
                                     'test_tag_newline_before',
                                     'test_tag_newline_after',
+                                    'test_tag_keyval_single',
+                                    'test_tag_keyval_double',
+                                    'test_tag_keyval_duplicate',
                                     'test_directives_regex'],
             'FindClassAndMethods': ['test_self',
                                     'test_with_pattern',
@@ -345,10 +366,10 @@ class FindClassAndMethods(UnlimitedDiff):
 
         sys.path.append(os.path.dirname(avocado_recursive_discovery_test1.path))
         tests = safeloader.find_avocado_tests(avocado_recursive_discovery_test2.path)[0]
-        expected = {'ThirdChild': [('test_third_child', set([])),
-                                   ('test_second_child', set([])),
-                                   ('test_first_child', set([])),
-                                   ('test_basic', set([]))]}
+        expected = {'ThirdChild': [('test_third_child', {}),
+                                   ('test_second_child', {}),
+                                   ('test_first_child', {}),
+                                   ('test_basic', {})]}
         self.assertEqual(expected, tests)
 
 


### PR DESCRIPTION
A use case that has appeared is to give more meaning to tags, for instance, to tag a test as being capable of running (or requiring) a given CPU architecture.  Right now, only "flat" tags, with common meaning are possible.

This includes a change of the internal format used to keep track of tags, so that it will be possible to add different values to a tag with the same key.  This would be valid for a test that say, can work on both `x86_64` and `ppc64`, so those values would live under a `arch` key.

The user facing behavior at this point should not have been changed by this.