### PR TITLE
Merge of stdout/stderr.expected files second implemantation [v3]

### DIFF
--- a/avocado/plugins/expected_files_merge.py
+++ b/avocado/plugins/expected_files_merge.py
@@ -1,0 +1,127 @@
+"""
+Functions for merging equal expected files together
+"""
+
+import os
+import shutil
+
+from avocado.core.plugin_interfaces import JobPost
+from avocado.utils import genio
+
+
+def _merge_expected_files(parent_directory):
+    """
+    Finds all output, stdout and stderr expected files in subdirectories and
+    groups equal files together. After that finds the biggest group for every
+    file type and creates file in parent directory which is equal to all files
+    in group. At the end it deletes files in group because they are no longer needed.
+    :param parent_directory: Directory where should be merge file created
+    :type parent_directory: str
+    """
+
+    stdout_dict = {}
+    stderr_dict = {}
+    output_dict = {}
+    for path in os.listdir(parent_directory):
+        variants_level_path = os.path.join(parent_directory, path)
+        if os.path.isdir(variants_level_path):
+            for filename in os.listdir(variants_level_path):
+                path = os.path.join(variants_level_path, filename)
+                if filename == 'output.expected':
+                    _save_file_to_group(path, output_dict)
+                elif filename == 'stdout.expected':
+                    _save_file_to_group(path, stdout_dict)
+                elif filename == 'stderr.expected':
+                    _save_file_to_group(path, stderr_dict)
+
+    for file_dic, filename in ((output_dict, 'output.expected'),
+                               (stdout_dict, 'stdout.expected'),
+                               (stderr_dict, 'stderr.expected')):
+        if file_dic:
+            merged_file = _get_best_group(file_dic)
+            if merged_file is not None:
+                not_useful_files = file_dic[merged_file]
+                shutil.copyfile(merged_file, os.path.join(parent_directory,
+                                                          filename))
+                _delete_files(not_useful_files)
+
+
+def _save_file_to_group(path, file_dict):
+    """
+    Saves file in to the dic under key which is the name of equal file
+    :param path: file name for grouping
+    :type path: str
+    :param file_dict: dictionary with groups of equal files
+    :type file_dict:  dict
+    """
+    is_same = False
+    for key in file_dict:
+        if genio.are_files_equal(key, path):
+            file_dict[key].append(path)
+            is_same = True
+            break
+    if not is_same:
+        file_dict[path] = [path]
+
+
+def _get_best_group(file_dict):
+    """
+    Finds the biggest group form dictionary
+    :param file_dict: dictionary with groups of equal files
+    :type file_dict:  dict
+    :return: key to the biggest group or None
+    :rtype:str
+    """
+    if len(file_dict) == 1:
+        return list(file_dict)[0]
+    size_array = [len(l)for _, l in file_dict.items()]
+    max_size = max(size_array)
+    min_size = min(size_array)
+    if max_size == min_size:
+        return None
+    return max(file_dict, key=lambda x: len(file_dict[x]))
+
+
+def _delete_files(files):
+    """
+    Deletes files and also directory if it's empty
+    :param files: list of files which should be deleted
+    :type files: list
+    """
+    for filename in files:
+        os.remove(filename)
+        try:
+            os.rmdir(os.path.dirname(filename))
+        except OSError:
+            continue
+
+
+def merge_expected_files(references):
+    """
+    Cascade merge of equal expected files in job references from
+    variant level to file level
+    :param references: list of job references
+    :type references: list
+    """
+    for reference in references:
+        file_level_path = os.path.abspath("%s.data" % reference)
+        if os.path.exists(file_level_path):
+            for path in os.listdir(file_level_path):
+                test_level_path = os.path.join(file_level_path, path)
+                if os.path.isdir(test_level_path):
+                    _merge_expected_files(test_level_path)
+            _merge_expected_files(file_level_path)
+
+
+class FilesMerge(JobPost):
+
+    """
+    Plugin for merging equal expected files together
+    """
+
+    name = 'merge'
+    description = 'Merge of equal expected files'
+
+    def post(self, job):
+        if job.config.get('output_check_record', None):
+            merge_expected_files(job.config['references'])

--- a/avocado/utils/genio.py
+++ b/avocado/utils/genio.py
@@ -20,6 +20,8 @@ import logging
 import os
 import re
 
+from . import crypto
+
 log = logging.getLogger('avocado.test')
 
 
@@ -191,3 +193,18 @@ def is_pattern_in_file(filename,  pattern):
         if re.search(pattern, content_file.read(), re.MULTILINE):
             return True
     return False
