### PR TITLE
ssh.py: disable pseudoterminal by default.

### DIFF
--- a/avocado/utils/ssh.py
+++ b/avocado/utils/ssh.py
@@ -105,7 +105,7 @@ class Session:
         else:
             options += (('PasswordAuthentication', 'yes'),
                         ('NumberOfPasswordPrompts', '1'),)
-        return self._ssh_cmd(options, ('-n',))
+        return self._ssh_cmd(options, ('-T', '-n'))
 
     def _create_ssh_askpass(self):
         """


### PR DESCRIPTION
Ran into this issue when trying to connect to an AIX partition. The ControlPath was not created since ssh stated this: "Pseudo-terminal will not be allocated because stdin is not a terminal.". Passing in the '-T' flag supressed this message and the ControlPath was created.

Signed-off-by: Cristobal Forno <cforno12@linux.ibm.com>