### PR TITLE
yaml to mux plugin: fix incorrect comparison.

### DIFF
--- a/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/__init__.py
+++ b/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/__init__.py
@@ -165,7 +165,7 @@ def _apply_using(name, cls_node, using, node):
     :param node: the node in which to handle control tags
     :type node: instance of :class:`avocado.core.tree.TreeNode` or similar
     """
-    if name is not '':
+    if name != '':
         for name in using.split('/')[::-1]:
             node = cls_node(name, children=[node])
     else:


### PR DESCRIPTION
After updating to Fedora 32, I started receiving this message while executing avocado command:

/home/wrampazz/src/avocado/avocado.dev/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/__init__.py:168: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if name is not '':

```
$ avocado
/home/wrampazz/src/avocado/avocado.dev/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/__init__.py:168: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if name is not '':
usage: avocado [-h] [-v] [--config [CONFIG_FILE]] [--paginator {on,off}] [-V] [--show [STREAM[:LVL]]]
               {assets,config,diff,distro,exec-path,list,nlist,nrun,plugins,run,sysinfo,variants,vmimage} ...

Avocado Test Runner

optional arguments:
  -h, --help            show this help message and exit
  -v, --version         show program's version number and exit
  --config [CONFIG_FILE]
                        Use custom configuration from a file
  --paginator {on,off}  Turn the paginator on/off. Useful when outputs are toolong. This will be a boolean soon.
  -V, --verbose         Some commands can produce more information. This option will enable the verbosity when
                        applicable.
  --show [STREAM[:LVL]]
                        List of comma separated builtin logs, or logging streams optionally followed by LEVEL
                        (DEBUG,INFO,...). Builtin streams are: "app": application output; "test": test output;
                        "debug": tracebacks and other debugging info; "remote": fabric/paramiko debug; "early":
                        early logging of other streams, including test (very verbose); "all": all builtin streams;
                        "none": disables regular output (leaving only errors enabled). By default: 'app'

subcommands:
  valid subcommands

  {assets,config,diff,distro,exec-path,list,nlist,nrun,plugins,run,sysinfo,variants,vmimage}
                        subcommand help
    assets              Manage assets
    config              Shows avocado config keys
    diff                Shows the difference between 2 jobs.
    distro              Shows detected Linux distribution
    exec-path           Returns path to avocado bash libraries and exits.
    list                List available tests
    nlist               *EXPERIMENTAL* list tests (runnables)
    nrun                *EXPERIMENTAL* runner: runs one or more tests
    plugins             Displays plugin information
    run                 Runs one or more tests (native test, test alias, binary or script)
    sysinfo             Collect system information
    variants            Tool to analyze and visualize test variants and params
    vmimage             Provides VM images acquired from official repositories

avocado: error: the following arguments are required: subcommand
```

Signed-off-by: Willian Rampazzo <willianr@redhat.com>