### PR TITLE
Sysinfo: support configuration files installed system wide [v2]

### DIFF
--- a/avocado/core/utils.py
+++ b/avocado/core/utils.py
@@ -34,3 +34,30 @@ def prepend_base_path(value):
         dist = get_distribution('avocado-framework')
         return os.path.join(dist.location, 'avocado', expanded)
     return expanded
+
+
+def system_wide_or_base_path(file_path):
+    """Returns either a system wide path, or one relative to the base.
+
+    If "etc/avocado/avocado.conf" is given as input, it checks for the
+    existence of "/etc/avocado/avocado.conf".  If that path does not exist,
+    then a path starting with the avocado's Python's distribution is returned.
+    In that case it'd return something like
+    "/usr/lib/python3.9/site-packages/avocado/etc/avocado/avocado.conf".
+
+    :param file_path: a filesystem path that can either be absolute, or
+                      relative.  If relative, the absolute equivalent
+                      (that is, by prefixing the filesystem root location)
+                      is checked for existence.  If it does not exist, a
+                      path relative to the Python's distribution base path
+                      is returned.
+    :type file_path: str
+    :rtype: str
+    """
+    if os.path.isabs(file_path):
+        abs_path = file_path
+    else:
+        abs_path = os.path.join(os.path.sep, file_path)
+    if os.path.exists(abs_path):
+        return abs_path
+    return prepend_base_path(file_path)

--- a/avocado/plugins/sysinfo.py
+++ b/avocado/plugins/sysinfo.py
@@ -19,7 +19,7 @@ from avocado.core import sysinfo
 from avocado.core.plugin_interfaces import (CLICmd, Init, JobPostTests,
                                             JobPreTests)
 from avocado.core.settings import settings
-from avocado.core.utils import prepend_base_path
+from avocado.core.utils import prepend_base_path, system_wide_or_base_path
 from avocado.utils import path
 
 
@@ -84,7 +84,7 @@ class SysinfoInit(Init):
 
         help_msg = ('File with list of commands that will be executed and '
                     'have their output collected')
-        default = prepend_base_path('etc/avocado/sysinfo/commands')
+        default = system_wide_or_base_path('etc/avocado/sysinfo/commands')
         settings.register_option(section='sysinfo.collectibles',
                                  key='commands',
                                  key_type=prepend_base_path,
@@ -92,7 +92,7 @@ class SysinfoInit(Init):
                                  help_msg=help_msg)
         help_msg = ('File with list of commands that will be executed and '
                     'have their output collected, in case of failed test')
-        default = prepend_base_path('etc/avocado/sysinfo/fail_commands')
+        default = system_wide_or_base_path('etc/avocado/sysinfo/fail_commands')
         settings.register_option(section='sysinfo.collectibles',
                                  key='fail_commands',
                                  key_type=prepend_base_path,
@@ -100,7 +100,7 @@ class SysinfoInit(Init):
                                  help_msg=help_msg)
 
         help_msg = 'File with list of files that will be collected verbatim'
-        default = prepend_base_path('etc/avocado/sysinfo/files')
+        default = system_wide_or_base_path('etc/avocado/sysinfo/files')
         settings.register_option(section='sysinfo.collectibles',
                                  key='files',
                                  key_type=prepend_base_path,
@@ -109,7 +109,7 @@ class SysinfoInit(Init):
 
         help_msg = ('File with list of files that will be collected verbatim'
                     ', in case of failed test')
-        default = prepend_base_path('etc/avocado/sysinfo/fail_files')
+        default = system_wide_or_base_path('etc/avocado/sysinfo/fail_files')
         settings.register_option(section='sysinfo.collectibles',
                                  key='fail_files',
                                  key_type=prepend_base_path,
@@ -118,7 +118,7 @@ class SysinfoInit(Init):
 
         help_msg = ('File with list of commands that will run alongside the '
                     'job/test')
-        default = prepend_base_path('etc/avocado/sysinfo/profilers')
+        default = system_wide_or_base_path('etc/avocado/sysinfo/profilers')
         settings.register_option(section='sysinfo.collectibles',
                                  key='profilers',
                                  key_type=prepend_base_path,


### PR DESCRIPTION
Commit 768455c3 removed the existing configuration files, and with
that, the patching that happened on the RPM SPEC file changing the
sysinfo defaults to the system wide /etc based locations.

Without a configuration file to tweak, we're left wither with patching
code, or making the code more dynamic and respecting the system wide
configuration paths no matter if it's an RPM based installation or
not.  This chooses the later.

Fixes: https://github.com/avocado-framework/avocado/issues/4208
Signed-off-by: Cleber Rosa <crosa@redhat.com>

---

Changes from v1 (#4508):
* Added docstring (@pevogam)
* Properly handle absolute paths given as input (@pevogam)