### PR TITLE
Multipath and PCI utilities: add return type to docstrings

### DIFF
--- a/avocado/utils/multipath.py
+++ b/avocado/utils/multipath.py
@@ -82,6 +82,7 @@ def get_mpath_name(wwid):
     :param wwid: wwid of multipath device.
 
     :return: Name of multipath device.
+    :rtype: str
     """
     if device_exists(wwid):
         cmd = "multipath -l %s" % wwid
@@ -94,6 +95,7 @@ def get_multipath_wwids():
     Get list of multipath wwids.
 
     :return: List of multipath wwids.
+    :rtype: list of str
     """
     cmd = "egrep -v '^($|#)' /etc/multipath/wwids"
     wwids = process.run(cmd, ignore_status=True,
@@ -107,6 +109,7 @@ def get_paths(wwid):
     Get list of paths, given a multipath wwid.
 
     :return: List of paths.
+    :rtype: list of str
     """
     if not device_exists(wwid):
         return
@@ -125,7 +128,8 @@ def get_multipath_details():
     Get multipath details as a dictionary, as given by the command:
     multipathd show maps json
 
-    :return: Dictionary of multipath output in json format.
+    :return: Dictionary of multipath output in json format
+    :rtype: dict
     """
     mpath_op = process.run("multipathd show maps json",
                            sudo=True).stdout_text
@@ -205,6 +209,7 @@ def get_policy(wwid):
     Gets path_checker policy, given a multipath wwid.
 
     :return: path checker policy.
+    :rtype: str
     """
     if device_exists(wwid):
         cmd = "multipath -ll %s" % wwid
@@ -219,6 +224,7 @@ def get_size(wwid):
     Gets size of device, given a multipath wwid.
 
     :return: size of multipath device.
+    :rtype: str
     """
     if device_exists(wwid):
         cmd = "multipath -ll %s" % wwid

--- a/avocado/utils/pci.py
+++ b/avocado/utils/pci.py
@@ -32,6 +32,7 @@ def get_domains():
     Example, it returns ['0000', '0001', ...]
 
     :return: List of PCI domains.
+    :rtype: list of str
     """
     cmd = "lspci -D"
     output = process.run(cmd, ignore_status=True).stdout_text
@@ -49,6 +50,7 @@ def get_pci_addresses():
     Does not return the PCI Bridges/Switches.
 
     :return: list of full PCI addresses including domain (0000:00:14.0)
+    :rtype: list of str
     """
     addresses = []
     cmd = "lspci -D"
@@ -69,6 +71,7 @@ def get_num_interfaces_in_pci(dom_pci_address):
                             address (0000, 0000:00:1f, 0000:00:1f.2, etc)
 
     :return: number of devices in a PCI domain.
+    :rtype: int
     """
     cmd = "ls -l /sys/class/*/ -1"
     output = process.run(cmd, ignore_status=True,
@@ -231,6 +234,7 @@ def get_pci_prop(pci_address, prop):
     :param part: prop of PCI ID.
 
     :return: specific PCI ID of a PCI address.
+    :rtype: str
     """
     cmd = "lspci -Dnvmm -s %s" % pci_address
     output = process.run(cmd, ignore_status=True).stdout_text
@@ -265,6 +269,7 @@ def get_driver(pci_address):
     :param pci_address: Any segment of a PCI address (1f, 0000:00:1f, ...)
 
     :return: driver of a PCI address.
+    :rtype: str
     """
     cmd = "lspci -ks %s" % pci_address
     output = process.run(cmd, ignore_status=True).stdout_text
@@ -284,6 +289,7 @@ def get_memory_address(pci_address):
     :param pci_address: Any segment of a PCI address (1f, 0000:00:1f, ...)
 
     :return: memory address of a pci_address.
+    :rtype: str
     """
     cmd = "lspci -bv -s %s" % pci_address
     output = process.run(cmd, ignore_status=True).stdout_text
@@ -303,6 +309,7 @@ def get_mask(pci_address):
     :param pci_address: Any segment of a PCI address (1f, 0000:00:1f, ...)
 
     :return: mask of a PCI address.
+    :rtype: str
     """
     cmd = "lspci -vv -s %s" % pci_address
     output = process.run(cmd, ignore_status=True).stdout_text
@@ -328,6 +335,7 @@ def get_vpd(dom_pci_address):
                             least bus addr (0003:00, 0003:00:1f.2, ...)
 
     :return: dictionary of VPD of a PCI address.
+    :rtype: dict
     """
     cmd = "lsvpd -l %s" % dom_pci_address
     vpd = process.run(cmd).stdout_text
@@ -362,6 +370,7 @@ def get_cfg(dom_pci_address):
                             least bus addr (0003:00, 0003:00:1f.2, ...)
 
     :return: dictionary of configuration data of a PCI address.
+    :rtype: dict
     """
     cmd = "lscfg -vl %s" % dom_pci_address
     cfg = process.run(cmd).stdout_text


### PR DESCRIPTION
This is a quick follow up to b258f0d88, which changed the return of
many utilities from bytes into str.  This makes it extra clear the
return type for those utilities.

Signed-off-by: Cleber Rosa <crosa@redhat.com>