### PR TITLE
Vmimage cmd [v2]

### DIFF
--- a/avocado/plugins/vmimage.py
+++ b/avocado/plugins/vmimage.py
@@ -1,0 +1,92 @@
+import os
+
+from avocado.core.output import LOG_UI
+from avocado.core.plugin_interfaces import CLICmd
+from avocado.core import data_dir, output
+from avocado.utils import vmimage, astring
+
+
+def list_downloaded_images():
+    """
+    List the available Image inside avocado cache
+
+    :return: list with image's parameters
+    :rtype: list of dicts
+    """
+    images = []
+    cache_dirs = data_dir.get_cache_dirs()
+    providers = [provider() for provider in vmimage.list_providers()]
+
+    for cache_dir in cache_dirs:
+        for root, _, files in os.walk(cache_dir):
+            if files:
+                for filename in files:
+                    for provider in providers:
+                        image = provider.get_image_parameters(filename)
+                        if image is not None:
+                            image["name"] = provider.name
+                            image["file"] = os.path.join(root, filename)
+                            images.append(image)
+                            break
+    return images
+
+
+def display_images_list(images):
+    """
+    Displays table with information about images
+
+    :param images: list with image's parameters
+    :type images: list of dicts
+    """
+    image_matrix = [[image['name'], image['version'], image['arch'],
+                     image['file']] for image in images]
+    LOG_UI.info('\n')
+    header = (output.TERM_SUPPORT.header_str('Provider'),
+              output.TERM_SUPPORT.header_str('Version'),
+              output.TERM_SUPPORT.header_str('Architecture'),
+              output.TERM_SUPPORT.header_str('File'))
+    for line in astring.iter_tabular_output(image_matrix, header=header,
+                                            strip=True):
+        LOG_UI.info(line)
+    LOG_UI.info('\n')
+
+
+class VMimage(CLICmd):
+    """
+    Implements the avocado 'vmimage' subcommand
+    """
+
+    name = 'vmimage'
+    description = 'Provides VM images acquired from official repositories'
+
+    def configure(self, parser):
+        parser = super(VMimage, self).configure(parser)
+        parser.add_argument('--list',
+                            help='List of all downloaded images',
+                            action='store_true')
+        subparsers = parser.add_subparsers()
+        download_subcommand_parser = subparsers.add_parser(
+            'get', help="Downloads chosen VMimage if it's not already in the cache")
+        download_subcommand_parser.add_argument('--distro',
+                                                help='Name of image distribution',
+                                                required=True)
+        download_subcommand_parser.add_argument('--distro-version',
+                                                help='Required version of image')
+        download_subcommand_parser.add_argument('--arch',
+                                                help='Required architecture image')
+
+    def run(self, config):
+        if config['list'] is True:
+            images = list_downloaded_images()
+            display_images_list(images)
+        else:
+            # Downloading the image
+            cache_dirs = data_dir.get_cache_dirs()
+            image = vmimage.get(name=config['distro'],
+                                version=config['distro_version'],
+                                arch=config['arch'], cache_dir=cache_dirs)
+
+            LOG_UI.info("The image was downloaded:")
+            image = [{'name': image.name, 'version': image.version,
+                      'arch': image.arch, 'file': image.base_image}]
+            display_images_list(image)

--- a/avocado/utils/vmimage.py
+++ b/avocado/utils/vmimage.py
@@ -72,7 +72,7 @@ class ImageProviderBase:
         self.url_versions = None
         self.url_images = None
         self.image_pattern = None
-
+        self._file_name = None
         self._version = version
         self._best_version = None
         self.build = build
@@ -85,6 +85,14 @@ class ImageProviderBase:
     @property
     def version_pattern(self):
         return '^%s/$' % self._version
+
+    @property
+    def file_name(self):
+        if not self._file_name:
+            self._file_name = self.image_pattern.format(version=self.version,
+                                                        build=self.build,
+                                                        arch=self.arch)
+        return self._file_name
 
     def _feed_html_parser(self, url, parser):
         try:
@@ -149,6 +157,23 @@ class ImageProviderBase:
             raise ImageProviderError("No images matching '%s' at '%s'. "
                                      "Wrong arch?" % (image, url_images))
 
