### PR TITLE
modifying device_exists function in multipath.py utils

### DIFF
--- a/avocado/utils/multipath.py
+++ b/avocado/utils/multipath.py
@@ -69,10 +69,12 @@ def device_exists(mpath):
 
     :return: True if path exists, False if does not exist.
     """
-    cmd = "multipath -l %s" % mpath
-    if process.system(cmd, ignore_status=True, sudo=True, shell=True):
-        return False
-    return True
+    cmd = "multipath -ll"
+    out = process.run(cmd, ignore_status=True, sudo=True,
+                      shell=True).stdout_text
+    if mpath in out:
+        return True
+    return False
 
 
 def get_mpath_name(wwid):


### PR DESCRIPTION
multipath -ll command used to exit with TRUE condition in previos logic
all the tim. Hence change it properly with the help of if condition which
checks for real existance of mpath.
Now it is working fine.

Signed-off-by: Naresh Bannoth <nbannoth@in.ibm.com>