### PR TITLE
selftests/modules-boundaries.sh: use bash as interpreter

### DIFF
--- a/selftests/modules-boundaries.sh
+++ b/selftests/modules-boundaries.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # number of infringements found
 RESULT=0


### PR DESCRIPTION
This shell script can not actually be used with non-bash sheels.  This
only manifests on some environments where /bin/sh is not bash, and the
exact outcome is similar to:

   * Checking for avocado.core imports from examples/tests: selftests/modules-boundaries.sh: 9: selftests/modules-boundaries.sh: RESULT: not found
   0
   * Checking for non-relative avocado imports from avocado/core: selftests/modules-boundaries.sh: 20: selftests/modules-boundaries.sh: RESULT: not found
   0
   * Checking for avocado imports from avocado/utils: selftests/modules-boundaries.sh: 31: selftests/modules-boundaries.sh: RESULT: not found
   0
   PASS: no module boundary infringement(s) found

Signed-off-by: Cleber Rosa <crosa@redhat.com>