### PR TITLE
datadir.paths.cache_dirs now is defined from settings registration

### DIFF
--- a/avocado/core/__init__.py
+++ b/avocado/core/__init__.py
@@ -82,11 +82,15 @@ def register_core_options():
                          help_msg=help_msg,
                          default=60)
 
+    # Let's assume that by default, cache will be located under the user's
+    # umbrella. This will make it easy for our deployments and it is a common
+    # place for other applications too.
     help_msg = 'Cache directories to be used by the avocado test'
+    default = prepend_base_path('~/avocado/data/cache')
     stgs.register_option(section='datadir.paths',
                          key='cache_dirs',
                          key_type=list,
-                         default=[],
+                         default=[default],
                          help_msg=help_msg)
 
     help_msg = 'Base directory for Avocado tests and auxiliary data'

--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -32,6 +32,7 @@ import shutil
 import sys
 import tempfile
 import time
+import warnings
 
 from ..utils import path as utils_path
 from ..utils.data_structures import Borg
@@ -202,13 +203,13 @@ def create_job_logs_dir(base_dir=None, unique_id=None):
 
 def get_cache_dirs():
     """
-    Returns the list of cache dirs, according to configuration and convention
+    Returns the list of cache dirs, according to configuration and convention.
+
+    This will be deprecated. Please use settings.as_dict() or self.config.
     """
-    cache_dirs = settings.as_dict().get('datadir.paths.cache_dirs')
-    datadir_cache = os.path.join(get_data_dir(), 'cache')
-    if datadir_cache not in cache_dirs:
-        cache_dirs.append(datadir_cache)
-    return cache_dirs
+    warnings.warn(("get_cache_dirs() is deprecated, get values from "
+                   "settings.as_dict() or self.config"), DeprecationWarning)
+    return settings.as_dict().get('datadir.paths.cache_dirs')
 
 
 class _TmpDirTracker(Borg):

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -34,7 +34,7 @@ from difflib import unified_diff
 from ..utils import asset, astring, data_structures, genio
 from ..utils import path as utils_path
 from ..utils import process, stacktrace
-from . import data_dir, exceptions, output, parameters, sysinfo, tapparser
+from . import exceptions, output, parameters, sysinfo, tapparser
 from .decorators import skip
 from .output import LOG_JOB
 from .settings import settings
@@ -455,7 +455,7 @@ class Test(unittest.TestCase, TestData):
         Returns a list of cache directories as set in config file.
         """
         if self.__cache_dirs is None:
-            self.__cache_dirs = data_dir.get_cache_dirs()
+            self.__cache_dirs = self._config.get('datadir.paths.cache_dirs')
         return self.__cache_dirs
 
     @property

--- a/avocado/plugins/assets.py
+++ b/avocado/plugins/assets.py
@@ -20,7 +20,7 @@ import ast
 import os
 from datetime import datetime
 
-from avocado.core import data_dir, exit_codes, safeloader
+from avocado.core import exit_codes, safeloader
 from avocado.core.nrunner import Runnable
 from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLICmd, JobPreTests
@@ -203,7 +203,7 @@ def fetch_assets(test_file, klass=None, method=None, logger=None):
     :returns: list of names that were successfully fetched and list of
     fails.
     """
-    cache_dirs = data_dir.get_cache_dirs()
+    cache_dirs = settings.as_dict().get('datadir.paths.cache_dirs')
     success = []
     fail = []
     handler = FetchAssetHandler(test_file, klass, method)
@@ -405,7 +405,7 @@ class Assets(CLICmd):
             LOG_UI.error(msg)
             return exit_codes.AVOCADO_FAIL
 
-        cache_dirs = data_dir.get_cache_dirs()
+        cache_dirs = config.get('datadir.paths.cache_dirs')
         try:
             if days is not None:
                 Asset.remove_assets_by_unused_for_days(days, cache_dirs)
@@ -436,8 +436,7 @@ class Assets(CLICmd):
             LOG_UI.error(msg)
             return exit_codes.AVOCADO_FAIL
 
-        # IMO, this should get data from config instead. See #4443
-        cache_dirs = data_dir.get_cache_dirs()
+        cache_dirs = config.get('datadir.paths.cache_dirs')
         try:
             assets = None
             if days is not None:
@@ -498,7 +497,7 @@ class Assets(CLICmd):
 
     @staticmethod
     def handle_register(config):
-        cache_dirs = data_dir.get_cache_dirs()
+        cache_dirs = config.get('datadir.paths.cache_dirs')
         name = config.get('assets.register.name')
         asset_hash = config.get('assets.register.sha1_hash')
         location = config.get('assets.register.url')

--- a/avocado/plugins/config.py
+++ b/avocado/plugins/config.py
@@ -94,6 +94,7 @@ class Config(CLICmd):
             for namespace, value in config.items():
                 LOG_UI.debug(format_str, namespace, value)
         else:
+            cache_dirs = config.get('datadir.paths.cache_dirs')
             LOG_UI.debug("Avocado replaces config dirs that can't be accessed")
             LOG_UI.debug("with sensible defaults. Please edit your local config")
             LOG_UI.debug("file to customize values")
