### PR TITLE
Fix issue in linux_modules

### DIFF
--- a/avocado/utils/linux_modules.py
+++ b/avocado/utils/linux_modules.py
@@ -53,7 +53,8 @@ def load_module(module_name):
     if module_is_loaded(module_name):
         return False
 
-    process.system('/sbin/modprobe ' + module_name)
+    if process.system('/sbin/modprobe ' + module_name, ignore_status=True):
+        return False
     return True
 
 

--- a/avocado/utils/linux_modules.py
+++ b/avocado/utils/linux_modules.py
@@ -51,7 +51,7 @@ def load_module(module_name):
     :rtype: Bool
     """
     if module_is_loaded(module_name):
-        return False
+        return True
 
     if process.system('/sbin/modprobe ' + module_name, ignore_status=True):
         return False


### PR DESCRIPTION
Fix issue as if modprobe fails library is error out
ex:
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.6/site-packages/avocado_framework-80.0-py3.6.egg/avocado/utils/linux_modules.py", line 56, in load_module
    process.system('/sbin/modprobe ' + module_name)
  File "/usr/local/lib/python3.6/site-packages/avocado_framework-80.0-py3.6.egg/avocado/utils/process.py", line 1103, in system
    encoding=encoding)
  File "/usr/local/lib/python3.6/site-packages/avocado_framework-80.0-py3.6.egg/avocado/utils/process.py", line 1040, in run
    raise CmdError(cmd, sp.result)
avocado.utils.process.CmdError: Command '/sbin/modprobe lkdtm' failed.
stdout: b''
stderr: b'modprobe: FATAL: Module lkdtm not found in directory /lib/modules/5.4.16\n'
additional_info: None
Fix issue in linux_modules as if module is loaded it give false result 
Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>
