### PR TITLE
small nrunner refactoring [v2]

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -37,6 +37,15 @@ class Runnable:
         return fmt.format(self.kind, self.uri,
                           self.args, self.kwargs, self.tags)
 
+    @classmethod
+    def from_args(cls, args):
+        """Returns a runnable from arguments"""
+        decoded_args = [_arg_decode_base64(arg) for arg in args.get('arg', ())]
+        return cls(args.get('kind'),
+                   args.get('uri'),
+                   *decoded_args,
+                   **_key_val_args_to_kwargs(args.get('kwargs', [])))
+
     def get_command_args(self):
         """
         Returns the command arguments that adhere to the runner interface
@@ -370,16 +379,8 @@ def _key_val_args_to_kwargs(kwargs):
     return result
 
 
-def runnable_from_args(args):
-    decoded_args = [_arg_decode_base64(arg) for arg in args.get('arg', ())]
-    return Runnable(args.get('kind'),
-                    args.get('uri'),
-                    *decoded_args,
-                    **_key_val_args_to_kwargs(args.get('kwargs', [])))
-
-
 def subcommand_runnable_run(args, echo=print):
-    runnable = runnable_from_args(args)
+    runnable = Runnable.from_args(args)
     runner = runner_from_runnable(runnable)
 
     for status in runner.run():
@@ -611,7 +612,7 @@ def task_run(task, echo):
 
 
 def subcommand_task_run(args, echo=print):
-    runnable = runnable_from_args(args)
+    runnable = Runnable.from_args(args)
     task = Task(args.get('identifier'), runnable,
                 args.get('status_uri', []))
     task_run(task, echo)

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -46,6 +46,22 @@ class Runnable:
                    *decoded_args,
                    **_key_val_args_to_kwargs(args.get('kwargs', [])))
 
+    @classmethod
+    def from_recipe(cls, recipe_path):
+        """
+        Returns a runnable from a runnable recipe file
+
+        :param recipe_path: Path to a recipe file
+
+        :rtype: instance of :class:`Runnable`
+        """
+        with open(recipe_path) as recipe_file:
+            recipe = json.load(recipe_file)
+        return cls(recipe.get('kind'),
+                   recipe.get('uri'),
+                   *recipe.get('args', ()),
+                   **recipe.get('kwargs', {}))
+
     def get_command_args(self):
         """
         Returns the command arguments that adhere to the runner interface
