### PR TITLE
selftests: use tempfile.TemporaryDirectory instead of mkdtemp

### DIFF
--- a/optional_plugins/html/tests/test_html_result.py
+++ b/optional_plugins/html/tests/test_html_result.py
@@ -1,6 +1,5 @@
 import json
 import os
-import shutil
 import tempfile
 import unittest
 from xml.dom import minidom
@@ -12,7 +11,7 @@ from avocado.utils import process
 
 class HtmlResultTest(unittest.TestCase):
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        self.tmpdir = tempfile.TemporaryDirectory(prefix='avocado_' + __name__)
 
     def check_output_files(self, debug_log):
         base_dir = os.path.dirname(debug_log)
@@ -36,7 +35,7 @@ class HtmlResultTest(unittest.TestCase):
 
     def test_output_incompatible_setup(self):
         cmd_line = ('avocado run --job-results-dir %s --sysinfo=off '
-                    '--html - passtest.py' % self.tmpdir)
+                    '--html - passtest.py' % self.tmpdir.name)
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_JOB_FAIL
         output = result.stdout + result.stderr
@@ -49,13 +48,13 @@ class HtmlResultTest(unittest.TestCase):
 
     def test_output_compatible_setup_2(self):
         prefix = 'avocado_' + __name__
-        tmpfile = tempfile.mktemp(prefix=prefix, dir=self.tmpdir)
-        tmpfile2 = tempfile.mktemp(prefix=prefix, dir=self.tmpdir)
-        tmpdir = tempfile.mkdtemp(prefix=prefix, dir=self.tmpdir)
+        tmpfile = tempfile.mktemp(prefix=prefix, dir=self.tmpdir.name)
+        tmpfile2 = tempfile.mktemp(prefix=prefix, dir=self.tmpdir.name)
+        tmpdir = tempfile.mkdtemp(prefix=prefix, dir=self.tmpdir.name)
         tmpfile3 = os.path.join(tmpdir, "result.html")
         cmd_line = ('avocado run --job-results-dir %s --sysinfo=off '
                     '--xunit %s --json %s --html %s --tap-include-logs '
-                    'passtest.py' % (self.tmpdir, tmpfile, tmpfile2, tmpfile3))
+                    'passtest.py' % (self.tmpdir.name, tmpfile, tmpfile2, tmpfile3))
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout + result.stderr
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -75,4 +74,4 @@ class HtmlResultTest(unittest.TestCase):
         minidom.parse(tmpfile)
 
     def tearDown(self):
-        shutil.rmtree(self.tmpdir)
+        self.tmpdir.cleanup()

--- a/optional_plugins/loader_yaml/tests/test_yaml_loader.py
+++ b/optional_plugins/loader_yaml/tests/test_yaml_loader.py
@@ -1,6 +1,5 @@
 import os
 import tempfile
-import shutil
 import unittest
 
 from avocado.core import exit_codes
@@ -12,7 +11,7 @@ from selftests import AVOCADO, BASEDIR
 class YamlLoaderTests(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        self.tmpdir = tempfile.TemporaryDirectory(prefix='avocado_' + __name__)
 
     def run_and_check(self, cmd_line, expected_rc, stdout_strings=None):
         os.chdir(BASEDIR)
@@ -31,7 +30,7 @@ class YamlLoaderTests(unittest.TestCase):
         tests = [b"passtest.py:PassTest.test", b"passtest.sh"]
         cmd = ('%s run --sysinfo=off --job-results-dir %s -- '
                'optional_plugins/loader_yaml/tests/.data/two_tests.yaml'
-               % (AVOCADO, self.tmpdir))
+               % (AVOCADO, self.tmpdir.name))
         res = self.run_and_check(cmd, exit_codes.AVOCADO_ALL_OK, tests)
         # Run replay job
         for line in res.stdout.splitlines():
@@ -41,11 +40,11 @@ class YamlLoaderTests(unittest.TestCase):
         else:
             self.fail("Unable to find 'JOB LOG' in:\n%s" % res)
         cmd = ('%s run --sysinfo=off --job-results-dir %s '
-               '--replay %s' % (AVOCADO, self.tmpdir, srcjob.decode('utf-8')))
+               '--replay %s' % (AVOCADO, self.tmpdir.name, srcjob.decode('utf-8')))
         self.run_and_check(cmd, exit_codes.AVOCADO_ALL_OK, tests)
 
     def tearDown(self):
-        shutil.rmtree(self.tmpdir)
+        self.tmpdir.cleanup()
 
 
 if __name__ == '__main__':

--- a/optional_plugins/runner_vm/tests/test_vm.py
+++ b/optional_plugins/runner_vm/tests/test_vm.py
@@ -1,5 +1,4 @@
 import argparse
-import shutil
 import tempfile
 import unittest.mock
 
@@ -30,7 +29,7 @@ class VMTestRunnerSetup(unittest.TestCase):
 
     def setUp(self):
         prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
+        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
 
     def test_setup(self):
         mock_vm = _FakeVM()
@@ -55,7 +54,7 @@ class VMTestRunnerSetup(unittest.TestCase):
                                       dry_run=True,
                                       env_keep=None,
                                       keep_tmp='on',
-                                      base_logdir=self.tmpdir)
+                                      base_logdir=self.tmpdir.name)
         with Job(job_args) as job:
             with unittest.mock.patch('avocado_runner_vm.vm_connect',
                                      return_value=mock_vm):
@@ -70,7 +69,7 @@ class VMTestRunnerSetup(unittest.TestCase):
 
     def tearDown(self):
         try:
-            shutil.rmtree(self.tmpdir)
+            self.tmpdir.cleanup()
             # may have been clean up already on job.cleanup()
         except FileNotFoundError:
             pass

--- a/optional_plugins/varianter_cit/tests/test_basic.py
+++ b/optional_plugins/varianter_cit/tests/test_basic.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 import tempfile
 import unittest
 
@@ -31,7 +30,7 @@ class Run(unittest.TestCase):
 
     def setUp(self):
         prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
+        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
 
     def test(self):
         os.chdir(BASEDIR)
@@ -44,7 +43,7 @@ class Run(unittest.TestCase):
             '--cit-order-of-combinations=1 '
             '--cit-parameter-file={2} '
             '-- {3}'
-        ).format(AVOCADO, self.tmpdir, params_path, test_path)
+        ).format(AVOCADO, self.tmpdir.name, params_path, test_path)
         result = process.run(cmd_line)
         # all values should be looked for at least once
         self.assertIn(b"PARAMS (key=color, path=*, default=None) => 'green'",
@@ -77,7 +76,7 @@ class Run(unittest.TestCase):
                       result.stdout)
 
     def tearDown(self):
-        shutil.rmtree(self.tmpdir)
+        self.tmpdir.cleanup()
 
 
 if __name__ == '__main__':

--- a/selftests/functional/test_export_variables.py
+++ b/selftests/functional/test_export_variables.py
@@ -1,6 +1,5 @@
 import os
 import tempfile
-import shutil
 import unittest
 
 from avocado import VERSION
@@ -33,7 +32,7 @@ class EnvironmentVariablesTest(unittest.TestCase):
 
     def setUp(self):
         prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
+        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
         self.script = script.TemporaryScript(
             'version.sh',
             SCRIPT_CONTENT,
@@ -43,7 +42,7 @@ class EnvironmentVariablesTest(unittest.TestCase):
     def test_environment_vars(self):
         os.chdir(BASEDIR)
         cmd_line = ('%s run --job-results-dir %s --sysinfo=on %s'
-                    % (AVOCADO, self.tmpdir, self.script.path))
+                    % (AVOCADO, self.tmpdir.name, self.script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
@@ -52,7 +51,7 @@ class EnvironmentVariablesTest(unittest.TestCase):
 
     def tearDown(self):
         self.script.remove()
-        shutil.rmtree(self.tmpdir)
+        self.tmpdir.cleanup()
 
 
 if __name__ == '__main__':

--- a/selftests/functional/test_gdb.py
+++ b/selftests/functional/test_gdb.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 import tempfile
 import unittest
 
@@ -12,13 +11,13 @@ class GDBPluginTest(unittest.TestCase):
 
     def setUp(self):
         prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
+        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
 
     def test_gdb_prerun_commands(self):
         os.chdir(BASEDIR)
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
                     '--gdb-prerun-commands=/dev/null passtest.py'
-                    % (AVOCADO, self.tmpdir))
+                    % (AVOCADO, self.tmpdir.name))
         process.run(cmd_line)
 
     def test_gdb_multiple_prerun_commands(self):
