### PR TITLE
nrunner/exec: do not add fail test status when returncode not produce…

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -434,12 +434,13 @@ class ExecTestRunner(ExecRunner):
                                               [])
         for most_current_execution_state in super(ExecTestRunner, self).run():
             returncode = most_current_execution_state.get('returncode')
-            if returncode in skip_codes:
-                most_current_execution_state['result'] = 'skip'
-            elif returncode == 0:
-                most_current_execution_state['result'] = 'pass'
-            else:
-                most_current_execution_state['result'] = 'fail'
+            if returncode is not None:
+                if returncode in skip_codes:
+                    most_current_execution_state['result'] = 'skip'
+                elif returncode == 0:
+                    most_current_execution_state['result'] = 'pass'
+                else:
+                    most_current_execution_state['result'] = 'fail'
             yield most_current_execution_state
 
 


### PR DESCRIPTION
…d yet

On 965e4daefa, the support for configurable skips based on the return code
was added.  But, it ended up introducing a bug, in which "'result': 'fail'"
is added right from the very first status ("status": "started").

Reference: https://github.com/avocado-framework/avocado/issues/4322
Signed-off-by: Cleber Rosa <crosa@redhat.com>