### PR TITLE
nrunner: spawner improvements

### DIFF
--- a/avocado/core/spawners/mock.py
+++ b/avocado/core/spawners/mock.py
@@ -1,0 +1,47 @@
+import asyncio
+import random
+
+from .common import BaseSpawner
+from .common import SpawnMethod
+
+
+class MockSpawner(BaseSpawner):
+    """A mocking spawner that performs no real operation.
+
+    Tasks asked to be spawned by this spawner will initially reported to
+    be alive, and on the next check, will report not being alive.
+    """
+
+    METHODS = [SpawnMethod.PYTHON_CLASS, SpawnMethod.STANDALONE_EXECUTABLE]
+
+    def __init__(self):
+        self._known_tasks = {}
+
+    def is_task_alive(self, task):
+        alive = self._known_tasks.get(task, None)
+        # task was never spawned
+        if alive is None:
+            return False
+        # task was spawned and should signal it's alive for the first time
+        if alive:
+            self._known_tasks[task] = False
+            return True
+        else:
+            # signal it's *not* alive after first check
+            return False
+
+    @asyncio.coroutine
+    def spawn_task(self, task):
+        self._known_tasks[task] = True
+        return True
+
+
+class MockRandomAliveSpawner(MockSpawner):
+    """A mocking spawner that simulates randomness about tasks being alive."""
+
+    def is_task_alive(self, task):
+        alive = self._known_tasks.get(task, None)
+        # task was never spawned
+        if alive is None:
+            return False
+        return random.choice([True, True, True, True, False])

--- a/avocado/core/spawners/process.py
+++ b/avocado/core/spawners/process.py
@@ -8,6 +8,10 @@ class ProcessSpawner(BaseSpawner):
 
     METHODS = [SpawnMethod.STANDALONE_EXECUTABLE]
 
+    @asyncio.coroutine
+    def _collect_task(self, task_handle):
+        yield from task_handle.wait()
+
     @staticmethod
     def is_task_alive(task):
         if getattr(task, 'spawn_handle', None) is None:
@@ -28,4 +32,5 @@ class ProcessSpawner(BaseSpawner):
                 stderr=asyncio.subprocess.PIPE)
         except (FileNotFoundError, PermissionError):
             return False
+        asyncio.ensure_future(self._collect_task(task.spawn_handle))
         return True

--- a/avocado/core/spawners/process.py
+++ b/avocado/core/spawners/process.py
@@ -10,6 +10,8 @@ class ProcessSpawner(BaseSpawner):
 
     @staticmethod
     def is_task_alive(task):
+        if getattr(task, 'spawn_handle', None) is None:
+            return False
         return task.spawn_handle.returncode is None
 
     async def spawn_task(self, task):

--- a/avocado/plugins/nrun.py
+++ b/avocado/plugins/nrun.py
@@ -143,7 +143,6 @@ class NRun(CLICmd):
                 self.spawner = PodmanSpawner()  # pylint: disable=W0201
             else:
                 self.spawner = ProcessSpawner()  # pylint: disable=W0201
-            loop = asyncio.get_event_loop()
             listen = config.get('nrun.status_server.listen')
             verbose = config.get('core.verbose')
             self.status_server = nrunner.StatusServer(listen,  # pylint: disable=W0201
@@ -152,6 +151,7 @@ class NRun(CLICmd):
                                                       verbose)
             self.status_server.start()
             parallel_tasks = config.get('nrun.parallel_tasks')
+            loop = asyncio.get_event_loop()
             loop.run_until_complete(self.spawn_tasks(parallel_tasks))
             loop.run_until_complete(self.status_server.wait())
             self.report_results()

--- a/selftests/unit/test_spawner.py
+++ b/selftests/unit/test_spawner.py
@@ -1,0 +1,55 @@
+import asyncio
+import unittest
+
+from avocado.core import nrunner
+from avocado.core.spawners.mock import MockSpawner
+from avocado.core.spawners.mock import MockRandomAliveSpawner
+
+
+class Mock(unittest.TestCase):
+
+    def setUp(self):
+        runnable = nrunner.Runnable('noop', 'uri')
+        self.task = nrunner.Task('1', runnable)
+        self.spawner = MockSpawner()
+
+    def test_spawned(self):
+        loop = asyncio.get_event_loop()
+        spawned = loop.run_until_complete(self.spawner.spawn_task(self.task))
+        self.assertTrue(spawned)
+
+    def test_never_spawned(self):
+        self.assertFalse(self.spawner.is_task_alive(self.task))
+        self.assertFalse(self.spawner.is_task_alive(self.task))
+
+    def test_spawned_is_alive(self):
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(self.spawner.spawn_task(self.task))
+        self.assertTrue(self.spawner.is_task_alive(self.task))
+        self.assertFalse(self.spawner.is_task_alive(self.task))
+
+
+class RandomMock(Mock):
+
+    def setUp(self):
+        runnable = nrunner.Runnable('noop', 'uri')
+        self.task = nrunner.Task('1', runnable)
+        self.spawner = MockRandomAliveSpawner()
+
+    def test_spawned_is_alive(self):
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(self.spawner.spawn_task(self.task))
+        # The likelihood of the random spawner returning the task is
+        # not alive is 1 in 5.  This gives the random code 10000
+        # chances of returning False, so it should, famous last words,
+        # be pretty safe
+        finished = False
+        for _ in range(10000):
+            if not self.spawner.is_task_alive(self.task):
+                finished = True
+                break
+        self.assertTrue(finished)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/selftests/unit/test_spawner.py
+++ b/selftests/unit/test_spawner.py
@@ -2,16 +2,16 @@ import asyncio
 import unittest
 
 from avocado.core import nrunner
+from avocado.core.spawners.process import ProcessSpawner
 from avocado.core.spawners.mock import MockSpawner
 from avocado.core.spawners.mock import MockRandomAliveSpawner
 
 
-class Mock(unittest.TestCase):
-
+class Process(unittest.TestCase):
     def setUp(self):
         runnable = nrunner.Runnable('noop', 'uri')
         self.task = nrunner.Task('1', runnable)
-        self.spawner = MockSpawner()
+        self.spawner = ProcessSpawner()
 
     def test_spawned(self):
         loop = asyncio.get_event_loop()
@@ -21,6 +21,14 @@ class Mock(unittest.TestCase):
     def test_never_spawned(self):
         self.assertFalse(self.spawner.is_task_alive(self.task))
         self.assertFalse(self.spawner.is_task_alive(self.task))
+
+
+class Mock(Process):
+
+    def setUp(self):
+        runnable = nrunner.Runnable('noop', 'uri')
+        self.task = nrunner.Task('1', runnable)
+        self.spawner = MockSpawner()
 
     def test_spawned_is_alive(self):
         loop = asyncio.get_event_loop()


### PR DESCRIPTION
This increases the test coverage of the Spawners, by introducing a mock spawners that behave as expected (different than live Spawners which are suject to timing issues).

It was originally part of PR #3765, but was split here because the scheduler introduced there needs some more TLC. 