### PR TITLE
assets: add --by-overall-limit to assets purge command (v2)

### DIFF
--- a/avocado/plugins/assets.py
+++ b/avocado/plugins/assets.py
@@ -28,6 +28,7 @@ from avocado.core.settings import settings
 from avocado.utils import data_structures
 from avocado.utils.asset import SUPPORTED_OPERATORS, Asset
 from avocado.utils.astring import iter_tabular_output
+from avocado.utils.data_structures import DataSize, InvalidDataSize
 from avocado.utils.output import display_data_size
 
 
@@ -272,7 +273,8 @@ class Assets(CLICmd):
     def _count_filter_args(config):
         sub_command = config.get('assets_subcommand')
         args = [config.get("assets.{}.days".format(sub_command)),
-                config.get("assets.{}.size_filter".format(sub_command))]
+                config.get("assets.{}.size_filter".format(sub_command)),
+                config.get("assets.{}.overall_limit".format(sub_command))]
         return len([a for a in args if a is not None])
 
     def configure(self, parser):
@@ -304,6 +306,20 @@ class Assets(CLICmd):
                                      key_type=int,
                                      metavar="DAYS",
                                      long_arg='--by-days',
+                                     parser=subparser)
+
+            help_msg = ("Filter will be based on a overall system limit "
+                        "threshold in bytes (with assets orded by last "
+                        "access) or with a suffix unit. Valid suffixes are: ")
+            help_msg += ','.join(DataSize.MULTIPLIERS.keys())
+
+            settings.register_option(section=section,
+                                     key='overall_limit',
+                                     help_msg=help_msg,
+                                     default=None,
+                                     key_type=str,
+                                     metavar="LIMIT",
+                                     long_arg='--by-overall-limit',
                                      parser=subparser)
 
         parser = super(Assets, self).configure(parser)
@@ -381,6 +397,8 @@ class Assets(CLICmd):
     def handle_purge(self, config):
         days = config.get('assets.purge.days')
         size_filter = config.get('assets.purge.size_filter')
+        overall_limit = config.get('assets.purge.overall_limit')
+
         if self._count_filter_args(config) != 1:
             msg = ("You should choose --by-size-filter or --by-days. "
                    "For help, run: avocado assets purge --help")
@@ -393,6 +411,17 @@ class Assets(CLICmd):
                 Asset.remove_assets_by_unused_for_days(days, cache_dirs)
             elif size_filter is not None:
                 Asset.remove_assets_by_size(size_filter, cache_dirs)
+            elif overall_limit is not None:
+                try:
+                    size = DataSize(overall_limit).b
+                    Asset.remove_assets_by_overall_limit(size, cache_dirs)
+                except InvalidDataSize:
+                    error_msg = "You are using an invalid suffix. "
+                    error_msg += "Use one of the following values: "
+                    error_msg += ",".join(DataSize.MULTIPLIERS.keys())
+                    LOG_UI.error(error_msg)
+                    return
+
         except (FileNotFoundError, OSError) as e:
             LOG_UI.error("Could not remove asset: %s", e)
 

--- a/avocado/plugins/assets.py
+++ b/avocado/plugins/assets.py
@@ -268,6 +268,13 @@ class Assets(CLICmd):
     name = 'assets'
     description = 'Manage assets'
 
