### PR TITLE
nrunner: use time.monotonic() for instrumented runner

### DIFF
--- a/avocado/core/nrunner_avocado_instrumented.py
+++ b/avocado/core/nrunner_avocado_instrumented.py
@@ -62,7 +62,7 @@ class AvocadoInstrumentedTestRunner(nrunner.BaseRunner):
             del state['name']
         if 'time_start' in state:
             del state['time_start']
-        state['time'] = time.time()
+        state['time'] = time.monotonic()
         queue.put(state)
 
     def run(self):
@@ -76,7 +76,7 @@ class AvocadoInstrumentedTestRunner(nrunner.BaseRunner):
         most_current_execution_state_time = None
         while queue.empty():
             time.sleep(nrunner.RUNNER_RUN_CHECK_INTERVAL)
-            now = time.time()
+            now = time.monotonic()
             if most_current_execution_state_time is not None:
                 next_execution_state_mark = (most_current_execution_state_time +
                                              nrunner.RUNNER_RUN_STATUS_INTERVAL)


### PR DESCRIPTION
As it's used on the core nrunner module.  If the same timing mechanism
is not used, the calculation of time elapsed gets done wrong.

Fixes: https://github.com/avocado-framework/avocado/issues/4160
Signed-off-by: Cleber Rosa <crosa@redhat.com>