### PR TITLE
HTML plugin: do not pin to Python 3.5 compatible requirements

### DIFF
--- a/optional_plugins/html/setup.py
+++ b/optional_plugins/html/setup.py
@@ -25,8 +25,7 @@ setup(name='avocado-framework-plugin-result-html',
       url='http://avocado-framework.github.io/',
       packages=find_packages(),
       include_package_data=True,
-      install_requires=['avocado-framework==%s' % VERSION,
-                        'markupsafe<2.0.0', 'jinja2<3.0.0'],
+      install_requires=['avocado-framework==%s' % VERSION, 'jinja2'],
       entry_points={
           'avocado.plugins.cli': [
               'html = avocado_result_html:HTML',


### PR DESCRIPTION
Jinja2 and Markupsafe versions were being pinned because of Python 3.5
requirements, which are not applicable anymore since 8ece3e244.

This also fixes a version conflict caused when other tools (such as
readthedocs.org) will use the latest Jinja2 versions.

Fixes: https://github.com/avocado-framework/avocado/issues/4596
Signed-off-by: Cleber Rosa <crosa@redhat.com>