### PR TITLE
Robot plugin: introduce loader tests

### DIFF
--- a/optional_plugins/robot/setup.py
+++ b/optional_plugins/robot/setup.py
@@ -25,6 +25,7 @@ setup(name='avocado-framework-plugin-robot',
       packages=find_packages(),
       include_package_data=True,
       install_requires=['robotframework'],
+      test_suite='tests',
       entry_points={
           'avocado.plugins.cli': [
               'robot = avocado_robot:RobotCLI',

--- a/optional_plugins/robot/tests/avocado.robot
+++ b/optional_plugins/robot/tests/avocado.robot
@@ -1,0 +1,10 @@
+*** Settings ***
+Documentation     Sleep test cases
+
+*** Test Cases ***
+NoSleep
+        Sleep   0
+        Log     "got no sleep"
+Sleep
+        Sleep   0.01
+        Log     "got some sleep"

--- a/optional_plugins/robot/tests/test_robot.py
+++ b/optional_plugins/robot/tests/test_robot.py
@@ -1,0 +1,47 @@
+import os
+import unittest
+import pkg_resources
+
+import avocado_robot
+
+
+def python_module_available(module_name):
+    '''
+    Checks if a given Python module is available
+
+    :param module_name: the name of the module
+    :type module_name: str
+    :returns: if the Python module is available in the system
+    :rtype: bool
+    '''
+    try:
+        pkg_resources.require(module_name)
+        return True
+    except pkg_resources.DistributionNotFound:
+        return False
+
+
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+ROBOT_AVOCADO = os.path.join(THIS_DIR, 'avocado.robot')
+
+
+class Loader(unittest.TestCase):
+
+    @unittest.skipUnless(python_module_available('robotframework'),
+                         'robotframework python module missing')
+    @unittest.skipUnless(python_module_available('avocado-framework-plugin-robot'),
+                         'avocado-framework-plugin-robot python module missing')
+    @unittest.skipUnless(os.path.isfile(ROBOT_AVOCADO),
+                         'Robot test file not found at "%s"' % ROBOT_AVOCADO)
+    def test_discover(self):
+        loader = avocado_robot.RobotLoader(None, {})
+        results = loader.discover(ROBOT_AVOCADO)
+        self.assertEqual(len(results), 2)
+        nosleep_klass, nosleep_params = results[0]
+        self.assertIs(nosleep_klass, avocado_robot.RobotTest)
+        self.assertEqual(nosleep_params['name'],
+                         "%s:Avocado.NoSleep" % ROBOT_AVOCADO)
+        sleep_klass, sleep_params = results[1]
+        self.assertIs(sleep_klass, avocado_robot.RobotTest)
+        self.assertEqual(sleep_params['name'],
+                         "%s:Avocado.Sleep" % ROBOT_AVOCADO)


### PR DESCRIPTION
This is a very simple test for the Robot plugin loader, that makes
sure Avocado sees the right tests from a ".robot" file.

Signed-off-by: Cleber Rosa <crosa@redhat.com>