### PR TITLE
Selftests: refactor skip condition for existing file

### DIFF
--- a/optional_plugins/loader_yaml/tests/test_yaml_loader.py
+++ b/optional_plugins/loader_yaml/tests/test_yaml_loader.py
@@ -5,7 +5,7 @@ import unittest
 from avocado.core import exit_codes
 from avocado.utils import process
 
-from selftests import AVOCADO, BASEDIR
+from selftests import AVOCADO, BASEDIR, skipUnlessPathExists
 
 
 class YamlLoaderTests(unittest.TestCase):
@@ -50,10 +50,8 @@ class YamlLoaderTests(unittest.TestCase):
                '--replay %s' % (AVOCADO, self.tmpdir.name, srcjob.decode('utf-8')))
         self.run_and_check(cmd, exit_codes.AVOCADO_ALL_OK, tests, not_tests)
 
-    @unittest.skipUnless(os.path.exists("/bin/true"), "/bin/true not "
-                         "available")
-    @unittest.skipUnless(os.path.exists("/bin/echo"), "/bin/echo not "
-                         "available")
+    @skipUnlessPathExists('/bin/true')
+    @skipUnlessPathExists('/bin/echo')
     def test_yaml_loader_list(self):
         # Verifies that yaml_loader list won't crash and is able to detect
         # various test types

--- a/selftests/__init__.py
+++ b/selftests/__init__.py
@@ -128,3 +128,9 @@ def skipOnLevelsInferiorThan(level):
     return unittest.skipIf(int(os.environ.get("AVOCADO_CHECK_LEVEL", 0)) < level,
                            "Skipping test that take a long time to run, are "
                            "resource intensive or time sensitve")
+
+
+def skipUnlessPathExists(path):
+    return unittest.skipUnless(os.path.exists(path),
+                               ('File or directory at path "%s" used in test is'
+                                ' not available in the system' % path))

--- a/selftests/functional/test_nrunner.py
+++ b/selftests/functional/test_nrunner.py
@@ -3,7 +3,7 @@ import sys
 import unittest
 import tempfile
 
-from .. import AVOCADO, BASEDIR, temp_dir_prefix
+from .. import AVOCADO, BASEDIR, temp_dir_prefix, skipUnlessPathExists
 
 from avocado.utils import process
 
@@ -31,9 +31,7 @@ class RunnableRun(unittest.TestCase):
         self.assertIn(b"'returncode': 99", res.stdout)
         self.assertEqual(res.exit_status, 0)
 
