### PR TITLE
[RFC] Remove per-test sysinfo collection

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -175,7 +175,6 @@ class Job:
         self.status = "RUNNING"
         self.result = None
         self.interrupted_reason = None
-        self.sysinfo = None
         timeout = self.config.get('run.job_timeout')
         try:
             self.timeout = data_structures.time_to_seconds(timeout)

--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -457,11 +457,6 @@ class SysInfo:
         self.start_test_collectibles = set()
         self.end_test_collectibles = set()
 
-        self.hook_mapping = {'start_job': self.start_job_collectibles,
-                             'end_job': self.end_job_collectibles,
-                             'start_test': self.start_test_collectibles,
-                             'end_test': self.end_test_collectibles}
-
         self.pre_dir = utils_path.init_dir(self.basedir, 'pre')
         self.post_dir = utils_path.init_dir(self.basedir, 'post')
         self.profile_dir = utils_path.init_dir(self.basedir, 'profile')
@@ -509,46 +504,6 @@ class SysInfo:
             log.info(details)
 
         self.end_test_collectibles.add(JournalctlWatcher())
-
-    def _get_collectibles(self, hook):
-        collectibles = self.hook_mapping.get(hook)
-        if collectibles is None:
-            raise ValueError('Incorrect hook, valid hook names: %s' %
-                             self.hook_mapping.keys())
-        return collectibles
-
-    def add_cmd(self, cmd, hook):
-        """
-        Add a command collectible.
-
-        :param cmd: Command to log.
-        :param hook: In which hook this cmd should be logged (start job, end
-                     job).
-        """
-        collectibles = self._get_collectibles(hook)
-        collectibles.add(Command(cmd))
-
-    def add_file(self, filename, hook):
-        """
-        Add a system file collectible.
-
-        :param filename: Path to the file to be logged.
-        :param hook: In which hook this file should be logged (start job, end
-                     job).
-        """
-        collectibles = self._get_collectibles(hook)
-        collectibles.add(Logfile(filename))
-
-    def add_watcher(self, filename, hook):
-        """
-        Add a system file watcher collectible.
-
-        :param filename: Path to the file to be logged.
-        :param hook: In which hook this watcher should be logged
-                    (start job, end job).
-        """
-        collectibles = self._get_collectibles(hook)
-        collectibles.add(LogWatcher(filename))
 
     def _get_installed_packages(self):
         sm = software_manager.SoftwareManager()

--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -367,12 +367,11 @@ class LogWatcher(Collectible):
 class SysInfo:
 
     """
-    Log different system properties at some key control points:
+    Log different system properties at some key control points.
 
-    * start_job
-    * start_test
-    * end_test
-    * end_job
+    Includes support for a start and stop event, with daemons running in
+    between.  An event may be a job, a test, or any other even with a
+    beginning and end.
     """
 
     def __init__(self, basedir=None, log_packages=None, profiler=None):
@@ -451,11 +450,8 @@ class SysInfo:
             log.debug('File %s does not exist.', profiler_file)
             self.profilers = []
 
-        self.start_job_collectibles = set()
-        self.end_job_collectibles = set()
-
-        self.start_test_collectibles = set()
-        self.end_test_collectibles = set()
+        self.start_collectibles = set()
+        self.end_collectibles = set()
 
         self.pre_dir = utils_path.init_dir(self.basedir, 'pre')
         self.post_dir = utils_path.init_dir(self.basedir, 'post')
@@ -474,36 +470,19 @@ class SysInfo:
                          logpaths)
 
     def _set_collectibles(self):
-        add_per_test = settings.get_value("sysinfo.collect", "per_test",
-                                          bool, None)
         if self.profiler:
             for cmd in self.profilers:
-                self.start_job_collectibles.add(Daemon(cmd))
-                if add_per_test:
-                    self.start_test_collectibles.add(Daemon(cmd))
+                self.start_collectibles.add(Daemon(cmd))
 
         for cmd in self.commands:
