### PR TITLE
Travis-CI: check the HEAD of the branch only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,35 +32,4 @@ install:
     - pip install -r requirements-selftests.txt
 
 script:
-    - |
-        # First cleanup the previously installed files
-        PYTHON=$(which python)
-        $(PYTHON) setup.py develop --uninstall
-        BINDIR=$(dirname $(which python))
-        for FILE in scripts/*; do
-            rm $BINDIR/$(basename $FILE)
-        done
-        # Run the "make check" per each commit in PR (TRAVIS_COMMIT_RANGE)
-        ERR=""
-        echo Branch is $TRAVIS_BRANCH
-        if [ "$TRAVIS_PULL_REQUEST_SHA" ]; then
-            # It's pull request, check only PR commits
-            COMMITS="$(git cherry origin/master | sed -n 's/+ \(.*\)/\1/p')"
-        else
-            # push check, try to check everything
-            COMMITS=$(git rev-list $TRAVIS_COMMIT_RANGE)
-        fi
-        for COMMIT in $COMMITS; do
-            echo
-            echo "--------------------< $(git log -1 --oneline $COMMIT) >--------------------"
-            echo
-            echo
-            git checkout $COMMIT || ERR=$(echo -e "$ERR\nUnable to checkout $(git log -1 --oneline $COMMIT)")
-            make PYTHON=$PYTHON check || ERR=$(echo -e "$ERR\nmake check of $(git log -1 --oneline) failed")
-            make PYTHON=$PYTHON clean
-        done
-        if [ "$ERR" ]; then
-            echo
-            echo "Incremental smokecheck failed: $ERR"
-            exit -1
-        fi
+    - make check

--- a/selftests/signedoff-check.sh
+++ b/selftests/signedoff-check.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
-AUTHOR="$(git log -1 --pretty='format:%aN <%aE>')"
-git log -1 --pretty=format:%B | grep "Signed-off-by: $AUTHOR"
+AUTHOR="$(git log --no-merges -1 --pretty='format:%aN <%aE>')"
+git log --no-merges -1 --pretty=format:%B | grep "Signed-off-by: $AUTHOR"
 if [ $? != 0 ]; then
     echo "The commit message does not contain author's signature (Signed-off-by: $AUTHOR)"
     return 1

--- a/selftests/signedoff-check.sh
+++ b/selftests/signedoff-check.sh
@@ -4,5 +4,5 @@ AUTHOR="$(git log --no-merges -1 --pretty='format:%aN <%aE>')"
 git log --no-merges -1 --pretty=format:%B | grep "Signed-off-by: $AUTHOR"
 if [ $? != 0 ]; then
     echo "The commit message does not contain author's signature (Signed-off-by: $AUTHOR)"
-    return 1
+    exit 1
 fi


### PR DESCRIPTION
For a long time we have resorted to a hack, let's call it "all commits
hack", to test all commits in a branch on Travis-CI.  While it clear
had a positive side, it also had its annoyances.

Now, more and more often, we're faced with the obligation of breaking
PRs in smaller pieces just because of the limitations that the free
tier of Travis-CI imposes (for instance max job time is 50 minutes).

For instance, as this is written, the status of the master branch
is broken, because of the max job time.  And there's no way to
waive it or tweak it.

Also, the hack caused some really interesting problems, and caused
a lot of time wasted, for instance, because it masks the merge commit
that Travis-CI creates, and consequently, makes the signedoff-check.sh
fail on the real HEAD of the merged branch.  Basically, the "all
commits hack" is a requirement to currently have signedoff-check.sh
passing on Travis-CI.

Signed-off-by: Cleber Rosa <crosa@redhat.com>