### PR TITLE
Fixed issue in avocado.utils.distro

### DIFF
--- a/avocado/utils/distro.py
+++ b/avocado/utils/distro.py
@@ -268,8 +268,8 @@ class RedHatProbe(Probe):
     CHECK_FILE = '/etc/redhat-release'
     CHECK_FILE_CONTAINS = 'Red Hat Enterprise Linux'
     CHECK_FILE_DISTRO_NAME = 'rhel'
-    CHECK_VERSION_REGEX = re.compile(
-        r'Red Hat Enterprise Linux \w+ release (\d{1,2})\.(\d{1,2}).*')
+    CHECK_VERSION_REGEX = re.compile(r'Red Hat Enterprise Linux\s+\w*\s*release\s+'
+                                     r'(\d{1,2})\.(\d{1,2}).*')
 
 
 class CentosProbe(RedHatProbe):


### PR DESCRIPTION
fixed redhat distro version check in Rhel8.0
/etc/redhat-release output pattern changed

cat /etc/redhat-release
Red Hat Enterprise Linux release 8.0 Beta (Ootpa)

changed regex pattern which handle Rhel8 case as well

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>