### PR TITLE
avocado/utils/disk.py: Enhance get_disks

### DIFF
--- a/avocado/utils/disk.py
+++ b/avocado/utils/disk.py
@@ -53,9 +53,9 @@ def get_disks():
     :returns: a list of paths to the physical disks on the system
     :rtype: list of str
     """
-    json_result = process.run('lsblk --json')
+    json_result = process.run('lsblk --json --paths --inverse')
     json_data = json.loads(json_result.stdout_text)
-    return ['/dev/%s' % str(disk['name']) for disk in json_data['blockdevices']]
+    return [str(disk['name']) for disk in json_data['blockdevices']]
 
 
 def get_available_filesystems():


### PR DESCRIPTION
Fixed get_disks to return all block devices, like multipaths,
LVs, etc. Previously we used to get only /dev/sdX devices.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>
Reported-by: Naresh Bannoth <nbannoth@in.ibm.com>