### PR TITLE
Output on fail fix

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -591,6 +591,7 @@ class Test(unittest.TestCase, TestData):
 
         self._file_handler.setFormatter(formatter)
         self.log.addHandler(self._file_handler)
+        self.log.propagate = False
 
         # add the test log handler to the root logger so that
         # everything logged while the test is running, for every

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -227,7 +227,8 @@ class Runner(RunnerInterface):
             elif status == 'finished':
                 this_task_data = self.status_repo.get_task_data(task_id)
                 last_task_status = this_task_data[-1]
-                test_state = {'status': last_task_status.get('result').upper()}
+                test_state = last_task_status.copy()
+                test_state['status'] = last_task_status.get('result').upper()
                 test_state.update(early_state)
 
                 time_start = this_task_data[0]['time']
@@ -238,7 +239,8 @@ class Runner(RunnerInterface):
                 test_state['time_elapsed'] = time_elapsed
 
                 # fake log dir, needed by some result plugins such as HTML
-                test_state['logdir'] = ''
+                if 'logdir' not in test_state:
+                    test_state['logdir'] = ''
 
                 base_path = os.path.join(job.logdir, 'test-results')
                 self._populate_task_logdir(base_path,


### PR DESCRIPTION
The Testlog plugin didn't have the information where avocado-instrumented-nrunner stores the logs of tests. This PR is about fixing this problem.

Reference:#4341
Signed-off-by: Jan Richter <jarichte@redhat.com>