### PR TITLE
Vmimage automatic documentation [v2]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ docs/source/api/test
 docs/source/api/utils
 docs/source/api/plugins
 docs/source/api/optional-plugins
+docs/source/guides/writer/libs/data/vmimage
 
 # This file should be generated with:
 # avocado config reference > docs/source/config/reference.rst

--- a/docs/source/guides/writer/libs/vmimage.rst
+++ b/docs/source/guides/writer/libs/vmimage.rst
@@ -102,3 +102,14 @@ with::
 
         def test(self):
             ...
+
+Supported images
+----------------
+The vmimage library has no hardcoded limitations of versions or architectures
+that can be supported. You can use it as you wish. This is the list of images
+that we tested and they work with vmimage:
+
+
+.. csv-table::
+    :file: ./data/vmimage/supported_images.csv
+    :header-rows: 1


### PR DESCRIPTION
This generates a documentation table with every tested distribution for
vmimage.

Signed-off-by: Jan Richter <jarichte@redhat.com>

---
Changes from v1 #4088:

- `docs/source/guides/writer/libs/vmimage.rst.data` in .gitingnore file
- import in top of file
