### PR TITLE
selftests/deployment: Disable fedora-modular repos [v2]

### DIFF
--- a/selftests/deployment/roles/common/tasks/repos.yml
+++ b/selftests/deployment/roles/common/tasks/repos.yml
@@ -1,3 +1,24 @@
+# Official + Copr Modules disable
+- name: Disable Fedora module to avoid conflict
+  ini_file:
+    path: /etc/yum.repos.d/fedora-modular.repo
+    section: fedora-modular
+    option: enabled
+    value: '0'
+  when:
+    - method == 'official' or method == 'copr'
+    - ansible_facts['distribution'] == "Fedora"
+
+- name: Disable Fedora module updates to avoid conflict
+  ini_file:
+    path: /etc/yum.repos.d/fedora-updates-modular.repo
+    section: updates-modular
+    option: enabled
+    value: '0'
+  when:
+    - method == 'official' or method == 'copr'
+    - ansible_facts['distribution'] == "Fedora"
+
 # Official repos
 - name: Install Avocado EPEL Official Releases repo
   yum_repository:


### PR DESCRIPTION
When you have Fedora modules enabled, Avocado package will be installed
from modules instead of the ones in the COPR or Official. This change
will disable fedora-modular and fedora-updates-modular repos during this
deployment.

Signed-off-by: Beraldo Leal <bleal@redhat.com>

----
Changes from v1:

  * Converted int to str