### PR TITLE
Fix RPM build on Fedora >= 30

### DIFF
--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -67,6 +67,9 @@ BuildRequires: fabric
 %if %{with_python3_fabric}
 BuildRequires: python3-fabric3
 %endif
+%if 0%{?fedora} >= 30
+BuildRequires: glibc-all-langpacks
+%endif
 
 %if 0%{?rhel} == 7
 BuildRequires: python-jinja2


### PR DESCRIPTION
Starting with Fedora 30, only a minimal set of language packs are
installed on build roots, and consequently available during the build
of packages.

Some of the Avocado tests use varied locale settings, so we need the
full language packs installed.

Reference: https://github.com/avocado-framework/avocado/issues/2978
Refernece: https://fedoraproject.org/wiki/Changes/Remove_glibc-langpacks-all_from_buildroot
Signed-off-by: Cleber Rosa <crosa@redhat.com>