### PR TITLE
 utils.process: Avoid hangs when timeouts are specified [v3]

### DIFF
--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -814,7 +814,9 @@ class SubProcess(object):
 
         :param timeout: Time (seconds) we'll wait until the process is
                         finished. If it's not, we'll try to terminate it
-                        and get a status.
+                        and get a status. When the process refuses to die
+                        within 1s we send SIGKILL to it and report the
+                        status (be it exit_code or zombie)
         :param sig: Signal to send to the process in case it did not end after
                     the specified timeout.
         """
@@ -838,12 +840,12 @@ class SubProcess(object):
         if rc is None:
             stop_time = time.time() + 1
             while time.time() < stop_time:
-                rc = self._popen.wait()
+                rc = self._popen.poll()
                 if rc is not None:
                     break
             else:
                 self.kill()
-                rc = self._popen.wait()
+                rc = self._popen.poll()
 
         if rc is None:
             # If all this work fails, we're dealing with a zombie process.
@@ -893,7 +895,9 @@ class SubProcess(object):
 
         :param timeout: Time (seconds) we'll wait until the process is
                         finished. If it's not, we'll try to terminate it
-                        and get a status.
+                        and get a status. When the process refuses to die
+                        within 1s we send SIGKILL to it and report the
+                        status (be it exit_code or zombie)
         :type timeout: float
         :param sig: Signal to send to the process in case it did not end after
                     the specified timeout.

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -808,14 +808,47 @@ class SubProcess(object):
             self._fill_results(rc)
         return rc
 
-    def wait(self):
+    def wait(self, timeout=None, sig=signal.SIGTERM):
         """
         Call the subprocess poll() method, fill results if rc is not None.
+
+        :param timeout: Time (seconds) we'll wait until the process is
+                        finished. If it's not, we'll try to terminate it
+                        and get a status.
+        :param sig: Signal to send to the process in case it did not end after
+                    the specified timeout.
         """
+        def timeout_handler():
+            self.send_signal(sig)
+            self.result.interrupted = "timeout after %ss" % timeout
+
         self._init_subprocess()
-        rc = self._popen.wait()
-        if rc is not None:
-            self._fill_results(rc)
+        rc = None
+
+        if timeout is None:
+            rc = self._popen.wait()
+        elif timeout > 0.0:
+            timer = threading.Timer(timeout, timeout_handler)
+            try:
+                timer.start()
+                rc = self._popen.wait()
+            finally:
+                timer.cancel()
+
+        if rc is None:
+            stop_time = time.time() + 1
+            while time.time() < stop_time:
+                rc = self._popen.wait()
+                if rc is not None:
+                    break
+            else:
+                self.kill()
+                rc = self._popen.wait()
+
+        if rc is None:
+            # If all this work fails, we're dealing with a zombie process.
+            raise AssertionError('Zombie Process %s' % self._popen.pid)
+        self._fill_results(rc)
         return rc
 
     def stop(self):
@@ -868,36 +901,8 @@ class SubProcess(object):
         :returns: The command result object.
         :rtype: A :class:`CmdResult` instance.
         """
-        def timeout_handler():
-            self.send_signal(sig)
-            self.result.interrupted = "timeout after %ss" % timeout
-
         self._init_subprocess()
