### PR TITLE
selftests/deployment: check for cirrus-ci build status on playbooks

### DIFF
--- a/selftests/deployment/deployment.yml
+++ b/selftests/deployment/deployment.yml
@@ -5,6 +5,7 @@
     - vars.yml
   roles:
     - common
+    - cirrus
     - virtualenv
     - avocado
     - tests

--- a/selftests/deployment/roles/cirrus/tasks/main.yml
+++ b/selftests/deployment/roles/cirrus/tasks/main.yml
@@ -1,0 +1,10 @@
+- name: Check for Cirrus-CI build status
+  uri:
+    url: https://api.cirrus-ci.com/github/avocado-framework/avocado.json
+    method: GET
+    return_content: yes
+    status_code: 200
+  register: this
+  failed_when: "'passing' not in this.content"
+  tags:
+    - cirrus


### PR DESCRIPTION
This is part of a bigger process that consists in automate most of our
manual checks before release. With this change, running our deployment
playbook will also check for Cirrus-CI status.

Signed-off-by: Beraldo Leal <bleal@redhat.com>