### PR TITLE
Distro detection: add unittests

### DIFF
--- a/selftests/unit/test_distro.py
+++ b/selftests/unit/test_distro.py
@@ -69,5 +69,26 @@ class ProbeTest(unittest.TestCase):
         self.assertEqual(distro_name, probed_distro_name)
 
 
+class DetectTest(unittest.TestCase):
+
+    def test_rhel_7_6(self):
+        open_mocked = unittest.mock.mock_open(
+            read_data='Red Hat Enterprise Linux Server release 7.6 (Maipo)\n')
+        with unittest.mock.patch('builtins.open', open_mocked):
+            detected = distro.RedHatProbe().get_distro()
+        self.assertEqual(detected.name, 'rhel')
+        self.assertEqual(detected.version, '7')
+        self.assertEqual(detected.release, '6')
+
+    def test_rhel_8_0(self):
+        open_mocked = unittest.mock.mock_open(
+            read_data='Red Hat Enterprise Linux release 8.0 (Ootpa)\n')
+        with unittest.mock.patch('builtins.open', open_mocked):
+            detected = distro.RedHatProbe().get_distro()
+        self.assertEqual(detected.name, 'rhel')
+        self.assertEqual(detected.version, '8')
+        self.assertEqual(detected.release, '0')
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
With the recent change to cover RHEL 8, let's make sure it doesn't
regress for itself, and for previous releases.

Signed-off-by: Cleber Rosa <crosa@redhat.com>