### PR TITLE
[LTS] avocado/utils/vmimage.py: s390x is also a Fedora secondary arch

### DIFF
--- a/avocado/utils/vmimage.py
+++ b/avocado/utils/vmimage.py
@@ -410,7 +410,7 @@ def get(name=None, version=None, build=None, arch=None, checksum=None,
         provider_args['build'] = build
     if arch is not None:
         provider_args['arch'] = arch
-        if name == 'fedora' and arch in ('ppc64', 'ppc64le'):
+        if name == 'fedora' and arch in ('ppc64', 'ppc64le', 's390x'):
             name = 'fedorasecondary'
 
     for provider in IMAGE_PROVIDERS:


### PR DESCRIPTION
And because of that, it's hosted in a different set of servers.

Signed-off-by: Cleber Rosa <crosa@redhat.com>