### PR TITLE
Vmimage cmd [v3]

### DIFF
--- a/avocado/plugins/vmimage.py
+++ b/avocado/plugins/vmimage.py
@@ -1,0 +1,133 @@
+import os
+
+from avocado.core.output import LOG_UI
+from avocado.core.plugin_interfaces import CLICmd
+from avocado.core import data_dir, output
+from avocado.utils import vmimage, astring
+
+
+def list_downloaded_images():
+    """
+    List the available Image inside avocado cache
+
+    :return: list with image's parameters
+    :rtype: list of dicts
+    """
+    images = []
+    for cache_dir in data_dir.get_cache_dirs():
+        cache_dir = os.path.join(cache_dir, 'vmimage')
+        for distro in os.listdir(cache_dir):
+            for version in os.listdir(os.path.join(cache_dir, distro)):
+                for arch in os.listdir(os.path.join(cache_dir, distro, version)):
+                    image_dir = os.path.join(cache_dir, distro, version, arch)
+                    file_path = get_image_path(image_dir)
+                    if file_path:
+                        images.append({"name": distro, "version": version,
+                                       "arch": arch, "file": file_path})
+    return images
+
+
+def download_image(distro, version=None, arch=None):
+    """
+    Downloads the vmimge to the vmimage cache directory if isn't already exists.
+
+    :param distro: Name of image distribution
+    :type distro: str
+    :param version: Version of image
+    :type version: str
+    :param arch: Architecture of image
+    :type arch: str
+    :raise AttributeError: When image can't be downloaded
+    :return: Information about downloaded image
+    :rtype: dict
+    """
+
+    cache_dir = data_dir.get_cache_dirs()[0]
+    image_info = vmimage.get_best_provider(name=distro, version=version,
+                                           arch=arch,)
+    image_dir = os.path.join(cache_dir, 'vmimage', image_info.name,
+                             str(image_info.version), image_info.arch)
+    file_path = get_image_path(image_dir)
+    if not os.path.exists(image_dir) or file_path is None:
+        image_info = vmimage.get(name=distro, version=version, arch=arch,
+                                 cache_dir=cache_dir)
+        file_path = image_info.base_image
+    image = {'name': distro, 'version': image_info.version,
+             'arch': image_info.arch, 'file': file_path}
+    return image
+
+
+def get_image_path(directory):
+    """
+    Finds path to the image inside directory.
+    :param directory: Directory where should by image
+    :return: Path to the image or if image don't exists return None
+    :rtype: str
+    """
+    for root, _, files in os.walk(directory):
+        if files:
+            files.sort(key=len)
+            return os.path.join(root, files[0])
+    return None
+
+
+def display_images_list(images):
+    """
+    Displays table with information about images
+
+    :param images: list with image's parameters
+    :type images: list of dicts
+    """
+    image_matrix = [[image['name'], image['version'], image['arch'],
+                     image['file']] for image in images]
+    LOG_UI.debug('\n')
+    header = (output.TERM_SUPPORT.header_str('Provider'),
+              output.TERM_SUPPORT.header_str('Version'),
+              output.TERM_SUPPORT.header_str('Architecture'),
+              output.TERM_SUPPORT.header_str('File'))
+    for line in astring.iter_tabular_output(image_matrix, header=header,
+                                            strip=True):
+        LOG_UI.debug(line)
+    LOG_UI.debug('\n')
+
+
+class VMimage(CLICmd):
+    """
+    Implements the avocado 'vmimage' subcommand
+    """
+
+    name = 'vmimage'
+    description = 'Provides VM images acquired from official repositories'
+
+    def configure(self, parser):
+        parser = super(VMimage, self).configure(parser)
+        parser.add_argument('--list',
+                            help='List of all downloaded images',
+                            action='store_true')
+        subparsers = parser.add_subparsers()
+        download_subcommand_parser = subparsers.add_parser(
+            'get', help="Downloads chosen VMimage if it's not already in the cache")
+        download_subcommand_parser.add_argument('--distro',
+                                                help='Name of image distribution',
+                                                required=True)
+        download_subcommand_parser.add_argument('--distro-version',
+                                                help='Required version of image')
+        download_subcommand_parser.add_argument('--arch',
+                                                help='Required architecture image')
+
+    def run(self, config):
+        if config['list'] is True:
+            images = list_downloaded_images()
+            display_images_list(images)
+        elif config.get('distro', None):
+            image = {'name': config['distro'],
+                     'version': config.get('distro_version', None),
+                     'arch': config.get('arch', None), 'file': None}
+            try:
+                image = download_image(config['distro'],
+                                       config.get('distro_version', None),
+                                       config.get('arch', None))
+                LOG_UI.debug("The image was downloaded:")
+            except AttributeError:
+                LOG_UI.debug("The image couldn't be downloaded:")
+            display_images_list([image])

