### PR TITLE
Fix issue in avocado:utils:cpu.get_cpu_vendor_name()

### DIFF
--- a/avocado/utils/cpu.py
+++ b/avocado/utils/cpu.py
@@ -99,10 +99,10 @@ def get_cpu_vendor_name():
     :rtype: `string`
     """
     vendors_map = {
-        'intel': ("GenuineIntel", ),
-        'amd': ("AMD", ),
-        'power7': ("POWER7", ),
-        'power8': ("POWER8", )
+        'intel': (b"GenuineIntel", ),
+        'amd': (b"AMD", ),
+        'power7': (b"POWER7", ),
+        'power8': (b"POWER8", )
     }
 
     cpu_info = _get_cpu_info()


### PR DESCRIPTION
as in python3 it complains about TypeError: cannot use a
string pattern on a bytes-like object

TODO: Remove LTS skip_notification from cirrus CI when this is merged (see: https://github.com/avocado-framework/avocado-vt/pull/2268 )