### PR TITLE
examples/tests/raise.py: fix use of bytes instead of string

### DIFF
--- a/examples/tests/raise.py
+++ b/examples/tests/raise.py
@@ -39,10 +39,10 @@ class Raise(Test):
         self.log.info(cmd_result)
         if signum == 0:
             expected_result = 0
-            self.assertIn("I'm alive!", cmd_result.stdout)
+            self.assertIn("I'm alive!", cmd_result.stdout_text)
         elif 0 < signum < 65:
             expected_result = -signum   # pylint: disable=E1130
         else:
             expected_result = 255
-            self.assertIn("raise: Invalid argument", cmd_result.stderr)
+            self.assertIn("raise: Invalid argument", cmd_result.stderr_text)
         self.assertEqual(cmd_result.exit_status, expected_result)


### PR DESCRIPTION
When run with the example varianter file:

```
   avocado run -m examples/tests/raise.py.data/raise.yaml \
       -- examples/tests/raise.py
```

The test gets to a block that misuses the process stdout as bytes
instead of as string.

Signed-off-by: Cleber Rosa <crosa@redhat.com>