### PR TITLE
[NRunner] Introduce task category

### DIFF
--- a/avocado/core/messages.py
+++ b/avocado/core/messages.py
@@ -101,7 +101,8 @@ class StartMessageHandler(BaseMessageHandler):
                     'base_path': base_path,
                     'task_path': task_path,
                     'time_start': message['time'],
-                    'name': task.identifier}
+                    'name': task.identifier,
+                    'task_category': task.category}
         job.result.start_test(metadata)
         job.result_events_dispatcher.map_method('start_test', job.result,
                                                 metadata)

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -662,7 +662,7 @@ class Task:
     """
 
     def __init__(self, runnable, identifier=None, status_uris=None,
-                 known_runners=None):
+                 known_runners=None, category=None):
         """Instantiates a new Task.
 
         :param runnable: the "description" of what the task should run.
@@ -679,9 +679,12 @@ class Task:
         :type status_uri: list
         :param known_runners: a mapping of runnable kinds to runners.
         :type known_runners: dict
+        :param category: category of this task. Defaults to 'test'.
+        :type category: str
         """
         self.runnable = runnable
         self.identifier = identifier or str(uuid1())
+        self.category = (category or 'test').lower()
         self.status_services = []
         if status_uris is not None:
             for status_uri in status_uris:

--- a/avocado/core/result.py
+++ b/avocado/core/result.py
@@ -96,6 +96,11 @@ class Result:
 
         :param test: A dict with test internal state
         """
+        # do not account for tasks that are not tests
+        task_category = state.get('task_category')
+        if task_category is not None and task_category != 'test':
+            return
+
         status = state.get('status')
         if status == "PASS":
             self.passed += 1

--- a/avocado/plugins/human.py
+++ b/avocado/plugins/human.py
@@ -61,6 +61,11 @@ class Human(ResultEvents):
             name = "<unknown>"
             uid = '?'
         if self.runner == 'nrunner':
+            # ignore tasks that are not tests
+            task_category = state.get('task_category')
+            if task_category is not None and task_category != 'test':
+                return
+
             LOG_UI.debug(' (%s/%s) %s: STARTED', uid, result.tests_total, name)
         else:
             LOG_UI.debug(' (%s/%s) %s:  ', uid, result.tests_total, name,
@@ -99,6 +104,11 @@ class Human(ResultEvents):
                     if status != "SKIP"
                     else "")
         if self.runner == 'nrunner':
+            # ignore tasks that are not tests
+            task_category = state.get('task_category')
+            if task_category is not None and task_category != 'test':
+                return
+
             if "name" in state:
                 name = state["name"]
                 uid = name.str_uid


### PR DESCRIPTION
This introduces the `category` attribute of a Task. It can be used to keep track of different kinds/categories of Tasks running and take actions based on it. The default value of a Task category is 'test'.

This also changes the result and the human UI to consider only tasks assigned to the `test` category or were never assigned to a category.

Signed-off-by: Willian Rampazzo <willianr@redhat.com>