### PR TITLE
N(ext)Runner: implement foundation for keeping track of tasks [v2]

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -39,6 +39,33 @@ class SpawnMethod(enum.Enum):
     ANY = object()
 
 
+class BaseSpawner:
+    """Defines an interface to be followed by all implementations."""
+
+    METHODS = []
+
+    def spawn_task(self, task):
+        pass
+
+
+class ProcessSpawner(BaseSpawner):
+
+    METHODS = [SpawnMethod.STANDALONE_EXECUTABLE]
+
+    @asyncio.coroutine
+    def spawn_task(self, task):
+        runner = task.pick_runner_command()
+        args = runner[1:] + ['task-run'] + task.get_command_args()
+        runner = runner[0]
+
+        #pylint: disable=E1133
+        yield from asyncio.create_subprocess_exec(
+            runner,
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE)
+
+
 class Runnable:
     """
     Describes an entity that be executed in the context of a task

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -73,6 +73,10 @@ class BaseSpawner:
 
     METHODS = []
 
+    @staticmethod
+    def is_task_alive(task):
+        pass
+
     def spawn_task(self, task):
         pass
 
@@ -81,6 +85,10 @@ class ProcessSpawner(BaseSpawner):
 
     METHODS = [SpawnMethod.STANDALONE_EXECUTABLE]
 
+    @staticmethod
+    def is_task_alive(task):
+        return task.spawn_handle.returncode is None
+
     @asyncio.coroutine
     def spawn_task(self, task):
         runner = task.pick_runner_command()
@@ -88,7 +96,7 @@ class ProcessSpawner(BaseSpawner):
         runner = runner[0]
 
         #pylint: disable=E1133
-        yield from asyncio.create_subprocess_exec(
+        task.spawn_handle = yield from asyncio.create_subprocess_exec(
             runner,
             *args,
             stdout=asyncio.subprocess.PIPE,
@@ -100,6 +108,23 @@ class PodmanSpawner(BaseSpawner):
     METHODS = [SpawnMethod.STANDALONE_EXECUTABLE]
     IMAGE = 'fedora:31'
     PODMAN_BIN = "/usr/bin/podman"
+
+    @staticmethod
+    def is_task_alive(task):
+        if task.spawn_handle is None:
+            return False
+
+        cmd = [PodmanSpawner.PODMAN_BIN, "ps", "--all", "--format={{.State}}",
+               "--filter=id=%s" % task.spawn_handle]
+        process = subprocess.Popen(cmd,
+                                   stdin=subprocess.DEVNULL,
+                                   stdout=subprocess.PIPE,
+                                   stderr=subprocess.DEVNULL)
+        out, _ = process.communicate()
+        # we have to be lenient and allow for the configured state to
+        # be considered "alive" because it happens before the
+        # container transitions into "running"
+        return out in [b'configured\n', b'running\n']
 
     @asyncio.coroutine
     def spawn_task(self, task):
@@ -121,6 +146,8 @@ class PodmanSpawner(BaseSpawner):
         _ = yield from proc.wait()
         stdout = yield from proc.stdout.read()
         container_id = stdout.decode().strip()
+
+        task.spawn_handle = container_id
 
         # Currently limited to avocado-runner, we'll expand on that
         # when the runner requirements system is in place
@@ -563,6 +590,7 @@ class Task:
         if known_runners is None:
             known_runners = {}
         self.known_runners = known_runners
+        self.spawn_handle = None
 
     def __repr__(self):
         fmt = '<Task identifier="{}" runnable="{}" status_services="{}"'

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -6,10 +6,10 @@ import inspect
 import io
 import json
 import multiprocessing
+import socket
 import subprocess
 import time
 import unittest
-import socket
 
 #: The amount of time (in seconds) between each internal status check
 RUNNER_RUN_CHECK_INTERVAL = 0.01

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -21,6 +21,9 @@ RUNNER_RUN_CHECK_INTERVAL = 0.01
 #: runner that performs its work asynchronously
 RUNNER_RUN_STATUS_INTERVAL = 0.5
 
+#: All known runners
+KNOWN_RUNNERS = {}
+
 
 class SpawnMethod(enum.Enum):
     """The method employed to spawn a runnable or task."""
@@ -521,7 +524,7 @@ class Task:
 
         return self.runnable.kind in capabilities.get('runnables', [])
 
-    def pick_runner_command(self, runners_registry):
+    def pick_runner_command(self, runners_registry=None):
         """Selects a runner command based on the task.
 
         And when finding a suitable runner, keeps found runners in registry.
