### PR TITLE
Yaml to mux documentation fix

### DIFF
--- a/docs/source/plugins/optional/varianter_yaml_to_mux.rst
+++ b/docs/source/plugins/optional/varianter_yaml_to_mux.rst
@@ -140,8 +140,9 @@ The environment created for the nodes ``fedora`` and ``osx`` are:
 
 Note that due to different usage of key and values in environment we disabled
 the automatic value conversion for keys while keeping it enabled for values.
-This means that the value can be of any YAML supported value, eg. bool, None,
-list or custom type, while the key is always string.
+This means that the key is always a string and the value can be YAML value,
+eg. bool, list, custom type, or string. Please be aware that the None type
+is unsupported and cannot be provided in yaml as null.
 
 Variants
 --------


### PR DESCRIPTION
Inside documentation of yaml to mux plugin is a problem with None type, which
is passed to parameters as a string due to distinguish between empty values and
default values. This commit should specify this behavior.

Signed-off-by: Jan Richter <jarichte@redhat.com>