### PR TITLE
Deployment checks: use DNF on Fedora and EL

### DIFF
--- a/selftests/deployment/roles/avocado/tasks/pip/plugins.yml
+++ b/selftests/deployment/roles/avocado/tasks/pip/plugins.yml
@@ -4,7 +4,7 @@
     name: "git+{{ avocado_git_url}}@{{ avocado_git_branch }}#egg=avocado-framework-plugin-result-html&subdirectory=optional_plugins/html"
     virtualenv: "{{ temporary_dir.path }}"
   when: method == 'pip'
-  
+
 - name: Avocado resultsdb plugin installation via pip
   pip:
     name: "git+{{ avocado_git_url}}@{{ avocado_git_branch }}#egg=avocado-framework-plugin-resultsdb&subdirectory=optional_plugins/resultsdb"

--- a/selftests/deployment/roles/avocado/tasks/rpm/avocado.yml
+++ b/selftests/deployment/roles/avocado/tasks/rpm/avocado.yml
@@ -1,6 +1,6 @@
 ---
 - name: Installing Avocado using RPM
-  package:
+  dnf:
     name: python3-avocado
     state: latest
   when:

--- a/selftests/deployment/roles/avocado/tasks/rpm/plugins.yml
+++ b/selftests/deployment/roles/avocado/tasks/rpm/plugins.yml
@@ -1,24 +1,23 @@
 ---
 - name: Install Avocado plugins using RPM
-  package:
-    name: "{{ item }}"
+  dnf:
+    name:
+      - python3-avocado-plugins-glib
+      - python3-avocado-plugins-golang
+      - python3-avocado-plugins-loader-yaml
+      - python3-avocado-plugins-output-html
+      - python3-avocado-plugins-result-upload
+      - python3-avocado-plugins-varianter-cit
+      - python3-avocado-plugins-varianter-pict
+      - python3-avocado-plugins-varianter-yaml-to-mux
     state: latest
-  with_items:
-    - python3-avocado-plugins-glib
-    - python3-avocado-plugins-golang
-    - python3-avocado-plugins-loader-yaml
-    - python3-avocado-plugins-output-html
-    - python3-avocado-plugins-result-upload
-    - python3-avocado-plugins-varianter-cit
-    - python3-avocado-plugins-varianter-pict
-    - python3-avocado-plugins-varianter-yaml-to-mux
   when:
     - ansible_facts['distribution_file_variety'] == "RedHat"
     - ansible_facts['distribution_major_version']|int >= 30
     - method != "pip"
 
 - name: Install the Avocado VT plugin using RPM
-  package:
+  dnf:
     name: python3-avocado-plugins-vt
     state: latest
   when:

--- a/selftests/deployment/roles/common/tasks/aexpect.yml
+++ b/selftests/deployment/roles/common/tasks/aexpect.yml
@@ -1,9 +1,7 @@
 - name: Install python3-aexpect first
-  package:
-    name: "{{ item }}"
+  dnf:
+    name: python3-aexpect
     state: present
-  with_items:
-    - python3-aexpect
   when:
     - ansible_facts['distribution_file_variety'] == "RedHat"
     - avocado_vt|default(false)|bool == true

--- a/selftests/deployment/roles/common/tasks/dependencies.yml
+++ b/selftests/deployment/roles/common/tasks/dependencies.yml
@@ -1,10 +1,8 @@
 # Install dependencies
 - name: Install Basic Depedencies on Red Hat (like) systems specific to pip method
   package:
-    name: "{{ item }}"
+    name: python3-pip
     state: latest
-  with_items:
-    - python3-pip
   when:
     - ansible_facts['distribution_file_variety'] == "RedHat"
     - avocado_vt|default(false)|bool == true

--- a/selftests/deployment/roles/common/tasks/dependencies.yml
+++ b/selftests/deployment/roles/common/tasks/dependencies.yml
@@ -9,20 +9,19 @@
     - method == 'pip'
 
 - name: Install Avocado-VT Depedencies on Red Hat (like) systems
-  package:
-    name: "{{ item }}"
+  dnf:
+    name:
+     - git
+     - gcc
+     - nc
+     - python3-netaddr
+     - python3-netifaces
+     - qemu-img
+     - qemu-kvm
+     - tcpdump
+     - iproute
+     - iputils
     state: latest
-  with_items:
-    - git
-    - gcc
-    - nc
-    - python3-netaddr
-    - python3-netifaces
-    - qemu-img
-    - qemu-kvm
-    - tcpdump
-    - iproute
-    - iputils
   when:
     - ansible_facts['distribution_file_variety'] == "RedHat"
     - avocado_vt|default(false)|bool == true


### PR DESCRIPTION
On RHEL and Fedora, when we have the installation of multiple packages, let's use dnf instead given that we only support RHEL and Fedora versions already "dnf capable". That speeds up significantly the playbooks, given that all those packages will be attempted to be installed at once.

Also a couple of other cleanups.