### PR TITLE
Job API enabler: switch from Namespace to dict for job config [v2]

### DIFF
--- a/avocado/core/app.py
+++ b/avocado/core/app.py
@@ -66,14 +66,14 @@ class AvocadoApp:
         except SystemExit as detail:
             # If someone tries to exit Avocado, we should first close the
             # STD_OUTPUT and only then exit.
-            setattr(self.parser.args, 'paginator', 'off')
-            output.reconfigure(self.parser.args)
+            output.reconfigure({'paginator': 'off',
+                                'show': getattr(self.parser.args, 'show', None)})
             STD_OUTPUT.close()
             sys.exit(detail.code)
         except:
             # For any other exception we also need to close the STD_OUTPUT.
-            setattr(self.parser.args, 'paginator', 'off')
-            output.reconfigure(self.parser.args)
+            output.reconfigure({'paginator': 'off',
+                                'show': getattr(self.parser.args, 'show', None)})
             STD_OUTPUT.close()
             raise
         else:
@@ -83,7 +83,7 @@ class AvocadoApp:
     def run(self):
         try:
             try:
-                subcmd = self.parser.args.subcommand
+                subcmd = self.parser.args.get('subcommand')
                 extension = self.cli_cmd_dispatcher[subcmd]
             except KeyError:
                 return

--- a/avocado/core/jobdata.py
+++ b/avocado/core/jobdata.py
@@ -74,7 +74,7 @@ def record(args, logdir, variants, references=None, cmdline=None):
         os.fsync(pwd_file)
 
     with open(path_args, 'w') as args_file:
-        json.dump(args.__dict__, args_file, default=lambda x: None)
+        json.dump(args, args_file, default=lambda x: None)
         args_file.flush()
         os.fsync(args_file)
 

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -120,9 +120,9 @@ class TestLoaderProxy:
             return out.rstrip('\n')
 
         # Register external runner when --external-runner is used
-        if getattr(args, "external_runner", None):
+        if args.get("external_runner", None):
             self.register_plugin(ExternalLoader)
-            args.loaders = ["external:%s" % args.external_runner]
+            args['loaders'] = ["external:%s" % args.get('external_runner')]
         else:
             # Add (default) file loader if not already registered
             if FileLoader not in self.registered_plugins:
@@ -134,7 +134,7 @@ class TestLoaderProxy:
         for plugin in self.registered_plugins:
             supported_types.extend(_good_test_types(plugin))
         # Load plugin by the priority from settings
-        loaders = getattr(args, 'loaders', None)
+        loaders = args.get('loaders', None)
         if not loaders:
             loaders = settings.get_value("plugins", "loaders", list, [])
         if '?' in loaders:
@@ -746,8 +746,8 @@ class ExternalLoader(TestLoader):
     @staticmethod
     def _process_external_runner(args, runner):
         """ Enables the external_runner when asked for """
