### PR TITLE
utils/network: Big refactoring on network library to improve consistency

### DIFF
--- a/avocado/utils/configure_network.py
+++ b/avocado/utils/configure_network.py
@@ -114,20 +114,20 @@ class NetworkInterface:
     def bring_down(self):
         """Utility used to Bring down interface """
 
-        cmd = "ifdown {}".format(self.name)
+        cmd = "ip link set {} down".format(self.name)
         try:
             _run_command(cmd, self.remote_session, sudo=True)
         except Exception as ex:
-            raise NWException("ifdown fails: %s" % ex)
+            raise NWException("Failed to bring down: %s" % ex)
 
     def bring_up(self):
         """Utility used to Bring up interface"""
 
-        cmd = "ifup {}".format(self.name)
+        cmd = "ip link set {} up".format(self.name)
         try:
             _run_command(cmd, self.remote_session, sudo=True)
         except Exception as ex:
-            raise NWException("ifup fails: %s" % ex)
+            raise NWException("Failed to bring up: %s" % ex)
 
     def is_link_up(self):
         """

--- a/avocado/utils/configure_network.py
+++ b/avocado/utils/configure_network.py
@@ -10,23 +10,40 @@
 # See LICENSE for more details.
 #
 #
-# Copyright: 2019 IBM
-# Authors : Vaishnavi Bhat <vaishnavi@linux.vnet.ibm.com>
+# Copyright: 2019-2020 IBM
+# Copyright: 2019-2020 Red Hat Inc.
+# Authors : Beraldo Leal <bleal@redhat.com>
+#         : Praveen K Pandey <praveen@linux.vnet.ibm.com>
+#         : Vaishnavi Bhat <vaishnavi@linux.vnet.ibm.com>
 
 """
 Configure network when interface name and interface IP is available.
 """
 
-import shutil
-import os
-
+import json
 import logging
+import os
+import shutil
+import time
+
+from ipaddress import ip_interface
+
 from . import distro
 from . import process
-from . import genio
+from . import wait
 from .ssh import Session
 
+
 log = logging.getLogger('avocado.test')
+
+# Probably this will be replaced by aexpect
+def _run_command(command, remote_session=None, sudo=False):
+    if remote_session:
+        if sudo:
+            command = "sudo {}".format(command)
+        return remote_session.cmd(command).stdout.decode('utf-8')
+    else:
+        return process.system_output(command, sudo=sudo).decode('utf-8')
 
 
 class NWException(Exception):
@@ -35,168 +52,281 @@ class NWException(Exception):
     """
 
 
-def set_ip(ipaddr, netmask, interface, interface_type=None):
-    """
-    Gets interface name, IP, subnet mask and creates interface
-    file based on distro.
-    """
-    if distro.detect().name == 'rhel':
-        conf_file = "/etc/sysconfig/network-scripts/ifcfg-%s" % interface
-        if os.path.exists(conf_file):
-            shutil.move(conf_file, conf_file+".backup")
-        else:
-            raise NWException("%s interface not available" % interface)
-        with open(conf_file, "w") as network_conf:
-            if interface_type is None:
-                interface_type = 'Ethernet'
-            network_conf.write("TYPE=%s \n" % interface_type)
-            network_conf.write("BOOTPROTO=none \n")
-            network_conf.write("NAME=%s \n" % interface)
-            network_conf.write("DEVICE=%s \n" % interface)
-            network_conf.write("ONBOOT=yes \n")
-            network_conf.write("IPADDR=%s \n" % ipaddr)
-            network_conf.write("NETMASK=%s \n" % netmask)
-            network_conf.write("IPV6INIT=yes \n")
-            network_conf.write("IPV6_AUTOCONF=yes \n")
-            network_conf.write("IPV6_DEFROUTE=yes")
+class NetworkInterface:
 
