### PR TITLE
signedoff-checks.sh: don't take letter case in account

### DIFF
--- a/selftests/signedoff-check.sh
+++ b/selftests/signedoff-check.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
 AUTHOR="$(git log --no-merges -1 --pretty='format:%aN <%aE>')"
-git log --no-merges -1 --pretty=format:%B | grep "Signed-off-by: $AUTHOR"
+git log --no-merges -1 --pretty=format:%B | grep -i "Signed-off-by: $AUTHOR"
 if [ $? != 0 ]; then
     echo "The commit message does not contain author's signature (Signed-off-by: $AUTHOR)"
     exit 1


### PR DESCRIPTION
Added -i option to grep to allow matching names and emails
when letter cases in them are different.

Signed-off-by: Pavel Dovgalyuk <Pavel.Dovgalyuk@ispras.ru>