### PR TITLE
Cirrus CI: expand coverage

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,3 +8,16 @@ redhat_version_task:
           - image: fedora:32
           - image: fedora:33
           - image: registry.access.redhat.com/ubi8/ubi
+
+debian_version_task:
+    version_script:
+       - python3 --version || (apt update && apt -y install python3 python3-setuptools)
+       - python3 setup.py develop --user
+       - python3 -m avocado --version
+
+    container:
+        matrix:
+          - image: debian:9.13
+          - image: debian:10.8
+          - image: ubuntu:18.04
+          - image: ubuntu:20.04

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -21,3 +21,12 @@ debian_version_task:
           - image: debian:10.8
           - image: ubuntu:18.04
           - image: ubuntu:20.04
+
+windows_version_task:
+    version_script:
+       - choco install -y python3 --version 3.9.0
+       - C:\Python39\python setup.py develop --user
+       - C:\Python39\python -m avocado --help
+       - C:\Python39\python -m avocado run --test-runner=nrunner examples\tests\passtest.py
+    windows_container:
+       image: cirrusci/windowsservercore:2019

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,6 +1,6 @@
 redhat_version_task:
     version_script:
-       - python3 --version || dnf -y install python3
+       - python3 -c 'import setuptools' || dnf -y install python3 python3-setuptools
        - python3 setup.py develop --user
        - python3 -m avocado --version
     container:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,4 +1,4 @@
-version_task:
+redhat_version_task:
     version_script:
        - python3 --version || dnf -y install python3
        - python3 setup.py develop --user

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,6 +5,6 @@ version_task:
        - python3 -m avocado --version
     container:
         matrix:
-          - image: fedora:30
-          - image: fedora:29
+          - image: fedora:32
+          - image: fedora:33
           - image: registry.access.redhat.com/ubi8/ubi


### PR DESCRIPTION
Given that our CI service is undergoing changes, it's a good idea to look into other services.  We've been using Cirrus CI lightly, but Avocado-VT uses it a lot, and it has always been rock solid.

This increases the coverage done on Cirrus CI, and may lead to more load being sent that way.