### PR TITLE
core: small refactoring on job.py and a smaller run_suite() signature

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -28,32 +28,13 @@ import time
 import traceback
 import uuid
 
-from . import data_dir
-from . import dispatcher
-from . import exceptions
-from . import exit_codes
-from . import job_id
-from . import jobdata
-from . import loader
-from . import nrunner
-from . import output
-from . import resolver
-from . import result
-from . import tags
-from . import varianter
-from . import version
-from ..utils import astring
-from ..utils import data_structures
-from ..utils import path
-from ..utils import process
-from ..utils import stacktrace
-from .output import LOG_JOB
-from .output import LOG_UI
-from .output import STD_OUTPUT
+from ..utils import astring, data_structures, path, process, stacktrace
+from . import (data_dir, dispatcher, exceptions, exit_codes, job_id, jobdata,
+               loader, nrunner, output, result, tags, varianter, version)
 from .future.settings import settings
+from .output import LOG_JOB, LOG_UI, STD_OUTPUT
 from .tags import filter_test_tags_runnable
 from .test import DryRunTest
-
 
 _NEW_ISSUE_LINK = 'https://github.com/avocado-framework/avocado/issues/new'
 

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -33,6 +33,7 @@ from . import (data_dir, dispatcher, exceptions, exit_codes, job_id, jobdata,
                loader, nrunner, output, result, tags, varianter, version)
 from .future.settings import settings
 from .output import LOG_JOB, LOG_UI, STD_OUTPUT
+from .resolver import (resolve, ReferenceResolutionResult)
 from .tags import filter_test_tags_runnable
 from .test import DryRunTest
 
@@ -65,19 +66,20 @@ def resolutions_to_tasks(resolutions, config):
     """
 
     tasks = []
-    resolutions = [res for res in resolutions if
-                   res.result == resolver.ReferenceResolutionResult.SUCCESS]
     filter_by_tags = config.get("filter.by_tags.tags")
+    include_empty = config.get("filter.by_tags.include_empty")
+    include_empty_key = config.get('filter.by_tags.include_empty_key')
+    status_server = config.get('nrun.status_server.listen')
     for resolution in resolutions:
+        if resolution.result != ReferenceResolutionResult.SUCCESS:
+            continue
         for runnable in resolution.resolutions:
             if filter_by_tags:
-                if not filter_test_tags_runnable(
-                        runnable,
-                        filter_by_tags,
-                        config.get("filter.by_tags.include_empty"),
-                        config.get('filter.by_tags.include_empty_key')):
+                if not filter_test_tags_runnable(runnable,
+                                                 filter_by_tags,
+                                                 include_empty,
+                                                 include_empty_key):
                     continue
-            status_server = config.get('nrun.status_server.listen')
             tasks.append(nrunner.Task(str(uuid.uuid1()), runnable,
                                       [status_server]))
     return tasks
@@ -434,14 +436,14 @@ class Job:
         for reference in references:
             results = [res.result for res in resolutions if
                        res.reference == reference]
-            if resolver.ReferenceResolutionResult.SUCCESS not in results:
+            if ReferenceResolutionResult.SUCCESS not in results:
                 missing.append(reference)
         if missing:
             msg = "Could not resolve references: %s" % ",".join(missing)
             raise exceptions.JobTestSuiteReferenceResolutionError(msg)
 
     def _make_test_suite_resolver(self, references, ignore_missing):
-        resolutions = resolver.resolve(references)
+        resolutions = resolve(references)
         if not ignore_missing:
             self._resolver_check_missing_references(references,
                                                     resolutions)

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -586,15 +586,11 @@ class Job:
 
         self._log_job_debug_info(variant)
         jobdata.record(self.config, self.logdir, variant, sys.argv)
-        replay_map = self.config.get('replay_map')
-        execution_order = self.config.get('run.execution_order')
         summary = self.test_runner.run_suite(self,
                                              self.result,
                                              self.test_suite,
                                              variant,
-                                             self.timeout,
-                                             replay_map,
-                                             execution_order)
+                                             self.config)
         # If it's all good so far, set job status to 'PASS'
         if self.status == 'RUNNING':
             self.status = 'PASS'

--- a/avocado/core/plugin_interfaces.py
+++ b/avocado/core/plugin_interfaces.py
@@ -312,8 +312,7 @@ class Runner(Plugin):
     """
 
     @abc.abstractmethod
-    def run_suite(self, job, result, test_suite, variants, timeout=0,
-                  replay_map=None, execution_order=None):
+    def run_suite(self, job, result, test_suite, variants, config):
         """
         Run one or more tests and report with test result.
 
@@ -321,11 +320,6 @@ class Runner(Plugin):
         :param result: an instance of :class:`avocado.core.result.Result`
         :param test_suite: a list of tests to run.
         :param variants: A varianter iterator to produce test params.
-        :param timeout: maximum amount of time (in seconds) to execute.
-        :param replay_map: optional list to override test class based on test
-                           index.
-        :param execution_order: Mode in which we should iterate through tests
-                                and variants.  If not provided, will default to
-                                :attr:`DEFAULT_EXECUTION_ORDER`.
+        :param config: config dict to run the suit.
         :return: a set with types of test failures.
         """

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -72,9 +72,9 @@ class Runner(RunnerInterface):
         with open(data_file, 'w') as fp:
             fp.write("{}\n".format(task.output_dir))
 
-    def run_suite(self, job, result, test_suite, variants, timeout=0,
-                  replay_map=None, execution_order=None):
+    def run_suite(self, job, result, test_suite, variants, config):
         summary = set()
+        timeout = config.get('run.job_timeout')
         if timeout > 0:
             deadline = time.time() + timeout
         else:


### PR DESCRIPTION
With the progress that we made on Avocado's config dict we can now pass the entire dict to methods and avoid long method signatures.

This is part of bigger refactoring to allow run jobs with multiple suites.