### PR TITLE
Loader: drop discover mode compatibility definitions

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -44,14 +44,6 @@ class DiscoverMode(Enum):
     ALL = object()
 
 
-#: Compatibility alias (to be removed) to :attr:`DiscoverMode.DEFAULT`
-DEFAULT = DiscoverMode.DEFAULT
-#: Compatibility alias (to be removed) to :attr:`DiscoverMode.AVAILABLE`
-AVAILABLE = DiscoverMode.AVAILABLE
-#: Compatibility alias (to be removed) to :attr:`DiscoverMode.ALL`
-ALL = DiscoverMode.ALL
-
-
 class MissingTest:
     """
     Class representing reference which failed to be discovered


### PR DESCRIPTION
These were intended to keep compatibility with other plugins,
but given that we're past an LTS release, it's desirable to
remove them.

Signed-off-by: Cleber Rosa <crosa@redhat.com>