### PR TITLE
The path.usable_ro_dir shouldn't create a dir

### DIFF
--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -105,17 +105,17 @@ def get_test_dir():
     4) User default test dir (~/avocado/tests) is used
     """
     configured = _get_settings_dir('test_dir')
-    if utils_path.usable_ro_dir(configured, False):
+    if utils_path.usable_ro_dir(configured):
         return configured
 
     if settings.settings.intree:
         base_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
         return os.path.join(base_dir, 'examples', 'tests')
 
-    if utils_path.usable_ro_dir(SYSTEM_TEST_DIR, False):
+    if utils_path.usable_ro_dir(SYSTEM_TEST_DIR):
         return SYSTEM_TEST_DIR
 
-    if utils_path.usable_ro_dir(USER_TEST_DIR):
+    if utils_path.usable_rw_dir(USER_TEST_DIR):
         return USER_TEST_DIR
 
 

--- a/avocado/utils/path.py
+++ b/avocado/utils/path.py
@@ -166,27 +166,19 @@ def usable_rw_dir(directory, create=True):
     return False
 
 
-def usable_ro_dir(directory, create=True):
+def usable_ro_dir(directory):
     """
     Verify whether dir exists and we can access its contents.
 
-    If a usable RO is there, use it no questions asked. If not, let's at
-    least try to create one.
+    Check if a usable RO directory is there.
 
     :param directory: Directory
-    :param create: whether to create the directory
     """
     cwd = os.getcwd()
     if os.path.isdir(directory):
         try:
             os.chdir(directory)
             os.chdir(cwd)
-            return True
-        except OSError:
-            pass
-    elif create:
-        try:
-            init_dir(directory)
             return True
         except OSError:
             pass


### PR DESCRIPTION
Change the behavior of usable_ro_dir so it does not create a dir.
If a new dir is needed, usable_rw_dir should be used.

Reference: https://trello.com/c/xsKNnIYu/
Signed-off-by: Willian Rampazzo <willianr@redhat.com>