### PR TITLE
Drop notation of "new-style" classes

### DIFF
--- a/avocado/core/app.py
+++ b/avocado/core/app.py
@@ -29,7 +29,7 @@ from .parser import Parser
 from ..utils import process
 
 
-class AvocadoApp(object):
+class AvocadoApp:
 
     """
     Avocado application.

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -56,7 +56,7 @@ from .output import LOG_UI
 _NEW_ISSUE_LINK = 'https://github.com/avocado-framework/avocado/issues/new'
 
 
-class Job(object):
+class Job:
 
     """
     A Job is a set of operations performed on a test machine.
@@ -586,7 +586,7 @@ class Job(object):
                     pass
 
 
-class TestProgram(object):
+class TestProgram:
 
     """
     Convenience class to make avocado test modules executable.

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -56,7 +56,7 @@ ALL = DiscoverMode.ALL
 _RE_UNIT_TEST = re.compile(r'test.*')
 
 
-class MissingTest(object):
+class MissingTest:
     """
     Class representing reference which failed to be discovered
     """
@@ -198,7 +198,7 @@ class LoaderUnhandledReferenceError(LoaderError):
                    " ".join(self.unhandled_references)))
 
 
-class TestLoaderProxy(object):
+class TestLoaderProxy:
 
     def __init__(self):
         self._initialized_plugins = []
@@ -421,7 +421,7 @@ class TestLoaderProxy(object):
         self.registered_plugins = []
 
 
-class TestLoader(object):
+class TestLoader:
 
     """
     Base for test loader classes
@@ -502,11 +502,11 @@ class TestLoader(object):
         raise NotImplementedError
 
 
-class BrokenSymlink(object):
+class BrokenSymlink:
     """ Dummy object to represent reference pointing to a BrokenSymlink path """
 
 
-class AccessDeniedPath(object):
+class AccessDeniedPath:
     """ Dummy object to represent reference pointing to a inaccessible path """
 
 
@@ -549,7 +549,7 @@ def add_loader_options(parser):
                               'run tests from files'))
 
 
-class NotATest(object):
+class NotATest:
     """
     Class representing something that is not a test
     """

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -43,7 +43,7 @@ BUILTIN_STREAM_SETS = {'all': 'all builtin streams',
                        'none': 'disables regular output (leaving only errors enabled)'}
 
 
-class TermSupport(object):
+class TermSupport:
 
     COLOR_BLUE = '\033[94m'
     COLOR_GREEN = '\033[92m'
@@ -199,7 +199,7 @@ class TermSupport(object):
 TERM_SUPPORT = TermSupport()
 
 
-class _StdOutputFile(object):
+class _StdOutputFile:
 
     """
     File-like object which stores (_is_stdout, content) into the provided list
@@ -250,7 +250,7 @@ class _StdOutputFile(object):
                           if _[0] == self._is_stdout))
 
 
-class StdOutput(object):
+class StdOutput:
 
     """
     Class to modify sys.stdout/sys.stderr
@@ -516,7 +516,7 @@ class MemStreamHandler(logging.StreamHandler):
         """
 
 
-class Paginator(object):
+class Paginator:
 
     """
     Paginator that uses less to display contents on the terminal.
@@ -589,7 +589,7 @@ def disable_log_handler(logger):
     logger.propagate = False
 
 
-class LoggingFile(object):
+class LoggingFile:
 
     """
     File-like object that will receive messages pass them to logging.
@@ -652,7 +652,7 @@ class LoggingFile(object):
         self._prefixes = self._prefixes[:idx] + self._prefixes[idx+1:]
 
 
-class Throbber(object):
+class Throbber:
 
     """
     Produces a spinner used to notify progress in the application UI.

--- a/avocado/core/parameters.py
+++ b/avocado/core/parameters.py
@@ -23,7 +23,7 @@ class NoMatchError(KeyError):
     pass
 
 
