### PR TITLE
spell.ignore: adding few words to make pylint happy

### DIFF
--- a/spell.ignore
+++ b/spell.ignore
@@ -656,3 +656,6 @@ mpathb
 vmlinux
 pyunittest
 defconfig
+Bonzini
+Paolo
+pbonzini


### PR DESCRIPTION
Added few words to spell.ignore so that pylint spell check stop
complaining.

Signed-off-by: Beraldo Leal <bleal@redhat.com>