### PR TITLE
Refactor cpu library to adopt common naming convention across arch

### DIFF
--- a/avocado/utils/cpu.py
+++ b/avocado/utils/cpu.py
@@ -31,6 +31,10 @@ import random
 def _list_matches(content_list, pattern):
     """
     Checks if any item in list matches the specified pattern
+
+    :param content_list: list of item to match
+    :param pattern: pattern string to match from list
+    :rtype: `bool`
     """
     for content in content_list:
         match = re.search(pattern, content)
@@ -39,7 +43,7 @@ def _list_matches(content_list, pattern):
     return False
 
 
-def _get_cpu_info():
+def _get_info():
     """
     Returns info on the 1st CPU entry from /proc/cpuinfo as a list of lines
 
@@ -55,7 +59,7 @@ def _get_cpu_info():
     return cpuinfo
 
 
-def _get_cpu_status(cpu):
+def _get_status(cpu):
     """
     Check if a CPU is online or offline
 
@@ -79,7 +83,7 @@ def cpu_has_flags(flags):
     :returns: `bool` True if all the flags were found or False if not
     :rtype: `list`
     """
-    cpu_info = _get_cpu_info()
+    cpu_info = _get_info()
 
     if not isinstance(flags, list):
         flags = [flags]
@@ -90,23 +94,48 @@ def cpu_has_flags(flags):
     return True
 
 
-def get_cpu_vendor_name():
+def get_version():
+    """
+    Get cpu version
+
+    :returns: string cpu version of given machine
+    E:g:- 'i5-5300U' for intel and 'POWER9' for ibm machines
+    incase for unknown/unhandled machines return empty string
+    """
+    version_pattern = {'x86_64': rb'\s([\S,\d]+)\sCPU',
+                       'i386': rb'\s([\S,\d]+)\sCPU',
+                       'powerpc': rb'revision\s+:\s+(\S+)',
+                       's390': rb'.*machine\s=\s(\d+)'
+                       }
+    cpu_info = _get_info()
+    arch = get_arch()
+    try:
+        version_pattern[arch]
+    except KeyError as Err:
+        logging.warning("No pattern string for arch: %s\n Error: %s", arch, Err)
+        return None
+    for line in cpu_info:
+        version_out = re.findall(version_pattern[arch], line)
+        if version_out:
+            break
+    return version_out[0].decode('utf-8') if version_out[0] else ""
+
+
+def get_vendor():
     """
     Get the current cpu vendor name
 
-    :returns: string 'intel' or 'amd' or 'power7' depending on the
+    :returns: string 'intel' or 'amd' or 'ibm' depending on the
          current CPU architecture.
     :rtype: `string`
     """
     vendors_map = {
         'intel': (b"GenuineIntel", ),
         'amd': (b"AMD", ),
-        'power7': (b"POWER7", ),
-        'power8': (b"POWER8", ),
-        'power9': (b"POWER9", )
+        'ibm': (rb"POWER\d", rb"IBM/S390", ),
     }
 
-    cpu_info = _get_cpu_info()
+    cpu_info = _get_info()
     for vendor, identifiers in vendors_map.items():
         for identifier in identifiers:
             if _list_matches(cpu_info, identifier):
@@ -114,18 +143,13 @@ def get_cpu_vendor_name():
     return None
 
 
-def get_cpu_arch():
+def get_arch():
     """
     Work out which CPU architecture we're running on
     """
-    cpu_table = [(b'^cpu.*(RS64|POWER3|Broadband Engine)', 'power'),
-                 (b'^cpu.*POWER4', 'power4'),
-                 (b'^cpu.*POWER5', 'power5'),
-                 (b'^cpu.*POWER6', 'power6'),
-                 (b'^cpu.*POWER7', 'power7'),
-                 (b'^cpu.*POWER8', 'power8'),
-                 (b'^cpu.*POWER9', 'power9'),
-                 (b'^cpu.*PPC970', 'power970'),
+    cpu_table = [(b'^cpu.*(RS64|Broadband Engine)', 'powerpc'),
+                 (rb'^cpu.*POWER\d+', 'powerpc'),
+                 (b'^cpu.*PPC970', 'powerpc'),
                  (b'(ARM|^CPU implementer|^CPU part|^CPU variant'
                   b'|^Features|^BogoMIPS|^CPU revision)', 'arm'),
                  (b'(^cpu MHz dynamic|^cpu MHz static|^features'
@@ -134,7 +158,7 @@ def get_cpu_arch():
                  (b'^flags.*:.* lm .*', 'x86_64'),
                  (b'^flags', 'i386'),
                  (b'^hart\\s*: 1$', 'riscv')]
-    cpuinfo = _get_cpu_info()
+    cpuinfo = _get_info()
     for (pattern, arch) in cpu_table:
         if _list_matches(cpuinfo, pattern):
             if arch == 'arm':
@@ -152,7 +176,47 @@ def get_cpu_arch():
     return platform.machine()
 
 
-def cpu_online_list():
+def get_family():
+    """
+    to get family name of the cpu like broadwell, Haswell, power8, power9
+    """
+    family = None
+    arch = get_arch()
+    if arch == 'x86_64' or arch == 'i386':
+        if get_vendor() == 'amd':
+            raise NotImplementedError
+        try:
+            # refer below links for microarchitectures names
+            # https://en.wikipedia.org/wiki/List_of_Intel_CPU_microarchitectures
+            # https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/events/intel/core.c#n4613
+            with open('/sys/devices/cpu/caps/pmu_name', 'rb') as mico_arch:
+                family = mico_arch.read().decode('utf-8').strip('\n').lower()
+        except FileNotFoundError as err:
+            logging.warning("Could not find micro-architecture/family, Error: %s", err)
+    elif arch == 'powerpc':
+        res = []
+        try:
+            for line in _get_info():
+                res = re.findall(rb'cpu\s+:\s+(POWER\d+)', line)
+                if res:
+                    break
+            family = res[0].decode('utf-8').lower()
+        except IndexError as err:
+            logging.warning("Unable to parse cpu family %s", err)
+    elif arch == 's390':
+        zfamily_map = {'3906': 'z14',
+                       '8561': 'z15'
+                       }
+        try:
+            family = zfamily_map[get_version()].lower()
+        except KeyError as err:
+            logging.warning("Could not find family for %s\nError: %s", get_version(), err)
+    elif arch == 'arm':
+        raise NotImplementedError
+    return family
+
+
+def online_list():
     """
     Reports a list of indexes of the online cpus
     """
@@ -169,14 +233,14 @@ def cpu_online_list():
     return cpus
 
 
-def total_cpus_count():
+def total_count():
     """
     Return Number of Total cpus in the system including offline cpus
     """
     return os.sysconf('SC_NPROCESSORS_CONF')
 
 
-def online_cpus_count():
+def online_count():
     """
     Return Number of Online cpus in the system
     """
@@ -189,7 +253,7 @@ def online(cpu):
     """
     with open("/sys/devices/system/cpu/cpu%s/online" % cpu, "wb") as fd:
         fd.write(b'1')
