### PR TITLE
SRPM builds: enforce reproducible short commit IDs on COPR

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,7 +1,7 @@
 pkg_install := $(shell dnf -y install git rpm-build)
 commit := $(shell git log --pretty=format:'%H' -n 1)
 commit_date := $(shell git log --pretty='format:%cd' --date='format:%Y%m%d' -n 1)
-short_commit := $(shell git log --pretty=format:'%h' -n 1)
+short_commit := $(shell git rev-parse --short=9 HEAD)
 
 srpm:
 	if test ! -d SOURCES; then mkdir SOURCES; fi


### PR DESCRIPTION
On commit 26b4ed895 the generation of the short commit IDs was fixed, but I
completely forgot that COPR makes use of a different Makefile.

Hopefully this third attempt will be the lucky one.

In the future, it'd be nice if both Makefile and .copr/Makefile rules
could be shared/combined.

Signed-off-by: Cleber Rosa <crosa@redhat.com>