### PR TITLE
selftests: Fix timeouts

### DIFF
--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -832,15 +832,17 @@ class RunnerSimpleTest(unittest.TestCase):
         avocado_proc = avocado_shell.children()[0]
         pid = avocado_proc.pid
         os.kill(pid, signal.SIGTSTP)   # This freezes the process
-        deadline = time.time() + 9
+        # The deadline is 3s timeout + 10s test postprocess before kill +
+        # 10s reserve for additional steps (still below 60s)
+        deadline = time.time() + 20
         while time.time() < deadline:
             if not proc.is_alive():
                 break
             time.sleep(0.1)
         else:
             proc.kill(signal.SIGKILL)
-            self.fail("Avocado process still alive 5s after job-timeout:\n%s"
-                      % proc.get_output())
+            self.fail("Avocado process still alive 17s after "
+                      "job-timeout:\n%s" % proc.get_output())
         output = proc.get_output()
         self.assertIn("ctrl+z pressed, stopping test", output, "SIGTSTP "
                       "message not in the output, test was probably not "

--- a/selftests/functional/test_interrupt.py
+++ b/selftests/functional/test_interrupt.py
@@ -133,7 +133,7 @@ class InterruptTest(unittest.TestCase):
         time.sleep(2.5)
         os.kill(self.proc.pid, signal.SIGINT)
 
-        if not wait.wait_for(self._is_finished, timeout=10):
+        if not wait.wait_for(self._is_finished, timeout=30):
             process.kill_process_tree(self.proc.pid)
             self.fail('Avocado was still running after receiving SIGINT '
                       'twice.')


### PR DESCRIPTION
Recently we fixed bug where timeouts were not kept under certain
conditions, but the fix lacked selftests modification of those 2
affected selftests as they rely on test-postprocess timing.

@cacarrara, please adjust your merge workflow to prevent such breakages as `make check` should catch these https://avocado-framework.readthedocs.io/en/67.0/ContributionGuide.html#code-review

PS: It wasn't on purpose, I just ran only a subset when polishing the commits and today when rebasing I found out `make check` is failing...