### PR TITLE
Skeleton for a Requirements Resolver

### DIFF
--- a/avocado/core/requirements/resolver.py
+++ b/avocado/core/requirements/resolver.py
@@ -1,0 +1,121 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2020
+# Authors: Willian Rampazzo <willianr@redhat.com>
+
+"""
+Requirements Resolver module.
+"""
+
+import asyncio
+
+from ..nrunner import Runnable, Task, RUNNERS_REGISTRY_PYTHON_CLASS
+from ..task.runtime import RuntimeTask
+
+SUPPORTED_REQUIREMENTS = {}
+
+
+async def check_task_requirements(spawner, runtime_task):
+    """Entry point for the Requirements Resolver.
+
+    This function isolates the Requirements Resolver object into this module.
+
+    :param spawner:
+    :param type: :class:`avocado.plugins.spawner`
+    :param runtime_task:
+    :param type: :class:`avocado.core.task.runtime.RuntimeTask`
+    """
+
+    if runtime_task.task.runnable.requirements is None:
+        return True
+
+    resolver = RequirementsResolver(spawner,
+                                    runtime_task.task.runnable.requirements)
+    return await resolver.check_task_requirements()
+
+class UnsupportedRequirementType(Exception):
+    pass
+
+class RequirementsResolver:
+    """
+
+    """
+
+    def __init__(self, spawner, requirements):
+        """
+
+        """
+        self._spawner = spawner
+        self._requirements = requirements
+
+    async def check_task_requirements(self):
+        """
+
+        """
+        print("Requirements: %s" % self._requirements)
+
+        for requirement in self._requirements:
+            try:
+                type_klass = SUPPORTED_REQUIREMENTS[requirement['type']]
+            except KeyError:
+                # ignore while in draft
+                continue
+                #raise UnsupportedRequirementType
+
+            fulfiller = type_klass(self._spawner, requirement)
+            await fulfiller.fulfill()
+        return True
+
+class BaseRequirement:
+    """Base interface for a requirement type."""
+
+    def __init__(self, spawner, requirement):
+        """
+
+        """
+        self._spawner = spawner
+        self._requirement = requirement
+
+    def fulfill(self):
+        """
+
+        """
+        raise NotImplementedError
+
+class PackageRequirement(BaseRequirement):
+    """
+
+    """
+
+    async def fulfill(self):
+        """
+
+        """
+        print('Fulfilling: %s' % self._requirement)
+        # change the argument to 'install' after draft
+        runnable = Runnable('exec', 'avocado-software-manager', 'check-installed',
+                            self._requirement['name'])
+        # decide how to handle ids and logs
+        task_id = 'requirement-%s' % self._requirement['name']
+        task = Task(task_id, runnable,
+                    known_runners=RUNNERS_REGISTRY_PYTHON_CLASS)
+        runtime_task = RuntimeTask(task)
+
+        # this is a subset without error handling of the task state machine
+        start_ok = await self._spawner.spawn_task(runtime_task)
+        if not start_ok:
+            return False
+        await asyncio.wait_for(self._spawner.wait_task(runtime_task), timeout=30)
+
+        return True
+
+SUPPORTED_REQUIREMENTS['package'] = PackageRequirement

--- a/avocado/core/task/statemachine.py
+++ b/avocado/core/task/statemachine.py
@@ -2,6 +2,8 @@ import asyncio
 import multiprocessing
 import time
 
+from ..requirements.resolver import check_task_requirements
+
 
 class TaskStateMachine:
     """Represents all phases that a task can go through its life."""
@@ -79,7 +81,8 @@ class Worker:
         except IndexError:
             return
 
-        requirements_ok = await self._spawner.check_task_requirements(runtime_task)
+        requirements_ok = await check_task_requirements(self._spawner,
+                                                        runtime_task)
         if requirements_ok:
             async with self._state_machine.lock:
                 self._state_machine.ready.append(runtime_task)


### PR DESCRIPTION
This is the initial idea and skeleton for a Requirements Resolver. This code **should not** be reviewed. Feel free to make comments related to the architecture proposed.

**Notes on the current code:**
  - Missing all possible error handling and logs.
  - Works with process and podman, but the podman image should have avocado installed. Feel free to use quay.io/willianr/avocado-82lts.
 - The PackageRequirement class uses the check-installed command and do not install them, so it is safe to run it.
 - Some ugly prints for debug purposes.

**Notes on further development:**
  - While I was implementing the PackageRequirement and creating tasks to be executed by the spawners, I noticed it may make more sense to start a task state machine instead of manually spawn the tasks. This will probably be the approach I'll take.
  - There needs to be a mechanism to fulfill the requirements into a podman image and pass this new image to the state of the state machine responsible to run the tests. The idea here is to create a podman image handler that can be used anywhere before, during or after the test runs, if needed.

Test I'm using for tests:

```python
from avocado import Test


class PassTest(Test):

    """
    Example test that passes.

    :avocado: tags=fast
    :avocado: requirement={"type": "package", "name": "vim-common"}
    :avocado: requirement={"type": "package", "name": "htop"}
    :avocado: requirement={"type": "file", "name": "foo.bar"}
    """

    def test(self):
        """
        A test simply doesn't have to fail in order to pass
        """
```

A run using process spawner and podman spawner:

```
[wrampazz@wrampazz requirements_resolver]$ avocado run --test-runner=nrunner passtest.py 
JOB ID     : ae28f11c10dd81fa05d58c0195eba01850a96b7c
JOB LOG    : /home/wrampazz/avocado/job-results/job-2020-10-23T17.21-ae28f11/job.log
Requirements: [{'type': 'package', 'name': 'vim-common'}, {'type': 'package', 'name': 'htop'}, {'type': 'file', 'name': 'foo.bar'}]
Fulfilling: {'type': 'package', 'name': 'vim-common'}
Fulfilling: {'type': 'package', 'name': 'htop'}
 (1/1) passtest.py:PassTest.test: STARTED
 (1/1) passtest.py:PassTest.test: PASS (0.01 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/wrampazz/avocado/job-results/job-2020-10-23T17.21-ae28f11/results.html
JOB TIME   : 2.89 s

[wrampazz@wrampazz requirements_resolver]$ avocado run --test-runner=nrunner --nrunner-spawner=podman passtest.py 
JOB ID     : bbb429d3fc12e1a58278537e5b49583a78e183c7
JOB LOG    : /home/wrampazz/avocado/job-results/job-2020-10-23T17.22-bbb429d/job.log
Requirements: [{'type': 'package', 'name': 'vim-common'}, {'type': 'package', 'name': 'htop'}, {'type': 'file', 'name': 'foo.bar'}]
Fulfilling: {'type': 'package', 'name': 'vim-common'}
Fulfilling: {'type': 'package', 'name': 'htop'}
 (1/1) passtest.py:PassTest.test: STARTED
 (1/1) passtest.py:PassTest.test: PASS (0.01 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/wrampazz/avocado/job-results/job-2020-10-23T17.22-bbb429d/results.html
JOB TIME   : 4.35 s
```