### PR TITLE
Python 2 leftovers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 ifndef PYTHON
-PYTHON=$(shell which python3 2>/dev/null || which python2 2>/dev/null || which python 2>/dev/null)
+PYTHON=$(shell which python3 2>/dev/null || which python 2>/dev/null)
 endif
 VERSION=$(shell $(PYTHON) setup.py --version 2>/dev/null)
 PYTHON_DEVELOP_ARGS=$(shell if ($(PYTHON) setup.py develop --help 2>/dev/null | grep -q '\-\-user'); then echo "--user"; else echo ""; fi)

--- a/avocado/core/settings.py
+++ b/avocado/core/settings.py
@@ -13,16 +13,12 @@
 # Author: Travis Miller <raphtee@google.com>
 
 """
-Reads the avocado settings from a .ini file (from python ConfigParser).
+Reads the avocado settings from a .ini file (with Python's configparser).
 """
 import ast
 import os
 import glob
-
-try:
-    import ConfigParser
-except ImportError:
-    import configparser as ConfigParser
+import configparser
 
 from pkg_resources import resource_filename
 from pkg_resources import resource_isdir
@@ -144,7 +140,7 @@ def convert_value_type(value, value_type):
 class Settings(object):
 
     """
-    Simple wrapper around ConfigParser, with a key type conversion available.
+    Simple wrapper around configparser, with a key type conversion available.
     """
 
     no_default = object()
@@ -155,7 +151,7 @@ class Settings(object):
 
         :param config_path: Path to a config file. Useful for unittesting.
         """
-        self.config = ConfigParser.ConfigParser()
+        self.config = configparser.ConfigParser()
         self.config_paths = []
         self.all_config_paths = []
         _source_tree_root = os.path.dirname(os.path.dirname(os.path.dirname(
@@ -295,9 +291,9 @@ class Settings(object):
         """
         try:
             val = self.config.get(section, key)
-        except ConfigParser.NoSectionError:
+        except configparser.NoSectionError:
             return self._handle_no_section(section, default)
-        except ConfigParser.Error:
+        except configparser.Error:
             return self._handle_no_value(section, key, default)
 
         if not val.strip() and not allow_blank:

--- a/avocado/utils/astring.py
+++ b/avocado/utils/astring.py
@@ -28,7 +28,6 @@ And not notice until their code starts failing.
 import itertools
 import locale
 import re
-import sys
 import string
 
 from six import string_types, PY3
@@ -315,8 +314,6 @@ def is_text(data):
     That is, if it can hold text that requires more than one byte for
     each character.
     """
-    if sys.version_info[0] < 3:
-        return isinstance(data, unicode)   # pylint: disable=E0602
     return isinstance(data, str)
 
 
@@ -341,8 +338,5 @@ def to_text(data, encoding=ENCODING, errors='strict'):
             encoding = ENCODING
         return data.decode(encoding, errors=errors)
     elif not isinstance(data, string_types):
-        if sys.version_info[0] < 3:
-            return unicode(data)    # pylint: disable=E0602
-        else:
-            return str(data)
+        return str(data)
     return data

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -28,7 +28,6 @@ import shutil
 import signal
 import stat
 import subprocess
-import sys
 import threading
 import time
 
@@ -312,14 +311,8 @@ def cmd_split(cmd):
 
     :param cmd: text (a multi byte string) encoded as 'utf-8'
     """
-    if sys.version_info[0] < 3:
-        data = cmd.encode('utf-8')
-        result = shlex.split(data)
-        result = [i.decode('utf-8') for i in result]
-    else:
-        data = astring.to_text(cmd, 'utf-8')
-        result = shlex.split(data)
-    return result
+    data = astring.to_text(cmd, 'utf-8')
+    return shlex.split(data)
 
 
 class CmdResult(object):

--- a/avocado/utils/software_manager.py
+++ b/avocado/utils/software_manager.py
@@ -40,6 +40,7 @@ import shutil
 import logging
 import optparse
 import tempfile
+import configparser
 
 try:
     import yum
@@ -47,11 +48,6 @@ except ImportError:
     HAS_YUM_MODULE = False
 else:
     HAS_YUM_MODULE = True
-
-try:
-    import ConfigParser
-except ImportError:
-    import configparser as ConfigParser
 
 from . import process
 from . import data_factory
@@ -403,7 +399,7 @@ class YumBackend(RpmBackend):
         base_arguments = '-y'
         self.base_command = executable + ' ' + base_arguments
         self.repo_file_path = '/etc/yum.repos.d/avocado-managed.repo'
