### PR TITLE
vmimage: Pass the backing file format to qemu-img

### DIFF
--- a/avocado/utils/vmimage.py
+++ b/avocado/utils/vmimage.py
@@ -495,9 +495,9 @@ class Image:
         if self.snapshot_dir is not None:
             new_image = os.path.join(self.snapshot_dir,
                                      os.path.basename(new_image))
-        cmd = '%s create -f qcow2 -b %s %s' % (qemu_img,
-                                               self.base_image,
-                                               new_image)
+        cmd = '%s create -f qcow2 -b %s -F qcow2 %s' % (qemu_img,
+                                                        self.base_image,
+                                                        new_image)
         process.run(cmd)
         return new_image
 


### PR DESCRIPTION
The qemu-img uses the cloud-init image as a backing file to build the new
image, but the command warns about:

"qemu-img: warning: Deprecated use of backing file without explicit backing format (detected format of qcow2)"

This adds "-F qcow2" to the list of parameters so that warning is quieted.

Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>