### PR TITLE
Several "settings" fixes and plugin to allow setting/modifying config file paths

### DIFF
--- a/avocado/core/dispatcher.py
+++ b/avocado/core/dispatcher.py
@@ -21,8 +21,14 @@ from stevedore import EnabledExtensionManager
 
 from .settings import settings
 from .settings import SettingsError
+from .settings import SettingsDispatcher
 from .output import LOG_UI
 from ..utils import stacktrace
+
+
+#: Settings dispatcher is simplified and has to be available before the
+#: settings object. Let's include it here for consistency
+SettingsDispatcher = SettingsDispatcher
 
 
 class Dispatcher(EnabledExtensionManager):

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -383,10 +383,6 @@ class Job(object):
         LOG_JOB.info('Config files read (in order):')
         for cfg_path in settings.config_paths:
             LOG_JOB.info(cfg_path)
-        if settings.config_paths_failed:
-            LOG_JOB.info('Config files failed to read (in order):')
-            for cfg_path in settings.config_paths_failed:
-                LOG_JOB.info(cfg_path)
         LOG_JOB.info('')
 
         LOG_JOB.info('Avocado config:')

--- a/avocado/core/plugin_interfaces.py
+++ b/avocado/core/plugin_interfaces.py
@@ -25,6 +25,22 @@ class Plugin(object):
     """
 
 
+class Settings(Plugin):
+
+    """
+    Base plugin to allow modifying settings.
+
+    Currently it only supports to extend/modify the default list of
+    paths to config files.
+    """
+
+    @abc.abstractmethod
+    def adjust_settings_paths(self, paths):
+        """
+        Entry point where plugin can modify the list of configuration paths
+        """
+
+
 class CLI(Plugin):
 
     """

--- a/avocado/core/settings.py
+++ b/avocado/core/settings.py
@@ -215,7 +215,6 @@ class Settings(object):
             else:
                 self.process_config_path(config_path_local)
         else:
-            # Unittests
             self.process_config_path(config_path)
 
     def process_config_path(self, pth):
@@ -224,6 +223,7 @@ class Settings(object):
             self.config_paths += read_configs
         else:
             self.config_paths_failed.append(pth)
+            # Only used by unittests (the --config parses the file later)
 
     def _handle_no_value(self, section, key, default):
         """

--- a/avocado/core/settings.py
+++ b/avocado/core/settings.py
@@ -140,9 +140,15 @@ class Settings(object):
         :param config_path: Path to a config file. Useful for unittesting.
         """
         self.config = ConfigParser.ConfigParser()
-        self.intree = False
         self.config_paths = []
         self.config_paths_failed = []
+        _source_tree_root = os.path.dirname(os.path.dirname(os.path.dirname(
+            sys.modules[__name__].__file__)))
+        # In case "examples" file exists in root, we are running from tree
+        if os.path.exists(os.path.join(_source_tree_root, 'examples')):
+            self.intree = True
+        else:
+            self.intree = False
         if config_path is None:
             if 'VIRTUAL_ENV' in os.environ:
                 cfg_dir = os.path.join(os.environ['VIRTUAL_ENV'], 'etc')
@@ -154,7 +160,6 @@ class Settings(object):
             _config_dir_system = os.path.join(cfg_dir, 'avocado')
             _config_dir_system_extra = os.path.join(cfg_dir, 'avocado', 'conf.d')
             _config_dir_local = os.path.join(user_dir, '.config', 'avocado')
-            _source_tree_root = os.path.join(sys.modules[__name__].__file__, "..", "..", "..")
             _config_path_intree = os.path.join(os.path.abspath(_source_tree_root),
                                                'avocado', 'etc', 'avocado')
             _config_path_intree_extra = os.path.join(_config_path_intree, 'conf.d')
@@ -184,7 +189,6 @@ class Settings(object):
                 if config_intree_extra:
                     for extra_file in glob.glob(os.path.join(_config_path_intree_extra, '*.conf')):
                         self.process_config_path(extra_file)
