### PR TITLE
Implement import policy with isort

### DIFF
--- a/avocado/__init__.py
+++ b/avocado/__init__.py
@@ -25,13 +25,8 @@ __all__ = ['Test',
            'TestCancel']
 
 
+from avocado.core.decorators import (cancel_on, fail_on, skip, skipIf,
+                                     skipUnless)
+from avocado.core.exceptions import TestCancel, TestError, TestFail
 from avocado.core.test import Test
 from avocado.core.version import VERSION
-from avocado.core.decorators import fail_on
-from avocado.core.decorators import cancel_on
-from avocado.core.decorators import skip
-from avocado.core.decorators import skipIf
-from avocado.core.decorators import skipUnless
-from avocado.core.exceptions import TestError
-from avocado.core.exceptions import TestFail
-from avocado.core.exceptions import TestCancel

--- a/avocado/__main__.py
+++ b/avocado/__main__.py
@@ -6,6 +6,5 @@ import sys
 
 from avocado.core.main import main
 
-
 if __name__ == '__main__':
     sys.exit(main())

--- a/avocado/core/__init__.py
+++ b/avocado/core/__init__.py
@@ -14,12 +14,13 @@
 
 
 import os
+
 import pkg_resources
 
 from .dispatcher import InitDispatcher
 from .future.settings import settings as future_settings
+from .streams import BUILTIN_STREAM_SETS, BUILTIN_STREAMS
 from .utils import prepend_base_path
-from .streams import BUILTIN_STREAMS, BUILTIN_STREAM_SETS
 
 
 def register_core_options():

--- a/avocado/core/app.py
+++ b/avocado/core/app.py
@@ -20,13 +20,12 @@ import os
 import signal
 import sys
 
+from ..utils import process
 from . import output
-from .dispatcher import CLICmdDispatcher
-from .dispatcher import CLIDispatcher
+from .dispatcher import CLICmdDispatcher, CLIDispatcher
+from .future.settings import settings
 from .output import STD_OUTPUT
 from .parser import Parser
-from .future.settings import settings
-from ..utils import process
 
 
 class AvocadoApp:

--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -30,15 +30,14 @@ import glob
 import os
 import shutil
 import sys
-import time
 import tempfile
+import time
 
-from . import job_id
-from . import exit_codes
-from .future.settings import settings as future_settings
-from .output import LOG_JOB, LOG_UI
 from ..utils import path as utils_path
 from ..utils.data_structures import Borg
+from . import exit_codes, job_id
+from .future.settings import settings as future_settings
+from .output import LOG_JOB, LOG_UI
 
 if 'VIRTUAL_ENV' in os.environ:
     SYSTEM_BASE_DIR = os.environ['VIRTUAL_ENV']

--- a/avocado/core/decorators.py
+++ b/avocado/core/decorators.py
@@ -12,8 +12,8 @@
 # Copyright: Red Hat Inc. 2017
 # Author: Amador Pahim <apahim@redhat.com>
 
-from functools import wraps
 import types
+from functools import wraps
 
 from . import exceptions as core_exceptions
 

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -29,10 +29,10 @@ import traceback
 
 from ..utils import astring, path, process
 from ..utils.data_structures import CallbackRegister, time_to_seconds
-from . import (data_dir, dispatcher, exceptions, exit_codes, jobdata,
-               output, result, version)
-from .job_id import create_unique_job_id
+from . import (data_dir, dispatcher, exceptions, exit_codes, jobdata, output,
+               result, version)
 from .future.settings import settings
+from .job_id import create_unique_job_id
 from .output import LOG_JOB, LOG_UI, STD_OUTPUT
 from .suite import TestSuite, TestSuiteError
 

--- a/avocado/core/job_id.py
+++ b/avocado/core/job_id.py
@@ -15,7 +15,6 @@
 import hashlib
 import random
 
-
 _RAND_POOL = random.SystemRandom()
 
 

--- a/avocado/core/jobdata.py
+++ b/avocado/core/jobdata.py
@@ -20,11 +20,10 @@ import ast
 import json
 import os
 
+from ..utils.path import init_dir
 from . import varianter
 from .future.settings import settings
-from .output import LOG_UI, LOG_JOB
-from ..utils.path import init_dir
-
+from .output import LOG_JOB, LOG_UI
 
 JOB_DATA_DIR = 'jobdata'
 CONFIG_FILENAME = 'config'

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -23,17 +23,13 @@ import os
 import re
 import shlex
 import sys
-
 from enum import Enum
 
-from . import data_dir
-from . import output
-from . import test
-from . import safeloader
-from .references import reference_split
 from ..utils import stacktrace
+from . import data_dir, output, safeloader, test
 from .future.settings import settings as future_settings
 from .output import LOG_UI
+from .references import reference_split
 
 
 class DiscoverMode(Enum):

--- a/avocado/core/main.py
+++ b/avocado/core/main.py
@@ -12,10 +12,10 @@
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
 
-import sys
 import os
-import time
+import sys
 import tempfile
+import time
 import traceback
 
 try:

--- a/avocado/core/nrunner_avocado_instrumented.py
+++ b/avocado/core/nrunner_avocado_instrumented.py
@@ -2,9 +2,7 @@ import multiprocessing
 import tempfile
 import time
 
-from . import job
-from . import loader
-from . import nrunner
+from . import job, loader, nrunner
 from .test import TestID
 from .tree import TreeNode
 

--- a/avocado/core/nrunner_tap.py
+++ b/avocado/core/nrunner_tap.py
@@ -3,8 +3,7 @@ import subprocess
 import time
 
 from . import nrunner
-from .tapparser import TapParser
-from .tapparser import TestResult
+from .tapparser import TapParser, TestResult
 
 
 class TAPRunner(nrunner.BaseRunner):

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -22,11 +22,10 @@ import re
 import sys
 import traceback
 
-from . import exit_codes
 from ..utils import path as utils_path
+from . import exit_codes
 from .future.settings import settings as future_settings
 from .streams import BUILTIN_STREAMS
-
 
 #: Handle cases of logging exceptions which will lead to recursion error
 logging.raiseExceptions = False

--- a/avocado/core/parser.py
+++ b/avocado/core/parser.py
@@ -17,20 +17,15 @@ Avocado application command line parsing.
 """
 
 import argparse
-
-from configparser import ConfigParser
-from configparser import NoOptionError
+from configparser import ConfigParser, NoOptionError
 from glob import glob
 
-from . import exit_codes
-from . import varianter
-from . import settings
-from .future.settings import settings as future_settings
+from . import exit_codes, settings, varianter
 from .future.settings import ConfigFileNotFound, SettingsError
+from .future.settings import settings as future_settings
 from .nrunner import Runnable
 from .output import LOG_UI
-from .resolver import ReferenceResolution
-from .resolver import ReferenceResolutionResult
+from .resolver import ReferenceResolution, ReferenceResolutionResult
 from .version import VERSION
 
 PROG = 'avocado'

--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -21,10 +21,10 @@ import os
 import signal
 import time
 
+from ..utils import wait
 from . import exceptions
 from .future.settings import settings
 from .output import LOG_JOB as TEST_LOG
-from ..utils import wait
 
 
 def add_runner_failure(test_state, new_status, message):

--- a/avocado/core/settings.py
+++ b/avocado/core/settings.py
@@ -16,14 +16,12 @@
 Reads the avocado settings from a .ini file (with Python's configparser).
 """
 import ast
-import os
-import glob
 import configparser
+import glob
+import os
 
-from pkg_resources import get_distribution
-from pkg_resources import resource_filename
-from pkg_resources import resource_isdir
-from pkg_resources import resource_listdir
+from pkg_resources import (get_distribution, resource_filename, resource_isdir,
+                           resource_listdir)
 
 from .settings_dispatcher import SettingsDispatcher
 

--- a/avocado/core/spawners/common.py
+++ b/avocado/core/spawners/common.py
@@ -1,13 +1,10 @@
 import enum
-
-from mmap import mmap
-from mmap import ACCESS_READ
+from mmap import ACCESS_READ, mmap
+from pathlib import Path
 
 from ...core.data_dir import get_job_results_dir
 from ...utils.astring import string_to_safe_path
 from .exceptions import SpawnerException
-
-from pathlib import Path
 
 
 class SpawnMethod(enum.Enum):

--- a/avocado/core/spawners/mock.py
+++ b/avocado/core/spawners/mock.py
@@ -1,7 +1,6 @@
 import random
 
-from .common import BaseSpawner
-from .common import SpawnMethod
+from .common import BaseSpawner, SpawnMethod
 
 
 class MockSpawner(BaseSpawner):

--- a/avocado/core/spawners/podman.py
+++ b/avocado/core/spawners/podman.py
@@ -1,10 +1,9 @@
 import asyncio
 import json
-import subprocess
 import os
+import subprocess
 
-from .common import BaseSpawner
-from .common import SpawnMethod
+from .common import BaseSpawner, SpawnMethod
 
 
 class PodmanSpawner(BaseSpawner):

--- a/avocado/core/spawners/process.py
+++ b/avocado/core/spawners/process.py
@@ -1,7 +1,6 @@
 import asyncio
 
-from .common import BaseSpawner
-from .common import SpawnMethod
+from .common import BaseSpawner, SpawnMethod
 
 
 class ProcessSpawner(BaseSpawner):

--- a/avocado/core/suite.py
+++ b/avocado/core/suite.py
@@ -1,15 +1,15 @@
 from enum import Enum
 from uuid import uuid1
 
+from .dispatcher import RunnerDispatcher
 from .exceptions import OptionValidationError
 from .future.settings import settings
-from .loader import loader, LoaderError, LoaderUnhandledReferenceError
+from .loader import LoaderError, LoaderUnhandledReferenceError, loader
 from .resolver import resolve
 from .tags import filter_test_tags
 from .test import DryRunTest
 from .utils import resolutions_to_tasks
 from .varianter import Varianter
-from .dispatcher import RunnerDispatcher
 
 
 class TestSuiteError(Exception):

--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -21,13 +21,11 @@ import shutil
 import subprocess
 import time
 
+from ..utils import astring, genio
+from ..utils import path as utils_path
+from ..utils import process, software_manager
 from . import output
 from .future.settings import settings as future_settings
-from ..utils import astring
-from ..utils import genio
-from ..utils import process
-from ..utils import software_manager
-from ..utils import path as utils_path
 
 log = logging.getLogger("avocado.sysinfo")
 

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -29,28 +29,17 @@ import sys
 import tempfile
 import time
 import unittest
-
 from difflib import unified_diff
 
-from . import data_dir
-from . import exceptions
-from . import output
-from . import parameters
-from . import sysinfo
-from . import tapparser
-from ..utils import asset
-from ..utils import astring
-from ..utils import data_structures
-from ..utils import genio
+from ..utils import asset, astring, data_structures, genio
 from ..utils import path as utils_path
-from ..utils import process
-from ..utils import stacktrace
+from ..utils import process, stacktrace
+from . import data_dir, exceptions, output, parameters, sysinfo, tapparser
 from .decorators import skip
 from .future.settings import settings
+from .output import LOG_JOB
 from .test_id import TestID
 from .version import VERSION
-from .output import LOG_JOB
-
 
 #: Environment variable used to store the location of a temporary
 #: directory which is preserved across all tests execution (usually in

--- a/avocado/core/utils.py
+++ b/avocado/core/utils.py
@@ -1,7 +1,7 @@
 import os
+from uuid import uuid1
 
 from pkg_resources import get_distribution
-from uuid import uuid1
 
 from .nrunner import Task
 from .resolver import ReferenceResolutionResult

--- a/avocado/core/varianter.py
+++ b/avocado/core/varianter.py
@@ -21,10 +21,8 @@ Base classes for implementing the varianter interface
 
 import hashlib
 
-from . import tree
-from . import dispatcher
-from . import output
 from ..utils import astring
+from . import dispatcher, output, tree
 
 
 def is_empty_variant(variant):

--- a/avocado/plugins/assets.py
+++ b/avocado/plugins/assets.py
@@ -20,16 +20,13 @@ import ast
 import os
 import urllib.parse
 
-from avocado.core import data_dir
-from avocado.core import exit_codes
-from avocado.core import safeloader
+from avocado.core import data_dir, exit_codes, safeloader
 from avocado.core.future.settings import settings
 from avocado.core.nrunner import Task
 from avocado.core.output import LOG_UI
