### PR TITLE
nrunner: provide a Task identifier when none is given [v2]

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -15,6 +15,7 @@ import sys
 import tempfile
 import time
 import unittest
+from uuid import uuid1
 
 try:
     import pkg_resources
@@ -645,25 +646,27 @@ class Task:
     that is, whether it is pending, is running or has finished.
     """
 
-    def __init__(self, identifier, runnable, status_uris=None,
+    def __init__(self, runnable, identifier=None, status_uris=None,
                  known_runners=None):
         """Instantiates a new Task.
 
+        :param runnable: the "description" of what the task should run.
+        :type runnable: :class:`avocado.core.nrunner.Runnable`
         :param identifier: any identifier that is guaranteed to be unique
                            within the context of a Job. A recommended value
                            is a :class:`avocado.core.test_id.TestID` instance
                            when a task represents a test, because besides the
-                           uniqueness aspect, it's also descriptive.
-        :param runnable: the "description" of what the task should run.
-        :type runnable: :class:`avocado.core.nrunner.Runnable`
+                           uniqueness aspect, it's also descriptive.  If an
+                           identifier is not given, an automatically generated
+                           one will be set.
         :param status_uri: the URIs for the status servers that this task
                            should send updates to.
         :type status_uri: list
         :param known_runners: a mapping of runnable kinds to runners.
         :type known_runners: dict
         """
-        self.identifier = identifier
         self.runnable = runnable
+        self.identifier = identifier or str(uuid1())
         self.status_services = []
         if status_uris is not None:
             for status_uri in status_uris:
@@ -714,7 +717,7 @@ class Task:
                             *runnable_recipe.get('args', ()),
                             config=runnable_recipe.get('config'))
         status_uris = recipe.get('status_uris')
-        return cls(identifier, runnable, status_uris, known_runners)
+        return cls(runnable, identifier, status_uris, known_runners)
 
     def get_command_args(self):
         """
@@ -956,7 +959,7 @@ class BaseRunnerApp:
         :type args: dict
         """
         runnable = Runnable.from_args(args)
-        task = Task(args.get('identifier'), runnable,
+        task = Task(runnable, args.get('identifier'),
                     args.get('status_uri', []),
                     known_runners=self.RUNNABLE_KINDS_CAPABLE)
         for status in task.run():

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -643,13 +643,25 @@ class Task:
     While a runnable describes what to be run, and gets run by a
     runner, a task should be a unique entity to track its state,
     that is, whether it is pending, is running or has finished.
-
-    :param identifier:
-    :param runnable:
     """
 
     def __init__(self, identifier, runnable, status_uris=None,
                  known_runners=None):
+        """Instantiates a new Task.
+
+        :param identifier: any identifier that is guaranteed to be unique
+                           within the context of a Job. A recommended value
+                           is a :class:`avocado.core.test_id.TestID` instance
+                           when a task represents a test, because besides the
+                           uniqueness aspect, it's also descriptive.
+        :param runnable: the "description" of what the task should run.
+        :type runnable: :class:`avocado.core.nrunner.Runnable`
+        :param status_uri: the URIs for the status servers that this task
+                           should send updates to.
+        :type status_uri: list
+        :param known_runners: a mapping of runnable kinds to runners.
+        :type known_runners: dict
+        """
         self.identifier = identifier
         self.runnable = runnable
         self.status_services = []

--- a/avocado/core/utils.py
+++ b/avocado/core/utils.py
@@ -1,5 +1,4 @@
 import os
-from uuid import uuid1
 
 from pkg_resources import get_distribution
 
@@ -80,5 +79,5 @@ def resolutions_to_tasks(resolutions, config):
                                                  include_empty,
                                                  include_empty_key):
                     continue
-            tasks.append(Task(str(uuid1()), runnable, [status_server]))
+            tasks.append(Task(runnable, None, [status_server]))
     return tasks

--- a/examples/jobs/passjob_custom.py
+++ b/examples/jobs/passjob_custom.py
@@ -12,9 +12,9 @@ config = {'run.test_runner': 'nrunner'}
 # creating tests suites for you).
 
 suite1 = TestSuite(config=config,
-                   tests=[Task("task1", Runnable("noop", "noop"))], name='suite1')
+                   tests=[Task(Runnable("noop", "noop"), "task1")], name='suite1')
 suite2 = TestSuite(config=config,
-                   tests=[Task("task2", Runnable("noop", "noop"))], name='suite2')
+                   tests=[Task(Runnable("noop", "noop"), "task2")], name='suite2')
 
 with Job(config, [suite1, suite2]) as j:
     sys.exit(j.run())

--- a/selftests/functional/test_task_statemachine.py
+++ b/selftests/functional/test_task_statemachine.py
@@ -19,7 +19,7 @@ class StateMachine(TestCase):
         number_of_workers = 8
 
         runnable = Runnable("noop", "noop")
-        runtime_tasks = [RuntimeTask(Task("%03i" % _, runnable))
+        runtime_tasks = [RuntimeTask(Task(runnable, "%03i" % _))
                          for _ in range(1, number_of_tasks + 1)]
         spawner = Spawner()
 

--- a/selftests/unit/test_spawner.py
+++ b/selftests/unit/test_spawner.py
@@ -10,7 +10,7 @@ from avocado.plugins.spawners.process import ProcessSpawner
 class Process(unittest.TestCase):
     def setUp(self):
         runnable = nrunner.Runnable('noop', 'uri')
-        task = nrunner.Task('1', runnable)
+        task = nrunner.Task(runnable, '1')
         self.runtime_task = RuntimeTask(task)
         self.spawner = ProcessSpawner()
 
@@ -28,7 +28,7 @@ class Mock(Process):
 
     def setUp(self):
         runnable = nrunner.Runnable('noop', 'uri')
-        task = nrunner.Task('1', runnable)
+        task = nrunner.Task(runnable, '1')
         self.runtime_task = RuntimeTask(task)
         self.spawner = MockSpawner()
 
@@ -43,7 +43,7 @@ class RandomMock(Mock):
 
     def setUp(self):
         runnable = nrunner.Runnable('noop', 'uri')
-        task = nrunner.Task('1', runnable)
+        task = nrunner.Task(runnable, '1')
         self.runtime_task = RuntimeTask(task)
         self.spawner = MockRandomAliveSpawner()
 

--- a/selftests/unit/test_task_runtime.py
+++ b/selftests/unit/test_task_runtime.py
@@ -8,7 +8,7 @@ class Runtime(TestCase):
 
     def setUp(self):
         runnable = Runnable('noop', 'noop')
-        task = Task('1-noop', runnable)
+        task = Task(runnable, '1-noop')
         self.runtime_task = RuntimeTask(task)
 
     def test_empty(self):


### PR DESCRIPTION
A task identifier is a mandatory attribute, and that fact is set clear in the class initializer. But, there are circumstances where users are not interested in manually set them, but just have them being unique.

---

Changes from v1 (#4461):
 * Changed the order of parameters in `Task`, making `identifier` the second (and optional) parameter