### PR TITLE
selftests/functional/test_output.py: write job results to temporary d…

### DIFF
--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -446,8 +446,8 @@ class OutputPluginTest(unittest.TestCase):
                    % os.path.relpath(self.tmpdir.name, "."))
         script.Script(config, content).save()
         cmd_line = ('%s --config %s --show all run '
-                    '--sysinfo=off whiteboard.py --json %s'
-                    % (AVOCADO, config, tmpfile))
+                    '--job-results-dir %s --sysinfo=off whiteboard.py '
+                    '--json %s' % (AVOCADO, config, self.tmpdir.name, tmpfile))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,


### PR DESCRIPTION
…irectory

This is the norm in almost all functional tests that involve running a
job, and this one was deviating from that norm.

When running `make check-full` this creates and leaves a new directory
in the user's default Avocado job results directory, making the job
results directory check fail.

Signed-off-by: Cleber Rosa <crosa@redhat.com>