### PR TITLE
avocado/utils/archive.py: bring back support for xz archives

### DIFF
--- a/avocado/utils/archive.py
+++ b/avocado/utils/archive.py
@@ -93,7 +93,8 @@ class ArchiveFile:
         '.tar.gz': (False, True, tarfile.open, ':gz'),
         '.tgz': (False, True, tarfile.open, ':gz'),
         '.tar.bz2': (False, True, tarfile.open, ':bz2'),
-        '.tbz2': (False, True, tarfile.open, ':bz2')}
+        '.tbz2': (False, True, tarfile.open, ':bz2'),
+        '.xz': (False, True, tarfile.open, ':xz')}
 
     def __init__(self, filename, mode='r'):
         """


### PR DESCRIPTION
Commit 4c6e6949d correctly removed the conditional and tarfile
wrappers for lzma capabilities, but incorrectly removed the '.xz' from
the extensions supported by ArchiveFile.

Let's put it back unconditionally.

Signed-off-by: Cleber Rosa <crosa@redhat.com>