### PR TITLE
Jobs: deprecate standalone jobs

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -27,6 +27,7 @@ import sys
 import tempfile
 import time
 import traceback
+import warnings
 
 from . import data_dir
 from . import dispatcher
@@ -737,6 +738,10 @@ class TestProgram:
                              ' fork loop.\n')
             sys.exit(exit_codes.AVOCADO_FAIL)
         os.environ['AVOCADO_STANDALONE_IN_MAIN'] = 'True'
+
+        warnings.warn("The standalone job feature will be removed soon. "
+                      "It can be replaced in the future by using the Job API "
+                      "and use __file__ as a reference.", FutureWarning)
 
         self.prog_name = os.path.basename(sys.argv[0])
         output.add_log_handler("", output.ProgressStreamHandler,

--- a/examples/jobs/passjob_with_test.py
+++ b/examples/jobs/passjob_with_test.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+import sys
+
+from avocado import Test
+from avocado.core.job import Job
+
+# When using __file__, you need to protect Job.run() within a
+# conditional block so that it doesn't get executed *again* and
+# generates a loop when loading this file at test execution time.
+config = {'run.references': [__file__]}
+
+
+class PassTest(Test):
+    def test(self):
+        pass
+
+
+if __name__ == '__main__':
+    with Job(config) as j:
+        sys.exit(j.run())


### PR DESCRIPTION
This feature can be easily replaced by the Job API, without using
hacks to protect the fork bomb, and doing things more explicitly.

An example job with a builtin test is here as an example.

Signed-off-by: Cleber Rosa <crosa@redhat.com>