### PR TITLE
Improve the output of "avocado run --help"

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -416,7 +416,8 @@ def add_loader_options(parser, section='run'):
                              default=['file', '@DEFAULT'],
                              help_msg=help_msg,
                              parser=arggrp,
-                             long_arg='--loaders')
+                             long_arg='--loaders',
+                             metavar='LOADER_NAME_OR_TEST_TYPE')
 
     help_msg = ("Path to an specific test runner that allows the use of its "
                 "own tests. This should be used for running tests that do not "
@@ -428,7 +429,8 @@ def add_loader_options(parser, section='run'):
                              default=None,
                              help_msg=help_msg,
                              parser=arggrp,
-                             long_arg='--external-runner')
+                             long_arg='--external-runner',
+                             metavar='EXTERNAL_RUNNER')
 
     help_msg = ("Change directory before executing tests. This option may be "
                 "necessary because of requirements and/or limitations of the "

--- a/avocado/plugins/json_variants.py
+++ b/avocado/plugins/json_variants.py
@@ -57,7 +57,8 @@ class JsonVariantsCLI(CLI):
                 namespace='json.variants.load',
                 parser=sparser,
                 long_arg='--json-variants-load',
-                allow_multiple=True)
+                allow_multiple=True,
+                metavar='FILE')
 
     def run(self, config):
         pass

--- a/avocado/plugins/legacy/replay.py
+++ b/avocado/plugins/legacy/replay.py
@@ -49,7 +49,8 @@ class Replay(CLI):
                                  default=None,
                                  help_msg=help_msg,
                                  parser=replay_parser,
-                                 long_arg='--replay')
+                                 long_arg='--replay',
+                                 metavar='JOB_ID')
 
         help_msg = 'Filter tests to replay by test status.'
         settings.register_option(section='run.replay',
@@ -58,7 +59,8 @@ class Replay(CLI):
                                  help_msg=help_msg,
                                  key_type=self._valid_status,
                                  parser=replay_parser,
-                                 long_arg='--replay-test-status')
+                                 long_arg='--replay-test-status',
+                                 metavar='TEST_STATUS')
 
         help_msg = 'Ignore variants and/or configuration from the source job.'
         settings.register_option(section='run.replay',
@@ -67,7 +69,8 @@ class Replay(CLI):
                                  help_msg=help_msg,
                                  key_type=self._valid_ignore,
                                  parser=replay_parser,
-                                 long_arg='--replay-ignore')
+                                 long_arg='--replay-ignore',
+                                 metavar='IGNORE')
 
         help_msg = 'Resume an interrupted job'
         settings.register_option(section='run.replay',

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -110,7 +110,8 @@ class Run(CLICmd):
                                  default='runner',
                                  help_msg=help_msg,
                                  parser=parser,
-                                 long_arg='--test-runner')
+                                 long_arg='--test-runner',
+                                 metavar='TEST_RUNNER')
 
         help_msg = ('Instead of running the test only list them and log '
                     'their params.')
@@ -142,7 +143,8 @@ class Run(CLICmd):
                                  default=None,
                                  help_msg=help_msg,
                                  parser=parser,
-                                 long_arg='--force-job-id')
+                                 long_arg='--force-job-id',
+                                 metavar='UNIQUE_JOB_ID')
 
         help_msg = 'Forces to use of an alternate job results directory.'
         settings.register_option(section='run',
@@ -212,7 +214,8 @@ class Run(CLICmd):
 
         settings.add_argparser_to_option('job.run.store_logging_stream',
                                          parser=parser.output,
-                                         long_arg='--store-logging-stream')
+                                         long_arg='--store-logging-stream',
+                                         metavar='LOGGING_STREAM')
 
         help_msg = ('Logs the possible data directories for each test. This '
                     'is helpful when writing new tests and not being sure '

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -117,16 +117,29 @@ class RunnerCLI(CLI):
                                          long_arg='--nrunner-shuffle',
                                          action='store_true')
 
-        # namespace mapping
-        ns = {'nrunner.status_server_listen': '--nrunner-status-server-listen',
-              'nrunner.status_server_uri': '--nrunner-status-server-uri',
-              'nrunner.max_parallel_tasks': '--nrunner-max-parallel-tasks',
-              'nrunner.spawner': '--nrunner-spawner'}
+        settings.add_argparser_to_option(
+            namespace='nrunner.status_server_listen',
+            parser=parser,
+            long_arg='--nrunner-status-server-listen',
+            metavar='HOST_PORT')
 
-        for k, v in ns.items():
-            settings.add_argparser_to_option(namespace=k,
-                                             parser=parser,
-                                             long_arg=v)
+        settings.add_argparser_to_option(
+            namespace='nrunner.status_server_uri',
+            parser=parser,
+            long_arg='--nrunner-status-server-uri',
+            metavar='HOST_PORT')
+
+        settings.add_argparser_to_option(
+            namespace='nrunner.max_parallel_tasks',
+            parser=parser,
+            long_arg='--nrunner-max-parallel-tasks',
+            metavar='NUMBER_OF_TASKS')
+
+        settings.add_argparser_to_option(
+            namespace='nrunner.spawner',
+            parser=parser,
+            long_arg='--nrunner-spawner',
+            metavar='SPAWNER')
 
     def run(self, config):
         pass

