### PR TITLE
add TAP test loader

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -120,6 +120,7 @@ class TestLoaderProxy:
                                        ", ".join(_good_test_types(plugin)))
             return out.rstrip('\n')
 
+        self.register_plugin(TapLoader)
         # Register external runner when --external-runner is used
         if args.get("external_runner", None):
             self.register_plugin(ExternalLoader)
@@ -855,6 +856,32 @@ class ExternalLoader(TestLoader):
     @staticmethod
     def get_decorator_mapping():
         return {test.ExternalRunnerTest: output.TERM_SUPPORT.healthy_str}
+
+
+class TapLoader(SimpleFileLoader):
+    """
+    Test Anything Protocol loader class
+    """
+    name = "tap"
+
+    @staticmethod
+    def get_type_label_mapping():
+        mapping = SimpleFileLoader.get_type_label_mapping()
+        mapping.update(
+            {test.TapTest: 'TAP'})
+        return mapping
+
+    @staticmethod
+    def get_decorator_mapping():
+        mapping = SimpleFileLoader.get_decorator_mapping()
+        mapping.update(
+            {test.TapTest: output.TERM_SUPPORT.healthy_str})
+        return mapping
+
+    def _make_simple_test(self, test_path, subtests_filter):
+        return self._make_test(test.TapTest, test_path,
+                               subtests_filter=subtests_filter,
+                               executable=test_path)
 
 
 loader = TestLoaderProxy()

