### PR TITLE
docs: Document the current recursive discovery

### DIFF
--- a/docs/source/SubclassingAvocado.rst
+++ b/docs/source/SubclassingAvocado.rst
@@ -68,17 +68,11 @@ proposed filesystem structure::
 
 
 
-- ``tests/test_example.py``: And this is how your test will look like. The most
-  important item here is to use the docstring ``:avocado: recursive``, so the
-  Avocado test loader will be able to recognize your test class as an Avocado
-  Test class::
+- ``tests/test_example.py``: And this is how your test will look like::
 
     from apricot import ApricotTest
 
     class MyTest(ApricotTest):
-        """
-        :avocado: recursive
-        """
         def test(self):
             self.assertTrue(self.some_useful_method())
 

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -1206,181 +1206,90 @@ Now let's follow with some docstring directives examples.
 
 .. _docstring-directive-enable-disable:
 
-Explicitly enabling or disabling tests
---------------------------------------
+Declaring test as NOT-INSTRUMENTED
+----------------------------------
 
-If your test is a method in a class that directly inherits from
-:class:`avocado.Test`, then Avocado will find it as one would expect.
+In order to say `this class is not an Avocado instrumented` test, one
+can use ``:avocado: disable`` directive. The result is that this
+class itself is not discovered as an instrumented test, but children
+classes might inherit it's ``test*`` methods (useful for base-classes)::
 
-Now, the need may arise for more complex tests, to use more advanced
-Python features such as inheritance.  For those tests that are written
-in a class not directly inherting from :class:`avocado.Test`, Avocado
-may need your help, because Avocado uses only static analysis to examine
-the files.
+   from avocado import Test
 
-For example, suppose that you define a new test class that inherits
-from the Avocado base test class, that is, :class:`avocado.Test`, and
-put it in ``mylibrary.py``::
+   class BaseClass(Test):
+       """
+       :avocado: disable
+       """
+       def test_shared(self):
+           pass
 
-    from avocado import Test
+   class SpecificTests(BaseClass):
+       def test_specific(self):
+           pass
 
+Results in::
 
-    class MyOwnDerivedTest(Test):
-        def __init__(self, methodName='test', name=None, params=None,
-                     base_logdir=None, job=None, runner_queue=None):
-            super(MyOwnDerivedTest, self).__init__(methodName, name, params,
-                                                   base_logdir, job,
-                                                   runner_queue)
-            self.log('Derived class example')
+   INSTRUMENTED test.py:SpecificTests.test_specific
+   INSTRUMENTED test.py:SpecificTests.test_shared
 
-
-Then you implement your actual test using that derived class, in
-``mytest.py``::
-
-    import mylibrary
+The ``test.py:BaseBase.test`` is not discovered due the tag while
+the ``test.py:SpecificTests.test_shared`` is inherited from the
+base-class.
 
 
-    class MyTest(mylibrary.MyOwnDerivedTest):
+Declaring test as INSTRUMENTED
+------------------------------
 
-        def test1(self):
-            self.log('Testing something important')
+The ``:avocado: enable`` tag might be useful when you want to
+override that this is an `INSTRUMENTED` test, even though it is
+not inherited from ``avocado.Test`` class and/or when you want
+to only limit the ``test*`` methods discovery to the current
+class::
 
-        def test2(self):
-            self.log('Testing something even more important')
+   from avocado import Test
 
+   class NotInheritedFromTest(object):
+       """
+       :avocado: enable
+       """
+       def test(self):
+           pass
 
-If you try to list the tests in that file, this is what you'll get:
+   class BaseClass(Test):
+       """
+       :avocado: disable
+       """
+       def test_shared(self):
+           pass
 
-.. code-block:: none
+   class SpecificTests(BaseClass):
+       """
+       :avocado: enable
+       """
+       def test_specific(self):
+           pass
 
-    scripts/avocado list mytest.py -V
-    Type       Test      Tag(s)
-    NOT_A_TEST mytest.py
+Results in::
 
-    TEST TYPES SUMMARY
-    ==================
-    ACCESS_DENIED: 0
-    BROKEN_SYMLINK: 0
-    EXTERNAL: 0
-    FILTERED: 0
-    INSTRUMENTED: 0
-    MISSING: 0
-    NOT_A_TEST: 1
-    SIMPLE: 0
-    VT: 0
+   INSTRUMENTED test.py:NotInheritedFromTest.test
+   INSTRUMENTED test.py:SpecificTests.test_specific
 
-You need to give avocado a little help by adding a docstring
-directive. That docstring directive is ``:avocado: enable``. It tells
-the Avocado safe test detection code to consider it as an avocado
-test, regardless of what the (admittedly simple) detection code thinks
-of it. Let's see how that works out. Add the docstring, as you can see
-the example below::
-
-    import mylibrary
-
-
-    class MyTest(mylibrary.MyOwnDerivedTest):
-        """
-        :avocado: enable
-        """
-        def test1(self):
-            self.log('Testing something important')
-
-        def test2(self):
-            self.log('Testing something even more important')
+The ``test.py:NotInheritedFromTest.test`` will not really work
+as it lacks several required methods, but still is discovered
+as an `INSTRUMENTED` test due to ``enable`` tag and the
+``SpecificTests`` only looks at it's ``test*`` methods,
+ignoring the inheritance, therefor the
+``test.py:SpecificTests.test_shared`` will not be discovered.
 
 
-Now, trying to list the tests on the ``mytest.py`` file again:
+(Deprecated) enabling recursive discovery
+-----------------------------------------
 