-class AvocadoParams(object):
+class AvocadoParams:
 
     """
     Params object used to retrieve params from given path. It supports
@@ -194,7 +194,7 @@ class AvocadoParams(object):
                 yield (path, key, value)
 
 
-class AvocadoParam(object):
+class AvocadoParam:
 
     """
     This is a single slice params. It can contain multiple leaves and tries to

--- a/avocado/core/parser.py
+++ b/avocado/core/parser.py
@@ -65,7 +65,7 @@ class FileOrStdoutAction(argparse.Action):
         setattr(namespace, self.dest, values)
 
 
-class Parser(object):
+class Parser:
 
     """
     Class to Parse the command line arguments.

--- a/avocado/core/plugin_interfaces.py
+++ b/avocado/core/plugin_interfaces.py
@@ -16,7 +16,7 @@
 import abc
 
 
-class Plugin(object):
+class Plugin:
 
     __metaclass__ = abc.ABCMeta
 

--- a/avocado/core/restclient/cli/app.py
+++ b/avocado/core/restclient/cli/app.py
@@ -28,7 +28,7 @@ from ...output import LOG_UI
 __all__ = ['App']
 
 
-class App(object):
+class App:
 
     """
     Base class for CLI application

--- a/avocado/core/restclient/connection.py
+++ b/avocado/core/restclient/connection.py
@@ -58,7 +58,7 @@ class UnexpectedHttpStatusCode(Exception):
         return msg % (self.expected, self.received)
 
 
-class Connection(object):
+class Connection:
 
     """
     Connection to the avocado server

--- a/avocado/core/restclient/response.py
+++ b/avocado/core/restclient/response.py
@@ -34,7 +34,7 @@ class InvalidResultResponseError(Exception):
     """
 
 
-class BaseResponse(object):
+class BaseResponse:
 
     """
     Base class that provides commonly used features for response handling

--- a/avocado/core/result.py
+++ b/avocado/core/result.py
@@ -18,7 +18,7 @@ Contains the Result class, used for result accounting.
 """
 
 
-class Result(object):
+class Result:
 
     """
     Result class, holder for job (and its tests) result information.

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -82,7 +82,7 @@ def add_runner_failure(test_state, new_status, message):
     return test_state
 
 
-class TestStatus(object):
+class TestStatus:
 
     """
     Test status handler
@@ -266,7 +266,7 @@ class TestStatus(object):
         return self._add_status_failures(test_state)
 
 
-class TestRunner(object):
+class TestRunner:
 
     """
     A test runner class that displays tests results.

--- a/avocado/core/safeloader.py
+++ b/avocado/core/safeloader.py
@@ -27,7 +27,7 @@ import sys
 from ..utils import data_structures
 
 
-class AvocadoModule(object):
+class AvocadoModule:
     """
     Representation of a module that might contain avocado.Test tests
     """

--- a/avocado/core/settings.py
+++ b/avocado/core/settings.py
@@ -120,7 +120,7 @@ def convert_value_type(value, value_type):
     return conv_val
 
 
-class Settings(object):
+class Settings:
 
     """
     Simple wrapper around configparser, with a key type conversion available.

--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -32,7 +32,7 @@ from ..utils import path as utils_path
 log = logging.getLogger("avocado.sysinfo")
 
 
-class Collectible(object):
+class Collectible:
 
     """
     Abstract class for representing collectibles by sysinfo.
@@ -357,7 +357,7 @@ class LogWatcher(Collectible):
             log.error("Log file %s collection failed: %s", self.path, detail)
 
 
-class SysInfo(object):
+class SysInfo:
 
     """
     Log different system properties at some key control points:

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -89,7 +89,7 @@ class RawFileHandler(logging.FileHandler):
             self.handleError(record)
 
 
-class TestID(object):
+class TestID:
 
     """
     Test ID construction and representation according to specification
@@ -171,7 +171,7 @@ class TestID(object):
                                % (self.str_uid, str(self)))
 
 
-class TestData(object):
+class TestData:
 
     """
     Class that adds the ability for tests to have access to data files
