### PR TITLE
debian: Update for Debian 10 v1

### DIFF
--- a/contrib/packages/debian/changelog
+++ b/contrib/packages/debian/changelog
@@ -1,3 +1,10 @@
+avocado (85.0) buster; urgency=medium
+
+  * Non-maintainer upload.
+  * Update version.
+
+ -- Baurzhan Ismagulov <ibr@radix50.net>  Sun, 14 Feb 2021 15:54:38 +0100
+
 avocado (0.29.0) vivid; urgency=medium
 
   * Automated (make builddeb) build.

--- a/contrib/packages/debian/control
+++ b/contrib/packages/debian/control
@@ -2,7 +2,7 @@ Source: avocado
 Section: python
 Priority: optional
 Maintainer: Lucas Meneghel Rodrigues (lmr) <lookkas@gmail.com>
-Build-Depends: debhelper (>=7.0.50~), python-support (>= 0.6), cdbs (>= 0.4.49), python-yaml, python-setuptools
+Build-Depends: debhelper (>=7.0.50~), cdbs (>= 0.4.49), python-yaml, python-setuptools
 Standards-Version: 3.8.4
 
 Package: avocado


### PR DESCRIPTION
Hello,

This small series contains minor fixes for the Debian packaging:

* debian: Remove dependency on python-support
* debian: Update package version

make check log: http://www.radix50.net/~ibr/job-2021-02-14T16.04-2659714-debian_buster-v1.log

There are 18 errors, should I fix them? I've only changed contrib/packages/debian.

Feedback welcome.

With kind regards,
Baurzhan.