### PR TITLE
avocado/utils/disk.py: Enhance get_disks

### DIFF
--- a/avocado/utils/disk.py
+++ b/avocado/utils/disk.py
@@ -53,9 +53,9 @@ def get_disks():
     :returns: a list of paths to the physical disks on the system
     :rtype: list of str
     """
-    json_result = process.run('lsblk --json')
+    json_result = process.run('lsblk --json --paths --inverse')
     json_data = json.loads(json_result.stdout_text)
-    return ['/dev/%s' % str(disk['name']) for disk in json_data['blockdevices']]
+    return [str(disk['name']) for disk in json_data['blockdevices']]
 
 
 def get_available_filesystems():

--- a/selftests/unit/test_utils_disk.py
+++ b/selftests/unit/test_utils_disk.py
@@ -7,12 +7,12 @@ from avocado.utils import process
 LSBLK_OUTPUT = b'''
 {
    "blockdevices": [
-      {"name": "vda", "maj:min": "252:0", "rm": "0", "size": "6G", "ro": "0", "type": "disk", "mountpoint": null,
+      {"name": "/dev/vda", "maj:min": "252:0", "rm": "0", "size": "6G", "ro": "0", "type": "disk", "mountpoint": null,
          "children": [
-            {"name": "vda1", "maj:min": "252:1", "rm": "0", "size": "1M", "ro": "0", "type": "part", "mountpoint": null},
-            {"name": "vda2", "maj:min": "252:2", "rm": "0", "size": "1G", "ro": "0", "type": "part", "mountpoint": "/boot"},
-            {"name": "vda3", "maj:min": "252:3", "rm": "0", "size": "615M", "ro": "0", "type": "part", "mountpoint": "[SWAP]"},
-            {"name": "vda4", "maj:min": "252:4", "rm": "0", "size": "4.4G", "ro": "0", "type": "part", "mountpoint": "/"}
+            {"name": "/dev/vda1", "maj:min": "252:1", "rm": "0", "size": "1M", "ro": "0", "type": "part", "mountpoint": null},
+            {"name": "/dev/vda2", "maj:min": "252:2", "rm": "0", "size": "1G", "ro": "0", "type": "part", "mountpoint": "/boot"},
+            {"name": "/dev/vda3", "maj:min": "252:3", "rm": "0", "size": "615M", "ro": "0", "type": "part", "mountpoint": "[SWAP]"},
+            {"name": "/dev/vda4", "maj:min": "252:4", "rm": "0", "size": "4.4G", "ro": "0", "type": "part", "mountpoint": "/"}
          ]
       }
    ]
@@ -40,7 +40,7 @@ class Disk(unittest.TestCase):
 
     def test_empty(self):
         mock_result = process.CmdResult(
-            command='lsblk --json',
+            command='lsblk --json --paths --inverse',
             stdout=b'{"blockdevices": []}')
         with unittest.mock.patch('avocado.utils.disk.process.run',
                                  return_value=mock_result):
@@ -48,7 +48,7 @@ class Disk(unittest.TestCase):
 
     def test_disks(self):
         mock_result = process.CmdResult(
-            command='lsblk --json',
+            command='lsblk --json --paths --inverse',
             stdout=LSBLK_OUTPUT)
         with unittest.mock.patch('avocado.utils.disk.process.run',
                                  return_value=mock_result):


### PR DESCRIPTION
Fixed get_disks to return all block devices, like multipaths,
LVs, etc. Previously we used to get only /dev/sdX devices.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>
Reported-by: Naresh Bannoth <nbannoth@in.ibm.com>
Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>
Signed-off-by: Cleber Rosa <crosa@redhat.com>