### PR TITLE
[RFC] Introduce avocado.core.resolver as an alternative to loader

### DIFF
--- a/avocado/core/plugin_interfaces.py
+++ b/avocado/core/plugin_interfaces.py
@@ -264,3 +264,24 @@ class Varianter(Plugin):
         :param kwargs: Other free-form arguments
         :rtype: str
         """
+
+
+class Resolver(Plugin):
+    """
+    Base plugin interface for resolving test interfaces into test factories
+    """
+
+    @abc.abstractmethod
+    def resolve(self, reference):
+        """
+        Resolves the given reference into a :class:`resolver.ReferenceResolution`
+
+        :param reference: a specification that can eventually be resolved
+                          into a test (in the form of a
+                          :class:`avocado.core.nrunner.Runnable`)
+        :type reference: str
+        :returns: the result of the resolution process, containing the
+                  success, failure or error, along with zero or more
+                  :class:`avocado.core.nrunner.Runnable`s
+        :rtype: :class:`avocado.core.resolver.ReferenceResolution`
+        """

--- a/avocado/plugins/plugins.py
+++ b/avocado/plugins/plugins.py
@@ -16,6 +16,7 @@ Plugins information plugin
 """
 
 from avocado.core import dispatcher
+from avocado.core.resolver import Resolver
 from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLICmd
 from avocado.utils import astring
@@ -51,7 +52,9 @@ class Plugins(CLICmd):
              ('Plugins that generate job result based on job/test events '
               '(result_events):')),
             (dispatcher.VarianterDispatcher(),
-             'Plugins that generate test variants (varianter): ')
+             'Plugins that generate test variants (varianter): '),
+            (Resolver(),
+             'Plugins that resolve test references: ')
         ]
         for plugins_active, msg in plugin_types:
             LOG_UI.info(msg)

--- a/avocado/plugins/resolve.py
+++ b/avocado/plugins/resolve.py
@@ -1,0 +1,122 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2019
+# Author: Cleber Rosa <crosa@redhat.com>
+
+from avocado.core.plugin_interfaces import CLICmd
+from avocado.core import resolver
+from avocado.core import output
+from avocado.core.output import LOG_UI
+
+from avocado.utils import astring
+
+
+class Resolve(CLICmd):
+
+    """
+    Implements the avocado 'resolve' subcommand
+    """
+
+    name = 'resolve'
+    description = 'Resolves test references'
+
+    def configure(self, parser):
+        parser = super(Resolve, self).configure(parser)
+        parser.add_argument('reference', type=str, default=[], nargs='*',
+                            help="Resolve given test references")
+        parser.add_argument('-V', '--verbose',
+                            action='store_true', default=False,
+                            help=("Show extra information on resolution, besides "
+                                  "sucessful resolutions"))
+
+    def run(self, args):
+        references = getattr(args, 'reference', [])
+        resolutions = resolver.resolve(references)
+        matrix, stats, tag_stats, resolution_matrix = self._get_resolution_matrix(resolutions)
+        self._display(matrix, stats, tag_stats, resolution_matrix, args.verbose)
+
+    def _get_resolution_matrix(self, resolutions):
+        test_matrix = []
+        resolution_matrix = []
+        decorator_mapping = {
+            resolver.ReferenceResolutionResult.SUCCESS: output.TERM_SUPPORT.healthy_str,
+            resolver.ReferenceResolutionResult.NOTFOUND: output.TERM_SUPPORT.fail_header_str,
+            resolver.ReferenceResolutionResult.ERROR: output.TERM_SUPPORT.fail_header_str
+            }
+
+        # keyed by runnable kind
+        stats = {}
+        # by tag
+        tag_stats = {}
+
+        for result in resolutions:
+            decorator = decorator_mapping.get(result.result,
+                                              output.TERM_SUPPORT.warn_header_str)
+            if result.resolutions:
+                for resolution in result.resolutions:
+                    type_label = resolution.kind
+                    if type_label.lower() not in stats:
+                        stats[type_label.lower()] = 0
+                    stats[type_label.lower()] += 1
+                    type_label = decorator(type_label)
+                    test_matrix.append((type_label, resolution.uri))
+            else:  # assuming that empty resolutions mean a NOTFOUND, ERROR, etc
+                if result.info is None:
+                    result_info = ''
+                else:
+                    result_info = result.info
+                if result.result == resolver.ReferenceResolutionResult.SUCCESS:
+                    if not result_info:
+                        result_info = "%i resolutions" % len(result.resolutions)
+                resolution_matrix.append((decorator(result.origin),
+                                          result.reference,
+                                          result_info))
+
+        return test_matrix, stats, tag_stats, resolution_matrix
+
+    def _display(self, test_matrix, stats, tag_stats, resolution_matrix, verbose=False):
+        header = None
+        if verbose:
+            header = (output.TERM_SUPPORT.header_str('Type'),
+                      output.TERM_SUPPORT.header_str('Test'))
+
+        if test_matrix:
+            for line in astring.iter_tabular_output(test_matrix,
+                                                    header=header,
+                                                    strip=True):
+                LOG_UI.debug(line)
+
+        if verbose:
+
+            if stats:
+                LOG_UI.info("")
+                LOG_UI.info("TEST TYPES SUMMARY")
+                LOG_UI.info("==================")
+                for key in sorted(stats):
+                    LOG_UI.info("%s: %s", key, stats[key])
+
+            if tag_stats:
+                LOG_UI.info("")
+                LOG_UI.info("TEST TAGS SUMMARY")
+                LOG_UI.info("=================")
+                for key in sorted(tag_stats):
+                    LOG_UI.info("%s: %s", key, tag_stats[key])
+
+            if resolution_matrix:
+                resolution_header = (output.TERM_SUPPORT.header_str('Resolver'),
+                                     output.TERM_SUPPORT.header_str('Reference'),
+                                     output.TERM_SUPPORT.header_str('Info'))
+                LOG_UI.info("")
+                for line in astring.iter_tabular_output(resolution_matrix,
+                                                        header=resolution_header,
+                                                        strip=True):
+                    LOG_UI.info(line)

