### PR TITLE
fix the issue: local variable 'dmsg_log' referenced before assignment

### DIFF
--- a/avocado/utils/dmesg.py
+++ b/avocado/utils/dmesg.py
@@ -102,6 +102,7 @@ def collect_errors_by_level(output_file=None, level_check=5, skip_errors=None):
     """
     if not isinstance(level_check, int):
         raise DmesgError("level_check param should be integer")
+    dmsg_log = ""
     cmd = "dmesg -T -l %s|grep ." % ",".join(
         map(str, range(0, int(level_check))))  # pylint: disable=W1638
     out = process.run(cmd, timeout=30, ignore_status=True,


### PR DESCRIPTION
when skip_dmesg_messages() return nothing getting failed in
collect_errors_by_level(),to avoid this error define a variable
dmsg_log with empty string.

Signed-off-by: bismurti bidhibrata pattajoshi <bbidhibr@in.ibm.com>