### PR TITLE
Documentation wannings fix

### DIFF
--- a/avocado/utils/service.py
+++ b/avocado/utils/service.py
@@ -677,7 +677,7 @@ def service_manager(run=process.run):
 
     Example of use:
 
-    .. code-block::
+    .. code-block:: python
 
       # Get the system service manager
       service_manager = ServiceManager()
@@ -753,7 +753,7 @@ def specific_service_manager(service_name, run=process.run):
 
     Example of use:
 
-    .. code-block::
+    .. code-block:: python
 
       # Get the specific service manager for sshd
       sshd = SpecificServiceManager("sshd")

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -48,26 +48,31 @@ generate_reference()
 # Second level module name (after avocado), Module description,
 # Output directory, List of directory to exclude from API  generation,
 # list of (duplicated) generated reST files to remove (and avoid warnings)
+# References tag
 API_SECTIONS = {"Test APIs": (None,
                               genio.read_file("api/headers/test"),
                               "test",
                               ("core", "utils", "plugins"),
-                              ("modules.rst", )),
+                              ("modules.rst", ),
+                              ".. _tests-api-reference:\n"),
                 "Utilities APIs": ("utils",
                                    genio.read_file("api/headers/utils"),
                                    "utils",
                                    ("core", "plugins"),
-                                   ("avocado.rst", "modules.rst")),
+                                   ("avocado.rst", "modules.rst"),
+                                   ""),
                 "Internal (Core) APIs": ("core",
                                          genio.read_file("api/headers/core"),
                                          "core",
                                          ("utils", "plugins"),
-                                         ("avocado.rst", "modules.rst")),
+                                         ("avocado.rst", "modules.rst"),
+                                         ""),
                 "Extension (plugin) APIs": ("plugins",
                                             genio.read_file("api/headers/plugins"),
                                             "plugins",
                                             ("core", "utils"),
-                                            ("avocado.rst", "modules.rst"))}
+                                            ("avocado.rst", "modules.rst"),
+                                            "")}
 
 # clean up all previous rst files. RTD is known to keep them from previous runs
 process.run("find %s -name '*.rst' -delete" % BASE_API_OUTPUT_DIR)
@@ -106,7 +111,7 @@ for (section, params) in API_SECTIONS.items():
         with open(main_rst) as main_rst_file:
             main_rst_content = main_rst_file.readlines()
 
-    new_main_rst_content = [section, "=" * len(section), "",
+    new_main_rst_content = [params[5],section, "=" * len(section), "",
                             params[1], ""]
     with open(main_rst, "w") as new_main_rst:
         new_main_rst.write("\n".join(new_main_rst_content))

--- a/docs/source/guides/user/chapters/configuring.rst
+++ b/docs/source/guides/user/chapters/configuring.rst
@@ -62,7 +62,7 @@ Besides the configuration files, the most used features can also be configured
 by command-line arguments.  For instance, regardless what you have on your
 configuration files, you can disable sysinfo logging by running:
 
-.. code-block::
+.. code-block:: shell
 
    $ avocado run --sysinfo off /bin/true
 

--- a/docs/source/guides/user/chapters/installing.rst
+++ b/docs/source/guides/user/chapters/installing.rst
@@ -44,6 +44,8 @@ the "venv" itself::
 Installing from packages
 ------------------------
 
+.. _fedora-from-avocados-own-repo:
+
 Fedora
 ~~~~~~
 


### PR DESCRIPTION
When compiling our current documentation with make html we had some warnings #4017. This PR fixing them.

The problem was:
```
avocado/avocado/utils/service.py:docstring of avocado.utils.service.ServiceManager:6: WARNING: Error in "code-block" directive:
1 argument(s) required, 0 supplied.
avocado/avocado/utils/service.py:docstring of avocado.utils.service.SpecificServiceManager:5: WARNING: Error in "code-block" directive:
1 argument(s) required, 0 supplied.
avocado/docs/source/guides/contributor/rfcs/lts.rst:176: WARNING: undefined label: fedora-from-avocados-own-repo (if the link has no caption the label must precede a section header)
avocado/docs/source/guides/writer/chapters/writing.rst:1658: WARNING: undefined label: tests-api-reference (if the link has no caption the label must precede a section header)
```