### PR TITLE
selftests: Setup avocado logging streams in unit tests

### DIFF
--- a/selftests/__init__.py
+++ b/selftests/__init__.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import pkg_resources
 import sys
@@ -50,6 +51,21 @@ def python_module_available(module_name):
         return True
     except pkg_resources.DistributionNotFound:
         return False
+
+
+def setup_avocado_loggers():
+    """
+    Setup avocado loggers to contain at least one logger
+
+    This is required for tests that directly utilize avocado.Test classes
+    because they require those loggers to be configured. Without this
+    it might (py2) result in infinite recursion while attempting to log
+    "No handlers could be found for logger ..." message.
+    """
+    for name in ('', 'avocado.test', 'avocado.app'):
+        logger = logging.getLogger(name)
+        if not logger.handlers:
+            logger.handlers.append(logging.NullHandler())
 
 
 #: The plugin module names and directories under optional_plugins

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -16,6 +16,11 @@ from avocado.core import job
 from avocado.core import test
 from avocado.utils import path as utils_path
 
+from .. import setup_avocado_loggers
+
+
+setup_avocado_loggers()
+
 
 class JobTest(unittest.TestCase):
 

--- a/selftests/unit/test_jobdata.py
+++ b/selftests/unit/test_jobdata.py
@@ -6,6 +6,10 @@ from six import PY3
 from avocado.core import jobdata
 
 from .. import BASEDIR
+from .. import setup_avocado_loggers
+
+
+setup_avocado_loggers()
 
 
 class JobdataTest(unittest.TestCase):

--- a/selftests/unit/test_jsonresult.py
+++ b/selftests/unit/test_jsonresult.py
@@ -10,6 +10,11 @@ from avocado.core import job
 from avocado.core.result import Result
 from avocado.plugins import jsonresult
 
+from .. import setup_avocado_loggers
+
+
+setup_avocado_loggers()
+
 
 class FakeJob(object):
 

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -8,6 +8,12 @@ from avocado.core import test
 from avocado.core import loader
 from avocado.utils import script
 
