### PR TITLE
Introduce avocado.core.resolver as an alternative to loader

### DIFF
--- a/avocado/core/plugin_interfaces.py
+++ b/avocado/core/plugin_interfaces.py
@@ -264,3 +264,24 @@ class Varianter(Plugin):
         :param kwargs: Other free-form arguments
         :rtype: str
         """
+
+
+class Resolver(Plugin):
+    """
+    Base plugin interface for resolving test interfaces into test factories
+    """
+
+    @abc.abstractmethod
+    def resolve(self, reference):
+        """
+        Resolves the given reference into a :class:`resolver.ReferenceResolution`
+
+        :param reference: a specification that can eventually be resolved
+                          into a test (in the form of a
+                          :class:`avocado.core.nrunner.Runnable`)
+        :type reference: str
+        :returns: the result of the resolution process, containing the
+                  success, failure or error, along with zero or more
+                  :class:`avocado.core.nrunner.Runnable`s
+        :rtype: :class:`avocado.core.resolver.ReferenceResolution`
+        """

--- a/avocado/core/resolver.py
+++ b/avocado/core/resolver.py
@@ -1,0 +1,174 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2019
+# Authors: Cleber Rosa <crosa@redhat.com>
+
+"""
+Test resolver module.
+"""
+
+import os
+from enum import Enum
+
+from .enabled_extension_manager import EnabledExtensionManager
+
+
+class ReferenceResolutionResult(Enum):
+    #: Given test reference was properly resolved
+    SUCCESS = object()
+    #: Given test reference was not properly resolved
+    NOTFOUND = object()
+    #: Internal error in the resolution process
+    ERROR = object()
+
+
+class ReferenceResolutionAction(Enum):
+    #: Stop trying to resolve the reference
+    RETURN = object()
+    #: Continue to resolve the given reference
+    CONTINUE = object()
+
+
+class ReferenceResolution:
+
+    """
+    Represents one complete reference resolution
+
+    Note that the reference itself may result in many resolutions, or
+    none.
+    """
+
+    def __init__(self, reference, result, resolutions=None, info=None, origin=None):
+        """
+        :param reference: a specification that can eventually be resolved
+                          into a test (in the form of a
+                          :class:`avocado.core.nrunner.Runnable`)
+        :type reference: str
+        :param result: if the complete resolution was a success,
+                       failure or error
+        :type result: :class:`ReferenceResolutionResult`
+        :param resolutions: the runnable definitions resulting from the
+        resolution
+        :type resolutions: list
+        :param info: free form information the resolver may add
+        :type info: str
+        :param origin: the name of the resolver that performed the resolution
+        :type origin: str
+        """
+        self.reference = reference
+        self.result = result
+        if resolutions is None:
+            resolutions = []
+        self.resolutions = resolutions
+        self.info = info
+        self.origin = origin
+
+
+class Resolver(EnabledExtensionManager):
+
+    """
+    Main test reference resolution utility.
+
+    This performs the actual resolution according to the active
+    resolver plugins and a resolution policy.
+    """
+
+    DEFAULT_POLICY = {
+        ReferenceResolutionResult.SUCCESS: ReferenceResolutionAction.RETURN,
+        ReferenceResolutionResult.NOTFOUND: ReferenceResolutionAction.CONTINUE,
+        ReferenceResolutionResult.ERROR: ReferenceResolutionAction.CONTINUE
+    }
+
+    def __init__(self):
+        super(Resolver, self).__init__('avocado.plugins.resolver')
+
+    def resolve(self, reference):
+        resolution = []
+        for ext in self.extensions:
+            try:
+                result = ext.obj.resolve(reference)
+                if not result.origin:
+                    result.origin = ext.name
+            except Exception as exc:
+                result = ReferenceResolution(reference,
+                                             ReferenceResolutionResult.ERROR,
+                                             info=exc,
+                                             origin=ext.name)
+            resolution.append(result)
+            action = self.DEFAULT_POLICY.get(result.result,
+                                             ReferenceResolutionAction.CONTINUE)
+            if action == ReferenceResolutionAction.RETURN:
+                break
+        return resolution
+
+
+def check_file(path, reference, suffix='.py',
+               type_check=os.path.isfile, type_name='regular file',
+               access_check=os.R_OK, access_name='readable'):
+    if suffix is not None:
+        if not path.endswith(suffix):
+            return ReferenceResolution(
+                reference,
+                ReferenceResolutionResult.NOTFOUND,
+                info='File path "%s" does not end with "%s"' % (path, suffix))
+
+    if not type_check(path):
+        return ReferenceResolution(
+            reference,
+            ReferenceResolutionResult.NOTFOUND,
+            info='File "%s" does not exist or is not a %s' % (path, type_name))
+
+    if not os.access(path, access_check):
+        return ReferenceResolution(
+            reference,
+            ReferenceResolutionResult.NOTFOUND,
+            info='File "%s" does not exist or is not %s' % (path, access_name))
+
+    return True
+
+
+def _extend_directory(path):
+    if not os.path.isdir(path):
+        return [path]
+    paths = []
+    # no error handling so far
+    for dirpath, dirs, filenames in os.walk(path):
+        dirs.sort()
+        for file_name in sorted(filenames):
+            # does it make sense to ignore hidden files here?
+            if file_name.startswith('.'):
+                continue
+            pth = os.path.join(dirpath, file_name)
+            paths.append(pth)
+    if not paths:
+        paths = [path]
+    return paths
+
+
+def resolve(references):
+    resolutions = []
+
+    if references:
+        # should be initialized with args, to define the behavior
+        # of this instance as a whole
+        resolver = Resolver()
+        extended_references = []
+        for reference in references:
+            # a reference extender is not (yet?) an extensible feature
+            # here it walks directories if one is given, and extends
+            # the original reference into final file paths
+            extended_references.extend(_extend_directory(reference))
+
+        for reference in extended_references:
+            resolutions.extend(resolver.resolve(reference))
+
+    return resolutions

--- a/avocado/etc/avocado/avocado.conf
+++ b/avocado/etc/avocado/avocado.conf
@@ -96,6 +96,9 @@ skip_broken_plugin_notification = []
 # The keyword "@DEFAULT" will be replaced with all available unused loaders.
 loaders = ['file', '@DEFAULT']
 
+[plugins.resolver]
+order = ['avocado-instrumented', 'python-unittest', 'glib', 'robot', 'exec-test']
+
 [simpletests.status]
 # Python regular expression that will make the test
 # status WARN when matched. Defaults to disabled.

--- a/avocado/plugins/nlist.py
+++ b/avocado/plugins/nlist.py
@@ -1,0 +1,153 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2019
+# Author: Cleber Rosa <crosa@redhat.com>
+
+from avocado.core.plugin_interfaces import CLICmd
+from avocado.core import resolver
+from avocado.core import output
+from avocado.core import parser_common_args
+from avocado.core.output import LOG_UI
+from avocado.core.tags import filter_test_tags_runnable
+from avocado.utils import astring
+
+
+class List(CLICmd):
+
+    """
+    Implements the avocado 'nlist' subcommand
+    """
+
+    name = 'nlist'
+    description = '*EXPERIMENTAL* list tests (runnables)'
+
+    def configure(self, parser):
+        parser = super(List, self).configure(parser)
+        parser.add_argument('references', type=str, default=[], nargs='*',
+                            help="Test references")
+        parser.add_argument('-V', '--verbose',
+                            action='store_true', default=False,
+                            help=("Show extra information on resolution, besides "
+                                  "sucessful resolutions"))
+        parser_common_args.add_tag_filter_args(parser)
+
+    def run(self, config):
+        references = config.get('references', [])
+        resolutions = resolver.resolve(references)
+        matrix, stats, tag_stats, resolution_matrix = self._get_resolution_matrix(config,
+                                                                                  resolutions)
+        self._display(matrix, stats, tag_stats, resolution_matrix, config.get('verbose'))
+
+    @staticmethod
+    def _get_resolution_matrix(config, resolutions):
+        test_matrix = []
+        resolution_matrix = []
+        decorator_mapping = {
+            resolver.ReferenceResolutionResult.SUCCESS: output.TERM_SUPPORT.healthy_str,
+            resolver.ReferenceResolutionResult.NOTFOUND: output.TERM_SUPPORT.fail_header_str,
+            resolver.ReferenceResolutionResult.ERROR: output.TERM_SUPPORT.fail_header_str
+            }
+
+        # keyed by runnable kind
+        stats = {}
+        # by tag
+        tag_stats = {}
+
+        for result in resolutions:
+            decorator = decorator_mapping.get(result.result,
+                                              output.TERM_SUPPORT.warn_header_str)
+            if result.resolutions:
+                for runnable in result.resolutions:
+
+                    filter_by_tags = config.get('filter_by_tags')
+                    if filter_by_tags:
+                        if not filter_test_tags_runnable(
+                                runnable,
+                                filter_by_tags,
+                                config.get('filter_by_tags_include_empty'),
+                                config.get('filter_by_tags_include_empty_key')):
+                            continue
+
+                    type_label = runnable.kind
+                    if type_label.lower() not in stats:
+                        stats[type_label.lower()] = 0
+                    stats[type_label.lower()] += 1
+                    type_label = decorator(type_label)
+
+                    if config.get('verbose'):
+                        if runnable.tags is not None:
+                            tags_repr = []
+                            for tag, vals in runnable.tags.items():
+                                if tag not in tag_stats:
+                                    tag_stats[tag] = 1
+                                else:
+                                    tag_stats[tag] += 1
+                                if vals:
+                                    tags_repr.append("%s(%s)" % (tag, ",".join(vals)))
+                                else:
+                                    tags_repr.append(tag)
+                            tags_repr = ",".join(tags_repr)
+                            test_matrix.append((type_label, runnable.uri, tags_repr))
+                    else:
+                        test_matrix.append((type_label, runnable.uri))
+            else:  # assuming that empty resolutions mean a NOTFOUND, ERROR, etc
+                if result.info is None:
+                    result_info = ''
+                else:
+                    result_info = result.info
+                if result.result == resolver.ReferenceResolutionResult.SUCCESS:
+                    if not result_info:
+                        result_info = "%i resolutions" % len(result.resolutions)
+                resolution_matrix.append((decorator(result.origin),
+                                          result.reference,
+                                          result_info))
+
+        return test_matrix, stats, tag_stats, resolution_matrix
+
+    def _display(self, test_matrix, stats, tag_stats, resolution_matrix, verbose=False):
+        header = None
+        if verbose:
+            header = (output.TERM_SUPPORT.header_str('Type'),
+                      output.TERM_SUPPORT.header_str('Test'),
+                      output.TERM_SUPPORT.header_str('Tags'))
+
+        if test_matrix:
+            for line in astring.iter_tabular_output(test_matrix,
+                                                    header=header,
+                                                    strip=True):
+                LOG_UI.debug(line)
+
+        if verbose:
+
+            if stats:
+                LOG_UI.info("")
+                LOG_UI.info("TEST TYPES SUMMARY")
+                LOG_UI.info("==================")
+                for key in sorted(stats):
+                    LOG_UI.info("%s: %s", key, stats[key])
+
+            if tag_stats:
+                LOG_UI.info("")
+                LOG_UI.info("TEST TAGS SUMMARY")
+                LOG_UI.info("=================")
+                for key in sorted(tag_stats):
+                    LOG_UI.info("%s: %s", key, tag_stats[key])
+
+            if resolution_matrix:
+                resolution_header = (output.TERM_SUPPORT.header_str('Resolver'),
+                                     output.TERM_SUPPORT.header_str('Reference'),
+                                     output.TERM_SUPPORT.header_str('Info'))
+                LOG_UI.info("")
+                for line in astring.iter_tabular_output(resolution_matrix,
+                                                        header=resolution_header,
+                                                        strip=True):
+                    LOG_UI.info(line)

--- a/avocado/plugins/nrun.py
+++ b/avocado/plugins/nrun.py
@@ -5,13 +5,11 @@ import random
 import sys
 
 from avocado.core import nrunner
-from avocado.core import loader
+from avocado.core import resolver
 from avocado.core import exit_codes
-from avocado.core import exceptions
 from avocado.core import test
 from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLICmd
-from avocado.utils import stacktrace
 from avocado.utils import path as utils_path
 
 
@@ -34,59 +32,20 @@ class NRun(CLICmd):
                             help="Host and port for status server, default is: %(default)s")
 
     @staticmethod
-    def create_test_suite(references):
-        """
-        Creates the test suite for this Job
-
-        This is a public Job API as part of the documented Job phases
-
-        NOTE: This is similar to avocado.core.Job.create_test_suite
-        """
-        try:
-            suite = loader.loader.discover(references)
-        except loader.LoaderError as details:
-            stacktrace.log_exc_info(sys.exc_info(), LOG_UI.getChild("debug"))
-            raise exceptions.OptionValidationError(details)
-
-        if not suite:
-            if references:
-                references = " ".join(references)
-                e_msg = ("No tests found for given test references, try "
-                         "'avocado list -V %s' for details" % references)
-            else:
-                e_msg = ("No test references provided nor any other arguments "
-                         "resolved into tests. Please double check the "
-                         "executed command.")
-            raise exceptions.OptionValidationError(e_msg)
-
-        return suite
-
-    @staticmethod
-    def suite_to_tasks(suite, status_uris):
+    def resolutions_to_tasks(resolutions, status_uris):
         tasks = []
         index = 0
-        no_digits = len(str(len(suite)))
-        for factory in suite:
-            klass, args = factory
-            name = args.get("name")
-            identifier = str(test.TestID(index + 1, name, None, no_digits))
-            if klass == test.PythonUnittest:
-                test_dir = args.get("test_dir")
-                module_prefix = test_dir.split(os.getcwd())[1][1:]
-                module_prefix = module_prefix.replace("/", ".")
-                unittest_path = "%s.%s" % (module_prefix, args.get("name"))
-                runnable = nrunner.Runnable('python-unittest', unittest_path)
-            elif klass == test.SimpleTest:
-                runnable = nrunner.Runnable('exec-test', args.get('executable'))
-            elif isinstance(klass, str):
-                runnable = nrunner.Runnable('avocado-instrumented', name)
-            else:
-                # FIXME: This should instead raise an error
-                print('WARNING: unknown test type "%s", using "noop"' % factory[0])
-                runnable = nrunner.Runnable('noop')
-
-            tasks.append(nrunner.Task(identifier, runnable, status_uris))
-            index += 1
+        resolutions = [res for res in resolutions if
+                       res.result == resolver.ReferenceResolutionResult.SUCCESS]
+        no_digits = len(str(len(resolutions)))
+        for resolution in resolutions:
+            name = resolution.reference
+            for runnable in resolution.resolutions:
+                if runnable.uri:
+                    name = runnable.uri
+                identifier = str(test.TestID(index + 1, name, None, no_digits))
+                tasks.append(nrunner.Task(identifier, runnable, status_uris))
+                index += 1
         return tasks
 
     @asyncio.coroutine
@@ -165,15 +124,9 @@ class NRun(CLICmd):
         return result
 
     def run(self, config):
-        try:
-            loader.loader.load_plugins(config)
-        except loader.LoaderError as details:
-            sys.stderr.write(str(details))
-            sys.stderr.write('\n')
-            sys.exit(exit_codes.AVOCADO_FAIL)
-
-        suite = self.create_test_suite(config.get('references'))
-        tasks = self.suite_to_tasks(suite, [config.get('status_server')])  # pylint: disable=W0201
+        resolutions = resolver.resolve(config.get('references'))
+        tasks = self.resolutions_to_tasks(resolutions,
+                                          [config.get('status_server')])
         self.pending_tasks = self.check_tasks_requirements(tasks)  # pylint: disable=W0201
 
         if not self.pending_tasks:

--- a/avocado/plugins/plugins.py
+++ b/avocado/plugins/plugins.py
@@ -16,6 +16,7 @@ Plugins information plugin
 """
 
 from avocado.core import dispatcher
