### PR TITLE
Fixup: Test name to include all variant tags

### DIFF
--- a/avocado/core/varianter.py
+++ b/avocado/core/varianter.py
@@ -45,9 +45,29 @@ def generate_variant_id(variant):
     :return: String compounded of ordered node names and a hash of all
              values.
     """
+    def get_variant_name(variant):
+        """
+        To get the variant full name string
+
+        :param variant: Avocado test variant (list of TreeNode-like objects)
+        :return: Complete variant name string
+        """
+        full_name = []
+        for node in variant:
+            var_str = []
+            while node:
+                var_str.append(node.name)
+                node = node.parent if hasattr(node, 'parent') else None
+            try:
+                # Let's drop repeated node names and empty string
+                full_name.extend([x for x in var_str[::-1][1:] if x not in full_name])
+            except IndexError:
+                pass
+        return "-".join(full_name)
+
     variant = sorted(variant, key=lambda x: x.path)
     fingerprint = "\n".join(_.fingerprint() for _ in variant)
-    return ("-".join(node.name for node in variant) + '-' +
+    return (get_variant_name(variant) + '-' +
             hashlib.sha1(fingerprint.encode(astring.ENCODING)).hexdigest()[:4])
 
 

--- a/optional_plugins/varianter_yaml_to_mux/tests/test_functional.py
+++ b/optional_plugins/varianter_yaml_to_mux/tests/test_functional.py
@@ -92,9 +92,9 @@ class MultiplexTests(unittest.TestCase):
                     % (AVOCADO, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         result = self.run_and_check(cmd_line, expected_rc, (4, 4))
-        self.assertIn(b"(1/8) passtest.py:PassTest.test;short", result.stdout)
-        self.assertIn(b"(2/8) passtest.py:PassTest.test;medium", result.stdout)
-        self.assertIn(b"(8/8) failtest.py:FailTest.test;longest",
+        self.assertIn(b"(1/8) passtest.py:PassTest.test;run-short-beaf", result.stdout)
+        self.assertIn(b"(2/8) passtest.py:PassTest.test;run-medium-5595", result.stdout)
+        self.assertIn(b"(8/8) failtest.py:FailTest.test;run-longest-efc4",
                       result.stdout)
 
     def test_run_mplex_failtest_tests_per_variant(self):
@@ -105,9 +105,9 @@ class MultiplexTests(unittest.TestCase):
                     % (AVOCADO, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         result = self.run_and_check(cmd_line, expected_rc, (4, 4))
-        self.assertIn(b"(1/8) passtest.py:PassTest.test;short", result.stdout)
-        self.assertIn(b"(2/8) failtest.py:FailTest.test;short", result.stdout)
-        self.assertIn(b"(8/8) failtest.py:FailTest.test;longest",
+        self.assertIn(b"(1/8) passtest.py:PassTest.test;run-short-beaf", result.stdout)
+        self.assertIn(b"(2/8) failtest.py:FailTest.test;run-short-beaf", result.stdout)
+        self.assertIn(b"(8/8) failtest.py:FailTest.test;run-longest-efc4",
                       result.stdout)
 
     def test_run_double_mplex(self):


### PR DESCRIPTION
This patch address the below reported issue on
test name not having complete variants tag names.

Now we get all relevant variants tags included in
the test name which will be useful for result
analysis.

Fixes: https://github.com/avocado-framework/avocado/issues/3615

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>