### PR TITLE
optional_plugins/runner_remote: Drop stderr from remote version check

### DIFF
--- a/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
+++ b/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
@@ -378,7 +378,7 @@ class RemoteTestRunner(TestRunner):
         if result.exit_status == 127:
             return (False, None)
 
-        match = self.remote_version_re.findall(result.stderr + result.stdout)
+        match = self.remote_version_re.findall(result.stdout)
         if match is None:
             return (False, None)
 


### PR DESCRIPTION
With python 3, avocado remote runner may fail with "Avocado job failed:
JobError: Remote machine does not seem to have avocado installed" if
stderr is non-empty. The version check includes stderr since python 2
writes the version output to stderr. Since avocado versions over 69.0 only
support python 3, drop stderr from the check.

Signed-off-by: John Allen <john.allen@amd.com>