### PR TITLE
Nrunner: fix Test IDs

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -54,7 +54,6 @@ from .output import STD_OUTPUT
 from .future.settings import settings
 from .tags import filter_test_tags_runnable
 from .test import DryRunTest
-from .test_id import TestID
 
 
 _NEW_ISSUE_LINK = 'https://github.com/avocado-framework/avocado/issues/new'
@@ -72,10 +71,9 @@ def resolutions_to_tasks(resolutions, config):
     :class:`avocado.core.nrunner.Runnable`.
 
     This method transforms those runnables into Tasks
-    (:class:`avocado.core.nrunner.Task`), which will include an
-    unique sequential identification and a status reporting URI.
-    It also performs tag based filtering on the runnables for
-    possibly excluding some of the Runnables.
+    (:class:`avocado.core.nrunner.Task`), which will include a status
+    reporting URI.  It also performs tag based filtering on the
+    runnables for possibly excluding some of the Runnables.
 
     :param resolutions: possible multiple resolutions for multiple
                         references
@@ -87,14 +85,11 @@ def resolutions_to_tasks(resolutions, config):
     """
 
     tasks = []
-    index = 0
     resolutions = [res for res in resolutions if
                    res.result == resolver.ReferenceResolutionResult.SUCCESS]
-    no_digits = len(str(len(resolutions)))
     sub_cmd = config.get('subcommand')
     filter_by_tags = config.get("{}.filter_by_tags".format(sub_cmd))
     for resolution in resolutions:
-        name = resolution.reference
         for runnable in resolution.resolutions:
             if filter_by_tags:
                 if not filter_test_tags_runnable(
@@ -103,13 +98,9 @@ def resolutions_to_tasks(resolutions, config):
                         config.get("{}.filter_by_tags_include_empty".format(sub_cmd)),
                         config.get('{}.filter_by_tags_include_empty_key'.format(sub_cmd))):
                     continue
-            if runnable.uri:
-                name = runnable.uri
-            identifier = str(TestID(index + 1, name, None, no_digits))
             status_server = config.get('nrun.status_server.listen')
-            tasks.append(nrunner.Task(identifier, runnable,
+            tasks.append(nrunner.Task(None, runnable,
                                       [status_server]))
-            index += 1
     return tasks
 
 

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -41,7 +41,6 @@ from . import output
 from . import resolver
 from . import result
 from . import tags
-from . import test
 from . import varianter
 from . import version
 from ..utils import astring
@@ -54,6 +53,8 @@ from .output import LOG_UI
 from .output import STD_OUTPUT
 from .future.settings import settings
 from .tags import filter_test_tags_runnable
+from .test import DryRunTest
+from .test_id import TestID
 
 
 _NEW_ISSUE_LINK = 'https://github.com/avocado-framework/avocado/issues/new'
@@ -104,7 +105,7 @@ def resolutions_to_tasks(resolutions, config):
                     continue
             if runnable.uri:
                 name = runnable.uri
-            identifier = str(test.TestID(index + 1, name, None, no_digits))
+            identifier = str(TestID(index + 1, name, None, no_digits))
             status_server = config.get('nrun.status_server.listen')
             tasks.append(nrunner.Task(identifier, runnable,
                                       [status_server]))
@@ -458,7 +459,7 @@ class Job:
         if not self.config.get('run.dry_run.enabled'):
             return suite
         for i in range(len(suite)):
-            suite[i] = [test.DryRunTest, suite[i][1]]
+            suite[i] = [DryRunTest, suite[i][1]]
         return suite
 
     def _make_test_suite_resolver(self, references):

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -48,6 +48,7 @@ from ..utils import process
 from ..utils import stacktrace
 from .decorators import skip
 from .settings import settings
+from .test_id import TestID
 from .version import VERSION
 from .output import LOG_JOB
 
@@ -89,88 +90,6 @@ class RawFileHandler(logging.FileHandler):
             self.flush()
         except Exception:  # pylint: disable=W0703
             self.handleError(record)
-
-
-class TestID:
-
-    """
-    Test ID construction and representation according to specification
-
-    This class wraps the representation of both Avocado's Test ID
-    specification and Avocado's Test Name, which is part of a Test ID.
-    """
-
-    def __init__(self, uid, name, variant=None, no_digits=None):
-        """
-        Constructs a TestID instance
-
-        :param uid: unique test id (within the job)
-        :param name: test name, as returned by the Avocado test resolver
-                     (AKA as test loader)
-        :param variant: the variant applied to this Test ID
-        :type variant: dict
-        :param no_digits: number of digits of the test uid
-        """
-        self.uid = uid
-        if no_digits is not None and no_digits >= 0:
-            self.str_uid = str(uid).zfill(no_digits if no_digits else 3)
-        else:
-            self.str_uid = str(uid)
-        self.name = name or "<unknown>"
-        if variant is None or variant["variant_id"] is None:
-            self.variant = None
-            self.str_variant = ""
-        else:
-            self.variant = variant["variant_id"]
-            self.str_variant = ";%s" % self.variant
-
-    def __str__(self):
-        return "%s-%s%s" % (self.str_uid, self.name, self.str_variant)
-
-    def __repr__(self):
-        return repr(str(self))
-
-    def __eq__(self, other):
-        if isinstance(other, str):
-            return str(self) == other
-        else:
-            return self.__dict__ == other.__dict__
-
-    @property
-    def str_filesystem(self):
-        """
-        Test ID in a format suitable for use in file systems
-
-        The string returned should be safe to be used as a file or
-        directory name.  This file system version of the test ID may
-        have to shorten either the Test Name or the Variant ID.
-
-        The first component of a Test ID, the numeric unique test id,
-        AKA "uid", will be used as a an stable identifier between the
-        Test ID and the file or directory created based on the return
-        value of this method.  If the filesystem can not even
-        represent the "uid", than an exception will be raised.
-
-        For Test ID "001-mytest;foo", examples of shortened file
-        system versions include "001-mytest;f" or "001-myte;foo".
-
-        :raises: RuntimeError if the test ID cannot be converted to a
-                 filesystem representation.
-        """
-        test_id = str(self)
-        test_id_fs = astring.string_to_safe_path(test_id)
-        if len(test_id) == len(test_id_fs):    # everything fits in
-            return test_id_fs
-        idx_fit_variant = len(test_id_fs) - len(self.str_variant)
-        if idx_fit_variant > len(self.str_uid):     # full uid+variant
-            return (test_id_fs[:idx_fit_variant] +
-                    astring.string_to_safe_path(self.str_variant))
-        elif len(self.str_uid) <= len(test_id_fs):   # full uid
-            return astring.string_to_safe_path(self.str_uid + self.str_variant)
-        else:       # not even uid could be stored in fs
-            raise RuntimeError('Test ID is too long to be stored on the '
-                               'filesystem: "%s"\nFull Test ID: "%s"'
-                               % (self.str_uid, str(self)))
 
 
 class TestData:

--- a/avocado/core/test_id.py
+++ b/avocado/core/test_id.py
@@ -1,0 +1,83 @@
+from ..utils import astring
+
+
+class TestID:
+
+    """
+    Test ID construction and representation according to specification
+
+    This class wraps the representation of both Avocado's Test ID
+    specification and Avocado's Test Name, which is part of a Test ID.
+    """
+
+    def __init__(self, uid, name, variant=None, no_digits=None):
+        """
+        Constructs a TestID instance
+
+        :param uid: unique test id (within the job)
+        :param name: test name, as returned by the Avocado test resolver
+                     (AKA as test loader)
+        :param variant: the variant applied to this Test ID
+        :type variant: dict
+        :param no_digits: number of digits of the test uid
+        """
+        self.uid = uid
+        if no_digits is not None and no_digits >= 0:
+            self.str_uid = str(uid).zfill(no_digits if no_digits else 3)
+        else:
+            self.str_uid = str(uid)
+        self.name = name or "<unknown>"
+        if variant is None or variant["variant_id"] is None:
+            self.variant = None
+            self.str_variant = ""
+        else:
+            self.variant = variant["variant_id"]
+            self.str_variant = ";%s" % self.variant
+
+    def __str__(self):
+        return "%s-%s%s" % (self.str_uid, self.name, self.str_variant)
+
+    def __repr__(self):
+        return repr(str(self))
+
+    def __eq__(self, other):
+        if isinstance(other, str):
+            return str(self) == other
+        else:
+            return self.__dict__ == other.__dict__
+
+    @property
+    def str_filesystem(self):
+        """
+        Test ID in a format suitable for use in file systems
+
+        The string returned should be safe to be used as a file or
+        directory name.  This file system version of the test ID may
+        have to shorten either the Test Name or the Variant ID.
+
+        The first component of a Test ID, the numeric unique test id,
+        AKA "uid", will be used as a an stable identifier between the
+        Test ID and the file or directory created based on the return
+        value of this method.  If the filesystem can not even
+        represent the "uid", than an exception will be raised.
+
+        For Test ID "001-mytest;foo", examples of shortened file
+        system versions include "001-mytest;f" or "001-myte;foo".
+
+        :raises: RuntimeError if the test ID cannot be converted to a
+                 filesystem representation.
+        """
+        test_id = str(self)
+        test_id_fs = astring.string_to_safe_path(test_id)
+        if len(test_id) == len(test_id_fs):    # everything fits in
+            return test_id_fs
+        idx_fit_variant = len(test_id_fs) - len(self.str_variant)
+        if idx_fit_variant > len(self.str_uid):     # full uid+variant
+            return (test_id_fs[:idx_fit_variant] +
+                    astring.string_to_safe_path(self.str_variant))
+        elif len(self.str_uid) <= len(test_id_fs):   # full uid
+            return astring.string_to_safe_path(self.str_uid + self.str_variant)
+        else:       # not even uid could be stored in fs
+            raise RuntimeError('Test ID is too long to be stored on the '
+                               'filesystem: "%s"\nFull Test ID: "%s"'
+                               % (self.str_uid, str(self)))

--- a/avocado/plugins/nrun.py
+++ b/avocado/plugins/nrun.py
@@ -14,6 +14,7 @@ from avocado.core.spawners.podman import PodmanSpawner
 from avocado.core.future.settings import settings
 from avocado.core.output import LOG_UI
 from avocado.core.parser import HintParser
+from avocado.core.test_id import TestID
 from avocado.core.plugin_interfaces import CLICmd
 
 
@@ -126,6 +127,9 @@ class NRun(CLICmd):
         if not self.pending_tasks:
             LOG_UI.error('No test to be executed, exiting...')
             sys.exit(exit_codes.AVOCADO_JOB_FAIL)
+
+        for index, task in enumerate(self.pending_tasks, start=1):
+            task.identifier = str(TestID(index, task.runnable.uri))
 
         if not config.get('nrun.disable_task_randomization'):
             random.shuffle(self.pending_tasks)

--- a/avocado/plugins/runner.py
+++ b/avocado/plugins/runner.py
@@ -32,7 +32,6 @@ from avocado.utils import wait
 from avocado.core import defaults
 from avocado.core import output
 from avocado.core import status
-from avocado.core import test
 from avocado.core import tree
 from avocado.core import varianter
 from avocado.core.loader import loader
@@ -43,6 +42,8 @@ from avocado.core.runner import add_runner_failure
 from avocado.core.runner import TestStatus
 from avocado.core.settings import settings
 from avocado.core.status import mapping
+from avocado.core.test import TimeOutSkipTest
+from avocado.core.test_id import TestID
 
 
 class TestRunner(Runner):
@@ -393,14 +394,14 @@ class TestRunner(Runner):
                 index += 1
                 test_parameters = test_factory[1]
                 name = test_parameters.get("name")
-                test_parameters["name"] = test.TestID(index + 1, name,
-                                                      variant,
-                                                      no_digits)
+                test_parameters["name"] = TestID(index + 1, name,
+                                                 variant,
+                                                 no_digits)
                 if deadline is not None and time.time() > deadline:
                     summary.add('INTERRUPTED')
                     if 'methodName' in test_parameters:
                         del test_parameters['methodName']
-                    test_factory = (test.TimeOutSkipTest, test_parameters)
+                    test_factory = (TimeOutSkipTest, test_parameters)
                     if not self.run_test(job, result, test_factory, queue, summary):
                         break
                 else:

--- a/avocado/plugins/runner.py
+++ b/avocado/plugins/runner.py
@@ -380,7 +380,7 @@ class TestRunner(Runner):
         test_result_total = variants.get_number_of_tests(test_suite)
         no_digits = len(str(test_result_total))
         result.tests_total = test_result_total
-        index = -1
+        index = 1
         try:
             for test_factory in test_suite:
                 test_factory[1]["base_logdir"] = job.logdir
@@ -391,10 +391,9 @@ class TestRunner(Runner):
                                                           test_suite,
                                                           variants,
                                                           execution_order):
-                index += 1
                 test_parameters = test_factory[1]
                 name = test_parameters.get("name")
-                test_parameters["name"] = TestID(index + 1, name,
+                test_parameters["name"] = TestID(index, name,
                                                  variant,
                                                  no_digits)
                 if deadline is not None and time.time() > deadline:
@@ -406,13 +405,14 @@ class TestRunner(Runner):
                         break
                 else:
                     if (replay_map is not None and
-                            replay_map[index] is not None):
+                            replay_map[index - 1] is not None):
                         test_parameters["methodName"] = "test"
                         test_factory = (replay_map[index], test_parameters)
 
                     if not self.run_test(job, result, test_factory, queue, summary,
                                          deadline):
                         break
+                index += 1
         except KeyboardInterrupt:
             TEST_LOG.error('Job interrupted by ctrl+c.')
             summary.add('INTERRUPTED')

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -80,12 +80,11 @@ class Runner(RunnerInterface):
         result.tests_total = len(test_suite)  # no support for variants yet
         result_dispatcher = job.result_events_dispatcher
 
-        for index, task in enumerate(test_suite):
+        for index, task in enumerate(test_suite, start=1):
             if deadline is not None and time.time() > deadline:
                 break
 
             task.known_runners = nrunner.RUNNERS_REGISTRY_PYTHON_CLASS
-            index += 1
             # this is all rubbish data
             early_state = {
                 'name': TestID(index, task.identifier),

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -22,8 +22,8 @@ import time
 
 from copy import copy
 
-from avocado.core import test
 from avocado.core.plugin_interfaces import Runner as RunnerInterface
+from avocado.core.test_id import TestID
 
 from avocado.core import nrunner
 
@@ -88,7 +88,7 @@ class Runner(RunnerInterface):
             index += 1
             # this is all rubbish data
             early_state = {
-                'name': test.TestID(index, task.identifier),
+                'name': TestID(index, task.identifier),
                 'job_logdir': job.logdir,
                 'job_unique_id': job.unique_id,
             }

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -79,6 +79,7 @@ class Runner(RunnerInterface):
         test_suite, _ = nrunner.check_tasks_requirements(test_suite)
         result.tests_total = len(test_suite)  # no support for variants yet
         result_dispatcher = job.result_events_dispatcher
+        no_digits = len(str(len(test_suite)))
 
         for index, task in enumerate(test_suite, start=1):
             if deadline is not None and time.time() > deadline:
@@ -86,8 +87,10 @@ class Runner(RunnerInterface):
 
             task.known_runners = nrunner.RUNNERS_REGISTRY_PYTHON_CLASS
             # this is all rubbish data
+            test_id = TestID(index, task.runnable.uri, None, no_digits)
+            task.identifier = str(test_id)
             early_state = {
-                'name': TestID(index, task.identifier),
+                'name': test_id,
                 'job_logdir': job.logdir,
                 'job_unique_id': job.unique_id,
             }

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -4,6 +4,7 @@ import tempfile
 import unittest.mock
 
 from avocado.core import test
+from avocado.core.test_id import TestID
 from avocado.core import loader
 from avocado.utils import script
 
@@ -178,7 +179,7 @@ class LoaderTest(unittest.TestCase):
         test_class, test_parameters = (
             self.loader.discover(simple_test.path, loader.DiscoverMode.ALL)[0])
         self.assertTrue(test_class == test.SimpleTest, test_class)
-        test_parameters['name'] = test.TestID(0, test_parameters['name'])
+        test_parameters['name'] = TestID(0, test_parameters['name'])
         test_parameters['base_logdir'] = self.tmpdir.name
         tc = test_class(**test_parameters)
         tc.run_avocado()
@@ -224,7 +225,7 @@ class LoaderTest(unittest.TestCase):
         test_class, test_parameters = (
             self.loader.discover(avocado_not_a_test.path, loader.DiscoverMode.ALL)[0])
         self.assertTrue(test_class == test.SimpleTest, test_class)
-        test_parameters['name'] = test.TestID(0, test_parameters['name'])
+        test_parameters['name'] = TestID(0, test_parameters['name'])
         test_parameters['base_logdir'] = self.tmpdir.name
         tc = test_class(**test_parameters)
         # The test can't be executed (no shebang), raising an OSError
@@ -240,7 +241,7 @@ class LoaderTest(unittest.TestCase):
             test_class, test_parameters = (
                 self.loader.discover(avocado_simple_test.path, loader.DiscoverMode.ALL)[0])
             self.assertTrue(test_class == test.SimpleTest)
-            test_parameters['name'] = test.TestID(0, test_parameters['name'])
+            test_parameters['name'] = TestID(0, test_parameters['name'])
             test_parameters['base_logdir'] = self.tmpdir.name
             tc = test_class(**test_parameters)
             tc.run_avocado()

--- a/selftests/unit/test_test_id.py
+++ b/selftests/unit/test_test_id.py
@@ -1,0 +1,86 @@
+import unittest
+
+from avocado.core.test_id import TestID
+from avocado.utils import astring
+
+
+class Test(unittest.TestCase):
+
+    def test_uid_name(self):
+        uid = 1
+        name = 'file.py:klass.test_method'
+        test_id = TestID(uid, name)
+        self.assertEqual(test_id.uid, 1)
+        self.assertEqual(test_id.str_uid, '1')
+        self.assertEqual(test_id.str_filesystem,
+                         astring.string_to_safe_path('%s-%s' % (uid, name)))
+        self.assertIs(test_id.variant, None)
+        self.assertIs(test_id.str_variant, '')
+
+    def test_uid_name_no_digits(self):
+        uid = 1
+        name = 'file.py:klass.test_method'
+        test_id = TestID(uid, name, no_digits=2)
+        self.assertEqual(test_id.uid, 1)
+        self.assertEqual(test_id.str_uid, '01')
+        self.assertEqual(test_id.str_filesystem,
+                         astring.string_to_safe_path('%s-%s' % ('01', name)))
+        self.assertIs(test_id.variant, None)
+        self.assertIs(test_id.str_variant, '')
+
+    def test_uid_name_large_digits(self):
+        """
+        Tests that when the filesystem can only cope with the size of
+        the Test ID, that's the only thing that will be kept.
+        """
+        uid = 1
+        name = 'test'
+        test_id = TestID(uid, name, no_digits=255)
+        self.assertEqual(test_id.uid, 1)
+        self.assertEqual(test_id.str_uid, '%0255i' % uid)
+        self.assertEqual(test_id.str_filesystem, '%0255i' % uid)
+        self.assertIs(test_id.variant, None)
+        self.assertIs(test_id.str_variant, '')
+
+    def test_uid_name_uid_too_large_digits(self):
+        """
+        Tests that when the filesystem can not cope with the size of
+        the Test ID, not even the test uid, an exception will be
+        raised.
+        """
+        test_id = TestID(1, 'test', no_digits=256)
+        self.assertRaises(RuntimeError, lambda: test_id.str_filesystem)
+
+    def test_uid_large_name(self):
+        """
+        Tests that when the filesystem can not cope with the size of
+        the Test ID, the name will be shortened.
+        """
+        uid = 1
+        name = 'test_' * 51     # 255 characters
+        test_id = TestID(uid, name)
+        self.assertEqual(test_id.uid, 1)
+        # only 253 can fit for the test name
+        self.assertEqual(test_id.str_filesystem, '%s-%s' % (uid, name[:253]))
+        self.assertIs(test_id.variant, None)
+        self.assertIs(test_id.str_variant, "")
+
+    def test_uid_name_large_variant(self):
+        """
+        Tests that when the filesystem can not cope with the size of
+        the Test ID, and a variant name is present, the name will be
+        removed.
+        """
+        uid = 1
+        name = 'test'
+        variant_id = 'fast_' * 51    # 255 characters
+        variant = {'variant_id': variant_id}
+        test_id = TestID(uid, name, variant=variant)
+        self.assertEqual(test_id.uid, 1)
+        self.assertEqual(test_id.str_filesystem, '%s_%s' % (uid, variant_id[:253]))
+        self.assertIs(test_id.variant, variant_id)
+        self.assertEqual(test_id.str_variant, ";%s" % variant_id)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The Test IDs (and the resulting presentation and job results structure) is different when using the nrunner in a job.  This should make the behavior the same between both implementations.