-
-        if timeout is None:
-            self.wait()
-        elif timeout > 0.0:
-            timer = threading.Timer(timeout, timeout_handler)
-            try:
-                timer.start()
-                self.wait()
-            finally:
-                timer.cancel()
-
-        if self.result.exit_status is None:
-            stop_time = time.time() + 1
-            while time.time() < stop_time:
-                self.poll()
-                if self.result.exit_status is not None:
-                    break
-            else:
-                self.kill()
-                self.poll()
-
-        # If all this work fails, we're dealing with a zombie process.
-        e_msg = 'Zombie Process %s' % self._popen.pid
-        assert self.result.exit_status is not None, e_msg
-
+        self.wait(timeout, sig)
         return self.result
 
 

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -822,7 +822,8 @@ class SubProcess(object):
                     the specified timeout.
         """
         def nuke_myself():
-            self.result.interrupted = "timeout after %ss" % timeout
+            self.result.interrupted = ("timeout after %ss"
+                                       % (time.time() - self.start_time))
             try:
                 kill_process_tree(self.get_pid(), sig, timeout=1)
             except Exception:

--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -4,6 +4,7 @@ import os
 import shlex
 import unittest
 import sys
+import time
 
 try:
     from unittest import mock
@@ -13,6 +14,7 @@ except ImportError:
 
 from .. import recent_mock
 from avocado.utils import astring
+from avocado.utils import script
 from avocado.utils import gdb
 from avocado.utils import process
 from avocado.utils import path
@@ -34,6 +36,20 @@ def probe_binary(binary):
 
 ECHO_CMD = probe_binary('echo')
 FICTIONAL_CMD = '/usr/bin/fictional_cmd'
+
+REFUSE_TO_DIE = """import signal
+import time
+
+for sig in range(64):
+    try:
+        signal.signal(sig, signal.SIG_IGN)
+    except:
+        pass
+
+end = time.time() + 120
+
+while time.time() < end:
+    time.sleep(1)"""
 
 
 class TestSubProcess(unittest.TestCase):
@@ -320,6 +336,40 @@ class TestProcessRun(unittest.TestCase):
         result = process.run(cmd, encoding='utf-8')
         self.assertEqual(result.stdout, encoded_text)
         self.assertEqual(result.stdout_text, text)
+
+    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 1)) < 2,
+                     "Skipping test that take a long time to run, are "
+                     "resource intensive or time sensitve")
+    def test_run_with_timeout_ugly_cmd(self):
+        with script.TemporaryScript("refuse_to_die", REFUSE_TO_DIE) as exe:
+            cmd = "%s '%s'" % (sys.executable, exe.path)
+            # Wait 1s to set the traps
+            res = process.run(cmd, timeout=1, ignore_status=True)
+            self.assertLess(res.duration, 100, "Took longer than expected, "
+                            "process probably not interrupted by Avocado.\n%s"
+                            % res)
+            self.assertNotEqual(res.exit_status, 0, "Command finished without "
+                                "reporting failure but should be killed.\n%s"
+                                % res)
+
+    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 2,
+                     "Skipping test that take a long time to run, are "
+                     "resource intensive or time sensitve")
+    def test_run_with_negative_timeout_ugly_cmd(self):
+        with script.TemporaryScript("refuse_to_die", REFUSE_TO_DIE) as exe:
+            cmd = "%s '%s'" % (sys.executable, exe.path)
+            # Wait 1s to set the traps
+            proc = process.SubProcess(cmd)
+            proc.start()
+            time.sleep(1)
+            proc.wait(-1)
+            res = proc.result
+            self.assertLess(res.duration, 100, "Took longer than expected, "
+                            "process probably not interrupted by Avocado.\n%s"
+                            % res)
+            self.assertNotEqual(res.exit_status, 0, "Command finished without "
+                                "reporting failure but should be killed.\n%s"
+                                % res)
 
 
 class MiscProcessTests(unittest.TestCase):


### PR DESCRIPTION
This series is inspired by a real bug where "process.run(..., timeout=something)" hangs for infinity. While on it I moved the timeout handling to wait instead of run as I always wanted to do so, then fix for the hang followed by improved killing mechanism are added. Last commit is just finishing touch that might improve the reported message.

v1: https://github.com/avocado-framework/avocado/pull/3005
v2: https://github.com/avocado-framework/avocado/pull/3017

Changes:

```yaml
v2: Adjust docstrings accordingly to the changes
v2: Style-fixes in selftests
v2: Skip one new selftest in travis and the other in both RPM and travis environments
v3: Log warning/error when killing process with non-default signal
```