@@ -26,11 +25,11 @@ class GDBPluginTest(unittest.TestCase):
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
                     '--gdb-prerun-commands=/dev/null '
                     '--gdb-prerun-commands=foo:/dev/null passtest.py'
-                    % (AVOCADO, self.tmpdir))
+                    % (AVOCADO, self.tmpdir.name))
         process.run(cmd_line)
 
     def tearDown(self):
-        shutil.rmtree(self.tmpdir)
+        self.tmpdir.cleanup()
 
 
 if __name__ == '__main__':

--- a/selftests/functional/test_getdata.py
+++ b/selftests/functional/test_getdata.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 import tempfile
 import unittest
 
@@ -14,19 +13,19 @@ class GetData(unittest.TestCase):
     def setUp(self):
         os.chdir(BASEDIR)
         prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
+        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
 
     def test(self):
         test_path = os.path.join(BASEDIR, "selftests", ".data", "get_data.py")
         test_variants_path = os.path.join(BASEDIR, "selftests", ".data",
                                           "get_data.py.data", "get_data.yaml")
         cmd_line = "%s run --sysinfo=off --job-results-dir '%s' -m %s -- %s"
-        cmd_line %= (AVOCADO, self.tmpdir, test_variants_path, test_path)
+        cmd_line %= (AVOCADO, self.tmpdir.name, test_variants_path, test_path)
         result = process.run(cmd_line)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
 
     def tearDown(self):
-        shutil.rmtree(self.tmpdir)
+        self.tmpdir.cleanup()
 
 
 if __name__ == '__main__':

--- a/selftests/functional/test_interrupt.py
+++ b/selftests/functional/test_interrupt.py
@@ -2,7 +2,6 @@ import os
 import tempfile
 import time
 import signal
-import shutil
 import stat
 import subprocess
 import unittest
@@ -98,7 +97,7 @@ class InterruptTest(unittest.TestCase):
 
     def setUp(self):
         prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
+        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
         self.test_module = None
 
     @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 2,
@@ -117,7 +116,7 @@ class InterruptTest(unittest.TestCase):
         self.test_module = bad_test.path
         os.chdir(BASEDIR)
         cmd = ('%s run %s --sysinfo=off --job-results-dir %s ' %
-               (AVOCADO, self.test_module, self.tmpdir))
+               (AVOCADO, self.test_module, self.tmpdir.name))
         self.proc = subprocess.Popen(cmd.split(),
                                      stdout=subprocess.PIPE,
                                      stderr=subprocess.STDOUT)
@@ -165,7 +164,7 @@ class InterruptTest(unittest.TestCase):
         self.test_module = bad_test.path
         os.chdir(BASEDIR)
         cmd = ('%s run %s --sysinfo=off --job-results-dir %s ' %
-               (AVOCADO, self.test_module, self.tmpdir))
+               (AVOCADO, self.test_module, self.tmpdir.name))
         self.proc = subprocess.Popen(cmd.split(),
                                      stdout=subprocess.PIPE,
                                      stderr=subprocess.STDOUT)
@@ -205,7 +204,7 @@ class InterruptTest(unittest.TestCase):
         self.test_module = good_test.path
         os.chdir(BASEDIR)
         cmd = ('%s run %s --sysinfo=off --job-results-dir %s ' %
-               (AVOCADO, self.test_module, self.tmpdir))
+               (AVOCADO, self.test_module, self.tmpdir.name))
         self.proc = subprocess.Popen(cmd.split(),
                                      stdout=subprocess.PIPE,
                                      stderr=subprocess.STDOUT)
@@ -249,7 +248,7 @@ class InterruptTest(unittest.TestCase):
         self.test_module = good_test.path
         os.chdir(BASEDIR)
         cmd = ('%s run %s --sysinfo=off --job-results-dir %s ' %
-               (AVOCADO, self.test_module, self.tmpdir))
+               (AVOCADO, self.test_module, self.tmpdir.name))
         self.proc = subprocess.Popen(cmd.split(),
                                      stdout=subprocess.PIPE,
                                      stderr=subprocess.STDOUT)
@@ -274,7 +273,7 @@ class InterruptTest(unittest.TestCase):
         self.assertIn(b'Terminated\n', self.proc.stdout.read())
 
     def tearDown(self):
-        shutil.rmtree(self.tmpdir)
+        self.tmpdir.cleanup()
 
 
 if __name__ == '__main__':

--- a/selftests/functional/test_journal.py
+++ b/selftests/functional/test_journal.py
@@ -2,7 +2,6 @@ import os
 import json
 import sqlite3
 import tempfile
-import shutil
 import unittest
 
 from avocado.core import exit_codes
@@ -16,10 +15,10 @@ class JournalPluginTests(unittest.TestCase):
     def setUp(self):
         os.chdir(BASEDIR)
         prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
+        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
         self.cmd_line = ('%s run --job-results-dir %s --sysinfo=off --json - '
                          '--journal examples/tests/passtest.py'
-                         % (AVOCADO, self.tmpdir))
+                         % (AVOCADO, self.tmpdir.name))
         self.result = process.run(self.cmd_line, ignore_status=True)
         data = json.loads(self.result.stdout_text)
         self.job_id = data['job_id']
@@ -51,7 +50,7 @@ class JournalPluginTests(unittest.TestCase):
 
     def tearDown(self):
         self.db.close()
-        shutil.rmtree(self.tmpdir)
+        self.tmpdir.cleanup()
 
 
 if __name__ == '__main__':

--- a/selftests/functional/test_json_variants.py
+++ b/selftests/functional/test_json_variants.py
@@ -1,7 +1,6 @@
 import json
 import os
 import tempfile
-import shutil
 import unittest
 
 from avocado.utils import process
@@ -13,8 +12,8 @@ class VariantsDumpLoadTests(unittest.TestCase):
 
     def setUp(self):
         prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
-        self.variants_file = os.path.join(self.tmpdir, 'variants.json')
+        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
+        self.variants_file = os.path.join(self.tmpdir.name, 'variants.json')
         os.chdir(BASEDIR)
 
     def test_variants_dump(self):
@@ -44,7 +43,7 @@ class VariantsDumpLoadTests(unittest.TestCase):
             file_obj.write(content)
         cmd_line = ('%s run passtest.py --json-variants-load %s '
                     '--job-results-dir %s --json -' %
-                    (AVOCADO, self.variants_file, self.tmpdir))
+                    (AVOCADO, self.variants_file, self.tmpdir.name))
         result = process.run(cmd_line)
         json_result = json.loads(result.stdout_text)
         self.assertEqual(json_result["pass"], 2)
@@ -54,7 +53,7 @@ class VariantsDumpLoadTests(unittest.TestCase):
                          "2-passtest.py:PassTest.test;bar-d06d")
 
     def tearDown(self):
-        shutil.rmtree(self.tmpdir)
+        self.tmpdir.cleanup()
 
 
 if __name__ == '__main__':

--- a/selftests/functional/test_loader.py
+++ b/selftests/functional/test_loader.py
@@ -4,7 +4,6 @@ import subprocess
 import time
 import stat
 import tempfile
-import shutil
 import signal
 import unittest
 
@@ -148,7 +147,7 @@ class LoaderTestFunctional(unittest.TestCase):
     def setUp(self):
         os.chdir(BASEDIR)
         prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
+        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
 
     def _test(self, name, content, exp_str, mode=MODE_0664, count=1):
         test_script = script.TemporaryScript(name, content,
@@ -243,7 +242,7 @@ class LoaderTestFunctional(unittest.TestCase):
         # job should be able to finish under 5 seconds. If this fails, it's
         # possible that we hit the "simple test fork bomb" bug
         cmd_line = ("%s run --sysinfo=off --job-results-dir '%s' -- '%s'"
-                    % (AVOCADO, self.tmpdir, mytest))
+                    % (AVOCADO, self.tmpdir.name, mytest))
         self._run_with_timeout(cmd_line, 5)
 
     @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 2,
