### PR TITLE
[LTS] Safeloader: handle add_import_object ImportFrom alias statement

### DIFF
--- a/avocado/core/safeloader.py
+++ b/avocado/core/safeloader.py
@@ -88,7 +88,7 @@ class AvocadoModule(object):
         Keeps track of objects names and importable entities
         """
         path = os.path.abspath(os.path.dirname(self.path))
-        if hasattr(statement, 'module'):
+        if getattr(statement, 'module', None) is not None:
             module_path = statement.module.replace('.', os.path.sep)
             path = os.path.join(path, module_path)
         for name in statement.names:

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -208,6 +208,8 @@ class Second(avocado.Test):
 PYTHON_UNITTEST = """#!/usr/bin/env python
 from unittest import TestCase
 
+from . import something
+
 class SampleTest(TestCase):
     def test(self):
         pass


### PR DESCRIPTION
A "from <module> import <symbol>" statement will not always have
a module name set, one example is:

   from . import BASEDIR

In these situations, the statement's module attribute will be None.

Signed-off-by: Cleber Rosa <crosa@redhat.com>