### PR TITLE
[Requirements resolver] Initial integration with the state machine v3

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -692,13 +692,16 @@ class Task:
         if known_runners is None:
             known_runners = {}
         self.known_runners = known_runners
+        self.dependencies = set()
         self.spawn_handle = None
         self.output_dir = None
         self.metadata = {}
 
     def __repr__(self):
-        fmt = '<Task identifier="{}" runnable="{}" status_services="{}"'
-        return fmt.format(self.identifier, self.runnable, self.status_services)
+        fmt = ('<Task identifier="{}" runnable="{}" dependencies="{}"'
+               ' status_services="{}"')
+        return fmt.format(self.identifier, self.runnable, self.dependencies,
+                          self.status_services)
 
     def are_requirements_available(self, runners_registry=None):
         """Verifies if requirements needed to run this task are available.

--- a/avocado/core/requirements/resolver.py
+++ b/avocado/core/requirements/resolver.py
@@ -1,0 +1,30 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2021
+# Authors: Willian Rampazzo <willianr@redhat.com>
+
+from ..nrunner import Runnable
+
+
+class RequirementsResolver:
+
+    name = 'requirements'
+    description = 'Requirements resolver for tests with requirements'
+
+    @staticmethod
+    def resolve(runnable):
+        requirements_runnables = []
+        for requirement in runnable.requirements:
+            kind = 'requirement-%s' % requirement.get('type')
+            requirement_runnable = Runnable(kind, None, **requirement)
+            requirements_runnables.append(requirement_runnable)
+        return requirements_runnables

--- a/avocado/core/runners/requirement_package.py
+++ b/avocado/core/runners/requirement_package.py
@@ -1,0 +1,87 @@
+import subprocess
+import time
+
+from ...utils import exit_codes
+from .. import nrunner
+
+
+class RequirementPackageRunner(nrunner.BaseRunner):
+    """Runner for requirements of type package
+
+    This runner handles, the installation, verification and removal of
+    packages using the avocado-software-manager.
+
+    Runnable attributes usage:
+
+     * kind: 'requirement-package'
+
+     * uri: not used
+
+     * args: not used one of 'install', 'check' or 'remove'
+
+     * kwargs: supported kwargs by this runner:
+                - name='package_name'
+                - optional: action= one of 'install', 'check' or 'remove'
+                  eg.: action=install, action=check, action=remove
+                  when 'action' is not defined, action='install' is the default
+    """
+
+    def run(self):
+        # check if there is a valid 'action' argument
+        cmd = self.runnable.kwargs.get('action')
+        if cmd not in ['install', 'check', 'remove']:
+            # missing or invalid argument is translated to 'install'
+            cmd = 'install'
+        # use the correct check command on avocado-software-manager
+        if cmd == 'check':
+            cmd = 'check-installed'
+
+        yield self.prepare_status('started')
+
+        package = self.runnable.kwargs.get('name')
+        # if package was passed correctly, run avocado-software-manager
+        if package is not None:
+            process = subprocess.Popen(
+                ['avocado-software-manager', cmd, package],
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE)
+
+            while process.poll() is None:
+                time.sleep(nrunner.RUNNER_RUN_STATUS_INTERVAL)
+                yield self.prepare_status('running')
+
+            result = 'pass'
+            if process.returncode == exit_codes.UTILITY_FAIL:
+                result = 'error'
+
+            returncode = process.returncode
+            stdout = process.stdout.read()
+            stderr = process.stderr.read()
+        else:
+            # Otherwise, log the missing package name
+            returncode = 1
+            result = 'error'
+            stdout = ''
+            stderr = ('Package name should be passed as kwargs using'
+                      ' name="package_name".')
+
+        yield self.prepare_status('finished',
+                                  {'result': result,
+                                   'returncode': returncode,
+                                   'stdout': stdout,
+                                   'stderr': stderr})
+
+
+class RunnerApp(nrunner.BaseRunnerApp):
+    PROG_NAME = 'avocado-runner-requirement-package'
+    PROG_DESCRIPTION = ('nrunner application for requirements of type package')
+    RUNNABLE_KINDS_CAPABLE = {'requirement-package': RequirementPackageRunner}
+
+
+def main():
+    nrunner.main(RunnerApp)
+
+
+if __name__ == '__main__':
+    main()

--- a/avocado/plugins/spawners/process.py
+++ b/avocado/plugins/spawners/process.py
@@ -42,18 +42,8 @@ class ProcessSpawner(Spawner, SpawnerMixin):
 
     @staticmethod
     async def check_task_requirements(runtime_task):
-        runnable_requirements = runtime_task.task.runnable.requirements
-        if not runnable_requirements:
-            return True
-
-        for requirements in runnable_requirements:
-            for (req_type, req_value) in requirements.items():
-                # The fact that this is avocado code means this
-                # requirement is fulfilled
-                if req_type == 'core' and req_value == 'avocado':
-                    continue
-                else:
-                    # current implementation can not check any other type of
-                    # requirement at this moment so fail
-                    return False
+        """Check for requirements a runtime task may have to run."""
+        # right now, checks only if the runner is available.
+        if runtime_task.task.runnable.pick_runner_command() is None:
+            return False
         return True

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -217,6 +217,7 @@ PATH=$HOME/.local/bin:$PATH LANG=en_US.UTF-8 AVOCADO_CHECK_LEVEL=0 %{__python3} 
 %{_bindir}/avocado-runner-python-unittest
 %{_bindir}/avocado-runner-avocado-instrumented
 %{_bindir}/avocado-runner-tap
+%{_bindir}/avocado-runner-requirement-package
 %{_bindir}/avocado-software-manager
 %{python3_sitelib}/avocado*
 %exclude %{python3_sitelib}/avocado_result_html*

--- a/selftests/functional/test_task_statemachine.py
+++ b/selftests/functional/test_task_statemachine.py
@@ -2,6 +2,7 @@ import asyncio
 from unittest import TestCase
 
 from avocado.core.nrunner import Runnable, Task
+from avocado.core.status.repo import StatusRepo
 from avocado.core.task import statemachine
 from avocado.core.task.runtime import RuntimeTask
 from avocado.plugins.spawners.process import ProcessSpawner as Spawner
@@ -22,8 +23,9 @@ class StateMachine(TestCase):
         runtime_tasks = [RuntimeTask(Task(runnable, "%03i" % _))
                          for _ in range(1, number_of_tasks + 1)]
         spawner = Spawner()
+        status_repo = StatusRepo()
 
-        state_machine = statemachine.TaskStateMachine(runtime_tasks)
+        state_machine = statemachine.TaskStateMachine(runtime_tasks, status_repo)
         loop = asyncio.get_event_loop()
         workers = [statemachine.Worker(state_machine, spawner).run()
                    for _ in range(number_of_workers)]

--- a/setup.py
+++ b/setup.py
@@ -136,6 +136,7 @@ if __name__ == '__main__':
                   'avocado-runner-python-unittest = avocado.core.nrunner:main',
                   'avocado-runner-avocado-instrumented = avocado.core.runners.avocado_instrumented:main',
                   'avocado-runner-tap = avocado.core.runners.tap:main',
+                  'avocado-runner-requirement-package = avocado.core.runners.requirement_package:main',
                   'avocado-software-manager = avocado.utils.software_manager.main:main',
                   ],
               "avocado.plugins.init": [


### PR DESCRIPTION
**NOTES**:
- The intent of this PR is to handle the architecture of the requirements resolver. Specifically, the addition of a resolver, changes to the state machine, and changes to the task creation.
- To help with the architecture part, a package requirement runner was added. IMHO, according to the architecture presented here, the runner seems to be good enough to be considered fully implemented.
- There are **massive** changes that need to be made to the Human UI to display a nice output. I would like to handle that in a different PR.
- As the Human UI is not reflecting the reality of the tests, I would like this feature to be considered as **experimental**.
- If this version does not have architectural changes, in the next PR version I will add the documentation and unit/functional tests.

This is a minimum set of changes to introduce and integrate the Requirements Resolver with the state machine. The following tests enable the code of this PR.

A single test that passes (`single_success.py`):

```python
from avocado import Test


class PassTest(Test):

    """
    Example test that passes.

    :avocado: tags=fast
    :avocado: requirement={"type": "package", "name": "vim-common"}
    """

    def test(self):
        """
        A test doesn't have to fail to pass
        """
```

Expected output:

```
$ avocado run --test-runner=nrunner single_success.py 
JOB ID     : 9cc29be300f2620006b3290508dbd32127a1877d
JOB LOG    : /home/wrampazz/avocado/job-results/job-2021-04-23T09.27-9cc29be/job.log
 (1/1) single_success.py:PassTest.test: STARTED
 (1/1) single_success.py:PassTest.test: PASS (0.15 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/wrampazz/avocado/job-results/job-2021-04-23T09.27-9cc29be/results.html
JOB TIME   : 7.12 s
```

A single test that fails (`single_fail.py`):

```python
from avocado import Test


class FailTest(Test):

    """
    :avocado: requirement={"type": "package", "name": "vim-common"}
    :avocado: requirement={"type": "package", "name": "bla"}
    :avocado: requirement={"type": "file", "name": "foo.bar"}
    """

    def test(self):
        """
        A fail test
        """
```

Expected output:

```
$ avocado run --test-runner=nrunner single_fail.py 
JOB ID     : 3a24d81bbb1d714461978e45fa6935a89bc14143
JOB LOG    : /home/wrampazz/avocado/job-results/job-2021-04-23T09.27-3a24d81/job.log
RESULTS    : PASS 0 | ERROR 0 | FAIL 0 | SKIP 1 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/wrampazz/avocado/job-results/job-2021-04-23T09.27-3a24d81/results.html
JOB TIME   : 6.17 s
```

**NOTE**: as the test task never starts, it is not accounted for in the Human UI, so it does not show in the execution or in the results.

Multiple tests that pass (`multipletests_success.py`):

```python
from avocado import Test


class PassTest(Test):

    """
    Example test that passes.

    """

    def test_a(self):
        """
        :avocado: requirement={"type": "package", "name": "vim-common"}
        """
    def test_b(self):
        """
        :avocado: requirement={"type": "package", "name": "vim-minimal"}
        """
    def test_c(self):
        """
        :avocado: requirement={"type": "package", "name": "vim-common"}
        """
```

Expected output:

```
$ avocado run --test-runner=nrunner multipletests_success.py 
JOB ID     : 4e2b0a3217838c70a596a125c41ce26387d186fe
JOB LOG    : /home/wrampazz/avocado/job-results/job-2021-04-23T09.28-4e2b0a3/job.log
 (1/3) multipletests_success.py:PassTest.test_a: STARTED
 (1/3) multipletests_success.py:PassTest.test_a: PASS (0.14 s)
 (2/3) multipletests_success.py:PassTest.test_b: STARTED
 (2/3) multipletests_success.py:PassTest.test_b: PASS (0.14 s)
 (3/3) multipletests_success.py:PassTest.test_c: STARTED
 (3/3) multipletests_success.py:PassTest.test_c: PASS (0.14 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/wrampazz/avocado/job-results/job-2021-04-23T09.28-4e2b0a3/results.html
JOB TIME   : 9.14 s
```

Multiple tests where two fail (`multipletests_fail.py`):

```python
from avocado import Test


class FailTest(Test):

    """
    Example test that fails.

    """

    def test_a(self):
        """
        :avocado: requirement={"type": "package", "name": "vim-common"}
        :avocado: requirement={"type": "package", "name": "bla"}
        """
    def test_b(self):
        """
        :avocado: requirement={"type": "package", "name": "vim-common"}
        """
    def test_c(self):
        """
        :avocado: requirement={"type": "package", "name": "vim-minimal"}
        :avocado: requirement={"type": "package", "name": "bla"}
        """
```

Expected output:

```
$ avocado run --test-runner=nrunner multipletests_fail.py 
JOB ID     : c04c72ebbea91ce45f91cc36c50a5de64c114368
JOB LOG    : /home/wrampazz/avocado/job-results/job-2021-04-23T09.29-c04c72e/job.log
 (2/3) multipletests_fail.py:FailTest.test_b: STARTED
 (2/3) multipletests_fail.py:FailTest.test_b: PASS (0.14 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 2 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/wrampazz/avocado/job-results/job-2021-04-23T09.29-c04c72e/results.html
JOB TIME   : 12.17 s
```

**NOTE**: again, as the test tasks never start, they are not accounted for in the Human UI, so it does not show them in the execution or in the results.

How to play with the requirements package runner:

```
$ avocado-runner-requirement-package runnable-run action=check name=vim-common
{'status': 'started', 'time': 104504.359667453}
{'status': 'running', 'time': 104504.861630231}
{'status': 'running', 'time': 104505.362315153}
{'result': 'pass', 'returncode': 0, 'stdout': b'', 'stderr': b"dnf module for Python is required. Using the basic support from rpm and dnf commands\nRunning 'rpm -q vim-common'\nCommand 'rpm -q vim-common' finished with 0 after 0.011124849319458008s\nPackage vim-common already installed\n", 'status': 'finished', 'time': 104505.362690156}
```

Changes from [v2](https://github.com/avocado-framework/avocado/pull/4481):
- Change the `avocado-runner-requirement-package` to handle kwargs instead of args.
- Add support to `check` and `remove` packages to the `avocado-runner-requirement-package`.
- Move the requirements resolver back to its own file at `avocado/core/requirements/resolver.py`.
- Add missing support to skip a test if one of its dependencies failed during triage or during the execution.

Changes from [v1](https://github.com/avocado-framework/avocado/pull/4423):
- Requirements are now handled as runners. Each requirement type is mapped to a specific runner. The addition of a new requirement type should be as simple as creating a new runner called `requirement_newtype.py`.
- Moved the resolver to the `avocado/plugins/resolvers.py` file as it is much simpler now.
- Changed the attribute name of the Task class to `dependency` instead of `prereqs`. This maps well to a dependency graph.
- Make the dependencies a set and improve the handling of it in the state machine.

Changes from [v0](https://github.com/avocado-framework/avocado/pull/4369):
- Improve docstring of RequirementRunner;
- Change the Requirements Resolver entry point to a static method;
- Variables renaming to make them more meaningful;
- Improve log message when the requirement type is not available;
- Classes reorder inside the file.