### PR TITLE
selftests: use the proper Python version when listing tests

### DIFF
--- a/selftests/checkall
+++ b/selftests/checkall
@@ -29,10 +29,10 @@ parallel_selftests() {
     # The directories that may contain files with tests, from the Avocado core
     # and from all optional plugins
     declare -A TESTS
-    TESTS[selftests]=$(${FIND_UNITTESTS} | sort -R)
+    TESTS[selftests]=$(${PYTHON} ${FIND_UNITTESTS} | sort -R)
     for PLUGIN in $(find optional_plugins -mindepth 1 -maxdepth 1 -type d); do
         PLUGIN_BASENAME=$(basename $PLUGIN)
-        THIS_DIR_TESTS=$(${FIND_UNITTESTS} --no-base-selftests --plugin-dirs $PLUGIN_BASENAME | sort -R)
+        THIS_DIR_TESTS=$(${PYTHON} ${FIND_UNITTESTS} --no-base-selftests --plugin-dirs $PLUGIN_BASENAME | sort -R)
         if [ -n "$THIS_DIR_TESTS" ]; then
             TESTS[$PLUGIN]=${THIS_DIR_TESTS};
         fi


### PR DESCRIPTION
In the parallel execution, not honoring the Python version used
elsewhere may cause unexpected issues.  One is an error situation in
which Python 3's unittest.loader can not load an exception definition
that exists only Python 2.

Signed-off-by: Cleber Rosa <crosa@redhat.com>