### PR TITLE
Fix: wrong start date on INTERRUPTED tests

### DIFF
--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -240,6 +240,7 @@ class TestStatus:
         # At this point there were failures, fill the new test status
         TEST_LOG.debug("Original status: %s", str(self.status))
         test_state = self.early_status
+        test_state['time_start'] = started
         test_state['time_elapsed'] = time.time() - started
         test_state['fail_reason'] = err
         test_state['status'] = exceptions.TestAbortError.status


### PR DESCRIPTION
When the test is interrupted, there is new test state created but without the start time.
This commit fixing the problem.

Signed-off-by: Jan Richter <jarichte@redhat.com>