### PR TITLE
optional_plugins: robot: fixed dependency version

### DIFF
--- a/optional_plugins/robot/setup.py
+++ b/optional_plugins/robot/setup.py
@@ -24,7 +24,7 @@ setup(name='avocado-framework-plugin-robot',
       url='http://avocado-framework.github.io/',
       packages=find_packages(),
       include_package_data=True,
-      install_requires=['robotframework'],
+      install_requires=['robotframework<=3.1.2'],
       test_suite='tests',
       entry_points={
           'console_scripts': [


### PR DESCRIPTION
The current requirement will install the new version of Robot Framework
(3.2), which is coming with incompatible APIs. This is breaking the
Avocado command line and making some tests to fail. This small fix
forces to install robotframework<=3.1.2.

Signed-off-by: Beraldo Leal <bleal@redhat.com>