### PR TITLE
[docs] Configuration reference fix

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,11 +33,12 @@ except path.CmdNotFoundError:
 
 
 def generate_reference():
-    from avocado.plugins.config import Config
+    avocado = os.path.join(API_SOURCE_DIR, '__main__.py')
+    result = process.run("%s %s  config reference" % (sys.executable, avocado))
     reference_path = os.path.join(ROOT_PATH, 'docs', 'source',
                                   'config', 'reference.rst')
     with open(reference_path, 'w') as reference:
-        Config.handle_reference(lambda x: reference.write(x + '\n'))
+        reference.write(result.stdout_text)
 
 
 generate_reference()


### PR DESCRIPTION
The documentation about configuration references was incomplete. This happened
because, when the documentation is created the settings module with references
is not completely loaded yet. This commit should fix it.

Reference: #3947
Signed-off-by: Jan Richter <jarichte@redhat.com>