### PR TITLE
[LTS] Specific version for jinja2 package

### DIFF
--- a/optional_plugins/html/setup.py
+++ b/optional_plugins/html/setup.py
@@ -24,7 +24,7 @@ setup(name='avocado-framework-plugin-result-html',
       url='http://avocado-framework.github.io/',
       packages=find_packages(),
       include_package_data=True,
-      install_requires=['avocado-framework', 'jinja2<3.0.0'],
+      install_requires=['avocado-framework', 'markupsafe<2.0.0', 'jinja2<3.0.0'],
       entry_points={
           'avocado.plugins.cli': [
               'html = avocado_result_html:HTML',

--- a/optional_plugins/html/setup.py
+++ b/optional_plugins/html/setup.py
@@ -24,7 +24,7 @@ setup(name='avocado-framework-plugin-result-html',
       url='http://avocado-framework.github.io/',
       packages=find_packages(),
       include_package_data=True,
-      install_requires=['avocado-framework', 'jinja2'],
+      install_requires=['avocado-framework', 'jinja2<3.0.0'],
       entry_points={
           'avocado.plugins.cli': [
               'html = avocado_result_html:HTML',


### PR DESCRIPTION
This is the LTS backport of https://github.com/avocado-framework/avocado/pull/3576 and https://github.com/avocado-framework/avocado/pull/3703, due to jinja2 and some of its dependencies have dropped support of python 2.7.