### PR TITLE
Avoid failing when sudo command do not have read attribute.

### DIFF
--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -585,7 +585,7 @@ class SubProcess:
     def _prepend_sudo(cmd, shell):
         if os.getuid() != 0:
             try:
-                sudo_cmd = '%s -n' % path.find_command('sudo')
+                sudo_cmd = '%s -n' % path.find_command('sudo', check_exec=False)
             except path.CmdNotFoundError as details:
                 log.error(details)
                 log.error('Parameter sudo=True provided, but sudo was '

--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -131,7 +131,7 @@ class TestSubProcess(unittest.TestCase):
         get_owner.assert_called_with(process_id)
 
 
-def mock_fail_find_cmd(cmd, default=None):  # pylint: disable=W0613
+def mock_fail_find_cmd(cmd, default=None, check_exec=True):  # pylint: disable=W0613
     path_paths = ["/usr/libexec", "/usr/local/sbin", "/usr/local/bin",
                   "/usr/sbin", "/usr/bin", "/sbin", "/bin"]
     raise path.CmdNotFoundError(cmd, path_paths)
@@ -160,7 +160,7 @@ class TestProcessRun(unittest.TestCase):
     def test_subprocess_sudo(self):
         expected_command = '/bin/sudo -n ls -l'
         p = process.SubProcess(cmd='ls -l', sudo=True)
-        path.find_command.assert_called_once_with('sudo')
+        path.find_command.assert_called_once_with('sudo', check_exec=False)
         self.assertEqual(p.cmd, expected_command)
 
     @unittest.mock.patch.object(path, 'find_command', mock_fail_find_cmd)
@@ -185,7 +185,7 @@ class TestProcessRun(unittest.TestCase):
     def test_subprocess_sudo_shell(self):
         expected_command = '/bin/sudo -n -s ls -l'
         p = process.SubProcess(cmd='ls -l', sudo=True, shell=True)
-        path.find_command.assert_called_once_with('sudo')
+        path.find_command.assert_called_once_with('sudo', check_exec=False)
         self.assertEqual(p.cmd, expected_command)
 
     @unittest.mock.patch.object(path, 'find_command', mock_fail_find_cmd)
@@ -225,7 +225,7 @@ class TestProcessRun(unittest.TestCase):
     def test_run_sudo(self):
         expected_command = '/bin/sudo -n ls -l'
         p = process.run(cmd='ls -l', sudo=True, ignore_status=True)
-        path.find_command.assert_called_once_with('sudo')
+        path.find_command.assert_called_once_with('sudo', check_exec=False)
         self.assertEqual(p.command, expected_command)
 
     @unittest.mock.patch.object(path, 'find_command', mock_fail_find_cmd)
@@ -250,7 +250,7 @@ class TestProcessRun(unittest.TestCase):
     def test_run_sudo_shell(self):
         expected_command = '/bin/sudo -n -s ls -l'
         p = process.run(cmd='ls -l', sudo=True, shell=True, ignore_status=True)
-        path.find_command.assert_called_once_with('sudo')
+        path.find_command.assert_called_once_with('sudo', check_exec=False)
         self.assertEqual(p.command, expected_command)
 
     @unittest.mock.patch.object(path, 'find_command', mock_fail_find_cmd)


### PR DESCRIPTION
On some systems, the sudo command does not have the read attribute set, failing avocado.utils.path.find_command as if sudo was not installed in the system.

This changes the behavior to check if the file exists, but do not
check if the file can be executed.

Fixes #4263 

Signed-off-by: Willian Rampazzo <willianr@redhat.com>