### PR TITLE
Way to provide sysinfo in case of test failure

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -1047,6 +1047,8 @@ class Test(unittest.TestCase, TestData):
         :warning message: This parameter will changed name to "msg" in the next
                           LTS release because of lint W0221
         """
+        if self.__sysinfo_enabled:
+            self.__sysinfo_logger.end_test_hook(status="FAIL")
         raise exceptions.TestFail(message)
 
     def error(self, message=None):  # pylint: disable=W0221

--- a/avocado/etc/avocado/avocado.conf
+++ b/avocado/etc/avocado/avocado.conf
@@ -29,8 +29,12 @@ per_test = False
 [sysinfo.collectibles]
 # File with list of commands that will be executed and have their output collected
 commands = etc/avocado/sysinfo/commands
+# File with list of commands that will be executed and have their output collected, in case of test failure
+fail_commands = etc/avocado/sysinfo/fail_commands
 # File with list of files that will be collected verbatim
 files = etc/avocado/sysinfo/files
+# File with list of files that will be collected verbatim, in case of test failure
+fail_files = etc/avocado/sysinfo/fail_files
 # File with list of commands that will run alongside the job/test
 profilers = etc/avocado/sysinfo/profilers
 


### PR DESCRIPTION
sysinfo collectibles were being collected in case of all test
results. But we need to collect some data in case of test failures
only. Introduced a way to do that.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>