### PR TITLE
sysinfo: fix location of implicit directory creation

### DIFF
--- a/avocado/plugins/sysinfo.py
+++ b/avocado/plugins/sysinfo.py
@@ -67,10 +67,13 @@ class SysInfo(CLICmd):
         """
         parser = super(SysInfo, self).configure(parser)
 
-        help_msg = 'Directory where Avocado will dump sysinfo data.'
+        help_msg = ('Directory where Avocado will dump sysinfo data.  If one '
+                    'is not given explicitly, it will default to a directory '
+                    'named "sysinfo-" followed by a timestamp in the current '
+                    'working directory.')
         settings.register_option(section='sysinfo.collect',
                                  key='sysinfodir',
-                                 default='./',
+                                 default=None,
                                  help_msg=help_msg,
                                  parser=parser,
                                  positional_arg=True,


### PR DESCRIPTION
When running the `avocado sysinfo` command, because of the current
"./" default, the logic that creates the custom "sysinfo-$timestamp"
directory is skipped, and the pre/post/profile directories are created
within the current working directory.  This is not the originally
intended behavior.

With this new default, users should have the previous experience again
(and a clearer expectation with the more verbose help message).

Signed-off-by: Cleber Rosa <crosa@redhat.com>