### PR TITLE
software_manager.py: Fix tolerant option with yum-builddep

### DIFF
--- a/avocado/utils/software_manager.py
+++ b/avocado/utils/software_manager.py
@@ -725,6 +725,22 @@ class DnfBackend(YumBackend):
         """
         super(DnfBackend, self).__init__(cmd='dnf')
 
+    def build_dep(self, name):
+        """
+        Install build-dependencies for package [name]
+
+        :param name: name of the package
+
+        :return True: If build dependencies are installed properly
+        """
+        try:
+            process.system('%s builddep %s' % (self.base_command, name),
+                           sudo=True)
+            return True
+        except process.CmdError as details:
+            log.error(details)
+            return False
+
 
 class ZypperBackend(RpmBackend):
 


### PR DESCRIPTION
software_manager.py: Add build dependency for DnfBackend

As --tolerant option is not supported with dnf-builddep, adding build dependency method to DnfBackend to fix this.

Signed-off-by: Harish <harish@linux.ibm.com>