### PR TITLE
Varianter CIT test: use BASEDIR from selftests module

### DIFF
--- a/optional_plugins/varianter_cit/tests/test_functional.py
+++ b/optional_plugins/varianter_cit/tests/test_functional.py
@@ -8,19 +8,14 @@ from avocado.utils import process
 from selftests import AVOCADO, BASEDIR, temp_dir_prefix
 
 
-basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..', '..')
-basedir = os.path.abspath(basedir)
-
-
 class Variants(unittest.TestCase):
 
     def test_max_variants(self):
-        os.chdir(basedir)
+        os.chdir(BASEDIR)
         cmd_line = (
             '{0} variants --cit-order-of-combinations=5 '
             '--cit-parameter-file examples/varianter_cit/params.ini'
         ).format(AVOCADO)
-        os.chdir(basedir)
         result = process.run(cmd_line)
         lines = result.stdout.splitlines()
         self.assertEqual(b'CIT Variants (216):', lines[0])


### PR DESCRIPTION
I clearly missed that on 71d915dd3, as there's no point of using
a locally defined "basedir" and the one from the sefltests module.

Signed-off-by: Cleber Rosa <crosa@redhat.com>