### PR TITLE
core: small refactoring on job.py and a smaller run_suite() signature (v2)

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -28,32 +28,13 @@ import time
 import traceback
 import uuid
 
-from . import data_dir
-from . import dispatcher
-from . import exceptions
-from . import exit_codes
-from . import job_id
-from . import jobdata
-from . import loader
-from . import nrunner
-from . import output
-from . import resolver
-from . import result
-from . import tags
-from . import varianter
-from . import version
-from ..utils import astring
-from ..utils import data_structures
-from ..utils import path
-from ..utils import process
-from ..utils import stacktrace
-from .output import LOG_JOB
-from .output import LOG_UI
-from .output import STD_OUTPUT
+from ..utils import astring, data_structures, path, process, stacktrace
+from . import (data_dir, dispatcher, exceptions, exit_codes, job_id, jobdata,
+               loader, nrunner, output, result, tags, varianter, version)
 from .future.settings import settings
+from .output import LOG_JOB, LOG_UI, STD_OUTPUT
 from .tags import filter_test_tags_runnable
 from .test import DryRunTest
-
 
 _NEW_ISSUE_LINK = 'https://github.com/avocado-framework/avocado/issues/new'
 

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -145,6 +145,7 @@ class Job:
         self.interrupted_reason = None
         self.timeout = self.config.get('run.job_timeout')
 
+        self._test_parameters = None
         self._unique_id = None
 
         #: The time at which the job has started or `-1` if it has not been
@@ -175,16 +176,6 @@ class Job:
         #: :attr:`test_suite`
         self.test_runner = None
 
-        #: Placeholder for test parameters (related to --test-parameters command
-        #: line option).  They're kept in the job because they will be prepared
-        #: only once, since they are read only and will be shared across all
-        #: tests of a job.
-        self.test_parameters = None
-        if "run.test_parameters" in self.config:
-            self.test_parameters = {}
-            for name, value in self.config.get('run.test_parameters'):
-                self.test_parameters[name] = value
-
         # The result events dispatcher is shared with the test runner.
         # Because of our goal to support using the phases of a job
         # freely, let's get the result events dispatcher ready early.
@@ -200,6 +191,20 @@ class Job:
 
     def __exit__(self, _exc_type, _exc_value, _traceback):
         self.cleanup()
+
+    @property
+    def test_parameters(self):
+        """Placeholder for test parameters.
+
+        This is related to --test-parameters command line option. They're kept
+        in the job because they will be prepared only once, since they are read
+        only and will be shared across all tests of a job.
+        """
+        if self._test_parameters is None:
+            self._test_parameters = {name: value for name, value
+                                     in self.config.get('run.test_parameters',
+                                                        [])}
+        return self._test_parameters
 
     @property
     def unique_id(self):

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -28,7 +28,8 @@ import time
 import traceback
 import uuid
 
-from ..utils import astring, data_structures, path, process, stacktrace
+from ..utils import astring, path, process, stacktrace
+from ..utils.data_structures import CallbackRegister
 from . import (data_dir, dispatcher, exceptions, exit_codes, jobdata,
                loader, nrunner, output, result, tags, varianter, version)
 from .job_id import create_unique_job_id
@@ -143,9 +144,9 @@ class Job:
         self.status = "RUNNING"
         self.result = None
         self.interrupted_reason = None
-        self.timeout = self.config.get('run.job_timeout')
 
         self._test_parameters = None
+        self._timeout = None
         self._unique_id = None
 
         #: The time at which the job has started or `-1` if it has not been
@@ -157,9 +158,7 @@ class Job:
         #: The total amount of time the job took from start to finish,
         #: or `-1` if it has not been started by means of the `run()` method
         self.time_elapsed = -1
-        self.funcatexit = data_structures.CallbackRegister("JobExit %s"
-                                                           % self.unique_id,
-                                                           LOG_JOB)
+        self.funcatexit = CallbackRegister("JobExit %s" % self.unique_id, LOG_JOB)
         self._stdout_stderr = None
         self.replay_sourcejob = self.config.get('replay_sourcejob')
         self.exitcode = exit_codes.AVOCADO_ALL_OK
@@ -205,6 +204,12 @@ class Job:
                                      in self.config.get('run.test_parameters',
                                                         [])}
         return self._test_parameters
+
+    @property
+    def timeout(self):
+        if self._timeout is None:
+            self._timeout = self.config.get('run.job_timeout')
+        return self._timeout
 
     @property
     def unique_id(self):

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -146,12 +146,7 @@ class Job:
         self.status = "RUNNING"
         self.result = None
         self.interrupted_reason = None
