### PR TITLE
SIMPLE Tests: improvements on failure presentation

### DIFF
--- a/avocado/core/__init__.py
+++ b/avocado/core/__init__.py
@@ -66,6 +66,14 @@ def register_core_options():
                          default='all',
                          help_msg=help_msg)
 
+    help_msg = ('Fields to include in the presentation of SIMPLE test '
+                'failures.  Accepted values: status, stdout, stderr.')
+    stgs.register_option(section='simpletests.status',
+                         key='failure_fields',
+                         key_type=list,
+                         default=['status', 'stdout', 'stderr'],
+                         help_msg=help_msg)
+
     help_msg = ('The amount of time to give to the test process after '
                 'it it has been interrupted (such as with CTRL+C)')
     stgs.register_option(section='runner.timeout',

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -1092,6 +1092,8 @@ class SimpleTest(Test):
         """
         self.log.info("Exit status: %s", result.exit_status)
         self.log.info("Duration: %s", result.duration)
+        self.log.info("STDOUT: %s", result.stdout_text.strip())
+        self.log.info("STDERR: %s", result.stderr_text.strip())
 
     @staticmethod
     def _cmd_error_to_test_failure(cmd_error):

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -1096,11 +1096,16 @@ class SimpleTest(Test):
         self.log.info("  STDOUT: %s", result.stdout_text.strip())
         self.log.info("  STDERR: %s", result.stderr_text.strip())
 
-    @staticmethod
-    def _cmd_error_to_test_failure(cmd_error):
-        return ("Exited with status: '%u', stdout: %r stderr: %r" %
-                (cmd_error.result.exit_status, cmd_error.result.stdout_text,
-                 cmd_error.result.stderr_text))
+    def _cmd_error_to_test_failure(self, cmd_error):
+        failure_fields = self._config.get('simpletests.status.failure_fields')
+        msgs = []
+        if 'status' in failure_fields:
+            msgs.append("Exited with status: '%u'" % cmd_error.result.exit_status)
+        if 'stdout' in failure_fields:
+            msgs.append("stdout: %r" % cmd_error.result.stdout_text)
+        if 'stderr' in failure_fields:
+            msgs.append("stderr: %r" % cmd_error.result.stdout_text)
+        return ", ".join(msgs)
 
     def _execute_cmd(self):
         """

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -1090,10 +1090,11 @@ class SimpleTest(Test):
 
         :param result: :class:`avocado.utils.process.CmdResult` instance.
         """
-        self.log.info("Exit status: %s", result.exit_status)
-        self.log.info("Duration: %s", result.duration)
-        self.log.info("STDOUT: %s", result.stdout_text.strip())
-        self.log.info("STDERR: %s", result.stderr_text.strip())
+        self.log.info("Detailed information about the executed command:")
+        self.log.info("  Exit status: %s", result.exit_status)
+        self.log.info("  Duration: %s", result.duration)
+        self.log.info("  STDOUT: %s", result.stdout_text.strip())
+        self.log.info("  STDERR: %s", result.stderr_text.strip())
 
     @staticmethod
     def _cmd_error_to_test_failure(cmd_error):

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -261,7 +261,7 @@ class Test(unittest.TestCase, TestData):
 
         self.__tags = tags
 
-        self.__config = config or settings.as_dict()
+        self._config = config or settings.as_dict()
 
         self.__base_logdir_tmp = None
         if base_logdir is None:
@@ -285,8 +285,8 @@ class Test(unittest.TestCase, TestData):
 
         self.__outputdir = utils_path.init_dir(self.logdir, 'data')
 
-        self.__sysinfo_enabled = self.__config.get('sysinfo.collect.per_test',
-                                                   False)
+        self.__sysinfo_enabled = self._config.get('sysinfo.collect.per_test',
+                                                  False)
 
         if self.__sysinfo_enabled:
             self.__sysinfodir = utils_path.init_dir(self.logdir, 'sysinfo')
@@ -786,8 +786,8 @@ class Test(unittest.TestCase, TestData):
         whiteboard_file = os.path.join(self.logdir, 'whiteboard')
         genio.write_file(whiteboard_file, self.whiteboard)
 
-        output_check_record = self.__config.get('run.output_check_record')
-        output_check = self.__config.get('run.output_check')
+        output_check_record = self._config.get('run.output_check_record')
+        output_check = self._config.get('run.output_check')
 
         # record the output if the modes are valid
         if output_check_record == 'combined':
@@ -1038,7 +1038,7 @@ class Test(unittest.TestCase, TestData):
         if self.__base_logdir_tmp is not None:
             self.__base_logdir_tmp.cleanup()
             self.__base_logdir_tmp = None
-        if not self.__config.get('run.keep_tmp') and os.path.exists(
+        if not self._config.get('run.keep_tmp') and os.path.exists(
                 self.__base_tmpdir):
             shutil.rmtree(self.__base_tmpdir)
 
@@ -1076,7 +1076,6 @@ class SimpleTest(Test):
         self._command = None
         if self.filename is not None:
             self._command = pipes.quote(self.filename)
-        self._config = settings.as_dict()
 
     @property
     def filename(self):

--- a/selftests/functional/plugin/test_logs.py
+++ b/selftests/functional/plugin/test_logs.py
@@ -1,9 +1,9 @@
 import os
 
 from avocado.core import exit_codes
-from avocado.utils import process
+from avocado.utils import process, script
 
-from ... import AVOCADO, TestCaseTmpDir
+from ... import AVOCADO, BASEDIR, TestCaseTmpDir
 
 CONFIG = """[job.output.testlogs]
 statuses = ["FAIL", "CANCEL"]"""
@@ -25,9 +25,39 @@ class TestLogs(TestCaseTmpDir):
                          "Avocado did not return rc %d:\n%s"
                          % (exit_codes.AVOCADO_ALL_OK, result))
         stdout_lines = result.stdout_text.splitlines()
-        self.assertNotIn('Log content for test "1-examples/tests/passtest.py'
+        self.assertNotIn('Log file "debug.log" content for test "1-examples/tests/passtest.py'
                          ':PassTest.test" (PASS)', stdout_lines)
-        self.assertIn('Log content for test "2-examples/tests/failtest.py:'
-                      'FailTest.test" (FAIL)', stdout_lines)
-        self.assertIn('Log content for test "3-examples/tests/canceltest.py'
-                      ':CancelTest.test" (CANCEL)', stdout_lines)
+        self.assertIn('Log file "debug.log" content for test "2-examples/tests/failtest.py:FailTest.test" (FAIL):', stdout_lines)
+        self.assertIn('Log file "debug.log" content for test "3-examples/tests/canceltest.py'
+                      ':CancelTest.test" (CANCEL):', stdout_lines)
+
+
+class TestLogsFiles(TestCaseTmpDir):
+
+    def setUp(self):
+        super(TestLogsFiles, self).setUp()
+        self.config_file = script.TemporaryScript(
+            'avocado.conf',
+            "[job.output.testlogs]\n"
+            "statuses = ['FAIL']\n"
+            "logfiles = ['stdout', 'stderr', 'DOES_NOT_EXIST']\n")
+        self.config_file.save()
+
+    def test_simpletest_logfiles(self):
+        fail_test = os.path.join(BASEDIR, 'examples', 'tests', 'failtest.sh')
+        cmd_line = ('%s --config %s run --job-results-dir %s --disable-sysinfo'
+                    ' -- %s' % (AVOCADO, self.config_file.path,
+                                self.tmpdir.name, fail_test))
+        result = process.run(cmd_line, ignore_status=True)
+        expected_rc = exit_codes.AVOCADO_TESTS_FAIL
+        self.assertEqual(result.exit_status, expected_rc,
+                         "Avocado did not return rc %d:\n%s" % (expected_rc, result))
+        self.assertNotIn('Log file "debug.log" content', result.stdout_text)
+        self.assertIn('Log file "stdout" content', result.stdout_text)
+        self.assertIn('Log file "stderr" content', result.stdout_text)
+        self.assertRegex(result.stderr_text,
+                         r'Failure to access log file.*DOES_NOT_EXIST"')
+
+    def tearDown(self):
+        super(TestLogsFiles, self).tearDown()
+        self.config_file.remove()

--- a/selftests/functional/plugin/test_logs.py
+++ b/selftests/functional/plugin/test_logs.py
@@ -3,7 +3,7 @@ import os
 from avocado.core import exit_codes
 from avocado.utils import process
 
-from .. import AVOCADO, TestCaseTmpDir
+from ... import AVOCADO, TestCaseTmpDir
 
 CONFIG = """[job.output.testlogs]
 statuses = ["FAIL", "CANCEL"]"""

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -942,6 +942,32 @@ class RunnerSimpleTestStatus(TestCaseTmpDir):
         self.config_file.remove()
 
 
+class RunnerSimpleTestFailureFields(TestCaseTmpDir):
+
+    def setUp(self):
+        super(RunnerSimpleTestFailureFields, self).setUp()
+        self.config_file = script.TemporaryScript(
+            'avocado.conf',
+            "[simpletests.status]\n"
+            "failure_fields = ['stdout', 'stderr']\n")
+        self.config_file.save()
+
+    def test_simpletest_failure_fields(self):
+        fail_test = os.path.join(BASEDIR, 'examples', 'tests', 'failtest.sh')
+        cmd_line = ('%s --config %s run --job-results-dir %s --disable-sysinfo'
+                    ' -- %s' % (AVOCADO, self.config_file.path,
+                                self.tmpdir.name, fail_test))
+        result = process.run(cmd_line, ignore_status=True)
+        expected_rc = exit_codes.AVOCADO_TESTS_FAIL
+        self.assertEqual(result.exit_status, expected_rc,
+                         "Avocado did not return rc %d:\n%s" % (expected_rc, result))
+        self.assertNotIn("Exited with status: '1'", result.stdout_text)
+
+    def tearDown(self):
+        super(RunnerSimpleTestFailureFields, self).tearDown()
+        self.config_file.remove()
+
+
 class ExternalRunnerTest(TestCaseTmpDir):
 
     def setUp(self):


### PR DESCRIPTION
This makes two improvements regarding how SIMPLE tests (executable tests) present their results:

* On the "failure reason" string presented along with test PASS/FAIL/ERROR status
* On the `testlogs` plugin that can show the tests log on if a given test result matches the configuration

Now it's possible to configure both the fields that will appear on the failure reason, and the log files that will be shown once the job is finished.