### PR TITLE
N(ext) Runner + Job: prep work

### DIFF
--- a/avocado/core/magic.py
+++ b/avocado/core/magic.py
@@ -1,0 +1,17 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat, Inc. 2020
+# Author: Cleber Rosa <crosa@redhat.com>
+
+
+#: Magic number used to check that an "avocado" command is indeed
+#: present and matches one's expectations
+MAGIC = "971dfda4234b6abbea36ed1e939664f45c0190b234918d627449c8b578f8072e"

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -687,7 +687,7 @@ class Task:
         :returns: the arguments that can be used on an avocado-runner command
         :rtype: list
         """
-        args = ['-i', self.identifier]
+        args = ['-i', str(self.identifier)]
         args += self.runnable.get_command_args()
 
         for status_service in self.status_services:

--- a/avocado/core/plugin_interfaces.py
+++ b/avocado/core/plugin_interfaces.py
@@ -266,9 +266,17 @@ class Spawner(Plugin):
 
     @staticmethod
     @abc.abstractmethod
-    def is_task_alive(task):
-        """Determines if a task is alive or not."""
+    def is_task_alive(task_info):
+        """Determines if a task is alive or not.
+
+        :param task_info: wrapper for a Task with additional runtime information
+        :type task_info: :class:`avocado.core.task.info.TaskInfo`
+        """
 
     @abc.abstractmethod
-    async def spawn_task(self, task):
-        """Spawns a task return whether the spawning was successful."""
+    async def spawn_task(self, task_info):
+        """Spawns a task return whether the spawning was successful.
+
+        :param task_info: wrapper for a Task with additional runtime information
+        :type task_info: :class:`avocado.core.task.info.TaskInfo`
+        """

--- a/avocado/core/plugin_interfaces.py
+++ b/avocado/core/plugin_interfaces.py
@@ -280,3 +280,11 @@ class Spawner(Plugin):
         :param task_info: wrapper for a Task with additional runtime information
         :type task_info: :class:`avocado.core.task.info.TaskInfo`
         """
+
+    @abc.abstractmethod
+    async def wait_task(self, task_info):
+        """Waits for a task to finish.
+
+        :param task_info: wrapper for a Task with additional runtime information
+        :type task_info: :class:`avocado.core.task.info.TaskInfo`
+        """

