### PR TITLE
selftests/deployment: installing aexpect first [v2]

### DIFF
--- a/selftests/deployment/roles/common/tasks/aexpect.yml
+++ b/selftests/deployment/roles/common/tasks/aexpect.yml
@@ -1,0 +1,9 @@
+- name: Install python3-aexpect first
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - python3-aexpect
+  when:
+    - ansible_facts['distribution_file_variety'] == "RedHat"
+    - avocado_vt|default(false)|bool == true

--- a/selftests/deployment/roles/common/tasks/dependencies.yml
+++ b/selftests/deployment/roles/common/tasks/dependencies.yml
@@ -20,7 +20,6 @@
     - nc
     - python3-netaddr
     - python3-netifaces
-    - python3-aexpect
     - qemu-img
     - qemu-kvm
     - tcpdump

--- a/selftests/deployment/roles/common/tasks/main.yml
+++ b/selftests/deployment/roles/common/tasks/main.yml
@@ -1,3 +1,4 @@
 ---
+- include: aexpect.yml
 - include: repos.yml
 - include: dependencies.yml


### PR DESCRIPTION
Since that python3-aexpect is only available on fedora module, we need
to install it before disabling the module.

Signed-off-by: Beraldo Leal <bleal@redhat.com>

----
Changes from v1:

  * Changed from latest to present