### PR TITLE
N(ext) Runner: Job integration 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ AVOCADO_OPTIONAL_PLUGINS_TESTS=$(patsubst %,%/tests/, $(AVOCADO_OPTIONAL_PLUGINS
 endif
 check: clean develop
 	# Unless manually set, this is equivalent to AVOCADO_CHECK_LEVEL=0
-	PYTHON=$(PYTHON) $(PYTHON) -m avocado nrun selftests/*.sh selftests/unit/ selftests/functional/ selftests/jobs/ $(AVOCADO_OPTIONAL_PLUGINS_TESTS)
+	PYTHON=$(PYTHON) $(PYTHON) -m avocado run --test-runner=nrunner --ignore-missing-references -- selftests/*.sh selftests/jobs/* selftests/unit/ selftests/functional/ $(AVOCADO_OPTIONAL_PLUGINS_TESTS)
 	PYTHON=$(PYTHON) $(PYTHON) selftests/job_api/test_features.py
 	selftests/check_tmp_dirs
 

--- a/avocado/core/utils.py
+++ b/avocado/core/utils.py
@@ -69,7 +69,9 @@ def resolutions_to_tasks(resolutions, config):
     filter_by_tags = config.get("filter.by_tags.tags")
     include_empty = config.get("filter.by_tags.include_empty")
     include_empty_key = config.get('filter.by_tags.include_empty_key')
-    status_server = config.get('nrun.status_server.listen')
+    status_server = config.get('nrunner.status_server_uri')
+    if status_server is None:
+        status_server = config.get('nrun.status_server.listen')
     for resolution in resolutions:
         if resolution.result != ReferenceResolutionResult.SUCCESS:
             continue

--- a/examples/jobs/nrunner.py
+++ b/examples/jobs/nrunner.py
@@ -7,11 +7,11 @@ from avocado.core.suite import TestSuite
 
 config = {
     'run.test_runner': 'nrunner',
+    'nrunner.status_server_uri': '127.0.0.1:9999',
     'run.references': [
         'selftests/unit/test_resolver.py',
         'selftests/functional/test_argument_parsing.py',
         '/bin/true',
-        '/bin/false',
     ],
     }
 

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,7 @@ if __name__ == '__main__':
                   "json_variants = avocado.plugins.json_variants:JsonVariantsInit",
                   "run = avocado.plugins.run:RunInit",
                   "podman = avocado.plugins.spawners.podman:PodmanSpawnerInit",
+                  "nrunner = avocado.plugins.runner_nrunner:RunnerInit",
               ],
               'avocado.plugins.cli': [
                   'wrapper = avocado.plugins.wrapper:Wrapper',
@@ -91,6 +92,7 @@ if __name__ == '__main__':
                   'tap = avocado.plugins.tap:TAP',
                   'zip_archive = avocado.plugins.archive:ArchiveCLI',
                   'json_variants = avocado.plugins.json_variants:JsonVariantsCLI',
+                  'nrunner = avocado.plugins.runner_nrunner:RunnerCLI',
                   ],
               'avocado.plugins.cli.cmd': [
                   'config = avocado.plugins.config:Config',


### PR DESCRIPTION
This completes the integration of the N(ext) Runner architecture into an Avocado Job.  It's "good enough" that's used to replace `avocado nrun` on `make check`.

From this point on, other improvements and bug fixes can follow.