### PR TITLE
future.settings: migrate --show to use the new API

### DIFF
--- a/avocado/core/app.py
+++ b/avocado/core/app.py
@@ -54,9 +54,9 @@ class AvocadoApp:
         self.parser.start()
         output.early_start()
 
-        show = getattr(self.parser.args, 'show', None)
+        show = getattr(self.parser.args, 'core.show')
         reconfigure_settings = {'core.paginator': 'off',
-                                'show': show}
+                                'core.show': show}
         try:
             self.cli_dispatcher = CLIDispatcher()
             self.cli_cmd_dispatcher = CLICmdDispatcher()

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -375,9 +375,7 @@ class Job:
                 self.__logging_handlers[handler] = [name]
 
         # Enable console loggers
-        # TODO: Fix this, this is one of the few cases where using the config
-        # generated from the new settings with a hardcoded 'default' value
-        enabled_logs = self.config.get("show", [])
+        enabled_logs = self.config.get("core.show")
         if ('test' in enabled_logs and
                 'early' not in enabled_logs):
             self._stdout_stderr = sys.stdout, sys.stderr
@@ -775,7 +773,7 @@ class TestProgram:
 
     def run_tests(self):
         self.config['standalone'] = True
-        self.config['show'] = ["test"]
+        self.config['core.show'] = ["test"]
         output.reconfigure(self.config)
         with Job(self.config) as self.job:
             exit_status = self.job.run()

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -406,10 +406,10 @@ def reconfigure(args):
     Adjust logging handlers accordingly to app args and re-log messages.
     """
     # Reconfigure stream loggers
-    enabled = args.get("show", None)
+    enabled = args.get("core.show")
     if not isinstance(enabled, list):
         enabled = ["app"]
-        args["show"] = enabled
+        args["core.show"] = enabled
     if "none" in enabled:
         del enabled[:]
     elif "all" in enabled:

--- a/avocado/core/parser.py
+++ b/avocado/core/parser.py
@@ -116,15 +116,18 @@ class Parser:
         streams = (['"%s": %s' % _ for _ in BUILTIN_STREAMS.items()] +
                    ['"%s": %s' % _ for _ in BUILTIN_STREAM_SETS.items()])
         streams = "; ".join(streams)
-        self.application.add_argument('--show', action="store",
-                                      type=lambda value: value.split(","),
-                                      metavar="STREAM[:LVL]", nargs='?',
-                                      default=['app'], help="List of comma "
-                                      "separated builtin logs, or logging "
-                                      "streams optionally followed by LEVEL "
-                                      "(DEBUG,INFO,...). Builtin streams "
-                                      "are: %s. By default: 'app'"
-                                      % streams)
+        help_msg = ("List of comma separated builtin logs, or logging streams "
+                    "optionally followed by LEVEL (DEBUG,INFO,...). Builtin "
+                    "streams are: %s. By default: 'app'" % streams)
+        future_settings.register_option(section='core',
+                                        key='show',
+                                        key_type=lambda x: x.split(','),
+                                        metavar="STREAM[:LVL]",
+                                        nargs='?',
+                                        default=['app'],
+                                        help_msg=help_msg,
+                                        parser=self.application,
+                                        long_arg='--show')
 
     def start(self):
         """

--- a/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
+++ b/optional_plugins/runner_remote/avocado_runner_remote/__init__.py
@@ -528,7 +528,7 @@ class RemoteTestRunner(Runner):
         fabric_logger.addHandler(file_handler)
         paramiko_logger.addHandler(file_handler)
         remote_logger.addHandler(file_handler)
-        if "test" in job.config.get("show", []):
+        if "test" in job.config.get("core.show"):
             output.add_log_handler(paramiko_logger.name)
         logger_list = [output.LOG_JOB]
         sys.stdout = output.LoggingFile(loggers=logger_list)

--- a/optional_plugins/runner_remote/tests/test_remote.py
+++ b/optional_plugins/runner_remote/tests/test_remote.py
@@ -62,6 +62,7 @@ class RemoteTestRunnerTest(unittest.TestCase):
                     'filter_by_tags_include_empty': False,
                     'env_keep': None,
                     'base_logdir': self.tmpdir.name,
+                    'core.show': ['test'],
                     'run.keep_tmp': 'on',
                     'run.store_logging_stream': [],
                     'run.dry_run.enabled': True,

--- a/optional_plugins/runner_vm/tests/test_vm.py
+++ b/optional_plugins/runner_vm/tests/test_vm.py
@@ -58,7 +58,8 @@ class VMTestRunnerSetup(unittest.TestCase):
                     'base_logdir': self.tmpdir.name,
                     'run.keep_tmp': 'on',
                     'run.store_logging_stream': [],
-                    'run.dry_run.enabled': True}
+                    'run.dry_run.enabled': True,
+                    'core.show': ['test']}
         with Job(job_args) as job:
             with unittest.mock.patch('avocado_runner_vm.vm_connect',
                                      return_value=mock_vm):

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -41,7 +41,7 @@ class JobTest(unittest.TestCase):
         config = {'job.output.loglevel': 'DEBUG',
                   'run.results_dir': self.tmpdir.name,
                   'run.store_logging_stream': [],
-                  'show': ['none']}
+                  'core.show': ['none']}
         self.job = job.Job(config)
         # Job without setup called
         self.assertIsNone(self.job.logdir)
