### PR TITLE
Test runner: work towards defining an interface

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -166,7 +166,7 @@ class Job:
             if self.config.get("base_logdir", None) is None:
                 self.config['base_logdir'] = tempfile.mkdtemp(prefix="avocado-dry-run-")
         self._setup_job_results()
-        self.result = result.Result(self)
+        self.result = result.Result(self.unique_id, self.logfile)
         self.__start_job_logging()
         self._setup_job_category()
         # Use "logdir" in case "keep_tmp" is enabled

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -515,7 +515,7 @@ class Job:
                                                        "variant: %s" % details)
 
         runner_klass = self.config.get('test_runner', runner.TestRunner)
-        self.test_runner = runner_klass(job=self, result=self.result)
+        self.test_runner = runner_klass()
         self._start_sysinfo()
 
         self._log_job_debug_info(variant)
@@ -523,7 +523,9 @@ class Job:
                        self.config.get('references'), sys.argv)
         replay_map = self.config.get('replay_map', None)
         execution_order = self.config.get('execution_order', None)
-        summary = self.test_runner.run_suite(self.test_suite,
+        summary = self.test_runner.run_suite(self,
+                                             self.result,
+                                             self.test_suite,
                                              variant,
                                              self.timeout,
                                              replay_map,

--- a/avocado/core/result.py
+++ b/avocado/core/result.py
@@ -24,14 +24,17 @@ class Result:
     Result class, holder for job (and its tests) result information.
     """
 
-    def __init__(self, job):
+    def __init__(self, job_unique_id, job_logfile):
         """
         Creates an instance of Result.
 
-        :param job: an instance of :class:`avocado.core.job.Job`.
+        :param job_unique_id: the job's unique ID, usually from
+                              :attr:`avocado.core.job.Job.unique_id`
+        :param job_logfile: the job's unique ID, usually from
+                            :attr:`avocado.core.job.Job.logfile`
         """
-        self.job_unique_id = getattr(job, "unique_id")
-        self.logfile = getattr(job, "logfile", None)
+        self.job_unique_id = job_unique_id
+        self.logfile = job_logfile
         self.tests_total = 0
         self.tests_run = 0
         self.tests_total_time = 0.0

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -290,7 +290,8 @@ class TestRunner:
         self.result = result
         self.sigstopped = False
 
-    def _run_test(self, test_factory, queue):
+    @staticmethod
+    def _run_test(job, result, test_factory, queue):
         """
         Run a test instance.
 
@@ -332,11 +333,11 @@ class TestRunner:
         except Exception:
             instance.error(stacktrace.str_unpickable_object(early_state))
 
-        self.result.start_test(early_state)
-        self.job.result_events_dispatcher.map_method('start_test',
-                                                     self.result,
-                                                     early_state)
-        if self.job.config.get('log_test_data_directories', False):
+        result.start_test(early_state)
+        job.result_events_dispatcher.map_method('start_test',
+                                                result,
+                                                early_state)
+        if job.config.get('log_test_data_directories', False):
             data_sources = getattr(instance, "DATA_SOURCES", [])
             if data_sources:
                 locations = []
@@ -392,7 +393,7 @@ class TestRunner:
                     self.sigstopped = True
 
         proc = multiprocessing.Process(target=self._run_test,
-                                       args=(test_factory, queue,))
+                                       args=(self.job, self.result, test_factory, queue,))
         test_status = TestStatus(self.job, queue)
 
         cycle_timeout = 1

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -552,22 +552,23 @@ class TestRunner:
                           "variant_id": varianter.generate_variant_id(var),
                           "paths": paths}
 
-    def _iter_suite(self, test_suite, variants, execution_order):
+    def _iter_suite(self, job, test_suite, variants, execution_order):
         """
         Iterates through test_suite and variants in defined order
 
+        :param job: an instance of :class:`avocado.core.job.Job`
         :param test_suite: a list of tests to run
         :param variants: a varianter object to produce test params
         :param execution_order: way of iterating through tests/variants
         :return: generator yielding tuple(test_factory, variant)
         """
         if execution_order == "variants-per-test":
