### PR TITLE
Deployment checks: update playbook to Fedora 29 and add Avocado-VT

### DIFF
--- a/selftests/deployment/README
+++ b/selftests/deployment/README
@@ -20,3 +20,8 @@ The following Ansible playbooks are available here:
  - pip-git.yml: deployment of Avocado and Avocado-VT using pip, from a
    GIT repository, on a Python virtual environment.  Tested on EL7,
    Fedora 28 and Fedora 29.
+
+ - rpm-copr.yml: deployment of Avocado and Avocado-VT using RPM, from
+   a Copr repository that follows the latest Avocado and Avocado-VT
+   from the GitHub repository master branch. Tested on EL7, Fedora 28
+   and Fedora 29.

--- a/selftests/deployment/README
+++ b/selftests/deployment/README
@@ -15,7 +15,8 @@ followed:
 
  4) Run a playbook with: ansible-playbook <PLAYBOOK_FILE_NAME>
 
-The following playbooks Ansible are available here:
+The following Ansible playbooks are available here:
 
- - pip-git.yml: deployment Avocado using pip, from a GIT repository,
-   on a Python virtual environment.
+ - pip-git.yml: deployment of Avocado and Avocado-VT using pip, from a
+   GIT repository, on a Python virtual environment.  Tested on EL7,
+   Fedora 28 and Fedora 29.

--- a/selftests/deployment/pip-git.yml
+++ b/selftests/deployment/pip-git.yml
@@ -14,6 +14,7 @@
     - include_vars: vars.yml
     - include_tasks: tasks/epel.yml
     - include_tasks: tasks/python_rpm_pkgs.yml
+    - include_tasks: tasks/virtualenv_script.yml
     - name: Temporary dir for Avocado venv
       tempfile:
         state: directory

--- a/selftests/deployment/pip-git.yml
+++ b/selftests/deployment/pip-git.yml
@@ -10,7 +10,6 @@
       # pip install "git+https://" quite obviously requires git
       - git
       - python-virtualenv
-    avocado_virtualenv_command: virtualenv-2.7
   tasks:
     - include_vars: vars.yml
     - include_tasks: tasks/epel.yml
@@ -22,7 +21,6 @@
     - name: Avocado installation via pip
       pip:
         name: "git+{{ avocado_git_url}}@{{ avocado_git_branch }}#egg={{ avocado_egg_name }}"
-        virtualenv_command: "{{ avocado_virtualenv_command }}"
         virtualenv: "{{ temporary_dir.path }}"
     - name: Avocado version
       shell: "{{ temporary_dir.path }}/bin/avocado --version"

--- a/selftests/deployment/pip-git.yml
+++ b/selftests/deployment/pip-git.yml
@@ -5,6 +5,9 @@
     avocado_git_url: https://github.com/avocado-framework/avocado.git
     avocado_git_branch: master
     avocado_egg_name: avocado-framework
+    avocado_vt_git_url: https://github.com/avocado-framework/avocado-vt.git
+    avocado_vt_git_branch: master
+    avocado_vt_egg_name: avocado-plugins-vt
     avocado_python_rpm_packages:
       - python-pip
       # pip install "git+https://" quite obviously requires git
@@ -23,6 +26,7 @@
       pip:
         name: "git+{{ avocado_git_url}}@{{ avocado_git_branch }}#egg={{ avocado_egg_name }}"
         virtualenv: "{{ temporary_dir.path }}"
+        virtualenv_site_packages: yes
     - name: Avocado version
       shell: "{{ temporary_dir.path }}/bin/avocado --version"
       changed_when: false
@@ -62,3 +66,12 @@
       pip:
         name: "git+{{ avocado_git_url}}@{{ avocado_git_branch }}#egg=avocado-framework-plugin-loader-yaml&subdirectory=optional_plugins/loader_yaml"
         virtualenv: "{{ temporary_dir.path }}"
