### PR TITLE
run_suite(): smaller method signature since job has already the attributes

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -607,7 +607,7 @@ class Job:
 
         self._log_job_debug_info(variant)
         jobdata.record(self.config, self.logdir, variant, sys.argv)
-        summary = self.test_runner.run_suite(self, variant)
+        summary = self.test_runner.run_job(self, variant)
         # If it's all good so far, set job status to 'PASS'
         if self.status == 'RUNNING':
             self.status = 'PASS'

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -607,10 +607,7 @@ class Job:
 
         self._log_job_debug_info(variant)
         jobdata.record(self.config, self.logdir, variant, sys.argv)
-        summary = self.test_runner.run_suite(self,
-                                             self.result,
-                                             self.test_suite,
-                                             variant)
+        summary = self.test_runner.run_suite(self, variant)
         # If it's all good so far, set job status to 'PASS'
         if self.status == 'RUNNING':
             self.status = 'PASS'

--- a/avocado/core/plugin_interfaces.py
+++ b/avocado/core/plugin_interfaces.py
@@ -312,9 +312,9 @@ class Runner(Plugin):
     """
 
     @abc.abstractmethod
-    def run_suite(self, job, variants):
+    def run_job(self, job, variants):
         """
-        Run one or more tests and report with test result.
+        Run a job with one test_suite (for now) and report with test result.
 
         :param job: an instance of :class:`avocado.core.job.Job`.
         :param variants: A varianter iterator to produce test params.

--- a/avocado/core/plugin_interfaces.py
+++ b/avocado/core/plugin_interfaces.py
@@ -312,13 +312,11 @@ class Runner(Plugin):
     """
 
     @abc.abstractmethod
-    def run_suite(self, job, result, test_suite, variants):
+    def run_suite(self, job, variants):
         """
         Run one or more tests and report with test result.
 
         :param job: an instance of :class:`avocado.core.job.Job`.
-        :param result: an instance of :class:`avocado.core.result.Result`
-        :param test_suite: a list of tests to run.
         :param variants: A varianter iterator to produce test params.
         :return: a set with types of test failures.
         """

--- a/avocado/plugins/runner.py
+++ b/avocado/plugins/runner.py
@@ -347,9 +347,9 @@ class TestRunner(Runner):
             raise NotImplementedError("Suite_order %s is not supported"
                                       % execution_order)
 
-    def run_suite(self, job, variants):
+    def run_job(self, job, variants):
         """
-        Run one or more tests and report with test result.
+        Run a job with one test_suite (for now) and report with test result.
 
         :param job: an instance of :class:`avocado.core.job.Job`.
         :param variants: A varianter iterator to produce test params.

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -72,7 +72,7 @@ class Runner(RunnerInterface):
         with open(data_file, 'w') as fp:
             fp.write("{}\n".format(task.output_dir))
 
-    def run_suite(self, job, variants):
+    def run_job(self, job, variants):
         summary = set()
         if job.timeout > 0:
             deadline = time.time() + job.timeout


### PR DESCRIPTION
`result` and `test_suite` are both job's properties. This will reduce the method's signature. Also since that we are passing a job and thinking in the near future that a job can have multiple test suites, IMO, makes more sense to call this method `run_job()`.