### PR TITLE
Fix filtering and popover in HTML report

### DIFF
--- a/optional_plugins/html/avocado_result_html/templates/avocado_html.js
+++ b/optional_plugins/html/avocado_result_html/templates/avocado_html.js
@@ -21,6 +21,8 @@ $(document).ready(function() {
       // Add all possible status to the select
       statusColumn.data().unique().sort().each(
         function (element) {
+          // Remove status text from its enclosing tag
+          element = $(element).text();
           select.append('<option value="' + element + '">' + element + '</option>');
         }
       );

--- a/optional_plugins/html/avocado_result_html/templates/results.html
+++ b/optional_plugins/html/avocado_result_html/templates/results.html
@@ -80,7 +80,7 @@
           <td><div>{{ test.variant }}</div></td>
           <td><div>{{ test.status }}</div></td>
           <td><div>{{ test.time }}</div></td>
-          <td title="{{ test.fail_reason|replace('<unknown>', '')|safe }}"><div>{{ test.fail_reason|safe }}</div></td>
+          <td><div>{{ test.fail_reason|safe }}</div></td>
           <td>
             <div>
               <a class="col-xs-1" href="{{ test.logfile }}"><img src="{{ data.source_path + '/images/logs_icon.svg'}}" title="Debug log"/></a>

--- a/optional_plugins/html/avocado_result_html/templates/style.css
+++ b/optional_plugins/html/avocado_result_html/templates/style.css
@@ -8,6 +8,9 @@
     background:#fff;
     white-space: pre;
 }
+.font-weight-normal {
+    font-weight: normal;
+}
 /* Restrict cells to a maximum width */
 .dataTable th, .dataTable div {
     max-width: 14.3em;


### PR DESCRIPTION
After commit 0d8b50e the popover of the info column was broken
due to the HTML title attribute being added. This column doesn't
need that tooltip as it already has a bootstrap popover applied
to it by __init__.py when filling this column.

Also, after commit d6f80ad the ability to filter by status was
lost after wrapping status element in divs, so we need to unwrap
them when filling the dropdown. Finally, bring back a CSS style
that was removed but is needed to make the status dropdown look
the same as the page dropdown added by datatables.

Signed-off-by: Samir Aguiar <samirjaguiar@gmail.com>