@@ -539,6 +542,8 @@ class Task:
         :returns: command line arguments to execute the runner
         :rtype: list of str or None
         """
+        if runners_registry is None:
+            runners_registry = KNOWN_RUNNERS
         kind = self.runnable.kind
         runner_cmd = runners_registry.get(kind)
         if runner_cmd is False:

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -2,6 +2,7 @@ import argparse
 import asyncio
 import base64
 import collections
+import enum
 import inspect
 import io
 import json
@@ -17,6 +18,20 @@ RUNNER_RUN_CHECK_INTERVAL = 0.01
 #: The amount of time (in seconds) between a status report from a
 #: runner that performs its work asynchronously
 RUNNER_RUN_STATUS_INTERVAL = 0.5
+
+
+class SpawnMethod(enum.Enum):
+    """The method employed to spawn a runnable or task."""
+    #: Spawns by running executing Python code, that is, having access to
+    #: a runnable or task instance, it calls its run() method.
+    PYTHON_CLASS = object()
+    #: Spawns by running a command, that is having either a path to an
+    #: executable or a list of arguments, it calls a function that will
+    #: execute that command (such as with os.system())
+    STANDALONE_EXECUTABLE = object()
+    #: Spawns with any method available, that is, it doesn't declare or
+    #: require a specific spawn method
+    ANY = object()
 
 
 class Runnable:

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -7,8 +7,10 @@ import inspect
 import io
 import json
 import multiprocessing
+import os
 import socket
 import subprocess
+import sys
 import time
 import unittest
 
@@ -499,6 +501,73 @@ class Task:
             args.append(status_service.uri)
 
         return args
+
+    def is_kind_supported_by_runner_command(self, runner_command):
+        """Checks if a runner command that seems a good fit declares support."""
+        cmd = runner_command + ['capabilities']
+        try:
+            process = subprocess.Popen(cmd,
+                                       stdin=subprocess.DEVNULL,
+                                       stdout=subprocess.PIPE,
+                                       stderr=subprocess.DEVNULL)
+        except FileNotFoundError:
+            return False
+        out, _ = process.communicate()
+
+        try:
+            capabilities = json.loads(out.decode())
+        except json.decoder.JSONDecodeError:
+            return False
+
+        return self.runnable.kind in capabilities.get('runnables', [])
+
+    def pick_runner_command(self, runners_registry):
+        """Selects a runner command based on the task.
+
+        And when finding a suitable runner, keeps found runners in registry.
+
+        This utility function will look at the given task and try to find
+        a matching runner.  The matching runner probe results are kept in
+        a registry (that is modified by this function) so that further
+        executions take advantage of previous probes.
+
+        This is related to the :data:`SpawnMethod.STANDALONE_EXECUTABLE`
+
+        :param runners_registry: a registry with previously found (and not
+                                 found) runners keyed by task kind
+        :param runners_registry: dict
+        :returns: command line arguments to execute the runner
+        :rtype: list of str or None
+        """
+        kind = self.runnable.kind
+        runner_cmd = runners_registry.get(kind)
+        if runner_cmd is False:
+            return None
+        if runner_cmd is not None:
+            return runner_cmd
+
+        standalone_executable_cmd = ['avocado-runner-%s' % kind]
+        if self.is_kind_supported_by_runner_command(standalone_executable_cmd):
+            runners_registry[kind] = standalone_executable_cmd
+            return standalone_executable_cmd
+
+        # attempt to find Python module files that are named after the
+        # runner convention within the avocado.core namespace dir.
+        # Looking for the file only avoids an attempt to load the module
+        # and should be a lot faster
+        core_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        module_name = kind.replace('-', '_')
+        module_filename = 'nrunner_%s.py' % module_name
+        if os.path.exists(os.path.join(core_dir, module_filename)):
+            full_module_name = 'avocado.core.%s' % module_name
+            candidate_cmd = [sys.executable, '-m', full_module_name]
+            if self.is_kind_supported_by_runner_command(candidate_cmd):
+                runners_registry[kind] = candidate_cmd
+                return candidate_cmd
+
+        # exhausted probes, let's save the negative on the cache and avoid
+        # future similar probles
+        runners_registry[kind] = False
 
     def run(self):
         runner = runner_from_runnable(self.runnable, self.known_runners)

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import argparse
 import asyncio
 import base64

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -95,6 +95,53 @@ class ProcessSpawner(BaseSpawner):
             stderr=asyncio.subprocess.PIPE)
 
 
+class PodmanSpawner(BaseSpawner):
+
+    METHODS = [SpawnMethod.STANDALONE_EXECUTABLE]
+    IMAGE = 'fedora:31'
+    PODMAN_BIN = "/usr/bin/podman"
+
+    @asyncio.coroutine
+    def spawn_task(self, task):
+        entry_point_cmd = '/tmp/avocado-runner'
+        entry_point_args = task.get_command_args()
+        entry_point_args.insert(0, "task-run")
+        entry_point_args.insert(0, entry_point_cmd)
+        entry_point = json.dumps(entry_point_args)
+        entry_point_arg = "--entrypoint=" + entry_point
+        # pylint: disable=E1133
+        proc = yield from asyncio.create_subprocess_exec(
+            self.PODMAN_BIN, "create",
+            "--net=host",
+            entry_point_arg,
+            self.IMAGE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE)
+
+        _ = yield from proc.wait()
+        stdout = yield from proc.stdout.read()
+        container_id = stdout.decode().strip()
+
+        # Currently limited to avocado-runner, we'll expand on that
+        # when the runner requirements system is in place
+        this_path = os.path.abspath(__file__)
+        common_path = os.path.dirname(os.path.dirname(this_path))
+        avocado_runner_path = os.path.join(common_path, 'core', 'nrunner.py')
+        proc = yield from asyncio.create_subprocess_exec(
+            self.PODMAN_BIN,
+            "cp",
+            avocado_runner_path,
+            "%s:%s" % (container_id, entry_point_cmd))
+        yield from proc.wait()
+
+        proc = yield from asyncio.create_subprocess_exec(self.PODMAN_BIN,
+                                                         "start",
+                                                         container_id,
+                                                         stdout=asyncio.subprocess.PIPE,
+                                                         stderr=asyncio.subprocess.PIPE)
+        yield from proc.wait()
+
+
 class Runnable:
     """
     Describes an entity that be executed in the context of a task

