### PR TITLE
 avocado:utils:cpu fix as well new lib add[V2]

### DIFF
--- a/avocado/utils/cpu.py
+++ b/avocado/utils/cpu.py
@@ -99,11 +99,11 @@ def get_cpu_vendor_name():
     :rtype: `string`
     """
     vendors_map = {
-        'intel': ("GenuineIntel", ),
-        'amd': ("AMD", ),
-        'power7': ("POWER7", ),
-        'power8': ("POWER8", ),
-        'power9': ("POWER9", )
+        'intel': (b"GenuineIntel", ),
+        'amd': (b"AMD", ),
+        'power7': (b"POWER7", ),
+        'power8': (b"POWER8", ),
+        'power9': (b"POWER9", )
     }
 
     cpu_info = _get_cpu_info()


### PR DESCRIPTION
1- Fix issue in avocado:utils:cpu lib (TypeError: cannot use a
string pattern on a bytes-like object )
2-Added a subroutine in avocado:utils:cpu about checking system has hyperthreading

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>