### PR TITLE
Add initial support to 'assets fetch' command with a simple parser [v4]

### DIFF
--- a/avocado/plugins/assets.py
+++ b/avocado/plugins/assets.py
@@ -1,0 +1,259 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2019
+# Authors: Willian Rampazzo <willianr@redhat.com>
+
+"""
+Assets subcommand
+"""
+
+import ast
+import os
+
+from avocado.core import data_dir
+from avocado.core import exit_codes
+from avocado.core import safeloader
+from avocado.core.output import LOG_UI
+from avocado.core.plugin_interfaces import CLICmd
+from avocado.utils.asset import Asset
+from avocado.utils import data_structures
+
+
+class FetchAssetHandler(ast.NodeVisitor):
+    """
+    Handles the parsing of instrumented tests for `fetch_asset` statements.
+    """
+
+    PATTERN = 'fetch_asset'
+
+    def __init__(self, file_name):
+        self.file_name = file_name
+        self.asgmts = {}
+        self.calls = []
+
+        # hold current class and current method to make sure we have the
+        # correct context for the assignment statement.
+        # at this time, module constants and class attributes are discarded.
+        self.current_klass = None
+        self.current_method = None
+
+        # check if we have valid instrumented tests
+        # discards disabled tests
+        self.tests = safeloader.find_avocado_tests(self.file_name)[0]
+
+        # create Abstract Syntax Tree from test source file
+        with open(self.file_name) as source_file:
+            self.tree = ast.parse(source_file.read(), self.file_name)
+
+        # build list of keyword arguments from calls that match pattern
+        self.visit(self.tree)
+
+    def _parse_args(self, node):
+        """
+        Parse the AST fetch_asset node and build the arguments dictionary.
+        :param node: AST node to be evaluated
+        :type node: ast.Attribute
+        :returns: keywords and arguments from a fetch_asset call.
+        :rtype: dict
+        """
+        args = []
+        # variables to make lines shorter
+        cur_klass = self.current_klass
+        cur_method = self.current_method
+
+        # parse args from call
+        for arg in node.args:
+            # handle string args
+            if isinstance(arg, ast.Str):
+                args.append(arg.s)
+            # handle variable args
+            elif isinstance(arg, ast.Name):
+                # look for assignments at method
+                if arg.id in self.asgmts[cur_klass][cur_method]:
+                    args.append(self.asgmts[cur_klass][cur_method][arg.id])
+                # right now we support just one level of variable as argument,
+                # with a pure string assignment, in the same context,
+                # just like `name = 'file.zip'`
+                else:
+                    return None
+
+        # starts building the keywords dictionary for the asset.Asset()
+        # class constructor.
+        keywords = ["name", "asset_hash", "algorithm", "locations", "expire"]
+        fetch_args = dict(zip(keywords, args))
+
+        # parse keyword args for call
+        for kwarg in node.keywords:
+            # variable to make lines shorter
+            kword = kwarg.arg
+            # handle `keyword = string`
+            if isinstance(kwarg.value, ast.Str):
+                fetch_args[kword] = kwarg.value.s
+            # handle `keyword = variable`
+            elif isinstance(kwarg.value, ast.Name):
+                name = kwarg.value.id
+                # look for assignments at method
+                if name in self.asgmts[cur_klass][cur_method]:
+                    fetch_args[kword] = self.asgmts[cur_klass][cur_method][name]
+                # right now we support just one level of variable as argument,
+                # with a pure string assignment, in the same context,
+                # just like `name = 'file.zip'`
+                else:
+                    return None
+
+        # Fill empty keywords with None
+        for kword in keywords:
+            if kword not in fetch_args:
+                fetch_args[kword] = None
+
+        return fetch_args
+
+    def visit_ClassDef(self, node):  # pylint: disable=C0103
+        """
+        Visit ClassDef on AST and save current Class.
+        :param node: AST node to be evaluated
+        :type node: ast.*
+        """
+        if node.name in self.tests:
+            self.current_klass = node.name
+            self.asgmts[self.current_klass] = {}
+            self.generic_visit(node)
+
+    def visit_FunctionDef(self, node):  # pylint: disable=C0103
+        """
+        Visit FunctionDef on AST and save current method.
+        :param node: AST node to be evaluated
+        :type node: ast.*
+        """
+        # make sure we are into a class method and not a fuction
+        if self.current_klass:
+            self.current_method = node.name
+            self.asgmts[self.current_klass][self.current_method] = {}
+        self.generic_visit(node)
+
+    def visit_Assign(self, node):  # pylint: disable=C0103
+        """
+        Visit Assign on AST and build list of assignments that matches the
+        pattern pattern `name = string`.
+        :param node: AST node to be evaluated
+        :type node: ast.*
+        """
+        if isinstance(node.value, ast.Str):
+            # make sure we are into a class method, we are not supporting
+            # attributes and module constant assignments at this time
+            if self.current_klass and self.current_method:
+                # variables to make dictionary assignment line shorter
+                cur_klass = self.current_klass
+                cur_method = self.current_method
+                name = node.targets[0].id
+                self.asgmts[cur_klass][cur_method][name] = node.value.s
+        self.generic_visit(node)
+
+    def visit_Call(self, node):  # pylint: disable=C0103
+        """
+        Visit Calls on AST and build list of calls that matches the pattern.
+        :param node: AST node to be evaluated
+        :type node: ast.*
+        """
+        # make sure we are into a class method
+        if self.current_klass and self.current_method:
+            if isinstance(node.func, ast.Attribute):
+                if self.PATTERN in node.func.attr:
+                    call = self._parse_args(node)
+                    if call:
+                        self.calls.append(call)
+
+
+def fetch_assets(test_file):
+    """
+    Fetches the assets based on keywords listed on FetchAssetHandler.calls.
+    :param test_file: File name of instrumented test to be evaluated
+    :type test_file: str
+    :returns: list of names that were successfuly fetched and list of
+    fails.
+    """
+    cache_dirs = data_dir.get_cache_dirs()
+    success = []
+    fail = []
+    handler = FetchAssetHandler(test_file)
+    for call in handler.calls:
+        expire = call.pop('expire', None)
+        if expire is not None:
+            expire = data_structures.time_to_seconds(str(expire))
+        try:
+            # make dictionary unpacking compatible with python 3.4 as it does
+            # not support constructions like:
+            # Asset(**call, cache_dirs=cache_dirs, expire=expire)
+            call['cache_dirs'] = cache_dirs
+            call['expire'] = expire
+            asset_obj = Asset(**call)
+            asset_obj.fetch()
+            success.append(call['name'])
+        except EnvironmentError as failed:
+            fail.append(failed)
+    return success, fail
+
+
+class Assets(CLICmd):
+    """
+    Implements the avocado 'assets' subcommand
+    """
+    name = 'assets'
+    description = 'Manage assets'
+
+    def configure(self, parser):
+        """
+        Add the subparser for the assets action.
+
+        :param parser: The Avocado command line application parser
+        :type parser: :class:`avocado.core.parser.ArgumentParser`
+        """
+        parser = super(Assets, self).configure(parser)
+
+        subcommands = parser.add_subparsers(dest='assets_subcommand')
+        subcommands.required = True
+
+        fetch_subcommand_parser = subcommands.add_parser(
+            'fetch',
+            help='Fetch assets from test source or config file if it\'s not'
+            ' already in the cache')
+        fetch_subcommand_parser.add_argument('references', nargs='+',
+                                             metavar='AVOCADO_INSTRUMENTED',
+                                             help='Path to avocado'
+                                             ' instrumented test')
+
+    def run(self, config):
+        subcommand = config.get('assets_subcommand')
+        # we want to let the command caller knows about fails
+        exitcode = exit_codes.AVOCADO_ALL_OK
+
+        if subcommand == 'fetch':
+            # fetch assets from instrumented tests
+            for test_file in config['references']:
+                if os.path.isfile(test_file) and test_file.endswith('.py'):
+                    LOG_UI.debug('Fetching assets from %s.', test_file)
+                    success, fail = fetch_assets(test_file)
+
+                    for asset_file in success:
+                        LOG_UI.debug('  File %s fetched or already on'
+                                     ' cache.', asset_file)
+                    for asset_file in fail:
+                        LOG_UI.error(asset_file)
+
+                    if fail:
+                        exitcode |= exit_codes.AVOCADO_FAIL
+                else:
+                    LOG_UI.warning('No such file or file not supported: %s',
+                                   test_file)
+                    exitcode |= exit_codes.AVOCADO_FAIL
+
+        return exitcode

