### PR TITLE
convert to bool option: --ignore-missing-references

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -246,7 +246,8 @@ class TestLoaderProxy:
                 tests.extend([(MissingTest, {'name': reference})
                               for reference in unhandled_references])
             else:
-                if force == 'on':
+                # This is a workaround to avoid changing the method signature
+                if force is True or force == 'on':
                     LOG_UI.error(LoaderUnhandledReferenceError(unhandled_references,
                                                                self._initialized_plugins))
                 else:

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -175,8 +175,8 @@ class Run(CLICmd):
                     '"off" will be deprecated soon.')
         settings.register_option(section='run',
                                  key='ignore_missing_references',
-                                 default='off',
-                                 choices=('on', 'off'),
+                                 default=False,
+                                 key_type=bool,
                                  help_msg=help_msg,
                                  parser=parser,
                                  long_arg='--ignore-missing-references')

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -282,8 +282,7 @@ class Run(CLICmd):
             process.OUTPUT_CHECK_RECORD_MODE = check_record
 
         warnings.warn("The following arguments will be changed to boolean soon: "
-                      "sysinfo, output-check, failfast, keep-tmp "
-                      "and ignore-missing-references.",
+                      "sysinfo, output-check, failfast and keep-tmp. ",
                       FutureWarning)
 
         unique_job_id = config.get('run.unique_job_id')

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -219,7 +219,7 @@ class RunnerOperationTest(unittest.TestCase):
 
     def test_runner_ignore_missing_references_one_missing(self):
         cmd_line = ('%s run --sysinfo=off --job-results-dir %s '
-                    'passtest.py badtest.py --ignore-missing-references on'
+                    'passtest.py badtest.py --ignore-missing-references'
                     % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         self.assertIn(b"Unable to resolve reference(s) 'badtest.py'", result.stderr)
@@ -230,7 +230,7 @@ class RunnerOperationTest(unittest.TestCase):
 
     def test_runner_ignore_missing_references_all_missing(self):
         cmd_line = ('%s run --sysinfo=off --job-results-dir %s '
-                    'badtest.py badtest2.py --ignore-missing-references on'
+                    'badtest.py badtest2.py --ignore-missing-references'
                     % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         self.assertIn(b"Unable to resolve reference(s) 'badtest.py', 'badtest2.py'",


### PR DESCRIPTION
This is part of the BP001 and aims to replace all "string booleans" to
real booleans in the command-line. For now, I'm starting small only with
the '--ignore-missing-references' option.