@@ -258,7 +257,7 @@ class LoaderTestFunctional(unittest.TestCase):
         # job should be able to finish under 5 seconds. If this fails, it's
         # possible that we hit the "simple test fork bomb" bug
         cmd_line = ("%s run --sysinfo=off --job-results-dir '%s' -- '%s'"
-                    % (AVOCADO, self.tmpdir, mytest))
+                    % (AVOCADO, self.tmpdir.name, mytest))
         self._run_with_timeout(cmd_line, 5)
 
     @unittest.skipUnless(os.path.exists("/bin/true"), "/bin/true not "
@@ -322,7 +321,7 @@ class LoaderTestFunctional(unittest.TestCase):
     def test_python_unittest(self):
         test_path = os.path.join(BASEDIR, "selftests", ".data", "unittests.py")
         cmd = ("%s run --sysinfo=off --job-results-dir %s --json - -- %s"
-               % (AVOCADO, self.tmpdir, test_path))
+               % (AVOCADO, self.tmpdir.name, test_path))
         result = process.run(cmd, ignore_status=True)
         jres = json.loads(result.stdout_text)
         self.assertEqual(result.exit_status, 1, result)
@@ -358,7 +357,7 @@ class LoaderTestFunctional(unittest.TestCase):
         self.assertEqual(expected, result.stdout)
 
     def tearDown(self):
-        shutil.rmtree(self.tmpdir)
+        self.tmpdir.cleanup()
 
 
 if __name__ == '__main__':

--- a/selftests/functional/test_lv_utils.py
+++ b/selftests/functional/test_lv_utils.py
@@ -7,7 +7,6 @@ avocado.utils.lv_utils selftests
 import glob
 import os
 import sys
-import shutil
 import tempfile
 import time
 import unittest
@@ -33,11 +32,11 @@ class LVUtilsTest(unittest.TestCase):
                      "passwordless sudo configured.")
     def setUp(self):
         prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
+        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
         self.vgs = []
 
     def tearDown(self):
-        shutil.rmtree(self.tmpdir)
+        self.tmpdir.cleanup()
         for vg_name in self.vgs:
             lv_utils.vg_remove(vg_name)
 
@@ -54,8 +53,8 @@ class LVUtilsTest(unittest.TestCase):
         ramdisk_filename = vg_ramdisk_dir = loop_device = None
         vg_name = "avocado_testing_vg_e5kj3erv11a"
         lv_name = "avocado_testing_lv_lk0ff33al5h"
-        ramdisk_basedir = os.path.join(self.tmpdir, "foo", "bar")
-        mount_loc = os.path.join(self.tmpdir, "lv_mount_location")
+        ramdisk_basedir = os.path.join(self.tmpdir.name, "foo", "bar")
+        mount_loc = os.path.join(self.tmpdir.name, "lv_mount_location")
         os.mkdir(mount_loc)
         try:
             # Create ramdisk vg

--- a/selftests/functional/test_output_check.py
+++ b/selftests/functional/test_output_check.py
@@ -1,6 +1,5 @@
 import json
 import os
-import shutil
 import tempfile
 import unittest
 
@@ -19,7 +18,7 @@ class RunnerSimpleTest(unittest.TestCase):
 
     def setUp(self):
         prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
+        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
         content = b"#!/bin/sh\n"
         content += b"echo \"" + STDOUT + b"\"\n"
         content += b"echo \"" + STDERR + b"\" >&2\n"
@@ -34,7 +33,7 @@ class RunnerSimpleTest(unittest.TestCase):
         os.chdir(BASEDIR)
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off %s '
                     '--output-check-record all'
-                    % (AVOCADO, self.tmpdir, self.output_script.path))
+                    % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
@@ -51,7 +50,7 @@ class RunnerSimpleTest(unittest.TestCase):
         os.chdir(BASEDIR)
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off %s '
                     '--output-check-record combined'
-                    % (AVOCADO, self.tmpdir, self.output_script.path))
+                    % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
@@ -65,7 +64,7 @@ class RunnerSimpleTest(unittest.TestCase):
         os.chdir(BASEDIR)
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off %s '
                     '--output-check-record none'
-                    % (AVOCADO, self.tmpdir, self.output_script.path))
+                    % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
@@ -80,7 +79,7 @@ class RunnerSimpleTest(unittest.TestCase):
         os.chdir(BASEDIR)
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off %s '
                     '--output-check-record stdout'
-                    % (AVOCADO, self.tmpdir, self.output_script.path))
+                    % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
@@ -95,7 +94,7 @@ class RunnerSimpleTest(unittest.TestCase):
     def test_output_record_and_check(self):
         self._check_output_record_all()
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off %s'
-                    % (AVOCADO, self.tmpdir, self.output_script.path))
+                    % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
@@ -105,7 +104,7 @@ class RunnerSimpleTest(unittest.TestCase):
     def test_output_record_and_check_combined(self):
         self._check_output_record_combined()
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off %s'
-                    % (AVOCADO, self.tmpdir, self.output_script.path))
+                    % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
@@ -119,7 +118,7 @@ class RunnerSimpleTest(unittest.TestCase):
         with open(stdout_file, 'wb') as stdout_file_obj:
             stdout_file_obj.write(tampered_msg)
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off %s --xunit -'
-                    % (AVOCADO, self.tmpdir, self.output_script.path))
+                    % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         self.assertEqual(result.exit_status, expected_rc,
@@ -134,7 +133,7 @@ class RunnerSimpleTest(unittest.TestCase):
         with open(output_file, 'wb') as output_file_obj:
             output_file_obj.write(tampered_msg)
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off %s --xunit -'
-                    % (AVOCADO, self.tmpdir, self.output_script.path))
+                    % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         self.assertEqual(result.exit_status, expected_rc,
@@ -156,7 +155,7 @@ class RunnerSimpleTest(unittest.TestCase):
             stderr_file_obj.write(tampered_msg_stderr)
 
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off %s --json -'
-                    % (AVOCADO, self.tmpdir, self.output_script.path))
+                    % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         self.assertEqual(result.exit_status, expected_rc,
@@ -199,7 +198,7 @@ class RunnerSimpleTest(unittest.TestCase):
             stdout_file_obj.write(tampered_msg)
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off %s '
                     '--output-check=off --xunit -'
-                    % (AVOCADO, self.tmpdir, self.output_script.path))
+                    % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
@@ -209,7 +208,7 @@ class RunnerSimpleTest(unittest.TestCase):
 
     def tearDown(self):
         self.output_script.remove()
-        shutil.rmtree(self.tmpdir)
+        self.tmpdir.cleanup()
 
 
 if __name__ == '__main__':

--- a/selftests/functional/test_plugin_jobscripts.py
+++ b/selftests/functional/test_plugin_jobscripts.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 import tempfile
 import unittest
 
@@ -43,10 +42,10 @@ class JobScriptsTest(unittest.TestCase):
 
     def setUp(self):
         prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.mkdtemp(prefix)
-        self.pre_dir = os.path.join(self.tmpdir, 'pre.d')
+        self.tmpdir = tempfile.TemporaryDirectory(prefix)
+        self.pre_dir = os.path.join(self.tmpdir.name, 'pre.d')
         os.mkdir(self.pre_dir)
-        self.post_dir = os.path.join(self.tmpdir, 'post.d')
+        self.post_dir = os.path.join(self.tmpdir.name, 'post.d')
         os.mkdir(self.post_dir)
         os.chdir(BASEDIR)
 
@@ -58,7 +57,7 @@ class JobScriptsTest(unittest.TestCase):
                                                   'touch.sh'),
                                      SCRIPT_PRE_TOUCH)
         touch_script.save()
-        test_check_touch = script.Script(os.path.join(self.tmpdir,
+        test_check_touch = script.Script(os.path.join(self.tmpdir.name,
                                                       'check_touch.sh'),
                                          TEST_CHECK_TOUCH)
         test_check_touch.save()
@@ -72,7 +71,7 @@ class JobScriptsTest(unittest.TestCase):
         with config:
             cmd = ('%s --config %s run --job-results-dir %s '
                    '--sysinfo=off %s'
-                   % (AVOCADO, config, self.tmpdir, test_check_touch))
+                   % (AVOCADO, config, self.tmpdir.name, test_check_touch))
             result = process.run(cmd)
 
         # Pre/Post scripts failures do not (currently?) alter the exit status
@@ -95,7 +94,7 @@ class JobScriptsTest(unittest.TestCase):
         with config:
             cmd = ('%s --config %s run --job-results-dir %s '
                    '--sysinfo=off passtest.py' % (AVOCADO, config,
-                                                  self.tmpdir))
+                                                  self.tmpdir.name))
             result = process.run(cmd)
 
         # Pre/Post scripts failures do not (currently?) alter the exit status
