### PR TITLE
plugins: change the avocado plugins output

### DIFF
--- a/avocado/plugins/plugins.py
+++ b/avocado/plugins/plugins.py
@@ -15,7 +15,7 @@
 Plugins information plugin
 """
 
-from avocado.core import dispatcher
+from avocado.core import dispatcher, output
 from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLICmd
 from avocado.core.resolver import Resolver
@@ -58,12 +58,17 @@ class Plugins(CLICmd):
         for plugins_active, msg in plugin_types:
             LOG_UI.info(msg)
             plugin_matrix = []
+            header = (output.TERM_SUPPORT.header_str('Package'),
+                      output.TERM_SUPPORT.header_str('Provides'),
+                      output.TERM_SUPPORT.header_str('Description'))
             for plugin in sorted(plugins_active, key=lambda x: x.name):
-                plugin_matrix.append((plugin.name, plugin.obj.description))
+                plugin_matrix.append((plugin.name,
+                                      plugins_active.namespace.replace(plugins_active.NAMESPACE_PREFIX, ''),
+                                      plugin.obj.description))
 
             if not plugin_matrix:
                 LOG_UI.debug("(No active plugin)")
             else:
-                for line in astring.iter_tabular_output(plugin_matrix):
+                for line in astring.iter_tabular_output(plugin_matrix, header=header):
                     LOG_UI.debug(line)
                 LOG_UI.debug("")

--- a/avocado/utils/astring.py
+++ b/avocado/utils/astring.py
@@ -200,16 +200,22 @@ def iter_tabular_output(matrix, header=None, strip=False):
     else:
         def str_out(x): return " ".join(x)
 
-    for row, row_lens in zip(str_matrix, len_matrix):
+    for count, zp in enumerate(zip(str_matrix, len_matrix)):
         out = []
+        row, row_lens = zp
         padding = [" " * (lengths[i] - row_lens[i])
                    for i in range(len(row_lens))]
         out = ["%s%s" % line for line in zip(row, padding)]
         try:
+            out = [str(i) + ' |' for i in out]
             out.append(row[-1])
         except IndexError:
             continue    # Skip empty rows
-        yield str_out(out)
+        if header and count == 0:
+            separator = '=' * (sum(lengths) + len(row_lens)*(1 + len(' |')))
+            yield str_out(out) + '\n' + separator
+        else:
+            yield str_out(out)
 
 
 def tabular_output(matrix, header=None, strip=False):

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -1055,8 +1055,9 @@ class PluginsTest(TestCaseTmpDir):
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK,
                          "Avocado did not return rc %d:\n%s"
                          % (exit_codes.AVOCADO_ALL_OK, result))
-        exp = (b"Type    Test                 Tag(s)\n"
-               b"MISSING this-wont-be-matched\n\n"
+        exp = (b"Type    | Test                 | Tag(s)\n"
+               b"=======================================\n"
+               b"MISSING | this-wont-be-matched |\n\n"
                b"TEST TYPES SUMMARY\n"
                b"==================\n"
                b"missing: 1\n")
@@ -1078,8 +1079,8 @@ class PluginsTest(TestCaseTmpDir):
         stdout_lines = result.stdout_text.splitlines()
         self.assertIn("Tag(s)", stdout_lines[0])
         full_test_name = "%s:MyTest.test" % test
-        self.assertEqual("INSTRUMENTED %s BIG_TAG_NAME" % full_test_name,
-                         stdout_lines[1])
+        self.assertEqual("INSTRUMENTED | %s | BIG_TAG_NAME" % full_test_name,
+                         stdout_lines[2])
         self.assertIn("TEST TYPES SUMMARY", stdout_lines)
         self.assertIn("instrumented: 1", stdout_lines)
         self.assertIn("TEST TAGS SUMMARY", stdout_lines)
@@ -1089,9 +1090,11 @@ class PluginsTest(TestCaseTmpDir):
         cmd_line = '%s plugins' % AVOCADO
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
+        stdout_lines = result.stdout_text.splitlines()
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %d:\n%s" %
                          (expected_rc, result))
+        self.assertRegex('Package* | Provides* | Description', stdout_lines[1])
         self.assertNotIn(b'Disabled', result.stdout)
 
     def test_config_plugin(self):

--- a/selftests/functional/test_loader.py
+++ b/selftests/functional/test_loader.py
@@ -290,11 +290,11 @@ class LoaderTestFunctional(TestCaseTmpDir):
         """
         cmd = "%s list examples/tests/:fail" % AVOCADO
         result = process.run(cmd)
