### PR TITLE
Make Fedora 31 builds work again

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -1,3 +1,24 @@
+ifneq "" "$(findstring fedora-31-,$(MOCK_CONFIG))$(findstring fedora-rawhide-,$(MOCK_CONFIG))"
+    modenable := avocado:latest
+    modrepos := --enablerepo=rawhide-modular
+else ifneq "" "$(findstring fedora-30-,$(MOCK_CONFIG))"
+    modenable := avocado:69lts
+    modrepos := --enablerepo=fedora-modular
+else ifneq "" "$(findstring fedora-29-,$(MOCK_CONFIG))"
+    modenable := avocado:stable
+    modrepos := --enablerepo=fedora-modular
+else
+    modenable :=
+endif
+
+mock-setup:
+	mock -r $(MOCK_CONFIG) --init
+ifneq "" "$(modenable)"
+	mock -r $(MOCK_CONFIG) $(modrepos) --dnf-cmd module enable $(modenable)
+	mock -r $(MOCK_CONFIG) $(modrepos) --dnf-cmd install "python3-aexpect"
+	mock -r $(MOCK_CONFIG) $(modrepos) --dnf-cmd module disable $(firstword $(subst :, ,$(modenable)))
+endif
+
 source: clean
 	if test ! -d SOURCES; then mkdir SOURCES; fi
 	git archive --prefix="$(ARCHIVE_BASE_NAME)-$(COMMIT)/" -o "SOURCES/$(ARCHIVE_BASE_NAME)-$(SHORT_COMMIT).tar.gz" HEAD
@@ -13,17 +34,17 @@ srpm: source
 	if test ! -d BUILD/SRPM; then mkdir -p BUILD/SRPM; fi
 	mock -r $(MOCK_CONFIG) --resultdir BUILD/SRPM -D "rel_build 0" -D "commit $(COMMIT)" -D "commit_date $(COMMIT_DATE)" --buildsrpm --spec $(RPM_BASE_NAME).spec --sources SOURCES
 
-rpm: srpm
+rpm: srpm mock-setup
 	if test ! -d BUILD/RPM; then mkdir -p BUILD/RPM; fi
-	mock -r $(MOCK_CONFIG) --resultdir BUILD/RPM -D "rel_build 0" -D "commit $(COMMIT)" -D "commit_date $(COMMIT_DATE)" --rebuild BUILD/SRPM/$(RPM_BASE_NAME)-$(VERSION)-*.src.rpm
+	mock -r $(MOCK_CONFIG) --no-clean --resultdir BUILD/RPM -D "rel_build 0" -D "commit $(COMMIT)" -D "commit_date $(COMMIT_DATE)" --rebuild BUILD/SRPM/$(RPM_BASE_NAME)-$(VERSION)-*.src.rpm
 
 srpm-release: source-release
 	if test ! -d BUILD/SRPM; then mkdir -p BUILD/SRPM; fi
 	mock -r $(MOCK_CONFIG) --resultdir BUILD/SRPM -D "rel_build 1" --buildsrpm --spec $(RPM_BASE_NAME).spec --sources SOURCES
 
-rpm-release: srpm-release
+rpm-release: srpm-release mock-setup
 	if test ! -d BUILD/RPM; then mkdir -p BUILD/RPM; fi
-	mock -r $(MOCK_CONFIG) --resultdir BUILD/RPM -D "rel_build 1" --rebuild BUILD/SRPM/$(RPM_BASE_NAME)-$(VERSION)-*.src.rpm
+	mock -r $(MOCK_CONFIG) --no-clean --resultdir BUILD/RPM -D "rel_build 1" --rebuild BUILD/SRPM/$(RPM_BASE_NAME)-$(VERSION)-*.src.rpm
 
 pip:
 	$(PYTHON) -m pip --version || $(PYTHON) -m ensurepip $(PYTHON_DEVELOP_ARGS) || $(PYTHON) -c "import os; import sys; import urllib; f = urllib.urlretrieve('https://bootstrap.pypa.io/get-pip.py')[0]; os.system('%s %s' % (sys.executable, f))"

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -26,6 +26,14 @@
 # enabled by default.
 %global with_tests 1
 
+# Avocado is currently incompatible with the Fabric API in Fedora 31 and later
+# https://github.com/avocado-framework/avocado/issues/3125
+%if 0%{?fedora} >= 31
+%global with_fabric 0
+%else
+%global with_fabric 1
+%endif
+
 # Python 3 version of Fabric package is new starting with Fedora 29
 %if 0%{?fedora} >= 29
 %global with_python3_fabric 1
@@ -41,7 +49,7 @@
 Summary: Framework with tools and libraries for Automated Testing
 Name: python-%{srcname}
 Version: 69.0
-Release: 0%{?gitrel}%{?dist}
+Release: 1%{?gitrel}%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.github.io/
@@ -53,9 +61,11 @@ Source0: https://github.com/avocado-framework/%{srcname}/archive/%{commit}.tar.g
 BuildArch: noarch
 BuildRequires: procps-ng
 BuildRequires: kmod
+%if %{with_fabric}
 %if %{with_python3_fabric}
 BuildRequires: python3-fabric3
 %endif
