### PR TITLE
[LTS] Selftests Requirements: pin PyYAML version

### DIFF
--- a/optional_plugins/robot/setup.py
+++ b/optional_plugins/robot/setup.py
@@ -24,7 +24,7 @@ setup(name='avocado-framework-plugin-robot',
       url='http://avocado-framework.github.io/',
       packages=find_packages(),
       include_package_data=True,
-      install_requires=['robotframework'],
+      install_requires=['robotframework<3.2'],
       entry_points={
           'avocado.plugins.cli': [
               'robot = avocado_robot:RobotCLI',

--- a/requirements-selftests.txt
+++ b/requirements-selftests.txt
@@ -40,3 +40,7 @@ libvirt-python==4.6.0
 
 # For avocado.utils.network selftests
 netifaces
+
+# Inspektor requires cliff, which in turn requires PyYAML
+# but only PyYAML <= 5.2 supports Python 3.4
+PyYAML==5.2


### PR DESCRIPTION
Because PyYAML is a requirement for cliff which is rquired for
inspektor.  PyYAML versions after 5.2 do not support Python 3.4, so we
need to pin it.

Signed-off-by: Cleber Rosa <crosa@redhat.com>