### PR TITLE
RPM Packages: don't build deprecated runners and drop mentions of "official" repos

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -1,25 +1,3 @@
-ifneq "" "$(findstring fedora-33-,$(MOCK_CONFIG))$(findstring fedora-rawhide-,$(MOCK_CONFIG))"
-    modenable := avocado:latest
-    modrepos  := --enablerepo=rawhide-modular
-else ifneq "" "$(findstring fedora-30-,$(MOCK_CONFIG))$(findstring fedora-31-,$(MOCK_CONFIG))"
-    modenable := avocado:69lts
-    modrepos  := --enablerepo=fedora-modular
-else ifneq "" "$(findstring fedora-29-,$(MOCK_CONFIG))"
-    modenable := avocado:stable
-    modrepos  := --enablerepo=fedora-modular
-else
-    modenable :=
-endif
-modpkgs := python3-aexpect
-
-mock-setup:
-	mock -r $(MOCK_CONFIG) --init
-ifneq "" "$(modenable)"
-	mock -r $(MOCK_CONFIG) $(modrepos) --dnf-cmd module enable $(modenable)
-	mock -r $(MOCK_CONFIG) $(modrepos) --dnf-cmd install $(modpkgs)
-	mock -r $(MOCK_CONFIG) $(modrepos) --dnf-cmd module disable $(firstword $(subst :, ,$(modenable)))
-endif
-
 source: clean
 	if test ! -d SOURCES; then mkdir SOURCES; fi
 	git archive --prefix="$(ARCHIVE_BASE_NAME)-$(COMMIT)/" -o "SOURCES/$(ARCHIVE_BASE_NAME)-$(SHORT_COMMIT).tar.gz" HEAD
@@ -35,7 +13,7 @@ srpm: source
 	if test ! -d BUILD/SRPM; then mkdir -p BUILD/SRPM; fi
 	mock -r $(MOCK_CONFIG) --resultdir BUILD/SRPM -D "rel_build 0" -D "commit $(COMMIT)" -D "commit_date $(COMMIT_DATE)" --buildsrpm --spec $(RPM_BASE_NAME).spec --sources SOURCES
 
-rpm: srpm mock-setup
+rpm: srpm
 	if test ! -d BUILD/RPM; then mkdir -p BUILD/RPM; fi
 	mock -r $(MOCK_CONFIG) --no-clean --resultdir BUILD/RPM -D "rel_build 0" -D "commit $(COMMIT)" -D "commit_date $(COMMIT_DATE)" --rebuild BUILD/SRPM/$(RPM_BASE_NAME)-$(VERSION)-*.src.rpm
 
@@ -43,7 +21,7 @@ srpm-release: source-release
 	if test ! -d BUILD/SRPM; then mkdir -p BUILD/SRPM; fi
 	mock -r $(MOCK_CONFIG) --resultdir BUILD/SRPM -D "rel_build 1" --buildsrpm --spec $(RPM_BASE_NAME).spec --sources SOURCES
 
-rpm-release: srpm-release mock-setup
+rpm-release: srpm-release
 	if test ! -d BUILD/RPM; then mkdir -p BUILD/RPM; fi
 	mock -r $(MOCK_CONFIG) --no-clean --resultdir BUILD/RPM -D "rel_build 1" --rebuild BUILD/SRPM/$(RPM_BASE_NAME)-$(VERSION)-*.src.rpm
 

--- a/docs/source/guides/user/chapters/installing.rst
+++ b/docs/source/guides/user/chapters/installing.rst
@@ -47,42 +47,19 @@ Installing from packages
 Fedora
 ~~~~~~
 
-Avocado is available in stock Fedora 24 and later.  The main package name is
-``python-avocado``, and can be installed with::
+Avocado modules are available on standard Fedora repos starting with
+version 29.  To subscribe to the latest version stream, run::
 
-    $ dnf install python-avocado
+  $ dnf module enable avocado:latest
 
-.. _fedora-from-avocados-own-repo:
+Or, to use the LTS (Long Term Stability) version stream, run::
 
-Fedora from Avocado's own Repo
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  $ dnf module enable avocado:69lts
 
