### PR TITLE
future.settings: Migrate sysinfo.collect options to use the new API

### DIFF
--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -425,10 +425,7 @@ class SysInfo:
             self.files = []
 
         if profiler is None:
-            self.profiler = settings.get_value('sysinfo.collect',
-                                               'profiler',
-                                               key_type='bool',
-                                               default=False)
+            self.profiler = config.get('sysinfo.collect.profiler')
         else:
             self.profiler = profiler
 

--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -388,16 +388,16 @@ class SysInfo:
         :param profiler: Whether to use the profiler. If not given explicitly,
                          tries to look in the config files.
         """
+        config = future_settings.as_dict()
+
         if basedir is None:
             basedir = utils_path.init_dir('sysinfo')
         self.basedir = basedir
 
         self._installed_pkgs = None
         if log_packages is None:
-            self.log_packages = settings.get_value('sysinfo.collect',
-                                                   'installed_packages',
-                                                   key_type='bool',
-                                                   default=False)
+            packages_namespace = 'sysinfo.collect.installed_packages'
+            self.log_packages = config.get(packages_namespace)
         else:
             self.log_packages = log_packages
 

--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -157,8 +157,7 @@ class Command(Collectible):
         locale = config.get("sysinfo.collect.locale")
         if locale:
             env["LC_ALL"] = locale
-        timeout = settings.get_value("sysinfo.collect", "commands_timeout",
-                                     int, -1)
+        timeout = config.get('sysinfo.collect.commands_timeout')
         # the sysinfo configuration supports negative or zero integer values
         # but the avocado.utils.process APIs define no timeouts as "None"
         if int(timeout) <= 0:

--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -22,6 +22,7 @@ import subprocess
 import time
 
 from . import output
+from .future.settings import settings as future_settings
 from .settings import settings
 from ..utils import astring
 from ..utils import genio
@@ -150,9 +151,10 @@ class Command(Collectible):
         :param logdir: Path to a log directory.
         """
         env = os.environ.copy()
+        config = future_settings.as_dict()
         if "PATH" not in env:
             env["PATH"] = "/usr/bin:/bin"
-        locale = settings.get_value("sysinfo.collect", "locale", str, None)
+        locale = config.get("sysinfo.collect.locale")
         if locale:
             env["LC_ALL"] = locale
         timeout = settings.get_value("sysinfo.collect", "commands_timeout",
@@ -205,9 +207,10 @@ class Daemon(Command):
         :param logdir: Path to a log directory.
         """
         env = os.environ.copy()
+        config = future_settings.as_dict()
         if "PATH" not in env:
             env["PATH"] = "/usr/bin:/bin"
-        locale = settings.get_value("sysinfo.collect", "locale", str, None)
+        locale = config.get("sysinfo.collect.locale")
         if locale:
             env["LC_ALL"] = locale
         logf_path = os.path.join(logdir, self.logf)

--- a/avocado/plugins/sysinfo.py
+++ b/avocado/plugins/sysinfo.py
@@ -54,6 +54,14 @@ class SysinfoInit(Init):
                                  default=-1,
                                  help_msg=help_msg)
 
+        help_msg = ('Whether to take a list of installed packages previous '
+                    'to avocado jobs')
+        settings.register_option(section='sysinfo.collect',
+                                 key='installed_packages',
+                                 key_type=bool,
+                                 default=False,
+                                 help_msg=help_msg)
+
         help_msg = 'Force LANG for sysinfo collection'
         settings.register_option(section='sysinfo.collect',
                                  key='locale',

--- a/avocado/plugins/sysinfo.py
+++ b/avocado/plugins/sysinfo.py
@@ -46,6 +46,14 @@ class SysinfoInit(Init):
                                  key_type=bool,
                                  help_msg=help_msg)
 
+        help_msg = ('Overall timeout to collect commands, when <=0'
+                    'no timeout is enforced')
+        settings.register_option(section='sysinfo.collect',
+                                 key='commands_timeout',
+                                 key_type=int,
+                                 default=-1,
+                                 help_msg=help_msg)
+
         help_msg = 'Force LANG for sysinfo collection'
         settings.register_option(section='sysinfo.collect',
                                  key='locale',

--- a/avocado/plugins/sysinfo.py
+++ b/avocado/plugins/sysinfo.py
@@ -46,6 +46,12 @@ class SysinfoInit(Init):
                                  key_type=bool,
                                  help_msg=help_msg)
 
+        help_msg = 'Force LANG for sysinfo collection'
+        settings.register_option(section='sysinfo.collect',
+                                 key='locale',
+                                 default='C',
+                                 help_msg=help_msg)
+
 
 class SysInfoJob(JobPreTests, JobPostTests):
 

--- a/avocado/plugins/sysinfo.py
+++ b/avocado/plugins/sysinfo.py
@@ -62,6 +62,14 @@ class SysinfoInit(Init):
                                  default=False,
                                  help_msg=help_msg)
 
+        help_msg = ('Whether to run certain commands in bg to give extra job '
+                    'debug information')
+        settings.register_option(section='sysinfo.collect',
+                                 key='profiler',
+                                 key_type=bool,
+                                 default=False,
+                                 help_msg=help_msg)
+
         help_msg = 'Force LANG for sysinfo collection'
         settings.register_option(section='sysinfo.collect',
                                  key='locale',


### PR DESCRIPTION
As part of the effort to remove default values scattered around the code, this change only migrates the remain sysinfo.collect options to use the new settings API.
