### PR TITLE
Introduce example for "magic words" test type [v2]

### DIFF
--- a/examples/plugins/tests/README.rst
+++ b/examples/plugins/tests/README.rst
@@ -1,0 +1,23 @@
+================================
+ New Test Types Plugin Examples
+================================
+
+Subdirectories of this folder contains "plugins" of at least two
+different types:
+
+ * resolvers: they resolve references into proper test descriptions
+   that Avocado can run
+
+ * runners: these make use of the resolutions made by resolvers and
+   actually execute the tests, reporting the results back to Avocado
+
+These are all based on the "nrunner" architecture.  To see them in
+effect, after enabling them with ``python setup.py develop --user``-like
+commands (see parent directory ``README.rst``), you will want to
+list tests with::
+
+  avocado list --resolver $REFERENCE
+
+And run tests with::
+
+  avocado run --test-runner=nrunner $REFERENCE

--- a/examples/plugins/tests/magic/avocado_magic/resolver.py
+++ b/examples/plugins/tests/magic/avocado_magic/resolver.py
@@ -1,0 +1,42 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2020
+# Authors: Cleber Rosa <crosa@redhat.com>
+
+"""
+Test resolver for magic test words
+"""
+
+from avocado.core.nrunner import Runnable
+from avocado.core.plugin_interfaces import Resolver
+from avocado.core.resolver import (ReferenceResolution,
+                                   ReferenceResolutionResult)
+
+VALID_MAGIC_WORDS = ['pass', 'fail']
+
+
+class MagicResolver(Resolver):
+
+    name = 'magic'
+    description = 'Test resolver for magic words'
+
+    @staticmethod
+    def resolve(reference):
+        if reference not in VALID_MAGIC_WORDS:
+            return ReferenceResolution(
+                reference,
+                ReferenceResolutionResult.NOTFOUND,
+                info='Word "%s" is not a valid magic word' % (reference))
+
+        return ReferenceResolution(reference,
+                                   ReferenceResolutionResult.SUCCESS,
+                                   [Runnable('magic', reference)])

--- a/examples/plugins/tests/magic/avocado_magic/runner.py
+++ b/examples/plugins/tests/magic/avocado_magic/runner.py
@@ -1,0 +1,43 @@
+from avocado.core import nrunner
+
+
+class MagicRunner(nrunner.BaseRunner):
+    """Runner for magic words
+
+    When creating the Runnable, use the following attributes:
+
+     * kind: should be 'magic';
+
+     * uri: the magic word, either "pass" or "fail";
+
+     * args: not used;
+
+     * kwargs: not used;
+
+    Example:
+
+       runnable = Runnable(kind='magic',
+                           uri='pass')
+    """
+
+    def run(self):
+        yield self.prepare_status('started')
+        if self.runnable.uri in ['pass', 'fail']:
+            result = self.runnable.uri
+        else:
+            result = 'error'
+        yield self.prepare_status('finished', {'result': result})
+
+
+class RunnerApp(nrunner.BaseRunnerApp):
+    PROG_NAME = 'avocado-runner-magic'
+    PROG_DESCRIPTION = 'nrunner application for magic tests'
+    RUNNABLE_KINDS_CAPABLE = {'magic': MagicRunner}
+
+
+def main():
+    nrunner.main(RunnerApp)
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/plugins/tests/magic/setup.py
+++ b/examples/plugins/tests/magic/setup.py
@@ -1,0 +1,20 @@
+from setuptools import setup
+
+name = 'magic'
+module = 'avocado_magic'
+resolver_ep = '%s = %s.resolver:%s' % (name, module, 'MagicResolver')
+runner_ep = '%s = %s.runner:%s' % (name, module, 'MagicRunner')
+runner_script = 'avocado-runner-%s = %s.runner:main' % (name, module)
+
+
+if __name__ == '__main__':
+    setup(name=name,
+          version='1.0',
+          description='Avocado "magic" test type',
+          py_modules=[module],
+          entry_points={
+              'avocado.plugins.resolver': [resolver_ep],
+              'avocado.plugins.runnable.runner': [runner_ep],
+              'console_scripts': [runner_script],
+              }
+          )


### PR DESCRIPTION
This is a very simple, hello world like, implementation of a resolver.
If given the right (magic) words, it will return a resolution for the
"magic" test type.

It also includes the simplest possible runner for "magic" words.
It'll result in a successfull test result for URI "pass", and a test
failure for URI "fail".  For anything else, it'll result in an error.

Signed-off-by: Cleber Rosa <crosa@redhat.com>

---

Changes from v1 (#4315):
 * Added section on Contributor’s Guide