### PR TITLE
Job: result categorization support

### DIFF
--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -92,6 +92,12 @@ class Run(CLICmd):
                             help=('Forces to use of an alternate job '
                                   'results directory.'))
 
+        parser.add_argument('--job-category', action='store',
+                            default=None, metavar='CATEGORY',
+                            help=('Categorizes this within a directory with '
+                                  'the same name, by creating a link to the '
+                                  'job result directory'))
+
         parser.add_argument('--job-timeout', action='store',
                             default=None, metavar='SECONDS',
                             help='Set the maximum amount of time (in SECONDS) '


### PR DESCRIPTION
This adds a command line option "--job-category" that allows one
running tests to quickly category this job in a directory.

A symbolic link is used to point to the (relative) path of the
complete job result directory.

Signed-off-by: Cleber Rosa <crosa@redhat.com>