### PR TITLE
Nrunner comunication

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -172,6 +172,10 @@ class Job:
                                        .load_failures)
         return self._result_events_dispatcher
 
+    @property
+    def test_results_path(self):
+        return os.path.join(self.logdir, 'test-results')
+
     def __enter__(self):
         self.setup()
         return self

--- a/avocado/core/messages.py
+++ b/avocado/core/messages.py
@@ -1,0 +1,271 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2021
+# Authors: Jan Richter <jarichte@redhat.com>
+
+"""
+Message resolver for runner messages
+"""
+
+import abc
+import os
+
+
+class MessageProcessor:
+    """Entry point for handling all types of messages."""
+
+    def __init__(self):
+        self._handlers = [StartMessageHandler(),
+                          RunningMessageHandler(),
+                          FinishMessageHandler()]
+
+    def process_message(self, message, task, job):
+        """
+        It transmits the message to the right handler.
+
+        :param message: message from runner
+        :type message: dict
+        :param task: runtime_task which message is related to
+        :type task: :class:`avocado.core.nrunner.Task`
+        :param job: job which task is related to
+        :type job: :class: `avocado.core.job.Job`
+        """
+        for handler in self._handlers:
+            if handler.handle(message, task, job):
+                break
+
+
+class MessageHandler(abc.ABC):
+    """
+    Base interface for resolving runner messages.
+
+    This is the interface a job uses to deal with messages form runners.
+    """
+
+    @abc.abstractmethod
+    def handle(self, message, task, job):
+        """
+        Handle message from runner.
+
+        :param message: message from runner.
+        :type message: dict
+        :param task: runtime_task which message is related to
+        :type task: :class:`avocado.core.nrunner.Task`
+        :param job: job which task is related to
+        :type job: :class: `avocado.core.job.Job`
+        """
+
+    @staticmethod
+    def _save_to_file(filename, buff, mode='a'):
+        with open(filename, mode) as fp:
+            fp.write("%s\n" % buff)
+
+
+class StartMessageHandler(MessageHandler):
+    """
+    Handler for started message. It will create the test base directories
+    and triggers the 'start_test' event.
+
+    This is triggered when the runner starts the test.
+
+    The started message properties:
+    param status: 'started'
+    param time: start time of the test
+    type time: float
+
+    example: {'status': 'started', 'time': 16444.819830573}
+    """
+
+    def handle(self, message, task, job):
+        if message['status'] != 'started':
+            return False
+
+        base_path = job.test_results_path
+        task_path = os.path.join(base_path, task.identifier.str_filesystem)
+        os.makedirs(task_path, exist_ok=True)
+        metadata = {'job_logdir': job.logdir, 'job_unique_id': job.unique_id,
+                    'base_path': base_path, 'task_path': task_path,
+                    'time_start': message['time'], 'name': task.identifier}
+        job.result.start_test(metadata)
+        job.result_events_dispatcher.map_method('start_test', job.result,
+                                                metadata)
+        task.metadata.update(metadata)
+        return True
+
+
+class FinishMessageHandler(MessageHandler):
+    """
+    Handler for finished message. It will report the test status and
+    triggers the 'end_test' event.
+
+    This is triggered when the runner ends the test.
+
+    The finished message properties:
+    param status: 'finished'
+    param result: test result
+    type result: `avocado.core.teststatus.user_facing_status`
+    param time: end time of the test
+    type time: float
+
+    example: {'status': 'finished', 'result': 'pass', 'time': 16444.819830573}
+    """
+
+    def handle(self, message, task, job):
+        if message['status'] != 'finished':
+            return False
+
+        message.update(task.metadata)
+        message['name'] = task.identifier
+        message['status'] = message.get('result').upper()
+
+        time_start = message['time_start']
+        time_end = message['time']
+        time_elapsed = time_end - time_start
+        message['time_end'] = time_end
+        message['time_elapsed'] = time_elapsed
+
+        message['logdir'] = task.metadata['task_path']
+
+        job.result.check_test(message)
+        job.result_events_dispatcher.map_method('end_test', job.result, message)
+        return True
+
+
+class RunningMessageHandler(MessageHandler):
+    """Entry point for handling running messages."""
+
+    def __init__(self):
+        self._running_handlers = [LogMessageHandler(),
+                                  StdoutMessageHandler(),
+                                  StderrMessageHandler(),
+                                  WhiteboardMessageHandler()]
+
+    def handle(self, message, task, job):
+        """
+        For the messages with status running choose the right handler
+        by type.
+        """
+        if message['status'] != 'running':
+            return False
+
+        for handler in self._running_handlers:
+            if handler.handle(message, task, job):
+                break
+        return True
+
+
+class LogMessageHandler(MessageHandler):
+    """
+    Handler for log message. It will save the log to the debug.log file in
+    the task directory.
+
+    The log message properties:
+    param status: 'running'
+    param type: 'log'
+    param log: log message
+    type log: string
+    param time: Time stamp of the message
+    type time: float
+
+    example: {'status': 'running', 'type': 'log', 'log': 'log message',
+             'time': 18405.55351474}
+    """
+
+    def handle(self, message, task, job):
+        if message.get('type', None) != 'log':
+            return False
+
+        task_path = task.metadata['task_path']
+        debug = os.path.join(task_path, 'debug.log')
+        self._save_to_file(debug, message['log'])
+        return True
+
+
+class StdoutMessageHandler(MessageHandler):
+    """
+    Handler for stdout message. It will save the stdout to the stdout file in
+    the task directory.
+
+    The log message properties:
+    param status: 'running'
+    param type: 'stdout'
+    param log: stdout message
+    type log: string
+    param time: Time stamp of the message
+    type time: float
+
+    example: {'status': 'running', 'type': 'stdout', 'log': 'stdout message',
+             'time': 18405.55351474}
+    """
+
+    def handle(self, message, task, job):
+        if message.get('type', None) != 'stdout':
+            return False
+
+        task_path = task.metadata['task_path']
+        stdout = os.path.join(task_path, 'stdout')
+        self._save_to_file(stdout, message['log'])
+        return True
+
+
+class StderrMessageHandler(MessageHandler):
+    """
+    Handler for stderr message. It will save the stderr to the stderr file in
+    the task directory.
+
+    The log message properties:
+    param status: 'running'
+    param type: 'stderr'
+    param log: stderr message
+    type log: string
+    param time: Time stamp of the message
+    type time: float
+
+    example: {'status': 'running', 'type': 'stderr', 'log': 'stderr message',
+             'time': 18405.55351474}
+    """
+
+    def handle(self, message, task, job):
+        if message.get('type', None) != 'stderr':
+            return False
+
+        task_path = task.metadata['task_path']
+        stderr = os.path.join(task_path, 'stderr')
+        self._save_to_file(stderr, message['log'])
+        return True
+
+
+class WhiteboardMessageHandler(MessageHandler):
+    """
+    Handler for whiteboard message. It will save the stderr to the whiteboard
+    file in the task directory.
+
+    The log message properties:
+    param status: 'running'
+    param type: 'whiteboard'
+    param log: whiteboard message
+    type log: string
+    param time: Time stamp of the message
+    type time: float
+
+    example: {'status': 'running', 'type': 'whiteboard',
+             'log': 'whiteboard message', 'time': 18405.55351474}
+    """
+
+    def handle(self, message, task, job):
+        if message.get('type', None) != 'whiteboard':
+            return False
+
+        task_path = task.metadata['task_path']
+        whiteboard = os.path.join(task_path, 'whiteboard')
+        self._save_to_file(whiteboard, message['log'])
+        return True

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -334,11 +334,11 @@ class BaseRunner(metaclass=abc.ABCMeta):
 
         :rtype: dict
         """
-        status = {'status': status_type,
-                  'time': time.monotonic()}
-
+        status = {}
         if isinstance(additional_info, dict):
-            status.update(additional_info)
+            status = additional_info
+        status.update({'status': status_type,
+                       'time': time.monotonic()})
         return status
 
     @abc.abstractmethod

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -687,6 +687,7 @@ class Task:
         self.known_runners = known_runners
         self.spawn_handle = None
         self.output_dir = None
+        self.metadata = {}
 
     def __repr__(self):
         fmt = '<Task identifier="{}" runnable="{}" status_services="{}"'

--- a/avocado/core/runners/avocado_instrumented.py
+++ b/avocado/core/runners/avocado_instrumented.py
@@ -1,10 +1,42 @@
+import logging
 import multiprocessing
+import sys
 import tempfile
 import time
 
-from .. import loader, nrunner, teststatus
+from .. import loader, nrunner, output
 from ..test import TestID
 from ..tree import TreeNode
+
+
+def _send_message(msg, queue, message_type):
+    status = {'type': message_type, 'log': msg}
+    queue.put(status)
+
+
+class RunnerLogHandler(logging.Handler):
+
+    def __init__(self, queue, message_type):
+        super().__init__()
+        self.queue = queue
+        self.message_type = message_type
+
+    def emit(self, record):
+        msg = self.format(record)
+        _send_message(msg, self.queue, self.message_type)
+
+
+class StreamToQueue:
+
+    def __init__(self,  queue, message_type):
+        self.queue = queue
+        self.message_type = message_type
+
+    def write(self, buf):
+        _send_message(buf, self.queue, self.message_type)
+
+    def flush(self):
+        pass
 
 
 class AvocadoInstrumentedTestRunner(nrunner.BaseRunner):
@@ -21,6 +53,24 @@ class AvocadoInstrumentedTestRunner(nrunner.BaseRunner):
      * args: not used
     """
     DEFAULT_TIMEOUT = 86400
