### PR TITLE
Fix: software_manager.py get_source method

### DIFF
--- a/avocado/utils/software_manager.py
+++ b/avocado/utils/software_manager.py
@@ -696,11 +696,11 @@ class YumBackend(RpmBackend):
             try:
                 process.run('yumdownloader --assumeyes --verbose --source %s '
                             '--destdir %s' % (name, path))
-                src_rpms = [_ for _ in os.walk(path).next()[2]
+                src_rpms = [_ for _ in next(os.walk(path))[2]
                             if _.endswith(".src.rpm")]
                 if len(src_rpms) != 1:
                     log.error("Failed to get downloaded src.rpm from %s:\n%s",
-                              path, os.walk(path).next()[2])
+                              path, next(os.walk(path))[2])
                     return ""
                 if self.rpm_install(os.path.join(path, src_rpms[-1])):
                     if self.build_dep(name):


### PR DESCRIPTION
Python3 no longer provides next() for generator object. Fixed it to be compliant with python3

Signed-off-by: Harish <harish@linux.ibm.com>