### PR TITLE
avocado.utils.network.is_port_free: default to checking all interfaces

### DIFF
--- a/avocado/utils/network.py
+++ b/avocado/utils/network.py
@@ -27,7 +27,7 @@ FAMILIES = (socket.AF_INET, socket.AF_INET6)
 PROTOCOLS = (socket.SOCK_STREAM, socket.SOCK_DGRAM)
 
 
-def is_port_free(port, address):
+def is_port_free(port, address=""):
     """
     Return True if the given port is available for use.
 
@@ -50,7 +50,7 @@ def is_port_free(port, address):
                 try:
                     sock = socket.socket(family, protocol)
                     if localhost:
-                        sock.bind(("", port))
+                        sock.bind((address, port))
                     else:
                         sock.connect((address, port))
                         return False


### PR DESCRIPTION
One of the reasons being a simplified API, which should allow users to
simply do:

   >>> network.is_port_free(8080)

The second reason is that lgtm.com complains that binding to all
interfaces is a problem, and it probably does that by looking at the
empty string being used.  Because we know what we're doing, that we
may really want to check port availability on all interfaces, this use
case is justified.  Respecting the address parameter given, though,
seems more correct.

Signed-off-by: Cleber Rosa <crosa@redhat.com>