### PR TITLE
Travis Ci: disable PIP cache for s390x and aarch64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,11 @@ matrix:
       arch: s390x
       env:
         - AVOCADO_PARALLEL_LINT_JOBS=1
+      # Travis s390x builders currently shows:
+      # [Errno 13] Permission denied: '/home/travis/.cache/pip/wheels/xx'
+      # Disable pip cache dir temporarily
+      install:
+       - pip install --no-cache-dir -r requirements-selftests.txt
       script:
         - make AVOCADO_OPTIONAL_PLUGINS="optional_plugins/glib optional_plugins/golang optional_plugins/html optional_plugins/loader_yaml optional_plugins/resultsdb optional_plugins/result_upload optional_plugins/robot optional_plugins/varianter_cit optional_plugins/varianter_pict optional_plugins/varianter_yaml_to_mux" check
     - python: "3.7"
@@ -64,6 +69,11 @@ matrix:
       arch: arm64
       env:
         - AVOCADO_PARALLEL_LINT_JOBS=1
+      # Travis amd64 builders currently shows:
+      # [Errno 13] Permission denied: '/home/travis/.cache/pip/wheels/xx'
+      # Disable pip cache dir temporarily
+      install:
+       - pip install --no-cache-dir -r requirements-selftests.txt
       script:
         - make AVOCADO_OPTIONAL_PLUGINS="optional_plugins/glib optional_plugins/golang optional_plugins/html optional_plugins/loader_yaml optional_plugins/resultsdb optional_plugins/result_upload optional_plugins/robot optional_plugins/varianter_cit optional_plugins/varianter_pict optional_plugins/varianter_yaml_to_mux" check
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 dist: xenial
 language: python
+cache: pip
 arch: amd64
 
 python:
@@ -14,10 +15,6 @@ env:
       SELF_CHECK_CONTINUOUS=y
       AVOCADO_CHECK_LEVEL=1
       PYTHONWARNINGS=ignore
-
-cache:
-    directories:
-        - $HOME/.cache/pip
 
 addons:
   apt:


### PR DESCRIPTION
Which are failing because of permission denied errors outside of our control.