### PR TITLE
docs: small change to fix str convertion when using test parameters

### DIFF
--- a/docs/source/guides/writer/chapters/logging.rst
+++ b/docs/source/guides/writer/chapters/logging.rst
@@ -18,7 +18,7 @@ clear stages on a single test::
     class Plant(Test):
 
         def test_plant_organic(self):
-            rows = self.params.get("rows", default=3)
+            rows = int(self.params.get("rows", default=3))
 
             # Preparing soil
             for row in range(rows):


### PR DESCRIPTION
If readers would like to test a different parameter then the current
code will break because will not convert string to integer. This closes

Signed-off-by: Beraldo Leal <bleal@redhat.com>