### PR TITLE
Travis CI: provide missing/default key names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+os: linux
 dist: xenial
 language: python
 cache: pip
@@ -28,7 +29,7 @@ install:
 script:
     - make check
 
-matrix:
+jobs:
   include:
     - name: "Code Coverage"
       python: "3.8"


### PR DESCRIPTION
Upon job validation, Travis shows:

  root: missing os, using the default linux
  root: key matrix is an alias for jobs, using jobs

Let's help it out, and give/use those keys/values.

Signed-off-by: Cleber Rosa <crosa@redhat.com>