### PR TITLE
Tags: more prep work for the support of key:val

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -82,8 +82,9 @@ def filter_test_tags(test_suite, filter_by_tags, include_empty=False):
     filtered = []
     for klass, info in test_suite:
         test_tags = info.get('tags', {})
-        if not test_tags and include_empty:
-            filtered.append((klass, info))
+        if not test_tags:
+            if include_empty:
+                filtered.append((klass, info))
             continue
 
         for raw_tags in filter_by_tags:

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -63,6 +63,33 @@ class MissingTest(object):
     """
 
 
+def parse_filter_by_tags(filter_by_tags):
+    """
+    Parses the various filter by tags in "command line" format
+
+    The filtering of tests usually happens my means of "--filter-by-tags"
+    command line options, and many can be given.  This parses the contents
+    of those into a list of must/must_not pairs, which can be used directly
+    for comparisons when filtering.
+
+    :param filter_by_tags: params in the format given to "-t/--filter-by-tags"
+    :type filter_by_tags: list of str
+    :returns: list of tuples with (set, set)
+    """
+    result = []
+    for raw_tags in filter_by_tags:
+        required_tags = raw_tags.split(',')
+        must = set()
+        must_not = set()
+        for tag in required_tags:
+            if tag.startswith('-'):
+                must_not.add(tag[1:])
+            else:
+                must.add(tag)
+        result.append((must, must_not))
+    return result
+
+
 def filter_test_tags(test_suite, filter_by_tags, include_empty=False):
     """
     Filter the existing (unfiltered) test suite based on tags
@@ -80,6 +107,8 @@ def filter_test_tags(test_suite, filter_by_tags, include_empty=False):
     :type include_empty: bool
     """
     filtered = []
+    must_must_nots = parse_filter_by_tags(filter_by_tags)
+
     for klass, info in test_suite:
         test_tags = info.get('tags', {})
         if not test_tags:
@@ -87,16 +116,7 @@ def filter_test_tags(test_suite, filter_by_tags, include_empty=False):
                 filtered.append((klass, info))
             continue
 
-        for raw_tags in filter_by_tags:
-            required_tags = raw_tags.split(',')
-            must = set()
-            must_not = set()
-            for tag in required_tags:
-                if tag.startswith('-'):
-                    must_not.add(tag[1:])
-                else:
-                    must.add(tag)
-
+        for must, must_not in must_must_nots:
             if must_not.intersection(test_tags):
                 continue
 

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -482,6 +482,20 @@ class TagFilter(unittest.TestCase):
         self.assertEqual(filtered[2][0], 'NoTagsTest')
         self.assertEqual(filtered[2][1]['methodName'], 'test_no_tags')
 
+    def test_filter_arch(self):
+        filtered = loader.filter_test_tags(self.test_suite, ['arch'], False)
+        self.assertEqual(len(filtered), 1)
+        self.assertEqual(filtered[0][0], 'SafeX86Test')
+        self.assertEqual(filtered[0][1]['methodName'], 'test_safe_x86')
+
+    def test_filter_arch_include_empty(self):
+        filtered = loader.filter_test_tags(self.test_suite, ['arch'], True)
+        self.assertEqual(len(filtered), 2)
+        self.assertEqual(filtered[0][0], 'SafeX86Test')
+        self.assertEqual(filtered[0][1]['methodName'], 'test_safe_x86')
+        self.assertEqual(filtered[1][0], 'NoTagsTest')
+        self.assertEqual(filtered[1][1]['methodName'], 'test_no_tags')
+
     def test_filter_fast_net__slow_disk_unsafe(self):
         filtered = loader.filter_test_tags(self.test_suite,
                                            ['fast,net',

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -100,6 +100,10 @@ class SafeX86Test(Test):
     def test_safe_x86(self):
         pass
 
+class NoTagsTest(Test):
+    def test_no_tags(self):
+        pass
+
 if __name__ == "__main__":
     main()
 """
@@ -444,7 +448,7 @@ class TagFilter(unittest.TestCase):
                                                    loader.DiscoverMode.ALL)
 
     def test_no_tag_filter(self):
-        self.assertEqual(len(self.test_suite), 6)
+        self.assertEqual(len(self.test_suite), 7)
         self.assertEqual(self.test_suite[0][0], 'FastTest')
         self.assertEqual(self.test_suite[0][1]['methodName'], 'test_fast')
         self.assertEqual(self.test_suite[1][0], 'FastTest')
@@ -457,19 +461,32 @@ class TagFilter(unittest.TestCase):
         self.assertEqual(self.test_suite[4][1]['methodName'], 'test_safe')
         self.assertEqual(self.test_suite[5][0], 'SafeX86Test')
         self.assertEqual(self.test_suite[5][1]['methodName'], 'test_safe_x86')
