### PR TITLE
utils/ssh: just a few improvements to API documentation

### DIFF
--- a/avocado/utils/ssh.py
+++ b/avocado/utils/ssh.py
@@ -1,3 +1,16 @@
+""" Provides utilities to carry out an SSH session.
+
+Example of use:
+
+.. code-block:: python
+
+    from avocado.utils import ssh
+
+    with ssh.Session(host, user='root', key='/path/to/file') as session:
+        ret = session.cmd('ls')
+        if ret.exit_status == 0:
+            print(ret.stdout_text)
+"""
 import os
 import shlex
 import stat

--- a/avocado/utils/ssh.py
+++ b/avocado/utils/ssh.py
@@ -20,6 +20,10 @@ class Session:
     """
     Represents an SSH session to a remote system, for the purpose of
     executing commands remotely.
+
+    :class:`Session` is also a context manager. On entering the context
+    it tries to establish the connection, therefore on exiting that
+    connection is closed.
     """
 
     DEFAULT_OPTIONS = (('StrictHostKeyChecking', 'no'),

--- a/avocado/utils/ssh.py
+++ b/avocado/utils/ssh.py
@@ -189,7 +189,7 @@ class Session:
         :param command: the command to execute over the SSH session
         :type command: str
         :returns: The command result object.
-        :rtype: A :class:`CmdResult` instance.
+        :rtype: A :class:`avocado.utils.process.CmdResult` instance.
         """
         return process.run(self.get_raw_ssh_command(command),
                            ignore_status=True)


### PR DESCRIPTION
I've only one doubt about use the content of examples/apis/utils/ssh.py in the module's documentation because this example seems outdated (it is easier to use the `cmd` function). Nevertheless, looking forward your opinion.