### PR TITLE
Style check: enable autopep8 functionality

### DIFF
--- a/avocado/core/extension_manager.py
+++ b/avocado/core/extension_manager.py
@@ -37,6 +37,7 @@ class Extension:
     This is a verbatim copy from the stevedore.extension class with the
     same name
     """
+
     def __init__(self, name, entry_point, plugin, obj):
         self.name = name
         self.entry_point = entry_point

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -76,6 +76,7 @@ class Runnable:
     A instance of :class:`BaseRunner` is the entity that will actually
     execute a runnable.
     """
+
     def __init__(self, kind, uri, *args, config=None, **kwargs):
         self.kind = kind
         self.uri = uri
@@ -351,6 +352,7 @@ class NoOpRunner(BaseRunner):
 
      * args: not used
     """
+
     def run(self):
         yield self.prepare_status('started')
         yield self.prepare_status('finished', {'result': 'pass'})
@@ -373,6 +375,7 @@ class ExecRunner(BaseRunner):
      * kwargs: key=val to be set as environment variables to the
        process
     """
+
     def run(self):
         env = None
         if self.runnable.kwargs:
@@ -427,6 +430,7 @@ class ExecTestRunner(ExecRunner):
 
     Runnable attributes usage is identical to :class:`ExecRunner`
     """
+
     def run(self):
         # Since Runners are standalone, and could be executed on a remote
         # machine in an "isolated" way, there is no way to assume a default
@@ -610,6 +614,7 @@ class TaskStatusService:
 
     TODO: make the interface generic and this just one of the implementations
     """
+
     def __init__(self, uri):
         self.uri = uri
         self.connection = None
@@ -642,6 +647,7 @@ class Task:
     :param identifier:
     :param runnable:
     """
+
     def __init__(self, identifier, runnable, status_uris=None,
                  known_runners=None):
         self.identifier = identifier

--- a/avocado/core/nrunner_tap.py
+++ b/avocado/core/nrunner_tap.py
@@ -30,6 +30,7 @@ class TAPRunner(nrunner.BaseRunner):
                            'bar', # arg 1
                            DEBUG='false') # kwargs 1 (environment)
     """
+
     def run(self):
         env = self.runnable.kwargs or None
         if env and 'PATH' not in env:

--- a/avocado/core/task/runtime.py
+++ b/avocado/core/task/runtime.py
@@ -7,6 +7,7 @@ class RuntimeTask:
     This class wraps a :class:`avocado.core.nrunner.Task`, with extra
     information about its execution by a spawner within a state machine.
     """
+
     def __init__(self, task):
         """Instantiates a new RuntimeTask.
 

--- a/avocado/core/task/statemachine.py
+++ b/avocado/core/task/statemachine.py
@@ -5,6 +5,7 @@ import time
 
 class TaskStateMachine:
     """Represents all phases that a task can go through its life."""
+
     def __init__(self, tasks):
         self._requested = tasks
         self._triaging = []

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -1159,6 +1159,7 @@ class ExternalRunnerSpec:
     """
     Defines the basic options used by ExternalRunner
     """
+
     def __init__(self, runner, chdir=None, test_dir=None):
         self.runner = runner
         self.chdir = chdir
@@ -1215,6 +1216,7 @@ class PythonUnittest(ExternalRunnerTest):
     """
     Python unittest test
     """
+
     def __init__(self, name, params=None, base_logdir=None, job=None,
                  test_dir=None, python_unittest_module=None,
                  tags=None):    # pylint: disable=W0613

--- a/avocado/utils/memory.py
+++ b/avocado/utils/memory.py
@@ -154,7 +154,7 @@ def memtotal_sys():
                 no_memblocks += 1
     path = os.path.join(sys_mempath, 'block_size_bytes')
     block_size = int(genio.read_file(path).strip(), 16)
-    return (no_memblocks * block_size)/1024.0
+    return (no_memblocks * block_size) / 1024.0
 
 
 def freememtotal():
@@ -470,6 +470,7 @@ class _MemInfoItem:
     """
     Representation of one item from /proc/meminfo
     """
+
     def __init__(self, name):
         self.name = name
 

--- a/avocado/utils/network/hosts.py
+++ b/avocado/utils/network/hosts.py
@@ -45,6 +45,7 @@ class Host:
         for i in remote.interfaces:
             print(i.name, i.is_link_up())
     """
+
     def __init__(self, host):
         if type(self) == Host:
             raise TypeError("Host class should not be instantiated")
@@ -91,6 +92,7 @@ class LocalHost(Host):
 
         local = LocalHost()
     """
+
     def __init__(self, host='localhost'):
         super().__init__(host)
 
