### PR TITLE
Varianter: remove registration of avocado_variants in the argparse

### DIFF
--- a/avocado/core/parser.py
+++ b/avocado/core/parser.py
@@ -20,7 +20,7 @@ import argparse
 from configparser import ConfigParser, NoOptionError
 from glob import glob
 
-from . import exit_codes, settings, varianter
+from . import exit_codes, settings
 from .future.settings import ConfigFileNotFound, SettingsError
 from .future.settings import settings as future_settings
 from .nrunner import Runnable
@@ -146,10 +146,6 @@ class Parser:
         # constructing the sub parsers, but it is possible to set that
         # option afterwards.
         self.subcommands.required = True
-
-        # Allow overriding default params by plugins
-        variants = varianter.Varianter(getattr(self.args, "variants.debug", False))
-        self.args.avocado_variants = variants
 
     def finish(self):
         """

--- a/avocado/plugins/variants.py
+++ b/avocado/plugins/variants.py
@@ -20,6 +20,7 @@ from avocado.core import exit_codes
 from avocado.core.future.settings import settings as future_settings
 from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLICmd
+from avocado.core.varianter import Varianter
 
 _VERBOSITY_LEVELS = {"none": 0, "brief": 1, "normal": 2, "verbose": 3,
                      "full": 4, "max": 99}
@@ -137,7 +138,7 @@ class Variants(CLICmd):
         if err:
             LOG_UI.error(err)
             sys.exit(exit_codes.AVOCADO_FAIL)
-        varianter = config.get('avocado_variants')
+        varianter = Varianter()
         try:
             varianter.parse(config)
         except (IOError, ValueError) as details:
@@ -157,19 +158,19 @@ class Variants(CLICmd):
                 variants += 2
 
         json_variants_dump = config.get('variants.json_variants_dump')
-        # Export the serialized avocado_variants
+        # Export the serialized variants
         if json_variants_dump is not None:
             try:
                 with open(json_variants_dump, 'w') as variants_file:
-                    json.dump(config.get('avocado_variants').dump(), variants_file)
+                    json.dump(varianter.dump(), variants_file)
             except IOError:
                 LOG_UI.error("Cannot write %s", json_variants_dump)
                 sys.exit(exit_codes.AVOCADO_FAIL)
 
         # Produce the output
-        lines = config.get('avocado_variants').to_str(summary=summary,
-                                                      variants=variants,
-                                                      use_utf8=use_utf8)
+        lines = varianter.to_str(summary=summary,
+                                 variants=variants,
+                                 use_utf8=use_utf8)
         for line in lines.splitlines():
             LOG_UI.debug(line)
 


### PR DESCRIPTION
And its usage in the result configuration dictionary.

There are no really worthy justification of this.  Last minor one was
to allow plugins to handle the ancient default_params, which is no
longer used as early as 69.0LTS and should be removed following this.

Fixes: https://github.com/avocado-framework/avocado/issues/3981
Signed-off-by: Cleber Rosa <crosa@redhat.com>