### PR TITLE
Record all logged messages during test run into the test log

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -667,6 +667,11 @@ class Test(unittest.TestCase, TestData):
         self.file_handler.setFormatter(formatter)
         self.log.addHandler(self.file_handler)
 
+        # add the test log handler to the root logger so that
+        # everything logged while the test is running, for every
+        # logger, also makes its way into the test log file
+        logging.root.addHandler(self.file_handler)
+
         stream_fmt = '%(message)s'
         stream_formatter = logging.Formatter(fmt=stream_fmt)
 


### PR DESCRIPTION
Each test has its own log file within a given job result dir,
located at "test-results/$(test-id)/debug.log".

If the test is an INSTRUMENTED test, using the standard Python logging
module/API, all produced content should be recorded into the test log
file.  This adds a handler that does exactly that to the logging
module root logger.

Signed-off-by: Cleber Rosa <crosa@redhat.com>