### PR TITLE
Software manager: refactors and make avocado-software-manager useful [v2]

### DIFF
--- a/avocado/utils/software_manager.py
+++ b/avocado/utils/software_manager.py
@@ -484,13 +484,11 @@ class YumBackend(RpmBackend):
         Initializes the base command and the yum package repository.
         """
         super(YumBackend, self).__init__()
-        executable = utils_path.find_command(cmd)
-        base_arguments = '-y'
-        self.base_command = executable + ' ' + base_arguments
+        self.base_command = '%s -y' % utils_path.find_command(cmd)
         self.repo_file_path = '/etc/yum.repos.d/avocado-managed.repo'
         self.cfgparser = configparser.ConfigParser()
         self.cfgparser.read(self.repo_file_path)
-        y_cmd = executable + ' --version | head -1'
+        y_cmd = self.base_command + ' --version | head -1'
         cmd_result = process.run(y_cmd, ignore_status=True,
                                  verbose=False, shell=True)
         out = cmd_result.stdout_text.strip()

--- a/avocado/utils/software_manager.py
+++ b/avocado/utils/software_manager.py
@@ -488,14 +488,14 @@ class YumBackend(RpmBackend):
         self.repo_file_path = '/etc/yum.repos.d/avocado-managed.repo'
         self.cfgparser = configparser.ConfigParser()
         self.cfgparser.read(self.repo_file_path)
-        y_cmd = self.base_command + '--version | head -1'
-        cmd_result = process.run(y_cmd, ignore_status=True,
-                                 verbose=False, shell=True)
-        out = cmd_result.stdout_text.strip()
+        version_result = process.run(self.base_command + '--version',
+                                     verbose=False,
+                                     ignore_status=True)
+        version_first_line = version_result.stdout_text.splitlines()[0].strip()
         try:
-            ver = re.findall(r'\d*.\d*.\d*', out)[0]
+            ver = re.findall(r'\d*.\d*.\d*', version_first_line)[0]
         except IndexError:
-            ver = out
+            ver = version_first_line
         self.pm_version = ver
         log.debug('%s version: %s', cmd, self.pm_version)
 

--- a/avocado/utils/software_manager.py
+++ b/avocado/utils/software_manager.py
@@ -484,11 +484,11 @@ class YumBackend(RpmBackend):
         Initializes the base command and the yum package repository.
         """
         super(YumBackend, self).__init__()
-        self.base_command = '%s -y' % utils_path.find_command(cmd)
+        self.base_command = '%s -y ' % utils_path.find_command(cmd)
         self.repo_file_path = '/etc/yum.repos.d/avocado-managed.repo'
         self.cfgparser = configparser.ConfigParser()
         self.cfgparser.read(self.repo_file_path)
-        y_cmd = self.base_command + ' --version | head -1'
+        y_cmd = self.base_command + '--version | head -1'
         cmd_result = process.run(y_cmd, ignore_status=True,
                                  verbose=False, shell=True)
         out = cmd_result.stdout_text.strip()
@@ -517,7 +517,7 @@ class YumBackend(RpmBackend):
         """
         Installs package [name]. Handles local installs.
         """
-        i_cmd = self.base_command + ' ' + 'install' + ' ' + name
+        i_cmd = self.base_command + 'install' + ' ' + name
 
         try:
             process.system(i_cmd, sudo=True)
@@ -531,7 +531,7 @@ class YumBackend(RpmBackend):
 
         :param name: Package name (eg. 'ipython').
         """
-        r_cmd = self.base_command + ' ' + 'erase' + ' ' + name
+        r_cmd = self.base_command + 'erase' + ' ' + name
         try:
             process.system(r_cmd, sudo=True)
             return True
@@ -608,9 +608,9 @@ class YumBackend(RpmBackend):
         :type name: str
         """
         if not name:
-            r_cmd = self.base_command + ' ' + 'update'
+            r_cmd = self.base_command + 'update'
         else:
-            r_cmd = self.base_command + ' ' + 'update' + ' ' + name
+            r_cmd = self.base_command + 'update' + ' ' + name
 
         try:
             process.system(r_cmd, sudo=True)

--- a/avocado/utils/software_manager.py
+++ b/avocado/utils/software_manager.py
@@ -46,7 +46,7 @@ from . import data_factory
 from . import distro
 from . import path as utils_path
 
-log = logging.getLogger('avocado.test')
+log = logging.getLogger('avocado.utils.software_manager')
 
 # If you want to make this lib to support your particular package
 # manager/distro, please implement the given backend class and
@@ -1237,7 +1237,13 @@ def main():
     parser.add_argument('--verbose', dest="debug", action='store_true',
                         help='include debug messages in console output')
 
-    _, args = parser.parse_known_args()
+    namespace, args = parser.parse_known_args()
+
+    if namespace.debug:
+        logging.basicConfig(level=logging.DEBUG, format='%(message)s')
+    else:
+        logging.basicConfig(level=logging.INFO, format='%(message)s')
+
     software_manager = SoftwareManager()
     if args:
         action = args[0]

--- a/avocado/utils/software_manager.py
+++ b/avocado/utils/software_manager.py
@@ -488,17 +488,7 @@ class YumBackend(RpmBackend):
         self.repo_file_path = '/etc/yum.repos.d/avocado-managed.repo'
         self.cfgparser = configparser.ConfigParser()
         self.cfgparser.read(self.repo_file_path)
-        version_result = process.run(self.base_command + '--version',
-                                     verbose=False,
-                                     ignore_status=True)
-        version_first_line = version_result.stdout_text.splitlines()[0].strip()
-        try:
-            ver = re.findall(r'\d*.\d*.\d*', version_first_line)[0]
-        except IndexError:
-            ver = version_first_line
-        self.pm_version = ver
-        log.debug('%s version: %s', cmd, self.pm_version)
-
+        self._set_version(cmd)
         if HAS_YUM_MODULE:
             self.yum_base = yum.YumBase()
         else:
@@ -512,6 +502,18 @@ class YumBackend(RpmBackend):
         Clean up the yum cache so new package information can be downloaded.
         """
         process.system("yum clean all", sudo=True)
+
+    def _set_version(self, cmd):
+        result = process.run(self.base_command + '--version',
+                             verbose=False,
+                             ignore_status=True)
+        first_line = result.stdout_text.splitlines()[0].strip()
+        try:
+            ver = re.findall(r'\d*.\d*.\d*', first_line)[0]
+        except IndexError:
+            ver = first_line
+        self.pm_version = ver
+        log.debug('%s version: %s', cmd, self.pm_version)
 
     def install(self, name):
         """


### PR DESCRIPTION
`avocado-software-manager` is now a script we ship, so it should be useful to users. Unfortunately, there's no output being generated at this point.

This basically does a few refactors, and then initializes the logging when `main()` is used.

---

Changes from v1 (#3604):
 * Replaced `executable` for `self.base_command` in first commit