### PR TITLE
SRPM builds: enforce reproducible short commit IDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ RELEASE_COMMIT=$(shell git log --pretty=format:'%H' -n 1 $(VERSION))
 RELEASE_SHORT_COMMIT=$(shell git rev-parse --short=9 $(VERSION))
 COMMIT=$(shell git log --pretty=format:'%H' -n 1)
 COMMIT_DATE=$(shell git log --pretty='format:%cd' --date='format:%Y%m%d' -n 1)
-SHORT_COMMIT=$(shell git log --pretty=format:'%h' -n 1)
+SHORT_COMMIT=$(shell git rev-parse --short=9 HEAD)
 MOCK_CONFIG=default
 ARCHIVE_BASE_NAME=avocado
 PYTHON_MODULE_NAME=avocado-framework


### PR DESCRIPTION
The COPR builds are currently broken, because the git produces a short
commit id with a different number of digits then expected.

We'd solved this problem for the release buildson 335448380, but
missed the regular builds.

Signed-off-by: Cleber Rosa <crosa@redhat.com>