### PR TITLE
Plugin Asset: introduces --ignore-errors to assets fetch command.

### DIFF
--- a/avocado/plugins/assets.py
+++ b/avocado/plugins/assets.py
@@ -287,6 +287,15 @@ class Assets(CLICmd):
                                  parser=fetch_subcommand_parser,
                                  positional_arg=True)
 
+        help_msg = "always return success for the fetch command."
+        settings.register_option(section='assets.fetch',
+                                 key='ignore_errors',
+                                 help_msg=help_msg,
+                                 default=False,
+                                 key_type=bool,
+                                 parser=fetch_subcommand_parser,
+                                 long_arg='--ignore-errors')
+
     def run(self, config):
         subcommand = config.get('assets_subcommand')
         # we want to let the command caller knows about fails
@@ -311,5 +320,9 @@ class Assets(CLICmd):
                     LOG_UI.warning('No such file or file not supported: %s',
                                    test_file)
                     exitcode |= exit_codes.AVOCADO_FAIL
+
+            # check if we should ignore the errors
+            if config.get('assets.fetch.ignore_errors'):
+                exitcode = exit_codes.AVOCADO_ALL_OK
 
         return exitcode

--- a/selftests/functional/test_plugin_assets.py
+++ b/selftests/functional/test_plugin_assets.py
@@ -234,6 +234,34 @@ class AssetsPlugin(unittest.TestCase):
         self.assertEqual(expected_rc, result.exit_status)
         self.assertIn(expected_stderr, result.stderr_text)
 
+    def test_asset_fetch_ignore_errors(self):
+        """
+        Test ends with warning but success error code
+        Problems while fetching asset from test source
+        """
+        fetch_content = r"""
+        self.hello = self.fetch_asset(
+            'hello-2.9.tar.gz',
+            locations='http://localhost/hello-2.9.tar.gz')
+        """
+        test_content = TEST_TEMPLATE.format(content=fetch_content)
+        test_file = tempfile.NamedTemporaryFile(suffix=".py", delete=False)
+        test_file.write(test_content.encode())
+        test_file.close()
+
+        expected_stderr = "Failed to fetch hello-2.9.tar.gz.\n"
+        expected_rc = exit_codes.AVOCADO_ALL_OK
+
+        cmd_line = "%s --config %s assets fetch --ignore-errors %s " % (
+            AVOCADO,
+            self.config_file.name,
+            test_file.name)
+        result = process.run(cmd_line, ignore_status=True)
+        os.remove(test_file.name)
+
+        self.assertEqual(expected_rc, result.exit_status)
+        self.assertIn(expected_stderr, result.stderr_text)
+
     def tearDown(self):
         os.remove(self.config_file.name)
         self.base_dir.cleanup()


### PR DESCRIPTION
When the command `avocado assets fetch` fails to download one of a list of assets, it ends with return code different from 0.

It may be useful to allow the command to end with a 0 return code, independent of any problem it had during the download execution. This allows, for example, Travis CI to continue.

Signed-off-by: Willian Rampazzo <willianr@redhat.com>