### PR TITLE
Nrunner: handle large stdout/stderr size limits

### DIFF
--- a/avocado/core/status/server.py
+++ b/avocado/core/status/server.py
@@ -1,5 +1,7 @@
 import asyncio
 
+from ..settings import settings
+
 
 class StatusServer:
     """Server that listens for status messages and updates a StatusRepo."""
@@ -18,17 +20,20 @@ class StatusServer:
         self._server_task = None
 
     async def create_server(self):
+        limit = settings.as_dict().get('nrunner.status_server_buffer_size')
         if ':' in self._uri:
             host, port = self._uri.split(':')
             port = int(port)
             self._server_task = await asyncio.start_server(
                 self.cb,
                 host=host,
-                port=port)
+                port=port,
+                limit=limit)
         else:
             self._server_task = await asyncio.start_unix_server(
                 self.cb,
-                path=self._uri)
+                path=self._uri,
+                limit=limit)
 
     async def serve_forever(self):
         if self._server_task is None:

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -67,6 +67,17 @@ class RunnerInit(Init):
                                  metavar="HOST:PORT",
                                  help_msg=help_msg)
 
+        help_msg = ('Buffer size that status server uses.  This should '
+                    'generally not be a concern to most users, but '
+                    'it can be tunned in case a runner generates very large '
+                    'status messages, which is common if a test generates a '
+                    'lot of output. Default is 33554432 (32MiB)')
+        settings.register_option(section=section,
+                                 key='status_server_buffer_size',
+                                 key_type=int,
+                                 default=2 ** 25,
+                                 help_msg=help_msg)
+
         help_msg = ('Number of maximum number tasks running in parallel. You '
                     'can disable parallel execution by setting this to 1. '
                     'Defaults to the amount of CPUs on this machine.')

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -264,7 +264,8 @@ class Runner(RunnerInterface):
         tsm = TaskStateMachine(self.tasks)
         spawner_name = test_suite.config.get('nrunner.spawner')
         spawner = SpawnerDispatcher(test_suite.config)[spawner_name].obj
-        max_running = test_suite.config.get('nrunner.max_parallel_tasks')
+        max_running = min(test_suite.config.get('nrunner.max_parallel_tasks'),
+                          len(self.tasks))
         workers = [Worker(tsm, spawner, max_running=max_running).run()
                    for _ in range(max_running)]
         asyncio.ensure_future(self._update_status(job))

--- a/avocado/plugins/spawners/process.py
+++ b/avocado/plugins/spawners/process.py
@@ -29,8 +29,8 @@ class ProcessSpawner(Spawner, SpawnerMixin):
             runtime_task.spawner_handle = await asyncio.create_subprocess_exec(
                 runner,
                 *args,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE)
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL)
         except (FileNotFoundError, PermissionError):
             return False
         asyncio.ensure_future(self._collect_task(runtime_task.spawner_handle))


### PR DESCRIPTION
This is a collection of fixes intended fix: https://github.com/avocado-framework/avocado/issues/4322