### PR TITLE
Remove iteritems() when inheriting from dict

### DIFF
--- a/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/mux.py
+++ b/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/mux.py
@@ -287,14 +287,10 @@ class ValueDict(dict):  # only container pylint: disable=R0903
             value = OutputValue(value, self.node, origin)
         return value
 
-    def iteritems(self):
+    def items(self):
         """ Slower implementation with the use of __getitem__ """
         for key in self:
             yield key, self[key]
-
-    def items(self):
-        """ Slower implementation with the use of __getitem__ """
-        return self.iteritems()  # pylint: disable=W1620
 
 
 class Control:  # Few methods pylint: disable=R0903


### PR DESCRIPTION
Since ``iteritems()`` is no longer an available method for dictionaries in
python3 and ``items()`` returns an iterator by default, it would be preferable
to use ``items()`` directly.

This was something commented briefly over #4411.

Signed-off-by: Tiago Honorato <tiagohonorato1@gmail.com>