### PR TITLE
Loader refactors

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -440,8 +440,8 @@ class FileLoader(TestLoader):
     """
 
     name = 'file'
-    __not_test_str = ("Not an INSTRUMENTED (avocado.Test based), PyUNITTEST ("
-                      "unittest.TestCase based) or SIMPLE (executable) test")
+    NOT_TEST_STR = ("Not an INSTRUMENTED (avocado.Test based), PyUNITTEST ("
+                    "unittest.TestCase based) or SIMPLE (executable) test")
 
     def __init__(self, args, extra_params):
         test_type = extra_params.pop('allowed_test_types', None)
@@ -589,7 +589,7 @@ class FileLoader(TestLoader):
             # Module does not have an avocado test class inside, and
             # it's not executable. Not a Test.
             return make_broken(NotATest, test_path,
-                               self.__not_test_str)
+                               self.NOT_TEST_STR)
 
     def _make_existing_file_tests(self, test_path, make_broken,
                                   subtests_filter, test_name=None):
@@ -721,7 +721,7 @@ class FileLoader(TestLoader):
                                                               test_name)
                 return make_broken(NotATest, test_name, "File not found "
                                    "('%s'; '%s')" % (test_name, test_path))
-        return make_broken(NotATest, test_name, self.__not_test_str)
+        return make_broken(NotATest, test_name, self.NOT_TEST_STR)
 
 
 class ExternalLoader(TestLoader):

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -591,8 +591,8 @@ class FileLoader(TestLoader):
             return make_broken(NotATest, test_path,
                                self.NOT_TEST_STR)
 
-    def _make_existing_file_tests(self, test_path, make_broken,
-                                  subtests_filter, test_name=None):
+    def _make_python_file_tests(self, test_path, make_broken,
+                                subtests_filter, test_name=None):
         if test_name is None:
             test_name = test_path
         try:
@@ -686,8 +686,8 @@ class FileLoader(TestLoader):
                 return make_broken(AccessDeniedPath, test_path, "Is not "
                                    "readable")
             if test_path.endswith('.py'):
-                return self._make_existing_file_tests(test_path, make_broken,
-                                                      subtests_filter)
+                return self._make_python_file_tests(test_path, make_broken,
+                                                    subtests_filter)
             else:
                 return self._make_simple_or_broken_test(test_path,
                                                         subtests_filter,
@@ -705,9 +705,9 @@ class FileLoader(TestLoader):
             # Try to resolve test ID (keep compatibility)
             test_path = os.path.join(data_dir.get_test_dir(), test_name)
             if os.path.exists(test_path):
-                return self._make_existing_file_tests(test_path, make_broken,
-                                                      subtests_filter,
-                                                      test_name)
+                return self._make_python_file_tests(test_path, make_broken,
+                                                    subtests_filter,
+                                                    test_name)
             else:
                 if not subtests_filter and ':' in test_name:
                     test_name, subtests_filter = test_name.split(':', 1)
@@ -715,10 +715,10 @@ class FileLoader(TestLoader):
                                              test_name)
                     if os.path.exists(test_path):
                         subtests_filter = re.compile(subtests_filter)
-                        return self._make_existing_file_tests(test_path,
-                                                              make_broken,
-                                                              subtests_filter,
-                                                              test_name)
+                        return self._make_python_file_tests(test_path,
+                                                            make_broken,
+                                                            subtests_filter,
+                                                            test_name)
                 return make_broken(NotATest, test_name, "File not found "
                                    "('%s'; '%s')" % (test_name, test_path))
         return make_broken(NotATest, test_name, self.NOT_TEST_STR)

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -575,13 +575,16 @@ class FileLoader(TestLoader):
                 result += candidates
         return result
 
+    def _make_simple_test(self, test_path, subtests_filter):
+        return self._make_test(test.SimpleTest, test_path,
+                               subtests_filter=subtests_filter,
+                               executable=test_path)
+
     def _make_simple_or_broken_test(self, test_path, subtests_filter, make_broken):
         if os.access(test_path, os.X_OK):
             # Module does not have an avocado test class inside but
             # it's executable, let's execute it.
-            return self._make_test(test.SimpleTest, test_path,
-                                   subtests_filter=subtests_filter,
-                                   executable=test_path)
+            return self._make_simple_test(test_path, subtests_filter)
         else:
             # Module does not have an avocado test class inside, and
             # it's not executable. Not a Test.
@@ -686,13 +689,9 @@ class FileLoader(TestLoader):
                 return self._make_existing_file_tests(test_path, make_broken,
                                                       subtests_filter)
             else:
-                if os.access(test_path, os.X_OK):
-                    return self._make_test(test.SimpleTest, test_path,
-                                           subtests_filter=subtests_filter,
-                                           executable=test_path)
-                else:
-                    return make_broken(NotATest, test_path,
-                                       self.__not_test_str)
+                return self._make_simple_or_broken_test(test_path,
+                                                        subtests_filter,
+                                                        make_broken)
         else:
             if os.path.islink(test_path):
                 try:


### PR DESCRIPTION
This is originally from #3393, described as:

"The first part of the pull request is actually a refactoring of FileLoader to simplify the creation of alternative loaders. The newly introduced class, SimpleFileLoader, is then used by the TAP plugin, but it could also be used by e.g. the GLib loader in order to get better error reporting (e.g. broken links) and remove duplicated code.".

The only change compared to #3393 is a very simple style fix.