### PR TITLE
Avocado jobs show: move closer to human UI [v2]

### DIFF
--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -157,53 +157,53 @@ class TermSupport:
         """
         return self.PARTIAL + msg + self.ENDC
 
-    def pass_str(self):
+    def pass_str(self, msg='PASS'):
         """
         Print a pass string (green colored).
 
         If the output does not support colors, just return the original string.
         """
-        return self.MOVE_BACK + self.PASS + 'PASS' + self.ENDC
+        return self.MOVE_BACK + self.PASS + msg + self.ENDC
 
-    def skip_str(self):
+    def skip_str(self, msg='SKIP'):
         """
         Print a skip string (yellow colored).
 
         If the output does not support colors, just return the original string.
         """
-        return self.MOVE_BACK + self.SKIP + 'SKIP' + self.ENDC
+        return self.MOVE_BACK + self.SKIP + msg + self.ENDC
 
-    def fail_str(self):
+    def fail_str(self, msg='FAIL'):
         """
         Print a fail string (red colored).
 
         If the output does not support colors, just return the original string.
         """
-        return self.MOVE_BACK + self.FAIL + 'FAIL' + self.ENDC
+        return self.MOVE_BACK + self.FAIL + msg + self.ENDC
 
-    def error_str(self):
+    def error_str(self, msg='ERROR'):
         """
         Print a error string (red colored).
 
         If the output does not support colors, just return the original string.
         """
-        return self.MOVE_BACK + self.ERROR + 'ERROR' + self.ENDC
+        return self.MOVE_BACK + self.ERROR + msg + self.ENDC
 
-    def interrupt_str(self):
+    def interrupt_str(self, msg='INTERRUPT'):
         """
         Print an interrupt string (red colored).
 
         If the output does not support colors, just return the original string.
         """
-        return self.MOVE_BACK + self.INTERRUPT + 'INTERRUPT' + self.ENDC
+        return self.MOVE_BACK + self.INTERRUPT + msg + self.ENDC
 
-    def warn_str(self):
+    def warn_str(self, msg='WARN'):
         """
         Print an warning string (yellow colored).
 
         If the output does not support colors, just return the original string.
         """
-        return self.MOVE_BACK + self.WARN + 'WARN' + self.ENDC
+        return self.MOVE_BACK + self.WARN + msg + self.ENDC
 
 
 #: Transparently handles colored terminal, when one is used

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -210,6 +210,17 @@ class TermSupport:
 TERM_SUPPORT = TermSupport()
 
 
+#: A collection of mapping from test statuses to colors to be used
+#: consistently across the various plugins
+TEST_STATUS_MAPPING = {'PASS': TERM_SUPPORT.PASS,
+                       'ERROR': TERM_SUPPORT.ERROR,
+                       'FAIL': TERM_SUPPORT.FAIL,
+                       'SKIP': TERM_SUPPORT.SKIP,
+                       'WARN': TERM_SUPPORT.WARN,
+                       'INTERRUPTED': TERM_SUPPORT.INTERRUPT,
+                       'CANCEL': TERM_SUPPORT.CANCEL}
+
+
 class _StdOutputFile:
 
     """

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -157,53 +157,53 @@ class TermSupport:
         """
         return self.PARTIAL + msg + self.ENDC
 
-    def pass_str(self, msg='PASS'):
+    def pass_str(self, msg='PASS', move=MOVE_BACK):
         """
         Print a pass string (green colored).
 
         If the output does not support colors, just return the original string.
         """
-        return self.MOVE_BACK + self.PASS + msg + self.ENDC
+        return move + self.PASS + msg + self.ENDC
 
-    def skip_str(self, msg='SKIP'):
+    def skip_str(self, msg='SKIP', move=MOVE_BACK):
         """
         Print a skip string (yellow colored).
 
         If the output does not support colors, just return the original string.
         """
-        return self.MOVE_BACK + self.SKIP + msg + self.ENDC
+        return move + self.SKIP + msg + self.ENDC
 
-    def fail_str(self, msg='FAIL'):
+    def fail_str(self, msg='FAIL', move=MOVE_BACK):
         """
         Print a fail string (red colored).
 
         If the output does not support colors, just return the original string.
         """
-        return self.MOVE_BACK + self.FAIL + msg + self.ENDC
+        return move + self.FAIL + msg + self.ENDC
 
-    def error_str(self, msg='ERROR'):
+    def error_str(self, msg='ERROR', move=MOVE_BACK):
         """
         Print a error string (red colored).
 
         If the output does not support colors, just return the original string.
         """
-        return self.MOVE_BACK + self.ERROR + msg + self.ENDC
+        return move + self.ERROR + msg + self.ENDC
 
-    def interrupt_str(self, msg='INTERRUPT'):
+    def interrupt_str(self, msg='INTERRUPT', move=MOVE_BACK):
         """
         Print an interrupt string (red colored).
 
         If the output does not support colors, just return the original string.
         """
-        return self.MOVE_BACK + self.INTERRUPT + msg + self.ENDC
+        return move + self.INTERRUPT + msg + self.ENDC
 
-    def warn_str(self, msg='WARN'):
+    def warn_str(self, msg='WARN', move=MOVE_BACK):
         """
         Print an warning string (yellow colored).
 
         If the output does not support colors, just return the original string.
         """
-        return self.MOVE_BACK + self.WARN + msg + self.ENDC
+        return move + self.WARN + msg + self.ENDC
 
 
 #: Transparently handles colored terminal, when one is used

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -221,6 +221,17 @@ TEST_STATUS_MAPPING = {'PASS': TERM_SUPPORT.PASS,
                        'CANCEL': TERM_SUPPORT.CANCEL}
 
 
+#: A collection of mapping from test status to formatting functions
+#: to be used consistently across the various plugins
+TEST_STATUS_DECORATOR_MAPPING = {'PASS': TERM_SUPPORT.pass_str,
+                                 'ERROR': TERM_SUPPORT.error_str,
+                                 'FAIL': TERM_SUPPORT.fail_str,
+                                 'SKIP': TERM_SUPPORT.skip_str,
+                                 'WARN': TERM_SUPPORT.warn_str,
+                                 'INTERRUPTED': TERM_SUPPORT.interrupt_str,
+                                 'CANCEL': TERM_SUPPORT.skip_str}
+
+
 class _StdOutputFile:
 
     """

