### PR TITLE
nrunner: exports to the tests a temporary output dir (and a small refactoring)

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -4,7 +4,6 @@ import argparse
 import asyncio
 import base64
 import collections
-import enum
 import inspect
 import io
 import json
@@ -34,20 +33,6 @@ RUNNERS_REGISTRY_STANDALONE_EXECUTABLE = {}
 RUNNERS_REGISTRY_PYTHON_CLASS = {}
 
 
-class SpawnMethod(enum.Enum):
-    """The method employed to spawn a runnable or task."""
-    #: Spawns by running executing Python code, that is, having access to
-    #: a runnable or task instance, it calls its run() method.
-    PYTHON_CLASS = object()
-    #: Spawns by running a command, that is having either a path to an
-    #: executable or a list of arguments, it calls a function that will
-    #: execute that command (such as with os.system())
-    STANDALONE_EXECUTABLE = object()
-    #: Spawns with any method available, that is, it doesn't declare or
-    #: require a specific spawn method
-    ANY = object()
-
-
 def check_tasks_requirements(tasks, runners_registry=None):
     """
     Checks if tasks have runner requirements fulfilled
@@ -74,107 +59,6 @@ def check_tasks_requirements(tasks, runners_registry=None):
         else:
             missing.append(task)
     return (ok, missing)
-
-
-class BaseSpawner:
-    """Defines an interface to be followed by all implementations."""
-
-    METHODS = []
-
-    @staticmethod
-    def is_task_alive(task):
-        pass
-
-    def spawn_task(self, task):
-        pass
-
-
-class ProcessSpawner(BaseSpawner):
-
-    METHODS = [SpawnMethod.STANDALONE_EXECUTABLE]
-
-    @staticmethod
-    def is_task_alive(task):
-        return task.spawn_handle.returncode is None
-
-    @asyncio.coroutine
-    def spawn_task(self, task):
-        runner = task.runnable.pick_runner_command()
-        args = runner[1:] + ['task-run'] + task.get_command_args()
-        runner = runner[0]
-
-        #pylint: disable=E1133
-        task.spawn_handle = yield from asyncio.create_subprocess_exec(
-            runner,
-            *args,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE)
-
-
-class PodmanSpawner(BaseSpawner):
-
-    METHODS = [SpawnMethod.STANDALONE_EXECUTABLE]
-    IMAGE = 'fedora:31'
-    PODMAN_BIN = "/usr/bin/podman"
-
-    @staticmethod
-    def is_task_alive(task):
-        if task.spawn_handle is None:
-            return False
-
-        cmd = [PodmanSpawner.PODMAN_BIN, "ps", "--all", "--format={{.State}}",
-               "--filter=id=%s" % task.spawn_handle]
-        process = subprocess.Popen(cmd,
-                                   stdin=subprocess.DEVNULL,
-                                   stdout=subprocess.PIPE,
-                                   stderr=subprocess.DEVNULL)
-        out, _ = process.communicate()
-        # we have to be lenient and allow for the configured state to
-        # be considered "alive" because it happens before the
-        # container transitions into "running"
-        return out in [b'configured\n', b'running\n']
-
-    @asyncio.coroutine
-    def spawn_task(self, task):
-        entry_point_cmd = '/tmp/avocado-runner'
-        entry_point_args = task.get_command_args()
-        entry_point_args.insert(0, "task-run")
-        entry_point_args.insert(0, entry_point_cmd)
-        entry_point = json.dumps(entry_point_args)
-        entry_point_arg = "--entrypoint=" + entry_point
-        # pylint: disable=E1133
-        proc = yield from asyncio.create_subprocess_exec(
-            self.PODMAN_BIN, "create",
-            "--net=host",
-            entry_point_arg,
-            self.IMAGE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE)
-
-        _ = yield from proc.wait()
-        stdout = yield from proc.stdout.read()
-        container_id = stdout.decode().strip()
-
-        task.spawn_handle = container_id
-
-        # Currently limited to avocado-runner, we'll expand on that
-        # when the runner requirements system is in place
-        this_path = os.path.abspath(__file__)
-        common_path = os.path.dirname(os.path.dirname(this_path))
-        avocado_runner_path = os.path.join(common_path, 'core', 'nrunner.py')
-        proc = yield from asyncio.create_subprocess_exec(
-            self.PODMAN_BIN,
-            "cp",
-            avocado_runner_path,
-            "%s:%s" % (container_id, entry_point_cmd))
-        yield from proc.wait()
-
-        proc = yield from asyncio.create_subprocess_exec(self.PODMAN_BIN,
-                                                         "start",
-                                                         container_id,
-                                                         stdout=asyncio.subprocess.PIPE,
-                                                         stderr=asyncio.subprocess.PIPE)
-        yield from proc.wait()
 
 
 class Runnable:

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -364,8 +364,9 @@ class ExecRunner(BaseRunner):
 
         return_code = process.returncode
         yield self.prepare_status('finished', {'returncode': return_code,
-                                                'stdout': stdout,
-                                                'stderr': stderr})
+                                               'stdout': stdout,
+                                               'stderr': stderr})
+
 
 RUNNERS_REGISTRY_PYTHON_CLASS['exec'] = ExecRunner
 

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -668,13 +668,14 @@ class Task:
 
 class StatusServer:
 
-    def __init__(self, uri, tasks_pending=None):
+    def __init__(self, uri, tasks_pending=None, verbose=False):
         self.uri = uri
         self.server_task = None
         self.result = {}
         if tasks_pending is None:
             tasks_pending = []
         self.tasks_pending = tasks_pending
+        self.verbose = verbose
         self.wait_on_tasks_pending = len(self.tasks_pending) > 0
 
     @asyncio.coroutine
@@ -713,7 +714,9 @@ class StatusServer:
         yield from server.wait_closed()
 
     def handle_task_started(self, data):
-        pass
+        if self.verbose:
+            print("Task started: {}. Outputdir: {}".format(data['id'],
+                                                           data['output_dir']))
 
     def handle_task_finished(self, data):
         try:

--- a/avocado/core/spawners/common.py
+++ b/avocado/core/spawners/common.py
@@ -1,0 +1,28 @@
+import enum
+
+
+class SpawnMethod(enum.Enum):
+    """The method employed to spawn a runnable or task."""
+    #: Spawns by running executing Python code, that is, having access to
+    #: a runnable or task instance, it calls its run() method.
+    PYTHON_CLASS = object()
+    #: Spawns by running a command, that is having either a path to an
+    #: executable or a list of arguments, it calls a function that will
+    #: execute that command (such as with os.system())
+    STANDALONE_EXECUTABLE = object()
+    #: Spawns with any method available, that is, it doesn't declare or
+    #: require a specific spawn method
+    ANY = object()
+
+
+class BaseSpawner:
+    """Defines an interface to be followed by all implementations."""
+
+    METHODS = []
+
+    @staticmethod
+    def is_task_alive(task):
+        pass
+
+    def spawn_task(self, task):
+        pass

--- a/avocado/core/spawners/podman.py
+++ b/avocado/core/spawners/podman.py
@@ -71,3 +71,9 @@ class PodmanSpawner(BaseSpawner):
                                                          stdout=asyncio.subprocess.PIPE,
                                                          stderr=asyncio.subprocess.PIPE)
         yield from proc.wait()
+
+    def create_output_dir_for_task(self, task):
+        """In this case is a remote folder."""
+        local_dir = '/tmp/avocado/tasks/{}/output'.format(task.identifier)
+        os.mkdirs(local_dir, exist_ok=True)
+        task.set_output_dir(local_dir)

--- a/avocado/core/spawners/podman.py
+++ b/avocado/core/spawners/podman.py
@@ -1,0 +1,73 @@
+import asyncio
+import json
+import subprocess
+import os
+
+from .common import BaseSpawner
+from .common import SpawnMethod
+
+
+class PodmanSpawner(BaseSpawner):
+
+    METHODS = [SpawnMethod.STANDALONE_EXECUTABLE]
+    IMAGE = 'fedora:31'
+    PODMAN_BIN = "/usr/bin/podman"
+
+    @staticmethod
+    def is_task_alive(task):
+        if task.spawn_handle is None:
+            return False
+
+        cmd = [PodmanSpawner.PODMAN_BIN, "ps", "--all", "--format={{.State}}",
+               "--filter=id=%s" % task.spawn_handle]
+        process = subprocess.Popen(cmd,
+                                   stdin=subprocess.DEVNULL,
+                                   stdout=subprocess.PIPE,
+                                   stderr=subprocess.DEVNULL)
+        out, _ = process.communicate()
+        # we have to be lenient and allow for the configured state to
+        # be considered "alive" because it happens before the
+        # container transitions into "running"
+        return out in [b'configured\n', b'running\n']
+
+    @asyncio.coroutine
+    def spawn_task(self, task):
+        entry_point_cmd = '/tmp/avocado-runner'
+        entry_point_args = task.get_command_args()
+        entry_point_args.insert(0, "task-run")
+        entry_point_args.insert(0, entry_point_cmd)
+        entry_point = json.dumps(entry_point_args)
+        entry_point_arg = "--entrypoint=" + entry_point
+        # pylint: disable=E1133
+        proc = yield from asyncio.create_subprocess_exec(
+            self.PODMAN_BIN, "create",
+            "--net=host",
+            entry_point_arg,
+            self.IMAGE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE)
+
+        _ = yield from proc.wait()
+        stdout = yield from proc.stdout.read()
+        container_id = stdout.decode().strip()
+
+        task.spawn_handle = container_id
+
+        # Currently limited to avocado-runner, we'll expand on that
+        # when the runner requirements system is in place
+        this_path = os.path.abspath(__file__)
+        common_path = os.path.dirname(os.path.dirname(this_path))
+        avocado_runner_path = os.path.join(common_path, 'core', 'nrunner.py')
+        proc = yield from asyncio.create_subprocess_exec(
+            self.PODMAN_BIN,
+            "cp",
+            avocado_runner_path,
+            "%s:%s" % (container_id, entry_point_cmd))
+        yield from proc.wait()
+
+        proc = yield from asyncio.create_subprocess_exec(self.PODMAN_BIN,
+                                                         "start",
+                                                         container_id,
+                                                         stdout=asyncio.subprocess.PIPE,
+                                                         stderr=asyncio.subprocess.PIPE)
+        yield from proc.wait()

--- a/avocado/core/spawners/process.py
+++ b/avocado/core/spawners/process.py
@@ -1,0 +1,26 @@
+import asyncio
+
+from .common import BaseSpawner
+from .common import SpawnMethod
+
+
+class ProcessSpawner(BaseSpawner):
+
+    METHODS = [SpawnMethod.STANDALONE_EXECUTABLE]
+
+    @staticmethod
+    def is_task_alive(task):
+        return task.spawn_handle.returncode is None
+
+    @asyncio.coroutine
+    def spawn_task(self, task):
+        runner = task.pick_runner_command()
+        args = runner[1:] + ['task-run'] + task.get_command_args()
+        runner = runner[0]
+
+        #pylint: disable=E1133
+        task.spawn_handle = yield from asyncio.create_subprocess_exec(
+            runner,
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE)

--- a/avocado/core/spawners/process.py
+++ b/avocado/core/spawners/process.py
@@ -18,7 +18,7 @@ class ProcessSpawner(BaseSpawner):
         args = runner[1:] + ['task-run'] + task.get_command_args()
         runner = runner[0]
 
-        #pylint: disable=E1133
+        # pylint: disable=E1133
         task.spawn_handle = yield from asyncio.create_subprocess_exec(
             runner,
             *args,

--- a/avocado/plugins/nrun.py
+++ b/avocado/plugins/nrun.py
@@ -132,9 +132,11 @@ class NRun(CLICmd):
                 self.spawner = ProcessSpawner()  # pylint: disable=W0201
             loop = asyncio.get_event_loop()
             listen = config.get('nrun.status_server.listen')
+            verbose = config.get('core.verbose')
             self.status_server = nrunner.StatusServer(listen,  # pylint: disable=W0201
                                                       [t.identifier for t in
-                                                       self.pending_tasks])
+                                                       self.pending_tasks],
+                                                      verbose)
             self.status_server.start()
             parallel_tasks = config.get('nrun.parallel_tasks')
             loop.run_until_complete(self.spawn_tasks(parallel_tasks))

--- a/avocado/plugins/nrun.py
+++ b/avocado/plugins/nrun.py
@@ -9,6 +9,8 @@ from avocado.core import job
 from avocado.core import nrunner
 from avocado.core import parser_common_args
 from avocado.core import resolver
+from avocado.core.spawners.process import ProcessSpawner
+from avocado.core.spawners.podman import PodmanSpawner
 from avocado.core.future.settings import settings
 from avocado.core.output import LOG_UI
 from avocado.core.parser import HintParser
@@ -118,16 +120,16 @@ class NRun(CLICmd):
 
         try:
             if config.get('nrun.spawners.podman.enabled'):
-                if not os.path.exists(nrunner.PodmanSpawner.PODMAN_BIN):
+                if not os.path.exists(PodmanSpawner.PODMAN_BIN):
                     msg = ('Podman Spawner selected, but podman binary "%s" '
                            'is not available on the system.  Please install '
                            'podman before attempting to use this feature.')
-                    msg %= nrunner.PodmanSpawner.PODMAN_BIN
+                    msg %= PodmanSpawner.PODMAN_BIN
                     LOG_UI.error(msg)
                     sys.exit(exit_codes.AVOCADO_JOB_FAIL)
-                self.spawner = nrunner.PodmanSpawner()  # pylint: disable=W0201
+                self.spawner = PodmanSpawner()  # pylint: disable=W0201
             else:
-                self.spawner = nrunner.ProcessSpawner()  # pylint: disable=W0201
+                self.spawner = ProcessSpawner()  # pylint: disable=W0201
             loop = asyncio.get_event_loop()
             listen = config.get('nrun.status_server.listen')
             self.status_server = nrunner.StatusServer(listen,  # pylint: disable=W0201

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -57,15 +57,15 @@ class Runner(RunnerInterface):
             for status in task.run():
                 result_dispatcher.map_method('test_progress', False)
                 statuses.append(status)
-                if status['status'] not in ["init", "running"]:
+                if status['status'] not in ["started", "running"]:
                     break
 
             # test execution time is currently missing
             test_state = {'status': statuses[-1]['status'].upper()}
             test_state.update(early_state)
 
-            time_start = statuses[0]['time_start']
-            time_end = statuses[-1]['time_end']
+            time_start = statuses[0]['time']
+            time_end = statuses[-1]['time']
             time_elapsed = time_end - time_start
             test_state['time_start'] = time_start
             test_state['time_end'] = time_end

--- a/selftests/check_tmp_dirs
+++ b/selftests/check_tmp_dirs
@@ -18,6 +18,9 @@ def check_tmp_dirs():
     for dir_to_check in dirs_to_check:
         dir_list = os.listdir(dir_to_check)
         avocado_tmp_dirs = [d for d in dir_list if d.startswith('avocado')]
+        # This is the only exception since that nrun will keep files when
+        # running locally (ProcessSpawner)
+        avocado_tmp_dirs.remove('avocado-tasks')
         try:
             assert len(avocado_tmp_dirs) == 0
             print('No temporary avocado dirs lying around in %s' %

--- a/selftests/functional/test_nrunner.py
+++ b/selftests/functional/test_nrunner.py
@@ -16,9 +16,9 @@ class RunnableRun(unittest.TestCase):
     def test_noop(self):
         res = process.run("%s runnable-run -k noop" % RUNNER,
                           ignore_status=True)
+        self.assertIn(b"'status': 'started'", res.stdout)
         self.assertIn(b"'status': 'finished'", res.stdout)
-        self.assertIn(b"'time_start': ", res.stdout)
-        self.assertIn(b"'time_end': ", res.stdout)
+        self.assertIn(b"'time': ", res.stdout)
         self.assertEqual(res.exit_status, 0)
 
     def test_exec(self):
@@ -61,11 +61,11 @@ class RunnableRun(unittest.TestCase):
         else:
             first_status = lines[0]
             final_status = lines[-1]
-            self.assertIn("'status': 'running'", first_status)
-            self.assertIn("'time_start': ", first_status)
+            self.assertIn("'status': 'started'", first_status)
+            self.assertIn("'time': ", first_status)
         self.assertIn("'status': 'finished'", final_status)
         self.assertIn("'stdout': b'Hello world!\\n'", final_status)
-        self.assertIn("'time_end': ", final_status)
+        self.assertIn("'time': ", final_status)
         self.assertEqual(res.exit_status, 0)
 
     def test_noop_valid_kwargs(self):
@@ -113,7 +113,7 @@ class TaskRun(unittest.TestCase):
         else:
             first_status = lines[0]
             final_status = lines[-1]
-            self.assertIn("'status': 'running'", first_status)
+            self.assertIn("'status': 'started'", first_status)
             self.assertIn("'id': 1", first_status)
         self.assertIn("'id': 1", first_status)
         self.assertIn("'status': 'finished'", final_status)
@@ -133,7 +133,7 @@ class TaskRun(unittest.TestCase):
         else:
             first_status = lines[0]
             final_status = lines[-1]
-            self.assertIn("'status': 'running'", first_status)
+            self.assertIn("'status': 'started'", first_status)
             self.assertIn("'id': 2", first_status)
         self.assertIn("'id': 2", first_status)
         self.assertIn("'status': 'finished'", final_status)
@@ -153,7 +153,7 @@ class TaskRun(unittest.TestCase):
         # this runnable should produce multiple status lines
         self.assertGreater(len(lines), 1)
         first_status = lines[0]
-        self.assertIn("'status': 'running'", first_status)
+        self.assertIn("'status': 'started'", first_status)
         self.assertIn("'id': 3", first_status)
         final_status = lines[-1]
         self.assertIn("'id': 3", first_status)

--- a/selftests/unit/test_nrunner.py
+++ b/selftests/unit/test_nrunner.py
@@ -191,7 +191,7 @@ class Runner(unittest.TestCase):
         results = [status for status in runner.run()]
         last_result = results[-1]
         self.assertEqual(last_result['status'], 'finished')
-        self.assertIn('time_end', last_result)
+        self.assertIn('time', last_result)
 
     def test_runner_exec(self):
         runnable = nrunner.Runnable('exec', sys.executable,
@@ -204,7 +204,7 @@ class Runner(unittest.TestCase):
         self.assertEqual(last_result['returncode'], 0)
         self.assertEqual(last_result['stdout'], b'')
         self.assertEqual(last_result['stderr'], b'')
-        self.assertIn('time_end', last_result)
+        self.assertIn('time', last_result)
 
     def test_runner_exec_test_ok(self):
         runnable = nrunner.Runnable('exec-test', sys.executable,
@@ -218,7 +218,7 @@ class Runner(unittest.TestCase):
         self.assertEqual(last_result['returncode'], 0)
         self.assertEqual(last_result['stdout'], b'')
         self.assertEqual(last_result['stderr'], b'')
-        self.assertIn('time_end', last_result)
+        self.assertIn('time', last_result)
 
     def test_runner_exec_test_fail(self):
         runnable = nrunner.Runnable('exec-test', '/bin/false')
@@ -231,7 +231,7 @@ class Runner(unittest.TestCase):
         self.assertEqual(last_result['returncode'], 1)
         self.assertEqual(last_result['stdout'], b'')
         self.assertEqual(last_result['stderr'], b'')
-        self.assertIn('time_end', last_result)
+        self.assertIn('time', last_result)
 
     def test_runner_python_unittest_ok(self):
         runnable = nrunner.Runnable('python-unittest', 'unittest.TestCase')


### PR DESCRIPTION
This pull request will introduce the ability to tests to see through the environment variable AVOCADO_TEST_OUTPUT_DIR where to write output results. This is part of #3695 and is the foundation to collect those results. Also a small organization is proposed here, removing spawners from nrunner.py.