### PR TITLE
plugins: jsonresult: add missing warn and interrupt fields

### DIFF
--- a/avocado/plugins/jsonresult.py
+++ b/avocado/plugins/jsonresult.py
@@ -58,6 +58,8 @@ class JSONResult(Result):
                    'failures': result.failed,
                    'skip': result.skipped,
                    'cancel': result.cancelled,
+                   'warn': result.warned,
+                   'interrupt': result.interrupted,
                    'time': result.tests_total_time}
         return json.dumps(content,
                           sort_keys=True,


### PR DESCRIPTION
The job results JSON file does not contain the counters for
interrupted and warned tests. This change add the 'warn' and
'interrupt' fields in the JSON file.

Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>