### PR TITLE
hintfile: added the Avocado hint file concept and parser

### DIFF
--- a/avocado/core/parser.py
+++ b/avocado/core/parser.py
@@ -18,11 +18,17 @@ Avocado application command line parsing.
 
 import argparse
 
+from configparser import ConfigParser
+from glob import glob
+
 from . import exit_codes
 from . import varianter
 from . import settings
 from .future.settings import settings as future_settings
+from .nrunner import Runnable
 from .output import BUILTIN_STREAMS, BUILTIN_STREAM_SETS, LOG_UI
+from .resolver import ReferenceResolution
+from .resolver import ReferenceResolutionResult
 from .version import VERSION
 
 PROG = 'avocado'
@@ -172,3 +178,94 @@ class Parser:
             self.application.error(msg)
         # from this point on, config is a dictionary based on a argparse.Namespace
         self.config = vars(args)
+
+
+class HintParser:
+    def __init__(self, filename):
+        self.filename = filename
+        self.config = None
+        self.hints = []
+        self._parse()
+
+    def _get_args_from_section(self, section):
+        args = self.config.get(section, 'args')
+        if args == '$test':
+            return [args]
+        return args.split(',')
+
+    def _get_kwargs_from_section(self, section):
+        result = {}
+        kwargs = self.config.get(section, 'kwargs', fallback='')
+        for kwarg in kwargs.split(','):
+            if kwarg == '':
+                continue
+            key, value = kwarg.split('=')
+            result[key] = value
+        return result
+
+    def _get_resolutions_by_kind(self, kind, paths):
+        self.validate_kind_section(kind)
+
+        resolutions = []
+        uri = self._get_uri_from_section(kind)
+        args = self._get_args_from_section(kind)
+        kwargs = self._get_kwargs_from_section(kind)
+        success = ReferenceResolutionResult.SUCCESS
+        if uri == '$test':
+            for path in paths:
+                runnable = Runnable(kind, path, *args, **kwargs)
+                resolutions.append(ReferenceResolution(reference=path,
+                                                       result=success,
+                                                       resolutions=[runnable],
+                                                       origin='hint-file'))
+        elif '$test' in args:
+            for path in paths:
+                runnable = Runnable(kind, uri, path, **kwargs)
+                resolutions.append(ReferenceResolution(reference=path,
+                                                       result=success,
+                                                       resolutions=[runnable],
+                                                       origin='hint-file'))
+        return resolutions
+
+    def _get_uri_from_section(self, section):
+        return self.config.get(section, 'uri')
+
+    def _parse(self):
+        self.config = ConfigParser()
+        config_paths = self.config.read(self.filename)
+        if not config_paths:
+            raise settings.ConfigFileNotFound(self.filename)
+
+    def get_resolutions(self):
+        """Return a list of resolutions based on the file definitions."""
+        resolutions = []
+        for kind in self.config['kinds']:
+            files = self.config.get('kinds', kind)
+            resolutions.extend(self._get_resolutions_by_kind(kind,
+                                                             glob(files)))
+        return resolutions
+
+    def validate_kind_section(self, kind):
+        """Validates a specific "kind section".
+
+        This method will raise a `settings.SettingsError` if any problem is
+        found on the file.
+
+        :param kind: a string with the specific section.
+        """
+        if kind not in self.config:
+            msg = 'Section {} is not defined. Please check your hint file.'
+            raise settings.SettingsError(msg.format(kind))
+
+        uri = self._get_uri_from_section(kind)
+        args = self._get_args_from_section(kind)
+        kwargs = self._get_kwargs_from_section(kind)
+        if uri is None:
+            msg = "uri needs to be defined inside {}".format(kind)
+            raise settings.SettingsError(msg)
+
+        count = [uri, *args, kwargs].count('$test')
+        if count != 1:
+            msg = ('$test must be used in only one variable. '
+                   'Choose to use with uri or args.')
+            raise settings.SettingsError(msg)

