### PR TITLE
Suites: respect registered settings when creating from config

### DIFF
--- a/avocado/core/suite.py
+++ b/avocado/core/suite.py
@@ -287,6 +287,9 @@ class TestSuite:
                            optional.
         :type job_config: dict
         """
+        suite_config = config
+        config = settings.as_dict()
+        config.update(suite_config)
         if job_config:
             config.update(job_config)
         runner = config.get('run.test_runner') or 'runner'

--- a/selftests/pre_release/jobs/pre_release.py
+++ b/selftests/pre_release/jobs/pre_release.py
@@ -14,7 +14,6 @@ parallel_1 = {
     'run.references': [os.path.join('selftests', 'unit'),
                        os.path.join('selftests', 'functional')],
     'filter.by_tags.tags': ['parallel:1'],
-    'nrunner.status_server_uri': '127.0.0.1:8888',
     'nrunner.max_parallel_tasks': 1,
     }
 


### PR DESCRIPTION
When calling `from_config()` the settings registered by the various
core options and plugins were not being respected.  This resulted in
crashes such as #4153.  A workaround was added previously in #4154,
but the core issue remained not solved.  With this fix, the workaround
can be removed.

Fixes: https://github.com/avocado-framework/avocado/issues/4157
Reference: https://github.com/avocado-framework/avocado/issues/4153
Reference: https://github.com/avocado-framework/avocado/issues/4154
Signed-off-by: Cleber Rosa <crosa@redhat.com>