-    if _get_cpu_status(cpu):
+    if _get_status(cpu):
         return 0
     return 1
 
@@ -200,19 +264,19 @@ def offline(cpu):
     """
     with open("/sys/devices/system/cpu/cpu%s/online" % cpu, "wb") as fd:
         fd.write(b'0')
-    if _get_cpu_status(cpu):
+    if _get_status(cpu):
         return 1
     return 0
 
 
-def get_cpuidle_state():
+def get_idle_state():
     """
     Get current cpu idle values
 
     :return: Dict of cpuidle states values for all cpus
     :rtype: Dict of dicts
     """
-    cpus_list = cpu_online_list()
+    cpus_list = online_list()
     states = range(len(glob.glob("/sys/devices/system/cpu/cpu0/cpuidle/state*")))
     cpu_idlestate = {}
     for cpu in cpus_list:
@@ -240,7 +304,7 @@ def _bool_to_binary(value):
     raise TypeError("Value is not a boolean: %s" % value)
 
 
-def set_cpuidle_state(state_number="all", disable=True, setstate=None):
+def set_idle_state(state_number="all", disable=True, setstate=None):
     """
     Set/Reset cpu idle states for all cpus
 
@@ -248,9 +312,9 @@ def set_cpuidle_state(state_number="all", disable=True, setstate=None):
     :param disable: whether to disable/enable given cpu idle state,
                     default is to disable (True). Must be a boolean value.
     :type disable: bool
-    :param setstate: cpuidle state value, output of `get_cpuidle_state()`
+    :param setstate: cpuidle state value, output of `get_idle_state()`
     """
-    cpus_list = cpu_online_list()
+    cpus_list = online_list()
     if not setstate:
         states = []
         if state_number == 'all':
@@ -278,7 +342,7 @@ def set_cpuidle_state(state_number="all", disable=True, setstate=None):
                                     "for state %s:\n%s", cpu, state_no, err)
 
 
-def set_cpufreq_governor(governor="random"):
+def set_freq_governor(governor="random"):
     """
     To change the given cpu frequency governor
 
@@ -287,14 +351,14 @@ def set_cpufreq_governor(governor="random"):
     """
     avl_gov_file = "/sys/devices/system/cpu/cpu0/cpufreq/scaling_available_governors"
     cur_gov_file = "/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor"
-    cur_gov = get_cpufreq_governor()
+    cur_gov = get_freq_governor()
     if not cur_gov:
         return False
     if not (os.access(avl_gov_file, os.R_OK) and os.access(cur_gov_file, os.W_OK)):
         logging.error("Could not locate frequency governor sysfs entries or\n"
                       " No proper permissions to read/write sysfs entries")
         return False
-    cpus_list = range(total_cpus_count())
+    cpus_list = range(total_count())
     with open(avl_gov_file, 'r') as fl:
         avl_govs = fl.read().strip().split(' ')
     if governor == "random":
@@ -318,7 +382,7 @@ def set_cpufreq_governor(governor="random"):
     return True
 
 
-def get_cpufreq_governor():
+def get_freq_governor():
     """
     Get current cpu frequency governor
     """

--- a/avocado/utils/cpu.py
+++ b/avocado/utils/cpu.py
@@ -26,6 +26,7 @@ import platform
 import glob
 import logging
 import random
+import warnings
 
 
 def _list_matches(content_list, pattern):
@@ -420,3 +421,32 @@ def get_pid_cpus(pid):
         except IOError:
             continue
     return list(cpus)
+
+
+def _deprecated(newfunc, oldfuncname):
+    """
+    Print a warning to user and return the new function
+
+    :param newfunc: new function to be assigned
+    :param oldfunctionname: Old function name string
+    :rtype: `function`
+    """
+    def wrap(*args, **kwargs):
+        fmt_str = "avocado.utils.cpu.{}() it is getting deprecat".format(oldfuncname)
+        fmt_str += "ed, Use avocado.utils.cpu.{}() instead".format(newfunc.__name__)
+        warnings.warn((fmt_str), DeprecationWarning, stacklevel=2)
+        return newfunc(*args, **kwargs)
+    return wrap
+
+
+total_cpus_count = _deprecated(total_count, "total_cpus_count")
+_get_cpu_info = _deprecated(_get_info, "_get_cpu_info")
+_get_cpu_status = _deprecated(_get_status, "_get_cpu_status")
+get_cpu_vendor_name = _deprecated(get_vendor, "get_cpu_vendor_name")
+get_cpu_arch = _deprecated(get_arch, "get_cpu_arch")
+cpu_online_list = _deprecated(online_list, "cpu_online_list")
+online_cpus_count = _deprecated(online_count, "online_cpus_count")
+get_cpuidle_state = _deprecated(get_idle_state, "get_cpuidle_state")
+set_cpuidle_state = _deprecated(set_idle_state, "set_cpuidle_state")
+set_cpufreq_governor = _deprecated(set_freq_governor, "set_cpufreq_governor")
+get_cpufreq_governor = _deprecated(get_freq_governor, "get_cpufreq_governor")

--- a/docs/source/releases/lts/next.rst
+++ b/docs/source/releases/lts/next.rst
@@ -25,6 +25,26 @@ Test APIs
 
 Utility APIs
 ~~~~~~~~~~~~
+* Starting from this release, below cpu utils API's on left hand side
+  will be deprecated and use respective ones on the right hand side.
+
+:func:`avocado.utils.cpu.total_cpus_count` = :func:`avocado.utils.cpu.total_count`
+:func:`avocado.utils.cpu._get_cpu_info` = :func:`avocado.utils.cpu._get_info`
+:func:`avocado.utils.cpu._get_cpu_status` = :func:`avocado.utils.cpu._get_status`
+:func:`avocado.utils.cpu.get_cpu_vendor_name` = :func:`avocado.utils.cpu.get_vendor`
+:func:`avocado.utils.cpu.get_cpu_arch` = :func:`avocado.utils.cpu.get_arch`
+:func:`avocado.utils.cpu.cpu_online_list` = :func:`avocado.utils.cpu.online_list`
+:func:`avocado.utils.cpu.online_cpus_count` = :func:`avocado.utils.cpu.online_count`
+:func:`avocado.utils.cpu.get_cpuidle_state` = :func:`avocado.utils.cpu.get_idle_state`
+:func:`avocado.utils.cpu.set_cpuidle_state` = :func:`avocado.utils.cpu.set_idle_state`
+:func:`avocado.utils.cpu.set_cpufreq_governor` = :func:`avocado.utils.cpu.set_freq_governor`
+:func:`avocado.utils.cpu.get_cpufreq_governor` = :func:`avocado.utils.cpu.get_freq_governor`
+
+* Additionally, :func:`avocado.utils.cpu.get_arch` implementation for
+  powerpc has been corrected to return ``powerpc`` instead of cpu
+  family values like ``power8``, ``power9``.
+* New :func:`avocado.utils.cpu.get_family` is added to get the cpu family
+  values like ``power8``, ``power9``.
 
 Users
 -----

--- a/selftests/unit/test_utils_cpu.py
+++ b/selftests/unit/test_utils_cpu.py
@@ -4,18 +4,7 @@ import unittest.mock
 from avocado.utils import cpu
 
 
-class Cpu(unittest.TestCase):
-
-    @staticmethod
-    def _get_file_mock(content):
-        file_mock = unittest.mock.Mock()
-        file_mock.__enter__ = unittest.mock.Mock(
-            return_value=io.BytesIO(content))
-        file_mock.__exit__ = unittest.mock.Mock()
-        return file_mock
-
-    def test_s390x_cpu_online(self):
-        s390x = b"""vendor_id       : IBM/S390
+s390x = b"""vendor_id       : IBM/S390
 # processors    : 2
 bogomips per cpu: 2913.00
 max thread id   : 0
@@ -40,7 +29,7 @@ cpu MHz static  : 5504
 
 """
 
