### PR TITLE
Add a backslash to the link of the docs badge.

### DIFF
--- a/docs/source/quickstart/index.rst
+++ b/docs/source/quickstart/index.rst
@@ -243,5 +243,5 @@ Build and Quality Status
      :target: https://codecov.io/gh/avocado-framework/avocado
 
   .. image:: https://readthedocs.org/projects/avocado-framework/badge/?version=latest
-     :target: https://avocado-framework.readthedocs.io/en/latest
+     :target: https://avocado-framework.readthedocs.io/en/latest/
      :alt: Documentation Status


### PR DESCRIPTION
For some awkward reason, the docs badge stopped working without the last backslash on the target link.

Signed-off-by: Willian Rampazzo <willianr@redhat.com>