+%endif # with_fabric
 %if 0%{?fedora} >= 30
 BuildRequires: glibc-all-langpacks
 %endif
@@ -94,7 +104,6 @@ Requires: python3-%{srcname}-common == %{version}
 Requires: gdb
 Requires: gdb-gdbserver
 Requires: procps-ng
-Requires: pyliblzma
 Requires: python3
 Requires: python3-requests
 Requires: python3-setuptools
@@ -125,19 +134,25 @@ pushd optional_plugins/html
 %py3_build
 popd
 pushd optional_plugins/runner_remote
+%if %{with_fabric}
 %if %{with_python3_fabric}
 %py3_build
 %endif
+%endif # with_fabric
 popd
 pushd optional_plugins/runner_vm
+%if %{with_fabric}
 %if %{with_python3_fabric}
 %py3_build
 %endif
+%endif # with_fabric
 popd
 pushd optional_plugins/runner_docker
+%if %{with_fabric}
 %if %{with_python3_fabric}
 %py3_build
 %endif
+%endif # with_fabric
 popd
 pushd optional_plugins/resultsdb
 %py3_build
@@ -178,19 +193,25 @@ pushd optional_plugins/html
 %py3_install
 popd
 pushd optional_plugins/runner_remote
+%if %{with_fabric}
 %if %{with_python3_fabric}
 %py3_install
 %endif
+%endif # with_fabric
 popd
 pushd optional_plugins/runner_vm
+%if %{with_fabric}
 %if %{with_python3_fabric}
 %py3_install
 %endif
+%endif # with_fabric
 popd
 pushd optional_plugins/runner_docker
+%if %{with_fabric}
 %if %{with_python3_fabric}
 %py3_install
 %endif
+%endif # with_fabric
 popd
 pushd optional_plugins/resultsdb
 %py3_install
@@ -239,6 +260,7 @@ find %{buildroot}%{_docdir}/avocado -type f -name '*.py' -exec %{__chmod} -c -x 
 pushd optional_plugins/html
 %{__python3} setup.py develop --user
 popd
+%if %{with_fabric}
 %if %{with_python3_fabric}
 pushd optional_plugins/runner_remote
 %{__python3} setup.py develop --user
@@ -249,7 +271,8 @@ popd
 pushd optional_plugins/runner_docker
 %{__python3} setup.py develop --user
 popd
-%endif
+%endif # with_python3_fabric
+%endif # with_fabric
 pushd optional_plugins/resultsdb
 %{__python3} setup.py develop --user
 popd
@@ -358,6 +381,7 @@ arbitrary filesystem location.
 %{python3_sitelib}/avocado_result_html*
 %{python3_sitelib}/avocado_framework_plugin_result_html*
 
+%if %{with_fabric}
 %if %{with_python3_fabric}
 %package -n python3-%{srcname}-plugins-runner-remote
 Summary: Avocado Runner for Remote Execution
@@ -371,8 +395,10 @@ connection.  Avocado must be previously installed on the remote machine.
 %files -n python3-%{srcname}-plugins-runner-remote
 %{python3_sitelib}/avocado_runner_remote*
 %{python3_sitelib}/avocado_framework_plugin_runner_remote*
-%endif
+%endif # with_python3_fabric
+%endif # with_fabric
 
+%if %{with_fabric}
 %if %{with_python3_fabric}
 %package -n python3-%{srcname}-plugins-runner-vm
 Summary: Avocado Runner for libvirt VM Execution
@@ -388,8 +414,10 @@ itself.  Avocado must be previously installed on the VM.
 %files -n python3-%{srcname}-plugins-runner-vm
 %{python3_sitelib}/avocado_runner_vm*
 %{python3_sitelib}/avocado_framework_plugin_runner_vm*
-%endif
+%endif # with_python3_fabric
+%endif # with_fabric
 
+%if %{with_fabric}
 %if %{with_python3_fabric}
 %package -n python3-%{srcname}-plugins-runner-docker
 Summary: Avocado Runner for Execution on Docker Containers
@@ -405,7 +433,8 @@ be previously installed on the container.
 %files -n python3-%{srcname}-plugins-runner-docker
 %{python3_sitelib}/avocado_runner_docker*
 %{python3_sitelib}/avocado_framework_plugin_runner_docker*
-%endif
+%endif # with_python3_fabric
+%endif # with_fabric
 
 %package -n python3-%{srcname}-plugins-resultsdb
 Summary: Avocado plugin to propagate job results to ResultsDB
@@ -541,6 +570,12 @@ Again Shell code (and possibly other similar shells).
 %{_libexecdir}/avocado*
 
 %changelog
+* Tue May 28 2019 Merlin Mathesius <mmathesi@redhat.com> - 69.0-1
+- Disable components dependent upon Fiber in Fedora 31 and later,
+  since avocado is currently incompatible with the new Fiber API.
+- Remove pyliblzma as it has always been Python 2-only, and it is
+  no longer available as of F31.
+
 * Tue Feb 26 2019 Cleber Rosa <cleber@redhat.com> - 69.0-0
 - New release
 


### PR DESCRIPTION
This is a follow-on to my earlier PR #3129, which got "make rpm" working again. This PR fixes up the avocado SPEC file so "make rpm" now succeeds for Fedora 31/Rawhide