### PR TITLE
Decorators: fix issue with conditional skips and None

### DIFF
--- a/avocado/core/decorators.py
+++ b/avocado/core/decorators.py
@@ -69,18 +69,15 @@ fail_on = deco_factory("fail", core_exceptions.TestFail)
 cancel_on = deco_factory("cancel", core_exceptions.TestCancel)
 
 
-def _skip_method_decorator(function, message, condition=None):
+def _skip_method_decorator(function, message, condition):
     """Creates a skip decorator for a method."""
     @wraps(function)
     def wrapper(obj, *args, **kwargs):  # pylint: disable=W0613
-        if condition is None:
-            raise core_exceptions.TestSkipError(message)
-        else:
-            if callable(condition):
-                if condition(obj):
-                    raise core_exceptions.TestSkipError(message)
-            elif condition:
+        if callable(condition):
+            if condition(obj):
                 raise core_exceptions.TestSkipError(message)
+        elif condition:
+            raise core_exceptions.TestSkipError(message)
     wrapper.__skip_test_decorator__ = True
     return wrapper
 
@@ -95,7 +92,7 @@ def _skip_class_decorator(cls, message, condition=None):
     return cls
 
 
-def _get_skip_method_or_class_decorator(message, condition=None):
+def _get_skip_method_or_class_decorator(message, condition):
     """Returns a method or class decorator, according to decorated type."""
     def decorator(obj):
         if isinstance(obj, type):
