### PR TITLE
Convert old style 'on'/''off' to real boolean arguments on remaining plugins

### DIFF
--- a/avocado/plugins/jsonresult.py
+++ b/avocado/plugins/jsonresult.py
@@ -19,7 +19,6 @@ JSON output module.
 
 import json
 import os
-import warnings
 
 from avocado.core.output import LOG_UI
 from avocado.core.parser import FileOrStdoutAction
@@ -78,7 +77,7 @@ class JSONResult(Result):
             return
 
         content = self._render(result)
-        if json_enabled == 'on':
+        if json_enabled:
             json_path = os.path.join(job.logdir, 'results.json')
             with open(json_path, 'w') as json_file:
                 json_file.write(content)
@@ -109,7 +108,8 @@ class JSONInit(Init):
                     'directory. File will be named "results.json".')
         settings.register_option(section='job.run.result.json',
                                  key='enabled',
-                                 default='on',
+                                 key_type=bool,
+                                 default=True,
                                  help_msg=help_msg)
 
 
@@ -127,11 +127,6 @@ class JSONCLI(CLI):
         if run_subcommand_parser is None:
             return
 
-        warning_msg = ("--json-job-result as string will be deprecated soon. "
-                       "This will be a bool option. On, Off will not be "
-                       "necessary in future releases")
-        warnings.warn(warning_msg)
-
         settings.add_argparser_to_option(
             namespace='job.run.result.json.output',
             action=FileOrStdoutAction,
@@ -141,9 +136,8 @@ class JSONCLI(CLI):
 
         settings.add_argparser_to_option(
             namespace='job.run.result.json.enabled',
-            choices=('on', 'off'),
             parser=run_subcommand_parser,
-            long_arg='--json-job-result')
+            long_arg='--disable-json-job-result')
 
     def run(self, config):
         pass

--- a/avocado/plugins/tap.py
+++ b/avocado/plugins/tap.py
@@ -16,7 +16,6 @@ TAP output module.
 """
 
 import os
-import warnings
 
 from avocado.core.output import LOG_UI
 from avocado.core.parser import FileOrStdoutAction
@@ -89,7 +88,7 @@ class TAPResult(ResultEvents):
         Log the test plan
         """
         # Should we add default results.tap?
-        if self.config.get('job.run.result.tap.enabled') == 'on':
+        if self.config.get('job.run.result.tap.enabled'):
             log = open(os.path.join(job.logdir, 'results.tap'), "w", 1)
             self.__open_files.append(log)
             self.__logs.append(file_log_factory(log))
@@ -169,8 +168,9 @@ class TAPInit(Init):
         settings.register_option(
             section=section,
             key='enabled',
-            help_msg=help_msg,
-            default='on')
+            key_type=bool,
+            default=True,
+            help_msg=help_msg)
 
         help_msg = 'Include test logs as comments in TAP output.'
         settings.register_option(
@@ -194,10 +194,6 @@ class TAP(CLI):
         cmd_parser = parser.subcommands.choices.get('run', None)
         if cmd_parser is None:
             return
-        warning_msg = ("--tap-job-result as string will be deprecated soon. "
-                       "This will be a bool option. On, Off will not be "
-                       "necessary in future releases")
-        warnings.warn(warning_msg)
 
         settings.add_argparser_to_option(
             namespace='job.run.result.tap.output',
@@ -208,9 +204,8 @@ class TAP(CLI):
 
         settings.add_argparser_to_option(
             namespace='job.run.result.tap.enabled',
-            choices=('on', 'off'),
             parser=cmd_parser,
-            long_arg='--tap-job-result')
+            long_arg='--disable-tap-job-result')
 
         settings.add_argparser_to_option(
             namespace='job.run.result.tap.include_logs',

--- a/avocado/plugins/xunit.py
+++ b/avocado/plugins/xunit.py
@@ -18,7 +18,6 @@
 import datetime
 import os
 import string
-import warnings
 from xml.dom.minidom import Document
 
 from avocado.core.output import LOG_UI
@@ -147,7 +146,7 @@ class XUnitResult(Result):
             'job.run.result.xunit.max_test_log_chars')
         job_name = job.config.get('job.run.result.xunit.job_name')
         content = self._render(result, max_test_log_size, job_name)
-        if xunit_enabled == 'on':
+        if xunit_enabled:
             xunit_path = os.path.join(job.logdir, 'results.xml')
             with open(xunit_path, 'wb') as xunit_file:
                 xunit_file.write(content)
@@ -179,8 +178,9 @@ class XUnitInit(Init):
                     'directory. File will be named "results.xml".')
         settings.register_option(section=section,
                                  key='enabled',
-                                 help_msg=help_msg,
-                                 default='on')
+                                 key_type=bool,
+                                 default=True,
+                                 help_msg=help_msg)
 
         help_msg = ('Override the reported job name. By default uses the '
                     'Avocado job name which is always unique. This is useful '
@@ -210,11 +210,6 @@ class XUnitCLI(CLI):
     description = 'xUnit output options'
 
     def configure(self, parser):
-        warning_msg = ("--xunit-job-result as string will be deprecated soon. "
-                       "This will be a bool option. On, Off will not be "
-                       "necessary in future releases")
-        warnings.warn(warning_msg)
-
         run_subcommand_parser = parser.subcommands.choices.get('run', None)
         if run_subcommand_parser is None:
             return
@@ -227,9 +222,8 @@ class XUnitCLI(CLI):
 
         settings.add_argparser_to_option(
             namespace='job.run.result.xunit.enabled',
-            choices=('on', 'off'),
             parser=run_subcommand_parser.output,
-            long_arg='--xunit-job-result')
+            long_arg='--disable-xunit-job-result')
 
         settings.add_argparser_to_option(
             namespace='job.run.result.xunit.job_name',

--- a/docs/source/plugins/optional/results.rst
+++ b/docs/source/plugins/optional/results.rst
@@ -24,10 +24,9 @@ Once installed it produces the results in job results dir::
     ...
 
 
-This can be disabled via --html-job-result on|off. One can also
-specify a custom location via --html . Last but not least
---open-browser can be used to start browser automatically once
-the job finishes.
+This can be disabled via --disable-html-job-result. One can also specify a
+custom location via --html . Last but not least --open-browser can be used to
+start browser automatically once the job finishes.
 
 .. _results-upload-plugin:
 

--- a/examples/jobs/passjob_html.py
+++ b/examples/jobs/passjob_html.py
@@ -6,7 +6,7 @@ from avocado.core.job import Job
 from avocado.core.suite import TestSuite
 
 config = {'run.references': ['examples/tests/passtest.py:PassTest.test'],
-          'job.run.result.html.enabled': 'on'}
+          'job.run.result.html.enabled': True}
 
 suite = TestSuite.from_config(config)
 with Job(config, [suite]) as j:

