### PR TITLE
Nrunner: introduce scheduler

### DIFF
--- a/avocado/core/scheduler.py
+++ b/avocado/core/scheduler.py
@@ -1,0 +1,143 @@
+import asyncio
+from multiprocessing import cpu_count
+
+from .spawners.process import ProcessSpawner
+
+
+class SchedulerException(Exception):
+    """Base exception for the Scheduller."""
+
+
+class SchedulerNoPendingTasksException(SchedulerException):
+    """Exception raised when there are no more pending tasks to be started."""
+
+
+class Scheduler:
+    """Manages the scheduling of tasks, keeping track of the their status."""
+
+    #: The interval given to other coroutines when a the scheduler needs
+    #: to wait, for instance, for the conclusion of all tasks
+    INTERVAL = 0.05
+
+    def __init__(self, tasks, parallel_tasks=None, spawner=None):
+        """Initializes a new scheduler.
+
+        :param tasks: the tasks to be scheduled to be executed
+        :type tasks: list of :class:`avocado.core.nrunner.Task`
+        :param parallel_tasks: the number of parallel tasks that will be kept
+                               running at any given time.  It defaults to
+                               twice the number of active CPUs in the local
+                               system, minus one.
+        :type parallel_tasks: int
+        :param spawner: an instance of a spawner to be used in starting tasks
+                        and checking for their "health", that is, if a task
+                        appears to be alive or not.  It defaults to a
+                       :class:`avocado.core.spawners.process.ProcessSpawner`
+        :type spawner: :class:`avocado.core.spawners.common.BaseSpawner`
+        """
+        self.pending_tasks = tasks
+
+        if parallel_tasks is None:
+            parallel_tasks = 2 * cpu_count() - 1
+        self.parallel_tasks = parallel_tasks
+
+        if spawner is None:
+            spawner = ProcessSpawner()
+        self.spawner = spawner
+        self.started_tasks = []
+        self.start_failed_tasks = []
+        #: Tasks that have finished from the manager perspective
+        self.finished_tasks = []
+
+    def __repr__(self):
+        return ('<Scheduler pending: "{}" started: "{}" start failed: {} '
+                'finished: "{}">').format(self.pending_tasks,
+                                          self.started_tasks,
+                                          self.start_failed_tasks,
+                                          self.finished_tasks)
+
+    @asyncio.coroutine
+    def tick(self):
+        """Runs one cycle of scheduler tasks, based on current parallel tasks.
+
+        This method facilitates the use of the scheduler in a loop.  It will
+        return False if new task was not spawned, which can be used to abort
+        a loop.
+
+        :rtype: bool
+        """
+        yield from self.reconcile_task_status()
+        if self.is_complete():
+            return False
+        if not self.should_spawn_new_task():
+            return False
+        try:
+            result = yield from self.spawn_next_task()
+            return result
+        except SchedulerNoPendingTasksException:
+            return False
+
+    def should_spawn_new_task(self):
+        """Whether to spawn a new task based on the current load."""
+        return len(self.started_tasks) < self.parallel_tasks
+
+    @asyncio.coroutine
+    def spawn_task(self, task):
+        """Spawns a task with the scheduler spawner.
+
+        If the task is found in the list of pending tasks, it's
+        removed from that list.  This allows users of the scheduler to
+        spawn tasks not originally in the list of pending tasks.
+        """
+        try:
+            self.pending_tasks.remove(task)
+        except ValueError:
+            pass
+        spawned_result = yield from self.spawner.spawn_task(task)
+        if spawned_result:
+            self.started_tasks.append(task)
+        else:
+            self.start_failed_tasks.append(task)
+        return spawned_result
+
+    @asyncio.coroutine
+    def spawn_next_task(self):
+        """Spawns the next pending task.
+
+        :raises: SchedulerNoPendingTasksException if there are no more pending
+                 tasks
+        """
+        try:
+            task = self.pending_tasks.pop(0)
+        except IndexError:
+            raise SchedulerNoPendingTasksException
+        spawned_result = yield from self.spawn_task(task)
+        return spawned_result
+
+    def is_complete(self):
+        """Returns whether there's any pending or not yet finished task.
+
+        :rtype: bool
+        """
+        return not (self.pending_tasks or self.started_tasks)
+
+    @asyncio.coroutine
+    def wait_until_complete(self):
+        """Waits until the scheduler is complete, reconciling often."""
+        while True:
+            if not self.is_complete():
+                yield from self.reconcile()
+            else:
+                break
+
+    @asyncio.coroutine
+    def reconcile_task_status(self):
+        """Reconcile the status of tasks, such as from started to finished.
+
+        This happens after letting coroutings check on tasks status."""
+        yield from asyncio.sleep(self.INTERVAL)
+        finished_tasks = [task for task in self.started_tasks
+                          if not self.spawner.is_task_alive(task)]
+        for task in finished_tasks:
+            self.started_tasks.remove(task)
+            self.finished_tasks.append(task)

