### PR TITLE
TAP runner: preserve stdout and stderr

### DIFF
--- a/avocado/core/nrunner_tap.py
+++ b/avocado/core/nrunner_tap.py
@@ -45,8 +45,8 @@ class TAPRunner(nrunner.BaseRunner):
             time.sleep(nrunner.RUNNER_RUN_STATUS_INTERVAL)
             yield self.prepare_status('running')
 
-        stdout = io.TextIOWrapper(process.stdout)
-        parser = TapParser(stdout)
+        stdout = process.stdout.read()
+        parser = TapParser(io.StringIO(stdout.decode()))
         result = 'error'
         for event in parser.parse():
             if isinstance(event, TapParser.Bailout):
@@ -67,7 +67,9 @@ class TAPRunner(nrunner.BaseRunner):
 
         yield self.prepare_status('finished',
                                   {'result': result,
-                                   'returncode': process.returncode})
+                                   'returncode': process.returncode,
+                                   'stdout': stdout,
+                                   'stderr': process.stderr.read()})
 
 
 class RunnerApp(nrunner.BaseRunnerApp):


### PR DESCRIPTION
So that, when run as part of a job, they'll be saved in the test
result's directory.

Signed-off-by: Cleber Rosa <crosa@redhat.com>