@@ -118,7 +117,7 @@ class JobScriptsTest(unittest.TestCase):
         with config:
             cmd = ('%s --config %s run --job-results-dir %s '
                    '--sysinfo=off passtest.py' % (AVOCADO, config,
-                                                  self.tmpdir))
+                                                  self.tmpdir.name))
             result = process.run(cmd)
 
         # Pre/Post scripts failures do not (currently?) alter the exit status
@@ -128,7 +127,7 @@ class JobScriptsTest(unittest.TestCase):
                          result.stderr_text)
 
     def tearDown(self):
-        shutil.rmtree(self.tmpdir)
+        self.tmpdir.cleanup()
 
 
 if __name__ == '__main__':

--- a/selftests/functional/test_replay_basic.py
+++ b/selftests/functional/test_replay_basic.py
@@ -1,6 +1,5 @@
 import glob
 import os
-import shutil
 import tempfile
 import unittest
 
@@ -14,14 +13,14 @@ class ReplayTests(unittest.TestCase):
 
     def setUp(self):
         prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.mkdtemp(prefix)
+        self.tmpdir = tempfile.TemporaryDirectory(prefix)
         cmd_line = ('%s run passtest.py '
                     '-m examples/tests/sleeptest.py.data/sleeptest.yaml '
                     '--job-results-dir %s --sysinfo=off --json -'
-                    % (AVOCADO, self.tmpdir))
+                    % (AVOCADO, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.run_and_check(cmd_line, expected_rc)
-        self.jobdir = ''.join(glob.glob(os.path.join(self.tmpdir, 'job-*')))
+        self.jobdir = ''.join(glob.glob(os.path.join(self.tmpdir.name, 'job-*')))
         idfile = ''.join(os.path.join(self.jobdir, 'id'))
         with open(idfile, 'r') as f:
             self.jobid = f.read().strip('\n')
@@ -40,7 +39,7 @@ class ReplayTests(unittest.TestCase):
         """
         cmd_line = ('%s run --replay %s '
                     '--job-results-dir %s --sysinfo=off'
-                    % (AVOCADO, 'foo', self.tmpdir))
+                    % (AVOCADO, 'foo', self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_FAIL
         self.run_and_check(cmd_line, expected_rc)
 
@@ -49,7 +48,7 @@ class ReplayTests(unittest.TestCase):
         Runs a replay job using the 'latest' keyword.
         """
         cmd_line = ('%s run --replay latest --job-results-dir %s --sysinfo=off'
-                    % (AVOCADO, self.tmpdir))
+                    % (AVOCADO, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.run_and_check(cmd_line, expected_rc)
 
@@ -69,7 +68,7 @@ class ReplayTests(unittest.TestCase):
         """
         cmd_line = ('%s run --replay %s '
                     '--job-results-dir %s --sysinfo=off'
-                    % (AVOCADO, self.jobid, self.tmpdir))
+                    % (AVOCADO, self.jobid, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.run_and_check(cmd_line, expected_rc)
 
@@ -80,7 +79,7 @@ class ReplayTests(unittest.TestCase):
         partial_id = self.jobid[:5]
         cmd_line = ('%s run --replay %s '
                     '--job-results-dir %s --sysinfo=off'
-                    % (AVOCADO, partial_id, self.tmpdir))
+                    % (AVOCADO, partial_id, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.run_and_check(cmd_line, expected_rc)
 
@@ -90,7 +89,7 @@ class ReplayTests(unittest.TestCase):
         """
         cmd_line = ('%s run --replay %s '
                     '--job-results-dir %s --sysinfo=off'
-                    % (AVOCADO, self.jobdir, self.tmpdir))
+                    % (AVOCADO, self.jobdir, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.run_and_check(cmd_line, expected_rc)
 
@@ -100,7 +99,7 @@ class ReplayTests(unittest.TestCase):
         """
         cmd_line = ('%s run --replay %s --replay-ignore foo'
                     '--job-results-dir %s --sysinfo=off'
-                    % (AVOCADO, self.jobid, self.tmpdir))
+                    % (AVOCADO, self.jobid, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_FAIL
         result = self.run_and_check(cmd_line, expected_rc)
         msg = (b'Invalid --replay-ignore option. Valid options are '
@@ -113,7 +112,7 @@ class ReplayTests(unittest.TestCase):
         """
         cmd_line = ('%s run --replay %s --replay-ignore variants '
                     '--job-results-dir %s --sysinfo=off'
-                    % (AVOCADO, self.jobid, self.tmpdir))
+                    % (AVOCADO, self.jobid, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_ALL_OK
         result = self.run_and_check(cmd_line, expected_rc)
         msg = b'Ignoring variants from source job with --replay-ignore.'
@@ -125,7 +124,7 @@ class ReplayTests(unittest.TestCase):
         """
         cmd_line = ('%s run --replay %s --replay-test-status E '
                     '--job-results-dir %s --sysinfo=off'
-                    % (AVOCADO, self.jobid, self.tmpdir))
+                    % (AVOCADO, self.jobid, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_FAIL
         result = self.run_and_check(cmd_line, expected_rc)
         msg = (b'Invalid --replay-test-status option. Valid options are (more '
@@ -138,7 +137,7 @@ class ReplayTests(unittest.TestCase):
         """
         cmd_line = ('%s run --replay %s --replay-test-status '
                     'FAIL --job-results-dir %s --sysinfo=off'
-                    % (AVOCADO, self.jobid, self.tmpdir))
+                    % (AVOCADO, self.jobid, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_ALL_OK
         result = self.run_and_check(cmd_line, expected_rc)
         msg = (b'RESULTS    : PASS 0 | ERROR 0 | FAIL 0 | SKIP 4 | WARN 0 | '
@@ -151,7 +150,7 @@ class ReplayTests(unittest.TestCase):
         """
         cmd_line = ('%s run --replay %s --replay-ignore variants '
                     '--replay-test-status FAIL --job-results-dir %s '
-                    '--sysinfo=off' % (AVOCADO, self.jobid, self.tmpdir))
+                    '--sysinfo=off' % (AVOCADO, self.jobid, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_FAIL
         result = self.run_and_check(cmd_line, expected_rc)
         msg = (b"Option `--replay-test-status` is incompatible with "
@@ -164,7 +163,7 @@ class ReplayTests(unittest.TestCase):
         """
         cmd_line = ('%s run sleeptest --replay %s '
                     '--replay-test-status FAIL --job-results-dir %s '
-                    '--sysinfo=off' % (AVOCADO, self.jobid, self.tmpdir))
+                    '--sysinfo=off' % (AVOCADO, self.jobid, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_FAIL
         result = self.run_and_check(cmd_line, expected_rc)
         msg = (b"Option --replay-test-status is incompatible with "
@@ -178,11 +177,11 @@ class ReplayTests(unittest.TestCase):
         """
         cmdline = ("%s run --replay %s --job-results-dir %s "
                    "--sysinfo=off -m selftests/.data/mux-selftest.yaml"
-                   % (AVOCADO, self.jobid, self.tmpdir))
+                   % (AVOCADO, self.jobid, self.tmpdir.name))
         self.run_and_check(cmdline, exit_codes.AVOCADO_ALL_OK)
 
     def tearDown(self):
-        shutil.rmtree(self.tmpdir)
+        self.tmpdir.cleanup()
 
 
 if __name__ == '__main__':

--- a/selftests/functional/test_replay_failfast.py
+++ b/selftests/functional/test_replay_failfast.py
@@ -1,7 +1,6 @@
 import glob
 import os
 import tempfile
-import shutil
 import unittest
 
 from avocado.core import exit_codes
@@ -14,13 +13,13 @@ class ReplayFailfastTests(unittest.TestCase):
 
     def setUp(self):
         prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
+        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
         cmd_line = ('%s run passtest.py failtest.py passtest.py '
                     '--failfast on --job-results-dir %s --sysinfo=off --json -'
-                    % (AVOCADO, self.tmpdir))
+                    % (AVOCADO, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL | exit_codes.AVOCADO_JOB_INTERRUPTED
         self.run_and_check(cmd_line, expected_rc)
-        self.jobdir = ''.join(glob.glob(os.path.join(self.tmpdir, 'job-*')))
+        self.jobdir = ''.join(glob.glob(os.path.join(self.tmpdir.name, 'job-*')))
         idfile = ''.join(os.path.join(self.jobdir, 'id'))
         with open(idfile, 'r') as f:
             self.jobid = f.read().strip('\n')
@@ -36,14 +35,14 @@ class ReplayFailfastTests(unittest.TestCase):
     def test_run_replay_failfast(self):
         cmd_line = ('%s run --replay %s '
                     '--job-results-dir %s --sysinfo=off'
-                    % (AVOCADO, self.jobid, self.tmpdir))
+                    % (AVOCADO, self.jobid, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL | exit_codes.AVOCADO_JOB_INTERRUPTED
         self.run_and_check(cmd_line, expected_rc)
 
     def test_run_replay_disable_failfast(self):
         cmd_line = ('%s run --replay %s --failfast off '
                     '--job-results-dir %s --sysinfo=off'
-                    % (AVOCADO, self.jobid, self.tmpdir))
+                    % (AVOCADO, self.jobid, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         result = self.run_and_check(cmd_line, expected_rc)
         msg = (b'Overriding the replay failfast with the --failfast value '
@@ -51,7 +50,7 @@ class ReplayFailfastTests(unittest.TestCase):
         self.assertIn(msg, result.stderr)
 
     def tearDown(self):
-        shutil.rmtree(self.tmpdir)
+        self.tmpdir.cleanup()
 
 
 if __name__ == '__main__':

--- a/selftests/functional/test_skiptests.py
+++ b/selftests/functional/test_skiptests.py
@@ -1,6 +1,5 @@
 import json
 import os
-import shutil
 import tempfile
 import unittest
 
@@ -80,24 +79,24 @@ class TestSkipDecorators(unittest.TestCase):
     def setUp(self):
         os.chdir(BASEDIR)
         prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
+        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
 
-        test_path = os.path.join(self.tmpdir, 'test_skip_decorators.py')
+        test_path = os.path.join(self.tmpdir.name, 'test_skip_decorators.py')
         self.test_module = script.Script(test_path,
                                          AVOCADO_TEST_SKIP_DECORATORS)
         self.test_module.save()
 
-        lib_path = os.path.join(self.tmpdir, 'lib_skip_decorators.py')
+        lib_path = os.path.join(self.tmpdir.name, 'lib_skip_decorators.py')
         self.test_lib = script.Script(lib_path, AVOCADO_TEST_SKIP_LIB)
         self.test_lib.save()
 
-        skip_setup_path = os.path.join(self.tmpdir,
+        skip_setup_path = os.path.join(self.tmpdir.name,
                                        'test_skip_decorator_setup.py')
         self.skip_setup = script.Script(skip_setup_path,
                                         AVOCADO_SKIP_DECORATOR_SETUP)
         self.skip_setup.save()
 
-        bad_teardown_path = os.path.join(self.tmpdir,
+        bad_teardown_path = os.path.join(self.tmpdir.name,
                                          'test_skip_decorator_teardown.py')
         self.bad_teardown = script.Script(bad_teardown_path,
                                           AVOCADO_SKIP_DECORATOR_TEARDOWN)
@@ -109,7 +108,7 @@ class TestSkipDecorators(unittest.TestCase):
                     'run',
                     '--sysinfo=off',
                     '--job-results-dir',
-                    '%s' % self.tmpdir,
+                    '%s' % self.tmpdir.name,
                     '%s' % self.test_module,
                     '--json -']
         result = process.run(' '.join(cmd_line), ignore_status=True)
@@ -129,7 +128,7 @@ class TestSkipDecorators(unittest.TestCase):
                     'run',
                     '--sysinfo=off',
                     '--job-results-dir',
-                    '%s' % self.tmpdir,
+                    '%s' % self.tmpdir.name,
                     '%s' % self.skip_setup,
                     '--json -']
         result = process.run(' '.join(cmd_line), ignore_status=True)
@@ -143,7 +142,7 @@ class TestSkipDecorators(unittest.TestCase):
                     'run',
                     '--sysinfo=off',
                     '--job-results-dir',
-                    '%s' % self.tmpdir,
+                    '%s' % self.tmpdir.name,
                     '%s' % self.bad_teardown,
                     '--json -']
         result = process.run(' '.join(cmd_line), ignore_status=True)
@@ -152,7 +151,7 @@ class TestSkipDecorators(unittest.TestCase):
         self.assertEqual(json_results['errors'], 1)
 
     def tearDown(self):
-        shutil.rmtree(self.tmpdir)
+        self.tmpdir.cleanup()
 
 
 if __name__ == '__main__':

--- a/selftests/functional/test_statuses.py
+++ b/selftests/functional/test_statuses.py
@@ -1,6 +1,5 @@
 import json
 import os
-import shutil
 import tempfile
 import unittest
 
@@ -131,7 +130,7 @@ class TestStatuses(unittest.TestCase):
 
     def setUp(self):
         prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
+        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
         test_file = os.path.abspath(os.path.join(os.path.dirname(__file__),
                                                  os.path.pardir,
                                                  ".data",
@@ -139,7 +138,7 @@ class TestStatuses(unittest.TestCase):
 
         os.chdir(BASEDIR)
         cmd = ('%s run %s --sysinfo=off --job-results-dir %s --json -' %
-               (AVOCADO, test_file, self.tmpdir))
+               (AVOCADO, test_file, self.tmpdir.name))
 
         results = process.run(cmd, ignore_status=True)
         self.results = json.loads(results.stdout_text)
@@ -182,7 +181,7 @@ class TestStatuses(unittest.TestCase):
                              (msg, klass_method, test, debug_log))
 
     def tearDown(self):
-        shutil.rmtree(self.tmpdir)
+        self.tmpdir.cleanup()
 
 
 if __name__ == '__main__':

--- a/selftests/functional/test_streams.py
+++ b/selftests/functional/test_streams.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 import shlex
 import tempfile
 import unittest
@@ -14,7 +13,7 @@ class StreamsTest(unittest.TestCase):
 
     def setUp(self):
         prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
+        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
         os.chdir(BASEDIR)
 
     def test_app_info_stdout(self):
@@ -48,10 +47,10 @@ class StreamsTest(unittest.TestCase):
         variable `AVOCADO_LOG_EARLY` being set.
         """
         cmds = (('%s --show early run --sysinfo=off '
-                 '--job-results-dir %s passtest.py' % (AVOCADO, self.tmpdir),
+                 '--job-results-dir %s passtest.py' % (AVOCADO, self.tmpdir.name),
                  {}),
                 ('%s run --sysinfo=off --job-results-dir'
-                 ' %s passtest.py' % (AVOCADO, self.tmpdir),
+                 ' %s passtest.py' % (AVOCADO, self.tmpdir.name),
                  {'AVOCADO_LOG_EARLY': 'y'}))
         for cmd, env in cmds:
             result = process.run(cmd, env=env, shell=True)
@@ -67,7 +66,7 @@ class StreamsTest(unittest.TestCase):
         Checks that the test stream (early in this case) goes to stdout
         """
         cmd = ('%s --show=test run --sysinfo=off --job-results-dir %s '
-               'passtest.py' % (AVOCADO, self.tmpdir))
+               'passtest.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
         # If using the Python interpreter, Avocado won't know about it
@@ -84,7 +83,7 @@ class StreamsTest(unittest.TestCase):
         Checks that only errors are output, and that they go to stderr
         """
         cmd = ('%s --show none run --sysinfo=off --job-results-dir %s '
-               'passtest.py' % (AVOCADO, self.tmpdir))
+               'passtest.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
         self.assertEqual(b'', result.stdout)
@@ -124,7 +123,7 @@ class StreamsTest(unittest.TestCase):
         run("avocado.app:30", 0)
 
     def tearDown(self):
-        shutil.rmtree(self.tmpdir)
+        self.tmpdir.cleanup()
 
 
 if __name__ == '__main__':

--- a/selftests/functional/test_unittest_compat.py
+++ b/selftests/functional/test_unittest_compat.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import shutil
 import tempfile
 import unittest
 
@@ -63,7 +62,7 @@ class UnittestCompat(unittest.TestCase):
 
     def setUp(self):
         prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
+        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
         self.original_pypath = os.environ.get('PYTHONPATH')
         if self.original_pypath is not None:
             os.environ['PYTHONPATH'] = '%s:%s' % (
@@ -72,17 +71,17 @@ class UnittestCompat(unittest.TestCase):
             os.environ['PYTHONPATH'] = '%s' % BASEDIR
         self.unittest_script_good = script.TemporaryScript(
             'unittest_good.py',
-            UNITTEST_GOOD % self.tmpdir,
+            UNITTEST_GOOD % self.tmpdir.name,
             'avocado_as_unittest_functional')
         self.unittest_script_good.save()
         self.unittest_script_fail = script.TemporaryScript(
             'unittest_fail.py',
-            UNITTEST_FAIL % self.tmpdir,
+            UNITTEST_FAIL % self.tmpdir.name,
             'avocado_as_unittest_functional')
         self.unittest_script_fail.save()
         self.unittest_script_error = script.TemporaryScript(
             'unittest_error.py',
-            UNITTEST_ERROR % self.tmpdir,
+            UNITTEST_ERROR % self.tmpdir.name,
             'avocado_as_unittest_functional')
         self.unittest_script_error.save()
 
@@ -112,7 +111,7 @@ class UnittestCompat(unittest.TestCase):
         self.unittest_script_error.remove()
         self.unittest_script_fail.remove()
         self.unittest_script_good.remove()
-        shutil.rmtree(self.tmpdir)
+        self.tmpdir.cleanup()
 
 
 if __name__ == '__main__':

--- a/selftests/functional/test_wrapper.py
+++ b/selftests/functional/test_wrapper.py
@@ -1,6 +1,5 @@
 import os
 import tempfile
-import shutil
 import unittest
 
 from avocado.core import exit_codes
@@ -33,7 +32,7 @@ class WrapperTest(unittest.TestCase):
 
     def setUp(self):
         prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
+        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
         self.tmpfile = tempfile.mktemp()
         self.script = script.TemporaryScript(
             'success.sh',
@@ -52,7 +51,7 @@ class WrapperTest(unittest.TestCase):
         os.chdir(BASEDIR)
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off --wrapper %s '
                     'examples/tests/datadir.py'
-                    % (AVOCADO, self.tmpdir, self.script.path))
+                    % (AVOCADO, self.tmpdir.name, self.script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
@@ -69,7 +68,7 @@ class WrapperTest(unittest.TestCase):
         os.chdir(BASEDIR)
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
                     '--wrapper %s:*/datadir examples/tests/datadir.py'
-                    % (AVOCADO, self.tmpdir, self.script.path))
+                    % (AVOCADO, self.tmpdir.name, self.script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
@@ -86,7 +85,7 @@ class WrapperTest(unittest.TestCase):
         os.chdir(BASEDIR)
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off --wrapper %s '
                     '--wrapper %s:*/datadir examples/tests/datadir.py'
-                    % (AVOCADO, self.tmpdir, self.dummy.path,
+                    % (AVOCADO, self.tmpdir.name, self.dummy.path,
                        self.script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -105,7 +104,7 @@ class WrapperTest(unittest.TestCase):
             os.remove(self.tmpfile)
         except OSError:
             pass
-        shutil.rmtree(self.tmpdir)
+        self.tmpdir.cleanup()
 
 
 if __name__ == '__main__':

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -1,6 +1,5 @@
 import argparse
 import os
-import shutil
 import tempfile
 import unittest.mock
 
@@ -23,7 +22,7 @@ class JobTest(unittest.TestCase):
         self.job = None
         data_dir._tmp_tracker.unittest_refresh_dir_tracker()
         prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
+        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
 
     @staticmethod
     def _find_simple_test_candidates(candidates=None):
@@ -38,7 +37,7 @@ class JobTest(unittest.TestCase):
         return found
 
     def test_job_empty_suite(self):
-        args = argparse.Namespace(base_logdir=self.tmpdir)
+        args = argparse.Namespace(base_logdir=self.tmpdir.name)
         self.job = job.Job(args)
         # Job without setup called
         self.assertIsNone(self.job.logdir)
@@ -73,12 +72,12 @@ class JobTest(unittest.TestCase):
         self.job.cleanup()
 
     def test_job_empty_has_id(self):
-        args = argparse.Namespace(base_logdir=self.tmpdir)
+        args = argparse.Namespace(base_logdir=self.tmpdir.name)
         self.job = job.Job(args)
         self.assertIsNotNone(self.job.unique_id)
 
     def test_two_jobs(self):
-        args = argparse.Namespace(base_logdir=self.tmpdir)
+        args = argparse.Namespace(base_logdir=self.tmpdir.name)
         with job.Job(args) as self.job, job.Job(args) as job2:
             job1 = self.job
             # uids, logdirs and tmpdirs must be different
@@ -91,12 +90,12 @@ class JobTest(unittest.TestCase):
             self.assertEqual(os.path.dirname(job1.logdir), os.path.dirname(job2.logdir))
 
     def test_job_test_suite_not_created(self):
-        args = argparse.Namespace(base_logdir=self.tmpdir)
+        args = argparse.Namespace(base_logdir=self.tmpdir.name)
         self.job = job.Job(args)
         self.assertIsNone(self.job.test_suite)
 
     def test_job_create_test_suite_empty(self):
-        args = argparse.Namespace(base_logdir=self.tmpdir)
+        args = argparse.Namespace(base_logdir=self.tmpdir.name)
         self.job = job.Job(args)
         self.job.setup()
         self.assertRaises(exceptions.OptionValidationError,
@@ -105,7 +104,7 @@ class JobTest(unittest.TestCase):
     def test_job_create_test_suite_simple(self):
         simple_tests_found = self._find_simple_test_candidates()
         args = argparse.Namespace(reference=simple_tests_found,
-                                  base_logdir=self.tmpdir)
+                                  base_logdir=self.tmpdir.name)
         self.job = job.Job(args)
         self.job.setup()
         self.job.create_test_suite()
@@ -123,7 +122,7 @@ class JobTest(unittest.TestCase):
                 super(JobFilterTime, self).pre_tests()
         simple_tests_found = self._find_simple_test_candidates()
         args = argparse.Namespace(reference=simple_tests_found,
-                                  base_logdir=self.tmpdir)
+                                  base_logdir=self.tmpdir.name)
         self.job = JobFilterTime(args)
         self.job.setup()
         self.job.create_test_suite()
@@ -136,7 +135,7 @@ class JobTest(unittest.TestCase):
     def test_job_run_tests(self):
         simple_tests_found = self._find_simple_test_candidates(['true'])
         args = argparse.Namespace(reference=simple_tests_found,
-                                  base_logdir=self.tmpdir)
+                                  base_logdir=self.tmpdir.name)
         self.job = job.Job(args)
         self.job.setup()
         self.job.create_test_suite()
@@ -151,7 +150,7 @@ class JobTest(unittest.TestCase):
                 super(JobLogPost, self).post_tests()
         simple_tests_found = self._find_simple_test_candidates()
         args = argparse.Namespace(reference=simple_tests_found,
-                                  base_logdir=self.tmpdir)
+                                  base_logdir=self.tmpdir.name)
         self.job = JobLogPost(args)
         self.job.setup()
         self.job.create_test_suite()
@@ -181,7 +180,7 @@ class JobTest(unittest.TestCase):
                 super(JobFilterLog, self).post_tests()
         simple_tests_found = self._find_simple_test_candidates()
         args = argparse.Namespace(reference=simple_tests_found,
-                                  base_logdir=self.tmpdir)
+                                  base_logdir=self.tmpdir.name)
         self.job = JobFilterLog(args)
         self.job.setup()
         self.assertEqual(self.job.run(),
@@ -192,7 +191,7 @@ class JobTest(unittest.TestCase):
                              reverse_id_file.read())
 
     def test_job_run_account_time(self):
-        args = argparse.Namespace(base_logdir=self.tmpdir)
+        args = argparse.Namespace(base_logdir=self.tmpdir.name)
         self.job = job.Job(args)
         self.job.setup()
         self.job.run()
@@ -201,7 +200,7 @@ class JobTest(unittest.TestCase):
         self.assertNotEqual(self.job.time_elapsed, -1)
 
     def test_job_self_account_time(self):
-        args = argparse.Namespace(base_logdir=self.tmpdir)
+        args = argparse.Namespace(base_logdir=self.tmpdir.name)
         self.job = job.Job(args)
         self.job.setup()
         self.job.time_start = 10.0
@@ -215,7 +214,7 @@ class JobTest(unittest.TestCase):
         self.assertEqual(self.job.time_elapsed, 100.0)
 
     def test_job_dryrun_no_unique_job_id(self):
-        args = argparse.Namespace(dry_run=True, base_logdir=self.tmpdir)
+        args = argparse.Namespace(dry_run=True, base_logdir=self.tmpdir.name)
         self.job = job.Job(args)
         self.job.setup()
         self.assertIsNotNone(self.job.args.unique_job_id)
@@ -223,11 +222,11 @@ class JobTest(unittest.TestCase):
     def test_job_no_base_logdir(self):
         args = argparse.Namespace()
         with unittest.mock.patch('avocado.core.job.data_dir.get_logs_dir',
-                                 return_value=self.tmpdir):
+                                 return_value=self.tmpdir.name):
             self.job = job.Job(args)
             self.job.setup()
         self.assertTrue(os.path.isdir(self.job.logdir))
-        self.assertEqual(os.path.dirname(self.job.logdir), self.tmpdir)
+        self.assertEqual(os.path.dirname(self.job.logdir), self.tmpdir.name)
         self.assertTrue(os.path.isfile(os.path.join(self.job.logdir, 'id')))
 
     def test_job_dryrun_no_base_logdir(self):
@@ -240,7 +239,7 @@ class JobTest(unittest.TestCase):
 
     def tearDown(self):
         data_dir._tmp_tracker.unittest_refresh_dir_tracker()
-        shutil.rmtree(self.tmpdir)
+        self.tmpdir.cleanup()
         if self.job is not None:
             self.job.cleanup()
 

--- a/selftests/unit/test_jsonresult.py
+++ b/selftests/unit/test_jsonresult.py
@@ -3,7 +3,6 @@ import os
 import json
 import argparse
 import tempfile
-import shutil
 
 from avocado import Test
 from avocado.core import job
@@ -34,21 +33,21 @@ class JSONResultTest(unittest.TestCase):
 
         self.tmpfile = tempfile.mkstemp()
         prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
+        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
         args = argparse.Namespace(json_output=self.tmpfile[1],
-                                  base_logdir=self.tmpdir)
+                                  base_logdir=self.tmpdir.name)
         self.job = job.Job(args)
         self.test_result = Result(FakeJob(args))
         self.test_result.filename = self.tmpfile[1]
         self.test_result.tests_total = 1
-        self.test1 = SimpleTest(job=self.job, base_logdir=self.tmpdir)
+        self.test1 = SimpleTest(job=self.job, base_logdir=self.tmpdir.name)
         self.test1._Test__status = 'PASS'
         self.test1.time_elapsed = 1.23
 
     def tearDown(self):
         os.close(self.tmpfile[0])
         os.remove(self.tmpfile[1])
-        shutil.rmtree(self.tmpdir)
+        self.tmpdir.cleanup()
 
     def test_add_success(self):
         self.test_result.start_test(self.test1)

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 import stat
 import tempfile
 import unittest.mock
@@ -170,7 +169,7 @@ class LoaderTest(unittest.TestCase):
     def setUp(self):
         self.loader = loader.FileLoader(None, {})
         prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
+        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
 
     def test_load_simple(self):
         simple_test = script.TemporaryScript('simpletest.sh', SIMPLE_TEST,
@@ -180,7 +179,7 @@ class LoaderTest(unittest.TestCase):
             self.loader.discover(simple_test.path, loader.DiscoverMode.ALL)[0])
         self.assertTrue(test_class == test.SimpleTest, test_class)
         test_parameters['name'] = test.TestID(0, test_parameters['name'])
-        test_parameters['base_logdir'] = self.tmpdir
+        test_parameters['base_logdir'] = self.tmpdir.name
         tc = test_class(**test_parameters)
         tc.run_avocado()
         suite = self.loader.discover(simple_test.path, loader.DiscoverMode.ALL)
@@ -226,7 +225,7 @@ class LoaderTest(unittest.TestCase):
             self.loader.discover(avocado_not_a_test.path, loader.DiscoverMode.ALL)[0])
         self.assertTrue(test_class == test.SimpleTest, test_class)
         test_parameters['name'] = test.TestID(0, test_parameters['name'])
-        test_parameters['base_logdir'] = self.tmpdir
+        test_parameters['base_logdir'] = self.tmpdir.name
         tc = test_class(**test_parameters)
         # The test can't be executed (no shebang), raising an OSError
         # (OSError: [Errno 8] Exec format error)
@@ -242,7 +241,7 @@ class LoaderTest(unittest.TestCase):
                 self.loader.discover(avocado_simple_test.path, loader.DiscoverMode.ALL)[0])
             self.assertTrue(test_class == test.SimpleTest)
             test_parameters['name'] = test.TestID(0, test_parameters['name'])
-            test_parameters['base_logdir'] = self.tmpdir
+            test_parameters['base_logdir'] = self.tmpdir.name
             tc = test_class(**test_parameters)
             tc.run_avocado()
 
@@ -414,7 +413,7 @@ class LoaderTest(unittest.TestCase):
                 self.assertEqual(tests[0][1]["name"], simple_test.path)
 
     def tearDown(self):
-        shutil.rmtree(self.tmpdir)
+        self.tmpdir.cleanup()
 
 
 if __name__ == '__main__':

--- a/selftests/unit/test_runner_queue.py
+++ b/selftests/unit/test_runner_queue.py
@@ -1,5 +1,4 @@
 import argparse
-import shutil
 import tempfile
 import unittest
 import multiprocessing
@@ -24,8 +23,8 @@ class TestRunnerQueue(unittest.TestCase):
 
     def setUp(self):
         prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
-        args = argparse.Namespace(base_logdir=self.tmpdir)
+        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
+        args = argparse.Namespace(base_logdir=self.tmpdir.name)
         self.job = Job(args)
         self.result = Result(self.job)
 
@@ -55,14 +54,14 @@ class TestRunnerQueue(unittest.TestCase):
                     'params': ([TreeNode(name='')], ['/run/*']),
                     'job': self.job,
                     'modulePath': module,
-                    'base_logdir': self.tmpdir}]
+                    'base_logdir': self.tmpdir.name}]
         msg = self._run_test(factory)
 
         self.assertEqual(msg['whiteboard'], 'TXkgbWVzc2FnZSBlbmNvZGVkIGluIGJhc2U2NA==\n')
         self.assertIn('phase', msg)
 
     def tearDown(self):
