### PR TITLE
Job: allow the selection of the test runner by command line [v2]

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -202,6 +202,9 @@ class Job:
         #: has not been attempted.  If set to an empty list, it means that no
         #: test was found during resolution.
         self.test_suite = None
+        #: An instance of the :class:`avocado.core.plugin_interfaces.Runner`
+        #: that will be used to effectivelly run the tests in the this job's
+        #: :attr:`test_suite`
         self.test_runner = None
 
         #: Placeholder for test parameters (related to --test-parameters command

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -204,7 +204,7 @@ class Job:
         self.test_suite = None
         # To avoid requiring an explicit runner from Job API users, this sets
         # a job built-in default for the runner
-        self._test_runner_name = self.config.get('test_runner') or 'runner'
+        self._test_runner_name = self.config.get('run.test_runner') or 'runner'
         #: An instance of the :class:`avocado.core.plugin_interfaces.Runner`
         #: that will be used to effectivelly run the tests in the this job's
         #: :attr:`test_suite`

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -202,6 +202,9 @@ class Job:
         #: has not been attempted.  If set to an empty list, it means that no
         #: test was found during resolution.
         self.test_suite = None
+        # To avoid requiring an explicit runner from Job API users, this sets
+        # a job built-in default for the runner
+        self._test_runner_name = self.config.get('test_runner') or 'runner'
         #: An instance of the :class:`avocado.core.plugin_interfaces.Runner`
         #: that will be used to effectivelly run the tests in the this job's
         #: :attr:`test_suite`
@@ -555,11 +558,8 @@ class Job:
         refs = self.config.get('run.references')
         if not refs:
             refs = self.config.get('nrun.references')
-        # TODO: Fix this, this is one of the few cases where using the config
-        # generated from the new settings with a hardcoded 'default' value
-        runner_name = self.config.get('test_runner', 'runner')
         try:
-            if runner_name == 'nrunner':
+            if self._test_runner_name == 'nrunner':
                 self.test_suite = self._make_test_suite_resolver(refs)
             else:
                 self.test_suite = self._make_test_suite_loader(refs)
@@ -605,11 +605,8 @@ class Job:
                 raise exceptions.OptionValidationError("Unable to parse "
                                                        "variant: %s" % details)
 
-        # TODO: Fix this, this is one of the few cases where using the config
-        # generated from the new settings with a hardcoded 'default' value
-        runner_name = self.config.get('test_runner', 'runner')
         try:
-            runner_extension = dispatcher.RunnerDispatcher()[runner_name]
+            runner_extension = dispatcher.RunnerDispatcher()[self._test_runner_name]
         except KeyError:
             return
         self.test_runner = runner_extension.obj

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -87,6 +87,19 @@ class Run(CLICmd):
                                  long_arg='--test-parameter',
                                  short_arg='-p')
 
+        help_msg = ('Selects the runner implementation from one of the '
+                    'installed and active implementations.  You can run '
+                    '"avocado plugins" and find the list of valid runners '
+                    'under the "Plugins that run test suites on a job '
+                    '(runners) section.  Defaults to "runner", which is '
+                    'the conventional and traditional runner.')
+        settings.register_option(section='run',
+                                 key='test_runner',
+                                 default='runner',
+                                 help_msg=help_msg,
+                                 parser=parser,
+                                 long_arg='--test-runner')
+
         help_msg = ('Instead of running the test only list them and log '
                     'their params.')
         settings.register_option(section='run.dry_run',

--- a/examples/jobs/nrunner.py
+++ b/examples/jobs/nrunner.py
@@ -4,7 +4,7 @@ import sys
 from avocado.core.job import Job
 
 config = {
-    'test_runner': 'nrunner',
+    'run.test_runner': 'nrunner',
     'run.references': [
         'selftests/unit/test_resolver.py',
         'selftests/functional/test_argument_parsing.py',

--- a/examples/jobs/podman.py
+++ b/examples/jobs/podman.py
@@ -4,7 +4,7 @@ import sys
 from avocado.core.job import Job
 
 config = {'run.references': ['/bin/true'],
-          'test_runner': 'docker',
+          'run.test_runner': 'docker',
           'docker': 'ldoktor/fedora-avocado',
           'docker_cmd': 'podman',
           'docker_options': '',

--- a/jobs/timesensitive.py
+++ b/jobs/timesensitive.py
@@ -9,7 +9,7 @@ from avocado.core.job import Job
 ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 CONFIG = {
-    'test_runner': 'nrunner',
+    'run.test_runner': 'nrunner',
     'nrun.references': [os.path.join(ROOT_DIR, 'selftests', 'unit'),
                         os.path.join(ROOT_DIR, 'selftests', 'functional')],
     'filter_by_tags': ['parallel:1'],

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -277,7 +277,7 @@ class JobTest(unittest.TestCase):
         config = {'run.results_dir': self.tmpdir.name,
                   'run.store_logging_stream': [],
                   'nrun.references': simple_tests_found,
-                  'test_runner': 'nrunner',
+                  'run.test_runner': 'nrunner',
                   'show': ['none']}
         self.job = job.Job(config)
         self.job.setup()


### PR DESCRIPTION
And some clarifications about a default runner being set and used by a job, as an exception.

Changes from v1 (#3816):

* Documented the `test_runner` attribute (new commit) 
* Set the default test runner early and once (new commit)