### PR TITLE
Fixup: Handle cpu utils failure on AMD and ARM cpu archs

### DIFF
--- a/avocado/utils/cpu.py
+++ b/avocado/utils/cpu.py
@@ -185,7 +185,9 @@ def get_family():
     arch = get_arch()
     if arch == 'x86_64' or arch == 'i386':
         if get_vendor() == 'amd':
-            raise NotImplementedError
+            # FIXME
+            logging.warning("Not implemented: Unknown cpu family for amd")
+            return family
         try:
             # refer below links for microarchitectures names
             # https://en.wikipedia.org/wiki/List_of_Intel_CPU_microarchitectures
@@ -213,7 +215,9 @@ def get_family():
         except KeyError as err:
             logging.warning("Could not find family for %s\nError: %s", get_version(), err)
     elif arch == 'arm':
-        raise NotImplementedError
+        # FIXME
+        logging.warning("Not implemented: Unknown cpu family for arm")
+        return family
     return family
 
 


### PR DESCRIPTION
get_family() method is not yet implemented for certain cpu archs like
amd, arm so while using in the generic code path like below in avocado-vt
libraries we hit below unwanted error, so let's warn the user and return
safely None.

 Reproduced traceback from: /usr/lib/python3.8/site-packages/avocado_vt/test.py:442
 Traceback (most recent call last):
   File "/usr/lib/python3.8/site-packages/virttest/error_context.py", line 135, in new_fn
     return fn(*args, **kwargs)
   File "/usr/lib/python3.8/site-packages/virttest/env_process.py", line 932, in preprocess
     cpu_family = cpu_utils.get_family() if hasattr(cpu_utils, 'get_family') else cpu_utils.get_cpu_arch()
   File "/usr/lib/python3.8/site-packages/avocado/utils/cpu.py", line 188, in get_family
     raise NotImplementedError
 NotImplementedError

Reported-by: Plamen Dimitrov <pdimitrov@pevogam.com>
Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>