-        chdir = getattr(args, 'external_runner_chdir', None)
-        test_dir = getattr(args, 'external_runner_testdir', None)
+        chdir = args.get('external_runner_chdir', None)
+        test_dir = args.get('external_runner_testdir', None)
 
         if runner:
             external_runner_and_args = shlex.split(runner)

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -183,9 +183,9 @@ CMD_RUNNABLE_RUN_ARGS = (
 
 
 def runnable_from_args(args):
-    return Runnable(getattr(args, 'kind'),
-                    getattr(args, 'uri'),
-                    *getattr(args, 'arg', ()))
+    return Runnable(args.get('kind'),
+                    args.get('uri'),
+                    *args.get('arg', ()))
 
 
 def subcommand_runnable_run(args, echo=print):
@@ -203,7 +203,7 @@ CMD_RUNNABLE_RUN_RECIPE_ARGS = (
 
 
 def subcommand_runnable_run_recipe(args, echo=print):
-    runnable = runnable_from_recipe(getattr(args, 'recipe'))
+    runnable = runnable_from_recipe(args.get('recipe'))
     runner = runner_from_runnable(runnable)
 
     for status in runner.run():
@@ -395,8 +395,8 @@ def task_run(task, echo):
 
 def subcommand_task_run(args, echo=print):
     runnable = runnable_from_args(args)
-    task = Task(getattr(args, 'identifier'), runnable,
-                getattr(args, 'status_uri', []))
+    task = Task(args.get('identifier'), runnable,
+                args.get('status_uri', []))
     task_run(task, echo)
 
 
@@ -407,7 +407,7 @@ CMD_TASK_RUN_RECIPE_ARGS = (
 
 
 def subcommand_task_run_recipe(args, echo=print):
-    task = task_from_recipe(getattr(args, 'recipe'))
+    task = task_from_recipe(args.get('recipe'))
     task_run(task, echo)
 
 
@@ -418,7 +418,7 @@ CMD_STATUS_SERVER_ARGS = (
 
 
 def subcommand_status_server(args):
-    server = StatusServer(args.uri)
+    server = StatusServer(args.get('uri'))
     server.start()
     loop = asyncio.get_event_loop()
     loop.run_until_complete(server.wait())
@@ -448,16 +448,17 @@ def parse():
 
 
 def main():
-    args = parse()
-    if args.subcommand == 'runnable-run':
+    args = vars(parse())
+    subcommand = args.get('subcommand')
+    if subcommand == 'runnable-run':
         subcommand_runnable_run(args)
-    elif args.subcommand == 'runnable-run-recipe':
+    elif subcommand == 'runnable-run-recipe':
         subcommand_runnable_run_recipe(args)
-    elif args.subcommand == 'task-run':
+    elif subcommand == 'task-run':
         subcommand_task_run(args)
-    elif args.subcommand == 'task-run-recipe':
+    elif subcommand == 'task-run-recipe':
         subcommand_task_run_recipe(args)
-    elif args.subcommand == 'status-server':
+    elif subcommand == 'status-server':
         subcommand_status_server(args)
 
 

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -364,10 +364,10 @@ def reconfigure(args):
     Adjust logging handlers accordingly to app args and re-log messages.
     """
     # Reconfigure stream loggers
-    enabled = getattr(args, "show", None)
+    enabled = args.get("show", None)
     if not isinstance(enabled, list):
         enabled = ["app"]
-        args.show = enabled
+        args["show"] = enabled
     if "none" in enabled:
         del enabled[:]
     elif "all" in enabled:
@@ -379,7 +379,7 @@ def reconfigure(args):
     # TODO: Avocado relies on stdout/stderr on some places, re-log them here
     # for now. This should be removed once we replace them with logging.
     if enabled:
-        if getattr(args, "paginator", False) == "on" and TERM_SUPPORT.enabled:
+        if args.get("paginator", False) == "on" and TERM_SUPPORT.enabled:
             STD_OUTPUT.enable_paginator()
         STD_OUTPUT.enable_outputs()
     else:

--- a/avocado/core/parser.py
+++ b/avocado/core/parser.py
@@ -138,7 +138,7 @@ class Parser:
 
         Side effect: set the final value for attribute `args`.
         """
-        self.args, extra = self.application.parse_known_args(namespace=self.args)
+        args, extra = self.application.parse_known_args(namespace=self.args)
         if extra:
             msg = 'unrecognized arguments: %s' % ' '.join(extra)
             for sub in self.application._subparsers._actions:
@@ -146,3 +146,5 @@ class Parser:
                     sub.choices[self.args.subcommand].error(msg)
 
             self.application.error(msg)
+        # from this point on, args is a dictionary, and not a argparse.Namespace
+        self.args = vars(args)

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -339,7 +339,7 @@ class TestRunner:
         self.job._result_events_dispatcher.map_method('start_test',
                                                       self.result,
                                                       early_state)
-        if getattr(self.job.args, 'log_test_data_directories', False):
+        if self.job.args.get('log_test_data_directories', False):
             data_sources = getattr(instance, "DATA_SOURCES", [])
             if data_sources:
                 locations = []
@@ -504,7 +504,7 @@ class TestRunner:
         elif not mapping[test_state['status']]:
             summary.add("FAIL")
 
-            if getattr(self.job.args, 'failfast', 'off') == 'on':
+            if self.job.args.get('failfast', 'off') == 'on':
                 summary.add("INTERRUPTED")
                 self.job.log.debug("Interrupting job (failfast).")
                 return False

--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -630,7 +630,7 @@ def collect_sysinfo(args):
     """
     output.add_log_handler(log.name)
 
-    basedir = args.sysinfodir
+    basedir = args.get('sysinfodir')
     if not basedir:
         cwd = os.getcwd()
         timestamp = time.strftime('%Y-%m-%d-%H.%M.%S')

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -884,10 +884,10 @@ class Test(unittest.TestCase, TestData):
         genio.write_file(whiteboard_file, self.whiteboard)
 
         if self.job is not None:
-            job_standalone = getattr(self.job.args, 'standalone', False)
-            output_check_record = getattr(self.job.args,
-                                          'output_check_record', 'none')
-            output_check = getattr(self.job.args, 'output_check', 'on')
+            job_standalone = self.job.args.get('standalone', False)
+            output_check_record = self.job.args.get('output_check_record',
+                                                    'none')
+            output_check = self.job.args.get('output_check', 'on')
 
             # record the output if the modes are valid
             if output_check_record == 'combined':

--- a/avocado/plugins/archive.py
+++ b/avocado/plugins/archive.py
@@ -24,7 +24,7 @@ class Archive(Result):
     description = 'Result archive (ZIP) support'
 
     def render(self, result, job):
-        if getattr(job.args, 'archive', False):
+        if job.args.get('archive', False):
             archive.compress("%s.zip" % job.logdir, job.logdir)
 
 

--- a/avocado/plugins/config.py
+++ b/avocado/plugins/config.py
@@ -45,7 +45,7 @@ class Config(CLICmd):
             else:
                 LOG_UI.debug('      %s', cfg_path)
         LOG_UI.debug("")
-        if not args.datadir:
+        if not args.get("datadir"):
             blength = 0
             for section in settings.config.sections():
                 for value in settings.config.items(section):

--- a/avocado/plugins/diff.py
+++ b/avocado/plugins/diff.py
@@ -107,8 +107,8 @@ class Diff(CLICmd):
         def _get_name_no_id(test):
             return str(test['id']).split('-', 1)[1]
 
-        job1_dir, job1_id = self._setup_job(args.jobids[0])
-        job2_dir, job2_id = self._setup_job(args.jobids[1])
+        job1_dir, job1_id = self._setup_job(args.get('jobids')[0])
+        job2_dir, job2_id = self._setup_job(args.get('jobids')[1])
 
         job1_data = self._get_job_data(job1_dir)
         job2_data = self._get_job_data(job2_dir)
@@ -117,7 +117,7 @@ class Diff(CLICmd):
         job1_results = [report_header]
         job2_results = [report_header]
 
-        if 'cmdline' in args.diff_filter:
+        if 'cmdline' in args.get('diff_filter'):
             cmdline1 = self._get_command_line(job1_dir)
             cmdline2 = self._get_command_line(job2_dir)
 
@@ -129,7 +129,7 @@ class Diff(CLICmd):
                 job2_results.extend(command_line_header)
                 job2_results.append(cmdline2)
 
-        if 'time' in args.diff_filter:
+        if 'time' in args.get('diff_filter'):
             time1 = '%.2f s\n' % job1_data['time']
             time2 = '%.2f s\n' % job2_data['time']
 
@@ -141,7 +141,7 @@ class Diff(CLICmd):
                 job2_results.extend(total_time_header)
                 job2_results.append(time2)
 
-        if 'variants' in args.diff_filter:
+        if 'variants' in args.get('diff_filter'):
             variants1 = self._get_variants(job1_dir)
             variants2 = self._get_variants(job2_dir)
 
@@ -153,9 +153,9 @@ class Diff(CLICmd):
                 job2_results.extend(variants_header)
                 job2_results.extend(variants2)
 
-        if 'results' in args.diff_filter:
+        if 'results' in args.get('diff_filter'):
             results1 = []
-            if args.diff_strip_id:
+            if args.get('diff_strip_id'):
                 get_name = _get_name_no_id
             else:
                 get_name = _get_name
@@ -177,7 +177,7 @@ class Diff(CLICmd):
                 job2_results.extend(test_results_header)
                 job2_results.extend(results2)
 
-        if 'config' in args.diff_filter:
+        if 'config' in args.get('diff_filter'):
             config1 = self._get_config(job1_dir)
             config2 = self._get_config(job2_dir)
 
@@ -189,7 +189,7 @@ class Diff(CLICmd):
                 job2_results.extend(config_header)
                 job2_results.extend(config2)
 
-        if 'sysinfo' in args.diff_filter:
+        if 'sysinfo' in args.get('diff_filter'):
             sysinfo_pre1 = self._get_sysinfo(job1_dir, 'pre')
             sysinfo_pre2 = self._get_sysinfo(job2_dir, 'pre')
 
@@ -212,7 +212,7 @@ class Diff(CLICmd):
                 job2_results.extend(sysinfo_header_post)
                 job2_results.extend(sysinfo_post2)
 
-        if getattr(args, 'create_reports', False):
+        if args.get('create_reports', False):
             self.std_diff_output = False
             prefix = 'avocado_diff_%s_' % job1_id[:7]
             tmp_file1 = tempfile.NamedTemporaryFile(mode='w',
@@ -232,8 +232,8 @@ class Diff(CLICmd):
 
             LOG_UI.info('%s %s', tmp_file1.name, tmp_file2.name)
 
-        if (getattr(args, 'open_browser', False) and
-                getattr(args, 'html', None) is None):
+        if (args.get('open_browser', False) and
+                args.get('html', None) is None):
 
             prefix = 'avocado_diff_%s_%s_' % (job1_id[:7], job2_id[:7])
             tmp_file = tempfile.NamedTemporaryFile(mode='w',
@@ -241,7 +241,7 @@ class Diff(CLICmd):
                                                    suffix='.html',
                                                    delete=False)
 
-            setattr(args, 'html', tmp_file.name)
+            args['html'] = tmp_file.name
 
         if getattr(args, 'html', None) is not None:
             self.std_diff_output = False
@@ -270,21 +270,21 @@ class Diff(CLICmd):
                                                     fromdesc=job1_id,
                                                     todesc=job2_id)
 
-                with open(args.html, 'w') as html_file:
+                with open(args.get('html'), 'w') as html_file:
                     html_file.writelines(job_diff_html.encode("utf-8"))
 
-                LOG_UI.info(args.html)
+                LOG_UI.info(args.get('html'))
 
             except IOError as exception:
                 LOG_UI.error(exception)
                 sys.exit(exit_codes.AVOCADO_FAIL)
 
-        if getattr(args, 'open_browser', False):
+        if args.get('open_browser', False):
             setsid = getattr(os, 'setsid', None)
             if not setsid:
                 setsid = getattr(os, 'setpgrp', None)
             with open(os.devnull, "r+") as inout:
-                cmd = ['xdg-open', args.html]
+                cmd = ['xdg-open', args.get('html')]
                 subprocess.Popen(cmd, close_fds=True, stdin=inout,
                                  stdout=inout, stderr=inout,
                                  preexec_fn=setsid)

--- a/avocado/plugins/distro.py
+++ b/avocado/plugins/distro.py
@@ -331,21 +331,23 @@ class Distro(CLICmd):
         It's not uncommon for some distros to not have a release number, so
         adapt the output file name to that
         """
-        if args.distro_def_release:
-            return '%s-%s.%s-%s.distro' % (args.distro_def_name,
-                                           args.distro_def_version,
-                                           args.distro_def_release,
-                                           args.distro_def_arch)
+        if args.get('distro_def_release'):
+            return '%s-%s.%s-%s.distro' % (args.get('distro_def_name'),
+                                           args.get('distro_def_version'),
+                                           args.get('distro_def_release'),
+                                           args.get('distro_def_arch'))
         else:
-            return '%s-%s-%s.distro' % (args.distro_def_name,
-                                        args.distro_def_version,
-                                        args.distro_def_arch)
+            return '%s-%s-%s.distro' % (args.get('distro_def_name'),
+                                        args.get('distro_def_version'),
+                                        args.get('distro_def_arch'))
 
     def run(self, args):
-        if args.distro_def_create:
-            if not (args.distro_def_name and args.distro_def_version and
-                    args.distro_def_arch and args.distro_def_type and
-                    args.distro_def_path):
+        if args.get('distro_def_create'):
+            if not (args.get('distro_def_name') and
+                    args.get('distro_def_version') and
+                    args.get('distro_def_arch') and
+                    args.get('distro_def_type') and
+                    args.get('distro_def_path')):
                 LOG_UI.error('Required arguments: name, version, arch, type '
                              'and path')
                 sys.exit(exit_codes.AVOCADO_FAIL)
@@ -358,12 +360,12 @@ class Distro(CLICmd):
             else:
                 LOG_UI.debug("Loading distro information from tree... "
                              "Please wait...")
-                distro = load_from_tree(args.distro_def_name,
-                                        args.distro_def_version,
-                                        args.distro_def_release,
-                                        args.distro_def_arch,
-                                        args.distro_def_type,
-                                        args.distro_def_path)
+                distro = load_from_tree(args.get('distro_def_name'),
+                                        args.get('distro_def_version'),
+                                        args.get('distro_def_release'),
+                                        args.get('distro_def_arch'),
+                                        args.get('distro_def_type'),
+                                        args.get('distro_def_path'))
                 save_distro(distro, output_file_name)
                 LOG_UI.debug('Distro information saved to "%s"',
                              output_file_name)

--- a/avocado/plugins/gdb.py
+++ b/avocado/plugins/gdb.py
@@ -62,11 +62,11 @@ class GDB(CLI):
 
     def run(self, args):
         if 'gdb_run_bin' in args:
-            for binary in args.gdb_run_bin:
+            for binary in args.get('gdb_run_bin'):
                 gdb.GDB_RUN_BINARY_NAMES_EXPR.append(binary)
 
         if 'gdb_prerun_commands' in args:
-            for commands in args.gdb_prerun_commands:
+            for commands in args.get('gdb_prerun_commands'):
                 if ':' in commands:
                     binary, commands_path = commands.split(':', 1)
                     gdb.GDB_PRERUN_COMMANDS['binary'] = commands_path
@@ -74,7 +74,7 @@ class GDB(CLI):
                     gdb.GDB_PRERUN_COMMANDS[''] = commands
 
         if 'gdb_coredump' in args:
-            gdb.GDB_ENABLE_CORE = True if args.gdb_coredump == 'on' else False
+            gdb.GDB_ENABLE_CORE = True if args.get('gdb_coredump') == 'on' else False
 
         system_gdb_path = utils_path.find_command('gdb', '/usr/bin/gdb')
         gdb.GDB_PATH = settings.get_value('gdb.paths', 'gdb', key_type='path',

--- a/avocado/plugins/human.py
+++ b/avocado/plugins/human.py
@@ -40,14 +40,14 @@ class Human(ResultEvents):
 
     def __init__(self, args):
         self.__throbber = output.Throbber()
-        stdout_claimed_by = getattr(args, 'stdout_claimed_by', None)
+        stdout_claimed_by = args.get('stdout_claimed_by', None)
         self.owns_stdout = not stdout_claimed_by
 
     def pre_tests(self, job):
         if not self.owns_stdout:
             return
         LOG_UI.info("JOB ID     : %s", job.unique_id)
-        replay_source_job = getattr(job.args, "replay_sourcejob", False)
+        replay_source_job = job.args.get("replay_sourcejob", False)
         if replay_source_job:
             LOG_UI.info("SRC JOB ID : %s", replay_source_job)
         LOG_UI.info("JOB LOG    : %s", job.logfile)
@@ -123,5 +123,5 @@ class HumanJob(JobPre, JobPost):
 
     def post(self, job):
         if job.status == 'PASS':
-            if not getattr(job.args, 'stdout_claimed_by', None):
+            if not job.args.get('stdout_claimed_by', None):
                 LOG_UI.info("JOB TIME   : %.2f s", job.time_elapsed)

--- a/avocado/plugins/json_variants.py
+++ b/avocado/plugins/json_variants.py
@@ -62,7 +62,7 @@ class JsonVariants(Varianter):
     variants = None
 
     def initialize(self, args):
-        load_variants = getattr(args, "json_variants_load", None)
+        load_variants = args.get("json_variants_load", None)
 
         if load_variants is None:
             self.variants = _NO_VARIANTS
@@ -73,7 +73,7 @@ class JsonVariants(Varianter):
         except IOError:
             LOG_UI.error("JSON serialized file '%s' could not be found or "
                          "is not readable", load_variants)
-            if args.subcommand == 'run':
+            if args.get('subcommand') == 'run':
                 sys.exit(exit_codes.AVOCADO_JOB_FAIL)
             else:
                 sys.exit(exit_codes.AVOCADO_FAIL)

--- a/avocado/plugins/jsonresult.py
+++ b/avocado/plugins/jsonresult.py
@@ -65,20 +65,20 @@ class JSONResult(Result):
                           separators=(',', ': '))
 
     def render(self, result, job):
-        if not (hasattr(job.args, 'json_job_result') or
-                hasattr(job.args, 'json_output')):
+        if not (job.args.get('json_job_result') or
+                job.args.get('json_output')):
             return
 
         if not result.tests_total:
             return
 
         content = self._render(result)
-        if getattr(job.args, 'json_job_result', 'off') == 'on':
+        if job.args.get('json_job_result', 'off') == 'on':
             json_path = os.path.join(job.logdir, 'results.json')
             with open(json_path, 'w') as json_file:
                 json_file.write(content)
 
-        json_path = getattr(job.args, 'json_output', 'None')
+        json_path = job.args.get('json_output', 'None')
         if json_path is not None:
             if json_path == '-':
                 LOG_UI.debug(content)

--- a/avocado/plugins/list.py
+++ b/avocado/plugins/list.py
@@ -42,7 +42,7 @@ class TestLister:
         loader.loader.get_extra_listing()
 
     def _get_test_suite(self, paths):
-        if self.args.verbose:
+        if self.args.get('verbose'):
             which_tests = loader.DiscoverMode.ALL
         else:
             which_tests = loader.DiscoverMode.AVAILABLE
@@ -72,7 +72,7 @@ class TestLister:
             stats[type_label.lower()] += 1
             type_label = decorator(type_label)
 
-            if self.args.verbose:
+            if self.args.get('verbose'):
                 if 'tags' in params:
                     tgs = params['tags']
                 else:
@@ -96,7 +96,7 @@ class TestLister:
 
     def _display(self, test_matrix, stats, tag_stats):
         header = None
-        if self.args.verbose:
+        if self.args.get('verbose'):
             header = (output.TERM_SUPPORT.header_str('Type'),
                       output.TERM_SUPPORT.header_str('Test'),
                       output.TERM_SUPPORT.header_str('Tag(s)'))
@@ -105,7 +105,7 @@ class TestLister:
                                                 strip=True):
             LOG_UI.debug(line)
 
-        if self.args.verbose:
+        if self.args.get('verbose'):
             LOG_UI.info("")
             LOG_UI.info("TEST TYPES SUMMARY")
             LOG_UI.info("==================")
@@ -121,13 +121,13 @@ class TestLister:
 
     def _list(self):
         self._extra_listing()
-        test_suite = self._get_test_suite(self.args.reference)
-        if getattr(self.args, 'filter_by_tags', False):
+        test_suite = self._get_test_suite(self.args.get('reference', []))
+        if self.args.get('filter_by_tags', False):
             test_suite = tags.filter_test_tags(
                 test_suite,
-                self.args.filter_by_tags,
-                self.args.filter_by_tags_include_empty,
-                self.args.filter_by_tags_include_empty_key)
+                self.args.get('filter_by_tags'),
+                self.args.get('filter_by_tags_include_empty'),
+                self.args.get('filter_by_tags_include_empty_key'))
         test_matrix, stats, tag_stats = self._get_test_matrix(test_suite)
         self._display(test_matrix, stats, tag_stats)
 

--- a/avocado/plugins/nrun.py
+++ b/avocado/plugins/nrun.py
@@ -145,17 +145,17 @@ class NRun(CLICmd):
             sys.stderr.write('\n')
             sys.exit(exit_codes.AVOCADO_FAIL)
 
-        suite = self.create_test_suite(args.reference)
-        self.pending_tasks = self.suite_to_tasks(suite, [args.status_server])
+        suite = self.create_test_suite(args.get('reference'))
+        self.pending_tasks = self.suite_to_tasks(suite, [args.get('status_server')])
 
-        if not args.disable_task_randomization:
+        if not args.get('disable_task_randomization'):
             random.shuffle(self.pending_tasks)
 
         self.spawned_tasks = []
 
         try:
             loop = asyncio.get_event_loop()
-            self.status_server = nrunner.StatusServer(args.status_server,
+            self.status_server = nrunner.StatusServer(args.get('status_server'),
                                                       [t.identifier for t in
                                                        self.pending_tasks])
             self.status_server.start()

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -215,20 +215,19 @@ class Run(CLICmd):
         :param args: Command line args received from the run subparser.
         """
         if 'output_check_record' in args:
-            process.OUTPUT_CHECK_RECORD_MODE = getattr(args,
-                                                       'output_check_record',
-                                                       None)
+            process.OUTPUT_CHECK_RECORD_MODE = args.get('output_check_record',
+                                                        None)
 
-        if args.unique_job_id is not None:
+        if args.get('unique_job_id') is not None:
             try:
-                int(args.unique_job_id, 16)
-                if len(args.unique_job_id) != 40:
+                int(args.get('unique_job_id'), 16)
+                if len(args.get('unique_job_id')) != 40:
                     raise ValueError
             except ValueError:
                 LOG_UI.error('Unique Job ID needs to be a 40 digit hex number')
                 sys.exit(exit_codes.AVOCADO_FAIL)
         try:
-            args.job_timeout = time_to_seconds(args.job_timeout)
+            args['job_timeout'] = time_to_seconds(args.get('job_timeout'))
         except ValueError as detail:
             LOG_UI.error(detail.args[0])
             sys.exit(exit_codes.AVOCADO_FAIL)

--- a/avocado/plugins/tap.py
+++ b/avocado/plugins/tap.py
@@ -55,7 +55,7 @@ class TAPResult(ResultEvents):
     def __init__(self, args):
         self.__logs = []
         self.__open_files = []
-        output = getattr(args, 'tap', None)
+        output = args.get('tap', None)
         if output == '-':
             log = LOG_UI.debug
             self.__logs.append(log)
@@ -63,7 +63,7 @@ class TAPResult(ResultEvents):
             log = open(output, "w", 1)
             self.__open_files.append(log)
             self.__logs.append(file_log_factory(log))
-        self.__include_logs = getattr(args, 'tap_include_logs', False)
+        self.__include_logs = args.get('tap_include_logs', False)
         self.is_header_printed = False
 
     def __write(self, msg, *writeargs):
@@ -86,7 +86,7 @@ class TAPResult(ResultEvents):
         Log the test plan
         """
         # Should we add default results.tap?
-        if getattr(job.args, 'tap_job_result', 'off') == 'on':
+        if job.args.get('tap_job_result', 'off') == 'on':
             log = open(os.path.join(job.logdir, 'results.tap'), "w", 1)
             self.__open_files.append(log)
             self.__logs.append(file_log_factory(log))

--- a/avocado/plugins/variants.py
+++ b/avocado/plugins/variants.py
@@ -83,14 +83,14 @@ class Variants(CLICmd):
 
     def run(self, args):
         err = None
-        if args.tree and args.varianter_debug:
+        if args.get('tree') and args.get('varianter_debug'):
             err = "Option --tree is incompatible with --debug."
-        elif not args.tree and args.inherit:
+        elif not args.get('tree') and args.get('inherit'):
             err = "Option --inherit can be only used with --tree"
         if err:
             LOG_UI.error(err)
             sys.exit(exit_codes.AVOCADO_FAIL)
-        varianter = args.avocado_variants
+        varianter = args.get('avocado_variants')
         try:
             varianter.parse(args)
         except (IOError, ValueError) as details:
@@ -98,34 +98,34 @@ class Variants(CLICmd):
             sys.exit(exit_codes.AVOCADO_FAIL)
         use_utf8 = settings.get_value("runner.output", "utf8",
                                       key_type=bool, default=None)
-        summary = args.summary or 0
-        variants = args.variants or 0
+        summary = args.get('summary') or 0
+        variants = args.get('variants') or 0
 
         # Parse obsolete options (unsafe to combine them with new args)
-        if args.tree:
+        if args.get('tree'):
             variants = 0
             summary += 1
-            if args.contents:
+            if args.get('contents'):
                 summary += 1
-            if args.inherit:
+            if args.get('inherit'):
                 summary += 2
         else:
-            if args.contents:
+            if args.get('contents'):
                 variants += 2
 
         # Export the serialized avocado_variants
-        if args.json_variants_dump is not None:
+        if args.get('json_variants_dump') is not None:
             try:
-                with open(args.json_variants_dump, 'w') as variants_file:
-                    json.dump(args.avocado_variants.dump(), variants_file)
+                with open(args.get('json_variants_dump'), 'w') as variants_file:
+                    json.dump(args.get('avocado_variants').dump(), variants_file)
             except IOError:
-                LOG_UI.error("Cannot write %s", args.json_variants_dump)
+                LOG_UI.error("Cannot write %s", args.get('json_variants_dump'))
                 sys.exit(exit_codes.AVOCADO_FAIL)
 
         # Produce the output
-        lines = args.avocado_variants.to_str(summary=summary,
-                                             variants=variants,
-                                             use_utf8=use_utf8)
+        lines = args.get('avocado_variants').to_str(summary=summary,
+                                                    variants=variants,
+                                                    use_utf8=use_utf8)
         for line in lines.splitlines():
             LOG_UI.debug(line)
 

--- a/avocado/plugins/wrapper.py
+++ b/avocado/plugins/wrapper.py
@@ -48,14 +48,14 @@ class Wrapper(CLI):
                                 'only one global wrapper can be defined.')
 
     def run(self, args):
-        wraps = getattr(args, "wrapper", None)
+        wraps = args.get("wrapper", None)
         if wraps:
-            if getattr(args, 'gdb_run_bin', None):
+            if args.get('gdb_run_bin', None):
                 LOG_UI.error('Command line option --wrapper is incompatible'
-                             ' with option --gdb-run-bin.\n%s', args.wrapper)
+                             ' with option --gdb-run-bin.\n%s', wraps)
                 sys.exit(exit_codes.AVOCADO_FAIL)
 
-            for wrap in args.wrapper:
+            for wrap in wraps:
                 if ':' not in wrap:
                     if process.WRAP_PROCESS is None:
                         script = os.path.abspath(wrap)

--- a/avocado/plugins/xunit.py
+++ b/avocado/plugins/xunit.py
@@ -132,22 +132,22 @@ class XUnitResult(Result):
         return document.toprettyxml(encoding='UTF-8')
 
     def render(self, result, job):
-        if not (hasattr(job.args, 'xunit_job_result') or
-                hasattr(job.args, 'xunit_output')):
+        if not (job.args.get('xunit_job_result') or
+                job.args.get('xunit_output')):
             return
 
         if not result.tests_total:
             return
 
-        max_test_log_size = getattr(job.args, 'xunit_max_test_log_chars', None)
-        job_name = getattr(job.args, 'xunit_job_name', None)
+        max_test_log_size = job.args.get('xunit_max_test_log_chars', None)
+        job_name = job.args.get('xunit_job_name', None)
         content = self._render(result, max_test_log_size, job_name)
-        if getattr(job.args, 'xunit_job_result', 'off') == 'on':
+        if job.args.get('xunit_job_result', 'off') == 'on':
             xunit_path = os.path.join(job.logdir, 'results.xml')
             with open(xunit_path, 'wb') as xunit_file:
                 xunit_file.write(content)
 
-        xunit_path = getattr(job.args, 'xunit_output', 'None')
+        xunit_path = job.args.get('xunit_output', 'None')
         if xunit_path is not None:
             if xunit_path == '-':
                 LOG_UI.debug(content.decode('UTF-8'))

--- a/optional_plugins/html/avocado_result_html/__init__.py
+++ b/optional_plugins/html/avocado_result_html/__init__.py
@@ -218,21 +218,21 @@ class HTMLResult(Result):
     def render(self, result, job):
         if job.status == "RUNNING":
             return  # Don't create results on unfinished jobs
-        if not (hasattr(job.args, 'html_job_result') or
-                hasattr(job.args, 'html_output')):
+        if not (job.args.get('html_job_result') or
+                job.args.get('html_output')):
             return
 
-        open_browser = getattr(job.args, 'open_browser', False)
-        if getattr(job.args, 'html_job_result', 'off') == 'on':
+        open_browser = job.args.get('open_browser', False)
+        if job.args.get('html_job_result', 'off') == 'on':
             html_path = os.path.join(job.logdir, 'results.html')
             self._render(result, html_path)
-            if getattr(job.args, 'stdout_claimed_by', None) is None:
+            if job.args.get('stdout_claimed_by', None) is None:
                 LOG_UI.info("JOB HTML   : %s", html_path)
             if open_browser:
                 self._open_browser(html_path)
                 open_browser = False
 
-        html_path = getattr(job.args, 'html_output', None)
+        html_path = job.args.get('html_output', None)
         if html_path is not None:
             self._render(result, html_path)
             if open_browser:
@@ -278,7 +278,7 @@ class HTML(CLI):
                   'File will be located at "html/results.html".'))
 
     def run(self, args):