-        self.cfgparser = ConfigParser.ConfigParser()
+        self.cfgparser = configparser.ConfigParser()
         self.cfgparser.read(self.repo_file_path)
         y_cmd = executable + ' --version | head -1'
         cmd_result = process.run(y_cmd, ignore_status=True,

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,9 +1,12 @@
 # Makefile for Sphinx documentation
 #
+ifndef PYTHON
+PYTHON=$(shell which python3 2>/dev/null || which python 2>/dev/null)
+endif
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = sphinx-build
+SPHINXBUILD   = $(PYTHON) -m sphinx
 PAPER         =
 BUILDDIR      = build
 

--- a/docs/source/Configuration.rst
+++ b/docs/source/Configuration.rst
@@ -8,7 +8,7 @@ and that's why a configuration system is in place to help with those cases
 
 The Avocado config file format is based on the (informal)
 `INI file 'specification' <http://en.wikipedia.org/wiki/INI_file>`__, that is implemented by
-Python's  :mod:`ConfigParser`. The format is simple and straightforward, composed by `sections`,
+Python's  :mod:`configparser`. The format is simple and straightforward, composed by `sections`,
 that contain a number of `keys` and `values`. Take for example a basic Avocado config file:
 
 .. code-block:: ini

--- a/optional_plugins/varianter_cit/tests/test_functional.py
+++ b/optional_plugins/varianter_cit/tests/test_functional.py
@@ -3,11 +3,11 @@ import unittest
 
 from avocado.utils import process
 
+from selftests import AVOCADO
+
 
 basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..', '..')
 basedir = os.path.abspath(basedir)
-
-AVOCADO = os.environ.get("UNITTEST_AVOCADO_CMD", "./scripts/avocado")
 
 
 class Variants(unittest.TestCase):

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -156,13 +156,9 @@ class RunnerOperationTest(unittest.TestCase):
     def test_show_version(self):
         result = process.run('%s -v' % AVOCADO, ignore_status=True)
         self.assertEqual(result.exit_status, 0)
-        if sys.version_info[0] == 3:
-            content = result.stdout_text
-        else:
-            content = result.stderr_text
-        self.assertTrue(re.match(r"^Avocado \d+\.\d+$", content),
+        self.assertTrue(re.match(r"^Avocado \d+\.\d+$", result.stdout_text),
                         "Version string does not match 'Avocado \\d\\.\\d:'\n"
-                        "%r" % (content))
+                        "%r" % (result.stdout_text))
 
     def test_alternate_config_datadir(self):
         """
@@ -438,11 +434,8 @@ class RunnerOperationTest(unittest.TestCase):
         cmd_line = AVOCADO
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_FAIL)
-        if sys.version_info[0] == 3:
-            exp = b'avocado: error: the following arguments are required'
-        else:
-            exp = b'error: too few arguments'
-        self.assertIn(exp, result.stderr)
+        self.assertIn(b'avocado: error: the following arguments are required',
+                      result.stderr)
 
     def test_empty_test_list(self):
         cmd_line = '%s run --sysinfo=off --job-results-dir %s' % (AVOCADO,
@@ -1120,8 +1113,7 @@ class PluginsTest(AbsPluginsTest, unittest.TestCase):
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %d:\n%s" %
                          (expected_rc, result))
-        if sys.version_info[:2] >= (2, 7, 0):
-            self.assertNotIn(b'Disabled', result.stdout)
+        self.assertNotIn(b'Disabled', result.stdout)
 
     def test_config_plugin(self):
         cmd_line = '%s config --paginator off' % AVOCADO

--- a/selftests/functional/test_loader.py
+++ b/selftests/functional/test_loader.py
@@ -6,7 +6,6 @@ import stat
 import tempfile
 import shutil
 import signal
-import sys
 import unittest
 
 from avocado.core import exit_codes
@@ -265,8 +264,6 @@ class LoaderTestFunctional(unittest.TestCase):
                     % (AVOCADO, self.tmpdir, mytest))
         self._run_with_timeout(cmd_line, 5)
 
-    @unittest.skipIf(sys.version_info[0] == 3,
-                     "Test currently broken on Python 3")
     @unittest.skipUnless(os.path.exists("/bin/true"), "/bin/true not "
                          "available")
     @unittest.skipUnless(os.path.exists("/bin/echo"), "/bin/echo not "

--- a/selftests/functional/test_standalone.py
+++ b/selftests/functional/test_standalone.py
@@ -48,10 +48,7 @@ class StandaloneTests(unittest.TestCase):
         cmd_line = '%s ./examples/tests/errortest_nasty.py -r' % PY_CMD
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         result = self.run_and_check(cmd_line, expected_rc, 'errortest_nasty')
-        if sys.version_info[0] == 3:
-            exc = u"errortest_nasty.NastyException: Nasty-string-like-exception\u017e"
-        else:
-            exc = u"NastyException: Nasty-string-like-exception\\u017e"
+        exc = u"errortest_nasty.NastyException: Nasty-string-like-exception\u017e"
         count = result.stdout_text.count(u"\n%s" % exc)
         self.assertEqual(count, 2, "Exception \\n%s should be present twice in"
                          "the log (once from the log, second time when parsing"
@@ -68,10 +65,7 @@ class StandaloneTests(unittest.TestCase):
         cmd_line = '%s ./examples/tests/errortest_nasty3.py -r' % PY_CMD
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         result = self.run_and_check(cmd_line, expected_rc, 'errortest_nasty3')
-        if sys.version_info[0] == 3:
-            exc = b"TypeError: exceptions must derive from BaseException"
-        else:
-            exc = b"TestError: <errortest_nasty3.NastyException instance at "
+        exc = b"TypeError: exceptions must derive from BaseException"
         self.assertIn(exc, result.stdout)
 
     def test_errortest(self):

--- a/selftests/unit/test_astring.py
+++ b/selftests/unit/test_astring.py
@@ -88,11 +88,7 @@ class AstringTest(unittest.TestCase):
         self.assertFalse(astring.is_bytes(text))
         self.assertTrue(hasattr(binary, 'decode'))
         self.assertTrue(astring.is_text(binary.decode()))
-        # on Python 2, each str member is also a single byte char
-        if sys.version_info[0] < 3:
-            self.assertTrue(astring.is_bytes(str('')))
-        else:
-            self.assertFalse(astring.is_bytes(str('')))
+        self.assertFalse(astring.is_bytes(str('')))
 
     def test_is_text(self):
         """

--- a/selftests/unit/test_utils_disk.py
+++ b/selftests/unit/test_utils_disk.py
@@ -1,4 +1,3 @@
-import sys
 import unittest.mock
 
 from .. import recent_mock
@@ -40,11 +39,6 @@ PROC_MOUNTS = (
 
 class Disk(unittest.TestCase):
 
-    @property
-    def builtin_open(self):
-        py_version = sys.version_info[0]
-        return 'builtins.open' if py_version == 3 else '__builtin__.open'
-
     def test_empty(self):
         mock_result = process.CmdResult(
             command='lsblk --json',
@@ -66,7 +60,7 @@ class Disk(unittest.TestCase):
     def test_get_filesystems(self):
         expected_fs = ['dax', 'bpf', 'pipefs', 'hugetlbfs', 'devpts', 'ext3']
         open_mocked = unittest.mock.mock_open(read_data=PROC_FILESYSTEMS)
-        with unittest.mock.patch(self.builtin_open, open_mocked):
+        with unittest.mock.patch('builtins.open', open_mocked):
             self.assertEqual(sorted(expected_fs),
                              sorted(disk.get_available_filesystems()))
 
@@ -74,14 +68,14 @@ class Disk(unittest.TestCase):
                          "mock library version cannot (easily) patch open()")
     def test_get_filesystem_type_default_root(self):
         open_mocked = unittest.mock.mock_open(read_data=PROC_MOUNTS)
-        with unittest.mock.patch(self.builtin_open, open_mocked):
+        with unittest.mock.patch('builtins.open', open_mocked):
             self.assertEqual('ext4', disk.get_filesystem_type())
 
     @unittest.skipUnless(recent_mock(),
                          "mock library version cannot (easily) patch open()")
     def test_get_filesystem_type(self):
         open_mocked = unittest.mock.mock_open(read_data=PROC_MOUNTS)
-        with unittest.mock.patch(self.builtin_open, open_mocked):
+        with unittest.mock.patch('builtins.open', open_mocked):
             self.assertEqual('ext2', disk.get_filesystem_type(mount_point='/home'))
 
 


### PR DESCRIPTION
Even though explicit Python 2 support was dropped, there are still some leftovers, unneeded code to accommodate it.

Let's clean those up.