-        shutil.rmtree(self.tmpdir)
+        self.tmpdir.cleanup()
 
 
 if __name__ == '__main__':

--- a/selftests/unit/test_sysinfo.py
+++ b/selftests/unit/test_sysinfo.py
@@ -1,6 +1,5 @@
 import os
 import tempfile
-import shutil
 import unittest
 
 from avocado.core import sysinfo
@@ -12,7 +11,7 @@ class SysinfoTest(unittest.TestCase):
 
     def setUp(self):
         prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
+        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
 
     def test_loggables_equal(self):
         cmd1 = sysinfo.Command("ls -l")
@@ -53,7 +52,7 @@ class SysinfoTest(unittest.TestCase):
         self.assertEqual(len(container), 5)
 
     def test_logger_job_hooks(self):
-        jobdir = os.path.join(self.tmpdir, 'job')
+        jobdir = os.path.join(self.tmpdir.name, 'job')
         sysinfo_logger = sysinfo.SysInfo(basedir=jobdir)
         sysinfo_logger.start_job_hook()
         self.assertTrue(os.path.isdir(jobdir))
@@ -66,7 +65,7 @@ class SysinfoTest(unittest.TestCase):
         self.assertTrue(os.path.isdir(job_postdir))
 
     def test_logger_test_hooks(self):