-        cmd = "ifup %s" % interface
+    """
+    NetworkInterface, Provides  API's to Perform certain
+    operation on a  Network Interface
+    """
+
+    def __init__(self, if_name, if_type='Ethernet', remote_session=None):  # pylint: disable=W0231
+        self.name = if_name
+        self.if_type = if_type
+        self.remote_session = remote_session
+
+    def _get_interface_details(self, version=4):
+        output = ''
+        cmd = "ip -{} -j address show {}".format(version, self.name)
+        output = _run_command(cmd, self.remote_session)
         try:
-            process.system(cmd, ignore_status=False, sudo=True)
-            return True
-        except process.CmdError as ex:
+            return json.loads(output)
+        except (KeyError, json.JSONDecodeError):
+            msg = "Unable to get IP address on interface {}".format(self.name)
+            log.error(msg)
+            raise NWException(msg)
+
+    def _move_file_to_backup(self, filename, ignore_missing=True):
+        destination = "{}.backup-{}".format(filename, time.time())
+        if os.path.exists(filename):
+            shutil.move(filename, destination)
+        else:
+            if not ignore_missing:
+                raise NWException("%s interface not available" % self.name)
+
+    def _write_to_file(self, filename, values):
+        self._move_file_to_backup(filename)
+
+        with open(filename, 'w+') as fp:
+            for key, value in values:
+                fp.write("{}={}\n".format(key, value))
+
+    def add_hwaddr(self, hwaddr):
+        """
+        Utility which add mac address to a interface return Status
+        :param hwaddr: Hardware Address (Mac Address)
+        :return: True  Based on success if fail raise NWException
+        """
+        cmd = "ip link set dev {} address {}".format(self.name, hwaddr)
+        try:
+            _run_command(cmd, self.remote_session, sudo=True)
+        except Exception as ex:
+            raise NWException("Adding hw address fails: %s" % ex)
+
+    def add_ipaddr(self, ipaddr, netmask):
+        ip = ip_interface("{}/{}".format(ipaddr, netmask))
+        cmd = 'ip addr add {} dev {}'.format(ip.compressed,
+                                             self.name)
+        try:
+            _run_command(cmd, self.remote_session, sudo=True)
+        except Exception as ex:
+            raise NWException("Failed to add address {}".format(ex))
+
+    def bring_down(self):
+        """Utility used to Bring down interface """
+
+        cmd = "ifdown {}".format(self.name)
+        try:
+            _run_command(cmd, self.remote_session, sudo=True)
+        except Exception as ex:
+            raise NWException("ifdown fails: %s" % ex)
+
+    def bring_up(self):
+        """Utility used to Bring up interface"""
+
+        cmd = "ifup {}".format(self.name)
+        try:
+            _run_command(cmd, self.remote_session, sudo=True)
+        except Exception as ex:
             raise NWException("ifup fails: %s" % ex)
 
-    if distro.detect().name == 'SuSE':
-        conf_file = "/etc/sysconfig/network/ifcfg-%s" % interface
-        if os.path.exists(conf_file):
-            shutil.move(conf_file, conf_file+".backup")
+    def is_link_up(self):
+        """
+        Checks if the interface link is up
+        :return: True if the interface's link up, False otherwise.
+        """
+        if self.get_link_state() in ['up', 'UP']:
+            return True
         else:
-            raise NWException("%s interface not available" % interface)
-        with open(conf_file, "w") as network_conf:
-            network_conf.write("IPADDR=%s \n" % ipaddr)
-            network_conf.write("NETMASK='%s' \n" % netmask)
-            network_conf.write("IPV6INIT=yes \n")
-            network_conf.write("IPV6_AUTOCONF=yes \n")
-            network_conf.write("IPV6_DEFROUTE=yes")
+            return False
 
