### PR TITLE
Vmimage cmd [v5]

### DIFF
--- a/avocado/plugins/vmimage.py
+++ b/avocado/plugins/vmimage.py
@@ -1,0 +1,126 @@
+import json
+import os
+import re
+
+from avocado.core.output import LOG_UI
+from avocado.core.plugin_interfaces import CLICmd
+from avocado.core import data_dir, output
+from avocado.utils import vmimage, astring
+
+
+def list_downloaded_images():
+    """
+    List the available Image inside avocado cache
+    :return: list with image's parameters
+    :rtype: list of dicts
+    """
+    images = []
+    for cache_dir in data_dir.get_cache_dirs():
+        for root, _, files in os.walk(cache_dir):
+            if files:
+                metadata_files = [pos_json for pos_json in files
+                                  if pos_json.endswith('_metadata.json')]
+                files = list(set(files) - set(metadata_files))
+                for metadata_file in metadata_files:
+                    with open(os.path.join(root, metadata_file), 'r') as data:
+                        metadata = json.loads(data.read())
+                    if isinstance(metadata, dict):
+                        if metadata.get("type", None) == "vmimage":
+                            provider = None
+                            for p in vmimage.IMAGE_PROVIDERS:
+                                if p.name == metadata["name"]:
+                                    provider = p(metadata["version"],
+                                                 metadata["build"],
+                                                 metadata["arch"])
+                                    break
+                            if provider is not None:
+                                for image in files:
+                                    if re.match(provider.file_name, image):
+                                        data = {"name": provider.name,
+                                                "version": provider.version,
+                                                "arch": provider.arch,
+                                                "file": os.path.join(root, image)}
+                                        images.append(data)
+                                        break
+    return images
+
+
+def download_image(distro, version=None, arch=None):
+    """
+    Downloads the vmimge to the vmimage cache directory if isn't already exists.
+    :param distro: Name of image distribution
+    :type distro: str
+    :param version: Version of image
+    :type version: str
+    :param arch: Architecture of image
+    :type arch: str
+    :raise AttributeError: When image can't be downloaded
+    :return: Information about downloaded image
+    :rtype: dict
+    """
+    cache_dir = data_dir.get_cache_dirs()[0]
+    image_info = vmimage.get(name=distro, version=version, arch=arch,
+                             cache_dir=cache_dir)
+    file_path = image_info.base_image
+    image = {'name': distro, 'version': image_info.version,
+             'arch': image_info.arch, 'file': file_path}
+    return image
+
+
+def display_images_list(images):
+    """
+    Displays table with information about images
+    :param images: list with image's parameters
+    :type images: list of dicts
+    """
+    image_matrix = [[image['name'], image['version'], image['arch'],
+                     image['file']] for image in images]
+    header = (output.TERM_SUPPORT.header_str('Provider'),
+              output.TERM_SUPPORT.header_str('Version'),
+              output.TERM_SUPPORT.header_str('Architecture'),
+              output.TERM_SUPPORT.header_str('File'))
+    for line in astring.iter_tabular_output(image_matrix, header=header,
+                                            strip=True):
+        LOG_UI.debug(line)
+
+
+class VMimage(CLICmd):
+    """
+    Implements the avocado 'vmimage' subcommand
+    """
+
+    name = 'vmimage'
+    description = 'Provides VM images acquired from official repositories'
+
+    def configure(self, parser):
+        parser = super(VMimage, self).configure(parser)
+        subcommands = parser.add_subparsers(dest='vmimage_subcommand')
+        subcommands.required = True
+        subcommands.add_parser('list', help='List of all downloaded images')
+        download_subcommand_parser = subcommands.add_parser(
+            'get', help="Downloads chosen VMimage if it's not already in the cache")
+        download_subcommand_parser.add_argument('--distro',
+                                                help='Name of image distribution',
+                                                required=True)
+        download_subcommand_parser.add_argument('--distro-version',
+                                                help='Required version of image')
+        download_subcommand_parser.add_argument('--arch',
+                                                help='Required architecture image')
+
+    def run(self, config):
+        subcommand = config.get("vmimage_subcommand")
+        if subcommand == 'list':
+            images = list_downloaded_images()
+            display_images_list(images)
+        elif subcommand == 'get':
+            image = {'name': config['distro'],
+                     'version': config.get('distro_version', None),
+                     'arch': config.get('arch', None), 'file': None}
+            try:
+                image = download_image(config['distro'],
+                                       config.get('distro_version', None),
+                                       config.get('arch', None))
+                LOG_UI.debug("The image was downloaded:")
+            except AttributeError:
+                LOG_UI.debug("The image couldn't be downloaded:")
+            display_images_list([image])

