### PR TITLE
NRunner: extra runners and avocado-instrumented support

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -459,7 +459,8 @@ COMMANDS_CAPABLE = {'capabilities': subcommand_capabilities,
 
 
 def parse():
-    parser = argparse.ArgumentParser(prog='nrunner')
+    parser = argparse.ArgumentParser(prog='avocado-runner',
+                                     description='*EXPERIMENTAL* N(ext) Runner')
     subcommands = parser.add_subparsers(dest='subcommand')
     subcommands.required = True
     subcommands.add_parser('capabilities')

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -173,11 +173,13 @@ RUNNABLE_KIND_CAPABLE = {'noop': NoOpRunner,
                          'python-unittest': PythonUnittestRunner}
 
 
-def runner_from_runnable(runnable):
+def runner_from_runnable(runnable, capables=None):
     """
     Gets a Runner instance from a Runnable
     """
-    runner = RUNNABLE_KIND_CAPABLE.get(runnable.kind, None)
+    if capables is None:
+        capables = RUNNABLE_KIND_CAPABLE
+    runner = capables.get(runnable.kind, None)
     if runner is not None:
         return runner(runnable)
     raise ValueError('Unsupported kind of runnable: %s' % runnable.kind)
@@ -293,9 +295,10 @@ class Task:
         if status_uris is not None:
             for status_uri in status_uris:
                 self.status_services.append(TaskStatusService(status_uri))
+        self.capables = RUNNABLE_KIND_CAPABLE
 
     def run(self):
-        runner = runner_from_runnable(self.runnable)
+        runner = runner_from_runnable(self.runnable, self.capables)
         for status in runner.run():
             status.update({"id": self.identifier})
             for status_service in self.status_services:

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -166,18 +166,20 @@ class PythonUnittestRunner(BaseRunner):
         yield queue.get()
 
 
+#: The runnables this specific application is capable of handling
+RUNNABLE_KIND_CAPABLE = {'noop': NoOpRunner,
+                         'exec': ExecRunner,
+                         'exec-test': ExecTestRunner,
+                         'python-unittest': PythonUnittestRunner}
+
+
 def runner_from_runnable(runnable):
     """
     Gets a Runner instance from a Runnable
     """
-    if runnable.kind == 'noop':
-        return NoOpRunner(runnable)
-    if runnable.kind == 'exec':
-        return ExecRunner(runnable)
-    if runnable.kind == 'exec-test':
-        return ExecTestRunner(runnable)
-    if runnable.kind == 'python-unittest':
-        return PythonUnittestRunner(runnable)
+    runner = RUNNABLE_KIND_CAPABLE.get(runnable.kind, None)
+    if runner is not None:
+        return runner(runnable)
     raise ValueError('Unsupported kind of runnable: %s' % runnable.kind)
 
 
@@ -442,10 +444,25 @@ def subcommand_status_server(args):
     loop.run_until_complete(server.wait())
 
 
+def subcommand_capabilities(_, echo=print):
+    data = {"runnables": [k for k in RUNNABLE_KIND_CAPABLE.keys()],
+            "commands": [k for k in COMMANDS_CAPABLE.keys()]}
+    echo(json.dumps(data))
+
+
+COMMANDS_CAPABLE = {'capabilities': subcommand_capabilities,
+                    'runnable-run': subcommand_runnable_run,
+                    'runnable-run-recipe': subcommand_runnable_run_recipe,
+                    'task-run': subcommand_task_run,
+                    'task-run-recipe': subcommand_task_run_recipe,
+                    'status-server': subcommand_status_server}
+
+
 def parse():
     parser = argparse.ArgumentParser(prog='nrunner')
     subcommands = parser.add_subparsers(dest='subcommand')
     subcommands.required = True
+    subcommands.add_parser('capabilities')
     runnable_run_parser = subcommands.add_parser('runnable-run')
     for arg in CMD_RUNNABLE_RUN_ARGS:
         runnable_run_parser.add_argument(*arg[0], **arg[1])
@@ -477,6 +494,8 @@ def main():
         subcommand_task_run_recipe(args)
     elif args.subcommand == 'status-server':
         subcommand_status_server(args)
+    elif args.subcommand == 'capabilities':
+        subcommand_capabilities(args)
 
 
 if __name__ == '__main__':

--- a/avocado/core/nrunner_avocado_instrumented.py
+++ b/avocado/core/nrunner_avocado_instrumented.py
@@ -1,0 +1,122 @@
+import argparse
+import json
+import multiprocessing
+import tempfile
+import time
+
+from . import job
+from . import loader
+from . import nrunner
+from .test import TestID
+from .tree import TreeNode
+
+
+class AvocadoInstrumentedTestRunner(nrunner.BaseRunner):
+
+    @staticmethod
+    def _run_avocado(runnable, queue):
+        # This assumes that a proper resolution (see resolver module)
+        # was performed, and that a URI contains:
+        # 1) path to python module
+        # 2) class
+        # 3) method
+        #
+        # TBD if the resolution uri should be composed like this, or
+        # broken down and stored into other data fields
+        module_path, klass_method = runnable.uri.split(':', 1)
+
+        klass, method = klass_method.split('.', 1)
+        test_factory = [klass,
+                        {'name': TestID(1, klass_method),
+                         'methodName': method,
+                         'base_logdir': tempfile.mkdtemp(),
+                         'job': job.Job(),
+                         'modulePath': module_path,
+                         'params': (TreeNode(), []),
+                         'tags': runnable.kwargs.get('tags')}]
+
+        instance = loader.loader.load_test(test_factory)
+        instance.run_avocado()
+        state = instance.get_state()
+        # This should probably be done in a xlator
+        if 'status' in state:
+            state['status'] = state['status'].lower()
+        # This is a hack because the name is a TestID instance that can not
+        # at this point be converted to JSON
+        if 'name' in state:
+            del state['name']
+        queue.put(state)
+
+    def run(self):
+        queue = multiprocessing.SimpleQueue()
+        process = multiprocessing.Process(target=self._run_avocado,
+                                          args=(self.runnable, queue))
+        process.start()
+
+        last_status = None
+        while queue.empty():
+            time.sleep(nrunner.RUNNER_RUN_CHECK_INTERVAL)
+            now = time.time()
+            if last_status is None or now > last_status + nrunner.RUNNER_RUN_STATUS_INTERVAL:
+                last_status = now
+                yield {'status': 'running'}
+
+        yield queue.get()
+
+
+def subcommand_capabilities(_, echo=print):
+    data = {"runnables": [k for k in RUNNABLE_KIND_CAPABLE.keys()],
+            "commands": [k for k in COMMANDS_CAPABLE.keys()]}
+    echo(json.dumps(data))
+
+
+def subcommand_runnable_run(args, echo=print):
+    runnable = nrunner.runnable_from_args(args)
+    runner = nrunner.runner_from_runnable(runnable, RUNNABLE_KIND_CAPABLE)
+
+    for status in runner.run():
+        echo(status)
+
+
+def subcommand_task_run(args, echo=print):
+    runnable = nrunner.runnable_from_args(args)
+    task = nrunner.Task(args.get('identifier'), runnable,
+                        args.get('status_uri', []))
+    task.capables = RUNNABLE_KIND_CAPABLE
+    nrunner.task_run(task, echo)
+
+
+COMMANDS_CAPABLE = {'capabilities': subcommand_capabilities,
+                    'runnable-run': subcommand_runnable_run,
+                    'task-run': subcommand_task_run}
+
+
+RUNNABLE_KIND_CAPABLE = {'avocado-instrumented': AvocadoInstrumentedTestRunner}
+
+
+def parse():
+    parser = argparse.ArgumentParser(
+        prog='avocado-runner-avocado-instrumented',
+        description='*EXPERIMENTAL* N(ext) Runner for avocado-instrumented tests')
+    subcommands = parser.add_subparsers(dest='subcommand')
+    subcommands.required = True
+    subcommands.add_parser('capabilities')
+    runnable_run_parser = subcommands.add_parser('runnable-run')
+    for arg in nrunner.CMD_RUNNABLE_RUN_ARGS:
+        runnable_run_parser.add_argument(*arg[0], **arg[1])
+    runnable_task_parser = subcommands.add_parser('task-run')
+    for arg in nrunner.CMD_TASK_RUN_ARGS:
+        runnable_task_parser.add_argument(*arg[0], **arg[1])
+    return parser.parse_args()
+
+
+def main():
+    args = vars(parse())
+    subcommand = args.get('subcommand')
+    kallable = COMMANDS_CAPABLE.get(subcommand)
+    if kallable is not None:
+        kallable(args)
+
+
+if __name__ == '__main__':
+    main()

--- a/avocado/plugins/nrun.py
+++ b/avocado/plugins/nrun.py
@@ -78,6 +78,8 @@ class NRun(CLICmd):
                 runnable = nrunner.Runnable('python-unittest', unittest_path)
             elif klass == test.SimpleTest:
                 runnable = nrunner.Runnable('exec-test', args.get('executable'))
+            elif isinstance(klass, str):
+                runnable = nrunner.Runnable('avocado-instrumented', name)
             else:
                 # FIXME: This should instead raise an error
                 print('WARNING: unknown test type "%s", using "noop"' % factory[0])

--- a/docs/source/NRunner.rst
+++ b/docs/source/NRunner.rst
@@ -125,6 +125,19 @@ file.  The format chosen is JSON, and that should allow both
 quick and easy machine handling and also manual creation of
 recipes when necessary.
 
+Runners
+=======
+
+A runner can be capable of running one or many different kinds of
+runnables.  A runner should implement a ``capabilities`` command
+that returns, among other info, a list of runnable kinds that it
+can (to the best of its knowledge) run.  Example::
+
+  python3 -m avocado.core.nrunner capabilities
+  {'runnables': ['noop', 'exec', 'exec-test', 'python-unittest'],
+   'commands': ['capabilities', 'runnable-run', 'runnable-run-recipe',
+   'task-run', 'task-run-recipe', 'status-server']}
+
 Runner Execution
 ================
 

--- a/docs/source/NRunner.rst
+++ b/docs/source/NRunner.rst
@@ -138,6 +138,13 @@ can (to the best of its knowledge) run.  Example::
    'commands': ['capabilities', 'runnable-run', 'runnable-run-recipe',
    'task-run', 'task-run-recipe', 'status-server']}
 
