### PR TITLE
plugins.xunit: Allow to override job-name

### DIFF
--- a/avocado/plugins/xunit.py
+++ b/avocado/plugins/xunit.py
@@ -91,10 +91,13 @@ class XUnitResult(Result):
         system_out.appendChild(system_out_cdata)
         return element, system_out
 
-    def _render(self, result, max_test_log_size):
+    def _render(self, result, max_test_log_size, job_name):
         document = Document()
         testsuite = document.createElement('testsuite')
-        testsuite.setAttribute('name', os.path.basename(os.path.dirname(result.logfile)))
+        if job_name:
+            testsuite.setAttribute('name', job_name)
+        else:
+            testsuite.setAttribute('name', os.path.basename(os.path.dirname(result.logfile)))
         testsuite.setAttribute('tests', self._escape_attr(result.tests_total))
         testsuite.setAttribute('errors', self._escape_attr(result.errors + result.interrupted))
         testsuite.setAttribute('failures', self._escape_attr(result.failed))
@@ -137,7 +140,8 @@ class XUnitResult(Result):
             return
 
         max_test_log_size = getattr(job.args, 'xunit_max_test_log_chars', None)
-        content = self._render(result, max_test_log_size)
+        job_name = getattr(job.args, 'xunit_job_name', None)
+        content = self._render(result, max_test_log_size, job_name)
         if getattr(job.args, 'xunit_job_result', 'off') == 'on':
             xunit_path = os.path.join(job.logdir, 'results.xml')
             with open(xunit_path, 'wb') as xunit_file:
@@ -179,6 +183,12 @@ class XUnitCLI(CLI):
             help=('Enables default xUnit result in the job results directory. '
                   'File will be named "results.xml". '
                   'Defaults to on.'))
+
+        run_subcommand_parser.output.add_argument(
+            '--xunit-job-name', default=None, help="Override the reported "
+            "job name. By default uses the Avocado job name which is always "
+            "unique. This is useful for reporting in Jenkins as it only "
+            "evaluates first-failure from jobs of the same name.")
 
         run_subcommand_parser.output.add_argument(
             '--xunit-max-test-log-chars', metavar='SIZE',

--- a/man/avocado.rst
+++ b/man/avocado.rst
@@ -133,6 +133,11 @@ Options for subcommand `run` (`avocado run --help`)::
       --xunit-job-result {on,off}
                             Enables default xUnit result in the job results
                             directory. File will be named "results.xml".
+      --xunit-job-name XUNIT_JOB_NAME
+                            Override the reported job name. By default uses the
+                            Avocado job name which is always unique. This is
+                            useful for reporting in Jenkins as it only evaluates
+                            first-failure from jobs of the same name.
       --xunit-max-test-log-chars SIZE
                             Limit the attached job log to given number of
                             characters (k/m/g suffix allowed)


### PR DESCRIPTION
Recently we modified the reported xunit job name to match the avocado
job name, but this breaks the Jenkins feature that detects first failure
as it only evaluates results of the same job name. Let's allow to set
this value so people can have multiple results easily comparable.

v1: https://github.com/avocado-framework/avocado/pull/3010

Changes:

```yaml
v2: Renamed variable "override_job_name" to "job_name"
v2: Added "man" entry
```