### PR TITLE
Add bind flag to skip checking of mounting device/point

### DIFF
--- a/avocado/utils/partition.py
+++ b/avocado/utils/partition.py
@@ -201,7 +201,7 @@ class Partition:
         else:
             self.fstype = fstype
 
-    def mount(self, mountpoint=None, fstype=None, args=''):
+    def mount(self, mountpoint=None, fstype=None, args='', mnt_check=True):
         """
         Mount this partition to a mount point
 
@@ -210,6 +210,7 @@ class Partition:
         :param fstype: Filesystem type. If not provided partition object value
                 will be used.
         :param args: Arguments to be passed to "mount" command.
+        :param mnt_check: Flag to check/avoid checking existing device/mountpoint
         """
         if not mountpoint:
             mountpoint = self.mountpoint
@@ -230,10 +231,11 @@ class Partition:
         args = args.lstrip()
 
         with MtabLock():
-            if self.device in self.list_mount_devices():
-                raise PartitionError(self, "Attempted to mount mounted device")
-            if mountpoint in self.list_mount_points():
-                raise PartitionError(self, "Attempted to mount busy directory")
+            if mnt_check:
+                if self.device in self.list_mount_devices():
+                    raise PartitionError(self, "Attempted to mount mounted device")
+                if mountpoint in self.list_mount_points():
+                    raise PartitionError(self, "Attempted to mount busy directory")
             if not os.path.isdir(mountpoint):
                 os.makedirs(mountpoint)
             try:


### PR DESCRIPTION
Most of the recent kernels support bind mounting automatically, hence introducing a flag which allows user to skip the check of existing mounted devices or mountpoints.

Signed-off-by: Harish <harish@linux.ibm.com>