-            self.start_job_collectibles.add(Command(cmd))
-            self.end_job_collectibles.add(Command(cmd))
-            if add_per_test:
-                self.start_test_collectibles.add(Command(cmd))
-                self.end_test_collectibles.add(Command(cmd))
+            self.start_collectibles.add(Command(cmd))
+            self.end_collectibles.add(Command(cmd))
 
         for filename in self.files:
-            self.start_job_collectibles.add(Logfile(filename))
-            self.end_job_collectibles.add(Logfile(filename))
-            if add_per_test:
-                self.start_test_collectibles.add(Logfile(filename))
-                self.end_test_collectibles.add(Logfile(filename))
+            self.start_collectibles.add(Logfile(filename))
+            self.end_collectibles.add(Logfile(filename))
 
-        # As the system log path is not standardized between distros,
-        # we have to probe and find out the correct path.
-        try:
-            self.end_test_collectibles.add(self._get_syslog_watcher())
-        except ValueError as details:
-            log.info(details)
-
-        self.end_test_collectibles.add(JournalctlWatcher())
+        self.end_collectibles.add(JournalctlWatcher())
 
     def _get_installed_packages(self):
         sm = software_manager.SoftwareManager()
@@ -529,11 +508,9 @@ class SysInfo:
         removed_packages = "\n".join(old_packages - new_packages) + "\n"
         genio.write_file(removed_path, removed_packages)
 
-    def start_job_hook(self):
-        """
-        Logging hook called whenever a job starts.
-        """
-        for log_hook in self.start_job_collectibles:
+    def start(self):
+        """Log all collectibles at the start of the event."""
+        for log_hook in self.start_collectibles:
             if isinstance(log_hook, Daemon):  # log daemons in profile directory
                 log_hook.run(self.profile_dir)
             else:
@@ -542,41 +519,14 @@ class SysInfo:
         if self.log_packages:
             self._log_installed_packages(self.pre_dir)
 
-    def end_job_hook(self):
+    def end(self):
         """
         Logging hook called whenever a job finishes.
         """
-        for log_hook in self.end_job_collectibles:
+        for log_hook in self.end_collectibles:
             log_hook.run(self.post_dir)
         # Stop daemon(s) started previously
-        for log_hook in self.start_job_collectibles:
-            if isinstance(log_hook, Daemon):
-                log_hook.stop()
-
-        if self.log_packages:
-            self._log_modified_packages(self.post_dir)
-
-    def start_test_hook(self):
-        """
-        Logging hook called before a test starts.
-        """
-        for log_hook in self.start_test_collectibles:
-            if isinstance(log_hook, Daemon):  # log daemons in profile directory
-                log_hook.run(self.profile_dir)
-            else:
-                log_hook.run(self.pre_dir)
-
-        if self.log_packages:
-            self._log_installed_packages(self.pre_dir)
-
-    def end_test_hook(self):
-        """
-        Logging hook called after a test finishes.
-        """
-        for log_hook in self.end_test_collectibles:
-            log_hook.run(self.post_dir)
-        # Stop daemon(s) started previously
-        for log_hook in self.start_test_collectibles:
+        for log_hook in self.start_collectibles:
             if isinstance(log_hook, Daemon):
                 log_hook.stop()
 
@@ -595,6 +545,6 @@ def collect_sysinfo(basedir):
         basedir = os.path.join(cwd, 'sysinfo-%s' % timestamp)
 
     sysinfo_logger = SysInfo(basedir=basedir)
-    sysinfo_logger.start_job_hook()
-    sysinfo_logger.end_job_hook()
+    sysinfo_logger.start()
+    sysinfo_logger.end()
     log.info("Logged system information to %s", basedir)

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -37,7 +37,6 @@ from . import defaults
 from . import exceptions
 from . import output
 from . import parameters
-from . import sysinfo
 from . import tapparser
 from ..utils import asset
 from ..utils import astring
