### PR TITLE
Move methods from jobdata to data_dir and refactor [v3]

### DIFF
--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -287,54 +287,62 @@ def clean_tmp_files():
         pass
 
 
-def get_resultsdir(logdir, jobid):
+def get_job_results_dir(job_ref, logs_dir=None):
     """
-    Gets the job results directory using a Job ID.
+    Get the job results directory from a job reference.
+
+    :param job_ref: job reference, which can be:
+                    * an valid path to the job results directory. In this case
+                      it is checked if 'id' file exists
+                    * the path to 'id' file
+                    * the job id, which can be 'latest'
+                    * an partial job id
+    :param logs_dir: path to base logs directory (optional), otherwise it uses
+                     the value from settings.
     """
-    if os.path.isdir(jobid):
-        return os.path.expanduser(jobid)
-    elif os.path.isfile(jobid):
-        return os.path.dirname(os.path.expanduser(jobid))
-    elif jobid == 'latest':
+    # Check if job_ref is actually the path to either the job logs
+    # directory itself or the job id file.
+    path_ref = os.path.expanduser(job_ref)
+    if os.path.isdir(path_ref):
+        # The id file should exists otherwise it is not the expected
+        # directory.
+        if os.path.isfile(os.path.join(path_ref, 'id')):
+            return os.path.abspath(path_ref)
+        return None
+    elif os.path.isfile(path_ref):
+        if os.path.basename(path_ref) == 'id':
+            return os.path.abspath(os.path.dirname(path_ref))
+        return None
+
+    # At this point job_ref is expected to be an id (can be partial) or
+    # the 'latest' symlink.
+    #
+
+    if logs_dir is None:
+        logs_dir = get_logs_dir()
+    else:
+        logs_dir = os.path.expanduser(logs_dir)
+
+    if job_ref == 'latest':
         try:
-            actual_dir = os.readlink(os.path.join(logdir, 'latest'))
-            return os.path.join(logdir, actual_dir)
+            actual_dir = os.readlink(os.path.join(logs_dir, 'latest'))
+            return os.path.join(logs_dir, actual_dir)
         except IOError:
             return None
 
     matches = 0
-    short_jobid = jobid[:7]
+    short_jobid = job_ref[:7]
     if len(short_jobid) < 7:
         short_jobid += '*'
-    idfile_pattern = os.path.join(logdir, 'job-*-%s' % short_jobid, 'id')
+    idfile_pattern = os.path.join(logs_dir, 'job-*-%s' % short_jobid, 'id')
     for id_file in glob.glob(idfile_pattern):
-        if get_id(id_file, jobid) is not None:
-            match_file = id_file
-            matches += 1
+        with open(id_file, 'r') as fid:
+            line = fid.read().strip('\n')
+            if line.startswith(job_ref):
+                match_file = id_file
+                matches += 1
             if matches > 1:
-                raise ValueError("hash '%s' is not unique enough" % jobid)
+                raise ValueError("hash '%s' is not unique enough" % job_ref)
     if matches == 1:
         return os.path.dirname(match_file)
-    else:
-        return None
-
-
-def get_id(path, jobid):
-    """
-    Gets the full Job ID using the results directory path and a partial
-    Job ID or the string 'latest'.
-    """
-    if os.path.isdir(jobid) or os.path.isfile(jobid):
-        jobid = ''
-    elif jobid == 'latest':
-        jobid = os.path.basename(os.path.dirname(path))[-7:]
-
-    if not os.path.exists(path):
-        return None
-
-    with open(path, 'r') as jobid_file:
-        content = jobid_file.read().strip('\n')
-    if content.startswith(jobid):
-        return content
-    else:
-        return None
+    return None