+        self.assertEqual(self.test_suite[6][0], 'NoTagsTest')
+        self.assertEqual(self.test_suite[6][1]['methodName'], 'test_no_tags')
 
     def test_filter_fast_net(self):
-        filtered = loader.filter_test_tags(self.test_suite, ['fast,net'])
+        filtered = loader.filter_test_tags(self.test_suite, ['fast,net'], False)
         self.assertEqual(len(filtered), 2)
         self.assertEqual(filtered[0][0], 'FastTest')
         self.assertEqual(filtered[0][1]['methodName'], 'test_fast')
         self.assertEqual(filtered[1][0], 'FastTest')
         self.assertEqual(filtered[1][1]['methodName'], 'test_fast_other')
 
+    def test_filter_fast_net_include_empty(self):
+        filtered = loader.filter_test_tags(self.test_suite, ['fast,net'], True)
+        self.assertEqual(len(filtered), 3)
+        self.assertEqual(filtered[0][0], 'FastTest')
+        self.assertEqual(filtered[0][1]['methodName'], 'test_fast')
+        self.assertEqual(filtered[1][0], 'FastTest')
+        self.assertEqual(filtered[1][1]['methodName'], 'test_fast_other')
+        self.assertEqual(filtered[2][0], 'NoTagsTest')
+        self.assertEqual(filtered[2][1]['methodName'], 'test_no_tags')
+
     def test_filter_fast_net__slow_disk_unsafe(self):
         filtered = loader.filter_test_tags(self.test_suite,
                                            ['fast,net',
-                                            'slow,disk,unsafe'])
+                                            'slow,disk,unsafe'],
+                                           False)
         self.assertEqual(len(filtered), 3)
         self.assertEqual(filtered[0][0], 'FastTest')
         self.assertEqual(filtered[0][1]['methodName'], 'test_fast')
@@ -481,7 +498,8 @@ class TagFilter(unittest.TestCase):
     def test_filter_fast_net__slow_disk(self):
         filtered = loader.filter_test_tags(self.test_suite,
                                            ['fast,net',
-                                            'slow,disk'])
+                                            'slow,disk'],
+                                           False)
         self.assertEqual(len(filtered), 4)
         self.assertEqual(filtered[0][0], 'FastTest')
         self.assertEqual(filtered[0][1]['methodName'], 'test_fast')
@@ -494,34 +512,52 @@ class TagFilter(unittest.TestCase):
 
     def test_filter_not_fast_not_slow(self):
         filtered = loader.filter_test_tags(self.test_suite,
-                                           ['-fast,-slow'])
+                                           ['-fast,-slow'],
+                                           False)
         self.assertEqual(len(filtered), 2)
         self.assertEqual(filtered[0][0], 'SafeTest')
         self.assertEqual(filtered[0][1]['methodName'], 'test_safe')
         self.assertEqual(filtered[1][0], 'SafeX86Test')
         self.assertEqual(filtered[1][1]['methodName'], 'test_safe_x86')
 
+    def test_filter_not_fast_not_slow_include_empty(self):
+        filtered = loader.filter_test_tags(self.test_suite,
+                                           ['-fast,-slow'],
+                                           True)
+        self.assertEqual(len(filtered), 3)
+        self.assertEqual(filtered[0][0], 'SafeTest')
+        self.assertEqual(filtered[0][1]['methodName'], 'test_safe')
+        self.assertEqual(filtered[1][0], 'SafeX86Test')
+        self.assertEqual(filtered[1][1]['methodName'], 'test_safe_x86')
+        self.assertEqual(filtered[2][0], 'NoTagsTest')
+        self.assertEqual(filtered[2][1]['methodName'], 'test_no_tags')
+
     def test_filter_not_fast_not_slow_not_safe(self):
         filtered = loader.filter_test_tags(self.test_suite,
-                                           ['-fast,-slow,-safe'])
+                                           ['-fast,-slow,-safe'],
+                                           False)
         self.assertEqual(len(filtered), 0)
 
     def test_filter_not_fast_not_slow_not_safe_others_dont_exist(self):
         filtered = loader.filter_test_tags(self.test_suite,
                                            ['-fast,-slow,-safe',
-                                            'does,not,exist'])
+                                            'does,not,exist'],
+                                           False)
         self.assertEqual(len(filtered), 0)
 
     def test_load_tags(self):
