### PR TITLE
Tests execution and temporary dir fixes

### DIFF
--- a/selftests/functional/test_plugin_jobscripts.py
+++ b/selftests/functional/test_plugin_jobscripts.py
@@ -42,7 +42,7 @@ class JobScriptsTest(unittest.TestCase):
 
     def setUp(self):
         prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.TemporaryDirectory(prefix)
+        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
         self.pre_dir = os.path.join(self.tmpdir.name, 'pre.d')
         os.mkdir(self.pre_dir)
         self.post_dir = os.path.join(self.tmpdir.name, 'post.d')

--- a/selftests/functional/test_replay_basic.py
+++ b/selftests/functional/test_replay_basic.py
@@ -13,7 +13,7 @@ class ReplayTests(unittest.TestCase):
 
     def setUp(self):
         prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.TemporaryDirectory(prefix)
+        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
         cmd_line = ('%s run passtest.py '
                     '-m examples/tests/sleeptest.py.data/sleeptest.yaml '
                     '--job-results-dir %s --sysinfo=off --json -'

--- a/selftests/functional/test_replay_external_runner.py
+++ b/selftests/functional/test_replay_external_runner.py
@@ -14,7 +14,7 @@ class ReplayExtRunnerTests(unittest.TestCase):
 
     def setUp(self):
         prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.TemporaryDirectory(prefix)
+        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
         test = script.make_script(os.path.join(self.tmpdir.name, 'test'), 'exit 0')
         cmd_line = ('%s run %s '
                     '-m examples/tests/sleeptest.py.data/sleeptest.yaml '

--- a/selftests/run
+++ b/selftests/run
@@ -26,9 +26,7 @@ class MyResult(unittest.TextTestResult):
         data_dir._tmp_tracker.unittest_refresh_dir_tracker()
         # Rung garbage collection (run __del__s) and force-sync disk
         gc.collect()
-        subprocess.Popen("sync", stdin=subprocess.PIPE,
-                         stdout=subprocess.PIPE,
-                         stderr=subprocess.PIPE).communicate()
+        os.sync()
         # ... and check whether some dirs were left behind
         dir_check = subprocess.Popen([sys.executable, CHECK_TMP_DIRS], stdout=subprocess.PIPE,
                                      stderr=subprocess.STDOUT)

--- a/selftests/run
+++ b/selftests/run
@@ -18,26 +18,41 @@ CHECK_TMP_DIRS = os.path.abspath(os.path.join(os.path.dirname(__file__),
                                               "check_tmp_dirs"))
 
 
-class MyResult(unittest.TextTestResult):
+class CheckTmpDirResult(unittest.TextTestResult):
+
+    """
+    Checks after every single test if temp dirs were left in the filesystem
+    """
+
     def stopTest(self, test):
-        # stopTest
-        super(MyResult, self).stopTest(test)
+        # stopTestRun
+        super(CheckTmpDirResult, self).stopTest(test)
         # Destroy the data_dir.get_tmpdir ...
         data_dir._tmp_tracker.unittest_refresh_dir_tracker()
         # Rung garbage collection (run __del__s) and force-sync disk
         gc.collect()
         os.sync()
+        test_name = str(test)
+        try:
+            test.tearDown()
+        except Exception:
+            pass
         # ... and check whether some dirs were left behind
         dir_check = subprocess.Popen([sys.executable, CHECK_TMP_DIRS], stdout=subprocess.PIPE,
                                      stderr=subprocess.STDOUT)
         if dir_check.wait():
             raise AssertionError("Test %s left some tmp files behind:\n%s"
-                                 % (test, dir_check.stdout.read().decode()))
+                                 % (test_name, dir_check.stdout.read().decode()))
 
 
 if __name__ == '__main__':
+    if os.environ.get('AVOCADO_CHECK_TMPDIR', False):
+        result_class = CheckTmpDirResult
+    else:
+        result_class = unittest.TextTestResult
+
     runner = unittest.TextTestRunner(failfast=not os.environ.get("SELF_CHECK_CONTINUOUS"),
-                                     verbosity=1, resultclass=MyResult)
+                                     verbosity=1, resultclass=result_class)
     result = runner.run(test_suite())
     if result.failures or result.errors:
         sys.exit(1)

--- a/selftests/run
+++ b/selftests/run
@@ -34,7 +34,7 @@ class MyResult(unittest.TextTestResult):
                                      stderr=subprocess.STDOUT)
         if dir_check.wait():
             raise AssertionError("Test %s left some tmp files behind:\n%s"
-                                 % (test, dir_check.stdout.read()))
+                                 % (test, dir_check.stdout.read().decode()))
 
 
 if __name__ == '__main__':

--- a/selftests/unit/test_nrunner.py
+++ b/selftests/unit/test_nrunner.py
@@ -137,7 +137,7 @@ class RunnableToRecipe(unittest.TestCase):
 
     def setUp(self):
         prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.TemporaryDirectory(prefix)
+        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
 
     def test_runnable_to_recipe_noop(self):
         runnable = nrunner.Runnable('noop', None)


### PR DESCRIPTION
This PR should fix leftover and badly named temporary directories as part of a `make check-full` command.