### PR TITLE
yaml_to_mux: bump pyyaml version

### DIFF
--- a/optional_plugins/varianter_yaml_to_mux/setup.py
+++ b/optional_plugins/varianter_yaml_to_mux/setup.py
@@ -25,7 +25,7 @@ setup(name='avocado-framework-plugin-varianter-yaml-to-mux',
       packages=find_packages(exclude=('tests*',)),
       include_package_data=True,
       install_requires=['avocado-framework',
-                        'PyYAML>=3.10,!=4.0,!=4.1,!=4.2b1'],
+                        'PyYAML>=4.2b1'],
       test_suite='tests',
       entry_points={
           "avocado.plugins.cli": [


### PR DESCRIPTION
This changes addresses the CVE-2017-18342[1] that defines: "In PyYAML
before 4.1, the yaml.load() API could execute arbitrary code. In other
words, yaml.safe_load is not used."

Since there's no 4.1 version released, the change updates PyYAML to the
next release available: 4.2b1.

[1] - https://nvd.nist.gov/vuln/detail/CVE-2017-18342

Signed-off-by: Caio Carrara <ccarrara@redhat.com>