### PR TITLE
Cross-platform reference to current and parent directories

### DIFF
--- a/optional_plugins/golang/avocado_golang/__init__.py
+++ b/optional_plugins/golang/avocado_golang/__init__.py
@@ -57,7 +57,7 @@ def find_files(path, recursive=True):
                 matches.append(os.path.join(root, filename))
         return matches
 
-    if path != '.':
+    if path != os.path.curdir:
         pattern = os.path.join(path, pattern)
     return glob.iglob(pattern)
 

--- a/optional_plugins/varianter_yaml_to_mux/tests/test_unit.py
+++ b/optional_plugins/varianter_yaml_to_mux/tests/test_unit.py
@@ -11,8 +11,8 @@ from avocado.core import parameters, tree
 from avocado.utils import astring
 from avocado_varianter_yaml_to_mux import mux
 
-BASEDIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..')
-BASEDIR = os.path.abspath(BASEDIR)
+BASEDIR = os.path.dirname(os.path.abspath(__file__))
+BASEDIR = os.path.abspath(os.path.join(BASEDIR, os.path.pardir))
 
 
 def combine(leaves_pools):

--- a/selftests/__init__.py
+++ b/selftests/__init__.py
@@ -7,7 +7,8 @@ import unittest
 import pkg_resources
 
 #: The base directory for the avocado source tree
-BASEDIR = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+BASEDIR = os.path.dirname(os.path.abspath(__file__))
+BASEDIR = os.path.abspath(os.path.join(BASEDIR, os.path.pardir))
 
 #: The name of the avocado test runner entry point
 AVOCADO = os.environ.get("UNITTEST_AVOCADO_CMD",


### PR DESCRIPTION
Changes string references to parent `'..'` and current `'.'` directories to cross-platform using `os.path.pardir` and `os.path.curdir` as discussed in  #3470