### PR TITLE
Migrate on/off options to booleans [v2]

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -576,7 +576,7 @@ class Job:
         self.__start_job_logging()
         self._setup_job_category()
         # Use "logdir" in case "keep_tmp" is enabled
-        if self.config.get('run.keep_tmp') == 'on':
+        if self.config.get('run.keep_tmp'):
             base_tmpdir = self.logdir
         else:
             base_tmpdir = data_dir.get_tmp_dir()

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -814,7 +814,7 @@ class Test(unittest.TestCase, TestData):
                                            "stderr.expected")
 
             # check the output and produce test failures
-            if output_check_record != 'none' and output_check == 'on':
+            if output_check_record != 'none' and output_check:
                 output_checked = False
                 try:
                     output_checked = self._check_reference(

--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -210,19 +210,19 @@ class Replay(CLI):
             config['replay_sourcejob'] = id_file.read().strip()
 
         replay_config = jobdata.retrieve_job_config(resultsdir)
-        whitelist = ['loaders',
-                     'external_runner',
-                     'external_runner_testdir',
-                     'external_runner_chdir',
-                     'failfast',
-                     'ignore_missing_references',
-                     'execution_order']
+        overridables = ['loaders',
+                        'external_runner',
+                        'external_runner_testdir',
+                        'external_runner_chdir',
+                        'failfast',
+                        'ignore_missing_references',
+                        'execution_order']
         if replay_config is None:
             LOG_UI.warn('Source job config data not found. These options will '
                         'not be loaded in this replay job: %s',
-                        ', '.join(whitelist))
+                        ', '.join(overridables))
         else:
-            for option in whitelist:
+            for option in overridables:
                 optvalue = config.get(option, None)
                 # Temporary, this will be removed soon
                 if option in ['failfast',

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -177,12 +177,12 @@ class Run(CLICmd):
                                  parser=parser,
                                  long_arg='--failfast')
 
-        help_msg = ('Keep job temporary files (useful for avocado debugging). '
-                    '"on" and "off" will be deprecated soon.')
+        help_msg = 'Keep job temporary files (useful for avocado debugging).'
         settings.register_option(section='run',
                                  key='keep_tmp',
-                                 choices=('on', 'off'),
-                                 default='off',
+                                 default=False,
+                                 key_type=bool,
+                                 action='store_true',
                                  help_msg=help_msg,
                                  parser=parser,
                                  long_arg='--keep-tmp')
@@ -285,7 +285,7 @@ class Run(CLICmd):
             process.OUTPUT_CHECK_RECORD_MODE = check_record
 
         warnings.warn("The following arguments will be changed to boolean soon: "
-                      "output-check, failfast and keep-tmp. ",
+                      "output-check and failfast.",
                       FutureWarning)
 
         unique_job_id = config.get('run.unique_job_id')

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -167,12 +167,12 @@ class Run(CLICmd):
                                          parser=parser,
                                          long_arg='--job-timeout')
 
-        help_msg = ('Enable or disable the job interruption on first failed '
-                    'test. "on" and "off" will be deprecated soon.')
+        help_msg = 'Enable the job interruption on first failed test.'
         settings.register_option(section='run',
                                  key='failfast',
-                                 choices=('on', 'off'),
-                                 default='off',
+                                 default=False,
+                                 key_type=bool,
+                                 action='store_true',
                                  help_msg=help_msg,
                                  parser=parser,
                                  long_arg='--failfast')
@@ -284,8 +284,8 @@ class Run(CLICmd):
             check_record = config.get('run.output_check_record')
             process.OUTPUT_CHECK_RECORD_MODE = check_record
 
-        warnings.warn("The following arguments will be changed to boolean soon: "
-                      "output-check and failfast.",
+        warnings.warn("The following argument will be changed to boolean soon: "
+                      "output-check.",
                       FutureWarning)
 
         unique_job_id = config.get('run.unique_job_id')

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -200,9 +200,8 @@ class Run(CLICmd):
 
         settings.add_argparser_to_option(namespace='sysinfo.collect.enabled',
                                          parser=parser,
-                                         choices=('on', 'off'),
-                                         short_arg='-S',
-                                         long_arg='--sysinfo')
+                                         action='store_false',
+                                         long_arg='--disable-sysinfo')
 
         settings.add_argparser_to_option('run.execution_order',
                                          parser=parser,
@@ -286,7 +285,7 @@ class Run(CLICmd):
             process.OUTPUT_CHECK_RECORD_MODE = check_record
 
         warnings.warn("The following arguments will be changed to boolean soon: "
-                      "sysinfo, output-check, failfast and keep-tmp. ",
+                      "output-check, failfast and keep-tmp. ",
                       FutureWarning)
 
         unique_job_id = config.get('run.unique_job_id')

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -18,7 +18,6 @@ Base Test Runner Plugins.
 
 import argparse
 import sys
-import warnings
 
 from avocado.core import exit_codes, job, loader, output, parser_common_args
 from avocado.core.dispatcher import JobPrePostDispatcher
@@ -257,17 +256,17 @@ class Run(CLICmd):
                                  default=None,
                                  long_arg='--output-check-record')
 
-        help_msg = ('Enable or disable test output (stdout/stderr) check. If '
-                    'this option is off, no output will be checked, even if '
-                    'there are reference files present for the test. "on" '
-                    'and "off" will be deprecated soon.')
+        help_msg = ('Disables test output (stdout/stderr) check. If this '
+                    'option is given, no output will be checked, even if '
+                    'there are reference files present for the test.')
         settings.register_option(section='run',
                                  key='output_check',
-                                 default='on',
-                                 choices=('on', 'off'),
+                                 default=True,
+                                 key_type=bool,
+                                 action='store_false',
                                  help_msg=help_msg,
                                  parser=out_check,
-                                 long_arg='--output-check')
+                                 long_arg='--disable-output-check')
 
         loader.add_loader_options(parser, 'run')
         parser_common_args.add_tag_filter_args(parser)
@@ -283,10 +282,6 @@ class Run(CLICmd):
         if 'run.output_check_record' in config:
             check_record = config.get('run.output_check_record')
             process.OUTPUT_CHECK_RECORD_MODE = check_record
-
-        warnings.warn("The following argument will be changed to boolean soon: "
-                      "output-check.",
-                      FutureWarning)
 
         unique_job_id = config.get('run.unique_job_id')
         if unique_job_id is not None:

--- a/avocado/plugins/runner.py
+++ b/avocado/plugins/runner.py
@@ -263,7 +263,7 @@ class TestRunner(Runner):
         elif not mapping[test_state['status']]:
             summary.add("FAIL")
 
-            if job.config.get('run.failfast') == 'on':
+            if job.config.get('run.failfast'):
                 summary.add("INTERRUPTED")
                 job.interrupted_reason = "Interrupting job (failfast)."
                 return False

--- a/avocado/plugins/sysinfo.py
+++ b/avocado/plugins/sysinfo.py
@@ -33,10 +33,9 @@ class SysinfoInit(Init):
                     'details, profiles, etc.')
         settings.register_option(section='sysinfo.collect',
                                  key='enabled',
-                                 default='on',
-                                 key_type=str,
-                                 help_msg=help_msg,
-                                 choices=('on', 'off'))
+                                 default=True,
+                                 key_type=bool,
+                                 help_msg=help_msg)
 
         help_msg = 'Enable sysinfo collection per-test'
         settings.register_option(section='sysinfo.collect',
@@ -134,7 +133,7 @@ class SysInfoJob(JobPreTests, JobPostTests):
 
     def __init__(self, config):
         self.sysinfo = None
-        self.sysinfo_enabled = config.get('sysinfo.collect.enabled') == 'on'
+        self.sysinfo_enabled = config.get('sysinfo.collect.enabled')
 
     def _init_sysinfo(self, job_logdir):
         if self.sysinfo is None:

--- a/docs/source/guides/user/chapters/configuring.rst
+++ b/docs/source/guides/user/chapters/configuring.rst
@@ -64,11 +64,8 @@ configuration files, you can disable sysinfo logging by running:
 
 .. code-block:: shell
 
-   $ avocado run --sysinfo off /bin/true
+   $ avocado run --disable-sysinfo /bin/true
 
-
-.. note:: Please keep in mind that sysinfo option will be a boolean
-  command-line option soon.
 
 So, command-line options always will have the highest precedence during the
 configuration parsing. Use this if you would like to change some behavior on
@@ -233,8 +230,8 @@ Example using the command-line:
   $ avocado run --verbose /bin/true
 
 .. note:: Currently we still have some "old style boolean" options where you
-  should pass "on" or "off" on the command-line. i.e: ``--sysinfo=off``. Those
-  options are going to be replaced soon.
+  should pass "on" or "off" on the command-line. i.e: ``--json-job-result=off``.
+  Those options are going to be replaced soon.
 
 Lists
 ~~~~~

--- a/docs/source/guides/user/chapters/introduction.rst
+++ b/docs/source/guides/user/chapters/introduction.rst
@@ -75,10 +75,10 @@ test timeout) are still running while the test's process is stopped.
 Interrupting the job on first fail (failfast)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The Avocado ``run`` command has the option ``--failfast on`` to exit the job on
+The Avocado ``run`` command has the option ``--failfast`` to exit the job on
 first failed test::
 
-    $ avocado run --failfast on /bin/true /bin/false /bin/true /bin/true
+    $ avocado run --failfast /bin/true /bin/false /bin/true /bin/true
     JOB ID     : eaf51b8c7d6be966bdf5562c9611b1ec2db3f68a
     JOB LOG    : $HOME/avocado/job-results/job-2016-07-19T09.43-eaf51b8/job.log
      (1/4) /bin/true: PASS (0.01 s)
@@ -87,8 +87,12 @@ first failed test::
     RESULTS    : PASS 1 | ERROR 0 | FAIL 1 | SKIP 2 | WARN 0 | INTERRUPT 0
     JOB TIME   : 0.12 s
 
-One can also use ``--failfast off`` in order to force-disable failfast mode
-when replaying a job executed with ``--failfast on``.
+The default behavior, that is, when ``--failfast`` is **not** set, is
+to try to execute all tests in a job, regardless individual of test failures.
+
+.. note:: Avocado versions 80.0 and earlier allowed replayed jobs to override
+          the failfast configuration by setting ``--failfast=off`` in a
+          ``avocado run --replay ..`` command line.  This is no longer possible.
 
 .. _the_hint_files:
 

--- a/docs/source/guides/user/chapters/operations.rst
+++ b/docs/source/guides/user/chapters/operations.rst
@@ -82,8 +82,9 @@ Of which one special example is ``--replay-test-status INTERRUPTED`` or simply
 which were CANCELED or not executed after a CANCELED test. This feature should
 work even on hard interruptions like system crash.
 
-When replaying jobs that were executed with the ``--failfast on`` option, you
-can disable the ``failfast`` option using ``--failfast off`` in the replay job.
+.. note:: Avocado versions 80.0 and earlier allowed replayed jobs to override
+          the failfast configuration by setting ``--failfast=off`` in a
+          ``avocado run --replay ..`` command line.  This is no longer possible.
 
 To be able to replay a job, Avocado records the job data in the same job
 results directory, inside a subdirectory named ``replay``. If a given job has a

