### PR TITLE
future/settings: Defaults experiment

### DIFF
--- a/avocado/core/app.py
+++ b/avocado/core/app.py
@@ -26,6 +26,7 @@ from .dispatcher import CLICmdDispatcher
 from .dispatcher import CLIDispatcher
 from .output import STD_OUTPUT
 from .parser import Parser
+from .future.settings import settings
 from ..utils import process
 
 
@@ -88,6 +89,7 @@ class AvocadoApp:
             except KeyError:
                 return
             method = extension.obj.run
+            settings.merge_with_arguments(self.parser.config)
             return method(self.parser.config)
         finally:
             # This makes sure we cleanup the console (stty echo). The only way

--- a/avocado/core/future/settings.py
+++ b/avocado/core/future/settings.py
@@ -1,0 +1,364 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# This code was inspired in the autotest project,
+# client/shared/settings.py
+#
+# Authors: Travis Miller <raphtee@google.com>
+#          Beraldo Leal <bleal@redhat.com>
+
+"""
+This module is a new and experimental configuration handler.
+
+This will handle both, command line args and configuration files.
+AvocadoSettings = configparser + argparser
+
+AvocadoSettings is an attempt to implement part of BP001 and concentrate all
+default values in one place. This module will read the Avocado configuration
+options from many sources, in the following order:
+
+  1. Default values (defaults.conf or defaults.py). This is a "source code"
+     file and should not be changed by the Avocado' user.
+
+  2. User/System configuration files (/etc/avocado or ~/.avocado/). This is
+     configured by the user, on a more "permanent way".
+
+  3. Command-line options parsed in runtime. This is configured by the user, on
+     a more "temporary way";
+
+ATTENTION: This is a future module, and will be moved out from this package
+soon.
+"""
+
+import configparser
+import glob
+import os
+import re
+
+from pkg_resources import resource_filename
+
+from ..settings_dispatcher import SettingsDispatcher
+from ...utils import path
+
+
+class SettingsError(Exception):
+    """
+    Base settings error.
+    """
+
+
+class ConfigFileNotFound(SettingsError):
+    """
+    Error thrown when the main settings file could not be found.
+    """
+
+    def __init__(self, path_list):
+        super(ConfigFileNotFound, self).__init__()
+        self.path_list = path_list
+
+    def __str__(self):
+        return ("Could not find the avocado config file after looking in: %s" %
+                self.path_list)
+
+
+class AvocadoSettings:
+    """AvocadoSettings, an experimental Avocado configuration handler.
+
+    It is a simple wrapper around configparser and argparse.
+
+    Also, one object of this class could be passed as config to plugins and
+    modules.
+
+    Please, not that most of methods and attributes here are private. Only
+    public methods and attributes should be used outside this module.
+    """
+
+    def __init__(self, config_path=None):
+        """Constructor. Tries to find the main settings files and load them.
+
+        :param config_path: Path to a config file. Useful for unittesting.
+        """
+        self._config = configparser.ConfigParser()
+        self._all_config_paths = []
+        self._config_paths = []
+        self._short_mapping = {}
+        self._long_mapping = {}
+        self._namespaces = {}
+
+        # 1. Prepare config paths
+        if config_path is None:
+            self._prepare_base_dirs()
+            self._append_config_paths()
+        else:
+            # Only used by unittests (the --config parses the file later)
+            self._all_config_paths.append(config_path)
+
+        # 2. Parse/read all config paths
+        self._config_paths = self._config.read(self._all_config_paths)
+        if not self._config_paths:
+            raise ConfigFileNotFound(self._all_config_paths)
+
+    def _append_config_paths(self):
+        # 1. Append Defaults
+        self._append_pkg_defaults()
+
+        # 2. Override with system config
+        self._append_system_config()
+
+        # Allow plugins to modify/extend the list of configs
+        dispatcher = SettingsDispatcher()
+        if dispatcher.extensions:
+            dispatcher.map_method('adjust_settings_paths',
+                                  self._all_config_paths)
+
+        # 3. Override with the user's local config
+        self._append_user_config()
+
+    def _append_pkg_defaults(self):
+        config_pkg_base = os.path.join('etc', 'avocado', 'defaults.conf')
+        config_path_pkg = resource_filename('avocado', config_pkg_base)
+        self._all_config_paths.append(config_path_pkg)
+
+    def _append_system_config(self):
+        self._all_config_paths.append(self._config_path_system)
+        configs = glob.glob(os.path.join(self._config_dir_system_extra,
+                                         '*.conf'))
+        for extra_file in configs:
+            self._all_config_paths.append(extra_file)
+
+    def _append_user_config(self):
+        if not os.path.exists(self._config_path_local):
+            self._create_empty_config()
+        self._all_config_paths.append(self._config_path_local)
+
+    def _create_empty_config(self):
+        try:
+            path.init_dir(self._config_dir_local)
+            with open(self._config_path_local, 'w') as config_local_fileobj:
+                content = ("# You can use this file to override "
+                           "configuration values from '%s and %s\n"
+                           % (self._config_path_system,
+                              self._config_dir_system_extra))
+                config_local_fileobj.write(content)
+        except IOError:     # Some users can't write it (docker)
+            pass
+
+    def _get_option_from_tag(self, tag):
+        try:
+            mapping = self._long_mapping[tag]
+            return self._namespaces[mapping]
+        except KeyError:
+            msg = "{} not found in internal mapping.".format(tag)
+            raise SettingsError(msg)
+
+    def _prepare_base_dirs(self):
+        def get_base_dirs():
+            if 'VIRTUAL_ENV' in os.environ:
+                cfg_dir = os.path.join(os.environ['VIRTUAL_ENV'], 'etc')
+                user_dir = os.environ['VIRTUAL_ENV']
+            else:
+                cfg_dir = '/etc'
+                user_dir = os.path.expanduser("~")
+            return cfg_dir, user_dir
+
+        cfg_dir, user_dir = get_base_dirs()
+
+        self._config_dir_system = os.path.join(cfg_dir, 'avocado')
+        self._config_dir_system_extra = os.path.join(cfg_dir,
+                                                     'avocado',
+                                                     'conf.d')
+        self._config_dir_local = os.path.join(user_dir, '.config', 'avocado')
+        self._config_path_system = os.path.join(self._config_dir_system,
+                                                'avocado.conf')
+        self._config_path_local = os.path.join(self._config_dir_local,
+                                               'avocado.conf')
+
+    def as_dict(self):
+        """Return an ordered dictionary with the current active settings.
+
+        This will return a ordered dict of both: configparse and merged
+        argparse options.
+        """
+        result = {}
+        for section in self._config.sections():
+            result[section] = dict(self._config.items(section))
+        return result
+
+    def get(self, section, key, key_type=str):
+        """Returns the current value inside a setion + key.
+
+        If this section do not exists on config files but it was registered
+        dynamicaly with `register_option` by a plugin, this will also get this
+        value.
+
+        :param section: Section in configuration file.
+        :param key: name of key inside that section.
+        :param key_type: how we should handle and return this value.
+        """
+        try:
+            if key_type is str:
+                return self._config.get(section, key)
+            elif key_type is bool:
+                return self._config.getboolean(section, key)
+            elif key_type is int:
+                return self._config.getint(section, key)
+            elif key_type is float:
+                return self._config.getfloat(section, key)
+            else:
+                msg = "Not implemented yet, this will be implemented soon."
+                raise SettingsError(msg)
+        except configparser.NoSectionError:
+            raise SettingsError("Section {} is invalid.".format(section))
+        except configparser.Error:
+            raise SettingsError("{} is invalid.".format(key))
+
+    def merge_with_arguments(self, arg_parse_config):
+        """This method will merge the configparse with argparse.
+
+        After parsing argument options this method should be executed to have
+        an unified settings.
+
+        :param arg_parse_config: argparse.config dictionary with all command
+        line parsed arguments.
+        """
+        for tag, value in arg_parse_config.items():
+            if value is not None:  # Ignoring None values
+                try:
+                    option = self._get_option_from_tag(tag)
+                except SettingsError:
+                    continue  # Not registered yet, using the new module
+                section = option.get('section')
+                key = option.get('key')
+                self.update_settings(section, key, value, False)
+
+    def register_option(self, section, key, default, key_type=str, parser=None,
+                        arg_parse_args=None):
+        """Register an option dinamically.
+
+        An "option" is a configuration option that could be a config file entry
+        alone or associated with a command line equivalent.
+
+        When there is a need for a plugin to register new command line options,
+        the plugin should use this method for convinience.
+
+        From now on, all command line options MUST have an associeted config
+        file option.
+
+        Make sure that default and key_type are equal to the arg_parse_args for
+        consistency.
+
+        :param section: Section name to be registered on configuration.
+        :param key: Key name inside the section.
+        :param default: Default value to be used if the key is not found on
+                        users' config file.
+        :param key_type: The option type. Default is str.
+        :param parser: Optional. This is the parser that the option should be
+                       added, only if there is a command line option too.
+                       Default is None.
+        :param arg_parse_args: Optional. This is a tuple with the arg parse
+                               arguments.
+
+        Example on how to call this method:
+
+        sysinfo = (('-S', '--sysinfo'), {'choices': ('on', 'off'),
+                                         'default': 'on',
+                                         'help': 'Enable or disable sysinfo '
+                                                 'information. Like hardware '
+                                                 'details, profiles, etc. '
+                                                 'Default is enabled.'})
+
+
+        register_option(section='sysinfo.collect', key='enabled', default=True,
+                        key_type=str, parser=parser, arg_parse_args=sysinfo)
+
+
+        Note: For now, this is example uses str as key_type, but soon this will
+              be converted into a bool.
+        """
+        def is_long_arg(tag):
+            regex = re.compile('^--[a-zA-Z].*')
+            return regex.match(tag)
+
+        def is_short_arg(tag):
+            regex = re.compile('^-[a-zA-Z].*')
+            return regex.match(tag)
+
+        def get_tags(arg_parse_args):
+            try:
+                return arg_parse_args[0]
+            except TypeError:
+                raise SettingsError("You need to pass arg_parse_args.")
+            except KeyError:
+                raise SettingsError("Your arg_parse_args must be a tuple.")
+
+        def get_long_arg(arg_parse_args, remove_dashes=True):
+            for tag in get_tags(arg_parse_args):
+                if is_long_arg(tag):
+                    if remove_dashes:
+                        return tag[2:]
+                    else:
+                        return tag
+            raise SettingsError("You need a long arg.")
+
+        def get_short_arg(arg_parse_args, remove_dash=True):
+            for tag in get_tags(arg_parse_args):
+                if is_short_arg(tag):
+                    if remove_dash:
+                        return tag[1:]
+                    else:
+                        return tag
+
+        namespace = "{}.{}".format(section, key)
+
+        # Check if namespace is already registered
+        if namespace in self._namespaces:
+            msg = "Key {} already registered on section {}".format(key,
+                                                                   section)
+            raise SettingsError(msg)
+
+        # Register the option to a dynamic in-memory namespaces
+        self._namespaces[namespace] = {'section': section,
+                                       'key': key,
+                                       'default': default,
+                                       'key_type': key_type,
+                                       'parser': parser,
+                                       'arg_parse_args': arg_parse_args}
+
+        if not parser:
+            # Nothing else to do here
+            return
+
+        long_arg = get_long_arg(arg_parse_args)
+        short_arg = get_short_arg(arg_parse_args)
+
+        # Check if long_arg is already registered
+        if long_arg and long_arg in self._long_mapping:
+            msg = "Option {} already registered.".format(long_arg)
+            raise SettingsError(msg)
+        self._long_mapping[long_arg] = namespace
+
+        # Add long_arg and short_arg to mappings. long_arg is mandatory here.
+        if short_arg:
+            self._short_mapping[short_arg] = long_arg
+
+        # Register the option argument equivalent to argparse
+        parser.add_argument(*arg_parse_args[0], **arg_parse_args[1])
+
+    def update_settings(self, section, key, value, raise_exception=True):
+        try:
+            # For configparser optionvalues must be string. The conversion
+            # happens on getting the value.
+            self._config[section][key] = str(value)
+        except KeyError:
+            if raise_exception:
+                raise SettingsError("{} not found in {}".format(key, section))
+
+
+settings = AvocadoSettings()  # pylint: disable-msg=invalid-name

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -42,16 +42,17 @@ from . import tags
 from . import test
 from . import varianter
 from . import version
