### PR TITLE
RPM build fixes (revealed by COPR builds) 

### DIFF
--- a/optional_plugins/varianter_yaml_to_mux/setup.py
+++ b/optional_plugins/varianter_yaml_to_mux/setup.py
@@ -13,16 +13,7 @@
 # Copyright: Red Hat Inc. 2017
 # Author: Cleber Rosa <crosa@redhat.com>
 
-import sys
 from setuptools import setup, find_packages
-
-
-INSTALL_REQUIREMENTS = ['avocado-framework']
-
-if sys.version_info[0] == 2:
-    INSTALL_REQUIREMENTS.append('PyYAML>=3.10')
-else:
-    INSTALL_REQUIREMENTS.append('PyYAML>=4.2b2')
 
 
 setup(name='avocado-framework-plugin-varianter-yaml-to-mux',
@@ -33,7 +24,7 @@ setup(name='avocado-framework-plugin-varianter-yaml-to-mux',
       url='http://avocado-framework.github.io/',
       packages=find_packages(exclude=('tests*',)),
       include_package_data=True,
-      install_requires=INSTALL_REQUIREMENTS,
+      install_requires=('avocado-framework', 'PyYAML>=4.2b2'),
       test_suite='tests',
       entry_points={
           "avocado.plugins.cli": [

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -214,6 +214,10 @@ sed -e "s/'libvirt-python'//" -i optional_plugins/runner_vm/setup.py
 %build
 %if 0%{?rhel} == 7
 sed -e "s/'six>=1.10.0'/'six>=1.9.0'/" -i setup.py
+sed -e "s/'PyYAML>=4.2b2'/'PyYAML>=3.10'/" -i optional_plugins/varianter_yaml_to_mux/setup.py
+%endif
+%if 0%{?fedora} && 0%{?fedora} < 29
+sed -e "s/'PyYAML>=4.2b2'/'PyYAML>=3.12'/" -i optional_plugins/varianter_yaml_to_mux/setup.py
 %endif
 %py2_build
 %if %{with_python3}

--- a/selftests/unit/test_utils_vmimage.py
+++ b/selftests/unit/test_utils_vmimage.py
@@ -133,13 +133,13 @@ class OpenSUSEImageProvider(unittest.TestCase):
 
     def test_get_best_version_default(self):
         suse_latest_version = 15.0
-        suse_provider = vmimage.OpenSUSEImageProvider()
+        suse_provider = vmimage.OpenSUSEImageProvider(arch='x86_64')
         self.assertEqual(suse_provider.get_best_version(self.suse_available_versions),
                          suse_latest_version)
 
     def test_get_best_version_leap_4_series(self):
         suse_latest_version = 42.3
-        suse_provider = vmimage.OpenSUSEImageProvider(version='4(.)*')
+        suse_provider = vmimage.OpenSUSEImageProvider(version='4(.)*', arch='x86_64')
         self.assertEqual(suse_provider.get_best_version(self.suse_available_versions),
                          suse_latest_version)
 
@@ -151,7 +151,7 @@ class OpenSUSEImageProvider(unittest.TestCase):
         urlopen_mock.return_value = mock.Mock(read=urlread_mocked)
         expected_image_url = self.base_images_url + image
 
-        suse_provider = vmimage.OpenSUSEImageProvider()
+        suse_provider = vmimage.OpenSUSEImageProvider(arch='x86_64')
         suse_provider.get_version = mock.Mock(return_value='15.0')
         self.assertEqual(suse_provider.get_image_url(), expected_image_url)
 
@@ -163,7 +163,8 @@ class OpenSUSEImageProvider(unittest.TestCase):
         urlopen_mock.return_value = mock.Mock(read=urlread_mocked)
         expected_image_url = self.base_images_url + image
 
-        suse_provider = vmimage.OpenSUSEImageProvider(build='1.1.1-Buildlp111.11.11')
+        suse_provider = vmimage.OpenSUSEImageProvider(build='1.1.1-Buildlp111.11.11',
+                                                      arch='x86_64')
         suse_provider.get_version = mock.Mock(return_value='15.0')
         self.assertEqual(suse_provider.get_image_url(), expected_image_url)
 


### PR DESCRIPTION
During some experiments with builds on COPR (), the two different build issues appeared.

For the first one, it affected Fedora 28 builds.  This build includes the first commit only:

https://copr.fedorainfracloud.org/coprs/cleber/avocado-copr-test/build/851713/

The second was related to builds happening on ppc64le.  The following COPR build includes both commits and includes ppc64le chroots:

https://copr.fedorainfracloud.org/coprs/cleber/avocado-copr-test/build/851721/