### PR TITLE
Remove stevedore package requirement [v2]

### DIFF
--- a/avocado/core/dispatcher.py
+++ b/avocado/core/dispatcher.py
@@ -20,64 +20,26 @@ dispatcher that these depend upon:
 :class:`avocado.core.settings_dispatcher.SettingsDispatcher`
 """
 
-import copy
-import sys
-
-from stevedore import EnabledExtensionManager
-
+from .extension_manager import ExtensionManager
 from .settings import settings
 from .settings import SettingsError
-from .output import LOG_UI
-from ..utils import stacktrace
 
 
-class Dispatcher(EnabledExtensionManager):
-
-    """
-    Base dispatcher for various extension types
-    """
-
-    #: Default namespace prefix for Avocado extensions
-    NAMESPACE_PREFIX = 'avocado.plugins.'
+class EnabledExtensionManager(ExtensionManager):
 
     def __init__(self, namespace, invoke_kwds=None):
-        if invoke_kwds is None:
-            invoke_kwds = {}
-        self.load_failures = []
-        super(Dispatcher, self).__init__(namespace=namespace,
-                                         check_func=self.enabled,
-                                         invoke_on_load=True,
-                                         invoke_kwds=invoke_kwds,
-                                         on_load_failure_callback=self.store_load_failure,
-                                         propagate_map_exceptions=True)
-
-    def plugin_type(self):
-        """
-        Subset of entry points namespace for this dispatcher
-
-        Given an entry point `avocado.plugins.foo`, plugin type is `foo`.  If
-        entry point does not conform to the Avocado standard prefix, it's
-        returned unchanged.
-        """
-        if self.namespace.startswith(self.NAMESPACE_PREFIX):
-            return self.namespace[len(self.NAMESPACE_PREFIX):]
-        else:
-            return self.namespace
-
-    def fully_qualified_name(self, extension):
-        """
-        Returns the Avocado fully qualified plugin name
-
-        :param extension: an Stevedore Extension instance
-        :type extension: :class:`stevedore.extension.Extension`
-        """
-        return "%s.%s" % (self.plugin_type(), extension.entry_point.name)
-
-    def settings_section(self):
-        """
-        Returns the config section name for the plugin type handled by itself
-        """
-        return "plugins.%s" % self.plugin_type()
+        super(EnabledExtensionManager, self).__init__(namespace, invoke_kwds)
+        configured_order = settings.get_value(self.settings_section(), "order",
+                                              key_type=list, default=[])
+        ordered = []
+        for name in configured_order:
+            for ext in self.extensions:
+                if name == ext.name:
+                    ordered.append(ext)
+        for ext in self.extensions:
+            if ext not in ordered:
+                ordered.append(ext)
+        self.extensions = ordered
 
     def enabled(self, extension):
         """
@@ -92,94 +54,8 @@ class Dispatcher(EnabledExtensionManager):
         except SettingsError:
             return True
 