--- a/avocado/plugins/nrun.py
+++ b/avocado/plugins/nrun.py
@@ -87,7 +87,11 @@ class NRun(CLICmd):
             identifier = task.identifier
             self.pending_tasks.remove(task)
             self.spawned_tasks.append(identifier)
-            print("%s spawned" % identifier)
+            alive = self.spawner.is_task_alive(task)
+            if not alive:
+                LOG_UI.warning("%s is not alive shortly after being spawned", identifier)
+            else:
+                LOG_UI.info("%s spawned and alive", identifier)
 
     @asyncio.coroutine
     def spawn_task(self, task):

--- a/avocado/plugins/nrun.py
+++ b/avocado/plugins/nrun.py
@@ -15,7 +15,7 @@ from avocado.core.parser import HintParser
 from avocado.core.plugin_interfaces import CLICmd
 
 
-def check_tasks_requirements(tasks, runners_registry):
+def check_tasks_requirements(tasks, runners_registry=None):
     """
     Checks if tasks have runner requirements fulfilled
 
@@ -39,8 +39,6 @@ class NRun(CLICmd):
 
     name = 'nrun'
     description = "*EXPERIMENTAL* runner: runs one or more tests"
-
-    KNOWN_EXTERNAL_RUNNERS = {}
 
     def configure(self, parser):
         parser = super(NRun, self).configure(parser)
@@ -105,7 +103,7 @@ class NRun(CLICmd):
 
     @asyncio.coroutine
     def spawn_task(self, task):
-        runner = task.pick_runner_command(self.KNOWN_EXTERNAL_RUNNERS)
+        runner = task.pick_runner_command()
         if runner is False:
             LOG_UI.error('Task "%s" has no matching runner. ', task)
             LOG_UI.error('This is an error condition and should have been caught '
@@ -129,9 +127,7 @@ class NRun(CLICmd):
             hint = HintParser(hint_filepath)
         resolutions = resolver.resolve(config.get('nrun.references'), hint)
         tasks = job.resolutions_to_tasks(resolutions, config)
-        self.pending_tasks = check_tasks_requirements(   # pylint: disable=W0201
-            tasks,
-            self.KNOWN_EXTERNAL_RUNNERS)
+        self.pending_tasks = check_tasks_requirements(tasks)   # pylint: disable=W0201
 
         if not self.pending_tasks:
             LOG_UI.error('No test to be executed, exiting...')

--- a/avocado/plugins/nrun.py
+++ b/avocado/plugins/nrun.py
@@ -15,26 +15,6 @@ from avocado.core.parser import HintParser
 from avocado.core.plugin_interfaces import CLICmd
 
 
-def check_tasks_requirements(tasks, runners_registry=None):
-    """
-    Checks if tasks have runner requirements fulfilled
-
-    :param tasks: the tasks whose runner requirements will be checked
-    :type tasks: list of :class:`avocado.core.nrunner.Task`
-    :param runners_registry: a registry with previously found (and not
-                             found) runners keyed by task kind
-    :param runners_registry: dict
-    """
-    result = []
-    for task in tasks:
-        runner = task.pick_runner_command(runners_registry)
-        if runner:
-            result.append(task)
-        else:
-            LOG_UI.warning('Task will not be run due to missing requirements: %s', task)
-    return result
-
-
 class NRun(CLICmd):
 
     name = 'nrun'
@@ -127,7 +107,12 @@ class NRun(CLICmd):
             hint = HintParser(hint_filepath)
         resolutions = resolver.resolve(config.get('nrun.references'), hint)
         tasks = job.resolutions_to_tasks(resolutions, config)
-        self.pending_tasks = check_tasks_requirements(tasks)   # pylint: disable=W0201
+        # pylint: disable=W0201
+        self.pending_tasks, missing_requirements = nrunner.check_tasks_requirements(tasks)
+        if missing_requirements:
+            missing_tasks_msg = "\n".join([str(t) for t in missing_requirements])
+            LOG_UI.warning('Tasks will not be run due to missing requirements: %s',
+                           missing_tasks_msg)
 
         if not self.pending_tasks:
             LOG_UI.error('No test to be executed, exiting...')

--- a/avocado/plugins/nrun.py
+++ b/avocado/plugins/nrun.py
@@ -103,15 +103,15 @@ class NRun(CLICmd):
             self.spawned_tasks.append(identifier)
             print("%s spawned" % identifier)
 
-    def pick_runner_or_default(self, task):
-        runner = task.pick_runner_command(self.KNOWN_EXTERNAL_RUNNERS)
-        if runner is None:
-            runner = [sys.executable, '-m', 'avocado.core.nrunner']
-        return runner
-
     @asyncio.coroutine
     def spawn_task(self, task):
-        runner = self.pick_runner_or_default(task)
+        runner = task.pick_runner_command(self.KNOWN_EXTERNAL_RUNNERS)
+        if runner is False:
+            LOG_UI.error('Task "%s" has no matching runner. ', task)
+            LOG_UI.error('This is an error condition and should have been caught '
+                         'when checking task requirements.')
+            sys.exit(exit_codes.AVOCADO_FAIL)
+
         args = runner[1:] + ['task-run'] + task.get_command_args()
         runner = runner[0]
 

--- a/avocado/plugins/nrun.py
+++ b/avocado/plugins/nrun.py
@@ -95,7 +95,7 @@ class NRun(CLICmd):
                 print("Finished spawning tasks")
                 break
 
-            yield from self.spawn_task(task)
+            yield from self.spawner.spawn_task(task)
             identifier = task.identifier
             self.pending_tasks.remove(task)
             self.spawned_tasks.append(identifier)
@@ -139,6 +139,7 @@ class NRun(CLICmd):
         self.spawned_tasks = []  # pylint: disable=W0201
 
         try:
+            self.spawner = nrunner.ProcessSpawner()  # pylint: disable=W0201
             loop = asyncio.get_event_loop()
             listen = config.get('nrun.status_server.listen')
             self.status_server = nrunner.StatusServer(listen,  # pylint: disable=W0201

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -19,7 +19,7 @@ NRunner based implementation of job compliant runner
 from avocado.core import test
 from avocado.core.plugin_interfaces import Runner as RunnerInterface
 
-from .nrun import check_tasks_requirements
+from avocado.core.nrunner import check_tasks_requirements
 
 
 class Runner(RunnerInterface):
@@ -33,7 +33,7 @@ class Runner(RunnerInterface):
     def run_suite(self, job, result, test_suite, variants, timeout=0,
                   replay_map=None, execution_order=None):
         summary = set()
-        test_suite = check_tasks_requirements(
+        test_suite, _ = check_tasks_requirements(
             test_suite,
             self.KNOWN_EXTERNAL_RUNNERS)  # pylint: disable=W0201
         result.tests_total = len(test_suite)  # no support for variants yet

--- a/selftests/unit/test_nrunner.py
+++ b/selftests/unit/test_nrunner.py
@@ -303,5 +303,48 @@ echo 'ok 2 - description 2'"""
         self.tmpdir.cleanup()
 
 
