### PR TITLE
Setuptools implementation

### DIFF
--- a/avocado/utils/kernel.py
+++ b/avocado/utils/kernel.py
@@ -22,7 +22,7 @@ import multiprocessing
 import os
 import shutil
 import tempfile
-from distutils.version import LooseVersion  # pylint: disable=E0611
+from packaging import version as versobjc
 
 from . import archive, asset, build, distro, process
 
@@ -207,4 +207,4 @@ def check_version(version):
     :type version: string
     :param version: version to be compared with current kernel version
     """
-    assert LooseVersion(os.uname()[2]) > LooseVersion(version), "Old kernel"
+    assert versobjc.parse(os.uname()[2]) > versobjc.parse(version), "Old kernel"

--- a/contrib/packages/debian/rules
+++ b/contrib/packages/debian/rules
@@ -4,7 +4,7 @@
 DEB_PYTHON_SYSTEM := pysupport
 
 include /usr/share/cdbs/1/rules/debhelper.mk
-include /usr/share/cdbs/1/class/python-distutils.mk
+#include /usr/share/cdbs/1/class/python-distutils.mk
 
 clean::
 	rm -rf build build-stamp configure-stamp build/ MANIFEST


### PR DESCRIPTION
- Replaced version check via `distutils.LooseVersion()` with the `packaging.version()`.
- Excluded `python-distuils` in Debian rules.
- Note that `packaging` is included in `setuptools`.