### PR TITLE
[RFC] nrunner requirements: work directory

### DIFF
--- a/docs/source/future/core/nrunner.rst
+++ b/docs/source/future/core/nrunner.rst
@@ -159,6 +159,16 @@ The runner's main method (``run()``) operates like a generator, and
 yields results which are dictionaries with relevant information about
 it.
 
+Runnable's Requirements
+-----------------------
+
+A Runnable may have some requirements defined, and those will be fulfilled
+on its behalf.  Requirements can vary wildly in complexity, and can range
+from a directory (to be used during the runnable execution) or requiring
+a package to be installed in the system (in theory also to be used during
+the runnable execution).
+
+
 Trying it out - standalone
 --------------------------
 

--- a/examples/nrunner-tests/creates-file-in-work-dir/README
+++ b/examples/nrunner-tests/creates-file-in-work-dir/README
@@ -1,0 +1,4 @@
+This test creates a temporary file in the work directory provided by
+the Avocado runner.  The test should fail if Avocado's work directory
+is not set (as an environment variable) or if the directory set does
+not exist.

--- a/examples/nrunner-tests/creates-file-in-work-dir/run.sh
+++ b/examples/nrunner-tests/creates-file-in-work-dir/run.sh
@@ -1,0 +1,13 @@
+#!/bin/sh -e
+
+if [ -z "$AVOCADO_WORK_DIR" ]; then
+    exit 1
+fi
+
+if ! [ -d "$AVOCADO_WORK_DIR" ]; then
+    exit 1
+fi
+
+OUTPUT_FILE="$AVOCADO_WORK_DIR/avocado-examples-nrunner-tests-creates-file-in-work-dir"
+echo "OUTPUT_FILE: $OUTPUT_FILE"
+echo 'THIS_FILE_SHOULD_BE_REMOVED_AUTOMATICALLY' > $OUTPUT_FILE

--- a/selftests/functional/test_nrunner.py
+++ b/selftests/functional/test_nrunner.py
@@ -87,6 +87,18 @@ class RunnableRun(unittest.TestCase):
         self.assertIn(b"'stdout': b'X=Y\\n'", res.stdout)
         self.assertEqual(res.exit_status, exit_codes.AVOCADO_ALL_OK)
 
+    @unittest.skipUnless(os.path.exists('/bin/sh'),
+                         ('Executable "/bin/sh" used in test is not '
+                          'available in the system'))
+    def test_work_dir(self):
+        test = os.path.join(BASEDIR, "examples", "nrunner-tests",
+                            "creates-file-in-work-dir", "run.sh")
+        cmd = "%s runnable-run -k exec -u %s --requires-work-dir" % (AVOCADO,
+                                                                     test)
+        res = process.run(cmd)
+        self.assertIn(b"'status': 'finished'", res.stdout)
+        self.assertIn(b"'returncode': 0", res.stdout)
+
 
 class TaskRun(unittest.TestCase):
 


### PR DESCRIPTION
The avocado.Test class provides tests with a "workdir", a temporary
directory that will be created by the test runner.  Tests are then
free to create any content that they seem fit there, and they will,
by default, be removed once the test is over.

The concept of "requirements" has been maturing in many discussions,
including around the Asset fetcher.  This is a very simplistic idea
that a temporary work directory may just as well be a test requirement
too.

It's anticipated that different test types will have different requirements,
and the very next one that is similar to this is probably a "tests'
result directory", one that will have its contents persisted, instead
of removed.

Internally, at this point, it's not properly defined as a "test
requirement" because the concept has not been introduced.  Other point
not covered here is that idea that different requirements may have
different "agents" to fulfill them.

Still, I hope that this helps the discussion to move forward.

Signed-off-by: Cleber Rosa <crosa@redhat.com>