### PR TITLE
Dry-run for nrunner

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -370,6 +370,30 @@ class NoOpRunner(BaseRunner):
 RUNNERS_REGISTRY_PYTHON_CLASS['noop'] = NoOpRunner
 
 
+class DryRunRunner(BaseRunner):
+    """
+    Runner for --dry-run.
+
+    It performs no action before reporting FINISHED status with cancel result.
+
+    Runnable attributes usage:
+
+     * uri: not used
+
+     * args: not used
+    """
+
+    def run(self):
+        yield self.prepare_status('started')
+        yield self.prepare_status('finished',
+                                  {'result': 'cancel',
+                                   'fail_reason': 'Test cancelled due to '
+                                                  '--dry-run'})
+
+
+RUNNERS_REGISTRY_PYTHON_CLASS['dry-run'] = DryRunRunner
+
+
 class ExecRunner(BaseRunner):
     """
     Runner for standalone executables with or without arguments

--- a/avocado/core/suite.py
+++ b/avocado/core/suite.py
@@ -103,8 +103,7 @@ class TestSuite:
         self._runner = None
         self._test_parameters = None
 
-        if (self.config.get('run.dry_run.enabled') and
-                self.config.get('run.test_runner') == 'runner'):
+        if self.config.get('run.dry_run.enabled'):
             self._convert_to_dry_run()
 
         if self.size == 0:
@@ -119,8 +118,12 @@ class TestSuite:
         return self.size
 
     def _convert_to_dry_run(self):
-        for i in range(self.size):
-            self.tests[i] = [DryRunTest, self.tests[i][1]]
+        if self.config.get('run.test_runner') == 'nrunner':
+            for runnable in self.tests:
+                runnable.kind = 'dry-run'
+        else:
+            for i in range(self.size):
+                self.tests[i] = [DryRunTest, self.tests[i][1]]
 
     @classmethod
     def _from_config_with_loader(cls, config, name=None):

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -167,6 +167,9 @@ class Runner(RunnerInterface):
             task_id = TestID(prefix,
                              name,
                              None)
+            # with --dry-run we don't want to run requirement
+            if runnable.kind == 'dry-run':
+                requirement_runnable.kind = 'noop'
             # creates the requirement task
             requirement_task = nrunner.Task(requirement_runnable,
                                             task_id,

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -212,6 +212,7 @@ PATH=$HOME/.local/bin:$PATH LANG=en_US.UTF-8 AVOCADO_CHECK_LEVEL=0 %{__python3} 
 %{_bindir}/avocado
 %{_bindir}/avocado-runner
 %{_bindir}/avocado-runner-noop
+%{_bindir}/avocado-runner-dry-run
 %{_bindir}/avocado-runner-exec
 %{_bindir}/avocado-runner-exec-test
 %{_bindir}/avocado-runner-python-unittest

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -518,8 +518,15 @@ class RunnerOperationTest(TestCaseTmpDir):
             avocado_process.wait()
 
     def test_dry_run(self):
-        cmd = ("%s run --disable-sysinfo --dry-run --dry-run-no-cleanup --json - "
-               "-- passtest.py failtest.py gendata.py " % AVOCADO)
+        examples_path = os.path.join('examples', 'tests')
+        passtest = os.path.join(examples_path, 'passtest.py')
+        failtest = os.path.join(examples_path, 'failtest.py')
+        gendata = os.path.join(examples_path, 'gendata.py')
+        cmd = ("%s run --test-runner=nrunner --disable-sysinfo --dry-run "
+               "--dry-run-no-cleanup --json - -- %s %s %s " % (AVOCADO,
+                                                               passtest,
+                                                               failtest,
+                                                               gendata))
         number_of_tests = 3
         result = json.loads(process.run(cmd).stdout_text)
         debuglog = result['debuglog']

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -337,6 +337,17 @@ class JobTest(unittest.TestCase):
         self.job.run()
         self.assertEqual(len(self.job.get_failed_tests()), 1)
 
+    def test_job_dryrun(self):
+        config = {'run.references': ['/bin/true', '/bin/false'],
+                  'run.results_dir': self.tmpdir.name,
+                  'run.dry_run.enabled': True,
+                  'core.show': ['none']}
+        suite = TestSuite.from_config(config)
+        self.job = job.Job(config, [suite])
+        self.job.setup()
+        self.job.run()
+        self.assertEqual(self.job.result.cancelled, 2)
+
     def tearDown(self):
         data_dir._tmp_tracker.unittest_refresh_dir_tracker()
         self.tmpdir.cleanup()

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -329,7 +329,6 @@ class JobTest(unittest.TestCase):
     def test_job_get_failed_tests(self):
         config = {'run.references': ['/bin/true', '/bin/false'],
                   'run.results_dir': self.tmpdir.name,
-                  'run.dry_run.enabled': True,
                   'core.show': ['none']}
         suite = TestSuite.from_config(config)
         self.job = job.Job(config, [suite])

--- a/setup.py
+++ b/setup.py
@@ -131,6 +131,7 @@ if __name__ == '__main__':
                   'avocado = avocado.core.main:main',
                   'avocado-runner = avocado.core.nrunner:main',
                   'avocado-runner-noop = avocado.core.nrunner:main',
+                  'avocado-runner-dry-run = avocado.core.nrunner:main',
                   'avocado-runner-exec = avocado.core.nrunner:main',
                   'avocado-runner-exec-test = avocado.core.nrunner:main',
                   'avocado-runner-python-unittest = avocado.core.nrunner:main',


### PR DESCRIPTION
This commit introduces the `--dry-run` option for nrunner. When you will
use `--dry-run` it will change every runnable kind to `dry-run` and the
tests will be run inside `DryRunRunner` which mark them as canceled.

Reference: #4575
Signed-off-by: Jan Richter <jarichte@redhat.com>