### PR TITLE
loader: fix avocado list when exception happens [v2]

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -768,7 +768,8 @@ class FileLoader(TestLoader):
                 raise  # Don't ignore ctrl+c
             else:
                 return self._make_simple_or_broken_test(test_path,
-                                                        subtests_filter)
+                                                        subtests_filter,
+                                                        make_broken)
 
     @staticmethod
     def _make_test(klass, uid, description=None, subtests_filter=None,

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -4,6 +4,11 @@ import stat
 import tempfile
 import unittest
 
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
 from avocado.core import test
 from avocado.core import loader
 from avocado.utils import script
@@ -437,6 +442,14 @@ class LoaderTest(unittest.TestCase):
                 ('Test3', 'selftests/.data/loader_instrumented/double_import.py:Test3.test3'),
                 ('Test4', 'selftests/.data/loader_instrumented/double_import.py:Test4.test4')]
         self._check_discovery(exps, tests)
+
+    def test_list_raising_exception(self):
+        simple_test = script.TemporaryScript('simpletest.py', PY_SIMPLE_TEST)
+        simple_test.save()
+        with mock.patch('avocado.core.loader.safeloader.find_avocado_tests') as _mock:
+            _mock.side_effect = BaseException()
+            tests = self.loader.discover(simple_test.path)
+            self.assertEqual(tests[0][1]["name"], simple_test.path)
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir)


### PR DESCRIPTION
During the "make existing file tests" process of File Loader discover
method a broader exception is used because a lot of problems can be
found in this point. Regarding Python files, any exception can be
raised. When one of those exceptions was raised, the method
`_make_simple_or_broken_test` was being called without the third
parameter. This bug was added by the commit "cd818a8a0".

Reference: https://trello.com/c/ggH77dKB
Signed-off-by: Caio Carrara <ccarrara@redhat.com>

---
Changes from v1 (#2982)
* Added a better commit description
* Added a unit test to avoid future regressions