--- a/avocado/core/tapparser.py
+++ b/avocado/core/tapparser.py
@@ -1,0 +1,167 @@
+import enum
+import re
+from collections import namedtuple
+
+
+@enum.unique
+class TestResult(enum.Enum):
+    PASS = 'PASS'
+    SKIP = 'SKIP'
+    FAIL = 'FAIL'
+    XFAIL = 'XFAIL'
+    XPASS = 'XPASS'
+
+
+# TapParser is based on Meson's TAP parser, which were licensed under the
+# MIT (X11) license and were contributed to both Meson and Avocado by the
+# same author (Paolo).
+
+class TapParser:
+    Plan = namedtuple('Plan', ['count', 'late', 'skipped', 'explanation'])
+    Bailout = namedtuple('Bailout', ['message'])
+    Test = namedtuple('Test', ['number', 'name', 'result', 'explanation'])
+    Error = namedtuple('Error', ['message'])
+    Version = namedtuple('Version', ['version'])
+
+    _MAIN = 1
+    _AFTER_TEST = 2
+    _YAML = 3
+
+    _RE_BAILOUT = re.compile(r'Bail out!\s*(.*)')
+    _RE_DIRECTIVE = re.compile(r'(?:\s*\#\s*([Ss][Kk][Ii][Pp]\S*|[Tt][Oo][Dd][Oo])\b\s*(.*))?')
+    _RE_PLAN = re.compile(r'1\.\.([0-9]+)' + _RE_DIRECTIVE.pattern)
+    _RE_TEST = re.compile(r'((?:not )?ok)\s*(?:([0-9]+)\s*)?([^#]*)' + _RE_DIRECTIVE.pattern)
+    _RE_VERSION = re.compile(r'TAP version ([0-9]+)')
+    _RE_YAML_START = re.compile(r'(\s+)---.*')
+    _RE_YAML_END = re.compile(r'\s+\.\.\.\s*')
+
+    def __init__(self, tap_io):
+        self.tap_io = tap_io
+
+    def parse_test(self, ok, num, name, directive, explanation):
+        name = name.strip()
+        explanation = explanation.strip() if explanation else None
+        if directive is not None:
+            directive = directive.upper()
+            if directive == 'SKIP':
+                if ok:
+                    yield self.Test(num, name, TestResult.SKIP, explanation)
+                    return
+            elif directive == 'TODO':
+                result = TestResult.XPASS if ok else TestResult.XFAIL
+                yield self.Test(num, name, result, explanation)
+                return
+            else:
+                yield self.Error('invalid directive "%s"' % (directive,))
+
+        result = TestResult.PASS if ok else TestResult.FAIL
+        yield self.Test(num, name, result, explanation)
+
+    def parse(self):
+        found_late_test = False
+        bailed_out = False
+        plan = None
+        lineno = 0
+        num_tests = 0
+        yaml_lineno = 0
+        yaml_indent = ''
+        state = self._MAIN
+        version = 12
+        while True:
+            lineno += 1
+            try:
+                line = next(self.tap_io).rstrip()
+            except StopIteration:
+                break
+
+            # YAML blocks are only accepted after a test
+            if state == self._AFTER_TEST:
+                if version >= 13:
+                    m = self._RE_YAML_START.match(line)
+                    if m:
+                        state = self._YAML
+                        yaml_lineno = lineno
+                        yaml_indent = m.group(1)
+                        continue
+                state = self._MAIN
+
+            elif state == self._YAML:
+                if self._RE_YAML_END.match(line):
+                    state = self._MAIN
+                    continue
+                if line.startswith(yaml_indent):
+                    continue
+                yield self.Error('YAML block not terminated (started on line %d)' % (yaml_lineno,))
+                state = self._MAIN
+
+            assert state == self._MAIN
+            if line.startswith('#'):
+                continue
+
+            m = self._RE_TEST.match(line)
+            if m:
+                if plan and plan.late and not found_late_test:
+                    yield self.Error('unexpected test after late plan')
+                    found_late_test = True
+                num_tests += 1
+                num = num_tests if m.group(2) is None else int(m.group(2))
+                if num != num_tests:
+                    yield self.Error('out of order test numbers')
+                yield from self.parse_test(m.group(1) == 'ok', num,
+                                           m.group(3), m.group(4), m.group(5))
+                state = self._AFTER_TEST
+                continue
+
+            m = self._RE_PLAN.match(line)
+            if m:
+                if plan:
+                    yield self.Error('more than one plan found')
+                else:
+                    count = int(m.group(1))
+                    skipped = (count == 0)
+                    if m.group(2):
+                        if m.group(2).upper().startswith('SKIP'):
+                            if count > 0:
+                                yield self.Error('invalid SKIP directive for plan')
+                            skipped = True
+                        else:
+                            yield self.Error('invalid directive for plan')
+                    plan = self.Plan(count=count, late=(num_tests > 0),
+                                     skipped=skipped, explanation=m.group(3))
+                    yield plan
+                continue
+
+            m = self._RE_BAILOUT.match(line)
+            if m:
+                yield self.Bailout(m.group(1))
+                bailed_out = True
+                continue
+
+            m = self._RE_VERSION.match(line)
+            if m:
+                # The TAP version is only accepted as the first line
+                if lineno != 1:
+                    yield self.Error('version number must be on the first line')
+                    continue
+                version = int(m.group(1))
+                if version < 13:
+                    yield self.Error('version number should be at least 13')
+                else:
+                    yield self.Version(version=version)
+                continue
+
+            if line == '':
+                continue
+
+            yield self.Error('unexpected input at line %d' % (lineno,))
+
+        if state == self._YAML:
+            yield self.Error('YAML block not terminated (started on line %d)' % (yaml_lineno,))
+
+        if not bailed_out and plan and num_tests != plan.count:
+            if num_tests < plan.count:
+                yield self.Error('Too few tests run (expected %d, got %d)'
+                                 % (plan.count, num_tests))
+            else:
+                yield self.Error('Too many tests run (expected %d, got %d)'
+                                 % (plan.count, num_tests))

--- a/avocado/plugins/resolvers.py
+++ b/avocado/plugins/resolvers.py
@@ -118,3 +118,23 @@ class AvocadoInstrumentedResolver(Resolver):
 
         return ReferenceResolution(reference,
                                    ReferenceResolutionResult.NOTFOUND)
+
+
+class TapResolver(Resolver):
+
+    name = 'tap'
+    description = 'Test resolver for executable files to be handled as tests'
+
+    @staticmethod
+    def resolve(reference):
+
+        criteria_check = check_file(reference, reference, suffix=None,
+                                    type_name='executable file',
+                                    access_check=os.R_OK | os.X_OK,
+                                    access_name='executable')
+        if criteria_check is not True:
+            return criteria_check
+
+        return ReferenceResolution(reference,
+                                   ReferenceResolutionResult.SUCCESS,
+                                   [Runnable('tap', reference)])

