### PR TITLE
Skip* Decorators: allow the conditional to be a callable

### DIFF
--- a/avocado/core/decorators.py
+++ b/avocado/core/decorators.py
@@ -89,19 +89,25 @@ def _skip_class_decorator(cls, message):
     return cls
 
 
-def skip(message=None):
-    """
-    Decorator to skip a test.
-
-    :param message: the message given when the test is skipped
-    :type message: str
-    """
+def _get_skip_method_or_class_decorator(message):
+    """Returns a method or class decorator, according to decorated type."""
     def decorator(obj):
         if isinstance(obj, type):
             return _skip_class_decorator(obj, message)
         else:
             return _skip_method_decorator(obj, message)
     return decorator
+
+
+def skip(message=None):
+    """
+    Decorator to skip a test.
+
+    :param message: the message given when the test is skipped
+    :type message: str
+
+    """
+    return _get_skip_method_or_class_decorator(message)
 
 
 def skipIf(condition, message=None):

--- a/avocado/core/decorators.py
+++ b/avocado/core/decorators.py
@@ -72,6 +72,9 @@ cancel_on = deco_factory("cancel", core_exceptions.TestCancel)
 def skip(message=None):
     """
     Decorator to skip a test.
+
+    :param message: the message given when the test is skipped
+    :type message: str
     """
     def decorator(obj):
         def method_decorator(function):
@@ -100,6 +103,11 @@ def skip(message=None):
 def skipIf(condition, message=None):
     """
     Decorator to skip a test if a condition is True.
+
+    :param condition: a condition that will be evaluated as either True or False
+    :type condition: bool
+    :param message: the message given when the test is skipped
+    :type message: str
     """
     if condition:
         return skip(message)
@@ -109,6 +117,11 @@ def skipIf(condition, message=None):
 def skipUnless(condition, message=None):
     """
     Decorator to skip a test if a condition is False.
+
+    :param condition: a condition that will be evaluated as either True or False
+    :type condition: bool
+    :param message: the message given when the test is skipped
+    :type message: str
     """
     if not condition:
         return skip(message)

--- a/avocado/core/decorators.py
+++ b/avocado/core/decorators.py
@@ -88,7 +88,7 @@ def skip(message=None):
 
         def class_decorator(cls):
             for key in cls.__dict__:
-                if callable(getattr(cls, key)):
+                if key.startswith('test') and callable(getattr(cls, key)):
                     wrapped = method_decorator(getattr(cls, key))
                     setattr(cls, key, wrapped)
             return cls

--- a/avocado/core/decorators.py
+++ b/avocado/core/decorators.py
@@ -74,9 +74,8 @@ def _skip_method_decorator(function, message):
     @wraps(function)
     def wrapper(*args, **kwargs):  # pylint: disable=W0613
         raise core_exceptions.TestSkipError(message)
-        function = wrapper
-    function.__skip_test_decorator__ = True
-    return function
+    wrapper.__skip_test_decorator__ = True
+    return wrapper
 
 
 def _skip_class_decorator(cls, message):

--- a/avocado/core/decorators.py
+++ b/avocado/core/decorators.py
@@ -71,10 +71,9 @@ cancel_on = deco_factory("cancel", core_exceptions.TestCancel)
 
 def _skip_method_decorator(function, message):
     """Creates a skip decorator for a method."""
-    if not isinstance(function, type):
-        @wraps(function)
-        def wrapper(*args, **kwargs):  # pylint: disable=W0613
-            raise core_exceptions.TestSkipError(message)
+    @wraps(function)
+    def wrapper(*args, **kwargs):  # pylint: disable=W0613
+        raise core_exceptions.TestSkipError(message)
         function = wrapper
     function.__skip_test_decorator__ = True
     return function

--- a/docs/source/guides/writer/chapters/writing.rst
+++ b/docs/source/guides/writer/chapters/writing.rst
@@ -1075,6 +1075,39 @@ the  ``setUp()`` method, the test method and the ``tearDown()`` method.
           ``ERROR``, to use any of the skip decorators on the
           ``tearDown()`` method.
 
