### PR TITLE
Test Setup: add support for tries and specific timeout [v2]

### DIFF
--- a/avocado/core/defaults.py
+++ b/avocado/core/defaults.py
@@ -22,3 +22,7 @@ ENCODING = 'utf-8'
 #: The amount of time to give to the test process after it it has been
 #: interrupted (such as with CTRL+C)
 TIMEOUT_AFTER_INTERRUPTED = 60
+
+#: The amount of to wait for a test status after the process
+#: has been noticed to be dead
+TIMEOUT_PROCESS_DIED = 10

--- a/avocado/core/defaults.py
+++ b/avocado/core/defaults.py
@@ -18,3 +18,7 @@ The Avocado core defaults
 
 #: The encoding used by default on all data input
 ENCODING = 'utf-8'
+
+#: The amount of time to give to the test process after it it has been
+#: interrupted (such as with CTRL+C)
+TIMEOUT_AFTER_INTERRUPTED = 60

--- a/avocado/core/defaults.py
+++ b/avocado/core/defaults.py
@@ -26,3 +26,7 @@ TIMEOUT_AFTER_INTERRUPTED = 60
 #: The amount of to wait for a test status after the process
 #: has been noticed to be dead
 TIMEOUT_PROCESS_DIED = 10
+
+#: The amount of time to wait after a test has reported status
+#: but the test process has not finished
+TIMEOUT_PROCESS_ALIVE = 60

--- a/avocado/core/defaults.py
+++ b/avocado/core/defaults.py
@@ -30,3 +30,6 @@ TIMEOUT_PROCESS_DIED = 10
 #: The amount of time to wait after a test has reported status
 #: but the test process has not finished
 TIMEOUT_PROCESS_ALIVE = 60
+
+#: The number of attempts to try to run an INSTRUMENTED test setUp()
+INSTRUMENTED_SETUP_ATTEMPTS = 3

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -27,6 +27,7 @@ import sys
 from enum import Enum
 
 from . import data_dir
+from . import defaults
 from . import output
 from . import test
 from . import safeloader
@@ -386,6 +387,10 @@ class TestLoaderProxy:
         else:
             test_path = None
         if isinstance(test_class, str):
+            # instrumented tests (only) accept the setup_attempts parameter
+            setup_attempts = settings.get_value("runner", "instrumented", int,
+                                                defaults.INSTRUMENTED_SETUP_ATTEMPTS)
+            test_parameters['setup_attempts'] = setup_attempts
             module_name = os.path.basename(test_path).split('.')[0]
             test_module_dir = os.path.abspath(os.path.dirname(test_path))
             # Tests with local dir imports need this

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -23,14 +23,16 @@ import signal
 import sys
 import time
 
-from . import test
-from . import tree
+from . import defaults
 from . import exceptions
 from . import output
 from . import status
+from . import test
+from . import tree
 from . import varianter
 from .loader import loader
 from .status import mapping
+from .settings import settings
 from ..utils import wait
 from ..utils import runtime
 from ..utils import process
@@ -39,8 +41,6 @@ from ..utils import stacktrace
 from .output import LOG_UI as APP_LOG
 from .output import LOG_JOB as TEST_LOG
 
-#: when test was interrupted (ctrl+c/timeout)
-TIMEOUT_TEST_INTERRUPTED = 60
 #: when the process died but the status was not yet delivered
 TIMEOUT_PROCESS_DIED = 10
 #: when test reported status but the process did not finish
@@ -466,7 +466,11 @@ class TestRunner:
 
         # Get/update the test status (decrease timeout on abort)
         if abort_reason:
