### PR TITLE
Vmimage pre_release tests clean up [v2]

### DIFF
--- a/selftests/pre_release/tests/vmimage.py
+++ b/selftests/pre_release/tests/vmimage.py
@@ -1,7 +1,10 @@
+import os
+import shutil
 from urllib.error import HTTPError
 from urllib.request import urlopen
 
 from avocado import Test, fail_on
+from avocado.plugins import vmimage as vmimage_plug
 from avocado.utils import process, vmimage
 
 
@@ -65,8 +68,22 @@ class Image(Base):
 
 
 class ImageFunctional(Base):
+
+    @staticmethod
+    def __get_cache_files():
+        return set(i['file'] for i in vmimage_plug.list_downloaded_images())
+
+    def setUp(self):
+        super().setUp()
+        self.cache_files = self.__get_cache_files()
+
     @fail_on(process.CmdError)
     def test_get(self):
         cmd = 'avocado vmimage get --distro=%s --distro-version=%s --arch=%s'
         cmd %= (self.vmimage_name, self.vmimage_version, self.vmimage_arch)
         process.run(cmd)
+
+    def tearDown(self):
+        dirty_files = self.__get_cache_files() - self.cache_files
+        for file_path in dirty_files:
+            shutil.rmtree(os.path.dirname(file_path))


### PR DESCRIPTION
In the vmimage pre_release testing we are downloading all avocado supported
images, but after testing the we leave them inside avocado cache. The images
can consume dozens gigabytes of data which can cause a memory issues. Because
of this problem we have to remove downloaded images from cache after the
testing.

Signed-off-by: Jan Richter <jarichte@redhat.com>

---
Changes form v1:
* Checking the status of cache before and after the test