-    def names(self):
-        """
-        Returns the names of the discovered extensions
 
-        This differs from :func:`stevedore.extension.ExtensionManager.names`
-        in that it returns names in a predictable order, by using standard
-        :func:`sorted`.
-        """
-        return sorted(super(Dispatcher, self).names())
-
-    def _init_plugins(self, extensions):
-        super(Dispatcher, self)._init_plugins(extensions)
-        self.extensions.sort(key=lambda x: x.name)
-        configured_order = settings.get_value(self.settings_section(), "order",
-                                              key_type=list, default=[])
-        ordered = []
-        for name in configured_order:
-            for ext in self.extensions:
-                if name == ext.name:
-                    ordered.append(ext)
-        for ext in self.extensions:
-            if ext not in ordered:
-                ordered.append(ext)
-        self.extensions = ordered
-
-    @staticmethod
-    def store_load_failure(manager, entrypoint, exception):
-        manager.load_failures.append((entrypoint, exception))
-
-    def map_method_with_return(self, method_name, *args, **kwargs):
-        """
-        The same as `map_method` but additionally reports the list of returned
-        values and optionally deepcopies the passed arguments
-
-        :param method_name: Name of the method to be called on each ext
-        :param args: Arguments to be passed to all called functions
-        :param kwargs: Key-word arguments to be passed to all called functions
-                        if `"deepcopy" == True` is present in kwargs the
-                        args and kwargs are deepcopied before passing it
-                        to each called function.
-        """
-        deepcopy = kwargs.pop("deepcopy", False)
-        ret = []
-        for ext in self.extensions:
-            try:
-                if hasattr(ext.obj, method_name):
-                    method = getattr(ext.obj, method_name)
-                    if deepcopy:
-                        copied_args = [copy.deepcopy(arg) for arg in args]
-                        copied_kwargs = copy.deepcopy(kwargs)
-                        ret.append(method(*copied_args, **copied_kwargs))
-                    else:
-                        ret.append(method(*args, **kwargs))
-            except SystemExit:
-                raise
-            except KeyboardInterrupt:
-                raise
-            except:     # catch any exception pylint: disable=W0702
-                stacktrace.log_exc_info(sys.exc_info(),
-                                        logger='avocado.app.debug')
-                LOG_UI.error('Error running method "%s" of plugin "%s": %s',
-                             method_name, ext.name, sys.exc_info()[1])
-        return ret
-
-    def map_method(self, method_name, *args):
-        """
-        Maps method_name on each extension in case the extension has the attr
-
-        :param method_name: Name of the method to be called on each ext
-        :param args: Arguments to be passed to all called functions
-        """
-        for ext in self.extensions:
-            try:
-                if hasattr(ext.obj, method_name):
-                    method = getattr(ext.obj, method_name)
-                    method(*args)
-            except SystemExit:
-                raise
-            except KeyboardInterrupt:
-                raise
-            except:     # catch any exception pylint: disable=W0702
-                stacktrace.log_exc_info(sys.exc_info(),
-                                        logger='avocado.app.debug')
-                LOG_UI.error('Error running method "%s" of plugin "%s": %s',
-                             method_name, ext.name, sys.exc_info()[1])
-
-
-class CLIDispatcher(Dispatcher):
+class CLIDispatcher(EnabledExtensionManager):
 
     """
     Calls extensions on configure/run
@@ -192,7 +68,7 @@ class CLIDispatcher(Dispatcher):
         super(CLIDispatcher, self).__init__('avocado.plugins.cli')
 
 
-class CLICmdDispatcher(Dispatcher):
+class CLICmdDispatcher(EnabledExtensionManager):
 
     """
     Calls extensions on configure/run
@@ -205,7 +81,7 @@ class CLICmdDispatcher(Dispatcher):
         super(CLICmdDispatcher, self).__init__('avocado.plugins.cli.cmd')
 
 
