### PR TITLE
Refactor Asset class to prepare for new features. [V2]

### DIFF
--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -18,6 +18,7 @@ Asset fetcher from multiple locations
 
 import errno
 import hashlib
+import json
 import logging
 import os
 import re
@@ -26,7 +27,6 @@ import stat
 import sys
 import tempfile
 import time
-import json
 
 try:
     import urlparse
@@ -40,11 +40,11 @@ from .download import url_download
 from .filelock import FileLock
 
 
-log = logging.getLogger('avocado.test')
-
-
+LOG = logging.getLogger('avocado.test')
 #: The default hash algorithm to use on asset cache operations
 DEFAULT_HASH_ALGORITHM = 'sha1'
+#: The default location for assets download into the cache
+LOCATION = 'by_location'
 
 
 class UnsupportedProtocolError(EnvironmentError):
@@ -55,11 +55,11 @@ class UnsupportedProtocolError(EnvironmentError):
 
 class Asset:
     """
-    Try to fetch/verify an asset file from multiple locations.
+    Handles assets from from multiple locations.
     """
 
-    def __init__(self, name, asset_hash, algorithm, locations, cache_dirs,
-                 expire=None, metadata=None):
+    def __init__(self, name, asset_hash=None, algorithm=None, locations=None,
+                 cache_dirs=None, expire=None, metadata=None):
         """
         Initialize the Asset() class.
 
@@ -71,20 +71,177 @@ class Asset:
         :param expire: time in seconds for the asset to expire
         :param metadata: metadata which will be saved inside metadata file
         """
-        self.name = name
+        parsed_url = urlparse.urlparse(name)
+        # Asset file name
+        self.basename = os.path.basename(parsed_url.path)
         self.asset_hash = asset_hash
-        if algorithm is None:
-            self.algorithm = DEFAULT_HASH_ALGORITHM
-        else:
-            self.algorithm = algorithm
 
-        if isinstance(locations, str):
-            self.locations = [locations]
+        if algorithm:
+            self.algorithm = algorithm
         else:
-            self.locations = locations
-        self.cache_dirs = cache_dirs
+            self.algorithm = DEFAULT_HASH_ALGORITHM
+
+        self.locations = []
+        # If `name` is an url, move it to `locations`
+        if parsed_url.scheme:
+            self.locations.append(os.path.dirname(parsed_url.geturl()))
+        # Let's be conservative and check `locations` type
+        if isinstance(locations, str):
+            # remove asset name from location
+            if self.basename in locations:
+                parsed_locations = urlparse.urlparse(locations)
+                self.locations.append(
+                    os.path.dirname(parsed_locations.geturl()))
+            else:
+                self.locations.append(locations)
+        elif isinstance(locations, list):
+            # remove asset name from location
+            for location in locations:
+                if self.basename in location:
+                    parsed_location = urlparse.urlparse(location)
+                    self.locations.append(
+                        os.path.dirname(parsed_location.geturl()))
+                else:
+                    self.locations.append(location)
+
+        # Let's make the user's life easy and handle the cache
+        if cache_dirs:
+            self.cache_dirs = cache_dirs
+        else:
+            # Break early if we don't have the cache_dirs. This is necessary
+            # so we don't change the Asset signature.
+            raise EnvironmentError("At least one cache directory is necessary"
+                                   " to download the asset.")
+
         self.expire = expire
         self.metadata = metadata
