### PR TITLE
[NRunner] Introduce task category v2

### DIFF
--- a/avocado/core/messages.py
+++ b/avocado/core/messages.py
@@ -102,9 +102,10 @@ class StartMessageHandler(BaseMessageHandler):
                     'task_path': task_path,
                     'time_start': message['time'],
                     'name': task.identifier}
-        job.result.start_test(metadata)
-        job.result_events_dispatcher.map_method('start_test', job.result,
-                                                metadata)
+        if task.category == 'test':
+            job.result.start_test(metadata)
+            job.result_events_dispatcher.map_method('start_test', job.result,
+                                                    metadata)
         task.metadata.update(metadata)
 
 
@@ -139,8 +140,10 @@ class FinishMessageHandler(BaseMessageHandler):
 
         message['logdir'] = task.metadata['task_path']
 
-        job.result.check_test(message)
-        job.result_events_dispatcher.map_method('end_test', job.result, message)
+        if task.category == 'test':
+            job.result.check_test(message)
+            job.result_events_dispatcher.map_method('end_test', job.result,
+                                                    message)
 
 
 class BaseRunningMessageHandler(BaseMessageHandler):

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -662,7 +662,7 @@ class Task:
     """
 
     def __init__(self, runnable, identifier=None, status_uris=None,
-                 known_runners=None):
+                 known_runners=None, category='test'):
         """Instantiates a new Task.
 
         :param runnable: the "description" of what the task should run.
@@ -679,9 +679,12 @@ class Task:
         :type status_uri: list
         :param known_runners: a mapping of runnable kinds to runners.
         :type known_runners: dict
+        :param category: category of this task. Defaults to 'test'.
+        :type category: str
         """
         self.runnable = runnable
         self.identifier = identifier or str(uuid1())
+        self.category = category
         self.status_services = []
         if status_uris is not None:
             for status_uri in status_uris:

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -161,6 +161,50 @@ if __name__ == '__main__':
         sys.exit(j.run())
 """
 
+AVOID_NON_TEST_TASKS = """#!/usr/bin/env python3
+
+from avocado.core import nrunner
+from avocado.core.job import Job
+from avocado.core.task.runtime import RuntimeTask
+from avocado.core.test_id import TestID
+from avocado.plugins import runner_nrunner
+from avocado.utils.network.ports import find_free_port
+
+
+class RunnerNRunnerWithFixedTasks(runner_nrunner.Runner):
+    @staticmethod
+    def _get_all_runtime_tasks(test_suite):
+        runtime_tasks = []
+        no_digits = len(str(len(test_suite)))
+        status_uris = [test_suite.config.get('nrunner.status_server_uri')]
+        for index, runnable in enumerate(test_suite.tests, start=1):
+            prefix = index
+            test_id = TestID(prefix, runnable.uri, None, no_digits)
+            if index % 2 == 1:
+                task = nrunner.Task(
+                    runnable, test_id, status_uris,
+                    nrunner.RUNNERS_REGISTRY_PYTHON_CLASS)
+            else:
+                task = nrunner.Task(
+                    runnable, test_id, status_uris,
+                    nrunner.RUNNERS_REGISTRY_PYTHON_CLASS,
+                    'non-test')
+            runtime_tasks.append(RuntimeTask(task))
+        return runtime_tasks
+
+
+if __name__ == '__main__':
+    status_server = '127.0.0.1:%u' % find_free_port()
+    config = {'run.test_runner': 'nrunner',
+              'nrunner.status_server_listen': status_server,
+              'nrunner.status_server_uri': status_server,
+              'run.references': ['/bin/true', '/bin/false']}
+    job = Job.from_config(config)
+    job.setup()
+    job.test_suites[0]._runner = RunnerNRunnerWithFixedTasks()
+    job.run()
+"""
+
 
 def perl_tap_parser_uncapable():
     return os.system("perl -e 'use TAP::Parser;'") != 0
@@ -318,6 +362,21 @@ class OutputTest(TestCaseTmpDir):
             bin_true_number = result.stdout_text.count('/bin/true')
             self.assertEqual(expected_job_id_number, job_id_number)
             self.assertEqual(expected_bin_true_number, bin_true_number)
+
+    @skipUnlessPathExists('/bin/true')
+    @skipUnlessPathExists('/bin/false')
+    def test_avoid_output_on_non_test_task(self):
+        """
+        Checks if `core.show` is respected in different configurations.
+        """
+        with script.Script(os.path.join(self.tmpdir.name,
+                                        'test_avoid_output_non_test_tasks.py'),
+                           AVOID_NON_TEST_TASKS) as test:
+            result = process.run(test.path)
+            self.assertIn('/bin/true', result.stdout_text)
+            self.assertIn('PASS 1', result.stdout_text,)
+            self.assertIn('SKIP 1', result.stdout_text,)
+            self.assertNotIn('/bin/false', result.stdout_text)
 
     def tearDown(self):
         self.tmpdir.cleanup()

--- a/selftests/unit/test_nrunner.py
+++ b/selftests/unit/test_nrunner.py
@@ -474,5 +474,18 @@ class PickRunner(unittest.TestCase):
         self.assertFalse(self.runnable.pick_runner_command({}))
 
 
+class Task(unittest.TestCase):
+
+    def test_default_category(self):
+        runnable = nrunner.Runnable('noop', 'noop_uri')
+        task = nrunner.Task(runnable, 'task_id')
+        self.assertEqual(task.category, 'test')
+
+    def test_set_category(self):
+        runnable = nrunner.Runnable('noop', 'noop_uri')
+        task = nrunner.Task(runnable, 'task_id', category='new_category')
+        self.assertEqual(task.category, 'new_category')
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This introduces the `category` attribute of a Task. It can be used to keep track of different kinds/categories of Tasks running and take actions based on it. The default value of a Task category is 'test'.

This also changes the `avocado.core.messages` to avoid non-`test` tasks being accounted as tests.

Signed-off-by: Willian Rampazzo <willianr@redhat.com>