-        cmd = "ifup %s" % interface
+    def is_remote(self):
+        if self.remote_session:
+            return True
+        else:
+            return False
+
+    def get_ipaddrs(self, version=4):
+        """Get the IP addresses from a network interface.
+
+        Interfaces can hold multiple IP addresses. This method will return a
+        list with all addresses on this interface.
+
+        :param version: IP version number (4 or 6). This must be a integer.
+        :return: IP address
+        """
+        if version not in [4, 6]:
+            raise NWException("Version {} not supported".format(version))
+
         try:
-            process.system(cmd, ignore_status=False, sudo=True)
-            return True
-        except process.CmdError as ex:
-            raise NWException("ifup fails: %s" % ex)
+            details = self._get_interface_details(version)
+            addr_info = details[0].get('addr_info')
+            if addr_info:
+                return list(map(lambda x: x.get('local'),
+                            addr_info))
+        except (NWException, IndexError, KeyError) as e:
+            raise NWException(e)
+
+    def get_hwaddr(self):
+        cmd = "cat /sys/class/net/{}/address".format(self.name)
+        try:
+            return _run_command(cmd, self.remote_session)
+        except Exception as ex:
+            raise NWException("Failed to get hw address: {}".format(ex))
+
+    def get_link_state(self):
+        """Method used to get the link state of an interface.
+
+        This method will return 'up', 'down' or 'unknown', based on the network
+        interface state. Or it will raise a NWException if is unabble to get
+        the interface state.
+        """
+        cmd = "cat /sys/class/net/{}/operstate".format(self.name)
+        try:
+            return _run_command(cmd, self.remote_session)
+        except process.CmdError as e:
+            msg = ('Failed to get link state. Maybe the interface is '
+                   'missing. {}'.format(e))
+            raise NWException(msg)
+
+    def get_mtu(self):
+        pass
+
+    def ping_check(self, peer_ip, options=None):
+        """This method will try to ping a peer address (IPv4 or IPv6).
+
+        You should provide a IPv4 or IPV6 that would like to ping. This
+        method will try to ping the peer and if fails it will raise a
+        NWException.
+
+        :param peer_ip: Peer IP address (IPv4 or IPv6)
+        :param options: ping command options. Default is None
+        """
+        cmd = "ping -I {} {}".format(self.name, peer_ip)
+        if options is not None:
+            cmd = "{} {}".format(cmd, options)
+        try:
+            _run_command(cmd, self.remote_session)
+        except Exception as ex:
+            raise NWException("Failed to ping: {}".format(ex))
+
+    def save(self, ipaddr, netmask):
+        """
+        Utility assign a IP  address (given to this utility ) to  Interface
+        And generate interface file in sysfs based on distribution
+
+        :param ipaddr : ip address which need to configure for interface
+        :param netmask: Netmask which is associated  to provided IP
+        :param interface_type: Interface type IPV4 or IPV6 , default is
+                               IPV4 style
+        """
+        current_distro = distro.detect()
+
+        filename = "ifcfg-{}".format(self.name)
+        if current_distro.name in ['rhel', 'fedora']:
+            path = "/etc/sysconfig/network-scripts"
+        elif current_distro.name == 'SuSE':
+            path = "/etc/sysconfig/network"
+        else:
+            msg = 'Distro not supported by API. Could not save ipaddr.'
+            raise NWException(msg)
+
+        if ipaddr not in self.get_ipaddrs():
+            msg = ('ipaddr not configured on interface. To avoid '
+                   'inconsistency, please Set the ipaddr first.')
+            raise NWException(msg)
+
+        self._write_to_file("{}/{}".format(path, filename),
+                            {'TYPE': self.if_type,
+                             'BOOTPROTO': 'none',
+                             'NAME': self.name,
+                             'DEVICE': self.name,
+                             'ONBOOT': 'yes',
+                             'IPADDR': ipaddr,
+                             'NETMASK': netmask,
+                             'IPV6INIT': 'yes',
+                             'IPV6_AUTOCONF': 'yes',
+                             'IPV6_DEFROUTE': 'yes'})
+
+    def set_hwaddr(self, hwaddr):
+        """
+        Utility which set Hw address to Interface
+        :param hwaddr: Pass Hardwae address for defined interface
+        """
+        cmd = 'ip link set {} address {}'.format(self.name, hwaddr)
+        try:
+            self._run_command(cmd, sudo=True)
+        except Exception as ex:
+            raise NWException("Setting Mac address failed: %s" % ex)
+
+    def set_mtu(self, mtu):
+        """
+        Utility set mtu size to a interface and return status
+
+        :param mtu :  mtu size that meed to be set
+        :ptype : String
+        :return : return True / False in case of mtu able to set
+        """
+        cmd = "ip link set %s mtu %s" % (self.name, mtu)
+        _run_command(cmd, self.remote_session, sudo=True)
+        wait.wait_for(self.is_link_up, timeout=timeout)
+        if mtu != self.get_mtu():
+            raise NWException("Failed to set MTU.")
+
+    def remove_ipaddr(self, ipaddr, netmask):
+        """Remove an IP address from this interface.
+
+        This method will try to remove the address from this interface
+        and if fails it will raise a NWException. Be careful, you can
+        lost connection.
+
+        You must have sudo permissions to run this method on a host.
+        """
+        ip = ip_interface("{}/{}".format(ipaddr, netmask))
+        cmd = 'ip addr del {} dev {}'.format(ip.compressed,
+                                             self.name)
+        try:
+            _run_command(cmd, self.remote_session, sudo=True)
+        except Exception as ex:
+            msg = 'Failed to remove ipaddr. {}'.format(ex)
+            raise NWException(msg)
 
 
-def unset_ip(interface):
-    """
-    Gets interface name unassigns the IP to the interface
-    """
-    if distro.detect().name == 'rhel':
-        conf_file = "/etc/sysconfig/network-scripts/ifcfg-%s" % interface
-
-    if distro.detect().name == 'SuSE':
-        conf_file = "/etc/sysconfig/network/ifcfg-%s" % interface
-
-    cmd = "ifdown %s" % interface
-    try:
-        process.system(cmd, sudo=True)
-        shutil.move(conf_file+".backup", conf_file)
-        return True
-    except Exception as ex:
-        raise NWException("ifdown fails: %s" % ex)
-
-
-def ping_check(interface, peer_ip, count, option=None, flood=False):
-    """
-    Checks if the ping to peer works.
-    """
-    cmd = "ping -I %s %s -c %s" % (interface, peer_ip, count)
-    if flood is True:
-        cmd = "%s -f" % cmd
-    elif option is not None:
-        cmd = "%s %s" % (cmd, option)
-    if process.system(cmd, shell=True, verbose=True,
-                      ignore_status=True) != 0:
-        return False
-    return True
-
-
-def set_mtu_host(interface, mtu):
-    """
-    Set MTU size in host interface
-    """
-    cmd = "ip link set %s mtu %s" % (interface, mtu)
-    try:
-        process.system(cmd, shell=True)
-    except process.CmdError as ex:
-        raise NWException("MTU size can not be set: %s" % ex)
-    try:
-        cmd = "ip add show %s" % interface
-        mtuvalue = process.system_output(cmd, shell=True).decode("utf-8") \
-                                                         .split()[4]
-        if mtuvalue == mtu:
-            return True
-    except Exception as ex:  # pylint: disable=W0703
-        log.error("setting MTU value in host failed: %s", ex)
-    return False
-
-
-class PeerInfo:
+class Host:
     """
     class for peer function
     """
 