+
+        # Break early. We need to know the source location of the asset.
+        if not self.locations:
+            raise EnvironmentError("An asset should have at least one source"
+                                   " location. Double check your asset name"
+                                   " and location and make sure to use a"
+                                   " supported protocol.")
+
+    def _create_hash_file(self, asset_path):
+        """
+        Compute the hash of the asset file and add it to the CHECKSUM
+        file.
+
+        :param asset_file: full path of the asset file.
+        """
+        result = crypto.hash_file(asset_path, algorithm=self.algorithm)
+        with open(self._get_hash_file(asset_path), 'w') as hash_file:
+            hash_file.write('%s %s\n' % (self.algorithm, result))
+
+    def _create_metadata_file(self, asset_dir):
+        """
+        Creates JSON file with metadata.
+        The file will be saved as `asset_file`_metadata.json
+
+        :param asset_dir: full path where the asset file is located.
+        """
+        metadata_file_name = "%s_metadata.json" % self.basename
+        metadata_path = os.path.join(os.path.dirname(asset_dir),
+                                     metadata_file_name)
+        metadata = json.dumps(self.metadata)
+        with open(metadata_path, "w") as metadata_file:
+            metadata_file.write(metadata)
+
+    def _download(self, url_obj, asset_path):
+        """
+        Download the asset from an url.
+
+        :param url_obj: object from urlparse.
+        :param asset_path: full path of the asset file.
+        :returns: if the downloaded file matches the hash.
+        :rtype: bool
+        """
+        try:
+            # Temporary unique name to use while downloading
+            temp = '%s.%s' % (asset_path,
+                              next(tempfile._get_candidate_names()))  # pylint: disable=W0212
+            url_download(url_obj.geturl(), temp)
+
+            # Acquire lock only after download the file
+            with FileLock(asset_path, 1):
+                shutil.move(temp, asset_path)
+                self._create_hash_file(asset_path)
+                return self._verify(asset_path)
+        except OSError:
+            if os.path.isfile(temp):
+                os.remove(temp)
+            elif os.path.isfile(asset_path):
+                os.remove(asset_path)
+
+    @staticmethod
+    def _get_hash_file(asset_path):
+        """
+        Returns the file name that contains the hash for a given asset file
+
+        :param asset_path: full path of the asset file.
+        :returns: the CHECKSUM path
+        :rtype: str
+        """
+        return '%s-CHECKSUM' % asset_path
+
+    def _get_hash_from_file(self, asset_path):
+        """
+        Read the CHECKSUM file from the asset and return the hash.
+
+        :param asset_path: full path of the asset file.
+        :returns: the hash, if it exists.
+        :rtype: str
+        """
+        discovered = None
+        hash_file = self._get_hash_file(asset_path)
+        if not os.path.isfile(hash_file):
+            self._create_hash_file(asset_path)
+
+        with open(hash_file, 'r') as hash_file:
+            hash_value = hash_file.read()
+            # md5 is 32 chars big and sha512 is 128 chars big.
+            # others supported algorithms are between those.
+            pattern = '%s [a-f0-9]{32,128}' % self.algorithm
+            if re.match(pattern, hash_value):
+                discovered = hash_value.split()[1]
+        return discovered
+
+    def _get_local_file(self, url_obj, asset_path):
+        """
+        Create a symlink for a local file into the cache.
+
+        :param url_obj: object from urlparse.
+        :param asset_path: full path of the asset file.
+        :returns: if the local file matches the hash.
+        :rtype: bool
+        """
+        with FileLock(asset_path, 1):
+            try:
+                os.symlink(url_obj.path, asset_path)
+                self._create_hash_file(asset_path)
+            except OSError as detail:
+                if detail.errno == errno.EEXIST:
+                    os.remove(asset_path)
+                    os.symlink(url_obj.path, asset_path)
+                    self._create_hash_file(asset_path)
+
+        return self._verify(asset_path)
+
+    @staticmethod
+    def _get_relative_dir(url):
+        """
+        All assets are saved on `LOCATION/hash_from_location`. This way we
+        know all assets are under `LOCATION`, making it easy to extend
+        command-line functionalities like assets `list` or `search`.
+
+        :param url: asset url/directory location.
+        :returns: target location of asset the file.
+        :rtype: str
+        """
+        url_hash = hashlib.new(DEFAULT_HASH_ALGORITHM,
+                               url.encode(astring.ENCODING))
+        return os.path.join(LOCATION, url_hash.hexdigest())
 
     def _get_writable_cache_dir(self):
         """
@@ -105,91 +262,34 @@ class Asset:
         raise EnvironmentError("Can't find a writable cache directory.")
 
     @staticmethod
-    def _get_hash_file(asset_file):
+    def _is_expired(asset_path, expire):
         """
