### PR TITLE
Makefile: update Fedora rawhide version

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -1,4 +1,4 @@
-ifneq "" "$(findstring fedora-32-,$(MOCK_CONFIG))$(findstring fedora-rawhide-,$(MOCK_CONFIG))"
+ifneq "" "$(findstring fedora-33-,$(MOCK_CONFIG))$(findstring fedora-rawhide-,$(MOCK_CONFIG))"
     modenable := avocado:latest
     modrepos  := --enablerepo=rawhide-modular
 else ifneq "" "$(findstring fedora-30-,$(MOCK_CONFIG))$(findstring fedora-31-,$(MOCK_CONFIG))"


### PR DESCRIPTION
Fedora 32 is no longer rawhide, but Fedora 33 is.  This fixes the
result of a "make MOCK_CONFIG=fedora-33-x86_64 rpm" command.

Signed-off-by: Cleber Rosa <crosa@redhat.com>