### PR TITLE
[LTS] Docs: add link to LTS version of the Copr repo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -201,14 +201,14 @@ ppc64le.
 If you're interested in using the very latest development version of
 Avocado from RPM packages, you can do so by running::
 
-  dnf copr enable @avocado/avocado-latest
+  dnf copr enable @avocado/avocado-latest-lts
   dnf install python*-avocado*
 
 The following image shows the status of the Avocado packages building
 on COPR:
 
-  .. image:: https://copr.fedorainfracloud.org/coprs/g/avocado/avocado-latest/package/python-avocado/status_image/last_build.png
-     :target: https://copr.fedorainfracloud.org/coprs/g/avocado/avocado-latest/package/python-avocado/
+  .. image:: https://copr.fedorainfracloud.org/coprs/g/avocado/avocado-latest-lts/package/python-avocado/status_image/last_build.png
+     :target: https://copr.fedorainfracloud.org/coprs/g/avocado/avocado-latest-lts/package/python-avocado/
 
 OpenSUSE
 ~~~~~~~~

--- a/docs/source/GetStartedGuide.rst
+++ b/docs/source/GetStartedGuide.rst
@@ -187,14 +187,14 @@ ppc64le.
 If you're interested in using the very latest development version of
 Avocado from RPM packages, you can do so by running::
 
-  dnf copr enable @avocado/avocado-latest
+  dnf copr enable @avocado/avocado-latest-lts
   dnf install python*-avocado*
 
 The following image shows the status of the Avocado packages building
 on COPR:
 
-  .. image:: https://copr.fedorainfracloud.org/coprs/g/avocado/avocado-latest/package/python-avocado/status_image/last_build.png
-     :target: https://copr.fedorainfracloud.org/coprs/g/avocado/avocado-latest/package/python-avocado/
+  .. image:: https://copr.fedorainfracloud.org/coprs/g/avocado/avocado-latest-lts/package/python-avocado/status_image/last_build.png
+     :target: https://copr.fedorainfracloud.org/coprs/g/avocado/avocado-latest-lts/package/python-avocado/
 
 OpenSUSE
 ~~~~~~~~


### PR DESCRIPTION
The "avocado-latest" Copr repo currently points to packages that are
built with the latest master branch.  Now, there's also a
"avocado-latest-lts" Copr repo, which points to the "latest state of
the latest LTS" branch, which means, the 69lts branch.

So, if a fix makes its way to 69lts, and users want that fix before a
minor version is released, they'd find that fix in the packages
generated from this repo.

Signed-off-by: Cleber Rosa <crosa@redhat.com>