### PR TITLE
avocado.utils.pmem: do not init, use which or shell

### DIFF
--- a/avocado/utils/pmem.py
+++ b/avocado/utils/pmem.py
@@ -298,6 +298,3 @@ class PMem:
                           shell=True, ignore_status=True):
             raise PMemException('Namespace destroy command failed')
         return True
-
-
-pmem = PMem()

--- a/avocado/utils/pmem.py
+++ b/avocado/utils/pmem.py
@@ -20,6 +20,7 @@ import json
 import glob
 import logging
 
+from . import path
 from . import process
 from . import genio
 
@@ -52,7 +53,7 @@ class PMem:
         :param daxctl: path to daxctl binary, defaults to ndctl
         """
         for lib_bin in [ndctl, daxctl]:
-            if process.system('which %s' % lib_bin, shell=True, ignore_status=True):
+            if not path.find_command(lib_bin):
                 raise PMemException("Cannot use library without "
                                     "proper binary %s" % lib_bin)
         self.ndctl = ndctl

--- a/avocado/utils/pmem.py
+++ b/avocado/utils/pmem.py
@@ -68,8 +68,8 @@ class PMem:
         :rtype: list of json objects
         """
         try:
-            json_op = json.loads(process.system_output(
-                '%s list %s' % (self.ndctl, option), shell=True))
+            cmd = '%s list %s' % (self.ndctl, option)
+            json_op = json.loads(process.system_output(cmd))
         except ValueError:
             json_op = []
         return json_op
@@ -97,8 +97,8 @@ class PMem:
         :return: By default returns entire list of json objects
         :rtype: list of json objects
         """
-        return json.loads(process.system_output(
-            '%s list %s' % (self.daxctl, options), shell=True))
+        cmd = '%s list %s' % (self.daxctl, options)
+        return json.loads(process.system_output(cmd))
 
     def get_slot_count(self, region):
         """

--- a/selftests/unit/test_utils_pmem.py
+++ b/selftests/unit/test_utils_pmem.py
@@ -1,0 +1,16 @@
+import unittest.mock
+
+from avocado.utils import pmem
+
+
+class PMem(unittest.TestCase):
+
+    def test_no_binaries(self):
+        with unittest.mock.patch('avocado.utils.path.find_command',
+                                 return_value=False):
+            with self.assertRaises(pmem.PMemException):
+                pmem.PMem()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This is simple a set of simplifications to the `avocado.utils.pmem` module.