### PR TITLE
[RFC] Switch from conventional runner to the nrunner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,7 +112,7 @@ jobs:
         - python3 setup.py develop --user
       script:
         - python3 -m avocado --help
-        - python3 -m avocado --verbose list --resolver selftests/unit/* selftests/functional/* selftests/*sh
+        - python3 -m avocado --verbose list selftests/unit/* selftests/functional/* selftests/*sh
         - python3 -m unittest discover -v selftests.unit
 
   allow_failures:

--- a/avocado/plugins/list.py
+++ b/avocado/plugins/list.py
@@ -234,16 +234,30 @@ class List(CLICmd):
                                  positional_arg=True)
         loader.add_loader_options(parser, 'list')
 
-        help_msg = ('What is the method used to detect tests? If --resolver '
-                    'used, Avocado will use the Next Runner Resolver method. '
-                    'If not the legacy one will be used.')
+        help_msg = ('Uses the Avocado resolver method (part of the nrunner '
+                    'architecture) to detect tests. This is enabled by '
+                    'default and exists only for compatibility purposes, '
+                    'and will be removed soon. To use the legacy (loader) '
+                    'method for finding tests, set the "--loader" option')
         settings.register_option(section='list',
-                                 key='resolver',
+                                 key='compatiblity_with_resolver_noop',
                                  key_type=bool,
-                                 default=False,
+                                 default=True,
                                  help_msg=help_msg,
                                  parser=parser,
                                  long_arg='--resolver')
+
+        help_msg = ('Uses the Avocado legacy (loader) method for finding '
+                    'tests. This option will exist only for a transitional '
+                    'period until the legacy (loader) method is deprecated '
+                    'and removed')
+        settings.register_option(section='list',
+                                 key='resolver',
+                                 key_type=bool,
+                                 default=True,
+                                 help_msg=help_msg,
+                                 parser=parser,
+                                 long_arg='--loader')
 
         help_msg = ('Writes runnable recipe files to a directory. Valid only '
                     'when using --resolver.')

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -103,11 +103,12 @@ class Run(CLICmd):
                     'installed and active implementations.  You can run '
                     '"avocado plugins" and find the list of valid runners '
                     'under the "Plugins that run test suites on a job '
-                    '(runners) section.  Defaults to "runner", which is '
-                    'the conventional and traditional runner.')
+                    '(runners) section.  Defaults to "nrunner", which is '
+                    'the new runner.  To use the conventional and traditional '
+                    'runner, use "runner".')
         settings.register_option(section='run',
                                  key='test_runner',
-                                 default='runner',
+                                 default='nrunner',
                                  help_msg=help_msg,
                                  parser=parser,
                                  long_arg='--test-runner',

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -32,6 +32,7 @@ from avocado.core.status.server import StatusServer
 from avocado.core.task.runtime import RuntimeTask
 from avocado.core.task.statemachine import TaskStateMachine, Worker
 from avocado.core.test_id import TestID
+from avocado.utils.network.ports import find_free_port
 
 
 class RunnerInit(Init):
@@ -48,11 +49,12 @@ class RunnerInit(Init):
                                  help_msg=help_msg,
                                  key_type=bool)
 
+        port = find_free_port()
         help_msg = ('URI for listing the status server. Usually '
                     'a "HOST:PORT" string')
         settings.register_option(section=section,
                                  key='status_server_listen',
-                                 default='127.0.0.1:8888',
+                                 default='127.0.0.1:%u' % port,
                                  metavar="HOST:PORT",
                                  help_msg=help_msg)
 
@@ -61,7 +63,7 @@ class RunnerInit(Init):
                     'is in another host, or different port')
         settings.register_option(section=section,
                                  key='status_server_uri',
-                                 default='127.0.0.1:8888',
+                                 default='127.0.0.1:%u' % port,
                                  metavar="HOST:PORT",
                                  help_msg=help_msg)
 

--- a/docs/source/guides/contributor/chapters/plugins.rst
+++ b/docs/source/guides/contributor/chapters/plugins.rst
@@ -260,14 +260,14 @@ Resolving magic tests
 ---------------------
 
 Resolving the "pass" and "fail" references that the magic plugin knows about
-can be seen by running ``avocado list --resolver pass fail``::
+can be seen by running ``avocado list pass fail``::
 
   magic pass
   magic fail
 
 And you may get more insight into the resolution results, by adding a
 verbose parameter and another reference.  Try running ``avocado -V
-list --resolver pass fail something-else``::
+list pass fail something-else``::
 
   Type  Test Tag(s)
   magic pass
@@ -310,9 +310,9 @@ tests is through a command starting with ``avocado
 run --test-runner=nrunner``.
 
 To run both the ``pass`` and ``fail`` magic tests, you'd run
-``avocado run --test-runner=nrunner -- pass fail``::
+``avocado run -- pass fail``::
 
-  $ avocado run --test-runner=nrunner -- pass fail
+  $ avocado run -- pass fail
   JOB ID     : 86fd45f8c1f2fe766c252eefbcac2704c2106db9
   JOB LOG    : $HOME/avocado/job-results/job-2021-02-05T12.43-86fd45f/job.log
    (1/2) pass: STARTED

--- a/man/avocado.rst
+++ b/man/avocado.rst
@@ -87,8 +87,9 @@ Options for subcommand `run` (`avocado run --help`)::
                             installed and active implementations. You can run
                             "avocado plugins" and find the list of valid runners
                             under the "Plugins that run test suites on a job
-                            (runners) section. Defaults to "runner", which is the
-                            conventional and traditional runner.
+                            (runners) section. Defaults to "nrunner", which is the
+                            new runner. To use the conventional and traditional
+                            runner, use "runner".
       -d, --dry-run         Instead of running the test only list them and log
                             their params.
       --dry-run-no-cleanup  Do not automatically clean up temporary directories
@@ -364,9 +365,15 @@ Options for subcommand `list` (`avocado list --help`)::
 
     optional arguments:
       -h, --help            show this help message and exit
-      --resolver            What is the method used to detect tests? If --resolver
-                            used, Avocado will use the Next Runner Resolver
-                            method. If not the legacy one will be used.
+      --resolver            Uses the Avocado resolver method (part of the nrunner
+                            architecture) to detect tests. This is enabled by
+                            default and exists only for compatibility purposes,
+                            and will be removed soon. To use the legacy (loader)
+                            method for finding tests, set the "--loader" option
+      --loader              Uses the Avocado legacy (loader) method for finding
+                            tests. This option will exist only for a transitional
+                            period until the legacy (loader) method is deprecated
+                            and removed
       --write-recipes-to-directory DIRECTORY
                             Writes runnable recipe files to a directory. Valid
                             only when using --resolver.

--- a/optional_plugins/html/tests/test_html_result.py
+++ b/optional_plugins/html/tests/test_html_result.py
@@ -53,6 +53,7 @@ class HtmlResultTest(unittest.TestCase):
         tmpfile3 = os.path.join(tmpdir, "result.html")
         cmd_line = ('avocado run --job-results-dir %s --disable-sysinfo '
                     '--xunit %s --json %s --html %s --tap-include-logs '
+                    '--test-runner=runner '
                     'passtest.py' % (self.tmpdir.name, tmpfile, tmpfile2, tmpfile3))
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout + result.stderr

--- a/optional_plugins/varianter_cit/tests/test_basic.py
+++ b/optional_plugins/varianter_cit/tests/test_basic.py
@@ -35,6 +35,7 @@ class Run(TestCaseTmpDir):
             '{0} --show=test run --disable-sysinfo --job-results-dir={1} '
             '--cit-order-of-combinations=1 '
             '--cit-parameter-file={2} '
+            '--test-runner=runner '
             '-- {3}'
         ).format(AVOCADO, self.tmpdir.name, params_path, test_path)
         result = process.run(cmd_line)

--- a/optional_plugins/varianter_yaml_to_mux/tests/test_functional.py
+++ b/optional_plugins/varianter_yaml_to_mux/tests/test_functional.py
@@ -49,6 +49,7 @@ class MultiplexTests(unittest.TestCase):
 
     def test_run_mplex_noid(self):
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
+                    '--test-runner=runner '
                     '-m examples/tests/sleeptest.py.data/sleeptest.yaml'
                     % (AVOCADO, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_JOB_FAIL
@@ -56,6 +57,7 @@ class MultiplexTests(unittest.TestCase):
 
     def test_run_mplex_passtest(self):
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
+                    '--test-runner=runner '
                     'passtest.py -m '
                     'examples/tests/sleeptest.py.data/sleeptest.yaml'
                     % (AVOCADO, self.tmpdir.name))
@@ -70,6 +72,7 @@ class MultiplexTests(unittest.TestCase):
 
     def test_run_mplex_doublepass(self):
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
+                    '--test-runner=runner '
                     'passtest.py passtest.py -m '
                     'examples/tests/sleeptest.py.data/sleeptest.yaml '
                     '--mux-path /foo/\\* /bar/\\* /baz/\\*'
@@ -85,6 +88,7 @@ class MultiplexTests(unittest.TestCase):
 
     def test_run_mplex_failtest(self):
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
+                    '--test-runner=runner '
                     'passtest.py failtest.py -m '
                     'examples/tests/sleeptest.py.data/sleeptest.yaml'
                     % (AVOCADO, self.tmpdir.name))
@@ -97,6 +101,7 @@ class MultiplexTests(unittest.TestCase):
 
     def test_run_mplex_failtest_tests_per_variant(self):
         cmd_line = ("%s run --job-results-dir %s --disable-sysinfo "
+                    "--test-runner=runner "
                     "passtest.py failtest.py -m "
                     "examples/tests/sleeptest.py.data/sleeptest.yaml "
                     "--execution-order tests-per-variant"
@@ -110,6 +115,7 @@ class MultiplexTests(unittest.TestCase):
 
     def test_run_double_mplex(self):
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
+                    '--test-runner=runner '
                     'passtest.py -m '
                     'examples/tests/sleeptest.py.data/sleeptest.yaml '
                     'examples/tests/sleeptest.py.data/sleeptest.yaml'
@@ -119,8 +125,9 @@ class MultiplexTests(unittest.TestCase):
 
     def test_empty_file(self):
         cmd_line = ("%s run --job-results-dir %s -m optional_plugins/"
-                    "varianter_yaml_to_mux/tests/.data/empty_file -- "
-                    "passtest.py" % (AVOCADO, self.tmpdir.name))
+                    "varianter_yaml_to_mux/tests/.data/empty_file "
+                    "--test-runner=runner "
+                    "-- passtest.py" % (AVOCADO, self.tmpdir.name))
         self.run_and_check(cmd_line, exit_codes.AVOCADO_ALL_OK, (1, 0))
 
     def test_run_mplex_params(self):
@@ -129,6 +136,7 @@ class MultiplexTests(unittest.TestCase):
                             ('/run/long', 'This is very long\nmultiline\ntext.')):
             variant, msg = variant_msg
             cmd_line = ('%s --show=test run --job-results-dir %s --disable-sysinfo '
+                        '--test-runner=runner '
                         'examples/tests/env_variables.sh '
                         '-m examples/tests/env_variables.sh.data/env_variables.yaml '
                         '--mux-filter-only %s'
@@ -158,6 +166,7 @@ class ReplayTests(unittest.TestCase):
         prefix = 'avocado__%s__%s__%s__' % (__name__, 'ReplayTests', 'setUp')
         self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
         cmd_line = ('%s run passtest.py '
+                    '--test-runner=runner '
                     '-m examples/tests/sleeptest.py.data/sleeptest.yaml '
                     '--job-results-dir %s --disable-sysinfo --json -'
                     % (AVOCADO, self.tmpdir.name))
@@ -184,6 +193,7 @@ class DryRun(unittest.TestCase):
 
     def test_dry_run(self):
         cmd = ("%s run --disable-sysinfo --dry-run --dry-run-no-cleanup --json - "
+               "--test-runner=runner "
                "--mux-inject foo:1 bar:2 baz:3 foo:foo:a "
                "foo:bar:b foo:baz:c bar:bar:bar "
                "-- passtest.py failtest.py gendata.py " % AVOCADO)

--- a/selftests/functional/plugin/test_jobscripts.py
+++ b/selftests/functional/plugin/test_jobscripts.py
@@ -87,6 +87,7 @@ class JobScriptsTest(TestCaseTmpDir):
                                         SCRIPT_NON_ZERO_CFG % self.pre_dir)
         with config:
             cmd = ('%s --config %s run --job-results-dir %s '
+                   '--test-runner=runner '
                    '--disable-sysinfo passtest.py' % (AVOCADO, config,
                                                       self.tmpdir.name))
             result = process.run(cmd)
@@ -110,6 +111,7 @@ class JobScriptsTest(TestCaseTmpDir):
                                         SCRIPT_NON_EXISTING_DIR_CFG % self.pre_dir)
         with config:
             cmd = ('%s --config %s run --job-results-dir %s '
+                   '--test-runner=runner '
                    '--disable-sysinfo passtest.py' % (AVOCADO, config,
                                                       self.tmpdir.name))
             result = process.run(cmd)

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -185,6 +185,7 @@ class RunnerOperationTest(TestCaseTmpDir):
 
     def test_runner_phases(self):
         cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
+                    '--test-runner=runner '
                     'phases.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line)
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -193,6 +194,7 @@ class RunnerOperationTest(TestCaseTmpDir):
 
     def test_runner_all_ok(self):
         cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
+                    '--test-runner=runner '
                     'passtest.py passtest.py' % (AVOCADO, self.tmpdir.name))
         process.run(cmd_line)
         # Also check whether jobdata contains correct parameter paths
@@ -203,6 +205,7 @@ class RunnerOperationTest(TestCaseTmpDir):
 
     def test_runner_failfast(self):
         cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
+                    '--test-runner=runner '
                     'passtest.py failtest.py passtest.py --failfast'
                     % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
@@ -214,6 +217,7 @@ class RunnerOperationTest(TestCaseTmpDir):
 
     def test_runner_ignore_missing_references_one_missing(self):
         cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
+                    '--test-runner=runner '
                     'passtest.py badtest.py --ignore-missing-references'
                     % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
@@ -225,6 +229,7 @@ class RunnerOperationTest(TestCaseTmpDir):
 
     def test_runner_ignore_missing_references_all_missing(self):
         cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
+                    '--test-runner=runner '
                     'badtest.py badtest2.py --ignore-missing-references'
                     % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
@@ -249,6 +254,7 @@ class RunnerOperationTest(TestCaseTmpDir):
                      '    def test(self):\n'
                      '        self.log.info(hello())\n')) as mytest:
                     cmd_line = ("%s run --disable-sysinfo --job-results-dir %s "
+                                "--test-runner=runner "
                                 "%s" % (AVOCADO, self.tmpdir.name, mytest))
                     process.run(cmd_line)
 
@@ -256,9 +262,10 @@ class RunnerOperationTest(TestCaseTmpDir):
         with script.TemporaryScript("fake_status.py",
                                     UNSUPPORTED_STATUS_TEST_CONTENTS,
                                     "avocado_unsupported_status") as tst:
-            res = process.run("%s run --disable-sysinfo --job-results-dir %s %s"
-                              " --json -" % (AVOCADO, self.tmpdir.name, tst),
-                              ignore_status=True)
+            cmd = ("%s run --disable-sysinfo --job-results-dir %s "
+                   "--test-runner=runner "
+                   "%s --json -") % (AVOCADO, self.tmpdir.name, tst)
+            res = process.run(cmd, ignore_status=True)
             self.assertEqual(res.exit_status, exit_codes.AVOCADO_TESTS_FAIL)
             results = json.loads(res.stdout_text)
             self.assertEqual(results["tests"][0]["status"], "ERROR",
@@ -276,9 +283,10 @@ class RunnerOperationTest(TestCaseTmpDir):
         with script.TemporaryScript("report_status_and_hang.py",
                                     REPORTS_STATUS_AND_HANG,
                                     "hanged_test_with_status") as tst:
-            res = process.run("%s run --disable-sysinfo --job-results-dir %s %s "
-                              "--json - --job-timeout 1" % (AVOCADO, self.tmpdir.name, tst),
-                              ignore_status=True)
+            cmd = ("%s run --disable-sysinfo --job-results-dir %s "
+                   "--test-runner=runner "
+                   "%s --json - --job-timeout 1") % (AVOCADO, self.tmpdir.name, tst)
+            res = process.run(cmd, ignore_status=True)
             self.assertEqual(res.exit_status, exit_codes.AVOCADO_TESTS_FAIL)
             results = json.loads(res.stdout_text)
             self.assertEqual(results["tests"][0]["status"], "ERROR",
@@ -298,9 +306,10 @@ class RunnerOperationTest(TestCaseTmpDir):
         with script.TemporaryScript("die_without_reporting_status.py",
                                     DIE_WITHOUT_REPORTING_STATUS,
                                     "no_status_reported") as tst:
-            res = process.run("%s run --disable-sysinfo --job-results-dir %s %s "
-                              "--json -" % (AVOCADO, self.tmpdir.name, tst),
-                              ignore_status=True)
+            cmd = ("%s run --disable-sysinfo --job-results-dir %s "
+                   "--test-runner=runner "
+                   "%s --json -" % (AVOCADO, self.tmpdir.name, tst))
+            res = process.run(cmd, ignore_status=True)
             self.assertEqual(res.exit_status, exit_codes.AVOCADO_TESTS_FAIL)
             results = json.loads(res.stdout_text)
             self.assertEqual(results["tests"][0]["status"], "ERROR",
@@ -310,16 +319,18 @@ class RunnerOperationTest(TestCaseTmpDir):
                           results["tests"][0]["fail_reason"])
 
     def test_runner_tests_fail(self):
-        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s passtest.py '
-                    'failtest.py passtest.py' % (AVOCADO, self.tmpdir.name))
+        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
+                    '--test-runner=runner '
+                    'passtest.py failtest.py passtest.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %d:\n%s" % (expected_rc, result))
 
     def test_runner_nonexistent_test(self):
-        cmd_line = ('%s run --disable-sysinfo --job-results-dir '
-                    '%s bogustest' % (AVOCADO, self.tmpdir.name))
+        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
+                    '--test-runner=runner '
+                    'bogustest' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_JOB_FAIL
         unexpected_rc = exit_codes.AVOCADO_FAIL
@@ -330,6 +341,7 @@ class RunnerOperationTest(TestCaseTmpDir):
 
     def test_runner_doublefail(self):
         cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
+                    '--test-runner=runner '
                     '--xunit - doublefail.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
@@ -345,6 +357,7 @@ class RunnerOperationTest(TestCaseTmpDir):
 
     def test_uncaught_exception(self):
         cmd_line = ("%s run --disable-sysinfo --job-results-dir %s "
+                    "--test-runner=runner "
                     "--json - uncaught_exception.py" % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
@@ -355,6 +368,7 @@ class RunnerOperationTest(TestCaseTmpDir):
 
     def test_fail_on_exception(self):
         cmd_line = ("%s run --disable-sysinfo --job-results-dir %s "
+                    "--test-runner=runner "
                     "--json - fail_on_exception.py" % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
@@ -365,6 +379,7 @@ class RunnerOperationTest(TestCaseTmpDir):
 
     def test_cancel_on_exception(self):
         cmd_line = ("%s run --disable-sysinfo --job-results-dir %s "
+                    "--test-runner=runner "
                     "--json - cancel_on_exception.py" % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -377,6 +392,7 @@ class RunnerOperationTest(TestCaseTmpDir):
 
     def test_assert_raises(self):
         cmd_line = ("%s run --disable-sysinfo --job-results-dir %s "
+                    "--test-runner=runner "
                     "-- assert.py" % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
@@ -399,6 +415,7 @@ class RunnerOperationTest(TestCaseTmpDir):
                                RAISE_CUSTOM_PATH_EXCEPTION_CONTENT)
         mytest.save()
         result = process.run("%s --show test run --disable-sysinfo "
+                             "--test-runner=runner "
                              "--job-results-dir %s %s"
                              % (AVOCADO, self.tmpdir.name, mytest))
         self.assertIn(b"mytest.py:SharedLibTest.test -> CancelExc: This "
@@ -408,6 +425,7 @@ class RunnerOperationTest(TestCaseTmpDir):
 
     def test_runner_timeout(self):
         cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
+                    '--test-runner=runner '
                     '--xunit - timeouttest.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout
@@ -428,6 +446,7 @@ class RunnerOperationTest(TestCaseTmpDir):
         :avocado: tags=parallel:1
         """
         cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
+                    '--test-runner=runner '
                     '--xunit - abort.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         excerpt = b'Test died without reporting the status.'
@@ -441,6 +460,7 @@ class RunnerOperationTest(TestCaseTmpDir):
 
     def test_silent_output(self):
         cmd_line = ('%s --show=none run --disable-sysinfo --job-results-dir %s '
+                    '--test-runner=runner '
                     'passtest.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
@@ -454,24 +474,27 @@ class RunnerOperationTest(TestCaseTmpDir):
                       result.stderr)
 
     def test_empty_test_list(self):
-        cmd_line = '%s run --disable-sysinfo --job-results-dir %s' \
-                   % (AVOCADO, self.tmpdir.name)
+        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s'
+                    '--test-runner=runner ' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_JOB_FAIL)
         self.assertIn(b'No test references provided nor any other arguments '
                       b'resolved into tests', result.stderr)
 
     def test_not_found(self):
-        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s sbrubles'
-                    % (AVOCADO, self.tmpdir.name))
+        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
+                    '--test-runner=runner '
+                    'sbrubles' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_JOB_FAIL)
         self.assertIn(b'Unable to resolve reference', result.stderr)
         self.assertNotIn(b'Unable to resolve reference', result.stdout)
 
     def test_invalid_unique_id(self):
-        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s --force-job-id '
-                    'foobar passtest.py' % (AVOCADO, self.tmpdir.name))
+        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
+                    '--force-job-id foobar '
+                    '--test-runner=runner '
+                    'passtest.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         self.assertNotEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
         self.assertIn(b'needs to be a 40 digit hex', result.stderr)
@@ -480,6 +503,7 @@ class RunnerOperationTest(TestCaseTmpDir):
     def test_valid_unique_id(self):
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
                     '--force-job-id 975de258ac05ce5e490648dec4753657b7ccc7d1 '
+                    '--test-runner=runner '
                     'passtest.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
@@ -488,6 +512,7 @@ class RunnerOperationTest(TestCaseTmpDir):
 
     def test_automatic_unique_id(self):
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
+                    '--test-runner=runner '
                     'passtest.py --json -' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
@@ -546,7 +571,9 @@ class RunnerOperationTest(TestCaseTmpDir):
         test = script.make_script(os.path.join(self.tmpdir.name, 'test.py'),
                                   INVALID_PYTHON_TEST)
         cmd_line = ('%s --show test run --disable-sysinfo '
-                    '--job-results-dir %s %s') % (AVOCADO, self.tmpdir.name, test)
+                    '--job-results-dir %s '
+                    '--test-runner=runner '
+                    '%s') % (AVOCADO, self.tmpdir.name, test)
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         self.assertEqual(result.exit_status, expected_rc,
@@ -571,6 +598,7 @@ class RunnerOperationTest(TestCaseTmpDir):
 
     def test_runner_test_parameters(self):
         cmd_line = ('%s --show=test run --disable-sysinfo --job-results-dir %s '
+                    '--test-runner=runner '
                     '-p "sleep_length=0.01" -- sleeptest.py ' % (AVOCADO,
                                                                  self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
@@ -588,6 +616,7 @@ class RunnerOperationTest(TestCaseTmpDir):
                 'avocado_functional_test_other_loggers') as mytest:
 
             cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
+                        '--test-runner=runner '
                         '-- %s' % (AVOCADO, self.tmpdir.name, mytest))
             result = process.run(cmd_line, ignore_status=True)
             expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -606,6 +635,7 @@ class RunnerHumanOutputTest(TestCaseTmpDir):
 
     def test_output_pass(self):
         cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
+                    '--test-runner=runner '
                     'passtest.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -616,6 +646,7 @@ class RunnerHumanOutputTest(TestCaseTmpDir):
 
     def test_output_fail(self):
         cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
+                    '--test-runner=runner '
                     'failtest.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
@@ -626,6 +657,7 @@ class RunnerHumanOutputTest(TestCaseTmpDir):
 
     def test_output_error(self):
         cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
+                    '--test-runner=runner '
                     'errortest.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
@@ -636,6 +668,7 @@ class RunnerHumanOutputTest(TestCaseTmpDir):
 
     def test_output_cancel(self):
         cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
+                    '--test-runner=runner '
                     'cancelonsetup.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -651,6 +684,7 @@ class RunnerHumanOutputTest(TestCaseTmpDir):
     def test_ugly_echo_cmd(self):
         cmd_line = ('%s --show=test run --external-runner "%s -ne" '
                     '"foo\\\\\\n\\\'\\\\\\"\\\\\\nbar/baz" --job-results-dir %s'
+                    ' --test-runner=runner '
                     ' --disable-sysinfo' %
                     (AVOCADO, GNU_ECHO_BINARY, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
@@ -674,11 +708,13 @@ class RunnerHumanOutputTest(TestCaseTmpDir):
 
     def test_replay_skip_skipped(self):
         cmd = ("%s run --job-results-dir %s --json - "
+               "--test-runner=runner "
                "cancelonsetup.py" % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd)
         result = json.loads(result.stdout_text)
         jobid = str(result["job_id"])
         cmd = ("%s run --job-results-dir %s --replay %s "
+               "--test-runner=runner "
                "--replay-test-status PASS" % (AVOCADO, self.tmpdir.name, jobid))
         process.run(cmd)
 
@@ -700,6 +736,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
 
     def test_simpletest_pass(self):
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo'
+                    ' --test-runner=runner'
                     ' "%s"' % (AVOCADO, self.tmpdir.name, self.pass_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -709,6 +746,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
 
     def test_simpletest_fail(self):
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo'
+                    ' --test-runner=runner'
                     ' %s' % (AVOCADO, self.tmpdir.name, self.fail_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
@@ -770,6 +808,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
         # access to an installed location for the libexec scripts
         os.environ['PATH'] += ":" + os.path.join(BASEDIR, 'libexec')
         cmd_line = ('%s --show=test run --job-results-dir %s --disable-sysinfo '
+                    '--test-runner=runner '
                     'examples/tests/simplewarning.sh'
                     % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
@@ -796,6 +835,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
                            "[sysinfo.collectibles]\ncommands = %s"
                            % commands_path)
         cmd_line = ("%s --show all --config %s run --job-results-dir %s "
+                    "--test-runner=runner "
                     "--external-runner %s -- \"'\\\"\\/|?*<>'\""
                     % (AVOCADO, config_path, self.tmpdir.name, GNU_ECHO_BINARY))
         process.run(cmd_line)
@@ -827,6 +867,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
         os.chdir(test_base_dir)
         test_file_name = os.path.basename(self.pass_script.path)
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo'
+                    ' --test-runner=runner'
                     ' "%s"' % (AVOCADO, self.tmpdir.name,
                                test_file_name))
         result = process.run(cmd_line, ignore_status=True)
@@ -843,6 +884,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
         :avocado: tags=parallel:1
         """
         proc = aexpect.Expect("%s run 60 --job-results-dir %s "
+                              "--test-runner=runner "
                               "--external-runner %s --disable-sysinfo "
                               "--job-timeout 3"
                               % (AVOCADO, self.tmpdir.name, SLEEP_BINARY))
@@ -912,6 +954,7 @@ class RunnerSimpleTestStatus(TestCaseTmpDir):
                                              'functional')
         warn_script.save()
         cmd_line = ('%s --config %s run --job-results-dir %s --disable-sysinfo'
+                    ' --test-runner=runner'
                     ' %s --json -' % (AVOCADO, self.config_file.path,
                                       self.tmpdir.name, warn_script.path))
         result = process.run(cmd_line, ignore_status=True)
@@ -925,6 +968,7 @@ class RunnerSimpleTestStatus(TestCaseTmpDir):
                                              'functional')
         skip_script.save()
         cmd_line = ('%s --config %s run --job-results-dir %s --disable-sysinfo'
+                    ' --test-runner=runner'
                     ' %s --json -' % (AVOCADO, self.config_file.path,
                                       self.tmpdir.name, skip_script.path))
         result = process.run(cmd_line, ignore_status=True)
@@ -938,6 +982,7 @@ class RunnerSimpleTestStatus(TestCaseTmpDir):
                                               'functional')
         skip2_script.save()
         cmd_line = ('%s --config %s run --job-results-dir %s --disable-sysinfo'
+                    ' --test-runner=runner'
                     ' %s --json -' % (AVOCADO, self.config_file.path,
                                       self.tmpdir.name, skip2_script.path))
         result = process.run(cmd_line, ignore_status=True)
@@ -986,6 +1031,7 @@ class RunnerSimpleTestFailureFields(TestCaseTmpDir):
     def test_simpletest_failure_fields(self):
         fail_test = os.path.join(BASEDIR, 'examples', 'tests', 'failtest.sh')
         cmd_line = ('%s --config %s run --job-results-dir %s --disable-sysinfo'
+                    ' --test-runner=runner'
                     ' -- %s' % (AVOCADO, self.config_file.path,
                                 self.tmpdir.name, fail_test))
         result = process.run(cmd_line, ignore_status=True)
@@ -1016,6 +1062,7 @@ class ExternalRunnerTest(TestCaseTmpDir):
 
     def test_externalrunner_pass(self):
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
+                    '--test-runner=runner '
                     '--external-runner=/bin/sh %s'
                     % (AVOCADO, self.tmpdir.name, self.pass_script.path))
         result = process.run(cmd_line, ignore_status=True)
@@ -1026,6 +1073,7 @@ class ExternalRunnerTest(TestCaseTmpDir):
 
     def test_externalrunner_fail(self):
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
+                    '--test-runner=runner '
                     '--external-runner=/bin/sh %s'
                     % (AVOCADO, self.tmpdir.name, self.fail_script.path))
         result = process.run(cmd_line, ignore_status=True)
@@ -1036,6 +1084,7 @@ class ExternalRunnerTest(TestCaseTmpDir):
 
     def test_externalrunner_chdir_no_testdir(self):
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
+                    '--test-runner=runner '
                     '--external-runner=/bin/sh --external-runner-chdir=test %s'
                     % (AVOCADO, self.tmpdir.name, self.pass_script.path))
         result = process.run(cmd_line, ignore_status=True)
@@ -1052,6 +1101,7 @@ class ExternalRunnerTest(TestCaseTmpDir):
         pass_abs = os.path.abspath(self.pass_script.path)
         os.chdir('/')
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
+                    '--test-runner=runner '
                     '--external-runner=bin/sh --external-runner-chdir=runner -- %s'
                     % (AVOCADO, self.tmpdir.name, pass_abs))
         result = process.run(cmd_line, ignore_status=True)
@@ -1062,6 +1112,7 @@ class ExternalRunnerTest(TestCaseTmpDir):
 
     def test_externalrunner_no_url(self):
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
+                    '--test-runner=runner '
                     '--external-runner=%s' % (AVOCADO, self.tmpdir.name, TRUE_CMD))
         result = process.run(cmd_line, ignore_status=True)
         expected_output = (b'No test references provided nor any other '
@@ -1101,13 +1152,14 @@ class PluginsTest(TestCaseTmpDir):
                          result.stdout)
 
     def test_list_error_output(self):
-        cmd_line = '%s list sbrubles' % AVOCADO
+        cmd_line = '%s list --loader sbrubles' % AVOCADO
         result = process.run(cmd_line, ignore_status=True)
         self.assertIn(b"Unable to resolve reference", result.stderr)
 
     def test_list_no_file_loader(self):
-        cmd_line = ("%s --verbose list --loaders external -- "
-                    "this-wont-be-matched" % AVOCADO)
+        cmd_line = ("%s --verbose list --loaders external "
+                    "--loader "
+                    "-- this-wont-be-matched" % AVOCADO)
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK,
                          "Avocado did not return rc %d:\n%s"
@@ -1126,8 +1178,9 @@ class PluginsTest(TestCaseTmpDir):
         """
         test = script.make_script(os.path.join(self.tmpdir.name, 'test.py'),
                                   VALID_PYTHON_TEST_WITH_TAGS)
-        cmd_line = ("%s --verbose list --loaders file -- %s" % (AVOCADO,
-                                                                test))
+        cmd_line = ("%s --verbose list "
+                    "--loader "
+                    "--loaders file -- %s" % (AVOCADO, test))
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK,
                          "Avocado did not return rc %d:\n%s"
@@ -1203,6 +1256,7 @@ class PluginsTest(TestCaseTmpDir):
         """
         def run_config(config_path):
             cmd = ('%s --config %s run passtest.py --archive '
+                   '--test-runner=runner '
                    '--job-results-dir %s --disable-sysinfo'
                    % (AVOCADO, config_path, self.tmpdir.name))
             result = process.run(cmd, ignore_status=True)
@@ -1280,6 +1334,7 @@ class PluginsXunitTest(TestCaseTmpDir):
     def run_and_check(self, testname, e_rc, e_ntests, e_nerrors,
                       e_nfailures, e_nskip):
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo'
+                    ' --test-runner=runner'
                     ' --xunit - %s' % (AVOCADO, self.tmpdir.name, testname))
         result = process.run(cmd_line, ignore_status=True)
         xml_output = result.stdout
@@ -1349,8 +1404,9 @@ class PluginsJSONTest(TestCaseTmpDir):
 
     def run_and_check(self, testname, e_rc, e_ntests, e_nerrors,
                       e_nfailures, e_nskip, e_ncancel=0, external_runner=None):
-        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo --json - '
-                    '--archive %s' % (AVOCADO, self.tmpdir.name, testname))
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
+                    '--test-runner=runner '
+                    '--json - --archive %s' % (AVOCADO, self.tmpdir.name, testname))
         if external_runner is not None:
             cmd_line += " --external-runner '%s'" % external_runner
         result = process.run(cmd_line, ignore_status=True)

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -16,9 +16,10 @@ from avocado.core import exit_codes
 from avocado.utils import astring, genio
 from avocado.utils import path as utils_path
 from avocado.utils import process, script
-from selftests.utils import (AVOCADO, BASEDIR, TestCaseTmpDir,
-                             python_module_available, skipOnLevelsInferiorThan,
-                             skipUnlessPathExists, temp_dir_prefix)
+
+from ..utils import (AVOCADO, BASEDIR, TestCaseTmpDir, python_module_available,
+                     skipOnLevelsInferiorThan, skipUnlessPathExists,
+                     temp_dir_prefix)
 
 try:
     import xmlschema

--- a/selftests/functional/test_export_variables.py
+++ b/selftests/functional/test_export_variables.py
@@ -36,6 +36,7 @@ class EnvironmentVariablesTest(TestCaseTmpDir):
     def test_environment_vars(self):
         os.chdir(BASEDIR)
         cmd_line = ('%s run --job-results-dir %s %s'
+                    ' --test-runner=runner'
                     % (AVOCADO, self.tmpdir.name, self.script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK

--- a/selftests/functional/test_fetch_asset.py
+++ b/selftests/functional/test_fetch_asset.py
@@ -62,9 +62,11 @@ class FetchAsset(unittest.TestCase):
         test_file.close()
 
         expected_rc = exit_codes.AVOCADO_ALL_OK
-        cmd_line = "%s --config %s run %s " % (AVOCADO,
-                                               self.config_file.name,
-                                               test_file.name)
+        cmd_line = ("%s --config %s run "
+                    "--test-runner=runner "
+                    "%s" % (AVOCADO,
+                            self.config_file.name,
+                            test_file.name))
         result = process.run(cmd_line)
         os.remove(localpath)
         self.assertEqual(expected_rc, result.exit_status)
@@ -93,9 +95,11 @@ class FetchAsset(unittest.TestCase):
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         expected_stdout = "not found in the cache"
 
-        cmd_line = "%s --config %s run %s " % (AVOCADO,
-                                               self.config_file.name,
-                                               test_file.name)
+        cmd_line = ("%s --config %s run "
+                    "--test-runner=runner "
+                    "%s" % (AVOCADO,
+                            self.config_file.name,
+                            test_file.name))
 
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(expected_rc, result.exit_status)
@@ -124,9 +128,11 @@ class FetchAsset(unittest.TestCase):
         expected_rc = exit_codes.AVOCADO_ALL_OK
         expected_stdout = "Missing asset"
 
-        cmd_line = "%s --config %s run %s " % (AVOCADO,
-                                               self.config_file.name,
-                                               test_file.name)
+        cmd_line = ("%s --config %s run "
+                    "--test-runner=runner "
+                    "%s" % (AVOCADO,
+                            self.config_file.name,
+                            test_file.name))
 
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(expected_rc, result.exit_status)
@@ -154,9 +160,11 @@ class FetchAsset(unittest.TestCase):
         expected_rc = exit_codes.AVOCADO_ALL_OK
         expected_stdout = "Missing asset"
 
-        cmd_line = "%s --config %s run %s " % (AVOCADO,
-                                               self.config_file.name,
-                                               test_file.name)
+        cmd_line = ("%s --config %s run "
+                    "--test-runner=runner "
+                    "%s " % (AVOCADO,
+                             self.config_file.name,
+                             test_file.name))
 
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(expected_rc, result.exit_status)

--- a/selftests/functional/test_job_timeout.py
+++ b/selftests/functional/test_job_timeout.py
@@ -103,12 +103,14 @@ class JobTimeOutTest(TestCaseTmpDir):
     def test_sleep_longer_timeout(self):
         """:avocado: tags=parallel:1"""
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
+                    '--test-runner=runner '
                     '--xunit - --job-timeout=5 %s examples/tests/passtest.py' %
                     (AVOCADO, self.tmpdir.name, self.script.path))
         self.run_and_check(cmd_line, 0, 2, 0, 0, 0)
 
     def test_sleep_short_timeout(self):
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
+                    '--test-runner=runner '
                     '--xunit - --job-timeout=1 %s examples/tests/passtest.py' %
                     (AVOCADO, self.tmpdir.name, self.script.path))
         self.run_and_check(cmd_line, exit_codes.AVOCADO_JOB_INTERRUPTED,
@@ -117,6 +119,7 @@ class JobTimeOutTest(TestCaseTmpDir):
 
     def test_sleep_short_timeout_with_test_methods(self):
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
+                    '--test-runner=runner '
                     '--xunit - --job-timeout=1 %s' %
                     (AVOCADO, self.tmpdir.name, self.py.path))
         self.run_and_check(cmd_line, exit_codes.AVOCADO_JOB_INTERRUPTED,

--- a/selftests/functional/test_json_variants.py
+++ b/selftests/functional/test_json_variants.py
@@ -38,6 +38,7 @@ class VariantsDumpLoadTests(TestCaseTmpDir):
         with open(self.variants_file, 'w') as file_obj:
             file_obj.write(content)
         cmd_line = ('%s run passtest.py --json-variants-load %s '
+                    '--test-runner=runner '
                     '--job-results-dir %s --json -' %
                     (AVOCADO, self.variants_file, self.tmpdir.name))
         result = process.run(cmd_line)

--- a/selftests/functional/test_legacy_replay_basic.py
+++ b/selftests/functional/test_legacy_replay_basic.py
@@ -11,8 +11,9 @@ class ReplayTests(TestCaseTmpDir):
 
     def setUp(self):
         super(ReplayTests, self).setUp()
-        cmd_line = ('%s run passtest.py passtest.py passtest.py passtest.py '
-                    '--job-results-dir %s --disable-sysinfo --json -'
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo --json - '
+                    '--test-runner=runner '
+                    'passtest.py passtest.py passtest.py passtest.py'
                     % (AVOCADO, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.run_and_check(cmd_line, expected_rc)
@@ -33,6 +34,7 @@ class ReplayTests(TestCaseTmpDir):
         Runs a replay job with an invalid jobid.
         """
         cmd_line = ('%s run --replay %s '
+                    '--test-runner=runner '
                     '--job-results-dir %s --disable-sysinfo'
                     % (AVOCADO, 'foo', self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_FAIL
@@ -43,6 +45,7 @@ class ReplayTests(TestCaseTmpDir):
         Runs a replay job using the 'latest' keyword.
         """
         cmd_line = ('%s run --replay latest --job-results-dir %s --disable-sysinfo'
+                    ' --test-runner=runner '
                     % (AVOCADO, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.run_and_check(cmd_line, expected_rc)
@@ -63,6 +66,7 @@ class ReplayTests(TestCaseTmpDir):
         """
         cmd_line = ('%s run --replay %s '
                     '--job-results-dir %s --disable-sysinfo'
+                    ' --test-runner=runner '
                     % (AVOCADO, self.jobid, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.run_and_check(cmd_line, expected_rc)
@@ -74,6 +78,7 @@ class ReplayTests(TestCaseTmpDir):
         partial_id = self.jobid[:5]
         cmd_line = ('%s run --replay %s '
                     '--job-results-dir %s --disable-sysinfo'
+                    ' --test-runner=runner'
                     % (AVOCADO, partial_id, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.run_and_check(cmd_line, expected_rc)
@@ -84,6 +89,7 @@ class ReplayTests(TestCaseTmpDir):
         """
         cmd_line = ('%s run --replay %s '
                     '--job-results-dir %s --disable-sysinfo'
+                    ' --test-runner=runner '
                     % (AVOCADO, self.jobdir, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.run_and_check(cmd_line, expected_rc)
@@ -94,6 +100,7 @@ class ReplayTests(TestCaseTmpDir):
         """
         cmd_line = ('%s run --replay %s --replay-ignore foo'
                     '--job-results-dir %s --disable-sysinfo'
+                    ' --test-runner=runner '
                     % (AVOCADO, self.jobid, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_FAIL
         result = self.run_and_check(cmd_line, expected_rc)
@@ -107,6 +114,7 @@ class ReplayTests(TestCaseTmpDir):
         """
         cmd_line = ('%s run --replay %s --replay-ignore variants '
                     '--job-results-dir %s --disable-sysinfo'
+                    ' --test-runner=runner '
                     % (AVOCADO, self.jobid, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_ALL_OK
         result = self.run_and_check(cmd_line, expected_rc)
@@ -119,6 +127,7 @@ class ReplayTests(TestCaseTmpDir):
         """
         cmd_line = ('%s run --replay %s --replay-test-status E '
                     '--job-results-dir %s --disable-sysinfo'
+                    ' --test-runner=runner '
                     % (AVOCADO, self.jobid, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_FAIL
         result = self.run_and_check(cmd_line, expected_rc)
@@ -134,6 +143,7 @@ class ReplayTests(TestCaseTmpDir):
         """
         cmd_line = ('%s run --replay %s --replay-test-status '
                     'FAIL --job-results-dir %s --disable-sysinfo'
+                    ' --test-runner=runner '
                     % (AVOCADO, self.jobid, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_ALL_OK
         result = self.run_and_check(cmd_line, expected_rc)
@@ -147,6 +157,7 @@ class ReplayTests(TestCaseTmpDir):
         """
         cmd_line = ('%s run --replay %s --replay-ignore variants '
                     '--replay-test-status FAIL --job-results-dir %s '
+                    '--test-runner=runner '
                     '--disable-sysinfo' % (AVOCADO, self.jobid, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_FAIL
         result = self.run_and_check(cmd_line, expected_rc)
@@ -160,6 +171,7 @@ class ReplayTests(TestCaseTmpDir):
         """
         cmd_line = ('%s run sleeptest --replay %s '
                     '--replay-test-status FAIL --job-results-dir %s '
+                    '--test-runner=runner '
                     '--disable-sysinfo' % (AVOCADO, self.jobid, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_FAIL
         result = self.run_and_check(cmd_line, expected_rc)

--- a/selftests/functional/test_legacy_replay_failfast.py
+++ b/selftests/functional/test_legacy_replay_failfast.py
@@ -11,8 +11,10 @@ class ReplayFailfastTests(TestCaseTmpDir):
 
     def setUp(self):
         super(ReplayFailfastTests, self).setUp()
-        cmd_line = ('%s run passtest.py failtest.py passtest.py '
-                    '--failfast --job-results-dir %s --disable-sysinfo --json -'
+        cmd_line = ('%s run --failfast --job-results-dir %s '
+                    '--disable-sysinfo --json - '
+                    '--test-runner=runner '
+                    'passtest.py failtest.py passtest.py '
                     % (AVOCADO, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL | exit_codes.AVOCADO_JOB_INTERRUPTED
         self.run_and_check(cmd_line, expected_rc)
@@ -30,6 +32,7 @@ class ReplayFailfastTests(TestCaseTmpDir):
 
     def test_run_replay_failfast(self):
         cmd_line = ('%s run --replay %s --failfast '
+                    '--test-runner=runner '
                     '--job-results-dir %s --disable-sysinfo'
                     % (AVOCADO, self.jobid, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL | exit_codes.AVOCADO_JOB_INTERRUPTED
@@ -37,6 +40,7 @@ class ReplayFailfastTests(TestCaseTmpDir):
 
     def test_run_replay_disable_failfast(self):
         cmd_line = ('%s run --replay %s '
+                    '--test-runner=runner '
                     '--job-results-dir %s --disable-sysinfo'
                     % (AVOCADO, self.jobid, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL

--- a/selftests/functional/test_list.py
+++ b/selftests/functional/test_list.py
@@ -8,7 +8,7 @@ from selftests.utils import AVOCADO, BASEDIR
 
 class List(unittest.TestCase):
 
-    list_command = 'list'
+    list_command = 'list --loader'
 
     def test_list_filter_by_tags(self):
         examples_dir = os.path.join(BASEDIR, 'examples', 'tests')

--- a/selftests/functional/test_nrunner.py
+++ b/selftests/functional/test_nrunner.py
@@ -166,7 +166,7 @@ class TaskRun(unittest.TestCase):
 class ResolveSerializeRun(TestCaseTmpDir):
     @skipUnlessPathExists('/bin/true')
     def test(self):
-        cmd = "%s list --resolver --write-recipes-to-directory=%s -- /bin/true"
+        cmd = "%s list --write-recipes-to-directory=%s -- /bin/true"
         cmd %= (AVOCADO, self.tmpdir.name)
         res = process.run(cmd)
         self.assertEqual(b'exec-test /bin/true\n', res.stdout)

--- a/selftests/functional/test_output_check.py
+++ b/selftests/functional/test_output_check.py
@@ -140,6 +140,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
 
     def _check_output_record_all(self):
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
+                    '--test-runner=runner '
                     '--output-check-record all'
                     % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
@@ -156,6 +157,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
 
     def _check_output_record_combined(self):
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
+                    '--test-runner=runner '
                     '--output-check-record combined'
                     % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
@@ -178,6 +180,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
 
     def test_output_record_none(self):
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
+                    '--test-runner=runner '
                     '--output-check-record none'
                     % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
@@ -190,6 +193,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
 
     def test_output_record_stdout(self):
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
+                    '--test-runner=runner '
                     '--output-check-record stdout'
                     % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
@@ -206,6 +210,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
     def test_output_record_and_check(self):
         self._check_output_record_all()
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s'
+                    ' --test-runner=runner'
                     % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -216,6 +221,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
     def test_output_record_and_check_combined(self):
         self._check_output_record_combined()
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s'
+                    ' --test-runner=runner'
                     % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -230,6 +236,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
         with open(stdout_file, 'wb') as stdout_file_obj:
             stdout_file_obj.write(tampered_msg)
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s --xunit -'
+                    ' --test-runner=runner'
                     % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
@@ -245,6 +252,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
         with open(output_file, 'wb') as output_file_obj:
             output_file_obj.write(tampered_msg)
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s --xunit -'
+                    ' --test-runner=runner'
                     % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
@@ -267,6 +275,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
             stderr_file_obj.write(tampered_msg_stderr)
 
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s --json -'
+                    ' --test-runner=runner'
                     % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
@@ -310,6 +319,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
             stdout_file_obj.write(tampered_msg)
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
                     '--disable-output-check --xunit -'
+                    ' --test-runner=runner'
                     % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -326,6 +336,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
         with open(simple_test, 'w') as file_obj:
             file_obj.write(TEST_WITH_SAME_EXPECTED_OUTPUT)
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
+                    '--test-runner=runner '
                     '--output-check-record both --json-variants-load %s' %
                     (AVOCADO, self.tmpdir.name, simple_test, variants_file))
         process.run(cmd_line, ignore_status=True)
@@ -336,6 +347,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
         simple_test, variants_file = self._setup_simple_test(
             TEST_WITH_DIFFERENT_EXPECTED_OUTPUT)
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
+                    '--test-runner=runner '
                     '--output-check-record both --json-variants-load %s' %
                     (AVOCADO, self.tmpdir.name, simple_test, variants_file))
         process.run(cmd_line, ignore_status=True)
@@ -350,6 +362,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
         simple_test, variants_file = self._setup_simple_test(
             TEST_WITH_DIFFERENT_EXPECTED_OUTPUT_VARIANTS)
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
+                    '--test-runner=runner '
                     '--output-check-record both --json-variants-load %s' %
                     (AVOCADO, self.tmpdir.name, simple_test, variants_file))
         process.run(cmd_line, ignore_status=True)
@@ -366,6 +379,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
         simple_test, variants_file = self._setup_simple_test(
             TEST_WITH_DIFFERENT_AND_SAME_EXPECTED_OUTPUT)
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
+                    '--test-runner=runner '
                     '--output-check-record both --json-variants-load %s' %
                     (AVOCADO, self.tmpdir.name, simple_test, variants_file))
         process.run(cmd_line, ignore_status=True)

--- a/selftests/functional/test_replay.py
+++ b/selftests/functional/test_replay.py
@@ -13,6 +13,7 @@ class ReplayTests(TestCaseTmpDir):
         super(ReplayTests, self).setUp()
         cmd_line = ('%s run passtest.py passtest.py passtest.py passtest.py '
                     '--job-results-dir %s --disable-sysinfo --json -'
+                    ' --test-runner=runner'
                     % (AVOCADO, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.run_and_check(cmd_line, expected_rc)

--- a/selftests/functional/test_resolver.py
+++ b/selftests/functional/test_resolver.py
@@ -24,7 +24,7 @@ class ResolverFunctional(unittest.TestCase):
         name = 'executable-test'
         with script.TemporaryScript(name, EXEC_TEST,
                                     name, self.MODE_0775) as test_file:
-            cmd_line = ('%s --verbose list --resolver %s' % (AVOCADO, test_file.path))
+            cmd_line = ('%s --verbose list %s' % (AVOCADO, test_file.path))
             result = process.run(cmd_line)
         self.assertIn('exec-test: 1', result.stdout_text)
 
@@ -32,7 +32,7 @@ class ResolverFunctional(unittest.TestCase):
         name = 'executable-test'
         with script.TemporaryScript(name, EXEC_TEST,
                                     name, self.MODE_0664) as test_file:
-            cmd_line = ('%s list --resolver %s' % (AVOCADO, test_file.path))
+            cmd_line = ('%s list %s' % (AVOCADO, test_file.path))
             result = process.run(cmd_line)
         self.assertNotIn('exec-test ', result.stdout_text)
 
@@ -40,7 +40,7 @@ class ResolverFunctional(unittest.TestCase):
         name = 'passtest.py'
         with script.TemporaryScript(name, AVOCADO_INSTRUMENTED_TEST,
                                     name, self.MODE_0664) as test_file:
-            cmd_line = ('%s --verbose list --resolver %s' % (AVOCADO, test_file.path))
+            cmd_line = ('%s --verbose list %s' % (AVOCADO, test_file.path))
             result = process.run(cmd_line)
         self.assertIn('passtest.py:PassTest.test', result.stdout_text)
         self.assertIn('avocado-instrumented: 1', result.stdout_text)

--- a/selftests/functional/test_statuses.py
+++ b/selftests/functional/test_statuses.py
@@ -131,8 +131,9 @@ class TestStatuses(TestCaseTmpDir):
                                                  ".data",
                                                  'test_statuses.py'))
 
-        cmd = ('%s run %s --disable-sysinfo --job-results-dir %s --json -' %
-               (AVOCADO, test_file, self.tmpdir.name))
+        cmd = ('%s run %s --disable-sysinfo --job-results-dir %s --json - '
+               '--test-runner=runner'
+               % (AVOCADO, test_file, self.tmpdir.name))
 
         results = process.run(cmd, ignore_status=True)
         self.results = json.loads(results.stdout_text)

--- a/selftests/functional/test_streams.py
+++ b/selftests/functional/test_streams.py
@@ -38,10 +38,12 @@ class StreamsTest(TestCaseTmpDir):
         variable `AVOCADO_LOG_EARLY` being set.
         """
         cmds = (('%s --show early run --disable-sysinfo '
+                 '--test-runner=runner '
                  '--job-results-dir %s passtest.py' % (AVOCADO, self.tmpdir.name),
                  {}),
-                ('%s run --disable-sysinfo --job-results-dir'
-                 ' %s passtest.py' % (AVOCADO, self.tmpdir.name),
+                ('%s run --disable-sysinfo --job-results-dir %s '
+                 '--test-runner=runner '
+                 'passtest.py' % (AVOCADO, self.tmpdir.name),
                  {'AVOCADO_LOG_EARLY': 'y'}))
         for cmd, env in cmds:
             result = process.run(cmd, env=env, shell=True)
@@ -56,6 +58,7 @@ class StreamsTest(TestCaseTmpDir):
         Checks that the test stream (early in this case) goes to stdout
         """
         cmd = ('%s --show=test run --disable-sysinfo --job-results-dir %s '
+               '--test-runner=runner '
                'passtest.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
@@ -72,6 +75,7 @@ class StreamsTest(TestCaseTmpDir):
         Checks that only errors are output, and that they go to stderr
         """
         cmd = ('%s --show none run --disable-sysinfo --job-results-dir %s '
+               '--test-runner=runner '
                'passtest.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)

--- a/selftests/functional/test_sysinfo.py
+++ b/selftests/functional/test_sysinfo.py
@@ -18,6 +18,7 @@ class SysInfoTest(TestCaseTmpDir):
 
     def test_sysinfo_enabled(self):
         cmd_line = ('%s run --job-results-dir %s '
+                    '--test-runner=runner '
                     'passtest.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line)
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -45,8 +46,9 @@ class SysInfoTest(TestCaseTmpDir):
             self.assertTrue(os.path.exists(sysinfo_subdir), msg)
 
     def test_sysinfo_disabled(self):
-        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo passtest.py'
-                    % (AVOCADO, self.tmpdir.name))
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
+                    '--test-runner=runner '
+                    'passtest.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
@@ -68,6 +70,7 @@ class SysInfoTest(TestCaseTmpDir):
     def test_sysinfo_html_output(self):
         html_output = "{}/output.html".format(self.tmpdir.name)
         cmd_line = ('{} run --html {} --job-results-dir {} '
+                    '--test-runner=runner '
                     'passtest.py'.format(AVOCADO, html_output,
                                          self.tmpdir.name))
         result = process.run(cmd_line)

--- a/selftests/functional/test_wrapper.py
+++ b/selftests/functional/test_wrapper.py
@@ -46,6 +46,7 @@ class WrapperTest(TestCaseTmpDir):
     def test_global_wrapper(self):
         os.chdir(BASEDIR)
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo --wrapper %s '
+                    '--test-runner=runner '
                     'examples/tests/datadir.py'
                     % (AVOCADO, self.tmpdir.name, self.script.path))
         result = process.run(cmd_line, ignore_status=True)
@@ -63,6 +64,7 @@ class WrapperTest(TestCaseTmpDir):
     def test_process_wrapper(self):
         os.chdir(BASEDIR)
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
+                    '--test-runner=runner '
                     '--wrapper %s:*/datadir examples/tests/datadir.py'
                     % (AVOCADO, self.tmpdir.name, self.script.path))
         result = process.run(cmd_line, ignore_status=True)
@@ -80,6 +82,7 @@ class WrapperTest(TestCaseTmpDir):
     def test_both_wrappers(self):
         os.chdir(BASEDIR)
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo --wrapper %s '
+                    '--test-runner=runner '
                     '--wrapper %s:*/datadir examples/tests/datadir.py'
                     % (AVOCADO, self.tmpdir.name, self.dummy.path,
                        self.script.path))


### PR DESCRIPTION
We've hit a milestone with support for the nrunner being added to Avocado-VT.  While there are still known issues and limitations with the nrunner, this is being proposed so that:

* a switch in default precedes the actual removal of the conventional runner
* the Avocado development team and the community gets to put the nrunner architecture to the ultimate and broadest test possible

I'm proposing this to be evaluated now, but included in the next milestone/release. For this release 89.0, we can *document* that it's the last release with the "legacy" runner being the default. Then, the release notes of the next release should be very verbose about the change in default runner (and thus, major change in behavior).

