### PR TITLE
Refactor base runner app

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -889,7 +889,7 @@ class BaseRunnerApp:
 
         :rtype: dict
         """
-        return {"runnables": [k for k in self.RUNNABLE_KINDS_CAPABLE.keys()],
+        return {"runnables": list(self.RUNNABLE_KINDS_CAPABLE.keys()),
                 "commands": self.get_commands()}
 
     def get_runner_from_runnable(self, runnable):


### PR DESCRIPTION
This is a small refactor to make the list of commands available as a class attribute avoiding multiple resolutions and string manipulation when a command needs to be resolved.

Also, it changes a list comprehension by a list casting as it is faster.

Signed-off-by: Willian Rampazzo <willianr@redhat.com>

Ps. this is related to my path to a full review and learning on the Avocado Nrunner architecture. If the code does not make sense, feel free to just close this PR.

