### PR TITLE
Move nrunner standalone runners to a new runners dir

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -255,10 +255,10 @@ class Runnable:
         # Looking for the file only avoids an attempt to load the module
         # and should be a lot faster
         core_dir = os.path.dirname(os.path.abspath(__file__))
-        module_name = "nrunner_%s" % self.kind.replace('-', '_')
+        module_name = self.kind.replace('-', '_')
         module_filename = '%s.py' % module_name
-        if os.path.exists(os.path.join(core_dir, module_filename)):
-            full_module_name = 'avocado.core.%s' % module_name
+        if os.path.exists(os.path.join(core_dir, 'runners', module_filename)):
+            full_module_name = 'avocado.core.runners.%s' % module_name
             candidate_cmd = [sys.executable, '-m', full_module_name]
             if self.is_kind_supported_by_runner_command(candidate_cmd):
                 runners_registry[self.kind] = candidate_cmd

--- a/avocado/core/runners/avocado_instrumented.py
+++ b/avocado/core/runners/avocado_instrumented.py
@@ -2,9 +2,9 @@ import multiprocessing
 import tempfile
 import time
 
-from . import loader, nrunner, teststatus
-from .test import TestID
-from .tree import TreeNode
+from .. import loader, nrunner, teststatus
+from ..test import TestID
+from ..tree import TreeNode
 
 
 class AvocadoInstrumentedTestRunner(nrunner.BaseRunner):

--- a/avocado/core/runners/tap.py
+++ b/avocado/core/runners/tap.py
@@ -3,8 +3,8 @@ import os
 import subprocess
 import time
 
-from . import nrunner
-from .tapparser import TapParser, TestResult
+from .. import nrunner
+from ..tapparser import TapParser, TestResult
 
 
 class TAPRunner(nrunner.BaseRunner):

--- a/selftests/unit/test_nrunner.py
+++ b/selftests/unit/test_nrunner.py
@@ -3,7 +3,8 @@ import sys
 import tempfile
 import unittest.mock
 
-from avocado.core import nrunner, nrunner_tap
+from avocado.core import nrunner
+from avocado.core.runners import tap as runner_tap
 
 from .. import skipUnlessPathExists, temp_dir_prefix
 
@@ -328,7 +329,7 @@ echo 'not ok 2 - description 2'"""
             fp.write(tap_script)
 
         runnable = nrunner.Runnable('tap', '/bin/sh', tap_path)
-        runner = nrunner_tap.TAPRunner(runnable)
+        runner = runner_tap.TAPRunner(runnable)
         results = [status for status in runner.run()]
         last_result = results[-1]
         self.assertEqual(last_result['status'], 'finished')
@@ -348,7 +349,7 @@ echo 'ok 2 - description 2'"""
             fp.write(tap_script)
 
         runnable = nrunner.Runnable('tap', '/bin/sh', tap_path)
-        runner = nrunner_tap.TAPRunner(runnable)
+        runner = runner_tap.TAPRunner(runnable)
         results = [status for status in runner.run()]
         last_result = results[-1]
         self.assertEqual(last_result['status'], 'finished')
@@ -368,7 +369,7 @@ echo 'ok 2 - description 2'"""
             fp.write(tap_script)
 
         runnable = nrunner.Runnable('tap', '/bin/sh', tap_path)
-        runner = nrunner_tap.TAPRunner(runnable)
+        runner = runner_tap.TAPRunner(runnable)
         results = [status for status in runner.run()]
         last_result = results[-1]
         self.assertEqual(last_result['status'], 'finished')
@@ -388,7 +389,7 @@ echo 'ok 2 - description 2'"""
             fp.write(tap_script)
 
         runnable = nrunner.Runnable('tap', '/bin/sh', tap_path)
-        runner = nrunner_tap.TAPRunner(runnable)
+        runner = runner_tap.TAPRunner(runnable)
         results = [status for status in runner.run()]
         last_result = results[-1]
         self.assertEqual(last_result['status'], 'finished')
@@ -408,7 +409,7 @@ echo 'ok 2 - description 2'"""
             fp.write(tap_script)
 
         runnable = nrunner.Runnable('tap', '/bin/sh', tap_path)
-        runner = nrunner_tap.TAPRunner(runnable)
+        runner = runner_tap.TAPRunner(runnable)
         results = [status for status in runner.run()]
         last_result = results[-1]
         self.assertEqual(last_result['status'], 'finished')

--- a/setup.py
+++ b/setup.py
@@ -99,8 +99,8 @@ if __name__ == '__main__':
                   'avocado-runner-exec = avocado.core.nrunner:main',
                   'avocado-runner-exec-test = avocado.core.nrunner:main',
                   'avocado-runner-python-unittest = avocado.core.nrunner:main',
-                  'avocado-runner-avocado-instrumented = avocado.core.nrunner_avocado_instrumented:main',
-                  'avocado-runner-tap = avocado.core.nrunner_tap:main',
+                  'avocado-runner-avocado-instrumented = avocado.core.runners.avocado_instrumented:main',
+                  'avocado-runner-tap = avocado.core.runners.tap:main',
                   'avocado-software-manager = avocado.utils.software_manager.main:main',
                   ],
               "avocado.plugins.init": [
@@ -178,8 +178,8 @@ if __name__ == '__main__':
                   ],
               'avocado.plugins.runnable.runner': [
                   ('avocado-instrumented = avocado.core.'
-                   'nrunner_avocado_instrumented:AvocadoInstrumentedTestRunner'),
-                  'tap = avocado.core.nrunner_tap:TAPRunner',
+                   'runners.avocado_instrumented:AvocadoInstrumentedTestRunner'),
+                  'tap = avocado.core.runners.tap:TAPRunner',
                   ],
               'avocado.plugins.spawner': [
                   'process = avocado.plugins.spawners.process:ProcessSpawner',


### PR DESCRIPTION
With the possibility of having new runners added to the nrunner architecture, let's move the standalone runners to a specific directory, just like the spawners' structure.

Signed-off-by: Willian Rampazzo <willianr@redhat.com>