### PR TITLE
Tags: make the registration of options generic to many commands

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -90,8 +90,7 @@ def resolutions_to_tasks(resolutions, config):
     resolutions = [res for res in resolutions if
                    res.result == resolver.ReferenceResolutionResult.SUCCESS]
     no_digits = len(str(len(resolutions)))
-    sub_cmd = config.get('subcommand')
-    filter_by_tags = config.get("{}.filter_by_tags".format(sub_cmd))
+    filter_by_tags = config.get("filter_by_tags.tags")
     for resolution in resolutions:
         name = resolution.reference
         for runnable in resolution.resolutions:
@@ -99,8 +98,8 @@ def resolutions_to_tasks(resolutions, config):
                 if not filter_test_tags_runnable(
                         runnable,
                         filter_by_tags,
-                        config.get("{}.filter_by_tags_include_empty".format(sub_cmd)),
-                        config.get('{}.filter_by_tags_include_empty_key'.format(sub_cmd))):
+                        config.get("filter_by_tags.include_empty"),
+                        config.get('filter_by_tags.include_empty_key')):
                     continue
             if runnable.uri:
                 name = runnable.uri
@@ -439,17 +438,16 @@ class Job:
         :returns: a test suite (a list of test factories)
         """
         loader.loader.load_plugins(self.config)
-        sub_cmd = self.config.get('subcommand')
         try:
             force = self.config.get('run.ignore_missing_references')
             suite = loader.loader.discover(references, force=force)
-            filter_tags = self.config.get("{}.filter_by_tags".format(sub_cmd))
+            filter_tags = self.config.get("filter_by_tags.tags")
             if filter_tags:
                 suite = tags.filter_test_tags(
                     suite,
                     filter_tags,
-                    self.config.get("{}.filter_by_tags_include_empty".format(sub_cmd)),
-                    self.config.get('{}.filter_by_tags_include_empty_key'.format(sub_cmd)))
+                    self.config.get("filter_by_tags.include_empty"),
+                    self.config.get('filter_by_tags.include_empty_key'))
         except loader.LoaderUnhandledReferenceError as details:
             raise exceptions.OptionValidationError(details)
         except KeyboardInterrupt:

--- a/avocado/core/parser_common_args.py
+++ b/avocado/core/parser_common_args.py
@@ -15,10 +15,11 @@
 from .future.settings import settings
 
 
-def add_tag_filter_args(parser, section):
+def add_tag_filter_args(parser):
+    section = 'filter_by_tags'
     group = parser.add_argument_group('filtering parameters')
     settings.register_option(section=section,
-                             key='filter_by_tags',
+                             key='tags',
                              help_msg='Filter tests based on tags',
                              action='append',
                              key_type=list,
@@ -26,26 +27,29 @@ def add_tag_filter_args(parser, section):
                              metavar='TAGS',
                              parser=group,
                              short_arg='-t',
-                             long_arg='--filter-by-tags')
+                             long_arg='--filter-by-tags',
+                             allow_multiple=True)
 
     help_msg = ('Include all tests without tags during filtering. This '
                 'effectively means they will be kept in the test suite '
                 'found previously to filtering.')
     settings.register_option(section=section,
-                             key='filter_by_tags_include_empty',
+                             key='include_empty',
                              default=False,
                              key_type=bool,
                              help_msg=help_msg,
                              parser=group,
-                             long_arg='--filter-by-tags-include-empty')
+                             long_arg='--filter-by-tags-include-empty',
+                             allow_multiple=True)
 
     help_msg = ('Include all tests that do not have a matching key in its '
                 'key:val tags. This effectively means those tests will be '
                 'kept in the test suite found previously to filtering.')
     settings.register_option(section=section,
-                             key='filter_by_tags_include_empty_key',
+                             key='include_empty_key',
                              default=False,
                              key_type=bool,
                              help_msg=help_msg,
                              parser=group,
-                             long_arg='--filter-by-tags-include-empty-key')
+                             long_arg='--filter-by-tags-include-empty-key',
+                             allow_multiple=True)

--- a/avocado/plugins/list.py
+++ b/avocado/plugins/list.py
@@ -173,7 +173,7 @@ class List(CLICmd):
                                  parser=parser,
                                  positional_arg=True)
         loader.add_loader_options(parser, 'list')
-        parser_common_args.add_tag_filter_args(parser, 'list')
+        parser_common_args.add_tag_filter_args(parser)
 
     def run(self, config):
         test_lister = TestLister(config)

--- a/avocado/plugins/nlist.py
+++ b/avocado/plugins/nlist.py
@@ -66,7 +66,7 @@ class List(CLICmd):
                                  parser=parser,
                                  long_arg='--write-recipes-to-directory')
 
-        parser_common_args.add_tag_filter_args(parser, 'nlist')
+        parser_common_args.add_tag_filter_args(parser)
 
     def run(self, config):
         references = config.get('nlist.references')

--- a/avocado/plugins/nrun.py
+++ b/avocado/plugins/nrun.py
@@ -72,7 +72,7 @@ class NRun(CLICmd):
                                  parser=parser,
                                  long_arg="--spawner")
 
-        parser_common_args.add_tag_filter_args(parser, 'nrun')
+        parser_common_args.add_tag_filter_args(parser)
 
     async def spawn_tasks(self, parallel_tasks):
         while True:

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -279,7 +279,7 @@ class Run(CLICmd):
                                  long_arg='--output-check')
 
         loader.add_loader_options(parser, 'run')
-        parser_common_args.add_tag_filter_args(parser, 'run')
+        parser_common_args.add_tag_filter_args(parser)
 
     def run(self, config):
         """

