### PR TITLE
Logging fix

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -173,8 +173,8 @@ class Job:
         return self._result_events_dispatcher
 
     def __enter__(self):
-        self.setup()
         output.reconfigure(self.config)
+        self.setup()
         return self
 
     def __exit__(self, _exc_type, _exc_value, _traceback):


### PR DESCRIPTION
After #4057 the systems stop logging messages from root logger. This has
happened because `Job` manipulates with loggers directly and not uses
`core.output`. This is just a hotfix and this problem has to be solved better
in the future.

Signed-off-by: Jan Richter <jarichte@redhat.com>