-The Avocado project also makes the latest release, and the LTS (Long Term
-Stability) releases available from its own package repository.  To use it,
-first get the package repositories configuration file by running the following
-command::
+Then proceed to install a module profile or individual packages.  If you're
+unsure about what to do, simply run::
 
-    $ sudo curl https://avocado-project.org/data/repos/avocado-fedora.repo -o /etc/yum.repos.d/avocado.repo
-
-Now check if you have the ``avocado`` and ``avocado-lts`` repositories
-configured by running::
-
-    $ sudo dnf repolist avocado avocado-lts
-    ...
-    repo id      repo name                          status
-    avocado      Avocado                            50
-    avocado-lts  Avocado LTS (Long Term Stability)  disabled
-
-Regular users of Avocado will want to use the standard ``avocado`` repository,
-which tracks the latest Avocado releases.  For more information about the LTS
-releases, please refer to :ref:`rfc-long-term-stability`  and to your package
-management docs on how to switch to the ``avocado-lts`` repo.
-
-Finally, after deciding between regular Avocado releases or LTS, you can
-install the RPM packages by running the following commands::
-
-    $ dnf install python-avocado
-
+  $ dnf module install avocado
 
 Enterprise Linux
 ~~~~~~~~~~~~~~~~

--- a/docs/source/guides/user/chapters/installing.rst
+++ b/docs/source/guides/user/chapters/installing.rst
@@ -64,22 +64,18 @@ unsure about what to do, simply run::
 Enterprise Linux
 ~~~~~~~~~~~~~~~~
 
-Avocado packages for Enterprise Linux are available from the Avocado project
-RPM repository.  Additionally, some packages from the EPEL repo are necessary,
-so you need to enable it first.  For EL7, running the following command should
-do it::
+Avocado modules are also available on EPEL (Extra Packages for Enterprise Linux)
+repos, starting with version 8.  To enable the EPEL repository, run::
 
-    $ yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+  $ dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 
-Then you must use the Avocado project RHEL repository_.  Running the following
-command should give you the basic Avocado installation ready::
+Then to enable the module, run::
 
-    $ curl https://avocado-project.org/data/repos/avocado-el.repo -o /etc/yum.repos.d/avocado.repo
-    $ yum install python-avocado
+  $ dnf module enable avocado:latest
 
-The LTS (Long Term Stability) repositories are also available for Enterprise
-Linux.  Please refer to :ref:`rfc-long-term-stability` and to your package
-management docs on how to switch to the ``avocado-lts`` repo.
+And finally, install any number of packages, such as::
+
+  $ dnf install python3-avocado python3-avocado-plugins-output-html python3-avocado-plugins-varianter-yaml-to-mux
 
 Latest Development RPM Packages from COPR
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -129,6 +125,5 @@ Then to install Avocado from the git repository run::
     $ sudo make requirements
     $ sudo python3 setup.py install
 
-.. _repository: https://avocado-project.org/data/repos/avocado-el.repo
 .. _OpenSUSE: https://build.opensuse.org/package/show/Virtualization:Tests/avocado
 .. _Avocado-VT: https://avocado-vt.readthedocs.io/en/latest/GetStartedGuide.html#installing-avocado-vt

--- a/docs/source/guides/user/chapters/installing.rst
+++ b/docs/source/guides/user/chapters/installing.rst
@@ -80,9 +80,10 @@ And finally, install any number of packages, such as::
 Latest Development RPM Packages from COPR
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Avocado provides a repository of continuously built packages from the GitHub
-repository's master branch.  These packages are currently available for EL7,
-Fedora 28 and Fedora 29, for both x86_64 and ppc64le.
+Avocado provides a repository of continuously built packages from the
+GitHub repository's master branch.  These packages are currently
+available for some of the latest Enterprise Linux and Fedora versions,
+for a few different architectures.
 
 If you're interested in using the very latest development version of Avocado
 from RPM packages, you can do so by running::

