### PR TITLE
Make test suite configuration available to spawners

### DIFF
--- a/avocado/core/dispatcher.py
+++ b/avocado/core/dispatcher.py
@@ -126,5 +126,6 @@ class InitDispatcher(EnabledExtensionManager):
 
 class SpawnerDispatcher(EnabledExtensionManager):
 
-    def __init__(self):
-        super(SpawnerDispatcher, self).__init__('avocado.plugins.spawner')
+    def __init__(self, config=None):
+        super(SpawnerDispatcher, self).__init__('avocado.plugins.spawner',
+                                                invoke_kwds={'config': config})

--- a/avocado/core/spawners/common.py
+++ b/avocado/core/spawners/common.py
@@ -3,6 +3,7 @@ from mmap import ACCESS_READ, mmap
 from pathlib import Path
 
 from ...core.data_dir import get_job_results_dir
+from ...core.settings import settings
 from ...utils.astring import string_to_safe_path
 from .exceptions import SpawnerException
 
@@ -25,6 +26,11 @@ class SpawnerMixin:
     """Common utilities for Spawner implementations."""
 
     METHODS = []
+
+    def __init__(self, config=None):
+        if config is None:
+            config = settings.as_dict()
+        self.config = config
 
     @staticmethod
     def bytes_from_file(filename):

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -234,7 +234,7 @@ class Runner(RunnerInterface):
             random.shuffle(self.tasks)
         tsm = TaskStateMachine(self.tasks)
         spawner_name = test_suite.config.get('nrunner.spawner')
-        spawner = SpawnerDispatcher()[spawner_name].obj
+        spawner = SpawnerDispatcher(test_suite.config)[spawner_name].obj
         max_running = test_suite.config.get('nrunner.max_parallel_tasks')
         workers = [Worker(tsm, spawner, max_running=max_running).run()
                    for _ in range(max_running)]

--- a/avocado/plugins/spawners/podman.py
+++ b/avocado/plugins/spawners/podman.py
@@ -61,8 +61,7 @@ class PodmanSpawner(Spawner, SpawnerMixin):
         entry_point = json.dumps(entry_point_args)
         entry_point_arg = "--entrypoint=" + entry_point
 
-        config = settings.as_dict()
-        podman_bin = config.get('spawner.podman.bin')
+        podman_bin = self.config.get('spawner.podman.bin')
 
         if not os.path.exists(podman_bin):
             msg = 'Podman binary "%s" is not available on the system'
@@ -70,7 +69,7 @@ class PodmanSpawner(Spawner, SpawnerMixin):
             runtime_task.status = msg
             return False
 
-        image = config.get('spawner.podman.image')
+        image = self.config.get('spawner.podman.image')
         try:
             # pylint: disable=E1133
             proc = await asyncio.create_subprocess_exec(


### PR DESCRIPTION
So that chosen configurations can be respected.  In the case of the
podman spawner, the image name and the podman binary were not being
respected.

Signed-off-by: Cleber Rosa <crosa@redhat.com>