-    def __init__(self, host, port=None, peer_user=None,
-                 key=None, peer_password=None):
-        """
-        create a object for accesses remote machine
-        """
+    def __init__(self, host, port=22, username=None,
+                 key=None, password=None):
+        self.host = host
+        self.port = port
+        self.username = username
+        self.key = key
+        self.password = password
+        self.remote_session = None
+
+        self._connect()
+
+    def _connect(self):
+        if self.host and self.port and self.username:
+            try:
+                self.remote_session = Session(host=self.host,
+                                              port=self.port,
+                                              user=self.username,
+                                              key=self.key,
+                                              password=self.password)
+            except Exception as ex:
+                raise NWException("Could not connect to host: {}".format(ex))
+
+    @property
+    def interfaces(self):
+        cmd = 'ls /sys/class/net'
         try:
-            self.session = Session(host, port=port, user=peer_user,
-                                   key=key, password=peer_password)
-        except Exception as ex:  # pylint: disable=W0703
-            log.error("connection not established to peer machine: %s", ex)
+            names = _run_command(cmd, self.remote_session).split()
+        except Exception as ex:
+            raise NWException("Failed to get interfaces: {}".format(ex))
 
-    def set_mtu_peer(self, peer_interface, mtu):
-        """
-        Set MTU size in peer interface
-        """
-        cmd = "ip link set %s mtu %s" % (peer_interface, mtu)
-        try:
-            self.session.cmd(cmd)
-            cmd = "ip add show %s" % peer_interface
-            mtuvalue = self.session.cmd(cmd).stdout.decode("utf-8").split()[4]
-            if mtuvalue == mtu:
-                return True
-        except Exception as ex:  # pylint: disable=W0703
-            log.error("setting MTU value in peer failed: %s", ex)
-        return False
-
-    def get_peer_interface(self, peer_ip):
-        """
-        get peer interface from peer ip
-        """
-        cmd = "ip addr show"
-        try:
-            for line in self.session.cmd(cmd).stdout.decode("utf-8") \
-                                                    .splitlines():
-                if peer_ip in line:
-                    peer_interface = line.split()[-1]
-        except Exception as ex:  # pylint: disable=W0703
-            if peer_interface == "":
-                log.error("unable to get peer interface: %s", ex)
-        else:
-            return peer_interface
-
-
-def is_interface_link_up(interface):
-    """
-    Checks if the interface link is up
-    :param interface: name of the interface
-    :return: True if the interface's link comes up, False otherwise.
-    """
-    if 'up' in genio.read_file("/sys/class/net/%s/operstate" % interface):
-        log.info("Interface %s link is up", interface)
-        return True
-    return False
+        session = self.remote_session
+        return list(map(lambda x: NetworkInterface(if_name=x,
+                                                   remote_session=session),
+                        names))