--- a/avocado/core/plugin_interfaces.py
+++ b/avocado/core/plugin_interfaces.py
@@ -288,3 +288,12 @@ class Spawner(Plugin):
         :param task_info: wrapper for a Task with additional runtime information
         :type task_info: :class:`avocado.core.task.info.TaskInfo`
         """
+
+    @staticmethod
+    @abc.abstractmethod
+    async def check_task_requirements(task_info):
+        """Checks if the requirements described within a task are available.
+
+        :param task_info: wrapper for a Task with additional runtime information
+        :type task_info: :class:`avocado.core.task.info.TaskInfo`
+        """

--- a/avocado/core/requirements.py
+++ b/avocado/core/requirements.py
@@ -1,0 +1,98 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2020
+# Authors: Cleber Rosa <crosa@redhat.com>
+
+"""
+Test requirements module.
+"""
+
+import os
+import sqlite3
+
+from .data_dir import get_datafile_path
+
+#: The location of the requirements cache database
+CACHE_DATABASE_PATH = get_datafile_path('cache', 'requirements.sqlite')
+
+#: The definition of the databse schema
+SCHEMA = [
+    'CREATE TABLE IF NOT EXISTS requirement_type (requirement_type TEXT UNIQUE)',
+    'CREATE TABLE IF NOT EXISTS environment_type (environment_type TEXT UNIQUE)',
+    ('CREATE TABLE IF NOT EXISTS environment ('
+     'environment_type TEXT,'
+     'environment TEXT,'
+     'FOREIGN KEY(environment_type) REFERENCES '
+     'environment_type(environment_type)'
+     ')'),
+    ('CREATE UNIQUE INDEX IF NOT EXISTS '
+     'environment_idx ON environment (environment, environment_type)'),
+    ('CREATE TABLE IF NOT EXISTS requirement ('
+     'environment_type TEXT,'
+     'environment TEXT,'
+     'requirement_type TEXT,'
+     'requirement TEXT,'
+     'FOREIGN KEY(environment_type) REFERENCES environment(environment_type),'
+     'FOREIGN KEY(environment) REFERENCES environment(environment),'
+     'FOREIGN KEY(requirement_type) REFERENCES requirement_type(requirement_type)'
+     ')'),
+    ('CREATE UNIQUE INDEX IF NOT EXISTS requirement_idx ON requirement '
+     '(environment_type, environment, requirement_type, requirement)')
+]
+
+
+def _create_requirement_cache_db():
+    with sqlite3.connect(CACHE_DATABASE_PATH) as conn:
+        cursor = conn.cursor()
+        for entry in SCHEMA:
+            _ = cursor.execute(entry)
+        conn.commit()
+
+
+def set_requirement_on_cache(environment_type, environment,
+                             requirement_type, requirement):
+    if not os.path.exists(CACHE_DATABASE_PATH):
+        _create_requirement_cache_db()
+
+    with sqlite3.connect(CACHE_DATABASE_PATH) as conn:
+        cursor = conn.cursor()
+        sql = "INSERT OR IGNORE INTO environment_type VALUES (?)"
+        cursor.execute(sql, (environment_type, ))
+        sql = "INSERT OR IGNORE INTO environment VALUES (?, ?)"
+        cursor.execute(sql, (environment_type, environment))
+        sql = "INSERT OR IGNORE INTO requirement_type VALUES (?)"
+        cursor.execute(sql, (requirement_type, ))
+        sql = "INSERT OR IGNORE INTO requirement VALUES (?, ?, ?, ?)"
+        cursor.execute(sql, (environment_type, environment,
+                             requirement_type, requirement))
+    conn.commit()
+
+
+def get_requirement_on_cache(environment_type, environment,
+                             requirement_type, requirement):
+    if not os.path.exists(CACHE_DATABASE_PATH):
+        return False
+
+    sql = ("SELECT COUNT(*) FROM requirement WHERE ("
+           "environment_type = ? AND "
+           "environment = ? AND "
+           "requirement_type = ? AND "
+           "requirement = ?)")
+
+    with sqlite3.connect(CACHE_DATABASE_PATH) as conn:
+        cursor = conn.cursor()
+        result = cursor.execute(sql, (environment_type, environment,
+                                      requirement_type, requirement))
+        row = result.fetchone()
+        if row is not None:
+            return row[0] == 1
+    return False

--- a/avocado/core/spawners/mock.py
+++ b/avocado/core/spawners/mock.py
@@ -16,29 +16,29 @@ class MockSpawner(Spawner):
     def __init__(self):
         self._known_tasks = {}
 
-    def is_task_alive(self, task):
-        alive = self._known_tasks.get(task, None)
+    def is_task_alive(self, task_info):
+        alive = self._known_tasks.get(task_info, None)
         # task was never spawned
         if alive is None:
             return False
         # task was spawned and should signal it's alive for the first time
         if alive:
-            self._known_tasks[task] = False
+            self._known_tasks[task_info] = False
             return True
         else:
             # signal it's *not* alive after first check
             return False
 
-    async def spawn_task(self, task):
-        self._known_tasks[task] = True
+    async def spawn_task(self, task_info):
+        self._known_tasks[task_info] = True
         return True
 
 
 class MockRandomAliveSpawner(MockSpawner):
     """A mocking spawner that simulates randomness about tasks being alive."""
 
-    def is_task_alive(self, task):
-        alive = self._known_tasks.get(task, None)
+    def is_task_alive(self, task_info):
+        alive = self._known_tasks.get(task_info, None)
         # task was never spawned
         if alive is None:
             return False

--- a/avocado/core/spawners/mock.py
+++ b/avocado/core/spawners/mock.py
@@ -40,6 +40,9 @@ class MockSpawner(Spawner):
                 return
             await asyncio.sleep(0.1)
 
+    @staticmethod
+    async def check_task_requirements(task_info):
+        return True
 
 
 class MockRandomAliveSpawner(MockSpawner):

--- a/avocado/core/spawners/mock.py
+++ b/avocado/core/spawners/mock.py
@@ -1,3 +1,4 @@
+import asyncio
 import random
 
 from ...core.plugin_interfaces import Spawner
@@ -32,6 +33,13 @@ class MockSpawner(Spawner):
     async def spawn_task(self, task_info):
         self._known_tasks[task_info] = True
         return True
+
+    async def wait_task(self, task_info):
+        while True:
+            if self.is_task_alive(task_info):
+                return
+            await asyncio.sleep(0.1)
+
 
 
 class MockRandomAliveSpawner(MockSpawner):

--- a/avocado/core/status/repo.py
+++ b/avocado/core/status/repo.py
@@ -32,7 +32,8 @@ class StatusRepo:
         result = message.get('result')
         if result not in self._by_result:
             self._by_result[result] = []
-        self._by_result[result].append(message['id'])
+        if message['id'] not in self._by_result[result]:
+            self._by_result[result].append(message['id'])
 
     def _set_task_data(self, message):
         """Appends all data on message to an entry keyed by the task's ID."""

--- a/avocado/core/status/repo.py
+++ b/avocado/core/status/repo.py
@@ -64,3 +64,7 @@ class StatusRepo:
         raw_message = raw_message.strip()
         message = json_loads(raw_message)
         self.process_message(message)
+
+    @property
+    def result_stats(self):
+        return {result: len(self._by_result[result]) for result in self._by_result}

--- a/avocado/core/status/repo.py
+++ b/avocado/core/status/repo.py
@@ -45,6 +45,10 @@ class StatusRepo:
         """Returns all data on a given task, by its ID."""
         return self._all_data.get(task_id)
 
+    def get_latest_task_data(self, task_id):
+        """Returns the latest data on a given task, by its ID."""
+        return self._all_data.get(task_id)[-1]
+
     def process_message(self, message):
         if 'id' not in message:
             raise StatusMsgMissingDataError('id')

--- a/avocado/core/status/repo.py
+++ b/avocado/core/status/repo.py
@@ -9,7 +9,9 @@ class StatusRepo:
     """Maintains tasks' status related data and provides aggregated info."""
 
     def __init__(self):
-        self._data = {}
+        #: Contains all reveived messages by a given task (by its ID)
+        self._all_data = {}
+        #: Contains the task IDs keyed by the result received
         self._by_result = {}
 
     def _handle_task_finished(self, message):
@@ -35,13 +37,13 @@ class StatusRepo:
     def _set_task_data(self, message):
         """Appends all data on message to an entry keyed by the task's ID."""
         task_id = message.pop('id')
-        if not task_id in self._data:
-            self._data[task_id] = []
-        self._data[task_id].append(message)
+        if not task_id in self._all_data:
+            self._all_data[task_id] = []
+        self._all_data[task_id].append(message)
 
     def get_task_data(self, task_id):
         """Returns all data on a given task, by its ID."""
