### PR TITLE
Lint: add isort check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,11 +88,11 @@ class Linter(SimpleCommand):
 
     def run(self):
         try:
-            check_call('selftests/signedoff-check.sh')
-            check_call('selftests/spell.sh')
             check_call('selftests/inspekt-indent.sh')
             check_call('selftests/inspekt-style.sh')
             check_call('selftests/lint.sh')
+            check_call('selftests/signedoff-check.sh')
+            check_call('selftests/spell.sh')
         except CalledProcessError as e:
             print("Failed during lint checks: ", e)
             sys.exit(128)

--- a/setup.py
+++ b/setup.py
@@ -90,6 +90,7 @@ class Linter(SimpleCommand):
         try:
             check_call('selftests/inspekt-indent.sh')
             check_call('selftests/inspekt-style.sh')
+            check_call('selftests/isort.sh')
             check_call('selftests/lint.sh')
             check_call('selftests/signedoff-check.sh')
             check_call('selftests/spell.sh')


### PR DESCRIPTION
`selftests/isort.sh` is missing from the list of commands executed for the lint checks.  This was caught when a local failure was not caught by the GitHub Actions job.