### PR TITLE
TAP: unify implementation with exec based runners

### DIFF
--- a/avocado/core/runners/tap.py
+++ b/avocado/core/runners/tap.py
@@ -1,13 +1,10 @@
 import io
-import os
-import subprocess
-import time
 
 from .. import nrunner
 from ..tapparser import TapParser, TestResult
 
 
-class TAPRunner(nrunner.BaseRunner):
+class TAPRunner(nrunner.ExecRunner):
     """Runner for standalone executables treated as TAP
 
     When creating the Runnable, use the following attributes:
@@ -31,23 +28,8 @@ class TAPRunner(nrunner.BaseRunner):
                            DEBUG='false') # kwargs 1 (environment)
     """
 
-    def run(self):
-        env = self.runnable.kwargs or None
-        if env and 'PATH' not in env:
-            env['PATH'] = os.environ.get('PATH')
-        process = subprocess.Popen(
-            [self.runnable.uri] + list(self.runnable.args),
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            env=env)
-        yield self.prepare_status('started')
-
-        while process.poll() is None:
-            time.sleep(nrunner.RUNNER_RUN_STATUS_INTERVAL)
-            yield self.prepare_status('running')
-
-        stdout = process.stdout.read()
+    @staticmethod
+    def _get_tap_result(stdout):
         parser = TapParser(io.StringIO(stdout.decode()))
         result = 'error'
         for event in parser.parse():
@@ -70,12 +52,14 @@ class TAPRunner(nrunner.BaseRunner):
                     break
                 else:
                     result = 'pass'
+        return result
 
-        yield self.prepare_status('finished',
-                                  {'result': result,
-                                   'returncode': process.returncode,
-                                   'stdout': stdout,
-                                   'stderr': process.stderr.read()})
+    def _process_final_status(self, process, stdout, stderr):
+        return self.prepare_status('finished',
+                                   {'result': self._get_tap_result(stdout),
+                                    'returncode': process.returncode,
+                                    'stdout': stdout,
+                                    'stderr': stderr})
 
 
 class RunnerApp(nrunner.BaseRunnerApp):

--- a/avocado/core/runners/tap.py
+++ b/avocado/core/runners/tap.py
@@ -41,6 +41,7 @@ class TAPRunner(nrunner.BaseRunner):
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             env=env)
+        yield self.prepare_status('started')
 
         while process.poll() is None:
             time.sleep(nrunner.RUNNER_RUN_STATUS_INTERVAL)

--- a/avocado/core/runners/tap.py
+++ b/avocado/core/runners/tap.py
@@ -56,6 +56,10 @@ class TAPRunner(nrunner.BaseRunner):
             elif isinstance(event, TapParser.Error):
                 result = 'error'
                 break
+            elif isinstance(event, TapParser.Plan):
+                if event.skipped:
+                    result = 'skip'
+                    break
             elif isinstance(event, TapParser.Test):
                 if event.result in (TestResult.XPASS, TestResult.FAIL):
                     result = 'fail'


### PR DESCRIPTION
The exec-test runner works by leveraging the exec runner, and doing additional check on the last stage, basically deciding the actual result of the test and what to report in the final status message.
    
The TAP runner is no different, but currently it basically re-implements the execution part of the code.  Because this code diverges, a bug fixed on the exec runner, supporting large outputs that exceed the buffer sizes, where not applied to the TAP runner.
    
With this change, runners based on exec can choose to simply implement the method that checks/builds the final status.