### PR TITLE
Updating pci and multipath utils to python3

### DIFF
--- a/avocado/utils/multipath.py
+++ b/avocado/utils/multipath.py
@@ -85,7 +85,8 @@ def get_mpath_name(wwid):
     """
     if device_exists(wwid):
         cmd = "multipath -l %s" % wwid
-        return process.system_output(cmd, sudo=True).split()[0]
+        return process.system_output(cmd,
+                                     sudo=True).decode("utf-8").split()[0]
 
 
 def get_multipath_wwids():
@@ -95,7 +96,8 @@ def get_multipath_wwids():
     :return: List of multipath wwids.
     """
     cmd = "egrep -v '^($|#)' /etc/multipath/wwids"
-    wwids = process.system_output(cmd, ignore_status=True, sudo=True)
+    wwids = process.system_output(cmd, ignore_status=True,
+                                  sudo=True).decode("utf-8")
     wwids = wwids.strip("\n").replace("/", "").split("\n")
     return wwids
 
@@ -109,7 +111,8 @@ def get_paths(wwid):
     if not device_exists(wwid):
         return
     cmd = "multipath -ll %s" % wwid
-    lines = process.system_output(cmd, sudo=True).strip("\n")
+    lines = process.system_output(cmd,
+                                  sudo=True).decode("utf-8").strip("\n")
     paths = []
     for line in lines.split("\n"):
         if not (('size' in line) or ('policy' in line) or (wwid in line)):
@@ -124,7 +127,8 @@ def get_multipath_details():
 
     :return: Dictionary of multipath output in json format.
     """
-    mpath_op = process.system_output("multipathd show maps json", sudo=True)
+    mpath_op = process.system_output("multipathd show maps json",
+                                     sudo=True).decode("utf-8")
     if 'multipath-tools v' in mpath_op:
         return ''
     mpath_op = ast.literal_eval(mpath_op.replace("\n", '').replace(' ', ''))
@@ -204,8 +208,8 @@ def get_policy(wwid):
     """
     if device_exists(wwid):
         cmd = "multipath -ll %s" % wwid
-        lines = process.system_output(cmd, sudo=True).strip("\n")
-        for line in lines.split("\n"):
+        lines = process.system_output(cmd, sudo=True).decode("utf-8")
+        for line in lines.strip("\n").split("\n"):
             if 'policy' in line:
                 return line.split("'")[1].split()[0]
 
@@ -218,8 +222,8 @@ def get_size(wwid):
     """
     if device_exists(wwid):
         cmd = "multipath -ll %s" % wwid
-        lines = process.system_output(cmd, sudo=True).strip("\n")
-        for line in lines.split("\n"):
+        lines = process.system_output(cmd, sudo=True).decode("utf-8")
+        for line in lines.strip("\n").split("\n"):
             if 'size' in line:
                 return line.split("=")[1].split()[0]
 

--- a/avocado/utils/pci.py
+++ b/avocado/utils/pci.py
@@ -34,12 +34,13 @@ def get_domains():
     :return: List of PCI domains.
     """
     cmd = "lspci -D"
-    output = process.system_output(cmd, ignore_status=True)
+    output = process.system_output(cmd, ignore_status=True).decode("utf-8")
     if output:
         domains = []
         for line in output.splitlines():
             domains.append(line.split(":")[0])
         return list(set(domains))
+    return []
 
 
 def get_pci_addresses():
@@ -51,11 +52,12 @@ def get_pci_addresses():
     """
     addresses = []
     cmd = "lspci -D"
-    for line in process.system_output(cmd).splitlines():
+    for line in process.system_output(cmd).decode("utf-8").splitlines():
         if not get_pci_prop(line.split()[0], 'Class').startswith('06'):
             addresses.append(line.split()[0])
     if addresses:
         return addresses
+    return []
 
 
 def get_num_interfaces_in_pci(dom_pci_address):
@@ -69,7 +71,8 @@ def get_num_interfaces_in_pci(dom_pci_address):
     :return: number of devices in a PCI domain.
     """
     cmd = "ls -l /sys/class/*/ -1"
-    output = process.system_output(cmd, ignore_status=True, shell=True)
+    output = process.system_output(cmd, ignore_status=True,
+                                   shell=True).decode("utf-8")
     if output:
         filt = '/%s' % dom_pci_address
         count = 0
@@ -77,6 +80,7 @@ def get_num_interfaces_in_pci(dom_pci_address):
             if filt in line:
                 count += 1
         return count
+    return 0
 
 
 def get_disks_in_pci_address(pci_address):
@@ -229,7 +233,7 @@ def get_pci_prop(pci_address, prop):
     :return: specific PCI ID of a PCI address.
     """
     cmd = "lspci -Dnvmm -s %s" % pci_address
-    output = process.system_output(cmd, ignore_status=True)
+    output = process.system_output(cmd, ignore_status=True).decode("utf-8")
     if output:
         for line in output.splitlines():
             if prop == line.split(':')[0]:
@@ -263,7 +267,7 @@ def get_driver(pci_address):
     :return: driver of a PCI address.
     """
     cmd = "lspci -ks %s" % pci_address
-    output = process.system_output(cmd, ignore_status=True)
+    output = process.system_output(cmd, ignore_status=True).decode("utf-8")
     if output:
         for line in output.splitlines():
             if 'Kernel driver in use:' in line:
@@ -282,7 +286,7 @@ def get_memory_address(pci_address):
     :return: memory address of a pci_address.
     """
     cmd = "lspci -bv -s %s" % pci_address
-    output = process.system_output(cmd, ignore_status=True)
+    output = process.system_output(cmd, ignore_status=True).decode("utf-8")
     if output:
         for line in output.splitlines():
             if 'Memory at' in line:
@@ -301,7 +305,7 @@ def get_mask(pci_address):
     :return: mask of a PCI address.
     """
     cmd = "lspci -vv -s %s" % pci_address
-    output = process.system_output(cmd, ignore_status=True)
+    output = process.system_output(cmd, ignore_status=True).decode("utf-8")
     if output:
         dic = {'K': 1024, 'M': 1048576, 'G': 1073741824}
         for line in output.splitlines():
@@ -326,7 +330,7 @@ def get_vpd(dom_pci_address):
     :return: dictionary of VPD of a PCI address.
     """
     cmd = "lsvpd -l %s" % dom_pci_address
-    vpd = process.system_output(cmd)
+    vpd = process.system_output(cmd).decode("utf-8")
     vpd_dic = {}
     dev_list = []
     for line in vpd.splitlines():
@@ -360,7 +364,7 @@ def get_cfg(dom_pci_address):
     :return: dictionary of configuration data of a PCI address.
     """
     cmd = "lscfg -vl %s" % dom_pci_address
-    cfg = process.system_output(cmd)
+    cfg = process.system_output(cmd).decode("utf-8")
     cfg_dic = {}
     desc = re.match(r'  (%s)( [-\w+,\.]+)+([ \n])+([-\w+, \(\)])+'
                     % dom_pci_address, cfg).group()


### PR DESCRIPTION
Updating pci and multipath utils to work with the latest
python standards. Also included pylint fixes.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>