### PR TITLE
Fix broken -f option on selftests/check.py

### DIFF
--- a/selftests/check.py
+++ b/selftests/check.py
@@ -496,8 +496,9 @@ def main():
     if args.features:
         features = []
         for suite in suites:
-            for variants in suite.config['run.dict_variants']:
-                features.append(variants['namespace'])
+            if suite.config.get('run.dict_variants') is not None:
+                for variants in suite.config['run.dict_variants']:
+                    features.append(variants['namespace'])
 
         unique_features = sorted(set(features))
         print('Features covered (%i):' %len(unique_features))


### PR DESCRIPTION
This fixes the following:

```
$ ./check.py -f
Traceback (most recent call last):
  File "/home/wrampazz/src/avocado/avocado.quick-dev/selftests/./check.py", line 518, in <module>
    sys.exit(main())
  File "/home/wrampazz/src/avocado/avocado.quick-dev/selftests/./check.py", line 500, in main
    for variants in suite.config['run.dict_variants']:
KeyError: 'run.dict_variants'
```

Signed-off-by: Willian Rampazzo <willianr@redhat.com>