### PR TITLE
selftests/unit/test_utils_diff_validator.py: allow test to run in par… [v2]

### DIFF
--- a/selftests/unit/test_utils_diff_validator.py
+++ b/selftests/unit/test_utils_diff_validator.py
@@ -1,16 +1,22 @@
 #!/usr/bin/env python
 
 import os
+import tempfile
 import unittest
 
 from avocado.utils import diff_validator
+
+from .. import temp_dir_prefix
 
 
 class ChangeValidationTest(unittest.TestCase):
 
     def setUp(self):
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
         self.change = diff_validator.Change()
-        self.files = ["file1.cnf", "file2.cnf"]
+        self.files = [os.path.join(self.tmpdir.name, "file1.cnf"),
+                      os.path.join(self.tmpdir.name, "file2.cnf")]
         with open(self.files[0], "w") as f:
             f.write("")
         with open(self.files[1], "w") as f:
@@ -18,8 +24,7 @@ class ChangeValidationTest(unittest.TestCase):
 
     def tearDown(self):
         diff_validator.del_temp_file_copies(self.change.get_target_files())
-        for f in self.files:
-            os.unlink(f)
+        self.tmpdir.cleanup()
 
     def test_change_success(self):
         files = self.files


### PR DESCRIPTION
…allel

The creation of the temporary files are done in the same place, so tests
can conflict with others when running in parallel (the default for
the N(ext) runner based executions).

This is what I've been seeing every now and then on Travis:

    ======================================================================
    ERROR: test_change_wrong_add (selftests.unit.test_utils_diff_validator.ChangeValidationTest)
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "/home/travis/build/avocado-framework/avocado/selftests/unit/test_utils_diff_validator.py", line 79, in test_change_wrong_add
        changes = diff_validator.extract_changes(change.get_target_files())
      File "/home/travis/build/avocado-framework/avocado/avocado/utils/diff_validator.py", line 143, in extract_changes
        with open(file1) as f1:
    FileNotFoundError: [Errno 2] No such file or directory: 'file1.cnf.tmp'

It's easy to reproduce on a local system running:

  $ avocado nrun selftests/unit/test_utils_diff_validator.py \
                 selftests/unit/test_utils_diff_validator.py \
                 selftests/unit/test_utils_diff_validator.py \
                 selftests/unit/test_utils_diff_validator.py \
                 selftests/unit/test_utils_diff_validator.py

The same test 5 times is just to increase the probability of clashes.

Signed-off-by: Cleber Rosa <crosa@redhat.com>

---

Changes from v1 (#3225):
 * Used `tempfile.TemporaryDirectory` instead of `tempfile.mkdtemp` + `shutil.rmtree`