### PR TITLE
Golang: add a nrunner based implementation

### DIFF
--- a/optional_plugins/golang/avocado_golang/runner.py
+++ b/optional_plugins/golang/avocado_golang/runner.py
@@ -1,0 +1,62 @@
+import subprocess
+import time
+
+from avocado.core import nrunner
+from avocado_golang import GO_BIN
+
+
+class GolangRunner(nrunner.BaseRunner):
+    """Runner for Golang tests.
+
+    When creating the Runnable, use the following attributes:
+
+     * kind: should be 'golang';
+
+     * uri: module name and optionally a test method name, separated by colon;
+
+     * args: not used
+
+     * kwargs: not used
+
+    Example:
+
+       runnable = Runnable(kind='golang',
+                           uri='countavocados:ExampleContainers')
+    """
+    def run(self):
+        module, test = self.runnable.uri.split(':', 1)
+
+        cmd = [GO_BIN, 'test', '-v', module]
+        if test is not None:
+            cmd += ['-run', '%s$' % test]
+
+        process = subprocess.Popen(
+            cmd,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE)
+
+        while process.poll() is None:
+            time.sleep(nrunner.RUNNER_RUN_STATUS_INTERVAL)
+            yield self.prepare_status('running')
+
+        result = 'pass' if process.returncode == 0 else 'fail'
+        yield self.prepare_status('finished',
+                                  {'result': result,
+                                   'returncode': process.returncode,
+                                   'stdout': process.stdout.read(),
+                                   'stderr': process.stderr.read()})
+
+
+class RunnerApp(nrunner.BaseRunnerApp):
+    PROG_NAME = 'avocado-runner-golang'
+    PROG_DESCRIPTION = 'nrunner application for golang tests'
+    RUNNABLE_KINDS_CAPABLE = {'golang': GolangRunner}
+
+
+def main():
+    nrunner.main(RunnerApp)
+
+
+if __name__ == '__main__':
+    main()

--- a/optional_plugins/golang/setup.py
+++ b/optional_plugins/golang/setup.py
@@ -28,10 +28,16 @@ setup(name='avocado-framework-plugin-golang',
       install_requires=['avocado-framework==%s' % VERSION],
       test_suite='tests',
       entry_points={
+          'console_scripts': [
+              'avocado-runner-golang = avocado_golang.runner:main',
+          ],
           'avocado.plugins.cli': [
               'golang = avocado_golang:GolangCLI',
           ],
           'avocado.plugins.resolver': [
               'golang = avocado_golang:GolangResolver',
+          ],
+          'avocado.plugins.runnable.runner': [
+              'golang = avocado_golang.runner:GolangRunner'
           ]}
       )

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -34,7 +34,7 @@
 Summary: Framework with tools and libraries for Automated Testing
 Name: python-%{srcname}
 Version: 82.0
-Release: 2%{?gitrel}%{?dist}
+Release: 3%{?gitrel}%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.github.io/
@@ -314,6 +314,7 @@ also run them.
 %files -n python3-%{srcname}-plugins-golang
 %{python3_sitelib}/avocado_golang*
 %{python3_sitelib}/avocado_framework_plugin_golang*
+%{_bindir}/avocado-runner-golang
 
 %package -n python3-%{srcname}-plugins-varianter-pict
 Summary: Varianter with combinatorial capabilities by PICT
@@ -383,6 +384,9 @@ Again Shell code (and possibly other similar shells).
 %{_libexecdir}/avocado*
 
 %changelog
+* Thu Sep 17 2020 Cleber Rosa <cleber@redhat.com> - 82.0-3
+- Added avocado-runner-golang script to golang package
+
 * Wed Sep 16 2020 Cleber Rosa <cleber@redhat.com> - 82.0-2
 - Removed yaml to mux loader plugin
 - Removed glib plugin

--- a/spell.ignore
+++ b/spell.ignore
@@ -732,3 +732,5 @@ dd
 kb
 segfault
 unpicked
+countavocados
+ExampleContainers


### PR DESCRIPTION
While a Golang resolver was available, a runner (nrunner-like) was
not.

Like the previous runner version, this does not attempt to manipulate
the GOROOT/GOPATH variables, so to try this out you want to run, from
the top of the Avocado source tree:

 $ GOPATH=`pwd`/optional_plugins/golang/tests:$GOPATH avocado run \
   --test-runner=nrunner countavocados

Signed-off-by: Cleber Rosa <crosa@redhat.com>