-            finish_deadline = TIMEOUT_TEST_INTERRUPTED + time.time()
+            finish_deadline = time.time() + settings.get_value(
+                'runner.timeout',
+                'after_interrupted',
+                key_type=int,
+                default=defaults.TIMEOUT_AFTER_INTERRUPTED)
         else:
             finish_deadline = deadline
         test_state = test_status.finish(proc, time_started, step,

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -216,14 +216,12 @@ class TestStatus:
                notifications)
         """
         # Wait for either process termination or test status
-        wait.wait_for(lambda: not proc.is_alive() or self.status, 1, 0,
-                      step)
+        wait.wait_for(lambda: not proc.is_alive() or self.status, 1, 0, step)
         if self.status:     # status exists, wait for process to finish
             deadline = min(deadline, time.time() + TIMEOUT_PROCESS_ALIVE)
             while time.time() < deadline:
                 result_dispatcher.map_method('test_progress', False)
-                if wait.wait_for(lambda: not proc.is_alive(), 1, 0,
-                                 step):
+                if wait.wait_for(lambda: not proc.is_alive(), 1, 0, step):
                     return self._add_status_failures(self.status)
             err = "Test reported status but did not finish"
         else:   # proc finished, wait for late status delivery

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -61,7 +61,8 @@ TEST_STATE_ATTRIBUTES = ('name', 'logdir', 'logfile',
                          'status', 'running', 'paused',
                          'time_start', 'time_elapsed', 'time_end',
                          'fail_reason', 'fail_class', 'traceback',
-                         'timeout', 'whiteboard', 'phase', 'setup_attempt')
+                         'timeout', 'setup_timeout', 'whiteboard',
+                         'phase', 'setup_attempt')
 
 
 class RawFileHandler(logging.FileHandler):
@@ -317,6 +318,8 @@ class Test(unittest.TestCase, TestData):
     time_elapsed = -1
     #: Test timeout (the timeout from params takes precedence)
     timeout = None
+    #: Setup timeout
+    setup_timeout = None
 
     def __init__(self, methodName='test', name=None, params=None,
                  base_logdir=None, job=None, runner_queue=None, tags=None,
@@ -392,6 +395,9 @@ class Test(unittest.TestCase, TestData):
                                                  self.__log.name)
         default_timeout = getattr(self, "timeout", None)
         self.timeout = self.params.get("timeout", default=default_timeout)
+        default_setup_timeout = getattr(self, "setup_timeout", None)
+        self.setup_timeout = self.params.get("setup_timeout",
+                                             default=default_setup_timeout)
 
         self.__status = None
         self.__fail_reason = None

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -61,7 +61,7 @@ TEST_STATE_ATTRIBUTES = ('name', 'logdir', 'logfile',
                          'status', 'running', 'paused',
                          'time_start', 'time_elapsed', 'time_end',
                          'fail_reason', 'fail_class', 'traceback',
-                         'timeout', 'whiteboard')
+                         'timeout', 'whiteboard', 'phase')
 
 
 class RawFileHandler(logging.FileHandler):
@@ -336,6 +336,8 @@ class Test(unittest.TestCase, TestData):
                             :func:`avocado.data_dir.create_job_logs_dir`.
         :param job: The job that this test is part of.
         """
+        self.__phase = 'INIT'
+
         def record_and_warn(*args, **kwargs):
             """ Record call to this function and log warning """
             if not self.__log_warn_used:
@@ -588,6 +590,15 @@ class Test(unittest.TestCase, TestData):
     def traceback(self):
         return self.__traceback
 
+    @property
+    def phase(self):
+        """
+        The current phase of the test execution
+
+        Possible (string) values are: INIT, SETUP, TEST and TEARDOWN
+        """
+        return self.__phase
+
     def __str__(self):
         return str(self.name)
 
@@ -818,6 +829,7 @@ class Test(unittest.TestCase, TestData):
         skip_test = getattr(testMethod, '__skip_test_decorator__', False)
         try:
             if skip_test is False:
+                self.__phase = 'SETUP'
                 self.setUp()
         except exceptions.TestSkipError as details:
             skip_test = True
@@ -832,6 +844,7 @@ class Test(unittest.TestCase, TestData):
             raise exceptions.TestSetupFail(details)
         else:
             try:
+                self.__phase = 'TEST'
                 testMethod()
             except exceptions.TestCancel as details:
                 stacktrace.log_exc_info(sys.exc_info(), logger=LOG_JOB)
@@ -849,6 +862,7 @@ class Test(unittest.TestCase, TestData):
         finally:
             try:
                 if skip_test is False:
+                    self.__phase = 'TEARDOWN'
                     self.tearDown()
             except exceptions.TestSkipError as details:
                 stacktrace.log_exc_info(sys.exc_info(), logger=LOG_JOB)
@@ -992,6 +1006,7 @@ class Test(unittest.TestCase, TestData):
             for e_line in tb_info:
                 self.log.error(e_line)
         finally:
+            self.__phase = 'FINISHED'
             self._tag_end()
             self._report()
             self.log.info("")

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -830,6 +830,7 @@ class Test(unittest.TestCase, TestData):
         try:
             if skip_test is False:
                 self.__phase = 'SETUP'
+                self.report_state()
                 self.setUp()
         except exceptions.TestSkipError as details:
             skip_test = True
@@ -845,6 +846,7 @@ class Test(unittest.TestCase, TestData):
         else:
             try:
                 self.__phase = 'TEST'
+                self.report_state()
                 testMethod()
             except exceptions.TestCancel as details:
                 stacktrace.log_exc_info(sys.exc_info(), logger=LOG_JOB)
