### PR TITLE
Status Server compatibility with python 3.6

### DIFF
--- a/avocado/core/status/server.py
+++ b/avocado/core/status/server.py
@@ -1,4 +1,5 @@
 import asyncio
+import sys
 
 from ..settings import settings
 
@@ -38,7 +39,10 @@ class StatusServer:
     async def serve_forever(self):
         if self._server_task is None:
             await self.create_server()
-        await self._server_task.serve_forever()
+
+        # TODO: Delete this after deprecation of python 3.6
+        if sys.version_info >= (3, 7):
+            await self._server_task.serve_forever()
 
     def close(self):
         self._server_task.close()


### PR DESCRIPTION
`asyncio` package is not compatible between python 3.6 and 3.7 this checks the
python version and solves problems with status server on python 3.6

Reference:#4359
Signed-off-by: Jan Richter <jarichte@redhat.com>