### PR TITLE
Add method which can be use for restore for interface file from backup

### DIFF
--- a/avocado/utils/network/interfaces.py
+++ b/avocado/utils/network/interfaces.py
@@ -314,3 +314,29 @@ class NetworkInterface:
         except Exception as ex:
             msg = 'Failed to remove ipaddr. {}'.format(ex)
             raise NWException(msg)
+
+    def move_interface_file(self, ignore_missing=True):
+        """
+        Revert interface file from backup
+
+        This method checks if a backup version  is available for given interface
+        then it copies backup file to interface file in /sysfs path
+        """
+
+        current_distro = distro_detect()
+
+        filename = "ifcfg-{}".format(self.name)
+        if current_distro.name in ['rhel', 'fedora']:
+            path = "/etc/sysconfig/network-scripts"
+        elif current_distro.name == 'SuSE':
+            path = "/etc/sysconfig/network"
+        else:
+            msg = 'Distro not supported by API. Could not save ipaddr.'
+            raise NWException(msg)
+
+        backup_file = "{}.backup-{}".format(filename, time.time())
+        if os.path.exists(backup_file):
+            shutil.move(backup_file, filename)
+        else:
+            if not ignore_missing:
+                raise NWException("%s interface not available" % self.name)


### PR DESCRIPTION
As we need to revert back the interface file when test completed
so added utility can be used for same

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>