-        if 'html_output' in args and args.html_output == '-':
+        if 'html_output' in args and args.get('html_output') == '-':
             LOG_UI.error('HTML to stdout not supported (not all HTML resources'
                          ' can be embedded on a single file)')
             sys.exit(exit_codes.AVOCADO_JOB_FAIL)

--- a/optional_plugins/loader_yaml/avocado_loader_yaml/__init__.py
+++ b/optional_plugins/loader_yaml/avocado_loader_yaml/__init__.py
@@ -95,8 +95,8 @@ class YamlTestsuiteLoader(loader.TestLoader):
         tests = []
         try:
             root = mux.apply_filters(create_from_yaml([reference], False),
-                                     getattr(self.args, "mux_suite_only", []),
-                                     getattr(self.args, "mux_suite_out", []))
+                                     self.args.get("mux_suite_only", []),
+                                     self.args.get("mux_suite_out", []))
         except Exception:
             return []
         mux_tree = mux.MuxTree(root)

--- a/optional_plugins/result_upload/avocado_result_upload/__init__.py
+++ b/optional_plugins/result_upload/avocado_result_upload/__init__.py
@@ -42,12 +42,12 @@ class ResultUpload(Result):
 
         """
         self.upload_url = None
-        if getattr(job.args, 'result_upload_url', None) is not None:
-            self.upload_url = job.args.result_upload_url
+        if job.args.get('result_upload_url', None) is not None:
+            self.upload_url = job.args.get('result_upload_url')
 
         self.upload_cmd = None
-        if getattr(job.args, 'result_upload_cmd', None) is not None:
-            self.upload_cmd = job.args.result_upload_cmd
+        if job.args.get('result_upload_cmd', None) is not None:
+            self.upload_cmd = job.args.get('result_upload_cmd')
 
         if self.upload_url is None:
             return
@@ -93,18 +93,18 @@ class ResultUploadCLI(CLI):
                             help='Specify the command to upload results')
 
     def run(self, args):
-        url = getattr(args, 'result_upload_url', None)
+        url = args.get('result_upload_url', None)
         if url is None:
             url = settings.get_value('plugins.result_upload',
                                      'url',
                                      default=None)
             if url is not None:
-                args.result_upload_url = url
+                args['result_upload_url'] = url
 
-        cmd = getattr(args, 'result_upload_cmd', None)
+        cmd = args.get('result_upload_cmd', None)
         if cmd is None:
             cmd = settings.get_value('plugins.result_upload',
                                      'command',
                                      default=None)
             if cmd is not None:
-                args.result_upload_cmd = cmd
+                args['result_upload_cmd'] = cmd

--- a/optional_plugins/resultsdb/avocado_resultsdb/__init__.py
+++ b/optional_plugins/resultsdb/avocado_resultsdb/__init__.py
@@ -40,16 +40,16 @@ class ResultsdbResultEvent(ResultEvents):
 
     def __init__(self, args):
         self.rdbapi = None
-        if getattr(args, 'resultsdb_api', None) is not None:
-            self.rdbapi = resultsdb_api.ResultsDBapi(args.resultsdb_api)
+        if args.get('resultsdb_api', None) is not None:
+            self.rdbapi = resultsdb_api.ResultsDBapi(args.get('resultsdb_api'))
 
         self.rdblogs = None
-        if getattr(args, 'resultsdb_logs', None) is not None:
-            self.rdblogs = args.resultsdb_logs
+        if args.get('resultsdb_logs', None) is not None:
+            self.rdblogs = args.get('resultsdb_logs')
 
         self.rdbnote_limit = 0
-        if getattr(args, 'resultsdb_note_limit', None) is not None:
-            self.rdbnote_limit = int(args.resultsdb_note_limit)
+        if args.get('resultsdb_note_limit', None) is not None:
+            self.rdbnote_limit = int(args.get('resultsdb_note_limit'))
 
         self.job_id = None
         self.job_logdir = None
@@ -159,8 +159,8 @@ class ResultsdbResult(Result):
     description = 'Resultsdb result support'
 
     def render(self, result, job):
-        if (getattr(job.args, 'resultsdb_logs', None) is not None and
-                getattr(job.args, 'stdout_claimed_by', None) is None):
+        if (job.args.get('resultsdb_logs', None) is not None and
+                job.args.get('stdout_claimed_by', None) is None):
             log_msg = "JOB URL    : %s/%s"
             LOG_UI.info(log_msg, job.args.resultsdb_logs, os.path.basename(job.logdir))
 
@@ -194,26 +194,26 @@ class ResultsdbCLI(CLI):
         self.configured = True
 
     def run(self, args):
-        resultsdb_api_url = getattr(args, 'resultsdb_api', None)
+        resultsdb_api_url = args.get('resultsdb_api', None)
         if resultsdb_api_url is None:
             resultsdb_api_url = settings.get_value('plugins.resultsdb',
                                                    'api_url',
                                                    default=None)
             if resultsdb_api_url is not None:
-                args.resultsdb_api = resultsdb_api_url
+                args['resultsdb_api'] = resultsdb_api_url
 
-        resultsdb_logs = getattr(args, 'resultsdb_logs', None)
+        resultsdb_logs = args.get('resultsdb_logs', None)
         if resultsdb_logs is None:
             resultsdb_logs = settings.get_value('plugins.resultsdb',
                                                 'logs_url',
                                                 default=None)
             if resultsdb_logs is not None:
-                args.resultsdb_logs = resultsdb_logs
+                args['resultsdb_logs'] = resultsdb_logs
 
-        resultsdb_note_limit = getattr(args, 'resultsdb_note_limit', None)
+        resultsdb_note_limit = args.get('resultsdb_note_limit', None)
         if resultsdb_note_limit is None:
             resultsdb_note_limit = settings.get_value('plugins.resultsdb',
                                                       'note_size_limit',
                                                       default=None)
             if resultsdb_note_limit is not None:
-                args.resultsdb_note_limit = resultsdb_note_limit
+                args['resultsdb_note_limit'] = resultsdb_note_limit

--- a/optional_plugins/runner_docker/avocado_runner_docker/__init__.py
+++ b/optional_plugins/runner_docker/avocado_runner_docker/__init__.py
@@ -120,11 +120,11 @@ class DockerTestRunner(RemoteTestRunner):
         self.remote = None      # Will be set in `setup`
 
     def setup(self):
-        dkrcmd = self.job.args.docker_cmd
-        dkr_opt = self.job.args.docker_options
+        dkrcmd = self.job.args.get('docker_cmd')
+        dkr_opt = self.job.args.get('docker_options')
         dkr_name = os.path.basename(self.job.logdir) + '.' + 'avocado'
         self.remote = DockerRemoter(dkrcmd, self.job.args.docker, dkr_opt, dkr_name)
-        stdout_claimed_by = getattr(self.job.args, 'stdout_claimed_by', None)
+        stdout_claimed_by = self.job.args.get('stdout_claimed_by', None)
         if not stdout_claimed_by:
             self.job.log.info("DOCKER     : Container id '%s'"
                               % self.remote.get_cid())
@@ -134,10 +134,10 @@ class DockerTestRunner(RemoteTestRunner):
         try:
             if self.remote:
                 self.remote.close()
-                if not self.job.args.docker_no_cleanup:
+                if not self.job.args.get('docker_no_cleanup'):
                     self.remote.cleanup()
         except Exception as details:
-            stdout_claimed_by = getattr(self.job.args, 'stdout_claimed_by', None)
+            stdout_claimed_by = self.job.args.get('stdout_claimed_by', None)
             if not stdout_claimed_by:
                 self.job.log.warn("DOCKER     : Fail to cleanup: %s" % details)
 
@@ -172,5 +172,5 @@ class DockerCLI(CLI):
                                 help="Preserve container after test")
 
     def run(self, args):
-        if getattr(args, "docker", None):
-            args.test_runner = DockerTestRunner
+        if args.get("docker", None):
+            args['test_runner'] = DockerTestRunner

--- a/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
+++ b/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
@@ -341,20 +341,20 @@ class RemoteTestRunner(TestRunner):
 
     def setup(self):
         """ Setup remote environment """
-        stdout_claimed_by = getattr(self.job.args, 'stdout_claimed_by', None)
+        stdout_claimed_by = self.job.args.get('stdout_claimed_by', None)
         if not stdout_claimed_by:
             self.job.log.info("LOGIN      : %s@%s:%d (TIMEOUT: %s seconds)",
-                              self.job.args.remote_username,
-                              self.job.args.remote_hostname,
-                              self.job.args.remote_port,
-                              self.job.args.remote_timeout)
-        self.remote = Remote(hostname=self.job.args.remote_hostname,
-                             username=self.job.args.remote_username,
-                             password=self.job.args.remote_password,
-                             key_filename=self.job.args.remote_key_file,
-                             port=self.job.args.remote_port,
-                             timeout=self.job.args.remote_timeout,
-                             env_keep=self.job.args.env_keep)
+                              self.job.args.get('remote_username'),
+                              self.job.args.get('remote_hostname'),
+                              self.job.args.get('remote_port'),
+                              self.job.args.get('remote_timeout'))
+        self.remote = Remote(hostname=self.job.args.get('remote_hostname'),
+                             username=self.job.args.get('remote_username'),
+                             password=self.job.args.get('remote_password'),
+                             key_filename=self.job.args.get('remote_key_file'),
+                             port=self.job.args.get('remote_port'),
+                             timeout=self.job.args.get('remote_timeout'),
+                             env_keep=self.job.args.get('env_keep'))
 
     def check_remote_avocado(self):
         """