+from .. import setup_avocado_loggers
+
+
+setup_avocado_loggers()
+
+
 #: What is commonly known as "0664" or "u=rw,g=rw,o=r"
 DEFAULT_NON_EXEC_MODE = (stat.S_IRUSR | stat.S_IWUSR |
                          stat.S_IRGRP | stat.S_IWGRP |

--- a/selftests/unit/test_replay.py
+++ b/selftests/unit/test_replay.py
@@ -6,6 +6,11 @@ import unittest
 from avocado.core import test
 from avocado.plugins import replay
 
+from .. import setup_avocado_loggers
+
+
+setup_avocado_loggers()
+
 
 class Replay(unittest.TestCase):
 

--- a/selftests/unit/test_runner_queue.py
+++ b/selftests/unit/test_runner_queue.py
@@ -11,6 +11,11 @@ from avocado.core.result import Result
 from avocado.core.runner import TestRunner
 from avocado.core.tree import TreeNode
 
+from .. import setup_avocado_loggers
+
+
+setup_avocado_loggers()
+
 
 class TestRunnerQueue(unittest.TestCase):
     """

--- a/selftests/unit/test_safeloader.py
+++ b/selftests/unit/test_safeloader.py
@@ -7,6 +7,11 @@ import unittest
 from avocado.core import safeloader
 from avocado.utils import script
 
+from .. import setup_avocado_loggers
+
+
+setup_avocado_loggers()
+
 
 KEEP_METHODS_ORDER = '''
 from avocado import Test

--- a/selftests/unit/test_test.py
+++ b/selftests/unit/test_test.py
@@ -10,6 +10,12 @@ except ImportError:
 from avocado.core import test, exceptions
 from avocado.utils import astring, script
 
+from .. import setup_avocado_loggers
+
+
+setup_avocado_loggers()
+
+
 PASS_SCRIPT_CONTENTS = """#!/bin/sh
 true
 """

--- a/selftests/unit/test_utils_asset.py
+++ b/selftests/unit/test_utils_asset.py
@@ -6,6 +6,11 @@ import unittest
 from avocado.utils import asset
 from avocado.utils.filelock import FileLock
 
+from .. import setup_avocado_loggers
+
+
+setup_avocado_loggers()
+
 
 class TestAsset(unittest.TestCase):
 

--- a/selftests/unit/test_utils_cloudinit.py
+++ b/selftests/unit/test_utils_cloudinit.py
@@ -15,6 +15,11 @@ from avocado.utils import iso9660
 from avocado.utils import network
 from avocado.utils import data_factory
 
+from .. import setup_avocado_loggers
+
+
+setup_avocado_loggers()
+
 
 def has_iso_create_write():
     return iso9660.iso9660(os.devnull, ["create", "write"]) is not None

--- a/selftests/unit/test_utils_genio.py
+++ b/selftests/unit/test_utils_genio.py
@@ -4,6 +4,11 @@ import unittest
 
 from avocado.utils import genio
 
+from .. import setup_avocado_loggers
+
+
+setup_avocado_loggers()
+
 
 class TestGenio(unittest.TestCase):
     def test_check_pattern_in_directory(self):

--- a/selftests/unit/test_utils_iso9660.py
+++ b/selftests/unit/test_utils_iso9660.py
@@ -14,6 +14,11 @@ except ImportError:
 
 from avocado.utils import iso9660, process
 
+from .. import setup_avocado_loggers
+
+
+setup_avocado_loggers()
+
 
 class Capabilities(unittest.TestCase):
 

--- a/selftests/unit/test_utils_kernel.py
+++ b/selftests/unit/test_utils_kernel.py
@@ -2,6 +2,11 @@ import unittest
 
 from avocado.utils.kernel import KernelBuild
 
+from .. import setup_avocado_loggers
+
+
+setup_avocado_loggers()
+
 
 class TestKernelBuild(unittest.TestCase):
     def setUp(self):

--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -19,6 +19,11 @@ from avocado.utils import path
 
 from six import string_types, PY2
 
+from .. import setup_avocado_loggers
+
+
+setup_avocado_loggers()
+
 
 def probe_binary(binary):
     try:

--- a/selftests/unit/test_utils_service.py
+++ b/selftests/unit/test_utils_service.py
@@ -25,6 +25,11 @@ except ImportError:
 
 from avocado.utils import service
 
+from .. import setup_avocado_loggers
+
+
+setup_avocado_loggers()
+
 
 class TestMultipleInstances(unittest.TestCase):
 

--- a/selftests/unit/test_utils_software_manager.py
+++ b/selftests/unit/test_utils_software_manager.py
@@ -4,6 +4,11 @@ import unittest
 from avocado.utils import distro
 from avocado.utils import software_manager
 
+from .. import setup_avocado_loggers
+
+
+setup_avocado_loggers()
+
 
 def apt_supported_distro():
     """

--- a/selftests/unit/test_utils_vmimage.py
+++ b/selftests/unit/test_utils_vmimage.py
@@ -8,6 +8,11 @@ from six.moves.urllib.error import HTTPError
 
 from avocado.utils import vmimage
 
+from .. import setup_avocado_loggers
+
+
+setup_avocado_loggers()
+
 
 class VMImage(unittest.TestCase):
 

--- a/selftests/unit/test_xunit.py
+++ b/selftests/unit/test_xunit.py
@@ -21,6 +21,11 @@ from avocado.core import job
 from avocado.core.result import Result
 from avocado.plugins import xunit
 
+from .. import setup_avocado_loggers
+
+
+setup_avocado_loggers()
+
 
 class ParseXMLError(Exception):
     pass


### PR DESCRIPTION
Avocado requires the logging streams to be set before some calls. Most
critical ones are 'avocado.Test' related ones as without initialization
the:

    No handlers could be found for logger...

messages can cause infinite recursion. Anyway there are other places
where avocado loggers are called so let's set it on (hopefully) all
places (we have to treat some utils as well as for backward
compatibility reasons these utils use avocado loggers directly).

Note in functional tests this is not required as Avocado always setup
logging streams prior using those utils (otherwise the failure would be
a real bug).

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>