### PR TITLE
core:runner: Added the suite name to the test name and using better name

### DIFF
--- a/avocado/core/suite.py
+++ b/avocado/core/suite.py
@@ -108,9 +108,9 @@ class TestSuite:
         except (LoaderUnhandledReferenceError, LoaderError) as details:
             raise TestSuiteError(details)
 
-        return cls(name=name or str(uuid4()),
-                   config=config,
-                   tests=tests)
+        if name is None:
+            name = str(uuid4())
+        return cls(name=name, config=config, tests=tests)
 
     @classmethod
     def _from_config_with_resolver(cls, config, name=None):
@@ -129,9 +129,9 @@ class TestSuite:
 
         tasks = resolutions_to_tasks(resolutions, config)
 
-        return cls(name=name or str(uuid4()),
-                   config=config,
-                   tests=tasks,
+        if name is None:
+            name = str(uuid4())
+        return cls(name=name, config=config, tests=tasks,
                    resolutions=resolutions)
 
     def _get_stats_from_nrunner(self):

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -295,7 +295,7 @@ class Run(CLICmd):
                 sys.exit(exit_codes.AVOCADO_FAIL)
 
         try:
-            suite = TestSuite.from_config(config, name='suite01')
+            suite = TestSuite.from_config(config, name='')
             if suite.size == 0:
                 sys.exit(exit_codes.AVOCADO_JOB_FAIL)
         except TestSuiteError as err:

--- a/avocado/plugins/runner.py
+++ b/avocado/plugins/runner.py
@@ -364,7 +364,12 @@ class TestRunner(Runner):
                                                           execution_order):
                 test_parameters = test_factory[1]
                 name = test_parameters.get("name")
-                test_parameters["name"] = TestID(index, name,
+                if test_suite.name is None:
+                    suite_prefix = "{}-{}".format(test_suite.name, index)
+                else:
+                    suite_prefix = index
+                test_parameters["name"] = TestID(suite_prefix,
+                                                 name,
                                                  variant,
                                                  no_digits)
                 if deadline is not None and time.time() > deadline:

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -156,7 +156,11 @@ class Runner(RunnerInterface):
         for index, task in enumerate(test_suite.tests, start=1):
             task.known_runners = nrunner.RUNNERS_REGISTRY_PYTHON_CLASS
             # this is all rubbish data
-            test_id = TestID("{}-{}".format(test_suite.name, index),
+            if test_suite.name is None:
+                prefix = "{}-{}".format(test_suite.name, index)
+            else:
+                prefix = index
+            test_id = TestID(prefix,
                              task.runnable.uri,
                              None,
                              no_digits)


### PR DESCRIPTION
Today, we already display the suite name as a prefix when using
--test-suite='nrunner'. This change will apply this to the default runner as
well. This closes #4083. I'm also renaming the default suite name here.

This is not the ideal solution, just a hotfix for LTS. We need to discuss better
this id situation. I created one issue (#4210) for that.

Signed-off-by: Beraldo Leal <bleal@redhat.com>

Changes from v1:

 - Renamed suite01 to SuiteDefault;
 - Removed the "SuiteDefault-" from Human Output when running from the command-line to keep compatibility with previous versions;