--- a/avocado/core/jobdata.py
+++ b/avocado/core/jobdata.py
@@ -17,7 +17,6 @@ Record/retrieve job information
 """
 
 import ast
-import glob
 import json
 import os
 
@@ -164,57 +163,3 @@ def retrieve_cmdline(resultsdir):
         return None
     with open(recorded_cmdline, 'r') as cmdline_file:
         return ast.literal_eval(cmdline_file.read())
-
-
-def get_resultsdir(logdir, jobid):
-    """
-    Gets the job results directory using a Job ID.
-    """
-    if os.path.isdir(jobid):
-        return os.path.expanduser(jobid)
-    elif os.path.isfile(jobid):
-        return os.path.dirname(os.path.expanduser(jobid))
-    elif jobid == 'latest':
-        try:
-            actual_dir = os.readlink(os.path.join(logdir, 'latest'))
-            return os.path.join(logdir, actual_dir)
-        except IOError:
-            return None
-
-    matches = 0
-    short_jobid = jobid[:7]
-    if len(short_jobid) < 7:
-        short_jobid += '*'
-    idfile_pattern = os.path.join(logdir, 'job-*-%s' % short_jobid, 'id')
-    for id_file in glob.glob(idfile_pattern):
-        if get_id(id_file, jobid) is not None:
-            match_file = id_file
-            matches += 1
-            if matches > 1:
-                raise ValueError("hash '%s' is not unique enough" % jobid)
-
-    if matches == 1:
-        return os.path.dirname(match_file)
-    else:
-        return None
-
-
-def get_id(path, jobid):
-    """
-    Gets the full Job ID using the results directory path and a partial
-    Job ID or the string 'latest'.
-    """
-    if os.path.isdir(jobid) or os.path.isfile(jobid):
-        jobid = ''
-    elif jobid == 'latest':
-        jobid = os.path.basename(os.path.dirname(path))[-7:]
-
-    if not os.path.exists(path):
-        return None
-
-    with open(path, 'r') as jobid_file:
-        content = jobid_file.read().strip('\n')
-    if content.startswith(jobid):
-        return content
-    else:
-        return None

--- a/avocado/plugins/diff.py
+++ b/avocado/plugins/diff.py
@@ -26,6 +26,7 @@ import tempfile
 
 from difflib import unified_diff, HtmlDiff
 
+from avocado.core import data_dir
 from avocado.core import exit_codes
 from avocado.core import jobdata
 from avocado.core import output
@@ -356,7 +357,7 @@ class Diff(CLICmd):
                                         key='logs_dir', key_type='path',
                                         default=None)
             try:
-                resultsdir = jobdata.get_resultsdir(logdir, job_id)
+                resultsdir = data_dir.get_resultsdir(logdir, job_id)
             except ValueError as exception:
                 LOG_UI.error(exception)
                 sys.exit(exit_codes.AVOCADO_FAIL)
@@ -366,7 +367,7 @@ class Diff(CLICmd):
                          job_id, logdir)
             sys.exit(exit_codes.AVOCADO_FAIL)
 
-        sourcejob = jobdata.get_id(os.path.join(resultsdir, 'id'), job_id)
+        sourcejob = data_dir.get_id(os.path.join(resultsdir, 'id'), job_id)
         if sourcejob is None:
             LOG_UI.error("Can't find matching job id '%s' in '%s' directory.",
                          job_id, resultsdir)

--- a/avocado/plugins/diff.py
+++ b/avocado/plugins/diff.py
@@ -33,7 +33,6 @@ from avocado.core import output
 
 from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLICmd
-from avocado.core.settings import settings
 
 
 class Diff(CLICmd):
@@ -346,32 +345,13 @@ class Diff(CLICmd):
 
     @staticmethod
     def _setup_job(job_id):
-        if os.path.isdir(job_id):
-            resultsdir = os.path.expanduser(job_id)
-            job_id = ''
-        elif os.path.isfile(job_id):
-            resultsdir = os.path.dirname(os.path.expanduser(job_id))
-            job_id = ''
-        else:
-            logdir = settings.get_value(section='datadir.paths',
-                                        key='logs_dir', key_type='path',
-                                        default=None)
-            try:
-                resultsdir = data_dir.get_resultsdir(logdir, job_id)
-            except ValueError as exception:
-                LOG_UI.error(exception)
-                sys.exit(exit_codes.AVOCADO_FAIL)
-
+        resultsdir = data_dir.get_job_results_dir(job_id)
         if resultsdir is None:
-            LOG_UI.error("Can't find job results directory for '%s' in '%s'",
-                         job_id, logdir)
+            LOG_UI.error("Can't find job results directory for '%s'", job_id)
             sys.exit(exit_codes.AVOCADO_FAIL)
 
-        sourcejob = data_dir.get_id(os.path.join(resultsdir, 'id'), job_id)
-        if sourcejob is None:
-            LOG_UI.error("Can't find matching job id '%s' in '%s' directory.",
-                         job_id, resultsdir)
-            sys.exit(exit_codes.AVOCADO_FAIL)
+        with open(os.path.join(resultsdir, 'id'), 'r') as id_file:
+            sourcejob = id_file.read().strip()
 
         return resultsdir, sourcejob
 

--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -180,30 +180,15 @@ class Replay(CLI):
             LOG_UI.error(err)
             sys.exit(exit_codes.AVOCADO_FAIL)
 
-        base_logdir = config.get('base_logdir', None)
-        if base_logdir is None:
-            base_logdir = settings.get_value(section='datadir.paths',
-                                             key='logs_dir', key_type='path',
-                                             default=None)
-        try:
-            resultsdir = data_dir.get_resultsdir(base_logdir,
-                                                 config.get('replay_jobid'))
-        except ValueError as exception:
-            LOG_UI.error(exception)
-            sys.exit(exit_codes.AVOCADO_FAIL)
-
+        resultsdir = data_dir.get_job_results_dir(config.get('replay_jobid'),
+                                                  config.get('base_logdir', None))
         if resultsdir is None:
-            LOG_UI.error("Can't find job results directory in '%s'", base_logdir)
+            LOG_UI.error("Can't find job results directory for '%s'",
+                         config.get('replay_jobid'))
             sys.exit(exit_codes.AVOCADO_FAIL)
 
-        sourcejob = data_dir.get_id(os.path.join(resultsdir, 'id'),
-                                    config.get('replay_jobid'))
-        if sourcejob is None:
-            msg = ("Can't find matching job id '%s' in '%s' directory."
-                   % (config.get('replay_jobid'), resultsdir))
-            LOG_UI.error(msg)
-            sys.exit(exit_codes.AVOCADO_FAIL)
-        config['replay_sourcejob'] = sourcejob
+        with open(os.path.join(resultsdir, 'id'), 'r') as id_file:
+            config['replay_sourcejob'] = id_file.read().strip()
 
         replay_config = jobdata.retrieve_job_config(resultsdir)
         whitelist = ['loaders',

--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -18,6 +18,7 @@ import os
 import re
 import sys
 
+from avocado.core import data_dir
 from avocado.core import exit_codes
 from avocado.core import jobdata
 from avocado.core import status
@@ -185,7 +186,8 @@ class Replay(CLI):
                                              key='logs_dir', key_type='path',
                                              default=None)
         try:
-            resultsdir = jobdata.get_resultsdir(base_logdir, config.get('replay_jobid'))
+            resultsdir = data_dir.get_resultsdir(base_logdir,
+                                                 config.get('replay_jobid'))
         except ValueError as exception:
             LOG_UI.error(exception)
             sys.exit(exit_codes.AVOCADO_FAIL)
@@ -194,8 +196,8 @@ class Replay(CLI):
             LOG_UI.error("Can't find job results directory in '%s'", base_logdir)
             sys.exit(exit_codes.AVOCADO_FAIL)
 
-        sourcejob = jobdata.get_id(os.path.join(resultsdir, 'id'),
-                                   config.get('replay_jobid'))
+        sourcejob = data_dir.get_id(os.path.join(resultsdir, 'id'),
+                                    config.get('replay_jobid'))
         if sourcejob is None:
             msg = ("Can't find matching job id '%s' in '%s' directory."
                    % (config.get('replay_jobid'), resultsdir))

--- a/contrib/scripts/avocado-get-job-results-dir.py
+++ b/contrib/scripts/avocado-get-job-results-dir.py
@@ -22,7 +22,7 @@
 
 import sys
 
-from avocado.core import jobdata
+from avocado.core import data_dir
 from avocado.core.settings import settings
 
 if __name__ == '__main__':
@@ -39,7 +39,7 @@ if __name__ == '__main__':
         sys.exit(-1)
 
     try:
-        resultsdir = jobdata.get_resultsdir(logdir, sys.argv[1])
+        resultsdir = data_dir.get_resultsdir(logdir, sys.argv[1])
     except ValueError as exception:
         sys.stderr.write('%s\n' % exception)
         sys.exit(-1)

--- a/contrib/scripts/avocado-get-job-results-dir.py
+++ b/contrib/scripts/avocado-get-job-results-dir.py
@@ -23,30 +23,16 @@
 import sys
 
 from avocado.core import data_dir
-from avocado.core.settings import settings
 
 if __name__ == '__main__':
     if len(sys.argv) < 2:
         sys.stderr.write("Please inform the Job ID.\n")
         sys.exit(-1)
 
-    logdir = settings.get_value(section='datadir.paths',
-                                key='logs_dir', key_type='path',
-                                default=None)
-
-    if logdir is None:
-        sys.sterr.write("Log directory not configured in Avocado settings.\n")
+    resultsdir = data_dir.get_job_results_dir(sys.argv[1])
+    if resultsdir is None:
+        sys.stderr.write("Can't find job results directory for '%s'\n" %
+                         sys.argv[1])
         sys.exit(-1)
 
-    try:
-        resultsdir = data_dir.get_resultsdir(logdir, sys.argv[1])
-    except ValueError as exception:
-        sys.stderr.write('%s\n' % exception)
-        sys.exit(-1)
-    else:
-        if resultsdir is None:
-            sys.stderr.write("Can't find job results directory in '%s'\n" %
-                             logdir)
-            sys.exit(-1)
-
-        sys.stdout.write('%s\n' % resultsdir)
+    sys.stdout.write('%s\n' % resultsdir)

--- a/optional_plugins/loader_yaml/tests/test_yaml_loader.py
+++ b/optional_plugins/loader_yaml/tests/test_yaml_loader.py
@@ -41,7 +41,8 @@ class YamlLoaderTests(unittest.TestCase):
         # Run replay job
         for line in res.stdout.splitlines():
             if line.startswith(b"JOB LOG"):
-                srcjob = line[13:]
+                joblog = line[13:]
+                srcjob = os.path.dirname(joblog)
                 break
         else:
             self.fail("Unable to find 'JOB LOG' in:\n%s" % res)

--- a/selftests/unit/test_datadir.py
+++ b/selftests/unit/test_datadir.py
@@ -99,6 +99,93 @@ class DataDirTest(unittest.TestCase):
                 self.assertEqual(data_dir_func(), self.alt_mapping[key])
             del data_dir
 
+    def test_get_job_results_dir(self):
+        from avocado.core import data_dir
+        from avocado.core import job_id
+
+        # First let's mock a jobs results directory
+        #
+
+        logs_dir = self.mapping.get('logs_dir')
+        self.assertNotEqual(None, logs_dir)
+        unique_id = job_id.create_unique_job_id()
+        # Expected job results dir
+        expected_jrd = data_dir.create_job_logs_dir(logs_dir, unique_id)
+
+        # Now let's test some cases
+        #
+
+        self.assertEqual(None,
+                         data_dir.get_job_results_dir(expected_jrd, logs_dir),
+                         ("If passing a directory reference, it expects the id"
+                          "file"))
+
+        # Create the id file.
+        id_file_path = os.path.join(expected_jrd, 'id')
+        with open(id_file_path, 'w') as id_file:
+            id_file.write("%s\n" % unique_id)
+            id_file.flush()
+            os.fsync(id_file)
+
+        self.assertEqual(expected_jrd,
+                         data_dir.get_job_results_dir(expected_jrd, logs_dir),
+                         "It should get from the path to the directory")
+
+        results_dirname = os.path.basename(expected_jrd)
+        self.assertEqual(None,
+                         data_dir.get_job_results_dir(results_dirname,
+                                                      logs_dir),
+                         "It should not get from a valid path to the directory")
+
+        pwd = os.getcwd()
+        os.chdir(logs_dir)
+        self.assertEqual(expected_jrd,
+                         data_dir.get_job_results_dir(results_dirname,
+                                                      logs_dir),
+                         "It should get from relative path to the directory")
+        os.chdir(pwd)
+
+        self.assertEqual(expected_jrd,
+                         data_dir.get_job_results_dir(id_file_path, logs_dir),
+                         "It should get from the path to the id file")
+
+        self.assertEqual(expected_jrd,
+                         data_dir.get_job_results_dir(unique_id, logs_dir),
+                         "It should get from the id")
+
+        another_id = job_id.create_unique_job_id()
+        self.assertNotEqual(unique_id, another_id)
+        self.assertEqual(None,
+                         data_dir.get_job_results_dir(another_id, logs_dir),
+                         "It should not get from unexisting job")
+
+        self.assertEqual(expected_jrd,
+                         data_dir.get_job_results_dir(unique_id[:7], logs_dir),
+                         "It should get from partial id equals to 7 digits")
+
+        self.assertEqual(expected_jrd,
+                         data_dir.get_job_results_dir(unique_id[:4], logs_dir),
+                         "It should get from partial id less than 7 digits")
+
+        almost_id = unique_id[:7] + ('a' * (len(unique_id) - 7))
+        self.assertNotEqual(unique_id, almost_id)
+        self.assertEqual(None,
+                         data_dir.get_job_results_dir(almost_id, logs_dir),
+                         ("It should not get if the id is equal on only"
+                          "the first 7 characters"))
+
+        os.symlink(expected_jrd, os.path.join(logs_dir, 'latest'))
+        self.assertEqual(expected_jrd,
+                         data_dir.get_job_results_dir('latest', logs_dir),
+                         "It should get from the 'latest' id")
+
+        stg = settings.Settings(self.config_file_path)
+        with unittest.mock.patch('avocado.core.data_dir.settings.settings',
+                                 stg):
+            self.assertEqual(expected_jrd,
+                             data_dir.get_job_results_dir(unique_id),
+                             "It should use the default base logs directory")
+
     def tearDown(self):
         os.unlink(self.config_file_path)
         self.base_dir.cleanup()


### PR DESCRIPTION
This PR contain commits that move methods from jobdata to data_dir which is conceptually the right place. Then I improved (renamed too) the methods, besides some improvements+fixes. It seems the only clients of those methods are the diff and replay plugins, so they were adapted (that resulted on cleaner code).

I added a bunch of tests in `selftests/unit/test_datadir.py.DataDirTests`. I thought in maybe create another test class on same module but I hold that change so that I could get a quicker overall feedback on those changes first.

---
Changes v2 -> v3:
 * Fixed style (missing and trailing newline)
 * Fixed `optional_plugins.loader_yaml.tests.test_yaml_loader.YamlLoaderTests.test_replay` that was using the full job log path as a reference to the job results dir.

Changes v1 -> v2: fixed pylint errors
v1: PR #3485