### PR TITLE
Sysinfo: register options so values from config are respected

### DIFF
--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -193,17 +193,11 @@ class Run(CLICmd):
                                  parser=parser,
                                  long_arg='--ignore-missing-references')
 
-        help_msg = ('Enable or disable sysinfo information. Like hardware '
-                    'details, profiles, etc.')
-        settings.register_option(section='sysinfo.collect',
-                                 key='enabled',
-                                 default='on',
-                                 key_type=str,
-                                 help_msg=help_msg,
-                                 choices=('on', 'off'),
-                                 parser=parser,
-                                 short_arg='-S',
-                                 long_arg='--sysinfo')
+        settings.add_argparser_to_option(namespace='sysinfo.collect.enabled',
+                                         parser=parser,
+                                         choices=('on', 'off'),
+                                         short_arg='-S',
+                                         long_arg='--sysinfo')
 
         help_msg = ('Defines the order of iterating through test suite '
                     'and test variants')

--- a/avocado/plugins/sysinfo.py
+++ b/avocado/plugins/sysinfo.py
@@ -16,11 +16,35 @@ System information plugin
 """
 
 from avocado.core.future.settings import settings
+from avocado.core.plugin_interfaces import Init
 from avocado.core.plugin_interfaces import CLICmd
 from avocado.core.plugin_interfaces import JobPreTests
 from avocado.core.plugin_interfaces import JobPostTests
 from avocado.core import sysinfo
 from avocado.utils import path
+
+
+class SysinfoInit(Init):
+
+    name = 'sysinfo'
+    description = 'Initializes sysinfo settings'
+
+    def initialize(self):
+        help_msg = ('Enable or disable sysinfo information. Like hardware '
+                    'details, profiles, etc.')
+        settings.register_option(section='sysinfo.collect',
+                                 key='enabled',
+                                 default='on',
+                                 key_type=str,
+                                 help_msg=help_msg,
+                                 choices=('on', 'off'))
+
+        help_msg = 'Enable sysinfo collection per-test'
+        settings.register_option(section='sysinfo.collect',
+                                 key='per_test',
+                                 default=False,
+                                 key_type=bool,
+                                 help_msg=help_msg)
 
 
 class SysInfoJob(JobPreTests, JobPostTests):

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,9 @@ if __name__ == '__main__':
                   'avocado-runner-tap = avocado.core.nrunner_tap:main',
                   'avocado-software-manager = avocado.utils.software_manager:main',
                   ],
+              "avocado.plugins.init": [
+                  "sysinfo = avocado.plugins.sysinfo:SysinfoInit",
+              ],
               'avocado.plugins.cli': [
                   'wrapper = avocado.plugins.wrapper:Wrapper',
                   'xunit = avocado.plugins.xunit:XUnitCLI',


### PR DESCRIPTION
The avocado.core.job module has been using future.settings for some
time now, instead of the legacy settings module.

While future.settings is able to read configuration files and merge
their content into the produced dictionary, it checks that the option
has been registered in the first place.

This adds one of the sysinfo configurations that are available on
the configuration file we ship, but that is not being registered.
A final version, if this approach is agreed upon, should include
all option in the configuration file.

Reference: https://github.com/avocado-framework/avocado/issues/3873
Signed-off-by: Cleber Rosa <crosa@redhat.com>