### PR TITLE
nrun: use LOG_UI instead of print

### DIFF
--- a/avocado/plugins/nrun.py
+++ b/avocado/plugins/nrun.py
@@ -82,7 +82,7 @@ class NRun(CLICmd):
             try:
                 task = self.pending_tasks[0]
             except IndexError:
-                print("Finished spawning tasks")
+                LOG_UI.info("Finished spawning tasks")
                 break
 
             spawn_result = await self.spawner.spawn_task(task)


### PR DESCRIPTION
All plugins that generate output for users to see, that is, a UI,
should use avocado.core.output.LOG_UI, because of convention and
because it applies the core `--show` command option.

There's one instenace in the nrun plugin which was using print
instead, and this fixes it.

Signed-off-by: Cleber Rosa <crosa@redhat.com>