### PR TITLE
docs: added a note warning about new concepts

### DIFF
--- a/docs/source/guides/user/chapters/concepts.rst
+++ b/docs/source/guides/user/chapters/concepts.rst
@@ -8,6 +8,11 @@ It is important to understand some basic concepts before start using Avocado.
 Test Resolution
 ---------------
 
+.. note:: Some definitions here may be out of date. The current runner can
+   still be using some of these definitions in its design, however, we are
+   working on an improved version of the runner, the NextRunner that will use
+   an alternative strategy.
+
 When you use the Avocado runner, frequently you'll provide paths to files,
 that will be inspected, and acted upon depending on their contents. The
 diagram below shows how Avocado analyzes a file and decides what to do with

--- a/docs/source/guides/user/chapters/loaders.rst
+++ b/docs/source/guides/user/chapters/loaders.rst
@@ -4,6 +4,11 @@ Undestanding the test discovery (Avocado Loaders)
 In this section you can learn how tests are being discovered and how to
 customize this process.
 
+.. note:: Some definitions here may be out of date. The current runner can
+   still be using some of these definitions in its design, however, we are
+   working on an improved version of the runner, the NextRunner that will use
+   an alternative strategy.
+
 Test Loaders
 ------------
 


### PR DESCRIPTION
The NextRunner introduces new concepts that can mix up with the current
ones. This small change adds a note to our documentation to warn our
users about that.

Signed-off-by: Beraldo Leal <bleal@redhat.com>