### PR TITLE
nrunner: exports to the tests a temporary output dir (and a small refactoring) - v2

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -336,7 +336,12 @@ class ExecRunner(BaseRunner):
        process
     """
     def run(self):
-        env = self.runnable.kwargs or None
+        env = None
+        if self.runnable.kwargs:
+            current = dict(os.environ)
+            current.update(self.runnable.kwargs)
+            env = current
+
         process = subprocess.Popen(
             [self.runnable.uri] + list(self.runnable.args),
             stdin=subprocess.DEVNULL,

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -4,7 +4,6 @@ import argparse
 import asyncio
 import base64
 import collections
-import enum
 import inspect
 import io
 import json
@@ -34,20 +33,6 @@ RUNNERS_REGISTRY_STANDALONE_EXECUTABLE = {}
 RUNNERS_REGISTRY_PYTHON_CLASS = {}
 
 
-class SpawnMethod(enum.Enum):
-    """The method employed to spawn a runnable or task."""
-    #: Spawns by running executing Python code, that is, having access to
-    #: a runnable or task instance, it calls its run() method.
-    PYTHON_CLASS = object()
-    #: Spawns by running a command, that is having either a path to an
-    #: executable or a list of arguments, it calls a function that will
-    #: execute that command (such as with os.system())
-    STANDALONE_EXECUTABLE = object()
-    #: Spawns with any method available, that is, it doesn't declare or
-    #: require a specific spawn method
-    ANY = object()
-
-
 def check_tasks_requirements(tasks, runners_registry=None):
     """
     Checks if tasks have runner requirements fulfilled
@@ -74,107 +59,6 @@ def check_tasks_requirements(tasks, runners_registry=None):
         else:
             missing.append(task)
     return (ok, missing)
-
-
-class BaseSpawner:
-    """Defines an interface to be followed by all implementations."""
-
-    METHODS = []
-
-    @staticmethod
-    def is_task_alive(task):
-        pass
-
-    def spawn_task(self, task):
-        pass
-
-
-class ProcessSpawner(BaseSpawner):
-
-    METHODS = [SpawnMethod.STANDALONE_EXECUTABLE]
-
-    @staticmethod
-    def is_task_alive(task):
-        return task.spawn_handle.returncode is None
-
-    @asyncio.coroutine
-    def spawn_task(self, task):
-        runner = task.runnable.pick_runner_command()
-        args = runner[1:] + ['task-run'] + task.get_command_args()
-        runner = runner[0]
-
-        #pylint: disable=E1133
-        task.spawn_handle = yield from asyncio.create_subprocess_exec(
-            runner,
-            *args,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE)
-
-
-class PodmanSpawner(BaseSpawner):
-
-    METHODS = [SpawnMethod.STANDALONE_EXECUTABLE]
-    IMAGE = 'fedora:31'
-    PODMAN_BIN = "/usr/bin/podman"
-
-    @staticmethod
-    def is_task_alive(task):
-        if task.spawn_handle is None:
-            return False
-
-        cmd = [PodmanSpawner.PODMAN_BIN, "ps", "--all", "--format={{.State}}",
-               "--filter=id=%s" % task.spawn_handle]
-        process = subprocess.Popen(cmd,
-                                   stdin=subprocess.DEVNULL,
-                                   stdout=subprocess.PIPE,
-                                   stderr=subprocess.DEVNULL)
-        out, _ = process.communicate()
-        # we have to be lenient and allow for the configured state to
-        # be considered "alive" because it happens before the
-        # container transitions into "running"
-        return out in [b'configured\n', b'running\n']
-
-    @asyncio.coroutine
-    def spawn_task(self, task):
-        entry_point_cmd = '/tmp/avocado-runner'
-        entry_point_args = task.get_command_args()
-        entry_point_args.insert(0, "task-run")
-        entry_point_args.insert(0, entry_point_cmd)
-        entry_point = json.dumps(entry_point_args)
-        entry_point_arg = "--entrypoint=" + entry_point
-        # pylint: disable=E1133
-        proc = yield from asyncio.create_subprocess_exec(
-            self.PODMAN_BIN, "create",
-            "--net=host",
-            entry_point_arg,
-            self.IMAGE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE)
-
-        _ = yield from proc.wait()
-        stdout = yield from proc.stdout.read()
-        container_id = stdout.decode().strip()
-
-        task.spawn_handle = container_id
-
-        # Currently limited to avocado-runner, we'll expand on that
-        # when the runner requirements system is in place
-        this_path = os.path.abspath(__file__)
-        common_path = os.path.dirname(os.path.dirname(this_path))
-        avocado_runner_path = os.path.join(common_path, 'core', 'nrunner.py')
-        proc = yield from asyncio.create_subprocess_exec(
-            self.PODMAN_BIN,
-            "cp",
-            avocado_runner_path,
-            "%s:%s" % (container_id, entry_point_cmd))
-        yield from proc.wait()
-
-        proc = yield from asyncio.create_subprocess_exec(self.PODMAN_BIN,
-                                                         "start",
-                                                         container_id,
-                                                         stdout=asyncio.subprocess.PIPE,
-                                                         stderr=asyncio.subprocess.PIPE)
-        yield from proc.wait()
 
 
 class Runnable:

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -12,8 +12,10 @@ import os
 import socket
 import subprocess
 import sys
