### PR TITLE
Selftests: increase granularity and simplify inheritance approach

### DIFF
--- a/selftests/unit/test_safeloader.py
+++ b/selftests/unit/test_safeloader.py
@@ -254,13 +254,13 @@ class FindClassAndMethods(UnlimitedDiff):
 
     def test_self(self):
         reference = {
-            'PythonModule': ['setUp',
-                             'test_add_imported_empty',
-                             'test_add_imported_object_from_module',
-                             'test_add_imported_object_from_module_asname',
-                             'test_is_not_avocado_test',
-                             'test_is_not_avocado_tests',
-                             'test_is_avocado_test'],
+            'PythonModuleSelf': ['setUp',
+                                 'test_add_imported_empty',
+                                 'test_add_imported_object_from_module',
+                                 'test_add_imported_object_from_module_asname',
+                                 'test_is_not_avocado_test',
+                                 'test_is_not_avocado_tests'],
+            'PythonModule': ['test_is_avocado_test'],
             'ModuleImportedAs': ['_test',
                                  'test_foo',
                                  'test_foo_as_bar',
@@ -297,12 +297,12 @@ class FindClassAndMethods(UnlimitedDiff):
 
     def test_with_pattern(self):
         reference = {
-            'PythonModule': ['test_add_imported_empty',
-                             'test_add_imported_object_from_module',
-                             'test_add_imported_object_from_module_asname',
-                             'test_is_not_avocado_test',
-                             'test_is_not_avocado_tests',
-                             'test_is_avocado_test'],
+            'PythonModuleSelf': ['test_add_imported_empty',
+                                 'test_add_imported_object_from_module',
+                                 'test_add_imported_object_from_module_asname',
+                                 'test_is_not_avocado_test',
+                                 'test_is_not_avocado_tests'],
+            'PythonModule': ['test_is_avocado_test'],
             'ModuleImportedAs': ['test_foo',
                                  'test_foo_as_bar',
                                  'test_foo_as_foo',
@@ -391,7 +391,10 @@ class FindClassAndMethods(UnlimitedDiff):
         self.assertEqual(expected, tests)
 
 
-class PythonModule(unittest.TestCase):
+class PythonModuleSelf(unittest.TestCase):
+    """
+    Has tests based on this source code file
+    """
 
     def setUp(self):
         self.path = os.path.abspath(os.path.dirname(get_this_file()))
@@ -420,6 +423,12 @@ class PythonModule(unittest.TestCase):
     def test_is_not_avocado_tests(self):
         for klass in self.module.iter_classes():
             self.assertFalse(self.module.is_matching_klass(klass))
+
+
+class PythonModule(unittest.TestCase):
+    """
+    Has tests based on other Python source code files
+    """
 
     def test_is_avocado_test(self):
         passtest_path = os.path.join(BASEDIR, 'examples', 'tests', 'passtest.py')

--- a/selftests/unit/test_utils_service.py
+++ b/selftests/unit/test_utils_service.py
@@ -160,29 +160,25 @@ class TestSpecificServiceManager(unittest.TestCase):
         self.assertFalse(hasattr(self.service_manager, "set_target"))
 
 
-class TestServiceManager(unittest.TestCase):
-
-    @staticmethod
-    def get_service_manager_from_init_and_run(init_name, run_mock):
-        command_generator = service._COMMAND_GENERATORS[init_name]
-        result_parser = service._RESULT_PARSERS[init_name]
-        service_manager = service._SERVICE_MANAGERS[init_name]
-        service_command_generator = service._ServiceCommandGenerator(
-            command_generator)
-        service_result_parser = service._ServiceResultParser(result_parser)
-        return service_manager(service_command_generator, service_result_parser,
-                               run_mock)
+def get_service_manager_from_init_and_run(init_name, run_mock):
+    command_generator = service._COMMAND_GENERATORS[init_name]
+    result_parser = service._RESULT_PARSERS[init_name]
+    service_manager = service._SERVICE_MANAGERS[init_name]
+    service_command_generator = service._ServiceCommandGenerator(
+        command_generator)
+    service_result_parser = service._ServiceResultParser(result_parser)
+    return service_manager(service_command_generator, service_result_parser,
+                           run_mock)
 
 
-class TestSystemdServiceManager(TestServiceManager):
+class TestSystemdServiceManager(unittest.TestCase):
 
     def setUp(self):
         self.run_mock = unittest.mock.Mock()
         self.init_name = "systemd"
-        self.service_manager = \
-            (super(TestSystemdServiceManager, self)
-             .get_service_manager_from_init_and_run(self.init_name,
-                                                    self.run_mock))
+        self.service_manager = get_service_manager_from_init_and_run(
+            self.init_name,
+            self.run_mock)
 
     def test_start(self):
         srv = "lldpad"
@@ -197,9 +193,8 @@ class TestSystemdServiceManager(TestServiceManager):
             "vsftpd.service disabled\n"
             "systemd-sysctl.service static\n")
         run_mock = unittest.mock.Mock(return_value=list_result_mock)
-        service_manager = \
-            (super(TestSystemdServiceManager, self)
-             .get_service_manager_from_init_and_run(self.init_name, run_mock))
+        service_manager = get_service_manager_from_init_and_run(self.init_name,
+                                                                run_mock)
         list_result = service_manager.list(ignore_status=False)
         self.assertEqual(run_mock.call_args[0][0],  # pylint: disable=E1136
                          "systemctl list-unit-files --type=service "
@@ -238,15 +233,14 @@ class TestSystemdServiceManager(TestServiceManager):
         self.assertEqual(service.convert_sysv_runlevel(6), "reboot.target")
 
 
-class TestSysVInitServiceManager(TestServiceManager):
+class TestSysVInitServiceManager(unittest.TestCase):
 
     def setUp(self):
         self.run_mock = unittest.mock.Mock()
         self.init_name = "init"
-        self.service_manager = \
-            super(TestSysVInitServiceManager,
-                  self).get_service_manager_from_init_and_run(self.init_name,
-                                                              self.run_mock)
+        self.service_manager = get_service_manager_from_init_and_run(
+            self.init_name,
+            self.run_mock)
 
     def test_start(self):
         srv = "lldpad"
@@ -266,10 +260,8 @@ class TestSysVInitServiceManager(TestServiceManager):
             "        chargen-dgram:  on\n")
 
         run_mock = unittest.mock.Mock(return_value=list_result_mock)
-        service_manager = \
-            super(TestSysVInitServiceManager,
-                  self).get_service_manager_from_init_and_run(self.init_name,
-                                                              run_mock)
+        service_manager = get_service_manager_from_init_and_run(self.init_name,
+                                                                run_mock)
         list_result = service_manager.list(ignore_status=False)
         self.assertEqual(run_mock.call_args[0][0], "chkconfig --list")  # pylint: disable=E1136
         self.assertEqual(list_result,


### PR DESCRIPTION
The `test_utils_service.py` file uses a more complex than necessary inheritance approach and a static method, while a single utility function is necessary.  The `test_safeloader.py` change is simpler and just puts one of the tests in a class that doesn't require the previous one's setup.