### PR TITLE
SSH: expose raw commands generated

### DIFF
--- a/avocado/utils/ssh.py
+++ b/avocado/utils/ssh.py
@@ -146,6 +146,22 @@ class Session:
             self._connection = master
         return self._check()
 
+    def get_raw_ssh_command(self, command):
+        """
+        Returns the raw command that will be executed locally
+
+        This should only be used if you need to interact with the ssh
+        subprocess, and most users will *NOT* need to.  Try to use the
+        :meth:`cmd` method instead.
+
+        :param command: the command to execute over the SSH session
+        :type command: str
+        :returns: The raw SSH command, that can be executed locally for
+                  the execution of a remote command.
+        :rtype: str
+        """
+        return self._ssh_cmd(self.DEFAULT_OPTIONS, ('-q', ), command)
+
     def cmd(self, command):
         """
         Runs a command over the SSH session
@@ -158,8 +174,8 @@ class Session:
         :returns: The command result object.
         :rtype: A :class:`CmdResult` instance.
         """
-        cmd = self._ssh_cmd(self.DEFAULT_OPTIONS, ('-q', ), command)
-        return process.run(cmd, ignore_status=True)
+        return process.run(self.get_raw_ssh_command(command),
+                           ignore_status=True)
 
     def quit(self):
         """

--- a/avocado/utils/ssh.py
+++ b/avocado/utils/ssh.py
@@ -170,7 +170,7 @@ class Session:
         the caller.
 
         :param command: the command to execute over the SSH session
-        :param command: str
+        :type command: str
         :returns: The command result object.
         :rtype: A :class:`CmdResult` instance.
         """

--- a/examples/apis/utils/ssh.py
+++ b/examples/apis/utils/ssh.py
@@ -1,0 +1,25 @@
+from avocado.utils.ssh import Session
+from avocado.utils.process import SubProcess
+import time
+
+with Session('host', user='root', key='/path/to/key') as s:
+    print('connected')
+    procs = []
+    cmd = s.get_raw_ssh_command('sleep 5')
+    for i in range(10):
+        p = SubProcess(cmd)
+        print(p.start())
+        procs.append(p)
+
+    while True:
+        for proc in procs:
+            proc.poll()
+
+        if all([p.result.exit_status is not None for p in procs]):
+            print('all finished')
+            break
+
+        time.sleep(1)
+        print('working...')
+
+print('session closed')


### PR DESCRIPTION
Given that most of the value of the `avocado.utils.ssh` module has to do with creating the command lines that will execute on remote systems, it seems fair to expose that.  This seems to be one way to allow for many use cases without bloating the API or introducing much complexity.

Related to https://github.com/avocado-framework/avocado/pull/3578