### PR TITLE
Use proper default option if no html_output option was provided

### DIFF
--- a/optional_plugins/html/avocado_result_html/__init__.py
+++ b/optional_plugins/html/avocado_result_html/__init__.py
@@ -227,7 +227,7 @@ class HTMLResult(Result):
                 self._open_browser(html_path)
                 open_browser = False
 
-        html_path = getattr(job.args, 'html_output', 'None')
+        html_path = getattr(job.args, 'html_output', None)
         if html_path is not None:
             self._render(result, html_path)
             if open_browser:


### PR DESCRIPTION
Current 'None' evaluates as string where 'None' is not None.