-        testdir = os.path.join(self.tmpdir, 'job', 'test1')
+        testdir = os.path.join(self.tmpdir.name, 'job', 'test1')
         sysinfo_logger = sysinfo.SysInfo(basedir=testdir)
         sysinfo_logger.start_test_hook()
         self.assertTrue(os.path.isdir(testdir))
@@ -89,7 +88,7 @@ class SysinfoTest(unittest.TestCase):
                         % os.listdir(job_postdir))
 
     def tearDown(self):
-        shutil.rmtree(self.tmpdir)
+        self.tmpdir.cleanup()
 
 
 if __name__ == '__main__':

--- a/selftests/unit/test_utils_asset.py
+++ b/selftests/unit/test_utils_asset.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 import tempfile
 import unittest
 
@@ -16,15 +15,15 @@ class TestAsset(unittest.TestCase):
 
     def setUp(self):
         prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.basedir = tempfile.mkdtemp(prefix=prefix)
-        self.assetdir = tempfile.mkdtemp(dir=self.basedir)
+        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
+        self.assetdir = tempfile.mkdtemp(dir=self.tmpdir.name)
         self.assetname = 'foo.tgz'
         self.assethash = '3a033a8938c1af56eeb793669db83bcbd0c17ea5'
         self.localpath = os.path.join(self.assetdir, self.assetname)
         with open(self.localpath, 'w') as f:
             f.write('Test!')
         self.url = 'file://%s' % self.localpath
