### PR TITLE
[v2] Utils kernel improvements

### DIFF
--- a/avocado/utils/kernel.py
+++ b/avocado/utils/kernel.py
@@ -123,6 +123,11 @@ class KernelBuild:
         if self.config_path is not None:
             dotconfig = os.path.join(self.linux_dir, '.config')
             shutil.copy(self.config_path, dotconfig)
+            build.make(self.linux_dir, extra_args='-C %s olddefconfig' %
+                       self.linux_dir)
+        else:
+            build.make(self.linux_dir, extra_args='-C %s defconfig' %
+                       self.linux_dir)
 
     def build(self, binary_package=False):
         """
@@ -138,12 +143,6 @@ class KernelBuild:
         if binary_package is True:
             if self.distro.name == "Ubuntu":
                 build_output_format = "deb-pkg"
-        if self.config_path is None:
-            build.make(self.linux_dir, extra_args='-C %s defconfig' %
-                       self.linux_dir)
-        else:
-            build.make(self.linux_dir, extra_args='-C %s olddefconfig' %
-                       self.linux_dir)
         build.make(self.linux_dir, extra_args='-C %s %s' %
                    (self.linux_dir, build_output_format))
 

--- a/avocado/utils/kernel.py
+++ b/avocado/utils/kernel.py
@@ -62,6 +62,16 @@ class KernelBuild:
                                               self.config_path,
                                               self.work_dir)
 
+    @property
+    def vmlinux(self):
+        """
+        Return the vmlinux path if the file exists
+        """
+        vmlinux_path = os.path.join(self.linux_dir, 'vmlinux')
+        if os.path.isfile(vmlinux_path):
+            return vmlinux_path
+        return None
+
     def _build_kernel_url(self, base_url=None):
         kernel_file = self.SOURCE.format(version=self.version)
         if base_url is None:

--- a/avocado/utils/kernel.py
+++ b/avocado/utils/kernel.py
@@ -67,9 +67,20 @@ class KernelBuild:
         """
         Return the vmlinux path if the file exists
         """
-        vmlinux_path = os.path.join(self.linux_dir, 'vmlinux')
+        if not self.build_dir:
+            return None
+        vmlinux_path = os.path.join(self.build_dir, 'vmlinux')
         if os.path.isfile(vmlinux_path):
             return vmlinux_path
+        return None
+
+    @property
+    def build_dir(self):
+        """
+        Return the build path if the directory exists
+        """
+        if os.path.isdir(self.linux_dir):
+            return self.linux_dir
         return None
 
     def _build_kernel_url(self, base_url=None):

--- a/avocado/utils/kernel.py
+++ b/avocado/utils/kernel.py
@@ -55,6 +55,7 @@ class KernelBuild:
             self.data_dirs = data_dirs
         else:
             self.data_dirs = [self.work_dir]
+        self.linux_dir = os.path.join(self.work_dir, 'linux-%s' % self.version)
 
     def __repr__(self):
         return "KernelBuild('%s, %s, %s')" % (self.version,
@@ -96,7 +97,6 @@ class KernelBuild:
         """
         Configure/prepare kernel source to build.
         """
-        self.linux_dir = os.path.join(self.work_dir, 'linux-%s' % self.version)  # pylint: disable=W0201
         build.make(self.linux_dir, extra_args='-C %s mrproper' %
                    self.linux_dir)
         if self.config_path is not None:

--- a/avocado/utils/kernel.py
+++ b/avocado/utils/kernel.py
@@ -114,9 +114,15 @@ class KernelBuild:
         else:
             raise Exception("Unable to find the tarball")
 
-    def configure(self):
+    def configure(self, targets=('defconfig'), extra_configs=None):
         """
         Configure/prepare kernel source to build.
+
+        :param targets: configuration targets. Default is 'defconfig'.
+        :type targets: list of str
+        :param extra_configs: additional configurations in the form of
+                              CONFIG_NAME=VALUE.
+        :type extra_configs: list of str
         """
         build.make(self.linux_dir, extra_args='-C %s mrproper' %
                    self.linux_dir)
@@ -126,8 +132,21 @@ class KernelBuild:
             build.make(self.linux_dir, extra_args='-C %s olddefconfig' %
                        self.linux_dir)
         else:
-            build.make(self.linux_dir, extra_args='-C %s defconfig' %
-                       self.linux_dir)
+            if isinstance(targets, list):
+                _targets = " ".join(targets)
+            else:
+                _targets = targets
+            build.make(self.linux_dir,
+                       extra_args='-C %s %s' % (self.linux_dir, _targets))
+        if extra_configs:
+            with tempfile.NamedTemporaryFile(mode='w+t',
+                                             prefix='avocado_') as config_file:
+                config_file.write('\n'.join(extra_configs))
+                config_file.flush()
+                cmd = ['cd', self.build_dir, '&&',
+                       './scripts/kconfig/merge_config.sh', '.config',
+                       config_file.name]
+                process.run(" ".join(cmd), shell=True)
 
     def build(self, binary_package=False):
         """

--- a/avocado/utils/kernel.py
+++ b/avocado/utils/kernel.py
@@ -55,9 +55,6 @@ class KernelBuild:
             self.data_dirs = data_dirs
         else:
             self.data_dirs = [self.work_dir]