+
+    @staticmethod
+    def _start_logging(runnable, queue):
+        log_level = runnable.config.get('job.output.loglevel', logging.DEBUG)
+        log_handler = RunnerLogHandler(queue, 'log')
+        fmt = '%(asctime)s %(levelname)-5.5s| %(message)s'
+        formatter = logging.Formatter(fmt=fmt, datefmt='%H:%M:%S')
+        log_handler.setFormatter(formatter)
+        log = output.LOG_JOB
+        log.addHandler(log_handler)
+        log.setLevel(log_level)
+        log.propagate = False
+        root_logger = logging.getLogger()
+        root_logger.addHandler(log_handler)
+        output.LOG_UI.addHandler(RunnerLogHandler(queue, 'stdout'))
+
+        sys.stdout = StreamToQueue(queue, "stdout")
+        sys.stderr = StreamToQueue(queue, "stderr")
 
     @staticmethod
     def _run_avocado(runnable, queue):
@@ -45,28 +95,15 @@ class AvocadoInstrumentedTestRunner(nrunner.BaseRunner):
                          'run.results_dir': tempfile.mkdtemp(),
                          }]
 
+        AvocadoInstrumentedTestRunner._start_logging(runnable, queue)
         instance = loader.loader.load_test(test_factory)
         early_state = instance.get_state()
