### PR TITLE
Nrunner: restore stdout/stderr log files

### DIFF
--- a/avocado/core/messages.py
+++ b/avocado/core/messages.py
@@ -194,7 +194,7 @@ class StdoutMessageHandler(BaseRunningMessageHandler):
     """
 
     def handle(self, message, task, job):
-        self._save_message_to_file('stdout', message['log'], task)
+        self._save_message_to_file('stdout', message['log'], task, mode='ab')
 
 
 class StderrMessageHandler(BaseRunningMessageHandler):
@@ -216,7 +216,7 @@ class StderrMessageHandler(BaseRunningMessageHandler):
     """
 
     def handle(self, message, task, job):
-        self._save_message_to_file('stderr', message['log'], task)
+        self._save_message_to_file('stderr', message['log'], task, mode='ab')
 
 
 class WhiteboardMessageHandler(BaseRunningMessageHandler):

--- a/avocado/core/messages.py
+++ b/avocado/core/messages.py
@@ -150,7 +150,7 @@ class BaseRunningMessageHandler(BaseMessageHandler):
     def _save_message_to_file(filename, buff, task, mode='a'):
         file = os.path.join(task.metadata['task_path'], filename)
         with open(file, mode) as fp:
-            fp.write("%s\n" % buff)
+            fp.write(buff)
 
 
 class LogMessageHandler(BaseRunningMessageHandler):
@@ -172,7 +172,7 @@ class LogMessageHandler(BaseRunningMessageHandler):
     """
 
     def handle(self, message, task, job):
-        self._save_message_to_file('debug.log', message['log'], task)
+        self._save_message_to_file('debug.log', "%s\n" % message['log'], task)
 
 
 class StdoutMessageHandler(BaseRunningMessageHandler):

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -384,11 +384,10 @@ class ExecRunner(BaseRunner):
        process
     """
 
-    def _process_final_status(self, process, stdout, stderr):
+    def _process_final_status(self, process,
+                              stdout=None, stderr=None):  # pylint: disable=W0613
         return self.prepare_status('finished',
-                                   {'returncode': process.returncode,
-                                    'stdout': stdout,
-                                    'stderr': stderr})
+                                   {'returncode': process.returncode})
 
     def run(self):
         env = None
@@ -424,6 +423,8 @@ class ExecRunner(BaseRunner):
                     now > next_execution_state_mark):
                 most_current_execution_state_time = now
                 yield self.prepare_status('running')
+        yield self.prepare_status('running', {'type': 'stdout', 'log': stdout})
+        yield self.prepare_status('running', {'type': 'stderr', 'log': stderr})
         yield self._process_final_status(process, stdout, stderr)
 
 
@@ -441,7 +442,8 @@ class ExecTestRunner(ExecRunner):
     Runnable attributes usage is identical to :class:`ExecRunner`
     """
 
-    def _process_final_status(self, process, stdout, stderr):
+    def _process_final_status(self, process,
+                              stdout=None, stderr=None):  # pylint: disable=W0613
         # Since Runners are standalone, and could be executed on a remote
         # machine in an "isolated" way, there is no way to assume a default
         # value, at this moment.
@@ -456,8 +458,6 @@ class ExecTestRunner(ExecRunner):
             final_status['result'] = 'fail'
 
         final_status['returncode'] = process.returncode
-        final_status['stdout'] = stdout
-        final_status['stderr'] = stderr
         return self.prepare_status('finished', final_status)
 
 

--- a/avocado/core/runners/tap.py
+++ b/avocado/core/runners/tap.py
@@ -54,12 +54,11 @@ class TAPRunner(nrunner.ExecRunner):
                     result = 'pass'
         return result
 
-    def _process_final_status(self, process, stdout, stderr):
+    def _process_final_status(self, process,
+                              stdout=None, stderr=None):  # pylint: disable=W0613
         return self.prepare_status('finished',
                                    {'result': self._get_tap_result(stdout),
-                                    'returncode': process.returncode,
-                                    'stdout': stdout,
-                                    'stderr': stderr})
+                                    'returncode': process.returncode})
 
 
 class RunnerApp(nrunner.BaseRunnerApp):

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -17,11 +17,8 @@ NRunner based implementation of job compliant runner
 """
 
 import asyncio
-import json
 import multiprocessing
-import os
 import random
-from copy import copy
 
 from avocado.core import nrunner
 from avocado.core.dispatcher import SpawnerDispatcher
@@ -138,45 +135,6 @@ class Runner(RunnerInterface):
 
     name = 'nrunner'
     description = 'nrunner based implementation of job compliant runner'
-
-    def _save_to_file(self, filename, buff, mode='wb'):
-        with open(filename, mode) as fp:
-            fp.write(buff)
-
-    def _populate_task_logdir(self, base_path, task, statuses, debug=False):
-        # We are copying here to avoid printing duplicated information
-        local_statuses = copy(statuses)
-        last = local_statuses[-1]
-        try:
-            stdout = last.pop('stdout')
-        except KeyError:
-            stdout = None
-        try:
-            stderr = last.pop('stderr')
-        except KeyError:
-            stderr = None
-
-        # Create task dir
-        task_path = os.path.join(base_path, task.identifier.str_filesystem)
-        os.makedirs(task_path, exist_ok=True)
-
-        # Save stdout and stderr
-        if stdout is not None:
-            stdout_file = os.path.join(task_path, 'stdout')
-            self._save_to_file(stdout_file, stdout)
-        if stderr is not None:
-            stderr_file = os.path.join(task_path, 'stderr')
-            self._save_to_file(stderr_file, stderr)
-
-        # Save debug
-        if debug:
-            debug = os.path.join(task_path, 'debug')
-            with open(debug, 'w') as fp:
-                json.dump(local_statuses, fp)
-
-        data_file = os.path.join(task_path, 'data')
-        with open(data_file, 'w') as fp:
-            fp.write("{}\n".format(task.output_dir))
 
     def _get_all_runtime_tasks(self, test_suite):
         runtime_tasks = []