--- a/avocado/utils/vmimage.py
+++ b/avocado/utils/vmimage.py
@@ -424,9 +424,13 @@ def get(name=None, version=None, build=None, arch=None, checksum=None,
               according to the parameters.
     """
     provider = get_best_provider(name, version, build, arch)
+    vmimage_dir = os.path.join("vmimage", provider.name, str(provider.version),
+                               provider.arch)
 
     if cache_dir is None:
-        cache_dir = tempfile.gettempdir()
+        cache_dir = os.path.join(tempfile.gettempdir(), vmimage_dir)
+    else:
+        cache_dir = os.path.join(cache_dir, vmimage_dir)
     try:
         return Image(name=provider.name, url=provider.get_image_url(),
                      version=provider.version, arch=provider.arch,

--- a/avocado/utils/vmimage.py
+++ b/avocado/utils/vmimage.py
@@ -72,7 +72,7 @@ class ImageProviderBase:
         self.url_versions = None
         self.url_images = None
         self.image_pattern = None
-
+        self._file_name = None
         self._version = version
         self._best_version = None
         self.build = build
@@ -85,6 +85,14 @@ class ImageProviderBase:
     @property
     def version_pattern(self):
         return '^%s/$' % self._version
+
+    @property
+    def file_name(self):
+        if not self._file_name:
+            self._file_name = self.image_pattern.format(version=self.version,
+                                                        build=self.build,
+                                                        arch=self.arch)
+        return self._file_name
 
     def _feed_html_parser(self, url, parser):
         try:
@@ -149,6 +157,23 @@ class ImageProviderBase:
             raise ImageProviderError("No images matching '%s' at '%s'. "
                                      "Wrong arch?" % (image, url_images))
 
+    def get_image_parameters(self, image):
+        """
+        Computation of image parameter from image_pattern
+
+        :param image: pattern with parameters
+        :type image: str
+        :return: dict with parameters
+        :rtype: dict
+        """
+        keywords = re.split(r'\{(.*?)\}', self.image_pattern)[1::2]
+        matches = re.match(self.file_name, image)
+
+        if not matches:
+            return None
+
+        return {x: matches.group(x) for x in keywords}
+
 
 class FedoraImageProviderBase(ImageProviderBase):
     """
@@ -178,7 +203,7 @@ class FedoraImageProvider(FedoraImageProviderBase):
         super(FedoraImageProvider, self).__init__(version, build, arch)
         self.url_versions = 'https://dl.fedoraproject.org/pub/fedora/linux/releases/'
         self.url_images = self.url_versions + '{version}/%s/{arch}/images/'
-        self.image_pattern = 'Fedora-Cloud-Base-{version}-{build}.{arch}.qcow2$'
+        self.image_pattern = 'Fedora-Cloud-Base-(?P<version>{version})-(?P<build>{build}).(?P<arch>{arch}).qcow2$'
 
 
 class FedoraSecondaryImageProvider(FedoraImageProviderBase):
@@ -194,7 +219,7 @@ class FedoraSecondaryImageProvider(FedoraImageProviderBase):
                                                            arch)
         self.url_versions = 'https://dl.fedoraproject.org/pub/fedora-secondary/releases/'
         self.url_images = self.url_versions + '{version}/%s/{arch}/images/'
