### PR TITLE
python warnings: fixes tests on python 3.5 and 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ env:
       AVOCADO_LOG_DEBUG=yes
       SELF_CHECK_CONTINUOUS=y
       AVOCADO_CHECK_LEVEL=1
-      PYTHONWARNINGS=ignore
 
 addons:
   apt:
@@ -34,7 +33,6 @@ matrix:
       arch: amd64
       env:
         - SELF_CHECK_CONTINUOUS=yes
-          PYTHONWARNINGS=ignore
       install:
         - pip install -r requirements-selftests.txt
         - pip install codecov

--- a/Makefile
+++ b/Makefile
@@ -138,11 +138,11 @@ AVOCADO_OPTIONAL_PLUGINS_TESTS=$(patsubst %,%/tests/, $(AVOCADO_OPTIONAL_PLUGINS
 endif
 check: clean develop
 	# Unless manually set, this is equivalent to AVOCADO_CHECK_LEVEL=0
-	export PYTHONWARNINGS=ignore;PYTHON=$(PYTHON) $(PYTHON) -m avocado nrun selftests/*.sh selftests/unit/ selftests/functional/ $(AVOCADO_OPTIONAL_PLUGINS_TESTS)
+	PYTHON=$(PYTHON) $(PYTHON) -m avocado nrun selftests/*.sh selftests/unit/ selftests/functional/ $(AVOCADO_OPTIONAL_PLUGINS_TESTS)
 	selftests/check_tmp_dirs
 
 check-full: clean develop
-	export PYTHONWARNINGS=ignore;PYTHON=$(PYTHON) AVOCADO_CHECK_LEVEL=3 selftests/checkall
+	PYTHON=$(PYTHON) AVOCADO_CHECK_LEVEL=3 selftests/checkall
 	selftests/check_tmp_dirs
 
 develop:


### PR DESCRIPTION
For some reason runing tests with PYTHONWARNINGS=ignore on python3.6
will hang some tests (this is not happening on 3.7). In anycase, we
should not ignore warnings during the tests but writer proper tests to
take this warnings into consideration.

Signed-off-by: Beraldo Leal <bleal@redhat.com>