### PR TITLE
future.settings: Migrate datadir.paths.* to use the new API. [V2]

### DIFF
--- a/avocado/core/__init__.py
+++ b/avocado/core/__init__.py
@@ -13,9 +13,12 @@
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
 
+import os
+
 from .dispatcher import InitDispatcher
 from .future.settings import settings as future_settings
 from .output import BUILTIN_STREAMS, BUILTIN_STREAM_SETS
+from .utils import prepend_base_path
 
 
 def register_core_options():
@@ -68,6 +71,45 @@ def register_core_options():
                                     key_type=int,
                                     help_msg=help_msg,
                                     default=60)
+
+    help_msg = 'Cache directories to be used by the avocado test'
+    future_settings.register_option(section='datadir.paths',
+                                    key='cache_dirs',
+                                    key_type=list,
+                                    default=[],
+                                    help_msg=help_msg)
+
+    help_msg = 'Base directory for Avocado tests and auxiliary data'
+    default = prepend_base_path('/var/lib/avocado')
+    future_settings.register_option(section='datadir.paths',
+                                    key='base_dir',
+                                    key_type=prepend_base_path,
+                                    default=default,
+                                    help_msg=help_msg)
+
+    help_msg = 'Test directory for Avocado tests'
+    default = prepend_base_path('/usr/share/doc/avocado/tests')
+    future_settings.register_option(section='datadir.paths',
+                                    key='test_dir',
+                                    key_type=prepend_base_path,
+                                    default=default,
+                                    help_msg=help_msg)
+
+    help_msg = 'Data directory for Avocado'
+    default = prepend_base_path('/var/lib/avocado/data')
+    future_settings.register_option(section='datadir.paths',
+                                    key='data_dir',
+                                    key_type=prepend_base_path,
+                                    default=default,
+                                    help_msg=help_msg)
+
+    help_msg = 'Logs directory for Avocado'
+    default = prepend_base_path('~/avocado/job-results')
+    future_settings.register_option(section='datadir.paths',
+                                    key='logs_dir',
+                                    key_type=prepend_base_path,
+                                    default=default,
+                                    help_msg=help_msg)
 
 
 def initialize_plugins():

--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -34,8 +34,8 @@ import time
 import tempfile
 
 from . import job_id
-from . import settings
 from . import exit_codes
+from .future.settings import settings as future_settings
 from .output import LOG_JOB, LOG_UI
 from ..utils import path as utils_path
 from ..utils.data_structures import Borg
@@ -60,7 +60,8 @@ def _get_settings_dir(dir_name):
     """
     Returns a given "datadir" directory as set by the configuration system
     """
-    path = settings.settings.get_value('datadir.paths', dir_name, 'path')
+    namespace = 'datadir.paths.{}'.format(dir_name)
+    path = future_settings.as_dict().get(namespace)
     return os.path.abspath(path)
 
 
@@ -204,8 +205,7 @@ def get_cache_dirs():
     """
     Returns the list of cache dirs, according to configuration and convention
     """
-    cache_dirs = settings.settings.get_value('datadir.paths', 'cache_dirs',
-                                             key_type=list, default=[])
+    cache_dirs = future_settings.as_dict().get('datadir.paths.cache_dirs')
     datadir_cache = os.path.join(get_data_dir(), 'cache')
     if datadir_cache not in cache_dirs:
         cache_dirs.append(datadir_cache)

--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -101,18 +101,19 @@ def get_test_dir():
     The heuristics used to determine the test dir are:
     1) If an explicit test dir is set in the configuration system, it
     is used.
-    2) If user is running Avocado out of the source tree, the example
-    test dir is used
-    3) System wide test dir is used
-    4) User default test dir (~/avocado/tests) is used
+    2) If user is running Avocado from its source code tree, the example test
+    dir is used.
+    3) System wide test dir is used.
+    4) User default test dir (~/avocado/tests) is used.
     """
     configured = _get_settings_dir('test_dir')
     if utils_path.usable_ro_dir(configured):
         return configured
 
-    if settings.settings.intree:
-        base_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
-        return os.path.join(base_dir, 'examples', 'tests')
+    source_tree_root = os.path.dirname(os.path.dirname(
+        os.path.dirname(__file__)))
+    if os.path.exists(os.path.join(source_tree_root, 'examples')):
+        return os.path.join(source_tree_root, 'examples', 'tests')
 
     if utils_path.usable_ro_dir(SYSTEM_TEST_DIR):
         return SYSTEM_TEST_DIR

--- a/selftests/unit/test_datadir.py
+++ b/selftests/unit/test_datadir.py
@@ -51,16 +51,11 @@ class DataDirTest(Base):
         When avocado.conf is present, honor the values coming from it.
         """
         stg = settings.Settings(self.config_file_path)