-        self.image_pattern = 'Fedora-Cloud-Base-{version}-{build}.{arch}.qcow2$'
+        self.image_pattern = 'Fedora-Cloud-Base-(?P<version>{version})-(?P<build>{build}).(?P<arch>{arch}).qcow2$'
 
 
 class CentOSImageProvider(ImageProviderBase):
@@ -208,7 +233,7 @@ class CentOSImageProvider(ImageProviderBase):
         super(CentOSImageProvider, self).__init__(version, build, arch)
         self.url_versions = 'https://cloud.centos.org/centos/'
         self.url_images = self.url_versions + '{version}/images/'
-        self.image_pattern = 'CentOS-{version}-{arch}-GenericCloud-{build}.qcow2.xz$'
+        self.image_pattern = 'CentOS-(?P<version>{version})-(?P<arch>{arch})-GenericCloud-(?P<build>{build}).qcow2.xz$'
 
 
 class UbuntuImageProvider(ImageProviderBase):
@@ -230,7 +255,7 @@ class UbuntuImageProvider(ImageProviderBase):
         super(UbuntuImageProvider, self).__init__(version, build, arch)
         self.url_versions = 'http://cloud-images.ubuntu.com/releases/'
         self.url_images = self.url_versions + 'releases/{version}/release/'
-        self.image_pattern = 'ubuntu-{version}-server-cloudimg-{arch}.img'
+        self.image_pattern = 'ubuntu-(?P<version>{version})-server-cloudimg-(?P<arch>{arch}).img'
 
 
 class DebianImageProvider(ImageProviderBase):
@@ -252,7 +277,7 @@ class DebianImageProvider(ImageProviderBase):
         super(DebianImageProvider, self).__init__(version, build, arch)
         self.url_versions = 'https://cdimage.debian.org/cdimage/openstack/'
         self.url_images = self.url_versions + '{version}/'
-        self.image_pattern = 'debian-{version}-openstack-{arch}.qcow2$'
+        self.image_pattern = 'debian-(?P<version>{version})-openstack-(?P<arch>{arch}).qcow2$'
 
 
 class JeosImageProvider(ImageProviderBase):
@@ -271,7 +296,7 @@ class JeosImageProvider(ImageProviderBase):
         super(JeosImageProvider, self).__init__(version, build, arch)
         self.url_versions = 'https://avocado-project.org/data/assets/jeos/'
         self.url_images = self.url_versions + '{version}/'
-        self.image_pattern = 'jeos-{version}-{arch}.qcow2.xz$'
+        self.image_pattern = 'jeos-(?P<version>{version})-(?P<arch>{arch}).qcow2.xz$'
 
 
 class OpenSUSEImageProvider(ImageProviderBase):
@@ -288,9 +313,11 @@ class OpenSUSEImageProvider(ImageProviderBase):
         self.url_images = self.url_versions + 'Leap_{version}/images/'
 
         if not build:
-            self.image_pattern = 'openSUSE-Leap-{version}-OpenStack.{arch}-((.)*).qcow2$'
+            self.image_pattern = 'openSUSE-Leap-(?P<version>{version})-OpenStack.(?P<arch>{arch})-((.)*).qcow2$'
+
         else:
-            self.image_pattern = 'openSUSE-Leap-{version}-OpenStack.{arch}-{build}.qcow2$'
+            self.image_pattern = 'openSUSE-Leap-(?P<version>{version})-OpenStack.' \
+                                 '(?P<arch>{arch})-(?P<build>{build}).qcow2$'
 
     @property
     def version_pattern(self):

--- a/avocado/utils/vmimage.py
+++ b/avocado/utils/vmimage.py
@@ -208,10 +208,7 @@ class CentOSImageProvider(ImageProviderBase):
         super(CentOSImageProvider, self).__init__(version, build, arch)
         self.url_versions = 'https://cloud.centos.org/centos/'
         self.url_images = self.url_versions + '{version}/images/'
