### PR TITLE
core/output: fix empty job.log when using the Job API

### DIFF
--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -431,7 +431,6 @@ def reconfigure(args):
                             STD_OUTPUT.stdout, logging.DEBUG)
         else:
             disable_log_handler("")
-            disable_log_handler(LOG_JOB)
     if "remote" in enabled:
         add_log_handler("avocado.fabric", stream=STD_OUTPUT.stdout,
                         level=logging.DEBUG)


### PR DESCRIPTION
When using the job API (with runner or nrunner) the `job.log` is a empty
file.  However this is only happening when calling for the first time. I
don't understand the logic behind AVOCADO_LOG_EARLY, but looks like we
don't want to have a empty file when calling from the job api. This
small change will bring back the job.log file. Github issue #3737 has
more details.

Reference: https://github.com/avocado-framework/avocado/issues/3737
Signed-off-by: Beraldo Leal <bleal@redhat.com>