--- a/avocado/utils/vmimage.py
+++ b/avocado/utils/vmimage.py
@@ -350,7 +350,7 @@ class CirrOSImageProvider(ImageProviderBase):
 
 
 class Image:
-    def __init__(self, name, url, version, arch, checksum, algorithm,
+    def __init__(self, name, url, version, arch, build, checksum, algorithm,
                  cache_dir, snapshot_dir=None):
         """
         Creates an instance of Image class.
@@ -363,6 +363,8 @@ class Image:
         :type version: int
         :param arch: Architecture of the system image.
         :type arch: str
+        :param build: Build of the system image.
+        :type build: str
         :param checksum: Hash of the system image to match after download.
         :type checksum: str
         :param algorithm: Hash type, used when the checksum is provided.
@@ -377,6 +379,7 @@ class Image:
         self.url = url
         self.version = version
         self.arch = arch
+        self.build = build
         self.checksum = checksum
         self.algorithm = algorithm
         self.cache_dir = cache_dir
@@ -469,7 +472,8 @@ def get(name=None, version=None, build=None, arch=None, checksum=None,
         return Image(name=provider.name, url=provider.get_image_url(),
                      version=provider.version, arch=provider.arch,
                      checksum=checksum, algorithm=algorithm,
-                     cache_dir=cache_dir, snapshot_dir=snapshot_dir)
+                     build=provider.build, cache_dir=cache_dir,
+                     snapshot_dir=snapshot_dir)
     except ImageProviderError:
         pass
 

--- a/avocado/utils/vmimage.py
+++ b/avocado/utils/vmimage.py
@@ -404,6 +404,9 @@ class Image:
                                                     self.arch)
 
     def get(self):
+        metadata = {"type": "vmimage", "name": self.name,
+                    "version": self.version, "arch": self.arch,
+                    "build": self.build}
         if isinstance(self.cache_dir, str):
             cache_dirs = [self.cache_dir]
         else:
@@ -413,7 +416,8 @@ class Image:
                                  algorithm=self.algorithm,
                                  locations=None,
                                  cache_dirs=cache_dirs,
-                                 expire=None).fetch()
+                                 expire=None,
+                                 metadata=metadata).fetch()
 
         if archive.is_archive(asset_path):
             uncompressed_path = os.path.splitext(asset_path)[0]

--- a/selftests/functional/test_plugin_vmimage.py
+++ b/selftests/functional/test_plugin_vmimage.py
@@ -1,0 +1,93 @@
+import json
+import os
+import tempfile
+import unittest.mock
+
+from avocado.utils import process, path
+from .. import AVOCADO, temp_dir_prefix
+
+
+def missing_binary(binary):
+    try:
+        path.find_command(binary)
+        return False
+    except path.CmdNotFoundError:
+        return True
+
+
+def create_metadata_file(image_file, metadata):
+    basename = os.path.splitext(image_file)[0]
+    metadata_file = "%s_metadata.json" % basename
+    metadata = json.dumps(metadata)
+    with open(metadata_file, "w") as f:
+        f.write(metadata)
+
+
+class VMImagePlugin(unittest.TestCase):
+
+    def _get_temporary_config(self):
+        """
+        Creates a temporary bogus config file
+        returns base directory, dictionary containing the temporary data dir
+        paths and the configuration file contain those same settings
+        """
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        base_dir = tempfile.TemporaryDirectory(prefix=prefix)
+        test_dir = os.path.join(base_dir.name, 'tests')
+        os.mkdir(test_dir)
+        data_directory = os.path.join(base_dir.name, 'data')
+        os.mkdir(data_directory)
+        cache_dir = os.path.join(data_directory, 'cache')
+        os.mkdir(cache_dir)
+        mapping = {'base_dir': base_dir.name,
+                   'test_dir': test_dir,
+                   'data_dir': data_directory,
+                   'logs_dir': os.path.join(base_dir.name, 'logs'),
+                   'cache_dir': cache_dir}
+        temp_settings = ('[datadir.paths]\n'
+                         'base_dir = %(base_dir)s\n'
+                         'test_dir = %(test_dir)s\n'
+                         'data_dir = %(data_dir)s\n'
+                         'logs_dir = %(logs_dir)s\n') % mapping
+        config_file = tempfile.NamedTemporaryFile('w', delete=False)
+        config_file.write(temp_settings)
+        config_file.close()
+        return base_dir, mapping, config_file
+
+    def setUp(self):
+        (self.base_dir, self.mapping, self.config_file) = self._get_temporary_config()
+
+    @unittest.skipIf(missing_binary('qemu-img'),
+                     "QEMU disk image utility is required by the vmimage utility ")
+    def test_download_image(self):
+        expected_output = "Fedora-Cloud-Base-30-1.2.x86_64.qcow2"
+        image_dir = os.path.join(self.mapping['cache_dir'], 'by_location',
+                                 '89b7a3293bbc1dd73bb143b15fa06f0f9c7188b8')
+        os.makedirs(image_dir)
+        open(os.path.join(image_dir, expected_output), "w").close()
+        cmd_line = "%s --config %s vmimage get --distro fedora --distro-version " \
+                   "30 --arch x86_64" % (AVOCADO, self.config_file.name)
+        result = process.run(cmd_line)
+        self.assertIn(expected_output, result.stdout_text)
+
+    def test_list_images(self):
+        expected_output = "Fedora-Cloud-Base-30-1.2.x86_64.qcow2"
+        metadata = {"type": "vmimage", "name": "Fedora", "version": 30,
+                    "arch": "x86_64", "build": 1.2}
+        image_dir = os.path.join(self.mapping['cache_dir'], 'by_location',
+                                 '89b7a3293bbc1dd73bb143b15fa06f0f9c7188b8')
+        os.makedirs(image_dir)
+        expected_file = os.path.join(image_dir, expected_output)
+        open(expected_file, "w").close()
+        create_metadata_file(expected_file, metadata)
+        cmd_line = "%s --config %s vmimage list" % (AVOCADO,
+                                                    self.config_file.name)
+        result = process.run(cmd_line)
+        self.assertIn(expected_output, result.stdout_text)
+
+    def tearDown(self):
+        self.base_dir.cleanup()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/selftests/unit/test_plugin_vmimage.py
+++ b/selftests/unit/test_plugin_vmimage.py
@@ -1,0 +1,156 @@
+import unittest.mock
+import os
+import tempfile
+from urllib.error import URLError
+
+from avocado.core import settings, data_dir
+from avocado.plugins import vmimage as vmimage_plugin
+from avocado.utils import vmimage as vmimage_util
+from .. import temp_dir_prefix
+from ..functional.test_plugin_vmimage import missing_binary, create_metadata_file
+
+#: extracted from https://dl.fedoraproject.org/pub/fedora/linux/releases/
+FEDORA_PAGE = """<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<html>
+ <head>
+  <title>Index of /pub/fedora/linux/releases</title>
+ </head>
+ <body>
+<h1>Index of /pub/fedora/linux/releases</h1>
+<pre><img src="/icons/blank.gif" alt="Icon "> <a href="?C=N;O=D">Name</a>
+<a href="?C=M;O=A">Last modified</a>      <a href="?C=S;O=A">Size</a>
+<a href="?C=D;O=A">Description</a><hr><img src="/icons/back.gif" alt="[PARENTDIR]">
+<a href="/pub/fedora/linux/">Parent Directory</a>                             -
+<img src="/icons/folder.gif" alt="[DIR]"> <a href="30/">30/</a>                     2019-04-26 20:58    -
+<hr></pre>
+</body></html>"""
+
+JEOS_PAGE = """<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<html>
+ <head>
+  <title>Index of /data/assets/jeos</title>
+ </head>
+ <body>
+<h1>Index of /data/assets/jeos</h1>
+<table><tr><th><img src="/icons/blank.gif" alt="[ICO]"></th><th>
+<a href="?C=N;O=D">Name</a></th><th><a href="?C=M;O=A">Last modified</a></th><th>
+<a href="?C=S;O=A">Size</a></th><th><a href="?C=D;O=A">Description</a></th></tr><tr><th colspan="5"><hr></th></tr>
+<tr><td valign="top"><img src="/icons/back.gif" alt="[DIR]"></td><td>
+<a href="/data/assets/">Parent Directory</a></td><td>&nbsp;</td><td align="right">  - </td><td>&nbsp;</td></tr>
+<tr><td valign="top"><img src="/icons/folder.gif" alt="[DIR]"></td><td><a href="27/">27/</a>
+</td><td align="right">11-Dec-2017 17:43  </td><td align="right">  - </td><td>&nbsp;</td></tr>
+<tr><th colspan="5"><hr></th></tr>
+</table>
+</body></html>"""
+
+#: extracted from https://download.cirros-cloud.net/
+CIRROS_PAGE = """<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<html>
+ <head>
+  <title>Index of /</title>
+ </head>
+ <body>
+<h1>Index of /</h1>
+<pre>      <a href="?C=N;O=D">Name</a>
+<a href="?C=M;O=A">Last modified</a>
+ <a href="?C=S;O=A">Size</a>  <a href="?C=D;O=A">Description</a><hr>
+ <a href="0.3.0/">0.3.0/</a>                                             2017-11-20 07:20    -
+
+      <a href="0.4.0/">0.4.0/</a>                                             2017-11-19 20:01    -
+
+<hr></pre>
+</body></html>"""
+
+
+class VMImagePlugin(unittest.TestCase):
+
+    def _get_temporary_dirs_mapping_and_config(self):
+        """
+        Creates a temporary bogus base data dir
+        And returns a dictionary containing the temporary data dir paths and
+        the path to a configuration file contain those same settings
+        """
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        base_dir = tempfile.TemporaryDirectory(prefix=prefix)
+        data_directory = os.path.join(base_dir.name, 'data')
+        os.mkdir(data_directory)
+        os.mkdir(os.path.join(data_directory, 'cache'))
+        mapping = {'base_dir': base_dir.name,
+                   'data_dir': data_directory}
+        temp_settings = ('[datadir.paths]\n'
+                         'base_dir = %(base_dir)s\n'
+                         'data_dir = %(data_dir)s\n') % mapping
+        config_file = tempfile.NamedTemporaryFile('w', delete=False)
+        config_file.write(temp_settings)
+        config_file.close()
+        return base_dir, mapping, config_file.name
+
+    @unittest.mock.patch('avocado.utils.vmimage.urlopen')
+    def _create_test_files(self, urlopen_mock):
+        with unittest.mock.patch('avocado.core.data_dir.settings.settings', self.stg):
+            expected_images = [{'name': 'Fedora', 'file': 'Fedora-Cloud-Base-{version}-{build}.{arch}.qcow2',
+                                'url': FEDORA_PAGE},
+                               {'name': 'JeOS', 'file': 'jeos-{version}-{arch}.qcow2.xz', 'url': JEOS_PAGE},
+                               {'name': 'CirrOS', 'file': 'cirros-{version}-{arch}-disk.img', 'url': CIRROS_PAGE}
+                               ]
+            cache_dir = data_dir.get_cache_dirs()[0]
+            providers = [provider() for provider in vmimage_util.list_providers()]
+
+            for provider in providers:
+                for image in expected_images:
+                    if image['name'] == provider.name:
+                        urlread_mocked = unittest.mock.Mock(return_value=image["url"])
+                        urlopen_mock.return_value = unittest.mock.Mock(read=urlread_mocked)
+                        image['type'] = "vmimage"
+                        image['version'] = provider.version
+                        image['arch'] = provider.arch
+                        image['build'] = "1234"
+                        image['file'] = os.path.join(cache_dir, image['file'].format(
+                            version=image['version'],
+                            build=image['build'],
+                            arch=image['arch']))
+                        open(image["file"], "w").close()
+                        create_metadata_file(image['file'], image)
+            return sorted(expected_images, key=lambda i: i['name'])
+
+    def setUp(self):
+        (self.base_dir, self.mapping,
+         self.config_file_path) = self._get_temporary_dirs_mapping_and_config()
+        self.stg = settings.Settings(self.config_file_path)
+        self.expected_images = self._create_test_files()
+
+    def test_list_downloaded_images(self):
+        with unittest.mock.patch('avocado.core.data_dir.settings.settings', self.stg):
+            images = sorted(vmimage_plugin.list_downloaded_images(), key=lambda i: i['name'])
+            for index, image in enumerate(images):
+                for key in image:
+                    self.assertEqual(self.expected_images[index][key], image[key],
+                                     "Found image is different from the expected one")
+
+    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 2,
+                     "Skipping test that take a long time to run, are "
+                     "resource intensive or time sensitve")
+    @unittest.skipIf(missing_binary('qemu-img'),
+                     "QEMU disk image utility is required by the vmimage utility ")
+    def test_download_image(self):
+        with unittest.mock.patch('avocado.core.data_dir.settings.settings', self.stg):
+            try:
+                expected_image_info = vmimage_util.get_best_provider(name="CirrOS")
+                image_info = vmimage_plugin.download_image(distro="CirrOS")
+            except URLError as details:
+                raise unittest.SkipTest(details)
+            self.assertEqual(expected_image_info.name, image_info['name'],
+                             "Downloaded image is different from the expected one")
+            self.assertEqual(expected_image_info.version, image_info['version'],
+                             "Downloaded image is different from the expected one")
+            self.assertEqual(expected_image_info.arch, image_info['arch'],
+                             "Downloaded image is different from the expected one")
+            self.assertTrue(os.path.isfile(image_info["file"]),
+                            "The image wasn't downloaded")
+
+    def tearDown(self):
+        self.base_dir.cleanup()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/selftests/unit/test_utils_asset.py
+++ b/selftests/unit/test_utils_asset.py
@@ -150,6 +150,42 @@ class TestAsset(unittest.TestCase):
         with open(a3_path, 'r') as a3_file:
             self.assertEqual(a3_file.read(), third_asset_content)
 
+    def test_create_metadata_file(self):
+        expected_metadata = {"Name": "name", "version": 1.2}
+        foo_tarball = asset.Asset(self.url,
+                                  asset_hash=self.assethash,
+                                  algorithm='sha1',
+                                  locations=None,
+                                  cache_dirs=[self.cache_dir],
+                                  expire=None,
+                                  metadata=expected_metadata).fetch()
+        expected_file = "%s_metadata.json" % os.path.splitext(foo_tarball)[0]
+        self.assertTrue(os.path.exists(expected_file))
+
+    def test_get_metadata_file_exists(self):
+        expected_metadata = {"Name": "name", "version": 1.2}
+        a = asset.Asset(self.url,
+                        asset_hash=self.assethash,
+                        algorithm='sha1',
+                        locations=None,
+                        cache_dirs=[self.cache_dir],
+                        expire=None,
+                        metadata=expected_metadata)
+        a.fetch()
+        metadata = a.get_metadata()
+        self.assertEqual(expected_metadata, metadata)
+
+    def test_get_metadata_file_not_exists(self):
+        expected_metadata = {"Name": "name", "version": 1.2}
+        a = asset.Asset(self.url,
+                        asset_hash=self.assethash,
+                        algorithm='sha1',
+                        locations=None,
+                        cache_dirs=[self.cache_dir],
+                        expire=None,
+                        metadata=expected_metadata)
+        self.assertIsNone(a.get_metadata())
+
     def tearDown(self):
         self.tmpdir.cleanup()
 

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,7 @@ if __name__ == '__main__':
                   'task-run = avocado.plugins.task_run:TaskRun',
                   'task-run-recipe = avocado.plugins.task_run_recipe:TaskRunRecipe',
                   'nrun = avocado.plugins.nrun:NRun',
+                  'vmimage = avocado.plugins.vmimage:VMimage',
                   ],
               'avocado.plugins.job.prepost': [
                   'jobscripts = avocado.plugins.jobscripts:JobScripts',


### PR DESCRIPTION
Vmimage plugin for management vm images. Has two functions one for downloading new vmimages to the avocado cache and one for listing all existing vmimages inside avocado cache.

---
Changes from v1 (#3264):
- Split into multiple commits
- In fedora secondary usage of local system arch
- For cash_dirs support for anything that can be looped over
- Fix bug with display of download image
- Better CLI
- Functional tests for the CLI

Changes from v2 (#3269):
- New directory structure for keeping information about images
- Changed `LOG_UI.info` to `LOG_UI.debug`
- Fix, problems with command-line options
- Fix, extra white chars in the docstring
- New unit test of downloading images
 
Changes from v3 (#3280):
- Metadata file for storing information about images
- Fixed typos
- Usage of CirrOS for testing
- Information message when parameters are missing
- Changed parameter `--list` to `list`

Changes from v4 (#3305):
- Usage of `with` statement for opening files.
- Opening files in write mode.
- Fixed typos.
- Split commits about build attribute and metadata.
- Updated output to be coherent with the other command outputs.