### PR TITLE
future.settings: Migrate plugins.*.order to use the new API.

### DIFF
--- a/avocado/core/__init__.py
+++ b/avocado/core/__init__.py
@@ -164,6 +164,13 @@ def register_core_options():
                                     default='utf-8',
                                     help_msg=help_msg)
 
+    help_msg = 'List of disabled plugins'
+    future_settings.register_option(section='plugins',
+                                    key='disable',
+                                    key_type=list,
+                                    default=[],
+                                    help_msg=help_msg)
+
 
 def initialize_plugins():
     InitDispatcher().map_method('initialize')

--- a/avocado/core/dispatcher.py
+++ b/avocado/core/dispatcher.py
@@ -21,6 +21,8 @@ dispatcher that these depend upon:
 """
 
 from .enabled_extension_manager import EnabledExtensionManager
+from .future.settings import DuplicatedNamespace
+from .future.settings import settings as future_settings
 
 
 class CLIDispatcher(EnabledExtensionManager):
@@ -106,7 +108,8 @@ class VarianterDispatcher(EnabledExtensionManager):
 
     def map_method_with_return_copy(self, method_name, *args, **kwargs):
         """
-        The same as map_method_with_return, but use copy.deepcopy on each passed arg
+        The same as map_method_with_return, but use copy.deepcopy on each
+        passed arg
         """
         return super(VarianterDispatcher, self).map_method_with_return(
             method_name, deepcopy=True, *args, **kwargs)
@@ -121,4 +124,84 @@ class RunnerDispatcher(EnabledExtensionManager):
 class InitDispatcher(EnabledExtensionManager):
 
     def __init__(self):
+        try:
+            help_msg = 'Init extension dispatcher'
+            future_settings.register_option(section='plugins.init',
+                                            key='order',
+                                            key_type=list,
+                                            default=[],
+                                            help_msg=help_msg)
+        except DuplicatedNamespace:
+            pass
+
+        try:
+            help_msg = 'CLI extension dispatcher'
+            future_settings.register_option(section='plugins.cli',
+                                            key='order',
+                                            key_type=list,
+                                            default=[],
+                                            help_msg=help_msg)
+        except DuplicatedNamespace:
+            pass
+
+        try:
+            help_msg = 'CLI command extension dispatcher'
+            future_settings.register_option(section='plugins.cli.cmd',
+                                            key='order',
+                                            key_type=list,
+                                            default=[],
+                                            help_msg=help_msg)
+        except DuplicatedNamespace:
+            pass
+
+        try:
+            help_msg = 'Job Pre/Post extension dispatcher'
+            future_settings.register_option(section='plugins.job.prepost',
+                                            key='order',
+                                            key_type=list,
+                                            default=[],
+                                            help_msg=help_msg)
+        except DuplicatedNamespace:
+            pass
+        try:
+            help_msg = 'Result extension dispatcher'
+            future_settings.register_option(section='plugins.result',
+                                            key='order',
+                                            key_type=list,
+                                            default=[],
+                                            help_msg=help_msg)
+        except DuplicatedNamespace:
+            pass
+
+        try:
+            help_msg = 'Result Events extension dispatcher'
+            future_settings.register_option(
+                section='plugins.result_events',
+                key='order',
+                key_type=list,
+                default=[],
+                help_msg=help_msg)
+        except DuplicatedNamespace:
+            pass
+
+        try:
+            help_msg = 'Varianter extension dispatcher'
+            future_settings.register_option(section='plugins.varianter',
+                                            key='order',
+                                            key_type=list,
+                                            default=[],
+                                            help_msg=help_msg)
+        except DuplicatedNamespace:
+            pass
+
+        try:
+            help_msg = 'Runner extension dispatcher'
+            future_settings.register_option(section='plugins.runner',
+                                            key='order',
+                                            key_type=list,
+                                            default=[],
+                                            help_msg=help_msg)
+        except DuplicatedNamespace:
+            pass
+
         super(InitDispatcher, self).__init__('avocado.plugins.init')

--- a/avocado/core/enabled_extension_manager.py
+++ b/avocado/core/enabled_extension_manager.py
@@ -17,7 +17,7 @@ Extension manager with disable/ordering support
 """
 
 from .extension_manager import ExtensionManager
-from .settings import settings
+from .future.settings import settings as future_settings
 from .settings import SettingsError
 
 
@@ -25,8 +25,8 @@ class EnabledExtensionManager(ExtensionManager):
 
     def __init__(self, namespace, invoke_kwds=None):
         super(EnabledExtensionManager, self).__init__(namespace, invoke_kwds)
-        configured_order = settings.get_value(self.settings_section(), "order",
-                                              key_type=list, default=[])
+        namespace = '{}.order'.format(self.settings_section())
+        configured_order = future_settings.as_dict().get(namespace)
         ordered = []
         for name in configured_order:
             for ext in self.extensions:
@@ -45,7 +45,7 @@ class EnabledExtensionManager(ExtensionManager):
         is disabled.
         """
         try:
-            disabled = settings.get_value('plugins', 'disable', key_type=list)
+            disabled = future_settings.as_dict().get('plugins.disable')
             return self.fully_qualified_name(extension) not in disabled
         except SettingsError:
             return True

--- a/avocado/core/resolver.py
+++ b/avocado/core/resolver.py
@@ -20,6 +20,7 @@ import os
 from enum import Enum
 
 from .enabled_extension_manager import EnabledExtensionManager
+from .future.settings import settings as future_settings
 
 
 class ReferenceResolutionResult(Enum):
@@ -95,6 +96,12 @@ class Resolver(EnabledExtensionManager):
     }
 
     def __init__(self):
+        help_msg = 'Resolver extension dispatcher'
+        future_settings.register_option(section='plugins.resolver',
+                                        key='order',
+                                        key_type=list,
+                                        default=[],
+                                        help_msg=help_msg)
         super(Resolver, self).__init__('avocado.plugins.resolver')
 
     def resolve(self, reference):


### PR DESCRIPTION
Implementation decisions to be discussed:
- I tried to register the `plugins.*.order` options into each specific class on `dispatcher.py`. Still, the configuration file is processed before the options are registered, resulting in the configuration file being ignored for `plugins.*.order`. This leads me to register the options into `InitDispatcher` class.
- The `InitDispatcher` class, in some cases, is instantiated more than once, and the registration of the option is also tried more than once. To overcome the `DuplicateNamespace` exception, the registrations are kept into a try/except block. Although it makes sense the register the options into `InitDispatcher`, maybe we can move them to `register_core_options` to avoid the multiple registrations of the same namespace and, in consequence, the try/except blocks.
- If we keep the registration the way it is now, we need to decide what goes into the `except` block. At that point in the code, the loggers are not instantiated to log a warning.

Signed-off-by: Willian Rampazzo <willianr@redhat.com>