### PR TITLE
Fix "avocado list" and "avocado nlist" filtering by tags support

### DIFF
--- a/avocado/core/tags.py
+++ b/avocado/core/tags.py
@@ -156,24 +156,25 @@ def filter_test_tags_runnable(runnable, filter_by_tags, include_empty=False,
     :type include_empty_key: bool
     """
     must_must_nots = _parse_filter_by_tags(filter_by_tags)
+    runnable_tags = runnable.tags or {}
 
-    if not runnable.tags:
+    if not runnable_tags:
         if include_empty:
             return True
 
     for must, must_not in must_must_nots:
-        if must_not.intersection(runnable.tags):
+        if must_not.intersection(runnable_tags):
             continue
 
         must_flat, must_key_val = _must_split_flat_key_val(must)
         if must_key_val:
             if not _must_key_val_matches(must_key_val,
-                                         runnable.tags,
+                                         runnable_tags,
                                          include_empty_key):
                 continue
 
         if must_flat:
-            if not must_flat.issubset(runnable.tags):
+            if not must_flat.issubset(runnable_tags):
                 continue
 
         return True

--- a/avocado/plugins/list.py
+++ b/avocado/plugins/list.py
@@ -121,12 +121,12 @@ class TestLister:
     def _list(self):
         self._extra_listing()
         test_suite = self._get_test_suite(self.config.get('list.references'))
-        if self.config.get('list.filter_by_tags'):
+        if self.config.get('filter.by_tags.tags'):
             test_suite = tags.filter_test_tags(
                 test_suite,
-                self.config.get('list.filter_by_tags'),
-                self.config.get('list.filter_by_tags_include_empty'),
-                self.config.get('list.filter_by_tags_include_empty_key'))
+                self.config.get('filter.by_tags.tags'),
+                self.config.get('filter_by_tags.include_empty'),
+                self.config.get('filter_by_tags.include_empty_key'))
         test_matrix, stats, tag_stats = self._get_test_matrix(test_suite)
         self._display(test_matrix, stats, tag_stats)
 

--- a/avocado/plugins/nlist.py
+++ b/avocado/plugins/nlist.py
@@ -44,17 +44,6 @@ class List(CLICmd):
                                  parser=parser,
                                  positional_arg=True)
 
-        help_msg = ('Show extra information on resolution, besides '
-                    'sucessful resolutions')
-        settings.register_option(section='nlist',
-                                 key='verbose',
-                                 default=False,
-                                 key_type=bool,
-                                 help_msg=help_msg,
-                                 parser=parser,
-                                 long_arg='--verbose',
-                                 short_arg='-V')
-
         help_msg = 'Writes runnable recipe files to a directory'
         settings.register_option(section='nlist.recipes',
                                  key='write_to_directory',
@@ -68,7 +57,7 @@ class List(CLICmd):
 
     def run(self, config):
         references = config.get('nlist.references')
-        verbose = config.get('nlist.verbose')
+        verbose = config.get('core.verbose')
         hint = None
         hint_filepath = '.avocado.hint'
         if os.path.exists(hint_filepath):

--- a/avocado/plugins/nlist.py
+++ b/avocado/plugins/nlist.py
@@ -98,13 +98,13 @@ class List(CLICmd):
             if result.resolutions:
                 for runnable in result.resolutions:
 
-                    filter_by_tags = config.get('nlist.filter_by_tags')
+                    filter_by_tags = config.get('filter.by_tags.tags')
                     if filter_by_tags:
                         if not filter_test_tags_runnable(
                                 runnable,
                                 filter_by_tags,
-                                config.get('nlist.filter_by_tags_include_empty'),
-                                config.get('nlist.filter_by_tags_include_empty_key')):
+                                config.get('filter.by_tags.include_empty'),
+                                config.get('filter.by_tags.include_empty_key')):
                             continue
 
                     type_label = runnable.kind

--- a/selftests/functional/test_list.py
+++ b/selftests/functional/test_list.py
@@ -1,0 +1,34 @@
+import os
+import unittest
+
+from avocado.core import exit_codes
+from avocado.utils import process
+
+from .. import AVOCADO, BASEDIR
+
+
+class List(unittest.TestCase):
+
+    list_command = 'list'
+    instrumented = 'INSTRUMENTED'
+
+    def test_list_filter_by_tags(self):
+        examples_dir = os.path.join(BASEDIR, 'examples', 'tests')
+        cmd_line = "%s --verbose %s -t fast -- %s" % (AVOCADO,
+                                                      self.list_command,
+                                                      examples_dir)
+        result = process.run(cmd_line)
+        self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK,
+                         "Avocado did not return rc %d:\n%s"
+                         % (exit_codes.AVOCADO_ALL_OK, result))
+        stdout_lines = result.stdout_text.splitlines()
+        self.assertIn("TEST TYPES SUMMARY", stdout_lines)
+        self.assertIn("%s: 2" % self.instrumented, stdout_lines)
+        self.assertIn("TEST TAGS SUMMARY", stdout_lines)
+        self.assertIn("fast: 2", stdout_lines)
+
+
+class NList(List):
+
+    list_command = 'nlist'
+    instrumented = 'avocado-instrumented'

--- a/selftests/functional/test_resolver.py
+++ b/selftests/functional/test_resolver.py
@@ -24,7 +24,7 @@ class ResolverFunctional(unittest.TestCase):
         name = 'executable-test'
         with script.TemporaryScript(name, EXEC_TEST,
                                     name, self.MODE_0775) as test_file:
-            cmd_line = ('%s nlist -V %s' % (AVOCADO, test_file.path))
+            cmd_line = ('%s --verbose nlist %s' % (AVOCADO, test_file.path))
             result = process.run(cmd_line)
         self.assertIn('exec-test: 1', result.stdout_text)
 
@@ -40,7 +40,7 @@ class ResolverFunctional(unittest.TestCase):
         name = 'passtest.py'
         with script.TemporaryScript(name, AVOCADO_INSTRUMENTED_TEST,
                                     name, self.MODE_0664) as test_file:
-            cmd_line = ('%s nlist -V %s' % (AVOCADO, test_file.path))
+            cmd_line = ('%s --verbose nlist %s' % (AVOCADO, test_file.path))
             result = process.run(cmd_line)
         self.assertIn('passtest.py:PassTest.test', result.stdout_text)
         self.assertIn('avocado-instrumented: 1', result.stdout_text)


### PR DESCRIPTION
While "avocado run" has been working, filtering while listing tests has been broken.  This fixes all issues found and adds tests to avoid regressions.