### PR TITLE
HTML Plugin: adapt to job status when job has an empty test suite

### DIFF
--- a/optional_plugins/html/avocado_result_html/__init__.py
+++ b/optional_plugins/html/avocado_result_html/__init__.py
@@ -218,7 +218,7 @@ class HTMLResult(Result):
             report_file.write(report_contents)
 
     def render(self, result, job):
-        if job.status in ("RUNNING", "ERROR"):
+        if job.status in ("RUNNING", "ERROR", "FAIL"):
             return  # Don't create results on unfinished or errored jobs
         if not (job.config.get('job.run.result.html.enabled') or
                 job.config.get('job.run.result.html.output')):


### PR DESCRIPTION
Currently, when running `avocado run`, the 'HTML RESULT' line is
printed, even if the job had no tests in the test suite and did not
really run.

The reason is that on 856c3b572 the TestSuite() class was introduced,
and with that, a different exception started to being raised when an
empty test suite was created.

When the new exception is handled, the job is set to FAILed, instead
of ERRORed.  We could change the exception or their handling, but I
think this side effect is actually a good thing.  A Job with an empty
test suite failed to proceed, but did not really ERRORed.

ERROR is currently reserved, and used in most cases, when things that
are not expected happen, and say, Avocado crashes.

Signed-off-by: Cleber Rosa <crosa@redhat.com>