### PR TITLE
Pre-release tests: check the status of readthedocs.org builds

### DIFF
--- a/examples/testplans/release/pre.json
+++ b/examples/testplans/release/pre.json
@@ -10,6 +10,9 @@
 	{"name": "Avocado source is sound",
 	 "description": "On your development machine, on a fresh Avocado source to be released, run `$ make check`. Expected result: Make command should say OK."},
 
+	{"name": "Set the readthedocs.org token",
+	 "description": "Generate and export the content of a token (from https://readthedocs.org/accounts/tokens/) as the AVOCADO_READTHEDOCS_TOKEN environment variable. For this step you have to be admin of avocado-framework project on readthedocs.org."},
+
 	{"name": "Avocado pre-release job",
 	 "description": "With a load as light as possible on your system, run `selftests/pre_release/jobs/pre_release.py`. Expected results: all tests PASSed"},
 

--- a/selftests/pre_release/tests/readthedocs.py
+++ b/selftests/pre_release/tests/readthedocs.py
@@ -1,0 +1,29 @@
+import json
+import os
+import urllib.request
+
+from avocado import Test
+
+
+class ReadtheDocs(Test):
+
+    def test(self):
+        token_from_env = os.environ.get('AVOCADO_READTHEDOCS_TOKEN', None)
+        token = self.params.get('token', default=token_from_env)
+        if not token:
+            self.fail('Please provide a readthedocs.org token either '
+                      'via the "token" parameter or the '
+                      '"AVOCADO_READTHEDOCS_TOKEN" environment variable')
+
+        headers = {'Authorization': 'Token %s' % token,
+                   # readthedocs.org throws a 403 without User-Agent header
+                   'User-Agent': ''}
+
+        url = ('https://readthedocs.org/api/v3/projects/avocado-framework/'
+               'builds/?limit=1&?version=latest')
+
+        http_request = urllib.request.Request(url, headers=headers)
+        http_response = urllib.request.urlopen(http_request)
+        content = http_response.read()
+        data = json.loads(content)
+        self.assertTrue(data['results'][0]['success'])


### PR DESCRIPTION
readthedocs.org is the platform we host documentation *and* release
notes, so it's very important that it's operational before we do our
release.

Experience has taught us that even outside changes (new requirements
being release on PyPI) can break the builds and cause issues with the
release process.

Let's add an automated check to catch possible build failures before a
release is tagged.

Reference: https://github.com/avocado-framework/avocado/issues/3456
Signed-off-by: Cleber Rosa <crosa@redhat.com>