### PR TITLE
[LTS] [DONT_MERGE] Bump six version to 1.12.0 when running tests

### DIFF
--- a/requirements-selftests.txt
+++ b/requirements-selftests.txt
@@ -12,7 +12,7 @@ inspektor==0.5.2
 mock>=2.0.0; python_version <= '2.7'
 
 # six
-six==1.11.0
+six==1.12.0
 
 # funcsigs
 funcsigs>=0.4


### PR DESCRIPTION
There's a highly reproducible issue with six 1.11.0 trying to get
installed on top of 1.10.0, resulting in:

  Found existing installation: six 1.10.0
    Uninstalling six-1.10.0:
      Successfully uninstalled six-1.10.0
  Rolling back uninstall of six

Let's bump the six version and in hope that it copes with the upgrade.

Signed-off-by: Cleber Rosa <crosa@redhat.com>