### PR TITLE
plugins.xunit: Format 'time' with 3 decimal places

### DIFF
--- a/avocado/plugins/xunit.py
+++ b/avocado/plugins/xunit.py
@@ -47,11 +47,15 @@ class XUnitResult(Result):
     def _get_attr(self, container, attrib):
         return self._escape_attr(container.get(attrib, self.UNKNOWN))
 
+    @staticmethod
+    def _format_time(time):
+        return "{:.3f}".format(float(time))
+
     def _create_testcase_element(self, document, state):
         testcase = document.createElement('testcase')
         testcase.setAttribute('classname', self._get_attr(state, 'class_name'))
         testcase.setAttribute('name', self._get_attr(state, 'name'))
-        testcase.setAttribute('time', self._get_attr(state, 'time_elapsed'))
+        testcase.setAttribute('time', self._format_time(self._get_attr(state, 'time_elapsed')))
         return testcase
 
     def _create_failure_or_error(self, document, test, element_type,
@@ -95,7 +99,7 @@ class XUnitResult(Result):
         testsuite.setAttribute('errors', self._escape_attr(result.errors + result.interrupted))
         testsuite.setAttribute('failures', self._escape_attr(result.failed))
         testsuite.setAttribute('skipped', self._escape_attr(result.skipped + result.cancelled))
-        testsuite.setAttribute('time', self._escape_attr(result.tests_total_time))
+        testsuite.setAttribute('time', self._escape_attr(self._format_time(result.tests_total_time)))
         testsuite.setAttribute('timestamp', self._escape_attr(datetime.datetime.now().isoformat()))
         document.appendChild(testsuite)
         for test in result.tests:

--- a/selftests/unit/test_xunit.py
+++ b/selftests/unit/test_xunit.py
@@ -58,7 +58,7 @@ class xUnitSucceedTest(unittest.TestCase):
                                     "job-2018-11-28T16.27-8fef221/job.log")
         self.test1 = SimpleTest(job=self.job, base_logdir=self.tmpdir)
         self.test1._Test__status = 'PASS'
-        self.test1.time_elapsed = 1.23
+        self.test1.time_elapsed = 678.23689
 
     def tearDown(self):
         errs = []
@@ -88,8 +88,14 @@ class xUnitSucceedTest(unittest.TestCase):
         except Exception as details:
             raise ParseXMLError("Error parsing XML: '%s'.\nXML Contents:\n%s" % (details, xml))
         self.assertTrue(dom)
+
+        els = dom.getElementsByTagName('testsuite')
+        self.assertEqual(len(els), 1)
+        self.assertEqual(els[0].attributes['time'].value, '678.237')
+
         els = dom.getElementsByTagName('testcase')
         self.assertEqual(len(els), 1)
+        self.assertEqual(els[0].attributes['time'].value, '678.237')
 
         junit_xsd = os.path.abspath(os.path.join(os.path.dirname(__file__),
                                                  os.path.pardir, ".data",


### PR DESCRIPTION
Any xUnit XML file when used to import test results in Jenkins CI
must comply to Ant and Maven's xUnit format specification. From
Jenkins' xUnit version 2.0 and up, the floating-point representation
of 'time' attribute should match Maven's surefire format
that restricts the use of at most 3 decimal places. But the Avocado's
xUnit plugin renders the 'time' attribute with several decimal places,
resulting in error to the load results.xml in Jenkins.

This change solves that problem by ensuring that the 'time' attribute
in Avocado's results.xml file is formatted with 3 decimal places.

Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>