### PR TITLE
avocado/core/nrunner_avocado_instrumented.py: fix timeout handling

### DIFF
--- a/avocado/core/nrunner_avocado_instrumented.py
+++ b/avocado/core/nrunner_avocado_instrumented.py
@@ -82,7 +82,7 @@ class AvocadoInstrumentedTestRunner(nrunner.BaseRunner):
             time.sleep(nrunner.RUNNER_RUN_CHECK_INTERVAL)
 
         early_status = queue.get()
-        timeout = float(early_status.get('timeout', self.DEFAULT_TIMEOUT))
+        timeout = float(early_status.get('timeout') or self.DEFAULT_TIMEOUT)
         interrupted = False
         most_current_execution_state_time = None
         while queue.empty():


### PR DESCRIPTION
The timeout from the early status can be an actual *None*, and in such
case, the runner will crash trying to convert it to a float.

This fixes the crashes such as:

    $ avocado-runner-avocado-instrumented runnable-run -u selftests/unit/test_utils_cpu.py:Cpu.test_x86_64_cpu_online
    {'status': 'started', 'time': 3637949.5979991}
    Traceback (most recent call last):
      File "/home/cleber/.local/bin/avocado-runner-avocado-instrumented", line 11, in <module>
        load_entry_point('avocado-framework', 'console_scripts', 'avocado-runner-avocado-instrumented')()
      File "/home/cleber/src/avocado/avocado/avocado/core/nrunner_avocado_instrumented.py", line 125, in main
        nrunner.main(RunnerApp)
      File "/home/cleber/src/avocado/avocado/avocado/core/nrunner.py", line 947, in main
        app.run()
      File "/home/cleber/src/avocado/avocado/avocado/core/nrunner.py", line 834, in run
        return kallable(args)
      File "/home/cleber/src/avocado/avocado/avocado/core/nrunner.py", line 897, in command_runnable_run
        for status in runner.run():
      File "/home/cleber/src/avocado/avocado/avocado/core/nrunner_avocado_instrumented.py", line 85, in run
        timeout = float(early_status.get('timeout', self.DEFAULT_TIMEOUT))
    TypeError: float() argument must be a string or a number, not 'NoneType'

Signed-off-by: Cleber Rosa <crosa@redhat.com>