### PR TITLE
future.settings: fixed problem with the settings loading order

### DIFF
--- a/avocado/__init__.py
+++ b/avocado/__init__.py
@@ -25,6 +25,13 @@ __all__ = ['Test',
            'TestCancel']
 
 
+from avocado.core import register_core_options, initialize_plugins
+from avocado.core.future.settings import settings
+
+register_core_options()
+settings.merge_with_configs()
+initialize_plugins()
+
 from avocado.core.decorators import (cancel_on, fail_on, skip, skipIf,
                                      skipUnless)
 from avocado.core.exceptions import TestCancel, TestError, TestFail

--- a/avocado/core/__init__.py
+++ b/avocado/core/__init__.py
@@ -190,7 +190,3 @@ def initialize_plugin_infrastructure():
 def initialize_plugins():
     initialize_plugin_infrastructure()
     InitDispatcher().map_method('initialize')
-
-
-register_core_options()
-initialize_plugins()

--- a/selftests/isort.sh
+++ b/selftests/isort.sh
@@ -3,4 +3,5 @@
 isort --recursive --check-only \
       --skip selftests/.data/loader_instrumented/dont_crash.py \
       --skip selftests/.data/loader_instrumented/double_import.py \
-      --skip selftests/.data/loader_instrumented/dont_detect_non_avocado.py
+      --skip selftests/.data/loader_instrumented/dont_detect_non_avocado.py \
+      --skip avocado/__init__.py


### PR DESCRIPTION
We need to move the initialization steps even earlier to accommodate a few options that are used during the import time. IMO, this is not the best approach, but a temporary fix to #4071 and #4081 before LTS.