### PR TITLE
nrunner/tap: implementing a TAPRunner first version [v4]

### DIFF
--- a/avocado/core/nrunner_tap.py
+++ b/avocado/core/nrunner_tap.py
@@ -1,0 +1,130 @@
+import argparse
+import io
+import json
+import subprocess
+import time
+
+from . import nrunner
+from .tapparser import TapParser
+from .tapparser import TestResult
+
+
+class TAPRunner(nrunner.BaseRunner):
+    """Runner for standalone executables treated as TAP
+
+    When creating the Runnable, use the following attributes:
+
+     * kind: should be 'tap';
+
+     * uri: path to a binary to be executed as another process. This must
+       provides a TAP output.
+
+     * args: any runnable argument will be given on the command line to the
+       binary given by path
+
+     * kwargs: you can specify multiple key=val as kwargs. This will be used as
+       environment variables to the process.
+
+    Example:
+
+       runnable = Runnable(kind='tap',
+                           uri='tests/foo.sh',
+                           'bar', # arg 1
+                           DEBUG='false') # kwarg 1 (environment)
+    """
+    def run(self):
+        env = self.runnable.kwargs or None
+        process = subprocess.Popen(
+            [self.runnable.uri] + list(self.runnable.args),
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env)
+
+        while process.poll() is None:
+            time.sleep(nrunner.RUNNER_RUN_STATUS_INTERVAL)
+            yield {'status': 'running',
+                   'timestamp': time.time()}
+
+        stdout = io.TextIOWrapper(process.stdout)
+        parser = TapParser(stdout)
+        status = 'error'
+        for event in parser.parse():
+            if isinstance(event, TapParser.Bailout):
+                status = 'error'
+                break
+            elif isinstance(event, TapParser.Error):
+                status = 'error'
+                break
+            elif isinstance(event, TapParser.Test):
+                if event.result in (TestResult.XPASS, TestResult.FAIL):
+                    status = 'fail'
+                    break
+                elif event.result == TestResult.SKIP:
+                    status = 'skip'
+                    break
+                else:
+                    status = 'pass'
+
+        yield {'status': status,
+               'returncode': process.returncode,
+               'timestamp': time.time()}
+
+
+def subcommand_capabilities(_, echo=print):
+    data = {"runnables": [k for k in RUNNABLE_KIND_CAPABLE.keys()],
+            "commands": [k for k in COMMANDS_CAPABLE.keys()]}
+    echo(json.dumps(data))
+
+
+def subcommand_runnable_run(args, echo=print):
+    runnable = nrunner.Runnable.from_args(args)
+    runner = nrunner.runner_from_runnable(runnable, RUNNABLE_KIND_CAPABLE)
+
+    for status in runner.run():
+        echo(status)
+
+
+def subcommand_task_run(args, echo=print):
+    runnable = nrunner.Runnable.from_args(args)
+    task = nrunner.Task(args.get('identifier'), runnable,
+                        args.get('status_uri', []))
+    task.capables = RUNNABLE_KIND_CAPABLE
+    nrunner.task_run(task, echo)
+
+
+COMMANDS_CAPABLE = {'capabilities': subcommand_capabilities,
+                    'runnable-run': subcommand_runnable_run,
+                    'task-run': subcommand_task_run}
+
+
+RUNNABLE_KIND_CAPABLE = {'tap': TAPRunner}
+
+
+def parse():
+    parser = argparse.ArgumentParser(
+        prog='avocado-runner-tap',
+        description=('*EXPERIMENTAL* N(ext) Runner for executable tests '
+                     'that produce TAP'))
+    subcommands = parser.add_subparsers(dest='subcommand')
+    subcommands.required = True
+    subcommands.add_parser('capabilities')
+    runnable_run_parser = subcommands.add_parser('runnable-run')
+    for arg in nrunner.CMD_RUNNABLE_RUN_ARGS:
+        runnable_run_parser.add_argument(*arg[0], **arg[1])
+    runnable_task_parser = subcommands.add_parser('task-run')
+    for arg in nrunner.CMD_TASK_RUN_ARGS:
+        runnable_task_parser.add_argument(*arg[0], **arg[1])
+    return parser.parse_args()
+
+
+def main():
+    args = vars(parse())
+    subcommand = args.get('subcommand')
+    kallable = COMMANDS_CAPABLE.get(subcommand)
+    if kallable is not None:
+        kallable(args)
+
+
+if __name__ == '__main__':
+    main()

--- a/selftests/unit/test_nrunner.py
+++ b/selftests/unit/test_nrunner.py
@@ -4,6 +4,7 @@ import tempfile
 import unittest.mock
 
 from avocado.core import nrunner
