### PR TITLE
nrunner: set the occurred test status to the suite summary [v2]

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -638,7 +638,7 @@ class Job:
 
         if 'INTERRUPTED' in summary:
             self.exitcode |= exit_codes.AVOCADO_JOB_INTERRUPTED
-        if 'FAIL' in summary:
+        if 'FAIL' in summary or 'ERROR' in summary:
             self.exitcode |= exit_codes.AVOCADO_TESTS_FAIL
 
         return self.exitcode

--- a/avocado/core/status/repo.py
+++ b/avocado/core/status/repo.py
@@ -113,3 +113,14 @@ class StatusRepo:
     @property
     def status_journal_summary(self):
         return self._status_journal_summary
+
+    @staticmethod
+    def _is_in_task(tasks, task_ids):
+        """Returns True if any of the tasks is in task_ids."""
+        return any([True for task_id in task_ids if task_id in tasks])
+
+    def get_result_set_for_tasks(self, task_ids):
+        """Returns a set of results for the given tasks."""
+        results = [key for key, value in self._by_result.items()
+                   if self._is_in_task(value, task_ids)]
+        return set(results)

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -245,8 +245,7 @@ class Runner(RunnerInterface):
             message_handler.process_message(message, task, job)
 
     def run_suite(self, job, test_suite):
-        # pylint: disable=W0201
-        self.summary = set()
+        summary = set()
 
         test_suite.tests, _ = nrunner.check_runnables_runner_requirements(
             test_suite.tests)
@@ -276,7 +275,7 @@ class Runner(RunnerInterface):
             loop.run_until_complete(asyncio.wait_for(asyncio.gather(*workers),
                                                      job.timeout or None))
         except (KeyboardInterrupt, asyncio.TimeoutError):
-            self.summary.add("INTERRUPTED")
+            summary.add("INTERRUPTED")
 
         # Wait until all messages may have been processed by the
         # status_updater. This should be replaced by a mechanism
@@ -288,4 +287,4 @@ class Runner(RunnerInterface):
 
         job.result.end_tests()
         self.status_server.close()
-        return self.summary
+        return summary

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -229,7 +229,7 @@ class Runner(RunnerInterface):
 
     async def _update_status(self, job):
         tasks_by_id = {str(runtime_task.task.identifier): runtime_task.task
-                       for runtime_task in self.tasks}
+                       for runtime_task in self.runtime_tasks}
         message_handler = MessageHandler()
         while True:
             try:
@@ -256,14 +256,14 @@ class Runner(RunnerInterface):
         self._start_status_server(listen)
 
         # pylint: disable=W0201
-        self.tasks = self._get_all_runtime_tasks(test_suite)
+        self.runtime_tasks = self._get_all_runtime_tasks(test_suite)
         if test_suite.config.get('nrunner.shuffle'):
-            random.shuffle(self.tasks)
-        tsm = TaskStateMachine(self.tasks, self.status_repo)
+            random.shuffle(self.runtime_tasks)
+        tsm = TaskStateMachine(self.runtime_tasks, self.status_repo)
         spawner_name = test_suite.config.get('nrunner.spawner')
         spawner = SpawnerDispatcher(test_suite.config)[spawner_name].obj
         max_running = min(test_suite.config.get('nrunner.max_parallel_tasks'),
-                          len(self.tasks))
+                          len(self.runtime_tasks))
         timeout = test_suite.config.get('task.timeout.running')
         workers = [Worker(state_machine=tsm,
                           spawner=spawner,

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -258,6 +258,8 @@ class Runner(RunnerInterface):
         self.runtime_tasks = self._get_all_runtime_tasks(test_suite)
         if test_suite.config.get('nrunner.shuffle'):
             random.shuffle(self.runtime_tasks)
+        test_ids = [rt.task.identifier for rt in self.runtime_tasks
+                    if rt.task.category == 'test']
         tsm = TaskStateMachine(self.runtime_tasks, self.status_repo)
         spawner_name = test_suite.config.get('nrunner.spawner')
         spawner = SpawnerDispatcher(test_suite.config)[spawner_name].obj
@@ -287,4 +289,9 @@ class Runner(RunnerInterface):
 
         job.result.end_tests()
         self.status_server.close()
+
+        # Update the overall summary with found test statuses, which will
+        # determine the Avocado command line exit status
+        summary.update([status.upper() for status in
+                        self.status_repo.get_result_set_for_tasks(test_ids)])
         return summary


### PR DESCRIPTION
The nrunner implementation currently fails to set the test statuses that ocurred on tests to the summary attribute. That attribute controls the exit code that the Avocado command line will set, to reflect tests that failed, had errors, etc.

---
Note: the reason for the CI failures are discussed in #4620
---

Changes from v1 (#4619)
 * split the nested list comprehension into a helper utility method
 * rename `tasks` into `runtime_tasks`
 * fix typo in docstring