### PR TITLE
Limit functional.test_utils.FileLockTest.test_filelock execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ check: clean develop
 	selftests/check_tmp_dirs
 
 check-full: clean develop
-	PYTHON=$(PYTHON) AVOCADO_CHECK_LEVEL=2 selftests/checkall
+	PYTHON=$(PYTHON) AVOCADO_CHECK_LEVEL=3 selftests/checkall
 	selftests/check_tmp_dirs
 
 develop:

--- a/selftests/functional/test_utils.py
+++ b/selftests/functional/test_utils.py
@@ -198,7 +198,7 @@ class FileLockTest(unittest.TestCase):
         prefix = temp_dir_prefix(__name__, self, 'setUp')
         self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
 
-    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 2,
+    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 3,
                      "Skipping test that take a long time to run, are "
                      "resource intensive or time sensitive")
     def test_filelock(self):


### PR DESCRIPTION
To the `make check-full` target, not running on the coverage
checks, which include their execution on Travis-CI.

Reference: https://github.com/avocado-framework/avocado/issues/3321
Signed-off-by: Cleber Rosa <crosa@redhat.com>