### PR TITLE
examples/tests/gendata.py: drop "bsod" example tests

### DIFF
--- a/examples/tests/gendata.py
+++ b/examples/tests/gendata.py
@@ -4,7 +4,6 @@ import os
 
 from avocado import Test
 from avocado import main
-from avocado.utils import genio
 
 
 class GenDataTest(Test):
@@ -12,27 +11,6 @@ class GenDataTest(Test):
     """
     Simple test that generates data to be persisted after the test is run
     """
-
-    def test_bsod(self):
-        try:
-            from PIL import Image
-            from PIL import ImageDraw
-        except ImportError:
-            self.cancel("PIL not available")
-
-        text = ["DREADED BLUE SCREEN OF DEATH"]
-        dmesg_path = os.path.join(self.job.logdir, "sysinfo", "pre", "dmesg_-c")
-        self.log.info("dmesg_path: %s", dmesg_path)
-        if os.path.exists(dmesg_path):
-            text = genio.read_all_lines(dmesg_path)[0:50]
-
-        bsod = Image.new("RGB", (640, 480), "blue")
-        draw = ImageDraw.Draw(bsod)
-        y = 2
-        for line in text:
-            draw.text((2, y), line)
-            y += 12
-        bsod.save(os.path.join(self.outputdir, "bsod.png"))
 
     def test_json(self):
         import json

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -502,6 +502,7 @@ class RunnerOperationTest(unittest.TestCase):
                "--mux-inject foo:1 bar:2 baz:3 foo:foo:a "
                "foo:bar:b foo:baz:c bar:bar:bar "
                "-- passtest.py failtest.py gendata.py " % AVOCADO)
+        number_of_tests = 3
         result = json.loads(process.run(cmd).stdout_text)
         debuglog = result['debuglog']
         log = genio.read_file(debuglog)
@@ -510,8 +511,8 @@ class RunnerOperationTest(unittest.TestCase):
         self.assertIn(tempfile.gettempdir(), debuglog)   # Use tmp dir, not default location
         self.assertEqual(result['job_id'], u'0' * 40)
         # Check if all tests were skipped
-        self.assertEqual(result['cancel'], 4)
-        for i in range(4):
+        self.assertEqual(result['cancel'], number_of_tests)
+        for i in range(number_of_tests):
             test = result['tests'][i]
             self.assertEqual(test['fail_reason'],
                              u'Test cancelled due to --dry-run')
@@ -520,7 +521,7 @@ class RunnerOperationTest(unittest.TestCase):
         # from test.
         for line in ("/:foo ==> 1", "/:baz ==> 3", "/foo:foo ==> a",
                      "/foo:bar ==> b", "/foo:baz ==> c", "/bar:bar ==> bar"):
-            self.assertEqual(log.count(line), 4,
+            self.assertEqual(log.count(line), number_of_tests,
                              "Avocado log count for param '%s' not as expected:\n%s" % (line, log))
 
     def test_invalid_python(self):


### PR DESCRIPTION
This is a really bad example of a test, in the sense that it requires
a huge library just to draw an image.

Let's drop it, given that the remaining example works just as well.

Signed-off-by: Cleber Rosa <crosa@redhat.com>