### PR TITLE
assets: introduce assets purge and list subcommands

### DIFF
--- a/avocado/plugins/assets.py
+++ b/avocado/plugins/assets.py
@@ -18,6 +18,7 @@ Assets subcommand
 
 import ast
 import os
+from datetime import datetime
 
 from avocado.core import data_dir, exit_codes, safeloader
 from avocado.core.nrunner import Task
@@ -26,6 +27,8 @@ from avocado.core.plugin_interfaces import CLICmd, JobPreTests
 from avocado.core.settings import settings
 from avocado.utils import data_structures
 from avocado.utils.asset import SUPPORTED_OPERATORS, Asset
+from avocado.utils.astring import iter_tabular_output
+from avocado.utils.output import display_data_size
 
 
 class FetchAssetHandler(ast.NodeVisitor):  # pylint: disable=R0902
@@ -360,8 +363,13 @@ class Assets(CLICmd):
         purge_subcommand_parser = subcommands.add_parser(
                 'purge',
                 help='Removes assets cached locally.')
-
         register_filter_options(purge_subcommand_parser, 'assets.purge')
+
+        help_msg = 'List all cached assets.'
+        list_subcommand_parser = subcommands.add_parser(
+                'list',
+                help=help_msg)
+        register_filter_options(list_subcommand_parser, 'assets.list')
 
     def handle_purge(self, config):
         days = config.get('assets.purge.days')
@@ -381,6 +389,50 @@ class Assets(CLICmd):
                 Asset.remove_assets_by_size(size_filter, cache_dirs)
         except (FileNotFoundError, OSError) as e:
             LOG_UI.error("Could not remove asset: %s", e)
+
+    def handle_list(self, config):
+        # IMO, this should get data from config instead. See #4443
+        cache_dirs = data_dir.get_cache_dirs()
+
+        days = config.get('assets.list.days')
+        size_filter = config.get('assets.list.size_filter')
+        if (days is not None and size_filter is not None):
+            msg = ("You should choose --by-size-filter or --by-days. "
+                   "For help, run: avocado assets list --help")
+            LOG_UI.error(msg)
+            return
+
+        cache_dirs = data_dir.get_cache_dirs()
+        try:
+            assets = None
+            if days is not None:
+                assets = Asset.get_assets_by_unused_for_days(days, cache_dirs)
+            elif size_filter is not None:
+                assets = Asset.get_assets_by_size(size_filter, cache_dirs)
+            elif assets is None:
+                assets = Asset.get_all_assets(cache_dirs)
+        except (FileNotFoundError, OSError) as e:
+            LOG_UI.error("Could get assets: %s", e)
+            return
+
+        matrix = []
+        for asset in assets:
+            stat = os.stat(asset)
+            basename = os.path.basename(asset)
+            hash_path = "{}-CHECKSUM".format(asset)
+            atime = datetime.fromtimestamp(stat.st_atime)
+            _, checksum = Asset.read_hash_from_file(hash_path)
+            matrix.append((basename,
+                           str(checksum or "unknown")[:10],
+                           atime.strftime('%Y-%m-%d %H:%M:%S'),
+                           display_data_size(stat.st_size)))
+        header = ("asset", "checksum", "atime", "size")
+        output = list(iter_tabular_output(matrix, header))
+        if len(output) == 1:
+            LOG_UI.info("No asset found in your cache system.")
+        else:
+            for line in output:
+                LOG_UI.info(line)
 
     def handle_fetch(self, config):
         exitcode = exit_codes.AVOCADO_ALL_OK
@@ -439,5 +491,7 @@ class Assets(CLICmd):
             return self.handle_register(config)
         elif subcommand == 'purge':
             return self.handle_purge(config)
+        elif subcommand == 'list':
+            return self.handle_list(config)
         else:
             return exit_codes.UTILITY_FAIL

--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -503,7 +503,6 @@ class Asset:
                 result.append(file_path)
         return result
 
