### PR TITLE
assets: introduce a way to register assets manually and small refactoring (v3)

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -1014,24 +1014,18 @@ class Test(unittest.TestCase, TestData):
         asset_obj = asset.Asset(name, asset_hash, algorithm, locations,
                                 self.cache_dirs, expire)
 
-        missing_asset_message = 'Missing asset %s' % name
-
-        # decide whether we need to find only or fetch
-        if find_only:
-            asset_func = asset_obj.find_asset_file
-        else:
-            asset_func = asset_obj.fetch
-
         try:
             # return the path to the asset when it was found or fetched
-            asset_path = asset_func()
-            return asset_path
+            if find_only:
+                return asset_obj.find_asset_file()
+            else:
+                return asset_obj.fetch()
         except OSError as e:
             # if asset is not in the cache or there was a problem fetching
             # the asset
             if cancel_on_missing:
                 # cancel when requested
-                self.cancel(missing_asset_message)
+                self.cancel("Missing asset {}".format(name))
             # otherwise re-throw OSError
             raise e
 

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -1011,6 +1011,23 @@ class Test(unittest.TestCase, TestData):
         if expire is not None:
             expire = data_structures.time_to_seconds(str(expire))
 
+        # If name has no protocol or network locations, attempt to find
+        # the asset "by name" first. This is valid use case when the
+        # asset has been previously put into any of the cache
+        # directories, either manually or by the caching process
+        # itself.
+        parsed_name = asset.Asset.parse_name(name)
+        if not (parsed_name.scheme or locations):
+            try:
+                return asset.Asset.get_asset_by_name(name,
+                                                     self.cache_dirs,
+                                                     expire,
+                                                     asset_hash)
+            except OSError as e:
+                if cancel_on_missing:
+                    self.cancel("Missing asset {}".format(name))
+                raise e
+
         asset_obj = asset.Asset(name, asset_hash, algorithm, locations,
                                 self.cache_dirs, expire)
 

--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -441,10 +441,15 @@ class Asset:
         if self.name_scheme:
             return self.parsed_name.geturl()
 
+    @staticmethod
+    def parse_name(name):
+        """Returns a ParseResult object for the given name."""
+        return urlparse(name)
+
     @property
     def parsed_name(self):
         """Returns a ParseResult object for the currently set name."""
-        return urlparse(self.name)
+        return self.parse_name(self.name)
 
     @property
     def relative_dir(self):

--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -335,10 +335,16 @@ class Asset:
         cache_dir = self._get_writable_cache_dir()
         # Now we have a writable cache_dir. Let's get the asset.
         for url in self.urls:
+            if url is None:
+                continue
             urlobj = urlparse(url)
             if urlobj.scheme in ['http', 'https', 'ftp']:
                 fetch = self._download
             elif urlobj.scheme == 'file':