+
+
+def are_files_equal(filename, other):
+    """
+    Comparision of two files line by line
+    :param filename: path to the first file
+    :type filename: str
+    :param other: path to the second file
+    :type other: str
+    :return: equality of file
+    :rtype: boolean
+    """
+    hash_1 = crypto.hash_file(filename)
+    hash_2 = crypto.hash_file(other)
+    return hash_1 == hash_2

--- a/selftests/functional/test_output_check.py
+++ b/selftests/functional/test_output_check.py
@@ -13,6 +13,136 @@ from .. import AVOCADO, BASEDIR, temp_dir_prefix
 STDOUT = b"Hello, \xc4\x9b\xc5\xa1\xc4\x8d\xc5\x99\xc5\xbe\xc3\xbd\xc3\xa1\xc3\xad\xc3\xa9!"
 STDERR = b"Hello, stderr!"
 
+JSON_VARIANTS = """
+[{"paths": ["/run/*"],
+ "variant": [["/run/params/foo",
+            [["/run/params/foo", "p2", "foo2"],
+             ["/run/params/foo", "p1", "foo1"]]]],
+ "variant_id": "foo"},
+{"paths": ["/run/*"],
+ "variant": [["/run/params/bar",
+            [["/run/params/bar", "p2", "bar2"],
+             ["/run/params/bar", "p1", "bar1"]]]],
+ "variant_id": "bar"}]
+ """
+
+TEST_WITH_SAME_EXPECTED_OUTPUT = """
+from avocado import Test
+from avocado import main
+import logging
+
+
+class PassTest(Test):
+
+    def test_1(self):
+
+        stdout = logging.getLogger('avocado.test.stdout')
+        stdout.info('Informational line that will go to stdout')
+        stderr = logging.getLogger('avocado.test.stderr')
+        stderr.info('Informational line that will go to stderr')
+
+    def test_2(self):
+
+        stdout = logging.getLogger('avocado.test.stdout')
+        stdout.info('Informational line that will go to stdout')
+        stderr = logging.getLogger('avocado.test.stderr')
+        stderr.info('Informational line that will go to stderr')
+
+
+if __name__ == "__main__":
+    main()
+"""
+
+TEST_WITH_DIFFERENT_EXPECTED_OUTPUT = """
+from avocado import Test
+from avocado import main
+import logging
+
+
+class PassTest(Test):
+
+    def test_1(self):
+
+        stdout = logging.getLogger('avocado.test.stdout')
+        stdout.info('Informational line that will go to stdout_1')
+        stderr = logging.getLogger('avocado.test.stderr')
+        stderr.info('Informational line that will go to stderr_1')
+
+    def test_2(self):
+
+        stdout = logging.getLogger('avocado.test.stdout')
+        stdout.info('Informational line that will go to stdout_2')
+        stderr = logging.getLogger('avocado.test.stderr')
+        stderr.info('Informational line that will go to stderr_2')
+
+
+if __name__ == "__main__":
+    main()
+"""
+
+TEST_WITH_DIFFERENT_EXPECTED_OUTPUT_VARIANTS = """
+from avocado import Test
+from avocado import main
+import logging
+
+
+class PassTest(Test):
+
+    def test_1(self):
+        foo = self.params.get("p1")
+        stdout = logging.getLogger('avocado.test.stdout')
+        stdout.info('Informational line that will go to stdout_1 %s'%foo)
+        stderr = logging.getLogger('avocado.test.stderr')
+        stderr.info('Informational line that will go to stderr_1 %s'%foo)
+        print("foo %s" %foo)
+
+    def test_2(self):
+        bar = self.params.get("p2")
+        stdout = logging.getLogger('avocado.test.stdout')
+        stdout.info('Informational line that will go to stdout_2 %s'%bar)
+        stderr = logging.getLogger('avocado.test.stderr')
+        stderr.info('Informational line that will go to stderr_2 %s'%bar)
+        print("bar %s" %bar)
+
+
+if __name__ == "__main__":
+    main()
+"""
+
+TEST_WITH_DIFFERENT_AND_SAME_EXPECTED_OUTPUT = """
+from avocado import Test
+from avocado import main
+import logging
+
+
+class PassTest(Test):
+
+    def test_1(self):
+
+        stdout = logging.getLogger('avocado.test.stdout')
+        stdout.info('Informational line that will go to stdout_1')
+        stderr = logging.getLogger('avocado.test.stderr')
+        stderr.info('Informational line that will go to stderr_1')
+
+    def test_2(self):
+
+        stdout = logging.getLogger('avocado.test.stdout')
+        stdout.info('Informational line that will go to stdout_2')
+        stderr = logging.getLogger('avocado.test.stderr')
+        stderr.info('Informational line that will go to stderr_2')
+
+    def test_3(self):
+
+        stdout = logging.getLogger('avocado.test.stdout')
+        stdout.info('Informational line that will go to stdout_2')
+        stderr = logging.getLogger('avocado.test.stderr')
+        stderr.info('Informational line that will go to stderr_2')
+
+
+if __name__ == "__main__":
+    main()
+"""
+
 
 class RunnerSimpleTest(unittest.TestCase):
 
