### PR TITLE
avocado/utils/vmimage.py: fix build usage

### DIFF
--- a/avocado/utils/vmimage.py
+++ b/avocado/utils/vmimage.py
@@ -407,7 +407,7 @@ def get(name=None, version=None, build=None, arch=None, checksum=None,
     if version is not None:
         provider_args['version'] = version
     if build is not None:
-        provider_args['build'] = version
+        provider_args['build'] = build
     if arch is not None:
         provider_args['arch'] = arch
         if name == 'fedora' and arch in ('ppc64', 'ppc64le'):


### PR DESCRIPTION
The build of a given image, when given to avocado.utils.vmimage.get()
is incorrectly being assigned the same version number.

Signed-off-by: Cleber Rosa <crosa@redhat.com>