### PR TITLE
Introduces the 'config' args to Runnable and extend exec-test to support skip tests

### DIFF
--- a/avocado/core/__init__.py
+++ b/avocado/core/__init__.py
@@ -166,6 +166,16 @@ def register_core_options():
                          default='utf-8',
                          help_msg=help_msg)
 
+    # All settings starting with 'runner.' will be passed to runner
+    # exec-test runner config
+    help_msg = ('Use a custom exit code list to consider a test as skipped. '
+                'This is only used by exec-test runners. Default is [130].')
+    stgs.register_option(section='runner.exectest.exitcodes',
+                         key='skip',
+                         default=[130],
+                         key_type=list,
+                         help_msg=help_msg)
+
 
 def initialize_plugin_infrastructure():
     help_msg = 'Plugins that will not be loaded and executed'

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -427,12 +427,19 @@ class ExecTestRunner(ExecRunner):
     Runnable attributes usage is identical to :class:`ExecRunner`
     """
     def run(self):
+        # Since Runners are standalone, and could be executed on a remote
+        # machine in an "isolated" way, there is no way to assume a default
+        # value, at this moment.
+        skip_codes = self.runnable.config.get('runner.exectest.exitcodes.skip',
+                                              [])
         for most_current_execution_state in super(ExecTestRunner, self).run():
-            if 'returncode' in most_current_execution_state:
-                if most_current_execution_state['returncode'] == 0:
-                    most_current_execution_state['result'] = 'pass'
-                else:
-                    most_current_execution_state['result'] = 'fail'
+            returncode = most_current_execution_state.get('returncode')
+            if returncode in skip_codes:
+                most_current_execution_state['result'] = 'skip'
+            elif returncode == 0:
+                most_current_execution_state['result'] = 'pass'
+            else:
+                most_current_execution_state['result'] = 'fail'
             yield most_current_execution_state
 
 

--- a/avocado/core/parser.py
+++ b/avocado/core/parser.py
@@ -209,7 +209,7 @@ class HintParser:
             if '$testpath' in kwargs.values():
                 kwargs = {k: v.replace('$testpath', path)
                           for k, v in kwargs.items()}
-            runnable = Runnable(kind, uri, *args, **kwargs)
+            runnable = Runnable(kind, uri, {}, *args, **kwargs)
             resolutions.append(ReferenceResolution(reference=path,
                                                    result=success,
                                                    resolutions=[runnable],

--- a/avocado/core/suite.py
+++ b/avocado/core/suite.py
@@ -65,6 +65,18 @@ class TestSuite:
                 self.config.get('run.test_runner') == 'runner'):
             self._convert_to_dry_run()
 
+        # This will update all runnables with only the configs starting with
+        # 'runner'
+        runner_config = settings.filter_config(self.config, r'^runner\.')
+        if self.size == 0:
+            return
+        for test in self.tests:
+            try:
+                test.runnable.config = runner_config
+            except AttributeError:
+                # This is not a Task or don't have a 'runnable' attribute
+                continue
+
     def __len__(self):
         """This is a convenient method to run `len()` over this object.
 

--- a/avocado/plugins/resolvers.py
+++ b/avocado/plugins/resolvers.py
@@ -25,6 +25,7 @@ from avocado.core.references import reference_split
 from avocado.core.resolver import (ReferenceResolution,
                                    ReferenceResolutionResult, check_file)
 from avocado.core.safeloader import find_avocado_tests, find_python_unittests
+from avocado.core.settings import settings
 
 
 class ExecTestResolver(Resolver):
@@ -44,7 +45,8 @@ class ExecTestResolver(Resolver):
 
         return ReferenceResolution(reference,
                                    ReferenceResolutionResult.SUCCESS,
-                                   [Runnable('exec-test', reference)])
+                                   [Runnable('exec-test', reference,
+                                             settings.as_dict('^runner'))])
 
 
 def python_resolver(name, reference, find_tests):
