### PR TITLE
NextRunner: Remove the ambiguity of "status" and introduce the "result" keyword

### DIFF
--- a/avocado/core/nrunner_tap.py
+++ b/avocado/core/nrunner_tap.py
@@ -30,6 +30,7 @@ class TAPRunner(nrunner.BaseRunner):
                            'bar', # arg 1
                            DEBUG='false') # kwargs 1 (environment)
     """
+
     def run(self):
         env = self.runnable.kwargs or None
         process = subprocess.Popen(
@@ -46,25 +47,26 @@ class TAPRunner(nrunner.BaseRunner):
 
         stdout = io.TextIOWrapper(process.stdout)
         parser = TapParser(stdout)
-        status = 'error'
+        result = 'error'
         for event in parser.parse():
             if isinstance(event, TapParser.Bailout):
-                status = 'error'
+                result = 'error'
                 break
             elif isinstance(event, TapParser.Error):
-                status = 'error'
+                result = 'error'
                 break
             elif isinstance(event, TapParser.Test):
                 if event.result in (TestResult.XPASS, TestResult.FAIL):
-                    status = 'fail'
+                    result = 'fail'
                     break
                 elif event.result == TestResult.SKIP:
-                    status = 'skip'
+                    result = 'skip'
                     break
                 else:
-                    status = 'pass'
+                    result = 'pass'
 
-        yield {'status': status,
+        yield {'status': 'finished',
+               'result': result,
                'returncode': process.returncode,
                'timestamp': time.time()}
 

--- a/optional_plugins/robot/avocado_robot/runner.py
+++ b/optional_plugins/robot/avocado_robot/runner.py
@@ -35,31 +35,33 @@ class RobotRunner(nrunner.BaseRunner):
         output_dir = tempfile.mkdtemp()
         file_name, suit_test = uri.split(':', 1)
         suite_name, test_name = suit_test.split('.', 1)
-        result = run(file_name,
+        output = run(file_name,
                      suite=suite_name,
                      test=test_name,
                      outputdir=output_dir,
                      stdout=stdout,
                      stderr=stderr)
         time_end = time.time()
-        if result:
-            status = 'fail'
+        if output:
+            result = 'fail'
         else:
-            status = 'pass'
+            result = 'pass'
 
         stdout.seek(0)
         stderr.seek(0)
-        result = {'status': status,
+        output = {'status': 'finished',
+                  'result': result,
                   'stdout': stdout.read(),
                   'stderr': stderr.read(),
                   'time_end': time_end}
         stdout.close()
         stderr.close()
-        queue.put(result)
+        queue.put(output)
 
     def run(self):
         if not self.runnable.uri:
-            yield {'status': 'error',
+            yield {'status': 'finished',
+                   'result': 'error',
                    'output': 'uri is required but was not given'}
             return
 

--- a/selftests/functional/test_nrunner.py
+++ b/selftests/functional/test_nrunner.py
@@ -176,7 +176,7 @@ class ResolveSerializeRun(unittest.TestCase):
         cmd = "%s runnable-run-recipe %s"
         cmd %= (RUNNER, os.path.join(self.tmpdir.name, '1.json'))
         res = process.run(cmd)
-        self.assertIn(b"'status': 'pass'", res.stdout)
+        self.assertIn(b"'status': 'finished'", res.stdout)
 
     def tearDown(self):
         self.tmpdir.cleanup()

--- a/selftests/unit/test_nrunner.py
+++ b/selftests/unit/test_nrunner.py
@@ -88,6 +88,15 @@ class Runnable(unittest.TestCase):
         expected = '{"kind": "noop", "uri": "_uri_", "args": ["arg1", "arg2"]}'
         self.assertEqual(runnable.get_json(), expected)
 
+    def test_runner_from_runnable_error(self):
+        runnable = nrunner.Runnable('unsupported_kind', '')
+        try:
+            nrunner.runner_from_runnable(
+                runnable,
+                nrunner.RunnerApp.RUNNABLE_KINDS_CAPABLE)
+        except ValueError as e:
+            self.assertEqual(str(e), 'Unsupported kind of runnable: unsupported_kind')
+
 
 class RunnableFromCommandLineArgs(unittest.TestCase):
 
@@ -265,7 +274,39 @@ class Runner(unittest.TestCase):
         self.assertTrue(result['output'].startswith(output1))
         self.assertTrue(result['output'].endswith(output2))
 
+    def test_runner_python_unittest_skip(self):
+        runnable = nrunner.Runnable(
+            'python-unittest',
+            'selftests.unit.test_test.TestClassTestUnit.DummyTest.skip')
+        runner = nrunner.runner_from_runnable(
+            runnable,
+            nrunner.RunnerApp.RUNNABLE_KINDS_CAPABLE)
+        results = [status for status in runner.run()]
+        output1 = ('----------------------------------------------------------'
+                   '------------\nRan 1 test in ')
+        output2 = 's\n\nOK (skipped=1)\n'
+        result = results[-1]
+        self.assertEqual(result['status'], 'finished')
+        self.assertEqual(result['result'], 'skip')
+        self.assertTrue(result['output'].startswith(output1))
+        self.assertTrue(result['output'].endswith(output2))
+
     def test_runner_python_unittest_error(self):
+        runnable = nrunner.Runnable('python-unittest', 'error')
+        runner = nrunner.runner_from_runnable(
+            runnable,
+            nrunner.RunnerApp.RUNNABLE_KINDS_CAPABLE)
+        results = [status for status in runner.run()]
+        output1 = ('============================================================='
+                   '=========\nERROR: error')
+        output2 = '\n\nFAILED (errors=1)\n'
+        result = results[-1]
+        self.assertEqual(result['status'], 'finished')
+        self.assertEqual(result['result'], 'error')
+        self.assertTrue(result['output'].startswith(output1))
+        self.assertTrue(result['output'].endswith(output2))
+
+    def test_runner_python_unittest_empty_uri_error(self):
         runnable = nrunner.Runnable('python-unittest', '')
         runner = nrunner.runner_from_runnable(
             runnable,
@@ -275,7 +316,7 @@ class Runner(unittest.TestCase):
         result = results[-1]
         self.assertEqual(result['status'], 'finished')
         self.assertEqual(result['result'], 'error')
-        self.assertTrue(result['output'].startswith(output))
+        self.assertEqual(result['output'], output)
 
     @unittest.skipUnless(os.path.exists('/bin/sh'),
                          ('Executable "/bin/sh" used in this test is not '
@@ -295,6 +336,7 @@ echo 'not ok 2 - description 2'"""
         runner = nrunner_tap.TAPRunner(runnable)
         results = [status for status in runner.run()]
         last_result = results[-1]