+from avocado.core import nrunner_tap
 
 from .. import temp_dir_prefix
 
@@ -176,6 +177,10 @@ class RunnableToRecipe(unittest.TestCase):
 
 class Runner(unittest.TestCase):
 
+    def setUp(self):
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
+
     def test_runner_noop(self):
         runnable = nrunner.Runnable('noop', None)
         runner = nrunner.runner_from_runnable(runnable)
@@ -219,6 +224,72 @@ class Runner(unittest.TestCase):
         self.assertEqual(result['status'], 'pass')
         self.assertTrue(result['output'].startswith(output1))
         self.assertTrue(result['output'].endswith(output2))
+
+    @unittest.skipUnless(os.path.exists('/bin/sh'),
+                         ('Executable "/bin/sh" used in this test is not '
+                          'available in the system'))
+    def test_runner_tap_fail(self):
+        tap_script = """#!/bin/sh
+echo '1..2'
+echo '# Defining an basic test'
+echo 'ok 1 - description 1'
+echo 'not ok 2 - description 2'"""
+        tap_path = os.path.join(self.tmpdir.name, 'tap.sh')
+
+        with open(tap_path, 'w') as fp:
+            fp.write(tap_script)
+
+        runnable = nrunner.Runnable('tap', '/bin/sh', tap_path)
+        runner = nrunner_tap.TAPRunner(runnable)
+        results = [status for status in runner.run()]
+        last_result = results[-1]
+        self.assertEqual(last_result['status'], 'fail')
+        self.assertEqual(last_result['returncode'], 0)
+
+    @unittest.skipUnless(os.path.exists('/bin/sh'),
+                         ('Executable "/bin/sh" used in this test is not '
+                          'available in the system'))
+    def test_runner_tap_ok(self):
+        tap_script = """#!/bin/sh
+echo '1..2'
+echo '# Defining an basic test'
+echo 'ok 1 - description 1'
+echo 'ok 2 - description 2'"""
+        tap_path = os.path.join(self.tmpdir.name, 'tap.sh')
+
+        with open(tap_path, 'w') as fp:
+            fp.write(tap_script)
+
+        runnable = nrunner.Runnable('tap', '/bin/sh', tap_path)
+        runner = nrunner_tap.TAPRunner(runnable)
+        results = [status for status in runner.run()]
+        last_result = results[-1]
+        self.assertEqual(last_result['status'], 'pass')
+        self.assertEqual(last_result['returncode'], 0)
+
+    @unittest.skipUnless(os.path.exists('/bin/sh'),
+                         ('Executable "/bin/sh" used in this test is not '
+                          'available in the system'))
+    def test_runner_tap_skip(self):
+        tap_script = """#!/bin/sh
+echo '1..2'
+echo '# Defining an basic test'
+echo 'ok 1 - # SKIP description 1'
+echo 'ok 2 - description 2'"""
+        tap_path = os.path.join(self.tmpdir.name, 'tap.sh')
+
+        with open(tap_path, 'w') as fp:
+            fp.write(tap_script)
+
+        runnable = nrunner.Runnable('tap', '/bin/sh', tap_path)
+        runner = nrunner_tap.TAPRunner(runnable)
+        results = [status for status in runner.run()]
+        last_result = results[-1]
+        self.assertEqual(last_result['status'], 'skip')
+        self.assertEqual(last_result['returncode'], 0)
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ if __name__ == '__main__':
                   'avocado-runner-exec-test = avocado.core.nrunner:main',
                   'avocado-runner-python-unittest = avocado.core.nrunner:main',
                   'avocado-runner-avocado-instrumented = avocado.core.nrunner_avocado_instrumented:main',
+                  'avocado-runner-tap = avocado.core.nrunner_tap:main',
                   ],
               'avocado.plugins.cli': [
                   'envkeep = avocado.plugins.envkeep:EnvKeep',


### PR DESCRIPTION
The first draft of a TAPRunner for the Next Runner.  This is using the
`tapparser` module to process TAP outputs. More improvements will come
here.

---
Changes from v3:
* Split TAP runner into its own script (given that it requires Avocado libraries, as this follows the current model as per `nrunner_avocado_instrumented.py`).

Changes from v2:
* Merged commits;
* Using `/bin/sh` instead of `/bin/bash` on tests;
* Tests are now checking if `/bin/sh` exists, otherwise will skip;
* Using the current "status approach". `status` instead of `result`;
* Removed `aborted` status;

Changes from v1:
* Added a better docstring;
* Added tests;
* Removed `encoding` argument from `subprocess.Popen` since that is only available on `>=python3.6`