--- a/avocado/plugins/resolver_avocado_instrumented.py
+++ b/avocado/plugins/resolver_avocado_instrumented.py
@@ -1,0 +1,52 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2019
+# Authors: Cleber Rosa <crosa@redhat.com>
+
+"""
+Test resolver for Avocado Instrumented tests
+"""
+
+import os
+
+from avocado.core.plugin_interfaces import Resolver
+from avocado.core.safeloader import find_avocado_tests
+from avocado.core.resolver import ReferenceResolution
+from avocado.core.resolver import ReferenceResolutionResult
+from avocado.core.nrunner import Runnable
+
+
+class AvocadoInstrumentedResolver(Resolver):
+
+    name = 'avocado-instrumented'
+    description = 'Test resolver for Avocado Instrumented tests'
+
+    @staticmethod
+    def resolve(reference):
+        if ':' in reference:
+            module_path, _ = reference.split(':', 1)
+        else:
+            module_path = reference
+        if os.path.isfile(module_path) and os.access(module_path, os.R_OK):
+            # disabled tests not needed here
+            class_methods_info, _ = find_avocado_tests(module_path)
+            runnables = []
+            for klass, methods_tags in class_methods_info.items():
+                for (method, _) in methods_tags:
+                    uri = "%s:%s.%s" % (module_path, klass, method)
+                    runnables.append(Runnable('avocado-instrumented', uri))
+            if runnables:
+                return ReferenceResolution(reference,
+                                           ReferenceResolutionResult.SUCCESS,
+                                           runnables)
+        return ReferenceResolution(reference,
+                                   ReferenceResolutionResult.NOTFOUND)

--- a/avocado/plugins/resolver_exec_test.py
+++ b/avocado/plugins/resolver_exec_test.py
@@ -1,0 +1,40 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2019
+# Authors: Cleber Rosa <crosa@redhat.com>
+
+"""
+Test resolver for executable files
+"""
+
+import os
+
+from avocado.core.plugin_interfaces import Resolver
+from avocado.core.resolver import ReferenceResolution
+from avocado.core.resolver import ReferenceResolutionResult
+from avocado.core.nrunner import Runnable
+
+
+class ExecTestResolver(Resolver):
+
+    name = 'exec-test'
+    description = 'Test resolver for executable files to be handled as tests'
+
+    @staticmethod
+    def resolve(reference):
+        if os.path.isfile(reference) and os.access(reference, os.X_OK):
+            return ReferenceResolution(reference,
+                                       ReferenceResolutionResult.SUCCESS,
+                                       [Runnable('exec-test', reference)])
+        else:
+            return ReferenceResolution(reference,
+                                       ReferenceResolutionResult.NOTFOUND)