@@ -119,18 +135,6 @@ class Runnable:
         """
         with open(recipe_path, 'w') as recipe_file:
             recipe_file.write(self.get_json())
-
-
-def runnable_from_recipe(recipe_path):
-    """
-    Returns a runnable from a runnable recipe file
-    """
-    with open(recipe_path) as recipe_file:
-        recipe = json.load(recipe_file)
-    return Runnable(recipe.get('kind'),
-                    recipe.get('uri'),
-                    *recipe.get('args', ()),
-                    **recipe.get('kwargs', {}))
 
 
 class BaseRunner:
@@ -394,7 +398,7 @@ CMD_RUNNABLE_RUN_RECIPE_ARGS = (
 
 
 def subcommand_runnable_run_recipe(args, echo=print):
-    runnable = runnable_from_recipe(args.get('recipe'))
+    runnable = Runnable.from_recipe(args.get('recipe'))
     runner = runner_from_runnable(runnable)
 
     for status in runner.run():

--- a/avocado/core/nrunner_avocado_instrumented.py
+++ b/avocado/core/nrunner_avocado_instrumented.py
@@ -91,7 +91,7 @@ def subcommand_capabilities(_, echo=print):
 
 
 def subcommand_runnable_run(args, echo=print):
-    runnable = nrunner.runnable_from_args(args)
+    runnable = nrunner.Runnable.from_args(args)
     runner = nrunner.runner_from_runnable(runnable, RUNNABLE_KIND_CAPABLE)
 
     for status in runner.run():
@@ -99,7 +99,7 @@ def subcommand_runnable_run(args, echo=print):
 
 
 def subcommand_task_run(args, echo=print):
-    runnable = nrunner.runnable_from_args(args)
+    runnable = nrunner.Runnable.from_args(args)
     task = nrunner.Task(args.get('identifier'), runnable,
                         args.get('status_uri', []))
     task.capables = RUNNABLE_KIND_CAPABLE

--- a/optional_plugins/robot/avocado_robot/runner.py
+++ b/optional_plugins/robot/avocado_robot/runner.py
@@ -29,7 +29,7 @@ from avocado.core.nrunner import CMD_TASK_RUN_ARGS
 from avocado.core.nrunner import RUNNER_RUN_CHECK_INTERVAL
 from avocado.core.nrunner import RUNNER_RUN_STATUS_INTERVAL
 from avocado.core.nrunner import Task
-from avocado.core.nrunner import runnable_from_args
+from avocado.core.nrunner import Runnable
 from avocado.core.nrunner import runner_from_runnable
 from avocado.core.nrunner import task_run
 
@@ -102,7 +102,7 @@ def subcommand_capabilities(_, echo=print):
 
 
 def subcommand_runnable_run(args, echo=print):
-    runnable = runnable_from_args(args)
+    runnable = Runnable.from_args(args)
     runner = runner_from_runnable(runnable, RUNNABLE_KIND_CAPABLE)
 
     for status in runner.run():
@@ -110,7 +110,7 @@ def subcommand_runnable_run(args, echo=print):
 
 
 def subcommand_task_run(args, echo=print):
-    runnable = runnable_from_args(args)
+    runnable = Runnable.from_args(args)
     task = Task(args.get('identifier'), runnable,
                 args.get('status_uri', []))
     task.capables = RUNNABLE_KIND_CAPABLE

--- a/selftests/unit/test_nrunner.py
+++ b/selftests/unit/test_nrunner.py
@@ -55,7 +55,7 @@ class Runnable(unittest.TestCase):
     def test_recipe_noop(self):
         open_mocked = unittest.mock.mock_open(read_data='{"kind": "noop"}')
         with unittest.mock.patch("builtins.open", open_mocked):
-            runnable = nrunner.runnable_from_recipe("fake_path")
+            runnable = nrunner.Runnable.from_recipe("fake_path")
         self.assertEqual(runnable.kind, "noop")
 
     def test_recipe_exec(self):
@@ -64,7 +64,7 @@ class Runnable(unittest.TestCase):
                        '"args": ["/etc/profile"], '
                        '"kwargs": {"TERM": "vt3270"}}'))
         with unittest.mock.patch("builtins.open", open_mocked):
-            runnable = nrunner.runnable_from_recipe("fake_path")
+            runnable = nrunner.Runnable.from_recipe("fake_path")
         self.assertEqual(runnable.kind, "exec")
         self.assertEqual(runnable.uri, "/bin/sh")
         self.assertEqual(runnable.args, ("/etc/profile",))
@@ -148,7 +148,7 @@ class RunnableToRecipe(unittest.TestCase):
         recipe_path = os.path.join(self.tmpdir.name, 'recipe.json')
         runnable.write_json(recipe_path)
         self.assertTrue(os.path.exists(recipe_path))
-        loaded_runnable = nrunner.runnable_from_recipe(recipe_path)
+        loaded_runnable = nrunner.Runnable.from_recipe(recipe_path)
         self.assertEqual(loaded_runnable.kind, 'noop')
 
     def test_runnable_to_recipe_uri(self):
@@ -156,7 +156,7 @@ class RunnableToRecipe(unittest.TestCase):
         recipe_path = os.path.join(self.tmpdir.name, 'recipe.json')
         runnable.write_json(recipe_path)
         self.assertTrue(os.path.exists(recipe_path))
-        loaded_runnable = nrunner.runnable_from_recipe(recipe_path)
+        loaded_runnable = nrunner.Runnable.from_recipe(recipe_path)
         self.assertEqual(loaded_runnable.kind, 'exec')
         self.assertEqual(loaded_runnable.uri, '/bin/true')
 
@@ -165,7 +165,7 @@ class RunnableToRecipe(unittest.TestCase):
         recipe_path = os.path.join(self.tmpdir.name, 'recipe.json')
         runnable.write_json(recipe_path)
         self.assertTrue(os.path.exists(recipe_path))
-        loaded_runnable = nrunner.runnable_from_recipe(recipe_path)
+        loaded_runnable = nrunner.Runnable.from_recipe(recipe_path)
         self.assertEqual(loaded_runnable.kind, 'exec')
         self.assertEqual(loaded_runnable.uri, '/bin/sleep')
         self.assertEqual(loaded_runnable.args, ('0.01', ))

--- a/selftests/unit/test_nrunner.py
+++ b/selftests/unit/test_nrunner.py
@@ -92,14 +92,14 @@ class RunnableFromCommandLineArgs(unittest.TestCase):
 
     def test_noop(self):
         parsed_args = {'kind': 'noop', 'uri': None}
-        runnable = nrunner.runnable_from_args(parsed_args)
+        runnable = nrunner.Runnable.from_args(parsed_args)
         self.assertEqual(runnable.kind, 'noop')
         self.assertIsNone(runnable.uri)
 
     def test_exec_args(self):
         parsed_args = {'kind': 'exec', 'uri': '/path/to/executable',
                        'arg': ['-a', '-b', '-c']}
-        runnable = nrunner.runnable_from_args(parsed_args)
+        runnable = nrunner.Runnable.from_args(parsed_args)
         self.assertEqual(runnable.kind, 'exec')
         self.assertEqual(runnable.uri, '/path/to/executable')
         self.assertEqual(runnable.args, ('-a', '-b', '-c'))
@@ -109,7 +109,7 @@ class RunnableFromCommandLineArgs(unittest.TestCase):
         parsed_args = {'kind': 'exec', 'uri': '/path/to/executable',
                        'arg': ['-a', '-b', '-c'],
                        'kwargs': [('DEBUG', '1'), ('LC_ALL', 'C')]}
-        runnable = nrunner.runnable_from_args(parsed_args)
+        runnable = nrunner.Runnable.from_args(parsed_args)
         self.assertEqual(runnable.kind, 'exec')
         self.assertEqual(runnable.uri, '/path/to/executable')
         self.assertEqual(runnable.args, ('-a', '-b', '-c'))
@@ -119,7 +119,7 @@ class RunnableFromCommandLineArgs(unittest.TestCase):
     def test_kwargs_json_empty_dict(self):
         parsed_args = {'kind': 'noop', 'uri': None,
                        'kwargs': [('empty', 'json:{}')]}
-        runnable = nrunner.runnable_from_args(parsed_args)
+        runnable = nrunner.Runnable.from_args(parsed_args)
         self.assertEqual(runnable.kind, 'noop')
         self.assertIsNone(runnable.uri)
         self.assertEqual(runnable.kwargs.get('empty'), {})
@@ -130,7 +130,7 @@ class RunnableFromCommandLineArgs(unittest.TestCase):
             'kwargs': [('tags', 'json:{"arch": ["x86_64", "ppc64"]}'),
                        ('hi', 'json:"hello"')]
         }
-        runnable = nrunner.runnable_from_args(parsed_args)
+        runnable = nrunner.Runnable.from_args(parsed_args)
         self.assertEqual(runnable.kind, 'noop')
         self.assertIsNone(runnable.uri)
         self.assertEqual(runnable.kwargs.get('hi'), 'hello')


### PR DESCRIPTION
The NextRunner will be a core component of Avocado and we could try to keep the code as clean as possible to facilitate the understanding and readability. This changes only the order of a few methods and moves other ones to the respective classes.

---
Changes from v1:
  * Merged tests changes into respective commits