### PR TITLE
Improve the HTML report

### DIFF
--- a/optional_plugins/html/avocado_result_html/templates/avocado_html.js
+++ b/optional_plugins/html/avocado_result_html/templates/avocado_html.js
@@ -1,5 +1,31 @@
 $(document).ready(function() {
-  $('#results').dataTable();
+  $('#results').dataTable({
+    "lengthMenu": [[10, 25, 50, 100, -1], [10, 25, 50, 100, "All"]],
+    initComplete: function() {
+      var statusColumn = this.api().column(4);
+      var select = $('<select class="form-control"><option value=""></option></select>')
+        .on('change', function () {
+          var val = $(this).val()
+          statusColumn.search(val ? '^' + val + '$' : '', true, false).draw();
+        });
+
+      $('#results_length').wrap('<div class="row"><div class="col-sm-4"></div></div>');
+      $('#results_length').parent().parent()
+        .append(
+          $('<div class="col-sm-8"></div>')
+          .append(
+            $('<label class="font-weight-normal">Status </label>').append(select)
+          )
+        );
+
+      // Add all possible status to the select
+      statusColumn.data().unique().sort().each(
+        function (element) {
+          select.append('<option value="' + element + '">' + element + '</option>');
+        }
+      );
+    }
+  });
 
   $(function () {$('[data-toggle="popover"]').popover()})
 

--- a/optional_plugins/html/avocado_result_html/templates/results.html
+++ b/optional_plugins/html/avocado_result_html/templates/results.html
@@ -73,12 +73,12 @@
         {% for test in data.tests %}
         <tr class="{{ data.row_class }}">
           <td>{{ test.time_start }}</td>
-          <td>{{ test.uid }}</td>
-          <td><a href="{{ test.logdir }}" title="{{ test.params }}">{{ test.name }}</a></td>
+          <td title="{{ test.uid }}">{{ test.uid }}</td>
+          <td><a href="{{ test.logdir }}" title="{{ test.name }} | {{ test.params }}">{{ test.name }}</a></td>
           <td>{{ test.variant }}</td>
           <td>{{ test.status }}</td>
           <td>{{ test.time }}</td>
-          <td>{{ test.fail_reason|safe }}</td>
+          <td title="{{ test.fail_reason|replace('<unknown>', '')|safe }}">{{ test.fail_reason|safe }}</td>
           <td class="row">
             <a class="col-md-1" href="{{ test.logfile }}"><img src="{{ data.source_path + '/images/logs_icon.svg'}}" title="Debug log"/></a>
             <span class="col-md-1">

--- a/optional_plugins/html/avocado_result_html/templates/style.css
+++ b/optional_plugins/html/avocado_result_html/templates/style.css
@@ -12,3 +12,14 @@ span:hover .spnTooltip{
     background:#fff;
 }
 .callout {z-index:20;position:absolute;top:30px;border:0;left:-12px;}
+.font-weight-normal {
+    font-weight: normal;
+}
+/* Restrict cells to a maximum width */
+.dataTable th, .dataTable td {
+    max-width: 14.3em;
+    min-width: 5em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}


### PR DESCRIPTION
Bring back some features from autotest report, namely the
ability to display all records in the table and an extra dropdown
to filter records by status.

Also, to avoid breaking the table layout when we have long
values we truncate those and add an ellipsis to the end. The
full content will then be displayed in a tooltip by hovering
over the cells.