### PR TITLE
vmimage: add complete online coverage

### DIFF
--- a/avocado/plugins/vmimage.py
+++ b/avocado/plugins/vmimage.py
@@ -5,7 +5,7 @@ import re
 from avocado.core.future.settings import settings
 from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLICmd
-from avocado.core import data_dir, output
+from avocado.core import data_dir, exit_codes, output
 from avocado.utils import vmimage, astring
 
 
@@ -150,5 +150,7 @@ class VMimage(CLICmd):
                 image = download_image(name, version, arch)
                 LOG_UI.debug("The image was downloaded:")
             except AttributeError:
-                LOG_UI.debug("The image couldn't be downloaded:")
+                LOG_UI.debug("The requested image could not be downloaded")
+                return exit_codes.AVOCADO_FAIL
             display_images_list([image])
+        return exit_codes.AVOCADO_ALL_OK

--- a/avocado/utils/vmimage.py
+++ b/avocado/utils/vmimage.py
@@ -272,6 +272,14 @@ class UbuntuImageProvider(ImageProviderBase):
         self.url_images = self.url_versions + 'releases/{version}/release/'
         self.image_pattern = 'ubuntu-(?P<version>{version})-server-cloudimg-(?P<arch>{arch}).img'
 
+    def get_versions(self):
+        """
+        Return all available versions for the current parameters
+        """
+        parser = VMImageHtmlParser(self.version_pattern)
+        self._feed_html_parser(self.url_versions, parser)
+        return parser.items
+
 
 class DebianImageProvider(ImageProviderBase):
     """

--- a/avocado/utils/vmimage.py
+++ b/avocado/utils/vmimage.py
@@ -338,10 +338,25 @@ class OpenSUSEImageProvider(ImageProviderBase):
     def version_pattern(self):
         return '^Leap_%s' % self._version
 
+    @staticmethod
+    def _convert_version_numbers(versions):
+        """
+        Return the pure version numbers
+
+        The version pattern return Leap_15.0, Leap_42.0, Leap_XY.Z,
+        but the actual version will numeric versions only
+        """
+        pattern = r'(^Leap_)?([0-9{2}.[0-9]{1})'
+        replace = r'\2'
+        return [float(re.sub(pattern, replace, str(v))) for v in versions]
+
+    def get_versions(self):
+        versions = super(OpenSUSEImageProvider, self).get_versions()
+        return self._convert_version_numbers(versions)
+
     def get_best_version(self, versions):
-        # versions pattern equals Leap_15.0, Leap_42.0, Leap_XY.Z
-        version_numbers = [float(v.split('_')[1]) for v in versions]
-        if self._version.startswith('4'):
+        version_numbers = self._convert_version_numbers(versions)
+        if str(self._version).startswith('4'):
             version_numbers = [v for v in version_numbers if v >= 40.0]
         else:
             version_numbers = [v for v in version_numbers if v < 40.0]

--- a/avocado/utils/vmimage.py
+++ b/avocado/utils/vmimage.py
@@ -111,16 +111,15 @@ class ImageProviderBase:
     def get_best_version(self, versions):
         return max(versions)
 
-    def get_version(self):
+    def get_versions(self):
         """
