### PR TITLE
scripts/avocado: fix the `OSError` complained by `get_crash_dir()`

### DIFF
--- a/scripts/avocado
+++ b/scripts/avocado
@@ -32,7 +32,10 @@ except ImportError:
 
 def get_crash_dir():
     crash_dir_path = os.path.join(data_dir.get_data_dir(), "crashes")
-    os.makedirs(crash_dir_path)
+    try:
+        os.makedirs(crash_dir_path)
+    except OSError:
+        pass
     return crash_dir_path
 
 


### PR DESCRIPTION
An `OSError` would be raised when avocado crashes the second time,
that because the crash dir has already existed while the script
attempted to create it again.

Let's catch the error and ignore it.

Signed-off-by: Xu Han <xuhan@redhat.com>