### PR TITLE
Job: assume the task of generating results

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -649,6 +649,16 @@ class Job:
         """
         self.result_events_dispatcher.map_method('post_tests', self)
 
+    def render_results(self):
+        """Render test results that depend on all tests having finished.
+
+        By default this runs the plugins that implement the
+        :class:`avocado.core.plugin_interfaces.Result` interface.
+        """
+        result_dispatcher = dispatcher.ResultDispatcher()
+        if result_dispatcher.extensions:
+            result_dispatcher.map_method('render', self.result, self)
+
     def run(self):
         """
         Runs all job phases, returning the test execution results.
@@ -696,6 +706,7 @@ class Job:
             if self.time_end == -1:
                 self.time_end = time.time()
                 self.time_elapsed = self.time_end - self.time_start
+            self.render_results()
 
     def cleanup(self):
         """

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -25,7 +25,6 @@ from avocado.core import job
 from avocado.core import loader
 from avocado.core import output
 from avocado.core import parser_common_args
-from avocado.core.dispatcher import ResultDispatcher
 from avocado.core.dispatcher import JobPrePostDispatcher
 from avocado.core.future.settings import settings
 from avocado.core.output import LOG_UI
@@ -320,9 +319,4 @@ class Run(CLICmd):
                 # Run JobPost plugins
                 pre_post_dispatcher.map_method('post', job_instance)
 
-            result_dispatcher = ResultDispatcher()
-            if result_dispatcher.extensions:
-                result_dispatcher.map_method('render',
-                                             job_instance.result,
-                                             job_instance)
         return job_run

--- a/examples/jobs/passjob_html.py
+++ b/examples/jobs/passjob_html.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+
+import sys
+from avocado.core.job import Job
+
+config = {'run.references': ['examples/tests/passtest.py:PassTest.test'],
+          'run.html_job_result': 'on',
+          'run.open_browser': True}
+
+with Job(config) as j:
+    sys.exit(j.run())


### PR DESCRIPTION
Users of the Job API expect the result files (such as JSON, xunit,
HTML, or any other format implemented by installed plugins) to be
respected by the job configurations.

By moving the handling from the plugin that implements "avocado run"
to the Job itself, both users will be able to use them.

Signed-off-by: Cleber Rosa <crosa@redhat.com>