### PR TITLE
utils/network: fixed long string on warning message

### DIFF
--- a/avocado/utils/configure_network.py
+++ b/avocado/utils/configure_network.py
@@ -27,7 +27,7 @@ from . import process
 from . import genio
 from .ssh import Session
 
-warnings.warn(("This module will be deprecated soon. Please use ",
+warnings.warn(("This module will be deprecated soon. Please use "
                "avocado.utils.network package."),
               DeprecationWarning,
               stacklevel=2)

--- a/avocado/utils/network/__init__.py
+++ b/avocado/utils/network/__init__.py
@@ -5,7 +5,7 @@ from .ports import find_free_port  # noqa pylint: disable=unused-import
 from .ports import find_free_ports  # noqa pylint: disable=unused-import
 from .ports import PortTracker  # noqa pylint: disable=unused-import
 
-warnings.warn(("Network as module will be deprecated, please use ",
+warnings.warn(("Network as module will be deprecated, please use "
                "utils.network.ports instead."),
               DeprecationWarning,
               stacklevel=2)


### PR DESCRIPTION
By mistake I introduced a comma to split a long string. This was
sending a tuple to warnings.war() method. This change will just remove
the comma from the long string.

Signed-off-by: Beraldo Leal <bleal@redhat.com>