### PR TITLE
N(ext) Runner: move the status server out of the nrunner module

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import argparse
-import asyncio
 import base64
 import collections
 import inspect
@@ -580,20 +579,8 @@ class StatusEncoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, o)
 
 
-def json_base64_decode(dct):
-    if '__base64_encoded__' in dct:
-        return base64.b64decode(dct['__base64_encoded__'])
-    return dct
-
-
 def json_dumps(data):
     return json.dumps(data, ensure_ascii=True, cls=StatusEncoder)
-
-
-def json_loads(data):
-    if isinstance(data, bytes):
-        data = data.decode()
-    return json.loads(data, object_hook=json_base64_decode)
 
 
 class TaskStatusService:
@@ -719,96 +706,6 @@ class Task:
             for status_service in self.status_services:
                 status_service.post(status)
             yield status
-
-
-class StatusServer:
-
-    def __init__(self, uri, tasks_pending=None, verbose=False):
-        self.uri = uri
-        self.server_task = None
-        self.result = {}
-        if tasks_pending is None:
-            tasks_pending = []
-        self.tasks_pending = tasks_pending
-        self.verbose = verbose
-        self.wait_on_tasks_pending = len(self.tasks_pending) > 0
-
-    async def cb(self, reader, _):
-        while True:
-            if self.wait_on_tasks_pending:
-                if not self.tasks_pending:
-                    print('Status server: exiting due to all tasks finished')
-                    self.server_task.cancel()
-                    await self.server_task
-                    return True
-
-            message = await reader.readline()
-            message = message.strip()
-            if message == b'bye':
-                print('Status server: exiting due to user request')
-                self.server_task.cancel()
-                await self.server_task
-                return True
-
-            if not message:
-                return False
-
-            try:
-                data = json_loads(message)
-            except json.decoder.JSONDecodeError:
-                return False
-
-            if data.get('status') in ['started']:
-                self.handle_task_started(data)
-            elif data.get('status') in ['finished']:
-                self.handle_task_finished(data)
-
-    async def create_server_task(self):
-        host, port = self.uri.split(':')
-        port = int(port)
-        server = await asyncio.start_server(self.cb, host=host, port=port)
-        print("Status server started at:", self.uri)
-        await server.wait_closed()
-
-    def handle_task_started(self, data):
-        if self.verbose:
-            print("Task started: {}. Outputdir: {}".format(data['id'],
-                                                           data['output_dir']))
-
-    def handle_task_finished(self, data):
-        if 'result' not in data:
-            return
-
-        result = data['result']
-        task_id = data['id']
-
-        if self.wait_on_tasks_pending:
-            self.tasks_pending.remove(task_id)
-
-        if result not in self.result:
-            self.result[result] = []
-        self.result[result].append(task_id)
-
-        if self.verbose:
-            print('Task complete (%s): %s' % (result, task_id))
-            if result not in ('pass', 'skip'):
-                stdout = data.get('stdout', b'')
-                if stdout:
-                    print('Task %s stdout:\n%s\n' % (task_id, stdout))
-                stderr = data.get('stderr', b'')
-                if stderr:
-                    print('Task %s stderr:\n%s\n' % (task_id, stderr))
-                output = data.get('output', b'')
-                if output:
-                    print('Task %s output:\n%s\n' % (task_id, output))
-
-    def start(self):
-        loop = asyncio.get_event_loop()
-        self.server_task = loop.create_task(self.create_server_task())
-
-    async def wait(self):
-        while not self.server_task.done():
-            await asyncio.sleep(0.1)
 
 
 class BaseRunnerApp:
@@ -1020,18 +917,6 @@ class BaseRunnerApp:
                                 self.RUNNABLE_KINDS_CAPABLE)
         for status in task.run():
             self.echo(status)
-
-    def command_status_server(self, args):
-        """
-        Runs a status server
-
-        :param args: parsed command line arguments turned into a dictionary
-        :type args: dict
-        """
-        server = StatusServer(args.get('uri'))
-        server.start()
-        loop = asyncio.get_event_loop()
-        loop.run_until_complete(server.wait())
 
 
 class RunnerApp(BaseRunnerApp):

