### PR TITLE
Empty reference in resolver [v3]

### DIFF
--- a/avocado/core/plugin_interfaces.py
+++ b/avocado/core/plugin_interfaces.py
@@ -234,6 +234,24 @@ class Resolver(Plugin):
         """
 
 
+class Discoverer(Plugin):
+    """Base plugin interface for discovering tests without reference."""
+
+    @abc.abstractmethod
+    def discover(self):
+        """Discovers a test resolutions
+
+        It will be used when the `test.references` variable is empty, but
+        the discoverer will be able to use another data for gathering test
+        resolutions. It work same as the Resolver, but without the test
+        reference.
+        :returns: the result of the resolution process, containing the
+                  success, failure or error, along with zero or more
+                  :class:`avocado.core.nrunner.Runnable` objects
+        :rtype: :class:`avocado.core.resolver.ReferenceResolution`
+        """
+
+
 class Runner(Plugin):
     """Base plugin interface for test runners.
 

--- a/docs/source/guides/contributor/chapters/plugins.rst
+++ b/docs/source/guides/contributor/chapters/plugins.rst
@@ -186,10 +186,14 @@ New test type plugin example
 ============================
 
 For a new test type to be recognized and executed by Avocado's "nrunner"
-architecture, there needs to be two types of plugins:
+architecture, there needs to be two types of plugins and one optional:
 
  * resolvers: they resolve references into proper test descriptions
    that Avocado can run
+
+ * discoverers (optional): They are doing the same job as resolvers but
+   without a reference. They are used when the tests can be created from
+   different data e.g.  config files.
 
  * runners: these make use of the resolutions made by resolvers and
    actually execute the tests, reporting the results back to Avocado
@@ -198,8 +202,8 @@ The following example shows real code for a resolver and a runner for
 a "magic" test type.  This "magic" test simply passes or fails
 depending on the test reference.
 
-Resolver example
-----------------
+Resolver and Discoverer example
+-------------------------------
 
 The resolver implementation will simply set the test type ("magic")
 and transform the reference given into its "url":

--- a/examples/plugins/tests/magic/avocado_magic/resolver.py
+++ b/examples/plugins/tests/magic/avocado_magic/resolver.py
@@ -17,7 +17,7 @@ Test resolver for magic test words
 """
 
 from avocado.core.nrunner import Runnable
-from avocado.core.plugin_interfaces import Resolver
+from avocado.core.plugin_interfaces import Discoverer, Resolver
 from avocado.core.resolver import (ReferenceResolution,
                                    ReferenceResolutionResult)
 
@@ -40,3 +40,16 @@ class MagicResolver(Resolver):
         return ReferenceResolution(reference,
                                    ReferenceResolutionResult.SUCCESS,
                                    [Runnable('magic', reference)])
+
+
+class MagicDiscoverer(Discoverer):
+
+    name = 'magic-discoverer'
+    description = 'Test discoverer for magic words'
+
+    @staticmethod
+    def discover():
+        resolutions = []
+        for reference in VALID_MAGIC_WORDS:
+            resolutions.append(MagicResolver.resolve(reference))
+        return resolutions

--- a/examples/plugins/tests/magic/setup.py
+++ b/examples/plugins/tests/magic/setup.py
@@ -3,6 +3,7 @@ from setuptools import setup
 name = 'magic'
 module = 'avocado_magic'
 resolver_ep = '%s = %s.resolver:%s' % (name, module, 'MagicResolver')
+discoverer_ep = '%s = %s.resolver:%s' % (name, module, 'MagicDiscoverer')
 runner_ep = '%s = %s.runner:%s' % (name, module, 'MagicRunner')
 runner_script = 'avocado-runner-%s = %s.runner:main' % (name, module)
 
@@ -14,6 +15,7 @@ if __name__ == '__main__':
           py_modules=[module],
           entry_points={
               'avocado.plugins.resolver': [resolver_ep],
+              'avocado.plugins.discoverer': [discoverer_ep],
               'avocado.plugins.runnable.runner': [runner_ep],
               'console_scripts': [runner_script],
               }


### PR DESCRIPTION
Some test might be able to be resolved without a reference. Config
files or other parameters from user can be used for that. As an example
is avocado vt which can use Cartesian configuration for resolving tests.
This commit adds the ability to discover tests from different data
without the test references.

Signed-off-by: Jan Richter <jarichte@redhat.com>

---
Changes from v1 (#4574)
Instead of creating `EmptyReference`. This PR introduces `Discoverer` plugin interface.

Changes from v2 (#4591)
* Removed commit about `list --resolver`
* Added example with Magic Tests
* Documentation update