### PR TITLE
Introduces the 'config' args to Runnable and extend exec-test to support skip tests (v2)

### DIFF
--- a/avocado/core/__init__.py
+++ b/avocado/core/__init__.py
@@ -166,6 +166,16 @@ def register_core_options():
                          default='utf-8',
                          help_msg=help_msg)
 
+    # All settings starting with 'runner.' will be passed to runner
+    # exec-test runner config
+    help_msg = ('Use a custom exit code list to consider a test as skipped. '
+                'This is only used by exec-test runners. Default is [].')
+    stgs.register_option(section='runner.exectest.exitcodes',
+                         key='skip',
+                         default=[],
+                         key_type=list,
+                         help_msg=help_msg)
+
 
 def initialize_plugin_infrastructure():
     help_msg = 'Plugins that will not be loaded and executed'

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -427,12 +427,19 @@ class ExecTestRunner(ExecRunner):
     Runnable attributes usage is identical to :class:`ExecRunner`
     """
     def run(self):
+        # Since Runners are standalone, and could be executed on a remote
+        # machine in an "isolated" way, there is no way to assume a default
+        # value, at this moment.
+        skip_codes = self.runnable.config.get('runner.exectest.exitcodes.skip',
+                                              [])
         for most_current_execution_state in super(ExecTestRunner, self).run():
-            if 'returncode' in most_current_execution_state:
-                if most_current_execution_state['returncode'] == 0:
-                    most_current_execution_state['result'] = 'pass'
-                else:
-                    most_current_execution_state['result'] = 'fail'
+            returncode = most_current_execution_state.get('returncode')
+            if returncode in skip_codes:
+                most_current_execution_state['result'] = 'skip'
+            elif returncode == 0:
+                most_current_execution_state['result'] = 'pass'
+            else:
+                most_current_execution_state['result'] = 'fail'
             yield most_current_execution_state
 
 

--- a/avocado/core/suite.py
+++ b/avocado/core/suite.py
@@ -65,6 +65,19 @@ class TestSuite:
                 self.config.get('run.test_runner') == 'runner'):
             self._convert_to_dry_run()
 
+        if self.size == 0:
+            return
+
+        # This will update all runnables with only the configs starting with
+        # 'runner'
+        runner_config = settings.filter_config(self.config, r'^runner\.')
+        for test in self.tests:
+            try:
+                test.runnable.config = runner_config
+            except AttributeError:
+                # This is not a Task or don't have a 'runnable' attribute
+                continue
+
     def __len__(self):
         """This is a convenient method to run `len()` over this object.
 

--- a/avocado/plugins/resolvers.py
+++ b/avocado/plugins/resolvers.py
@@ -25,6 +25,7 @@ from avocado.core.references import reference_split
 from avocado.core.resolver import (ReferenceResolution,
                                    ReferenceResolutionResult, check_file)
 from avocado.core.safeloader import find_avocado_tests, find_python_unittests
+from avocado.core.settings import settings
 
 
 class ExecTestResolver(Resolver):
@@ -44,7 +45,8 @@ class ExecTestResolver(Resolver):
 
         return ReferenceResolution(reference,
                                    ReferenceResolutionResult.SUCCESS,
-                                   [Runnable('exec-test', reference)])
+                                   [Runnable('exec-test', reference,
+                                             config=settings.as_dict(r'^runner\.'))])
 
 
 def python_resolver(name, reference, find_tests):
@@ -68,7 +70,8 @@ def python_resolver(name, reference, find_tests):
             runnables.append(Runnable(name,
                                       uri=uri,
                                       tags=tags,
-                                      requirements=reqs))
+                                      requirements=reqs,
+                                      config=settings.as_dict(r'^runner\.')))
     if runnables:
         return ReferenceResolution(reference,
                                    ReferenceResolutionResult.SUCCESS,
@@ -124,4 +127,5 @@ class TapResolver(Resolver):
 
         return ReferenceResolution(reference,
                                    ReferenceResolutionResult.SUCCESS,
-                                   [Runnable('tap', reference)])
+                                   [Runnable('tap', reference,
+                                             config=settings.as_dict(r'^runner\.'))])

--- a/selftests/functional/test_nrunner.py
+++ b/selftests/functional/test_nrunner.py
@@ -2,11 +2,27 @@ import os
 import sys
 import unittest
 
