### PR TITLE
nrruner: forces runnable-run to return the correct returncode

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -742,8 +742,10 @@ class BaseRunnerApp:
         """
         runnable = Runnable.from_args(args)
         runner = self.get_runner_from_runnable(runnable)
+        status = {}
         for status in runner.run():
             self.echo(status)
+        return status.get('returncode', 0)
 
     def command_runnable_run_recipe(self, args):
         """
@@ -809,7 +811,7 @@ class RunnerApp(BaseRunnerApp):
 
 def main(app_class=RunnerApp):
     app = app_class(print)
-    app.run()
+    return app.run()
 
 
 if __name__ == '__main__':

--- a/avocado/core/nrunner_tap.py
+++ b/avocado/core/nrunner_tap.py
@@ -77,7 +77,7 @@ class RunnerApp(nrunner.BaseRunnerApp):
 
 
 def main():
-    nrunner.main(RunnerApp)
+    return nrunner.main(RunnerApp)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When running runners from command line the return code is always 0, even
when the runner fails to execute something. This change will modify
nrunner to return the returncode of a runner. As example I'm also
changing tap-runner to use this feature.

Signed-off-by: Beraldo Leal <bleal@redhat.com>