### PR TITLE
nrunner: use current PATH on avocado-runner-exec and avocado-runner-tap

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -371,6 +371,8 @@ class ExecRunner(BaseRunner):
             current.update(self.runnable.kwargs)
             env = current
 
+        if env and 'PATH' not in env:
+            env['PATH'] = os.environ.get('PATH')
         process = subprocess.Popen(
             [self.runnable.uri] + list(self.runnable.args),
             stdin=subprocess.DEVNULL,

--- a/avocado/core/nrunner_tap.py
+++ b/avocado/core/nrunner_tap.py
@@ -1,4 +1,5 @@
 import io
+import os
 import subprocess
 import time
 
@@ -31,6 +32,8 @@ class TAPRunner(nrunner.BaseRunner):
     """
     def run(self):
         env = self.runnable.kwargs or None
+        if env and 'PATH' not in env:
+            env['PATH'] = os.environ.get('PATH')
         process = subprocess.Popen(
             [self.runnable.uri] + list(self.runnable.args),
             stdin=subprocess.DEVNULL,


### PR DESCRIPTION
Sometimes, third-party applications and/or tests will call binaries
without a full path. They need a previous path to be set.  When running
an `avocado-runner-exec` or `avocado-runner-tap` we use `kwargs` as
environment variables. But `env` argument from `subprocess.run()` will
pass to the subprocess only the desired dict. This PR fixes that.

Signed-off-by: Beraldo Leal <bleal@redhat.com>