-        s390x_2 = b"""vendor_id       : IBM/S390
+s390x_2 = b"""vendor_id       : IBM/S390
 # processors    : 4
 bogomips per cpu: 2913.00
 max thread id   : 0
@@ -74,241 +63,283 @@ cpu MHz dynamic : 5504
 cpu MHz static  : 5504
 """
 
-        with unittest.mock.patch('avocado.utils.cpu.platform.machine',
-                                 return_value='s390x'):
-            with unittest.mock.patch('builtins.open',
-                                     return_value=self._get_file_mock(s390x)):
-                self.assertEqual(len(cpu.cpu_online_list()), 2)
-            with unittest.mock.patch('builtins.open',
-                                     return_value=self._get_file_mock(s390x_2)):
-                self.assertEqual(len(cpu.cpu_online_list()), 4)
-
-    def test_x86_64_cpu_online(self):
-        x86_64 = b"""processor	: 0
-vendor_id	: GenuineIntel
-cpu family	: 6
-model		: 60
-model name	: Intel(R) Core(TM) i7-4710MQ CPU @ 2.50GHz
-stepping	: 3
-microcode	: 0x22
-cpu MHz		: 2494.301
-cache size	: 6144 KB
-physical id	: 0
-siblings	: 8
-core id		: 0
-cpu cores	: 4
-apicid		: 0
-initial apicid	: 0
-fpu		: yes
-fpu_exception	: yes
-cpuid level	: 13
-wp		: yes
-flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm cpuid_fault epb tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt dtherm ida arat pln pts
-bugs		:
-bogomips	: 4988.60
-clflush size	: 64
-cache_alignment	: 64
-address sizes	: 39 bits physical, 48 bits virtual
-power management:
-
-processor	: 1
-vendor_id	: GenuineIntel
-cpu family	: 6
-model		: 60
-model name	: Intel(R) Core(TM) i7-4710MQ CPU @ 2.50GHz
-stepping	: 3
-microcode	: 0x22
-cpu MHz		: 2494.301
-cache size	: 6144 KB
-physical id	: 0
-siblings	: 8
-core id		: 0
-cpu cores	: 4
-apicid		: 1
-initial apicid	: 1
-fpu		: yes
-fpu_exception	: yes
-cpuid level	: 13
-wp		: yes
-flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm cpuid_fault epb tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt dtherm ida arat pln pts
-bugs		:
-bogomips	: 4988.60
-clflush size	: 64
-cache_alignment	: 64
-address sizes	: 39 bits physical, 48 bits virtual
-power management:
-
-processor	: 2
-vendor_id	: GenuineIntel
-cpu family	: 6
-model		: 60
-model name	: Intel(R) Core(TM) i7-4710MQ CPU @ 2.50GHz
-stepping	: 3
-microcode	: 0x22
-cpu MHz		: 2494.301
-cache size	: 6144 KB
-physical id	: 0
-siblings	: 8
-core id		: 1
-cpu cores	: 4
-apicid		: 2
-initial apicid	: 2
-fpu		: yes
-fpu_exception	: yes
-cpuid level	: 13
-wp		: yes
-flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm cpuid_fault epb tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt dtherm ida arat pln pts
-bugs		:
-bogomips	: 4988.60
-clflush size	: 64
-cache_alignment	: 64
-address sizes	: 39 bits physical, 48 bits virtual
-power management:
-
-processor	: 3
-vendor_id	: GenuineIntel
-cpu family	: 6
-model		: 60
-model name	: Intel(R) Core(TM) i7-4710MQ CPU @ 2.50GHz
-stepping	: 3
-microcode	: 0x22
-cpu MHz		: 2494.301
-cache size	: 6144 KB
-physical id	: 0
-siblings	: 8
-core id		: 1
-cpu cores	: 4
-apicid		: 3
-initial apicid	: 3
-fpu		: yes
-fpu_exception	: yes
-cpuid level	: 13
-wp		: yes
-flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm cpuid_fault epb tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt dtherm ida arat pln pts
-bugs		:
-bogomips	: 4988.60
-clflush size	: 64
-cache_alignment	: 64
-address sizes	: 39 bits physical, 48 bits virtual
-power management:
-
-processor	: 4
-vendor_id	: GenuineIntel
-cpu family	: 6
-model		: 60
-model name	: Intel(R) Core(TM) i7-4710MQ CPU @ 2.50GHz
-stepping	: 3
-microcode	: 0x22
-cpu MHz		: 2494.301
-cache size	: 6144 KB
-physical id	: 0
-siblings	: 8
-core id		: 2
-cpu cores	: 4
-apicid		: 4
-initial apicid	: 4
-fpu		: yes
-fpu_exception	: yes
-cpuid level	: 13
-wp		: yes
-flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm cpuid_fault epb tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt dtherm ida arat pln pts
-bugs		:
-bogomips	: 4988.60
-clflush size	: 64
-cache_alignment	: 64
-address sizes	: 39 bits physical, 48 bits virtual
-power management:
-
-processor	: 5
-vendor_id	: GenuineIntel
-cpu family	: 6
-model		: 60
-model name	: Intel(R) Core(TM) i7-4710MQ CPU @ 2.50GHz
-stepping	: 3
-microcode	: 0x22
-cpu MHz		: 2494.301
-cache size	: 6144 KB
-physical id	: 0
-siblings	: 8
-core id		: 2
-cpu cores	: 4
-apicid		: 5
-initial apicid	: 5
-fpu		: yes
-fpu_exception	: yes
-cpuid level	: 13
-wp		: yes
-flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm cpuid_fault epb tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt dtherm ida arat pln pts
-bugs		:
-bogomips	: 4988.60
-clflush size	: 64
-cache_alignment	: 64
-address sizes	: 39 bits physical, 48 bits virtual
-power management:
-
-processor	: 6
-vendor_id	: GenuineIntel
-cpu family	: 6
-model		: 60
-model name	: Intel(R) Core(TM) i7-4710MQ CPU @ 2.50GHz
-stepping	: 3
-microcode	: 0x22
-cpu MHz		: 2494.301
-cache size	: 6144 KB
-physical id	: 0
-siblings	: 8
-core id		: 3
-cpu cores	: 4
-apicid		: 6
-initial apicid	: 6
-fpu		: yes
-fpu_exception	: yes
-cpuid level	: 13
-wp		: yes
-flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm cpuid_fault epb tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt dtherm ida arat pln pts
-bugs		:
-bogomips	: 4988.60
-clflush size	: 64
-cache_alignment	: 64
-address sizes	: 39 bits physical, 48 bits virtual
-power management:
-
-processor	: 7
-vendor_id	: GenuineIntel
-cpu family	: 6
-model		: 60
-model name	: Intel(R) Core(TM) i7-4710MQ CPU @ 2.50GHz
-stepping	: 3
-microcode	: 0x22
-cpu MHz		: 2494.301
-cache size	: 6144 KB
-physical id	: 0
-siblings	: 8
-core id		: 3
-cpu cores	: 4
-apicid		: 7
-initial apicid	: 7
-fpu		: yes
-fpu_exception	: yes
-cpuid level	: 13
-wp		: yes
-flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm cpuid_fault epb tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt dtherm ida arat pln pts
-bugs		:
-bogomips	: 4988.60
-clflush size	: 64
-cache_alignment	: 64
-address sizes	: 39 bits physical, 48 bits virtual
-power management:
-
+s390x_3 = b"""vendor_id       : IBM/S390
+# processors    : 24
+bogomips per cpu: 24038.00
+max thread id   : 1
+features    : esan3 zarch stfle msa ldisp eimm dfp edat etf3eh highgprs te vx vxd vxe gs sie
+facilities      : 0 1 2 3 4 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 30 31 32 33 34 35 36 37 38 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 57 58 59 60 61 64 65 66 67 68 69 70 71 72 73 75 76 77 78 80 81 82 128 129 130 131 132 133 134 135 138 139 141 142 144 145 146 148 149 150 151 152 155 156
+cache0          : level=1 type=Data scope=Private size=128K line_size=256 associativity=8
+cache1          : level=1 type=Instruction scope=Private size=128K line_size=256 associativity=8
+cache2          : level=2 type=Data scope=Private size=4096K line_size=256 associativity=8
+cache3          : level=2 type=Instruction scope=Private size=4096K line_size=256 associativity=8
+cache4          : level=3 type=Unified scope=Shared size=262144K line_size=256 associativity=32
+cache5          : level=4 type=Unified scope=Shared size=983040K line_size=256 associativity=60
+processor 0: version = 00,  identification = 2A66A8,  machine = 8561
+processor 1: version = 00,  identification = 2A66A8,  machine = 8561
+processor 2: version = 00,  identification = 2A66A8,  machine = 8561
+processor 3: version = 00,  identification = 2A66A8,  machine = 8561
+processor 4: version = 00,  identification = 2A66A8,  machine = 8561
+processor 5: version = 00,  identification = 2A66A8,  machine = 8561
+processor 6: version = 00,  identification = 2A66A8,  machine = 8561
+processor 7: version = 00,  identification = 2A66A8,  machine = 8561
+processor 8: version = 00,  identification = 2A66A8,  machine = 8561
+processor 9: version = 00,  identification = 2A66A8,  machine = 8561
+processor 10: version = 00,  identification = 2A66A8,  machine = 8561
+processor 11: version = 00,  identification = 2A66A8,  machine = 8561
+processor 12: version = 00,  identification = 2A66A8,  machine = 8561
+processor 13: version = 00,  identification = 2A66A8,  machine = 8561
+processor 14: version = 00,  identification = 2A66A8,  machine = 8561
+processor 15: version = 00,  identification = 2A66A8,  machine = 8561
+processor 16: version = 00,  identification = 2A66A8,  machine = 8561
+processor 17: version = 00,  identification = 2A66A8,  machine = 8561
+processor 18: version = 00,  identification = 2A66A8,  machine = 8561
+processor 19: version = 00,  identification = 2A66A8,  machine = 8561
+processor 20: version = 00,  identification = 2A66A8,  machine = 8561
+processor 21: version = 00,  identification = 2A66A8,  machine = 8561
+processor 22: version = 00,  identification = 2A66A8,  machine = 8561
+processor 23: version = 00,  identification = 2A66A8,  machine = 8561
+cpu number      : 0
+cpu MHz dynamic : 5200
+cpu MHz static  : 5200
+cpu number      : 1
+cpu MHz dynamic : 5200
+cpu MHz static  : 5200
+cpu number      : 2
+cpu MHz dynamic : 5200
+cpu MHz static  : 5200
+cpu number      : 3
+cpu MHz dynamic : 5200
+cpu MHz static  : 5200
+cpu number      : 4
+cpu MHz dynamic : 5200
+cpu MHz static  : 5200
+cpu number      : 5
+cpu MHz dynamic : 5200
+cpu MHz static  : 5200
 """
