### PR TITLE
Introduce direct inheritance with abstract classes

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -313,7 +313,7 @@ class Runnable:
         raise ValueError('Unsupported kind of runnable: %s' % self.kind)
 
 
-class BaseRunner(metaclass=abc.ABCMeta):
+class BaseRunner(abc.ABC):
     """
     Base interface for a Runner
     """

--- a/avocado/core/plugin_interfaces.py
+++ b/avocado/core/plugin_interfaces.py
@@ -16,7 +16,7 @@
 import abc
 
 
-class Plugin(metaclass=abc.ABCMeta):
+class Plugin(abc.ABC):
     """Base for all plugins."""
 
 

--- a/avocado/utils/datadrainer.py
+++ b/avocado/utils/datadrainer.py
@@ -29,7 +29,7 @@ import select
 import threading
 
 
-class BaseDrainer(metaclass=abc.ABCMeta):
+class BaseDrainer(abc.ABC):
 
     """
     Base drainer, doesn't provide complete functionality to be useful.


### PR DESCRIPTION
As mentioned by @pevogam over #4476, using ``abc.ABC`` is much simpler
and direct when compared with ``metaclass=ABCMeta``. 

Since python 3.4, the abc module contains a helper class called ``ABC`` that
will set the metaclass internally. This makes creating an abstract class
more readable and simple as it is only necessary to inherit from ``ABC``.
Avocado, currently, supports python 3.5+ so version should not be a
problem.

Signed-off-by: Tiago Honorato <tiagohonorato1@gmail.com>