### PR TITLE
nrunner: restore collection of tasks output

### DIFF
--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -207,6 +207,13 @@ class Runner(RunnerInterface):
 
                 # fake log dir, needed by some result plugins such as HTML
                 test_state['logdir'] = ''
+
+                base_path = os.path.join(job.logdir, 'test-results')
+                self._populate_task_logdir(base_path,
+                                           task,
+                                           this_task_data,
+                                           job.config.get('core.debug'))
+
                 job.result.check_test(test_state)
                 job.result_events_dispatcher.map_method('end_test',
                                                         job.result,


### PR DESCRIPTION
Into the reespective test results directory with a test.

Fixes: https://github.com/avocado-framework/avocado/issues/3695
Signed-off-by: Cleber Rosa <crosa@redhat.com>