### PR TITLE
Drop --silent and --show-job-log

### DIFF
--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -365,18 +365,13 @@ def reconfigure(args):
     if not isinstance(enabled, list):
         enabled = ["app"]
         args.show = enabled
-    if getattr(args, "show_job_log", False):
-        del enabled[:]
-        enabled.append("test")
-    if getattr(args, "silent", False):
-        del enabled[:]
-    # "silent" is incompatible with "paginator"
-    elif getattr(args, "paginator", False) == "on" and TERM_SUPPORT.enabled:
-        STD_OUTPUT.enable_paginator()
     if "none" in enabled:
         del enabled[:]
     elif "all" in enabled:
         enabled.extend([_ for _ in BUILTIN_STREAMS if _ not in enabled])
+    elif getattr(args, "show_job_log", False):
+        del enabled[:]
+        enabled.append("test")
     if os.environ.get("AVOCADO_LOG_EARLY") and "early" not in enabled:
         enabled.append("early")
     if os.environ.get("AVOCADO_LOG_DEBUG") and "debug" not in enabled:
@@ -386,6 +381,8 @@ def reconfigure(args):
     if enabled:
         STD_OUTPUT.enable_outputs()
     else:
+        if getattr(args, "paginator", False) == "on" and TERM_SUPPORT.enabled:
+            STD_OUTPUT.enable_paginator()
         STD_OUTPUT.enable_stderr()
     STD_OUTPUT.print_records()
     if "app" in enabled:

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -369,9 +369,6 @@ def reconfigure(args):
         del enabled[:]
     elif "all" in enabled:
         enabled.extend([_ for _ in BUILTIN_STREAMS if _ not in enabled])
-    elif getattr(args, "show_job_log", False):
-        del enabled[:]
-        enabled.append("test")
     if os.environ.get("AVOCADO_LOG_EARLY") and "early" not in enabled:
         enabled.append("early")
     if os.environ.get("AVOCADO_LOG_DEBUG") and "debug" not in enabled:

--- a/avocado/core/parser.py
+++ b/avocado/core/parser.py
@@ -94,10 +94,6 @@ class Parser:
                                       "(DEBUG,INFO,...). Builtin streams "
                                       "are: %s. By default: 'app'"
                                       % streams)