@@ -67,6 +69,7 @@ def python_resolver(name, reference, find_tests):
             uri = "%s:%s" % (module_path, klass_method)
             runnables.append(Runnable(name,
                                       uri=uri,
+                                      config=settings.as_dict('^runner'),
                                       tags=tags,
                                       requirements=reqs))
     if runnables:
@@ -124,4 +127,5 @@ class TapResolver(Resolver):
 
         return ReferenceResolution(reference,
                                    ReferenceResolutionResult.SUCCESS,
-                                   [Runnable('tap', reference)])
+                                   [Runnable('tap', reference,
+                                             settings.as_dict('^runner'))])

--- a/examples/jobs/passjob_custom.py
+++ b/examples/jobs/passjob_custom.py
@@ -12,9 +12,9 @@ config = {'run.test_runner': 'nrunner'}
 # creating tests suites for you).
 
 suite1 = TestSuite(config=config,
-                   tests=[Task("task1", Runnable("noop", "noop"))], name='suite1')
+                   tests=[Task("task1", Runnable("noop", "noop", {}))], name='suite1')
 suite2 = TestSuite(config=config,
-                   tests=[Task("task2", Runnable("noop", "noop"))], name='suite2')
+                   tests=[Task("task2", Runnable("noop", "noop", {}))], name='suite2')
 
 with Job(config, [suite1, suite2]) as j:
     sys.exit(j.run())

--- a/optional_plugins/golang/avocado_golang/__init__.py
+++ b/optional_plugins/golang/avocado_golang/__init__.py
@@ -257,7 +257,9 @@ class GolangResolver(Resolver):
                     match_package = os.path.relpath(test_file, common_prefix)
                     test_name = "%s:%s" % (os.path.dirname(match_package),
                                            item)
-                    runnables.append(Runnable('golang', uri=test_name))
+                    runnables.append(Runnable(kind='golang',
+                                              uri=test_name,
+                                              config={}))
 
         if runnables:
             return ReferenceResolution(reference,

--- a/optional_plugins/golang/avocado_golang/runner.py
+++ b/optional_plugins/golang/avocado_golang/runner.py
@@ -21,7 +21,8 @@ class GolangRunner(nrunner.BaseRunner):
     Example:
 
        runnable = Runnable(kind='golang',
-                           uri='countavocados:ExampleContainers')
+                           uri='countavocados:ExampleContainers',
+                           config={})
     """
     def run(self):
         module, test = self.runnable.uri.split(':', 1)

--- a/optional_plugins/robot/avocado_robot/__init__.py
+++ b/optional_plugins/robot/avocado_robot/__init__.py
@@ -157,7 +157,9 @@ class RobotResolver(Resolver):
                                     item,
                                     robot_test['test_name'])
 
-                runnables.append(Runnable('robot', uri=uri))
+                runnables.append(Runnable(kind='robot',
+                                          uri=uri,
+                                          config={}))
 
         if runnables:
             return ReferenceResolution(reference,

--- a/selftests/functional/test_nrunner.py
+++ b/selftests/functional/test_nrunner.py
@@ -2,6 +2,7 @@ import os
 import sys
 import unittest
 
+from avocado.core.job import Job
 from avocado.utils import process
 
 from .. import AVOCADO, BASEDIR, TestCaseTmpDir, skipUnlessPathExists
@@ -143,6 +144,14 @@ class TaskRun(unittest.TestCase):
         self.assertIn("'id': 3", first_status)
         self.assertIn("'status': 'finished'", final_status)
         self.assertEqual(res.exit_status, 0)
+
+    @skipUnlessPathExists('/bin/false')
+    def test_custom_exit_codes(self):
+        config = {'run.references': ['/bin/false'],
+                  'run.test_runner': 'nrunner',
+                  'runner.exectest.exitcodes.skip': [1]}
+        with Job.from_config(job_config=config) as job:
+            self.assertEqual(job.run(), 0)
 
 
 class ResolveSerializeRun(TestCaseTmpDir):

--- a/selftests/functional/test_task_statemachine.py
+++ b/selftests/functional/test_task_statemachine.py
@@ -18,7 +18,7 @@ class StateMachine(TestCase):
         number_of_tasks = 80
         number_of_workers = 8
 
-        runnable = Runnable("noop", "noop")
+        runnable = Runnable("noop", "noop", {})
         runtime_tasks = [RuntimeTask(Task("%03i" % _, runnable))
                          for _ in range(1, number_of_tasks + 1)]
         spawner = Spawner()

--- a/selftests/unit/test_future_settings.py
+++ b/selftests/unit/test_future_settings.py
@@ -7,6 +7,7 @@ from avocado.core import settings
 
 example = """[foo]
 bar = default from file