-        if archive.LZMA_CAPABLE:
-            self.image_pattern = 'CentOS-{version}-{arch}-GenericCloud-{build}.qcow2.xz$'
-        else:
-            self.image_pattern = 'CentOS-{version}-{arch}-GenericCloud-{build}.qcow2$'
+        self.image_pattern = 'CentOS-{version}-{arch}-GenericCloud-{build}.qcow2.xz$'
 
 
 class UbuntuImageProvider(ImageProviderBase):

--- a/avocado/utils/vmimage.py
+++ b/avocado/utils/vmimage.py
@@ -364,11 +364,15 @@ class Image:
                                                     self.arch)
 
     def get(self):
+        if isinstance(self.cache_dir, str):
+            cache_dirs = [self.cache_dir]
+        else:
+            cache_dirs = self.cache_dir
         asset_path = asset.Asset(name=self.url,
                                  asset_hash=self.checksum,
                                  algorithm=self.algorithm,
                                  locations=None,
-                                 cache_dirs=[self.cache_dir],
+                                 cache_dirs=cache_dirs,
                                  expire=None).fetch()
 
         if os.path.splitext(asset_path)[1] == '.xz':

--- a/selftests/functional/test_plugin_vmimage.py
+++ b/selftests/functional/test_plugin_vmimage.py
@@ -1,0 +1,83 @@
+import os
+import tempfile
+import unittest.mock
+
+from avocado.utils import process, path
+from .. import AVOCADO, temp_dir_prefix
+
+
+def missing_binary(binary):
+    try:
+        path.find_command(binary)
+        return False
+    except path.CmdNotFoundError:
+        return True
+
+
+class VMImagePlugin(unittest.TestCase):
+
+    def _get_temporary_config(self):
+        """
+        Creates a temporary bogus config file
+
+        returns base directory, dictionary containing the temporary data dir
+        paths and the configuration file contain those same settings
+        """
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        base_dir = tempfile.TemporaryDirectory(prefix=prefix)
+        test_dir = os.path.join(base_dir.name, 'tests')
+        os.mkdir(test_dir)
+        data_directory = os.path.join(base_dir.name, 'data')
+        os.mkdir(data_directory)
+        cache_dir = os.path.join(data_directory, 'cache')
+        os.mkdir(cache_dir)
+        mapping = {'base_dir': base_dir.name,
+                   'test_dir': test_dir,
+                   'data_dir': data_directory,
+                   'logs_dir': os.path.join(base_dir.name, 'logs'),
+                   'cache_dir': cache_dir}
+        temp_settings = ('[datadir.paths]\n'
+                         'base_dir = %(base_dir)s\n'
+                         'test_dir = %(test_dir)s\n'
+                         'data_dir = %(data_dir)s\n'
+                         'logs_dir = %(logs_dir)s\n') % mapping
+        config_file = tempfile.NamedTemporaryFile('w', delete=False)
+        config_file.write(temp_settings)
+        config_file.close()
+        return base_dir, mapping, config_file
+
+    def setUp(self):
+        (self.base_dir, self.mapping, self.config_file) = self._get_temporary_config()
+
+    @unittest.skipIf(missing_binary('qemu-img'),
+                     "QEMU disk image utility is required by the vmimage utility ")
+    def test_download_image(self):
+        expected_output = "Fedora-Cloud-Base-30-1.2.x86_64.qcow2"
+        image_dir = os.path.join(self.mapping['cache_dir'], 'vmimage', 'Fedora',
+                                 '30', 'x86_64', 'by_location',
+                                 '89b7a3293bbc1dd73bb143b15fa06f0f9c7188b8')
+        os.makedirs(image_dir)
+        open(os.path.join(image_dir, expected_output), "a").close()
+        cmd_line = "%s --config %s vmimage get --distro fedora --distro-version " \
+                   "30 --arch x86_64" % (AVOCADO, self.config_file.name)
+        result = process.run(cmd_line)
+        self.assertIn(expected_output, result.stdout_text)
+
+    def test_list_images(self):
+        expected_output = "Fedora-Cloud-Base-30-1.2.x86_64.qcow2"
+        image_dir = os.path.join(self.mapping['cache_dir'], 'vmimage', 'Fedora',
+                                 '30', 'x86_64', 'by_location',
+                                 '89b7a3293bbc1dd73bb143b15fa06f0f9c7188b8')
+        os.makedirs(image_dir)
+        open(os.path.join(image_dir, expected_output), "a").close()
+        cmd_line = "%s --config %s vmimage --list" % (AVOCADO,
+                                                      self.config_file.name)
+        result = process.run(cmd_line)
+        self.assertIn(expected_output, result.stdout_text)
+
+    def tearDown(self):
+        self.base_dir.cleanup()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/selftests/unit/test_plugin_vmimage.py
+++ b/selftests/unit/test_plugin_vmimage.py
@@ -1,0 +1,100 @@
+import unittest.mock
+import os
+import tempfile
+
+from avocado.core import settings, data_dir
+from avocado.plugins import vmimage as vmimage_plugin
+from avocado.utils import vmimage as vmiage_util
+from .. import temp_dir_prefix
+from ..functional.test_plugin_vmimage import missing_binary
+
+
+class VMImagePlugin(unittest.TestCase):
+
+    def _get_temporary_dirs_mapping_and_config(self):
+        """
+        Creates a temporary bogus base data dir
+
+        And returns a dictionary containing the temporary data dir paths and
+        the path to a configuration file contain those same settings
+        """
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        base_dir = tempfile.TemporaryDirectory(prefix=prefix)
+        data_directory = os.path.join(base_dir.name, 'data')
+        os.mkdir(data_directory)
+        os.mkdir(os.path.join(data_directory, 'cache'))
+        mapping = {'base_dir': base_dir.name,
+                   'data_dir': data_directory}
+        temp_settings = ('[datadir.paths]\n'
+                         'base_dir = %(base_dir)s\n'
+                         'data_dir = %(data_dir)s\n') % mapping
+        config_file = tempfile.NamedTemporaryFile('w', delete=False)
+        config_file.write(temp_settings)
+        config_file.close()
+        return base_dir, mapping, config_file.name
+
+    def _create_test_files(self):
+        with unittest.mock.patch('avocado.core.data_dir.settings.settings', self.stg):
+            expected_images = [{'name': 'CentOS', 'file': 'CentOS-{version}-{arch}-GenericCloud-{build}.qcow2.xz$'},
+                               {'name': 'Debian', 'file': 'debian-{version}-openstack-{arch}.qcow2$'},
+                               {'name': 'JeOS', 'file': 'jeos-{version}-{arch}.qcow2.xz$'},
+                               {'name': 'OpenSUSE', 'file': 'openSUSE-Leap-{version}-OpenStack.{arch}-{build}.qcow2$'},
+                               {'name': 'Ubuntu', 'file': 'ubuntu-{version}-server-cloudimg-{arch}.img'}
+                               ]
+            cache_dir = data_dir.get_cache_dirs()[0]
+            providers = [provider() for provider in vmiage_util.list_providers()]
+
+            for provider in providers:
+                for image in expected_images:
+                    if image['name'] == provider.name:
+                        path = os.path.join(cache_dir, "vmimage", image['name'],
+                                            str(provider.version), provider.arch)
+                        os.makedirs(path)
+                        image['version'] = str(provider.version)
+                        image['arch'] = provider.arch
+                        image['build'] = "1234"
+                        image['file'] = os.path.join(path, image['file'].format(
+                            version=provider.version,
+                            build=image['build'],
+                            arch=provider.arch).replace('$', ''))
+                        open(image["file"], "a").close()
+            return sorted(expected_images, key=lambda i: i['name'])
+
+    def setUp(self):
+        (self.base_dir, self.mapping,
+         self.config_file_path) = self._get_temporary_dirs_mapping_and_config()
+        self.stg = settings.Settings(self.config_file_path)
+        self.expected_images = self._create_test_files()
+
+    def test_list_downloaded_images(self):
+        with unittest.mock.patch('avocado.core.data_dir.settings.settings', self.stg):
+            images = sorted(vmimage_plugin.list_downloaded_images(), key=lambda i: i['name'])
+            for index, image in enumerate(images):
+                for key in image:
+                    self.assertEqual(self.expected_images[index][key], image[key],
+                                     "Founded image is different from the expected one")
+
+    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 2,
+                     "Skipping test that take a long time to run, are "
+                     "resource intensive or time sensitve")
+    @unittest.skipIf(missing_binary('qemu-img'),
+                     "QEMU disk image utility is required by the vmimage utility ")
+    def test_download_image(self):
+        with unittest.mock.patch('avocado.core.data_dir.settings.settings', self.stg):
+            expected_image_info = vmiage_util.get_best_provider(name="Fedora")
+            image_info = vmimage_plugin.download_image(distro="Fedora")
+            self.assertEqual(expected_image_info.name, image_info['name'],
+                             "Downloaded image is different from the expected one")
+            self.assertEqual(expected_image_info.version, image_info['version'],
+                             "Downloaded image is different from the expected one")
+            self.assertEqual(expected_image_info.arch, image_info['arch'],
+                             "Downloaded image is different from the expected one")
+            self.assertTrue(os.path.isfile(image_info["file"]),
+                            "The image wasn't downloaded")
+
+    def tearDown(self):
+        self.base_dir.cleanup()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/selftests/unit/test_utils_vmimage.py
+++ b/selftests/unit/test_utils_vmimage.py
@@ -163,6 +163,29 @@ class OpenSUSEImageProvider(unittest.TestCase):
         suse_provider.get_version = unittest.mock.Mock(return_value='15.0')
         self.assertEqual(suse_provider.get_image_url(), expected_image_url)
 
