### PR TITLE
Assets: small fix on Asset constructor consistency

### DIFF
--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -50,11 +50,11 @@ class Asset:
     Try to fetch/verify an asset file from multiple locations.
     """
 
-    def __init__(self, name, asset_hash=None, algorithm=None, locations=None,
-                 cache_dirs=None, expire=None, metadata=None):
+    def __init__(self, name=None, asset_hash=None, algorithm=None,
+                 locations=None, cache_dirs=None, expire=None, metadata=None):
         """Initialize the Asset() class.
 
-        :param name: the asset filename. url is also supported
+        :param name: the asset filename. url is also supported. Default is ''.
         :param asset_hash: asset hash
         :param algorithm: hash algorithm
         :param locations: location(s) where the asset can be fetched from


### PR DESCRIPTION
Commit 27614569 was introduced as a default value but without effect on the
constructor signature. This small change will allow objects to be
constructed without having to pass None or `''` to the first argument
while keeps `''` as the default value.

Signed-off-by: Beraldo Leal <bleal@redhat.com>