### PR TITLE
Journal Plugin: store test names without quotes

### DIFF
--- a/avocado/plugins/journal.py
+++ b/avocado/plugins/journal.py
@@ -96,7 +96,7 @@ class JournalResult(ResultEvents):
             status = None
 
         self.journal_cursor.execute(sql,
-                                    (repr(state['name']),
+                                    (str(state['name']),
                                      datetime.datetime(1, 1, 1).now().isoformat(),
                                      action,
                                      status))


### PR DESCRIPTION
Because the "conversion to string" was being done using the
representation of the object, we ended up with quotes on the test
names, and we don't want that.

Signed-off-by: Cleber Rosa <crosa@redhat.com>