### PR TITLE
Specific version for jinja2 package

### DIFF
--- a/optional_plugins/html/setup.py
+++ b/optional_plugins/html/setup.py
@@ -24,7 +24,7 @@ setup(name='avocado-framework-plugin-result-html',
       url='http://avocado-framework.github.io/',
       packages=find_packages(),
       include_package_data=True,
-      install_requires=['avocado-framework', 'jinja2'],
+      install_requires=['avocado-framework', 'jinja2<3.0.0'],
       entry_points={
           'avocado.plugins.cli': [
               'html = avocado_result_html:HTML',


### PR DESCRIPTION
Because jinja2 drops support of python 3.5 with the new version, we have to
stay on the jinja2 older version with python 3.5 support. Because of this, we were having a problem with using HTML optional plugin on python 3.5

Signed-off-by: Jan Richter <jarichte@redhat.com>