-        Returns the file name that contains the hash for a given asset file
-        """
-        return '%s-CHECKSUM' % asset_file
+        Checks if a file is expired according to expired parameter.
 
-    def _get_relative_dir(self, parsed_url):
+        :param path: full path of the asset file.
+        :returns: the expired status of an asset.
+        :rtype: bool
         """
-        When an asset name is not an URL, and it also has a hash,
-        there's a clear intention for it to be unique *by name*,
-        overwriting it if the file is corrupted or expired.  These
-        will be stored in the cache directory indexed by name.
+        if expire is None:
+            return False
+        creation_time = os.lstat(asset_path)[stat.ST_CTIME]
+        expire_time = creation_time + expire
+        if time.time() > expire_time:
+            return True
+        return False
 
-        When an asset name is an URL, whether it has a hash or not, it
-        will be saved according to their locations, so that multiple
-        assets with the same file name, but completely unrelated to
-        each other, will still coexist.
+    def _verify(self, asset_path):
         """
-        if self.asset_hash and not parsed_url.scheme:
-            return 'by_name'
-        base_url = "%s://%s/%s" % (parsed_url.scheme,
-                                   parsed_url.netloc,
-                                   os.path.dirname(parsed_url.path))
-        base_url_hash = hashlib.new(DEFAULT_HASH_ALGORITHM,
-                                    base_url.encode(astring.ENCODING))
-        return os.path.join('by_location', base_url_hash.hexdigest())
+        Verify if the `asset_path` hash matches the hash in the hash file.
 
-    def _find_asset_file(self, relative_path):
+        :param asset_path: full path of the asset file.
+        :returns: True when self.asset_hash is None or when it has the same
+        value as the hash of the asset_file, otherwise return False.
+        :rtype: bool
         """
-        Search for the asset file in each one of the cache locations
-        :param relative_path: Path where file should be
-        :return: asset file if exists or None
-        :rtype: str or None
-        """
-        for cache_dir in self.cache_dirs:
-            cache_dir = os.path.expanduser(cache_dir)
-            asset_file = os.path.join(cache_dir, relative_path)
-
-            # To use a cached file, it must:
-            # - Exists.
-            # - Be valid (not expired).
-            # - Be verified (hash check).
-            if (os.path.isfile(asset_file) and
-                    not self._is_expired(asset_file, self.expire)):
-                try:
-                    with FileLock(asset_file, 30):
-                        if self._verify(asset_file):
-                            return asset_file
-                except Exception:  # pylint: disable=W0703
-                    exc_type, exc_value = sys.exc_info()[:2]
-                    log.error('%s: %s', exc_type.__name__, exc_value)
-        return None
-
-    def _create_metadata_file(self, asset_file):
-        """
-        Creates JSON file with metadata.
-        The file will be saved as "asset_file"_metadata.json
-        :param asset_file: The asset whose metadata will be saved
-        :type asset_file: str
-        """
-        if self.metadata is not None:
-            basename = os.path.splitext(asset_file)[0]
-            metadata_file = "%s_metadata.json" % basename
-            metadata = json.dumps(self.metadata)
-            with open(metadata_file, "w") as f:
-                f.write(metadata)
-
-    def get_metadata(self):
-        """
-        Returns metadata of the asset if it exists or None.
-        :return: metadata
-        """
-        parsed_url = urlparse.urlparse(self.name)
-        basename = os.path.basename(parsed_url.path)
-        cache_relative_dir = self._get_relative_dir(parsed_url)
-        asset_file = self._find_asset_file(os.path.join(cache_relative_dir,
-                                                        basename))
-        if asset_file is not None:
-            basename = os.path.splitext(asset_file)[0]
-            metadata_file = "%s_metadata.json" % basename
-            if os.path.isfile(metadata_file):
-                with open(metadata_file, "r") as f:
-                    metadata = json.loads(f.read())
-                    return metadata
-        return None
+        return bool(not self.asset_hash or
+                    (self.asset_hash and
+                     self._get_hash_from_file(asset_path) == self.asset_hash))
 
     def fetch(self):
         """
@@ -199,127 +299,105 @@ class Asset:
 
         :raise EnvironmentError: When it fails to fetch the asset
         :returns: The path for the file on the cache directory.
