### PR TITLE
Nrunner: Runnable support for picking command or class [v2]

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -23,8 +23,9 @@ RUNNER_RUN_CHECK_INTERVAL = 0.01
 #: runner that performs its work asynchronously
 RUNNER_RUN_STATUS_INTERVAL = 0.5
 
-#: All known runners
-KNOWN_RUNNERS = {}
+#: All known runner commands, capable of being used by a
+#: SpawnMethod.STANDALONE_EXECUTABLE compatible spawners
+RUNNERS_REGISTRY_STANDALONE_EXECUTABLE = {}
 
 
 class SpawnMethod(enum.Enum):
@@ -47,8 +48,9 @@ def check_tasks_requirements(tasks, runners_registry=None):
 
     :param tasks: the tasks whose runner requirements will be checked
     :type tasks: list of :class:`Task`
-    :param runners_registry: a registry with previously found (and not
-                             found) runners keyed by task kind
+    :param runners_registry: a registry with previously found (and not found)
+                             runners keyed by a task's runnable kind.  Defauts
+                             to :attr:`RUNNERS_REGISTRY_STANDALONE_EXECUTABLE`
     :type runners_registry: dict
     :return: two list of tasks in a tuple, with the first being the tasks
              that pass the requirements check and the second the tasks that
@@ -56,7 +58,7 @@ def check_tasks_requirements(tasks, runners_registry=None):
     :rtype: tuple of (list, list)
     """
     if runners_registry is None:
-        runners_registry = KNOWN_RUNNERS
+        runners_registry = RUNNERS_REGISTRY_STANDALONE_EXECUTABLE
     ok = []
     missing = []
     for task in tasks:
@@ -327,7 +329,7 @@ class Runnable:
         :rtype: list of str or None
         """
         if runners_registry is None:
-            runners_registry = KNOWN_RUNNERS
+            runners_registry = RUNNERS_REGISTRY_STANDALONE_EXECUTABLE
         runner_cmd = runners_registry.get(self.kind)
         if runner_cmd is False:
             return None
