### PR TITLE
Fix: os.write expects string encode

### DIFF
--- a/avocado/utils/genio.py
+++ b/avocado/utils/genio.py
@@ -138,9 +138,9 @@ def write_file_or_fail(filename, data):
     :type data: str
     :raises GenIOError: On write Failure
     """
-    fd = os.open(filename, os.O_WRONLY)
     try:
-        os.write(fd, data)
+        with open(filename, 'w') as file_obj:
+            file_obj.write(data)
     except OSError as details:
         raise GenIOError("The write to %s failed: %s" % (
                          filename, details))


### PR DESCRIPTION
Patch fixes genio utility with os.write expecting string encoding with python3.

ERROR|   File "avocado/utils/genio.py", line 143, in write_file_or_fail
ERROR|     os.write(fd, data)
ERROR| TypeError: a bytes-like object is required, not 'str'

Signed-off-by: Harish <harish@linux.vnet.ibm.com>