@@ -443,14 +443,14 @@ class RemoteTestRunner(TestRunner):
         # bool or nargs
         for arg in ["--mux-yaml", "--dry-run",
                     "--filter-by-tags-include-empty"]:
-            value = getattr(self.job.args, arg_to_dest(arg), None)
+            value = self.job.args.get(arg_to_dest(arg), None)
             if value is True:
                 extra_params.append(arg)
             elif value:
                 extra_params.append("%s %s" % (arg, " ".join(value)))
         # append
         for arg in ["--filter-by-tags"]:
-            value = getattr(self.job.args, arg_to_dest(arg), None)
+            value = self.job.args.get(arg_to_dest(arg), None)
             if value:
                 join = ' %s ' % arg
                 extra_params.append("%s %s" % (arg, join.join(value)))
@@ -521,7 +521,7 @@ class RemoteTestRunner(TestRunner):
         fabric_logger.addHandler(file_handler)
         paramiko_logger.addHandler(file_handler)
         remote_logger.addHandler(file_handler)
-        if "test" in getattr(self.job.args, "show", []):
+        if "test" in self.job.args.get("show", []):
             output.add_log_handler(paramiko_logger.name)
         logger_list = [output.LOG_JOB]
         sys.stdout = output.LoggingFile(loggers=logger_list)
