### PR TITLE
N(ext)Runner: implement foundation for keeping track of tasks

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -139,6 +139,34 @@ def pick_runner_command(task, runners_registry=None):
     runners_registry[kind] = False
 
 
+def check_tasks_requirements(tasks, runners_registry=None):
+    """
+    Checks if tasks have runner requirements fulfilled
+
+    :param tasks: the tasks whose runner requirements will be checked
+    :type tasks: list of :class:`avocado.core.nrunner.Task`
+    :param runners_registry: a registry with previously found (and not
+                             found) runners keyed by task kind
+    :param runners_registry: dict
+    :return: two list of tasks in a tupple, with the first being the tasks
+             that pass the requirements check and the second the tasks that
+             fail the requirements check
+    :rtype: tupple of (list, list)
+    """
+    if runners_registry is None:
+        runners_registry = KNOWN_RUNNERS
+
+    ok = []
+    missing = []
+    for task in tasks:
+        runner = pick_runner_command(task, runners_registry)
+        if runner:
+            ok.append(task)
+        else:
+            missing.append(task)
+    return (ok, missing)
+
+
 class Runnable:
     """
     Describes an entity that be executed in the context of a task

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -6,10 +6,10 @@ import inspect
 import io
 import json
 import multiprocessing
+import socket
 import subprocess
 import time
 import unittest
-import socket
 
 #: The amount of time (in seconds) between each internal status check
 RUNNER_RUN_CHECK_INTERVAL = 0.01

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -2,6 +2,7 @@ import argparse
 import asyncio
 import base64
 import collections
+import enum
 import inspect
 import io
 import json
@@ -17,6 +18,20 @@ RUNNER_RUN_CHECK_INTERVAL = 0.01
 #: The amount of time (in seconds) between a status report from a
 #: runner that performs its work asynchronously
 RUNNER_RUN_STATUS_INTERVAL = 0.5
+
+
+class SpawnMethod(enum.Enum):
+    """The method employed to spawn a runnable or task."""
+    #: Spawns by running executing Python code, that is, having access to
+    #: a runnable or task instance, it calls its run() method.
+    PYTHON_CLASS = object()
+    #: Spawns by running a command, that is having either a path to an
+    #: executable or a list of arguments, it calls a function that will
+    #: execute that command (such as with os.system())
+    STANDALONE_EXECUTABLE = object()
+    #: Spawns with any method available, that is, it doesn't declare or
+    #: require a specific spawn method
+    ANY = object()
 
 
 class Runnable:

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import argparse
 import asyncio
 import base64

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -21,6 +21,9 @@ RUNNER_RUN_CHECK_INTERVAL = 0.01
 #: runner that performs its work asynchronously
 RUNNER_RUN_STATUS_INTERVAL = 0.5
 
+#: All known runners
+KNOWN_RUNNERS = {}
+
 
 class SpawnMethod(enum.Enum):
     """The method employed to spawn a runnable or task."""
@@ -56,7 +59,7 @@ def check_runner_command_candidate(task_kind, runner_command):
     return task_kind in capabilities.get('runnables', [])
 
 
-def pick_runner_command(task, runners_registry):
+def pick_runner_command(task, runners_registry=None):
     """
     Selects a runner based on the task and keeps found runners in registry
 
@@ -75,6 +78,9 @@ def pick_runner_command(task, runners_registry):
     :returns: command line arguments to execute the runner
     :rtype: list of str or None
     """
+    if runners_registry is None:
+        runners_registry = KNOWN_RUNNERS
+
     kind = task.runnable.kind
     runner = runners_registry.get(kind)
     if runner is False:

--- a/avocado/plugins/nrun.py
+++ b/avocado/plugins/nrun.py
@@ -15,7 +15,7 @@ from avocado.core.parser import HintParser
 from avocado.core.plugin_interfaces import CLICmd
 
 
-def check_tasks_requirements(tasks, runners_registry):
+def check_tasks_requirements(tasks, runners_registry=None):
     """
     Checks if tasks have runner requirements fulfilled
 
