### PR TITLE
future/settings: Migrate varianter_yaml_to_mux optional plugin to use the new API

### DIFF
--- a/optional_plugins/runner_remote/tests/test_remote.py
+++ b/optional_plugins/runner_remote/tests/test_remote.py
@@ -58,8 +58,6 @@ class RemoteTestRunnerTest(unittest.TestCase):
                     'remote_password': 'password',
                     'remote_key_file': None,
                     'remote_timeout': 60,
-                    'mux_yaml': ['~/avocado/tests/foo.yaml',
-                                 '~/avocado/tests/bar/baz.yaml'],
                     'filter_by_tags': ["-foo", "-bar"],
                     'filter_by_tags_include_empty': False,
                     'env_keep': None,
@@ -104,8 +102,7 @@ class RemoteTestRunnerTest(unittest.TestCase):
         cmd_line = ('avocado run --force-job-id '
                     '0000000000000000000000000000000000000000 --json - '
                     '--archive /tests/sleeptest.py /tests/other/test '
-                    'passtest.py --mux-yaml ~/avocado/tests/foo.yaml '
-                    '~/avocado/tests/bar/baz.yaml --dry-run --filter-'
+                    'passtest.py --dry-run --filter-'
                     'by-tags -foo --filter-by-tags -bar')
         runner.remote.run.assert_called_with(cmd_line,
                                              ignore_status=True,

--- a/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/__init__.py
+++ b/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/__init__.py
@@ -22,17 +22,17 @@ import sys
 
 import yaml
 
-try:
-    from yaml import CSafeLoader as SafeLoader
-except ImportError:
-    from yaml import SafeLoader
-
 from avocado.core import exit_codes
 from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLI, Varianter
 from avocado.utils import astring
 
 from . import mux  # pylint: disable=W0406
+
+try:
+    from yaml import CSafeLoader as SafeLoader
+except ImportError:
+    from yaml import SafeLoader
 
 
 # Mapping for yaml flags


### PR DESCRIPTION
As part of the effort to remove default values scattered around the
code, this change only migrates the varianter_yaml_to_mux optional
plugin options to use the new module.
 
This Pull Request also removes the `varianter_yaml_to_mux` dependency
from the `runner_remote` plugin.