-        return self._data.get(task_id)
+        return self._all_data.get(task_id)
 
     def process_message(self, message):
         if 'id' not in message:

--- a/avocado/core/status/server.py
+++ b/avocado/core/status/server.py
@@ -1,0 +1,46 @@
+import asyncio
+
+
+class StatusServer:
+    """Server that listens for status messages and updates a StatusRepo."""
+
+    def __init__(self, uri, repo):
+        """Initializes a new StatusServer.
+
+        :param uri: either a "host:port" string or a path to a UNIX socket
+        :type uri: str
+        :param repo: the repository to use to process received status
+                     messages
+        :type repo: :class:`avocado.core.status.repo.StatusRepo`
+        """
+        self._uri = uri
+        self._repo = repo
+        self._server_task = None
+
+    async def create_server(self):
+        if ':' in self._uri:
+            host, port = self._uri.split(':')
+            port = int(port)
+            self._server_task = await asyncio.start_server(
+                self.cb,
+                host=host,
+                port=port)
+        else:
+            self._server_task = await asyncio.start_unix_server(
+                self.cb,
+                path=self._uri)
+
+    async def serve_forever(self):
+        if self._server_task is None:
+            await self.create_server()
+        await self._server_task.serve_forever()
+
+    def close(self):
+        self._server_task.close()
+
+    async def cb(self, reader, _):
+        while True:
+            raw_message = await reader.readline()
+            if not raw_message:
+                return
+            self._repo.process_raw_message(raw_message)

--- a/avocado/core/task/info.py
+++ b/avocado/core/task/info.py
@@ -1,0 +1,35 @@
+class TaskInfo:
+    """Task with extra status information on its life cycle status.
+
+    The :class:`avocado.core.nrunner.Task` class contains information
+    that is necessary to describe its persistence and execution.  This
+    class wraps a :class:`avocado.core.nrunner.Task`, with extra
+    information about its execution aspects.
+    """
+    def __init__(self, task):
+        """Instantiates a new TaskInfo.
+
+        :param task: The task to keep additional information about
+        :type task: :class:`avocado.core.nrunner.Task`
+        """
+        #: The :class:`avocado.core.nrunner.Task`
+        self.task = task
+        #: Additional descriptive information about the task status
+        self.status = None
+        #: Timeout limit for the completion of the task execution
+        self.execution_timeout = None
+        #: A handle that may be set by a spawner, and that may be
+        #: spawner implementation specific, to keep track the task
+        #: execution.  This may be a PID, a container ID, a FQDN+PID
+        #: etc.
+        self.spawner_handle = None
+        #: The result of the spawning of a Task
+        self.spawning_result = None
+
+    def __repr__(self):
+        if self.status is None:
+            return '<TaskInfo Task Identifier: "%s">' % self.task.identifier
+        else:
+            return '<TaskInfo Task Identifier: "%s" Status: "%s">' % (
+                self.task.identifier,
+                self.status)

--- a/avocado/core/task/statemachine.py
+++ b/avocado/core/task/statemachine.py
@@ -1,0 +1,152 @@
+import asyncio
+import multiprocessing
+import time
+
+
+class TaskStateMachine:
+    """Represents all phases that a task can go through its life."""
+    def __init__(self, tasks):
+        self._requested = tasks
+        self._triaging = []
+        self._ready = []
+        self._started = []
+        self._finished = []
+        self._lock = asyncio.Lock()
+
+    @property
+    def requested(self):
+        return self._requested
+
+    @property
+    def triaging(self):
+        return self._triaging
+
+    @property
+    def ready(self):
+        return self._ready
+
+    @property
+    def started(self):
+        return self._started
+
+    @property
+    def finished(self):
+        return self._finished
+
+    @property
+    def lock(self):
+        return self._lock
+
+    @property
+    async def complete(self):
+        async with self._lock:
+            pending = any([self._requested, self._triaging,
+                           self._ready, self._started])
+        return not pending
+
+
+class Worker:
+
+    def __init__(self, task_state_machine, spawner,
+                 max_triaging=None, max_running=None, task_timeout=None):
+        self._tsm = task_state_machine
+        self._spawner = spawner
+        if max_triaging is None:
+            max_triaging = multiprocessing.cpu_count()
+        self._max_triaging = max_triaging
+        if max_running is None:
+            max_running = 2 * multiprocessing.cpu_count() - 1
+        self._max_running = max_running
+        self._task_timeout = task_timeout
+
+    async def bootstrap(self):
+        """Reads from requested, moves into triaging."""
+        try:
+            async with self._tsm.lock:
+                if len(self._tsm.triaging) < self._max_triaging:
+                    task_info = self._tsm.requested.pop()
+                    self._tsm.triaging.append(task_info)
+                else:
+                    return
+        except IndexError:
+            return
+
+    async def triage(self):
+        """Reads from triaging, moves into either: ready or finished."""
+        try:
+            async with self._tsm.lock:
+                task_info = self._tsm.triaging.pop()
+        except IndexError:
+            return
+
+        requirements_ok = await self._spawner.spawn_task(task_info)
+        if requirements_ok:
+            async with self._tsm.lock:
+                self._tsm.ready.append(task_info)
+        else:
+            async with self._tsm.lock:
+                self._tsm.finished.append(task_info)
+                task_info.status = 'FAILED ON TRIAGE'
+
+    async def start(self):
+        """Reads from ready, moves into either: started or finished."""
+        try:
+            async with self._tsm.lock:
+                task_info = self._tsm.ready.pop()
+        except IndexError:
+            return
+
+        # enforce a rate limit on the number of started (currently
+        # running) tasks.  this is a global limit, but the spawners
+        # can also be queried with regards to their capacity to handle
+        # new tasks
+        async with self._tsm.lock:
+            if len(self._tsm.started) >= self._max_running:
+                self._tsm.ready.insert(0, task_info)
+                task_info.status = 'WAITING'
+                return
+
+        start_ok = await self._spawner.spawn_task(task_info)
+        if start_ok:
+            task_info.status = None
+            if self._task_timeout is not None:
+                task_info.execution_timeout = time.monotonic() + self._task_timeout
+            async with self._tsm.lock:
+                self._tsm.started.append(task_info)
+        else:
+            async with self._tsm.lock:
+                self._tsm.finished.append(task_info)
+
+    async def monitor(self):
+        """Reads from started, moves into finished."""
+        try:
+            async with self._tsm.lock:
+                task_info = self._tsm.started.pop()
+        except IndexError:
+            return
+
+        if self._spawner.is_task_alive(task_info):
+            try:
+                if task_info.execution_timeout is None:
+                    remaining = None
+                else:
+                    remaining = task_info.timeout - time.monotonic()
+                await asyncio.wait_for(self._spawner.wait_task(task_info),
+                                       remaining)
+                task_info.status = 'FINISHED'
+            except asyncio.TimeoutError:
+                task_info.status = 'FINISHED W/ TIMEOUT'
+
+        async with self._tsm.lock:
+            self._tsm.finished.append(task_info)
+
+    async def run(self):
+        """Pushes Tasks forward and makes them do something with their lifes."""
+        while True:
+            is_complete = await self._tsm.complete
+            if is_complete:
+                break
+            await self.bootstrap()
+            await self.triage()
+            await self.start()
+            await self.monitor()

