### PR TITLE
selftests: removes unnecessary proc.wait()

### DIFF
--- a/selftests/unit/test_utils_partition.py
+++ b/selftests/unit/test_utils_partition.py
@@ -124,7 +124,6 @@ class TestPartitionMkfsMount(Base):
         proc = self.run_process_to_use_mnt()
         self.assertRaises(partition.PartitionError, self.disk.unmount)
         proc.terminate()
-        proc.wait()
 
     @unittest.skipIf(not process.can_sudo(sys.executable + " -c ''"),
                      "requires running Python as a privileged user")
@@ -141,12 +140,8 @@ class TestPartitionMkfsMount(Base):
                 self.assertRaises(partition.PartitionError, self.disk.unmount)
                 mocked_system_output.assert_called_with('lsof ' + self.mountpoint,
                                                         sudo=True)
-        # TODO: process.terminate() should be enough, but currently isn't.
-        # debug the root cause of why the process fails to terminate and the
-        # test hangs on wait()
         self.disk.unmount()
         proc.terminate()
-        proc.wait()
 
     def test_double_mount(self):
         """ Check the attempt for second mount fails """


### PR DESCRIPTION
This change removes unnecessary proc.wait() call since proc.terminate()
is apparently enough.

Signed-off-by: Caio Carrara <ccarrara@redhat.com>