@@ -375,17 +374,6 @@ class Test(unittest.TestCase, TestData):
         self._logging_handlers = {}
 
         self.__outputdir = utils_path.init_dir(self.logdir, 'data')
-
-        # For some reason, sometimes, job.config if None here.
-        # This is the only place that we create a "default" in code.
-        try:
-            self.__sysinfo_enabled = job.config.get('sysinfo.collect.per_test')
-        except AttributeError:
-            self.__sysinfo_enabled = False
-
-        if self.__sysinfo_enabled:
-            self.__sysinfodir = utils_path.init_dir(self.logdir, 'sysinfo')
-            self.__sysinfo_logger = sysinfo.SysInfo(basedir=self.__sysinfodir)
 
         self.__log = LOG_JOB
         original_log_warn = self.log.warning
@@ -831,8 +819,6 @@ class Test(unittest.TestCase, TestData):
 
         testMethod = getattr(self, self._testMethodName)
         self._start_logging()
-        if self.__sysinfo_enabled:
-            self.__sysinfo_logger.start()
         test_exception = None
         cleanup_exception = None
         output_check_exception = None
@@ -951,9 +937,6 @@ class Test(unittest.TestCase, TestData):
                                                 logger=LOG_JOB)
                         stderr_check_exception = details
 
-        if self.__sysinfo_enabled:
-            self.__sysinfo_logger.end()
-
         # pylint: disable=E0702
         if test_exception is not None:
             raise test_exception
@@ -980,8 +963,6 @@ class Test(unittest.TestCase, TestData):
         os.environ['AVOCADO_TEST_LOGDIR'] = self.logdir
         os.environ['AVOCADO_TEST_LOGFILE'] = self.logfile
         os.environ['AVOCADO_TEST_OUTPUTDIR'] = self.outputdir
-        if self.__sysinfo_enabled:
-            os.environ['AVOCADO_TEST_SYSINFODIR'] = self.__sysinfodir
 
     def run_avocado(self):
         """

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -379,7 +379,7 @@ class Test(unittest.TestCase, TestData):
         # For some reason, sometimes, job.config if None here.
         # This is the only place that we create a "default" in code.
         try:
-            self.__sysinfo_enabled = job.config.get('sysinfo.collect.enabled')
+            self.__sysinfo_enabled = job.config.get('sysinfo.collect.per_test')
         except AttributeError:
             self.__sysinfo_enabled = False
 
@@ -832,7 +832,7 @@ class Test(unittest.TestCase, TestData):
         testMethod = getattr(self, self._testMethodName)
         self._start_logging()
         if self.__sysinfo_enabled:
-            self.__sysinfo_logger.start_test_hook()
+            self.__sysinfo_logger.start()
         test_exception = None
         cleanup_exception = None
         output_check_exception = None
@@ -952,7 +952,7 @@ class Test(unittest.TestCase, TestData):
                         stderr_check_exception = details
 
         if self.__sysinfo_enabled:
-            self.__sysinfo_logger.end_test_hook()
+            self.__sysinfo_logger.end()
 
         # pylint: disable=E0702
         if test_exception is not None:

--- a/avocado/etc/avocado/avocado.conf
+++ b/avocado/etc/avocado/avocado.conf
@@ -23,8 +23,6 @@ installed_packages = False
 profiler = False
 # Force LANG for sysinfo collection
 locale = C
-# Enable sysinfo collection per-test
-per_test = False
 
 [sysinfo.collectibles]
 # File with list of commands that will be executed and have their output collected

--- a/avocado/plugins/runner.py
+++ b/avocado/plugins/runner.py
@@ -370,8 +370,6 @@ class TestRunner(Runner):
         :return: a set with types of test failures.
         """
         summary = set()
-        if job.sysinfo is not None:
-            job.sysinfo.start_job_hook()
         queue = multiprocessing.SimpleQueue()
         if timeout > 0:
             deadline = time.time() + timeout