@@ -113,7 +110,7 @@ def skip(message=None):
     :type message: str
 
     """
-    return _get_skip_method_or_class_decorator(message)
+    return _get_skip_method_or_class_decorator(message, True)
 
 
 def skipIf(condition, message=None):

--- a/selftests/functional/test_skiptests.py
+++ b/selftests/functional/test_skiptests.py
@@ -196,6 +196,14 @@ class AvocadoSkipTests(avocado.Test):
 
 class Base(TestCaseTmpDir):
 
+    FILE_NAME_CONTENT_MAP = {}
+    SCRIPT_TO_EXEC = 'script_to_exec.py'
+
+    def setUp(self):
+        super(Base, self).setUp()
+        for name, content in self.FILE_NAME_CONTENT_MAP.items():
+            self._create_tmp_file(name, content)
+
     def _create_tmp_file(self, name, content):
         scr_obj = script.Script(os.path.join(self.tmpdir.name, name), content)
         scr_obj.save()
@@ -207,7 +215,7 @@ class Base(TestCaseTmpDir):
                     '--disable-sysinfo',
                     '--job-results-dir',
                     '%s' % self.tmpdir.name,
-                    '%s' % self.script_to_exec,
+                    '%s' % os.path.join(self.tmpdir.name, self.SCRIPT_TO_EXEC),
                     '--json -']
         result = process.run(' '.join(cmd_line), ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
@@ -237,13 +245,10 @@ class Base(TestCaseTmpDir):
 
 class Skip(Base):
 
-    def setUp(self):
-        super(Skip, self).setUp()
-        _ = self._create_tmp_file('lib_skip_decorators.py',
-                                  AVOCADO_TEST_SKIP_LIB)
-        self.script_to_exec = self._create_tmp_file(
-            'test_skip_decorators.py',
-            AVOCADO_TEST_SKIP_DECORATORS)
+    FILE_NAME_CONTENT_MAP = {
+        'lib_skip_decorators.py': AVOCADO_TEST_SKIP_LIB,
+        'script_to_exec.py': AVOCADO_TEST_SKIP_DECORATORS
+    }
 
     def test_skip_decorators(self):
         self.check_skips_and_content(5)
@@ -251,13 +256,10 @@ class Skip(Base):
 
 class SkipClass(Base):
 
-    def setUp(self):
-        super(SkipClass, self).setUp()
-        _ = self._create_tmp_file('lib_skip_decorators.py',
-                                  AVOCADO_TEST_SKIP_LIB)
-        self.script_to_exec = self._create_tmp_file(
-            'test_skip_class_decorators.py',
-            AVOCADO_TEST_SKIP_CLASS_DECORATORS)
+    FILE_NAME_CONTENT_MAP = {
+        'lib_skip_decorators.py': AVOCADO_TEST_SKIP_LIB,
+        'script_to_exec.py': AVOCADO_TEST_SKIP_CLASS_DECORATORS
+    }
 
     def test_skip_class_decorators(self):
         self.check_skips_and_content(3)
@@ -265,13 +267,10 @@ class SkipClass(Base):
 
 class SkipIfClass(Base):
 
-    def setUp(self):
-        super(SkipIfClass, self).setUp()
-        _ = self._create_tmp_file('lib_skip_decorators.py',
-                                  AVOCADO_TEST_SKIP_LIB)
-        self.script_to_exec = self._create_tmp_file(
-            'test_skip_if_class_decorators.py',
-            AVOCADO_TEST_SKIP_IF_CLASS_DECORATORS)
+    FILE_NAME_CONTENT_MAP = {
+        'lib_skip_decorators.py': AVOCADO_TEST_SKIP_LIB,
+        'script_to_exec.py': AVOCADO_TEST_SKIP_IF_CLASS_DECORATORS
+    }
 
     def test_skipIf_class_decorators(self):
         self.check_status(**{'skip': 3, 'pass': 3})
@@ -279,13 +278,10 @@ class SkipIfClass(Base):
 
 class SkipUnlessClass(Base):
 
-    def setUp(self):
-        super(SkipUnlessClass, self).setUp()
-        _ = self._create_tmp_file('lib_skip_decorators.py',
-                                  AVOCADO_TEST_SKIP_LIB)
-        self.script_to_exec = self._create_tmp_file(
-            'test_skip_unless_class_decorators.py',
-            AVOCADO_TEST_SKIP_UNLESS_CLASS_DECORATORS)
+    FILE_NAME_CONTENT_MAP = {
+        'lib_skip_decorators.py': AVOCADO_TEST_SKIP_LIB,
+        'script_to_exec.py': AVOCADO_TEST_SKIP_UNLESS_CLASS_DECORATORS
+    }
 
     def test_skipUnless_class_decorators(self):
         self.check_status(**{'skip': 3, 'pass': 3})
@@ -293,11 +289,9 @@ class SkipUnlessClass(Base):
 
 class SkipSetup(Base):
 
-    def setUp(self):
-        super(SkipSetup, self).setUp()
-        self.script_to_exec = self._create_tmp_file(
-            'test_skip_decorator_setup.py',
-            AVOCADO_SKIP_DECORATOR_SETUP)
+    FILE_NAME_CONTENT_MAP = {
+        'script_to_exec.py': AVOCADO_SKIP_DECORATOR_SETUP
+    }
 
     def test_skip_setup(self):
         self.check_status(skip=1)
@@ -305,11 +299,9 @@ class SkipSetup(Base):
 
 class SkipTearDown(Base):
 
-    def setUp(self):
-        super(SkipTearDown, self).setUp()
-        self.script_to_exec = self._create_tmp_file(
-            'test_skip_decorator_teardown.py',
-            AVOCADO_SKIP_DECORATOR_TEARDOWN)
+    FILE_NAME_CONTENT_MAP = {
+        'script_to_exec.py': AVOCADO_SKIP_DECORATOR_TEARDOWN
+    }
 
     def _get_json_result(self):
         cmd_line = [AVOCADO,
@@ -317,7 +309,7 @@ class SkipTearDown(Base):
                     '--disable-sysinfo',
                     '--job-results-dir',
                     '%s' % self.tmpdir.name,
-                    '%s' % self.script_to_exec,
+                    '%s' % os.path.join(self.tmpdir.name, self.SCRIPT_TO_EXEC),
                     '--json -']
         result = process.run(' '.join(cmd_line), ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_TESTS_FAIL)

--- a/selftests/functional/test_skiptests.py
+++ b/selftests/functional/test_skiptests.py
@@ -43,9 +43,67 @@ class AvocadoSkipTests(avocado.Test):
     def test5(self):
         self.log.info('test executed')
 
+    @avocado.skipIf(lambda x: x.FALSE_CONDITION,
+                    'skipIf with False condition, should not happen')
+    def test6(self):
+        self.log.info('test executed')
+
+    @avocado.skipUnless(lambda x: x.TRUE_CONDITION,
+                        'skipUnless with True condition, should not happen')
+    def test7(self):
+        self.log.info('test executed')
+
     def tearDown(self):
         self.log.info('teardown executed')
 """