-        with unittest.mock.patch('avocado.utils.cpu.platform.machine',
-                                 return_value='x86_64'):
-            with unittest.mock.patch('builtins.open',
-                                     return_value=self._get_file_mock(x86_64)):
-                self.assertEqual(len(cpu.cpu_online_list()), 8)
 
-    def test_cpu_arch_i386(self):
-        cpu_output = b"""processor       : 0
+x86_64 = b"""processor    : 0
+vendor_id    : GenuineIntel
+cpu family    : 6
+model        : 60
+model name    : Intel(R) Core(TM) i7-4710MQ CPU @ 2.50GHz
+stepping    : 3
+microcode    : 0x22
+cpu MHz        : 2494.301
+cache size    : 6144 KB
+physical id    : 0
+siblings    : 8
+core id        : 0
+cpu cores    : 4
+apicid        : 0
+initial apicid    : 0
+fpu        : yes
+fpu_exception    : yes
+cpuid level    : 13
+wp        : yes
+flags        : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm cpuid_fault epb tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt dtherm ida arat pln pts
+bugs        :
+bogomips    : 4988.60
+clflush size    : 64
+cache_alignment    : 64
+address sizes    : 39 bits physical, 48 bits virtual
+power management:
+
+processor    : 1
+vendor_id    : GenuineIntel
+cpu family    : 6
+model        : 60
+model name    : Intel(R) Core(TM) i7-4710MQ CPU @ 2.50GHz
+stepping    : 3
+microcode    : 0x22
+cpu MHz        : 2494.301
+cache size    : 6144 KB
+physical id    : 0
+siblings    : 8
+core id        : 0
+cpu cores    : 4
+apicid        : 1
+initial apicid    : 1
+fpu        : yes
+fpu_exception    : yes
+cpuid level    : 13
+wp        : yes
+flags        : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm cpuid_fault epb tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt dtherm ida arat pln pts
+bugs        :
+bogomips    : 4988.60
+clflush size    : 64
+cache_alignment    : 64
+address sizes    : 39 bits physical, 48 bits virtual
+power management:
+
+processor    : 2
+vendor_id    : GenuineIntel
+cpu family    : 6
+model        : 60
+model name    : Intel(R) Core(TM) i7-4710MQ CPU @ 2.50GHz
+stepping    : 3
+microcode    : 0x22
+cpu MHz        : 2494.301
+cache size    : 6144 KB
+physical id    : 0
+siblings    : 8
+core id        : 1
+cpu cores    : 4
+apicid        : 2
+initial apicid    : 2
+fpu        : yes
+fpu_exception    : yes
+cpuid level    : 13
+wp        : yes
+flags        : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm cpuid_fault epb tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt dtherm ida arat pln pts
+bugs        :
+bogomips    : 4988.60
+clflush size    : 64
+cache_alignment    : 64
+address sizes    : 39 bits physical, 48 bits virtual
+power management:
+
+processor    : 3
+vendor_id    : GenuineIntel
+cpu family    : 6
+model        : 60
+model name    : Intel(R) Core(TM) i7-4710MQ CPU @ 2.50GHz
+stepping    : 3
+microcode    : 0x22
+cpu MHz        : 2494.301
+cache size    : 6144 KB
+physical id    : 0
+siblings    : 8
+core id        : 1
+cpu cores    : 4
+apicid        : 3
+initial apicid    : 3
+fpu        : yes
+fpu_exception    : yes
+cpuid level    : 13
+wp        : yes
+flags        : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm cpuid_fault epb tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt dtherm ida arat pln pts
+bugs        :
+bogomips    : 4988.60
+clflush size    : 64
+cache_alignment    : 64
+address sizes    : 39 bits physical, 48 bits virtual
+power management:
+
+processor    : 4
+vendor_id    : GenuineIntel
+cpu family    : 6
+model        : 60
+model name    : Intel(R) Core(TM) i7-4710MQ CPU @ 2.50GHz
+stepping    : 3
+microcode    : 0x22
+cpu MHz        : 2494.301
+cache size    : 6144 KB
+physical id    : 0
+siblings    : 8
+core id        : 2
+cpu cores    : 4
+apicid        : 4
+initial apicid    : 4
+fpu        : yes
+fpu_exception    : yes
+cpuid level    : 13
+wp        : yes
+flags        : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm cpuid_fault epb tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt dtherm ida arat pln pts
+bugs        :
+bogomips    : 4988.60
+clflush size    : 64
+cache_alignment    : 64
+address sizes    : 39 bits physical, 48 bits virtual
+power management:
+
+processor    : 5
+vendor_id    : GenuineIntel
+cpu family    : 6
+model        : 60
+model name    : Intel(R) Core(TM) i7-4710MQ CPU @ 2.50GHz
+stepping    : 3
+microcode    : 0x22
+cpu MHz        : 2494.301
+cache size    : 6144 KB
+physical id    : 0
+siblings    : 8
+core id        : 2
+cpu cores    : 4
+apicid        : 5
+initial apicid    : 5
+fpu        : yes
+fpu_exception    : yes
+cpuid level    : 13
+wp        : yes
+flags        : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm cpuid_fault epb tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt dtherm ida arat pln pts
+bugs        :
+bogomips    : 4988.60
+clflush size    : 64
+cache_alignment    : 64
+address sizes    : 39 bits physical, 48 bits virtual
+power management:
+
+processor    : 6
+vendor_id    : GenuineIntel
+cpu family    : 6
+model        : 60
+model name    : Intel(R) Core(TM) i7-4710MQ CPU @ 2.50GHz
+stepping    : 3
+microcode    : 0x22
+cpu MHz        : 2494.301
+cache size    : 6144 KB
+physical id    : 0
+siblings    : 8
+core id        : 3
+cpu cores    : 4
+apicid        : 6
+initial apicid    : 6
+fpu        : yes
+fpu_exception    : yes
+cpuid level    : 13
+wp        : yes
+flags        : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm cpuid_fault epb tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt dtherm ida arat pln pts
+bugs        :
+bogomips    : 4988.60
+clflush size    : 64
+cache_alignment    : 64
+address sizes    : 39 bits physical, 48 bits virtual
+power management:
+
+processor    : 7
+vendor_id    : GenuineIntel
+cpu family    : 6
+model        : 60
+model name    : Intel(R) Core(TM) i7-4710MQ CPU @ 2.50GHz
+stepping    : 3
+microcode    : 0x22
+cpu MHz        : 2494.301
+cache size    : 6144 KB
+physical id    : 0
+siblings    : 8
+core id        : 3
+cpu cores    : 4
+apicid        : 7
+initial apicid    : 7
+fpu        : yes
+fpu_exception    : yes
+cpuid level    : 13
+wp        : yes
+flags        : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm cpuid_fault epb tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt dtherm ida arat pln pts
+bugs        :
+bogomips    : 4988.60
+clflush size    : 64
+cache_alignment    : 64
+address sizes    : 39 bits physical, 48 bits virtual
+power management:
+"""
+
+x86_64_pmu = b"""broadwell
+"""
+
+i386 = b"""processor       : 0
 vendor_id       : GenuineIntel
 cpu family      : 6
 model           : 13
