### PR TITLE
resolver: add support for filters for avocado-instrumented

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -30,6 +30,7 @@ from . import data_dir
 from . import output
 from . import test
 from . import safeloader
+from .references import reference_split
 from ..utils import stacktrace
 from .settings import settings
 from .output import LOG_UI
@@ -520,12 +521,9 @@ class FileLoader(TestLoader):
                          '__main__.py')
 
         # Look for filename:test_method pattern
-        subtests_filter = None
-        if ':' in reference:
-            _reference, _subtests_filter = reference.split(':', 1)
-            if os.path.exists(_reference):  # otherwise it's ':' in the file name
-                reference = _reference
-                subtests_filter = re.compile(_subtests_filter)
+        reference, subtests_filter = reference_split(reference)
+        if subtests_filter is not None:
+            subtests_filter = re.compile(subtests_filter)
 
         if not os.path.isdir(reference):  # Single file
             return self._make_tests(reference, which_tests == DiscoverMode.ALL,

--- a/avocado/core/references.py
+++ b/avocado/core/references.py
@@ -1,0 +1,37 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2019
+# Authors: Lucas Meneghel Rodrigues <lmr@redhat.com>
+#          Ruda Moura <rmoura@redhat.com>
+
+"""
+Test loader module.
+"""
+
+import os
+
+
+def reference_split(reference):
+    '''
+    Splits a test reference into a path and additional info
+
+    This should be used depedent on the specific type of resolver.  If
+    a resolver is not expected to support multiple test references inside
+    a given file, then this is not suitable.
+
+    :returns: (path, additional_info)
+    :type: (str, str or None)
+    '''
+    if not os.path.exists(reference):
+        if ':' in reference:
+            return reference.rsplit(':', 1)
+    return (reference, None)

--- a/avocado/core/resolver.py
+++ b/avocado/core/resolver.py
@@ -72,6 +72,12 @@ class ReferenceResolution:
         self.info = info
         self.origin = origin
 
+    def __repr__(self):
+        fmt = ('<ReferenceResolution reference="{}" result="{}" '
+               'resolutions="{}" info="{}" origin="{}">')
+        return fmt.format(self.reference, self.result, self.resolutions,
+                          self.info, self.origin)
+
 
 class Resolver(EnabledExtensionManager):
 

--- a/avocado/plugins/resolvers.py
+++ b/avocado/plugins/resolvers.py
@@ -24,6 +24,7 @@ from avocado.core.safeloader import find_python_unittests
 from avocado.core.resolver import ReferenceResolution
 from avocado.core.resolver import ReferenceResolutionResult
 from avocado.core.resolver import check_file
+from avocado.core.references import reference_split
 from avocado.core.nrunner import Runnable
 
 
@@ -88,10 +89,7 @@ class AvocadoInstrumentedResolver(Resolver):
 
     @staticmethod
     def resolve(reference):
-        if ':' in reference:
-            module_path, _ = reference.split(':', 1)
-        else:
-            module_path = reference
+        module_path, _ = reference_split(reference)
 
         criteria_check = check_file(module_path, reference)
         if criteria_check is not True:

--- a/docs/source/ReferenceGuide.rst
+++ b/docs/source/ReferenceGuide.rst
@@ -40,6 +40,25 @@ it is completely abstract to the other components of Avocado.
    by command-line switches like `--external-runner`, which
    completelly changes the meaning of the given strings.
 
+Conventions
+~~~~~~~~~~~
+
+Even though each resolver implementation is free to interpret a
+reference string as it sees fit, it's a good idea to set common user
+expectations.
+
+It's common for a single file to contain multiple tests.  In that
+case, information about the specific test to reference can be added
+after the filesystem location and a colon, that is, for the
+reference::
+
+  passtest.py:PassTest.test
+
+Unless a file with that exact name exists, most resolvers will split
+it into `passtest.py` as the filesystem path, and `PassTest.test` as
+an additional specification for the individual test.  It's also
+possible that some resolvers will support regular expressions and
+globs for the additional information component.
 
 Test Name
 ---------

--- a/selftests/unit/test_references.py
+++ b/selftests/unit/test_references.py
@@ -1,0 +1,24 @@
+import unittest
+
+from avocado.core import references
+
+
+class References(unittest.TestCase):
+
+    def test_split_file_does_not_exist(self):
+        not_a_file = '/should/be/safe/to/assume/it/is/not/a/file:foo'
+        path, additional_info = references.reference_split(not_a_file)
+        self.assertEqual(path, '/should/be/safe/to/assume/it/is/not/a/file')
+        self.assertEqual(additional_info, 'foo')
+
+    def test_split_file_exists(self):
+        file_name = 'file_contains_a_colon_:_indeed'
+        with unittest.mock.patch('avocado.core.references.os.path.exists',
+                                 return_value=True):
+            path, additional_info = references.reference_split(file_name)
+        self.assertEqual(path, file_name)
+        self.assertEqual(additional_info, None)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/selftests/unit/test_resolver.py
+++ b/selftests/unit/test_resolver.py
@@ -1,6 +1,10 @@
+import os
 import unittest
 
 from avocado.core import resolver
+from avocado.plugins.resolvers import AvocadoInstrumentedResolver
+
+from .. import BASEDIR
 
 
 class ReferenceResolution(unittest.TestCase):
@@ -24,6 +28,43 @@ class ReferenceResolution(unittest.TestCase):
             resolver.ReferenceResolutionResult.NOTFOUND)
         self.assertEqual(len(resolution.resolutions), 0,
                          "Unexpected resolutions found")
+
+
+class AvocadoInstrumented(unittest.TestCase):
+
+    def test_passtest(self):
+        passtest = os.path.join(BASEDIR, 'examples', 'tests', 'passtest.py')
+        test = 'PassTest.test'
+        uri = '%s:%s' % (passtest, test)
+        res = AvocadoInstrumentedResolver().resolve(passtest)
+        self.assertEqual(res.reference, passtest)
+        self.assertEqual(res.result, resolver.ReferenceResolutionResult.SUCCESS)
+        self.assertIsNone(res.info)
+        self.assertIsNone(res.origin)
+        self.assertEqual(len(res.resolutions), 1)
+        resolution = res.resolutions[0]
+        self.assertEqual(resolution.kind, 'avocado-instrumented')
+        self.assertEqual(resolution.uri, uri)
+        self.assertEqual(resolution.args, ())
+        self.assertEqual(resolution.kwargs, {})
+        self.assertEqual(resolution.tags, {'fast': None})
+
+    def test_passtest_filter_found(self):
+        passtest = os.path.join(BASEDIR, 'examples', 'tests', 'passtest.py')
+        test_filter = 'test'
+        reference = '%s:%s' % (passtest, test_filter)
+        res = AvocadoInstrumentedResolver().resolve(reference)
+        self.assertEqual(res.reference, reference)
+        self.assertEqual(res.result, resolver.ReferenceResolutionResult.SUCCESS)
+        self.assertEqual(len(res.resolutions), 1)
+
+    def test_passtest_filter_notfound(self):
+        passtest = os.path.join(BASEDIR, 'examples', 'tests', 'passtest.py')
+        test_filter = 'test_other'
+        reference = '%s:%s' % (passtest, test_filter)
+        res = AvocadoInstrumentedResolver().resolve(reference)
+        self.assertEqual(res.reference, reference)
+        self.assertEqual(res.result, resolver.ReferenceResolutionResult.NOTFOUND)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The loader code has support for filters, so that one can specificy a subset of tests with list/run.  Let's add the same feature to nlist/nrun, that is, to the resolver code.