### PR TITLE
Merge of stdout/stderr.expected files second implemantation [v2]

### DIFF
--- a/avocado/plugins/expected_files_merge.py
+++ b/avocado/plugins/expected_files_merge.py
@@ -1,0 +1,149 @@
+
+"""
+Functions for merging equal expected files together
+"""
+
+import os
+import shutil
+
+from avocado.core.plugin_interfaces import JobPost, CLI
+from avocado.utils import genio
+
+
+def _merge_expected_files(parent_directory):
+    """
+    Finds all output, stdout and stderr expected files in subdirectories and
+    groups equal files together. After that finds the biggest group for every
+    file type and creates file in parent directory which is equal to all files
+    in group. At the end it deletes files in group because they are no long needed.
+    :param parent_directory: Directory where should be merge file created
+    :type parent_directory: str
+    """
+
+    stdout_dict = {}
+    stderr_dict = {}
+    output_dict = {}
+    for path in os.listdir(parent_directory):
+        variants_level_path = os.path.join(parent_directory, path)
+        if os.path.isdir(variants_level_path):
+            for file in os.listdir(variants_level_path):
+                file = os.path.join(variants_level_path, file)
+                if file.endswith('output.expected'):
+                    _save_file_to_group(file, output_dict)
+                elif file.endswith('stdout.expected'):
+                    _save_file_to_group(file, stdout_dict)
+                elif file.endswith('stderr.expected'):
+                    _save_file_to_group(file, stderr_dict)
+    if output_dict:
+        merged_file = _get_best_group(output_dict)
+        if merged_file is not None:
+            not_useful_files = output_dict[merged_file]
+            shutil.copyfile(merged_file, os.path.join(parent_directory, 'output.expected'))
+            _delete_files(not_useful_files)
+    if stdout_dict:
+        merged_file = _get_best_group(stdout_dict)
+        if merged_file is not None:
+            not_useful_files = stdout_dict[merged_file]
+            shutil.copyfile(merged_file, os.path.join(parent_directory, 'stdout.expected'))
+            _delete_files(not_useful_files)
+    if stderr_dict:
+        merged_file = _get_best_group(stderr_dict)
+        if merged_file is not None:
+            not_useful_files = stderr_dict[merged_file]
+            shutil.copyfile(merged_file, os.path.join(parent_directory, 'stderr.expected'))
+            _delete_files(not_useful_files)
+
+
+def _save_file_to_group(file, file_dict):
+    """
+    Saves file in to the dic under key which is the name of equal file
+    :param file: file name for grouping
+    :type file: str
+    :param file_dict: dictionary with groups of equal files
+    :type file_dict:  dict
+    """
+    is_same = False
+    for key in file_dict:
+        if genio.are_files_equal(key, file):
+            file_dict[key].append(file)
+            is_same = True
+            break
+    if not is_same:
+        file_dict[file] = [file]
+
+
+def _get_best_group(file_dict):
+    """
+    Finds the biggest group form dictionary
+    :param file_dict: dictionary with groups of equal files
+    :type file_dict:  dict
+    :return: key to the biggest group or None
+    :rtype:str
+    """
+    if len(file_dict) == 1:
+        return list(file_dict)[0]
+    size_array = [len(l)for _, l in file_dict.items()]
+    max_size = max(size_array)
+    min_size = min(size_array)
+    if max_size == min_size:
+        return None
+    return max(file_dict, key=lambda x: len(file_dict[x]))
+
+
+def _delete_files(files):
+    """
+    Deletes files and also directory if it's empty
+    :param files: list of files which should be deleted
+    :type files: list
+    """
+    for file in files:
+        os.remove(file)
+        try:
+            os.rmdir(os.path.dirname(file))
+        except OSError:
+            continue
+
+
+def merge_expected_files(references):
+    """
+    Cascade merge of equal expected files in job references from
+    variant level to file level
+    :param references: list of job references
+    :type references: list
+    """
+    for reference in references:
+        file_level_path = os.path.abspath("%s.data" % reference)
+        if os.path.exists(file_level_path):
+            for path in os.listdir(file_level_path):
+                test_level_path = os.path.join(file_level_path, path)
+                if os.path.isdir(test_level_path):
+                    _merge_expected_files(test_level_path)
+            _merge_expected_files(file_level_path)
+
+
+class FilesMerge(JobPost, CLI):
+
+    """
+    Plugin for merging equal expected files together
+    """
+
+    name = 'merge'
+    description = 'Merge of equal expected files'
+    _instance = None
+    output_check_record = False
+
+    def __new__(class_, *args, **kwargs):
+        if not isinstance(class_._instance, class_):
+            class_._instance = object.__new__(class_, *args, **kwargs)
+        return class_._instance
+
+    def configure(self, parser):
+        pass
+
+    def run(self, config):
+        if config.get('output_check_record', None):
+            self.output_check_record = True
+
+    def post(self, job):
+        if self.output_check_record:
+            merge_expected_files(job.config['references'])

