### PR TITLE
avocado.utils.cpu: fix bytes/string issue with cpu_has_flags

### DIFF
--- a/avocado/utils/cpu.py
+++ b/avocado/utils/cpu.py
@@ -80,7 +80,7 @@ def cpu_has_flags(flags):
     Check if a list of flags are available on current CPU info
 
     :param flags: A `list` of cpu flags that must exists on the current CPU.
-    :type flags: `list`
+    :type flags: `list` of str
     :returns: `bool` True if all the flags were found or False if not
     :rtype: `list`
     """
@@ -90,7 +90,7 @@ def cpu_has_flags(flags):
         flags = [flags]
 
     for flag in flags:
-        if not _list_matches(cpu_info, '.*%s.*' % flag):
+        if not any([flag.encode() in line for line in cpu_info]):
             return False
     return True
 

--- a/selftests/unit/test_utils_cpu.py
+++ b/selftests/unit/test_utils_cpu.py
@@ -49,6 +49,15 @@ class Cpu(Test):
                                  return_value=self._get_data_mock('x86_64')):
             self.assertEqual(cpu.get_arch(), "x86_64")
 
+    def test_cpu_has_flags(self):
+        with unittest.mock.patch('builtins.open',
+                                 return_value=self._get_data_mock('x86_64')):
+            self.assertTrue(cpu.cpu_has_flags('flexpriority'))
+            self.assertTrue(cpu.cpu_has_flags(['sse4_2', 'xsaveopt']))
+            self.assertFalse(cpu.cpu_has_flags('THIS_WILL_NEVER_BE_A_FLAG_NAME'))
+            self.assertFalse(cpu.cpu_has_flags(['THIS_WILL_NEVER_BE_A_FLAG_NAME',
+                                                'NEITHER_WILL_THIS_WILL_EVER_BE']))
+
     def test_cpu_arch_power8(self):
         with unittest.mock.patch('builtins.open',
                                  return_value=self._get_data_mock('power8')):


### PR DESCRIPTION
This fixes an attempt to use a string regex with bytes coming
from the /proc/cpuinfo file.  Before this:

   >>> cpu.cpu_has_flags('PowerNv')
   Traceback (most recent call last):
     File "<stdin>", line 1, in <module>
     File "/root/tests/avocado/avocado/utils/cpu.py", line 93, in cpu_has_flags
       if not _list_matches(cpu_info, '.*%s.*' % flag):
     File "/root/tests/avocado/avocado/utils/cpu.py", line 41, in _list_matches
       match = re.search(pattern, content)
     File "/usr/lib64/python3.6/re.py", line 182, in search
       return _compile(pattern, flags).search(string)
   TypeError: cannot use a string pattern on a bytes-like object
   >>>

Becase the regex being built is simply a presence check, we can skip
the regex and do just that, a presence check after decoding the
flag string into bytes.

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>
Signed-off-by: Cleber Rosa <crosa@redhat.com>