### PR TITLE
Safeloader: refactor [v2]

### DIFF
--- a/avocado/core/safeloader.py
+++ b/avocado/core/safeloader.py
@@ -312,6 +312,9 @@ def _examine_class(path, class_name, is_avocado):
     :type path: str
     :param class_name: the specific class to be found
     :type path: str
+    :param is_avocado: whether the inheritance from 'avocado.Test' has
+                       been determined or not
+    :type is_avocado: bool
     :returns: tuple where first item is a list of test methods detected
               for given class; second item is set of class names which
               look like avocado tests but are force-disabled.
@@ -419,8 +422,6 @@ def find_avocado_tests(path):
     Attempts to find Avocado instrumented tests from Python source files
 
     :param path: path to a Python source code file
-    :type path: str
-    :param class_name: the specific class to be found
     :type path: str
     :returns: tuple where first item is dict with class name and additional
               info such as method names and tags; the second item is

--- a/avocado/core/safeloader.py
+++ b/avocado/core/safeloader.py
@@ -107,13 +107,9 @@ class AvocadoModule:
             if isinstance(statement, ast.ImportFrom):
                 self.add_imported_object(statement)
                 if statement.module == 'avocado':
-                    for name in statement.names:
-                        if name.name == 'Test':
-                            if name.asname is not None:
-                                self.test_imports.add(name.asname)
-                            else:
-                                self.test_imports.add(name.name)
-                            break
+                    test_imports = statement_import_as(statement).get('Test', None)
+                    if test_imports is not None:
+                        self.test_imports.add(test_imports)
 
             # Looking for a 'import avocado'
             elif isinstance(statement, ast.Import):

--- a/avocado/core/safeloader.py
+++ b/avocado/core/safeloader.py
@@ -321,8 +321,6 @@ def _examine_class(path, class_name, is_avocado):
     :rtype: tuple
     """
     module = AvocadoModule(path)
-    path = module.path  # path might get updated (__init__.py)
-    ppath = os.path.dirname(path)
     info = []
     disabled = []
 
@@ -363,7 +361,7 @@ def _examine_class(path, class_name, is_avocado):
                 # a module
                 continue
             parent_class = parent.id
-            _info, _disabled, _avocado = _examine_class(path, parent_class,
+            _info, _disabled, _avocado = _examine_class(module.path, parent_class,
                                                         is_avocado)
             if _info:
                 parents.remove(parent)
@@ -402,7 +400,8 @@ def _examine_class(path, class_name, is_avocado):
                 parent_path, parent_module, parent_class = (
                     _parent.rsplit(os.path.sep, 2))
 
-            modules_paths = [parent_path, ppath] + sys.path
+            modules_paths = [parent_path,
+                             os.path.dirname(module.path)] + sys.path
             _, found_ppath, _ = imp.find_module(parent_module,
                                                 modules_paths)
             _info, _dis, _avocado = _examine_class(found_ppath,
@@ -430,8 +429,6 @@ def find_avocado_tests(path):
     :rtype: tuple
     """
     module = AvocadoModule(path)
-    path = module.path  # path might get updated (__init__.py)
-    ppath = os.path.dirname(path)
     # The resulting test classes
     result = collections.OrderedDict()
     disabled = set()
@@ -474,7 +471,7 @@ def find_avocado_tests(path):
                 # a module
                 continue
             parent_class = parent.id