@@ -1192,7 +1192,7 @@ class SimpleTest(Test):
         self._execute_cmd()
 
 
-class ExternalRunnerSpec(object):
+class ExternalRunnerSpec:
     """
     Defines the basic options used by ExternalRunner
     """

--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -114,7 +114,7 @@ class TreeEnvironment(dict):
                          astring.to_text(self.filter_out)))
 
 
-class TreeNodeEnvOnly(object):
+class TreeNodeEnvOnly:
 
     """
     Minimal TreeNode-like class providing interface for AvocadoParams
@@ -158,7 +158,7 @@ class TreeNodeEnvOnly(object):
         return self.path
 
 
-class TreeNode(object):
+class TreeNode:
 
     """
     Class for bounding nodes into tree-structure.

--- a/avocado/core/varianter.py
+++ b/avocado/core/varianter.py
@@ -115,7 +115,7 @@ def dump_ivariants(ivariants):
     return variants
 
 
-class FakeVariantDispatcher(object):
+class FakeVariantDispatcher:
 
     """
     This object can act instead of VarianterDispatcher to report loaded
@@ -164,7 +164,7 @@ class FakeVariantDispatcher(object):
         return sum(1 for _ in self)
 
 
-class Varianter(object):
+class Varianter:
 
     """
     This object takes care of producing test variants

--- a/avocado/plugins/distro.py
+++ b/avocado/plugins/distro.py
@@ -25,7 +25,7 @@ from avocado.utils import path as utils_path
 from avocado.utils import process
 
 
-class SoftwarePackage(object):
+class SoftwarePackage:
 
     """
     Definition of relevant information on a software package
@@ -98,7 +98,7 @@ class DistroDef(utils_distro.LinuxDistro):
         return json.dumps(self.to_dict())
 
 
-class DistroPkgInfoLoader(object):
+class DistroPkgInfoLoader:
 
     """
     Loads information from the distro installation tree into a DistroDef

--- a/avocado/plugins/list.py
+++ b/avocado/plugins/list.py
@@ -24,7 +24,7 @@ from avocado.core.plugin_interfaces import CLICmd
 from avocado.utils import astring
 
 
-class TestLister(object):
+class TestLister:
 
     """
     Lists available test modules

--- a/avocado/utils/archive.py
+++ b/avocado/utils/archive.py
@@ -77,7 +77,7 @@ class ArchiveException(Exception):
     """
 
 
-class _WrapLZMA(object):
+class _WrapLZMA:
 
     """ wraps tar.xz for python 2.7's tarfile """
 
@@ -124,7 +124,7 @@ if LZMA_CAPABLE:
         return extracted_file
 
 
-class ArchiveFile(object):
+class ArchiveFile:
 
     """
     Class that represents an Archive file.

--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -52,7 +52,7 @@ class UnsupportedProtocolError(EnvironmentError):
     """
 
 
-class Asset(object):
+class Asset:
     """
     Try to fetch/verify an asset file from multiple locations.
     """

--- a/avocado/utils/data_structures.py
+++ b/avocado/utils/data_structures.py
@@ -164,7 +164,7 @@ class Borg:
         self.__dict__ = self.__shared_state
 
 
-class LazyProperty(object):
+class LazyProperty:
 
     """
     Lazily instantiated property.
@@ -188,7 +188,7 @@ class LazyProperty(object):
         return value
 
 
-class CallbackRegister(object):
+class CallbackRegister:
 
     """
     Registers pickable functions to be executed later.
@@ -269,7 +269,7 @@ def time_to_seconds(time):
     return seconds
 
 
