### PR TITLE
optional_plugins.loader_yaml: Fix dict usage after nrunner commits

### DIFF
--- a/optional_plugins/loader_yaml/avocado_loader_yaml/__init__.py
+++ b/optional_plugins/loader_yaml/avocado_loader_yaml/__init__.py
@@ -84,8 +84,7 @@ class YamlTestsuiteLoader(loader.TestLoader):
             args = self.args
         else:
             args = copy.copy(self.args)
-            for key, value in _args.items():
-                setattr(args, key, value)
+            args.update(_args)
         extra_params = params.get("test_reference_resolver_extra", default={})
         if extra_params:
             extra_params = copy.deepcopy(extra_params)

--- a/optional_plugins/loader_yaml/tests/.data/two_tests.yaml
+++ b/optional_plugins/loader_yaml/tests/.data/two_tests.yaml
@@ -1,5 +1,17 @@
 !mux
 instrumented:
     test_reference: passtest.py
+    test_reference_resolver_args: !!python/dict
+        this: should not interfere with anything
+    test_reference_resolver_extra: !!python/dict
+        allowed_test_types: INSTRUMENTED
 simple:
     test_reference: passtest.sh
+not_allowed:
+    test_reference: failtest.py
+    test_reference_resolver_args: !!python/dict
+        this: should not interfere with anything
+    # This should tweak the discovery to allow only SIMPLE tests,
+    # therefor it should result in no matching test.
+    test_reference_resolver_extra: !!python/dict
+        allowed_test_types: SIMPLE

--- a/optional_plugins/loader_yaml/tests/test_yaml_loader.py
+++ b/optional_plugins/loader_yaml/tests/test_yaml_loader.py
@@ -13,7 +13,7 @@ class YamlLoaderTests(unittest.TestCase):
     def setUp(self):
         self.tmpdir = tempfile.TemporaryDirectory(prefix='avocado_' + __name__)
 
-    def run_and_check(self, cmd_line, expected_rc, stdout_strings=None):
+    def run_and_check(self, cmd_line, expected_rc, stdout_strings=None, stdout_excluded_strings=None):
         os.chdir(BASEDIR)
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, expected_rc,
@@ -23,15 +23,20 @@ class YamlLoaderTests(unittest.TestCase):
             for exp in stdout_strings:
                 self.assertIn(exp, result.stdout, "%s not in stdout:"
                               "\n%s" % (exp, result))
+        if stdout_excluded_strings is not None:
+            for exp in stdout_excluded_strings:
+                self.assertNotIn(exp, result.stdout)
         return result
 
     def test_replay(self):
         # Run source job
         tests = [b"passtest.py:PassTest.test", b"passtest.sh"]
+        not_tests = [b"failtest.py"]
         cmd = ('%s run --sysinfo=off --job-results-dir %s -- '
                'optional_plugins/loader_yaml/tests/.data/two_tests.yaml'
                % (AVOCADO, self.tmpdir.name))
-        res = self.run_and_check(cmd, exit_codes.AVOCADO_ALL_OK, tests)
+        res = self.run_and_check(cmd, exit_codes.AVOCADO_ALL_OK, tests,
+                                 not_tests)
         # Run replay job
         for line in res.stdout.splitlines():
             if line.startswith(b"JOB LOG"):
@@ -41,7 +46,7 @@ class YamlLoaderTests(unittest.TestCase):
             self.fail("Unable to find 'JOB LOG' in:\n%s" % res)
         cmd = ('%s run --sysinfo=off --job-results-dir %s '
                '--replay %s' % (AVOCADO, self.tmpdir.name, srcjob.decode('utf-8')))
-        self.run_and_check(cmd, exit_codes.AVOCADO_ALL_OK, tests)
+        self.run_and_check(cmd, exit_codes.AVOCADO_ALL_OK, tests, not_tests)
 
     def tearDown(self):
         self.tmpdir.cleanup()


### PR DESCRIPTION
The nrunner commits switched from Namespace to dict args, but this has
not been tackled for loader_yaml plugin. Let's fix it now.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>