### PR TITLE
nrunner: encoded args and keyword args support

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -251,10 +251,27 @@ CMD_RUNNABLE_RUN_ARGS = (
     )
 
 
+def _arg_decode_base64(arg):
+    """
+    Decode arguments possibly endcoded as base64
+
+    :param arg: the possibly encoded argument
+    :type arg: str
+    :returns: the decoded argument
+    :rtype: str
+    """
+    prefix = 'base64:'
+    if arg.startswith(prefix):
+        content = arg[len(prefix):]
+        return base64.decodebytes(content.encode()).decode()
+    return arg
+
+
 def runnable_from_args(args):
+    decoded_args = [_arg_decode_base64(arg) for arg in args.get('arg', ())]
     return Runnable(args.get('kind'),
                     args.get('uri'),
-                    *args.get('arg', ()))
+                    *decoded_args)
 
 
 def subcommand_runnable_run(args, echo=print):

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -268,7 +268,7 @@ CMD_RUNNABLE_RUN_ARGS = (
      {'type': str, 'default': None, 'help': 'URI of runnable'}),
 
     (("-a", "--arg"),
-     {'action': "append", 'default': [], 'help': 'Positional arguments to runnable'})
+     {'action': "append", 'default': [], 'help': 'Simple arguments to runnable'})
     )
 
 

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -115,6 +115,12 @@ class BaseRunner:
 class NoOpRunner(BaseRunner):
     """
     Sample runner that performs no action before reporting FINISHED status
+
+    Runnable attributes usage:
+
+     * uri: not used
+
+     * args: not used
     """
     def run(self):
         yield {'status': 'finished'}
