### PR TITLE
Misc Asset: update get_metadata to throw an exception.

### DIFF
--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -370,8 +370,7 @@ class Asset:
         try:
             asset_file = self.find_asset_file()
         except OSError:
-            LOG.info("Metadata not available.")
-            return None
+            raise OSError("Metadata not available.")
 
         basename = os.path.splitext(asset_file)[0]
         metadata_file = "%s_metadata.json" % basename

--- a/selftests/functional/test_utils_asset.py
+++ b/selftests/functional/test_utils_asset.py
@@ -184,7 +184,8 @@ class TestAsset(unittest.TestCase):
                         cache_dirs=[self.cache_dir],
                         expire=None,
                         metadata=expected_metadata)
-        self.assertIsNone(a.get_metadata())
+        with self.assertRaises(OSError):
+            a.get_metadata()
 
     def tearDown(self):
         self.tmpdir.cleanup()


### PR DESCRIPTION
Other public methods from Asset class were changed to throw an exception instead of returning `None` when the action expected from the method fails. The only method still returning `None` is `get_metadata`. This changes the behavior to throw an exception instead of returning `None`.

Signed-off-by: Willian Rampazzo <willianr@redhat.com>