-        Probes the higher version available for the current parameters.
+        Return all available versions for the current parameters
         """
         parser = VMImageHtmlParser(self.version_pattern)
-
         self._feed_html_parser(self.url_versions, parser)
 
+        resulting_versions = []
         if parser.items:
-            resulting_versions = []
             for version in parser.items:
                 # Trying to convert version to int or float so max()
                 # can compare numerical values.
@@ -134,6 +133,15 @@ class ImageProviderBase:
                     except ValueError:
                         # So it's just a string
                         resulting_versions.append(version)
+
+        return resulting_versions
+
+    def get_version(self):
+        """
+        Probes the higher version available for the current parameters.
+        """
+        resulting_versions = self.get_versions()
+        if resulting_versions:
             self._best_version = self.get_best_version(resulting_versions)
             return self._best_version
         else:

--- a/avocado/utils/vmimage.py
+++ b/avocado/utils/vmimage.py
@@ -280,7 +280,7 @@ class DebianImageProvider(ImageProviderBase):
 
     name = 'Debian'
 
-    def __init__(self, version='[0-9]+.[0-9]+.[0-9]+-.*', build=None,
+    def __init__(self, version='[0-9]+.[0-9]+.[0-9]+.*', build=None,
                  arch=os.uname()[4]):
         # Debian uses 'amd64' instead of 'x86_64'
         if arch == 'x86_64':

--- a/avocado/utils/vmimage.py
+++ b/avocado/utils/vmimage.py
@@ -250,6 +250,13 @@ class CentOSImageProvider(ImageProviderBase):
         self.url_images = self.url_versions + '{version}/images/'
         self.image_pattern = 'CentOS-(?P<version>{version})-(?P<arch>{arch})-GenericCloud-(?P<build>{build}).qcow2.xz$'
 
+    def get_image_url(self):
+        if int(self.version) >= 8:
+            self.build = r'[\d\.\-]+'
+            self.url_images = self.url_versions + '{version}/{arch}/images/'
+            self.image_pattern = 'CentOS-(?P<version>{version})-GenericCloud-(?P<build>{build}).(?P<arch>{arch}).qcow2$'
+        return super(CentOSImageProvider, self).get_image_url()
+
 
 class UbuntuImageProvider(ImageProviderBase):
     """

--- a/jobs/release.py
+++ b/jobs/release.py
@@ -1,0 +1,20 @@
+#!/bin/env python3
+
+import os
+import sys
+
+from avocado.core.job import Job
+
+
+ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+RELEASE_TESTS_DIR = os.path.join(os.path.join(ROOT_DIR, 'selftests', 'release'))
+
+CONFIG = {
+    'run.references': [os.path.join(RELEASE_TESTS_DIR, 'vmimage.py')],
+    'mux_yaml': [os.path.join(RELEASE_TESTS_DIR, 'vmimage.py.data', 'variants.yml')],
+    }
+
+
+if __name__ == '__main__':
+    with Job(CONFIG) as j:
+        sys.exit(j.run())

--- a/selftests/functional/test_plugin_vmimage.py
+++ b/selftests/functional/test_plugin_vmimage.py
@@ -3,6 +3,7 @@ import os
 import tempfile
 import unittest.mock
 
+from avocado.core import exit_codes
 from avocado.utils import process, path
 from .. import AVOCADO, temp_dir_prefix
 
@@ -71,6 +72,12 @@ class VMImagePlugin(unittest.TestCase):
                    "30 --arch x86_64" % (AVOCADO, self.config_file.name)
         result = process.run(cmd_line)
         self.assertIn(expected_output, result.stdout_text)
+
+    def test_download_image_fail(self):
+        cmd_line = "%s --config %s vmimage get --distro=SHOULD_NEVER_EXIST " \
+                   "999 --arch zzz_64" % (AVOCADO, self.config_file.name)
+        result = process.run(cmd_line, ignore_status=True)
+        self.assertEqual(result.exit_status, exit_codes.AVOCADO_FAIL)
 
     def test_list_images(self):
         expected_output = "Fedora-Cloud-Base-30-1.2.x86_64.qcow2"

