### PR TITLE
[Requirements resolver] Initial integration with the state machine and suite

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -15,6 +15,7 @@ import sys
 import tempfile
 import time
 import unittest
+from uuid import uuid4
 
 try:
     import pkg_resources
@@ -664,6 +665,7 @@ class Task:
     def __init__(self, identifier, runnable, status_uris=None,
                  known_runners=None):
         self.identifier = identifier
+        self.uid = str(uuid4())
         self.runnable = runnable
         self.status_services = []
         if status_uris is not None:
@@ -672,12 +674,15 @@ class Task:
         if known_runners is None:
             known_runners = {}
         self.known_runners = known_runners
+        self.prereqs = []
         self.spawn_handle = None
         self.output_dir = None
 
     def __repr__(self):
-        fmt = '<Task identifier="{}" runnable="{}" status_services="{}"'
-        return fmt.format(self.identifier, self.runnable, self.status_services)
+        fmt = ('<Task identifier="{}" runnable="{}" prereqs="{}"'
+               ' status_services="{}"')
+        return fmt.format(self.identifier, self.runnable, self.prereqs,
+                          self.status_services)
 
     def are_requirements_available(self, runners_registry=None):
         """Verifies if requirements needed to run this task are available.

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -448,6 +448,25 @@ class ExecTestRunner(ExecRunner):
 RUNNERS_REGISTRY_PYTHON_CLASS['exec-test'] = ExecTestRunner
 
 
+class RequirementRunner(ExecRunner):
+    """
+    Runner for standalone executables treated as requirements
+
+    Runnable attributes usage is identical to :class:`ExecRunner`
+    """
+    def run(self):
+        for most_current_execution_state in super().run():
+            returncode = most_current_execution_state.get('returncode')
+            if returncode == 0:
+                most_current_execution_state['result'] = 'pass'
+            else:
+                most_current_execution_state['result'] = 'fail'
+            yield most_current_execution_state
+
+
+RUNNERS_REGISTRY_PYTHON_CLASS['requirement'] = RequirementRunner
+
+
 class PythonUnittestRunner(BaseRunner):
     """
     Runner for Python unittests

--- a/avocado/core/requirements/resolver.py
+++ b/avocado/core/requirements/resolver.py
@@ -1,0 +1,106 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2020
+# Authors: Willian Rampazzo <willianr@redhat.com>
+
+"""
+Requirements Resolver module.
+"""
+
+from ..nrunner import RUNNERS_REGISTRY_PYTHON_CLASS, Runnable, Task
+
+SUPPORTED_REQUIREMENTS = {}
+
+
+def create_requirements_tasks(tasks):
+    """Entry point for the Requirements Resolver.
+
+    This function isolates the Requirements Resolver object into this module.
+
+    :param tasks: List of tasks
+    :type tasks: list
+    """
+    resolver = RequirementsResolver(tasks)
+    return resolver.create_requirements_tasks()
+
+
+class UnsupportedRequirementType(Exception):
+    pass
+
+
+class RequirementsResolver:
+    """Requirements Resolver class."""
+
+    def __init__(self, tasks):
+        """
+        :param tasks: List of tasks to be resolved
+        :type tasks: list
+        """
+        self._tasks = tasks
+
+    def create_requirements_tasks(self):
+        """Create the list of tasks based on the test requirements."""
+        requirements_tasks = []
+        for task in self._tasks:
+            if not task.runnable.requirements:
+                continue
+
+            uris = [status_service.uri
+                    for status_service in task.status_services]
+
+            for requirement in task.runnable.requirements:
+                try:
+                    type_klass = SUPPORTED_REQUIREMENTS[requirement['type']]
+                except KeyError:
+                    raise UnsupportedRequirementType
+
+                type_resolver = type_klass(requirement, uris)
+                # create the new task based on requirement information
+                requirement_task = type_resolver.task_from_requirement()
+                # add the new task to the requirements tasks list
+                requirements_tasks.append(requirement_task)
+                # update the dependency list of the father task
+                task.prereqs.append(requirement_task.uid)
+        # update the tasks list with the new requirements tasks
+        self._tasks.extend(requirements_tasks)
+        return self._tasks
+
+
+class BaseRequirement:
+    """Base interface for a requirement type."""
+
+    def __init__(self, requirement, uris):
+        self._requirement = requirement
+        self._uris = uris
+
+    def task_from_requirement(self):
+        raise NotImplementedError
+
+
+class PackageRequirement(BaseRequirement):
+    """Handle requirements of type `package`."""
+
+    def task_from_requirement(self):
+        """Create a new software-manager task from the requirement info."""
+        # create a software-manager runnable
+        runnable = Runnable('requirement', 'avocado-software-manager',
+                            'install',
+                            self._requirement['name'])
+        task_id = 'requirement-%s-%s' % (self._requirement['type'],
+                                         self._requirement['name'])
+        # create the new software-manager task for the requirement
+        task = Task(task_id, runnable,
+                    status_uris=self._uris,
+                    known_runners=RUNNERS_REGISTRY_PYTHON_CLASS)
+        return task
+
+SUPPORTED_REQUIREMENTS['package'] = PackageRequirement