--- a/selftests/functional/test_nrunner.py
+++ b/selftests/functional/test_nrunner.py
@@ -52,7 +52,7 @@ class RunnableRun(unittest.TestCase):
                "_Avocado_Runner_" % RUNNER)
         res = process.run(cmd, ignore_status=True)
         self.assertIn(b"'status': 'finished'", res.stdout)
-        self.assertIn(b"'stdout': b'_Avocado_Runner_'", res.stdout)
+        self.assertIn(b"'log': b'_Avocado_Runner_'", res.stdout)
         self.assertIn(b"'returncode': 0", res.stdout)
         self.assertEqual(res.exit_status, 0)
 
@@ -68,11 +68,12 @@ class RunnableRun(unittest.TestCase):
             first_status = final_status = lines[0]
         else:
             first_status = lines[0]
+            stdout_status = lines[-3]
             final_status = lines[-1]
             self.assertIn("'status': 'started'", first_status)
             self.assertIn("'time': ", first_status)
         self.assertIn("'status': 'finished'", final_status)
-        self.assertIn("'stdout': b'Hello world!\\n'", final_status)
+        self.assertIn("'log': b'Hello world!\\n'", stdout_status)
         self.assertIn("'time': ", final_status)
         self.assertEqual(res.exit_status, 0)
 
@@ -134,12 +135,13 @@ class TaskRun(unittest.TestCase):
             first_status = final_status = lines[0]
         else:
             first_status = lines[0]
+            stdout_status = lines[-3]
             final_status = lines[-1]
             self.assertIn("'status': 'started'", first_status)
             self.assertIn("'id': 2", first_status)
         self.assertIn("'id': 2", first_status)
         self.assertIn("'status': 'finished'", final_status)
-        self.assertIn("'stdout': b'avocado'", final_status)
+        self.assertIn("'log': b'avocado'", stdout_status)
         self.assertEqual(res.exit_status, 0)
 
     @skipUnlessPathExists('/bin/sleep')

--- a/selftests/unit/test_nrunner.py
+++ b/selftests/unit/test_nrunner.py
@@ -204,11 +204,15 @@ class Runner(unittest.TestCase):
         runner_klass = runnable.pick_runner_class()
         runner = runner_klass(runnable)
         results = [status for status in runner.run()]
+        stdout_result = results[-3]
+        stderr_result = results[-2]
         last_result = results[-1]
+        self.assertEqual(stdout_result['type'], 'stdout')
+        self.assertEqual(stdout_result['log'], b'')
+        self.assertEqual(stderr_result['type'], 'stderr')
+        self.assertEqual(stderr_result['log'], b'')
         self.assertEqual(last_result['status'], 'finished')
         self.assertEqual(last_result['returncode'], 0)
-        self.assertEqual(last_result['stdout'], b'')
-        self.assertEqual(last_result['stderr'], b'')
         self.assertIn('time', last_result)
 
     def test_runner_exec_test_ok(self):
@@ -217,12 +221,16 @@ class Runner(unittest.TestCase):
         runner_klass = runnable.pick_runner_class()
         runner = runner_klass(runnable)
         results = [status for status in runner.run()]
+        stdout_result = results[-3]
+        stderr_result = results[-2]
         last_result = results[-1]
+        self.assertEqual(stdout_result['type'], 'stdout')
+        self.assertEqual(stdout_result['log'], b'')
+        self.assertEqual(stderr_result['type'], 'stderr')
+        self.assertEqual(stderr_result['log'], b'')
         self.assertEqual(last_result['status'], 'finished')
         self.assertEqual(last_result['result'], 'pass')
         self.assertEqual(last_result['returncode'], 0)
-        self.assertEqual(last_result['stdout'], b'')
-        self.assertEqual(last_result['stderr'], b'')
         self.assertIn('time', last_result)
 
     @skipUnlessPathExists('/bin/false')
@@ -231,12 +239,16 @@ class Runner(unittest.TestCase):
         runner_klass = runnable.pick_runner_class()
         runner = runner_klass(runnable)
         results = [status for status in runner.run()]
+        stdout_result = results[-3]
+        stderr_result = results[-2]
         last_result = results[-1]
+        self.assertEqual(stdout_result['type'], 'stdout')
+        self.assertEqual(stdout_result['log'], b'')
+        self.assertEqual(stderr_result['type'], 'stderr')
+        self.assertEqual(stderr_result['log'], b'')
         self.assertEqual(last_result['status'], 'finished')
         self.assertEqual(last_result['result'], 'fail')
         self.assertEqual(last_result['returncode'], 1)
-        self.assertEqual(last_result['stdout'], b'')
-        self.assertEqual(last_result['stderr'], b'')
         self.assertIn('time', last_result)
 
     def test_runner_python_unittest_ok(self):


### PR DESCRIPTION
The current changes to the message processing resulted in the stdout/stderr files not being preserved.  This restores it.