### PR TITLE
isort: fixing import order for avocado/plugins/list.py

### DIFF
--- a/avocado/plugins/list.py
+++ b/avocado/plugins/list.py
@@ -13,8 +13,8 @@
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 # Author: Beraldo Leal <bleal@redhat.com>
 
-import os
 import json
+import os
 
 from avocado.core import exit_codes, loader, parser_common_args
 from avocado.core.output import LOG_UI, TERM_SUPPORT


### PR DESCRIPTION
isort fix for GitHub actions

Signed-off-by: Jan Richter <jarichte@redhat.com>