### PR TITLE
Settings, variables swap

### DIFF
--- a/avocado/core/settings.py
+++ b/avocado/core/settings.py
@@ -394,7 +394,7 @@ class Settings:
             msg = "Parser already registered for this namespace"
             raise SettingsError(msg)
 
-        option.add_argparser(parser, short_arg, long_arg, positional_arg,
+        option.add_argparser(parser, long_arg, short_arg, positional_arg,
                              choices, nargs, metavar, required, action)
 
     def as_dict(self, regex=None):


### PR DESCRIPTION
In `add_argparser_to_option` the variables `long_arg` and `short_arg` are
swapped.

Signed-off-by: Jan Richter <jarichte@redhat.com>