### PR TITLE
nrunner: give time_start and time_end information

### DIFF
--- a/selftests/functional/test_nrunner.py
+++ b/selftests/functional/test_nrunner.py
@@ -13,7 +13,9 @@ class RunnableRun(unittest.TestCase):
     def test_noop(self):
         res = process.run("%s runnable-run -k noop" % AVOCADO,
                           ignore_status=True)
-        self.assertEqual(res.stdout, b"{'status': 'finished'}\n")
+        self.assertIn(b"'status': 'finished'", res.stdout)
+        self.assertIn(b"'time_start': ", res.stdout)
+        self.assertIn(b"'time_end': ", res.stdout)
         self.assertEqual(res.exit_status, exit_codes.AVOCADO_ALL_OK)
 
     def test_exec(self):
@@ -54,8 +56,10 @@ class RunnableRun(unittest.TestCase):
             first_status = lines[0]
             final_status = lines[-1]
             self.assertIn("'status': 'running'", first_status)
+            self.assertIn("'time_start': ", first_status)
         self.assertIn("'status': 'finished'", final_status)
         self.assertIn("'stdout': b'avocado'", final_status)
+        self.assertIn("'time_end': ", final_status)
         self.assertEqual(res.exit_status, exit_codes.AVOCADO_ALL_OK)
 
     def test_noop_valid_kwargs(self):

--- a/selftests/unit/test_nrunner.py
+++ b/selftests/unit/test_nrunner.py
@@ -176,27 +176,33 @@ class Runner(unittest.TestCase):
         runnable = nrunner.Runnable('noop', None)
         runner = nrunner.runner_from_runnable(runnable)
         results = [status for status in runner.run()]
-        self.assertEqual(results, [{'status': 'finished'}])
+        last_result = results[-1]
+        self.assertEqual(last_result['status'], 'finished')
+        self.assertIn('time_end', last_result)
 
     def test_runner_exec(self):
         runnable = nrunner.Runnable('exec', sys.executable,
                                     '-c', '"import time; time.sleep(0.01)"')
         runner = nrunner.runner_from_runnable(runnable)
         results = [status for status in runner.run()]
-        self.assertEqual(results[-1], {'status': 'finished',
-                                       'returncode': 0,
-                                       'stdout': b'',
-                                       'stderr': b''})
+        last_result = results[-1]
+        self.assertEqual(last_result['status'], 'finished')
+        self.assertEqual(last_result['returncode'], 0)
+        self.assertEqual(last_result['stdout'], b'')
+        self.assertEqual(last_result['stderr'], b'')
+        self.assertIn('time_end', last_result)
 
     def test_runner_exec_test(self):
         runnable = nrunner.Runnable('exec-test', sys.executable,
                                     '-c', '"import time; time.sleep(0.01)"')
         runner = nrunner.runner_from_runnable(runnable)
         results = [status for status in runner.run()]
-        self.assertEqual(results[-1], {'status': 'pass',
-                                       'returncode': 0,
-                                       'stdout': b'',
-                                       'stderr': b''})
+        last_result = results[-1]
+        self.assertEqual(last_result['status'], 'pass')
+        self.assertEqual(last_result['returncode'], 0)
+        self.assertEqual(last_result['stdout'], b'')
+        self.assertEqual(last_result['stderr'], b'')
+        self.assertIn('time_end', last_result)
 
     def test_runner_python_unittest(self):
         runnable = nrunner.Runnable('python-unittest', 'unittest.TestCase')


### PR DESCRIPTION
The avocado.core.test.Test class provides a large number of
information on each state message that gets sent to the runner.  Among
those are some related to the execution time of each test.  That
information is consumed by the job and makes its way into the test
results.

Let's start providing information on the various nrunner based
runners, taking the time (pun not intended) to think if those are
really necessary or the responsibility of the runner.  For instance,
the "time_elapsed" information is probably best calculated by the job
and not by each individual runner.

Signed-off-by: Cleber Rosa <crosa@redhat.com>