-.. code-block:: none
+The ``:avocado: recursive`` tag was used to enable recursive
+discovery, but nowadays this is the default. By using this
+tag one explicitly sets the class as `INSTRUMENTED`, therefor
+inheritance from `avocado.Test` is not required.
 
-    scripts/avocado list mytest.py -V
-    Type         Test                   Tag(s)
-    INSTRUMENTED mytest.py:MyTest.test1
-    INSTRUMENTED mytest.py:MyTest.test2
-
-    TEST TYPES SUMMARY
-    ==================
-    ACCESS_DENIED: 0
-    BROKEN_SYMLINK: 0
-    EXTERNAL: 0
-    FILTERED: 0
-    INSTRUMENTED: 2
-    MISSING: 0
-    NOT_A_TEST: 0
-    SIMPLE: 0
-    VT: 0
-
-You can also use the ``:avocado: disable`` docstring directive, that
-works the opposite way: something that would be considered an Avocado
-test, but we force it to not be listed as one.
-
-The docstring ``:avocado: disable`` is evaluated first by Avocado,
-meaning that if both ``:avocado: disable`` and ``:avocado: enable`` are
-present in the same docstring, the test will not be listed.
-
-.. _docstring-directive-recursive:
-
-Recursively Discovering Tests
------------------------------
-
-In addition to the ``:avocado: enable`` and ``:avocado: disable``
-docstring directives, Avocado has support for the ``:avocado: recursive``
-directive. It is intended to be used in inherited classes when you want
-to tell Avocado to also discover the ancestor classes.
-
-The ``:avocado: recursive`` directive will direct Avocado to evaluate all
-the ancestors of the class until the base class, the one derived from
-from ``avocado.Test``.
-
-Example:
-
-File `/usr/share/doc/avocado/tests/test_base_class.py`::
-
-    from avocado import Test
-
-
-    class BaseClass(Test):
-
-        def test_basic(self):
-            pass
-
-
-File `/usr/share/doc/avocado/tests/test_first_child.py`::
-
-    from test_base_class import BaseClass
-
-
-    class FirstChild(BaseClass):
-
-        def test_first_child(self):
-            pass
-
-
-File `/usr/share/doc/avocado/tests/test_second_child.py`::
-
-    from test_first_child import FirstChild
-
-
-    class SecondChild(FirstChild):
-        """
-        :avocado: recursive
-        """
-
-        def test_second_child(self):
-            pass
-
-Using only `test_second_child.py` as a test reference will result in::
-
-    $ avocado list test_second_child.py
-    INSTRUMENTED test_second_child.py:SecondChild.test_second_child
-    INSTRUMENTED test_second_child.py:SecondChild.test_first_child
-    INSTRUMENTED test_second_child.py:SecondChild.test_basic
-
-Notice that the ``:avocado: disable`` docstring will be ignored in
-ancestors during the recursive discovery. What means that even if an
-ancestor contains the docstring ``:avocado: disable``, that ancestor will
-still be included in the results.
 
 .. _categorizing-tests:
 

--- a/docs/source/release_notes/51_0.rst
+++ b/docs/source/release_notes/51_0.rst
@@ -42,7 +42,7 @@ Users/Test Writers
   ``--execution-order=variants-per-test``.
 
 * Test methods on parent classes are now found upon the use of the new
-  :ref:`recursive <docstring-directive-recursive>` docstring
+  `recursive <docstring-directive-recursive>` docstring
   directive.  While ``:avocado: enable`` enables Avocado to find
   INSTRUMENTED tests that do not look like one (more details :ref:`here
   <docstring-directive-enable-disable>`), ``recursive`` will do that

--- a/docs/source/release_notes/lts/52_0.rst
+++ b/docs/source/release_notes/lts/52_0.rst
@@ -317,7 +317,7 @@ attention to following changes:
   it is now possible to mark a class as avocado test including all
   ``test*`` methods coming from all parent classes (similarly to how
   dynamic discovery works inside python unittest, see
-  :ref:`docstring-directive-recursive` for details)
+  `docstring-directive-recursive` for details)
 * The ``self.text_output`` is not published after the test execution. If
   you were using it simply open the ``self.logfile`` and read the content
   yourself.

--- a/docs/source/release_notes/lts/next.rst
+++ b/docs/source/release_notes/lts/next.rst
@@ -274,6 +274,10 @@ introduced by the next LTS version are:
 * Including test logs in TAP plugin is disabled by default and can
   be enabled using ``--tap-include-logs``.
 
+* Switched the `FileLoader` discovery to `:avocado: recursive` by
+  default. All tags `enable`, `disable` and `recursive` are still
+  available and might help fine-tuning the class visibility.
+
 Complete list of changes
 ========================
 


### PR DESCRIPTION
We recently switched from simple to recursive discovery by default,
let's document how the discovery works now.

This is related to https://github.com/avocado-framework/avocado/pull/3024