### PR TITLE
avocado/utils/ssh.py: do not capture and supress exception at __exit__

### DIFF
--- a/avocado/utils/ssh.py
+++ b/avocado/utils/ssh.py
@@ -71,7 +71,7 @@ class Session:
         return self
 
     def __exit__(self, _exc_type, _exc_value, _traceback):
-        return self.quit()
+        self.quit()
 
     def _dash_o_opts_to_str(self, opts):
         """


### PR DESCRIPTION
It was never the intention, AFAICT, to capture and supress the
exceptions that could occurr during the use of an ssh.Session()
instance as a context manager.  But, because it was returning True,
that was effectively what was happening.

By not returning True, any exceptions that happen during the context
will be propagated.

Reference: https://docs.python.org/3/reference/datamodel.html#object.__exit__
Signed-off-by: Cleber Rosa <crosa@redhat.com>