### PR TITLE
Job: allow the selection of the test runner by command line

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -548,7 +548,7 @@ class Job:
         refs = self.config.get('run.references')
         if not refs:
             refs = self.config.get('nrun.references')
-        runner_name = self.config.get('test_runner', 'runner')
+        runner_name = self.config.get('run.test_runner', 'runner')
         try:
             if runner_name == 'nrunner':
                 self.test_suite = self._make_test_suite_resolver(refs)
@@ -595,7 +595,7 @@ class Job:
                 raise exceptions.OptionValidationError("Unable to parse "
                                                        "variant: %s" % details)
 
-        runner_name = self.config.get('test_runner', 'runner')
+        runner_name = self.config.get('run.test_runner', 'runner')
         try:
             runner_extension = dispatcher.RunnerDispatcher()[runner_name]
         except KeyError:

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -87,6 +87,19 @@ class Run(CLICmd):
                                  long_arg='--test-parameter',
                                  short_arg='-p')
 
+        help_msg = ('Selects the runner implementation from one of the '
+                    'installed and active implementations.  You can run '
+                    '"avocado plugins" and find the list of valid runners '
+                    'under the "Plugins that run test suites on a job '
+                    '(runners) section.  Defaults to "runner", which is '
+                    'the conventional and traditional runner.')
+        settings.register_option(section='run',
+                                 key='test_runner',
+                                 default='runner',
+                                 help_msg=help_msg,
+                                 parser=parser,
+                                 long_arg='--test-runner')
+
         help_msg = ('Instead of running the test only list them and log '
                     'their params.')
         settings.register_option(section='run.dry_run',

--- a/examples/jobs/nrunner.py
+++ b/examples/jobs/nrunner.py
@@ -4,7 +4,7 @@ import sys
 from avocado.core.job import Job
 
 config = {
-    'test_runner': 'nrunner',
+    'run.test_runner': 'nrunner',
     'run.references': [
         'selftests/unit/test_resolver.py',
         'selftests/functional/test_argument_parsing.py',

--- a/examples/jobs/podman.py
+++ b/examples/jobs/podman.py
@@ -4,7 +4,7 @@ import sys
 from avocado.core.job import Job
 
 config = {'run.references': ['/bin/true'],
-          'test_runner': 'docker',
+          'run.test_runner': 'docker',
           'docker': 'ldoktor/fedora-avocado',
           'docker_cmd': 'podman',
           'docker_options': '',

--- a/jobs/timesensitive.py
+++ b/jobs/timesensitive.py
@@ -9,7 +9,7 @@ from avocado.core.job import Job
 ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 CONFIG = {
-    'test_runner': 'nrunner',
+    'run.test_runner': 'nrunner',
     'nrun.references': [os.path.join(ROOT_DIR, 'selftests', 'unit'),
                         os.path.join(ROOT_DIR, 'selftests', 'functional')],
     'filter_by_tags': ['parallel:1'],

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -276,7 +276,7 @@ class JobTest(unittest.TestCase):
         config = {'run.results_dir': self.tmpdir.name,
                   'run.store_logging_stream': [],
                   'nrun.references': simple_tests_found,
-                  'test_runner': 'nrunner',
+                  'run.test_runner': 'nrunner',
                   'show': ['none']}
         self.job = job.Job(config)
         self.job.setup()


### PR DESCRIPTION
With the migration to the N(ext)Runner, it's handy to run one-off
avocado jobs on the command line, with the current runner and then
compare it with the nrunner implementation.  This command line switch
makes that possible, while fixing the current configuration key to
match the other configurations related to running tests to be
prefixed with "run.".

Signed-off-by: Cleber Rosa <crosa@redhat.com>