+    @staticmethod
+    def _count_filter_args(config):
+        sub_command = config.get('assets_subcommand')
+        args = [config.get("assets.{}.days".format(sub_command)),
+                config.get("assets.{}.size_filter".format(sub_command))]
+        return len([a for a in args if a is not None])
+
     def configure(self, parser):
         """
         Add the subparser for the assets action.
@@ -374,8 +381,7 @@ class Assets(CLICmd):
     def handle_purge(self, config):
         days = config.get('assets.purge.days')
         size_filter = config.get('assets.purge.size_filter')
-        if (days is None and size_filter is None) \
-                or (days is not None and size_filter is not None):
+        if self._count_filter_args(config) != 1:
             msg = ("You should choose --by-size-filter or --by-days. "
                    "For help, run: avocado assets purge --help")
             LOG_UI.error(msg)
@@ -393,7 +399,7 @@ class Assets(CLICmd):
     def handle_list(self, config):
         days = config.get('assets.list.days')
         size_filter = config.get('assets.list.size_filter')
-        if (days is not None and size_filter is not None):
+        if self._count_filter_args(config) == 2:
             msg = ("You should choose --by-size-filter or --by-days. "
                    "For help, run: avocado assets list --help")
             LOG_UI.error(msg)

--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -431,7 +431,7 @@ class Asset:
         return os.path.basename(self.parsed_name.path)
 
     @classmethod
-    def get_all_assets(cls, cache_dirs):
+    def get_all_assets(cls, cache_dirs, sort=True):
         """Returns all assets stored in all cache dirs."""
         assets = []
         for cache_dir in cache_dirs:
@@ -441,6 +441,11 @@ class Asset:
                     if not f.endswith('-CHECKSUM') and \
                        not f.endswith('_metadata.json'):
                         assets.append(os.path.join(root, f))
+        if sort:
+            assets = {a: os.stat(a).st_atime for a in assets}
+            return [a[0] for a in sorted(assets.items(),
+                                         key=lambda x: x[1],
+                                         reverse=True)]
         return assets
 
     @classmethod

--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -539,6 +539,27 @@ class Asset:
         return result
 
     @classmethod
+    def remove_assets_by_overall_limit(cls, limit, cache_dirs):
+        """This will remove assets based on overall limit.
+
+        We are going to sort the assets based on the access time first.
+        For instance it may be the case that a GitLab cache limit is 4
+        GiB, in that case we can sort by last access, and remove all
+        that exceeds 4 GiB (that is, keep the last accessed 4 GiB worth
+        of cached files).
+
+        Note: during the usage of this method, you should use bytes as limit.
+
+        :param limit: a integer limit in bytes.
+        :param cache_dirs: list of directories to use during the search.
+        """
+        size_sum = 0
+        for asset in cls.get_all_assets(cache_dirs):
+            size_sum += os.stat(asset).st_size
+            if size_sum >= limit:
+                cls.remove_asset_by_path(asset)
+
+    @classmethod
     def remove_assets_by_size(cls, size_filter, cache_dirs):
         for file_path in cls.get_assets_by_size(size_filter, cache_dirs):
             cls.remove_asset_by_path(file_path)

--- a/docs/source/guides/user/chapters/assets.rst
+++ b/docs/source/guides/user/chapters/assets.rst
@@ -52,6 +52,25 @@ Assets can be removed applying the same filters as described when listing them.
 You can remove assets by a size filter (`--by-size-filter`) or assets older
 than N days (`--by-days`).
 
+Removing by overall cache limit
+-------------------------------
+
+Besides the existing features, Avocado is able to set an overall limit, so that
+it matches the storage limitations of users (and CI systems).
+
+For instance it may be the case that a GitLab cache limit is 4 GiB, in that
+case we can sort by last access, and remove all that exceeds 4 GiB (that is,
+keep the last accessed 4 GiB worth of cached files). You can run the following
+command::
+
+ $ avocado assets purge --by-overall-limit=4g
+
+This would ensure that the cache is automatically being removed of files that
+were used last (and possibly not used anymore).
+
+Please, note that at the moment, you can only use 'b', 'k', 'm', 'g' and 't' as
+suffix.
+
 Changing the default cache dirs
 -------------------------------
 

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -502,7 +502,8 @@ def create_suites(args):
                            'selftests/unit/',
                            'selftests/functional/'],
         'run.test_runner': 'nrunner',
-        'run.ignore_missing_references': True
+        'run.ignore_missing_references': True,
+        'job.output.testlogs.statuses': ['FAIL']
     }
 
     if not args.disable_static_checks:

--- a/spell.ignore
+++ b/spell.ignore
@@ -741,3 +741,4 @@ crit
 err
 getpcaps
 libcap
+GiB


### PR DESCRIPTION
This will remove assets by an overall limit sorting assets by atime.
For instance, it may be the case that a GitLab cache limit is 4 GiB, in
that case, we can sort by last access, and remove all that exceeds 4 GiB
(that is, keep the last accessed 4 GiB worth of cached files). This
fixes #4457.

Signed-off-by: Beraldo Leal bleal@redhat.com

Changes from v1:

 - fixed typo on commit log msg;
 - Improved docstring to make explicitly about bytes;
 - Improved documentation on our user guide about suffixes;
 - Getting valid suffixes from DataSize class;
 - Squashed two commits (about spell.ignore)