-            _info, _dis, _avocado = _examine_class(path, parent_class,
+            _info, _dis, _avocado = _examine_class(module.path, parent_class,
                                                    is_avocado)
             if _info:
                 parents.remove(parent)
@@ -513,7 +510,8 @@ def find_avocado_tests(path):
                 parent_path, parent_module, parent_class = (
                     _parent.rsplit(os.path.sep, 2))
 
-            modules_paths = [parent_path, ppath] + sys.path
+            modules_paths = [parent_path,
+                             os.path.dirname(module.path)] + sys.path
             _, found_ppath, _ = imp.find_module(parent_module, modules_paths)
             _info, _dis, _avocado = _examine_class(found_ppath,
                                                    parent_class,

--- a/avocado/core/safeloader.py
+++ b/avocado/core/safeloader.py
@@ -351,7 +351,6 @@ def _examine_class(path, class_name, is_avocado):
             continue
 
         docstring = ast.get_docstring(klass)
-        cl_tags = get_docstring_directives_tags(docstring)
 
         # Only detect 'avocado.Test' if not yet decided
         if is_avocado is False:
@@ -365,7 +364,8 @@ def _examine_class(path, class_name, is_avocado):
             if is_avocado is False:    # Still not decided, try inheritance
                 is_avocado = module.is_matching_klass(klass)
 
-        info = get_methods_info(klass.body, cl_tags)
+        info = get_methods_info(klass.body,
+                                get_docstring_directives_tags(docstring))
         disabled = set()
 
         # Getting the list of parents of the current class
@@ -463,10 +463,9 @@ def find_avocado_tests(path):
             disabled.add(klass.name)
             continue
 
-        cl_tags = get_docstring_directives_tags(docstring)
-
         if check_docstring_directive(docstring, 'enable'):
-            info = get_methods_info(klass.body, cl_tags)
+            info = get_methods_info(klass.body,
+                                    get_docstring_directives_tags(docstring))
             result[klass.name] = info
             continue
 
@@ -479,7 +478,8 @@ def find_avocado_tests(path):
             is_avocado = True
         else:
             is_avocado = module.is_matching_klass(klass)
-        info = get_methods_info(klass.body, cl_tags)
+        info = get_methods_info(klass.body,
+                                get_docstring_directives_tags(docstring))
         _disabled = set()
 
         # Getting the list of parents of the current class

--- a/selftests/unit/test_safeloader.py
+++ b/selftests/unit/test_safeloader.py
@@ -254,12 +254,13 @@ class FindClassAndMethods(UnlimitedDiff):
 
     def test_self(self):
         reference = {
-            'AvocadoModule': ['setUp',
-                              'test_add_imported_empty',
-                              'test_add_imported_object_from_module',
-                              'test_add_imported_object_from_module_asname',
-                              'test_is_not_avocado_test',
-                              'test_is_avocado_test'],
+            'PythonModule': ['setUp',
+                             'test_add_imported_empty',
+                             'test_add_imported_object_from_module',
+                             'test_add_imported_object_from_module_asname',
+                             'test_is_not_avocado_test',
+                             'test_is_not_avocado_tests',
+                             'test_is_avocado_test'],
             'ModuleImportedAs': ['_test',
                                  'test_foo',
                                  'test_foo_as_bar',
@@ -296,11 +297,12 @@ class FindClassAndMethods(UnlimitedDiff):
 
     def test_with_pattern(self):
         reference = {
-            'AvocadoModule': ['test_add_imported_empty',
-                              'test_add_imported_object_from_module',
-                              'test_add_imported_object_from_module_asname',
-                              'test_is_not_avocado_test',
-                              'test_is_avocado_test'],
+            'PythonModule': ['test_add_imported_empty',
+                             'test_add_imported_object_from_module',
+                             'test_add_imported_object_from_module_asname',
+                             'test_is_not_avocado_test',
+                             'test_is_not_avocado_tests',
+                             'test_is_avocado_test'],
             'ModuleImportedAs': ['test_foo',
                                  'test_foo_as_bar',
                                  'test_foo_as_foo',
@@ -389,11 +391,11 @@ class FindClassAndMethods(UnlimitedDiff):
         self.assertEqual(expected, tests)
 
 
-class AvocadoModule(unittest.TestCase):
+class PythonModule(unittest.TestCase):
 
     def setUp(self):
         self.path = os.path.abspath(os.path.dirname(get_this_file()))
-        self.module = safeloader.AvocadoModule(self.path)
+        self.module = safeloader.PythonModule(self.path)
 
     def test_add_imported_empty(self):
         self.assertEqual(self.module.imported_objects, {})
@@ -413,17 +415,21 @@ class AvocadoModule(unittest.TestCase):
                          os.path.join(self.path, 'foo', 'bar'))
 
     def test_is_not_avocado_test(self):
-        self.assertFalse(self.module.is_avocado_test(ast.ClassDef()))
+        self.assertFalse(self.module.is_matching_klass(ast.ClassDef()))
+
+    def test_is_not_avocado_tests(self):
+        for klass in self.module.iter_classes():
+            self.assertFalse(self.module.is_matching_klass(klass))
 
     def test_is_avocado_test(self):
         passtest_path = os.path.join(BASEDIR, 'examples', 'tests', 'passtest.py')
-        passtest_module = safeloader.AvocadoModule(passtest_path)
+        passtest_module = safeloader.PythonModule(passtest_path)
         classes = [klass for klass in passtest_module.iter_classes()]
         # there's only one class and one *worthy* Test import in passtest.py
         self.assertEqual(len(classes), 1)
         self.assertEqual(len(passtest_module.test_imports), 1)
         self.assertEqual(len(passtest_module.mod_imports), 0)
-        self.assertTrue(passtest_module.is_avocado_test(classes[0]))
+        self.assertTrue(passtest_module.is_matching_klass(classes[0]))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This does a number of refactors to the safeloader, with the goal of simplifying the code, reducing duplication and preparing for further changes.

---

Changes from v1 (#3097):
 * Fixed docstring typo (`s/module/klass`) - spotted by @PraveenPenguin 