+        early_state['type'] = "early_state"
         queue.put(early_state)
         instance.run_avocado()
         state = instance.get_state()
-        # This should probably be done in a translator
-        if 'status' in state:
-            status = state['status'].lower()
-            final_status = [_.lower() for _ in teststatus.user_facing_status]
-            if status in final_status:
-                state['result'] = status
-                state['status'] = 'finished'
-            else:
-                state['status'] = 'running'
-
-        # This is a hack because the name is a TestID instance that can not
-        # at this point be converted to JSON
-        if 'name' in state:
-            del state['name']
-        if 'time_start' in state:
-            del state['time_start']
-        queue.put(state)
+        _send_message(state['whiteboard'], queue, 'whiteboard')
+        queue.put({'status': 'finished', 'result': state['status'].lower()})
 
     def run(self):
         queue = multiprocessing.SimpleQueue()
@@ -77,41 +114,41 @@ class AvocadoInstrumentedTestRunner(nrunner.BaseRunner):
 
         time_started = time.monotonic()
         yield self.prepare_status('started')
-
-        # Waiting for early status
-        while queue.empty():
-            time.sleep(nrunner.RUNNER_RUN_CHECK_INTERVAL)
-
-        early_status = queue.get()
-        timeout = float(early_status.get('timeout') or self.DEFAULT_TIMEOUT)
-        interrupted = False
+        early_status = {}
+        timeout = float(self.DEFAULT_TIMEOUT)
         most_current_execution_state_time = None
