### PR TITLE
Variants: drop update defaults and default parameters

### DIFF
--- a/avocado/core/jobdata.py
+++ b/avocado/core/jobdata.py
@@ -21,14 +21,13 @@ import json
 import os
 
 from ..utils.path import init_dir
-from . import varianter
 from .future.settings import settings
 from .output import LOG_JOB, LOG_UI
+from .varianter import VARIANTS_FILENAME
 
 JOB_DATA_DIR = 'jobdata'
 CONFIG_FILENAME = 'config'
 TEST_REFERENCES_FILENAME = 'test_references'
-VARIANTS_FILENAME = 'variants.json'
 PWD_FILENAME = 'pwd'
 JOB_CONFIG_FILENAME = 'args.json'
 CMDLINE_FILENAME = 'cmdline'
@@ -117,16 +116,6 @@ def get_variants_path(resultsdir):
     Retrieves the variants path from the results directory.
     """
     return _retrieve(resultsdir, VARIANTS_FILENAME)
-
-
-def retrieve_variants(resultsdir):
-    """
-    Retrieves the job variants object from the results directory.
-    """
-    recorded_variants = _retrieve(resultsdir, VARIANTS_FILENAME)
-    if recorded_variants:
-        with open(recorded_variants, 'r') as variants_file:
-            return varianter.Varianter(state=json.load(variants_file))
 
 
 def retrieve_job_config(resultsdir):

--- a/avocado/core/plugin_interfaces.py
+++ b/avocado/core/plugin_interfaces.py
@@ -257,14 +257,6 @@ class Varianter(Plugin):
         """
 
     @abc.abstractmethod
-    def update_defaults(self, defaults):
-        """
-        Add default values
-
-        :note: Those values should not be part of the variant_id
-        """
-
-    @abc.abstractmethod
     def to_str(self, summary, variants, **kwargs):
         """
         Return human readable representation

--- a/avocado/core/varianter.py
+++ b/avocado/core/varianter.py
@@ -265,15 +265,7 @@ class Varianter:
         :rtype: str
         """
         if self._no_variants == 0:  # No variants, only defaults:
