### PR TITLE
Change --dry-run to correctly shows test "filename" [v2]

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -292,6 +292,8 @@ class TestLoaderProxy:
                     if issubclass(obj, test.Test):
                         test_class = obj
                         break
+        if test_class is test.DryRunTest:
+            test_parameters['modulePath'] = test_path
         test_instance = test_class(**test_parameters)
 
         return test_instance

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -1421,11 +1421,29 @@ class DryRunTest(MockingTest):
     Fake test which logs itself and reports as CANCEL
     """
 
+    def __init__(self, *args, **kwargs):
+        if 'modulePath' in kwargs:
+            self._filename = kwargs.pop('modulePath')
+        if self._filename is None:
+            self._filename = kwargs["name"].name
+        super(DryRunTest, self).__init__(**kwargs)
+
     def setUp(self):
         self.log.info("Test params:")
         for path, key, value in self.params.iteritems():
             self.log.info("%s:%s ==> %s", path, key, value)
         self.cancel('Test cancelled due to --dry-run')
+
+    @property
+    def filename(self):
+        try:
+            source = os.path.abspath(self._filename)
+            if os.path.exists(source):
+                return source
+            else:
+                return None
+        except AttributeError:
+            return None
 
 
 class ReplaySkipTest(MockingTest):


### PR DESCRIPTION
The tests which were run as `dry-run` had wrong filename property. This
commit fixes this problem with `dry-run` option by setting the right
filename for `dry-run` tests.

Reference: https://github.com/avocado-framework/avocado/issues/3486
Signed-off-by: Jan Richter <jarichte@redhat.com>

---
Changes from v1 (#3596):
- `modulePath` key can be set to None
- reuse of `test` module