### PR TITLE
Pre-release tests: update tested versions of Debian and Fedora 

### DIFF
--- a/selftests/pre_release/tests/vmimage.py.data/variants.yml
+++ b/selftests/pre_release/tests/vmimage.py.data/variants.yml
@@ -39,10 +39,10 @@ distro: !mux
     x86_64:
       arch: amd64
     version: !mux
-      9.13.7:
-        version: 9.13.7-20201108
-      10.6.1:
-        version: 10.6.1-20201023
+      9.13.9:
+        version: 9.13.9-20201210
+      10.7.2:
+        version: 10.7.2-20201210
   fedora:
     name: fedora
     !filter-out : /run/architectures/arm

--- a/selftests/pre_release/tests/vmimage.py.data/variants.yml
+++ b/selftests/pre_release/tests/vmimage.py.data/variants.yml
@@ -50,8 +50,6 @@ distro: !mux
     !filter-out : /run/architectures/ppc
     !filter-out : /run/architectures/ppc64
     version: !mux
-      31:
-        version: 31
       32:
         version: 32
       33:


### PR DESCRIPTION
Debian often updates their versions, and Fedora has recently retired version 31.