+    def test_get_image_parameters_match(self):
+        expected_version = '30'
+        expected_arch = 'x86_64'
+        expected_build = '1234'
+        provider = vmimage.FedoraImageProvider(expected_version, expected_build,
+                                               expected_arch)
+        image = "Fedora-Cloud-Base-%s-%s.%s.qcow2" % (expected_version, expected_build,
+                                                      expected_arch)
+        parameters = provider.get_image_parameters(image)
+        self.assertEqual(expected_version, parameters['version'],
+                         "Founded version is wrong")
+        self.assertEqual(expected_build, parameters['build'],
+                         "Founded build is wrong")
+        self.assertEqual(expected_arch, parameters['arch'],
+                         "Founded arch is wrong")
+
+    def test_get_image_parameters_not_match(self):
+        provider = vmimage.FedoraImageProvider('30', '1234',
+                                               'x86_64')
+        image = 'openSUSE-Leap-15.0-OpenStack.x86_64-1.1.1-Buildlp111.11.11.qcow2'
+        parameters = provider.get_image_parameters(image)
+        self.assertIsNone(parameters, "get_image_parameters() finds parameters where they are not")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,7 @@ if __name__ == '__main__':
                   'task-run = avocado.plugins.task_run:TaskRun',
                   'task-run-recipe = avocado.plugins.task_run_recipe:TaskRunRecipe',
                   'nrun = avocado.plugins.nrun:NRun',
+                  'vmimage = avocado.plugins.vmimage:VMimage'
                   ],
               'avocado.plugins.job.prepost': [
                   'jobscripts = avocado.plugins.jobscripts:JobScripts',


### PR DESCRIPTION
vmimage plugin for management vm images. Has two functions one for downloading new vmimages to the avocado cache and one for listing all existing vmimages inside avocado cache.

---
Changes from v1 (#3264):
- Split into multiple commits
- In fedora secondary usage of local system arch
- For cash_dirs support for anything that can be looped over
- Fix bug with display of download image
- Better CLI
- Functional tests for the CLI

Changes from v2 (#3269):
- New directory structure for keeping information about images
- Changed `LOG_UI.info` to `LOG_UI.debug`
- Fix, problems with command-line options
- Fix, extra white chars in the docstring
- New unit test of downloading images
 