### PR TITLE
Sysinfo: job collection implemented as a plugin

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -32,7 +32,6 @@ from . import data_dir
 from . import dispatcher
 from . import runner
 from . import loader
-from . import sysinfo
 from . import result
 from . import exit_codes
 from . import exceptions
@@ -335,11 +334,6 @@ class Job:
             if os.path.exists(proc_latest):
                 os.unlink(proc_latest)
 
-    def _start_sysinfo(self):
-        if self.config.get('sysinfo', None) == 'on':
-            sysinfo_dir = path.init_dir(self.logdir, 'sysinfo')
-            self.sysinfo = sysinfo.SysInfo(basedir=sysinfo_dir)
-
     def _make_test_suite(self, references=None):
         """
         Prepares a test suite to be used for running tests
@@ -516,8 +510,6 @@ class Job:
 
         runner_klass = self.config.get('test_runner', runner.TestRunner)
         self.test_runner = runner_klass()
-        self._start_sysinfo()
-
         self._log_job_debug_info(variant)
         jobdata.record(self.config, self.logdir, variant,
                        self.config.get('references'), sys.argv)

--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -625,15 +625,11 @@ class SysInfo:
             self._log_modified_packages(self.post_dir)
 
 
-def collect_sysinfo(args):
+def collect_sysinfo(basedir):
     """
     Collect sysinfo to a base directory.
-
-    :param args: :class:`argparse.Namespace` object with command line params.
     """
     output.add_log_handler(log.name)
-
-    basedir = args.get('sysinfodir')
     if not basedir:
         cwd = os.getcwd()
         timestamp = time.strftime('%Y-%m-%d-%H.%M.%S')

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -370,7 +370,9 @@ class Test(unittest.TestCase, TestData):
         self._logging_handlers = {}
 
         self.__outputdir = utils_path.init_dir(self.logdir, 'data')
-        self.__sysinfo_enabled = getattr(self.job, 'sysinfo', False)
+        self.__sysinfo_enabled = (self.job is not None and
+                                  self.job.config is not None and
+                                  self.job.config.get('sysinfo', None) == 'on')
         if self.__sysinfo_enabled:
             self.__sysinfodir = utils_path.init_dir(self.logdir, 'sysinfo')
             self.__sysinfo_logger = sysinfo.SysInfo(basedir=self.__sysinfodir)

--- a/avocado/plugins/sysinfo.py
+++ b/avocado/plugins/sysinfo.py
@@ -40,4 +40,4 @@ class SysInfo(CLICmd):
                             nargs='?', default='')
 
     def run(self, config):
-        sysinfo.collect_sysinfo(config)
+        sysinfo.collect_sysinfo(config.get('sysinfodir'))

--- a/avocado/plugins/sysinfo.py
+++ b/avocado/plugins/sysinfo.py
@@ -16,7 +16,36 @@ System information plugin
 """
 
 from avocado.core.plugin_interfaces import CLICmd
+from avocado.core.plugin_interfaces import JobPre
+from avocado.core.plugin_interfaces import JobPost
 from avocado.core import sysinfo
+from avocado.utils import path
+
+
+class SysInfoJob(JobPre, JobPost):
+
+    name = 'sysinfo'
+    description = 'Collects system information before/after the job is run'
+
+    def __init__(self):
+        self.sysinfo = None
+
+    def _init_sysinfo(self, job_logdir):
+        if self.sysinfo is None:
+            basedir = path.init_dir(job_logdir, 'sysinfo')
+            self.sysinfo = sysinfo.SysInfo(basedir=basedir)
+
+    def pre(self, job):
+        if job.config.get('sysinfo', None) != 'on':
+            return
+        self._init_sysinfo(job.logdir)
+        self.sysinfo.start_job_hook()
+
+    def post(self, job):
+        if job.config.get('sysinfo', None) != 'on':
+            return
+        self._init_sysinfo(job.logdir)
+        self.sysinfo.end_job_hook()
 
 
 class SysInfo(CLICmd):

--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,7 @@ if __name__ == '__main__':
                   'teststmpdir = avocado.plugins.teststmpdir:TestsTmpDir',
                   'human = avocado.plugins.human:HumanJob',
                   'merge_files = avocado.plugins.expected_files_merge:FilesMerge',
+                  'sysinfo = avocado.plugins.sysinfo:SysInfoJob',
                   ],
               'avocado.plugins.result': [
                   'xunit = avocado.plugins.xunit:XUnitResult',


### PR DESCRIPTION
The infrastructure to run code before and after jobs are run already exist.  Let's make use of those, and in due time, do the same for the sysinfo collection on tests.