+from avocado.core.resolver import Resolver
 from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLICmd
 from avocado.utils import astring
@@ -51,7 +52,9 @@ class Plugins(CLICmd):
              ('Plugins that generate job result based on job/test events '
               '(result_events):')),
             (dispatcher.VarianterDispatcher(),
-             'Plugins that generate test variants (varianter): ')
+             'Plugins that generate test variants (varianter): '),
+            (Resolver(),
+             'Plugins that resolve test references (resolver): ')
         ]
         for plugins_active, msg in plugin_types:
             LOG_UI.info(msg)

--- a/avocado/plugins/resolvers.py
+++ b/avocado/plugins/resolvers.py
@@ -1,0 +1,115 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2019
+# Authors: Cleber Rosa <crosa@redhat.com>
+
+"""
+Test resolver for builtin test types
+"""
+
+import os
+
+from avocado.core.plugin_interfaces import Resolver
+from avocado.core.safeloader import find_avocado_tests
+from avocado.core.safeloader import find_python_unittests
+from avocado.core.resolver import ReferenceResolution
+from avocado.core.resolver import ReferenceResolutionResult
+from avocado.core.resolver import check_file
+from avocado.core.nrunner import Runnable
+
+
+class ExecTestResolver(Resolver):
+
+    name = 'exec-test'
+    description = 'Test resolver for executable files to be handled as tests'
+
+    @staticmethod
+    def resolve(reference):
+
+        criteria_check = check_file(reference, reference, suffix=None,
+                                    type_name='executable file',
+                                    access_check=os.R_OK | os.X_OK,
+                                    access_name='executable')
+        if criteria_check is not True:
+            return criteria_check
+
+        return ReferenceResolution(reference,
+                                   ReferenceResolutionResult.SUCCESS,
+                                   [Runnable('exec-test', reference)])
+
+
+class PythonUnittestResolver(Resolver):
+
+    name = 'python-unittest'
+    description = 'Test resolver for Python Unittests'
+
+    @staticmethod
+    def resolve(reference):
+
+        criteria_check = check_file(reference, reference)
+        if criteria_check is not True:
+            return criteria_check
+
+        class_methods = find_python_unittests(reference)
+        if class_methods:
+            runnables = []
+            mod = os.path.relpath(reference)
+            if mod.endswith('.py'):
+                mod = mod[:-3]
+            mod = mod.replace(os.path.sep, ".")
+            for klass, meths in class_methods.items():
+                for (meth, tags) in meths:
+                    uri = '%s.%s.%s' % (mod, klass, meth)
+                    runnables.append(Runnable('python-unittest',
+                                              uri=uri,
+                                              tags=tags))
+            if runnables:
+                return ReferenceResolution(reference,
+                                           ReferenceResolutionResult.SUCCESS,
+                                           runnables)
+
+        return ReferenceResolution(reference,
+                                   ReferenceResolutionResult.NOTFOUND)
+
+
+class AvocadoInstrumentedResolver(Resolver):
+
+    name = 'avocado-instrumented'
+    description = 'Test resolver for Avocado Instrumented tests'
+
+    @staticmethod
+    def resolve(reference):
+        if ':' in reference:
+            module_path, _ = reference.split(':', 1)
+        else:
+            module_path = reference
+
+        criteria_check = check_file(module_path, reference)
+        if criteria_check is not True:
+            return criteria_check
+
+        # disabled tests not needed here
+        class_methods_info, _ = find_avocado_tests(module_path)
+        runnables = []
+        for klass, methods_tags in class_methods_info.items():
+            for (method, tags) in methods_tags:
+                uri = "%s:%s.%s" % (module_path, klass, method)
+                runnables.append(Runnable('avocado-instrumented',
+                                          uri=uri,
+                                          tags=tags))
+        if runnables:
+            return ReferenceResolution(reference,
+                                       ReferenceResolutionResult.SUCCESS,
+                                       runnables)
+
+        return ReferenceResolution(reference,
+                                   ReferenceResolutionResult.NOTFOUND)

