### PR TITLE
Nrunner: introduce a job compliant runner

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -337,7 +337,7 @@ class Job:
             if os.path.exists(proc_latest):
                 os.unlink(proc_latest)
 
-    def _make_test_suite(self, references=None):
+    def _make_test_suite(self, references):
         """
         Prepares a test suite to be used for running tests
 

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -34,7 +34,9 @@ from . import exit_codes
 from . import job_id
 from . import jobdata
 from . import loader
+from . import nrunner
 from . import output
+from . import resolver
 from . import result
 from . import tags
 from . import test
@@ -49,9 +51,61 @@ from .output import LOG_JOB
 from .output import LOG_UI
 from .output import STD_OUTPUT
 from .settings import settings
+from .tags import filter_test_tags_runnable
 
 
 _NEW_ISSUE_LINK = 'https://github.com/avocado-framework/avocado/issues/new'
+
+
+def resolutions_to_tasks(resolutions, config):
+    """
+    Transforms resolver resolutions into tasks
+
+    A resolver resolution
+    (:class:`avocado.core.resolver.ReferenceResolution`) contains
+    information about the resolution process (if it was successful
+    or not) and in case of sucessful resolutions a list of
+    resolutions.  It's expected that the resolution are
+    :class:`avocado.core.nrunner.Runnable`.
+
+    This method transforms those runnables into Tasks
+    (:class:`avocado.core.nrunner.Task`), which will include an
+    unique sequential identification and a status reporting URI.
+    It also performs tag based filtering on the runnables for
+    possibly excluding some of the Runnables.
+
+    :param resolutions: possible multiple resolutions for multiple
+                        references
+    :type resolutions: list of :class:`avocado.core.resolver.ReferenceResolution`
+    :param config: job configuration
+    :type config: dict
+    :returns: the resolutions converted to tasks
+    :rtype: list of :class:`avocado.core.nrunner.Task`
+    """
+
+    tasks = []
+    index = 0
+    resolutions = [res for res in resolutions if
+                   res.result == resolver.ReferenceResolutionResult.SUCCESS]
+    no_digits = len(str(len(resolutions)))
+    for resolution in resolutions:
+        name = resolution.reference
+        for runnable in resolution.resolutions:
+            filter_by_tags = config.get('filter_by_tags')
+            if filter_by_tags:
+                if not filter_test_tags_runnable(
+                        runnable,
+                        filter_by_tags,
+                        config.get('filter_by_tags_include_empty'),
+                        config.get('filter_by_tags_include_empty_key')):
+                    continue
+            if runnable.uri:
+                name = runnable.uri
+            identifier = str(test.TestID(index + 1, name, None, no_digits))
+            tasks.append(nrunner.Task(identifier, runnable,
+                                      [config.get('status_server')]))
+            index += 1
+    return tasks
 
 
 class Job:

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -341,9 +341,9 @@ class Job:
         """
         Prepares a test suite to be used for running tests
 
