### PR TITLE
Fix of tests execution from cit variants

### DIFF
--- a/optional_plugins/varianter_cit/avocado_varianter_cit/__init__.py
+++ b/optional_plugins/varianter_cit/avocado_varianter_cit/__init__.py
@@ -107,8 +107,11 @@ class VarianterCit(Varianter):
                                          for key in self.headers]))
 
         for vid, variant in zip(variant_ids, self.variants):
+            variant_tree_nodes = []
+            for key, val in variant.items():
+                variant_tree_nodes.append(TreeNode(key, {key: val}))
             yield {"variant_id": vid,
-                   "variant": TreeNode('', variant),
+                   "variant": variant_tree_nodes,
                    "paths": ['/']}
 
     def __len__(self):


### PR DESCRIPTION
The variants were added to the runner in the wrong format. This commit solves the problem.