### PR TITLE
mux-inject: Maintain data type of injected value [v2]

### DIFF
--- a/docs/source/plugins/optional/varianter_yaml_to_mux.rst
+++ b/docs/source/plugins/optional/varianter_yaml_to_mux.rst
@@ -612,3 +612,12 @@ Or, add the / to the list of paths searched for by default::
 
    $ avocado --show=test run --mux-inject os_type:myos --mux-path / -- examples/tests/multiplextest.py  | grep os_type
    PARAMS (key=os_type, path=*, default=linux) => 'myos'
+
+.. warning:: By default, the values are parsed for the respective data types.
+   When not possible, it falls back to string. If you want to maintain some
+   value as string, enclose within quotes, properly escaped, and eclose that
+   again in quotes.
+   For example: a value of ``1`` is treated as integer, a value of ``1,2`` is
+   treated as list, a value of ``abc`` is treated as string, a value of
+   ``1,2,5-10`` is treated as list of integers as ``1,2,-5``. If you want to
+   maintain this as string, provide the value as ``"\"1,2,5-10\""``

--- a/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/__init__.py
+++ b/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/__init__.py
@@ -14,6 +14,7 @@
 
 """Varianter plugin to parse yaml files to params"""
 
+import ast
 import collections
 import copy
 import os
@@ -21,6 +22,7 @@ import re
 import sys
 
 import yaml
+
 from avocado.core import exit_codes
 from avocado.core.future.settings import settings
 from avocado.core.output import LOG_UI
@@ -484,12 +486,17 @@ class YamlToMux(mux.MuxPlugin, Varianter):
 
         # Extend default multiplex tree of --mux-inject values
         for inject in config.get("yaml_to_mux.inject"):
-            entry = inject.split(':', 3)
+            entry = inject.split(':', 2)
             if len(entry) < 2:
                 raise ValueError("key:entry pairs required, found only %s"
                                  % (entry))
             elif len(entry) == 2:   # key, entry
                 entry.insert(0, '')  # add path='' (root)
+            # We try to maintain the data type of the provided value
+            try:
+                entry[2] = ast.literal_eval(entry[2])
+            except (ValueError, SyntaxError, NameError, RecursionError):
+                pass
             data.get_node(entry[0], True).value[entry[1]] = entry[2]
 
         mux_filter_only = config.get('yaml_to_mux.filter_only')


### PR DESCRIPTION
When using --mux-inject, we parse the whole path, key and value
as one string. So, the value passed to test is always a string.
Fixed that by maintaining the data type using ast.literal_eval().

V2 of https://github.com/avocado-framework/avocado/pull/3988, with documentation added.

Reported-by: Harish <harish@linux.ibm.com>
Suggested-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>
Tested-by: Harish <harish@linux.ibm.com>
Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>