### PR TITLE
Nrunner: Extend status server exit and command handling.

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -696,7 +696,8 @@ class StatusServer:
                     return True
 
             message = await reader.readline()
-            if message == b'bye\n':
+            message = message.strip()
+            if message == b'bye':
                 print('Status server: exiting due to user request')
                 self.server_task.cancel()
                 await self.server_task
@@ -705,7 +706,7 @@ class StatusServer:
             if not message:
                 return False
 
-            data = json_loads(message.strip())
+            data = json_loads(message)
 
             if data.get('status') in ['started']:
                 self.handle_task_started(data)

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -706,7 +706,10 @@ class StatusServer:
             if not message:
                 return False
 
-            data = json_loads(message)
+            try:
+                data = json_loads(message)
+            except json.decoder.JSONDecodeError:
+                return False
 
             if data.get('status') in ['started']:
                 self.handle_task_started(data)


### PR DESCRIPTION
While testing the status server using telnet, when a `bye` is sent, it is translated to `b'bye\r\n'`, making the status server crash and not exit.

Do not crash the StatusServer when an unknown command or a malformed JSON is received.

Signed-off-by: Willian Rampazzo <willianr@redhat.com>

Changes from [V3]:
- added a commit to handle unknown command or malformed JSON to avoid crashing.

Changes from [V2]:
- `strip` can handle it, no need to use `splitlines`.

Changes from [V1}:
- split the message with `splitlines`. This handles a good amount of separators.