-class DataSize(object):
+class DataSize:
     """
     Data Size object with builtin unit-converted attributes.
 

--- a/avocado/utils/distro.py
+++ b/avocado/utils/distro.py
@@ -32,7 +32,7 @@ __all__ = ['LinuxDistro',
 
 
 # pylint: disable=R0903
-class LinuxDistro(object):
+class LinuxDistro:
 
     """
     Simple collection of information for a Linux Distribution
@@ -87,7 +87,7 @@ UNKNOWN_DISTRO = LinuxDistro(UNKNOWN_DISTRO_NAME,
                              UNKNOWN_DISTRO_ARCH)
 
 
-class Probe(object):
+class Probe:
 
     """
     Probes the machine and does it best to confirm it's the right distro
@@ -419,7 +419,7 @@ def detect():
     return distro
 
 
-class Spec(object):
+class Spec:
 
     """
     Describes a distro, usually for setting minimum distro requirements

--- a/avocado/utils/filelock.py
+++ b/avocado/utils/filelock.py
@@ -31,7 +31,7 @@ class LockFailed(Exception):
     pass
 
 
-class FileLock(object):
+class FileLock:
 
     """
     Creates an exclusive advisory lock for a file.

--- a/avocado/utils/gdb.py
+++ b/avocado/utils/gdb.py
@@ -273,7 +273,7 @@ def remote_decode(data):
     return payload
 
 
-class CommandResult(object):
+class CommandResult:
 
     """
     A GDB command, its result, and other possible messages
@@ -308,7 +308,7 @@ class CommandResult(object):
         return "%s at %s" % (self.command, self.timestamp)
 
 
-class GDB(object):
+class GDB:
 
     """
     Wraps a GDB subprocess for easier manipulation
@@ -597,7 +597,7 @@ class GDB(object):
         return self.process.wait()
 
 
-class GDBServer(object):
+class GDBServer:
 
     """
     Wraps a gdbserver instance
@@ -711,7 +711,7 @@ class GDBServer(object):
             self.stderr.close()
 
 
-class GDBRemote(object):
+class GDBRemote:
 
     def __init__(self, host, port, no_ack_mode=True, extended_mode=True):
         """

--- a/avocado/utils/git.py
+++ b/avocado/utils/git.py
@@ -26,7 +26,7 @@ from . import path
 __all__ = ["GitRepoHelper", "get_repo"]
 
 
-class GitRepoHelper(object):
+class GitRepoHelper:
 
     """
     Helps to deal with git repos, mostly fetching content from a repo

--- a/avocado/utils/iso9660.py
+++ b/avocado/utils/iso9660.py
@@ -120,7 +120,7 @@ def can_mount():
     return True
 
 
-class BaseIso9660(object):
+class BaseIso9660:
 
     """
     Represents a ISO9660 filesystem
@@ -169,7 +169,7 @@ class BaseIso9660(object):
         """
 
 
-class MixInMntDirMount(object):
+class MixInMntDirMount:
     """
     Mix in class which defines `mnt_dir` property and instantiates the
     Iso9660Mount class to provide one. It requires `self.path` to store

--- a/avocado/utils/kernel.py
+++ b/avocado/utils/kernel.py
@@ -24,7 +24,7 @@ from . import asset, archive, build, distro, process
 log = logging.getLogger('avocado.test')
 
 
-class KernelBuild(object):
+class KernelBuild:
 
     """
     Build the Linux Kernel from official tarballs.

--- a/avocado/utils/memory.py
+++ b/avocado/utils/memory.py
@@ -464,7 +464,7 @@ class _MemInfoItem(DataSize):
         return getattr(datasize, attr)
 
 
-class MemInfo(object):
+class MemInfo:
     """
     Representation of /proc/meminfo
     """

--- a/avocado/utils/output.py
+++ b/avocado/utils/output.py
@@ -44,7 +44,7 @@ def display_data_size(size):
     return '%.2f %s' % (size, prefixes[i])
 
 
