### PR TITLE
fixes yaml.load deprecation warning

### DIFF
--- a/optional_plugins/varianter_yaml_to_mux/tests/test_unit.py
+++ b/optional_plugins/varianter_yaml_to_mux/tests/test_unit.py
@@ -450,7 +450,7 @@ class TestMultipleLoaders(unittest.TestCase):
             children_type = ("<class 'avocado_varianter_yaml_to_mux."
                              "NamedTreeNodeDebug'>")
         self.assertEqual(children_type, str(type(debug.children[0])))
-        plain = yaml.load("foo: bar")
+        plain = yaml.load("foo: bar", Loader=yaml.SafeLoader)
         self.assertEqual(type(plain), dict)
 
 


### PR DESCRIPTION
Use of PyYAML's yaml.load function without specifying the Loader=... parameter,
has been deprecated and a warning is displayed when running selftests/run.
This small change fixes that.

Reference: https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

Signed-off-by: Beraldo Leal <bleal@redhat.com>