### PR TITLE
utils/network: Big refactoring on network library to improve consistency

### DIFF
--- a/avocado/utils/configure_network.py
+++ b/avocado/utils/configure_network.py
@@ -10,23 +10,40 @@
 # See LICENSE for more details.
 #
 #
-# Copyright: 2019 IBM
-# Authors : Vaishnavi Bhat <vaishnavi@linux.vnet.ibm.com>
+# Copyright: 2019-2020 IBM
+# Copyright: 2019-2020 Red Hat Inc.
+# Authors : Beraldo Leal <bleal@redhat.com>
+#         : Praveen K Pandey <praveen@linux.vnet.ibm.com>
+#         : Vaishnavi Bhat <vaishnavi@linux.vnet.ibm.com>
 
 """
-Configure network when interface name and interface IP is available.
+This module provides useful network interfaces methods.
 """
 
-import shutil
-import os
-
+import json
 import logging
+import os
+import shutil
+import time
+
+from ipaddress import ip_interface
+
 from . import distro
 from . import process
-from . import genio
+from . import wait
 from .ssh import Session
 
+
 log = logging.getLogger('avocado.test')
+
+
+# Probably this will be replaced by aexpect
+def _run_command(command, remote_session=None, sudo=False):
+    if remote_session:
+        if sudo:
+            command = "sudo {}".format(command)
+        return remote_session.cmd(command).stdout.decode('utf-8')
+    return process.system_output(command, sudo=sudo).decode('utf-8')
 
 
 class NWException(Exception):
@@ -35,168 +52,350 @@ class NWException(Exception):
     """
 
 
-def set_ip(ipaddr, netmask, interface, interface_type=None):
+class NetworkInterface:
     """
-    Gets interface name, IP, subnet mask and creates interface
-    file based on distro.
-    """
-    if distro.detect().name == 'rhel':
-        conf_file = "/etc/sysconfig/network-scripts/ifcfg-%s" % interface
-        if os.path.exists(conf_file):
-            shutil.move(conf_file, conf_file+".backup")
-        else:
-            raise NWException("%s interface not available" % interface)
-        with open(conf_file, "w") as network_conf:
-            if interface_type is None:
-                interface_type = 'Ethernet'
-            network_conf.write("TYPE=%s \n" % interface_type)
-            network_conf.write("BOOTPROTO=none \n")
-            network_conf.write("NAME=%s \n" % interface)
-            network_conf.write("DEVICE=%s \n" % interface)
-            network_conf.write("ONBOOT=yes \n")
-            network_conf.write("IPADDR=%s \n" % ipaddr)
-            network_conf.write("NETMASK=%s \n" % netmask)
-            network_conf.write("IPV6INIT=yes \n")
-            network_conf.write("IPV6_AUTOCONF=yes \n")
-            network_conf.write("IPV6_DEFROUTE=yes")
+    This class represents a network card interface (NIC).
 
-        cmd = "ifup %s" % interface
+    An "NetworkInterface" could be local or remote. If remote (has
+    remote_session) then all commands will be executed on a
+    remote_session. Otherwise will be executed locally.
+
+    Here you will find a few methods to perform basic operations on a NIC.
+    """
+
+    def __init__(self, if_name, if_type='Ethernet', remote_session=None):
+        self.name = if_name
+        self.if_type = if_type
+        self.remote_session = remote_session
+
+    def _get_interface_details(self, version=4):
+        output = ''
+        cmd = "ip -{} -j address show {}".format(version, self.name)
+        output = _run_command(cmd, self.remote_session)
         try:
