### PR TITLE
Job API: standardize job run result namespace 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ requirements-selftests: pip
 	- $(PYTHON) -m pip install -r requirements-selftests.txt
 
 smokecheck: clean develop
-	./scripts/avocado run passtest.py
+	PYTHON=$(PYTHON) $(PYTHON) -m avocado run passtest.py
 
 ifndef AVOCADO_OPTIONAL_PLUGINS_TESTS
 AVOCADO_OPTIONAL_PLUGINS_TESTS=$(patsubst %,%/tests/, $(AVOCADO_OPTIONAL_PLUGINS))

--- a/avocado/__main__.py
+++ b/avocado/__main__.py
@@ -4,8 +4,8 @@ Main entry point when called by 'python -m'.
 
 import sys
 
-from avocado.core.app import AvocadoApp
+from avocado.core.main import main
+
 
 if __name__ == '__main__':
-    main = AvocadoApp()
-    sys.exit(main.run())
+    sys.exit(main())

--- a/avocado/core/app.py
+++ b/avocado/core/app.py
@@ -20,7 +20,6 @@ import os
 import signal
 import sys
 
-from . import data_dir
 from . import output
 from .dispatcher import CLICmdDispatcher
 from .dispatcher import CLIDispatcher
@@ -100,5 +99,3 @@ class AvocadoApp:
             # This makes sure we cleanup the console (stty echo). The only way
             # to avoid cleaning it is to kill the less (paginator) directly
             STD_OUTPUT.close()
-            # Force-close tmp dir
-            data_dir.clean_tmp_files()

