### PR TITLE
[PoC] Nrunner comunication

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -677,6 +677,7 @@ class Task:
         self.known_runners = known_runners
         self.spawn_handle = None
         self.output_dir = None
+        self.data = {}
 
     def __repr__(self):
         fmt = '<Task identifier="{}" runnable="{}" status_services="{}"'

--- a/avocado/core/status/repo.py
+++ b/avocado/core/status/repo.py
@@ -52,9 +52,13 @@ class StatusRepo:
             self._all_data[task_id] = []
         self._all_data[task_id].append(message)
 
-    def get_task_data(self, task_id):
+    def get_all_task_data(self, task_id):
         """Returns all data on a given task, by its ID."""
         return self._all_data.get(task_id)
+
+    def get_task_data(self, task_id, index):
+        """Returns data on a given task, by its ID."""
+        return self._all_data.get(task_id)[index]
 
     def get_latest_task_data(self, task_id):
         """Returns the latest data on a given task, by its ID."""
@@ -72,12 +76,13 @@ class StatusRepo:
             return
         if task_id not in self._status:
             self._status[task_id] = (status, time)
-            self._status_journal_summary.append((task_id, status, time))
+            self._status_journal_summary.append((task_id, status, time, 0))
         else:
-            current_status, current_time = self._status[task_id]
-            # journal even with the same time, if there's a change in status
-            if (status != current_status) and (time >= current_time):
-                self._status_journal_summary.append((task_id, status, time))
+            _, current_time = self._status[task_id]
+            if time >= current_time:
+                index = len(self.get_all_task_data(task_id))
+                self._status_journal_summary.append((task_id, status, time,
+                                                     index))
             if time > current_time:
                 self._status[task_id] = (status, time)
 

--- a/avocado/plugins/messages.py
+++ b/avocado/plugins/messages.py
@@ -1,0 +1,123 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2021
+# Authors: Jan Richter <jarichte@redhat.com>
+
+"""
+Message resolver for runner messages
+"""
+
+import abc
+import os
+
+
+class MessageProcessor:
+    """Entry point for handling all types of messages"""
+
+    def __init__(self):
+        self._handlers = [StartMessageHandler(),
+                          RunningMessageProcessor(),
+                          FinishMessageHandler()]
+
+    def process_message(self, message, task, job):
+        for handler in self._handlers:
+            if handler.handle(message, task, job):
+                break
+
+
+class MessageHandler(metaclass=abc.ABCMeta):
+    """Base interface for resolving runner messages.
+
+    This is the interface a job uses to deal with messages form runners.
+    """
+
+    @abc.abstractmethod
+    def handle(self, message, task, job):
+        """Handle message from runner.
+
+        :param message: message from runner.
+        :type message: dict
+        :param task: runtime_task which message is related to
+        :type task: :class:`avocado.core.nrunner.Task`
+        :param job: job which task is related to
+        :type job: :class: `avocado.core.job.Job`
+        """
+
+
+class StartMessageHandler(MessageHandler):
+
+    def handle(self, message, task, job):
+        if message['status'] == 'started':
+            base_path = os.path.join(job.logdir, 'test-results')
+            task_path = os.path.join(base_path, task.identifier.str_filesystem)
+            os.makedirs(task_path, exist_ok=True)
+            early_state = {'name': task.identifier, 'job_logdir': job.logdir,
+                           'job_unique_id': job.unique_id,
+                           'base_path': base_path, 'task_path': task_path,
+                           'time_start': message['time']}
+            job.result.start_test(early_state)
+            job.result_events_dispatcher.map_method('start_test', job.result,
+                                                    early_state)
+            task.data.update(early_state)
+            return True
+        return False
+
+
+class FinishMessageHandler(MessageHandler):
+
+    def handle(self, message, task, job):
+        if message['status'] == 'finished':
+            message.update(task.data)
+            message['status'] = message.get('result').upper()
+
+            time_start = message['time_start']
+            time_end = message['time']
+            time_elapsed = time_end - time_start
+            message['time_end'] = time_end
+            message['time_elapsed'] = time_elapsed
+
+            # fake log dir, needed by some result plugins such as HTML
+            if 'logdir' not in message:
+                message['logdir'] = ''
+
+            job.result.check_test(message)
+            job.result_events_dispatcher.map_method('end_test',
+                                                    job.result,
+                                                    message)
+            return True
+        return False
+
+
+class RunningMessageProcessor(MessageHandler):
+
+    def __init__(self):
+        self._running_handlers = [LogMessageHandler()]
+
+    def handle(self, message, task, job):
+        if message['status'] == 'running':
+            for handler in self._running_handlers:
+                if handler.handle(message, task, job):
+                    break
+            return True
+        return False
+
+
+class LogMessageHandler(MessageHandler):
+
+    def handle(self, message, task, job):
+        if message.get('type', None) == 'log':
+            task_path = task.data['task_path']
+            debug = os.path.join(task_path, 'debug.log')
+            with open(debug, 'a') as fp:
+                fp.write("%s\n" % message['log'])
+            return True
+        return False

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -210,7 +210,7 @@ class Runner(RunnerInterface):
                        for runtime_task in self.tasks}
         while True:
             try:
-                (task_id, status, _) = self.status_repo.status_journal_summary.pop(0)
+                (task_id, status, _, _) = self.status_repo.status_journal_summary.pop(0)
 
             except IndexError:
                 await asyncio.sleep(0.05)
@@ -226,7 +226,7 @@ class Runner(RunnerInterface):
                                                         job.result,
                                                         early_state)
             elif status == 'finished':
-                this_task_data = self.status_repo.get_task_data(task_id)
+                this_task_data = self.status_repo.get_all_task_data(task_id)
                 last_task_status = this_task_data[-1]
                 test_state = last_task_status.copy()
                 test_state['status'] = last_task_status.get('result').upper()

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -33,7 +33,7 @@ from avocado.core.status.server import StatusServer
 from avocado.core.task.runtime import RuntimeTask
 from avocado.core.task.statemachine import TaskStateMachine, Worker
 from avocado.core.test_id import TestID
-from avocado.core.teststatus import mapping
+from avocado.plugins.messages import MessageProcessor
 
 
 class RunnerInit(Init):
@@ -208,54 +208,19 @@ class Runner(RunnerInterface):
     async def _update_status(self, job):
         tasks_by_id = {str(runtime_task.task.identifier): runtime_task.task
                        for runtime_task in self.tasks}
+        message_processor = MessageProcessor()
         while True:
             try:
-                (task_id, status, _, _) = self.status_repo.status_journal_summary.pop(0)
+                (task_id, _, _, index) = \
+                    self.status_repo.status_journal_summary.pop(0)
 
             except IndexError:
                 await asyncio.sleep(0.05)
                 continue
 
+            message = self.status_repo.get_task_data(task_id, index)
             task = tasks_by_id.get(task_id)
-            early_state = {'name': task.identifier,
-                           'job_logdir': job.logdir,
-                           'job_unique_id': job.unique_id}
-            if status == 'started':
-                job.result.start_test(early_state)
-                job.result_events_dispatcher.map_method('start_test',
-                                                        job.result,
-                                                        early_state)
-            elif status == 'finished':
-                this_task_data = self.status_repo.get_all_task_data(task_id)
-                last_task_status = this_task_data[-1]
-                test_state = last_task_status.copy()
-                test_state['status'] = last_task_status.get('result').upper()
-                test_state.update(early_state)
-
-                time_start = this_task_data[0]['time']
-                time_end = last_task_status['time']
-                time_elapsed = time_end - time_start
-                test_state['time_start'] = time_start
-                test_state['time_end'] = time_end
-                test_state['time_elapsed'] = time_elapsed
-
-                # fake log dir, needed by some result plugins such as HTML
-                if 'logdir' not in test_state:
-                    test_state['logdir'] = ''
-
-                base_path = os.path.join(job.logdir, 'test-results')
-                self._populate_task_logdir(base_path,
-                                           task,
-                                           this_task_data,
-                                           job.config.get('core.debug'))
-
-                job.result.check_test(test_state)
-                job.result_events_dispatcher.map_method('end_test',
-                                                        job.result,
-                                                        test_state)
-
-                if not mapping[test_state['status']]:
-                    self.summary.add("FAIL")
+            message_processor.process_message(message, task, job)
 
     def run_suite(self, job, test_suite):
         # pylint: disable=W0201