@@ -418,8 +416,6 @@ class TestRunner(Runner):
             TEST_LOG.error('Job interrupted by ctrl+c.')
             summary.add('INTERRUPTED')
 
-        if job.sysinfo is not None:
-            job.sysinfo.end_job_hook()
         result.end_tests()
         job.funcatexit.run()
         signal.signal(signal.SIGTSTP, signal.SIG_IGN)

--- a/avocado/plugins/sysinfo.py
+++ b/avocado/plugins/sysinfo.py
@@ -41,13 +41,13 @@ class SysInfoJob(JobPreTests, JobPostTests):
         if not self.sysinfo_enabled:
             return
         self._init_sysinfo(job.logdir)
-        self.sysinfo.start_job_hook()
+        self.sysinfo.start()
 
     def post_tests(self, job):
         if not self.sysinfo_enabled:
             return
         self._init_sysinfo(job.logdir)
-        self.sysinfo.end_job_hook()
+        self.sysinfo.end()
 
 
 class SysInfo(CLICmd):

--- a/avocado/plugins/sysinfo.py
+++ b/avocado/plugins/sysinfo.py
@@ -17,33 +17,34 @@ System information plugin
 
 from avocado.core.future.settings import settings
 from avocado.core.plugin_interfaces import CLICmd
-from avocado.core.plugin_interfaces import JobPre
-from avocado.core.plugin_interfaces import JobPost
+from avocado.core.plugin_interfaces import JobPreTests
+from avocado.core.plugin_interfaces import JobPostTests
 from avocado.core import sysinfo
 from avocado.utils import path
 
 
-class SysInfoJob(JobPre, JobPost):
+class SysInfoJob(JobPreTests, JobPostTests):
 
     name = 'sysinfo'
     description = 'Collects system information before/after the job is run'
 
-    def __init__(self):
+    def __init__(self, config):
         self.sysinfo = None
+        self.sysinfo_enabled = config.get('sysinfo.collect.enabled') == 'on'
 
     def _init_sysinfo(self, job_logdir):
         if self.sysinfo is None:
             basedir = path.init_dir(job_logdir, 'sysinfo')
             self.sysinfo = sysinfo.SysInfo(basedir=basedir)
 
-    def pre(self, job):
-        if job.config.get('sysinfo.collect.enabled') != 'on':
+    def pre_tests(self, job):
+        if not self.sysinfo_enabled:
             return
         self._init_sysinfo(job.logdir)
         self.sysinfo.start_job_hook()
 
-    def post(self, job):
-        if job.config.get('sysinfo.collect.enabled') != 'on':
+    def post_tests(self, job):
+        if not self.sysinfo_enabled:
             return
         self._init_sysinfo(job.logdir)
         self.sysinfo.end_job_hook()

--- a/optional_plugins/html/avocado_result_html/templates/results.html
+++ b/optional_plugins/html/avocado_result_html/templates/results.html
@@ -151,7 +151,7 @@
                     <div class="panel panel-default">
                       <div class="panel-heading" role="tab" id="{{ sysinfo.element_id }}">
                         <h4 class="panel-title">
-                          <a data-toggle="collapse" data-parent="#accordionPre2" href="#{{ sysinfo.collapse_id}}" aria-expanded="false" aria-controls="{{ sysinfo.collapse_id }}"><tt>{{ sysinfo.file }}</tt></a>
+                          <a data-toggle="collapse" data-parent="#accordionPre2" href="#{{ sysinfo.collapse_id }}" aria-expanded="false" aria-controls="{{ sysinfo.collapse_id }}"><tt>{{ sysinfo.file }}</tt></a>
                         </h4>
                       </div>
                       <div id="{{ sysinfo.collapse_id }}" class="panel-collapse collapse" role="tabpanel" aria-labelledby="{{ sysinfo.element_id }}">
@@ -186,7 +186,9 @@
                     {% for sysinfo in data.sysinfo_post %}
                     <div class="panel panel-default">
                       <div class="panel-heading" role="tab" id="{{ sysinfo.element_id }}">
