### PR TITLE
Fix issue in avocado:utils:cpu.get_cpu_vendor_name()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,9 +48,10 @@ script:
         # Run the "make check" per each commit in PR (TRAVIS_COMMIT_RANGE)
         ERR=""
         echo Branch is $TRAVIS_BRANCH
+        git fetch origin $TRAVIS_BRANCH
         if [ "$TRAVIS_PULL_REQUEST_SHA" ]; then
             # It's pull request, check only PR commits
-            COMMITS="$(git cherry origin/master | sed -n 's/+ \(.*\)/\1/p')"
+            COMMITS="$(git cherry FETCH_HEAD | sed -n 's/+ \(.*\)/\1/p')"
         else
             # push check, try to check everything
             COMMITS=$(git rev-list $TRAVIS_COMMIT_RANGE)

--- a/avocado/utils/cpu.py
+++ b/avocado/utils/cpu.py
@@ -99,10 +99,10 @@ def get_cpu_vendor_name():
     :rtype: `string`
     """
     vendors_map = {
-        'intel': ("GenuineIntel", ),
-        'amd': ("AMD", ),
-        'power7': ("POWER7", ),
-        'power8': ("POWER8", )
+        'intel': (b"GenuineIntel", ),
+        'amd': (b"AMD", ),
+        'power7': (b"POWER7", ),
+        'power8': (b"POWER8", )
     }
 
     cpu_info = _get_cpu_info()


### PR DESCRIPTION
as in python3 it complains about TypeError: cannot use a
string pattern on a bytes-like object

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>