### PR TITLE
N(ext) Runner: introduce a job that tests different script implementa…

### DIFF
--- a/selftests/jobs/nrunner_interface
+++ b/selftests/jobs/nrunner_interface
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+import sys
+
+from avocado.core.job import Job
+
+config = {'run.references': ['selftests/functional/test_nrunner_interface.py'],
+          'run.dict_variants': [
+              {'runner': 'avocado-runner-noop'},
+              {'runner': 'avocado-runner-exec'},
+              {'runner': 'avocado-runner-exec-test'},
+              {'runner': 'avocado-runner-python-unittest'},
+              {'runner': 'avocado-runner-avocado-instrumented'},
+              {'runner': 'avocado-runner-tap'},
+              ]}
+
+with Job(config) as j:
+    sys.exit(j.run())


### PR DESCRIPTION
…tions

To make sure that all interface checks, current and future, will be
run with all the existing runner implementations.

Reference: https://github.com/avocado-framework/avocado/issues/4058
Signed-off-by: Cleber Rosa <crosa@redhat.com>