### PR TITLE
added verbose and paginator deprecation message

### DIFF
--- a/avocado/plugins/config.py
+++ b/avocado/plugins/config.py
@@ -12,6 +12,8 @@
 # Copyright: Red Hat Inc. 2013-2014
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
+import warnings
+
 from avocado.core import data_dir
 from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLICmd
@@ -33,12 +35,17 @@ class Config(CLICmd):
                             help='Shows the data directories currently being used by avocado')
         parser.add_argument('--paginator',
                             choices=('on', 'off'), default='on',
-                            help='Turn the paginator on/off. '
-                            'Current: %(default)s')
+                            help='Turn the paginator on/off. Will be '
+                                 'deprecated soon. Current: %(default)s')
 
     def run(self, config):
         LOG_UI.info("Config files read (in order, '*' means the file exists "
                     "and had been read):")
+
+        warnings.warn("avocado config --paginator will be deprecated soon: "
+                      "avocado --paginator config will be used instead.",
+                      FutureWarning)
+
         for cfg_path in settings.all_config_paths:
             if cfg_path in settings.config_paths:
                 LOG_UI.debug('    * %s', cfg_path)

--- a/avocado/plugins/diff.py
+++ b/avocado/plugins/diff.py
@@ -23,6 +23,7 @@ import os
 import subprocess
 import sys
 import tempfile
+import warnings
 
 from difflib import unified_diff, HtmlDiff
 
@@ -91,8 +92,8 @@ class Diff(CLICmd):
 
         parser.add_argument('--paginator',
                             choices=('on', 'off'), default='on',
-                            help='Turn the paginator on/off. '
-                            'Current: %(default)s')
+                            help='Turn the paginator on/off. Will be '
+                                 'deprecated soon. Current: %(default)s')
 
         parser.add_argument('--create-reports', action='store_true',
                             help='Create temporary files with job reports '
@@ -107,6 +108,10 @@ class Diff(CLICmd):
 
         def _get_name_no_id(test):
             return str(test['id']).split('-', 1)[1]
+
+        warnings.warn("avocado diff --paginator will be deprecated soon: "
+                      "avocado --paginator diff will be used instead.",
+                      FutureWarning)
 
         job1_dir, job1_id = self._setup_job(config.get('jobids')[0])
         job2_dir, job2_id = self._setup_job(config.get('jobids')[1])

--- a/avocado/plugins/list.py
+++ b/avocado/plugins/list.py
@@ -13,6 +13,7 @@
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
 import sys
+import warnings
 
 from avocado.core import exit_codes, output
 from avocado.core import loader
@@ -168,15 +169,20 @@ class List(CLICmd):
                             "plugins)")
         parser.add_argument('-V', '--verbose',
                             action='store_true', default=False,
-                            help='Whether to show extra information '
-                            '(headers and summary). Current: %(default)s')
+                            help='Whether to show extra information (headers '
+                                 'and summary). Will be deprecated soon. '
+                                 'Current: %(default)s')
         parser.add_argument('--paginator',
                             choices=('on', 'off'), default='on',
-                            help='Turn the paginator on/off. '
-                            'Current: %(default)s')
+                            help='Turn the paginator on/off. Will be '
+                            'deprecated soon. Defaultt: %(default)s')
         loader.add_loader_options(parser)
         parser_common_args.add_tag_filter_args(parser)
 
     def run(self, config):
+        warnings.warn("--paginator and --verbose will be deprecated soon: "
+                      "They are going to be global, instead.",
+                      FutureWarning)
+
         test_lister = TestLister(config)
         return test_lister.list()

--- a/avocado/plugins/plugins.py
+++ b/avocado/plugins/plugins.py
@@ -14,6 +14,7 @@
 """
 Plugins information plugin
 """
+import warnings
 
 from avocado.core import dispatcher
 from avocado.core.resolver import Resolver
@@ -35,10 +36,14 @@ class Plugins(CLICmd):
         parser = super(Plugins, self).configure(parser)
         parser.add_argument('--paginator',
                             choices=('on', 'off'), default='on',
-                            help='Turn the paginator on/off. '
-                            'Current: %(default)s')
+                            help='Turn the paginator on/off. Will be '
+                            'deprecated soon. Current: %(default)s')
 
     def run(self, config):
+        warnings.warn("avocado plugins --paginator will be deprecated soon: "
+                      "avocado --paginator plugins will be used instead.",
+                      FutureWarning)
+
         plugin_types = [
             (dispatcher.CLICmdDispatcher(),
              'Plugins that add new commands (cli.cmd):'),


### PR DESCRIPTION
Currently, --paginator and --verbose are configured locally by few
plugins but used globally (due to the argparse design). With the new
settings module being implemented, we need to put everything inside a
'settings namespace'. During a meeting discussion, we agreed that
--paginator and --verbose should be a global option. This just add a
warning message for this future change.

Signed-off-by: Beraldo Leal <bleal@redhat.com>