--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -25,6 +25,7 @@ The general reasoning to find paths is:
 * The next best location is the default system wide one.
 * The next best location is the default user specific one.
 """
+import atexit
 import glob
 import os
 import shutil
@@ -346,3 +347,6 @@ def get_job_results_dir(job_ref, logs_dir=None):
     if matches == 1:
         return os.path.dirname(match_file)
     return None
+
+
+atexit.register(clean_tmp_files)

--- a/avocado/core/main.py
+++ b/avocado/core/main.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; specifically version 2 of the License.
@@ -60,7 +58,7 @@ def handle_exception(*exc_info):
     sys.exit(-1)
 
 
-if __name__ == '__main__':
+def main():
     sys.excepthook = handle_exception
     from avocado.core.app import AvocadoApp    # pylint: disable=E0611
 
@@ -75,4 +73,8 @@ if __name__ == '__main__':
         if os.path.exists("/var/tmp"):
             os.environ["TMP"] = "/var/tmp"
     app = AvocadoApp()
-    sys.exit(app.run())
+    return app.run()
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/avocado/plugins/jsonresult.py
+++ b/avocado/plugins/jsonresult.py
@@ -23,7 +23,7 @@ import os
 from avocado.core.future.settings import settings
 from avocado.core.output import LOG_UI
 from avocado.core.parser import FileOrStdoutAction
-from avocado.core.plugin_interfaces import CLI, Result
+from avocado.core.plugin_interfaces import Init, CLI, Result
 from avocado.utils import astring
 
 
@@ -68,16 +68,17 @@ class JSONResult(Result):
                           separators=(',', ': '))
 
     def render(self, result, job):
-        json_output = job.config.get('run.json.output')
-        json_job_result = job.config.get('run.json.job_result')
-        if not (json_job_result or json_output):
+        json_output = job.config.get('job.run.result.json.output')
+        json_enabled = job.config.get('job.run.result.json.enabled')
+
+        if not (json_enabled or json_output):
             return
 
         if not result.tests_total:
             return
 
         content = self._render(result)
-        if json_job_result == 'on':
+        if json_enabled == 'on':
             json_path = os.path.join(job.logdir, 'results.json')
             with open(json_path, 'w') as json_file:
                 json_file.write(content)
@@ -89,6 +90,27 @@ class JSONResult(Result):
             else:
                 with open(json_path, 'w') as json_file:
                     json_file.write(content)
+
+
+class JSONInit(Init):
+
+    name = 'json'
+    description = "JSON job result plugin initialization"
+
+    def initialize(self):
+        help_msg = ('Enable JSON result format and write it to FILE. '
+                    'Use "-" to redirect to the standard output.')
+        settings.register_option(section='job.run.result.json',
+                                 key='output',
+                                 default=None,
+                                 help_msg=help_msg)
+
+        help_msg = ('Enables default JSON result in the job results '
+                    'directory. File will be named "results.json".')
+        settings.register_option(section='job.run.result.json',
+                                 key='enabled',
+                                 default='on',
+                                 help_msg=help_msg)
 
 
 class JSONCLI(CLI):
@@ -105,26 +127,18 @@ class JSONCLI(CLI):
         if run_subcommand_parser is None:
             return
 
-        help_msg = ('Enable JSON result format and write it to FILE. '
-                    'Use "-" to redirect to the standard output.')
-        settings.register_option(section='run.json',
-                                 key='output',
-                                 default=None,
-                                 action=FileOrStdoutAction,
-                                 help_msg=help_msg,
-                                 metavar='FILE',
-                                 parser=run_subcommand_parser,
-                                 long_arg='--json')
+        settings.add_argparser_to_option(
+            namespace='job.run.result.json.output',
+            action=FileOrStdoutAction,
+            metavar='FILE',
+            parser=run_subcommand_parser,
+            long_arg='--json')
 
-        help_msg = ('Enables default JSON result in the job results '
-                    'directory. File will be named "results.json".')
-        settings.register_option(section='run.json',
-                                 key='job_result',
-                                 default='on',
-                                 choices=('on', 'off'),
-                                 help_msg=help_msg,
-                                 parser=run_subcommand_parser,
-                                 long_arg='--json-job-result')
+        settings.add_argparser_to_option(
+            namespace='job.run.result.json.enabled',
+            choices=('on', 'off'),
+            parser=run_subcommand_parser,
+            long_arg='--json-job-result')
 
     def run(self, config):
         pass

--- a/docs/source/guides/contributor/chapters/tips.rst
+++ b/docs/source/guides/contributor/chapters/tips.rst
@@ -36,7 +36,7 @@ install it using pip::
 and then simply mark the desired function with `@profile` (no need to import
 it from anywhere). Then you execute::
 
-    kernprof -l -v ./scripts/avocado run ...
+    kernprof -l -v avocado run ...
 
 and when the process finishes you'll see the profiling information. (sometimes
 the binary is called `kernprof.py`)

--- a/docs/source/guides/user/chapters/advanced.rst
+++ b/docs/source/guides/user/chapters/advanced.rst
@@ -42,11 +42,11 @@ Example of a transparent way of running strace as a wrapper::
 
 To have all programs started by ``test.py`` wrapped with ``~/bin/my-wrapper.sh``::
 
-    $ scripts/avocado run --wrapper ~/bin/my-wrapper.sh tests/test.py
+    $ avocado run --wrapper ~/bin/my-wrapper.sh tests/test.py
 
 To have only ``my-binary`` wrapped with ``~/bin/my-wrapper.sh``::
 
-    $ scripts/avocado run --wrapper ~/bin/my-wrapper.sh:*my-binary tests/test.py
+    $ avocado run --wrapper ~/bin/my-wrapper.sh:*my-binary tests/test.py
 
 Caveats
 ~~~~~~~

--- a/docs/source/guides/writer/chapters/writing.rst
+++ b/docs/source/guides/writer/chapters/writing.rst
@@ -813,7 +813,7 @@ that returns 0 (PASSed) or != 0 (FAILed). Let's consider our bogus example::
 
 Let's record the output for this one::
 
-    $ scripts/avocado run output_record.sh --output-check-record all
+    $ avocado run output_record.sh --output-check-record all
     JOB ID    : 25c4244dda71d0570b7f849319cd71fe1722be8b
     JOB LOG   : $HOME/avocado/job-results/job-2014-09-25T20.49-25c4244/job.log
      (1/1) output_record.sh: PASS (0.01 s)
@@ -837,7 +837,7 @@ Now, every time this test runs, it'll take into account the expected files that
 were recorded, no need to do anything else but run the test. Let's see what
 happens if we change the ``stdout.expected`` file contents to ``Hello, Avocado!``::
 
-    $ scripts/avocado run output_record.sh
+    $ avocado run output_record.sh
     JOB ID    : f0521e524face93019d7cb99c5765aedd933cb2e
     JOB LOG   : $HOME/avocado/job-results/job-2014-09-25T20.52-f0521e5/job.log
      (1/1) output_record.sh: FAIL (0.02 s)

--- a/man/avocado.rst
+++ b/man/avocado.rst
@@ -487,7 +487,7 @@ straight output of the job log in the stdout, without having to tail the
 job log. In order to do that, you can use --show=test to the avocado
 test runner::
 
-    $ scripts/avocado --show=test run examples/tests/sleeptest.py
+    $ avocado --show=test run examples/tests/sleeptest.py
     ...
     PARAMS (key=timeout, path=*, default=None) => None
     START 1-sleeptest.py:SleepTest.test
@@ -509,7 +509,7 @@ Edit your `~/.config/avocado/avocado.conf` file and add::
 
 Running the same example with this option will give you::
 
-    $ scripts/avocado --show=test run sleeptest.py
+    $ avocado --show=test run sleeptest.py
     ...
     START 1-sleeptest.py:SleepTest.test
     PASS 1-sleeptest.py:SleepTest.test

--- a/optional_plugins/varianter_yaml_to_mux/tests/test_functional.py
+++ b/optional_plugins/varianter_yaml_to_mux/tests/test_functional.py
@@ -3,19 +3,14 @@ import json
 import os
 import tempfile
 import unittest
-import sys
 import shutil
 
 from avocado.core import exit_codes
 from avocado.utils import process
 from avocado.utils import genio
 
+from selftests import AVOCADO, BASEDIR
 
-basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..', '..')
-basedir = os.path.abspath(basedir)
-
-AVOCADO = os.environ.get("UNITTEST_AVOCADO_CMD",
-                         "%s ./scripts/avocado" % sys.executable)
 
 DEBUG_OUT = b"""
 Variant mint-debug-amd-virtio-022a:    amd@optional_plugins/varianter_yaml_to_mux/tests/.data/mux-environment.yaml, virtio@optional_plugins/varianter_yaml_to_mux/tests/.data/mux-environment.yaml, mint@optional_plugins/varianter_yaml_to_mux/tests/.data/mux-environment.yaml, debug@optional_plugins/varianter_yaml_to_mux/tests/.data/mux-environment.yaml
