### PR TITLE
avocado.utils.pmem: use absolute location for daxctl binary

### DIFF
--- a/avocado/utils/pmem.py
+++ b/avocado/utils/pmem.py
@@ -62,7 +62,7 @@ class PMem:
         if not abs_daxctl:
             raise PMemException("Cannot use library without "
                                 "proper daxctl binary")
-        self.daxctl = daxctl
+        self.daxctl = abs_daxctl
 
     def run_ndctl_list(self, option=''):
         """


### PR DESCRIPTION
And not the given parameter, in accordance to the same logic used for
ndctl.

Signed-off-by: Cleber Rosa <crosa@redhat.com>