### PR TITLE
Used time.monotonic() for utils/process.py timeout

### DIFF
--- a/avocado/utils/kernel.py
+++ b/avocado/utils/kernel.py
@@ -22,7 +22,7 @@ import multiprocessing
 import os
 import shutil
 import tempfile
-from distutils.version import LooseVersion  # pylint: disable=E0611
+from packaging import version as versobjc
 
 from . import archive, asset, build, distro, process
 
@@ -207,4 +207,4 @@ def check_version(version):
     :type version: string
     :param version: version to be compared with current kernel version
     """
-    assert LooseVersion(os.uname()[2]) > LooseVersion(version), "Old kernel"
+    assert versobjc.parse(os.uname()[2]) > versobjc.parse(version), "Old kernel"


### PR DESCRIPTION
- Ran a `grep -Ril "start_time" | grep ".py"` and `grep -Ril "stop_time" | grep ".py"` to recursively scan for occurrences of "start_time" and "stop_time" (which would infer that duration is most likely being calculated in those Python files) and listed them. (Reference is taken from #3887)
```
$ grep -Ril "start_time" | grep ".py"
avocado/core/data_dir.py
avocado/utils/process.py
avocado/utils/wait.py
```
```
$ grep -Ril "stop_time" | grep ".py"
avocado/utils/process.py
```
- Made some 7 replacements in `avocado/utils/process.py`.
- Made the commit from the browser itself so it gets automatically signed.
- Please disregard #4243 and consider reviewing this.