### PR TITLE
runner: Fix deadline evaluation

### DIFF
--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -469,7 +469,7 @@ class TestRunner(object):
 
         # Get/update the test status (decrease timeout on abort)
         if abort_reason:
-            finish_deadline = TIMEOUT_TEST_INTERRUPTED
+            finish_deadline = TIMEOUT_TEST_INTERRUPTED + time.time()
         else:
             finish_deadline = deadline
         test_state = test_status.finish(proc, time_started, step,

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -17,7 +17,6 @@
 Test runner module.
 """
 
-import multiprocessing
 import multiprocessing.queues
 import os
 import signal


### PR DESCRIPTION
The first commit fixes issue where:

    avocado --show all run sleeptenmin.py --mux-inject /run:timeout:1

always reported unfinished test process even though it finished properly. The second commit is a simple pylint-fix.