### PR TITLE
Python based tests: use same style of reference resolution

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -422,9 +422,29 @@ class PythonUnittestRunner(BaseRunner):
      * kwargs: not used
     """
     @staticmethod
+    def _uri_to_unittest_name(uri):
+        if ':' in uri:
+            module, class_method = uri.rsplit(':', 1)
+        else:
+            module = uri
+            class_method = None
+        if module.endswith('.py'):
+            module = module[:-3]
+        if module.startswith(os.path.curdir):
+            module = module[1:]
+            if module.startswith(os.path.sep):
+                module = module[1:]
+        module = module.replace(os.path.sep, ".")
+        if class_method:
+            return '%s.%s' % (module, class_method)
+        else:
+            return module
+
+    @staticmethod
     def _run_unittest(uri, queue):
         stream = io.StringIO()
-        suite = unittest.TestLoader().loadTestsFromName(uri)
+        unittest_name = PythonUnittestRunner._uri_to_unittest_name(uri)
+        suite = unittest.TestLoader().loadTestsFromName(unittest_name)
         runner = unittest.TextTestRunner(stream=stream, verbosity=0)
         unittest_result = runner.run(suite)
         time_end = time.time()


### PR DESCRIPTION
The "avocado-instrumented" test and the Python unittest share a
good deal of similarity, including a common ancestry, and this
attempts to improve it even further.

In Avocado, the "reference resolution" produces a user visible
"test name", which, according to our own guidelines, should be
a valid reference.  This allows users to copy and past those test
names and run tests from them.  Example:

 $ avocado list examples/tests/passtest.py
 INSTRUMENTED examples/tests/passtest.py:PassTest.test

 $ avocado list examples/tests/passtest.py:PassTest.test
 INSTRUMENTED examples/tests/passtest.py:PassTest.test

This is what enables a user to do:

 $ avocado list multiple.py
 INSTRUMENTED multiple.py:Test.test_1
 INSTRUMENTED multiple.py:Test.test_2
 INSTRUMENTED multiple.py:Test.test_3

 $ avocado run multiple.py:Test.test_3

And have a valid test executed.

So, the idea here is to allow the same to happen for Python unittests.
Internally, at execution time, the valid "unittest name" is still
used, but to the user, a test name that is reusable and coherent with
the overall Avocado experience and guidelines is used.

The example given, though, is about the principle, using the current
runner (and loader), while these changes are clearly about the nrunner
and resolver.

Signed-off-by: Cleber Rosa <crosa@redhat.com>