### PR TITLE
six: completely remove the library

### DIFF
--- a/avocado/plugins/json_variants.py
+++ b/avocado/plugins/json_variants.py
@@ -15,8 +15,6 @@
 import json
 import sys
 
-from six import iteritems
-
 from avocado.core import exit_codes
 from avocado.core import varianter
 from avocado.core.output import LOG_UI
@@ -135,7 +133,7 @@ class JsonVariants(Varianter):
                     continue
                 env = set()
                 for node in variant["variant"]:
-                    for key, value in iteritems(node.environment):
+                    for key, value in node.environment.items():
                         origin = node.environment.origin[key].path
                         env.add(("%s:%s" % (origin, key), str(value)))
                 if not env:

--- a/avocado/plugins/list.py
+++ b/avocado/plugins/list.py
@@ -14,8 +14,6 @@
 
 import sys
 
-from six import string_types
-
 from avocado.core import exit_codes, output
 from avocado.core import loader
 from avocado.core import test
@@ -66,7 +64,7 @@ class TestLister(object):
             stats[value.lower()] = 0
 
         for cls, params in test_suite:
-            if isinstance(cls, string_types):
+            if isinstance(cls, str):
                 cls = test.Test
             type_label = type_label_mapping[cls]
             decorator = decorator_mapping[cls]

--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -18,8 +18,6 @@ import os
 import re
 import sys
 
-from six.moves import xrange as range
-
 from avocado.core import exit_codes
 from avocado.core import jobdata
 from avocado.core import status

--- a/avocado/utils/archive.py
+++ b/avocado/utils/archive.py
@@ -23,8 +23,6 @@ import stat
 import tarfile
 import zipfile
 
-from six import iteritems
-
 
 LOG = logging.getLogger(__name__)
 
@@ -234,7 +232,7 @@ class ArchiveFile(object):
             LOG.warn("Attr handling in zip files only supported on Linux.")
             return
         # Walk all files and re-create files as symlinks