-from avocado.core.plugin_interfaces import CLICmd
-from avocado.core.plugin_interfaces import JobPreTests
-from avocado.utils.asset import Asset
+from avocado.core.plugin_interfaces import CLICmd, JobPreTests
 from avocado.utils import data_structures
+from avocado.utils.asset import Asset
 
 
 class FetchAssetHandler(ast.NodeVisitor):  # pylint: disable=R0902

--- a/avocado/plugins/diff.py
+++ b/avocado/plugins/diff.py
@@ -17,19 +17,16 @@ Job Diff
 """
 
 from __future__ import absolute_import
+
 import argparse
 import json
 import os
 import subprocess
 import sys
 import tempfile
+from difflib import HtmlDiff, unified_diff
 
-from difflib import unified_diff, HtmlDiff
-
-from avocado.core import data_dir
-from avocado.core import exit_codes
-from avocado.core import jobdata
-from avocado.core import output
+from avocado.core import data_dir, exit_codes, jobdata, output
 from avocado.core.future.settings import settings
 from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLICmd

--- a/avocado/plugins/distro.py
+++ b/avocado/plugins/distro.py
@@ -19,8 +19,8 @@ import sys
 
 from avocado.core import exit_codes
 from avocado.core.future.settings import settings
-from avocado.core.plugin_interfaces import CLICmd
 from avocado.core.output import LOG_UI
+from avocado.core.plugin_interfaces import CLICmd
 from avocado.utils import distro as utils_distro
 from avocado.utils import path as utils_path
 from avocado.utils import process

--- a/avocado/plugins/exec_path.py
+++ b/avocado/plugins/exec_path.py
@@ -17,6 +17,7 @@ Libexec PATHs modifier
 import os
 
 from pkg_resources import resource_filename
+
 from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLICmd
 

--- a/avocado/plugins/human.py
+++ b/avocado/plugins/human.py
@@ -15,10 +15,9 @@
 Human result UI
 """
 
-from avocado.core.output import LOG_UI
-from avocado.core.plugin_interfaces import ResultEvents
-from avocado.core.plugin_interfaces import JobPre, JobPost
 from avocado.core import output
+from avocado.core.output import LOG_UI
+from avocado.core.plugin_interfaces import JobPost, JobPre, ResultEvents
 
 
 class Human(ResultEvents):

--- a/avocado/plugins/jobs.py
+++ b/avocado/plugins/jobs.py
@@ -17,12 +17,10 @@ Jobs subcommand
 """
 import json
 import os
-
 from datetime import datetime
 from glob import glob
 
-from avocado.core import exit_codes
-from avocado.core import output
+from avocado.core import exit_codes, output
 from avocado.core.data_dir import get_job_results_dir, get_logs_dir
 from avocado.core.future.settings import settings
 from avocado.core.output import LOG_UI

--- a/avocado/plugins/jobscripts.py
+++ b/avocado/plugins/jobscripts.py
@@ -2,7 +2,7 @@ import os
 
 from avocado.core.future.settings import settings as future_settings
 from avocado.core.output import LOG_UI
-from avocado.core.plugin_interfaces import JobPre, JobPost, Init
+from avocado.core.plugin_interfaces import Init, JobPost, JobPre
 from avocado.core.utils import prepend_base_path
 from avocado.utils import process
 

--- a/avocado/plugins/journal.py
+++ b/avocado/plugins/journal.py
@@ -14,13 +14,12 @@
 
 """Journal Plugin"""
 
+import datetime
 import os
 import sqlite3
-import datetime
 
 from avocado.core.future.settings import settings
 from avocado.core.plugin_interfaces import CLI, ResultEvents
-
 
 JOURNAL_FILENAME = ".journal.sqlite"
 

--- a/avocado/plugins/json_variants.py
+++ b/avocado/plugins/json_variants.py
@@ -15,13 +15,10 @@
 import json
 import sys
 
-from avocado.core import exit_codes
-from avocado.core import varianter
+from avocado.core import exit_codes, varianter
 from avocado.core.future.settings import settings
 from avocado.core.output import LOG_UI
-from avocado.core.plugin_interfaces import CLI
-from avocado.core.plugin_interfaces import Varianter
-
+from avocado.core.plugin_interfaces import CLI, Varianter
 
 _NO_VARIANTS = -1
 

--- a/avocado/plugins/jsonresult.py
+++ b/avocado/plugins/jsonresult.py
@@ -23,9 +23,8 @@ import os
 from avocado.core.future.settings import settings
 from avocado.core.output import LOG_UI
 from avocado.core.parser import FileOrStdoutAction
-from avocado.core.plugin_interfaces import Init, CLI, Result
+from avocado.core.plugin_interfaces import CLI, Init, Result
 from avocado.utils import astring
-
 
 UNKNOWN = '<unknown>'
 

--- a/avocado/plugins/list.py
+++ b/avocado/plugins/list.py
@@ -14,13 +14,10 @@
 
 import sys
 
-from avocado.core import exit_codes, output
-from avocado.core import loader
-from avocado.core import test
-from avocado.core import tags
-from avocado.core import parser_common_args
-from avocado.core.output import LOG_UI
+from avocado.core import (exit_codes, loader, output, parser_common_args, tags,
+                          test)
 from avocado.core.future.settings import settings
+from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLICmd
 from avocado.utils import astring
 

--- a/avocado/plugins/nlist.py
+++ b/avocado/plugins/nlist.py
@@ -14,13 +14,11 @@
 
 import os
 
+from avocado.core import output, parser_common_args, resolver
 from avocado.core.future.settings import settings
-from avocado.core.plugin_interfaces import CLICmd
-from avocado.core import resolver
-from avocado.core import output
-from avocado.core import parser_common_args
 from avocado.core.output import LOG_UI
 from avocado.core.parser import HintParser
+from avocado.core.plugin_interfaces import CLICmd
 from avocado.core.tags import filter_test_tags_runnable
 from avocado.utils import astring
 

--- a/avocado/plugins/nrun.py
+++ b/avocado/plugins/nrun.py
@@ -4,18 +4,15 @@ import os
 import random
 import sys
 
-from avocado.core import exit_codes
-from avocado.core import nrunner
-from avocado.core import parser_common_args
-from avocado.core import resolver
-from avocado.core.spawners.process import ProcessSpawner
-from avocado.core.spawners.podman import PodmanSpawner
-from avocado.core.utils import resolutions_to_tasks
+from avocado.core import exit_codes, nrunner, parser_common_args, resolver
 from avocado.core.future.settings import settings
 from avocado.core.output import LOG_UI
 from avocado.core.parser import HintParser
-from avocado.core.test_id import TestID
 from avocado.core.plugin_interfaces import CLICmd
+from avocado.core.spawners.podman import PodmanSpawner
+from avocado.core.spawners.process import ProcessSpawner
+from avocado.core.test_id import TestID
+from avocado.core.utils import resolutions_to_tasks
 
 
 class NRun(CLICmd):

--- a/avocado/plugins/plugins.py
+++ b/avocado/plugins/plugins.py
@@ -16,9 +16,9 @@ Plugins information plugin
 """
 
 from avocado.core import dispatcher
-from avocado.core.resolver import Resolver
 from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLICmd
+from avocado.core.resolver import Resolver
 from avocado.utils import astring
 
 

--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -18,11 +18,7 @@ import os
 import re
 import sys
 
-from avocado.core import data_dir
-from avocado.core import exit_codes
-from avocado.core import jobdata
-from avocado.core import status
-
+from avocado.core import data_dir, exit_codes, jobdata, status
 from avocado.core.future.settings import settings as future_settings
 from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLI

--- a/avocado/plugins/resolvers.py
+++ b/avocado/plugins/resolvers.py
@@ -19,14 +19,12 @@ Test resolver for builtin test types
 import os
 import re
 
-from avocado.core.plugin_interfaces import Resolver
-from avocado.core.safeloader import find_avocado_tests
-from avocado.core.safeloader import find_python_unittests
-from avocado.core.resolver import ReferenceResolution
-from avocado.core.resolver import ReferenceResolutionResult
-from avocado.core.resolver import check_file
-from avocado.core.references import reference_split
 from avocado.core.nrunner import Runnable
+from avocado.core.plugin_interfaces import Resolver
+from avocado.core.references import reference_split
+from avocado.core.resolver import (ReferenceResolution,
+                                   ReferenceResolutionResult, check_file)
+from avocado.core.safeloader import find_avocado_tests, find_python_unittests
 
 
 class ExecTestResolver(Resolver):

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -20,11 +20,7 @@ import argparse
 import sys
 import warnings
 
-from avocado.core import exit_codes
-from avocado.core import job
-from avocado.core import loader
-from avocado.core import output
-from avocado.core import parser_common_args
+from avocado.core import exit_codes, job, loader, output, parser_common_args
 from avocado.core.dispatcher import JobPrePostDispatcher
 from avocado.core.future.settings import settings
 from avocado.core.output import LOG_UI

--- a/avocado/plugins/runner.py
+++ b/avocado/plugins/runner.py
@@ -18,30 +18,23 @@
 Conventional Test Runner Plugin
 """
 
+import multiprocessing
 import os
-import time
 import signal
 import sys
-import multiprocessing
+import time
 from queue import Full as queueFullException
 
-
-from avocado.utils import process
-from avocado.utils import stacktrace
-from avocado.utils import wait
-from avocado.core import output
-from avocado.core import status
-from avocado.core import tree
-from avocado.core import varianter
+from avocado.core import output, status, tree, varianter
 from avocado.core.loader import loader
 from avocado.core.output import LOG_JOB as TEST_LOG
 from avocado.core.output import LOG_UI as APP_LOG
 from avocado.core.plugin_interfaces import Runner
-from avocado.core.runner import add_runner_failure
-from avocado.core.runner import TestStatus
+from avocado.core.runner import TestStatus, add_runner_failure
 from avocado.core.status import mapping
 from avocado.core.test import TimeOutSkipTest
 from avocado.core.test_id import TestID
+from avocado.utils import process, stacktrace, wait
 
 
 class TestRunner(Runner):

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -19,13 +19,11 @@ NRunner based implementation of job compliant runner
 import json
 import os
 import time
-
 from copy import copy
 
+from avocado.core import nrunner
 from avocado.core.plugin_interfaces import Runner as RunnerInterface
 from avocado.core.test_id import TestID
-
-from avocado.core import nrunner
 
 
 class Runner(RunnerInterface):

--- a/avocado/plugins/sysinfo.py
+++ b/avocado/plugins/sysinfo.py
@@ -15,12 +15,10 @@
 System information plugin
 """
 
-from avocado.core.future.settings import settings
-from avocado.core.plugin_interfaces import Init
-from avocado.core.plugin_interfaces import CLICmd
-from avocado.core.plugin_interfaces import JobPreTests
-from avocado.core.plugin_interfaces import JobPostTests
 from avocado.core import sysinfo
+from avocado.core.future.settings import settings
+from avocado.core.plugin_interfaces import (CLICmd, Init, JobPostTests,
+                                            JobPreTests)
 from avocado.core.utils import prepend_base_path
 from avocado.utils import path
 

--- a/avocado/plugins/tap.py
+++ b/avocado/plugins/tap.py
@@ -20,7 +20,7 @@ import os
 from avocado.core.future.settings import settings
 from avocado.core.output import LOG_UI
 from avocado.core.parser import FileOrStdoutAction
-from avocado.core.plugin_interfaces import Init, CLI, ResultEvents
+from avocado.core.plugin_interfaces import CLI, Init, ResultEvents
 
 
 def file_log_factory(log_file):

--- a/avocado/plugins/teststmpdir.py
+++ b/avocado/plugins/teststmpdir.py
@@ -19,8 +19,8 @@ import os
 import shutil
 import tempfile
 
-from avocado.core.plugin_interfaces import JobPre, JobPost
 from avocado.core import test
+from avocado.core.plugin_interfaces import JobPost, JobPre
 
 
 class TestsTmpDir(JobPre, JobPost):

--- a/avocado/plugins/variants.py
+++ b/avocado/plugins/variants.py
@@ -21,7 +21,6 @@ from avocado.core.future.settings import settings as future_settings
 from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLICmd
 
