### PR TITLE
DictVariants Plugin: cast value to string before join

### DIFF
--- a/avocado/plugins/dict_variants.py
+++ b/avocado/plugins/dict_variants.py
@@ -39,7 +39,7 @@ class DictVariants(Varianter):
 
         variant_ids = []
         for variant in self.variants:
-            variant_ids.append("-".join([variant.get(key)
+            variant_ids.append("-".join([str(variant.get(key))
                                          for key in self.headers]))
 
         for vid, variant in zip(variant_ids, self.variants):


### PR DESCRIPTION
This adds support to values different than strings, like True or False, to be used in the dictionary.

Signed-off-by: Willian Rampazzo <willianr@redhat.com>