### PR TITLE
GDB Remote: fix checksum format

### DIFF
--- a/avocado/utils/gdb.py
+++ b/avocado/utils/gdb.py
@@ -704,7 +704,7 @@ class GDBRemote:
             total += i
         result = total % 256
 
-        return b'%2x' % result
+        return b'%02x' % result
 
     @staticmethod
     def encode(data):


### PR DESCRIPTION
Remote protocol specification states that the checksum should be two-digit.
This patch fixes one-digit checksum formatting.