### PR TITLE
Add a switch for enforcing colored output to non-tty targets

### DIFF
--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -87,8 +87,16 @@ class TermSupport:
         term = os.environ.get("TERM")
         colored = settings.get_value('runner.output', 'colored',
                                      key_type='bool', default=True)
-        if not colored or not os.isatty(1) or term not in allowed_terms:
+        force_color = settings.get_value('runner.output', 'color',
+                                         default="auto")
+        if force_color == "never":
             self.disable()
+        elif force_color == "auto":
+            if not colored or not os.isatty(1) or term not in allowed_terms:
+                self.disable()
+        elif force_color != "always":
+            raise ValueError("The value for runner.output.color must be one of "
+                             "'always', 'never', 'auto' and not " + force_color)
 
     def disable(self):
         """

--- a/avocado/etc/avocado/avocado.conf
+++ b/avocado/etc/avocado/avocado.conf
@@ -37,6 +37,9 @@ profilers = etc/avocado/sysinfo/profilers
 [runner.output]
 # Whether to display colored output in terminals that support it
 colored = True
+# Whether to force colored output to non-tty outputs (e.g. log files)
+# Allowed values: auto, always, never
+color = auto
 # Use utf8 encoding (True, False, None=autodetect)
 utf8 =
 


### PR DESCRIPTION
In some cases we are redirecting the output to a periodically
checked log file and preserving the colors to easily detect the
test statuses can be useful too.

Signed-off-by: Plamen Dimitrov <pdimitrov@pevogam.com>