### PR TITLE
[nrunner] introduce avocado-runner-requirement-asset

### DIFF
--- a/avocado/core/runners/requirement_asset.py
+++ b/avocado/core/runners/requirement_asset.py
@@ -1,0 +1,108 @@
+import time
+from multiprocessing import Process, SimpleQueue
+
+from ...utils import data_structures
+from ...utils.asset import Asset
+from .. import nrunner
+from ..settings import settings
+
+
+class RequirementAssetRunner(nrunner.BaseRunner):
+    """Runner for requirements of type package
+
+    This runner handles the fetch of files using the Avocado Assets utility.
+
+    Runnable attributes usage:
+
+     * kind: 'requirement-asset'
+
+     * uri: not used
+
+     * args: not used
+
+     * kwargs:
+        - name: the file name or uri (required)
+        - asset_hash: hash of the file (optional)
+        - algorithm: hash algorithm (optional)
+        - locations: location(s) where the file can be fetched from (optional)
+        - expire: time in seconds for the asset to expire (optional)
+    """
+
+    @staticmethod
+    def _fetch_asset(name, asset_hash, algorithm, locations, expire, queue):
+        cache_dirs = settings.as_dict().get('datadir.paths.cache_dirs')
+
+        asset_manager = Asset(name, asset_hash, algorithm, locations,
+                              cache_dirs, expire)
+
+        result = 'pass'
+        stdout = ''
+        stderr = ''
+        try:
+            asset_file = asset_manager.fetch()
+            stdout = 'File fetched at %s' % asset_file
+        except OSError as exc:
+            result = 'error'
+            stderr = str(exc)
+
+        output = {'result': result,
+                  'stdout': stdout,
+                  'stderr': stderr}
+        queue.put(output)
+
+    def run(self):
+        yield self.prepare_status('started')
+
+        name = self.runnable.kwargs.get('name')
+        asset_hash = self.runnable.kwargs.get('asset_hash')
+        algorithm = self.runnable.kwargs.get('algorithm')
+        locations = self.runnable.kwargs.get('locations')
+        expire = self.runnable.kwargs.get('expire')
+        if expire is not None:
+            expire = data_structures.time_to_seconds(str(expire))
+        # if name was passed correctly, run the Avocado Asset utility
+        if name is not None:
+            # let's spawn it to another process to be able to update the
+            # status messages and avoid the Asset to lock this process
+            queue = SimpleQueue()
+            process = Process(target=self._fetch_asset,
+                              args=(name, asset_hash, algorithm, locations,
+                                    expire, queue))
+            process.start()
+
+            while queue.empty():
+                time.sleep(nrunner.RUNNER_RUN_STATUS_INTERVAL)
+                yield self.prepare_status('running')
+
+            output = queue.get()
+            result = output['result']
+            stdout = output['stdout']
+            stderr = output['stderr']
+        else:
+            # Otherwise, log the missing package name
+            result = 'error'
+            stdout = ''
+            stderr = ('At least name should be passed as kwargs using'
+                      ' name="uri".')
+
+        yield self.prepare_status('running',
+                                  {'type': 'stdout',
+                                   'log': stdout.encode()})
+        yield self.prepare_status('running',
+                                  {'type': 'stderr',
+                                   'log': stderr.encode()})
+        yield self.prepare_status('finished', {'result': result})
+
+
+class RunnerApp(nrunner.BaseRunnerApp):
+    PROG_NAME = 'avocado-runner-requirement-asset'
+    PROG_DESCRIPTION = ('nrunner application for requirements of type asset')
+    RUNNABLE_KINDS_CAPABLE = {'requirement-asset': RequirementAssetRunner}
+
+
+def main():
+    nrunner.main(RunnerApp)
+
+
+if __name__ == '__main__':
+    main()

--- a/docs/source/guides/user/chapters/requirements.rst
+++ b/docs/source/guides/user/chapters/requirements.rst
@@ -83,3 +83,17 @@ parameters available to use the package `type` of requirements are:
 Following is an example of a test using the Package requirement:
 
 .. literalinclude:: ../../../../../examples/tests/passtest_with_requirement.py
