### PR TITLE
avocado.utils.vmimage: add openEuler support

### DIFF
--- a/avocado/utils/vmimage.py
+++ b/avocado/utils/vmimage.py
@@ -395,6 +395,32 @@ class CirrOSImageProvider(ImageProviderBase):
         self.image_pattern = 'cirros-{version}-{arch}-disk.img$'
 
 
+class OpenEulerImageProvider(ImageProviderBase):
+    """OpenEuler Image Provider."""
+
+    name = 'openEuler'
+
+    def __init__(self, version=r'[0-9]+\.[0-9]+(\-LTS)?',
+                 build=None, arch=DEFAULT_ARCH):
+        super(OpenEulerImageProvider, self).__init__(version=version, build=build, arch=arch)
+        self.url_versions = 'https://repo.openeuler.org/'
+        self.url_images = self.url_versions + 'openEuler-{version}/virtual_machine_img/{arch}/'
+        self.image_pattern = 'openEuler-(?P<version>{version}).(?P<arch>{arch}).qcow2.xz$'
+
+    @property
+    def version_pattern(self):
+        return '^openEuler-%s' % self._version
+
+    def get_versions(self):
+        parser = VMImageHtmlParser(self.version_pattern)
+        self._feed_html_parser(self.url_versions, parser)
+        result = []
+        for version in parser.items:
+            if version.startswith('openEuler-'):
+                result.append(version[10:])
+        return result
+
+
 class Image:
     def __init__(self, name, url, version, arch, build, checksum, algorithm,
                  cache_dir, snapshot_dir=None):

--- a/selftests/pre_release/tests/vmimage.py.data/variants.yml
+++ b/selftests/pre_release/tests/vmimage.py.data/variants.yml
@@ -85,6 +85,17 @@ distro: !mux
       42.3:
         !filter-out : /run/architectures/aarch64
         version: 42.3
+  openeuler:
+    name: openeuler
+    !filter-out : /run/architectures/arm
+    !filter-out : /run/architectures/i386
+    !filter-out : /run/architectures/ppc
+    !filter-out : /run/architectures/ppc64
+    !filter-out : /run/architectures/ppc64le
+    !filter-out : /run/architectures/s390x
+    version:
+      20.03-LTS:
+        version: 20.03-LTS
 
 architectures: !mux
   arm:


### PR DESCRIPTION
Given that Avocado has received support for detecting the same familiy
of distributions, let's also add support for getting the images.

The test for this implementation is present as a pre-release test,
and can be run with:

   $ avocado run -m selftests/pre_release/tests/vmimage.py.data/variants.yml \
     --mux-filter-only '/run/distro/openeuler' \
     selftests/pre_release/tests/vmimage.py

Signed-off-by: Cleber Rosa <crosa@redhat.com>