### PR TITLE
yaml_to_mux: bump pyyaml version [v3]

### DIFF
--- a/optional_plugins/varianter_yaml_to_mux/setup.py
+++ b/optional_plugins/varianter_yaml_to_mux/setup.py
@@ -13,7 +13,16 @@
 # Copyright: Red Hat Inc. 2017
 # Author: Cleber Rosa <crosa@redhat.com>
 
+import sys
 from setuptools import setup, find_packages
+
+
+INSTALL_REQUIREMENTS = ['avocado-framework']
+
+if sys.version_info[0] == 2:
+    INSTALL_REQUIREMENTS.append('PyYAML>=3.10')
+else:
+    INSTALL_REQUIREMENTS.append('PyYAML>=4.2b2')
 
 
 setup(name='avocado-framework-plugin-varianter-yaml-to-mux',
@@ -24,8 +33,7 @@ setup(name='avocado-framework-plugin-varianter-yaml-to-mux',
       url='http://avocado-framework.github.io/',
       packages=find_packages(exclude=('tests*',)),
       include_package_data=True,
-      install_requires=['avocado-framework',
-                        'PyYAML>=3.10,!=4.0,!=4.1,!=4.2b1'],
+      install_requires=INSTALL_REQUIREMENTS,
       test_suite='tests',
       entry_points={
           "avocado.plugins.cli": [


### PR DESCRIPTION
This changes addresses the CVE-2017-18342[1] that defines: "In PyYAML
before 4.1, the yaml.load() API could execute arbitrary code. In other
words, yaml.safe_load is not used."

The change affects only installation using Python 3 because when
building EL7 RPMs, we want to use version 3.10, which is packaged on
EPEL.

[1] - https://nvd.nist.gov/vuln/detail/CVE-2017-18342

Signed-off-by: Caio Carrara <ccarrara@redhat.com>

---
Changes from v2 (#2992)
* Adjust PyYAML version definition for Python 2 because rpm building

Changes from v1 (#2990)
* Apply the PyYAML version bump only for Python 3 installation