--- a/avocado/core/spawners/mock.py
+++ b/avocado/core/spawners/mock.py
@@ -1,0 +1,47 @@
+import asyncio
+import random
+
+from .common import BaseSpawner
+from .common import SpawnMethod
+
+
+class MockSpawner(BaseSpawner):
+    """A mocking spawner that performs no real operation.
+
+    Tasks asked to be spawned by this spawner will initially reported to
+    be alive, and on the next check, will report not being alive.
+    """
+
+    METHODS = [SpawnMethod.PYTHON_CLASS, SpawnMethod.STANDALONE_EXECUTABLE]
+
+    def __init__(self):
+        self._known_tasks = {}
+
+    def is_task_alive(self, task):
+        alive = self._known_tasks.get(task, None)
+        # task was never spawned
+        if alive is None:
+            return False
+        # task was spawned and should signal it's alive for the first time
+        if alive:
+            self._known_tasks[task] = False
+            return True
+        else:
+            # signal it's *not* alive after first check
+            return False
+
+    @asyncio.coroutine
+    def spawn_task(self, task):
+        self._known_tasks[task] = True
+        return True
+
+
+class MockRandomAliveSpawner(MockSpawner):
+    """A mocking spawner that simulates randomness about tasks being alive."""
+
+    def is_task_alive(self, task):
+        alive = self._known_tasks.get(task, None)
+        # task was never spawned
+        if alive is None:
+            return False
+        return random.choice([True, True, True, True, False])

--- a/avocado/core/spawners/process.py
+++ b/avocado/core/spawners/process.py
@@ -8,6 +8,10 @@ class ProcessSpawner(BaseSpawner):
 
     METHODS = [SpawnMethod.STANDALONE_EXECUTABLE]
 
+    @asyncio.coroutine
+    def _collect_task(self, task_handle):
+        yield from task_handle.wait()
+
     @staticmethod
     def is_task_alive(task):
         if getattr(task, 'spawn_handle', None) is None:
@@ -29,4 +33,5 @@ class ProcessSpawner(BaseSpawner):
                 stderr=asyncio.subprocess.PIPE)
         except (FileNotFoundError, PermissionError):
             return False
+        asyncio.ensure_future(self._collect_task(task.spawn_handle))
         return True

--- a/avocado/core/spawners/process.py
+++ b/avocado/core/spawners/process.py
@@ -10,6 +10,8 @@ class ProcessSpawner(BaseSpawner):
 
     @staticmethod
     def is_task_alive(task):
+        if getattr(task, 'spawn_handle', None) is None:
+            return False
         return task.spawn_handle.returncode is None
 
     @asyncio.coroutine

--- a/avocado/plugins/nrun.py
+++ b/avocado/plugins/nrun.py
@@ -144,7 +144,6 @@ class NRun(CLICmd):
                 self.spawner = PodmanSpawner()  # pylint: disable=W0201
             else:
                 self.spawner = ProcessSpawner()  # pylint: disable=W0201