--- a/selftests/release/vmimage.py
+++ b/selftests/release/vmimage.py
@@ -1,0 +1,74 @@
+from avocado import Test
+from avocado import fail_on
+from avocado.utils import vmimage
+from avocado.utils import process
+
+from urllib.request import urlopen
+from urllib.error import HTTPError
+
+
+class Base(Test):
+    """
+    Tests if avocado.utils.vmimage providers are current and can reach images
+
+    :avocado: tags=network
+    """
+
+    DEFAULTS = {'name': 'fedora',
+                'version': '31',
+                'build': None,
+                'arch': 'x86_64'}
+
+    def setUp(self):
+        self.vmimage_name = self.params.get('name',
+                                            default=self.DEFAULTS.get('name'))
+        self.vmimage_version = self.params.get('version',
+                                               default=self.DEFAULTS.get('version'))
+        self.vmimage_build = self.params.get('build',
+                                             default=self.DEFAULTS.get('build'))
+        # This is the "standard" archtiecture name
+        arch = self.params.get('arch', path='*/architectures/*',
+                               default=self.DEFAULTS.get('arch'))
+        # Distros may use slightly different values for their architecture names.
+        # For instance, Cirros ppc images are called powerpc, so we look
+        distro_arch_path = '/run/distro/%s/%s/*' % (self.vmimage_name, arch)
+        self.vmimage_arch = self.params.get('arch', path=distro_arch_path, default=arch)
+
+
+class Provider(Base):
+    def setUp(self):
+        super(Provider, self).setUp()
+        self.vmimage_provider = vmimage.get_best_provider(self.vmimage_name,
+                                                          self.vmimage_version,
+                                                          self.vmimage_build,
+                                                          self.vmimage_arch)
+        self.log.info(self.vmimage_provider)
+
+    @fail_on(HTTPError)
+    def test_url_versions(self):
+        """
+        Tests that the version url is reachable
+        """
+        urlopen(self.vmimage_provider.url_versions).read()
+
+    def test_version(self):
+        """
+        Tests that the version set is found in by the provider
+        """
+        self.assertIn(str(self.vmimage_version),
+                      [str(v) for v in self.vmimage_provider.get_versions()])
+
+
+class Image(Base):
+    @fail_on(AttributeError)
+    def test_get(self):
+        vmimage.get(self.vmimage_name, self.vmimage_version,
+                    self.vmimage_build, self.vmimage_arch)
+
+
+class ImageFunctional(Base):
+    @fail_on(process.CmdError)
+    def test_get(self):
+        cmd = 'avocado vmimage get --distro=%s --distro-version=%s --arch=%s'
+        cmd %= (self.vmimage_name, self.vmimage_version, self.vmimage_arch)
+        process.run(cmd)

--- a/selftests/release/vmimage.py.data/variants.yml
+++ b/selftests/release/vmimage.py.data/variants.yml
@@ -1,0 +1,105 @@
+distro: !mux
+  centos:
+    name: centos
+    !filter-out : /run/architectures/arm
+    !filter-out : /run/architectures/i386
+    !filter-out : /run/architectures/ppc
+    !filter-out : /run/architectures/ppc64
+    !filter-out : /run/architectures/s390x
+    version: !mux
+      8:
+        version: 8
+      7:
+        !filter-out : /run/architectures/aarch64
+        !filter-out : /run/architectures/ppc64le
+        !filter-out : /run/architectures/s390x
+        version: 7
+  cirros:
+    name: cirros
+    !filter-out : /run/architectures/s390x
+    ppc:
+      arch: powerpc
+    version: !mux
+      0.5.1:
+        version: 0.5.1
+      0.5.0:
+        version: 0.5.0
+      0.4.0:
+        version: 0.4.0
+  debian:
+    name: debian
+    !filter-out : /run/architectures/arm
+    !filter-out : /run/architectures/i386
+    !filter-out : /run/architectures/ppc
+    !filter-out : /run/architectures/ppc64
+    !filter-out : /run/architectures/ppc64le
+    !filter-out : /run/architectures/s390x
+    aarch64:
+      arch: arm64
+    x86_64:
+      arch: amd64
+    version: !mux
+      9.12.1-20200328:
+        version: 9.12.1-20200328
+      10.3.1:
+        version: 10.3.1-20200328
+  fedora:
+    name: fedora
+    !filter-out : /run/architectures/arm
+    !filter-out : /run/architectures/i386
+    !filter-out : /run/architectures/ppc
+    !filter-out : /run/architectures/ppc64
+    version: !mux
+      31:
+        version: 31
+      30:
+        !filter-out : /run/architectures/ppc64le
+        !filter-out : /run/architectures/s390x
+        version: 30
+  ubuntu:
+    name: ubuntu
+    !filter-out : /run/architectures/arm
+    !filter-out : /run/architectures/ppc
+    !filter-out : /run/architectures/ppc64
+    ppc64le:
+      arch: ppc64el
+    version: !mux
+      18.04:
+        version: '18.04'
+      19.10:
+        version: '19.10'
+  opensuse:
+    name: opensuse
+    !filter-out : /run/architectures/arm
+    !filter-out : /run/architectures/i386
+    !filter-out : /run/architectures/ppc
+    !filter-out : /run/architectures/ppc64
+    !filter-out : /run/architectures/ppc64le
+    !filter-out : /run/architectures/s390x
+    version: !mux
+      15.2:
+        !filter-out : /run/architectures/aarch64
+        version: 15.2
+      15.1:
+        version: 15.1
+      42.3:
+        !filter-out : /run/architectures/aarch64
+        version: 42.3
+
+architectures: !mux
+  arm:
+    arch: arm
+  aarch64:
+    arch: aarch64
+  i386:
+    arch: i386
+  ppc64:
+    arch: ppc64
+  ppc64le:
+    arch: ppc64le
+  ppc:
+    arch: ppc
+  s390x:
+    arch: s390x
+  x86_64:
+    arch: x86_64

