### PR TITLE
Pre release checks: add a Cirrus CI status check

### DIFF
--- a/selftests/pre_release/jobs/pre_release.py
+++ b/selftests/pre_release/jobs/pre_release.py
@@ -9,6 +9,10 @@ THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 ROOT_DIR = os.path.dirname(os.path.dirname(os.path.dirname(THIS_DIR)))
 TESTS_DIR = os.path.join(os.path.dirname(THIS_DIR), 'tests')
 
+cirrus_ci = {
+    'run.references': [os.path.join(TESTS_DIR, 'cirrusci.py')],
+    }
+
 parallel_1 = {
     'run.test_runner': 'nrunner',
     'run.references': [os.path.join('selftests', 'unit'),
@@ -25,6 +29,6 @@ vmimage = {
 
 if __name__ == '__main__':
     os.chdir(ROOT_DIR)
-    with Job.from_config({}, [parallel_1, vmimage]) as j:
+    with Job.from_config({}, [cirrus_ci, parallel_1, vmimage]) as j:
         os.environ['AVOCADO_CHECK_LEVEL'] = '3'
         sys.exit(j.run())

--- a/selftests/pre_release/tests/cirrusci.py
+++ b/selftests/pre_release/tests/cirrusci.py
@@ -1,0 +1,16 @@
+import json
+import unittest
+
+from avocado.utils import download
+
+
+class CirrusCI(unittest.TestCase):
+
+    def test(self):
+        url = 'https://api.cirrus-ci.com/github/avocado-framework/avocado.json'
+        http_response = download.url_open(url)
+        self.assertEqual(http_response.code, 200)
+        content = http_response.read()
+        data = json.loads(content)
+        self.assertIn('status', data)
+        self.assertEqual(data['status'], 'passing')


### PR DESCRIPTION
This makes sure we're not progressing with a release that is broken
in Cirrus CI.

Reference: https://github.com/avocado-framework/avocado/issues/3456
Reference: https://github.com/avocado-framework/avocado/pull/3551
Signed-off-by: Cleber Rosa <crosa@redhat.com>