### PR TITLE
GDBRemote: convert to use bytes

### DIFF
--- a/avocado/utils/gdb.py
+++ b/avocado/utils/gdb.py
@@ -59,11 +59,11 @@ REMOTE_TRANSMISSION_SUCCESS = '+'
 REMOTE_TRANSMISSION_FAILURE = '-'
 
 #: How the remote protocol flags the start of a packet
-REMOTE_PREFIX = '$'
+REMOTE_PREFIX = b'$'
 
 #: How the remote protocol flags the end of the packet payload, and that the
 #: two digits checksum follow
-REMOTE_DELIMITER = '#'
+REMOTE_DELIMITER = b'#'
 
 #: Rather conservative default maximum packet size for clients using the
 #: remote protocol. Individual connections can ask (and do so by default)
@@ -248,21 +248,21 @@ def remote_decode(data):
     Decodes a packet and returns its payload
 
     :param command_data: the command data payload
-    :type command_data: str
+    :type command_data: bytes
     :returns: the encoded command, ready to be sent to a remote GDB
-    :rtype: str
+    :rtype: bytes
     """
-    if data[0] != REMOTE_PREFIX:
+    if data[0:1] != REMOTE_PREFIX:
         raise InvalidPacketError
 
-    if data[-3] != REMOTE_DELIMITER:
+    if data[-3:-2] != REMOTE_DELIMITER:
         raise InvalidPacketError
 
     payload = data[1:-3]
     checksum = data[-2:]
 
-    if payload == '':
-        expected_checksum = '00'
+    if payload == b'':
+        expected_checksum = b'00'
     else:
         expected_checksum = remote_checksum(payload)
 

--- a/avocado/utils/gdb.py
+++ b/avocado/utils/gdb.py
@@ -236,11 +236,11 @@ def remote_encode(data):
     That is, add prefix, suffix and checksum
 
     :param command_data: the command data payload
-    :type command_data: str
+    :type command_data: bytes
     :returns: the encoded command, ready to be sent to a remote GDB
-    :rtype: str
+    :rtype: bytes
     """
-    return "$%s#%s" % (data, remote_checksum(data))
+    return b'$%b#%b' % (data, remote_checksum(data))
 
 
 def remote_decode(data):

--- a/avocado/utils/gdb.py
+++ b/avocado/utils/gdb.py
@@ -217,17 +217,16 @@ def remote_checksum(input_message):
 
     :param input_message: the message input payload, without the start and end
                           markers
