### PR TITLE
avocado.utils.ssh: support password based authenticaction

### DIFF
--- a/avocado/utils/ssh.py
+++ b/avocado/utils/ssh.py
@@ -14,16 +14,21 @@ class Session:
     MASTER_OPTIONS = (('ControlMaster', 'yes'),
                       ('ControlPersist', 'yes'))
 
-    def __init__(self, address, credentials):
+    def __init__(self, host, port=None, user=None, key=None):
         """
-        :param address: a hostname or IP address and port, in the same format
-                        given to socket and other servers
-        :type address: tuple
-        :param credentials: username and path to a key for authentication purposes
-        :type credentials: tuple
+        :param host: a host name or IP address
+        :type host: str
+        :param port: port number
+        :type port: int
+        :param user: the name of the remote user
+        :type user: str
+        :param key: path to a key for authentication purpose
+        :type key: str
         """
-        self.address = address
-        self.credentials = credentials
+        self.host = host
+        self.port = port
+        self.user = user
+        self.key = key
         self._connection = None
 
     def __enter__(self):
@@ -41,13 +46,13 @@ class Session:
 
     def _ssh_cmd(self, dash_o_opts=(), opts=(), command=''):
         cmd = self._dash_o_opts_to_str(dash_o_opts)
-        if self.credentials:
-            cmd += " -l %s" % self.credentials[0]
-            if self.credentials[1] is not None:
-                cmd += " -i %s" % self.credentials[1]
-        if self.address[1] is not None:
-            cmd += " -p %s" % self.address[1]
-        cmd = "ssh %s %s %s '%s'" % (cmd, " ".join(opts), self.address[0], command)
+        if self.user is not None:
+            cmd += " -l %s" % self.user
+            if self.key is not None:
+                cmd += " -i %s" % self.key
+        if self.port is not None:
+            cmd += " -p %s" % self.port
+        cmd = "ssh %s %s %s '%s'" % (cmd, " ".join(opts), self.host, command)
         return cmd
 
     def _master_connection(self):

--- a/avocado/utils/ssh.py
+++ b/avocado/utils/ssh.py
@@ -56,7 +56,9 @@ class Session:
         return cmd
 
     def _master_connection(self):
-        return self._ssh_cmd(self.DEFAULT_OPTIONS + self.MASTER_OPTIONS, ('-n',))
+        options = self.DEFAULT_OPTIONS + self.MASTER_OPTIONS
+        options += (('PubkeyAuthentication', 'yes' if self.key else 'no'),)
+        return self._ssh_cmd(options, ('-n',))
 
     def _master_command(self, command):
         cmd = self._ssh_cmd(self.DEFAULT_OPTIONS, ('-O', command))

--- a/avocado/utils/ssh.py
+++ b/avocado/utils/ssh.py
@@ -5,7 +5,15 @@ import subprocess
 import sys
 import tempfile
 
+from . import path as path_utils
 from . import process
+
+
+try:
+    #: The SSH client binary to use, if one is found in the system
+    SSH_CLIENT_BINARY = path_utils.find_command('ssh')
+except path_utils.CmdNotFoundError:
+    SSH_CLIENT_BINARY = None
 
 
 class Session:
@@ -62,7 +70,8 @@ class Session:
                 cmd += " -i %s" % self.key
         if self.port is not None:
             cmd += " -p %s" % self.port
-        cmd = "ssh %s %s %s '%s'" % (cmd, " ".join(opts), self.host, command)
+        cmd = "%s %s %s %s '%s'" % (SSH_CLIENT_BINARY, cmd,
+                                    " ".join(opts), self.host, command)
         return cmd
 
     def _master_connection(self):
@@ -107,6 +116,9 @@ class Session:
         :returns: whether the connection is successfully established
         :rtype: bool
         """
+        if SSH_CLIENT_BINARY is None:
+            return False
+
         if not self._check():
             cmd = shlex.split(self._master_connection())
             if self.password is not None:

--- a/selftests/unit/test_utils_ssh.py
+++ b/selftests/unit/test_utils_ssh.py
@@ -1,0 +1,29 @@
+import unittest
+
+from avocado.utils import ssh
+
+
+class Session(unittest.TestCase):
+
+    def test_minimal(self):
+        session = ssh.Session('host')
+        self.assertEqual(session.host, 'host')
+        self.assertIsNone(session.port)
+        self.assertIsNone(session.user)
+        self.assertIsNone(session.key)
+        self.assertIsNone(session._connection)
+
+    def test_ssh_cmd_port(self):
+        session = ssh.Session('hostname', port=22)
+        ssh_cmd = session._ssh_cmd()
+        self.assertIn(" -p ", ssh_cmd)
+
+    def test_ssh_cmd_user_key(self):
+        session = ssh.Session('hostname', user='user', key='/path/to/key')
+        ssh_cmd = session._ssh_cmd()
+        self.assertIn(" -l ", ssh_cmd)
+        self.assertIn(" -i ", ssh_cmd)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/selftests/unit/test_utils_ssh.py
+++ b/selftests/unit/test_utils_ssh.py
@@ -1,5 +1,5 @@
 import os
-import unittest
+import unittest.mock
 
 from avocado.utils import ssh
 from avocado.utils import process
@@ -53,6 +53,11 @@ class Session(unittest.TestCase):
         ssh_askpass_password = process.run(ssh_askpass_path)
         os.unlink(ssh_askpass_path)
         self.assertEqual(ssh_askpass_password.stdout_text.rstrip(), password)
+
+    def test_no_ssh_client_binary(self):
+        session = ssh.Session('hostname')
+        with unittest.mock.patch('avocado.utils.ssh.SSH_CLIENT_BINARY', None):
+            self.assertFalse(session.connect())
 
 
 if __name__ == '__main__':

--- a/selftests/unit/test_utils_ssh.py
+++ b/selftests/unit/test_utils_ssh.py
@@ -24,6 +24,16 @@ class Session(unittest.TestCase):
         self.assertIn(" -l ", ssh_cmd)
         self.assertIn(" -i ", ssh_cmd)
 
+    def test_master_connection_key(self):
+        session = ssh.Session('hostname', user='user', key='/path/to/key')
+        master_connection = session._master_connection()
+        self.assertIn(" -o 'PubkeyAuthentication=yes'", master_connection)
+
+    def test_master_connection_no_key(self):
+        session = ssh.Session('hostname', user='user')
+        master_connection = session._master_connection()
+        self.assertIn(" -o 'PubkeyAuthentication=no'", master_connection)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This, among other minor things, adds password based authentication.  A use can be seen here:

https://github.com/clebergnu/qemu/tree/ssh_password

More specifically:

https://github.com/clebergnu/qemu/commit/f295b3a06b1cc2f689063dd23d4f2c710e980e29