-
 _VERBOSITY_LEVELS = {"none": 0, "brief": 1, "normal": 2, "verbose": 3,
                      "full": 4, "max": 99}
 

--- a/avocado/plugins/vmimage.py
+++ b/avocado/plugins/vmimage.py
@@ -2,11 +2,11 @@ import json
 import os
 import re
 
+from avocado.core import data_dir, exit_codes, output
 from avocado.core.future.settings import settings
 from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLICmd
-from avocado.core import data_dir, exit_codes, output
-from avocado.utils import vmimage, astring
+from avocado.utils import astring, vmimage
 
 
 def list_downloaded_images():

--- a/avocado/plugins/xunit.py
+++ b/avocado/plugins/xunit.py
@@ -21,9 +21,9 @@ import string
 from xml.dom.minidom import Document
 
 from avocado.core.future.settings import settings
-from avocado.core.parser import FileOrStdoutAction
 from avocado.core.output import LOG_UI
-from avocado.core.plugin_interfaces import Init, CLI, Result
+from avocado.core.parser import FileOrStdoutAction
+from avocado.core.plugin_interfaces import CLI, Init, Result
 from avocado.utils import astring
 from avocado.utils.data_structures import DataSize
 

--- a/avocado/utils/archive.py
+++ b/avocado/utils/archive.py
@@ -24,7 +24,6 @@ import stat
 import tarfile
 import zipfile
 
-
 LOG = logging.getLogger(__name__)
 
 

--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -29,12 +29,10 @@ import tempfile
 import time
 import urllib.parse
 
-from . import astring
-from . import crypto
+from . import astring, crypto
 from . import path as utils_path
 from .download import url_download
 from .filelock import FileLock
-
 
 LOG = logging.getLogger('avocado.test')
 #: The default hash algorithm to use on asset cache operations

--- a/avocado/utils/astring.py
+++ b/avocado/utils/astring.py
@@ -29,7 +29,6 @@ import itertools
 import locale
 import re
 
-
 #: On import evaluated value representing the system encoding
 #: based on system locales using :func:`locale.getpreferredencoding`.
 #: Use this value wisely as some files are dumped in different

--- a/avocado/utils/cloudinit.py
+++ b/avocado/utils/cloudinit.py
@@ -21,12 +21,9 @@ to configure operating system images via the cloudinit tooling.
 :see: http://cloudinit.readthedocs.io.
 """
 
-from http.server import HTTPServer
-from http.server import BaseHTTPRequestHandler
+from http.server import BaseHTTPRequestHandler, HTTPServer
 
-from . import astring
-from . import iso9660
-
+from . import astring, iso9660
 
 #: The meta-data file template
 #:

--- a/avocado/utils/configure_network.py
+++ b/avocado/utils/configure_network.py
@@ -17,14 +17,12 @@
 Configure network when interface name and interface IP is available.
 """
 
-import shutil
+import logging
 import os
+import shutil
 import warnings
 