+
+
+AVOCADO_TEST_NOT_SKIP_DECORATORS = """
+import avocado
+from lib_skip_decorators import check_condition
+
+class AvocadoSkipTests(avocado.Test):
+
+    TRUE_CONDITION = True
+    FALSE_CONDITION = False
+
+    def setUp(self):
+        self.log.info('setup executed')
+
+    @avocado.skipIf(False,
+                    'skipIf with False condition, should not happen')
+    def test1(self):
+        self.log.info('test executed')
+
+    @avocado.skipUnless(True,
+                        'SkipUnless with True condition, should not happen')
+    def test2(self):
+        self.log.info('test executed')
+
+    @avocado.skipIf(lambda x: x.FALSE_CONDITION,
+                    'skipIf with False condition, should not happen')
+    def test3(self):
+        self.log.info('test executed')
+
+    @avocado.skipUnless(lambda x: x.TRUE_CONDITION,
+                        'skipUnless with True condition, should not happen')
+    def test4(self):
+        self.log.info('test executed')
+
+    @avocado.skipIf(None,
+                    'skipIf with None condition, should not happen')
+    def test5(self):
+        self.log.info('test executed')
+
+    @avocado.skipIf(lambda x: None,
+                    'skipIf with None condition, should not happen')
+    def test6(self):
+        self.log.info('test executed')
+
+    def tearDown(self):
+        self.log.info('teardown executed')
+"""
+
 
 AVOCADO_TEST_SKIP_CLASS_DECORATORS = """
 import avocado
@@ -252,6 +310,17 @@ class Skip(Base):
 
     def test_skip_decorators(self):
         self.check_skips_and_content(5)
+
+
+class NotSkip(Base):
+
+    FILE_NAME_CONTENT_MAP = {
+        'lib_skip_decorators.py': AVOCADO_TEST_SKIP_LIB,
+        'script_to_exec.py': AVOCADO_TEST_NOT_SKIP_DECORATORS
+    }
+
+    def test(self):
+        self.check_status(**{'pass': 6, 'skip': 0})
 
 
 class SkipClass(Base):

--- a/selftests/functional/test_skiptests.py
+++ b/selftests/functional/test_skiptests.py
@@ -219,6 +219,10 @@ class Base(TestCaseTmpDir):
         self.check_status_occurrences(json_results, skip=number_of_skips)
         self.check_content(json_results)
 
+    def check_status(self, **kwargs):
+        json_results = self._get_json_result()
+        self.check_status_occurrences(json_results, **kwargs)
+
     def check_status_occurrences(self, json_results, **kwargs):
         for status, number_of_occurrences in kwargs.items():
             self.assertEqual(json_results[status], number_of_occurrences)
@@ -270,19 +274,7 @@ class SkipIfClass(Base):
             AVOCADO_TEST_SKIP_IF_CLASS_DECORATORS)
 
     def test_skipIf_class_decorators(self):
-        cmd_line = [AVOCADO,
-                    'run',
-                    '--disable-sysinfo',
-                    '--job-results-dir',
-                    '%s' % self.tmpdir.name,
-                    '%s' % self.script_to_exec,
-                    '--json -']
-        result = process.run(' '.join(cmd_line), ignore_status=True)
-        json_results = json.loads(result.stdout_text)
-
-        self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
-        self.assertEqual(json_results['skip'], 3)
-        self.assertEqual(json_results['pass'], 3)
+        self.check_status(**{'skip': 3, 'pass': 3})
 
 
 class SkipUnlessClass(Base):
@@ -296,19 +288,7 @@ class SkipUnlessClass(Base):
             AVOCADO_TEST_SKIP_UNLESS_CLASS_DECORATORS)
 
     def test_skipUnless_class_decorators(self):
-        cmd_line = [AVOCADO,
-                    'run',
-                    '--disable-sysinfo',
-                    '--job-results-dir',
-                    '%s' % self.tmpdir.name,
-                    '%s' % self.script_to_exec,
-                    '--json -']
-        result = process.run(' '.join(cmd_line), ignore_status=True)
-        json_results = json.loads(result.stdout_text)
-
-        self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
-        self.assertEqual(json_results['skip'], 3)
-        self.assertEqual(json_results['pass'], 3)
+        self.check_status(**{'skip': 3, 'pass': 3})
 
 
 class SkipSetup(Base):
@@ -320,17 +300,7 @@ class SkipSetup(Base):
             AVOCADO_SKIP_DECORATOR_SETUP)
 
     def test_skip_setup(self):
-        cmd_line = [AVOCADO,
-                    'run',
-                    '--disable-sysinfo',
-                    '--job-results-dir',
-                    '%s' % self.tmpdir.name,
-                    '%s' % self.script_to_exec,
-                    '--json -']
-        result = process.run(' '.join(cmd_line), ignore_status=True)
-        json_results = json.loads(result.stdout_text)
-        self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
-        self.assertEqual(json_results['skip'], 1)
+        self.check_status(skip=1)
 
 
 class SkipTearDown(Base):
@@ -341,7 +311,7 @@ class SkipTearDown(Base):
             'test_skip_decorator_teardown.py',
             AVOCADO_SKIP_DECORATOR_TEARDOWN)
 
-    def test_skip_teardown(self):
+    def _get_json_result(self):
         cmd_line = [AVOCADO,
                     'run',
                     '--disable-sysinfo',
@@ -350,9 +320,12 @@ class SkipTearDown(Base):
                     '%s' % self.script_to_exec,
                     '--json -']
         result = process.run(' '.join(cmd_line), ignore_status=True)
-        json_results = json.loads(result.stdout_text)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_TESTS_FAIL)
-        self.assertEqual(json_results['errors'], 1)
+        json_results = json.loads(result.stdout_text)
+        return json_results
+
+    def test_skip_teardown(self):
+        self.check_status(errors=1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Callable conditional were introduced in f402b6d81, but it also introduced a bug.  In an effort to support both non-conditionals (plain "@skip") and conditionals ("@skipIf" and "@skipUnless") a parameter called condition was introduced, and checked for being None.
    
The problem is that None should evaluate to False, and thus cause the `skipIf` to *not* skip, such as in:
 
```python 
@avocado.skipIf(None, 'skipIf with None condition, should not happen')
```

And conversely, `skipUnless` to skip. The bugfix simply makes the non-conditional skip have a `True` condition instead.