### PR TITLE
assets: warn the user when a hash is not provided

### DIFF
--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -299,6 +299,8 @@ class Asset:
         If asset_hash is None then will consider a valid asset.
         """
         if asset_hash is None:
+            LOG.warning("No hash provided. Cannot check the asset file"
+                        " integrity.")
             return True
 
         hash_path = cls._get_hash_file(asset_path)


### PR DESCRIPTION
If the Asset.fetch() caller does not provide a hash for the asset then
it is not possible to check its integrity. Problems may arise from using
corrupted files. So let's log a message warning the user about it.

Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>