### PR TITLE
Job: remove unused sysinfo attributes and calls

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -175,7 +175,6 @@ class Job:
         self.status = "RUNNING"
         self.result = None
         self.interrupted_reason = None
-        self.sysinfo = None
         timeout = self.config.get('run.job_timeout')
         try:
             self.timeout = data_structures.time_to_seconds(timeout)

--- a/avocado/plugins/runner.py
+++ b/avocado/plugins/runner.py
@@ -370,8 +370,6 @@ class TestRunner(Runner):
         :return: a set with types of test failures.
         """
         summary = set()
-        if job.sysinfo is not None:
-            job.sysinfo.start_job_hook()
         queue = multiprocessing.SimpleQueue()
         if timeout > 0:
             deadline = time.time() + timeout
@@ -418,8 +416,6 @@ class TestRunner(Runner):
             TEST_LOG.error('Job interrupted by ctrl+c.')
             summary.add('INTERRUPTED')
 
-        if job.sysinfo is not None:
-            job.sysinfo.end_job_hook()
         result.end_tests()
         job.funcatexit.run()
         signal.signal(signal.SIGTSTP, signal.SIG_IGN)

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -48,7 +48,6 @@ class JobTest(unittest.TestCase):
         self.assertIsNone(self.job.logfile)
         self.assertIsNone(self.job.replay_sourcejob)
         self.assertIsNone(self.job.result)
-        self.assertIsNone(self.job.sysinfo)
         self.assertIsNone(self.job.test_runner)
         self.assertIsNone(self.job.test_suite)
         self.assertIsNone(self.job.tmpdir)


### PR DESCRIPTION
There's already a "job.prepost" plugin implementation that get's
called correctly before and after a job.

Reference: https://github.com/avocado-framework/avocado/issues/3460
Signed-off-by: Cleber Rosa <crosa@redhat.com>