@@ -683,7 +685,7 @@ class Task:
         :doc:`/blueprints/BP002`.
         """
         if runners_registry is None:
-            runners_registry = KNOWN_RUNNERS
+            runners_registry = RUNNERS_REGISTRY_STANDALONE_EXECUTABLE
         return self.runnable.pick_runner_command(runners_registry)
 
     @classmethod

--- a/avocado/core/nrunner_avocado_instrumented.py
+++ b/avocado/core/nrunner_avocado_instrumented.py
@@ -51,7 +51,11 @@ class AvocadoInstrumentedTestRunner(nrunner.BaseRunner):
         state = instance.get_state()
         # This should probably be done in a translator
         if 'status' in state:
-            state['status'] = state['status'].lower()
+            status = state['status'].lower()
+            if status in ['pass', 'fail', 'skip', 'error']:
+                state['result'] = status
+                state['status'] = 'finished'
+
         # This is a hack because the name is a TestID instance that can not
         # at this point be converted to JSON
         if 'name' in state:

--- a/avocado/core/nrunner_avocado_instrumented.py
+++ b/avocado/core/nrunner_avocado_instrumented.py
@@ -92,7 +92,7 @@ class AvocadoInstrumentedTestRunner(nrunner.BaseRunner):
 
 
 class RunnerApp(nrunner.BaseRunnerApp):
-    PROG_NAME = 'avocado-runner-avocado-instrumented',
+    PROG_NAME = 'avocado-runner-avocado-instrumented'
     PROG_DESCRIPTION = '*EXPERIMENTAL* N(ext) Runner for avocado-instrumented tests'
     RUNNABLE_KINDS_CAPABLE = {
         'avocado-instrumented': AvocadoInstrumentedTestRunner

--- a/selftests/unit/test_nrunner.py
+++ b/selftests/unit/test_nrunner.py
@@ -91,9 +91,7 @@ class Runnable(unittest.TestCase):
     def test_runner_from_runnable_error(self):
         runnable = nrunner.Runnable('unsupported_kind', '')
         try:
-            nrunner.runner_from_runnable(
-                runnable,
-                nrunner.RunnerApp.RUNNABLE_KINDS_CAPABLE)
+            runnable.pick_runner_class()
         except ValueError as e:
             self.assertEqual(str(e), 'Unsupported kind of runnable: unsupported_kind')
 
@@ -188,9 +186,8 @@ class Runner(unittest.TestCase):
 
     def test_runner_noop(self):
         runnable = nrunner.Runnable('noop', None)
-        runner = nrunner.runner_from_runnable(
-            runnable,
-            nrunner.RunnerApp.RUNNABLE_KINDS_CAPABLE)
+        runner_klass = runnable.pick_runner_class()
+        runner = runner_klass(runnable)
         results = [status for status in runner.run()]
         last_result = results[-1]
         self.assertEqual(last_result['status'], 'finished')
@@ -199,9 +196,8 @@ class Runner(unittest.TestCase):
     def test_runner_exec(self):
         runnable = nrunner.Runnable('exec', sys.executable,
                                     '-c', 'import time; time.sleep(0.01)')
-        runner = nrunner.runner_from_runnable(
-            runnable,
-            nrunner.RunnerApp.RUNNABLE_KINDS_CAPABLE)
+        runner_klass = runnable.pick_runner_class()
+        runner = runner_klass(runnable)
         results = [status for status in runner.run()]
         last_result = results[-1]
         self.assertEqual(last_result['status'], 'finished')
@@ -213,9 +209,8 @@ class Runner(unittest.TestCase):
     def test_runner_exec_test_ok(self):
         runnable = nrunner.Runnable('exec-test', sys.executable,
                                     '-c', 'import time; time.sleep(0.01)')
-        runner = nrunner.runner_from_runnable(
-            runnable,
-            nrunner.RunnerApp.RUNNABLE_KINDS_CAPABLE)
+        runner_klass = runnable.pick_runner_class()
+        runner = runner_klass(runnable)
         results = [status for status in runner.run()]
         last_result = results[-1]
         self.assertEqual(last_result['status'], 'finished')
@@ -227,9 +222,8 @@ class Runner(unittest.TestCase):
 
     def test_runner_exec_test_fail(self):
         runnable = nrunner.Runnable('exec-test', '/bin/false')
-        runner = nrunner.runner_from_runnable(
-            runnable,
-            nrunner.RunnerApp.RUNNABLE_KINDS_CAPABLE)
+        runner_klass = runnable.pick_runner_class()
+        runner = runner_klass(runnable)
         results = [status for status in runner.run()]
         last_result = results[-1]
         self.assertEqual(last_result['status'], 'finished')
@@ -241,9 +235,8 @@ class Runner(unittest.TestCase):
 
     def test_runner_python_unittest_ok(self):
         runnable = nrunner.Runnable('python-unittest', 'unittest.TestCase')
-        runner = nrunner.runner_from_runnable(
-            runnable,
-            nrunner.RunnerApp.RUNNABLE_KINDS_CAPABLE)
+        runner_klass = runnable.pick_runner_class()
+        runner = runner_klass(runnable)
         results = [status for status in runner.run()]
         output1 = ('----------------------------------------------------------'
                    '------------\nRan 0 tests in ')
@@ -256,9 +249,8 @@ class Runner(unittest.TestCase):
 
     def test_runner_python_unittest_fail(self):
         runnable = nrunner.Runnable('python-unittest', 'unittest.TestCase.fail')
-        runner = nrunner.runner_from_runnable(
-            runnable,
-            nrunner.RunnerApp.RUNNABLE_KINDS_CAPABLE)
+        runner_klass = runnable.pick_runner_class()
+        runner = runner_klass(runnable)
         results = [status for status in runner.run()]
         output1 = ('============================================================='
                    '=========\nFAIL: fail (unittest.case.TestCase)'
@@ -274,9 +266,8 @@ class Runner(unittest.TestCase):
         runnable = nrunner.Runnable(
             'python-unittest',
             'selftests.unit.test_test.TestClassTestUnit.DummyTest.skip')
-        runner = nrunner.runner_from_runnable(
-            runnable,
-            nrunner.RunnerApp.RUNNABLE_KINDS_CAPABLE)
+        runner_klass = runnable.pick_runner_class()
+        runner = runner_klass(runnable)
         results = [status for status in runner.run()]
         output1 = ('----------------------------------------------------------'
                    '------------\nRan 1 test in ')
@@ -289,9 +280,8 @@ class Runner(unittest.TestCase):
 
     def test_runner_python_unittest_error(self):
         runnable = nrunner.Runnable('python-unittest', 'error')
-        runner = nrunner.runner_from_runnable(
-            runnable,
-            nrunner.RunnerApp.RUNNABLE_KINDS_CAPABLE)
+        runner_klass = runnable.pick_runner_class()
+        runner = runner_klass(runnable)
         results = [status for status in runner.run()]
         output1 = ('============================================================='
                    '=========\nERROR: error')
@@ -304,9 +294,8 @@ class Runner(unittest.TestCase):
 
     def test_runner_python_unittest_empty_uri_error(self):
         runnable = nrunner.Runnable('python-unittest', '')
-        runner = nrunner.runner_from_runnable(
-            runnable,
-            nrunner.RunnerApp.RUNNABLE_KINDS_CAPABLE)
+        runner_klass = runnable.pick_runner_class()
+        runner = runner_klass(runnable)
         results = [status for status in runner.run()]
         output = 'uri is required but was not given'
         result = results[-1]

--- a/selftests/unit/test_nrunner.py
+++ b/selftests/unit/test_nrunner.py
@@ -441,41 +441,39 @@ echo 'ok 2 - description 2'"""
 class RunnerCommandSelection(unittest.TestCase):
 
     def setUp(self):
