### PR TITLE
selftests: avoid duplication of skip blocks with a custom decorator

### DIFF
--- a/selftests/__init__.py
+++ b/selftests/__init__.py
@@ -91,3 +91,9 @@ def test_suite(base_selftests=True, plugin_selftests=None):
                                 plugin_dir, 'tests')
             suite.addTests(loader.discover(start_dir=path, top_level_dir=path))
     return suite
+
+
+def skipOnLevelsInferiorThan(level):
+    return unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < level,
+                           "Skipping test that take a long time to run, are "
+                           "resource intensive or time sensitve")

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -32,6 +32,7 @@ from avocado.utils import script
 from avocado.utils import path as utils_path
 
 from .. import AVOCADO, BASEDIR, python_module_available, temp_dir_prefix
+from .. import skipOnLevelsInferiorThan
 
 
 UNSUPPORTED_STATUS_TEST_CONTENTS = '''
@@ -272,9 +273,7 @@ class RunnerOperationTest(unittest.TestCase):
             self.assertIn("Runner error occurred: Test reports unsupported",
                           results["tests"][0]["fail_reason"])
 
-    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 1,
-                     "Skipping test that take a long time to run, are "
-                     "resource intensive or time sensitve")
+    @skipOnLevelsInferiorThan(1)
     def test_hanged_test_with_status(self):
         """ Check that avocado handles hanged tests properly """
         with script.TemporaryScript("report_status_and_hang.py",
@@ -426,9 +425,7 @@ class RunnerOperationTest(unittest.TestCase):
         # Ensure no test aborted error messages show up
         self.assertNotIn(b"TestAbortError: Test aborted unexpectedly", output)
 
-    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 2,
-                     "Skipping test that take a long time to run, are "
-                     "resource intensive or time sensitve")
+    @skipOnLevelsInferiorThan(2)
     def test_runner_abort(self):
         cmd_line = ('%s run --sysinfo=off --job-results-dir %s '
                     '--xunit - abort.py' % (AVOCADO, self.tmpdir.name))
@@ -498,9 +495,7 @@ class RunnerOperationTest(unittest.TestCase):
         int(r['job_id'], 16)  # it's an hex number
         self.assertEqual(len(r['job_id']), 40)
 
-    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 2,
-                     "Skipping test that take a long time to run, are "
-                     "resource intensive or time sensitve")
+    @skipOnLevelsInferiorThan(2)
     def test_early_latest_result(self):
         """
         Tests that the `latest` link to the latest job results is created early
@@ -552,9 +547,7 @@ class RunnerOperationTest(unittest.TestCase):
                       result.stdout_text)
 
     @unittest.skipIf(not READ_BINARY, "read binary not available.")
-    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 1,
-                     "Skipping test that take a long time to run, are "
-                     "resource intensive or time sensitve")
+    @skipOnLevelsInferiorThan(1)
     def test_read(self):
         cmd = "%s run --sysinfo=off --job-results-dir %%s %%s" % AVOCADO
         cmd %= (self.tmpdir.name, READ_BINARY)
@@ -724,9 +717,7 @@ class RunnerSimpleTest(unittest.TestCase):
                          "Avocado did not return rc %d:\n%s" %
                          (expected_rc, result))
 
-    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 2,
-                     "Skipping test that take a long time to run, are "
-                     "resource intensive or time sensitve")
+    @skipOnLevelsInferiorThan(2)
     def test_runner_onehundred_fail_timing(self):
         """
         We can be pretty sure that a failtest should return immediately. Let's
@@ -746,9 +737,7 @@ class RunnerSimpleTest(unittest.TestCase):
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %d:\n%s" % (expected_rc, result))
 
-    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 2,
-                     "Skipping test that take a long time to run, are "
-                     "resource intensive or time sensitve")
+    @skipOnLevelsInferiorThan(2)
     def test_runner_sleep_fail_sleep_timing(self):
         """
         Sleeptest is supposed to take 1 second, let's make a sandwich of
@@ -845,9 +834,7 @@ class RunnerSimpleTest(unittest.TestCase):
                          (expected_rc, result))
 
     @unittest.skipIf(not SLEEP_BINARY, 'sleep binary not available')
-    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 2,
-                     "Skipping test that take a long time to run, are "
-                     "resource intensive or time sensitve")
+    @skipOnLevelsInferiorThan(2)
     @unittest.skipUnless(AEXPECT_CAPABLE, 'aexpect package not available')
     def test_kill_stopped_sleep(self):
         proc = aexpect.Expect("%s run 60 --job-results-dir %s "

--- a/selftests/functional/test_interrupt.py
+++ b/selftests/functional/test_interrupt.py
@@ -13,7 +13,7 @@ from avocado.utils import wait
 from avocado.utils import script
 from avocado.utils import data_factory
 
-from .. import AVOCADO, BASEDIR, temp_dir_prefix
+from .. import AVOCADO, BASEDIR, temp_dir_prefix, skipOnLevelsInferiorThan
 
 # What is commonly known as "0755" or "u=rwx,g=rx,o=rx"
 DEFAULT_MODE = (stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR |
@@ -102,9 +102,7 @@ class InterruptTest(unittest.TestCase):
         self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
         self.test_module = None
 
-    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 2,
-                     "Skipping test that take a long time to run, are "
-                     "resource intensive or time sensitve")
+    @skipOnLevelsInferiorThan(2)
     def test_badly_behaved_sigint(self):
         """
         Make sure avocado can cleanly get out of a loop of badly behaved tests.
@@ -150,9 +148,7 @@ class InterruptTest(unittest.TestCase):
         # Make sure the Killing test subprocess message did appear
         self.assertIn(b'Killing test subprocess', output)
 
-    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 2,
-                     "Skipping test that take a long time to run, are "
-                     "resource intensive or time sensitve")
+    @skipOnLevelsInferiorThan(2)
     def test_badly_behaved_sigterm(self):
         """
         Make sure avocado can cleanly get out of a loop of badly behaved tests.
@@ -190,9 +186,7 @@ class InterruptTest(unittest.TestCase):
         # Make sure the Interrupted test sentence is there
         self.assertIn(b'Terminated\n', proc.stdout.read())
 
-    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 2,
-                     "Skipping test that take a long time to run, are "
-                     "resource intensive or time sensitve")
+    @skipOnLevelsInferiorThan(2)
     def test_well_behaved_sigint(self):
         """
         Make sure avocado can cleanly get out of a loop of well behaved tests.
@@ -234,9 +228,7 @@ class InterruptTest(unittest.TestCase):
         # Make sure the Killing test subprocess message is not there
         self.assertNotIn(b'Killing test subprocess', output)
 
-    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 2,
-                     "Skipping test that take a long time to run, are "
-                     "resource intensive or time sensitve")
+    @skipOnLevelsInferiorThan(2)
     def test_well_behaved_sigterm(self):
         """
         Make sure avocado can cleanly get out of a loop of well behaved tests.

--- a/selftests/functional/test_loader.py
+++ b/selftests/functional/test_loader.py
@@ -11,7 +11,7 @@ from avocado.core import exit_codes
 from avocado.utils import script
 from avocado.utils import process
 
-from .. import AVOCADO, BASEDIR, temp_dir_prefix
+from .. import AVOCADO, BASEDIR, temp_dir_prefix, skipOnLevelsInferiorThan
 
 
 AVOCADO_TEST_OK = """#!/usr/bin/env python
@@ -186,9 +186,7 @@ class LoaderTestFunctional(unittest.TestCase):
         # 2 because both FileLoader and the TAP loader cannot recognize the test
         self._test('passtest', AVOCADO_TEST_OK, 'NOT_A_TEST', count=2)
 
-    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 2,
-                     "Skipping test that take a long time to run, are "
-                     "resource intensive or time sensitve")
+    @skipOnLevelsInferiorThan(2)
     def test_sleep_a_lot(self):
         """
         Verifies that the test loader, at list time, does not load the Python
@@ -225,9 +223,7 @@ class LoaderTestFunctional(unittest.TestCase):
         # 2 because both FileLoader and the TAP loader cannot recognize the test
         self._test('notatest.py', NOT_A_TEST, 'NOT_A_TEST', count=2)
 
-    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 2,
-                     "Skipping test that take a long time to run, are "
-                     "resource intensive or time sensitve")
+    @skipOnLevelsInferiorThan(2)
     def test_runner_simple_python_like_multiple_files(self):
         mylib = script.TemporaryScript(
             'test2.py',
@@ -249,9 +245,7 @@ class LoaderTestFunctional(unittest.TestCase):
                     % (AVOCADO, self.tmpdir.name, mytest))
         self._run_with_timeout(cmd_line, 5)
 
-    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 2,
-                     "Skipping test that take a long time to run, are "
-                     "resource intensive or time sensitve")
+    @skipOnLevelsInferiorThan(2)
     def test_simple_using_main(self):
         mytest = script.TemporaryScript("simple_using_main.py",
                                         AVOCADO_TEST_SIMPLE_USING_MAIN,

--- a/selftests/functional/test_sysinfo.py
+++ b/selftests/functional/test_sysinfo.py
@@ -6,7 +6,7 @@ from avocado.core import exit_codes
 from avocado.utils import process
 from avocado.utils import script
 
-from .. import AVOCADO, BASEDIR, temp_dir_prefix
+from .. import AVOCADO, BASEDIR, temp_dir_prefix, skipOnLevelsInferiorThan
 
 
 COMMANDS_TIMEOUT_CONF = """
@@ -137,15 +137,11 @@ class SysInfoTest(unittest.TestCase):
                                  "existing location '%s' contains:\n%s"
                                  % (sleep_log, path, os.listdir(path)))
 
-    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 2,
-                     "Skipping test that take a long time to run, are "
-                     "resource intensive or time sensitve")
+    @skipOnLevelsInferiorThan(2)
     def test_sysinfo_interrupted(self):
         self.run_sysinfo_interrupted(10, 1, 15)
 
-    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 2,
-                     "Skipping test that take a long time to run, are "
-                     "resource intensive or time sensitve")
+    @skipOnLevelsInferiorThan(2)
     def test_sysinfo_not_interrupted(self):
         self.run_sysinfo_interrupted(5, -1, 10)
 

--- a/selftests/functional/test_utils.py
+++ b/selftests/functional/test_utils.py
@@ -11,7 +11,7 @@ from avocado.utils.filelock import FileLock
 from avocado.utils.stacktrace import prepare_exc_info
 from avocado.utils import process
 
-from .. import temp_dir_prefix
+from .. import temp_dir_prefix, skipOnLevelsInferiorThan
 
 
 # What is commonly known as "0775" or "u=rwx,g=rwx,o=rx"
@@ -139,9 +139,7 @@ class ProcessTest(unittest.TestCase):
             fake_uptime_obj.write(FAKE_UPTIME_CONTENTS)
         os.chmod(self.fake_uptime, DEFAULT_MODE)
 
-    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 2,
-                     "Skipping test that take a long time to run, are "
-                     "resource intensive or time sensitive")
+    @skipOnLevelsInferiorThan(2)
     def test_process_start(self):
         proc = process.SubProcess('%s 1 0' % self.fake_vmstat)
         proc.start()
@@ -152,9 +150,7 @@ class ProcessTest(unittest.TestCase):
         self.assertIn('memory', stdout, 'result: %s' % stdout)
         self.assertRegex(stdout, '[0-9]+')
 
-    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 2,
-                     "Skipping test that take a long time to run, are "
-                     "resource intensive or time sensitive")
+    @skipOnLevelsInferiorThan(2)
     def test_process_stop_interrupted(self):
         proc = process.SubProcess('%s 1 3' % self.fake_vmstat)
         proc.start()
@@ -163,9 +159,7 @@ class ProcessTest(unittest.TestCase):
         result = proc.result
         self.assertIn('timeout after', result.interrupted, "Process wasn't interrupted")
 
-    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 2,
-                     "Skipping test that take a long time to run, are "
-                     "resource intensive or time sensitive")
+    @skipOnLevelsInferiorThan(2)
     def test_process_stop_uninterrupted(self):
         proc = process.SubProcess('%s 1 3' % self.fake_vmstat)
         proc.start()
@@ -198,9 +192,7 @@ class FileLockTest(unittest.TestCase):
         prefix = temp_dir_prefix(__name__, self, 'setUp')
         self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
 
-    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 3,
-                     "Skipping test that take a long time to run, are "
-                     "resource intensive or time sensitive")
+    @skipOnLevelsInferiorThan(3)
     def test_filelock(self):
         # Calculate the timeout based on t_100_iter + 2e-5*players
         start = time.time()

--- a/selftests/unit/test_plugin_vmimage.py
+++ b/selftests/unit/test_plugin_vmimage.py
@@ -6,7 +6,7 @@ from urllib.error import URLError
 from avocado.core import settings, data_dir
 from avocado.plugins import vmimage as vmimage_plugin
 from avocado.utils import vmimage as vmimage_util
-from .. import temp_dir_prefix
+from .. import temp_dir_prefix, skipOnLevelsInferiorThan
 from ..functional.test_plugin_vmimage import missing_binary, create_metadata_file
 
 #: extracted from https://dl.fedoraproject.org/pub/fedora/linux/releases/
@@ -128,9 +128,7 @@ class VMImagePlugin(unittest.TestCase):
                         self.assertEqual(self.expected_images[index][key], image[key],
                                          "Found image is different from the expected one")
 
-    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 2,
-                     "Skipping test that take a long time to run, are "
-                     "resource intensive or time sensitve")
+    @skipOnLevelsInferiorThan(2)
     @unittest.skipIf(missing_binary('qemu-img'),
                      "QEMU disk image utility is required by the vmimage utility ")
     def test_download_image(self):

--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -10,7 +10,7 @@ from avocado.utils import script
 from avocado.utils import process
 from avocado.utils import path
 
-from .. import setup_avocado_loggers
+from .. import setup_avocado_loggers, skipOnLevelsInferiorThan
 
 
 setup_avocado_loggers()
@@ -290,9 +290,7 @@ class TestProcessRun(unittest.TestCase):
         self.assertEqual(result.stdout, encoded_text)
         self.assertEqual(result.stdout_text, text)
 
-    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 1)) < 2,
-                     "Skipping test that take a long time to run, are "
-                     "resource intensive or time sensitve")
+    @skipOnLevelsInferiorThan(2)
     def test_run_with_timeout_ugly_cmd(self):
         with script.TemporaryScript("refuse_to_die", REFUSE_TO_DIE) as exe:
             cmd = "%s '%s'" % (sys.executable, exe.path)
@@ -305,9 +303,7 @@ class TestProcessRun(unittest.TestCase):
                                 "reporting failure but should be killed.\n%s"
                                 % res)
 
-    @unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < 2,
-                     "Skipping test that take a long time to run, are "
-                     "resource intensive or time sensitve")
+    @skipOnLevelsInferiorThan(2)
     def test_run_with_negative_timeout_ugly_cmd(self):
         with script.TemporaryScript("refuse_to_die", REFUSE_TO_DIE) as exe:
             cmd = "%s '%s'" % (sys.executable, exe.path)


### PR DESCRIPTION
That will consolidate the same message and checks at a common
location.

Signed-off-by: Cleber Rosa <crosa@redhat.com>