### PR TITLE
[POC] Requirements resolver command-line

### DIFF
--- a/avocado/core/requirements.py
+++ b/avocado/core/requirements.py
@@ -1,0 +1,94 @@
+
+import argparse
+import os
+
+from . import data_dir
+from . import safeloader
+from ..utils.asset import Asset
+from ..utils.vmimage import get as get_vmimage
+from ..utils import data_structures
+
+
+class RequirementsResolver:
+
+    def __init__(self, references):
+        self.references = references
+        self.supported_requirements = {
+            'file': self._handle_assets,
+            'image': self._handle_vmimage,
+        }
+
+    @staticmethod
+    def _extract_requirements_from_reference(test):
+        requirements = []
+        # work with enabled tests only (index 0)
+        test_info = safeloader.find_avocado_tests(test)[0]
+        for tests in test_info.values():
+            for test in tests:
+                # requirements are the 3rd item in the set
+                requirements.extend(test[2])
+        return requirements
+
+    @staticmethod
+    def _handle_assets(params):
+        # set cache directory
+        params['cache_dirs'] = data_dir.get_cache_dirs()
+        # set algorithm
+        algorithm = params.pop('algorithm', None)
+        params['algorithm'] = algorithm
+        # set expire
+        expire = params.pop('expire', None)
+        if expire is not None:
+            params['expire'] = data_structures.time_to_seconds(str(expire))
+        params['expire'] = expire
+
+        # fetch asset
+        try:
+            print('Fulfilling file requirement: %s' % params['name'])
+            asset_obj = Asset(**params)
+            asset_destination = asset_obj.fetch()
+            print(' File requirement: %s' % asset_destination)
+        except (OSError, ValueError) as failed:
+            print(failed)
+
+    @staticmethod
+    def _handle_vmimage(params):
+        # set cache directory
+        params['cache_dir'] = data_dir.get_cache_dirs()
+
+        # download image
+        try:
+            print('Fulfilling image requirement: %s' % params['name'])
+            vmimage_info = get_vmimage(**params)
+            print(' Image requirement: %s' % vmimage_info.base_image)
+        except AttributeError as failed:
+            print(failed)
+
+    def _resolve_from_docstring(self, test):
+        # list of requirements in docstring format
+        requirements = self._extract_requirements_from_reference(test)
+        # handle each of the requirements
+        for requirement in requirements:
+            if requirement.get('type') in self.supported_requirements:
+                requirement_handler = self.supported_requirements.get(
+                    requirement.pop('type'))
+                requirement_handler(requirement)
+
+    def resolve(self):
+        for test in self.references:
+            if os.path.isfile(test):
+                # it can also be a Python executable representation, but let's
+                # assume it is a test for now.
+                self._resolve_from_docstring(test)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('reference', nargs='+', help='Test reference')
+    args = parser.parse_args()
+    resolver = RequirementsResolver(args.reference)
+    resolver.resolve()
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/requirements/docstring.py
+++ b/examples/requirements/docstring.py
@@ -1,0 +1,102 @@
+
+from avocado import Test
+from avocado.utils import vmimage
+
+
+class GPL2(Test):
+    """
+    Example test using docstring requirements.
+
+    :avocado: requirement={"type": "file", "name": "gpl-2.0.txt", "locations": "https://mirrors.kernel.org/gnu/Licenses/gpl-2.0.txt", "asset_hash": "4cc77b90af91e615a64ae04893fdffa7939db84c"}
+    """
+
+    def setUp(self):
+        # To make testing easy, lets fetch a small assets into `by_name`.
+        location = 'https://mirrors.kernel.org/gnu/Licenses/'
+        gpl2 = 'gpl-2.0.txt'
+        gpl2_location = "%s%s" % (location, gpl2)
+        self.gpl2 = self.fetch_asset(
+            name=gpl2,
+            asset_hash='4cc77b90af91e615a64ae04893fdffa7939db84c',
+            locations=gpl2_location,
+            find_only=True,
+            cancel_on_missing=True)
+
+    def test_find_gpl(self):
+        self.assertIsInstance(self.gpl2, str)
+
+
+class GPL3(Test):
+    """
+    Example test using docstring requirements.
+
+    :avocado: requirement={"type": "file", "name": "gpl-3.0.txt", "locations": "https://mirrors.kernel.org/gnu/Licenses/gpl-3.0.txt", "asset_hash": "31a3d460bb3c7d98845187c716a30db81c44b615"}
+    """
+
+    def setUp(self):
+        # To make testing easy, lets fetch a small assets into `by_name`.
+        location = 'https://mirrors.kernel.org/gnu/Licenses/'
+        gpl3 = 'gpl-3.0.txt'
+        gpl3_location = "%s%s" % (location, gpl3)
+        self.gpl3 = self.fetch_asset(
+            name=gpl3,
+            asset_hash='31a3d460bb3c7d98845187c716a30db81c44b615',
+            locations=gpl3_location,
+            find_only=True,
+            cancel_on_missing=True)
+
+    def test_find_gpl(self):
+        self.assertIsInstance(self.gpl3, str)
+
+
+class LGPL2(Test):
+    """
+    Example test using docstring requirements.
+
+    :avocado: requirement={"type": "file", "name": "lgpl-2.0.txt", "locations": "https://mirrors.kernel.org/gnu/Licenses/lgpl-2.0.txt", "asset_hash": "ba8966e2473a9969bdcab3dc82274c817cfd98a1"}
+    :avocado: requirement={"type": "file", "name": "lgpl-2.1.txt", "locations": "https://mirrors.kernel.org/gnu/Licenses/lgpl-2.1.txt", "asset_hash": "01a6b4bf79aca9b556822601186afab86e8c4fbf"}
+    """
+
+    def setUp(self):
+        # To make testing easy, lets fetch a small assets into `by_name`.
+        location = 'https://mirrors.kernel.org/gnu/Licenses/'
+        lgpl2 = 'lgpl-2.0.txt'
+        lgpl2_1 = 'lgpl-2.1.txt'
+        lgpl2_location = "%s%s" % (location, lgpl2)
+        lgpl2_1_location = "%s%s" % (location, lgpl2_1)
+        self.lgpl2 = self.fetch_asset(
+            name=lgpl2,
+            asset_hash='ba8966e2473a9969bdcab3dc82274c817cfd98a1',
+            locations=lgpl2_location,
+            find_only=True,
+            cancel_on_missing=True)
+        self.lgpl2_1 = self.fetch_asset(
+            name=lgpl2_1,
+            asset_hash='01a6b4bf79aca9b556822601186afab86e8c4fbf',
+            locations=lgpl2_1_location,
+            find_only=True,
+            cancel_on_missing=True)
+
+    def test_find_lgpl2(self):
+        self.assertIsInstance(self.lgpl2, str)
+
+    def test_find_lgpl2_1(self):
+        self.assertIsInstance(self.lgpl2_1, str)
+
+
+class Vmimage(Test):
+    """
+    Example test using docstring requirements.
+
+    :avocado: requirement={"type": "image", "name": "cirros", "version": "0.5.0", "arch": "x86_64"}
+    """
+
+    def setUp(self):
+        # To make testing easy, lets download a small image (16MB).
+        self.image = vmimage.get(
+            'cirros', arch='x86_64', version='0.5.0',
+            cache_dir=self.cache_dirs[0]
+        )
+
+    def test_find_image(self):
+        self.assertIsInstance(self.image, vmimage.Image)

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ if __name__ == '__main__':
           scripts=['scripts/avocado'],
           entry_points={
               'console_scripts': [
+                  'avocado-requirements = avocado.core.requirements:main',
                   'avocado-runner = avocado.core.nrunner:main',
                   'avocado-runner-noop = avocado.core.nrunner:main',
                   'avocado-runner-exec = avocado.core.nrunner:main',


### PR DESCRIPTION
This is the POC for the command-line Requirements Resolver.

**Usage:**
`avocado-requirements examples/requirements/docstring.py`

**Supported Requirements types:**
`file` and `image`

**Note:** requirement docstring should follow the `Asset` class parameters for file type and `vmimage` `get` method parameters for image type.

```
[wrampazz@wrampazz avocado.dev]$ avocado-requirements examples/requirements/docstring.py 
Fulfilling file requirement: gpl-2.0.txt
 File requirement: /home/wrampazz/avocado/data/cache/by_name/gpl-2.0.txt
Fulfilling file requirement: gpl-3.0.txt
 File requirement: /home/wrampazz/avocado/data/cache/by_name/gpl-3.0.txt
Fulfilling file requirement: lgpl-2.0.txt
 File requirement: /home/wrampazz/avocado/data/cache/by_name/lgpl-2.0.txt
Fulfilling file requirement: lgpl-2.1.txt
 File requirement: /home/wrampazz/avocado/data/cache/by_name/lgpl-2.1.txt
Fulfilling image requirement: cirros
 Image requirement: /home/wrampazz/avocado/data/cache/by_location/e3507e8a76e35c36e4542bac145441d9b7f61fbd/cirros-0.5.0-x86_64-disk.img
```

When running the test with `find_only=True` and `cancel_on_missing=True` parameters for `fetch` after running the `avocado-requirements` command:

```
[wrampazz@wrampazz avocado.dev]$ avocado run examples/requirements/docstring.py
/home/wrampazz/src/avocado/avocado.dev/avocado/plugins/run.py:284: FutureWarning: The following arguments will be changed to boolean soon: sysinfo, output-check, failfast, keep-tmp and ignore-missing-references.
  warnings.warn("The following arguments will be changed to boolean soon: "
JOB ID     : 656b3ad584470ac6e72770ca1e89870a39a87d8f
JOB LOG    : /home/wrampazz/avocado/job-results/job-2020-04-29T16.51-656b3ad/job.log
 (1/5) examples/requirements/docstring.py:GPL2.test_find_gpl: PASS (0.05 s)
 (2/5) examples/requirements/docstring.py:GPL3.test_find_gpl: PASS (0.02 s)
 (3/5) examples/requirements/docstring.py:LGPL2.test_find_lgpl2: PASS (0.06 s)
 (4/5) examples/requirements/docstring.py:LGPL2.test_find_lgpl2_1: PASS (0.03 s)
 (5/5) examples/requirements/docstring.py:Vmimage.test_find_image: PASS (2.17 s)
RESULTS    : PASS 5 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 2.66 s
JOB HTML   : /home/wrampazz/avocado/job-results/job-2020-04-29T16.51-656b3ad/results.html
```

Signed-off-by: Willian Rampazzo <willianr@redhat.com>