### PR TITLE
[nrunner]Multiple suites

### DIFF
--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -285,4 +285,5 @@ class Runner(RunnerInterface):
         loop.run_until_complete(asyncio.sleep(0.05))
 
         job.result.end_tests()
+        self.status_server.close()
         return self.summary


### PR DESCRIPTION
The status servers serve on specific uri even when his test suite finish.
Because of that it blocks other servers from different suites with the same
uri. And avocado doesn't get status from other suites.

Reference: #4346
Signed-off-by: Jan Richter <jarichte@redhat.com>