-class JobPrePostDispatcher(Dispatcher):
+class JobPrePostDispatcher(EnabledExtensionManager):
 
     """
     Calls extensions before Job execution
@@ -218,13 +94,13 @@ class JobPrePostDispatcher(Dispatcher):
         super(JobPrePostDispatcher, self).__init__('avocado.plugins.job.prepost')
 
 
-class ResultDispatcher(Dispatcher):
+class ResultDispatcher(EnabledExtensionManager):
 
     def __init__(self):
         super(ResultDispatcher, self).__init__('avocado.plugins.result')
 
 
-class ResultEventsDispatcher(Dispatcher):
+class ResultEventsDispatcher(EnabledExtensionManager):
 
     def __init__(self, args):
         super(ResultEventsDispatcher, self).__init__(
@@ -232,7 +108,7 @@ class ResultEventsDispatcher(Dispatcher):
             invoke_kwds={'args': args})
 
 
-class VarianterDispatcher(Dispatcher):
+class VarianterDispatcher(EnabledExtensionManager):
 
     def __init__(self):
         super(VarianterDispatcher, self).__init__('avocado.plugins.varianter')

--- a/avocado/core/extension_manager.py
+++ b/avocado/core/extension_manager.py
@@ -1,0 +1,183 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2015-2019
+# Author: Cleber Rosa <cleber@redhat.com>
+
+"""
+Base extension manager
+
+This is a mix of stevedore-like APIs and behavior, with Avocado's
+own look and feel.
+"""
+
+import copy
+import logging
+import sys
+
+import pkg_resources
+
+from ..utils import stacktrace
+
+# This is also defined in avocado.core.output, but this avoids a
+# circular import
+LOG_UI = logging.getLogger("avocado.app")
+
+
+class Extension:
+    """
+    This is a verbatim copy from the stevedore.extension class with the
+    same name
+    """
+    def __init__(self, name, entry_point, plugin, obj):
+        self.name = name
+        self.entry_point = entry_point
+        self.plugin = plugin
+        self.obj = obj
+
+
+class ExtensionManager:
+
+    #: Default namespace prefix for Avocado extensions
+    NAMESPACE_PREFIX = 'avocado.plugins.'
+
+    def __init__(self, namespace, invoke_kwds=None):
+        self.namespace = namespace
+        self.extensions = []
+        self.load_failures = []
+        if invoke_kwds is None:
+            invoke_kwds = {}
+
+        # load plugins
+        for ep in pkg_resources.iter_entry_points(self.namespace):
+            try:
+                plugin = ep.load()
+                obj = plugin(**invoke_kwds)
+            except Exception as exception:
+                self.load_failures.append(exception)
+            else:
+                ext = Extension(ep.name, ep, plugin, obj)
+                if self.enabled(ext):  # lgtm [py/init-calls-subclass]
+                    self.extensions.append(ext)
+        self.extensions.sort(key=lambda x: x.name)
+
+    def enabled(self, extension):  # pylint: disable=W0613
+        """
+        Checks if a plugin is enabled
+
+        Sub classes can change this implementation to determine their own
+        criteria.
+        """
+        return True
+
+    def plugin_type(self):
+        """
+        Subset of entry points namespace for this dispatcher
+
+        Given an entry point `avocado.plugins.foo`, plugin type is `foo`.  If
+        entry point does not conform to the Avocado standard prefix, it's
+        returned unchanged.
+        """
+        if self.namespace.startswith(self.NAMESPACE_PREFIX):
+            return self.namespace[len(self.NAMESPACE_PREFIX):]
+        else:
+            return self.namespace
+
+    def fully_qualified_name(self, extension):
+        """
+        Returns the Avocado fully qualified plugin name
+
+        :param extension: an Extension instance
+        :type extension: :class:`Extension`
+        """
+        return "%s.%s" % (self.plugin_type(), extension.entry_point.name)
+
+    def settings_section(self):
+        """
+        Returns the config section name for the plugin type handled by itself
+        """
+        return "plugins.%s" % self.plugin_type()
+
+    def names(self):
+        """
+        Returns the names of the discovered extensions
+
+        This differs from :func:`stevedore.extension.ExtensionManager.names`
+        in that it returns names in a predictable order, by using standard
+        :func:`sorted`.
+        """
+        return sorted(super(ExtensionManager, self).names())
+
+    def map_method_with_return(self, method_name, *args, **kwargs):
+        """
+        The same as `map_method` but additionally reports the list of returned
+        values and optionally deepcopies the passed arguments
+
+        :param method_name: Name of the method to be called on each ext
+        :param args: Arguments to be passed to all called functions
+        :param kwargs: Key-word arguments to be passed to all called functions
+                        if `"deepcopy" == True` is present in kwargs the
+                        args and kwargs are deepcopied before passing it
+                        to each called function.
+        """
+        deepcopy = kwargs.pop("deepcopy", False)
+        ret = []
+        for ext in self.extensions:
+            try:
+                if hasattr(ext.obj, method_name):
+                    method = getattr(ext.obj, method_name)
+                    if deepcopy:
+                        copied_args = [copy.deepcopy(arg) for arg in args]
+                        copied_kwargs = copy.deepcopy(kwargs)
+                        ret.append(method(*copied_args, **copied_kwargs))
+                    else:
+                        ret.append(method(*args, **kwargs))
+            except SystemExit:
+                raise
+            except KeyboardInterrupt:
+                raise
+            except:     # catch any exception pylint: disable=W0702
+                stacktrace.log_exc_info(sys.exc_info(),
+                                        logger='avocado.app.debug')
+                LOG_UI.error('Error running method "%s" of plugin "%s": %s',
+                             method_name, ext.name, sys.exc_info()[1])
+        return ret
+
+    def map_method(self, method_name, *args):
+        """
+        Maps method_name on each extension in case the extension has the attr
+
+        :param method_name: Name of the method to be called on each ext
+        :param args: Arguments to be passed to all called functions
+        """
+        for ext in self.extensions:
+            try:
+                if hasattr(ext.obj, method_name):
+                    method = getattr(ext.obj, method_name)
+                    method(*args)
+            except SystemExit:
+                raise
+            except KeyboardInterrupt:
+                raise
+            except:     # catch any exception pylint: disable=W0702
+                stacktrace.log_exc_info(sys.exc_info(),
+                                        logger='avocado.app.debug')
+                LOG_UI.error('Error running method "%s" of plugin "%s": %s',
+                             method_name, ext.name, sys.exc_info()[1])
+
+    def __getitem__(self, name):
+        for ext in self.extensions:
+            if ext.name == name:
+                return ext
+        raise KeyError
+
+    def __iter__(self):
+        return iter(self.extensions)

--- a/avocado/core/settings_dispatcher.py
+++ b/avocado/core/settings_dispatcher.py
@@ -20,8 +20,7 @@ will be read by the other dispatchers, while still being a dispatcher
 for configuration sources.
 """
 