--- a/avocado/etc/avocado/.avocado.hint.example
+++ b/avocado/etc/avocado/.avocado.hint.example
@@ -1,0 +1,29 @@
+# This is just a example file. Insert this file inside your project root
+# folder and Avocado Next Runner will use it.
+#
+# Each "kind" must have a section with the same name. Here, note that
+# tap has a section named 'tap'. On that section you need to specify
+# uri, args and kwargs for your specific runner kind.
+
+[kinds]
+# Declare here all your tests by types (kind).
+# You can use lists and wildcards. For each test Avocado will try to call the
+# specific runner.
+tap = ./scripts/*/*.t
+
+[tags]
+# You can use tags to a better organization. All tests defined
+# here must be classified before on 'tests' section.
+# Note: Tags is not being used yet.
+domain = ./scripts/domain/*.t
+network = ./scripts/networks/*.t
+slow = ./scripts/domain/*.t,./scripts/networks/*.t
+
+[tap]
+# Configure here uri, arg and kwargs for tap. If you don't have uri, arg
+# and kwargs configure, Avocado will try to run the tests as executables
+# without args and kwargs. You can use "$test" on uri,arg or kwargs and
+# Avocado will iterate over it.
+uri = perl
+args = $test
+kwargs = PATH=$PATH,PERL5LIB=./lib,LIBVIRT_TCK_CONFIG=./conf/default.cfg,LIBVIRT_TCK_AUTOCLEAN=1

--- a/avocado/plugins/nlist.py
+++ b/avocado/plugins/nlist.py
@@ -20,6 +20,7 @@ from avocado.core import resolver
 from avocado.core import output
 from avocado.core import parser_common_args
 from avocado.core.output import LOG_UI
+from avocado.core.parser import HintParser
 from avocado.core.tags import filter_test_tags_runnable
 from avocado.utils import astring
 
@@ -70,7 +71,12 @@ class List(CLICmd):
     def run(self, config):
         references = config.get('nlist.references')
         verbose = config.get('nlist.verbose')
-        resolutions = resolver.resolve(references)
+        hint_filepath = '.avocado.hint'
+        if os.path.exists(hint_filepath):
+            hint = HintParser(hint_filepath)
+            resolutions = hint.get_resolutions()
+        else:
+            resolutions = resolver.resolve(references)
         matrix, stats, tag_stats, resolution_matrix = self._get_resolution_matrix(config,
                                                                                   resolutions,
                                                                                   verbose)

--- a/avocado/plugins/nrun.py
+++ b/avocado/plugins/nrun.py
@@ -11,6 +11,7 @@ from avocado.core import parser_common_args
 from avocado.core import resolver
 from avocado.core.future.settings import settings
 from avocado.core.output import LOG_UI
+from avocado.core.parser import HintParser
 from avocado.core.plugin_interfaces import CLICmd
 from avocado.utils import path as utils_path
 
@@ -161,7 +162,12 @@ class NRun(CLICmd):
             stderr=asyncio.subprocess.PIPE)
 
     def run(self, config):
-        resolutions = resolver.resolve(config.get('nrun.references'))
+        hint_filepath = '.avocado.hint'
+        if os.path.exists(hint_filepath):
+            hint = HintParser(hint_filepath)
+            resolutions = hint.get_resolutions()
+        else:
+            resolutions = resolver.resolve(config.get('nrun.references'))
         tasks = job.resolutions_to_tasks(resolutions, config)
         self.pending_tasks = check_tasks_requirements(   # pylint: disable=W0201
             tasks,


### PR DESCRIPTION
In order to facilitate the Avocado resolution test process, we are introducing the `.avocado.hint` file concept. Basically you must create this file inside your project and Avocado next runner commands will take this "hint file" into consideration. See an example of this file inside conf/avocado/.

This also changes nrun and nlist to look at this file.