+
+Asset
++++++
+
+Support fetching assets using the Avocado Assets utility. The
+parameters available to use the asset `type` of requirements are:
+
+ * `type`: `asset`
+ * `name`: the file name or uri (required)
+ * `asset_has`: hash of the file (optional)
+ * `algorithm`: hash algorithm (optional)
+ * `locations`: location(s) where the file can be fetched from (optional)
+ * `expire`: time in seconds for the asset to expire (optional)
+

--- a/examples/nrunner/recipes/runnables/requirement_asset.json
+++ b/examples/nrunner/recipes/runnables/requirement_asset.json
@@ -1,0 +1,1 @@
+{"kind": "requirement-asset", "kwargs": {"name": "gpl-2.0.txt", "locations": "https://mirrors.kernel.org/gnu/Licenses/gpl-2.0.txt"}}

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -213,6 +213,7 @@ PATH=$HOME/.local/bin:$PATH LANG=en_US.UTF-8 AVOCADO_CHECK_LEVEL=0 %{__python3} 
 %{_bindir}/avocado-runner-python-unittest
 %{_bindir}/avocado-runner-avocado-instrumented
 %{_bindir}/avocado-runner-tap
+%{_bindir}/avocado-runner-requirement-asset
 %{_bindir}/avocado-runner-requirement-package
 %{_bindir}/avocado-software-manager
 %{python3_sitelib}/avocado*