+from avocado.core.job import Job
 from avocado.utils import process
+from avocado.utils.network.ports import find_free_port
 
 from .. import AVOCADO, BASEDIR, TestCaseTmpDir, skipUnlessPathExists
 
 RUNNER = "%s -m avocado.core.nrunner" % sys.executable
+
+
+class NRunnerFeatures(unittest.TestCase):
+    @skipUnlessPathExists('/bin/false')
+    def test_custom_exit_codes(self):
+        status_server = "127.0.0.1:%u" % find_free_port()
+        config = {'run.references': ['/bin/false'],
+                  'run.test_runner': 'nrunner',
+                  'runner.exectest.exitcodes.skip': [1],
+                  'nrunner.status_server_listen': status_server,
+                  'nrunner.status_server_uri': status_server,
+                  'run.keep_tmp': True}
+        with Job.from_config(job_config=config) as job:
+            self.assertEqual(job.run(), 0)
 
 
 class RunnableRun(unittest.TestCase):

--- a/selftests/unit/test_future_settings.py
+++ b/selftests/unit/test_future_settings.py
@@ -7,6 +7,7 @@ from avocado.core import settings
 
 example = """[foo]
 bar = default from file
+baz = other default from file
 non_registered = this should be ignored
 """
 
@@ -111,6 +112,20 @@ class SettingsTest(unittest.TestCase):
                              parser=parser2, long_arg='--other-option',
                              allow_multiple=True)
         self.assertIs(stgs._namespaces['section.key'].parser, parser2)
+
+    def test_filter(self):
+        stgs = settings.Settings()
+        stgs.process_config_path(self.config_file.name)
+        stgs.register_option(section='foo',
+                             key='bar',
+                             default='default from file',
+                             help_msg='just a test')
+        stgs.register_option(section='foo',
+                             key='baz',
+                             default='other default from file',
+                             help_msg='just a test')
+        self.assertEqual(stgs.as_dict(r'foo.bar$'),
+                         {'foo.bar': 'default from file'})
 
     def tearDown(self):
         os.unlink(self.config_file.name)

--- a/selftests/unit/test_nrunner.py
+++ b/selftests/unit/test_nrunner.py
@@ -73,18 +73,23 @@ class Runnable(unittest.TestCase):
     def test_runnable_command_args(self):
         runnable = nrunner.Runnable('noop', 'uri', 'arg1', 'arg2')
         actual_args = runnable.get_command_args()
-        exp_args = ['-k', 'noop', '-u', 'uri', '-a', 'arg1', '-a', 'arg2']
+        exp_args = ['-k', 'noop', '-u', 'uri', '-c', '{}', '-a', 'arg1',
+                    '-a', 'arg2']
         self.assertEqual(actual_args, exp_args)
 
     def test_get_dict(self):
         runnable = nrunner.Runnable('noop', '_uri_', 'arg1', 'arg2')
         self.assertEqual(runnable.get_dict(),
                          {'kind': 'noop', 'uri': '_uri_',
-                          'args': ('arg1', 'arg2')})
+                          'args': ('arg1', 'arg2'),
+                          'config': {}})
 
     def test_get_json(self):
         runnable = nrunner.Runnable('noop', '_uri_', 'arg1', 'arg2')
-        expected = '{"kind": "noop", "uri": "_uri_", "args": ["arg1", "arg2"]}'
+        expected = ('{"kind": "noop", '
+                    '"uri": "_uri_", '
+                    '"config": {}, '
+                    '"args": ["arg1", "arg2"]}')
         self.assertEqual(runnable.get_json(), expected)
 
     def test_runner_from_runnable_error(self):


### PR DESCRIPTION
This PR is doing two things, but they are related: First I'm introducing the ability to send custom settings (config) to the Runners via Runnables, by sending all settings namespaces starting with 'runners'. Finally, I'm using this feature to configure custom exit codes for exec-test runners in case of 'skip'. Today, exec-test is limited to understand only what is fail and pass.

Fixes #4286

### Changes from v1:

  * config arg is not optional
  * default for `runner.exectest.exitcodes.skip` now is `[]`
  * small changes suggested by @willianrampazzo 
  * using `'^runner\.'` as regex