### PR TITLE
selftests.functional.test_nrunner.TaskRun.test_recipe_exec_3: sleep l…

### DIFF
--- a/examples/recipes/tasks/exec/3-sleep.json
+++ b/examples/recipes/tasks/exec/3-sleep.json
@@ -1,1 +1,1 @@
-{"id": 3, "runnable": {"kind": "exec", "uri": "/bin/sleep", "args": ["0.01"]}}
+{"id": 3, "runnable": {"kind": "exec", "uri": "/bin/sleep", "args": ["0.6"]}}


### PR DESCRIPTION
…onger

So that the probability that the task will finish before both
RUNNER_RUN_CHECK_INTERVAL (0.01 seconds) and
RUNNER_RUN_STATUS_INTERVAL (0.5 seconds) is greatly minimized.  In
theory, an OS level scheduler can still alocate time to the test
process and no time to the runner process, but this is very unlikely.

Fixes: https://github.com/avocado-framework/avocado/issues/3492
Signed-off-by: Cleber Rosa <crosa@redhat.com>