### PR TITLE
safeloader: fix support for multiple classes per import statement

### DIFF
--- a/avocado/core/safeloader.py
+++ b/avocado/core/safeloader.py
@@ -118,9 +118,9 @@ class PythonModule:
             for _ in range(level - 1):
                 path = os.path.dirname(path)
         for name in statement.names:
-            path = os.path.join(path, name.name.replace('.', os.path.sep))
+            full_path = os.path.join(path, name.name.replace('.', os.path.sep))
             final_name = self._get_name_from_alias_statement(name)
-            self.imported_objects[final_name] = path
+            self.imported_objects[final_name] = full_path
 
     @staticmethod
     def _get_name_from_alias_statement(alias):

--- a/selftests/unit/test_safeloader.py
+++ b/selftests/unit/test_safeloader.py
@@ -43,7 +43,8 @@ class Anyclass(Logger): pass
 '''
 
 RECURSIVE_DISCOVERY_TEST1 = """
-from avocado import Test
+# skip is not used, but stresses the safeloader
+from avocado import skip, Test
 
 class BaseClass(Test):
     def test_basic(self):
@@ -75,7 +76,8 @@ class ThirdChild(Test, SecondChild):
 
 
 RECURSIVE_DISCOVERY_PYTHON_UNITTEST = """
-from unittest import TestCase
+# main is not used, but stresses the safeloader
+from unittest import main, TestCase
 
 class BaseClass(TestCase):
     '''


### PR DESCRIPTION
We were adding to the import path on each iteration, which would break
everything starting from the second imported name.

Fixes: https://github.com/avocado-framework/avocado/issues/4038
Signed-off-by: Cleber Rosa <crosa@redhat.com>