### PR TITLE
Revert "Check namespaces exists before command executes"

### DIFF
--- a/avocado/utils/pmem.py
+++ b/avocado/utils/pmem.py
@@ -209,9 +209,6 @@ class PMem:
             args = '%s -r %s' % (args, region)
         if bus:
             args = '%s -b %s' % (args, bus)
-        if namespace == 'all':
-            if not self.run_ndctl_list('%s -N' % args.replace(namespace, '')):
-                return True
         if verbose:
             args = '%s -v' % args
 
@@ -315,9 +312,6 @@ class PMem:
         for option in list(args_dict.keys()):
             if option:
                 args += ' %s %s' % (args_dict[option], option)
-        if namespace == 'all':
-            if not self.run_ndctl_list('%s -N' % args.replace(namespace, '')):
-                return True
         if force:
             args += ' -f'
 


### PR DESCRIPTION
This reverts commit 3038c8fb75f0eda2651c11aed3b3743caf2ada47. As the reason for the above commit to actually include this fix is declared a bug.

This is not expected to happen with any device and it was a bad stack update.

$ ndctl disable-namespace all
error disabling namespaces: No such device or address
disabled 0 namespaces

So removing the unnecessary changes.

Signed-off-by: Harish <harish@linux.ibm.com>