### PR TITLE
adding function interfacewait that waits for the link up

### DIFF
--- a/avocado/utils/configure_network.py
+++ b/avocado/utils/configure_network.py
@@ -92,3 +92,16 @@ def unset_ip(interface):
         return True
     except Exception as ex:
         raise NWException("ifdown fails: %s" % ex)
+
+
+def interfacewait(interface):
+    """
+    Waits for the interface link to be UP
+    """
+    for _ in range(0, 600, 5):
+        if 'UP' or 'yes' in \
+           process.system_output("timeout 120 ip link show %s | head -1"
+                                 % device, shell=True, ignore_status=True):
+            print("Interface %s link is up" % interface)
+            return True
+    return False


### PR DESCRIPTION
of a interface.

This function will wait for a interface's link to be up
after link down/up. This functionality is used in other
NIC tests like ethtool test, etc..

Signed-off-by: Vaishnavi Bhat <vaishnavi@linux.vnet.ibm.com>