-            return (self._template_to_factory(self.job.test_parameters,
+            return (self._template_to_factory(job.test_parameters,
                                               template, variant)
                     for template in test_suite
                     for variant in variants.itertests())
         elif execution_order == "tests-per-variant":
-            return (self._template_to_factory(self.job.test_parameters,
+            return (self._template_to_factory(job.test_parameters,
                                               template, variant)
                     for variant in variants.itertests()
                     for template in test_suite)
@@ -609,7 +610,9 @@ class TestRunner:
                 test_factory[1]["job"] = self.job
             if execution_order is None:
                 execution_order = self.DEFAULT_EXECUTION_ORDER
-            for test_factory, variant in self._iter_suite(test_suite, variants,
+            for test_factory, variant in self._iter_suite(self.job,
+                                                          test_suite,
+                                                          variants,
                                                           execution_order):
                 index += 1
                 test_parameters = test_factory[1]

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -511,10 +511,13 @@ class TestRunner:
             return False
         return True
 
-    def _template_to_factory(self, template, variant):
+    @staticmethod
+    def _template_to_factory(test_parameters, template, variant):
         """
         Applies test params from variant to the test template
 
+        :param test_parameters: a simpler set of parameters (currently
+                                given to the run command via "-p" parameters)
         :param template: a test template, containing the class name,
                          followed by parameters to the class
         :type template: tuple
@@ -529,9 +532,9 @@ class TestRunner:
 
         if "params" not in template[1]:
             factory = [template[0], template[1].copy()]
-            if self.job.test_parameters and empty_variants:
+            if test_parameters and empty_variants:
                 var[0] = tree.TreeNode().get_node("/", True)
-                var[0].value = self.job.test_parameters
+                var[0].value = test_parameters
                 paths = ["/"]
             factory[1]["params"] = (var, paths)
             return factory, variant
@@ -559,11 +562,13 @@ class TestRunner:
         :return: generator yielding tuple(test_factory, variant)
         """
         if execution_order == "variants-per-test":
-            return (self._template_to_factory(template, variant)
+            return (self._template_to_factory(self.job.test_parameters,
+                                              template, variant)
                     for template in test_suite
                     for variant in variants.itertests())
         elif execution_order == "tests-per-variant":
-            return (self._template_to_factory(template, variant)
+            return (self._template_to_factory(self.job.test_parameters,
+                                              template, variant)
                     for variant in variants.itertests()
                     for template in test_suite)
         else:

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -279,15 +279,10 @@ class TestRunner:
     #: The allowed values are "variants-per-test" or "tests-per-variant"
     DEFAULT_EXECUTION_ORDER = "variants-per-test"
 
-    def __init__(self, job, result):
+    def __init__(self):
         """
         Creates an instance of TestRunner class.
-
-        :param job: an instance of :class:`avocado.core.job.Job`.
-        :param result: an instance of :class:`avocado.core.result.Result`
         """
-        self.job = job
-        self.result = result
         self.sigstopped = False
 
     @staticmethod
@@ -358,7 +353,7 @@ class TestRunner:
             except Exception:
                 instance.error(stacktrace.str_unpickable_object(state))
 
-    def run_test(self, test_factory, queue, summary, job_deadline=0):
+    def run_test(self, job, result, test_factory, queue, summary, job_deadline=0):
         """
         Run a test instance inside a subprocess.
 
@@ -393,8 +388,8 @@ class TestRunner:
                     self.sigstopped = True
 
         proc = multiprocessing.Process(target=self._run_test,
-                                       args=(self.job, self.result, test_factory, queue,))
-        test_status = TestStatus(self.job, queue)
+                                       args=(job, result, test_factory, queue,))
+        test_status = TestStatus(job, queue)
 
         cycle_timeout = 1
         time_started = time.time()
@@ -422,7 +417,7 @@ class TestRunner:
         first = 0.01
         step = 0.01
         abort_reason = None
-        result_dispatcher = self.job.result_events_dispatcher
+        result_dispatcher = job.result_events_dispatcher
 
         while True:
             try:
@@ -453,18 +448,18 @@ class TestRunner:
                 if ctrl_c_count == 1:
                     if not stage_1_msg_displayed:
                         abort_reason = "Interrupted by ctrl+c"
-                        self.job.log.debug("\nInterrupt requested. Waiting %d "
-                                           "seconds for test to finish "
-                                           "(ignoring new Ctrl+C until then)",
-                                           ignore_window)
+                        job.log.debug("\nInterrupt requested. Waiting %d "
+                                      "seconds for test to finish "
+                                      "(ignoring new Ctrl+C until then)",
+                                      ignore_window)
                         stage_1_msg_displayed = True
                     ignore_time_started = time.time()
                     process.kill_process_tree(proc.pid, signal.SIGINT)
                 if (ctrl_c_count > 1) and (time_elapsed > ignore_window):
                     if not stage_2_msg_displayed:
                         abort_reason = "Interrupted by ctrl+c (multiple-times)"
-                        self.job.log.debug("Killing test subprocess %s",
-                                           proc.pid)
+                        job.log.debug("Killing test subprocess %s",
+                                      proc.pid)
                         stage_2_msg_displayed = True
                     process.kill_process_tree(proc.pid, signal.SIGKILL)
 
@@ -488,23 +483,23 @@ class TestRunner:
 
         # don't process other tests from the list
         if ctrl_c_count > 0:
-            self.job.log.debug('')
+            job.log.debug('')
 
         # Make sure the test status is correct
         if test_state.get('status') not in status.user_facing_status:
             test_state = add_runner_failure(test_state, "ERROR", "Test reports"
                                             " unsupported test status.")
 
-        self.result.check_test(test_state)
-        result_dispatcher.map_method('end_test', self.result, test_state)
+        result.check_test(test_state)
+        result_dispatcher.map_method('end_test', result, test_state)
         if test_state['status'] == "INTERRUPTED":
             summary.add("INTERRUPTED")
         elif not mapping[test_state['status']]:
             summary.add("FAIL")
 
-            if self.job.config.get('failfast', 'off') == 'on':
+            if job.config.get('failfast', 'off') == 'on':
                 summary.add("INTERRUPTED")
-                self.job.interrupted_reason = "Interrupting job (failfast)."
+                job.interrupted_reason = "Interrupting job (failfast)."
                 return False
 
         if ctrl_c_count > 0:
@@ -576,11 +571,13 @@ class TestRunner:
             raise NotImplementedError("Suite_order %s is not supported"
                                       % execution_order)
 
-    def run_suite(self, test_suite, variants, timeout=0, replay_map=None,
-                  execution_order=None):
+    def run_suite(self, job, result, test_suite, variants, timeout=0,
+                  replay_map=None, execution_order=None):
         """
         Run one or more tests and report with test result.
 
+        :param job: an instance of :class:`avocado.core.job.Job`.
+        :param result: an instance of :class:`avocado.core.result.Result`
         :param test_suite: a list of tests to run.
         :param variants: A varianter iterator to produce test params.
         :param timeout: maximum amount of time (in seconds) to execute.
@@ -592,8 +589,8 @@ class TestRunner:
         :return: a set with types of test failures.
         """
         summary = set()
-        if self.job.sysinfo is not None:
-            self.job.sysinfo.start_job_hook()
+        if job.sysinfo is not None:
+            job.sysinfo.start_job_hook()
         queue = multiprocessing.SimpleQueue()
         if timeout > 0:
             deadline = time.time() + timeout
@@ -602,15 +599,15 @@ class TestRunner:
 
         test_result_total = variants.get_number_of_tests(test_suite)
         no_digits = len(str(test_result_total))
-        self.result.tests_total = test_result_total
+        result.tests_total = test_result_total
         index = -1
         try:
             for test_factory in test_suite:
-                test_factory[1]["base_logdir"] = self.job.logdir
-                test_factory[1]["job"] = self.job
+                test_factory[1]["base_logdir"] = job.logdir
+                test_factory[1]["job"] = job
             if execution_order is None:
                 execution_order = self.DEFAULT_EXECUTION_ORDER
-            for test_factory, variant in self._iter_suite(self.job,
+            for test_factory, variant in self._iter_suite(job,
                                                           test_suite,
                                                           variants,
                                                           execution_order):
@@ -625,7 +622,7 @@ class TestRunner:
                     if 'methodName' in test_parameters:
                         del test_parameters['methodName']
                     test_factory = (test.TimeOutSkipTest, test_parameters)
-                    if not self.run_test(test_factory, queue, summary):
+                    if not self.run_test(job, result, test_factory, queue, summary):
                         break
                 else:
                     if (replay_map is not None and
@@ -633,16 +630,16 @@ class TestRunner:
                         test_parameters["methodName"] = "test"
                         test_factory = (replay_map[index], test_parameters)
 
-                    if not self.run_test(test_factory, queue, summary,
+                    if not self.run_test(job, result, test_factory, queue, summary,
                                          deadline):
                         break
         except KeyboardInterrupt:
             TEST_LOG.error('Job interrupted by ctrl+c.')
             summary.add('INTERRUPTED')
 
-        if self.job.sysinfo is not None:
-            self.job.sysinfo.end_job_hook()
-        self.result.end_tests()
-        self.job.funcatexit.run()
+        if job.sysinfo is not None:
+            job.sysinfo.end_job_hook()
+        result.end_tests()
+        job.funcatexit.run()
         signal.signal(signal.SIGTSTP, signal.SIG_IGN)
         return summary

--- a/optional_plugins/runner_docker/avocado_runner_docker/__init__.py
+++ b/optional_plugins/runner_docker/avocado_runner_docker/__init__.py
@@ -115,32 +115,32 @@ class DockerTestRunner(RemoteTestRunner):
     Test runner which runs the job inside a docker container
     """
 
-    def __init__(self, job, result):
-        super(DockerTestRunner, self).__init__(job, result)
+    def __init__(self):
+        super(DockerTestRunner, self).__init__()
         self.remote = None      # Will be set in `setup`
 
-    def setup(self):
-        dkr_name = os.path.basename(self.job.logdir) + '.' + 'avocado'
-        self.remote = DockerRemoter(self.job.config.get('docker_cmd'),
-                                    self.job.config.get('docker'),
-                                    self.job.config.get('docker_options'),
+    def setup(self, job):
+        dkr_name = os.path.basename(job.logdir) + '.' + 'avocado'
+        self.remote = DockerRemoter(job.config.get('docker_cmd'),
+                                    job.config.get('docker'),
+                                    job.config.get('docker_options'),
                                     dkr_name)
-        stdout_claimed_by = self.job.config.get('stdout_claimed_by', None)
+        stdout_claimed_by = job.config.get('stdout_claimed_by', None)
         if not stdout_claimed_by:
-            self.job.log.info("DOCKER     : Container id '%s'"
-                              % self.remote.get_cid())
-            self.job.log.info("DOCKER     : Container name '%s'" % dkr_name)
+            job.log.info("DOCKER     : Container id '%s'"
+                         % self.remote.get_cid())
+            job.log.info("DOCKER     : Container name '%s'" % dkr_name)
 
-    def tear_down(self):
+    def tear_down(self, job):
         try:
             if self.remote:
                 self.remote.close()
-                if not self.job.config.get('docker_no_cleanup'):
+                if not job.config.get('docker_no_cleanup'):
                     self.remote.cleanup()
         except Exception as details:
-            stdout_claimed_by = self.job.config.get('stdout_claimed_by', None)
+            stdout_claimed_by = job.config.get('stdout_claimed_by', None)
             if not stdout_claimed_by:
-                self.job.log.warn("DOCKER     : Fail to cleanup: %s" % details)
+                job.log.warn("DOCKER     : Fail to cleanup: %s" % details)
 
 
 class DockerCLI(CLI):

--- a/optional_plugins/runner_remote/tests/test_remote.py
+++ b/optional_plugins/runner_remote/tests/test_remote.py
@@ -71,7 +71,7 @@ class RemoteTestRunnerTest(unittest.TestCase):
                     'base_logdir': self.tmpdir.name}
 
         with Job(job_args) as job:
-            runner = avocado_runner_remote.RemoteTestRunner(job, job.result)
+            runner = avocado_runner_remote.RemoteTestRunner()
             return_value = (True, (version.MAJOR, version.MINOR))
             runner.check_remote_avocado = unittest.mock.Mock(return_value=return_value)
 
@@ -93,7 +93,7 @@ class RemoteTestRunnerTest(unittest.TestCase):
                 # zip file instead, but it's really overkill
                 with unittest.mock.patch('avocado_runner_remote.archive.uncompress'):
                     with unittest.mock.patch('avocado_runner_remote.os.remove'):
-                        runner.run_suite(None, None, 61)
+                        runner.run_suite(job, job.result, None, None, 61)
 
         # The job was created with dry_run so it should have a zeroed id
         self.assertEqual(job.result.job_unique_id, '0' * 40)

--- a/optional_plugins/runner_vm/tests/test_vm.py
+++ b/optional_plugins/runner_vm/tests/test_vm.py
@@ -58,9 +58,9 @@ class VMTestRunnerSetup(unittest.TestCase):
             with unittest.mock.patch('avocado_runner_vm.vm_connect',
                                      return_value=mock_vm):
                 # VMTestRunner()
-                runner = avocado_runner_vm.VMTestRunner(job, None)
-                runner.setup()
-                runner.tear_down()
+                runner = avocado_runner_vm.VMTestRunner()
+                runner.setup(job)
+                runner.tear_down(job)
                 mock_vm.start.assert_called_once_with()
                 mock_vm.create_snapshot.assert_called_once_with()
                 mock_vm.stop.assert_called_once_with()

--- a/selftests/unit/test_jsonresult.py
+++ b/selftests/unit/test_jsonresult.py
@@ -14,11 +14,8 @@ from .. import setup_avocado_loggers, temp_dir_prefix
 setup_avocado_loggers()
 
 
-class FakeJob:
-
-    def __init__(self, config):
-        self.config = config
-        self.unique_id = '0000000000000000000000000000000000000000'
+UNIQUE_ID = '0000000000000000000000000000000000000000'
+LOGFILE = None
 
 
 class JSONResultTest(unittest.TestCase):
@@ -36,7 +33,7 @@ class JSONResultTest(unittest.TestCase):
         config = {'json_output': self.tmpfile[1],
                   'base_logdir': self.tmpdir.name}
         self.job = job.Job(config)
-        self.test_result = Result(FakeJob(config))
+        self.test_result = Result(UNIQUE_ID, LOGFILE)
         self.test_result.filename = self.tmpfile[1]
         self.test_result.tests_total = 1
         self.test1 = SimpleTest(job=self.job, base_logdir=self.tmpdir.name)

--- a/selftests/unit/test_result.py
+++ b/selftests/unit/test_result.py
@@ -1,65 +1,58 @@
-import argparse
 import unittest
 
 from avocado.core.result import Result
 
 
-class FakeJobMissingUniqueId:
-
-    def __init__(self, args):
-        self.args = args
-
-
-class FakeJob:
-
-    def __init__(self, args):
-        self.args = args
-        self.unique_id = '0000000000000000000000000000000000000000'
+UNIQUE_ID = '0000000000000000000000000000000000000000'
+LOGFILE = None
 
 
 class ResultTest(unittest.TestCase):
 
-    def test_result_job_without_id(self):
-        args = argparse.Namespace()
-        Result(FakeJob(args))
-        self.assertRaises(AttributeError, Result, FakeJobMissingUniqueId(args))
+    def test_result_no_job_id(self):
+        with self.assertRaises(TypeError):
+            Result()
+
+    def test_result_no_job_logfile(self):
+        with self.assertRaises(TypeError):
+            Result(UNIQUE_ID)
 
     def test_result_rate_all_succeeded(self):
-        result = Result(FakeJob([]))
+        result = Result(UNIQUE_ID, LOGFILE)
         result.check_test({'status': 'PASS'})
         result.end_tests()
         self.assertEqual(result.rate, 100.0)
 
     def test_result_rate_all_succeeded_with_warns(self):
-        result = Result(FakeJob([]))
+        result = Result(UNIQUE_ID, LOGFILE)
         result.check_test({'status': 'PASS'})
         result.check_test({'status': 'WARN'})
         result.end_tests()
         self.assertEqual(result.rate, 100.0)
 
     def test_result_rate_all_succeeded_with_skips(self):
-        result = Result(FakeJob([]))
+        result = Result(UNIQUE_ID, LOGFILE)
         result.check_test({'status': 'PASS'})
         result.check_test({'status': 'SKIP'})
         result.end_tests()
         self.assertEqual(result.rate, 100.0)
 
     def test_result_rate_all_succeeded_with_cancelled(self):
-        result = Result(FakeJob([]))
+        result = Result(UNIQUE_ID, LOGFILE)
         result.check_test({'status': 'PASS'})
         result.check_test({'status': 'CANCEL'})
         result.end_tests()
         self.assertEqual(result.rate, 100.0)
 
     def test_result_rate_half_succeeded(self):
-        result = Result(FakeJob([]))
+        result = Result(UNIQUE_ID, LOGFILE)
         result.check_test({'status': 'PASS'})
         result.check_test({'status': 'FAIL'})
         result.end_tests()
         self.assertEqual(result.rate, 50.0)
 
     def test_result_rate_none_succeeded(self):
-        result = Result(FakeJob([]))
+        result = Result(UNIQUE_ID, LOGFILE)
         result.check_test({'status': 'FAIL'})
         result.end_tests()
         self.assertEqual(result.rate, 0.0)

--- a/selftests/unit/test_runner_queue.py
+++ b/selftests/unit/test_runner_queue.py
@@ -15,6 +15,10 @@ from .. import setup_avocado_loggers, temp_dir_prefix
 setup_avocado_loggers()
 
 
+UNIQUE_ID = '0000000000000000000000000000000000000000'
+LOGFILE = None
+
+
 class TestRunnerQueue(unittest.TestCase):
     """
     Test the Runner/Test Queue
@@ -25,7 +29,7 @@ class TestRunnerQueue(unittest.TestCase):
         self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
         args = {'base_logdir': self.tmpdir.name}
         self.job = Job(args)
-        self.result = Result(self.job)
+        self.result = Result(UNIQUE_ID, LOGFILE)
 
     def _run_test(self, factory):
         """

--- a/selftests/unit/test_runner_queue.py
+++ b/selftests/unit/test_runner_queue.py
@@ -38,7 +38,7 @@ class TestRunnerQueue(unittest.TestCase):
         :return: the last queue message from the test
         """
         queue = multiprocessing.SimpleQueue()
-        runner = TestRunner(job=self.job, result=self.result)
+        runner = TestRunner()
         runner._run_test(self.job, self.result, factory, queue)
         while not queue.empty():
             msg = queue.get()

--- a/selftests/unit/test_runner_queue.py
+++ b/selftests/unit/test_runner_queue.py
@@ -39,7 +39,7 @@ class TestRunnerQueue(unittest.TestCase):
         """
         queue = multiprocessing.SimpleQueue()
         runner = TestRunner(job=self.job, result=self.result)
-        runner._run_test(factory, queue)
+        runner._run_test(self.job, self.result, factory, queue)
         while not queue.empty():
             msg = queue.get()
         return msg

--- a/selftests/unit/test_xunit.py
+++ b/selftests/unit/test_xunit.py
@@ -20,15 +20,12 @@ from .. import setup_avocado_loggers, temp_dir_prefix
 setup_avocado_loggers()
 
 
+UNIQUE_ID = '0000000000000000000000000000000000000000'
+LOGFILE = None
+
+
 class ParseXMLError(Exception):
     pass
-
-
-class FakeJob:
-
-    def __init__(self, config):
-        self.config = config
-        self.unique_id = '0000000000000000000000000000000000000000'
 
 
 class xUnitSucceedTest(unittest.TestCase):
@@ -46,7 +43,7 @@ class xUnitSucceedTest(unittest.TestCase):
         config = {'base_logdir': self.tmpdir.name,
                   'xunit_output': self.tmpfile[1]}
         self.job = job.Job(config)
-        self.test_result = Result(FakeJob(config))
+        self.test_result = Result(UNIQUE_ID, LOGFILE)
         self.test_result.tests_total = 1
         self.test_result.logfile = ("/.../avocado/job-results/"
                                     "job-2018-11-28T16.27-8fef221/job.log")


### PR DESCRIPTION
Even though there are currently multiple implementations of test runners, (`avocado_runner_remote.RemoteTestRunner`, and `avocado_runner_vm.VMTestRunner` and `avocado_runner_docker.DockerTestRunner`)  there's no interface currently defined.  

The `avocado.core.runner.TestRunner` is currently both the main (local) implementation and serves as the base class for other runners.

This currently makes the internal interface more clear, and further work will define the final and "public" interface in `avocado.core.plugin_interfaces`.