### PR TITLE
Makefile AVOCADO_DIRNAME fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ endif
 VERSION=$(shell $(PYTHON) setup.py --version 2>/dev/null)
 PYTHON_DEVELOP_ARGS=$(shell if ($(PYTHON) setup.py develop --help 2>/dev/null | grep -q '\-\-user'); then echo "--user"; else echo ""; fi)
 DESTDIR=/
-AVOCADO_DIRNAME=$(shell echo $${PWD\#\#*/})
+AVOCADO_DIRNAME=$(shell basename ${PWD})
 AVOCADO_EXTERNAL_PLUGINS=$(filter-out ../$(AVOCADO_DIRNAME), $(shell find ../ -maxdepth 1 -mindepth 1 -type d))
 AVOCADO_OPTIONAL_PLUGINS=$(shell find ./optional_plugins -maxdepth 1 -mindepth 1 -type d)
 AVOCADO_PLUGINS=$(AVOCADO_OPTIONAL_PLUGINS) $(AVOCADO_EXTERNAL_PLUGINS)


### PR DESCRIPTION
The variable `AVOCADO_DIRNAME` in Makefile is not set properly on Fedora 33 and
make has warning:

/bin/sh: ${PWD\#\#*/}: bad substitution.

This is fixing it.

Reference:#4318
Signed-off-by: Jan Richter <jarichte@redhat.com>