### PR TITLE
spell.ignore: adding few words to make pylint happy

### DIFF
--- a/spell.ignore
+++ b/spell.ignore
@@ -649,3 +649,10 @@ Willian
 Rampazzo
 willianr
 nrunner
+multipaths
+mpath
+mpatha
+mpathb
+vmlinux
+pyunittest
+defconfig


### PR DESCRIPTION
Added few words to spell.ignore so that pylint spell check stop
complaining.

Signed-off-by: Beraldo Leal <bleal@redhat.com>