+Advanced Conditionals
+~~~~~~~~~~~~~~~~~~~~~
+
+More advanced use cases may require to evaluate the condition for
+skipping tests later, and may also need to introspect into the
+class that contains the test method in question.
+
+It's possible to achieve both by supplying a callable to the condition
+parameters instead.  The following example does just that:
+
+.. literalinclude:: ../../../../../examples/tests/skip_conditional.py
+
+Even though the conditions for skipping tests are defined in the
+``BaseTest`` class, the conditions will be evaluated when the tests
+are actually checked for execution, in the ``BareMetal`` and
+``NonBareMetal`` classes.  The result of running that test is::
+
+    JOB ID     : 77d636c93ed3b5e6fef9c7b6c8d9fe0c84af1518
+    JOB LOG    : $HOME/avocado/job-results/job-2021-03-17T20.10-77d636c/job.log
+     (01/10) skip_conditional.py:BareMetal.test_specific: PASS (0.00 s)
+     (02/10) skip_conditional.py:BareMetal.test_bare_metal: PASS (0.00 s)
+     (03/10) skip_conditional.py:BareMetal.test_large_memory: SKIP: Not enough memory for test
+     (04/10) skip_conditional.py:BareMetal.test_nested_virtualization: SKIP: Virtual Machine environment is required
+     (05/10) skip_conditional.py:BareMetal.test_container: SKIP: Container environment is required
+     (06/10) skip_conditional.py:NonBareMetal.test_specific: PASS (0.00 s)
+     (07/10) skip_conditional.py:NonBareMetal.test_bare_metal: SKIP: Bare metal environment is required
+     (08/10) skip_conditional.py:NonBareMetal.test_large_memory: SKIP: Not enough memory for test
+     (09/10) skip_conditional.py:NonBareMetal.test_nested_virtualization: PASS (0.00 s)
+     (10/10) skip_conditional.py:NonBareMetal.test_container: PASS (0.00 s)
+    RESULTS    : PASS 5 | ERROR 0 | FAIL 0 | SKIP 5 | WARN 0 | INTERRUPT 0 | CANCEL 0
+    JOB HTML   : $HOME/avocado/job-results/job-2021-03-17T20.10-77d636c/results.html
+    JOB TIME   : 0.82 s
+
 Canceling Tests
 ----------------
 

--- a/docs/source/guides/writer/chapters/writing.rst
+++ b/docs/source/guides/writer/chapters/writing.rst
@@ -1069,7 +1069,7 @@ Notice the ``test3`` was not skipped because the provided condition was
 not ``False``.
 
 Using the skip decorators, nothing is actually executed. We will skip
-the  `setUp()` method, the test method and the `tearDown()` method.
+the  ``setUp()`` method, the test method and the ``tearDown()`` method.
 
 .. note:: It's an erroneous condition, reported with test status
           ``ERROR``, to use any of the skip decorators on the

--- a/docs/source/guides/writer/chapters/writing.rst
+++ b/docs/source/guides/writer/chapters/writing.rst
@@ -1030,11 +1030,9 @@ Skipping Tests
 To skip tests is in Avocado, you must use one of the Avocado skip
 decorators:
 
-- ``@avocado.skip(reason)``: Skips a test.
-- ``@avocado.skipIf(condition, reason)``: Skips a test if the condition is
-  ``True``.
-- ``@avocado.skipUnless(condition, reason)``: Skips a test if the condition is
-  ``False``
+- :func:`avocado.skip`: Skips a test.
+- :func:`avocado.skipIf`: Skips a test if the condition is ``True``.
+- :func:`avocado.skipUnless`: Skips a test if the condition is ``False``
 
 Those decorators can be used with classes and both ``setUp()`` method and/or and in the
 ``test*()`` methods. The test below::

