### PR TITLE
Remote/VM/Docker runners: deprecate them

### DIFF
--- a/optional_plugins/runner_docker/avocado_runner_docker/__init__.py
+++ b/optional_plugins/runner_docker/avocado_runner_docker/__init__.py
@@ -17,6 +17,7 @@ import logging
 import os
 import socket
 import time
+import warnings
 
 import aexpect
 
@@ -116,7 +117,7 @@ class DockerTestRunner(RemoteTestRunner):
     """
 
     name = 'docker'
-    description = 'Runs on a Docker (or compatible) container'
+    description = '*DEPRECATED* Runs on a Docker (or compatible) container'
 
     def __init__(self):
         super(DockerTestRunner, self).__init__()
@@ -153,7 +154,7 @@ class DockerCLI(CLI):
     """
 
     name = 'docker'
-    description = "Run tests inside docker container"
+    description = "*DEPRECATED* Run tests inside docker container"
 
     def configure(self, parser):
         run_subcommand_parser = parser.subcommands.choices.get('run', None)
@@ -177,4 +178,6 @@ class DockerCLI(CLI):
 
     def run(self, config):
         if config.get("docker", None):
+            warnings.warn("The docker runner plugin is deprecated, and will "
+                          "be removed soon", FutureWarning)
             config['test_runner'] = 'docker'

--- a/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
+++ b/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
@@ -20,6 +20,7 @@ import os
 import re
 import sys
 import time
+import warnings
 
 import fabric.api
 import fabric.network
@@ -329,7 +330,7 @@ class RemoteTestRunner(Runner):
     """
 
     name = 'remote'
-    description = 'Runs on a remote machine using SSH'
+    description = '*DEPRECATED* Runs on a remote machine using SSH'
 
     # Let's use re.MULTILINE because sometimes servers might have MOTD
     # that will introduce a line break on output.
@@ -607,7 +608,7 @@ class RemoteCLI(CLI):
     """
 
     name = 'remote'
-    description = "Remote machine options for 'run' subcommand"
+    description = "*DEPRECATED* Remote machine options for 'run' subcommand"
 
     def configure(self, parser):
         run_subcommand_parser = parser.subcommands.choices.get('run', None)
@@ -682,6 +683,8 @@ class RemoteCLI(CLI):
     def run(self, config):
         if self._check_required_config(config, 'remote_hostname',
                                        ('remote_hostname',)):
+            warnings.warn("The remote runner plugin is deprecated, and will "
+                          "be removed soon", FutureWarning)
             loader.loader.clear_plugins()
             loader.loader.register_plugin(DummyLoader)
             config['test_runner'] = 'remote'

--- a/optional_plugins/runner_vm/avocado_runner_vm/__init__.py
+++ b/optional_plugins/runner_vm/avocado_runner_vm/__init__.py
@@ -17,6 +17,7 @@ import getpass
 import logging
 import sys
 import time
+import warnings
 from xml.dom import minidom
 
 import libvirt
@@ -366,7 +367,7 @@ class VMTestRunner(RemoteTestRunner):
     """
 
     name = 'vm'
-    description = 'Runs on a VM using SSH'
+    description = '*DEPRECATED* Runs on a VM using SSH'
 
     def __init__(self):
         super(VMTestRunner, self).__init__()
@@ -433,7 +434,7 @@ class VMCLI(CLI):
     """
 
     name = 'vm'
-    description = "Virtual Machine options for 'run' subcommand"
+    description = "*DEPRECATED* Virtual Machine options for 'run' subcommand"
 
     def configure(self, parser):
         run_subcommand_parser = parser.subcommands.choices.get('run', None)
@@ -503,4 +504,6 @@ class VMCLI(CLI):
 
     def run(self, config):
         if self._check_required_config(config, 'vm_domain', ('vm_domain',)):
+            warnings.warn("The vm runner plugin is deprecated, and will "
+                          "be removed soon", FutureWarning)
             config['test_runner'] = 'vm'


### PR DESCRIPTION
The remote, vm and docker runner plugins (the ones that allows users
to run a job on those environments), all depend on the Fabric3, which
in turn depends on many other Python modules.  Fabric3 is dead with
the Python 3 compatible releases of fabric, but it requires an API
overhaul, very close to rewriting those plugins.

Maintaining those plugins is proving increasingly hard due to version
mismatch failures and bitrot, and the migration effort, given the
current plans of the Avocado project, is not really worth it.  With
the N(ext)Runner architecture, the goal is for *individual* tests to
be able to be executed in remote environments, so some of the
functionality may be brought back in the future, but under a very
different implementation, which may include even different
dependencies.

Reference: https://github.com/avocado-framework/avocado/issues/3799
Signed-off-by: Cleber Rosa <crosa@redhat.com>