### PR TITLE
nrunner: fix location and name of runner modules

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -244,9 +244,9 @@ class Runnable:
         # runner convention within the avocado.core namespace dir.
         # Looking for the file only avoids an attempt to load the module
         # and should be a lot faster
-        core_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        module_name = self.kind.replace('-', '_')
-        module_filename = 'nrunner_%s.py' % module_name
+        core_dir = os.path.dirname(os.path.abspath(__file__))
+        module_name = "nrunner_%s" % self.kind.replace('-', '_')
+        module_filename = '%s.py' % module_name
         if os.path.exists(os.path.join(core_dir, module_filename)):
             full_module_name = 'avocado.core.%s' % module_name
             candidate_cmd = [sys.executable, '-m', full_module_name]


### PR DESCRIPTION
While looking for suitable runners for a given kind, an
`avocado-runner-$kind` executable is tried out.  This is convenient
because any executable on the system could play the role of an
runner.

But, in some circunstances, those valid executables won't be in a
location that is the `PATH` environment variable.  For instance, on
non-activated Python virtual environments, a command such as:

 /path/to/venv/bin/avocado run --test-runner /path/to/test

Won't have `/path/to/venv/bin` in the `PATH`.  One can argue that this
is an uncommon deployment scenario, but it's a valid one and currently
used by projects such as QEMU.

Now, there's already support for alternative ways of finding the test
runners, and the next one attempted is looking for a
"avocado.core.nrunner_$kind" Python module.  This fixes the location
and module name, so that it's corretly found in the venv scenarios
mentioned earlier.

Signed-off-by: Cleber Rosa <crosa@redhat.com>