### PR TITLE
RPM check on COPR: bump fedora version used on the script

### DIFF
--- a/selftests/pre_release/tests/check-copr-rpm-version.sh
+++ b/selftests/pre_release/tests/check-copr-rpm-version.sh
@@ -10,6 +10,6 @@ git fetch $ORIGIN
 ORIGIN_MASTER_COMMIT=$(git log --pretty=format:'%h' -n 1 $ORIGIN/master)
 
 PODMAN=$(which podman)
-PODMAN_IMAGE=fedora:31
+PODMAN_IMAGE=fedora:33
 
 $PODMAN run --rm -ti $PODMAN_IMAGE /bin/bash -c "dnf -y module disable avocado && dnf -y install 'dnf-command(copr)' && dnf -y copr enable @avocado/avocado-latest && dnf -y install python3-avocado && (rpm -q python3-avocado | grep $ORIGIN_MASTER_COMMIT)"


### PR DESCRIPTION
COPR only builds packages for current Fedora versions, so let's bump
the version.

Signed-off-by: Cleber Rosa <crosa@redhat.com>