### PR TITLE
Introduce Data Drainer (avocado.utils.datadrainer) [v2]

### DIFF
--- a/avocado/utils/datadrainer.py
+++ b/avocado/utils/datadrainer.py
@@ -23,6 +23,9 @@ of the user.
 """
 
 import abc
+import io
+import os
+import select
 import threading
 
 
@@ -104,3 +107,38 @@ class BaseDrainer:
         Waits on the thread completion
         """
         self._thread.join()
+
+
+class FDDrainer(BaseDrainer):
+    """
+    Drainer whose source is a file descriptor
+
+    This drainer uses select to efficiently wait for data to be available on
+    a file descriptor.  If the file descriptor is closed, the drainer responds
+    by shuting itself down.
+
+    This drainer doesn't provide a write() implementation, and is
+    consequently not a complete implementation users can pick and use.
+    """
+
+    name = 'avocado.utils.datadrainer.FDDrainer'
+
+    def data_available(self):
+        try:
+            return select.select([self._source], [], [], 1)[0]
+        except OSError as exc:
+            if exc.errno == 9:
+                return False
+
+    def read(self):
+        data = b''
+        try:
+            data = os.read(self._source, io.DEFAULT_BUFFER_SIZE)
+        except OSError as exc:
+            if exc.errno == 9:
+                self._internal_quit = True
+        return data
+
+    def write(self, data):
+        # necessary to avoid pylint W0223
+        raise NotImplementedError

--- a/avocado/utils/datadrainer.py
+++ b/avocado/utils/datadrainer.py
@@ -1,0 +1,106 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2019
+# Author: Cleber Rosa <crosa@redhat.com>
+
+"""
+data drainer
+
+This module provides utility classes for draining data and dispatching
+it to different destinations.  This is intended to be used
+concurrenly with other code, usually test code producing the output
+to be drained/processed.  A thread is started and maintained on behalf
+of the user.
+"""
+
+import abc
+import threading
+
+
+class BaseDrainer:
+    """
+    Base drainer, doesn't provide complete functionality to be useful.
+    """
+
+    name = 'avocado.utils.datadrainer.BaseDrainer'
+
+    def __init__(self, source, stop_check=None, name=None):
+        """
+        :param source: where to read data from, this is intentionally
+                       abstract
+        :param stop_check: callable that should determine if the
+                           drainer should quit.  If None is given, it
+                           will never stop.
+        :type stop_check: function
+        :param name: instance name of the drainer, used for describing
+                     the name of the thread maintained by this instance
+        :type name: str
+        """
+        self._source = source
+        if stop_check is None:
+            def stop_check():   # pylint: disable=E0102
+                return False
+        self._stop_check = stop_check
+        if name is not None:
+            self.name = name
+        # internal state flag, used to stop processing because of a
+        # condition that may have happened in between the loop cycles
+        self._internal_quit = False
+
+    def data_available(self):
+        """
+        Checks if source appears to have data to be drained
+        """
+        return False
+
+    @abc.abstractmethod
+    def read(self):
+        """
+        Abstract method supposed to read from the data source
+        """
+
+    @abc.abstractmethod
+    def write(self, data):
+        """
+        Abstract method supposed to write the read data to its destination
+        """
+
+    def _loop(self):
+        """
+        Basic implementation of the thread target
+
+        This loops until either an internal quit flag is set, or when
+        the stop_check function evaluates to True.
+        """
+        while True:
+            if self._internal_quit:
+                break
+            if self.data_available():
+                self.write(self.read())
+            if self._stop_check():
+                break
+
+    def start(self):
+        """
+        Starts a thread to do the data draining
+        """
+        self._thread = threading.Thread(target=self._loop,
+                                        name=self.name)
+
+        self._thread.daemon = True
+        self._thread.start()
+
+    def wait(self):
+        """
+        Waits on the thread completion
+        """
+        self._thread.join()

--- a/avocado/utils/datadrainer.py
+++ b/avocado/utils/datadrainer.py
@@ -142,3 +142,25 @@ class FDDrainer(BaseDrainer):
     def write(self, data):
         # necessary to avoid pylint W0223
         raise NotImplementedError
