### PR TITLE
optional_plugins: Increase test coverage of mux-suite

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+codecov:
+  notify:
+    require_ci_to_pass: no

--- a/optional_plugins/loader_yaml/tests/.data/two_tests.yaml
+++ b/optional_plugins/loader_yaml/tests/.data/two_tests.yaml
@@ -1,5 +1,6 @@
 !mux
 instrumented:
+    mux_suite_test_name_prefix: "PASSTEST.PY PREFIX: "
     test_reference: passtest.py
     test_reference_resolver_args: !!python/dict
         this: should not interfere with anything
@@ -15,3 +16,8 @@ not_allowed:
     # therefor it should result in no matching test.
     test_reference_resolver_extra: !!python/dict
         allowed_test_types: SIMPLE
+external_runner:
+    test_reference_resolver_class: avocado.core.loader.ExternalLoader
+    test_reference_resolver_extra: !!python/dict
+        loader_options: /bin/true
+    test_reference: executes bin true

--- a/optional_plugins/loader_yaml/tests/test_yaml_loader.py
+++ b/optional_plugins/loader_yaml/tests/test_yaml_loader.py
@@ -30,7 +30,8 @@ class YamlLoaderTests(unittest.TestCase):
 
     def test_replay(self):
         # Run source job
-        tests = [b"passtest.py:PassTest.test", b"passtest.sh"]
+        tests = [b"PASSTEST.PY PREFIX: passtest.py:PassTest.test",
+                 b"passtest.sh", b"executes bin true"]
         not_tests = [b"failtest.py"]
         cmd = ('%s run --sysinfo=off --job-results-dir %s -- '
                'optional_plugins/loader_yaml/tests/.data/two_tests.yaml'


### PR DESCRIPTION
Add tests for other yaml-loader features that I use in my CI (and want them to stay functional :-)). While on it also added codecov config to not to require CI PASS.