-                self.intree = True
             # Override with system config
             if config_system:
                 self.process_config_path(config_path_system)

--- a/avocado/core/settings.py
+++ b/avocado/core/settings.py
@@ -25,7 +25,6 @@ try:
 except ImportError:
     import configparser as ConfigParser
 
-from pkg_resources import resource_exists
 from pkg_resources import resource_filename
 from pkg_resources import resource_isdir
 from pkg_resources import resource_listdir
@@ -144,7 +143,7 @@ class Settings(object):
         """
         self.config = ConfigParser.ConfigParser()
         self.config_paths = []
-        self.config_paths_failed = []
+        self.all_config_paths = []
         _source_tree_root = os.path.dirname(os.path.dirname(os.path.dirname(
             sys.modules[__name__].__file__)))
         # In case "examples" file exists in root, we are running from tree
@@ -168,11 +167,7 @@ class Settings(object):
             config_path_system = os.path.join(_config_dir_system, config_filename)
             config_path_local = os.path.join(_config_dir_local, config_filename)
 
-            config_system = os.path.exists(config_path_system)
-            config_system_extra = os.path.exists(_config_dir_system_extra)
-            config_local = os.path.exists(config_path_local)
             config_pkg_base = os.path.join('etc', 'avocado', config_filename)
-            config_pkg = resource_exists('avocado', config_pkg_base)
             config_path_pkg = resource_filename('avocado', config_pkg_base)
             _config_pkg_extra = os.path.join('etc', 'avocado', 'conf.d')
             if resource_isdir('avocado', _config_pkg_extra):
@@ -180,28 +175,20 @@ class Settings(object):
                                                     _config_pkg_extra)
                 _config_pkg_extra = resource_filename('avocado', _config_pkg_extra)
             else:
-                config_pkg_extra = None
-            if not (config_system or config_local or
-                    config_pkg):
-                raise ConfigFileNotFound([config_path_system,
-                                          config_path_local,
-                                          config_path_pkg])
+                config_pkg_extra = []
             # First try pkg/in-tree config
-            if config_pkg:
-                self.process_config_path(config_path_pkg)
-                if config_pkg_extra:
-                    for extra_file in (os.path.join(_config_pkg_extra, _)
-                                       for _ in config_pkg_extra
-                                       if _.endswith('.conf')):
-                        self.process_config_path(extra_file)
+            self.all_config_paths.append(config_path_pkg)
+            for extra_file in (os.path.join(_config_pkg_extra, _)
+                               for _ in config_pkg_extra
+                               if _.endswith('.conf')):
+                self.all_config_paths.append(extra_file)
             # Override with system config
-            if config_system:
-                self.process_config_path(config_path_system)
-                if config_system_extra:
-                    for extra_file in glob.glob(os.path.join(_config_dir_system_extra, '*.conf')):
-                        self.process_config_path(extra_file)
+            self.all_config_paths.append(config_path_system)
+            for extra_file in glob.glob(os.path.join(_config_dir_system_extra,
+                                                     '*.conf')):
+                self.all_config_paths.append(extra_file)
             # And the local config
-            if not config_local:
+            if not os.path.exists(config_path_local):
                 try:
                     path.init_dir(_config_dir_local)
                     with open(config_path_local, 'w') as config_local_fileobj:
@@ -212,18 +199,20 @@ class Settings(object):
                         config_local_fileobj.write(content)
                 except IOError:     # Some users can't write it (docker)
                     pass
-            else:
-                self.process_config_path(config_path_local)
+            self.all_config_paths.append(config_path_local)
         else:
-            self.process_config_path(config_path)
+            # Only used by unittests (the --config parses the file later)
+            self.all_config_paths.append(config_path)
+        self.config_paths = self.config.read(self.all_config_paths)
+        if not self.config_paths:
+            raise ConfigFileNotFound(self.all_config_paths)
 
     def process_config_path(self, pth):
-        read_configs = self.config.read(pth)
-        if read_configs:
-            self.config_paths += read_configs
-        else:
-            self.config_paths_failed.append(pth)
-            # Only used by unittests (the --config parses the file later)
+        """
+        Update list of config paths and process the given pth
+        """
+        self.all_config_paths.append(pth)
+        self.config_paths.extend(self.config.read(pth))
 
     def _handle_no_value(self, section, key, default):
         """

