### PR TITLE
utils/partition.py: Fix fetching the exact mount point

### DIFF
--- a/avocado/utils/partition.py
+++ b/avocado/utils/partition.py
@@ -140,7 +140,7 @@ class Partition:
             with open(filename) as open_file:
                 for line in open_file:
                     parts = line.split()
-                    if parts[0] == self.device or parts[1] == self.mountpoint:
+                    if parts[0] == self.device and parts[1] == self.mountpoint:
                         return parts[1]    # The mountpoint where it's mounted
                 return None
 


### PR DESCRIPTION
Patch fixes the partition library by matching both the device and
the mountpoint. This is required because all recent kernels
support device mounting multiple times as well as same mount point
being used for different devices

E.g:
/dev/pmem0 on /mnt/pmem type ext4 (rw,relatime,seclabel)
/dev/pmem0 on /pmem_map type ext4 (rw,relatime,seclabel)
/dev/pmem1 on /pmem_map type ext4 (rw,relatime,seclabel)

Also many generic mountpoints like none, tmpfs would need this for
a cleaner and proper unmount.

Signed-off-by: Harish <harish@linux.ibm.com>