-        self.application.add_argument('-s', '--silent',
-                                      default=argparse.SUPPRESS,
-                                      action="store_true",
-                                      help=BUILTIN_STREAM_SETS['none'])
 
     def start(self):
         """

--- a/avocado/etc/avocado/avocado.conf
+++ b/avocado/etc/avocado/avocado.conf
@@ -54,7 +54,7 @@ reject_unknown_hosts = False
 disable_known_hosts = False
 
 [job.output]
-# Base log level for --show-job-log.
+# Base loging level for --show
 # Allowed levels: debug, info, warning, error, critical
 loglevel = debug
 

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -130,15 +130,10 @@ class Run(CLICmd):
 
         parser.output = parser.add_argument_group('output and result format')
 
-        parser.output.add_argument('-s', '--silent', action="store_true",
-                                   default=argparse.SUPPRESS,
-                                   help='Silence stdout')
-
         parser.output.add_argument('--show-job-log', action='store_true',
                                    default=False, help="Display only the job "
                                    "log on stdout. Useful for test debugging "
-                                   "purposes. No output will be displayed if "
-                                   "you also specify --silent")
+                                   "purposes.")
 
         parser.output.add_argument("--store-logging-stream", nargs="*",
                                    default=[], metavar="STREAM[:LEVEL]",

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -130,11 +130,6 @@ class Run(CLICmd):
 
         parser.output = parser.add_argument_group('output and result format')
 
-        parser.output.add_argument('--show-job-log', action='store_true',
-                                   default=False, help="Display only the job "
-                                   "log on stdout. Useful for test debugging "
-                                   "purposes.")
-
         parser.output.add_argument("--store-logging-stream", nargs="*",
                                    default=[], metavar="STREAM[:LEVEL]",
                                    help="Store given logging STREAMs in "

--- a/docs/source/DebuggingWithGDB.rst
+++ b/docs/source/DebuggingWithGDB.rst
@@ -183,5 +183,5 @@ You can see that instead of running the executable using
 us to automate the interaction with the GDB in means of setting
 breakpoints, executing commands and querying for output.
 
-When you check the output (``--show-job-log``) you can see that despite
+When you check the output (``--show=test``) you can see that despite
 declaring the variable as 0, ff is injected and printed instead.

--- a/docs/source/GetStartedGuide.rst
+++ b/docs/source/GetStartedGuide.rst
@@ -493,10 +493,9 @@ Showing test output
 When developing new tests, you frequently want to look straight at the
 job log, without switching screens or having to "tail" the job log.
 
-In order to do that, you can use ``avocado --show test run ...`` or
-``avocado run --show-job-log ...`` options::
+In order to do that, you can use ``avocado --show=test run ...``::
 
-    $ avocado --show test run examples/tests/sleeptest.py
+    $ avocado --show=test run examples/tests/sleeptest.py
     ...
     Job ID: f9ea1742134e5352dec82335af584d1f151d4b85
 

--- a/docs/source/ResultFormats.rst
+++ b/docs/source/ResultFormats.rst
@@ -178,11 +178,11 @@ Provides the basic `TAP <http://testanything.org/>`__ (Test Anything Protocol) r
 Silent result
 ~~~~~~~~~~~~~
 
-This result disables all stdout logging (while keeping the error messages
-being printed to stderr). One can then use the return code to learn about
-the result::
+It's possible to silence all output to stdout (while keeping the error
+messages being printed to stderr). One can then use the return code to
+learn about the result::
 
-    $ avocado --silent run failtest.py
+    $ avocado --show=none run failtest.py
     $ echo $?
     1
 
@@ -191,7 +191,7 @@ Avocado and check its results::
 
     #!/bin/bash
     ...
-    $ avocado --silent run /path/to/my/test.py
+    $ avocado --show=none run /path/to/my/test.py
     if [ $? == 0 ]; then
        echo "great success!"
     elif

--- a/man/avocado.rst
+++ b/man/avocado.rst
@@ -93,8 +93,6 @@ Options for subcommand `run` (`avocado run --help`)::
                             How to iterate through test suite and variants
 
     output and result format:
-      --show-job-log        Display only the job log on stdout. Useful for test
-                            debugging purposes.
       --store-logging-stream [STREAM[:LEVEL] [STREAM[:LEVEL] ...]]
                             Store given logging STREAMs in
                             $JOB_RESULTS_DIR/$STREAM.$LEVEL.
@@ -483,10 +481,10 @@ DEBUGGING TESTS
 
 When you are developing new tests, frequently you want to look at the
 straight output of the job log in the stdout, without having to tail the
-job log. In order to do that, you can use --show-job-log to the avocado
+job log. In order to do that, you can use --show=test to the avocado
 test runner::
 
-    $ scripts/avocado run examples/tests/sleeptest.py --show-job-log
+    $ scripts/avocado --show=test run examples/tests/sleeptest.py
     ...
     PARAMS (key=timeout, path=*, default=None) => None
     START 1-sleeptest.py:SleepTest.test
@@ -508,7 +506,7 @@ Edit your `~/.config/avocado/avocado.conf` file and add::
 
 Running the same example with this option will give you::
 
-    $ scripts/avocado run sleeptest --show-job-log
+    $ scripts/avocado --show=test run sleeptest.py
     ...
     START 1-sleeptest.py:SleepTest.test
     PASS 1-sleeptest.py:SleepTest.test
@@ -526,9 +524,7 @@ SILENCING RUNNER STDOUT
 =======================
 
 You may specify `--show=none`, that means avocado will turn off all
-runner stdout. Even if you specify things like `--show-job-log` in the
-CLI, `--show=none` will have precedence and you will not get
-application stdout.  Note that `--show=none` does not affect on disk
+runner stdout.  Note that `--show=none` does not affect on disk
 job logs, those continue to be generated normally.
 
 SILENCING SYSINFO REPORT

--- a/man/avocado.rst
+++ b/man/avocado.rst
@@ -42,7 +42,6 @@ on them being loaded (`avocado --help`)::
                           fabric/paramiko debug; "all": all builtin streams;
                           "none": disables regular output (leaving only errors
                           enabled). By default: 'app'
-    -s, --silent          disables regular output (leaving only errors enabled)
 
 Real use of avocado depends on running avocado subcommands. This a
 typical list of avocado subcommands::
@@ -94,10 +93,8 @@ Options for subcommand `run` (`avocado run --help`)::
                             How to iterate through test suite and variants
 
     output and result format:
-      -s, --silent          Silence stdout
       --show-job-log        Display only the job log on stdout. Useful for test
-                            debugging purposes. No output will be displayed if you
-                            also specify --silent
+                            debugging purposes.
       --store-logging-stream [STREAM[:LEVEL] [STREAM[:LEVEL] ...]]
                             Store given logging STREAMs in
                             $JOB_RESULTS_DIR/$STREAM.$LEVEL.
@@ -528,11 +525,11 @@ stdout, making this a useful feature for test development/debugging.
 SILENCING RUNNER STDOUT
 =======================
 
-You may specify `--silent`, that means avocado will turn off all runner
-stdout. Even if you specify things like `--show-job-log` in the CLI,
-`--silent` will have precedence and you will not get application stdout.
-Note that `--silent` does not affect on disk job logs, those continue to
-be generated normally.
+You may specify `--show=none`, that means avocado will turn off all
+runner stdout. Even if you specify things like `--show-job-log` in the
+CLI, `--show=none` will have precedence and you will not get
+application stdout.  Note that `--show=none` does not affect on disk
+job logs, those continue to be generated normally.
 
 SILENCING SYSINFO REPORT
 ========================

--- a/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
+++ b/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
@@ -521,7 +521,7 @@ class RemoteTestRunner(TestRunner):
         fabric_logger.addHandler(file_handler)
         paramiko_logger.addHandler(file_handler)
         remote_logger.addHandler(file_handler)
-        if self.job.args.show_job_log:
+        if "test" in getattr(self.job.args, "show", []):
             output.add_log_handler(paramiko_logger.name)
         logger_list = [output.LOG_JOB]
         sys.stdout = output.LoggingFile(loggers=logger_list)

--- a/optional_plugins/runner_remote/tests/test_remote.py
+++ b/optional_plugins/runner_remote/tests/test_remote.py
@@ -60,7 +60,6 @@ class RemoteTestRunnerTest(unittest.TestCase):
                                       remote_password='password',
                                       remote_key_file=None,
                                       remote_timeout=60,
-                                      show_job_log=False,
                                       mux_yaml=['~/avocado/tests/foo.yaml',
                                                 '~/avocado/tests/bar/baz.yaml'],
                                       filter_by_tags=["-foo", "-bar"],

--- a/optional_plugins/varianter_yaml_to_mux/tests/test_multiplex.py
+++ b/optional_plugins/varianter_yaml_to_mux/tests/test_multiplex.py
@@ -155,10 +155,10 @@ class MultiplexTests(unittest.TestCase):
                             ('/run/medium', 'ASDFASDF'),
                             ('/run/long', 'This is very long\nmultiline\ntext.')):
             variant, msg = variant_msg
-            cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
+            cmd_line = ('%s --show=test run --job-results-dir %s --sysinfo=off '
                         'examples/tests/env_variables.sh '
                         '-m examples/tests/env_variables.sh.data/env_variables.yaml '
-                        '--mux-filter-only %s --show-job-log'
+                        '--mux-filter-only %s'
                         % (AVOCADO, self.tmpdir, variant))
             expected_rc = exit_codes.AVOCADO_ALL_OK
             result = self.run_and_check(cmd_line, expected_rc)

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -637,9 +637,9 @@ class RunnerHumanOutputTest(unittest.TestCase):
     @unittest.skipIf(not GNU_ECHO_BINARY,
                      'GNU style echo binary not available')
     def test_ugly_echo_cmd(self):
-        cmd_line = ('%s run --external-runner "%s -ne" '
+        cmd_line = ('%s --show=test run --external-runner "%s -ne" '
                     '"foo\\\\\\n\\\'\\\\\\"\\\\\\nbar/baz" --job-results-dir %s'
-                    ' --sysinfo=off  --show-job-log' %
+                    ' --sysinfo=off' %
                     (AVOCADO, GNU_ECHO_BINARY, self.tmpdir))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -762,8 +762,8 @@ class RunnerSimpleTest(unittest.TestCase):
         # simplewarning.sh calls "avocado exec-path" which hasn't
         # access to an installed location for the libexec scripts
         os.environ['PATH'] += ":" + os.path.join(BASEDIR, 'libexec')
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
-                    'examples/tests/simplewarning.sh --show-job-log'
+        cmd_line = ('%s --show=test run --job-results-dir %s --sysinfo=off '
+                    'examples/tests/simplewarning.sh'
                     % (AVOCADO, self.tmpdir))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -419,7 +419,7 @@ class RunnerOperationTest(unittest.TestCase):
         self.assertIn(excerpt, result.stdout)
 
     def test_silent_output(self):
-        cmd_line = ('%s --silent run --sysinfo=off --job-results-dir %s '
+        cmd_line = ('%s --show=none run --sysinfo=off --job-results-dir %s '
                     'passtest.py' % (AVOCADO, self.tmpdir))
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -347,8 +347,8 @@ class OutputPluginTest(unittest.TestCase):
     def test_output_compatible_setup_nooutput(self):
         tmpfile = tempfile.mktemp(dir=self.tmpdir)
         tmpfile2 = tempfile.mktemp(dir=self.tmpdir)
-        # Verify --silent can be supplied as app argument
-        cmd_line = ('%s --silent run --job-results-dir %s '
+        # Verify --show=none can be supplied as app argument
+        cmd_line = ('%s --show=none run --job-results-dir %s '
                     '--sysinfo=off --xunit %s --json %s --tap-include-logs '
                     'passtest.py' % (AVOCADO, self.tmpdir, tmpfile, tmpfile2))
         result = process.run(cmd_line, ignore_status=True)
@@ -401,8 +401,8 @@ class OutputPluginTest(unittest.TestCase):
         self.assertEqual(len(job_id), 40)
 
     def test_silent_trumps_show_job_log(self):
-        # Also verify --silent can be supplied as run option
-        cmd_line = ('%s run --silent --job-results-dir %s '
+        # Also verify --show=none can be supplied as run option
+        cmd_line = ('%s --show=none run --job-results-dir %s '
                     '--sysinfo=off passtest.py --show-job-log'
                     % (AVOCADO, self.tmpdir))
         result = process.run(cmd_line, ignore_status=True)

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -385,9 +385,9 @@ class OutputPluginTest(unittest.TestCase):
                         % output)
         self.check_output_files(debug_log)
 
-    def test_show_job_log(self):
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
-                    'passtest.py --show-job-log' % (AVOCADO, self.tmpdir))
+    def test_show_test(self):
+        cmd_line = ('%s --show=test run --job-results-dir %s --sysinfo=off '
+                    'passtest.py' % (AVOCADO, self.tmpdir))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
@@ -400,10 +400,10 @@ class OutputPluginTest(unittest.TestCase):
         job_id = job_id_list[0]
         self.assertEqual(len(job_id), 40)
 
-    def test_silent_trumps_show_job_log(self):
+    def test_silent_trumps_test(self):
         # Also verify --show=none can be supplied as run option
-        cmd_line = ('%s --show=none run --job-results-dir %s '
-                    '--sysinfo=off passtest.py --show-job-log'
+        cmd_line = ('%s --show=test --show=none run --job-results-dir %s '
+                    '--sysinfo=off passtest.py'
                     % (AVOCADO, self.tmpdir))
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout + result.stderr

--- a/selftests/functional/test_streams.py
+++ b/selftests/functional/test_streams.py
@@ -70,30 +70,26 @@ class StreamsTest(unittest.TestCase):
     def test_test(self):
         """
         Checks that the test stream (early in this case) goes to stdout
