### PR TITLE
Test status: remove obsolete and rename / document definitions

### DIFF
--- a/avocado/core/runners/avocado_instrumented.py
+++ b/avocado/core/runners/avocado_instrumented.py
@@ -53,7 +53,7 @@ class AvocadoInstrumentedTestRunner(nrunner.BaseRunner):
         # This should probably be done in a translator
         if 'status' in state:
             status = state['status'].lower()
-            final_status = [_.lower() for _ in teststatus.user_facing_status]
+            final_status = [_.lower() for _ in teststatus.STATUSES]
             if status in final_status:
                 state['result'] = status
                 state['status'] = 'finished'

--- a/avocado/core/teststatus.py
+++ b/avocado/core/teststatus.py
@@ -24,10 +24,4 @@ mapping = {"SKIP": True,
            "INTERRUPTED": False,
            "CANCEL": True}
 
-user_facing_status = ["SKIP",
-                      "ERROR",
-                      "FAIL",
-                      "WARN",
-                      "PASS",
-                      "INTERRUPTED",
-                      "CANCEL"]
+user_facing_status = [key for key in mapping.keys()]

--- a/avocado/core/teststatus.py
+++ b/avocado/core/teststatus.py
@@ -10,18 +10,18 @@
 # See LICENSE for more details.
 
 """
-Maps the different status strings in avocado to booleans.
-
-This is used by methods and functions to return a cut and dry answer to whether
-a test or a job in avocado PASSed or FAILed.
+Valid test statuses and whether they signal success (or failure).
 """
 
-mapping = {"SKIP": True,
-           "ERROR": False,
-           "FAIL": False,
-           "WARN": True,
-           "PASS": True,
-           "INTERRUPTED": False,
-           "CANCEL": True}
+#: Maps the different status strings in avocado to booleans.
+STATUSES_SUCCESS = {"SKIP": True,
+                    "ERROR": False,
+                    "FAIL": False,
+                    "WARN": True,
+                    "PASS": True,
+                    "INTERRUPTED": False,
+                    "CANCEL": True}
 
-user_facing_status = [key for key in mapping.keys()]
+#: Valid test statuses, if a returned status is not listed here, it
+#: should be handled as error condition.
+STATUSES = [key for key in STATUSES_SUCCESS.keys()]

