### PR TITLE
Python Unittests: add support for Avocado tags

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -688,8 +688,8 @@ class FileLoader(TestLoader):
                 test_path = test_path[:-3]
             test_module_name = os.path.relpath(test_path)
             test_module_name = test_module_name.replace(os.path.sep, ".")
-            candidates = ["%s.%s.%s" % (test_module_name, klass, method)
-                          for method in methods]
+            candidates = [("%s.%s.%s" % (test_module_name, klass, method), tags)
+                          for (method, tags) in methods]
             if subtests_filter:
                 result += [_ for _ in candidates if subtests_filter.search(_)]
             else:
@@ -745,8 +745,9 @@ class FileLoader(TestLoader):
                 os.chdir(old_dir)
             if python_unittests:
                 return [(test.PythonUnittest, {"name": name,
-                                               "test_dir": py_test_dir})
-                        for name in python_unittests]
+                                               "test_dir": py_test_dir,
+                                               "tags": tags})
+                        for (name, tags) in python_unittests]
             else:
                 return self._make_simple_or_broken_test(test_path,
                                                         subtests_filter,

--- a/avocado/core/safeloader.py
+++ b/avocado/core/safeloader.py
@@ -621,14 +621,12 @@ def find_python_unittests(path):
     result = collections.OrderedDict()
 
     for klass in module.iter_classes():
-
+        docstring = ast.get_docstring(klass)
         parents = klass.bases
         is_unittest = module.is_matching_klass(klass)
 
-        info = [st.name for st in klass.body if
-                isinstance(st, ast.FunctionDef) and
-                st.name.startswith('test')]
-        info = data_structures.ordered_list_unique(info)
+        info = get_methods_info(klass.body,
+                                get_docstring_directives_tags(docstring))
 
         # Searching the parents in the same module
         for parent in parents[:]:

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -1261,7 +1261,8 @@ class PythonUnittest(ExternalRunnerTest):
     Python unittest test
     """
     def __init__(self, name, params=None, base_logdir=None, job=None,
-                 test_dir=None, python_unittest_module=None):
+                 test_dir=None, python_unittest_module=None,
+                 tags=None):    # pylint: disable=W0613
         runner = "%s -m unittest -q -c" % sys.executable
         external_runner = ExternalRunnerSpec(runner, "test", test_dir)
         super(PythonUnittest, self).__init__(name, params, base_logdir, job,

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -206,6 +206,10 @@ from unittest import TestCase
 from . import something
 
 class SampleTest(TestCase):
+    '''
+    :avocado: tags=flattag
+    :avocado: tags=foo:bar
+    '''
     def test(self):
         pass
 """
@@ -416,6 +420,7 @@ class LoaderTest(unittest.TestCase):
         tests = self.loader.discover(python_unittest.path)
         exp = [(test.PythonUnittest,
                 {"name": "python_unittest.SampleTest.test",
+                 "tags": {"flattag": None, "foo": {"bar"}},
                  "test_dir": os.path.dirname(python_unittest.path)})]
         self.assertEqual(tests, exp)
 


### PR DESCRIPTION
This adds support for the Avocado tags mechanism to plain Python
Unittests.  It's possible to filter tests based on both "flat" and
"key:val" tags.

Signed-off-by: Cleber Rosa <crosa@redhat.com>