### PR TITLE
Fix: Handle None type input in yaml

### DIFF
--- a/docs/source/plugins/optional/varianter_yaml_to_mux.rst
+++ b/docs/source/plugins/optional/varianter_yaml_to_mux.rst
@@ -141,8 +141,8 @@ The environment created for the nodes ``fedora`` and ``osx`` are:
 Note that due to different usage of key and values in environment we disabled
 the automatic value conversion for keys while keeping it enabled for values.
 This means that the key is always a string and the value can be YAML value,
-eg. bool, list, custom type, or string. Please be aware that the None type
-is unsupported and cannot be provided in yaml as null.
+eg. bool, list, custom type, or string. Please be aware that due to limitation
+None type can be provided in yaml specifically as string 'null'.
 
 Variants
 --------

--- a/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/__init__.py
+++ b/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/__init__.py
@@ -188,6 +188,8 @@ def _node_content_from_dict(path, node, values, using):
         elif (isinstance(value, collections.OrderedDict) or
               value is None):
             node.add_child(_tree_node_from_values(path, key, value, using))
+        elif value == 'null':
+            node.value[key] = None
         else:
             node.value[key] = value
     return using
@@ -242,6 +244,8 @@ def _mapping_to_tree_loader(loader, node, looks_like_node=False):
                                                   values, loader.using))
         elif values is None:            # Empty node
             objects.append(mux.MuxTreeNode(astring.to_text(name)))
+        elif values == 'null':
+            objects.append((name, None))
         else:                           # Values
             objects.append((name, values))
     return objects


### PR DESCRIPTION
Patch handles None type input in yaml as a special case due to limitation in avocado implementation
```
YAML:
setup:
    disk_type: 'nvdimm'
    fs_type: !mux
        fs_xfs:
            exclude: null
            gen_exclude: 'null'

Before patch:
Variant run-setup-disk_type-fs_type-fs_xfs-exclude-83a1:    /run/setup/fs_type/fs_xfs/exclude
    /run/setup/disk_type:type             => nvdimm
    /run/setup/fs_type/fs_xfs:fs          => xfs
    /run/setup/fs_type/fs_xfs:gen_exclude => null

After patch:
Variant run-setup-disk_type-fs_type-fs_xfs-exclude-8cde:    /run/setup/fs_type/fs_xfs/exclude
    /run/setup/disk_type:type             => nvdimm
    /run/setup/fs_type/fs_xfs:fs          => xfs
    /run/setup/fs_type/fs_xfs:gen_exclude => None
```
Fixes: #4010 

Signed-off-by: Harish <harish@linux.ibm.com>