-import logging
-from . import distro
-from . import process
-from . import genio
+from . import distro, genio, process
 from .ssh import Session
 
 warnings.warn(("This module will be deprecated soon. Please use "

--- a/avocado/utils/cpu.py
+++ b/avocado/utils/cpu.py
@@ -20,12 +20,12 @@
 Get information from the current's machine CPU.
 """
 
-import re
-import os
-import platform
 import glob
 import logging
+import os
+import platform
 import random
+import re
 import warnings
 
 

--- a/avocado/utils/crypto.py
+++ b/avocado/utils/crypto.py
@@ -12,10 +12,10 @@
 # Copyright: Red Hat Inc. 2013-2014
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
-import io
-import os
-import logging
 import hashlib
+import io
+import logging
+import os
 
 
 def hash_file(filename, size=None, algorithm="md5"):

--- a/avocado/utils/data_structures.py
+++ b/avocado/utils/data_structures.py
@@ -22,8 +22,8 @@ avocado core code or plugins.
 """
 
 
-import sys
 import math
+import sys
 
 
 class InvalidDataSize(ValueError):

--- a/avocado/utils/debug.py
+++ b/avocado/utils/debug.py
@@ -16,9 +16,8 @@
 This file contains tools for (not only) Avocado developers.
 """
 import logging
-import time
 import os
-
+import time
 
 # Use this for debug logging
 LOGGER = logging.getLogger("avocado.app.debug")

--- a/avocado/utils/diff_validator.py
+++ b/avocado/utils/diff_validator.py
@@ -40,8 +40,8 @@ If test fails due to invalid change on the system:
 
 """
 
-import os
 import difflib
+import os
 import shutil
 
 

--- a/avocado/utils/disk.py
+++ b/avocado/utils/disk.py
@@ -23,8 +23,8 @@ Disk utilities
 """
 
 
-import os
 import json
+import os
 import re
 
 from . import process

--- a/avocado/utils/distro.py
+++ b/avocado/utils/distro.py
@@ -20,7 +20,6 @@ it's running under.
 import os
 import re
 
-
 __all__ = ['LinuxDistro',
            'UNKNOWN_DISTRO_NAME',
            'UNKNOWN_DISTRO_VERSION',

--- a/avocado/utils/download.py
+++ b/avocado/utils/download.py
@@ -19,14 +19,11 @@ Methods to download URLs and regular files.
 
 import logging
 import os
-import socket
 import shutil
-
+import socket
 from urllib.request import urlopen
 
-from . import aurl
-from . import output
-from . import crypto
+from . import aurl, crypto, output
 
 log = logging.getLogger('avocado.test')
 

--- a/avocado/utils/external/gdbmi_parser.py
+++ b/avocado/utils/external/gdbmi_parser.py
@@ -24,8 +24,8 @@
 #   Michael Eddington (mike@phed.org)
 
 
-import re
 import pprint
+import re
 
 from . import spark
 

--- a/avocado/utils/file_utils.py
+++ b/avocado/utils/file_utils.py
@@ -24,12 +24,12 @@ INTERFACE
 
 """
 
-from glob import iglob
-import os
-from pwd import getpwnam, getpwuid
-from grp import getgrnam, getgrgid
-from stat import S_IMODE
 import logging
+import os
+from glob import iglob
+from grp import getgrgid, getgrnam
+from pwd import getpwnam, getpwuid
+from stat import S_IMODE
 
 
 def check_owner(owner, group, file_name_pattern, check_recursive=False):

--- a/avocado/utils/gdb.py
+++ b/avocado/utils/gdb.py
@@ -19,15 +19,15 @@ Module that provides communication with GDB via its GDB/MI interpreter
 __all__ = ['GDB', 'GDBServer', 'GDBRemote']
 
 
-import os
-import time
 import fcntl
+import os
 import socket
 import subprocess
 import tempfile
+import time
 
-from .network import ports
 from .external import gdbmi_parser
+from .network import ports
 
 #: Contains a list of binary names that should be run via the GNU debugger
 #: and be stopped at a given point. That means that a breakpoint will be set

--- a/avocado/utils/git.py
+++ b/avocado/utils/git.py
@@ -16,12 +16,10 @@
 APIs to download/update git repositories from inside python scripts.
 """
 
-import os
 import logging
+import os
 
-from . import process
-from . import astring
-from . import path
+from . import astring, path, process
 
 __all__ = ["GitRepoHelper", "get_repo"]
 

--- a/avocado/utils/iso9660.py
+++ b/avocado/utils/iso9660.py
@@ -35,7 +35,6 @@ import tempfile
 
 from . import process
 
-
 try:
     import pycdlib
 except ImportError:

--- a/avocado/utils/kernel.py
+++ b/avocado/utils/kernel.py
@@ -17,14 +17,14 @@
 Provides utilities for the Linux kernel.
 """
 
-import os
-import shutil
 import logging
 import multiprocessing
+import os
+import shutil
 import tempfile
 from distutils.version import LooseVersion  # pylint: disable=E0611
 
-from . import asset, archive, build, distro, process
+from . import archive, asset, build, distro, process
 
 LOG = logging.getLogger('avocado.test')
 

--- a/avocado/utils/linux_modules.py
+++ b/avocado/utils/linux_modules.py
@@ -21,15 +21,12 @@
 Linux kernel modules APIs
 """
 
-import re
 import logging
 import platform
-
+import re
 from enum import Enum
 
-from . import astring
-from . import process
-from . import data_structures
+from . import astring, data_structures, process
 
 LOG = logging.getLogger('avocado.test')
 

--- a/avocado/utils/lv_utils.py
+++ b/avocado/utils/lv_utils.py
@@ -24,8 +24,8 @@ import re
 import shutil
 import time
 import warnings
-from . import process
 
+from . import process
 
 LOGGER = logging.getLogger('avocado.test')
 

--- a/avocado/utils/memory.py
+++ b/avocado/utils/memory.py
@@ -17,16 +17,13 @@
 # Authors: Yiqiao Pu <ypu@redhat.com>
 
 
+import glob
+import logging
+import math
 import os
 import re
-import glob
-import math
-import logging
 
-from . import process
-from . import genio
-from . import wait
-from . import data_structures
+from . import data_structures, genio, process, wait
 from .data_structures import DataSize
 
 

--- a/avocado/utils/multipath.py
+++ b/avocado/utils/multipath.py
@@ -17,13 +17,11 @@ Module with multipath related utility functions.
 It needs root access.
 """
 
-import time
-import logging
 import ast
-from . import distro
-from . import process
-from . import service
-from . import wait
+import logging
+import time
+
+from . import distro, process, service, wait
 
 
 class MPException(Exception):

--- a/avocado/utils/network/__init__.py
+++ b/avocado/utils/network/__init__.py
@@ -1,9 +1,9 @@
 import warnings
 
-from .ports import is_port_free  # noqa pylint: disable=unused-import
+from .ports import PortTracker  # noqa pylint: disable=unused-import
 from .ports import find_free_port  # noqa pylint: disable=unused-import
 from .ports import find_free_ports  # noqa pylint: disable=unused-import
-from .ports import PortTracker  # noqa pylint: disable=unused-import
+from .ports import is_port_free  # noqa pylint: disable=unused-import
 
 warnings.warn(("Network as module will be deprecated, please use "
                "utils.network.ports instead."),

--- a/avocado/utils/network/hosts.py
+++ b/avocado/utils/network/hosts.py
@@ -18,10 +18,9 @@ This module provides an useful API for hosts in a network.
 """
 
 from ..ssh import Session
-
 from .common import run_command
-from .interfaces import NetworkInterface
 from .exceptions import NWException
+from .interfaces import NetworkInterface
 
 
 class Host:

--- a/avocado/utils/network/interfaces.py
+++ b/avocado/utils/network/interfaces.py
@@ -20,16 +20,13 @@ import json
 import logging
 import os
 import shutil
-
 from ipaddress import ip_interface
-
-from .common import run_command
-from .exceptions import NWException
 
 from ..distro import detect as distro_detect
 from ..process import CmdError
 from ..wait import wait_for
-
+from .common import run_command
+from .exceptions import NWException
 
 log = logging.getLogger('avocado.test')
 

--- a/avocado/utils/network/ports.py
+++ b/avocado/utils/network/ports.py
@@ -16,8 +16,8 @@
 Module with network related utility functions
 """
 
-import socket
 import random
+import socket
 
 from ..data_structures import Borg
 

--- a/avocado/utils/partition.py
+++ b/avocado/utils/partition.py
@@ -22,14 +22,12 @@
 Utility for handling partitions.
 """
 
+import hashlib
 import logging
 import os
-import hashlib
 import tempfile
 
-from . import process
-from . import filelock
-
+from . import filelock, process
 
 LOG = logging.getLogger(__name__)
 

--- a/avocado/utils/pci.py
+++ b/avocado/utils/pci.py
@@ -21,9 +21,10 @@ Module for all PCI devices related functions.
 """
 
 
-import re
 import os
-from . import process, genio
+import re
+
+from . import genio, process
 
 
 def get_domains():

--- a/avocado/utils/pmem.py
+++ b/avocado/utils/pmem.py
@@ -15,14 +15,12 @@
 #
 
 
-import re
-import json
 import glob
+import json
 import logging
+import re
 
-from . import path
-from . import process
-from . import genio
+from . import genio, path, process
 
 log = logging.getLogger('avocado.test')
 

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -29,11 +29,9 @@ import signal
 import subprocess
 import threading
 import time
-
 from io import BytesIO, UnsupportedOperation
 
-from . import astring
-from . import path
+from . import astring, path
 from .wait import wait_for
 
 log = logging.getLogger('avocado.test')

--- a/avocado/utils/script.py
+++ b/avocado/utils/script.py
@@ -17,12 +17,11 @@ Module to handle scripts creation.
 """
 
 import os
-import stat
 import shutil
+import stat
 import tempfile
 
 from . import path as utils_path
-
 
 #: What is commonly known as "0775" or "u=rwx,g=rwx,o=rx"
 DEFAULT_MODE = (stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR |

--- a/avocado/utils/service.py
+++ b/avocado/utils/service.py
@@ -21,9 +21,9 @@
 # client/shared/service.py
 # Original author: Ross Brattain <ross.b.brattain@intel.com>
 
+import logging
 import os
 import re
-import logging
 from tempfile import mkstemp
 
 from . import process

--- a/avocado/utils/software_manager/__init__.py
+++ b/avocado/utils/software_manager/__init__.py
@@ -31,5 +31,5 @@ and multiple high level package managers (here called backends).
 __all__ = ['install_distro_packages', 'SoftwareManager']
 
 
-from .manager import SoftwareManager
 from .distro_packages import install_distro_packages
+from .manager import SoftwareManager

--- a/avocado/utils/software_manager/backends/apt.py
+++ b/avocado/utils/software_manager/backends/apt.py
@@ -3,10 +3,9 @@ import os
 import re
 import tempfile
 
-from .dpkg import DpkgBackend
 from ... import path as utils_path
 from ... import process
-
+from .dpkg import DpkgBackend
 
 log = logging.getLogger('avocado.utils.software_manager')
 

--- a/avocado/utils/software_manager/backends/base.py
+++ b/avocado/utils/software_manager/backends/base.py
@@ -21,7 +21,6 @@
 
 import logging
 
-
 log = logging.getLogger('avocado.utils.software_manager')
 
 

--- a/avocado/utils/software_manager/backends/dnf.py
+++ b/avocado/utils/software_manager/backends/dnf.py
@@ -1,8 +1,7 @@
 import logging
 
-from .yum import YumBackend
 from ... import process
-
+from .yum import YumBackend
 
 log = logging.getLogger('avocado.utils.software_manager')
 

--- a/avocado/utils/software_manager/backends/dpkg.py
+++ b/avocado/utils/software_manager/backends/dpkg.py
@@ -1,10 +1,9 @@
 import logging
 import os
 
-from .base import BaseBackend
-
 from ... import path as utils_path
 from ... import process
+from .base import BaseBackend
 
 log = logging.getLogger('avocado.utils.software_manager')
 

--- a/avocado/utils/software_manager/backends/rpm.py
+++ b/avocado/utils/software_manager/backends/rpm.py
@@ -2,10 +2,9 @@ import logging
 import os
 import re
 
-from .base import BaseBackend
 from ... import path as utils_path
 from ... import process
-
+from .base import BaseBackend
 
 log = logging.getLogger('avocado.utils.software_manager')
 

--- a/avocado/utils/software_manager/backends/yum.py
+++ b/avocado/utils/software_manager/backends/yum.py
@@ -5,10 +5,10 @@ import re
 import shutil
 import tempfile
 
-from .rpm import RpmBackend
 from ... import data_factory
 from ... import path as utils_path
 from ... import process
+from .rpm import RpmBackend
 
 try:
     import yum

--- a/avocado/utils/software_manager/backends/zypper.py
+++ b/avocado/utils/software_manager/backends/zypper.py
@@ -1,10 +1,9 @@
-import re
 import logging
+import re
 
-from .rpm import RpmBackend
 from ... import path as utils_path
 from ... import process
-
+from .rpm import RpmBackend
 
 log = logging.getLogger('avocado.utils.software_manager')
 

--- a/avocado/utils/software_manager/distro_packages.py
+++ b/avocado/utils/software_manager/distro_packages.py
@@ -1,9 +1,8 @@
 import logging
 import os
 
-from .manager import SoftwareManager
 from .. import distro
-
+from .manager import SoftwareManager
 
 log = logging.getLogger('avocado.utils.software_manager')
 

--- a/avocado/utils/software_manager/inspector.py
+++ b/avocado/utils/software_manager/inspector.py
@@ -20,14 +20,12 @@
 # client/shared/software_manager.py
 
 
-from .backends.apt import AptBackend
-from .backends.yum import YumBackend
-from .backends.dnf import DnfBackend
-from .backends.zypper import ZypperBackend
-
-from .. import path as utils_path
 from .. import distro
-
+from .. import path as utils_path
+from .backends.apt import AptBackend
+from .backends.dnf import DnfBackend
+from .backends.yum import YumBackend
+from .backends.zypper import ZypperBackend
 
 #: Mapping of package manager name to implementation class.
 SUPPORTED_PACKAGE_MANAGERS = {

--- a/avocado/utils/software_manager/main.py
+++ b/avocado/utils/software_manager/main.py
@@ -1,9 +1,7 @@
 import argparse
 import logging
 
-
 from .manager import SoftwareManager
-
 
 log = logging.getLogger('avocado.utils.software_manager')
 

--- a/avocado/utils/software_manager/manager.py
+++ b/avocado/utils/software_manager/manager.py
@@ -1,4 +1,4 @@
-from .inspector import SystemInspector, SUPPORTED_PACKAGE_MANAGERS
+from .inspector import SUPPORTED_PACKAGE_MANAGERS, SystemInspector
 
 
 class SoftwareManager:

--- a/avocado/utils/ssh.py
+++ b/avocado/utils/ssh.py
@@ -21,7 +21,6 @@ import tempfile
 from . import path as path_utils
 from . import process
 
-
 try:
     #: The SSH client binary to use, if one is found in the system
     SSH_CLIENT_BINARY = path_utils.find_command('ssh')

--- a/avocado/utils/stacktrace.py
+++ b/avocado/utils/stacktrace.py
@@ -1,11 +1,11 @@
 """
 Traceback standard module plus some additional APIs.
 """
-from traceback import format_exception
-import logging
 import inspect
+import logging
 import pickle
 from pprint import pformat
+from traceback import format_exception
 
 
 def tb_info(exc_info):

--- a/avocado/utils/vmimage.py
+++ b/avocado/utils/vmimage.py
@@ -20,14 +20,11 @@ import os
 import re
 import tempfile
 import uuid
-
-from urllib.request import urlopen
-from urllib.error import HTTPError
 from html.parser import HTMLParser
+from urllib.error import HTTPError
+from urllib.request import urlopen
 
-from . import archive
-from . import asset
-from . import astring
+from . import archive, asset, astring
 from . import path as utils_path
 from . import process
 

--- a/contrib/scripts/vmimage-populate-cache.py
+++ b/contrib/scripts/vmimage-populate-cache.py
@@ -4,9 +4,8 @@
 Script that downloads cloud images via avocado.utils.vmimage
 """
 
-from avocado.utils import vmimage
 from avocado.core import data_dir
-
+from avocado.utils import vmimage
 
 KNOWN_IMAGES = (
     # from https://download.cirros-cloud.net/0.4.0/MD5SUMS

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,15 +6,16 @@ import importlib
 import os
 import sys
 
+from avocado.utils import genio  # pylint: disable=C0413
+from avocado.utils import path  # pylint: disable=C0413
+from avocado.utils import process  # pylint: disable=C0413
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 ROOT_PATH = os.path.abspath(os.path.join("..", ".."))
 sys.path.insert(0, ROOT_PATH)
 
-from avocado.utils import genio  # pylint: disable=C0413
-from avocado.utils import path  # pylint: disable=C0413
-from avocado.utils import process  # pylint: disable=C0413
 
 
 # Flag that tells if the docs are being built on readthedocs.org

--- a/examples/apis/utils/ssh.py
+++ b/examples/apis/utils/ssh.py
@@ -1,6 +1,7 @@
-from avocado.utils.ssh import Session
-from avocado.utils.process import SubProcess
 import time
+
+from avocado.utils.process import SubProcess
+from avocado.utils.ssh import Session
 
 with Session('host', user='root', key='/path/to/key') as s:
     print('connected')

--- a/examples/jobs/failjob.py
+++ b/examples/jobs/failjob.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+
 from avocado.core.job import Job
 
 config = {'run.references': ['examples/tests/failtest.py:FailTest.test']}

--- a/examples/jobs/nrunner.py
+++ b/examples/jobs/nrunner.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+
 from avocado.core.job import Job
 
 config = {

--- a/examples/jobs/passjob.py
+++ b/examples/jobs/passjob.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+
 from avocado.core.job import Job
 
 config = {'run.references': ['examples/tests/passtest.py:PassTest.test']}

--- a/examples/jobs/passjob_cit_varianter.py
+++ b/examples/jobs/passjob_cit_varianter.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+
 from avocado.core.job import Job
 
 config = {'run.references': ['examples/tests/passtest.py:PassTest.test'],

--- a/examples/jobs/passjob_html.py
+++ b/examples/jobs/passjob_html.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+
 from avocado.core.job import Job
 
 config = {'run.references': ['examples/tests/passtest.py:PassTest.test'],

--- a/examples/plugins/job-pre-post/mail/avocado_job_mail.py
+++ b/examples/plugins/job-pre-post/mail/avocado_job_mail.py
@@ -1,9 +1,9 @@
 import smtplib
 from email.mime.text import MIMEText
 
-from avocado.core.output import LOG_UI
 from avocado.core.future.settings import settings as future_settings
-from avocado.core.plugin_interfaces import JobPre, JobPost, Init
+from avocado.core.output import LOG_UI
+from avocado.core.plugin_interfaces import Init, JobPost, JobPre
 
 
 class MailInit(Init):

--- a/examples/plugins/job-pre-post/sleep/avocado_job_sleep.py
+++ b/examples/plugins/job-pre-post/sleep/avocado_job_sleep.py
@@ -1,8 +1,8 @@
 import time
 
-from avocado.core.output import LOG_UI
 from avocado.core.future.settings import settings as future_settings
-from avocado.core.plugin_interfaces import JobPre, JobPost, Init
+from avocado.core.output import LOG_UI
+from avocado.core.plugin_interfaces import Init, JobPost, JobPre
 
 
 class SleepInit(Init):

--- a/examples/tests/assets.py
+++ b/examples/tests/assets.py
@@ -1,10 +1,7 @@
 import os
 
-from avocado import Test
-from avocado import fail_on
-from avocado.utils import archive
-from avocado.utils import build
-from avocado.utils import process
+from avocado import Test, fail_on
+from avocado.utils import archive, build, process
 
 
 class Hello(Test):

--- a/examples/tests/cabort.py
+++ b/examples/tests/cabort.py
@@ -2,8 +2,7 @@ import os
 import shutil
 
 from avocado import Test
-from avocado.utils import build
-from avocado.utils import process
+from avocado.utils import build, process
 
 
 class CAbort(Test):

--- a/examples/tests/datadir.py
+++ b/examples/tests/datadir.py
@@ -2,8 +2,7 @@ import os
 import shutil
 
 from avocado import Test
-from avocado.utils import build
-from avocado.utils import process
+from avocado.utils import build, process
 
 
 class DataDirTest(Test):

--- a/examples/tests/doublefree.py
+++ b/examples/tests/doublefree.py
@@ -3,8 +3,7 @@ import shutil
 import sys
 
 from avocado import Test
-from avocado.utils import build
-from avocado.utils import process
+from avocado.utils import build, process
 
 
 class DoubleFreeTest(Test):

--- a/examples/tests/doublefree_nasty.py
+++ b/examples/tests/doublefree_nasty.py
@@ -2,8 +2,7 @@ import os
 import shutil
 
 from avocado import Test
-from avocado.utils import build
-from avocado.utils import process
+from avocado.utils import build, process
 
 
 class DoubleFreeTest(Test):

--- a/examples/tests/failtest_ugly.py
+++ b/examples/tests/failtest_ugly.py
@@ -3,7 +3,6 @@ Please don't get inspired by this ugly code
 """
 import sys
 
-
 sys.stdout.write("Direct output to stdout\n")
 sys.stderr.write("Direct output to stderr\n")
 input("I really want some input on each import")

--- a/examples/tests/gdbtest.py
+++ b/examples/tests/gdbtest.py
@@ -1,9 +1,7 @@
 import os
 
 from avocado import Test
-from avocado.utils import gdb
-from avocado.utils import genio
-from avocado.utils import process
+from avocado.utils import gdb, genio, process
 
 
 class GdbTest(Test):

--- a/examples/tests/modify_variable.py
+++ b/examples/tests/modify_variable.py
@@ -2,8 +2,7 @@ import os
 import shutil
 
 from avocado import Test
-from avocado.utils import gdb
-from avocado.utils import build
+from avocado.utils import build, gdb
 
 
 class PrintVariableTest(Test):

--- a/examples/tests/raise.py
+++ b/examples/tests/raise.py
@@ -2,8 +2,7 @@ import os
 import shutil
 
 from avocado import Test
-from avocado.utils import build
-from avocado.utils import process
+from avocado.utils import build, process
 
 
 class Raise(Test):

--- a/examples/tests/synctest.py
+++ b/examples/tests/synctest.py
@@ -3,9 +3,7 @@
 import os
 
 from avocado import Test
-from avocado.utils import archive
-from avocado.utils import build
-from avocado.utils import process
+from avocado.utils import archive, build, process
 
 
 class SyncTest(Test):

--- a/examples/tests/vm-cleanup.py
+++ b/examples/tests/vm-cleanup.py
@@ -3,8 +3,7 @@ import shutil
 import tempfile
 
 from avocado import Test
-from avocado.utils import script
-from avocado.utils import process
+from avocado.utils import process, script
 
 CLEAN_TEST = """import os
 from avocado import Test

--- a/examples/wip/download-output/download.py
+++ b/examples/wip/download-output/download.py
@@ -26,13 +26,13 @@ files inside `test-results/<task_id>/data` folder. You can create files there
 manually if necessary.
 """
 
-import sys
 import json
 import os
+import sys
 
-from avocado.core.spawners.process import ProcessSpawner
-from avocado.core.spawners.podman import PodmanSpawner
 from avocado.core.spawners.exceptions import SpawnerException
+from avocado.core.spawners.podman import PodmanSpawner
+from avocado.core.spawners.process import ProcessSpawner
 
 
 def discover_spawner(job_id):

--- a/optional_plugins/glib/avocado_glib/__init__.py
+++ b/optional_plugins/glib/avocado_glib/__init__.py
@@ -19,18 +19,13 @@ Plugin to run GLib Test Framework tests in Avocado
 import os
 import re
 
-from avocado.utils import path
-from avocado.utils import process
-
-from avocado.core import loader
-from avocado.core import output
-from avocado.core import test
-from avocado.core.plugin_interfaces import CLI
-from avocado.core.plugin_interfaces import Resolver
+from avocado.core import loader, output, test
 from avocado.core.future.settings import settings
-from avocado.core.resolver import ReferenceResolution
-from avocado.core.resolver import ReferenceResolutionResult
 from avocado.core.nrunner import Runnable
+from avocado.core.plugin_interfaces import CLI, Resolver
+from avocado.core.resolver import (ReferenceResolution,
+                                   ReferenceResolutionResult)
+from avocado.utils import path, process
 
 
 class GLibTest(test.SimpleTest):

--- a/optional_plugins/glib/setup.py
+++ b/optional_plugins/glib/setup.py
@@ -13,8 +13,7 @@
 # Copyright: Red Hat Inc. 2018
 # Author: Amador Pahim <apahim@redhat.com>
 
-from setuptools import setup, find_packages
-
+from setuptools import find_packages, setup
 
 VERSION = open("VERSION", "r").read().strip()
 

--- a/optional_plugins/golang/avocado_golang/__init__.py
+++ b/optional_plugins/golang/avocado_golang/__init__.py
@@ -21,18 +21,13 @@ import glob
 import os
 import re
 
-from avocado.core import exceptions
-from avocado.core import loader
-from avocado.core import output
-from avocado.core import test
-from avocado.core.plugin_interfaces import Resolver
+from avocado.core import exceptions, loader, output, test
 from avocado.core.nrunner import Runnable
-from avocado.core.resolver import ReferenceResolution
-from avocado.core.resolver import ReferenceResolutionResult
-from avocado.core.plugin_interfaces import CLI
+from avocado.core.plugin_interfaces import CLI, Resolver
+from avocado.core.resolver import (ReferenceResolution,
+                                   ReferenceResolutionResult)
 from avocado.utils import path as utils_path
 from avocado.utils import process
-
 
 try:
     GO_BIN = utils_path.find_command('go')

--- a/optional_plugins/golang/setup.py
+++ b/optional_plugins/golang/setup.py
@@ -13,7 +13,7 @@
 # Copyright: Red Hat Inc. 2017
 # Author: Amador Pahim <apahim@redhat.com>
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 VERSION = open("VERSION", "r").read().strip()
 

--- a/optional_plugins/golang/tests/test_golang.py
+++ b/optional_plugins/golang/tests/test_golang.py
@@ -1,9 +1,8 @@
 import os
 import unittest.mock
 
-from avocado.core.resolver import ReferenceResolutionResult
 import avocado_golang
-
+from avocado.core.resolver import ReferenceResolutionResult
 
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 

--- a/optional_plugins/html/avocado_result_html/__init__.py
+++ b/optional_plugins/html/avocado_result_html/__init__.py
@@ -15,12 +15,12 @@
 HTML output module.
 """
 
+import base64
 import codecs
 import os
 import subprocess
 import sys
 import time
-import base64
 
 import jinja2 as jinja
 

--- a/optional_plugins/html/setup.py
+++ b/optional_plugins/html/setup.py
@@ -13,8 +13,7 @@
 # Copyright: Red Hat Inc. 2016
 # Author: Cleber Rosa <crosa@redhat.com>
 
-from setuptools import setup, find_packages
-
+from setuptools import find_packages, setup
 
 VERSION = open("VERSION", "r").read().strip()
 

--- a/optional_plugins/html/tests/test_html_result.py
+++ b/optional_plugins/html/tests/test_html_result.py
@@ -5,8 +5,7 @@ import unittest
 from xml.dom import minidom
 
 from avocado.core import exit_codes
-from avocado.utils import genio
-from avocado.utils import process
+from avocado.utils import genio, process
 
 
 class HtmlResultTest(unittest.TestCase):

--- a/optional_plugins/loader_yaml/avocado_loader_yaml/__init__.py
+++ b/optional_plugins/loader_yaml/avocado_loader_yaml/__init__.py
@@ -15,13 +15,10 @@
 
 import copy
 
-from avocado.core import loader
-from avocado.core import parameters
-from avocado.core import output
+from avocado.core import loader, output, parameters
 from avocado.core.future.settings import settings
 from avocado.core.plugin_interfaces import CLI
-from avocado_varianter_yaml_to_mux import create_from_yaml
-from avocado_varianter_yaml_to_mux import mux
+from avocado_varianter_yaml_to_mux import create_from_yaml, mux
 
 
 class YamlTestsuiteLoader(loader.TestLoader):

--- a/optional_plugins/loader_yaml/setup.py
+++ b/optional_plugins/loader_yaml/setup.py
@@ -13,7 +13,7 @@
 # Copyright: Red Hat Inc. 2017
 # Author: Cleber Rosa <crosa@redhat.com>
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 VERSION = open("VERSION", "r").read().strip()
 

--- a/optional_plugins/loader_yaml/tests/test_yaml_loader.py
+++ b/optional_plugins/loader_yaml/tests/test_yaml_loader.py
@@ -4,7 +4,6 @@ import unittest
 
 from avocado.core import exit_codes
 from avocado.utils import process
-
 from selftests import AVOCADO, BASEDIR, skipUnlessPathExists
 
 

--- a/optional_plugins/result_upload/setup.py
+++ b/optional_plugins/result_upload/setup.py
@@ -13,8 +13,7 @@
 # Copyright: Virtuozzo Inc. 2017
 # Authors: Dmitry Monakhov <dmonakhov@openvz.org>
 
-from setuptools import setup, find_packages
-
+from setuptools import find_packages, setup
 
 VERSION = open("VERSION", "r").read().strip()
 

--- a/optional_plugins/resultsdb/avocado_resultsdb/__init__.py
+++ b/optional_plugins/resultsdb/avocado_resultsdb/__init__.py
@@ -21,9 +21,9 @@ import time
 
 import resultsdb_api
 
-from avocado.core.plugin_interfaces import CLI, ResultEvents, Result
 from avocado.core.future.settings import settings
 from avocado.core.output import LOG_UI
+from avocado.core.plugin_interfaces import CLI, Result, ResultEvents
 
 
 class ResultsdbResultEvent(ResultEvents):

--- a/optional_plugins/resultsdb/setup.py
+++ b/optional_plugins/resultsdb/setup.py
@@ -13,7 +13,7 @@
 # Copyright: Red Hat Inc. 2017
 # Author: Amador Pahim <apahim@redhat.com>
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 VERSION = open("VERSION", "r").read().strip()
 

--- a/optional_plugins/robot/avocado_robot/__init__.py
+++ b/optional_plugins/robot/avocado_robot/__init__.py
@@ -19,21 +19,17 @@ Plugin to run Robot Framework tests in Avocado
 import logging
 import re
 
-from avocado.core import loader
-from avocado.core import output
-from avocado.core import test
-from avocado.core.plugin_interfaces import CLI
-from avocado.core.plugin_interfaces import Resolver
-from avocado.core.resolver import ReferenceResolution
-from avocado.core.resolver import ReferenceResolutionResult
-from avocado.core.resolver import check_file
-from avocado.core.nrunner import Runnable
 from robot import run
 from robot.errors import DataError
-from robot.parsing.model import TestData
 from robot.model import SuiteNamePatterns
 from robot.output.logger import LOGGER
+from robot.parsing.model import TestData
 
+from avocado.core import loader, output, test
+from avocado.core.nrunner import Runnable
+from avocado.core.plugin_interfaces import CLI, Resolver
+from avocado.core.resolver import (ReferenceResolution,
+                                   ReferenceResolutionResult, check_file)
 
 LOGGER.unregister_console_logger()
 

--- a/optional_plugins/robot/avocado_robot/runner.py
+++ b/optional_plugins/robot/avocado_robot/runner.py
@@ -21,9 +21,9 @@ import multiprocessing
 import tempfile
 import time
 
-from avocado.core import nrunner
-
 from robot import run
+
+from avocado.core import nrunner
 
 
 class RobotRunner(nrunner.BaseRunner):

--- a/optional_plugins/robot/setup.py
+++ b/optional_plugins/robot/setup.py
@@ -13,8 +13,7 @@
 # Copyright: Red Hat Inc. 2017
 # Author: Amador Pahim <apahim@redhat.com>
 
-from setuptools import setup, find_packages
-
+from setuptools import find_packages, setup
 
 VERSION = open("VERSION", "r").read().strip()
 

--- a/optional_plugins/robot/tests/test_robot.py
+++ b/optional_plugins/robot/tests/test_robot.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+
 import pkg_resources
 
 import avocado_robot

--- a/optional_plugins/varianter_cit/avocado_varianter_cit/Cit.py
+++ b/optional_plugins/varianter_cit/avocado_varianter_cit/Cit.py
@@ -1,11 +1,10 @@
-import random
 import logging
+import random
 
-from avocado.core.output import LOG_UI
-from avocado.core.output import Throbber
+from avocado.core.output import LOG_UI, Throbber
 
-from .Solver import Solver
 from .CombinationMatrix import CombinationMatrix
+from .Solver import Solver
 
 ITERATIONS_SIZE = 600
 LOG = LOG_UI.getChild("Cit")

--- a/optional_plugins/varianter_cit/setup.py
+++ b/optional_plugins/varianter_cit/setup.py
@@ -14,8 +14,7 @@
 #          Cleber Rosa <crosa@redhat.com>
 
 
-from setuptools import setup, find_packages
-
+from setuptools import find_packages, setup
 
 VERSION = open("VERSION", "r").read().strip()
 

--- a/optional_plugins/varianter_cit/tests/test_basic.py
+++ b/optional_plugins/varianter_cit/tests/test_basic.py
@@ -3,7 +3,6 @@ import tempfile
 import unittest
 
 from avocado.utils import process
-
 from selftests import AVOCADO, BASEDIR, temp_dir_prefix
 
 

--- a/optional_plugins/varianter_cit/tests/test_combinationRow.py
+++ b/optional_plugins/varianter_cit/tests/test_combinationRow.py
@@ -1,4 +1,5 @@
 import unittest
+
 from avocado_varianter_cit.CombinationRow import CombinationRow
 
 

--- a/optional_plugins/varianter_pict/setup.py
+++ b/optional_plugins/varianter_pict/setup.py
@@ -13,8 +13,7 @@
 # Copyright: Red Hat Inc. 2017
 # Author: Cleber Rosa <crosa@redhat.com>
 
-from setuptools import setup, find_packages
-
+from setuptools import find_packages, setup
 
 VERSION = open("VERSION", "r").read().strip()
 

--- a/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/__init__.py
+++ b/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/__init__.py
@@ -21,6 +21,7 @@ import re
 import sys
 
 import yaml
+
 from avocado.core import exit_codes
 from avocado.core.future.settings import settings
 from avocado.core.output import LOG_UI

--- a/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/mux.py
+++ b/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/mux.py
@@ -27,7 +27,6 @@ import re
 
 from avocado.core import output, tree, varianter
 
-
 #
 # Multiplex-enabled tree objects
 #

--- a/optional_plugins/varianter_yaml_to_mux/setup.py
+++ b/optional_plugins/varianter_yaml_to_mux/setup.py
@@ -13,8 +13,7 @@
 # Copyright: Red Hat Inc. 2017
 # Author: Cleber Rosa <crosa@redhat.com>
 
-from setuptools import setup, find_packages
-
+from setuptools import find_packages, setup
 
 VERSION = open("VERSION", "r").read().strip()
 

--- a/optional_plugins/varianter_yaml_to_mux/tests/test_functional.py
+++ b/optional_plugins/varianter_yaml_to_mux/tests/test_functional.py
@@ -1,14 +1,12 @@
 import glob
 import json
 import os
+import shutil
 import tempfile
 import unittest
-import shutil
 
 from avocado.core import exit_codes
-from avocado.utils import process
-from avocado.utils import genio
-
+from avocado.utils import genio, process
 from selftests import AVOCADO, BASEDIR
 
 

--- a/optional_plugins/varianter_yaml_to_mux/tests/test_unit.py
+++ b/optional_plugins/varianter_yaml_to_mux/tests/test_unit.py
@@ -7,9 +7,9 @@ import unittest
 import yaml
 
 import avocado_varianter_yaml_to_mux as yaml_to_mux
-from avocado_varianter_yaml_to_mux import mux
-from avocado.core import tree, parameters
+from avocado.core import parameters, tree
 from avocado.utils import astring
+from avocado_varianter_yaml_to_mux import mux
 
 BASEDIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..')
 BASEDIR = os.path.abspath(BASEDIR)

--- a/requirements-selftests.txt
+++ b/requirements-selftests.txt
@@ -1,6 +1,7 @@
 # Avocado test requirements
 
 # inspektor (static and style checks)
+isort==4.3.21
 pylint==2.5.0
 astroid==2.4.0
 inspektor==0.5.2

--- a/scripts/avocado-run-testplan
+++ b/scripts/avocado-run-testplan
@@ -14,14 +14,13 @@
 # Author: Cleber Rosa <cleber@redhat.com>
 
 
+import argparse
 import datetime
 import getpass
 import json
 import os
 import subprocess
 import sys
-
-import argparse
 
 
 class Parser(argparse.ArgumentParser):

--- a/selftests/.data/loader_instrumented/imports.py
+++ b/selftests/.data/loader_instrumented/imports.py
@@ -2,14 +2,15 @@
 
 # module imports
 import parent1  # .names[0].name => parent1
+# class imports
+import parent7.Class7  # .names[0].name => parent7.Class7   # bad example pylint: disable=I,C,W,E
 import path.parent2  # .names[0].name => path.parent2
+
 from path import parent3  # .module => path; .names[0] => parent3
 import parent4 as asparent4  # .names[0].asname => asparent4; .names[0].name => parent4
 import path.parent5 as asparent5  # .names[0].asname => asparent5; .names[0].name => path.parent5
 from path import parent6 as asparent6  # .module => path; .names[0].asname => asparent6; .names[0].name => path.parent6
 
-# class imports
-import parent7.Class7  # .names[0].name => parent7.Class7   # bad example pylint: disable=I,C,W,E
 from .path.parent8 import Class8  # .module = path.parent8; name[0].name = Class8
 import parent9.Class9 as AsClass9  # .names[0].asname => AsClass9; .names[0].name => parent9.Class9   # bad example pylint: disable=I,C,W,E
 from .path.parent10 import Class10 as AsClass10  # .module => path.parent10; .names[0].asname => AsClass10; .names[0].name => Class10

--- a/selftests/.data/whiteboard.py
+++ b/selftests/.data/whiteboard.py
@@ -2,8 +2,7 @@
 
 import base64
 
-from avocado import Test
-from avocado import main
+from avocado import Test, main
 
 
 class WhiteBoard(Test):

--- a/selftests/__init__.py
+++ b/selftests/__init__.py
@@ -1,10 +1,10 @@
 import logging
 import os
-import pkg_resources
 import sys
 import tempfile
 import unittest.mock
 
+import pkg_resources
 
 #: The base directory for the avocado source tree
 BASEDIR = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))

--- a/selftests/functional/test_argument_parsing.py
+++ b/selftests/functional/test_argument_parsing.py
@@ -1,10 +1,8 @@
-import os
 import glob
+import os
 import unittest
 
-from avocado.core import data_dir
-from avocado.core import job_id
-from avocado.core import exit_codes
+from avocado.core import data_dir, exit_codes, job_id
 from avocado.utils import process
 
 from .. import AVOCADO, BASEDIR

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -6,10 +6,19 @@ import shutil
 import signal
 import tempfile
 import time
+import unittest
 import xml.dom.minidom
 import zipfile
-import unittest
+
 import psutil
+
+from avocado.core import exit_codes
+from avocado.utils import astring, genio
+from avocado.utils import path as utils_path
+from avocado.utils import process, script
+
+from .. import (AVOCADO, BASEDIR, python_module_available,
+                skipOnLevelsInferiorThan, temp_dir_prefix)
 
 try:
     import xmlschema
@@ -23,15 +32,7 @@ try:
 except ImportError:
     AEXPECT_CAPABLE = False
 
-from avocado.core import exit_codes
-from avocado.utils import astring
-from avocado.utils import genio
-from avocado.utils import process
-from avocado.utils import script
-from avocado.utils import path as utils_path
 
-from .. import AVOCADO, BASEDIR, python_module_available, temp_dir_prefix
-from .. import skipOnLevelsInferiorThan
 
 
 UNSUPPORTED_STATUS_TEST_CONTENTS = '''

--- a/selftests/functional/test_export_variables.py
+++ b/selftests/functional/test_export_variables.py
@@ -4,8 +4,7 @@ import unittest
 
 from avocado import VERSION
 from avocado.core import exit_codes
-from avocado.utils import process
-from avocado.utils import script
+from avocado.utils import process, script
 
 from .. import AVOCADO, BASEDIR, temp_dir_prefix
 

--- a/selftests/functional/test_fetch_asset.py
+++ b/selftests/functional/test_fetch_asset.py
@@ -10,8 +10,8 @@ import warnings
 
 from avocado.core import exit_codes
 from avocado.utils import process
-from .. import AVOCADO, get_temporary_config
 
+from .. import AVOCADO, get_temporary_config
 
 TEST_TEMPLATE = r"""
 from avocado import Test

--- a/selftests/functional/test_interrupt.py
+++ b/selftests/functional/test_interrupt.py
@@ -1,19 +1,16 @@
 import os
-import tempfile
-import time
 import signal
 import stat
 import subprocess
+import tempfile
+import time
 import unittest
 
 import psutil
 
-from avocado.utils import process
-from avocado.utils import wait
-from avocado.utils import script
-from avocado.utils import data_factory
+from avocado.utils import data_factory, process, script, wait
 
-from .. import AVOCADO, BASEDIR, temp_dir_prefix, skipOnLevelsInferiorThan
+from .. import AVOCADO, BASEDIR, skipOnLevelsInferiorThan, temp_dir_prefix
 
 # What is commonly known as "0755" or "u=rwx,g=rx,o=rx"
 DEFAULT_MODE = (stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR |

--- a/selftests/functional/test_job_api_features.py
+++ b/selftests/functional/test_job_api_features.py
@@ -6,10 +6,10 @@ import os
 import tempfile
 import unittest
 
-from .. import temp_dir_prefix
-
-from avocado.core.job import Job
 from avocado.core import exit_codes
+from avocado.core.job import Job
+
+from .. import temp_dir_prefix
 
 
 class Test(unittest.TestCase):

--- a/selftests/functional/test_job_timeout.py
+++ b/selftests/functional/test_job_timeout.py
@@ -1,16 +1,13 @@
 import glob
 import os
 import tempfile
-import xml.dom.minidom
 import unittest
+import xml.dom.minidom
 
 from avocado.core import exit_codes
-from avocado.utils import genio
-from avocado.utils import process
-from avocado.utils import script
+from avocado.utils import genio, process, script
 
 from .. import AVOCADO, BASEDIR, temp_dir_prefix
-
 
 SCRIPT_CONTENT = """#!/bin/bash
 sleep 2

--- a/selftests/functional/test_journal.py
+++ b/selftests/functional/test_journal.py
@@ -1,5 +1,5 @@
-import os
 import json
+import os
 import sqlite3
 import tempfile
 import unittest

--- a/selftests/functional/test_loader.py
+++ b/selftests/functional/test_loader.py
@@ -1,18 +1,16 @@
-import os
 import json
-import subprocess
-import time
-import stat
-import tempfile
+import os
 import signal
+import stat
+import subprocess
+import tempfile
+import time
 import unittest
 
 from avocado.core import exit_codes
-from avocado.utils import script
-from avocado.utils import process
+from avocado.utils import process, script
 
-from .. import AVOCADO, BASEDIR, temp_dir_prefix, skipOnLevelsInferiorThan
-
+from .. import AVOCADO, BASEDIR, skipOnLevelsInferiorThan, temp_dir_prefix
 
 AVOCADO_TEST_OK = """#!/usr/bin/env python
 from avocado import Test

--- a/selftests/functional/test_lv_utils.py
+++ b/selftests/functional/test_lv_utils.py
@@ -11,9 +11,7 @@ import tempfile
 import time
 import unittest
 
-from avocado.utils import process
-from avocado.utils import lv_utils
-from avocado.utils import linux_modules
+from avocado.utils import linux_modules, lv_utils, process
 
 from .. import temp_dir_prefix
 

--- a/selftests/functional/test_nrunner.py
+++ b/selftests/functional/test_nrunner.py
@@ -1,12 +1,11 @@
 import os
 import sys
-import unittest
 import tempfile
-
-from .. import AVOCADO, BASEDIR, temp_dir_prefix, skipUnlessPathExists
+import unittest
 
 from avocado.utils import process
 
+from .. import AVOCADO, BASEDIR, skipUnlessPathExists, temp_dir_prefix
 
 RUNNER = "%s -m avocado.core.nrunner" % sys.executable
 

--- a/selftests/functional/test_nrunner_interface.py
+++ b/selftests/functional/test_nrunner_interface.py
@@ -1,9 +1,7 @@
 import json
 import sys
 
-from avocado import Test
-from avocado import fail_on
-
+from avocado import Test, fail_on
 from avocado.utils import process
 
 

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -9,12 +9,10 @@ from xml.dom import minidom
 from avocado.core import exit_codes
 from avocado.core.output import TermSupport
 from avocado.utils import genio
-from avocado.utils import process
-from avocado.utils import script
 from avocado.utils import path as utils_path
+from avocado.utils import process, script
 
 from .. import AVOCADO, BASEDIR, temp_dir_prefix
-
 
 # AVOCADO may contain more than a single command, as it can be
 # prefixed by the Python interpreter

--- a/selftests/functional/test_output_check.py
+++ b/selftests/functional/test_output_check.py
@@ -4,11 +4,9 @@ import tempfile
 import unittest
 
 from avocado.core import exit_codes
-from avocado.utils import process
-from avocado.utils import script
+from avocado.utils import process, script
 
 from .. import AVOCADO, BASEDIR, temp_dir_prefix
-
 
 STDOUT = b"Hello, \xc4\x9b\xc5\xa1\xc4\x8d\xc5\x99\xc5\xbe\xc3\xbd\xc3\xa1\xc3\xad\xc3\xa9!"
 STDERR = b"Hello, stderr!"

--- a/selftests/functional/test_plugin_assets.py
+++ b/selftests/functional/test_plugin_assets.py
@@ -10,8 +10,8 @@ import warnings
 
 from avocado.core import exit_codes
 from avocado.utils import process
-from .. import AVOCADO, get_temporary_config
 
+from .. import AVOCADO, get_temporary_config
 
 TEST_TEMPLATE = r"""
 from avocado import Test

--- a/selftests/functional/test_plugin_diff.py
+++ b/selftests/functional/test_plugin_diff.py
@@ -4,8 +4,7 @@ import tempfile
 import unittest
 
 from avocado.core import exit_codes
-from avocado.utils import process
-from avocado.utils import script
+from avocado.utils import process, script
 
 from .. import AVOCADO, BASEDIR, temp_dir_prefix
 

--- a/selftests/functional/test_plugin_jobscripts.py
+++ b/selftests/functional/test_plugin_jobscripts.py
@@ -3,11 +3,9 @@ import tempfile
 import unittest
 
 from avocado.core import exit_codes
-from avocado.utils import process
-from avocado.utils import script
+from avocado.utils import process, script
 
 from .. import AVOCADO, BASEDIR, temp_dir_prefix
-
 
 SCRIPT_PRE_TOUCH = """#!/bin/sh -e
 touch %s"""

--- a/selftests/functional/test_plugin_vmimage.py
+++ b/selftests/functional/test_plugin_vmimage.py
@@ -3,7 +3,8 @@ import os
 import unittest.mock
 
 from avocado.core import exit_codes
-from avocado.utils import process, path
+from avocado.utils import path, process
+
 from .. import AVOCADO, get_temporary_config
 
 

--- a/selftests/functional/test_replay_external_runner.py
+++ b/selftests/functional/test_replay_external_runner.py
@@ -4,8 +4,7 @@ import tempfile
 import unittest
 
 from avocado.core import exit_codes
-from avocado.utils import process
-from avocado.utils import script
+from avocado.utils import process, script
 
 from .. import AVOCADO, BASEDIR, temp_dir_prefix
 

--- a/selftests/functional/test_resolver.py
+++ b/selftests/functional/test_resolver.py
@@ -1,15 +1,13 @@
 import stat
 import unittest
 
-from avocado.utils import script
-from avocado.utils import process
+from avocado.utils import process, script
 
 from .. import AVOCADO
-
 # Use the same definitions from loader to make sure the behavior
 # is also the same
-from .test_loader import SIMPLE_TEST as EXEC_TEST
 from .test_loader import AVOCADO_TEST_OK as AVOCADO_INSTRUMENTED_TEST
+from .test_loader import SIMPLE_TEST as EXEC_TEST
 
 
 class ResolverFunctional(unittest.TestCase):

--- a/selftests/functional/test_skiptests.py
+++ b/selftests/functional/test_skiptests.py
@@ -4,9 +4,7 @@ import tempfile
 import unittest
 
 from avocado.core import exit_codes
-from avocado.utils import genio
-from avocado.utils import process
-from avocado.utils import script
+from avocado.utils import genio, process, script
 
 from .. import AVOCADO, BASEDIR, temp_dir_prefix
 

--- a/selftests/functional/test_statuses.py
+++ b/selftests/functional/test_statuses.py
@@ -3,11 +3,9 @@ import os
 import tempfile
 import unittest
 
-from avocado.utils import genio
-from avocado.utils import process
+from avocado.utils import genio, process
 
 from .. import AVOCADO, BASEDIR, temp_dir_prefix
-
 
 ALL_MESSAGES = ['setup pre',
                 'setup post',

--- a/selftests/functional/test_sysinfo.py
+++ b/selftests/functional/test_sysinfo.py
@@ -3,11 +3,9 @@ import tempfile
 import unittest
 
 from avocado.core import exit_codes
-from avocado.utils import process
-from avocado.utils import script
+from avocado.utils import process, script
 
-from .. import AVOCADO, BASEDIR, temp_dir_prefix, skipOnLevelsInferiorThan
-
+from .. import AVOCADO, BASEDIR, skipOnLevelsInferiorThan, temp_dir_prefix
 
 COMMANDS_TIMEOUT_CONF = """
 [sysinfo.collect]

--- a/selftests/functional/test_teststmpdir.py
+++ b/selftests/functional/test_teststmpdir.py
@@ -2,13 +2,10 @@ import os
 import tempfile
 import unittest
 
-from avocado.core import exit_codes
-from avocado.core import test
-from avocado.utils import process
-from avocado.utils import script
+from avocado.core import exit_codes, test
+from avocado.utils import process, script
 
 from .. import AVOCADO, BASEDIR, temp_dir_prefix
-
 
 INSTRUMENTED_SCRIPT = """import os
 import tempfile

--- a/selftests/functional/test_thirdparty_bugs.py
+++ b/selftests/functional/test_thirdparty_bugs.py
@@ -1,10 +1,9 @@
-import re
 import json
+import re
 import unittest
 from urllib.error import URLError
 
-from avocado.utils import astring
-from avocado.utils import download
+from avocado.utils import astring, download
 
 
 def get_content_by_encoding(url):

--- a/selftests/functional/test_unittest_compat.py
+++ b/selftests/functional/test_unittest_compat.py
@@ -3,11 +3,9 @@ import sys
 import tempfile
 import unittest
 
-from avocado.utils import script
-from avocado.utils import process
+from avocado.utils import process, script
 
 from .. import BASEDIR, temp_dir_prefix
-
 
 UNITTEST_GOOD = """from avocado import Test
 from unittest import main

--- a/selftests/functional/test_utils.py
+++ b/selftests/functional/test_utils.py
@@ -7,12 +7,11 @@ import tempfile
 import time
 import unittest
 
+from avocado.utils import process
 from avocado.utils.filelock import FileLock
 from avocado.utils.stacktrace import prepare_exc_info
-from avocado.utils import process
 
-from .. import temp_dir_prefix, skipOnLevelsInferiorThan
-
+from .. import skipOnLevelsInferiorThan, temp_dir_prefix
 
 # What is commonly known as "0775" or "u=rwx,g=rwx,o=rx"
 DEFAULT_MODE = (stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR |

--- a/selftests/functional/test_utils_asset.py
+++ b/selftests/functional/test_utils_asset.py
@@ -7,7 +7,6 @@ from avocado.utils.filelock import FileLock
 
 from .. import setup_avocado_loggers, temp_dir_prefix
 
-
 setup_avocado_loggers()
 
 

--- a/selftests/functional/test_wrapper.py
+++ b/selftests/functional/test_wrapper.py
@@ -3,12 +3,10 @@ import tempfile
 import unittest
 
 from avocado.core import exit_codes
-from avocado.utils import process
-from avocado.utils import script
 from avocado.utils import path as utils_path
+from avocado.utils import process, script
 
 from .. import AVOCADO, BASEDIR, temp_dir_prefix
-
 
 SCRIPT_CONTENT = """#!/bin/bash
 touch %s

--- a/selftests/isort.sh
+++ b/selftests/isort.sh
@@ -1,0 +1,6 @@
+#!/bin/sh -e
+
+isort --recursive --check-only \
+      --skip selftests/.data/loader_instrumented/dont_crash.py \
+      --skip selftests/.data/loader_instrumented/double_import.py \
+      --skip selftests/.data/loader_instrumented/dont_detect_non_avocado.py

--- a/selftests/jobs/pass
+++ b/selftests/jobs/pass
@@ -4,6 +4,7 @@
 
 import os
 import sys
+
 from avocado.core.job import Job
 
 config = {

--- a/selftests/pre_release/jobs/vmimage.py
+++ b/selftests/pre_release/jobs/vmimage.py
@@ -5,7 +5,6 @@ import sys
 
 from avocado.core.job import Job
 
-
 COMMON_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 TEST_DIR = os.path.join(COMMON_DIR, 'tests')
 

--- a/selftests/pre_release/tests/vmimage.py
+++ b/selftests/pre_release/tests/vmimage.py
@@ -1,10 +1,8 @@
-from avocado import Test
-from avocado import fail_on
-from avocado.utils import vmimage
-from avocado.utils import process
-
-from urllib.request import urlopen
 from urllib.error import HTTPError
+from urllib.request import urlopen
+
+from avocado import Test, fail_on
+from avocado.utils import process, vmimage
 
 
 class Base(Test):

--- a/selftests/run
+++ b/selftests/run
@@ -10,9 +10,7 @@ import sys
 import unittest
 
 from avocado.core import data_dir
-
 from selftests import test_suite
-
 
 CHECK_TMP_DIRS = os.path.abspath(os.path.join(os.path.dirname(__file__),
                                               "check_tmp_dirs"))

--- a/selftests/unit/test_archive.py
+++ b/selftests/unit/test_archive.py
@@ -1,12 +1,10 @@
-import unittest
-import tempfile
 import os
-import sys
 import random
+import sys
+import tempfile
+import unittest
 
-from avocado.utils import archive
-from avocado.utils import crypto
-from avocado.utils import data_factory
+from avocado.utils import archive, crypto, data_factory
 
 from .. import BASEDIR, temp_dir_prefix
 

--- a/selftests/unit/test_gdb.py
+++ b/selftests/unit/test_gdb.py
@@ -1,7 +1,6 @@
 import unittest
 
-from avocado.utils.gdb import GDBRemote
-from avocado.utils.gdb import InvalidPacketError
+from avocado.utils.gdb import GDBRemote, InvalidPacketError
 
 
 class GDBRemoteTest(unittest.TestCase):

--- a/selftests/unit/test_hintfiles.py
+++ b/selftests/unit/test_hintfiles.py
@@ -1,13 +1,12 @@
 import tempfile
 import unittest
 
+from avocado.core.future.settings import SettingsError
 from avocado.core.nrunner import Runnable
 from avocado.core.parser import HintParser
 from avocado.core.resolver import ReferenceResolution
-from avocado.core.future.settings import SettingsError
 
 from .. import skipUnlessPathExists
-
 
 BAD = """[kinds]
 tap = ./tests/*.t

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -3,17 +3,12 @@ import os
 import tempfile
 import unittest.mock
 
-from avocado.core import data_dir
-from avocado.core import exit_codes
-from avocado.core import job
-from avocado.core import nrunner
-from avocado.core import test
+from avocado.core import data_dir, exit_codes, job, nrunner, test
 from avocado.core.exceptions import JobBaseException
 from avocado.core.suite import TestSuite, TestSuiteStatus
 from avocado.utils import path as utils_path
 
 from .. import setup_avocado_loggers, temp_dir_prefix
-
 
 setup_avocado_loggers()
 

--- a/selftests/unit/test_jsonresult.py
+++ b/selftests/unit/test_jsonresult.py
@@ -1,7 +1,7 @@
-import unittest
-import os
 import json
+import os
 import tempfile
+import unittest
 
 from avocado import Test
 from avocado.core import job
@@ -9,7 +9,6 @@ from avocado.core.result import Result
 from avocado.plugins import jsonresult
 
 from .. import setup_avocado_loggers, temp_dir_prefix
-
 
 setup_avocado_loggers()
 

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -3,13 +3,11 @@ import stat
 import tempfile
 import unittest.mock
 
-from avocado.core import test
+from avocado.core import loader, test
 from avocado.core.test_id import TestID
-from avocado.core import loader
 from avocado.utils import script
 
 from .. import setup_avocado_loggers, temp_dir_prefix
-
 
 setup_avocado_loggers()
 

--- a/selftests/unit/test_nrunner.py
+++ b/selftests/unit/test_nrunner.py
@@ -3,10 +3,9 @@ import sys
 import tempfile
 import unittest.mock
 
-from avocado.core import nrunner
-from avocado.core import nrunner_tap
+from avocado.core import nrunner, nrunner_tap
 
-from .. import temp_dir_prefix, skipUnlessPathExists
+from .. import skipUnlessPathExists, temp_dir_prefix
 
 
 class Runnable(unittest.TestCase):

--- a/selftests/unit/test_output.py
+++ b/selftests/unit/test_output.py
@@ -1,8 +1,8 @@
 import sys
 import unittest.mock
 
-from avocado.utils import path as utils_path
 from avocado.core import output
+from avocado.utils import path as utils_path
 
 
 class TestStdOutput(unittest.TestCase):

--- a/selftests/unit/test_parameters.py
+++ b/selftests/unit/test_parameters.py
@@ -1,7 +1,6 @@
 import unittest
 
-from avocado.core import parameters
-from avocado.core import tree
+from avocado.core import parameters, tree
 
 
 class Parameters(unittest.TestCase):

--- a/selftests/unit/test_plugin_assets.py
+++ b/selftests/unit/test_plugin_assets.py
@@ -4,8 +4,7 @@ Assets plugin unit tests
 
 import ast
 import unittest
-
-from unittest.mock import patch, mock_open
+from unittest.mock import mock_open, patch
 
 from avocado.plugins import assets
 

--- a/selftests/unit/test_plugin_vmimage.py
+++ b/selftests/unit/test_plugin_vmimage.py
@@ -1,14 +1,16 @@
-import unittest.mock
 import os
 import tempfile
+import unittest.mock
 from urllib.error import URLError
 
 from avocado.core import data_dir
+from avocado.core.future import settings as future_settings
 from avocado.plugins import vmimage as vmimage_plugin
 from avocado.utils import vmimage as vmimage_util
-from avocado.core.future import settings as future_settings
-from .. import temp_dir_prefix, skipOnLevelsInferiorThan
-from ..functional.test_plugin_vmimage import missing_binary, create_metadata_file
+
+from .. import skipOnLevelsInferiorThan, temp_dir_prefix
+from ..functional.test_plugin_vmimage import (create_metadata_file,
+                                              missing_binary)
 
 #: extracted from https://dl.fedoraproject.org/pub/fedora/linux/releases/
 FEDORA_PAGE = """<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">

--- a/selftests/unit/test_replay.py
+++ b/selftests/unit/test_replay.py
@@ -7,7 +7,6 @@ from avocado.plugins import replay
 
 from .. import setup_avocado_loggers, temp_dir_prefix
 
-
 setup_avocado_loggers()
 
 

--- a/selftests/unit/test_result.py
+++ b/selftests/unit/test_result.py
@@ -2,7 +2,6 @@ import unittest
 
 from avocado.core.result import Result
 
-
 UNIQUE_ID = '0000000000000000000000000000000000000000'
 LOGFILE = None
 

--- a/selftests/unit/test_safeloader.py
+++ b/selftests/unit/test_safeloader.py
@@ -1,14 +1,13 @@
 import ast
-import sys
 import os
 import re
+import sys
 import unittest
 
 from avocado.core import safeloader
 from avocado.utils import script
 
 from .. import BASEDIR, setup_avocado_loggers
-
 
 setup_avocado_loggers()
 

--- a/selftests/unit/test_settings.py
+++ b/selftests/unit/test_settings.py
@@ -4,6 +4,7 @@ import tempfile
 import unittest
 
 from pkg_resources import get_distribution
+
 from avocado.core import settings
 from avocado.core.future.settings import DuplicatedNamespace
 from avocado.core.future.settings import settings as future_settings

--- a/selftests/unit/test_spawner.py
+++ b/selftests/unit/test_spawner.py
@@ -2,9 +2,8 @@ import asyncio
 import unittest
 
 from avocado.core import nrunner
+from avocado.core.spawners.mock import MockRandomAliveSpawner, MockSpawner
 from avocado.core.spawners.process import ProcessSpawner
-from avocado.core.spawners.mock import MockSpawner
-from avocado.core.spawners.mock import MockRandomAliveSpawner
 
 
 class Process(unittest.TestCase):

--- a/selftests/unit/test_tags.py
+++ b/selftests/unit/test_tags.py
@@ -1,12 +1,9 @@
 import stat
 import unittest
 
-from avocado.core import loader
-from avocado.core import tags
-from avocado.utils import script
-
+from avocado.core import loader, tags
 from avocado.core.nrunner import Runnable
-
+from avocado.utils import script
 
 #: What is commonly known as "0664" or "u=rw,g=rw,o=r"
 DEFAULT_NON_EXEC_MODE = (stat.S_IRUSR | stat.S_IWUSR |

--- a/selftests/unit/test_tap.py
+++ b/selftests/unit/test_tap.py
@@ -15,8 +15,7 @@
 import io
 import unittest
 
-from avocado.core.tapparser import TestResult, TapParser
-
+from avocado.core.tapparser import TapParser, TestResult
 
 # The TapParser unit tests are based on Meson's unit tests for TAP parsing,
 # which were licensed under the MIT (X11) license and were contributed to

--- a/selftests/unit/test_test.py
+++ b/selftests/unit/test_test.py
@@ -2,12 +2,11 @@ import os
 import tempfile
 import unittest.mock
 
-from avocado.core import test, exceptions
+from avocado.core import exceptions, test
 from avocado.core.test_id import TestID
 from avocado.utils import script
 
 from .. import setup_avocado_loggers, temp_dir_prefix
-
 
 setup_avocado_loggers()
 

--- a/selftests/unit/test_utils_cloudinit.py
+++ b/selftests/unit/test_utils_cloudinit.py
@@ -1,15 +1,12 @@
+import http.client
 import os
 import tempfile
 import threading
 import unittest.mock
-import http.client
 
-from avocado.utils import cloudinit
-from avocado.utils import iso9660
-from avocado.utils import data_factory
+from avocado.utils import cloudinit, data_factory, iso9660
 
 from .. import setup_avocado_loggers, temp_dir_prefix
-
 
 setup_avocado_loggers()
 

--- a/selftests/unit/test_utils_disk.py
+++ b/selftests/unit/test_utils_disk.py
@@ -1,8 +1,6 @@
 import unittest.mock
 
-from avocado.utils import disk
-from avocado.utils import process
-
+from avocado.utils import disk, process
 
 LSBLK_OUTPUT = b'''
 {

--- a/selftests/unit/test_utils_filelock.py
+++ b/selftests/unit/test_utils_filelock.py
@@ -2,8 +2,7 @@ import os
 import tempfile
 import unittest
 
-from avocado.utils.filelock import AlreadyLocked
-from avocado.utils.filelock import FileLock
+from avocado.utils.filelock import AlreadyLocked, FileLock
 
 from .. import temp_dir_prefix
 

--- a/selftests/unit/test_utils_genio.py
+++ b/selftests/unit/test_utils_genio.py
@@ -8,7 +8,6 @@ from avocado.utils import genio
 
 from .. import setup_avocado_loggers, temp_dir_prefix
 
-
 setup_avocado_loggers()
 
 

--- a/selftests/unit/test_utils_iso9660.py
+++ b/selftests/unit/test_utils_iso9660.py
@@ -9,7 +9,6 @@ from avocado.utils import iso9660, process
 
 from .. import setup_avocado_loggers, temp_dir_prefix
 
-
 setup_avocado_loggers()
 
 

--- a/selftests/unit/test_utils_kernel.py
+++ b/selftests/unit/test_utils_kernel.py
@@ -4,7 +4,6 @@ from avocado.utils.kernel import KernelBuild
 
 from .. import setup_avocado_loggers
 
-
 setup_avocado_loggers()
 
 

--- a/selftests/unit/test_utils_network.py
+++ b/selftests/unit/test_utils_network.py
@@ -1,13 +1,14 @@
 import socket
 import unittest.mock
 
+import avocado.utils.network.ports as ports
+
 try:
     import netifaces
     HAS_NETIFACES = True
 except ImportError:
     HAS_NETIFACES = False
 
-import avocado.utils.network.ports as ports
 
 
 class PortTrackerTest(unittest.TestCase):

--- a/selftests/unit/test_utils_partition.py
+++ b/selftests/unit/test_utils_partition.py
@@ -9,9 +9,9 @@ import sys
 import tempfile
 import unittest.mock
 
-from avocado.utils import partition, process
+from avocado.utils import partition
 from avocado.utils import path as utils_path
-from avocado.utils import wait
+from avocado.utils import process, wait
 
 from .. import temp_dir_prefix
 

--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -1,18 +1,14 @@
 import io
 import logging
 import os
-import unittest.mock
 import sys
 import time
+import unittest.mock
 
+from avocado.utils import path, process, script
 
-from avocado.utils import script
-from avocado.utils import process
-from avocado.utils import path
-
-from .. import setup_avocado_loggers, skipOnLevelsInferiorThan
-from .. import skipUnlessPathExists
-
+from .. import (setup_avocado_loggers, skipOnLevelsInferiorThan,
+                skipUnlessPathExists)
 
 setup_avocado_loggers()
 

--- a/selftests/unit/test_utils_script.py
+++ b/selftests/unit/test_utils_script.py
@@ -1,7 +1,6 @@
 import os
 import unittest
 
-
 from avocado.utils import script
 
 

--- a/selftests/unit/test_utils_service.py
+++ b/selftests/unit/test_utils_service.py
@@ -22,7 +22,6 @@ from avocado.utils import service
 
 from .. import setup_avocado_loggers
 
-
 setup_avocado_loggers()
 
 

--- a/selftests/unit/test_utils_software_manager.py
+++ b/selftests/unit/test_utils_software_manager.py
@@ -1,11 +1,9 @@
 import os
 import unittest
 
-from avocado.utils import distro
-from avocado.utils import software_manager
+from avocado.utils import distro, software_manager
 
 from .. import setup_avocado_loggers
-
 
 setup_avocado_loggers()
 

--- a/selftests/unit/test_utils_ssh.py
+++ b/selftests/unit/test_utils_ssh.py
@@ -1,8 +1,7 @@
 import os
 import unittest.mock
 
-from avocado.utils import ssh
-from avocado.utils import process
+from avocado.utils import process, ssh
 
 
 class Session(unittest.TestCase):

--- a/selftests/unit/test_utils_stacktrace.py
+++ b/selftests/unit/test_utils_stacktrace.py
@@ -15,9 +15,9 @@
 avocado.utils.stacktrace unittests
 """
 
+import pickle
 import re
 import unittest
-import pickle
 
 from avocado.utils import stacktrace
 

--- a/selftests/unit/test_utils_vmimage.py
+++ b/selftests/unit/test_utils_vmimage.py
@@ -5,7 +5,6 @@ from avocado.utils import vmimage
 
 from .. import setup_avocado_loggers
 
-
 setup_avocado_loggers()
 
 

--- a/selftests/unit/test_xunit.py
+++ b/selftests/unit/test_xunit.py
@@ -3,18 +3,20 @@ import tempfile
 import unittest
 from xml.dom import minidom
 
-try:
-    import xmlschema
-    SCHEMA_CAPABLE = True
-except ImportError:
-    SCHEMA_CAPABLE = False
-
 from avocado import Test
 from avocado.core import job
 from avocado.core.result import Result
 from avocado.plugins import xunit
 
 from .. import setup_avocado_loggers, temp_dir_prefix
+
+try:
+    import xmlschema
+    SCHEMA_CAPABLE = True
+except ImportError:
+    SCHEMA_CAPABLE = False
+
+
 
 
 setup_avocado_loggers()

--- a/setup.py
+++ b/setup.py
@@ -15,9 +15,11 @@
 
 import os
 import sys
+
+from setuptools import find_packages, setup
+
 # pylint: disable=E0611
 
-from setuptools import setup, find_packages
 
 BASE_PATH = os.path.dirname(__file__)
 with open(os.path.join(BASE_PATH, 'VERSION'), 'r') as version_file:


### PR DESCRIPTION
Including a mass change using the default style, and a check to make
sure we don't regress.

There are a few exceptions on selftests that play with the import
order on purpose, so those are skipped from the checks.

Signed-off-by: Cleber Rosa <crosa@redhat.com>