### PR TITLE
Lzma files detection fix

### DIFF
--- a/avocado/utils/archive.py
+++ b/avocado/utils/archive.py
@@ -68,6 +68,8 @@ def is_lzma_file(path):
             _ = lzma_file.read(1)
         except lzma.LZMAError:
             return False
+        except EOFError:
+            return False
     return True
 
 


### PR DESCRIPTION
When we run `is_lzma_file` on an empty file the application will crash because
of `EOFError`. This commit fixes this problem.

Signed-off-by: Jan Richter <jarichte@redhat.com>