### PR TITLE
core.future.setting: Fixup: Add package default avocado config

### DIFF
--- a/avocado/core/future/settings.py
+++ b/avocado/core/future/settings.py
@@ -44,6 +44,8 @@ import glob
 import json
 import os
 
+from pkg_resources import resource_filename
+
 from ..settings_dispatcher import SettingsDispatcher
 
 
@@ -272,6 +274,7 @@ class Settings:
         self._append_user_config()
 
     def _append_system_config(self):
+        self._all_config_paths.append(self._config_path_pkg)
         self._all_config_paths.append(self._config_path_system)
         configs = glob.glob(os.path.join(self._config_dir_system_extra,
                                          '*.conf'))
@@ -290,15 +293,18 @@ class Settings:
             cfg_dir = os.path.join(os.environ['VIRTUAL_ENV'], 'etc')
             user_dir = os.environ['VIRTUAL_ENV']
 
+        config_file_name = 'avocado.conf'
+        config_pkg_base = os.path.join('etc', 'avocado', config_file_name)
+        self._config_path_pkg = resource_filename('avocado', config_pkg_base)
         self._config_dir_system = os.path.join(cfg_dir, 'avocado')
         self._config_dir_system_extra = os.path.join(cfg_dir,
                                                      'avocado',
                                                      'conf.d')
         self._config_dir_local = os.path.join(user_dir, '.config', 'avocado')
         self._config_path_system = os.path.join(self._config_dir_system,
-                                                'avocado.conf')
+                                                config_file_name)
         self._config_path_local = os.path.join(self._config_dir_local,
-                                               'avocado.conf')
+                                               config_file_name)
 
     def add_argparser_to_option(self, namespace, parser, long_arg,
                                 short_arg=None, positional_arg=False,


### PR DESCRIPTION
Avocado future settings misses package default config
file to be parsed, let's add it.

Fixes: https://github.com/avocado-framework/avocado/issues/3884

Reported-by: Narasimhan V <sim@linux.vnet.ibm.com>
Suggested-by: Cleber Rosa <crosa@redhat.com>
Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>