### PR TITLE
rpm: Get string type of output of installed version to be compared with

### DIFF
--- a/avocado/utils/software_manager/backends/rpm.py
+++ b/avocado/utils/software_manager/backends/rpm.py
@@ -34,7 +34,7 @@ class RpmBackend(BaseBackend):
         :param version: Package version.
         """
         cmd = (self.lowlevel_base_cmd + ' -q --qf %{VERSION} ' + name)
-        inst_version = process.system_output(cmd, ignore_status=True)
+        inst_version = process.run(cmd, ignore_status=True).stdout_text
 
         if 'not installed' in inst_version:
             return False


### PR DESCRIPTION
Current code got `inst_version` as `byte` type and cannot compare with
a string or error would be throw out. Replace with `process.run()` to
get string type of output to fix the problem.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>

---

This is a backport of 5a8a642b6e13c59691bf8840c743473a3ef7400b