### PR TITLE
Task identifier as TestID [v3]

### DIFF
--- a/avocado/core/messages.py
+++ b/avocado/core/messages.py
@@ -14,6 +14,8 @@
 
 import os
 
+from .test_id import TestID
+
 
 class BaseMessageHandler:
     """
@@ -93,15 +95,16 @@ class StartMessageHandler(BaseMessageHandler):
     """
 
     def handle(self, message, task, job):
+        task_id = TestID.from_identifier(task.identifier)
         base_path = job.test_results_path
-        task_path = os.path.join(base_path, task.identifier.str_filesystem)
+        task_path = os.path.join(base_path, task_id.str_filesystem)
         os.makedirs(task_path, exist_ok=True)
         metadata = {'job_logdir': job.logdir,
                     'job_unique_id': job.unique_id,
                     'base_path': base_path,
                     'task_path': task_path,
                     'time_start': message['time'],
-                    'name': task.identifier}
+                    'name': task_id}
         if task.category == 'test':
             job.result.start_test(metadata)
             job.result_events_dispatcher.map_method('start_test', job.result,
@@ -129,7 +132,7 @@ class FinishMessageHandler(BaseMessageHandler):
 
     def handle(self, message, task, job):
         message.update(task.metadata)
-        message['name'] = task.identifier
+        message['name'] = TestID.from_identifier(task.identifier)
         message['status'] = message.get('result').upper()
 
         time_start = message['time_start']

--- a/avocado/core/test_id.py
+++ b/avocado/core/test_id.py
@@ -84,3 +84,19 @@ class TestID:
             raise RuntimeError('Test ID is too long to be stored on the '
                                'filesystem: "%s"\nFull Test ID: "%s"'
                                % (self.str_uid, str(self)))
+
+    @classmethod
+    def from_identifier(cls, identifier):
+        """
+        It wraps an identifier by the TestID class.
+
+        :param identifier: Any identifier that is guaranteed to be unique
+        within the context of an avocado Job.
+        :return: TestID with `uid` as string representation of `identifier`
+        and `name` "test".
+        :rtype :class:`avocado.core.test_id.TestID`
+        """
+        if type(identifier) is cls:
+            return identifier
+        else:
+            return cls(str(identifier), "test")


### PR DESCRIPTION
Some `ResultEvents` plugins expecting that when task is a test that the
identifier is `avocado.core.test_id.TestID`, but this is not enforced an
even the default identifier of Task is not `TestID` but it is a string.
This PR adds the ability to convert `Task.identifier` to `TestID`
before is used by `ResultEvents` plugins.

Signed-off-by: Jan Richter <jarichte@redhat.com>

---
Changes from v1 (#4550)
* The convertor moved from the Task to Messages.


Changes from v2 (#4554)
* The convertor moved from the Messages to TestID.