--- a/avocado/core/teststatus.py
+++ b/avocado/core/teststatus.py
@@ -17,15 +17,10 @@ a test or a job in avocado PASSed or FAILed.
 """
 
 mapping = {"SKIP": True,
-           "ABORT": False,
            "ERROR": False,
            "FAIL": False,
            "WARN": True,
            "PASS": True,
-           "START": True,
-           "ALERT": False,
-           "RUNNING": False,
-           "NOSTATUS": False,
            "INTERRUPTED": False,
            "CANCEL": True}
 

--- a/avocado/plugins/legacy/replay.py
+++ b/avocado/plugins/legacy/replay.py
@@ -83,11 +83,11 @@ class Replay(CLI):
             return []
         status_list = string.split(',')
         for item in status_list:
-            if item not in teststatus.user_facing_status:
+            if item not in teststatus.STATUSES:
                 msg = ('Invalid --replay-test-status option. Valid '
                        'options are (more than one allowed): %s' %
                        ','.join([item for item
-                                 in teststatus.user_facing_status]))
+                                 in teststatus.STATUSES]))
                 raise argparse.ArgumentTypeError(msg)
 
         return status_list

--- a/avocado/plugins/runner.py
+++ b/avocado/plugins/runner.py
@@ -33,7 +33,7 @@ from avocado.core.plugin_interfaces import Runner
 from avocado.core.runner import TestStatus, add_runner_failure
 from avocado.core.test import TimeOutSkipTest
 from avocado.core.test_id import TestID
-from avocado.core.teststatus import mapping, user_facing_status
+from avocado.core.teststatus import STATUSES, STATUSES_SUCCESS
 from avocado.utils import process, stacktrace, wait
 
 
@@ -256,7 +256,7 @@ class TestRunner(Runner):
             job.log.debug('')
 
         # Make sure the test status is correct
-        if test_state.get('status') not in user_facing_status:
+        if test_state.get('status') not in STATUSES:
             test_state = add_runner_failure(test_state, "ERROR", "Test reports"
                                             " unsupported test status.")
 
@@ -264,7 +264,7 @@ class TestRunner(Runner):
         result_dispatcher.map_method('end_test', job.result, test_state)
         if test_state['status'] == "INTERRUPTED":
             summary.add("INTERRUPTED")
-        elif not mapping[test_state['status']]:
+        elif not STATUSES_SUCCESS[test_state['status']]:
             summary.add("FAIL")
 
             if job.config.get('run.failfast'):

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -33,7 +33,7 @@ from avocado.core.status.server import StatusServer
 from avocado.core.task.runtime import RuntimeTask
 from avocado.core.task.statemachine import TaskStateMachine, Worker
 from avocado.core.test_id import TestID
-from avocado.core.teststatus import mapping
+from avocado.core.teststatus import STATUSES_SUCCESS
 
 
 class RunnerInit(Init):
@@ -254,7 +254,7 @@ class Runner(RunnerInterface):
                                                         job.result,
                                                         test_state)
 
-                if not mapping[test_state['status']]:
+                if not STATUSES_SUCCESS[test_state['status']]:
                     self.summary.add("FAIL")
 
     def run_suite(self, job, test_suite):

--- a/avocado/plugins/testlogs.py
+++ b/avocado/plugins/testlogs.py
@@ -4,7 +4,7 @@ import os
 from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import Init, JobPost, JobPre
 from avocado.core.settings import settings
-from avocado.core.teststatus import user_facing_status
+from avocado.core.teststatus import STATUSES
 
 
 class TestLogsInit(Init):
@@ -14,7 +14,7 @@ class TestLogsInit(Init):
     def initialize(self):
         help_msg = ("Status that will trigger the output of a test's logs "
                     "after the job ends. "
-                    "Valid statuses: %s" % ", ".join(user_facing_status))
+                    "Valid statuses: %s" % ", ".join(STATUSES))
         settings.register_option(section='job.output.testlogs',
                                  key='statuses',
                                  key_type=list,

--- a/docs/source/guides/user/chapters/concepts.rst
+++ b/docs/source/guides/user/chapters/concepts.rst
@@ -213,9 +213,8 @@ not always an instrumented test, but may work as a simple test.
 The instrumented tests allows the writer finer control over the process
 including logging, test result status and other more sophisticated test APIs.
 
-Test statuses ``PASS``, ``WARN``, ``START`` and ``SKIP`` are considered as
-successful builds. The ``ABORT``, ``ERROR``, ``FAIL``, ``ALERT``, ``RUNNING``,
-``NOSTATUS`` and ``INTERRUPTED`` are considered as failed ones.
+Test statuses ``PASS``, ``WARN`` and ``SKIP`` are considered
+successful. The ``ERROR``, ``FAIL`` and ``INTERRUPTED`` signal failures.
 
 TAP
 ~~~

--- a/optional_plugins/html/avocado_result_html/__init__.py
+++ b/optional_plugins/html/avocado_result_html/__init__.py
@@ -85,15 +85,10 @@ class ReportModel:
     @property
     def tests(self):
         mapping = {"SKIP": "warning",
-                   "ABORT": "danger",
                    "ERROR": "danger",
                    "FAIL": "danger",
                    "WARN": "warning",
                    "PASS": "success",
-                   "START": "info",
-                   "ALERT": "danger",
-                   "RUNNING": "info",
-                   "NOSTATUS": "info",
                    "INTERRUPTED": "danger",
                    "CANCEL": "warning"}
         test_info = []

--- a/selftests/functional/test_legacy_replay_basic.py
+++ b/selftests/functional/test_legacy_replay_basic.py
@@ -124,7 +124,7 @@ class ReplayTests(TestCaseTmpDir):
         expected_rc = exit_codes.AVOCADO_FAIL
         result = self.run_and_check(cmd_line, expected_rc)
         msg = (b'Invalid --replay-test-status option. Valid options are (more '
-               b'than one allowed): SKIP,ERROR,FAIL,WARN,PASS,INTERRUPTED')
+               b'than one allowed): SKIP,ERROR,FAIL,WARN,PASS,INTERRUPTED,CANCEL')
         self.assertIn(msg, result.stderr)
 
     def test_run_replay_statusfail(self):


### PR DESCRIPTION
There are a number of test status which are not being used (maybe have never been).  Lets remove them, and rename and document the current definitions to better match the general style.