### PR TITLE
GLib loader plugin: implement safe mode by default

### DIFF
--- a/avocado/etc/avocado/conf.d/glib.conf
+++ b/avocado/etc/avocado/conf.d/glib.conf
@@ -1,0 +1,3 @@
+[plugins.glib]
+# Wether to run executables in an attempt to discover tests
+unsafe = False

--- a/docs/source/optional_plugins/glib.rst
+++ b/docs/source/optional_plugins/glib.rst
@@ -7,6 +7,12 @@ GLib Plugin
 This optional plugin enables Avocado to list and run tests written using the
 `GLib Test Framework <https://developer.gnome.org/glib/stable/glib-Testing.html>`_.
 
+.. tip:: To see the GLIB tests, it's necessary to execute the
+         binaries.  For safety reasons, this is not enable by default
+         in Avocado.  Please edit the ``unsafe`` configuration entry
+         in the ``[plugins.glib]`` section to enable it.  Also notice
+         that a ``glib.conf`` file ships with Avocado.
+
 To list the tests, just provide the test file path::
 
     $ avocado list --loaders glib -- tests/check-qnum

--- a/optional_plugins/glib/avocado_glib/__init__.py
+++ b/optional_plugins/glib/avocado_glib/__init__.py
@@ -26,6 +26,7 @@ from avocado.core import loader
 from avocado.core import output
 from avocado.core import test
 from avocado.core.plugin_interfaces import CLI
+from avocado.core.settings import settings
 
 
 class GLibTest(test.SimpleTest):
@@ -86,7 +87,8 @@ class GLibLoader(loader.TestLoader):
             subtests_filter = re.compile(_subtests_filter)
 
         if (os.path.isfile(reference) and
-                path.PathInspector(reference).has_exec_permission()):
+                path.PathInspector(reference).has_exec_permission() and
+                settings.get_value("plugins.glib", "unsafe", bool, False)):
             try:
                 cmd = '%s -l' % (reference)
                 result = process.run(cmd)

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -59,7 +59,7 @@
 Summary: Framework with tools and libraries for Automated Testing
 Name: python-%{srcname}
 Version: 70.0
-Release: 0%{?gitrel}%{?dist}
+Release: 1%{?gitrel}%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.github.io/
@@ -550,6 +550,7 @@ GLib Test Framework.
 %files -n python3-%{srcname}-plugins-glib
 %{python3_sitelib}/avocado_glib*
 %{python3_sitelib}/avocado_framework_plugin_glib*
+%config(noreplace)%{_sysconfdir}/avocado/conf.d/glib.conf
 
 %package -n python3-%{srcname}-examples
 Summary: Avocado Test Framework Example Tests
@@ -583,6 +584,9 @@ Again Shell code (and possibly other similar shells).
 %{_libexecdir}/avocado*
 
 %changelog
+* Tue Jul  9 2019 Cleber Rosa <cleber@redhat.com> - 70.0-1
+- Add config file to glib plugin subpackage
+
 * Wed Jun 26 2019 Cleber Rosa <cleber@redhat.com> - 70.0-0
 - New release
 


### PR DESCRIPTION
This plugin will try to run every executable file it can find with the
-l parameter, which is not so good.

This keeps things simple and creating a unsafe configuration, and
requiring the user to manually set it to True.

Reference: https://trello.com/c/xewwbjpq
Signed-off-by: Cleber Rosa <crosa@redhat.com>