### PR TITLE
Job Replay: simplify variants usage

### DIFF
--- a/avocado/core/jobdata.py
+++ b/avocado/core/jobdata.py
@@ -112,6 +112,13 @@ def retrieve_references(resultsdir):
         return ast.literal_eval(references_file.read())
 
 
+def get_variants_path(resultsdir):
+    """
+    Retrieves the variants path from the results directory.
+    """
+    return _retrieve(resultsdir, VARIANTS_FILENAME)
+
+
 def retrieve_variants(resultsdir):
     """
     Retrieves the job variants object from the results directory.

--- a/avocado/core/suite.py
+++ b/avocado/core/suite.py
@@ -123,8 +123,7 @@ class TestSuite:
     @property
     def variants(self):
         if self._variants is None:
-            # TODO: We need to register this with register_option()
-            variants = self.config.get('avocado_variants', Varianter())
+            variants = Varianter()
             if not variants.is_parsed():
                 try:
                     variants.parse(self.config)

--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -268,7 +268,7 @@ class Replay(CLI):
                 LOG_UI.error('Source job variants data not found. Aborting.')
                 sys.exit(exit_codes.AVOCADO_FAIL)
             else:
-                LOG_UI.warning("Using src job Mux data only, use "
+                LOG_UI.warning("Using src job variants data only, use "
                                "`--replay-ignore variants` to override "
                                "them.")
                 config["avocado_variants"] = variants

--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -263,7 +263,7 @@ class Replay(CLI):
             LOG_UI.warn("Ignoring variants from source job with "
                         "--replay-ignore.")
         else:
-            variants = jobdata.retrieve_variants(resultsdir)
+            variants = jobdata.get_variants_path(resultsdir)
             if variants is None:
                 LOG_UI.error('Source job variants data not found. Aborting.')
                 sys.exit(exit_codes.AVOCADO_FAIL)
@@ -271,7 +271,7 @@ class Replay(CLI):
                 LOG_UI.warning("Using src job variants data only, use "
                                "`--replay-ignore variants` to override "
                                "them.")
-                config["avocado_variants"] = variants
+                config["json_variants_load"] = variants
 
         # Extend "replay_test_status" of "INTERRUPTED" when --replay-resume
         # supplied.

--- a/optional_plugins/varianter_yaml_to_mux/tests/test_functional.py
+++ b/optional_plugins/varianter_yaml_to_mux/tests/test_functional.py
@@ -182,7 +182,8 @@ class ReplayTests(unittest.TestCase):
         ignored)
         """
         cmdline = ("%s run --replay %s --job-results-dir %s "
-                   "--sysinfo=off -m selftests/.data/mux-selftest.yaml"
+                   "--sysinfo=off -m optional_plugins/varianter_yaml_to_mux"
+                   "/tests/.data/mux-selftest.yaml"
                    % (AVOCADO, self.jobid, self.tmpdir.name))
         self.run_and_check(cmdline, exit_codes.AVOCADO_ALL_OK)
 


### PR DESCRIPTION
By resorting to using the configuration file in the job configuration, instead of the actual `Varianter()` instance.