-
     @classmethod
     def get_assets_by_size(cls, size_filter, cache_dirs):
         """Return a list of all assets in cache based on its size in MB.

--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -423,6 +423,19 @@ class Asset:
         return os.path.basename(self.parsed_name.path)
 
     @classmethod
+    def get_all_assets(cls, cache_dirs):
+        """Returns all assets stored in all cache dirs."""
+        assets = []
+        for cache_dir in cache_dirs:
+            expanded = os.path.expanduser(cache_dir)
+            for root, _, files in os.walk(expanded):
+                for f in files:
+                    if not f.endswith('-CHECKSUM') and \
+                       not f.endswith('_metadata.json'):
+                        assets.append(os.path.join(root, f))
+        return assets
+
+    @classmethod
     def get_asset_by_name(cls, name, cache_dirs, expire=None, asset_hash=None):
         """This method will return a cached asset based on name if exists.
 

--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -20,6 +20,7 @@ import errno
 import hashlib
 import json
 import logging
+import operator
 import os
 import re
 import shutil
@@ -37,6 +38,12 @@ from .filelock import FileLock
 LOG = logging.getLogger('avocado.test')
 #: The default hash algorithm to use on asset cache operations
 DEFAULT_HASH_ALGORITHM = 'sha1'
+
+SUPPORTED_OPERATORS = {'==': operator.eq,
+                       '<': operator.lt,
+                       '>': operator.gt,
+                       '<=': operator.le,
+                       '>=': operator.ge}
 
 
 class UnsupportedProtocolError(OSError):
@@ -476,6 +483,42 @@ class Asset:
 
         raise OSError("File %s not found in the cache." % name)
 
