### PR TITLE
Requirements checks: basic feature and core/avocado checks 

### DIFF
--- a/avocado/core/magic.py
+++ b/avocado/core/magic.py
@@ -1,0 +1,17 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat, Inc. 2020
+# Author: Cleber Rosa <crosa@redhat.com>
+
+
+#: Magic number used to check that an "avocado" command is indeed
+#: present and matches one's expectations
+MAGIC = "971dfda4234b6abbea36ed1e939664f45c0190b234918d627449c8b578f8072e"

--- a/avocado/core/requirements.py
+++ b/avocado/core/requirements.py
@@ -1,0 +1,98 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2020
+# Authors: Cleber Rosa <crosa@redhat.com>
+
+"""
+Test requirements module.
+"""
+
+import os
+import sqlite3
+
+from .data_dir import get_datafile_path
+
+#: The location of the requirements cache database
+CACHE_DATABASE_PATH = get_datafile_path('cache', 'requirements.sqlite')
+
+#: The definition of the databse schema
+SCHEMA = [
+    'CREATE TABLE IF NOT EXISTS requirement_type (requirement_type TEXT UNIQUE)',
+    'CREATE TABLE IF NOT EXISTS environment_type (environment_type TEXT UNIQUE)',
+    ('CREATE TABLE IF NOT EXISTS environment ('
+     'environment_type TEXT,'
+     'environment TEXT,'
+     'FOREIGN KEY(environment_type) REFERENCES '
+     'environment_type(environment_type)'
+     ')'),
+    ('CREATE UNIQUE INDEX IF NOT EXISTS '
+     'environment_idx ON environment (environment, environment_type)'),
+    ('CREATE TABLE IF NOT EXISTS requirement ('
+     'environment_type TEXT,'
+     'environment TEXT,'
+     'requirement_type TEXT,'
+     'requirement TEXT,'
+     'FOREIGN KEY(environment_type) REFERENCES environment(environment_type),'
+     'FOREIGN KEY(environment) REFERENCES environment(environment),'
+     'FOREIGN KEY(requirement_type) REFERENCES requirement_type(requirement_type)'
+     ')'),
+    ('CREATE UNIQUE INDEX IF NOT EXISTS requirement_idx ON requirement '
+     '(environment_type, environment, requirement_type, requirement)')
+]
+
+
+def _create_requirement_cache_db():
+    with sqlite3.connect(CACHE_DATABASE_PATH) as conn:
+        cursor = conn.cursor()
+        for entry in SCHEMA:
+            _ = cursor.execute(entry)
+        conn.commit()
+
+
+def set_requirement_on_cache(environment_type, environment,
+                             requirement_type, requirement):
+    if not os.path.exists(CACHE_DATABASE_PATH):
+        _create_requirement_cache_db()
+
+    with sqlite3.connect(CACHE_DATABASE_PATH) as conn:
+        cursor = conn.cursor()
+        sql = "INSERT OR IGNORE INTO environment_type VALUES (?)"
+        cursor.execute(sql, (environment_type, ))
+        sql = "INSERT OR IGNORE INTO environment VALUES (?, ?)"
+        cursor.execute(sql, (environment_type, environment))
+        sql = "INSERT OR IGNORE INTO requirement_type VALUES (?)"
+        cursor.execute(sql, (requirement_type, ))
+        sql = "INSERT OR IGNORE INTO requirement VALUES (?, ?, ?, ?)"
+        cursor.execute(sql, (environment_type, environment,
+                             requirement_type, requirement))
+    conn.commit()
+
+
+def get_requirement_on_cache(environment_type, environment,
+                             requirement_type, requirement):
+    if not os.path.exists(CACHE_DATABASE_PATH):
+        return False
+
+    sql = ("SELECT COUNT(*) FROM requirement WHERE ("
+           "environment_type = ? AND "
+           "environment = ? AND "
+           "requirement_type = ? AND "
+           "requirement = ?)")
+
+    with sqlite3.connect(CACHE_DATABASE_PATH) as conn:
+        cursor = conn.cursor()
+        result = cursor.execute(sql, (environment_type, environment,
+                                      requirement_type, requirement))
+        row = result.fetchone()
+        if row is not None:
+            return row[0] == 1
+    return False

--- a/avocado/core/spawners/podman.py
+++ b/avocado/core/spawners/podman.py
@@ -3,13 +3,13 @@ import json
 import os
 import subprocess
 
+from ..future.settings import settings
 from .common import BaseSpawner, SpawnMethod
 
 
 class PodmanSpawner(BaseSpawner):
 
     METHODS = [SpawnMethod.STANDALONE_EXECUTABLE]
-    IMAGE = 'fedora:31'
     PODMAN_BIN = "/usr/bin/podman"
 
     @staticmethod
@@ -42,7 +42,7 @@ class PodmanSpawner(BaseSpawner):
                 self.PODMAN_BIN, "create",
                 "--net=host",
                 entry_point_arg,
-                self.IMAGE,
+                settings.as_dict().get('nrun.spawner.podman.image'),
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE)
         except (FileNotFoundError, PermissionError):

