### PR TITLE
lv_utils: deprecate vg_ramdisk, vg_ramdisk_cleanup

### DIFF
--- a/avocado/utils/lv_utils.py
+++ b/avocado/utils/lv_utils.py
@@ -120,6 +120,8 @@ def vg_ramdisk(disk, vg_name, ramdisk_vg_size,
     - lv_snapshot_size='1G'
     The ramdisk volume group size is in MB.
     """
+    warnings.warn("deprecated, use existing methods: vg_create, lv_create",
+                  DeprecationWarning)
     vg_size = ramdisk_vg_size
     vg_ramdisk_dir = os.path.join(ramdisk_basedir, vg_name)
     ramdisk_filename = os.path.join(vg_ramdisk_dir,
@@ -194,6 +196,8 @@ def vg_ramdisk_cleanup(ramdisk_filename=None, vg_ramdisk_dir=None,
     :rtype: (str, str, str, str)
     :raises: :py:class:`LVException` on intolerable failure at any stage
     """
+    warnings.warn("deprecated, use existing methods: vg_remove, lv_remove",
+                  DeprecationWarning)
     errs = []
     if vg_name is not None:
         loop_device = re.search(r"([/\w-]+) +%s +lvm2" % vg_name,


### PR DESCRIPTION
The functions vg_ramdisk() and vg_ramdisk_cleanup() were more
complex in what they did, assuming loop devices and trying to
boost performance, though there was little evidence. There
was no obvious benefit in terms of the operation it performed
as well. The code maintainence was also becoming more complex.
So deprecating it, and encouraging to use the individual
functions instead.

Check the pull request for more details:
avocado-framework/avocado/pull/3857

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>