-        while queue.empty():
+        while True:
             time.sleep(nrunner.RUNNER_RUN_CHECK_INTERVAL)
             now = time.monotonic()
-            if most_current_execution_state_time is not None:
-                next_execution_state_mark = (most_current_execution_state_time +
-                                             nrunner.RUNNER_RUN_STATUS_INTERVAL)
-            if (most_current_execution_state_time is None or
-                    now > next_execution_state_mark):
-                most_current_execution_state_time = now
-                yield self.prepare_status('running')
-            if (now - time_started) > timeout:
-                process.terminate()
-                interrupted = True
-                break
-        if interrupted:
-            status = early_status
-            status['result'] = 'interrupted'
-            status['status'] = 'finished'
-            if 'name' in status:
-                del status['name']
-            if 'time_start' in status:
-                del status['time_start']
-        else:
-            status = queue.get()
-        status['time'] = time.monotonic()
-        yield status
+            if queue.empty():
+                if most_current_execution_state_time is not None:
+                    next_execution_state_mark = (most_current_execution_state_time +
+                                                 nrunner.RUNNER_RUN_STATUS_INTERVAL)
+                if (most_current_execution_state_time is None or
+                        now > next_execution_state_mark):
+                    most_current_execution_state_time = now
+                    yield self.prepare_status('running')
+                if (now - time_started) > timeout:
+                    process.terminate()
+                    status = early_status
+                    status['result'] = 'interrupted'
+                    if 'name' in status:
+                        del status['name']
+                    if 'time_start' in status:
+                        del status['time_start']
+                    yield self.prepare_status('finished', status)
+                    break
+            else:
+                status = queue.get()
+                if status.get('status', None) == 'finished':
+                    yield self.prepare_status('finished', status)
+                    break
+                elif status.get('type') == 'early_state':
+                    early_status = status
+                    timeout = float(early_status.get('timeout') or
+                                    self.DEFAULT_TIMEOUT)
+                else:
+                    yield self.prepare_status('running', status)
 
 
 class RunnerApp(nrunner.BaseRunnerApp):

--- a/avocado/core/status/repo.py
+++ b/avocado/core/status/repo.py
@@ -52,9 +52,14 @@ class StatusRepo:
             self._all_data[task_id] = []
         self._all_data[task_id].append(message)
 
-    def get_task_data(self, task_id):
+    def get_all_task_data(self, task_id):
         """Returns all data on a given task, by its ID."""
         return self._all_data.get(task_id)
+
+    def get_task_data(self, task_id, index):
+        """Returns data on a given task, by its ID."""
+        task_data = self._all_data.get(task_id)
+        return task_data[index]
 
     def get_latest_task_data(self, task_id):
         """Returns the latest data on a given task, by its ID."""
@@ -72,12 +77,13 @@ class StatusRepo:
             return
         if task_id not in self._status:
             self._status[task_id] = (status, time)
-            self._status_journal_summary.append((task_id, status, time))
+            self._status_journal_summary.append((task_id, status, time, 0))
         else:
-            current_status, current_time = self._status[task_id]
-            # journal even with the same time, if there's a change in status
-            if (status != current_status) and (time >= current_time):
-                self._status_journal_summary.append((task_id, status, time))
+            _, current_time = self._status[task_id]
+            if time >= current_time:
+                index = len(self.get_all_task_data(task_id))
+                self._status_journal_summary.append((task_id, status, time,
+                                                     index))
             if time > current_time:
                 self._status[task_id] = (status, time)
 

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -210,7 +210,7 @@ class Runner(RunnerInterface):
                        for runtime_task in self.tasks}
         while True:
             try:
-                (task_id, status, _) = self.status_repo.status_journal_summary.pop(0)
+                (task_id, status, _, _) = self.status_repo.status_journal_summary.pop(0)
 
             except IndexError:
                 await asyncio.sleep(0.05)
@@ -226,7 +226,7 @@ class Runner(RunnerInterface):
                                                         job.result,
                                                         early_state)
             elif status == 'finished':
-                this_task_data = self.status_repo.get_task_data(task_id)
+                this_task_data = self.status_repo.get_all_task_data(task_id)
                 last_task_status = this_task_data[-1]
                 test_state = last_task_status.copy()
                 test_state['status'] = last_task_status.get('result').upper()

--- a/docs/source/guides/contributor/chapters/runners.rst
+++ b/docs/source/guides/contributor/chapters/runners.rst
@@ -568,3 +568,96 @@ for runnables with kind ``foo``.
 .. literalinclude:: ../../../../../examples/nrunner/runners/avocado-runner-foo
    :language: python
    :linenos:
+
+
+Runners messages
+----------------
+
+Every runner have to send information about the run to the avocado
+core. Those informations are sent by messages which have different
+types based on the information which they are transmitting. Avocado
+understands three main types of messages, the start, running, and
+finish. The start and finish messages are obligatory and every
+runner have to send those. The running messages can transmitting
+different information during runner run-time like logs, warnings,
+errors .etc and those informations will be processed by avocado core.
+
+Supported message types
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Start message
++++++++++++++
+This message has to be sent when the runner starts the test.
+
+:param status: 'started'
+:param time: start time of the test
+:type time: float
+:example: {'status': 'started', 'time': 16444.819830573}
+
+Finished message
+++++++++++++++++
+This message has to be sent when the runner finishes the test.
+
+:param status: 'finished'
+:param result: test result
+:type result: `avocado.core.teststatus.user_facing_status`
+:param time: end time of the test
+:type time: float
+:example: {'status': 'finished', 'result': 'pass', 'time': 16444.819830573}
+
+Running messages
+++++++++++++++++
+This message can be used during the run-time and has different properties
+based on the information which is being transmitted.
+
+Log message
+***********
+It will save the log to the debug.log file in the task directory.
+
+:param status: 'running'
+:param type: 'log'
+:param log: log message
+:type log: string
+:param time: Time stamp of the message
+:type time: float
+:example: {'status': 'running', 'type': 'log', 'log': 'log message',
+         'time': 18405.55351474}
+
+Stdout message
+**************
+It will save the stdout to the stdout file in the task directory.
+
+:param status: 'running'
+:param type: 'stdout'
+:param log: stdout message
+:type log: string
+:param time: Time stamp of the message
+:type time: float
+:example: {'status': 'running', 'type': 'stdout', 'log': 'stdout message',
+         'time': 18405.55351474}
+
+Stderr message
+**************
+It will save the stderr to the stderr file in the task directory.
+
+:param status: 'running'
+:param type: 'stderr'
+:param log: stderr message
+:type log: string
+:param time: Time stamp of the message
+:type time: float
+:example: {'status': 'running', 'type': 'stderr', 'log': 'stderr message',
+         'time': 18405.55351474}
+
+Whiteboard message
+******************
+It will save the stderr to the whiteboard file in the task directory.
+
+:param status: 'running'
+:param type: 'whiteboard'
+:param log: whiteboard message
+:type log: string
+:param time: Time stamp of the message
+:type time: float
+:example: {'status': 'running', 'type': 'whiteboard',
+         'log': 'whiteboard message', 'time': 18405.55351474}

--- a/examples/nrunner/runners/avocado-runner-foo
+++ b/examples/nrunner/runners/avocado-runner-foo
@@ -5,9 +5,8 @@ from avocado.core import nrunner
 
 class FooRunner(nrunner.BaseRunner):
     def run(self):
