### PR TITLE
utils.disk: adds utility functions for filesystem types [v2]

### DIFF
--- a/avocado/utils/disk.py
+++ b/avocado/utils/disk.py
@@ -24,6 +24,7 @@ Disk utilities
 
 import os
 import json
+import re
 
 from . import process
 
@@ -55,3 +56,13 @@ def get_disks():
     json_result = process.run('lsblk --json')
     json_data = json.loads(json_result.stdout_text)
     return ['/dev/%s' % str(disk['name']) for disk in json_data['blockdevices']]
+
+
+def get_filesystems():
+    """
+    Return a list of all available filesystems
+
+    :returns: a list of filesystem string
+    :rtype: list of str
+    """
+    return [re.sub('(nodev)?\s*', '', fs) for fs in open('/proc/filesystems')]

--- a/avocado/utils/disk.py
+++ b/avocado/utils/disk.py
@@ -58,21 +58,32 @@ def get_disks():
     return ['/dev/%s' % str(disk['name']) for disk in json_data['blockdevices']]
 
 
-def get_filesystems():
+def get_available_filesystems():
     """
-    Return a list of all available filesystems
+    Return a list of all available filesystem types
 
-    :returns: a list of filesystem string
+    :returns: a list of filesystem types
     :rtype: list of str
     """
-    return [re.sub('(nodev)?\\s*', '', fs) for fs in open('/proc/filesystems')]
+    filesystems = set()
+    with open('/proc/filesystems') as proc_fs:
+        for proc_fs_line in proc_fs.readlines():
+            filesystems.add(re.sub(r'(nodev)?\s*', '', proc_fs_line))
+    return list(filesystems)
 
 
-def get_rootfilesystem():
+def get_filesystem_type(mount_point='/'):
     """
-    Return a root  filesystem
+    Returns the type of the filesystem of mount point informed.
+    The default mount point considered when none is informed
+    is the root "/" mount point.
 
-    :returns: file system string
+    :param str mount_point: mount point to asses the filesystem type, default "/"
+    :returns: filesystem type
     :rtype: str
     """
-    return process.system_output('findmnt / -o FSTYPE -n')
+    with open('/proc/mounts') as mounts:
+        for mount_line in mounts.readlines():
+            _, fs_file, fs_vfstype, _, _, _ = mount_line.split()
+            if fs_file == mount_point:
+                return fs_vfstype

--- a/avocado/utils/disk.py
+++ b/avocado/utils/disk.py
@@ -65,4 +65,14 @@ def get_filesystems():
     :returns: a list of filesystem string
     :rtype: list of str
     """
-    return [re.sub('(nodev)?\s*', '', fs) for fs in open('/proc/filesystems')]
+    return [re.sub('(nodev)?\\s*', '', fs) for fs in open('/proc/filesystems')]
+
+
+def get_rootfilesystem():
+    """
+    Return a root  filesystem
+
+    :returns: file system string
+    :rtype: str
+    """
+    return process.system_output('findmnt / -o FSTYPE -n')

--- a/selftests/unit/test_utils_disk.py
+++ b/selftests/unit/test_utils_disk.py
@@ -10,9 +10,7 @@ from avocado.utils import disk
 from avocado.utils import process
 
 
-class Disk(unittest.TestCase):
-
-    LSBLK_OUTPUT = b'''
+LSBLK_OUTPUT = b'''
 {
    "blockdevices": [
       {"name": "vda", "maj:min": "252:0", "rm": "0", "size": "6G", "ro": "0", "type": "disk", "mountpoint": null,
@@ -26,6 +24,26 @@ class Disk(unittest.TestCase):
    ]
 }'''
 
+
+PROC_FILESYSTEMS = (
+    'nodev   dax\n' +
+    'nodev   bpf\n' +
+    'nodev   pipefs\n' +
+    'nodev   hugetlbfs\n' +
+    'nodev   devpts\n' +
+    '        ext3'
+)
+
+PROC_MOUNTS = (
+    "/dev/mapper/fedora-root / ext4 rw,seclabel,relatime 0 0\n" +
+    "/dev/mapper/fedora-home /home ext2 rw,seclabel,relatime 0 0\n" +
+    "sysfs /sys sysfs rw,seclabel,nosuid,nodev,noexec,relatime 0 0\n" +
+    "proc /proc proc rw,nosuid,nodev,noexec,relatime 0 0"
+)
+
+
+class Disk(unittest.TestCase):
+
     def test_empty(self):
         mock_result = process.CmdResult(
             command='lsblk --json',
@@ -37,10 +55,27 @@ class Disk(unittest.TestCase):
     def test_disks(self):
         mock_result = process.CmdResult(
             command='lsblk --json',
-            stdout=self.LSBLK_OUTPUT)
+            stdout=LSBLK_OUTPUT)
         with mock.patch('avocado.utils.disk.process.run',
                         return_value=mock_result):
             self.assertEqual(disk.get_disks(), ['/dev/vda'])
+
+    def test_get_filesystems(self):
+        expected_fs = ['dax', 'bpf', 'pipefs', 'hugetlbfs', 'devpts', 'ext3']
+        open_mocked = mock.mock_open(read_data=PROC_FILESYSTEMS)
+        with mock.patch('avocado.utils.disk.open', open_mocked):
+            self.assertEqual(sorted(expected_fs),
+                             sorted(disk.get_available_filesystems()))
+
+    def test_get_filesystem_type_default_root(self):
+        open_mocked = mock.mock_open(read_data=PROC_MOUNTS)
+        with mock.patch('avocado.utils.disk.open', open_mocked):
+            self.assertEqual('ext4', disk.get_filesystem_type())
+
+    def test_get_filesystem_type(self):
+        open_mocked = mock.mock_open(read_data=PROC_MOUNTS)
+        with mock.patch('avocado.utils.disk.open', open_mocked):
+            self.assertEqual('ext2', disk.get_filesystem_type(mount_point='/home'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adds utility which return all supported filesystem on running kernel
and also other utility function to return filesystem from a given mount point.

The use cases can be found in the test file added.

This work started with Praveen contribution (#2865) and I've just
continued with some refactorings and test inclusions.

---
Changes from v1 (#2962)
* squashed my changes
* ~try~ fix lint errors