--- a/optional_plugins/glib/setup.py
+++ b/optional_plugins/glib/setup.py
@@ -28,5 +28,8 @@ setup(name='avocado-framework-plugin-glib',
       entry_points={
           'avocado.plugins.cli': [
               'glib = avocado_glib:GLibCLI',
+          ],
+          'avocado.plugins.resolver': [
+              'glib = avocado_glib:GLibResolver'
           ]}
       )

--- a/optional_plugins/golang/setup.py
+++ b/optional_plugins/golang/setup.py
@@ -29,5 +29,8 @@ setup(name='avocado-framework-plugin-golang',
       entry_points={
           'avocado.plugins.cli': [
               'golang = avocado_golang:GolangCLI',
+          ],
+          'avocado.plugins.resolver': [
+              'golang = avocado_golang:GolangResolver',
           ]}
       )

--- a/optional_plugins/golang/tests/test_golang.py
+++ b/optional_plugins/golang/tests/test_golang.py
@@ -1,20 +1,24 @@
 import os
-import unittest
+import unittest.mock
 
+from avocado.core.resolver import ReferenceResolutionResult
 import avocado_golang
 
 
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
-class Loader(unittest.TestCase):
+@unittest.skipIf(avocado_golang.GO_BIN is None, "go binary not found")
+class LoaderResolverModule(unittest.TestCase):
+    """
+    Test golang loading/resolution when a module name is given
+    """
 
     def setUp(self):
         self.previous_go_path = os.environ.get('GOPATH', None)
         os.environ['GOPATH'] = THIS_DIR
 
