### PR TITLE
Temporarily fix a stack overflow problem in python 3.7

### DIFF
--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -27,6 +27,9 @@ from ..utils import path as utils_path
 from .settings import settings
 
 
+#: Handle cases of logging exceptions which will lead to recursion error
+logging.raiseExceptions = False
+
 #: Pre-defined Avocado human UI logger
 LOG_UI = logging.getLogger("avocado.app")
 #: Pre-defined Avocado job/test logger


### PR DESCRIPTION
It turns out there are three separate errors on three different levels
playing together that I can call the good, the bad, and the ugly. The
ugly one is the entire python 3.7 interpreter crashing as described here:

https://bugs.python.org/issue36272

Python crashing instead of handling the recursion with RecursionError is
then fixed in a patch like:

diff --git a/Lib/logging/__init__.py b/Lib/logging/__init__.py
index b4659af7cc..7457549cb9 100644
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -1094,6 +1094,8 @@ class StreamHandler(Handler):
             # issue 35046: merged two stream.writes into one.
             stream.write(msg + self.terminator)
             self.flush()
+        except RecursionError as e:
+            raise
         except Exception:
             self.handleError(record)

which was not yet available at time of writing this but merged. This can
handle the ugly crashing that made us go all the way to core dumps.

The bad is then the recursion part which happens because of the far too
bold and rather invasive output handling of avocado's output module:

    def fake_outputs(self):
        """
        Replace sys.stdout/sys.stderr with in-memory-objects
        """
        sys.stdout = _StdOutputFile(True, self.records)
        sys.stderr = _StdOutputFile(False, self.records)

This replaces the standard outputs where the standard logging module,
unaware of such thing, decides to print errors encountered during
logging. This then results in avocado handling the to-be-logged error
but it passes the ball back to the logging module which passes it back
to stout/stderr. A clear question here should be why doesn't this happen
all the time? The reason is that the logging module decides to print to
stdout when it has encountered error during logging (thus believing
logging is not an option to speak its mind anymore) and the error here
seems to be related to reentrancy as in:

https://en.wikipedia.org/wiki/Reentrancy_%28computing%29

This re-entrancy however is a result of handling file descriptors
multiple times which comes as a result of the good guy which is a
resource warning

ResourceWarning("unclosed file <_io.FileIO name=26 mode='rb' closefd=True>"

printed to the log file which is busy outputting other stuff at the same
moment. This resource warning happens only sometimes mostly because if
comes from a file which is being closed (and garbage collected) at this
exact time. I am not sure why the resource warning would come before the
file closes and the intentions are clearly good (the good error) but
this leads to the rise of the bad error and in turn of the ugly error.

Signed-off-by: Plamen Dimitrov <pdimitrov@pevogam.com>