### PR TITLE
Allow Avocado to be used from an egg distribution

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,12 +9,44 @@ redhat_version_task:
           - image: fedora:33
           - image: registry.access.redhat.com/ubi8/ubi
 
+redhat_egg_task:
+    egg_script:
+       - python3 -c 'import setuptools' || dnf -y install python3 python3-setuptools
+       - python3 setup.py bdist_egg
+       - mv dist/avocado_framework-*egg /tmp
+       - python3 setup.py clean --all
+       - python3 -c 'import sys; import glob; sys.path.insert(0, glob.glob("/tmp/avocado_framework-*.egg")[0]); from avocado.core.main import main; sys.exit(main())' run /bin/true
+       - cd /tmp
+       - python3 -c 'import sys; from pkg_resources import require; require("avocado-framework"); from avocado.core.main import main; sys.exit(main())' run /bin/true
+    container:
+        matrix:
+          - image: fedora:32
+          - image: fedora:33
+          - image: fedora:34
+          - image: registry.access.redhat.com/ubi8/ubi
+
 debian_version_task:
     version_script:
        - python3 --version || (apt update && apt -y install python3 python3-setuptools)
        - python3 setup.py develop --user
        - python3 -m avocado --version
 
+    container:
+        matrix:
+          - image: debian:9.13
+          - image: debian:10.8
+          - image: ubuntu:18.04
+          - image: ubuntu:20.04
+
+debian_egg_task:
+    egg_script:
+       - python3 --version || (apt update && apt -y install python3 python3-setuptools)
+       - python3 setup.py bdist_egg
+       - mv dist/avocado_framework-*egg /tmp
+       - python3 setup.py clean --all
+       - python3 -c 'import sys; import glob; sys.path.insert(0, glob.glob("/tmp/avocado_framework-*.egg")[0]); from avocado.core.main import main; sys.exit(main())' run /bin/true
+       - cd /tmp
+       - python3 -c 'import sys; from pkg_resources import require; require("avocado-framework"); from avocado.core.main import main; sys.exit(main())' run /bin/true
     container:
         matrix:
           - image: debian:9.13

--- a/avocado/core/settings.py
+++ b/avocado/core/settings.py
@@ -43,7 +43,7 @@ import json
 import os
 import re
 
-from pkg_resources import resource_filename
+from pkg_resources import resource_exists, resource_filename
 
 from .settings_dispatcher import SettingsDispatcher
 
@@ -293,7 +293,8 @@ class Settings:
         self._append_user_config()
 
     def _append_system_config(self):
-        self.all_config_paths.append(self._config_path_pkg)
+        if self._config_path_pkg is not None:
+            self.all_config_paths.append(self._config_path_pkg)
         self.all_config_paths.append(self._config_path_system)
         configs = glob.glob(os.path.join(self._config_dir_system_extra,
                                          '*.conf'))
@@ -314,7 +315,10 @@ class Settings:
 
         config_file_name = 'avocado.conf'
         config_pkg_base = os.path.join('etc', 'avocado', config_file_name)
-        self._config_path_pkg = resource_filename('avocado', config_pkg_base)
+        if resource_exists('avocado', config_pkg_base):
+            self._config_path_pkg = resource_filename('avocado', config_pkg_base)
+        else:
+            self._config_path_pkg = None
         self._config_dir_system = os.path.join(cfg_dir, 'avocado')
         self._config_dir_system_extra = os.path.join(cfg_dir,
                                                      'avocado',


### PR DESCRIPTION
This fixes an issue and allows/checks that Avocado can be used with an egg-based distribution.

---

This is related to https://github.com/avocado-framework/avocado/issues/4336