### PR TITLE
Avocado jobs show: move closer to human UI

### DIFF
--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -157,53 +157,53 @@ class TermSupport:
         """
         return self.PARTIAL + msg + self.ENDC
 
-    def pass_str(self):
+    def pass_str(self, msg='PASS'):
         """
         Print a pass string (green colored).
 
         If the output does not support colors, just return the original string.
         """
-        return self.MOVE_BACK + self.PASS + 'PASS' + self.ENDC
+        return self.MOVE_BACK + self.PASS + msg + self.ENDC
 
-    def skip_str(self):
+    def skip_str(self, msg='SKIP'):
         """
         Print a skip string (yellow colored).
 
         If the output does not support colors, just return the original string.
         """
-        return self.MOVE_BACK + self.SKIP + 'SKIP' + self.ENDC
+        return self.MOVE_BACK + self.SKIP + msg + self.ENDC
 
-    def fail_str(self):
+    def fail_str(self, msg='FAIL'):
         """
         Print a fail string (red colored).
 
         If the output does not support colors, just return the original string.
         """
-        return self.MOVE_BACK + self.FAIL + 'FAIL' + self.ENDC
+        return self.MOVE_BACK + self.FAIL + msg + self.ENDC
 
-    def error_str(self):
+    def error_str(self, msg='ERROR'):
         """
         Print a error string (red colored).
 
         If the output does not support colors, just return the original string.
         """
-        return self.MOVE_BACK + self.ERROR + 'ERROR' + self.ENDC
+        return self.MOVE_BACK + self.ERROR + msg + self.ENDC
 
-    def interrupt_str(self):
+    def interrupt_str(self, msg='INTERRUPT'):
         """
         Print an interrupt string (red colored).
 
         If the output does not support colors, just return the original string.
         """
-        return self.MOVE_BACK + self.INTERRUPT + 'INTERRUPT' + self.ENDC
+        return self.MOVE_BACK + self.INTERRUPT + msg + self.ENDC
 
-    def warn_str(self):
+    def warn_str(self, msg='WARN'):
         """
         Print an warning string (yellow colored).
 
         If the output does not support colors, just return the original string.
         """
-        return self.MOVE_BACK + self.WARN + 'WARN' + self.ENDC
+        return self.MOVE_BACK + self.WARN + msg + self.ENDC
 
 
 #: Transparently handles colored terminal, when one is used

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -210,6 +210,17 @@ class TermSupport:
 TERM_SUPPORT = TermSupport()
 
 
+#: A collection of mapping from test statuses to colors to be used
+#: consistently across the various plugins
+TEST_STATUS_MAPPING = {'PASS': TERM_SUPPORT.PASS,
+                       'ERROR': TERM_SUPPORT.ERROR,
+                       'FAIL': TERM_SUPPORT.FAIL,
+                       'SKIP': TERM_SUPPORT.SKIP,
+                       'WARN': TERM_SUPPORT.WARN,
+                       'INTERRUPTED': TERM_SUPPORT.INTERRUPT,
+                       'CANCEL': TERM_SUPPORT.CANCEL}
+
+
 class _StdOutputFile:
 
     """

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -157,53 +157,53 @@ class TermSupport:
         """
         return self.PARTIAL + msg + self.ENDC
 
-    def pass_str(self, msg='PASS'):
+    def pass_str(self, msg='PASS', move=MOVE_BACK):
         """
         Print a pass string (green colored).
 
         If the output does not support colors, just return the original string.
         """
-        return self.MOVE_BACK + self.PASS + msg + self.ENDC
+        return move + self.PASS + msg + self.ENDC
 
-    def skip_str(self, msg='SKIP'):
+    def skip_str(self, msg='SKIP', move=MOVE_BACK):
         """
         Print a skip string (yellow colored).
 
         If the output does not support colors, just return the original string.
         """
-        return self.MOVE_BACK + self.SKIP + msg + self.ENDC
+        return move + self.SKIP + msg + self.ENDC
 
-    def fail_str(self, msg='FAIL'):
+    def fail_str(self, msg='FAIL', move=MOVE_BACK):
         """
         Print a fail string (red colored).
 
         If the output does not support colors, just return the original string.
         """
-        return self.MOVE_BACK + self.FAIL + msg + self.ENDC
+        return move + self.FAIL + msg + self.ENDC
 
-    def error_str(self, msg='ERROR'):
+    def error_str(self, msg='ERROR', move=MOVE_BACK):
         """
         Print a error string (red colored).
 
         If the output does not support colors, just return the original string.
         """
-        return self.MOVE_BACK + self.ERROR + msg + self.ENDC
+        return move + self.ERROR + msg + self.ENDC
 
-    def interrupt_str(self, msg='INTERRUPT'):
+    def interrupt_str(self, msg='INTERRUPT', move=MOVE_BACK):
         """
         Print an interrupt string (red colored).
 
         If the output does not support colors, just return the original string.
         """
-        return self.MOVE_BACK + self.INTERRUPT + msg + self.ENDC
+        return move + self.INTERRUPT + msg + self.ENDC
 
-    def warn_str(self, msg='WARN'):
+    def warn_str(self, msg='WARN', move=MOVE_BACK):
         """
         Print an warning string (yellow colored).
 
         If the output does not support colors, just return the original string.
         """
-        return self.MOVE_BACK + self.WARN + msg + self.ENDC
+        return move + self.WARN + msg + self.ENDC
 
 
 #: Transparently handles colored terminal, when one is used

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -221,6 +221,17 @@ TEST_STATUS_MAPPING = {'PASS': TERM_SUPPORT.PASS,
                        'CANCEL': TERM_SUPPORT.CANCEL}
 
 
+#: A collection of mapping from test status to formatting functions
+#: to be used consistently across the various plugins
+TEST_STATUS_DECORATOR_MAPPING = {'PASS': TERM_SUPPORT.pass_str,
+                                 'ERROR': TERM_SUPPORT.error_str,
+                                 'FAIL': TERM_SUPPORT.fail_str,
+                                 'SKIP': TERM_SUPPORT.skip_str,
+                                 'WARN': TERM_SUPPORT.warn_str,
+                                 'INTERRUPTED': TERM_SUPPORT.interrupt_str,
+                                 'CANCEL': TERM_SUPPORT.skip_str}
+
+
 class _StdOutputFile:
 
     """

