### PR TITLE
Safeloader: support relative imports in the PythonModule class

### DIFF
--- a/avocado/core/safeloader.py
+++ b/avocado/core/safeloader.py
@@ -111,6 +111,12 @@ class PythonModule:
         if getattr(statement, 'module', None) is not None:
             module_path = statement.module.replace('.', os.path.sep)
             path = os.path.join(path, module_path)
+        else:
+            # Module has no name, its path is relative to the directory
+            # structure
+            level = getattr(statement, 'level', 0)
+            for _ in range(level - 1):
+                path = os.path.dirname(path)
         for name in statement.names:
             path = os.path.join(path, name.name.replace('.', os.path.sep))
             final_name = self._get_name_from_alias_statement(name)

--- a/avocado/core/safeloader.py
+++ b/avocado/core/safeloader.py
@@ -113,10 +113,13 @@ class PythonModule:
             path = os.path.join(path, module_path)
         for name in statement.names:
             path = os.path.join(path, name.name.replace('.', os.path.sep))
-            if name.asname is None:
-                self.imported_objects[name.name] = path
-            else:
-                self.imported_objects[name.asname] = path
+            final_name = self._get_name_from_alias_statement(name)
+            self.imported_objects[final_name] = path
+
+    @staticmethod
+    def _get_name_from_alias_statement(alias):
+        """Returns the aliased name or original one."""
+        return alias.asname if alias.asname else alias.name
 
     def _handle_import_from(self, statement):
         self.add_imported_object(statement)

--- a/selftests/unit/test_safeloader.py
+++ b/selftests/unit/test_safeloader.py
@@ -317,7 +317,8 @@ class FindClassAndMethods(UnlimitedDiff):
                                  'test_is_not_avocado_test',
                                  'test_is_not_avocado_tests'],
             'PythonModule': ['test_is_avocado_test',
-                             'test_import_of_all_module_level'],
+                             'test_import_of_all_module_level',
+                             'test_import_relative'],
             'ModuleImportedAs': ['_test',
                                  'test_foo',
                                  'test_foo_as_bar',
@@ -365,7 +366,8 @@ class FindClassAndMethods(UnlimitedDiff):
                                  'test_is_not_avocado_test',
                                  'test_is_not_avocado_tests'],
             'PythonModule': ['test_is_avocado_test',
-                             'test_import_of_all_module_level'],
+                             'test_import_of_all_module_level',
+                             'test_import_relative'],
             'ModuleImportedAs': ['test_foo',
                                  'test_foo_as_bar',
                                  'test_foo_as_foo',
@@ -558,6 +560,14 @@ class PythonModule(unittest.TestCase):
         for _ in module.iter_classes():
             pass
         self.assertIn('unittest', module.mod_imports)
+
+    def test_import_relative(self):
+        """Tests if relative imports are tracked on the module object."""
+        path = os.path.join(BASEDIR, 'selftests', 'functional', 'test_basic.py')
+        module = safeloader.PythonModule(path)
+        for _ in module.iter_classes():
+            pass
+        self.assertIn('TestCaseTmpDir', module.imported_objects)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The safeloader is failing to keep track of relative imports, because a relative location has no explicit module name within the code.
    
To test that, we resort to parsing a functional test file that does a relative import for the TestCaseTmpDir class.

Fixes: https://github.com/avocado-framework/avocado/issues/4036