### PR TITLE
future.settings: brings back the previous parsing method for lists

### DIFF
--- a/avocado/core/future/settings.py
+++ b/avocado/core/future/settings.py
@@ -39,6 +39,7 @@ ATTENTION: This is a future module, and will be moved out from this package
 soon.
 """
 
+import ast
 import configparser
 import glob
 import json
@@ -170,7 +171,7 @@ class ConfigOption:
             return []
 
         if isinstance(value, str):
-            return [v for v in value.strip('[]').split(',') if v]
+            return ast.literal_eval(value)
 
         if isinstance(value, list):
             return value

--- a/selftests/unit/test_future_settings.py
+++ b/selftests/unit/test_future_settings.py
@@ -122,7 +122,7 @@ class ConfigOption(unittest.TestCase):
         config_option = settings.ConfigOption('namespace', 'help_message')
         self.assertEqual(config_option._as_list(''), [])
         self.assertEqual(config_option._as_list('[]'), [])
-        self.assertEqual(config_option._as_list('[,,,]'), [])
+        self.assertEqual(2, len(config_option._as_list('["foo", "bar", ]')))
 
     def test_as_list_fails(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
This is using the ast module to eval lists as lists in python (using
single or double quotation marks). In the near future we can replace
this eval with a more inteligent and save method.

Signed-off-by: Beraldo Leal <bleal@redhat.com>