### PR TITLE
Added Power9 in get_cpu_vendor_name subroutine

### DIFF
--- a/avocado/utils/cpu.py
+++ b/avocado/utils/cpu.py
@@ -102,7 +102,8 @@ def get_cpu_vendor_name():
         'intel': ("GenuineIntel", ),
         'amd': ("AMD", ),
         'power7': ("POWER7", ),
-        'power8': ("POWER8", )
+        'power8': ("POWER8", ),
+        'power9': ("POWER9", )
     }
 
     cpu_info = _get_cpu_info()


### PR DESCRIPTION
Added Power9 in get_cpu_vendor_name subroutine as
in power9 system it returns None

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>