+@unittest.skipUnless(os.path.exists('/bin/sh'),
+                     ('Executable "/bin/sh" used in this test is not '
+                      'available in the system'))
+class RunnerCommandSelection(unittest.TestCase):
+
+    def setUp(self):
+        runnable = nrunner.Runnable('mykind',
+                                    'test_runner_command_selection')
+        self.task = nrunner.Task('1-test_runner_command_selection', runnable)
+
+    def test_is_task_kind_supported(self):
+        cmd = ['sh', '-c',
+               'test $0 = capabilities && '
+               'echo -n {\\"runnables\\": [\\"mykind\\"]}']
+        self.assertTrue(self.task.is_kind_supported_by_runner_command(cmd))
+
+    def test_is_task_kind_supported_other_kind(self):
+        cmd = ['sh', '-c',
+               'test $0 = capabilities && '
+               'echo -n {\\"runnables\\": [\\"otherkind\\"]}']
+        self.assertFalse(self.task.is_kind_supported_by_runner_command(cmd))
+
+    def test_is_task_kind_supported_no_output(self):
+        cmd = ['sh', '-c', 'echo -n ""']
+        self.assertFalse(self.task.is_kind_supported_by_runner_command(cmd))
+
+
+class PickRunner(unittest.TestCase):
+
+    def setUp(self):
+        runnable = nrunner.Runnable('lets-image-a-kind',
+                                    'test_pick_runner_command')
+        self.task = nrunner.Task('1-test_pick_runner_command', runnable)
+
+    def test_pick_runner_command(self):
+        runner = ['avocado-runner-lets-image-a-kind']
+        known = {'lets-image-a-kind': runner}
+        self.assertEqual(self.task.pick_runner_command(known), runner)
+
+    def test_pick_runner_command_empty(self):
+        self.assertFalse(self.task.pick_runner_command({}))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/selftests/unit/test_nrunner.py
+++ b/selftests/unit/test_nrunner.py
@@ -177,10 +177,6 @@ class RunnableToRecipe(unittest.TestCase):
 
 class Runner(unittest.TestCase):
 
