### PR TITLE
Python unittest support: do not remove extra info (such as tags)

### DIFF
--- a/avocado/core/safeloader.py
+++ b/avocado/core/safeloader.py
@@ -639,10 +639,9 @@ def find_python_unittests(path):
                                                        is_unittest, module_name,
                                                        class_name,
                                                        _determine_match_unittest)
-            methods = [i[0] for i in _info]
             if _info:
                 parents.remove(parent)
-                info.extend(methods)
+                info.extend(_info)
             if _is_unittest is not is_unittest:
                 is_unittest = _is_unittest
 
@@ -685,9 +684,8 @@ def find_python_unittests(path):
                                                        module_name,
                                                        class_name,
                                                        _determine_match_unittest)
-            methods = [i[0] for i in _info]
             if _info:
-                info.extend(methods)
+                info.extend(_info)
             if _is_unittest is not is_unittest:
                 is_unittest = _is_unittest
 

--- a/selftests/unit/test_safeloader.py
+++ b/selftests/unit/test_safeloader.py
@@ -65,6 +65,25 @@ class ThirdChild(Test, SecondChild):
 """
 
 
+RECURSIVE_DISCOVERY_UNITTEST = """
+from unittest import TestCase
+
+class BaseClass(TestCase):
+    '''
+    :avocado: tags=base
+    '''
+    def test_basic(self):
+        pass
+
+class Child(BaseClass):
+    '''
+    :avocado: tags=child
+    '''
+    def test_child(self):
+        pass
+"""
+
+
 def get_this_file():
     this_file = __file__
     if this_file.endswith('.py'):
@@ -290,7 +309,8 @@ class FindClassAndMethods(UnlimitedDiff):
                                     'test_with_base_class',
                                     'test_with_pattern_and_base_class',
                                     'test_methods_order',
-                                    'test_recursive_discovery'],
+                                    'test_recursive_discovery',
+                                    'test_recursive_discovery_unittest'],
             'UnlimitedDiff': ['setUp']
         }
         found = safeloader.find_class_and_methods(get_this_file())
@@ -332,7 +352,8 @@ class FindClassAndMethods(UnlimitedDiff):
                                     'test_with_base_class',
                                     'test_with_pattern_and_base_class',
                                     'test_methods_order',
-                                    'test_recursive_discovery'],
+                                    'test_recursive_discovery',
+                                    'test_recursive_discovery_unittest'],
             'UnlimitedDiff': []
         }
         found = safeloader.find_class_and_methods(get_this_file(),
@@ -346,7 +367,8 @@ class FindClassAndMethods(UnlimitedDiff):
                                     'test_with_base_class',
                                     'test_with_pattern_and_base_class',
                                     'test_methods_order',
-                                    'test_recursive_discovery'],
+                                    'test_recursive_discovery',
+                                    'test_recursive_discovery_unittest'],
         }
         found = safeloader.find_class_and_methods(get_this_file(),
                                                   base_class='UnlimitedDiff')
@@ -390,6 +412,17 @@ class FindClassAndMethods(UnlimitedDiff):
                                    ('test_second_child', {}),
                                    ('test_first_child', {}),
                                    ('test_basic', {})]}
+        self.assertEqual(expected, tests)
+
+    def test_recursive_discovery_unittest(self):
+        temp_test = script.TemporaryScript(
+            'recursive_discovery_unittest.py',
+            RECURSIVE_DISCOVERY_UNITTEST)
+        temp_test.save()
+        tests = safeloader.find_python_unittests(temp_test.path)
+        expected = {'BaseClass': [('test_basic', {'base': None})],
+                    'Child': [('test_child', {'child': None}),
+                              ('test_basic', {'base': None})]}
         self.assertEqual(expected, tests)
 
 


### PR DESCRIPTION
On c26a93675 support for tags on Python unittests was added.  But,
when base classes are used, the extra info was being discarded and
only method names were being returned.  Let's fix that.

Signed-off-by: Cleber Rosa <crosa@redhat.com>