### PR TITLE
Selftests: use builtins.open for mock

### DIFF
--- a/selftests/__init__.py
+++ b/selftests/__init__.py
@@ -13,21 +13,6 @@ AVOCADO = os.environ.get("UNITTEST_AVOCADO_CMD",
                          "%s ./scripts/avocado" % sys.executable)
 
 
-def recent_mock():
-    '''
-    Checks if a recent and capable enough mock library is available
-
-    On Python 3, mock from the standard library is used, but Python
-    3.6 or later is required.
-
-    Also, it assumes that on a future Python major version, functionality
-    won't regress.
-    '''
-    if sys.version_info[0] == 3:
-        return sys.version_info[1] >= 6
-    return sys.version_info[0] > 3
-
-
 def python_module_available(module_name):
     '''
     Checks if a given Python module is available

--- a/selftests/unit/test_utils_cpu.py
+++ b/selftests/unit/test_utils_cpu.py
@@ -1,7 +1,6 @@
 import io
 import unittest.mock
 
-from .. import recent_mock
 from avocado.utils import cpu
 
 
@@ -14,8 +13,6 @@ class Cpu(unittest.TestCase):
         file_mock.__exit__ = unittest.mock.Mock()
         return file_mock
 
-    @unittest.skipUnless(recent_mock(),
-                         "mock library version cannot (easily) patch open()")
     def test_s390x_cpu_online(self):
         s390x = b"""vendor_id       : IBM/S390
 # processors    : 2
@@ -78,15 +75,13 @@ cpu MHz static  : 5504
 
         with unittest.mock.patch('avocado.utils.cpu.platform.machine',
                                  return_value='s390x'):
-            with unittest.mock.patch('avocado.utils.cpu.open',
+            with unittest.mock.patch('builtins.open',
                                      return_value=self._get_file_mock(s390x)):
                 self.assertEqual(len(cpu.cpu_online_list()), 2)
-            with unittest.mock.patch('avocado.utils.cpu.open',
+            with unittest.mock.patch('builtins.open',
                                      return_value=self._get_file_mock(s390x_2)):
                 self.assertEqual(len(cpu.cpu_online_list()), 4)
 
-    @unittest.skipUnless(recent_mock(),
-                         "mock library version cannot (easily) patch open()")
     def test_x86_64_cpu_online(self):
         x86_64 = b"""processor	: 0
 vendor_id	: GenuineIntel
@@ -307,12 +302,10 @@ power management:
 """
         with unittest.mock.patch('avocado.utils.cpu.platform.machine',
                                  return_value='x86_64'):
-            with unittest.mock.patch('avocado.utils.cpu.open',
+            with unittest.mock.patch('builtins.open',
                                      return_value=self._get_file_mock(x86_64)):
                 self.assertEqual(len(cpu.cpu_online_list()), 8)
 
-    @unittest.skipUnless(recent_mock(),
-                         "mock library version cannot (easily) patch open()")
     def test_cpu_arch_i386(self):
         cpu_output = b"""processor       : 0
 vendor_id       : GenuineIntel
@@ -344,12 +337,10 @@ cache_alignment : 64
 address sizes   : 32 bits physical, 32 bits virtual
 power management:
 """
-        with unittest.mock.patch('avocado.utils.cpu.open',
+        with unittest.mock.patch('builtins.open',
                                  return_value=self._get_file_mock(cpu_output)):
             self.assertEqual(cpu.get_cpu_arch(), "i386")
 
-    @unittest.skipUnless(recent_mock(),
-                         "mock library version cannot (easily) patch open()")
     def test_cpu_arch_x86_64(self):
         cpu_output = b"""processor       : 0
 vendor_id       : GenuineIntel
@@ -378,12 +369,10 @@ cache_alignment : 64
 address sizes   : 39 bits physical, 48 bits virtual
 power management:
 """
-        with unittest.mock.patch('avocado.utils.cpu.open',
+        with unittest.mock.patch('builtins.open',
                                  return_value=self._get_file_mock(cpu_output)):
             self.assertEqual(cpu.get_cpu_arch(), "x86_64")
 
-    @unittest.skipUnless(recent_mock(),
-                         "mock library version cannot (easily) patch open()")
     def test_cpu_arch_ppc64_power8(self):
         cpu_output = b"""processor       : 88
 cpu             : POWER8E (raw), altivec supported
@@ -396,12 +385,10 @@ model           : 8247-21L
 machine         : PowerNV 8247-21L
 firmware        : OPAL v3
 """
-        with unittest.mock.patch('avocado.utils.cpu.open',
+        with unittest.mock.patch('builtins.open',
                                  return_value=self._get_file_mock(cpu_output)):
             self.assertEqual(cpu.get_cpu_arch(), "power8")
 
-    @unittest.skipUnless(recent_mock(),
-                         "mock library version cannot (easily) patch open()")
     def test_cpu_arch_ppc64_le_power8(self):
         cpu_output = b"""processor       : 88
 cpu             : POWER8E (raw), altivec supported
@@ -414,12 +401,10 @@ model           : 8247-21L
 machine         : PowerNV 8247-21L
 firmware        : OPAL v3
 """
-        with unittest.mock.patch('avocado.utils.cpu.open',
+        with unittest.mock.patch('builtins.open',
                                  return_value=self._get_file_mock(cpu_output)):
             self.assertEqual(cpu.get_cpu_arch(), "power8")
 
-    @unittest.skipUnless(recent_mock(),
-                         "mock library version cannot (easily) patch open()")
     def test_cpu_arch_ppc64_le_power9(self):
         cpu_output = b"""processor	: 20
 cpu		: POWER9 (raw), altivec supported
@@ -432,12 +417,10 @@ model		: 8375-42A
 machine		: PowerNV 8375-42A
 firmware	: OPAL
 """
-        with unittest.mock.patch('avocado.utils.cpu.open',
+        with unittest.mock.patch('builtins.open',
                                  return_value=self._get_file_mock(cpu_output)):
             self.assertEqual(cpu.get_cpu_arch(), "power9")
 
-    @unittest.skipUnless(recent_mock(),
-                         "mock library version cannot (easily) patch open()")
     def test_cpu_arch_s390(self):
         cpu_output = b"""vendor_id       : IBM/S390
 # processors    : 2
@@ -462,12 +445,10 @@ cpu number      : 1
 cpu MHz dynamic : 5504
 cpu MHz static  : 5504
 """
-        with unittest.mock.patch('avocado.utils.cpu.open',
+        with unittest.mock.patch('builtins.open',
                                  return_value=self._get_file_mock(cpu_output)):
             self.assertEqual(cpu.get_cpu_arch(), "s390")
 
-    @unittest.skipUnless(recent_mock(),
-                         "mock library version cannot (easily) patch open()")
     def test_cpu_arch_arm_v7(self):
         cpu_output = b"""Processor       : ARMv7 Processor rev 2 (v7l)
 BogoMIPS        : 994.65
@@ -482,12 +463,10 @@ Hardware        : herring
 Revision        : 0034
 Serial          : 3534268a5e0700ec
 """
-        with unittest.mock.patch('avocado.utils.cpu.open',
+        with unittest.mock.patch('builtins.open',
                                  return_value=self._get_file_mock(cpu_output)):
             self.assertEqual(cpu.get_cpu_arch(), "arm")
 
-    @unittest.skipUnless(recent_mock(),
-                         "mock library version cannot (easily) patch open()")
     def test_cpu_arch_arm_v8(self):
         cpu_output = b"""processor       : 0
 BogoMIPS        : 200.00
@@ -498,81 +477,69 @@ CPU variant     : 0x1
 CPU part        : 0x0a1
 CPU revision    : 1
 """
-        with unittest.mock.patch('avocado.utils.cpu.open',
+        with unittest.mock.patch('builtins.open',
                                  return_value=self._get_file_mock(cpu_output)):
             self.assertEqual(cpu.get_cpu_arch(), "aarch64")
 
-    @unittest.skipUnless(recent_mock(),
-                         "mock library version cannot (easily) patch open()")
     def test_cpu_arch_risc_v(self):
         cpu_output = b"""hart	: 1
 isa	: rv64imafdc
 mmu	: sv39
 uarch	: sifive,rocket0
 """
-        with unittest.mock.patch('avocado.utils.cpu.open',
+        with unittest.mock.patch('builtins.open',
                                  return_value=self._get_file_mock(cpu_output)):
             self.assertEqual(cpu.get_cpu_arch(), "riscv")
 
-    @unittest.skipUnless(recent_mock(),
-                         "mock library version cannot (easily) patch open()")
     def test_get_cpuidle_state_off(self):
         retval = {0: {0: 0}}
         with unittest.mock.patch('avocado.utils.cpu.cpu_online_list',
                                  return_value=[0]):
             with unittest.mock.patch('glob.glob',
                                      return_value=['/sys/devices/system/cpu/cpu0/cpuidle/state1']):
-                with unittest.mock.patch('avocado.utils.cpu.open',
+                with unittest.mock.patch('builtins.open',
                                          return_value=io.BytesIO(b'0')):
                     self.assertEqual(cpu.get_cpuidle_state(), retval)
 
-    @unittest.skipUnless(recent_mock(),
-                         "mock library version cannot (easily) patch open()")
     def test_get_cpuidle_state_on(self):
         retval = {0: {0: 1}}
         with unittest.mock.patch('avocado.utils.cpu.cpu_online_list',
                                  return_value=[0]):
             with unittest.mock.patch('glob.glob',
                                      return_value=['/sys/devices/system/cpu/cpu0/cpuidle/state1']):
-                with unittest.mock.patch('avocado.utils.cpu.open',
+                with unittest.mock.patch('builtins.open',
                                          return_value=io.BytesIO(b'1')):
                     self.assertEqual(cpu.get_cpuidle_state(), retval)
 
-    @unittest.skipUnless(recent_mock(),
-                         "mock library version cannot (easily) patch open()")
     def test_set_cpuidle_state_default(self):
         output = io.BytesIO()
         with unittest.mock.patch('avocado.utils.cpu.cpu_online_list',
                                  return_value=[0]):
             with unittest.mock.patch('glob.glob',
                                      return_value=['/sys/devices/system/cpu/cpu0/cpuidle/state1']):
-                with unittest.mock.patch('avocado.utils.cpu.open',
+                with unittest.mock.patch('builtins.open',
                                          return_value=output):
                     cpu.set_cpuidle_state()
                     self.assertEqual(output.getvalue(), b'1')
 
-    @unittest.skipUnless(recent_mock(),
-                         "mock library version cannot (easily) patch open()")
     def test_set_cpuidle_state_withstateno(self):
         output = io.BytesIO()
         with unittest.mock.patch('avocado.utils.cpu.cpu_online_list',
                                  return_value=[0]):
             with unittest.mock.patch('glob.glob',
                                      return_value=['/sys/devices/system/cpu/cpu0/cpuidle/state2']):
-                with unittest.mock.patch('avocado.utils.cpu.open',
+                with unittest.mock.patch('builtins.open',
                                          return_value=output):
                     cpu.set_cpuidle_state(disable=False, state_number='2')
                     self.assertEqual(output.getvalue(), b'0')
 
-    @unittest.skipUnless(recent_mock(),
-                         "mock library version cannot (easily) patch open()")
     def test_set_cpuidle_state_withsetstate(self):
         output = io.BytesIO()
         with unittest.mock.patch('avocado.utils.cpu.cpu_online_list',
                                  return_value=[0, 2]):
             with unittest.mock.patch('glob.glob',
                                      return_value=['/sys/devices/system/cpu/cpu0/cpuidle/state1']):
-                with unittest.mock.patch('avocado.utils.cpu.open',
+                with unittest.mock.patch('builtins.open',
                                          return_value=output):
                     cpu.set_cpuidle_state(setstate={0: {0: 1}, 2: {0: 0}})
                     self.assertEqual(output.getvalue(), b'10')

--- a/selftests/unit/test_utils_disk.py
+++ b/selftests/unit/test_utils_disk.py
@@ -1,7 +1,5 @@
-import sys
 import unittest.mock
 
-from .. import recent_mock
 from avocado.utils import disk
 from avocado.utils import process
 
@@ -40,11 +38,6 @@ PROC_MOUNTS = (
 
 class Disk(unittest.TestCase):
 
-    @property
-    def builtin_open(self):
-        py_version = sys.version_info[0]
-        return 'builtins.open' if py_version == 3 else '__builtin__.open'
-
     def test_empty(self):
         mock_result = process.CmdResult(
             command='lsblk --json',
@@ -61,27 +54,21 @@ class Disk(unittest.TestCase):
                                  return_value=mock_result):
             self.assertEqual(disk.get_disks(), ['/dev/vda'])
 
-    @unittest.skipUnless(recent_mock(),
-                         "mock library version cannot (easily) patch open()")
     def test_get_filesystems(self):
         expected_fs = ['dax', 'bpf', 'pipefs', 'hugetlbfs', 'devpts', 'ext3']
         open_mocked = unittest.mock.mock_open(read_data=PROC_FILESYSTEMS)
-        with unittest.mock.patch(self.builtin_open, open_mocked):
+        with unittest.mock.patch('builtins.open', open_mocked):
             self.assertEqual(sorted(expected_fs),
                              sorted(disk.get_available_filesystems()))
 
-    @unittest.skipUnless(recent_mock(),
-                         "mock library version cannot (easily) patch open()")
     def test_get_filesystem_type_default_root(self):
         open_mocked = unittest.mock.mock_open(read_data=PROC_MOUNTS)
-        with unittest.mock.patch(self.builtin_open, open_mocked):
+        with unittest.mock.patch('builtins.open', open_mocked):
             self.assertEqual('ext4', disk.get_filesystem_type())
 
-    @unittest.skipUnless(recent_mock(),
-                         "mock library version cannot (easily) patch open()")
     def test_get_filesystem_type(self):
         open_mocked = unittest.mock.mock_open(read_data=PROC_MOUNTS)
-        with unittest.mock.patch(self.builtin_open, open_mocked):
+        with unittest.mock.patch('builtins.open', open_mocked):
             self.assertEqual('ext2', disk.get_filesystem_type(mount_point='/home'))
 
 

--- a/selftests/unit/test_utils_linux_modules.py
+++ b/selftests/unit/test_utils_linux_modules.py
@@ -1,7 +1,6 @@
 import io
 import unittest.mock
 
-from .. import recent_mock
 from avocado.utils import linux_modules
 
 
@@ -195,10 +194,8 @@ video 45056 2 thinkpad_acpi,i915, Live 0x0000000000000000
                                       'used': 1,
                                       'submodules': ['ebtable_broute']})
 
-    @unittest.skipUnless(recent_mock(),
-                         "mock library version cannot (easily) patch open()")
     def test_is_module_loaded(self):
-        with unittest.mock.patch('avocado.utils.linux_modules.open',
+        with unittest.mock.patch('builtins.open',
                                  return_value=self._get_file_mock(self.PROC_MODULES_OUT)):
             self.assertTrue(linux_modules.module_is_loaded("rfcomm"))
             self.assertFalse(linux_modules.module_is_loaded("unknown_module"))

--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -7,7 +7,6 @@ import sys
 import time
 
 
-from .. import recent_mock
 from avocado.utils import astring
 from avocado.utils import script
 from avocado.utils import gdb
@@ -422,11 +421,9 @@ class MiscProcessTests(unittest.TestCase):
                          [u"avok\xe1do_test_runner",
                           u"arguments"])
 
-    @unittest.skipUnless(recent_mock(),
-                         "mock library version cannot (easily) patch open()")
     def test_get_parent_pid(self):
         stat = b'18405 (bash) S 24139 18405 18405 34818 8056 4210688 9792 170102 0 7 11 4 257 84 20 0 1 0 44336493 235409408 4281 18446744073709551615 94723230367744 94723231442728 140723100226000 0 0 0 65536 3670020 1266777851 0 0 0 17 1 0 0 0 0 0 94723233541456 94723233588580 94723248717824 140723100229613 140723100229623 140723100229623 140723100233710 0'
-        with unittest.mock.patch('avocado.utils.process.open',
+        with unittest.mock.patch('builtins.open',
                                  return_value=io.BytesIO(stat)):
             self.assertTrue(process.get_parent_pid(0), 24139)
 


### PR DESCRIPTION
When the recent_mock() utility was introduced, I may have missed the
fact that it would be possible to mock builtins.open().  Or, it may
be that was only possible in Python 3.

Anyway, now that we only support Python 3, let's just mock
builtins.open() and drop this custom decorator.

Signed-off-by: Cleber Rosa <crosa@redhat.com>