### PR TITLE
release selftests: update the version of Debian supported vmimage

### DIFF
--- a/selftests/release/vmimage.py.data/variants.yml
+++ b/selftests/release/vmimage.py.data/variants.yml
@@ -39,10 +39,10 @@ distro: !mux
     x86_64:
       arch: amd64
     version: !mux
-      9.12.1-20200328:
+      9.12.1:
         version: 9.12.1-20200328
-      10.3.1:
-        version: 10.3.1-20200328
+      10.3.2:
+        version: 10.3.2-20200406
   fedora:
     name: fedora
     !filter-out : /run/architectures/arm


### PR DESCRIPTION
And make the YAML tree structure more coherent, by using shorter
versions in the upper nodes and the full version in the value only.

Signed-off-by: Cleber Rosa <crosa@redhat.com>