### PR TITLE
Disabled the json output print in multipath.py

### DIFF
--- a/avocado/utils/multipath.py
+++ b/avocado/utils/multipath.py
@@ -134,7 +134,7 @@ def get_multipath_details():
     :rtype: dict
     """
     mpath_op = process.run("multipathd show maps json",
-                           sudo=True).stdout_text
+                           sudo=True, verbose=False).stdout_text
     if 'multipath-tools v' in mpath_op:
         return ''
     mpath_op = ast.literal_eval(mpath_op.replace("\n", '').replace(' ', ''))


### PR DESCRIPTION
json output is very huge for larger configuration which is making
difficult in debugging the script and actual issues. so disabled
the json output by adding verbose=False.

Signed-off-by: Naresh Bannoth <nbannoth@in.ibm.com>