@@ -338,44 +369,8 @@ cache_alignment : 64
 address sizes   : 32 bits physical, 32 bits virtual
 power management:
 """
-        with unittest.mock.patch('builtins.open',
-                                 return_value=self._get_file_mock(cpu_output)):
-            self.assertEqual(cpu.get_cpu_arch(), "i386")
 
-    def test_cpu_arch_x86_64(self):
-        cpu_output = b"""processor       : 0
-vendor_id       : GenuineIntel
-cpu family      : 6
-model           : 60
-model name      : Intel(R) Core(TM) i7-4810MQ CPU @ 2.80GHz
-stepping        : 3
-microcode       : 0x24
-cpu MHz         : 1766.058
-cache size      : 6144 KB
-physical id     : 0
-siblings        : 8
-core id         : 0
-cpu cores       : 4
-apicid          : 0
-initial apicid  : 0
-fpu             : yes
-fpu_exception   : yes
-cpuid level     : 13
-wp              : yes
-flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm cpuid_fault epb invpcid_single pti tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt ibpb ibrs stibp dtherm ida arat pln pts
-bugs            : cpu_meltdown spectre_v1 spectre_v2
-bogomips        : 5586.93
-clflush size    : 64
-cache_alignment : 64
-address sizes   : 39 bits physical, 48 bits virtual
-power management:
-"""
-        with unittest.mock.patch('builtins.open',
-                                 return_value=self._get_file_mock(cpu_output)):
-            self.assertEqual(cpu.get_cpu_arch(), "x86_64")
-
-    def test_cpu_arch_ppc64_power8(self):
-        cpu_output = b"""processor       : 88
+power8 = b"""processor       : 88
 cpu             : POWER8E (raw), altivec supported
 clock           : 3325.000000MHz
 revision        : 2.1 (pvr 004b 0201)
@@ -386,72 +381,20 @@ model           : 8247-21L
 machine         : PowerNV 8247-21L
 firmware        : OPAL v3
 """
