### PR TITLE
docs/source/quickstart/index.rst: make welcome message more generic

### DIFF
--- a/docs/source/quickstart/index.rst
+++ b/docs/source/quickstart/index.rst
@@ -1,6 +1,6 @@
-==================================
-Welcome to Avocado's Documentation
-==================================
+==================
+Welcome to Avocado
+==================
 
 Avocado is a set of tools and libraries to help with automated testing.
 


### PR DESCRIPTION
Because the Quick Start index page is also now being used as the
README page, it's confusing to be welcoming users to the Avocado
Documentation from there.  Also, when users open the documentation,
they already know they're there, and a simpler message also does the
job well IMO.

Signed-off-by: Cleber Rosa <crosa@redhat.com>