+        self.assertEqual(last_result['status'], 'finished')
         self.assertEqual(last_result['result'], 'fail')
         self.assertEqual(last_result['returncode'], 0)
 
@@ -316,6 +358,7 @@ echo 'ok 2 - description 2'"""
         runner = nrunner_tap.TAPRunner(runnable)
         results = [status for status in runner.run()]
         last_result = results[-1]
+        self.assertEqual(last_result['status'], 'finished')
         self.assertEqual(last_result['result'], 'pass')
         self.assertEqual(last_result['returncode'], 0)
 
@@ -337,13 +380,14 @@ echo 'ok 2 - description 2'"""
         runner = nrunner_tap.TAPRunner(runnable)
         results = [status for status in runner.run()]
         last_result = results[-1]
+        self.assertEqual(last_result['status'], 'finished')
         self.assertEqual(last_result['result'], 'skip')
         self.assertEqual(last_result['returncode'], 0)
 
     @unittest.skipUnless(os.path.exists('/bin/sh'),
                          ('Executable "/bin/sh" used in this test is not '
                           'available in the system'))
-    def test_runner_tap_error(self):
+    def test_runner_tap_bailout(self):
         tap_script = """#!/bin/sh
 echo '1..2'
 echo '# Defining an basic test'
@@ -358,6 +402,29 @@ echo 'ok 2 - description 2'"""
         runner = nrunner_tap.TAPRunner(runnable)
         results = [status for status in runner.run()]
         last_result = results[-1]
+        self.assertEqual(last_result['status'], 'finished')
+        self.assertEqual(last_result['result'], 'error')
+        self.assertEqual(last_result['returncode'], 0)
+
+    @unittest.skipUnless(os.path.exists('/bin/sh'),
+                         ('Executable "/bin/sh" used in this test is not '
+                          'available in the system'))
+    def test_runner_tap_error(self):
+        tap_script = """#!/bin/sh
+    echo '1..2'
+    echo '# Defining an basic test'
+    echo 'error - description 1'
+    echo 'ok 2 - description 2'"""
+        tap_path = os.path.join(self.tmpdir.name, 'tap.sh')
+
+        with open(tap_path, 'w') as fp:
+            fp.write(tap_script)
+
+        runnable = nrunner.Runnable('tap', '/bin/sh', tap_path)
+        runner = nrunner_tap.TAPRunner(runnable)
+        results = [status for status in runner.run()]
+        last_result = results[-1]
+        self.assertEqual(last_result['status'], 'finished')
         self.assertEqual(last_result['result'], 'error')
         self.assertEqual(last_result['returncode'], 0)
 

