### PR TITLE
Travis CI: install supporting packages for spell checking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ env:
 addons:
   apt:
     packages:
+    - enchant
+    - hunspell-en-us
     - golang
 
 install:

--- a/requirements-selftests.txt
+++ b/requirements-selftests.txt
@@ -2,6 +2,7 @@
 
 # inspektor (static and style checks)
 isort==4.3.21
+pyenchant==2.0.0
 pylint==2.5.0
 astroid==2.4.0
 inspektor==0.5.2


### PR DESCRIPTION
pylint requires a dictionary, and the enchant library.

Signed-off-by: Cleber Rosa <crosa@redhat.com>