@@ -649,8 +649,8 @@ class RemoteCLI(CLI):
         :return: True when enable_arg enabled and all required args are set
         :raise sys.exit: When missing required argument.
         """
-        if (not hasattr(args, enable_arg) or
-                not getattr(args, enable_arg)):
+        if (enable_arg not in args or
+                not args.get(enable_arg)):
             return False
         missing = []
         for arg in required_args:
@@ -669,4 +669,4 @@ class RemoteCLI(CLI):
                                      ('remote_hostname',)):
             loader.loader.clear_plugins()
             loader.loader.register_plugin(DummyLoader)
-            args.test_runner = RemoteTestRunner
+            args['test_runner'] = RemoteTestRunner

--- a/optional_plugins/runner_remote/tests/test_remote.py
+++ b/optional_plugins/runner_remote/tests/test_remote.py
@@ -1,4 +1,3 @@
-import argparse
 import glob
 import os
 import shutil
@@ -53,24 +52,24 @@ class RemoteTestRunnerTest(unittest.TestCase):
         4) Assert that those results are properly parsed into the
            job's result
         """
-        job_args = argparse.Namespace(test_result_total=1,
-                                      remote_username='username',
-                                      remote_hostname='hostname',
-                                      remote_port=22,
-                                      remote_password='password',
-                                      remote_key_file=None,
-                                      remote_timeout=60,
-                                      mux_yaml=['~/avocado/tests/foo.yaml',
-                                                '~/avocado/tests/bar/baz.yaml'],
-                                      filter_by_tags=["-foo", "-bar"],
-                                      filter_by_tags_include_empty=False,
-                                      dry_run=True,
-                                      env_keep=None,
-                                      reference=['/tests/sleeptest.py',
-                                                 '/tests/other/test',
-                                                 'passtest.py'],
-                                      keep_tmp='on',
-                                      base_logdir=self.tmpdir)
+        job_args = {'test_result_total': 1,
+                    'remote_username': 'username',
+                    'remote_hostname': 'hostname',
+                    'remote_port': 22,
+                    'remote_password': 'password',
+                    'remote_key_file': None,
+                    'remote_timeout': 60,
+                    'mux_yaml': ['~/avocado/tests/foo.yaml',
+                                 '~/avocado/tests/bar/baz.yaml'],
+                    'filter_by_tags': ["-foo", "-bar"],
+                    'filter_by_tags_include_empty': False,
+                    'dry_run': True,
+                    'env_keep': None,
+                    'reference': ['/tests/sleeptest.py',
+                                  '/tests/other/test',
+                                  'passtest.py'],
+                    'keep_tmp': 'on',
+                    'base_logdir': self.tmpdir}
 
         with Job(job_args) as job:
             runner = avocado_runner_remote.RemoteTestRunner(job, job.result)
