### PR TITLE
Add support to `requirement` docstring [v2]

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -676,8 +676,8 @@ class FileLoader(SimpleFileLoader):
                 test_path = test_path[:-3]
             test_module_name = os.path.relpath(test_path)
             test_module_name = test_module_name.replace(os.path.sep, ".")
-            candidates = [("%s.%s.%s" % (test_module_name, klass, method), tags)
-                          for (method, tags) in methods]
+            candidates = [("%s.%s.%s" % (test_module_name, klass, method),
+                           tags) for (method, tags, _) in methods]
             if subtests_filter:
                 result += [_ for _ in candidates if subtests_filter.search(_)]
             else:
@@ -711,7 +711,7 @@ class FileLoader(SimpleFileLoader):
                 test_factories = []
                 for test_class, info in avocado_tests.items():
                     if isinstance(test_class, str):
-                        for test_method, tgs in info:
+                        for test_method, tags, _ in info:
                             name = test_name + \
                                 ':%s.%s' % (test_class, test_method)
                             if (subtests_filter and
@@ -720,7 +720,7 @@ class FileLoader(SimpleFileLoader):
                             tst = (test_class, {'name': name,
                                                 'modulePath': test_path,
                                                 'methodName': test_method,
-                                                'tags': tgs})
+                                                'tags': tags})
                             test_factories.append(tst)
                 return test_factories
             # Python unittests

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -189,12 +189,14 @@ class Runnable:
         self.uri = uri
         self.args = args
         self.tags = kwargs.pop('tags', None)
+        self.requirements = kwargs.pop('requirements', None)
         self.kwargs = kwargs
 
     def __repr__(self):
-        fmt = '<Runnable kind="{}" uri="{}" args="{}" kwargs="{}" tags="{}">'
-        return fmt.format(self.kind, self.uri,
-                          self.args, self.kwargs, self.tags)
+        fmt = ('<Runnable kind="{}" uri="{}" args="{}" kwargs="{}" tags="{}" '
+               'requirements="{}">')
+        return fmt.format(self.kind, self.uri, self.args, self.kwargs,
+                          self.tags, self.requirements)
 
     @classmethod
     def from_args(cls, args):

--- a/avocado/core/safeloader.py
+++ b/avocado/core/safeloader.py
@@ -342,7 +342,7 @@ def find_class_and_methods(path, method_pattern=None, base_class=None):
     return result
 
 
-def get_methods_info(statement_body, class_tags):
+def get_methods_info(statement_body, class_tags, class_requirements):
     """
     Returns information on an Avocado instrumented test method
     """
@@ -351,12 +351,16 @@ def get_methods_info(statement_body, class_tags):
         if (isinstance(st, ast.FunctionDef) and
                 st.name.startswith('test')):
             docstring = ast.get_docstring(st)
+
             mt_tags = get_docstring_directives_tags(docstring)
             mt_tags.update(class_tags)
 
-            methods = [method for method, _ in methods_info]
+            mt_requirements = get_docstring_directives_requirements(docstring)
+            mt_requirements.extend(class_requirements)
+
+            methods = [method for method, _, _ in methods_info]
             if st.name not in methods:
-                methods_info.append((st.name, mt_tags))
+                methods_info.append((st.name, mt_tags, mt_requirements))
 
     return methods_info
 
@@ -415,7 +419,9 @@ def _examine_class(path, class_name, match, target_module, target_class,
             match = determine_match(module, klass, docstring)
 
         info = get_methods_info(klass.body,
-                                get_docstring_directives_tags(docstring))
+                                get_docstring_directives_tags(docstring),
+                                get_docstring_directives_requirements(
+                                    docstring))
 
         # Getting the list of parents of the current class
         parents = klass.bases
@@ -522,7 +528,9 @@ def find_avocado_tests(path):
 
         if check_docstring_directive(docstring, 'enable'):
             info = get_methods_info(klass.body,
-                                    get_docstring_directives_tags(docstring))
+                                    get_docstring_directives_tags(docstring),
+                                    get_docstring_directives_requirements(
+                                        docstring))
             result[klass.name] = info
             continue
 