-        for path, info in iteritems(self._engine.NameToInfo):
+        for path, info in self._engine.NameToInfo.items():
             dst = os.path.join(dst_dir, path)
             if not os.path.exists(dst):
                 LOG.warn("One or more files in the ZIP archive '%s' could "

--- a/avocado/utils/astring.py
+++ b/avocado/utils/astring.py
@@ -28,11 +28,6 @@ And not notice until their code starts failing.
 import itertools
 import locale
 import re
-import string
-
-from six import string_types, PY3
-from six.moves import zip
-from six.moves import xrange as range
 
 
 #: On import evaluated value representing the system encoding
@@ -45,11 +40,8 @@ ENCODING = locale.getpreferredencoding()
 FS_UNSAFE_CHARS = '<>:"/\\|?*;'
 
 # Translate table to replace fs-unfriendly chars
-if PY3:
-    _FS_TRANSLATE = bytes.maketrans(bytes(FS_UNSAFE_CHARS, "ascii"),
-                                    b'__________')
-else:
-    _FS_TRANSLATE = string.maketrans(FS_UNSAFE_CHARS, '__________')
+_FS_TRANSLATE = bytes.maketrans(bytes(FS_UNSAFE_CHARS, "ascii"),
+                                b'__________')
 
 
 def bitlist_to_string(data):
@@ -192,8 +184,6 @@ def iter_tabular_output(matrix, header=None, strip=False):
         len_matrix.append([])
         str_matrix.append([string_safe_encode(column) for column in row])
         for i, column in enumerate(str_matrix[-1]):
-            if not PY3:
-                column = column.decode("utf-8")
             col_len = len(strip_console_codes(column))
             len_matrix[-1].append(col_len)
             try:
@@ -254,16 +244,9 @@ def string_safe_encode(input_str):
                       be turned into a string
     :returns: a utf-8 encoded ascii stream
     """
-    if not isinstance(input_str, string_types):
+    if not isinstance(input_str, str):
         input_str = str(input_str)
-
-    if PY3:
-        return input_str
-
-    try:
-        return input_str.encode("utf-8")
-    except UnicodeDecodeError:
-        return input_str.decode("utf-8", "replace").encode("utf-8")
+    return input_str
 
 
 def string_to_safe_path(input_str):
@@ -337,6 +320,6 @@ def to_text(data, encoding=ENCODING, errors='strict'):
         if encoding is None:
             encoding = ENCODING
         return data.decode(encoding, errors=errors)
-    elif not isinstance(data, string_types):
+    elif not isinstance(data, str):
         return str(data)
     return data

--- a/avocado/utils/cloudinit.py
+++ b/avocado/utils/cloudinit.py
@@ -19,7 +19,8 @@ This module can be easily used with :mod:`avocado.utils.vmimage`,
 to configure operating system images via the cloudinit tooling.
 """
 
-from six.moves import BaseHTTPServer
+from http.server import HTTPServer
+from http.server import BaseHTTPRequestHandler
 
 from . import astring
 from . import iso9660
@@ -120,7 +121,7 @@ def iso(output_path, instance_id, username=None, password=None,
     out.close()
 
 
-class PhoneHomeServerHandler(BaseHTTPServer.BaseHTTPRequestHandler):
+class PhoneHomeServerHandler(BaseHTTPRequestHandler):
 
     def do_POST(self):
         path = self.path[1:]
@@ -134,10 +135,10 @@ class PhoneHomeServerHandler(BaseHTTPServer.BaseHTTPRequestHandler):
         pass
 
 
-class PhoneHomeServer(BaseHTTPServer.HTTPServer):
+class PhoneHomeServer(HTTPServer):
 
     def __init__(self, address, instance_id):
-        BaseHTTPServer.HTTPServer.__init__(self, address, PhoneHomeServerHandler)
+        HTTPServer.__init__(self, address, PhoneHomeServerHandler)
         self.instance_id = instance_id
         self.instance_phoned_back = False
 

--- a/avocado/utils/data_factory.py
+++ b/avocado/utils/data_factory.py
@@ -22,8 +22,6 @@ import random
 import string
 import tempfile
 
-from six.moves import xrange as range
-
 _RAND_POOL = random.SystemRandom()
 
 log = logging.getLogger('avocado.test')

--- a/avocado/utils/data_structures.py
+++ b/avocado/utils/data_structures.py
@@ -25,8 +25,6 @@ avocado core code or plugins.
 import sys
 import math
 
-from six.moves import zip
-
 
 class InvalidDataSize(ValueError):
     """

--- a/avocado/utils/debug.py
+++ b/avocado/utils/debug.py
@@ -19,9 +19,6 @@ import logging
 import time
 import os
 
-from six import iteritems
-from six import get_function_code
-
 
 # Use this for debug logging
 LOGGER = logging.getLogger("avocado.app.debug")
@@ -55,7 +52,7 @@ def log_calls_class(length=None):
     :param length: Max message length
     """
     def wrap(orig_cls):
-        for key, attr in iteritems(orig_cls.__dict__):
+        for key, attr in orig_cls.__dict__.items():
             if callable(attr):
                 setattr(orig_cls, key,
                         _log_calls(attr, length, orig_cls.__name__))
@@ -70,11 +67,11 @@ def _log_calls(func, length=None, cls_name=None):
     def wrapper(*args, **kwargs):
         """ Wrapper function """
         msg = ("CALL: %s:%s%s(%s, %s)"
-               % (os.path.relpath(get_function_code(func).co_filename),
+               % (os.path.relpath(func.__code__.co_filename),
                   cls_name, func.__name__,
                   ", ".join([str(_) for _ in args]),
                   ", ".join(["%s=%s" % (key, value)
-                             for key, value in iteritems(kwargs)])))
+                             for key, value in kwargs.items()])))
         if length:
             msg = msg[:length]
         LOGGER.debug(msg)

--- a/avocado/utils/download.py
+++ b/avocado/utils/download.py
@@ -22,7 +22,7 @@ import os
 import socket
 import shutil
 
-from six.moves.urllib.request import urlopen
+from urllib.request import urlopen
 
 from . import aurl
 from . import output

--- a/avocado/utils/external/spark.py
+++ b/avocado/utils/external/spark.py
@@ -23,8 +23,6 @@ __version__ = 'SPARK-0.7 (pre-alpha-7)'
 
 import re
 
-from six.moves import xrange as range
-
 
 def _namelist(instance):
     namelist, namedict, classlist = [], {}, [instance.__class__]

--- a/avocado/utils/genio.py
+++ b/avocado/utils/genio.py
@@ -21,8 +21,6 @@ import os
 import time
 import re
 
