### PR TITLE
[LTS] Bump setuptools version while testing [v2]

### DIFF
--- a/requirements-selftests.txt
+++ b/requirements-selftests.txt
@@ -1,4 +1,6 @@
 # Avocado test requirements
+setuptools==41.0.1
+
 # sphinx (doc build test)
 Sphinx==1.7.8
 


### PR DESCRIPTION
Onn Travis CI, setuptools (pkg_resources) is finding a six installation at:

```
   /opt/python/3.4.6/lib/python3.4/site-packages/pkg_resources/_vendor/six.py
```

But attempting to uninstall it from:

```
   /home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/six-1.10.0.dist-info
```

Producing the following error:

```
   FileNotFoundError: [Errno 2] No such file or directory: '/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/six-1.10.0.dist-info/METADATA'
```

Not only that, but a whole world of problems are solved with the
setuptools upgrade.  Basically, because of the older setuptools, some
dependencies to be installed from pip are fetched from .tar.gz, such
as this on Travis' Python 3.4.6:

```
   Installed /home/travis/build/avocado-framework/avocado/optional_plugins/runner_remote
   Processing dependencies for avocado-framework-plugin-runner-remote==69.0
   Searching for Fabric3
   Reading https://pypi.python.org/simple/Fabric3/
   Downloading https://files.pythonhosted.org/packages/24/ce/05901538f2112f48b78e1e0db0e9c8fff874ca3aa989faa4c8dfe6e6b796/Fabric3-1.14.post1.tar.gz#sha256=647e485ec83f30b587862f92374d6affc217f3d79819d1d7f512e42e7ae51e81
   Best match: Fabric3 1.14.post1
   Processing Fabric3-1.14.post1.tar.gz
   Writing /tmp/easy_install-20lv1wv6/Fabric3-1.14.post1/setup.cfg
   Running Fabric3-1.14.post1/setup.py -q bdist_egg --dist-dir /tmp/easy_install-20lv1wv6/Fabric3-1.14.post1/egg-dist-tmp-lg4vhxvh
   warning: no previously-included files matching '*' found under directory 'sites/docs/_build'
   warning: no previously-included files matching '*' found under directory 'sites/www/_build'
   warning: no previously-included files matching '*.pyc' found under directory 'tests'
   warning: no previously-included files matching '*.pyo' found under directory 'tests'
   zip_safe flag not set; analyzing archive contents...
   fabric.__pycache__.version.cpython-34: module references __file__
   creating /home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/Fabric3-1.14.post1-py3.4.egg
   Extracting Fabric3-1.14.post1-py3.4.egg to /home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages
   Adding Fabric3 1.14.post1 to easy-install.pth file
   Installing fab script to /home/travis/virtualenv/python3.4.6/bin
```

While on Python 3.5.6, with a newer setuptools:

```
   Installed /home/travis/build/avocado-framework/avocado/optional_plugins/runner_remote
   Processing dependencies for avocado-framework-plugin-runner-remote==69.0
   Searching for Fabric3
   Reading https://pypi.org/simple/Fabric3/
   Downloading https://files.pythonhosted.org/packages/85/14/0b4f34e1f9a351bbe0f1ddea8b12f8103e77e9b5dc7b935c25c2260fc2e5/Fabric3-1.14.post1-py3-none-any.whl#sha256=7c5a5f2eb3079eb6bd2a69931f1ca298844c730ce3fdc68111db16e8857a0408
   Best match: Fabric3 1.14.post1
   Processing Fabric3-1.14.post1-py3-none-any.whl
   Installing Fabric3-1.14.post1-py3-none-any.whl to /home/travis/virtualenv/python3.5.6/lib/python3.5/site-packages
   writing requirements to /home/travis/virtualenv/python3.5.6/lib/python3.5/site-packages/Fabric3-1.14.post1-py3.5.egg/EGG-INFO/requires.txt
   Adding Fabric3 1.14.post1 to easy-install.pth file
   Installing fab script to /home/travis/virtualenv/python3.5.6/bin
```

This is just an example, but the different installation, wheel versus
sources, ends up producing a "cryptography" installation (from source)
than when executed produces warnings such as:

```
   /home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/cryptography-2.7-py3.4-linux-x86_64.egg/cryptography/hazmat/bindings/openssl/binding.py:163
   CryptographyDeprecationWarning: OpenSSL version 1.0.1 is no longer supported by the OpenSSL project, please upgrade. A future version of cryptography will drop support for it.
```

And causes failures such as

```
   FAIL: test_test (selftests.functional.test_streams.StreamsTest)
   ----------------------------------------------------------------------
   Traceback (most recent call last):
     File "/home/travis/build/avocado-framework/avocado/selftests/functional/test_streams.py", line 95, in test_test
       self.assertEqual(b'', result.stderr)
   AssertionError: b'' != b'/home/travis/virtualenv/python3.4.6/lib/p[329 chars]ng\n'
```

Because the previous warning goes to STDERR, and the expects STDERR to be empty.

Signed-off-by: Cleber Rosa <crosa@redhat.com>

---

Changes from v1 (#3140):
 * Incorporated comments into commit message (largest ever?)
 * Removed comments from selftests-requirements.txt