### PR TITLE
Makefile: make the short commit of a more predictable size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ AVOCADO_OPTIONAL_PLUGINS=$(shell find ./optional_plugins -maxdepth 1 -mindepth 1
 endif
 AVOCADO_PLUGINS=$(AVOCADO_OPTIONAL_PLUGINS) $(AVOCADO_EXTERNAL_PLUGINS)
 RELEASE_COMMIT=$(shell git log --pretty=format:'%H' -n 1 $(VERSION))
-RELEASE_SHORT_COMMIT=$(shell git log --pretty=format:'%h' -n 1 $(VERSION))
+RELEASE_SHORT_COMMIT=$(shell git rev-parse --short=9 $(VERSION))
 COMMIT=$(shell git log --pretty=format:'%H' -n 1)
 COMMIT_DATE=$(shell git log --pretty='format:%cd' --date='format:%Y%m%d' -n 1)
 SHORT_COMMIT=$(shell git log --pretty=format:'%h' -n 1)


### PR DESCRIPTION
git changes, from time to time, that is, from version to version, the
meaning of the '%h' formatting string, for short commits.  This
attempts to make it more stable.

BTW, git will use the minimum amount of charatecters needed to
uniquely identify a commit.  We hope that 9 charatecters will be OK
for now.

Signed-off-by: Cleber Rosa <crosa@redhat.com>