### PR TITLE
avocado.utils.wait: use monotonic time

### DIFF
--- a/avocado/utils/wait.py
+++ b/avocado/utils/wait.py
@@ -22,14 +22,14 @@ def wait_for(func, timeout, first=0.0, step=1.0, text=None, args=None, kwargs=No
         args = []
     if kwargs is None:
         kwargs = {}
-    start_time = time.time()
+    start_time = time.monotonic()
     end_time = start_time + timeout
 
     time.sleep(first)
 
-    while time.time() < end_time:
+    while time.monotonic() < end_time:
         if text:
-            log.debug("%s (%f secs)", text, (time.time() - start_time))
+            log.debug("%s (%f secs)", text, (time.monotonic() - start_time))
 
         output = func(*args, **kwargs)
         if output:

--- a/avocado/utils/wait.py
+++ b/avocado/utils/wait.py
@@ -23,7 +23,7 @@ def wait_for(func, timeout, first=0.0, step=1.0, text=None, args=None, kwargs=No
     if kwargs is None:
         kwargs = {}
     start_time = time.time()
-    end_time = time.time() + timeout
+    end_time = start_time + timeout
 
     time.sleep(first)
 


### PR DESCRIPTION
As explained in the Python docs, and suggested in the referenced issue, this should make Avocado more reliable wrt times.  Running tests that play with the clock is not that uncommon, and this could improve the chances of Avocado not breaking under such conditions.
    
Reference: https://github.com/avocado-framework/avocado/issues/3565