### PR TITLE
Check summary [v2]

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -534,6 +534,18 @@ class Job:
         if result_dispatcher.extensions:
             result_dispatcher.map_method('render', self.result, self)
 
+    def get_failed_tests(self):
+        """Gets the tests with status 'FAIL' and 'ERROR' after the Job ended.
+
+        :return: List of failed tests
+        """
+        tests = []
+        if self.result:
+            for test in self.result.tests:
+                if test.get('status') in ['FAIL', 'ERROR']:
+                    tests.append(test)
+        return tests
+
     def run(self):
         """
         Runs all job phases, returning the test execution results.

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -518,6 +518,13 @@ def create_suites(args):
     return suites
 
 
+def print_failed_tests(tests):
+    if tests:
+        print("Failed tests:")
+        for test in tests:
+            print(test.get('name'), test.get('status'))
+
+
 def main():
     args = parse_args()
     suites = create_suites(args)
@@ -541,7 +548,9 @@ def main():
     config = {'core.show': ['app'],
               'run.test_runner': 'nrunner'}
     with Job(config, suites) as j:
-        return j.run()
+        exit_code = j.run()
+    print_failed_tests(j.get_failed_tests())
+    return exit_code
 
 
 if __name__ == '__main__':

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -341,6 +341,18 @@ class JobTest(unittest.TestCase):
         if self.job.test_suite:
             self.assertIsInstance(self.job.test_suite.tests[0], nrunner.Task)
 
+    def test_job_get_failed_tests(self):
+        config = {'run.references': ['/bin/true', '/bin/false'],
+                  'run.results_dir': self.tmpdir.name,
+                  'run.store_logging_stream': [],
+                  'run.dry_run.enabled': True,
+                  'core.show': ['none']}
+        suite = TestSuite.from_config(config)
+        self.job = job.Job(config, [suite])
+        self.job.setup()
+        self.job.run()
+        self.assertEqual(len(self.job.get_failed_tests()), 1)
+
     def tearDown(self):
         data_dir._tmp_tracker.unittest_refresh_dir_tracker()
         self.tmpdir.cleanup()


### PR DESCRIPTION
Output of selftests check with summary of all failed tests.

Signed-off-by: Jan Richter <jarichte@redhat.com>

Now the check output will look like this:
```
...
 (check-852/956) selftests/lint.sh: FAIL (91.79 s)
RESULTS    : PASS 956 | ERROR 1 | FAIL 3 | SKIP 44 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/jarichte/avocado/job-results/job-2021-03-10T15.40-f7a9604/results.html
JOB TIME   : 462.65 s
Failed tests:
check-417-selftests/unit/test_test.py:MockingTest.test_combination_2  ERROR
check-416-selftests/unit/test_test.py:MockingTest.test_combination  FAIL
check-772-selftests/functional/test_loader.py:LoaderTestFunctional.test_python_unittest  FAIL
check-852-selftests/lint.sh  FAIL
```
---
Changes form v1 #4448:

Usage of Job API instead of journal plugin