### PR TITLE
Restore loader's extra listing support

### DIFF
--- a/avocado/plugins/list.py
+++ b/avocado/plugins/list.py
@@ -207,11 +207,15 @@ class List(CLICmd):
         parser_common_args.add_tag_filter_args(parser)
 
     def run(self, config):
-        runner = 'nrunner' if config.get('list.resolver') else 'runner'
+        resolver = config.get('list.resolver')
+        runner = 'nrunner' if resolver else 'runner'
         config['run.references'] = config.get('list.references')
         config['run.ignore_missing_references'] = True
         config['run.test_runner'] = runner
         try:
+            if not resolver:
+                loader.loader.load_plugins(config)
+                loader.loader.get_extra_listing()
             suite = TestSuite.from_config(config)
             if runner == 'nrunner':
                 matrix = self._get_resolution_matrix(suite)


### PR DESCRIPTION
On 875cfed6, the support for calling a loader's "extra listing" was
removed.  This is not a pretty interface, but it's the only one
currently available that supports Avocado-VT `--vt-list-guests` or
`--vt-list-archs`.

Let's restore it, and call it only when the loader implementation is
used.

Signed-off-by: Cleber Rosa <crosa@redhat.com>