### PR TITLE
bp000: option-arguments should not be optional

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -407,7 +407,7 @@ def add_loader_options(parser, section='run'):
                 "settings->plugins.loaders.")
     settings.register_option(section=section,
                              key='loaders',
-                             nargs='*',
+                             nargs='+',
                              key_type=list,
                              default=['file', '@DEFAULT'],
                              help_msg=help_msg,

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -213,7 +213,7 @@ class Run(CLICmd):
                     '"$JOB_RESULTS_DIR/$STREAM.$LEVEL."')
         settings.register_option(section='run',
                                  key='store_logging_stream',
-                                 nargs='*',
+                                 nargs='+',
                                  help_msg=help_msg,
                                  default=[],
                                  metavar='STREAM[:LEVEL]',

--- a/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/__init__.py
+++ b/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/__init__.py
@@ -424,35 +424,35 @@ class YamlToMuxCLI(CLI):
                 long_arg='--mux-yaml',
                 short_arg='-m',
                 metavar='FILE',
-                nargs='*',
+                nargs='+',
                 allow_multiple=True)
 
             settings.add_argparser_to_option(
                 namespace="%s.%s" % (self.name, 'filter_only'),
                 parser=agroup,
                 long_arg='--mux-filter-only',
-                nargs='*',
+                nargs='+',
                 allow_multiple=True)
 
             settings.add_argparser_to_option(
                 namespace="%s.%s" % (self.name, 'filter_out'),
                 parser=agroup,
                 long_arg='--mux-filter-out',
-                nargs='*',
+                nargs='+',
                 allow_multiple=True)
 
             settings.add_argparser_to_option(
                 namespace="%s.%s" % (self.name, 'parameter_paths'),
                 parser=agroup,
                 long_arg='--mux-path',
-                nargs='*',
+                nargs='+',
                 allow_multiple=True)
 
             settings.add_argparser_to_option(
                 namespace="%s.%s" % (self.name, 'inject'),
                 parser=agroup,
                 long_arg='--mux-inject',
-                nargs='*',
+                nargs='+',
                 allow_multiple=True)
 
     def run(self, config):


### PR DESCRIPTION
This is a cosmetic change but help us having a better command-line
syntax as discussed on BP000. Basically this will make argparse raise
errors when option-arguments have no arguments and also fixes the syntax
displayed on help. Fixes #3441.

AFAICT, the only remaining optional option-arguments is 'refeferences' for both 'run'  and 'list' commands. Those are kept there because makes sense.

Signed-off-by: Beraldo Leal <bleal@redhat.com>