--- a/docs/source/guides/user/chapters/concepts.rst
+++ b/docs/source/guides/user/chapters/concepts.rst
@@ -200,6 +200,15 @@ Test statuses ``PASS``, ``WARN``, ``START`` and ``SKIP`` are considered as
 successful builds. The ``ABORT``, ``ERROR``, ``FAIL``, ``ALERT``, ``RUNNING``,
 ``NOSTATUS`` and ``INTERRUPTED`` are considered as failed ones.
 
+TAP
+~~~
+
+TAP tests are pretty much like Simple tests in the sense tha they are
+programs (either binaries or scripts) that will executed.  The
+difference is that the test result will be decided based on the
+produced output, that should be in `Test Anything Protocol
+<https://testanything.org>`_ format.
+
 Test statuses
 -------------
 

--- a/docs/source/guides/user/chapters/loaders.rst
+++ b/docs/source/guides/user/chapters/loaders.rst
@@ -195,4 +195,19 @@ to actually execute ``/bin/sleep 20`` and check for its return code::
    Considering that syntax, the command for the example above would be:
    ``avocado run --loaders external:/bin/sleep -- 20``
 
+TAP Loader
+~~~~~~~~~~
 
+This loader enables Avocado to execute binaries or scripts and parse
+their `Test Anything Protocol <https://testanything.org>`_ output.
+
+The tests can be run as usual::
+
+    $ avocado run --loaders tap -- ./mytaptest
+
+Notice that you have to be explicit about the test loader you're
+using, otherwise, since the test files are executable binaries, the
+``FileLoader`` will detect the file as a ``SIMPLE`` test, making the
+whole test suite to be executed as one test only from the Avocado
+perspective.  Because TAP test programs should exit with a zero exit
+status, this will cause the test to pass even if there are failures.

--- a/selftests/functional/test_loader.py
+++ b/selftests/functional/test_loader.py
@@ -176,13 +176,15 @@ class LoaderTestFunctional(unittest.TestCase):
         self._test('simpletest.sh', SIMPLE_TEST, 'SIMPLE', self.MODE_0775)
 
     def test_simple_not_exec(self):
-        self._test('simpletest.sh', SIMPLE_TEST, 'NOT_A_TEST')
+        # 2 because both FileLoader and the TAP loader cannot recognize the test
+        self._test('simpletest.sh', SIMPLE_TEST, 'NOT_A_TEST', count=2)
 
     def test_pass(self):
         self._test('passtest.py', AVOCADO_TEST_OK, 'INSTRUMENTED')
 
     def test_not_python_module(self):
-        self._test('passtest', AVOCADO_TEST_OK, 'NOT_A_TEST')
+        # 2 because both FileLoader and the TAP loader cannot recognize the test
+        self._test('passtest', AVOCADO_TEST_OK, 'NOT_A_TEST', count=2)
 
     @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 2,
                      "Skipping test that take a long time to run, are "
@@ -220,7 +222,8 @@ class LoaderTestFunctional(unittest.TestCase):
         self._test('notatest.py', NOT_A_TEST, 'SIMPLE', self.MODE_0775)
 
     def test_load_not_a_test_not_exec(self):
-        self._test('notatest.py', NOT_A_TEST, 'NOT_A_TEST')
+        # 2 because both FileLoader and the TAP loader cannot recognize the test
+        self._test('notatest.py', NOT_A_TEST, 'NOT_A_TEST', count=2)
 
     @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 2,
                      "Skipping test that take a long time to run, are "

