### PR TITLE
[PoC] add support for tearDown() timeouts

### DIFF
--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -216,14 +216,12 @@ class TestStatus(object):
                notifications)
         """
         # Wait for either process termination or test status
-        wait.wait_for(lambda: not proc.is_alive() or self.status, 1, 0,
-                      step)
+        wait.wait_for(lambda: not proc.is_alive() or self.status, 1, 0, step)
         if self.status:     # status exists, wait for process to finish
             deadline = min(deadline, time.time() + TIMEOUT_PROCESS_ALIVE)
             while time.time() < deadline:
                 result_dispatcher.map_method('test_progress', False)
-                if wait.wait_for(lambda: not proc.is_alive(), 1, 0,
-                                 step):
+                if wait.wait_for(lambda: not proc.is_alive(), 1, 0, step):
                     return self._add_status_failures(self.status)
             err = "Test reported status but did not finish"
         else:   # proc finished, wait for late status delivery

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -61,7 +61,7 @@ TEST_STATE_ATTRIBUTES = ('name', 'logdir', 'logfile',
                          'status', 'running', 'paused',
                          'time_start', 'time_elapsed', 'time_end',
                          'fail_reason', 'fail_class', 'traceback',
-                         'timeout', 'whiteboard')
+                         'timeout', 'whiteboard', 'phase')
 
 
 class RawFileHandler(logging.FileHandler):
@@ -336,6 +336,8 @@ class Test(unittest.TestCase, TestData):
                             :func:`avocado.data_dir.create_job_logs_dir`.
         :param job: The job that this test is part of.
         """
+        self.__phase = 'INIT'
+
         def record_and_warn(*args, **kwargs):
             """ Record call to this function and log warning """
             if not self.__log_warn_used:
@@ -591,6 +593,15 @@ class Test(unittest.TestCase, TestData):
     def traceback(self):
         return self.__traceback
 
+    @property
+    def phase(self):
+        """
+        The current phase of the test execution
+
+        Possible (string) values are: INIT, SETUP, TEST and TEARDOWN
+        """
+        return self.__phase
+
     def __str__(self):
         return str(self.name)
 
@@ -821,6 +832,7 @@ class Test(unittest.TestCase, TestData):
         skip_test = getattr(testMethod, '__skip_test_decorator__', False)
         try:
             if skip_test is False:
+                self.__phase = 'SETUP'
                 self.setUp()
         except exceptions.TestSkipError as details:
             skip_test = True
@@ -835,6 +847,7 @@ class Test(unittest.TestCase, TestData):
             raise exceptions.TestSetupFail(details)
         else:
             try:
+                self.__phase = 'TEST'
                 testMethod()
             except exceptions.TestCancel as details:
                 stacktrace.log_exc_info(sys.exc_info(), logger=LOG_JOB)
@@ -852,6 +865,7 @@ class Test(unittest.TestCase, TestData):
         finally:
             try:
                 if skip_test is False:
+                    self.__phase = 'TEARDOWN'
                     self.tearDown()
             except exceptions.TestSkipError as details:
                 stacktrace.log_exc_info(sys.exc_info(), logger=LOG_JOB)
@@ -995,6 +1009,7 @@ class Test(unittest.TestCase, TestData):
             for e_line in tb_info:
                 self.log.error(e_line)
         finally:
+            self.__phase = 'FINISHED'
             self._tag_end()
             self._report()
             self.log.info("")

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -833,6 +833,7 @@ class Test(unittest.TestCase, TestData):
         try:
             if skip_test is False:
                 self.__phase = 'SETUP'
+                self.report_state()
                 self.setUp()
         except exceptions.TestSkipError as details:
             skip_test = True
@@ -848,6 +849,7 @@ class Test(unittest.TestCase, TestData):
         else:
             try:
                 self.__phase = 'TEST'
+                self.report_state()
                 testMethod()
             except exceptions.TestCancel as details:
                 stacktrace.log_exc_info(sys.exc_info(), logger=LOG_JOB)
@@ -866,6 +868,7 @@ class Test(unittest.TestCase, TestData):
             try:
                 if skip_test is False:
                     self.__phase = 'TEARDOWN'
+                    self.report_state()
                     self.tearDown()
             except exceptions.TestSkipError as details:
                 stacktrace.log_exc_info(sys.exc_info(), logger=LOG_JOB)

--- a/examples/tests/longteardown.py
+++ b/examples/tests/longteardown.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+
+import time
+
+from avocado import main
+from avocado import Test
+
+
+class LongTearDown(Test):
+
+    """
+    Example test with a longer than usual tearDown()
+    """
+
+    timeout = 1.0
+
+    def test(self):
+        """
+        Should be interrupted because of sleep longer than test timeout
+        """
+        time.sleep(2)
+
+    def tearDown(self):
+        time.sleep(2)
+        self.whiteboard = 'TEARDOWN PERFORMED'
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/tests/phases.py
+++ b/examples/tests/phases.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+
+from avocado import main
+from avocado import Test
+
+
+class Phases(Test):
+
+    """
+    Example test for checking the reported test phases
+    """
+
+    def setUp(self):
+        self.assertEqual(self.phase, 'SETUP')
+
+    def test(self):
+        self.assertEqual(self.phase, 'TEST')
+
+    def tearDown(self):
+        self.assertEqual(self.phase, 'TEARDOWN')
+
+
+if __name__ == "__main__":
+    main()

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -196,6 +196,14 @@ class RunnerOperationTest(unittest.TestCase):
         self.assertIn('    data     ' + mapping['data_dir'], result.stdout_text)
         self.assertIn('    logs     ' + mapping['logs_dir'], result.stdout_text)
 
+    def test_runner_phases(self):
+        cmd_line = ('%s run --sysinfo=off --job-results-dir %s '
+                    'phases.py' % (AVOCADO, self.tmpdir))
+        result = process.run(cmd_line)
+        expected_rc = exit_codes.AVOCADO_ALL_OK
+        self.assertEqual(result.exit_status, expected_rc,
+                         "Avocado did not return rc %d:\n%s" % (expected_rc, result))
+
     def test_runner_all_ok(self):
         cmd_line = ('%s run --sysinfo=off --job-results-dir %s '
                     'passtest.py passtest.py' % (AVOCADO, self.tmpdir))

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -315,7 +315,9 @@ class RunnerOperationTest(unittest.TestCase):
             self.assertEqual(results["tests"][0]["status"], "ERROR",
                              "%s != %s\n%s" % (results["tests"][0]["status"],
                                                "ERROR", res))
-            self.assertIn("Test died without reporting the status",
+            self.assertIn("Test reports unsupported test status",
+                          results["tests"][0]["fail_reason"])
+            self.assertIn("status: None",
                           results["tests"][0]["fail_reason"])
 
     def test_runner_tests_fail(self):

--- a/selftests/unit/test_runner_queue.py
+++ b/selftests/unit/test_runner_queue.py
@@ -61,6 +61,7 @@ class TestRunnerQueue(unittest.TestCase):
         msg = self._run_test(factory)
 
         self.assertEqual(msg['whiteboard'], 'TXkgbWVzc2FnZSBlbmNvZGVkIGluIGJhc2U2NA==\n')
+        self.assertIn('phase', msg)
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir)


### PR DESCRIPTION
This is a PoC, based on https://github.com/avocado-framework/avocado/issues/2908.

Feedback and testing is welcome.