### PR TITLE
(Legacy) Replay: fix replay by status

### DIFF
--- a/avocado/plugins/legacy/replay.py
+++ b/avocado/plugins/legacy/replay.py
@@ -162,7 +162,7 @@ class Replay(CLI):
             with open(json_results, 'r') as json_file:
                 results = json.loads(json_file.read())
                 tests = results["tests"]
-                for _ in range(results["total"] + 1 - len(tests)):
+                for _ in range(results["total"] - len(tests)):
                     tests.append({"test": "UNKNOWN", "status": "INTERRUPTED"})
         else:
             # get partial results from tap

--- a/avocado/plugins/runner.py
+++ b/avocado/plugins/runner.py
@@ -377,9 +377,7 @@ class TestRunner(Runner):
                 else:
                     if (replay_map is not None and
                             replay_map[index - 1] is not None):
-                        test_parameters["methodName"] = "test"
-                        test_factory = (replay_map[index], test_parameters)
-
+                        test_factory = (replay_map[index - 1], test_parameters)
                     if not self.run_test(job, test_factory, queue, summary,
                                          deadline):
                         break

--- a/selftests/unit/test_legacy_replay.py
+++ b/selftests/unit/test_legacy_replay.py
@@ -33,10 +33,10 @@ class Replay(unittest.TestCase):
         rep = replay_legacy.Replay()
         act = rep._create_replay_map(self.tmpdir.name, ["PASS"])
         exp = [None, test.ReplaySkipTest, test.ReplaySkipTest,
-               test.ReplaySkipTest, test.ReplaySkipTest]
+               test.ReplaySkipTest]
         self.assertEqual(act, exp)
         act = rep._create_replay_map(self.tmpdir.name, ["INTERRUPTED"])
-        exp = [test.ReplaySkipTest, None, None, None, None]
+        exp = [test.ReplaySkipTest, None, None, None]
         self.assertEqual(act, exp)
 
     def test_replay_map_after_crash(self):


### PR DESCRIPTION
There are two off-by-one errors in the replay map handling and usage.

Fixes: https://github.com/avocado-framework/avocado/issues/4176
Signed-off-by: Cleber Rosa <crosa@redhat.com>