### PR TITLE
SPEC: remove PYTHONWARNINGS from rpm builds

### DIFF
--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -59,7 +59,7 @@
 Summary: Framework with tools and libraries for Automated Testing
 Name: python-%{srcname}
 Version: 76.0
-Release: 0%{?gitrel}%{?dist}
+Release: 1%{?gitrel}%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.github.io/
@@ -329,7 +329,7 @@ popd
 # unittests needs to be a Python specific one on Fedora >= 28.  Let's
 # use the one that was setup in the source tree by the "setup.py
 # develop --user" step and is guaranteed to be version specific.
-LANG=en_US.UTF-8 AVOCADO_CHECK_LEVEL=0 UNITTEST_AVOCADO_CMD=$HOME/.local/bin/avocado PYTHONWARNINGS=ignore %{__python3} selftests/run
+LANG=en_US.UTF-8 AVOCADO_CHECK_LEVEL=0 UNITTEST_AVOCADO_CMD=$HOME/.local/bin/avocado %{__python3} selftests/run
 %endif
 
 %files -n python3-%{srcname}
@@ -604,6 +604,9 @@ Again Shell code (and possibly other similar shells).
 %{_libexecdir}/avocado*
 
 %changelog
+* Mon Mar 16 2020 Cleber Rosa <cleber@redhat.com> - 76.0-1
+- Removed PYTHONWARNINGS environment variable when running tests
+
 * Fri Feb 21 2020 Cleber Rosa <cleber@redhat.com> - 76.0-0
 - New release
 


### PR DESCRIPTION
Commit 8f658866 removed most of the PYTHONWARNINGS set during
selftest executions, but missed this one in the spec file.

Signed-off-by: Cleber Rosa <crosa@redhat.com>