### PR TITLE
Unify jobs used on "make check"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,8 +132,7 @@ AVOCADO_OPTIONAL_PLUGINS_TESTS=$(patsubst %,%/tests/, $(AVOCADO_OPTIONAL_PLUGINS
 endif
 check: clean develop
 	# Unless manually set, this is equivalent to AVOCADO_CHECK_LEVEL=0
-	PYTHON=$(PYTHON) $(PYTHON) -m avocado run --test-runner=nrunner --ignore-missing-references -- selftests/*.sh selftests/jobs/* selftests/unit/ selftests/functional/ $(AVOCADO_OPTIONAL_PLUGINS_TESTS)
-	PYTHON=$(PYTHON) $(PYTHON) selftests/job_api/test_features.py
+	PYTHON=$(PYTHON) $(PYTHON) selftests/check.py
 	selftests/check_tmp_dirs
 
 develop:

--- a/avocado/plugins/human.py
+++ b/avocado/plugins/human.py
@@ -73,8 +73,9 @@ class Human(ResultEvents):
             color = output.TERM_SUPPORT.PASS
         else:
             color = output.TERM_SUPPORT.PARTIAL
-        LOG_UI.debug('%s%s%s', color, self.__throbber.render(),
-                     output.TERM_SUPPORT.ENDC, extra={"skip_newline": True})
+        if self.runner == 'runner':
+            LOG_UI.debug('%s%s%s', color, self.__throbber.render(),
+                         output.TERM_SUPPORT.ENDC, extra={"skip_newline": True})
 
     def get_colored_status(self, status, extra=None):
         out = (output.TERM_SUPPORT.MOVE_BACK + output.TEST_STATUS_MAPPING[status] +

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 
 import argparse
+import glob
 import os
 import sys
-import time
 
 from avocado import Test
 from avocado.core import exit_codes
@@ -206,6 +206,7 @@ def create_suites():
                          % (__file__, test_class))
     config_check_archive_file_exists = (
         {'run.references': [check_archive_file_exists],
+         'run.test_runner': 'runner',
          'run.dict_variants': [
 
              {'namespace': 'run.results.archive',
@@ -215,7 +216,7 @@ def create_suites():
          ]})
 
     suites.append(TestSuite.from_config(config_check_archive_file_exists,
-                                        "%s" % (len(suites) + 1)))
+                                        "job-api-%s" % (len(suites) + 1)))
 
     # ========================================================================
     # Test if the category directory was created
@@ -225,6 +226,7 @@ def create_suites():
         % (__file__, test_class))
     config_check_category_directory_exists = (
         {'run.references': [check_category_directory_exists],
+         'run.test_runner': 'runner',
          'run.dict_variants': [
 
              {'namespace': 'run.job_category',
@@ -234,7 +236,7 @@ def create_suites():
          ]})
 
     suites.append(TestSuite.from_config(config_check_category_directory_exists,
-                                        "%s" % (len(suites) + 1)))
+                                        "job-api-%s" % (len(suites) + 1)))
 
     # ========================================================================
     # Test if a directory was created
@@ -243,6 +245,7 @@ def create_suites():
                               % (__file__, test_class))
     config_check_directory_exists = (
         {'run.references': [check_directory_exists],
+         'run.test_runner': 'runner',
          'run.dict_variants': [
 
              {'namespace': 'sysinfo.collect.enabled',
@@ -258,7 +261,7 @@ def create_suites():
          ]})
 
     suites.append(TestSuite.from_config(config_check_directory_exists,
-                                        "%s" % (len(suites) + 1)))
+                                        "job-api-%s" % (len(suites) + 1)))
 
     # ========================================================================
     # Test the content of a file
@@ -267,6 +270,7 @@ def create_suites():
                           % (__file__, test_class))
     config_check_file_content = (
         {'run.references': [check_file_content],
+         'run.test_runner': 'runner',
          'run.dict_variants': [
 
              # finding the correct 'content' here is trick because any
@@ -338,7 +342,7 @@ def create_suites():
          ]})
 
     suites.append(TestSuite.from_config(config_check_file_content,
-                                        "%s" % (len(suites) + 1)))
+                                        "job-api-%s" % (len(suites) + 1)))
 
     # ========================================================================
     # Test if the result file was created
@@ -347,6 +351,7 @@ def create_suites():
                          % (__file__, test_class))
     config_check_file_exists = (
         {'run.references': [check_file_exists],
+         'run.test_runner': 'runner',
          'run.dict_variants': [
 
              {'namespace': 'job.run.result.html.enabled',
@@ -413,7 +418,7 @@ def create_suites():
          ]})
 
     suites.append(TestSuite.from_config(config_check_file_exists,
-                                        "%s" % (len(suites) + 1)))
+                                        "job-api-%s" % (len(suites) + 1)))
 
     # ========================================================================
     # Test if a file was created
@@ -422,6 +427,7 @@ def create_suites():
                          % (__file__, test_class))
     config_check_output_file = (
         {'run.references': [check_output_file],
+         'run.test_runner': 'runner',
          'run.dict_variants': [
 
              {'namespace': 'job.run.result.html.output',
@@ -444,7 +450,7 @@ def create_suites():
          ]})
 
     suites.append(TestSuite.from_config(config_check_output_file,
-                                        "%s" % (len(suites) + 1)))
+                                        "job-api-%s" % (len(suites) + 1)))
 
     # ========================================================================
     # Test if the temporary directory was created
@@ -453,6 +459,7 @@ def create_suites():
                               % (__file__, test_class))
     config_check_tmp_directory_exists = (
         {'run.references': [check_tmp_directory_exists],
+         'run.test_runner': 'runner',
          'run.dict_variants': [
 
              {'namespace': 'run.keep_tmp',
@@ -462,7 +469,21 @@ def create_suites():
          ]})
 
     suites.append(TestSuite.from_config(config_check_tmp_directory_exists,
-                                        "%s" % (len(suites) + 1)))
+                                        "job-api-%s" % (len(suites) + 1)))
+
+    # ========================================================================
+    # Run all static checks, unit and functional tests
+    # ========================================================================
+    config_check = (
+        {'run.references': (glob.glob('selftests/*.sh') +
+                            glob.glob('selftests/jobs/*') +
+                            glob.glob('selftests/unit/*.py') +
+                            glob.glob('selftests/functional/*.py') +
+                            glob.glob('optional_plugins/*/tests/*.py')),
+         'run.test_runner': 'nrunner',
+         'run.ignore_missing_references': True}
+        )
+    suites.append(TestSuite.from_config(config_check, "check"))
     return suites
 
 
@@ -486,7 +507,8 @@ def main():
     # ========================================================================
     # Job execution
     # ========================================================================
-    config = {'core.show': ['app']}
+    config = {'core.show': ['app'],
+              'run.test_runner': 'nrunner'}
     with Job(config, suites) as j:
         return j.run()
 

--- a/selftests/functional/test_job_api_features.py
+++ b/selftests/functional/test_job_api_features.py
@@ -17,7 +17,8 @@ class Test(TestCaseTmpDir):
         super(Test, self).setUp()
         self.base_config = {'core.show': ['none'],
                             'run.results_dir': self.tmpdir.name,
-                            'run.references': ['examples/tests/passtest.py']}
+                            'run.references': ['examples/tests/passtest.py'],
+                            'run.keep_tmp': True}
 
     def test_job_run_result_json_enabled(self):
         self.base_config['job.run.result.json.enabled'] = 'on'

--- a/selftests/functional/test_journal.py
+++ b/selftests/functional/test_journal.py
@@ -47,7 +47,7 @@ class JournalPluginTests(TestCaseTmpDir):
 
     def tearDown(self):
         self.db.close()
-        super(JournalPluginTests, self).setUp()
+        super(JournalPluginTests, self).tearDown()
 
 
 if __name__ == '__main__':

--- a/selftests/functional/test_replay.py
+++ b/selftests/functional/test_replay.py
@@ -21,6 +21,14 @@ class ReplayTests(TestCaseTmpDir):
         idfile = ''.join(os.path.join(self.jobdir, 'id'))
         with open(idfile, 'r') as f:
             self.jobid = f.read().strip('\n')
+        self.config_path = self._create_config()
+
+    def _create_config(self):
+        config_path = os.path.join(self.tmpdir.name, 'config')
+        with open(config_path, 'w') as config:
+            config.write("[datadir.paths]\n")
+            config.write("logs_dir = %s\n" % self.tmpdir.name)
+        return config_path
 
     def run_and_check(self, cmd_line, expected_rc):
         result = process.run(cmd_line, ignore_status=True)
@@ -33,7 +41,9 @@ class ReplayTests(TestCaseTmpDir):
         """
         Runs a replay job with an invalid jobid.
         """
-        cmd_line = '%s replay %s' % (AVOCADO, 'foo')
+        cmd_line = '%s --config=%s replay %s' % (AVOCADO,
+                                                 self.config_path,
+                                                 'foo')
         expected_rc = exit_codes.AVOCADO_FAIL
         self.run_and_check(cmd_line, expected_rc)
 
@@ -41,7 +51,8 @@ class ReplayTests(TestCaseTmpDir):
         """
         Runs a replay job using the 'latest' keyword.
         """
-        cmd_line = '%s replay latest' % AVOCADO
+        cmd_line = '%s --config=%s replay latest' % (AVOCADO,
+                                                     self.config_path)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.run_and_check(cmd_line, expected_rc)
 
@@ -59,7 +70,9 @@ class ReplayTests(TestCaseTmpDir):
         """
         Runs a replay job.
         """
-        cmd_line = '%s replay %s' % (AVOCADO, self.jobdir)
+        cmd_line = '%s --config=%s replay %s' % (AVOCADO,
+                                                 self.config_path,
+                                                 self.jobdir)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.run_and_check(cmd_line, expected_rc)
 

--- a/selftests/job_api/test_features.py
+++ b/selftests/job_api/test_features.py
@@ -2,6 +2,7 @@
 
 import argparse
 import os
+import sys
 import time
 
 from avocado import Test
@@ -465,7 +466,7 @@ def create_suites():
     return suites
 
 
-if __name__ == '__main__':
+def main():
     suites = create_suites()
     # ========================================================================
     # Print features covered in this test
@@ -487,4 +488,8 @@ if __name__ == '__main__':
     # ========================================================================
     config = {'core.show': ['app']}
     with Job(config, suites) as j:
-        j.run()
+        return j.run()
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/selftests/job_api/test_features.py
+++ b/selftests/job_api/test_features.py
@@ -213,7 +213,8 @@ def create_suites():
 
          ]})
 
-    suites.append(TestSuite.from_config(config_check_archive_file_exists))
+    suites.append(TestSuite.from_config(config_check_archive_file_exists,
+                                        "%s" % (len(suites) + 1)))
 
     # ========================================================================
     # Test if the category directory was created
@@ -231,7 +232,8 @@ def create_suites():
 
          ]})
 
-    suites.append(TestSuite.from_config(config_check_category_directory_exists))
+    suites.append(TestSuite.from_config(config_check_category_directory_exists,
+                                        "%s" % (len(suites) + 1)))
 
     # ========================================================================
     # Test if a directory was created
@@ -254,7 +256,8 @@ def create_suites():
 
          ]})
 
-    suites.append(TestSuite.from_config(config_check_directory_exists))
+    suites.append(TestSuite.from_config(config_check_directory_exists,
+                                        "%s" % (len(suites) + 1)))
 
     # ========================================================================
     # Test the content of a file
@@ -333,7 +336,8 @@ def create_suites():
 
          ]})
 
-    suites.append(TestSuite.from_config(config_check_file_content))
+    suites.append(TestSuite.from_config(config_check_file_content,
+                                        "%s" % (len(suites) + 1)))
 
     # ========================================================================
     # Test if the result file was created
@@ -407,7 +411,8 @@ def create_suites():
 
          ]})
 
-    suites.append(TestSuite.from_config(config_check_file_exists))
+    suites.append(TestSuite.from_config(config_check_file_exists,
+                                        "%s" % (len(suites) + 1)))
 
     # ========================================================================
     # Test if a file was created
@@ -437,7 +442,8 @@ def create_suites():
 
          ]})
 
-    suites.append(TestSuite.from_config(config_check_output_file))
+    suites.append(TestSuite.from_config(config_check_output_file,
+                                        "%s" % (len(suites) + 1)))
 
     # ========================================================================
     # Test if the temporary directory was created
@@ -454,7 +460,8 @@ def create_suites():
 
          ]})
 
-    suites.append(TestSuite.from_config(config_check_tmp_directory_exists))
+    suites.append(TestSuite.from_config(config_check_tmp_directory_exists,
+                                        "%s" % (len(suites) + 1)))
     return suites
 
 

--- a/selftests/job_api/test_features.py
+++ b/selftests/job_api/test_features.py
@@ -194,8 +194,7 @@ def parse_args():
     return parser.parse_args()
 
 
-if __name__ == '__main__':
-
+def create_suites():
     test_class = 'JobAPIFeaturesTest'
     suites = []
 
@@ -456,7 +455,11 @@ if __name__ == '__main__':
          ]})
 
     suites.append(TestSuite.from_config(config_check_tmp_directory_exists))
+    return suites
 
+
+if __name__ == '__main__':
+    suites = create_suites()
     # ========================================================================
     # Print features covered in this test
     # ========================================================================

--- a/selftests/job_api/test_features.py
+++ b/selftests/job_api/test_features.py
@@ -184,14 +184,17 @@ class JobAPIFeaturesTest(Test):
         self.check_exit_code(result)
         self.check_directory_exists(tmpdir)
 
-if __name__ == '__main__':
 
+def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument('-f',
                         '--features',
                         help='show the features tested by this test.',
                         action='store_true')
-    args = parser.parse_args()
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
 
     test_class = 'JobAPIFeaturesTest'
     suites = []
@@ -457,6 +460,7 @@ if __name__ == '__main__':
     # ========================================================================
     # Print features covered in this test
     # ========================================================================
+    args = parse_args()
     if args.features:
         features = []
         for suite in suites:

--- a/selftests/unit/test_jsonresult.py
+++ b/selftests/unit/test_jsonresult.py
@@ -28,7 +28,8 @@ class JSONResultTest(TestCaseTmpDir):
 
         json_output_path = os.path.join(self.tmpdir.name, 'results.json')
         config = {'run.results_dir': self.tmpdir.name,
-                  'job.run.result.json.output': json_output_path}
+                  'job.run.result.json.output': json_output_path,
+                  'run.keep_tmp': True}
         self.job = job.Job(config)
         self.job.setup()
         self.test_result = Result(UNIQUE_ID, LOGFILE)

--- a/selftests/unit/test_jsonresult.py
+++ b/selftests/unit/test_jsonresult.py
@@ -80,7 +80,8 @@ class JSONResultTest(TestCaseTmpDir):
         json_result = jsonresult.JSONResult()
         json_result.render(self.test_result, self.job)
         output = self.job.config.get('job.run.result.json.output')
-        res = json.loads(open(output).read())
+        with open(output) as json_output:
+            res = json.loads(json_output.read())
         check_item("[pass]", res["pass"], 2)
         check_item("[errors]", res["errors"], 4)
         check_item("[failures]", res["failures"], 1)
@@ -99,7 +100,8 @@ class JSONResultTest(TestCaseTmpDir):
         json_result = jsonresult.JSONResult()
         json_result.render(self.test_result, self.job)
         output = self.job.config.get('job.run.result.json.output')
-        res = json.loads(open(output).read())
+        with open(output) as json_output:
+            res = json.loads(json_output.read())
         check_item("[total]", res["total"], 1)
         check_item("[skip]", res["skip"], 0)
         check_item("[pass]", res["pass"], 1)

--- a/selftests/unit/test_jsonresult.py
+++ b/selftests/unit/test_jsonresult.py
@@ -1,6 +1,5 @@
 import json
 import os
-import tempfile
 import unittest
 
 from avocado import Test
@@ -8,7 +7,7 @@ from avocado.core import job
 from avocado.core.result import Result
 from avocado.plugins import jsonresult
 
-from .. import setup_avocado_loggers, temp_dir_prefix
+from .. import TestCaseTmpDir, setup_avocado_loggers
 
 setup_avocado_loggers()
 
@@ -17,34 +16,27 @@ UNIQUE_ID = '0000000000000000000000000000000000000000'
 LOGFILE = None
 
 
-class JSONResultTest(unittest.TestCase):
+class JSONResultTest(TestCaseTmpDir):
 
     def setUp(self):
+        super(JSONResultTest, self).setUp()
 
         class SimpleTest(Test):
 
             def test(self):
                 pass
 
-        self.tmpfile = tempfile.mkstemp()
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
+        json_output_path = os.path.join(self.tmpdir.name, 'results.json')
         config = {'run.results_dir': self.tmpdir.name,
-                  'job.run.result.json.output': self.tmpfile[1]}
+                  'job.run.result.json.output': json_output_path}
         self.job = job.Job(config)
         self.job.setup()
         self.test_result = Result(UNIQUE_ID, LOGFILE)
-        self.test_result.filename = self.tmpfile[1]
+        self.test_result.filename = json_output_path
         self.test_result.tests_total = 1
         self.test1 = SimpleTest(job=self.job, base_logdir=self.tmpdir.name)
         self.test1._Test__status = 'PASS'
         self.test1.time_elapsed = 1.23
-
-    def tearDown(self):
-        self.job.cleanup()
-        os.close(self.tmpfile[0])
-        os.remove(self.tmpfile[1])
-        self.tmpdir.cleanup()
 
     def test_add_success(self):
         self.test_result.start_test(self.test1)
@@ -111,6 +103,10 @@ class JSONResultTest(unittest.TestCase):
         check_item("[total]", res["total"], 1)
         check_item("[skip]", res["skip"], 0)
         check_item("[pass]", res["pass"], 1)
+
+    def tearDown(self):
+        self.job.cleanup()
+        super(JSONResultTest, self).tearDown()
 
 
 if __name__ == '__main__':

--- a/selftests/unit/test_xunit.py
+++ b/selftests/unit/test_xunit.py
@@ -43,7 +43,8 @@ class xUnitSucceedTest(unittest.TestCase):
         prefix = temp_dir_prefix(__name__, self, 'setUp')
         self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
         config = {'job.run.result.xunit.output': self.tmpfile[1],
-                  'run.results_dir': self.tmpdir.name}
+                  'run.results_dir': self.tmpdir.name,
+                  'run.keep_tmp': True}
         self.job = job.Job(config)
         self.job.setup()
         self.test_result = Result(UNIQUE_ID, LOGFILE)


### PR DESCRIPTION
The Job API, with its support for multiple test suites, has as of its goals, to be able to consolidate all checks that a project has.  This is *not* what Avocado is doing itself so far.

This consolidates both the "Job API Features" tests, and the regular "selftests" checks into a single job.