### PR TITLE
added boolean args deprecation message [v2]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
       AVOCADO_LOG_DEBUG=yes
       SELF_CHECK_CONTINUOUS=y
       AVOCADO_CHECK_LEVEL=1
+      PYTHONWARNINGS=ignore
 
 cache:
     directories:
@@ -36,6 +37,7 @@ matrix:
       arch: amd64
       env:
         - SELF_CHECK_CONTINUOUS=yes
+          PYTHONWARNINGS=ignore
       install:
         - pip install -r requirements-selftests.txt
         - pip install codecov

--- a/Makefile
+++ b/Makefile
@@ -138,11 +138,11 @@ AVOCADO_OPTIONAL_PLUGINS_TESTS=$(patsubst %,%/tests/, $(AVOCADO_OPTIONAL_PLUGINS
 endif
 check: clean develop
 	# Unless manually set, this is equivalent to AVOCADO_CHECK_LEVEL=0
-	PYTHON=$(PYTHON) $(PYTHON) -m avocado nrun selftests/*.sh selftests/unit/ selftests/functional/ $(AVOCADO_OPTIONAL_PLUGINS_TESTS)
+	export PYTHONWARNINGS=ignore;PYTHON=$(PYTHON) $(PYTHON) -m avocado nrun selftests/*.sh selftests/unit/ selftests/functional/ $(AVOCADO_OPTIONAL_PLUGINS_TESTS)
 	selftests/check_tmp_dirs
 
 check-full: clean develop
-	PYTHON=$(PYTHON) AVOCADO_CHECK_LEVEL=3 selftests/checkall
+	export PYTHONWARNINGS=ignore;PYTHON=$(PYTHON) AVOCADO_CHECK_LEVEL=3 selftests/checkall
 	selftests/check_tmp_dirs
 
 develop:

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -18,6 +18,7 @@ Base Test Runner Plugins.
 
 import argparse
 import sys
+import warnings
 
 from avocado.core import exit_codes
 from avocado.core import job
@@ -108,16 +109,19 @@ class Run(CLICmd):
                             ' s (seconds), m (minutes), h (hours). ')
 
         parser.add_argument('--failfast', choices=('on', 'off'),
-                            help='Enable or disable the job interruption on '
-                            'first failed test.')
+                            help="Enable or disable the job interruption on "
+                            "first failed test. 'on' and 'off' will be "
+                            "deprecated soon. ")
 
         parser.add_argument('--keep-tmp', choices=('on', 'off'),
-                            default='off', help='Keep job temporary files '
-                            '(useful for avocado debugging). Defaults to off.')
+                            default='off', help="Keep job temporary files "
+                            "(useful for avocado debugging). 'on' and 'off' "
+                            "will be deprecated soon. Defaults to off.")
 
         parser.add_argument('--ignore-missing-references', choices=('on', 'off'),
                             help="Force the job execution, even if some of "
-                            "the test references are not resolved to tests.")
+                            "the test references are not resolved to tests."
+                            "'on' and 'off' will be deprecated soon.")
 
         sysinfo_default = settings.get_value('sysinfo.collect',
                                              'enabled',
@@ -127,7 +131,8 @@ class Run(CLICmd):
         parser.add_argument('--sysinfo', choices=('on', 'off'),
                             default=sysinfo_default, help="Enable or disable "
                             "system information (hardware details, profilers, "
-                            "etc.). Current:  %(default)s")
+                            "etc.). 'on' and 'off' will be deprecated soon. "
+                            "Current:  %(default)s")
 
         parser.add_argument("--execution-order",
                             choices=("tests-per-variant",
@@ -185,7 +190,8 @@ class Run(CLICmd):
                                "stderr) check. If this option is off, no "
                                "output will be checked, even if there are "
                                "reference files present for the test. "
-                               "Current: on (output check enabled)")
+                               "'on' and 'off' will be deprecated soon. "
+                               "Current: on (output check enabled). ")
 
         loader.add_loader_options(parser)
         parser_common_args.add_tag_filter_args(parser)
@@ -201,6 +207,11 @@ class Run(CLICmd):
         if 'output_check_record' in config:
             process.OUTPUT_CHECK_RECORD_MODE = config.get('output_check_record',
                                                           None)
+
+        warnings.warn("The following arguments will be changed to boolean soon: "
+                      "sysinfo, output-check, failfast, keep-tmp, "
+                      "ignore-missing-references, sysinfo and output-check",
+                      FutureWarning)
 
         if config.get('unique_job_id') is not None:
             try:


### PR DESCRIPTION
As discussed during the RFC and blueprint 001, we need to warn users
that sysinfo and other boolean args on and off will be deprecated soon.

Signed-off-by: Beraldo Leal <bleal@redhat.com>

-----
Changes from v1:

  * Removed unused import
  * Suppress warnings when running tests