### PR TITLE
selftests/functional/test_output.py: only attempt to parse JSON from …

### DIFF
--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -329,7 +329,7 @@ class OutputPluginTest(unittest.TestCase):
                          "Avocado did not return rc %d:\n%s" %
                          (expected_rc, result))
         # Check if we are producing valid outputs
-        json.loads(output)
+        json.loads(result.stdout_text)
         minidom.parse(tmpfile)
 
     def test_output_compatible_setup_2(self):


### PR DESCRIPTION
…stdout

The content that goes to STDERR can include any type of error
messages, and will not conform or be part of the intended JSON
produced by the JSON result plugin.

This fixes the following error observed when the PYTHONWARNING setting
is *not* set to ignore:

   ERROR: test_output_compatible_setup (selftests.functional.test_output.OutputPluginTest)
   ----------------------------------------------------------------------
   Traceback (most recent call last):
     File "/builddir/build/BUILD/avocado-a257e52c24b41976ce5ca8f0159d8148f273f0e9/selftests/functional/test_output.py", line 332, in test_output_compatible_setup
       json.loads(output)
     File "/usr/lib64/python3.6/json/__init__.py", line 354, in loads
       return _default_decoder.decode(s)
     File "/usr/lib64/python3.6/json/decoder.py", line 342, in decode
       raise JSONDecodeError("Extra data", s, end)
   json.decoder.JSONDecodeError: Extra data: line 27 column 1 (char 1038)

Signed-off-by: Cleber Rosa <crosa@redhat.com>