### PR TITLE
run-kvm-unit-test.sh: Re-support for adding avocado arguments

### DIFF
--- a/contrib/testsuites/run-kvm-unit-test.sh
+++ b/contrib/testsuites/run-kvm-unit-test.sh
@@ -85,7 +85,7 @@ make standalone >/dev/null || { echo Fail to "make standalone" kvm-unit-test; ex
 setup_skip_exitcode
 
 cd tests
-eval "avocado run --test-runner='nrunner' ./$WILDCARD"
+eval "avocado run --test-runner='nrunner' ./$WILDCARD $*"
 RET=$?
 
 # Cleanup and exit


### PR DESCRIPTION
The problem comes from #4358, it lacks the symbol "$*", so the script
cannot accept extra avocado arguments.

Signed-off-by: Yihuang Yu <yihyu@redhat.com>