### PR TITLE
YAML Loader: behave when empty references are given

### DIFF
--- a/optional_plugins/loader_yaml/avocado_loader_yaml/__init__.py
+++ b/optional_plugins/loader_yaml/avocado_loader_yaml/__init__.py
@@ -92,6 +92,8 @@ class YamlTestsuiteLoader(loader.TestLoader):
 
     def discover(self, reference, which_tests=loader.DiscoverMode.DEFAULT):
         tests = []
+        if reference is None:
+            return tests
         try:
             root = mux.apply_filters(create_from_yaml([reference], False),
                                      self.args.get("mux_suite_only", []),


### PR DESCRIPTION
A loader's discover() method can be passed a None reference, which is
a valid scenario, and the given loader may for instance return all
builtin/default tests.

In the case of the YAML Loader, this references is expected to be a
path to YAML file, so it should bail out early when None is given.

This fixes the error that can be seen on the command line similar to:

  Test discovery plugin <avocado_loader_yaml.YamlTestsuiteLoader
  object at 0x7f544a6c62e8> failed: expected string or bytes-like object

Signed-off-by: Cleber Rosa <crosa@redhat.com>