-class ProgressBar(object):
+class ProgressBar:
 
     """
     Displays interactively the progress of a given task

--- a/avocado/utils/partition.py
+++ b/avocado/utils/partition.py
@@ -50,7 +50,7 @@ class PartitionError(Exception):
                                       super(PartitionError, self).__str__())
 
 
-class MtabLock(object):
+class MtabLock:
     device = "/etc/mtab"
 
     def __init__(self, timeout=60):
@@ -76,7 +76,7 @@ class MtabLock(object):
         self.lock.__exit__(exc_type, exc_value, exc_traceback)
 
 
-class Partition(object):
+class Partition:
 
     """
     Class for handling partitions and filesystems

--- a/avocado/utils/path.py
+++ b/avocado/utils/path.py
@@ -103,7 +103,7 @@ def find_command(cmd, default=None):
         raise CmdNotFoundError(cmd, path_paths)
 
 
-class PathInspector(object):
+class PathInspector:
 
     def __init__(self, path):
         self.path = path

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -315,7 +315,7 @@ def cmd_split(cmd):
     return shlex.split(data)
 
 
-class CmdResult(object):
+class CmdResult:
 
     """
     Command execution result.
@@ -377,7 +377,7 @@ class CmdResult(object):
         raise TypeError("Unable to decode stderr into a string-like type")
 
 
-class FDDrainer(object):
+class FDDrainer:
 
     def __init__(self, fd, result, name=None, logger=None, logger_prefix='%s',
                  stream_logger=None, ignore_bg_processes=False, verbose=False):
@@ -486,7 +486,7 @@ class FDDrainer(object):
                     handler.close()
 
 
-class SubProcess(object):
+class SubProcess:
 
     """
     Run a subprocess in the background, collecting stdout/stderr streams.
@@ -941,7 +941,7 @@ class WrapSubProcess(SubProcess):
                                              ignore_bg_processes, encoding)
 
 
-class GDBSubProcess(object):
+class GDBSubProcess:
 
     """
     Runs a subprocess inside the GNU Debugger

--- a/avocado/utils/script.py
+++ b/avocado/utils/script.py
@@ -33,7 +33,7 @@ DEFAULT_MODE = (stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR |
 READ_ONLY_MODE = (stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
 
 
-class Script(object):
+class Script:
 
     """
     Class that represents a script.

--- a/avocado/utils/service.py
+++ b/avocado/utils/service.py
@@ -346,7 +346,7 @@ COMMANDS = (
 )
 
 
-class _ServiceResultParser(object):  # pylint: disable=too-few-public-methods
+class _ServiceResultParser:  # pylint: disable=too-few-public-methods
 
     """
     A class that contains staticmethods to parse the result of service command.
@@ -380,7 +380,7 @@ class _ServiceResultParser(object):  # pylint: disable=too-few-public-methods
         return True
 
 
-class _ServiceCommandGenerator(object):  # pylint: disable=too-few-public-methods
+class _ServiceCommandGenerator:  # pylint: disable=too-few-public-methods
 
     """
     Generate command lists for starting/stopping services.
@@ -430,7 +430,7 @@ def get_name_of_init(run=process.run):
         return os.path.basename(output)
 
 
-class _SpecificServiceManager(object):  # pylint: disable=too-few-public-methods
+class _SpecificServiceManager:  # pylint: disable=too-few-public-methods
 
     def __init__(self, service_name, service_command_generator,
                  service_result_parser, run=process.run):
@@ -507,7 +507,7 @@ class _SpecificServiceManager(object):  # pylint: disable=too-few-public-methods
         return run
 
 
-class _GenericServiceManager(object):  # pylint: disable=too-few-public-methods
+class _GenericServiceManager:  # pylint: disable=too-few-public-methods
 
     """
     Base class for SysVInitServiceManager and SystemdServiceManager.

--- a/avocado/utils/software_manager.py
+++ b/avocado/utils/software_manager.py
@@ -60,7 +60,7 @@ log = logging.getLogger('avocado.test')
 SUPPORTED_PACKAGE_MANAGERS = ['apt-get', 'yum', 'zypper', 'dnf']
 
 
-class SystemInspector(object):
+class SystemInspector:
 
     """
     System inspector class.