+    def get_image_parameters(self, image):
+        """
+        Computation of image parameter from image_pattern
+
+        :param image: pattern with parameters
+        :type image: str
+        :return: dict with parameters
+        :rtype: dict
+        """
+        keywords = re.split(r'\{(.*?)\}', self.image_pattern)[1::2]
+        matches = re.match(self.file_name, image)
+
+        if not matches:
+            return None
+
+        return {x: matches.group(x) for x in keywords}
+
 
 class FedoraImageProviderBase(ImageProviderBase):
     """
@@ -178,7 +203,7 @@ class FedoraImageProvider(FedoraImageProviderBase):
         super(FedoraImageProvider, self).__init__(version, build, arch)
         self.url_versions = 'https://dl.fedoraproject.org/pub/fedora/linux/releases/'
         self.url_images = self.url_versions + '{version}/%s/{arch}/images/'
-        self.image_pattern = 'Fedora-Cloud-Base-{version}-{build}.{arch}.qcow2$'
+        self.image_pattern = 'Fedora-Cloud-Base-(?P<version>{version})-(?P<build>{build}).(?P<arch>{arch}).qcow2$'
 
 
 class FedoraSecondaryImageProvider(FedoraImageProviderBase):
@@ -194,7 +219,7 @@ class FedoraSecondaryImageProvider(FedoraImageProviderBase):
                                                            arch)
         self.url_versions = 'https://dl.fedoraproject.org/pub/fedora-secondary/releases/'
         self.url_images = self.url_versions + '{version}/%s/{arch}/images/'
-        self.image_pattern = 'Fedora-Cloud-Base-{version}-{build}.{arch}.qcow2$'
+        self.image_pattern = 'Fedora-Cloud-Base-(?P<version>{version})-(?P<build>{build}).(?P<arch>{arch}).qcow2$'
 
 
 class CentOSImageProvider(ImageProviderBase):
@@ -208,7 +233,7 @@ class CentOSImageProvider(ImageProviderBase):
         super(CentOSImageProvider, self).__init__(version, build, arch)
         self.url_versions = 'https://cloud.centos.org/centos/'
         self.url_images = self.url_versions + '{version}/images/'
-        self.image_pattern = 'CentOS-{version}-{arch}-GenericCloud-{build}.qcow2.xz$'
+        self.image_pattern = 'CentOS-(?P<version>{version})-(?P<arch>{arch})-GenericCloud-(?P<build>{build}).qcow2.xz$'
 
 
 class UbuntuImageProvider(ImageProviderBase):
@@ -230,7 +255,7 @@ class UbuntuImageProvider(ImageProviderBase):
         super(UbuntuImageProvider, self).__init__(version, build, arch)
         self.url_versions = 'http://cloud-images.ubuntu.com/releases/'
         self.url_images = self.url_versions + 'releases/{version}/release/'
-        self.image_pattern = 'ubuntu-{version}-server-cloudimg-{arch}.img'
+        self.image_pattern = 'ubuntu-(?P<version>{version})-server-cloudimg-(?P<arch>{arch}).img'
 
 
 class DebianImageProvider(ImageProviderBase):
@@ -252,7 +277,7 @@ class DebianImageProvider(ImageProviderBase):
         super(DebianImageProvider, self).__init__(version, build, arch)
         self.url_versions = 'https://cdimage.debian.org/cdimage/openstack/'
         self.url_images = self.url_versions + '{version}/'
-        self.image_pattern = 'debian-{version}-openstack-{arch}.qcow2$'
+        self.image_pattern = 'debian-(?P<version>{version})-openstack-(?P<arch>{arch}).qcow2$'
 
 
 class JeosImageProvider(ImageProviderBase):
@@ -271,7 +296,7 @@ class JeosImageProvider(ImageProviderBase):
         super(JeosImageProvider, self).__init__(version, build, arch)
         self.url_versions = 'https://avocado-project.org/data/assets/jeos/'
         self.url_images = self.url_versions + '{version}/'
-        self.image_pattern = 'jeos-{version}-{arch}.qcow2.xz$'
+        self.image_pattern = 'jeos-(?P<version>{version})-(?P<arch>{arch}).qcow2.xz$'
 
 
 class OpenSUSEImageProvider(ImageProviderBase):
@@ -288,9 +313,11 @@ class OpenSUSEImageProvider(ImageProviderBase):
         self.url_images = self.url_versions + 'Leap_{version}/images/'
 
         if not build:
-            self.image_pattern = 'openSUSE-Leap-{version}-OpenStack.{arch}-((.)*).qcow2$'
+            self.image_pattern = 'openSUSE-Leap-(?P<version>{version})-OpenStack.(?P<arch>{arch})-((.)*).qcow2$'
+
         else:
-            self.image_pattern = 'openSUSE-Leap-{version}-OpenStack.{arch}-{build}.qcow2$'
+            self.image_pattern = 'openSUSE-Leap-(?P<version>{version})-OpenStack.' \
+                                 '(?P<arch>{arch})-(?P<build>{build}).qcow2$'
 
     @property
     def version_pattern(self):

--- a/avocado/utils/vmimage.py
+++ b/avocado/utils/vmimage.py
@@ -208,10 +208,7 @@ class CentOSImageProvider(ImageProviderBase):
         super(CentOSImageProvider, self).__init__(version, build, arch)
         self.url_versions = 'https://cloud.centos.org/centos/'
         self.url_images = self.url_versions + '{version}/images/'
-        if archive.LZMA_CAPABLE:
-            self.image_pattern = 'CentOS-{version}-{arch}-GenericCloud-{build}.qcow2.xz$'
-        else:
-            self.image_pattern = 'CentOS-{version}-{arch}-GenericCloud-{build}.qcow2$'
+        self.image_pattern = 'CentOS-{version}-{arch}-GenericCloud-{build}.qcow2.xz$'
 
 
 class UbuntuImageProvider(ImageProviderBase):

--- a/selftests/functional/test_plugin_vmimage.py
+++ b/selftests/functional/test_plugin_vmimage.py
@@ -1,0 +1,81 @@
+import os
+import tempfile
+import unittest.mock
+
+from avocado.utils import process, path
+from .. import AVOCADO, temp_dir_prefix
+
+
+def missing_binary(binary):
+    try:
+        path.find_command(binary)
+        return False
+    except path.CmdNotFoundError:
+        return True
+
+
+class VMImagePlugin(unittest.TestCase):
+
+    def _get_temporary_config(self):
+        """
+        Creates a temporary bogus config file
+
+        returns base directory, dictionary containing the temporary data dir
+        paths and the configuration file contain those same settings
+        """
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        base_dir = tempfile.TemporaryDirectory(prefix=prefix)
+        test_dir = os.path.join(base_dir.name, 'tests')
+        os.mkdir(test_dir)
+        data_directory = os.path.join(base_dir.name, 'data')
+        os.mkdir(data_directory)
+        cache_dir = os.path.join(data_directory, 'cache')
+        os.mkdir(cache_dir)
+        mapping = {'base_dir': base_dir.name,
+                   'test_dir': test_dir,
+                   'data_dir': data_directory,
+                   'logs_dir': os.path.join(base_dir.name, 'logs'),
+                   'cache_dir': cache_dir}
+        temp_settings = ('[datadir.paths]\n'
+                         'base_dir = %(base_dir)s\n'
+                         'test_dir = %(test_dir)s\n'
+                         'data_dir = %(data_dir)s\n'
+                         'logs_dir = %(logs_dir)s\n') % mapping
+        config_file = tempfile.NamedTemporaryFile('w', delete=False)
+        config_file.write(temp_settings)
+        config_file.close()
+        return base_dir, mapping, config_file
+
+    def setUp(self):
+        (self.base_dir, self.mapping, self.config_file) = self._get_temporary_config()
+
+    @unittest.skipIf(missing_binary('qemu-img'),
+                     "QEMU disk image utility is required by the vmimage utility ")
+    def test_download_image(self):
+        expected_output = "Fedora-Cloud-Base-30-1.2.x86_64.qcow2"
+        image_dir = os.path.join(self.mapping['cache_dir'], 'by_location',
+                                 '89b7a3293bbc1dd73bb143b15fa06f0f9c7188b8')
+        os.makedirs(image_dir)
+        open(os.path.join(image_dir, expected_output), "a").close()
+        cmd_line = "%s --config %s vmimage get --distro fedora --distro-version " \
+                   "30 --arch x86_64" % (AVOCADO, self.config_file.name)
+        result = process.run(cmd_line)
+        self.assertIn(expected_output, result.stdout_text)
+
+    def test_list_images(self):
+        expected_output = "Fedora-Cloud-Base-30-1.2.x86_64.qcow2"
+        image_dir = os.path.join(self.mapping['cache_dir'], 'by_location',
+                                 '89b7a3293bbc1dd73bb143b15fa06f0f9c7188b8')
+        os.makedirs(image_dir)
+        open(os.path.join(image_dir, expected_output), "a").close()
+        cmd_line = "%s --config %s vmimage --list" % (AVOCADO,
+                                                      self.config_file.name)
+        result = process.run(cmd_line)
+        self.assertIn(expected_output, result.stdout_text)
+
+    def tearDown(self):
+        self.base_dir.cleanup()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/selftests/unit/test_plugin_vmimage.py
+++ b/selftests/unit/test_plugin_vmimage.py
@@ -1,0 +1,73 @@
+import unittest.mock
+import os
+import tempfile
+
+from avocado.core import settings, data_dir
+from avocado.plugins import vmimage as vmimage_plugin
+from avocado.utils import vmimage as vmiage_util
+from .. import temp_dir_prefix
+
+
+class VMImagePlugin(unittest.TestCase):
+
+    def _get_temporary_dirs_mapping_and_config(self):
+        """
+        Creates a temporary bogus base data dir
+
+        And returns a dictionary containing the temporary data dir paths and
+        the path to a configuration file contain those same settings
+        """
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        base_dir = tempfile.TemporaryDirectory(prefix=prefix)
+        data_directory = os.path.join(base_dir.name, 'data')
+        os.mkdir(data_directory)
+        os.mkdir(os.path.join(data_directory, 'cache'))
+        mapping = {'base_dir': base_dir.name,
+                   'data_dir': data_directory}
+        temp_settings = ('[datadir.paths]\n'
+                         'base_dir = %(base_dir)s\n'
+                         'data_dir = %(data_dir)s\n') % mapping
+        config_file = tempfile.NamedTemporaryFile('w', delete=False)
+        config_file.write(temp_settings)
+        config_file.close()
+        return base_dir, mapping, config_file.name
+
+    def setUp(self):
+        (self.base_dir, self.mapping,
+         self.config_file_path) = self._get_temporary_dirs_mapping_and_config()
+        self.stg = settings.Settings(self.config_file_path)
+
+    def test_list_downloaded_images(self):
+        with unittest.mock.patch('avocado.core.data_dir.settings.settings', self.stg):
+            expected_images = [{'name': 'CentOS', 'file': 'CentOS-{version}-{arch}-GenericCloud-{build}.qcow2.xz$'},
+                               {'name': 'Debian', 'file': 'debian-{version}-openstack-{arch}.qcow2$'},
+                               {'name': 'JeOS', 'file': 'jeos-{version}-{arch}.qcow2.xz$'},
+                               {'name': 'OpenSUSE', 'file': 'openSUSE-Leap-{version}-OpenStack.{arch}-{build}.qcow2$'},
+                               {'name': 'Ubuntu', 'file': 'ubuntu-{version}-server-cloudimg-{arch}.img'}
+                               ]
+            cache_dir = data_dir.get_cache_dirs()[0]
+            providers = [provider() for provider in vmiage_util.list_providers()]
+
+            for provider in providers:
+                for image in expected_images:
+                    if image['name'] == provider.name:
+                        image['version'] = str(provider.version)
+                        image['arch'] = provider.arch
+                        image['build'] = "1234"
+                        image['file'] = os.path.join(cache_dir, image['file'].
+                                                     format(version=provider.version,
+                                                            build=image['build'],
+                                                            arch=provider.arch).replace('$', ''))
+                        open(image["file"], "a").close()
+            expected_images = sorted(expected_images, key=lambda i: i['name'])
+            images = sorted(vmimage_plugin.list_downloaded_images(), key=lambda i: i['name'])
+            for index, image in enumerate(images):
+                for key in image:
+                    self.assertEqual(expected_images[index][key], image[key])
+
+    def tearDown(self):
+        self.base_dir.cleanup()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/selftests/unit/test_utils_vmimage.py
+++ b/selftests/unit/test_utils_vmimage.py
@@ -163,6 +163,29 @@ class OpenSUSEImageProvider(unittest.TestCase):
         suse_provider.get_version = unittest.mock.Mock(return_value='15.0')
         self.assertEqual(suse_provider.get_image_url(), expected_image_url)
 
+    def test_get_image_parameters_match(self):
+        expected_version = '30'
+        expected_arch = 'x86_64'
+        expected_build = '1234'
+        provider = vmimage.FedoraImageProvider(expected_version, expected_build,
+                                               expected_arch)
+        image = "Fedora-Cloud-Base-%s-%s.%s.qcow2" % (expected_version, expected_build,
+                                                      expected_arch)
+        parameters = provider.get_image_parameters(image)
+        self.assertEqual(expected_version, parameters['version'],
+                         "Founded version is wrong")
+        self.assertEqual(expected_build, parameters['build'],
+                         "Founded build is wrong")
+        self.assertEqual(expected_arch, parameters['arch'],
+                         "Founded arch is wrong")
+
+    def test_get_image_parameters_not_match(self):
+        provider = vmimage.FedoraImageProvider('30', '1234',
+                                               'x86_64')
+        image = 'openSUSE-Leap-15.0-OpenStack.x86_64-1.1.1-Buildlp111.11.11.qcow2'
+        parameters = provider.get_image_parameters(image)
+        self.assertIsNone(parameters, "get_image_parameters() finds parameters where they are not")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,7 @@ if __name__ == '__main__':
                   'task-run = avocado.plugins.task_run:TaskRun',
                   'task-run-recipe = avocado.plugins.task_run_recipe:TaskRunRecipe',
                   'nrun = avocado.plugins.nrun:NRun',
+                  'vmimage = avocado.plugins.vmimage:VMimage'
                   ],
               'avocado.plugins.job.prepost': [
                   'jobscripts = avocado.plugins.jobscripts:JobScripts',


### PR DESCRIPTION
vmimage plugin for management vm images. Has two functions one for downloading new vmimages to the avocado cache and one for listing all existing vmimages inside avocado cache.

---

Changes from v1 (#3264):

- Split into multiple commits
- In fedora secondary usage of local system arch
- For cash_dirs support for  anything that can be looped over
- Fix bug with display of download image
- Better CLI 
- Functional tests for the CLI