-        timeout = self.config.get('run.job_timeout')
-        try:
-            self.timeout = data_structures.time_to_seconds(timeout)
-        except ValueError as detail:
-            LOG_UI.error(detail.args[0])
-            sys.exit(exit_codes.AVOCADO_FAIL)
+        self.timeout = self.config.get('run.job_timeout')
 
         #: The time at which the job has started or `-1` if it has not been
         #: started by means of the `run()` method.
@@ -586,15 +581,10 @@ class Job:
 
         self._log_job_debug_info(variant)
         jobdata.record(self.config, self.logdir, variant, sys.argv)
-        replay_map = self.config.get('replay_map')
-        execution_order = self.config.get('run.execution_order')
         summary = self.test_runner.run_suite(self,
                                              self.result,
                                              self.test_suite,
-                                             variant,
-                                             self.timeout,
-                                             replay_map,
-                                             execution_order)
+                                             variant)
         # If it's all good so far, set job status to 'PASS'
         if self.status == 'RUNNING':
             self.status = 'PASS'

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -29,7 +29,7 @@ import traceback
 import uuid
 
 from ..utils import astring, path, process, stacktrace
-from ..utils.data_structures import CallbackRegister
+from ..utils.data_structures import CallbackRegister, time_to_seconds
 from . import (data_dir, dispatcher, exceptions, exit_codes, jobdata,
                loader, nrunner, output, result, tags, varianter, version)
 from .job_id import create_unique_job_id
@@ -100,6 +100,16 @@ def register_job_options():
                              key='loglevel',
                              default='DEBUG',
                              help_msg=msg)
+
+    help_msg = ('Set the maximum amount of time (in SECONDS) that tests are '
+                'allowed to execute. Values <= zero means "no timeout". You '
+                'can also use suffixes, like: s (seconds), m (minutes), h '
+                '(hours). ')
+    settings.register_option(section='job.run',
+                             key='timeout',
+                             default=0,
+                             key_type=time_to_seconds,
+                             help_msg=help_msg)
 
 
 register_job_options()
@@ -208,7 +218,7 @@ class Job:
     @property
     def timeout(self):
         if self._timeout is None:
-            self._timeout = self.config.get('run.job_timeout')
+            self._timeout = self.config.get('job.run.timeout')
         return self._timeout
 
     @property

--- a/avocado/core/plugin_interfaces.py
+++ b/avocado/core/plugin_interfaces.py
@@ -312,8 +312,7 @@ class Runner(Plugin):
     """
 
     @abc.abstractmethod
-    def run_suite(self, job, result, test_suite, variants, timeout=0,
-                  replay_map=None, execution_order=None):
+    def run_suite(self, job, result, test_suite, variants):
         """
         Run one or more tests and report with test result.
 
@@ -321,11 +320,5 @@ class Runner(Plugin):
         :param result: an instance of :class:`avocado.core.result.Result`
         :param test_suite: a list of tests to run.
         :param variants: A varianter iterator to produce test params.
-        :param timeout: maximum amount of time (in seconds) to execute.
-        :param replay_map: optional list to override test class based on test
-                           index.
-        :param execution_order: Mode in which we should iterate through tests
-                                and variants.  If not provided, will default to
-                                :attr:`DEFAULT_EXECUTION_ORDER`.
         :return: a set with types of test failures.
         """

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -30,6 +30,7 @@ from avocado.core.future.settings import settings
 from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLICmd
 from avocado.utils import process
+from avocado.utils.data_structures import time_to_seconds
 
 
 class Run(CLICmd):
@@ -157,7 +158,8 @@ class Run(CLICmd):
         settings.register_option(section='run',
                                  key='job_timeout',
                                  help_msg=help_msg,
-                                 default='0',
+                                 default=0,
+                                 key_type=time_to_seconds,
                                  metavar='SECONDS',
                                  parser=parser,
                                  long_arg='--job-timeout')

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -30,7 +30,6 @@ from avocado.core.future.settings import settings
 from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLICmd
 from avocado.utils import process
-from avocado.utils.data_structures import time_to_seconds
 
 
 class Run(CLICmd):
@@ -151,18 +150,10 @@ class Run(CLICmd):
                                  metavar='CATEGORY',
                                  long_arg='--job-category')
 
-        help_msg = ('Set the maximum amount of time (in SECONDS) that tests '
-                    'are allowed to execute. Values <= zero means "no '
-                    'timeout". You can also use suffixes, like: s (seconds), '
-                    'm (minutes), h (hours). ')
-        settings.register_option(section='run',
-                                 key='job_timeout',
-                                 help_msg=help_msg,
-                                 default=0,
-                                 key_type=time_to_seconds,
-                                 metavar='SECONDS',
-                                 parser=parser,
-                                 long_arg='--job-timeout')
+        settings.add_argparser_to_option(namespace='job.run.timeout',
+                                         metavar='SECONDS',
+                                         parser=parser,
+                                         long_arg='--job-timeout')
 
         help_msg = ('Enable or disable the job interruption on first failed '
                     'test. "on" and "off" will be deprecated soon.')

--- a/avocado/plugins/runner.py
+++ b/avocado/plugins/runner.py
@@ -348,8 +348,7 @@ class TestRunner(Runner):
             raise NotImplementedError("Suite_order %s is not supported"
                                       % execution_order)
 
-    def run_suite(self, job, result, test_suite, variants, timeout=0,
-                  replay_map=None, execution_order=None):
+    def run_suite(self, job, result, test_suite, variants):
         """
         Run one or more tests and report with test result.
 
