### PR TITLE
Safeloader: improve Python unittest support

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -52,10 +52,6 @@ AVAILABLE = DiscoverMode.AVAILABLE
 ALL = DiscoverMode.ALL
 
 
-# Regexp to find python unittests
-_RE_UNIT_TEST = re.compile(r'test.*')
-
-
 class MissingTest:
     """
     Class representing reference which failed to be discovered
@@ -684,8 +680,7 @@ class FileLoader(TestLoader):
 
     def _find_python_unittests(self, test_path, disabled, subtests_filter):
         result = []
-        class_methods = safeloader.find_class_and_methods(test_path,
-                                                          _RE_UNIT_TEST)
+        class_methods = safeloader.find_python_unittests(test_path)
         for klass, methods in class_methods.items():
             if klass in disabled:
                 continue

--- a/avocado/core/safeloader.py
+++ b/avocado/core/safeloader.py
@@ -363,7 +363,7 @@ def _examine_class(path, class_name, match, target_module, target_class):
     """
     module = PythonModule(path, target_module, target_class)
     info = []
-    disabled = []
+    disabled = set()
 
     for klass in module.iter_classes():
         if class_name != klass.name:
@@ -385,7 +385,6 @@ def _examine_class(path, class_name, match, target_module, target_class):
 
         info = get_methods_info(klass.body,
                                 get_docstring_directives_tags(docstring))
-        disabled = set()
 
         # Getting the list of parents of the current class
         parents = klass.bases
@@ -446,14 +445,14 @@ def _examine_class(path, class_name, match, target_module, target_class):
                              os.path.dirname(module.path)] + sys.path
             _, found_ppath, _ = imp.find_module(parent_module,
                                                 modules_paths)
-            _info, _dis, _match = _examine_class(found_ppath,
-                                                 parent_class,
-                                                 match,
-                                                 target_module,
-                                                 target_class)
+            _info, _disabled, _match = _examine_class(found_ppath,
+                                                      parent_class,
+                                                      match,
+                                                      target_module,
+                                                      target_class)
             if _info:
                 info.extend(_info)
-                _disabled.update(_dis)
+                disabled.update(_disabled)
             if _match is not match:
                 match = _match
 

--- a/avocado/core/safeloader.py
+++ b/avocado/core/safeloader.py
@@ -125,11 +125,25 @@ class PythonModule:
         if name is not None:
             self.klass_imports.add(name)
 
+    @staticmethod
+    def _all_module_level_names(full_module_name):
+        result = []
+        components = full_module_name.split(".")[:-1]
+        for topmost in range(len(components)):
+            result.append(".".join(components[-topmost:]))
+            components.pop()
+        return result
+
     def _handle_import(self, statement):
         self.add_imported_object(statement)
-        name = statement_import_as(statement).get(self.module, None)
+        imported_as = statement_import_as(statement)
+        name = imported_as.get(self.module, None)
         if name is not None:
             self.mod_imports.add(name)
+        for as_name in imported_as.values():
+            for mod_name in self._all_module_level_names(as_name):
+                if mod_name == self.module:
+                    self.mod_imports.add(mod_name)
 
     def iter_classes(self):
         """

--- a/avocado/core/safeloader.py
+++ b/avocado/core/safeloader.py
@@ -35,7 +35,7 @@ class PythonModule:
     instrumented tests, but it's supposed to be agnostic enough to
     be used for, say, Python unittests.
     """
