### PR TITLE
fixes CVE-2019-18874

### DIFF
--- a/requirements-selftests.txt
+++ b/requirements-selftests.txt
@@ -10,7 +10,7 @@ funcsigs>=0.4
 
 # To run make check
 aexpect==1.5.1
-psutil==5.4.7
+psutil==5.6.6
 
 # pycdlib is an optional requirement in production
 # but is necessary for selftests


### PR DESCRIPTION
psutils is only used by selftests but psutil through 5.6.5 can have a
double free.  This occurs because of refcount mishandling within a while
or for loop that converts system data into a Python object.

Signed-off-by: Beraldo Leal <bleal@redhat.com>