### PR TITLE
Future Settings: reuse the namespace already available [v2]

### DIFF
--- a/avocado/core/future/settings.py
+++ b/avocado/core/future/settings.py
@@ -433,18 +433,13 @@ class Settings:
         :param arg_parse_config: argparse.config dictionary with all
                                  command-line parsed arguments.
         """
-        for tag, value in arg_parse_config.items():
+        for namespace, value in arg_parse_config.items():
             # This check is important! For argparse when an option is
             # not passed will return None. We need to update only the
             # options that the user has specified.
             if value is not None:
-                try:
-                    option = self._namespaces[tag]
-                except KeyError:
-                    continue  # Not registered yet, using the new module
-                self.update_option("{}.{}".format(option.section,
-                                                  option.key),
-                                   value)
+                if namespace in self._namespaces:
+                    self.update_option(namespace, value)
 
     def merge_with_configs(self):
         """Merge the current settings with the config file options.


### PR DESCRIPTION
Instead of trying to create the name from the option instance
information.  While at it, rename the tag variable appropriately.

Signed-off-by: Cleber Rosa <crosa@redhat.com>

---

Changes from v1 (#3954):
 * Replaced try/except block with dictionary presence check