--- a/selftests/functional/test_runner_requirement_asset.py
+++ b/selftests/functional/test_runner_requirement_asset.py
@@ -1,0 +1,63 @@
+import os
+import sys
+import unittest
+
+from avocado.utils import process
+from selftests.utils import BASEDIR
+
+RUNNER = "%s -m avocado.core.runners.requirement_asset" % sys.executable
+
+
+class RunnableRun(unittest.TestCase):
+
+    skip_message = ('This test depends on internet connectivity.'
+                    'Skipping to run on CI only.')
+
+    def test_no_kwargs(self):
+        res = process.run("%s runnable-run -k requirement-asset" % RUNNER,
+                          ignore_status=True)
+        self.assertIn(b"'status': 'started'", res.stdout)
+        self.assertIn(b"'status': 'finished'", res.stdout)
+        self.assertIn(b"At least name should be passed as kwargs", res.stdout)
+        self.assertIn(b"'time': ", res.stdout)
+        self.assertEqual(res.exit_status, 0)
+
+    @unittest.skipUnless(os.getenv('CI'), skip_message)
+    def test_fetch(self):
+        name = 'name=gpl-2.0.txt'
+        locations = 'locations=https://mirrors.kernel.org/gnu/Licenses/gpl-2.0.txt'
+        res = process.run("%s runnable-run -k requirement-asset %s %s"
+                          % (RUNNER, name, locations), ignore_status=True)
+        self.assertIn(b"'status': 'started'", res.stdout)
+        self.assertIn(b"'status': 'finished'", res.stdout)
+        self.assertIn(b"'time': ", res.stdout)
+        self.assertIn(b"'log': b\'File fetched at",
+                      res.stdout)
+        self.assertEqual(res.exit_status, 0)
+
+    @unittest.skipUnless(os.getenv('CI'), skip_message)
+    def test_recipe(self):
+        recipe = os.path.join(BASEDIR, "examples", "nrunner",
+                              "recipes", "runnables",
+                              "requirement_asset.json")
+        cmd = "%s runnable-run-recipe %s" % (RUNNER, recipe)
+        res = process.run(cmd, ignore_status=True)
+        self.assertIn(b"'status': 'started'", res.stdout)
+        self.assertIn(b"'status': 'finished'", res.stdout)
+        self.assertIn(b"'log': b\'File fetched at", res.stdout)
+        self.assertEqual(res.exit_status, 0)
+
+
+class TaskRun(unittest.TestCase):
+
+    def test_no_kwargs(self):
+        res = process.run("%s task-run -i XXXreq-pacXXX -k requirement-asset"
+                          % RUNNER, ignore_status=True)
+        self.assertIn(b"'status': 'finished'", res.stdout)
+        self.assertIn(b"'result': 'error'", res.stdout)
+        self.assertIn(b"'id': 'XXXreq-pacXXX'", res.stdout)
+        self.assertEqual(res.exit_status, 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/selftests/unit/test_runner_requirement_asset.py
+++ b/selftests/unit/test_runner_requirement_asset.py
@@ -1,0 +1,94 @@
+import unittest
+from unittest.mock import patch
+
+from avocado.core.nrunner import Runnable
+from avocado.core.runners.requirement_asset import RequirementAssetRunner
+
+
+class BasicTests(unittest.TestCase):
+    """Basic unit tests for the RequirementAssetRunner class"""
+
+    def test_no_kwargs(self):
+        runnable = Runnable(kind='requirement-asset', uri=None)
+        runner = RequirementAssetRunner(runnable)
+        status = runner.run()
+        messages = []
+        while True:
+            try:
+                messages.append(next(status))
+            except StopIteration:
+                break
+        result = 'error'
+        self.assertIn(result, messages[-1]['result'])
+        stderr = b'At least name should be passed as kwargs'
+        self.assertIn(stderr, messages[-2]['log'])
+
+    def test_wrong_name(self):
+        runnable = Runnable(kind='requirement-asset', uri=None,
+                            **{'name': 'foo'})
+        runner = RequirementAssetRunner(runnable)
+        status = runner.run()
+        messages = []
+        while True:
+            try:
+                messages.append(next(status))
+            except StopIteration:
+                break
+        result = 'error'
+        self.assertIn(result, messages[-1]['result'])
+        stderr = b"Failed to fetch foo (unknown)."
+        self.assertIn(stderr, messages[-2]['log'])
+
+
+class FetchTests(unittest.TestCase):
+    """Unit tests for the actions on RequirementPackageRunner class"""
+
+    def setUp(self):
+        """Mock SoftwareManager"""
+
+        self.sm_patcher = patch(
+            'avocado.core.runners.requirement_asset.Asset',
+            autospec=True)
+        self.mock_sm = self.sm_patcher.start()
+        self.addCleanup(self.sm_patcher.stop)
+
+    def test_success_fetch(self):
+
+        self.mock_sm.return_value.fetch.return_value = '/tmp/asset.txt'
+        runnable = Runnable(kind='requirement-asset', uri=None,
+                            **{'name': 'asset.txt'})
+        runner = RequirementAssetRunner(runnable)
+        status = runner.run()
+        messages = []
+        while True:
+            try:
+                messages.append(next(status))
+            except StopIteration:
+                break
+        result = 'pass'
+        self.assertIn(result, messages[-1]['result'])
+        stdout = b'File fetched at /tmp/asset.txt'
+        self.assertIn(stdout, messages[-3]['log'])
+
+    def test_fail_fetch(self):
+
+        self.mock_sm.return_value.fetch = lambda: (_ for _ in ()).throw(
+            OSError('Failed to fetch asset.txt'))
+        runnable = Runnable(kind='requirement-asset', uri=None,
+                            **{'name': 'asset.txt'})
+        runner = RequirementAssetRunner(runnable)
+        status = runner.run()
+        messages = []
+        while True:
+            try:
+                messages.append(next(status))
+            except StopIteration:
+                break
+        result = 'error'
+        self.assertIn(result, messages[-1]['result'])
+        stderr = b'Failed to fetch asset.txt'
+        self.assertIn(stderr, messages[-2]['log'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -137,6 +137,7 @@ if __name__ == '__main__':
                   'avocado-runner-python-unittest = avocado.core.nrunner:main',
                   'avocado-runner-avocado-instrumented = avocado.core.runners.avocado_instrumented:main',
                   'avocado-runner-tap = avocado.core.runners.tap:main',
+                  'avocado-runner-requirement-asset = avocado.core.runners.requirement_asset:main',
                   'avocado-runner-requirement-package = avocado.core.runners.requirement_package:main',
                   'avocado-software-manager = avocado.utils.software_manager.main:main',
                   ],


### PR DESCRIPTION
This runner handles assets using the Avocado Asset utility. It can be used as a requirement type on tests that define requirements.

Signed-off-by: Willian Rampazzo <willianr@redhat.com>