@@ -80,7 +79,8 @@ class RemoteTestRunnerTest(unittest.TestCase):
             # These are mocked at their source, and will prevent fabric from
             # trying to contact remote hosts
             with unittest.mock.patch('avocado_runner_remote.Remote'):
-                runner.remote = avocado_runner_remote.Remote(job_args.remote_hostname)
+                remote_hostname = job_args.get('remote_hostname')
+                runner.remote = avocado_runner_remote.Remote(remote_hostname)
 
                 # This is the result that the run_suite() will get from remote.run
                 remote_run_result = process.CmdResult()

--- a/optional_plugins/runner_vm/avocado_runner_vm/__init__.py
+++ b/optional_plugins/runner_vm/avocado_runner_vm/__init__.py
@@ -375,39 +375,39 @@ class VMTestRunner(RemoteTestRunner):
         Initialize VM and establish connection
         """
         # Super called after VM is found and initialized
-        stdout_claimed_by = getattr(self.job.args, 'stdout_claimed_by', None)
+        stdout_claimed_by = self.job.args.get('stdout_claimed_by', None)
         if not stdout_claimed_by:
-            self.job.log.info("DOMAIN     : %s", self.job.args.vm_domain)
+            self.job.log.info("DOMAIN     : %s", self.job.args.get('vm_domain'))
         try:
-            self.vm = vm_connect(self.job.args.vm_domain,
-                                 self.job.args.vm_hypervisor_uri)
+            self.vm = vm_connect(self.job.args.get('vm_domain'),
+                                 self.job.args.get('vm_hypervisor_uri'))
         except VirtError as exception:
             raise exceptions.JobError(exception)
         if self.vm.start() is False:
-            e_msg = "Could not start VM '%s'" % self.job.args.vm_domain
+            e_msg = "Could not start VM '%s'" % self.job.args.get('vm_domain')
             raise exceptions.JobError(e_msg)
         assert self.vm.domain.isActive() is not False
         # If hostname wasn't given, let's try to find out the IP address
-        if self.job.args.vm_hostname is None:
-            self.job.args.vm_hostname = self.vm.ip_address()
-            if self.job.args.vm_hostname is None:
+        if self.job.args.get('vm_hostname') is None:
+            self.job.args['vm_hostname'] = self.vm.ip_address()
+            if self.job.args.get('vm_hostname') is None:
                 e_msg = ("Could not find the IP address for VM '%s'. Please "
                          "set it explicitly with --vm-hostname" %
-                         self.job.args.vm_domain)
+                         self.job.args.get('vm_domain'))
                 raise exceptions.JobError(e_msg)
-        if self.job.args.vm_cleanup is True:
+        if self.job.args.get('vm_cleanup') is True:
             self.vm.create_snapshot()
             if self.vm.snapshot is None:
                 e_msg = ("Could not create snapshot on VM '%s'" %
                          self.job.args.vm_domain)
                 raise exceptions.JobError(e_msg)
         # Finish remote setup and copy the tests
-        self.job.args.remote_hostname = self.job.args.vm_hostname
-        self.job.args.remote_port = self.job.args.vm_port
-        self.job.args.remote_username = self.job.args.vm_username
-        self.job.args.remote_password = self.job.args.vm_password
-        self.job.args.remote_key_file = self.job.args.vm_key_file
-        self.job.args.remote_timeout = self.job.args.vm_timeout
+        self.job.args['remote_hostname'] = self.job.args.get('vm_hostname')
+        self.job.args['remote_port'] = self.job.args.get('vm_port')
+        self.job.args['remote_username'] = self.job.args.get('vm_username')
+        self.job.args['remote_password'] = self.job.args.get('vm_password')
+        self.job.args['remote_key_file'] = self.job.args.get('vm_key_file')
+        self.job.args['remote_timeout'] = self.job.args.get('vm_timeout')
         super(VMTestRunner, self).setup()
 
     def tear_down(self):
@@ -415,7 +415,7 @@ class VMTestRunner(RemoteTestRunner):
         Stop VM and restore snapshot (if asked for it)
         """
         super(VMTestRunner, self).tear_down()
-        if (self.job.args.vm_cleanup is True and
+        if (self.job.args.get('vm_cleanup') is True and
                 isinstance(getattr(self, 'vm', None), VM)):
             self.vm.stop()
             if self.vm.snapshot is not None:
@@ -482,12 +482,12 @@ class VMCLI(CLI):
         :return: True when enable_arg enabled and all required args are set
         :raise sys.exit: When missing required argument.
         """
-        if (not hasattr(args, enable_arg) or
-                not getattr(args, enable_arg)):
+        if (enable_arg not in args or
+                not args.get(enable_arg)):
             return False
         missing = []
         for arg in required_args:
-            if not getattr(args, arg):
+            if not args.get(arg):
                 missing.append(arg)
         if missing:
             LOG_UI.error("Use of %s requires %s arguments to be set. Please "
@@ -499,4 +499,4 @@ class VMCLI(CLI):
 
     def run(self, args):
         if self._check_required_args(args, 'vm_domain', ('vm_domain',)):
-            args.test_runner = VMTestRunner
+            args['test_runner'] = VMTestRunner

--- a/optional_plugins/runner_vm/tests/test_vm.py
+++ b/optional_plugins/runner_vm/tests/test_vm.py
@@ -1,4 +1,3 @@
-import argparse
 import shutil
 import tempfile
 import unittest.mock
@@ -38,24 +37,24 @@ class VMTestRunnerSetup(unittest.TestCase):
         mock_vm.create_snapshot = unittest.mock.Mock()
         mock_vm.stop = unittest.mock.Mock()
         mock_vm.restore_snapshot = unittest.mock.Mock()
-        job_args = argparse.Namespace(test_result_total=1,
-                                      vm_domain='domain',
-                                      vm_username='username',
-                                      vm_hostname='hostname',
-                                      vm_port=22,
-                                      vm_password='password',
-                                      vm_key_file=None,
-                                      vm_cleanup=True,
-                                      vm_no_copy=False,
-                                      vm_timeout=120,
-                                      vm_hypervisor_uri='my_hypervisor_uri',
-                                      reference=['/tests/sleeptest.py',
-                                                 '/tests/other/test',
-                                                 'passtest.py'],
-                                      dry_run=True,
-                                      env_keep=None,
-                                      keep_tmp='on',
-                                      base_logdir=self.tmpdir)
+        job_args = {'test_result_total': 1,
+                    'vm_domain': 'domain',
+                    'vm_username': 'username',
+                    'vm_hostname': 'hostname',
+                    'vm_port': 22,
+                    'vm_password': 'password',
+                    'vm_key_file': None,
+                    'vm_cleanup': True,
+                    'vm_no_copy': False,
+                    'vm_timeout': 120,
+                    'vm_hypervisor_uri': 'my_hypervisor_uri',
+                    'reference': ['/tests/sleeptest.py',
+                                  '/tests/other/test',
+                                  'passtest.py'],
+                    'dry_run': True,
+                    'env_keep': None,
+                    'keep_tmp': 'on',
+                    'base_logdir': self.tmpdir}
         with Job(job_args) as job:
             with unittest.mock.patch('avocado_runner_vm.vm_connect',
                                      return_value=mock_vm):

--- a/optional_plugins/varianter_cit/avocado_varianter_cit/__init__.py
+++ b/optional_plugins/varianter_cit/avocado_varianter_cit/__init__.py
@@ -26,6 +26,10 @@ from avocado_varianter_cit.Cit import Cit, LOG
 from avocado_varianter_cit.Parser import Parser
 
 
+#: The default order of combinations
+DEFAULT_ORDER_OF_COMBINATIONS = 2
+
+
 class VarianterCitCLI(CLI):
 
     """
@@ -45,7 +49,8 @@ class VarianterCitCLI(CLI):
             cit.add_argument('--cit-parameter-file', metavar='PATH',
                              help="Paths to a parameter file")
             cit.add_argument('--cit-order-of-combinations',
-                             metavar='ORDER', type=int, default=2,
+                             metavar='ORDER', type=int,
+                             default=DEFAULT_ORDER_OF_COMBINATIONS,
                              help=("Order of combinations. Defaults to "
                                    "%(default)s, maximum number is 6"))
 
@@ -65,7 +70,7 @@ class VarianterCit(Varianter):
 
     def initialize(self, args):
         self.variants = None
-        order = args.get('cit_order_of_combinations')
+        order = args.get('cit_order_of_combinations', DEFAULT_ORDER_OF_COMBINATIONS)
         if order > 6:
             LOG_UI.error("The order of combinations is bigger then 6")
             self.error_exit(args)

--- a/optional_plugins/varianter_cit/avocado_varianter_cit/__init__.py
+++ b/optional_plugins/varianter_cit/avocado_varianter_cit/__init__.py
@@ -50,7 +50,7 @@ class VarianterCitCLI(CLI):
                                    "%(default)s, maximum number is 6"))
 
     def run(self, args):
