### PR TITLE
Deployment checks: update to py3

### DIFF
--- a/selftests/deployment/rpm-copr.yml
+++ b/selftests/deployment/rpm-copr.yml
@@ -36,3 +36,6 @@
     - name: Avocado-VT test available
       shell: avocado list boot
       changed_when: false
+    - name: Avocado-VT dry-run execution
+      shell: avocado run --dry-run -- boot
+      changed_when: false

--- a/selftests/deployment/rpm-copr.yml
+++ b/selftests/deployment/rpm-copr.yml
@@ -10,18 +10,18 @@
         name: "{{ item }}"
         state: latest
       with_items:
-        - python2-avocado
-        - python2-avocado-plugins-glib
-        - python2-avocado-plugins-golang
-        - python2-avocado-plugins-loader-yaml
-        - python2-avocado-plugins-output-html
-        - python2-avocado-plugins-result-upload
-        - python2-avocado-plugins-runner-docker
-        - python2-avocado-plugins-runner-remote
-        - python2-avocado-plugins-runner-vm
-        - python2-avocado-plugins-varianter-cit
-        - python2-avocado-plugins-varianter-pict
-        - python2-avocado-plugins-varianter-yaml-to-mux
+        - python3-avocado
+        - python3-avocado-plugins-glib
+        - python3-avocado-plugins-golang
+        - python3-avocado-plugins-loader-yaml
+        - python3-avocado-plugins-output-html
+        - python3-avocado-plugins-result-upload
+        - python3-avocado-plugins-runner-docker
+        - python3-avocado-plugins-runner-remote
+        - python3-avocado-plugins-runner-vm
+        - python3-avocado-plugins-varianter-cit
+        - python3-avocado-plugins-varianter-pict
+        - python3-avocado-plugins-varianter-yaml-to-mux
     - name: Avocado version
       shell: "avocado --version"
       changed_when: false
@@ -29,7 +29,7 @@
     - include_tasks: tasks/avocado_vt_copr_repo.yml
     - name: Avocado-VT package
       package:
-        name: python2-avocado-plugins-vt
+        name: python3-avocado-plugins-vt
         state: latest
     - name: Avocado-VT bootstrap
       shell: avocado vt-bootstrap --yes-to-all --vt-skip-verify-download-assets

--- a/selftests/deployment/tasks/avocado_vt_rpm_pkgs.yml
+++ b/selftests/deployment/tasks/avocado_vt_rpm_pkgs.yml
@@ -6,9 +6,9 @@
     with_items:
       - gcc
       - nc
-      - python-netaddr
-      - python-netifaces
-      - python2-aexpect
+      - python3-netaddr
+      - python3-netifaces
+      - python3-aexpect
       - qemu-img
       - qemu-kvm
       - tcpdump


### PR DESCRIPTION
The name says it all, updates to the deployment checks to reflect the fact Avocado is Python 3 based.