### PR TITLE
[Diff Plugin] skip file if it cannot be decoded [v2].

### DIFF
--- a/avocado/plugins/diff.py
+++ b/avocado/plugins/diff.py
@@ -415,7 +415,13 @@ class Diff(CLICmd):
                 name_header = ['\n', '** %s **\n' % name]
                 sysinfo.extend(name_header)
                 with open(os.path.join(path, name), 'r') as sysinfo_file:
-                    sysinfo.extend(sysinfo_file.readlines())
+                    try:
+                        sysinfo.extend(sysinfo_file.readlines())
+                    except UnicodeDecodeError:
+                        msg = ("Ignoring file %s as it cannot be decoded."
+                               % name)
+                        LOG_UI.debug(msg)
+                        continue
 
         if sysinfo:
             del sysinfo[0]

--- a/docs/source/guides/user/chapters/operations.rst
+++ b/docs/source/guides/user/chapters/operations.rst
@@ -210,6 +210,9 @@ Avocado Diff can compare and create an unified diff of:
 - Configuration.
 - Sysinfo pre and post.
 
+.. note:: Avocado Diff will ignore files containing non UTF-8 characters, like
+          binaries, as an example.
+
 Only sections with different content will be included in the results. You can
 also enable/disable those sections with ``--diff-filter``. Please see ``avocado
 diff --help`` for more information.


### PR DESCRIPTION
The SysInfo plugin produces a `journalctl.gz` that cannot be decoded with the current Diff plugin implementation.

Let's skip files that cannot be decoded for now and propose a more robust solution later.

Signed-off-by: Willian Rampazzo <willianr@redhat.com>

Changes from v1:
- Add debug message;
- Update the documentation.