### PR TITLE
Resolver: show similar output for various file checks

### DIFF
--- a/avocado/core/resolver.py
+++ b/avocado/core/resolver.py
@@ -126,7 +126,7 @@ def check_file(path, reference, suffix='.py',
             return ReferenceResolution(
                 reference,
                 ReferenceResolutionResult.NOTFOUND,
-                info='File path "%s" does not end with "%s"' % (path, suffix))
+                info='File "%s" does not end with "%s"' % (path, suffix))
 
     if not type_check(path):
         return ReferenceResolution(


### PR DESCRIPTION
Currently, when using "avocado nlist -V", which means using the resolver
in verbose mode, a user will see messages such as:

```
  ...
  avocado-instrumented  /my/file   File path "/my/file" does not end with ".py"
  python-unittest       /my/file   File path "/my/file" does not end with ".py"
  exec-test             /my/file   File "/my/file" does not exist or is not executable
  tap                   /my/file   File "/my/file" does not exist or is not executable
  ...
```

With basically unaligns the information.  Given that "/my/file" is clearly
a file path, an not the file content, let's ommit that word, resulting in:

```
  ...
  avocado-instrumented  /my/file   File "/my/file" does not end with ".py"
  python-unittest       /my/file   File "/my/file" does not end with ".py"
  exec-test             /my/file   File "/my/file" does not exist or is not executable
  tap                   /my/file   File "/my/file" does not exist or is not executable
  ...
```

Signed-off-by: Cleber Rosa <crosa@redhat.com>