### PR TITLE
Way to provide sysinfo in case of test failure [v2]

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -870,9 +870,6 @@ class Test(unittest.TestCase, TestData):
                                                 logger=LOG_JOB)
                         stderr_check_exception = details
 
-        if self.__sysinfo_enabled:
-            self.__sysinfo_logger.end()
-
         # pylint: disable=E0702
         if test_exception is not None:
             raise test_exception
@@ -936,6 +933,8 @@ class Test(unittest.TestCase, TestData):
             for e_line in tb_info:
                 self.log.error(e_line)
         finally:
+            if self.__sysinfo_enabled:
+                self.__sysinfo_logger.end(self.__status)
             self.__phase = 'FINISHED'
             self._tag_end()
             self._report()

--- a/avocado/etc/avocado/avocado.conf
+++ b/avocado/etc/avocado/avocado.conf
@@ -29,8 +29,12 @@ per_test = False
 [sysinfo.collectibles]
 # File with list of commands that will be executed and have their output collected
 commands = etc/avocado/sysinfo/commands
+# File with list of commands that will be executed and have their output collected, in case of test failure
+fail_commands = etc/avocado/sysinfo/fail_commands
 # File with list of files that will be collected verbatim
 files = etc/avocado/sysinfo/files
+# File with list of files that will be collected verbatim, in case of test failure
+fail_files = etc/avocado/sysinfo/fail_files
 # File with list of commands that will run alongside the job/test
 profilers = etc/avocado/sysinfo/profilers
 


### PR DESCRIPTION
sysinfo collectibles were being collected in case of all test
results. But we need to collect some data in case of test failures
only. Introduced a way to do that.

v2 of https://github.com/avocado-framework/avocado/pull/3590

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>