+
+
+class BufferFDDrainer(FDDrainer):
+    """
+    Drains data from a file descriptor and stores it in an internal buffer
+    """
+
+    name = 'avocado.utils.datadrainer.BufferFDDrainer'
+
+    def __init__(self, source, stop_check=None, name=None):
+        super(BufferFDDrainer, self).__init__(source, stop_check, name)
+        self._data = io.BytesIO()
+
+    def write(self, data):
+        self._data.write(data)
+
+    @property
+    def data(self):
+        """
+        Returns the buffer data, as bytes
+        """
+        return self._data.getvalue()

--- a/selftests/unit/test_utils_datadrainer.py
+++ b/selftests/unit/test_utils_datadrainer.py
@@ -74,3 +74,31 @@ class CustomSocket(unittest.TestCase):
     def tearDown(self):
         self.socket1.close()
         self.socket2.close()
+
+
+class SocketBuffer(datadrainer.BufferFDDrainer):
+
+    name = 'test_utils_datadrainer.SocketBuffer'
+
+    def __init__(self, source):
+        super(SocketBuffer, self).__init__(source)
+        self._stop_check = lambda: len(self.data) > 2
+
+
+class CustomSocketBuffer(unittest.TestCase):
+
+    def setUp(self):
+        self.socket1, self.socket2 = socket.socketpair(socket.AF_UNIX)
+
+    def test(self):
+        socket_drainer = SocketBuffer(self.socket2.fileno())
+        socket_drainer.start()
+        self.socket1.send(b'1')
+        self.socket1.send(b'2')
+        self.socket1.send(b'3')
+        socket_drainer.wait()
+        self.assertEqual(socket_drainer.data, b'123')
+
+    def tearDown(self):
+        self.socket1.close()
+        self.socket2.close()

--- a/selftests/unit/test_utils_datadrainer.py
+++ b/selftests/unit/test_utils_datadrainer.py
@@ -1,0 +1,39 @@
+import unittest
+
+from avocado.utils import datadrainer
+
+
+class Base(unittest.TestCase):
+
+    def test_instantiate(self):
+        datadrainer.BaseDrainer(None)
+
+    def test_start_wait(self):
+        base = datadrainer.BaseDrainer(None, lambda: True)
+        base.start()
+        base.wait()
+
+
+class Magic(datadrainer.BaseDrainer):
+
+    name = 'test_utils_datadrainer.Magic'
+    magic = 'MAGIC_magic_MAGIC'
+
+    def data_available(self):
+        return True
+
+    def read(self):
+        return self.magic
+
+    def write(self, data):
+        self.destination = data
+        self._internal_quit = True
+
+
+class Custom(unittest.TestCase):
+
+    def test(self):
+        magic = Magic(None)
+        magic.start()
+        magic.wait()
+        self.assertEqual(Magic.magic, magic.destination)

--- a/selftests/unit/test_utils_datadrainer.py
+++ b/selftests/unit/test_utils_datadrainer.py
@@ -1,3 +1,5 @@
+import io
+import socket
 import unittest
 
 from avocado.utils import datadrainer
@@ -37,3 +39,38 @@ class Custom(unittest.TestCase):
         magic.start()
         magic.wait()
         self.assertEqual(Magic.magic, magic.destination)
+
+
+class Socket(datadrainer.FDDrainer):
+
+    name = 'test_utils_datadrainer.Socket'
+
+    def __init__(self, source):
+        super(Socket, self).__init__(source)
+        self.data_buffer = io.BytesIO()
+        self._write_count = 0
+
+    def write(self, data):
+        self.data_buffer.write(data)
+        self._write_count += len(data)
+        if self._write_count > 2:
+            self._internal_quit = True
+
+
+class CustomSocket(unittest.TestCase):
+
+    def setUp(self):
+        self.socket1, self.socket2 = socket.socketpair(socket.AF_UNIX)
+
+    def test(self):
+        socket_drainer = Socket(self.socket2.fileno())
+        socket_drainer.start()
+        self.socket1.send(b'1')
+        self.socket1.send(b'2')
+        self.socket1.send(b'3')
+        socket_drainer.wait()
+        self.assertEqual(socket_drainer.data_buffer.getvalue(), b'123')
+
+    def tearDown(self):
+        self.socket1.close()
+        self.socket2.close()


### PR DESCRIPTION
This module is a loose generalization of the FDDrainer present in avocado.utils.process, but intended for a wider audience.

---

Changes from v1 (#3133):
 * Made base class an ABC (@apahim)
 * Strip only newlines on line logger (@apahim)