### PR TITLE
Travis CI: bump distro from Trusty to Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 
 matrix:


### PR DESCRIPTION
So that we can start testing newer Python versions and more
up to date platforms.

Signed-off-by: Cleber Rosa <crosa@redhat.com>