### PR TITLE
docs: Fix warnings when running `make html`

### DIFF
--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -293,7 +293,7 @@ def get_job_results_dir(job_ref, logs_dir=None):
 
     :param job_ref: job reference, which can be:
                     * an valid path to the job results directory. In this case
-                      it is checked if 'id' file exists
+                    it is checked if 'id' file exists
                     * the path to 'id' file
                     * the job id, which can be 'latest'
                     * an partial job id

--- a/avocado/core/plugin_interfaces.py
+++ b/avocado/core/plugin_interfaces.py
@@ -282,7 +282,7 @@ class Resolver(Plugin):
         :type reference: str
         :returns: the result of the resolution process, containing the
                   success, failure or error, along with zero or more
-                  :class:`avocado.core.nrunner.Runnable`s
+                  :class:`avocado.core.nrunner.Runnable` objects
         :rtype: :class:`avocado.core.resolver.ReferenceResolution`
         """
 

--- a/avocado/core/resolver.py
+++ b/avocado/core/resolver.py
@@ -57,7 +57,7 @@ class ReferenceResolution:
                        failure or error
         :type result: :class:`ReferenceResolutionResult`
         :param resolutions: the runnable definitions resulting from the
-        resolution
+                            resolution
         :type resolutions: list of :class:`avocado.core.nrunner.Runnable`
         :param info: free form information the resolver may add
         :type info: str

--- a/avocado/utils/configure_network.py
+++ b/avocado/utils/configure_network.py
@@ -194,8 +194,7 @@ def is_interface_link_up(interface):
     """
     Checks if the interface link is up
     :param interface: name of the interface
-    :return: True if the interface's link comes up,
-     False otherwise.
+    :return: True if the interface's link comes up, False otherwise.
     """
     if 'up' in genio.read_file("/sys/class/net/%s/operstate" % interface):
         log.info("Interface %s link is up", interface)


### PR DESCRIPTION
Fix the following warnings when running `make html` to build html documents:

```
/home/wrampazz/src/avocado/avocado.dev/avocado/core/data_dir.py:docstring of avocado.core.data_dir.get_job_results_dir:5: WARNING: Unexpected indentation.
/home/wrampazz/src/avocado/avocado.dev/avocado/core/data_dir.py:docstring of avocado.core.data_dir.get_job_results_dir:6: WARNING: Block quote ends without a blank line; unexpected unindent.
/home/wrampazz/src/avocado/avocado.dev/avocado/core/plugin_interfaces.py:docstring of avocado.core.plugin_interfaces.Resolver.resolve:7: WARNING: Inline interpreted text or phrase reference start-string without end-string.
/home/wrampazz/src/avocado/avocado.dev/avocado/core/resolver.py:docstring of avocado.core.resolver.ReferenceResolution:14: WARNING: Field list ends without a blank line; unexpected unindent.
/home/wrampazz/src/avocado/avocado.dev/optional_plugins/glib/avocado_glib/__init__.py:docstring of avocado_glib.GLibResolver.resolve:7: WARNING: Inline interpreted text or phrase reference start-string without end-string.
/home/wrampazz/src/avocado/avocado.dev/optional_plugins/golang/avocado_golang/__init__.py:docstring of avocado_golang.GolangResolver.resolve:7: WARNING: Inline interpreted text or phrase reference start-string without end-string.
/home/wrampazz/src/avocado/avocado.dev/optional_plugins/robot/avocado_robot/__init__.py:docstring of avocado_robot.RobotResolver.resolve:7: WARNING: Inline interpreted text or phrase reference start-string without end-string.
/home/wrampazz/src/avocado/avocado.dev/avocado/plugins/resolvers.py:docstring of avocado.plugins.resolvers.AvocadoInstrumentedResolver.resolve:7: WARNING: Inline interpreted text or phrase reference start-string without end-string.
/home/wrampazz/src/avocado/avocado.dev/avocado/plugins/resolvers.py:docstring of avocado.plugins.resolvers.ExecTestResolver.resolve:7: WARNING: Inline interpreted text or phrase reference start-string without end-string.
/home/wrampazz/src/avocado/avocado.dev/avocado/plugins/resolvers.py:docstring of avocado.plugins.resolvers.PythonUnittestResolver.resolve:7: WARNING: Inline interpreted text or phrase reference start-string without end-string.
/home/wrampazz/src/avocado/avocado.dev/avocado/plugins/resolvers.py:docstring of avocado.plugins.resolvers.TapResolver.resolve:7: WARNING: Inline interpreted text or phrase reference start-string without end-string.
/home/wrampazz/src/avocado/avocado.dev/avocado/utils/configure_network.py:docstring of avocado.utils.configure_network.is_interface_link_up:4: WARNING: Unexpected indentation.
```

Signed-off-by: Willian Rampazzo <willianr@redhat.com>