### PR TITLE
Empty reference in resolver [v2]

### DIFF
--- a/avocado/core/plugin_interfaces.py
+++ b/avocado/core/plugin_interfaces.py
@@ -234,6 +234,24 @@ class Resolver(Plugin):
         """
 
 
+class Discoverer(Plugin):
+    """Base plugin interface for discovering tests without reference."""
+
+    @abc.abstractmethod
+    def discover(self):
+        """Discovers a test resolutions
+
+        It will be used when the `test.references` variable is empty, but
+        the discoverer will be able to use another data for gathering test
+        resolutions. It work same as the Resolver, but without the test
+        reference.
+        :returns: the result of the resolution process, containing the
+                  success, failure or error, along with zero or more
+                  :class:`avocado.core.nrunner.Runnable` objects
+        :rtype: :class:`avocado.core.resolver.ReferenceResolution`
+        """
+
+
 class Runner(Plugin):
     """Base plugin interface for test runners.
 

--- a/avocado/core/resolver.py
+++ b/avocado/core/resolver.py
@@ -173,7 +173,7 @@ def check_file(path, reference, suffix='.py',
     return True
 
 
-def _extend_directory(path):
+def extend_directory(path):
     if not os.path.isdir(path):
         return [path]
     paths = []
@@ -212,7 +212,7 @@ def resolve(references, hint=None, ignore_missing=True):
             # a reference extender is not (yet?) an extensible feature
             # here it walks directories if one is given, and extends
             # the original reference into final file paths
-            extended_references.extend(_extend_directory(reference))
+            extended_references.extend(extend_directory(reference))
         for reference in extended_references:
             if reference in hint_references:
                 resolutions.append(hint_references[reference])

--- a/setup.py
+++ b/setup.py
@@ -209,6 +209,12 @@ if __name__ == '__main__':
                   'avocado-instrumented = avocado.plugins.resolvers:AvocadoInstrumentedResolver',
                   'tap = avocado.plugins.resolvers:TapResolver',
                   ],
+              'avocado.plugins.discoverer': [
+                  'exec-test = avocado.plugins.resolvers:ExecTestDiscoverer',
+                  'python-unittest = avocado.plugins.resolvers:PythonUnittestDiscoverer',
+                  'avocado-instrumented = avocado.plugins.resolvers:AvocadoInstrumentedDiscoverer',
+                  'tap = avocado.plugins.resolvers:TapDiscoverer',
+              ],
               'avocado.plugins.runner': [
                   'runner = avocado.plugins.runner:TestRunner',
                   'nrunner = avocado.plugins.runner_nrunner:Runner',


### PR DESCRIPTION
Some test might be able to be resolved without a reference. Config
files or other parameters from user can be used for that. As an example
is avocado vt which can use Cartesian configuration for resolving tests.
This commit adds the ability to discover tests from different data
without the test references.

Signed-off-by: Jan Richter <jarichte@redhat.com>

---
Changes from v1 (#4574)
Instead of creating `EmptyReference`. This PR introduces `Discoverer` plugin interface.