### PR TITLE
Runner: make timeouts configurable

### DIFF
--- a/avocado/core/defaults.py
+++ b/avocado/core/defaults.py
@@ -22,3 +22,7 @@ ENCODING = 'utf-8'
 #: The amount of time to give to the test process after it it has been
 #: interrupted (such as with CTRL+C)
 TIMEOUT_AFTER_INTERRUPTED = 60
+
+#: The amount of to wait for a test status after the process
+#: has been noticed to be dead
+TIMEOUT_PROCESS_DIED = 10

--- a/avocado/core/defaults.py
+++ b/avocado/core/defaults.py
@@ -18,3 +18,7 @@ The Avocado core defaults
 
 #: The encoding used by default on all data input
 ENCODING = 'utf-8'
+
+#: The amount of time to give to the test process after it it has been
+#: interrupted (such as with CTRL+C)
+TIMEOUT_AFTER_INTERRUPTED = 60

--- a/avocado/core/defaults.py
+++ b/avocado/core/defaults.py
@@ -26,3 +26,7 @@ TIMEOUT_AFTER_INTERRUPTED = 60
 #: The amount of to wait for a test status after the process
 #: has been noticed to be dead
 TIMEOUT_PROCESS_DIED = 10
+
+#: The amount of time to wait after a test has reported status
+#: but the test process has not finished
+TIMEOUT_PROCESS_ALIVE = 60

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -23,14 +23,16 @@ import signal
 import sys
 import time
 
-from . import test
-from . import tree
+from . import defaults
 from . import exceptions
 from . import output
 from . import status
+from . import test
+from . import tree
 from . import varianter
 from .loader import loader
 from .status import mapping
+from .settings import settings
 from ..utils import wait
 from ..utils import runtime
 from ..utils import process
@@ -39,8 +41,6 @@ from ..utils import stacktrace
 from .output import LOG_UI as APP_LOG
 from .output import LOG_JOB as TEST_LOG
 
-#: when test was interrupted (ctrl+c/timeout)
-TIMEOUT_TEST_INTERRUPTED = 60
 #: when the process died but the status was not yet delivered
 TIMEOUT_PROCESS_DIED = 10
 #: when test reported status but the process did not finish
@@ -466,7 +466,11 @@ class TestRunner:
 
         # Get/update the test status (decrease timeout on abort)
         if abort_reason:
-            finish_deadline = TIMEOUT_TEST_INTERRUPTED + time.time()
+            finish_deadline = time.time() + settings.get_value(
+                'runner.timeout',
+                'after_interrupted',
+                key_type=int,
+                default=defaults.TIMEOUT_AFTER_INTERRUPTED)
         else:
             finish_deadline = deadline
         test_state = test_status.finish(proc, time_started, step,

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -216,14 +216,12 @@ class TestStatus:
                notifications)
         """
         # Wait for either process termination or test status
-        wait.wait_for(lambda: not proc.is_alive() or self.status, 1, 0,
-                      step)
+        wait.wait_for(lambda: not proc.is_alive() or self.status, 1, 0, step)
         if self.status:     # status exists, wait for process to finish
             deadline = min(deadline, time.time() + TIMEOUT_PROCESS_ALIVE)
             while time.time() < deadline:
                 result_dispatcher.map_method('test_progress', False)
-                if wait.wait_for(lambda: not proc.is_alive(), 1, 0,
-                                 step):
+                if wait.wait_for(lambda: not proc.is_alive(), 1, 0, step):
                     return self._add_status_failures(self.status)
             err = "Test reported status but did not finish"
         else:   # proc finished, wait for late status delivery

--- a/avocado/etc/avocado/avocado.conf
+++ b/avocado/etc/avocado/avocado.conf
@@ -40,6 +40,11 @@ colored = True
 # Use utf8 encoding (True, False, None=autodetect)
 utf8 =
 
+[runner.timeout]
+# The amount of time to give to the test process after it it has been
+# interrupted (such as with CTRL+C)
+after_interrupted = 60
+
 [remoter.behavior]
 # __Insecure__, reject unknown SSH host keys.
 # 'False' will leave you wide open to man-in-the-middle attacks!

--- a/avocado/etc/avocado/avocado.conf
+++ b/avocado/etc/avocado/avocado.conf
@@ -44,6 +44,9 @@ utf8 =
 # The amount of time to give to the test process after it it has been
 # interrupted (such as with CTRL+C)
 after_interrupted = 60
+# The amount of to wait for a test status after the process has been
+# noticed to be dead
+process_died = 10
 
 [remoter.behavior]
 # __Insecure__, reject unknown SSH host keys.

--- a/avocado/etc/avocado/avocado.conf
+++ b/avocado/etc/avocado/avocado.conf
@@ -47,6 +47,9 @@ after_interrupted = 60
 # The amount of to wait for a test status after the process has been
 # noticed to be dead
 process_died = 10
+# The amount of time to wait after a test has reported status but the
+# test process has not finished
+process_alive = 60
 
 [remoter.behavior]
 # __Insecure__, reject unknown SSH host keys.


### PR DESCRIPTION
This makes the various test runner timeout variables into better defined defaults (for internal consumption) and allow them to be configured by the user.

This is a foundation step for issue https://github.com/avocado-framework/avocado/issues/2908 .