### PR TITLE
nrunner/tap: implementing a TAPRunner first version [v3]

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -10,6 +10,9 @@ import time
 import unittest
 import socket
 
+from .tapparser import TapParser
+from .tapparser import TestResult
+
 #: The amount of time (in seconds) between each internal status check
 RUNNER_RUN_CHECK_INTERVAL = 0.01
 
@@ -309,11 +312,74 @@ class PythonUnittestRunner(BaseRunner):
         yield queue.get()
 
 
+class TAPRunner(BaseRunner):
+    """Runner for standalone executables treated as TAP
+
+    When creating the Runnable, use the following attributes:
+
+     * kind: should be 'tap';
+
+     * uri: path to a binary to be executed as another process. This must
+       provides a TAP output.
+
+     * args: any runnable argument will be given on the command line to the
+       binary given by path
+
+     * kwargs: you can specify multiple key=val as kwargs. This will be used as
+       environment variables to the process.
+
+    Example:
+
+       runnable = Runnable(kind='tap',
+                           uri='tests/foo.sh',
+                           'bar', # arg 1
+                           DEBUG='false') # kwarg 1 (environment)
+    """
+    def run(self):
+        env = self.runnable.kwargs or None
+        process = subprocess.Popen(
+            [self.runnable.uri] + list(self.runnable.args),
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env)
+
+        while process.poll() is None:
+            time.sleep(RUNNER_RUN_STATUS_INTERVAL)
+            yield {'status': 'running',
+                   'timestamp': time.time()}
+
+        stdout = io.TextIOWrapper(process.stdout)
+        parser = TapParser(stdout)
+        status = 'error'
+        for event in parser.parse():
+            if isinstance(event, TapParser.Bailout):
+                status = 'error'
+                break
+            elif isinstance(event, TapParser.Error):
+                status = 'error'
+                break
+            elif isinstance(event, TapParser.Test):
+                if event.result in (TestResult.XPASS, TestResult.FAIL):
+                    status = 'fail'
+                    break
+                elif event.result == TestResult.SKIP:
+                    status = 'skip'
+                    break
+                else:
+                    status = 'pass'
+
+        yield {'status': status,
+               'returncode': process.returncode,
+               'timestamp': time.time()}
+
+
 #: The runnables this specific application is capable of handling
 RUNNABLE_KIND_CAPABLE = {'noop': NoOpRunner,
                          'exec': ExecRunner,
                          'exec-test': ExecTestRunner,
-                         'python-unittest': PythonUnittestRunner}
+                         'python-unittest': PythonUnittestRunner,
+                         'tap': TAPRunner}
 
 
 def runner_from_runnable(runnable, capables=None):

--- a/selftests/unit/test_nrunner.py
+++ b/selftests/unit/test_nrunner.py
@@ -176,6 +176,10 @@ class RunnableToRecipe(unittest.TestCase):
 
 class Runner(unittest.TestCase):
 
+    def setUp(self):
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
+
     def test_runner_noop(self):
         runnable = nrunner.Runnable('noop', None)
         runner = nrunner.runner_from_runnable(runnable)
@@ -219,6 +223,72 @@ class Runner(unittest.TestCase):
         self.assertEqual(result['status'], 'pass')
         self.assertTrue(result['output'].startswith(output1))
         self.assertTrue(result['output'].endswith(output2))
+
+    @unittest.skipUnless(os.path.exists('/bin/sh'),
+                         ('Executable "/bin/sh" used in this test is not '
+                          'available in the system'))
+    def test_runner_tap_fail(self):
+        tap_script = """#!/bin/sh
+echo '1..2'
+echo '# Defining an basic test'
+echo 'ok 1 - description 1'
+echo 'not ok 2 - description 2'"""
+        tap_path = os.path.join(self.tmpdir.name, 'tap.sh')
+
+        with open(tap_path, 'w') as fp:
+            fp.write(tap_script)
+
+        runnable = nrunner.Runnable('tap', '/bin/sh', tap_path)
+        runner = nrunner.runner_from_runnable(runnable)
+        results = [status for status in runner.run()]
+        last_result = results[-1]
+        self.assertEqual(last_result['status'], 'fail')
+        self.assertEqual(last_result['returncode'], 0)
+
+    @unittest.skipUnless(os.path.exists('/bin/sh'),
+                         ('Executable "/bin/sh" used in this test is not '
+                          'available in the system'))
+    def test_runner_tap_ok(self):
+        tap_script = """#!/bin/sh
+echo '1..2'
+echo '# Defining an basic test'
+echo 'ok 1 - description 1'
+echo 'ok 2 - description 2'"""
+        tap_path = os.path.join(self.tmpdir.name, 'tap.sh')
+
+        with open(tap_path, 'w') as fp:
+            fp.write(tap_script)
+
+        runnable = nrunner.Runnable('tap', '/bin/sh', tap_path)
+        runner = nrunner.runner_from_runnable(runnable)
+        results = [status for status in runner.run()]
+        last_result = results[-1]
+        self.assertEqual(last_result['status'], 'pass')
+        self.assertEqual(last_result['returncode'], 0)
+
+    @unittest.skipUnless(os.path.exists('/bin/sh'),
+                         ('Executable "/bin/sh" used in this test is not '
+                          'available in the system'))
+    def test_runner_tap_skip(self):
+        tap_script = """#!/bin/sh
+echo '1..2'
+echo '# Defining an basic test'
+echo 'ok 1 - # SKIP description 1'
+echo 'ok 2 - description 2'"""
+        tap_path = os.path.join(self.tmpdir.name, 'tap.sh')
+
+        with open(tap_path, 'w') as fp:
+            fp.write(tap_script)
+
+        runnable = nrunner.Runnable('tap', '/bin/sh', tap_path)
+        runner = nrunner.runner_from_runnable(runnable)
+        results = [status for status in runner.run()]
+        last_result = results[-1]
+        self.assertEqual(last_result['status'], 'skip')
+        self.assertEqual(last_result['returncode'], 0)
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The first draft of a TAPRunner for the Next Runner.  This is using the
`tapparser` module to process TAP outputs. More improvements will come
here.

Signed-off-by: Beraldo Leal <bleal@redhat.com>

---
Changes from v2:
* Merged commits;
* Using `/bin/sh` instead of `/bin/bash` on tests;
* Tests are now checking if `/bin/sh` exists, otherwise will skip;
* Using the current "status approach". `status` instead of `result`;
* Removed `aborted` status;

Changes from v1:
* Added a better docstring;
* Added tests;
* Removed `encoding` argument from `subprocess.Popen` since that is only available on `>=python3.6`