-        yield {'status': 'pass',
-               # some extra info that a custom runner may return
-               'foo_level': len(self.runnable.uri)}
+        yield self.prepare_status('started')
+        yield self.prepare_status('finished', {'result': 'pass'})
 
 
 class RunnerApp(nrunner.BaseRunnerApp):

--- a/selftests/unit/test_status_repo.py
+++ b/selftests/unit/test_status_repo.py
@@ -26,7 +26,7 @@ class StatusRepo(TestCase):
     def test_handle_task_started(self):
         msg = {"id": "1-foo", "status": "started", "output_dir": "/fake/path"}
         self.status_repo._handle_task_started(msg)
-        self.assertEqual(self.status_repo.get_task_data("1-foo"),
+        self.assertEqual(self.status_repo.get_all_task_data("1-foo"),
                          [{"status": "started", "output_dir": "/fake/path"}])
 
     def test_handle_task_started_no_output_dir(self):
@@ -37,33 +37,33 @@ class StatusRepo(TestCase):
     def test_handle_task_finished_no_result(self):
         msg = {"id": "1-foo", "status": "finished"}
         self.status_repo._handle_task_finished(msg)
-        self.assertEqual(self.status_repo.get_task_data("1-foo"),
+        self.assertEqual(self.status_repo.get_all_task_data("1-foo"),
                          [{"status": "finished"}])
         self.assertEqual(self.status_repo._by_result.get(None), ["1-foo"])
 
     def test_handle_task_finished_result(self):
         msg = {"id": "1-foo", "status": "finished", "result": "pass"}
         self.status_repo._handle_task_finished(msg)
-        self.assertEqual(self.status_repo.get_task_data("1-foo"),
+        self.assertEqual(self.status_repo.get_all_task_data("1-foo"),
                          [{"status": "finished", "result": "pass"}])
         self.assertEqual(self.status_repo._by_result.get("pass"), ["1-foo"])
 
     def test_process_message_running(self):
         msg = {"id": "1-foo", "status": "running"}
         self.status_repo.process_message(msg)
-        self.assertEqual(self.status_repo.get_task_data("1-foo"),
+        self.assertEqual(self.status_repo.get_all_task_data("1-foo"),
                          [{"status": "running"}])
 
     def test_process_raw_message_task_started(self):
         msg = '{"id": "1-foo", "status": "started", "output_dir": "/fake/path"}'
         self.status_repo.process_raw_message(msg)
-        self.assertEqual(self.status_repo.get_task_data("1-foo"),
+        self.assertEqual(self.status_repo.get_all_task_data("1-foo"),
                          [{"status": "started", "output_dir": "/fake/path"}])
 
     def test_process_raw_message_task_running(self):
         msg = '{"id": "1-foo", "status": "running"}'
         self.status_repo.process_raw_message(msg)
-        self.assertEqual(self.status_repo.get_task_data("1-foo"),
+        self.assertEqual(self.status_repo.get_all_task_data("1-foo"),
                          [{"status": "running"}])
 
     def test_process_messages_running(self):
@@ -110,8 +110,8 @@ class StatusRepo(TestCase):
         self.status_repo.process_message(msg)
         self.assertEqual(self.status_repo.get_task_status("1-foo"), "finished")
         self.assertEqual(self.status_repo.status_journal_summary.pop(),
-                         ("1-foo", "finished", 1000000004.0))
+                         ("1-foo", "finished", 1000000004.0, 3))
         self.assertEqual(self.status_repo.status_journal_summary.pop(),
-                         ("1-foo", "running", 1000000003.0))
+                         ("1-foo", "running", 1000000003.0, 0))
         with self.assertRaises(IndexError):
             self.status_repo.status_journal_summary.pop()

--- a/spell.ignore
+++ b/spell.ignore
@@ -741,3 +741,4 @@ crit
 err
 getpcaps
 libcap
+jarichte


### PR DESCRIPTION
This is the messaging between runners and avocado core. It adds the ability to nrunners sending messages to avocado core in runtime. It is created from #4479

As example when you run the instrumented test it will create a test log file under `job/test-result/test`

It based on #4418, and it solves part of #4308