### PR TITLE
[NRunner] Introduce task category v3

### DIFF
--- a/avocado/core/messages.py
+++ b/avocado/core/messages.py
@@ -102,9 +102,10 @@ class StartMessageHandler(BaseMessageHandler):
                     'task_path': task_path,
                     'time_start': message['time'],
                     'name': task.identifier}
-        job.result.start_test(metadata)
-        job.result_events_dispatcher.map_method('start_test', job.result,
-                                                metadata)
+        if task.category == 'test':
+            job.result.start_test(metadata)
+            job.result_events_dispatcher.map_method('start_test', job.result,
+                                                    metadata)
         task.metadata.update(metadata)
 
 
@@ -139,8 +140,10 @@ class FinishMessageHandler(BaseMessageHandler):
 
         message['logdir'] = task.metadata['task_path']
 
-        job.result.check_test(message)
-        job.result_events_dispatcher.map_method('end_test', job.result, message)
+        if task.category == 'test':
+            job.result.check_test(message)
+            job.result_events_dispatcher.map_method('end_test', job.result,
+                                                    message)
 
 
 class BaseRunningMessageHandler(BaseMessageHandler):

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -662,7 +662,7 @@ class Task:
     """
 
     def __init__(self, runnable, identifier=None, status_uris=None,
-                 known_runners=None):
+                 known_runners=None, category='test'):
         """Instantiates a new Task.
 
         :param runnable: the "description" of what the task should run.
@@ -679,9 +679,12 @@ class Task:
         :type status_uri: list
         :param known_runners: a mapping of runnable kinds to runners.
         :type known_runners: dict
+        :param category: category of this task. Defaults to 'test'.
+        :type category: str
         """
         self.runnable = runnable
         self.identifier = identifier or str(uuid1())
+        self.category = category
         self.status_services = []
         if status_uris is not None:
             for status_uri in status_uris:

--- a/selftests/unit/test_nrunner.py
+++ b/selftests/unit/test_nrunner.py
@@ -474,5 +474,18 @@ class PickRunner(unittest.TestCase):
         self.assertFalse(self.runnable.pick_runner_command({}))
 
 
+class Task(unittest.TestCase):
+
+    def test_default_category(self):
+        runnable = nrunner.Runnable('noop', 'noop_uri')
+        task = nrunner.Task(runnable, 'task_id')
+        self.assertEqual(task.category, 'test')
+
+    def test_set_category(self):
+        runnable = nrunner.Runnable('noop', 'noop_uri')
+        task = nrunner.Task(runnable, 'task_id', category='new_category')
+        self.assertEqual(task.category, 'new_category')
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This introduces the `category` attribute of a Task. It can be used to keep track of different kinds/categories of Tasks running and take actions based on it. The default value of a Task category is 'test'.

This also changes the `avocado.core.messages` to avoid non-`test` tasks being accounted as tests.

Signed-off-by: Willian Rampazzo <willianr@redhat.com>