### PR TITLE
Safeloader: prevent duplicated tests from being found

### DIFF
--- a/avocado/core/safeloader.py
+++ b/avocado/core/safeloader.py
@@ -380,6 +380,13 @@ def _determine_match_avocado(module, klass, docstring):
     return module.is_matching_klass(klass)
 
 
+def _extend_test_list(current, new):
+    for test in new:
+        test_method_name = test[0]
+        if test_method_name not in [_[0] for _ in current]:
+            current.append(test)
+
+
 def _examine_class(path, class_name, match, target_module, target_class,
                    determine_match):
     """
@@ -444,7 +451,7 @@ def _examine_class(path, class_name, match, target_module, target_class,
                                                       _determine_match_avocado)
             if _info:
                 parents.remove(parent)
-                info.extend(_info)
+                _extend_test_list(info, _info)
                 disabled.update(_disabled)
             if _match is not match:
                 match = _match
@@ -490,7 +497,7 @@ def _examine_class(path, class_name, match, target_module, target_class,
                                                       target_class,
                                                       _determine_match_avocado)
             if _info:
-                info.extend(_info)
+                _extend_test_list(info, _info)
                 disabled.update(_disabled)
             if _match is not match:
                 match = _match
@@ -566,7 +573,7 @@ def find_avocado_tests(path):
                                                    _determine_match_avocado)
             if _info:
                 parents.remove(parent)
-                info.extend(_info)
+                _extend_test_list(info, _info)
                 _disabled.update(_dis)
             if _avocado is not is_avocado:
                 is_avocado = _avocado
@@ -677,7 +684,7 @@ def find_python_unittests(path):
                                                        _determine_match_unittest)
             if _info:
                 parents.remove(parent)
-                info.extend(_info)
+                _extend_test_list(info, _info)
             if _is_unittest is not is_unittest:
                 is_unittest = _is_unittest
 
@@ -724,7 +731,7 @@ def find_python_unittests(path):
                                                        class_name,
                                                        _determine_match_unittest)
             if _info:
-                info.extend(_info)
+                _extend_test_list(info, _info)
             if _is_unittest is not is_unittest:
                 is_unittest = _is_unittest
 

--- a/avocado/core/safeloader.py
+++ b/avocado/core/safeloader.py
@@ -728,7 +728,7 @@ def find_python_unittests(path):
             if _is_unittest is not is_unittest:
                 is_unittest = _is_unittest
 
-        # Only update the results if this was detected as 'avocado.Test'
+        # Only update the results if this was detected as 'unittest.TestCase'
         if is_unittest:
             result[klass.name] = info
 

--- a/selftests/unit/test_safeloader.py
+++ b/selftests/unit/test_safeloader.py
@@ -83,6 +83,9 @@ class BaseClass(TestCase):
     :avocado: tags=base-tag
     :avocado: tags=base.tag
     '''
+    def test_maybe_replaced_by_child(self):
+        pass
+
     def test_basic(self):
         pass
 
@@ -91,6 +94,9 @@ class Child(BaseClass):
     :avocado: tags=child-tag
     :avocado: tags=child.tag
     '''
+    def test_maybe_replaced_by_child(self):
+        pass
+
     def test_child(self):
         pass
 """
@@ -472,10 +478,18 @@ class FindClassAndMethods(UnlimitedDiff):
             RECURSIVE_DISCOVERY_PYTHON_UNITTEST)
         temp_test.save()
         tests = safeloader.find_python_unittests(temp_test.path)
-        expected = {'BaseClass': [('test_basic', {'base-tag': None,
-                                                  'base.tag': None},
-                                   [])],
-                    'Child': [('test_child', {'child-tag': None,
+        expected = {'BaseClass': [('test_maybe_replaced_by_child',
+                                   {'base-tag': None,
+                                    'base.tag': None},
+                                   []),
+                                  ('test_basic',
+                                   {'base-tag': None,
+                                    'base.tag': None}, [])],
+                    'Child': [('test_maybe_replaced_by_child',
+                               {'child-tag': None,
+                                'child.tag': None},
+                               []),
+                              ('test_child', {'child-tag': None,
                                               'child.tag': None},
                                []),
                               ('test_basic', {'base-tag': None,


### PR DESCRIPTION
This fixes a bug where a class inheriting from a base class containing a test with the same name would appear in the list of discovered tests twice.