### PR TITLE
selftests/functional: Test sysinfo HTML output

### DIFF
--- a/examples/testplans/release/pre.json
+++ b/examples/testplans/release/pre.json
@@ -31,9 +31,6 @@
 	{"name": "Avocado Remote Machine HTML report",
 	 "description": "On a web browser, open the previously generated  HTML report at `/tmp/report.html`. Verify that all the links such as `job-YYYY-MM-DD...` (under `Results Dir`), `1-/**/avocado/tests/**/examples/tests/passtest.py:PassTest.test` (under `Test ID`) and `debug.log` point to valid locations."},
 
-	{"name": "Avocado HTML report sysinfo",
-	 "description": "On the HTML report, click on `Sysinfo (pre/post/profile, click to expand)` and verify that system information such as `hostname` and `cpuinfo` are present and accurate"},
-
 	{"name": "Avocado HTML report links",
 	 "description": "On the HTML report, verify that all the links such as `job-YYYY-MM-DD...` (under `Results Dir`), `1-type_specific.io-github-autotest-qemu.migrate.default.tcp` (under `Test ID`) and `debug.log` point to valid locations."},
 

--- a/selftests/functional/test_sysinfo.py
+++ b/selftests/functional/test_sysinfo.py
@@ -31,7 +31,8 @@ class SysInfoTest(unittest.TestCase):
         result = process.run(cmd_line)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         'Avocado did not return rc %d:\n%s' % (expected_rc, result))
+                         'Avocado did not return rc %d:\n%s' % (expected_rc,
+                                                                result))
         output = result.stdout_text + result.stderr_text
         sysinfo_dir = None
         for line in output.splitlines():
@@ -41,13 +42,15 @@ class SysInfoTest(unittest.TestCase):
         self.assertIsNotNone(sysinfo_dir,
                              ('Could not find sysinfo dir from human output. '
                               'Output produced: "%s" % output'))
-        msg = "Avocado didn't create sysinfo directory %s:\n%s" % (sysinfo_dir, result)
+        msg = "Avocado didn't create sysinfo directory %s:\n%s" % (sysinfo_dir,
+                                                                   result)
         self.assertTrue(os.path.isdir(sysinfo_dir), msg)
         msg = 'The sysinfo directory is empty:\n%s' % result
         self.assertGreater(len(os.listdir(sysinfo_dir)), 0, msg)
         for hook in ('pre', 'post'):
             sysinfo_subdir = os.path.join(sysinfo_dir, hook)
-            msg = 'The sysinfo/%s subdirectory does not exist:\n%s' % (hook, result)
+            msg = 'The sysinfo/%s subdirectory does not exist:\n%s' % (hook,
+                                                                       result)
             self.assertTrue(os.path.exists(sysinfo_subdir), msg)
 
     def test_sysinfo_disabled(self):
@@ -57,7 +60,8 @@ class SysInfoTest(unittest.TestCase):
         result = process.run(cmd_line)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         'Avocado did not return rc %d:\n%s' % (expected_rc, result))
+                         'Avocado did not return rc %d:\n%s' % (expected_rc,
+                                                                result))
         output = result.stdout_text + result.stderr_text
         sysinfo_dir = None
         for line in output.splitlines():
@@ -67,7 +71,8 @@ class SysInfoTest(unittest.TestCase):
         self.assertIsNotNone(sysinfo_dir,
                              ('Could not find sysinfo dir from human output. '
                               'Output produced: "%s" % output'))
-        msg = 'Avocado created sysinfo directory %s:\n%s' % (sysinfo_dir, result)
+        msg = 'Avocado created sysinfo directory %s:\n%s' % (sysinfo_dir,
+                                                             result)
         self.assertFalse(os.path.isdir(sysinfo_dir), msg)
 
     def test_sysinfo_html_output(self):

--- a/selftests/functional/test_sysinfo.py
+++ b/selftests/functional/test_sysinfo.py
@@ -70,6 +70,25 @@ class SysInfoTest(unittest.TestCase):
         msg = 'Avocado created sysinfo directory %s:\n%s' % (sysinfo_dir, result)
         self.assertFalse(os.path.isdir(sysinfo_dir), msg)
 
+    def test_sysinfo_html_output(self):
+        os.chdir(BASEDIR)
+        html_output = "{}/output.html".format(self.tmpdir.name)
+        cmd_line = ('{} run --html {} --job-results-dir {} --sysinfo=on '
+                    'passtest.py'.format(AVOCADO, html_output,
+                                         self.tmpdir.name))
+        result = process.run(cmd_line)
+        expected_rc = exit_codes.AVOCADO_ALL_OK
+        self.assertEqual(result.exit_status, expected_rc,
+                         'Avocado did not return rc %d:\n%s' % (expected_rc,
+                                                                result))
+        with open(html_output, 'rt') as fp:
+            output = fp.read()
+
+        # Try to find some strings on HTML
+        self.assertNotEqual(output.find('vendor_id'), -1)
+        self.assertNotEqual(output.find('root='), -1)
+        self.assertNotEqual(output.find('MemAvailable'), -1)
+
     def tearDown(self):
         self.tmpdir.cleanup()
 


### PR DESCRIPTION
As part of the process of reducing the manual steps, and automate as
much as possible on pre-release manual steps, this change adds the HTML
check on sysinfo output.
