### PR TITLE
software_manager.py: Change approach to install dependencies

### DIFF
--- a/avocado/utils/software_manager.py
+++ b/avocado/utils/software_manager.py
@@ -693,10 +693,10 @@ class YumBackend(RpmBackend):
                               path, next(os.walk(path))[2])
                     return ""
                 if self.rpm_install(os.path.join(path, src_rpms[-1])):
-                    if self.build_dep(name):
-                        spec_path = os.path.join(os.environ['HOME'],
-                                                 "rpmbuild", "SPECS",
-                                                 "%s.spec" % name)
+                    spec_path = os.path.join(os.environ['HOME'],
+                                             "rpmbuild", "SPECS",
+                                             "%s.spec" % name)
+                    if self.build_dep(spec_path):
                         return self.prepare_source(spec_path, dest_path)
                     else:
                         log.error("Installing build dependencies failed")


### PR DESCRIPTION
Patch changes the approach to install the build dependencies as the existing method needs a work around suggested in redhat BZ https://bugzilla.redhat.com/show_bug.cgi?id=1717532#c28

As the bugzilla states, SRPM is generated in the build system on an x86_64 host and the Requires determined for the SRPM are set by the macros that are evaluated at the time of its creation. Because it is generated on an x86_64 host, the packages are added as a Requires to the SRPM. The yum-builddep command attempts to honor this.

The workaround is to install the kernel SRPM via rpm and run yum builddep on the kernel.spec file that is installed on the host. This ensure the proper macros are set for the architecture one
wishes to build for.

Signed-off-by: Harish <harish@linux.ibm.com>