-from ..utils import astring
-from ..utils import data_structures
-from ..utils import path
-from ..utils import process
-from ..utils import stacktrace
+from .future.settings import settings as future_settings
 from .output import LOG_JOB
 from .output import LOG_UI
 from .output import STD_OUTPUT
 from .settings import settings
 from .tags import filter_test_tags_runnable
+from ..utils import astring
+from ..utils import data_structures
+from ..utils import path
+from ..utils import process
+from ..utils import stacktrace
 
 
 _NEW_ISSUE_LINK = 'https://github.com/avocado-framework/avocado/issues/new'
@@ -143,7 +144,9 @@ class Job:
             unique_id = self.config.get('unique_job_id', None)
             if unique_id is None:
                 self.config['unique_job_id'] = '0' * 40
-            self.config['sysinfo'] = False
+            future_settings.update_settings('sysinfo.collect',
+                                            'enabled',
+                                            False)
 
         unique_id = self.config.get('unique_job_id', None)
         if unique_id is None:

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -48,6 +48,7 @@ from ..utils import process
 from ..utils import stacktrace
 from .decorators import skip
 from .settings import settings
+from .future.settings import settings as future_settings
 from .version import VERSION
 from .output import LOG_JOB
 
@@ -377,7 +378,7 @@ class Test(unittest.TestCase, TestData):
         self.__outputdir = utils_path.init_dir(self.logdir, 'data')
         self.__sysinfo_enabled = (self.job is not None and
                                   self.job.config is not None and
-                                  self.job.config.get('sysinfo', None) == 'on')
+                                  future_settings.get('sysinfo.collect', 'enabled', bool))
         if self.__sysinfo_enabled:
             self.__sysinfodir = utils_path.init_dir(self.logdir, 'sysinfo')
             self.__sysinfo_logger = sysinfo.SysInfo(basedir=self.__sysinfodir)

