### PR TITLE
Add link to our documentation about contibuting guidelines

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,1 @@
+docs/source/ContributionGuide.rst


### PR DESCRIPTION
Common location for contributing guidelines is "./CONTRIBUTING*" and
even github encourages us to use it. Let's symlink our documentation to
simplify first-time contributions (and also to make github happier).

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>