### PR TITLE
better output message and code when using ignore-missing-references

### DIFF
--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -296,7 +296,11 @@ class Run(CLICmd):
         try:
             suite = TestSuite.from_config(config, name='')
             if suite.size == 0:
-                sys.exit(exit_codes.AVOCADO_JOB_FAIL)
+                msg = ("Suite is empty. There is no tests to run. This usually "
+                       "happens when you pass --ignore-missing-references and "
+                       "there is no more references to process.")
+                LOG_UI.warning(msg)
+                sys.exit(exit_codes.AVOCADO_FAIL)
         except TestSuiteError as err:
             LOG_UI.error(err)
             sys.exit(exit_codes.AVOCADO_JOB_FAIL)

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -229,8 +229,8 @@ class RunnerOperationTest(TestCaseTmpDir):
         result = process.run(cmd_line, ignore_status=True)
         self.assertIn(b"Unable to resolve reference(s) 'badtest.py', 'badtest2.py'",
                       result.stderr)
-        self.assertEqual(b'', result.stdout)
-        expected_rc = exit_codes.AVOCADO_JOB_FAIL
+        self.assertIn(b'Suite is empty. There is no tests to run.', result.stderr)
+        expected_rc = exit_codes.AVOCADO_FAIL
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %d:\n%s" % (expected_rc, result))
 


### PR DESCRIPTION
When using ignore-missing-references, Avocado was returning
AVOCADO_JOB_FAIL without explaining the reason. Since we don't have
exactly an job failed here, I'm changing the return code and adding a
warning message. Fixes #4527.

Signed-off-by: Beraldo Leal <bleal@redhat.com>