--- a/avocado/core/test_id.py
+++ b/avocado/core/test_id.py
@@ -37,6 +37,9 @@ class TestID:
     def __str__(self):
         return "%s-%s%s" % (self.str_uid, self.name, self.str_variant)
 
+    def __hash__(self):
+        return id(self)
+
     def __repr__(self):
         return repr(str(self))
 

--- a/avocado/plugins/magic.py
+++ b/avocado/plugins/magic.py
@@ -1,0 +1,33 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2020
+# Author: Cleber Rosa <crosa@redhat.com>
+"""
+Outputs the Avocado magic string
+"""
+
+from avocado.core.magic import MAGIC
+from avocado.core.output import LOG_UI
+from avocado.core.plugin_interfaces import CLICmd
+
+
+class Magic(CLICmd):
+
+    """
+    Outputs the Avocado magic string
+    """
+
+    name = 'magic'
+    description = 'Outputs the Avocado magic string'
+
+    def run(self, config):
+        LOG_UI.info(MAGIC)

--- a/avocado/plugins/nrun.py
+++ b/avocado/plugins/nrun.py
@@ -89,11 +89,12 @@ class NRun(CLICmd):
             spawn_result = await self.spawner.spawn_task(task_info)
             identifier = task_info.task.identifier
             self.pending_tasks.remove(task_info)
-            self.spawned_tasks.append(identifier)
             if not spawn_result:
-                LOG_UI.error("ERROR: failed to spawn task: %s", identifier)
+                LOG_UI.error('ERROR: failed to spawn task "%s": "%s"',
+                             identifier, task_info.status)
+                sys.exit(exit_codes.AVOCADO_JOB_FAIL)
                 continue
-
+            self.spawned_tasks.append(identifier)
             alive = self.spawner.is_task_alive(task_info)
             if not alive:
                 LOG_UI.warning("%s is not alive shortly after being spawned", identifier)
@@ -138,14 +139,6 @@ class NRun(CLICmd):
 
         try:
             if config.get('nrun.spawner') == 'podman':
-                podman_bin = config.get('spawner.podman.podman_bin')
-                if not os.path.exists(podman_bin):
-                    msg = ('Podman Spawner selected, but podman binary "%s" '
-                           'is not available on the system.  Please install '
-                           'podman before attempting to use this feature.')
-                    msg %= podman_bin
-                    LOG_UI.error(msg)
-                    sys.exit(exit_codes.AVOCADO_JOB_FAIL)
                 self.spawner = PodmanSpawner()  # pylint: disable=W0201
             elif config.get('nrun.spawner') == 'process':
                 self.spawner = ProcessSpawner()  # pylint: disable=W0201

--- a/avocado/plugins/nrun.py
+++ b/avocado/plugins/nrun.py
@@ -6,6 +6,7 @@ import sys
 
 from avocado.core import (exit_codes, nrunner, parser_common_args, resolver,
                           status_server)
+from avocado.core.dispatcher import SpawnerDispatcher
 from avocado.core.output import LOG_UI
 from avocado.core.parser import HintParser
 from avocado.core.plugin_interfaces import CLICmd
@@ -13,9 +14,6 @@ from avocado.core.settings import settings
 from avocado.core.task.info import TaskInfo
 from avocado.core.test_id import TestID
 from avocado.core.utils import resolutions_to_tasks
-
-from .spawners.podman import PodmanSpawner
-from .spawners.process import ProcessSpawner
 
 
 class NRun(CLICmd):
