### PR TITLE
Drop Python 2 [v3]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ matrix:
     - python: "nightly"
 
 python:
-    - "2.7"
     - "3.4"
     - "3.5"
     - "3.6"

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ Avocado is a set of tools and libraries to help with automated testing.
 
 One can call it a test framework with benefits.  Native tests are
 written in Python and they follow the unittest
-(https://docs.python.org/2.7/library/unittest.html) pattern, but any
+(https://docs.python.org/3.6/library/unittest.html) pattern, but any
 executable can serve as a test.
 
 Avocado is composed of:
@@ -44,8 +44,8 @@ Installing with standard Python tools
 -------------------------------------
 
 The simplest installation method is through ``pip``.  On most POSIX
-systems with Python 2.7 and ``pip`` available, installation can be
-performed with a single command::
+systems with Python 3.4 (or later) and ``pip`` available, installation
+can be performed with a single command::
 
   pip install --user avocado-framework
 
@@ -60,7 +60,7 @@ If you want even more isolation, Avocado can also be installed in a
 Python virtual environment. with no additional steps besides creating
 and activating the "venv" itself::
 
-  python -m virtualenv /path/to/new/virtual_environment
+  python -m venv /path/to/new/virtual_environment
   . /path/to/new/virtual_environment/bin/activate
   pip install avocado-framework
 

--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -31,8 +31,6 @@ import sys
 import time
 import tempfile
 
-from six.moves import xrange as range
-
 from . import job_id
 from . import settings
 from . import exit_codes

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -27,9 +27,6 @@ import tempfile
 import time
 import traceback
 
-from six import iteritems
-from six.moves import xrange as range
-
 from . import version
 from . import data_dir
 from . import dispatcher
@@ -260,7 +257,7 @@ class Job(object):
     def __stop_job_logging(self):
         if self._stdout_stderr:
             sys.stdout, sys.stderr = self._stdout_stderr
-        for handler, loggers in iteritems(self.__logging_handlers):
+        for handler, loggers in self.__logging_handlers.items():
             for logger in loggers:
                 logging.getLogger(logger).removeHandler(handler)
 

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -25,7 +25,6 @@ import shlex
 import sys
 
 from enum import Enum
-from six import string_types, iteritems
 
 from . import data_dir
 from . import output
@@ -229,7 +228,7 @@ class TestLoaderProxy(object):
             # Using __func__ to avoid problem with different term_supp instances
             healthy_func = getattr(output.TERM_SUPPORT.healthy_str, '__func__')
             types = [mapping[_[0]]
-                     for _ in iteritems(plugin.get_decorator_mapping())
+                     for _ in plugin.get_decorator_mapping().items()
                      if _[1].__func__ is healthy_func]
             return [name + '.' + _ for _ in types]
 
@@ -390,7 +389,7 @@ class TestLoaderProxy(object):
             test_path = test_parameters.pop('modulePath')
         else:
             test_path = None
-        if isinstance(test_class, string_types):
+        if isinstance(test_class, str):
             module_name = os.path.basename(test_path).split('.')[0]
             test_module_dir = os.path.abspath(os.path.dirname(test_path))
             # Tests with local dir imports need this
@@ -614,13 +613,13 @@ class FileLoader(TestLoader):
                 # Instrumented tests are defined as string and loaded at the
                 # execution time.
                 for tst in tests:
-                    if not isinstance(tst[0], string_types):
+                    if not isinstance(tst[0], str):
                         return None
             else:
-                test_class = next(key for key, value in iteritems(mapping)
+                test_class = next(key for key, value in mapping.items()
                                   if value == self.test_type)
                 for tst in tests:
-                    if (isinstance(tst[0], string_types) or
+                    if (isinstance(tst[0], str) or
                             not issubclass(tst[0], test_class)):
                         return None
         return tests
@@ -687,7 +686,7 @@ class FileLoader(TestLoader):
         result = []
         class_methods = safeloader.find_class_and_methods(test_path,
                                                           _RE_UNIT_TEST)
-        for klass, methods in iteritems(class_methods):
+        for klass, methods in class_methods.items():
             if klass in disabled:
                 continue
             if test_path.endswith(".py"):
@@ -725,7 +724,7 @@ class FileLoader(TestLoader):
             if avocado_tests:
                 test_factories = []
                 for test_class, info in avocado_tests.items():
-                    if isinstance(test_class, string_types):
+                    if isinstance(test_class, str):
                         for test_method, tags in info:
                             name = test_name + \
                                 ':%s.%s' % (test_class, test_method)

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -22,8 +22,6 @@ import re
 import sys
 import traceback
 
-from six import string_types, iterkeys
-
 from . import exit_codes
 from ..utils import path as utils_path
 from .settings import settings
@@ -433,7 +431,7 @@ def reconfigure(args):
             disable_log_handler(LOG_UI.getChild("debug"))
 
     # Add custom loggers
-    for name in [_ for _ in enabled if _ not in iterkeys(BUILTIN_STREAMS)]:
+    for name in [_ for _ in enabled if _ not in BUILTIN_STREAMS]:
         stream_level = re.split(r'(?<!\\):', name, maxsplit=1)
         name = stream_level[0]
         if len(stream_level) == 1:
@@ -569,11 +567,11 @@ def add_log_handler(logger, klass=logging.StreamHandler, stream=sys.stdout,
     :param level: Log level (defaults to `INFO``)
     :param fmt: Logging format (defaults to ``%(name)s: %(message)s``)
     """
-    if isinstance(logger, string_types):
+    if isinstance(logger, str):
         logger = logging.getLogger(logger)
     handler = klass(stream)
     handler.setLevel(level)
-    if isinstance(fmt, string_types):
+    if isinstance(fmt, str):
         fmt = logging.Formatter(fmt=fmt)
     handler.setFormatter(fmt)
     logger.addHandler(handler)
@@ -582,7 +580,7 @@ def add_log_handler(logger, klass=logging.StreamHandler, stream=sys.stdout,
 
 
 def disable_log_handler(logger):
-    if isinstance(logger, string_types):
+    if isinstance(logger, str):
         logger = logging.getLogger(logger)
     # Handlers might be reused elsewhere, can't delete them
     while logger.handlers:

--- a/avocado/core/parameters.py
+++ b/avocado/core/parameters.py
@@ -18,9 +18,6 @@ Module related to test parameters
 import logging
 import re
 
-from six import iterkeys, iteritems
-from six.moves import xrange as range
-
 
 class NoMatchError(KeyError):
     pass
@@ -62,9 +59,9 @@ class AvocadoParams(object):
         self._logger_name = logger_name
 
     def __eq__(self, other):
-        if set(iterkeys(self.__dict__)) != set(iterkeys(other.__dict__)):
+        if set(self.__dict__) != set(other.__dict__):
             return False
-        for attr in iterkeys(self.__dict__):
+        for attr in self.__dict__:
             if (getattr(self, attr) != getattr(other, attr)):
                 return False
         return True
@@ -265,5 +262,5 @@ class AvocadoParam(object):
         which generates lots of duplicate entries due to inherited values.
         """
         for leaf in self._leaves:
-            for key, value in iteritems(leaf.environment):
+            for key, value in leaf.environment.items():
                 yield (leaf.environment.origin[key].path, key, value)

--- a/avocado/core/parser.py
+++ b/avocado/core/parser.py
@@ -18,8 +18,6 @@ Avocado application command line parsing.
 
 import argparse
 
-from six import iteritems
-
 from . import exit_codes
 from . import varianter
 from . import settings
@@ -84,8 +82,8 @@ class Parser(object):
         self.application.add_argument('--config', metavar='CONFIG_FILE',
                                       nargs='?',
                                       help='Use custom configuration from a file')
-        streams = (['"%s": %s' % _ for _ in iteritems(BUILTIN_STREAMS)] +
-                   ['"%s": %s' % _ for _ in iteritems(BUILTIN_STREAM_SETS)])
+        streams = (['"%s": %s' % _ for _ in BUILTIN_STREAMS.items()] +
+                   ['"%s": %s' % _ for _ in BUILTIN_STREAM_SETS.items()])
         streams = "; ".join(streams)
         self.application.add_argument('--show', action="store",
                                       type=lambda value: value.split(","),

--- a/avocado/core/settings.py
+++ b/avocado/core/settings.py
@@ -27,7 +27,6 @@ except ImportError:
 from pkg_resources import resource_filename
 from pkg_resources import resource_isdir
 from pkg_resources import resource_listdir
-from six import string_types
 from stevedore import ExtensionManager
 
 from ..utils import path
@@ -97,7 +96,7 @@ def convert_value_type(value, value_type):
     except Exception:
         sval = value
 
-    if isinstance(value_type, string_types):
+    if isinstance(value_type, str):
         if value_type == 'str':
             value_type = str
         elif value_type == 'bool':

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -30,7 +30,6 @@ import time
 import unittest
 
 from difflib import unified_diff
-from six import string_types, iteritems
 
 from . import data_dir
 from . import defaults
@@ -130,7 +129,7 @@ class TestID(object):
         return repr(str(self))
 
     def __eq__(self, other):
-        if isinstance(other, string_types):
+        if isinstance(other, str):
             return str(self) == other
         else:
             return self.__dict__ == other.__dict__
@@ -710,7 +709,7 @@ class Test(unittest.TestCase, TestData):
             sys.stderr.rm_logger(LOG_JOB.getChild("stderr"))
         if isinstance(sys.stdout, output.LoggingFile):
             sys.stdout.rm_logger(LOG_JOB.getChild("stdout"))
-        for name, handler in iteritems(self._logging_handlers):
+        for name, handler in self._logging_handlers.items():
             logging.getLogger(name).removeHandler(handler)
 
     def _record_reference(self, produced_file_path, reference_file_name):
@@ -848,7 +847,7 @@ class Test(unittest.TestCase, TestData):
                 test_exception = details
                 self.log.debug("Local variables:")
                 local_vars = inspect.trace()[1][0].f_locals
-                for key, value in iteritems(local_vars):
+                for key, value in local_vars.items():
                     self.log.debug(' -> %s %s: %s', key, type(value), value)
         finally:
             try:

--- a/avocado/core/varianter.py
+++ b/avocado/core/varianter.py
@@ -21,8 +21,6 @@ Base classes for implementing the varianter interface
 
 import hashlib
 
-from six import iteritems, itervalues
-
 from . import tree
 from . import dispatcher
 from . import output
@@ -81,7 +79,7 @@ def variant_to_str(variant, verbosity, out_args=None, debug=False):
     if verbosity:
         env = set()
         for node in variant["variant"]:
-            for key, value in iteritems(node.environment):
+            for key, value in node.environment.items():
                 origin = node.environment.origin[key].path
                 env.add(("%s:%s" % (origin, key), astring.to_text(value)))
         if not env:
@@ -103,7 +101,7 @@ def dump_ivariants(ivariants):
         return (astring.to_text(node.path),
                 [(astring.to_text(node.environment.origin[key].path),
                   astring.to_text(key), value)
-                 for key, value in iteritems(node.environment)])
+                 for key, value in node.environment.items()])
 
     variants = []
     for variant in ivariants():
@@ -149,7 +147,7 @@ class FakeVariantDispatcher(object):
                                                 paths))
             env = set()
             for node in variant["variant"]:
-                for key, value in iteritems(node.environment):
+                for key, value in node.environment.items():
                     origin = node.environment.origin[key].path
                     env.add(("%s:%s" % (origin, key), astring.to_text(value)))
             if not env:
@@ -196,7 +194,7 @@ class Varianter(object):
         :param args: Parsed cmdline arguments
         """
         default_params = self.node_class()
-        for default_param in itervalues(self.default_params):
+        for default_param in self.default_params.values():
             default_params.merge(default_param)
         self._default_params = default_params
         self.default_params.clear()

--- a/optional_plugins/runner_remote/setup.py
+++ b/optional_plugins/runner_remote/setup.py
@@ -20,14 +20,11 @@ from avocado.utils import distro
 
 from setuptools import setup, find_packages
 
-if sys.version_info[0] == 3:
-    fabric = 'Fabric3'
-else:
-    fabric = 'fabric>=1.5.4,<2.0.0'
 detected_distro = distro.detect()
 if detected_distro.name == 'fedora' and int(detected_distro.version) >= 29:
     fabric = 'Fabric3>=1.1.4,<2.0.0'
-
+else:
+    fabric = 'Fabric3'
 
 setup(name='avocado-framework-plugin-runner-remote',
       description='Avocado Runner for Remote Execution',

--- a/optional_plugins/runner_remote/tests/test_remote.py
+++ b/optional_plugins/runner_remote/tests/test_remote.py
@@ -3,12 +3,7 @@ import glob
 import os
 import shutil
 import tempfile
-import unittest
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+import unittest.mock
 
 from avocado.core.job import Job
 from avocado.core import exit_codes, version
@@ -75,25 +70,25 @@ class RemoteTestRunnerTest(unittest.TestCase):
             job.setup()
             runner = avocado_runner_remote.RemoteTestRunner(job, job.result)
             return_value = (True, (version.MAJOR, version.MINOR))
-            runner.check_remote_avocado = mock.Mock(return_value=return_value)
+            runner.check_remote_avocado = unittest.mock.Mock(return_value=return_value)
 
             # These are mocked at their source, and will prevent fabric from
             # trying to contact remote hosts
-            with mock.patch('avocado_runner_remote.Remote'):
+            with unittest.mock.patch('avocado_runner_remote.Remote'):
                 runner.remote = avocado_runner_remote.Remote(job_args.remote_hostname)
 
                 # This is the result that the run_suite() will get from remote.run
                 remote_run_result = process.CmdResult()
                 remote_run_result.stdout = JSON_RESULTS
                 remote_run_result.exit_status = 0
-                runner.remote.run = mock.Mock(return_value=remote_run_result)
+                runner.remote.run = unittest.mock.Mock(return_value=remote_run_result)
 
                 # We have to fake the uncompressing and removal of the zip
                 # archive that was never generated on the "remote" end
                 # This test could be expand by mocking creating an actual
                 # zip file instead, but it's really overkill
-                with mock.patch('avocado_runner_remote.archive.uncompress'):
-                    with mock.patch('avocado_runner_remote.os.remove'):
+                with unittest.mock.patch('avocado_runner_remote.archive.uncompress'):
+                    with unittest.mock.patch('avocado_runner_remote.os.remove'):
                         runner.run_suite(None, None, 61)
 
             # The job was created with dry_run so it should have a zeroed id

--- a/optional_plugins/runner_vm/tests/test_vm.py
+++ b/optional_plugins/runner_vm/tests/test_vm.py
@@ -1,10 +1,6 @@
 import argparse
 import shutil
-import unittest
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+import unittest.mock
 
 from avocado.core.job import Job
 import avocado_runner_vm
@@ -20,8 +16,8 @@ class _FakeVM(avocado_runner_vm.VM):
     def __init__(self):  # pylint: disable=W0231
         # don't call avocado_runner_vm.VM.__init__
         self.snapshot = True
-        self.domain = mock.Mock()
-        self.domain.isActive = mock.Mock(return_value=True)
+        self.domain = unittest.mock.Mock()
+        self.domain.isActive = unittest.mock.Mock(return_value=True)
 
 
 class VMTestRunnerSetup(unittest.TestCase):
@@ -30,10 +26,10 @@ class VMTestRunnerSetup(unittest.TestCase):
 
     def test_setup(self):
         mock_vm = _FakeVM()
-        mock_vm.start = mock.Mock(return_value=True)
-        mock_vm.create_snapshot = mock.Mock()
-        mock_vm.stop = mock.Mock()
-        mock_vm.restore_snapshot = mock.Mock()
+        mock_vm.start = unittest.mock.Mock(return_value=True)
+        mock_vm.create_snapshot = unittest.mock.Mock()
+        mock_vm.stop = unittest.mock.Mock()
+        mock_vm.restore_snapshot = unittest.mock.Mock()
         job_args = argparse.Namespace(test_result_total=1,
                                       vm_domain='domain',
                                       vm_username='username',
@@ -54,8 +50,8 @@ class VMTestRunnerSetup(unittest.TestCase):
         try:
             job = Job(job_args)
             job.setup()
-            with mock.patch('avocado_runner_vm.vm_connect',
-                            return_value=mock_vm):
+            with unittest.mock.patch('avocado_runner_vm.vm_connect',
+                                     return_value=mock_vm):
                 # VMTestRunner()
                 runner = avocado_runner_vm.VMTestRunner(job, None)
                 runner.setup()

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -26,26 +26,11 @@
 # enabled by default.
 %global with_tests 1
 
-%if 0%{?rhel}
-%global with_python3 0
-%else
-%global with_python3 1
-%endif
-
 # Python 3 version of Fabric package is new starting with Fedora 29
-%if %{with_python3} && 0%{?fedora} >= 29
+%if 0%{?fedora} >= 29
 %global with_python3_fabric 1
 %else
 %global with_python3_fabric 0
-%endif
-
-# Python2 binary packages are being removed
-# See https://fedoraproject.org/wiki/Changes/Mass_Python_2_Package_Removal
-# python2-resultsdb_api package has been removed in F30
-%if (0%{?fedora} && 0%{?fedora} <= 29) || (0%{?rhel} && 0%{?rhel} <= 7)
-%global with_python2_resultsdb 1
-%else
-%global with_python2_resultsdb 0
 %endif
 
 # The Python dependencies are already tracked by the python2
@@ -68,11 +53,6 @@ Source0: https://github.com/avocado-framework/%{srcname}/archive/%{commit}.tar.g
 BuildArch: noarch
 BuildRequires: procps-ng
 BuildRequires: kmod
-%if 0%{?fedora} >= 29
-BuildRequires: python2-fabric3
-%else
-BuildRequires: fabric
-%endif
 %if %{with_python3_fabric}
 BuildRequires: python3-fabric3
 %endif
@@ -80,46 +60,6 @@ BuildRequires: python3-fabric3
 BuildRequires: glibc-all-langpacks
 %endif
 
-%if 0%{?rhel} == 7
-BuildRequires: python-jinja2
-BuildRequires: python-lxml
-BuildRequires: python-setuptools
-BuildRequires: python-stevedore
-BuildRequires: python-enum34
-BuildRequires: python2-aexpect
-BuildRequires: python2-devel
-BuildRequires: python2-docutils
-BuildRequires: python2-mock
-BuildRequires: python2-psutil
-BuildRequires: python2-requests
-BuildRequires: python2-six
-BuildRequires: python2-sphinx
-BuildRequires: yum
-%else
-BuildRequires: python2-jinja2
-BuildRequires: python2-aexpect
-BuildRequires: python2-devel
-BuildRequires: python2-docutils
-BuildRequires: python2-enum34
-BuildRequires: python2-lxml
-BuildRequires: python2-mock
-BuildRequires: python2-psutil
-BuildRequires: python2-requests
-BuildRequires: python2-setuptools
-BuildRequires: python2-six
-BuildRequires: python2-sphinx
-BuildRequires: python2-stevedore
-%endif
-%if 0%{?fedora} && 0%{?fedora} <= 29
-# Python2 binary packages are being removed
-# See https://fedoraproject.org/wiki/Changes/Mass_Python_2_Package_Removal
-BuildRequires: python2-pycdlib
-%endif
-%if %{with_python2_resultsdb}
-BuildRequires: python2-resultsdb_api
-%endif
-
-%if %{with_python3}
 BuildRequires: python3-jinja2
 BuildRequires: python3-aexpect
 BuildRequires: python3-devel
@@ -129,11 +69,9 @@ BuildRequires: python3-psutil
 BuildRequires: python3-requests
 BuildRequires: python3-resultsdb_api
 BuildRequires: python3-setuptools
-BuildRequires: python3-six
 BuildRequires: python3-sphinx
 BuildRequires: python3-stevedore
 BuildRequires: python3-pycdlib
-%endif
 
 %if %{with_tests}
 BuildRequires: genisoimage
@@ -141,61 +79,18 @@ BuildRequires: libcdio
 BuildRequires: libvirt-python
 BuildRequires: perl-Test-Harness
 BuildRequires: psmisc
-%if 0%{?rhel}
-BuildRequires: PyYAML
-BuildRequires: python-netifaces
-%else
-BuildRequires: python2-yaml
-BuildRequires: python2-netifaces
-%endif
-%if %{with_python3}
 BuildRequires: python3-libvirt
 BuildRequires: python3-yaml
 BuildRequires: python3-netifaces
-%endif
 %endif
 
 %description
 Avocado is a set of tools and libraries (what people call
 these days a framework) to perform automated testing.
 
-%package -n python2-%{srcname}
-Summary: %{summary}
-Requires: %{name}-common == %{version}
-Requires: gdb
-Requires: gdb-gdbserver
-Requires: procps-ng
-Requires: pyliblzma
-%if 0%{?rhel} == 7
-Requires: python
-Requires: python-enum34
-Requires: python-setuptools
-Requires: python-six
-Requires: python-stevedore
-Requires: python2-requests
-%else
-Requires: python2
-Requires: python2-enum34
-Requires: python2-requests
-Requires: python2-setuptools
-Requires: python2-six
-Requires: python2-stevedore
-%endif
-%if 0%{?fedora} && 0%{?fedora} <= 29
-# Python2 binary packages are being removed
-# See https://fedoraproject.org/wiki/Changes/Mass_Python_2_Package_Removal
-Requires: python2-pycdlib
-%endif
-%{?python_provide:%python_provide python2-%{srcname}}
-
-%description -n python2-%{srcname}
-Avocado is a set of tools and libraries (what people call
-these days a framework) to perform automated testing.
-
-%if %{with_python3}
 %package -n python3-%{srcname}
 Summary: %{summary}
-Requires: %{name}-common == %{version}
+Requires: python3-%{srcname}-common == %{version}
 Requires: gdb
 Requires: gdb-gdbserver
 Requires: procps-ng
@@ -203,15 +98,12 @@ Requires: pyliblzma
 Requires: python3
 Requires: python3-requests
 Requires: python3-setuptools
-Requires: python3-six
 Requires: python3-stevedore
 Requires: python3-pycdlib
-%{?python_provide:%python_provide python3-%{srcname}}
 
 %description -n python3-%{srcname}
 Avocado is a set of tools and libraries (what people call
 these days a framework) to perform automated testing.
-%endif
 
 %prep
 %if 0%{?rel_build}
@@ -225,187 +117,104 @@ these days a framework) to perform automated testing.
 sed -e "s/'libvirt-python'//" -i optional_plugins/runner_vm/setup.py
 
 %build
-%if 0%{?rhel} == 7
-sed -e "s/'six>=1.10.0'/'six>=1.9.0'/" -i setup.py
-sed -e "s/'PyYAML>=4.2b2'/'PyYAML>=3.10'/" -i optional_plugins/varianter_yaml_to_mux/setup.py
-%endif
 %if 0%{?fedora} && 0%{?fedora} < 29
 sed -e "s/'PyYAML>=4.2b2'/'PyYAML>=3.12'/" -i optional_plugins/varianter_yaml_to_mux/setup.py
 %endif
-%py2_build
-%if %{with_python3}
 %py3_build
-%endif
 pushd optional_plugins/html
-%py2_build
-%if %{with_python3}
 %py3_build
-%endif
 popd
 pushd optional_plugins/runner_remote
-%py2_build
 %if %{with_python3_fabric}
 %py3_build
 %endif
 popd
 pushd optional_plugins/runner_vm
-%py2_build
 %if %{with_python3_fabric}
 %py3_build
 %endif
 popd
 pushd optional_plugins/runner_docker
-%py2_build
 %if %{with_python3_fabric}
 %py3_build
 %endif
 popd
 pushd optional_plugins/resultsdb
-%if %{with_python2_resultsdb}
-%py2_build
-%endif
-%if %{with_python3}
 %py3_build
-%endif
 popd
 pushd optional_plugins/varianter_yaml_to_mux
-%py2_build
-%if %{with_python3}
 %py3_build
-%endif
 popd
 pushd optional_plugins/loader_yaml
-%py2_build
-%if %{with_python3}
 %py3_build
-%endif
 popd
 pushd optional_plugins/golang
-%py2_build
-%if %{with_python3}
 %py3_build
-%endif
 popd
 pushd optional_plugins/varianter_pict
-%py2_build
-%if %{with_python3}
 %py3_build
-%endif
 popd
 pushd optional_plugins/varianter_cit
-%py2_build
-%if %{with_python3}
 %py3_build
-%endif
 popd
 pushd optional_plugins/result_upload
-%py2_build
-%if %{with_python3}
 %py3_build
-%endif
 popd
 pushd optional_plugins/glib
-%py2_build
-%if %{with_python3}
 %py3_build
-%endif
 popd
+# python3-docutils on Fedora 28 uses a rst2man binary with -3 prefix
+%if 0%{?fedora} == 28
+/usr/bin/rst2man-3 man/avocado.rst man/avocado.1
+/usr/bin/rst2man-3 man/avocado-rest-client.rst man/avocado-rest-client.1
+%else
 %{__make} man
+%endif
 
 %install
-%py2_install
-%{__mv} %{buildroot}%{python2_sitelib}/avocado/etc %{buildroot}
-mv %{buildroot}%{_bindir}/avocado %{buildroot}%{_bindir}/avocado-%{python2_version}
-ln -s avocado-%{python2_version} %{buildroot}%{_bindir}/avocado-2
-mv %{buildroot}%{_bindir}/avocado-rest-client %{buildroot}%{_bindir}/avocado-rest-client-%{python2_version}
-ln -s avocado-rest-client-%{python2_version} %{buildroot}%{_bindir}/avocado-rest-client-2
-%if %{with_python3}
 %py3_install
-mv %{buildroot}%{_bindir}/avocado %{buildroot}%{_bindir}/avocado-%{python3_version}
-ln -s avocado-%{python3_version} %{buildroot}%{_bindir}/avocado-3
-mv %{buildroot}%{_bindir}/avocado-rest-client %{buildroot}%{_bindir}/avocado-rest-client-%{python3_version}
-ln -s avocado-rest-client-%{python3_version} %{buildroot}%{_bindir}/avocado-rest-client-3
-# configuration is held at /etc/avocado only and part of the
-# python-avocado-common package
-%{__rm} -rf %{buildroot}%{python3_sitelib}/avocado/etc
-# ditto for libexec files
-%{__rm} -rf %{buildroot}%{python3_sitelib}/avocado/libexec
-%endif
-ln -s avocado-%{python2_version} %{buildroot}%{_bindir}/avocado
-ln -s avocado-rest-client-%{python2_version} %{buildroot}%{_bindir}/avocado-rest-client
+%{__mv} %{buildroot}%{python3_sitelib}/avocado/etc %{buildroot}
 pushd optional_plugins/html
-%py2_install
-%if %{with_python3}
 %py3_install
-%endif
 popd
 pushd optional_plugins/runner_remote
-%py2_install
 %if %{with_python3_fabric}
 %py3_install
 %endif
 popd
 pushd optional_plugins/runner_vm
-%py2_install
 %if %{with_python3_fabric}
 %py3_install
 %endif
 popd
 pushd optional_plugins/runner_docker
-%py2_install
 %if %{with_python3_fabric}
 %py3_install
 %endif
 popd
 pushd optional_plugins/resultsdb
-%if %{with_python2_resultsdb}
-%py2_install
-%endif
-%if %{with_python3}
 %py3_install
-%endif
 popd
 pushd optional_plugins/varianter_yaml_to_mux
-%py2_install
-%if %{with_python3}
 %py3_install
-%endif
 popd
 pushd optional_plugins/loader_yaml
-%py2_install
-%if %{with_python3}
 %py3_install
-%endif
 popd
 pushd optional_plugins/golang
-%py2_install
-%if %{with_python3}
 %py3_install
-%endif
 popd
 pushd optional_plugins/varianter_pict
-%py2_install
-%if %{with_python3}
 %py3_install
-%endif
 popd
 pushd optional_plugins/varianter_cit
-%py2_install
-%if %{with_python3}
 %py3_install
-%endif
 popd
 pushd optional_plugins/result_upload
-%py2_install
-%if %{with_python3}
 %py3_install
-%endif
 popd
 pushd optional_plugins/glib
-%py2_install
-%if %{with_python3}
 %py3_install
-%endif
 popd
 %{__mkdir} -p %{buildroot}%{_mandir}/man1
 %{__install} -m 0644 man/avocado.1 %{buildroot}%{_mandir}/man1/avocado.1
@@ -422,60 +231,10 @@ popd
 %{__cp} -r examples/varianter_cit %{buildroot}%{_docdir}/avocado
 find %{buildroot}%{_docdir}/avocado -type f -name '*.py' -exec %{__chmod} -c -x {} ';'
 %{__mkdir} -p %{buildroot}%{_libexecdir}/avocado
-%{__mv} %{buildroot}%{python2_sitelib}/avocado/libexec/* %{buildroot}%{_libexecdir}/avocado
+%{__mv} %{buildroot}%{python3_sitelib}/avocado/libexec/* %{buildroot}%{_libexecdir}/avocado
 
 %check
 %if %{with_tests}
-%{__python2} setup.py develop --user
-pushd optional_plugins/html
-%{__python2} setup.py develop --user
-popd
-pushd optional_plugins/runner_remote
-%{__python2} setup.py develop --user
-popd
-pushd optional_plugins/runner_vm
-%{__python2} setup.py develop --user
-popd
-pushd optional_plugins/runner_docker
-%{__python2} setup.py develop --user
-popd
-pushd optional_plugins/resultsdb
-%if %{with_python2_resultsdb}
-%{__python2} setup.py develop --user
-%endif
-popd
-pushd optional_plugins/varianter_yaml_to_mux
-%{__python2} setup.py develop --user
-popd
-pushd optional_plugins/loader_yaml
-%{__python2} setup.py develop --user
-popd
-pushd optional_plugins/golang
-%{__python2} setup.py develop --user
-popd
-pushd optional_plugins/varianter_pict
-%{__python2} setup.py develop --user
-popd
-pushd optional_plugins/varianter_cit
-%{__python2} setup.py develop --user
-popd
-pushd optional_plugins/result_upload
-%{__python2} setup.py develop --user
-popd
-pushd optional_plugins/glib
-%{__python2} setup.py develop --user
-popd
-# LANG: to make the results predictable, we pin the language
-# that is used during test execution.
-# AVOCADO_CHECK_LEVEL: package build environments have the least
-# amount of resources we have observed so far.  Let's avoid tests that
-# require too much resources or are time sensitive
-# UNITTEST_AVOCADO_CMD: the "avocado" command to be run during
-# unittests needs to be a Python specific one on Fedora >= 28.  Let's
-# use the one that was setup in the source tree by the "setup.py
-# develop --user" step and is guaranteed to be version specific.
-LANG=en_US.UTF-8 AVOCADO_CHECK_LEVEL=0 UNITTEST_AVOCADO_CMD=$HOME/.local/bin/avocado %{__python2} selftests/run
-%if %{with_python3}
 %{__python3} setup.py develop --user
 pushd optional_plugins/html
 %{__python3} setup.py develop --user
@@ -515,55 +274,23 @@ popd
 pushd optional_plugins/glib
 %{__python3} setup.py develop --user
 popd
+# LANG: to make the results predictable, we pin the language
+# that is used during test execution.
+# AVOCADO_CHECK_LEVEL: package build environments have the least
+# amount of resources we have observed so far.  Let's avoid tests that
+# require too much resources or are time sensitive
+# UNITTEST_AVOCADO_CMD: the "avocado" command to be run during
+# unittests needs to be a Python specific one on Fedora >= 28.  Let's
+# use the one that was setup in the source tree by the "setup.py
+# develop --user" step and is guaranteed to be version specific.
 LANG=en_US.UTF-8 AVOCADO_CHECK_LEVEL=0 UNITTEST_AVOCADO_CMD=$HOME/.local/bin/avocado %{__python3} selftests/run
 %endif
-%endif
 
-%files -n python2-%{srcname}
-%defattr(-,root,root,-)
-%doc README.rst LICENSE
-%{python2_sitelib}/avocado*
-%{_bindir}/avocado
-%{_bindir}/avocado-2
-%{_bindir}/avocado-%{python2_version}
-%{_bindir}/avocado-rest-client
-%{_bindir}/avocado-rest-client-2
-%{_bindir}/avocado-rest-client-%{python2_version}
-%exclude %{python2_sitelib}/avocado_result_html*
-%exclude %{python2_sitelib}/avocado_runner_remote*
-%exclude %{python2_sitelib}/avocado_runner_vm*
-%exclude %{python2_sitelib}/avocado_runner_docker*
-%exclude %{python2_sitelib}/avocado_resultsdb*
-%exclude %{python2_sitelib}/avocado_loader_yaml*
-%exclude %{python2_sitelib}/avocado_golang*
-%exclude %{python2_sitelib}/avocado_varianter_yaml_to_mux*
-%exclude %{python2_sitelib}/avocado_varianter_pict*
-%exclude %{python2_sitelib}/avocado_varianter_cit*
-%exclude %{python2_sitelib}/avocado_result_upload*
-%exclude %{python2_sitelib}/avocado_glib*
-%exclude %{python2_sitelib}/avocado_framework_plugin_result_html*
-%exclude %{python2_sitelib}/avocado_framework_plugin_runner_remote*
-%exclude %{python2_sitelib}/avocado_framework_plugin_runner_vm*
-%exclude %{python2_sitelib}/avocado_framework_plugin_runner_docker*
-%exclude %{python2_sitelib}/avocado_framework_plugin_resultsdb*
-%exclude %{python2_sitelib}/avocado_framework_plugin_varianter_yaml_to_mux*
-%exclude %{python2_sitelib}/avocado_framework_plugin_varianter_pict*
-%exclude %{python2_sitelib}/avocado_framework_plugin_varianter_cit*
-%exclude %{python2_sitelib}/avocado_framework_plugin_loader_yaml*
-%exclude %{python2_sitelib}/avocado_framework_plugin_golang*
-%exclude %{python2_sitelib}/avocado_framework_plugin_result_upload*
-%exclude %{python2_sitelib}/avocado_framework_plugin_glib*
-%exclude %{python2_sitelib}/avocado/libexec*
-%exclude %{python2_sitelib}/tests*
-
-%if %{with_python3}
 %files -n python3-%{srcname}
 %defattr(-,root,root,-)
 %doc README.rst LICENSE
-%{_bindir}/avocado-3
-%{_bindir}/avocado-%{python3_version}
-%{_bindir}/avocado-rest-client-3
-%{_bindir}/avocado-rest-client-%{python3_version}
+%{_bindir}/avocado
+%{_bindir}/avocado-rest-client
 %{python3_sitelib}/avocado*
 %exclude %{python3_sitelib}/avocado_result_html*
 %exclude %{python3_sitelib}/avocado_runner_remote*
@@ -590,15 +317,14 @@ LANG=en_US.UTF-8 AVOCADO_CHECK_LEVEL=0 UNITTEST_AVOCADO_CMD=$HOME/.local/bin/avo
 %exclude %{python3_sitelib}/avocado_framework_plugin_result_upload*
 %exclude %{python3_sitelib}/avocado_framework_plugin_glib*
 %exclude %{python3_sitelib}/tests*
-%endif
 
-%package common
+%package -n python3-%{srcname}-common
 Summary: Avocado common files
 
-%description common
+%description -n python3-%{srcname}-common
 Common files (such as configuration) for the Avocado Testing Framework.
 
-%files common
+%files -n python3-%{srcname}-common
 %{_mandir}/man1/avocado.1.gz
 %{_mandir}/man1/avocado-rest-client.1.gz
 %dir %{_sysconfdir}/avocado
@@ -619,25 +345,6 @@ Common files (such as configuration) for the Avocado Testing Framework.
 %config(noreplace)%{_sysconfdir}/avocado/scripts/job/pre.d/README
 %config(noreplace)%{_sysconfdir}/avocado/scripts/job/post.d/README
 
-%package -n python2-%{srcname}-plugins-output-html
-Summary: Avocado HTML report plugin
-Requires: python2-%{srcname} == %{version},
-%if 0%{?rhel} == 7
-Requires: python-jinja2
-%else
-Requires: python2-jinja2
-%endif
-
-%description -n python2-%{srcname}-plugins-output-html
-Adds to avocado the ability to generate an HTML report at every job results
-directory. It also gives the user the ability to write a report on an
-arbitrary filesystem location.
-
-%files -n python2-%{srcname}-plugins-output-html
-%{python2_sitelib}/avocado_result_html*
-%{python2_sitelib}/avocado_framework_plugin_result_html*
-
-%if %{with_python3}
 %package -n python3-%{srcname}-plugins-output-html
 Summary: Avocado HTML report plugin
 Requires: python3-%{srcname} == %{version}, python3-jinja2
@@ -650,24 +357,6 @@ arbitrary filesystem location.
 %files -n python3-%{srcname}-plugins-output-html
 %{python3_sitelib}/avocado_result_html*
 %{python3_sitelib}/avocado_framework_plugin_result_html*
-%endif
-
-%package -n python2-%{srcname}-plugins-runner-remote
-Summary: Avocado Runner for Remote Execution
-Requires: python2-%{srcname} == %{version}
-%if 0%{?fedora} >= 29
-Requires: python2-fabric3
-%else
-Requires: fabric
-%endif
-
-%description -n python2-%{srcname}-plugins-runner-remote
-Allows Avocado to run jobs on a remote machine, by means of an SSH
-connection.  Avocado must be previously installed on the remote machine.
-
-%files -n python2-%{srcname}-plugins-runner-remote
-%{python2_sitelib}/avocado_runner_remote*
-%{python2_sitelib}/avocado_framework_plugin_runner_remote*
 
 %if %{with_python3_fabric}
 %package -n python3-%{srcname}-plugins-runner-remote
@@ -683,21 +372,6 @@ connection.  Avocado must be previously installed on the remote machine.
 %{python3_sitelib}/avocado_runner_remote*
 %{python3_sitelib}/avocado_framework_plugin_runner_remote*
 %endif
-
-%package -n python2-%{srcname}-plugins-runner-vm
-Summary: Avocado Runner for libvirt VM Execution
-Requires: python2-%{srcname} == %{version}
-Requires: python2-%{srcname}-plugins-runner-remote == %{version}
-Requires: libvirt-python
-
-%description -n python2-%{srcname}-plugins-runner-vm
-Allows Avocado to run jobs on a libvirt based VM, by means of
-interaction with a libvirt daemon and an SSH connection to the VM
-itself.  Avocado must be previously installed on the VM.
-
-%files -n python2-%{srcname}-plugins-runner-vm
-%{python2_sitelib}/avocado_runner_vm*
-%{python2_sitelib}/avocado_framework_plugin_runner_vm*
 
 %if %{with_python3_fabric}
 %package -n python3-%{srcname}-plugins-runner-vm
@@ -716,21 +390,6 @@ itself.  Avocado must be previously installed on the VM.
 %{python3_sitelib}/avocado_framework_plugin_runner_vm*
 %endif
 
-%package -n python2-%{srcname}-plugins-runner-docker
-Summary: Avocado Runner for Execution on Docker Containers
-Requires: python2-%{srcname} == %{version}
-Requires: python2-%{srcname}-plugins-runner-remote == %{version}
-Requires: python2-aexpect
-
-%description -n python2-%{srcname}-plugins-runner-docker
-Allows Avocado to run jobs on a Docker container by interacting with a
-Docker daemon and attaching to the container itself.  Avocado must
-be previously installed on the container.
-
-%files -n python2-%{srcname}-plugins-runner-docker
-%{python2_sitelib}/avocado_runner_docker*
-%{python2_sitelib}/avocado_framework_plugin_runner_docker*
-
 %if %{with_python3_fabric}
 %package -n python3-%{srcname}-plugins-runner-docker
 Summary: Avocado Runner for Execution on Docker Containers
@@ -748,23 +407,6 @@ be previously installed on the container.
 %{python3_sitelib}/avocado_framework_plugin_runner_docker*
 %endif
 
-%if %{with_python2_resultsdb}
-%package -n python2-%{srcname}-plugins-resultsdb
-Summary: Avocado plugin to propagate job results to ResultsDB
-Requires: python2-%{srcname} == %{version}
-Requires: python2-resultsdb_api
-
-%description -n python2-%{srcname}-plugins-resultsdb
-Allows Avocado to send job results directly to a ResultsDB
-server.
-
-%files -n python2-%{srcname}-plugins-resultsdb
-%{python2_sitelib}/avocado_resultsdb*
-%{python2_sitelib}/avocado_framework_plugin_resultsdb*
-%config(noreplace)%{_sysconfdir}/avocado/conf.d/resultsdb.conf
-%endif
-
-%if %{with_python3}
 %package -n python3-%{srcname}-plugins-resultsdb
 Summary: Avocado plugin to propagate job results to ResultsDB
 Requires: python3-%{srcname} == %{version}
@@ -778,26 +420,7 @@ server.
 %{python3_sitelib}/avocado_resultsdb*
 %{python3_sitelib}/avocado_framework_plugin_resultsdb*
 %config(noreplace)%{_sysconfdir}/avocado/conf.d/resultsdb.conf
-%endif
 
-%package -n python2-%{srcname}-plugins-varianter-yaml-to-mux
-Summary: Avocado plugin to generate variants out of yaml files
-Requires: python2-%{srcname} == %{version}
-%if 0%{?rhel}
-Requires: PyYAML
-%else
-Requires: python2-yaml
-%endif
-
-%description -n python2-%{srcname}-plugins-varianter-yaml-to-mux
-Can be used to produce multiple test variants with test parameters
-defined in a yaml file(s).
-
-%files -n python2-%{srcname}-plugins-varianter-yaml-to-mux
-%{python2_sitelib}/avocado_varianter_yaml_to_mux*
-%{python2_sitelib}/avocado_framework_plugin_varianter_yaml_to_mux*
-
-%if %{with_python3}
 %package -n python3-%{srcname}-plugins-varianter-yaml-to-mux
 Summary: Avocado plugin to generate variants out of yaml files
 Requires: python3-%{srcname} == %{version}
@@ -810,21 +433,7 @@ defined in a yaml file(s).
 %files -n python3-%{srcname}-plugins-varianter-yaml-to-mux
 %{python3_sitelib}/avocado_varianter_yaml_to_mux*
 %{python3_sitelib}/avocado_framework_plugin_varianter_yaml_to_mux*
-%endif
 
-%package -n python2-%{srcname}-plugins-loader-yaml
-Summary: Avocado Plugin that loads tests from YAML files
-Requires: python2-%{srcname}-plugins-varianter-yaml-to-mux == %{version}
-
-%description -n python2-%{srcname}-plugins-loader-yaml
-Can be used to produce a test suite from definitions in a YAML file,
-similar to the one used in the yaml_to_mux varianter plugin.
-
-%files -n python2-%{srcname}-plugins-loader-yaml
-%{python2_sitelib}/avocado_loader_yaml*
-%{python2_sitelib}/avocado_framework_plugin_loader_yaml*
-
-%if %{with_python3}
 %package -n python3-%{srcname}-plugins-loader-yaml
 Summary: Avocado Plugin that loads tests from YAML files
 Requires: python3-%{srcname}-plugins-varianter-yaml-to-mux == %{version}
@@ -836,22 +445,7 @@ similar to the one used in the yaml_to_mux varianter plugin.
 %files -n python3-%{srcname}-plugins-loader-yaml
 %{python3_sitelib}/avocado_loader_yaml*
 %{python3_sitelib}/avocado_framework_plugin_loader_yaml*
-%endif
 
-%package -n python2-%{srcname}-plugins-golang
-Summary: Avocado Plugin for Execution of golang tests
-Requires: python2-%{srcname} == %{version}
-Requires: golang
-
-%description -n python2-%{srcname}-plugins-golang
-Allows Avocado to list golang tests, and if golang is installed,
-also run them.
-
-%files -n python2-%{srcname}-plugins-golang
-%{python2_sitelib}/avocado_golang*
-%{python2_sitelib}/avocado_framework_plugin_golang*
-
-%if %{with_python3}
 %package -n python3-%{srcname}-plugins-golang
 Summary: Avocado Plugin for Execution of golang tests
 Requires: python3-%{srcname} == %{version}
@@ -864,21 +458,7 @@ also run them.
 %files -n python3-%{srcname}-plugins-golang
 %{python3_sitelib}/avocado_golang*
 %{python3_sitelib}/avocado_framework_plugin_golang*
-%endif
 
-%package -n python2-%{srcname}-plugins-varianter-pict
-Summary: Varianter with combinatorial capabilities by PICT
-Requires: python2-%{srcname} == %{version}
-
-%description -n python2-%{srcname}-plugins-varianter-pict
-This plugin uses a third-party tool to provide variants created by
-Pair-Wise algorithms, also known as Combinatorial Independent Testing.
-
-%files -n python2-%{srcname}-plugins-varianter-pict
-%{python2_sitelib}/avocado_varianter_pict*
-%{python2_sitelib}/avocado_framework_plugin_varianter_pict*
-
-%if %{with_python3}
 %package -n python3-%{srcname}-plugins-varianter-pict
 Summary: Varianter with combinatorial capabilities by PICT
 Requires: python3-%{srcname} == %{version}
@@ -890,22 +470,7 @@ Pair-Wise algorithms, also known as Combinatorial Independent Testing.
 %files -n python3-%{srcname}-plugins-varianter-pict
 %{python3_sitelib}/avocado_varianter_pict*
 %{python3_sitelib}/avocado_framework_plugin_varianter_pict*
-%endif
 
-%package -n python2-%{srcname}-plugins-varianter-cit
-Summary: Varianter with Combinatorial Independent Testing capabilities
-Requires: python2-%{srcname} == %{version}
-
-%description -n python2-%{srcname}-plugins-varianter-cit
-A varianter plugin that generates variants using Combinatorial
-Independent Testing (AKA Pair-Wise) algorithm developed in
-collaboration with CVUT Prague.
-
-%files -n python2-%{srcname}-plugins-varianter-cit
-%{python2_sitelib}/avocado_varianter_cit*
-%{python2_sitelib}/avocado_framework_plugin_varianter_cit*
-
-%if %{with_python3}
 %package -n python3-%{srcname}-plugins-varianter-cit
 Summary: Varianter with Combinatorial Independent Testing capabilities
 Requires: python3-%{srcname} == %{version}
@@ -918,22 +483,7 @@ collaboration with CVUT Prague.
 %files -n python3-%{srcname}-plugins-varianter-cit
 %{python3_sitelib}/avocado_varianter_cit*
 %{python3_sitelib}/avocado_framework_plugin_varianter_cit*
-%endif
 
-%package -n python2-%{srcname}-plugins-result-upload
-Summary: Avocado Plugin to propagate Job results to a remote host
-Requires: python2-%{srcname} == %{version}
-
-%description -n python2-%{srcname}-plugins-result-upload
-This optional plugin is intended to upload the Avocado Job results to
-a dedicated sever.
-
-%files -n python2-%{srcname}-plugins-result-upload
-%{python2_sitelib}/avocado_result_upload*
-%{python2_sitelib}/avocado_framework_plugin_result_upload*
-%config(noreplace)%{_sysconfdir}/avocado/conf.d/result_upload.conf
-
-%if %{with_python3}
 %package -n python3-%{srcname}-plugins-result-upload
 Summary: Avocado Plugin to propagate Job results to a remote host
 Requires: python3-%{srcname} == %{version}
@@ -946,21 +496,7 @@ a dedicated sever.
 %{python3_sitelib}/avocado_result_upload*
 %{python3_sitelib}/avocado_framework_plugin_result_upload*
 %config(noreplace)%{_sysconfdir}/avocado/conf.d/result_upload.conf
-%endif
 
-%package -n python2-%{srcname}-plugins-glib
-Summary: Avocado Plugin for Execution of GLib Test Framework tests
-Requires: python2-%{srcname} == %{version}
-
-%description -n python2-%{srcname}-plugins-glib
-This optional plugin is intended to list and run tests written in the
-GLib Test Framework.
-
-%files -n python2-%{srcname}-plugins-glib
-%{python2_sitelib}/avocado_glib*
-%{python2_sitelib}/avocado_framework_plugin_glib*
-
-%if %{with_python3}
 %package -n python3-%{srcname}-plugins-glib
 Summary: Avocado Plugin for Execution of GLib Test Framework tests
 Requires: python3-%{srcname} == %{version}
@@ -972,18 +508,17 @@ GLib Test Framework.
 %files -n python3-%{srcname}-plugins-glib
 %{python3_sitelib}/avocado_glib*
 %{python3_sitelib}/avocado_framework_plugin_glib*
-%endif
 
-%package examples
+%package -n python3-%{srcname}-examples
 Summary: Avocado Test Framework Example Tests
-Requires: %{name} == %{version}
+Requires: python3-%{srcname} == %{version}
 
-%description examples
+%description -n python3-%{srcname}-examples
 The set of example tests present in the upstream tree of the Avocado framework.
 Some of them are used as functional tests of the framework, others serve as
 examples of how to write tests on your own.
 
-%files examples
+%files -n python3-%{srcname}-examples
 %dir %{_docdir}/avocado
 %{_docdir}/avocado/gdb-prerun-scripts
 %{_docdir}/avocado/plugins
@@ -994,15 +529,15 @@ examples of how to write tests on your own.
 %{_docdir}/avocado/varianter_pict
 %{_docdir}/avocado/varianter_cit
 
-%package bash
+%package -n python3-%{srcname}-bash
 Summary: Avocado Test Framework Bash Utilities
-Requires: %{name} == %{version}
+Requires: python3-%{srcname} == %{version}
 
-%description bash
+%description -n python3-%{srcname}-bash
 A small set of utilities to interact with Avocado from the Bourne
 Again Shell code (and possibly other similar shells).
 
-%files bash
+%files -n python3-%{srcname}-bash
 %{_libexecdir}/avocado*
 
 %changelog

--- a/requirements-selftests.txt
+++ b/requirements-selftests.txt
@@ -3,16 +3,9 @@
 Sphinx==1.7.8
 
 # inspektor (static and style checks)
-pylint==1.9.3; python_version <= '2.7'
-pylint==2.3.0; python_version >= '3.4'
-astroid==2.2.0; python_version >= '3.4'
+pylint==2.3.0
+astroid==2.2.0
 inspektor==0.5.2
-
-# mock (some unittests use it)
-mock>=2.0.0; python_version <= '2.7'
-
-# six
-six==1.11.0
 
 # funcsigs
 funcsigs>=0.4

--- a/selftests/__init__.py
+++ b/selftests/__init__.py
@@ -2,12 +2,7 @@ import logging
 import os
 import pkg_resources
 import sys
-import unittest
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+import unittest.mock
 
 
 #: The base directory for the avocado source tree
@@ -22,19 +17,15 @@ def recent_mock():
     '''
     Checks if a recent and capable enough mock library is available
 
-    On Python 2.7, it requires at least mock version 2.0.  On Python 3,
-    mock from the standard library is used, but Python 3.6 or later is
-    required.
+    On Python 3, mock from the standard library is used, but Python
+    3.6 or later is required.
 
     Also, it assumes that on a future Python major version, functionality
     won't regress.
     '''
-    if sys.version_info[0] < 3:
-        major = int(mock.__version__.split('.')[0])
-        return major >= 2
-    elif sys.version_info[0] == 3:
+    if sys.version_info[0] == 3:
         return sys.version_info[1] >= 6
-    return True
+    return sys.version_info[0] > 3
 
 
 def python_module_available(module_name):

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -12,20 +12,13 @@ import xml.dom.minidom
 import zipfile
 import unittest
 import psutil
-
-try:
-    from io import BytesIO
-except ImportError:
-    from BytesIO import BytesIO
+from io import BytesIO
 
 try:
     from lxml import etree
     SCHEMA_CAPABLE = True
 except ImportError:
     SCHEMA_CAPABLE = False
-
-from six import iteritems
-from six.moves import xrange as range
 
 from avocado.core import exit_codes
 from avocado.utils import astring
@@ -185,7 +178,7 @@ class RunnerOperationTest(unittest.TestCase):
                    'data_dir': os.path.join(base_dir, 'data'),
                    'logs_dir': os.path.join(base_dir, 'logs')}
         config = '[datadir.paths]\n'
-        for key, value in iteritems(mapping):
+        for key, value in mapping.items():
             if not os.path.isdir(value):
                 os.mkdir(value)
             config += "%s = %s\n" % (key, value)

--- a/selftests/functional/test_lv_utils.py
+++ b/selftests/functional/test_lv_utils.py
@@ -12,8 +12,6 @@ import tempfile
 import time
 import unittest
 
-from six.moves import xrange as range
-
 from avocado.utils import process
 from avocado.utils import lv_utils
 from avocado.utils import linux_modules

--- a/selftests/functional/test_thirdparty_bugs.py
+++ b/selftests/functional/test_thirdparty_bugs.py
@@ -1,8 +1,7 @@
 import re
 import json
 import unittest
-
-from six.moves.urllib.error import URLError
+from urllib.error import URLError
 
 from avocado.utils import astring
 from avocado.utils import download

--- a/selftests/functional/test_utils.py
+++ b/selftests/functional/test_utils.py
@@ -8,8 +8,6 @@ import tempfile
 import time
 import unittest
 
-from six.moves import xrange as range
-
 from avocado.utils.filelock import FileLock
 from avocado.utils.stacktrace import prepare_exc_info
 from avocado.utils import process

--- a/selftests/unit/test_archive.py
+++ b/selftests/unit/test_archive.py
@@ -5,8 +5,6 @@ import shutil
 import sys
 import random
 
-from six.moves import xrange as range
-
 from avocado.utils import archive
 from avocado.utils import crypto
 from avocado.utils import data_factory

--- a/selftests/unit/test_data_structures.py
+++ b/selftests/unit/test_data_structures.py
@@ -1,7 +1,5 @@
 import unittest
 
-from six.moves import xrange as range
-
 from avocado.utils import data_structures
 
 

--- a/selftests/unit/test_datadir.py
+++ b/selftests/unit/test_datadir.py
@@ -1,14 +1,7 @@
-import unittest
 import os
 import shutil
 import tempfile
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
-
-from six.moves import xrange as range
+import unittest.mock
 
 from avocado.core import settings
 
@@ -51,7 +44,7 @@ class DataDirTest(unittest.TestCase):
         stg = settings.Settings(self.config_file_path)
         # Trick the module to think we're on a system wide install
         stg.intree = False
-        with mock.patch('avocado.core.data_dir.settings.settings', stg):
+        with unittest.mock.patch('avocado.core.data_dir.settings.settings', stg):
             from avocado.core import data_dir
             self.assertFalse(data_dir.settings.settings.intree)
             for key in self.mapping.keys():
@@ -66,8 +59,8 @@ class DataDirTest(unittest.TestCase):
         unique results.
         """
         from avocado.core import data_dir
-        with mock.patch('avocado.core.data_dir.time.strftime',
-                        return_value="date_would_go_here"):
+        with unittest.mock.patch('avocado.core.data_dir.time.strftime',
+                                 return_value="date_would_go_here"):
             logdir = os.path.join(self.mapping['base_dir'], "foor", "bar", "baz")
             path_prefix = os.path.join(logdir, "job-date_would_go_here-")
             uid = "1234567890"*4
@@ -96,7 +89,7 @@ class DataDirTest(unittest.TestCase):
         (self.alt_mapping,
          self.alt_config_file_path) = self._get_temporary_dirs_mapping_and_config()
         stg = settings.Settings(self.alt_config_file_path)
-        with mock.patch('avocado.core.data_dir.settings.settings', stg):
+        with unittest.mock.patch('avocado.core.data_dir.settings.settings', stg):
             from avocado.core import data_dir
             for key in self.alt_mapping.keys():
                 data_dir_func = getattr(data_dir, 'get_%s' % key)

--- a/selftests/unit/test_distro.py
+++ b/selftests/unit/test_distro.py
@@ -1,10 +1,5 @@
 import re
-import unittest
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+import unittest.mock
 
 from avocado.utils import distro
 
@@ -67,8 +62,8 @@ class ProbeTest(unittest.TestCase):
             CHECK_FILE_DISTRO_NAME = distro_name
 
         my_probe = MyProbe()
-        with mock.patch('avocado.utils.distro.os.path.exists',
-                        return_value=True) as mocked:
+        with unittest.mock.patch('avocado.utils.distro.os.path.exists',
+                                 return_value=True) as mocked:
             probed_distro_name = my_probe.name_for_file()
             mocked.assert_called_once_with(distro_file)
         self.assertEqual(distro_name, probed_distro_name)

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -2,12 +2,7 @@ import argparse
 import os
 import shutil
 import tempfile
-import unittest
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+import unittest.mock
 
 from avocado.core import data_dir
 from avocado.core import exceptions
@@ -226,8 +221,8 @@ class JobTest(unittest.TestCase):
 
     def test_job_no_base_logdir(self):
         args = argparse.Namespace()
-        with mock.patch('avocado.core.job.data_dir.get_logs_dir',
-                        return_value=self.tmpdir):
+        with unittest.mock.patch('avocado.core.job.data_dir.get_logs_dir',
+                                 return_value=self.tmpdir):
             self.job = job.Job(args)
             self.job.setup()
         self.assertTrue(os.path.isdir(self.job.logdir))

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -2,12 +2,7 @@ import os
 import shutil
 import stat
 import tempfile
-import unittest
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+import unittest.mock
 
 from avocado.core import test
 from avocado.core import loader
@@ -476,7 +471,7 @@ class LoaderTest(unittest.TestCase):
     def test_list_raising_exception(self):
         simple_test = script.TemporaryScript('simpletest.py', PY_SIMPLE_TEST)
         simple_test.save()
-        with mock.patch('avocado.core.loader.safeloader.find_avocado_tests') as _mock:
+        with unittest.mock.patch('avocado.core.loader.safeloader.find_avocado_tests') as _mock:
             _mock.side_effect = BaseException()
             tests = self.loader.discover(simple_test.path)
             self.assertEqual(tests[0][1]["name"], simple_test.path)

--- a/selftests/unit/test_output.py
+++ b/selftests/unit/test_output.py
@@ -1,9 +1,5 @@
 import sys
-import unittest
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+import unittest.mock
 
 from avocado.utils import path as utils_path
 from avocado.core import output
@@ -23,9 +19,9 @@ class TestStdOutput(unittest.TestCase):
     def test_paginator_not_available(self):
         """Check that without paginator command we proceed without changes"""
         std = output.StdOutput()
-        with mock.patch('avocado.utils.path.find_command',
-                        side_effect=utils_path.CmdNotFoundError('just',
-                                                                ['mocking'])):
+        with unittest.mock.patch('avocado.utils.path.find_command',
+                                 side_effect=utils_path.CmdNotFoundError('just',
+                                                                         ['mocking'])):
             std.enable_paginator()
         self.assertEqual(self.stdout, sys.stdout)
         self.assertEqual(self.stderr, sys.stderr)

--- a/selftests/unit/test_test.py
+++ b/selftests/unit/test_test.py
@@ -1,11 +1,7 @@
 import os
 import shutil
 import tempfile
-import unittest
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+import unittest.mock
 
 from avocado.core import test, exceptions
 from avocado.utils import astring, script
@@ -123,7 +119,7 @@ class TestClassTestUnit(unittest.TestCase):
         tst._record_reference('output', 'output.expected')
 
     def test_all_dirs_exists_no_hang(self):
-        with mock.patch('os.path.exists', return_value=True):
+        with unittest.mock.patch('os.path.exists', return_value=True):
             self.assertRaises(exceptions.TestSetupFail, self.DummyTest, "test",
                               test.TestID(1, "name"), base_logdir=self.tmpdir)
 

--- a/selftests/unit/test_utils_cloudinit.py
+++ b/selftests/unit/test_utils_cloudinit.py
@@ -2,13 +2,8 @@ import os
 import shutil
 import tempfile
 import threading
-import unittest     # pylint: disable=C0411
-try:
-    from unittest import mock
-except ImportError:
-    import mock
-
-from six.moves import http_client
+import unittest.mock
+import http.client
 
 from avocado.utils import cloudinit
 from avocado.utils import iso9660
@@ -28,7 +23,7 @@ def has_iso_create_write():
 class CloudInit(unittest.TestCase):
 
     def test_iso_no_create_write(self):
-        with mock.patch('avocado.utils.iso9660.iso9660', return_value=None):
+        with unittest.mock.patch('avocado.utils.iso9660.iso9660', return_value=None):
             self.assertRaises(RuntimeError, cloudinit.iso, os.devnull, "INSTANCE_ID")
 
 
@@ -60,7 +55,7 @@ class PhoneHome(unittest.TestCase):
     ADDRESS = '127.0.0.1'
 
     def post_ignore_response(self, url):
-        conn = http_client.HTTPConnection(self.ADDRESS, self.port)
+        conn = http.client.HTTPConnection(self.ADDRESS, self.port)
         conn.request('POST', url)
         try:
             conn.getresponse()

--- a/selftests/unit/test_utils_cpu.py
+++ b/selftests/unit/test_utils_cpu.py
@@ -1,10 +1,5 @@
 import io
-import unittest
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+import unittest.mock
 
 from .. import recent_mock
 from avocado.utils import cpu
@@ -14,9 +9,9 @@ class Cpu(unittest.TestCase):
 
     @staticmethod
     def _get_file_mock(content):
-        file_mock = mock.Mock()
-        file_mock.__enter__ = mock.Mock(return_value=io.BytesIO(content))
-        file_mock.__exit__ = mock.Mock()
+        file_mock = unittest.mock.Mock()
+        file_mock.__enter__ = unittest.mock.Mock(return_value=io.BytesIO(content))
+        file_mock.__exit__ = unittest.mock.Mock()
         return file_mock
 
     @unittest.skipUnless(recent_mock(),
@@ -81,12 +76,13 @@ cpu MHz dynamic : 5504
 cpu MHz static  : 5504
 """
 
-        with mock.patch('avocado.utils.cpu.platform.machine', return_value='s390x'):
-            with mock.patch('avocado.utils.cpu.open',
-                            return_value=self._get_file_mock(s390x)):
+        with unittest.mock.patch('avocado.utils.cpu.platform.machine',
+                                 return_value='s390x'):
+            with unittest.mock.patch('avocado.utils.cpu.open',
+                                     return_value=self._get_file_mock(s390x)):
                 self.assertEqual(len(cpu.cpu_online_list()), 2)
-            with mock.patch('avocado.utils.cpu.open',
-                            return_value=self._get_file_mock(s390x_2)):
+            with unittest.mock.patch('avocado.utils.cpu.open',
+                                     return_value=self._get_file_mock(s390x_2)):
                 self.assertEqual(len(cpu.cpu_online_list()), 4)
 
     @unittest.skipUnless(recent_mock(),
@@ -309,9 +305,10 @@ address sizes	: 39 bits physical, 48 bits virtual
 power management:
 
 """
-        with mock.patch('avocado.utils.cpu.platform.machine', return_value='x86_64'):
-            with mock.patch('avocado.utils.cpu.open',
-                            return_value=self._get_file_mock(x86_64)):
+        with unittest.mock.patch('avocado.utils.cpu.platform.machine',
+                                 return_value='x86_64'):
+            with unittest.mock.patch('avocado.utils.cpu.open',
+                                     return_value=self._get_file_mock(x86_64)):
                 self.assertEqual(len(cpu.cpu_online_list()), 8)
 
     @unittest.skipUnless(recent_mock(),
@@ -347,8 +344,8 @@ cache_alignment : 64
 address sizes   : 32 bits physical, 32 bits virtual
 power management:
 """
-        with mock.patch('avocado.utils.cpu.open',
-                        return_value=self._get_file_mock(cpu_output)):
+        with unittest.mock.patch('avocado.utils.cpu.open',
+                                 return_value=self._get_file_mock(cpu_output)):
             self.assertEqual(cpu.get_cpu_arch(), "i386")
 
     @unittest.skipUnless(recent_mock(),
@@ -381,8 +378,8 @@ cache_alignment : 64
 address sizes   : 39 bits physical, 48 bits virtual
 power management:
 """
-        with mock.patch('avocado.utils.cpu.open',
-                        return_value=self._get_file_mock(cpu_output)):
+        with unittest.mock.patch('avocado.utils.cpu.open',
+                                 return_value=self._get_file_mock(cpu_output)):
             self.assertEqual(cpu.get_cpu_arch(), "x86_64")
 
     @unittest.skipUnless(recent_mock(),
@@ -399,8 +396,8 @@ model           : 8247-21L
 machine         : PowerNV 8247-21L
 firmware        : OPAL v3
 """
-        with mock.patch('avocado.utils.cpu.open',
-                        return_value=self._get_file_mock(cpu_output)):
+        with unittest.mock.patch('avocado.utils.cpu.open',
+                                 return_value=self._get_file_mock(cpu_output)):
             self.assertEqual(cpu.get_cpu_arch(), "power8")
 
     @unittest.skipUnless(recent_mock(),
@@ -417,8 +414,8 @@ model           : 8247-21L
 machine         : PowerNV 8247-21L
 firmware        : OPAL v3
 """
-        with mock.patch('avocado.utils.cpu.open',
-                        return_value=self._get_file_mock(cpu_output)):
+        with unittest.mock.patch('avocado.utils.cpu.open',
+                                 return_value=self._get_file_mock(cpu_output)):
             self.assertEqual(cpu.get_cpu_arch(), "power8")
 
     @unittest.skipUnless(recent_mock(),
@@ -435,8 +432,8 @@ model		: 8375-42A
 machine		: PowerNV 8375-42A
 firmware	: OPAL
 """
-        with mock.patch('avocado.utils.cpu.open',
-                        return_value=self._get_file_mock(cpu_output)):
+        with unittest.mock.patch('avocado.utils.cpu.open',
+                                 return_value=self._get_file_mock(cpu_output)):
             self.assertEqual(cpu.get_cpu_arch(), "power9")
 
     @unittest.skipUnless(recent_mock(),
@@ -465,8 +462,8 @@ cpu number      : 1
 cpu MHz dynamic : 5504
 cpu MHz static  : 5504
 """
-        with mock.patch('avocado.utils.cpu.open',
-                        return_value=self._get_file_mock(cpu_output)):
+        with unittest.mock.patch('avocado.utils.cpu.open',
+                                 return_value=self._get_file_mock(cpu_output)):
             self.assertEqual(cpu.get_cpu_arch(), "s390")
 
     @unittest.skipUnless(recent_mock(),
@@ -485,8 +482,8 @@ Hardware        : herring
 Revision        : 0034
 Serial          : 3534268a5e0700ec
 """
-        with mock.patch('avocado.utils.cpu.open',
-                        return_value=self._get_file_mock(cpu_output)):
+        with unittest.mock.patch('avocado.utils.cpu.open',
+                                 return_value=self._get_file_mock(cpu_output)):
             self.assertEqual(cpu.get_cpu_arch(), "arm")
 
     @unittest.skipUnless(recent_mock(),
@@ -501,8 +498,8 @@ CPU variant     : 0x1
 CPU part        : 0x0a1
 CPU revision    : 1
 """
-        with mock.patch('avocado.utils.cpu.open',
-                        return_value=self._get_file_mock(cpu_output)):
+        with unittest.mock.patch('avocado.utils.cpu.open',
+                                 return_value=self._get_file_mock(cpu_output)):
             self.assertEqual(cpu.get_cpu_arch(), "aarch64")
 
     @unittest.skipUnless(recent_mock(),
@@ -513,35 +510,44 @@ isa	: rv64imafdc
 mmu	: sv39
 uarch	: sifive,rocket0
 """
-        with mock.patch('avocado.utils.cpu.open',
-                        return_value=self._get_file_mock(cpu_output)):
+        with unittest.mock.patch('avocado.utils.cpu.open',
+                                 return_value=self._get_file_mock(cpu_output)):
             self.assertEqual(cpu.get_cpu_arch(), "riscv")
 
     @unittest.skipUnless(recent_mock(),
                          "mock library version cannot (easily) patch open()")
     def test_get_cpuidle_state_off(self):
         retval = {0: {0: 0}}
-        with mock.patch('avocado.utils.cpu.cpu_online_list', return_value=[0]):
-            with mock.patch('glob.glob', return_value=['/sys/devices/system/cpu/cpu0/cpuidle/state1']):
-                with mock.patch('avocado.utils.cpu.open', return_value=io.BytesIO(b'0')):
+        with unittest.mock.patch('avocado.utils.cpu.cpu_online_list',
+                                 return_value=[0]):
+            with unittest.mock.patch('glob.glob',
+                                     return_value=['/sys/devices/system/cpu/cpu0/cpuidle/state1']):
+                with unittest.mock.patch('avocado.utils.cpu.open',
+                                         return_value=io.BytesIO(b'0')):
                     self.assertEqual(cpu.get_cpuidle_state(), retval)
 
     @unittest.skipUnless(recent_mock(),
                          "mock library version cannot (easily) patch open()")
     def test_get_cpuidle_state_on(self):
         retval = {0: {0: 1}}
-        with mock.patch('avocado.utils.cpu.cpu_online_list', return_value=[0]):
-            with mock.patch('glob.glob', return_value=['/sys/devices/system/cpu/cpu0/cpuidle/state1']):
-                with mock.patch('avocado.utils.cpu.open', return_value=io.BytesIO(b'1')):
+        with unittest.mock.patch('avocado.utils.cpu.cpu_online_list',
+                                 return_value=[0]):
+            with unittest.mock.patch('glob.glob',
+                                     return_value=['/sys/devices/system/cpu/cpu0/cpuidle/state1']):
+                with unittest.mock.patch('avocado.utils.cpu.open',
+                                         return_value=io.BytesIO(b'1')):
                     self.assertEqual(cpu.get_cpuidle_state(), retval)
 
     @unittest.skipUnless(recent_mock(),
                          "mock library version cannot (easily) patch open()")
     def test_set_cpuidle_state_default(self):
         output = io.BytesIO()
-        with mock.patch('avocado.utils.cpu.cpu_online_list', return_value=[0]):
-            with mock.patch('glob.glob', return_value=['/sys/devices/system/cpu/cpu0/cpuidle/state1']):
-                with mock.patch('avocado.utils.cpu.open', return_value=output):
+        with unittest.mock.patch('avocado.utils.cpu.cpu_online_list',
+                                 return_value=[0]):
+            with unittest.mock.patch('glob.glob',
+                                     return_value=['/sys/devices/system/cpu/cpu0/cpuidle/state1']):
+                with unittest.mock.patch('avocado.utils.cpu.open',
+                                         return_value=output):
                     cpu.set_cpuidle_state()
                     self.assertEqual(output.getvalue(), b'1')
 
@@ -549,9 +555,12 @@ uarch	: sifive,rocket0
                          "mock library version cannot (easily) patch open()")
     def test_set_cpuidle_state_withstateno(self):
         output = io.BytesIO()
-        with mock.patch('avocado.utils.cpu.cpu_online_list', return_value=[0]):
-            with mock.patch('glob.glob', return_value=['/sys/devices/system/cpu/cpu0/cpuidle/state2']):
-                with mock.patch('avocado.utils.cpu.open', return_value=output):
+        with unittest.mock.patch('avocado.utils.cpu.cpu_online_list',
+                                 return_value=[0]):
+            with unittest.mock.patch('glob.glob',
+                                     return_value=['/sys/devices/system/cpu/cpu0/cpuidle/state2']):
+                with unittest.mock.patch('avocado.utils.cpu.open',
+                                         return_value=output):
                     cpu.set_cpuidle_state(disable=False, state_number='2')
                     self.assertEqual(output.getvalue(), b'0')
 
@@ -559,9 +568,12 @@ uarch	: sifive,rocket0
                          "mock library version cannot (easily) patch open()")
     def test_set_cpuidle_state_withsetstate(self):
         output = io.BytesIO()
-        with mock.patch('avocado.utils.cpu.cpu_online_list', return_value=[0, 2]):
-            with mock.patch('glob.glob', return_value=['/sys/devices/system/cpu/cpu0/cpuidle/state1']):
-                with mock.patch('avocado.utils.cpu.open', return_value=output):
+        with unittest.mock.patch('avocado.utils.cpu.cpu_online_list',
+                                 return_value=[0, 2]):
+            with unittest.mock.patch('glob.glob',
+                                     return_value=['/sys/devices/system/cpu/cpu0/cpuidle/state1']):
+                with unittest.mock.patch('avocado.utils.cpu.open',
+                                         return_value=output):
                     cpu.set_cpuidle_state(setstate={0: {0: 1}, 2: {0: 0}})
                     self.assertEqual(output.getvalue(), b'10')
 

--- a/selftests/unit/test_utils_disk.py
+++ b/selftests/unit/test_utils_disk.py
@@ -1,10 +1,5 @@
 import sys
-import unittest
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+import unittest.mock
 
 from .. import recent_mock
 from avocado.utils import disk
@@ -54,39 +49,39 @@ class Disk(unittest.TestCase):
         mock_result = process.CmdResult(
             command='lsblk --json',
             stdout=b'{"blockdevices": []}')
-        with mock.patch('avocado.utils.disk.process.run',
-                        return_value=mock_result):
+        with unittest.mock.patch('avocado.utils.disk.process.run',
+                                 return_value=mock_result):
             self.assertEqual(disk.get_disks(), [])
 
     def test_disks(self):
         mock_result = process.CmdResult(
             command='lsblk --json',
             stdout=LSBLK_OUTPUT)
-        with mock.patch('avocado.utils.disk.process.run',
-                        return_value=mock_result):
+        with unittest.mock.patch('avocado.utils.disk.process.run',
+                                 return_value=mock_result):
             self.assertEqual(disk.get_disks(), ['/dev/vda'])
 
     @unittest.skipUnless(recent_mock(),
                          "mock library version cannot (easily) patch open()")
     def test_get_filesystems(self):
         expected_fs = ['dax', 'bpf', 'pipefs', 'hugetlbfs', 'devpts', 'ext3']
-        open_mocked = mock.mock_open(read_data=PROC_FILESYSTEMS)
-        with mock.patch(self.builtin_open, open_mocked):
+        open_mocked = unittest.mock.mock_open(read_data=PROC_FILESYSTEMS)
+        with unittest.mock.patch(self.builtin_open, open_mocked):
             self.assertEqual(sorted(expected_fs),
                              sorted(disk.get_available_filesystems()))
 
     @unittest.skipUnless(recent_mock(),
                          "mock library version cannot (easily) patch open()")
     def test_get_filesystem_type_default_root(self):
-        open_mocked = mock.mock_open(read_data=PROC_MOUNTS)
-        with mock.patch(self.builtin_open, open_mocked):
+        open_mocked = unittest.mock.mock_open(read_data=PROC_MOUNTS)
+        with unittest.mock.patch(self.builtin_open, open_mocked):
             self.assertEqual('ext4', disk.get_filesystem_type())
 
     @unittest.skipUnless(recent_mock(),
                          "mock library version cannot (easily) patch open()")
     def test_get_filesystem_type(self):
-        open_mocked = mock.mock_open(read_data=PROC_MOUNTS)
-        with mock.patch(self.builtin_open, open_mocked):
+        open_mocked = unittest.mock.mock_open(read_data=PROC_MOUNTS)
+        with unittest.mock.patch(self.builtin_open, open_mocked):
             self.assertEqual('ext2', disk.get_filesystem_type(mount_point='/home'))
 
 

--- a/selftests/unit/test_utils_iso9660.py
+++ b/selftests/unit/test_utils_iso9660.py
@@ -4,13 +4,7 @@ Verifies the avocado.utils.iso9660 functionality
 import os
 import shutil
 import tempfile
-import unittest
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
-
+import unittest.mock
 
 from avocado.utils import iso9660, process
 
@@ -27,16 +21,16 @@ class Capabilities(unittest.TestCase):
                                                      os.path.pardir, ".data",
                                                      "sample.iso"))
 
-    @mock.patch('avocado.utils.iso9660.has_pycdlib', return_value=True)
+    @unittest.mock.patch('avocado.utils.iso9660.has_pycdlib', return_value=True)
     def test_capabilities_pycdlib(self, has_pycdlib_mocked):
         instance = iso9660.iso9660(self.iso_path, ['read', 'create', 'write'])
         self.assertIsInstance(instance, iso9660.ISO9660PyCDLib)
         self.assertTrue(has_pycdlib_mocked.called)
 
-    @mock.patch('avocado.utils.iso9660.has_pycdlib', return_value=False)
-    @mock.patch('avocado.utils.iso9660.has_isoinfo', return_value=False)
-    @mock.patch('avocado.utils.iso9660.has_isoread', return_value=False)
-    @mock.patch('avocado.utils.iso9660.can_mount', return_value=False)
+    @unittest.mock.patch('avocado.utils.iso9660.has_pycdlib', return_value=False)
+    @unittest.mock.patch('avocado.utils.iso9660.has_isoinfo', return_value=False)
+    @unittest.mock.patch('avocado.utils.iso9660.has_isoread', return_value=False)
+    @unittest.mock.patch('avocado.utils.iso9660.can_mount', return_value=False)
     def test_capabilities_nobackend(self, has_pycdlib_mocked, has_isoinfo_mocked,
                                     has_isoread_mocked, can_mount_mocked):
         self.assertIsNone(iso9660.iso9660(self.iso_path, ['read']))

--- a/selftests/unit/test_utils_linux_modules.py
+++ b/selftests/unit/test_utils_linux_modules.py
@@ -1,10 +1,5 @@
 import io
-import unittest
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+import unittest.mock
 
 from .. import recent_mock
 from avocado.utils import linux_modules
@@ -166,9 +161,9 @@ video 45056 2 thinkpad_acpi,i915, Live 0x0000000000000000
 
     @staticmethod
     def _get_file_mock(content):
-        file_mock = mock.Mock()
-        file_mock.__enter__ = mock.Mock(return_value=io.BytesIO(content))
-        file_mock.__exit__ = mock.Mock()
+        file_mock = unittest.mock.Mock()
+        file_mock.__enter__ = unittest.mock.Mock(return_value=io.BytesIO(content))
+        file_mock.__exit__ = unittest.mock.Mock()
         return file_mock
 
     def test_parse_lsmod(self):
@@ -203,8 +198,8 @@ video 45056 2 thinkpad_acpi,i915, Live 0x0000000000000000
     @unittest.skipUnless(recent_mock(),
                          "mock library version cannot (easily) patch open()")
     def test_is_module_loaded(self):
-        with mock.patch('avocado.utils.linux_modules.open',
-                        return_value=self._get_file_mock(self.PROC_MODULES_OUT)):
+        with unittest.mock.patch('avocado.utils.linux_modules.open',
+                                 return_value=self._get_file_mock(self.PROC_MODULES_OUT)):
             self.assertTrue(linux_modules.module_is_loaded("rfcomm"))
             self.assertFalse(linux_modules.module_is_loaded("unknown_module"))
 

--- a/selftests/unit/test_utils_memory.py
+++ b/selftests/unit/test_utils_memory.py
@@ -1,9 +1,4 @@
-import unittest
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+import unittest.mock
 
 from avocado.utils import memory
 
@@ -14,9 +9,9 @@ class UtilsMemoryTest(unittest.TestCase):
         file_values = [u"0\n", u"1-3", u"0-1,12-14\n"]
         expected_values = [[0], [1, 2, 3], [0, 1, 12, 13, 14]]
         for value, exp in zip(file_values, expected_values):
-            with mock.patch('os.path.exists', return_value=True):
-                with mock.patch('avocado.utils.genio.read_file',
-                                return_value=value):
+            with unittest.mock.patch('os.path.exists', return_value=True):
+                with unittest.mock.patch('avocado.utils.genio.read_file',
+                                         return_value=value):
                     self.assertEqual(memory.numa_nodes_with_memory(), exp)
 
 
@@ -27,7 +22,8 @@ BUDDY_INFO_RESPONSE = '\n'.join([
 ])
 
 
-@mock.patch('avocado.utils.memory._get_buddy_info_content', return_value=BUDDY_INFO_RESPONSE)
+@unittest.mock.patch('avocado.utils.memory._get_buddy_info_content',
+                     return_value=BUDDY_INFO_RESPONSE)
 class UtilsMemoryTestGetBuddyInfo(unittest.TestCase):
 
     def test_get_buddy_info_simple_chunk_size(self, buddy_info_content_mocked):

--- a/selftests/unit/test_utils_network.py
+++ b/selftests/unit/test_utils_network.py
@@ -1,10 +1,5 @@
 import socket
-import unittest
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+import unittest.mock
 
 try:
     import netifaces
@@ -19,7 +14,7 @@ class PortTrackerTest(unittest.TestCase):
 
     def test_register_port(self):
         tracker = network.PortTracker()
-        network.is_port_free = mock.MagicMock(return_value=True)
+        network.is_port_free = unittest.mock.MagicMock(return_value=True)
         self.assertNotIn(22, tracker.retained_ports)
         tracker.register_port(22)
         network.is_port_free.assert_called_once_with(22, tracker.address)
@@ -27,8 +22,8 @@ class PortTrackerTest(unittest.TestCase):
 
     def test_release_port_does_not_poke_system(self):
         tracker = network.PortTracker()
-        tracker.release_port = mock.MagicMock()
-        network.is_port_free = mock.MagicMock()
+        tracker.release_port = unittest.mock.MagicMock()
+        network.is_port_free = unittest.mock.MagicMock()
         tracker.release_port(22)
         tracker.release_port.assert_called_once_with(22)
         network.is_port_free.assert_not_called()

--- a/selftests/unit/test_utils_partition.py
+++ b/selftests/unit/test_utils_partition.py
@@ -8,11 +8,7 @@ import os
 import shutil
 import sys
 import tempfile
-import unittest     # pylint: disable=C0411
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+import unittest.mock
 
 from avocado.utils import partition, process
 from avocado.utils import path as utils_path
@@ -133,10 +129,10 @@ class TestPartitionMkfsMount(Base):
             proc_mounts = proc_mounts_file.read()
         self.assertIn(self.mountpoint, proc_mounts)
         proc = self.run_process_to_use_mnt()
-        with mock.patch('avocado.utils.partition.process.run',
-                        side_effect=process.CmdError):
-            with mock.patch('avocado.utils.partition.process.system_output',
-                            side_effect=OSError) as mocked_system_output:
+        with unittest.mock.patch('avocado.utils.partition.process.run',
+                                 side_effect=process.CmdError):
+            with unittest.mock.patch('avocado.utils.partition.process.system_output',
+                                     side_effect=OSError) as mocked_system_output:
                 self.assertRaises(partition.PartitionError, self.disk.unmount)
                 mocked_system_output.assert_called_with('lsof ' + self.mountpoint,
                                                         sudo=True)
@@ -184,8 +180,8 @@ class TestMtabLock(unittest.TestCase):
     def test_lock(self):
         """ Check double-lock raises exception after 60s (in 0.1s) """
         with partition.MtabLock():
-            with mock.patch('avocado.utils.filelock.time.time',
-                            mock.MagicMock(side_effect=[1, 2, 62])):
+            with unittest.mock.patch('avocado.utils.filelock.time.time',
+                                     unittest.mock.MagicMock(side_effect=[1, 2, 62])):
                 self.assertRaises(partition.PartitionError,
                                   partition.MtabLock().__enter__)
 

--- a/selftests/unit/test_utils_path.py
+++ b/selftests/unit/test_utils_path.py
@@ -1,10 +1,5 @@
 import os
-import unittest
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+import unittest.mock
 
 from avocado.utils import path
 
@@ -12,8 +7,8 @@ from avocado.utils import path
 class Path(unittest.TestCase):
 
     def test_check_readable_exists(self):
-        with mock.patch('avocado.utils.path.os.path.exists',
-                        return_value=False) as mocked_exists:
+        with unittest.mock.patch('avocado.utils.path.os.path.exists',
+                                 return_value=False) as mocked_exists:
             with self.assertRaises(OSError) as cm:
                 path.check_readable(os.devnull)
             self.assertEqual('File "%s" does not exist' % os.devnull,
@@ -21,8 +16,8 @@ class Path(unittest.TestCase):
             mocked_exists.assert_called_with(os.devnull)
 
     def test_check_readable_access(self):
-        with mock.patch('avocado.utils.path.os.access',
-                        return_value=False) as mocked_access:
+        with unittest.mock.patch('avocado.utils.path.os.access',
+                                 return_value=False) as mocked_access:
             with self.assertRaises(OSError) as cm:
                 path.check_readable(os.devnull)
             self.assertEqual('File "%s" can not be read' % os.devnull,

--- a/selftests/unit/test_utils_pci.py
+++ b/selftests/unit/test_utils_pci.py
@@ -1,9 +1,4 @@
-import unittest
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+import unittest.mock
 
 from avocado.utils import pci
 
@@ -15,15 +10,15 @@ class UtilsPciTest(unittest.TestCase):
         file_values = ['S0001', 'S0001[', 'Slot2', 'SLOT1', 'Backplane USB', 'U78CB.001.WZS07CU-P1-C9-T1', 'PLX Slot1', 'Onboard USB', 'U78D5.001.CSS130E-P1-P2-P2-C1-T1']
         expected_values = ['S0001', 'S0001', 'Slot2', 'SLOT1', 'Backplane USB', 'U78CB.001.WZS07CU-P1-C9', 'PLX Slot1', 'Onboard USB', 'U78D5.001.CSS130E-P1-P2-P2-C1']
         for value, exp in zip(file_values, expected_values):
-            with mock.patch('os.path.isfile', return_value=True):
-                with mock.patch('avocado.utils.genio.read_file',
-                                return_value=value):
+            with unittest.mock.patch('os.path.isfile', return_value=True):
+                with unittest.mock.patch('avocado.utils.genio.read_file',
+                                         return_value=value):
                     self.assertEqual(pci.get_slot_from_sysfs(pcid), exp)
 
     def test_get_slot_from_sysfs_negative(self):
-        with mock.patch('os.path.isfile', return_value=True):
-            with mock.patch('avocado.utils.genio.read_file',
-                            return_value='.....bad-value.....'):
+        with unittest.mock.patch('os.path.isfile', return_value=True):
+            with unittest.mock.patch('avocado.utils.genio.read_file',
+                                     return_value='.....bad-value.....'):
                 self.assertRaises(ValueError, pci.get_slot_from_sysfs,
                                   '0002:01:00.1')
 

--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -2,14 +2,9 @@ import io
 import logging
 import os
 import shlex
-import unittest
+import unittest.mock
 import sys
 import time
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 
 
 from .. import recent_mock
@@ -58,11 +53,11 @@ class TestSubProcess(unittest.TestCase):
         self.assertRaises(ValueError, process.SubProcess,
                           FICTIONAL_CMD, False, "invalid")
 
-    @mock.patch('avocado.utils.process.SubProcess._init_subprocess')
-    @mock.patch('avocado.utils.process.SubProcess.is_sudo_enabled')
-    @mock.patch('avocado.utils.process.SubProcess.get_pid')
-    @mock.patch('avocado.utils.process.get_children_pids')
-    @mock.patch('avocado.utils.process.run')
+    @unittest.mock.patch('avocado.utils.process.SubProcess._init_subprocess')
+    @unittest.mock.patch('avocado.utils.process.SubProcess.is_sudo_enabled')
+    @unittest.mock.patch('avocado.utils.process.SubProcess.get_pid')
+    @unittest.mock.patch('avocado.utils.process.get_children_pids')
+    @unittest.mock.patch('avocado.utils.process.run')
     def test_send_signal_sudo_enabled(self, run, get_children, pid, sudo, init):  # pylint: disable=W0613
         signal = 1
         child_pid = 123
@@ -75,11 +70,11 @@ class TestSubProcess(unittest.TestCase):
         expected_cmd = 'kill -%d %d' % (signal, child_pid)
         run.assert_called_with(expected_cmd, sudo=True)
 
-    @mock.patch('avocado.utils.process.SubProcess._init_subprocess')
-    @mock.patch('avocado.utils.process.SubProcess.is_sudo_enabled')
-    @mock.patch('avocado.utils.process.SubProcess.get_pid')
-    @mock.patch('avocado.utils.process.get_children_pids')
-    @mock.patch('avocado.utils.process.run')
+    @unittest.mock.patch('avocado.utils.process.SubProcess._init_subprocess')
+    @unittest.mock.patch('avocado.utils.process.SubProcess.is_sudo_enabled')
+    @unittest.mock.patch('avocado.utils.process.SubProcess.get_pid')
+    @unittest.mock.patch('avocado.utils.process.get_children_pids')
+    @unittest.mock.patch('avocado.utils.process.run')
     def test_send_signal_sudo_enabled_with_exception(
             self, run, get_children, pid, sudo, init):  # pylint: disable=W0613
         signal = 1
@@ -94,9 +89,9 @@ class TestSubProcess(unittest.TestCase):
         expected_cmd = 'kill -%d %d' % (signal, child_pid)
         run.assert_called_with(expected_cmd, sudo=True)
 
-    @mock.patch('avocado.utils.process.SubProcess._init_subprocess')
-    @mock.patch('avocado.utils.process.SubProcess.get_pid')
-    @mock.patch('avocado.utils.process.get_owner_id')
+    @unittest.mock.patch('avocado.utils.process.SubProcess._init_subprocess')
+    @unittest.mock.patch('avocado.utils.process.SubProcess.get_pid')
+    @unittest.mock.patch('avocado.utils.process.get_owner_id')
     def test_get_user_id(self, get_owner, get_pid, init):  # pylint: disable=W0613
         user_id = 1
         process_id = 123
@@ -108,9 +103,9 @@ class TestSubProcess(unittest.TestCase):
         self.assertEqual(subprocess.get_user_id(), user_id)
         get_owner.assert_called_with(process_id)
 
-    @mock.patch('avocado.utils.process.SubProcess._init_subprocess')
-    @mock.patch('avocado.utils.process.SubProcess.get_pid')
-    @mock.patch('avocado.utils.process.get_owner_id')
+    @unittest.mock.patch('avocado.utils.process.SubProcess._init_subprocess')
+    @unittest.mock.patch('avocado.utils.process.SubProcess.get_pid')
+    @unittest.mock.patch('avocado.utils.process.get_owner_id')
     def test_is_sudo_enabled_false(self, get_owner, get_pid, init):  # pylint: disable=W0613
         user_id = 1
         process_id = 123
@@ -122,9 +117,9 @@ class TestSubProcess(unittest.TestCase):
         self.assertFalse(subprocess.is_sudo_enabled())
         get_owner.assert_called_with(process_id)
 
-    @mock.patch('avocado.utils.process.SubProcess._init_subprocess')
-    @mock.patch('avocado.utils.process.SubProcess.get_pid')
-    @mock.patch('avocado.utils.process.get_owner_id')
+    @unittest.mock.patch('avocado.utils.process.SubProcess._init_subprocess')
+    @unittest.mock.patch('avocado.utils.process.SubProcess.get_pid')
+    @unittest.mock.patch('avocado.utils.process.get_owner_id')
     def test_is_sudo_enabled_true(self, get_owner, get_pid, init):  # pylint: disable=W0613
         user_id = 0
         process_id = 123
@@ -203,71 +198,79 @@ def mock_fail_find_cmd(cmd, default=None):  # pylint: disable=W0613
 
 class TestProcessRun(unittest.TestCase):
 
-    @mock.patch.object(os, 'getuid',
-                       mock.Mock(return_value=1000))
+    @unittest.mock.patch.object(os, 'getuid',
+                                unittest.mock.Mock(return_value=1000))
     def test_subprocess_nosudo(self):
         expected_command = 'ls -l'
         p = process.SubProcess(cmd='ls -l')
         self.assertEqual(p.cmd, expected_command)
 
-    @mock.patch.object(os, 'getuid', mock.Mock(return_value=0))
+    @unittest.mock.patch.object(os, 'getuid',
+                                unittest.mock.Mock(return_value=0))
     def test_subprocess_nosudo_uid_0(self):
         expected_command = 'ls -l'
         p = process.SubProcess(cmd='ls -l')
         self.assertEqual(p.cmd, expected_command)
 
-    @mock.patch.object(path, 'find_command',
-                       mock.Mock(return_value='/bin/sudo'))
-    @mock.patch.object(os, 'getuid',
-                       mock.Mock(return_value=1000))
+    @unittest.mock.patch.object(path, 'find_command',
+                                unittest.mock.Mock(return_value='/bin/sudo'))
+    @unittest.mock.patch.object(os, 'getuid',
+                                unittest.mock.Mock(return_value=1000))
     def test_subprocess_sudo(self):
         expected_command = '/bin/sudo -n ls -l'
         p = process.SubProcess(cmd='ls -l', sudo=True)
         path.find_command.assert_called_once_with('sudo')
         self.assertEqual(p.cmd, expected_command)
 
-    @mock.patch.object(path, 'find_command', mock_fail_find_cmd)
-    @mock.patch.object(os, 'getuid', mock.Mock(return_value=1000))
+    @unittest.mock.patch.object(path, 'find_command', mock_fail_find_cmd)
+    @unittest.mock.patch.object(os, 'getuid',
+                                unittest.mock.Mock(return_value=1000))
     def test_subprocess_sudo_no_sudo_installed(self):
         expected_command = 'ls -l'
         p = process.SubProcess(cmd='ls -l', sudo=True)
         self.assertEqual(p.cmd, expected_command)
 
-    @mock.patch.object(os, 'getuid', mock.Mock(return_value=0))
+    @unittest.mock.patch.object(os, 'getuid',
+                                unittest.mock.Mock(return_value=0))
     def test_subprocess_sudo_uid_0(self):
         expected_command = 'ls -l'
         p = process.SubProcess(cmd='ls -l', sudo=True)
         self.assertEqual(p.cmd, expected_command)
 
-    @mock.patch.object(path, 'find_command',
-                       mock.Mock(return_value='/bin/sudo'))
-    @mock.patch.object(os, 'getuid', mock.Mock(return_value=1000))
+    @unittest.mock.patch.object(path, 'find_command',
+                                unittest.mock.Mock(return_value='/bin/sudo'))
+    @unittest.mock.patch.object(os, 'getuid',
+                                unittest.mock.Mock(return_value=1000))
     def test_subprocess_sudo_shell(self):
         expected_command = '/bin/sudo -n -s ls -l'
         p = process.SubProcess(cmd='ls -l', sudo=True, shell=True)
         path.find_command.assert_called_once_with('sudo')
         self.assertEqual(p.cmd, expected_command)
 
-    @mock.patch.object(path, 'find_command', mock_fail_find_cmd)
-    @mock.patch.object(os, 'getuid', mock.Mock(return_value=1000))
+    @unittest.mock.patch.object(path, 'find_command', mock_fail_find_cmd)
+    @unittest.mock.patch.object(os, 'getuid',
+                                unittest.mock.Mock(return_value=1000))
     def test_subprocess_sudo_shell_no_sudo_installed(self):
         expected_command = 'ls -l'
         p = process.SubProcess(cmd='ls -l', sudo=True, shell=True)
         self.assertEqual(p.cmd, expected_command)
 
-    @mock.patch.object(os, 'getuid', mock.Mock(return_value=0))
+    @unittest.mock.patch.object(os, 'getuid',
+                                unittest.mock.Mock(return_value=0))
     def test_subprocess_sudo_shell_uid_0(self):
         expected_command = 'ls -l'
         p = process.SubProcess(cmd='ls -l', sudo=True, shell=True)
         self.assertEqual(p.cmd, expected_command)
 
-    @mock.patch.object(os, 'getuid', mock.Mock(return_value=1000))
+    @unittest.mock.patch.object(os, 'getuid',
+                                unittest.mock.Mock(return_value=1000))
     def test_run_nosudo(self):
         expected_command = 'ls -l'
         p = process.run(cmd='ls -l', ignore_status=True)
         self.assertEqual(p.command, expected_command)
 
-    @mock.patch.object(os, 'getuid', mock.Mock(return_value=0))
+    @unittest.mock.patch.object(os, 'getuid',
+                                unittest.mock.Mock(return_value=0))
     def test_run_nosudo_uid_0(self):
         expected_command = 'ls -l'
         p = process.run(cmd='ls -l', ignore_status=True)
@@ -275,45 +278,51 @@ class TestProcessRun(unittest.TestCase):
 
     @unittest.skipUnless(os.path.exists('/bin/sudo'),
                          "/bin/sudo not available")
-    @mock.patch.object(path, 'find_command',
-                       mock.Mock(return_value='/bin/sudo'))
-    @mock.patch.object(os, 'getuid', mock.Mock(return_value=1000))
+    @unittest.mock.patch.object(path, 'find_command',
+                                unittest.mock.Mock(return_value='/bin/sudo'))
+    @unittest.mock.patch.object(os, 'getuid',
+                                unittest.mock.Mock(return_value=1000))
     def test_run_sudo(self):
         expected_command = '/bin/sudo -n ls -l'
         p = process.run(cmd='ls -l', sudo=True, ignore_status=True)
         path.find_command.assert_called_once_with('sudo')
         self.assertEqual(p.command, expected_command)
 
-    @mock.patch.object(path, 'find_command', mock_fail_find_cmd)
-    @mock.patch.object(os, 'getuid', mock.Mock(return_value=1000))
+    @unittest.mock.patch.object(path, 'find_command', mock_fail_find_cmd)
+    @unittest.mock.patch.object(os, 'getuid',
+                                unittest.mock.Mock(return_value=1000))
     def test_run_sudo_no_sudo_installed(self):
         expected_command = 'ls -l'
         p = process.run(cmd='ls -l', sudo=True, ignore_status=True)
         self.assertEqual(p.command, expected_command)
 
-    @mock.patch.object(os, 'getuid', mock.Mock(return_value=0))
+    @unittest.mock.patch.object(os, 'getuid',
+                                unittest.mock.Mock(return_value=0))
     def test_run_sudo_uid_0(self):
         expected_command = 'ls -l'
         p = process.run(cmd='ls -l', sudo=True, ignore_status=True)
         self.assertEqual(p.command, expected_command)
 
-    @mock.patch.object(path, 'find_command',
-                       mock.Mock(return_value='/bin/sudo'))
-    @mock.patch.object(os, 'getuid', mock.Mock(return_value=1000))
+    @unittest.mock.patch.object(path, 'find_command',
+                                unittest.mock.Mock(return_value='/bin/sudo'))
+    @unittest.mock.patch.object(os, 'getuid',
+                                unittest.mock.Mock(return_value=1000))
     def test_run_sudo_shell(self):
         expected_command = '/bin/sudo -n -s ls -l'
         p = process.run(cmd='ls -l', sudo=True, shell=True, ignore_status=True)
         path.find_command.assert_called_once_with('sudo')
         self.assertEqual(p.command, expected_command)
 
-    @mock.patch.object(path, 'find_command', mock_fail_find_cmd)
-    @mock.patch.object(os, 'getuid', mock.Mock(return_value=1000))
+    @unittest.mock.patch.object(path, 'find_command', mock_fail_find_cmd)
+    @unittest.mock.patch.object(os, 'getuid',
+                                unittest.mock.Mock(return_value=1000))
     def test_run_sudo_shell_no_sudo_installed(self):
         expected_command = 'ls -l'
         p = process.run(cmd='ls -l', sudo=True, shell=True, ignore_status=True)
         self.assertEqual(p.command, expected_command)
 
-    @mock.patch.object(os, 'getuid', mock.Mock(return_value=0))
+    @unittest.mock.patch.object(os, 'getuid',
+                                unittest.mock.Mock(return_value=0))
     def test_run_sudo_shell_uid_0(self):
         expected_command = 'ls -l'
         p = process.run(cmd='ls -l', sudo=True, shell=True, ignore_status=True)
@@ -417,8 +426,8 @@ class MiscProcessTests(unittest.TestCase):
                          "mock library version cannot (easily) patch open()")
     def test_get_parent_pid(self):
         stat = b'18405 (bash) S 24139 18405 18405 34818 8056 4210688 9792 170102 0 7 11 4 257 84 20 0 1 0 44336493 235409408 4281 18446744073709551615 94723230367744 94723231442728 140723100226000 0 0 0 65536 3670020 1266777851 0 0 0 17 1 0 0 0 0 0 94723233541456 94723233588580 94723248717824 140723100229613 140723100229623 140723100229623 140723100233710 0'
-        with mock.patch('avocado.utils.process.open',
-                        return_value=io.BytesIO(stat)):
+        with unittest.mock.patch('avocado.utils.process.open',
+                                 return_value=io.BytesIO(stat)):
             self.assertTrue(process.get_parent_pid(0), 24139)
 
     @unittest.skipUnless(sys.platform.startswith('linux'),
@@ -429,8 +438,8 @@ class MiscProcessTests(unittest.TestCase):
         '''
         self.assertGreaterEqual(len(process.get_children_pids(1)), 1)
 
-    @mock.patch('avocado.utils.process.os.kill')
-    @mock.patch('avocado.utils.process.get_owner_id')
+    @unittest.mock.patch('avocado.utils.process.os.kill')
+    @unittest.mock.patch('avocado.utils.process.get_owner_id')
     def test_safe_kill(self, owner_mocked, kill_mocked):
         owner_id = 1
         process_id = 123
@@ -441,8 +450,8 @@ class MiscProcessTests(unittest.TestCase):
         self.assertTrue(killed)
         kill_mocked.assert_called_with(process_id, signal)
 
-    @mock.patch('avocado.utils.process.os.kill')
-    @mock.patch('avocado.utils.process.get_owner_id')
+    @unittest.mock.patch('avocado.utils.process.os.kill')
+    @unittest.mock.patch('avocado.utils.process.get_owner_id')
     def test_safe_kill_with_exception(self, owner_mocked, kill_mocked):
         owner_id = 1
         process_id = 123
@@ -454,8 +463,8 @@ class MiscProcessTests(unittest.TestCase):
         self.assertFalse(killed)
         kill_mocked.assert_called_with(process_id, signal)
 
-    @mock.patch('avocado.utils.process.run')
-    @mock.patch('avocado.utils.process.get_owner_id')
+    @unittest.mock.patch('avocado.utils.process.run')
+    @unittest.mock.patch('avocado.utils.process.get_owner_id')
     def test_safe_kill_sudo_enabled(self, owner_mocked, run_mocked):
         owner_id = 0
         process_id = 123
@@ -467,8 +476,8 @@ class MiscProcessTests(unittest.TestCase):
         self.assertTrue(killed)
         run_mocked.assert_called_with(expected_cmd, sudo=True)
 
-    @mock.patch('avocado.utils.process.run')
-    @mock.patch('avocado.utils.process.get_owner_id')
+    @unittest.mock.patch('avocado.utils.process.run')
+    @unittest.mock.patch('avocado.utils.process.get_owner_id')
     def test_safe_kill_sudo_enabled_with_exception(self, owner_mocked, run_mocked):
         owner_id = 0
         process_id = 123
@@ -481,18 +490,18 @@ class MiscProcessTests(unittest.TestCase):
         self.assertFalse(killed)
         run_mocked.assert_called_with(expected_cmd, sudo=True)
 
-    @mock.patch('avocado.utils.process.os.stat')
+    @unittest.mock.patch('avocado.utils.process.os.stat')
     def test_process_get_owner_id(self, stat_mock):
         process_id = 123
         owner_user_id = 13
-        stat_mock.return_value = mock.Mock(st_uid=owner_user_id)
+        stat_mock.return_value = unittest.mock.Mock(st_uid=owner_user_id)
 
         returned_owner_id = process.get_owner_id(process_id)
 
         self.assertEqual(returned_owner_id, owner_user_id)
         stat_mock.assert_called_with('/proc/%d/' % process_id)
 
-    @mock.patch('avocado.utils.process.os.stat')
+    @unittest.mock.patch('avocado.utils.process.os.stat')
     def test_process_get_owner_id_with_pid_not_found(self, stat_mock):
         process_id = 123
         stat_mock.side_effect = OSError()
@@ -502,9 +511,9 @@ class MiscProcessTests(unittest.TestCase):
         self.assertIsNone(returned_owner_id)
         stat_mock.assert_called_with('/proc/%d/' % process_id)
 
-    @mock.patch('avocado.utils.process.time.sleep')
-    @mock.patch('avocado.utils.process.safe_kill')
-    @mock.patch('avocado.utils.process.get_children_pids')
+    @unittest.mock.patch('avocado.utils.process.time.sleep')
+    @unittest.mock.patch('avocado.utils.process.safe_kill')
+    @unittest.mock.patch('avocado.utils.process.get_children_pids')
     def test_kill_process_tree_nowait(self, get_children_pids, safe_kill,
                                       sleep):
         safe_kill.return_value = True
@@ -512,11 +521,11 @@ class MiscProcessTests(unittest.TestCase):
         self.assertEqual([1], process.kill_process_tree(1))
         self.assertEqual(sleep.call_count, 0)
 
-    @mock.patch('avocado.utils.process.safe_kill')
-    @mock.patch('avocado.utils.process.get_children_pids')
-    @mock.patch('avocado.utils.process.time.time')
-    @mock.patch('avocado.utils.process.time.sleep')
-    @mock.patch('avocado.utils.process.pid_exists')
+    @unittest.mock.patch('avocado.utils.process.safe_kill')
+    @unittest.mock.patch('avocado.utils.process.get_children_pids')
+    @unittest.mock.patch('avocado.utils.process.time.time')
+    @unittest.mock.patch('avocado.utils.process.time.sleep')
+    @unittest.mock.patch('avocado.utils.process.pid_exists')
     def test_kill_process_tree_timeout_3s(self, pid_exists, sleep, p_time,
                                           get_children_pids, safe_kill):
         safe_kill.return_value = True
@@ -529,11 +538,11 @@ class MiscProcessTests(unittest.TestCase):
                           timeout=3)
         self.assertLess(p_time.call_count, 10)
 
-    @mock.patch('avocado.utils.process.safe_kill')
-    @mock.patch('avocado.utils.process.get_children_pids')
-    @mock.patch('avocado.utils.process.time.time')
-    @mock.patch('avocado.utils.process.time.sleep')
-    @mock.patch('avocado.utils.process.pid_exists')
+    @unittest.mock.patch('avocado.utils.process.safe_kill')
+    @unittest.mock.patch('avocado.utils.process.get_children_pids')
+    @unittest.mock.patch('avocado.utils.process.time.time')
+    @unittest.mock.patch('avocado.utils.process.time.sleep')
+    @unittest.mock.patch('avocado.utils.process.pid_exists')
     def test_kill_process_tree_dont_timeout_3s(self, pid_exists, sleep,
                                                p_time, get_children_pids,
                                                safe_kill):
@@ -545,10 +554,10 @@ class MiscProcessTests(unittest.TestCase):
         self.assertEqual([76], process.kill_process_tree(76, timeout=3))
         self.assertLess(p_time.call_count, 10)
 
-    @mock.patch('avocado.utils.process.safe_kill')
-    @mock.patch('avocado.utils.process.get_children_pids')
-    @mock.patch('avocado.utils.process.time.sleep')
-    @mock.patch('avocado.utils.process.pid_exists')
+    @unittest.mock.patch('avocado.utils.process.safe_kill')
+    @unittest.mock.patch('avocado.utils.process.get_children_pids')
+    @unittest.mock.patch('avocado.utils.process.time.sleep')
+    @unittest.mock.patch('avocado.utils.process.pid_exists')
     def test_kill_process_tree_dont_timeout_infinity(self, pid_exists, sleep,
                                                      get_children_pids,
                                                      safe_kill):
@@ -562,9 +571,9 @@ class MiscProcessTests(unittest.TestCase):
         self.assertEqual(pid_exists.call_count, 6)
         self.assertEqual(sleep.call_count, 5)
 
-    @mock.patch('avocado.utils.process.time.sleep')
-    @mock.patch('avocado.utils.process.safe_kill')
-    @mock.patch('avocado.utils.process.get_children_pids')
+    @unittest.mock.patch('avocado.utils.process.time.sleep')
+    @unittest.mock.patch('avocado.utils.process.safe_kill')
+    @unittest.mock.patch('avocado.utils.process.get_children_pids')
     def test_kill_process_tree_children(self, get_children_pids, safe_kill,
                                         sleep):
         safe_kill.return_value = True

--- a/selftests/unit/test_utils_service.py
+++ b/selftests/unit/test_utils_service.py
@@ -16,12 +16,7 @@
 #  The full GNU General Public License is included in this distribution in
 #  the file called "COPYING".
 
-import unittest
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+import unittest.mock
 
 from avocado.utils import service
 
@@ -35,14 +30,14 @@ class TestMultipleInstances(unittest.TestCase):
 
     def test_different_runners(self):
         # Call 'set_target' on first runner
-        runner1 = mock.Mock()
+        runner1 = unittest.mock.Mock()
         runner1.return_value.stdout = 'systemd'
         service1 = service.service_manager(run=runner1)
         service1.set_target('foo_target')
         self.assertEqual(runner1.call_args[0][0],  # pylint: disable=E1136
                          'systemctl isolate foo_target')
         # Call 'start' on second runner
-        runner2 = mock.Mock()
+        runner2 = unittest.mock.Mock()
         runner2.return_value.stdout = 'init'
         service2 = service.service_manager(run=runner2)
         service2.start('foo_service')
@@ -127,15 +122,17 @@ class TestSysVInit(unittest.TestCase):
 class TestSpecificServiceManager(unittest.TestCase):
 
     def setUp(self):
-        self.run_mock = mock.Mock()
+        self.run_mock = unittest.mock.Mock()
         self.init_name = "init"
-        get_name_of_init_mock = mock.Mock(return_value="init")
+        get_name_of_init_mock = unittest.mock.Mock(return_value="init")
 
-        @mock.patch.object(service, "get_name_of_init", get_name_of_init_mock)
+        @unittest.mock.patch.object(service, "get_name_of_init",
+                                    get_name_of_init_mock)
         def patch_service_command_generator():
             return service._auto_create_specific_service_command_generator()
 
-        @mock.patch.object(service, "get_name_of_init", get_name_of_init_mock)
+        @unittest.mock.patch.object(service, "get_name_of_init",
+                                    get_name_of_init_mock)
         def patch_service_result_parser():
             return service._auto_create_specific_service_result_parser()
         service_command_generator = patch_service_command_generator()
@@ -180,7 +177,7 @@ class TestServiceManager(unittest.TestCase):
 class TestSystemdServiceManager(TestServiceManager):
 
     def setUp(self):
-        self.run_mock = mock.Mock()
+        self.run_mock = unittest.mock.Mock()
         self.init_name = "systemd"
         self.service_manager = \
             (super(TestSystemdServiceManager, self)
@@ -194,11 +191,12 @@ class TestSystemdServiceManager(TestServiceManager):
         self.assertEqual(self.run_mock.call_args[0][0], cmd)  # pylint: disable=E1136
 
     def test_list(self):
-        list_result_mock = mock.Mock(exit_status=0,
-                                     stdout_text="sshd.service enabled\n"
-                                     "vsftpd.service disabled\n"
-                                     "systemd-sysctl.service static\n")
-        run_mock = mock.Mock(return_value=list_result_mock)
+        list_result_mock = unittest.mock.Mock(
+            exit_status=0,
+            stdout_text="sshd.service enabled\n"
+            "vsftpd.service disabled\n"
+            "systemd-sysctl.service static\n")
+        run_mock = unittest.mock.Mock(return_value=list_result_mock)
         service_manager = \
             (super(TestSystemdServiceManager, self)
              .get_service_manager_from_init_and_run(self.init_name, run_mock))
@@ -212,13 +210,13 @@ class TestSystemdServiceManager(TestServiceManager):
 
     def test_set_default_runlevel(self):
         runlevel = service.convert_sysv_runlevel(3)
-        mktemp_mock = mock.Mock(return_value="temp_filename")
-        symlink_mock = mock.Mock()
-        rename_mock = mock.Mock()
+        mktemp_mock = unittest.mock.Mock(return_value="temp_filename")
+        symlink_mock = unittest.mock.Mock()
+        rename_mock = unittest.mock.Mock()
 
-        @mock.patch.object(service, "mktemp", mktemp_mock)
-        @mock.patch("os.symlink", symlink_mock)
-        @mock.patch("os.rename", rename_mock)
+        @unittest.mock.patch.object(service, "mktemp", mktemp_mock)
+        @unittest.mock.patch("os.symlink", symlink_mock)
+        @unittest.mock.patch("os.rename", rename_mock)
         def _():
             self.service_manager.change_default_runlevel(runlevel)
             self.assertTrue(mktemp_mock.called)
@@ -243,7 +241,7 @@ class TestSystemdServiceManager(TestServiceManager):
 class TestSysVInitServiceManager(TestServiceManager):
 
     def setUp(self):
-        self.run_mock = mock.Mock()
+        self.run_mock = unittest.mock.Mock()
         self.init_name = "init"
         self.service_manager = \
             super(TestSysVInitServiceManager,
@@ -257,7 +255,7 @@ class TestSysVInitServiceManager(TestServiceManager):
         self.assertEqual(self.run_mock.call_args[0][0], cmd)  # pylint: disable=E1136
 
     def test_list(self):
-        list_result_mock = mock.Mock(
+        list_result_mock = unittest.mock.Mock(
             exit_status=0,
             stdout_text="sshd             0:off   1:off   "
             "2:off   3:off   4:off   5:off   6:off\n"
@@ -267,7 +265,7 @@ class TestSysVInitServiceManager(TestServiceManager):
             "        amanda:         off\n"
             "        chargen-dgram:  on\n")
 
-        run_mock = mock.Mock(return_value=list_result_mock)
+        run_mock = unittest.mock.Mock(return_value=list_result_mock)
         service_manager = \
             super(TestSysVInitServiceManager,
                   self).get_service_manager_from_init_and_run(self.init_name,

--- a/selftests/unit/test_utils_vmimage.py
+++ b/selftests/unit/test_utils_vmimage.py
@@ -1,10 +1,5 @@
-import unittest
-try:
-    from unittest import mock
-except ImportError:
-    import mock
-
-from six.moves.urllib.error import HTTPError
+import unittest.mock
+from urllib.error import HTTPError
 
 from avocado.utils import vmimage
 
@@ -63,31 +58,31 @@ class ImageProviderBase(unittest.TestCase):
         html = '<html><head><title>Test</title></head><body>%s</body></html>'
         return html % ''.join(['<a href="%s/" />' % v for v in versions])
 
-    @mock.patch('avocado.utils.vmimage.urlopen')
+    @unittest.mock.patch('avocado.utils.vmimage.urlopen')
     def test_get_version(self, urlopen_mock):
         html_fixture = self.get_html_with_versions([10, 11, 12])
-        urlread_mocked = mock.Mock(return_value=html_fixture)
-        urlopen_mock.return_value = mock.Mock(read=urlread_mocked)
+        urlread_mocked = unittest.mock.Mock(return_value=html_fixture)
+        urlopen_mock.return_value = unittest.mock.Mock(read=urlread_mocked)
         base_image = vmimage.ImageProviderBase(version='[0-9]+', build=None, arch=None)
         self.assertEqual(base_image.get_version(), 12)
 
-    @mock.patch('avocado.utils.vmimage.urlopen')
+    @unittest.mock.patch('avocado.utils.vmimage.urlopen')
     def test_get_version_with_float_versions(self, urlopen_mock):
         html_fixture = self.get_html_with_versions([10.1, 10.3, 10.2])
-        urlread_mocked = mock.Mock(return_value=html_fixture)
-        urlopen_mock.return_value = mock.Mock(read=urlread_mocked)
+        urlread_mocked = unittest.mock.Mock(return_value=html_fixture)
+        urlopen_mock.return_value = unittest.mock.Mock(read=urlread_mocked)
         base_image = vmimage.ImageProviderBase(version=r'[0-9]+\.[0-9]+', build=None, arch=None)
         self.assertEqual(base_image.get_version(), 10.3)
 
-    @mock.patch('avocado.utils.vmimage.urlopen')
+    @unittest.mock.patch('avocado.utils.vmimage.urlopen')
     def test_get_version_with_string_versions(self, urlopen_mock):
         html_fixture = self.get_html_with_versions(['abc', 'abcd', 'abcde'])
-        urlread_mocked = mock.Mock(return_value=html_fixture)
-        urlopen_mock.return_value = mock.Mock(read=urlread_mocked)
+        urlread_mocked = unittest.mock.Mock(return_value=html_fixture)
+        urlopen_mock.return_value = unittest.mock.Mock(read=urlread_mocked)
         base_image = vmimage.ImageProviderBase(version=r'[\w]+', build=None, arch=None)
         self.assertEqual(base_image.get_version(), 'abcde')
 
-    @mock.patch('avocado.utils.vmimage.urlopen')
+    @unittest.mock.patch('avocado.utils.vmimage.urlopen')
     def test_get_version_from_bad_url_open(self, urlopen_mock):
         urlopen_mock.side_effect = HTTPError(None, None, None, None, None)
         base_image = vmimage.ImageProviderBase(version='[0-9]+', build=None, arch=None)
@@ -97,11 +92,11 @@ class ImageProviderBase(unittest.TestCase):
 
         self.assertIn('Cannot open', exc.exception.args[0])
 
-    @mock.patch('avocado.utils.vmimage.urlopen')
+    @unittest.mock.patch('avocado.utils.vmimage.urlopen')
     def test_get_version_versions_not_found(self, urlopen_mock):
         html_fixture = self.get_html_with_versions([])
-        urlread_mocked = mock.Mock(return_value=html_fixture)
-        urlopen_mock.return_value = mock.Mock(read=urlread_mocked)
+        urlread_mocked = unittest.mock.Mock(return_value=html_fixture)
+        urlopen_mock.return_value = unittest.mock.Mock(read=urlread_mocked)
         base_image = vmimage.ImageProviderBase(version='[0-9]+', build=None, arch=None)
 
         with self.assertRaises(vmimage.ImageProviderError) as exc:
@@ -143,29 +138,29 @@ class OpenSUSEImageProvider(unittest.TestCase):
         self.assertEqual(suse_provider.get_best_version(self.suse_available_versions),
                          suse_latest_version)
 
-    @mock.patch('avocado.utils.vmimage.urlopen')
+    @unittest.mock.patch('avocado.utils.vmimage.urlopen')
     def test_get_image_url(self, urlopen_mock):
         image = 'openSUSE-Leap-15.0-OpenStack.x86_64-0.0.4-Buildlp150.12.30.qcow2'
         html_fixture = self.get_html_with_image_link(image)
-        urlread_mocked = mock.Mock(return_value=html_fixture)
-        urlopen_mock.return_value = mock.Mock(read=urlread_mocked)
+        urlread_mocked = unittest.mock.Mock(return_value=html_fixture)
+        urlopen_mock.return_value = unittest.mock.Mock(read=urlread_mocked)
         expected_image_url = self.base_images_url + image
 
         suse_provider = vmimage.OpenSUSEImageProvider(arch='x86_64')
-        suse_provider.get_version = mock.Mock(return_value='15.0')
+        suse_provider.get_version = unittest.mock.Mock(return_value='15.0')
         self.assertEqual(suse_provider.get_image_url(), expected_image_url)
 
-    @mock.patch('avocado.utils.vmimage.urlopen')
+    @unittest.mock.patch('avocado.utils.vmimage.urlopen')
     def test_get_image_url_defining_build(self, urlopen_mock):
         image = 'openSUSE-Leap-15.0-OpenStack.x86_64-1.1.1-Buildlp111.11.11.qcow2'
         html_fixture = self.get_html_with_image_link(image)
-        urlread_mocked = mock.Mock(return_value=html_fixture)
-        urlopen_mock.return_value = mock.Mock(read=urlread_mocked)
+        urlread_mocked = unittest.mock.Mock(return_value=html_fixture)
+        urlopen_mock.return_value = unittest.mock.Mock(read=urlread_mocked)
         expected_image_url = self.base_images_url + image
 
         suse_provider = vmimage.OpenSUSEImageProvider(build='1.1.1-Buildlp111.11.11',
                                                       arch='x86_64')
-        suse_provider.get_version = mock.Mock(return_value='15.0')
+        suse_provider.get_version = unittest.mock.Mock(return_value='15.0')
         self.assertEqual(suse_provider.get_image_url(), expected_image_url)
 
 

--- a/selftests/unit/test_xunit.py
+++ b/selftests/unit/test_xunit.py
@@ -4,11 +4,7 @@ import shutil
 import tempfile
 import unittest
 from xml.dom import minidom
-
-try:
-    from io import BytesIO
-except ImportError:
-    from BytesIO import BytesIO
+from io import BytesIO
 
 try:
     from lxml import etree

--- a/setup.py
+++ b/setup.py
@@ -30,10 +30,7 @@ def get_long_description():
     return req_contents
 
 
-INSTALL_REQUIREMENTS = ['requests', 'stevedore>=0.14', 'six>=1.10.0', 'setuptools']
-
-if sys.version_info[0] == 2:
-    INSTALL_REQUIREMENTS.append('enum34')
+INSTALL_REQUIREMENTS = ['requests', 'stevedore>=0.14', 'setuptools']
 
 if __name__ == '__main__':
     # Force "make develop" inside the "readthedocs.org" environment
@@ -55,8 +52,6 @@ if __name__ == '__main__':
               "Operating System :: POSIX",
               "Topic :: Software Development :: Quality Assurance",
               "Topic :: Software Development :: Testing",
-              "Programming Language :: Python :: 2",
-              "Programming Language :: Python :: 2.7",
               "Programming Language :: Python :: 3",
               "Programming Language :: Python :: 3.4",
               "Programming Language :: Python :: 3.5",
@@ -112,5 +107,5 @@ if __name__ == '__main__':
               },
           zip_safe=False,
           test_suite='selftests',
-          python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+          python_requires='>=3.4',
           install_requires=INSTALL_REQUIREMENTS)


### PR DESCRIPTION
And the compatiblity helper six.  With Python 2 gone, a number of
package changes are also introduced, so that the packages are always
named python3-<suffix>.

Also, because it would be confusing not having an "avocado" script,
and to conform with the system wide change introduced by distros that
now offer Python 3 by default, the scripts are no longer called
avocado-3 (or avocado-3.x), but simply "avocado".

Signed-off-by: Cleber Rosa <crosa@redhat.com>

---

Changes from v2 (#3054):
* Updated unittest library pointer to 3.6 (@wainersm)
* Used a single import pattern for `unittest.mock` (@wainersm)

Changes from v1 (#3049):
* Rebased after CI hotfix