### PR TITLE
Fix orphan Job().result_proxy reference

### DIFF
--- a/avocado/core/runner.py
+++ b/avocado/core/runner.py
@@ -184,7 +184,6 @@ class TestStatus(object):
                 self.interrupt = True
             elif "paused" in msg:
                 self.status = msg
-                self.job.result_proxy.notify_progress(False)
                 self.job._result_events_dispatcher.map_method('test_progress',
                                                               False)
                 if msg['paused']:


### PR DESCRIPTION
Job().result_proxy was removed in ed4dcd1 however references to it
remained.

This removes one of the remaining references.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>