--- a/avocado/etc/avocado/defaults.conf
+++ b/avocado/etc/avocado/defaults.conf
@@ -1,0 +1,124 @@
+[datadir.paths]
+# Avocado data dir (holds tests and test auxiliary data, such as ISO files).
+base_dir = /var/lib/avocado
+# You may override the specific test directory with test_dir
+test_dir = /usr/share/doc/avocado/tests
+# You may override the specific test auxiliary data directory with data_dir
+data_dir = /var/lib/avocado/data
+# You may override the specific job results directory with logs_dir
+logs_dir = ~/avocado/job-results
+# You can set a list of cache directories to be used by the avocado test
+# fetch_asset() with 'cache_dirs'. read-only cache directories are also
+# supported.
+# cache_dirs = ['~/avocado/cache', '/mnt/cache']
+
+[sysinfo.collect]
+# Whether to collect system information during avocado jobs
+enabled = True
+# Overall timeout to collect commands, when <=0 no timeout is enforced
+commands_timeout = -1
+# Whether to take a list of installed packages previous to avocado jobs
+installed_packages = False
+# Whether to run certain commands in bg to give extra job debug information
+profiler = False
+# Force LANG for sysinfo collection
+locale = C
+# Enable sysinfo collection per-test
+per_test = False
+
+[sysinfo.collectibles]
+# File with list of commands that will be executed and have their output collected
+commands = etc/avocado/sysinfo/commands
+# File with list of files that will be collected verbatim
+files = etc/avocado/sysinfo/files
+# File with list of commands that will run alongside the job/test
+profilers = etc/avocado/sysinfo/profilers
+
+[runner.output]
+# Whether to display colored output in terminals that support it
+colored = True
+# Whether to force colored output to non-tty outputs (e.g. log files)
+# Allowed values: auto, always, never
+color = auto
+# Use utf8 encoding (True, False, None=autodetect)
+utf8 =
+
+[runner.timeout]
+# The amount of time to give to the test process after it it has been
+# interrupted (such as with CTRL+C)
+after_interrupted = 60
+# The amount of to wait for a test status after the process has been
+# noticed to be dead
+process_died = 10
+# The amount of time to wait after a test has reported status but the
+# test process has not finished
+process_alive = 60
+
+[remoter.behavior]
+# __Insecure__, reject unknown SSH host keys.
+# 'False' will leave you wide open to man-in-the-middle attacks!
+# 'True' will only work with RSA keys (due to a bug in Paramiko).
+# If using 'True', accept the remote host key fingerprint by using:
+#   $ ssh -oHostKeyAlgorithms='ssh-rsa' <host>
+reject_unknown_hosts = False
+# __Insecure__, SSH layer to skip loading the user's known-hosts
+# file. Useful for avoiding exceptions in situations where a
+# 'known host' changing its host key is actually valid (e.g. cloud
+# servers such as EC2.)
+disable_known_hosts = False
+
+[job.output]
+# Base loging level for --show
+# Allowed levels: debug, info, warning, error, critical
+loglevel = debug
+
+[restclient.connection]
+# Hostname where the rest service runs
+hostname = localhost
+# Port where the rest service runs
+port = 9405
+# If authentication is set, pass username
+username =
+# If authentication is set, pass password
+password =
+
+[plugins]
+# Disable listed plugins completely.  Use the fully qualified plugin
+# name, as described in the Avocado documentation "Plugins" section.
+# (e.g. "results.html")
+disable = []
+# Suppress notification about broken plugins in the app standard error.
+# Add the name of each broken plugin you want to suppress the notification
+# in the list. (e.g. "avocado_result_html")
+skip_broken_plugin_notification = []
+# Optionally you can specify the priority of test loaders (file) or test
+# types (file.SIMPLE). Some of the plugins even support extra params
+# (external:/bin/echo -e). Plugins will be used accordingly to the plugin
+# priorities. It's possible to list plugins multiple times (with different
+# options or test types).
+# The keyword "@DEFAULT" will be replaced with all available unused loaders.
+loaders = ['file', '@DEFAULT']
+
+[plugins.resolver]
+order = ['avocado-instrumented', 'python-unittest', 'glib', 'robot', 'exec-test']
+
+[simpletests.status]
+# Python regular expression that will make the test
+# status WARN when matched. Defaults to disabled.
+# Reference: http://docs.python.org/2.7/howto/regex.html
+# warn_regex = ^WARN$
+
+# Location to search the regular expression on.
+# Accepted values: all, stdout, stderr.
+# Defaults to all.
+# warn_location = all
+
+# Python regular expression that will make the test
+# status SKIP when matched. Defaults to disabled.
+# Reference: http://docs.python.org/2.7/howto/regex.html
+# skip_regex = ^SKIP$
+
+# Location to search the regular expression on.
+# Accepted values: all, stdout, stderr.
+# Defaults to all.
+# skip_location = all

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -25,11 +25,11 @@ from avocado.core import job
 from avocado.core import loader
 from avocado.core import output
 from avocado.core import parser_common_args