--- a/avocado/plugins/resolver_python_unittest.py
+++ b/avocado/plugins/resolver_python_unittest.py
@@ -1,0 +1,52 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2019
+# Authors: Cleber Rosa <crosa@redhat.com>
+
+"""
+Test resolver for executable files
+"""
+
+import os
+
+from avocado.core.plugin_interfaces import Resolver
+from avocado.core.safeloader import find_python_unittests
+from avocado.core.resolver import ReferenceResolution
+from avocado.core.resolver import ReferenceResolutionResult
+from avocado.core.nrunner import Runnable
+
+
+class PythonUnittestResolver(Resolver):
+
+    name = 'python-unittest'
+    description = 'Test resolver for Python Unittests'
+
+    @staticmethod
+    def resolve(reference):
+        if os.path.isfile(reference) and os.access(reference, os.R_OK):
+            class_methods = find_python_unittests(reference)
+            if class_methods:
+                runnables = []
+                mod = os.path.relpath(reference)
+                if mod.endswith('.py'):
+                    mod = mod[:-3]
+                mod = mod.replace(os.path.sep, ".")
+                for klass, meths in class_methods.items():
+                    for (meth, _) in meths:
+                        runnables.append(Runnable('python-unittest',
+                                                  '%s.%s.%s' % (mod, klass, meth)))
+            return ReferenceResolution(reference,
+                                       ReferenceResolutionResult.SUCCESS,
+                                       runnables)
+        else:
+            return ReferenceResolution(reference,
+                                       ReferenceResolutionResult.NOTFOUND)

--- a/optional_plugins/glib/avocado_glib/__init__.py
+++ b/optional_plugins/glib/avocado_glib/__init__.py
@@ -26,7 +26,11 @@ from avocado.core import loader
 from avocado.core import output
 from avocado.core import test
 from avocado.core.plugin_interfaces import CLI
+from avocado.core.plugin_interfaces import Resolver
 from avocado.core.settings import settings
+from avocado.core.resolver import ReferenceResolution
+from avocado.core.resolver import ReferenceResolutionResult
+from avocado.core.nrunner import Runnable
 
 
 class GLibTest(test.SimpleTest):
@@ -119,6 +123,36 @@ class GLibLoader(loader.TestLoader):
     def get_decorator_mapping():
         return {GLibTest: output.TERM_SUPPORT.healthy_str,
                 NotGLibTest: output.TERM_SUPPORT.fail_header_str}
+
+
+class GLibResolver(Resolver):
+
+    name = 'glib'
+    description = 'Test resolver for GLib tests'
+
+    @staticmethod
+    def resolve(reference):
+        if (os.path.isfile(reference) and
+                os.access(reference, os.R_OK) and
+                settings.get_value("plugins.glib", "unsafe", bool, False)):
+            try:
+                cmd = '%s -l' % (reference)
+                result = process.run(cmd)
+            except Exception as details:
+                return ReferenceResolution(reference,
+                                           ReferenceResolutionResult.ERROR,
+                                           info=details,
+                                           origin=GLibResolver.name)
+            runnables = []
+            for test_item in result.stdout_text.splitlines():
+                uri = "%s:%s" % (reference, test_item)
+                runnables.append(Runnable('glib', uri))
+            if runnables:
+                return ReferenceResolution(reference,
+                                           ReferenceResolutionResult.SUCCESS,
+                                           runnables)
+        return ReferenceResolution(reference,
+                                   ReferenceResolutionResult.NOTFOUND)
 
 
 class GLibCLI(CLI):

--- a/optional_plugins/glib/setup.py
+++ b/optional_plugins/glib/setup.py
@@ -28,5 +28,8 @@ setup(name='avocado-framework-plugin-glib',
       entry_points={
           'avocado.plugins.cli': [
               'glib = avocado_glib:GLibCLI',
+          ],
+          'avocado.plugins.resolver': [
+              'glib = avocado_glib:GLibResolver'
           ]}
       )

--- a/optional_plugins/robot/avocado_robot/__init__.py
+++ b/optional_plugins/robot/avocado_robot/__init__.py
@@ -23,6 +23,11 @@ from avocado.core import loader
 from avocado.core import output
 from avocado.core import test
 from avocado.core.plugin_interfaces import CLI
+from avocado.core.plugin_interfaces import Resolver
+from avocado.core.resolver import ReferenceResolution
+from avocado.core.resolver import ReferenceResolutionResult
+# FIXME: needed when implementation becomes non-stub
+# from avocado.core.nrunner import Runnable
 from robot import run
 from robot.errors import DataError
 from robot.parsing.model import TestData
@@ -141,6 +146,18 @@ class RobotLoader(loader.TestLoader):
     def get_decorator_mapping():
         return {RobotTest: output.TERM_SUPPORT.healthy_str,
                 NotRobotTest: output.TERM_SUPPORT.fail_header_str}
+
+
+class RobotResolver(Resolver):
+
+    name = 'robot'
+    description = 'Test resolver for Robot tests'
+
+    @staticmethod
+    def resolve(reference):
+        # FIXME: stub implementation
+        return ReferenceResolution(reference,
+                                   ReferenceResolutionResult.NOTFOUND)
 
 
 class RobotCLI(CLI):

--- a/optional_plugins/robot/setup.py
+++ b/optional_plugins/robot/setup.py
@@ -28,5 +28,8 @@ setup(name='avocado-framework-plugin-robot',
       entry_points={
           'avocado.plugins.cli': [
               'robot = avocado_robot:RobotCLI',
+          ],
+          'avocado.plugins.resolver': [
+              'glib = avocado_glib:GLibResolver'
           ]}
       )