@@ -205,6 +335,116 @@ class RunnerSimpleTest(unittest.TestCase):
                          "Avocado did not return rc %d:\n%s" %
                          (expected_rc, result))
         self.assertNotIn(tampered_msg, result.stdout)
+
+    def test_merge_records_same_output(self):
+        os.chdir(BASEDIR)
+        variants_file = os.path.join(self.tmpdir.name, 'variants.json')
+        with open(variants_file, 'w') as file_obj:
+            file_obj.write(JSON_VARIANTS)
+        simple_test = os.path.join(self.tmpdir.name, 'simpletest.py')
+        with open(simple_test, 'w') as file_obj:
+            file_obj.write(TEST_WITH_SAME_EXPECTED_OUTPUT)
+        cmd_line = ('%s run --job-results-dir %s --sysinfo=off %s '
+                    '--output-check-record both --json-variants-load %s' %
+                    (AVOCADO, self.tmpdir.name, simple_test, variants_file))
+        process.run(cmd_line, ignore_status=True)
+        self.assertTrue(os.path.isfile(os.path.join("%s.data/stdout.expected" %
+                                                    simple_test)))
+        self.assertTrue(os.path.isfile(os.path.join("%s.data/stderr.expected" %
+                                                    simple_test)))
+
+    def test_merge_records_different_output(self):
+        os.chdir(BASEDIR)
+        variants_file = os.path.join(self.tmpdir.name, 'variants.json')
+        with open(variants_file, 'w') as file_obj:
+            file_obj.write(JSON_VARIANTS)
+        simple_test = os.path.join(self.tmpdir.name, 'simpletest.py')
+        with open(simple_test, 'w') as file_obj:
+            file_obj.write(TEST_WITH_DIFFERENT_EXPECTED_OUTPUT)
+        cmd_line = ('%s run --job-results-dir %s --sysinfo=off %s '
+                    '--output-check-record both --json-variants-load %s' %
+                    (AVOCADO, self.tmpdir.name, simple_test, variants_file))
+        process.run(cmd_line, ignore_status=True)
+        self.assertFalse(os.path.isfile(os.path.join("%s.data/stdout.expected" %
+                                                     simple_test)))
+        self.assertFalse(os.path.isfile(os.path.join("%s.data/stderr.expected" %
+                                                     simple_test)))
+        self.assertTrue(os.path.isfile(os.path.join("%s.data/PassTest.test_1/"
+                                                    "stdout.expected" %
+                                                    simple_test)))
+        self.assertTrue(os.path.isfile(os.path.join("%s.data/PassTest.test_1/"
+                                                    "stderr.expected" %
+                                                    simple_test)))
+        self.assertTrue(os.path.isfile(os.path.join("%s.data/PassTest.test_2/"
+                                                    "stdout.expected" %
+                                                    simple_test)))
+        self.assertTrue(os.path.isfile(os.path.join("%s.data/PassTest.test_2/"
+                                                    "stderr.expected" %
+                                                    simple_test)))
+
+    def test_merge_records_different_output_variants(self):
+        os.chdir(BASEDIR)
+        variants_file = os.path.join(self.tmpdir.name, 'variants.json')
+        with open(variants_file, 'w') as file_obj:
+            file_obj.write(JSON_VARIANTS)
+        simple_test = os.path.join(self.tmpdir.name, 'simpletest.py')
+        with open(simple_test, 'w') as file_obj:
+            file_obj.write(TEST_WITH_DIFFERENT_EXPECTED_OUTPUT_VARIANTS)
+        cmd_line = ('%s run --job-results-dir %s --sysinfo=off %s '
+                    '--output-check-record both --json-variants-load %s' %
+                    (AVOCADO, self.tmpdir.name, simple_test, variants_file))
+        process.run(cmd_line, ignore_status=True)
+        self.assertFalse(os.path.isfile(os.path.join("%s.data/stdout.expected" %
+                                                     simple_test)))
+        self.assertFalse(os.path.isfile(os.path.join("%s.data/stderr.expected" %
+                                                     simple_test)))
+        self.assertFalse(os.path.isfile(os.path.join("%s.data/PassTest.test_1/"
+                                                     "stdout.expected" %
+                                                     simple_test)))
+        self.assertFalse(os.path.isfile(os.path.join("%s.data/PassTest.test_1/"
+                                                     "stderr.expected" %
+                                                     simple_test)))
+        self.assertFalse(os.path.isfile(os.path.join("%s.data/PassTest.test_2/"
+                                                     "stdout.expected" %
+                                                     simple_test)))
+        self.assertFalse(os.path.isfile(os.path.join("%s.data/PassTest.test_2/"
+                                                     "stderr.expected" %
+                                                     simple_test)))
+        self.assertTrue(os.path.isfile(os.path.join("%s.data/PassTest.test_2/"
+                                                    "bar/stderr.expected" %
+                                                    simple_test)))
+        self.assertTrue(os.path.isfile(os.path.join("%s.data/PassTest.test_2/"
+                                                    "foo/stderr.expected" %
+                                                    simple_test)))
+
+    def test_merge_records_different_and_same_output(self):
+        os.chdir(BASEDIR)
+        variants_file = os.path.join(self.tmpdir.name, 'variants.json')
+        with open(variants_file, 'w') as file_obj:
+            file_obj.write(JSON_VARIANTS)
+        simple_test = os.path.join(self.tmpdir.name, 'simpletest.py')
+        with open(simple_test, 'w') as file_obj:
+            file_obj.write(TEST_WITH_DIFFERENT_AND_SAME_EXPECTED_OUTPUT)
+        cmd_line = ('%s run --job-results-dir %s --sysinfo=off %s '
+                    '--output-check-record both --json-variants-load %s' %
+                    (AVOCADO, self.tmpdir.name, simple_test, variants_file))
+        process.run(cmd_line, ignore_status=True)
+        self.assertTrue(os.path.isfile(os.path.join("%s.data/stdout.expected" %
+                                                    simple_test)))
+        self.assertTrue(os.path.isfile(os.path.join("%s.data/stderr.expected" %
+                                                    simple_test)))
+        self.assertTrue(os.path.isfile(os.path.join("%s.data/PassTest.test_1/"
+                                                    "stdout.expected" %
+                                                    simple_test)))
+        self.assertTrue(os.path.isfile(os.path.join("%s.data/PassTest.test_1/"
+                                                    "stderr.expected" %
+                                                    simple_test)))
+        self.assertFalse(os.path.isfile(os.path.join("%s.data/PassTest.test_2/"
+                                                     "stdout.expected" %
+                                                     simple_test)))
+        self.assertFalse(os.path.isfile(os.path.join("%s.data/PassTest.test_2/"
+                                                     "stderr.expected" %
+                                                     simple_test)))
 
     def tearDown(self):
         self.output_script.remove()

