### PR TITLE
core/output: Catching ignored exception [v2]

### DIFF
--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -542,6 +542,7 @@ class Paginator:
     """
 
     def __init__(self):
+        self.pipe = None
         paginator = os.environ.get('PAGER')
         if not paginator:
             try:
@@ -555,19 +556,21 @@ class Paginator:
         self.close()
 
     def close(self):
-        try:
-            self.pipe.close()
-        except OSError:
-            pass
+        if self.pipe:
+            try:
+                self.pipe.close()
+            except OSError:
+                pass
 
     def write(self, msg):
-        try:
-            self.pipe.write(msg)
-        except (OSError, ValueError):
-            pass
+        if self.pipe:
+            try:
+                self.pipe.write(msg)
+            except (OSError, ValueError):
+                pass
 
     def flush(self):
-        if not self.pipe.closed:
+        if self.pipe and not self.pipe.closed:
             self.pipe.flush()
 
 


### PR DESCRIPTION
When self.pipe do not exist, an AttributeError exception is raised.
This change just adds this catch.

Signed-off-by: Beraldo Leal <bleal@redhat.com>

-----------------------
Changes from v1:

  * Changed the approach as suggested by @clebergnu.
    Now is check if self.pipe exists on close, write and flush methods.