### PR TITLE
Optional plugins: require the same Avocado version

### DIFF
--- a/optional_plugins/glib/setup.py
+++ b/optional_plugins/glib/setup.py
@@ -16,15 +16,17 @@
 from setuptools import setup, find_packages
 
 
+VERSION = open("VERSION", "r").read().strip()
+
 setup(name='avocado-framework-plugin-glib',
       description='Avocado Plugin for Execution of GLib Test Framework tests',
-      version=open("VERSION", "r").read().strip(),
+      version=VERSION,
       author='Avocado Developers',
       author_email='avocado-devel@redhat.com',
       url='http://avocado-framework.github.io/',
       packages=find_packages(),
       include_package_data=True,
-      install_requires=['avocado-framework'],
+      install_requires=['avocado-framework==%s' % VERSION],
       entry_points={
           'avocado.plugins.cli': [
               'glib = avocado_glib:GLibCLI',

--- a/optional_plugins/golang/setup.py
+++ b/optional_plugins/golang/setup.py
@@ -15,16 +15,17 @@
 
 from setuptools import setup, find_packages
 
+VERSION = open("VERSION", "r").read().strip()
 
 setup(name='avocado-framework-plugin-golang',
       description='Avocado Plugin for Execution of Golang tests',
-      version=open("VERSION", "r").read().strip(),
+      version=VERSION,
       author='Avocado Developers',
       author_email='avocado-devel@redhat.com',
       url='http://avocado-framework.github.io/',
       packages=find_packages(),
       include_package_data=True,
-      install_requires=['avocado-framework'],
+      install_requires=['avocado-framework==%s' % VERSION],
       test_suite='tests',
       entry_points={
           'avocado.plugins.cli': [

--- a/optional_plugins/html/setup.py
+++ b/optional_plugins/html/setup.py
@@ -16,15 +16,18 @@
 from setuptools import setup, find_packages
 
 
+VERSION = open("VERSION", "r").read().strip()
+
 setup(name='avocado-framework-plugin-result-html',
       description='Avocado HTML Report for Jobs',
-      version=open("VERSION", "r").read().strip(),
+      version=VERSION,
       author='Avocado Developers',
       author_email='avocado-devel@redhat.com',
       url='http://avocado-framework.github.io/',
       packages=find_packages(),
       include_package_data=True,
-      install_requires=['avocado-framework', 'markupsafe<2.0.0', 'jinja2<3.0.0'],
+      install_requires=['avocado-framework==%s' % VERSION,
+                        'markupsafe<2.0.0', 'jinja2<3.0.0'],
       entry_points={
           'avocado.plugins.cli': [
               'html = avocado_result_html:HTML',

--- a/optional_plugins/loader_yaml/setup.py
+++ b/optional_plugins/loader_yaml/setup.py
@@ -15,16 +15,18 @@
 
 from setuptools import setup, find_packages
 
+VERSION = open("VERSION", "r").read().strip()
 
 setup(name='avocado-framework-plugin-loader-yaml',
       description='Avocado Plugin that loads tests from YAML files',
-      version=open("VERSION", "r").read().strip(),
+      version=VERSION,
       author='Avocado Developers',
       author_email='avocado-devel@redhat.com',
       url='http://avocado-framework.github.io/',
       packages=find_packages(),
       include_package_data=True,
-      install_requires=['avocado-framework-plugin-varianter-yaml-to-mux'],
+      install_requires=[('avocado-framework-plugin-varianter'
+                         '-yaml-to-mux==%s' % VERSION)],
       entry_points={
           "avocado.plugins.cli": [
               "loader_yaml = avocado_loader_yaml:LoaderYAML"]})

--- a/optional_plugins/result_upload/setup.py
+++ b/optional_plugins/result_upload/setup.py
@@ -16,15 +16,17 @@
 from setuptools import setup, find_packages
 
 
+VERSION = open("VERSION", "r").read().strip()
+
 setup(name='avocado-framework-plugin-result-upload',
       description='Avocado Plugin to propagate Job results to remote host',
-      version=open("VERSION", "r").read().strip(),
+      version=VERSION,
       author='Avocado Developers',
       author_email='avocado-devel@redhat.com',
       url='http://avocado-framework.github.io/',
       packages=find_packages(),
       include_package_data=True,
-      install_requires=['avocado-framework'],
+      install_requires=['avocado-framework==%s' % VERSION],
       entry_points={
           'avocado.plugins.cli': [
               'results_upload = avocado_result_upload:ResultUploadCLI',

--- a/optional_plugins/resultsdb/setup.py
+++ b/optional_plugins/resultsdb/setup.py
@@ -15,16 +15,18 @@
 
 from setuptools import setup, find_packages
 
+VERSION = open("VERSION", "r").read().strip()
 
 setup(name='avocado-framework-plugin-resultsdb',
       description='Avocado Plugin to propagate Job results to Resultsdb',
-      version=open("VERSION", "r").read().strip(),
+      version=VERSION,
       author='Avocado Developers',
       author_email='avocado-devel@redhat.com',
       url='http://avocado-framework.github.io/',
       packages=find_packages(),
       include_package_data=True,
-      install_requires=['avocado-framework', 'resultsdb-api'],
+      install_requires=['avocado-framework==%s' % VERSION,
+                        'resultsdb-api'],
       entry_points={
           'avocado.plugins.cli': [
               'resultsdb = avocado_resultsdb:ResultsdbCLI',

--- a/optional_plugins/robot/setup.py
+++ b/optional_plugins/robot/setup.py
@@ -16,15 +16,18 @@
 from setuptools import setup, find_packages
 
 
+VERSION = open("VERSION", "r").read().strip()
+
 setup(name='avocado-framework-plugin-robot',
       description='Avocado Plugin for Execution of Robot Framework tests',
-      version=open("VERSION", "r").read().strip(),
+      version=VERSION,
       author='Avocado Developers',
       author_email='avocado-devel@redhat.com',
       url='http://avocado-framework.github.io/',
       packages=find_packages(),
       include_package_data=True,
-      install_requires=['robotframework<=3.1.2'],
+      install_requires=['avocado-framework==%s' % VERSION,
+                        'robotframework<=3.1.2'],
       test_suite='tests',
       entry_points={
           'console_scripts': [

--- a/optional_plugins/runner_docker/setup.py
+++ b/optional_plugins/runner_docker/setup.py
@@ -16,15 +16,18 @@
 from setuptools import setup, find_packages
 
 
+VERSION = open("VERSION", "r").read().strip()
+
 setup(name='avocado-framework-plugin-runner-docker',
       description='Avocado Runner for Execution on Docker Containers',
-      version=open("VERSION", "r").read().strip(),
+      version=VERSION,
       author='Avocado Developers',
       author_email='avocado-devel@redhat.com',
       url='http://avocado-framework.github.io/',
       packages=find_packages(),
       include_package_data=True,
-      install_requires=['avocado-framework-plugin-runner-remote', 'aexpect'],
+      install_requires=['avocado-framework-plugin-runner-remote==%s' % VERSION,
+                        'aexpect'],
       entry_points={
           'avocado.plugins.cli': [
               'docker = avocado_runner_docker:DockerCLI',

--- a/optional_plugins/runner_remote/setup.py
+++ b/optional_plugins/runner_remote/setup.py
@@ -26,15 +26,18 @@ if detected_distro.name == 'fedora' and int(detected_distro.version) >= 29:
 else:
     fabric = 'Fabric3'
 
+
+VERSION = open("VERSION", "r").read().strip()
+
 setup(name='avocado-framework-plugin-runner-remote',
       description='Avocado Runner for Remote Execution',
-      version=open("VERSION", "r").read().strip(),
+      version=VERSION,
       author='Avocado Developers',
       author_email='avocado-devel@redhat.com',
       url='http://avocado-framework.github.io/',
       packages=find_packages(exclude=('tests*',)),
       include_package_data=True,
-      install_requires=['avocado-framework', fabric],
+      install_requires=['avocado-framework==%s' % VERSION, fabric],
       test_suite='tests',
       entry_points={
           'avocado.plugins.cli': [

--- a/optional_plugins/runner_vm/setup.py
+++ b/optional_plugins/runner_vm/setup.py
@@ -16,15 +16,18 @@
 from setuptools import setup, find_packages
 
 
+VERSION = open("VERSION", "r").read().strip()
+
 setup(name='avocado-framework-plugin-runner-vm',
       description='Avocado Runner for libvirt VM Execution',
-      version=open("VERSION", "r").read().strip(),
+      version=VERSION,
       author='Avocado Developers',
       author_email='avocado-devel@redhat.com',
       url='http://avocado-framework.github.io/',
       packages=find_packages(exclude=('tests*',)),
       include_package_data=True,
-      install_requires=['avocado-framework-plugin-runner-remote', 'libvirt-python'],
+      install_requires=['avocado-framework-plugin-runner-remote==%s' % VERSION,
+                        'libvirt-python'],
       test_suite='tests',
       entry_points={
           'avocado.plugins.cli': [

--- a/optional_plugins/varianter_cit/setup.py
+++ b/optional_plugins/varianter_cit/setup.py
@@ -17,6 +17,8 @@
 from setuptools import setup, find_packages
 
 
+VERSION = open("VERSION", "r").read().strip()
+
 setup(name='avocado-framework-plugin-varianter-cit',
       description='Varianter with combinatorial capabilities',
       version=open("VERSION", "r").read().strip(),
@@ -25,7 +27,7 @@ setup(name='avocado-framework-plugin-varianter-cit',
       url='http://avocado-framework.github.io/',
       packages=find_packages(),
       include_package_data=True,
-      install_requires=['avocado-framework', ],
+      install_requires=['avocado-framework==%s' % VERSION],
       test_suite='tests',
       entry_points={
           'avocado.plugins.cli': [

--- a/optional_plugins/varianter_pict/setup.py
+++ b/optional_plugins/varianter_pict/setup.py
@@ -16,15 +16,17 @@
 from setuptools import setup, find_packages
 
 
+VERSION = open("VERSION", "r").read().strip()
+
 setup(name='avocado-framework-plugin-varianter-pict',
       description='Varianter with combinatorial capabilities by PICT',
-      version=open("VERSION", "r").read().strip(),
+      version=VERSION,
       author='Avocado Developers',
       author_email='avocado-devel@redhat.com',
       url='http://avocado-framework.github.io/',
       packages=find_packages(),
       include_package_data=True,
-      install_requires=['avocado-framework', ],
+      install_requires=['avocado-framework==%s' % VERSION],
       entry_points={
           'avocado.plugins.cli': [
               'varianter_pict = avocado_varianter_pict:VarianterPictCLI',

--- a/optional_plugins/varianter_yaml_to_mux/setup.py
+++ b/optional_plugins/varianter_yaml_to_mux/setup.py
@@ -16,15 +16,17 @@
 from setuptools import setup, find_packages
 
 
+VERSION = open("VERSION", "r").read().strip()
+
 setup(name='avocado-framework-plugin-varianter-yaml-to-mux',
       description='Avocado Varianter plugin to parse YAML file into variants',
-      version=open("VERSION", "r").read().strip(),
+      version=VERSION,
       author='Avocado Developers',
       author_email='avocado-devel@redhat.com',
       url='http://avocado-framework.github.io/',
       packages=find_packages(exclude=('tests*',)),
       include_package_data=True,
-      install_requires=('avocado-framework', 'PyYAML>=4.2b2'),
+      install_requires=['avocado-framework==%s' % VERSION, 'PyYAML>=4.2b2'],
       test_suite='tests',
       entry_points={
           "avocado.plugins.cli": [


### PR DESCRIPTION
Right now the requirements from plugins only state that they need
avocado-framework.  But, changes between versions can cause
incompatiblity between plugins and Avocado proper.  This enforces a
stricter and safer approach that matches the Avocado and plugin
versions.

Signed-off-by: Cleber Rosa <crosa@redhat.com>