--- a/docs/source/guides/writer/chapters/writing.rst
+++ b/docs/source/guides/writer/chapters/writing.rst
@@ -788,7 +788,7 @@ generated match the reference(s) file(s) content.  If they don't
 match, the test will finish with a ``FAIL`` status.
 
 You can disable this automatic check when a reference file exists by
-passing ``--output-check=off`` to the test runner.
+passing ``--disable-output-check`` to the test runner.
 
 .. tip:: The :mod:`avocado.utils.process` APIs have a parameter called
          ``allow_output_check`` that let you individually select the

--- a/man/avocado.rst
+++ b/man/avocado.rst
@@ -87,8 +87,8 @@ Options for subcommand `run` (`avocado run --help`)::
                             test.
       --keep-tmp {on,off}   Keep job temporary files (useful for avocado
                             debugging). Defaults to off.
-      --sysinfo {on,off}    Enable or disable system information (hardware
-                            details, profilers, etc.). Current: on
+      --disable-sysinfo     Enable or disable sysinfo information. Like hardware
+                            details, profiles, etc.
       --execution-order {tests-per-variant,variants-per-test}
                             How to iterate through test suite and variants
 

--- a/man/avocado.rst
+++ b/man/avocado.rst
@@ -83,7 +83,7 @@ Options for subcommand `run` (`avocado run --help`)::
                             are allowed to execute. Values <= zero means "no
                             timeout". You can also use suffixes, like: s
                             (seconds), m (minutes), h (hours).
-      --failfast {on,off}   Enable or disable the job interruption on first failed
+      --failfast            Enable the job interruption on first failed test.
                             test.
       --keep-tmp            Keep job temporary files (useful for avocado
                             debugging).

--- a/man/avocado.rst
+++ b/man/avocado.rst
@@ -85,8 +85,8 @@ Options for subcommand `run` (`avocado run --help`)::
                             (seconds), m (minutes), h (hours).
       --failfast {on,off}   Enable or disable the job interruption on first failed
                             test.
-      --keep-tmp {on,off}   Keep job temporary files (useful for avocado
-                            debugging). Defaults to off.
+      --keep-tmp            Keep job temporary files (useful for avocado
+                            debugging).
       --disable-sysinfo     Enable or disable sysinfo information. Like hardware
                             details, profiles, etc.
       --execution-order {tests-per-variant,variants-per-test}

--- a/man/avocado.rst
+++ b/man/avocado.rst
@@ -145,11 +145,10 @@ Options for subcommand `run` (`avocado run --help`)::
                             all (record both stdout and stderr), stdout (record
                             only stderr), stderr (record only stderr). Current:
                             none
-      --output-check {on,off}
-                            Enable or disable test output (stdout/stderr) check.
-                            If this option is off, no output will be checked, even
-                            if there are reference files present for the test.
-                            Current: on (output check enabled)
+      --disable-output-check
+                            Disables test output (stdout/stderr) check. If this
+                            option is given, no output will be checked, even if
+                            there are reference files present for the test.
 
     loader options:
       --loaders [LOADERS [LOADERS ...]]

--- a/optional_plugins/html/tests/test_html_result.py
+++ b/optional_plugins/html/tests/test_html_result.py
@@ -33,7 +33,7 @@ class HtmlResultTest(unittest.TestCase):
         self.assertIn("\n# debug.log of ", tap)
 
     def test_output_incompatible_setup(self):