--- a/examples/tests/skip_conditional.py
+++ b/examples/tests/skip_conditional.py
@@ -1,0 +1,47 @@
+from avocado import Test, skipIf, skipUnless
+
+
+class BaseTest(Test):
+    """Base class for tests
+
+    :avocado: disable
+    """
+
+    SUPPORTED_ENVS = []
+
+    @skipUnless(lambda x: 'BARE_METAL' in x.SUPPORTED_ENVS,
+                'Bare metal environment is required')
+    def test_bare_metal(self):
+        pass
+
+    @skipIf(lambda x: getattr(x, 'MEMORY', 0) < 4096,
+            'Not enough memory for test')
+    def test_large_memory(self):
+        pass
+
+    @skipUnless(lambda x: 'VIRTUAL_MACHINE' in x.SUPPORTED_ENVS,
+                'Virtual Machine environment is required')
+    def test_nested_virtualization(self):
+        pass
+
+    @skipUnless(lambda x: 'CONTAINER' in x.SUPPORTED_ENVS,
+                'Container environment is required')
+    def test_container(self):
+        pass
+
+
+class BareMetal(BaseTest):
+
+    SUPPORTED_ENVS = ['BARE_METAL']
+    MEMORY = 2048
+
+    def test_specific(self):
+        pass
+
+
+class NonBareMetal(BaseTest):
+
+    SUPPORTED_ENVS = ['VIRTUAL_MACHINE', 'CONTAINER']
+
+    def test_specific(self):
+        pass

--- a/selftests/functional/test_skiptests.py
+++ b/selftests/functional/test_skiptests.py
@@ -62,7 +62,7 @@ AVOCADO_TEST_SKIP_IF_CLASS_DECORATORS = """
 import avocado
 from lib_skip_decorators import check_condition
 @avocado.skipIf(check_condition(True),
-                    'Skipped due to the True condition')
+                'Skipped due to the True condition')
 class AvocadoSkipTests(avocado.Test):
 
     def setUp(self):
@@ -81,7 +81,7 @@ class AvocadoSkipTests(avocado.Test):
         self.log.info('teardown executed')
 
 @avocado.skipIf(check_condition(False),
-                    'Skipped due to the True condition')
+                'Skipped due to the True condition')
 class AvocadoNoSkipTests(avocado.Test):
 
     def setUp(self):

--- a/selftests/functional/test_skiptests.py
+++ b/selftests/functional/test_skiptests.py
@@ -13,6 +13,9 @@ from lib_skip_decorators import check_condition
 
 class AvocadoSkipTests(avocado.Test):
 
+    TRUE_CONDITION = True
+    FALSE_CONDITION = False
+
     def setUp(self):
         self.log.info('setup executed')
 
@@ -28,6 +31,16 @@ class AvocadoSkipTests(avocado.Test):
     @avocado.skipUnless(check_condition(False),
                         'Skipped due to the False condition')
     def test3(self):
+        self.log.info('test executed')
+
+    @avocado.skipIf(lambda x: x.TRUE_CONDITION,
+                    'Skipped due to the True condition')
+    def test4(self):
+        self.log.info('test executed')
+
+    @avocado.skipUnless(lambda x: x.FALSE_CONDITION,
+                        'Skipped due to the False condition')
+    def test5(self):
         self.log.info('test executed')
 
     def tearDown(self):
@@ -237,7 +250,7 @@ class TestSkipDecorators(TestCaseTmpDir):
         debuglog = json_results['debuglog']
 
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
-        self.assertEqual(json_results['skip'], 3)
+        self.assertEqual(json_results['skip'], 5)
         debuglog_contents = genio.read_file(debuglog)
         self.assertFalse('setup executed' in debuglog_contents)
         self.assertFalse('test executed' in debuglog_contents)


### PR DESCRIPTION
The `sosreport` project needs to evaluate the conditions for skipping tests based on properties of the classes that contain them.  That is a valid use case, so this implements such a feature, up until now missing from Avocado's `skipIf` and `skipUnless` decorators.

The PR that contains their custom `skipIf` decorator can be found at: https://github.com/sosreport/sos/pull/2431