### PR TITLE
avocado/utils/network.py: use random port allocation by default

### DIFF
--- a/avocado/utils/network.py
+++ b/avocado/utils/network.py
@@ -66,7 +66,7 @@ def is_port_free(port, address):
             sock.close()
 
 
-def find_free_port(start_port=1024, end_port=65535, address="localhost", sequent=True):
+def find_free_port(start_port=1024, end_port=65535, address="localhost", sequent=False):
     """
     Return a host free port in the range [start_port, end_port].
 
@@ -86,7 +86,7 @@ def find_free_port(start_port=1024, end_port=65535, address="localhost", sequent
     return None
 
 
-def find_free_ports(start_port, end_port, count, address="localhost", sequent=True):
+def find_free_ports(start_port, end_port, count, address="localhost", sequent=False):
     """
     Return count of host free ports in the range [start_port, end_port].
 


### PR DESCRIPTION
AFAICT, most users of find_free_port() don't really care about the
port number being the first in the range, and to be honest, most users
I've seen don't even give a range.

So, the result when using the first port in the range is a high change
of collision, with no real benefit.  Let's change the default policy,
using a random port allocation.

PS: this is motivated by real world collisions I've experienced when
running tests in parallel, *and* when running other loads in the same
machine along tests.

Signed-off-by: Cleber Rosa <crosa@redhat.com>