### PR TITLE
Travis CI: use the branch set by Travis to find commits to test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,9 +48,10 @@ script:
         # Run the "make check" per each commit in PR (TRAVIS_COMMIT_RANGE)
         ERR=""
         echo Branch is $TRAVIS_BRANCH
+        git fetch origin $TRAVIS_BRANCH
         if [ "$TRAVIS_PULL_REQUEST_SHA" ]; then
             # It's pull request, check only PR commits
-            COMMITS="$(git cherry origin/master | sed -n 's/+ \(.*\)/\1/p')"
+            COMMITS="$(git cherry FETCH_HEAD | sed -n 's/+ \(.*\)/\1/p')"
         else
             # push check, try to check everything
             COMMITS=$(git rev-list $TRAVIS_COMMIT_RANGE)


### PR DESCRIPTION
Instead of using origin/master, and finding the wrong commits.

Signed-off-by: Cleber Rosa <crosa@redhat.com>