@@ -113,7 +113,7 @@ class SystemInspector(object):
         return pm_supported
 
 
-class SoftwareManager(object):
+class SoftwareManager:
 
     """
     Package management abstraction layer.
@@ -159,7 +159,7 @@ class SoftwareManager(object):
         return self.backend.__getattribute__(name)
 
 
-class BaseBackend(object):
+class BaseBackend:
 
     """
     This class implements all common methods among backends.

--- a/avocado/utils/ssh.py
+++ b/avocado/utils/ssh.py
@@ -1,7 +1,7 @@
 from . import process
 
 
-class Session(object):
+class Session:
     """
     Represents an SSH session to a remote system, for the purpose of
     executing commands remotely.

--- a/avocado/utils/vmimage.py
+++ b/avocado/utils/vmimage.py
@@ -60,7 +60,7 @@ class VMImageHtmlParser(HTMLParser):  # pylint: disable=W0223
                     self.items.append(match)
 
 
-class ImageProviderBase(object):
+class ImageProviderBase:
     """
     Base class to define the common methods and attributes of an
     image. Intended to be sub-classed by the specific image providers.
@@ -310,7 +310,7 @@ class OpenSUSEImageProvider(ImageProviderBase):
         return max(version_numbers)
 
 
-class Image(object):
+class Image:
     def __init__(self, name, url, version, arch, checksum, algorithm,
                  cache_dir, snapshot_dir=None):
         self.name = name

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -1248,7 +1248,7 @@ class::
 
    from avocado import Test
 
-   class NotInheritedFromTest(object):
+   class NotInheritedFromTest:
        """
        :avocado: enable
        """

--- a/optional_plugins/glib/avocado_glib/__init__.py
+++ b/optional_plugins/glib/avocado_glib/__init__.py
@@ -58,7 +58,7 @@ class GLibTest(test.SimpleTest):
                       'non-0 exit code (%s)' % result)
 
 
-class NotGLibTest(object):
+class NotGLibTest:
 
     """
     Not a GLib Test (for reporting purposes)

--- a/optional_plugins/golang/avocado_golang/__init__.py
+++ b/optional_plugins/golang/avocado_golang/__init__.py
@@ -74,7 +74,7 @@ class GolangTest(test.SimpleTest):
                       'non-0 exit code (%s)' % result)
 
 
-class NotGolangTest(object):
+class NotGolangTest:
 
     """
     Not a golang test (for reporting purposes)

--- a/optional_plugins/html/avocado_result_html/__init__.py
+++ b/optional_plugins/html/avocado_result_html/__init__.py
@@ -31,7 +31,7 @@ from avocado.core.plugin_interfaces import CLI, Result
 from avocado.utils import astring
 
 
-class ReportModel(object):
+class ReportModel:
 
     """
     Prepares an object that can be passed up to mustache for rendering.

--- a/optional_plugins/robot/avocado_robot/__init__.py
+++ b/optional_plugins/robot/avocado_robot/__init__.py
@@ -73,7 +73,7 @@ class RobotTest(test.SimpleTest):
                       'non-0 exit code (%s)' % result)
 
 
-class NotRobotTest(object):
+class NotRobotTest:
 
     """
     Not a robot test (for reporting purposes)

--- a/optional_plugins/runner_docker/avocado_runner_docker/__init__.py
+++ b/optional_plugins/runner_docker/avocado_runner_docker/__init__.py
@@ -26,7 +26,7 @@ from avocado.utils.wait import wait_for
 from avocado_runner_remote import RemoteTestRunner
 
 
