### PR TITLE
Added utilities to set and get /proc/sys settings [v2]

### DIFF
--- a/avocado/utils/linux.py
+++ b/avocado/utils/linux.py
@@ -1,0 +1,53 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# This code was inspired in the autotest project,
+#
+# client/base_utils.py
+#
+# Copyright: IBM, 2019
+#            Red Hat Inc. 2019
+# Authors : Praveen K Pandey <praveen@linux.vnet.ibm.com>
+#           Cleber Rosa <crosa@redhat.com>
+
+
+"""
+Linux OS utilities
+"""
+
+import os
+
+from . import genio
+
+
+def get_proc_sys(key):
+    """
+    Read values from /proc/sys
+
+    :param key: A location under /proc/sys
+    :return: The single-line sysctl value as a string.
+    """
+    path = os.path.join('/proc/sys/%s', key)
+    return genio.read_one_line(path)
+
+
+def set_proc_sys(key, value):
+    """
+    Set values on /proc/sys
+
+    :param key: A location under /proc/sys
+    :param value: If not None, a value to write into the sysctl.
+
+    :return: The single-line sysctl value as a string.
+    """
+    path = os.path.join('/proc/sys/%s', key)
+    genio.write_one_line(path, value)
+    return get_proc_sys(key)


### PR DESCRIPTION
Thse two allow users to get and set content from /proc/sys

PS: The namespace chosen for this module acklowdges that we have way
too much content that is Linux specific, without actually defining it
as such.  This may be start of a proper "avocado.utils.linux" module,
with modules such "avocado.utils.lv_utils" being moved there, and
consequently being named "avocado.utils.linux.lv" for instance.

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>
Signed-off-by: Cleber Rosa <crosa@redhat.com>

---

This is a version based on the comments from #3091.