### PR TITLE
Docs: remove mention of azure plugin

### DIFF
--- a/docs/source/OtherResources.rst
+++ b/docs/source/OtherResources.rst
@@ -25,5 +25,4 @@ Public test repositories
 * `Avocado Misc Tests <https://github.com/avocado-framework-tests/avocado-misc-tests>`__
 * `Cockpit tests <https://github.com/cockpit-project/cockpit/tree/master/test/avocado>`__
 * `Modularity framework tests (uses custom docker image) <https://github.com/fedora-modularity/meta-test-family>`__
-* `Azure Tests (requires plugin) <https://github.com/yuxisun1217/avocado-azure/>`__
 * `OpenPOWER Host OS and Guest Virtual Machine (VM) stability tests <https://github.com/open-power-host-os/>`__

--- a/docs/source/optional_plugins/azure.rst
+++ b/docs/source/optional_plugins/azure.rst
@@ -1,8 +1,0 @@
-.. _azure-plugin:
-
-============
-Azure Plugin
-============
-
-This plugin allows you to run tests on Microsoft Azure Virtual
-Machine instances. `Details available here <https://github.com/yuxisun1217/avocado-azure>`__

--- a/docs/source/optional_plugins/index.rst
+++ b/docs/source/optional_plugins/index.rst
@@ -20,4 +20,3 @@ optional plugins:
    golang
    glib
    avocado_ec2
-   azure


### PR DESCRIPTION
Because of deprecation according to author.

Reference: https://github.com/avocado-framework/avocado/issues/3074
Signed-off-by: Cleber Rosa <crosa@redhat.com>