### PR TITLE
Vmimage pre_release tests clean up

### DIFF
--- a/selftests/pre_release/tests/vmimage.py
+++ b/selftests/pre_release/tests/vmimage.py
@@ -1,3 +1,5 @@
+import os
+import shutil
 from urllib.error import HTTPError
 from urllib.request import urlopen
 
@@ -69,4 +71,6 @@ class ImageFunctional(Base):
     def test_get(self):
         cmd = 'avocado vmimage get --distro=%s --distro-version=%s --arch=%s'
         cmd %= (self.vmimage_name, self.vmimage_version, self.vmimage_arch)
-        process.run(cmd)
+        out = process.run(cmd)
+        image_path = out.stdout_text.split()[-1]
+        shutil.rmtree(os.path.dirname(image_path))


### PR DESCRIPTION
In the vmimage pre_release testing we are downloading all avocado supported
images, but after testing the we leave them inside avocado cache. The images
can consume dozens gigabytes of data which can cause a memory issues. Because
of this problem we have to remove downloaded images from cache after the
testing.

Signed-off-by: Jan Richter <jarichte@redhat.com>