### PR TITLE
Job API example: use a simpler and runnable example

### DIFF
--- a/docs/source/quickstart/index.rst
+++ b/docs/source/quickstart/index.rst
@@ -187,10 +187,8 @@ create custom jobs and test suites:
   import sys
 
   from avocado.core.job import Job
-  from avocado.core.suite import TestSuite
 
-  suite = TestSuite(name='CustomSuite', config=suite_config, tests=tests)
-  with Job(config=job_config, test_suites=[suite]) as job:
+  with Job.from_config({'run.references': ['/bin/true']}) as job:
       sys.exit(job.run())
 
 How to install


### PR DESCRIPTION
This is the first impression users will have about the Job API, so
it's better to have a simpler and runnable example.

Fixes: #4161 
Signed-off-by: Cleber Rosa <crosa@redhat.com>