### PR TITLE
Bump libvirt-python package version on requirements-selftests.txt

### DIFF
--- a/requirements-selftests.txt
+++ b/requirements-selftests.txt
@@ -20,7 +20,7 @@ pycdlib==1.6.0
 # libvirt-python properly with the the current process
 # in make develop. The proper solution would be migrate
 # our make develop process to use pip
-libvirt-python==4.6.0
+libvirt-python==5.9.0
 
 # For avocado.utils.network selftests
 netifaces


### PR DESCRIPTION
When the git repository is cloned and the required packages are installed using `pip install -r requirements-selftests.txt`, it fails as new libvirt interfaces have changed. Update libvirt-python package version fix the problem.

Signed-off-by: Willian Rampazzo <willianr@redhat.com>