### PR TITLE
gh-actions: Fixes fetch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Installing selftests requirements
         run: pip install -r requirements-selftests.txt


### PR DESCRIPTION
Only a single commit is fetched by default, for the ref/SHA that triggered the
workflow. Set fetch-depth: 0 to fetch all history for all branches and tags.

Signed-off-by: Beraldo Leal <bleal@redhat.com>