### PR TITLE
Add support to `requirement` docstring

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -676,8 +676,8 @@ class FileLoader(SimpleFileLoader):
                 test_path = test_path[:-3]
             test_module_name = os.path.relpath(test_path)
             test_module_name = test_module_name.replace(os.path.sep, ".")
-            candidates = [("%s.%s.%s" % (test_module_name, klass, method), tags)
-                          for (method, tags) in methods]
+            candidates = [("%s.%s.%s" % (test_module_name, klass, method),
+                           tags, reqs) for (method, tags, reqs) in methods]
             if subtests_filter:
                 result += [_ for _ in candidates if subtests_filter.search(_)]
             else:
@@ -711,7 +711,7 @@ class FileLoader(SimpleFileLoader):
                 test_factories = []
                 for test_class, info in avocado_tests.items():
                     if isinstance(test_class, str):
-                        for test_method, tgs in info:
+                        for test_method, tags, reqs in info:
                             name = test_name + \
                                 ':%s.%s' % (test_class, test_method)
                             if (subtests_filter and
@@ -720,7 +720,8 @@ class FileLoader(SimpleFileLoader):
                             tst = (test_class, {'name': name,
                                                 'modulePath': test_path,
                                                 'methodName': test_method,
-                                                'tags': tgs})
+                                                'tags': tags,
+                                                'requirements': reqs})
                             test_factories.append(tst)
                 return test_factories
             # Python unittests
@@ -737,8 +738,9 @@ class FileLoader(SimpleFileLoader):
             if python_unittests:
                 return [(test.PythonUnittest, {"name": name,
                                                "test_dir": py_test_dir,
-                                               "tags": tags})
-                        for (name, tags) in python_unittests]
+                                               "tags": tags,
+                                               "requirements": reqs})
+                        for (name, tags, reqs) in python_unittests]
             else:
                 # Module does not have an avocado test or pyunittest class inside,
                 # but maybe it's a Python executable.

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -181,6 +181,7 @@ class Runnable:
         self.uri = uri
         self.args = args
         self.tags = kwargs.pop('tags', None)
+        self.requirements = kwargs.pop('requirements', None)
         self.kwargs = kwargs
 
     def __repr__(self):

--- a/avocado/core/safeloader.py
+++ b/avocado/core/safeloader.py
@@ -342,7 +342,7 @@ def find_class_and_methods(path, method_pattern=None, base_class=None):
     return result
 
 
-def get_methods_info(statement_body, class_tags):
+def get_methods_info(statement_body, class_tags, class_requirements):
     """
     Returns information on an Avocado instrumented test method
     """
@@ -351,12 +351,16 @@ def get_methods_info(statement_body, class_tags):
         if (isinstance(st, ast.FunctionDef) and
                 st.name.startswith('test')):
             docstring = ast.get_docstring(st)
+
             mt_tags = get_docstring_directives_tags(docstring)
             mt_tags.update(class_tags)
 
-            methods = [method for method, _ in methods_info]
+            mt_requirements = get_docstring_directives_requirements(docstring)
+            mt_requirements.extend(class_requirements)
+
+            methods = [method for method, _, _ in methods_info]
             if st.name not in methods:
-                methods_info.append((st.name, mt_tags))
+                methods_info.append((st.name, mt_tags, mt_requirements))
 
     return methods_info
 
@@ -415,7 +419,9 @@ def _examine_class(path, class_name, match, target_module, target_class,
             match = determine_match(module, klass, docstring)
 
         info = get_methods_info(klass.body,
-                                get_docstring_directives_tags(docstring))
+                                get_docstring_directives_tags(docstring),
+                                get_docstring_directives_requirements(
+                                    docstring))
 
         # Getting the list of parents of the current class
         parents = klass.bases
@@ -522,7 +528,9 @@ def find_avocado_tests(path):
 
         if check_docstring_directive(docstring, 'enable'):
             info = get_methods_info(klass.body,
-                                    get_docstring_directives_tags(docstring))
+                                    get_docstring_directives_tags(docstring),
+                                    get_docstring_directives_requirements(
+                                        docstring))
             result[klass.name] = info
             continue
 
