### PR TITLE
Fix can not load svg files in HTML

### DIFF
--- a/optional_plugins/html/avocado_result_html/__init__.py
+++ b/optional_plugins/html/avocado_result_html/__init__.py
@@ -22,6 +22,7 @@ import shutil
 import subprocess
 import sys
 import time
+import base64
 
 import jinja2 as jinja
 
@@ -63,13 +64,24 @@ class ReportModel:
             sysinfo_contents = "Error reading %s: %s" % (sysinfo_path, details)
         return sysinfo_contents
 
+    @staticmethod
+    def _icon_data(icon_name):
+        with open(os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                               'templates', 'images', icon_name), 'rb') as icon:
+            icon_base64 = base64.b64encode(icon.read()).decode()
+        return icon_base64
+
     @property
     def hostname(self):
         return self._get_sysinfo('hostname').strip()
 
     @property
-    def source_path(self):
-        return os.path.join(os.path.dirname(os.path.abspath(__file__)), 'templates')
+    def logs_icon(self):
+        return self._icon_data('logs_icon.svg')
+
+    @property
+    def whiteboard_icon(self):
+        return self._icon_data('whiteboard_icon.svg')
 
     @property
     def tests(self):

--- a/optional_plugins/html/avocado_result_html/templates/results.html
+++ b/optional_plugins/html/avocado_result_html/templates/results.html
@@ -83,8 +83,8 @@
           <td><div>{{ test.fail_reason|safe }}</div></td>
           <td>
             <div>
-              <a class="col-xs-1" href="{{ test.logfile }}"><img src="{{ data.source_path + '/images/logs_icon.svg'}}" title="Debug log"/></a>
-              <div class="col-xs-1 hiddenText"><img src="{{ data.source_path + '/images/whiteboard_icon.svg'}}"/></div>
+              <a class="col-xs-1" href="{{ test.logfile }}"><span class="icon" id="icon-logs" title="Debug log"></span></a>
+              <div class="col-xs-1 hiddenText"><span class="icon" id="icon-whiteboard"></span></div>
             </div>
             <span class="spnTooltip"><strong>Whiteboard:</strong><br>{{test.whiteboard}}</span>
           </td>

--- a/optional_plugins/html/avocado_result_html/templates/style.css
+++ b/optional_plugins/html/avocado_result_html/templates/style.css
@@ -6,7 +6,7 @@
     color:#111;
     border:1px solid #337ab7;
     background:#fff;
-    white-space: pre;
+    white-space: pre-wrap;
 }
 .font-weight-normal {
     font-weight: normal;
@@ -18,4 +18,19 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+}
+/* Basic metadata for svg */
+.icon {
+    padding-left: 11px;
+    padding-right: 11px;
+    width: 22px;
+    height: 22px;
+    background-repeat: no-repeat;
+    display: table-cell;
+}
+#icon-logs {
+    background-image: url("data:image/svg+xml;base64,{{ data.logs_icon|safe }}");
+}
+#icon-whiteboard {
+    background-image: url("data:image/svg+xml;base64,{{ data.whiteboard_icon|safe }}");
 }


### PR DESCRIPTION
1. Inline SVG in CSS instead of retrieving SVG files from directory.
2. Replace `white-space: pre` with `white-space: pre-wrap`

Signed-off-by: Yihuang Yu <yihyu@redhat.com>