### PR TITLE
avocado.utils.vmimage: add CirrOS provider

### DIFF
--- a/avocado/utils/vmimage.py
+++ b/avocado/utils/vmimage.py
@@ -309,6 +309,22 @@ class OpenSUSEImageProvider(ImageProviderBase):
         return max(version_numbers)
 
 
+class CirrOSImageProvider(ImageProviderBase):
+    """
+    CirrOS Image Provider
+
+    CirrOS is a Tiny OS that specializes in running on a cloud.
+    """
+
+    name = 'CirrOS'
+
+    def __init__(self, version=r'[0-9]+\.[0-9]+\.[0-9]+', build=None, arch=os.uname()[4]):
+        super(CirrOSImageProvider, self).__init__(version=version, build=build, arch=arch)
+        self.url_versions = 'https://download.cirros-cloud.net/'
+        self.url_images = self.url_versions + '{version}/'
+        self.image_pattern = 'cirros-{version}-{arch}-disk.img$'
+
+
 class Image:
     def __init__(self, name, url, version, arch, checksum, algorithm,
                  cache_dir, snapshot_dir=None):

--- a/contrib/scripts/vmimage-populate-cache.py
+++ b/contrib/scripts/vmimage-populate-cache.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+"""
+Script that downloads cloud images via avocado.utils.vmimage
+"""
+
+from avocado.utils import vmimage
+from avocado.core import data_dir
+
+
+KNOWN_IMAGES = (
+    # from https://download.cirros-cloud.net/0.4.0/MD5SUMS
+    ('cirros', '0.4.0', 'aarch64', 'ecc9a5132e7a0f11a4c585f513cd0873', 'md5'),
+    ('cirros', '0.4.0', 'arm', '7e9cfcb763e83573a4b9d9315f56cc5f', 'md5'),
+    ('cirros', '0.4.0', 'i386', 'b7d8ac291c698c3f1dc0705ce52a3b64', 'md5'),
+    ('cirros', '0.4.0', 'x86_64', '443b7623e27ecf03dc9e01ee93f67afe', 'md5'),
+)
+
+
+def main():
+    for image in KNOWN_IMAGES:
+        name, version, arch, checksum, algorithm = image
+        print("%s version %s (%s): " % (name, version, arch), end='')
+        download = vmimage.get(name=name, version=version, arch=arch,
+                               checksum=checksum, algorithm=algorithm,
+                               cache_dir=data_dir.get_cache_dirs()[0])
+        print(download.base_image)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
CirrOS is a very popular, tiny cloud image.  It's just natural that
we add support to vmimage.

Also added here is a contrib script that can validate this provider,
and can always be extended later.

Signed-off-by: Cleber Rosa <crosa@redhat.com>