@@ -35,7 +30,7 @@ class MultiplexTests(unittest.TestCase):
         self.tmpdir = tempfile.TemporaryDirectory(prefix='avocado_' + __name__)
 
     def run_and_check(self, cmd_line, expected_rc, tests=None):
-        os.chdir(basedir)
+        os.chdir(BASEDIR)
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, expected_rc,
                          "Command %s did not return rc "
@@ -199,7 +194,7 @@ class ReplayTests(unittest.TestCase):
             self.jobid = f.read().strip('\n')
 
     def run_and_check(self, cmd_line, expected_rc):
-        os.chdir(basedir)
+        os.chdir(BASEDIR)
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, expected_rc,
                          "Command %s did not return rc "

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -34,7 +34,7 @@
 Summary: Framework with tools and libraries for Automated Testing
 Name: python-%{srcname}
 Version: 79.0
-Release: 1%{?gitrel}%{?dist}
+Release: 2%{?gitrel}%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.github.io/
@@ -230,11 +230,7 @@ popd
 # AVOCADO_CHECK_LEVEL: package build environments have the least
 # amount of resources we have observed so far.  Let's avoid tests that
 # require too much resources or are time sensitive
-# UNITTEST_AVOCADO_CMD: the "avocado" command to be run during
-# unittests needs to be a Python specific one on Fedora >= 28.  Let's
-# use the one that was setup in the source tree by the "setup.py
-# develop --user" step and is guaranteed to be version specific.
-PATH=$HOME/.local/bin:$PATH LANG=en_US.UTF-8 AVOCADO_CHECK_LEVEL=0 UNITTEST_AVOCADO_CMD=$HOME/.local/bin/avocado %{__python3} selftests/run
+PATH=$HOME/.local/bin:$PATH LANG=en_US.UTF-8 AVOCADO_CHECK_LEVEL=0 %{__python3} selftests/run
 %endif
 
 %files -n python3-%{srcname}
