### PR TITLE
core.test: save stdout, stderr and output as formated files

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -607,15 +607,15 @@ class Test(unittest.TestCase, TestData):
         self._register_log_file_handler(log_test_stdout,
                                         stream_formatter,
                                         self._stdout_file,
-                                        raw=True)
+                                        raw=False)
         self._register_log_file_handler(log_test_stderr,
                                         stream_formatter,
                                         self._stderr_file,
-                                        raw=True)
+                                        raw=False)
         self._register_log_file_handler(log_test_output,
                                         stream_formatter,
                                         self._output_file,
-                                        raw=True)
+                                        raw=False)
 
         if isinstance(sys.stdout, output.LoggingFile):
             sys.stdout.add_logger(log_test_stdout)

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -226,10 +226,10 @@ class OutputTest(TestCaseTmpDir):
         _check_output(joblog, exps, "job.log")
         testdir = res["tests"][0]["logdir"]
         with open(os.path.join(testdir, "stdout"), 'rb') as stdout_file:
-            self.assertEqual(b"test_print\ntest_stdout\ntest_process__test_stdout__",
+            self.assertEqual(b"test_print\n\n\ntest_stdout\n\ntest_process\n__test_stdout__\n",
                              stdout_file.read())
         with open(os.path.join(testdir, "stderr"), 'rb') as stderr_file:
-            self.assertEqual(b"test_stderr\n__test_stderr__",
+            self.assertEqual(b"test_stderr\n\n__test_stderr__\n",
                              stderr_file.read())
 
         # Now run the same test, but with combined output
@@ -244,7 +244,7 @@ class OutputTest(TestCaseTmpDir):
         res = json.loads(result.stdout_text)
         testdir = res["tests"][0]["logdir"]
         with open(os.path.join(testdir, "output")) as output_file:
-            self.assertEqual("test_process__test_stderr____test_stdout__",
+            self.assertEqual("test_process\n__test_stderr__\n__test_stdout__\n",
                              output_file.read())
 
     def test_check_record_no_module_default(self):
@@ -296,12 +296,12 @@ class OutputTest(TestCaseTmpDir):
             self.assertTrue(os.path.exists(stdout_path))
             with open(stdout_path, 'r') as stdout:
                 self.assertEqual(stdout.read(),
-                                 '__STDOUT_CONTENT____STDOUT_DO_RECORD_CONTENT__')
+                                 '__STDOUT_CONTENT__\n__STDOUT_DO_RECORD_CONTENT__\n')
             stderr_path = os.path.join(testdir, 'stderr')
             self.assertTrue(os.path.exists(stderr_path))
             with open(stderr_path, 'r') as stderr:
                 self.assertEqual(stderr.read(),
-                                 '__STDERR_CONTENT____STDERR_DO_RECORD_CONTENT__')
+                                 '__STDERR_CONTENT__\n__STDERR_DO_RECORD_CONTENT__\n')
 
     @skipUnlessPathExists('/bin/true')
     def test_show(self):

--- a/selftests/functional/test_output_check.py
+++ b/selftests/functional/test_output_check.py
@@ -153,9 +153,9 @@ class RunnerSimpleTest(TestCaseTmpDir):
         stdout_file = "%s.data/stdout.expected" % self.output_script
         stderr_file = "%s.data/stderr.expected" % self.output_script
         with open(stdout_file, 'rb') as fd_stdout:
-            self.assertEqual(fd_stdout.read(), STDOUT)
+            self.assertEqual(fd_stdout.read(), STDOUT + b"\n")
         with open(stderr_file, 'rb') as fd_stderr:
-            self.assertEqual(fd_stderr.read(), STDERR)
+            self.assertEqual(fd_stderr.read(), STDERR + b"\n")
 
     def _check_output_record_combined(self):
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
@@ -168,7 +168,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
                          (expected_rc, result))
         output_file = "%s.data/output.expected" % self.output_script
         with open(output_file, 'rb') as fd_output:
-            self.assertEqual(fd_output.read(), STDOUT + STDERR)
+            self.assertEqual(fd_output.read(), STDOUT + b"\n" + STDERR + b"\n")
 
     def _setup_simple_test(self, simple_test_content):
         variants_file = os.path.join(self.tmpdir.name, 'variants.json')
@@ -203,7 +203,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
         stdout_file = "%s.data/stdout.expected" % self.output_script
         stderr_file = "%s.data/stderr.expected" % self.output_script
         with open(stdout_file, 'rb') as fd_stdout:
-            self.assertEqual(fd_stdout.read(), STDOUT)
+            self.assertEqual(fd_stdout.read(), STDOUT + b"\n")
         self.assertIsNotFile(stderr_file)
 
     def test_output_record_and_check(self):


### PR DESCRIPTION
When using raw handler, new lines are not preserved. This was the cause
of some issues. This closes #4167.

Signed-off-by: Beraldo Leal <bleal@redhat.com>