-        self.cache_dir = tempfile.mkdtemp(dir=self.basedir)
+        self.cache_dir = tempfile.mkdtemp(dir=self.tmpdir.name)
 
     def test_fetch_url_cache_by_location(self):
         foo_tarball = asset.Asset(self.url,
@@ -59,7 +58,7 @@ class TestAsset(unittest.TestCase):
             content1 = f.read()
 
         # Create the file in a different location with a different content
-        new_assetdir = tempfile.mkdtemp(dir=self.basedir)
+        new_assetdir = tempfile.mkdtemp(dir=self.tmpdir.name)
         new_localpath = os.path.join(new_assetdir, self.assetname)
         new_hash = '9f1ad57044be4799f288222dc91d5eab152921e9'
         new_url = 'file://%s' % new_localpath
@@ -120,7 +119,7 @@ class TestAsset(unittest.TestCase):
         a hash is used or not.
         """
         second_assetname = self.assetname
-        second_asset_origin_dir = tempfile.mkdtemp(dir=self.basedir)
+        second_asset_origin_dir = tempfile.mkdtemp(dir=self.tmpdir.name)
         second_asset_local_path = os.path.join(second_asset_origin_dir,
                                                second_assetname)
         second_asset_content = 'This is not your first asset content!'
@@ -138,7 +137,7 @@ class TestAsset(unittest.TestCase):
             self.assertEqual(a2_file.read(), second_asset_content)
 
         third_assetname = self.assetname
-        third_asset_origin_dir = tempfile.mkdtemp(dir=self.basedir)
+        third_asset_origin_dir = tempfile.mkdtemp(dir=self.tmpdir.name)
         third_asset_local_path = os.path.join(third_asset_origin_dir,
                                               third_assetname)
         third_asset_content = 'Another content!'
@@ -152,7 +151,7 @@ class TestAsset(unittest.TestCase):
             self.assertEqual(a3_file.read(), third_asset_content)
 
     def tearDown(self):
-        shutil.rmtree(self.basedir)
+        self.tmpdir.cleanup()
 
 
 if __name__ == "__main__":

--- a/selftests/unit/test_utils_cloudinit.py
+++ b/selftests/unit/test_utils_cloudinit.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 import tempfile
 import threading
 import unittest.mock
@@ -31,12 +30,12 @@ class CloudInitISO(unittest.TestCase):
 
     def setUp(self):
         prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
+        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
 
     @unittest.skipUnless(has_iso_create_write(),
                          "system lacks support for creating ISO images")
     def test_iso_no_phone_home(self):
-        path = os.path.join(self.tmpdir, "cloudinit.iso")
+        path = os.path.join(self.tmpdir.name, "cloudinit.iso")
         instance_id = b"INSTANCE_ID"
         username = b"AVOCADO_USER"
         password = b"AVOCADO_PASSWORD"
@@ -48,7 +47,7 @@ class CloudInitISO(unittest.TestCase):
         self.assertIn(password, user_data)
 
     def tearDown(self):
-        shutil.rmtree(self.tmpdir)
+        self.tmpdir.cleanup()
 
 
 class PhoneHome(unittest.TestCase):

--- a/selftests/unit/test_utils_filelock.py
+++ b/selftests/unit/test_utils_filelock.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 import tempfile
 import unittest
 
@@ -13,8 +12,8 @@ class TestFileLock(unittest.TestCase):
 
     def setUp(self):
         prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.basedir = tempfile.mkdtemp(prefix=prefix)
-        self.filename = os.path.join(self.basedir, 'file.img')
+        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
+        self.filename = os.path.join(self.tmpdir.name, 'file.img')
         self.content = 'Foo bar'
         with open(self.filename, 'w') as f:
             f.write(self.content)
@@ -37,7 +36,7 @@ class TestFileLock(unittest.TestCase):
         self.assertRaises(AlreadyLocked, self._readfile)
 
     def tearDown(self):
-        shutil.rmtree(self.basedir)
+        self.tmpdir.cleanup()
 
 
 if __name__ == "__main__":

--- a/selftests/unit/test_utils_iso9660.py
+++ b/selftests/unit/test_utils_iso9660.py
@@ -2,7 +2,6 @@
 Verifies the avocado.utils.iso9660 functionality
 """
 import os
-import shutil
 import tempfile
 import unittest.mock
 
@@ -56,7 +55,7 @@ class BaseIso9660:
                                                      "sample.iso"))
         self.iso = None
         prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