-                        <h4 class="panel-title"><a data-toggle="collapse" data-parent="#accordionPost2" href="#{{ sysinfo.collapse_id }}" aria-expanded="false" aria-controls="{{ sysinfo.collapse_id }}"><tt>{{ sysinfo.file }}</tt></a></h4>
+                        <h4 class="panel-title">
+                          <a data-toggle="collapse" data-parent="#accordionPost2" href="#{{ sysinfo.collapse_id }}" aria-expanded="false" aria-controls="{{ sysinfo.collapse_id }}"><tt>{{ sysinfo.file }}</tt></a>
+                        </h4>
                       </div>
                       <div id="{{ sysinfo.collapse_id }}" class="panel-collapse collapse" role="tabpanel" aria-labelledby="{{ sysinfo.element_id }}">
                         <div class="panel-body">

--- a/optional_plugins/html/avocado_result_html/templates/results.html
+++ b/optional_plugins/html/avocado_result_html/templates/results.html
@@ -193,6 +193,12 @@
                       <div id="{{ sysinfo.collapse_id }}" class="panel-collapse collapse" role="tabpanel" aria-labelledby="{{ sysinfo.element_id }}">
                         <div class="panel-body">
                           <pre>{{ sysinfo.contents }}</pre>
+                          {% if 'err' in sysinfo %}
+                            <span>{{ sysinfo['err'] }}</span>
+                            <a href="{{ sysinfo['err_file'] }}">{{ sysinfo['err_file'] }}</a>
+                            <br />
+                            <span>{{ sysinfo['err_details'] }}</span>
+                          {% endif %}
                         </div>
                       </div>
                     </div>
@@ -223,6 +229,12 @@
                       <div id="{{ sysinfo.collapse_id }}" class="panel-collapse collapse" role="tabpanel" aria-labelledby="{{ sysinfo.element_id }}">
                         <div class="panel-body">
                           <pre>{{ sysinfo.contents }}</pre>
+                          {% if 'err' in sysinfo %}
+                            <span>{{ sysinfo['err'] }}</span>
+                            <a href="{{ sysinfo['err_file'] }}">{{ sysinfo['err_file'] }}</a>
+                            <br />
+                            <span>{{ sysinfo['err_details'] }}</span>
+                          {% endif %}
                         </div>
                       </div>
                     </div>

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -48,7 +48,6 @@ class JobTest(unittest.TestCase):
         self.assertIsNone(self.job.logfile)
         self.assertIsNone(self.job.replay_sourcejob)
         self.assertIsNone(self.job.result)
-        self.assertIsNone(self.job.sysinfo)
         self.assertIsNone(self.job.test_runner)
         self.assertIsNone(self.job.test_suite)
         self.assertIsNone(self.job.tmpdir)

--- a/selftests/unit/test_sysinfo.py
+++ b/selftests/unit/test_sysinfo.py
@@ -79,13 +79,13 @@ class SysinfoTest(unittest.TestCase):
         sysinfo_logger.end_test_hook()
         self.assertGreaterEqual(len(os.listdir(testdir)), 2,
                                 "Test does not have 'pre' dir")
-        job_postdir = os.path.join(testdir, 'post')
-        self.assertTrue(os.path.isdir(job_postdir))
+        test_postdir = os.path.join(testdir, 'post')
+        self.assertTrue(os.path.isdir(test_postdir))
         # By default, there are no post test files
-        self.assertLess(len(os.listdir(job_postdir)), 3,
+        self.assertLess(len(os.listdir(test_postdir)), 3,
                         "Post dir can contain 0-2 files depending on whether "
                         "sys messages are obtainable or not:\n%s"
-                        % os.listdir(job_postdir))
+                        % os.listdir(test_postdir))
 
     def tearDown(self):
         self.tmpdir.cleanup()