-        expected = (b"INSTRUMENTED examples/tests/assert.py:Assert.test_fails_to_raise\n"
-                    b"INSTRUMENTED examples/tests/doublefail.py:DoubleFail.test\n"
-                    b"INSTRUMENTED examples/tests/fail_on_exception.py:FailOnException.test\n"
-                    b"INSTRUMENTED examples/tests/failtest.py:FailTest.test\n"
-                    b"SIMPLE       examples/tests/failtest.sh\n")
+        expected = (b"INSTRUMENTED | examples/tests/assert.py:Assert.test_fails_to_raise\n"
+                    b"INSTRUMENTED | examples/tests/doublefail.py:DoubleFail.test\n"
+                    b"INSTRUMENTED | examples/tests/fail_on_exception.py:FailOnException.test\n"
+                    b"INSTRUMENTED | examples/tests/failtest.py:FailTest.test\n"
+                    b"SIMPLE       | examples/tests/failtest.sh\n")
         self.assertEqual(expected, result.stdout)
 
     @skipUnlessPathExists('/bin/sh')

--- a/selftests/functional/test_nrunner.py
+++ b/selftests/functional/test_nrunner.py
@@ -167,7 +167,7 @@ class ResolveSerializeRun(TestCaseTmpDir):
         cmd = "%s list --resolver --write-recipes-to-directory=%s -- /bin/true"
         cmd %= (AVOCADO, self.tmpdir.name)
         res = process.run(cmd)
-        self.assertEqual(b'exec-test /bin/true\n', res.stdout)
+        self.assertEqual(b'exec-test | /bin/true\n', res.stdout)
         cmd = "%s runnable-run-recipe %s"
         cmd %= (RUNNER, os.path.join(self.tmpdir.name, '1.json'))
         res = process.run(cmd)

--- a/selftests/unit/test_astring.py
+++ b/selftests/unit/test_astring.py
@@ -10,13 +10,14 @@ class AstringTest(unittest.TestCase):
         matrix = [('foo', 'bar'), ('/bin/bar/sbrubles',
                                    '/home/myuser/sbrubles')]
         self.assertEqual(astring.tabular_output(matrix),
-                         ('foo               bar\n'
-                          '/bin/bar/sbrubles /home/myuser/sbrubles'))
+                         ('foo               | bar\n'
+                          '/bin/bar/sbrubles | /home/myuser/sbrubles'))
         header = ['id', 'path']
         self.assertEqual(astring.tabular_output(matrix, header),
-                         ('id                path\n'
-                          'foo               bar\n'
-                          '/bin/bar/sbrubles /home/myuser/sbrubles'))
+                         ('id                | path\n'
+                          '=========================================\n'
+                          'foo               | bar\n'
+                          '/bin/bar/sbrubles | /home/myuser/sbrubles'))
 
     def test_tabular_with_console_codes(self):
         matrix = [("a", "an", "dog", "word", "last"),
@@ -28,18 +29,19 @@ class AstringTest(unittest.TestCase):
                    "last")]
         header = ['0', '1', '2', '3', '4']
         self.assertEqual(astring.tabular_output(matrix, header),
-                         "0 1  2   3    4\n"
-                         "a an dog word last\n"
-                         "[94ma [0man cc[91mc "
-                         "[91md[92md[94md[90md[0m last")
+                         "0 | 1  | 2   | 3    | 4\n"
+                         "==========================\n"
+                         "a | an | dog | word | last\n"
+                         "[94ma | [0man | cc[91mc | "
+                         "[91md[92md[94md[90md[0m | last")
 
     def test_tabular_output_different_no_cols(self):
         matrix = [[], [1], [2, 2], [333, 333, 333], [4, 4, 4, 4444]]
         self.assertEqual(astring.tabular_output(matrix),
                          "1\n"
-                         "2   2\n"
-                         "333 333 333\n"
-                         "4   4   4   4444")
+                         "2   | 2\n"
+                         "333 | 333 | 333\n"
+                         "4   | 4   | 4   | 4444")
 
     # This could be a skip based on the Python version, but this is more
     # specific to the exact reason why it does/doesn't make sense to run it