+        :rtype: str
         """
-        urls = []
-        parsed_url = urlparse.urlparse(self.name)
-        basename = os.path.basename(parsed_url.path)
-        cache_relative_dir = self._get_relative_dir(parsed_url)
-
-        # If name is actually an url, it has to be included in urls list
-        if parsed_url.scheme:
-            urls.append(parsed_url.geturl())
-
         # First let's search for the file in each one of the cache locations
-        asset_file = self._find_asset_file(os.path.join(cache_relative_dir,
-                                                        basename))
-        if asset_file is not None:
-            if self.metadata is not None:
-                self._create_metadata_file(asset_file)
-            return asset_file
+        asset_path = self.find_asset_file()
+        # If asset file exists locally, let's create the metadata and return
+        # the path to the file.
+        if asset_path:
+            if self.metadata:
+                self._create_metadata_file(asset_path)
+            return asset_path
 
-        # If we get to this point, we have to download it from a location.
-        # A writable cache directory is then needed. The first available
-        # writable cache directory will be used.
+        # If we get to this point, we have to download the asset.
+        # We need a writable cache directory. The first available writable
+        # cache directory is used.
         cache_dir = self._get_writable_cache_dir()
-        # Now we have a writable cache_dir. Let's get the asset.
-        # Adding the user defined locations to the urls list:
-        if self.locations is not None:
-            for item in self.locations:
-                urls.append(item)
 
-        cache_relative_dir = self._get_relative_dir(parsed_url)
-        for url in urls:
+        # We have a writable cache_dir. Let's get the asset.
+        # Download asset from first available url and return its local path.
+        for location in self.locations:
+            url = os.path.join(location, self.basename)
             urlobj = urlparse.urlparse(url)
+            # Select the correct transport protocol.
             if urlobj.scheme in ['http', 'https', 'ftp']:
-                fetch = self._download
+                fetch_func = self._download
             elif urlobj.scheme == 'file':
-                fetch = self._get_local_file
+                fetch_func = self._get_local_file
             else:
                 raise UnsupportedProtocolError("Unsupported protocol"
                                                ": %s" % urlobj.scheme)
-            asset_file = os.path.join(cache_dir, cache_relative_dir, basename)
-            dirname = os.path.dirname(asset_file)
+
+            # Create the target directory for the asset
+            relative_dir = self._get_relative_dir(location)
+            asset_path = os.path.join(cache_dir, relative_dir, self.basename)
+            dirname = os.path.dirname(asset_path)
             if not os.path.isdir(dirname):
                 os.makedirs(dirname)
+
+            # Let's try to download the asset.
             try:
-                if fetch(urlobj, asset_file):
-                    if self.metadata is not None:
-                        self._create_metadata_file(asset_file)
-                    return asset_file
+                if fetch_func(urlobj, asset_path):
+                    # Success! Create metadata.
+                    if self.metadata:
+                        self._create_metadata_file(asset_path)
+                    return asset_path
+                # If fetch_func returns False, we have a hash mismatch
+                raise EnvironmentError("Hash mismatch for asset %s."
+                                       % self.basename)
             except Exception:  # pylint: disable=W0703
                 exc_type, exc_value = sys.exc_info()[:2]
-                log.error('%s: %s', exc_type.__name__, exc_value)
+                LOG.error('%s: %s', exc_type.__name__, exc_value)
 
-        raise EnvironmentError("Failed to fetch %s." % basename)
+        # If we get here, we could not download the asset.
+        raise EnvironmentError("Failed to fetch %s." % self.basename)
 
-    def _download(self, url_obj, asset_file):
-        try:
-            # Temporary unique name to use while downloading
-            temp = '%s.%s' % (asset_file,
-                              next(tempfile._get_candidate_names()))  # pylint: disable=W0212
-            url_download(url_obj.geturl(), temp)
+    def find_asset_file(self):
+        """
+        Search for the asset file in each one of the cache locations
 