@@ -39,8 +39,6 @@ class NRun(CLICmd):
 
     name = 'nrun'
     description = "*EXPERIMENTAL* runner: runs one or more tests"
-
-    KNOWN_EXTERNAL_RUNNERS = {}
 
     def configure(self, parser):
         parser = super(NRun, self).configure(parser)
@@ -105,7 +103,7 @@ class NRun(CLICmd):
 
     @asyncio.coroutine
     def spawn_task(self, task):
-        runner = nrunner.pick_runner_command(task, self.KNOWN_EXTERNAL_RUNNERS)
+        runner = nrunner.pick_runner_command(task)
         if runner is False:
             LOG_UI.error('Task "%s" has no matching runner. ', task)
             LOG_UI.error('This is an error condition and should have been caught '
@@ -129,9 +127,7 @@ class NRun(CLICmd):
             hint = HintParser(hint_filepath)
         resolutions = resolver.resolve(config.get('nrun.references'), hint)
         tasks = job.resolutions_to_tasks(resolutions, config)
-        self.pending_tasks = check_tasks_requirements(   # pylint: disable=W0201
-            tasks,
-            self.KNOWN_EXTERNAL_RUNNERS)
+        self.pending_tasks = check_tasks_requirements(tasks)   # pylint: disable=W0201
 
         if not self.pending_tasks:
             LOG_UI.error('No test to be executed, exiting...')

--- a/avocado/plugins/nrun.py
+++ b/avocado/plugins/nrun.py
@@ -95,7 +95,7 @@ class NRun(CLICmd):
                 print("Finished spawning tasks")
                 break
 
-            yield from self.spawn_task(task)
+            yield from self.spawner.spawn(task)
             identifier = task.identifier
             self.pending_tasks.remove(task)
             self.spawned_tasks.append(identifier)
@@ -139,6 +139,7 @@ class NRun(CLICmd):
         self.spawned_tasks = []  # pylint: disable=W0201
 
         try:
+            self.spawner = nrunner.ProcessSpawner()  # pylint: disable=W0201
             loop = asyncio.get_event_loop()
             listen = config.get('nrun.status_server.listen')
             self.status_server = nrunner.StatusServer(listen,  # pylint: disable=W0201

--- a/avocado/plugins/nrun.py
+++ b/avocado/plugins/nrun.py
@@ -103,15 +103,15 @@ class NRun(CLICmd):
             self.spawned_tasks.append(identifier)
             print("%s spawned" % identifier)
 
-    def pick_runner_or_default(self, task):
-        runner = nrunner.pick_runner_command(task, self.KNOWN_EXTERNAL_RUNNERS)
-        if runner is None:
-            runner = [sys.executable, '-m', 'avocado.core.nrunner']
-        return runner
-
     @asyncio.coroutine
     def spawn_task(self, task):
-        runner = self.pick_runner_or_default(task)
+        runner = nrunner.pick_runner_command(task, self.KNOWN_EXTERNAL_RUNNERS)
+        if runner is False:
+            LOG_UI.error('Task "%s" has no matching runner. ', task)
+            LOG_UI.error('This is an error condition and should have been caught '
+                         'when checking task requirements.')
+            sys.exit(exit_codes.AVOCADO_FAIL)
+
         args = runner[1:] + ['task-run'] + task.get_command_args()
         runner = runner[0]
 

--- a/avocado/plugins/nrun.py
+++ b/avocado/plugins/nrun.py
@@ -13,54 +13,6 @@ from avocado.core.future.settings import settings
 from avocado.core.output import LOG_UI
 from avocado.core.parser import HintParser
 from avocado.core.plugin_interfaces import CLICmd
-from avocado.utils import path as utils_path
-
-
-def pick_runner(task, runners_registry):
-    """
-    Selects a runner based on the task and keeps found runners in registry
-
-    This utility function will look at the given task and try to find
-    a matching runner.  The matching runner probe results are kept in
-    a registry (that is modified by this function) so that further
-    executions take advantage of previous probes.
-
-    :param task: the task that needs a runner to be selected
-    :type task: :class:`avocado.core.nrunner.Task`
-    :param runners_registry: a registry with previously found (and not
-                             found) runners keyed by task kind
-    :param runners_registry: dict
-    :returns: command line arguments to execute the runner
-    :rtype: list of str
-    """
-    kind = task.runnable.kind
-    runner = runners_registry.get(kind)
-    if runner is False:
-        return None
-    if runner is not None:
-        return runner
-
-    # first attempt to find Python module files that are named
-    # after the runner convention within the avocado.core
-    # namespace dir.  Looking for the file only avoids an attempt
-    # to load the module and should be a lot faster
-    core_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    module_name = kind.replace('-', '_')
-    module_filename = 'nrunner_%s.py' % module_name
-    if os.path.exists(os.path.join(core_dir, module_filename)):
-        full_module_name = 'avocado.core.%s' % module_name
-        runner = [sys.executable, '-m', full_module_name]
-        runners_registry[kind] = runner
-        return runner
-
-    # try to find executable in the path
-    runner_by_name = 'avocado-runner-%s' % kind
-    try:
-        runner = utils_path.find_command(runner_by_name)
-        runners_registry[kind] = [runner]
-        return [runner]
-    except utils_path.CmdNotFoundError:
-        runners_registry[kind] = False
 
 
 def check_tasks_requirements(tasks, runners_registry):
@@ -75,7 +27,7 @@ def check_tasks_requirements(tasks, runners_registry):
     """
     result = []
     for task in tasks:
-        runner = pick_runner(task, runners_registry)
+        runner = nrunner.pick_runner_command(task, runners_registry)
         if runner:
             result.append(task)
         else:
@@ -152,7 +104,7 @@ class NRun(CLICmd):
             print("%s spawned" % identifier)
 
     def pick_runner_or_default(self, task):
-        runner = pick_runner(task, self.KNOWN_EXTERNAL_RUNNERS)
+        runner = nrunner.pick_runner_command(task, self.KNOWN_EXTERNAL_RUNNERS)
         if runner is None:
             runner = [sys.executable, '-m', 'avocado.core.nrunner']
         return runner

--- a/avocado/plugins/nrun.py
+++ b/avocado/plugins/nrun.py
@@ -87,7 +87,11 @@ class NRun(CLICmd):
             identifier = task.identifier
             self.pending_tasks.remove(task)
             self.spawned_tasks.append(identifier)
-            print("%s spawned" % identifier)
+            alive = self.spawner.is_alive(task)
+            if not alive:
+                LOG_UI.warning("%s is not alive shortly after being spawned", identifier)
+            else:
+                LOG_UI.info("%s spawned and alive", identifier)
 
     @asyncio.coroutine
     def spawn_task(self, task):

--- a/avocado/plugins/nrun.py
+++ b/avocado/plugins/nrun.py
@@ -61,6 +61,14 @@ class NRun(CLICmd):
                                  parser=parser,
                                  long_arg='--status-server')
 
+        settings.register_option(section="nrun.podman",
+                                 key="enabled",
+                                 default=False,
+                                 key_type=bool,
+                                 help_msg="Spawn tests in podman containers",
+                                 parser=parser,
+                                 long_arg="--podman")
+
         parser_common_args.add_tag_filter_args(parser)
 
     @asyncio.coroutine
@@ -124,7 +132,10 @@ class NRun(CLICmd):
         self.spawned_tasks = []  # pylint: disable=W0201
 
         try:
-            self.spawner = nrunner.ProcessSpawner()  # pylint: disable=W0201
+            if config.get('nrun.podman.enabled'):
+                self.spawner = nrunner.PodmanSpawner()  # pylint: disable=W0201
+            else:
+                self.spawner = nrunner.ProcessSpawner()  # pylint: disable=W0201
             loop = asyncio.get_event_loop()
             listen = config.get('nrun.status_server.listen')
             self.status_server = nrunner.StatusServer(listen,  # pylint: disable=W0201

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -19,7 +19,7 @@ NRunner based implementation of job compliant runner
 from avocado.core import test
 from avocado.core.plugin_interfaces import Runner as RunnerInterface
 
-from .nrun import check_tasks_requirements
+from avocado.core.nrunner import check_tasks_requirements
 
 
 class Runner(RunnerInterface):
@@ -33,7 +33,7 @@ class Runner(RunnerInterface):
     def run_suite(self, job, result, test_suite, variants, timeout=0,
                   replay_map=None, execution_order=None):
         summary = set()
-        test_suite = check_tasks_requirements(
+        test_suite, _ = check_tasks_requirements(
             test_suite,
             self.KNOWN_EXTERNAL_RUNNERS)  # pylint: disable=W0201
         result.tests_total = len(test_suite)  # no support for variants yet

--- a/selftests/unit/test_nrunner.py
+++ b/selftests/unit/test_nrunner.py
@@ -303,5 +303,43 @@ echo 'ok 2 - description 2'"""
         self.tmpdir.cleanup()
 
 
+@unittest.skipUnless(os.path.exists('/bin/sh'),
+                     ('Executable "/bin/sh" used in this test is not '
+                      'available in the system'))
+class RunnerCommandSelection(unittest.TestCase):
+
+    def test_check_runner_command_candidate(self):
+        cmd = ['sh', '-c',
+               'test $0 = capabilities && '
+               'echo -n {\\"runnables\\": [\\"mykind\\"]}']
+        self.assertTrue(nrunner.check_runner_command_candidate('mykind', cmd))
+
+    def test_check_runner_command_candidate_other_kind(self):
+        cmd = ['sh', '-c',
+               'test $0 = capabilities && '
+               'echo -n {\\"runnables\\": [\\"otherkind\\"]}']
+        self.assertFalse(nrunner.check_runner_command_candidate('mykind', cmd))
+
+    def test_check_runner_command_candidate_no_output(self):
+        cmd = ['sh', '-c', 'echo -n ""']
+        self.assertFalse(nrunner.check_runner_command_candidate('', cmd))
+
+
+class PickRunner(unittest.TestCase):
+
+    def setUp(self):
+        runnable = nrunner.Runnable('lets-image-a-kind',
+                                    'test_pick_runner_command')
+        self.task = nrunner.Task('1-test_pick_runner_command', runnable)
+
+    def test_pick_runner_command(self):
+        runner = ['avocado-runner-lets-image-a-kind']
+        known = {'lets-image-a-kind': runner}
+        self.assertEqual(nrunner.pick_runner_command(self.task, known), runner)
+
+    def test_pick_runner_command_empty(self):
+        self.assertFalse(nrunner.pick_runner_command(self.task, {}))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/selftests/unit/test_nrunner.py
+++ b/selftests/unit/test_nrunner.py
@@ -177,10 +177,6 @@ class RunnableToRecipe(unittest.TestCase):
 
 class Runner(unittest.TestCase):
 
-    def setUp(self):
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
-
     def test_runner_noop(self):
         runnable = nrunner.Runnable('noop', None)
         runner = nrunner.runner_from_runnable(
@@ -232,6 +228,13 @@ class Runner(unittest.TestCase):
         self.assertEqual(result['status'], 'pass')
         self.assertTrue(result['output'].startswith(output1))
         self.assertTrue(result['output'].endswith(output2))
+
+
+class RunnerTmp(unittest.TestCase):
+
+    def setUp(self):
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
 
     @unittest.skipUnless(os.path.exists('/bin/sh'),
                          ('Executable "/bin/sh" used in this test is not '


### PR DESCRIPTION
The current nrunner execution model is one such that it "fires (a task) and forgets" about it. It hopes that they will eventually return information to the status server, but the universe conspires against that.

This implements some foundation work so that we can keep track of the "alive" status of a task. This status is not used to its full potential, as it requires the status server (or a replacement to it) to keep checking if spawned tasks that have not responded (yet?) are still alive.  This is expected to be the implemented following this.