### PR TITLE
Settings: do not attempt to create empty configuration value

### DIFF
--- a/avocado/core/future/settings.py
+++ b/avocado/core/future/settings.py
@@ -45,7 +45,6 @@ import json
 import os
 
 from ..settings_dispatcher import SettingsDispatcher
-from ...utils import path
 
 
 class SettingsError(Exception):
@@ -304,21 +303,8 @@ class Settings:
             self._all_config_paths.append(extra_file)
 
     def _append_user_config(self):
-        if not os.path.exists(self._config_path_local):
-            self._create_empty_config()
-        self._all_config_paths.append(self._config_path_local)
-
-    def _create_empty_config(self):
-        try:
-            path.init_dir(self._config_dir_local)
-            with open(self._config_path_local, 'w') as config_local_fileobj:
-                content = ("# You can use this file to override "
-                           "configuration values from '%s and %s\n"
-                           % (self._config_path_system,
-                              self._config_dir_system_extra))
-                config_local_fileobj.write(content)
-        except IOError:     # Some users can't write it (docker)
-            pass
+        if os.path.exists(self._config_path_local):
+            self._all_config_paths.append(self._config_path_local)
 
     def _prepare_base_dirs(self):
         cfg_dir = '/etc'

--- a/avocado/core/future/settings.py
+++ b/avocado/core/future/settings.py
@@ -65,20 +65,6 @@ class NamespaceNotRegistered(SettingsError):
     """
 
 
-class ConfigFileNotFound(SettingsError):
-    """
-    Error thrown when the main settings file could not be found.
-    """
-
-    def __init__(self, path_list):
-        super(ConfigFileNotFound, self).__init__()
-        self.path_list = path_list
-
-    def __str__(self):
-        return ("Could not find the avocado config file after looking in: %s" %
-                self.path_list)
-
-
 class ConfigOption:
     def __init__(self, namespace, help_msg, key_type=str, default=None,
                  parser=None, short_arg=None, long_arg=None,
@@ -278,9 +264,6 @@ class Settings:
 
         # 2. Parse/read all config paths
         self._config_paths = self._config.read(self._all_config_paths)
-
-        if not self._config_paths:
-            raise ConfigFileNotFound(self._all_config_paths)
 
     def _append_config_paths(self):
         # Override with system config


### PR DESCRIPTION
The value of doing this is very questionable, because most users
will probably never change anything.  The users that want to do
so, can manually create a directory and file.

Reference: https://github.com/avocado-framework/avocado/issues/3541
Signed-off-by: Cleber Rosa <crosa@redhat.com>