--- a/selftests/unit/test_nrunner.py
+++ b/selftests/unit/test_nrunner.py
@@ -205,7 +205,7 @@ class Runner(unittest.TestCase):
         self.assertEqual(last_result['stderr'], b'')
         self.assertIn('time_end', last_result)
 
-    def test_runner_exec_test(self):
+    def test_runner_exec_test_ok(self):
         runnable = nrunner.Runnable('exec-test', sys.executable,
                                     '-c', 'import time; time.sleep(0.01)')
         runner = nrunner.runner_from_runnable(
@@ -220,7 +220,21 @@ class Runner(unittest.TestCase):
         self.assertEqual(last_result['stderr'], b'')
         self.assertIn('time_end', last_result)
 
-    def test_runner_python_unittest(self):
+    def test_runner_exec_test_fail(self):
+        runnable = nrunner.Runnable('exec-test', '/bin/false')
+        runner = nrunner.runner_from_runnable(
+            runnable,
+            nrunner.RunnerApp.RUNNABLE_KINDS_CAPABLE)
+        results = [status for status in runner.run()]
+        last_result = results[-1]
+        self.assertEqual(last_result['status'], 'finished')
+        self.assertEqual(last_result['result'], 'fail')
+        self.assertEqual(last_result['returncode'], 1)
+        self.assertEqual(last_result['stdout'], b'')
+        self.assertEqual(last_result['stderr'], b'')
+        self.assertIn('time_end', last_result)
+
+    def test_runner_python_unittest_ok(self):
         runnable = nrunner.Runnable('python-unittest', 'unittest.TestCase')
         runner = nrunner.runner_from_runnable(
             runnable,
@@ -234,6 +248,34 @@ class Runner(unittest.TestCase):
         self.assertEqual(result['result'], 'pass')
         self.assertTrue(result['output'].startswith(output1))
         self.assertTrue(result['output'].endswith(output2))
+
+    def test_runner_python_unittest_fail(self):
+        runnable = nrunner.Runnable('python-unittest', 'unittest.TestCase.fail')
+        runner = nrunner.runner_from_runnable(
+            runnable,
+            nrunner.RunnerApp.RUNNABLE_KINDS_CAPABLE)
+        results = [status for status in runner.run()]
+        output1 = ('============================================================='
+                   '=========\nFAIL: fail (unittest.case.TestCase)'
+                   '\nFail immediately, with the given message.')
+        output2 = '\n\nFAILED (failures=1)\n'
+        result = results[-1]
+        self.assertEqual(result['status'], 'finished')
+        self.assertEqual(result['result'], 'fail')
+        self.assertTrue(result['output'].startswith(output1))
+        self.assertTrue(result['output'].endswith(output2))
+
+    def test_runner_python_unittest_error(self):
+        runnable = nrunner.Runnable('python-unittest', '')
+        runner = nrunner.runner_from_runnable(
+            runnable,
+            nrunner.RunnerApp.RUNNABLE_KINDS_CAPABLE)
+        results = [status for status in runner.run()]
+        output = 'uri is required but was not given'
+        result = results[-1]
+        self.assertEqual(result['status'], 'finished')
+        self.assertEqual(result['result'], 'error')
+        self.assertTrue(result['output'].startswith(output))
 
     @unittest.skipUnless(os.path.exists('/bin/sh'),
                          ('Executable "/bin/sh" used in this test is not '

--- a/selftests/unit/test_test.py
+++ b/selftests/unit/test_test.py
@@ -26,6 +26,9 @@ class TestClassTestUnit(unittest.TestCase):
         def test(self):
             pass
 
+        def skip(self):
+            self.skipTest('dummy skip test')
+
     def setUp(self):
         prefix = temp_dir_prefix(__name__, self, 'setUp')
         self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)


### PR DESCRIPTION
`status` keyword in `avocado-runner-*` is being used for both: runner execution status and test result status.
After fix `avocado-runner-tap` output will be:
```
$ avocado-runner-tap runnable-run -k "tap" -u "/bin/sh" -a "/tmp/foo.sh"
{'status': 'running', 'timestamp': 1585773826.9089062}
{'status': 'running', 'timestamp': 1585773828.913483}
{'status': 'finished', 'result': 'pass', 'returncode': 0, 'timestamp': 1585773828.9147718}
```
`make check` passed: [job.log](https://cpaste.org/?ce009b9759f250cf#5JjRo1QKvpT7NBBbQdQpg5KaEaqusyHfdNmHFJVjsWKA)

One more test `test_runner_tap_error` added:
 `Task complete (pass): 143-selftests.unit.test_nrunner.Runner.test_runner_tap_error`

Issue: https://github.com/avocado-framework/avocado/issues/3547