### PR TITLE
Test features/options using Python dictionary variants.

### DIFF
--- a/selftests/pre_release/jobs/features.py
+++ b/selftests/pre_release/jobs/features.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+
+import os
+
+from avocado import Test
+from avocado.core import exit_codes
+from avocado.core.job import Job
+
+BOOLEAN_ENABLED = 'on'
+BOOLEAN_DISABLED = 'off'
+
+
+class JobAPIFeaturesTest(Test):
+
+    def check_exit_code(self, exit_code):
+        """Check if job ended with success"""
+        expected_exit_code = self.params.get('exit_code',
+                                             default=exit_codes.AVOCADO_ALL_OK)
+        self.assertEqual(expected_exit_code, exit_code)
+
+    def check_file_exists(self, file_path, value):
+        """Check if a file exist or not depending on the `assert_func`"""
+        assert_func = self.get_assert_function(value)
+        assert_func(os.path.exists(file_path))
+
+    def check_file_content(self, file_path, value):
+        """Check if `content` exists or not in a file."""
+        content = self.params.get('content')
+        assert_func = self.get_assert_function(value)
+        assert_func(self.file_has_content(file_path, content))
+
+    @staticmethod
+    def file_has_content(file_path, content):
+        """Check if a file has `content`."""
+        if os.path.isfile(file_path):
+            with open(file_path, "r") as f:
+                source_content = f.read()
+            if content in source_content:
+                return True
+        return False
+
+    def get_assert_function(self, value):
+        """Return an assert function depending on the value passed"""
+        if value == BOOLEAN_ENABLED:
+            assert_func = self.assertTrue
+        else:
+            assert_func = self.assertFalse
+        return assert_func
+
+    @property
+    def result_file_path(self):
+        file_name = self.params.get('file')
+        return os.path.join(self.workdir, 'latest', file_name)
+
+    def test_check_file(self):
+        """Test to check if a file was created."""
+
+        config = {'core.show': ['none'],
+                  'run.results_dir': self.workdir,
+                  'run.references': ['/bin/true']}
+        namespace = self.params.get('namespace')
+        value = self.params.get('value')
+        config[namespace] = value
+
+        # run the job
+        with Job(config) as j:
+            result = j.run()
+
+        # Asserts
+        self.check_exit_code(result)
+        self.check_file_exists(self.result_file_path, value)
+
+    def test_check_content(self):
+        """Test to check if a file has the desired content."""
+
+        config = {'core.show': ['none'],
+                  'run.results_dir': self.workdir,
+                  'run.references': ['/bin/true']}
+        namespace = self.params.get('namespace')
+        value = self.params.get('value')
+        config[namespace] = value
+
+        # run the job
+        with Job(config) as j:
+            result = j.run()
+
+        # Asserts
+        self.check_exit_code(result)
+        self.check_file_content(self.result_file_path, value)
+
+
+if __name__ == '__main__':
+
+    #DIR = os.path.dirname(os.path.abspath(__file__))
+
+    # First test with its config
+    reference = '%s:JobAPIFeaturesTest.test_check_file' % __file__
+    config = {'run.references': [reference],
+              'run.dict_variants': [
+
+                  {'namespace': 'job.run.result.html.enabled',
+                   'file': 'results.html',
+                   'value': 'on'},
+
+                  {'namespace': 'job.run.result.html.enabled',
+                   'file': 'results.html',
+                   'value': 'off'},
+
+                  {'namespace': 'job.run.result.json.enabled',
+                   'file': 'results.json',
+                   'value': 'on'},
+
+                  {'namespace': 'job.run.result.json.enabled',
+                   'file': 'results.json',
+                   'value': 'off'},
+
+                  {'namespace': 'job.run.result.tap.enabled',
+                   'file': 'results.tap',
+                   'value': 'on'},
+
+                  {'namespace': 'job.run.result.tap.enabled',
+                   'file': 'results.tap',
+                   'value': 'off'},
+
+                  {'namespace': 'job.run.result.xunit.enabled',
+                   'file': 'results.xml',
+                   'value': 'on'},
+
+                  {'namespace': 'job.run.result.xunit.enabled',
+                   'file': 'results.xml',
+                   'value': 'off'},
+
+              ]}
+
+    with Job(config) as j:
+        j.run()
+
+    # Second test with its config
+    reference = '%s:JobAPIFeaturesTest.test_check_content' % __file__
+    config = {'run.references': [reference],
+              'run.dict_variants': [
+
+                  {'namespace': 'job.run.result.tap.include_logs',
+                   'file': 'results.tap',
+                   'content': "Command '/bin/true' finished with 0",
+                   'value': 'on'},
+
+                  {'namespace': 'job.run.result.tap.include_logs',
+                   'file': 'results.tap',
+                   'content': "Command '/bin/true' finished with 0",
+                   'value': 'off'},
+
+              ]}
+
+    with Job(config) as j:
+        j.run()


### PR DESCRIPTION
This is the change to use Python dictionary variants of #4005 

Advantages I see with this implementation:
- Use one single file for the test instead of one test file and multiple YAML files;
- Easy to read the variants as they are defined on a Python dictionary with all its variables;
- We can ignore variants we think are not useful without the need to handle with the YAML tricks.

Disadvantages I see with this implementation:
- All variants need to be defined manually. We lose the automatic variants creation;

I see this approach as a mid-term between the implementation of a full-YAML test "framework," and the implementation of a single test and its variants for each feature/option. IMHO, the effort of the first implementation to manually create all the necessary variants for each feature/option is worth it and may help in future maintenance.

I consider this is a good code base for the implementation of the features/options test.

Signed-off-by: Willian Rampazzo <willianr@redhat.com>