--- a/examples/testplans/release/release.json
+++ b/examples/testplans/release/release.json
@@ -40,6 +40,10 @@
          "description": "Visit the link below:\n\nhttps://readthedocs.org/dashboard/avocado-framework/edit/\n\n 1) Click in *Versions*. In *Choose Active Versions*, find the version you're releasing and check the *Active* option. *Submit*;\n 2) Click in *Versions* again. In *Default Version*, select the new version you're releasing. *Submit*."
 	 },
          {
+	 "name": "Update the Fedora and EPEL RPM packages and module",
+         "description": "Follow the instructions on:\n\nhttps://github.com/mmathesius/howtos/blob/master/how_to_refresh_avocado_module_for_new_upstream_release.rst\n\nand work with the package maintainer by sending a PR to update the Avocado version on the `avocado:latest` stream."
+	 },
+         {
 	 "name": "Send e-emails",
          "description": "Send the e-email with the release notes to avocado-devel and virt-test-devel."
 	 }

--- a/examples/testplans/release/release.json
+++ b/examples/testplans/release/release.json
@@ -20,6 +20,10 @@
          "description": "Commit the version bump, python-avocado.spec and release notes. Don't forget to commit the changes of 'linked' plugins as they live in different repositories."
 	 },
          {
+	 "name": "Version Bump: Tag the repository",
+         "description": "Tagging the repository locally (but not pushing it yet), will let you do a `make rpm-release` in the next step. Run `git tag -u $(GPG_ID) -s $(RELEASE) -m 'Release $(RELEASE)'`"
+	 },
+         {
 	 "name": "Build RPMs",
          "description": "Go to the source directory and do:\n\n`make rpm-release && echo $?`\n\nThis should be all. It will build packages using mock, targeting your default configuration. That usually means the same platform you’re currently on."
 	 },