@@ -138,11 +136,12 @@ class NRun(CLICmd):
         self.spawned_tasks = []  # pylint: disable=W0201
 
         try:
-            if config.get('nrun.spawner') == 'podman':
-                self.spawner = PodmanSpawner()  # pylint: disable=W0201
-            elif config.get('nrun.spawner') == 'process':
-                self.spawner = ProcessSpawner()  # pylint: disable=W0201
-            else:
+            try:
+                spawner_name = config.get('nrun.spawner')
+                spawner_extension = SpawnerDispatcher()[spawner_name]
+                # pylint: disable=W0201
+                self.spawner = spawner_extension.obj
+            except KeyError:
                 LOG_UI.error("Spawner not implemented or invalid.")
                 sys.exit(exit_codes.AVOCADO_JOB_FAIL)
 

--- a/avocado/plugins/nrun.py
+++ b/avocado/plugins/nrun.py
@@ -138,11 +138,12 @@ class NRun(CLICmd):
 
         try:
             if config.get('nrun.spawner') == 'podman':
-                if not os.path.exists(PodmanSpawner.PODMAN_BIN):
+                podman_bin = config.get('spawner.podman.podman_bin')
+                if not os.path.exists(podman_bin):
                     msg = ('Podman Spawner selected, but podman binary "%s" '
                            'is not available on the system.  Please install '
                            'podman before attempting to use this feature.')
-                    msg %= PodmanSpawner.PODMAN_BIN
+                    msg %= podman_bin
                     LOG_UI.error(msg)
                     sys.exit(exit_codes.AVOCADO_JOB_FAIL)
                 self.spawner = PodmanSpawner()  # pylint: disable=W0201

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -24,6 +24,7 @@ from copy import copy
 from avocado.core import nrunner
 from avocado.core.plugin_interfaces import Runner as RunnerInterface
 from avocado.core.status.repo import StatusRepo
+from avocado.core.task.info import TaskInfo
 from avocado.core.test_id import TestID
 
 
@@ -71,6 +72,20 @@ class Runner(RunnerInterface):
         with open(data_file, 'w') as fp:
             fp.write("{}\n".format(task.output_dir))
 
+    def _get_all_tasks_info(self, test_suite):
+        result = []
+        no_digits = len(str(len(test_suite)))
+        for index, task in enumerate(test_suite.tests, start=1):
+            task.known_runners = nrunner.RUNNERS_REGISTRY_PYTHON_CLASS
+            # this is all rubbish data
+            test_id = TestID("{}-{}".format(test_suite.name, index),
+                             task.runnable.uri,
+                             None,
+                             no_digits)
+            task.identifier = test_id
+            result.append(TaskInfo(task))
+        return result
+
     def run_suite(self, job, test_suite):
         summary = set()
         if job.timeout > 0:
@@ -81,22 +96,14 @@ class Runner(RunnerInterface):
         test_suite.tests, _ = nrunner.check_tasks_requirements(test_suite.tests)
         job.result.tests_total = test_suite.size  # no support for variants yet
         result_dispatcher = job.result_events_dispatcher
-        no_digits = len(str(len(test_suite)))
         status_repo = StatusRepo()
-
-        for index, task in enumerate(test_suite.tests, start=1):
+        for task_info in self._get_all_tasks_info(test_suite):
             if deadline is not None and time.time() > deadline:
                 break
+            task = task_info.task
 
-            task.known_runners = nrunner.RUNNERS_REGISTRY_PYTHON_CLASS
-            # this is all rubbish data
-            test_id = TestID("{}-{}".format(test_suite.name, index),
-                             task.runnable.uri,
-                             None,
-                             no_digits)
-            task.identifier = test_id
             early_state = {
-                'name': test_id,
+                'name': task.identifier,
                 'job_logdir': job.logdir,
                 'job_unique_id': job.unique_id,
             }

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -50,7 +50,7 @@ class Runner(RunnerInterface):
             stderr = None
 
         # Create task dir
-        task_path = os.path.join(base_path, task.identifier.replace('/', '_'))
+        task_path = os.path.join(base_path, task.identifier.str_filesystem)
         os.makedirs(task_path, exist_ok=True)
 
         # Save stdout and stderr
@@ -94,7 +94,7 @@ class Runner(RunnerInterface):
                              task.runnable.uri,
                              None,
                              no_digits)
-            task.identifier = str(test_id)
+            task.identifier = test_id
             early_state = {
                 'name': test_id,
                 'job_logdir': job.logdir,

--- a/avocado/plugins/spawners/podman.py
+++ b/avocado/plugins/spawners/podman.py
@@ -26,10 +26,8 @@ class PodmanSpawner(Spawner, SpawnerMixin):
                                    stdout=subprocess.PIPE,
                                    stderr=subprocess.DEVNULL)
         out, _ = process.communicate()
-        # we have to be lenient and allow for the configured state to
-        # be considered "alive" because it happens before the
-        # container transitions into "running"
-        return out in [b'configured\n', b'running\n']
+        # FIXME: check how podman 2.x is reporting valid "OK" states
+        return out.startswith(b'Up ')
 
     async def spawn_task(self, task):
         entry_point_cmd = '/tmp/avocado-runner'

--- a/avocado/plugins/spawners/podman.py
+++ b/avocado/plugins/spawners/podman.py
@@ -61,6 +61,13 @@ class PodmanSpawner(Spawner, SpawnerMixin):
 
         config = settings.as_dict()
         podman_bin = config.get('spawner.podman.podman_bin')