@@ -446,6 +442,9 @@ Again Shell code (and possibly other similar shells).
 %{_libexecdir}/avocado*
 
 %changelog
+* Thu Jun  4 2020 Cleber Rosa <cleber@redhat.com> - 79.0-2
+- Dropped use of custom avocado command for tests
+
 * Tue May 12 2020 Cleber Rosa <cleber@redhat.com> - 79.0-1
 - Do not build deprecated runners
 

--- a/selftests/__init__.py
+++ b/selftests/__init__.py
@@ -11,7 +11,7 @@ BASEDIR = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)
 
 #: The name of the avocado test runner entry point
 AVOCADO = os.environ.get("UNITTEST_AVOCADO_CMD",
-                         "%s ./scripts/avocado" % sys.executable)
+                         "%s -m avocado" % sys.executable)
 
 
 def python_module_available(module_name):

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -4,7 +4,6 @@ import os
 import re
 import shutil
 import signal
-import sys
 import tempfile
 import time
 import xml.dom.minidom
@@ -835,12 +834,11 @@ class RunnerSimpleTest(unittest.TestCase):
             self.assertTrue(sysinfo)
 
     def test_non_absolute_path(self):
-        avocado_path = os.path.join(BASEDIR, 'scripts', 'avocado')
         test_base_dir = os.path.dirname(self.pass_script.path)
         os.chdir(test_base_dir)
         test_file_name = os.path.basename(self.pass_script.path)
-        cmd_line = ('%s %s run --job-results-dir %s --sysinfo=off'
-                    ' "%s"' % (sys.executable, avocado_path, self.tmpdir.name,
+        cmd_line = ('%s run --job-results-dir %s --sysinfo=off'
+                    ' "%s"' % (AVOCADO, self.tmpdir.name,
                                test_file_name))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -1018,12 +1016,11 @@ class ExternalRunnerTest(unittest.TestCase):
 
     @unittest.skipIf(os.environ.get("RUNNING_COVERAGE"), "Running coverage")
     def test_externalrunner_chdir_runner_relative(self):
-        avocado_abs = " ".join([os.path.abspath(_) for _ in AVOCADO.split(" ")])
         pass_abs = os.path.abspath(self.pass_script.path)
         os.chdir('/')
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
                     '--external-runner=bin/sh --external-runner-chdir=runner -- %s'
-                    % (avocado_abs, self.tmpdir.name, pass_abs))
+                    % (AVOCADO, self.tmpdir.name, pass_abs))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,

