### PR TITLE
Test suite specific loader

### DIFF
--- a/avocado/core/nrunner_avocado_instrumented.py
+++ b/avocado/core/nrunner_avocado_instrumented.py
@@ -2,7 +2,8 @@ import multiprocessing
 import tempfile
 import time
 
-from . import job, loader, nrunner
+from . import job, nrunner
+from .loader import TestLoaderProxy
 from .test import TestID
 from .tree import TreeNode
 
@@ -44,7 +45,7 @@ class AvocadoInstrumentedTestRunner(nrunner.BaseRunner):
                          'run.results_dir': tempfile.mkdtemp(),
                          }]
 
-        instance = loader.loader.load_test(test_factory)
+        instance = TestLoaderProxy.load_test(test_factory)
         instance.run_avocado()
         state = instance.get_state()
         # This should probably be done in a translator

--- a/avocado/plugins/list.py
+++ b/avocado/plugins/list.py
@@ -104,8 +104,8 @@ class List(CLICmd):
         """Used for loader."""
         test_matrix = []
 
-        type_label_mapping = loader.loader.get_type_label_mapping()
-        decorator_mapping = loader.loader.get_decorator_mapping()
+        type_label_mapping = suite.loader.get_type_label_mapping()
+        decorator_mapping = suite.loader.get_decorator_mapping()
 
         verbose = suite.config.get('core.verbose')
         for cls, params in suite.tests:

--- a/avocado/plugins/runner.py
+++ b/avocado/plugins/runner.py
@@ -26,7 +26,6 @@ import time
 from queue import Full as queueFullException
 
 from avocado.core import output, tree, varianter
-from avocado.core.loader import loader
 from avocado.core.output import LOG_JOB as TEST_LOG
 from avocado.core.output import LOG_UI as APP_LOG
 from avocado.core.plugin_interfaces import Runner
@@ -87,7 +86,7 @@ class TestRunner(Runner):
         # `multiprocessing.Process()`
         os.dup2(sys.stdin.fileno(), 0)
 
-        instance = loader.load_test(test_factory)
+        instance = job.test_suite.loader.load_test(test_factory)
         if instance.runner_queue is None:
             instance.set_runner_queue(queue)
         early_state = instance.get_state()

--- a/optional_plugins/golang/avocado_golang/__init__.py
+++ b/optional_plugins/golang/avocado_golang/__init__.py
@@ -281,4 +281,4 @@ class GolangCLI(CLI):
         pass
 
     def run(self, config):
-        loader.loader.register_plugin(GolangLoader)
+        loader.TestLoaderProxy.register_plugin(GolangLoader)

--- a/optional_plugins/robot/avocado_robot/__init__.py
+++ b/optional_plugins/robot/avocado_robot/__init__.py
@@ -181,4 +181,4 @@ class RobotCLI(CLI):
         pass
 
     def run(self, config):
-        loader.loader.register_plugin(RobotLoader)
+        loader.TestLoaderProxy.register_plugin(RobotLoader)


### PR DESCRIPTION
We have multiple test suites inside one Job and each of them can have different
configurations from the user. Unfortunately, we have just one instance of the
test loader which is not able to deal with different configurations of test
suites. This commit creates for each test suite instance its own test loader
which will work with the right configuration.

Signed-off-by: Jan Richter <jarichte@redhat.com>