### PR TITLE
sysinfo: don't use a shell to mask out errors

### DIFF
--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -161,13 +161,16 @@ class Command(Collectible):
         # but the avocado.utils.process APIs define no timeouts as "None"
         if int(timeout) <= 0:
             timeout = None
-        result = process.run(self.cmd,
-                             timeout=timeout,
-                             verbose=False,
-                             ignore_status=True,
-                             allow_output_check='combined',
-                             shell=True,
-                             env=env)
+        try:
+            result = process.run(self.cmd,
+                                 timeout=timeout,
+                                 verbose=False,
+                                 ignore_status=True,
+                                 allow_output_check='combined',
+                                 env=env)
+        except Exception as exc:
+            log.warn('Could not execute "%s": %s', self.cmd, exc)
+            return
         logf_path = os.path.join(logdir, self.logf)
         if self._compress_log:
             with gzip.GzipFile(logf_path, 'wb') as logf:


### PR DESCRIPTION
When collecting command output, sysinfo will currently use a shell
which is unnecessary, will mask out errors and will put the wrong
content on files on error conditions.

Example is running `avocado sysinfo` on a system without brctl.

```
   $ cat sysinfo-2019-10-01-14.03.39/pre/brctl\ show
   /bin/sh: brctl: command not found
```

With this change, this a sample output of the `avocado sysinfo`
execution:

```
   $ avocado sysinfo
   avocado.sysinfo: Commands configured by file: /home/cleber/src/avocado/avocado/etc/avocado/sysinfo/commands
   avocado.sysinfo: Files configured by file: /home/cleber/src/avocado/avocado/etc/avocado/sysinfo/files
   avocado.sysinfo: Profilers configured by file: /home/cleber/src/avocado/avocado/etc/avocado/sysinfo/profilers
   avocado.sysinfo: Profiler disabled
   avocado.sysinfo: Could not execute "brctl show": [Errno 2] No such file or directory: 'brctl' (brctl show): 'brctl'
   avocado.sysinfo: Logged system information to /home/cleber/sysinfo-2019-10-01-14.20.16
```

And the 'brctl show' file is not generated, instead of being generated
without the wrong content.

Signed-off-by: Cleber Rosa <crosa@redhat.com>