--- a/examples/jobs/passjob_html_browser.py
+++ b/examples/jobs/passjob_html_browser.py
@@ -6,7 +6,7 @@ from avocado.core.job import Job
 from avocado.core.suite import TestSuite
 
 config = {'run.references': ['examples/tests/passtest.py:PassTest.test'],
-          'job.run.result.html.enabled': 'on',
+          'job.run.result.html.enabled': True,
           'job.run.result.html.open_browser': True}
 
 suite = TestSuite.from_config(config)

--- a/optional_plugins/html/avocado_result_html/__init__.py
+++ b/optional_plugins/html/avocado_result_html/__init__.py
@@ -21,7 +21,6 @@ import os
 import subprocess
 import sys
 import time
-import warnings
 
 import jinja2 as jinja
 
@@ -226,7 +225,7 @@ class HTMLResult(Result):
             return
 
         open_browser = job.config.get('job.run.result.html.open_browser', False)
-        if job.config.get('job.run.result.html.enabled', 'off') == 'on':
+        if job.config.get('job.run.result.html.enabled'):
             html_path = os.path.join(job.logdir, 'results.html')
             self._render(result, html_path)
             if job.config.get('stdout_claimed_by', None) is None:
@@ -273,7 +272,8 @@ class HTMLInit(Init):
                     'directory. File will be named "results.html".')
         settings.register_option(section=section,
                                  key='enabled',
-                                 default='on',
+                                 key_type=bool,
+                                 default=True,
                                  help_msg=help_msg)
 
 
@@ -291,11 +291,6 @@ class HTML(CLI):
         if run_subcommand_parser is None:
             return
 
-        warning_msg = ("--html-job-result as string will be deprecated soon. "
-                       "This will be a bool option. On, Off will not be "
-                       "necessary in future releases")
-        warnings.warn(warning_msg)
-
         settings.add_argparser_to_option(
             namespace='job.run.result.html.output',
             parser=run_subcommand_parser,
@@ -309,9 +304,8 @@ class HTML(CLI):
 
         settings.add_argparser_to_option(
             namespace='job.run.result.html.enabled',
-            choices=('on', 'off'),
             parser=run_subcommand_parser,
-            long_arg='--html-job-result')
+            long_arg='--disable-html-job-result')
 
     def run(self, config):
         if config.get('job.run.result.html.output') == '-':

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -365,12 +365,12 @@ def create_suites():
               'assert': False},
 
              {'namespace': 'job.run.result.json.enabled',
-              'value': 'on',
+              'value': True,
               'file': 'results.json',
               'assert': True},
 
              {'namespace': 'job.run.result.json.enabled',
-              'value': 'off',
+              'value': False,
               'file': 'results.json',
               'assert': False},
 

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -385,12 +385,12 @@ def create_suites():
               'assert': False},
 
              {'namespace': 'job.run.result.xunit.enabled',
-              'value': 'on',
+              'value': True,
               'file': 'results.xml',
               'assert': True},
 
              {'namespace': 'job.run.result.xunit.enabled',
-              'value': 'off',
+              'value': False,
               'file': 'results.xml',
               'assert': False},
 

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -375,12 +375,12 @@ def create_suites():
               'assert': False},
 
              {'namespace': 'job.run.result.tap.enabled',
-              'value': 'on',
+              'value': True,
               'file': 'results.tap',
               'assert': True},
 
              {'namespace': 'job.run.result.tap.enabled',
-              'value': 'off',
+              'value': False,
               'file': 'results.tap',
               'assert': False},
 

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -355,12 +355,12 @@ def create_suites():
          'run.dict_variants': [
 
              {'namespace': 'job.run.result.html.enabled',
-              'value': 'on',
+              'value': True,
               'file': 'results.html',
               'assert': True},
 
              {'namespace': 'job.run.result.html.enabled',
-              'value': 'off',
+              'value': False,
               'file': 'results.html',
               'assert': False},
 

--- a/selftests/functional/test_job_api_features.py
+++ b/selftests/functional/test_job_api_features.py
@@ -21,7 +21,7 @@ class Test(TestCaseTmpDir):
                             'run.keep_tmp': True}
 
     def test_job_run_result_json_enabled(self):
-        self.base_config['job.run.result.json.enabled'] = 'on'
+        self.base_config['job.run.result.json.enabled'] = True
         j = Job.from_config(self.base_config)
         j.setup()
         result = j.run()


### PR DESCRIPTION
This is removing old style 'on'/'off' from some configuration namespaces and replacing by a true bool. This is part of BP001.
Fixes #3440