### PR TITLE
nrunner: escape command line arguments that stat with a dash

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -79,6 +79,8 @@ class Runnable:
 
         for arg in self.args:
             args.append('-a')
+            if arg.startswith('-'):
+                arg = 'base64:%s' % base64.b64encode(arg.encode()).decode('ascii')
             args.append(arg)
 
         if self.tags is not None:


### PR DESCRIPTION
Because argparser will attempt to parse arguments that start with a
dash as yet another option, instead of the value to the '-a' option,
we need to escape them.

This is a complement to 48826017e, which introduced this concept and
the decoding of base64 arguments, but failed to encode the necessary
ones when creating a list of arguments.

Signed-off-by: Cleber Rosa <crosa@redhat.com>