### PR TITLE
Job: don't produce output that goes to the UI

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -106,6 +106,7 @@ class Job:
         self.__keep_tmpdir = True
         self.status = "RUNNING"
         self.result = None
+        self.interrupted_reason = None
         self.sysinfo = None
         self.timeout = self.config.get('job_timeout', 0)
         #: The time at which the job has started or `-1` if it has not been

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -503,7 +503,7 @@ class TestRunner:
 
             if self.job.config.get('failfast', 'off') == 'on':
                 summary.add("INTERRUPTED")
-                self.job.log.debug("Interrupting job (failfast).")
+                self.job.interrupted_reason = "Interrupting job (failfast)."
                 return False
 
         if ctrl_c_count > 0:

--- a/avocado/plugins/human.py
+++ b/avocado/plugins/human.py
@@ -101,6 +101,10 @@ class Human(ResultEvents):
     def post_tests(self, job):
         if not self.owns_stdout:
             return
+
+        if job.interrupted_reason is not None:
+            LOG_UI.info(job.interrupted_reason)
+
         if job.status == 'PASS':
             LOG_UI.info("RESULTS    : PASS %d | ERROR %d | FAIL %d | SKIP %d | "
                         "WARN %d | INTERRUPT %s | CANCEL %s", job.result.passed,

--- a/avocado/plugins/tap.py
+++ b/avocado/plugins/tap.py
@@ -137,6 +137,11 @@ class TAPResult(ResultEvents):
         pass
 
     def post_tests(self, job):
+        if job.interrupted_reason is not None:
+            for pending_test in range(job.result.tests_run + 1, job.result.tests_total + 1):
+                self.__write("ok %s # SKIP %s", pending_test, job.interrupted_reason)
+            self.__flush()
+
         for open_file in self.__open_files:
             open_file.close()
 


### PR DESCRIPTION
This is the responsibility of the human UI plugin, which should check
if other plugin has taken ownership of the STDOUT.

This keeps the job interruption reason in the job itself, because,
quite simply, it's a job wide event.

Reference: https://github.com/avocado-framework/avocado/issues/3317
Signed-off-by: Cleber Rosa <crosa@redhat.com>