### PR TITLE
core.suite: small fix on getting config

### DIFF
--- a/avocado/core/suite.py
+++ b/avocado/core/suite.py
@@ -103,7 +103,7 @@ class TestSuite:
         self._runner = None
         self._test_parameters = None
 
-        if (config.get('run.dry_run.enabled') and
+        if (self.config.get('run.dry_run.enabled') and
                 self.config.get('run.test_runner') == 'runner'):
             self._convert_to_dry_run()
 


### PR DESCRIPTION
When no config is used and default one is used (None) an AttributeError
will happen here. Fixes #4573.

Signed-off-by: Beraldo Leal <bleal@redhat.com>