### PR TITLE
nrunner: use more consistent time reporting

### DIFF
--- a/avocado/core/nrunner_avocado_instrumented.py
+++ b/avocado/core/nrunner_avocado_instrumented.py
@@ -62,7 +62,6 @@ class AvocadoInstrumentedTestRunner(nrunner.BaseRunner):
             del state['name']
         if 'time_start' in state:
             del state['time_start']
-        state['time'] = time.monotonic()
         queue.put(state)
 
     def run(self):
@@ -85,7 +84,9 @@ class AvocadoInstrumentedTestRunner(nrunner.BaseRunner):
                 most_current_execution_state_time = now
                 yield self.prepare_status('running')
 
-        yield queue.get()
+        status = queue.get()
+        status['time'] = time.monotonic()
+        yield status
 
 
 class RunnerApp(nrunner.BaseRunnerApp):


### PR DESCRIPTION
This is a similar change to that in 1f5a3e887, but now applied to
the avocado-instrumented runner.

First, by using time.monotonic(), we make sure that status messages
don't get generated with inconsistent times, that is, an earlier
"finished" message than a "running" one.

We also defer to the very last minute to time the message so that the
earlier "finished" than running example, which was actually happening,
doesn't happen.

This fixes a bug in which the 'finished' status is produced with an
earlier time than the 'running' status, and causes the status repo
to discard this update because it's an older message.

Signed-off-by: Cleber Rosa <crosa@redhat.com>