### PR TITLE
Tags: extend the supported character set allowing dashes

### DIFF
--- a/avocado/core/safeloader.py
+++ b/avocado/core/safeloader.py
@@ -219,7 +219,7 @@ def modules_imported_as(module):
 
 #: Gets the docstring directive value from a string. Used to tweak
 #: test behavior in various ways
-DOCSTRING_DIRECTIVE_RE_RAW = r'\s*:avocado:[ \t]+([a-zA-Z0-9]+?[a-zA-Z0-9_:,\=]*)\s*$'
+DOCSTRING_DIRECTIVE_RE_RAW = r'\s*:avocado:[ \t]+([a-zA-Z0-9]+?[a-zA-Z0-9_:,\=\-\.]*)\s*$'
 DOCSTRING_DIRECTIVE_RE = re.compile(DOCSTRING_DIRECTIVE_RE_RAW)
 
 

--- a/selftests/unit/test_safeloader.py
+++ b/selftests/unit/test_safeloader.py
@@ -70,14 +70,16 @@ from unittest import TestCase
 
 class BaseClass(TestCase):
     '''
-    :avocado: tags=base
+    :avocado: tags=base-tag
+    :avocado: tags=base.tag
     '''
     def test_basic(self):
         pass
 
 class Child(BaseClass):
     '''
-    :avocado: tags=child
+    :avocado: tags=child-tag
+    :avocado: tags=child.tag
     '''
     def test_child(self):
         pass
@@ -420,9 +422,12 @@ class FindClassAndMethods(UnlimitedDiff):
             RECURSIVE_DISCOVERY_PYTHON_UNITTEST)
         temp_test.save()
         tests = safeloader.find_python_unittests(temp_test.path)
-        expected = {'BaseClass': [('test_basic', {'base': None})],
-                    'Child': [('test_child', {'child': None}),
-                              ('test_basic', {'base': None})]}
+        expected = {'BaseClass': [('test_basic', {'base-tag': None,
+                                                  'base.tag': None})],
+                    'Child': [('test_child', {'child-tag': None,
+                                              'child.tag': None}),
+                              ('test_basic', {'base-tag': None,
+                                              'base.tag': None})]}
         self.assertEqual(expected, tests)
 
 


### PR DESCRIPTION
Some use cases, for instance on QEMU, will use tag values as a default
value for some key characteristics of the test.  For instance:

   :avocado: tags=arch:x86_64

Is already used for determining the architecture specific aspect of a
test, and will that value set if a parameter was not explicitly set.
But, due to the limited character set supported in tags, some values
can not be set.  For instance:

   :avocado: tags=machine:s390-ccw-virtio

Cannot be properly recognized without dashes being supported.

Signed-off-by: Cleber Rosa <crosa@redhat.com>