### PR TITLE
introduce decorator cancel_on

### DIFF
--- a/avocado/__init__.py
+++ b/avocado/__init__.py
@@ -29,6 +29,7 @@ from avocado.core.job import main
 from avocado.core.test import Test
 from avocado.core.version import VERSION
 from avocado.core.decorators import fail_on
+from avocado.core.decorators import cancel_on
 from avocado.core.decorators import skip
 from avocado.core.decorators import skipIf
 from avocado.core.decorators import skipUnless

--- a/docs/source/WritingTests.rst
+++ b/docs/source/WritingTests.rst
@@ -146,6 +146,17 @@ Once again, keeping your tests up-to-date and distinguishing between
 ``FAIL`` and ``ERROR`` will save you a lot of time while reviewing the
 test results.
 
+Turning errors into cancels
+---------------------------
+It is also possible to assume unhandled exception to be as a test ``CANCEL``
+instead of a test ``ERROR`` simply by using ``cancel_on`` decorator::
+
+    def test(self):
+        @avocado.cancel_on(TypeError)
+        def foo():
+            raise TypeError
+        foo()
+
 .. _saving-test-generated-custom-data:
 
 Saving test generated (custom) data

--- a/examples/tests/cancel_on_exception.py
+++ b/examples/tests/cancel_on_exception.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+
+import avocado
+
+
+class CancelOnException(avocado.Test):
+
+    """
+    Test illustrating the usage of the cancel_on decorator.
+    """
+
+    def test(self):
+        """
+        This should end with CANCEL.
+
+        Avocado tests should end with ERROR when a generic exception such as
+        RuntimeError is raised. The avocado.cancel_on decorator allows you
+        to override this behavior, and turn your generic exceptions into
+        test CANCEL.
+        """
+        @avocado.cancel_on(RuntimeError)
+        def foo():
+            raise RuntimeError
+        foo()
+
+
+if __name__ == "__main__":
+    avocado.main()

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -356,6 +356,18 @@ class RunnerOperationTest(unittest.TestCase):
                                                                 result))
         self.assertIn(b'"status": "FAIL"', result.stdout)
 
+    def test_cancel_on_exception(self):
+        cmd_line = ("%s run --sysinfo=off --job-results-dir %s "
+                    "--json - cancel_on_exception.py" % (AVOCADO, self.tmpdir))
+        result = process.run(cmd_line, ignore_status=True)
+        expected_rc = exit_codes.AVOCADO_ALL_OK
+        self.assertEqual(result.exit_status, expected_rc,
+                         "Avocado did not return rc %d:\n%s" % (expected_rc,
+                                                                result))
+        result = json.loads(result.stdout_text)
+        for test in result['tests']:
+            self.assertEqual(test['status'], 'CANCEL')
+
     def test_assert_raises(self):
         cmd_line = ("%s run --sysinfo=off --job-results-dir %s "
                     "-- assert.py" % (AVOCADO, self.tmpdir))


### PR DESCRIPTION
aims to cancel the test after certain type of exception is raised within
the wrapped function.

Signed-off-by: lolyu <lolyu@redhat.com>