### PR TITLE
Resolver: ignore references to directories not resolved

### DIFF
--- a/avocado/core/resolver.py
+++ b/avocado/core/resolver.py
@@ -198,6 +198,10 @@ def resolve(references, hint=None, ignore_missing=True):
                        res.reference == reference]
             if ReferenceResolutionResult.SUCCESS not in results:
                 missing.append(reference)
+        # directories are automatically expanded, and thus they can
+        # not be considered a reference that needs to exist after the
+        # resolution process
+        missing = [_ for _ in missing if not os.path.isdir(_)]
         if missing:
             msg = "Could not resolve references: %s" % ",".join(missing)
             raise JobTestSuiteReferenceResolutionError(msg)

--- a/avocado/core/suite.py
+++ b/avocado/core/suite.py
@@ -2,7 +2,8 @@ from enum import Enum
 from uuid import uuid4
 
 from .dispatcher import RunnerDispatcher
-from .exceptions import OptionValidationError
+from .exceptions import (JobTestSuiteReferenceResolutionError,
+                         OptionValidationError)
 from .loader import LoaderError, LoaderUnhandledReferenceError, loader
 from .resolver import resolve
 from .settings import settings
@@ -81,7 +82,11 @@ class TestSuite:
     def _from_config_with_resolver(cls, config, name=None):
         ignore_missing = config.get('run.ignore_missing_references')
         references = config.get('run.references')
-        resolutions = resolve(references, ignore_missing=ignore_missing)
+        try:
+            resolutions = resolve(references, ignore_missing=ignore_missing)
+        except JobTestSuiteReferenceResolutionError as details:
+            raise TestSuiteError(details)
+
         tasks = resolutions_to_tasks(resolutions, config)
 
         return cls(name=name or str(uuid4()),


### PR DESCRIPTION
Because of the automatic expansion of directories entries, it's not
expected that directories themselves will have their resolutions.

Reference: https://github.com/avocado-framework/avocado/issues/4094
Signed-off-by: Cleber Rosa <crosa@redhat.com>