-    @unittest.skipIf(avocado_golang.GO_BIN is None, "go binary not found")
-    def test_discover(self):
+    def test_loader_discover(self):
         loader = avocado_golang.GolangLoader(None, {})
         results = loader.discover('countavocados')
         self.assertEqual(len(results), 2)
@@ -26,6 +30,23 @@ class Loader(unittest.TestCase):
         self.assertIs(no_container_klass, avocado_golang.GolangTest)
         self.assertEqual(no_container_params['name'],
                          "countavocados:TestNoContainers")
+
+    def test_resolver_no_go_bin(self):
+        with unittest.mock.patch('avocado_golang.GO_BIN', None):
+            res = avocado_golang.GolangResolver().resolve('countavocados')
+        self.assertEqual(res.reference, 'countavocados')
+        self.assertEqual(res.result, ReferenceResolutionResult.NOTFOUND)
+
+    def test_resolver(self):
+        res = avocado_golang.GolangResolver().resolve('countavocados')
+        self.assertEqual(res.result, ReferenceResolutionResult.SUCCESS)
+        self.assertEqual(len(res.resolutions), 2)
+        empty_container = res.resolutions[0]
+        self.assertEqual(empty_container.kind, 'golang')
+        self.assertEqual(empty_container.uri, 'countavocados:TestEmptyContainers')
+        no_container = res.resolutions[1]
+        self.assertEqual(no_container.kind, 'golang')
+        self.assertEqual(no_container.uri, 'countavocados:TestNoContainers')
 
     def tearDown(self):
         if self.previous_go_path is not None:

