### PR TITLE
Remove __future__ imports with functionality already in Python 3

### DIFF
--- a/avocado/plugins/diff.py
+++ b/avocado/plugins/diff.py
@@ -16,8 +16,6 @@
 Job Diff
 """
 
-from __future__ import absolute_import
-
 import argparse
 import json
 import os

--- a/selftests/.data/get_data.py
+++ b/selftests/.data/get_data.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from avocado import Test
 
 


### PR DESCRIPTION
Since Avocado requires ``python>=3.5``, maybe ``print_function`` and 
``absolute_import`` features from ``__future__`` could be removed as 
those provide functionality already builtin in python 3, used mainly to
provide backwards compatibility with python 2.