@@ -103,4 +104,4 @@ class Config(CLICmd):
             LOG_UI.debug('    tests    %s', data_dir.get_test_dir())
             LOG_UI.debug('    data     %s', data_dir.get_data_dir())
             LOG_UI.debug('    logs     %s', data_dir.get_logs_dir())
-            LOG_UI.debug('    cache    %s', ", ".join(data_dir.get_cache_dirs()))
+            LOG_UI.debug('    cache    %s', ", ".join(cache_dirs))

--- a/avocado/plugins/vmimage.py
+++ b/avocado/plugins/vmimage.py
@@ -2,7 +2,7 @@ import json
 import os
 import re
 
-from avocado.core import data_dir, exit_codes, output
+from avocado.core import exit_codes, output
 from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLICmd
 from avocado.core.settings import settings
@@ -16,7 +16,7 @@ def list_downloaded_images():
     :rtype: list of dicts
     """
     images = []
-    for cache_dir in data_dir.get_cache_dirs():
+    for cache_dir in settings.as_dict().get('datadir.paths.cache_dirs'):
         for root, _, files in os.walk(cache_dir):
             if files:
                 metadata_files = [pos_json for pos_json in files
@@ -60,7 +60,7 @@ def download_image(distro, version=None, arch=None):
     :return: Information about downloaded image
     :rtype: dict
     """
-    cache_dir = data_dir.get_cache_dirs()[0]
+    cache_dir = settings.as_dict().get('datadir.paths.cache_dirs')[0]
     image_info = vmimage.get(name=distro, version=version, arch=arch,
                              cache_dir=cache_dir)
     file_path = image_info.base_image

--- a/contrib/scripts/vmimage-populate-cache.py
+++ b/contrib/scripts/vmimage-populate-cache.py
@@ -4,7 +4,7 @@
 Script that downloads cloud images via avocado.utils.vmimage
 """
 
-from avocado.core import data_dir
+from avocado.core.settings import settings
 from avocado.utils import vmimage
 
 KNOWN_IMAGES = (
@@ -20,9 +20,10 @@ def main():
     for image in KNOWN_IMAGES:
         name, version, arch, checksum, algorithm = image
         print("%s version %s (%s): " % (name, version, arch), end='')
+        cache_dir = settings.as_dict().get('datadir.paths.cache_dirs')[0]
         download = vmimage.get(name=name, version=version, arch=arch,
                                checksum=checksum, algorithm=algorithm,
-                               cache_dir=data_dir.get_cache_dirs()[0])
+                               cache_dir=cache_dir)
         print(download.base_image)
 
 

--- a/selftests/unit/plugin/test_vmimage.py
+++ b/selftests/unit/plugin/test_vmimage.py
@@ -3,7 +3,6 @@ import tempfile
 import unittest.mock
 from urllib.error import URLError
 
-from avocado.core import data_dir
 from avocado.core.settings import Settings
 from avocado.plugins import vmimage as vmimage_plugin
 from avocado.utils import vmimage as vmimage_util
@@ -75,13 +74,16 @@ class VMImagePlugin(unittest.TestCase):
         prefix = temp_dir_prefix(__name__, self, 'setUp')
         base_dir = tempfile.TemporaryDirectory(prefix=prefix)
         data_directory = os.path.join(base_dir.name, 'data')
+        cache_directory = os.path.join(data_directory, 'cache')
         os.mkdir(data_directory)
-        os.mkdir(os.path.join(data_directory, 'cache'))
+        os.mkdir(cache_directory)
         mapping = {'base_dir': base_dir.name,
-                   'data_dir': data_directory}
+                   'data_dir': data_directory,
+                   'cache_dirs': [cache_directory]}
         temp_settings = ('[datadir.paths]\n'
                          'base_dir = %(base_dir)s\n'
-                         'data_dir = %(data_dir)s\n') % mapping
+                         'data_dir = %(data_dir)s\n'
+                         'cache_dirs = %(cache_dirs)s\n') % mapping
         config_file = tempfile.NamedTemporaryFile('w', delete=False)
         config_file.write(temp_settings)
         config_file.close()
@@ -95,7 +97,7 @@ class VMImagePlugin(unittest.TestCase):
                                {'name': 'JeOS', 'file': 'jeos-{version}-{arch}.qcow2.xz', 'url': JEOS_PAGE},
                                {'name': 'CirrOS', 'file': 'cirros-{version}-{arch}-disk.img', 'url': CIRROS_PAGE}
                                ]
-            cache_dir = data_dir.get_cache_dirs()[0]
+            cache_dir = self.mapping.get('cache_dirs')[0]
             providers = [provider() for provider in vmimage_util.list_providers()]
 
             for provider in providers:


### PR DESCRIPTION
The current code is creating a custom logic adding a default value that is hardcoded. data_dir module was created way before our new settings logic was introduced, default values now are defined at registration time.  Also, with the current logic "avocado config --datadirs" and "avocado config" output are not consistent (when looking to the cache_dirs).

On top of that, when users define a custom value, in some cases Avocado is replacing this value with a default hardcoded value, instead of respecting users' choice (for instance when users have no permissions).

My proposal here is to use `~/avocado/data/cache` as the default cache dir since usually, a cache dir is useful regardless of the method of installation. This is part of #4443, and if approved I will work on the remaining datadir.paths.*
    
Signed-off-by: Beraldo Leal <bleal@redhat.com>