### PR TITLE
RFC: Add avocado plugin to install custom python packages for tests

### DIFF
--- a/avocado/etc/avocado/avocado.conf
+++ b/avocado/etc/avocado/avocado.conf
@@ -122,3 +122,21 @@ order = ['avocado-instrumented', 'python-unittest', 'glib', 'robot', 'exec-test'
 # Accepted values: all, stdout, stderr.
 # Defaults to all.
 # skip_location = all
+#
+#
+[job.pipinst]
+# plugin to install custom python packages required for tests
+# Default: False, either enable it by changing below boolean
+# to True or use --pipinstall while running job
+enabled = False
+# List of python packages to be installed as comma seperated
+# string.
+packages = netaddr,configparser
+# Flag(boolean) to set whether or not uninstall packages after
+# the job run.
+# Default: True
+uninstall = True
+# Flag(boolean) to set whether or not job to be proceeded
+# incase of failure caused during package installation.
+# bydefault it will proceed, enable below flag otherwise.
+exit_job_on_failure = False

--- a/avocado/plugins/pipinst.py
+++ b/avocado/plugins/pipinst.py
@@ -1,0 +1,61 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: 2020 IBM Corp
+# Author: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>
+"""
+Install additional python packages required for test using pip
+"""
+
+import sys
+
+from avocado.core import exit_codes
+from avocado.core.plugin_interfaces import JobPre
+from avocado.core.plugin_interfaces import JobPost
+from avocado.core.settings import settings
+from avocado.utils import process
+
+
+class PipInst(JobPre, JobPost):
+
+    name = 'PipInst'
+    description = 'Install new python packages required for test'
+
+    def __init__(self):
+        self.enabled = settings.get_value('job.pipinst', 'enabled',
+                                          key_type='bool', default=False)
+        self.uninstall = settings.get_value('job.pipinst', 'uninstall',
+                                            key_type='bool', default=False)
+        self.packages = settings.get_value('job.pipinst', 'packages',
+                                           key_type='str', default="").split(',')
+        self.exit_job = settings.get_value('job.pipinst', 'exit_job_on_failure',
+                                           key_type='bool', default=False)
+
+    def pre(self, job):
+        self.enabled = job.config.get('job.pipinst.enabled')
+        if not self.enabled:
+            return
+        for item in self.packages:
+            output = process.run('pip install --user %s' % item,
+                                 ignore_status=True,
+                                 shell=True)
+            if output.exit_status != 0 and self.exit_job:
+                print("Exiting job due to pipinstall failure")
+                sys.exit(exit_codes.AVOCADO_JOB_FAIL)
+
+    def post(self, job):
+        self.enabled = job.config.get('job.pipinst.enabled')
+        if not (self.enabled and self.uninstall):
+            return
+        for item in self.packages:
+            process.run('pip uninstall -y %s' % item,
+                        ignore_status=True,
+                        shell=True)

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -193,6 +193,16 @@ class Run(CLICmd):
                                  short_arg='-S',
                                  long_arg='--sysinfo')
 
+        help_msg = ('Enable or disable pipinstall of custom packages'
+                    ' needed for a test job')
+        settings.register_option(section='job.pipinst',
+                                 key='enabled',
+                                 default=False,
+                                 key_type=bool,
+                                 help_msg=help_msg,
+                                 parser=parser,
+                                 long_arg='--pipinstall')
+
         help_msg = ('Defines the order of iterating through test suite '
                     'and test variants')
         settings.register_option(section='run',

--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,7 @@ if __name__ == '__main__':
                   'human = avocado.plugins.human:HumanJob',
                   'merge_files = avocado.plugins.expected_files_merge:FilesMerge',
                   'sysinfo = avocado.plugins.sysinfo:SysInfoJob',
+                  'pipinst = avocado.plugins.pipinst:PipInst',
                   ],
               'avocado.plugins.result': [
                   'xunit = avocado.plugins.xunit:XUnitResult',


### PR DESCRIPTION
This patch adds support for installing custom python packages
which are not available on the environment, as provided by users
if enabled through a plugin.

Background, some of the python modules imported by the tests
are not available in default installation of certain environment,
due to which the testcase would fail and these modules(python packages)
can not be installed as a part of test as it would be importing
them as part of test, so only option is to install them before even
starting the test, so this patch tries to add a avocado plugin
to address this issue, by taking the list of python packages from
user through avocado config, it will install them before starting
the job run and optionally it will exit job incase of failure and
optionally it will uninstall packages during end of job run.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>