### PR TITLE
Improve contributor usability with some explicit requirments

### DIFF
--- a/docs/source/guides/contributor/chapters/environment.rst
+++ b/docs/source/guides/contributor/chapters/environment.rst
@@ -5,6 +5,17 @@ Development environment
 
 .. warning:: TODO: Needs improvment here. i.e: virtualenvs, GPG, etc.
 
+Installing dependencies
+-----------------------
+
+You need to install few dependencies before start coding::
+
+ $ sudo dnf install gcc libvirt-devel
+
+
+Installing in develop mode
+--------------------------
+
 Since version 0.31.0, our plugin system requires Setuptools entry points to be
 registered. If you're hacking on Avocado and want to use the same, possibly
 modified, source for running your tests and experiments, you may do so with one

--- a/requirements-selftests.txt
+++ b/requirements-selftests.txt
@@ -12,6 +12,9 @@ funcsigs>=0.4
 aexpect==1.5.1
 psutil==5.4.7
 
+# To test optional_plugins/varianter_yaml_to_mux
+pyaml==19.12.0
+
 # pycdlib is an optional requirement in production
 # but is necessary for selftests
 pycdlib==1.6.0


### PR DESCRIPTION
Today, in order to install selfttests-requirements we need make and libvirt-devel. Without this, make requirements-selftests will fail. This will add this instruction to our contributor guide. Also, this will add pyaml as a requirement since that is a need in order to test varianter_yaml_to_mux.