### PR TITLE
Skip Decorators: fix issues when setUp or the test function would/would not be run

### DIFF
--- a/avocado/core/decorators.py
+++ b/avocado/core/decorators.py
@@ -78,6 +78,7 @@ def _skip_method_decorator(function, message, condition):
                 raise core_exceptions.TestSkipError(message)
         elif condition:
             raise core_exceptions.TestSkipError(message)
+        return function(obj, *args, **kwargs)
     wrapper.__skip_test_decorator__ = True
     return wrapper
 

--- a/avocado/core/decorators.py
+++ b/avocado/core/decorators.py
@@ -82,7 +82,7 @@ def _skip_method_decorator(function, message, condition):
     return wrapper
 
 
-def _skip_class_decorator(cls, message, condition=None):
+def _skip_class_decorator(cls, message, condition):
     """Creates a skip decorator for a class."""
     for key in cls.__dict__:
         if key.startswith('test') and callable(getattr(cls, key)):

--- a/avocado/core/decorators.py
+++ b/avocado/core/decorators.py
@@ -88,7 +88,8 @@ def _skip_method_decorator(function, message, condition, negate):
                 if condition:
                     raise core_exceptions.TestSkipError(message)
         return function(obj, *args, **kwargs)
-    wrapper.__skip_test_decorator__ = True
+    wrapper.__skip_test_condition__ = condition
+    wrapper.__skip_test_condition_negate__ = negate
     return wrapper
 
 

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -729,7 +729,21 @@ class Test(unittest.TestCase, TestData):
         output_check_exception = None
         stdout_check_exception = None
         stderr_check_exception = None
-        skip_test = getattr(testMethod, '__skip_test_decorator__', False)
+        skip_test_condition = getattr(testMethod, '__skip_test_condition__', False)
+        skip_test_condition_negate = getattr(testMethod, '__skip_test_condition_negate__', False)
+        if skip_test_condition:
+            if callable(skip_test_condition):
+                if skip_test_condition_negate:
+                    skip_test = not bool(skip_test_condition(self))
+                else:
+                    skip_test = bool(skip_test_condition(self))
+            else:
+                if skip_test_condition_negate:
+                    skip_test = not bool(skip_test_condition)
+                else:
+                    skip_test = bool(skip_test_condition)
+        else:
+            skip_test = bool(skip_test_condition)
         try:
             if skip_test is False:
                 self.__phase = 'SETUP'

--- a/selftests/functional/test_skiptests.py
+++ b/selftests/functional/test_skiptests.py
@@ -313,8 +313,7 @@ class Skip(Base):
     }
 
     def test_skip_decorators(self):
-        self.check_skips_and_content(5)
-        self.check_status(cancel=2)
+        self.check_status(skip=5, cancel=2)
 
 
 class NotSkip(Base):

--- a/selftests/functional/test_skiptests.py
+++ b/selftests/functional/test_skiptests.py
@@ -44,14 +44,18 @@ class AvocadoSkipTests(avocado.Test):
         self.log.info('test executed')
 
     @avocado.skipIf(lambda x: x.FALSE_CONDITION,
-                    'skipIf with False condition, should not happen')
+                    'skipIf with False condition should never happen')
     def test6(self):
-        self.log.info('test executed')
+        # test "runs", because skipIf with False condition runs a test
+        self.cancel('ran, but was canceled')
+        self.log.info('test executed')  # should never get here
 
     @avocado.skipUnless(lambda x: x.TRUE_CONDITION,
-                        'skipUnless with True condition, should not happen')
+                        'skipUnless with True condition should never happen')
     def test7(self):
-        self.log.info('test executed')
+        # test "runs", because skipUnless with True condition runs a test
+        self.cancel('ran, but was canceled')
+        self.log.info('test executed')  # should never get here
 
     def tearDown(self):
         self.log.info('teardown executed')
@@ -310,6 +314,7 @@ class Skip(Base):
 
     def test_skip_decorators(self):
         self.check_skips_and_content(5)
+        self.check_status(cancel=2)
 
 
 class NotSkip(Base):


### PR DESCRIPTION
There are two different issues with the skip decorators fixed here:

1) the condition for executing setUp() methods were not being evaluated dynamically
2) where no skip would be performed, the test function would also not be performed
