### PR TITLE
Empty reference in resolver

### DIFF
--- a/avocado/core/resolver.py
+++ b/avocado/core/resolver.py
@@ -39,6 +39,15 @@ class ReferenceResolutionAction(Enum):
     CONTINUE = object()
 
 
+class EmptyReference:
+    """Definition of the empty reference
+
+    It indicates the empty reference. It will be used when the `test.reference`
+    variable is empty, so the resolver have to use another data for resolving
+    tests.
+    """
+
+
 class ReferenceResolution:
 
     """
@@ -173,10 +182,10 @@ def resolve(references, hint=None, ignore_missing=True):
     if not references and hint_references:
         references = list(hint_references.keys())
 
+    resolver = Resolver()
     if references:
         # should be initialized with args, to define the behavior
         # of this instance as a whole
-        resolver = Resolver()
         extended_references = []
         for reference in references:
             # a reference extender is not (yet?) an extensible feature
@@ -188,6 +197,8 @@ def resolve(references, hint=None, ignore_missing=True):
                 resolutions.append(hint_references[reference])
             else:
                 resolutions.extend(resolver.resolve(reference))
+    else:
+        resolutions.extend(resolver.resolve(EmptyReference))
 
     # This came up from a previous method and can be refactored to improve
     # performance since that we could merge with the loop above.

--- a/examples/plugins/tests/magic/avocado_magic/resolver.py
+++ b/examples/plugins/tests/magic/avocado_magic/resolver.py
@@ -18,7 +18,7 @@ Test resolver for magic test words
 
 from avocado.core.nrunner import Runnable
 from avocado.core.plugin_interfaces import Resolver
-from avocado.core.resolver import (ReferenceResolution,
+from avocado.core.resolver import (EmptyReference, ReferenceResolution,
                                    ReferenceResolutionResult)
 
 VALID_MAGIC_WORDS = ['pass', 'fail']
@@ -36,6 +36,10 @@ class MagicResolver(Resolver):
                 reference,
                 ReferenceResolutionResult.NOTFOUND,
                 info='Word "%s" is not a valid magic word' % (reference))
+        if reference is EmptyReference:
+            return ReferenceResolution('pass',
+                                       ReferenceResolutionResult.SUCCESS,
+                                       [Runnable('magic', reference)])
 
         return ReferenceResolution(reference,
                                    ReferenceResolutionResult.SUCCESS,


### PR DESCRIPTION
Some resolvers might be able to resolve tests without the test
reference. They can use config files or other parameters from user. As
an example is vt-resolver which can use Cartesian configuration for
resolving tests. This commit adds the ability for resolvers to resolve
tests from different  data without the test references.

Signed-off-by: Jan Richter <jarichte@redhat.com>