### PR TITLE
Rename args to config

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -138,7 +138,7 @@ class Job:
         self.log = LOG_UI
         self.loglevel = self.config.get('job.output.loglevel')
         self.__logging_handlers = {}
-        if self.config.get('run.dry_run.enabled'):  # Modify args for dry-run
+        if self.config.get('run.dry_run.enabled'):  # Modify config for dry-run
             unique_id = self.config.get('run.unique_job_id')
             if unique_id is None:
                 self.config['run.unique_job_id'] = '0' * 40
@@ -292,7 +292,7 @@ class Job:
             LOG_JOB.warning(msg)
             return
 
-        # we could also get "base_logdir" from args, but I believe this is
+        # we could also get "base_logdir" from config, but I believe this is
         # the best choice because it reduces the dependency surface (depends
         # only on self.logdir)
         category_path = os.path.join(os.path.dirname(self.logdir),

--- a/avocado/plugins/list.py
+++ b/avocado/plugins/list.py
@@ -31,20 +31,20 @@ class TestLister:
     Lists available test modules
     """
 
-    def __init__(self, args):
+    def __init__(self, config):
         try:
-            loader.loader.load_plugins(args)
+            loader.loader.load_plugins(config)
         except loader.LoaderError as details:
             sys.stderr.write(str(details))
             sys.stderr.write('\n')
             sys.exit(exit_codes.AVOCADO_FAIL)
-        self.args = args
+        self.config = config
 
     def _extra_listing(self):
         loader.loader.get_extra_listing()
 
     def _get_test_suite(self, paths):
-        if self.args.get('core.verbose'):
+        if self.config.get('core.verbose'):
             which_tests = loader.DiscoverMode.ALL
         else:
             which_tests = loader.DiscoverMode.AVAILABLE
@@ -74,7 +74,7 @@ class TestLister:
             stats[type_label.lower()] += 1
             type_label = decorator(type_label)
 
-            if self.args.get('core.verbose'):
+            if self.config.get('core.verbose'):
                 if 'tags' in params:
                     tgs = params['tags']
                 else:
@@ -98,7 +98,7 @@ class TestLister:
 
     def _display(self, test_matrix, stats, tag_stats):
         header = None
-        if self.args.get('core.verbose'):
+        if self.config.get('core.verbose'):
             header = (output.TERM_SUPPORT.header_str('Type'),
                       output.TERM_SUPPORT.header_str('Test'),
                       output.TERM_SUPPORT.header_str('Tag(s)'))
@@ -107,7 +107,7 @@ class TestLister:
                                                 strip=True):
             LOG_UI.debug(line)
 
-        if self.args.get('core.verbose'):
+        if self.config.get('core.verbose'):
             LOG_UI.info("")
             LOG_UI.info("TEST TYPES SUMMARY")
             LOG_UI.info("==================")
@@ -123,13 +123,13 @@ class TestLister:
 
     def _list(self):
         self._extra_listing()
-        test_suite = self._get_test_suite(self.args.get('list.references'))
-        if self.args.get('list.filter_by_tags'):
+        test_suite = self._get_test_suite(self.config.get('list.references'))
+        if self.config.get('list.filter_by_tags'):
             test_suite = tags.filter_test_tags(
                 test_suite,
-                self.args.get('list.filter_by_tags'),
-                self.args.get('list.filter_by_tags_include_empty'),
-                self.args.get('list.filter_by_tags_include_empty_key'))
+                self.config.get('list.filter_by_tags'),
+                self.config.get('list.filter_by_tags_include_empty'),
+                self.config.get('list.filter_by_tags_include_empty_key'))
         test_matrix, stats, tag_stats = self._get_test_matrix(test_suite)
         self._display(test_matrix, stats, tag_stats)
 

--- a/optional_plugins/loader_yaml/avocado_loader_yaml/__init__.py
+++ b/optional_plugins/loader_yaml/avocado_loader_yaml/__init__.py
@@ -82,14 +82,14 @@ class YamlTestsuiteLoader(loader.TestLoader):
                                % (mod, klass))
         _args = params.get("test_reference_resolver_args")
         if not _args:
-            args = self.args
+            config = self.config
         else:
-            args = copy.copy(self.args)
-            args.update(_args)
+            config = copy.copy(self.config)
+            config.update(_args)
         extra_params = params.get("test_reference_resolver_extra", default={})
         if extra_params:
             extra_params = copy.deepcopy(extra_params)
-        return loader_class(args, extra_params)
+        return loader_class(config, extra_params)
 
     def discover(self, reference, which_tests=loader.DiscoverMode.DEFAULT):
         tests = []
@@ -97,8 +97,8 @@ class YamlTestsuiteLoader(loader.TestLoader):
             return tests
         try:
             root = mux.apply_filters(create_from_yaml([reference], False),
-                                     self.args.get("run.mux_suite_only", []),
-                                     self.args.get("run.mux_suite_out", []))
+                                     self.config.get("run.mux_suite_only", []),
+                                     self.config.get("run.mux_suite_out", []))
         except IOError:
             return []
         mux_tree = mux.MuxTree(root)


### PR DESCRIPTION
A instance of `argparse.Namespace` has been used for a long time as
the main source of configuration, and that name is still present in
many places in the code.

We're now at the point where all configuration (but a few exceptions,
before the complete settings module is initialized and generates a
configuration) comes from the "avocado.core.future.settings" module,
and it may not even have a argparser or command line option
contributing to it.

So, let's rename those "args" occurences to "config" which is now
the unified output of the settings module.

Signed-off-by: Cleber Rosa <crosa@redhat.com>