-        tags_map = {'FastTest.test_fast': {'fast': None, 'net': None},
-                    'FastTest.test_fast_other': {'fast': None, 'net': None},
-                    'SlowTest.test_slow': {'slow': None, 'disk': None},
-                    'SlowUnsafeTest.test_slow_unsafe': {'slow': None,
-                                                        'disk': None,
-                                                        'unsafe': None},
-                    'SafeTest.test_safe': {'safe': None},
-                    'SafeX86Test.test_safe_x86': {'safe': None,
-                                                  'arch': set(['x86_64'])}}
+        tags_map = {
+            'FastTest.test_fast': {'fast': None, 'net': None},
+            'FastTest.test_fast_other': {'fast': None, 'net': None},
+            'SlowTest.test_slow': {'slow': None, 'disk': None},
+            'SlowUnsafeTest.test_slow_unsafe': {'slow': None,
+                                                'disk': None,
+                                                'unsafe': None},
+            'SafeTest.test_safe': {'safe': None},
+            'SafeX86Test.test_safe_x86': {'safe': None,
+                                          'arch': set(['x86_64'])},
+            'NoTagsTest.test_no_tags': {}
+        }
 
         for _, info in self.test_suite:
             name = info['name'].split(':', 1)[1]
@@ -540,7 +576,7 @@ class TagFilter2(unittest.TestCase):
             this_loader = loader.FileLoader(None, {})
             test_suite = this_loader.discover(test_script.path,
                                               loader.DiscoverMode.ALL)
-            self.assertEqual([], loader.filter_test_tags(test_suite, []))
+            self.assertEqual([], loader.filter_test_tags(test_suite, [], False))
             self.assertEqual(test_suite,
                              loader.filter_test_tags(test_suite, [], True))
 

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -595,5 +595,22 @@ class TagFilter2(unittest.TestCase):
                          loader.filter_test_tags(test_suite, [], True))
 
 
+class ParseFilterByTags(unittest.TestCase):
+
+    def test_must(self):
+        self.assertEqual(loader.parse_filter_by_tags(['foo,bar,baz']),
+                         [(set(['foo', 'bar', 'baz']), set([]))])
+
+    def test_must_must_not(self):
+        self.assertEqual(loader.parse_filter_by_tags(['foo,-bar,baz']),
+                         [(set(['foo', 'baz']), set(['bar']))])
+
+    def test_musts_must_nots(self):
+        self.assertEqual(loader.parse_filter_by_tags(['foo,bar,baz',
+                                                      '-FOO,-BAR,-BAZ']),
+                         [(set(['foo', 'bar', 'baz']), set([])),
+                          (set([]), set(['FOO', 'BAR', 'BAZ']))])
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -455,6 +455,8 @@ class TagFilter(unittest.TestCase):
         self.assertEqual(self.test_suite[3][1]['methodName'], 'test_slow_unsafe')
         self.assertEqual(self.test_suite[4][0], 'SafeTest')
         self.assertEqual(self.test_suite[4][1]['methodName'], 'test_safe')
+        self.assertEqual(self.test_suite[5][0], 'SafeX86Test')
+        self.assertEqual(self.test_suite[5][1]['methodName'], 'test_safe_x86')
 
     def test_filter_fast_net(self):
         filtered = loader.filter_test_tags(self.test_suite, ['fast,net'])
@@ -496,6 +498,8 @@ class TagFilter(unittest.TestCase):
         self.assertEqual(len(filtered), 2)
         self.assertEqual(filtered[0][0], 'SafeTest')
         self.assertEqual(filtered[0][1]['methodName'], 'test_safe')
+        self.assertEqual(filtered[1][0], 'SafeX86Test')
+        self.assertEqual(filtered[1][1]['methodName'], 'test_safe_x86')
 
     def test_filter_not_fast_not_slow_not_safe(self):
         filtered = loader.filter_test_tags(self.test_suite,

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -576,9 +576,9 @@ class TagFilter2(unittest.TestCase):
             this_loader = loader.FileLoader(None, {})
             test_suite = this_loader.discover(test_script.path,
                                               loader.DiscoverMode.ALL)
-            self.assertEqual([], loader.filter_test_tags(test_suite, [], False))
-            self.assertEqual(test_suite,
-                             loader.filter_test_tags(test_suite, [], True))
+        self.assertEqual([], loader.filter_test_tags(test_suite, [], False))
+        self.assertEqual(test_suite,
+                         loader.filter_test_tags(test_suite, [], True))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Just like #2965, this contains a number of new tests and refactors in preparation for the support of key:val tags.

The description on #2965 also applies here:

---

A use case that has appeared is to give more meaning to tags, for instance, to tag a test as being capable of running (or requiring) a given CPU architecture. Right now, only "flat" tags, with common meaning are possible.

This includes a change of the internal format used to keep track of tags, so that it will be possible to add different values to a tag with the same key. This would be valid for a test that say, can work on both x86_64 and ppc64, so those values would live under a arch key.

The user facing behavior at this point should not have been changed by this.

---