### PR TITLE
Release test plan: use the Avocado COPR repo

### DIFF
--- a/examples/testplans/release.json
+++ b/examples/testplans/release.json
@@ -13,7 +13,7 @@
 	 "description": "On a fresh virtual machine, install Avocado using its COPR repo.  Run:\n- dnf -y copr enable @avocado/avocado-latest\n- dnf -y install python-avocado-* python2-avocado-* python3-avocado-* qemu-guest-agent rpmlint\n- systemctl start qemu-guest-agent\n- systemctl enable qemu-guest-agent"},
 
         {"name": "Avocado RPM lint",
-        "description": "On the same machine you just installed Avocado, check if there are no unexpected packaging errors or warnings by running: `$ rpmlint python*-avocado*`.  Expected result: 3 packages and 0 specfiles checked; 0 errors, 0 warnings. (some missing man-pages can be ignored)"},
+        "description": "On the same machine you just installed Avocado, check if there are packaging errors by running: `$ rpmlint python*-avocado*`.  Expected result: XX packages and 0 spec files checked; 0 errors, YY warnings."},
 
 	{"name": "Avocado Test Run on RPM based installation",
 	 "description": "On the same machine you just installed Avocado used during RPM packages ('Avocado RPM install'), run the simplest possible test with `$ avocado run passtest.py`. Expected results: `(1/1) passtest.py: PASS (0.00 s)`. After the test, shutdown the virtual machine."},

--- a/examples/testplans/release.json
+++ b/examples/testplans/release.json
@@ -9,14 +9,11 @@
 	{"name": "Avocado source does not contain spelling errors",
 	 "description": "On your development machine, on a freshen Avocado source to be released, run `$ make spell`. Expected result: Make command should say OK."},
 
-	{"name": "Avocado RPM build",
-	 "description": "On your development machine, build the Avocado RPM packages using: `$ make rpm`. Expected result: SRPM and RPM files at `BUILD/RPM/python-avocado-x.y.z-r.distro.{src,noarch}.rpm`"},
-
-	{"name": "Avocado RPM lint",
-	 "description": "With the built RPMs, check if there are no unexpected packaging errors or warnings by running: `$ rpmlint BUILD/RPM/python*-avocado-x.y*.rpm`.  Expected result: 3 packages and 0 specfiles checked; 0 errors, 0 warnings. (some missing man-pages can be ignored)"},
-
 	{"name": "Avocado RPM install",
-	 "description": "On a fresh virtual machine, perform the installation of Avocado using the packages built on test 'Avocado RPM build'. Also install and start the qemu-guest-agent."},
+	 "description": "On a fresh virtual machine, install Avocado using its COPR repo.  Run:\n- dnf -y copr enable @avocado/avocado-latest\n- dnf -y install python-avocado-* python2-avocado-* python3-avocado-* qemu-guest-agent rpmlint\n- systemctl start qemu-guest-agent\n- systemctl enable qemu-guest-agent"},
+
+        {"name": "Avocado RPM lint",
+        "description": "On the same machine you just installed Avocado, check if there are no unexpected packaging errors or warnings by running: `$ rpmlint python*-avocado*`.  Expected result: 3 packages and 0 specfiles checked; 0 errors, 0 warnings. (some missing man-pages can be ignored)"},
 
 	{"name": "Avocado Test Run on RPM based installation",
 	 "description": "On the same machine you just installed Avocado used during RPM packages ('Avocado RPM install'), run the simplest possible test with `$ avocado run passtest.py`. Expected results: `(1/1) passtest.py: PASS (0.00 s)`. After the test, shutdown the virtual machine."},
@@ -32,7 +29,6 @@
 
 	{"name": "Avocado VT",
 	 "description": "Configure avocado vt as described in http://avocado-vt.readthedocs.org/en/latest/GetStartedGuide.html including the `avocado list` and running the migration test. Expected result: No errors."},
-
 
 	{"name": "Avocado HTML report sysinfo",
 	 "description": "On the HTML report, click on `Sysinfo (pre/post/profile, click to expand)` and verify that system information such as `hostname` and `cpuinfo` are present and accurate"},


### PR DESCRIPTION
Instead of, now, re-building the packages locally. The COPR repo already builds them for different distros and on two architectures.

---

Changes from v1 (#3029):
 * Squashed the first two commits
 * Added a commit about the `rpmlint` step