### PR TITLE
utils.cpu: Handle "aarch64" in get_family()

### DIFF
--- a/avocado/utils/cpu.py
+++ b/avocado/utils/cpu.py
@@ -212,7 +212,7 @@ def get_family():
             family = zfamily_map[get_version()].lower()
         except KeyError as err:
             logging.warning("Could not find family for %s\nError: %s", get_version(), err)
-    elif arch == 'arm':
+    elif arch == 'arm' or arch == 'aarch64':
         raise NotImplementedError
     return family
 

--- a/selftests/unit/test_utils_cpu.py
+++ b/selftests/unit/test_utils_cpu.py
@@ -163,6 +163,16 @@ class Cpu(Test):
                                      return_value=self._get_data_mock('power9')):
                 self.assertEqual(cpu.get_family(), "power9")
 
+    def test_arm_get_family(self):
+        with unittest.mock.patch('avocado.utils.cpu.get_arch', return_value='arm'):
+            with self.assertRaises(NotImplementedError):
+                cpu.get_family()
+
+    def test_aarch64_get_family(self):
+        with unittest.mock.patch('avocado.utils.cpu.get_arch', return_value='aarch64'):
+            with self.assertRaises(NotImplementedError):
+                cpu.get_family()
+
     def test_get_idle_state_off(self):
         retval = {0: {0: False}}
         with unittest.mock.patch('avocado.utils.cpu.online_list',


### PR DESCRIPTION
utils.cpu.get_arch() can return "aarch64" but get_family() missed this
value, add it to handle this situation.

https://github.com/avocado-framework/avocado/blob/e97540793998c4f24a16000465dd7fdd213bf2b9/avocado/utils/cpu.py#L165-L175
Signed-off-by: Yihuang Yu <yihyu@redhat.com>