### PR TITLE
nrunner: get the task status update as a FIFO

### DIFF
--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -177,7 +177,7 @@ class Runner(RunnerInterface):
                        for runtime_task in self.tasks}
         while True:
             try:
-                (task_id, status, _) = self.status_repo.status_journal_summary.pop()
+                (task_id, status, _) = self.status_repo.status_journal_summary.pop(0)
 
             except IndexError:
                 await asyncio.sleep(0.05)


### PR DESCRIPTION
Without this change, the following is given to the ResultEvents (and
thus the following shows up in the Human UI):

   JOB ID     : 3af3f0017081df17162bbee5abaca08f4ec3a561
   JOB LOG    : /home/cleber/avocado/job-results/job-2020-09-09T12.03-3af3f00/job.log
    (suite01-3/4) examples/tests/passtest.py:PassTest.test: PASS (0.01 s)
    (suite01-3/4) examples/tests/passtest.py:PassTest.test: STARTED
    (suite01-1/4) examples/tests/passtest.py:PassTest.test: PASS (0.01 s)
    (suite01-1/4) examples/tests/passtest.py:PassTest.test: STARTED
    (suite01-4/4) examples/tests/passtest.py:PassTest.test: PASS (0.01 s)
    (suite01-2/4) examples/tests/passtest.py:PassTest.test: PASS (0.01 s)
    (suite01-4/4) examples/tests/passtest.py:PassTest.test: STARTED
    (suite01-2/4) examples/tests/passtest.py:PassTest.test: STARTED
   RESULTS    : PASS 4 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
   JOB HTML   : /home/cleber/avocado/job-results/job-2020-09-09T12.03-3af3f00/results.html
   JOB TIME   : 1.17 s

With this change, the order the events were added to the status repo
are respected, and the output looks like:

   JOB ID     : dc9d884b9b20a98a89a755d3cd55f54ceb355e98
   JOB LOG    : /home/cleber/avocado/job-results/job-2020-09-09T12.06-dc9d884/job.log
    (suite01-2/4) examples/tests/passtest.py:PassTest.test: STARTED
    (suite01-3/4) examples/tests/passtest.py:PassTest.test: STARTED
    (suite01-2/4) examples/tests/passtest.py:PassTest.test: PASS (0.02 s)
    (suite01-3/4) examples/tests/passtest.py:PassTest.test: PASS (0.01 s)
    (suite01-1/4) examples/tests/passtest.py:PassTest.test: STARTED
    (suite01-4/4) examples/tests/passtest.py:PassTest.test: STARTED
    (suite01-1/4) examples/tests/passtest.py:PassTest.test: PASS (0.01 s)
    (suite01-4/4) examples/tests/passtest.py:PassTest.test: PASS (0.01 s)
   RESULTS    : PASS 4 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
   JOB HTML   : /home/cleber/avocado/job-results/job-2020-09-09T12.06-dc9d884/results.html
   JOB TIME   : 1.21 s

Signed-off-by: Cleber Rosa <crosa@redhat.com>