-    @unittest.skipUnless(os.path.exists('/bin/echo'),
-                         ('Executable "/bin/echo" used in test is not '
-                          'available in the system'))
+    @skipUnlessPathExists('/bin/sh')
     def test_exec_echo(self):
         # 'base64:LW4=' becomes '-n' and prevents echo from printing a newline
         cmd = ("%s runnable-run -k exec -u /bin/echo -a 'base64:LW4=' -a "
@@ -44,12 +42,8 @@ class RunnableRun(unittest.TestCase):
         self.assertIn(b"'returncode': 0", res.stdout)
         self.assertEqual(res.exit_status, 0)
 
-    @unittest.skipUnless(os.path.exists('/bin/sh'),
-                         ('Executable "/bin/sh" used in recipe is not '
-                          'available in the system'))
-    @unittest.skipUnless(os.path.exists('/bin/echo'),
-                         ('Executable "/bin/echo" used in recipe is not '
-                          'available in the system'))
+    @skipUnlessPathExists('/bin/sh')
+    @skipUnlessPathExists('/bin/echo')
     def test_recipe(self):
         recipe = os.path.join(BASEDIR, "examples", "nrunner", "recipes",
                               "runnables", "exec_sh_echo_env_var.json")
@@ -79,9 +73,7 @@ class RunnableRun(unittest.TestCase):
         self.assertIn(b'Invalid keyword parameter: "foo"', res.stderr)
         self.assertEqual(res.exit_status, 2)
 
-    @unittest.skipUnless(os.path.exists('/bin/env'),
-                         ('Executable "/bin/env" used in test is not '
-                          'available in the system'))
+    @skipUnlessPathExists('/bin/env')
     def test_exec_kwargs(self):
         res = process.run("%s runnable-run -k exec -u /bin/env X=Y" % RUNNER,
                           ignore_status=True)
@@ -99,9 +91,7 @@ class TaskRun(unittest.TestCase):
         self.assertIn(b"'id': 'XXXno-opXXX'", res.stdout)
         self.assertEqual(res.exit_status, 0)
 
-    @unittest.skipUnless(os.path.exists('/bin/uname'),
-                         ('Executable "/bin/uname" used in recipe is not '
-                          'available in the system'))
+    @skipUnlessPathExists('/bin/uname')
     def test_recipe_exec_1(self):
         recipe = os.path.join(BASEDIR, "examples", "nrunner", "recipes",
                               "tasks", "exec", "1-uname.json")
@@ -119,9 +109,7 @@ class TaskRun(unittest.TestCase):
         self.assertIn("'status': 'finished'", final_status)
         self.assertEqual(res.exit_status, 0)
 
-    @unittest.skipUnless(os.path.exists('/bin/echo'),
-                         ('Executable "/bin/echo" used in recipe is not '
-                          'available in the system'))
+    @skipUnlessPathExists('/bin/echo')
     def test_recipe_exec_2(self):
         recipe = os.path.join(BASEDIR, "examples", "nrunner", "recipes",
                               "tasks", "exec", "2-echo.json")
@@ -140,9 +128,7 @@ class TaskRun(unittest.TestCase):
         self.assertIn("'stdout': b'avocado'", final_status)
         self.assertEqual(res.exit_status, 0)
 
-    @unittest.skipUnless(os.path.exists('/bin/sleep'),
-                         ('Executable "/bin/sleep" used in recipe is not '
-                          'available in the system'))
+    @skipUnlessPathExists('/bin/sleep')
     def test_recipe_exec_3(self):
         recipe = os.path.join(BASEDIR, "examples", "nrunner", "recipes",
                               "tasks", "exec", "3-sleep.json")
@@ -162,8 +148,7 @@ class TaskRun(unittest.TestCase):
 
 
 class ResolveSerializeRun(unittest.TestCase):
-    @unittest.skipUnless(os.path.exists('/bin/true'),
-                         ('Executable "/bin/true" used in test'))
+    @skipUnlessPathExists('/bin/true')
     def setUp(self):
         prefix = temp_dir_prefix(__name__, self, 'setUp')
         self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)

--- a/selftests/unit/test_nrunner.py
+++ b/selftests/unit/test_nrunner.py
@@ -393,10 +393,10 @@ echo 'ok 2 - description 2'"""
     @skipUnlessPathExists('/bin/sh')
     def test_runner_tap_error(self):
         tap_script = """#!/bin/sh
-    echo '1..2'
-    echo '# Defining an basic test'
-    echo 'error - description 1'
-    echo 'ok 2 - description 2'"""
+echo '1..2'
+echo '# Defining an basic test'
+echo 'error - description 1'
+echo 'ok 2 - description 2'"""
         tap_path = os.path.join(self.tmpdir.name, 'tap.sh')
 
         with open(tap_path, 'w') as fp:

--- a/selftests/unit/test_nrunner.py
+++ b/selftests/unit/test_nrunner.py
@@ -6,7 +6,7 @@ import unittest.mock
 from avocado.core import nrunner
 from avocado.core import nrunner_tap
 
-from .. import temp_dir_prefix
+from .. import temp_dir_prefix, skipUnlessPathExists
 
 
 class Runnable(unittest.TestCase):
@@ -310,9 +310,7 @@ class RunnerTmp(unittest.TestCase):
         prefix = temp_dir_prefix(__name__, self, 'setUp')
         self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
 
