### PR TITLE
moving pre/post hooks to job module

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -549,6 +549,9 @@ class Job:
             self.time_start = time.time()
         try:
             self.result.tests_total = self.size
+            pre_post_dispatcher = dispatcher.JobPrePostDispatcher()
+            output.log_plugin_failures(pre_post_dispatcher.load_failures)
+            pre_post_dispatcher.map_method('pre', self)
             self.pre_tests()
             return self.run_tests()
         except exceptions.JobBaseException as details:
@@ -582,6 +585,7 @@ class Job:
                 self.time_end = time.time()
                 self.time_elapsed = self.time_end - self.time_start
             self.render_results()
+            pre_post_dispatcher.map_method('post', self)
 
     def run_tests(self):
         """

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -19,8 +19,7 @@ Base Test Runner Plugins.
 import argparse
 import sys
 
-from avocado.core import exit_codes, job, loader, output, parser_common_args
-from avocado.core.dispatcher import JobPrePostDispatcher
+from avocado.core import exit_codes, job, loader, parser_common_args
 from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLICmd, Init
 from avocado.core.settings import settings
@@ -302,15 +301,4 @@ class Run(CLICmd):
             LOG_UI.error(err)
             sys.exit(exit_codes.AVOCADO_JOB_FAIL)
         with job.Job(config, [suite]) as job_instance:
-            pre_post_dispatcher = JobPrePostDispatcher()
-            try:
-                # Run JobPre plugins
-                output.log_plugin_failures(pre_post_dispatcher.load_failures)
-                pre_post_dispatcher.map_method('pre', job_instance)
-
-                job_run = job_instance.run()
-            finally:
-                # Run JobPost plugins
-                pre_post_dispatcher.map_method('post', job_instance)
-
-        return job_run
+            return job_instance.run()


### PR DESCRIPTION
When running a job using the JobAPI(), pre/post hooks are not being
used.  IMO, users of JobAPI should not have to call this in they
scripts. This is moving the hooks from run command-line to the Job
itself.

Fixes #4339.

Signed-off-by: Beraldo Leal <bleal@redhat.com>