### PR TITLE
Nrunner: minor changes to the status server for consistency.

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -735,7 +735,8 @@ class StatusServer:
         result = data['result']
         task_id = data['id']
 
-        self.tasks_pending.remove(task_id)
+        if self.wait_on_tasks_pending:
+            self.tasks_pending.remove(task_id)
         print('Task complete (%s): %s' % (result, task_id))
 
         if result not in self.result:

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -737,22 +737,23 @@ class StatusServer:
 
         if self.wait_on_tasks_pending:
             self.tasks_pending.remove(task_id)
-        print('Task complete (%s): %s' % (result, task_id))
 
         if result not in self.result:
             self.result[result] = []
         self.result[result].append(task_id)
 
-        if result not in ('pass', 'skip'):
-            stdout = data.get('stdout', b'')
-            if stdout:
-                print('Task %s stdout:\n%s\n' % (task_id, stdout))
-            stderr = data.get('stderr', b'')
-            if stderr:
-                print('Task %s stderr:\n%s\n' % (task_id, stderr))
-            output = data.get('output', b'')
-            if output:
-                print('Task %s output:\n%s\n' % (task_id, output))
+        if self.verbose:
+            print('Task complete (%s): %s' % (result, task_id))
+            if result not in ('pass', 'skip'):
+                stdout = data.get('stdout', b'')
+                if stdout:
+                    print('Task %s stdout:\n%s\n' % (task_id, stdout))
+                stderr = data.get('stderr', b'')
+                if stderr:
+                    print('Task %s stderr:\n%s\n' % (task_id, stderr))
+                output = data.get('output', b'')
+                if output:
+                    print('Task %s output:\n%s\n' % (task_id, output))
 
     def start(self):
         loop = asyncio.get_event_loop()

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -720,7 +720,7 @@ class StatusServer:
         host, port = self.uri.split(':')
         port = int(port)
         server = await asyncio.start_server(self.cb, host=host, port=port)
-        print("Results server started at:", self.uri)
+        print("Status server started at:", self.uri)
         await server.wait_closed()
 
     def handle_task_started(self, data):


### PR DESCRIPTION
- Remove the task just if the status server is waiting for it;
- Follow the `handle_task_started` method pattern, printing just when `self.verbose = True`;
- Change the start message string from `Results` to `Status`, just like the other messages on this class.

Signed-off-by: Willian Rampazzo <willianr@redhat.com>

Despite thinking that the `handle_task_started` and the `handle_task_finished` are placeholders for future development (as I don't think they are responsible for printing status, stdout, stderr, and output), let's make the methods behave the same way.