### PR TITLE
BluePrints: add a template file

### DIFF
--- a/docs/source/blueprints/BP000.rst
+++ b/docs/source/blueprints/BP000.rst
@@ -128,6 +128,9 @@ will adopt .rst format here too. All blueprints will be located inside
 `docs/source/blueprints` with the filename `BPXXX.rst`, where XXX is the number
 of the blueprint. Just pick the next number available for your blueprint.
 
+It's recomended that you use ``docs/source/blueprints/template.rst``
+as a starting point.
+
 Write for your audience
 -----------------------
 
@@ -273,11 +276,15 @@ section:
    of Avocado? Should we deprecate some modules, classes, or methods? Are we
    going to keep backwards compatibility or not?
 
- * Security Implications: Do you have any concerns about security with your
-   proposed solution and what are they?
+ * Security Implications: Do you have any concerns about security with
+   your proposed solution and what are they?  If there's functionality
+   that is insecure but highly convenient, consider how to make it
+   "opt-in", disabled by default.
 
  * How to Teach This: What is the best way to inform our devs and users about
-   your new feature/solution?
+   your new feature/solution?  Consider both "how-to" and reference
+   style documentation, and if appropriate, examples (under ``examples/``)
+   using the feature.
 
  * Related Issues: Here, you should mention Github links for both: a) current
    open issues that are blocking while waiting for your BP and b) all open

--- a/docs/source/blueprints/template.rst
+++ b/docs/source/blueprints/template.rst
@@ -1,0 +1,89 @@
+BP???
+#####
+
+.. Please refer to BP000 for detailed instructions on how to write a
+   BluePrint (and remove this comment from your final document).
+
+:Number: BP???
+:Title:
+:Author: Your Name <you@domain>
+:Discussions-To: avocado-devel@redhat.com
+:Reviewers:
+:Created:
+:Type:
+:Status:
+
+.. contents:: Table of Contents
+
+TL;DR
+*****
+
+Short summary of the contents of this blueprint.
+
+Motivation
+**********
+
+Why is this needed? Current problems and benefits of the proposed
+solution.
+
+Specification
+*************
+
+How is this going to be implemented?  Can contain pseudo-code or
+architectural descriptions.
+
+Topic 1
+=======
+
+Topic 1 description.
+
+Sub-topic 1
+-----------
+
+Sub-topic 1 description.
+
+Topic 2
+=======
+
+Topic 2 description.
+
+Sub-topic 2
+------------
+
+Sub-topic 1 description.
+
+Backwards Compatibility
+***********************
+
+How will this break users of previous versions?  Users with tests
+using older APIs?  External plugins such as Avocado-VT?
+
+Security Implications
+*********************
+
+Do you have any concerns about security with your proposed solution
+and what are they?  If there's functionality that is insecure but
+highly convenient, consider how to make it "opt-in", disabled by
+default.
+
+How to Teach This
+*****************
+
+What is the best way to inform our devs and users about your new
+feature/solution?  Consider both "how-to" and reference style
+documentation, and if appropriate, examples (under ``examples/``)
+using the feature.
+
+Related Issues
+**************
+
+Here a list of all issues related to this blueprint:
+
+#.
+
+References
+**********
+
+[1] - Reference 1
+
+[2] - Reference 2


### PR DESCRIPTION
Anticipating that writing BluePrints will become more common, let's
also provide a template file that will help with that.

A few sections of BP000 were augmented just to refer to the template
file or to provide a bit more helpful information to BluePrint
writers.

Signed-off-by: Cleber Rosa <crosa@redhat.com>