### PR TITLE
Clean up of remaining Python 2 compatibility code

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -1115,10 +1115,6 @@ class SimpleTest(Test):
         self._command = None
         if self.filename is not None:
             self._command = pipes.quote(self.filename)
-            # process.run expects unicode as the command, but pipes.quote
-            # turns it into a "bytes" array in Python 2
-            if not astring.is_text(self._command):
-                self._command = astring.to_text(self._command, defaults.ENCODING)
 
     @property
     def filename(self):

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -628,18 +628,12 @@ class SubProcess:
 
             self.start_time = time.time()
 
-            # The Thread to be started by the FDDrainer cannot have a name
-            # from a non-ascii string (this is a Python 2 internal limitation).
-            # To keep some relation between the command name and the Thread
-            # this resorts to attempting the conversion to ascii, replacing
-            # characters it can not convert
-            cmd_name = self.cmd.encode('ascii', 'replace')
             # prepare fd drainers
             if self.allow_output_check == 'combined':
                 self._combined_drainer = FDDrainer(
                     self._popen.stdout.fileno(),
                     self.result,
-                    name="%s-combined" % cmd_name,
+                    name="%s-combined" % self.cmd,
                     logger=log,
                     logger_prefix="[output] %s",
                     # FIXME, in fact, a new log has to be used here
@@ -658,7 +652,7 @@ class SubProcess:
                 self._stdout_drainer = FDDrainer(
                     self._popen.stdout.fileno(),
                     self.result,
-                    name="%s-stdout" % cmd_name,
+                    name="%s-stdout" % self.cmd,
                     logger=log,
                     logger_prefix="[stdout] %s",
                     stream_logger=stdout_stream_logger,
@@ -667,7 +661,7 @@ class SubProcess:
                 self._stderr_drainer = FDDrainer(
                     self._popen.stderr.fileno(),
                     self.result,
-                    name="%s-stderr" % cmd_name,
+                    name="%s-stderr" % self.cmd,
                     logger=log,
                     logger_prefix="[stderr] %s",
                     stream_logger=stderr_stream_logger,

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -293,25 +293,17 @@ def binary_from_shell_cmd(cmd):
     :type cmd: unicode string
     :return: first found binary from the cmd
     """
-    cmds = cmd_split(cmd)
+    cmds = shlex.split(cmd)
     for item in cmds:
         if not _RE_BASH_SET_VARIABLE.match(item):
             return item
     raise ValueError("Unable to parse first binary from '%s'" % cmd)
 
 
-def cmd_split(cmd):
-    """
-    Splits a command line into individual components
-
-    This is a simple wrapper around :func:`shlex.split`, which has the
-    requirement of having text (not bytes) as its argument on Python 3,
-    but bytes on Python 2.
-
-    :param cmd: text (a multi byte string) encoded as 'utf-8'
-    """
-    data = astring.to_text(cmd, 'utf-8')
-    return shlex.split(data)
+#: This is kept for compatibility purposes, but is now deprecated and
+#: will be removed in later versions.  Please use :func:`shlex.split`
+#: instead.
+cmd_split = shlex.split
 
 
 class CmdResult:
@@ -617,7 +609,7 @@ class SubProcess:
             if self.verbose:
                 log.info("Running '%s'", self.cmd)
             if self.shell is False:
-                cmd = cmd_split(self.cmd)
+                cmd = shlex.split(self.cmd)
             else:
                 cmd = self.cmd
             try:
@@ -968,7 +960,7 @@ class GDBSubProcess:
             encoding = astring.ENCODING
         self.cmd = cmd
 
-        self.args = cmd_split(cmd)
+        self.args = shlex.split(cmd)
         self.binary = self.args[0]
         self.binary_path = os.path.abspath(self.cmd)
         self.result = CmdResult(cmd, encoding=encoding)
@@ -1252,7 +1244,7 @@ def should_run_inside_gdb(cmd):
         return False
 
     try:
-        args = cmd_split(cmd)
+        args = shlex.split(cmd)
     except ValueError:
         log.warning("Unable to check whether command '%s' should run inside "
                     "GDB, fallback to simplified method...", cmd)
@@ -1274,7 +1266,7 @@ def should_run_inside_wrapper(cmd):
     """
     global CURRENT_WRAPPER  # pylint: disable=W0603
     CURRENT_WRAPPER = None
-    args = cmd_split(cmd)
+    args = shlex.split(cmd)
     cmd_binary_name = args[0]
 
     for script, cmd_expr in WRAP_PROCESS_NAMES_EXPR:

--- a/docs/source/GetStartedGuide.rst
+++ b/docs/source/GetStartedGuide.rst
@@ -32,8 +32,8 @@ Installing with standard Python tools
 -------------------------------------
 
 The simplest installation method is through ``pip``.  On most POSIX
-systems with Python 2.7 and ``pip`` available, installation can be
-performed with a single command::
+systems with Python 3.4 (or later) and ``pip`` available, installation
+can be performed with a single command::
 
   pip install --user avocado-framework
 
@@ -48,7 +48,7 @@ If you want even more isolation, Avocado can also be installed in a
 Python virtual environment. with no additional steps besides creating
 and activating the "venv" itself::
 
-  python -m virtualenv /path/to/new/virtual_environment
+  python -m venv /path/to/new/virtual_environment
   . /path/to/new/virtual_environment/bin/activate
   pip install avocado-framework
 

--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -1,13 +1,11 @@
 import io
 import logging
 import os
-import shlex
 import unittest.mock
 import sys
 import time
 
 
-from avocado.utils import astring
 from avocado.utils import script
 from avocado.utils import gdb
 from avocado.utils import process
@@ -394,30 +392,10 @@ class MiscProcessTests(unittest.TestCase):
         self.assertEqual("./bin", res)
 
     def test_cmd_split(self):
-        plain_str = ''
-        unicode_str = u''
-        empty_bytes = b''
-        # shlex.split() can work with "plain_str" and "unicode_str" on both
-        # Python 2 and Python 3.  While we're not testing Python itself,
-        # this will help us catch possible differences in the Python
-        # standard library should they arise.
-        self.assertEqual(shlex.split(plain_str), [])
-        self.assertEqual(shlex.split(astring.to_text(plain_str)), [])
-        self.assertEqual(shlex.split(unicode_str), [])
-        self.assertEqual(shlex.split(astring.to_text(unicode_str)), [])
-        # on Python 3, shlex.split() won't work with bytes, raising:
-        # AttributeError: 'bytes' object has no attribute 'read'.
-        # To turn bytes into text (when necessary), that is, on
-        # Python 3 only, use astring.to_text()
-        self.assertEqual(shlex.split(astring.to_text(empty_bytes)), [])
-        # Now let's test our specific implementation to split commands
-        self.assertEqual(process.cmd_split(plain_str), [])
-        self.assertEqual(process.cmd_split(unicode_str), [])
-        self.assertEqual(process.cmd_split(empty_bytes), [])
-        unicode_command = u"avok\xe1do_test_runner arguments"
-        self.assertEqual(process.cmd_split(unicode_command),
-                         [u"avok\xe1do_test_runner",
-                          u"arguments"])
+        self.assertEqual(process.cmd_split(''), [])
+        self.assertEqual(process.cmd_split("avok\xe1do_test_runner arguments"),
+                         ["avok\xe1do_test_runner",
+                          "arguments"])
 
     def test_get_parent_pid(self):
         stat = b'18405 (bash) S 24139 18405 18405 34818 8056 4210688 9792 170102 0 7 11 4 257 84 20 0 1 0 44336493 235409408 4281 18446744073709551615 94723230367744 94723231442728 140723100226000 0 0 0 65536 3670020 1266777851 0 0 0 17 1 0 0 0 0 0 94723233541456 94723233588580 94723248717824 140723100229613 140723100229623 140723100229623 140723100233710 0'


### PR DESCRIPTION
There are still some code present that would help with Python 2 compatibility, and for Avocado 70.0 and later, we don't need any of it as only Python 3.4 is now supported.

Note: 69.x is still supported for Python 2 users.