### PR TITLE
Fixup: Pin stevedore to a version under 3.0 before API change

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ def get_long_description():
     return req_contents
 
 
-INSTALL_REQUIREMENTS = ['requests', 'stevedore>=0.14', 'six>=1.10.0', 'setuptools']
+INSTALL_REQUIREMENTS = ['requests', 'stevedore>=0.14,<3.0', 'six>=1.10.0', 'setuptools']
 
 if sys.version_info[0] == 2:
     INSTALL_REQUIREMENTS.append('enum34')


### PR DESCRIPTION
In function log_plugin_failures() of output.py, failure[0] is
an instance of EntryPoint.
In the previous version of stevedore, the EntryPoint is
pkg_resources.EntryPoint. In the latest released stevedore-3.0, 
EntryPoint is actually importlib_metadata.EntryPoint, which doesn't
have the attribute 'module_name'. Pinning stevedore under version
3.0 could fix this problem.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>