### PR TITLE
Nrunner: extend status server checks for user request to exit [V2]

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -696,7 +696,8 @@ class StatusServer:
                     return True
 
             message = await reader.readline()
-            if message == b'bye\n':
+            exit_command = message.splitlines()
+            if exit_command and exit_command[0] == b'bye':
                 print('Status server: exiting due to user request')
                 self.server_task.cancel()
                 await self.server_task


### PR DESCRIPTION
While testing the status server using telnet, when a `bye` is sent, it is translated to `b'bye\r\n'`, making the status server crash and not exit.

Signed-off-by: Willian Rampazzo <willianr@redhat.com>

Changes from [V1}:
- split the message with `splitlines`. This handles a good amount of separators.