-    @unittest.skipUnless(os.path.exists('/bin/sh'),
-                         ('Executable "/bin/sh" used in this test is not '
-                          'available in the system'))
+    @skipUnlessPathExists('/bin/sh')
     def test_runner_tap_fail(self):
         tap_script = """#!/bin/sh
 echo '1..2'
@@ -332,9 +330,7 @@ echo 'not ok 2 - description 2'"""
         self.assertEqual(last_result['result'], 'fail')
         self.assertEqual(last_result['returncode'], 0)
 
-    @unittest.skipUnless(os.path.exists('/bin/sh'),
-                         ('Executable "/bin/sh" used in this test is not '
-                          'available in the system'))
+    @skipUnlessPathExists('/bin/sh')
     def test_runner_tap_ok(self):
         tap_script = """#!/bin/sh
 echo '1..2'
@@ -354,9 +350,7 @@ echo 'ok 2 - description 2'"""
         self.assertEqual(last_result['result'], 'pass')
         self.assertEqual(last_result['returncode'], 0)
 
-    @unittest.skipUnless(os.path.exists('/bin/sh'),
-                         ('Executable "/bin/sh" used in this test is not '
-                          'available in the system'))
+    @skipUnlessPathExists('/bin/sh')
     def test_runner_tap_skip(self):
         tap_script = """#!/bin/sh
 echo '1..2'
@@ -376,9 +370,7 @@ echo 'ok 2 - description 2'"""
         self.assertEqual(last_result['result'], 'skip')
         self.assertEqual(last_result['returncode'], 0)
 
-    @unittest.skipUnless(os.path.exists('/bin/sh'),
-                         ('Executable "/bin/sh" used in this test is not '
-                          'available in the system'))
+    @skipUnlessPathExists('/bin/sh')
     def test_runner_tap_bailout(self):
         tap_script = """#!/bin/sh
 echo '1..2'
@@ -398,9 +390,7 @@ echo 'ok 2 - description 2'"""
         self.assertEqual(last_result['result'], 'error')
         self.assertEqual(last_result['returncode'], 0)
 
-    @unittest.skipUnless(os.path.exists('/bin/sh'),
-                         ('Executable "/bin/sh" used in this test is not '
-                          'available in the system'))
+    @skipUnlessPathExists('/bin/sh')
     def test_runner_tap_error(self):
         tap_script = """#!/bin/sh
     echo '1..2'
@@ -424,9 +414,7 @@ echo 'ok 2 - description 2'"""
         self.tmpdir.cleanup()
 
 
-@unittest.skipUnless(os.path.exists('/bin/sh'),
-                     ('Executable "/bin/sh" used in this test is not '
-                      'available in the system'))
+@skipUnlessPathExists('/bin/sh')
 class RunnerCommandSelection(unittest.TestCase):
 
     def setUp(self):

--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -11,6 +11,7 @@ from avocado.utils import process
 from avocado.utils import path
 
 from .. import setup_avocado_loggers, skipOnLevelsInferiorThan
+from .. import skipUnlessPathExists
 
 
 setup_avocado_loggers()
@@ -220,8 +221,7 @@ class TestProcessRun(unittest.TestCase):
         p = process.run(cmd='ls -l', ignore_status=True)
         self.assertEqual(p.command, expected_command)
 
-    @unittest.skipUnless(os.path.exists('/bin/sudo'),
-                         "/bin/sudo not available")
+    @skipUnlessPathExists('/bin/sudo')
     @unittest.mock.patch.object(path, 'find_command',
                                 unittest.mock.Mock(return_value='/bin/sudo'))
     @unittest.mock.patch.object(os, 'getuid',


### PR DESCRIPTION
By introducing a decorator that skips a test unless the file at the
path given as parameter exists.

Signed-off-by: Cleber Rosa <crosa@redhat.com>