-            process.system(cmd, ignore_status=False, sudo=True)
-            return True
-        except process.CmdError as ex:
+            return json.loads(output)
+        except json.JSONDecodeError:
+            msg = "Unable to get IP address on interface {}".format(self.name)
+            log.error(msg)
+            raise NWException(msg)
+
+    def _move_file_to_backup(self, filename, ignore_missing=True):
+        destination = "{}.backup-{}".format(filename, time.time())
+        if os.path.exists(filename):
+            shutil.move(filename, destination)
+        else:
+            if not ignore_missing:
+                raise NWException("%s interface not available" % self.name)
+
+    def _write_to_file(self, filename, values):
+        self._move_file_to_backup(filename)
+
+        with open(filename, 'w+') as fp:
+            for key, value in values.items():
+                fp.write("{}={}\n".format(key, value))
+
+    def set_hwaddr(self, hwaddr):
+        """Sets a Hardware Address (MAC Address) to the interface.
+
+        This method will try to set a new hwaddr to this interface, if
+        fails it will raise a NWException.
+
+        You must have sudo permissions to run this method on a host.
+
+        :param hwaddr: Hardware Address (Mac Address)
+        """
+        cmd = "ip link set dev {} address {}".format(self.name, hwaddr)
+        try:
+            _run_command(cmd, self.remote_session, sudo=True)
+        except Exception as ex:
+            raise NWException("Adding hw address fails: %s" % ex)
+
+    def add_ipaddr(self, ipaddr, netmask):
+        """Add an IP Address (with netmask) to the interface.
+
+        This method will try to add a new ipaddr/netmask this interface, if
+        fails it will raise a NWException.
+
+        You must have sudo permissions to run this method on a host.
+
+        :param ipaddr: IP Address
+        :param netmask: Network mask
+        """
+
+        ip = ip_interface("{}/{}".format(ipaddr, netmask))
+        cmd = 'ip addr add {} dev {}'.format(ip.compressed,
+                                             self.name)
+        try:
+            _run_command(cmd, self.remote_session, sudo=True)
+        except Exception as ex:
+            raise NWException("Failed to add address {}".format(ex))
+
+    def bring_down(self):
+        """Shutdown the interface.
+
+        This will shutdown the interface link. Be careful, you might lost
+        connection to the host.
+
+        You must have sudo permissions to run this method on a host.
+        """
+
+        cmd = "ifdown {}".format(self.name)
+        try:
+            _run_command(cmd, self.remote_session, sudo=True)
+        except Exception as ex:
+            raise NWException("ifdown fails: %s" % ex)
+
+    def bring_up(self):
+        """"Wake-up the interface.
+
+        This will wake-up the interface link.
+
+        You must have sudo permissions to run this method on a host.
+        """
+        cmd = "ifup {}".format(self.name)
+        try:
+            _run_command(cmd, self.remote_session, sudo=True)
+        except Exception as ex:
             raise NWException("ifup fails: %s" % ex)
 
-    if distro.detect().name == 'SuSE':
-        conf_file = "/etc/sysconfig/network/ifcfg-%s" % interface
-        if os.path.exists(conf_file):
-            shutil.move(conf_file, conf_file+".backup")
-        else:
-            raise NWException("%s interface not available" % interface)
-        with open(conf_file, "w") as network_conf:
-            network_conf.write("IPADDR=%s \n" % ipaddr)
-            network_conf.write("NETMASK='%s' \n" % netmask)
-            network_conf.write("IPV6INIT=yes \n")
-            network_conf.write("IPV6_AUTOCONF=yes \n")
-            network_conf.write("IPV6_DEFROUTE=yes")
+    def is_link_up(self):
+        """Check if the interface is up or not.
 
-        cmd = "ifup %s" % interface
-        try:
-            process.system(cmd, ignore_status=False, sudo=True)
+        :return: True or False. True if the current state is UP, otherwise will
+        return False.
+        """
+        if self.get_link_state() == 'up':
             return True
