### PR TITLE
Misc Asset: return correct fail during download problems.

### DIFF
--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -132,7 +132,11 @@ class Asset:
                 self._create_hash_file(asset_path)
                 return self._verify_hash(asset_path)
         finally:
-            os.remove(temp)
+            try:
+                os.remove(temp)
+            except FileNotFoundError:
+                LOG.info("Temporary asset file unavailable due to failed"
+                         " download attempt.")
 
     @staticmethod
     def _get_hash_file(asset_path):


### PR DESCRIPTION
When there is a problem downloading an asset, there is no need to remove the temporary file as it was never created. This issue was masking the real download problem.

Signed-off-by: Willian Rampazzo <willianr@redhat.com>