### PR TITLE
Optimize sysinfo by not logging duplicates in post

### DIFF
--- a/avocado/etc/avocado/avocado.conf
+++ b/avocado/etc/avocado/avocado.conf
@@ -25,6 +25,8 @@ profiler = False
 locale = C
 # Enable sysinfo collection per-test
 per_test = False
+# Optimize sysinfo collection by removing duplicates between pre and post
+optimize = False
 
 [sysinfo.collectibles]
 # File with list of commands that will be executed and have their output collected

--- a/avocado/plugins/sysinfo.py
+++ b/avocado/plugins/sysinfo.py
@@ -77,6 +77,14 @@ class SysinfoInit(Init):
                                  default='C',
                                  help_msg=help_msg)
 
+        help_msg = ('Optimize sysinfo collected so that duplicates between pre '
+                    'and post re not stored in post')
+        settings.register_option(section='sysinfo.collect',
+                                 key='optimize',
+                                 default=False,
+                                 key_type=bool,
+                                 help_msg=help_msg)
+
         help_msg = ('File with list of commands that will be executed and '
                     'have their output collected')
         default = prepend_base_path('etc/avocado/sysinfo/commands')


### PR DESCRIPTION
Sysinfo files and commands are logged in pre and post. We can
optimize this by checking if the file or command output has
changed, and not logging when not changed.

Provided a parameter in avocado.conf to control this behaviour.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>