+    - include_tasks: tasks/avocado_vt_rpm_pkgs.yml
+    - name: Avocado-VT plugin installation via pip
+      pip:
+        name: "git+{{ avocado_vt_git_url}}@{{ avocado_vt_git_branch }}#egg={{ avocado_vt_egg_name }}"
+        virtualenv: "{{ temporary_dir.path }}"
+    - name: Avocado-VT bootstrap
+      shell: "{{ temporary_dir.path }}/bin/avocado vt-bootstrap --yes-to-all --vt-skip-verify-download-assets"
+    - name: Avocado-VT test available
+      shell: "{{ temporary_dir.path }}/bin/avocado list boot"

--- a/selftests/deployment/pip-git.yml
+++ b/selftests/deployment/pip-git.yml
@@ -26,7 +26,6 @@
         virtualenv: "{{ temporary_dir.path }}"
     - name: Avocado version
       shell: "{{ temporary_dir.path }}/bin/avocado --version"
-      register: avocado_version_result
       changed_when: false
     - name: Avocado HTML report plugin installation via pip
       pip:

--- a/selftests/deployment/rpm-copr.yml
+++ b/selftests/deployment/rpm-copr.yml
@@ -1,0 +1,38 @@
+---
+- name: Installs Avocado using RPM packages from the Copr repo
+  hosts: avocado-test-deployment
+  tasks:
+    - include_vars: vars.yml
+    - include_tasks: tasks/epel.yml
+    - include_tasks: tasks/avocado_copr_repo.yml
+    - name: Install Avocado packages
+      package:
+        name: "{{ item }}"
+        state: latest
+      with_items:
+        - python2-avocado
+        - python2-avocado-plugins-glib
+        - python2-avocado-plugins-golang
+        - python2-avocado-plugins-loader-yaml
+        - python2-avocado-plugins-output-html
+        - python2-avocado-plugins-result-upload
+        - python2-avocado-plugins-runner-docker
+        - python2-avocado-plugins-runner-remote
+        - python2-avocado-plugins-runner-vm
+        - python2-avocado-plugins-varianter-cit
+        - python2-avocado-plugins-varianter-pict
+        - python2-avocado-plugins-varianter-yaml-to-mux
+    - name: Avocado version
+      shell: "avocado --version"
+      changed_when: false
+    - include_tasks: tasks/avocado_vt_rpm_pkgs.yml
+    - include_tasks: tasks/avocado_vt_copr_repo.yml
+    - name: Avocado-VT package
+      package:
+        name: python2-avocado-plugins-vt
+        state: latest
+    - name: Avocado-VT bootstrap
+      shell: avocado vt-bootstrap --yes-to-all --vt-skip-verify-download-assets
+    - name: Avocado-VT test available
+      shell: avocado list boot
+      changed_when: false

--- a/selftests/deployment/tasks/avocado_copr_repo.yml
+++ b/selftests/deployment/tasks/avocado_copr_repo.yml
@@ -1,0 +1,18 @@
+---
+    - name: Avocado EPEL Copr repo
+      yum_repository:
+        name: avocado-latest
+        description: Copr repo for avocado-latest
+        baseurl: https://copr-be.cloud.fedoraproject.org/results/@avocado/avocado-latest/epel-7-$basearch/
+        gpgcheck: no
+      when:
+        - ansible_facts['distribution_file_variety'] == "RedHat"
+        - ansible_facts['distribution_major_version'] == "7"
+    - name: Avocado Fedora Copr repo
+      yum_repository:
+        name: avocado-latest
+        description: Copr repo for avocado-latest
+        baseurl: https://copr-be.cloud.fedoraproject.org/results/@avocado/avocado-latest/fedora-$releasever-$basearch/
+        gpgcheck: no
+      when:
+        - ansible_facts['distribution'] == "Fedora"

