### PR TITLE
nrunner: populate task logdir - v2

### DIFF
--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -71,12 +71,11 @@ class Runner(RunnerInterface):
                   replay_map=None, execution_order=None):
         summary = set()
         test_suite, _ = nrunner.check_tasks_requirements(test_suite)
-        for task in test_suite:
-            task.known_runners = nrunner.RUNNERS_REGISTRY_PYTHON_CLASS
         result.tests_total = len(test_suite)  # no support for variants yet
         result_dispatcher = job.result_events_dispatcher
 
         for index, task in enumerate(test_suite):
+            task.known_runners = nrunner.RUNNERS_REGISTRY_PYTHON_CLASS
             index += 1
             # this is all rubbish data
             early_state = {


### PR DESCRIPTION
This will generate a basic output inside the tasks logdir.

-----
Changes from v2:

 * Assuming that the last status will not always have 'stdout' and 'stderr';