### PR TITLE
[Requirements resolver] Initial integration with the state machine v2

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -675,12 +675,15 @@ class Task:
         if known_runners is None:
             known_runners = {}
         self.known_runners = known_runners
+        self.dependencies = set()
         self.spawn_handle = None
         self.output_dir = None
 
     def __repr__(self):
-        fmt = '<Task identifier="{}" runnable="{}" status_services="{}"'
-        return fmt.format(self.identifier, self.runnable, self.status_services)
+        fmt = ('<Task identifier="{}" runnable="{}" dependencies="{}"'
+               ' status_services="{}"')
+        return fmt.format(self.identifier, self.runnable, self.dependencies,
+                          self.status_services)
 
     def are_requirements_available(self, runners_registry=None):
         """Verifies if requirements needed to run this task are available.

--- a/avocado/core/runners/requirement_package.py
+++ b/avocado/core/runners/requirement_package.py
@@ -1,0 +1,58 @@
+import os
+import subprocess
+import time
+
+from ...utils import exit_codes
+from .. import nrunner
+
+
+class RequirementPackageRunner(nrunner.BaseRunner):
+    """
+    Runner for requirements of type package
+
+    This runner handles, initially, the installation of packages using the
+    avocado-software-manager. It can be easily extended to support other
+    arguments, like `remove`.
+
+    The arguments represent the packages that should be installed.
+    """
+
+    def run(self):
+        env = self.runnable.kwargs or None
+        if env and 'PATH' not in env:
+            env['PATH'] = os.environ.get('PATH')
+        process = subprocess.Popen(
+            ['avocado-software-manager', 'install'] + list(self.runnable.args),
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env)
+
+        yield self.prepare_status('started')
+        while process.poll() is None:
+            time.sleep(nrunner.RUNNER_RUN_STATUS_INTERVAL)
+            yield self.prepare_status('running')
+
+        result = 'pass'
+        if process.returncode == exit_codes.UTILITY_FAIL:
+            result = 'error'
+
+        yield self.prepare_status('finished',
+                                  {'result': result,
+                                   'returncode': process.returncode,
+                                   'stdout': process.stdout.read(),
+                                   'stderr': process.stderr.read()})
+
+
+class RunnerApp(nrunner.BaseRunnerApp):
+    PROG_NAME = 'avocado-runner-requirement-package'
+    PROG_DESCRIPTION = ('nrunner application for requirements of type package')
+    RUNNABLE_KINDS_CAPABLE = {'requirement-package': RequirementPackageRunner}
+
+
+def main():
+    nrunner.main(RunnerApp)
+
+
+if __name__ == '__main__':
+    main()

--- a/avocado/plugins/resolvers.py
+++ b/avocado/plugins/resolvers.py
@@ -110,6 +110,25 @@ class AvocadoInstrumentedResolver(Resolver):
                                find_avocado_tests)
 
 
+class RequirementsResolver:
+
+    name = 'requirements'
+    description = 'Requirements resolver for tests with requirements'
+
+    @staticmethod
+    def resolve(runnable):
+        requirements_runnables = []
+        for requirement in runnable.requirements:
+            requirement_copy = requirement.copy()
+            kind = 'requirement-%s' % requirement_copy.pop('type')
+            args = requirement_copy.values()
+            requirement_runnable = Runnable(kind, None, *args)
+            # for now, ignore unsupported requirements types
+            if requirement_runnable.pick_runner_command() is not None:
+                requirements_runnables.append(requirement_runnable)
+        return requirements_runnables
+
+
 class TapResolver(Resolver):
 
     name = 'tap'

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -217,6 +217,7 @@ PATH=$HOME/.local/bin:$PATH LANG=en_US.UTF-8 AVOCADO_CHECK_LEVEL=0 %{__python3} 
 %{_bindir}/avocado-runner-python-unittest
 %{_bindir}/avocado-runner-avocado-instrumented
 %{_bindir}/avocado-runner-tap
+%{_bindir}/avocado-runner-requirement-package
 %{_bindir}/avocado-software-manager
 %{python3_sitelib}/avocado*
 %exclude %{python3_sitelib}/avocado_result_html*

--- a/setup.py
+++ b/setup.py
@@ -101,6 +101,7 @@ if __name__ == '__main__':
                   'avocado-runner-python-unittest = avocado.core.nrunner:main',
                   'avocado-runner-avocado-instrumented = avocado.core.runners.avocado_instrumented:main',
                   'avocado-runner-tap = avocado.core.runners.tap:main',
+                  'avocado-runner-requirement-package = avocado.core.runners.requirement_package:main',
                   'avocado-software-manager = avocado.utils.software_manager.main:main',
                   ],
               "avocado.plugins.init": [


### PR DESCRIPTION
This is a minimum set of changes to introduce and integrate the Requirements Resolver with the state machine. Although there are some caveats, the changes do not impact the current behavior if the requirements docstrings are not used.

The following test enables the code of this PR:

```python
from avocado import Test


class PassTest(Test):

    """
    Example test that passes.

    :avocado: tags=fast
    :avocado: requirement={"type": "package", "name": "vim-common"}
    :avocado: requirement={"type": "package", "name": "bla"}
    """

    def test(self):
        """
        A test doesn't have to fail to pass
        """
```

Caveats:
- Although tasks with dependencies wait for them to finish, the test will still run if some dependency fails due to lack of status after a task finishes. To solve this problem, after a task finishes, it needs to have the real finish state (success, fail), and the state machine needs to have access to it.
- For now, unsupported requirements `type` are ignored.

Changes from [v1](https://github.com/avocado-framework/avocado/pull/4423):
- Requirements are now handled as runners. Each requirement type is mapped to a specific runner. The addition of a new requirement type should be as simple as creating a new runner called `requirement_newtype.py`.
- Moved the resolver to the `avocado/plugins/resolvers.py` file as it is much simpler now.
- Changed the attribute name of the Task class to `dependency` instead of `prereqs`. This maps well to a dependency graph.
- Make the dependencies a set and improve the handling of it in the state machine.

Changes from [v0](https://github.com/avocado-framework/avocado/pull/4369):
- Improve docstring of RequirementRunner;
- Change the Requirements Resolver entry point to a static method;
- Variables renaming to make them more meaningful;
- Improve log message when the requirement type is not available;
- Classes reorder inside the file.