--- a/selftests/unit/test_utils_vmimage.py
+++ b/selftests/unit/test_utils_vmimage.py
@@ -231,6 +231,15 @@ class FedoraImageProvider(unittest.TestCase):
         self.assertIsNone(parameters, "get_image_parameters() finds parameters "
                                       "where there should be none")
 
+    @unittest.mock.patch('avocado.utils.vmimage.urlopen')
+    def test_get_versions(self, urlopen_mock):
+        urlread_mocked = unittest.mock.Mock(return_value=self.VERSION_LISTING)
+        urlopen_mock.return_value = unittest.mock.Mock(read=urlread_mocked)
+        provider = vmimage.FedoraImageProvider()
+        self.assertEqual(provider.get_versions(),
+                         [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
+                          23, 24, 25, 26, 27, 28, 29, 30, 7, 8, 9])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/selftests/unit/test_utils_vmimage.py
+++ b/selftests/unit/test_utils_vmimage.py
@@ -113,6 +113,105 @@ class ImageProviderBase(unittest.TestCase):
         self.assertIn('attributes are required to get image url', exc.exception.args[0])
 
 
+class DebianImageProvider(unittest.TestCase):
+
+    #: Extract from https://cdimage.debian.org/cdimage/openstack/
+    VERSION_LISTING = """<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<html>
+ <head>
+  <title>Index of /cdimage/openstack</title>
+  <link rel="stylesheet" href="/layout/autoindex.css" type="text/css">
+<meta name="viewport" content="width=device-width, initial-scale=1"> </head>
+ <body>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>Debian Official Cloud Images for OpenStack -- Getting Debian  - www.debian.org</title>
+<link rel="author" href="mailto:webmaster@debian.org">
+<link href="https://www.debian.org/debian.css" rel="stylesheet" type="text/css">
+<link href="https://www.debian.org/debian-en.css" rel="stylesheet" type="text/css" media="all">
+
+<div id="header">
+    <div id="upperheader">
+        <div id="logo">
+            <a href="https://www.debian.org/" title="Debian Home"><img src="https://www.debian.org/Pics/openlogo-50.png" alt="Debian" width="50" height="61"></a>
+        </div> <!-- end logo -->
+        <div id="navbar">
+            <p class="hidecss"><a href="#content">Skip Quicknav</a></p>
+            <ul>
+                <li><a href="https://www.debian.org/intro/about">About Debian</a></li>
+                <li><a href="https://www.debian.org/distrib/">Getting Debian</a></li>
+                <li><a href="https://www.debian.org/support">Support</a></li>
+                <li><a href="https://www.debian.org/devel/">Developers' Corner</a></li>
+            </ul>
+        </div> <!-- end navbar -->
+    </div> <!-- end upperheader -->
+
+    <h1>Debian Official Cloud Images for OpenStack</h1>
+
+
+    <p>
+    These are files containing cloud images of the Debian GNU/Linux
+    operating system designed for OpenStack.  The files in this
+    directory are specifically for the <code>amd64</code>
+    and <code>arm64</code> architectures.
+    </p>
+
+    <h2>Will the image work on a cloud platform other than OpenStack?</h2>
+
+    <p>
+    If your platform supports the EC2 style metadata server (which is
+    contacted by cloud-init), and also supports an HDD image (using either
+    raw or qcow2 format), then most likely it will work. Note that it will
+    <strong>not</strong> work on Amazon EC2 if you are not using the
+    HVM mode.
+    </p>
+
+    <h2>Where are the Jessie (Debian 8) images?</h2>
+
+    <p>
+    Debian Jessie is no longer supported by the Debian Cloud Team, as
+    official security support for it ended in June 2018. We strongly
+    recommend that users should move on to use Stretch (Debian 9)
+    or Buster (Debian 10) instead, our current supported versions.
+    </p>
+
+    <p>
+    If you understand the lack of support and still have a strong need
+    for a Jessie image, they are still available for download - see
+    the "archive" directory.
+    </p>
+
+    <h2>Other questions?</h2>
+
+    <p>
+    Other questions can be forwarded to the OpenStack packaging
+    team: <b>debian-openstack at lists.debian.org</b>.
+    </p>
+
+</div>
+  <table id="indexlist">
+   <tr class="indexhead"><th class="indexcolicon"><img src="/icons2/blank.png" alt="[ICO]"></th><th class="indexcolname"><a href="?C=N;O=D">Name</a></th><th class="indexcollastmod"><a href="?C=M;O=A">Last modified</a></th><th class="indexcolsize"><a href="?C=S;O=A">Size</a></th></tr>
+   <tr class="indexbreakrow"><th colspan="4"><hr></th></tr>
+   <tr class="even"><td class="indexcolicon"><a href="/cdimage/"><img src="/icons2/go-previous.png" alt="[PARENTDIR]"></a></td><td class="indexcolname"><a href="/cdimage/">Parent Directory</a></td><td class="indexcollastmod">&nbsp;</td><td class="indexcolsize">  - </td></tr>
+   <tr class="odd"><td class="indexcolicon"><a href="9.12.0/"><img src="/icons2/folder.png" alt="[DIR]"></a></td><td class="indexcolname"><a href="9.12.0/">9.12.0/</a></td><td class="indexcollastmod">2020-02-09 16:03  </td><td class="indexcolsize">  - </td></tr>
+   <tr class="even"><td class="indexcolicon"><a href="10.3.0/"><img src="/icons2/folder.png" alt="[DIR]"></a></td><td class="indexcolname"><a href="10.3.0/">10.3.0/</a></td><td class="indexcollastmod">2020-02-09 03:02  </td><td class="indexcolsize">  - </td></tr>
+   <tr class="odd"><td class="indexcolicon"><a href="archive/"><img src="/icons2/folder.png" alt="[DIR]"></a></td><td class="indexcolname"><a href="archive/">archive/</a></td><td class="indexcollastmod">2020-02-09 16:10  </td><td class="indexcolsize">  - </td></tr>
+   <tr class="even"><td class="indexcolicon"><a href="current-9/"><img src="/icons2/folder.png" alt="[DIR]"></a></td><td class="indexcolname"><a href="current-9/">current-9/</a></td><td class="indexcollastmod">2020-02-09 16:03  </td><td class="indexcolsize">  - </td></tr>
+   <tr class="odd"><td class="indexcolicon"><a href="current-10/"><img src="/icons2/folder.png" alt="[DIR]"></a></td><td class="indexcolname"><a href="current-10/">current-10/</a></td><td class="indexcollastmod">2020-02-09 03:02  </td><td class="indexcolsize">  - </td></tr>
+   <tr class="even"><td class="indexcolicon"><a href="current/"><img src="/icons2/folder.png" alt="[DIR]"></a></td><td class="indexcolname"><a href="current/">current/</a></td><td class="indexcollastmod">2020-02-09 03:02  </td><td class="indexcolsize">  - </td></tr>
+   <tr class="odd"><td class="indexcolicon"><a href="testing/"><img src="/icons2/folder.png" alt="[DIR]"></a></td><td class="indexcolname"><a href="testing/">testing/</a></td><td class="indexcollastmod">2019-07-08 13:30  </td><td class="indexcolsize">  - </td></tr>
+   <tr class="indexbreakrow"><th colspan="4"><hr></th></tr>
+</table>
+<address>Apache/2.4.41 (Unix) Server at cdimage.debian.org Port 443</address>
+</body></html>"""
+
+    @unittest.mock.patch('avocado.utils.vmimage.urlopen')
+    def test_get_versions(self, urlopen_mock):
+        urlread_mocked = unittest.mock.Mock(return_value=self.VERSION_LISTING)
+        urlopen_mock.return_value = unittest.mock.Mock(read=urlread_mocked)
+        provider = vmimage.DebianImageProvider()
+        self.assertEqual(provider.get_versions(), ['9.12.0', '10.3.0'])
+
+
 class OpenSUSEImageProvider(unittest.TestCase):
     def setUp(self):
         self.suse_available_versions = ['Leap_15.0', 'Leap_42.1', 'Leap_42.2', 'Leap_42.3']

