### PR TITLE
 N(ext) Runner: implement entry point based runner selection

### DIFF
--- a/avocado/core/nrunner_avocado_instrumented.py
+++ b/avocado/core/nrunner_avocado_instrumented.py
@@ -55,6 +55,8 @@ class AvocadoInstrumentedTestRunner(nrunner.BaseRunner):
             if status in ['pass', 'fail', 'skip', 'error']:
                 state['result'] = status
                 state['status'] = 'finished'
+            else:
+                state['status'] = 'running'
 
         # This is a hack because the name is a TestID instance that can not
         # at this point be converted to JSON
@@ -62,14 +64,17 @@ class AvocadoInstrumentedTestRunner(nrunner.BaseRunner):
             del state['name']
         if 'time_start' in state:
             del state['time_start']
+        state['time'] = time.time()
         queue.put(state)
 
     def run(self):
         queue = multiprocessing.SimpleQueue()
         process = multiprocessing.Process(target=self._run_avocado,
                                           args=(self.runnable, queue))
+
         process.start()
 
+        self.prepare_status('started')
         most_current_execution_state_time = None
         while queue.empty():
             time.sleep(nrunner.RUNNER_RUN_CHECK_INTERVAL)

--- a/selftests/jobs/pass
+++ b/selftests/jobs/pass
@@ -6,7 +6,12 @@ import os
 import sys
 from avocado.core.job import Job
 
-config = {'run.references': [os.path.join(os.path.dirname(__file__), 'tests', 'pass')]}
+config = {
+    'run.references': [
+        os.path.join(os.path.dirname(__file__), 'tests', 'pass'),
+        os.path.join(os.path.dirname(__file__), 'tests', 'passtest.py')
+        ]
+    }
 
 with Job(config) as j:
     sys.exit(j.run())

--- a/selftests/jobs/tests/passtest.py
+++ b/selftests/jobs/tests/passtest.py
@@ -1,0 +1,1 @@
+../../../examples/tests/passtest.py

--- a/setup.py
+++ b/setup.py
@@ -134,6 +134,11 @@ if __name__ == '__main__':
                   'runner = avocado.plugins.runner:TestRunner',
                   'nrunner = avocado.plugins.runner_nrunner:Runner',
                   ],
+              'avocado.plugins.runnable.runner': [
+                  ('avocado-instrumented = avocado.core.'
+                   'nrunner_avocado_instrumented:AvocadoInstrumentedTestRunner'),
+                  'tap = avocado.core.nrunner_tap:TAPRunner',
+                  ],
               },
           zip_safe=False,
           test_suite='selftests',


### PR DESCRIPTION
If the `avocado.core.nrunner` module is being used by the Avocado Job, via the `avocado.plugins.runner_nrunner`, it can benefit from being on a system that has setuptools installed and can pick runner for runnables from there.
    
But, if the "nrunner" module is being executed by itself, let's say, on a remote system, it may not access to setuptools or entrypoints, so it should still rely on its internal runner registry.
    
This change allows the Avocado Job to run all ranges of test types (runnable kinds, really) currently supported.  This is true for executions without spawners and always local, which currently, in a job, it's the only way they're done.

This is related to https://github.com/avocado-framework/avocado/issues/3865