### PR TITLE
Non UNIX portability improvements

### DIFF
--- a/avocado/core/app.py
+++ b/avocado/core/app.py
@@ -48,7 +48,8 @@ class AvocadoApp:
             raise SystemExit('Terminated')
 
         signal.signal(signal.SIGTERM, sigterm_handler)
-        signal.signal(signal.SIGTSTP, signal.SIG_IGN)   # ignore ctrl+z
+        if hasattr(signal, 'SIGTSTP'):
+            signal.signal(signal.SIGTSTP, signal.SIG_IGN)   # ignore ctrl+z
         self.parser = Parser()
         self.parser.start()
         output.early_start()

--- a/avocado/core/app.py
+++ b/avocado/core/app.py
@@ -44,7 +44,7 @@ class AvocadoApp:
         def sigterm_handler(signum, frame):     # pylint: disable=W0613
             children = process.get_children_pids(os.getpid())
             for child in children:
-                process.kill_process_tree(int(child), sig=signal.SIGKILL)
+                process.kill_process_tree(int(child))
             raise SystemExit('Terminated')
 
         signal.signal(signal.SIGTERM, sigterm_handler)

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -192,15 +192,15 @@ def get_children_pids(parent_pid, recursive=False):
     return children
 
 
-def kill_process_tree(pid, sig=signal.SIGKILL, send_sigcont=True,
-                      timeout=0):
+def kill_process_tree(pid, sig=None, send_sigcont=True, timeout=0):
     """
     Signal a process and all of its children.
 
     If the process does not exist -- return.
 
     :param pid: The pid of the process to signal.
-    :param sig: The signal to send to the processes.
+    :param sig: The signal to send to the processes, defaults to
+                :data:`signal.SIGKILL`
     :param send_sigcont: Send SIGCONT to allow killing stopped processes
     :param timeout: How long to wait for the pid(s) to die
                     (negative=infinity, 0=don't wait,
@@ -213,6 +213,9 @@ def kill_process_tree(pid, sig=signal.SIGKILL, send_sigcont=True,
             if pid_exists(pid):
                 return False
         return True
+
+    if sig is None:
+        sig = signal.SIGKILL
 
     if timeout > 0:
         start = time.time()

--- a/avocado/utils/vmimage.py
+++ b/avocado/utils/vmimage.py
@@ -39,6 +39,16 @@ from . import process
 QEMU_IMG = None
 
 
+#: Default image architecture, which defaults to the current machine
+#: architecture, if that's can be retrieved via :func:`os.uname`. If
+#: not, it defaults to "x86_64" simply because it's the most commonly
+#: used architecture and lack of a better default
+if hasattr(os, 'uname'):
+    DEFAULT_ARCH = os.uname()[4]
+else:
+    DEFAULT_ARCH = 'x86_64'
+
+
 class ImageProviderError(Exception):
     """
     Generic error class for ImageProvider
@@ -210,7 +220,7 @@ class FedoraImageProvider(FedoraImageProviderBase):
     name = 'Fedora'
 
     def __init__(self, version='[0-9]+', build='[0-9]+.[0-9]+',
-                 arch=os.uname()[4]):
+                 arch=DEFAULT_ARCH):
         super(FedoraImageProvider, self).__init__(version, build, arch)
         self.url_versions = 'https://dl.fedoraproject.org/pub/fedora/linux/releases/'
         self.url_images = self.url_versions + '{version}/%s/{arch}/images/'
@@ -225,7 +235,7 @@ class FedoraSecondaryImageProvider(FedoraImageProviderBase):
     name = 'FedoraSecondary'
 
     def __init__(self, version='[0-9]+', build='[0-9]+.[0-9]+',
-                 arch=os.uname()[4]):
+                 arch=DEFAULT_ARCH):
         super(FedoraSecondaryImageProvider, self).__init__(version, build,
                                                            arch)
         self.url_versions = 'https://dl.fedoraproject.org/pub/fedora-secondary/releases/'
@@ -240,7 +250,7 @@ class CentOSImageProvider(ImageProviderBase):
 
     name = 'CentOS'
 
-    def __init__(self, version='[0-9]+', build='[0-9]{4}', arch=os.uname()[4]):
+    def __init__(self, version='[0-9]+', build='[0-9]{4}', arch=DEFAULT_ARCH):
         super(CentOSImageProvider, self).__init__(version, build, arch)
         self.url_versions = 'https://cloud.centos.org/centos/'
         self.url_images = self.url_versions + '{version}/images/'
@@ -262,7 +272,7 @@ class UbuntuImageProvider(ImageProviderBase):
     name = 'Ubuntu'
 
     def __init__(self, version='[0-9]+.[0-9]+', build=None,
-                 arch=os.uname()[4]):
+                 arch=DEFAULT_ARCH):
         # Ubuntu uses 'amd64' instead of 'x86_64'
         if arch == 'x86_64':
             arch = 'amd64'
@@ -290,7 +300,7 @@ class DebianImageProvider(ImageProviderBase):
     name = 'Debian'
 
     def __init__(self, version='[0-9]+.[0-9]+.[0-9]+.*', build=None,
-                 arch=os.uname()[4]):
+                 arch=DEFAULT_ARCH):
         # Debian uses 'amd64' instead of 'x86_64'
         if arch == 'x86_64':
             arch = 'amd64'
@@ -312,7 +322,7 @@ class JeosImageProvider(ImageProviderBase):
     name = 'JeOS'
 
     def __init__(self, version='[0-9]+', build=None,
-                 arch=os.uname()[4]):
+                 arch=DEFAULT_ARCH):
         # JeOS uses '64' instead of 'x86_64'
         if arch == 'x86_64':
             arch = '64'
@@ -331,7 +341,7 @@ class OpenSUSEImageProvider(ImageProviderBase):
     HTML_ENCODING = 'iso-8859-1'
     name = 'OpenSUSE'
 
-    def __init__(self, version='[0-9]{2}.[0-9]{1}', build=None, arch=os.uname()[4]):
+    def __init__(self, version='[0-9]{2}.[0-9]{1}', build=None, arch=DEFAULT_ARCH):
         super(OpenSUSEImageProvider, self).__init__(version, build, arch)
         self.url_versions = 'https://download.opensuse.org/repositories/Cloud:/Images:/'
         self.url_images = self.url_versions + 'Leap_{version}/images/'
@@ -381,7 +391,7 @@ class CirrOSImageProvider(ImageProviderBase):
 
     name = 'CirrOS'
 
-    def __init__(self, version=r'[0-9]+\.[0-9]+\.[0-9]+', build=None, arch=os.uname()[4]):
+    def __init__(self, version=r'[0-9]+\.[0-9]+\.[0-9]+', build=None, arch=DEFAULT_ARCH):
         super(CirrOSImageProvider, self).__init__(version=version, build=build, arch=arch)
         self.url_versions = 'https://download.cirros-cloud.net/'
         self.url_images = self.url_versions + '{version}/'


### PR DESCRIPTION
Just some quick workarounds/fixes found while trying to run Avocado on non-UNIX platforms.  This basically means adhering to what Python itself makes available on UNIX platforms, so it's a "strictness" improvement in itself.