### PR TITLE
Warning of loader and external runner incompatibility [v3] 

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -74,7 +74,6 @@ class Job:
 
     Most of the time, we are interested in simply running tests,
     along with setup operations and event recording.
-    husa
     """
 
     def __init__(self, config=None):

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -74,6 +74,7 @@ class Job:
 
     Most of the time, we are interested in simply running tests,
     along with setup operations and event recording.
+    husa
     """
 
     def __init__(self, config=None):

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -23,6 +23,7 @@ import os
 import re
 import shlex
 import sys
+import warnings
 from enum import Enum
 
 from ..utils import stacktrace
@@ -123,6 +124,10 @@ class TestLoaderProxy:
         if external_runner:
             self.register_plugin(ExternalLoader)
             key = "{}.loaders".format(subcommand)
+            if set(config[key]) != {'file', '@DEFAULT'}:
+                warnings.warn("The loaders and external-runner are incompatible."
+                              "The values in loaders will be ignored.",
+                              RuntimeWarning)
             config[key] = ["external:{}".format(external_runner)]
         else:
             # Add (default) file loader if not already registered

--- a/docs/source/guides/user/chapters/introduction.rst
+++ b/docs/source/guides/user/chapters/introduction.rst
@@ -215,6 +215,10 @@ But now consider the following example::
 This effectively makes `/bin/curl` an "external test runner", responsible for
 trying to fetch those URLs, and reporting PASS or FAIL for each of them.
 
+.. warning:: The external runner is incompatible with loaders from
+   :ref:`test-loaders`. If you use external runner and loader together
+   the job will use the external runner and ignore the loader.
+
 Runner outputs
 --------------
 

--- a/docs/source/guides/user/chapters/loaders.rst
+++ b/docs/source/guides/user/chapters/loaders.rst
@@ -1,3 +1,5 @@
+.. _test-loaders:
+
 Undestanding the test discovery (Avocado Loaders)
 =================================================
 

--- a/docs/source/guides/user/chapters/loaders.rst
+++ b/docs/source/guides/user/chapters/loaders.rst
@@ -1,7 +1,7 @@
 .. _test-loaders:
 
-Undestanding the test discovery (Avocado Loaders)
-=================================================
+Understanding the test discovery (Avocado Loaders)
+==================================================
 
 In this section you can learn how tests are being discovered and how to
 customize this process.

--- a/selftests/functional/test_loader.py
+++ b/selftests/functional/test_loader.py
@@ -296,6 +296,29 @@ class LoaderTestFunctional(TestCaseTmpDir):
                     b"SIMPLE       examples/tests/failtest.sh\n")
         self.assertEqual(expected, result.stdout)
 
+    def test_loader_and_external_runner_incompatibility(self):
+        """
+        Check if the user is inform about incompatibility between loader and
+        external_runner.
+        """
+        test_script = script.TemporaryScript('simpletest.sh', SIMPLE_TEST,
+                                             'avocado_loader_test',
+                                             mode=self.MODE_0775)
+        test_script.save()
+
+        cmd = "%s run --loaders=FOO " \
+                "--external-runner=/bin/sh %s" % (AVOCADO, test_script.path)
+        result = process.run(cmd)
+        expected_warning = "The loaders and external-runner are incompatible." \
+                           "The values in loaders will be ignored."
+        self.assertIn(expected_warning, result.stderr_text)
+
+        cmd = "%s run --external-runner=/bin/sh %s" % (AVOCADO,
+                                                         test_script.path)
+        result = process.run(cmd)
+        self.assertNotIn(expected_warning, result.stderr_text)
+
+        test_script.remove()
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
avocado run command line can accept options --loaders and --external-runner in
one time. But when we use external runner there is a specific loader and we
don't use values from option --loaders. When user uses both these options, we
have to warn him about this behaviour.

Reference: #3899

---

Changes from v1 (#4024):
 * Typo fixes
 * Documentation
 * Tests

---

Changes from v2 (#4046):
 * `assertTrue` to `assertIn`
 * `assertFalse` to `assertNotIn`
 * usage of `/bin/sh`