### PR TITLE
Functional selftests: reduce code duplication by introducing TestCaseTmpDir

### DIFF
--- a/optional_plugins/varianter_cit/tests/test_basic.py
+++ b/optional_plugins/varianter_cit/tests/test_basic.py
@@ -1,9 +1,8 @@
 import os
-import tempfile
 import unittest
 
 from avocado.utils import process
-from selftests import AVOCADO, BASEDIR, temp_dir_prefix
+from selftests import AVOCADO, BASEDIR, TestCaseTmpDir
 
 
 class Basic(unittest.TestCase):
@@ -25,14 +24,9 @@ class Basic(unittest.TestCase):
                 self.assertIn(b"green", lines[i])
 
 
-class Run(unittest.TestCase):
-
-    def setUp(self):
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
+class Run(TestCaseTmpDir):
 
     def test(self):
-        os.chdir(BASEDIR)
         params_path = os.path.join(BASEDIR, 'examples',
                                    'varianter_cit', 'test_params.cit')
         test_path = os.path.join(BASEDIR, 'examples',
@@ -73,9 +67,6 @@ class Run(unittest.TestCase):
                       result.stdout)
         self.assertIn(b"PARAMS (key=coating, path=*, default=None) => 'cathodic'",
                       result.stdout)
-
-    def tearDown(self):
-        self.tmpdir.cleanup()
 
 
 if __name__ == '__main__':

--- a/selftests/__init__.py
+++ b/selftests/__init__.py
@@ -2,7 +2,7 @@ import logging
 import os
 import sys
 import tempfile
-import unittest.mock
+import unittest
 
 import pkg_resources
 
@@ -134,3 +134,14 @@ def skipUnlessPathExists(path):
     return unittest.skipUnless(os.path.exists(path),
                                ('File or directory at path "%s" used in test is'
                                 ' not available in the system' % path))
+
+
+class TestCaseTmpDir(unittest.TestCase):
+
+    def setUp(self):
+        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
+        os.chdir(BASEDIR)
+
+    def tearDown(self):
+        self.tmpdir.cleanup()

--- a/selftests/functional/test_export_variables.py
+++ b/selftests/functional/test_export_variables.py
@@ -1,12 +1,11 @@
 import os
-import tempfile
 import unittest
 
 from avocado import VERSION
 from avocado.core import exit_codes
 from avocado.utils import process, script
 
-from .. import AVOCADO, BASEDIR, temp_dir_prefix
+from .. import AVOCADO, BASEDIR, TestCaseTmpDir
 
 SCRIPT_CONTENT = """#!/bin/sh
 echo "Avocado Version: $AVOCADO_VERSION"
@@ -25,11 +24,10 @@ test "$AVOCADO_VERSION" = "{version}" -a \
 """.format(version=VERSION)
 
 
-class EnvironmentVariablesTest(unittest.TestCase):
+class EnvironmentVariablesTest(TestCaseTmpDir):
 
     def setUp(self):
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
+        super(EnvironmentVariablesTest, self).setUp()
         self.script = script.TemporaryScript(
             'version.sh',
             SCRIPT_CONTENT,
@@ -47,8 +45,8 @@ class EnvironmentVariablesTest(unittest.TestCase):
                          (expected_rc, result))
 
     def tearDown(self):
+        super(EnvironmentVariablesTest, self).tearDown()
         self.script.remove()
-        self.tmpdir.cleanup()
 
 
 if __name__ == '__main__':

--- a/selftests/functional/test_getdata.py
+++ b/selftests/functional/test_getdata.py
@@ -1,19 +1,13 @@
 import os
-import tempfile
 import unittest
 
 from avocado.core import exit_codes
 from avocado.utils import process
 
-from .. import AVOCADO, BASEDIR, temp_dir_prefix
+from .. import AVOCADO, BASEDIR, TestCaseTmpDir
 
 
-class GetData(unittest.TestCase):
-
-    def setUp(self):
-        os.chdir(BASEDIR)
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
+class GetData(TestCaseTmpDir):
 
     def test(self):
         test_path = os.path.join(BASEDIR, "selftests", ".data", "get_data.py")
@@ -31,9 +25,6 @@ class GetData(unittest.TestCase):
         cmd_line %= (AVOCADO, self.tmpdir.name, test_variants_path, test_path)
         result = process.run(cmd_line)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
-
-    def tearDown(self):
-        self.tmpdir.cleanup()
 
 
 if __name__ == '__main__':

--- a/selftests/functional/test_interrupt.py
+++ b/selftests/functional/test_interrupt.py
@@ -2,7 +2,6 @@ import os
 import signal
 import stat
 import subprocess
-import tempfile
 import time
 import unittest
 
@@ -10,7 +9,7 @@ import psutil
 
 from avocado.utils import data_factory, process, script, wait
 
