### PR TITLE
future/settings: Migrate resultsdb optional plugin to use the new API

### DIFF
--- a/optional_plugins/resultsdb/avocado_resultsdb/__init__.py
+++ b/optional_plugins/resultsdb/avocado_resultsdb/__init__.py
@@ -17,15 +17,12 @@ Avocado Plugin to propagate Job results to Resultsdb
 """
 
 import os
-import sys
 import time
 
 import resultsdb_api
 
 from avocado.core.plugin_interfaces import CLI, ResultEvents, Result
 from avocado.core.settings import settings
-from avocado.core import exceptions
-from avocado.utils import stacktrace
 from avocado.core.output import LOG_UI
 
 


### PR DESCRIPTION
As part of the effort to remove default values scattered around the
code, this change only migrates the resultsdb optional plugin options to
use the new module. This will associate --resultsdb-api,
--resultsdb-logs, and --resultsdb-note-limit to
plugins.resultsdb.api_url, plugins.resultsdb.logs_url and
plugins.resultsdb.note_size_limit respectively on the configuration file.