### PR TITLE
Move extension manager with disable/order support to its own module

### DIFF
--- a/avocado/core/dispatcher.py
+++ b/avocado/core/dispatcher.py
@@ -20,39 +20,7 @@ dispatcher that these depend upon:
 :class:`avocado.core.settings_dispatcher.SettingsDispatcher`
 """
 
-from .extension_manager import ExtensionManager
-from .settings import settings
-from .settings import SettingsError
-
-
-class EnabledExtensionManager(ExtensionManager):
-
-    def __init__(self, namespace, invoke_kwds=None):
-        super(EnabledExtensionManager, self).__init__(namespace, invoke_kwds)
-        configured_order = settings.get_value(self.settings_section(), "order",
-                                              key_type=list, default=[])
-        ordered = []
-        for name in configured_order:
-            for ext in self.extensions:
-                if name == ext.name:
-                    ordered.append(ext)
-        for ext in self.extensions:
-            if ext not in ordered:
-                ordered.append(ext)
-        self.extensions = ordered
-
-    def enabled(self, extension):
-        """
-        Checks configuration for explicit mention of plugin in a disable list
-
-        If configuration section or key doesn't exist, it means no plugin
-        is disabled.
-        """
-        try:
-            disabled = settings.get_value('plugins', 'disable', key_type=list)
-            return self.fully_qualified_name(extension) not in disabled
-        except SettingsError:
-            return True
+from .enabled_extension_manager import EnabledExtensionManager
 
 
 class CLIDispatcher(EnabledExtensionManager):

--- a/avocado/core/enabled_extension_manager.py
+++ b/avocado/core/enabled_extension_manager.py
@@ -1,0 +1,51 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2015-2019
+# Author: Cleber Rosa <cleber@redhat.com>
+
+"""
+Extension manager with disable/ordering support
+"""
+
+from .extension_manager import ExtensionManager
+from .settings import settings
+from .settings import SettingsError
+
+
+class EnabledExtensionManager(ExtensionManager):
+
+    def __init__(self, namespace, invoke_kwds=None):
+        super(EnabledExtensionManager, self).__init__(namespace, invoke_kwds)
+        configured_order = settings.get_value(self.settings_section(), "order",
+                                              key_type=list, default=[])
+        ordered = []
+        for name in configured_order:
+            for ext in self.extensions:
+                if name == ext.name:
+                    ordered.append(ext)
+        for ext in self.extensions:
+            if ext not in ordered:
+                ordered.append(ext)
+        self.extensions = ordered
+
+    def enabled(self, extension):
+        """
+        Checks configuration for explicit mention of plugin in a disable list
+
+        If configuration section or key doesn't exist, it means no plugin
+        is disabled.
+        """
+        try:
+            disabled = settings.get_value('plugins', 'disable', key_type=list)
+            return self.fully_qualified_name(extension) not in disabled
+        except SettingsError:
+            return True


### PR DESCRIPTION
This class is not really a dispatcher designed to be used standalone,
but a extension manager with additional features that can be used as
the basis for real dispatchers.

If it didn't depend on the settings module, it'd be a good candidate
for living in the avocado.core.extension_manager module, but to avoid
circular dependencies there, it needs to live elsewhere.  With those
things in mind, let's put it in its own module.

Signed-off-by: Cleber Rosa <crosa@redhat.com>