-from six.moves import input
-
 from . import path as utils_path
 
 log = logging.getLogger('avocado.test')

--- a/avocado/utils/lv_utils.py
+++ b/avocado/utils/lv_utils.py
@@ -24,8 +24,6 @@ import re
 import shutil
 import time
 
-from six.moves import xrange as range
-
 from . import process
 
 

--- a/avocado/utils/network.py
+++ b/avocado/utils/network.py
@@ -19,8 +19,6 @@ Module with network related utility functions
 import socket
 import random
 
-from six.moves import xrange as range
-
 from .data_structures import Borg
 
 #: Families taken into account in this class

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -32,7 +32,6 @@ import threading
 import time
 
 from io import BytesIO, UnsupportedOperation
-from six import string_types
 
 from . import astring
 from . import gdb
@@ -364,7 +363,7 @@ class CmdResult(object):
     def stdout_text(self):
         if hasattr(self.stdout, 'decode'):
             return self.stdout.decode(self.encoding)
-        if isinstance(self.stdout, string_types):
+        if isinstance(self.stdout, str):
             return self.stdout
         raise TypeError("Unable to decode stdout into a string-like type")
 
@@ -372,7 +371,7 @@ class CmdResult(object):
     def stderr_text(self):
         if hasattr(self.stderr, 'decode'):
             return self.stderr.decode(self.encoding)
-        if isinstance(self.stderr, string_types):
+        if isinstance(self.stderr, str):
             return self.stderr
         raise TypeError("Unable to decode stderr into a string-like type")
 

--- a/avocado/utils/stacktrace.py
+++ b/avocado/utils/stacktrace.py
@@ -7,8 +7,6 @@ import inspect
 import pickle
 from pprint import pformat
 
-from six import string_types, iteritems
-
 
 def tb_info(exc_info):
     """
@@ -36,7 +34,7 @@ def log_exc_info(exc_info, logger=''):
     :param exc_info: Exception info produced by sys.exc_info()
     :param logger: Name or logger instance (defaults to '')
     """
-    if isinstance(logger, string_types):
+    if isinstance(logger, str):
         logger = logging.getLogger(logger)
     logger.error('')
     called_from = inspect.currentframe().f_back
