### PR TITLE
Misc Asset: Adds a wrapper function to find a file in the cache.

### DIFF
--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -371,3 +371,12 @@ class Asset:
                     metadata = json.load(f)
                     return metadata
         return None
+
+
+def find_file(name, cache_dirs, asset_hash=None, algorithm=None,
+              locations=None, expire=None):
+    """
+    Wrapper function to find a file downloaded by the Asset class in the cache.
+    """
+    return Asset(name, asset_hash, algorithm, locations, cache_dirs,
+                 expire).find_asset_file()

--- a/examples/tests/cancel_by_asset.py
+++ b/examples/tests/cancel_by_asset.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+
+from avocado import Test
+from avocado import main
+
+from avocado.utils.asset import find_file
+
+
+class CancelByAsset(Test):
+
+    """
+    Example test that cancels the current test when an asset is not available.
+    """
+
+    def setUp(self):
+        mirrors = ['https://mirrors.peers.community/mirrors/gnu/hello/',
+                   'https://mirrors.kernel.org/gnu/hello/',
+                   'http://gnu.c3sl.ufpr.br/ftp/',
+                   'ftp://ftp.funet.fi/pub/gnu/prep/hello/']
+        # Mess up with the original file name
+        hello = 'HELLO-2.9.tar.gz'
+        hello_locations = ["%s/%s" % (loc, hello) for loc in mirrors]
+
+        asset_file = find_file(
+            hello,
+            self.cache_dirs,
+            locations=hello_locations)
+
+        if asset_file is None:
+            self.cancel("Missing Asset")
+
+    def test_wont_be_executed(self):
+        """
+        This won't get to be executed, given that setUp calls .cancel().
+        """
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This adds a wrapper function to find an asset downloaded in the cache. It makes it possible to cancel a test if an asset is missing.

Cancelling a test can be as simple as:

```
asset_file = find_file(asset, self.cache_dirs)
if asset_file is None:
    self.cancel("Missing Asset")
```

The choice to use `find_file` instead of `find_asset_file`, like the original class method name, is to start to standardize this class to a _file_ handler for the _Requirements Resolver_ (BP002).

Signed-off-by: Willian Rampazzo <willianr@redhat.com>