### PR TITLE
nrunner: resolver prep work

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -453,6 +453,25 @@ class Task:
                 status_service.post(status)
             yield status
 
+    def get_command_args(self):
+        """
+        Returns the command arguments that adhere to the runner interface
+
+        This is useful for building 'task-run' commands that can be
+        executed on a command line interface.
+
+        :returns: the arguments that can be used on an avocado-runner command
+        :rtype: list
+        """
+        args = ['-i', self.identifier]
+        args += self.runnable.get_command_args()
+
+        for status_service in self.status_services:
+            args.append('-s')
+            args.append(status_service.uri)
+
+        return args
+
     def __repr__(self):
         fmt = '<Task identifier="{}" runnable="{}" status_services="{}"'
         return fmt.format(self.identifier, self.runnable, self.status_services)

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -57,7 +57,13 @@ class Runnable:
             args.append(arg)
 
         if self.tags is not None:
-            args.append('tags=json:%s' % json.dumps(self.tags))
+            tags = {}
+            # sets are not serializable in json
+            for key, val in self.tags.items():
+                if isinstance(val, set):
+                    val = list(val)
+                tags[key] = val
+            args.append('tags=json:%s' % json.dumps(tags))
 
         for key, val in self.kwargs.items():
             if not isinstance(val, str) or isinstance(val, int):

--- a/avocado/plugins/nrun.py
+++ b/avocado/plugins/nrun.py
@@ -154,6 +154,16 @@ class NRun(CLICmd):
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE)
 
+    def check_tasks_requirements(self, tasks):
+        result = []
+        for task in tasks:
+            runner = self.pick_runner(task)
+            if runner:
+                result.append(task)
+            else:
+                LOG_UI.warning('Task will not be run due to missing requirements: %s', task)
+        return result
+
     def run(self, config):
         try:
             loader.loader.load_plugins(config)
@@ -163,7 +173,8 @@ class NRun(CLICmd):
             sys.exit(exit_codes.AVOCADO_FAIL)
 
         suite = self.create_test_suite(config.get('references'))
-        self.pending_tasks = self.suite_to_tasks(suite, [config.get('status_server')])  # pylint: disable=W0201
+        tasks = self.suite_to_tasks(suite, [config.get('status_server')])  # pylint: disable=W0201
+        self.pending_tasks = self.check_tasks_requirements(tasks)  # pylint: disable=W0201
 
         if not self.pending_tasks:
             LOG_UI.error('No test to be executed, exiting...')

--- a/avocado/plugins/nrun.py
+++ b/avocado/plugins/nrun.py
@@ -140,22 +140,11 @@ class NRun(CLICmd):
 
     @asyncio.coroutine
     def spawn_task(self, task):
-        status_service_args = []
-        for status_service in task.status_services:
-            status_service_args.append('-s')
-            status_service_args.append(status_service.uri)
-
-        args = ['task-run',
-                '-i', task.identifier]
-
-        args += list(task.runnable.get_command_args())
-        args += list(status_service_args)
-
         runner = self.pick_runner(task)
         if runner is None:
             runner = [sys.executable, '-m', 'avocado.core.nrunner']
 
-        args = runner[1:] + args
+        args = runner[1:] + ['task-run'] + task.get_command_args()
         runner = runner[0]
 
         #pylint: disable=E1133

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -59,7 +59,7 @@
 Summary: Framework with tools and libraries for Automated Testing
 Name: python-%{srcname}
 Version: 72.0
-Release: 0%{?gitrel}%{?dist}
+Release: 1%{?gitrel}%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.github.io/
@@ -320,6 +320,10 @@ LANG=en_US.UTF-8 AVOCADO_CHECK_LEVEL=0 UNITTEST_AVOCADO_CMD=$HOME/.local/bin/avo
 %doc README.rst LICENSE
 %{_bindir}/avocado
 %{_bindir}/avocado-runner
+%{_bindir}/avocado-runner-noop
+%{_bindir}/avocado-runner-exec
+%{_bindir}/avocado-runner-exec-test
+%{_bindir}/avocado-runner-python-unittest
 %{_bindir}/avocado-runner-avocado-instrumented
 %{python3_sitelib}/avocado*
 %exclude %{python3_sitelib}/avocado_result_html*
@@ -579,6 +583,9 @@ Again Shell code (and possibly other similar shells).
 %{_libexecdir}/avocado*
 
 %changelog
+* Fri Sep 27 2019 Cleber Rosa <cleber@redhat.com> - 72.0-1
+- Added new avocado-runner-* runner scripts
+
 * Tue Sep 17 2019 Cleber Rosa <cleber@redhat.com> - 72.0-0
 - New release
 

--- a/selftests/unit/test_tags.py
+++ b/selftests/unit/test_tags.py
@@ -5,6 +5,8 @@ from avocado.core import loader
 from avocado.core import tags
 from avocado.utils import script
 
+from avocado.core.nrunner import Runnable
+
 
 #: What is commonly known as "0664" or "u=rw,g=rw,o=r"
 DEFAULT_NON_EXEC_MODE = (stat.S_IRUSR | stat.S_IWUSR |
@@ -306,3 +308,10 @@ class ParseFilterByTags(unittest.TestCase):
                                                     '-FOO,-BAR,-BAZ']),
                          [(set(['foo', 'bar', 'baz']), set([])),
                           (set([]), set(['FOO', 'BAR', 'BAZ']))])
+
+
+class FilterRunnable(unittest.TestCase):
+
+    def test_no_tags(self):
+        runnable = Runnable('noop', None)
+        self.assertFalse(tags.filter_test_tags_runnable(runnable, []))

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,10 @@ if __name__ == '__main__':
           entry_points={
               'console_scripts': [
                   'avocado-runner = avocado.core.nrunner:main',
+                  'avocado-runner-noop = avocado.core.nrunner:main',
+                  'avocado-runner-exec = avocado.core.nrunner:main',
+                  'avocado-runner-exec-test = avocado.core.nrunner:main',
+                  'avocado-runner-python-unittest = avocado.core.nrunner:main',
                   'avocado-runner-avocado-instrumented = avocado.core.nrunner_avocado_instrumented:main',
                   ],
               'avocado.plugins.cli': [


### PR DESCRIPTION
The nrunner is soon going to be hooked up to the "resolver"[1][2] plugins, and disconnected from the current "test loader" code.

These changes are the adaptations I found necessary to then introduce the resolver.

[1] - https://github.com/clebergnu/avocado/commits/wip/resolver
[2] - https://github.com/clebergnu/avocado/commit/d9835d51682af13a332130cd4c9a78b4788190b7