@@ -55,7 +53,7 @@ def log_message(message, logger=''):
     :param message: Message
     :param logger: Name or logger instance (defaults to '')
     """
-    if isinstance(logger, string_types):
+    if isinstance(logger, str):
         logger = logging.getLogger(logger)
     for line in message.splitlines():
         logger.error(line)
@@ -84,7 +82,7 @@ def analyze_unpickable_item(path_prefix, obj):
             subitems = enumerate(obj.__iter__())
             path_prefix += "<%s>"
         elif hasattr(obj, "__dict__"):
-            subitems = iteritems(obj.__dict__)
+            subitems = obj.__dict__.items()
             path_prefix += ".%s"
         else:
             return [(path_prefix, obj)]

--- a/avocado/utils/vmimage.py
+++ b/avocado/utils/vmimage.py
@@ -21,10 +21,9 @@ import re
 import tempfile
 import uuid
 
-from six import itervalues
-from six.moves.urllib.request import urlopen
-from six.moves.urllib.error import HTTPError
-from six.moves.html_parser import HTMLParser
+from urllib.request import urlopen
+from urllib.error import HTTPError
+from html.parser import HTMLParser
 
 from . import archive
 from . import asset
@@ -435,7 +434,7 @@ def list_providers():
     """
     List the available Image Providers
     """
-    return set(_ for _ in itervalues(globals())
+    return set(_ for _ in globals().values()
                if (isinstance(_, type) and
                    issubclass(_, ImageProviderBase) and
                    hasattr(_, 'name')))

--- a/examples/plugins/job-pre-post/sleep/avocado_job_sleep.py
+++ b/examples/plugins/job-pre-post/sleep/avocado_job_sleep.py
@@ -1,7 +1,5 @@
 import time
 
-from six.moves import xrange as range
-
 from avocado.core.output import LOG_UI
 from avocado.core.settings import settings
 from avocado.core.plugin_interfaces import JobPre, JobPost

--- a/examples/tests/gdbtest.py
+++ b/examples/tests/gdbtest.py
@@ -2,8 +2,6 @@
 
 import os
 
-from six.moves import xrange as range
-
 from avocado import Test
 from avocado import main
 from avocado.utils import gdb

--- a/examples/tests/sleeptenmin.py
+++ b/examples/tests/sleeptenmin.py
@@ -3,8 +3,6 @@
 import os
 import time
 
-from six.moves import xrange as range
-
 from avocado import main
 from avocado import Test
 

--- a/optional_plugins/loader_yaml/avocado_loader_yaml/__init__.py
+++ b/optional_plugins/loader_yaml/avocado_loader_yaml/__init__.py
@@ -15,8 +15,6 @@
 
 import copy
 
-from six import iteritems
-
 from avocado.core import loader
 from avocado.core import parameters
 from avocado.core import output
@@ -86,7 +84,7 @@ class YamlTestsuiteLoader(loader.TestLoader):
             args = self.args
         else:
             args = copy.copy(self.args)
-            for key, value in iteritems(_args):
+            for key, value in _args.items():
                 setattr(args, key, value)
         extra_params = params.get("test_reference_resolver_extra", default={})
         if extra_params:

--- a/optional_plugins/resultsdb/avocado_resultsdb/__init__.py
+++ b/optional_plugins/resultsdb/avocado_resultsdb/__init__.py
@@ -21,7 +21,6 @@ import sys
 import time
 
 import resultsdb_api
-from six import iteritems
 
 from avocado.core.plugin_interfaces import CLI, ResultEvents, Result
 from avocado.core.settings import settings

--- a/optional_plugins/runner_vm/avocado_runner_vm/__init__.py
+++ b/optional_plugins/runner_vm/avocado_runner_vm/__init__.py
@@ -20,7 +20,6 @@ import time
 from xml.dom import minidom
 
 import libvirt
-from six import iteritems
 
 from avocado.core import exit_codes, exceptions
 from avocado.core.output import LOG_UI
@@ -330,7 +329,7 @@ class VM(object):
         ipversion = libvirt.VIR_IP_ADDR_TYPE_IPV4
 
         ifaces = self.domain.interfaceAddresses(querytype)
-        for _, data in iteritems(ifaces):
+        for _, data in ifaces.items():
             if data['addrs'] and data['hwaddr'] != '00:00:00:00:00:00':
                 ip_addr = data['addrs'][0]['addr']
                 ip_type = data['addrs'][0]['type']

--- a/optional_plugins/varianter_cit/avocado_varianter_cit/__init__.py
+++ b/optional_plugins/varianter_cit/avocado_varianter_cit/__init__.py
@@ -12,15 +12,12 @@
 #          Bestoun S. Ahmed <bestoon82@gmail.com>
 #          Cleber Rosa <crosa@redhat.com>
 
+import configparser
 import copy
 import itertools
 import os
 import random
 import sys
-
-from six import iteritems
-from six.moves import configparser
-from six.moves import zip
 
 from avocado.core import exit_codes
 from avocado.core import varianter

--- a/optional_plugins/varianter_pict/avocado_varianter_pict/__init__.py
+++ b/optional_plugins/varianter_pict/avocado_varianter_pict/__init__.py
@@ -17,8 +17,6 @@ import itertools
 import os
 import sys
 
-from six import iteritems
-
 from avocado.core import exit_codes
 from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLI
@@ -186,7 +184,7 @@ class VarianterPict(Varianter):
                 continue
             env = set()
             for node in variant["variant"]:
-                for key, value in iteritems(node.environment):
+                for key, value in node.environment.items():
                     origin = node.environment.origin[key].path
                     env.add(("%s:%s" % (origin, key), str(value)))
             if not env:

--- a/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/__init__.py
+++ b/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/__init__.py
@@ -26,8 +26,6 @@ try:
 except ImportError:
     from yaml import Loader
 
-from six import iteritems
-
 from avocado.core import exit_codes
 from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLI, Varianter
@@ -201,7 +199,7 @@ def _create_from_yaml(path, cls_node=mux.MuxTreeNode):
 
         def node_content_from_dict(node, values, using):
             """Processes dict values into the current node content"""
-            for key, value in iteritems(values):
+            for key, value in values.items():
                 if isinstance(key, mux.Control):
                     if key.code == YAML_USING:
                         using = _handle_control_tag_using(path, name, using, value)

--- a/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/mux.py
+++ b/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/mux.py
@@ -26,10 +26,6 @@ import itertools
 import re
 import os
 
-from six import iterkeys, iteritems
-from six.moves import xrange as range
-from six.moves import zip
-
 from avocado.core import tree
 from avocado.core import varianter
 from avocado.core import output
@@ -285,7 +281,7 @@ class ValueDict(dict):  # only container pylint: disable=R0903
         self.yaml = srcyaml
         self.node = node
         self.yaml_per_key = {}
-        for key, value in iteritems(values):
+        for key, value in values.items():
             self[key] = value
 
     def __setitem__(self, key, value):
@@ -311,7 +307,7 @@ class ValueDict(dict):  # only container pylint: disable=R0903
 
     def iteritems(self):
         """ Slower implementation with the use of __getitem__ """
-        for key in iterkeys(self):
+        for key in self:
             yield key, self[key]
 
     def items(self):
@@ -367,7 +363,7 @@ class MuxTreeNode(tree.TreeNode):
                 elif ctrl.code == REMOVE_VALUE:
                     remove = []
                     regexp = re.compile(ctrl.value)
-                    for key in iterkeys(self.value):
+                    for key in self.value:
                         if regexp.match(key):
                             remove.append(key)
                     for key in remove:

--- a/selftests/.data/whiteboard.py
+++ b/selftests/.data/whiteboard.py
@@ -2,8 +2,6 @@
 
 import base64
 
-from six.moves import xrange as range
-
 from avocado import Test
 from avocado import main
 

--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -14,8 +14,6 @@ from avocado.utils import gdb
 from avocado.utils import process
 from avocado.utils import path
 
-from six import string_types, PY2
-
 from .. import setup_avocado_loggers
 
 
@@ -590,15 +588,11 @@ class CmdResultTests(unittest.TestCase):
         result = process.CmdResult("ls", b"unicode_follows: \xc5\xa1",
                                    b"cp1250 follows: \xfd", 1, 2, 3,
                                    "wrong_encoding")
-        if PY2:
-            prefix = ''
-        else:
-            prefix = 'b'
         self.assertEqual(str(result), "command: 'ls'\nexit_status: 1"
                          "\nduration: 2\ninterrupted: False\npid: "
                          "3\nencoding: 'wrong_encoding'\nstdout: "
-                         "%s'unicode_follows: \\xc5\\xa1'\nstderr: "
-                         "%s'cp1250 follows: \\xfd'" % (prefix, prefix))
+                         "b'unicode_follows: \\xc5\\xa1'\nstderr: "
+                         "b'cp1250 follows: \\xfd'")
 
     def test_cmd_result_stdout_stderr_bytes(self):
         result = process.CmdResult()
@@ -607,8 +601,8 @@ class CmdResultTests(unittest.TestCase):
 
     def test_cmd_result_stdout_stderr_text(self):
         result = process.CmdResult()
-        self.assertTrue(isinstance(result.stdout_text, string_types))
-        self.assertTrue(isinstance(result.stderr_text, string_types))
+        self.assertTrue(isinstance(result.stdout_text, str))
+        self.assertTrue(isinstance(result.stderr_text, str))
 
     def test_cmd_result_stdout_stderr_already_text(self):
         result = process.CmdResult()
@@ -632,14 +626,10 @@ class CmdErrorTests(unittest.TestCase):
                                    b"cp1250 follows: \xfd", 1, 2, 3,
                                    "wrong_encoding")
         err = process.CmdError("ls", result, "please don't crash")
-        if PY2:
-            prefix = ''
-        else:
-            prefix = 'b'
         self.assertEqual(str(err), "Command 'ls' failed.\nstdout: "
-                         "%s'unicode_follows: \\xc5\\xa1'\nstderr: "
-                         "%s'cp1250 follows: \\xfd'\nadditional_info: "
-                         "please don't crash" % (prefix, prefix))
+                         "b'unicode_follows: \\xc5\\xa1'\nstderr: "
+                         "b'cp1250 follows: \\xfd'\nadditional_info: "
+                         "please don't crash")
 
 
 class FDDrainerTests(unittest.TestCase):


### PR DESCRIPTION
The previous working dropping Python 2, removed the explicit
requirement of the six module, but because stevedore depends
on it, it would still be installed.

Now, every trace of explicit six usage has been removed.

Signed-off-by: Cleber Rosa <crosa@redhat.com>