-        except process.CmdError as ex:
-            raise NWException("ifup fails: %s" % ex)
-
-
-def unset_ip(interface):
-    """
-    Gets interface name unassigns the IP to the interface
-    """
-    if distro.detect().name == 'rhel':
-        conf_file = "/etc/sysconfig/network-scripts/ifcfg-%s" % interface
-
-    if distro.detect().name == 'SuSE':
-        conf_file = "/etc/sysconfig/network/ifcfg-%s" % interface
-
-    cmd = "ifdown %s" % interface
-    try:
-        process.system(cmd, sudo=True)
-        shutil.move(conf_file+".backup", conf_file)
-        return True
-    except Exception as ex:
-        raise NWException("ifdown fails: %s" % ex)
-
-
-def ping_check(interface, peer_ip, count, option=None, flood=False):
-    """
-    Checks if the ping to peer works.
-    """
-    cmd = "ping -I %s %s -c %s" % (interface, peer_ip, count)
-    if flood is True:
-        cmd = "%s -f" % cmd
-    elif option is not None:
-        cmd = "%s %s" % (cmd, option)
-    if process.system(cmd, shell=True, verbose=True,
-                      ignore_status=True) != 0:
-        return False
-    return True
-
-
-def set_mtu_host(interface, mtu):
-    """
-    Set MTU size in host interface
-    """
-    cmd = "ip link set %s mtu %s" % (interface, mtu)
-    try:
-        process.system(cmd, shell=True)
-    except process.CmdError as ex:
-        raise NWException("MTU size can not be set: %s" % ex)
-    try:
-        cmd = "ip add show %s" % interface
-        mtuvalue = process.system_output(cmd, shell=True).decode("utf-8") \
-                                                         .split()[4]
-        if mtuvalue == mtu:
-            return True
-    except Exception as ex:  # pylint: disable=W0703
-        log.error("setting MTU value in host failed: %s", ex)
-    return False
-
-
-class PeerInfo:
-    """
-    class for peer function
-    """
-
-    def __init__(self, host, port=None, peer_user=None,
-                 key=None, peer_password=None):
-        """
-        create a object for accesses remote machine
-        """
-        try:
-            self.session = Session(host, port=port, user=peer_user,
-                                   key=key, password=peer_password)
-        except Exception as ex:  # pylint: disable=W0703
-            log.error("connection not established to peer machine: %s", ex)
-
-    def set_mtu_peer(self, peer_interface, mtu):
-        """
-        Set MTU size in peer interface
-        """
-        cmd = "ip link set %s mtu %s" % (peer_interface, mtu)
-        try:
-            self.session.cmd(cmd)
-            cmd = "ip add show %s" % peer_interface
-            mtuvalue = self.session.cmd(cmd).stdout.decode("utf-8").split()[4]
-            if mtuvalue == mtu:
-                return True
-        except Exception as ex:  # pylint: disable=W0703
-            log.error("setting MTU value in peer failed: %s", ex)
         return False
 
-    def get_peer_interface(self, peer_ip):
+    def is_remote(self):
+        """Check if this interface is on a remote host or not.
+
+        :return: True or False. If yes, it will return True, otherwise will
+                 return False.
         """
-        get peer interface from peer ip
+        if self.remote_session:
+            return True
+        return False
+
+    def get_ipaddrs(self, version=4):
+        """Get the IP addresses from a network interface.
+
+        Interfaces can hold multiple IP addresses. This method will return a
+        list with all addresses on this interface.
+
+        :param version: Address Family Version (4 or 6). This must be a integer
+                        and default is 4.
+        :return: IP address as string.
         """
-        cmd = "ip addr show"
+        if version not in [4, 6]:
+            raise NWException("Version {} not supported".format(version))
+
         try:
