### PR TITLE
Enable codecov coverage reports for Avocado

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 dist: xenial
 language: python
 
-matrix:
-  allow_failures:
-    - python: "nightly"
-
 python:
     - "3.4"
     - "3.5"
@@ -19,6 +15,13 @@ env:
       SELF_CHECK_CONTINUOUS=y
       AVOCADO_CHECK_LEVEL=1
 
+matrix:
+  include:
+    - python: "3.7"
+      env: RUN_ONLY_COVERAGE=yes
+  allow_failures:
+    - python: "nightly"
+
 cache:
     directories:
         - $HOME/.cache/pip
@@ -32,4 +35,4 @@ install:
     - pip install -r requirements-selftests.txt
 
 script:
-    - make check
+    - if [ "$RUN_ONLY_COVERAGE" == yes ]; then pip install codecov && make develop && ./selftests/run_coverage && codecov; else make check; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,9 @@ env:
 matrix:
   include:
     - python: "3.7"
-      env: RUN_ONLY_COVERAGE=yes
+      env:
+        - RUN_ONLY_COVERAGE=yes
+        - SELF_CHECK_CONTINUOUS=yes
   allow_failures:
     - python: "nightly"
 

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -1022,6 +1022,7 @@ class ExternalRunnerTest(unittest.TestCase):
                          "Avocado did not return rc %d:\n%s" %
                          (expected_rc, result))
 
+    @unittest.skipIf(os.environ.get("RUNNING_COVERAGE"), "Running coverage")
     def test_externalrunner_chdir_runner_relative(self):
         avocado_split = AVOCADO.rsplit(" ", 1)
         avocado_abs = "%s %s" % (avocado_split[0],

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -1023,7 +1023,9 @@ class ExternalRunnerTest(unittest.TestCase):
                          (expected_rc, result))
 
     def test_externalrunner_chdir_runner_relative(self):
-        avocado_abs = " ".join([os.path.abspath(_) for _ in AVOCADO.split(" ")])
+        avocado_split = AVOCADO.rsplit(" ", 1)
+        avocado_abs = "%s %s" % (avocado_split[0],
+                                 os.path.abspath(avocado_split[1]))
         pass_abs = os.path.abspath(self.pass_script.path)
         os.chdir('/')
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off '

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -2,6 +2,7 @@ import json
 import os
 import re
 import shutil
+import shlex
 import tempfile
 import unittest
 from xml.dom import minidom
@@ -18,11 +19,11 @@ from .. import AVOCADO, BASEDIR, temp_dir_prefix
 
 # AVOCADO may contain more than a single command, as it can be
 # prefixed by the Python interpreter
-AVOCADO_QUOTED = ", ".join(["'%s'" % cmd for cmd in AVOCADO.split(' ')])
+AVOCADO_QUOTED = "', '".join(shlex.split(AVOCADO))
 PERL_TAP_PARSER_SNIPPET = """#!/bin/env perl
 use TAP::Parser;
 
-my $parser = TAP::Parser->new( { exec => [%s, 'run', 'passtest.py', 'errortest.py', 'warntest.py', '--tap', '-', '--sysinfo', 'off', '--job-results-dir', '%%s'] } );
+my $parser = TAP::Parser->new( { exec => ['%s', 'run', 'passtest.py', 'errortest.py', 'warntest.py', '--tap', '-', '--sysinfo', 'off', '--job-results-dir', '%%s'] } );
 
 while ( my $result = $parser->next ) {
         $result->is_unknown && die "Unknown line \\"" . $result->as_string . "\\" in the TAP output!\n";

--- a/selftests/functional/test_plugin_diff.py
+++ b/selftests/functional/test_plugin_diff.py
@@ -1,8 +1,8 @@
 import glob
 import os
-import sys
 import tempfile
 import shutil
+import shlex
 import unittest
 
 from avocado.core import exit_codes
@@ -50,10 +50,7 @@ class DiffTests(unittest.TestCase):
         result = self.run_and_check(cmd_line, expected_rc)
         # Avocado won't know about the Python interpreter used on the
         # command line
-        if AVOCADO.startswith(sys.executable):
-            avocado_in_log = AVOCADO[len(sys.executable)+1:]
-        else:
-            avocado_in_log = AVOCADO
+        avocado_in_log = shlex.split(AVOCADO)[-1]
         self.assertIn(b"# COMMAND LINE", result.stdout)
         self.assertIn("-%s run" % avocado_in_log, result.stdout_text)
         self.assertIn("+%s run" % avocado_in_log, result.stdout_text)

--- a/selftests/functional/test_streams.py
+++ b/selftests/functional/test_streams.py
@@ -1,6 +1,6 @@
 import os
 import shutil
-import sys
+import shlex
 import tempfile
 import unittest
 
@@ -57,10 +57,7 @@ class StreamsTest(unittest.TestCase):
             result = process.run(cmd, env=env, shell=True)
             self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
             # If using the Python interpreter, Avocado won't know about it
-            if AVOCADO.startswith(sys.executable):
-                cmd_in_log = cmd[len(sys.executable)+1:]
-            else:
-                cmd_in_log = cmd
+            cmd_in_log = shlex.split(AVOCADO)[-1]
             self.assertIn("avocado.test: Command line: %s" % cmd_in_log,
                           result.stdout_text)
             self.assertEqual(b'', result.stderr)
@@ -74,10 +71,7 @@ class StreamsTest(unittest.TestCase):
         result = process.run(cmd)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
         # If using the Python interpreter, Avocado won't know about it
-        if AVOCADO.startswith(sys.executable):
-            cmd_in_log = cmd[len(sys.executable)+1:]
-        else:
-            cmd_in_log = cmd
+        cmd_in_log = shlex.split(AVOCADO)[-1]
         self.assertIn("Command line: %s" % cmd_in_log,
                       result.stdout_text)
         self.assertIn(b"\nSTART 1-passtest.py:PassTest.test",

--- a/selftests/run_coverage
+++ b/selftests/run_coverage
@@ -5,11 +5,13 @@
 # License: GPLv2
 # Author: Lukas Doktor <ldoktor@redhat.com>
 
-coverage erase
+COVERAGE="$(which coverage3 coverage coverage2 | head -n 1)"
+
+$COVERAGE erase
 rm .coverage.*
-AVOCADO_CHECK_LEVEL=2 UNITTEST_AVOCADO_CMD="coverage run -p --include 'avocado/*' ./scripts/avocado" coverage run -p --include "avocado/*" ./selftests/run
-coverage combine .coverage*
+RUNNING_COVERAGE=1 AVOCADO_CHECK_LEVEL=2 UNITTEST_AVOCADO_CMD="$COVERAGE run -p --include 'avocado/*' ./scripts/avocado" $COVERAGE run -p --include "avocado/*" ./selftests/run
+$COVERAGE combine .coverage*
 echo
-coverage report -m --include "avocado/core/*"
+$COVERAGE report -m --include "avocado/core/*"
 echo
-coverage report -m --include "avocado/utils/*"
+$COVERAGE report -m --include "avocado/utils/*"


### PR DESCRIPTION
The codecov.io service allows easy reporting of coverage data, let's
include that in our CI to put additional stress on committers to write
tests as well as on us to require them.

Sample output is here: https://github.com/ldoktor/avocado/pull/2