--- a/selftests/unit/test_utils_vmimage.py
+++ b/selftests/unit/test_utils_vmimage.py
@@ -213,6 +213,75 @@ class DebianImageProvider(unittest.TestCase):
 
 
 class OpenSUSEImageProvider(unittest.TestCase):
+
+    #: extracted from https://download.opensuse.org/repositories/Cloud:/Images:/
+    VERSION_LISTING = """
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>Index of /repositories/Cloud:/Images:</title>
+  <link rel="stylesheet" href="/icons/index.css" type="text/css" />
+<script src="/icons/include/setloc.js" type="text/javascript"></script> </head>
+ <body>
+<div id="oss-header">
+  <div>
+    <h1 id="oss-header-title">openSUSE Mirror Index</h1>
+    <!-- <a href="/" title="home" id="oss-header-logo">openSUSE Mirror</a> -->
+    <h5 id="oss-header-subtitle">Sub domains</h5>
+    &nbsp;
+    <ul>
+      <li><a href="https://www.opensuse.org" title="openSUSE homepage">openSUSE</a></li>
+      <li><a href="http://openbuildservice.org/" title="Open Build Service homepage">Open Build Service</a></li>
+      <li><a href="https://mirrors.opensuse.org/" title="List of mirror servers">Mirrors</a></li>
+      <li><a href="https://software.opensuse.org/" title="Software portal">Software</a></li>
+    </ul>
+  </div>
+  <div id="oss-header-clear"></div>
+</div>
+<div id="mirrorbrain-details">
+<h1>openSUSE download server</h1>
+<p>This is the download area of the <a href="https://www.opensuse.org/">openSUSE distribution</a> and the <a href="http://build.opensuse.org/">openSUSE Build Service</a>. If you are searching for a specific package for your distribution, we recommend to use our <a href="https://software.opensuse.org/">Software Portal</a> instead.
+<br />
+Short overview over the important directories and their content:</p>
+  <table>
+    <tr><td><a href="/debug/">debug</a> : </td><td><a href="/debug/">debug packages for official released distribution packages</a></td></tr>
+    <tr><td><a href="/distribution/">distribution</a> : </td><td><a href="/distribution/">official released openSUSE distributions - online repositories and ISO images</a></td></tr>
+    <tr><td><a href="/factory/">factory</a> : </td><td><a href="/factory/">Tumbleweed (former Factory) installation sources and ISO images</a></td></tr>
+    <tr><td><a href="/ports/">ports</a> : </td><td><a href="/ports/">ports of the openSUSE distribution</a></td></tr>
+    <tr><td><a href="/repositories/">repositories</a> : </td><td><a href="/repositories/">repositories and images created with the Open Build Service</a></td></tr>
+    <tr><td><a href="/source/">source</a> : </td><td><a href="/source/">source packages of official released distribution packages</a></td></tr>
+    <tr><td><a href="/tumbleweed/">tumbleweed</a> : </td><td><a href="/tumbleweed/">Tumbleweed installation sources and ISO images</a></td></tr>
+    <tr><td><a href="/update/">update</a> : </td><td><a href="/update/">updated packages for official released distribution packages</a></td></tr>
+  </table>
+</div>
+<div id="mirrorbrain-wrap">
+<h2 id="breadcrumbs">Index of <a href="/">download.opensuse.org</a>/</h2>
+<script type="text/javascript">setloc();</script>
+<table><tr><th><img src="/icons/blank.gif" alt="[ICO]" width="16" height="16" /></th><th><a href="?C=N;O=D">Name</a></th><th><a href="?C=M;O=A">Last modified</a></th><th><a href="?C=S;O=A">Size</a></th><th>Metadata</th></tr><tr><th colspan="5"><hr /></th></tr>
+<tr><td valign="top"><a href="/repositories/Cloud:/"><img src="/icons/up.png" alt="[DIR]" width="16" height="16" /></a></td><td><a href="/repositories/Cloud:/">Parent Directory</a></td><td>&nbsp;</td><td align="right">  - </td><td>&nbsp;</td></tr>
+<tr><td valign="top"><a href="Leap_15.0/"><img src="/icons/folder.png" alt="[DIR]" width="16" height="16" /></a></td><td><a href="Leap_15.0/">Leap_15.0/</a></td><td align="right">08-Feb-2018 10:04  </td><td align="right">  - </td><td>&nbsp;</td></tr>
+<tr><td valign="top"><a href="Leap_15.1/"><img src="/icons/folder.png" alt="[DIR]" width="16" height="16" /></a></td><td><a href="Leap_15.1/">Leap_15.1/</a></td><td align="right">20-May-2019 19:34  </td><td align="right">  - </td><td>&nbsp;</td></tr>
+<tr><td valign="top"><a href="Leap_15.2/"><img src="/icons/folder.png" alt="[DIR]" width="16" height="16" /></a></td><td><a href="Leap_15.2/">Leap_15.2/</a></td><td align="right">21-Oct-2019 12:09  </td><td align="right">  - </td><td>&nbsp;</td></tr>
+<tr><td valign="top"><a href="Leap_42.1/"><img src="/icons/folder.png" alt="[DIR]" width="16" height="16" /></a></td><td><a href="Leap_42.1/">Leap_42.1/</a></td><td align="right">06-Dec-2016 01:06  </td><td align="right">  - </td><td>&nbsp;</td></tr>
+<tr><td valign="top"><a href="Leap_42.2/"><img src="/icons/folder.png" alt="[DIR]" width="16" height="16" /></a></td><td><a href="Leap_42.2/">Leap_42.2/</a></td><td align="right">06-Dec-2016 13:14  </td><td align="right">  - </td><td>&nbsp;</td></tr>
+<tr><td valign="top"><a href="Leap_42.3/"><img src="/icons/folder.png" alt="[DIR]" width="16" height="16" /></a></td><td><a href="Leap_42.3/">Leap_42.3/</a></td><td align="right">21-Feb-2017 06:49  </td><td align="right">  - </td><td>&nbsp;</td></tr>
+<tr><td valign="top"><a href="openSUSE_13.1/"><img src="/icons/folder.png" alt="[DIR]" width="16" height="16" /></a></td><td><a href="openSUSE_13.1/">openSUSE_13.1/</a></td><td align="right">01-Nov-2017 13:10  </td><td align="right">  - </td><td>&nbsp;</td></tr>
+<tr><td valign="top"><a href="openSUSE_13.2/"><img src="/icons/folder.png" alt="[DIR]" width="16" height="16" /></a></td><td><a href="openSUSE_13.2/">openSUSE_13.2/</a></td><td align="right">01-Nov-2017 13:10  </td><td align="right">  - </td><td>&nbsp;</td></tr>
+<tr><td valign="top"><a href="SLES_12.3/"><img src="/icons/folder.png" alt="[DIR]" width="16" height="16" /></a></td><td><a href="SLES_12.3/">SLES_12.3/</a></td><td align="right">01-Nov-2017 13:25  </td><td align="right">  - </td><td>&nbsp;</td></tr>
+<tr><th colspan="5"><hr /></th></tr>
+</table>
+</div>
+<div class="oss-header-clear"></div>
+<div id="mirrorbrain-footer">
+  <a href="https://www.opensuse.org/">openSUSE</a> download area - powered by <a href="http://httpd.apache.org/">Apache</a> and <a href="http://mirrorbrain.org/">MirrorBrain</a>.
+  <p>If you find a bug, please report it at: <a href="https://bugzilla.opensuse.org/" target="_blank">https://bugzilla.opensuse.org</a>.
+  If you have a server with some space left: <a href='https://en.opensuse.org/openSUSE:Mirror_howto'>become a mirror</a>!</p>
+ <p class="text-center">&copy; 2015-2017 SUSE LLC. <span lang="en">All Rights Reserved.</span> <a lang="en" href="https://en.opensuse.org/Imprint">Imprint.</a></p>
+</div>
+</body></html>
+"""
+
     def setUp(self):
         self.suse_available_versions = ['Leap_15.0', 'Leap_42.1', 'Leap_42.2', 'Leap_42.3']
         self.base_images_url = 'https://download.opensuse.org/repositories/Cloud:/Images:/Leap_15.0/images/'