-            for line in self.session.cmd(cmd).stdout.decode("utf-8") \
-                                                    .splitlines():
-                if peer_ip in line:
-                    peer_interface = line.split()[-1]
-        except Exception as ex:  # pylint: disable=W0703
-            if peer_interface == "":
-                log.error("unable to get peer interface: %s", ex)
+            details = self._get_interface_details(version)
+            addr_info = details[0].get('addr_info')
+            if addr_info:
+                return [x.get('local') for x in addr_info]
+        except (NWException, IndexError):
+            msg = "Could not get ip addresses for {}".format(self.name)
+            log.debug(msg)
+            return []
+
+    def get_hwaddr(self):
+        """Get the Hardware Address (MAC) of this interface.
+
+        This method will try to get the address and if fails it will raise a
+        NWException.
+        """
+        cmd = "cat /sys/class/net/{}/address".format(self.name)
+        try:
+            return _run_command(cmd, self.remote_session)
+        except Exception as ex:
+            raise NWException("Failed to get hw address: {}".format(ex))
+
+    def get_link_state(self):
+        """Method used to get the current link state of this interface.
+
+        This method will return 'up', 'down' or 'unknown', based on the
+        network interface state. Or it will raise a NWException if is
+        unable to get the interface state.
+        """
+        cmd = "cat /sys/class/net/{}/operstate".format(self.name)
+        try:
+            return _run_command(cmd, self.remote_session)
+        except process.CmdError as e:
+            msg = ('Failed to get link state. Maybe the interface is '
+                   'missing. {}'.format(e))
+            raise NWException(msg)
+
+    def get_mtu(self):
+        """Return the current MTU value of this interface.
+        This method will try to get the current MTU value, if fails will
+        raise a NWException.
+        """
+        try:
+            return self._get_interface_details()[0].get('mtu')
+        except (NWException, IndexError):
+            raise NWException("Could not get MUT value.")
+
+    def ping_check(self, peer_ip, count=2, options=None):
+        """This method will try to ping a peer address (IPv4 or IPv6).
+
+        You should provide a IPv4 or IPV6 that would like to ping. This
+        method will try to ping the peer and if fails it will raise a
+        NWException.
+
+        :param peer_ip: Peer IP address (IPv4 or IPv6)
+        :param count: How many packets to send. Default is 2
+        :param options: ping command options. Default is None
+        """
+        cmd = "ping -I {} {} -c {}".format(self.name, peer_ip, count)
+        if options is not None:
+            cmd = "{} {}".format(cmd, options)
+        try:
+            _run_command(cmd, self.remote_session)
+        except Exception as ex:
+            raise NWException("Failed to ping: {}".format(ex))
+
+    def save(self, ipaddr, netmask):
+        """Save current interface IP Address to the system configuration file.
+
+        If the ipaddr is valid (currently being used by the interface)
+        this will try to save the current settings into /etc/. This
+        check is necessary to avoid inconsistency. Before save, you
+        should add_ipaddr, first.
+
+        Currently, only RHEL, Fedora and SuSE are supported. And this
+        will create a backup file of your current configuration if
+        found.
+
+        :param ipaddr : IP Address which need to configure for interface
+        :param netmask: Network mask which is associated to the provided IP
+        """
+        if ipaddr not in self.get_ipaddrs():
+            msg = ('ipaddr not configured on interface. To avoid '
+                   'inconsistency, please add the ipaddr first.')
+            raise NWException(msg)
+
+        current_distro = distro.detect()
+
+        filename = "ifcfg-{}".format(self.name)
+        if current_distro.name in ['rhel', 'fedora']:
+            path = "/etc/sysconfig/network-scripts"
+        elif current_distro.name == 'SuSE':
+            path = "/etc/sysconfig/network"
         else:
-            return peer_interface
+            msg = 'Distro not supported by API. Could not save ipaddr.'
+            raise NWException(msg)
+
+        self._write_to_file("{}/{}".format(path, filename),
+                            {'TYPE': self.if_type,
+                             'BOOTPROTO': 'none',
+                             'NAME': self.name,
+                             'DEVICE': self.name,
+                             'ONBOOT': 'yes',
+                             'IPADDR': ipaddr,
+                             'NETMASK': netmask,
+                             'IPV6INIT': 'yes',
+                             'IPV6_AUTOCONF': 'yes',
+                             'IPV6_DEFROUTE': 'yes'})
+
+    def set_mtu(self, mtu, timeout=30):
+        """Sets a new MTU value to this interface.
+
+        This method will try to set a new MTU value to this interface,
+        if fails it will raise a NWException. Also it will wait until
+        the Interface is up before returning or until timeout be
+        reached.
+
+        You must have sudo permissions to run this method on a host.
+
+        :param mtu:  mtu size that need to be set. This must be an int.
+        :param timeout: how many seconds to wait until the interface is
+                        up again. Default is 30.
+        """
+        cmd = "ip link set %s mtu %s" % (self.name, mtu)
+        _run_command(cmd, self.remote_session, sudo=True)
+        wait.wait_for(self.is_link_up, timeout=timeout)
+        if int(mtu) != self.get_mtu():
+            raise NWException("Failed to set MTU.")
+
+    def remove_ipaddr(self, ipaddr, netmask):
+        """Removes an IP address from this interface.
+
+        This method will try to remove the address from this interface
+        and if fails it will raise a NWException. Be careful, you can
+        lost connection.
+
+        You must have sudo permissions to run this method on a host.
+        """
+        ip = ip_interface("{}/{}".format(ipaddr, netmask))
+        cmd = 'ip addr del {} dev {}'.format(ip.compressed,
+                                             self.name)
+        try:
+            _run_command(cmd, self.remote_session, sudo=True)
+        except Exception as ex:
+            msg = 'Failed to remove ipaddr. {}'.format(ex)
+            raise NWException(msg)
 
 
-def is_interface_link_up(interface):
+class Host:
     """
-    Checks if the interface link is up
-    :param interface: name of the interface
-    :return: True if the interface's link comes up, False otherwise.
+    This class represents a Host.
+
+    A host can be local or remote. If you pass port, username, key or password,
+    a connection will attempt to be created.
+
+    During the initialization, all interfaces will be detected and available
+    via `interfaces` attribute.
+
+    So, for instance you could have a local and a remote host::
+
+        local = Host(host='foo', port=22, username='foo', password='bar')
+        remote = Host(host='bar')
+
+    You can iterate over the network interfaces of any host::
+
+        for i in remote.interfaces:
+            print(i.name, i.is_link_up())
     """
-    if 'up' in genio.read_file("/sys/class/net/%s/operstate" % interface):
-        log.info("Interface %s link is up", interface)
-        return True
-    return False
+
+    def __init__(self, host, port=22, username=None,
+                 key=None, password=None):
+        self.host = host
+        self.port = port
+        self.username = username
+        self.key = key
+        self.password = password
+        self.remote_session = None
+
+        self._connect()
+
+    def _connect(self):
+        if self.host and self.port and self.username:
+            try:
+                self.remote_session = Session(host=self.host,
+                                              port=self.port,
+                                              user=self.username,
+                                              key=self.key,
+                                              password=self.password)
+            except Exception as ex:
+                raise NWException("Could not connect to host: {}".format(ex))
+
+    @property
+    def interfaces(self):
+        cmd = 'ls /sys/class/net'
+        try:
+            names = _run_command(cmd, self.remote_session).split()
+        except Exception as ex:
+            raise NWException("Failed to get interfaces: {}".format(ex))
+
+        session = self.remote_session
+        return [NetworkInterface(if_name=name,
+                                 remote_session=session) for name in names]
+
+    def get_interface_by_ipaddr(self, ipaddr):
+        """Return an interface that has a specific ipaddr."""
+        for interface in self.interfaces:
+            if ipaddr in interface.get_ipaddrs():
+                return interface

--- a/avocado/utils/gdb.py
+++ b/avocado/utils/gdb.py
@@ -26,7 +26,7 @@ import socket
 import subprocess
 import tempfile
 
-from . import network
+from .network import ports
 from .external import gdbmi_parser
 
 #: Contains a list of binary names that should be run via the GNU debugger
@@ -633,7 +633,7 @@ class GDBServer:
         args += self.REQUIRED_ARGS
 
         if port is None:
-            self.port = network.find_free_port(*self.PORT_RANGE)
+            self.port = ports.find_free_port(*self.PORT_RANGE)
         else:
             self.port = port
         args.append(":%s" % self.port)

--- a/avocado/utils/network/common.py
+++ b/avocado/utils/network/common.py
@@ -1,0 +1,10 @@
+from .. import process
+
+
+# Probably this will be replaced by aexpect
+def _run_command(command, remote_session=None, sudo=False):
+    if remote_session:
+        if sudo:
+            command = "sudo {}".format(command)
+        return remote_session.cmd(command).stdout.decode('utf-8')
+    return process.system_output(command, sudo=sudo).decode('utf-8')

--- a/avocado/utils/network/exceptions.py
+++ b/avocado/utils/network/exceptions.py
@@ -1,0 +1,4 @@
+class NWException(Exception):
+    """
+    Base Exception Class for all exceptions
+    """

--- a/avocado/utils/network/hosts.py
+++ b/avocado/utils/network/hosts.py
@@ -1,0 +1,86 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+#
+# Copyright: 2019-2020 Red Hat Inc.
+# Authors : Beraldo Leal <bleal@redhat.com>
+
+"""
+This module provides an useful API for hosts in a network.
+"""
+
+from ..ssh import Session
+
+from .common import _run_command
+from .interfaces import NetworkInterface
+from .exceptions import NWException
+
+
+class Host:
+    """
+    This class represents a Host.
+
+    A host can be local or remote. If you pass port, username, key or password,
+    a connection will attempt to be created.
+
+    During the initialization, all interfaces will be detected and available
+    via `interfaces` attribute.
+
+    So, for instance you could have a local and a remote host::
+
+        local = Host(host='foo', port=22, username='foo', password='bar')
+        remote = Host(host='bar')
+
+    You can iterate over the network interfaces of any host::
+
+        for i in remote.interfaces:
+            print(i.name, i.is_link_up())
+    """
+
+    def __init__(self, host, port=22, username=None,
+                 key=None, password=None):
+        self.host = host
+        self.port = port
+        self.username = username
+        self.key = key
+        self.password = password
+        self.remote_session = None
+
+        self._connect()
+
+    def _connect(self):
+        if self.host and self.port and self.username:
+            try:
+                self.remote_session = Session(host=self.host,
+                                              port=self.port,
+                                              user=self.username,
+                                              key=self.key,
+                                              password=self.password)
+            except Exception as ex:
+                raise NWException("Could not connect to host: {}".format(ex))
+
+    @property
+    def interfaces(self):
+        cmd = 'ls /sys/class/net'
+        try:
+            names = _run_command(cmd, self.remote_session).split()
+        except Exception as ex:
+            raise NWException("Failed to get interfaces: {}".format(ex))
+
+        session = self.remote_session
+        return [NetworkInterface(if_name=name,
+                                 remote_session=session) for name in names]
+
+    def get_interface_by_ipaddr(self, ipaddr):
+        """Return an interface that has a specific ipaddr."""
+        for interface in self.interfaces:
+            if ipaddr in interface.get_ipaddrs():
+                return interface

--- a/avocado/utils/network/ports.py
+++ b/avocado/utils/network/ports.py
@@ -19,7 +19,7 @@ Module with network related utility functions
 import socket
 import random
 
-from .data_structures import Borg
+from ..data_structures import Borg
 
 #: Families taken into account in this class
 FAMILIES = (socket.AF_INET, socket.AF_INET6)


### PR DESCRIPTION
Multiple pull requests were trying to add more features to this library.
But because of a lack of convention, it was getting hard to understand
this and we were losing usability. Besides a complete rewrite here, this
pull request is a) adding a complete set of methods to handle network
interfaces parameters; b) adding a wait when setting MTU values on
interfaces; and c) better support for IPv6.
    
Thanks for @anascko, @vaishnavibhat, @PraveenPenguin, and @smruti77
