### PR TITLE
Fix of whiteboard visibility HTML

### DIFF
--- a/optional_plugins/html/avocado_result_html/templates/avocado_html.js
+++ b/optional_plugins/html/avocado_result_html/templates/avocado_html.js
@@ -33,3 +33,10 @@ $(document).ready(function() {
     .removeClass( 'display' )
     .addClass('table table-striped table-bordered');
 } );
+
+$(".hiddenText").hover(function(){
+    var x = $(this).position();
+    $(this).parent().next(".spnTooltip").css({'display': 'block', "top": x.top + 30, "left": x.left -50});
+  }, function(){
+    $(this).parent().next(".spnTooltip").css('display', 'none');
+});

--- a/optional_plugins/html/avocado_result_html/templates/results.html
+++ b/optional_plugins/html/avocado_result_html/templates/results.html
@@ -72,19 +72,21 @@
         </thead>
         {% for test in data.tests %}
         <tr class="{{ data.row_class }}">
-          <td>{{ test.time_start }}</td>
-          <td title="{{ test.uid }}">{{ test.uid }}</td>
-          <td><a href="{{ test.logdir }}" title="{{ test.name }} | {{ test.params }}">{{ test.name }}</a></td>
-          <td>{{ test.variant }}</td>
-          <td>{{ test.status }}</td>
-          <td>{{ test.time }}</td>
-          <td title="{{ test.fail_reason|replace('<unknown>', '')|safe }}">{{ test.fail_reason|safe }}</td>
-          <td class="row">
-            <a class="col-md-1" href="{{ test.logfile }}"><img src="{{ data.source_path + '/images/logs_icon.svg'}}" title="Debug log"/></a>
-            <span class="col-md-1">
-              <span class="spnTooltip"><strong>Whiteboard:</strong><br>{{test.whiteboard}}</span>
-              <img src="{{ data.source_path + '/images/whiteboard_icon.svg'}}"/>
-            </span>
+          <td><div>{{ test.time_start }}</div></td>
+          <td title="{{ test.uid }}"><div>{{ test.uid }}</div></td>
+          <td><div><a class="hiddenText" href="{{ test.logdir }}">{{ test.name }}</a></div>
+              <span class="spnTooltip">{{ test.name }} | {{ test.params }}</span>
+          </td>
+          <td><div>{{ test.variant }}</div></td>
+          <td><div>{{ test.status }}</div></td>
+          <td><div>{{ test.time }}</div></td>
+          <td title="{{ test.fail_reason|replace('<unknown>', '')|safe }}"><div>{{ test.fail_reason|safe }}</div></td>
+          <td>
+            <div>
+              <a class="col-xs-1" href="{{ test.logfile }}"><img src="{{ data.source_path + '/images/logs_icon.svg'}}" title="Debug log"/></a>
+              <div class="col-xs-1 hiddenText"><img src="{{ data.source_path + '/images/whiteboard_icon.svg'}}"/></div>
+            </div>
+            <span class="spnTooltip"><strong>Whiteboard:</strong><br>{{test.whiteboard}}</span>
           </td>
         </tr>
         {% endfor %}

--- a/optional_plugins/html/avocado_result_html/templates/style.css
+++ b/optional_plugins/html/avocado_result_html/templates/style.css
@@ -1,22 +1,15 @@
-span .spnTooltip {
-    z-index:10;
+.spnTooltip {
     display:none;
+    z-index: 10;
     padding:14px 20px;
-}
-span:hover .spnTooltip{
-    display:inline;
     position:absolute;
-    right: 50px;
     color:#111;
     border:1px solid #337ab7;
     background:#fff;
-}
-.callout {z-index:20;position:absolute;top:30px;border:0;left:-12px;}
-.font-weight-normal {
-    font-weight: normal;
+    white-space: pre;
 }
 /* Restrict cells to a maximum width */
-.dataTable th, .dataTable td {
+.dataTable th, .dataTable div {
     max-width: 14.3em;
     min-width: 5em;
     overflow: hidden;


### PR DESCRIPTION
After commit 0d8b50e the visibility of whiteboard tooltip was broken. This commit solves this problem and also creates same style for all tooltips inside results table.

Signed-off-by: Jan Richter <jarichte@redhat.com>