### PR TITLE
Selftests: temporary file management improvements

### DIFF
--- a/selftests/__init__.py
+++ b/selftests/__init__.py
@@ -44,6 +44,14 @@ def setup_avocado_loggers():
             logger.handlers.append(logging.NullHandler())
 
 
+def temp_dir_prefix(module_name, klass, method):
+    """
+    Returns a standard name for the temp dir prefix used by the tests
+    """
+    fmt = 'avocado__%s__%s__%s__'
+    return fmt % (module_name, klass.__class__.__name__, method)
+
+
 #: The plugin module names and directories under optional_plugins
 PLUGINS = {'varianter_yaml_to_mux': 'avocado-framework-plugin-varianter-yaml-to-mux',
            'runner_remote': 'avocado-framework-plugin-runner-remote',

--- a/selftests/functional/test_export_variables.py
+++ b/selftests/functional/test_export_variables.py
@@ -8,7 +8,7 @@ from avocado.core import exit_codes
 from avocado.utils import process
 from avocado.utils import script
 
-from .. import AVOCADO, BASEDIR
+from .. import AVOCADO, BASEDIR, temp_dir_prefix
 
 SCRIPT_CONTENT = """#!/bin/sh
 echo "Avocado Version: $AVOCADO_VERSION"
@@ -32,7 +32,8 @@ test "$AVOCADO_VERSION" = "{version}" -a \
 class EnvironmentVariablesTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
         self.script = script.TemporaryScript(
             'version.sh',
             SCRIPT_CONTENT,

--- a/selftests/functional/test_gdb.py
+++ b/selftests/functional/test_gdb.py
@@ -5,13 +5,14 @@ import unittest
 
 from avocado.utils import process
 
-from .. import AVOCADO, BASEDIR
+from .. import AVOCADO, BASEDIR, temp_dir_prefix
 
 
 class GDBPluginTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
 
     def test_gdb_prerun_commands(self):
         os.chdir(BASEDIR)

--- a/selftests/functional/test_getdata.py
+++ b/selftests/functional/test_getdata.py
@@ -6,14 +6,15 @@ import unittest
 from avocado.core import exit_codes
 from avocado.utils import process
 
-from .. import AVOCADO, BASEDIR
+from .. import AVOCADO, BASEDIR, temp_dir_prefix
 
 
 class GetData(unittest.TestCase):
 
     def setUp(self):
         os.chdir(BASEDIR)
-        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
 
     def test(self):
         test_path = os.path.join(BASEDIR, "selftests", ".data", "get_data.py")

--- a/selftests/functional/test_interrupt.py
+++ b/selftests/functional/test_interrupt.py
@@ -14,7 +14,7 @@ from avocado.utils import wait
 from avocado.utils import script
 from avocado.utils import data_factory
 
-from .. import AVOCADO, BASEDIR
+from .. import AVOCADO, BASEDIR, temp_dir_prefix
 
 # What is commonly known as "0755" or "u=rwx,g=rx,o=rx"
 DEFAULT_MODE = (stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR |
@@ -97,7 +97,8 @@ class InterruptTest(unittest.TestCase):
         return len(test_processes) == 0
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
         self.test_module = None
 
     @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 2,

--- a/selftests/functional/test_job_timeout.py
+++ b/selftests/functional/test_job_timeout.py
@@ -10,7 +10,7 @@ from avocado.utils import genio
 from avocado.utils import process
 from avocado.utils import script
 
-from .. import AVOCADO, BASEDIR
+from .. import AVOCADO, BASEDIR, temp_dir_prefix
 
 
 SCRIPT_CONTENT = """#!/bin/bash
@@ -48,7 +48,8 @@ class JobTimeOutTest(unittest.TestCase):
             PYTHON_CONTENT,
             'avocado_timeout_functional')
         self.py.save()