--- a/avocado/core/settings.py
+++ b/avocado/core/settings.py
@@ -29,8 +29,26 @@ from pkg_resources import resource_filename
 from pkg_resources import resource_isdir
 from pkg_resources import resource_listdir
 from six import string_types
+from stevedore import ExtensionManager
 
 from ..utils import path
+
+
+class SettingsDispatcher(ExtensionManager):
+
+    """
+    Dispatchers that allows plugins to modify settings
+
+    It's not the standard "avocado.core.dispatcher" because that one depends
+    on settings. This dispatcher is the bare-stevedore dispatcher which is
+    executed before settings is parsed.
+    """
+
+    def __init__(self):
+        super(SettingsDispatcher, self).__init__('avocado.plugins.settings',
+                                                 invoke_on_load=True,
+                                                 invoke_kwds={},
+                                                 propagate_map_exceptions=True)
 
 
 class SettingsError(Exception):
@@ -199,6 +217,12 @@ class Settings(object):
                         config_local_fileobj.write(content)
                 except IOError:     # Some users can't write it (docker)
                     pass
+            # Allow plugins to modify/extend the list of configs
+            dispatcher = SettingsDispatcher()
+            if dispatcher.extensions:
+                dispatcher.map_method('adjust_settings_paths',
+                                      self.all_config_paths)
+            # Register user config as last to always take precedence
             self.all_config_paths.append(config_path_local)
         else:
             # Only used by unittests (the --config parses the file later)

