### PR TITLE
nrunner: fix path when loading python unit tests

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -468,6 +468,7 @@ class PythonUnittestRunner(BaseRunner):
 
     @staticmethod
     def _run_unittest(uri, queue):
+        sys.path.insert(0, ".")
         stream = io.StringIO()
         unittest_name = PythonUnittestRunner._uri_to_unittest_name(uri)
         suite = unittest.TestLoader().loadTestsFromName(unittest_name)


### PR DESCRIPTION
The current runner loader/discovery method is a custom build and finds
modules/tests recursively on the current folder. With the new runner,
part of the python unittest discover was delegated to
'loadTestsFromName()' on the standard library that uses a different
logic for this (assumes that we need to import the test). Because of
that we need 1) create a custom base loader here, or 2) prepend the path
with the current dir so loadTestsFromName will return a valid test
suite.

This might not be the perfect solution but was a hot-fix found for LTS.
Fixes #3851

Reference: https://docs.python.org/3/library/unittest.html#unittest.TestLoader.loadTestsFromName
Signed-off-by: Beraldo Leal <bleal@redhat.com>