### PR TITLE
assets: introduce assets list subcommand

### DIFF
--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -423,6 +423,19 @@ class Asset:
         return os.path.basename(self.parsed_name.path)
 
     @classmethod
+    def get_all_assets(cls, cache_dirs):
+        """Returns all assets stored in all cache dirs."""
+        assets = []
+        for cache_dir in cache_dirs:
+            expanded = os.path.expanduser(cache_dir)
+            for root, _, files in os.walk(expanded):
+                for f in files:
+                    if not f.endswith('-CHECKSUM') and \
+                       not f.endswith('_metadata.json'):
+                        assets.append(os.path.join(root, f))
+        return assets
+
+    @classmethod
     def get_asset_by_name(cls, name, cache_dirs, expire=None, asset_hash=None):
         """This method will return a cached asset based on name if exists.
 


### PR DESCRIPTION
This command will allow users to browse easly cached files.  Since we
plan to change the asset logic, I'm not displaying, intentionally, the
"by_name"/"by_location" part. I would like to hide this detail from
users.  Also, it is important to notice that part of this code could
implemented inside the Asset class, but today we don't have a safe way
to convert a filename into an 'asset' object without passing by
assumptions implemented on this class.  This is part of the QEMU
requirements and it is related to #4311.

Signed-off-by: Beraldo Leal <bleal@redhat.com>