### PR TITLE
core.settings: fixed configfile paths when using non-distro installs [v1]

### DIFF
--- a/avocado/core/settings.py
+++ b/avocado/core/settings.py
@@ -27,6 +27,8 @@ from pkg_resources import resource_listdir
 from .settings_dispatcher import SettingsDispatcher
 from ..utils import path
 
+# pylint: disable-msg=too-many-locals
+# pylint: disable-msg=too-many-arguments
 
 class SettingsError(Exception):
     """
@@ -162,8 +164,7 @@ class Settings:
             msg = ("Value '%s' not found in section '%s'" %
                    (key, section))
             raise SettingsError(msg)
-        else:
-            return default
+        return default
 
     def _handle_no_section(self, section, default):
         """
@@ -179,8 +180,7 @@ class Settings:
         if default is self.no_default:
             msg = "Section '%s' doesn't exist in configuration" % section
             raise SettingsError(msg)
-        else:
-            return default
+        return default
 
     def get_value(self, section, key, key_type=str, default=no_default,
                   allow_blank=False):
@@ -278,4 +278,4 @@ class Settings:
                                      (val, key_type, key, section, details))
 
 
-settings = Settings()
+settings = Settings()  # pylint: disable-msg=invalid-name

--- a/avocado/core/settings.py
+++ b/avocado/core/settings.py
@@ -20,6 +20,7 @@ import os
 import glob
 import configparser
 
+from pkg_resources import get_distribution
 from pkg_resources import resource_filename
 from pkg_resources import resource_isdir
 from pkg_resources import resource_listdir
@@ -29,6 +30,7 @@ from ..utils import path
 
 # pylint: disable-msg=too-many-locals
 # pylint: disable-msg=too-many-arguments
+
 
 class SettingsError(Exception):
     """
@@ -229,6 +231,12 @@ class Settings:
                 return False
             return True
 
+        def _prepend_base_path(value):
+            if not value.startswith(('/', '~')):
+                dist = get_distribution('avocado-framework')
+                return os.path.join(dist.location, 'avocado', value)
+            return value
+
         def _get_empty_value(value_type):
             returns = {'str': "",
                        'path': "",
@@ -256,6 +264,9 @@ class Settings:
             # Handle special cases
             if method_or_type == bool:
                 return _string_to_bool(value_stripped)
+
+            if method_or_type == os.path.expanduser:
+                value_stripped = _prepend_base_path(value_stripped)
 
             # Handle other cases
             return method_or_type(value_stripped)

--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -169,7 +169,7 @@ class Command(Collectible):
                                  allow_output_check='combined',
                                  env=env)
         except Exception as exc:  # pylint: disable=W0703
-            log.warn('Could not execute "%s": %s', self.cmd, exc)
+            log.warning('Could not execute "%s": %s', self.cmd, exc)
             return
         logf_path = os.path.join(logdir, self.logf)
         if self._compress_log:

--- a/avocado/etc/avocado/avocado.conf
+++ b/avocado/etc/avocado/avocado.conf
@@ -28,11 +28,11 @@ per_test = False
 
 [sysinfo.collectibles]
 # File with list of commands that will be executed and have their output collected
-commands = /etc/avocado/sysinfo/commands
+commands = etc/avocado/sysinfo/commands
 # File with list of files that will be collected verbatim
-files = /etc/avocado/sysinfo/files
+files = etc/avocado/sysinfo/files
 # File with list of commands that will run alongside the job/test
-profilers = /etc/avocado/sysinfo/profilers
+profilers = etc/avocado/sysinfo/profilers
 
 [runner.output]
 # Whether to display colored output in terminals that support it

--- a/selftests/unit/test_settings.py
+++ b/selftests/unit/test_settings.py
@@ -2,6 +2,7 @@ import os
 import tempfile
 import unittest
 
+from pkg_resources import get_distribution
 from avocado.core import settings
 
 example_1 = """[foo]
@@ -12,6 +13,7 @@ bool_key = True
 list_key = ['I', 'love', 'settings']
 empty_key =
 path = ~/path/at/home
+relative_path = path/at/home
 home_path = ~
 """
 
@@ -48,6 +50,13 @@ class SettingsTest(unittest.TestCase):
                                 len(raw_from_settings))
         self.assertEqual(os.path.expanduser(home_str_from_settings),
                          self.settings.get_value('foo', 'home_path', 'path'))
+
+    def test_relative_path(self):
+        dist = get_distribution('avocado-framework')
+        path_from_settings = self.settings.get_value('foo',
+                                                     'relative_path',
+                                                     'path')
+        self.assertTrue(path_from_settings.startswith(dist.location))
 
     def test_path_on_str_key(self):
         self.assertEqual(self.settings.get_value('foo', 'path', str),


### PR DESCRIPTION
When installing from pip, configfile paths are not relatives to the
current distribution installation path. This set of changes will fix the
the behavior for paths inside configfiles: if a path is relative, then
prepend the right distribution path before using it.