### PR TITLE
Assets: default asset name to empty string

### DIFF
--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -62,7 +62,7 @@ class Asset:
         :param expire: time in seconds for the asset to expire
         :param metadata: metadata which will be saved inside metadata file
         """
-        self.name = name
+        self.name = name or ''
         self.asset_hash = asset_hash
 
         if isinstance(locations, str):


### PR DESCRIPTION
Instead of allowing it to be given an explicit None.  The problem with
allowing None is that the name is given to Python's urlparse(), and it
has the behavior of returning either a ParseResult or a
ParseResultBytes depending on the input given.

To prevent having to add further logic on a large part of the asset
code, let's just normalize the input.

Reference: https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urlparse
Signed-off-by: Cleber Rosa <crosa@redhat.com>