### PR TITLE
List and better filter support for key:val tags

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -109,13 +109,21 @@ def must_key_val_matches(must_key_vals, test_tags, include_empty_key):
 
     :rtype: bool
     """
+    key_val_test_tags = {}
+    for k, v in test_tags.items():
+        if v is None:
+            continue
+        key_val_test_tags[k] = v
+
     for k, v in must_key_vals.items():
-        if k in test_tags:
-            return v in test_tags[k]
-        else:
+        if k not in test_tags:
             if include_empty_key:
-                return True
-    return False
+                continue
+            else:
+                return False
+        if v not in key_val_test_tags.get(k, set()):
+            return False
+    return True
 
 
 def filter_test_tags(test_suite, filter_by_tags, include_empty=False,

--- a/avocado/plugins/list.py
+++ b/avocado/plugins/list.py
@@ -75,14 +75,19 @@ class TestLister:
                 if 'tags' in params:
                     tags = params['tags']
                 else:
-                    tags = set()
-                for tag in tags:
+                    tags = {}
+                tags_repr = []
+                for tag, vals in tags.items():
                     if tag not in tag_stats:
                         tag_stats[tag] = 1
                     else:
                         tag_stats[tag] += 1
-                tags = ",".join(tags)
-                test_matrix.append((type_label, params['name'], tags))
+                    if vals:
+                        tags_repr.append("%s(%s)" % (tag, ",".join(vals)))
+                    else:
+                        tags_repr.append(tag)
+                tags_repr = ",".join(tags_repr)
+                test_matrix.append((type_label, params['name'], tags_repr))
             else:
                 test_matrix.append((type_label, params['name']))
 


### PR DESCRIPTION
The list command was not showing the values for keys.  Also, this fixes filtering multiple key:vals. 