--- a/avocado/plugins/human.py
+++ b/avocado/plugins/human.py
@@ -30,14 +30,6 @@ class Human(ResultEvents):
     name = 'human'
     description = "Human Interface UI"
 
-    output_mapping = {'PASS': output.TERM_SUPPORT.PASS,
-                      'ERROR': output.TERM_SUPPORT.ERROR,
-                      'FAIL': output.TERM_SUPPORT.FAIL,
-                      'SKIP': output.TERM_SUPPORT.SKIP,
-                      'WARN': output.TERM_SUPPORT.WARN,
-                      'INTERRUPTED': output.TERM_SUPPORT.INTERRUPT,
-                      'CANCEL': output.TERM_SUPPORT.CANCEL}
-
     def __init__(self, config):
         self.__throbber = output.Throbber()
         stdout_claimed_by = config.get('stdout_claimed_by', None)
@@ -76,7 +68,7 @@ class Human(ResultEvents):
                      output.TERM_SUPPORT.ENDC, extra={"skip_newline": True})
 
     def get_colored_status(self, status, extra=None):
-        out = (output.TERM_SUPPORT.MOVE_BACK + self.output_mapping[status] +
+        out = (output.TERM_SUPPORT.MOVE_BACK + output.TEST_STATUS_MAPPING[status] +
                status)
         if extra:
             if len(extra) > 255:

--- a/avocado/plugins/jobs.py
+++ b/avocado/plugins/jobs.py
@@ -22,13 +22,13 @@ from datetime import datetime
 from glob import glob
 
 from avocado.core import exit_codes
-from avocado.core.output import LOG_UI
 from avocado.core.data_dir import get_job_results_dir, get_logs_dir
-from avocado.core.spawners.process import ProcessSpawner
-from avocado.core.spawners.podman import PodmanSpawner
-from avocado.core.spawners.exceptions import SpawnerException
 from avocado.core.future.settings import settings
+from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLICmd
+from avocado.core.spawners.exceptions import SpawnerException
+from avocado.core.spawners.podman import PodmanSpawner
+from avocado.core.spawners.process import ProcessSpawner
 
 
 class Jobs(CLICmd):


### PR DESCRIPTION
Running a job, by means of `avocado run` produces a UI (handled by the human UI plugin).  It feels to me that the output should be more similar. This moves `avocado jobs show` closer to `avocado run`.

Also, during the development/review of #3829, a number of comments were made about using some utility methods also used by `avocado list` and others.

---

Changes from v1 (#3833):
* Squashed commits that change the `avocado jobs show` output to the final result