### PR TITLE
future.settings: added a 'reference' option to the 'config' command-line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ docs/source/api/test
 docs/source/api/utils
 docs/source/api/plugins
 docs/source/api/optional-plugins
+
+# This file should be generated with:
+# avocado config reference > docs/source/config/reference.rst
+docs/source/config/reference.rst

--- a/avocado/core/future/settings.py
+++ b/avocado/core/future/settings.py
@@ -390,6 +390,16 @@ class Settings:
             result[namespace] = option.value
         return result
 
+    def as_full_dict(self):
+        result = {}
+        for namespace, option in self._namespaces.items():
+            result[namespace] = {'help': option.help_msg,
+                                 'type': option.key_type,
+                                 'default': option.default,
+                                 'section': option.section,
+                                 'key': option.key}
+        return result
+
     def as_json(self):
         """Return a JSON with the current active settings.
 

--- a/avocado/plugins/config.py
+++ b/avocado/plugins/config.py
@@ -11,6 +11,9 @@
 #
 # Copyright: Red Hat Inc. 2013-2014
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+#         Beraldo Leal <bleal@redhat.com>
+
+import textwrap
 
 from avocado.core import data_dir
 from avocado.core.future.settings import settings as future_settings
@@ -39,7 +42,32 @@ class Config(CLICmd):
                                         parser=parser,
                                         long_arg='--datadir')
 
+        subcommands = parser.add_subparsers(dest='config_subcommand',
+                                            metavar='sub-command')
+
+        help_msg = 'Show a configuration reference with all registered options'
+        subcommands.add_parser('reference', help=help_msg)
+
     def run(self, config):
+        if config.get('config_subcommand') == 'reference':
+            self.handle_reference()
+        else:
+            self.handle_default(config)
+
+    def handle_reference(self):
+        full = future_settings.as_full_dict()
+        for namespace, option in full.items():
+            LOG_UI.debug(namespace)
+            LOG_UI.debug("~" * len(namespace))
+            help_lines = textwrap.wrap(option.get('help'))
+            for line in help_lines:
+                LOG_UI.debug(line)
+            LOG_UI.debug("")
+            LOG_UI.debug("* Default: %s", option.get('default'))
+            LOG_UI.debug("* Type: %s", option.get('type'))
+            LOG_UI.debug("")
+
+    def handle_default(self, config):
         LOG_UI.info("Config files read (in order, '*' means the file exists "
                     "and had been read):")
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -45,6 +45,7 @@ clean:
 	-rm -rf $(BUILDDIR)
 
 html:
+	avocado config reference > source/config/reference.rst
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."

--- a/docs/source/config/index.rst
+++ b/docs/source/config/index.rst
@@ -1,0 +1,16 @@
+Avocado's Configuration Reference
+=================================
+
+This is current Avocado Configuration reference. You can adjust the values by two ways:
+
+ - Configuration file options;
+ - Command-line options (when available)
+
+Some options that are used often are available for your convenience also at the command-line.
+ This list has all options registered with Avocado so far.
+
+.. note:: Please, keep in mind that we are in constant evolution and doing a
+  huge improvements on how to configure Avocado, some options here can be changed
+  in the near future.
+
+.. include:: reference.rst

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -47,6 +47,13 @@ Contents:
 
    misc/index
 
+.. toctree::
+   :caption: Configuration Reference
+   :maxdepth: 3
+
+   config/index
+
+
 ========
 Test API
 ========


### PR DESCRIPTION
This will add a new command "avocado config reference" that will print
on output the current configuration reference guide in rst format. And
can be used to update our documentation.  This PR also change our
documentation to include this reference. There is room for improvements,
for instance we can soon split the configuration into sections and also
give the ability to download a config file template.

Signed-off-by: Beraldo Leal <bleal@redhat.com>