-        with unittest.mock.patch('builtins.open',
-                                 return_value=self._get_file_mock(cpu_output)):
-            self.assertEqual(cpu.get_cpu_arch(), "power8")
 
-    def test_cpu_arch_ppc64_le_power8(self):
-        cpu_output = b"""processor       : 88
-cpu             : POWER8E (raw), altivec supported
-clock           : 3325.000000MHz
-revision        : 2.1 (pvr 004b 0201)
+power9 = b"""processor    : 20
+cpu        : POWER9 (raw), altivec supported
+clock        : 2050.000000MHz
+revision    : 1.0 (pvr 004e 0100)
 
-timebase        : 512000000
-platform        : PowerNV
-model           : 8247-21L
-machine         : PowerNV 8247-21L
-firmware        : OPAL v3
+timebase    : 512000000
+platform    : PowerNV
+model        : 8375-42A
+machine        : PowerNV 8375-42A
+firmware    : OPAL
 """
-        with unittest.mock.patch('builtins.open',
-                                 return_value=self._get_file_mock(cpu_output)):
-            self.assertEqual(cpu.get_cpu_arch(), "power8")
 
-    def test_cpu_arch_ppc64_le_power9(self):
-        cpu_output = b"""processor	: 20
-cpu		: POWER9 (raw), altivec supported
-clock		: 2050.000000MHz
-revision	: 1.0 (pvr 004e 0100)
-
-timebase	: 512000000
-platform	: PowerNV
-model		: 8375-42A
-machine		: PowerNV 8375-42A
-firmware	: OPAL
-"""
-        with unittest.mock.patch('builtins.open',
-                                 return_value=self._get_file_mock(cpu_output)):
-            self.assertEqual(cpu.get_cpu_arch(), "power9")
-
-    def test_cpu_arch_s390(self):
-        cpu_output = b"""vendor_id       : IBM/S390
-# processors    : 2
-bogomips per cpu: 2913.00
-max thread id   : 0
-features        : esan3 zarch stfle msa ldisp eimm dfp edat etf3eh highgprs te sie
-facilities      : 0 1 2 3 4 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 30 31 32 33 34 35 36 37 40 41 42 43 44 45 46 47 48 49 50 51 52 57 64 65 66 67 68 69 70 71 72 73 75 76 77 78 81 82 131 132
-cache0          : level=1 type=Data scope=Private size=96K line_size=256 associativity=6
-cache1          : level=1 type=Instruction scope=Private size=64K line_size=256 associativity=4
-cache2          : level=2 type=Data scope=Private size=1024K line_size=256 associativity=8
-cache3          : level=2 type=Instruction scope=Private size=1024K line_size=256 associativity=8
-cache4          : level=3 type=Unified scope=Shared size=49152K line_size=256 associativity=12
-cache5          : level=4 type=Unified scope=Shared size=393216K line_size=256 associativity=24
-processor 0: version = 00,  identification = 3FC047,  machine = 2827
-processor 1: version = 00,  identification = 3FC047,  machine = 2827
-
-cpu number      : 0
-cpu MHz dynamic : 5504
-cpu MHz static  : 5504
-
-cpu number      : 1
-cpu MHz dynamic : 5504
-cpu MHz static  : 5504
-"""
-        with unittest.mock.patch('builtins.open',
-                                 return_value=self._get_file_mock(cpu_output)):
-            self.assertEqual(cpu.get_cpu_arch(), "s390")
-
-    def test_cpu_arch_arm_v7(self):
-        cpu_output = b"""Processor       : ARMv7 Processor rev 2 (v7l)
+armv7 = b"""Processor       : ARMv7 Processor rev 2 (v7l)
 BogoMIPS        : 994.65
 Features        : swp half thumb fastmult vfp edsp thumbee neon vfpv3
 CPU implementer : 0x41
@@ -464,12 +407,8 @@ Hardware        : herring
 Revision        : 0034
 Serial          : 3534268a5e0700ec
 """
-        with unittest.mock.patch('builtins.open',
-                                 return_value=self._get_file_mock(cpu_output)):
-            self.assertEqual(cpu.get_cpu_arch(), "arm")
 
-    def test_cpu_arch_arm_v8(self):
-        cpu_output = b"""processor       : 0
+armv8 = b"""processor       : 0
 BogoMIPS        : 200.00
 Features        : fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid
 CPU implementer : 0x43
