### PR TITLE
Spawner: introduce basic tests

### DIFF
--- a/avocado/core/spawners/mock.py
+++ b/avocado/core/spawners/mock.py
@@ -1,0 +1,47 @@
+import asyncio
+import random
+
+from .common import BaseSpawner
+from .common import SpawnMethod
+
+
+class MockSpawner(BaseSpawner):
+    """A mocking spawner that performs no real operation.
+
+    Tasks asked to be spawned by this spawner will initially reported to
+    be alive, and on the next check, will report not being alive.
+    """
+
+    METHODS = [SpawnMethod.PYTHON_CLASS, SpawnMethod.STANDALONE_EXECUTABLE]
+
+    def __init__(self):
+        self._known_tasks = {}
+
+    def is_task_alive(self, task):
+        alive = self._known_tasks.get(task, None)
+        # task was never spawned
+        if alive is None:
+            return False
+        # task was spawned and should signal it's alive for the first time
+        if alive:
+            self._known_tasks[task] = False
+            return True
+        else:
+            # signal it's *not* alive after first check
+            return False
+
+    @asyncio.coroutine
+    def spawn_task(self, task):
+        self._known_tasks[task] = True
+        return True
+
+
+class MockRandomAliveSpawner(MockSpawner):
+    """A mocking spawner that simulates randomness about tasks being alive."""
+
+    def is_task_alive(self, task):
+        alive = self._known_tasks.get(task, None)
+        # task was never spawned
+        if alive is None:
+            return False
+        return random.choice([True, True, True, True, False])

--- a/selftests/unit/test_spawner.py
+++ b/selftests/unit/test_spawner.py
@@ -1,0 +1,55 @@
+import asyncio
+import unittest
+
+from avocado.core import nrunner
+from avocado.core.spawners.mock import MockSpawner
+from avocado.core.spawners.mock import MockRandomAliveSpawner
+
+
+class Mock(unittest.TestCase):
+
+    def setUp(self):
+        runnable = nrunner.Runnable('noop', 'uri')
+        self.task = nrunner.Task('1', runnable)
+        self.spawner = MockSpawner()
+
+    def test_spawned(self):
+        loop = asyncio.get_event_loop()
+        spawned = loop.run_until_complete(self.spawner.spawn_task(self.task))
+        self.assertTrue(spawned)
+
+    def test_never_spawned(self):
+        self.assertFalse(self.spawner.is_task_alive(self.task))
+        self.assertFalse(self.spawner.is_task_alive(self.task))
+
+    def test_spawned_is_alive(self):
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(self.spawner.spawn_task(self.task))
+        self.assertTrue(self.spawner.is_task_alive(self.task))
+        self.assertFalse(self.spawner.is_task_alive(self.task))
+
+
+class RandomMock(Mock):
+
+    def setUp(self):
+        runnable = nrunner.Runnable('noop', 'uri')
+        self.task = nrunner.Task('1', runnable)
+        self.spawner = MockRandomAliveSpawner()
+
+    def test_spawned_is_alive(self):
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(self.spawner.spawn_task(self.task))
+        # The likelihood of the random spawner returning the task is
+        # not alive is 1 in 5.  This gives the random code 10000
+        # chances of returning False, so it should, famous last words,
+        # be pretty safe
+        finished = False
+        for _ in range(10000):
+            if not self.spawner.is_task_alive(self.task):
+                finished = True
+                break
+        self.assertTrue(finished)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The spawners will, for the vast majority of time, be dealing with the
real world, spawning processes, containers (and possibly other
execution environments such as VMs in the future).

Because of the randonmess inherent to the real world, we need a
predictable behavior to test its interfaces, introduce here as as the
MockSpawner.  It's also useful to test how upper layer code will
handle the randomness without actually resorting to running processes,
containers, etc, and for that reason another spawner implementation is
introduced and tested here.

Signed-off-by: Cleber Rosa <crosa@redhat.com>