### PR TITLE
Selftests/lint: allow netifaces to be loaded for proper linting

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -3,7 +3,7 @@
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code.
-extension-pkg-whitelist=
+extension-pkg-whitelist=netifaces
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.


### PR DESCRIPTION
Depending on the configuration, while running ./selftests/lint.sh,
one may get a series of lines that look like:

   selftests/unit/test_utils_network.py:49:48: I1101: Module 'netifaces'
   has no 'AF_INET6' member, but source is unavailable. Consider adding
   this module to extension-pkg-whitelist if you want to perform analysis
   based on run-time introspection of living objects. (c-extension-no-member)

I think it's safe enough to allow the netiface module to be evaluated at
run-time for a proper linting, and get rid of those messages.

Signed-off-by: Cleber Rosa <crosa@redhat.com>