### PR TITLE
[Utils] Add common exit codes and use it at software manager.

### DIFF
--- a/avocado/utils/exit_codes.py
+++ b/avocado/utils/exit_codes.py
@@ -1,0 +1,38 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+
+"""
+Avocado Utilities exit codes.
+
+These codes are returned on the command-line and may be used by the Avocado
+command-line utilities.
+"""
+
+#: The utility finished successfully
+UTILITY_OK = 0x0000
+
+#: The utility ran, but needs to signalize something minor, like a check
+#: returning FALSE.
+UTILITY_LOW = 0x0001
+
+#: The utility ran, but needs to signalize a failure, like an internal action
+#: that failed to execute.
+UTILITY_MEDIUM = 0x0002
+
+#: Something else went wrong and the utility failed (or crashed).
+UTILITY_HIGH = 0x0004
+
+#: The utility was explicitly interrupted. Usually this means that a user
+#: hit CTRL+C while the utility was still running.
+UTILITY_INTERRUPTED = 0x0008
+
+#: Utility generic crash
+UTILITY_GENERIC_CRASH = -1

--- a/avocado/utils/software_manager/main.py
+++ b/avocado/utils/software_manager/main.py
@@ -1,12 +1,14 @@
 import argparse
 import logging
 
+from .. import exit_codes
 from .manager import SoftwareManager
 
 log = logging.getLogger('avocado.utils.software_manager')
 
 
 def main():
+    exitcode = exit_codes.UTILITY_OK
     parser = argparse.ArgumentParser(
         "install|remove|check-installed|list-all|list-files|add-repo|"
         "remove-repo|upgrade|what-provides|install-what-provides arguments")
@@ -32,18 +34,21 @@ def main():
             log.info("Packages %s installed successfully", args)
         else:
             log.error("Failed to install %s", args)
+            exitcode |= exit_codes.UTILITY_MEDIUM
 
     elif action == 'remove':
         if software_manager.remove(args):
             log.info("Packages %s removed successfully", args)
         else:
             log.error("Failed to remove %s", args)
+            exitcode |= exit_codes.UTILITY_MEDIUM
 
     elif action == 'check-installed':
         if software_manager.check_installed(args):
             log.info("Package %s already installed", args)
         else:
             log.info("Package %s not installed", args)
+            exitcode |= exit_codes.UTILITY_LOW
 
     elif action == 'list-all':
         for pkg in software_manager.list_all():
@@ -58,12 +63,14 @@ def main():
             log.info("Repo %s added successfully", args)
         else:
             log.error("Failed to remove repo %s", args)
+            exitcode |= exit_codes.UTILITY_MEDIUM
 
     elif action == 'remove-repo':
         if software_manager.remove_repo(args):
             log.info("Repo %s removed successfully", args)
         else:
             log.error("Failed to remove repo %s", args)
+            exitcode |= exit_codes.UTILITY_MEDIUM
 
     elif action == 'upgrade':
         if software_manager.upgrade():
@@ -80,3 +87,5 @@ def main():
 
     elif action == 'show-help':
         parser.print_help()
+
+    return exitcode


### PR DESCRIPTION
This adds basic exit status codes to the Avocado utilities. To avoid module boundary infringements and to use a meaningful name for the exit codes not related to tests execution, a new exit code file was created under the utility directory.

My imagination is not good today, so I could not come up with good names for the exit code variables. I'm open to suggestions.

This also adapts the `avocado-software-manager` to use the newly created exit codes.