--- a/avocado/utils/configure_network.py
+++ b/avocado/utils/configure_network.py
@@ -189,7 +189,10 @@ class NetworkInterface:
             raise NWException(msg)
 
     def get_mtu(self):
-        pass
+        try:
+            return self._get_interface_details()[0].get('mtu')
+        except (KeyError, IndexError):
+            raise NWException("Could not get MUT value.")
 
     def ping_check(self, peer_ip, options=None):
         """This method will try to ping a peer address (IPv4 or IPv6).
@@ -258,7 +261,7 @@ class NetworkInterface:
         except Exception as ex:
             raise NWException("Setting Mac address failed: %s" % ex)
 
-    def set_mtu(self, mtu):
+    def set_mtu(self, mtu, timeout=30):
         """
         Utility set mtu size to a interface and return status
 


### PR DESCRIPTION
Multiple pull requests were trying to add more features to this library.
But because of a lack of convention, it was getting hard to understand
this and we were losing usability. Besides a complete rewrite here, this
pull request is a) adding a complete set of methods to handle network
interfaces parameters; b) adding a wait when setting MTU values on
interfaces; and c) better support for IPv6.
    
Thanks for @anascko, @vaishnavibhat, @PraveenPenguin, and @smruti77
    
Signed-off-by: Beraldo Leal <bleal@redhat.com>
Signed-off-by: Oksana Vohchana <ovoshcha@redhat.com>
Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>
Signed-off-by: Vaishnavi Bhat <vaishnavi@linux.vnet.ibm.com>
