### PR TITLE
nrunner: update asyncio syntax usage

### DIFF
--- a/avocado/core/spawners/process.py
+++ b/avocado/core/spawners/process.py
@@ -12,15 +12,14 @@ class ProcessSpawner(BaseSpawner):
     def is_task_alive(task):
         return task.spawn_handle.returncode is None
 
-    @asyncio.coroutine
-    def spawn_task(self, task):
+    async def spawn_task(self, task):
         runner = task.runnable.pick_runner_command()
         args = runner[1:] + ['task-run'] + task.get_command_args()
         runner = runner[0]
 
         # pylint: disable=E1133
         try:
-            task.spawn_handle = yield from asyncio.create_subprocess_exec(
+            task.spawn_handle = await asyncio.create_subprocess_exec(
                 runner,
                 *args,
                 stdout=asyncio.subprocess.PIPE,

--- a/avocado/plugins/nrun.py
+++ b/avocado/plugins/nrun.py
@@ -73,11 +73,10 @@ class NRun(CLICmd):
 
         parser_common_args.add_tag_filter_args(parser)
 
-    @asyncio.coroutine
-    def spawn_tasks(self, parallel_tasks):
+    async def spawn_tasks(self, parallel_tasks):
         while True:
             while len(set(self.status_server.tasks_pending).intersection(self.spawned_tasks)) >= parallel_tasks:
-                yield from asyncio.sleep(0.1)
+                await asyncio.sleep(0.1)
 
             try:
                 task = self.pending_tasks[0]
@@ -85,7 +84,7 @@ class NRun(CLICmd):
                 print("Finished spawning tasks")
                 break
 
-            spawn_result = yield from self.spawner.spawn_task(task)
+            spawn_result = await self.spawner.spawn_task(task)
             identifier = task.identifier
             self.pending_tasks.remove(task)
             self.spawned_tasks.append(identifier)


### PR DESCRIPTION
This is a complement to e422cd52815f6b7a6afa73956a9da05014aec9db,
given that Avocado only supports Python 3.5 and later.

Signed-off-by: Cleber Rosa <crosa@redhat.com>