### PR TITLE
avocado/utils/linux_modules.py: remove compatiblity definitions

### DIFF
--- a/avocado/utils/linux_modules.py
+++ b/avocado/utils/linux_modules.py
@@ -43,14 +43,6 @@ class ModuleConfig(Enum):
     BUILTIN = object()
 
 
-#: Compatibility alias (to be removed) to :attr:`ModuleConfig.NOT_SET`
-NOT_SET = ModuleConfig.NOT_SET
-#: Compatibility alias (to be removed) to :attr:`ModuleConfig.MODULE`
-MODULE = ModuleConfig.MODULE
-#: Compatibility alias (to be removed) to :attr:`ModuleConfig.BUILTIN`
-BUILTIN = ModuleConfig.BUILTIN
-
-
 def load_module(module_name):
     """
     Checks if a module has already been loaded.


### PR DESCRIPTION
The new definitions (Enum based) have been present for quite a long
time.  Let's remove the deprecated ones in accordance to previous
planning.

Reference: https://trello.com/c/BMC7yFbX
Signed-off-by: Cleber Rosa <crosa@redhat.com>