@@ -110,6 +112,7 @@ class RemoteHost(Host):
 
     You can also provide a key instead of a password.
     """
+
     def __init__(self, host, username, port=22, key=None, password=None):
         super().__init__(host)
         self.port = port

--- a/avocado/utils/pmem.py
+++ b/avocado/utils/pmem.py
@@ -29,6 +29,7 @@ class PMemException(Exception):
     """
     Error raised for all PMem failures
     """
+
     def __init__(self, additional_text=None):  # pylint: disable=W0231
         self.additional_text = additional_text
 

--- a/avocado/utils/softwareraid.py
+++ b/avocado/utils/softwareraid.py
@@ -41,6 +41,7 @@ class SoftwareRaid:
     :param spare_disks: List of spare disks for software raid
     :type spare_disks: list
     """
+
     def __init__(self, name, level, disks, metadata, spare_disks=None):
         self.name = name
         self.level = level

--- a/examples/nrunner/task-state-machine.py
+++ b/examples/nrunner/task-state-machine.py
@@ -43,6 +43,7 @@ def mock_monitor_task_finished():
 
 class Task:
     """Used here as a placeholder for an avocado.core.nrunner.Task."""
+
     def __init__(self, identification):
         self._identification = identification
 
@@ -52,6 +53,7 @@ class TaskInfo(Task):
 
     The equivalent of a StatusServer will contain this information
     in the real implementation."""
+
     def __init__(self, identification):
         super(TaskInfo, self).__init__(identification)
         self._status = None
@@ -83,6 +85,7 @@ class TaskInfo(Task):
 
 class TaskStateMachine:
     """Represents all phases that a task can go through its life."""
+
     def __init__(self, tasks):
         self._requested = tasks
         self._triaging = []

--- a/optional_plugins/golang/avocado_golang/runner.py
+++ b/optional_plugins/golang/avocado_golang/runner.py
@@ -23,6 +23,7 @@ class GolangRunner(nrunner.BaseRunner):
        runnable = Runnable(kind='golang',
                            uri='countavocados:ExampleContainers')
     """
+
     def run(self):
         module, test = self.runnable.uri.split(':', 1)
 

--- a/optional_plugins/varianter_cit/avocado_varianter_cit/CombinationRow.py
+++ b/optional_plugins/varianter_cit/avocado_varianter_cit/CombinationRow.py
@@ -11,7 +11,6 @@ class CombinationRow:
     """
 
     def __init__(self, input_data, t_value, parameters):
-
         """
         :param input_data: list of data from user
         :param t_value: t number from user
@@ -30,7 +29,6 @@ class CombinationRow:
             self.hash_table[i] = 0
 
     def cover_cell(self, key):
-
         """
         Cover one combination inside Row
 
@@ -51,7 +49,6 @@ class CombinationRow:
         return self.uncovered - old_uncovered, self.covered_more_than_ones - old_covered_more_than_ones
 
     def uncover_cell(self, key):
-
         """
         Uncover one combination inside Row
 
@@ -72,7 +69,6 @@ class CombinationRow:
         return self.uncovered - old_uncovered, self.covered_more_than_ones - old_covered_more_than_ones
 
     def completely_uncover(self):
-
         """
         Uncover all combinations inside Row
         """
@@ -85,7 +81,6 @@ class CombinationRow:
                 self.uncovered += 1
 
     def del_cell(self, key):
-
         """
         Disable one combination. If combination is disabled it means that
         the combination does not match the constraints
@@ -103,7 +98,6 @@ class CombinationRow:
             return 0
 
     def is_valid(self, key):
-
         """
         Is the combination match the constraints.
 
@@ -117,7 +111,6 @@ class CombinationRow:
             return True
 
     def get_all_uncovered_combinations(self):
-
         """
         :return: list of all uncovered combination
         """

--- a/optional_plugins/varianter_yaml_to_mux/tests/test_functional.py
+++ b/optional_plugins/varianter_yaml_to_mux/tests/test_functional.py
@@ -63,7 +63,7 @@ class MultiplexTests(unittest.TestCase):
         self.run_and_check(cmd_line, expected_rc, (4, 0))
         # Also check whether jobdata contains correct parameter paths
         with open(os.path.join(self.tmpdir.name, "latest", "jobdata",
-                  "variants.json")) as variants_file:
+                               "variants.json")) as variants_file:
             variants = variants_file.read()
         self.assertIn('["/run/*"]', variants, "parameter paths stored in "
                       "jobdata does not contains [\"/run/*\"]\n%s" % variants)
