### PR TITLE
Docs: show configuration reference on builds done at readthedocs.io

### DIFF
--- a/avocado/plugins/config.py
+++ b/avocado/plugins/config.py
@@ -50,22 +50,23 @@ class Config(CLICmd):
 
     def run(self, config):
         if config.get('config_subcommand') == 'reference':
-            self.handle_reference()
+            self.handle_reference(LOG_UI.debug)
         else:
             self.handle_default(config)
 
-    def handle_reference(self):
+    @staticmethod
+    def handle_reference(print_function):
         full = future_settings.as_full_dict()
         for namespace, option in full.items():
-            LOG_UI.debug(namespace)
-            LOG_UI.debug("~" * len(namespace))
+            print_function(namespace)
+            print_function("~" * len(namespace))
             help_lines = textwrap.wrap(option.get('help'))
             for line in help_lines:
-                LOG_UI.debug(line)
-            LOG_UI.debug("")
-            LOG_UI.debug("* Default: %s", option.get('default'))
-            LOG_UI.debug("* Type: %s", option.get('type'))
-            LOG_UI.debug("")
+                print_function(line)
+            print_function("")
+            print_function("* Default: %s" % option.get('default'))
+            print_function("* Type: %s" % option.get('type'))
+            print_function("")
 
     def handle_default(self, config):
         LOG_UI.info("Config files read (in order, '*' means the file exists "

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -45,7 +45,6 @@ clean:
 	-rm -rf $(BUILDDIR)
 
 html:
-	avocado config reference > source/config/reference.rst
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -31,6 +31,17 @@ try:
 except path.CmdNotFoundError:
     APIDOC = False
 
+
+def generate_reference():
+    from avocado.plugins.config import Config
+    reference_path = os.path.join(ROOT_PATH, 'docs', 'source',
+                                  'config', 'reference.rst')
+    with open(reference_path, 'w') as reference:
+        Config.handle_reference(lambda x: reference.write(x + '\n'))
+
+
+generate_reference()
+
 # Documentation sections. Key is the name of the section, followed by:
 # Second level module name (after avocado), Module description,
 # Output directory, List of directory to exclude from API  generation,


### PR DESCRIPTION
Which doesn't do builds by makefiles, but by using conf.py only. So,
currently, at:

  https://avocado-framework.readthedocs.io/en/latest/config/index.html

The config reference is now being shown, and this is a fix.

Signed-off-by: Cleber Rosa <crosa@redhat.com>