### PR TITLE
Robot plugin: silence output in the console

### DIFF
--- a/optional_plugins/robot/avocado_robot/__init__.py
+++ b/optional_plugins/robot/avocado_robot/__init__.py
@@ -27,6 +27,10 @@ from robot import run
 from robot.errors import DataError
 from robot.parsing.model import TestData
 from robot.model import SuiteNamePatterns
+from robot.output.logger import LOGGER
+
+
+LOGGER.unregister_console_logger()
 
 
 class RobotTest(test.SimpleTest):


### PR DESCRIPTION
When the Robot Framework finds an issue worthwhile to be shown on
the UI, it will do so, but that confuses Avocado users by mixing
the content from both layers.

Let's disable the Robot framework console logger, and only shown
the messages we intend to.

Signed-off-by: Cleber Rosa <crosa@redhat.com>