--- a/selftests/deployment/tasks/avocado_vt_copr_repo.yml
+++ b/selftests/deployment/tasks/avocado_vt_copr_repo.yml
@@ -1,0 +1,18 @@
+---
+    - name: Avocado-VT Copr repo
+      yum_repository:
+        name: avocado-vt-latest
+        description: Copr repo for avocado-vt-latest
+        baseurl: https://copr-be.cloud.fedoraproject.org/results/@avocado/avocado-vt-latest/epel-7-$basearch/
+        gpgcheck: no
+      when:
+        - ansible_facts['distribution_file_variety'] == "RedHat"
+        - ansible_facts['distribution_major_version'] == "7"
+    - name: Avocado-VT Copr repo
+      yum_repository:
+        name: avocado-vt-latest
+        description: Copr repo for avocado-vt-latest
+        baseurl: https://copr-be.cloud.fedoraproject.org/results/@avocado/avocado-vt-latest/fedora-$releasever-$basearch/
+        gpgcheck: no
+      when:
+        - ansible_facts['distribution'] == "Fedora"

--- a/selftests/deployment/tasks/avocado_vt_rpm_pkgs.yml
+++ b/selftests/deployment/tasks/avocado_vt_rpm_pkgs.yml
@@ -1,0 +1,15 @@
+---
+  - name: Install Avocado-VT Depedencies on Red Hat (like) systems
+    package:
+      name: "{{ item }}"
+      state: latest
+    with_items:
+      - gcc
+      - nc
+      - python-netaddr
+      - python-netifaces
+      - python2-aexpect
+      - qemu-img
+      - qemu-kvm
+      - tcpdump
+    when: ansible_facts['distribution_file_variety'] == "RedHat"

--- a/selftests/deployment/tasks/epel.yml
+++ b/selftests/deployment/tasks/epel.yml
@@ -4,5 +4,5 @@
       name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
     when:
       # This should work on both RHEL, CentOS, Scientific Linux, etc
-      - ansible_distribution_file_variety == "RedHat"
-      - ansible_distribution_major_version == "7"
+      - ansible_facts['distribution_file_variety'] == "RedHat"
+      - ansible_facts['distribution_major_version'] == "7"

--- a/selftests/deployment/tasks/python_rpm_pkgs.yml
+++ b/selftests/deployment/tasks/python_rpm_pkgs.yml
@@ -4,4 +4,4 @@
       name: "{{ item }}"
       state: latest
     with_items: "{{ avocado_python_rpm_packages }}"
-    when: ansible_distribution_file_variety == "RedHat"
+    when: ansible_facts['distribution_file_variety'] == "RedHat"

--- a/selftests/deployment/tasks/python_rpm_pkgs.yml
+++ b/selftests/deployment/tasks/python_rpm_pkgs.yml
@@ -5,3 +5,14 @@
       state: latest
     with_items: "{{ avocado_python_rpm_packages }}"
     when: ansible_facts['distribution_file_variety'] == "RedHat"
+  - name: Install Python 2 Depedencies on Fedora 29 and later systems
+    package:
+      name: "{{ item }}"
+      state: latest
+    with_items:
+      - python2-pip
+      - python2-virtualenv
+      - python2-libselinux
+    when:
+       - ansible_facts['distribution'] == "Fedora"
+       - ansible_facts['distribution_major_version'] == "29"

--- a/selftests/deployment/tasks/virtualenv_script.yml
+++ b/selftests/deployment/tasks/virtualenv_script.yml
@@ -1,0 +1,9 @@
+---
+    - name: Virtualenv script for systems without one
+      copy:
+        content: "#!/usr/bin/python\nimport virtualenv\nvirtualenv.main()"
+        dest: /usr/local/bin/virtualenv
+        mode: 0775
+      when:
+        - ansible_facts['distribution'] == "Fedora"
+        - ansible_facts['distribution_major_version'] == "29"


### PR DESCRIPTION
This updates the playbooks to check the deployment on Fedora 29, and adds Avocado-VT deployment checks, given that it's a very important plugin and checks the plugin interfaces of Avocado itself.