### PR TITLE
Makefile: show help message as the default target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,6 @@ ARCHIVE_BASE_NAME=avocado
 PYTHON_MODULE_NAME=avocado-framework
 RPM_BASE_NAME=python-avocado
 
-include Makefile.include
 
 all:
 	@echo
@@ -56,6 +55,8 @@ all:
 	@echo "rpm-release:        Generate binary RPMs for the latest tagged release"
 	@echo "propagate-version:  Propagate './VERSION' to all plugins/modules"
 	@echo
+
+include Makefile.include
 
 source-pypi: clean
 	if test ! -d PYPI_UPLOAD; then mkdir PYPI_UPLOAD; fi


### PR DESCRIPTION
Because of the addition of the Makefile.include file, the first
target was changed to the first on Makefile.include, while it
should have been the "all" target that shows the help message.

Let's change the order of the include to restore the behavior
of showing the help message when running just `make`.

Signed-off-by: Cleber Rosa <crosa@redhat.com>