--- a/selftests/unit/test_utils_genio.py
+++ b/selftests/unit/test_utils_genio.py
@@ -1,4 +1,6 @@
 import os
+import random
+import string
 import tempfile
 import unittest
 
@@ -35,3 +37,13 @@ class TestGenio(unittest.TestCase):
             temp_file.write('123')
             temp_file.seek(0)
             self.assertFalse(genio.is_pattern_in_file(temp_file.name, r'\D{3}'))
+
+    def test_are_files_equal(self):
+        file_1 = tempfile.NamedTemporaryFile(mode='w')
+        file_2 = tempfile.NamedTemporaryFile(mode='w')
+        for _ in range(100000):
+            line = ''.join(random.choice(string.ascii_letters + string.digits
+                                         + '\n'))
+            file_1.write(line)
+            file_2.write(line)
+        self.assertTrue(genio.are_files_equal(file_1.name, file_2.name))

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,7 @@ if __name__ == '__main__':
                   'jobscripts = avocado.plugins.jobscripts:JobScripts',
                   'teststmpdir = avocado.plugins.teststmpdir:TestsTmpDir',
                   'human = avocado.plugins.human:HumanJob',
+                  'merge_files = avocado.plugins.expected_files_merge:FilesMerge',
                   ],
               'avocado.plugins.result': [
                   'xunit = avocado.plugins.xunit:XUnitResult',


### PR DESCRIPTION
It is the implementation of .expected files merge, which after the job execution cascadely merge equal .expected files from variant level to file level. When the .expected files at the same level are equal, they are deleted and it is created a new file in the upper level.

Signed-off-by: Jan Richter <jarichte@redhat.com>

---

Changes from v1 (#3243):

- Solved problem with the unwanted move to the upper-level directory
- Comparison of two files by hash
- Tests for new functions in genio utility
- Created plugin for merging files

Changes from v2 (#3259):

- Changed names of variables like `file` to `filename`
- Deleted repeated code
- Typo fixes
- New test for expected_files_merge
- Deleted CLI plugin interface
- Usage `avocado.utils.crypto.hash_file` in genio
- Better equality check for file names
