### PR TITLE
selftests: Kill the process before waiting

### DIFF
--- a/selftests/functional/test_utils.py
+++ b/selftests/functional/test_utils.py
@@ -142,6 +142,7 @@ class ProcessTest(unittest.TestCase):
         proc = process.SubProcess('%s 1' % self.fake_vmstat)
         proc.start()
         time.sleep(3)
+        proc.terminate()
         proc.wait(timeout=1)
         stdout = proc.get_stdout().decode()
         self.assertIn('memory', stdout, 'result: %s' % stdout)


### PR DESCRIPTION
The fake-vmstat process should run for infinity. Using wait with 1s
timeout will eventually destroy the test after the timeout, but cleaner
solution is to explicitly terminate it and then use the wait to make
sure it finished (or eventually nuke it)

introduced in: https://github.com/avocado-framework/avocado/pull/3036