### PR TITLE
selftests/unit/test_job.py: fixes for using the nrunner plugin

### DIFF
--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -126,8 +126,13 @@ class JobTest(unittest.TestCase):
             def pre_tests(self):
                 filtered_test_suite = []
                 for test_factory in self.test_suite:
-                    if test_factory[0] is test.SimpleTest:
-                        if not test_factory[1].get('name', '').endswith('time'):
+                    if self.config.get('run.test_runner') == 'runner':
+                        if test_factory[0] is test.SimpleTest:
+                            if not test_factory[1].get('name', '').endswith('time'):
+                                filtered_test_suite.append(test_factory)
+                    elif self.config.get('run.test_runner') == 'nrunner':
+                        task = test_factory
+                        if not task.runnable.url.endswith('time'):
                             filtered_test_suite.append(test_factory)
                 self.test_suite = filtered_test_suite
                 super(JobFilterTime, self).pre_tests()
@@ -185,8 +190,13 @@ class JobTest(unittest.TestCase):
             def pre_tests(self):
                 filtered_test_suite = []
                 for test_factory in self.test_suite:
-                    if test_factory[0] is test.SimpleTest:
-                        if not test_factory[1].get('name', '').endswith('time'):
+                    if self.config.get('run.test_runner') == 'runner':
+                        if test_factory[0] is test.SimpleTest:
+                            if not test_factory[1].get('name', '').endswith('time'):
+                                filtered_test_suite.append(test_factory)
+                    elif self.config.get('run.test_runner') == 'nrunner':
+                        task = test_factory
+                        if not task.runnable.url.endswith('time'):
                             filtered_test_suite.append(test_factory)
                 self.test_suite = filtered_test_suite
                 super(JobFilterLog, self).pre_tests()


### PR DESCRIPTION
**Note for reviewers**

This PR takes into account that we'll have, soon, a knob to change the test runner or test both at `make check` time.  For now, a reviewer has to edit the default runner at `avocado.core.job` manually to test it with the nrunner plugin.

Also, some failures in other unittests are fixed by other PRs that are under review.

---

When setting the "run.test_runner" configuration key to "nrunner",
these unittests for the job class fail to take into account that the
test suite will be comprised of nrunner.Tasks, instead of so called
"test factories".

This change takes that into account and makes the tests succeed.  It's
necessary, though, to manually set the runner to verify the fix.

It's expected that we'll add a full coverage for both test runner
implementations soon, and address the good number of functional tests
failures, but this simple fix resolves the issue with all the
unittests.

Signed-off-by: Cleber Rosa <crosa@redhat.com>