### PR TITLE
nrunner: replacing poll() with communicate() in subprocess call

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -10,6 +10,7 @@ import multiprocessing
 import os
 import re
 import socket
+import struct
 import subprocess
 import sys
 import tempfile
@@ -621,7 +622,11 @@ class TaskStatusService:
             self.connection = socket.create_connection((host, port))
 
         data = json_dumps(status)
-        self.connection.send(data.encode('ascii') + "\n".encode('ascii'))
+        # First 8 bytes (Q) are carring the message size
+        size = len(data)
+        self.connection.send(struct.pack('!Q{}s'.format(size),
+                                         size,
+                                         data.encode('ascii')))
 
     def close(self):
         if self.connection is not None:


### PR DESCRIPTION
Not sure if this is the right solution, but subprocess library documentation
recommend to use "communicate() rather than .(stdout|stderr).read to avoid
deadlocks due to any of the other OS pipe buffers filling up and blocking the
child process". Issue #4322 might be one of those cases. This PR it is
replacing poll() with communicate() call.

Although the communicate() documentation says "The data read is buffered in
memory, so do not use this method if the data size is large or unlimited.",
IMO, this only occurs in some *huge* cases. I tested with some very large
outputs (>42k output lines) and managed to run without problems.

Signed-off-by: Beraldo Leal <bleal@redhat.com>