### PR TITLE
Tags: unify command line arguments

### DIFF
--- a/avocado/core/parser_common_args.py
+++ b/avocado/core/parser_common_args.py
@@ -1,0 +1,33 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2019
+# Author: Cleber Rosa <crosa@redhat.com>
+
+
+def add_tag_filter_args(parser):
+    group = parser.add_argument_group('filtering parameters')
+    group.add_argument('-t', '--filter-by-tags', metavar='TAGS',
+                       action='append',
+                       help='Filter tests based on tags')
+    group.add_argument('--filter-by-tags-include-empty',
+                       action='store_true', default=False,
+                       help=('Include all tests without tags during '
+                             'filtering. This effectively means they '
+                             'will be kept in the test suite found '
+                             'previously to filtering.'))
+    group.add_argument('--filter-by-tags-include-empty-key',
+                       action='store_true', default=False,
+                       help=('Include all tests that do not have a '
+                             'matching key in its key:val tags. This '
+                             'effectively means those tests will be '
+                             'kept in the test suite found previously '
+                             'to filtering.'))

--- a/avocado/plugins/list.py
+++ b/avocado/plugins/list.py
@@ -18,6 +18,7 @@ from avocado.core import exit_codes, output
 from avocado.core import loader
 from avocado.core import test
 from avocado.core import tags
+from avocado.core import parser_common_args
 from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLICmd
 from avocado.utils import astring
@@ -173,26 +174,7 @@ class List(CLICmd):
                             help='Turn the paginator on/off. '
                             'Current: %(default)s')
         loader.add_loader_options(parser)
-
-        filtering = parser.add_argument_group('filtering parameters')
-        filtering.add_argument('-t', '--filter-by-tags', metavar='TAGS',
-                               action='append',
-                               help='Filter INSTRUMENTED tests based on '
-                               '":avocado: tags=tag1,tag2" notation in '
-                               'their class docstring')
-        filtering.add_argument('--filter-by-tags-include-empty',
-                               action='store_true', default=False,
-                               help=('Include all tests without tags during '
-                                     'filtering. This effectively means they '
-                                     'will be kept in the test suite found '
-                                     'previously to filtering.'))
-        filtering.add_argument('--filter-by-tags-include-empty-key',
-                               action='store_true', default=False,
-                               help=('Include all tests that do not have a '
-                                     'matching key in its key:val tags. This '
-                                     'effectively means those tests will be '
-                                     'kept in the test suite found previously '
-                                     'to filtering.'))
+        parser_common_args.add_tag_filter_args(parser)
 
     def run(self, args):
         test_lister = TestLister(args)

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -23,6 +23,7 @@ from avocado.core import exit_codes
 from avocado.core import job
 from avocado.core import loader
 from avocado.core import output
+from avocado.core import parser_common_args
 from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLICmd
 from avocado.core.dispatcher import ResultDispatcher
@@ -187,26 +188,7 @@ class Run(CLICmd):
                                "Current: on (output check enabled)")
 
         loader.add_loader_options(parser)
-
-        filtering = parser.add_argument_group('filtering parameters')
-        filtering.add_argument('-t', '--filter-by-tags', metavar='TAGS',
-                               action='append',
-                               help='Filter INSTRUMENTED tests based on '
-                               '":avocado: tags=tag1,tag2" notation in '
-                               'their class docstring')
-        filtering.add_argument('--filter-by-tags-include-empty',
-                               action='store_true', default=False,
-                               help=('Include all tests without tags during '
-                                     'filtering. This effectively means they '
-                                     'will be kept in the test suite found '
-                                     'previously to filtering.'))
-        filtering.add_argument('--filter-by-tags-include-empty-key',
-                               action='store_true', default=False,
-                               help=('Include all tests that do not have a '
-                                     'matching key in its key:val tags. This '
-                                     'effectively means those tests will be '
-                                     'kept in the test suite found previously '
-                                     'to filtering.'))
+        parser_common_args.add_tag_filter_args(parser)
 
     def run(self, args):
         """


### PR DESCRIPTION
Let's extract the common command line arguments into its own module
and reuse on all commands that use it.

Signed-off-by: Cleber Rosa <crosa@redhat.com>