--- a/selftests/functional/test_job_api_features.py
+++ b/selftests/functional/test_job_api_features.py
@@ -1,0 +1,45 @@
+"""
+Functional tests for features available through the job API
+"""
+
+import os
+import tempfile
+import unittest
+
+from .. import temp_dir_prefix
+
+from avocado.core.job import Job
+from avocado.core import exit_codes
+
+
+class Test(unittest.TestCase):
+
+    def setUp(self):
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
+        self.base_config = {'core.show': ['none'],
+                            'run.results_dir': self.tmpdir.name,
+                            'run.references': ['examples/tests/passtest.py']}
+
+    def test_job_run_result_json_enabled(self):
+        self.base_config['job.run.result.json.enabled'] = 'on'
+        with Job(self.base_config) as j:
+            result = j.run()
+        self.assertEqual(result, exit_codes.AVOCADO_ALL_OK)
+        json_results_path = os.path.join(self.tmpdir.name, 'latest', 'results.json')
+        self.assertTrue(os.path.exists(json_results_path))
+
+    def test_job_run_result_json_output(self):
+        json_results_path = os.path.join(self.tmpdir.name, 'myresults.json')
+        self.base_config['job.run.result.json.output'] = json_results_path
+        with Job(self.base_config) as j:
+            result = j.run()
+        self.assertEqual(result, exit_codes.AVOCADO_ALL_OK)
+        self.assertTrue(os.path.exists(json_results_path))
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/selftests/functional/test_plugin_diff.py
+++ b/selftests/functional/test_plugin_diff.py
@@ -1,7 +1,6 @@
 import glob
 import os
 import tempfile
-import shlex
 import unittest
 
 from avocado.core import exit_codes
@@ -42,14 +41,14 @@ class DiffTests(unittest.TestCase):
                          "%d:\n%s" % (cmd_line, expected_rc, result))
         return result
 
+    @unittest.skipIf(os.environ.get("RUNNING_COVERAGE"), "Running coverage")
     def test_diff(self):
         cmd_line = ('%s diff %s %s' %
                     (AVOCADO, self.jobdir, self.jobdir2))
         expected_rc = exit_codes.AVOCADO_ALL_OK
         result = self.run_and_check(cmd_line, expected_rc)
-        # Avocado won't know about the Python interpreter used on the
-        # command line
-        avocado_in_log = shlex.split(AVOCADO)[-1]
+        # Avocado will see the main module on the command line
+        avocado_in_log = os.path.join(BASEDIR, 'avocado', '__main__.py')
         self.assertIn(b"# COMMAND LINE", result.stdout)
         self.assertIn("-%s run" % avocado_in_log, result.stdout_text)
         self.assertIn("+%s run" % avocado_in_log, result.stdout_text)

--- a/selftests/functional/test_streams.py
+++ b/selftests/functional/test_streams.py
@@ -1,5 +1,4 @@
 import os
-import shlex
 import tempfile
 import unittest
 
@@ -54,9 +53,9 @@ class StreamsTest(unittest.TestCase):
                  {'AVOCADO_LOG_EARLY': 'y'}))
         for cmd, env in cmds:
             result = process.run(cmd, env=env, shell=True)
+            # Avocado will see the main module on the command line
+            cmd_in_log = os.path.join(BASEDIR, 'avocado', '__main__.py')
             self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
-            # If using the Python interpreter, Avocado won't know about it
-            cmd_in_log = shlex.split(AVOCADO)[-1]
             self.assertIn("avocado.test: Command line: %s" % cmd_in_log,
                           result.stdout_text)
 
@@ -68,8 +67,8 @@ class StreamsTest(unittest.TestCase):
                'passtest.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
