### PR TITLE
Skip requirements resolver functional tests until collision is fixed

### DIFF
--- a/selftests/functional/test_requirements.py
+++ b/selftests/functional/test_requirements.py
@@ -104,6 +104,7 @@ class BasicTest(TestCaseTmpDir):
             self.assertIn('PASS 1', result.stdout_text,)
             self.assertNotIn('bash', result.stdout_text,)
 
+    @unittest.skip('Skipping until test collision is fixed (#4620).')
     @unittest.skipUnless(os.getenv('CI'), skip_package_manager_message)
     def test_single_fail(self):
         with script.Script(os.path.join(self.tmpdir.name,
@@ -117,6 +118,7 @@ class BasicTest(TestCaseTmpDir):
             self.assertIn('SKIP 1', result.stdout_text,)
             self.assertNotIn('-foo-bar-', result.stdout_text,)
 
+    @unittest.skip('Skipping until test collision is fixed (#4620).')
     @unittest.skipUnless(os.getenv('CI'), skip_install_message)
     def test_multiple_success(self):
         with script.Script(os.path.join(self.tmpdir.name,
@@ -129,6 +131,7 @@ class BasicTest(TestCaseTmpDir):
             self.assertIn('PASS 3', result.stdout_text,)
             self.assertNotIn('vim-common', result.stdout_text,)
 
+    @unittest.skip('Skipping until test collision is fixed (#4620).')
     @unittest.skipUnless(os.getenv('CI'), skip_install_message)
     def test_multiple_fails(self):
         with script.Script(os.path.join(self.tmpdir.name,

--- a/selftests/functional/test_runner_requirement_package.py
+++ b/selftests/functional/test_runner_requirement_package.py
@@ -10,6 +10,7 @@ RUNNER = "%s -m avocado.core.runners.requirement_package" % sys.executable
 
 class RunnableRun(unittest.TestCase):
 
+    @unittest.skip('Skipping until test collision is fixed (#4620).')
     def test_no_kwargs(self):
         res = process.run("%s runnable-run -k requirement-package" % RUNNER,
                           ignore_status=True)
@@ -18,6 +19,7 @@ class RunnableRun(unittest.TestCase):
         self.assertIn(b"'time': ", res.stdout)
         self.assertEqual(res.exit_status, 0)
 
+    @unittest.skip('Skipping until test collision is fixed (#4620).')
     def test_action_check_alone(self):
         action = 'action=check'
         res = process.run("%s runnable-run -k requirement-package %s"
@@ -29,6 +31,7 @@ class RunnableRun(unittest.TestCase):
                       res.stdout)
         self.assertEqual(res.exit_status, 0)
 
+    @unittest.skip('Skipping until test collision is fixed (#4620).')
     @unittest.skipUnless(os.getenv('CI'), "This test runs on CI environments"
                          " only as it depends on the system package manager,"
                          " and some environments don't have it available.")
@@ -54,6 +57,7 @@ class RunnableRun(unittest.TestCase):
 
 class TaskRun(unittest.TestCase):
 
+    @unittest.skip('Skipping until test collision is fixed (#4620).')
     def test_no_kwargs(self):
         res = process.run("%s task-run -i XXXreq-pacXXX -k requirement-package"
                           % RUNNER, ignore_status=True)


### PR DESCRIPTION
With https://github.com/avocado-framework/avocado/pull/4622, the tests collision described here https://github.com/avocado-framework/avocado/issues/4620 are evident.

Let's skip the functional tests for the requirements resolver until the collision problem is fixed.

Signed-off-by: Willian Rampazzo <willianr@redhat.com>