@@ -30,10 +34,6 @@
          {
 	 "name": "Upload packages to repository: Create the metadata",
          "description": "The current distribution method is based on serving content over HTTP. That means that repository metadata is created locally and synchronized to the well know public Web server. Create the repo metadata with the command:\n\n`cd $REPO_ROOT && for DIR in epel-?-noarch fedora-??-noarch; do cd $DIR && createrepo -v . && cd ..; done;`"
-	 },
-         {
-	 "name": "Version Bump: Tag the repository",
-         "description": "When everything is in good shape, commit the version changes and tag that commit in master with:\n\n`git tag -u $(GPG_ID) -s $(RELEASE) -m 'Avocado Release $(RELEASE)'`"
 	 },
          {
 	 "name": "Version Bump: Push the tag",

--- a/examples/testplans/release/release.json
+++ b/examples/testplans/release/release.json
@@ -28,20 +28,8 @@
          "description": "Go to the source directory and do:\n\n`make rpm-release && echo $?`\n\nThis should be all. It will build packages using mock, targeting your default configuration. That usually means the same platform you’re currently on. Also make sure it builds on other supported distros, by setting the MOCK_CONFIG variable to values such as `epel-8-x86_64`."
 	 },
          {
-	 "name": "Sign Packages",
-         "description": "All the packages should be signed for safer public consumption. The process is, of course, dependent on the private keys, put is based on running:\n\nrpm --resign"
-	 },
-         {
-	 "name": "Upload packages to repository: Create the metadata",
-         "description": "The current distribution method is based on serving content over HTTP. That means that repository metadata is created locally and synchronized to the well know public Web server. Create the repo metadata with the command:\n\n`cd $REPO_ROOT && for DIR in epel-?-noarch fedora-??-noarch; do cd $DIR && createrepo -v . && cd ..; done;`"
-	 },
-         {
 	 "name": "Version Bump: Push the tag",
          "description": "The tag should be pushed to the GIT repository with:\n\n`git push --tags`"
-	 },
-         {
-	 "name": "Upload packages to repository: Copy the content",
-         "description": "Copy the content with the command:\n\n`rsync -va $REPO_ROOT user@repo_web_server:/path`"
 	 },
          {
 	 "name": "Upload package to PyPI",

--- a/examples/testplans/release/release.json
+++ b/examples/testplans/release/release.json
@@ -12,12 +12,12 @@
          "description": "Run the command: `make propagate-version` to propagate this change to all optional and “linkabe” plugins sharing the parent dir (eg. avocado-vt)."
 	 },
          {
-	 "name": "Version Bump: Commit the bump",
-         "description": "Commit the version bump. Don't forget to commit the changes of 'linked' plugins as they live in different repositories."
+	 "name": "Write the release notes",
+         "description": "Under `docs/source/releases/` create a new .rst file describing the release changes. Also, update the `docs/source/releases/index.rst` file.  Look at the sprint issues and PRs on GitHub, specially the ones with the `comment-on-sprint-review` label."
 	 },
          {
-	 "name": "Changelog: Create a Changelog",
-         "description": "Under `docs/source/releases/` create a new .rst file describing the release changes. Also, update the `docs/source/releases/index.rst` file"
+	 "name": "Version Bump: Commit the bump",
+         "description": "Commit the version bump, python-avocado.spec and release notes. Don't forget to commit the changes of 'linked' plugins as they live in different repositories."
 	 },
          {
 	 "name": "Build RPMs",
@@ -42,10 +42,6 @@
          {
 	 "name": "Upload packages to repository: Copy the content",
          "description": "Copy the content with the command:\n\n`rsync -va $REPO_ROOT user@repo_web_server:/path`"
-	 },
-         {
-	 "name": "Write release notes",
-         "description": "Release notes give an idea of what has changed on a given development cycle. Good places to go for release notes are: 1) git logs; 2) Trello cards (look for the done list); 3) Github compare views.\n\nGo there and try to write a text that represents the changes that the release encompasses."
 	 },
          {
 	 "name": "Upload package to PyPI",

--- a/examples/testplans/release/release.json
+++ b/examples/testplans/release/release.json
@@ -25,7 +25,7 @@
 	 },
          {
 	 "name": "Build RPMs",
-         "description": "Go to the source directory and do:\n\n`make rpm-release && echo $?`\n\nThis should be all. It will build packages using mock, targeting your default configuration. That usually means the same platform you’re currently on."
+         "description": "Go to the source directory and do:\n\n`make rpm-release && echo $?`\n\nThis should be all. It will build packages using mock, targeting your default configuration. That usually means the same platform you’re currently on. Also make sure it builds on other supported distros, by setting the MOCK_CONFIG variable to values such as `epel-8-x86_64`."
 	 },
          {
 	 "name": "Sign Packages",

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -26,31 +26,6 @@
 # enabled by default.
 %global with_tests 1
 
-# Avocado is currently incompatible with the Fabric API in Fedora 31 and later
-# https://github.com/avocado-framework/avocado/issues/3125
-%if 0%{?fedora} >= 31
-%global with_fabric 0
-%else
-%global with_fabric 1
-%endif
-
-# Python 3 version of Fabric package is new starting with Fedora 29
-%if 0%{?fedora} >= 29
-%global with_python3_fabric 1
-%else
-%global with_python3_fabric 0
-%endif
-
-# Python 3 version of aexpect is available on a module on Fedora >= 30
-# and package build dependency resolution seems to be currently broken
-# for modules.  Other developers have reported similar scenarios as this:
-# https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/V6SBSAS5TBGNORGLYW75TIRX6JDBXQ2Q/
-%if 0%{?fedora} >= 30 || 0%{?rhel}
-%global with_python3_aexpect 0
-%else
-%global with_python3_aexpect 1
-%endif
-
 # The Python dependencies are already tracked by the python2
 # or python3 "Requires".  This filters out the python binaries
 # from the RPM automatic requires/provides scanner.
@@ -59,7 +34,7 @@
 Summary: Framework with tools and libraries for Automated Testing
 Name: python-%{srcname}
 Version: 79.0
-Release: 0%{?gitrel}%{?dist}
+Release: 1%{?gitrel}%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.github.io/
@@ -71,19 +46,9 @@ Source0: https://github.com/avocado-framework/%{srcname}/archive/%{commit}.tar.g
 BuildArch: noarch
 BuildRequires: procps-ng
 BuildRequires: kmod
-%if %{with_fabric}
-%if %{with_python3_fabric}
-BuildRequires: python3-fabric3
-%endif
-%endif
-# with_fabric
 %if 0%{?fedora} >= 30
 BuildRequires: glibc-all-langpacks
 %endif
-%if %{with_python3_aexpect}
-BuildRequires: python3-aexpect
-%endif
-
 BuildRequires: python3-jinja2
 BuildRequires: python3-devel
 BuildRequires: python3-docutils
@@ -146,33 +111,6 @@ sed -e "s/'PyYAML>=4.2b2'/'PyYAML>=3.12'/" -i optional_plugins/varianter_yaml_to
 pushd optional_plugins/html
 %py3_build
 popd
-pushd optional_plugins/runner_remote
-%if %{with_fabric}
-%if %{with_python3_fabric}
-%py3_build
-%endif
-%endif
-# with_fabric
-popd
-pushd optional_plugins/runner_vm
-%if %{with_fabric}
-%if %{with_python3_fabric}
-%py3_build
-%endif
-%endif
-# with_fabric
-popd
-pushd optional_plugins/runner_docker
-%if %{with_python3_aexpect}
-%if %{with_fabric}
-%if %{with_python3_fabric}
-%py3_build
-%endif
-%endif
-# with_fabric
-%endif
-# with_python3_aexpect
-popd
 %if ! 0%{?rhel}
 pushd optional_plugins/resultsdb
 %py3_build
@@ -212,33 +150,6 @@ popd
 %{__sed} -e 's/ etc\/avocado\/sysinfo\// \/etc\/avocado\/sysinfo\//' -i %{buildroot}/etc/avocado/avocado.conf
 pushd optional_plugins/html
 %py3_install
-popd
-pushd optional_plugins/runner_remote
-%if %{with_fabric}
-%if %{with_python3_fabric}
-%py3_install
-%endif
-%endif
-# with_fabric
-popd
-pushd optional_plugins/runner_vm
-%if %{with_fabric}
-%if %{with_python3_fabric}
-%py3_install
-%endif
-%endif
-# with_fabric
-popd
-pushd optional_plugins/runner_docker
-%if %{with_python3_aexpect}
-%if %{with_fabric}
-%if %{with_python3_fabric}
-%py3_install
-%endif
-%endif
-# with_fabric
-%endif
-# with_python3_aexpect
 popd
 %if ! 0%{?rhel}
 pushd optional_plugins/resultsdb
@@ -288,24 +199,6 @@ find %{buildroot}%{_docdir}/avocado -type f -name '*.py' -exec %{__chmod} -c -x 
 pushd optional_plugins/html
 %{__python3} setup.py develop --user
 popd
-%if %{with_fabric}
-%if %{with_python3_fabric}
-pushd optional_plugins/runner_remote
-%{__python3} setup.py develop --user
-popd
-pushd optional_plugins/runner_vm
-%{__python3} setup.py develop --user
-popd
-pushd optional_plugins/runner_docker
-%if %{with_python3_aexpect}
-%{__python3} setup.py develop --user
-%endif
-# with_python3_aexpect
-popd
-%endif
-# with_python3_fabric
-%endif
-# with_fabric
 %if ! 0%{?rhel}
 pushd optional_plugins/resultsdb
 %{__python3} setup.py develop --user
@@ -358,9 +251,6 @@ PATH=$HOME/.local/bin:$PATH LANG=en_US.UTF-8 AVOCADO_CHECK_LEVEL=0 UNITTEST_AVOC
 %{_bindir}/avocado-software-manager
 %{python3_sitelib}/avocado*
 %exclude %{python3_sitelib}/avocado_result_html*
-%exclude %{python3_sitelib}/avocado_runner_remote*
-%exclude %{python3_sitelib}/avocado_runner_vm*
-%exclude %{python3_sitelib}/avocado_runner_docker*
 %exclude %{python3_sitelib}/avocado_resultsdb*
 %exclude %{python3_sitelib}/avocado_loader_yaml*
 %exclude %{python3_sitelib}/avocado_golang*
@@ -370,9 +260,6 @@ PATH=$HOME/.local/bin:$PATH LANG=en_US.UTF-8 AVOCADO_CHECK_LEVEL=0 UNITTEST_AVOC
 %exclude %{python3_sitelib}/avocado_result_upload*
 %exclude %{python3_sitelib}/avocado_glib*
 %exclude %{python3_sitelib}/avocado_framework_plugin_result_html*
-%exclude %{python3_sitelib}/avocado_framework_plugin_runner_remote*
-%exclude %{python3_sitelib}/avocado_framework_plugin_runner_vm*
-%exclude %{python3_sitelib}/avocado_framework_plugin_runner_docker*
 %exclude %{python3_sitelib}/avocado_framework_plugin_resultsdb*
 %exclude %{python3_sitelib}/avocado_framework_plugin_varianter_yaml_to_mux*
 %exclude %{python3_sitelib}/avocado_framework_plugin_varianter_pict*
@@ -421,70 +308,6 @@ arbitrary filesystem location.
 %files -n python3-%{srcname}-plugins-output-html
 %{python3_sitelib}/avocado_result_html*
 %{python3_sitelib}/avocado_framework_plugin_result_html*
-
-%if %{with_fabric}
-%if %{with_python3_fabric}
-%package -n python3-%{srcname}-plugins-runner-remote
-Summary: Avocado Runner for Remote Execution
-Requires: python3-%{srcname} == %{version}
-Requires: python3-fabric3
-
-%description -n python3-%{srcname}-plugins-runner-remote
-Allows Avocado to run jobs on a remote machine, by means of an SSH
-connection.  Avocado must be previously installed on the remote machine.
-
-%files -n python3-%{srcname}-plugins-runner-remote
-%{python3_sitelib}/avocado_runner_remote*
-%{python3_sitelib}/avocado_framework_plugin_runner_remote*
-%endif
-# with_python3_fabric
-%endif
-# with_fabric
-
-%if %{with_fabric}
-%if %{with_python3_fabric}
-%package -n python3-%{srcname}-plugins-runner-vm
-Summary: Avocado Runner for libvirt VM Execution
-Requires: python3-%{srcname} == %{version}
-Requires: python3-%{srcname}-plugins-runner-remote == %{version}
-Requires: python3-libvirt
-
-%description -n python3-%{srcname}-plugins-runner-vm
-Allows Avocado to run jobs on a libvirt based VM, by means of
-interaction with a libvirt daemon and an SSH connection to the VM
-itself.  Avocado must be previously installed on the VM.
-
-%files -n python3-%{srcname}-plugins-runner-vm
-%{python3_sitelib}/avocado_runner_vm*
-%{python3_sitelib}/avocado_framework_plugin_runner_vm*
-%endif
-# with_python3_fabric
-%endif
-# with_fabric
-
-%if %{with_python3_aexpect}
-%if %{with_fabric}
-%if %{with_python3_fabric}
-%package -n python3-%{srcname}-plugins-runner-docker
-Summary: Avocado Runner for Execution on Docker Containers
-Requires: python3-%{srcname} == %{version}
-Requires: python3-%{srcname}-plugins-runner-remote == %{version}
-Requires: python3-aexpect
-
-%description -n python3-%{srcname}-plugins-runner-docker
-Allows Avocado to run jobs on a Docker container by interacting with a
-Docker daemon and attaching to the container itself.  Avocado must
-be previously installed on the container.
-
-%files -n python3-%{srcname}-plugins-runner-docker
-%{python3_sitelib}/avocado_runner_docker*
-%{python3_sitelib}/avocado_framework_plugin_runner_docker*
-%endif
-# with_python3_fabric
-%endif
-# with_fabric
-%endif
-# with_python3_aexpect
 
 %if ! 0%{?rhel}
 %package -n python3-%{srcname}-plugins-resultsdb
@@ -623,6 +446,9 @@ Again Shell code (and possibly other similar shells).
 %{_libexecdir}/avocado*
 
 %changelog
+* Tue May 12 2020 Cleber Rosa <cleber@redhat.com> - 79.0-1
+- Do not build deprecated runners
+
 * Mon May 11 2020 Cleber Rosa <cleber@redhat.com> - 79.0-0
 - New release
 - Added current user's ~/local/.bin to the PATH environment variable


### PR DESCRIPTION
We want to minimize our maintenance effort and avoid duplication, so let's stop building the deprecated plugins ASAP, and let's point users towards the distro repos, so that we can in the near future remove both the runners and Avocado's own repo.

This is related to https://github.com/avocado-framework/avocado/issues/3519