### PR TITLE
Utils kernel improvements

### DIFF
--- a/avocado/utils/kernel.py
+++ b/avocado/utils/kernel.py
@@ -117,6 +117,11 @@ class KernelBuild:
         if self.config_path is not None:
             dotconfig = os.path.join(self.linux_dir, '.config')
             shutil.copy(self.config_path, dotconfig)
+            build.make(self.linux_dir, extra_args='-C %s olddefconfig' %
+                       self.linux_dir)
+        else:
+            build.make(self.linux_dir, extra_args='-C %s defconfig' %
+                       self.linux_dir)
 
     def build(self, binary_package=False):
         """
@@ -132,12 +137,6 @@ class KernelBuild:
         if binary_package is True:
             if self.distro.name == "Ubuntu":
                 build_output_format = "deb-pkg"
-        if self.config_path is None:
-            build.make(self.linux_dir, extra_args='-C %s defconfig' %
-                       self.linux_dir)
-        else:
-            build.make(self.linux_dir, extra_args='-C %s olddefconfig' %
-                       self.linux_dir)
         build.make(self.linux_dir, extra_args='-C %s %s' %
                    (self.linux_dir, build_output_format))
 

--- a/avocado/utils/kernel.py
+++ b/avocado/utils/kernel.py
@@ -55,6 +55,7 @@ class KernelBuild:
             self.data_dirs = data_dirs
         else:
             self.data_dirs = [self.work_dir]
+        self.linux_dir = os.path.join(self.work_dir, 'linux-%s' % self.version)
 
     def __repr__(self):
         return "KernelBuild('%s, %s, %s')" % (self.version,
@@ -96,7 +97,6 @@ class KernelBuild:
         """
         Configure/prepare kernel source to build.
         """
-        self.linux_dir = os.path.join(self.work_dir, 'linux-%s' % self.version)  # pylint: disable=W0201
         build.make(self.linux_dir, extra_args='-C %s mrproper' %
                    self.linux_dir)
         if self.config_path is not None:

--- a/avocado/utils/kernel.py
+++ b/avocado/utils/kernel.py
@@ -55,9 +55,6 @@ class KernelBuild:
             self.data_dirs = data_dirs
         else:
             self.data_dirs = [self.work_dir]
-        self.build_dir = os.path.join(self.work_dir, 'build')
-        if not os.path.isdir(self.build_dir):
-            os.makedirs(self.build_dir)
 
     def __repr__(self):
         return "KernelBuild('%s, %s, %s')" % (self.version,

--- a/avocado/utils/kernel.py
+++ b/avocado/utils/kernel.py
@@ -86,9 +86,14 @@ class KernelBuild:
     def uncompress(self):
         """
         Uncompress kernel source.
+
+        :raises: Exception in case the tarball is not downloaded
         """
-        log.info("Uncompressing tarball")
-        archive.extract(self.asset_path, self.work_dir)
+        if self.asset_path:
+            log.info("Uncompressing tarball")
+            archive.extract(self.asset_path, self.work_dir)
+        else:
+            raise Exception("Unable to find the tarball")
 
     def configure(self):
         """

--- a/avocado/utils/kernel.py
+++ b/avocado/utils/kernel.py
@@ -62,6 +62,13 @@ class KernelBuild:
                                               self.config_path,
                                               self.work_dir)
 
+    @property
+    def vmlinux(self):
+        vmlinux_path = os.path.join(self.linux_dir, 'vmlinux')
+        if os.path.isfile(vmlinux_path):
+            return vmlinux_path
+        return None
+
     def _build_kernel_url(self, base_url=None):
         kernel_file = self.SOURCE.format(version=self.version)
         if base_url is None:

--- a/avocado/utils/kernel.py
+++ b/avocado/utils/kernel.py
@@ -64,9 +64,17 @@ class KernelBuild:
 
     @property
     def vmlinux(self):
-        vmlinux_path = os.path.join(self.linux_dir, 'vmlinux')
+        if not self.build_dir:
+            return None
+        vmlinux_path = os.path.join(self.build_dir, 'vmlinux')
         if os.path.isfile(vmlinux_path):
             return vmlinux_path
+        return None
+
+    @property
+    def build_dir(self):
+        if os.path.isdir(self.linux_dir):
+            return self.linux_dir
         return None
 
     def _build_kernel_url(self, base_url=None):


### PR DESCRIPTION
This PR includes a set of improvements to avocado.utils.kernel module.

The changes came out of the necessity to allow configure() more flexible so that I could compile a vanilla kernel with 'kvmconfig' configuration plus CONFIG_PVH=y, then use on the following test case to QEMU: https://github.com/wainersm/qemu/commit/f66488c1e87156d57804ef139c0170a5f8c0ba53
