### PR TITLE
Fix incorrect option key in result_upload optional plugin.

### DIFF
--- a/optional_plugins/result_upload/avocado_result_upload/__init__.py
+++ b/optional_plugins/result_upload/avocado_result_upload/__init__.py
@@ -88,7 +88,7 @@ class ResultUploadCLI(CLI):
 
         help_msg = 'Specify the command to upload results'
         settings.register_option(section='plugins.result_upload',
-                                 key='command',
+                                 key='cmd',
                                  help_msg=help_msg,
                                  default=def_upload_cmd,
                                  parser=parser,


### PR DESCRIPTION
The incorrect key caused the `--result-upload-cmd` option to be
ignored.