### PR TITLE
nrunner: provide a Task identifier when none is given

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -15,6 +15,7 @@ import sys
 import tempfile
 import time
 import unittest
+from uuid import uuid1
 
 try:
     import pkg_resources
@@ -653,7 +654,9 @@ class Task:
                            within the context of a Job. A recommended value
                            is a :class:`avocado.core.test_id.TestID` instance
                            when a task represents a test, because besides the
-                           uniqueness aspect, it's also descriptive.
+                           uniqueness aspect, it's also descriptive.  If an
+                           identifier is not given, an automatically generated
+                           one will be set.
         :param runnable: the "description" of what the task should run.
         :type runnable: :class:`avocado.core.nrunner.Runnable`
         :param status_uri: the URIs for the status servers that this task
@@ -662,7 +665,7 @@ class Task:
         :param known_runners: a mapping of runnable kinds to runners.
         :type known_runners: dict
         """
-        self.identifier = identifier
+        self.identifier = identifier or str(uuid1())
         self.runnable = runnable
         self.status_services = []
         if status_uris is not None:

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -643,13 +643,25 @@ class Task:
     While a runnable describes what to be run, and gets run by a
     runner, a task should be a unique entity to track its state,
     that is, whether it is pending, is running or has finished.
-
-    :param identifier:
-    :param runnable:
     """
 
     def __init__(self, identifier, runnable, status_uris=None,
                  known_runners=None):
+        """Instantiates a new Task.
+
+        :param identifier: any identifier that is guaranteed to be unique
+                           within the context of a Job. A recommended value
+                           is a :class:`avocado.core.test_id.TestID` instance
+                           when a task represents a test, because besides the
+                           uniqueness aspect, it's also descriptive.
+        :param runnable: the "description" of what the task should run.
+        :type runnable: :class:`avocado.core.nrunner.Runnable`
+        :param status_uri: the URIs for the status servers that this task
+                           should send updates to.
+        :type status_uri: list
+        :param known_runners: a mapping of runnable kinds to runners.
+        :type known_runners: dict
+        """
         self.identifier = identifier
         self.runnable = runnable
         self.status_services = []

--- a/avocado/core/utils.py
+++ b/avocado/core/utils.py
@@ -1,5 +1,4 @@
 import os
-from uuid import uuid1
 
 from pkg_resources import get_distribution
 
@@ -80,5 +79,5 @@ def resolutions_to_tasks(resolutions, config):
                                                  include_empty,
                                                  include_empty_key):
                     continue
-            tasks.append(Task(str(uuid1()), runnable, [status_server]))
+            tasks.append(Task(None, runnable, [status_server]))
     return tasks


### PR DESCRIPTION
A task identifier is a mandatory attribute, and that fact is set clear in the class initializer.  But, there are circunstances where users     are not interested in manually set them, but just have them being unique.
