### PR TITLE
Code style: enforce W601

### DIFF
--- a/avocado/utils/external/gdbmi_parser.py
+++ b/avocado/utils/external/gdbmi_parser.py
@@ -215,7 +215,7 @@ def __private():
                 node.value = node[1].value
                 for result in node[2].value:
                     for n, v in result.items():
-                        if node.value.has_key(n):
+                        if n in node.value:
                             old = node.value[n]
                             if not isinstance(old, list):
                                 node.value[n] = [node.value[n]]

--- a/avocado/utils/external/spark.py
+++ b/avocado/utils/external/spark.py
@@ -84,8 +84,7 @@ class GenericScanner:
             groups = m.groups()
             self.pos = m.end()
             for i in range(len(groups)):
-                if groups[i] is not None and \
-                   self.index2func.has_key(i):
+                if groups[i] is not None and i in self.index2func:
                     self.index2func[i](groups[i])
 
     def t_default(self, s):  # pylint: disable=W0613
@@ -162,7 +161,7 @@ class GenericParser:
             for k, v in self.edges.items():
                 if v is None:
                     state, sym = k
-                    if self.states.has_key(state):
+                    if state in self.states:
                         self.goto(state, sym)
                         changes = 1
         rv = self.__dict__.copy()

--- a/selftests/inspekt-style.sh
+++ b/selftests/inspekt-style.sh
@@ -1,2 +1,2 @@
 #!/bin/sh -e
-inspekt style --exclude=.git --disable E501,W601,E402,E722
+inspekt style --exclude=.git --disable E501,E402,E722


### PR DESCRIPTION
`has_key()` was deprecated in Python 2. It is recommended to use the
in operator instead.

This basically removes the global whitelist for W601, and fixes the
few occurrences where it happens.

Signed-off-by: Cleber Rosa <crosa@redhat.com>