-        cmd_line = ('avocado run --job-results-dir %s --sysinfo=off '
+        cmd_line = ('avocado run --job-results-dir %s --disable-sysinfo '
                     '--html - passtest.py' % self.tmpdir.name)
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_JOB_FAIL
@@ -51,7 +51,7 @@ class HtmlResultTest(unittest.TestCase):
         tmpfile2 = tempfile.mktemp(prefix=prefix, dir=self.tmpdir.name)
         tmpdir = tempfile.mkdtemp(prefix=prefix, dir=self.tmpdir.name)
         tmpfile3 = os.path.join(tmpdir, "result.html")
-        cmd_line = ('avocado run --job-results-dir %s --sysinfo=off '
+        cmd_line = ('avocado run --job-results-dir %s --disable-sysinfo '
                     '--xunit %s --json %s --html %s --tap-include-logs '
                     'passtest.py' % (self.tmpdir.name, tmpfile, tmpfile2, tmpfile3))
         result = process.run(cmd_line, ignore_status=True)

--- a/optional_plugins/loader_yaml/tests/test_yaml_loader.py
+++ b/optional_plugins/loader_yaml/tests/test_yaml_loader.py
@@ -32,7 +32,7 @@ class YamlLoaderTests(unittest.TestCase):
         tests = [b"PASSTEST.PY PREFIX: passtest.py:PassTest.test",
                  b"passtest.sh", b"executes bin true"]
         not_tests = [b"failtest.py"]
-        cmd = ('%s run --sysinfo=off --job-results-dir %s -- '
+        cmd = ('%s run --disable-sysinfo --job-results-dir %s -- '
                'optional_plugins/loader_yaml/tests/.data/two_tests.yaml'
                % (AVOCADO, self.tmpdir.name))
         res = self.run_and_check(cmd, exit_codes.AVOCADO_ALL_OK, tests,
@@ -45,7 +45,7 @@ class YamlLoaderTests(unittest.TestCase):
                 break
         else:
             self.fail("Unable to find 'JOB LOG' in:\n%s" % res)
-        cmd = ('%s run --sysinfo=off --job-results-dir %s '
+        cmd = ('%s run --disable-sysinfo --job-results-dir %s '
                '--replay %s' % (AVOCADO, self.tmpdir.name, srcjob.decode('utf-8')))
         self.run_and_check(cmd, exit_codes.AVOCADO_ALL_OK, tests, not_tests)
 

--- a/optional_plugins/varianter_cit/tests/test_basic.py
+++ b/optional_plugins/varianter_cit/tests/test_basic.py
@@ -32,7 +32,7 @@ class Run(TestCaseTmpDir):
         test_path = os.path.join(BASEDIR, 'examples',
                                  'tests', 'cit_parameters.py')
         cmd_line = (
-            '{0} --show=test run --sysinfo=off --job-results-dir={1} '
+            '{0} --show=test run --disable-sysinfo --job-results-dir={1} '
             '--cit-order-of-combinations=1 '
             '--cit-parameter-file={2} '
             '-- {3}'

--- a/optional_plugins/varianter_yaml_to_mux/tests/test_functional.py
+++ b/optional_plugins/varianter_yaml_to_mux/tests/test_functional.py
@@ -48,14 +48,14 @@ class MultiplexTests(unittest.TestCase):
         self.assertIn(b' /foo/baz/bar', result.stdout)
 
     def test_run_mplex_noid(self):
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
                     '-m examples/tests/sleeptest.py.data/sleeptest.yaml'
                     % (AVOCADO, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_JOB_FAIL
         self.run_and_check(cmd_line, expected_rc)
 
     def test_run_mplex_passtest(self):
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
                     'passtest.py -m '
                     'examples/tests/sleeptest.py.data/sleeptest.yaml'
                     % (AVOCADO, self.tmpdir.name))
@@ -69,7 +69,7 @@ class MultiplexTests(unittest.TestCase):
                       "jobdata does not contains [\"/run/*\"]\n%s" % variants)
 
     def test_run_mplex_doublepass(self):
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
                     'passtest.py passtest.py -m '
                     'examples/tests/sleeptest.py.data/sleeptest.yaml '
                     '--mux-path /foo/\\* /bar/\\* /baz/\\*'
@@ -84,7 +84,7 @@ class MultiplexTests(unittest.TestCase):
                       "does not contains %s\n%s" % (exp, variants))
 
     def test_run_mplex_failtest(self):
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
                     'passtest.py failtest.py -m '
                     'examples/tests/sleeptest.py.data/sleeptest.yaml'
                     % (AVOCADO, self.tmpdir.name))
@@ -96,7 +96,7 @@ class MultiplexTests(unittest.TestCase):
                       result.stdout)
 
     def test_run_mplex_failtest_tests_per_variant(self):
-        cmd_line = ("%s run --job-results-dir %s --sysinfo=off "
+        cmd_line = ("%s run --job-results-dir %s --disable-sysinfo "
                     "passtest.py failtest.py -m "
                     "examples/tests/sleeptest.py.data/sleeptest.yaml "
                     "--execution-order tests-per-variant"
@@ -109,7 +109,7 @@ class MultiplexTests(unittest.TestCase):
                       result.stdout)
 
     def test_run_double_mplex(self):
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
                     'passtest.py -m '
                     'examples/tests/sleeptest.py.data/sleeptest.yaml '
                     'examples/tests/sleeptest.py.data/sleeptest.yaml'
@@ -128,7 +128,7 @@ class MultiplexTests(unittest.TestCase):
                             ('/run/medium', 'ASDFASDF'),
                             ('/run/long', 'This is very long\nmultiline\ntext.')):
             variant, msg = variant_msg
-            cmd_line = ('%s --show=test run --job-results-dir %s --sysinfo=off '
+            cmd_line = ('%s --show=test run --job-results-dir %s --disable-sysinfo '
                         'examples/tests/env_variables.sh '
                         '-m examples/tests/env_variables.sh.data/env_variables.yaml '
                         '--mux-filter-only %s'
@@ -159,7 +159,7 @@ class ReplayTests(unittest.TestCase):
         self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
         cmd_line = ('%s run passtest.py '
                     '-m examples/tests/sleeptest.py.data/sleeptest.yaml '
-                    '--job-results-dir %s --sysinfo=off --json -'
+                    '--job-results-dir %s --disable-sysinfo --json -'
                     % (AVOCADO, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.run_and_check(cmd_line, expected_rc)
@@ -182,7 +182,7 @@ class ReplayTests(unittest.TestCase):
         ignored)
         """
         cmdline = ("%s run --replay %s --job-results-dir %s "
-                   "--sysinfo=off -m optional_plugins/varianter_yaml_to_mux"
+                   "--disable-sysinfo -m optional_plugins/varianter_yaml_to_mux"
                    "/tests/.data/mux-selftest.yaml"
                    % (AVOCADO, self.jobid, self.tmpdir.name))
         self.run_and_check(cmdline, exit_codes.AVOCADO_ALL_OK)
@@ -194,7 +194,7 @@ class ReplayTests(unittest.TestCase):
 class DryRun(unittest.TestCase):
 
     def test_dry_run(self):
-        cmd = ("%s run --sysinfo=off --dry-run --dry-run-no-cleanup --json - "
+        cmd = ("%s run --disable-sysinfo --dry-run --dry-run-no-cleanup --json - "
                "--mux-inject foo:1 bar:2 baz:3 foo:foo:a "
                "foo:bar:b foo:baz:c bar:bar:bar "
                "-- passtest.py failtest.py gendata.py " % AVOCADO)

--- a/selftests/functional/test_argument_parsing.py
+++ b/selftests/functional/test_argument_parsing.py
@@ -20,7 +20,7 @@ class ArgumentParsingTest(unittest.TestCase):
 
     def test_known_command_bad_choice(self):
         os.chdir(BASEDIR)
-        cmd_line = '%s run --sysinfo=foo passtest' % AVOCADO
+        cmd_line = '%s run --disable-sysinfo=foo passtest' % AVOCADO
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_FAIL
         self.assertEqual(result.exit_status, expected_rc,
@@ -28,7 +28,7 @@ class ArgumentParsingTest(unittest.TestCase):
 
     def test_known_command_bad_argument(self):
         os.chdir(BASEDIR)
-        cmd_line = '%s run --sysinfo=off --whacky-argument passtest' % AVOCADO
+        cmd_line = '%s run --disable-sysinfo --whacky-argument passtest' % AVOCADO
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_FAIL
         self.assertEqual(result.exit_status, expected_rc,
@@ -52,7 +52,7 @@ class ArgumentParsingErrorEarlyTest(unittest.TestCase):
         log_dir = data_dir.get_logs_dir()
         self.assertIsNotNone(log_dir)
         job = job_id.create_unique_job_id()
-        cmd_line = '%s run --sysinfo=off --force-job-id=%%s %%s' % AVOCADO
+        cmd_line = '%s run --disable-sysinfo --force-job-id=%%s %%s' % AVOCADO
         cmd_line %= (job, complement_args)
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, expected_rc,

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -185,7 +185,7 @@ class RunnerOperationTest(TestCaseTmpDir):
         self.assertIn('    logs     ' + mapping['logs_dir'], result.stdout_text)
 
     def test_runner_phases(self):
-        cmd_line = ('%s run --sysinfo=off --job-results-dir %s '
+        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
                     'phases.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line)
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -193,7 +193,7 @@ class RunnerOperationTest(TestCaseTmpDir):
                          "Avocado did not return rc %d:\n%s" % (expected_rc, result))
 
     def test_runner_all_ok(self):
-        cmd_line = ('%s run --sysinfo=off --job-results-dir %s '
+        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
                     'passtest.py passtest.py' % (AVOCADO, self.tmpdir.name))
         process.run(cmd_line)
         # Also check whether jobdata contains correct parameter paths
@@ -203,7 +203,7 @@ class RunnerOperationTest(TestCaseTmpDir):
                       "does not contains [\"/run/*\"]\n%s" % variants)
 
     def test_runner_failfast(self):
-        cmd_line = ('%s run --sysinfo=off --job-results-dir %s '
+        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
                     'passtest.py failtest.py passtest.py --failfast on'
                     % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
@@ -214,7 +214,7 @@ class RunnerOperationTest(TestCaseTmpDir):
                          "Avocado did not return rc %d:\n%s" % (expected_rc, result))
 
     def test_runner_ignore_missing_references_one_missing(self):
-        cmd_line = ('%s run --sysinfo=off --job-results-dir %s '
+        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
                     'passtest.py badtest.py --ignore-missing-references'
                     % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
@@ -225,7 +225,7 @@ class RunnerOperationTest(TestCaseTmpDir):
                          "Avocado did not return rc %d:\n%s" % (expected_rc, result))
 
     def test_runner_ignore_missing_references_all_missing(self):
-        cmd_line = ('%s run --sysinfo=off --job-results-dir %s '
+        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
                     'badtest.py badtest2.py --ignore-missing-references'
                     % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
@@ -249,7 +249,7 @@ class RunnerOperationTest(TestCaseTmpDir):
                      'class LocalImportTest(Test):\n'
                      '    def test(self):\n'
                      '        self.log.info(hello())\n')) as mytest:
-                    cmd_line = ("%s run --sysinfo=off --job-results-dir %s "
+                    cmd_line = ("%s run --disable-sysinfo --job-results-dir %s "
                                 "%s" % (AVOCADO, self.tmpdir.name, mytest))
                     process.run(cmd_line)
 
@@ -257,7 +257,7 @@ class RunnerOperationTest(TestCaseTmpDir):
         with script.TemporaryScript("fake_status.py",
                                     UNSUPPORTED_STATUS_TEST_CONTENTS,
                                     "avocado_unsupported_status") as tst:
-            res = process.run("%s run --sysinfo=off --job-results-dir %s %s"
+            res = process.run("%s run --disable-sysinfo --job-results-dir %s %s"
                               " --json -" % (AVOCADO, self.tmpdir.name, tst),
                               ignore_status=True)
             self.assertEqual(res.exit_status, exit_codes.AVOCADO_TESTS_FAIL)
@@ -277,7 +277,7 @@ class RunnerOperationTest(TestCaseTmpDir):
         with script.TemporaryScript("report_status_and_hang.py",
                                     REPORTS_STATUS_AND_HANG,
                                     "hanged_test_with_status") as tst:
-            res = process.run("%s run --sysinfo=off --job-results-dir %s %s "
+            res = process.run("%s run --disable-sysinfo --job-results-dir %s %s "
                               "--json - --job-timeout 1" % (AVOCADO, self.tmpdir.name, tst),
                               ignore_status=True)
             self.assertEqual(res.exit_status, exit_codes.AVOCADO_TESTS_FAIL)
@@ -299,7 +299,7 @@ class RunnerOperationTest(TestCaseTmpDir):
         with script.TemporaryScript("die_without_reporting_status.py",
                                     DIE_WITHOUT_REPORTING_STATUS,
                                     "no_status_reported") as tst:
-            res = process.run("%s run --sysinfo=off --job-results-dir %s %s "
+            res = process.run("%s run --disable-sysinfo --job-results-dir %s %s "
                               "--json -" % (AVOCADO, self.tmpdir.name, tst),
                               ignore_status=True)
             self.assertEqual(res.exit_status, exit_codes.AVOCADO_TESTS_FAIL)
@@ -311,7 +311,7 @@ class RunnerOperationTest(TestCaseTmpDir):
                           results["tests"][0]["fail_reason"])
 
     def test_runner_tests_fail(self):
-        cmd_line = ('%s run --sysinfo=off --job-results-dir %s passtest.py '
+        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s passtest.py '
                     'failtest.py passtest.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
@@ -319,7 +319,7 @@ class RunnerOperationTest(TestCaseTmpDir):
                          "Avocado did not return rc %d:\n%s" % (expected_rc, result))
 
     def test_runner_nonexistent_test(self):
-        cmd_line = ('%s run --sysinfo=off --job-results-dir '
+        cmd_line = ('%s run --disable-sysinfo --job-results-dir '
                     '%s bogustest' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_JOB_FAIL
@@ -330,7 +330,7 @@ class RunnerOperationTest(TestCaseTmpDir):
                          "Avocado did not return rc %d:\n%s" % (expected_rc, result))
 
     def test_runner_doublefail(self):
-        cmd_line = ('%s run --sysinfo=off --job-results-dir %s '
+        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
                     '--xunit - doublefail.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
@@ -345,7 +345,7 @@ class RunnerOperationTest(TestCaseTmpDir):
                       "Test did not fail with action exception:\n%s" % result.stdout)
 
     def test_uncaught_exception(self):
-        cmd_line = ("%s run --sysinfo=off --job-results-dir %s "
+        cmd_line = ("%s run --disable-sysinfo --job-results-dir %s "
                     "--json - uncaught_exception.py" % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
@@ -355,7 +355,7 @@ class RunnerOperationTest(TestCaseTmpDir):
         self.assertIn(b'"status": "ERROR"', result.stdout)
 
     def test_fail_on_exception(self):
-        cmd_line = ("%s run --sysinfo=off --job-results-dir %s "
+        cmd_line = ("%s run --disable-sysinfo --job-results-dir %s "
                     "--json - fail_on_exception.py" % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
@@ -365,7 +365,7 @@ class RunnerOperationTest(TestCaseTmpDir):
         self.assertIn(b'"status": "FAIL"', result.stdout)
 
     def test_cancel_on_exception(self):
-        cmd_line = ("%s run --sysinfo=off --job-results-dir %s "
+        cmd_line = ("%s run --disable-sysinfo --job-results-dir %s "
                     "--json - cancel_on_exception.py" % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -377,7 +377,7 @@ class RunnerOperationTest(TestCaseTmpDir):
             self.assertEqual(test['status'], 'CANCEL')
 
     def test_assert_raises(self):
-        cmd_line = ("%s run --sysinfo=off --job-results-dir %s "
+        cmd_line = ("%s run --disable-sysinfo --job-results-dir %s "
                     "-- assert.py" % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
@@ -399,7 +399,7 @@ class RunnerOperationTest(TestCaseTmpDir):
         mytest = script.Script(os.path.join(self.tmpdir.name, "mytest.py"),
                                RAISE_CUSTOM_PATH_EXCEPTION_CONTENT)
         mytest.save()
-        result = process.run("%s --show test run --sysinfo=off "
+        result = process.run("%s --show test run --disable-sysinfo "
                              "--job-results-dir %s %s"
                              % (AVOCADO, self.tmpdir.name, mytest))
         self.assertIn(b"mytest.py:SharedLibTest.test -> CancelExc: This "
@@ -408,7 +408,7 @@ class RunnerOperationTest(TestCaseTmpDir):
         self.assertNotIn(b"Failed to read queue", result.stdout)
 
     def test_runner_timeout(self):
-        cmd_line = ('%s run --sysinfo=off --job-results-dir %s '
+        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
                     '--xunit - timeouttest.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout
@@ -428,7 +428,7 @@ class RunnerOperationTest(TestCaseTmpDir):
         """
         :avocado: tags=parallel:1
         """
-        cmd_line = ('%s run --sysinfo=off --job-results-dir %s '
+        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
                     '--xunit - abort.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         excerpt = b'Test died without reporting the status.'
@@ -441,7 +441,7 @@ class RunnerOperationTest(TestCaseTmpDir):
         self.assertIn(excerpt, result.stdout)
 
     def test_silent_output(self):
-        cmd_line = ('%s --show=none run --sysinfo=off --job-results-dir %s '
+        cmd_line = ('%s --show=none run --disable-sysinfo --job-results-dir %s '
                     'passtest.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
@@ -455,7 +455,7 @@ class RunnerOperationTest(TestCaseTmpDir):
                       result.stderr)
 
     def test_empty_test_list(self):
-        cmd_line = '%s run --sysinfo=off --job-results-dir %s' % (AVOCADO,
+        cmd_line = '%s run --disable-sysinfo --job-results-dir %s' % (AVOCADO,
                                                                   self.tmpdir.name)
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_JOB_FAIL)
@@ -463,7 +463,7 @@ class RunnerOperationTest(TestCaseTmpDir):
                       b'resolved into tests', result.stderr)
 
     def test_not_found(self):
-        cmd_line = ('%s run --sysinfo=off --job-results-dir %s sbrubles'
+        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s sbrubles'
                     % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_JOB_FAIL)
@@ -471,7 +471,7 @@ class RunnerOperationTest(TestCaseTmpDir):
         self.assertNotIn(b'Unable to resolve reference', result.stdout)
 
     def test_invalid_unique_id(self):
-        cmd_line = ('%s run --sysinfo=off --job-results-dir %s --force-job-id '
+        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s --force-job-id '
                     'foobar passtest.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         self.assertNotEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
@@ -479,7 +479,7 @@ class RunnerOperationTest(TestCaseTmpDir):
         self.assertNotIn(b'needs to be a 40 digit hex', result.stdout)
 
     def test_valid_unique_id(self):
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
                     '--force-job-id 975de258ac05ce5e490648dec4753657b7ccc7d1 '
                     'passtest.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
@@ -488,7 +488,7 @@ class RunnerOperationTest(TestCaseTmpDir):
         self.assertIn(b'PASS', result.stdout)
 
     def test_automatic_unique_id(self):
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
                     'passtest.py --json -' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
@@ -503,7 +503,7 @@ class RunnerOperationTest(TestCaseTmpDir):
 
         :avocado: tags=parallel:1
         """
-        cmd_line = ('%s run --sysinfo=off --job-results-dir %s '
+        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
                     'examples/tests/passtest.py' % (AVOCADO, self.tmpdir.name))
         avocado_process = process.SubProcess(cmd_line)
         try:
@@ -520,7 +520,7 @@ class RunnerOperationTest(TestCaseTmpDir):
             avocado_process.wait()
 
     def test_dry_run(self):
-        cmd = ("%s run --sysinfo=off --dry-run --dry-run-no-cleanup --json - "
+        cmd = ("%s run --disable-sysinfo --dry-run --dry-run-no-cleanup --json - "
                "-- passtest.py failtest.py gendata.py " % AVOCADO)
         number_of_tests = 3
         result = json.loads(process.run(cmd).stdout_text)
@@ -539,7 +539,7 @@ class RunnerOperationTest(TestCaseTmpDir):
     def test_invalid_python(self):
         test = script.make_script(os.path.join(self.tmpdir.name, 'test.py'),
                                   INVALID_PYTHON_TEST)
-        cmd_line = ('%s --show test run --sysinfo=off '
+        cmd_line = ('%s --show test run --disable-sysinfo '
                     '--job-results-dir %s %s') % (AVOCADO, self.tmpdir.name, test)
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
@@ -555,7 +555,7 @@ class RunnerOperationTest(TestCaseTmpDir):
         """
         :avocado: tags=parallel:1
         """
-        cmd = "%s run --sysinfo=off --job-results-dir %%s %%s" % AVOCADO
+        cmd = "%s run --disable-sysinfo --job-results-dir %%s %%s" % AVOCADO
         cmd %= (self.tmpdir.name, READ_BINARY)
         result = process.run(cmd, timeout=10, ignore_status=True)
         self.assertLess(result.duration, 8, "Duration longer than expected."
@@ -564,7 +564,7 @@ class RunnerOperationTest(TestCaseTmpDir):
                          % result)
 
     def test_runner_test_parameters(self):
-        cmd_line = ('%s --show=test run --sysinfo=off --job-results-dir %s '
+        cmd_line = ('%s --show=test run --disable-sysinfo --job-results-dir %s '
                     '-p "sleep_length=0.01" -- sleeptest.py ' % (AVOCADO,
                                                                  self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
@@ -581,7 +581,7 @@ class RunnerOperationTest(TestCaseTmpDir):
                 TEST_OTHER_LOGGERS_CONTENT,
                 'avocado_functional_test_other_loggers') as mytest:
 
-            cmd_line = ('%s run --sysinfo=off --job-results-dir %s '
+            cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
                         '-- %s' % (AVOCADO, self.tmpdir.name, mytest))
             result = process.run(cmd_line, ignore_status=True)
             expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -599,7 +599,7 @@ class RunnerOperationTest(TestCaseTmpDir):
 class RunnerHumanOutputTest(TestCaseTmpDir):
 
     def test_output_pass(self):
-        cmd_line = ('%s run --sysinfo=off --job-results-dir %s '
+        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
                     'passtest.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -609,7 +609,7 @@ class RunnerHumanOutputTest(TestCaseTmpDir):
         self.assertIn(b'passtest.py:PassTest.test:  PASS', result.stdout)
 
     def test_output_fail(self):
-        cmd_line = ('%s run --sysinfo=off --job-results-dir %s '
+        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
                     'failtest.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
@@ -619,7 +619,7 @@ class RunnerHumanOutputTest(TestCaseTmpDir):
         self.assertIn(b'failtest.py:FailTest.test:  FAIL', result.stdout)
 
     def test_output_error(self):
-        cmd_line = ('%s run --sysinfo=off --job-results-dir %s '
+        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
                     'errortest.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
@@ -629,7 +629,7 @@ class RunnerHumanOutputTest(TestCaseTmpDir):
         self.assertIn(b'errortest.py:ErrorTest.test:  ERROR', result.stdout)
 
     def test_output_cancel(self):
-        cmd_line = ('%s run --sysinfo=off --job-results-dir %s '
+        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
                     'cancelonsetup.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -645,7 +645,7 @@ class RunnerHumanOutputTest(TestCaseTmpDir):
     def test_ugly_echo_cmd(self):
         cmd_line = ('%s --show=test run --external-runner "%s -ne" '
                     '"foo\\\\\\n\\\'\\\\\\"\\\\\\nbar/baz" --job-results-dir %s'
-                    ' --sysinfo=off' %
+                    ' --disable-sysinfo' %
                     (AVOCADO, GNU_ECHO_BINARY, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -693,7 +693,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
         self.fail_script.save()
 
     def test_simpletest_pass(self):
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off'
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo'
                     ' "%s"' % (AVOCADO, self.tmpdir.name, self.pass_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -702,7 +702,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
                          (expected_rc, result))
 
     def test_simpletest_fail(self):
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off'
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo'
                     ' %s' % (AVOCADO, self.tmpdir.name, self.fail_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
@@ -722,7 +722,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
         :avocado: tags=parallel:1
         """
         one_hundred = 'failtest.py ' * 100
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off %s'
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s'
                     % (AVOCADO, self.tmpdir.name, one_hundred))
         initial_time = time.time()
         result = process.run(cmd_line, ignore_status=True)
@@ -742,7 +742,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
         """
         sleep_fail_sleep = ('sleeptest.py ' + 'failtest.py ' * 100 +
                             'sleeptest.py')
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off %s'
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s'
                     % (AVOCADO, self.tmpdir.name, sleep_fail_sleep))
         initial_time = time.time()
         result = process.run(cmd_line, ignore_status=True)
@@ -763,7 +763,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
         # simplewarning.sh calls "avocado exec-path" which hasn't
         # access to an installed location for the libexec scripts
         os.environ['PATH'] += ":" + os.path.join(BASEDIR, 'libexec')
-        cmd_line = ('%s --show=test run --job-results-dir %s --sysinfo=off '
+        cmd_line = ('%s --show=test run --job-results-dir %s --disable-sysinfo '
                     'examples/tests/simplewarning.sh'
                     % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
@@ -790,7 +790,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
                            "[sysinfo.collectibles]\ncommands = %s"
                            % commands_path)
         cmd_line = ("%s --show all --config %s run --job-results-dir %s "
-                    "--sysinfo=on --external-runner %s -- \"'\\\"\\/|?*<>'\""
+                    "--external-runner %s -- \"'\\\"\\/|?*<>'\""
                     % (AVOCADO, config_path, self.tmpdir.name, GNU_ECHO_BINARY))
         process.run(cmd_line)
         self.assertTrue(os.path.exists(os.path.join(self.tmpdir.name, "latest",
@@ -820,7 +820,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
         test_base_dir = os.path.dirname(self.pass_script.path)
         os.chdir(test_base_dir)
         test_file_name = os.path.basename(self.pass_script.path)
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off'
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo'
                     ' "%s"' % (AVOCADO, self.tmpdir.name,
                                test_file_name))
         result = process.run(cmd_line, ignore_status=True)
@@ -837,7 +837,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
         :avocado: tags=parallel:1
         """
         proc = aexpect.Expect("%s run 60 --job-results-dir %s "
-                              "--external-runner %s --sysinfo=off "
+                              "--external-runner %s --disable-sysinfo "
                               "--job-timeout 3"
                               % (AVOCADO, self.tmpdir.name, SLEEP_BINARY))
         proc.read_until_output_matches([r"\(1/1\)"], timeout=3,
@@ -905,7 +905,7 @@ class RunnerSimpleTestStatus(TestCaseTmpDir):
                                              'avocado_simpletest_'
                                              'functional')
         warn_script.save()
-        cmd_line = ('%s --config %s run --job-results-dir %s --sysinfo=off'
+        cmd_line = ('%s --config %s run --job-results-dir %s --disable-sysinfo'
                     ' %s --json -' % (AVOCADO, self.config_file.path,
                                       self.tmpdir.name, warn_script.path))
         result = process.run(cmd_line, ignore_status=True)
@@ -918,7 +918,7 @@ class RunnerSimpleTestStatus(TestCaseTmpDir):
                                              'avocado_simpletest_'
                                              'functional')
         skip_script.save()
-        cmd_line = ('%s --config %s run --job-results-dir %s --sysinfo=off'
+        cmd_line = ('%s --config %s run --job-results-dir %s --disable-sysinfo'
                     ' %s --json -' % (AVOCADO, self.config_file.path,
                                       self.tmpdir.name, skip_script.path))
         result = process.run(cmd_line, ignore_status=True)
@@ -931,7 +931,7 @@ class RunnerSimpleTestStatus(TestCaseTmpDir):
                                               'avocado_simpletest_'
                                               'functional')
         skip2_script.save()
-        cmd_line = ('%s --config %s run --job-results-dir %s --sysinfo=off'
+        cmd_line = ('%s --config %s run --job-results-dir %s --disable-sysinfo'
                     ' %s --json -' % (AVOCADO, self.config_file.path,
                                       self.tmpdir.name, skip2_script.path))
         result = process.run(cmd_line, ignore_status=True)
@@ -961,7 +961,7 @@ class ExternalRunnerTest(TestCaseTmpDir):
         self.fail_script.save()
 
     def test_externalrunner_pass(self):
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
                     '--external-runner=/bin/sh %s'
                     % (AVOCADO, self.tmpdir.name, self.pass_script.path))
         result = process.run(cmd_line, ignore_status=True)
@@ -971,7 +971,7 @@ class ExternalRunnerTest(TestCaseTmpDir):
                          (expected_rc, result))
 
     def test_externalrunner_fail(self):
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
                     '--external-runner=/bin/sh %s'
                     % (AVOCADO, self.tmpdir.name, self.fail_script.path))
         result = process.run(cmd_line, ignore_status=True)
@@ -981,7 +981,7 @@ class ExternalRunnerTest(TestCaseTmpDir):
                          (expected_rc, result))
 
     def test_externalrunner_chdir_no_testdir(self):
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
                     '--external-runner=/bin/sh --external-runner-chdir=test %s'
                     % (AVOCADO, self.tmpdir.name, self.pass_script.path))
         result = process.run(cmd_line, ignore_status=True)
@@ -997,7 +997,7 @@ class ExternalRunnerTest(TestCaseTmpDir):
     def test_externalrunner_chdir_runner_relative(self):
         pass_abs = os.path.abspath(self.pass_script.path)
         os.chdir('/')
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
                     '--external-runner=bin/sh --external-runner-chdir=runner -- %s'
                     % (AVOCADO, self.tmpdir.name, pass_abs))
         result = process.run(cmd_line, ignore_status=True)
@@ -1007,7 +1007,7 @@ class ExternalRunnerTest(TestCaseTmpDir):
                          (expected_rc, result))
 
     def test_externalrunner_no_url(self):
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
                     '--external-runner=%s' % (AVOCADO, self.tmpdir.name, TRUE_CMD))
         result = process.run(cmd_line, ignore_status=True)
         expected_output = (b'No test references provided nor any other '
@@ -1154,7 +1154,7 @@ class PluginsTest(TestCaseTmpDir):
         """
         def run_config(config_path):
             cmd = ('%s --config %s run passtest.py --archive '
-                   '--job-results-dir %s --sysinfo=off'
+                   '--job-results-dir %s --disable-sysinfo'
                    % (AVOCADO, config_path, self.tmpdir.name))
             result = process.run(cmd, ignore_status=True)
             expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -1230,7 +1230,7 @@ class PluginsXunitTest(TestCaseTmpDir):
 
     def run_and_check(self, testname, e_rc, e_ntests, e_nerrors,
                       e_nfailures, e_nskip):
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off'
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo'
                     ' --xunit - %s' % (AVOCADO, self.tmpdir.name, testname))
         result = process.run(cmd_line, ignore_status=True)
         xml_output = result.stdout
@@ -1300,7 +1300,7 @@ class PluginsJSONTest(TestCaseTmpDir):
 
     def run_and_check(self, testname, e_rc, e_ntests, e_nerrors,
                       e_nfailures, e_nskip, e_ncancel=0, external_runner=None):
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off --json - '
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo --json - '
                     '--archive %s' % (AVOCADO, self.tmpdir.name, testname))
         if external_runner is not None:
             cmd_line += " --external-runner '%s'" % external_runner

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -204,7 +204,7 @@ class RunnerOperationTest(TestCaseTmpDir):
 
     def test_runner_failfast(self):
         cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
-                    'passtest.py failtest.py passtest.py --failfast on'
+                    'passtest.py failtest.py passtest.py --failfast'
                     % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         self.assertIn(b'Interrupting job (failfast).', result.stdout)

--- a/selftests/functional/test_export_variables.py
+++ b/selftests/functional/test_export_variables.py
@@ -36,7 +36,7 @@ class EnvironmentVariablesTest(TestCaseTmpDir):
 
     def test_environment_vars(self):
         os.chdir(BASEDIR)
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=on %s'
+        cmd_line = ('%s run --job-results-dir %s %s'
                     % (AVOCADO, self.tmpdir.name, self.script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK

--- a/selftests/functional/test_getdata.py
+++ b/selftests/functional/test_getdata.py
@@ -11,7 +11,7 @@ class GetData(TestCaseTmpDir):
 
     def test(self):
         test_path = os.path.join(BASEDIR, "selftests", ".data", "get_data.py")
-        cmd_line = "%s run --sysinfo=off --job-results-dir '%s' -- %s"
+        cmd_line = "%s run --disable-sysinfo --job-results-dir '%s' -- %s"
         cmd_line %= (AVOCADO, self.tmpdir.name, test_path)
         result = process.run(cmd_line)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
@@ -20,7 +20,7 @@ class GetData(TestCaseTmpDir):
         test_path = os.path.join(BASEDIR, "selftests", ".data", "get_data.py")
         test_variants_path = os.path.join(BASEDIR, "selftests", ".data",
                                           "get_data.py.data", "get_data.json")
-        cmd_line = ("%s run --sysinfo=off --job-results-dir '%s' "
+        cmd_line = ("%s run --disable-sysinfo --job-results-dir '%s' "
                     "--json-variants-load %s -- %s")
         cmd_line %= (AVOCADO, self.tmpdir.name, test_variants_path, test_path)
         result = process.run(cmd_line)

--- a/selftests/functional/test_interrupt.py
+++ b/selftests/functional/test_interrupt.py
@@ -112,7 +112,7 @@ class InterruptTest(TestCaseTmpDir):
         bad_test.save()
         self.test_module = bad_test.path
         os.chdir(BASEDIR)
-        cmd = ('%s run %s --sysinfo=off --job-results-dir %s ' %
+        cmd = ('%s run %s --disable-sysinfo --job-results-dir %s ' %
                (AVOCADO, self.test_module, self.tmpdir.name))
         proc = subprocess.Popen(cmd.split(),
                                 stdout=subprocess.PIPE,
@@ -160,7 +160,7 @@ class InterruptTest(TestCaseTmpDir):
         bad_test.save()
         self.test_module = bad_test.path
         os.chdir(BASEDIR)
-        cmd = ('%s run %s --sysinfo=off --job-results-dir %s ' %
+        cmd = ('%s run %s --disable-sysinfo --job-results-dir %s ' %
                (AVOCADO, self.test_module, self.tmpdir.name))
         proc = subprocess.Popen(cmd.split(),
                                 stdout=subprocess.PIPE,
@@ -200,7 +200,7 @@ class InterruptTest(TestCaseTmpDir):
         good_test.save()
         self.test_module = good_test.path
         os.chdir(BASEDIR)
-        cmd = ('%s run %s --sysinfo=off --job-results-dir %s ' %
+        cmd = ('%s run %s --disable-sysinfo --job-results-dir %s ' %
                (AVOCADO, self.test_module, self.tmpdir.name))
         proc = subprocess.Popen(cmd.split(),
                                 stdout=subprocess.PIPE,
@@ -244,7 +244,7 @@ class InterruptTest(TestCaseTmpDir):
         good_test.save()
         self.test_module = good_test.path
         os.chdir(BASEDIR)
-        cmd = ('%s run %s --sysinfo=off --job-results-dir %s ' %
+        cmd = ('%s run %s --disable-sysinfo --job-results-dir %s ' %
                (AVOCADO, self.test_module, self.tmpdir.name))
         proc = subprocess.Popen(cmd.split(),
                                 stdout=subprocess.PIPE,

--- a/selftests/functional/test_job_timeout.py
+++ b/selftests/functional/test_job_timeout.py
@@ -102,13 +102,13 @@ class JobTimeOutTest(TestCaseTmpDir):
     @skipOnLevelsInferiorThan(1)
     def test_sleep_longer_timeout(self):
         """:avocado: tags=parallel:1"""
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
                     '--xunit - --job-timeout=5 %s examples/tests/passtest.py' %
                     (AVOCADO, self.tmpdir.name, self.script.path))
         self.run_and_check(cmd_line, 0, 2, 0, 0, 0)
 
     def test_sleep_short_timeout(self):
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
                     '--xunit - --job-timeout=1 %s examples/tests/passtest.py' %
                     (AVOCADO, self.tmpdir.name, self.script.path))
         self.run_and_check(cmd_line, exit_codes.AVOCADO_JOB_INTERRUPTED,
@@ -116,7 +116,7 @@ class JobTimeOutTest(TestCaseTmpDir):
         self._check_timeout_msg(1)
 
     def test_sleep_short_timeout_with_test_methods(self):
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
                     '--xunit - --job-timeout=1 %s' %
                     (AVOCADO, self.tmpdir.name, self.py.path))
         self.run_and_check(cmd_line, exit_codes.AVOCADO_JOB_INTERRUPTED,
@@ -124,13 +124,13 @@ class JobTimeOutTest(TestCaseTmpDir):
         self._check_timeout_msg(1)
 
     def test_invalid_values(self):
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
                     '--job-timeout=1,5 examples/tests/passtest.py'
                     % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_FAIL)
         self.assertIn(b'invalid time_to_seconds value', result.stderr)
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
                     '--job-timeout=123x examples/tests/passtest.py'
                     % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
@@ -138,22 +138,22 @@ class JobTimeOutTest(TestCaseTmpDir):
         self.assertIn(b'invalid time_to_seconds', result.stderr)
 
     def test_valid_values(self):
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
                     '--job-timeout=123 examples/tests/passtest.py'
                     % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
                     '--job-timeout=123s examples/tests/passtest.py'
                     % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
                     '--job-timeout=123m examples/tests/passtest.py'
                     % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
                     '--job-timeout=123h examples/tests/passtest.py'
                     % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)

--- a/selftests/functional/test_journal.py
+++ b/selftests/functional/test_journal.py
@@ -13,7 +13,7 @@ class JournalPluginTests(TestCaseTmpDir):
 
     def setUp(self):
         super(JournalPluginTests, self).setUp()
-        self.cmd_line = ('%s run --job-results-dir %s --sysinfo=off --json - '
+        self.cmd_line = ('%s run --job-results-dir %s --disable-sysinfo --json - '
                          '--journal examples/tests/passtest.py'
                          % (AVOCADO, self.tmpdir.name))
         self.result = process.run(self.cmd_line, ignore_status=True)

--- a/selftests/functional/test_loader.py
+++ b/selftests/functional/test_loader.py
@@ -239,7 +239,7 @@ class LoaderTestFunctional(TestCaseTmpDir):
         self.assertIn(b'SIMPLE: 1', result.stdout)
         # job should be able to finish under 5 seconds. If this fails, it's
         # possible that we hit the "simple test fork bomb" bug
-        cmd_line = ("%s run --sysinfo=off --job-results-dir '%s' -- '%s'"
+        cmd_line = ("%s run --disable-sysinfo --job-results-dir '%s' -- '%s'"
                     % (AVOCADO, self.tmpdir.name, mytest))
         self._run_with_timeout(cmd_line, 5)
 
@@ -255,13 +255,13 @@ class LoaderTestFunctional(TestCaseTmpDir):
         os.chdir(BASEDIR)
         # job should be able to finish under 5 seconds. If this fails, it's
         # possible that we hit the "simple test fork bomb" bug
-        cmd_line = ("%s run --sysinfo=off --job-results-dir '%s' -- '%s'"
+        cmd_line = ("%s run --disable-sysinfo --job-results-dir '%s' -- '%s'"
                     % (AVOCADO, self.tmpdir.name, mytest))
         self._run_with_timeout(cmd_line, 5)
 
     def test_python_unittest(self):
         test_path = os.path.join(BASEDIR, "selftests", ".data", "unittests.py")
-        cmd = ("%s run --sysinfo=off --job-results-dir %s --json - -- %s"
+        cmd = ("%s run --disable-sysinfo --job-results-dir %s --json - -- %s"
                % (AVOCADO, self.tmpdir.name, test_path))
         result = process.run(cmd, ignore_status=True)
         jres = json.loads(result.stdout_text)

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -20,7 +20,7 @@ AVOCADO_QUOTED = "', '".join(shlex.split(AVOCADO))
 PERL_TAP_PARSER_SNIPPET = """#!/bin/env perl
 use TAP::Parser;
 
-my $parser = TAP::Parser->new( { exec => ['%s', 'run', 'passtest.py', 'errortest.py', 'warntest.py', '--tap', '-', '--sysinfo', 'off', '--job-results-dir', '%%s'] } );
+my $parser = TAP::Parser->new( { exec => ['%s', 'run', 'passtest.py', 'errortest.py', 'warntest.py', '--tap', '-', '--disable-sysinfo', '--job-results-dir', '%%s'] } );
 
 while ( my $result = $parser->next ) {
         $result->is_unknown && die "Unknown line \\"" . $result->as_string . "\\" in the TAP output!\n";
@@ -34,7 +34,7 @@ $parser->plan eq '1..3' || die "Plan does not match what was expected!\n";
 PERL_TAP_PARSER_FAILFAST_SNIPPET = """#!/bin/env perl
 use TAP::Parser;
 
-my $parser = TAP::Parser->new( { exec => ['%s', 'run', 'failtest.py', 'errortest.py', 'warntest.py', '--tap', '-', '--failfast', 'on', '--sysinfo', 'off', '--job-results-dir', '%%s'] } );
+my $parser = TAP::Parser->new( { exec => ['%s', 'run', 'failtest.py', 'errortest.py', 'warntest.py', '--tap', '-', '--failfast', 'on', '--disable-sysinfo', '--job-results-dir', '%%s'] } );
 
 while ( my $result = $parser->next ) {
         $result->is_unknown && die "Unknown line \\"" . $result->as_string . "\\" in the TAP output!\n";
@@ -174,7 +174,7 @@ class OutputTest(TestCaseTmpDir):
     @unittest.skipIf(missing_binary('cc'),
                      "C compiler is required by the underlying doublefree.py test")
     def test_output_doublefree(self):
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
                     'doublefree.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -208,7 +208,7 @@ class OutputTest(TestCaseTmpDir):
         test = script.Script(os.path.join(self.tmpdir.name, "output_test.py"),
                              OUTPUT_TEST_CONTENT)
         test.save()
-        result = process.run("%s run --job-results-dir %s --sysinfo=off "
+        result = process.run("%s run --job-results-dir %s --disable-sysinfo "
                              "--json - -- %s" % (AVOCADO, self.tmpdir.name, test))
         res = json.loads(result.stdout_text)
         joblog = res["debuglog"]
@@ -233,7 +233,7 @@ class OutputTest(TestCaseTmpDir):
         # the correct fix is to run the entire test process with redirected
         # stdout and stderr, and *not* play with sys.stdout and sys.stderr.
         # But this change will come later
-        result = process.run("%s run --job-results-dir %s --sysinfo=off "
+        result = process.run("%s run --job-results-dir %s --disable-sysinfo "
                              "--output-check-record=combined "
                              "--json - -- %s" % (AVOCADO, self.tmpdir.name, test))
         res = json.loads(result.stdout_text)
@@ -258,7 +258,7 @@ class OutputTest(TestCaseTmpDir):
         with script.Script(os.path.join(self.tmpdir.name, "output_mode_none.py"),
                            OUTPUT_MODE_NONE_CONTENT,
                            script.READ_ONLY_MODE) as test:
-            command = ("%s run --job-results-dir %s --sysinfo=off "
+            command = ("%s run --job-results-dir %s --disable-sysinfo "
                        "--json - --output-check-record none -- %s") % (AVOCADO,
                                                                        self.tmpdir.name,
                                                                        test.path)
@@ -282,7 +282,7 @@ class OutputTest(TestCaseTmpDir):
         with script.Script(os.path.join(self.tmpdir.name, "test_check_on_off.py"),
                            OUTPUT_CHECK_ON_OFF_CONTENT,
                            script.READ_ONLY_MODE) as test:
-            command = ("%s run --job-results-dir %s --sysinfo=off "
+            command = ("%s run --job-results-dir %s --disable-sysinfo "
                        "--json - -- %s") % (AVOCADO, self.tmpdir.name, test.path)
             result = process.run(command)
             res = json.loads(result.stdout_text)
@@ -341,7 +341,7 @@ class OutputPluginTest(TestCaseTmpDir):
         self.assertIn("\n# debug.log of ", tap)
 
     def test_output_incompatible_setup(self):
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
                     '--xunit - --json - passtest.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_FAIL
@@ -358,7 +358,7 @@ class OutputPluginTest(TestCaseTmpDir):
 
     def test_output_compatible_setup(self):
         tmpfile = tempfile.mktemp(dir=self.tmpdir.name)
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
                     '--journal --xunit %s --json - passtest.py' %
                     (AVOCADO, self.tmpdir.name, tmpfile))
         result = process.run(cmd_line, ignore_status=True)
@@ -372,7 +372,7 @@ class OutputPluginTest(TestCaseTmpDir):
 
     def test_output_compatible_setup_2(self):
         tmpfile = tempfile.mktemp(dir=self.tmpdir.name)
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
                     '--xunit - --json %s --tap-include-logs passtest.py'
                     % (AVOCADO, self.tmpdir.name, tmpfile))
         result = process.run(cmd_line, ignore_status=True)
@@ -392,7 +392,7 @@ class OutputPluginTest(TestCaseTmpDir):
         tmpfile2 = tempfile.mktemp(dir=self.tmpdir.name)
         # Verify --show=none can be supplied as app argument
         cmd_line = ('%s --show=none run --job-results-dir %s '
-                    '--sysinfo=off --xunit %s --json %s --tap-include-logs '
+                    '--disable-sysinfo --xunit %s --json %s --tap-include-logs '
                     'passtest.py' % (AVOCADO, self.tmpdir.name, tmpfile, tmpfile2))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -411,7 +411,7 @@ class OutputPluginTest(TestCaseTmpDir):
     def test_nonprintable_chars(self):
         cmd_line = ("%s run --external-runner /bin/ls "
                     "'NON_EXISTING_FILE_WITH_NONPRINTABLE_CHARS_IN_HERE\x1b' "
-                    "--job-results-dir %s --sysinfo=off --tap-include-logs"
+                    "--job-results-dir %s --disable-sysinfo --tap-include-logs"
                     % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout_text + result.stderr_text
@@ -429,7 +429,7 @@ class OutputPluginTest(TestCaseTmpDir):
         self.check_output_files(debug_log)
 
     def test_show_test(self):
-        cmd_line = ('%s --show=test run --job-results-dir %s --sysinfo=off '
+        cmd_line = ('%s --show=test run --job-results-dir %s --disable-sysinfo '
                     'passtest.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -446,7 +446,7 @@ class OutputPluginTest(TestCaseTmpDir):
     def test_silent_trumps_test(self):
         # Also verify --show=none can be supplied as run option
         cmd_line = ('%s --show=test --show=none run --job-results-dir %s '
-                    '--sysinfo=off passtest.py'
+                    '--disable-sysinfo passtest.py'
                     % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -456,7 +456,7 @@ class OutputPluginTest(TestCaseTmpDir):
         self.assertEqual(result.stdout, b"")
 
     def test_default_enabled_plugins(self):
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
                     '--tap-include-logs passtest.py'
                     % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
@@ -482,7 +482,7 @@ class OutputPluginTest(TestCaseTmpDir):
                    % os.path.relpath(self.tmpdir.name, "."))
         script.Script(config, content).save()
         cmd_line = ('%s --config %s --show all run '
-                    '--job-results-dir %s --sysinfo=off whiteboard.py '
+                    '--job-results-dir %s --disable-sysinfo whiteboard.py '
                     '--json %s' % (AVOCADO, config, self.tmpdir.name, tmpfile))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -500,7 +500,7 @@ class OutputPluginTest(TestCaseTmpDir):
     def test_gendata(self):
         tmpfile = tempfile.mktemp(dir=self.tmpdir.name)
         cmd_line = ("%s run --job-results-dir %s "
-                    "--sysinfo=off gendata.py --json %s" %
+                    "--disable-sysinfo gendata.py --json %s" %
                     (AVOCADO, self.tmpdir.name, tmpfile))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -524,7 +524,7 @@ class OutputPluginTest(TestCaseTmpDir):
     def test_redirect_output(self):
         redirected_output_path = tempfile.mktemp(dir=self.tmpdir.name)
         cmd_line = ('%s run --job-results-dir %s '
-                    '--sysinfo=off passtest.py > %s'
+                    '--disable-sysinfo passtest.py > %s'
                     % (AVOCADO, self.tmpdir.name, redirected_output_path))
         result = process.run(cmd_line, ignore_status=True, shell=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -34,7 +34,7 @@ $parser->plan eq '1..3' || die "Plan does not match what was expected!\n";
 PERL_TAP_PARSER_FAILFAST_SNIPPET = """#!/bin/env perl
 use TAP::Parser;
 
-my $parser = TAP::Parser->new( { exec => ['%s', 'run', 'failtest.py', 'errortest.py', 'warntest.py', '--tap', '-', '--failfast', 'on', '--disable-sysinfo', '--job-results-dir', '%%s'] } );
+my $parser = TAP::Parser->new( { exec => ['%s', 'run', 'failtest.py', 'errortest.py', 'warntest.py', '--tap', '-', '--failfast', '--disable-sysinfo', '--job-results-dir', '%%s'] } );
 
 while ( my $result = $parser->next ) {
         $result->is_unknown && die "Unknown line \\"" . $result->as_string . "\\" in the TAP output!\n";

--- a/selftests/functional/test_output_check.py
+++ b/selftests/functional/test_output_check.py
@@ -312,7 +312,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
         with open(stdout_file, 'wb') as stdout_file_obj:
             stdout_file_obj.write(tampered_msg)
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
-                    '--output-check=off --xunit -'
+                    '--disable-output-check --xunit -'
                     % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK

--- a/selftests/functional/test_output_check.py
+++ b/selftests/functional/test_output_check.py
@@ -142,7 +142,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
         self.output_script.save()
 
     def _check_output_record_all(self):
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off %s '
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
                     '--output-check-record all'
                     % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
@@ -158,7 +158,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
             self.assertEqual(fd_stderr.read(), STDERR)
 
     def _check_output_record_combined(self):
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off %s '
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
                     '--output-check-record combined'
                     % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
@@ -180,7 +180,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
         return (simple_test, variants_file)
 
     def test_output_record_none(self):
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off %s '
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
                     '--output-check-record none'
                     % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
@@ -192,7 +192,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
         self.assertIsNotFile("%s.data/stderr.expected" % self.output_script)
 
     def test_output_record_stdout(self):
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off %s '
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
                     '--output-check-record stdout'
                     % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
@@ -208,7 +208,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
 
     def test_output_record_and_check(self):
         self._check_output_record_all()
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off %s'
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s'
                     % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -218,7 +218,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
 
     def test_output_record_and_check_combined(self):
         self._check_output_record_combined()
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off %s'
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s'
                     % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -232,7 +232,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
         stdout_file = "%s.data/stdout.expected" % self.output_script.path
         with open(stdout_file, 'wb') as stdout_file_obj:
             stdout_file_obj.write(tampered_msg)
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off %s --xunit -'
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s --xunit -'
                     % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
@@ -247,7 +247,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
         output_file = "%s.data/output.expected" % self.output_script.path
         with open(output_file, 'wb') as output_file_obj:
             output_file_obj.write(tampered_msg)
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off %s --xunit -'
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s --xunit -'
                     % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
@@ -269,7 +269,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
         with open(stderr_file, 'wb') as stderr_file_obj:
             stderr_file_obj.write(tampered_msg_stderr)
 
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off %s --json -'
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s --json -'
                     % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
@@ -311,7 +311,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
         stdout_file = "%s.data/stdout.expected" % self.output_script.path
         with open(stdout_file, 'wb') as stdout_file_obj:
             stdout_file_obj.write(tampered_msg)
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off %s '
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
                     '--output-check=off --xunit -'
                     % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
@@ -328,7 +328,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
         simple_test = os.path.join(self.tmpdir.name, 'simpletest.py')
         with open(simple_test, 'w') as file_obj:
             file_obj.write(TEST_WITH_SAME_EXPECTED_OUTPUT)
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off %s '
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
                     '--output-check-record both --json-variants-load %s' %
                     (AVOCADO, self.tmpdir.name, simple_test, variants_file))
         process.run(cmd_line, ignore_status=True)
@@ -338,7 +338,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
     def test_merge_records_different_output(self):
         simple_test, variants_file = self._setup_simple_test(
             TEST_WITH_DIFFERENT_EXPECTED_OUTPUT)
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off %s '
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
                     '--output-check-record both --json-variants-load %s' %
                     (AVOCADO, self.tmpdir.name, simple_test, variants_file))
         process.run(cmd_line, ignore_status=True)
@@ -352,7 +352,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
     def test_merge_records_different_output_variants(self):
         simple_test, variants_file = self._setup_simple_test(
             TEST_WITH_DIFFERENT_EXPECTED_OUTPUT_VARIANTS)
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off %s '
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
                     '--output-check-record both --json-variants-load %s' %
                     (AVOCADO, self.tmpdir.name, simple_test, variants_file))
         process.run(cmd_line, ignore_status=True)
@@ -368,7 +368,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
     def test_merge_records_different_and_same_output(self):
         simple_test, variants_file = self._setup_simple_test(
             TEST_WITH_DIFFERENT_AND_SAME_EXPECTED_OUTPUT)
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off %s '
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
                     '--output-check-record both --json-variants-load %s' %
                     (AVOCADO, self.tmpdir.name, simple_test, variants_file))
         process.run(cmd_line, ignore_status=True)

--- a/selftests/functional/test_plugin_diff.py
+++ b/selftests/functional/test_plugin_diff.py
@@ -16,7 +16,7 @@ class DiffTests(TestCaseTmpDir):
         test = script.make_script(os.path.join(self.tmpdir.name, 'test'), 'exit 0')
         cmd_line = ('%s run %s '
                     '--external-runner /bin/bash '
-                    '--job-results-dir %s --sysinfo=off --json -' %
+                    '--job-results-dir %s --disable-sysinfo --json -' %
                     (AVOCADO, test, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.run_and_check(cmd_line, expected_rc)
@@ -25,7 +25,7 @@ class DiffTests(TestCaseTmpDir):
         self.tmpdir2 = tempfile.TemporaryDirectory(prefix=self.tmpdir.name)
         cmd_line = ('%s run %s '
                     '--external-runner /bin/bash '
-                    '--job-results-dir %s --sysinfo=off --json -' %
+                    '--job-results-dir %s --disable-sysinfo --json -' %
                     (AVOCADO, test, self.tmpdir2.name))
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.run_and_check(cmd_line, expected_rc)

--- a/selftests/functional/test_plugin_jobscripts.py
+++ b/selftests/functional/test_plugin_jobscripts.py
@@ -65,7 +65,7 @@ class JobScriptsTest(TestCaseTmpDir):
                                                                self.post_dir))
         with config:
             cmd = ('%s --config %s run --job-results-dir %s '
-                   '--sysinfo=off %s'
+                   '--disable-sysinfo %s'
                    % (AVOCADO, config, self.tmpdir.name, test_check_touch))
             result = process.run(cmd)
 
@@ -88,7 +88,7 @@ class JobScriptsTest(TestCaseTmpDir):
                                         SCRIPT_NON_ZERO_CFG % self.pre_dir)
         with config:
             cmd = ('%s --config %s run --job-results-dir %s '
-                   '--sysinfo=off passtest.py' % (AVOCADO, config,
+                   '--disable-sysinfo passtest.py' % (AVOCADO, config,
                                                   self.tmpdir.name))
             result = process.run(cmd)
 
@@ -111,7 +111,7 @@ class JobScriptsTest(TestCaseTmpDir):
                                         SCRIPT_NON_EXISTING_DIR_CFG % self.pre_dir)
         with config:
             cmd = ('%s --config %s run --job-results-dir %s '
-                   '--sysinfo=off passtest.py' % (AVOCADO, config,
+                   '--disable-sysinfo passtest.py' % (AVOCADO, config,
                                                   self.tmpdir.name))
             result = process.run(cmd)
 

--- a/selftests/functional/test_replay_basic.py
+++ b/selftests/functional/test_replay_basic.py
@@ -13,7 +13,7 @@ class ReplayTests(TestCaseTmpDir):
     def setUp(self):
         super(ReplayTests, self).setUp()
         cmd_line = ('%s run passtest.py passtest.py passtest.py passtest.py '
-                    '--job-results-dir %s --sysinfo=off --json -'
+                    '--job-results-dir %s --disable-sysinfo --json -'
                     % (AVOCADO, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.run_and_check(cmd_line, expected_rc)
@@ -34,7 +34,7 @@ class ReplayTests(TestCaseTmpDir):
         Runs a replay job with an invalid jobid.
         """
         cmd_line = ('%s run --replay %s '
-                    '--job-results-dir %s --sysinfo=off'
+                    '--job-results-dir %s --disable-sysinfo'
                     % (AVOCADO, 'foo', self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_FAIL
         self.run_and_check(cmd_line, expected_rc)
@@ -43,7 +43,7 @@ class ReplayTests(TestCaseTmpDir):
         """
         Runs a replay job using the 'latest' keyword.
         """
-        cmd_line = ('%s run --replay latest --job-results-dir %s --sysinfo=off'
+        cmd_line = ('%s run --replay latest --job-results-dir %s --disable-sysinfo'
                     % (AVOCADO, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.run_and_check(cmd_line, expected_rc)
@@ -63,7 +63,7 @@ class ReplayTests(TestCaseTmpDir):
         Runs a replay job.
         """
         cmd_line = ('%s run --replay %s '
-                    '--job-results-dir %s --sysinfo=off'
+                    '--job-results-dir %s --disable-sysinfo'
                     % (AVOCADO, self.jobid, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.run_and_check(cmd_line, expected_rc)
@@ -74,7 +74,7 @@ class ReplayTests(TestCaseTmpDir):
         """
         partial_id = self.jobid[:5]
         cmd_line = ('%s run --replay %s '
-                    '--job-results-dir %s --sysinfo=off'
+                    '--job-results-dir %s --disable-sysinfo'
                     % (AVOCADO, partial_id, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.run_and_check(cmd_line, expected_rc)
@@ -84,7 +84,7 @@ class ReplayTests(TestCaseTmpDir):
         Runs a replay job identifying the job by its results directory.
         """
         cmd_line = ('%s run --replay %s '
-                    '--job-results-dir %s --sysinfo=off'
+                    '--job-results-dir %s --disable-sysinfo'
                     % (AVOCADO, self.jobdir, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.run_and_check(cmd_line, expected_rc)
@@ -94,7 +94,7 @@ class ReplayTests(TestCaseTmpDir):
         Runs a replay job with an invalid option for '--replay-ignore'
         """
         cmd_line = ('%s run --replay %s --replay-ignore foo'
-                    '--job-results-dir %s --sysinfo=off'
+                    '--job-results-dir %s --disable-sysinfo'
                     % (AVOCADO, self.jobid, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_FAIL
         result = self.run_and_check(cmd_line, expected_rc)
@@ -107,7 +107,7 @@ class ReplayTests(TestCaseTmpDir):
         Runs a replay job ignoring the variants.
         """
         cmd_line = ('%s run --replay %s --replay-ignore variants '
-                    '--job-results-dir %s --sysinfo=off'
+                    '--job-results-dir %s --disable-sysinfo'
                     % (AVOCADO, self.jobid, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_ALL_OK
         result = self.run_and_check(cmd_line, expected_rc)
@@ -119,7 +119,7 @@ class ReplayTests(TestCaseTmpDir):
         Runs a replay job with an invalid option for '--replay-test-status'
         """
         cmd_line = ('%s run --replay %s --replay-test-status E '
-                    '--job-results-dir %s --sysinfo=off'
+                    '--job-results-dir %s --disable-sysinfo'
                     % (AVOCADO, self.jobid, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_FAIL
         result = self.run_and_check(cmd_line, expected_rc)
@@ -132,7 +132,7 @@ class ReplayTests(TestCaseTmpDir):
         Runs a replay job only with tests that failed.
         """
         cmd_line = ('%s run --replay %s --replay-test-status '
-                    'FAIL --job-results-dir %s --sysinfo=off'
+                    'FAIL --job-results-dir %s --disable-sysinfo'
                     % (AVOCADO, self.jobid, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_ALL_OK
         result = self.run_and_check(cmd_line, expected_rc)
@@ -146,7 +146,7 @@ class ReplayTests(TestCaseTmpDir):
         """
         cmd_line = ('%s run --replay %s --replay-ignore variants '
                     '--replay-test-status FAIL --job-results-dir %s '
-                    '--sysinfo=off' % (AVOCADO, self.jobid, self.tmpdir.name))
+                    '--disable-sysinfo' % (AVOCADO, self.jobid, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_FAIL
         result = self.run_and_check(cmd_line, expected_rc)
         msg = (b"Option `--replay-test-status` is incompatible with "
@@ -159,7 +159,7 @@ class ReplayTests(TestCaseTmpDir):
         """
         cmd_line = ('%s run sleeptest --replay %s '
                     '--replay-test-status FAIL --job-results-dir %s '
-                    '--sysinfo=off' % (AVOCADO, self.jobid, self.tmpdir.name))
+                    '--disable-sysinfo' % (AVOCADO, self.jobid, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_FAIL
         result = self.run_and_check(cmd_line, expected_rc)
         msg = (b"Option --replay-test-status is incompatible with "

--- a/selftests/functional/test_replay_external_runner.py
+++ b/selftests/functional/test_replay_external_runner.py
@@ -15,7 +15,7 @@ class ReplayExtRunnerTests(TestCaseTmpDir):
         test = script.make_script(os.path.join(self.tmpdir.name, 'test'), 'exit 0')
         cmd_line = ('%s run %s '
                     '--external-runner /bin/bash '
-                    '--job-results-dir %s --sysinfo=off --json -'
+                    '--job-results-dir %s --disable-sysinfo --json -'
                     % (AVOCADO, test, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.run_and_check(cmd_line, expected_rc)
@@ -34,7 +34,7 @@ class ReplayExtRunnerTests(TestCaseTmpDir):
     def test_run_replay_external_runner(self):
         cmd_line = ('%s run --replay %s '
                     '--external-runner /bin/sh '
-                    '--job-results-dir %s --sysinfo=off'
+                    '--job-results-dir %s --disable-sysinfo'
                     % (AVOCADO, self.jobid, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_ALL_OK
         result = self.run_and_check(cmd_line, expected_rc)

--- a/selftests/functional/test_replay_failfast.py
+++ b/selftests/functional/test_replay_failfast.py
@@ -13,7 +13,7 @@ class ReplayFailfastTests(TestCaseTmpDir):
     def setUp(self):
         super(ReplayFailfastTests, self).setUp()
         cmd_line = ('%s run passtest.py failtest.py passtest.py '
-                    '--failfast on --job-results-dir %s --disable-sysinfo --json -'
+                    '--failfast --job-results-dir %s --disable-sysinfo --json -'
                     % (AVOCADO, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL | exit_codes.AVOCADO_JOB_INTERRUPTED
         self.run_and_check(cmd_line, expected_rc)
@@ -30,14 +30,14 @@ class ReplayFailfastTests(TestCaseTmpDir):
         return result
 
     def test_run_replay_failfast(self):
-        cmd_line = ('%s run --replay %s --failfast on '
+        cmd_line = ('%s run --replay %s --failfast '
                     '--job-results-dir %s --disable-sysinfo'
                     % (AVOCADO, self.jobid, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL | exit_codes.AVOCADO_JOB_INTERRUPTED
         self.run_and_check(cmd_line, expected_rc)
 
     def test_run_replay_disable_failfast(self):
-        cmd_line = ('%s run --replay %s --failfast off '
+        cmd_line = ('%s run --replay %s '
                     '--job-results-dir %s --disable-sysinfo'
                     % (AVOCADO, self.jobid, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL

--- a/selftests/functional/test_replay_failfast.py
+++ b/selftests/functional/test_replay_failfast.py
@@ -13,7 +13,7 @@ class ReplayFailfastTests(TestCaseTmpDir):
     def setUp(self):
         super(ReplayFailfastTests, self).setUp()
         cmd_line = ('%s run passtest.py failtest.py passtest.py '
-                    '--failfast on --job-results-dir %s --sysinfo=off --json -'
+                    '--failfast on --job-results-dir %s --disable-sysinfo --json -'
                     % (AVOCADO, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL | exit_codes.AVOCADO_JOB_INTERRUPTED
         self.run_and_check(cmd_line, expected_rc)
@@ -31,14 +31,14 @@ class ReplayFailfastTests(TestCaseTmpDir):
 
     def test_run_replay_failfast(self):
         cmd_line = ('%s run --replay %s --failfast on '
-                    '--job-results-dir %s --sysinfo=off'
+                    '--job-results-dir %s --disable-sysinfo'
                     % (AVOCADO, self.jobid, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL | exit_codes.AVOCADO_JOB_INTERRUPTED
         self.run_and_check(cmd_line, expected_rc)
 
     def test_run_replay_disable_failfast(self):
         cmd_line = ('%s run --replay %s --failfast off '
-                    '--job-results-dir %s --sysinfo=off'
+                    '--job-results-dir %s --disable-sysinfo'
                     % (AVOCADO, self.jobid, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         result = self.run_and_check(cmd_line, expected_rc)

--- a/selftests/functional/test_skiptests.py
+++ b/selftests/functional/test_skiptests.py
@@ -227,7 +227,7 @@ class TestSkipDecorators(TestCaseTmpDir):
     def test_skip_decorators(self):
         cmd_line = [AVOCADO,
                     'run',
-                    '--sysinfo=off',
+                    '--disable-sysinfo',
                     '--job-results-dir',
                     '%s' % self.tmpdir.name,
                     '%s' % self.test_module,
@@ -246,7 +246,7 @@ class TestSkipDecorators(TestCaseTmpDir):
     def test_skip_class_decorators(self):
         cmd_line = [AVOCADO,
                     'run',
-                    '--sysinfo=off',
+                    '--disable-sysinfo',
                     '--job-results-dir',
                     '%s' % self.tmpdir.name,
                     '%s' % self.class_module,
@@ -265,7 +265,7 @@ class TestSkipDecorators(TestCaseTmpDir):
     def test_skipIf_class_decorators(self):
         cmd_line = [AVOCADO,
                     'run',
-                    '--sysinfo=off',
+                    '--disable-sysinfo',
                     '--job-results-dir',
                     '%s' % self.tmpdir.name,
                     '%s' % self.class_if_module,
@@ -280,7 +280,7 @@ class TestSkipDecorators(TestCaseTmpDir):
     def test_skipUnless_class_decorators(self):
         cmd_line = [AVOCADO,
                     'run',
-                    '--sysinfo=off',
+                    '--disable-sysinfo',
                     '--job-results-dir',
                     '%s' % self.tmpdir.name,
                     '%s' % self.class_unless_module,
@@ -295,7 +295,7 @@ class TestSkipDecorators(TestCaseTmpDir):
     def test_skip_setup(self):
         cmd_line = [AVOCADO,
                     'run',
-                    '--sysinfo=off',
+                    '--disable-sysinfo',
                     '--job-results-dir',
                     '%s' % self.tmpdir.name,
                     '%s' % self.skip_setup,
@@ -308,7 +308,7 @@ class TestSkipDecorators(TestCaseTmpDir):
     def test_skip_teardown(self):
         cmd_line = [AVOCADO,
                     'run',
-                    '--sysinfo=off',
+                    '--disable-sysinfo',
                     '--job-results-dir',
                     '%s' % self.tmpdir.name,
                     '%s' % self.bad_teardown,

--- a/selftests/functional/test_statuses.py
+++ b/selftests/functional/test_statuses.py
@@ -132,7 +132,7 @@ class TestStatuses(TestCaseTmpDir):
                                                  ".data",
                                                  'test_statuses.py'))
 
-        cmd = ('%s run %s --sysinfo=off --job-results-dir %s --json -' %
+        cmd = ('%s run %s --disable-sysinfo --job-results-dir %s --json -' %
                (AVOCADO, test_file, self.tmpdir.name))
 
         results = process.run(cmd, ignore_status=True)

--- a/selftests/functional/test_streams.py
+++ b/selftests/functional/test_streams.py
@@ -39,10 +39,10 @@ class StreamsTest(TestCaseTmpDir):
         Also checks the symmetry between `--show early` and the environment
         variable `AVOCADO_LOG_EARLY` being set.
         """
-        cmds = (('%s --show early run --sysinfo=off '
+        cmds = (('%s --show early run --disable-sysinfo '
                  '--job-results-dir %s passtest.py' % (AVOCADO, self.tmpdir.name),
                  {}),
-                ('%s run --sysinfo=off --job-results-dir'
+                ('%s run --disable-sysinfo --job-results-dir'
                  ' %s passtest.py' % (AVOCADO, self.tmpdir.name),
                  {'AVOCADO_LOG_EARLY': 'y'}))
         for cmd, env in cmds:
@@ -57,7 +57,7 @@ class StreamsTest(TestCaseTmpDir):
         """
         Checks that the test stream (early in this case) goes to stdout
         """
-        cmd = ('%s --show=test run --sysinfo=off --job-results-dir %s '
+        cmd = ('%s --show=test run --disable-sysinfo --job-results-dir %s '
                'passtest.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
@@ -73,7 +73,7 @@ class StreamsTest(TestCaseTmpDir):
         """
         Checks that only errors are output, and that they go to stderr
         """
-        cmd = ('%s --show none run --sysinfo=off --job-results-dir %s '
+        cmd = ('%s --show none run --disable-sysinfo --job-results-dir %s '
                'passtest.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)

--- a/selftests/functional/test_sysinfo.py
+++ b/selftests/functional/test_sysinfo.py
@@ -18,7 +18,7 @@ commands = %s
 class SysInfoTest(TestCaseTmpDir):
 
     def test_sysinfo_enabled(self):
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=on '
+        cmd_line = ('%s run --job-results-dir %s '
                     'passtest.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line)
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -46,7 +46,7 @@ class SysInfoTest(TestCaseTmpDir):
             self.assertTrue(os.path.exists(sysinfo_subdir), msg)
 
     def test_sysinfo_disabled(self):
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off passtest.py'
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo passtest.py'
                     % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line)
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -68,7 +68,7 @@ class SysInfoTest(TestCaseTmpDir):
 
     def test_sysinfo_html_output(self):
         html_output = "{}/output.html".format(self.tmpdir.name)
-        cmd_line = ('{} run --html {} --job-results-dir {} --sysinfo=on '
+        cmd_line = ('{} run --html {} --job-results-dir {} '
                     'passtest.py'.format(AVOCADO, html_output,
                                          self.tmpdir.name))
         result = process.run(cmd_line)
@@ -91,7 +91,7 @@ class SysInfoTest(TestCaseTmpDir):
         script.make_script(config_path,
                            COMMANDS_TIMEOUT_CONF % (timeout, commands_path))
         cmd_line = ("%s --show all --config %s run --job-results-dir %s "
-                    "--sysinfo=on passtest.py"
+                    "passtest.py"
                     % (AVOCADO, config_path, self.tmpdir.name))
         result = process.run(cmd_line)
         if timeout > 0:

--- a/selftests/functional/test_teststmpdir.py
+++ b/selftests/functional/test_teststmpdir.py
@@ -57,7 +57,7 @@ class TestsTmpDirTests(TestCaseTmpDir):
         Tests whether automatically created teststmpdir is shared across
         all tests.
         """
-        cmd_line = ("%s run --sysinfo=off "
+        cmd_line = ("%s run --disable-sysinfo "
                     "--job-results-dir %s %s %s"
                     % (AVOCADO, self.tmpdir.name, self.simple_test,
                        self.instrumented_test))
@@ -69,7 +69,7 @@ class TestsTmpDirTests(TestCaseTmpDir):
         avocado
         """
         with tempfile.TemporaryDirectory(dir=self.tmpdir.name) as shared_tmp:
-            cmd = ("%s run --sysinfo=off --job-results-dir %s %%s"
+            cmd = ("%s run --disable-sysinfo --job-results-dir %s %%s"
                    % (AVOCADO, self.tmpdir.name))
             self.run_and_check(cmd % self.simple_test, exit_codes.AVOCADO_ALL_OK,
                                {test.COMMON_TMPDIR_NAME: shared_tmp})

--- a/selftests/functional/test_wrapper.py
+++ b/selftests/functional/test_wrapper.py
@@ -46,7 +46,7 @@ class WrapperTest(TestCaseTmpDir):
                      "C compiler is required by the underlying datadir.py test")
     def test_global_wrapper(self):
         os.chdir(BASEDIR)
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off --wrapper %s '
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo --wrapper %s '
                     'examples/tests/datadir.py'
                     % (AVOCADO, self.tmpdir.name, self.script.path))
         result = process.run(cmd_line, ignore_status=True)
@@ -63,7 +63,7 @@ class WrapperTest(TestCaseTmpDir):
                      "C compiler is required by the underlying datadir.py test")
     def test_process_wrapper(self):
         os.chdir(BASEDIR)
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off '
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
                     '--wrapper %s:*/datadir examples/tests/datadir.py'
                     % (AVOCADO, self.tmpdir.name, self.script.path))
         result = process.run(cmd_line, ignore_status=True)
@@ -80,7 +80,7 @@ class WrapperTest(TestCaseTmpDir):
                      "C compiler is required by the underlying datadir.py test")
     def test_both_wrappers(self):
         os.chdir(BASEDIR)
-        cmd_line = ('%s run --job-results-dir %s --sysinfo=off --wrapper %s '
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo --wrapper %s '
                     '--wrapper %s:*/datadir examples/tests/datadir.py'
                     % (AVOCADO, self.tmpdir.name, self.dummy.path,
                        self.script.path))


### PR DESCRIPTION
While working on the new Job Replay plugin (`avocado replay`), I found out that I'd have to:

* Replicate the warnings about such options to the new command
* Think of how `--failfast=off` would behave on the new replayed job

So I decided to remove the warnings once and for all by converting all options, and simplifying the handling (and capability) of the `failfast` option on replayed jobs on specific scenarios.

---

Changes from v1 (#4066):
 * Kept documentation section about options that still take on/off