### PR TITLE
lv_utils: Automatic yes for vgcreate command

### DIFF
--- a/avocado/utils/lv_utils.py
+++ b/avocado/utils/lv_utils.py
@@ -327,15 +327,14 @@ def vg_create(vg_name, pv_list, force=False):
     """
     if vg_check(vg_name):
         raise LVException("Volume group '%s' already exist" % vg_name)
-    if force:
-        cmd = "vgcreate -f"
-    else:
-        cmd = "vgcreate"
+    cmd = "vgcreate"
     if isinstance(pv_list, list):
         pv_list = " ".join(pv_list)
     else:
         pv_list = str(pv_list)
     cmd += " %s %s" % (vg_name, pv_list)
+    if force:
+        cmd += "%s -f -y" % cmd
     process.run(cmd, sudo=True)
 
 


### PR DESCRIPTION
Providing automatic yes for vgcreate command, since vg creation
can fail if, say, a filesystem is already present.

Reported-by: Wen Xiong <wenxiong@linux.vnet.ibm.com>
Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>