-            loop = asyncio.get_event_loop()
             listen = config.get('nrun.status_server.listen')
             verbose = config.get('core.verbose')
             self.status_server = nrunner.StatusServer(listen,  # pylint: disable=W0201
@@ -153,6 +152,7 @@ class NRun(CLICmd):
                                                       verbose)
             self.status_server.start()
             parallel_tasks = config.get('nrun.parallel_tasks')
+            loop = asyncio.get_event_loop()
             loop.run_until_complete(self.spawn_tasks(parallel_tasks))
             loop.run_until_complete(self.status_server.wait())
             self.report_results()

--- a/selftests/unit/test_scheduler.py
+++ b/selftests/unit/test_scheduler.py
@@ -1,0 +1,86 @@
+import asyncio
+import unittest
+
+from avocado.core import nrunner
+from avocado.core.spawners.mock import MockSpawner
+from avocado.core.scheduler import Scheduler, SchedulerNoPendingTasksException
+
+
+class Test(unittest.TestCase):
+
+    def setUp(self):
+        runnable = nrunner.Runnable('noop', 'none')
+        self.task1 = nrunner.Task('1', runnable)
+        self.task2 = nrunner.Task('2', runnable)
+        self.tasks = [self.task1, self.task2]
+        self.scheduler = Scheduler(self.tasks, spawner=MockSpawner())
+
+    def test_initial_state(self):
+        self.assertEqual(self.scheduler.pending_tasks, self.tasks)
+        self.assertEqual(self.scheduler.finished_tasks, [])
+
+    def test_spawn_task_not_pending(self):
+        task = nrunner.Task('3', nrunner.Runnable('noop', 'none'))
+        loop = asyncio.get_event_loop()
+        spawn = loop.run_until_complete(self.scheduler.spawn_task(task))
+        self.assertTrue(spawn)
+
+    def test_spawn_task(self):
+        loop = asyncio.get_event_loop()
+        spawn = loop.run_until_complete(self.scheduler.spawn_task(self.task1))
+        self.assertTrue(spawn)
+        self.assertNotIn(self.task1, self.scheduler.pending_tasks)
+
+    def test_spawn_next_task(self):
+        loop = asyncio.get_event_loop()
+        spawn = loop.run_until_complete(self.scheduler.spawn_next_task())
+        self.assertTrue(spawn)
+        self.assertIn(self.task1, self.scheduler.started_tasks)
+        self.assertNotIn(self.task1, self.scheduler.pending_tasks)
+        self.assertNotIn(self.task1, self.scheduler.start_failed_tasks)
+        self.assertIn(self.task2, self.scheduler.pending_tasks)
+
+    def test_is_complete_nothing_spawned(self):
+        self.assertFalse(self.scheduler.is_complete())
+
+    def test_is_complete(self):
+        loop = asyncio.get_event_loop()
+        spawn = loop.run_until_complete(self.scheduler.spawn_next_task())
+        self.assertTrue(spawn)
+        loop.run_until_complete(self.scheduler.reconcile_task_status())
+        spawn = loop.run_until_complete(self.scheduler.spawn_next_task())
+        self.assertTrue(spawn)
+        loop.run_until_complete(self.scheduler.reconcile_task_status())
+        # give a chance for tasks to finish
+        loop.run_until_complete(asyncio.sleep(self.scheduler.INTERVAL * 10))
+        loop.run_until_complete(self.scheduler.reconcile_task_status())
+        self.assertTrue(self.scheduler.is_complete())
+
+    def test_tick(self):
+        loop = asyncio.get_event_loop()
+        tick_count = 0
+        while tick_count < 2:
+            # wait for two positive ticks.  In theory they should be the
+            # first two attempts given that the tasks are very lightweight
+            # but this is safer
+            result = loop.run_until_complete(self.scheduler.tick())
+            if result:
+                tick_count += 1
+            # an arbitrary number to avoid this running forever
+            self.assertLess(tick_count, 1000,
+                            "Too many ticks to spawn two tasks")
+        # The next tick will report False since we don't have more tasks
+        self.assertFalse(loop.run_until_complete(self.scheduler.tick()))
+
+
+class TestException(unittest.TestCase):
+
+    def test(self):
+        scheduler = Scheduler([], spawner=MockSpawner())
+        loop = asyncio.get_event_loop()
+        with self.assertRaises(SchedulerNoPendingTasksException):
+            loop.run_until_complete(scheduler.spawn_next_task())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/selftests/unit/test_spawner.py
+++ b/selftests/unit/test_spawner.py
@@ -1,0 +1,55 @@
+import asyncio
+import unittest
+
+from avocado.core import nrunner
+from avocado.core.spawners.mock import MockSpawner
+from avocado.core.spawners.mock import MockRandomAliveSpawner
+
+
+class Mock(unittest.TestCase):
+
+    def setUp(self):
+        runnable = nrunner.Runnable('noop', 'uri')
+        self.task = nrunner.Task('1', runnable)
+        self.spawner = MockSpawner()
+
+    def test_spawned(self):
+        loop = asyncio.get_event_loop()
+        spawned = loop.run_until_complete(self.spawner.spawn_task(self.task))
+        self.assertTrue(spawned)
+
+    def test_never_spawned(self):
+        self.assertFalse(self.spawner.is_task_alive(self.task))
+        self.assertFalse(self.spawner.is_task_alive(self.task))
+
+    def test_spawned_is_alive(self):
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(self.spawner.spawn_task(self.task))
+        self.assertTrue(self.spawner.is_task_alive(self.task))
+        self.assertFalse(self.spawner.is_task_alive(self.task))
+
+
+class RandomMock(Mock):
+
+    def setUp(self):
+        runnable = nrunner.Runnable('noop', 'uri')
+        self.task = nrunner.Task('1', runnable)
+        self.spawner = MockRandomAliveSpawner()
+
+    def test_spawned_is_alive(self):
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(self.spawner.spawn_task(self.task))
+        # The likelihood of the random spawner returning the task is
+        # not alive is 1 in 5.  This gives the random code 10000
+        # chances of returning False, so it should, famous last words,
+        # be pretty safe
+        finished = False
+        for _ in range(10000):
+            if not self.spawner.is_task_alive(self.task):
+                finished = True
+                break
+        self.assertTrue(finished)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/selftests/unit/test_spawner.py
+++ b/selftests/unit/test_spawner.py
@@ -2,16 +2,16 @@ import asyncio
 import unittest
 
 from avocado.core import nrunner