@@ -123,6 +129,13 @@ class NoOpRunner(BaseRunner):
 class ExecRunner(BaseRunner):
     """
     Runner for standalone executables with or without arguments
+
+    Runnable attributes usage:
+
+     * uri: path to a binary to be executed as another process
+
+     * args: arguments to be given on the command line to the
+       binary given by path
     """
     def run(self):
         process = subprocess.Popen(
@@ -157,6 +170,8 @@ class ExecTestRunner(ExecRunner):
     This is similar in concept to the Avocado "SIMPLE" test type, in which an
     executable returning 0 means that a test passed, and anything else means
     that a test failed.
+
+    Runnable attributes usage is identical to :class:`ExecRunner`
     """
     def run(self):
         for status in super(ExecTestRunner, self).run():
@@ -175,6 +190,12 @@ class PythonUnittestRunner(BaseRunner):
     The runnable uri is used as the test name that the native unittest
     TestLoader will use to find the test.  A native unittest test
     runner (TextTestRunner) will be used to execute the test.
+
+    Runnable attributes usage:
+
+     * uri: path to a binary to be executed as another process
+
+     * args: not used
     """
     @staticmethod
     def _run_unittest(uri, queue):

--- a/avocado/core/nrunner_avocado_instrumented.py
+++ b/avocado/core/nrunner_avocado_instrumented.py
@@ -12,6 +12,18 @@ from .tree import TreeNode
 
 
 class AvocadoInstrumentedTestRunner(nrunner.BaseRunner):
+    """
+    Runner for Avocado INSTRUMENTED tests
+
+    Runnable attributes usage:
+
+     * uri: path to a test file, combined with an Avocado.Test
+       inherited class name and method.  The test file path and
+       class and method names should be separated by a ":".  One
+       example of a valid uri is "mytest.py:Class.test_method".
+
+     * args: not used
+    """
 
     @staticmethod
     def _run_avocado(runnable, queue):

--- a/examples/recipes/runnables/exec_echo_no_newline.json
+++ b/examples/recipes/runnables/exec_echo_no_newline.json
@@ -1,0 +1,1 @@
+{"kind": "exec", "uri": "/bin/echo", "args": ["-n", "avocado"]}

--- a/selftests/functional/test_nrunner.py
+++ b/selftests/functional/test_nrunner.py
@@ -1,5 +1,6 @@
-import unittest
 import os
+import sys
+import unittest
 
 from .. import AVOCADO, BASEDIR
 
@@ -13,6 +14,48 @@ class RunnableRun(unittest.TestCase):
         res = process.run("%s runnable-run -k noop" % AVOCADO,
                           ignore_status=True)
         self.assertEqual(res.stdout, b"{'status': 'finished'}\n")
+        self.assertEqual(res.exit_status, exit_codes.AVOCADO_ALL_OK)
+
+    def test_exec(self):
+        # 'base64:LWM=' becomes '-c' and makes Python execute the
+        # commands on the subsequent argument
+        cmd = ("%s runnable-run -k exec -u %s -a 'base64:LWM=' -a "
+               "'import sys; sys.exit(99)'" % (AVOCADO, sys.executable))
+        res = process.run(cmd, ignore_status=True)
+        self.assertIn(b"'status': 'finished'", res.stdout)
+        self.assertIn(b"'returncode': 99", res.stdout)
+        self.assertEqual(res.exit_status, exit_codes.AVOCADO_ALL_OK)
+
+    @unittest.skipUnless(os.path.exists('/bin/echo'),
+                         ('Executable "/bin/echo" used in test is not '
+                          'available in the system'))
+    def test_exec_echo(self):
+        # 'base64:LW4=' becomes '-n' and prevents echo from printing a newline
+        cmd = ("%s runnable-run -k exec -u /bin/echo -a 'base64:LW4=' -a "
+               "_Avocado_Runner_" % AVOCADO)
+        res = process.run(cmd, ignore_status=True)
+        self.assertIn(b"'status': 'finished'", res.stdout)
+        self.assertIn(b"'stdout': b'_Avocado_Runner_'", res.stdout)
+        self.assertIn(b"'returncode': 0", res.stdout)
+        self.assertEqual(res.exit_status, exit_codes.AVOCADO_ALL_OK)
+
+    @unittest.skipUnless(os.path.exists('/bin/echo'),
+                         ('Executable "/bin/echo" used in recipe is not '
+                          'available in the system'))
+    def test_recipe(self):
+        recipe = os.path.join(BASEDIR, "examples", "recipes", "runnables",
+                              "exec_echo_no_newline.json")
+        cmd = "%s runnable-run-recipe %s" % (AVOCADO, recipe)
+        res = process.run(cmd, ignore_status=True)
+        lines = res.stdout_text.splitlines()
+        if len(lines) == 1:
+            first_status = final_status = lines[0]
+        else:
+            first_status = lines[0]
+            final_status = lines[-1]
+            self.assertIn("'status': 'running'", first_status)
+        self.assertIn("'status': 'finished'", final_status)
+        self.assertIn("'stdout': b'avocado'", final_status)
         self.assertEqual(res.exit_status, exit_codes.AVOCADO_ALL_OK)
 
 

--- a/selftests/functional/test_nrunner.py
+++ b/selftests/functional/test_nrunner.py
@@ -58,6 +58,17 @@ class RunnableRun(unittest.TestCase):
         self.assertIn("'stdout': b'avocado'", final_status)
         self.assertEqual(res.exit_status, exit_codes.AVOCADO_ALL_OK)
 
+    def test_noop_valid_kwargs(self):
+        res = process.run("%s runnable-run -k noop foo=bar" % AVOCADO,
+                          ignore_status=True)
+        self.assertEqual(res.exit_status, exit_codes.AVOCADO_ALL_OK)
+
+    def test_noop_invalid_kwargs(self):
+        res = process.run("%s runnable-run -k noop foo" % AVOCADO,
+                          ignore_status=True)
+        self.assertIn(b'Invalid keyword parameter: "foo"', res.stderr)
+        self.assertEqual(res.exit_status, exit_codes.AVOCADO_FAIL)
+
 
 class TaskRun(unittest.TestCase):
 

--- a/selftests/unit/test_nrunner.py
+++ b/selftests/unit/test_nrunner.py
@@ -68,6 +68,35 @@ class Runnable(unittest.TestCase):
         self.assertEqual(runnable.get_json(), expected)
 
 
+class RunnableFromCommandLineArgs(unittest.TestCase):
+
+    def test_noop(self):
+        parsed_args = {'kind': 'noop', 'uri': None}
+        runnable = nrunner.runnable_from_args(parsed_args)
+        self.assertEqual(runnable.kind, 'noop')
+        self.assertIsNone(runnable.uri)
+
+    def test_exec_args(self):
+        parsed_args = {'kind': 'exec', 'uri': '/path/to/executable',
+                       'arg': ['-a', '-b', '-c']}
+        runnable = nrunner.runnable_from_args(parsed_args)
+        self.assertEqual(runnable.kind, 'exec')
+        self.assertEqual(runnable.uri, '/path/to/executable')
+        self.assertEqual(runnable.args, ('-a', '-b', '-c'))
+        self.assertEqual(runnable.kwargs, {})
+
+    def test_exec_args_kwargs(self):
+        parsed_args = {'kind': 'exec', 'uri': '/path/to/executable',
+                       'arg': ['-a', '-b', '-c'],
+                       'kwargs': [('DEBUG', '1'), ('LC_ALL', 'C')]}
+        runnable = nrunner.runnable_from_args(parsed_args)
+        self.assertEqual(runnable.kind, 'exec')
+        self.assertEqual(runnable.uri, '/path/to/executable')
+        self.assertEqual(runnable.args, ('-a', '-b', '-c'))
+        self.assertEqual(runnable.kwargs.get('DEBUG'), '1')
+        self.assertEqual(runnable.kwargs.get('LC_ALL'), 'C')
+
+
 class RunnableToRecipe(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
This improves the nrunner code with support for encoded (in base64) simple arguments, and proper support for keyword arguments.