@@ -863,6 +865,7 @@ class Test(unittest.TestCase, TestData):
             try:
                 if skip_test is False:
                     self.__phase = 'TEARDOWN'
+                    self.report_state()
                     self.tearDown()
             except exceptions.TestSkipError as details:
                 stacktrace.log_exc_info(sys.exc_info(), logger=LOG_JOB)

--- a/avocado/etc/avocado/avocado.conf
+++ b/avocado/etc/avocado/avocado.conf
@@ -40,6 +40,11 @@ colored = True
 # Use utf8 encoding (True, False, None=autodetect)
 utf8 =
 
+[runner.timeout]
+# The amount of time to give to the test process after it it has been
+# interrupted (such as with CTRL+C)
+after_interrupted = 60
+
 [remoter.behavior]
 # __Insecure__, reject unknown SSH host keys.
 # 'False' will leave you wide open to man-in-the-middle attacks!

--- a/avocado/etc/avocado/avocado.conf
+++ b/avocado/etc/avocado/avocado.conf
@@ -51,6 +51,10 @@ process_died = 10
 # test process has not finished
 process_alive = 60
 
+[runner.instrumented]
+# the number of attempts to run setup before giving up
+setup_attempts = 3
+
 [remoter.behavior]
 # __Insecure__, reject unknown SSH host keys.
 # 'False' will leave you wide open to man-in-the-middle attacks!

--- a/avocado/etc/avocado/avocado.conf
+++ b/avocado/etc/avocado/avocado.conf
@@ -44,6 +44,9 @@ utf8 =
 # The amount of time to give to the test process after it it has been
 # interrupted (such as with CTRL+C)
 after_interrupted = 60
+# The amount of to wait for a test status after the process has been
+# noticed to be dead
+process_died = 10
 
 [remoter.behavior]
 # __Insecure__, reject unknown SSH host keys.

--- a/avocado/etc/avocado/avocado.conf
+++ b/avocado/etc/avocado/avocado.conf
@@ -47,6 +47,9 @@ after_interrupted = 60
 # The amount of to wait for a test status after the process has been
 # noticed to be dead
 process_died = 10
+# The amount of time to wait after a test has reported status but the
+# test process has not finished
+process_alive = 60
 
 [remoter.behavior]
 # __Insecure__, reject unknown SSH host keys.

--- a/examples/tests/long_setup.py
+++ b/examples/tests/long_setup.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+
+from time import sleep
+
+from avocado import main
+from avocado import Test
+
+
+class LongSetup(Test):
+
+    """
+    Example test for a setUp() method that will fail for a number of times
+
+    The "timeout" will be applicable won't be applicable to the
+    setUp() method, which has its own timeout.
+
+    The setup timeout is set to twice the expected amount of time it'll take,
+    while it'll take more than twice the test timeout set.
+    """
+
+    timeout = 0.2
+    setup_timeout = 1
+
+    def setUp(self):
+        sleep(0.5)
+
+    def test(self):
+        """
+        A test simply doesn't have to fail in order to pass
+        """
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/tests/phases.py
+++ b/examples/tests/phases.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+
+from avocado import main
+from avocado import Test
+
+
+class Phases(Test):
+
+    """
+    Example test for checking the reported test phases
+    """
+
+    def setUp(self):
+        self.assertEqual(self.phase, 'SETUP')
+
+    def test(self):
+        self.assertEqual(self.phase, 'TEST')
+
+    def tearDown(self):
+        self.assertEqual(self.phase, 'TEARDOWN')
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/tests/setup_retry.py
+++ b/examples/tests/setup_retry.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+from avocado import main
+from avocado import Test
+
+
+class SetupRetry(Test):
+
+    """
+    Example test for a setUp() method that will fail for a number of times
+
+    :avocado: tags=fast
+    """
+
+    count = 0
+
+    def setUp(self):
+        self.count += 1
+        setup_failures = int(self.params.get("setup_failures", default=2))
+        if self.count <= setup_failures:
+            raise RuntimeError
+
+    def test(self):
+        """
+        A test simply doesn't have to fail in order to pass
+        """
+
+
+if __name__ == "__main__":
+    main()

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -183,6 +183,14 @@ class RunnerOperationTest(unittest.TestCase):
         self.assertIn('    data     ' + mapping['data_dir'], result.stdout_text)
         self.assertIn('    logs     ' + mapping['logs_dir'], result.stdout_text)
 
