### PR TITLE
[Release 81] fix some lgtm alerts

### DIFF
--- a/avocado/utils/iso9660.py
+++ b/avocado/utils/iso9660.py
@@ -154,6 +154,7 @@ class BaseIso9660:
         with open(dst, 'w+b') as output:
             output.write(content)
 
+    @property
     def mnt_dir(self):
         """
         Returns a path to the browsable content of the iso


### PR DESCRIPTION
Fix the following alerts on lgtm:

`Base classes have conflicting values for attribute 'mnt_dir':
 Property mnt_dir and Function mnt_dir.`

Signed-off-by: Willian Rampazzo <willianr@redhat.com>