--- a/selftests/functional/test_resolver.py
+++ b/selftests/functional/test_resolver.py
@@ -1,0 +1,52 @@
+import stat
+import unittest
+
+from avocado.utils import script
+from avocado.utils import process
+
+from .. import AVOCADO
+
+# Use the same definitions from loader to make sure the behavior
+# is also the same
+from .test_loader import SIMPLE_TEST as EXEC_TEST
+from .test_loader import AVOCADO_TEST_OK as AVOCADO_INSTRUMENTED_TEST
+
+
+class ResolverFunctional(unittest.TestCase):
+
+    MODE_0664 = (stat.S_IRUSR | stat.S_IWUSR |
+                 stat.S_IRGRP | stat.S_IWGRP |
+                 stat.S_IROTH)
+
+    MODE_0775 = (stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR |
+                 stat.S_IRGRP | stat.S_IWGRP | stat.S_IXGRP |
+                 stat.S_IROTH | stat.S_IXOTH)
+
+    def test_exec_test(self):
+        name = 'executable-test'
+        with script.TemporaryScript(name, EXEC_TEST,
+                                    name, self.MODE_0775) as test_file:
+            cmd_line = ('%s resolve -V %s' % (AVOCADO, test_file.path))
+            result = process.run(cmd_line)
+        self.assertIn('exec-test: 1', result.stdout_text)
+
+    def test_not_exec_test(self):
+        name = 'executable-test'
+        with script.TemporaryScript(name, EXEC_TEST,
+                                    name, self.MODE_0664) as test_file:
+            cmd_line = ('%s resolve %s' % (AVOCADO, test_file.path))
+            result = process.run(cmd_line)
+        self.assertNotIn('exec-test ', result.stdout_text)
+
+    def test_avocado_instrumented(self):
+        name = 'passtest.py'
+        with script.TemporaryScript(name, AVOCADO_INSTRUMENTED_TEST,
+                                    name, self.MODE_0664) as test_file:
+            cmd_line = ('%s resolve -V %s' % (AVOCADO, test_file.path))
+            result = process.run(cmd_line)
+        self.assertIn('passtest.py:PassTest.test', result.stdout_text)
+        self.assertIn('avocado-instrumented: 1', result.stdout_text)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/selftests/unit/test_resolver.py
+++ b/selftests/unit/test_resolver.py
@@ -1,0 +1,30 @@
+import unittest
+
+from avocado.core import resolver
+
+
+class ReferenceResolution(unittest.TestCase):
+
+    """
+    Tests on how to initialize and use
+    :class:`avocado.core.resolver.ReferenceResolution`
+    """
+
+    def test_no_args(self):
+        with self.assertRaises(TypeError):
+            resolver.ReferenceResolution()
+
+    def test_no_result(self):
+        with self.assertRaises(TypeError):
+            resolver.ReferenceResolution('/test/reference')
+
+    def test_no_resolutions(self):
+        resolution = resolver.ReferenceResolution(
+            '/test/reference',
+            resolver.ReferenceResolutionResult.NOTFOUND)
+        self.assertEqual(len(resolution.resolutions), 0,
+                         "Unexpected resolutions found")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,7 @@ if __name__ == '__main__':
                   'task-run = avocado.plugins.task_run:TaskRun',
                   'task-run-recipe = avocado.plugins.task_run_recipe:TaskRunRecipe',
                   'nrun = avocado.plugins.nrun:NRun',
+                  'resolve = avocado.plugins.resolve:Resolve',
                   ],
               'avocado.plugins.job.prepost': [
                   'jobscripts = avocado.plugins.jobscripts:JobScripts',
@@ -106,7 +107,13 @@ if __name__ == '__main__':
                   ],
               'avocado.plugins.varianter': [
                   'json_variants = avocado.plugins.json_variants:JsonVariants',
-                 ],
+                  ],
+              'avocado.plugins.resolver': [
+                  'exec-test = avocado.plugins.resolver_exec_test:ExecTestResolver',
+                  'error = avocado.plugins.resolver_error:ErrorResolver',
+                  'python-unittest = avocado.plugins.resolver_python_unittest:PythonUnittestResolver',
+                  'avocado-instrumented = avocado.plugins.resolver_avocado_instrumented:AvocadoInstrumentedResolver',
+                  ],
               },
           zip_safe=False,
           test_suite='selftests',


### PR DESCRIPTION
This new module, plugin interface and associated infrastructure
provides an alternative that is better integrated to the other Avocado
plugins.

Currently, it's only leveraged by the N(ext) runner, but plan is
to also available to the current runner.

Signed-off-by: Cleber Rosa <crosa@redhat.com>