+baz = other default from file
 non_registered = this should be ignored
 """
 
@@ -111,6 +112,20 @@ class SettingsTest(unittest.TestCase):
                              parser=parser2, long_arg='--other-option',
                              allow_multiple=True)
         self.assertIs(stgs._namespaces['section.key'].parser, parser2)
+
+    def test_filter(self):
+        stgs = settings.Settings()
+        stgs.process_config_path(self.config_file.name)
+        stgs.register_option(section='foo',
+                             key='bar',
+                             default='default from file',
+                             help_msg='just a test')
+        stgs.register_option(section='foo',
+                             key='baz',
+                             default='other default from file',
+                             help_msg='just a test')
+        self.assertEqual(stgs.as_dict(r'foo.bar$'),
+                         {'foo.bar': 'default from file'})
 
     def tearDown(self):
         os.unlink(self.config_file.name)

--- a/selftests/unit/test_spawner.py
+++ b/selftests/unit/test_spawner.py
@@ -9,7 +9,7 @@ from avocado.plugins.spawners.process import ProcessSpawner
 
 class Process(unittest.TestCase):
     def setUp(self):
-        runnable = nrunner.Runnable('noop', 'uri')
+        runnable = nrunner.Runnable('noop', 'uri', {})
         task = nrunner.Task('1', runnable)
         self.runtime_task = RuntimeTask(task)
         self.spawner = ProcessSpawner()
@@ -27,7 +27,7 @@ class Process(unittest.TestCase):
 class Mock(Process):
 
     def setUp(self):
-        runnable = nrunner.Runnable('noop', 'uri')
+        runnable = nrunner.Runnable('noop', 'uri', {})
         task = nrunner.Task('1', runnable)
         self.runtime_task = RuntimeTask(task)
         self.spawner = MockSpawner()
@@ -42,7 +42,7 @@ class Mock(Process):
 class RandomMock(Mock):
 
     def setUp(self):
-        runnable = nrunner.Runnable('noop', 'uri')
+        runnable = nrunner.Runnable('noop', 'uri', {})
         task = nrunner.Task('1', runnable)
         self.runtime_task = RuntimeTask(task)
         self.spawner = MockRandomAliveSpawner()

--- a/selftests/unit/test_tags.py
+++ b/selftests/unit/test_tags.py
@@ -310,5 +310,5 @@ class ParseFilterByTags(unittest.TestCase):
 class FilterRunnable(unittest.TestCase):
 
     def test_no_tags(self):
-        runnable = Runnable('noop', None)
+        runnable = Runnable('noop', None, {})
         self.assertFalse(tags.filter_test_tags_runnable(runnable, []))

--- a/selftests/unit/test_task_runtime.py
+++ b/selftests/unit/test_task_runtime.py
@@ -7,7 +7,7 @@ from avocado.core.task.runtime import RuntimeTask
 class Runtime(TestCase):
 
     def setUp(self):
-        runnable = Runnable('noop', 'noop')
+        runnable = Runnable('noop', 'noop', {})
         task = Task('1-noop', runnable)
         self.runtime_task = RuntimeTask(task)
 


### PR DESCRIPTION
This PR is doing two things, but they are related: First I'm introducing the ability to send custom settings (config) to the Runners via Runnables, by sending all settings namespaces starting with 'runners'. Finally, I'm using this feature to configure custom exit codes for exec-test runners in case of 'skip'. Today, exec-test is limited to understand only what is fail and pass.

Fixes #4286 