--- a/avocado/utils/genio.py
+++ b/avocado/utils/genio.py
@@ -19,6 +19,8 @@ Avocado generic IO related functions.
 import logging
 import os
 import re
+import hashlib
+import io
 
 log = logging.getLogger('avocado.test')
 
@@ -191,3 +193,35 @@ def is_pattern_in_file(filename,  pattern):
         if re.search(pattern, content_file.read(), re.MULTILINE):
             return True
     return False
+
+
+def get_file_hash(filename):
+    """
+    Compute hash of file content. For computation is used algorithm MD5
+    :param filename: Name of file for hashing
+    :type filename: str
+    :return: Hash of file content
+    :rtype: str
+    """
+    hasher = hashlib.md5()
+    with open(filename, 'rb') as file:
+        buf = file.read(io.DEFAULT_BUFFER_SIZE)
+        while len(buf) > 0:
+            hasher.update(buf)
+            buf = file.read(io.DEFAULT_BUFFER_SIZE)
+    return hasher.hexdigest()
+
+
+def are_files_equal(filename, other):
+    """
+    Comparision of two files line by line
+    :param filename: path to the first file
+    :type filename: str
+    :param other: path to the second file
+    :type other: str
+    :return: equality of file
+    :rtype: boolean
+    """
+    hash_1 = get_file_hash(filename)
+    hash_2 = get_file_hash(other)
+    return hash_1 == hash_2

--- a/selftests/unit/test_utils_genio.py
+++ b/selftests/unit/test_utils_genio.py
@@ -1,4 +1,7 @@
+import hashlib
 import os
+import random
+import string
 import tempfile
 import unittest
 
@@ -35,3 +38,26 @@ class TestGenio(unittest.TestCase):
             temp_file.write('123')
             temp_file.seek(0)
             self.assertFalse(genio.is_pattern_in_file(temp_file.name, r'\D{3}'))
+
+    def test_get_file_hash(self):
+        hasher = hashlib.md5()
+        text = ''
+        with tempfile.NamedTemporaryFile(mode='wb') as temp_file:
+            for _ in range(100000):
+                line = ''.join(random.choice(string.ascii_letters + string.digits
+                                             + '\n'))
+                text += line
+            text = text.encode()
+            temp_file.write(text)
+            hasher.update(text)
+            self.assertEqual(hasher.hexdigest(), genio.get_file_hash(temp_file.name))
+
+    def test_are_files_equal(self):
+        file_1 = tempfile.NamedTemporaryFile(mode='w')
+        file_2 = tempfile.NamedTemporaryFile(mode='w')
+        for _ in range(100000):
+            line = ''.join(random.choice(string.ascii_letters + string.digits
+                                         + '\n'))
+            file_1.write(line)
+            file_2.write(line)
+        self.assertTrue(genio.are_files_equal(file_1.name, file_2.name))

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ if __name__ == '__main__':
                   'tap = avocado.plugins.tap:TAP',
                   'zip_archive = avocado.plugins.archive:ArchiveCLI',
                   'json_variants = avocado.plugins.json_variants:JsonVariantsCLI',
+                  'merge_files = avocado.plugins.expected_files_merge:FilesMerge',
                   ],
               'avocado.plugins.cli.cmd': [
                   'config = avocado.plugins.config:Config',
@@ -92,6 +93,7 @@ if __name__ == '__main__':
                   'jobscripts = avocado.plugins.jobscripts:JobScripts',
                   'teststmpdir = avocado.plugins.teststmpdir:TestsTmpDir',
                   'human = avocado.plugins.human:HumanJob',
+                  'merge_files = avocado.plugins.expected_files_merge:FilesMerge',
                   ],
               'avocado.plugins.result': [
                   'xunit = avocado.plugins.xunit:XUnitResult',


### PR DESCRIPTION
It is the implementation of `.expected` files merge, which after the job execution cascadely merge equal `.expected` files from variant level to file level. When the `.expected` files at the same level are equal, they are deleted and it is created a new file in the upper level.

Signed-off-by: Jan Richter <jarichte@redhat.com>


---

Changes from v1 (#3243):

- Solved problem with the unwanted move to the upper-level directory
- Comparison of two files by hash
- Tests for new functions in genio utility
- Created plugin for merging files