-
-        Also checks the symmetry between `--show test` and `--show-job-log`
         """
-        for cmd in (('%s --show test run --sysinfo=off --job-results-dir %s '
-                     'passtest.py' % (AVOCADO, self.tmpdir)),
-                    ('%s run --show-job-log --sysinfo=off --job-results-dir %s'
-                     ' passtest.py' % (AVOCADO, self.tmpdir))):
-            result = process.run(cmd)
-            self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
-            self.assertNotIn(b"stevedore.extension: found extension EntryPoint.parse",
-                             result.stdout)
-            self.assertNotIn(b"stevedore.extension: found extension EntryPoint.parse",
-                             result.stderr)
-            # If using the Python interpreter, Avocado won't know about it
-            if AVOCADO.startswith(sys.executable):
-                cmd_in_log = cmd[len(sys.executable)+1:]
-            else:
-                cmd_in_log = cmd
-            self.assertIn("Command line: %s" % cmd_in_log,
-                          result.stdout_text)
-            self.assertIn(b"\nSTART 1-passtest.py:PassTest.test",
-                          result.stdout)
-            self.assertIn(b"PASS 1-passtest.py:PassTest.test", result.stdout)
-            self.assertEqual(b'', result.stderr)
+        cmd = ('%s --show=test run --sysinfo=off --job-results-dir %s '
+               'passtest.py' % (AVOCADO, self.tmpdir))
+        result = process.run(cmd)
+        self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
+        self.assertNotIn(b"stevedore.extension: found extension EntryPoint.parse",
+                         result.stdout)
+        self.assertNotIn(b"stevedore.extension: found extension EntryPoint.parse",
+                         result.stderr)
+        # If using the Python interpreter, Avocado won't know about it
+        if AVOCADO.startswith(sys.executable):
+            cmd_in_log = cmd[len(sys.executable)+1:]
+        else:
+            cmd_in_log = cmd
+        self.assertIn("Command line: %s" % cmd_in_log,
+                      result.stdout_text)
+        self.assertIn(b"\nSTART 1-passtest.py:PassTest.test",
+                      result.stdout)
+        self.assertIn(b"PASS 1-passtest.py:PassTest.test", result.stdout)
+        self.assertEqual(b'', result.stderr)
 
     def test_none_success(self):
         """

