### PR TITLE
Revert "selftests: Improve avocado_abs command"

### DIFF
--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -1023,9 +1023,7 @@ class ExternalRunnerTest(unittest.TestCase):
 
     @unittest.skipIf(os.environ.get("RUNNING_COVERAGE"), "Running coverage")
     def test_externalrunner_chdir_runner_relative(self):
-        avocado_split = AVOCADO.rsplit(" ", 1)
-        avocado_abs = "%s %s" % (avocado_split[0],
-                                 os.path.abspath(avocado_split[1]))
+        avocado_abs = " ".join([os.path.abspath(_) for _ in AVOCADO.split(" ")])
         pass_abs = os.path.abspath(self.pass_script.path)
         os.chdir('/')
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off '


### PR DESCRIPTION
The commit this reverts was added to handle the unittest execution
within the context of coverage reporting.  But, it breaks the test
execution when the AVOCADO variable can not be splitted into more than
one component.

Later, a skip for this test was added when running within the context
of coverage reporting, so reverting this would seem logical even if it
was not breaking a test.

This reverts commit f87bab3513459415ba1088ec637c56d952132022.

Signed-off-by: Cleber Rosa <crosa@redhat.com>