### PR TITLE
utils.archive.extract_lzma: open in binary

### DIFF
--- a/avocado/utils/archive.py
+++ b/avocado/utils/archive.py
@@ -118,7 +118,7 @@ if LZMA_CAPABLE:
         extracted_file = os.path.splitext(path)[0]
         if not force and os.path.exists(extracted_file):
             return extracted_file
-        with open(path, 'r') as file_obj:
+        with open(path, 'rb') as file_obj:
             with open(extracted_file, 'wb') as newfile_obj:
                 newfile_obj.write(lzma.decompress(file_obj.read()))
         return extracted_file


### PR DESCRIPTION
fix that opens compressed file in binary instead of text mode.

Signed-off-by: lolyu <lolyu@redhat.com>