### PR TITLE
core:runner: Added the suite name to the test name

### DIFF
--- a/avocado/plugins/runner.py
+++ b/avocado/plugins/runner.py
@@ -364,7 +364,9 @@ class TestRunner(Runner):
                                                           execution_order):
                 test_parameters = test_factory[1]
                 name = test_parameters.get("name")
-                test_parameters["name"] = TestID(index, name,
+                modified_index = "{}-{}".format(test_suite.name, index)
+                test_parameters["name"] = TestID(modified_index,
+                                                 name,
                                                  variant,
                                                  no_digits)
                 if deadline is not None and time.time() > deadline:

--- a/optional_plugins/varianter_yaml_to_mux/tests/test_functional.py
+++ b/optional_plugins/varianter_yaml_to_mux/tests/test_functional.py
@@ -90,9 +90,9 @@ class MultiplexTests(unittest.TestCase):
                     % (AVOCADO, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         result = self.run_and_check(cmd_line, expected_rc, (4, 4))
-        self.assertIn(b"(1/8) passtest.py:PassTest.test;run-short-beaf", result.stdout)
-        self.assertIn(b"(2/8) passtest.py:PassTest.test;run-medium-5595", result.stdout)
-        self.assertIn(b"(8/8) failtest.py:FailTest.test;run-longest-efc4",
+        self.assertIn(b"(suite01-1/8) passtest.py:PassTest.test;run-short-beaf", result.stdout)
+        self.assertIn(b"(suite01-2/8) passtest.py:PassTest.test;run-medium-5595", result.stdout)
+        self.assertIn(b"(suite01-8/8) failtest.py:FailTest.test;run-longest-efc4",
                       result.stdout)
 
     def test_run_mplex_failtest_tests_per_variant(self):
@@ -103,9 +103,9 @@ class MultiplexTests(unittest.TestCase):
                     % (AVOCADO, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         result = self.run_and_check(cmd_line, expected_rc, (4, 4))
-        self.assertIn(b"(1/8) passtest.py:PassTest.test;run-short-beaf", result.stdout)
-        self.assertIn(b"(2/8) failtest.py:FailTest.test;run-short-beaf", result.stdout)
-        self.assertIn(b"(8/8) failtest.py:FailTest.test;run-longest-efc4",
+        self.assertIn(b"(suite01-1/8) passtest.py:PassTest.test;run-short-beaf", result.stdout)
+        self.assertIn(b"(suite01-2/8) failtest.py:FailTest.test;run-short-beaf", result.stdout)
+        self.assertIn(b"(suite01-8/8) failtest.py:FailTest.test;run-longest-efc4",
                       result.stdout)
 
     def test_run_double_mplex(self):

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -590,7 +590,7 @@ class RunnerOperationTest(TestCaseTmpDir):
                              (expected_rc, result))
 
             test_log_dir = glob.glob(os.path.join(self.tmpdir.name, 'job-*',
-                                                  'test-results', '1-*'))[0]
+                                                  'test-results', 'suite01-1-*'))[0]
             test_log_path = os.path.join(test_log_dir, 'debug.log')
             with open(test_log_path, 'rb') as test_log:
                 self.assertIn(b'SHOULD BE ON debug.log', test_log.read())
@@ -655,7 +655,7 @@ class RunnerHumanOutputTest(TestCaseTmpDir):
         self.assertIn(b'[stdout] foo', result.stdout, result)
         self.assertIn(b'[stdout] \'"', result.stdout, result)
         self.assertIn(b'[stdout] bar/baz', result.stdout, result)
-        self.assertIn(b'PASS 1-foo\\\\n\\\'\\"\\\\nbar/baz',
+        self.assertIn(b'PASS suite01-1-foo\\\\n\\\'\\"\\\\nbar/baz',
                       result.stdout, result)
         # logdir name should escape special chars (/)
         test_dirs = glob.glob(os.path.join(self.tmpdir.name, 'latest',
@@ -664,7 +664,7 @@ class RunnerHumanOutputTest(TestCaseTmpDir):
                          " test-results dir, but only one test was executed: "
                          "%s" % (test_dirs))
         self.assertEqual(os.path.basename(test_dirs[0]),
-                         "1-foo__n_'____nbar_baz")
+                         "suite01-1-foo__n_'____nbar_baz")
 
     def test_replay_skip_skipped(self):
         cmd = ("%s run --job-results-dir %s --json - "
@@ -795,7 +795,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
         process.run(cmd_line)
         self.assertTrue(os.path.exists(os.path.join(self.tmpdir.name, "latest",
                                                     "test-results",
-                                                    "1-\'________\'/")))
+                                                    "suite01-1-\'________\'/")))
         self.assertTrue(os.path.exists(os.path.join(self.tmpdir.name, "latest",
                                                     "sysinfo", "pre",
                                                     "echo \'________\'")))
@@ -807,9 +807,9 @@ class RunnerSimpleTest(TestCaseTmpDir):
             # test results should replace odd chars with "_"
             # HTML could contain either the literal char, or an entity reference
             test1_href = (os.path.join("test-results",
-                                       "1-'________'") in html_results or
+                                       "suite01-1-'________'") in html_results or
                           os.path.join("test-results",
-                                       "1-&#39;________&#39;") in html_results)
+                                       "suite01-1-&#39;________&#39;") in html_results)
             self.assertTrue(test1_href)
             # sysinfo replaces "_" with " "
             sysinfo = ("echo '________'" in html_results or
@@ -1351,10 +1351,10 @@ class PluginsJSONTest(TestCaseTmpDir):
                                   0, 0, external_runner=GNU_ECHO_BINARY)
         # The executed test should be this
         self.assertEqual(data['tests'][0]['id'],
-                         '1--ne foo\\\\n\\\'\\"\\\\nbar/baz')
+                         'suite01-1--ne foo\\\\n\\\'\\"\\\\nbar/baz')
         # logdir name should escape special chars (/)
         self.assertEqual(os.path.basename(data['tests'][0]['logdir']),
-                         "1--ne foo__n_'____nbar_baz")
+                         "suite01-1--ne foo__n_'____nbar_baz")
 
 
 if __name__ == '__main__':

