### PR TITLE
Makefile: migrate clean target to setup.py and cleanups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,10 @@ RPM_BASE_NAME=python-avocado
 all:
 	@echo
 	@echo "Development related targets:"
-	@echo "check:       Runs tree static check, unittests and fast functional tests"
-	@echo "develop:     Runs 'python setup.py --develop' on this tree alone"
-	@echo "link:        Runs 'python setup.py --develop' in all subprojects and links the needed resources"
-	@echo "clean:       Get rid of build scratch from this project and subprojects"
+	@echo "check:             Runs tree static check, unittests and fast functional tests"
+	@echo "develop:           Runs 'python setup.py --develop' on this tree alone"
+	@echo "develop-external:  Install Avocado's external plugins in develop mode. You need to set AVOCADO_EXTERNAL_PLUGINS_PATH"
+	@echo "clean:             Get rid of build scratch from this project and subprojects"
 	@echo
 	@echo "Package requirements related targets"
 	@echo "requirements-selftests:  Install runtime and selftests requirements"
@@ -128,8 +128,11 @@ develop:
 		else echo ">> SKIP $$PLUGIN"; fi;\
 	done
 
-link: develop
-	for PLUGIN in $(AVOCADO_OPTIONAL_PLUGINS); do\
+develop-external:
+ifndef AVOCADO_EXTERNAL_PLUGINS_PATH
+	$(error AVOCADO_EXTERNAL_PLUGINS_PATH is not defined)
+endif
+	for PLUGIN in $(shell find $(AVOCADO_EXTERNAL_PLUGINS_PATH) -maxdepth 1 -mindepth 1 -type d); do\
 		if test -f $$PLUGIN/Makefile -o -f $$PLUGIN/setup.py; then echo ">> LINK $$PLUGIN";\
 			if test -f $$PLUGIN/Makefile; then AVOCADO_DIRNAME=$(AVOCADO_DIRNAME) make -C $$PLUGIN PYTHON="$(PYTHON)" link &>/dev/null || echo ">> FAIL $$PLUGIN";\
 			elif test -f $$PLUGIN/setup.py; then cd $$PLUGIN; $(PYTHON) setup.py develop $(PYTHON_DEVELOP_ARGS); cd -; fi;\
@@ -162,7 +165,7 @@ propagate-version:
 		else echo ">> Skipping $$DIR"; fi;\
 	done
 
-.PHONY: source install clean check link variables
+.PHONY: source install clean check variables
 
 # implicit rule/recipe for man page creation
 %.1: %.rst

--- a/Makefile
+++ b/Makefile
@@ -89,15 +89,6 @@ pypi: wheel source-pypi develop
 	@echo
 
 clean:
-	for PLUGIN in $(AVOCADO_OPTIONAL_PLUGINS); do\
-		if test -f $$PLUGIN/setup.py; then cd $$PLUGIN; $(PYTHON) setup.py clean --all; cd -; echo ">> UNLINK $$PLUGIN";\
-		else echo ">> SKIP $$PLUGIN"; fi;\
-	done
-	$(PYTHON) setup.py clean
-	rm -rf build/ MANIFEST BUILD BUILDROOT SPECS RPMS SRPMS SOURCES PYPI_UPLOAD
-	rm -f man/avocado.1
-	rm -rf docs/build
-	find docs/source/api/ -name '*.rst' -delete
 	$(PYTHON) setup.py clean --all
 
 uninstall:
@@ -108,11 +99,6 @@ uninstall:
 		else echo ">> SKIP $$PLUGIN"; fi;\
 	done
 	$(PYTHON) setup.py develop --uninstall $(PYTHON_DEVELOP_ARGS)
-	rm -rf avocado_framework.egg-info
-	rm -rf /var/tmp/avocado*
-	rm -rf /tmp/avocado*
-	find . -name '*.pyc' -delete
-	find $(AVOCADO_OPTIONAL_PLUGINS) -name '*.egg-info' -exec rm -r {} +
 
 requirements-plugins:
 	for PLUGIN in $(AVOCADO_OPTIONAL_PLUGINS);do\

--- a/docs/source/guides/contributor/chapters/environment.rst
+++ b/docs/source/guides/contributor/chapters/environment.rst
@@ -32,11 +32,19 @@ available).
 
 Avocado supports various plugins, which are distributed as separate projects,
 for example "avocado-vt" and "avocado-virt". These also need to be
-deployed and linked in order to work properly with the Avocado from
-sources (installed version works out of the box). To simplify this you can
-use `make requirements-plugins` from the main Avocado project to install
-requirements of the plugins and `make link` to link and develop the
-plugins. The workflow could be::
+deployed and "linked" in order to work properly with the Avocado from
+sources (installed version works out of the box).
+
+You can install external plugins as you wish, and/or according to the
+specific plugin's maintainer recommendations.
+
+Plugins that are developed by the Avocado team, will try to follow the
+same Setuptools standard for distributing the packages. Because of that,
+as a facility, you can use `make requirements-plugins` from the main
+Avocado project to install requirements of the plugins and `make
+develop-external` to install plugins in develop mode to. You just need
+to set where your plugins are installed, by using the environment
+variable `$AVOCADO_EXTERNAL_PLUGINS_PATH`. The workflow could be::
 
     $ cd $AVOCADO_PROJECTS_DIR
     $ git clone $AVOCADO_GIT
@@ -44,6 +52,7 @@ plugins. The workflow could be::
     $ # Add more projects
     $ cd avocado    # go into the main Avocado project dir
     $ make requirements-plugins
-    $ make link
+    $ export AVOCADO_EXTERNAL_PLUGINS_PATH=$AVOCADO_PROJECTS_DIR
+    $ make develop-external
 
 You should see the process and status of each directory.


### PR DESCRIPTION
This is the first step/experiment for moving Makefile targets to setup.py. Although setuptools is the choice in the Python community to distribute/compile packages, its documentation is not yet complete and even official Python documentation still maintains the distutils documentation as a reference for items not covered by setuptools. This is the case with clean command. This is part of a bigger effort to make our build environments and CI consistent regardless of where we are running the target commands. For sure that we have room for improvements here but in this PR, I would like to focus on the migration only.

Signed-off-by: Beraldo Leal <bleal@redhat.com>