### PR TITLE
Fix: Remove 16G hugepage only for Hash MMU

### DIFF
--- a/avocado/utils/memory.py
+++ b/avocado/utils/memory.py
@@ -258,7 +258,8 @@ def get_supported_huge_pages_size():
     # the <size> will always start from index 10.
     output = [int(each[10:].rstrip('kB')) for each in output]
     if os.uname()[4] in ['ppc64', 'ppc64le'] and b'PowerVM'\
-            in process.system_output("pseries_platform", ignore_status=True):
+            in process.system_output("pseries_platform", ignore_status=True)\
+            and 'MMU\t\t: Hash' in genio.read_file('/proc/cpuinfo').rstrip('\t\r\n\0'):
         output.remove(16777216)
     return output
 


### PR DESCRIPTION
Currently a PowerVM machine has the capability to run on both Hash and Radix MMU, hence remove 16G hugepages only in case of Radix.

Signed-off-by: Harish <harish@linux.ibm.com>