+import tempfile
 import time
 import unittest
+
 
 #: The amount of time (in seconds) between each internal status check
 RUNNER_RUN_CHECK_INTERVAL = 0.01
@@ -572,7 +574,8 @@ class Task:
     :param identifier:
     :param runnable:
     """
-    def __init__(self, identifier, runnable, status_uris=None, known_runners=None):
+    def __init__(self, identifier, runnable, status_uris=None,
+                 known_runners=None):
         self.identifier = identifier
         self.runnable = runnable
         self.status_services = []
@@ -583,6 +586,7 @@ class Task:
             known_runners = {}
         self.known_runners = known_runners
         self.spawn_handle = None
+        self._output_dir = None
 
     def __repr__(self):
         fmt = '<Task identifier="{}" runnable="{}" status_services="{}"'
@@ -598,6 +602,11 @@ class Task:
         if runners_registry is None:
             runners_registry = RUNNERS_REGISTRY_STANDALONE_EXECUTABLE
         return self.runnable.pick_runner_command(runners_registry)
+
+    def setup_output_dir(self):
+        self._output_dir = tempfile.mkdtemp(prefix='.avocado-task-')
+        env_var = {'AVOCADO_TEST_OUTPUT_DIR': self._output_dir}
+        self.runnable.kwargs.update(env_var)
 
     @classmethod
     def from_recipe(cls, task_path, known_runners):
@@ -640,9 +649,12 @@ class Task:
         return args
 
     def run(self):
+        self.setup_output_dir()
         runner_klass = self.runnable.pick_runner_class(self.known_runners)
         runner = runner_klass(self.runnable)
         for status in runner.run():
+            if status['status'] == 'started':
+                status.update({'output_dir': self._output_dir})
             status.update({"id": self.identifier})
             for status_service in self.status_services:
                 status_service.post(status)

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -364,8 +364,9 @@ class ExecRunner(BaseRunner):
 
         return_code = process.returncode
         yield self.prepare_status('finished', {'returncode': return_code,
-                                                'stdout': stdout,
-                                                'stderr': stderr})
+                                               'stdout': stdout,
+                                               'stderr': stderr})
+
 
 RUNNERS_REGISTRY_PYTHON_CLASS['exec'] = ExecRunner
 

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -668,13 +668,14 @@ class Task:
 
 class StatusServer:
 
-    def __init__(self, uri, tasks_pending=None):
+    def __init__(self, uri, tasks_pending=None, verbose=False):
         self.uri = uri
         self.server_task = None
         self.result = {}
         if tasks_pending is None:
             tasks_pending = []
         self.tasks_pending = tasks_pending
+        self.verbose = verbose
         self.wait_on_tasks_pending = len(self.tasks_pending) > 0
 
     @asyncio.coroutine
@@ -713,7 +714,9 @@ class StatusServer:
         yield from server.wait_closed()
 
     def handle_task_started(self, data):
-        pass
+        if self.verbose:
+            print("Task started: {}. Outputdir: {}".format(data['id'],
+                                                           data['output_dir']))
 
     def handle_task_finished(self, data):
         try:

--- a/avocado/core/nrunner_avocado_instrumented.py
+++ b/avocado/core/nrunner_avocado_instrumented.py
@@ -68,8 +68,6 @@ class AvocadoInstrumentedTestRunner(nrunner.BaseRunner):
         queue = multiprocessing.SimpleQueue()
         process = multiprocessing.Process(target=self._run_avocado,
                                           args=(self.runnable, queue))
-        time_start = time.time()
-        time_start_sent = False
         process.start()
 
         most_current_execution_state_time = None
@@ -82,11 +80,7 @@ class AvocadoInstrumentedTestRunner(nrunner.BaseRunner):
             if (most_current_execution_state_time is None or
                     now > next_execution_state_mark):
                 most_current_execution_state_time = now
-                if not time_start_sent:
-                    time_start_sent = True
-                    yield {'status': 'running',
-                           'time_start': time_start}
-                yield {'status': 'running'}
+                yield self.prepare_status('running')
 
         yield queue.get()
 

--- a/avocado/core/nrunner_tap.py
+++ b/avocado/core/nrunner_tap.py
@@ -41,8 +41,7 @@ class TAPRunner(nrunner.BaseRunner):
 
         while process.poll() is None:
             time.sleep(nrunner.RUNNER_RUN_STATUS_INTERVAL)
-            yield {'status': 'running',
-                   'timestamp': time.time()}
+            yield self.prepare_status('running')
 
         stdout = io.TextIOWrapper(process.stdout)
         parser = TapParser(stdout)
@@ -64,10 +63,9 @@ class TAPRunner(nrunner.BaseRunner):
                 else:
                     result = 'pass'
 
-        yield {'status': 'finished',
-               'result': result,
-               'returncode': process.returncode,
-               'timestamp': time.time()}
+        yield self.prepare_status('finished',
+                                  {'result': result,
+                                   'returncode': process.returncode})
 
 
 class RunnerApp(nrunner.BaseRunnerApp):

--- a/avocado/core/spawners/common.py
+++ b/avocado/core/spawners/common.py
@@ -1,0 +1,28 @@
+import enum
+
+
+class SpawnMethod(enum.Enum):
+    """The method employed to spawn a runnable or task."""
+    #: Spawns by running executing Python code, that is, having access to
+    #: a runnable or task instance, it calls its run() method.
+    PYTHON_CLASS = object()
+    #: Spawns by running a command, that is having either a path to an
+    #: executable or a list of arguments, it calls a function that will
+    #: execute that command (such as with os.system())
+    STANDALONE_EXECUTABLE = object()
+    #: Spawns with any method available, that is, it doesn't declare or
+    #: require a specific spawn method
+    ANY = object()
+
+
+class BaseSpawner:
+    """Defines an interface to be followed by all implementations."""
+
+    METHODS = []
+
+    @staticmethod
+    def is_task_alive(task):
+        pass
+
+    def spawn_task(self, task):
+        pass

--- a/avocado/core/spawners/podman.py
+++ b/avocado/core/spawners/podman.py
@@ -1,0 +1,73 @@
+import asyncio
+import json
+import subprocess
+import os
+
+from .common import BaseSpawner
+from .common import SpawnMethod
+
+
+class PodmanSpawner(BaseSpawner):
+
+    METHODS = [SpawnMethod.STANDALONE_EXECUTABLE]
+    IMAGE = 'fedora:31'
+    PODMAN_BIN = "/usr/bin/podman"
+
+    @staticmethod
+    def is_task_alive(task):
+        if task.spawn_handle is None:
+            return False
+
+        cmd = [PodmanSpawner.PODMAN_BIN, "ps", "--all", "--format={{.State}}",
+               "--filter=id=%s" % task.spawn_handle]
+        process = subprocess.Popen(cmd,
+                                   stdin=subprocess.DEVNULL,
+                                   stdout=subprocess.PIPE,
+                                   stderr=subprocess.DEVNULL)
+        out, _ = process.communicate()
+        # we have to be lenient and allow for the configured state to
+        # be considered "alive" because it happens before the
+        # container transitions into "running"
+        return out in [b'configured\n', b'running\n']
+
+    @asyncio.coroutine
+    def spawn_task(self, task):
+        entry_point_cmd = '/tmp/avocado-runner'
+        entry_point_args = task.get_command_args()
+        entry_point_args.insert(0, "task-run")
+        entry_point_args.insert(0, entry_point_cmd)
+        entry_point = json.dumps(entry_point_args)
+        entry_point_arg = "--entrypoint=" + entry_point
+        # pylint: disable=E1133
+        proc = yield from asyncio.create_subprocess_exec(
+            self.PODMAN_BIN, "create",
+            "--net=host",
+            entry_point_arg,
+            self.IMAGE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE)
+
+        _ = yield from proc.wait()
+        stdout = yield from proc.stdout.read()
+        container_id = stdout.decode().strip()
+
+        task.spawn_handle = container_id
+
+        # Currently limited to avocado-runner, we'll expand on that
+        # when the runner requirements system is in place
+        this_path = os.path.abspath(__file__)
+        common_path = os.path.dirname(os.path.dirname(this_path))
+        avocado_runner_path = os.path.join(common_path, 'core', 'nrunner.py')
+        proc = yield from asyncio.create_subprocess_exec(
+            self.PODMAN_BIN,
+            "cp",
+            avocado_runner_path,
+            "%s:%s" % (container_id, entry_point_cmd))
+        yield from proc.wait()
+
+        proc = yield from asyncio.create_subprocess_exec(self.PODMAN_BIN,
+                                                         "start",
+                                                         container_id,
+                                                         stdout=asyncio.subprocess.PIPE,
+                                                         stderr=asyncio.subprocess.PIPE)
+        yield from proc.wait()

--- a/avocado/core/spawners/process.py
+++ b/avocado/core/spawners/process.py
@@ -1,0 +1,26 @@
+import asyncio
+
+from .common import BaseSpawner
+from .common import SpawnMethod
+
+
+class ProcessSpawner(BaseSpawner):
+
+    METHODS = [SpawnMethod.STANDALONE_EXECUTABLE]
+
+    @staticmethod
+    def is_task_alive(task):
+        return task.spawn_handle.returncode is None
+
+    @asyncio.coroutine
+    def spawn_task(self, task):
+        runner = task.runnable.pick_runner_command()
+        args = runner[1:] + ['task-run'] + task.get_command_args()
+        runner = runner[0]
+
+        #pylint: disable=E1133
+        task.spawn_handle = yield from asyncio.create_subprocess_exec(
+            runner,
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE)

--- a/avocado/core/spawners/process.py
+++ b/avocado/core/spawners/process.py
@@ -18,7 +18,7 @@ class ProcessSpawner(BaseSpawner):
         args = runner[1:] + ['task-run'] + task.get_command_args()
         runner = runner[0]
 
-        #pylint: disable=E1133
+        # pylint: disable=E1133
         task.spawn_handle = yield from asyncio.create_subprocess_exec(
             runner,
             *args,

--- a/avocado/plugins/nrun.py
+++ b/avocado/plugins/nrun.py
@@ -132,9 +132,11 @@ class NRun(CLICmd):
                 self.spawner = ProcessSpawner()  # pylint: disable=W0201
             loop = asyncio.get_event_loop()
             listen = config.get('nrun.status_server.listen')
+            verbose = config.get('core.verbose')
             self.status_server = nrunner.StatusServer(listen,  # pylint: disable=W0201
                                                       [t.identifier for t in
-                                                       self.pending_tasks])
+                                                       self.pending_tasks],
+                                                      verbose)
             self.status_server.start()
             parallel_tasks = config.get('nrun.parallel_tasks')
             loop.run_until_complete(self.spawn_tasks(parallel_tasks))

--- a/avocado/plugins/nrun.py
+++ b/avocado/plugins/nrun.py
@@ -9,6 +9,8 @@ from avocado.core import job
 from avocado.core import nrunner
 from avocado.core import parser_common_args
 from avocado.core import resolver
+from avocado.core.spawners.process import ProcessSpawner
+from avocado.core.spawners.podman import PodmanSpawner
 from avocado.core.future.settings import settings
 from avocado.core.output import LOG_UI
 from avocado.core.parser import HintParser
@@ -118,16 +120,16 @@ class NRun(CLICmd):
 
         try:
             if config.get('nrun.spawners.podman.enabled'):
-                if not os.path.exists(nrunner.PodmanSpawner.PODMAN_BIN):
+                if not os.path.exists(PodmanSpawner.PODMAN_BIN):
                     msg = ('Podman Spawner selected, but podman binary "%s" '
                            'is not available on the system.  Please install '
                            'podman before attempting to use this feature.')
-                    msg %= nrunner.PodmanSpawner.PODMAN_BIN
+                    msg %= PodmanSpawner.PODMAN_BIN
                     LOG_UI.error(msg)
                     sys.exit(exit_codes.AVOCADO_JOB_FAIL)
-                self.spawner = nrunner.PodmanSpawner()  # pylint: disable=W0201
+                self.spawner = PodmanSpawner()  # pylint: disable=W0201
             else:
-                self.spawner = nrunner.ProcessSpawner()  # pylint: disable=W0201
+                self.spawner = ProcessSpawner()  # pylint: disable=W0201
             loop = asyncio.get_event_loop()
             listen = config.get('nrun.status_server.listen')
             self.status_server = nrunner.StatusServer(listen,  # pylint: disable=W0201

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -54,7 +54,7 @@ class Runner(RunnerInterface):
             for status in task.run():
                 result_dispatcher.map_method('test_progress', False)
                 statuses.append(status)
-                if status['status'] not in ["init", "running"]:
+                if status['status'] not in ["started", "running"]:
                     break
 
             # test execution time is currently missing
@@ -64,8 +64,8 @@ class Runner(RunnerInterface):
             test_state = {'status': statuses[-1]['result'].upper()}
             test_state.update(early_state)
 
-            time_start = statuses[0]['time_start']
-            time_end = statuses[-1]['time_end']
+            time_start = statuses[0]['time']
+            time_end = statuses[-1]['time']
             time_elapsed = time_end - time_start
             test_state['time_start'] = time_start
             test_state['time_end'] = time_end

--- a/selftests/functional/test_nrunner.py
+++ b/selftests/functional/test_nrunner.py
@@ -86,7 +86,7 @@ class RunnableRun(unittest.TestCase):
         res = process.run("%s runnable-run -k exec -u /bin/env X=Y" % RUNNER,
                           ignore_status=True)
         self.assertIn(b"'status': 'finished'", res.stdout)
-        self.assertIn(b"'stdout': b'X=Y\\n'", res.stdout)
+        self.assertIn(b"X=Y\\n", res.stdout)
         self.assertEqual(res.exit_status, 0)
 
 

--- a/selftests/functional/test_nrunner.py
+++ b/selftests/functional/test_nrunner.py
@@ -16,9 +16,9 @@ class RunnableRun(unittest.TestCase):
     def test_noop(self):
         res = process.run("%s runnable-run -k noop" % RUNNER,
                           ignore_status=True)
+        self.assertIn(b"'status': 'started'", res.stdout)
         self.assertIn(b"'status': 'finished'", res.stdout)
-        self.assertIn(b"'time_start': ", res.stdout)
-        self.assertIn(b"'time_end': ", res.stdout)
+        self.assertIn(b"'time': ", res.stdout)
         self.assertEqual(res.exit_status, 0)
 
     def test_exec(self):
@@ -61,11 +61,11 @@ class RunnableRun(unittest.TestCase):
         else:
             first_status = lines[0]
             final_status = lines[-1]
-            self.assertIn("'status': 'running'", first_status)
-            self.assertIn("'time_start': ", first_status)
+            self.assertIn("'status': 'started'", first_status)
+            self.assertIn("'time': ", first_status)
         self.assertIn("'status': 'finished'", final_status)
         self.assertIn("'stdout': b'Hello world!\\n'", final_status)
-        self.assertIn("'time_end': ", final_status)
+        self.assertIn("'time': ", final_status)
         self.assertEqual(res.exit_status, 0)
 
     def test_noop_valid_kwargs(self):
@@ -113,7 +113,7 @@ class TaskRun(unittest.TestCase):
         else:
             first_status = lines[0]
             final_status = lines[-1]
-            self.assertIn("'status': 'running'", first_status)
+            self.assertIn("'status': 'started'", first_status)
             self.assertIn("'id': 1", first_status)
         self.assertIn("'id': 1", first_status)
         self.assertIn("'status': 'finished'", final_status)
@@ -133,7 +133,7 @@ class TaskRun(unittest.TestCase):
         else:
             first_status = lines[0]
             final_status = lines[-1]
-            self.assertIn("'status': 'running'", first_status)
+            self.assertIn("'status': 'started'", first_status)
             self.assertIn("'id': 2", first_status)
         self.assertIn("'id': 2", first_status)
         self.assertIn("'status': 'finished'", final_status)
@@ -153,7 +153,7 @@ class TaskRun(unittest.TestCase):
         # this runnable should produce multiple status lines
         self.assertGreater(len(lines), 1)
         first_status = lines[0]
-        self.assertIn("'status': 'running'", first_status)
+        self.assertIn("'status': 'started'", first_status)
         self.assertIn("'id': 3", first_status)
         final_status = lines[-1]
         self.assertIn("'id': 3", first_status)

--- a/selftests/unit/test_nrunner.py
+++ b/selftests/unit/test_nrunner.py
@@ -191,7 +191,7 @@ class Runner(unittest.TestCase):
         results = [status for status in runner.run()]
         last_result = results[-1]
         self.assertEqual(last_result['status'], 'finished')
-        self.assertIn('time_end', last_result)
+        self.assertIn('time', last_result)
 
     def test_runner_exec(self):
         runnable = nrunner.Runnable('exec', sys.executable,
@@ -204,7 +204,7 @@ class Runner(unittest.TestCase):
         self.assertEqual(last_result['returncode'], 0)
         self.assertEqual(last_result['stdout'], b'')
         self.assertEqual(last_result['stderr'], b'')
-        self.assertIn('time_end', last_result)
+        self.assertIn('time', last_result)
 
     def test_runner_exec_test_ok(self):
         runnable = nrunner.Runnable('exec-test', sys.executable,
@@ -218,7 +218,7 @@ class Runner(unittest.TestCase):
         self.assertEqual(last_result['returncode'], 0)
         self.assertEqual(last_result['stdout'], b'')
         self.assertEqual(last_result['stderr'], b'')
-        self.assertIn('time_end', last_result)
+        self.assertIn('time', last_result)
 
     def test_runner_exec_test_fail(self):
         runnable = nrunner.Runnable('exec-test', '/bin/false')
@@ -231,7 +231,7 @@ class Runner(unittest.TestCase):
         self.assertEqual(last_result['returncode'], 1)
         self.assertEqual(last_result['stdout'], b'')
         self.assertEqual(last_result['stderr'], b'')
-        self.assertIn('time_end', last_result)
+        self.assertIn('time', last_result)
 
     def test_runner_python_unittest_ok(self):
         runnable = nrunner.Runnable('python-unittest', 'unittest.TestCase')


### PR DESCRIPTION
This pull request will introduce the ability to tests to see through the environment variable AVOCADO_TEST_OUTPUT_DIR where to write output results. This is part of #3695 and is the foundation to collect those results. Also, a small organization is proposed here, removing spawners from nrunner.py.

Changes from v1:

- Removed leftovers from a bad merge;
- Replaced `mkdir /uuid4()` with `mkdtemp()`;
- Moved unittest changes to the right commit;
- Calling self.prepare_status on other runners;
- Fixed kwargs vs env logic;