### PR TITLE
avocado.utils.process: function for getting matching output

### DIFF
--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -1307,19 +1307,17 @@ def get_owner_id(pid):
         return None
 
 
-def get_perf_events(pattern):
+def get_command_output_matching(command, pattern):
     """
-    Run 'perf list' command, with the matching pattern create a
-    list and return it.
+    Runs a command, and if the pattern is in in the output, returns it.
 
-    :param pattern: Pattern to search.
-    :type pattern: str.
+    :param command: the command to execute
+    :type command: str
+    :param pattern: pattern to search in the output, in a line by line basis
+    :type pattern: str
 
-    :return: list of events matching the 'pattern'.
-    :rtype: list of str.
+    :return: list of lines matching the pattern
+    :rtype: list of str
     """
-    list_of_events = []
-    for line in system_output("perf list").split('\n'):
-        if pattern in line:
-            list_of_events.append(line)
-    return list_of_events
+    return [line for line in run(command).stdout_text.splitlines()
+            if pattern in line]

--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -646,5 +646,23 @@ class FDDrainerTests(unittest.TestCase):
         self.assertEqual(data.getvalue(), u"Avok\ufffd\ufffddo\n")
 
 
+class GetCommandOutputPattern(unittest.TestCase):
+
+    @unittest.skipUnless(ECHO_CMD, "Echo command not available in system")
+    def test_matches(self):
+        res = process.get_command_output_matching("echo foo", "foo")
+        self.assertEqual(res, ["foo"])
+
+    @unittest.skipUnless(ECHO_CMD, "Echo command not available in system")
+    def test_matches_multiple(self):
+        res = process.get_command_output_matching("echo -e 'foo\nfoo\n'", "foo")
+        self.assertEqual(res, ["foo", "foo"])
+
+    @unittest.skipUnless(ECHO_CMD, "Echo command not available in system")
+    def test_does_not_match(self):
+        res = process.get_command_output_matching("echo foo", "bar")
+        self.assertEqual(res, [])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
It's definitely a common pattern to run commands, and if the output
matches a given expected pattern, have that output.  On a previous
discussion, I pointed out that:

  "I think this could be introduced as an avocado.utils.process
  utility instead, one that takes a command and a pattern. I don't
  think this justifies a new module (avocado.utils.perf) and the
  hardcoded perf list list command. If, the perf list command output
  were to be parsed into a proper data structure, then I think it'd
  make sense to have a perf module."

What I meant there, it's that a generic utility function could be
added, not one that runs "perf list".  This makes the function
introduced here to be a generic function.  Users for this function
should simply start using:

   get_command_output_matching("perf list", "pattern")

Reference: https://github.com/avocado-framework/avocado/pull/3108
Signed-off-by: Cleber Rosa <crosa@redhat.com>