@@ -536,7 +544,9 @@ def find_avocado_tests(path):
         else:
             is_avocado = module.is_matching_klass(klass)
         info = get_methods_info(klass.body,
-                                get_docstring_directives_tags(docstring))
+                                get_docstring_directives_tags(docstring),
+                                get_docstring_directives_requirements(
+                                    docstring))
         _disabled = set()
 
         # Getting the list of parents of the current class
@@ -650,7 +660,9 @@ def find_python_unittests(path):
         is_unittest = module.is_matching_klass(klass)
 
         info = get_methods_info(klass.body,
-                                get_docstring_directives_tags(docstring))
+                                get_docstring_directives_tags(docstring),
+                                get_docstring_directives_requirements(
+                                    docstring))
 
         # Searching the parents in the same module
         for parent in parents[:]:

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -321,7 +321,8 @@ class Test(unittest.TestCase, TestData):
     timeout = None
 
     def __init__(self, methodName='test', name=None, params=None,
-                 base_logdir=None, job=None, runner_queue=None, tags=None):
+                 base_logdir=None, job=None, runner_queue=None, tags=None,
+                 requirements=None):
         """
         Initializes the test.
 
@@ -352,6 +353,7 @@ class Test(unittest.TestCase, TestData):
 
         self.__job = job
         self.__tags = tags
+        self.__requirements = requirements
 
         self.__base_logdir_tmp = None
         if base_logdir is None:
@@ -463,6 +465,13 @@ class Test(unittest.TestCase, TestData):
         The tags associated with this test
         """
         return self.__tags
+
+    @property
+    def requirements(self):
+        """
+        The requirements associated with this test
+        """
+        return self.__requirements
 
     @property
     def log(self):
@@ -1320,7 +1329,7 @@ class PythonUnittest(ExternalRunnerTest):
     """
     def __init__(self, name, params=None, base_logdir=None, job=None,
                  test_dir=None, python_unittest_module=None,
-                 tags=None):    # pylint: disable=W0613
+                 tags=None, requirements=None):    # pylint: disable=W0613
         runner = "%s -m unittest -q -c" % sys.executable
         external_runner = ExternalRunnerSpec(runner, "test", test_dir)
         super(PythonUnittest, self).__init__(name, params, base_logdir, job,

--- a/avocado/plugins/resolvers.py
+++ b/avocado/plugins/resolvers.py
@@ -101,8 +101,8 @@ class AvocadoInstrumentedResolver(Resolver):
         # disabled tests not needed here
         class_methods_info, _ = find_avocado_tests(module_path)
         runnables = []
-        for klass, methods_tags in class_methods_info.items():
-            for (method, tags) in methods_tags:
+        for klass, methods_tags_reqs in class_methods_info.items():
+            for (method, tags, reqs) in methods_tags_reqs:
                 klass_method = "%s.%s" % (klass, method)
                 if tests_filter is not None:
                     if not tests_filter.search(klass_method):
@@ -110,7 +110,8 @@ class AvocadoInstrumentedResolver(Resolver):
                 uri = "%s:%s" % (module_path, klass_method)
                 runnables.append(Runnable('avocado-instrumented',
                                           uri=uri,
-                                          tags=tags))
+                                          tags=tags,
+                                          requirements=reqs))
         if runnables:
             return ReferenceResolution(reference,
                                        ReferenceResolutionResult.SUCCESS,

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -354,6 +354,7 @@ class LoaderTest(unittest.TestCase):
         exp = [(test.PythonUnittest,
                 {"name": "python_unittest.SampleTest.test",
                  "tags": {"flattag": None, "foo": {"bar"}},
+                 "requirements": [],
                  "test_dir": os.path.dirname(python_unittest.path)})]
         self.assertEqual(tests, exp)
 


### PR DESCRIPTION
This adds support to use `requirement` docstrings to define a test requirement in JSON format.

ps. nrunner changes coming next!