### PR TITLE
COPR SCM/"make srpm" support

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,0 +1,15 @@
+pkg_install := $(shell dnf -y install git rpm-build)
+commit := $(shell git log --pretty=format:'%H' -n 1)
+commit_date := $(shell git log --pretty='format:%cd' --date='format:%Y%m%d' -n 1)
+short_commit := $(shell git log --pretty=format:'%h' -n 1)
+
+srpm:
+	if test ! -d SOURCES; then mkdir SOURCES; fi
+	if test ! -d SPEC; then mkdir SPEC; fi
+	git archive --prefix="avocado-$(commit)/" -o "SOURCES/avocado-$(short_commit).tar.gz" HEAD
+	cp python-avocado.spec SPEC
+	sed -i -e 's/\%global rel_build .*/\%global rel_build 0/' SPEC/python-avocado.spec
+	sed -i -e 's/\%global commit .*/\%global commit $(commit)/' SPEC/python-avocado.spec
+	sed -i -e 's/\%global commit_date .*/\%global commit_date $(commit_date)/' SPEC/python-avocado.spec
+	rpmbuild -D '_topdir .' -bs SPEC/python-avocado.spec
+	mv SRPMS/*.src.rpm $(outdir)


### PR DESCRIPTION
This adds a Makefile that adds support for the Fedora COPR service to
build packages for Avocado, right out of a Git repo.  To do so, create
your project, and in "Builds" tab, select "New Build".

On "1. Select source type" section, select "SCM".  On section
"2. Provide the source", under "Clone url" add the URL of your repo.
For instance, this has been tested with:

  https://github.com/clebergnu/avocado

Under "Committish", enter a reference to a given commit.  For instance, this
has been tested with the name of this branch: "copr_makefile".

Under "3. How to build SRPM from the source", select "make srpm".
Finally, select the appropriate Chroots.  It's better not to have
"Enable internet access during this build" option checked.

Finally, it's advisable to not attempt to run this Makefile locally,
as it's designed to be run on the environment that CORP provides, that
is, a mock based chroot with super user privileges.

Signed-off-by: Cleber Rosa <crosa@redhat.com>