@@ -77,7 +77,7 @@ class MultiplexTests(unittest.TestCase):
         self.run_and_check(cmd_line, exit_codes.AVOCADO_ALL_OK, (8, 0))
         # Also check whether jobdata contains correct parameter paths
         with open(os.path.join(self.tmpdir.name, "latest", "jobdata",
-                  "variants.json")) as variants_file:
+                               "variants.json")) as variants_file:
             variants = variants_file.read()
         exp = '["/foo/*", "/bar/*", "/baz/*"]'
         self.assertIn(exp, variants, "parameter paths stored in jobdata "

--- a/requirements-selftests.txt
+++ b/requirements-selftests.txt
@@ -6,6 +6,7 @@ pyenchant==2.0.0
 pylint==2.5.0
 astroid==2.4.0
 inspektor==0.5.2
+autopep8==1.5.4
 
 coverage==5.1
 

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -196,7 +196,7 @@ class RunnerOperationTest(TestCaseTmpDir):
         process.run(cmd_line)
         # Also check whether jobdata contains correct parameter paths
         variants = open(os.path.join(self.tmpdir.name, "latest", "jobdata",
-                        "variants.json")).read()
+                                     "variants.json")).read()
         self.assertIn('["/run/*"]', variants, "paths stored in jobdata "
                       "does not contains [\"/run/*\"]\n%s" % variants)
 

--- a/selftests/functional/test_interrupt.py
+++ b/selftests/functional/test_interrupt.py
@@ -136,7 +136,7 @@ class InterruptTest(TestCaseTmpDir):
                       'twice.')
 
         self.assertTrue(wait.wait_for(self._no_test_in_process_table,
-                        timeout=10), 'Avocado left processes behind.')
+                                      timeout=10), 'Avocado left processes behind.')
 
         output = proc.stdout.read()
         # Make sure the Interrupted requested sentence is there
@@ -180,7 +180,7 @@ class InterruptTest(TestCaseTmpDir):
                       'twice.')
 
         self.assertTrue(wait.wait_for(self._no_test_in_process_table,
-                        timeout=10), 'Avocado left processes behind.')
+                                      timeout=10), 'Avocado left processes behind.')
 
         # Make sure the Interrupted test sentence is there
         self.assertIn(b'Terminated\n', proc.stdout.read())
@@ -220,7 +220,7 @@ class InterruptTest(TestCaseTmpDir):
                       'twice.')
 
         self.assertTrue(wait.wait_for(self._no_test_in_process_table,
-                        timeout=10), 'Avocado left processes behind.')
+                                      timeout=10), 'Avocado left processes behind.')
 
         output = proc.stdout.read()
         # Make sure the Interrupted requested sentence is there
@@ -264,7 +264,7 @@ class InterruptTest(TestCaseTmpDir):
                       'twice.')
 
         self.assertTrue(wait.wait_for(self._no_test_in_process_table,
-                        timeout=10), 'Avocado left processes behind.')
+                                      timeout=10), 'Avocado left processes behind.')
 
         # Make sure the Interrupted test sentence is there
         self.assertIn(b'Terminated\n', proc.stdout.read())

--- a/selftests/unit/test_archive.py
+++ b/selftests/unit/test_archive.py
@@ -147,7 +147,7 @@ class ArchiveTest(unittest.TestCase):
 
     def test_empty_tbz2(self):
         ret = archive.uncompress(os.path.join(BASEDIR, 'selftests', '.data',
-                                 'empty.tar.bz2'), self.decompressdir)
+                                              'empty.tar.bz2'), self.decompressdir)
         self.assertEqual(ret, None, "Empty archive should return None (%s)"
                          % ret)
 

--- a/selftests/unit/test_tags.py
+++ b/selftests/unit/test_tags.py
@@ -302,7 +302,7 @@ class ParseFilterByTags(unittest.TestCase):
 
     def test_musts_must_nots(self):
         self.assertEqual(tags._parse_filter_by_tags(['foo,bar,baz',
-                                                    '-FOO,-BAR,-BAZ']),
+                                                     '-FOO,-BAR,-BAZ']),
                          [(set(['foo', 'bar', 'baz']), set([])),
                           (set([]), set(['FOO', 'BAR', 'BAZ']))])
 

--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -574,6 +574,7 @@ class FDDrainerTests(unittest.TestCase):
             """
             Handler used just to confirm that a logging event happened
             """
+
             def __init__(self, *args, **kwargs):
                 super(CatchHandler, self).__init__(*args, **kwargs)
                 self.caught_record = False


### PR DESCRIPTION
Inspektor has the ability to use autopep8 transparently (if installed)
which catches a number of different style issues.

Signed-off-by: Cleber Rosa <crosa@redhat.com>