### PR TITLE
Asset fetcher: fix the name + hash use case

### DIFF
--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -65,7 +65,7 @@ class Asset(object):
         :param name: the asset filename. url is also supported
         :param asset_hash: asset hash
         :param algorithm: hash algorithm
-        :param locations: list of locations fetch asset from
+        :param locations: list of locations where the asset can be fetched from
         :param cache_dirs: list of cache directories
         :param expire: time in seconds for the asset to expire
         """

--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -106,16 +106,17 @@ class Asset(object):
 
     def _get_relative_dir(self, parsed_url):
         """
-        When an asset has a name and a hash, there's a clear intention
-        for it to be unique *by name*, overwriting it if the file is
-        corrupted or expired.  These will be stored in the cache directory
-        indexed by name.
+        When an asset name is not an URL, and it also has a hash,
+        there's a clear intention for it to be unique *by name*,
+        overwriting it if the file is corrupted or expired.  These
+        will be stored in the cache directory indexed by name.
 
-        When an asset does not have a hash, they will be saved according
-        to their locations, so that multiple assets with the same file name,
-        but completely unrelated to each other, will still coexist.
+        When an asset name is an URL, wether it has a hash or not, it
+        will be saved according to their locations, so that multiple
+        assets with the same file name, but completely unrelated to
+        each other, will still coexist.
         """
-        if self.asset_hash:
+        if self.asset_hash and not parsed_url.scheme:
             return 'by_name'
         base_url = "%s://%s/%s" % (parsed_url.scheme,
                                    parsed_url.netloc,

--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -171,6 +171,7 @@ class Asset(object):
             for item in self.locations:
                 urls.append(item)
 
+        cache_relative_dir = self._get_relative_dir(parsed_url)
         for url in urls:
             urlobj = urlparse.urlparse(url)
             if urlobj.scheme in ['http', 'https', 'ftp']:
@@ -180,7 +181,6 @@ class Asset(object):
             else:
                 raise UnsupportedProtocolError("Unsupported protocol"
                                                ": %s" % urlobj.scheme)
-            cache_relative_dir = self._get_relative_dir(urlobj)
             asset_file = os.path.join(cache_dir, cache_relative_dir, basename)
             dirname = os.path.dirname(asset_file)
             if not os.path.isdir(dirname):

--- a/selftests/unit/test_utils_asset.py
+++ b/selftests/unit/test_utils_asset.py
@@ -25,27 +25,27 @@ class TestAsset(unittest.TestCase):
         self.url = 'file://%s' % self.localpath
         self.cache_dir = tempfile.mkdtemp(dir=self.basedir)
 
-    def test_fetch_urlname(self):
+    def test_fetch_url_cache_by_location(self):
         foo_tarball = asset.Asset(self.url,
                                   asset_hash=self.assethash,
                                   algorithm='sha1',
                                   locations=None,
                                   cache_dirs=[self.cache_dir],
                                   expire=None).fetch()
-        expected_tarball = os.path.join(self.cache_dir, 'by_name',
-                                        self.assetname)
-        self.assertEqual(foo_tarball, expected_tarball)
+        expected_location = os.path.join(self.cache_dir, 'by_location')
+        self.assertTrue(foo_tarball.startswith(expected_location))
+        self.assertTrue(foo_tarball.endswith(self.assetname))
 
-    def test_fetch_location(self):
+    def test_fetch_name_cache_by_name(self):
         foo_tarball = asset.Asset(self.assetname,
                                   asset_hash=self.assethash,
                                   algorithm='sha1',
                                   locations=[self.url],
                                   cache_dirs=[self.cache_dir],
                                   expire=None).fetch()
-        expected_tarball = os.path.join(self.cache_dir, 'by_name',
-                                        self.assetname)
-        self.assertEqual(foo_tarball, expected_tarball)
+        expected_location = os.path.join(self.cache_dir, 'by_name',
+                                         self.assetname)
+        self.assertEqual(foo_tarball, expected_location)
 
     def test_fetch_expire(self):
         foo_tarball = asset.Asset(self.assetname,
@@ -98,7 +98,7 @@ class TestAsset(unittest.TestCase):
         dirname = os.path.join(self.cache_dir, 'by_name')
         os.makedirs(dirname)
         with FileLock(os.path.join(dirname, self.assetname)):
-            a = asset.Asset(self.url,
+            a = asset.Asset(self.assetname,
                             asset_hash=self.assethash,
                             algorithm='sha1',
                             locations=None,


### PR DESCRIPTION
The primary parameter of the asset fetcher is the asset name.  The asset name can be an URL, but it can also be an asset name.  When an asset name is given with a hash, the intention is very specific, but currently broken.

This PR fixes that specific use case, and prevents valid files in the cache from being evicted, because they happen to have the same name, but are different files from different locations (name is given as an URL in those cases).