### PR TITLE
avocado/core: sysinfo: Improve the log message when the command is not found

### DIFF
--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -168,6 +168,10 @@ class Command(Collectible):
                                  ignore_status=True,
                                  allow_output_check='combined',
                                  env=env)
+        except FileNotFoundError as exc_fnf:
+            log.debug("Not logging '%s' (command '%s' was not found)", self.cmd,
+                      exc_fnf.filename)
+            return
         except Exception as exc:  # pylint: disable=W0703
             log.warning('Could not execute "%s": %s', self.cmd, exc)
             return


### PR DESCRIPTION

Currently when a sysinfo's triggered command does not exit in the system the job's
log get printed with the Python exception. Instead let's print an user-friendly
message stating that the command is not found.

Before this change
```
2020-01-29 10:23:04,769 sysinfo          L0445 INFO | Profiler disabled
2020-01-29 10:23:04,782 sysinfo          L0172 WARNI| Could not execute "numactl --hardware show": [Errno 2] No such file or directory: 'numactl' (numactl --hardware show): 'numactl'
2020-01-29 10:23:04,795 sysinfo          L0105 DEBUG| Not logging /sys/kernel/debug/sched_features (file does not exist)
2020-01-29 10:23:04,797 sysinfo          L0105 DEBUG| Not logging /proc/pci (file does not exist)
2020-01-29 10:23:04,798 sysinfo          L0105 DEBUG| Not logging /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor (file does not exist)
2020-01-29 10:23:04,798 sysinfo          L0103 DEBUG| Not logging /proc/slabinfo (lack of permissions)
2020-01-29 10:23:04,981 job              L0437 INFO | Command line: /home/wainersm/venvs/avocado-devel/bin/avocado run /bin/true
```

After this change
```
2020-01-29 10:15:58,325 sysinfo          L0449 INFO | Profiler disabled
2020-01-29 10:15:58,530 sysinfo          L0103 DEBUG| Not logging /proc/slabinfo (lack of permissions)
2020-01-29 10:15:58,552 sysinfo          L0105 DEBUG| Not logging /proc/pci (file does not exist)
2020-01-29 10:15:58,557 sysinfo          L0105 DEBUG| Not logging /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor (file does not exist)
2020-01-29 10:15:58,557 sysinfo          L0105 DEBUG| Not logging /sys/kernel/debug/sched_features (file does not exist)
2020-01-29 10:15:58,623 sysinfo          L0173 DEBUG| Not logging 'numactl --hardware show' (command 'numactl' is not found)
2020-01-29 10:15:58,651 job              L0437 INFO | Command line: /home/wainersm/venvs/avocado-devel/bin/avocado run /bin/true
```

Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>