--- a/selftests/unit/test_status_repo.py
+++ b/selftests/unit/test_status_repo.py
@@ -26,7 +26,7 @@ class StatusRepo(TestCase):
     def test_handle_task_started(self):
         msg = {"id": "1-foo", "status": "started", "output_dir": "/fake/path"}
         self.status_repo._handle_task_started(msg)
-        self.assertEqual(self.status_repo.get_task_data("1-foo"),
+        self.assertEqual(self.status_repo.get_all_task_data("1-foo"),
                          [{"status": "started", "output_dir": "/fake/path"}])
 
     def test_handle_task_started_no_output_dir(self):
@@ -37,33 +37,33 @@ class StatusRepo(TestCase):
     def test_handle_task_finished_no_result(self):
         msg = {"id": "1-foo", "status": "finished"}
         self.status_repo._handle_task_finished(msg)
-        self.assertEqual(self.status_repo.get_task_data("1-foo"),
+        self.assertEqual(self.status_repo.get_all_task_data("1-foo"),
                          [{"status": "finished"}])
         self.assertEqual(self.status_repo._by_result.get(None), ["1-foo"])
 
     def test_handle_task_finished_result(self):
         msg = {"id": "1-foo", "status": "finished", "result": "pass"}
         self.status_repo._handle_task_finished(msg)
-        self.assertEqual(self.status_repo.get_task_data("1-foo"),
+        self.assertEqual(self.status_repo.get_all_task_data("1-foo"),
                          [{"status": "finished", "result": "pass"}])
         self.assertEqual(self.status_repo._by_result.get("pass"), ["1-foo"])
 
     def test_process_message_running(self):
         msg = {"id": "1-foo", "status": "running"}
         self.status_repo.process_message(msg)
-        self.assertEqual(self.status_repo.get_task_data("1-foo"),
+        self.assertEqual(self.status_repo.get_all_task_data("1-foo"),
                          [{"status": "running"}])
 
     def test_process_raw_message_task_started(self):
         msg = '{"id": "1-foo", "status": "started", "output_dir": "/fake/path"}'
         self.status_repo.process_raw_message(msg)
-        self.assertEqual(self.status_repo.get_task_data("1-foo"),
+        self.assertEqual(self.status_repo.get_all_task_data("1-foo"),
                          [{"status": "started", "output_dir": "/fake/path"}])
 
     def test_process_raw_message_task_running(self):
         msg = '{"id": "1-foo", "status": "running"}'
         self.status_repo.process_raw_message(msg)
-        self.assertEqual(self.status_repo.get_task_data("1-foo"),
+        self.assertEqual(self.status_repo.get_all_task_data("1-foo"),
                          [{"status": "running"}])
 
     def test_process_messages_running(self):
@@ -110,8 +110,8 @@ class StatusRepo(TestCase):
         self.status_repo.process_message(msg)
         self.assertEqual(self.status_repo.get_task_status("1-foo"), "finished")
         self.assertEqual(self.status_repo.status_journal_summary.pop(),
-                         ("1-foo", "finished", 1000000004.0))
+                         ("1-foo", "finished", 1000000004.0, 3))
         self.assertEqual(self.status_repo.status_journal_summary.pop(),
-                         ("1-foo", "running", 1000000003.0))
+                         ("1-foo", "running", 1000000003.0, 0))
         with self.assertRaises(IndexError):
             self.status_repo.status_journal_summary.pop()

--- a/spell.ignore
+++ b/spell.ignore
@@ -741,3 +741,4 @@ crit
 err
 getpcaps
 libcap
+jarichte


### PR DESCRIPTION
This is the PoC of messaging between runners and avocado core. It adds the ability to nrunners sending messages to avocado core in runtime. Right now it adds the ability to runner send logs (the instrumented runner is used as an example), but when it will be complete there can be many types of messages like error, output etc. 

As example when you run the instrumented test it will create a test log file under `job/test-result/test`

It based on #4418 and when it will be completed it will solve #4308