### PR TITLE
[nrunner]Multiple suites

### DIFF
--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -285,4 +285,5 @@ class Runner(RunnerInterface):
         loop.run_until_complete(asyncio.sleep(0.05))
 
         job.result.end_tests()
+        self.status_server.close()
         return self.summary

--- a/examples/jobs/nrunner.py
+++ b/examples/jobs/nrunner.py
@@ -4,10 +4,14 @@ import sys
 
 from avocado.core.job import Job
 from avocado.core.suite import TestSuite
+from avocado.utils.network.ports import find_free_port
+
+status_server = '127.0.0.1:%u' % find_free_port()
 
 config = {
     'run.test_runner': 'nrunner',
-    'nrunner.status_server_uri': '127.0.0.1:9999',
+    'nrunner.status_server_listen': status_server,
+    'nrunner.status_server_uri': status_server,
     'run.references': [
         'selftests/unit/test_resolver.py',
         'selftests/functional/test_argument_parsing.py',


### PR DESCRIPTION
The status servers serve on specific uri even when his test suite finish.
Because of that it blocks other servers from different suites with the same
uri. And avocado doesn't get status from other suites.

Reference: #4346
Signed-off-by: Jan Richter jarichte@redhat.com

---

This PR also includes a fix to the example job, hoping that it fixes the check error on #4351 