### PR TITLE
Fix packit conf

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -1,15 +1,8 @@
 specfile_path: python-avocado.spec
-synced_files:
-  - python-avocado.spec
-  - .packit.yml
-upstream_project_name: avocado-framework
 downstream_package_name: python-avocado
 jobs:
   - job: copr_build
     trigger: pull_request
     metadata:
       targets:
-      - fedora-29-x86_64
-      - fedora-30-x86_64
-      - fedora-31-x86_64
-      - fedora-rawhide-x86_64
+      - fedora-all


### PR DESCRIPTION
 - remove upstream_package_name - pypi name is not used for archives
 - use alias for fedora chroots
 - remove synced_files <- not used