### PR TITLE
Use more appropriate default name for the stored root logger stream

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -231,7 +231,8 @@ class Job(object):
                          else logging.getLevelName(name[1].upper()))
                 name = name[0]
             try:
-                logfile = os.path.join(self.logdir, name + "." +
+                logname = "log" if name == "" else name
+                logfile = os.path.join(self.logdir, logname + "." +
                                        logging.getLevelName(level))
                 handler = output.add_log_handler(name, logging.FileHandler,
                                                  logfile, level, formatter)


### PR DESCRIPTION
The log files produced for the root logger are confused with hidden
files (.INFO, .DEBUG, .WARN, .ERROR) because the root logger's name
is an empty string.

Signed-off-by: Plamen Dimitrov <pdimitrov@pevogam.com>