### PR TITLE
backport code   #3078  and  #3081 to 69lts

### DIFF
--- a/avocado/utils/distro.py
+++ b/avocado/utils/distro.py
@@ -268,8 +268,8 @@ class RedHatProbe(Probe):
     CHECK_FILE = '/etc/redhat-release'
     CHECK_FILE_CONTAINS = 'Red Hat Enterprise Linux'
     CHECK_FILE_DISTRO_NAME = 'rhel'
-    CHECK_VERSION_REGEX = re.compile(
-        r'Red Hat Enterprise Linux \w+ release (\d{1,2})\.(\d{1,2}).*')
+    CHECK_VERSION_REGEX = re.compile(r'Red Hat Enterprise Linux\s+\w*\s*release\s+'
+                                     r'(\d{1,2})\.(\d{1,2}).*')
 
 
 class CentosProbe(RedHatProbe):

--- a/avocado/utils/genio.py
+++ b/avocado/utils/genio.py
@@ -203,6 +203,29 @@ def write_file_or_fail(filename, data):
                          filename, details))
 
 
+def append_file(filename, data):
+    """
+    Append data to a file.
+    :param filename: Path to the file.
+    :type filename: str
+    :param line: Line to be written.
+    :type line: str
+    """
+    with open(filename, 'a+') as file_obj:
+        file_obj.write(data)
+
+
+def append_one_line(filename, line):
+    """
+    Append one line of text to filename.
+    :param filename: Path to the file.
+    :type filename: str
+    :param line: Line to be written.
+    :type line: str
+    """
+    append_file(filename, line.rstrip('\n') + '\n')
+
+
 def is_pattern_in_file(filename,  pattern):
     """
     Check if a pattern matches in a specified file. If a non


### PR DESCRIPTION
backport code   #3078  and  #3081 to 69lts

1- Added append_file, append_one_line functions to genio.
There are situations where files with more than one line
are to be created with some filtered data. In those
situations, the existing functions namely write_file,
write_one_line are not helping.

Signed-off-by: Nageswara R Sastry <rnsastry@linux.vnet.ibm.com>
Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>

2- fixed redhat distro version check in Rhel8.0
/etc/redhat-release output pattern changed

cat /etc/redhat-release
Red Hat Enterprise Linux release 8.0 Beta (Ootpa)

changed regex pattern which handle Rhel8 case as well

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>