-class DockerRemoter(object):
+class DockerRemoter:
 
     """
     Remoter object similar to

--- a/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
+++ b/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
@@ -205,7 +205,7 @@ class DummyLoader(loader.TestLoader):
         return {MockingTest: output.TERM_SUPPORT.healthy_str}
 
 
-class Remote(object):
+class Remote:
 
     """
     Performs remote operations.

--- a/optional_plugins/runner_vm/avocado_runner_vm/__init__.py
+++ b/optional_plugins/runner_vm/avocado_runner_vm/__init__.py
@@ -36,7 +36,7 @@ class VirtError(Exception):
     """
 
 
-class Hypervisor(object):
+class Hypervisor:
 
     """
     The Hypervisor connection class.
@@ -101,7 +101,7 @@ class Hypervisor(object):
         """
 
 
-class VM(object):
+class VM:
 
     """
     The Virtual Machine handler class.

--- a/optional_plugins/varianter_cit/avocado_varianter_cit/__init__.py
+++ b/optional_plugins/varianter_cit/avocado_varianter_cit/__init__.py
@@ -145,7 +145,7 @@ class VarianterCit(Varianter):
         return "\n".join(out)
 
 
-class Cit(object):
+class Cit:
 
     MATRIX_ROW_SIZE = 20
     MAX_ITERATIONS = 15

--- a/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/mux.py
+++ b/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/mux.py
@@ -42,7 +42,7 @@ REMOVE_NODE = 0
 REMOVE_VALUE = 1
 
 
-class MuxTree(object):
+class MuxTree:
 
     """
     Object representing part of the tree from the root to leaves or another
@@ -150,7 +150,7 @@ class MuxTree(object):
         return True
 
 
-class MuxPlugin(object):
+class MuxPlugin:
     """
     Base implementation of Mux-like Varianter plugin. It should be used as
     a base class in conjunction with
@@ -235,7 +235,7 @@ class MuxPlugin(object):
         return sum(1 for _ in self)
 
 
-class OutputValue(object):  # only container pylint: disable=R0903
+class OutputValue:  # only container pylint: disable=R0903
 
     """ Ordinary value with some debug info """
 
@@ -319,7 +319,7 @@ class ValueDict(dict):  # only container pylint: disable=R0903
         return self.iteritems()
 
 
-class Control(object):  # Few methods pylint: disable=R0903
+class Control:  # Few methods pylint: disable=R0903
 
     """ Container used to identify node vs. control sequence """
 

--- a/scripts/avocado-journal-replay
+++ b/scripts/avocado-journal-replay
@@ -45,7 +45,7 @@ class ArgumentParser(argparse.ArgumentParser):
                           help='Path to the journal file (.journal.sqlite)')
 
 
-class App(object):
+class App:
 
     def __init__(self):
         self.app_parser = ArgumentParser()

--- a/scripts/avocado-run-testplan
+++ b/scripts/avocado-run-testplan
@@ -53,7 +53,7 @@ RESULT_MAP = {"P": "PASS",
               "s": "SKIP"}
 
 
-class App(object):
+class App:
 
     def __init__(self):
         self.parser = Parser()

--- a/selftests/.data/loader_instrumented/dont_crash.py
+++ b/selftests/.data/loader_instrumented/dont_crash.py
@@ -12,7 +12,7 @@ from avocado import Test
 
 
 # on "import avocado" this requires some skipping
-class DontCrash1(object):
+class DontCrash1:
     pass
 
 
@@ -35,7 +35,7 @@ class DiscoverMe3(object, Test, main):  # pylint: disable=E0240,E0602
         pass
 
 
-class DontCrash2p(object):
+class DontCrash2p:
     class Bar(avocado.Test):
         def test(self):
             pass
@@ -52,7 +52,7 @@ class DiscoverMe4(DiscoverMe4p):    # pylint: disable=E0601
     """:avocado: recursive"""
 
 
-class DiscoverMe4p(object):
+class DiscoverMe4p:
     def test(self):
         pass
 

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -1027,7 +1027,7 @@ class ExternalRunnerTest(unittest.TestCase):
         shutil.rmtree(self.tmpdir)
 
 
