### PR TITLE
[V2]Add method which can be use for restore for interface file from backup

### DIFF
--- a/avocado/utils/network/interfaces.py
+++ b/avocado/utils/network/interfaces.py
@@ -313,3 +313,27 @@ class NetworkInterface:
         except Exception as ex:
             msg = 'Failed to remove ipaddr. {}'.format(ex)
             raise NWException(msg)
+
+    def restore_from_backup(self):
+        """Revert interface file from backup.
+
+        This method checks if a backup version  is available for given interface
+        then it copies backup file to interface file in /sysfs path
+        """
+
+        current_distro = distro_detect()
+        filename = "ifcfg-{}".format(self.name)
+        if current_distro.name in ['rhel', 'fedora']:
+            path = "/etc/sysconfig/network-scripts"
+        elif current_distro.name == 'SuSE':
+            path = "/etc/sysconfig/network"
+        else:
+            msg = 'Distro not supported by API. Could not restore the backup file.'
+            raise NWException(msg)
+        filename = "{}/{}".format(path, filename)
+        backup_file = "{}.backup".format(filename)
+        if os.path.exists(backup_file):
+            shutil.move(backup_file, filename)
+        else:
+            raise NWException(
+                "Backup file not available, could not restore file.")


### PR DESCRIPTION
As we need to revert back the interface file when test completed
so added utility can be used for same

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>