-        runnable = nrunner.Runnable('mykind',
-                                    'test_runner_command_selection')
-        self.task = nrunner.Task('1-test_runner_command_selection', runnable)
+        self.runnable = nrunner.Runnable('mykind',
+                                         'test_runner_command_selection')
 
     def test_is_task_kind_supported(self):
         cmd = ['sh', '-c',
                'test $0 = capabilities && '
                'echo -n {\\"runnables\\": [\\"mykind\\"]}']
-        self.assertTrue(self.task.is_kind_supported_by_runner_command(cmd))
+        self.assertTrue(self.runnable.is_kind_supported_by_runner_command(cmd))
 
     def test_is_task_kind_supported_other_kind(self):
         cmd = ['sh', '-c',
                'test $0 = capabilities && '
                'echo -n {\\"runnables\\": [\\"otherkind\\"]}']
-        self.assertFalse(self.task.is_kind_supported_by_runner_command(cmd))
+        self.assertFalse(self.runnable.is_kind_supported_by_runner_command(cmd))
 
     def test_is_task_kind_supported_no_output(self):
         cmd = ['sh', '-c', 'echo -n ""']
-        self.assertFalse(self.task.is_kind_supported_by_runner_command(cmd))
+        self.assertFalse(self.runnable.is_kind_supported_by_runner_command(cmd))
 
 
 class PickRunner(unittest.TestCase):
 
     def setUp(self):
-        runnable = nrunner.Runnable('lets-image-a-kind',
-                                    'test_pick_runner_command')
-        self.task = nrunner.Task('1-test_pick_runner_command', runnable)
+        self.runnable = nrunner.Runnable('lets-image-a-kind',
+                                         'test_pick_runner_command')
 
     def test_pick_runner_command(self):
         runner = ['avocado-runner-lets-image-a-kind']
         known = {'lets-image-a-kind': runner}
-        self.assertEqual(self.task.pick_runner_command(known), runner)
+        self.assertEqual(self.runnable.pick_runner_command(known), runner)
 
     def test_pick_runner_command_empty(self):
-        self.assertFalse(self.task.pick_runner_command({}))
+        self.assertFalse(self.runnable.pick_runner_command({}))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This, besides fixing some unrelated issues (described in their own commits), implements a more coherent location for the registries of known runners, both in the command and class forms.

The commands are currently and usually used by an upper layer, such the current spawners, and the classes are used internally in the runner scripts. But, it should be possible in the future to also have classes being used by (most probably local only) spawners for increased efficiency.

---

Changes from v1 (#3712):
 * Set the `status` key to `finished` on the final `avocado-instrumented` state message (@beraldoleal)