### PR TITLE
utils.disk: Adds utility functions related to filesystems [v3]

### DIFF
--- a/selftests/unit/test_utils_disk.py
+++ b/selftests/unit/test_utils_disk.py
@@ -10,9 +10,7 @@ from avocado.utils import disk
 from avocado.utils import process
 
 
-class Disk(unittest.TestCase):
-
-    LSBLK_OUTPUT = b'''
+LSBLK_OUTPUT = b'''
 {
    "blockdevices": [
       {"name": "vda", "maj:min": "252:0", "rm": "0", "size": "6G", "ro": "0", "type": "disk", "mountpoint": null,
@@ -26,6 +24,26 @@ class Disk(unittest.TestCase):
    ]
 }'''
 
+
+PROC_FILESYSTEMS = (
+    'nodev   dax\n' +
+    'nodev   bpf\n' +
+    'nodev   pipefs\n' +
+    'nodev   hugetlbfs\n' +
+    'nodev   devpts\n' +
+    '        ext3'
+)
+
+PROC_MOUNTS = (
+    "/dev/mapper/fedora-root / ext4 rw,seclabel,relatime 0 0\n" +
+    "/dev/mapper/fedora-home /home ext2 rw,seclabel,relatime 0 0\n" +
+    "sysfs /sys sysfs rw,seclabel,nosuid,nodev,noexec,relatime 0 0\n" +
+    "proc /proc proc rw,nosuid,nodev,noexec,relatime 0 0"
+)
+
+
+class Disk(unittest.TestCase):
+
     def test_empty(self):
         mock_result = process.CmdResult(
             command='lsblk --json',
@@ -37,10 +55,27 @@ class Disk(unittest.TestCase):
     def test_disks(self):
         mock_result = process.CmdResult(
             command='lsblk --json',
-            stdout=self.LSBLK_OUTPUT)
+            stdout=LSBLK_OUTPUT)
         with mock.patch('avocado.utils.disk.process.run',
                         return_value=mock_result):
             self.assertEqual(disk.get_disks(), ['/dev/vda'])
+
+    def test_get_filesystems(self):
+        expected_fs = ['dax', 'bpf', 'pipefs', 'hugetlbfs', 'devpts', 'ext3']
+        open_mocked = mock.mock_open(read_data=PROC_FILESYSTEMS)
+        with mock.patch('avocado.utils.disk.open', open_mocked):
+            self.assertEqual(sorted(expected_fs),
+                             sorted(disk.get_available_filesystems()))
+
+    def test_get_filesystem_type_default_root(self):
+        open_mocked = mock.mock_open(read_data=PROC_MOUNTS)
+        with mock.patch('avocado.utils.disk.open', open_mocked):
+            self.assertEqual('ext4', disk.get_filesystem_type())
+
+    def test_get_filesystem_type(self):
+        open_mocked = mock.mock_open(read_data=PROC_MOUNTS)
+        with mock.patch('avocado.utils.disk.open', open_mocked):
+            self.assertEqual('ext2', disk.get_filesystem_type(mount_point='/home'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This change introduces two new utility functions related with
filesystems. One function returns all filesystem types supported by the
running kernel and the other returns the filesystem type of a given
mount point.

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>
Signed-off-by: Caio Carrara <ccarrara@redhat.com>

--
Changes from v2 (#2967)
* squashed all changes in only one commit because of lint error in previous commits

Changes from v1 (#2962)
* squashed my changes
 * try fix lint errors
