### PR TITLE
passwordless scp add function to ssh.py

### DIFF
--- a/avocado/utils/ssh.py
+++ b/avocado/utils/ssh.py
@@ -29,6 +29,12 @@ except path_utils.CmdNotFoundError:
     SSH_CLIENT_BINARY = None
 
 
+class NWException(Exception):
+    """
+    Base Exception Class for all exceptions
+    """
+
+
 class Session:
     """
     Represents an SSH session to a remote system, for the purpose of
@@ -214,3 +220,32 @@ class Session:
         :rtype: bool
         """
         return self._master_command('exit')
+
+    def copy_files(self, source, destination, recursive=False):
+        """
+        Copy Files to and from remote through scp session.
+
+        :param source: Source file
+        :type: str
+        :param destination: Destination file location
+        :type: str
+        :param recursive: Scp option for copy file. if set to True
+                          copy files inside directory recursively.
+        :type: bool
+        :returns: True if success and an exception if not.
+        :rtype: bool
+        """
+        try:
+            cmd = path_utils.find_command('scp')
+        except path_utils.CmdNotFoundError as exc:
+            raise exc
+        options = self._dash_o_opts_to_str(self.DEFAULT_OPTIONS)
+        if recursive:
+            options += ' -r'
+        options += " {} {}".format(source, destination)
+        try:
+            result = process.run("{} {}".format(cmd, options),
+                                 ignore_status=True)
+            return result.exit_status == 0
+        except process.CmdError as exc:
+            raise NWException("failed to copy file {}".format(exc))


### PR DESCRIPTION
add scp_connection() and scp_cmd() to ssh.py for copy file to
remote and from remote through session.

Signed-off-by: bismurti bidhibrata pattajoshi <bbidhibr@in.ibm.com>