-    :type input_message: str
-    :returns: two digit checksum
-    :rtype: str
+    :type input_message: bytes
+    :returns: two byte checksum
+    :rtype: bytes
     """
     total = 0
     for i in input_message:
-        total += ord(i)
+        total += i
     result = total % 256
 
-    hexa = "%2x" % result
-    return hexa.lower()
+    return b'%2x' % result
 
 
 def remote_encode(data):

--- a/selftests/unit/test_gdb.py
+++ b/selftests/unit/test_gdb.py
@@ -6,38 +6,29 @@ from avocado.utils import gdb
 class GDBRemoteTest(unittest.TestCase):
 
     def test_checksum(self):
-        in_out = (('!', '21'),
-                  ('OK', '9a'),
-                  ('foo', '44'))
-        for io in in_out:
-            i, o = io
-            self.assertEqual(gdb.remote_checksum(i), o)
+        self.assertEqual(gdb.remote_checksum('!'), '21')
+        self.assertEqual(gdb.remote_checksum('OK'), '9a')
+        self.assertEqual(gdb.remote_checksum('foo'), '44')
 
     def test_encode_command(self):
-        in_out = (('!', '$!#21'),
-                  ('OK', '$OK#9a'),
-                  ('foo', '$foo#44'))
-        for io in in_out:
-            i, o = io
-            self.assertEqual(gdb.remote_encode(i), o)
+        self.assertEqual(gdb.remote_encode('!'), '$!#21')
+        self.assertEqual(gdb.remote_encode('OK'), '$OK#9a')
+        self.assertEqual(gdb.remote_encode('foo'), '$foo#44')
 
     def test_decode_response(self):
-        in_out = (('$!#21', '!'),
-                  ('$OK#9a', 'OK'),
-                  ('$foo#44', 'foo'))
-        for io in in_out:
-            i, o = io
-            self.assertEqual(gdb.remote_decode(i), o)
+        self.assertEqual(gdb.remote_decode('$!#21'), '!')
+        self.assertEqual(gdb.remote_decode('$OK#9a'), 'OK')
+        self.assertEqual(gdb.remote_decode('$foo#44'), 'foo')
 
     def test_decode_invalid(self):
-        invalid_packets = ['$!#22',
-                           '$foo$bar#21',
-                           '!!#21',
-                           '+$!#21']
-        for p in invalid_packets:
-            self.assertRaises(gdb.InvalidPacketError,
-                              gdb.remote_decode, p)
-
+        with self.assertRaises(gdb.InvalidPacketError):
+            gdb.remote_decode('$!#22')
+        with self.assertRaises(gdb.InvalidPacketError):
+            gdb.remote_decode('$foo$bar#21')
+        with self.assertRaises(gdb.InvalidPacketError):
+            gdb.remote_decode('!!#21')
+        with self.assertRaises(gdb.InvalidPacketError):
+            gdb.remote_decode('+$!#21')
 
 if __name__ == '__main__':
     unittest.main()

--- a/selftests/unit/test_gdb.py
+++ b/selftests/unit/test_gdb.py
@@ -7,11 +7,11 @@ class GDBRemoteTest(unittest.TestCase):
 
     def test_checksum(self):
         in_out = (('!', '21'),
-                  ('OK', '9A'),
+                  ('OK', '9a'),
                   ('foo', '44'))
         for io in in_out:
             i, o = io
-            self.assertTrue(gdb.remote_checksum(i), o)
+            self.assertEqual(gdb.remote_checksum(i), o)
 
     def test_encode_command(self):
         in_out = (('!', '$!#21'),
@@ -19,7 +19,7 @@ class GDBRemoteTest(unittest.TestCase):
                   ('foo', '$foo#44'))
         for io in in_out:
             i, o = io
-            self.assertTrue(gdb.remote_encode(i), o)
+            self.assertEqual(gdb.remote_encode(i), o)
 
     def test_decode_response(self):
         in_out = (('$!#21', '!'),
@@ -27,7 +27,7 @@ class GDBRemoteTest(unittest.TestCase):
                   ('$foo#44', 'foo'))
         for io in in_out:
             i, o = io
-            self.assertTrue(gdb.remote_decode(i), o)
+            self.assertEqual(gdb.remote_decode(i), o)
 
     def test_decode_invalid(self):
         invalid_packets = ['$!#22',

--- a/selftests/unit/test_gdb.py
+++ b/selftests/unit/test_gdb.py
@@ -6,9 +6,9 @@ from avocado.utils import gdb
 class GDBRemoteTest(unittest.TestCase):
 
     def test_checksum(self):
-        self.assertEqual(gdb.remote_checksum('!'), '21')
-        self.assertEqual(gdb.remote_checksum('OK'), '9a')
-        self.assertEqual(gdb.remote_checksum('foo'), '44')
+        self.assertEqual(gdb.remote_checksum(b'!'), b'21')
+        self.assertEqual(gdb.remote_checksum(b'OK'), b'9a')
+        self.assertEqual(gdb.remote_checksum(b'foo'), b'44')
 
     def test_encode_command(self):
         self.assertEqual(gdb.remote_encode('!'), '$!#21')

--- a/selftests/unit/test_gdb.py
+++ b/selftests/unit/test_gdb.py
@@ -1,34 +1,35 @@
 import unittest
 
-from avocado.utils import gdb
+from avocado.utils.gdb import GDBRemote
+from avocado.utils.gdb import InvalidPacketError
 
 
 class GDBRemoteTest(unittest.TestCase):
 
     def test_checksum(self):
-        self.assertEqual(gdb.remote_checksum(b'!'), b'21')
-        self.assertEqual(gdb.remote_checksum(b'OK'), b'9a')
-        self.assertEqual(gdb.remote_checksum(b'foo'), b'44')
+        self.assertEqual(GDBRemote.checksum(b'!'), b'21')
+        self.assertEqual(GDBRemote.checksum(b'OK'), b'9a')
+        self.assertEqual(GDBRemote.checksum(b'foo'), b'44')
 
     def test_encode_command(self):
-        self.assertEqual(gdb.remote_encode(b'!'), b'$!#21')
-        self.assertEqual(gdb.remote_encode(b'OK'), b'$OK#9a')
-        self.assertEqual(gdb.remote_encode(b'foo'), b'$foo#44')
+        self.assertEqual(GDBRemote.encode(b'!'), b'$!#21')
+        self.assertEqual(GDBRemote.encode(b'OK'), b'$OK#9a')
+        self.assertEqual(GDBRemote.encode(b'foo'), b'$foo#44')
 
     def test_decode_response(self):
-        self.assertEqual(gdb.remote_decode(b'$!#21'), b'!')
-        self.assertEqual(gdb.remote_decode(b'$OK#9a'), b'OK')
-        self.assertEqual(gdb.remote_decode(b'$foo#44'), b'foo')
+        self.assertEqual(GDBRemote.decode(b'$!#21'), b'!')
+        self.assertEqual(GDBRemote.decode(b'$OK#9a'), b'OK')
+        self.assertEqual(GDBRemote.decode(b'$foo#44'), b'foo')
 
     def test_decode_invalid(self):
-        with self.assertRaises(gdb.InvalidPacketError):
-            gdb.remote_decode(b'$!#22')
-        with self.assertRaises(gdb.InvalidPacketError):
-            gdb.remote_decode(b'$foo$bar#21')
-        with self.assertRaises(gdb.InvalidPacketError):
-            gdb.remote_decode(b'!!#21')
-        with self.assertRaises(gdb.InvalidPacketError):
-            gdb.remote_decode(b'+$!#21')
+        with self.assertRaises(InvalidPacketError):
+            GDBRemote.decode(b'$!#22')
+        with self.assertRaises(InvalidPacketError):
+            GDBRemote.decode(b'$foo$bar#21')
+        with self.assertRaises(InvalidPacketError):
+            GDBRemote.decode(b'!!#21')
+        with self.assertRaises(InvalidPacketError):
+            GDBRemote.decode(b'+$!#21')
 
 if __name__ == '__main__':
     unittest.main()

--- a/selftests/unit/test_gdb.py
+++ b/selftests/unit/test_gdb.py
@@ -11,9 +11,9 @@ class GDBRemoteTest(unittest.TestCase):
         self.assertEqual(gdb.remote_checksum(b'foo'), b'44')
 
     def test_encode_command(self):
-        self.assertEqual(gdb.remote_encode('!'), '$!#21')
-        self.assertEqual(gdb.remote_encode('OK'), '$OK#9a')
-        self.assertEqual(gdb.remote_encode('foo'), '$foo#44')
+        self.assertEqual(gdb.remote_encode(b'!'), b'$!#21')
+        self.assertEqual(gdb.remote_encode(b'OK'), b'$OK#9a')
+        self.assertEqual(gdb.remote_encode(b'foo'), b'$foo#44')
 
     def test_decode_response(self):
         self.assertEqual(gdb.remote_decode('$!#21'), '!')

--- a/selftests/unit/test_gdb.py
+++ b/selftests/unit/test_gdb.py
@@ -16,19 +16,19 @@ class GDBRemoteTest(unittest.TestCase):
         self.assertEqual(gdb.remote_encode(b'foo'), b'$foo#44')
 
     def test_decode_response(self):
-        self.assertEqual(gdb.remote_decode('$!#21'), '!')
-        self.assertEqual(gdb.remote_decode('$OK#9a'), 'OK')
-        self.assertEqual(gdb.remote_decode('$foo#44'), 'foo')
+        self.assertEqual(gdb.remote_decode(b'$!#21'), b'!')
+        self.assertEqual(gdb.remote_decode(b'$OK#9a'), b'OK')
+        self.assertEqual(gdb.remote_decode(b'$foo#44'), b'foo')
 
     def test_decode_invalid(self):
         with self.assertRaises(gdb.InvalidPacketError):
-            gdb.remote_decode('$!#22')
+            gdb.remote_decode(b'$!#22')
         with self.assertRaises(gdb.InvalidPacketError):
-            gdb.remote_decode('$foo$bar#21')
+            gdb.remote_decode(b'$foo$bar#21')
         with self.assertRaises(gdb.InvalidPacketError):
-            gdb.remote_decode('!!#21')
+            gdb.remote_decode(b'!!#21')
         with self.assertRaises(gdb.InvalidPacketError):
-            gdb.remote_decode('+$!#21')
+            gdb.remote_decode(b'+$!#21')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Instead of strings, which is a more honest approach to a "wire level" protocol and Python 3.

Relates to #3504 #3521 