@@ -478,144 +417,214 @@ CPU variant     : 0x1
 CPU part        : 0x0a1
 CPU revision    : 1
 """
+
+risc_v = b"""hart    : 1
+isa    : rv64imafdc
+mmu    : sv39
+uarch    : sifive,rocket0
+"""
+
+
+class Cpu(unittest.TestCase):
+
+    @staticmethod
+    def _get_file_mock(content):
+        file_mock = unittest.mock.Mock()
+        file_mock.__enter__ = unittest.mock.Mock(
+            return_value=io.BytesIO(content))
+        file_mock.__exit__ = unittest.mock.Mock()
+        return file_mock
+
+    def test_s390x_cpu_online(self):
+        with unittest.mock.patch('avocado.utils.cpu.platform.machine',
+                                 return_value='s390x'):
+            with unittest.mock.patch('builtins.open',
+                                     return_value=self._get_file_mock(s390x)):
+                self.assertEqual(len(cpu.online_list()), 2)
+            with unittest.mock.patch('builtins.open',
+                                     return_value=self._get_file_mock(s390x_2)):
+                self.assertEqual(len(cpu.online_list()), 4)
+
+    def test_x86_64_cpu_online(self):
+        with unittest.mock.patch('avocado.utils.cpu.platform.machine',
+                                 return_value='x86_64'):
+            with unittest.mock.patch('builtins.open',
+                                     return_value=self._get_file_mock(x86_64)):
+                self.assertEqual(len(cpu.online_list()), 8)
+
+    def test_cpu_arch_i386(self):
         with unittest.mock.patch('builtins.open',
-                                 return_value=self._get_file_mock(cpu_output)):
-            self.assertEqual(cpu.get_cpu_arch(), "aarch64")
+                                 return_value=self._get_file_mock(i386)):
+            self.assertEqual(cpu.get_arch(), "i386")
+
+    def test_cpu_arch_x86_64(self):
+        with unittest.mock.patch('builtins.open',
+                                 return_value=self._get_file_mock(x86_64)):
+            self.assertEqual(cpu.get_arch(), "x86_64")
+
+    def test_cpu_arch_power8(self):
+        with unittest.mock.patch('builtins.open',
+                                 return_value=self._get_file_mock(power8)):
+            self.assertEqual(cpu.get_arch(), "powerpc")
+
+    def test_cpu_arch_power9(self):
+        with unittest.mock.patch('builtins.open',
+                                 return_value=self._get_file_mock(power9)):
+            self.assertEqual(cpu.get_arch(), "powerpc")
+
+    def test_cpu_arch_s390(self):
+        with unittest.mock.patch('builtins.open',
+                                 return_value=self._get_file_mock(s390x)):
+            self.assertEqual(cpu.get_arch(), "s390")
+
+    def test_cpu_arch_arm_v7(self):
+        with unittest.mock.patch('builtins.open',
+                                 return_value=self._get_file_mock(armv7)):
+            self.assertEqual(cpu.get_arch(), "arm")
+
+    def test_cpu_arch_arm_v8(self):
+        with unittest.mock.patch('builtins.open',
+                                 return_value=self._get_file_mock(armv8)):
+            self.assertEqual(cpu.get_arch(), "aarch64")
 
     def test_cpu_arch_risc_v(self):
-        cpu_output = b"""hart	: 1
-isa	: rv64imafdc
-mmu	: sv39
-uarch	: sifive,rocket0
-"""
         with unittest.mock.patch('builtins.open',
-                                 return_value=self._get_file_mock(cpu_output)):
-            self.assertEqual(cpu.get_cpu_arch(), "riscv")
+                                 return_value=self._get_file_mock(risc_v)):
+            self.assertEqual(cpu.get_arch(), "riscv")
 
     def test_cpu_vendor_intel(self):
-        cpu_output = b"""processor       : 0
-vendor_id       : GenuineIntel
-cpu family      : 6
-model           : 60
-model name      : Intel(R) Core(TM) i7-4810MQ CPU @ 2.80GHz
-stepping        : 3
-microcode       : 0x24
-cpu MHz         : 1766.058
-cache size      : 6144 KB
-physical id     : 0
-siblings        : 8
-core id         : 0
-cpu cores       : 4
-apicid          : 0
-initial apicid  : 0
-fpu             : yes
-fpu_exception   : yes
-cpuid level     : 13
-wp              : yes
-flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm cpuid_fault epb invpcid_single pti tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt ibpb ibrs stibp dtherm ida arat pln pts
-bugs            : cpu_meltdown spectre_v1 spectre_v2
-bogomips        : 5586.93
-clflush size    : 64
-cache_alignment : 64
-address sizes   : 39 bits physical, 48 bits virtual
-power management:
-"""
         with unittest.mock.patch('builtins.open',
-                                 return_value=self._get_file_mock(cpu_output)):
-            self.assertEqual(cpu.get_cpu_vendor_name(), "intel")
+                                 return_value=self._get_file_mock(x86_64)):
+            self.assertEqual(cpu.get_vendor(), "intel")
 
     def test_cpu_vendor_power8(self):
-        cpu_output = b"""processor       : 88
-cpu             : POWER8E (raw), altivec supported
-clock           : 3325.000000MHz
-revision        : 2.1 (pvr 004b 0201)
-timebase        : 512000000
-platform        : PowerNV
-model           : 8247-21L
-machine         : PowerNV 8247-21L
-firmware        : OPAL v3
-"""
         with unittest.mock.patch('builtins.open',
-                                 return_value=self._get_file_mock(cpu_output)):
-            self.assertEqual(cpu.get_cpu_vendor_name(), "power8")
+                                 return_value=self._get_file_mock(power8)):
+            self.assertEqual(cpu.get_vendor(), "ibm")
 
     def test_cpu_vendor_power9(self):
-        cpu_output = b"""processor	: 20
-cpu		: POWER9 (raw), altivec supported
-clock		: 2050.000000MHz
-revision	: 1.0 (pvr 004e 0100)
-timebase	: 512000000
-platform	: PowerNV
-model		: 8375-42A
-machine		: PowerNV 8375-42A
-firmware	: OPAL
-"""
         with unittest.mock.patch('builtins.open',
-                                 return_value=self._get_file_mock(cpu_output)):
-            self.assertEqual(cpu.get_cpu_vendor_name(), "power9")
+                                 return_value=self._get_file_mock(power9)):
+            self.assertEqual(cpu.get_vendor(), "ibm")
 
-    def test_get_cpuidle_state_off(self):
+    def test_s390x_get_version(self):
+        with unittest.mock.patch('avocado.utils.cpu.platform.machine',
+                                 return_value='s390x'):
+            with unittest.mock.patch('builtins.open',
+                                     return_value=self._get_file_mock(s390x)):
+                self.assertEqual(cpu.get_version(), "2827")
+
+    def test_intel_get_version(self):
+        with unittest.mock.patch('avocado.utils.cpu.platform.machine',
+                                 return_value='x86_64'):
+            with unittest.mock.patch('builtins.open',
+                                     return_value=self._get_file_mock(x86_64)):
+                self.assertEqual(cpu.get_version(), "i7-4710MQ")
+
+    def test_power8_get_version(self):
+        with unittest.mock.patch('avocado.utils.cpu.platform.machine',
+                                 return_value='powerpc'):
+            with unittest.mock.patch('builtins.open',
+                                     return_value=self._get_file_mock(power8)):
+                self.assertEqual(cpu.get_version(), "2.1")
+
+    def test_power9_get_version(self):
+        with unittest.mock.patch('avocado.utils.cpu.platform.machine',
+                                 return_value='powerpc'):
+            with unittest.mock.patch('builtins.open',
+                                     return_value=self._get_file_mock(power9)):
+                self.assertEqual(cpu.get_version(), "1.0")
+
+    def test_s390x_get_family(self):
+        with unittest.mock.patch('avocado.utils.cpu.get_arch',
+                                 return_value='s390'):
+            with unittest.mock.patch('avocado.utils.cpu.get_version',
+                                     return_value='8561'):
+                self.assertEqual(cpu.get_family(), "z15")
+
+    def test_intel_get_family(self):
+        with unittest.mock.patch('avocado.utils.cpu.get_arch',
+                                 return_value='x86_64'):
+            with unittest.mock.patch('avocado.utils.cpu.get_vendor',
+                                     return_value='intel'):
+                with unittest.mock.patch('builtins.open',
+                                         return_value=self._get_file_mock(x86_64_pmu)):
+                    self.assertEqual(cpu.get_family(), "broadwell")
+
+    def test_power8_get_family(self):
+        with unittest.mock.patch('avocado.utils.cpu.get_arch',
+                                 return_value='powerpc'):
+            with unittest.mock.patch('builtins.open',
+                                     return_value=self._get_file_mock(power8)):
+                self.assertEqual(cpu.get_family(), "power8")
+
+    def test_power9_get_family(self):
+        with unittest.mock.patch('avocado.utils.cpu.get_arch', return_value='powerpc'):
+            with unittest.mock.patch('builtins.open', return_value=self._get_file_mock(power9)):
+                self.assertEqual(cpu.get_family(), "power9")
+
+    def test_get_idle_state_off(self):
         retval = {0: {0: False}}
-        with unittest.mock.patch('avocado.utils.cpu.cpu_online_list',
+        with unittest.mock.patch('avocado.utils.cpu.online_list',
                                  return_value=[0]):
             with unittest.mock.patch('glob.glob',
                                      return_value=['/sys/devices/system/cpu/cpu0/cpuidle/state1']):
                 with unittest.mock.patch('builtins.open',
                                          return_value=io.BytesIO(b'0')):
-                    self.assertEqual(cpu.get_cpuidle_state(), retval)
+                    self.assertEqual(cpu.get_idle_state(), retval)
 
-    def test_get_cpuidle_state_on(self):
+    def test_get_idle_state_on(self):
         retval = {0: {0: True}}
-        with unittest.mock.patch('avocado.utils.cpu.cpu_online_list',
+        with unittest.mock.patch('avocado.utils.cpu.online_list',
                                  return_value=[0]):
             with unittest.mock.patch('glob.glob',
                                      return_value=['/sys/devices/system/cpu/cpu0/cpuidle/state1']):
                 with unittest.mock.patch('builtins.open',
                                          return_value=io.BytesIO(b'1')):
-                    self.assertEqual(cpu.get_cpuidle_state(), retval)
+                    self.assertEqual(cpu.get_idle_state(), retval)
 
-    def test_set_cpuidle_state_default(self):
+    def test_set_idle_state_default(self):
         output = io.BytesIO()
-        with unittest.mock.patch('avocado.utils.cpu.cpu_online_list',
+        with unittest.mock.patch('avocado.utils.cpu.online_list',
                                  return_value=[0]):
             with unittest.mock.patch('glob.glob',
                                      return_value=['/sys/devices/system/cpu/cpu0/cpuidle/state1']):
                 with unittest.mock.patch('builtins.open',
                                          return_value=output):
-                    cpu.set_cpuidle_state()
+                    cpu.set_idle_state()
                     self.assertEqual(output.getvalue(), b'1')
 
-    def test_set_cpuidle_state_withstateno(self):
+    def test_set_idle_state_withstateno(self):
         output = io.BytesIO()
-        with unittest.mock.patch('avocado.utils.cpu.cpu_online_list',
+        with unittest.mock.patch('avocado.utils.cpu.online_list',
                                  return_value=[0]):
             with unittest.mock.patch('glob.glob',
                                      return_value=['/sys/devices/system/cpu/cpu0/cpuidle/state2']):
                 with unittest.mock.patch('builtins.open',
                                          return_value=output):
-                    cpu.set_cpuidle_state(disable=False, state_number='2')
+                    cpu.set_idle_state(disable=False, state_number='2')
                     self.assertEqual(output.getvalue(), b'0')
 
-    def test_set_cpuidle_state_withsetstate(self):
+    def test_set_idle_state_withsetstate(self):
         output = io.BytesIO()
-        with unittest.mock.patch('avocado.utils.cpu.cpu_online_list',
+        with unittest.mock.patch('avocado.utils.cpu.online_list',
                                  return_value=[0, 2]):
             with unittest.mock.patch('glob.glob',
                                      return_value=['/sys/devices/system/cpu/cpu0/cpuidle/state1']):
                 with unittest.mock.patch('builtins.open',
                                          return_value=output):
-                    cpu.set_cpuidle_state(setstate={0: {0: True}, 2: {0: False}})
+                    cpu.set_idle_state(setstate={0: {0: True}, 2: {0: False}})
                     self.assertEqual(output.getvalue(), b'10')
 
-    def test_set_cpuidle_state_disable(self):
+    def test_set_idle_state_disable(self):
         output = io.BytesIO()
-        function = 'avocado.utils.cpu.cpu_online_list'
+        function = 'avocado.utils.cpu.online_list'
         state_file = '/sys/devices/system/cpu/cpu0/cpuidle/state1'
         with unittest.mock.patch(function, return_value=[0, 2]):
             with unittest.mock.patch('glob.glob', return_value=[state_file]):
                 with unittest.mock.patch('builtins.open', return_value=output):
                     with self.assertRaises(TypeError):
-                        cpu.set_cpuidle_state(disable=1)
+                        cpu.set_idle_state(disable=1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
cpu vendor logic for PowerPC is wrong since long time,
instead of `ibm` method was returning the cpu version, this
patchs fixes the same and adds a new method to return the
cpu version, similarly the method to get cpu arch even did the
same thing in case of PowerPC, so fixed that too.

While refactoring, based on community suggestions,
have unified naming conventions across arch accordingly.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>