--- a/avocado/core/spawners/podman.py
+++ b/avocado/core/spawners/podman.py
@@ -4,6 +4,8 @@ import os
 import subprocess
 
 from ..future.settings import settings
+from ..magic import MAGIC
+from ..requirements import get_requirement_on_cache, set_requirement_on_cache
 from .common import BaseSpawner, SpawnMethod
 
 
@@ -28,6 +30,54 @@ class PodmanSpawner(BaseSpawner):
         # be considered "alive" because it happens before the
         # container transitions into "running"
         return out in [b'configured\n', b'running\n']
+
+
+    async def check_requirement_core_avocado(self):
+        env_type = 'podman'
+        env = settings.as_dict().get('nrun.spawner.podman.image')
+        req_type = 'core'
+        req = 'avocado'
+
+        on_cache = get_requirement_on_cache(env_type, env,
+                                            req_type, req)
+        if on_cache:
+            return True
+
+        try:
+            # pylint: disable=E1133
+            proc = await asyncio.create_subprocess_exec(
+                self.PODMAN_BIN, "run", env,
+                "avocado", "magic",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE)
+        except (FileNotFoundError, PermissionError):
+            return False
+
+        await proc.wait()
+        if proc.returncode != 0:
+            return False
+
+        stdout = await proc.stdout.read()
+        result = stdout.rstrip().decode() == MAGIC
+        if result:
+            set_requirement_on_cache(env_type, env,
+                                     req_type, req)
+            return True
+        return False
+
+
+    async def check_requirements(self, task):
+        """Checks if the requirements described within a task are available."""
+        if not task.runnable.requirements:
+            return True
+        for requirements in task.runnable.requirements:
+            for (req_type, req_value) in requirements.items():
+                # This is currently limited to one requirement type as a PoC
+                if req_type == 'core' and req_value == 'avocado':
+                    avocado_capable = await self.check_requirement_core_avocado()
+                    return avocado_capable
+        return True
+
 
     async def spawn_task(self, task):
         entry_point_cmd = '/tmp/avocado-runner'

--- a/avocado/core/spawners/process.py
+++ b/avocado/core/spawners/process.py
@@ -16,6 +16,19 @@ class ProcessSpawner(BaseSpawner):
             return False
         return task.spawn_handle.returncode is None
 
+    async def check_requirements(self, task):
+        """Checks if the requirements described within a task are available."""
+        if not task.runnable.requirements:
+            return True
+
+        for requirements in task.runnable.requirements:
+            for (req_type, req_value) in requirements.items():
+                # The fact that this is avocado code means this
+                # requirement is fulfilled
+                if req_type == 'core' and req_value == 'avocado':
+                    continue
+        return True
+
     async def spawn_task(self, task):
         runner = task.runnable.pick_runner_command()
         args = runner[1:] + ['task-run'] + task.get_command_args()

--- a/avocado/plugins/magic.py
+++ b/avocado/plugins/magic.py
@@ -1,0 +1,33 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2020
+# Author: Cleber Rosa <crosa@redhat.com>
+"""
+Outputs the Avocado magic string
+"""
+
+from avocado.core.magic import MAGIC
+from avocado.core.output import LOG_UI
+from avocado.core.plugin_interfaces import CLICmd
+
+
+class Magic(CLICmd):
+
+    """
+    Outputs the Avocado magic string
+    """
+
+    name = 'magic'
+    description = 'Outputs the Avocado magic string'
+
+    def run(self, config):
+        LOG_UI.info(MAGIC)

--- a/avocado/plugins/nrun.py
+++ b/avocado/plugins/nrun.py
@@ -70,6 +70,14 @@ class NRun(CLICmd):
                                  parser=parser,
                                  long_arg="--spawner")
 
+        help_msg = ("Select a container image for the podman spawner")
+        settings.register_option(section="nrun.spawner.podman",
+                                 key="image",
+                                 default='fedora:latest',
+                                 help_msg=help_msg,
+                                 parser=parser,
+                                 long_arg="--spawner-image")
+
         parser_common_args.add_tag_filter_args(parser)
 
     async def spawn_tasks(self, parallel_tasks):

--- a/selftests/functional/test_magic.py
+++ b/selftests/functional/test_magic.py
@@ -1,0 +1,14 @@
+from unittest import TestCase
+
+from avocado.core import exit_codes, magic
+from avocado.utils import process
+
+
+class Magic(TestCase):
+
+    def test(self):
+        result = process.run('avocado magic', ignore_status=True)
+        self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK,
+                         'Error running "avocado magic"')
+        self.assertEqual(result.stdout_text.rstrip(), magic.MAGIC,
+                         'Magic numbers mismatch')

