### PR TITLE
Memory Region output fix in pci utils

### DIFF
--- a/avocado/utils/pci.py
+++ b/avocado/utils/pci.py
@@ -304,7 +304,7 @@ def get_mask(pci_address):
     if output:
         dic = {'K': 1024, 'M': 1048576, 'G': 1073741824}
         for line in output.splitlines():
-            if 'Region' in line and 'Memory at' in line:
+            if 'Memory at' in line:
                 val = line.split('=')[-1].split(']')[0]
                 memory_size = int(val[:-1]) * dic[val[-1]]
                 break


### PR DESCRIPTION
Previously, the lspci -bv output format contained information
about Memory Region also, now it does not on latest pciutils.
It is as below. So, handling it for get_mask()

Memory at f0020000 (64-bit, non-prefetchable)

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>