### PR TITLE
avocado.utils.process: restore newline on stdout/stderr/output

### DIFF
--- a/selftests/functional/test_output_check.py
+++ b/selftests/functional/test_output_check.py
@@ -7,8 +7,8 @@ from avocado.utils import process, script
 
 from .. import AVOCADO, TestCaseTmpDir
 
-STDOUT = b"Hello, \xc4\x9b\xc5\xa1\xc4\x8d\xc5\x99\xc5\xbe\xc3\xbd\xc3\xa1\xc3\xad\xc3\xa9!"
-STDERR = b"Hello, stderr!"
+STDOUT = b"Hello, \xc4\x9b\xc5\xa1\xc4\x8d\xc5\x99\xc5\xbe\xc3\xbd\xc3\xa1\xc3\xad\xc3\xa9!\n"
+STDERR = b"Hello, stderr!\n"
 
 JSON_VARIANTS = """
 [{"paths": ["/run/*"],
@@ -131,9 +131,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
 
     def setUp(self):
         super(RunnerSimpleTest, self).setUp()
-        content = b"#!/bin/sh\n"
-        content += b"echo \"" + STDOUT + b"\"\n"
-        content += b"echo \"" + STDERR + b"\" >&2\n"
+        content = b"#!/bin/sh\necho -n '%s';echo -n '%s'>&2" % (STDOUT, STDERR)
         self.output_script = script.TemporaryScript(
             'output_check.sh',
             content,


### PR DESCRIPTION
The FDDrainer reads data from processes and writes than to both a
regular logger, that has as '[stdout]' (or similar prefix) and to a
stream logger that writes the stdout/stderr/output files.

It looks for newlines in an attempt to present a human readable
result, but it fails to restore the newline on the
stdout/stderr/output files.  This restores it.

Fixes: https://github.com/avocado-framework/avocado/issues/4167
Signed-off-by: Cleber Rosa <crosa@redhat.com>