### PR TITLE
Replaced LooseVersion with Version from packaging

### DIFF
--- a/avocado/utils/kernel.py
+++ b/avocado/utils/kernel.py
@@ -22,7 +22,8 @@ import multiprocessing
 import os
 import shutil
 import tempfile
-from distutils.version import LooseVersion  # pylint: disable=E0611
+
+from pkg_resources import packaging
 
 from . import archive, asset, build, distro, process
 
@@ -207,4 +208,6 @@ def check_version(version):
     :type version: string
     :param version: version to be compared with current kernel version
     """
-    assert LooseVersion(os.uname()[2]) > LooseVersion(version), "Old kernel"
+    os_version = packaging.version.parse(os.uname()[2])
+    version = packaging.version.parse(version)
+    assert os_version > version, "Old kernel"

--- a/contrib/packages/debian/rules
+++ b/contrib/packages/debian/rules
@@ -4,7 +4,6 @@
 DEB_PYTHON_SYSTEM := pysupport
 
 include /usr/share/cdbs/1/rules/debhelper.mk
-include /usr/share/cdbs/1/class/python-distutils.mk
 
 clean::
 	rm -rf build build-stamp configure-stamp build/ MANIFEST


### PR DESCRIPTION
Also, removed distutils from debian rules

Signed-off-by: t0xic0der <akashdeep.dhar@gmail.com>

Resolves #4228. Had to make a new PR because I was not able to figure out how to amend and sign off those which were already pushed. Sincere apologies for the inexperience. I also took care of the corrections requested [here](https://github.com/avocado-framework/avocado/pull/4248#discussion_r494208281), [here](https://github.com/avocado-framework/avocado/pull/4248#discussion_r494162839) and [here](https://github.com/avocado-framework/avocado/pull/4248#pullrequestreview-495379241).

I ran a check locally and it returned 0 errors.

```
...
Extracting PyYAML-5.3.1-py3.8-linux-x86_64.egg to /home/t0xic0der/.local/lib/python3.8/site-packages
Adding PyYAML 5.3.1 to easy-install.pth file

Installed /home/t0xic0der/.local/lib/python3.8/site-packages/PyYAML-5.3.1-py3.8-linux-x86_64.egg
Searching for avocado-framework==82.0
Best match: avocado-framework 82.0
avocado-framework 82.0 is already the active version in easy-install.pth
Installing avocado script to /home/t0xic0der/.local/bin
Installing avocado-runner script to /home/t0xic0der/.local/bin
Installing avocado-runner-avocado-instrumented script to /home/t0xic0der/.local/bin
Installing avocado-runner-exec script to /home/t0xic0der/.local/bin
Installing avocado-runner-exec-test script to /home/t0xic0der/.local/bin
Installing avocado-runner-noop script to /home/t0xic0der/.local/bin
Installing avocado-runner-python-unittest script to /home/t0xic0der/.local/bin
Installing avocado-runner-tap script to /home/t0xic0der/.local/bin
Installing avocado-software-manager script to /home/t0xic0der/.local/bin

Using /home/t0xic0der/Projects/avocado
Searching for setuptools==50.3.0
Best match: setuptools 50.3.0
Adding setuptools 50.3.0 to easy-install.pth file
Installing easy_install script to /home/t0xic0der/.local/bin
Installing easy_install-3.8 script to /home/t0xic0der/.local/bin

Using /usr/lib/python3.8/site-packages
Finished processing dependencies for avocado-framework-plugin-varianter-yaml-to-mux==82.0
/home/t0xic0der/Projects/avocado
# Unless manually set, this is equivalent to AVOCADO_CHECK_LEVEL=0
PYTHON=/usr/bin/python3 /usr/bin/python3 -m avocado run --test-runner=nrunner --ignore-missing-references -- selftests/*.sh selftests/jobs/* selftests/unit/ selftests/functional/ ./optional_plugins/robot/tests/ ./optional_plugins/resultsdb/tests/ ./optional_plugins/html/tests/ ./optional_plugins/golang/tests/ ./optional_plugins/varianter_pict/tests/ ./optional_plugins/varianter_cit/tests/ ./optional_plugins/result_upload/tests/ ./optional_plugins/varianter_yaml_to_mux/tests/
JOB ID     : 2954b5eca043dafa8eed7124a7c4c8034f90c11b
JOB LOG    : /home/t0xic0der/avocado/job-results/job-2020-09-27T08.23-2954b5e/job.log
RESULTS    : PASS 0 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/t0xic0der/avocado/job-results/job-2020-09-27T08.23-2954b5e/results.html
JOB TIME   : 9.36 s
PYTHON=/usr/bin/python3 /usr/bin/python3 selftests/job_api/test_features.py
JOB ID     : ba101600fdac7343a99fff00957ffe67b1fa7eec
JOB LOG    : /home/t0xic0der/avocado/job-results/job-2020-09-27T08.23-ba10160/job.log
 (b38a4397-af66-4ad6-ab47-29832093fba9-1/1) selftests/job_api/test_features.py:JobAPIFeaturesTest.test_check_archive_file_exists;run.results.archive-True-True: PASS (0.45 s)
 (3b022aae-82fe-4093-88c0-bb9bb7e301dd-1/1) selftests/job_api/test_features.py:JobAPIFeaturesTest.test_check_category_directory_exists;run.job_category-foo-True: PASS (0.45 s)
 (7c61a883-d9ae-4621-8437-e0200be94c80-1/2) selftests/job_api/test_features.py:JobAPIFeaturesTest.test_check_directory_exists;sysinfo.collect.enabled-True-sysinfo-True: PASS (0.34 s)
 (7c61a883-d9ae-4621-8437-e0200be94c80-2/2) selftests/job_api/test_features.py:JobAPIFeaturesTest.test_check_directory_exists;sysinfo.collect.enabled-False-sysinfo-False: PASS (0.16 s)
 (9b8ad0ff-b547-4631-b21b-9ff87cb555df-1/9) selftests/job_api/test_features.py:JobAPIFeaturesTest.test_check_file_content;job.output.loglevel-INFO-job.log-DEBUG| Test metadata-False: PASS (0.35 s)
 (9b8ad0ff-b547-4631-b21b-9ff87cb555df-2/9) selftests/job_api/test_features.py:JobAPIFeaturesTest.test_check_file_content;job.run.result.tap.include_logs-True-results.tap-Command '/bin/true' finished with 0-True: PASS (0.58 s)
 (9b8ad0ff-b547-4631-b21b-9ff87cb555df-3/9) selftests/job_api/test_features.py:JobAPIFeaturesTest.test_check_file_content;job.run.result.tap.include_logs-False-results.tap-Command '/bin/true' finished with 0-False: PASS (0.38 s)
 (9b8ad0ff-b547-4631-b21b-9ff87cb555df-4/9) selftests/job_api/test_features.py:JobAPIFeaturesTest.test_check_file_content;job.run.result.xunit.job_name-foo-results.xml-name="foo"-True: PASS (0.43 s)
 (9b8ad0ff-b547-4631-b21b-9ff87cb555df-5/9) selftests/job_api/test_features.py:JobAPIFeaturesTest.test_check_file_content;job.run.result.xunit.max_test_log_chars-1-results.xml---[ CUT DUE TO XML PER TEST LIMIT ]---True: PASS (0.37 s)
 (9b8ad0ff-b547-4631-b21b-9ff87cb555df-6/9) selftests/job_api/test_features.py:JobAPIFeaturesTest.test_check_file_content;run.failfast-True-results.json-"skip": 1-True: PASS (0.38 s)
 (9b8ad0ff-b547-4631-b21b-9ff87cb555df-7/9) selftests/job_api/test_features.py:JobAPIFeaturesTest.test_check_file_content;run.ignore_missing_references-on-results.json-"pass": 1-True:  Unable to resolve reference(s) 'foo' with plugins(s) 'file', 'tap', 'external', 'file', 'tap', 'external', 'file', 'tap', 'external', 'file', 'tap', 'external', 'file', 'tap', 'external', 'file', 'tap', 'external', 'file', 'tap', 'external', 'file', 'tap', 'external', try running 'avocado -V list foo' to see the details.
PASS (0.42 s)
 (9b8ad0ff-b547-4631-b21b-9ff87cb555df-8/9) selftests/job_api/test_features.py:JobAPIFeaturesTest.test_check_file_content;run.unique_job_id-abcdefghi-job.log-Job ID: abcdefghi-True: PASS (0.35 s)
 (9b8ad0ff-b547-4631-b21b-9ff87cb555df-9/9) selftests/job_api/test_features.py:JobAPIFeaturesTest.test_check_file_content;job.run.timeout-1-job.log-RuntimeError: Test interrupted by SIGTERM-True: PASS (1.51 s)
 (db7efd5a-a501-4b18-9d2c-bc8e82128a43-1/12) selftests/job_api/test_features.py:JobAPIFeaturesTest.test_check_file_exists;job.run.result.html.enabled-on-results.html-True: PASS (0.33 s)
 (db7efd5a-a501-4b18-9d2c-bc8e82128a43-2/12) selftests/job_api/test_features.py:JobAPIFeaturesTest.test_check_file_exists;job.run.result.html.enabled-off-results.html-False: PASS (0.32 s)
 (db7efd5a-a501-4b18-9d2c-bc8e82128a43-3/12) selftests/job_api/test_features.py:JobAPIFeaturesTest.test_check_file_exists;job.run.result.json.enabled-on-results.json-True: PASS (0.72 s)
 (db7efd5a-a501-4b18-9d2c-bc8e82128a43-4/12) selftests/job_api/test_features.py:JobAPIFeaturesTest.test_check_file_exists;job.run.result.json.enabled-off-results.json-False: PASS (0.50 s)
 (db7efd5a-a501-4b18-9d2c-bc8e82128a43-5/12) selftests/job_api/test_features.py:JobAPIFeaturesTest.test_check_file_exists;job.run.result.tap.enabled-on-results.tap-True: PASS (0.60 s)
 (db7efd5a-a501-4b18-9d2c-bc8e82128a43-6/12) selftests/job_api/test_features.py:JobAPIFeaturesTest.test_check_file_exists;job.run.result.tap.enabled-off-results.tap-False: PASS (0.68 s)
 (db7efd5a-a501-4b18-9d2c-bc8e82128a43-7/12) selftests/job_api/test_features.py:JobAPIFeaturesTest.test_check_file_exists;job.run.result.xunit.enabled-on-results.xml-True: PASS (0.67 s)
 (db7efd5a-a501-4b18-9d2c-bc8e82128a43-8/12) selftests/job_api/test_features.py:JobAPIFeaturesTest.test_check_file_exists;job.run.result.xunit.enabled-off-results.xml-False: PASS (0.91 s)
 (db7efd5a-a501-4b18-9d2c-bc8e82128a43-9/12) selftests/job_api/test_features.py:JobAPIFeaturesTest.test_check_file_exists;run.dry_run.enabled-True-job.log-False: PASS (0.63 s)
 (db7efd5a-a501-4b18-9d2c-bc8e82128a43-10/12) selftests/job_api/test_features.py:JobAPIFeaturesTest.test_check_file_exists;run.dry_run.no_cleanup-True-job.log-True: PASS (0.64 s)
 (db7efd5a-a501-4b18-9d2c-bc8e82128a43-11/12) selftests/job_api/test_features.py:JobAPIFeaturesTest.test_check_file_exists;plugins.disable-['result.xunit']-result.xml-False: PASS (0.62 s)
 (db7efd5a-a501-4b18-9d2c-bc8e82128a43-12/12) selftests/job_api/test_features.py:JobAPIFeaturesTest.test_check_file_exists;run.journal.enabled-True-.journal.sqlite-True: PASS (1.08 s)
 (f6022ffa-9c17-4591-ab0b-5eb51d75bc0f-1/4) selftests/job_api/test_features.py:JobAPIFeaturesTest.test_check_output_file;job.run.result.html.output-custom.html-True: PASS (0.62 s)
 (f6022ffa-9c17-4591-ab0b-5eb51d75bc0f-2/4) selftests/job_api/test_features.py:JobAPIFeaturesTest.test_check_output_file;job.run.result.json.output-custom.json-True: PASS (0.62 s)
 (f6022ffa-9c17-4591-ab0b-5eb51d75bc0f-3/4) selftests/job_api/test_features.py:JobAPIFeaturesTest.test_check_output_file;job.run.result.tap.output-custom.tap-True: PASS (0.59 s)
 (f6022ffa-9c17-4591-ab0b-5eb51d75bc0f-4/4) selftests/job_api/test_features.py:JobAPIFeaturesTest.test_check_output_file;job.run.result.xunit.output-custom.xml-True: PASS (0.66 s)
 (5ce48a59-5bf4-47b5-bab6-1b10ef20f039-1/1) selftests/job_api/test_features.py:JobAPIFeaturesTest.test_check_tmp_directory_exists;run.keep_tmp-True-True: PASS (0.32 s)
RESULTS    : PASS 30 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
selftests/check_tmp_dirs
No temporary avocado dirs lying around in /tmp
[t0xic0der@ToxicDragon avocado]$ echo "Happy Hacktoberfest! :)"
Happy Hacktoberfest! :)
...
```

Please disregard #4248 if this works just fine.