--- a/avocado/core/settings.py
+++ b/avocado/core/settings.py
@@ -17,7 +17,6 @@ Reads the avocado settings from a .ini file (from python ConfigParser).
 """
 import ast
 import os
-import sys
 import glob
 
 try:
@@ -116,27 +115,25 @@ def convert_value_type(value, value_type):
         value_type = str
 
     # if length of string is zero then return None
-    if len(sval) == 0:
+    if not sval:
         if value_type == str:
             return ""
-        elif value_type == os.path.expanduser:
+        if value_type == os.path.expanduser:
             return ""
-        elif value_type == bool:
+        if value_type == bool:
             return False
-        elif value_type == int:
+        if value_type == int:
             return 0
-        elif value_type == float:
+        if value_type == float:
             return 0.0
-        elif value_type == list:
+        if value_type == list:
             return []
-        else:
-            return None
+        return None
 
     if value_type == bool:
         if sval.lower() == "false":
             return False
-        else:
-            return True
+        return True
 
     if value_type == list:
         return ast.literal_eval(sval)
@@ -163,12 +160,10 @@ class Settings(object):
         self.config_paths = []
         self.all_config_paths = []
         _source_tree_root = os.path.dirname(os.path.dirname(os.path.dirname(
-            sys.modules[__name__].__file__)))
+            __file__)))
         # In case "examples" file exists in root, we are running from tree
-        if os.path.exists(os.path.join(_source_tree_root, 'examples')):
-            self.intree = True
-        else:
-            self.intree = False
+        self.intree = bool(os.path.exists(os.path.join(_source_tree_root,
+                                                       'examples')))
         if config_path is None:
             if 'VIRTUAL_ENV' in os.environ:
                 cfg_dir = os.path.join(os.environ['VIRTUAL_ENV'], 'etc')

--- a/avocado/plugins/config.py
+++ b/avocado/plugins/config.py
@@ -37,13 +37,13 @@ class Config(CLICmd):
                             'Current: %(default)s')
 
     def run(self, args):
-        LOG_UI.info('Config files read (in order):')
-        for cfg_path in settings.config_paths:
-            LOG_UI.debug('    %s', cfg_path)
-        if settings.config_paths_failed:
-            LOG_UI.error('\nConfig files that failed to read:')
-            for cfg_path in settings.config_paths_failed:
-                LOG_UI.error('    %s', cfg_path)
+        LOG_UI.info("Config files read (in order, '*' means the file exists "
+                    "and had been read):")
+        for cfg_path in settings.all_config_paths:
+            if cfg_path in settings.config_paths:
+                LOG_UI.debug('    * %s', cfg_path)
+            else:
+                LOG_UI.debug('      %s', cfg_path)
         LOG_UI.debug("")
         if not args.datadir:
             blength = 0

--- a/docs/source/Configuration.rst
+++ b/docs/source/Configuration.rst
@@ -72,7 +72,26 @@ So the file parsing order is:
 * ``/etc/avocado/conf.d/*.conf``
 * ``~/.config/avocado/avocado.conf``
 
-In this order, meaning that what you set on your local config file may override what's defined in the system wide files.
+You can see the actual set of files/location by using ``avocado config``
+which uses ``*`` to mark existing and used files::
+
+   $ avocado config
+   Config files read (in order, '*' means the file exists and had been read):
+    * /etc/avocado/avocado.conf
+    * /etc/avocado/conf.d/resultsdb.conf
+    * /etc/avocado/conf.d/result_upload.conf
+    * /etc/avocado/conf.d/jobscripts.conf
+    * /etc/avocado/conf.d/gdb.conf
+      /home/medic/.config/avocado/avocado.conf
+
+    Section.Key                              Value
+    datadir.paths.base_dir                   /var/lib/avocado
+    datadir.paths.test_dir                   /usr/share/doc/avocado/tests
+    ...
+
+
+Where the lower config files override values of the upper files and
+the ``/home/medic/.config/avocado/avocado.conf`` file missing.
 
 .. note::  Please note that if avocado is running from git repos, those files will be ignored in favor of in tree configuration files. This is something that would normally only affect people developing avocado, and if you are in doubt, ``avocado config`` will tell you exactly which files are being used in any given situation.
 .. note::  When avocado runs inside virtualenv than path for global config files is also changed. For example, `avocado.conf` comes from the virual-env path `venv/etc/avocado/avocado.conf`.
@@ -93,26 +112,6 @@ example), we established the following order of precedence for variables (from l
 So the least important value comes from the library or test code default,
 going all the way up to the test parameters system.
 
-Config plugin
-=============
-
-A configuration plugin is provided for users that wish to quickly see what's defined in all sections of their Avocado
-configuration, after all the files are parsed in their correct resolution order. Example::
-
-    $ avocado config
-    Config files read (in order):
-        /etc/avocado/avocado.conf
-        $HOME/.config/avocado/avocado.conf
-
-        Section.Key     Value
-        runner.base_dir /var/lib/avocado
-        runner.test_dir /usr/share/doc/avocado/tests
-        runner.data_dir /var/lib/avocado/data
-        runner.logs_dir ~/avocado/job-results
-
-The command also shows the order in which your config files were parsed, giving you a better understanding of
-what's going on. The Section.Key nomenclature was inspired in ``git config --list`` output.
-
 Avocado Data Directories
 ========================
 
@@ -132,8 +131,12 @@ it will give you an output similar to the one seen below::
 
     $ avocado config --datadir
     Config files read (in order):
-        /etc/avocado/avocado.conf
-        $HOME/.config/avocado/avocado.conf
+        * /etc/avocado/avocado.conf
+        * /etc/avocado/conf.d/resultsdb.conf
+        * /etc/avocado/conf.d/result_upload.conf
+        * /etc/avocado/conf.d/jobscripts.conf
+        * /etc/avocado/conf.d/gdb.conf
+          $HOME/.config/avocado/avocado.conf
 
     Avocado replaces config dirs that can't be accessed
     with sensible defaults. Please edit your local config

--- a/docs/source/Configuration.rst
+++ b/docs/source/Configuration.rst
@@ -49,10 +49,54 @@ will read the config files present in the git repos, and will ignore the system 
 Plugin config files
 ===================
 
-Plugins can also be configured by config files. In order to not disturb the main Avocado config file, those plugins,
-if they wish so, may install additional config files to ``/etc/avocado/conf.d/[pluginname].conf``, that will be parsed
-after the system wide config file. Users can override those values as well at the local config file level.
-Considering the config for the hypothethical plugin ``salad``:
+There are two ways to extend settings of extra plugin configuration. Plugins
+can extend the list of files parsed by ``Settings`` object by using
+``avocado.plugins.settings`` entry-point (Python-way) or they can
+simply drop the individual config files into ``/etc/avocado/conf.d``
+(linux/posix-way).
+
+`avocado.plugins.settings`
+--------------------------
+
+This entry-point uses ``avocado.core.plugin_interfaces.Settings``-like object
+to extend the list of parsed files. It only accepts individual files, but
+you can use something like ``glob.glob("*.conf")`` to add all config files
+inside a directory.
+
+You need to create the plugin (eg. ``my_plugin/settings.py``)::
+
+   from avocado.core.plugin_interfaces import Settings
+
+   class MyPluginSettings(Settings):
+       def adjust_settings_paths(self, paths):
+           paths.extend(glob.glob("/etc/my_plugin/conf.d/*.conf"))
+
+
+And register it in your ``setup.py`` entry-points::
+
+   from setuptools import setup
+   ...
+   setup(name="my-plugin",
+         entry_points={
+             'avocado.plugins.settings': [
+                 "my-plugin-settings = my_plugin.settings.MyPluginSettings",
+                 ],
+             ...
+
+Which extends the list of files to be parsed by settings object. Note this
+has to be executed early in the code so try to keep the required deps
+minimal (for example the `avocado.core.settings.settings` is not yet
+available).
+
+`/etc/avocado/conf.d`
+---------------------
+
+In order to not disturb the main Avocado config file, those plugins,
+if they wish so, may install additional config files to
+``/etc/avocado/conf.d/[pluginname].conf``, that will be parsed
+after the system wide config file. Users can override those values
+as well at the local config file level. Considering the config for
+the hypothethical plugin ``salad``:
 
 .. code-block:: ini
 
@@ -70,6 +114,7 @@ So the file parsing order is:
 
 * ``/etc/avocado/avocado.conf``
 * ``/etc/avocado/conf.d/*.conf``
+* ``avocado.plugins.settings`` plugins (but they can insert to any location)
 * ``~/.config/avocado/avocado.conf``
 
 You can see the actual set of files/location by using ``avocado config``
@@ -82,6 +127,8 @@ which uses ``*`` to mark existing and used files::
     * /etc/avocado/conf.d/result_upload.conf
     * /etc/avocado/conf.d/jobscripts.conf
     * /etc/avocado/conf.d/gdb.conf
+    * /etc/avocado_vt/conf.d/vt.conf
+    * /etc/avocado_vt/conf.d/vt_joblock.conf
       /home/medic/.config/avocado/avocado.conf
 
     Section.Key                              Value


### PR DESCRIPTION
This PR fixes several issues in "avocado.core.settings" and on top adds plugin to allow to extend/modify the list of config-file locations to be parsed into settings. This plugin is to be used by Avocado-vt (and hopefully other plugins will follow) to clearly define their config files.

v1: https://github.com/avocado-framework/avocado/pull/2780
related: https://github.com/avocado-framework/avocado-vt/pull/1142

Changes:

```yaml
v2: Use ExtensionManager instead of EnabledExtensionManager
v2: New commit with style fixes
v2: Added documentation in "settings: Change the way config files are processed" and
    "Add support for SettingsPlugin".
```