-        if getattr(args, "varianter_debug", False):
+        if args.get("varianter_debug", False):
             LOG.setLevel(logging.DEBUG)
 
 
@@ -65,12 +65,12 @@ class VarianterCit(Varianter):
 
     def initialize(self, args):
         self.variants = None
-        order = args.cit_order_of_combinations
+        order = args.get('cit_order_of_combinations')
         if order > 6:
             LOG_UI.error("The order of combinations is bigger then 6")
             self.error_exit(args)
 
-        cit_parameter_file = getattr(args, "cit_parameter_file", None)
+        cit_parameter_file = args.get("cit_parameter_file", None)
         if cit_parameter_file is None:
             return
         else:
@@ -99,7 +99,7 @@ class VarianterCit(Varianter):
 
     @staticmethod
     def error_exit(args):
-        if args.subcommand == 'run':
+        if args.get('subcommand') == 'run':
             sys.exit(exit_codes.AVOCADO_JOB_FAIL)
         else:
             sys.exit(exit_codes.AVOCADO_FAIL)

--- a/optional_plugins/varianter_pict/avocado_varianter_pict/__init__.py
+++ b/optional_plugins/varianter_pict/avocado_varianter_pict/__init__.py
@@ -96,7 +96,7 @@ class VarianterPict(Varianter):
         self.variants = None
         error = False
 
-        pict_parameter_file = getattr(args, "pict_parameter_file", None)
+        pict_parameter_file = args.get("pict_parameter_file", None)
         if pict_parameter_file is None:
             return
         else:
@@ -106,7 +106,7 @@ class VarianterPict(Varianter):
                              "is not readable", pict_parameter_file)
                 error = True
 
-        pict_binary = getattr(args, "pict_binary", None)
+        pict_binary = args.get("pict_binary", None)
         if pict_binary is None:
             LOG_UI.error("pict binary could not be found in $PATH. Please set "
                          "its location with --pict-binary or put it in your "
@@ -121,16 +121,16 @@ class VarianterPict(Varianter):
                 error = True
 
         if error:
-            if args.subcommand == 'run':
+            if args.get('subcommand') == 'run':
                 sys.exit(exit_codes.AVOCADO_JOB_FAIL)
             else:
                 sys.exit(exit_codes.AVOCADO_FAIL)
 
-        self.parameter_path = getattr(args, "pict_parameter_path")
+        self.parameter_path = args.get("pict_parameter_path")
 
         output = run_pict(pict_binary,
                           pict_parameter_file,
-                          getattr(args, "pict_order_of_combinations"))
+                          args.get("pict_order_of_combinations"))
         self.headers, self.variants = parse_pict_output(output)
 
     def __iter__(self):

--- a/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/__init__.py
+++ b/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/__init__.py
@@ -421,7 +421,7 @@ class YamlToMux(mux.MuxPlugin, Varianter):
     description = 'Multiplexer plugin to parse yaml files to params'
 
     def initialize(self, args):
-        debug = getattr(args, "varianter_debug", False)
+        debug = args.get("varianter_debug", False)
 
         if debug:
             data = mux.MuxTreeNodeDebug()
@@ -429,20 +429,20 @@ class YamlToMux(mux.MuxPlugin, Varianter):
             data = mux.MuxTreeNode()
 
         # Merge the multiplex
-        multiplex_files = getattr(args, "mux_yaml", None)
+        multiplex_files = args.get("mux_yaml", None)
         if multiplex_files:
             try:
                 data.merge(create_from_yaml(multiplex_files, debug))
             except IOError as details:
                 error_msg = "%s : %s" % (details.strerror, details.filename)
                 LOG_UI.error(error_msg)
-                if args.subcommand == 'run':
+                if args.get('subcommand') == 'run':
                     sys.exit(exit_codes.AVOCADO_JOB_FAIL)
                 else:
                     sys.exit(exit_codes.AVOCADO_FAIL)
 
         # Extend default multiplex tree of --mux-inject values