-        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
         os.chdir(BASEDIR)
 
     def run_and_check(self, cmd_line, e_rc, e_ntests, e_nerrors, e_nfailures,

--- a/selftests/functional/test_journal.py
+++ b/selftests/functional/test_journal.py
@@ -8,14 +8,15 @@ import unittest
 from avocado.core import exit_codes
 from avocado.utils import process
 
-from .. import AVOCADO, BASEDIR
+from .. import AVOCADO, BASEDIR, temp_dir_prefix
 
 
 class JournalPluginTests(unittest.TestCase):
 
     def setUp(self):
         os.chdir(BASEDIR)
-        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
         self.cmd_line = ('%s run --job-results-dir %s --sysinfo=off --json - '
                          '--journal examples/tests/passtest.py'
                          % (AVOCADO, self.tmpdir))

--- a/selftests/functional/test_json_variants.py
+++ b/selftests/functional/test_json_variants.py
@@ -6,13 +6,14 @@ import unittest
 
 from avocado.utils import process
 
-from .. import AVOCADO, BASEDIR
+from .. import AVOCADO, BASEDIR, temp_dir_prefix
 
 
 class VariantsDumpLoadTests(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
         self.variants_file = os.path.join(self.tmpdir, 'variants.json')
         os.chdir(BASEDIR)
 

--- a/selftests/functional/test_loader.py
+++ b/selftests/functional/test_loader.py
@@ -12,7 +12,7 @@ from avocado.core import exit_codes
 from avocado.utils import script
 from avocado.utils import process
 
-from .. import AVOCADO, BASEDIR
+from .. import AVOCADO, BASEDIR, temp_dir_prefix
 
 
 AVOCADO_TEST_OK = """#!/usr/bin/env python
@@ -151,7 +151,8 @@ class LoaderTestFunctional(unittest.TestCase):
 
     def setUp(self):
         os.chdir(BASEDIR)
-        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
 
     def _test(self, name, content, exp_str, mode=MODE_0664, count=1):
         test_script = script.TemporaryScript(name, content,

--- a/selftests/functional/test_lv_utils.py
+++ b/selftests/functional/test_lv_utils.py
@@ -16,6 +16,8 @@ from avocado.utils import process
 from avocado.utils import lv_utils
 from avocado.utils import linux_modules
 
+from .. import temp_dir_prefix
+
 
 class LVUtilsTest(unittest.TestCase):
 
@@ -30,7 +32,8 @@ class LVUtilsTest(unittest.TestCase):
     @unittest.skipIf(not process.can_sudo(), "This test requires root or "
                      "passwordless sudo configured.")
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
         self.vgs = []
 
     def tearDown(self):

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -13,7 +13,7 @@ from avocado.utils import process
 from avocado.utils import script
 from avocado.utils import path as utils_path
 
-from .. import AVOCADO, BASEDIR
+from .. import AVOCADO, BASEDIR, temp_dir_prefix
 
 
 # AVOCADO may contain more than a single command, as it can be
@@ -133,7 +133,8 @@ def missing_binary(binary):
 class OutputTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
         os.chdir(BASEDIR)
 
     @unittest.skipIf(missing_binary('cc'),
@@ -270,7 +271,8 @@ class OutputTest(unittest.TestCase):
 class OutputPluginTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
         os.chdir(BASEDIR)
 
     def check_output_files(self, debug_log):
@@ -510,11 +512,11 @@ class OutputPluginTest(unittest.TestCase):
     @unittest.skipIf(perl_tap_parser_uncapable(),
                      "Uncapable of using Perl TAP::Parser library")
     def test_tap_parser(self):
-        perl_script = script.TemporaryScript("tap_parser.pl",
-                                             PERL_TAP_PARSER_SNIPPET
-                                             % self.tmpdir)
-        perl_script.save()
-        process.run("perl %s" % perl_script)
+        with script.TemporaryScript(
+                "tap_parser.pl",
+                PERL_TAP_PARSER_SNIPPET % self.tmpdir,
+                self.tmpdir) as perl_script:
+            process.run("perl %s" % perl_script)
 
     def test_tap_totaltests(self):
         cmd_line = ("%s run passtest.py "

--- a/selftests/functional/test_output_check.py
+++ b/selftests/functional/test_output_check.py
@@ -8,7 +8,7 @@ from avocado.core import exit_codes
 from avocado.utils import process
 from avocado.utils import script
 
-from .. import AVOCADO, BASEDIR
+from .. import AVOCADO, BASEDIR, temp_dir_prefix
 
 
 STDOUT = b"Hello, \xc4\x9b\xc5\xa1\xc4\x8d\xc5\x99\xc5\xbe\xc3\xbd\xc3\xa1\xc3\xad\xc3\xa9!"
@@ -18,7 +18,8 @@ STDERR = b"Hello, stderr!"
 class RunnerSimpleTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
         content = b"#!/bin/sh\n"
         content += b"echo \"" + STDOUT + b"\"\n"
         content += b"echo \"" + STDERR + b"\" >&2\n"

--- a/selftests/functional/test_plugin_diff.py
+++ b/selftests/functional/test_plugin_diff.py
@@ -9,13 +9,14 @@ from avocado.core import exit_codes
 from avocado.utils import process
 from avocado.utils import script
 
-from .. import AVOCADO, BASEDIR
+from .. import AVOCADO, BASEDIR, temp_dir_prefix
 
 
 class DiffTests(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
         test = script.make_script(os.path.join(self.tmpdir, 'test'), 'exit 0')
         cmd_line = ('%s run %s '
                     '--external-runner /bin/bash '
@@ -25,7 +26,7 @@ class DiffTests(unittest.TestCase):
         self.run_and_check(cmd_line, expected_rc)
         self.jobdir = ''.join(glob.glob(os.path.join(self.tmpdir, 'job-*')))
 
-        self.tmpdir2 = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        self.tmpdir2 = tempfile.mkdtemp(prefix=prefix)
         cmd_line = ('%s run %s '
                     '--external-runner /bin/bash '
                     '--job-results-dir %s --sysinfo=off --json -' %

--- a/selftests/functional/test_plugin_jobscripts.py
+++ b/selftests/functional/test_plugin_jobscripts.py
@@ -7,7 +7,7 @@ from avocado.core import exit_codes
 from avocado.utils import process
 from avocado.utils import script
 
-from .. import AVOCADO, BASEDIR
+from .. import AVOCADO, BASEDIR, temp_dir_prefix
 
 
 SCRIPT_PRE_TOUCH = """#!/bin/sh -e
@@ -42,7 +42,8 @@ warn_non_zero_status = True"""
 class JobScriptsTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.mkdtemp(prefix)
         self.pre_dir = os.path.join(self.tmpdir, 'pre.d')
         os.mkdir(self.pre_dir)
         self.post_dir = os.path.join(self.tmpdir, 'post.d')

--- a/selftests/functional/test_replay_basic.py
+++ b/selftests/functional/test_replay_basic.py
@@ -7,13 +7,14 @@ import unittest
 from avocado.core import exit_codes
 from avocado.utils import process
 
-from .. import AVOCADO, BASEDIR
+from .. import AVOCADO, BASEDIR, temp_dir_prefix
 
 
 class ReplayTests(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.mkdtemp(prefix)
         cmd_line = ('%s run passtest.py '
                     '-m examples/tests/sleeptest.py.data/sleeptest.yaml '
                     '--job-results-dir %s --sysinfo=off --json -'

--- a/selftests/functional/test_replay_external_runner.py
+++ b/selftests/functional/test_replay_external_runner.py
@@ -8,13 +8,14 @@ from avocado.core import exit_codes
 from avocado.utils import process
 from avocado.utils import script
 
-from .. import AVOCADO, BASEDIR
+from .. import AVOCADO, BASEDIR, temp_dir_prefix
 
 
 class ReplayExtRunnerTests(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.mkdtemp(prefix)
         test = script.make_script(os.path.join(self.tmpdir, 'test'), 'exit 0')
         cmd_line = ('%s run %s '
                     '-m examples/tests/sleeptest.py.data/sleeptest.yaml '

--- a/selftests/functional/test_replay_failfast.py
+++ b/selftests/functional/test_replay_failfast.py
@@ -7,13 +7,14 @@ import unittest
 from avocado.core import exit_codes
 from avocado.utils import process
 
-from .. import AVOCADO, BASEDIR
+from .. import AVOCADO, BASEDIR, temp_dir_prefix
 
 
 class ReplayFailfastTests(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
         cmd_line = ('%s run passtest.py failtest.py passtest.py '
                     '--failfast on --job-results-dir %s --sysinfo=off --json -'
                     % (AVOCADO, self.tmpdir))

--- a/selftests/functional/test_skiptests.py
+++ b/selftests/functional/test_skiptests.py
@@ -9,7 +9,7 @@ from avocado.utils import genio
 from avocado.utils import process
 from avocado.utils import script
 
-from .. import AVOCADO, BASEDIR
+from .. import AVOCADO, BASEDIR, temp_dir_prefix
 
 AVOCADO_TEST_SKIP_DECORATORS = """
 import avocado
@@ -79,7 +79,8 @@ class TestSkipDecorators(unittest.TestCase):
 
     def setUp(self):
         os.chdir(BASEDIR)
-        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
 
         test_path = os.path.join(self.tmpdir, 'test_skip_decorators.py')
         self.test_module = script.Script(test_path,

--- a/selftests/functional/test_statuses.py
+++ b/selftests/functional/test_statuses.py
@@ -7,7 +7,7 @@ import unittest
 from avocado.utils import genio
 from avocado.utils import process
 
-from .. import AVOCADO, BASEDIR
+from .. import AVOCADO, BASEDIR, temp_dir_prefix
 
 
 ALL_MESSAGES = ['setup pre',
@@ -130,7 +130,8 @@ EXPECTED_RESULTS = {'SkipSetup.test': ('SKIP',
 class TestStatuses(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
         test_file = os.path.abspath(os.path.join(os.path.dirname(__file__),
                                                  os.path.pardir,
                                                  ".data",

--- a/selftests/functional/test_streams.py
+++ b/selftests/functional/test_streams.py
@@ -7,13 +7,14 @@ import unittest
 from avocado.core import exit_codes
 from avocado.utils import process
 
-from .. import AVOCADO, BASEDIR
+from .. import AVOCADO, BASEDIR, temp_dir_prefix
 
 
 class StreamsTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
         os.chdir(BASEDIR)
 
     def test_app_info_stdout(self):

--- a/selftests/functional/test_sysinfo.py
+++ b/selftests/functional/test_sysinfo.py
@@ -7,7 +7,7 @@ from avocado.core import exit_codes
 from avocado.utils import process
 from avocado.utils import script
 
-from .. import AVOCADO, BASEDIR
+from .. import AVOCADO, BASEDIR, temp_dir_prefix
 
 
 COMMANDS_TIMEOUT_CONF = """
@@ -22,7 +22,8 @@ commands = %s
 class SysInfoTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
 
     def test_sysinfo_enabled(self):
         os.chdir(BASEDIR)

--- a/selftests/functional/test_teststmpdir.py
+++ b/selftests/functional/test_teststmpdir.py
@@ -8,7 +8,7 @@ from avocado.core import test
 from avocado.utils import process
 from avocado.utils import script
 
-from .. import AVOCADO, BASEDIR
+from .. import AVOCADO, BASEDIR, temp_dir_prefix
 
 
 INSTRUMENTED_SCRIPT = """import os
@@ -36,7 +36,8 @@ fi
 class TestsTmpDirTests(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
         self.simple_test = script.TemporaryScript(
             'test_simple.sh',
             SIMPLE_SCRIPT)

--- a/selftests/functional/test_unittest_compat.py
+++ b/selftests/functional/test_unittest_compat.py
@@ -7,7 +7,7 @@ import unittest
 from avocado.utils import script
 from avocado.utils import process
 
-from .. import BASEDIR
+from .. import BASEDIR, temp_dir_prefix
 
 
 UNITTEST_GOOD = """from avocado import Test
@@ -62,7 +62,8 @@ if __name__ == '__main__':
 class UnittestCompat(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp(prefix="avocado_" + __name__)
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
         self.original_pypath = os.environ.get('PYTHONPATH')
         if self.original_pypath is not None:
             os.environ['PYTHONPATH'] = '%s:%s' % (

--- a/selftests/functional/test_utils.py
+++ b/selftests/functional/test_utils.py
@@ -12,6 +12,8 @@ from avocado.utils.filelock import FileLock
 from avocado.utils.stacktrace import prepare_exc_info
 from avocado.utils import process
 
+from .. import temp_dir_prefix
+
 
 # What is commonly known as "0775" or "u=rwx,g=rwx,o=rx"
 DEFAULT_MODE = (stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR |
@@ -125,7 +127,8 @@ if __name__ == '__main__':
 class ProcessTest(unittest.TestCase):
 
     def setUp(self):
-        self.base_logdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.base_logdir = tempfile.mkdtemp(prefix=prefix)
         self.fake_vmstat = os.path.join(self.base_logdir, 'vmstat')
         with open(self.fake_vmstat, 'w') as fake_vmstat_obj:
             fake_vmstat_obj.write(FAKE_VMSTAT_CONTENTS)
@@ -167,7 +170,8 @@ def file_lock_action(args):
 class FileLockTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
 
     @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 2,
                      "Skipping test that take a long time to run, are "

--- a/selftests/functional/test_wrapper.py
+++ b/selftests/functional/test_wrapper.py
@@ -8,7 +8,7 @@ from avocado.utils import process
 from avocado.utils import script
 from avocado.utils import path as utils_path
 
-from .. import AVOCADO, BASEDIR
+from .. import AVOCADO, BASEDIR, temp_dir_prefix
 
 
 SCRIPT_CONTENT = """#!/bin/bash
@@ -32,7 +32,8 @@ def missing_binary(binary):
 class WrapperTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
         self.tmpfile = tempfile.mktemp()
         self.script = script.TemporaryScript(
             'success.sh',

--- a/selftests/unit/test_archive.py
+++ b/selftests/unit/test_archive.py
@@ -9,13 +9,14 @@ from avocado.utils import archive
 from avocado.utils import crypto
 from avocado.utils import data_factory
 
-from .. import BASEDIR
+from .. import BASEDIR, temp_dir_prefix
 
 
 class ArchiveTest(unittest.TestCase):
 
     def setUp(self):
-        self.basedir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.basedir = tempfile.mkdtemp(prefix=prefix)
         self.compressdir = tempfile.mkdtemp(dir=self.basedir)
         self.decompressdir = tempfile.mkdtemp(dir=self.basedir)
         self.sys_random = random.SystemRandom()

--- a/selftests/unit/test_datadir.py
+++ b/selftests/unit/test_datadir.py
@@ -5,18 +5,20 @@ import unittest.mock
 
 from avocado.core import settings
 
+from .. import temp_dir_prefix
+
 
 class DataDirTest(unittest.TestCase):
 
-    @staticmethod
-    def _get_temporary_dirs_mapping_and_config():
+    def _get_temporary_dirs_mapping_and_config(self):
         """
         Creates a temporary bogus base data dir
 
         And returns a dictionary containing the temporary data dir paths and
         a the path to a configuration file contain those same settings
         """
-        base_dir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        base_dir = tempfile.mkdtemp(prefix=prefix)
         test_dir = os.path.join(base_dir, 'tests')
         os.mkdir(test_dir)
         mapping = {'base_dir': base_dir,

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -11,7 +11,7 @@ from avocado.core import job
 from avocado.core import test
 from avocado.utils import path as utils_path
 
-from .. import setup_avocado_loggers
+from .. import setup_avocado_loggers, temp_dir_prefix
 
 
 setup_avocado_loggers()
@@ -22,7 +22,8 @@ class JobTest(unittest.TestCase):
     def setUp(self):
         self.job = None
         data_dir._tmp_tracker.unittest_refresh_dir_tracker()
-        self.tmpdir = tempfile.mkdtemp(prefix="avocado_" + __name__)
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
 
     @staticmethod
     def _find_simple_test_candidates(candidates=None):

--- a/selftests/unit/test_jsonresult.py
+++ b/selftests/unit/test_jsonresult.py
@@ -10,7 +10,7 @@ from avocado.core import job
 from avocado.core.result import Result
 from avocado.plugins import jsonresult
 
-from .. import setup_avocado_loggers
+from .. import setup_avocado_loggers, temp_dir_prefix
 
 
 setup_avocado_loggers()
@@ -33,7 +33,8 @@ class JSONResultTest(unittest.TestCase):
                 pass
 
         self.tmpfile = tempfile.mkstemp()
-        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
         args = argparse.Namespace(json_output=self.tmpfile[1],
                                   base_logdir=self.tmpdir)
         self.job = job.Job(args)

--- a/selftests/unit/test_replay.py
+++ b/selftests/unit/test_replay.py
@@ -6,7 +6,7 @@ import unittest
 from avocado.core import test
 from avocado.plugins import replay
 
-from .. import setup_avocado_loggers
+from .. import setup_avocado_loggers, temp_dir_prefix
 
 
 setup_avocado_loggers()
@@ -19,7 +19,8 @@ class Replay(unittest.TestCase):
     """
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir)

--- a/selftests/unit/test_runner_queue.py
+++ b/selftests/unit/test_runner_queue.py
@@ -11,7 +11,7 @@ from avocado.core.result import Result
 from avocado.core.runner import TestRunner
 from avocado.core.tree import TreeNode
 
-from .. import setup_avocado_loggers
+from .. import setup_avocado_loggers, temp_dir_prefix
 
 
 setup_avocado_loggers()
@@ -23,7 +23,8 @@ class TestRunnerQueue(unittest.TestCase):
     """
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp(prefix="avocado_" + __name__)
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
         args = argparse.Namespace(base_logdir=self.tmpdir)
         self.job = Job(args)
         self.result = Result(self.job)

--- a/selftests/unit/test_sysinfo.py
+++ b/selftests/unit/test_sysinfo.py
@@ -5,11 +5,14 @@ import unittest
 
 from avocado.core import sysinfo
 
+from .. import temp_dir_prefix
+
 
 class SysinfoTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp(prefix="sysinfo_unittest")
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
 
     def test_loggables_equal(self):
         cmd1 = sysinfo.Command("ls -l")

--- a/selftests/unit/test_test.py
+++ b/selftests/unit/test_test.py
@@ -6,7 +6,7 @@ import unittest.mock
 from avocado.core import test, exceptions
 from avocado.utils import astring, script
 
-from .. import setup_avocado_loggers
+from .. import setup_avocado_loggers, temp_dir_prefix
 
 
 setup_avocado_loggers()
@@ -28,7 +28,8 @@ class TestClassTestUnit(unittest.TestCase):
             pass
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp(prefix="avocado_" + __name__)
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
 
     def _get_fake_filename_test(self, name):
 
@@ -175,7 +176,8 @@ class TestClassTest(unittest.TestCase):
                 self.assertTrue(variable)
                 self.whiteboard = 'foo'
 
-        self.base_logdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.base_logdir = tempfile.mkdtemp(prefix=prefix)
         self.tst_instance_pass = AvocadoPass(base_logdir=self.base_logdir)
         self.tst_instance_pass.run_avocado()
 
@@ -212,7 +214,8 @@ class TestClassTest(unittest.TestCase):
 class SimpleTestClassTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
         self.script = None
 
     def test_simple_test_pass_status(self):
@@ -248,7 +251,8 @@ class SimpleTestClassTest(unittest.TestCase):
 class MockingTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
 
     def test_init_minimal_params(self):
         test.MockingTest(base_logdir=self.tmpdir)

--- a/selftests/unit/test_utils_asset.py
+++ b/selftests/unit/test_utils_asset.py
@@ -6,7 +6,7 @@ import unittest
 from avocado.utils import asset
 from avocado.utils.filelock import FileLock
 
-from .. import setup_avocado_loggers
+from .. import setup_avocado_loggers, temp_dir_prefix
 
 
 setup_avocado_loggers()
@@ -15,7 +15,8 @@ setup_avocado_loggers()
 class TestAsset(unittest.TestCase):
 
     def setUp(self):
-        self.basedir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.basedir = tempfile.mkdtemp(prefix=prefix)
         self.assetdir = tempfile.mkdtemp(dir=self.basedir)
         self.assetname = 'foo.tgz'
         self.assethash = '3a033a8938c1af56eeb793669db83bcbd0c17ea5'

--- a/selftests/unit/test_utils_cloudinit.py
+++ b/selftests/unit/test_utils_cloudinit.py
@@ -10,7 +10,7 @@ from avocado.utils import iso9660
 from avocado.utils import network
 from avocado.utils import data_factory
 
-from .. import setup_avocado_loggers
+from .. import setup_avocado_loggers, temp_dir_prefix
 
 
 setup_avocado_loggers()
@@ -30,7 +30,8 @@ class CloudInit(unittest.TestCase):
 class CloudInitISO(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp(prefix="avocado_" + __name__)
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
 
     @unittest.skipUnless(has_iso_create_write(),
                          "system lacks support for creating ISO images")

--- a/selftests/unit/test_utils_filelock.py
+++ b/selftests/unit/test_utils_filelock.py
@@ -6,11 +6,14 @@ import unittest
 from avocado.utils.filelock import AlreadyLocked
 from avocado.utils.filelock import FileLock
 
+from .. import temp_dir_prefix
+
 
 class TestFileLock(unittest.TestCase):
 
     def setUp(self):
-        self.basedir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.basedir = tempfile.mkdtemp(prefix=prefix)
         self.filename = os.path.join(self.basedir, 'file.img')
         self.content = 'Foo bar'
         with open(self.filename, 'w') as f:

--- a/selftests/unit/test_utils_genio.py
+++ b/selftests/unit/test_utils_genio.py
@@ -4,7 +4,7 @@ import unittest
 
 from avocado.utils import genio
 
-from .. import setup_avocado_loggers
+from .. import setup_avocado_loggers, temp_dir_prefix
 
 
 setup_avocado_loggers()
@@ -12,7 +12,8 @@ setup_avocado_loggers()
 
 class TestGenio(unittest.TestCase):
     def test_check_pattern_in_directory(self):
-        tempdirname = tempfile.mkdtemp()
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        tempdirname = tempfile.mkdtemp(prefix=prefix)
         with self.assertRaises(genio.GenIOError):
             genio.is_pattern_in_file(tempdirname, 'something')
         os.rmdir(tempdirname)

--- a/selftests/unit/test_utils_iso9660.py
+++ b/selftests/unit/test_utils_iso9660.py
@@ -8,7 +8,7 @@ import unittest.mock
 
 from avocado.utils import iso9660, process
 
-from .. import setup_avocado_loggers
+from .. import setup_avocado_loggers, temp_dir_prefix
 
 
 setup_avocado_loggers()
@@ -55,7 +55,8 @@ class BaseIso9660:
                                                      os.path.pardir, ".data",
                                                      "sample.iso"))
         self.iso = None
-        self.tmpdir = tempfile.mkdtemp(prefix="avocado_" + __name__)
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
 
     def test_basic_workflow(self):
         """

--- a/selftests/unit/test_utils_partition.py
+++ b/selftests/unit/test_utils_partition.py
@@ -14,6 +14,8 @@ from avocado.utils import partition, process
 from avocado.utils import path as utils_path
 from avocado.utils import wait
 
+from .. import temp_dir_prefix
+
 
 def missing_binary(binary):
     try:
@@ -37,7 +39,8 @@ class Base(unittest.TestCase):
                      'current user must be allowed to run "mkfs.ext2" under '
                      'sudo')
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp(prefix="avocado_" + __name__)
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
         self.mountpoint = os.path.join(self.tmpdir, "disk")
         os.mkdir(self.mountpoint)
         self.disk = partition.Partition(os.path.join(self.tmpdir, "block"), 1,

--- a/selftests/unit/test_xunit.py
+++ b/selftests/unit/test_xunit.py
@@ -17,7 +17,7 @@ from avocado.core import job
 from avocado.core.result import Result
 from avocado.plugins import xunit
 
-from .. import setup_avocado_loggers
+from .. import setup_avocado_loggers, temp_dir_prefix
 
 
 setup_avocado_loggers()
@@ -44,7 +44,8 @@ class xUnitSucceedTest(unittest.TestCase):
                 pass
 
         self.tmpfile = tempfile.mkstemp()
-        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
         args = argparse.Namespace(base_logdir=self.tmpdir)
         args.xunit_output = self.tmpfile[1]
         self.job = job.Job(args)


### PR DESCRIPTION
Rules such as "check" on our Makefile make sure that no temporary
directory created by Avocado is left behind, but, it's very hard to
tell who created a rogue directory.

This brings improvements to the naming of the temporary directory, so
that it's trivial to tell which test created in the first place.

Additionally, it improves the temporary directory creation, usually by
making use of a tearDown() test phase, instead of other more fragile
methods.

Signed-off-by: Cleber Rosa <crosa@redhat.com>