-        # If using the Python interpreter, Avocado won't know about it
-        cmd_in_log = shlex.split(AVOCADO)[-1]
+        # Avocado will see the main module on the command line
+        cmd_in_log = os.path.join(BASEDIR, 'avocado', '__main__.py')
         self.assertIn("Command line: %s" % cmd_in_log,
                       result.stdout_text)
         self.assertIn(b"\nSTART 1-passtest.py:PassTest.test",

--- a/selftests/jobs/pass
+++ b/selftests/jobs/pass
@@ -6,11 +6,7 @@ import os
 import sys
 from avocado.core.job import Job
 
-config = {'run.references': [os.path.join(os.path.dirname(__file__), 'tests', 'pass')],
-          # This creates the temporary directory along the results directory
-          # preventing a failure from the "selftests/check_tmp_dirs" that runs
-          # right after the tests in Avocado's "make check" rule
-          'run.keep_tmp': 'on'}
+config = {'run.references': [os.path.join(os.path.dirname(__file__), 'tests', 'pass')]}
 
 with Job(config) as j:
     sys.exit(j.run())

--- a/selftests/run_coverage
+++ b/selftests/run_coverage
@@ -15,7 +15,7 @@ echo "Using coverage utilty: $COVERAGE"
 
 $COVERAGE erase
 rm -f .coverage.*
-RUNNING_COVERAGE=1 AVOCADO_CHECK_LEVEL=1 UNITTEST_AVOCADO_CMD="$COVERAGE run -p --include 'avocado/*,optional_plugins/*' ./scripts/avocado" $COVERAGE run -p --include "avocado/*,optional_plugins/*" ./selftests/run
+RUNNING_COVERAGE=1 AVOCADO_CHECK_LEVEL=1 UNITTEST_AVOCADO_CMD="$COVERAGE run -p --include 'avocado/*,optional_plugins/*' $PYTHON -m avocado" $COVERAGE run -p --include "avocado/*,optional_plugins/*" ./selftests/run
 $COVERAGE combine .coverage*
 echo
 $COVERAGE report -m --include "avocado/core/*"

--- a/selftests/unit/test_jsonresult.py
+++ b/selftests/unit/test_jsonresult.py
@@ -31,8 +31,9 @@ class JSONResultTest(unittest.TestCase):
         prefix = temp_dir_prefix(__name__, self, 'setUp')
         self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
         config = {'run.results_dir': self.tmpdir.name,
-                  'run.json.output': self.tmpfile[1]}
+                  'job.run.result.json.output': self.tmpfile[1]}
         self.job = job.Job(config)
+        self.job.setup()
         self.test_result = Result(UNIQUE_ID, LOGFILE)
         self.test_result.filename = self.tmpfile[1]
         self.test_result.tests_total = 1
@@ -41,6 +42,7 @@ class JSONResultTest(unittest.TestCase):
         self.test1.time_elapsed = 1.23
 
     def tearDown(self):
+        self.job.cleanup()
         os.close(self.tmpfile[0])
         os.remove(self.tmpfile[1])
         self.tmpdir.cleanup()
@@ -51,7 +53,7 @@ class JSONResultTest(unittest.TestCase):
         self.test_result.end_tests()
         json_result = jsonresult.JSONResult()
         json_result.render(self.test_result, self.job)
-        with open(self.job.config.get('run.json.output')) as fp:
+        with open(self.job.config.get('job.run.result.json.output')) as fp:
             j = fp.read()
         obj = json.loads(j)
         self.assertTrue(obj)
@@ -86,7 +88,7 @@ class JSONResultTest(unittest.TestCase):
         self.test_result.end_tests()
         json_result = jsonresult.JSONResult()
         json_result.render(self.test_result, self.job)
-        output = self.job.config.get('run.json.output')
+        output = self.job.config.get('job.run.result.json.output')
         res = json.loads(open(output).read())
         check_item("[pass]", res["pass"], 2)
         check_item("[errors]", res["errors"], 4)
@@ -105,7 +107,7 @@ class JSONResultTest(unittest.TestCase):
         self.test_result.end_tests()
         json_result = jsonresult.JSONResult()
         json_result.render(self.test_result, self.job)
-        output = self.job.config.get('run.json.output')
+        output = self.job.config.get('job.run.result.json.output')
         res = json.loads(open(output).read())
         check_item("[total]", res["total"], 1)
         check_item("[skip]", res["skip"], 0)