+    @classmethod
+    def get_assets_by_size(cls, size_filter, cache_dirs):
+        """Return a list of all assets in cache based on its size in MB.
+
+        :param size_filter: a string with a filter (comparison operator +
+        value). Ex ">20", "<=200". Supported operators: ==, <, >, <=, >=.
+        :param cache_dirs: list of directories to use during the search.
+        """
+        try:
+            op = re.match('^(\\D+)(\\d+)$', size_filter).group(1)
+            value = int(re.match('^(\\D+)(\\d+)$', size_filter).group(2))
+        except (AttributeError, ValueError):
+            msg = ("Invalid syntax. You need to pass an comparison operatator",
+                   " and a value. Ex: '>=200'")
+            raise OSError(msg)
+
+        try:
+            method = SUPPORTED_OPERATORS[op]
+        except KeyError:
+            msg = ("Operator not supported. Currented valid values are: ",
+                   ", ".join(SUPPORTED_OPERATORS))
+            raise OSError(msg)
+
+        result = []
+        for file_path in cls.get_all_assets(cache_dirs):
+            file_size = os.path.getsize(file_path)
+            if method(file_size, value):
+                result.append(file_path)
+        return result
+
+    @classmethod
+    def remove_assets_by_size(cls, size_filter, cache_dirs):
+
+        for file_path in cls.get_assets_by_size(size_filter, cache_dirs):
+            cls.remove_asset_by_path(file_path)
+
     @property
     def name_scheme(self):
         """This property will return the scheme part of the name if is an URL.
@@ -508,6 +551,19 @@ class Asset:
     @property
     def relative_dir(self):
         return os.path.join(self._get_relative_dir(), self.asset_name)
+
+    @classmethod
+    def remove_asset_by_path(cls, asset_path):
+        """Remove an asset and its checksum.
+
+        To be fixed: Due the current implementation limitation, this method
+        will not remove the metadata to avoid removing other asset metadata.
+
+        :param asset_path: full path of the asset file.
+        """
+        os.remove(asset_path)
+        filename = "{}-CHECKSUM".format(asset_path)
+        os.remove(filename)
 
     @property
     def urls(self):

--- a/docs/source/guides/user/chapters/assets.rst
+++ b/docs/source/guides/user/chapters/assets.rst
@@ -1,0 +1,60 @@
+Managing Assets
+===============
+
+..note:: Please note that we are improve constantly how we handle assets inside
+         Avocado. Probably some changes will be delivered during the next
+         releases.
+
+Assets are artifacts that can be used in your tests. Avocado can download those
+assets automatically when parsing your tests or on demand, when you register an
+asset at the command-line.
+
+Sometimes those assets, depending on your case, can be a bottleneck when it
+comes to disk space. If you are constantly using large assets in your tests, it
+is important to have a good idea on how Avocado stores and handle those
+artifacts.
+
+TODO: [Improve this section describing assets in general]
+
+Listing assets
+--------------
+
+If you would like to list assets that are cached in your system, you can run
+the following command::
+
+ $ avocado assets list
+
+This command supports `--by-size-filter` and `--by-days` options. When using
+the former you should pass a comparison filter and a size in bytes. For
+instance::
+
+ $ avocado assets list --by-size-filter=">=2048"
+
+The command above will list only assets bigger than 2Kb. We support the
+following operators: `=`, `>=`, `<=`, `<` and `>`.
+
+Now, if you are looking for assets older (based on the acces time) than 10
+days, you could use this command::
+
+ $ avocado assets list --by-days=10
+
+Removing assets
+---------------
+
+You can remove the files in your cache directories manually. However, we have
+provided a utility to help you with that::
+
+ $ avocado assets purge --help
+
+Assets can be removed applying the same filters as described when listing them.
+You can remove assets by a size filter (`--by-size-filter`) or assets older
+than N days (`--by-days`).
+
+Changing the default cache dirs
+-------------------------------
+
+Assets are stored inside the `datadir.paths.cache_dirs` option. You can change
+this in your configuration file and discover your current value with the
+following command::
+
+ $ avocado config | grep datadir.paths.cache_dirs

--- a/docs/source/guides/user/index.rst
+++ b/docs/source/guides/user/index.rst
@@ -13,6 +13,7 @@ Avocado User's Guide
    chapters/results
    chapters/tags
    chapters/configuring
+   chapters/assets
    chapters/datadirs
    chapters/logging
    chapters/plugins

--- a/selftests/functional/test_plugin_assets.py
+++ b/selftests/functional/test_plugin_assets.py
@@ -115,6 +115,31 @@ class AssetsFetchSuccess(TestCaseTmpDir):
         self.assertIn("Now you can reference it by name hosts",
                       result.stdout_text)
 
+    def test_asset_purge(self):
+        """Make sure that we can remove a asset from cache."""
+        # creates a single byte asset
+        asset_file = tempfile.NamedTemporaryFile(delete=False)
+        asset_file.write(b'\xff')
+        asset_file.close()
+
+        config = self.config_file.name
+        url = asset_file.name
+        name = "should-be-removed"
+        cmd_line = "%s --config %s assets register %s %s" % (AVOCADO,
+                                                             config,
+                                                             name,
+                                                             url)
+        result = process.run(cmd_line)
+        self.assertIn("Now you can reference it by name {}".format(name),
+                      result.stdout_text)
+
+        cmd_line = "%s --config %s assets purge --by-size-filter '==1'" % (AVOCADO, config)
+        process.run(cmd_line)
+
+        cmd_line = "%s --config %s assets list" % (AVOCADO, config)
+        result = process.run(cmd_line)
+        self.assertNotIn(name, result.stdout_text)
+
     def tearDown(self):
         self.base_dir.cleanup()
 

--- a/selftests/functional/test_plugin_assets.py
+++ b/selftests/functional/test_plugin_assets.py
@@ -140,6 +140,24 @@ class AssetsFetchSuccess(TestCaseTmpDir):
         result = process.run(cmd_line)
         self.assertNotIn(name, result.stdout_text)
 
+    @skipUnlessPathExists('/etc/hosts')
+    def test_asset_list(self):
+        """Make sure that we have a list working properly."""
+        url = "/etc/hosts"
+        config = self.config_file.name
+        name = "should-be-part-of-list"
+        cmd_line = "%s --config %s assets register %s %s" % (AVOCADO,
+                                                             config,
+                                                             name,
+                                                             url)
+        result = process.run(cmd_line)
+        self.assertIn("Now you can reference it by name {}".format(name),
+                      result.stdout_text)
+        cmd_line = "%s --config %s assets list" % (AVOCADO,
+                                                   config)
+        result = process.run(cmd_line)
+        self.assertIn(name, result.stdout_text)
+
     def tearDown(self):
         self.base_dir.cleanup()
 


### PR DESCRIPTION
This PR will introduce some foundation methods and new command-line options for the "avocado assets" command. From now on we have "purge" and "list", options. More information on individual commit messages.