@@ -536,7 +544,9 @@ def find_avocado_tests(path):
         else:
             is_avocado = module.is_matching_klass(klass)
         info = get_methods_info(klass.body,
-                                get_docstring_directives_tags(docstring))
+                                get_docstring_directives_tags(docstring),
+                                get_docstring_directives_requirements(
+                                    docstring))
         _disabled = set()
 
         # Getting the list of parents of the current class
@@ -650,7 +660,9 @@ def find_python_unittests(path):
         is_unittest = module.is_matching_klass(klass)
 
         info = get_methods_info(klass.body,
-                                get_docstring_directives_tags(docstring))
+                                get_docstring_directives_tags(docstring),
+                                get_docstring_directives_requirements(
+                                    docstring))
 
         # Searching the parents in the same module
         for parent in parents[:]:

--- a/avocado/core/safeloader.py
+++ b/avocado/core/safeloader.py
@@ -20,6 +20,7 @@ Safe (AST based) test loader module utilities
 import ast
 import collections
 import imp
+import json
 import os
 import re
 import sys
@@ -219,7 +220,8 @@ def modules_imported_as(module):
 
 #: Gets the docstring directive value from a string. Used to tweak
 #: test behavior in various ways
-DOCSTRING_DIRECTIVE_RE_RAW = r'\s*:avocado:[ \t]+([a-zA-Z0-9]+?[a-zA-Z0-9_:,\=\-\.]*)\s*$'
+DOCSTRING_DIRECTIVE_RE_RAW = r'\s*:avocado:[ \t]+(([a-zA-Z0-9]+?[a-zA-Z0-9_:,\=\-\.]*)|(r[a-zA-Z0-9]+?[a-zA-Z0-9_:,\=\{\}\"\-\. ]*))\s*$'
+# the RE will match `:avocado: tags=category` or `:avocado: requirements={}`
 DOCSTRING_DIRECTIVE_RE = re.compile(DOCSTRING_DIRECTIVE_RE_RAW)
 
 
@@ -277,6 +279,25 @@ def get_docstring_directives_tags(docstring):
                 else:
                     result[tag] = None
     return result
+
+
+def get_docstring_directives_requirements(docstring):
+    """
+    Returns the test requirements from docstring patterns like
+    `:avocado: requirement={}`.
+
+    :rtype: list
+    """
+    requirements = []
+    for item in get_docstring_directives(docstring):
+        if item.startswith('requirement='):
+            _, requirement_str = item.split('requirement=', 1)
+            try:
+                requirements.append(json.loads(requirement_str))
+            except json.decoder.JSONDecodeError:
+                # ignore requirement in case of malformed dictionary
+                continue
+    return requirements
 
 
 def find_class_and_methods(path, method_pattern=None, base_class=None):

--- a/avocado/plugins/resolvers.py
+++ b/avocado/plugins/resolvers.py
@@ -101,8 +101,8 @@ class AvocadoInstrumentedResolver(Resolver):
         # disabled tests not needed here
         class_methods_info, _ = find_avocado_tests(module_path)
         runnables = []
-        for klass, methods_tags in class_methods_info.items():
-            for (method, tags) in methods_tags:
+        for klass, methods_tags_reqs in class_methods_info.items():
+            for (method, tags, reqs) in methods_tags_reqs:
                 klass_method = "%s.%s" % (klass, method)
                 if tests_filter is not None:
                     if not tests_filter.search(klass_method):
