### PR TITLE
Update regex for cpu version of x86

### DIFF
--- a/avocado/utils/cpu.py
+++ b/avocado/utils/cpu.py
@@ -103,7 +103,7 @@ def get_version():
               Eg.:- 'i5-5300U' for Intel and 'POWER9' for IBM machines in
               case of unknown/unsupported machines, return an empty string.
     """
-    version_pattern = {'x86_64': rb'\s([\S,\d]+)\sCPU',
+    version_pattern = {'x86_64': rb'\s([\w,\d,-.]+)\sCPU',
                        'i386': rb'\s([\S,\d]+)\sCPU',
                        'powerpc': rb'revision\s+:\s+(\S+)',
                        's390': rb'.*machine\s=\s(\d+)'


### PR DESCRIPTION
The original regex could match with string with '()' in it, which
is not the expected version and will be written into host.cfg
during bootstrap. '()' in hosts.cfg  cannot be parsed which will
lead to list failure. This patch will set regex strict to a list
of options therefore could fix the problem.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>