### PR TITLE
setup.py: fix Python version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -188,6 +188,6 @@ if __name__ == '__main__':
               },
           zip_safe=False,
           test_suite='selftests',
-          python_requires='>=3.4',
+          python_requires='>=3.5',
           cmdclass={'clean': Clean},
           install_requires=['setuptools'])


### PR DESCRIPTION
We advertise (and test) support for 3.5 and later, so let's bump
the requirement.

Signed-off-by: Cleber Rosa <crosa@redhat.com>