### PR TITLE
Cirrus CI: run selftests on Fedora

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -22,7 +22,7 @@ debian_version_task:
           - image: ubuntu:18.04
           - image: ubuntu:20.04
 
-windows_version_task:
+windows_smokecheck_task:
     version_script:
        - choco install -y python3 --version 3.9.0
        - C:\Python39\python setup.py develop --user

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -30,3 +30,12 @@ windows_version_task:
        - C:\Python39\python -m avocado run --test-runner=nrunner examples\tests\passtest.py
     windows_container:
        image: cirrusci/windowsservercore:2019
+
+fedora_selftests_task:
+    selftests_script:
+       - make develop
+       - PATH=$HOME/.local/bin:$PATH LANG=en_US.UTF-8 AVOCADO_CHECK_LEVEL=0 python3 selftests/check.py --disable-static-checks
+    container:
+        matrix:
+          - image: quay.io/avocado-framework/avocado-ci-fedora-32
+          - image: quay.io/avocado-framework/avocado-ci-fedora-33

--- a/contrib/containers/ci/selftests/fedora-32.docker
+++ b/contrib/containers/ci/selftests/fedora-32.docker
@@ -1,0 +1,6 @@
+FROM fedora:32
+LABEL description "Fedora image used on integration checks, such as cirrus-ci"
+RUN dnf -y module enable avocado:latest
+RUN dnf -y install dnf-plugins-core git findutils make which
+RUN dnf -y builddep python-avocado
+RUN dnf -y clean all

--- a/contrib/containers/ci/selftests/fedora-33.docker
+++ b/contrib/containers/ci/selftests/fedora-33.docker
@@ -1,0 +1,6 @@
+FROM fedora:33
+LABEL description "Fedora image used on integration checks, such as cirrus-ci"
+RUN dnf -y module enable avocado:latest
+RUN dnf -y install dnf-plugins-core git findutils make which
+RUN dnf -y builddep python-avocado
+RUN dnf -y clean all

--- a/selftests/unit/test_utils_iso9660.py
+++ b/selftests/unit/test_utils_iso9660.py
@@ -73,6 +73,8 @@ class BaseIso9660:
 
     @unittest.skipIf(not process.can_sudo("mount"),
                      "This test requires mount to run under sudo or root")
+    @unittest.skipUnless(process.has_capability("cap_sys_admin"),
+                         "Capability to mount is required (cap_sys_admin)")
     @unittest.skipIf(os.getenv('TRAVIS') and
                      os.getenv('TRAVIS_CPU_ARCH') in ['arm64', 'ppc64le', 's390x'],
                      'TRAVIS Environment is unsuitable for these tests')
@@ -132,6 +134,8 @@ class IsoMount(BaseIso9660, unittest.TestCase):
 
     @unittest.skipIf(not process.can_sudo("mount"),
                      "This test requires sudo or root")
+    @unittest.skipUnless(process.has_capability("cap_sys_admin"),
+                         "Capability to mount is required (cap_sys_admin)")
     @unittest.skipIf(os.getenv('TRAVIS') and
                      os.getenv('TRAVIS_CPU_ARCH') in ['arm64', 'ppc64le', 's390x'],
                      'TRAVIS Environment is unsuitable for these tests')

--- a/selftests/unit/test_utils_network.py
+++ b/selftests/unit/test_utils_network.py
@@ -47,6 +47,10 @@ def get_all_local_addrs():
                        for _ in ifaddresses.get(netifaces.AF_INET, [])]
         ipv6_addrs += [_['addr']
                        for _ in ifaddresses.get(netifaces.AF_INET6, [])]
+    if ipv4_addrs:
+        ipv4_addrs += ["localhost", ""]
+    if ipv6_addrs:
+        ipv6_addrs += ["localhost", ""]
     return ipv4_addrs, ipv6_addrs
 
 
@@ -57,9 +61,7 @@ class FreePort(unittest.TestCase):
     def test_is_port_free(self):
         port = ports.find_free_port(sequent=False)
         self.assertTrue(ports.is_port_free(port, "localhost"))
-        local_addrs = get_all_local_addrs()
-        ipv4_addrs = ["localhost", ""] + list(local_addrs[0])
-        ipv6_addrs = ["localhost", ""] + list(local_addrs[1])
+        ipv4_addrs, ipv6_addrs = get_all_local_addrs()
         good = []
         bad = []
         skip = []

--- a/selftests/unit/test_utils_partition.py
+++ b/selftests/unit/test_utils_partition.py
@@ -37,6 +37,8 @@ class Base(unittest.TestCase):
     @unittest.skipIf(not process.can_sudo('mkfs.ext2 -V'),
                      'current user must be allowed to run "mkfs.ext2" under '
                      'sudo')
+    @unittest.skipUnless(utils_path.find_command('mkfs.ext2', False),
+                         'mkfs.ext2 utility must be available')
     @unittest.skipIf(os.getenv('TRAVIS') and
                      os.getenv('TRAVIS_CPU_ARCH') in ['arm64', 'ppc64le', 's390x'],
                      'TRAVIS Environment is unsuitable for these tests')

--- a/selftests/unit/test_utils_partition.py
+++ b/selftests/unit/test_utils_partition.py
@@ -39,6 +39,8 @@ class Base(unittest.TestCase):
                      'sudo')
     @unittest.skipUnless(utils_path.find_command('mkfs.ext2', False),
                          'mkfs.ext2 utility must be available')
