### PR TITLE
future/settings: Migrate varianter_pict optional plugin to use the new API

### DIFF
--- a/optional_plugins/varianter_pict/avocado_varianter_pict/__init__.py
+++ b/optional_plugins/varianter_pict/avocado_varianter_pict/__init__.py
@@ -19,8 +19,7 @@ import sys
 
 from avocado.core import exit_codes
 from avocado.core.output import LOG_UI
-from avocado.core.plugin_interfaces import CLI
-from avocado.core.plugin_interfaces import Varianter
+from avocado.core.plugin_interfaces import CLI, Varianter
 from avocado.core.tree import TreeNode
 from avocado.utils import path as utils_path
 from avocado.utils import process


### PR DESCRIPTION
As part of the effort to remove default values scattered around the
code, this change only migrates the varianter_pict optional plugin
options to use the new module.