### PR TITLE
Nrunner: improvements to the status server [v2]

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -727,30 +727,30 @@ class StatusServer:
                                                            data['output_dir']))
 
     def handle_task_finished(self, data):
-        try:
-            self.tasks_pending.remove(data['id'])
-            print('Task complete (%s): %s' % (data['result'],
-                                              data['id']))
-        except IndexError:
-            pass
-        except ValueError:
-            pass
-        if 'result' in data:
-            if data['result'] in self.result:
-                self.result[data['result']] += 1
-            else:
-                self.result[data['result']] = 1
+        if 'result' not in data:
+            return
 
-        if data.get('result') not in ('pass', 'skip'):
+        result = data['result']
+        task_id = data['id']
+
+        self.tasks_pending.remove(task_id)
+        print('Task complete (%s): %s' % (result, task_id))
+
+        if result in self.result:
+            self.result[result] += 1
+        else:
+            self.result[result] = 1
+
+        if result not in ('pass', 'skip'):
             stdout = data.get('stdout', b'')
             if stdout:
-                print('Task %s stdout:\n%s\n' % (data['id'], stdout))
+                print('Task %s stdout:\n%s\n' % (task_id, stdout))
             stderr = data.get('stderr', b'')
             if stderr:
-                print('Task %s stderr:\n%s\n' % (data['id'], stderr))
+                print('Task %s stderr:\n%s\n' % (task_id, stderr))
             output = data.get('output', b'')
             if output:
-                print('Task %s output:\n%s\n' % (data['id'], output))
+                print('Task %s output:\n%s\n' % (task_id, output))
 
     def start(self):
         loop = asyncio.get_event_loop()

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -736,10 +736,9 @@ class StatusServer:
         self.tasks_pending.remove(task_id)
         print('Task complete (%s): %s' % (result, task_id))
 
-        if result in self.result:
-            self.result[result] += 1
-        else:
-            self.result[result] = 1
+        if result not in self.result:
+            self.result[result] = []
+        self.result[result].append(task_id)
 
         if result not in ('pass', 'skip'):
             stdout = data.get('stdout', b'')

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -708,9 +708,9 @@ class StatusServer:
 
             data = json_loads(message.strip())
 
-            if data['status'] in ['started']:
+            if data.get('status') in ['started']:
                 self.handle_task_started(data)
-            elif data['status'] in ['finished']:
+            elif data.get('status') in ['finished']:
                 self.handle_task_finished(data)
 
     @asyncio.coroutine
@@ -735,12 +735,13 @@ class StatusServer:
             pass
         except ValueError:
             pass
-        if data['result'] in self.result:
-            self.result[data['result']] += 1
-        else:
-            self.result[data['result']] = 1
+        if 'result' in data:
+            if data['result'] in self.result:
+                self.result[data['result']] += 1
+            else:
+                self.result[data['result']] = 1
 
-        if data['result'] not in ('pass', 'skip'):
+        if data.get('result') not in ('pass', 'skip'):
             stdout = data.get('stdout', b'')
             if stdout:
                 print('Task %s stdout:\n%s\n' % (data['id'], stdout))

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -193,7 +193,7 @@ class Runnable:
                                        stdin=subprocess.DEVNULL,
                                        stdout=subprocess.PIPE,
                                        stderr=subprocess.DEVNULL)
-        except FileNotFoundError:
+        except (FileNotFoundError, PermissionError):
             return False
         out, _ = process.communicate()
 

--- a/avocado/core/spawners/process.py
+++ b/avocado/core/spawners/process.py
@@ -19,8 +19,12 @@ class ProcessSpawner(BaseSpawner):
         runner = runner[0]
 
         # pylint: disable=E1133
-        task.spawn_handle = yield from asyncio.create_subprocess_exec(
-            runner,
-            *args,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE)
+        try:
+            task.spawn_handle = yield from asyncio.create_subprocess_exec(
+                runner,
+                *args,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE)
+        except (FileNotFoundError, PermissionError):
+            return False
+        return True

--- a/avocado/plugins/nrun.py
+++ b/avocado/plugins/nrun.py
@@ -95,6 +95,16 @@ class NRun(CLICmd):
             else:
                 LOG_UI.info("%s spawned and alive", identifier)
 
+    def report_results(self):
+        """Reports a summary, with verbose listing of fail/error tasks."""
+        summary = {status: len(tasks)
+                   for (status, tasks) in self.status_server.result.items()}
+        LOG_UI.info("Tasks result summary: %s", summary)
+        for status, tasks in self.status_server.result.items():
+            if status in ('fail', 'error'):
+                LOG_UI.error("Tasks ended with '%s': %s",
+                             status, ", ".join(tasks))
+
     def run(self, config):
         hint_filepath = '.avocado.hint'
         hint = None
@@ -141,7 +151,7 @@ class NRun(CLICmd):
             parallel_tasks = config.get('nrun.parallel_tasks')
             loop.run_until_complete(self.spawn_tasks(parallel_tasks))
             loop.run_until_complete(self.status_server.wait())
-            print(self.status_server.result)
+            self.report_results()
             exit_code = exit_codes.AVOCADO_ALL_OK
             if self.status_server.result.get('fail') is not None:
                 exit_code |= exit_codes.AVOCADO_TESTS_FAIL

--- a/avocado/plugins/nrun.py
+++ b/avocado/plugins/nrun.py
@@ -85,10 +85,14 @@ class NRun(CLICmd):
                 print("Finished spawning tasks")
                 break
 
-            yield from self.spawner.spawn_task(task)
+            spawn_result = yield from self.spawner.spawn_task(task)
             identifier = task.identifier
             self.pending_tasks.remove(task)
             self.spawned_tasks.append(identifier)
+            if not spawn_result:
+                LOG_UI.error("ERROR: failed to spawn task: %s", identifier)
+                continue
+
             alive = self.spawner.is_task_alive(task)
             if not alive:
                 LOG_UI.warning("%s is not alive shortly after being spawned", identifier)


### PR DESCRIPTION
The most important feature is a list of the failed/errored tasks, which currently usually requires a scrollback/search of the previous output.

---

Changes from v1 (#3753):
 * Renamed `id_` variable to `task_id` (@beraldoleal)