### PR TITLE
Remove old libvirt dependency from requirements-selftests.txt

### DIFF
--- a/requirements-selftests.txt
+++ b/requirements-selftests.txt
@@ -16,12 +16,6 @@ psutil==5.4.7
 # but is necessary for selftests
 pycdlib==1.6.0
 
-# this is a workaround since easy_install cannot install
-# libvirt-python properly with the the current process
-# in make develop. The proper solution would be migrate
-# our make develop process to use pip
-libvirt-python==4.6.0
-
 # For avocado.utils.network selftests
 netifaces
 


### PR DESCRIPTION
As libvirt is handled in the spec file, it is not necessary to
install it using pip anymore.

Signed-off-by: Willian Rampazzo <willianr@redhat.com>