### PR TITLE
[DRAFT] N(ext) Runner: isolation model draft implementation

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import argparse
 import asyncio
 import base64


### PR DESCRIPTION
With a basic podman implementation.

This is a draft version, very much limited in functionality, intended
only to align the general ideas about the isolation models that
standalone runners can provide.

The automation in creation the isolated environment comes down at this
point to sending a version of the basic "avocado-runner" runner to the
isolated environment (to the container).  The eventual runner
dependencies can be implemented in the future with a "avocado-runner
requirements" like command.

The execution of the test is done by configuring the container
entrypoint.

The results are delivered to the status server via a host network.  In
the future, it could run without network and the upper (around the job
layer) could fetch the results from the container.

The test files, and its requirements, are not fulfilled in any way at
this point, but it's expected that the "Requirements Resolver" set of
features could be used here.

To test this, if you have podman installed, you should be able to run
(optional, once only to improve the experience):

  $ podman pull fedora:31

Then:

  $ avocado nrun --podman -- /bin/true /bin/false

There's currently no cleanup implemented for the containers, so you
may want to also run "podman rm --all" when finished playing around
with this.

Signed-off-by: Cleber Rosa <crosa@redhat.com>