### PR TITLE
Robot/Golang plugins: extract utilities

### DIFF
--- a/optional_plugins/golang/avocado_golang/__init__.py
+++ b/optional_plugins/golang/avocado_golang/__init__.py
@@ -95,7 +95,6 @@ class GolangLoader(loader.TestLoader):
             return []
 
         avocado_suite = []
-        package_paths = []
         test_files = []
         subtest = None
         tests_filter = None
@@ -138,6 +137,7 @@ class GolangLoader(loader.TestLoader):
                                                    'reference.')
 
         # When a package is provided
+        package_paths = []
         go_root = os.environ.get('GOROOT')
         go_path = os.environ.get('GOPATH')
 


### PR DESCRIPTION
With the work on the test resolver (which should replace some of the current test "loader" mechanism), we'll have two implementations living (loader and resolver) for some time.

To avoid duplicating code, the let's extract code that is going to be used on the resolver version of those plugins.