--- a/selftests/functional/test_requirements.py
+++ b/selftests/functional/test_requirements.py
@@ -1,0 +1,46 @@
+import os
+import tempfile
+import unittest
+
+from avocado.core import requirements
+
+from .. import temp_dir_prefix
+
+ENTRIES = [
+    ('podman',
+     'cd34d13b2980d0a9d438f754b2e94f85443076d0ebe1b0db09a0439f35feca5e',
+     'package',
+     'bash'),
+    ('podman',
+     'cd34d13b2980d0a9d438f754b2e94f85443076d0ebe1b0db09a0439f35feca5e',
+     'core',
+     'avocado'),
+    ('local',
+     'localhost.localdomain',
+     'core',
+     'avocado')
+    ]
+
+
+class Requirement(unittest.TestCase):
+
+    def setUp(self):
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
+
+    def test_entries(self):
+        with unittest.mock.patch('avocado.core.requirements.CACHE_DATABASE_PATH',
+                                 os.path.join(self.tmpdir.name,
+                                              'requirements.sqlite')):
+            for entry in ENTRIES:
+                requirements.set_requirement_on_cache(*entry)
+                self.assertTrue(requirements.get_requirement_on_cache(*entry))
+
+    def test_empty(self):
+        with unittest.mock.patch('avocado.core.requirements.CACHE_DATABASE_PATH',
+                                 os.path.join(self.tmpdir.name,
+                                              'requirements.sqlite')):
+            self.assertFalse(requirements.get_requirement_on_cache(*ENTRIES[0]))
+
+    def tearDown(self):
+        self.tmpdir.cleanup()

--- a/setup.py
+++ b/setup.py
@@ -104,6 +104,7 @@ if __name__ == '__main__':
                   'nlist = avocado.plugins.nlist:List',
                   'assets = avocado.plugins.assets:Assets',
                   'jobs = avocado.plugins.jobs:Jobs',
+                  'magic = avocado.plugins.magic:Magic',
                   ],
               'avocado.plugins.job.prepost': [
                   'jobscripts = avocado.plugins.jobscripts:JobScripts',


### PR DESCRIPTION
The first steps in the proposed N(ext) Runner scheduler has to do with checking the conditions for a task to be executed.  From the document posted to the mailing list:

```
Iteration I
~~~~~~~~~~~

Task #1 is selected on the first iteration, and it's found that:

1. A suitable runner for tasks of kind ``python-unittest`` exists

2. The ``mylib.py`` requirement is already present on the current
   environment

3. The ``gcc`` and ``libc-devel`` packages are not installed in the
   current environment

4. The system is capable of *attempting* to fulfill "package" types of
   requirements.
```

So a check for a suitable runner is needed (1), then all the various requirement types should be checked (2 and 3).  This PR does not attempt to fulfill requirements though (4).  To be able to assert that logic, in the upcoming scheduler, this introduces the basic interfaces and a check for one "core" requirement called "avocado", which is about checking for Avocado's presence in the environment the task is supposed to run.  This means those checks should be done by spanwers.

Note: It's still to be decided if we'll pursue this idea of having special types of "core" requirements (maybe such as "network", or "special_filesystem", etc), but this serves a point right now.

A caching for the requirement information is present, and should behave seamlessly, so a positive check for "core/avocado" would not be repeated for the same environment (say, the same podman image).

---

To test the main functionality on this PR, follow these steps:

1. Create a `/tmp/avocado_test.py` file, containing:

```python
from avocado import Test, fail_on
from avocado.utils import process


class Avocado(Test):

    @fail_on(process.CmdError)
    def test(self):
        """
        :avocado: requirement={"core": "avocado"}
        """
        process.run('avocado --version')
```

2. Run tests locally (in the `process` spawner), that is:

```
$ avocado nrun /tmp/avocado_test.py /bin/true 

Status server started at: 127.0.0.1:8888
1-/tmp/avocado_test.py:Avocado.test spawned and alive
2-/bin/true spawned and alive
Finished spawning tasks
Status server: exiting due to all tasks finished
Tasks result summary: {'pass': 2}
```

3. Now run with the `podman` spawner and the default image:

```
$ avocado nrun --spawner=podman /tmp/avocado_test.py /bin/true 
Status server started at: 127.0.0.1:8888
1-/bin/true is not alive shortly after being spawned
Finished spawning tasks
Status server: exiting due to all tasks finished
Tasks result summary: {'pass': 1}
```

What happened here is that the "core/avocado" requirement check failed and thus one task was not moved forward to be executed.

4. Now fetch a custom image with Avocado (and the `/tmp/avocado_test.py`) installed:

```
$ podman pull quay.io/clebergnu/avocado-devel
```

5. And run with that image:

```
$ avocado nrun --spawner=podman --spawner-image=quay.io/clebergnu/avocado-devel /tmp/avocado_test.py /bin/true 
Status server started at: 127.0.0.1:8888
1-/tmp/avocado_test.py:Avocado.test is not alive shortly after being spawned
2-/bin/true is not alive shortly after being spawned
Finished spawning tasks
Status server: exiting due to all tasks finished
Tasks result summary: {'pass': 2}
```

After step 5, an interesting point is that you can check for the cached requirement information with:

```
$ sqlite3 ~/avocado/data/cache/requirements.sqlite
Enter ".help" for usage hints.
sqlite> select * from requirement;
podman|quay.io/clebergnu/avocado-devel|core|avocado
```