### PR TITLE
Task identifier as TestID

### DIFF
--- a/avocado/core/messages.py
+++ b/avocado/core/messages.py
@@ -93,15 +93,16 @@ class StartMessageHandler(BaseMessageHandler):
     """
 
     def handle(self, message, task, job):
+        task_id = task.identifier_as_test_id
         base_path = job.test_results_path
-        task_path = os.path.join(base_path, task.identifier.str_filesystem)
+        task_path = os.path.join(base_path, task_id.str_filesystem)
         os.makedirs(task_path, exist_ok=True)
         metadata = {'job_logdir': job.logdir,
                     'job_unique_id': job.unique_id,
                     'base_path': base_path,
                     'task_path': task_path,
                     'time_start': message['time'],
-                    'name': task.identifier}
+                    'name': task_id}
         if task.category == 'test':
             job.result.start_test(metadata)
             job.result_events_dispatcher.map_method('start_test', job.result,
@@ -129,7 +130,7 @@ class FinishMessageHandler(BaseMessageHandler):
 
     def handle(self, message, task, job):
         message.update(task.metadata)
-        message['name'] = task.identifier
+        message['name'] = task.identifier_as_test_id
         message['status'] = message.get('result').upper()
 
         time_start = message['time_start']

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -18,6 +18,8 @@ import time
 import unittest
 from uuid import uuid1
 
+from .test_id import TestID
+
 try:
     import pkg_resources
     PKG_RESOURCES_AVAILABLE = True
@@ -695,6 +697,13 @@ class Task:
         self.spawn_handle = None
         self.output_dir = None
         self.metadata = {}
+
+    @property
+    def identifier_as_test_id(self):
+        if type(self.identifier) is TestID:
+            return self.identifier
+        else:
+            return TestID(str(self.identifier), "task")
 
     def __repr__(self):
         fmt = '<Task identifier="{}" runnable="{}" status_services="{}"'


### PR DESCRIPTION
Some of our plugins expecting that when task is a test that the
identifier is `avocado.core.test_id.TestID`, but this is not enforced an
even the default identifier is not `TestID` but it is a string. This
PR adds the ability to convert `Task.identifier` to `TestID` when
it's needed.

Signed-off-by: Jan Richter <jarichte@redhat.com>