-        self.build_dir = os.path.join(self.work_dir, 'build')
-        if not os.path.isdir(self.build_dir):
-            os.makedirs(self.build_dir)
 
     def __repr__(self):
         return "KernelBuild('%s, %s, %s')" % (self.version,

--- a/avocado/utils/kernel.py
+++ b/avocado/utils/kernel.py
@@ -13,6 +13,10 @@
 # Author: Ruda Moura <rmoura@redhat.com>
 # Author: Santhosh G <santhog4@linux.vnet.ibm.com>
 
+"""
+Provides utilities for the Linux kernel.
+"""
+
 import os
 import shutil
 import logging
@@ -21,7 +25,7 @@ from distutils.version import LooseVersion  # pylint: disable=E0611
 
 from . import asset, archive, build, distro, process
 
-log = logging.getLogger('avocado.test')
+LOG = logging.getLogger('avocado.test')
 
 
 class KernelBuild:
@@ -109,7 +113,7 @@ class KernelBuild:
         :raises: Exception in case the tarball is not downloaded
         """
         if self.asset_path:
-            log.info("Uncompressing tarball")
+            LOG.info("Uncompressing tarball")
             archive.extract(self.asset_path, self.work_dir)
         else:
             raise Exception("Unable to find the tarball")
@@ -157,7 +161,7 @@ class KernelBuild:
                                   for install() to use
         :type binary_pacakge: bool
         """
-        log.info("Starting build the kernel")
+        LOG.info("Starting build the kernel")
         build_output_format = ""
         if binary_package is True:
             if self.distro.name == "Ubuntu":
@@ -169,12 +173,12 @@ class KernelBuild:
         """
         Install built kernel.
         """
-        log.info("Starting kernel install")
+        LOG.info("Starting kernel install")
         if self.distro.name == "Ubuntu":
             process.run('dpkg -i %s/*.deb' %
                         self.work_dir, shell=True, sudo=True)
         else:
-            log.info("Skipping kernel install")
+            LOG.info("Skipping kernel install")
 
     def __del__(self):
         shutil.rmtree(self.work_dir)

--- a/avocado/utils/kernel.py
+++ b/avocado/utils/kernel.py
@@ -86,9 +86,14 @@ class KernelBuild:
     def uncompress(self):
         """
         Uncompress kernel source.
+
+        :raises: Exception in case the tarball is not downloaded
         """
-        log.info("Uncompressing tarball")
-        archive.extract(self.asset_path, self.work_dir)
+        if self.asset_path:
+            log.info("Uncompressing tarball")
+            archive.extract(self.asset_path, self.work_dir)
+        else:
+            raise Exception("Unable to find the tarball")
 
     def configure(self):
         """

--- a/avocado/utils/kernel.py
+++ b/avocado/utils/kernel.py
@@ -55,7 +55,7 @@ class KernelBuild:
             self.data_dirs = data_dirs
         else:
             self.data_dirs = [self.work_dir]
-        self.linux_dir = os.path.join(self.work_dir, 'linux-%s' % self.version)
+        self._build_dir = os.path.join(self.work_dir, 'linux-%s' % self.version)
 
     def __repr__(self):
         return "KernelBuild('%s, %s, %s')" % (self.version,
@@ -79,8 +79,8 @@ class KernelBuild:
         """
         Return the build path if the directory exists
         """
-        if os.path.isdir(self.linux_dir):
-            return self.linux_dir
+        if os.path.isdir(self._build_dir):
+            return self._build_dir
         return None
 
     def _build_kernel_url(self, base_url=None):
@@ -124,26 +124,26 @@ class KernelBuild:
                               CONFIG_NAME=VALUE.
         :type extra_configs: list of str
         """
-        build.make(self.linux_dir, extra_args='-C %s mrproper' %
-                   self.linux_dir)
+        build.make(self._build_dir, extra_args='-C %s mrproper' %
+                   self._build_dir)
         if self.config_path is not None:
-            dotconfig = os.path.join(self.linux_dir, '.config')
+            dotconfig = os.path.join(self._build_dir, '.config')
             shutil.copy(self.config_path, dotconfig)
-            build.make(self.linux_dir, extra_args='-C %s olddefconfig' %
-                       self.linux_dir)
+            build.make(self._build_dir, extra_args='-C %s olddefconfig' %
+                       self._build_dir)
         else:
             if isinstance(targets, list):
                 _targets = " ".join(targets)
             else:
                 _targets = targets
-            build.make(self.linux_dir,
-                       extra_args='-C %s %s' % (self.linux_dir, _targets))
+            build.make(self.build_dir,
+                       extra_args='-C %s %s' % (self.build_dir, _targets))
         if extra_configs:
             with tempfile.NamedTemporaryFile(mode='w+t',
                                              prefix='avocado_') as config_file:
                 config_file.write('\n'.join(extra_configs))
                 config_file.flush()
-                cmd = ['cd', self.build_dir, '&&',
+                cmd = ['cd', self._build_dir, '&&',
                        './scripts/kconfig/merge_config.sh', '.config',
                        config_file.name]
                 process.run(" ".join(cmd), shell=True)
@@ -162,8 +162,8 @@ class KernelBuild:
         if binary_package is True:
             if self.distro.name == "Ubuntu":
                 build_output_format = "deb-pkg"
-        build.make(self.linux_dir, extra_args='-C %s %s' %
-                   (self.linux_dir, build_output_format))
+        build.make(self._build_dir, extra_args='-C %s %s' %
+                   (self._build_dir, build_output_format))
 
     def install(self):
         """


### PR DESCRIPTION
Version 2 of https://github.com/avocado-framework/avocado/pull/3386

Changes:
 - Accepted @clebergnu 's suggestions
 - Added a handler for `targets` parameter of `configure()` when it uses default value (commit https://github.com/avocado-framework/avocado/commit/786f7a4cd3675916e950580c6fb3e0c0fd6a9b86)
 - Added docstring for `build_dir` property
 - Added commit that fixes pylint warnings