### PR TITLE
avocado/utils/partition.py: remove dead code

### DIFF
--- a/avocado/utils/partition.py
+++ b/avocado/utils/partition.py
@@ -251,10 +251,6 @@ class Partition:
         Returns a list of processes using a given mountpoint
         """
         try:
-            FileNotFoundError
-        except NameError:
-            FileNotFoundError = IOError   # pylint: disable=W0622
-        try:
             cmd = "lsof " + mnt
             out = process.system_output(cmd, sudo=True)
             return [int(line.split()[1]) for line in out.splitlines()[1:]]


### PR DESCRIPTION
Which seems to exist only because FileNotFoundError was not available
on Python <= 3.2, so it should have been removed alongside Python 2
support.

Signed-off-by: Cleber Rosa <crosa@redhat.com>