### PR TITLE
JSON Result: store possible empty fail_reason as null

### DIFF
--- a/avocado/plugins/jsonresult.py
+++ b/avocado/plugins/jsonresult.py
@@ -37,6 +37,9 @@ class JSONResult(Result):
     def _render(self, result):
         tests = []
         for test in result.tests:
+            fail_reason = test.get('fail_reason', UNKNOWN)
+            if fail_reason is not None:
+                fail_reason = astring.to_text(fail_reason)
             tests.append({'id': str(test.get('name', UNKNOWN)),
                           'start': test.get('time_start', -1),
                           'end': test.get('time_end', -1),
@@ -45,7 +48,7 @@ class JSONResult(Result):
                           'whiteboard': test.get('whiteboard', UNKNOWN),
                           'logdir': test.get('logdir', UNKNOWN),
                           'logfile': test.get('logfile', UNKNOWN),
-                          'fail_reason': astring.to_text(test.get('fail_reason', UNKNOWN))})
+                          'fail_reason': fail_reason})
         content = {'job_id': result.job_unique_id,
                    'debuglog': result.logfile,
                    'tests': tests,


### PR DESCRIPTION
Instead of a stringified version of Python's version of null,
that is, "None".

The generated JSON file is consumed by the remote test runner,
and given that the failure reason is a valid string, it's shown
in the Human UI.

Reference: https://trello.com/c/ihTDNdov/1472-bug-remote-vm-runner-prints-none-on-pass-results
Signed-off-by: Cleber Rosa <crosa@redhat.com>