+from avocado.core.spawners.process import ProcessSpawner
 from avocado.core.spawners.mock import MockSpawner
 from avocado.core.spawners.mock import MockRandomAliveSpawner
 
 
-class Mock(unittest.TestCase):
-
+class Process(unittest.TestCase):
     def setUp(self):
         runnable = nrunner.Runnable('noop', 'uri')
         self.task = nrunner.Task('1', runnable)
-        self.spawner = MockSpawner()
+        self.spawner = ProcessSpawner()
 
     def test_spawned(self):
         loop = asyncio.get_event_loop()
@@ -21,6 +21,14 @@ class Mock(unittest.TestCase):
     def test_never_spawned(self):
         self.assertFalse(self.spawner.is_task_alive(self.task))
         self.assertFalse(self.spawner.is_task_alive(self.task))
+
+
+class Mock(Process):
+
+    def setUp(self):
+        runnable = nrunner.Runnable('noop', 'uri')
+        self.task = nrunner.Task('1', runnable)
+        self.spawner = MockSpawner()
 
     def test_spawned_is_alive(self):
         loop = asyncio.get_event_loop()


### PR DESCRIPTION
The `nrun` command has its own logic implemented for starting new tasks, in the plugin itself, but `nrun` is really a temporary command and the `avocado run test1 test2` will continue to be the primary user interface.

On the way to have the nrunner replace the current test execution code on the `avocado run test1 test2` kind of usage, we need a method for scheduling Tasks (tests) to be executed according to some policies (currently the number of available parallel task slots).  This introduces such a class.

Even though this does port `nrun` to use this scheduler ( or for that same matter neither`avocado run`), another draft PR (https://github.com/avocado-framework/avocado/pull/3766) contains such a experimental port to prove the usability of this code.