### PR TITLE
Show test logs depending on status [v2]

### DIFF
--- a/avocado/plugins/testlogs.py
+++ b/avocado/plugins/testlogs.py
@@ -1,0 +1,48 @@
+import json
+import os
+
+from avocado.core.output import LOG_UI
+from avocado.core.plugin_interfaces import Init, JobPost, JobPre
+from avocado.core.settings import settings
+from avocado.core.teststatus import user_facing_status
+
+
+class TestLogsInit(Init):
+
+    description = "Initialize testlogs plugin settings"
+
+    def initialize(self):
+        help_msg = ("Status that will trigger the output of a test's logs "
+                    "after the job ends. "
+                    "Valid statuses: %s" % ", ".join(user_facing_status))
+        settings.register_option(section='job.output.testlogs',
+                                 key='statuses',
+                                 key_type=list,
+                                 default=[],
+                                 help_msg=help_msg)
+
+
+class TestLogs(JobPre, JobPost):
+
+    description = "Shows content from tests' logs"
+
+    def pre(self, job):
+        pass
+
+    def post(self, job):
+        statuses = job.config.get('job.output.testlogs.statuses')
+        if not statuses:
+            return
+
+        try:
+            with open(os.path.join(job.logdir, 'results.json')) as json_file:
+                results = json.load(json_file)
+        except FileNotFoundError:
+            return
+
+        for test in results['tests']:
+            if test['status'] not in statuses:
+                continue
+            LOG_UI.info('Log content for test "%s" (%s)', test['id'], test['status'])
+            with open(test['logfile']) as log:
+                LOG_UI.debug(log.read())

--- a/docs/source/guides/user/chapters/plugins.rst
+++ b/docs/source/guides/user/chapters/plugins.rst
@@ -267,3 +267,28 @@ this is not set.
 
 Finally, any failures in the Pre/Post scripts will not alter the
 status of the corresponding jobs.
+
+Tests' logs plugin
+~~~~~~~~~~~~~~~~~~
+
+It's natural that Avocado will be used in environments where access to
+the integral job results won't be easily accessible.
+
+For instance, on Continuous Integration (CI) services, one usually
+gets access to the output produced on the console, while access to
+other files produced (generally called artifacts) may or may not be
+acessible.
+
+For this reason, it may be helpful to simply output the logs for tests
+that have "interesting" outcomes, which usually means that fail and
+need to be investigated.
+
+To show the content for test that are canceled, skipped and fail, you
+can set on your configuration file::
+
+  [job.output.testlogs]
+  statuses = ["CANCEL", "SKIP", "FAIL"]
+
+At the end of the job, a header will be printed for each test that
+ended with any of the statuses given, followed by the raw content of
+its reespective log file.

--- a/selftests/functional/test_logs.py
+++ b/selftests/functional/test_logs.py
@@ -1,0 +1,33 @@
+import os
+
+from avocado.core import exit_codes
+from avocado.utils import process
+
+from .. import AVOCADO, TestCaseTmpDir
+
+CONFIG = """[job.output.testlogs]
+statuses = ["FAIL", "CANCEL"]"""
+
+
+class TestLogs(TestCaseTmpDir):
+
+    def setUp(self):
+        super(TestLogs, self).setUp()
+        with open(os.path.join(self.tmpdir.name, 'config'), 'w') as config:
+            config.write(CONFIG)
+
+    def test(self):
+        cmd_line = ("%s --config=%s run -- examples/tests/passtest.py "
+                    "examples/tests/failtest.py examples/tests/canceltest.py ")
+        cmd_line %= (AVOCADO, os.path.join(self.tmpdir.name, 'config'))
+        result = process.run(cmd_line, ignore_status=True)
+        self.assertEqual(result.exit_status, exit_codes.AVOCADO_TESTS_FAIL,
+                         "Avocado did not return rc %d:\n%s"
+                         % (exit_codes.AVOCADO_ALL_OK, result))
+        stdout_lines = result.stdout_text.splitlines()
+        self.assertNotIn('Log content for test "1-examples/tests/passtest.py'
+                         ':PassTest.test" (PASS)', stdout_lines)
+        self.assertIn('Log content for test "2-examples/tests/failtest.py:'
+                      'FailTest.test" (FAIL)', stdout_lines)
+        self.assertIn('Log content for test "3-examples/tests/canceltest.py'
+                      ':CancelTest.test" (CANCEL)', stdout_lines)

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ if __name__ == '__main__':
                   "run = avocado.plugins.run:RunInit",
                   "podman = avocado.plugins.spawners.podman:PodmanSpawnerInit",
                   "nrunner = avocado.plugins.runner_nrunner:RunnerInit",
+                  "testlogs = avocado.plugins.testlogs:TestLogsInit",
               ],
               'avocado.plugins.cli': [
                   'wrapper = avocado.plugins.wrapper:Wrapper',
@@ -115,6 +116,7 @@ if __name__ == '__main__':
                   'teststmpdir = avocado.plugins.teststmpdir:TestsTmpDir',
                   'human = avocado.plugins.human:HumanJob',
                   'merge_files = avocado.plugins.expected_files_merge:FilesMerge',
+                  'testlogs = avocado.plugins.testlogs:TestLogs',
                   ],
               'avocado.plugins.result': [
                   'xunit = avocado.plugins.xunit:XUnitResult',


### PR DESCRIPTION
When running tests on certain scenarios, such as on CI environments,
it's usually not a good idea to pollute the output with very verbose
output. On the other hand, when failures occurs, the only debugging
aid is many times printing out the entire test log.

Fixes: https://github.com/avocado-framework/avocado/issues/4266
Signed-off-by: Cleber Rosa <crosa@redhat.com>

---

Changes from v1 (#4301):
 * renamed namespace from `job.run.testlogs` to `job.output.testlogs`