+                fetch = self._get_local_file
+            # We are assuming that everything starting with './' or '/' are a
+            # file too.
+            elif url.startswith(('/', './')):
                 fetch = self._get_local_file
             else:
                 raise UnsupportedProtocolError("Unsupported protocol"

--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -50,10 +50,9 @@ class Asset:
     Try to fetch/verify an asset file from multiple locations.
     """
 
-    def __init__(self, name, asset_hash, algorithm, locations, cache_dirs,
-                 expire=None, metadata=None):
-        """
-        Initialize the Asset() class.
+    def __init__(self, name, asset_hash=None, algorithm=None, locations=None,
+                 cache_dirs=None, expire=None, metadata=None):
+        """Initialize the Asset() class.
 
         :param name: the asset filename. url is also supported
         :param asset_hash: asset hash
@@ -69,7 +68,7 @@ class Asset:
         if isinstance(locations, str):
             self.locations = [locations]
         else:
-            self.locations = locations
+            self.locations = locations or []
 
         if algorithm is None:
             self.algorithm = DEFAULT_HASH_ALGORITHM
@@ -229,7 +228,7 @@ class Asset:
             return 'by_name'
 
         # check if the URI is located on self.locations or self.parsed_name
-        if self.locations is not None:
+        if self.locations:
             # if it is on self.locations, we need to check if it has the
             # asset name on it or a trailing '/'
             if ((self.asset_name in self.locations[0]) or
@@ -447,7 +446,7 @@ class Asset:
         if self.name_scheme:
             urls.append(self.name_url)
 
-        if self.locations is not None:
+        if self.locations:
             urls.extend(self.locations)
 
         return urls

--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -422,6 +422,47 @@ class Asset:
     def asset_name(self):
         return os.path.basename(self.parsed_name.path)
 
+    @classmethod
+    def get_asset_by_name(cls, name, cache_dirs, expire=None, asset_hash=None):
+        """This method will return a cached asset based on name if exists.
+
+        You don't have to instantiate an object of Asset class. Just use this
+        method.
+
+        To be improved soon: cache_dirs should be not necessary.
+
+        :param name: the asset filename used during registration.
+        :param cache_dirs: list of directories to use during the search.
+        :param expire: time in seconds for the asset to expire. Expired assets
+                       will not be returned.
+        :param asset_hash: asset hash.
+
+        :return: asset path, if it exists in the cache.
+        :rtype: str
+        :raises: OSError
+        """
+
+        for cache_dir in cache_dirs:
+            asset_file = os.path.join(os.path.expanduser(cache_dir),
+                                      'by_name',
+                                      name)
+
+            # Ignore non-files
+            if not os.path.isfile(asset_file):
+                continue
+
+            # Ignore expired asset files
+            if cls._is_expired(asset_file, expire):
+                continue
+
+            # Ignore mismatch hash
+            if not cls._has_valid_hash(asset_file, asset_hash):
+                continue
+
+            return asset_file
+
+        raise OSError("File %s not found in the cache." % name)
+
     @property
     def name_scheme(self):
         """This property will return the scheme part of the name if is an URL.

--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -88,8 +88,10 @@ class Asset:
         :param asset_path: full path of the asset file.
         """
         result = crypto.hash_file(asset_path, algorithm=self.algorithm)
-        with open(self._get_hash_file(asset_path), 'w') as hash_file:
-            hash_file.write('%s %s\n' % (self.algorithm, result))
+        hash_file = self._get_hash_file(asset_path)
+        with FileLock(hash_file, 30):
+            with open(hash_file, 'w') as fp:
+                fp.write('%s %s\n' % (self.algorithm, result))
 
     def _create_metadata_file(self, asset_file):
         """

--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -443,7 +443,7 @@ class Asset:
 
     @property
     def parsed_name(self):
-        """This property will return a ParseResult object if name is an URL."""
+        """Returns a ParseResult object for the currently set name."""
         return urlparse(self.name)
 
     @property

--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -66,24 +66,16 @@ class Asset:
         self.name = name
         self.asset_hash = asset_hash
 
-        # we currently support the following options for name and locations:
-        # 1. name is a full URI and locations is empty;
-        # 2. name is a single file name and locations is one or more entries.
-        # raise an exception if we have an unsupported use of those arguments
-        if ((self.name_scheme and locations is not None) or
-                (not self.name_scheme and locations is None)):
-            raise ValueError("Incorrect use of parameter name with parameter"
-                             " locations.")
+        if isinstance(locations, str):
+            self.locations = [locations]
+        else:
+            self.locations = locations
 
         if algorithm is None:
             self.algorithm = DEFAULT_HASH_ALGORITHM
         else:
             self.algorithm = algorithm
 
-        if isinstance(locations, str):
-            self.locations = [locations]
-        else:
-            self.locations = locations
         self.cache_dirs = cache_dirs
         self.expire = expire
         self.metadata = metadata

--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -282,6 +282,21 @@ class Asset:
             return True
         return False
 
+    @classmethod
+    def _has_valid_hash(cls, asset_path, asset_hash=None):
+        """Checks if a file has a valid hash based on the hash parameter.
+
+        If asset_hash is None then will consider a valid asset.
+        """
+        if asset_hash is None:
+            return True
+
+        hash_path = cls._get_hash_file(asset_path)
+        _, hash_from_file = cls.read_hash_from_file(hash_path)
+        if hash_from_file == asset_hash:
+            return True
+        return False
+
     def _verify_hash(self, asset_path):
         """
         Verify if the `asset_path` hash matches the hash in the hash file.
@@ -291,10 +306,7 @@ class Asset:
         value as the hash of the asset_file, otherwise return False.
         :rtype: bool
         """
-        if self.asset_hash is None or (
-                self._get_hash_from_file(asset_path) == self.asset_hash):
-            return True
-        return False
+        return self._has_valid_hash(asset_path, self.asset_hash)
 
     def fetch(self):
         """

--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -372,19 +372,19 @@ class Asset:
             cache_dir = os.path.expanduser(cache_dir)
             asset_file = os.path.join(cache_dir, self.relative_dir)
 
-            # To use a cached file, it must:
-            # - Exists.
-            # - Be valid (not expired).
-            # - Be verified (hash check).
-            if (os.path.isfile(asset_file) and
-                    not self._is_expired(asset_file, self.expire)):
-                try:
-                    with FileLock(asset_file, 30):
-                        if self._verify_hash(asset_file):
-                            return asset_file
-                except Exception:  # pylint: disable=W0703
-                    exc_type, exc_value = sys.exc_info()[:2]
-                    LOG.error('%s: %s', exc_type.__name__, exc_value)
+            # Ignore non-files
+            if not os.path.isfile(asset_file):
+                continue
+
+            # Ignore expired asset files
+            if self._is_expired(asset_file, self.expire):
+                continue
+
+            # Ignore mismatch hash
+            if not self._has_valid_hash(asset_file, self.asset_hash):
+                continue
+
+            return asset_file
 
         raise OSError("File %s not found in the cache." % self.asset_name)
 

--- a/selftests/__init__.py
+++ b/selftests/__init__.py
@@ -77,6 +77,7 @@ def get_temporary_config(module_name, klass, method):
                      'base_dir = %(base_dir)s\n'
                      'test_dir = %(test_dir)s\n'
                      'data_dir = %(data_dir)s\n'
+                     'cache_dirs = ["%(cache_dir)s"]\n'
                      'logs_dir = %(logs_dir)s\n') % mapping
     config_file = tempfile.NamedTemporaryFile('w', delete=False)
     config_file.write(temp_settings)

--- a/selftests/functional/test_plugin_assets.py
+++ b/selftests/functional/test_plugin_assets.py
@@ -11,7 +11,8 @@ import warnings
 from avocado.core import exit_codes
 from avocado.utils import process
 
-from .. import AVOCADO, get_temporary_config
+from .. import (AVOCADO, TestCaseTmpDir, get_temporary_config,
+                skipUnlessPathExists)
 
 TEST_TEMPLATE = r"""
 from avocado import Test
@@ -43,7 +44,7 @@ class FetchAssets:
 """
 
 
-class AssetsFetchSuccess(unittest.TestCase):
+class AssetsFetchSuccess(TestCaseTmpDir):
     """
     Assets fetch with success functional test class
     """
@@ -88,6 +89,31 @@ class AssetsFetchSuccess(unittest.TestCase):
 
         self.assertEqual(expected_rc, result.exit_status)
         self.assertIn(expected_output, result.stdout_text)
+
+    def test_asset_register_by_name_fail(self):
+        """Test register command failure."""
+        url = "https://urlnotfound"
+        config = self.config_file.name
+        cmd_line = "%s --config %s assets register foo %s" % (AVOCADO,
+                                                              config,
+                                                              url)
+        result = process.run(cmd_line)
+
+        self.assertIn("Failed to fetch",
+                      result.stderr_text)
+
+    @skipUnlessPathExists('/etc/hosts')
+    def test_asset_register_by_name_success(self):
+        """Test register command success."""
+        url = "/etc/hosts"
+        config = self.config_file.name
+        cmd_line = "%s --config %s assets register hosts %s" % (AVOCADO,
+                                                                config,
+                                                                url)
+        result = process.run(cmd_line)
+
+        self.assertIn("Now you can reference it by name hosts",
+                      result.stdout_text)
 
     def tearDown(self):
         self.base_dir.cleanup()

--- a/selftests/functional/test_plugin_assets.py
+++ b/selftests/functional/test_plugin_assets.py
@@ -218,7 +218,7 @@ class AssetsPlugin(unittest.TestCase):
         test_file.write(test_content.encode())
         test_file.close()
 
-        expected_stderr = "Failed to fetch hello-2.9.tar.gz.\n"
+        expected_stderr = "Failed to fetch hello-2.9.tar.gz"
         expected_rc = exit_codes.AVOCADO_FAIL
 
         cmd_line = "%s --config %s assets fetch %s " % (AVOCADO,
@@ -245,7 +245,7 @@ class AssetsPlugin(unittest.TestCase):
         test_file.write(test_content.encode())
         test_file.close()
 
-        expected_stderr = "Failed to fetch hello-2.9.tar.gz.\n"
+        expected_stderr = "Failed to fetch hello-2.9.tar.gz"
         expected_rc = exit_codes.AVOCADO_ALL_OK
 
         cmd_line = "%s --config %s assets fetch --ignore-errors %s " % (

--- a/selftests/functional/test_utils_asset.py
+++ b/selftests/functional/test_utils_asset.py
@@ -97,20 +97,6 @@ class TestAsset(TestCaseTmpDir):
             content2 = f.read()
         self.assertNotEqual(content1, content2)
 
-    def test_incorrect_name_locations_parameter_case1(self):
-        # 1. name is a full URI and locations is empty
-        with self.assertRaises(ValueError):
-            asset.Asset(name='file://bar.tgz', asset_hash=None, algorithm=None,
-                        locations='file://foo', cache_dirs=[self.cache_dir],
-                        expire=None)
-
-    def test_incorrect_name_locations_parameter_case2(self):
-        # 2. name is a single file name and locations is one or more entries.
-        with self.assertRaises(ValueError):
-            asset.Asset(name='bar.tgz', asset_hash=None, algorithm=None,
-                        locations=None, cache_dirs=[self.cache_dir],
-                        expire=None)
-
     def test_fetch_lockerror(self):
         dirname = os.path.join(self.cache_dir, 'by_name')
         os.makedirs(dirname)


### PR DESCRIPTION
This proposal is based on some of Avocado's user's needs. They are asking for ways to register assets manually and referencing them by name later, which is not possible in the current design.

This is a small hack to avoid a bigger change. But in general, this proposed approach will change three things: 1) we don't have to initialize objects to do basic operations, since there is a lot of unnecessary arguments when initializing that could be avoided. (vide class methods); 2) Lazy evaluation/validation of objects is being used, for better reuse of objects; 3) a new test method is available: self.fetch_asset_by_name(), I tried to explain the reason for that in the commit message;

Also, I'm doing small refactoring to improve code readability and maintainability.

IMO, this needs a much deeper cleanup to do soon. But that is it.

This fixes #4342 and #4313.

Signed-off-by: Beraldo Leal bleal@redhat.com

---

From v2 to v3, I attempted to fulfill the use case addressing assets by name when they are either previously registered by `avocado assets register` or previously cached by a `self.fetch_asset()`.  Given that the issues driving this feature came from QEMU, I used their existing tests to prove the feature.  Using `tests/acceptance/boot_linux_console.py` I added a new test, looking like:

```python
    def test_x86_64_pc_local_fedora_kernel(self):
        """
        :avocado: tags=arch:x86_64
        :avocado: tags=machine:pc
        """
        kernel_path = self.fetch_asset('fedora-31-x86_64-kernel')

        self.vm.set_console()
        kernel_command_line = self.KERNEL_COMMON_COMMAND_LINE + 'console=ttyS0'
        self.vm.add_args('-kernel', kernel_path,
                         '-append', kernel_command_line)
        self.vm.launch()
        console_pattern = 'Kernel command line: %s' % kernel_command_line
        self.wait_for_console_pattern(console_pattern)
```

And this is what happens *before* that name is registered:

```
  $ avocado run tests/acceptance/boot_linux_console.py:BootLinuxConsole.test_x86_64_pc_local_fedora_kernel
  Fetching asset from tests/acceptance/boot_linux_console.py:BootLinuxConsole.test_x86_64_pc_local_fedora_kernel
   JOB ID     : 51b635cbf4c61495922f1cf9e1df93f3dd31dd8b
   JOB LOG    : /home/cleber/avocado/job-results/job-2021-02-05T17.51-51b635c/job.log
    (1/1) tests/acceptance/boot_linux_console.py:BootLinuxConsole.test_x86_64_pc_local_fedora_kernel: CANCEL: Missing asset fedora-31-x86_64-kernel (0.00 s)
   RESULTS    : PASS 0 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 1
   JOB HTML   : /home/cleber/avocado/job-results/job-2021-02-05T17.51-51b635c/results.html
   JOB TIME   : 0.39 s
```

Which is expected.  Now, registering the kernel with that name:

```
   $ avocado assets register fedora-31-x86_64-kernel /boot/vmlinuz-5.8.18-100.fc31.x86_64 
   Done. Now you can reference it by name fedora-31-x86_64-kernel
```

And now running the test again:

```
   $ avocado run tests/acceptance/boot_linux_console.py:BootLinuxConsole.test_x86_64_pc_local_fedora_kernel
   Fetching asset from tests/acceptance/boot_linux_console.py:BootLinuxConsole.test_x86_64_pc_local_fedora_kernel
   JOB ID     : 9b9f84433e984788b965d5d6200bcd81f13fa95c
   JOB LOG    : /home/cleber/avocado/job-results/job-2021-02-05T17.52-9b9f844/job.log
    (1/1) tests/acceptance/boot_linux_console.py:BootLinuxConsole.test_x86_64_pc_local_fedora_kernel: PASS (1.15 s)
   RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
   JOB HTML   : /home/cleber/avocado/job-results/job-2021-02-05T17.52-9b9f844/results.html
   JOB TIME   : 1.55 s
```

The full test log can be seen at: https://paste.centos.org/view/28f6498d.  The following part contains relevant bits:

```
   VM launch command: './qemu-system-x86_64 -display none -vga none -chardev socket,id=mon,path=/tmp/avo_qemu_sock__vlteccb/qemu-1677272-monitor.sock -mon chardev=mon,mode=control -machine pc -chardev socket,id=console,path=/tmp/avo_qemu_sock__vlteccb/qemu-1677272-console.sock,server=on,wait=off -serial chardev:console -kernel /home/cleber/avocado/data/cache/by_name/fedora-31-x86_64-kernel -append printk.time=0 console=ttyS0'
```

---

Changes from v2:
 - Added behavior for fetching assets "by name" only (new commit, code mostly by @beraldoleal )
 - Added docstring fix

Changes from v1:
 - Removed commit adding new method to the public API;
 - Added a new commit to set a temporary cache_dirs inside the temporary config file