### PR TITLE
selftests: Fix python3 compatibility

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -63,7 +63,7 @@ API_SECTIONS = {"Test APIs": (None,
 # clean up all previous rst files. RTD is known to keep them from previous runs
 process.run("find %s -name '*.rst' -delete" % base_api_output_dir)
 
-for (section, params) in API_SECTIONS.iteritems():
+for (section, params) in API_SECTIONS.items():
     output_dir = os.path.join(base_api_output_dir, params[2])
     exclude_dirs = [os.path.join(api_source_dir, d)
                     for d in params[3]]


### PR DESCRIPTION
This test was always skipped due to different urllib handling in
python3. Let's use our download library to check the connectivity.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>