@@ -110,7 +110,8 @@ class AvocadoInstrumentedResolver(Resolver):
                 uri = "%s:%s" % (module_path, klass_method)
                 runnables.append(Runnable('avocado-instrumented',
                                           uri=uri,
-                                          tags=tags))
+                                          tags=tags,
+                                          requirements=reqs))
         if runnables:
             return ReferenceResolution(reference,
                                        ReferenceResolutionResult.SUCCESS,

--- a/selftests/unit/test_safeloader.py
+++ b/selftests/unit/test_safeloader.py
@@ -460,10 +460,10 @@ class FindClassAndMethods(UnlimitedDiff):
 
         sys.path.append(os.path.dirname(avocado_recursive_discovery_test1.path))
         tests = safeloader.find_avocado_tests(avocado_recursive_discovery_test2.path)[0]
-        expected = {'ThirdChild': [('test_third_child', {}),
-                                   ('test_second_child', {}),
-                                   ('test_first_child', {}),
-                                   ('test_basic', {})]}
+        expected = {'ThirdChild': [('test_third_child', {}, []),
+                                   ('test_second_child', {}, []),
+                                   ('test_first_child', {}, []),
+                                   ('test_basic', {}, [])]}
         self.assertEqual(expected, tests)
 
     def test_recursive_discovery_python_unittest(self):
@@ -473,11 +473,14 @@ class FindClassAndMethods(UnlimitedDiff):
         temp_test.save()
         tests = safeloader.find_python_unittests(temp_test.path)
         expected = {'BaseClass': [('test_basic', {'base-tag': None,
-                                                  'base.tag': None})],
+                                                  'base.tag': None},
+                                   [])],
                     'Child': [('test_child', {'child-tag': None,
-                                              'child.tag': None}),
+                                              'child.tag': None},
+                               []),
                               ('test_basic', {'base-tag': None,
-                                              'base.tag': None})]}
+                                              'base.tag': None},
+                               [])]}
         self.assertEqual(expected, tests)
 
 

--- a/selftests/unit/test_safeloader.py
+++ b/selftests/unit/test_safeloader.py
@@ -169,6 +169,12 @@ class DocstringDirectives(unittest.TestCase):
                ":avocado: tags=SLOW,disk, invalid",
                ":avocado: tags=SLOW,disk , invalid"]
 
+    NO_REQS = [":AVOCADO: REQUIREMENT=['FOO':'BAR']",
+               ":avocado: requirement={'foo':'bar'}",
+               ":avocado: requirement={foo",
+               ":avocado: requirements=",
+               ":avocado: requirement="]
+
     def test_longline(self):
         docstring = ("This is a very long docstring in a single line. "
                      "Since we have nothing useful to put in here let's just "
@@ -260,6 +266,20 @@ class DocstringDirectives(unittest.TestCase):
         exp = {"fast": None, "arch": set(["x86_64", "ppc64"])}
         self.assertEqual(safeloader.get_docstring_directives_tags(raw), exp)
 
+    def test_get_requirement_empty(self):
+        for req in self.NO_REQS:
+            self.assertEqual([], safeloader.get_docstring_directives_requirements(req))
+
+    def test_requirement_single(self):
+        raw = ":avocado: requirement={\"foo\":\"bar\"}"
+        exp = [{"foo": "bar"}]
+        self.assertEqual(safeloader.get_docstring_directives_requirements(raw), exp)
+
+    def test_requirement_double(self):
+        raw = ":avocado: requirement={\"foo\":\"bar\"}\n:avocado: requirement={\"newfoo\":\"newbar\"}"
+        exp = [{"foo": "bar"}, {"newfoo": "newbar"}]
+        self.assertEqual(safeloader.get_docstring_directives_requirements(raw), exp)
+
     def test_directives_regex(self):
         """
         Tests the regular expressions that deal with docstring directives
@@ -315,6 +335,9 @@ class FindClassAndMethods(UnlimitedDiff):
                                     'test_tag_keyval_single',
                                     'test_tag_keyval_double',
                                     'test_tag_keyval_duplicate',
+                                    'test_get_requirement_empty',
+                                    'test_requirement_single',
+                                    'test_requirement_double',
                                     'test_directives_regex'],
             'FindClassAndMethods': ['test_self',
                                     'test_with_pattern',
@@ -359,6 +382,9 @@ class FindClassAndMethods(UnlimitedDiff):
                                     'test_tag_keyval_single',
                                     'test_tag_keyval_double',
                                     'test_tag_keyval_duplicate',
+                                    'test_get_requirement_empty',
+                                    'test_requirement_single',
+                                    'test_requirement_double',
                                     'test_directives_regex'],
             'FindClassAndMethods': ['test_self',
                                     'test_with_pattern',


### PR DESCRIPTION
This adds support to use `requirement` docstrings to define a test requirement in JSON format.

Changes from v1:

- Moved unittests to the correct commit;
- Spell fixes;
- Removed support on loader and test class;
- Added more code to nrunner from https://github.com/avocado-framework/avocado/pull/3718#pullrequestreview-395075773.