### PR TITLE
Future Settings: check if _value is None into value property.

### DIFF
--- a/avocado/core/future/settings.py
+++ b/avocado/core/future/settings.py
@@ -125,7 +125,7 @@ class ConfigOption:
 
     @property
     def value(self):
-        if self._value:
+        if self._value is not None:
             return self._value
         return self.default
 


### PR DESCRIPTION
When _value is 0, the value property returns the default value instead of the correct _value.

Signed-off-by: Beraldo Leal <bleal@redhat.com>
Signed-off-by: Willian Rampazzo <willianr@redhat.com>