### PR TITLE
Varianter CIT Plugin: fix data type of variant nodes

### DIFF
--- a/examples/tests/cit_parameters.py
+++ b/examples/tests/cit_parameters.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+
+from avocado import main
+from avocado import Test
+
+
+class CitParameters(Test):
+
+    """
+    Example test that fetches the parameters set on examples/cit/params.ini
+
+    :avocado: tags=fast
+    """
+
+    def test(self):
+        self.params.get('color')
+        self.params.get('shape')
+        self.params.get('state')
+        self.params.get('material')
+        self.params.get('coating')
+
+
+if __name__ == "__main__":
+    main()

--- a/optional_plugins/varianter_cit/avocado_varianter_cit/__init__.py
+++ b/optional_plugins/varianter_cit/avocado_varianter_cit/__init__.py
@@ -108,7 +108,7 @@ class VarianterCit(Varianter):
 
         for vid, variant in zip(variant_ids, self.variants):
             yield {"variant_id": vid,
-                   "variant": TreeNode('', variant),
+                   "variant": [TreeNode('', variant)],
                    "paths": ['/']}
 
     def __len__(self):

--- a/optional_plugins/varianter_cit/tests/test_functional.py
+++ b/optional_plugins/varianter_cit/tests/test_functional.py
@@ -1,9 +1,11 @@
 import os
+import shutil
+import tempfile
 import unittest
 
 from avocado.utils import process
 
-from selftests import AVOCADO
+from selftests import AVOCADO, BASEDIR, temp_dir_prefix
 
 
 basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..', '..')
@@ -23,6 +25,65 @@ class Variants(unittest.TestCase):
         lines = result.stdout.splitlines()
         self.assertEqual(b'CIT Variants (216):', lines[0])
         self.assertEqual(217, len(lines))
+
+
+class Run(unittest.TestCase):
+
+    def setUp(self):
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
+
+    def test(self):
+        os.chdir(BASEDIR)
+        params_path = os.path.join(BASEDIR, 'examples',
+                                   'varianter_cit', 'params.ini')
+        test_path = os.path.join(BASEDIR, 'examples',
+                                 'tests', 'cit_parameters.py')
+        cmd_line = (
+            '{0} --show=test run --sysinfo=off --job-results-dir={1} '
+            '--cit-order-of-combinations=1 '
+            '--cit-parameter-file={2} '
+            '-- {3}'
+        ).format(AVOCADO, self.tmpdir, params_path, test_path)
+        result = process.run(cmd_line)
+        # all values of colors should be looked for at least once
+        self.assertIn(b"PARAMS (key=color, path=*, default=None) => 'black'",
+                      result.stdout)
+        self.assertIn(b"PARAMS (key=color, path=*, default=None) => 'gold'",
+                      result.stdout)
+        self.assertIn(b"PARAMS (key=color, path=*, default=None) => 'red'",
+                      result.stdout)
+        self.assertIn(b"PARAMS (key=color, path=*, default=None) => 'green'",
+                      result.stdout)
+        # all values of shape should be looked for at least once
+        self.assertIn(b"PARAMS (key=shape, path=*, default=None) => 'square'",
+                      result.stdout)
+        self.assertIn(b"PARAMS (key=shape, path=*, default=None) => 'triangle'",
+                      result.stdout)
+        self.assertIn(b"PARAMS (key=shape, path=*, default=None) => 'circle'",
+                      result.stdout)
+        # all values of state should be looked for at least once
+        self.assertIn(b"PARAMS (key=state, path=*, default=None) => 'liquid'",
+                      result.stdout)
+        self.assertIn(b"PARAMS (key=state, path=*, default=None) => 'solid'",
+                      result.stdout)
+        self.assertIn(b"PARAMS (key=state, path=*, default=None) => 'gas'",
+                      result.stdout)
+        # all values of material should be looked for at least once
+        self.assertIn(b"PARAMS (key=material, path=*, default=None) => 'leather'",
+                      result.stdout)
+        self.assertIn(b"PARAMS (key=material, path=*, default=None) => 'plastic'",
+                      result.stdout)
+        self.assertIn(b"PARAMS (key=material, path=*, default=None) => 'aluminum'",
+                      result.stdout)
+        # all values of coating should be looked for at least once
+        self.assertIn(b"PARAMS (key=coating, path=*, default=None) => 'anodic'",
+                      result.stdout)
+        self.assertIn(b"PARAMS (key=coating, path=*, default=None) => 'cathodic'",
+                      result.stdout)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The data type expected to be given to each yield variant contains the
variant id, the "variant" itself, which should be a list of
TreeNode-like instances, and finally the applicable default search
paths.

The "variant" itself, has to be a list, given that on the very first
varianter implementation, it's supposed to contain one item for each
branch of the tree.

Signed-off-by: Cleber Rosa <crosa@redhat.com>