### PR TITLE
Feature tests: Tentative framework for feature tests.

### DIFF
--- a/selftests/pre_release/jobs/features/features.py
+++ b/selftests/pre_release/jobs/features/features.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+
+import glob
+import os
+import shutil
+import sys
+
+from avocado.core.job import Job
+
+DIR = os.path.dirname(os.path.abspath(__file__))
+TEST_DIR = os.path.join(DIR, 'tests')
+
+FEAT_TESTS = [
+    # job.run.result.html.enabled
+    {'test_body_set_config': {'feature': 'job.run.result.html.enabled',
+                              'value': 'on'},
+     'test_body_job': {},
+     'test_body_check_file': {'file': 'results.html',
+                              'assert': 'self.assertTrue',
+                              'assert_err': 'AssertTrue: could not find file %s'}
+     },
+
+    {'test_body_set_config': {'feature': 'job.run.result.html.enabled',
+                              'value': 'off'},
+     'test_body_job': {},
+     'test_body_check_file': {'file': 'results.html',
+                              'assert': 'self.assertFalse',
+                              'assert_err': 'AssertFalse: found file %s'}
+     },
+    # job.run.result.json.enabled
+    {'test_body_set_config': {'feature': 'job.run.result.json.enabled',
+                              'value': 'on'},
+     'test_body_job': {},
+     'test_body_check_file': {'file': 'results.json',
+                              'assert': 'self.assertTrue',
+                              'assert_err': 'AssertTrue: could not find file %s'}
+     },
+
+    {'test_body_set_config': {'feature': 'job.run.result.json.enabled',
+                              'value': 'off'},
+     'test_body_job': {},
+     'test_body_check_file': {'file': 'results.json',
+                              'assert': 'self.assertFalse',
+                              'assert_err': 'AssertFalse: found file %s'}
+     },
+    # job.run.result.tap.enabled
+    {'test_body_set_config': {'feature': 'job.run.result.tap.enabled',
+                              'value': 'on'},
+     'test_body_job': {},
+     'test_body_check_file': {'file': 'results.tap',
+                              'assert': 'self.assertTrue',
+                              'assert_err': 'AssertTrue: could not find file %s'}
+     },
+
+    {'test_body_set_config': {'feature': 'job.run.result.tap.enabled',
+                              'value': 'off'},
+     'test_body_job': {},
+     'test_body_check_file': {'file': 'results.tap',
+                              'assert': 'self.assertFalse',
+                              'assert_err': 'AssertFalse: found file %s'}
+     },
+    # job.run.result.tap.include_logs
+    {'test_body_set_config': {'feature': 'job.run.result.tap.include_logs',
+                              'value': 'on'},
+     'test_body_job': {},
+     'test_body_check_file': {'file': 'results.tap',
+                              'assert': 'self.assertTrue',
+                              'assert_err': 'AssertTrue: could not find file %s'},
+     'test_body_check_file_content': {'content': 'PASS 1-examples/tests/passtest.py:PassTest.test',}
+     },
+    # job.run.result.xunit.enabled
+    {'test_body_set_config': {'feature': 'job.run.result.xunit.enabled',
+                              'value': 'on'},
+     'test_body_job': {},
+     'test_body_check_file': {'file': 'results.xml',
+                              'assert': 'self.assertTrue',
+                              'assert_err': 'AssertTrue: could not find file %s'}
+     },
+
+    {'test_body_set_config': {'feature': 'job.run.result.xunit.enabled',
+                              'value': 'off'},
+     'test_body_job': {},
+     'test_body_check_file': {'file': 'results.xml',
+                              'assert': 'self.assertFalse',
+                              'assert_err': 'AssertFalse: found file %s'}
+     },
+
+]
+
+
+def load_templates():
+    """
+    Loads templates from files and returns a dictionary.
+    """
+
+    template_files = glob.glob(os.path.join(DIR, 'templates', '*.template'))
+
+    templates = {}
+    for template_file in template_files:
+        with open(template_file, 'r') as f:
+            template_name = os.path.basename(template_file)[:-9]
+            templates[template_name] = f.read()
+
+    return templates
+
+
+if __name__ == '__main__':
+
+    os.makedirs(TEST_DIR, exist_ok=True)
+    templates = load_templates()
+
+    references = []
+    # build the tests
+    for test in FEAT_TESTS:
+        test_dict = {}
+        feature = test['test_body_set_config']['feature'].replace('.', '_')
+        value = test['test_body_set_config']['value']
+        namespace = '%s_%s' % (feature, value)
+        test_dict['class_name'] = feature
+        test_dict['test_name'] = namespace
+        test_dict['setup'] = templates['setup_create_tmpdir']
+
+        # build the body
+        body_list = []
+        for code in test:
+            body_list.append(templates[code].format(**test[code]))
+
+        test_dict['test_body'] = ''.join(body_list)
+
+        test_dict['tear_down'] = templates['teardown_clean_tmpdir']
+
+        # save test to disk
+        file_name = 'test_%s.py' % namespace
+        with open(os.path.join(TEST_DIR, file_name), 'w') as f:
+            f.write(templates['test_class'].format(**test_dict))
+            references.append(f.name)
+
+    # run all the tests
+    config = {'run.references': references}
+    with Job(config) as j:
+        j.run()
+
+    shutil.rmtree(TEST_DIR)