--- a/avocado/core/suite.py
+++ b/avocado/core/suite.py
@@ -22,6 +22,7 @@ from .exceptions import (JobTestSuiteReferenceResolutionError,
 from .loader import (DiscoverMode, LoaderError, LoaderUnhandledReferenceError,
                      loader)
 from .parser import HintParser
+from .requirements.resolver import create_requirements_tasks
 from .resolver import resolve
 from .settings import settings
 from .tags import filter_test_tags
@@ -141,6 +142,7 @@ class TestSuite:
             raise TestSuiteError(details)
 
         tasks = resolutions_to_tasks(resolutions, config)
+        tasks = create_requirements_tasks(tasks)
 
         if name is None:
             name = str(uuid4())

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -214,6 +214,7 @@ PATH=$HOME/.local/bin:$PATH LANG=en_US.UTF-8 AVOCADO_CHECK_LEVEL=0 %{__python3} 
 %{_bindir}/avocado-runner-noop
 %{_bindir}/avocado-runner-exec
 %{_bindir}/avocado-runner-exec-test
+%{_bindir}/avocado-runner-requirement
 %{_bindir}/avocado-runner-python-unittest
 %{_bindir}/avocado-runner-avocado-instrumented
 %{_bindir}/avocado-runner-tap

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ if __name__ == '__main__':
                   'avocado-runner-noop = avocado.core.nrunner:main',
                   'avocado-runner-exec = avocado.core.nrunner:main',
                   'avocado-runner-exec-test = avocado.core.nrunner:main',
+                  'avocado-runner-requirement = avocado.core.nrunner:main',
                   'avocado-runner-python-unittest = avocado.core.nrunner:main',
                   'avocado-runner-avocado-instrumented = avocado.core.nrunner_avocado_instrumented:main',
                   'avocado-runner-tap = avocado.core.nrunner_tap:main',


### PR DESCRIPTION
This is a minimum set of changes to introduce and integrate the Requirements Resolver with the state machine and the test suite. Although there are some caveats, the changes do not impact the current behavior if the requirements docstrings are not used.

The following test enables the code of this PR:

```python
from avocado import Test


class PassTest(Test):

    """
    Example test that passes.

    :avocado: tags=fast
    :avocado: requirement={"type": "package", "name": "vim-common"}
    :avocado: requirement={"type": "package", "name": "bla"}
    """

    def test(self):
        """
        A test doesn't have to fail to pass
        """
```

Caveats:
- Although tasks with dependencies wait for them to finish, if some dependency fails, the test will still run due to lack of status after a task finishes. To solve this problem, after a task finishes, it needs to have the real finish state (success, fail), and the state machine needs to have access to it.
- Unsupported `type` will crash Avocado due to lack of exception handling on the state machine.