+    @unittest.skipUnless(process.has_capability("cap_sys_admin"),
+                         "Capability to mount is required (cap_sys_admin)")
     @unittest.skipIf(os.getenv('TRAVIS') and
                      os.getenv('TRAVIS_CPU_ARCH') in ['arm64', 'ppc64le', 's390x'],
                      'TRAVIS Environment is unsuitable for these tests')

--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -671,5 +671,50 @@ class GetCommandOutputPattern(unittest.TestCase):
         self.assertEqual(res, [])
 
 
+class GetCapabilities(unittest.TestCase):
+
+    def test_get_capabilities(self):
+        stdout = b"""1: cap_chown,cap_dac_override,cap_fowner,cap_fsetid,cap_kill,cap_setgid,cap_setuid,cap_setpcap,cap_net_bind_service,cap_net_raw,cap_sys_chroot,cap_mknod,cap_audit_write,cap_setfcap=eip"""
+        cmd_result = process.CmdResult(stdout=stdout, exit_status=0)
+        expected = ['cap_chown', 'cap_dac_override', 'cap_fowner',
+                    'cap_fsetid', 'cap_kill', 'cap_setgid', 'cap_setuid',
+                    'cap_setpcap', 'cap_net_bind_service', 'cap_net_raw',
+                    'cap_sys_chroot', 'cap_mknod', 'cap_audit_write',
+                    'cap_setfcap=eip']
+        with unittest.mock.patch('avocado.utils.process.run',
+                                 return_value=cmd_result):
+            capabilities = process.get_capabilities()
+        self.assertEqual(capabilities, expected)
+
+    def test_get_capabilities_legacy(self):
+        stderr = b"""Capabilities for `3114520': = cap_chown,cap_dac_override,cap_dac_read_search,cap_fowner,cap_fsetid,cap_kill,cap_setgid,cap_setuid,cap_setpcap,cap_linux_immutable,cap_net_bind_service,cap_net_broadcast,cap_net_admin,cap_net_raw,cap_ipc_lock,cap_ipc_owner,cap_sys_module,cap_sys_rawio,cap_sys_chroot,cap_sys_ptrace,cap_sys_pacct,cap_sys_admin,cap_sys_boot,cap_sys_nice,cap_sys_resource,cap_sys_time,cap_sys_tty_config,cap_mknod,cap_lease,cap_audit_write,cap_audit_control,cap_setfcap,cap_mac_override,cap_mac_admin,cap_syslog,cap_wake_alarm,cap_block_suspend,cap_audit_read,38,39+ep"""
+        cmd_result = process.CmdResult(stderr=stderr, exit_status=0)
+        expected = ['cap_chown', 'cap_dac_override', 'cap_dac_read_search',
+                    'cap_fowner', 'cap_fsetid', 'cap_kill', 'cap_setgid',
+                    'cap_setuid', 'cap_setpcap', 'cap_linux_immutable',
+                    'cap_net_bind_service', 'cap_net_broadcast',
+                    'cap_net_admin', 'cap_net_raw', 'cap_ipc_lock',
+                    'cap_ipc_owner', 'cap_sys_module', 'cap_sys_rawio',
+                    'cap_sys_chroot', 'cap_sys_ptrace', 'cap_sys_pacct',
+                    'cap_sys_admin', 'cap_sys_boot', 'cap_sys_nice',
+                    'cap_sys_resource', 'cap_sys_time', 'cap_sys_tty_config',
+                    'cap_mknod', 'cap_lease', 'cap_audit_write',
+                    'cap_audit_control', 'cap_setfcap', 'cap_mac_override',
+                    'cap_mac_admin', 'cap_syslog', 'cap_wake_alarm',
+                    'cap_block_suspend', 'cap_audit_read', '38', '39+ep']
+        with unittest.mock.patch('avocado.utils.process.run',
+                                 return_value=cmd_result):
+            capabilities = process.get_capabilities()
+        self.assertEqual(capabilities, expected)
+
+    def test_failure_no_capabilities(self):
+        stdout = b"1: cap_chown,cap_dac_override"
+        cmd_result = process.CmdResult(stdout=stdout, exit_status=1)
+        with unittest.mock.patch('avocado.utils.process.run',
+                                 return_value=cmd_result):
+            capabilities = process.get_capabilities()
+        self.assertEqual(capabilities, [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/selftests/unit/test_utils_process.py
+++ b/selftests/unit/test_utils_process.py
@@ -356,7 +356,7 @@ class MiscProcessTests(unittest.TestCase):
         '''
         Gets the list of children process.  Linux only.
         '''
-        self.assertGreaterEqual(len(process.get_children_pids(1)), 1)
+        self.assertGreaterEqual(len(process.get_children_pids(os.getppid())), 1)
 
     @unittest.mock.patch('avocado.utils.process.os.kill')
     @unittest.mock.patch('avocado.utils.process.get_owner_id')

--- a/spell.ignore
+++ b/spell.ignore
@@ -739,3 +739,5 @@ emerg
 alert
 crit
 err
+getpcaps
+libcap


### PR DESCRIPTION
The tasks introduce here make use of the build requirements (most for running the selftests) that are already coded in the Fedora upstream packages.
    
Then, it installs those dependencies and sets up a development environment and runs the tests. This should be very similar to the steps that a new Avocado developer on a Fedora distro would go through.

In my observation, the overall jobs finish ~40% quicker than the Travis CI counterparts. 