-    __slots__ = ('path', 'test_imports', 'mod_imports', 'mod', 'imported_objects',
+    __slots__ = ('path', 'klass_imports', 'mod_imports', 'mod', 'imported_objects',
                  'module', 'klass')
 
     def __init__(self, path, module='avocado', klass='Test'):
@@ -51,7 +51,7 @@ class PythonModule:
         :param klass: the possibly interesting class original name
         :type klass: str
         """
-        self.test_imports = set()
+        self.klass_imports = set()
         self.mod_imports = set()
         if os.path.isdir(path):
             path = os.path.join(path, "__init__.py")
@@ -83,11 +83,11 @@ class PythonModule:
         :rtype: bool
         """
         # Is it inherited from Test? 'class FooTest(Test):'
-        if self.test_imports:
+        if self.klass_imports:
             base_ids = [base.id for base in klass.bases
                         if isinstance(base, ast.Name)]
             # Looking for a 'class FooTest(Test):'
-            if not self.test_imports.isdisjoint(base_ids):
+            if not self.klass_imports.isdisjoint(base_ids):
                 return True
 
         # Is it inherited from avocado.Test? 'class FooTest(avocado.Test):'
@@ -123,7 +123,7 @@ class PythonModule:
             return
         name = statement_import_as(statement).get(self.klass, None)
         if name is not None:
-            self.test_imports.add(name)
+            self.klass_imports.add(name)
 
     def _handle_import(self, statement):
         self.add_imported_object(statement)

--- a/contrib/scripts/avocado-find-unittests
+++ b/contrib/scripts/avocado-find-unittests
@@ -22,18 +22,16 @@
 #
 
 import os
-import re
 import sys
 
-from avocado.core.safeloader import find_class_and_methods
+from avocado.core.safeloader import find_python_unittests
 
 if __name__ == '__main__':
     test_module_paths = sys.argv[1:]
     result = []
     for test_module_path in test_module_paths:
         try:
-            test_class_methods = find_class_and_methods(test_module_path,
-                                                        re.compile(r'test.*'))
+            test_class_methods = find_python_unittests(test_module_path)
         except IOError as error:
             continue
         for klass, methods in test_class_methods.items():

--- a/selftests/.data/loader_instrumented/dont_detect_non_avocado.py
+++ b/selftests/.data/loader_instrumented/dont_detect_non_avocado.py
@@ -1,9 +1,8 @@
 from avocado.core.test import Test  # pylint: disable=W0404
 
 
-# On load this will be avocado.Test, but in static analysis
-# it's avocado.core.test.Test and should not match
-# (only as a unittest)
+# On load this will be avocado.Test, but in static analysis it's
+# avocado.core.test.Test and should not match.
 class StaticallyNotAvocadoTest(Test):
     def test(self):
         pass
@@ -17,7 +16,7 @@ from avocado import Test    # pylint: disable=W0404
 
 # On recursive discovery this should be imported from
 # avocado.core.test and not avocado.Test, therefor it should
-# not be detected (only as a unittest)
+# not be detected (ditto for the Python unittest discover behavior)
 class NotTest(StaticallyNotAvocadoTest):
     def test2(self):
         pass

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -448,9 +448,7 @@ class LoaderTest(unittest.TestCase):
         path = os.path.join(os.path.dirname(os.path.dirname(__file__)),
                             '.data', 'loader_instrumented', 'dont_detect_non_avocado.py')
         tests = self.loader.discover(path)
-        exps = [(test.PythonUnittest, 'dont_detect_non_avocado.StaticallyNotAvocadoTest.test'),
-                (test.PythonUnittest, 'dont_detect_non_avocado.NotTest.test2')]
-        self._check_discovery(exps, tests)
+        self._check_discovery([], tests)
 
     def test_infinite_recurse(self):
         """Checks we don't crash on infinite recursion"""

--- a/selftests/unit/test_safeloader.py
+++ b/selftests/unit/test_safeloader.py
@@ -260,7 +260,8 @@ class FindClassAndMethods(UnlimitedDiff):
                                  'test_add_imported_object_from_module_asname',
                                  'test_is_not_avocado_test',
                                  'test_is_not_avocado_tests'],
-            'PythonModule': ['test_is_avocado_test'],
+            'PythonModule': ['test_is_avocado_test',
+                             'test_import_of_all_module_level'],
             'ModuleImportedAs': ['_test',
                                  'test_foo',
                                  'test_foo_as_bar',
@@ -302,7 +303,8 @@ class FindClassAndMethods(UnlimitedDiff):
                                  'test_add_imported_object_from_module_asname',
                                  'test_is_not_avocado_test',
                                  'test_is_not_avocado_tests'],
-            'PythonModule': ['test_is_avocado_test'],
+            'PythonModule': ['test_is_avocado_test',
+                             'test_import_of_all_module_level'],
             'ModuleImportedAs': ['test_foo',
                                  'test_foo_as_bar',
                                  'test_foo_as_foo',
@@ -439,6 +441,19 @@ class PythonModule(unittest.TestCase):
         self.assertEqual(len(passtest_module.klass_imports), 1)
         self.assertEqual(len(passtest_module.mod_imports), 0)
         self.assertTrue(passtest_module.is_matching_klass(classes[0]))
+
+    def test_import_of_all_module_level(self):
+        """
+        Checks if all levels of a module import are taken into account
+
+        This specific source file imports unittest.mock, and we want to
+        make sure that unittest is accounted for.
+        """
+        path = os.path.join(BASEDIR, 'selftests', 'unit', 'test_loader.py')
+        module = safeloader.PythonModule(path, 'unittest', 'TestCase')
+        for _ in module.iter_classes():
+            pass
+        self.assertIn('unittest', module.mod_imports)
 
 
 if __name__ == '__main__':

--- a/selftests/unit/test_safeloader.py
+++ b/selftests/unit/test_safeloader.py
@@ -436,7 +436,7 @@ class PythonModule(unittest.TestCase):
         classes = [klass for klass in passtest_module.iter_classes()]
         # there's only one class and one *worthy* Test import in passtest.py
         self.assertEqual(len(classes), 1)
-        self.assertEqual(len(passtest_module.test_imports), 1)
+        self.assertEqual(len(passtest_module.klass_imports), 1)
         self.assertEqual(len(passtest_module.mod_imports), 0)
         self.assertTrue(passtest_module.is_matching_klass(classes[0]))
 


### PR DESCRIPTION
This adds another round of refactors to the safeloader module, but on top of it, it implements a much improved function for finding Python unittests.

Even with two rounds of refactors (this PR and #3099), I must say there's still some code duplication and optimization opportunities.

Anyway, this brings a foundation in which it will be possible to switch Avocado's own test execution to a new experimental runner.