### PR TITLE
Nrunner: extend status server checks for user request to exit

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -696,7 +696,7 @@ class StatusServer:
                     return True
 
             message = await reader.readline()
-            if message == b'bye\n':
+            if b'bye'in message:
                 print('Status server: exiting due to user request')
                 self.server_task.cancel()
                 await self.server_task


### PR DESCRIPTION
While testing the status server using telnet, when a `bye` is sent, it is translated to `b'bye\r\n'`, making the status server crash and not exit.

Here we check if there is a `bye` in any place of the message, instead of strictly finding only it.

Signed-off-by: Willian Rampazzo <willianr@redhat.com>