### PR TITLE
vmimage: fixes to tests

### DIFF
--- a/selftests/functional/test_plugin_vmimage.py
+++ b/selftests/functional/test_plugin_vmimage.py
@@ -54,6 +54,8 @@ class VMImagePlugin(unittest.TestCase):
         config_file.close()
         return base_dir, mapping, config_file
 
+    @unittest.skipUnless(os.environ.get('AVOCADO_SELFTESTS_NETWORK_ENABLED', False),
+                         "Network required to run these tests")
     def setUp(self):
         (self.base_dir, self.mapping, self.config_file) = self._get_temporary_config()
 

--- a/selftests/unit/test_plugin_vmimage.py
+++ b/selftests/unit/test_plugin_vmimage.py
@@ -121,11 +121,12 @@ class VMImagePlugin(unittest.TestCase):
 
     def test_list_downloaded_images(self):
         with unittest.mock.patch('avocado.core.data_dir.settings.settings', self.stg):
-            images = sorted(vmimage_plugin.list_downloaded_images(), key=lambda i: i['name'])
-            for index, image in enumerate(images):
-                for key in image:
-                    self.assertEqual(self.expected_images[index][key], image[key],
-                                     "Found image is different from the expected one")
+            with unittest.mock.patch('avocado.utils.vmimage.ImageProviderBase.get_version'):
+                images = sorted(vmimage_plugin.list_downloaded_images(), key=lambda i: i['name'])
+                for index, image in enumerate(images):
+                    for key in image:
+                        self.assertEqual(self.expected_images[index][key], image[key],
+                                         "Found image is different from the expected one")
 
     @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 2,
                      "Skipping test that take a long time to run, are "


### PR DESCRIPTION
Basically to deal with network access aspects of some tests, which shouldn't happen by default.