### PR TITLE
avocado.utils.asset: generously increase the lock acquisition timeout

### DIFF
--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -150,7 +150,7 @@ class Asset:
             if (os.path.isfile(asset_file) and
                     not self._is_expired(asset_file, self.expire)):
                 try:
-                    with FileLock(asset_file, 1):
+                    with FileLock(asset_file, 30):
                         if self._verify(asset_file):
                             return asset_file
                 except Exception:


### PR DESCRIPTION
Under systems with heavy load, and multiple tests contending for
access to an asset file, the test can error because of the short
timeout.

This is a simple workaround that favors less false negatives and
trades it off with a possibly longer test execution time.  The
complementary and definitive solution, though, is to avoid
recalculating the hash if a "verified" flag is in place and it's newer
than the asset file itself.

Reference: https://trello.com/c/WdnjY4n7
Signed-off-by: Cleber Rosa <crosa@redhat.com>