### PR TITLE
Nrunner: runnable serialization

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -37,6 +37,15 @@ class Runnable:
         return fmt.format(self.kind, self.uri,
                           self.args, self.kwargs, self.tags)
 
+    def get_serializable_tags(self):
+        tags = {}
+        # sets are not serializable in json
+        for key, val in self.tags.items():
+            if isinstance(val, set):
+                val = list(val)
+            tags[key] = val
+        return tags
+
     def get_command_args(self):
         """
         Returns the command arguments that adhere to the runner interface
@@ -57,13 +66,7 @@ class Runnable:
             args.append(arg)
 
         if self.tags is not None:
-            tags = {}
-            # sets are not serializable in json
-            for key, val in self.tags.items():
-                if isinstance(val, set):
-                    val = list(val)
-                tags[key] = val
-            args.append('tags=json:%s' % json.dumps(tags))
+            args.append('tags=json:%s' % json.dumps(self.get_serializable_tags()))
 
         for key, val in self.kwargs.items():
             if not isinstance(val, str) or isinstance(val, int):
@@ -86,6 +89,11 @@ class Runnable:
             recipe['uri'] = self.uri
         if self.args is not None:
             recipe['args'] = self.args
+        kwargs = self.kwargs.copy()
+        if self.tags is not None:
+            kwargs['tags'] = self.get_serializable_tags()
+        if kwargs:
+            recipe['kwargs'] = kwargs
         return recipe
 
     def get_json(self):

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -112,7 +112,8 @@ def runnable_from_recipe(recipe_path):
         recipe = json.load(recipe_file)
     return Runnable(recipe.get('kind'),
                     recipe.get('uri'),
-                    *recipe.get('args', ()))
+                    *recipe.get('args', ()),
+                    **recipe.get('kwargs', {}))
 
 
 class BaseRunner:

--- a/examples/recipes/runnables/exec_sh_echo_env_var.json
+++ b/examples/recipes/runnables/exec_sh_echo_env_var.json
@@ -1,0 +1,1 @@
+{"kind": "exec", "uri": "/bin/sh", "args": ["-c", "/bin/echo $ENV_VAR"], "kwargs": {"ENV_VAR": "Hello world!"}}

--- a/selftests/functional/test_nrunner.py
+++ b/selftests/functional/test_nrunner.py
@@ -41,12 +41,15 @@ class RunnableRun(unittest.TestCase):
         self.assertIn(b"'returncode': 0", res.stdout)
         self.assertEqual(res.exit_status, exit_codes.AVOCADO_ALL_OK)
 
+    @unittest.skipUnless(os.path.exists('/bin/sh'),
+                         ('Executable "/bin/sh" used in recipe is not '
+                          'available in the system'))
     @unittest.skipUnless(os.path.exists('/bin/echo'),
                          ('Executable "/bin/echo" used in recipe is not '
                           'available in the system'))
     def test_recipe(self):
         recipe = os.path.join(BASEDIR, "examples", "recipes", "runnables",
-                              "exec_echo_no_newline.json")
+                              "exec_sh_echo_env_var.json")
         cmd = "%s runnable-run-recipe %s" % (AVOCADO, recipe)
         res = process.run(cmd, ignore_status=True)
         lines = res.stdout_text.splitlines()
@@ -58,7 +61,7 @@ class RunnableRun(unittest.TestCase):
             self.assertIn("'status': 'running'", first_status)
             self.assertIn("'time_start': ", first_status)
         self.assertIn("'status': 'finished'", final_status)
-        self.assertIn("'stdout': b'avocado'", final_status)
+        self.assertIn("'stdout': b'Hello world!\\n'", final_status)
         self.assertIn("'time_end': ", final_status)
         self.assertEqual(res.exit_status, exit_codes.AVOCADO_ALL_OK)
 

--- a/selftests/functional/test_nrunner.py
+++ b/selftests/functional/test_nrunner.py
@@ -1,8 +1,9 @@
 import os
 import sys
 import unittest
+import tempfile
 
-from .. import AVOCADO, BASEDIR
+from .. import AVOCADO, BASEDIR, temp_dir_prefix
 
 from avocado.utils import process
 from avocado.core import exit_codes
@@ -156,3 +157,24 @@ class TaskRun(unittest.TestCase):
         self.assertIn("'id': 3", first_status)
         self.assertIn("'status': 'finished'", final_status)
         self.assertEqual(res.exit_status, exit_codes.AVOCADO_ALL_OK)
+
+
+class ResolveSerializeRun(unittest.TestCase):
+    @unittest.skipUnless(os.path.exists('/bin/true'),
+                         ('Executable "/bin/true" used in test'))
+    def setUp(self):
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
+
+    def test(self):
+        cmd = "%s nlist --write-recipes-to-directory=%s -- /bin/true"
+        cmd %= (AVOCADO, self.tmpdir.name)
+        res = process.run(cmd)
+        self.assertEqual(b'exec-test /bin/true\n', res.stdout)
+        cmd = "%s runnable-run-recipe %s"
+        cmd %= (AVOCADO, os.path.join(self.tmpdir.name, '1.json'))
+        res = process.run(cmd)
+        self.assertIn(b"'status': 'pass'", res.stdout)
+
+    def tearDown(self):
+        self.tmpdir.cleanup()

--- a/selftests/unit/test_nrunner.py
+++ b/selftests/unit/test_nrunner.py
@@ -61,12 +61,14 @@ class Runnable(unittest.TestCase):
     def test_recipe_exec(self):
         open_mocked = unittest.mock.mock_open(
             read_data=('{"kind": "exec", "uri": "/bin/sh", '
-                       '"args": ["/etc/profile"]}'))
+                       '"args": ["/etc/profile"], '
+                       '"kwargs": {"TERM": "vt3270"}}'))
         with unittest.mock.patch("builtins.open", open_mocked):
             runnable = nrunner.runnable_from_recipe("fake_path")
         self.assertEqual(runnable.kind, "exec")
         self.assertEqual(runnable.uri, "/bin/sh")
         self.assertEqual(runnable.args, ("/etc/profile",))
+        self.assertEqual(runnable.kwargs, {"TERM": "vt3270"})
 
     def test_runnable_command_args(self):
         runnable = nrunner.Runnable('noop', 'uri', 'arg1', 'arg2')

--- a/selftests/unit/test_nrunner.py
+++ b/selftests/unit/test_nrunner.py
@@ -60,11 +60,13 @@ class Runnable(unittest.TestCase):
 
     def test_recipe_exec(self):
         open_mocked = unittest.mock.mock_open(
-            read_data='{"kind": "exec", "uri": "/bin/sh"}')
+            read_data=('{"kind": "exec", "uri": "/bin/sh", '
+                       '"args": ["/etc/profile"]}'))
         with unittest.mock.patch("builtins.open", open_mocked):
             runnable = nrunner.runnable_from_recipe("fake_path")
         self.assertEqual(runnable.kind, "exec")
         self.assertEqual(runnable.uri, "/bin/sh")
+        self.assertEqual(runnable.args, ("/etc/profile",))
 
     def test_runnable_command_args(self):
         runnable = nrunner.Runnable('noop', 'uri', 'arg1', 'arg2')


### PR DESCRIPTION
The current nrunner implementation already contains the concept of "recipes", which are file based representation of Runnables and Tasks.

This PR improves the state of serialization of Runnables, making it possible to create recipes straight from the reference resolution process.  Basic workflow is:

```
$ avocado nlist --write-recipes-to-directory=/tmp/ -- /bin/true /bin/false
exec-test /bin/true
exec-test /bin/false

$ avocado runnable-run-recipe /tmp/1.json
{'status': 'running', 'time_start': 1571866686.689068}
{'status': 'running'}
{'status': 'pass', 'returncode': 0, 'stdout': b'', 'stderr': b'', 'time_end': 1571866686.7021923}

$ avocado runnable-run-recipe /tmp/2.json
{'status': 'running', 'time_start': 1571866689.989536}
{'status': 'running'}
{'status': 'fail', 'returncode': 1, 'stdout': b'', 'stderr': b'', 'time_end': 1571866690.0093668}
```