--- a/avocado/plugins/spawners/podman.py
+++ b/avocado/plugins/spawners/podman.py
@@ -44,11 +44,13 @@ class PodmanCLI(CLI):
         parser = parser.add_argument_group('podman spawner specific options')
         settings.add_argparser_to_option(namespace='spawner.podman.bin',
                                          parser=parser,
-                                         long_arg='--spawner-podman-bin')
+                                         long_arg='--spawner-podman-bin',
+                                         metavar='PODMAN_BIN')
 
         settings.add_argparser_to_option(namespace='spawner.podman.image',
                                          parser=parser,
-                                         long_arg='--spawner-podman-image')
+                                         long_arg='--spawner-podman-image',
+                                         metavar='CONTAINER_IMAGE')
 
     def run(self, config):
         pass

--- a/avocado/plugins/xunit.py
+++ b/avocado/plugins/xunit.py
@@ -228,7 +228,8 @@ class XUnitCLI(CLI):
         settings.add_argparser_to_option(
             namespace='job.run.result.xunit.job_name',
             parser=run_subcommand_parser.output,
-            long_arg='--xunit-job-name')
+            long_arg='--xunit-job-name',
+            metavar='XUNIT_JOB_NAME')
 
         settings.add_argparser_to_option(
             namespace='job.run.result.xunit.max_test_log_chars',

--- a/optional_plugins/result_upload/avocado_result_upload/__init__.py
+++ b/optional_plugins/result_upload/avocado_result_upload/__init__.py
@@ -75,7 +75,8 @@ class ResultUploadCLI(CLI):
                                  default=None,
                                  help_msg=help_msg,
                                  parser=parser,
-                                 long_arg='--result-upload-url')
+                                 long_arg='--result-upload-url',
+                                 metavar='URL')
 
         try:
             rsync_bin = utils_path.find_command('rsync')
@@ -92,7 +93,8 @@ class ResultUploadCLI(CLI):
                                  help_msg=help_msg,
                                  default=def_upload_cmd,
                                  parser=parser,
-                                 long_arg='--result-upload-cmd')
+                                 long_arg='--result-upload-cmd',
+                                 metavar='COMMAND')
 
     def run(self, config):
         pass

--- a/optional_plugins/resultsdb/avocado_resultsdb/__init__.py
+++ b/optional_plugins/resultsdb/avocado_resultsdb/__init__.py
@@ -182,7 +182,8 @@ class ResultsdbCLI(CLI):
                                  default=None,
                                  help_msg=help_msg,
                                  parser=parser,
-                                 long_arg='--resultsdb-api')
+                                 long_arg='--resultsdb-api',
+                                 metavar='API_URL')
 
         help_msg = 'Specify the URL where the logs are published'
         settings.register_option(section='plugins.resultsdb',
@@ -190,7 +191,8 @@ class ResultsdbCLI(CLI):
                                  default=None,
                                  help_msg=help_msg,
                                  parser=parser,
-                                 long_arg='--resultsdb-logs')
+                                 long_arg='--resultsdb-logs',
+                                 metavar='LOGS_URL')
 
         help_msg = 'Maximum note size limit'
         settings.register_option(section='plugins.resultsdb',
@@ -199,7 +201,8 @@ class ResultsdbCLI(CLI):
                                  key_type=int,
                                  help_msg=help_msg,
                                  parser=parser,
-                                 long_arg='--resultsdb-note-limit')
+                                 long_arg='--resultsdb-note-limit',
+                                 metavar='SIZE_LIMIT')
 
     def run(self, config):
         pass

--- a/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/__init__.py
+++ b/optional_plugins/varianter_yaml_to_mux/avocado_varianter_yaml_to_mux/__init__.py
@@ -436,28 +436,32 @@ class YamlToMuxCLI(CLI):
                 parser=agroup,
                 long_arg='--mux-filter-only',
                 nargs='+',
-                allow_multiple=True)
+                allow_multiple=True,
+                metavar='FILTER')
 
             settings.add_argparser_to_option(
                 namespace="%s.%s" % (self.name, 'filter_out'),
                 parser=agroup,
                 long_arg='--mux-filter-out',
                 nargs='+',
-                allow_multiple=True)
+                allow_multiple=True,
+                metavar='FILTER')
 
             settings.add_argparser_to_option(
                 namespace="%s.%s" % (self.name, 'parameter_paths'),
                 parser=agroup,
                 long_arg='--mux-path',
                 nargs='+',
-                allow_multiple=True)
+                allow_multiple=True,
+                metavar='PATH')
 
             settings.add_argparser_to_option(
                 namespace="%s.%s" % (self.name, 'inject'),
                 parser=agroup,
                 long_arg='--mux-inject',
                 nargs='+',
-                allow_multiple=True)
+                allow_multiple=True,
+                metavar='PATH_KEY_NODE')
 
     def run(self, config):
         """


### PR DESCRIPTION
The automatically generated help message reuses the option names as
their "metavar" is this makes the output quite confusing in some
cases.

This is an attempt to make the help message more human friendly.

Signed-off-by: Cleber Rosa <crosa@redhat.com>

---

This is attempts to address [this type](https://github.com/avocado-framework/avocado/pull/4583/commits/419a455e7b0f615c2e40df6241ce59adc5bcd7a9#r631875133) of "regression".