### PR TITLE
varianter_yaml_to_mux: Fix displaying empty/null value from yaml

### DIFF
--- a/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/__init__.py
+++ b/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/__init__.py
@@ -185,8 +185,7 @@ def _node_content_from_dict(path, node, values, using):
                 using = _handle_control_tag_using(path, node.name, using, value)
             else:
                 _handle_control_tag(path, node, [key, value])
-        elif (isinstance(value, collections.OrderedDict) or
-              value is None):
+        elif isinstance(value, collections.OrderedDict):
             node.add_child(_tree_node_from_values(path, key, value, using))
         else:
             node.value[key] = value
@@ -240,8 +239,6 @@ def _mapping_to_tree_loader(loader, node, looks_like_node=False):
         if isinstance(values, ListOfNodeObjects):   # New node from list
             objects.append(_tree_node_from_values(loader.path, name,
                                                   values, loader.using))
-        elif values is None:            # Empty node
-            objects.append(mux.MuxTreeNode(astring.to_text(name)))
         else:                           # Values
             objects.append((name, values))
     return objects


### PR DESCRIPTION
Patch fixes displaying empty/null value node provided from yaml

Before patch:
```
$ avocado variants -m nvdimm.yaml -c
Variant run-setup-disk_type-disk_scratch-disk_test-fs_type-fs_xfs-exclude-gen_exclude-b86f:    /run/setup/fs_type/fs_xfs/exclude, /run/setup/fs_type/fs_xfs/gen_exclude, /run/setup/disk_type/disk_test, /run/setup/disk_type/disk_scratch
    /run/setup/disk_type:type          => nvdimm
    /run/setup/fs_type/fs_xfs:fs       => xfs
    /run/setup/fs_type/fs_xfs:mkfs_opt => -b size=65536 -s size=4096 -m reflink=0
    /run/setup:mount_opt               => -o dax
```
After patch:
```
Variant run-setup-disk_type-fs_type-fs_xfs-8ca7:    /run/setup/fs_type/fs_xfs, /run/setup/disk_type
    /run/setup/disk_type:disk_scratch     => None
    /run/setup/disk_type:disk_test        => None
    /run/setup/disk_type:type             => nvdimm
    /run/setup/fs_type/fs_xfs:exclude     => None
    /run/setup/fs_type/fs_xfs:fs          => xfs
    /run/setup/fs_type/fs_xfs:gen_exclude => None
    /run/setup/fs_type/fs_xfs:mkfs_opt    => -b size=65536 -s size=4096 -m reflink=0
    /run/setup:mount_opt                  => -o dax
```
yaml
```
$ cat nvdimm.yaml
setup:
    mount_opt: '-o dax'
    fs_type: !mux
        fs_xfs:
            fs: 'xfs'
            mkfs_opt: '-b size=65536 -s size=4096 -m reflink=0'
            exclude: null
            gen_exclude: null
    disk_type:
        type: 'nvdimm'
        disk_test:
        disk_scratch:
```
Fixes: #4010

Signed-off-by: Harish <harish@linux.ibm.com>