### PR TITLE
Way to provide sysinfo in case of test failure [v3]

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -862,9 +862,6 @@ class Test(unittest.TestCase, TestData):
                                                 logger=LOG_JOB)
                         stderr_check_exception = details
 
-        if self.__sysinfo_enabled:
-            self.__sysinfo_logger.end()
-
         # pylint: disable=E0702
         if test_exception is not None:
             raise test_exception
@@ -928,6 +925,8 @@ class Test(unittest.TestCase, TestData):
             for e_line in tb_info:
                 self.log.error(e_line)
         finally:
+            if self.__sysinfo_enabled:
+                self.__sysinfo_logger.end(self.__status)
             self.__phase = 'FINISHED'
             self._tag_end()
             self._report()

--- a/avocado/plugins/sysinfo.py
+++ b/avocado/plugins/sysinfo.py
@@ -93,11 +93,28 @@ class SysinfoInit(Init):
                                  key_type=prepend_base_path,
                                  default=default,
                                  help_msg=help_msg)
+        help_msg = ('File with list of commands that will be executed and '
+                    'have their output collected, in case of failed test')
+        default = prepend_base_path('etc/avocado/sysinfo/fail_commands')
+        settings.register_option(section='sysinfo.collectibles',
+                                 key='fail_commands',
+                                 key_type=prepend_base_path,
+                                 default=default,
+                                 help_msg=help_msg)
 
         help_msg = 'File with list of files that will be collected verbatim'
         default = prepend_base_path('etc/avocado/sysinfo/files')
         settings.register_option(section='sysinfo.collectibles',
                                  key='files',
+                                 key_type=prepend_base_path,
+                                 default=default,
+                                 help_msg=help_msg)
+
+        help_msg = ('File with list of files that will be collected verbatim'
+                    ', in case of failed test')
+        default = prepend_base_path('etc/avocado/sysinfo/fail_files')
+        settings.register_option(section='sysinfo.collectibles',
+                                 key='fail_files',
                                  key_type=prepend_base_path,
                                  default=default,
                                  help_msg=help_msg)


### PR DESCRIPTION
sysinfo collectibles were being collected in case of all test
results. But we need to collect some data in case of test failures
only. Introduced a way to do that.

v3 of #3874 

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>