--- a/selftests/unit/test_sysinfo.py
+++ b/selftests/unit/test_sysinfo.py
@@ -51,41 +51,33 @@ class SysinfoTest(unittest.TestCase):
 
         self.assertEqual(len(container), 5)
 
-    def test_logger_job_hooks(self):
+    def test_logger_job(self):
         jobdir = os.path.join(self.tmpdir.name, 'job')
         sysinfo_logger = sysinfo.SysInfo(basedir=jobdir)
-        sysinfo_logger.start_job_hook()
+        sysinfo_logger.start()
         self.assertTrue(os.path.isdir(jobdir))
         self.assertGreaterEqual(len(os.listdir(jobdir)), 1,
                                 "Job does not have 'pre' dir")
         job_predir = os.path.join(jobdir, 'pre')
         self.assertTrue(os.path.isdir(job_predir))
-        sysinfo_logger.end_job_hook()
+        sysinfo_logger.end()
         job_postdir = os.path.join(jobdir, 'post')
         self.assertTrue(os.path.isdir(job_postdir))
 
-    def test_logger_test_hooks(self):
+    def test_logger_test(self):
         testdir = os.path.join(self.tmpdir.name, 'job', 'test1')
         sysinfo_logger = sysinfo.SysInfo(basedir=testdir)
-        sysinfo_logger.start_test_hook()
+        sysinfo_logger.start()
         self.assertTrue(os.path.isdir(testdir))
         self.assertGreaterEqual(len(os.listdir(testdir)), 1,
                                 "Test does not have 'pre' dir")
         test_predir = os.path.join(testdir, 'pre')
         self.assertTrue(os.path.isdir(test_predir))
-        # By default, there are no pre test files
-        self.assertEqual(len(os.listdir(test_predir)), 0,
-                         "Test pre dir is not empty")
-        sysinfo_logger.end_test_hook()
+        sysinfo_logger.end()
         self.assertGreaterEqual(len(os.listdir(testdir)), 2,
                                 "Test does not have 'pre' dir")
         test_postdir = os.path.join(testdir, 'post')
         self.assertTrue(os.path.isdir(test_postdir))
-        # By default, there are no post test files
-        self.assertLess(len(os.listdir(test_postdir)), 3,
-                        "Post dir can contain 0-2 files depending on whether "
-                        "sys messages are obtainable or not:\n%s"
-                        % os.listdir(test_postdir))
 
     def tearDown(self):
         self.tmpdir.cleanup()

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,6 @@ if __name__ == '__main__':
                   'teststmpdir = avocado.plugins.teststmpdir:TestsTmpDir',
                   'human = avocado.plugins.human:HumanJob',
                   'merge_files = avocado.plugins.expected_files_merge:FilesMerge',
-                  'sysinfo = avocado.plugins.sysinfo:SysInfoJob',
                   ],
               'avocado.plugins.result': [
                   'xunit = avocado.plugins.xunit:XUnitResult',
@@ -113,6 +112,7 @@ if __name__ == '__main__':
                   'tap = avocado.plugins.tap:TAPResult',
                   'journal = avocado.plugins.journal:JournalResult',
                   'fetchasset = avocado.plugins.assets:FetchAssetJob',
+                  'sysinfo = avocado.plugins.sysinfo:SysInfoJob',
                   ],
               'avocado.plugins.varianter': [
                   'json_variants = avocado.plugins.json_variants:JsonVariants',


### PR DESCRIPTION
The current implementation of per-test sysinfo collection is,
well, nasty.  It's called by the test itself, and not by whoever
is running the test.

With the world (including testing) moving to containers, and with the
parallel and very different approach of the Avocado N(ext) Runner,
this feature may be ressurrected, but it feels like it's going to
be completely different.

For instance, if running with a "process" spawner, the pre-test will
probably be done once before spawning a batch of tests (to avoid
changes in the same system caused by tests which are starting to run).
And when running with a "podman" spawner, it makes sense to either
capture the information from the container once, or even keep the
entire container instead?

Signed-off-by: Cleber Rosa <crosa@redhat.com>