### PR TITLE
Add the entry point info to the load failures list

### DIFF
--- a/avocado/core/extension_manager.py
+++ b/avocado/core/extension_manager.py
@@ -62,7 +62,7 @@ class ExtensionManager:
                 plugin = ep.load()
                 obj = plugin(**invoke_kwds)
             except Exception as exception:
-                self.load_failures.append(exception)
+                self.load_failures.append((ep, exception))
             else:
                 ext = Extension(ep.name, ep, plugin, obj)
                 if self.enabled(ext):  # lgtm [py/init-calls-subclass]


### PR DESCRIPTION
The original (stevedore based) implementation would also put
the entry point information to the list of load failures.

This is needed by avocado.core.output.log_plugin_failures(),
and causes a crash if any plugin fails to load.  Let's put
it back then.

Reference: https://github.com/avocado-framework/avocado/pull/3192#issuecomment-510831956
Signed-off-by: Cleber Rosa <crosa@redhat.com>