--- a/selftests/pre_release/jobs/timesensitive.py
+++ b/selftests/pre_release/jobs/timesensitive.py
@@ -11,9 +11,11 @@ ROOT_DIR = os.path.dirname(os.path.dirname(os.path.dirname(THIS_DIR)))
 
 CONFIG = {
     'run.test_runner': 'nrunner',
-    'nrun.references': [os.path.join(ROOT_DIR, 'selftests', 'unit'),
-                        os.path.join(ROOT_DIR, 'selftests', 'functional')],
-    'filter_by_tags': ['parallel:1'],
+    'run.references': [os.path.join(ROOT_DIR, 'selftests', 'unit'),
+                       os.path.join(ROOT_DIR, 'selftests', 'functional')],
+    # FIXME: when using the job API, there's no command to be registered as part
+    # of the section name
+    'None.filter_by_tags': ['parallel:1'],
     # These are not currently supported by plugins/runner_nrunner.py, but better
     # be prepared
     'nrun.parallel_tasks': 1,

--- a/selftests/pre_release/jobs/timesensitive.py
+++ b/selftests/pre_release/jobs/timesensitive.py
@@ -13,9 +13,7 @@ CONFIG = {
     'run.test_runner': 'nrunner',
     'run.references': [os.path.join(ROOT_DIR, 'selftests', 'unit'),
                        os.path.join(ROOT_DIR, 'selftests', 'functional')],
-    # FIXME: when using the job API, there's no command to be registered as part
-    # of the section name
-    'None.filter_by_tags': ['parallel:1'],
+    'filter_by_tags.tags': ['parallel:1'],
     # These are not currently supported by plugins/runner_nrunner.py, but better
     # be prepared
     'nrun.parallel_tasks': 1,

--- a/selftests/unit/test_future_settings.py
+++ b/selftests/unit/test_future_settings.py
@@ -90,6 +90,19 @@ class SettingsTest(unittest.TestCase):
         stgs.add_argparser_to_option('section.key', parser, '--other-arg',
                                      allow_multiple=True)
 
+    def test_multiple_parsers(self):
+        stgs = settings.Settings(self.config_file.name)
+        parser1 = argparse.ArgumentParser(description='description')
+        stgs.register_option('section', 'key', 'default', 'help',
+                             parser=parser1, long_arg='--first-option')
+        parser2 = argparse.ArgumentParser(description='other description')
+        with self.assertRaises(settings.DuplicatedNamespace):
+            stgs.register_option('section', 'key', 'default', 'help',
+                                 parser=parser2, long_arg='--other-option')
+        stgs.register_option('section', 'key', 'default', 'help',
+                             parser=parser2, long_arg='--other-option',
+                             allow_multiple=True)
+
     def tearDown(self):
         os.unlink(self.config_file.name)
 


### PR DESCRIPTION
Which is needed to fix the `timesensitive.py` breakage with filtering by tags not being applied (or having a section name including `None`.