### PR TITLE
Nrunner: extra runners and INSTRUMENTED support

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -459,7 +459,8 @@ COMMANDS_CAPABLE = {'capabilities': subcommand_capabilities,
 
 
 def parse():
-    parser = argparse.ArgumentParser(prog='nrunner')
+    parser = argparse.ArgumentParser(prog='avocado-runner',
+                                     description='*EXPERIMENTAL* N(ext) Runner')
     subcommands = parser.add_subparsers(dest='subcommand')
     subcommands.required = True
     subcommands.add_parser('capabilities')

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -173,11 +173,13 @@ RUNNABLE_KIND_CAPABLE = {'noop': NoOpRunner,
                          'python-unittest': PythonUnittestRunner}
 
 
-def runner_from_runnable(runnable):
+def runner_from_runnable(runnable, capables=None):
     """
     Gets a Runner instance from a Runnable
     """
-    runner = RUNNABLE_KIND_CAPABLE.get(runnable.kind, None)
+    if capables is None:
+        capables = RUNNABLE_KIND_CAPABLE
+    runner = capables.get(runnable.kind, None)
     if runner is not None:
         return runner(runnable)
     raise ValueError('Unsupported kind of runnable: %s' % runnable.kind)
@@ -293,9 +295,10 @@ class Task:
         if status_uris is not None:
             for status_uri in status_uris:
                 self.status_services.append(TaskStatusService(status_uri))
+        self.capables = RUNNABLE_KIND_CAPABLE
 
     def run(self):
-        runner = runner_from_runnable(self.runnable)
+        runner = runner_from_runnable(self.runnable, self.capables)
         for status in runner.run():
             status.update({"id": self.identifier})
             for status_service in self.status_services:

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -166,18 +166,20 @@ class PythonUnittestRunner(BaseRunner):
         yield queue.get()
 
 
+#: The runnables this specific application is capable of handling
+RUNNABLE_KIND_CAPABLE = {'noop': NoOpRunner,
+                         'exec': ExecRunner,
+                         'exec-test': ExecTestRunner,
+                         'python-unittest': PythonUnittestRunner}
+
+
 def runner_from_runnable(runnable):
     """
     Gets a Runner instance from a Runnable
     """
-    if runnable.kind == 'noop':
-        return NoOpRunner(runnable)
-    if runnable.kind == 'exec':
-        return ExecRunner(runnable)
-    if runnable.kind == 'exec-test':
-        return ExecTestRunner(runnable)
-    if runnable.kind == 'python-unittest':
-        return PythonUnittestRunner(runnable)
+    runner = RUNNABLE_KIND_CAPABLE.get(runnable.kind, None)
+    if runner is not None:
+        return runner(runnable)
     raise ValueError('Unsupported kind of runnable: %s' % runnable.kind)
 
 
@@ -442,10 +444,25 @@ def subcommand_status_server(args):
     loop.run_until_complete(server.wait())
 
 
+def subcommand_capabilities(_, echo=print):
+    data = {"runnables": [k for k in RUNNABLE_KIND_CAPABLE.keys()],
+            "commands": [k for k in COMMANDS_CAPABLE.keys()]}
+    echo(json.dumps(data))
+
+
+COMMANDS_CAPABLE = {'capabilities': subcommand_capabilities,
+                    'runnable-run': subcommand_runnable_run,
+                    'runnable-run-recipe': subcommand_runnable_run_recipe,
+                    'task-run': subcommand_task_run,
+                    'task-run-recipe': subcommand_task_run_recipe,
+                    'status-server': subcommand_status_server}
+
+
 def parse():
     parser = argparse.ArgumentParser(prog='nrunner')
     subcommands = parser.add_subparsers(dest='subcommand')
     subcommands.required = True
+    subcommands.add_parser('capabilities')
     runnable_run_parser = subcommands.add_parser('runnable-run')
     for arg in CMD_RUNNABLE_RUN_ARGS:
         runnable_run_parser.add_argument(*arg[0], **arg[1])
@@ -478,6 +495,8 @@ def main():
         subcommand_task_run_recipe(args)
     elif subcommand == 'status-server':
         subcommand_status_server(args)
+    elif subcommand == 'capabilities':
+        subcommand_capabilities(args)
 
 
 if __name__ == '__main__':

--- a/avocado/core/nrunner_avocado_instrumented.py
+++ b/avocado/core/nrunner_avocado_instrumented.py
@@ -1,0 +1,122 @@
+import argparse
+import json
+import multiprocessing
+import tempfile
+import time
+
+from . import job
+from . import loader
+from . import nrunner
+from .test import TestID
+from .tree import TreeNode
+
+
+class AvocadoInstrumentedTestRunner(nrunner.BaseRunner):
+
+    @staticmethod
+    def _run_avocado(runnable, queue):
+        # This assumes that a proper resolution (see resolver module)
+        # was performed, and that a URI contains:
+        # 1) path to python module
+        # 2) class
+        # 3) method
+        #
+        # TBD if the resolution uri should be composed like this, or
+        # broken down and stored into other data fields
+        module_path, klass_method = runnable.uri.split(':', 1)
+
+        klass, method = klass_method.split('.', 1)
+        test_factory = [klass,
+                        {'name': TestID(1, klass_method),
+                         'methodName': method,
+                         'base_logdir': tempfile.mkdtemp(),
+                         'job': job.Job(),
+                         'modulePath': module_path,
+                         'params': (TreeNode(), []),
+                         'tags': runnable.kwargs.get('tags')}]
+
+        instance = loader.loader.load_test(test_factory)
+        instance.run_avocado()
+        state = instance.get_state()
+        # This should probably be done in a xlator
+        if 'status' in state:
+            state['status'] = state['status'].lower()
+        # This is a hack because the name is a TestID instance that can not
+        # at this point be converted to JSON
+        if 'name' in state:
+            del state['name']
+        queue.put(state)
+
+    def run(self):
+        queue = multiprocessing.SimpleQueue()
+        process = multiprocessing.Process(target=self._run_avocado,
+                                          args=(self.runnable, queue))
+        process.start()
+
+        last_status = None
+        while queue.empty():
+            time.sleep(nrunner.RUNNER_RUN_CHECK_INTERVAL)
+            now = time.time()
+            if last_status is None or now > last_status + nrunner.RUNNER_RUN_STATUS_INTERVAL:
+                last_status = now
+                yield {'status': 'running'}
+
+        yield queue.get()
+
+
+def subcommand_capabilities(_, echo=print):
+    data = {"runnables": [k for k in RUNNABLE_KIND_CAPABLE.keys()],
+            "commands": [k for k in COMMANDS_CAPABLE.keys()]}
+    echo(json.dumps(data))
+
+
+def subcommand_runnable_run(args, echo=print):
+    runnable = nrunner.runnable_from_args(args)
+    runner = nrunner.runner_from_runnable(runnable, RUNNABLE_KIND_CAPABLE)
+
+    for status in runner.run():
+        echo(status)
+
+
+def subcommand_task_run(args, echo=print):
+    runnable = nrunner.runnable_from_args(args)
+    task = nrunner.Task(args.get('identifier'), runnable,
+                        args.get('status_uri', []))
+    task.capables = RUNNABLE_KIND_CAPABLE
+    nrunner.task_run(task, echo)
+
+
+COMMANDS_CAPABLE = {'capabilities': subcommand_capabilities,
+                    'runnable-run': subcommand_runnable_run,
+                    'task-run': subcommand_task_run}
+
+
+RUNNABLE_KIND_CAPABLE = {'avocado-instrumented': AvocadoInstrumentedTestRunner}
+
+
+def parse():
+    parser = argparse.ArgumentParser(
+        prog='avocado-runner-avocado-instrumented',
+        description='*EXPERIMENTAL* N(ext) Runner for avocado-instrumented tests')
+    subcommands = parser.add_subparsers(dest='subcommand')
+    subcommands.required = True
+    subcommands.add_parser('capabilities')
+    runnable_run_parser = subcommands.add_parser('runnable-run')
+    for arg in nrunner.CMD_RUNNABLE_RUN_ARGS:
+        runnable_run_parser.add_argument(*arg[0], **arg[1])
+    runnable_task_parser = subcommands.add_parser('task-run')
+    for arg in nrunner.CMD_TASK_RUN_ARGS:
+        runnable_task_parser.add_argument(*arg[0], **arg[1])
+    return parser.parse_args()
+
+
+def main():
+    args = vars(parse())
+    subcommand = args.get('subcommand')
+    kallable = COMMANDS_CAPABLE.get(subcommand)
+    if kallable is not None:
+        kallable(args)
+
+
+if __name__ == '__main__':
+    main()

--- a/avocado/plugins/nrun.py
+++ b/avocado/plugins/nrun.py
@@ -12,12 +12,15 @@ from avocado.core import test
 from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLICmd
 from avocado.utils import stacktrace
+from avocado.utils import path as utils_path
 
 
 class NRun(CLICmd):
 
     name = 'nrun'
     description = "*EXPERIMENTAL* runner: runs one or more tests"
+
+    KNOWN_EXTERNAL_RUNNERS = {}
 
     def configure(self, parser):
         parser = super(NRun, self).configure(parser)
@@ -103,9 +106,38 @@ class NRun(CLICmd):
             self.spawned_tasks.append(identifier)
             print("%s spawned" % identifier)
 
-    @staticmethod
+    def pick_runner(self, task):
+        kind = task.runnable.kind
+        runner = self.KNOWN_EXTERNAL_RUNNERS.get(kind)
+        if runner is False:
+            return None
+        if runner is not None:
+            return runner
+
+        # first attempt to find Python module files that are named
+        # after the runner convention within the avocado.core
+        # namespace dir.  Looking for the file only avoids an attempt
+        # to load the module and should be a lot faster
+        core_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        module_name = kind.replace('-', '_')
+        module_filename = 'nrunner_%s.py' % module_name
+        if os.path.exists(os.path.join(core_dir, module_filename)):
+            full_module_name = 'avocado.core.%s' % module_name
+            runner = [sys.executable, '-m', full_module_name]
+            self.KNOWN_EXTERNAL_RUNNERS[kind] = runner
+            return runner
+
+        # try to find executable in the path
+        runner_by_name = 'avocado-runner-%s' % kind
+        try:
+            runner = utils_path.find_command(runner_by_name)
+            self.KNOWN_EXTERNAL_RUNNERS[kind] = [runner]
+            return [runner]
+        except utils_path.CmdNotFoundError:
+            self.KNOWN_EXTERNAL_RUNNERS[kind] = False
+
     @asyncio.coroutine
-    def spawn_task(task):
+    def spawn_task(self, task):
         status_service_args = []
         for status_service in task.status_services:
             status_service_args.append('-s')
@@ -121,8 +153,7 @@ class NRun(CLICmd):
         if task.runnable.uri is not None:
             runner_args += ['-u', task.runnable.uri]
 
-        args = ['-m', 'avocado.core.nrunner',
-                'task-run',
+        args = ['task-run',
                 '-i', task.identifier,
                 '-k', task.runnable.kind]
 
@@ -130,9 +161,16 @@ class NRun(CLICmd):
         args += list(runner_args)
         args += list(status_service_args)
 
+        runner = self.pick_runner(task)
+        if runner is None:
+            runner = [sys.executable, '-m', 'avocado.core.nrunner']
+
+        args = runner[1:] + args
+        runner = runner[0]
+
         #pylint: disable=E1133
         yield from asyncio.create_subprocess_exec(
-            sys.executable,
+            runner,
             *args,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE)

--- a/avocado/plugins/nrun.py
+++ b/avocado/plugins/nrun.py
@@ -78,6 +78,8 @@ class NRun(CLICmd):
                 runnable = nrunner.Runnable('python-unittest', unittest_path)
             elif klass == test.SimpleTest:
                 runnable = nrunner.Runnable('exec-test', args.get('executable'))
+            elif isinstance(klass, str):
+                runnable = nrunner.Runnable('avocado-instrumented', name)
             else:
                 # FIXME: This should instead raise an error
                 print('WARNING: unknown test type "%s", using "noop"' % factory[0])

--- a/docs/source/NRunner.rst
+++ b/docs/source/NRunner.rst
@@ -127,6 +127,19 @@ file.  The format chosen is JSON, and that should allow both
 quick and easy machine handling and also manual creation of
 recipes when necessary.
 
+Runners
+=======
+
+A runner can be capable of running one or many different kinds of
+runnables.  A runner should implement a ``capabilities`` command
+that returns, among other info, a list of runnable kinds that it
+can (to the best of its knowledge) run.  Example::
+
+  python3 -m avocado.core.nrunner capabilities
+  {'runnables': ['noop', 'exec', 'exec-test', 'python-unittest'],
+   'commands': ['capabilities', 'runnable-run', 'runnable-run-recipe',
+   'task-run', 'task-run-recipe', 'status-server']}
+
 Runner Execution
 ================
 

--- a/docs/source/NRunner.rst
+++ b/docs/source/NRunner.rst
@@ -140,6 +140,13 @@ can (to the best of its knowledge) run.  Example::
    'commands': ['capabilities', 'runnable-run', 'runnable-run-recipe',
    'task-run', 'task-run-recipe', 'status-server']}
 
+Runner scripts
+==============
+
+The primary runner implementation is a Python module that can be run,
+as shown before, with the ``avocado.core.nrunner`` module name.
+Additionally it's also available as the ``avocado-runner`` script.
+
 Runner Execution
 ================
 

--- a/selftests/functional/test_nrunner_interface.py
+++ b/selftests/functional/test_nrunner_interface.py
@@ -1,0 +1,32 @@
+import json
+import sys
+
+from avocado import Test
+from avocado import fail_on
+
+from avocado.utils import process
+
+
+class Interface(Test):
+
+    def get_runner(self):
+        default_runner = "%s -m avocado.core.nrunner" % sys.executable
+        return self.params.get("runner", default=default_runner)
+
+    @fail_on(process.CmdError)
+    def test_help(self):
+        """
+        Makes sure a runner can be called with --help and that the
+        basic required commands are present in the help message
+        """
+        cmd = "%s --help" % self.get_runner()
+        result = process.run(cmd)
+        self.assertIn(b"capabilities", result.stdout,
+                      "Mention to capabilities command not found")
+
+    @fail_on(process.CmdError)
+    def test_capabilities(self):
+        cmd = "%s capabilities" % self.get_runner()
+        result = process.run(cmd)
+        capabilities = json.loads(result.stdout_text)
+        self.assertIn("runnables", capabilities)

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ if __name__ == '__main__':
           entry_points={
               'console_scripts': [
                   'avocado-runner = avocado.core.nrunner:main',
+                  'avocado-runner-avocado-instrumented = avocado.core.nrunner_avocado_instrumented:main',
                   ],
               'avocado.plugins.cli': [
                   'envkeep = avocado.plugins.envkeep:EnvKeep',

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,9 @@ if __name__ == '__main__':
           include_package_data=True,
           scripts=['scripts/avocado'],
           entry_points={
+              'console_scripts': [
+                  'avocado-runner = avocado.core.nrunner:main',
+                  ],
               'avocado.plugins.cli': [
                   'envkeep = avocado.plugins.envkeep:EnvKeep',
                   'wrapper = avocado.plugins.wrapper:Wrapper',


### PR DESCRIPTION
This adds some introspection to a runner by means of the `capabilities` command, and makes the `avocado nrun` command (the early equivalent to the creation of an Avocado job and counterpart to the `avocado run` command) able to use other external binaries/scripts to run different kinds of tests (runnables).

The last commit adds, for the first time, an Avocado selftests written as an Avocado INSTRUMENTED test, with the following goals:

1) test the basic behavior of multiple runner implementations
2) experience with Avocado selftests written as Avocado INSTRUMENTED tests
3) test "avocado nrun" and the avocado-runner-avocado-instrumented
