### PR TITLE
Added check in cpu utility is cpu is already online or offline

### DIFF
--- a/avocado/utils/cpu.py
+++ b/avocado/utils/cpu.py
@@ -252,10 +252,11 @@ def online(cpu):
     """
     Online given CPU
     """
-    with open("/sys/devices/system/cpu/cpu%s/online" % cpu, "wb") as fd:
-        fd.write(b'1')
-    if _get_status(cpu):
-        return 0
+    if _get_status(cpu) is False:
+        with open("/sys/devices/system/cpu/cpu%s/online" % cpu, "wb") as fd:
+            fd.write(b'1')
+        if _get_status(cpu):
+            return 0
     return 1
 
 
@@ -263,10 +264,11 @@ def offline(cpu):
     """
     Offline given CPU
     """
-    with open("/sys/devices/system/cpu/cpu%s/online" % cpu, "wb") as fd:
-        fd.write(b'0')
     if _get_status(cpu):
-        return 1
+        with open("/sys/devices/system/cpu/cpu%s/online" % cpu, "wb") as fd:
+            fd.write(b'0')
+        if _get_status(cpu):
+            return 1
     return 0
 
 


### PR DESCRIPTION
and user want to do operation it will fail as python error (bash error)
and it feels user as lib is broken , so this patch address this

before this patch :

03:16:25 ERROR|   File "/home/OpTest/avocado-fvt-wrapper/tests/avocado-misc-tests/cpu/cpustress.py", line 103, in __online_cpus
    cpu.online(cpus)
03:16:25 ERROR|   File "/usr/lib/python3.6/site-packages/avocado_framework-77.0-py3.6.egg/avocado/utils/cpu.py", line 256, in online
    fd.write(b'1')

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>