### PR TITLE
increase timeout value

### DIFF
--- a/avocado/utils/network/interfaces.py
+++ b/avocado/utils/network/interfaces.py
@@ -302,7 +302,7 @@ class NetworkInterface:
             ifcfg_dict.pop('BOOTPROTO')
         self._write_to_file("{}/{}".format(path, filename), ifcfg_dict)
 
-    def set_mtu(self, mtu, timeout=30):
+    def set_mtu(self, mtu, timeout=120):
         """Sets a new MTU value to this interface.
 
         This method will try to set a new MTU value to this interface,


### PR DESCRIPTION
increasing the timeout value from 30s to 120s.
On changing the mtu value, few adapters take a longer time for the
operational state to come up. Setting this mtu value to max timeout
value.

Signed-off-by: Vaishnavi Bhat <vaishnavi@linux.vnet.ibm.com>