--- a/selftests/functional/test_job_timeout.py
+++ b/selftests/functional/test_job_timeout.py
@@ -89,7 +89,8 @@ class JobTimeOutTest(TestCaseTmpDir):
 
     def _check_timeout_msg(self, idx):
         res_dir = os.path.join(self.tmpdir.name, "latest", "test-results")
-        debug_log_paths = glob.glob(os.path.join(res_dir, "%s-*" % idx, "debug.log"))
+        debug_log_paths = glob.glob(os.path.join(res_dir, "suite01-%s-*" % idx,
+                                                 "debug.log"))
         debug_log = genio.read_file(debug_log_paths[0])
         self.assertIn("Runner error occurred: Timeout reached", debug_log,
                       "Runner error occurred: Timeout reached message not "

--- a/selftests/functional/test_json_variants.py
+++ b/selftests/functional/test_json_variants.py
@@ -45,9 +45,9 @@ class VariantsDumpLoadTests(TestCaseTmpDir):
         json_result = json.loads(result.stdout_text)
         self.assertEqual(json_result["pass"], 2)
         self.assertEqual(json_result["tests"][0]["id"],
-                         "1-passtest.py:PassTest.test;foo-0ead")
+                         "suite01-1-passtest.py:PassTest.test;foo-0ead")
         self.assertEqual(json_result["tests"][1]["id"],
-                         "2-passtest.py:PassTest.test;bar-d06d")
+                         "suite01-2-passtest.py:PassTest.test;bar-d06d")
 
 
 if __name__ == '__main__':

--- a/selftests/functional/test_streams.py
+++ b/selftests/functional/test_streams.py
@@ -65,9 +65,9 @@ class StreamsTest(TestCaseTmpDir):
         cmd_in_log = os.path.join(BASEDIR, 'avocado', '__main__.py')
         self.assertIn("Command line: %s" % cmd_in_log,
                       result.stdout_text)
-        self.assertIn(b"\nSTART 1-passtest.py:PassTest.test",
+        self.assertIn(b"\nSTART suite01-1-passtest.py:PassTest.test",
                       result.stdout)
-        self.assertIn(b"PASS 1-passtest.py:PassTest.test", result.stdout)
+        self.assertIn(b"PASS suite01-1-passtest.py:PassTest.test", result.stdout)
 
     def test_none_success(self):
         """


### PR DESCRIPTION
Today, we already display the suite name as a prefix when using
--test-suite='nrunner'. This change will apply this to the default
runner as well. This closes #4083.

Signed-off-by: Beraldo Leal <bleal@redhat.com>