### PR TITLE
Selftests: pin pylint and astroid version

### DIFF
--- a/requirements-selftests.txt
+++ b/requirements-selftests.txt
@@ -4,7 +4,8 @@ Sphinx==1.7.8
 
 # inspektor (static and style checks)
 pylint==1.9.3; python_version <= '2.7'
-pylint==2.2.0; python_version >= '3.4'
+pylint==2.3.0; python_version >= '3.4'
+astroid==2.2.0; python_version >= '3.4'
 inspektor==0.5.2
 
 # mock (some unittests use it)


### PR DESCRIPTION
The pylint version in use requires a specific version (or a not
so greater version) of astroid.  When the astroid version is not
pinned, astroid version 2.2.4 currently gets installed.

Then, pylint (and thus inspektor) fails with:

  'Import' object has no attribute 'infer_name_module'

Let's bump the pylint version (already pinned) and pin a compatible
astroid version too.

Signed-off-by: Cleber Rosa <crosa@redhat.com>