--- a/selftests/pre_release/jobs/features/templates/setup_create_tmpdir.template
+++ b/selftests/pre_release/jobs/features/templates/setup_create_tmpdir.template
@@ -1,0 +1,5 @@
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
+        self.base_config = {'core.show': ['none'],
+                            'run.results_dir': self.tmpdir.name,
+                            'run.references': ['examples/tests/passtest.py']}

--- a/selftests/pre_release/jobs/features/templates/teardown_clean_tmpdir.template
+++ b/selftests/pre_release/jobs/features/templates/teardown_clean_tmpdir.template
@@ -1,0 +1,2 @@
+        # clean up temp dir
+        self.tmpdir.cleanup()

--- a/selftests/pre_release/jobs/features/templates/test_body_check_file.template
+++ b/selftests/pre_release/jobs/features/templates/test_body_check_file.template
@@ -1,0 +1,6 @@
+        # check file
+        file_path = os.path.join(
+            self.tmpdir.name, 'latest', '{file}')
+        msg_file = '{assert_err}' % file_path
+        {assert}(os.path.exists(file_path), msg_file)
+

--- a/selftests/pre_release/jobs/features/templates/test_body_check_file_content.template
+++ b/selftests/pre_release/jobs/features/templates/test_body_check_file_content.template
@@ -1,0 +1,9 @@
+        # check file content
+        msg_content = 'Could not find content on %s: %s' % (
+            file_path, '{content}')
+        self.assertTrue(
+            file_has_content(
+                file_path,
+                '{content}'
+            ), msg_content)
+

--- a/selftests/pre_release/jobs/features/templates/test_body_job.template
+++ b/selftests/pre_release/jobs/features/templates/test_body_job.template
@@ -1,0 +1,7 @@
+        # run the job
+        with Job(self.base_config) as j:
+            result = j.run()
+
+        # check if job ended with success
+        self.assertEqual(result, exit_codes.AVOCADO_ALL_OK)
+

--- a/selftests/pre_release/jobs/features/templates/test_body_set_config.template
+++ b/selftests/pre_release/jobs/features/templates/test_body_set_config.template
@@ -1,0 +1,3 @@
+        # add the feature to the config
+        self.base_config['{feature}'] = '{value}'
+

--- a/selftests/pre_release/jobs/features/templates/test_class.template
+++ b/selftests/pre_release/jobs/features/templates/test_class.template
@@ -1,0 +1,39 @@
+import os
+import tempfile
+
+from avocado import Test
+from avocado.core import exit_codes
+from avocado.core.job import Job
+
+
+def file_has_content(file_path, content):
+    """
+    Check if a file contains `content`.
+    """
+
+    if os.path.isfile(file_path):
+        with open(file_path, "r") as f:
+            source_content = f.read()
+
+    if content in source_content:
+        return True
+    return False
+
+def temp_dir_prefix(module_name, klass, method):
+    """
+    Returns a standard name for the temp dir prefix used by the tests
+    """
+    fmt = 'avocado__%s__%s__%s__'
+    return fmt % (module_name, klass.__class__.__name__, method)
+
+
+class JobAPI_{class_name}(Test):
+
+    def setUp(self):
+{setup}
+
+    def test_{test_name}(self):
+{test_body}
+
+    def tearDown(self):
+{tear_down}


### PR DESCRIPTION
This is an initial tentative for a framework to test Avocado features.

The advantages of this implementation I can think of are:
- Flexibility to use templates for different blocks of codes - inspired by Lego :);
- Easy to reproduce a problem and debug a specific failing test (`--keep-tests` command-line option to be added);
- It can be extended to other kinds of tests later.

Signed-off-by: Willian Rampazzo <willianr@redhat.com>