### PR TITLE
Implements the assets fetch functionality during the JobPreTests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -115,6 +115,7 @@ if __name__ == '__main__':
                   'human = avocado.plugins.human:Human',
                   'tap = avocado.plugins.tap:TAPResult',
                   'journal = avocado.plugins.journal:JournalResult',
+                  'fetchasset = avocado.plugins.assets:FetchAssetJob',
                   ],
               'avocado.plugins.varianter': [
                   'json_variants = avocado.plugins.json_variants:JsonVariants',


### PR DESCRIPTION
This implementation adds the functionality of assets fetch command JobPreTests. This way, all assets are fetched prior to the tests starts. If the asset fails to be downloaded, it will try again during the test
execution. This is a note for the future implementation of a decorator that skips the test if an asset is not available.

Signed-off-by: Willian Rampazzo <willianr@redhat.com>