### PR TITLE
Warning of loader and external runner incompatibility

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -23,6 +23,7 @@ import os
 import re
 import shlex
 import sys
+import warnings
 from enum import Enum
 
 from ..utils import stacktrace
@@ -123,6 +124,10 @@ class TestLoaderProxy:
         if external_runner:
             self.register_plugin(ExternalLoader)
             key = "{}.loaders".format(subcommand)
+            if set(config[key]) != {'file', '@DEFAULT'}:
+                warnings.warn("The loadres and external-runner are incompatible."
+                              "The values in loadres will be ignored.",
+                              RuntimeWarning)
             config[key] = ["external:{}".format(external_runner)]
         else:
             # Add (default) file loader if not already registered


### PR DESCRIPTION
avocado run command line can accept options --loaders and --external-runner in
one time. But when we use external runner there is a specific loader and we
don't use values from option --loaders. When user uses both these options, we
have to warn him about this behaviour.

Reference: #3899
Signed-off-by: Jan Richter <jarichte@redhat.com>