+Runner scripts
+==============
+
+The primary runner implementation is a Python module that can be run,
+as shown before, with the ``avocado.core.nrunner`` module name.
+Additionally it's also available as the ``avocado-runner`` script.
+
 Runner Execution
 ================
 

--- a/selftests/functional/test_nrunner_interface.py
+++ b/selftests/functional/test_nrunner_interface.py
@@ -1,0 +1,33 @@
+import json
+import sys
+
+from avocado import Test
+from avocado import fail_on
+
+from avocado.utils import process
+
+
+class Interface(Test):
+
+    def get_runner(self):
+        default_runner = "%s -m avocado.core.nrunner" % sys.executable
+        return self.params.get("runner", default=default_runner)
+
+    @fail_on(process.CmdError)
+    def test_help(self):
+        """
+        Makes sure a runner can be called with --help and that the
+        basic required commands are present in the help message
+        """
+        cmd = "%s --help" % self.get_runner()
+        result = process.run(cmd)
+        self.assertIn(b"capabilities", result.stdout,
+                      "Mention to capabilities command not found")
+
+    @fail_on(process.CmdError)
+    @fail_on(json.JSONDecodeError)
+    def test_capabilities(self):
+        cmd = "%s capabilities" % self.get_runner()
+        result = process.run(cmd)
+        capabilities = json.loads(result.stdout_text)
+        self.assertIn("runnables", capabilities)

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ if __name__ == '__main__':
           entry_points={
               'console_scripts': [
                   'avocado-runner = avocado.core.nrunner:main',
+                  'avocado-runner-avocado-instrumented = avocado.core.nrunner_avocado_instrumented:main',
                   ],
               'avocado.plugins.cli': [
                   'envkeep = avocado.plugins.envkeep:EnvKeep',

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,9 @@ if __name__ == '__main__':
           include_package_data=True,
           scripts=['scripts/avocado'],
           entry_points={
+              'console_scripts': [
+                  'avocado-runner = avocado.core.nrunner:main',
+                  ],
               'avocado.plugins.cli': [
                   'envkeep = avocado.plugins.envkeep:EnvKeep',
                   'gdb = avocado.plugins.gdb:GDB',


### PR DESCRIPTION
This adds some introspection to a runner by means of the `capabilities` command, and makes the `avocado nrun` command (the early equivalent to the creation of an Avocado job and counterpart to the `avocado run` command) able to use other external binaries/scripts to run different kinds of tests (runnables).

The last commit adds, for the first time, an Avocado selftests written as an Avocado INSTRUMENTED test, with the following goals:

1) test the basic behavior of multiple runner implementations
2) experience with Avocado selftests written as Avocado INSTRUMENTED tests
3) test "avocado nrun" and the avocado-runner-avocado-instrumented