+        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
 
     def test_basic_workflow(self):
         """
@@ -64,7 +63,7 @@ class BaseIso9660:
         """
         self.assertEqual(self.iso.read("file"),
                          b"file content\n")
-        dst = os.path.join(self.tmpdir, "file")
+        dst = os.path.join(self.tmpdir.name, "file")
         self.iso.copy(os.path.join("Dir", "in_dir_file"), dst)
         self.assertEqual(open(dst).read(), "content of in-dir-file\n")
         self.iso.close()
@@ -91,7 +90,7 @@ class BaseIso9660:
     def tearDown(self):
         if self.iso is not None:
             self.iso.close()
-        shutil.rmtree(self.tmpdir)
+        self.tmpdir.cleanup()
 
 
 class IsoInfo(BaseIso9660, unittest.TestCase):
@@ -145,7 +144,7 @@ class PyCDLib(BaseIso9660, unittest.TestCase):
         self.iso = iso9660.ISO9660PyCDLib(self.iso_path)
 
     def test_create_write(self):
-        new_iso_path = os.path.join(self.tmpdir, 'new.iso')
+        new_iso_path = os.path.join(self.tmpdir.name, 'new.iso')
         new_iso = iso9660.ISO9660PyCDLib(new_iso_path)
         new_iso.create()
         content = b"AVOCADO"

--- a/selftests/unit/test_utils_partition.py
+++ b/selftests/unit/test_utils_partition.py
@@ -5,7 +5,6 @@ avocado.utils.partition unittests
 """
 
 import os
-import shutil
 import sys
 import tempfile
 import unittest.mock
@@ -40,15 +39,15 @@ class Base(unittest.TestCase):
                      'sudo')
     def setUp(self):
         prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.mkdtemp(prefix=prefix)
-        self.mountpoint = os.path.join(self.tmpdir, "disk")
+        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
+        self.mountpoint = os.path.join(self.tmpdir.name, "disk")
         os.mkdir(self.mountpoint)
-        self.disk = partition.Partition(os.path.join(self.tmpdir, "block"), 1,
+        self.disk = partition.Partition(os.path.join(self.tmpdir.name, "block"), 1,
                                         self.mountpoint)
 
     def tearDown(self):
         self.disk.unmount()
-        shutil.rmtree(self.tmpdir)
+        self.tmpdir.cleanup()
 
 
 class TestPartition(Base):


### PR DESCRIPTION
Which makes using shutil.rmtree() unnecessary, as the cleanup()
method of the TemporaryDirectory can be used instead.

CC: Jan Richter <jarichte@redhat.com>
Signed-off-by: Cleber Rosa <crosa@redhat.com>