### PR TITLE
nrunner: enable "avocado jobs get-output-files" command

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -599,7 +599,7 @@ class Task:
             known_runners = {}
         self.known_runners = known_runners
         self.spawn_handle = None
-        self._output_dir = None
+        self.output_dir = None
 
     def __repr__(self):
         fmt = '<Task identifier="{}" runnable="{}" status_services="{}"'
@@ -617,8 +617,8 @@ class Task:
         return self.runnable.pick_runner_command(runners_registry)
 
     def setup_output_dir(self):
-        self._output_dir = tempfile.mkdtemp(prefix='.avocado-task-')
-        env_var = {'AVOCADO_TEST_OUTPUT_DIR': self._output_dir}
+        self.output_dir = tempfile.mkdtemp(prefix='.avocado-task-')
+        env_var = {'AVOCADO_TEST_OUTPUT_DIR': self.output_dir}
         self.runnable.kwargs.update(env_var)
 
     @classmethod
@@ -667,7 +667,7 @@ class Task:
         runner = runner_klass(self.runnable)
         for status in runner.run():
             if status['status'] == 'started':
-                status.update({'output_dir': self._output_dir})
+                status.update({'output_dir': self.output_dir})
             status.update({"id": self.identifier})
             for status_service in self.status_services:
                 status_service.post(status)

--- a/avocado/core/spawners/common.py
+++ b/avocado/core/spawners/common.py
@@ -55,7 +55,8 @@ class BaseSpawner:
         """
         results_dir = get_job_results_dir(job_id)
         task_id = string_to_safe_path(task_id)
-        src = '{}/test-results/{}/data'.format(results_dir, task_id)
+        data_pointer = '{}/test-results/{}/data'.format(results_dir, task_id)
+        src = open(data_pointer, 'r').readline().rstrip()
         try:
             for path in Path(src).expanduser().iterdir():
                 if path.is_file() and path.stat().st_size != 0:

--- a/avocado/plugins/jobs.py
+++ b/avocado/plugins/jobs.py
@@ -161,8 +161,8 @@ class Jobs(CLICmd):
             try:
                 files_buffers = spawner().stream_output(job_id, test_id)
                 for filename, stream in files_buffers:
-                    destination = os.path.join(destination, filename)
-                    self._save_stream_to_file(stream, destination)
+                    dest = os.path.join(destination, filename)
+                    self._save_stream_to_file(stream, dest)
             except SpawnerException as ex:
                 LOG_UI.error("Error: Failed to download: %s. Exiting...", ex)
                 return exit_codes.AVOCADO_GENERIC_CRASH

--- a/avocado/plugins/jobs.py
+++ b/avocado/plugins/jobs.py
@@ -232,6 +232,7 @@ class Jobs(CLICmd):
 
         # We could improve this soon with more data and colors
         self._print_job_details(data)
+        LOG_UI.info("")
         self._print_job_tests(results_data.get('tests'))
         results = ('PASS %d | ERROR %d | FAIL %d | SKIP %d |'
                    'WARN %d | INTERRUPT %s | CANCEL %s')

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -68,6 +68,10 @@ class Runner(RunnerInterface):
             with open(debug, 'w') as fp:
                 json.dump(local_statuses, fp)
 
+        data_file = os.path.join(task_path, 'data')
+        with open(data_file, 'w') as fp:
+            fp.write("{}\n".format(task.output_dir))
+
     def run_suite(self, job, result, test_suite, variants, timeout=0,
                   replay_map=None, execution_order=None):
         summary = set()


### PR DESCRIPTION
This patch will fix the get-output-files logic on the next runner. After this, you will be able to download files that are executed using the `--test-runner=nrunner`.

In order to test this, you need to create a test that will generate any file inside the `$AVOCADO_TEST_OUTPUT_DIR` folder.

This is also adding an empty line when showing jobs details with `avocado jobs show` command.