### PR TITLE
Update outputs of avocado <subcommand> --help

### DIFF
--- a/avocado/plugins/diff.py
+++ b/avocado/plugins/diff.py
@@ -94,6 +94,7 @@ class Diff(CLICmd):
                     '(no)config,(no)sysinfo (defaults to all enabled).')
         settings.register_option(section='diff',
                                  key='filter',
+                                 metavar='DIFF_FILTER',
                                  key_type=self._validate_filters,
                                  help_msg=help_msg,
                                  default=['cmdline', 'time', 'variants',

--- a/avocado/plugins/distro.py
+++ b/avocado/plugins/distro.py
@@ -305,7 +305,7 @@ class Distro(CLICmd):
     def configure(self, parser):
         parser = super(Distro, self).configure(parser)
 
-        help_msg = 'Cretes a distro definition file based on the path given.'
+        help_msg = 'Creates a distro definition file based on the path given.'
         settings.register_option(section='distro',
                                  key='distro_def_create',
                                  default=False,
@@ -320,7 +320,8 @@ class Distro(CLICmd):
                                  default='',
                                  help_msg=help_msg,
                                  parser=parser,
-                                 long_arg='--distro-def-name')
+                                 long_arg='--distro-def-name',
+                                 metavar='DISTRO_DEF_NAME')
 
         help_msg = 'Distribution major version name'
         settings.register_option(section='distro',
@@ -328,7 +329,8 @@ class Distro(CLICmd):
                                  default='',
                                  help_msg=help_msg,
                                  parser=parser,
-                                 long_arg='--distro-def-version')
+                                 long_arg='--distro-def-version',
+                                 metavar='DISTRO_DEF_VERSION')
 
         help_msg = 'Distribution release version number'
         settings.register_option(section='distro',
@@ -336,7 +338,8 @@ class Distro(CLICmd):
                                  default='',
                                  help_msg=help_msg,
                                  parser=parser,
-                                 long_arg='--distro-def-release')
+                                 long_arg='--distro-def-release',
+                                 metavar='DISTRO_DEF_RELEASE')
 
         help_msg = 'Primary architecture that the distro targets'
         settings.register_option(section='distro',
@@ -344,7 +347,8 @@ class Distro(CLICmd):
                                  default='',
                                  help_msg=help_msg,
                                  parser=parser,
-                                 long_arg='--distro-def-arch')
+                                 long_arg='--distro-def-arch',
+                                 metavar='DISTRO_DEF_ARCH')
 
         help_msg = 'Top level directory of the distro installation files'
         settings.register_option(section='distro',

--- a/avocado/plugins/variants.py
+++ b/avocado/plugins/variants.py
@@ -58,7 +58,8 @@ class Variants(CLICmd):
                                  default=0,
                                  help_msg=help_msg,
                                  parser=parser,
-                                 long_arg='--summary')
+                                 long_arg='--summary',
+                                 metavar='SUMMARY')
 
         help_msg = 'Verbosity of the list of variants. ' + verbosity_levels
         settings.register_option(section='variants',
@@ -67,7 +68,8 @@ class Variants(CLICmd):
                                  default=1,
                                  help_msg=help_msg,
                                  parser=parser,
-                                 long_arg='--variants')
+                                 long_arg='--variants',
+                                 metavar='VARIANTS')
 
         help_msg = ('[obsoleted by --variants] Shows the node content '
                     '(variables)')
@@ -86,7 +88,8 @@ class Variants(CLICmd):
                                  help_msg=help_msg,
                                  default=None,
                                  parser=parser,
-                                 long_arg='--json-variants-dump')
+                                 long_arg='--json-variants-dump',
+                                 metavar='FILE')
 
         env_parser = parser.add_argument_group("environment view options")
 


### PR DESCRIPTION
Follow-up for PR #4587.
Improve the output of generated help messages by diff, distro
and variants to make the output more readable.

Signed-off-by: Ana Guerrero Lopez <agl@redhat.com>