### PR TITLE
Check namespaces exists before command executes

### DIFF
--- a/avocado/utils/pmem.py
+++ b/avocado/utils/pmem.py
@@ -194,6 +194,9 @@ class PMem:
             args = '%s -r %s' % (args, region)
         if bus:
             args = '%s -b %s' % (args, bus)
+        if namespace == 'all':
+            if not self.run_ndctl_list('%s -N' % args.replace(namespace, '')):
+                return True
         if verbose:
             args = '%s -v' % args
 
@@ -297,6 +300,9 @@ class PMem:
         for option in list(args_dict.keys()):
             if option:
                 args += ' %s %s' % (args_dict[option], option)
+        if namespace == 'all':
+            if not self.run_ndctl_list('%s -N' % args.replace(namespace, '')):
+                return True
         if force:
             args += ' -f'
 


### PR DESCRIPTION
With recent changes to ndctl utility, the behaviour for changed for disabling/destroying namespaces with "all"

Before recent changes, it always iterates idle namespaces
```
$ ndctl disable-namespace all
disabled 2 namespaces
$ echo $?
0
```
Now it returns failure even if idle namespaces are found
```
$ ndctl disable-namespace all
error disabling namespaces: No such device or address
disabled 0 namespaces
$ echo $?
250
```
With this check, command executes only if active namespaces are available

Signed-off-by: Harish <harish@linux.ibm.com>