### PR TITLE
selftests: acknowledge the use of stderr for its natural purpose

### DIFF
--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -323,13 +323,12 @@ class OutputPluginTest(unittest.TestCase):
                     '--journal --xunit %s --json - passtest.py' %
                     (AVOCADO, self.tmpdir.name, tmpfile))
         result = process.run(cmd_line, ignore_status=True)
-        output = result.stdout_text + result.stderr_text
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %d:\n%s" %
                          (expected_rc, result))
         # Check if we are producing valid outputs
-        json.loads(output)
+        json.loads(result.stdout_text)
         minidom.parse(tmpfile)
 
     def test_output_compatible_setup_2(self):
@@ -338,7 +337,6 @@ class OutputPluginTest(unittest.TestCase):
                     '--xunit - --json %s --tap-include-logs passtest.py'
                     % (AVOCADO, self.tmpdir.name, tmpfile))
         result = process.run(cmd_line, ignore_status=True)
-        output = result.stdout + result.stderr
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %d:\n%s" %
@@ -348,7 +346,7 @@ class OutputPluginTest(unittest.TestCase):
             json_results = json.load(fp)
             debug_log = json_results['debuglog']
             self.check_output_files(debug_log)
-        minidom.parseString(output)
+        minidom.parseString(result.stdout_text)
 
     def test_output_compatible_setup_nooutput(self):
         tmpfile = tempfile.mktemp(dir=self.tmpdir.name)
@@ -358,12 +356,12 @@ class OutputPluginTest(unittest.TestCase):
                     '--sysinfo=off --xunit %s --json %s --tap-include-logs '
                     'passtest.py' % (AVOCADO, self.tmpdir.name, tmpfile, tmpfile2))
         result = process.run(cmd_line, ignore_status=True)
-        output = result.stdout + result.stderr
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %d:\n%s" %
                          (expected_rc, result))
-        self.assertEqual(output, b"", "Output is not empty:\n%s" % output)
+        self.assertEqual(result.stdout, b"",
+                         "Output is not empty:\n%s" % result.stdout)
         # Check if we are producing valid outputs
         with open(tmpfile2, 'r') as fp:
             json_results = json.load(fp)
@@ -412,12 +410,11 @@ class OutputPluginTest(unittest.TestCase):
                     '--sysinfo=off passtest.py'
                     % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
-        output = result.stdout + result.stderr
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %d:\n%s" %
                          (expected_rc, result))
-        self.assertEqual(output, b"")
+        self.assertEqual(result.stdout, b"")
 
     def test_default_enabled_plugins(self):
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
@@ -491,13 +488,12 @@ class OutputPluginTest(unittest.TestCase):
                     '--sysinfo=off passtest.py > %s'
                     % (AVOCADO, self.tmpdir.name, redirected_output_path))
         result = process.run(cmd_line, ignore_status=True, shell=True)
-        output = result.stdout + result.stderr
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %d:\n%s" %
                          (expected_rc, result))
-        self.assertEqual(output, b'',
-                         'After redirecting to file, output is not empty: %s' % output)
+        self.assertEqual(result.stdout, b'',
+                         'After redirecting to file, output is not empty: %s' % result.stdout)
         with open(redirected_output_path, 'r') as redirected_output_file_obj:
             redirected_output = redirected_output_file_obj.read()
             for code in TermSupport.ESCAPE_CODES:

--- a/selftests/functional/test_plugin_jobscripts.py
+++ b/selftests/functional/test_plugin_jobscripts.py
@@ -99,8 +99,8 @@ class JobScriptsTest(unittest.TestCase):
 
         # Pre/Post scripts failures do not (currently?) alter the exit status
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
-        self.assertEqual('Pre job script "%s" exited with status "1"\n' % non_zero_script,
-                         result.stderr_text)
+        self.assertIn('Pre job script "%s" exited with status "1"\n' % non_zero_script,
+                      result.stderr_text)
 
     def test_non_existing_dir(self):
         """

--- a/selftests/functional/test_streams.py
+++ b/selftests/functional/test_streams.py
@@ -59,7 +59,6 @@ class StreamsTest(unittest.TestCase):
             cmd_in_log = shlex.split(AVOCADO)[-1]
             self.assertIn("avocado.test: Command line: %s" % cmd_in_log,
                           result.stdout_text)
-            self.assertEqual(b'', result.stderr)
 
     def test_test(self):
         """
@@ -76,7 +75,6 @@ class StreamsTest(unittest.TestCase):
         self.assertIn(b"\nSTART 1-passtest.py:PassTest.test",
                       result.stdout)
         self.assertIn(b"PASS 1-passtest.py:PassTest.test", result.stdout)
-        self.assertEqual(b'', result.stderr)
 
     def test_none_success(self):
         """
@@ -87,7 +85,6 @@ class StreamsTest(unittest.TestCase):
         result = process.run(cmd)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
         self.assertEqual(b'', result.stdout)
-        self.assertEqual(b'', result.stderr)
 
     def test_none_error(self):
         """


### PR DESCRIPTION
There are a number of selftests that assume that the stderr should
never contain anything.  In truthfulness, that is more appropriate
to the stdout, once the stderr can produce content even when a
silent operation is requested.

On some other cases, the intention of stderr is mixed with that of the
stdout, like attempting to parse JSON from stdout and from stderr.
The content that goes to stderr can include any type of error
messages, and will not conform or be part of the intended JSON
produced by the JSON result plugin.

This fixes errors such as:

```
   ERROR: test_output_compatible_setup (selftests.functional.test_output.OutputPluginTest)
   ----------------------------------------------------------------------
   Traceback (most recent call last):
     File "/builddir/build/BUILD/avocado-a257e52c24b41976ce5ca8f0159d8148f273f0e9/selftests/functional/test_output.py", line 332, in test_output_compatible_setup
       json.loads(output)
     File "/usr/lib64/python3.6/json/__init__.py", line 354, in loads
       return _default_decoder.decode(s)
     File "/usr/lib64/python3.6/json/decoder.py", line 342, in decode
       raise JSONDecodeError("Extra data", s, end)
   json.decoder.JSONDecodeError: Extra data: line 27 column 1 (char 1038)
```

Signed-off-by: Cleber Rosa <crosa@redhat.com>