--- a/selftests/functional/test_streams.py
+++ b/selftests/functional/test_streams.py
@@ -98,30 +98,23 @@ class StreamsTest(unittest.TestCase):
     def test_none_success(self):
         """
         Checks that only errors are output, and that they go to stderr
-
-        Also checks the symmetry between `--show none` and `--silent`
         """
-        for cmd in (('%s --show none run --sysinfo=off --job-results-dir %s '
-                     'passtest.py' % (AVOCADO, self.tmpdir)),
-                    ('%s --silent run --sysinfo=off --job-results-dir %s '
-                     'passtest.py' % (AVOCADO, self.tmpdir))):
-            result = process.run(cmd)
-            self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
-            self.assertEqual(b'', result.stdout)
-            self.assertEqual(b'', result.stderr)
+        cmd = ('%s --show none run --sysinfo=off --job-results-dir %s '
+               'passtest.py' % (AVOCADO, self.tmpdir))
+        result = process.run(cmd)
+        self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
+        self.assertEqual(b'', result.stdout)
+        self.assertEqual(b'', result.stderr)
 
     def test_none_error(self):
         """
         Checks that only errors are output, and that they go to stderr
-
-        Also checks the symmetry between `--show none` and `--silent`
         """
-        for cmd in ('%s --show none unknown-whacky-command' % AVOCADO,
-                    '%s --silent unknown-whacky-command' % AVOCADO):
-            result = process.run(cmd, ignore_status=True)
-            self.assertEqual(result.exit_status, exit_codes.AVOCADO_FAIL)
-            self.assertEqual(b'', result.stdout)
-            self.assertNotEqual(b'', result.stderr)
+        cmd = '%s --show=none unknown-whacky-command' % AVOCADO
+        result = process.run(cmd, ignore_status=True)
+        self.assertEqual(result.exit_status, exit_codes.AVOCADO_FAIL)
+        self.assertEqual(b'', result.stdout)
+        self.assertNotEqual(b'', result.stderr)
 
     def test_custom_stream_and_level(self):
         """


### PR DESCRIPTION
Those are older forms of `--show=none` and `--show=test`, so let's remove some clutter and keep only one of each.