### PR TITLE
Implements FetchAssetJob plugin to fetch assets during JobPreTests [v3]

### DIFF
--- a/avocado/plugins/assets.py
+++ b/avocado/plugins/assets.py
@@ -24,6 +24,7 @@ from avocado.core import exit_codes
 from avocado.core import safeloader
 from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLICmd
+from avocado.core.plugin_interfaces import JobPreTests
 from avocado.utils.asset import Asset
 from avocado.utils import data_structures
 
@@ -212,6 +213,32 @@ def fetch_assets(test_file, klass=None, method=None):
         except EnvironmentError as failed:
             fail.append(failed)
     return success, fail
+
+
+class FetchAssetJob(JobPreTests):  # pylint: disable=R0903
+    """
+    Implements the assets fetch job pre tests. This has the same effect of
+    running the 'avocado assets fetch INSTRUMENTED', but it runs during the
+    test execution, before the actual test starts.
+    """
+    name = "fetchasset"
+    description = "Fetch assets before the test run"
+
+    def __init__(self, config=None):
+        pass
+
+    def pre_tests(self, job):
+        for test in job.test_suite:
+            # fetch assets only on instrumented tests
+            if isinstance(test[0], str):
+                if not job.config.get('stdout_claimed_by', None):
+                    job.log.info('Fetching assets from %s:%s.%s',
+                                 test[1]['modulePath'],
+                                 test[0],
+                                 test[1]['methodName'])
+                fetch_assets(test[1]['modulePath'],
+                             test[0],
+                             test[1]['methodName'],)
 
 
 class Assets(CLICmd):

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -435,8 +435,8 @@ class OutputPluginTest(unittest.TestCase):
         self.assertGreaterEqual(len(output_lines), 6,
                                 ('Basic human interface did not produce the '
                                  'expect output. Output produced: "%s"' % output))
-        second_line = output_lines[1]
-        debug_log = second_line.split()[-1]
+        third_line = output_lines[2]
+        debug_log = third_line.split()[-1]
         self.check_output_files(debug_log)
 
     def test_verify_whiteboard_save(self):

--- a/setup.py
+++ b/setup.py
@@ -115,6 +115,7 @@ if __name__ == '__main__':
                   'human = avocado.plugins.human:Human',
                   'tap = avocado.plugins.tap:TAPResult',
                   'journal = avocado.plugins.journal:JournalResult',
+                  'fetchasset = avocado.plugins.assets:FetchAssetJob',
                   ],
               'avocado.plugins.varianter': [
                   'json_variants = avocado.plugins.json_variants:JsonVariants',


### PR DESCRIPTION
This implementation adds the functionality of assets fetch command during JobPreTests. This way, all assets are fetched prior to the tests starts. If the asset fails to be downloaded, it will try again during the test execution. This is a note for the future implementation of a decorator that skips the test if an asset is not available.

Signed-off-by: Willian Rampazzo willianr@redhat.com

---
Changes from v1:
- improved granularity of fetch assets functionality to be able to look at specific tests.
- used information from job.test_suite instead of config.

Changes from v2:
- improved user output message.
- adjusted one functional test with the new output.