### PR TITLE
Make "make rpm" work again

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -1,3 +1,24 @@
+ifneq "" "$(findstring fedora-31-,$(MOCK_CONFIG))$(findstring fedora-rawhide-,$(MOCK_CONFIG))"
+    modenable := avocado:latest
+    modrepos := --enablerepo=rawhide-modular
+else ifneq "" "$(findstring fedora-30-,$(MOCK_CONFIG))"
+    modenable := avocado:69lts
+    modrepos := --enablerepo=fedora-modular
+else ifneq "" "$(findstring fedora-29-,$(MOCK_CONFIG))"
+    modenable := avocado:stable
+    modrepos := --enablerepo=fedora-modular
+else
+    modenable :=
+endif
+
+mock-setup:
+	mock -r $(MOCK_CONFIG) --init
+ifneq "" "$(modenable)"
+	mock -r $(MOCK_CONFIG) $(modrepos) --dnf-cmd module enable $(modenable)
+	mock -r $(MOCK_CONFIG) $(modrepos) --dnf-cmd install "python3-aexpect"
+	mock -r $(MOCK_CONFIG) $(modrepos) --dnf-cmd module disable $(firstword $(subst :, ,$(modenable)))
+endif
+
 source: clean
 	if test ! -d SOURCES; then mkdir SOURCES; fi
 	git archive --prefix="$(ARCHIVE_BASE_NAME)-$(COMMIT)/" -o "SOURCES/$(ARCHIVE_BASE_NAME)-$(SHORT_COMMIT).tar.gz" HEAD
@@ -13,17 +34,17 @@ srpm: source
 	if test ! -d BUILD/SRPM; then mkdir -p BUILD/SRPM; fi
 	mock -r $(MOCK_CONFIG) --resultdir BUILD/SRPM -D "rel_build 0" -D "commit $(COMMIT)" -D "commit_date $(COMMIT_DATE)" --buildsrpm --spec $(RPM_BASE_NAME).spec --sources SOURCES
 
-rpm: srpm
+rpm: srpm mock-setup
 	if test ! -d BUILD/RPM; then mkdir -p BUILD/RPM; fi
-	mock -r $(MOCK_CONFIG) --resultdir BUILD/RPM -D "rel_build 0" -D "commit $(COMMIT)" -D "commit_date $(COMMIT_DATE)" --rebuild BUILD/SRPM/$(RPM_BASE_NAME)-$(VERSION)-*.src.rpm
+	mock -r $(MOCK_CONFIG) --no-clean --resultdir BUILD/RPM -D "rel_build 0" -D "commit $(COMMIT)" -D "commit_date $(COMMIT_DATE)" --rebuild BUILD/SRPM/$(RPM_BASE_NAME)-$(VERSION)-*.src.rpm
 
 srpm-release: source-release
 	if test ! -d BUILD/SRPM; then mkdir -p BUILD/SRPM; fi
 	mock -r $(MOCK_CONFIG) --resultdir BUILD/SRPM -D "rel_build 1" --buildsrpm --spec $(RPM_BASE_NAME).spec --sources SOURCES
 
-rpm-release: srpm-release
+rpm-release: srpm-release mock-setup
 	if test ! -d BUILD/RPM; then mkdir -p BUILD/RPM; fi
-	mock -r $(MOCK_CONFIG) --resultdir BUILD/RPM -D "rel_build 1" --rebuild BUILD/SRPM/$(RPM_BASE_NAME)-$(VERSION)-*.src.rpm
+	mock -r $(MOCK_CONFIG) --no-clean --resultdir BUILD/RPM -D "rel_build 1" --rebuild BUILD/SRPM/$(RPM_BASE_NAME)-$(VERSION)-*.src.rpm
 
 pip:
 	$(PYTHON) -m pip --version || $(PYTHON) -m ensurepip $(PYTHON_DEVELOP_ARGS) || $(PYTHON) -c "import os; import sys; import urllib; f = urllib.urlretrieve('https://bootstrap.pypa.io/get-pip.py')[0]; os.system('%s %s' % (sys.executable, f))"


### PR DESCRIPTION
Makefile update so "make rpm", etc. can be used to build with mock using the python3-aexpect package from the Fedora modular repositories.