--- a/avocado/plugins/human.py
+++ b/avocado/plugins/human.py
@@ -30,14 +30,6 @@ class Human(ResultEvents):
     name = 'human'
     description = "Human Interface UI"
 
-    output_mapping = {'PASS': output.TERM_SUPPORT.PASS,
-                      'ERROR': output.TERM_SUPPORT.ERROR,
-                      'FAIL': output.TERM_SUPPORT.FAIL,
-                      'SKIP': output.TERM_SUPPORT.SKIP,
-                      'WARN': output.TERM_SUPPORT.WARN,
-                      'INTERRUPTED': output.TERM_SUPPORT.INTERRUPT,
-                      'CANCEL': output.TERM_SUPPORT.CANCEL}
-
     def __init__(self, config):
         self.__throbber = output.Throbber()
         stdout_claimed_by = config.get('stdout_claimed_by', None)
@@ -76,7 +68,7 @@ class Human(ResultEvents):
                      output.TERM_SUPPORT.ENDC, extra={"skip_newline": True})
 
     def get_colored_status(self, status, extra=None):
-        out = (output.TERM_SUPPORT.MOVE_BACK + self.output_mapping[status] +
+        out = (output.TERM_SUPPORT.MOVE_BACK + output.TEST_STATUS_MAPPING[status] +
                status)
         if extra:
             if len(extra) > 255:

--- a/avocado/plugins/jobs.py
+++ b/avocado/plugins/jobs.py
@@ -49,7 +49,7 @@ class Jobs(CLICmd):
 
     def _print_job_details(self, details):
         for key, value in details.items():
-            LOG_UI.info("%-15s: %s", key, value)
+            LOG_UI.info("%-12s: %s", key, value)
 
     def _print_job_tests(self, tests):
         test_matrix = []
@@ -230,14 +230,20 @@ class Jobs(CLICmd):
         except FileNotFoundError:
             pass
 
-        data = {'Job id': job_id,
-                'Debug log': results_data.get('debuglog'),
-                'Spawner': config_data.get('nrun.spawner', 'unknown'),
-                '#total tests': results_data.get('total'),
-                '#pass tests': results_data.get('pass'),
-                '#skip tests': results_data.get('skip'),
-                '#errors tests': results_data.get('errors'),
-                '#cancel tests': results_data.get('cancel')}
+        results = ('PASS %d | ERROR %d | FAIL %d | SKIP %d |'
+                   'WARN %d | INTERRUPT %s | CANCEL %s')
+        results %= (results_data.get('pass', 0),
+                    results_data.get('error', 0),
+                    results_data.get('failures', 0),
+                    results_data.get('skip', 0),
+                    results_data.get('warn', 0),
+                    results_data.get('interrupt', 0),
+                    results_data.get('cancel', 0))
+
+        data = {'JOB ID': job_id,
+                'JOB LOG': results_data.get('debuglog'),
+                'SPAWNER': config_data.get('nrun.spawner', 'unknown'),
+                'RESULTS': results}
 
         # We could improve this soon with more data and colors
         self._print_job_details(data)

--- a/avocado/plugins/jobs.py
+++ b/avocado/plugins/jobs.py
@@ -22,6 +22,7 @@ from datetime import datetime
 from glob import glob
 
 from avocado.core import exit_codes
+from avocado.core import output
 from avocado.core.data_dir import get_job_results_dir, get_logs_dir
 from avocado.core.future.settings import settings
 from avocado.core.output import LOG_UI
@@ -29,6 +30,7 @@ from avocado.core.plugin_interfaces import CLICmd
 from avocado.core.spawners.exceptions import SpawnerException
 from avocado.core.spawners.podman import PodmanSpawner
 from avocado.core.spawners.process import ProcessSpawner
+from avocado.utils import astring
 
 
 class Jobs(CLICmd):
@@ -50,20 +52,28 @@ class Jobs(CLICmd):
             LOG_UI.info("%-15s: %s", key, value)
 
     def _print_job_tests(self, tests):
-        LOG_UI.info("\nTests:\n")
+        test_matrix = []
         date_fmt = "%Y/%m/%d %H:%M:%S"
-        LOG_UI.info(" Status  End Time              Run Time   Test ID")
         for test in tests:
-            end = datetime.fromtimestamp(test.get('end'))
             status = test.get('status')
-            method = LOG_UI.info
-            if status in ['ERROR', 'FAIL']:
-                method = LOG_UI.error
-            method(" %-7s %-20s  %.5f    %s",
-                   status,
-                   end.strftime(date_fmt),
-                   float(test.get('time')),
-                   test.get('id'))
+            decorator = output.TEST_STATUS_DECORATOR_MAPPING.get(status)
+            end = datetime.fromtimestamp(test.get('end'))
+            test_matrix.append((decorator(status, ''),
+                                end.strftime(date_fmt),
+                                "%5f" % float(test.get('time')),
+                                test.get('id')))
+        header = (output.TERM_SUPPORT.header_str('Status'),
+                  output.TERM_SUPPORT.header_str('End Time'),
+                  output.TERM_SUPPORT.header_str('Run Time'),
+                  output.TERM_SUPPORT.header_str('Test ID'))
+        separator = False
+        for line in astring.iter_tabular_output(test_matrix,
+                                                header=header,
+                                                strip=True):
+            if not separator:
+                LOG_UI.debug('')
+                separator = True
+            LOG_UI.debug(line)
 
     def _save_stream_to_file(self, stream, filename):
         """Save stream to a file.
@@ -75,8 +85,8 @@ class Jobs(CLICmd):
             LOG_UI.error("%s does not exist. Exiting...", dirname)
             return exit_codes.AVOCADO_GENERIC_CRASH
 
-        with open(filename, 'ab') as output:
-            output.write(stream)
+        with open(filename, 'ab') as output_file:
+            output_file.write(stream)
 
     def configure(self, parser):
         """

--- a/avocado/plugins/jobs.py
+++ b/avocado/plugins/jobs.py
@@ -22,13 +22,13 @@ from datetime import datetime
 from glob import glob
 
 from avocado.core import exit_codes
-from avocado.core.output import LOG_UI
 from avocado.core.data_dir import get_job_results_dir, get_logs_dir
-from avocado.core.spawners.process import ProcessSpawner
-from avocado.core.spawners.podman import PodmanSpawner
-from avocado.core.spawners.exceptions import SpawnerException
 from avocado.core.future.settings import settings
+from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLICmd
+from avocado.core.spawners.exceptions import SpawnerException
+from avocado.core.spawners.podman import PodmanSpawner
+from avocado.core.spawners.process import ProcessSpawner
 
 
 class Jobs(CLICmd):


### PR DESCRIPTION
Running a job, by means of `avocado run` produces a UI (handled by the human UI plugin).  It feels to me that the output should be more similar. This moves `avocado jobs show` closer to `avocado run`, one step at at time so that we can measure how similar the output should be.

Also, during the development/review of #3829, a number of comments were made about using some utility methods also used by `avocado list` and others.