### PR TITLE
[LTS] Travis CI: add 69lts to the list of branches to be checked

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ branches:
     only:
         - master
         - 52lts
+        - 69lts
 
 cache:
     directories:


### PR DESCRIPTION
This basically means that any pushes to the 69lts branch will also
generate a new Travis CI job.

Signed-off-by: Cleber Rosa <crosa@redhat.com>