### PR TITLE
core/output: Catching ignored exception

### DIFF
--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -557,7 +557,7 @@ class Paginator:
     def close(self):
         try:
             self.pipe.close()
-        except OSError:
+        except (OSError, AttributeError):
             pass
 
     def write(self, msg):


### PR DESCRIPTION
When self.pipe do not exists, an AttributeError exception is raised.
This change just add this catch.

Signed-off-by: Beraldo Leal <bleal@redhat.com>