### PR TITLE
utils/service: replace mktemp with mkstemp

### DIFF
--- a/avocado/utils/service.py
+++ b/avocado/utils/service.py
@@ -24,7 +24,7 @@
 import os
 import re
 import logging
-from tempfile import mktemp
+from tempfile import mkstemp
 
 from . import process
 
@@ -655,7 +655,7 @@ class _SystemdServiceManager(_GenericServiceManager):
         :param runlevel: default systemd target
         :type runlevel: str
         """
-        tmp_symlink = mktemp(dir="/etc/systemd/system")
+        tmp_symlink = mkstemp(dir="/etc/systemd/system")
         os.symlink("/usr/lib/systemd/system/%s" % runlevel, tmp_symlink)
         os.rename(tmp_symlink, "/etc/systemd/system/default.target")
 

--- a/selftests/unit/test_utils_service.py
+++ b/selftests/unit/test_utils_service.py
@@ -209,7 +209,7 @@ class TestSystemdServiceManager(unittest.TestCase):
         symlink_mock = unittest.mock.Mock()
         rename_mock = unittest.mock.Mock()
 
-        @unittest.mock.patch.object(service, "mktemp", mktemp_mock)
+        @unittest.mock.patch.object(service, "mkstemp", mktemp_mock)
         @unittest.mock.patch("os.symlink", symlink_mock)
         @unittest.mock.patch("os.rename", rename_mock)
         def _():


### PR DESCRIPTION
lgtm was alerting one error related to mktemp deprecated function. This
small change replaces mktemp with mkstemp.

Reference: https://lgtm.com/rules/1507928201922/

Signed-off-by: Beraldo Leal <bleal@redhat.com>