--- a/optional_plugins/robot/setup.py
+++ b/optional_plugins/robot/setup.py
@@ -29,5 +29,8 @@ setup(name='avocado-framework-plugin-robot',
       entry_points={
           'avocado.plugins.cli': [
               'robot = avocado_robot:RobotCLI',
+          ],
+          'avocado.plugins.resolver': [
+              'robot = avocado_robot:RobotResolver'
           ]}
       )

--- a/selftests/functional/test_resolver.py
+++ b/selftests/functional/test_resolver.py
@@ -1,0 +1,52 @@
+import stat
+import unittest
+
+from avocado.utils import script
+from avocado.utils import process
+
+from .. import AVOCADO
+
+# Use the same definitions from loader to make sure the behavior
+# is also the same
+from .test_loader import SIMPLE_TEST as EXEC_TEST
+from .test_loader import AVOCADO_TEST_OK as AVOCADO_INSTRUMENTED_TEST
+
+
+class ResolverFunctional(unittest.TestCase):
+
+    MODE_0664 = (stat.S_IRUSR | stat.S_IWUSR |
+                 stat.S_IRGRP | stat.S_IWGRP |
+                 stat.S_IROTH)
+
+    MODE_0775 = (stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR |
+                 stat.S_IRGRP | stat.S_IWGRP | stat.S_IXGRP |
+                 stat.S_IROTH | stat.S_IXOTH)
+
+    def test_exec_test(self):
+        name = 'executable-test'
+        with script.TemporaryScript(name, EXEC_TEST,
+                                    name, self.MODE_0775) as test_file:
+            cmd_line = ('%s nlist -V %s' % (AVOCADO, test_file.path))
+            result = process.run(cmd_line)
+        self.assertIn('exec-test: 1', result.stdout_text)
+
+    def test_not_exec_test(self):
+        name = 'executable-test'
+        with script.TemporaryScript(name, EXEC_TEST,
+                                    name, self.MODE_0664) as test_file:
+            cmd_line = ('%s nlist %s' % (AVOCADO, test_file.path))
+            result = process.run(cmd_line)
+        self.assertNotIn('exec-test ', result.stdout_text)
+
+    def test_avocado_instrumented(self):
+        name = 'passtest.py'
+        with script.TemporaryScript(name, AVOCADO_INSTRUMENTED_TEST,
+                                    name, self.MODE_0664) as test_file:
+            cmd_line = ('%s nlist -V %s' % (AVOCADO, test_file.path))
+            result = process.run(cmd_line)
+        self.assertIn('passtest.py:PassTest.test', result.stdout_text)
+        self.assertIn('avocado-instrumented: 1', result.stdout_text)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/selftests/unit/test_resolver.py
+++ b/selftests/unit/test_resolver.py
@@ -1,0 +1,30 @@
+import unittest
+
+from avocado.core import resolver
+
+
+class ReferenceResolution(unittest.TestCase):
+
+    """
+    Tests on how to initialize and use
+    :class:`avocado.core.resolver.ReferenceResolution`
+    """
+
+    def test_no_args(self):
+        with self.assertRaises(TypeError):
+            resolver.ReferenceResolution()
+
+    def test_no_result(self):
+        with self.assertRaises(TypeError):
+            resolver.ReferenceResolution('/test/reference')
+
+    def test_no_resolutions(self):
+        resolution = resolver.ReferenceResolution(
+            '/test/reference',
+            resolver.ReferenceResolutionResult.NOTFOUND)
+        self.assertEqual(len(resolution.resolutions), 0,
+                         "Unexpected resolutions found")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,7 @@ if __name__ == '__main__':
                   'task-run-recipe = avocado.plugins.task_run_recipe:TaskRunRecipe',
                   'nrun = avocado.plugins.nrun:NRun',
                   'vmimage = avocado.plugins.vmimage:VMimage',
