### PR TITLE
Plugin Asset: reset method pointer when parsing a new class.

### DIFF
--- a/avocado/plugins/assets.py
+++ b/avocado/plugins/assets.py
@@ -135,6 +135,8 @@ class FetchAssetHandler(ast.NodeVisitor):  # pylint: disable=R0902
             if self.klass and node.name != self.klass:
                 return
 
+            # reset the curret method pointer
+            self.current_method = None
             self.current_klass = node.name
             self.asgmts[self.current_klass] = {}
             self.generic_visit(node)


### PR DESCRIPTION
If there are multiple test classes in the same file, the current method pointer is not reset when parsing the next test class in the file. This may cause a KeyError exception when there is an assignment in a class attribute in the following class.

Signed-off-by: Willian Rampazzo <willianr@redhat.com>