### PR TITLE
assets: introduce a way to register assets manually and small refactoring

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -1029,6 +1029,33 @@ class Test(unittest.TestCase, TestData):
             # otherwise re-throw OSError
             raise e
 
+    def get_asset_by_name(self, name, expire=None, asset_hash=None,
+                          cancel_on_missing=False):
+        """Same as fetch_asset, but by name. It will not download if not found.
+
+        This is used to query only on cache and with a single reference: a
+        asset name.
+
+        :param name: Name used during the registration process.
+        :param expire: Time for the asset to expire.
+        :param asset_hash: Asset hash.
+        :param cancel_on_missing: Whether the test should be canceled if the
+                                  asset was not found in the cache or if
+                                  `fetch` could not add the asset to the cache.
+                                  Defaults to `False`.
+        :raises OSError:  when it fails to fetch the asset from cache and
+                         `cancel_on_missing` is `False`.
+        """
+        try:
+            return asset.Asset.get_asset_by_name(name,
+                                                 self.cache_dirs,
+                                                 expire,
+                                                 asset_hash)
+        except OSError as e:
+            if cancel_on_missing:
+                self.cancel("Missing asset {}".format(name))
+            raise e
+
     def tearDown(self):
         if self.__base_logdir_tmp is not None:
             self.__base_logdir_tmp.cleanup()

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -1014,24 +1014,18 @@ class Test(unittest.TestCase, TestData):
         asset_obj = asset.Asset(name, asset_hash, algorithm, locations,
                                 self.cache_dirs, expire)
 
-        missing_asset_message = 'Missing asset %s' % name
-
-        # decide whether we need to find only or fetch
-        if find_only:
-            asset_func = asset_obj.find_asset_file
-        else:
-            asset_func = asset_obj.fetch
-
         try:
             # return the path to the asset when it was found or fetched
-            asset_path = asset_func()
-            return asset_path
+            if find_only:
+                return asset_obj.find_asset_file()
+            else:
+                return asset_obj.fetch()
         except OSError as e:
             # if asset is not in the cache or there was a problem fetching
             # the asset
             if cancel_on_missing:
                 # cancel when requested
-                self.cancel(missing_asset_message)
+                self.cancel("Missing asset {}".format(name))
             # otherwise re-throw OSError
             raise e
 

--- a/avocado/plugins/assets.py
+++ b/avocado/plugins/assets.py
@@ -18,6 +18,7 @@ Assets subcommand
 
 import ast
 import os
+import re
 
 from avocado.core import data_dir, exit_codes, safeloader
 from avocado.core.nrunner import Task
@@ -33,7 +34,7 @@ class FetchAssetHandler(ast.NodeVisitor):  # pylint: disable=R0902
     Handles the parsing of instrumented tests for `fetch_asset` statements.
     """
 
-    PATTERN = 'fetch_asset'
+    PATTERN = 'fetch_asset$'
 
     def __init__(self, file_name, klass=None, method=None):
         self.file_name = file_name
@@ -185,7 +186,7 @@ class FetchAssetHandler(ast.NodeVisitor):  # pylint: disable=R0902
         # make sure we are into a class method
         if self.current_klass and self.current_method:
             if isinstance(node.func, ast.Attribute):
-                if self.PATTERN in node.func.attr:
+                if re.match(self.PATTERN, node.func.attr):
                     call = self._parse_args(node)
                     if call:
                         self.calls.append(call)

--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -335,10 +335,16 @@ class Asset:
         cache_dir = self._get_writable_cache_dir()
         # Now we have a writable cache_dir. Let's get the asset.
         for url in self.urls:
+            if url is None:
+                continue
             urlobj = urlparse(url)
             if urlobj.scheme in ['http', 'https', 'ftp']:
                 fetch = self._download
             elif urlobj.scheme == 'file':
+                fetch = self._get_local_file
+            # We are assuming that everything starting with './' or '/' are a
+            # file too.
+            elif url.startswith(('/', './')):
                 fetch = self._get_local_file
             else:
                 raise UnsupportedProtocolError("Unsupported protocol"

--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -417,6 +417,47 @@ class Asset:
     def asset_name(self):
         return os.path.basename(self.parsed_name.path)
 
+    @classmethod
+    def get_asset_by_name(cls, name, cache_dirs, expire=None, asset_hash=None):
+        """This method will return a cached asset based on name if exists.
+
+        You don't have to instantiate an object of Asset class. Just use this
+        method.
+
+        To be improved soon: cache_dirs should be not necessary.
+
+        :param name: the asset filename used during registration.
+        :param cache_dirs: list of directories to use during the search.
+        :param expire: time in seconds for the asset to expire. Expired assets
+                       will not be returned.
+        :param asset_hash: asset hash.
+
+        :return: asset path, if it exists in the cache.
+        :rtype: str
+        :raises: OSError
+        """
+
+        for cache_dir in cache_dirs:
+            asset_file = os.path.join(os.path.expanduser(cache_dir),
+                                      'by_name',
+                                      name)
+
+            # Ignore non-files
+            if not os.path.isfile(asset_file):
+                continue
+
+            # Ignore expired asset files
+            if cls._is_expired(asset_file, expire):
+                continue
+
+            # Ignore mismatch hash
+            if not cls._has_valid_hash(asset_file, asset_hash):
+                continue
+
+            return asset_file
+
+        raise OSError("File %s not found in the cache." % name)
+
     @property
     def name_scheme(self):
         """This property will return the scheme part of the name if is an URL.

