### PR TITLE
Python 3.8 support: fix SyntaxWarning on avocado.utils.cpu

### DIFF
--- a/avocado/utils/cpu.py
+++ b/avocado/utils/cpu.py
@@ -245,9 +245,9 @@ def _legacy_disable(value):
     TODO: this should be removed in the near future
     Reference: https://trello.com/c/aJzNUeA5/
     '''
-    if value is 0:
+    if value == 0:
         return b'0'
-    if value is 1:
+    if value == 1:
         return b'1'
     return _bool_to_binary(value)
 


### PR DESCRIPTION
We're checking for identity with literal integers.  Let's fix the

 SyntaxWarning: "is" with a literal. Did you mean "=="

given by Python 3.8 and later.