### PR TITLE
Safeloader: recursive by default review

### DIFF
--- a/avocado/core/safeloader.py
+++ b/avocado/core/safeloader.py
@@ -33,13 +33,11 @@ class AvocadoModule(object):
     __slots__ = 'path', 'test_imports', 'mod_imports', 'mod'
 
     def __init__(self, path):
-        self.path = path
         self.test_imports = set()
         self.mod_imports = set()
         if os.path.isdir(path):
-            self.path = os.path.join(path, "__init__.py")
-        else:
-            self.path = path
+            path = os.path.join(path, "__init__.py")
+        self.path = path
         with open(self.path) as source_file:
             self.mod = ast.parse(source_file.read(), self.path)
 

--- a/selftests/unit/test_safeloader.py
+++ b/selftests/unit/test_safeloader.py
@@ -254,6 +254,10 @@ class FindClassAndMethods(UnlimitedDiff):
 
     def test_self(self):
         reference = {
+            'AvocadoModule': ['setUp',
+                              'test_add_imported_empty',
+                              'test_add_imported_object_from_module',
+                              'test_add_imported_object_from_module_asname'],
             'ModuleImportedAs': ['_test',
                                  'test_foo',
                                  'test_foo_as_bar',
@@ -290,6 +294,9 @@ class FindClassAndMethods(UnlimitedDiff):
 
     def test_with_pattern(self):
         reference = {
+            'AvocadoModule': ['test_add_imported_empty',
+                              'test_add_imported_object_from_module',
+                              'test_add_imported_object_from_module_asname'],
             'ModuleImportedAs': ['test_foo',
                                  'test_foo_as_bar',
                                  'test_foo_as_foo',
@@ -376,6 +383,30 @@ class FindClassAndMethods(UnlimitedDiff):
                                    ('test_first_child', {}),
                                    ('test_basic', {})]}
         self.assertEqual(expected, tests)
+
+
+class AvocadoModule(unittest.TestCase):
+
+    def setUp(self):
+        self.path = os.path.abspath(os.path.dirname(get_this_file()))
+        self.module = safeloader.AvocadoModule(self.path)
+
+    def test_add_imported_empty(self):
+        self.assertEqual(self.module.imported_objects, {})
+
+    def test_add_imported_object_from_module(self):
+        import_stm = ast.ImportFrom(module='foo', names=[ast.Name(name='bar',
+                                                                  asname=None)])
+        self.module.add_imported_object(import_stm)
+        self.assertEqual(self.module.imported_objects['bar'],
+                         os.path.join(self.path, 'foo', 'bar'))
+
+    def test_add_imported_object_from_module_asname(self):
+        import_stm = ast.ImportFrom(module='foo', names=[ast.Name(name='bar',
+                                                                  asname='baz')])
+        self.module.add_imported_object(import_stm)
+        self.assertEqual(self.module.imported_objects['baz'],
+                         os.path.join(self.path, 'foo', 'bar'))
 
 
 if __name__ == '__main__':

--- a/selftests/unit/test_safeloader.py
+++ b/selftests/unit/test_safeloader.py
@@ -7,7 +7,7 @@ import unittest
 from avocado.core import safeloader
 from avocado.utils import script
 
-from .. import setup_avocado_loggers
+from .. import BASEDIR, setup_avocado_loggers
 
 
 setup_avocado_loggers()
@@ -257,7 +257,9 @@ class FindClassAndMethods(UnlimitedDiff):
             'AvocadoModule': ['setUp',
                               'test_add_imported_empty',
                               'test_add_imported_object_from_module',
-                              'test_add_imported_object_from_module_asname'],
+                              'test_add_imported_object_from_module_asname',
+                              'test_is_not_avocado_test',
+                              'test_is_avocado_test'],
             'ModuleImportedAs': ['_test',
                                  'test_foo',
                                  'test_foo_as_bar',
@@ -296,7 +298,9 @@ class FindClassAndMethods(UnlimitedDiff):
         reference = {
             'AvocadoModule': ['test_add_imported_empty',
                               'test_add_imported_object_from_module',
-                              'test_add_imported_object_from_module_asname'],
+                              'test_add_imported_object_from_module_asname',
+                              'test_is_not_avocado_test',
+                              'test_is_avocado_test'],
             'ModuleImportedAs': ['test_foo',
                                  'test_foo_as_bar',
                                  'test_foo_as_foo',
@@ -407,6 +411,19 @@ class AvocadoModule(unittest.TestCase):
         self.module.add_imported_object(import_stm)
         self.assertEqual(self.module.imported_objects['baz'],
                          os.path.join(self.path, 'foo', 'bar'))
+
+    def test_is_not_avocado_test(self):
+        self.assertFalse(self.module.is_avocado_test(ast.ClassDef()))
+
+    def test_is_avocado_test(self):
+        passtest_path = os.path.join(BASEDIR, 'examples', 'tests', 'passtest.py')
+        passtest_module = safeloader.AvocadoModule(passtest_path)
+        classes = [klass for klass in passtest_module.iter_classes()]
+        # there's only one class and one *worthy* Test import in passtest.py
+        self.assertEqual(len(classes), 1)
+        self.assertEqual(len(passtest_module.test_imports), 1)
+        self.assertEqual(len(passtest_module.mod_imports), 0)
+        self.assertTrue(passtest_module.is_avocado_test(classes[0]))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is a collection of commits out of my review of #2839.

As evidenced by the description of the commit ("...plus many fixes") and the size of the commit itself, I suggested that individual parts of the patch be broken down.  With the individual pieces added, it should be possible to have:

 * Test coverage for the parts added
 * Easier review
 * More effective bisecting

@ldoktor please take this either as a general but more clear direction of what I meant in the review, *or* if you wish, take the commits as is (after your review).  Since this is mean as an example of what I meant in the review, I didn't get all the way to the end, so there should be no behavior changes. 