### PR TITLE
Selftests: pin astroid version

### DIFF
--- a/requirements-selftests.txt
+++ b/requirements-selftests.txt
@@ -5,6 +5,7 @@ Sphinx==1.7.8
 # inspektor (static and style checks)
 pylint==1.9.3; python_version <= '2.7'
 pylint==2.2.0; python_version >= '3.4'
+astroid==2.2.0; python_version >= '3.4'
 inspektor==0.5.2
 
 # mock (some unittests use it)


### PR DESCRIPTION
The pylint version in used requires a specific version (or a not
so greater version) of astroid.  When the astroid version is not
pinned, astroid version 2.2.4 currently gets installed.

Then, pylint (and thus inspektor) fails with:

  'Import' object has no attribute 'infer_name_module'

Signed-off-by: Cleber Rosa <crosa@redhat.com>