### PR TITLE
hintfile: added the Avocado hint file concept and parser - v2

### DIFF
--- a/avocado/core/resolver.py
+++ b/avocado/core/resolver.py
@@ -160,8 +160,14 @@ def _extend_directory(path):
     return paths
 
 
-def resolve(references):
+def resolve(references, hint=None):
     resolutions = []
+    hint_resolutions = []
+    hint_references = {}
+
+    if hint:
+        hint_resolutions = hint.get_resolutions()
+        hint_references = {r.reference: r for r in hint_resolutions}
 
     if references:
         # should be initialized with args, to define the behavior
@@ -175,6 +181,9 @@ def resolve(references):
             extended_references.extend(_extend_directory(reference))
 
         for reference in extended_references:
-            resolutions.extend(resolver.resolve(reference))
+            if reference in hint_references:
+                resolutions.append(hint_references[reference])
+            else:
+                resolutions.extend(resolver.resolve(reference))
 
     return resolutions

--- a/avocado/plugins/nlist.py
+++ b/avocado/plugins/nlist.py
@@ -20,6 +20,7 @@ from avocado.core import resolver
 from avocado.core import output
 from avocado.core import parser_common_args
 from avocado.core.output import LOG_UI
+from avocado.core.parser import HintParser
 from avocado.core.tags import filter_test_tags_runnable
 from avocado.utils import astring
 
@@ -70,7 +71,12 @@ class List(CLICmd):
     def run(self, config):
         references = config.get('nlist.references')
         verbose = config.get('nlist.verbose')
-        resolutions = resolver.resolve(references)
+        hint_filepath = '.avocado.hint'
+        if os.path.exists(hint_filepath):
+            hint = HintParser(hint_filepath)
+            resolutions = resolver.resolve(references, hint)
+        else:
+            resolutions = resolver.resolve(references)
         matrix, stats, tag_stats, resolution_matrix = self._get_resolution_matrix(config,
                                                                                   resolutions,
                                                                                   verbose)

--- a/avocado/plugins/nrun.py
+++ b/avocado/plugins/nrun.py
@@ -11,6 +11,7 @@ from avocado.core import parser_common_args
 from avocado.core import resolver
 from avocado.core.future.settings import settings
 from avocado.core.output import LOG_UI
+from avocado.core.parser import HintParser
 from avocado.core.plugin_interfaces import CLICmd
 from avocado.utils import path as utils_path
 
@@ -170,7 +171,12 @@ class NRun(CLICmd):
             stderr=asyncio.subprocess.PIPE)
 
     def run(self, config):
-        resolutions = resolver.resolve(config.get('nrun.references'))
+        hint_filepath = '.avocado.hint'
+        if os.path.exists(hint_filepath):
+            hint = HintParser(hint_filepath)
+            resolutions = resolver.resolve(config.get('nrun.references'), hint)
+        else:
+            resolutions = resolver.resolve(config.get('nrun.references'))
         tasks = job.resolutions_to_tasks(resolutions, config)
         self.pending_tasks = check_tasks_requirements(   # pylint: disable=W0201
             tasks,

--- a/examples/.avocado.hint.example
+++ b/examples/.avocado.hint.example
@@ -1,0 +1,29 @@
+# This is just a example file. Insert this file inside your project root
+# folder and Avocado Next Runner will use it.
+#
+# Each "kind" must have a section with the same name. Here, note that
+# tap has a section named 'tap'. On that section you need to specify
+# uri, args and kwargs for your specific runner kind.
+
+[kinds]
+# Declare here all your tests by types (kind).
+# You can use lists and wildcards. For each test Avocado will try to call the
+# specific runner.
+tap = ./scripts/*/*.t
+
+[tags]
+# You can use tags to a better organization. All tests defined
+# here must be classified before on 'tests' section.
+# Note: Tags is not being used yet.
+domain = ./scripts/domain/*.t
+network = ./scripts/networks/*.t
+slow = ./scripts/domain/*.t,./scripts/networks/*.t
+
+[tap]
+# Configure here uri, arg and kwargs for tap. If you don't have uri, arg and
+# kwargs configure, Avocado will try to run the tests as executables without
+# args and kwargs. You can use "$testpath" on uri,arg or kwargs and Avocado
+# will iterate over it.
+uri = perl
+args = $testpath
+kwargs = PATH=/usr/bin:/usr/sbin,PERL5LIB=./lib,LIBVIRT_TCK_CONFIG=./conf/default.cfg,LIBVIRT_TCK_AUTOCLEAN=1


### PR DESCRIPTION
In order to facilitate the Avocado resolution test process, we are introducing the `.avocado.hint` file concept. Basically you must create this file inside your project and Avocado next runner commands will take this "hint file" into consideration. See an example of this file inside conf/avocado/.

This also changes nrun and nlist to look at this file.

##### Changes from v1:

 * Renamed the var name (`$test` -> `$testpath`);
 * Removed restriction on `$testpath`, now you can use in any of `uri`, `args` and `kwargs`;
 * Moved example file to `examples/`
 * Improved the resolution to merge `references` and `.avocado.hint` file
