### PR TITLE
COPR check: attempt to install a specific package NVR

### DIFF
--- a/examples/testplans/release/pre.json
+++ b/examples/testplans/release/pre.json
@@ -14,7 +14,7 @@
 	 "description": "With a load as light as possible on your system, run `selftests/pre_release/jobs/pre_release.py`. Expected results: all tests PASSed"},
 
         {"name": "Check the right RPM packages are available in COPR",
-         "description": "Run `selftests/pre_release/tests/check-copr-rpm-version.sh`. Expected result: last line with: python3-avocado-$VERSION-$DATE-git$COMMIT"},
+         "description": "Run `selftests/pre_release/tests/check-copr-rpm-version.sh`. Expected result: last line with: Complete!"},
 
 	{"name": "Avocado deployment",
 	 "description": "Execute the ansible playbook located at selftests/deployments/deployment.yml with '-e method=copr' on one or many fresh virtual machines."},

--- a/selftests/pre_release/tests/check-copr-rpm-version.sh
+++ b/selftests/pre_release/tests/check-copr-rpm-version.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 
 # Put here the name of your GIT remote that tracks the official
 # repo, that is, https://github.com/avocado-framework/avocado
@@ -8,8 +8,16 @@ ORIGIN=origin
 git fetch $ORIGIN
 
 ORIGIN_MASTER_COMMIT=$(git log --pretty=format:'%h' -n 1 $ORIGIN/master)
+VERSION=$(python setup.py --version 2>/dev/null)
+COMMIT_DATE=$(git log --pretty='format:%cd' --date='format:%Y%m%d' -n 1)
+SHORT_COMMIT=$(git rev-parse --short=9 $ORIGIN/master)
+RPM_RELEASE_NUMBER=$(grep -E '^Release:\s([0-9]+)' python-avocado.spec | sed -E 's/Release:\s([0-9]+).*/\1/')
+DISTRO=fedora
+DISTRO_VERSION=33
+
+RPM_NVR="python3-avocado-${VERSION}-${RPM_RELEASE_NUMBER}.${COMMIT_DATE}git${SHORT_COMMIT}.fc${DISTRO_VERSION}"
 
 PODMAN=$(which podman)
-PODMAN_IMAGE=fedora:33
+PODMAN_IMAGE="${DISTRO}:${DISTRO_VERSION}"
 
-$PODMAN run --rm -ti $PODMAN_IMAGE /bin/bash -c "dnf -y module disable avocado && dnf -y install 'dnf-command(copr)' && dnf -y copr enable @avocado/avocado-latest && dnf -y install python3-avocado && (rpm -q python3-avocado | grep $ORIGIN_MASTER_COMMIT)"
+$PODMAN run --rm -ti $PODMAN_IMAGE /bin/bash -c "dnf -y module disable avocado && dnf -y install 'dnf-command(copr)' && dnf -y copr enable @avocado/avocado-latest && dnf -y install ${RPM_NVR}"


### PR DESCRIPTION
Instead of installing the "latest" package and looking for signs
of installation, let's request the exact package based on its
NVR.

Also let's be more strict with possible errors from the script.

Signed-off-by: Cleber Rosa <crosa@redhat.com>