### PR TITLE
Simple (executable) Tests: provide a more human friendly message on f…

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -1090,6 +1090,13 @@ class SimpleTest(Test):
         self.log.info("Exit status: %s", result.exit_status)
         self.log.info("Duration: %s", result.duration)
 
+    @staticmethod
+    def _cmd_error_to_test_failure(cmd_error):
+        return ("Exited with status: '%u', stdout: %r stderr: %r" %
+                (cmd_error.result.exit_status, cmd_error.result.stdout_text,
+                 cmd_error.result.stderr_text))
+
+
     def _execute_cmd(self):
         """
         Run the executable, and log its detailed execution.
@@ -1107,7 +1114,8 @@ class SimpleTest(Test):
             self._log_detailed_cmd_info(result)
         except process.CmdError as details:
             self._log_detailed_cmd_info(details.result)
-            raise exceptions.TestFail(details)
+            test_failure = self._cmd_error_to_test_failure(details)
+            raise exceptions.TestFail(test_failure)
 
         warn_regex = self._config.get('simpletests.status.warn_regex')
         warn_location = self._config.get('simpletests.status.warn_location')


### PR DESCRIPTION
Currently we pass/show the raw CmdError as the failure information, resulting
in output like this:

```
   JOB ID     : 989cf0b0c8d90fb593eb5bc6ff9291aa3248955c
   JOB LOG    : /home/cleber/avocado/job-results/job-2020-08-02T16.31-989cf0b/job.log
    (1/1) /bin/false: FAIL: Command '/bin/false' failed.\nstdout: b''\nstderr: b''\nadditional_info: None (0.06 s)
   RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
   JOB HTML   : /home/cleber/avocado/job-results/job-2020-08-02T16.31-989cf0b/results.html
   JOB TIME   : 0.14 s
```

Which contains a duplicate of the command path (already in the test
name) an always empty and useless "additional_info", needless new
lines, and very bad formatting.  This changes turns it into:

```
   JOB ID     : 9cde24d36988d6441f755c14f79b2e908ae533ef
   JOB LOG    : /home/cleber/avocado/job-results/job-2020-08-02T16.58-9cde24d/job.log
    (1/1) /bin/false: FAIL: Exited with status: '1', stdout: '' stderr: '' (0.08 s)
   RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
   JOB HTML   : /home/cleber/avocado/job-results/job-2020-08-02T16.58-9cde24d/results.html
   JOB TIME   : 0.16 s
```

Removing the superfluous, and adding the execution exit status, and
better formatting.

Signed-off-by: Cleber Rosa <crosa@redhat.com>
