### PR TITLE
sysinfo.collect.enabled: True -> on

### DIFF
--- a/avocado/etc/avocado/avocado.conf
+++ b/avocado/etc/avocado/avocado.conf
@@ -14,7 +14,7 @@ logs_dir = ~/avocado/job-results
 
 [sysinfo.collect]
 # Whether to collect system information during avocado jobs
-enabled = True
+enabled = on
 # Overall timeout to collect commands, when <=0 no timeout is enforced
 commands_timeout = -1
 # Whether to take a list of installed packages previous to avocado jobs


### PR DESCRIPTION
enabled parameter is parsed as on / off, but it is True / False
in the avocado.conf file. This issue is exposed only if per_test
is False.

Reported-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>
Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>