### PR TITLE
Docs: improve the docstring about the parser argument

### DIFF
--- a/avocado/plugins/diff.py
+++ b/avocado/plugins/diff.py
@@ -52,7 +52,8 @@ class Diff(CLICmd):
         """
         Add the subparser for the diff action.
 
-        :param parser: Main test runner parser.
+        :param parser: The Avocado command line application parser
+        :type parser: :class:`avocado.core.parser.ArgumentParser`
         """
         parser = super(Diff, self).configure(parser)
 

--- a/avocado/plugins/list.py
+++ b/avocado/plugins/list.py
@@ -153,7 +153,8 @@ class List(CLICmd):
         """
         Add the subparser for the list action.
 
-        :param parser: Main test runner parser.
+        :param parser: The Avocado command line application parser
+        :type parser: :class:`avocado.core.parser.ArgumentParser`
         """
         parser = super(List, self).configure(parser)
         parser.add_argument('references', type=str, default=[], nargs='*',

--- a/avocado/plugins/sysinfo.py
+++ b/avocado/plugins/sysinfo.py
@@ -61,7 +61,8 @@ class SysInfo(CLICmd):
         """
         Add the subparser for the run action.
 
-        :param parser: Main test runner parser.
+        :param parser: The Avocado command line application parser
+        :type parser: :class:`avocado.core.parser.ArgumentParser`
         """
         parser = super(SysInfo, self).configure(parser)
         parser.add_argument('sysinfodir', type=str,


### PR DESCRIPTION
The command line parser is really the entire "avocado" command line
parser, and not limited to the "test running" aspects.  The original
text is not wrong, but a bit misleading.

While at it, let's reduce the possible confusion that may be caused by
the `avocado.core.parser` module having two similar classes, with very
different origins, and give the right type of the parser argument to
the configure method.

Signed-off-by: Cleber Rosa <crosa@redhat.com>