### PR TITLE
selftests: Include "optional_plugins/*" to coverage report

### DIFF
--- a/selftests/run_coverage
+++ b/selftests/run_coverage
@@ -9,9 +9,11 @@ COVERAGE="$(which coverage3 coverage coverage2 | head -n 1)"
 
 $COVERAGE erase
 rm .coverage.*
-RUNNING_COVERAGE=1 AVOCADO_CHECK_LEVEL=2 UNITTEST_AVOCADO_CMD="$COVERAGE run -p --include 'avocado/*' ./scripts/avocado" $COVERAGE run -p --include "avocado/*" ./selftests/run
+RUNNING_COVERAGE=1 AVOCADO_CHECK_LEVEL=2 UNITTEST_AVOCADO_CMD="$COVERAGE run -p --include 'avocado/*,optional_plugins/*' ./scripts/avocado" $COVERAGE run -p --include "avocado/*,optional_plugins/*" ./selftests/run
 $COVERAGE combine .coverage*
 echo
 $COVERAGE report -m --include "avocado/core/*"
 echo
 $COVERAGE report -m --include "avocado/utils/*"
+echo
+$COVERAGE report -m --include "optional_plugins/*"


### PR DESCRIPTION
We're running "optional_plugins/*" selftests so it makes sense to
include it into the report as well.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>