-from avocado.core.output import LOG_UI
-from avocado.core.plugin_interfaces import CLICmd
 from avocado.core.dispatcher import ResultDispatcher
 from avocado.core.dispatcher import JobPrePostDispatcher
+from avocado.core.output import LOG_UI
 from avocado.core.settings import settings
+from avocado.core.plugin_interfaces import CLICmd
 from avocado.utils.data_structures import time_to_seconds
 from avocado.utils import process
 

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -27,8 +27,8 @@ from avocado.core import output
 from avocado.core import parser_common_args
 from avocado.core.dispatcher import ResultDispatcher
 from avocado.core.dispatcher import JobPrePostDispatcher
+from avocado.core.future.settings import settings
 from avocado.core.output import LOG_UI
-from avocado.core.settings import settings
 from avocado.core.plugin_interfaces import CLICmd
 from avocado.utils.data_structures import time_to_seconds
 from avocado.utils import process
@@ -123,16 +123,17 @@ class Run(CLICmd):
                             "the test references are not resolved to tests."
                             "'on' and 'off' will be deprecated soon.")
 
-        sysinfo_default = settings.get_value('sysinfo.collect',
-                                             'enabled',
-                                             key_type='bool',
-                                             default=True)
-        sysinfo_default = 'on' if sysinfo_default is True else 'off'
-        parser.add_argument('--sysinfo', choices=('on', 'off'),
-                            default=sysinfo_default, help="Enable or disable "
-                            "system information (hardware details, profilers, "
-                            "etc.). 'on' and 'off' will be deprecated soon. "
-                            "Current:  %(default)s")
+        # This is experimental and it is using the future.settings module.
+        # Soon, this will be replaced by a boolean type.
+        sysinfo = (('-S', '--sysinfo'), {'choices': ('on', 'off'),
+                                         'default': 'on',
+                                         'help': 'Enable or disable sysinfo '
+                                                 'information. Like hardware '
+                                                 'details, profiles, etc. '
+                                                 'Default is enabled.'})
+        settings.register_option(section='sysinfo.collect', key='enabled',
+                                 default=True, key_type=str, parser=parser,
+                                 arg_parse_args=sysinfo)
 
         parser.add_argument("--execution-order",
                             choices=("tests-per-variant",

--- a/avocado/plugins/sysinfo.py
+++ b/avocado/plugins/sysinfo.py
@@ -15,6 +15,7 @@
 System information plugin
 """
 
+from avocado.core.future.settings import settings
 from avocado.core.plugin_interfaces import CLICmd
 from avocado.core.plugin_interfaces import JobPre
 from avocado.core.plugin_interfaces import JobPost
@@ -36,13 +37,13 @@ class SysInfoJob(JobPre, JobPost):
             self.sysinfo = sysinfo.SysInfo(basedir=basedir)
 
     def pre(self, job):
-        if job.config.get('sysinfo', None) != 'on':
+        if not settings.get('sysinfo.collect', 'enabled', bool):
             return
         self._init_sysinfo(job.logdir)
         self.sysinfo.start_job_hook()
 
     def post(self, job):
-        if job.config.get('sysinfo', None) != 'on':
+        if not settings.get('sysinfo.collect', 'enabled', bool):
             return
         self._init_sysinfo(job.logdir)
         self.sysinfo.end_job_hook()


### PR DESCRIPTION
As part of the effort to remove default values scattered around the
code, this change only migrates the sysinfo option to use the new
module. This will associate the `--sysinfo` command-line option with the
`enabled` configuration of the `sysinfo.collect` section in the
configuration file. If this gets accepted, I will start migrating all
the options for this new model.

Signed-off-by: Beraldo Leal <bleal@redhat.com>
