### PR TITLE
future.settings: fix custom configs after plugins load too

### DIFF
--- a/avocado/__init__.py
+++ b/avocado/__init__.py
@@ -31,6 +31,7 @@ from avocado.core.settings import settings
 register_core_options()
 settings.merge_with_configs()
 initialize_plugins()
+settings.merge_with_configs()
 
 from avocado.core.decorators import (cancel_on, fail_on, skip, skipIf,
                                      skipUnless)


### PR DESCRIPTION
Some plugins have custom configs we need to parse this as soon plugins
are loaded.

Signed-off-by: Beraldo Leal <bleal@redhat.com>
Signed-off-by: Plamen Dimitrov <pdimitrov@pevogam.com>