--- a/selftests/functional/test_plugin_assets.py
+++ b/selftests/functional/test_plugin_assets.py
@@ -1,0 +1,240 @@
+"""
+Assets plugin functional tests
+"""
+
+
+import os
+import tempfile
+import unittest
+import warnings
+
+from avocado.core import exit_codes
+from avocado.utils import process
+from .. import AVOCADO, temp_dir_prefix
+
+
+TEST_TEMPLATE = r"""
+from avocado import Test
+
+MODULE_CONST = "let's break the code"
+
+def break_it():
+    fake_test = Test()
+    foo = "bar"
+    bar = "foo"
+    fake_test.fetch_asset(foo, bar)
+
+class FetchAssets(Test):
+    def test_fetch_assets(self):
+{content}
+"""
+
+NOT_TEST_TEMPLATE = r"""
+MODULE_CONST = "let's break the code"
+
+def break_it():
+    foo = "bar"
+    bar = "foo"
+    return foo, bar
+
+class FetchAssets:
+    def test_fetch_assets(self):
+{content}
+"""
+
+
+def get_temporary_config(args):
+    """
+    Creates a temporary bogus config file
+    returns base directory, dictionary containing the temporary data dir
+    paths and the configuration file contain those same settings
+    """
+    prefix = temp_dir_prefix(__name__, args, 'setUp')
+    base_dir = tempfile.TemporaryDirectory(prefix=prefix)
+    test_dir = os.path.join(base_dir.name, 'tests')
+    os.mkdir(test_dir)
+    data_directory = os.path.join(base_dir.name, 'data')
+    os.mkdir(data_directory)
+    cache_dir = os.path.join(data_directory, 'cache')
+    os.mkdir(cache_dir)
+    mapping = {'base_dir': base_dir.name,
+               'test_dir': test_dir,
+               'data_dir': data_directory,
+               'logs_dir': os.path.join(base_dir.name, 'logs'),
+               'cache_dir': cache_dir}
+    temp_settings = ('[datadir.paths]\n'
+                     'base_dir = %(base_dir)s\n'
+                     'test_dir = %(test_dir)s\n'
+                     'data_dir = %(data_dir)s\n'
+                     'logs_dir = %(logs_dir)s\n') % mapping
+    config_file = tempfile.NamedTemporaryFile('w', delete=False)
+    config_file.write(temp_settings)
+    config_file.close()
+    return base_dir, mapping, config_file
+
+
+class AssetsFetchSuccess(unittest.TestCase):
+    """
+    Assets fetch with success fuctional test class
+    """
+
+    def setUp(self):
+        """
+        Setup configuration file and folders
+        """
+        warnings.simplefilter("ignore", ResourceWarning)
+        self.base_dir, self.mapping, self.config_file = (
+            get_temporary_config(self))
+        asset_dir = os.path.join(self.mapping['cache_dir'], 'by_location',
+                                 '14b59763b6863a2760ae804cf988dfcf4258d9b0')
+        os.makedirs(asset_dir)
+        open(os.path.join(asset_dir, 'hello-2.9.tar.gz'), "w").close()
+
+    def test_asset_fetch_success(self):
+        """
+        Test ends successfully
+        Asset is fetched from test source
+        """
+        fetch_content = r"""
+        self.hello = self.fetch_asset(
+            'hello-2.9.tar.gz',
+            locations='https://mirrors.kernel.org/gnu/hello/hello-2.9.tar.gz')
+        """
+        test_content = TEST_TEMPLATE.format(content=fetch_content)
+        test_file = tempfile.NamedTemporaryFile(suffix=".py", delete=False)
+        test_file.write(test_content.encode())
+        test_file.close()
+
+        expected_output = "Fetching assets from %s.\n" \
+            "  File hello-2.9.tar.gz fetched or already on cache.\n" \
+            % test_file.name
+        expected_rc = exit_codes.AVOCADO_ALL_OK
+
+        cmd_line = "%s --config %s assets fetch %s " % (AVOCADO,
+                                                        self.config_file.name,
+                                                        test_file.name)
+        result = process.run(cmd_line)
+        os.remove(test_file.name)
+
+        self.assertEqual(expected_rc, result.exit_status)
+        self.assertIn(expected_output, result.stdout_text)
+
+
+class AssetsPlugin(unittest.TestCase):
+    """
+    Main assets plugin fuctional test class
+    """
+
+    def setUp(self):
+        """
+        Setup configuration file and folders
+        """
+        warnings.simplefilter("ignore", ResourceWarning)
+        self.base_dir, self.mapping, self.config_file = (
+            get_temporary_config(self))
+
+    def test_asset_fetch(self):
+        """
+        Command ends with warning
+        Exercise `avocado assets fetch` without any argument
+        """
+        expected_stderr = "avocado assets fetch: error: the following" \
+            " arguments are required: AVOCADO_INSTRUMENTED\n"
+        expected_rc = exit_codes.AVOCADO_FAIL
+
+        cmd_line = "%s --config %s assets fetch" % (AVOCADO,
+                                                    self.config_file.name)
+        result = process.run(cmd_line, ignore_status=True)
+
+        self.assertEqual(expected_rc, result.exit_status)
+        self.assertIn(expected_stderr, result.stderr_text)
+
+    def test_asset_fetch_unsupported_class(self):
+        """
+        Test ends with warning
+        No supported class into the test file
+        """
+        fetch_content = r"""
+        self.hello = self.fetch_asset(
+            'hello-2.9.tar.gz',
+            locations='https://mirrors.kernel.org/gnu/hello/hello-2.9.tar.gz')
+        """
+        test_content = NOT_TEST_TEMPLATE.format(content=fetch_content)
+        test_file = tempfile.NamedTemporaryFile(suffix=".py", delete=False)
+        test_file.write(test_content.encode())
+        test_file.close()
+
+        expected_stdout = "Fetching assets from %s.\n" % test_file.name
+        expected_rc = exit_codes.AVOCADO_ALL_OK
+
+        cmd_line = "%s --config %s assets fetch %s " % (AVOCADO,
+                                                        self.config_file.name,
+                                                        test_file.name)
+        result = process.run(cmd_line, ignore_status=True)
+        os.remove(test_file.name)
+
+        self.assertEqual(expected_rc, result.exit_status)
+        self.assertIn(expected_stdout, result.stdout_text)
+
+    def test_asset_fetch_unsupported_file(self):
+        """
+        Test ends with warning
+        No supported test file
+        """
+        fetch_content = r"""
+        self.hello = self.fetch_asset(
+            'hello-2.9.tar.gz',
+            locations='https://mirrors.kernel.org/gnu/hello/hello-2.9.tar.gz')
+        """
+        test_content = TEST_TEMPLATE.format(content=fetch_content)
+        test_file = tempfile.NamedTemporaryFile(suffix=".c", delete=False)
+        test_file.write(test_content.encode())
+        test_file.close()
+
+        expected_stderr = "No such file or file not supported: %s\n" \
+            % test_file.name
+        expected_rc = exit_codes.AVOCADO_FAIL
+
+        cmd_line = "%s --config %s assets fetch %s " % (AVOCADO,
+                                                        self.config_file.name,
+                                                        test_file.name)
+        result = process.run(cmd_line, ignore_status=True)
+        os.remove(test_file.name)
+
+        self.assertEqual(expected_rc, result.exit_status)
+        self.assertIn(expected_stderr, result.stderr_text)
+
+    def test_asset_fetch_invalid_url(self):
+        """
+        Test ends with warning
+        Problems while fetching asset from test source
+        """
+        fetch_content = r"""
+        self.hello = self.fetch_asset(
+            'hello-2.9.tar.gz',
+            locations='http://localhost/hello-2.9.tar.gz')
+        """
+        test_content = TEST_TEMPLATE.format(content=fetch_content)
+        test_file = tempfile.NamedTemporaryFile(suffix=".py", delete=False)
+        test_file.write(test_content.encode())
+        test_file.close()
+
+        expected_stderr = "Failed to fetch hello-2.9.tar.gz.\n"
+        expected_rc = exit_codes.AVOCADO_FAIL
+
+        cmd_line = "%s --config %s assets fetch %s " % (AVOCADO,
+                                                        self.config_file.name,
+                                                        test_file.name)
+        result = process.run(cmd_line, ignore_status=True)
+        os.remove(test_file.name)
+
+        self.assertEqual(expected_rc, result.exit_status)
+        self.assertIn(expected_stderr, result.stderr_text)
+
+    def tearDown(self):
+        os.remove(self.config_file.name)
+        self.base_dir.cleanup()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/selftests/unit/test_plugin_assets.py
+++ b/selftests/unit/test_plugin_assets.py
@@ -1,0 +1,235 @@
+"""
+Assets plugin unit tests
+"""
+
+import ast
+import unittest
+
+from unittest.mock import patch, mock_open
+
+from avocado.plugins import assets
+
+
+class AssetsPlugin(unittest.TestCase):
+    """
+    Unit tesits for Assets Plugin
+    """
+
+    @patch('avocado.plugins.assets.FetchAssetHandler')
+    def test_fetch_assets_sucess_fail(self, mocked_fetch_asset_handler):
+        """
+        Excersise a normal fetch for a success and a fail assets.
+        """
+        mocked_fetch_asset_handler.return_value.calls = [
+            {'name': 'success.tar.gz',
+             'locations': 'https://localhost/success.tar.gz',
+             'asset_hash': None, 'algorithm': None, 'expire': None},
+            {'name': 'fail.tar.gz',
+             'locations': 'https://localhost/fail.tar.gz',
+             'asset_hash': None, 'algorithm': None, 'expire': None},
+        ]
+        with patch('avocado.plugins.assets.Asset') as mocked_asset:
+            mocked_asset.return_value.fetch.side_effect = [
+                True,
+                OSError('Failed to fetch fail.tar.gz.')]
+            success, fail = assets.fetch_assets('test.py')
+        expected_success = ['success.tar.gz']
+        expected_fail_exception = OSError
+        self.assertEqual(expected_success, success)
+        self.assertTrue(isinstance(fail[0], expected_fail_exception))
+
+    @patch('avocado.plugins.assets.FetchAssetHandler')
+    def test_fetch_assets_sucess(self, mocked_fetch_asset_handler):
+        """
+        Excersise a normal fetch for a success asset.
+        """
+        mocked_fetch_asset_handler.return_value.calls = [
+            {'name': 'success.tar.gz',
+             'locations': 'https://localhost/success.tar.gz',
+             'asset_hash': None, 'algorithm': None, 'expire': None},
+        ]
+        with patch('avocado.plugins.assets.Asset') as mocked_asset:
+            mocked_asset.return_value.fetch.side_effect = [
+                True]
+            success, fail = assets.fetch_assets('test.py')
+        expected_success = ['success.tar.gz']
+        expected_fail = []
+        self.assertEqual(expected_success, success)
+        self.assertEqual(fail, expected_fail)
+
+    @patch('avocado.plugins.assets.FetchAssetHandler')
+    def test_fetch_assets_fail(self, mocked_fetch_asset_handler):
+        """
+        Excersise a normal fetch for a fail asset.
+        """
+        mocked_fetch_asset_handler.return_value.calls = [
+            {'name': 'fail.tar.gz',
+             'locations': 'https://localhost/fail.tar.gz',
+             'asset_hash': None, 'algorithm': None, 'expire': None},
+        ]
+        with patch('avocado.plugins.assets.Asset') as mocked_asset:
+            mocked_asset.return_value.fetch.side_effect = [
+                OSError('Failed to fetch fail.tar.gz.')]
+            success, fail = assets.fetch_assets('test.py')
+        expected_success = []
+        expected_fail_exception = OSError
+        self.assertEqual(expected_success, success)
+        self.assertTrue(isinstance(fail[0], expected_fail_exception))
+
+    @patch('avocado.plugins.assets.FetchAssetHandler')
+    def test_fetch_assets_empty_calls(self, mocked_fetch_asset_handler):
+        """
+        Excersise a normal fetch_assets for an empty `calls` variable.
+        """
+        mocked_fetch_asset_handler.return_value.calls = []
+        success, fail = assets.fetch_assets('test.py')
+        expected_success = []
+        expected_fail = []
+        self.assertEqual(expected_success, success)
+        self.assertEqual(expected_fail, fail)
+
+
+TEST_CLASS_SOURCE = r"""
+from avocado import Test
+
+class FetchAssets(Test):
+    def test_fetch_assets(self):
+        foo = "bar"
+"""
+
+NOT_TEST_CLASS_SOURCE = r"""
+from avocado import Test
+
+class FetchAssets:
+    def test_fetch_assets(self):
+        foo = "bar"
+"""
+
+
+class AssetsClass(unittest.TestCase):
+    """
+    Unit tests for Asset Class
+    """
+
+    @patch('avocado.plugins.assets.safeloader')
+    def test_visit_classdef_valid_class(self, mocked_safeloader):
+        """
+        Make sure that current_klass is correctly assigned with a class name
+        """
+        mocked_safeloader.find_avocado_tests.return_value = [
+            'FetchAssets'
+        ]
+        tree = ast.parse(TEST_CLASS_SOURCE)
+        node = tree.body[1]
+        with patch("builtins.open", mock_open(read_data=TEST_CLASS_SOURCE)):
+            with patch.object(assets.ast, "parse"):
+                with patch.object(assets.FetchAssetHandler, "visit"):
+                    with patch.object(assets.FetchAssetHandler,
+                                      "generic_visit"):
+                        handler = assets.FetchAssetHandler("fake_file.py")
+                        handler.visit_ClassDef(node)
+                        self.assertEqual(handler.current_klass, 'FetchAssets')
+
+    @patch('avocado.plugins.assets.safeloader')
+    def test_visit_classdef_invalid_class(self, mocked_safeloader):
+        """
+        Make sure that current_klass is not assigned with a class name
+        """
+        mocked_safeloader.find_avocado_tests.return_value = [[]]
+        tree = ast.parse(NOT_TEST_CLASS_SOURCE)
+        node = tree.body[1]
+        with patch("builtins.open", mock_open(read_data=NOT_TEST_CLASS_SOURCE)):
+            with patch.object(assets.ast, "parse"):
+                with patch.object(assets.FetchAssetHandler, "visit"):
+                    with patch.object(assets.FetchAssetHandler,
+                                      "generic_visit"):
+                        handler = assets.FetchAssetHandler("fake_file.py")
+                        handler.visit_ClassDef(node)
+                        self.assertTrue((handler.current_klass is None))
+
+    @patch('avocado.plugins.assets.safeloader')
+    def test_visit_fuctiondef_valid_class(self, mocked_safeloader):
+        """
+        Make sure that current_klass is correctly assigned with a class name
+        """
+        mocked_safeloader.find_avocado_tests.return_value = [
+            'FetchAssets'
+        ]
+        tree = ast.parse(TEST_CLASS_SOURCE)
+        node_class = tree.body[1]
+        node_function = tree.body[1].body[0]
+        expected_method = "test_fetch_assets"
+        with patch("builtins.open", mock_open(read_data=TEST_CLASS_SOURCE)):
+            with patch.object(assets.ast, "parse"):
+                with patch.object(assets.FetchAssetHandler, "visit"):
+                    with patch.object(assets.FetchAssetHandler,
+                                      "generic_visit"):
+                        handler = assets.FetchAssetHandler("fake_file.py")
+                        handler.visit_ClassDef(node_class)
+                        handler.visit_FunctionDef(node_function)
+                        self.assertEqual(handler.current_method, expected_method)
+
+    @patch('avocado.plugins.assets.safeloader')
+    def test_visit_fuctiondef_invalid_class(self, mocked_safeloader):
+        """
+        Make sure that current_klass is not assigned with a class name
+        """
+        mocked_safeloader.find_avocado_tests.return_value = [[]]
+        tree = ast.parse(NOT_TEST_CLASS_SOURCE)
+        node = tree.body[1].body[0]
+        with patch("builtins.open", mock_open(read_data=NOT_TEST_CLASS_SOURCE)):
+            with patch.object(assets.ast, "parse"):
+                with patch.object(assets.FetchAssetHandler, "visit"):
+                    with patch.object(assets.FetchAssetHandler,
+                                      "generic_visit"):
+                        handler = assets.FetchAssetHandler("fake_file.py")
+                        handler.visit_FunctionDef(node)
+                        self.assertTrue((handler.current_method is None))
+
+    @patch('avocado.plugins.assets.safeloader')
+    def test_visit_assign_valid_class_method(self, mocked_safeloader):
+        """
+        Make sure that current_klass is correctly assigned with a class name
+        """
+        mocked_safeloader.find_avocado_tests.return_value = [
+            'FetchAssets'
+        ]
+        tree = ast.parse(TEST_CLASS_SOURCE)
+        node_class = tree.body[1]
+        node_function = tree.body[1].body[0]
+        node_assign = tree.body[1].body[0].body[0]
+        expected_assign = "bar"
+        with patch("builtins.open", mock_open(read_data=TEST_CLASS_SOURCE)):
+            with patch.object(assets.ast, "parse"):
+                with patch.object(assets.FetchAssetHandler, "visit"):
+                    with patch.object(assets.FetchAssetHandler,
+                                      "generic_visit"):
+                        handler = assets.FetchAssetHandler("fake_file.py")
+                        handler.visit_ClassDef(node_class)
+                        handler.visit_FunctionDef(node_function)
+                        handler.visit_Assign(node_assign)
+                        self.assertEqual(
+                            (handler.asgmts[handler.current_klass]
+                             [handler.current_method]['foo']),
+                            expected_assign)
+
+    @patch('avocado.plugins.assets.safeloader')
+    def test_visit_assign_invalid_class_method(self, mocked_safeloader):
+        """
+        Make sure that current_klass is not assigned with a class name
+        """
+        mocked_safeloader.find_avocado_tests.return_value = [[]]
+        tree = ast.parse(NOT_TEST_CLASS_SOURCE)
+        node = tree.body[1].body[0].body[0]
+        with patch("builtins.open", mock_open(read_data=NOT_TEST_CLASS_SOURCE)):
+            with patch.object(assets.ast, "parse"):
+                with patch.object(assets.FetchAssetHandler, "visit"):
+                    with patch.object(assets.FetchAssetHandler,
+                                      "generic_visit"):
+                        handler = assets.FetchAssetHandler("fake_file.py")
+                        handler.visit_Assign(node)
+                        self.assertTrue((handler.current_method is None))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -97,6 +97,7 @@ if __name__ == '__main__':
                   'nrun = avocado.plugins.nrun:NRun',
                   'vmimage = avocado.plugins.vmimage:VMimage',
                   'nlist = avocado.plugins.nlist:List',
+                  'assets = avocado.plugins.assets:Assets',
                   ],
               'avocado.plugins.job.prepost': [
                   'jobscripts = avocado.plugins.jobscripts:JobScripts',


### PR DESCRIPTION
Implements 'assets fetch' command that uses a parser on instrumented test source to find 'fetch_asset' calls composed of simple strings as parameters, or at least one level of variable in the same context
with a string assignment, and fetch those assets without running the test.

Signed-off-by: Willian Rampazzo <willianr@redhat.com>

---

Changes from v1 (#3333)

- Executing asset.Asset instead of an avocado test.
- Handling one level of variable string assignment.
- Fix lots of pylint messages.
- Changed the way the call is built to fit asset.Asset call.

Changes from v2 (#3337)

- Fix bug that incorrectly considered functions outside of the classes.
- Add command return codes.
- Move `fetch_assets` out of the node visitor class.
- Add functional tests.
- Add some unit tests. Some are still missing.

Changes from v3 (#3344)

- Create a new functional test class to allow the correct use of setup for the expected file in the test.
- Move `pattern` to class attribute.
- Relax return code when no supported test was found in the file.
- Improve help message.