--- a/selftests/unit/test_xunit.py
+++ b/selftests/unit/test_xunit.py
@@ -40,9 +40,10 @@ class xUnitSucceedTest(unittest.TestCase):
         self.tmpfile = tempfile.mkstemp()
         prefix = temp_dir_prefix(__name__, self, 'setUp')
         self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
-        config = {'run.xunit.output': self.tmpfile[1],
+        config = {'job.run.result.xunit.output': self.tmpfile[1],
                   'run.results_dir': self.tmpdir.name}
         self.job = job.Job(config)
+        self.job.setup()
         self.test_result = Result(UNIQUE_ID, LOGFILE)
         self.test_result.tests_total = 1
         self.test_result.logfile = ("/.../avocado/job-results/"
@@ -53,6 +54,7 @@ class xUnitSucceedTest(unittest.TestCase):
         self.test1.time_elapsed = 678.23689
 
     def tearDown(self):
+        self.job.cleanup()
         errs = []
         cleanups = (lambda: os.close(self.tmpfile[0]),
                     lambda: os.remove(self.tmpfile[1]),
@@ -73,7 +75,7 @@ class xUnitSucceedTest(unittest.TestCase):
         self.test_result.end_tests()
         xunit_result = xunit.XUnitResult()
         xunit_result.render(self.test_result, self.job)
-        xunit_output = self.job.config.get('run.xunit.output')
+        xunit_output = self.job.config.get('job.run.result.xunit.output')
         with open(xunit_output, 'rb') as fp:
             xml = fp.read()
         try:
@@ -112,7 +114,7 @@ class xUnitSucceedTest(unittest.TestCase):
         self.test_result.end_tests()
         xunit_result = xunit.XUnitResult()
         xunit_result.render(self.test_result, self.job)
-        xunit_output = self.job.config.get('run.xunit.output')
+        xunit_output = self.job.config.get('job.run.result.xunit.output')
         with open(xunit_output, 'rb') as fp:
             unlimited = fp.read()
         self.job.config['xunit.max_test_log_chars'] = 10

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ if __name__ == '__main__':
                   "xunit = avocado.plugins.xunit:XUnitInit",
                   "jsonresult = avocado.plugins.jsonresult:JSONInit",
                   "sysinfo = avocado.plugins.sysinfo:SysinfoInit",
+                  "tap = avocado.plugins.tap:TAPInit",
               ],
               'avocado.plugins.cli': [
                   'wrapper = avocado.plugins.wrapper:Wrapper',

--- a/setup.py
+++ b/setup.py
@@ -58,9 +58,9 @@ if __name__ == '__main__':
               ],
           packages=find_packages(exclude=('selftests*',)),
           include_package_data=True,
-          scripts=['scripts/avocado'],
           entry_points={
               'console_scripts': [
+                  'avocado = avocado.core.main:main',
                   'avocado-runner = avocado.core.nrunner:main',
                   'avocado-runner-noop = avocado.core.nrunner:main',
                   'avocado-runner-exec = avocado.core.nrunner:main',

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ if __name__ == '__main__':
                   'avocado-software-manager = avocado.utils.software_manager:main',
                   ],
               "avocado.plugins.init": [
+                  "jsonresult = avocado.plugins.jsonresult:JSONInit",
                   "sysinfo = avocado.plugins.sysinfo:SysinfoInit",
               ],
               'avocado.plugins.cli': [

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ if __name__ == '__main__':
                   'avocado-software-manager = avocado.utils.software_manager:main',
                   ],
               "avocado.plugins.init": [
+                  "xunit = avocado.plugins.xunit:XUnitInit",
                   "jsonresult = avocado.plugins.jsonresult:JSONInit",
                   "sysinfo = avocado.plugins.sysinfo:SysinfoInit",
               ],


### PR DESCRIPTION
This makes all the builtin result plugins use the same namespace, and allow the configuration to be set either via the Job API, configuration files or command line.

This is part of https://github.com/avocado-framework/avocado/issues/3795