-        # Trick the module to think we're on a system wide install
-        stg.intree = False
         with unittest.mock.patch('avocado.core.data_dir.settings.settings', stg):
             from avocado.core import data_dir
-            self.assertFalse(data_dir.settings.settings.intree)
             for key in self.mapping.keys():
                 data_dir_func = getattr(data_dir, 'get_%s' % key)
                 self.assertEqual(data_dir_func(), stg.get_value('datadir.paths', key))
-        # make sure that without the patch, we have a different value here
-        self.assertTrue(data_dir.settings.settings.intree)
 
     def test_unique_log_dir(self):
         """

--- a/selftests/unit/test_datadir.py
+++ b/selftests/unit/test_datadir.py
@@ -2,7 +2,7 @@ import os
 import tempfile
 import unittest.mock
 
-from avocado.core import settings
+from avocado.core.future import settings as future_settings
 
 from .. import temp_dir_prefix
 
@@ -50,12 +50,18 @@ class DataDirTest(Base):
         """
         When avocado.conf is present, honor the values coming from it.
         """
-        stg = settings.Settings(self.config_file_path)
-        with unittest.mock.patch('avocado.core.data_dir.settings.settings', stg):
+        stg = future_settings.Settings()
+        with unittest.mock.patch('avocado.core.future_settings', stg):
+            import avocado.core
+            avocado.core.register_core_options()
+        stg.process_config_path(self.config_file_path)
+        stg.merge_with_configs()
+        with unittest.mock.patch('avocado.core.data_dir.future_settings', stg):
             from avocado.core import data_dir
             for key in self.mapping.keys():
                 data_dir_func = getattr(data_dir, 'get_%s' % key)
-                self.assertEqual(data_dir_func(), stg.get_value('datadir.paths', key))
+                namespace = 'datadir.paths.{}'.format(key)
+                self.assertEqual(data_dir_func(), stg.as_dict().get(namespace))
 
     def test_unique_log_dir(self):
         """
@@ -159,8 +165,13 @@ class DataDirTest(Base):
                          data_dir.get_job_results_dir('latest', logs_dir),
                          "It should get from the 'latest' id")
 
