### PR TITLE
utils/network: Bring back the simple backup method

### DIFF
--- a/avocado/utils/network/interfaces.py
+++ b/avocado/utils/network/interfaces.py
@@ -20,7 +20,6 @@ import json
 import logging
 import os
 import shutil
-import time
 
 from ipaddress import ip_interface
 
@@ -67,7 +66,7 @@ class NetworkInterface:
             raise NWException(msg)
 
     def _move_file_to_backup(self, filename, ignore_missing=True):
-        destination = "{}.backup-{}".format(filename, time.time())
+        destination = "{}.backup".format(filename)
         if os.path.exists(filename):
             shutil.move(filename, destination)
         else:


### PR DESCRIPTION
This is a quick fix to bring back the simple backup method, without the
timestamp. This will avoid the directory of being full with a lot of
backup files. We still need to improve this backup routine in the near
future to support backup per interface.

Signed-off-by: Beraldo Leal <bleal@redhat.com>