### PR TITLE
future/settings: Migrate results_upload optional plugin to use the new API

### DIFF
--- a/optional_plugins/result_upload/avocado_result_upload/__init__.py
+++ b/optional_plugins/result_upload/avocado_result_upload/__init__.py
@@ -18,7 +18,7 @@ Avocado Plugin to propagate Job results to remote host
 
 from avocado.core.plugin_interfaces import CLI, Result
 
-from avocado.core.settings import settings
+from avocado.core.future.settings import settings
 from avocado.utils import process
 from avocado.utils import path as utils_path
 
@@ -41,9 +41,8 @@ class ResultUpload(Result):
             return  # Don't create results on unfinished jobs
 
         """
-        self.upload_url = job.config.get('result_upload_url', None)   # pylint: disable=W0201
-
-        self.upload_cmd = job.config.get('result_upload_cmd', None)  # pylint: disable=W0201
+        self.upload_url = job.config.get('plugins.result_upload.url')  # pylint: disable=W0201
+        self.upload_cmd = job.config.get('plugins.result_upload.cmd')  # pylint: disable=W0201
 
         if self.upload_url is None:
             return
@@ -71,9 +70,13 @@ class ResultUploadCLI(CLI):
 
         msg = 'result-upload options'
         parser = run_subcommand_parser.add_argument_group(msg)
-        parser.add_argument('--result-upload-url',
-                            dest='result_upload_url', default=None,
-                            help='Specify the result upload url')
+        help_msg = 'Specify the result upload url'
+        settings.register_option(section='plugins.result_upload',
+                                        key='url',
+                                        default=None,
+                                        help_msg=help_msg,
+                                        parser=parser,
+                                        long_arg='--result-upload-url')
 
         try:
             rsync_bin = utils_path.find_command('rsync')
@@ -84,23 +87,13 @@ class ResultUploadCLI(CLI):
         except utils_path.CmdNotFoundError:
             def_upload_cmd = None
 
-        parser.add_argument('--result-upload-cmd',
-                            dest='result_upload_cmd', default=def_upload_cmd,
-                            help='Specify the command to upload results')
+        help_msg = 'Specify the command to upload results'
+        settings.register_option(section='plugins.result_upload',
+                                        key='command',
+                                        help_msg=help_msg,
+                                        default=def_upload_cmd,
+                                        parser=parser,
+                                        long_arg='--result-upload-cmd')
 
     def run(self, config):
-        url = config.get('result_upload_url', None)
-        if url is None:
-            url = settings.get_value('plugins.result_upload',
-                                     'url',
-                                     default=None)
-            if url is not None:
-                config['result_upload_url'] = url
-
-        cmd = config.get('result_upload_cmd', None)
-        if cmd is None:
-            cmd = settings.get_value('plugins.result_upload',
-                                     'command',
-                                     default=None)
-            if cmd is not None:
-                config['result_upload_cmd'] = cmd
+        pass

--- a/optional_plugins/result_upload/avocado_result_upload/__init__.py
+++ b/optional_plugins/result_upload/avocado_result_upload/__init__.py
@@ -16,11 +16,10 @@
 Avocado Plugin to propagate Job results to remote host
 """
 
-from avocado.core.plugin_interfaces import CLI, Result
-
 from avocado.core.future.settings import settings
-from avocado.utils import process
+from avocado.core.plugin_interfaces import CLI, Result
 from avocado.utils import path as utils_path
+from avocado.utils import process
 
 
 class ResultUpload(Result):


### PR DESCRIPTION
As part of the effort to remove default values scattered around the
code, this change only migrates the results_upload optional plugin
options to use the new module. This will associate  --results-upload-url
and --results-upload-cmd to plugins.result_upload.url and
plugins.result_upload.cmd respectively on the configuration file.