+                  'nlist = avocado.plugins.nlist:List',
                   ],
               'avocado.plugins.job.prepost': [
                   'jobscripts = avocado.plugins.jobscripts:JobScripts',
@@ -115,7 +116,12 @@ if __name__ == '__main__':
                   ],
               'avocado.plugins.varianter': [
                   'json_variants = avocado.plugins.json_variants:JsonVariants',
-                 ],
+                  ],
+              'avocado.plugins.resolver': [
+                  'exec-test = avocado.plugins.resolvers:ExecTestResolver',
+                  'python-unittest = avocado.plugins.resolvers:PythonUnittestResolver',
+                  'avocado-instrumented = avocado.plugins.resolvers:AvocadoInstrumentedResolver',
+                  ],
               },
           zip_safe=False,
           test_suite='selftests',


### PR DESCRIPTION
Introduce avocado.core.resolver as an alternative to loader
    
This new module, plugin interface and associated infrastructure provides an alternative that is better integrated to the other Avocado plugins. 

Currently, it's only leveraged by the N(ext) runner, and exposed via an also experimental `nlist` command.

---

An explanation was presented here:

https://www.redhat.com/archives/avocado-devel/2019-July/msg00002.html

I'm aware of a few limitations on this version, including not being able to filter by test name (what the loader calls "subtest filter").  All the limitations will be addressed before this feature is considered stable (it's currently marked as experimental, and limited to the also experimental `nrunner`)