--- a/selftests/unit/test_tap.py
+++ b/selftests/unit/test_tap.py
@@ -1,0 +1,300 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2019
+# Authors: Paolo Bonzini <pbonzini@redhat.com>
+
+import io
+import unittest
+
+from avocado.core.tapparser import TestResult, TapParser
+
+
+# The TapParser unit tests are based on Meson's unit tests for TAP parsing,
+# which were licensed under the MIT (X11) license and were contributed to
+# both Meson and Avocado by the same author (Paolo).
+
+
+class TapParserTests(unittest.TestCase):
+    def assert_test(self, events, **kwargs):
+        if 'explanation' not in kwargs:
+            kwargs['explanation'] = None
+        self.assertEqual(next(events), TapParser.Test(**kwargs))
+
+    def assert_plan(self, events, **kwargs):
+        if 'skipped' not in kwargs:
+            kwargs['skipped'] = False
+        if 'explanation' not in kwargs:
+            kwargs['explanation'] = None
+        self.assertEqual(next(events), TapParser.Plan(**kwargs))
+
+    def assert_version(self, events, **kwargs):
+        self.assertEqual(next(events), TapParser.Version(**kwargs))
+
+    def assert_error(self, events):
+        self.assertEqual(type(next(events)), TapParser.Error)
+
+    def assert_bailout(self, events, **kwargs):
+        self.assertEqual(next(events), TapParser.Bailout(**kwargs))
+
+    def assert_last(self, events):
+        with self.assertRaises(StopIteration):
+            next(events)
+
+    def parse_tap(self, s):
+        parser = TapParser(io.StringIO(s))
+        return iter(parser.parse())
+
+    def parse_tap_v13(self, s):
+        events = self.parse_tap('TAP version 13\n' + s)
+        self.assert_version(events, version=13)
+        return events
+
+    def test_empty(self):
+        events = self.parse_tap('')
+        self.assert_last(events)
+
+    def test_empty_plan(self):
+        events = self.parse_tap('1..0')
+        self.assert_plan(events, count=0, late=False, skipped=True)
+        self.assert_last(events)
+
+    def test_plan_directive(self):
+        events = self.parse_tap('1..0 # skipped for some reason')
+        self.assert_plan(events, count=0, late=False, skipped=True,
+                         explanation='for some reason')
+        self.assert_last(events)
+
+        events = self.parse_tap('1..1 # skipped for some reason\nok 1')
+        self.assert_error(events)
+        self.assert_plan(events, count=1, late=False, skipped=True,
+                         explanation='for some reason')
+        self.assert_test(events, number=1, name='', result=TestResult.PASS)
+        self.assert_last(events)
+
+        events = self.parse_tap('1..1 # todo not supported here\nok 1')
+        self.assert_error(events)
+        self.assert_plan(events, count=1, late=False, skipped=False,
+                         explanation='not supported here')
+        self.assert_test(events, number=1, name='', result=TestResult.PASS)
+        self.assert_last(events)
+
+    def test_one_test_ok(self):
+        events = self.parse_tap('ok')
+        self.assert_test(events, number=1, name='', result=TestResult.PASS)
+        self.assert_last(events)
+
+    def test_one_test_with_number(self):
+        events = self.parse_tap('ok 1')
+        self.assert_test(events, number=1, name='', result=TestResult.PASS)
+        self.assert_last(events)
+
+    def test_one_test_with_name(self):
+        events = self.parse_tap('ok 1 abc')
+        self.assert_test(events, number=1, name='abc', result=TestResult.PASS)
+        self.assert_last(events)
+
+    def test_one_test_not_ok(self):
+        events = self.parse_tap('not ok')
+        self.assert_test(events, number=1, name='', result=TestResult.FAIL)
+        self.assert_last(events)
+
+    def test_one_test_todo(self):
+        events = self.parse_tap('not ok 1 abc # TODO')
+        self.assert_test(events, number=1, name='abc', result=TestResult.XFAIL)
+        self.assert_last(events)
+
+        events = self.parse_tap('ok 1 abc # TODO')
+        self.assert_test(events, number=1, name='abc', result=TestResult.XPASS)
+        self.assert_last(events)
+
+    def test_one_test_skip(self):
+        events = self.parse_tap('ok 1 abc # SKIP')
+        self.assert_test(events, number=1, name='abc', result=TestResult.SKIP)
+        self.assert_last(events)
+
+    def test_one_test_skip_failure(self):
+        events = self.parse_tap('not ok 1 abc # SKIP')
+        self.assert_test(events, number=1, name='abc', result=TestResult.FAIL)
+        self.assert_last(events)
+
+    def test_many_early_plan(self):
+        events = self.parse_tap('1..4\nok 1\nnot ok 2\nok 3\nnot ok 4')
+        self.assert_plan(events, count=4, late=False)
+        self.assert_test(events, number=1, name='', result=TestResult.PASS)
+        self.assert_test(events, number=2, name='', result=TestResult.FAIL)
+        self.assert_test(events, number=3, name='', result=TestResult.PASS)
+        self.assert_test(events, number=4, name='', result=TestResult.FAIL)
+        self.assert_last(events)
+
+    def test_many_late_plan(self):
+        events = self.parse_tap('ok 1\nnot ok 2\nok 3\nnot ok 4\n1..4')
+        self.assert_test(events, number=1, name='', result=TestResult.PASS)
+        self.assert_test(events, number=2, name='', result=TestResult.FAIL)
+        self.assert_test(events, number=3, name='', result=TestResult.PASS)
+        self.assert_test(events, number=4, name='', result=TestResult.FAIL)
+        self.assert_plan(events, count=4, late=True)
+        self.assert_last(events)
+
+    def test_directive_case(self):
+        events = self.parse_tap('ok 1 abc # skip')
+        self.assert_test(events, number=1, name='abc', result=TestResult.SKIP)
+        self.assert_last(events)
+
+        events = self.parse_tap('ok 1 abc # ToDo')
+        self.assert_test(events, number=1, name='abc', result=TestResult.XPASS)
+        self.assert_last(events)
+
+    def test_directive_explanation(self):
+        events = self.parse_tap('ok 1 abc # skip why')
+        self.assert_test(events, number=1, name='abc', result=TestResult.SKIP,
+                         explanation='why')
+        self.assert_last(events)
+
+        events = self.parse_tap('ok 1 abc # ToDo Because')
+        self.assert_test(events, number=1, name='abc', result=TestResult.XPASS,
+                         explanation='Because')
+        self.assert_last(events)
+
+    def test_one_test_early_plan(self):
+        events = self.parse_tap('1..1\nok')
+        self.assert_plan(events, count=1, late=False)
+        self.assert_test(events, number=1, name='', result=TestResult.PASS)
+        self.assert_last(events)
+
+    def test_one_test_late_plan(self):
+        events = self.parse_tap('ok\n1..1')
+        self.assert_test(events, number=1, name='', result=TestResult.PASS)
+        self.assert_plan(events, count=1, late=True)
+        self.assert_last(events)
+
+    def test_out_of_order(self):
+        events = self.parse_tap('ok 2')
+        self.assert_error(events)
+        self.assert_test(events, number=2, name='', result=TestResult.PASS)
+        self.assert_last(events)
+
+    def test_middle_plan(self):
+        events = self.parse_tap('ok 1\n1..2\nok 2')
+        self.assert_test(events, number=1, name='', result=TestResult.PASS)
+        self.assert_plan(events, count=2, late=True)
+        self.assert_error(events)
+        self.assert_test(events, number=2, name='', result=TestResult.PASS)
+        self.assert_last(events)
+
+    def test_too_many_plans(self):
+        events = self.parse_tap('1..1\n1..2\nok 1')
+        self.assert_plan(events, count=1, late=False)
+        self.assert_error(events)
+        self.assert_test(events, number=1, name='', result=TestResult.PASS)
+        self.assert_last(events)
+
+    def test_too_many(self):
+        events = self.parse_tap('ok 1\nnot ok 2\n1..1')
+        self.assert_test(events, number=1, name='', result=TestResult.PASS)
+        self.assert_test(events, number=2, name='', result=TestResult.FAIL)
+        self.assert_plan(events, count=1, late=True)
+        self.assert_error(events)
+        self.assert_last(events)
+
+        events = self.parse_tap('1..1\nok 1\nnot ok 2')
+        self.assert_plan(events, count=1, late=False)
+        self.assert_test(events, number=1, name='', result=TestResult.PASS)
+        self.assert_test(events, number=2, name='', result=TestResult.FAIL)
+        self.assert_error(events)
+        self.assert_last(events)
+
+    def test_too_few(self):
+        events = self.parse_tap('ok 1\nnot ok 2\n1..3')
+        self.assert_test(events, number=1, name='', result=TestResult.PASS)
+        self.assert_test(events, number=2, name='', result=TestResult.FAIL)
+        self.assert_plan(events, count=3, late=True)
+        self.assert_error(events)
+        self.assert_last(events)
+
+        events = self.parse_tap('1..3\nok 1\nnot ok 2')
+        self.assert_plan(events, count=3, late=False)
+        self.assert_test(events, number=1, name='', result=TestResult.PASS)
+        self.assert_test(events, number=2, name='', result=TestResult.FAIL)
+        self.assert_error(events)
+        self.assert_last(events)
+
+    def test_too_few_bailout(self):
+        events = self.parse_tap('1..3\nok 1\nnot ok 2\nBail out! no third test')
+        self.assert_plan(events, count=3, late=False)
+        self.assert_test(events, number=1, name='', result=TestResult.PASS)
+        self.assert_test(events, number=2, name='', result=TestResult.FAIL)
+        self.assert_bailout(events, message='no third test')
+        self.assert_last(events)
+
+    def test_diagnostics(self):
+        events = self.parse_tap('1..1\n# ignored\nok 1')
+        self.assert_plan(events, count=1, late=False)
+        self.assert_test(events, number=1, name='', result=TestResult.PASS)
+        self.assert_last(events)
+
+        events = self.parse_tap('# ignored\n1..1\nok 1\n# ignored too')
+        self.assert_plan(events, count=1, late=False)
+        self.assert_test(events, number=1, name='', result=TestResult.PASS)
+        self.assert_last(events)
+
+        events = self.parse_tap('# ignored\nok 1\n1..1\n# ignored too')
+        self.assert_test(events, number=1, name='', result=TestResult.PASS)
+        self.assert_plan(events, count=1, late=True)
+        self.assert_last(events)
+
+    def test_empty_line(self):
+        events = self.parse_tap('1..1\n\nok 1')
+        self.assert_plan(events, count=1, late=False)
+        self.assert_test(events, number=1, name='', result=TestResult.PASS)
+        self.assert_last(events)
+
+    def test_unexpected(self):
+        events = self.parse_tap('1..1\ninvalid\nok 1')
+        self.assert_plan(events, count=1, late=False)
+        self.assert_error(events)
+        self.assert_test(events, number=1, name='', result=TestResult.PASS)
+        self.assert_last(events)
+
+    def test_version(self):
+        events = self.parse_tap('TAP version 13\n')
+        self.assert_version(events, version=13)
+        self.assert_last(events)
+
+        events = self.parse_tap('TAP version 12\n')
+        self.assert_error(events)
+        self.assert_last(events)
+
+        events = self.parse_tap('1..0\nTAP version 13\n')
+        self.assert_plan(events, count=0, late=False, skipped=True)
+        self.assert_error(events)
+        self.assert_last(events)
+
+    def test_yaml(self):
+        events = self.parse_tap_v13('ok\n ---\n foo: abc\n  bar: def\n ...\nok 2')
+        self.assert_test(events, number=1, name='', result=TestResult.PASS)
+        self.assert_test(events, number=2, name='', result=TestResult.PASS)
+        self.assert_last(events)
+
+        events = self.parse_tap_v13('ok\n ---\n foo: abc\n  bar: def')
+        self.assert_test(events, number=1, name='', result=TestResult.PASS)
+        self.assert_error(events)
+        self.assert_last(events)
+
+        events = self.parse_tap_v13('ok 1\n ---\n foo: abc\n  bar: def\nnot ok 2')
+        self.assert_test(events, number=1, name='', result=TestResult.PASS)
+        self.assert_error(events)
+        self.assert_test(events, number=2, name='', result=TestResult.FAIL)
+        self.assert_last(events)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -123,6 +123,7 @@ if __name__ == '__main__':
                   'exec-test = avocado.plugins.resolvers:ExecTestResolver',
                   'python-unittest = avocado.plugins.resolvers:PythonUnittestResolver',
                   'avocado-instrumented = avocado.plugins.resolvers:AvocadoInstrumentedResolver',
+                  'tap = avocado.plugins.resolvers:TapResolver',
                   ],
               'avocado.plugins.runner': [
                   'runner = avocado.plugins.runner:TestRunner',


### PR DESCRIPTION
The new loader comes with a TAP parser, which logs individual failures
that were reported in the executable's output, and transforms them into
an overall PASS/FAIL/SKIP state.

Signed-off-by: Paolo Bonzini <pbonzini@redhat.com>
Signed-off-by: Cleber Rosa <crosa@redhat.com>

---

Note: this version is different from the original work (https://github.com/avocado-framework/avocado/pull/3393/commits/081ce9c9cb683c342227d57395ff160c43c81724) only in the sense that it makes the TAP test loader a core feature, as oposed to an optional plugin).