--- a/avocado/core/status_server.py
+++ b/avocado/core/status_server.py
@@ -1,0 +1,105 @@
+import asyncio
+import base64
+import json
+
+
+def json_loads(data):
+    if isinstance(data, bytes):
+        data = data.decode()
+    return json.loads(data, object_hook=json_base64_decode)
+
+
+def json_base64_decode(dct):
+    if '__base64_encoded__' in dct:
+        return base64.b64decode(dct['__base64_encoded__'])
+    return dct
+
+
+class StatusServer:
+
+    def __init__(self, uri, tasks_pending=None, verbose=False):
+        self.uri = uri
+        self.server_task = None
+        self.result = {}
+        if tasks_pending is None:
+            tasks_pending = []
+        self.tasks_pending = tasks_pending
+        self.verbose = verbose
+        self.wait_on_tasks_pending = len(self.tasks_pending) > 0
+
+    async def cb(self, reader, _):
+        while True:
+            if self.wait_on_tasks_pending:
+                if not self.tasks_pending:
+                    print('Status server: exiting due to all tasks finished')
+                    self.server_task.cancel()
+                    await self.server_task
+                    return True
+
+            message = await reader.readline()
+            message = message.strip()
+            if message == b'bye':
+                print('Status server: exiting due to user request')
+                self.server_task.cancel()
+                await self.server_task
+                return True
+
+            if not message:
+                return False
+
+            try:
+                data = json_loads(message)
+            except json.decoder.JSONDecodeError:
+                return False
+
+            if data.get('status') in ['started']:
+                self.handle_task_started(data)
+            elif data.get('status') in ['finished']:
+                self.handle_task_finished(data)
+
+    async def create_server_task(self):
+        host, port = self.uri.split(':')
+        port = int(port)
+        server = await asyncio.start_server(self.cb, host=host, port=port)
+        print("Status server started at:", self.uri)
+        await server.wait_closed()
+
+    def handle_task_started(self, data):
+        if self.verbose:
+            print("Task started: {}. Outputdir: {}".format(data['id'],
+                                                           data['output_dir']))
+
+    def handle_task_finished(self, data):
+        if 'result' not in data:
+            return
+
+        result = data['result']
+        task_id = data['id']
+
+        if self.wait_on_tasks_pending:
+            self.tasks_pending.remove(task_id)
+
+        if result not in self.result:
+            self.result[result] = []
+        self.result[result].append(task_id)
+
+        if self.verbose:
+            print('Task complete (%s): %s' % (result, task_id))
+            if result not in ('pass', 'skip'):
+                stdout = data.get('stdout', b'')
+                if stdout:
+                    print('Task %s stdout:\n%s\n' % (task_id, stdout))
+                stderr = data.get('stderr', b'')
+                if stderr:
+                    print('Task %s stderr:\n%s\n' % (task_id, stderr))
+                output = data.get('output', b'')
+                if output:
+                    print('Task %s output:\n%s\n' % (task_id, output))
+
+    def start(self):
+        loop = asyncio.get_event_loop()
+        self.server_task = loop.create_task(self.create_server_task())
+
+    async def wait(self):
+        while not self.server_task.done():
+            await asyncio.sleep(0.1)

--- a/avocado/plugins/nrun.py
+++ b/avocado/plugins/nrun.py
@@ -4,7 +4,8 @@ import os
 import random
 import sys
 
-from avocado.core import exit_codes, nrunner, parser_common_args, resolver
+from avocado.core import (exit_codes, nrunner, parser_common_args, resolver,
+                          status_server)
 from avocado.core.future.settings import settings
 from avocado.core.output import LOG_UI
 from avocado.core.parser import HintParser
@@ -151,10 +152,11 @@ class NRun(CLICmd):
 
             listen = config.get('nrun.status_server.listen')
             verbose = config.get('core.verbose')
-            self.status_server = nrunner.StatusServer(listen,  # pylint: disable=W0201
-                                                      [t.identifier for t in
-                                                       self.pending_tasks],
-                                                      verbose)
+            self.status_server = status_server.StatusServer(
+                listen,  # pylint: disable=W0201
+                [t.identifier for t in
+                 self.pending_tasks],
+                verbose)
             self.status_server.start()
             parallel_tasks = config.get('nrun.parallel_tasks')
             loop = asyncio.get_event_loop()


### PR DESCRIPTION
The only reason for the "avocado/core/nrunner.py" to be standalone is
to ease its deployment into an environment that contains nothing but
Python itself.  This will hopefully change in the future when we solve
the deployment problem.

For now, it's clear that at least the StatusServer does not need to
live in that module and be deployed when tests are executed in a
different environment.  The StatusServer is used solely by the
`avocado nrun` command, and thus, can live on another module.

Signed-off-by: Cleber Rosa <crosa@redhat.com>