### PR TITLE
 Log information when running tests

### DIFF
--- a/avocado/plugins/testlogs.py
+++ b/avocado/plugins/testlogs.py
@@ -7,7 +7,7 @@ from avocado.core.settings import settings
 from avocado.core.teststatus import STATUSES
 
 
-class TestLogsInit(Init):
+class TestLogsUIInit(Init):
 
     description = "Initialize testlogs plugin settings"
 
@@ -31,7 +31,7 @@ class TestLogsInit(Init):
                                  help_msg=help_msg)
 
 
-class TestLogs(JobPre, JobPost):
+class TestLogsUI(JobPre, JobPost):
 
     description = "Shows content from tests' logs"
 

--- a/avocado/plugins/testlogs.py
+++ b/avocado/plugins/testlogs.py
@@ -1,8 +1,8 @@
 import json
 import os
 
-from avocado.core.output import LOG_UI
-from avocado.core.plugin_interfaces import Init, JobPost, JobPre
+from avocado.core.output import LOG_JOB, LOG_UI
+from avocado.core.plugin_interfaces import Init, JobPost, JobPre, ResultEvents
 from avocado.core.settings import settings
 from avocado.core.teststatus import STATUSES
 
@@ -63,3 +63,41 @@ class TestLogsUI(JobPre, JobPost):
                 except (FileNotFoundError, PermissionError) as error:
                     LOG_UI.error('Failure to access log file "%s": %s',
                                  path, error)
+
+
+class TestLogging(ResultEvents):
+    """
+    TODO: The description should be changed when the legacy runner will be
+          deprecated.
+    """
+
+    description = "Nrunner specific Test logs for Job"
+
+    def __init__(self, config):
+        self.runner = config.get('run.test_runner')
+
+    @staticmethod
+    def _get_name(state):
+        name = state.get('name')
+        if name is None:
+            return "<unknown>"
+        return name.name + name.str_variant
+
+    def pre_tests(self, job):
+        pass
+
+    def post_tests(self, job):
+        pass
+
+    def start_test(self, result, state):
+        if self.runner == 'nrunner':
+            LOG_JOB.info('%s: STARTED', self._get_name(state))
+
+    def test_progress(self, progress=False):
+        pass
+
+    def end_test(self, result, state):
+        if self.runner == 'nrunner':
+            LOG_JOB.info('%s: %s', self._get_name(state),
+                         state.get("status", "ERROR"))
+            LOG_JOB.info('More information in %s', state.get('task_path', ''))

--- a/selftests/functional/plugin/test_logs.py
+++ b/selftests/functional/plugin/test_logs.py
@@ -61,3 +61,17 @@ class TestLogsFilesUI(TestCaseTmpDir):
     def tearDown(self):
         super(TestLogsFilesUI, self).tearDown()
         self.config_file.remove()
+
+
+class TestLogging(TestCaseTmpDir):
+
+    def test_job_log(self):
+        pass_test = os.path.join(BASEDIR, 'examples', 'tests', 'passtest.py')
+        cmd_line = ('%s run --job-results-dir %s --test-runner=nrunner %s' %
+                    (AVOCADO, self.tmpdir.name, pass_test))
+        process.run(cmd_line)
+        log_file = os.path.join(self.tmpdir.name, 'latest', 'job.log')
+        with open(log_file, 'r') as fp:
+            log = fp.read()
+        self.assertIn('passtest.py:PassTest.test: STARTED', log)
+        self.assertIn('passtest.py:PassTest.test: PASS', log)

--- a/selftests/functional/plugin/test_logs.py
+++ b/selftests/functional/plugin/test_logs.py
@@ -9,10 +9,10 @@ CONFIG = """[job.output.testlogs]
 statuses = ["FAIL", "CANCEL"]"""
 
 
-class TestLogs(TestCaseTmpDir):
+class TestLogsUI(TestCaseTmpDir):
 
     def setUp(self):
-        super(TestLogs, self).setUp()
+        super(TestLogsUI, self).setUp()
         with open(os.path.join(self.tmpdir.name, 'config'), 'w') as config:
             config.write(CONFIG)
 
@@ -32,10 +32,10 @@ class TestLogs(TestCaseTmpDir):
                       ':CancelTest.test" (CANCEL):', stdout_lines)
 
 
-class TestLogsFiles(TestCaseTmpDir):
+class TestLogsFilesUI(TestCaseTmpDir):
 
     def setUp(self):
-        super(TestLogsFiles, self).setUp()
+        super(TestLogsFilesUI, self).setUp()
         self.config_file = script.TemporaryScript(
             'avocado.conf',
             "[job.output.testlogs]\n"
@@ -59,5 +59,5 @@ class TestLogsFiles(TestCaseTmpDir):
                          r'Failure to access log file.*DOES_NOT_EXIST"')
 
     def tearDown(self):
-        super(TestLogsFiles, self).tearDown()
+        super(TestLogsFilesUI, self).tearDown()
         self.config_file.remove()

--- a/setup.py
+++ b/setup.py
@@ -149,7 +149,7 @@ if __name__ == '__main__':
                   "run = avocado.plugins.run:RunInit",
                   "podman = avocado.plugins.spawners.podman:PodmanSpawnerInit",
                   "nrunner = avocado.plugins.runner_nrunner:RunnerInit",
-                  "testlogs = avocado.plugins.testlogs:TestLogsInit",
+                  "testlogsui = avocado.plugins.testlogs:TestLogsUIInit",
               ],
               'avocado.plugins.cli': [
                   'wrapper = avocado.plugins.wrapper:Wrapper',
@@ -183,7 +183,7 @@ if __name__ == '__main__':
                   'teststmpdir = avocado.plugins.teststmpdir:TestsTmpDir',
                   'human = avocado.plugins.human:HumanJob',
                   'merge_files = avocado.plugins.expected_files_merge:FilesMerge',
-                  'testlogs = avocado.plugins.testlogs:TestLogs',
+                  'testlogsui = avocado.plugins.testlogs:TestLogsUI',
                   ],
               'avocado.plugins.result': [
                   'xunit = avocado.plugins.xunit:XUnitResult',

--- a/setup.py
+++ b/setup.py
@@ -196,6 +196,7 @@ if __name__ == '__main__':
                   'journal = avocado.plugins.journal:JournalResult',
                   'fetchasset = avocado.plugins.assets:FetchAssetJob',
                   'sysinfo = avocado.plugins.sysinfo:SysInfoJob',
+                  'testlogging = avocado.plugins.testlogs:TestLogging',
                   ],
               'avocado.plugins.varianter': [
                   'json_variants = avocado.plugins.json_variants:JsonVariants',


### PR DESCRIPTION
Adds the test start and finish information in the `job.log`. So, if a
test "1-foo" passes, that should be easy to spot in the job.log file.

Reference: #4366
Signed-off-by: Jan Richter <jarichte@redhat.com>