@@ -261,6 +330,14 @@ class OpenSUSEImageProvider(unittest.TestCase):
                                                       arch='x86_64')
         suse_provider.get_version = unittest.mock.Mock(return_value='15.0')
         self.assertEqual(suse_provider.get_image_url(), expected_image_url)
+
+    @unittest.mock.patch('avocado.utils.vmimage.urlopen')
+    def test_get_versions(self, urlopen_mock):
+        urlread_mocked = unittest.mock.Mock(return_value=self.VERSION_LISTING)
+        urlopen_mock.return_value = unittest.mock.Mock(read=urlread_mocked)
+        provider = vmimage.OpenSUSEImageProvider()
+        self.assertEqual(provider.get_versions(),
+                         [15.0, 15.1, 15.2, 42.1, 42.2, 42.3])
 
 
 class FedoraImageProvider(unittest.TestCase):


### PR DESCRIPTION
The `avocado.utils.vmimage` library allows users to fetch images for Operating Systems that should be capable of being executed as virtual machines. It retrieves those images directly from the organizations that publish them. But, the hard truth, is that those organizations change the structure from time to time.

To avoid release Avocado with vmimage "provider" broken, and to make it clear what we have tested and "support", this introduces a "release job" and release tests. Those tests are expected to take longer to run and require more resources, such as network access. To run the release job, one just needs to:

```
./jobs/release.py
```

Subsequent to this, the idea is to publish the list of images being tested for support with the documentation. LTS releases may receive backports keeping it current too.