@@ -357,15 +356,12 @@ class TestRunner(Runner):
         :param result: an instance of :class:`avocado.core.result.Result`
         :param test_suite: a list of tests to run.
         :param variants: A varianter iterator to produce test params.
-        :param timeout: maximum amount of time (in seconds) to execute.
-        :param replay_map: optional list to override test class based on test
-                           index.
-        :param execution_order: Mode in which we should iterate through tests
-                                and variants.  If not provided, will default to
-                                :attr:`DEFAULT_EXECUTION_ORDER`.
         :return: a set with types of test failures.
         """
         summary = set()
+        timeout = job.config.get('run.job_timeout')
+        replay_map = job.config.get('replay_map')
+        execution_order = job.config.get('run.execution_order')
         queue = multiprocessing.SimpleQueue()
         if timeout > 0:
             deadline = time.time() + timeout

--- a/avocado/plugins/runner.py
+++ b/avocado/plugins/runner.py
@@ -359,12 +359,11 @@ class TestRunner(Runner):
         :return: a set with types of test failures.
         """
         summary = set()
-        timeout = job.config.get('run.job_timeout')
         replay_map = job.config.get('replay_map')
         execution_order = job.config.get('run.execution_order')
         queue = multiprocessing.SimpleQueue()
-        if timeout > 0:
-            deadline = time.time() + timeout
+        if job.timeout > 0:
+            deadline = time.time() + job.timeout
         else:
             deadline = None
 

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -72,9 +72,9 @@ class Runner(RunnerInterface):
         with open(data_file, 'w') as fp:
             fp.write("{}\n".format(task.output_dir))
 
-    def run_suite(self, job, result, test_suite, variants, timeout=0,
-                  replay_map=None, execution_order=None):
+    def run_suite(self, job, result, test_suite, variants):
         summary = set()
+        timeout = job.config.get('run.job_timeout')
         if timeout > 0:
             deadline = time.time() + timeout
         else:

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -74,9 +74,8 @@ class Runner(RunnerInterface):
 
     def run_suite(self, job, result, test_suite, variants):
         summary = set()
-        timeout = job.config.get('run.job_timeout')
-        if timeout > 0:
-            deadline = time.time() + timeout
+        if job.timeout > 0:
+            deadline = time.time() + job.timeout
         else:
             deadline = None
 

--- a/selftests/functional/test_job_timeout.py
+++ b/selftests/functional/test_job_timeout.py
@@ -133,13 +133,13 @@ class JobTimeOutTest(unittest.TestCase):
                     % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_FAIL)
-        self.assertIn(b'Invalid value', result.stderr)
+        self.assertIn(b'invalid time_to_seconds value', result.stderr)
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
                     '--job-timeout=123x examples/tests/passtest.py'
                     % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_FAIL)
-        self.assertIn(b'Invalid value', result.stderr)
+        self.assertIn(b'invalid time_to_seconds', result.stderr)
 
     def test_valid_values(self):
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off '


### PR DESCRIPTION
With the progress that we made on Avocado's config dict we can now pass the entire dict to methods and avoid long method signatures. We have here also an attempt to reduce the lines on the `__init__()` method to improve code readability and maintainability making some attributes a `@property` (since our configuration is now via the `config` dictionary, those changes will protect the properties and avoid unwanted setters).

This is part of bigger refactoring to allow run jobs with multiple suites.

**Changes from v1:**

 - Fixed the `time_to_seconds()`: now it is being called at register_option;
 - Removed `()` (parentesis) at import line;
 - Fixed commit log message;
 - Added a few commits to convert some attributes to a `@property`;
 - Migrates the registration of run.job_timeout from plugins.run to core.job