-
-from stevedore import ExtensionManager
+from .extension_manager import ExtensionManager
 
 
 class SettingsDispatcher(ExtensionManager):
@@ -35,7 +34,4 @@ class SettingsDispatcher(ExtensionManager):
     """
 
     def __init__(self):
-        super(SettingsDispatcher, self).__init__('avocado.plugins.settings',
-                                                 invoke_on_load=True,
-                                                 invoke_kwds={},
-                                                 propagate_map_exceptions=True)
+        super(SettingsDispatcher, self).__init__('avocado.plugins.settings')

--- a/contrib/docker/Dockerfile.debian
+++ b/contrib/docker/Dockerfile.debian
@@ -31,7 +31,6 @@ RUN apt-get update && \
 	    python-pip \
 	    python-pystache \
 	    python-setuptools \
-	    python-stevedore  \
 	    python-yaml && \
     echo install extra avocado packages && \
     apt-get install -y --no-install-recommends \

--- a/docs/source/Plugins.rst
+++ b/docs/source/Plugins.rst
@@ -69,10 +69,10 @@ output.
 Registering Plugins
 ~~~~~~~~~~~~~~~~~~~
 
-Avocado makes use of the `Stevedore`_ library to load and activate plugins.
-Stevedore itself uses `setuptools`_ and its `entry points`_ to register
-and find Python objects. So, to make your new plugin visible to Avocado, you need
-to add to your setuptools based `setup.py` file something like::
+Avocado makes use of the `setuptools`_ and its `entry points`_ to
+register and find Python objects. So, to make your new plugin visible
+to Avocado, you need to add to your setuptools based `setup.py` file
+something like::
 
  setup(name='mypluginpack',
  ...
@@ -179,18 +179,16 @@ the standard Avocado ``job.prepost.jobscripts`` does.
 Wrap Up
 ~~~~~~~
 
-We have briefly discussed the making of Avocado plugins. We recommend
-the `Stevedore documentation`_ and also a look at the
-:mod:`avocado.core.plugin_interfaces` module for the various plugin interface definitions.
+We have briefly discussed the making of Avocado plugins.  We recommend
+you look at the `entry points`_ documentation and also take a look at
+the :mod:`avocado.core.plugin_interfaces` module for the various
+plugin interface definitions.
 
 Some plugins examples are available in the `Avocado source tree`_, under ``examples/plugins``.
 
 Finally, exploring the real plugins shipped with Avocado in :mod:`avocado.plugins`
 is the final "documentation" source.
 
-
-.. _Stevedore: https://github.com/openstack/stevedore
-.. _Stevedore documentation: http://docs.openstack.org/developer/stevedore/index.html
 .. _setuptools: https://setuptools.readthedocs.io/en/latest/
 .. _entry points: https://setuptools.readthedocs.io/en/latest/pkg_resources.html#entry-points
 .. _Avocado source tree: https://github.com/avocado-framework/avocado/tree/master/examples/plugins

--- a/docs/source/SubclassingAvocado.rst
+++ b/docs/source/SubclassingAvocado.rst
@@ -100,10 +100,6 @@ To (non-intrusively) install your module, use::
     avocado-framework 55.0 is already the active version in easy-install.pth
 
     Using /home/apahim/git/avocado
-    Searching for stevedore==1.25.0
-    Best match: stevedore 1.25.0
-    Adding stevedore 1.25.0 to easy-install.pth file
-
     Using /usr/lib/python2.7/site-packages
     Searching for six==1.10.0
     Best match: six 1.10.0

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -90,7 +90,6 @@ BuildRequires: python3-lxml
 BuildRequires: python3-psutil
 BuildRequires: python3-resultsdb_api
 BuildRequires: python3-setuptools
-BuildRequires: python3-stevedore
 BuildRequires: python3-pycdlib
 
 %if %{with_tests}
@@ -116,7 +115,6 @@ Requires: gdb-gdbserver
 Requires: procps-ng
 Requires: python3
 Requires: python3-setuptools
-Requires: python3-stevedore
 Requires: python3-pycdlib
 
 %description -n python3-%{srcname}

--- a/requirements-selftests.txt
+++ b/requirements-selftests.txt
@@ -16,9 +16,6 @@ psutil==5.4.7
 # but is necessary for selftests
 pycdlib==1.6.0
 
-# stevedore for loading "new style" plugins
-stevedore==1.29.0
-
 # this is a workaround since easy_install cannot install
 # libvirt-python properly with the the current process
 # in make develop. The proper solution would be migrate

--- a/selftests/functional/test_streams.py
+++ b/selftests/functional/test_streams.py
@@ -56,8 +56,6 @@ class StreamsTest(unittest.TestCase):
         for cmd, env in cmds:
             result = process.run(cmd, env=env, shell=True)
             self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
-            self.assertIn(b"stevedore.extension: found extension EntryPoint.parse",
-                          result.stdout)
             # If using the Python interpreter, Avocado won't know about it
             if AVOCADO.startswith(sys.executable):
                 cmd_in_log = cmd[len(sys.executable)+1:]
@@ -75,10 +73,6 @@ class StreamsTest(unittest.TestCase):
                'passtest.py' % (AVOCADO, self.tmpdir))
         result = process.run(cmd)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
-        self.assertNotIn(b"stevedore.extension: found extension EntryPoint.parse",
-                         result.stdout)
-        self.assertNotIn(b"stevedore.extension: found extension EntryPoint.parse",
-                         result.stderr)
         # If using the Python interpreter, Avocado won't know about it
         if AVOCADO.startswith(sys.executable):
             cmd_in_log = cmd[len(sys.executable)+1:]

--- a/selftests/unit/test_dispatcher.py
+++ b/selftests/unit/test_dispatcher.py
@@ -1,21 +1,21 @@
 import unittest
 
-from avocado.core import dispatcher
+from avocado.core.dispatcher import EnabledExtensionManager
 
 
 class DispatcherTest(unittest.TestCase):
 
     def test_order(self):
+        """
+        Simply checks that the default order is based on the extension names
+        """
         namespaces = ['avocado.plugins.cli',
                       'avocado.plugins.cli.cmd',
                       'avocado.plugins.job.prepost',
                       'avocado.plugins.result']
         for namespace in namespaces:
-            names = dispatcher.Dispatcher(namespace).names()
             ext_names = [ext.name for ext in
-                         dispatcher.Dispatcher(namespace).extensions]
-            self.assertEqual(names, ext_names)
-            self.assertEqual(names, sorted(names))
+                         EnabledExtensionManager(namespace).extensions]
             self.assertEqual(ext_names, sorted(ext_names))
 
 

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,6 @@ def get_long_description():
     return readme_contents
 
 
-INSTALL_REQUIREMENTS = ['stevedore>=0.14', 'setuptools']
-
 if __name__ == '__main__':
     # Force "make develop" inside the "readthedocs.org" environment
     if os.environ.get("READTHEDOCS") and "install" in sys.argv:
@@ -108,4 +106,4 @@ if __name__ == '__main__':
           zip_safe=False,
           test_suite='selftests',
           python_requires='>=3.4',
-          install_requires=INSTALL_REQUIREMENTS)
+          install_requires=['setuptools'])


### PR DESCRIPTION
Avocado uses the stevedore library, which has origins in OpenStack, as
a way to find plugins and activate them.  It's very useful, but
Avocado itself only uses a very small part of it, and actually extends
most of what it uses.

Given that stevedore itself is a simple wrapper around setuptools
(pkg_resources, really), this simply adds the little code we need
around pkg_resources.

The benefits is that the core Avocado application now depends only on
Python and setuptools (which is bundled together on many systems).

Reference: https://trello.com/c/vCgzJ02N
Signed-off-by: Cleber Rosa <crosa@redhat.com>

---

Changes from v1 (#3182):
 * Added (back) docstrings to `enabled()`, both in `extension_manager` and `dispatcher` modules.
 * Removed mention to Stevedore in the Wrap up section of the docs. 