### PR TITLE
utils/pci: Fix for accomodating newer slot names

### DIFF
--- a/avocado/utils/pci.py
+++ b/avocado/utils/pci.py
@@ -191,7 +191,7 @@ def get_slot_from_sysfs(full_pci_address):
     if not os.path.isfile("/proc/device-tree/%s/ibm,loc-code" % devspec):
         return
     slot = genio.read_file("/proc/device-tree/%s/ibm,loc-code" % devspec)
-    slot_ibm = re.match(r'((\w+)[.])+(\w+)-[P(\d+)-]*C(\d+)', slot)
+    slot_ibm = re.match(r'((\w+)[.])+(\w+)-[PC(\d+)-]*C(\d+)', slot)
     if slot_ibm:
         return slot_ibm.group()
     slot_openpower = re.match(r'(\w+)[\s]*(\w+)(\d*)', slot)


### PR DESCRIPTION
Newer pci slot names are in the format: U78D8.ND0.XXXXXX-P0-C7-C0.
So, enhancing the function to accomodate them as well.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>