@@ -76,14 +76,14 @@ class JobTest(unittest.TestCase):
 
     def test_job_empty_has_id(self):
         config = {'run.results_dir': self.tmpdir.name,
-                  'show': ['none']}
+                  'core.show': ['none']}
         self.job = job.Job(config)
         self.assertIsNotNone(self.job.unique_id)
 
     def test_two_jobs(self):
         config = {'run.results_dir': self.tmpdir.name,
                   'run.store_logging_stream': [],
-                  'show': ['none']}
+                  'core.show': ['none']}
         with job.Job(config) as self.job, job.Job(config) as job2:
             job1 = self.job
             # uids, logdirs and tmpdirs must be different
@@ -97,14 +97,14 @@ class JobTest(unittest.TestCase):
 
     def test_job_test_suite_not_created(self):
         config = {'run.results_dir': self.tmpdir.name,
-                  'show': ['none']}
+                  'core.show': ['none']}
         self.job = job.Job(config)
         self.assertIsNone(self.job.test_suite)
 
     def test_job_create_test_suite_empty(self):
         config = {'run.results_dir': self.tmpdir.name,
                   'run.store_logging_stream': [],
-                  'show': ['none']}
+                  'core.show': ['none']}
         self.job = job.Job(config)
         self.job.setup()
         self.assertRaises(exceptions.OptionValidationError,
@@ -112,7 +112,7 @@ class JobTest(unittest.TestCase):
 
     def test_job_create_test_suite_simple(self):
         simple_tests_found = self._find_simple_test_candidates()
-        config = {'show': ['none'],
+        config = {'core.show': ['none'],
                   'run.results_dir': self.tmpdir.name,
                   'run.store_logging_stream': [],
                   'run.references': simple_tests_found}
@@ -132,7 +132,7 @@ class JobTest(unittest.TestCase):
                 self.test_suite = filtered_test_suite
                 super(JobFilterTime, self).pre_tests()
         simple_tests_found = self._find_simple_test_candidates()
-        config = {'show': ['none'],
+        config = {'core.show': ['none'],
                   'run.results_dir': self.tmpdir.name,
                   'run.store_logging_stream': [],
                   'run.references': simple_tests_found}
@@ -147,7 +147,7 @@ class JobTest(unittest.TestCase):
 
     def test_job_run_tests(self):
         simple_tests_found = self._find_simple_test_candidates(['true'])
-        config = {'show': ['none'],
+        config = {'core.show': ['none'],
                   'run.results_dir': self.tmpdir.name,
                   'run.store_logging_stream': [],
                   'run.references': simple_tests_found}
@@ -164,7 +164,7 @@ class JobTest(unittest.TestCase):
                     f.write(self.unique_id[::-1])
                 super(JobLogPost, self).post_tests()
         simple_tests_found = self._find_simple_test_candidates()
-        config = {'show': ['none'],
+        config = {'core.show': ['none'],
                   'run.results_dir': self.tmpdir.name,
                   'run.store_logging_stream': [],
                   'run.references': simple_tests_found}
@@ -196,7 +196,7 @@ class JobTest(unittest.TestCase):
                     f.write(self.unique_id[::-1])
                 super(JobFilterLog, self).post_tests()
         simple_tests_found = self._find_simple_test_candidates()
-        config = {'show': ['none'],
+        config = {'core.show': ['none'],
                   'run.results_dir': self.tmpdir.name,
                   'run.store_logging_stream': [],
                   'run.references': simple_tests_found}
@@ -210,7 +210,7 @@ class JobTest(unittest.TestCase):
                              reverse_id_file.read())
 
     def test_job_run_account_time(self):
-        config = {'show': ['none'],
+        config = {'core.show': ['none'],
                   'run.results_dir': self.tmpdir.name,
                   'run.store_logging_stream': []}
         self.job = job.Job(config)
@@ -224,7 +224,7 @@ class JobTest(unittest.TestCase):
         self.assertNotEqual(self.job.time_elapsed, -1)
 
     def test_job_self_account_time(self):
-        config = {'show': ['none'],
+        config = {'core.show': ['none'],
                   'run.results_dir': self.tmpdir.name,
                   'run.store_logging_stream': []}
         self.job = job.Job(config)
@@ -246,13 +246,13 @@ class JobTest(unittest.TestCase):
         config = {'run.results_dir': self.tmpdir.name,
                   'run.store_logging_stream': [],
                   'run.dry_run.enabled': True,
-                  'show': ['none']}
+                  'core.show': ['none']}
         self.job = job.Job(config)
         self.job.setup()
         self.assertIsNotNone(self.job.config.get('run.unique_job_id'))
 
     def test_job_no_base_logdir(self):
-        config = {'show': ['none'],
+        config = {'core.show': ['none'],
                   'run.store_logging_stream': []}
         with unittest.mock.patch('avocado.core.job.data_dir.get_logs_dir',
                                  return_value=self.tmpdir.name):
@@ -263,7 +263,7 @@ class JobTest(unittest.TestCase):
         self.assertTrue(os.path.isfile(os.path.join(self.job.logdir, 'id')))
 
     def test_job_dryrun_no_base_logdir(self):
-        config = {'show': ['none'],
+        config = {'core.show': ['none'],
                   'run.store_logging_stream': [],
                   'run.dry_run.enabled': True}
         self.job = job.Job(config)
@@ -278,7 +278,7 @@ class JobTest(unittest.TestCase):
                   'run.store_logging_stream': [],
                   'nrun.references': simple_tests_found,
                   'run.test_runner': 'nrunner',
-                  'show': ['none']}
+                  'core.show': ['none']}
         self.job = job.Job(config)
         self.job.setup()
         self.job.create_test_suite()


### PR DESCRIPTION
As part of the effort to remove default values scattered around the
code, this change only migrates the core option --show
option to use the new settings API.

Signed-off-by: Beraldo Leal <bleal@redhat.com>