### PR TITLE
Job API: fixes and jobs as tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ AVOCADO_OPTIONAL_PLUGINS_TESTS=$(patsubst %,%/tests/, $(AVOCADO_OPTIONAL_PLUGINS
 endif
 check: clean develop
 	# Unless manually set, this is equivalent to AVOCADO_CHECK_LEVEL=0
-	PYTHON=$(PYTHON) $(PYTHON) -m avocado nrun selftests/*.sh selftests/unit/ selftests/functional/ $(AVOCADO_OPTIONAL_PLUGINS_TESTS)
+	PYTHON=$(PYTHON) $(PYTHON) -m avocado nrun selftests/*.sh selftests/unit/ selftests/functional/ selftests/jobs/ $(AVOCADO_OPTIONAL_PLUGINS_TESTS)
 	selftests/check_tmp_dirs
 
 develop:

--- a/avocado/core/__init__.py
+++ b/avocado/core/__init__.py
@@ -11,3 +11,26 @@
 #
 # Copyright: Red Hat Inc. 2013-2014
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+
+
+from .future.settings import settings as future_settings
+from .output import BUILTIN_STREAMS, BUILTIN_STREAM_SETS
+
+
+def register_core_options():
+    streams = (['"%s": %s' % _ for _ in BUILTIN_STREAMS.items()] +
+               ['"%s": %s' % _ for _ in BUILTIN_STREAM_SETS.items()])
+    streams = "; ".join(streams)
+    help_msg = ("List of comma separated builtin logs, or logging streams "
+                "optionally followed by LEVEL (DEBUG,INFO,...). Builtin "
+                "streams are: %s. By default: 'app'" % streams)
+    future_settings.register_option(section='core',
+                                    key='show',
+                                    key_type=lambda x: x.split(','),
+                                    metavar="STREAM[:LVL]",
+                                    nargs='?',
+                                    default=['app'],
+                                    help_msg=help_msg)
+
+
+register_core_options()

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -557,8 +557,6 @@ class Job:
         This is a public Job API as part of the documented Job phases
         """
         refs = self.config.get('run.references')
-        if not refs:
-            refs = self.config.get('nrun.references')
         try:
             if self._test_runner_name == 'nrunner':
                 self.test_suite = self._make_test_suite_resolver(refs)
@@ -595,8 +593,6 @@ class Job:
         """
         variant = self.config.get("avocado_variants")
         refs = self.config.get('run.references')
-        if not refs:
-            refs = self.config.get('nrun.references')
         if variant is None:
             variant = varianter.Varianter()
         if not variant.is_parsed():   # Varianter not yet parsed, apply args

--- a/avocado/core/parser.py
+++ b/avocado/core/parser.py
@@ -27,7 +27,7 @@ from . import varianter
 from . import settings
 from .future.settings import settings as future_settings
 from .nrunner import Runnable
-from .output import BUILTIN_STREAMS, BUILTIN_STREAM_SETS, LOG_UI
+from .output import LOG_UI
 from .resolver import ReferenceResolution
 from .resolver import ReferenceResolutionResult
 from .version import VERSION
@@ -113,21 +113,9 @@ class Parser:
                                         long_arg='--verbose',
                                         short_arg='-V')
 
-        streams = (['"%s": %s' % _ for _ in BUILTIN_STREAMS.items()] +
-                   ['"%s": %s' % _ for _ in BUILTIN_STREAM_SETS.items()])
-        streams = "; ".join(streams)
-        help_msg = ("List of comma separated builtin logs, or logging streams "
-                    "optionally followed by LEVEL (DEBUG,INFO,...). Builtin "
-                    "streams are: %s. By default: 'app'" % streams)
-        future_settings.register_option(section='core',
-                                        key='show',
-                                        key_type=lambda x: x.split(','),
-                                        metavar="STREAM[:LVL]",
-                                        nargs='?',
-                                        default=['app'],
-                                        help_msg=help_msg,
-                                        parser=self.application,
-                                        long_arg='--show')
+        future_settings.add_argparser_to_option(namespace='core.show',
+                                                parser=self.application,
+                                                long_arg='--show')
 
     def start(self):
         """

--- a/selftests/jobs/pass
+++ b/selftests/jobs/pass
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+# Minimal job that runs an also mininal executable test
+
+import os
+import sys
+from avocado.core.job import Job
+
+config = {'run.references': [os.path.join(os.path.dirname(__file__), 'tests', 'pass')],
+          # This creates the temporary directory along the results directory
+          # preventing a failure from the "selftests/check_tmp_dirs" that runs
+          # right after the tests in Avocado's "make check" rule
+          'run.keep_tmp': 'on'}
+
+with Job(config) as j:
+    sys.exit(j.run())

--- a/selftests/jobs/tests/pass
+++ b/selftests/jobs/tests/pass
@@ -1,0 +1,2 @@
+#!/bin/sh
+exit 0

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -275,7 +275,7 @@ class JobTest(unittest.TestCase):
         simple_tests_found = self._find_simple_test_candidates()
         config = {'run.results_dir': self.tmpdir.name,
                   'run.store_logging_stream': [],
-                  'nrun.references': simple_tests_found,
+                  'run.references': simple_tests_found,
                   'run.test_runner': 'nrunner',
                   'core.show': ['none']}
         self.job = job.Job(config)


### PR DESCRIPTION
This restores the job API usage, which was broken by 89e07d6f6ffb3180851471f9e471d96d7212a7a2, and adds a job as selftests, to avoid regressions.