-    def setUp(self):
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
-
     def test_runner_noop(self):
         runnable = nrunner.Runnable('noop', None)
         runner = nrunner.runner_from_runnable(
@@ -232,6 +228,13 @@ class Runner(unittest.TestCase):
         self.assertEqual(result['status'], 'pass')
         self.assertTrue(result['output'].startswith(output1))
         self.assertTrue(result['output'].endswith(output2))
+
+
+class RunnerTmp(unittest.TestCase):
+
+    def setUp(self):
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
 
     @unittest.skipUnless(os.path.exists('/bin/sh'),
                          ('Executable "/bin/sh" used in this test is not '


### PR DESCRIPTION
The current nrunner execution model is one such that it "fires (a task) and forgets" about it. It hopes that they will eventually return information to the status server, but the universe conspires against that.

This implements some foundation work so that we can keep track of the "alive" status of a task. This status is not used to its full potential, as it requires the status server (or a replacement to it) to keep checking if spawned tasks that have not responded (yet?) are still alive.  This is expected to be the implemented following this.

---

Changes from v1 (#3685):
* Renamed candidate variable to candidate_cmd in pick_runner_command()
* Moved check_runner_command_candidate() function to a Task method by
  the name is_kind_supported_by_runner_command
* Renamed runner variable to runner_cmd in pick_runner_command()
* Renamed the configuration section from "nrun.podman" to
  "nrun.spawners.podman"
* Renamed the command line option from "--podman" to "--podman-spawner"
* Defined the podman binary used as PODMAN_BIN attributed
* Checked the existence of podman on the system before attempting to use
  it on `nrun` command.
* Renamed spawn() method to spawn_task()
* Renamed is_alive() method to is_task_alive()
