### PR TITLE
Migrate loader settings to use the new API

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -32,7 +32,7 @@ from . import test
 from . import safeloader
 from .references import reference_split
 from ..utils import stacktrace
-from .settings import settings
+from .future.settings import settings as future_settings
 from .output import LOG_UI
 
 
@@ -120,11 +120,13 @@ class TestLoaderProxy:
                                        ", ".join(_good_test_types(plugin)))
             return out.rstrip('\n')
 
+        subcommand = args.get('subcommand')
         self.register_plugin(TapLoader)
         # Register external runner when --external-runner is used
         if args.get("external_runner", None):
             self.register_plugin(ExternalLoader)
-            args['loaders'] = ["external:%s" % args.get('external_runner')]
+            key = "{}.loaders".format(subcommand)
+            args[key] = ["external:%s" % args.get('external_runner')]
         else:
             # Add (default) file loader if not already registered
             if FileLoader not in self.registered_plugins:
@@ -135,10 +137,10 @@ class TestLoaderProxy:
         supported_types = []
         for plugin in self.registered_plugins:
             supported_types.extend(_good_test_types(plugin))
-        # Load plugin by the priority from settings
-        loaders = args.get('loaders', None)
-        if not loaders:
-            loaders = settings.get_value("plugins", "loaders", list, [])
+
+        # Here is one of the few exceptions that can has a hardcoded default
+        loaders = args.get("{}.loaders".format(subcommand)) or ['file',
+                                                                '@DEFAULT']
         if "@DEFAULT" in loaders:  # Replace @DEFAULT with unused loaders
             idx = loaders.index("@DEFAULT")
             loaders = (loaders[:idx] + [plugin for plugin in supported_loaders
@@ -394,13 +396,21 @@ class AccessDeniedPath:
     """ Dummy object to represent reference pointing to a inaccessible path """
 
 
-def add_loader_options(parser):
+def add_loader_options(parser, section='run'):
     arggrp = parser.add_argument_group('loader options')
-    arggrp.add_argument('--loaders', nargs='*', help="Overrides the priority "
-                        "of the test loaders. You can specify either "
-                        "@loader_name or TEST_TYPE. By default it tries all "
-                        "available loaders according to priority set in "
-                        "settings->plugins.loaders.")
+    help_msg = ("Overrides the priority of the test loaders. You can specify "
+                "either @loader_name or TEST_TYPE. By default it tries all "
+                "available loaders according to priority set in "
+                "settings->plugins.loaders.")
+    future_settings.register_option(section=section,
+                                    key='loaders',
+                                    nargs='*',
+                                    key_type=list,
+                                    default=['file', '@DEFAULT'],
+                                    help_msg=help_msg,
+                                    parser=arggrp,
+                                    long_arg='--loaders')
+
     arggrp.add_argument('--external-runner', default=None,
                         metavar='EXECUTABLE',
                         help=('Path to an specific test runner that '

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -424,18 +424,21 @@ def add_loader_options(parser, section='run'):
                                     parser=arggrp,
                                     long_arg='--external-runner')
 
-    chdir_help = ('Change directory before executing tests. This option '
-                  'may be necessary because of requirements and/or '
-                  'limitations of the external test runner. If the external '
-                  'runner requires to be run from its own base directory,'
-                  'use "runner" here. If the external runner runs tests based'
-                  ' on files and requires to be run from the directory '
-                  'where those files are located, use "test" here and '
-                  'specify the test directory with the option '
-                  '"--external-runner-testdir". Defaults to "%(default)s"')
-    arggrp.add_argument('--external-runner-chdir', default=None,
-                        choices=('runner', 'test'),
-                        help=chdir_help)
+    help_msg = ("Change directory before executing tests. This option may be "
+                "necessary because of requirements and/or limitations of the "
+                "external test runner. If the external runner requires to be "
+                "run from its own base directory, use 'runner' here. If the "
+                "external runner runs tests based  on files and requires to "
+                "be run from the directory where those files are located, "
+                "use 'test' here and specify the test directory with the "
+                "option '--external-runner-testdir'.")
+    future_settings.register_option(section=section,
+                                    key='external_runner_chdir',
+                                    help_msg=help_msg,
+                                    default=None,
+                                    parser=arggrp,
+                                    choices=('runner', 'test'),
+                                    long_arg='--external-runner-chdir')
 
     arggrp.add_argument('--external-runner-testdir', metavar='DIRECTORY',
                         default=None,
@@ -821,7 +824,8 @@ class ExternalLoader(TestLoader):
     @staticmethod
     def _process_external_runner(args, runner):
         """ Enables the external_runner when asked for """
-        chdir = args.get('external_runner_chdir', None)
+        subcommand = args.get('subcommand')
+        chdir = args.get("{}.external_runner_chdir".format(subcommand))
         test_dir = args.get('external_runner_testdir', None)
 
         if runner:

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -139,8 +139,6 @@ class TestLoaderProxy:
         loaders = args.get('loaders', None)
         if not loaders:
             loaders = settings.get_value("plugins", "loaders", list, [])
-        if '?' in loaders:
-            raise LoaderError("Available loader plugins:\n%s" % _str_loaders())
         if "@DEFAULT" in loaders:  # Replace @DEFAULT with unused loaders
             idx = loaders.index("@DEFAULT")
             loaders = (loaders[:idx] + [plugin for plugin in supported_loaders

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -123,10 +123,11 @@ class TestLoaderProxy:
         subcommand = args.get('subcommand')
         self.register_plugin(TapLoader)
         # Register external runner when --external-runner is used
-        if args.get("external_runner", None):
+        external_runner = args.get("{}.external_runner".format(subcommand))
+        if external_runner:
             self.register_plugin(ExternalLoader)
             key = "{}.loaders".format(subcommand)
-            args[key] = ["external:%s" % args.get('external_runner')]
+            args[key] = ["external:{}".format(external_runner)]
         else:
             # Add (default) file loader if not already registered
             if FileLoader not in self.registered_plugins:
@@ -411,15 +412,17 @@ def add_loader_options(parser, section='run'):
                                     parser=arggrp,
                                     long_arg='--loaders')
 
-    arggrp.add_argument('--external-runner', default=None,
-                        metavar='EXECUTABLE',
-                        help=('Path to an specific test runner that '
-                              'allows the use of its own tests. This '
-                              'should be used for running tests that '
-                              'do not conform to Avocado\' SIMPLE test'
-                              'interface and can not run standalone. Note: '
-                              'the use of --external-runner overwrites the --'
-                              'loaders to "external_runner"'))
+    help_msg = ("Path to an specific test runner that allows the use of its "
+                "own tests. This should be used for running tests that do not "
+                "conform to Avocado\' SIMPLE test interface and can not run "
+                "standalone. Note: the use of --external-runner overwrites "
+                "the --loaders to 'external_runner'")
+    future_settings.register_option(section=section,
+                                    key='external_runner',
+                                    default=None,
+                                    help_msg=help_msg,
+                                    parser=arggrp,
+                                    long_arg='--external-runner')
 
     chdir_help = ('Change directory before executing tests. This option '
                   'may be necessary because of requirements and/or '

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -440,13 +440,17 @@ def add_loader_options(parser, section='run'):
                                     choices=('runner', 'test'),
                                     long_arg='--external-runner-chdir')
 
-    arggrp.add_argument('--external-runner-testdir', metavar='DIRECTORY',
-                        default=None,
-                        help=('Where test files understood by the external'
-                              ' test runner are located in the '
-                              'filesystem. Obviously this assumes and '
-                              'only applies to external test runners that '
-                              'run tests from files'))
+    help_msg = ("Where test files understood by the external test runner "
+                "are located in the filesystem. Obviously this assumes and "
+                "only applies to external test runners that run tests from "
+                "files")
+    future_settings.register_option(section=section,
+                                    key='external_runner_testdir',
+                                    metavar='DIRECTORY',
+                                    default=None,
+                                    help_msg=help_msg,
+                                    parser=arggrp,
+                                    long_arg='--external-runner-testdir')
 
 
 class NotATest:
@@ -826,7 +830,7 @@ class ExternalLoader(TestLoader):
         """ Enables the external_runner when asked for """
         subcommand = args.get('subcommand')
         chdir = args.get("{}.external_runner_chdir".format(subcommand))
-        test_dir = args.get('external_runner_testdir', None)
+        test_dir = args.get("{}.external_runner_testdir".format(subcommand))
 
         if runner:
             external_runner_and_args = shlex.split(runner)

--- a/avocado/plugins/list.py
+++ b/avocado/plugins/list.py
@@ -172,7 +172,7 @@ class List(CLICmd):
                                  help_msg=help_msg,
                                  parser=parser,
                                  positional_arg=True)
-        loader.add_loader_options(parser)
+        loader.add_loader_options(parser, 'list')
         parser_common_args.add_tag_filter_args(parser)
 
     def run(self, config):

--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -234,7 +234,9 @@ class Replay(CLI):
                               'ignore_missing_references',
                               'execution_order',
                               'loaders',
-                              'external_runner']:
+                              'external_runner',
+                              'external_runner_testdir',
+                              'external_runner_chdir']:
                     optvalue = config.get('run.{}'.format(option))
                 if optvalue is not None:
                     LOG_UI.warn("Overriding the replay %s with the --%s value "

--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -233,7 +233,8 @@ class Replay(CLI):
                 if option in ['failfast',
                               'ignore_missing_references',
                               'execution_order',
-                              'loaders']:
+                              'loaders',
+                              'external_runner']:
                     optvalue = config.get('run.{}'.format(option))
                 if optvalue is not None:
                     LOG_UI.warn("Overriding the replay %s with the --%s value "

--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -232,7 +232,8 @@ class Replay(CLI):
                 # Temporary, this will be removed soon
                 if option in ['failfast',
                               'ignore_missing_references',
-                              'execution_order']:
+                              'execution_order',
+                              'loaders']:
                     optvalue = config.get('run.{}'.format(option))
                 if optvalue is not None:
                     LOG_UI.warn("Overriding the replay %s with the --%s value "

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -266,7 +266,7 @@ class Run(CLICmd):
                                  parser=out_check,
                                  long_arg='--output-check')
 
-        loader.add_loader_options(parser)
+        loader.add_loader_options(parser, 'run')
         parser_common_args.add_tag_filter_args(parser)
 
     def run(self, config):


### PR DESCRIPTION
This will migrate `--loaders`, `--external-runner`, `--external-runner-chdir` and `--external-runner-testdir` to use the new API calls.  