### PR TITLE
nrunner/tap: implementing a TAPRunner first version [v2]

### DIFF
--- a/selftests/unit/test_nrunner.py
+++ b/selftests/unit/test_nrunner.py
@@ -176,6 +176,10 @@ class RunnableToRecipe(unittest.TestCase):
 
 class Runner(unittest.TestCase):
 
+    def setUp(self):
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
+
     def test_runner_noop(self):
         runnable = nrunner.Runnable('noop', None)
         runner = nrunner.runner_from_runnable(runnable)
@@ -219,6 +223,72 @@ class Runner(unittest.TestCase):
         self.assertEqual(result['status'], 'pass')
         self.assertTrue(result['output'].startswith(output1))
         self.assertTrue(result['output'].endswith(output2))
+
+    @unittest.skipUnless(os.path.exists('/bin/sh'),
+                         ('Executable "/bin/sh" used in this test is not '
+                          'available in the system'))
+    def test_runner_tap_fail(self):
+        tap_script = """#!/bin/sh
+echo '1..2'
+echo '# Defining an basic test'
+echo 'ok 1 - description 1'
+echo 'not ok 2 - description 2'"""
+        tap_path = os.path.join(self.tmpdir.name, 'tap.sh')
+
+        with open(tap_path, 'w') as fp:
+            fp.write(tap_script)
+
+        runnable = nrunner.Runnable('tap', '/bin/bash', tap_path)
+        runner = nrunner.runner_from_runnable(runnable)
+        results = [status for status in runner.run()]
+        last_result = results[-1]
+        self.assertEqual(last_result['status'], 'fail')
+        self.assertEqual(last_result['returncode'], 0)
+
+    @unittest.skipUnless(os.path.exists('/bin/sh'),
+                         ('Executable "/bin/sh" used in this test is not '
+                          'available in the system'))
+    def test_runner_tap_ok(self):
+        tap_script = """#!/bin/sh
+echo '1..2'
+echo '# Defining an basic test'
+echo 'ok 1 - description 1'
+echo 'ok 2 - description 2'"""
+        tap_path = os.path.join(self.tmpdir.name, 'tap.sh')
+
+        with open(tap_path, 'w') as fp:
+            fp.write(tap_script)
+
+        runnable = nrunner.Runnable('tap', '/bin/bash', tap_path)
+        runner = nrunner.runner_from_runnable(runnable)
+        results = [status for status in runner.run()]
+        last_result = results[-1]
+        self.assertEqual(last_result['status'], 'pass')
+        self.assertEqual(last_result['returncode'], 0)
+
+    @unittest.skipUnless(os.path.exists('/bin/sh'),
+                         ('Executable "/bin/sh" used in this test is not '
+                          'available in the system'))
+    def test_runner_tap_skip(self):
+        tap_script = """#!/bin/sh
+echo '1..2'
+echo '# Defining an basic test'
+echo 'ok 1 - # SKIP description 1'
+echo 'ok 2 - description 2'"""
+        tap_path = os.path.join(self.tmpdir.name, 'tap.sh')
+
+        with open(tap_path, 'w') as fp:
+            fp.write(tap_script)
+
+        runnable = nrunner.Runnable('tap', '/bin/bash', tap_path)
+        runner = nrunner.runner_from_runnable(runnable)
+        results = [status for status in runner.run()]
+        last_result = results[-1]
+        self.assertEqual(last_result['status'], 'skip')
+        self.assertEqual(last_result['returncode'], 0)
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The first draft of a TAPRunner for the Next Runner.  This is using the
`tapparser` module to process TAP outputs. More improvements will come
here.

Signed-off-by: Beraldo Leal <bleal@redhat.com>

---

Changes from v1:
* Added a better docstring;
* Added tests;
* Removed `encoding` argument from `subprocess.Popen` since that is only available on `>=python3.6`