### PR TITLE
Temporarily suppress console errors on Job unit tests.

### DIFF
--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import tempfile
 import unittest.mock
@@ -204,7 +205,10 @@ class JobTest(unittest.TestCase):
                   'show': ['none']}
         self.job = job.Job(config)
         self.job.setup()
+        # temporarily disable logging on console
+        logging.disable(logging.ERROR)
         self.job.run()
+        logging.disable(logging.NOTSET)
         self.assertNotEqual(self.job.time_start, -1)
         self.assertNotEqual(self.job.time_end, -1)
         self.assertNotEqual(self.job.time_elapsed, -1)
@@ -215,7 +219,10 @@ class JobTest(unittest.TestCase):
         self.job = job.Job(config)
         self.job.setup()
         self.job.time_start = 10.0
+        # temporarily disable logging on console
+        logging.disable(logging.ERROR)
         self.job.run()
+        logging.disable(logging.NOTSET)
         self.job.time_end = 20.0
         # forcing a different value to check if it's not being
         # calculated when time_start or time_end are manually set


### PR DESCRIPTION
When running selftests, two unit tests from the Job class are throwing `No test references provided nor any other arguments resolved into tests. Please double check the executed command.`
error message to the output. The messages were suppressed by this change when the run method from the Job class is called to avoid polluting the output.

Signed-off-by: Willian Rampazzo <willianr@redhat.com>