### PR TITLE
Register run.dict_variants missing option from dict_variants plugin.

### DIFF
--- a/avocado/plugins/dict_variants.py
+++ b/avocado/plugins/dict_variants.py
@@ -13,9 +13,23 @@
 # Authors: Cleber Rosa <crosa@redhat.com>
 
 from avocado.core import varianter
-from avocado.core.plugin_interfaces import Varianter
+from avocado.core.plugin_interfaces import Init, Varianter
+from avocado.core.settings import settings
 from avocado.core.tree import TreeNode
 
+
+class DictVariantsInit(Init):
+
+    name = 'dict_variants'
+    description = "Python Dictionary based varianter"
+
+    def initialize(self):
+        help_msg = 'Load the Variants from Python dictionaries'
+        settings.register_option(section='run',
+                                 key='dict_variants',
+                                 default=[],
+                                 key_type=list,
+                                 help_msg=help_msg)
 
 class DictVariants(Varianter):
 

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ if __name__ == '__main__':
                   "sysinfo = avocado.plugins.sysinfo:SysinfoInit",
                   "tap = avocado.plugins.tap:TAPInit",
                   "jobscripts = avocado.plugins.jobscripts:JobScriptsInit",
+                  "dict_variants = avocado.plugins.dict_variants:DictVariantsInit",
                   "json_variants = avocado.plugins.json_variants:JsonVariantsInit",
                   "run = avocado.plugins.run:RunInit",
                   "podman = avocado.plugins.spawners.podman:PodmanSpawnerInit",


### PR DESCRIPTION
This fixes the following:

```
$ ./check.py -f
Traceback (most recent call last):
  File "/home/wrampazz/src/avocado/avocado.quick-dev/selftests/./check.py", line 518, in <module>
    sys.exit(main())
  File "/home/wrampazz/src/avocado/avocado.quick-dev/selftests/./check.py", line 500, in main
    for variants in suite.config['run.dict_variants']:
KeyError: 'run.dict_variants'
```

Signed-off-by: Willian Rampazzo <willianr@redhat.com>