--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -50,10 +50,9 @@ class Asset:
     Try to fetch/verify an asset file from multiple locations.
     """
 
-    def __init__(self, name, asset_hash, algorithm, locations, cache_dirs,
-                 expire=None, metadata=None):
-        """
-        Initialize the Asset() class.
+    def __init__(self, name, asset_hash=None, algorithm=None, locations=None,
+                 cache_dirs=None, expire=None, metadata=None):
+        """Initialize the Asset() class.
 
         :param name: the asset filename. url is also supported
         :param asset_hash: asset hash
@@ -69,7 +68,7 @@ class Asset:
         if isinstance(locations, str):
             self.locations = [locations]
         else:
-            self.locations = locations
+            self.locations = locations or []
 
         if algorithm is None:
             self.algorithm = DEFAULT_HASH_ALGORITHM
@@ -229,7 +228,7 @@ class Asset:
             return 'by_name'
 
         # check if the URI is located on self.locations or self.parsed_name
-        if self.locations is not None:
+        if self.locations:
             # if it is on self.locations, we need to check if it has the
             # asset name on it or a trailing '/'
             if ((self.asset_name in self.locations[0]) or
@@ -447,7 +446,7 @@ class Asset:
         if self.name_scheme:
             urls.append(self.name_url)
 
-        if self.locations is not None:
+        if self.locations:
             urls.extend(self.locations)
 
         return urls

--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -88,8 +88,10 @@ class Asset:
         :param asset_path: full path of the asset file.
         """
         result = crypto.hash_file(asset_path, algorithm=self.algorithm)
-        with open(self._get_hash_file(asset_path), 'w') as hash_file:
-            hash_file.write('%s %s\n' % (self.algorithm, result))
+        hash_file = self._get_hash_file(asset_path)
+        with FileLock(hash_file, 30):
+            with open(hash_file, 'w') as fp:
+                fp.write('%s %s\n' % (self.algorithm, result))
 
     def _create_metadata_file(self, asset_file):
         """

--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -66,24 +66,16 @@ class Asset:
         self.name = name
         self.asset_hash = asset_hash
 
-        # we currently support the following options for name and locations:
-        # 1. name is a full URI and locations is empty;
-        # 2. name is a single file name and locations is one or more entries.
-        # raise an exception if we have an unsupported use of those arguments
-        if ((self.name_scheme and locations is not None) or
-                (not self.name_scheme and locations is None)):
-            raise ValueError("Incorrect use of parameter name with parameter"
-                             " locations.")
+        if isinstance(locations, str):
+            self.locations = [locations]
+        else:
+            self.locations = locations
 
         if algorithm is None:
             self.algorithm = DEFAULT_HASH_ALGORITHM
         else:
             self.algorithm = algorithm
 
-        if isinstance(locations, str):
-            self.locations = [locations]
-        else:
-            self.locations = locations
         self.cache_dirs = cache_dirs
         self.expire = expire
         self.metadata = metadata

--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -282,6 +282,21 @@ class Asset:
             return True
         return False
 
+    @classmethod
+    def _has_valid_hash(cls, asset_path, asset_hash=None):
+        """Checks if a file has a valid hash based on the hash parameter.
+
+        If asset_hash is None then will consider a valid asset.
+        """
+        if asset_hash is None:
+            return True
+
+        hash_path = cls._get_hash_file(asset_path)
+        _, hash_from_file = cls.read_hash_from_file(hash_path)
+        if hash_from_file == asset_hash:
+            return True
+        return False
+
     def _verify_hash(self, asset_path):
         """
         Verify if the `asset_path` hash matches the hash in the hash file.
@@ -291,10 +306,7 @@ class Asset:
         value as the hash of the asset_file, otherwise return False.
         :rtype: bool
         """
-        if self.asset_hash is None or (
-                self._get_hash_from_file(asset_path) == self.asset_hash):
-            return True
-        return False
+        return self._has_valid_hash(asset_path, self.asset_hash)
 
     def fetch(self):
         """

--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -372,19 +372,19 @@ class Asset:
             cache_dir = os.path.expanduser(cache_dir)
             asset_file = os.path.join(cache_dir, self.relative_dir)
 