-        :param references: String with tests references to be resolved, and
-                           then run, separated by whitespace. Optionally, a
-                           list of tests (each test a string).
+        :param references: List of tests references to be resolved and
+                           transformed into test factories
+        :type references: list of str
         :returns: a test suite (a list of test factories)
         """
         loader.loader.load_plugins(self.config)

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -27,28 +27,28 @@ import tempfile
 import time
 import traceback
 
-from . import version
 from . import data_dir
 from . import dispatcher
-from . import loader
-from . import result
-from . import exit_codes
 from . import exceptions
+from . import exit_codes
 from . import job_id
-from . import output
-from . import varianter
-from . import test
-from . import tags
 from . import jobdata
-from .output import STD_OUTPUT
-from .settings import settings
+from . import loader
+from . import output
+from . import result
+from . import tags
+from . import test
+from . import varianter
+from . import version
 from ..utils import astring
-from ..utils import path
-from ..utils import stacktrace
 from ..utils import data_structures
+from ..utils import path
 from ..utils import process
+from ..utils import stacktrace
 from .output import LOG_JOB
 from .output import LOG_UI
+from .output import STD_OUTPUT
+from .settings import settings
 
 
 _NEW_ISSUE_LINK = 'https://github.com/avocado-framework/avocado/issues/new'

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -33,7 +33,7 @@ class Runnable:
         self.kwargs = kwargs
 
     def __repr__(self):
-        fmt = '<Runnable kind="{}" uri="{}" args="{}" kwargs="{}" tags="{}"'
+        fmt = '<Runnable kind="{}" uri="{}" args="{}" kwargs="{}" tags="{}">'
         return fmt.format(self.kind, self.uri,
                           self.args, self.kwargs, self.tags)
 

--- a/avocado/core/resolver.py
+++ b/avocado/core/resolver.py
@@ -58,7 +58,7 @@ class ReferenceResolution:
         :type result: :class:`ReferenceResolutionResult`
         :param resolutions: the runnable definitions resulting from the
         resolution
-        :type resolutions: list
+        :type resolutions: list of :class:`avocado.core.nrunner.Runnable`
         :param info: free form information the resolver may add
         :type info: str
         :param origin: the name of the resolver that performed the resolution

--- a/avocado/plugins/assets.py
+++ b/avocado/plugins/assets.py
@@ -22,6 +22,7 @@ import os
 from avocado.core import data_dir
 from avocado.core import exit_codes
 from avocado.core import safeloader
+from avocado.core.nrunner import Task
 from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLICmd
 from avocado.core.plugin_interfaces import JobPreTests
@@ -236,6 +237,11 @@ class FetchAssetJob(JobPreTests):  # pylint: disable=R0903
         else:
             logger = None
         for test in job.test_suite:
+            # ignore nrunner/resolver based test suites that contain
+            # task, because the requirements resolution planned is
+            # completely different from the traditional job runner
+            if isinstance(test, Task):
+                continue
             # fetch assets only on instrumented tests
             if isinstance(test[0], str):
                 fetch_assets(test[1]['modulePath'],

--- a/avocado/plugins/nrun.py
+++ b/avocado/plugins/nrun.py
@@ -14,6 +14,53 @@ from avocado.core.plugin_interfaces import CLICmd
 from avocado.utils import path as utils_path
 
 
+def pick_runner(task, runners_registry):
+    """
+    Selects a runner based on the task and keeps found runners in registry
+
+    This utility function will lool at the given task and try to find
+    a matching runner.  The matching runner probe results are kept in
+    a registry (that is modified by this function) so that further
+    executions take advantage of previous probes.
+
+    :param task: the task that needs a runner to be selected
+    :type task: :class:`avocado.core.nrunner.Task`
+    :param runners_registry: a registry with previously found (and not
+                             found) runners keyed by task kind
+    :param runners_registry: dict
+    :returns: command line arguments to execute the runner
+    :rtype: list of str
+    """
+    kind = task.runnable.kind
+    runner = runners_registry.get(kind)
+    if runner is False:
+        return None
+    if runner is not None:
+        return runner
+
+    # first attempt to find Python module files that are named
+    # after the runner convention within the avocado.core
+    # namespace dir.  Looking for the file only avoids an attempt
+    # to load the module and should be a lot faster
+    core_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    module_name = kind.replace('-', '_')
+    module_filename = 'nrunner_%s.py' % module_name
+    if os.path.exists(os.path.join(core_dir, module_filename)):
+        full_module_name = 'avocado.core.%s' % module_name
+        runner = [sys.executable, '-m', full_module_name]
+        runners_registry[kind] = runner
+        return runner
+
+    # try to find executable in the path
+    runner_by_name = 'avocado-runner-%s' % kind
+    try:
+        runner = utils_path.find_command(runner_by_name)
+        runners_registry[kind] = [runner]
+        return [runner]
+    except utils_path.CmdNotFoundError:
+        runners_registry[kind] = False
+
+
 class NRun(CLICmd):
 
     name = 'nrun'
@@ -52,38 +99,8 @@ class NRun(CLICmd):
             self.spawned_tasks.append(identifier)
             print("%s spawned" % identifier)
 
-    def pick_runner(self, task):
-        kind = task.runnable.kind
-        runner = self.KNOWN_EXTERNAL_RUNNERS.get(kind)
-        if runner is False:
-            return None
-        if runner is not None:
-            return runner
-
-        # first attempt to find Python module files that are named
-        # after the runner convention within the avocado.core
-        # namespace dir.  Looking for the file only avoids an attempt
-        # to load the module and should be a lot faster
-        core_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        module_name = kind.replace('-', '_')
-        module_filename = 'nrunner_%s.py' % module_name
-        if os.path.exists(os.path.join(core_dir, module_filename)):
-            full_module_name = 'avocado.core.%s' % module_name
-            runner = [sys.executable, '-m', full_module_name]
-            self.KNOWN_EXTERNAL_RUNNERS[kind] = runner
-            return runner
-
-        # try to find executable in the path
-        runner_by_name = 'avocado-runner-%s' % kind
-        try:
-            runner = utils_path.find_command(runner_by_name)
-            self.KNOWN_EXTERNAL_RUNNERS[kind] = [runner]
-            return [runner]
-        except utils_path.CmdNotFoundError:
-            self.KNOWN_EXTERNAL_RUNNERS[kind] = False
-
     def pick_runner_or_default(self, task):
-        runner = self.pick_runner(task)
+        runner = pick_runner(task, self.KNOWN_EXTERNAL_RUNNERS)
         if runner is None:
             runner = [sys.executable, '-m', 'avocado.core.nrunner']
         return runner
@@ -104,7 +121,7 @@ class NRun(CLICmd):
     def check_tasks_requirements(self, tasks):
         result = []
         for task in tasks:
-            runner = self.pick_runner(task)
+            runner = pick_runner(task, self.KNOWN_EXTERNAL_RUNNERS)
             if runner:
                 result.append(task)
             else:

--- a/avocado/plugins/nrun.py
+++ b/avocado/plugins/nrun.py
@@ -4,15 +4,15 @@ import os
 import random
 import sys
 
-from avocado.core import nrunner
-from avocado.core import resolver
 from avocado.core import exit_codes
-from avocado.core import test
+from avocado.core import nrunner
 from avocado.core import parser_common_args
+from avocado.core import resolver
+from avocado.core import test
 from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLICmd
-from avocado.utils import path as utils_path
 from avocado.core.tags import filter_test_tags_runnable
+from avocado.utils import path as utils_path
 
 
 class NRun(CLICmd):

--- a/avocado/plugins/nrun.py
+++ b/avocado/plugins/nrun.py
@@ -82,12 +82,15 @@ class NRun(CLICmd):
         except utils_path.CmdNotFoundError:
             self.KNOWN_EXTERNAL_RUNNERS[kind] = False
 
-    @asyncio.coroutine
-    def spawn_task(self, task):
+    def pick_runner_or_default(self, task):
         runner = self.pick_runner(task)
         if runner is None:
             runner = [sys.executable, '-m', 'avocado.core.nrunner']
+        return runner
 
+    @asyncio.coroutine
+    def spawn_task(self, task):
+        runner = self.pick_runner_or_default(task)
         args = runner[1:] + ['task-run'] + task.get_command_args()
         runner = runner[0]
 

--- a/avocado/plugins/nrun.py
+++ b/avocado/plugins/nrun.py
@@ -36,6 +36,31 @@ class NRun(CLICmd):
 
     @staticmethod
     def resolutions_to_tasks(resolutions, config):
+        """
+        Transforms resolver resolutions into tasks
+
+        A resolver resolution
+        (:class:`avocado.core.resolver.ReferenceResolution`) contains
+        information about the resolution process (if it was successful
+        or not) and in case of sucessful resolutions a list of
+        resolutions.  It's expected that the resolution are
+        :class:`avocado.core.nrunner.Runnable`.
+
+        This method transforms those runnables into Tasks
+        (:class:`avocado.core.nrunner.Task`), which will include an
+        unique sequential identification and a status reporting URI.
+        It also performs tag based filtering on the runnables for
+        possibly excluding some of the Runnables.
+
+        :param resolutions: possible multiple resolutions for multiple
+                            references
+        :type resolutions: list of :class:`avocado.core.resolver.ReferenceResolution`
+        :param config: job configuration
+        :type config: dict
+        :returns: the resolutions converted to tasks
+        :rtype: list of :class:`avocado.core.nrunner.Task`
+        """
+
         tasks = []
         index = 0
         resolutions = [res for res in resolutions if

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -1,0 +1,79 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2019-2020
+# Authors: Cleber Rosa <crosa@redhat.com>
+
+"""
+NRunner based implementation of job compliant runner
+"""
+
+from avocado.core import test
+from avocado.core.plugin_interfaces import Runner as RunnerInterface
+
+from .nrun import check_tasks_requirements
+
+
+class Runner(RunnerInterface):
+
+    name = 'nrunner'
+    description = '*EXPERIMENTAL* nrunner based implementation of job compliant runner'
+
+    #: registry of known test runners
+    KNOWN_EXTERNAL_RUNNERS = {}
+
+    def run_suite(self, job, result, test_suite, variants, timeout=0,
+                  replay_map=None, execution_order=None):
+        summary = set()
+        test_suite = check_tasks_requirements(
+            test_suite,
+            self.KNOWN_EXTERNAL_RUNNERS)  # pylint: disable=W0201
+        result.tests_total = len(test_suite)  # no support for variants yet
+        result_dispatcher = job.result_events_dispatcher
+
+        for index, task in enumerate(test_suite):
+            index += 1
+            # this is all rubish data
+            early_state = {
+                'name': test.TestID(index, task.identifier),
+                'job_logdir': job.logdir,
+                'job_unique_id': job.unique_id,
+            }
+            result.start_test(early_state)
+            job.result_events_dispatcher.map_method('start_test',
+                                                    result,
+                                                    early_state)
+
+            statuses = []
+            task.status_services = []
+            for status in task.run():
+                result_dispatcher.map_method('test_progress', False)
+                statuses.append(status)
+                if status['status'] not in ["init", "running"]:
+                    break
+
+            # test execution time is currently missing
+            test_state = {'status': statuses[-1]['status'].upper()}
+            test_state.update(early_state)
+
+            time_start = statuses[0]['time_start']
+            time_end = statuses[-1]['time_end']
+            time_elapsed = time_end - time_start
+            test_state['time_start'] = time_start
+            test_state['time_end'] = time_end
+            test_state['time_elapsed'] = time_elapsed
+
+            # fake log dir, needed by some result plugins such as HTML
+            test_state['logdir'] = ''
+
+            result.check_test(test_state)
+            result_dispatcher.map_method('end_test', result, test_state)
+        return summary

--- a/examples/jobs/nrunner.py
+++ b/examples/jobs/nrunner.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+
+import sys
+from avocado.core.job import Job
+
+config = {
+    'test_runner': 'nrunner',
+    'references': [
+        'selftests/unit/test_resolver.py',
+        'selftests/functional/test_argument_parsing.py',
+        '/bin/true',
+        '/bin/false',
+    ],
+    }
+
+with Job(config) as j:
+    sys.exit(j.run())

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -6,6 +6,7 @@ from avocado.core import data_dir
 from avocado.core import exceptions
 from avocado.core import exit_codes
 from avocado.core import job
+from avocado.core import nrunner
 from avocado.core import test
 from avocado.utils import path as utils_path
 
@@ -248,6 +249,19 @@ class JobTest(unittest.TestCase):
             self.assertTrue(os.path.isdir(self.job.logdir))
             self.assertTrue(os.path.isfile(os.path.join(self.job.logdir, 'id')))
         self.assertFalse(os.path.isdir(self.job.logdir))
+
+    def test_job_make_test_suite_resolver(self):
+        simple_tests_found = self._find_simple_test_candidates()
+        config = {'references': simple_tests_found,
+                  'base_logdir': self.tmpdir.name,
+                  'test_runner': 'nrunner',
+                  'show': ['none']}
+        self.job = job.Job(config)
+        self.job.setup()
+        self.job.create_test_suite()
+        self.assertEqual(len(simple_tests_found), len(self.job.test_suite))
+        if self.job.test_suite:
+            self.assertIsInstance(self.job.test_suite[0], nrunner.Task)
 
     def tearDown(self):
         data_dir._tmp_tracker.unittest_refresh_dir_tracker()

--- a/setup.py
+++ b/setup.py
@@ -127,6 +127,7 @@ if __name__ == '__main__':
                   ],
               'avocado.plugins.runner': [
                   'runner = avocado.plugins.runner:TestRunner',
+                  'nrunner = avocado.plugins.runner_nrunner:Runner',
                   ],
               },
           zip_safe=False,


### PR DESCRIPTION
This introduces a "job compliant test runner" based on the nrunner.  It still lacks a number of features, such as:
 * Variants
 * Test type support for anything available outside of the core "avocado.core.nrunner" module
 * Proper result collection and storage

And many other features.  But, it lays a skeleton of an implementation that we can work with.  The only way to use it right now is to run the supplied `examples/job/nrunner.py` job file. 