### PR TITLE
Settings Dispatcher: move it to its own module

### DIFF
--- a/avocado/core/dispatcher.py
+++ b/avocado/core/dispatcher.py
@@ -12,7 +12,13 @@
 # Copyright: Red Hat Inc. 2015
 # Author: Cleber Rosa <cleber@redhat.com>
 
-"""Extensions/plugins dispatchers."""
+"""
+Extensions/plugins dispatchers
+
+Besides the dispatchers listed here, there's also a lower level
+dispatcher that these depend upon:
+:class:`avocado.core.settings_dispatcher.SettingsDispatcher`
+"""
 
 import copy
 import sys
@@ -21,14 +27,8 @@ from stevedore import EnabledExtensionManager
 
 from .settings import settings
 from .settings import SettingsError
-from .settings import SettingsDispatcher
 from .output import LOG_UI
 from ..utils import stacktrace
-
-
-#: Settings dispatcher is simplified and has to be available before the
-#: settings object. Let's include it here for consistency
-SettingsDispatcher = SettingsDispatcher
 
 
 class Dispatcher(EnabledExtensionManager):

--- a/avocado/core/settings.py
+++ b/avocado/core/settings.py
@@ -27,26 +27,9 @@ except ImportError:
 from pkg_resources import resource_filename
 from pkg_resources import resource_isdir
 from pkg_resources import resource_listdir
-from stevedore import ExtensionManager
 
+from .settings_dispatcher import SettingsDispatcher
 from ..utils import path
-
-
-class SettingsDispatcher(ExtensionManager):
-
-    """
-    Dispatchers that allows plugins to modify settings
-
-    It's not the standard "avocado.core.dispatcher" because that one depends
-    on settings. This dispatcher is the bare-stevedore dispatcher which is
-    executed before settings is parsed.
-    """
-
-    def __init__(self):
-        super(SettingsDispatcher, self).__init__('avocado.plugins.settings',
-                                                 invoke_on_load=True,
-                                                 invoke_kwds={},
-                                                 propagate_map_exceptions=True)
 
 
 class SettingsError(Exception):

--- a/avocado/core/settings_dispatcher.py
+++ b/avocado/core/settings_dispatcher.py
@@ -1,0 +1,41 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2018-2019
+
+"""
+Settings Dispatcher
+
+This is a special case for the dispatchers that can be found in
+:mod:`avocado.core.dispatcher`.  This one deals with settings that
+will be read by the other dispatchers, while still being a dispatcher
+for configuration sources.
+"""
+
+
+from stevedore import ExtensionManager
+
+
+class SettingsDispatcher(ExtensionManager):
+
+    """
+    Dispatchers that allows plugins to modify settings
+
+    It's not the standard "avocado.core.dispatcher" because that one depends
+    on settings. This dispatcher is the bare-stevedore dispatcher which is
+    executed before settings is parsed.
+    """
+
+    def __init__(self):
+        super(SettingsDispatcher, self).__init__('avocado.plugins.settings',
+                                                 invoke_on_load=True,
+                                                 invoke_kwds={},
+                                                 propagate_map_exceptions=True)


### PR DESCRIPTION
This avoids the circular import that was originally a problem, and
removes the "weird" SettingsDispatcher assignment to itself, while
still adding documentation to keep this and the other dispatchers
"linked".

Reference: https://github.com/avocado-framework/avocado/issues/3065
Signed-off-by: Cleber Rosa <crosa@redhat.com>