### PR TITLE
Job API: use "job.run.results" section for result related features

### DIFF
--- a/selftests/functional/test_job_api_features.py
+++ b/selftests/functional/test_job_api_features.py
@@ -1,0 +1,45 @@
+"""
+Functional tests for features available through the job API
+"""
+
+import os
+import tempfile
+import unittest
+
+from .. import temp_dir_prefix
+
+from avocado.core.job import Job
+from avocado.core import exit_codes
+
+
+class Test(unittest.TestCase):
+
+    def setUp(self):
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
+        self.base_config = {'core.show': ['none'],
+                            'run.results_dir': self.tmpdir.name,
+                            'run.references': ['examples/tests/passtest.py']}
+
+    def test_job_run_result_json_enabled(self):
+        self.base_config['job.run.result.json.enabled'] = 'on'
+        with Job(self.base_config) as j:
+            result = j.run()
+        self.assertEqual(result, exit_codes.AVOCADO_ALL_OK)
+        json_results_path = os.path.join(self.tmpdir.name, 'latest', 'results.json')
+        self.assertTrue(os.path.exists(json_results_path))
+
+    def test_job_run_result_json_output(self):
+        json_results_path = os.path.join(self.tmpdir.name, 'myresults.json')
+        self.base_config['job.run.result.json.output'] = json_results_path
+        with Job(self.base_config) as j:
+            result = j.run()
+        self.assertEqual(result, exit_codes.AVOCADO_ALL_OK)
+        self.assertTrue(os.path.exists(json_results_path))
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ if __name__ == '__main__':
                   'avocado-software-manager = avocado.utils.software_manager:main',
                   ],
               "avocado.plugins.init": [
+                  "jsonresult = avocado.plugins.jsonresult:JSONInit",
                   "sysinfo = avocado.plugins.sysinfo:SysinfoInit",
               ],
               'avocado.plugins.cli': [


### PR DESCRIPTION
As we organize the Job API, we're choosing the namespaces for features.
One common pattern we have, is that a lot of features are simply organized
under a "run." prefix, because of their legacy implementation in
"avocado/plugins/run.py" or the idea that they were features only
available at "avocado run" time.

The proposal here is to try to think first of the underlying job
level for those features which "run.*", and try to organize them
around the different job phases/features.

For instance, a JSON result (or HTML) is only generated when
a job is run.  So IMO, it makes to organize it as:

 * job - no way to generate a JSON elsewhere
 * run - only when running a job it's possible to have data
         for a JSON result file
 * result - that's the general group of feature, and should
            be shared with HTML, xUNIT, etc

So the section for JSON result plugin, in the contect of generating
it when running a job, becomes "job.run.result.json".

Also, tests for the feature using the underlying job API configuration
are added.  I don't have a clear answer at this point (RFC welcome)
but I believe these can serve as a replacement for much of the
functional tests that run the avocado command line app, because we'd
only be testing the command line parsing, in addition to what's been
tested here.

Signed-off-by: Cleber Rosa <crosa@redhat.com>

---

Related to: https://github.com/avocado-framework/avocado/issues/3795