+    def test_runner_phases(self):
+        cmd_line = ('%s run --sysinfo=off --job-results-dir %s '
+                    'phases.py' % (AVOCADO, self.tmpdir))
+        result = process.run(cmd_line)
+        expected_rc = exit_codes.AVOCADO_ALL_OK
+        self.assertEqual(result.exit_status, expected_rc,
+                         "Avocado did not return rc %d:\n%s" % (expected_rc, result))
+
     def test_runner_all_ok(self):
         cmd_line = ('%s run --sysinfo=off --job-results-dir %s '
                     'passtest.py passtest.py' % (AVOCADO, self.tmpdir))

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -312,6 +312,13 @@ class RunnerOperationTest(unittest.TestCase):
                             "which is likely because the hanged test was not "
                             "interrupted. Results:\n%s" % res)
 
+    def test_setup_timeout(self):
+        """ Check that avocado handles hanged tests properly """
+        cmd = ("%s run --sysinfo=off --job-results-dir %s -- "
+               "examples/tests/long_setup.py " % (AVOCADO, self.tmpdir))
+        res = process.run(cmd, ignore_status=True)
+        self.assertEqual(res.exit_status, exit_codes.AVOCADO_ALL_OK)
+
     def test_no_status_reported(self):
         with script.TemporaryScript("die_without_reporting_status.py",
                                     DIE_WITHOUT_REPORTING_STATUS,

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -306,7 +306,9 @@ class RunnerOperationTest(unittest.TestCase):
             self.assertEqual(results["tests"][0]["status"], "ERROR",
                              "%s != %s\n%s" % (results["tests"][0]["status"],
                                                "ERROR", res))
-            self.assertIn("Test died without reporting the status",
+            self.assertIn("Test reports unsupported test status",
+                          results["tests"][0]["fail_reason"])
+            self.assertIn("status: None",
                           results["tests"][0]["fail_reason"])
 
     def test_runner_tests_fail(self):

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -191,6 +191,24 @@ class RunnerOperationTest(unittest.TestCase):
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %d:\n%s" % (expected_rc, result))
 
+    def test_runner_setup_attempts_ok(self):
+        cmd_line = ('%s --show=test run --sysinfo=off --job-results-dir %s '
+                    'setup_retry.py' % (AVOCADO, self.tmpdir))
+        result = process.run(cmd_line)
+        expected_rc = exit_codes.AVOCADO_ALL_OK
+        self.assertEqual(result.exit_status, expected_rc,
+                         "Avocado did not return rc %d:\n%s" % (expected_rc, result))
+        self.assertIn(b"(attempt 2/3 FAILED)", result.stdout,
+                      "Could not find second attempt to run setup in output")
+
+    def test_runner_setup_attempts_test_fail(self):
+        cmd_line = ('%s run -p setup_failures=4 --sysinfo=off --job-results-dir %s '
+                    'setup_retry.py' % (AVOCADO, self.tmpdir))
+        result = process.run(cmd_line, ignore_status=True)
+        expected_rc = exit_codes.AVOCADO_TESTS_FAIL
+        self.assertEqual(result.exit_status, expected_rc,
+                         "Avocado did not return rc %d:\n%s" % (expected_rc, result))
+
     def test_runner_all_ok(self):
         cmd_line = ('%s run --sysinfo=off --job-results-dir %s '
                     'passtest.py passtest.py' % (AVOCADO, self.tmpdir))

--- a/selftests/unit/test_runner_queue.py
+++ b/selftests/unit/test_runner_queue.py
@@ -59,6 +59,7 @@ class TestRunnerQueue(unittest.TestCase):
         msg = self._run_test(factory)
 
         self.assertEqual(msg['whiteboard'], 'TXkgbWVzc2FnZSBlbmNvZGVkIGluIGJhc2U2NA==\n')
+        self.assertIn('phase', msg)
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir)


### PR DESCRIPTION
Test setups can sometimes take longer than test themselves, and for better reliability of tests, ideally those phases would be treated individually.  With the setup phase treated individually, it can even be (re-)tried a number of times.

This is built on top of:
 * https://github.com/avocado-framework/avocado/pull/3152
 * https://github.com/avocado-framework/avocado/pull/3154

Besides the example test given here, a "real world" example can be seen here:
 * https://github.com/clebergnu/qemu/blob/examples/avocado_setup_timeout/tests/acceptance/boot_linux.py#L25
 * https://github.com/clebergnu/qemu/commit/19897901a2da9bdedd57d0e078404021bb82d13d

That simulates a longer expected setup than the amount of expected time for the test execution.

---

Changes from v1 (#3155):
 * Addressed lgtm warnings, which revealed a broken logic (setting variables to be used in the loop  before breaking from the loop)