### PR TITLE
avocado:utils:cpu fix as well new lib add

### DIFF
--- a/avocado/utils/cpu.py
+++ b/avocado/utils/cpu.py
@@ -99,11 +99,11 @@ def get_cpu_vendor_name():
     :rtype: `string`
     """
     vendors_map = {
-        'intel': ("GenuineIntel", ),
-        'amd': ("AMD", ),
-        'power7': ("POWER7", ),
-        'power8': ("POWER8", ),
-        'power9': ("POWER9", )
+        'intel': (b"GenuineIntel", ),
+        'amd': (b"AMD", ),
+        'power7': (b"POWER7", ),
+        'power8': (b"POWER8", ),
+        'power9': (b"POWER9", )
     }
 
     cpu_info = _get_cpu_info()

--- a/avocado/utils/cpu.py
+++ b/avocado/utils/cpu.py
@@ -213,14 +213,17 @@ def get_cpuidle_state():
     :rtype: Dict of dicts
     """
     cpus_list = cpu_online_list()
-    states = range(len(glob.glob("/sys/devices/system/cpu/cpu0/cpuidle/state*")))
+    states = range(
+        len(glob.glob("/sys/devices/system/cpu/cpu0/cpuidle/state*")))
     cpu_idlestate = {}
     for cpu in cpus_list:
         cpu_idlestate[cpu] = {}
         for state_no in states:
-            state_file = "/sys/devices/system/cpu/cpu%s/cpuidle/state%s/disable" % (cpu, state_no)
+            state_file = "/sys/devices/system/cpu/cpu%s/cpuidle/state%s/disable" % (
+                cpu, state_no)
             try:
-                cpu_idlestate[cpu][state_no] = int(open(state_file, 'rb').read())
+                cpu_idlestate[cpu][state_no] = int(
+                    open(state_file, 'rb').read())
             except IOError as err:
                 logging.warning("Failed to read idle state on cpu %s "
                                 "for state %s:\n%s", cpu, state_no, err)
@@ -266,13 +269,15 @@ def set_cpuidle_state(state_number="all", disable=True, setstate=None):
     if not setstate:
         states = []
         if state_number == 'all':
-            states = range(0, len(glob.glob("/sys/devices/system/cpu/cpu0/cpuidle/state*")))
+            states = range(
+                0, len(glob.glob("/sys/devices/system/cpu/cpu0/cpuidle/state*")))
         else:
             states.append(state_number)
         disable = _legacy_disable(disable)
         for cpu in cpus_list:
             for state_no in states:
-                state_file = "/sys/devices/system/cpu/cpu%s/cpuidle/state%s/disable" % (cpu, state_no)
+                state_file = "/sys/devices/system/cpu/cpu%s/cpuidle/state%s/disable" % (
+                    cpu, state_no)
                 try:
                     open(state_file, "wb").write(disable)
                 except IOError as err:
@@ -281,7 +286,8 @@ def set_cpuidle_state(state_number="all", disable=True, setstate=None):
     else:
         for cpu, stateval in setstate.items():
             for state_no, value in stateval.items():
-                state_file = "/sys/devices/system/cpu/cpu%s/cpuidle/state%s/disable" % (cpu, state_no)
+                state_file = "/sys/devices/system/cpu/cpu%s/cpuidle/state%s/disable" % (
+                    cpu, state_no)
                 disable = _legacy_disable(value)
                 try:
                     open(state_file, "wb").write(disable)

--- a/avocado/utils/cpu.py
+++ b/avocado/utils/cpu.py
@@ -27,6 +27,8 @@ import glob
 import logging
 import random
 
+from . import process
+
 
 def _list_matches(content_list, pattern):
     """
@@ -374,3 +376,28 @@ def get_pid_cpus(pid):
         except IOError:
             continue
     return list(cpus)
+
+
+def _is_smt():
+
+    """
+    Return True/False Based on if system has hyperthreading enabled
+    :return: True/False
+    :rtype: boolean
+    """
+
+    if get_cpu_vendor_name().startswith('power'):
+        try:
+            if b'is not SMT capable' in process.system_output("ppc64_cpu --smt"):
+                return False
+            return True
+        except process.CmdError as err:
+            logging.error("Unable to get Simultaneous multithreading status as errror:%s", err)
+            return False
+    else:
+        with open('/proc/cpuinfo') as cpu_file:
+            cpuinfo = dict(map(
+                lambda line: map(str.strip, line.split(':', 1)),
+                filter(lambda line: ':' in line, cpu_file)
+                ))
+        return (cpuinfo['siblings'] != cpuinfo['cpu cores'])


### PR DESCRIPTION
1-Fix issue in avocado:utils:cpu.get_cpu_vendor_name() 
as in python3 it complains about TypeError: cannot use a
string pattern on a bytes-like object
2- Fix pep8 issue in  avocado:utils:cpu lib

3- Added a subroutine in avocado:utils:cpu about checking system has hyper-threading

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>
