### PR TITLE
avocado.utils.ssh: fixes for the master connection

### DIFF
--- a/avocado/utils/ssh.py
+++ b/avocado/utils/ssh.py
@@ -8,7 +8,8 @@ class Session(object):
     """
 
     DEFAULT_OPTIONS = (('StrictHostKeyChecking', 'no'),
-                       ('UpdateHostKeys', 'no'))
+                       ('UpdateHostKeys', 'no'),
+                       ('ControlPath', '~/.ssh/avocado-master-%r@%h:%p'))
 
     MASTER_OPTIONS = (('ControlMaster', 'yes'),
                       ('ControlPersist', 'yes'))

--- a/avocado/utils/ssh.py
+++ b/avocado/utils/ssh.py
@@ -77,7 +77,7 @@ class Session(object):
             if not master.exit_status == 0:
                 return False
             self._connection = master
-        return True
+        return self._check()
 
     def cmd(self, command):
         """


### PR DESCRIPTION
The master connection is not currently being initialized properly due to the lack of the control path configuration is missing.