### PR TITLE
[Diff Plugin] skip file if it cannot be decoded.

### DIFF
--- a/avocado/plugins/diff.py
+++ b/avocado/plugins/diff.py
@@ -415,7 +415,10 @@ class Diff(CLICmd):
                 name_header = ['\n', '** %s **\n' % name]
                 sysinfo.extend(name_header)
                 with open(os.path.join(path, name), 'r') as sysinfo_file:
-                    sysinfo.extend(sysinfo_file.readlines())
+                    try:
+                        sysinfo.extend(sysinfo_file.readlines())
+                    except UnicodeDecodeError:
+                        continue
 
         if sysinfo:
             del sysinfo[0]


### PR DESCRIPTION
The SysInfo plugin produces a `journalctl.gz` that cannot be decoded with the current Diff plugin implementation.

Let's skip files that cannot be decoded for now and propose a more robust solution later.

Signed-off-by: Willian Rampazzo <willianr@redhat.com>

First I tried an approach of ignoring errors with:

```
--- a/avocado/plugins/diff.py
+++ b/avocado/plugins/diff.py
@@ -414,11 +414,9 @@ class Diff(CLICmd):
             for name in sorted(files):
                 name_header = ['\n', '** %s **\n' % name]
                 sysinfo.extend(name_header)
-                with open(os.path.join(path, name), 'r') as sysinfo_file:
-                    try:
-                        sysinfo.extend(sysinfo_file.readlines())
-                    except UnicodeDecodeError:
-                        continue
+                with open(os.path.join(path, name), 'r',
+                          errors='ignore') as sysinfo_file:
+                    sysinfo.extend(sysinfo_file.readlines())
 
         if sysinfo:
             del sysinfo[0]
```

It works, but for the `journalctl.gz` file it will display useless information like:

```
** journalctl.gz **
,W_journalctl
.W_journalctl
```

I also did a test creating a file into the `sysinfo` directory with `dd if=/dev/urandom of=/home/wrampazz/avocado/job-results/job-2020-09-08T16.30-2656b04/sysinfo/post/random count=100` supposing the tester may add another kind of binary file. The approach worked, showing the string content of the file, but, maybe, not so useful as it is ignoring some characters.

With the current approach proposed here, Avocado successfully skipped the `journalctl.gz` and the file randomly generated. So, my take is to go with this implementation and discuss a more robust solution after the LTS for the Diff plugin.