### PR TITLE
Fix Jinja2 dependency of MarkupSafe to support Python 3.5

### DIFF
--- a/optional_plugins/html/setup.py
+++ b/optional_plugins/html/setup.py
@@ -24,7 +24,7 @@ setup(name='avocado-framework-plugin-result-html',
       url='http://avocado-framework.github.io/',
       packages=find_packages(),
       include_package_data=True,
-      install_requires=['avocado-framework', 'jinja2<3.0.0'],
+      install_requires=['avocado-framework', 'markupsafe<2.0.0', 'jinja2<3.0.0'],
       entry_points={
           'avocado.plugins.cli': [
               'html = avocado_result_html:HTML',


### PR DESCRIPTION
The new MarkupSafe 2.0.0 do not support Python 3.5. We need to restrict MarkupSafe version to 1.x.

Signed-off-by: Willian Rampazzo <willianr@redhat.com>