### PR TITLE
Fix the recently introduced "bit more informative" plugin failure

### DIFF
--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -20,6 +20,7 @@ import logging
 import os
 import re
 import sys
+import traceback
 
 from six import string_types, iterkeys
 
@@ -703,12 +704,16 @@ def log_plugin_failures(failures):
                      :class:`avocado.core.dispatcher.Dispatcher`
                      attribute `load_failures`
     """
-    msg_fmt = 'Failed to load plugin from module "%s": %s'
+    msg_fmt = 'Failed to load plugin from module "%s": %s :\n%s'
     silenced = settings.get_value('plugins',
                                   'skip_broken_plugin_notification',
                                   list, [])
     for failure in failures:
         if failure[0].module_name in silenced:
             continue
+        if hasattr(failure[1], "__traceback__"):
+            str_tb = ''.join(traceback.format_tb(failure[1].__traceback__))
+        else:
+            str_tb = "Traceback not available"
         LOG_UI.error(msg_fmt, failure[0].module_name,
-                     failure[1].__repr__())
+                     failure[1].__repr__(), str_tb)

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -20,7 +20,6 @@ import logging
 import os
 import re
 import sys
-import traceback
 
 from six import string_types, iterkeys
 
@@ -704,7 +703,7 @@ def log_plugin_failures(failures):
                      :class:`avocado.core.dispatcher.Dispatcher`
                      attribute `load_failures`
     """
-    msg_fmt = 'Failed to load plugin from module "%s": %s :\n%s'
+    msg_fmt = 'Failed to load plugin from module "%s": %s'
     silenced = settings.get_value('plugins',
                                   'skip_broken_plugin_notification',
                                   list, [])
@@ -712,5 +711,4 @@ def log_plugin_failures(failures):
         if failure[0].module_name in silenced:
             continue
         LOG_UI.error(msg_fmt, failure[0].module_name,
-                     failure[1].__repr__(),
-                     ''.join(traceback.format_tb(failure[1].__traceback__)))
+                     failure[1].__repr__())


### PR DESCRIPTION
The `__traceback__` is not available on all platforms: https://travis-ci.org/avocado-framework/avocado-vt/jobs/483918589 Let's revert the original patch to mark it as broken (as make check can fail) and bring it back with the required fixes.