+
+        if not os.path.exists(podman_bin):
+            msg = 'Podman binary "%s" is not available on the system'
+            msg %= podman_bin
+            task_info.status = msg
+            return False
+
         image = config.get('spawner.podman.image')
         try:
             # pylint: disable=E1133

--- a/avocado/plugins/spawners/podman.py
+++ b/avocado/plugins/spawners/podman.py
@@ -62,7 +62,7 @@ class PodmanSpawner(Spawner, SpawnerMixin):
         # Currently limited to avocado-runner, we'll expand on that
         # when the runner requirements system is in place
         this_path = os.path.abspath(__file__)
-        base_path = os.path.dirname(os.path.dirname(this_path))
+        base_path = os.path.dirname(os.path.dirname(os.path.dirname(this_path)))
         avocado_runner_path = os.path.join(base_path, 'core', 'nrunner.py')
         try:
             # pylint: disable=E1133

--- a/avocado/plugins/spawners/podman.py
+++ b/avocado/plugins/spawners/podman.py
@@ -15,12 +15,12 @@ class PodmanSpawner(Spawner, SpawnerMixin):
     PODMAN_BIN = "/usr/bin/podman"
 
     @staticmethod
-    def is_task_alive(task):
-        if task.spawn_handle is None:
+    def is_task_alive(task_info):
+        if task_info.spawner_handle is None:
             return False
 
         cmd = [PodmanSpawner.PODMAN_BIN, "ps", "--all", "--format={{.State}}",
-               "--filter=id=%s" % task.spawn_handle]
+               "--filter=id=%s" % task_info.spawner_handle]
         process = subprocess.Popen(cmd,
                                    stdin=subprocess.DEVNULL,
                                    stdout=subprocess.PIPE,
@@ -29,7 +29,8 @@ class PodmanSpawner(Spawner, SpawnerMixin):
         # FIXME: check how podman 2.x is reporting valid "OK" states
         return out.startswith(b'Up ')
 
-    async def spawn_task(self, task):
+    async def spawn_task(self, task_info):
+        task = task_info.task
         entry_point_cmd = '/tmp/avocado-runner'
         entry_point_args = task.get_command_args()
         entry_point_args.insert(0, "task-run")
@@ -55,7 +56,7 @@ class PodmanSpawner(Spawner, SpawnerMixin):
         stdout = await proc.stdout.read()
         container_id = stdout.decode().strip()
 
-        task.spawn_handle = container_id
+        task_info.spawner_handle = container_id
 
         # Currently limited to avocado-runner, we'll expand on that
         # when the runner requirements system is in place

--- a/avocado/plugins/spawners/podman.py
+++ b/avocado/plugins/spawners/podman.py
@@ -90,3 +90,10 @@ class PodmanSpawner(Spawner, SpawnerMixin):
 
         await proc.wait()
         return proc.returncode == 0
+
+    @staticmethod
+    async def wait_task(task_info):
+        while True:
+            if not PodmanSpawner.is_task_alive(task_info):
+                return
+            await asyncio.sleep(0.1)

--- a/avocado/plugins/spawners/process.py
+++ b/avocado/plugins/spawners/process.py
@@ -35,3 +35,7 @@ class ProcessSpawner(Spawner, SpawnerMixin):
             return False
         asyncio.ensure_future(self._collect_task(task_info.spawner_handle))
         return True
+
+    @staticmethod
+    async def wait_task(task_info):
+        await task_info.spawner_handle.wait()

--- a/avocado/plugins/spawners/process.py
+++ b/avocado/plugins/spawners/process.py
@@ -39,3 +39,21 @@ class ProcessSpawner(Spawner, SpawnerMixin):
     @staticmethod
     async def wait_task(task_info):
         await task_info.spawner_handle.wait()
+
+    @staticmethod
+    async def check_task_requirements(task_info):
+        runnable_requirements = task_info.task.runnable.requirements
+        if not runnable_requirements:
+            return True
+
+        for requirements in runnable_requirements:
+            for (req_type, req_value) in requirements.items():
+                # The fact that this is avocado code means this
+                # requirement is fulfilled
+                if req_type == 'core' and req_value == 'avocado':
+                    continue
+                else:
+                    # current implementation can not check any other type of
+                    # requirement at this moment so fail
+                    return False
+        return True

--- a/avocado/plugins/spawners/process.py
+++ b/avocado/plugins/spawners/process.py
@@ -13,24 +13,25 @@ class ProcessSpawner(Spawner, SpawnerMixin):
         await task_handle.wait()
 
     @staticmethod
-    def is_task_alive(task):
-        if getattr(task, 'spawn_handle', None) is None:
+    def is_task_alive(task_info):
+        if task_info.spawner_handle is None:
             return False
-        return task.spawn_handle.returncode is None
+        return task_info.spawner_handle.returncode is None
 
-    async def spawn_task(self, task):
+    async def spawn_task(self, task_info):
+        task = task_info.task
         runner = task.runnable.pick_runner_command()
         args = runner[1:] + ['task-run'] + task.get_command_args()
         runner = runner[0]
 
         # pylint: disable=E1133
         try:
-            task.spawn_handle = await asyncio.create_subprocess_exec(
+            task_info.spawner_handle = await asyncio.create_subprocess_exec(
                 runner,
                 *args,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE)
         except (FileNotFoundError, PermissionError):
             return False
-        asyncio.ensure_future(self._collect_task(task.spawn_handle))
+        asyncio.ensure_future(self._collect_task(task_info.spawner_handle))
         return True

--- a/examples/tests/passtest_explicit_requirement.py
+++ b/examples/tests/passtest_explicit_requirement.py
@@ -1,0 +1,15 @@
+from avocado import Test
+
+
+class PassTest(Test):
+
+    """
+    Example test that passes.
+
+    :avocado: requirement={"core": "avocado"}
+    """
+
+    def test(self):
+        """
+        A test simply doesn't have to fail in order to pass
+        """

--- a/selftests/functional/test_magic.py
+++ b/selftests/functional/test_magic.py
@@ -1,0 +1,14 @@
+from unittest import TestCase
+
+from avocado.core import exit_codes, magic
+from avocado.utils import process
+
+
+class Magic(TestCase):
+
+    def test(self):
+        result = process.run('avocado magic', ignore_status=True)
+        self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK,
+                         'Error running "avocado magic"')
+        self.assertEqual(result.stdout_text.rstrip(), magic.MAGIC,
+                         'Magic numbers mismatch')

--- a/selftests/functional/test_requirements.py
+++ b/selftests/functional/test_requirements.py
@@ -1,0 +1,38 @@
+import os
+import unittest.mock
+
+from avocado.core import requirements
+
+from .. import TestCaseTmpDir
+
+ENTRIES = [
+    ('podman',
+     'cd34d13b2980d0a9d438f754b2e94f85443076d0ebe1b0db09a0439f35feca5e',
+     'package',
+     'bash'),
+    ('podman',
+     'cd34d13b2980d0a9d438f754b2e94f85443076d0ebe1b0db09a0439f35feca5e',
+     'core',
+     'avocado'),
+    ('local',
+     'localhost.localdomain',
+     'core',
+     'avocado')
+    ]
+
+
+class Requirement(TestCaseTmpDir):
+
+    def test_entries(self):
+        with unittest.mock.patch('avocado.core.requirements.CACHE_DATABASE_PATH',
+                                 os.path.join(self.tmpdir.name,
+                                              'requirements.sqlite')):
+            for entry in ENTRIES:
+                requirements.set_requirement_on_cache(*entry)
+                self.assertTrue(requirements.get_requirement_on_cache(*entry))
+
+    def test_empty(self):
+        with unittest.mock.patch('avocado.core.requirements.CACHE_DATABASE_PATH',
+                                 os.path.join(self.tmpdir.name,
+                                              'requirements.sqlite')):
+            self.assertFalse(requirements.get_requirement_on_cache(*ENTRIES[0]))

--- a/selftests/functional/test_task_statemachine.py
+++ b/selftests/functional/test_task_statemachine.py
@@ -1,0 +1,32 @@
+import asyncio
+from unittest import TestCase
+
+from avocado.core.nrunner import Runnable, Task
+from avocado.core.task import statemachine
+from avocado.core.task.info import TaskInfo
+from avocado.plugins.spawners.process import ProcessSpawner as Spawner
+
+# This test should, provided the environment supports, also be able
+# to run successfully with other spawners, such as:
+#
+# from avocado.plugins.spawners.podman import PodmanSpawner as Spawner
+
+
+class StateMachine(TestCase):
+
+    def test(self):
+        number_of_tasks = 80
+        number_of_workers = 8
+
+        runnable = Runnable("noop", "noop")
+        tasks_info = [TaskInfo(Task("%03i" % _, runnable))
+                      for _ in range(1, number_of_tasks + 1)]
+        spawner = Spawner()
+
+        state_machine = statemachine.TaskStateMachine(tasks_info)
+        loop = asyncio.get_event_loop()
+        workers = [statemachine.Worker(state_machine, spawner).run()
+                   for _ in range(number_of_workers)]
+
+        loop.run_until_complete(asyncio.gather(*workers))
+        self.assertEqual(number_of_tasks, len(state_machine.finished))

--- a/selftests/unit/test_spawner.py
+++ b/selftests/unit/test_spawner.py
@@ -3,56 +3,60 @@ import unittest
 
 from avocado.core import nrunner
 from avocado.core.spawners.mock import MockRandomAliveSpawner, MockSpawner
+from avocado.core.task.info import TaskInfo
 from avocado.plugins.spawners.process import ProcessSpawner
 
 
 class Process(unittest.TestCase):
     def setUp(self):
         runnable = nrunner.Runnable('noop', 'uri')
-        self.task = nrunner.Task('1', runnable)
+        task = nrunner.Task('1', runnable)
+        self.task_info = TaskInfo(task)
         self.spawner = ProcessSpawner()
 
     def test_spawned(self):
         loop = asyncio.get_event_loop()
-        spawned = loop.run_until_complete(self.spawner.spawn_task(self.task))
+        spawned = loop.run_until_complete(self.spawner.spawn_task(self.task_info))
         self.assertTrue(spawned)
 
     def test_never_spawned(self):
-        self.assertFalse(self.spawner.is_task_alive(self.task))
-        self.assertFalse(self.spawner.is_task_alive(self.task))
+        self.assertFalse(self.spawner.is_task_alive(self.task_info))
+        self.assertFalse(self.spawner.is_task_alive(self.task_info))
 
 
 class Mock(Process):
 
     def setUp(self):
         runnable = nrunner.Runnable('noop', 'uri')
-        self.task = nrunner.Task('1', runnable)
+        task = nrunner.Task('1', runnable)
+        self.task_info = TaskInfo(task)
         self.spawner = MockSpawner()
 
     def test_spawned_is_alive(self):
         loop = asyncio.get_event_loop()
-        loop.run_until_complete(self.spawner.spawn_task(self.task))
-        self.assertTrue(self.spawner.is_task_alive(self.task))
-        self.assertFalse(self.spawner.is_task_alive(self.task))
+        loop.run_until_complete(self.spawner.spawn_task(self.task_info))
+        self.assertTrue(self.spawner.is_task_alive(self.task_info))
+        self.assertFalse(self.spawner.is_task_alive(self.task_info))
 
 
 class RandomMock(Mock):
 
     def setUp(self):
         runnable = nrunner.Runnable('noop', 'uri')
-        self.task = nrunner.Task('1', runnable)
+        task = nrunner.Task('1', runnable)
+        self.task_info = TaskInfo(task)
         self.spawner = MockRandomAliveSpawner()
 
     def test_spawned_is_alive(self):
         loop = asyncio.get_event_loop()
-        loop.run_until_complete(self.spawner.spawn_task(self.task))
+        loop.run_until_complete(self.spawner.spawn_task(self.task_info))
         # The likelihood of the random spawner returning the task is
         # not alive is 1 in 5.  This gives the random code 10000
         # chances of returning False, so it should, famous last words,
         # be pretty safe
         finished = False
         for _ in range(10000):
-            if not self.spawner.is_task_alive(self.task):
+            if not self.spawner.is_task_alive(self.task_info):
                 finished = True
                 break
         self.assertTrue(finished)

--- a/selftests/unit/test_status_repo.py
+++ b/selftests/unit/test_status_repo.py
@@ -20,7 +20,7 @@ class StatusRepo(TestCase):
 
     def test_set_task_data(self):
         self.status_repo._set_task_data({"id": "1-foo", "status": "started"})
-        self.assertEqual(self.status_repo._data["1-foo"],
+        self.assertEqual(self.status_repo._all_data["1-foo"],
                          [{"status": "started"}])
 
     def test_handle_task_started(self):

--- a/selftests/unit/test_status_repo.py
+++ b/selftests/unit/test_status_repo.py
@@ -65,3 +65,11 @@ class StatusRepo(TestCase):
         self.status_repo.process_raw_message(msg)
         self.assertEqual(self.status_repo.get_task_data("1-foo"),
                          [{"status": "running"}])
+
+    def test_process_messages_running(self):
+        msg = {"id": "1-foo", "status": "running", "time": 1597894378.6080744}
+        self.status_repo.process_message(msg)
+        msg = {"id": "1-foo", "status": "running", "time": 1597894378.6103745}
+        self.status_repo.process_message(msg)
+        self.assertEqual(self.status_repo.get_latest_task_data("1-foo"),
+                         {"status": "running", "time": 1597894378.6103745})

--- a/selftests/unit/test_task_info.py
+++ b/selftests/unit/test_task_info.py
@@ -1,0 +1,24 @@
+from unittest import TestCase
+
+from avocado.core.nrunner import Runnable, Task
+from avocado.core.task.info import TaskInfo
+
+
+class Info(TestCase):
+
+    def setUp(self):
+        runnable = Runnable('noop', 'noop')
+        task = Task('1-noop', runnable)
+        self.task_info = TaskInfo(task)
+
+    def test_empty(self):
+        self.assertIsNone(self.task_info.status)
+        self.assertIsNone(self.task_info.execution_timeout)
+        self.assertIsNone(self.task_info.spawner_handle)
+        self.assertIsNone(self.task_info.spawning_result)
+
+    def test(self):
+        self.task_info.status = 'LOST CONTACT'
+        self.assertEqual(self.task_info.task.runnable.kind, 'noop')
+        self.assertEqual(self.task_info.task.runnable.uri, 'noop')
+        self.assertEqual(self.task_info.status, 'LOST CONTACT')

--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ if __name__ == '__main__':
                   "jobscripts = avocado.plugins.jobscripts:JobScriptsInit",
                   "json_variants = avocado.plugins.json_variants:JsonVariantsInit",
                   "run = avocado.plugins.run:RunInit",
+                  "podman = avocado.plugins.spawners.podman:PodmanSpawnerInit",
               ],
               'avocado.plugins.cli': [
                   'wrapper = avocado.plugins.wrapper:Wrapper',

--- a/setup.py
+++ b/setup.py
@@ -107,6 +107,7 @@ if __name__ == '__main__':
                   'assets = avocado.plugins.assets:Assets',
                   'jobs = avocado.plugins.jobs:Jobs',
                   'replay = avocado.plugins.replay:Replay',
+                  'magic = avocado.plugins.magic:Magic',
                   ],
               'avocado.plugins.job.prepost': [
                   'jobscripts = avocado.plugins.jobscripts:JobScripts',


### PR DESCRIPTION
This contains a large number of fixes and prep work, before the final integration PR.  A few notes:

* The selftests for the TastStateMachine is *functional* and can work with other spawners.  I've used it successfully with the podman spawner, and maybe we could add a pre release test with it)
* The status repo is receiving new utility methods as the final monitoring/UI/ results aspects of the job integration are being developed.
* Because the BP003 describe the triage step, I've decided to include the core/avocado requirement checker here, as it gives a concrete example of triaging in the context of the spawners. 
* If reviewers are interested in seeing this prep work in use, this [commit](https://github.com/clebergnu/avocado/commit/8c7b763cb48f996e2e5fa8304fa7e10f27ea9434) should give an idea.  As the commit message itself explains, there's some work pending there, but it should be possible to see the TaskTateMachine, workers, spawners, status server and status repo in use.