### PR TITLE
get_disks_in_pci_address: add a path check

### DIFF
--- a/avocado/utils/pci.py
+++ b/avocado/utils/pci.py
@@ -97,6 +97,8 @@ def get_disks_in_pci_address(pci_address):
     """
     disks_path = "/dev/disk/by-path/"
     disk_list = []
+    if not os.path.exists(disks_path):
+        return disk_list
     for dev in os.listdir(disks_path):
         if pci_address in dev:
             link = os.readlink(os.path.join(disks_path, dev))


### PR DESCRIPTION
If the test system do not have any physical disks, the path /dev/disk/by-path/
is invalid, make sure the path exists before it proceeds

fixes ERROR: [Errno 2] No such file or directory: '/dev/disk/by-path/'

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>