### PR TITLE
Suite: replace Tasks for Runnables

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -42,12 +42,12 @@ RUNNERS_REGISTRY_STANDALONE_EXECUTABLE = {}
 RUNNERS_REGISTRY_PYTHON_CLASS = {}
 
 
-def check_tasks_requirements(tasks, runners_registry=None):
+def check_runnables_requirements(runnables, runners_registry=None):
     """
-    Checks if tasks have runner requirements fulfilled
+    Checks if runnables have runner requirements fulfilled
 
-    :param tasks: the tasks whose runner requirements will be checked
-    :type tasks: list of :class:`Task`
+    :param runnables: the tasks whose runner requirements will be checked
+    :type runnable: list of :class:`Runnable`
     :param runners_registry: a registry with previously found (and not found)
                              runners keyed by a task's runnable kind. Defaults
                              to :attr:`RUNNERS_REGISTRY_STANDALONE_EXECUTABLE`
@@ -61,12 +61,13 @@ def check_tasks_requirements(tasks, runners_registry=None):
         runners_registry = RUNNERS_REGISTRY_STANDALONE_EXECUTABLE
     ok = []
     missing = []
-    for task in tasks:
-        runner = task.runnable.pick_runner_command(runners_registry)
+
+    for runnable in runnables:
+        runner = runnable.pick_runner_command(runners_registry)
         if runner:
-            ok.append(task)
+            ok.append(runnable)
         else:
-            missing.append(task)
+            missing.append(runnable)
     return (ok, missing)
 
 

--- a/avocado/core/utils.py
+++ b/avocado/core/utils.py
@@ -3,9 +3,6 @@ import os
 from pkg_resources import get_distribution
 
 from ..utils import path, process
-from .nrunner import Task
-from .resolver import ReferenceResolutionResult
-from .tags import filter_test_tags_runnable
 
 
 def get_avocado_git_version():
@@ -37,72 +34,3 @@ def prepend_base_path(value):
         dist = get_distribution('avocado-framework')
         return os.path.join(dist.location, 'avocado', expanded)
     return expanded
-
-
-def resolution_to_filtered_runnables(resolutions, config):
-    """
-    Transforms resolver resolutions into a list of filtered runnables
-
-    A resolver resolution
-    (:class:`avocado.core.resolver.ReferenceResolution`) contains
-    information about the resolution process (if it was successful
-    or not) and in case of successful resolutions a list of
-    resolutions.  It's expected that the resolution contain one
-    or more :class:`avocado.core.nrunner.Runnable`.
-
-    This method also performs tag based filtering on the runnables for
-    possibly excluding some of the Runnables.
-
-    :param resolutions: possible multiple resolutions for multiple
-                        references
-    :type resolutions: list of :class:`avocado.core.resolver.ReferenceResolution`
-    :param config: job configuration
-    :type config: dict
-    :returns: the resolutions converted to tasks
-    :rtype: list of :class:`avocado.core.nrunner.Task`
-    """
-    result = []
-    filter_by_tags = config.get("filter.by_tags.tags")
-    include_empty = config.get("filter.by_tags.include_empty")
-    include_empty_key = config.get('filter.by_tags.include_empty_key')
-    for resolution in resolutions:
-        if resolution.result != ReferenceResolutionResult.SUCCESS:
-            continue
-        for runnable in resolution.resolutions:
-            if filter_by_tags:
-                if not filter_test_tags_runnable(runnable,
-                                                 filter_by_tags,
-                                                 include_empty,
-                                                 include_empty_key):
-                    continue
-            result.append(runnable)
-    return result
-
-
-def resolutions_to_tasks(resolutions, config):
-    """
-    Transforms resolver resolutions into tasks
-
-    A resolver resolution
-    (:class:`avocado.core.resolver.ReferenceResolution`) contains
-    information about the resolution process (if it was successful
-    or not) and in case of successful resolutions a list of
-    resolutions.  It's expected that the resolution contain one
-    or more :class:`avocado.core.nrunner.Runnable`.
-
-    This method transforms those runnables into Tasks
-    (:class:`avocado.core.nrunner.Task`), which will include a status
-    reporting URI.  It also performs tag based filtering on the
-    runnables for possibly excluding some of the Runnables.
-
-    :param resolutions: possible multiple resolutions for multiple
-                        references
-    :type resolutions: list of :class:`avocado.core.resolver.ReferenceResolution`
-    :param config: job configuration
-    :type config: dict
-    :returns: the resolutions converted to tasks
-    :rtype: list of :class:`avocado.core.nrunner.Task`
-    """
-    status_server = config.get('nrunner.status_server_uri')
-    return [Task(runnable, status_uris=[status_server]) for runnable in
-            resolution_to_filtered_runnables(resolutions, config)]

--- a/avocado/core/utils.py
+++ b/avocado/core/utils.py
@@ -47,8 +47,8 @@ def resolutions_to_tasks(resolutions, config):
     (:class:`avocado.core.resolver.ReferenceResolution`) contains
     information about the resolution process (if it was successful
     or not) and in case of successful resolutions a list of
-    resolutions.  It's expected that the resolution are
-    :class:`avocado.core.nrunner.Runnable`.
+    resolutions.  It's expected that the resolution contain one
+    or more :class:`avocado.core.nrunner.Runnable`.
 
     This method transforms those runnables into Tasks
     (:class:`avocado.core.nrunner.Task`), which will include a status

--- a/avocado/plugins/list.py
+++ b/avocado/plugins/list.py
@@ -129,9 +129,7 @@ class List(CLICmd):
         """Used for resolver."""
         test_matrix = []
         verbose = suite.config.get('core.verbose')
-        for test in suite.tests:
-            runnable = test.runnable
-
+        for runnable in suite.tests:
             type_label = TERM_SUPPORT.healthy_str(runnable.kind)
 
             if verbose:

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -181,18 +181,19 @@ class Runner(RunnerInterface):
     def _get_all_runtime_tasks(self, test_suite):
         result = []
         no_digits = len(str(len(test_suite)))
-        for index, task in enumerate(test_suite.tests, start=1):
-            task.known_runners = nrunner.RUNNERS_REGISTRY_PYTHON_CLASS
+        status_uris = [test_suite.config.get('nrunner.status_server_uri')]
+        for index, runnable in enumerate(test_suite.tests, start=1):
             # this is all rubbish data
             if test_suite.name:
                 prefix = "{}-{}".format(test_suite.name, index)
             else:
                 prefix = index
             test_id = TestID(prefix,
-                             task.runnable.uri,
+                             runnable.uri,
                              None,
                              no_digits)
-            task.identifier = test_id
+            task = nrunner.Task(runnable, test_id, status_uris,
+                                nrunner.RUNNERS_REGISTRY_PYTHON_CLASS)
             result.append(RuntimeTask(task))
         return result
 
@@ -260,7 +261,7 @@ class Runner(RunnerInterface):
         # pylint: disable=W0201
         self.summary = set()
 
-        test_suite.tests, _ = nrunner.check_tasks_requirements(test_suite.tests)
+        test_suite.tests, _ = nrunner.check_runnables_requirements(test_suite.tests)
         job.result.tests_total = test_suite.size  # no support for variants yet
 
         listen = test_suite.config.get('nrunner.status_server_listen')

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -339,7 +339,7 @@ class JobTest(unittest.TestCase):
         self.job.setup()
         self.assertEqual(len(simple_tests_found), len(self.job.test_suite))
         if self.job.test_suite:
-            self.assertIsInstance(self.job.test_suite.tests[0], nrunner.Task)
+            self.assertIsInstance(self.job.test_suite.tests[0], nrunner.Runnable)
 
     def test_job_get_failed_tests(self):
         config = {'run.references': ['/bin/true', '/bin/false'],


### PR DESCRIPTION
A Runnable is meant to contain all descriptive information about what is to be run, while a Task is supposed to contain information that is needed at run time while executing a runnable within the context of a job (and its status server).
    
This change will keep Runnables in the test suite (which are simpler) and will create the Tasks once they are about to be handed for execution in a job.
    
This also solves the dilemma of changing a Task identifier, which was not really a problem with the Tasks, but a problem caused by    them being created way too earlier than necessary