### PR TITLE
docs: Remove double index reference to RFC on Contributor's Guide.

### DIFF
--- a/docs/source/guides/contributor/index.rst
+++ b/docs/source/guides/contributor/index.rst
@@ -16,5 +16,4 @@ Useful pointers on how to participate of the Avocado community and contribute.
    chapters/rfc
    chapters/releasing
    chapters/tips
-   chapters/rfc
    chapters/contact


### PR DESCRIPTION
Signed-off-by: Willian Rampazzo <willianr@redhat.com>