-class AbsPluginsTest(object):
+class AbsPluginsTest:
 
     def setUp(self):
         self.base_outputdir = tempfile.mkdtemp(prefix='avocado_' + __name__)

--- a/selftests/functional/test_utils.py
+++ b/selftests/functional/test_utils.py
@@ -24,7 +24,7 @@ import random
 import signal
 import sys
 
-class FakeVMStat(object):
+class FakeVMStat:
     def __init__(self, interval):
         self.interval = interval
         self._sysrand = random.SystemRandom()

--- a/selftests/unit/test_data_structures.py
+++ b/selftests/unit/test_data_structures.py
@@ -53,7 +53,7 @@ class TestDataStructures(unittest.TestCase):
         """
         Verify the value is initialized lazily with the correct value
         """
-        class DummyClass(object):
+        class DummyClass:
             value = False
 
             @data_structures.LazyProperty
@@ -69,7 +69,7 @@ class TestDataStructures(unittest.TestCase):
         """
         Checks CallbackRegister
         """
-        class Log(object):
+        class Log:
             msgs = []
 
             def error(self, *args, **kwargs):

--- a/selftests/unit/test_jsonresult.py
+++ b/selftests/unit/test_jsonresult.py
@@ -16,7 +16,7 @@ from .. import setup_avocado_loggers
 setup_avocado_loggers()
 
 
-class FakeJob(object):
+class FakeJob:
 
     def __init__(self, args):
         self.args = args

--- a/selftests/unit/test_result.py
+++ b/selftests/unit/test_result.py
@@ -4,13 +4,13 @@ import unittest
 from avocado.core.result import Result
 
 
-class FakeJobMissingUniqueId(object):
+class FakeJobMissingUniqueId:
 
     def __init__(self, args):
         self.args = args
 
 
-class FakeJob(object):
+class FakeJob:
 
     def __init__(self, args):
         self.args = args

--- a/selftests/unit/test_safeloader.py
+++ b/selftests/unit/test_safeloader.py
@@ -96,7 +96,7 @@ class ModuleImportedAs(unittest.TestCase):
         self._test('import foo as foo', {'foo': 'foo'})
 
     def test_import_inside_class(self):
-        self._test("class Foo(object): import foo as foo", {})
+        self._test("class Foo: import foo as foo", {})
 
 
 class DocstringDirectives(unittest.TestCase):

--- a/selftests/unit/test_utils_iso9660.py
+++ b/selftests/unit/test_utils_iso9660.py
@@ -44,7 +44,7 @@ class Capabilities(unittest.TestCase):
                                           ['non-existing', 'capabilities']))
 
 
-class BaseIso9660(object):
+class BaseIso9660:
 
     """
     Base class defining setup and tests for shared Iso9660 functionality

--- a/selftests/unit/test_utils_stacktrace.py
+++ b/selftests/unit/test_utils_stacktrace.py
@@ -21,7 +21,7 @@ import unittest
 from avocado.utils import stacktrace
 
 
-class Unpickable(object):
+class Unpickable:
     """
     Dummy class which does not support pickling
     """
@@ -30,7 +30,7 @@ class Unpickable(object):
         raise NotImplementedError()
 
 
-class InClassUnpickable(object):
+class InClassUnpickable:
     """
     Dummy class containing unpickable object inside itself
     """

--- a/selftests/unit/test_xunit.py
+++ b/selftests/unit/test_xunit.py
@@ -27,7 +27,7 @@ class ParseXMLError(Exception):
     pass
 
 
-class FakeJob(object):
+class FakeJob:
 
     def __init__(self, args):
         self.args = args


### PR DESCRIPTION
Which are only necessary under Python 2, and thus, not needed
anymore.

Signed-off-by: Cleber Rosa <crosa@redhat.com>