### PR TITLE
Migrate the kvm-unit-tests repository to the link currently in use

### DIFF
--- a/contrib/testsuites/run-kvm-unit-test.sh
+++ b/contrib/testsuites/run-kvm-unit-test.sh
@@ -59,7 +59,7 @@ done
 [ "$KVM_UNIT_TEST" ] || KVM_UNIT_TEST="$(mktemp -d)"
 [ -d "$KVM_UNIT_TEST" ] || { mkdir -p "$KVM_UNIT_TEST"; CLEAN_DIR=true; }
 cd "$KVM_UNIT_TEST"
-[ -f "configure" ] || git clone --depth 1 -q git://git.kernel.org/pub/scm/virt/kvm/kvm-unit-tests.git .
+[ -f "configure" ] || git clone --depth 1 -q https://gitlab.com/kvm-unit-tests/kvm-unit-tests.git .
 
 # Compile kvm-unit-test as standalone to get tests as separate files
 ./configure $ENDIAN $CONFIGURE_ARGS || { echo Fail to configure kvm-unit-test; exit -1; }


### PR DESCRIPTION
git://git.kernel.org/pub/scm/virt/kvm/kvm-unit-tests is not used
anymore, use https://gitlab.com/kvm-unit-tests/kvm-unit-tests instead.

Signed-off-by: Yihuang Yu <yihyu@redhat.com>