### PR TITLE
HTML Plugin: update the new data directory name

### DIFF
--- a/optional_plugins/html/MANIFEST.in
+++ b/optional_plugins/html/MANIFEST.in
@@ -1,2 +1,2 @@
-recursive-include avocado_result_html/resources *
+recursive-include avocado_result_html/templates *
 include VERSION


### PR DESCRIPTION
Without this, the data files associated with the avocado_result_html
module won't be installed.

Signed-off-by: Cleber Rosa <crosa@redhat.com>