### PR TITLE
avocado.utils.path.find_command: provide a more constant list of paths

### DIFF
--- a/avocado/utils/path.py
+++ b/avocado/utils/path.py
@@ -106,6 +106,7 @@ def find_command(cmd, default=None, check_exec=True):
     if default is not None:
         return default
     else:
+        path_paths.sort()
         raise CmdNotFoundError(cmd, path_paths)
 
 


### PR DESCRIPTION
When signaling that a command was not found, the list of paths that
were tried are returned.  These are usually logged as part of a test.

When running two identical tests, and comparing results, the different
order of the list of tried paths adds a lot of noise.  Let's always
return a sorted list of paths, given that the order is, at this point,
not important anymore (given that the command was not found anywhere).

Signed-off-by: Cleber Rosa <crosa@redhat.com>