### PR TITLE
Fix python3 issue when use cpu_has_flags lib

### DIFF
--- a/avocado/utils/cpu.py
+++ b/avocado/utils/cpu.py
@@ -90,7 +90,7 @@ def cpu_has_flags(flags):
         flags = [flags]
 
     for flag in flags:
-        if not _list_matches(cpu_info, '.*%s.*' % flag):
+        if not _list_matches(map(str, cpu_info), '.*%s.*' % flag):
             return False
     return True
 


### PR DESCRIPTION
before this patch :

>>> cpu.cpu_has_flags('PowerNv')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/root/tests/avocado/avocado/utils/cpu.py", line 93, in cpu_has_flags
    if not _list_matches(cpu_info, '.*%s.*' % flag):
  File "/root/tests/avocado/avocado/utils/cpu.py", line 41, in _list_matches
    match = re.search(pattern, content)
  File "/usr/lib64/python3.6/re.py", line 182, in search
    return _compile(pattern, flags).search(string)
TypeError: cannot use a string pattern on a bytes-like object
>>>

after this patch

Python 3.6.8 (default, Dec  5 2019, 16:11:43)
[GCC 8.3.1 20191121 (Red Hat 8.3.1-5)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from avocado.utils import cpu
>>> cpu.cpu_has_flags('PowerNv')
False
>>> cpu.cpu_has_flags('processor')
True
>>>

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>