-from .. import AVOCADO, BASEDIR, skipOnLevelsInferiorThan, temp_dir_prefix
+from .. import AVOCADO, BASEDIR, TestCaseTmpDir, skipOnLevelsInferiorThan
 
 # What is commonly known as "0755" or "u=rwx,g=rx,o=rx"
 DEFAULT_MODE = (stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR |
@@ -50,7 +49,7 @@ if __name__ == "__main__":
 """
 
 
-class InterruptTest(unittest.TestCase):
+class InterruptTest(TestCaseTmpDir):
 
     @staticmethod
     def has_children(proc):
@@ -95,8 +94,7 @@ class InterruptTest(unittest.TestCase):
         return len(test_processes) == 0
 
     def setUp(self):
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
+        super(InterruptTest, self).setUp()
         self.test_module = None
 
     @skipOnLevelsInferiorThan(2)
@@ -270,9 +268,6 @@ class InterruptTest(unittest.TestCase):
 
         # Make sure the Interrupted test sentence is there
         self.assertIn(b'Terminated\n', proc.stdout.read())
-
-    def tearDown(self):
-        self.tmpdir.cleanup()
 
 
 if __name__ == '__main__':

--- a/selftests/functional/test_job_api_features.py
+++ b/selftests/functional/test_job_api_features.py
@@ -3,20 +3,18 @@ Functional tests for features available through the job API
 """
 
 import os
-import tempfile
 import unittest
 
 from avocado.core import exit_codes
 from avocado.core.job import Job
 
-from .. import temp_dir_prefix
+from .. import TestCaseTmpDir
 
 
-class Test(unittest.TestCase):
+class Test(TestCaseTmpDir):
 
     def setUp(self):
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
+        super(Test, self).setUp()
         self.base_config = {'core.show': ['none'],
                             'run.results_dir': self.tmpdir.name,
                             'run.references': ['examples/tests/passtest.py']}
@@ -36,9 +34,6 @@ class Test(unittest.TestCase):
             result = j.run()
         self.assertEqual(result, exit_codes.AVOCADO_ALL_OK)
         self.assertTrue(os.path.exists(json_results_path))
-
-    def tearDown(self):
-        self.tmpdir.cleanup()
 
 
 if __name__ == '__main__':

--- a/selftests/functional/test_job_timeout.py
+++ b/selftests/functional/test_job_timeout.py
@@ -1,13 +1,12 @@
 import glob
 import os
-import tempfile
 import unittest
 import xml.dom.minidom
 
 from avocado.core import exit_codes
 from avocado.utils import genio, process, script
 
-from .. import AVOCADO, BASEDIR, temp_dir_prefix
+from .. import AVOCADO, BASEDIR, TestCaseTmpDir
 
 SCRIPT_CONTENT = """#!/bin/bash
 sleep 2
@@ -31,9 +30,10 @@ class ParseXMLError(Exception):
     pass
 
 
-class JobTimeOutTest(unittest.TestCase):
+class JobTimeOutTest(TestCaseTmpDir):
 
     def setUp(self):
+        super(JobTimeOutTest, self).setUp()
         self.script = script.TemporaryScript(
             'sleep.sh',
             SCRIPT_CONTENT,
@@ -44,9 +44,6 @@ class JobTimeOutTest(unittest.TestCase):
             PYTHON_CONTENT,
             'avocado_timeout_functional')
         self.py.save()
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
-        os.chdir(BASEDIR)
 
     def run_and_check(self, cmd_line, e_rc, e_ntests, e_nerrors, e_nfailures,
                       e_nskip):
@@ -161,9 +158,9 @@ class JobTimeOutTest(unittest.TestCase):
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
 
     def tearDown(self):
+        super(JobTimeOutTest, self).tearDown()
         self.script.remove()
         self.py.remove()
-        self.tmpdir.cleanup()
 
 
 if __name__ == '__main__':

--- a/selftests/functional/test_journal.py
+++ b/selftests/functional/test_journal.py
@@ -1,21 +1,18 @@
 import json
 import os
 import sqlite3
-import tempfile
 import unittest
 
 from avocado.core import exit_codes
 from avocado.utils import process
 
-from .. import AVOCADO, BASEDIR, temp_dir_prefix
+from .. import AVOCADO, TestCaseTmpDir
 
 
-class JournalPluginTests(unittest.TestCase):
+class JournalPluginTests(TestCaseTmpDir):
 
     def setUp(self):
-        os.chdir(BASEDIR)
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
+        super(JournalPluginTests, self).setUp()
         self.cmd_line = ('%s run --job-results-dir %s --sysinfo=off --json - '
                          '--journal examples/tests/passtest.py'
                          % (AVOCADO, self.tmpdir.name))
@@ -50,7 +47,7 @@ class JournalPluginTests(unittest.TestCase):
 
     def tearDown(self):
         self.db.close()
-        self.tmpdir.cleanup()
+        super(JournalPluginTests, self).setUp()
 
 
 if __name__ == '__main__':

--- a/selftests/functional/test_json_variants.py
+++ b/selftests/functional/test_json_variants.py
@@ -1,20 +1,17 @@
 import json
 import os
-import tempfile
 import unittest
 
 from avocado.utils import process
 
-from .. import AVOCADO, BASEDIR, temp_dir_prefix
+from .. import AVOCADO, TestCaseTmpDir
 
 
-class VariantsDumpLoadTests(unittest.TestCase):
+class VariantsDumpLoadTests(TestCaseTmpDir):
 
     def setUp(self):
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
+        super(VariantsDumpLoadTests, self).setUp()
         self.variants_file = os.path.join(self.tmpdir.name, 'variants.json')
-        os.chdir(BASEDIR)
 
     def test_variants_dump(self):
         cmd_line = ('%s variants --json-variants-dump %s' %
@@ -51,9 +48,6 @@ class VariantsDumpLoadTests(unittest.TestCase):
                          "1-passtest.py:PassTest.test;foo-0ead")
         self.assertEqual(json_result["tests"][1]["id"],
                          "2-passtest.py:PassTest.test;bar-d06d")
-
-    def tearDown(self):
-        self.tmpdir.cleanup()
 
 
 if __name__ == '__main__':

--- a/selftests/functional/test_loader.py
+++ b/selftests/functional/test_loader.py
@@ -3,14 +3,13 @@ import os
 import signal
 import stat
 import subprocess
-import tempfile
 import time
 import unittest
 
 from avocado.core import exit_codes
 from avocado.utils import process, script
 
-from .. import AVOCADO, BASEDIR, skipOnLevelsInferiorThan, temp_dir_prefix
+from .. import AVOCADO, BASEDIR, TestCaseTmpDir, skipOnLevelsInferiorThan
 
 AVOCADO_TEST_OK = """#!/usr/bin/env python
 from avocado import Test
@@ -132,7 +131,7 @@ if __name__ == "__main__":
 """
 
 
-class LoaderTestFunctional(unittest.TestCase):
+class LoaderTestFunctional(TestCaseTmpDir):
 
     MODE_0664 = (stat.S_IRUSR | stat.S_IWUSR |
                  stat.S_IRGRP | stat.S_IWGRP |
@@ -141,11 +140,6 @@ class LoaderTestFunctional(unittest.TestCase):
     MODE_0775 = (stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR |
                  stat.S_IRGRP | stat.S_IWGRP | stat.S_IXGRP |
                  stat.S_IROTH | stat.S_IXOTH)
-
-    def setUp(self):
-        os.chdir(BASEDIR)
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
 
     def _test(self, name, content, exp_str, mode=MODE_0664, count=1):
         test_script = script.TemporaryScript(name, content,
@@ -301,9 +295,6 @@ class LoaderTestFunctional(unittest.TestCase):
                     b"INSTRUMENTED examples/tests/failtest.py:FailTest.test\n"
                     b"SIMPLE       examples/tests/failtest.sh\n")
         self.assertEqual(expected, result.stdout)
-
-    def tearDown(self):
-        self.tmpdir.cleanup()
 
 
 if __name__ == '__main__':

--- a/selftests/functional/test_lv_utils.py
+++ b/selftests/functional/test_lv_utils.py
@@ -7,16 +7,15 @@ avocado.utils.lv_utils selftests
 import glob
 import os
 import sys
-import tempfile
 import time
 import unittest
 
 from avocado.utils import linux_modules, lv_utils, process
 
-from .. import temp_dir_prefix
+from .. import TestCaseTmpDir
 
 
-class LVUtilsTest(unittest.TestCase):
+class LVUtilsTest(TestCaseTmpDir):
 
     """
     Check the LVM related utilities
@@ -29,8 +28,7 @@ class LVUtilsTest(unittest.TestCase):
     @unittest.skipIf(not process.can_sudo(), "This test requires root or "
                      "passwordless sudo configured.")
     def setUp(self):
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
+        super(LVUtilsTest, self).setUp()
         self.vgs = []
 
     def tearDown(self):

--- a/selftests/functional/test_nrunner.py
+++ b/selftests/functional/test_nrunner.py
@@ -1,11 +1,10 @@
 import os
 import sys
-import tempfile
 import unittest
 
 from avocado.utils import process
 
-from .. import AVOCADO, BASEDIR, skipUnlessPathExists, temp_dir_prefix
+from .. import AVOCADO, BASEDIR, TestCaseTmpDir, skipUnlessPathExists
 
 RUNNER = "%s -m avocado.core.nrunner" % sys.executable
 
@@ -146,12 +145,8 @@ class TaskRun(unittest.TestCase):
         self.assertEqual(res.exit_status, 0)
 
 
-class ResolveSerializeRun(unittest.TestCase):
+class ResolveSerializeRun(TestCaseTmpDir):
     @skipUnlessPathExists('/bin/true')
-    def setUp(self):
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
-
     def test(self):
         cmd = "%s nlist --write-recipes-to-directory=%s -- /bin/true"
         cmd %= (AVOCADO, self.tmpdir.name)
@@ -161,6 +156,3 @@ class ResolveSerializeRun(unittest.TestCase):
         cmd %= (RUNNER, os.path.join(self.tmpdir.name, '1.json'))
         res = process.run(cmd)
         self.assertIn(b"'status': 'finished'", res.stdout)
-
-    def tearDown(self):
-        self.tmpdir.cleanup()

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -12,7 +12,7 @@ from avocado.utils import genio
 from avocado.utils import path as utils_path
 from avocado.utils import process, script
 
-from .. import AVOCADO, BASEDIR, temp_dir_prefix
+from .. import AVOCADO, TestCaseTmpDir
 
 # AVOCADO may contain more than a single command, as it can be
 # prefixed by the Python interpreter
@@ -134,12 +134,7 @@ def missing_binary(binary):
         return True
 
 
-class OutputTest(unittest.TestCase):
-
-    def setUp(self):
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
-        os.chdir(BASEDIR)
+class OutputTest(TestCaseTmpDir):
 
     @unittest.skipIf(missing_binary('cc'),
                      "C compiler is required by the underlying doublefree.py test")
@@ -272,12 +267,7 @@ class OutputTest(unittest.TestCase):
         self.tmpdir.cleanup()
 
 
-class OutputPluginTest(unittest.TestCase):
-
-    def setUp(self):
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
-        os.chdir(BASEDIR)
+class OutputPluginTest(TestCaseTmpDir):
 
     def check_output_files(self, debug_log):
         base_dir = os.path.dirname(debug_log)
@@ -559,9 +549,6 @@ class OutputPluginTest(unittest.TestCase):
 
         # Check that plugins do not produce errors
         self.assertNotIn(b"Error running method ", result.stderr)
-
-    def tearDown(self):
-        self.tmpdir.cleanup()
 
 
 if __name__ == '__main__':

--- a/selftests/functional/test_plugin_diff.py
+++ b/selftests/functional/test_plugin_diff.py
@@ -6,14 +6,13 @@ import unittest
 from avocado.core import exit_codes
 from avocado.utils import process, script
 
-from .. import AVOCADO, BASEDIR, temp_dir_prefix
+from .. import AVOCADO, BASEDIR, TestCaseTmpDir
 
 
-class DiffTests(unittest.TestCase):
+class DiffTests(TestCaseTmpDir):
 
     def setUp(self):
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
+        super(DiffTests, self).setUp()
         test = script.make_script(os.path.join(self.tmpdir.name, 'test'), 'exit 0')
         cmd_line = ('%s run %s '
                     '--external-runner /bin/bash '
@@ -23,7 +22,7 @@ class DiffTests(unittest.TestCase):
         self.run_and_check(cmd_line, expected_rc)
         self.jobdir = ''.join(glob.glob(os.path.join(self.tmpdir.name, 'job-*')))
 
-        self.tmpdir2 = tempfile.TemporaryDirectory(prefix=prefix)
+        self.tmpdir2 = tempfile.TemporaryDirectory(prefix=self.tmpdir.name)
         cmd_line = ('%s run %s '
                     '--external-runner /bin/bash '
                     '--job-results-dir %s --sysinfo=off --json -' %
@@ -33,7 +32,6 @@ class DiffTests(unittest.TestCase):
         self.jobdir2 = ''.join(glob.glob(os.path.join(self.tmpdir2.name, 'job-*')))
 
     def run_and_check(self, cmd_line, expected_rc):
-        os.chdir(BASEDIR)
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, expected_rc,
                          "Command %s did not return rc "

--- a/selftests/functional/test_plugin_jobscripts.py
+++ b/selftests/functional/test_plugin_jobscripts.py
@@ -1,11 +1,10 @@
 import os
-import tempfile
 import unittest
 
 from avocado.core import exit_codes
 from avocado.utils import process, script
 
-from .. import AVOCADO, BASEDIR, temp_dir_prefix
+from .. import AVOCADO, TestCaseTmpDir
 
 SCRIPT_PRE_TOUCH = """#!/bin/sh -e
 touch %s"""
@@ -36,16 +35,14 @@ warn_non_existing_dir = False
 warn_non_zero_status = True"""
 
 
-class JobScriptsTest(unittest.TestCase):
+class JobScriptsTest(TestCaseTmpDir):
 
     def setUp(self):
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
+        super(JobScriptsTest, self).setUp()
         self.pre_dir = os.path.join(self.tmpdir.name, 'pre.d')
         os.mkdir(self.pre_dir)
         self.post_dir = os.path.join(self.tmpdir.name, 'post.d')
         os.mkdir(self.post_dir)
-        os.chdir(BASEDIR)
 
     def test_pre_post(self):
         """
@@ -123,9 +120,6 @@ class JobScriptsTest(unittest.TestCase):
         self.assertIn(b'-job scripts has not been found', result.stderr)
         self.assertNotIn('Pre job script "%s" exited with status "1"' % non_zero_script,
                          result.stderr_text)
-
-    def tearDown(self):
-        self.tmpdir.cleanup()
 
 
 if __name__ == '__main__':

--- a/selftests/functional/test_replay_basic.py
+++ b/selftests/functional/test_replay_basic.py
@@ -1,19 +1,17 @@
 import glob
 import os
-import tempfile
 import unittest
 
 from avocado.core import exit_codes
 from avocado.utils import process
 
-from .. import AVOCADO, BASEDIR, temp_dir_prefix
+from .. import AVOCADO, TestCaseTmpDir
 
 
-class ReplayTests(unittest.TestCase):
+class ReplayTests(TestCaseTmpDir):
 
     def setUp(self):
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
+        super(ReplayTests, self).setUp()
         cmd_line = ('%s run passtest.py passtest.py passtest.py passtest.py '
                     '--job-results-dir %s --sysinfo=off --json -'
                     % (AVOCADO, self.tmpdir.name))
@@ -25,7 +23,6 @@ class ReplayTests(unittest.TestCase):
             self.jobid = f.read().strip('\n')
 
     def run_and_check(self, cmd_line, expected_rc):
-        os.chdir(BASEDIR)
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, expected_rc,
                          "Command %s did not return rc "
@@ -168,9 +165,6 @@ class ReplayTests(unittest.TestCase):
         msg = (b"Option --replay-test-status is incompatible with "
                b"test references given on the command line.")
         self.assertIn(msg, result.stderr)
-
-    def tearDown(self):
-        self.tmpdir.cleanup()
 
 
 if __name__ == '__main__':

--- a/selftests/functional/test_replay_external_runner.py
+++ b/selftests/functional/test_replay_external_runner.py
@@ -1,19 +1,17 @@
 import glob
 import os
-import tempfile
 import unittest
 
 from avocado.core import exit_codes
 from avocado.utils import process, script
 
-from .. import AVOCADO, BASEDIR, temp_dir_prefix
+from .. import AVOCADO, TestCaseTmpDir
 
 
-class ReplayExtRunnerTests(unittest.TestCase):
+class ReplayExtRunnerTests(TestCaseTmpDir):
 
     def setUp(self):
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
+        super(ReplayExtRunnerTests, self).setUp()
         test = script.make_script(os.path.join(self.tmpdir.name, 'test'), 'exit 0')
         cmd_line = ('%s run %s '
                     '--external-runner /bin/bash '
@@ -27,7 +25,6 @@ class ReplayExtRunnerTests(unittest.TestCase):
             self.jobid = f.read().strip('\n')
 
     def run_and_check(self, cmd_line, expected_rc):
-        os.chdir(BASEDIR)
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, expected_rc,
                          "Command %s did not return rc "
@@ -44,9 +41,6 @@ class ReplayExtRunnerTests(unittest.TestCase):
         msg = (b"Overriding the replay external-runner with the "
                b"--external-runner value given on the command line.")
         self.assertIn(msg, result.stderr)
-
-    def tearDown(self):
-        self.tmpdir.cleanup()
 
 
 if __name__ == '__main__':

--- a/selftests/functional/test_replay_failfast.py
+++ b/selftests/functional/test_replay_failfast.py
@@ -1,19 +1,17 @@
 import glob
 import os
-import tempfile
 import unittest
 
 from avocado.core import exit_codes
 from avocado.utils import process
 
-from .. import AVOCADO, BASEDIR, temp_dir_prefix
+from .. import AVOCADO, TestCaseTmpDir
 
 
-class ReplayFailfastTests(unittest.TestCase):
+class ReplayFailfastTests(TestCaseTmpDir):
 
     def setUp(self):
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
+        super(ReplayFailfastTests, self).setUp()
         cmd_line = ('%s run passtest.py failtest.py passtest.py '
                     '--failfast on --job-results-dir %s --sysinfo=off --json -'
                     % (AVOCADO, self.tmpdir.name))
@@ -25,7 +23,6 @@ class ReplayFailfastTests(unittest.TestCase):
             self.jobid = f.read().strip('\n')
 
     def run_and_check(self, cmd_line, expected_rc):
-        os.chdir(BASEDIR)
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, expected_rc,
                          "Command %s did not return rc "
@@ -48,9 +45,6 @@ class ReplayFailfastTests(unittest.TestCase):
         msg = (b'Overriding the replay failfast with the --failfast value '
                b'given on the command line.')
         self.assertIn(msg, result.stderr)
-
-    def tearDown(self):
-        self.tmpdir.cleanup()
 
 
 if __name__ == '__main__':

--- a/selftests/functional/test_skiptests.py
+++ b/selftests/functional/test_skiptests.py
@@ -1,12 +1,11 @@
 import json
 import os
-import tempfile
 import unittest
 
 from avocado.core import exit_codes
 from avocado.utils import genio, process, script
 
-from .. import AVOCADO, BASEDIR, temp_dir_prefix
+from .. import AVOCADO, TestCaseTmpDir
 
 AVOCADO_TEST_SKIP_DECORATORS = """
 import avocado
@@ -182,13 +181,10 @@ class AvocadoSkipTests(avocado.Test):
 """
 
 
-class TestSkipDecorators(unittest.TestCase):
+class TestSkipDecorators(TestCaseTmpDir):
 
     def setUp(self):
-        os.chdir(BASEDIR)
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
-
+        super(TestSkipDecorators, self).setUp()
         test_path = os.path.join(self.tmpdir.name, 'test_skip_decorators.py')
         self.test_module = script.Script(test_path,
                                          AVOCADO_TEST_SKIP_DECORATORS)
@@ -229,7 +225,6 @@ class TestSkipDecorators(unittest.TestCase):
         self.bad_teardown.save()
 
     def test_skip_decorators(self):
-        os.chdir(BASEDIR)
         cmd_line = [AVOCADO,
                     'run',
                     '--sysinfo=off',
@@ -249,7 +244,6 @@ class TestSkipDecorators(unittest.TestCase):
         self.assertFalse('teardown executed' in debuglog_contents)
 
     def test_skip_class_decorators(self):
-        os.chdir(BASEDIR)
         cmd_line = [AVOCADO,
                     'run',
                     '--sysinfo=off',
@@ -269,7 +263,6 @@ class TestSkipDecorators(unittest.TestCase):
         self.assertFalse('teardown executed' in debuglog_contents)
 
     def test_skipIf_class_decorators(self):
-        os.chdir(BASEDIR)
         cmd_line = [AVOCADO,
                     'run',
                     '--sysinfo=off',
@@ -285,7 +278,6 @@ class TestSkipDecorators(unittest.TestCase):
         self.assertEqual(json_results['pass'], 3)
 
     def test_skipUnless_class_decorators(self):
-        os.chdir(BASEDIR)
         cmd_line = [AVOCADO,
                     'run',
                     '--sysinfo=off',
@@ -301,7 +293,6 @@ class TestSkipDecorators(unittest.TestCase):
         self.assertEqual(json_results['pass'], 3)
 
     def test_skip_setup(self):
-        os.chdir(BASEDIR)
         cmd_line = [AVOCADO,
                     'run',
                     '--sysinfo=off',
@@ -315,7 +306,6 @@ class TestSkipDecorators(unittest.TestCase):
         self.assertEqual(json_results['skip'], 1)
 
     def test_skip_teardown(self):
-        os.chdir(BASEDIR)
         cmd_line = [AVOCADO,
                     'run',
                     '--sysinfo=off',
@@ -327,9 +317,6 @@ class TestSkipDecorators(unittest.TestCase):
         json_results = json.loads(result.stdout_text)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_TESTS_FAIL)
         self.assertEqual(json_results['errors'], 1)
-
-    def tearDown(self):
-        self.tmpdir.cleanup()
 
 
 if __name__ == '__main__':

--- a/selftests/functional/test_statuses.py
+++ b/selftests/functional/test_statuses.py
@@ -1,11 +1,10 @@
 import json
 import os
-import tempfile
 import unittest
 
 from avocado.utils import genio, process
 
-from .. import AVOCADO, BASEDIR, temp_dir_prefix
+from .. import AVOCADO, TestCaseTmpDir
 
 ALL_MESSAGES = ['setup pre',
                 'setup post',
@@ -124,17 +123,15 @@ EXPECTED_RESULTS = {'SkipSetup.test': ('SKIP',
                     }
 
 
-class TestStatuses(unittest.TestCase):
+class TestStatuses(TestCaseTmpDir):
 
     def setUp(self):
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
+        super(TestStatuses, self).setUp()
         test_file = os.path.abspath(os.path.join(os.path.dirname(__file__),
                                                  os.path.pardir,
                                                  ".data",
                                                  'test_statuses.py'))
 
-        os.chdir(BASEDIR)
         cmd = ('%s run %s --sysinfo=off --job-results-dir %s --json -' %
                (AVOCADO, test_file, self.tmpdir.name))
 
@@ -177,9 +174,6 @@ class TestStatuses(unittest.TestCase):
                              "\nJSON results:\n%s"
                              "\nDebug Log:\n%s" %
                              (msg, klass_method, test, debug_log))
-
-    def tearDown(self):
-        self.tmpdir.cleanup()
 
 
 if __name__ == '__main__':

--- a/selftests/functional/test_streams.py
+++ b/selftests/functional/test_streams.py
@@ -1,19 +1,13 @@
 import os
-import tempfile
 import unittest
 
 from avocado.core import exit_codes
 from avocado.utils import process
 
-from .. import AVOCADO, BASEDIR, temp_dir_prefix
+from .. import AVOCADO, BASEDIR, TestCaseTmpDir
 
 
-class StreamsTest(unittest.TestCase):
-
-    def setUp(self):
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
-        os.chdir(BASEDIR)
+class StreamsTest(TestCaseTmpDir):
 
     def test_app_info_stdout(self):
         """
@@ -117,9 +111,6 @@ class StreamsTest(unittest.TestCase):
         run("avocado.app:20", 1)
         run("avocado.app:wARn", 0)
         run("avocado.app:30", 0)
-
-    def tearDown(self):
-        self.tmpdir.cleanup()
 
 
 if __name__ == '__main__':

--- a/selftests/functional/test_sysinfo.py
+++ b/selftests/functional/test_sysinfo.py
@@ -1,11 +1,10 @@
 import os
-import tempfile
 import unittest
 
 from avocado.core import exit_codes
 from avocado.utils import process, script
 
-from .. import AVOCADO, BASEDIR, skipOnLevelsInferiorThan, temp_dir_prefix
+from .. import AVOCADO, TestCaseTmpDir, skipOnLevelsInferiorThan
 
 COMMANDS_TIMEOUT_CONF = """
 [sysinfo.collect]
@@ -16,14 +15,9 @@ commands = %s
 """
 
 
-class SysInfoTest(unittest.TestCase):
-
-    def setUp(self):
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
+class SysInfoTest(TestCaseTmpDir):
 
     def test_sysinfo_enabled(self):
-        os.chdir(BASEDIR)
         cmd_line = ('%s run --job-results-dir %s --sysinfo=on '
                     'passtest.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line)
@@ -52,7 +46,6 @@ class SysInfoTest(unittest.TestCase):
             self.assertTrue(os.path.exists(sysinfo_subdir), msg)
 
     def test_sysinfo_disabled(self):
-        os.chdir(BASEDIR)
         cmd_line = ('%s run --job-results-dir %s --sysinfo=off passtest.py'
                     % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line)
@@ -74,7 +67,6 @@ class SysInfoTest(unittest.TestCase):
         self.assertFalse(os.path.isdir(sysinfo_dir), msg)
 
     def test_sysinfo_html_output(self):
-        os.chdir(BASEDIR)
         html_output = "{}/output.html".format(self.tmpdir.name)
         cmd_line = ('{} run --html {} --job-results-dir {} --sysinfo=on '
                     'passtest.py'.format(AVOCADO, html_output,
@@ -92,11 +84,7 @@ class SysInfoTest(unittest.TestCase):
         self.assertNotEqual(output.find('root='), -1)
         self.assertNotEqual(output.find('MemAvailable'), -1)
 
-    def tearDown(self):
-        self.tmpdir.cleanup()
-
     def run_sysinfo_interrupted(self, sleep, timeout, exp_duration):
-        os.chdir(BASEDIR)
         commands_path = os.path.join(self.tmpdir.name, "commands")
         script.make_script(commands_path, "sleep %s" % sleep)
         config_path = os.path.join(self.tmpdir.name, "config.conf")

--- a/selftests/functional/test_teststmpdir.py
+++ b/selftests/functional/test_teststmpdir.py
@@ -5,7 +5,7 @@ import unittest
 from avocado.core import exit_codes, test
 from avocado.utils import process, script
 
-from .. import AVOCADO, BASEDIR, temp_dir_prefix
+from .. import AVOCADO, TestCaseTmpDir
 
 INSTRUMENTED_SCRIPT = """import os
 import tempfile
@@ -29,11 +29,10 @@ fi
 """.format(test.COMMON_TMPDIR_NAME)
 
 
-class TestsTmpDirTests(unittest.TestCase):
+class TestsTmpDirTests(TestCaseTmpDir):
 
     def setUp(self):
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
+        super(TestsTmpDirTests, self).setUp()
         self.simple_test = script.TemporaryScript(
             'test_simple.sh',
             SIMPLE_SCRIPT)
@@ -44,7 +43,6 @@ class TestsTmpDirTests(unittest.TestCase):
         self.instrumented_test.save()
 
     def run_and_check(self, cmd_line, expected_rc, env=None):
-        os.chdir(BASEDIR)
         result = process.run(cmd_line, ignore_status=True, env=env)
         self.assertEqual(result.exit_status, expected_rc,
                          "Command %s did not return rc "
@@ -84,9 +82,9 @@ class TestsTmpDirTests(unittest.TestCase):
                              % (len(content), content))
 
     def tearDown(self):
+        super(TestsTmpDirTests, self).tearDown()
         self.instrumented_test.remove()
         self.simple_test.remove()
-        self.tmpdir.cleanup()
 
 
 if __name__ == '__main__':

--- a/selftests/functional/test_unittest_compat.py
+++ b/selftests/functional/test_unittest_compat.py
@@ -1,11 +1,10 @@
 import os
 import sys
-import tempfile
 import unittest
 
 from avocado.utils import process, script
 
-from .. import BASEDIR, temp_dir_prefix
+from .. import BASEDIR, TestCaseTmpDir
 
 UNITTEST_GOOD = """from avocado import Test
 from unittest import main
@@ -56,11 +55,10 @@ if __name__ == '__main__':
 """
 
 
-class UnittestCompat(unittest.TestCase):
+class UnittestCompat(TestCaseTmpDir):
 
     def setUp(self):
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
+        super(UnittestCompat, self).setUp()
         self.original_pypath = os.environ.get('PYTHONPATH')
         if self.original_pypath is not None:
             os.environ['PYTHONPATH'] = '%s:%s' % (
@@ -106,10 +104,10 @@ class UnittestCompat(unittest.TestCase):
         self.assertIn(b'FAILED (errors=1)', result.stderr)
 
     def tearDown(self):
+        super(UnittestCompat, self).tearDown()
         self.unittest_script_error.remove()
         self.unittest_script_fail.remove()
         self.unittest_script_good.remove()
-        self.tmpdir.cleanup()
 
 
 if __name__ == '__main__':

--- a/selftests/functional/test_utils.py
+++ b/selftests/functional/test_utils.py
@@ -3,7 +3,6 @@ import os
 import random
 import stat
 import sys
-import tempfile
 import time
 import unittest
 
@@ -11,7 +10,7 @@ from avocado.utils import process
 from avocado.utils.filelock import FileLock
 from avocado.utils.stacktrace import prepare_exc_info
 
-from .. import skipOnLevelsInferiorThan, temp_dir_prefix
+from .. import TestCaseTmpDir, skipOnLevelsInferiorThan
 
 # What is commonly known as "0775" or "u=rwx,g=rwx,o=rx"
 DEFAULT_MODE = (stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR |
@@ -123,11 +122,10 @@ if __name__ == '__main__':
 """.format(python=sys.executable)
 
 
-class ProcessTest(unittest.TestCase):
+class ProcessTest(TestCaseTmpDir):
 
     def setUp(self):
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
+        super(ProcessTest, self).setUp()
         self.fake_vmstat = os.path.join(self.tmpdir.name, 'vmstat')
         with open(self.fake_vmstat, 'w') as fake_vmstat_obj:
             fake_vmstat_obj.write(FAKE_VMSTAT_CONTENTS)
@@ -182,9 +180,6 @@ class ProcessTest(unittest.TestCase):
         self.assertEqual(result.exit_status, 0, 'result: %s' % result)
         self.assertIn(b'load average', result.stdout)
 
-    def tearDown(self):
-        self.tmpdir.cleanup()
-
 
 def file_lock_action(args):
     path, players, max_individual_timeout = args
@@ -194,11 +189,7 @@ def file_lock_action(args):
         time.sleep(sleeptime)
 
 
-class FileLockTest(unittest.TestCase):
-
-    def setUp(self):
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
+class FileLockTest(TestCaseTmpDir):
 
     @skipOnLevelsInferiorThan(3)
     def test_filelock(self):
@@ -220,9 +211,6 @@ class FileLockTest(unittest.TestCase):
             msg = 'Failed to run FileLock with %s players:\n%s'
             msg %= (players, prepare_exc_info(sys.exc_info()))
             self.fail(msg)
-
-    def tearDown(self):
-        self.tmpdir.cleanup()
 
 
 if __name__ == '__main__':

--- a/selftests/functional/test_utils.py
+++ b/selftests/functional/test_utils.py
@@ -127,13 +127,13 @@ class ProcessTest(unittest.TestCase):
 
     def setUp(self):
         prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.base_logdir = tempfile.TemporaryDirectory(prefix=prefix)
-        self.fake_vmstat = os.path.join(self.base_logdir.name, 'vmstat')
+        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
+        self.fake_vmstat = os.path.join(self.tmpdir.name, 'vmstat')
         with open(self.fake_vmstat, 'w') as fake_vmstat_obj:
             fake_vmstat_obj.write(FAKE_VMSTAT_CONTENTS)
         os.chmod(self.fake_vmstat, DEFAULT_MODE)
 
-        self.fake_uptime = os.path.join(self.base_logdir.name, 'uptime')
+        self.fake_uptime = os.path.join(self.tmpdir.name, 'uptime')
         with open(self.fake_uptime, 'w') as fake_uptime_obj:
             fake_uptime_obj.write(FAKE_UPTIME_CONTENTS)
         os.chmod(self.fake_uptime, DEFAULT_MODE)
@@ -183,7 +183,7 @@ class ProcessTest(unittest.TestCase):
         self.assertIn(b'load average', result.stdout)
 
     def tearDown(self):
-        self.base_logdir.cleanup()
+        self.tmpdir.cleanup()
 
 
 def file_lock_action(args):

--- a/selftests/functional/test_utils_asset.py
+++ b/selftests/functional/test_utils_asset.py
@@ -5,16 +5,15 @@ import unittest
 from avocado.utils import asset
 from avocado.utils.filelock import FileLock
 
-from .. import setup_avocado_loggers, temp_dir_prefix
+from .. import TestCaseTmpDir, setup_avocado_loggers
 
 setup_avocado_loggers()
 
 
-class TestAsset(unittest.TestCase):
+class TestAsset(TestCaseTmpDir):
 
     def setUp(self):
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
+        super(TestAsset, self).setUp()
         self.assetdir = tempfile.mkdtemp(dir=self.tmpdir.name)
         self.assetname = 'foo.tgz'
         self.assethash = '3a033a8938c1af56eeb793669db83bcbd0c17ea5'
@@ -204,9 +203,6 @@ class TestAsset(unittest.TestCase):
                         metadata=expected_metadata)
         with self.assertRaises(OSError):
             a.get_metadata()
-
-    def tearDown(self):
-        self.tmpdir.cleanup()
 
 
 if __name__ == "__main__":

--- a/selftests/functional/test_wrapper.py
+++ b/selftests/functional/test_wrapper.py
@@ -6,7 +6,7 @@ from avocado.core import exit_codes
 from avocado.utils import path as utils_path
 from avocado.utils import process, script
 
-from .. import AVOCADO, BASEDIR, temp_dir_prefix
+from .. import AVOCADO, BASEDIR, TestCaseTmpDir
 
 SCRIPT_CONTENT = """#!/bin/bash
 touch %s
@@ -26,11 +26,10 @@ def missing_binary(binary):
         return True
 
 
-class WrapperTest(unittest.TestCase):
+class WrapperTest(TestCaseTmpDir):
 
     def setUp(self):
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
+        super(WrapperTest, self).setUp()
         self.tmpfile = tempfile.mktemp()
         self.script = script.TemporaryScript(
             'success.sh',
@@ -96,13 +95,13 @@ class WrapperTest(unittest.TestCase):
                         (self.tmpfile, cmd_line, result.stdout))
 
     def tearDown(self):
+        super(WrapperTest, self).tearDown()
         self.script.remove()
         self.dummy.remove()
         try:
             os.remove(self.tmpfile)
         except OSError:
             pass
-        self.tmpdir.cleanup()
 
 
 if __name__ == '__main__':

--- a/selftests/unit/test_references.py
+++ b/selftests/unit/test_references.py
@@ -1,4 +1,4 @@
-import unittest
+import unittest.mock
 
 from avocado.core import references
 


### PR DESCRIPTION
Which is a simple class that contains setUp/tearDown methods that create and cleanup a temporary directory for the test's usage.
    
It also changes into Avocado's base directory to allow for consistent execution, which is a common pattern and ensures these tests are more consistent among themselves.