### PR TITLE
[Documentation] fix the verbose option position for list command.

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -499,7 +499,7 @@ class Job:
             if self.test_suite and self.test_suite.size == 0:
                 refs = self.test_suite.references
                 msg = ("No tests found for given test references, try "
-                       "'avocado list -V %s' for details") % " ".join(refs)
+                       "'avocado -V list %s' for details") % " ".join(refs)
                 raise exceptions.JobTestSuiteEmptyError(msg)
         except TestSuiteError as details:
             raise exceptions.JobBaseException(details)

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -67,7 +67,7 @@ class LoaderUnhandledReferenceError(LoaderError):
 
     def __str__(self):
         return ("Unable to resolve reference(s) '%s' with plugins(s) '%s', "
-                "try running 'avocado list -V %s' to see the details."
+                "try running 'avocado -V list %s' to see the details."
                 % ("', '" .join(self.unhandled_references),
                    "', '".join(self.plugins),
                    " ".join(self.unhandled_references)))

--- a/docs/source/guides/user/chapters/introduction.rst
+++ b/docs/source/guides/user/chapters/introduction.rst
@@ -138,14 +138,14 @@ them to tests. If one or more test references can not be resolved to tests, the
 Job will not be created. Example::
 
     $ avocado run passtest.py badtest.py
-    Unable to resolve reference(s) 'badtest.py' with plugins(s) 'file', 'robot', 'external', try running 'avocado list -V badtest.py' to see the details.
+    Unable to resolve reference(s) 'badtest.py' with plugins(s) 'file', 'robot', 'external', try running 'avocado -V list badtest.py' to see the details.
 
 But if you want to execute the Job anyway, with the tests that could be
 resolved, you can use ``--ignore-missing-references on``. The same message will
 appear in the UI, but the Job will be executed::
 
     $ avocado run passtest.py badtest.py --ignore-missing-references on
-    Unable to resolve reference(s) 'badtest.py' with plugins(s) 'file', 'robot', 'external', try running 'avocado list -V badtest.py' to see the details.
+    Unable to resolve reference(s) 'badtest.py' with plugins(s) 'file', 'robot', 'external', try running 'avocado -V list badtest.py' to see the details.
     JOB ID     : 85927c113074b9defd64ea595d6d1c3fdfc1f58f
     JOB LOG    : $HOME/avocado/job-results/job-2017-05-17T10.54-85927c1/job.log
      (1/1) passtest.py:PassTest.test: PASS (0.02 s)

--- a/docs/source/guides/user/chapters/loaders.rst
+++ b/docs/source/guides/user/chapters/loaders.rst
@@ -189,7 +189,7 @@ Example::
 
     $ avocado run 20
     Unable to resolve reference(s) '20' with plugins(s) 'file', 'robot',
-    'vt', 'external', try running 'avocado list -V 20' to see the details.
+    'vt', 'external', try running 'avocado -V list 20' to see the details.
 
 In the command above, no loaders can resolve ``20`` as a test. But running
 the command above with the External Runner ``/bin/sleep`` will make Avocado


### PR DESCRIPTION
Update the avocado list command to show the -V option in the
correct position (global option).

Update related occurrences in the documentation.

Signed-off-by: Willian Rampazzo <willianr@redhat.com>