### PR TITLE
[NRunner] remove the structure of spawner.check_task_requirements

### DIFF
--- a/avocado/core/plugin_interfaces.py
+++ b/avocado/core/plugin_interfaces.py
@@ -288,12 +288,3 @@ class Spawner(Plugin):
         :param runtime_task: wrapper for a Task with additional runtime information
         :type runtime_task: :class:`avocado.core.task.runtime.RuntimeTask`
         """
-
-    @staticmethod
-    @abc.abstractmethod
-    async def check_task_requirements(runtime_task):
-        """Checks if the requirements described within a task are available.
-
-        :param runtime_task: wrapper for a Task with additional runtime information
-        :type runtime_task: :class:`avocado.core.task.runtime.RuntimeTask`
-        """

--- a/avocado/core/spawners/mock.py
+++ b/avocado/core/spawners/mock.py
@@ -40,10 +40,6 @@ class MockSpawner(Spawner):
                 return
             await asyncio.sleep(0.1)
 
-    @staticmethod
-    async def check_task_requirements(runtime_task):
-        return True
-
 
 class MockRandomAliveSpawner(MockSpawner):
     """A mocking spawner that simulates randomness about tasks being alive."""

--- a/avocado/core/task/statemachine.py
+++ b/avocado/core/task/statemachine.py
@@ -80,14 +80,8 @@ class Worker:
         except IndexError:
             return
 
-        requirements_ok = await self._spawner.check_task_requirements(runtime_task)
-        if requirements_ok:
-            async with self._state_machine.lock:
-                self._state_machine.ready.append(runtime_task)
-        else:
-            async with self._state_machine.lock:
-                self._state_machine.finished.append(runtime_task)
-                runtime_task.status = 'FAILED ON TRIAGE'
+        async with self._state_machine.lock:
+            self._state_machine.ready.append(runtime_task)
 
     async def start(self):
         """Reads from ready, moves into either: started or finished."""

--- a/avocado/plugins/spawners/podman.py
+++ b/avocado/plugins/spawners/podman.py
@@ -1,11 +1,9 @@
 import asyncio
 import json
 import os
-import re
 import subprocess
 
 from avocado.core.plugin_interfaces import CLI, Init, Spawner
-from avocado.core.requirements import cache
 from avocado.core.settings import settings
 from avocado.core.spawners.common import SpawnerMixin, SpawnMethod
 
@@ -154,54 +152,3 @@ class PodmanSpawner(Spawner, SpawnerMixin):
             if not PodmanSpawner.is_task_alive(runtime_task):
                 return
             await asyncio.sleep(0.1)
-
-    @staticmethod
-    async def _check_requirement_core_avocado():
-        env_type = 'podman'
-        env = settings.as_dict().get('spawner.podman.image')
-        req_type = 'core'
-        req = 'avocado'
-
-        on_cache = cache.get_requirement(env_type, env,
-                                         req_type, req)
-        if on_cache:
-            return True
-
-        podman_bin = settings.as_dict().get('spawner.podman.bin')
-        try:
-            # pylint: disable=E1133
-            proc = await asyncio.create_subprocess_exec(
-                podman_bin, "run", env,
-                "avocado", "--version",
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE)
-        except (FileNotFoundError, PermissionError):
-            return False
-
-        await proc.wait()
-        if proc.returncode != 0:
-            return False
-
-        stdout = await proc.stdout.read()
-        if re.match(rb'^Avocado (\d+)\.(\d+)\r?$', stdout):
-            cache.set_requirement(env_type, env,
-                                  req_type, req)
-            return True
-        return False
-
-    @staticmethod
-    async def check_task_requirements(runtime_task):
-        runnable_requirements = runtime_task.task.runnable.requirements
-        if not runnable_requirements:
-            return True
-        for requirements in runnable_requirements:
-            for (req_type, req_value) in requirements.items():
-                # This is currently limited to one requirement type as a PoC
-                if req_type == 'core' and req_value == 'avocado':
-                    avocado_capable = await PodmanSpawner._check_requirement_core_avocado()
-                    return avocado_capable
-                else:
-                    # current implementation can not check any other type of
-                    # requirement at this moment so fail
-                    return False
-        return True

--- a/avocado/plugins/spawners/process.py
+++ b/avocado/plugins/spawners/process.py
@@ -39,21 +39,3 @@ class ProcessSpawner(Spawner, SpawnerMixin):
     @staticmethod
     async def wait_task(runtime_task):
         await runtime_task.spawner_handle.wait()
-
-    @staticmethod
-    async def check_task_requirements(runtime_task):
-        runnable_requirements = runtime_task.task.runnable.requirements
-        if not runnable_requirements:
-            return True
-
-        for requirements in runnable_requirements:
-            for (req_type, req_value) in requirements.items():
-                # The fact that this is avocado code means this
-                # requirement is fulfilled
-                if req_type == 'core' and req_value == 'avocado':
-                    continue
-                else:
-                    # current implementation can not check any other type of
-                    # requirement at this moment so fail
-                    return False
-        return True


### PR DESCRIPTION
The original code made to check a task requirement is mapped in a way that if requirements are defined in a test, those listed in the check_task_requirements method should be in the list of requirements of a test.

The mapping should work in the reversed way. If a requirement is defined in the test, NRunner should be able to check if each of the requirements are fulfilled and do not expect extra requirements, if they are not set. This operation should happen in the Requirements Resolver when it is implemented.

The following example of the test illustrates the current workflow:

```python
from avocado import Test


class PassTest(Test):

    """
    Example test that passes.

    :avocado: requirement={"type": "package", "name": "vim-common"}
    :avocado: requirement={"type": "package", "name": "bla"}
    :avocado: requirement={"type": "file", "name": "foo.bar"}
    """

    def test(self):
        """
        A test simply doesn't have to fail in order to pass
        """
```

The list of requirements is triggered by:

https://github.com/avocado-framework/avocado/blob/333015a04362d95682c011bace6f6aded56103e4/avocado/plugins/spawners/process.py#L49

But as the type `core` and value `avocado` does not exist in the list of requirements, this method returns `False`, failing the test execution.

As I mentioned in the beginning, the current mapping forces those requirements listed into the method to be defined in the test's list of requirements. IMO, the requirements should be handled case by case on a specialized architecture (aka, the Requirements Resolver).

Signed-off-by: Willian Rampazzo <willianr@redhat.com>