### PR TITLE
Unittest compatibility: test assertRaises()

### DIFF
--- a/examples/tests/assert.py
+++ b/examples/tests/assert.py
@@ -1,0 +1,20 @@
+from avocado import Test
+
+
+class MyException(Exception):
+    pass
+
+
+def raises_exception():
+    raise MyException
+
+
+class Assert(Test):
+
+    def test_assert_raises(self):
+        with self.assertRaises(MyException):
+            raises_exception()
+
+    def test_fails_to_raise(self):
+        with self.assertRaises(MyException):
+            pass

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -361,6 +361,18 @@ class RunnerOperationTest(unittest.TestCase):
                                                                 result))
         self.assertIn(b'"status": "FAIL"', result.stdout)
 
+    def test_assert_raises(self):
+        cmd_line = ("%s run --sysinfo=off --job-results-dir %s "
+                    "-- assert.py" % (AVOCADO, self.tmpdir))
+        result = process.run(cmd_line, ignore_status=True)
+        expected_rc = exit_codes.AVOCADO_TESTS_FAIL
+        self.assertEqual(result.exit_status, expected_rc,
+                         "Avocado did not return rc %d:\n%s" % (expected_rc,
+                                                                result))
+        self.assertIn(b'Assert.test_assert_raises:  PASS', result.stdout)
+        self.assertIn(b'Assert.test_fails_to_raise:  FAIL', result.stdout)
+        self.assertIn(b'PASS 1 | ERROR 0 | FAIL 1 ', result.stdout)
+
     def test_exception_not_in_path(self):
         os.mkdir(os.path.join(self.tmpdir, "shared_lib"))
         mylib = script.Script(os.path.join(self.tmpdir, "shared_lib",

--- a/selftests/functional/test_loader.py
+++ b/selftests/functional/test_loader.py
@@ -356,7 +356,8 @@ class LoaderTestFunctional(unittest.TestCase):
         """
         cmd = "%s list examples/tests/:fail" % AVOCADO
         result = process.run(cmd)
-        expected = (b"INSTRUMENTED examples/tests/doublefail.py:DoubleFail.test\n"
+        expected = (b"INSTRUMENTED examples/tests/assert.py:Assert.test_fails_to_raise\n"
+                    b"INSTRUMENTED examples/tests/doublefail.py:DoubleFail.test\n"
                     b"INSTRUMENTED examples/tests/fail_on_exception.py:FailOnException.test\n"
                     b"INSTRUMENTED examples/tests/failtest.py:FailTest.test\n"
                     b"SIMPLE       examples/tests/failtest.sh\n")


### PR DESCRIPTION
Based on some reports of failures to behave properly on
unittest.TestCase's assertRaises methods, let's improve the test
coverage on these situations.

References: https://github.com/avocado-framework/avocado/issues/2791
Signed-off-by: Cleber Rosa <crosa@redhat.com>