### PR TITLE
utils.process: Avoid hangs when timeouts are specified

### DIFF
--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -832,12 +832,12 @@ class SubProcess(object):
         if rc is None:
             stop_time = time.time() + 1
             while time.time() < stop_time:
-                rc = self._popen.wait()
+                rc = self._popen.poll()
                 if rc is not None:
                     break
             else:
                 self.kill()
-                rc = self._popen.wait()
+                rc = self._popen.poll()
 
         if rc is None:
             # If all this work fails, we're dealing with a zombie process.

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -813,7 +813,8 @@ class SubProcess(object):
         Call the subprocess poll() method, fill results if rc is not None.
         """
         def nuke_myself():
-            self.result.interrupted = "timeout after %ss" % timeout
+            self.result.interrupted = ("timeout after %ss"
+                                       % (time.time() - self.start_time))
             try:
                 kill_process_tree(self.get_pid(), sig, timeout=1)
             except Exception:


### PR DESCRIPTION
This series is inspired by a real bug where "process.run(..., timeout=something)" hangs for infinity. While on it I moved the timeout handling to `wait` instead of `run` as I always wanted to do so, then fix for the hang followed by improved killing mechanism are added. Last commit is just finishing touch that might improve the reported message.