### PR TITLE
nrunner: improve support for keyword arguments and introduce JSON

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -29,12 +29,13 @@ class Runnable:
         self.kind = kind
         self.uri = uri
         self.args = args
+        self.tags = kwargs.pop('tags', None)
         self.kwargs = kwargs
 
     def __repr__(self):
-        fmt = '<Runnable kind="{}" uri="{}" args="{}" kwargs="{}"'
+        fmt = '<Runnable kind="{}" uri="{}" args="{}" kwargs="{}" tags="{}"'
         return fmt.format(self.kind, self.uri,
-                          self.args, self.kwargs)
+                          self.args, self.kwargs, self.tags)
 
     def get_command_args(self):
         """
@@ -54,6 +55,9 @@ class Runnable:
         for arg in self.args:
             args.append('-a')
             args.append(arg)
+
+        if self.tags is not None:
+            args.append('tags=json:%s' % json.dumps(self.tags))
 
         for key, val in self.kwargs.items():
             if not isinstance(val, str) or isinstance(val, int):

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -136,13 +136,18 @@ class ExecRunner(BaseRunner):
 
      * args: arguments to be given on the command line to the
        binary given by path
+
+     * kwargs: key=val to be set as environment variables to the
+       process
     """
     def run(self):
+        env = self.runnable.kwargs or None
         process = subprocess.Popen(
             [self.runnable.uri] + list(self.runnable.args),
             stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE)
+            stderr=subprocess.PIPE,
+            env=env)
 
         last_status = None
         while process.poll() is None:

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -55,6 +55,11 @@ class Runnable:
             args.append('-a')
             args.append(arg)
 
+        for key, val in self.kwargs.items():
+            if not isinstance(val, str) or isinstance(val, int):
+                val = "json:%s" % json.dumps(val)
+            args.append('%s=%s' % (key, val))
+
         return args
 
     def get_dict(self):
@@ -306,10 +311,25 @@ def _arg_decode_base64(arg):
     return arg
 
 
+def _kwarg_decode_json(value):
+    """
+    Decode arguments possibly endcoded as base64
+
+    :param value: the possibly encoded argument
+    :type value: str
+    :returns: the decoded keyword argument as Python object
+    """
+    prefix = 'json:'
+    if value.startswith(prefix):
+        content = value[len(prefix):]
+        return json.loads(content)
+    return value
+
+
 def _key_val_args_to_kwargs(kwargs):
     result = {}
     for key, val in kwargs:
-        result[key] = val
+        result[key] = _kwarg_decode_json(val)
     return result
 
 

--- a/avocado/core/nrunner_avocado_instrumented.py
+++ b/avocado/core/nrunner_avocado_instrumented.py
@@ -45,7 +45,7 @@ class AvocadoInstrumentedTestRunner(nrunner.BaseRunner):
                          'job': job.Job(),
                          'modulePath': module_path,
                          'params': (TreeNode(), []),
-                         'tags': runnable.kwargs.get('tags')}]
+                         'tags': runnable.tags}]
 
         instance = loader.loader.load_test(test_factory)
         instance.run_avocado()

--- a/selftests/functional/test_nrunner.py
+++ b/selftests/functional/test_nrunner.py
@@ -69,6 +69,16 @@ class RunnableRun(unittest.TestCase):
         self.assertIn(b'Invalid keyword parameter: "foo"', res.stderr)
         self.assertEqual(res.exit_status, exit_codes.AVOCADO_FAIL)
 
+    @unittest.skipUnless(os.path.exists('/bin/env'),
+                         ('Executable "/bin/env" used in test is not '
+                          'available in the system'))
+    def test_exec_kwargs(self):
+        res = process.run("%s runnable-run -k exec -u /bin/env X=Y" % AVOCADO,
+                          ignore_status=True)
+        self.assertIn(b"'status': 'finished'", res.stdout)
+        self.assertIn(b"'stdout': b'X=Y\\n'", res.stdout)
+        self.assertEqual(res.exit_status, exit_codes.AVOCADO_ALL_OK)
+
 
 class TaskRun(unittest.TestCase):
 

--- a/selftests/unit/test_nrunner.py
+++ b/selftests/unit/test_nrunner.py
@@ -96,6 +96,25 @@ class RunnableFromCommandLineArgs(unittest.TestCase):
         self.assertEqual(runnable.kwargs.get('DEBUG'), '1')
         self.assertEqual(runnable.kwargs.get('LC_ALL'), 'C')
 
+    def test_kwargs_json_empty_dict(self):
+        parsed_args = {'kind': 'noop', 'uri': None,
+                       'kwargs': [('tags', 'json:{}')]}
+        runnable = nrunner.runnable_from_args(parsed_args)
+        self.assertEqual(runnable.kind, 'noop')
+        self.assertIsNone(runnable.uri)
+        self.assertEqual(runnable.kwargs.get('tags'), {})
+
+    def test_kwargs_json_dict(self):
+        parsed_args = {
+            'kind': 'noop', 'uri': None,
+            'kwargs': [('tags', 'json:{"arch": ["x86_64", "ppc64"]}')]
+        }
+        runnable = nrunner.runnable_from_args(parsed_args)
+        self.assertEqual(runnable.kind, 'noop')
+        self.assertIsNone(runnable.uri)
+        self.assertEqual(runnable.kwargs.get('tags'),
+                         {"arch": ["x86_64", "ppc64"]})
+
 
 class RunnableToRecipe(unittest.TestCase):
 


### PR DESCRIPTION
The `kwargs` attribute on the nrunner Runnables has not been properly used so far.  This introduces serialization and de-serialization support for kwargs, and with that, makes tags a "first class" runnable attribute.