### PR TITLE
Travis CI: fixes and inclusion of basic Python 3.9 checks and exteded OS X / Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,17 @@ jobs:
       # Disable pip cache dir temporarily
       install:
        - pip install --no-cache-dir -r requirements-selftests.txt
+    - name: "Smokecheck on Windows"
+      os: windows
+      language: sh
+      python: "3.9"
+      before_install:
+        - choco install python3 --version 3.9.0
+      install:
+        - /c/Python39/python setup.py develop --user
+      script:
+        - /c/Python39/python -m avocado --help
+        - /c/Python39/python -m avocado run --test-runner=nrunner examples/tests/passtest.py
     - name: "Ad hoc checks on OS X"
       os: osx
       language: c

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,21 @@ jobs:
       script:
         - /c/Python39/python -m avocado --help
         - /c/Python39/python -m avocado run --test-runner=nrunner examples/tests/passtest.py
+    - name: "Smokecheck on OS X"
+      os: osx
+      language: c
+      osx_image: xcode10.3
+      compiler: clang
+      addons:
+        homebrew:
+          packages:
+            - python
+          update: false
+      install:
+        - python3 setup.py develop --user
+      script:
+        - python3 -m avocado --help
+        - python3 -m avocado run --test-runner=nrunner examples/tests/passtest.py
     - name: "Ad hoc checks on OS X"
       os: osx
       language: c
@@ -103,4 +118,4 @@ jobs:
 
   allow_failures:
     - python: "nightly"
-    - os: osx
+    - name: "Ad hoc checks on OS X"

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ jobs:
         - python3 setup.py develop --user
       script:
         - python3 -m avocado --help
-        - python3 -m avocado nlist --verbose selftests/unit/* selftests/functional/* selftests/*sh
+        - python3 -m avocado --verbose list --resolver selftests/unit/* selftests/functional/* selftests/*sh
         - python3 -m unittest discover -v selftests.unit
 
   allow_failures:

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -244,9 +244,9 @@ class Runnable:
         # runner convention within the avocado.core namespace dir.
         # Looking for the file only avoids an attempt to load the module
         # and should be a lot faster
-        core_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        module_name = self.kind.replace('-', '_')
-        module_filename = 'nrunner_%s.py' % module_name
+        core_dir = os.path.dirname(os.path.abspath(__file__))
+        module_name = "nrunner_%s" % self.kind.replace('-', '_')
+        module_filename = '%s.py' % module_name
         if os.path.exists(os.path.join(core_dir, module_filename)):
             full_module_name = 'avocado.core.%s' % module_name
             candidate_cmd = [sys.executable, '-m', full_module_name]


### PR DESCRIPTION
This adds one fix to the "Ad hoc checks on OS X", but primarily it's about adding very basic smokechecks (enforced) so that the functionality is not regressed.

This is not claiming that those platforms will now be supported, and if it proves difficult to support even those smokechecks, we can revert them.

The fix from #4259 is also added here because it's needed for running Avocado with runners not on PATH.