-        stg = settings.Settings(self.config_file_path)
-        with unittest.mock.patch('avocado.core.data_dir.settings.settings',
+        stg = future_settings.Settings()
+        with unittest.mock.patch('avocado.core.future_settings', stg):
+            import avocado.core
+            avocado.core.register_core_options()
+        stg.process_config_path(self.config_file_path)
+        stg.merge_with_configs()
+        with unittest.mock.patch('avocado.core.data_dir.future_settings',
                                  stg):
             self.assertEqual(expected_jrd,
                              data_dir.get_job_results_dir(unique_id),
@@ -181,8 +192,13 @@ class AltDataDirTest(Base):
         from data_dir APIs.
         """
         # Initial settings with initial data_dir locations
-        stg = settings.Settings(self.config_file_path)
-        with unittest.mock.patch('avocado.core.data_dir.settings.settings', stg):
+        stg = future_settings.Settings()
+        with unittest.mock.patch('avocado.core.future_settings', stg):
+            import avocado.core
+            avocado.core.register_core_options()
+        stg.process_config_path(self.config_file_path)
+        stg.merge_with_configs()
+        with unittest.mock.patch('avocado.core.data_dir.future_settings', stg):
             from avocado.core import data_dir
             for key in self.mapping.keys():
                 data_dir_func = getattr(data_dir, 'get_%s' % key)
@@ -194,8 +210,13 @@ class AltDataDirTest(Base):
          self.alt_config_file_path) = self._get_temp_dirs_mapping_and_config()
 
         # Alternate settings with different data_dir location
-        alt_stg = settings.Settings(self.alt_config_file_path)
-        with unittest.mock.patch('avocado.core.data_dir.settings.settings', alt_stg):
+        alt_stg = future_settings.Settings()
+        with unittest.mock.patch('avocado.core.future_settings', alt_stg):
+            import avocado.core
+            avocado.core.register_core_options()
+        alt_stg.process_config_path(self.alt_config_file_path)
+        alt_stg.merge_with_configs()
+        with unittest.mock.patch('avocado.core.data_dir.future_settings', alt_stg):
             for key in alt_mapping.keys():
                 data_dir_func = getattr(data_dir, 'get_%s' % key)
                 self.assertEqual(data_dir_func(), alt_mapping[key])

--- a/selftests/unit/test_plugin_vmimage.py
+++ b/selftests/unit/test_plugin_vmimage.py
@@ -3,9 +3,10 @@ import os
 import tempfile
 from urllib.error import URLError
 
-from avocado.core import settings, data_dir
+from avocado.core import data_dir
 from avocado.plugins import vmimage as vmimage_plugin
 from avocado.utils import vmimage as vmimage_util
+from avocado.core.future import settings as future_settings
 from .. import temp_dir_prefix, skipOnLevelsInferiorThan
 from ..functional.test_plugin_vmimage import missing_binary, create_metadata_file
 
@@ -87,7 +88,7 @@ class VMImagePlugin(unittest.TestCase):
 
     @unittest.mock.patch('avocado.utils.vmimage.urlopen')
     def _create_test_files(self, urlopen_mock):
-        with unittest.mock.patch('avocado.core.data_dir.settings.settings', self.stg):
+        with unittest.mock.patch('avocado.core.data_dir.future_settings', self.stg):
             expected_images = [{'name': 'Fedora', 'file': 'Fedora-Cloud-Base-{version}-{build}.{arch}.qcow2',
                                 'url': FEDORA_PAGE},
                                {'name': 'JeOS', 'file': 'jeos-{version}-{arch}.qcow2.xz', 'url': JEOS_PAGE},
@@ -116,11 +117,16 @@ class VMImagePlugin(unittest.TestCase):
     def setUp(self):
         (self.base_dir, self.mapping,
          self.config_file_path) = self._get_temporary_dirs_mapping_and_config()
-        self.stg = settings.Settings(self.config_file_path)
+        self.stg = future_settings.Settings()
+        with unittest.mock.patch('avocado.core.future_settings', self.stg):
+            import avocado.core
+            avocado.core.register_core_options()
+        self.stg.process_config_path(self.config_file_path)
+        self.stg.merge_with_configs()
         self.expected_images = self._create_test_files()
 
     def test_list_downloaded_images(self):
-        with unittest.mock.patch('avocado.core.data_dir.settings.settings', self.stg):
+        with unittest.mock.patch('avocado.core.data_dir.future_settings', self.stg):
             with unittest.mock.patch('avocado.utils.vmimage.ImageProviderBase.get_version'):
                 images = sorted(vmimage_plugin.list_downloaded_images(), key=lambda i: i['name'])
                 for index, image in enumerate(images):
@@ -135,7 +141,7 @@ class VMImagePlugin(unittest.TestCase):
         """
         :avocado: tags=parallel:1
         """
-        with unittest.mock.patch('avocado.core.data_dir.settings.settings', self.stg):
+        with unittest.mock.patch('avocado.core.data_dir.future_settings', self.stg):
             try:
                 expected_image_info = vmimage_util.get_best_provider(name="CirrOS")
                 image_info = vmimage_plugin.download_image(distro="CirrOS")


### PR DESCRIPTION
Besides migrating `datadir.paths.*` to use the new API, this also moves the logic of `intree` attribute from legacy `Settings` class to `data_dir` module as this is the only place that uses it. The new API does not have the `intree` attribute and, in my opinion, should not have for now.

This effort was explicitly to migrate the `datadir.paths.*` to the new API, but looking at `get_test_dir` function in the `data_dir` module, it seems to me that we will need to evaluate its logic with the new Settings API.

Changes from V1:
- Update unit tests to use settings with context manager instead of creating a function to register the options.
- Update description about in tree execution.