-            # Acquire lock only after download the file
-            with FileLock(asset_file, 1):
-                shutil.copy(temp, asset_file)
-                self._compute_hash(asset_file)
-                return self._verify(asset_file)
-        finally:
-            os.remove(temp)
+        :return: asset file if exists or None
+        :rtype: str or None
+        """
+        for cache_dir in self.cache_dirs:
+            cache_dir = os.path.expanduser(cache_dir)
 
-    def _compute_hash(self, asset_file):
-        result = crypto.hash_file(asset_file, algorithm=self.algorithm)
-        with open(self._get_hash_file(asset_file), 'w') as f:
-            f.write('%s %s\n' % (self.algorithm, result))
+            for location in self.locations:
+                relative_dir = self._get_relative_dir(location)
+                asset_path = os.path.join(cache_dir,
+                                          relative_dir,
+                                          self.basename)
 
-    def _get_hash_from_file(self, asset_file):
-        discovered = None
-        hash_file = self._get_hash_file(asset_file)
-        if not os.path.isfile(hash_file):
-            self._compute_hash(asset_file)
+                # To use a cached file, it must:
+                # - Exists.
+                # - Be valid (not expired).
+                # - Be verified (hash check).
+                if (os.path.isfile(asset_path) and
+                        not self._is_expired(asset_path, self.expire)):
+                    try:
+                        with FileLock(asset_path, 30):
+                            if self._verify(asset_path):
+                                return asset_path
+                    except Exception:  # pylint: disable=W0703
+                        exc_type, exc_value = sys.exc_info()[:2]
+                        LOG.error('%s: %s', exc_type.__name__, exc_value)
+        return None
 
-        with open(hash_file, 'r') as hash_file:
-            for line in hash_file:
-                # md5 is 32 chars big and sha512 is 128 chars big.
-                # others supported algorithms are between those.
-                pattern = '%s [a-f0-9]{32,128}' % self.algorithm
-                if re.match(pattern, line):
-                    discovered = line.split()[1]
-                    break
-        return discovered
+    def get_metadata(self):
+        """
+        Returns metadata of the asset if it exists or None.
 
-    def _verify(self, asset_file):
-        if not self.asset_hash:
-            return True
-        if self._get_hash_from_file(asset_file) == self.asset_hash:
-            return True
-        else:
-            return False
-
-    def _get_local_file(self, url_obj, asset_file):
-        if os.path.isdir(url_obj.path):
-            path = os.path.join(url_obj.path, self.name)
-        else:
-            path = url_obj.path
-
-        with FileLock(asset_file, 1):
-            try:
-                os.symlink(path, asset_file)
-                self._compute_hash(asset_file)
-                return self._verify(asset_file)
-            except OSError as detail:
-                if detail.errno == errno.EEXIST:
-                    os.remove(asset_file)
-                    os.symlink(path, asset_file)
-                    self._compute_hash(asset_file)
-                    return self._verify(asset_file)
-
-    @staticmethod
-    def _is_expired(path, expire):
-        if expire is None:
-            return False
-        creation_time = os.lstat(path)[stat.ST_CTIME]
-        expire_time = creation_time + expire
-        if time.time() > expire_time:
-            return True
-        return False
+        :return: metadata
+        :rtype: dict or None
+        """
+        asset_path = self.find_asset_file()
+        if asset_path:
+            metadata_file_name = "%s_metadata.json" % self.basename
+            metadata_path = os.path.join(os.path.dirname(asset_path),
+                                         metadata_file_name)
+            if os.path.isfile(metadata_path):
+                with open(metadata_path, "r") as metadata_file:
+                    metadata = json.loads(metadata_file.read())
+                    return metadata
+        return None


### PR DESCRIPTION
Some new requirements on assets need a more flexible Asset class. The intent of this patch is to refactor some parts of the Asset class, making it simple and improving the flexibility for future extensions.

The option to save an asset on `by_name` directory was removed. All assets are now saved on `by_location` directory. Directory hash is based on asset location. This makes it easy to implement new features, like the `find` and `list` command-line options.

Added some checks on class constructor to avoid breaking the class API.

Signed-off-by: Willian Rampazzo <willianr@redhat.com>

Changes from V1:
- added some missing docstrings;
- removed old testing code that was left by mistake.