--- a/selftests/unit/test_utils_astring.py
+++ b/selftests/unit/test_utils_astring.py
@@ -8,39 +8,58 @@ class AstringUtilsTest(unittest.TestCase):
     def test_tabular_output(self):
 
         self.assertEqual(astring.tabular_output([]), "")
+        self.assertEqual(astring.tabular_output([], []), "")
+        self.assertEqual(astring.tabular_output([[]], []), "")
         self.assertEqual(astring.tabular_output([],
                                                 header=('C1', 'C2', 'C3')),
-                         "C1 C2 C3")
+                         "C1 | C2 | C3" + "\n" +
+                         "============")
+        self.assertEqual(astring.tabular_output([['v11', 'v12', 'v13']],
+                                                header=('C1', 'C2', 'C3')),
+                         "C1  | C2  | C3" + "\n" +
+                         "===============" + "\n" +
+                         "v11 | v12 | v13")
         self.assertEqual(astring.tabular_output([['v11', 'v12', 'v13']]),
-                         "v11 v12 v13")
+                         "v11 | v12 | v13")
         self.assertEqual(astring.tabular_output([['v11', 'v12', 'v13'],
                                                  ['v21', 'v22', 'v23']],
                                                 header=('C1', 'C2', 'C3')),
-                         "C1  C2  C3" + "\n" +
-                         "v11 v12 v13" + "\n" +
-                         "v21 v22 v23")
+                         "C1  | C2  | C3" + "\n" +
+                         "===============" + "\n" +
+                         "v11 | v12 | v13" + "\n" +
+                         "v21 | v22 | v23")
+        self.assertEqual(astring.tabular_output([['C1', 'C2', 'C3'],
+                                                 ['v21', 'v22', 'v23']],
+                                                header=('C1', 'C2', 'C3')),
+                         "C1  | C2  | C3" + "\n" +
+                         "===============" + "\n" +
+                         "C1  | C2  | C3" + "\n" +
+                         "v21 | v22 | v23")
         self.assertEqual(astring.tabular_output([['v11', 'v12', ''],
                                                  ['v21', 'v22', 'v23']],
                                                 header=('C1', 'C2', 'C3')),
-                         "C1  C2  C3" + "\n" +
-                         "v11 v12 " + "\n" +
-                         "v21 v22 v23")
+                         "C1  | C2  | C3" + "\n" +
+                         "===============" + "\n" +
+                         "v11 | v12 | " + "\n" +
+                         "v21 | v22 | v23")
         self.assertEqual(astring.tabular_output([['v11', 'v12', ''],
                                                  ['v21', 'v22', 'v23']],
                                                 header=('C1', 'C2', 'C3'),
                                                 strip=True),
-                         "C1  C2  C3" + "\n" +
-                         "v11 v12" + "\n" +
-                         "v21 v22 v23")
+                         "C1  | C2  | C3" + "\n" +
+                         "===============" + "\n" +
+                         "v11 | v12 |" + "\n" +
+                         "v21 | v22 | v23")
 
         self.assertEqual(astring.tabular_output([['v11', 'v12', ''],
                                                  ['v2100', 'v22', 'v23'],
                                                  ['v31', 'v320', 'v33']],
                                                 header=('C1', 'C02', 'COL3')),
-                         "C1    C02  COL3" + "\n" +
-                         "v11   v12  " + "\n" +
-                         "v2100 v22  v23" + "\n" +
-                         "v31   v320 v33")
+                         "C1    | C02  | COL3" + "\n" +
+                         "===================" + "\n" +
+                         "v11   | v12  | " + "\n" +
+                         "v2100 | v22  | v23" + "\n" +
+                         "v31   | v320 | v33")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Currently, avocado plugins command displays some internal implementation
details. To improve user experience, we could print a better output,
focused on Avocado users instead of Avocado developers.

Reference: https://github.com/avocado-framework/avocado/issues/3476

Signed-off-by: Denis Karpelevich <dkarpele@redhat.com>
Signed-off-by: Cleber Rosa <crosa@redhat.com>

---

This is a rebase of https://github.com/avocado-framework/avocado/pull/3715, with hopes to help resume the work already done by @dkarpele  