### PR TITLE
loader: fix avocado list in verbose mode

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -641,7 +641,7 @@ class FileLoader(TestLoader):
             else:
                 reference = data_dir.get_test_dir()
         ignore_suffix = ('.data', '.pyc', '.pyo', '__init__.py',
-                         '__main__.py')
+                         '__main__.py', '.rst', '.md', '.txt')
 
         # Look for filename:test_method pattern
         subtests_filter = None

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -674,15 +674,16 @@ class FileLoader(TestLoader):
         for dirpath, dirs, filenames in os.walk(reference, onerror=onerror):
             dirs.sort()
             for file_name in sorted(filenames):
-                if not file_name.startswith('.'):
-                    for suffix in ignore_suffix:
-                        if file_name.endswith(suffix):
-                            break
-                    else:
-                        pth = os.path.join(dirpath, file_name)
-                        tests.extend(self._make_tests(pth,
-                                                      which_tests == DiscoverMode.ALL,
-                                                      subtests_filter))
+                if file_name.startswith('.'):
+                    continue
+
+                if file_name.endswith(ignore_suffix):
+                    continue
+
+                pth = os.path.join(dirpath, file_name)
+                tests.extend(self._make_tests(pth,
+                                              which_tests == DiscoverMode.ALL,
+                                              subtests_filter))
         return tests
 
     def _find_python_unittests(self, test_path, disabled, subtests_filter):


### PR DESCRIPTION
When avocado list was run in verbose mode, rst files and others was being
taken as test files. This change adds the proper file extensions to ignore list 
so these files will be ignored.

It also simplifies file name check to be processed.

Reference: https://trello.com/c/ZaFksYGr
Signed-off-by: Caio Carrara <ccarrara@redhat.com>