### PR TITLE
Packit Initial Support

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -1,0 +1,15 @@
+specfile_path: python-avocado.spec
+synced_files:
+  - python-avocado.spec
+  - .packit.yml
+upstream_project_name: avocado-framework
+downstream_package_name: python-avocado
+jobs:
+  - job: copr_build
+    trigger: pull_request
+    metadata:
+      targets:
+      - fedora-29-x86_64
+      - fedora-30-x86_64
+      - fedora-31-x86_64
+      - fedora-rawhide-x86_64


### PR DESCRIPTION
This is an initial attempt to implement Packit as a service to
build packages on pull requests.

The goal is to not have changes that will cause breakages to
packaging, and thus, releases should be smoother.  Also, if users
choose to, they should be able to have RPMs for all development
versions at any time too.

Signed-off-by: Cleber Rosa <crosa@redhat.com>