### PR TITLE
Tags: make tags available to tests as a property

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -386,10 +386,6 @@ class TestLoaderProxy(object):
         :return: an instance of :class:`avocado.core.test.Test`.
         """
         test_class, test_parameters = test_factory
-        # discard tags, as they are *not* intended to be parameters
-        # for the test, but used previously during filtering
-        if 'tags' in test_parameters:
-            del(test_parameters['tags'])
         if 'modulePath' in test_parameters:
             test_path = test_parameters.pop('modulePath')
         else:

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -320,7 +320,7 @@ class Test(unittest.TestCase, TestData):
     timeout = None
 
     def __init__(self, methodName='test', name=None, params=None,
-                 base_logdir=None, job=None, runner_queue=None):
+                 base_logdir=None, job=None, runner_queue=None, tags=None):
         """
         Initializes the test.
 
@@ -349,6 +349,7 @@ class Test(unittest.TestCase, TestData):
             self.__name = TestID(0, self.__class__.__name__)
 
         self.__job = job
+        self.__tags = tags
 
         if base_logdir is None:
             base_logdir = data_dir.create_job_logs_dir()
@@ -442,6 +443,13 @@ class Test(unittest.TestCase, TestData):
         The job this test is associated with
         """
         return self.__job
+
+    @property
+    def tags(self):
+        """
+        The tags associated with this test
+        """
+        return self.__tags
 
     @property
     def log(self):


### PR DESCRIPTION
On some situations, the same information may be given on tags that can
be reused during test runtime.  Let's create a property to allow a
test to read them.

Signed-off-by: Cleber Rosa <crosa@redhat.com>