### PR TITLE
NextRunner: Remove the ambiguity of "status" and introduce the "result" keyword

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -344,12 +344,16 @@ class ExecRunner(BaseRunner):
             stderr=subprocess.PIPE,
             env=env)
 
-        last_status = None
+        most_current_execution_state_time = None
         while process.poll() is None:
             time.sleep(RUNNER_RUN_CHECK_INTERVAL)
             now = time.time()
-            if last_status is None or now > last_status + RUNNER_RUN_STATUS_INTERVAL:
-                last_status = now
+            if most_current_execution_state_time is not None:
+                next_execution_state_mark = (most_current_execution_state_time +
+                                             RUNNER_RUN_STATUS_INTERVAL)
+            if (most_current_execution_state_time is None or
+                    now > next_execution_state_mark):
+                most_current_execution_state_time = now
                 if not time_start_sent:
                     time_start_sent = True
                     yield {'status': 'running',
@@ -379,13 +383,13 @@ class ExecTestRunner(ExecRunner):
     Runnable attributes usage is identical to :class:`ExecRunner`
     """
     def run(self):
-        for status in super(ExecTestRunner, self).run():
-            if 'returncode' in status:
-                if status['returncode'] == 0:
-                    status['status'] = 'pass'
+        for most_current_execution_state in super(ExecTestRunner, self).run():
+            if 'returncode' in most_current_execution_state:
+                if most_current_execution_state['returncode'] == 0:
+                    most_current_execution_state['status'] = 'pass'
                 else:
-                    status['status'] = 'fail'
-            yield status
+                    most_current_execution_state['status'] = 'fail'
+            yield most_current_execution_state
 
 
 class PythonUnittestRunner(BaseRunner):
@@ -445,12 +449,16 @@ class PythonUnittestRunner(BaseRunner):
         time_start_sent = False
         process.start()
 
-        last_status = None
+        most_current_execution_state_time = None
         while queue.empty():
             time.sleep(RUNNER_RUN_CHECK_INTERVAL)
             now = time.time()
-            if last_status is None or now > last_status + RUNNER_RUN_STATUS_INTERVAL:
-                last_status = now
+            if most_current_execution_state_time is not None:
+                next_execution_state_mark = (most_current_execution_state_time +
+                                             RUNNER_RUN_STATUS_INTERVAL)
+            if (most_current_execution_state_time is None or
+                    now > next_execution_state_mark):
+                most_current_execution_state_time = now
                 if not time_start_sent:
                     time_start_sent = True
                     yield {'status': 'running',

--- a/avocado/core/nrunner_avocado_instrumented.py
+++ b/avocado/core/nrunner_avocado_instrumented.py
@@ -68,12 +68,16 @@ class AvocadoInstrumentedTestRunner(nrunner.BaseRunner):
         time_start_sent = False
         process.start()
 
-        last_status = None
+        most_current_execution_state_time = None
         while queue.empty():
             time.sleep(nrunner.RUNNER_RUN_CHECK_INTERVAL)
             now = time.time()
-            if last_status is None or now > last_status + nrunner.RUNNER_RUN_STATUS_INTERVAL:
-                last_status = now
+            if most_current_execution_state_time is not None:
+                next_execution_state_mark = (most_current_execution_state_time +
+                                             nrunner.RUNNER_RUN_STATUS_INTERVAL)
+            if (most_current_execution_state_time is None or
+                    now > next_execution_state_mark):
+                most_current_execution_state_time = now
                 if not time_start_sent:
                     time_start_sent = True
                     yield {'status': 'running',

--- a/avocado/core/nrunner_tap.py
+++ b/avocado/core/nrunner_tap.py
@@ -46,25 +46,26 @@ class TAPRunner(nrunner.BaseRunner):
 
         stdout = io.TextIOWrapper(process.stdout)
         parser = TapParser(stdout)
-        status = 'error'
+        result = 'error'
         for event in parser.parse():
             if isinstance(event, TapParser.Bailout):
-                status = 'error'
+                result = 'error'
                 break
             elif isinstance(event, TapParser.Error):
-                status = 'error'
+                result = 'error'
                 break
             elif isinstance(event, TapParser.Test):
                 if event.result in (TestResult.XPASS, TestResult.FAIL):
-                    status = 'fail'
+                    result = 'fail'
                     break
                 elif event.result == TestResult.SKIP:
-                    status = 'skip'
+                    result = 'skip'
                     break
                 else:
-                    status = 'pass'
+                    result = 'pass'
 
-        yield {'status': status,
+        yield {'status': 'finished',
+               'result': result,
                'returncode': process.returncode,
                'timestamp': time.time()}
 

--- a/avocado/plugins/nrun.py
+++ b/avocado/plugins/nrun.py
@@ -156,11 +156,11 @@ class NRun(CLICmd):
             parallel_tasks = config.get('nrun.parallel_tasks')
             loop.run_until_complete(self.spawn_tasks(parallel_tasks))
             loop.run_until_complete(self.status_server.wait())
-            print(self.status_server.status)
+            print(self.status_server.result)
             exit_code = exit_codes.AVOCADO_ALL_OK
-            if self.status_server.status.get('fail') is not None:
+            if self.status_server.result.get('fail') is not None:
                 exit_code |= exit_codes.AVOCADO_TESTS_FAIL
-            elif self.status_server.status.get('error') is not None:
+            elif self.status_server.result.get('error') is not None:
                 exit_code |= exit_codes.AVOCADO_TESTS_FAIL
             return exit_code
         except Exception as e:  # pylint: disable=W0703

--- a/optional_plugins/robot/avocado_robot/runner.py
+++ b/optional_plugins/robot/avocado_robot/runner.py
@@ -43,23 +43,25 @@ class RobotRunner(nrunner.BaseRunner):
                                   stderr=stderr)
         time_end = time.time()
         if native_robot_result:
-            status = 'fail'
+            result = 'fail'
         else:
-            status = 'pass'
+            result = 'pass'
 
         stdout.seek(0)
         stderr.seek(0)
-        result = {'status': status,
+        output = {'status': 'finished',
+                  'result': result,
                   'stdout': stdout.read(),
                   'stderr': stderr.read(),
                   'time_end': time_end}
         stdout.close()
         stderr.close()
-        queue.put(result)
+        queue.put(output)
 
     def run(self):
         if not self.runnable.uri:
-            yield {'status': 'error',
+            yield {'status': 'finished',
+                   'result': 'error',
                    'output': 'uri is required but was not given'}
             return
 

--- a/optional_plugins/robot/avocado_robot/runner.py
+++ b/optional_plugins/robot/avocado_robot/runner.py
@@ -35,14 +35,14 @@ class RobotRunner(nrunner.BaseRunner):
         output_dir = tempfile.mkdtemp()
         file_name, suit_test = uri.split(':', 1)
         suite_name, test_name = suit_test.split('.', 1)
-        result = run(file_name,
-                     suite=suite_name,
-                     test=test_name,
-                     outputdir=output_dir,
-                     stdout=stdout,
-                     stderr=stderr)
+        native_robot_result = run(file_name,
+                                  suite=suite_name,
+                                  test=test_name,
+                                  outputdir=output_dir,
+                                  stdout=stdout,
+                                  stderr=stderr)
         time_end = time.time()
-        if result:
+        if native_robot_result:
             status = 'fail'
         else:
             status = 'pass'

--- a/optional_plugins/robot/avocado_robot/runner.py
+++ b/optional_plugins/robot/avocado_robot/runner.py
@@ -70,12 +70,16 @@ class RobotRunner(nrunner.BaseRunner):
         time_start_sent = False
         process.start()
 
-        last_status = None
+        most_current_execution_state_time = None
         while queue.empty():
             time.sleep(nrunner.RUNNER_RUN_CHECK_INTERVAL)
             now = time.time()
-            if last_status is None or now > last_status + nrunner.RUNNER_RUN_STATUS_INTERVAL:
-                last_status = now
+            if most_current_execution_state_time is not None:
+                next_execution_state_mark = (most_current_execution_state_time +
+                                             nrunner.RUNNER_RUN_STATUS_INTERVAL)
+            if (most_current_execution_state_time is None or
+                    now > next_execution_state_mark):
+                most_current_execution_state_time = now
                 if not time_start_sent:
                     time_start_sent = True
                     yield {'status': 'running',

--- a/selftests/functional/test_nrunner.py
+++ b/selftests/functional/test_nrunner.py
@@ -176,7 +176,7 @@ class ResolveSerializeRun(unittest.TestCase):
         cmd = "%s runnable-run-recipe %s"
         cmd %= (RUNNER, os.path.join(self.tmpdir.name, '1.json'))
         res = process.run(cmd)
-        self.assertIn(b"'status': 'pass'", res.stdout)
+        self.assertIn(b"'status': 'finished'", res.stdout)
 
     def tearDown(self):
         self.tmpdir.cleanup()

--- a/selftests/unit/test_nrunner.py
+++ b/selftests/unit/test_nrunner.py
@@ -209,7 +209,8 @@ class Runner(unittest.TestCase):
             nrunner.RunnerApp.RUNNABLE_KINDS_CAPABLE)
         results = [status for status in runner.run()]
         last_result = results[-1]
-        self.assertEqual(last_result['status'], 'pass')
+        self.assertEqual(last_result['status'], 'finished')
+        self.assertEqual(last_result['result'], 'pass')
         self.assertEqual(last_result['returncode'], 0)
         self.assertEqual(last_result['stdout'], b'')
         self.assertEqual(last_result['stderr'], b'')
@@ -225,7 +226,8 @@ class Runner(unittest.TestCase):
                    '------------\nRan 0 tests in ')
         output2 = 's\n\nOK\n'
         result = results[-1]
-        self.assertEqual(result['status'], 'pass')
+        self.assertEqual(result['status'], 'finished')
+        self.assertEqual(result['result'], 'pass')
         self.assertTrue(result['output'].startswith(output1))
         self.assertTrue(result['output'].endswith(output2))
 
@@ -254,7 +256,7 @@ echo 'not ok 2 - description 2'"""
         runner = nrunner_tap.TAPRunner(runnable)
         results = [status for status in runner.run()]
         last_result = results[-1]
-        self.assertEqual(last_result['status'], 'fail')
+        self.assertEqual(last_result['result'], 'fail')
         self.assertEqual(last_result['returncode'], 0)
 
     @unittest.skipUnless(os.path.exists('/bin/sh'),
@@ -275,7 +277,7 @@ echo 'ok 2 - description 2'"""
         runner = nrunner_tap.TAPRunner(runnable)
         results = [status for status in runner.run()]
         last_result = results[-1]
-        self.assertEqual(last_result['status'], 'pass')
+        self.assertEqual(last_result['result'], 'pass')
         self.assertEqual(last_result['returncode'], 0)
 
     @unittest.skipUnless(os.path.exists('/bin/sh'),
@@ -296,7 +298,28 @@ echo 'ok 2 - description 2'"""
         runner = nrunner_tap.TAPRunner(runnable)
         results = [status for status in runner.run()]
         last_result = results[-1]
-        self.assertEqual(last_result['status'], 'skip')
+        self.assertEqual(last_result['result'], 'skip')
+        self.assertEqual(last_result['returncode'], 0)
+
+    @unittest.skipUnless(os.path.exists('/bin/sh'),
+                         ('Executable "/bin/sh" used in this test is not '
+                          'available in the system'))
+    def test_runner_tap_error(self):
+        tap_script = """#!/bin/sh
+echo '1..2'
+echo '# Defining an basic test'
+echo 'Bail out! - description 1'
+echo 'ok 2 - description 2'"""
+        tap_path = os.path.join(self.tmpdir.name, 'tap.sh')
+
+        with open(tap_path, 'w') as fp:
+            fp.write(tap_script)
+
+        runnable = nrunner.Runnable('tap', '/bin/sh', tap_path)
+        runner = nrunner_tap.TAPRunner(runnable)
+        results = [status for status in runner.run()]
+        last_result = results[-1]
+        self.assertEqual(last_result['result'], 'error')
         self.assertEqual(last_result['returncode'], 0)
 
     def tearDown(self):

--- a/selftests/unit/test_test.py
+++ b/selftests/unit/test_test.py
@@ -26,6 +26,9 @@ class TestClassTestUnit(unittest.TestCase):
         def test(self):
             pass
 
+        def skip(self):
+            self.skipTest('dummy skip test')
+
     def setUp(self):
         prefix = temp_dir_prefix(__name__, self, 'setUp')
         self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)


### PR DESCRIPTION
`status` keyword in `avocado-runner-*` is being used for both: runner execution status and test result status.
After fix `avocado-runner-tap` output will be:
```
$ avocado-runner-tap runnable-run -k "tap" -u "/bin/sh" -a "/tmp/foo.sh"
{'status': 'running', 'timestamp': 1585773826.9089062}
{'status': 'running', 'timestamp': 1585773828.913483}
{'status': 'finished', 'result': 'pass', 'returncode': 0, 'timestamp': 1585773828.9147718}
```
`make check` passed: [job.log](https://cpaste.org/?ce009b9759f250cf#5JjRo1QKvpT7NBBbQdQpg5KaEaqusyHfdNmHFJVjsWKA)

One more test `test_runner_tap_error` added:
 `Task complete (pass): 143-selftests.unit.test_nrunner.Runner.test_runner_tap_error`

Issue: https://github.com/avocado-framework/avocado/issues/3547

---

This is a rebase of #3692 to solve conflicts, and with a few extra patches and needed fixes found during review.