### PR TITLE
sysinfo: Introduce AVOCADO_SYSINFODIR

### DIFF
--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -177,6 +177,7 @@ class Command(Collectible):
                                  verbose=False,
                                  ignore_status=True,
                                  allow_output_check='combined',
+                                 shell=True,
                                  env=env)
         except FileNotFoundError as exc_fnf:
             log.debug("Not logging '%s' (command '%s' was not found)", self.cmd,
@@ -532,6 +533,7 @@ class SysInfo:
 
     def start(self):
         """Log all collectibles at the start of the event."""
+        os.environ['AVOCADO_SYSINFODIR'] = self.pre_dir
         for log_hook in self.start_collectibles:
             if isinstance(log_hook, Daemon):  # log daemons in profile directory
                 log_hook.run(self.profile_dir)
@@ -545,6 +547,7 @@ class SysInfo:
         """
         Logging hook called whenever a job finishes.
         """
+        os.environ['AVOCADO_SYSINFODIR'] = self.post_dir
         for log_hook in self.end_collectibles:
             log_hook.run(self.post_dir)
 

--- a/docs/source/guides/user/chapters/introduction.rst
+++ b/docs/source/guides/user/chapters/introduction.rst
@@ -515,6 +515,8 @@ the sysinfo collection. Avocado supports three types of tasks:
    before and after the job/test (single execution commands). It is possible
    to set a timeout which is enforced per each executed command in
    [sysinfo.collect] by setting "commands_timeout" to a positive number.
+   You can also use the environment variable AVOCADO_SYSINFODIR which points
+   to the sysinfo directory in results.
 2. files - file with new-line separated list of files to be copied
 3. profilers - file with new-line separated list of commands to be executed
    before the job/test and killed at the end of the job/test (follow-like


### PR DESCRIPTION
sysinfo collectibles commands generate not only outputs, but also
files. The output is stored in appropriate test sysinfo directory,
but not the files generated.

Now, with the introduction of new environment variable
AVOCADO_SYSINFODIR, the sysinfo commands can use them to place the
directory appropriately.
This new environment variable takes care of pre/post as well.

This was to handle the issue from:
https://github.com/avocado-framework/avocado/issues/3977

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>