### PR TITLE
Migration from imp to importlib

### DIFF
--- a/avocado/core/safeloader.py
+++ b/avocado/core/safeloader.py
@@ -19,11 +19,11 @@ Safe (AST based) test loader module utilities
 
 import ast
 import collections
-import importlib
 import json
 import os
 import re
 import sys
+from importlib.machinery import PathFinder
 
 from ..utils import data_structures
 
@@ -497,8 +497,8 @@ def _examine_class(path, class_name, match, target_module, target_class,
 
             modules_paths = [parent_path,
                              os.path.dirname(module.path)] + sys.path
-            found_ppath = importlib.machinery.PathFinder.find_spec(
-                parent_module, modules_paths).origin
+            found_ppath = PathFinder.find_spec(parent_module,
+                                               modules_paths).origin
             _info, _disabled, _match = _examine_class(found_ppath,
                                                       parent_class,
                                                       match,
@@ -630,8 +630,8 @@ def find_python_tests(module_name, class_name, determine_match, path):
 
             modules_paths = [parent_path,
                              os.path.dirname(module.path)] + sys.path
-            found_ppath = importlib.machinery.PathFinder.find_spec(
-                parent_module, modules_paths).origin
+            found_ppath = PathFinder.find_spec(parent_module,
+                                               modules_paths).origin
             if found_ppath is None:
                 continue
             _info, _dis, _python_test = _examine_class(found_ppath,

--- a/avocado/core/safeloader.py
+++ b/avocado/core/safeloader.py
@@ -19,7 +19,7 @@ Safe (AST based) test loader module utilities
 
 import ast
 import collections
-import imp
+import importlib
 import json
 import os
 import re
@@ -497,8 +497,8 @@ def _examine_class(path, class_name, match, target_module, target_class,
 
             modules_paths = [parent_path,
                              os.path.dirname(module.path)] + sys.path
-            _, found_ppath, _ = imp.find_module(parent_module,
-                                                modules_paths)
+            found_ppath = importlib.machinery.PathFinder.find_spec(
+                parent_module, modules_paths).origin
             _info, _disabled, _match = _examine_class(found_ppath,
                                                       parent_class,
                                                       match,
@@ -630,9 +630,9 @@ def find_python_tests(module_name, class_name, determine_match, path):
 
             modules_paths = [parent_path,
                              os.path.dirname(module.path)] + sys.path
-            try:
-                _, found_ppath, _ = imp.find_module(parent_module, modules_paths)
-            except ImportError:
+            found_ppath = importlib.machinery.PathFinder.find_spec(
+                parent_module, modules_paths).origin
+            if found_ppath is None:
                 continue
             _info, _dis, _python_test = _examine_class(found_ppath,
                                                        parent_class,

--- a/avocado/core/safeloader.py
+++ b/avocado/core/safeloader.py
@@ -497,14 +497,14 @@ def _examine_class(path, class_name, match, target_module, target_class,
 
             modules_paths = [parent_path,
                              os.path.dirname(module.path)] + sys.path
-            found_ppath = PathFinder.find_spec(parent_module,
-                                               modules_paths).origin
-            _info, _disabled, _match = _examine_class(found_ppath,
-                                                      parent_class,
-                                                      match,
-                                                      target_module,
-                                                      target_class,
-                                                      _determine_match_avocado)
+            found_spec = PathFinder.find_spec(parent_module, modules_paths)
+            if found_spec is not None:
+                _info, _disabled, _match = _examine_class(found_spec.origin,
+                                                          parent_class,
+                                                          match,
+                                                          target_module,
+                                                          target_class,
+                                                          _determine_match_avocado)
             if _info:
                 _extend_test_list(info, _info)
                 disabled.update(_disabled)
@@ -630,11 +630,10 @@ def find_python_tests(module_name, class_name, determine_match, path):
 
             modules_paths = [parent_path,
                              os.path.dirname(module.path)] + sys.path
-            found_ppath = PathFinder.find_spec(parent_module,
-                                               modules_paths).origin
-            if found_ppath is None:
+            found_spec = PathFinder.find_spec(parent_module, modules_paths)
+            if found_spec is None:
                 continue
-            _info, _dis, _python_test = _examine_class(found_ppath,
+            _info, _dis, _python_test = _examine_class(found_spec.origin,
                                                        parent_class,
                                                        is_valid_test,
                                                        module_name,


### PR DESCRIPTION
Migrates from imp to importlib, as the former is depreciated since version 3.4.
As discussed in #3468, for now, only safeloader.py was altered.

Signed-off-by: Tiago Honorato <tiagohonorato1@gmail.com>