-            # To use a cached file, it must:
-            # - Exists.
-            # - Be valid (not expired).
-            # - Be verified (hash check).
-            if (os.path.isfile(asset_file) and
-                    not self._is_expired(asset_file, self.expire)):
-                try:
-                    with FileLock(asset_file, 30):
-                        if self._verify_hash(asset_file):
-                            return asset_file
-                except Exception:  # pylint: disable=W0703
-                    exc_type, exc_value = sys.exc_info()[:2]
-                    LOG.error('%s: %s', exc_type.__name__, exc_value)
+            # Ignore non-files
+            if not os.path.isfile(asset_file):
+                continue
+
+            # Ignore expired asset files
+            if self._is_expired(asset_file, self.expire):
+                continue
+
+            # Ignore mismatch hash
+            if not self._has_valid_hash(asset_file, self.asset_hash):
+                continue
+
+            return asset_file
 
         raise OSError("File %s not found in the cache." % self.asset_name)
 

--- a/selftests/functional/test_plugin_assets.py
+++ b/selftests/functional/test_plugin_assets.py
@@ -215,7 +215,7 @@ class AssetsPlugin(unittest.TestCase):
         test_file.write(test_content.encode())
         test_file.close()
 
-        expected_stderr = "Failed to fetch hello-2.9.tar.gz.\n"
+        expected_stderr = "Failed to fetch hello-2.9.tar.gz"
         expected_rc = exit_codes.AVOCADO_FAIL
 
         cmd_line = "%s --config %s assets fetch %s " % (AVOCADO,
@@ -242,7 +242,7 @@ class AssetsPlugin(unittest.TestCase):
         test_file.write(test_content.encode())
         test_file.close()
 
-        expected_stderr = "Failed to fetch hello-2.9.tar.gz.\n"
+        expected_stderr = "Failed to fetch hello-2.9.tar.gz"
         expected_rc = exit_codes.AVOCADO_ALL_OK
 
         cmd_line = "%s --config %s assets fetch --ignore-errors %s " % (

--- a/selftests/functional/test_plugin_assets.py
+++ b/selftests/functional/test_plugin_assets.py
@@ -6,6 +6,7 @@ Assets plugin functional tests
 import os
 import tempfile
 import unittest
+import uuid
 import warnings
 
 from avocado.core import exit_codes
@@ -88,6 +89,28 @@ class AssetsFetchSuccess(unittest.TestCase):
 
         self.assertEqual(expected_rc, result.exit_status)
         self.assertIn(expected_output, result.stdout_text)
+
+    def test_asset_register_by_name_fail(self):
+        """Test register command failure."""
+        url = "https://urlnotfound"
+        random = str(uuid.uuid4())
+        cmd_line = "%s assets register %s %s" % (AVOCADO, random, url)
+        result = process.run(cmd_line)
+
+        self.assertIn("Failed to fetch",
+                      result.stderr_text)
+
+    @unittest.skipIf(not os.path.isfile('/etc/hosts'),
+                     " Missing /etc/hosts")
+    def test_asset_register_by_name_success(self):
+        """Test register command success."""
+        url = "/etc/hosts"
+        random = str(uuid.uuid4())
+        cmd_line = "%s assets register %s %s" % (AVOCADO, random, url)
+        result = process.run(cmd_line)
+
+        self.assertIn("Now you can reference it by name %s" % random,
+                      result.stdout_text)
 
     def tearDown(self):
         self.base_dir.cleanup()

--- a/selftests/functional/test_utils_asset.py
+++ b/selftests/functional/test_utils_asset.py
@@ -97,20 +97,6 @@ class TestAsset(TestCaseTmpDir):
             content2 = f.read()
         self.assertNotEqual(content1, content2)
 
-    def test_incorrect_name_locations_parameter_case1(self):
-        # 1. name is a full URI and locations is empty
-        with self.assertRaises(ValueError):
-            asset.Asset(name='file://bar.tgz', asset_hash=None, algorithm=None,
-                        locations='file://foo', cache_dirs=[self.cache_dir],
-                        expire=None)
-
-    def test_incorrect_name_locations_parameter_case2(self):
-        # 2. name is a single file name and locations is one or more entries.
-        with self.assertRaises(ValueError):
-            asset.Asset(name='bar.tgz', asset_hash=None, algorithm=None,
-                        locations=None, cache_dirs=[self.cache_dir],
-                        expire=None)
-
     def test_fetch_lockerror(self):
         dirname = os.path.join(self.cache_dir, 'by_name')
         os.makedirs(dirname)


### PR DESCRIPTION
This proposal is based on some of Avocado's user's needs. They are asking for ways to register assets manually and referencing them by name later, which is not possible in the current design.

This is a small hack to avoid a bigger change. But in general, this proposed approach will change three things: 1) we don't have to initialize objects to do basic operations, since there is a lot of unnecessary arguments when initializing that could be avoided. (vide class methods); 2) Lazy evaluation/validation of objects is being used, for better reuse of objects; 3) a new test method is available: `self.fetch_asset_by_name()`, I tried to explain the reason for that in the commit message; 

Also, I'm doing small refactoring to improve code readability and maintainability.

IMO, this needs a much deeper cleanup to do soon. But that is it.

This fixes #4342 and #4313.

Signed-off-by: Beraldo Leal <bleal@redhat.com>