-            out = []
-            if summary:
-                out.append("No variants available, using defaults only")
-            if variants:
-                variant = next(self.itertests())
-                variant["variant_id"] = ""  # Don't confuse people with None
-                out.append("\n".join(variant_to_str(variant, variants - 1,
-                                                    kwargs, self.debug)))
-            return "\n\n".join(out)
+            return ""
 
         out = [item for item in self._variant_plugins.map_method_with_return("to_str",
                                                                              summary,

--- a/avocado/core/varianter.py
+++ b/avocado/core/varianter.py
@@ -223,7 +223,6 @@ class Varianter:
         self._default_params = default_params
         self.default_params.clear()
         self._variant_plugins.map_method_with_return("initialize", config)
-        self._variant_plugins.map_method_with_return_copy("update_defaults", self._default_params)
         self._no_variants = sum(self._variant_plugins.map_method_with_return("__len__"))
 
     def is_parsed(self):

--- a/avocado/core/varianter.py
+++ b/avocado/core/varianter.py
@@ -20,9 +20,13 @@ Base classes for implementing the varianter interface
 """
 
 import hashlib
+import json
+import os
 
 from ..utils import astring
 from . import dispatcher, output, tree
+
+VARIANTS_FILENAME = 'variants.json'
 
 
 def is_empty_variant(variant):
@@ -361,6 +365,18 @@ class Varianter:
             yield {"variant": self._default_params.get_leaves(),
                    "variant_id": None,
                    "paths": ["/run/*"]}
+
+    @classmethod
+    def from_resultsdir(cls, resultsdir):
+        """
+        Retrieves the job variants object from the results directory.
+        """
+        path = os.path.join(resultsdir, 'jobdata', VARIANTS_FILENAME)
+        if not os.path.exists(path):
+            return None
+
+        with open(path, 'r') as variants_file:
+            return cls(state=json.load(variants_file))
 
     def __len__(self):
         return self._no_variants

--- a/avocado/plugins/dict_variants.py
+++ b/avocado/plugins/dict_variants.py
@@ -50,9 +50,6 @@ class DictVariants(Varianter):
     def __len__(self):
         return sum(1 for _ in self.variants) if self.variants else 0
 
-    def update_defaults(self, defaults):
-        pass
-
     def to_str(self, summary, variants, **kwargs):
         """
         Return human readable representation

--- a/avocado/plugins/diff.py
+++ b/avocado/plugins/diff.py
@@ -30,6 +30,7 @@ from avocado.core import data_dir, exit_codes, jobdata, output
 from avocado.core.future.settings import settings
 from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLICmd
+from avocado.core.varianter import Varianter
 
 
 class Diff(CLICmd):
@@ -387,7 +388,7 @@ class Diff(CLICmd):
     @staticmethod
     def _get_variants(resultsdir):
         results = []
-        variants = jobdata.retrieve_variants(resultsdir)
+        variants = Varianter.from_resultsdir(resultsdir)
         if variants is not None:
             results.extend(variants.to_str(variants=2).splitlines())
         else:

--- a/avocado/plugins/json_variants.py
+++ b/avocado/plugins/json_variants.py
@@ -109,9 +109,6 @@ class JsonVariants(Varianter):
 
         return len(self.variants)
 
-    def update_defaults(self, defaults):
-        pass
-
     def to_str(self, summary, variants, **kwargs):
         """
         Return human readable representation

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -24,8 +24,24 @@ from avocado.core import exit_codes, job, loader, output, parser_common_args
 from avocado.core.dispatcher import JobPrePostDispatcher
 from avocado.core.future.settings import settings
 from avocado.core.output import LOG_UI
-from avocado.core.plugin_interfaces import CLICmd
+from avocado.core.plugin_interfaces import CLICmd, Init
 from avocado.utils import process
+
+
+class RunInit(Init):
+
+    name = 'run'
+    description = 'Initializes the run options'
+
+    def initialize(self):
+        help_msg = ('Defines the order of iterating through test suite '
+                    'and test variants')
+        settings.register_option(section='run',
+                                 key='execution_order',
+                                 choices=('tests-per-variant',
+                                          'variants-per-test'),
+                                 default='variants-per-test',
+                                 help_msg=help_msg)
 
 
 class Run(CLICmd):
@@ -188,16 +204,9 @@ class Run(CLICmd):
                                          short_arg='-S',
                                          long_arg='--sysinfo')
 
-        help_msg = ('Defines the order of iterating through test suite '
-                    'and test variants')
-        settings.register_option(section='run',
-                                 key='execution_order',
-                                 choices=('tests-per-variant',
-                                          'variants-per-test'),
-                                 default=None,
-                                 help_msg=help_msg,
-                                 parser=parser,
-                                 long_arg='--execution-order')
+        settings.add_argparser_to_option('run.execution_order',
+                                         parser=parser,
+                                         long_arg='--execution-order')
 
         parser.output = parser.add_argument_group('output and result format')
 

--- a/avocado/plugins/runner.py
+++ b/avocado/plugins/runner.py
@@ -48,10 +48,6 @@ class TestRunner(Runner):
 
     DEFAULT_TIMEOUT = 86400
 
-    #: Mode in which this runner should iterate through tests and variants.
-    #: The allowed values are "variants-per-test" or "tests-per-variant"
-    DEFAULT_EXECUTION_ORDER = "variants-per-test"
-
     def __init__(self):
         """
         Creates an instance of TestRunner class.
@@ -365,8 +361,6 @@ class TestRunner(Runner):
             for test_factory in test_suite.tests:
                 test_factory[1]["base_logdir"] = job.logdir
                 test_factory[1]["job"] = job
-            if execution_order is None:
-                execution_order = self.DEFAULT_EXECUTION_ORDER
             for test_factory, variant in self._iter_suite(job,
                                                           test_suite,
                                                           execution_order):

--- a/docs/source/guides/writer/chapters/parameters.rst
+++ b/docs/source/guides/writer/chapters/parameters.rst
@@ -40,16 +40,12 @@ Overall picture of how the params handling works is:
    +-------------------+ provide variants +-----------------------+
    |                   |<-----------------|                       |
    | Varianter API     |                  | Varianter plugins API |
-   |                   |----------------->|                       |
-   +-------------------+  update defaults +-----------------------+
-             ^                                ^
-             |                                |
-             |  // default params injected    |  // All plugins are invoked
-   +--------------------------------------+   |  // in turns
-   | +--------------+ +-----------------+ |   |
-   | | avocado-virt | | other providers | |   |
-   | +--------------+ +-----------------+ |   |
-   +--------------------------------------+   |
+   |                   |                  |                       |
+   +-------------------+                  +-----------------------+
+                                              ^
+                                              |
+                                              |  // All plugins are invoked
+                                              |  // in turns
                                               |
                  +----------------------------+-----+
                  |                                  |

--- a/docs/source/guides/writer/chapters/parameters.rst
+++ b/docs/source/guides/writer/chapters/parameters.rst
@@ -205,8 +205,6 @@ Example workflow of `avocado run passtest.py -m example.yaml` is::
      |
      + parser.finish -> Varianter.__init__  // dispatcher initializes all plugins
      |
-     + $PLUGIN -> args.default_avocado_params.add_default_param  // could be used to insert default values
-     |
      + job.run_tests -> Varianter.is_parsed
      |
      + job.run_tests -> Varianter.parse

--- a/docs/source/guides/writer/chapters/writing.rst
+++ b/docs/source/guides/writer/chapters/writing.rst
@@ -519,7 +519,7 @@ an example that does that::
         """
         def setUp(self):
             """
-            Set default params and build the synctest suite.
+            Set attributes from params and build the synctest suite.
             """
             sync_tarball = self.params.get('sync_tarball',
                                            default='synctest.tar.bz2')

--- a/docs/source/plugins/optional/multiplexer.rst
+++ b/docs/source/plugins/optional/multiplexer.rst
@@ -177,9 +177,8 @@ Where:
   of the variant/value/environment as the value for listing purposes
   and is __NOT__ intended for test execution.
 
-This method must be called before the :ref:`varianter`'s second stage
-(the latest opportunity is during ``self.update_defaults``). The
-`MuxPlugin`_'s code will take care of the rest.
+This method must be called before the :ref:`varianter`'s second
+stage. The `MuxPlugin`_'s code will take care of the rest.
 
 MuxTree
 ~~~~~~~

--- a/optional_plugins/varianter_cit/avocado_varianter_cit/__init__.py
+++ b/optional_plugins/varianter_cit/avocado_varianter_cit/__init__.py
@@ -136,9 +136,6 @@ class VarianterCit(Varianter):
     def __len__(self):
         return sum(1 for _ in self.variants) if self.variants else 0
 
-    def update_defaults(self, defaults):
-        pass
-
     def to_str(self, summary, variants, **kwargs):
         """
         Return human readable representation

--- a/optional_plugins/varianter_pict/avocado_varianter_pict/__init__.py
+++ b/optional_plugins/varianter_pict/avocado_varianter_pict/__init__.py
@@ -183,9 +183,6 @@ class VarianterPict(Varianter):
     def __len__(self):
         return sum(1 for _ in self)
 
-    def update_defaults(self, defaults):
-        pass
-
     def to_str(self, summary, variants, **kwargs):
         """
         Return human readable representation

--- a/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/__init__.py
+++ b/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/__init__.py
@@ -473,11 +473,12 @@ class YamlToMux(mux.MuxPlugin, Varianter):
 
     def initialize(self, config):
         subcommand = config.get('subcommand')
-        data = mux.MuxTreeNode()
+        data = None
 
         # Merge the multiplex
         multiplex_files = config.get("yaml_to_mux.files")
         if multiplex_files:
+            data = mux.MuxTreeNode()
             try:
                 data.merge(create_from_yaml(multiplex_files))
             except IOError as details:
@@ -501,11 +502,13 @@ class YamlToMux(mux.MuxPlugin, Varianter):
                 entry[2] = ast.literal_eval(entry[2])
             except (ValueError, SyntaxError, NameError, RecursionError):
                 pass
+            if data is None:
+                data = mux.MuxTreeNode()
             data.get_node(entry[0], True).value[entry[1]] = entry[2]
 
-        mux_filter_only = config.get('yaml_to_mux.filter_only')
-        mux_filter_out = config.get('yaml_to_mux.filter_out')
-        data = mux.apply_filters(data, mux_filter_only, mux_filter_out)
-        if data != mux.MuxTreeNode():
+        if data is not None:
+            mux_filter_only = config.get('yaml_to_mux.filter_only')
+            mux_filter_out = config.get('yaml_to_mux.filter_out')
+            data = mux.apply_filters(data, mux_filter_only, mux_filter_out)
             paths = config.get("yaml_to_mux.parameter_paths")
             self.initialize_mux(data, paths)

--- a/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/mux.py
+++ b/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/mux.py
@@ -163,8 +163,10 @@ class MuxPlugin:
         """
         self.root = root
         self.paths = paths
-        self.variant_ids = [varianter.generate_variant_id(variant)
-                            for variant in MuxTree(self.root)]
+        if self.root is not None:
+            self.variant_ids = [varianter.generate_variant_id(variant)
+                                for variant in MuxTree(self.root)]
+            self.variants = MuxTree(self.root)
 
     def __iter__(self):
         """

--- a/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/mux.py
+++ b/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/mux.py
@@ -180,20 +180,6 @@ class MuxPlugin:
                    "variant": variant,
                    "paths": self.paths}
 
-    def update_defaults(self, defaults):
-        """
-        See
-        :meth:`avocado.core.plugin_interfaces.Varianter.update_defaults`
-        """
-        if self.root is None:
-            return
-        if self.default_params:
-            self.default_params.merge(defaults)
-        self.default_params = defaults
-        combination = defaults
-        combination.merge(self.root)
-        self.variants = MuxTree(combination)
-
     def to_str(self, summary, variants, **kwargs):
         """
         See :meth:`avocado.core.plugin_interfaces.Varianter.to_str`

--- a/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/mux.py
+++ b/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/mux.py
@@ -150,7 +150,6 @@ class MuxPlugin:
     """
     root = None
     variants = None
-    default_params = None
     paths = None
     variant_ids = []
 

--- a/optional_plugins/varianter_yaml_to_mux/tests/test_unit.py
+++ b/optional_plugins/varianter_yaml_to_mux/tests/test_unit.py
@@ -229,8 +229,6 @@ class TestMuxTree(unittest.TestCase):
         mux2 = mux.MuxPlugin()
         mux1.initialize_mux(tree1, "")
         mux2.initialize_mux(tree2, "")
-        mux1.update_defaults(tree.TreeNode())
-        mux2.update_defaults(tree.TreeNode())
         variant1 = next(iter(mux1))
         variant2 = next(iter(mux2))
         self.assertNotEqual(variant1, variant2)

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ if __name__ == '__main__':
                   "tap = avocado.plugins.tap:TAPInit",
                   "jobscripts = avocado.plugins.jobscripts:JobScriptsInit",
                   "json_variants = avocado.plugins.json_variants:JsonVariantsInit",
+                  "run = avocado.plugins.run:RunInit",
               ],
               'avocado.plugins.cli': [
                   'wrapper = avocado.plugins.wrapper:Wrapper',


### PR DESCRIPTION
Both are ancient and correlated, seldom used, but makes us carry a lot of internal baggage.  Let's clean up the interface of varianters by dropping them.