-        for inject in getattr(args, "mux_inject", []):
+        for inject in args.get("mux_inject", []):
             entry = inject.split(':', 3)
             if len(entry) < 2:
                 raise ValueError("key:entry pairs required, found only %s"
@@ -451,11 +451,11 @@ class YamlToMux(mux.MuxPlugin, Varianter):
                 entry.insert(0, '')  # add path='' (root)
             data.get_node(entry[0], True).value[entry[1]] = entry[2]
 
-        mux_filter_only = getattr(args, 'mux_filter_only', None)
-        mux_filter_out = getattr(args, 'mux_filter_out', None)
+        mux_filter_only = args.get('mux_filter_only', None)
+        mux_filter_out = args.get('mux_filter_out', None)
         data = mux.apply_filters(data, mux_filter_only, mux_filter_out)
         if data != mux.MuxTreeNode():
-            paths = getattr(args, "mux_parameter_paths", ["/run/*"])
+            paths = args.get("mux_parameter_paths", ["/run/*"])
             if paths is None:
                 paths = ["/run/*"]
             self.initialize_mux(data, paths, debug)

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -1,4 +1,3 @@
-import argparse
 import os
 import shutil
 import tempfile
@@ -38,7 +37,7 @@ class JobTest(unittest.TestCase):
         return found
 
     def test_job_empty_suite(self):
-        args = argparse.Namespace(base_logdir=self.tmpdir)
+        args = {'base_logdir': self.tmpdir}
         self.job = job.Job(args)
         # Job without setup called
         self.assertIsNone(self.job.logdir)
@@ -73,12 +72,12 @@ class JobTest(unittest.TestCase):
         self.job.cleanup()
 
     def test_job_empty_has_id(self):
-        args = argparse.Namespace(base_logdir=self.tmpdir)
+        args = {'base_logdir': self.tmpdir}
         self.job = job.Job(args)
         self.assertIsNotNone(self.job.unique_id)
 
     def test_two_jobs(self):
-        args = argparse.Namespace(base_logdir=self.tmpdir)
+        args = {'base_logdir': self.tmpdir}
         with job.Job(args) as self.job, job.Job(args) as job2:
             job1 = self.job
             # uids, logdirs and tmpdirs must be different
@@ -91,12 +90,12 @@ class JobTest(unittest.TestCase):
             self.assertEqual(os.path.dirname(job1.logdir), os.path.dirname(job2.logdir))
 
     def test_job_test_suite_not_created(self):
-        args = argparse.Namespace(base_logdir=self.tmpdir)
+        args = {'base_logdir': self.tmpdir}
         self.job = job.Job(args)
         self.assertIsNone(self.job.test_suite)
 
     def test_job_create_test_suite_empty(self):
-        args = argparse.Namespace(base_logdir=self.tmpdir)
+        args = {'base_logdir': self.tmpdir}
         self.job = job.Job(args)
         self.job.setup()
         self.assertRaises(exceptions.OptionValidationError,
@@ -104,8 +103,8 @@ class JobTest(unittest.TestCase):
 
     def test_job_create_test_suite_simple(self):
         simple_tests_found = self._find_simple_test_candidates()
-        args = argparse.Namespace(reference=simple_tests_found,
-                                  base_logdir=self.tmpdir)
+        args = {'reference': simple_tests_found,
+                'base_logdir': self.tmpdir}
         self.job = job.Job(args)
         self.job.setup()
         self.job.create_test_suite()
@@ -122,8 +121,8 @@ class JobTest(unittest.TestCase):
                 self.test_suite = filtered_test_suite
                 super(JobFilterTime, self).pre_tests()
         simple_tests_found = self._find_simple_test_candidates()
-        args = argparse.Namespace(reference=simple_tests_found,
-                                  base_logdir=self.tmpdir)
+        args = {'reference': simple_tests_found,
+                'base_logdir': self.tmpdir}
         self.job = JobFilterTime(args)
         self.job.setup()
         self.job.create_test_suite()
@@ -135,8 +134,8 @@ class JobTest(unittest.TestCase):
 
     def test_job_run_tests(self):
         simple_tests_found = self._find_simple_test_candidates(['true'])
-        args = argparse.Namespace(reference=simple_tests_found,
-                                  base_logdir=self.tmpdir)
+        args = {'reference': simple_tests_found,
+                'base_logdir': self.tmpdir}
         self.job = job.Job(args)
         self.job.setup()
         self.job.create_test_suite()
@@ -150,8 +149,8 @@ class JobTest(unittest.TestCase):
                     f.write(self.unique_id[::-1])
                 super(JobLogPost, self).post_tests()
         simple_tests_found = self._find_simple_test_candidates()
-        args = argparse.Namespace(reference=simple_tests_found,
-                                  base_logdir=self.tmpdir)
+        args = {'reference': simple_tests_found,
+                'base_logdir': self.tmpdir}
         self.job = JobLogPost(args)
         self.job.setup()
         self.job.create_test_suite()
@@ -180,8 +179,8 @@ class JobTest(unittest.TestCase):
                     f.write(self.unique_id[::-1])
                 super(JobFilterLog, self).post_tests()
         simple_tests_found = self._find_simple_test_candidates()
-        args = argparse.Namespace(reference=simple_tests_found,
-                                  base_logdir=self.tmpdir)
+        args = {'reference': simple_tests_found,
+                'base_logdir': self.tmpdir}
         self.job = JobFilterLog(args)
         self.job.setup()
         self.assertEqual(self.job.run(),
@@ -192,7 +191,7 @@ class JobTest(unittest.TestCase):
                              reverse_id_file.read())
 
     def test_job_run_account_time(self):
-        args = argparse.Namespace(base_logdir=self.tmpdir)
+        args = {'base_logdir': self.tmpdir}
         self.job = job.Job(args)
         self.job.setup()
         self.job.run()
@@ -201,7 +200,7 @@ class JobTest(unittest.TestCase):
         self.assertNotEqual(self.job.time_elapsed, -1)
 
     def test_job_self_account_time(self):
-        args = argparse.Namespace(base_logdir=self.tmpdir)
+        args = {'base_logdir': self.tmpdir}
         self.job = job.Job(args)
         self.job.setup()
         self.job.time_start = 10.0
@@ -215,13 +214,13 @@ class JobTest(unittest.TestCase):
         self.assertEqual(self.job.time_elapsed, 100.0)
 
     def test_job_dryrun_no_unique_job_id(self):
-        args = argparse.Namespace(dry_run=True, base_logdir=self.tmpdir)
+        args = {'dry_run': True, 'base_logdir': self.tmpdir}
         self.job = job.Job(args)
         self.job.setup()
-        self.assertIsNotNone(self.job.args.unique_job_id)
+        self.assertIsNotNone(self.job.args.get('unique_job_id'))
 
     def test_job_no_base_logdir(self):
-        args = argparse.Namespace()
+        args = {}
         with unittest.mock.patch('avocado.core.job.data_dir.get_logs_dir',
                                  return_value=self.tmpdir):
             self.job = job.Job(args)
@@ -231,7 +230,7 @@ class JobTest(unittest.TestCase):
         self.assertTrue(os.path.isfile(os.path.join(self.job.logdir, 'id')))
 
     def test_job_dryrun_no_base_logdir(self):
-        args = argparse.Namespace(dry_run=True)
+        args = {'dry_run': True}
         self.job = job.Job(args)
         with self.job:
             self.assertTrue(os.path.isdir(self.job.logdir))

--- a/selftests/unit/test_jsonresult.py
+++ b/selftests/unit/test_jsonresult.py
@@ -1,7 +1,6 @@
 import unittest
 import os
 import json
-import argparse
 import tempfile
 import shutil
 
@@ -35,8 +34,8 @@ class JSONResultTest(unittest.TestCase):
         self.tmpfile = tempfile.mkstemp()
         prefix = temp_dir_prefix(__name__, self, 'setUp')
         self.tmpdir = tempfile.mkdtemp(prefix=prefix)
-        args = argparse.Namespace(json_output=self.tmpfile[1],
-                                  base_logdir=self.tmpdir)
+        args = {'json_output': self.tmpfile[1],
+                'base_logdir': self.tmpdir}
         self.job = job.Job(args)
         self.test_result = Result(FakeJob(args))
         self.test_result.filename = self.tmpfile[1]
@@ -56,7 +55,7 @@ class JSONResultTest(unittest.TestCase):
         self.test_result.end_tests()
         json_result = jsonresult.JSONResult()
         json_result.render(self.test_result, self.job)
-        with open(self.job.args.json_output) as fp:
+        with open(self.job.args.get('json_output')) as fp:
             j = fp.read()
         obj = json.loads(j)
         self.assertTrue(obj)
@@ -91,7 +90,7 @@ class JSONResultTest(unittest.TestCase):
         self.test_result.end_tests()
         json_result = jsonresult.JSONResult()
         json_result.render(self.test_result, self.job)
-        res = json.loads(open(self.job.args.json_output).read())
+        res = json.loads(open(self.job.args.get('json_output')).read())
         check_item("[pass]", res["pass"], 2)
         check_item("[errors]", res["errors"], 4)
         check_item("[failures]", res["failures"], 1)
@@ -109,7 +108,7 @@ class JSONResultTest(unittest.TestCase):
         self.test_result.end_tests()
         json_result = jsonresult.JSONResult()
         json_result.render(self.test_result, self.job)
-        res = json.loads(open(self.job.args.json_output).read())
+        res = json.loads(open(self.job.args.get('json_output')).read())
         check_item("[total]", res["total"], 1)
         check_item("[skip]", res["skip"], 0)
         check_item("[pass]", res["pass"], 1)

--- a/selftests/unit/test_runner_queue.py
+++ b/selftests/unit/test_runner_queue.py
@@ -1,4 +1,3 @@
-import argparse
 import shutil
 import tempfile
 import unittest
@@ -25,7 +24,7 @@ class TestRunnerQueue(unittest.TestCase):
     def setUp(self):
         prefix = temp_dir_prefix(__name__, self, 'setUp')
         self.tmpdir = tempfile.mkdtemp(prefix=prefix)
-        args = argparse.Namespace(base_logdir=self.tmpdir)
+        args = {'base_logdir': self.tmpdir}
         self.job = Job(args)
         self.result = Result(self.job)
 

--- a/selftests/unit/test_xunit.py
+++ b/selftests/unit/test_xunit.py
@@ -1,4 +1,3 @@
-import argparse
 import os
 import shutil
 import tempfile
@@ -45,8 +44,8 @@ class xUnitSucceedTest(unittest.TestCase):
         self.tmpfile = tempfile.mkstemp()
         prefix = temp_dir_prefix(__name__, self, 'setUp')
         self.tmpdir = tempfile.mkdtemp(prefix=prefix)
-        args = argparse.Namespace(base_logdir=self.tmpdir)
-        args.xunit_output = self.tmpfile[1]
+        args = {'base_logdir': self.tmpdir,
+                'xunit_output': self.tmpfile[1]}
         self.job = job.Job(args)
         self.test_result = Result(FakeJob(args))
         self.test_result.tests_total = 1
@@ -77,7 +76,7 @@ class xUnitSucceedTest(unittest.TestCase):
         self.test_result.end_tests()
         xunit_result = xunit.XUnitResult()
         xunit_result.render(self.test_result, self.job)
-        with open(self.job.args.xunit_output, 'rb') as fp:
+        with open(self.job.args.get('xunit_output'), 'rb') as fp:
             xml = fp.read()
         try:
             dom = minidom.parseString(xml)
@@ -97,7 +96,7 @@ class xUnitSucceedTest(unittest.TestCase):
                                                  os.path.pardir, ".data",
                                                  'jenkins-junit.xsd'))
         xml_schema = xmlschema.XMLSchema(junit_xsd)
-        self.assertTrue(xml_schema.is_valid(self.job.args.xunit_output))
+        self.assertTrue(xml_schema.is_valid(self.job.args.get('xunit_output')))
 
     def test_max_test_log_size(self):
         def get_system_out(out):
@@ -115,15 +114,15 @@ class xUnitSucceedTest(unittest.TestCase):
         self.test_result.end_tests()
         xunit_result = xunit.XUnitResult()
         xunit_result.render(self.test_result, self.job)
-        with open(self.job.args.xunit_output, 'rb') as fp:
+        with open(self.job.args.get('xunit_output'), 'rb') as fp:
             unlimited = fp.read()
-        self.job.args.xunit_max_test_log_chars = 10
+        self.job.args['xunit_max_test_log_chars'] = 10
         xunit_result.render(self.test_result, self.job)
-        with open(self.job.args.xunit_output, 'rb') as fp:
+        with open(self.job.args.get('xunit_output'), 'rb') as fp:
             limited = fp.read()
-        self.job.args.xunit_max_test_log_chars = 100000
+        self.job.args['xunit_max_test_log_chars'] = 100000
         xunit_result.render(self.test_result, self.job)
-        with open(self.job.args.xunit_output, 'rb') as fp:
+        with open(self.job.args.get('xunit_output'), 'rb') as fp:
             limited_but_fits = fp.read()
         self.assertLess(len(limited), len(unlimited) - 500,
                         "Length of xunit limitted to 10 chars was greater "


### PR DESCRIPTION
A `argparse.Namespace` instance has been used so far for the
configuration of virtually all job (and plugins) aspects.  The problem
is that `argparse.Namespace` is really intended as the result of the
parsing of the command line, and it's a lot less flexible and less
natural for developers than a Python dictionary.

Given that we want to let users write their own jobs, it makes
sense to use Python native data types for that.  For instance,
this is a trivial job that can be written with this change:

```python
   from avocado.core.job import Job
   config = {'reference': ['examples/tests/passtest.py:PassTest.test',
                           'examples/tests/passtest.py:PassTest.test']}
   with Job(config) as j:
       j.run()
```

Instead of:

```python
   import argparse
   from avocado.core.job import Job
   config = argparse.Namespace()
   setattr(config, 'reference', ['examples/tests/passtest.py:PassTest.test',
                                  'examples/tests/passtest.py:PassTest.test'])
   with Job(config) as j:
       j.run()
```

As soon as the command line parser is done parsing the command line
arguments (see avocado.core.parser.Parser.finish()) args will be
become a dictionary.

In the future, we may want to rename "args" to something like config
or job_config, so that it's more obvious what it's about and doesn't
get confused with say positional args.

---

Changes from v1 (#3207):
 * Rebased and resolved conflicts
 * Added missing optional plugins (resultsdb, runner_docker, etc)