### PR TITLE
use monotonic time

### DIFF
--- a/avocado/core/__init__.py
+++ b/avocado/core/__init__.py
@@ -197,7 +197,7 @@ def initialize_plugin_infrastructure():
                          default=[],
                          help_msg=help_msg)
 
-    kinds = pkg_resources.get_entry_map('avocado-framework').keys()
+    kinds = list(pkg_resources.get_entry_map('avocado-framework').keys())
     plugin_types = [kind[8:] for kind in kinds
                     if kind.startswith('avocado.plugins.')]
     for plugin_type in plugin_types:

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -570,7 +570,7 @@ class Job:
         """
         assert self.tmpdir is not None, "Job.setup() not called"
         if self.time_start == -1:
-            self.time_start = time.time()
+            self.time_start = time.monotonic()
         try:
             self.result.tests_total = self.size
             pre_post_dispatcher = dispatcher.JobPrePostDispatcher()
@@ -606,7 +606,7 @@ class Job:
         finally:
             self.post_tests()
             if self.time_end == -1:
-                self.time_end = time.time()
+                self.time_end = time.monotonic()
                 self.time_elapsed = self.time_end - self.time_start
             self.render_results()
             pre_post_dispatcher.map_method('post', self)

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -519,17 +519,17 @@ class Test(unittest.TestCase, TestData):
     def _tag_start(self):
         self.log.info('START %s', self.name)
         self.__running = True
-        self.time_start = time.time()
+        self.time_start = time.monotonic()
 
     def _tag_end(self):
         self.__running = False
-        self.time_end = time.time()
+        self.time_end = time.monotonic()
         # for consistency sake, always use the same stupid method
         self._update_time_elapsed(self.time_end)
 
     def _update_time_elapsed(self, current_time=None):
         if current_time is None:
-            current_time = time.time()
+            current_time = time.monotonic()
         self.time_elapsed = current_time - self.time_start
 
     def report_state(self):

--- a/avocado/plugins/runner.py
+++ b/avocado/plugins/runner.py
@@ -165,7 +165,7 @@ class TestRunner(Runner):
         test_status = TestStatus(job, queue)
 
         cycle_timeout = 1
-        time_started = time.time()
+        time_started = time.monotonic()
         signal.signal(signal.SIGTSTP, signal.SIG_IGN)
         proc.start()
         signal.signal(signal.SIGTSTP, sigtstp_handler)
@@ -184,7 +184,7 @@ class TestRunner(Runner):
 
         ctrl_c_count = 0
         ignore_window = 2.0
-        ignore_time_started = time.time()
+        ignore_time_started = time.monotonic()
         stage_1_msg_displayed = False
         stage_2_msg_displayed = False
         first = 0.01
@@ -194,7 +194,7 @@ class TestRunner(Runner):
 
         while True:
             try:
-                if time.time() >= deadline:
+                if time.monotonic() >= deadline:
                     abort_reason = "Timeout reached"
                     try:
                         os.kill(proc.pid, signal.SIGTERM)
@@ -216,7 +216,7 @@ class TestRunner(Runner):
                 else:
                     break
             except KeyboardInterrupt:
-                time_elapsed = time.time() - ignore_time_started
+                time_elapsed = time.monotonic() - ignore_time_started
                 ctrl_c_count += 1
                 if ctrl_c_count == 1:
                     if not stage_1_msg_displayed:
@@ -226,7 +226,7 @@ class TestRunner(Runner):
                                       "(ignoring new Ctrl+C until then)",
                                       ignore_window)
                         stage_1_msg_displayed = True
-                    ignore_time_started = time.time()
+                    ignore_time_started = time.monotonic()
                     process.kill_process_tree(proc.pid, signal.SIGINT)
                 if (ctrl_c_count > 1) and (time_elapsed > ignore_window):
                     if not stage_2_msg_displayed:
@@ -239,7 +239,7 @@ class TestRunner(Runner):
         # Get/update the test status (decrease timeout on abort)
         if abort_reason:
             after_interrupted = job.config.get('runner.timeout.after_interrupted')
-            finish_deadline = time.time() + after_interrupted
+            finish_deadline = time.monotonic() + after_interrupted
         else:
             finish_deadline = deadline
         test_state = test_status.finish(proc, time_started, step,
@@ -352,7 +352,7 @@ class TestRunner(Runner):
         execution_order = job.config.get('run.execution_order')
         queue = multiprocessing.SimpleQueue()
         if job.timeout > 0:
-            deadline = time.time() + job.timeout
+            deadline = time.monotonic() + job.timeout
         else:
             deadline = None
 
@@ -376,7 +376,7 @@ class TestRunner(Runner):
                                                  name,
                                                  variant,
                                                  no_digits)
-                if deadline is not None and time.time() > deadline:
+                if deadline is not None and time.monotonic() > deadline:
                     summary.add('INTERRUPTED')
                     if 'methodName' in test_parameters:
                         del test_parameters['methodName']

--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -288,7 +288,7 @@ class Asset:
             return False
         creation_time = os.lstat(path)[stat.ST_CTIME]
         expire_time = creation_time + expire
-        if time.time() > expire_time:
+        if time.monotonic() > expire_time:
             return True
         return False
 

--- a/avocado/utils/debug.py
+++ b/avocado/utils/debug.py
@@ -33,11 +33,11 @@ def measure_duration(func):
     """
     def wrapper(*args, **kwargs):
         """ Wrapper function """
-        start = time.time()
+        start = time.monotonic()
         try:
             return func(*args, **kwargs)
         finally:
-            duration = time.time() - start
+            duration = time.monotonic() - start
             __MEASURE_DURATION[func] = (__MEASURE_DURATION.get(func, 0) +
                                         duration)
             LOGGER.debug("PERF: %s: (%ss, %ss)", func, duration,

--- a/avocado/utils/filelock.py
+++ b/avocado/utils/filelock.py
@@ -48,7 +48,7 @@ class FileLock:
 
     def __enter__(self):
         flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY | os.O_SYNC
-        timelimit = time.time() + self.timeout
+        timelimit = time.monotonic() + self.timeout
         while True:
             try:
                 fd = os.open(self.filename, flags)
@@ -82,7 +82,7 @@ class FileLock:
                 # to be released.
                 if self.timeout <= 0:
                     raise AlreadyLocked('File is already locked.')
-                elif time.time() > timelimit:
+                elif time.monotonic() > timelimit:
                     raise AlreadyLocked('Timeout waiting for the lock.')
                 else:
                     time.sleep(0.1)

--- a/avocado/utils/gdb.py
+++ b/avocado/utils/gdb.py
@@ -219,7 +219,7 @@ class CommandResult:
 
     def __init__(self, command):
         self.command = command
-        self.timestamp = time.time()
+        self.timestamp = time.monotonic()
         self.stream_messages = []
         self.application_output = []
         self.result = None
@@ -603,8 +603,8 @@ class GDBServer:
     def _wait_until_running(self):
         connection_ok = False
         c = GDB()
-        end_time = time.time() + self.INIT_TIMEOUT
-        while time.time() < end_time:
+        end_time = time.monotonic() + self.INIT_TIMEOUT
+        while time.monotonic() < end_time:
             try:
                 c.connect(self.port)
                 connection_ok = True

--- a/optional_plugins/robot/avocado_robot/runner.py
+++ b/optional_plugins/robot/avocado_robot/runner.py
@@ -71,7 +71,7 @@ class RobotRunner(nrunner.BaseRunner):
         most_current_execution_state_time = None
         while queue.empty():
             time.sleep(nrunner.RUNNER_RUN_CHECK_INTERVAL)
-            now = time.time()
+            now = time.monotonic()
             if most_current_execution_state_time is not None:
                 next_execution_state_mark = (most_current_execution_state_time +
                                              nrunner.RUNNER_RUN_STATUS_INTERVAL)

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -729,9 +729,9 @@ class RunnerSimpleTest(TestCaseTmpDir):
         one_hundred = 'failtest.py ' * 100
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s'
                     % (AVOCADO, self.tmpdir.name, one_hundred))
-        initial_time = time.time()
+        initial_time = time.monotonic()
         result = process.run(cmd_line, ignore_status=True)
-        actual_time = time.time() - initial_time
+        actual_time = time.monotonic() - initial_time
         self.assertLess(actual_time, 30.0)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         self.assertEqual(result.exit_status, expected_rc,
@@ -749,9 +749,9 @@ class RunnerSimpleTest(TestCaseTmpDir):
                             'sleeptest.py')
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s'
                     % (AVOCADO, self.tmpdir.name, sleep_fail_sleep))
-        initial_time = time.time()
+        initial_time = time.monotonic()
         result = process.run(cmd_line, ignore_status=True)
-        actual_time = time.time() - initial_time
+        actual_time = time.monotonic() - initial_time
         self.assertLess(actual_time, 33.0)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         self.assertEqual(result.exit_status, expected_rc,
@@ -854,8 +854,8 @@ class RunnerSimpleTest(TestCaseTmpDir):
         os.kill(pid, signal.SIGTSTP)   # This freezes the process
         # The deadline is 3s timeout + 10s test postprocess before kill +
         # 10s reserve for additional steps (still below 60s)
-        deadline = time.time() + 20
-        while time.time() < deadline:
+        deadline = time.monotonic() + 20
+        while time.monotonic() < deadline:
             if not proc.is_alive():
                 break
             time.sleep(0.1)

--- a/selftests/functional/test_loader.py
+++ b/selftests/functional/test_loader.py
@@ -152,13 +152,13 @@ class LoaderTestFunctional(TestCaseTmpDir):
         test_script.remove()
 
     def _run_with_timeout(self, cmd_line, timeout):
-        current_time = time.time()
+        current_time = time.monotonic()
         deadline = current_time + timeout
         test_process = subprocess.Popen(cmd_line, stdout=subprocess.PIPE,  # pylint: disable=W1509
                                         stderr=subprocess.PIPE,
                                         preexec_fn=os.setsid, shell=True)
         while not test_process.poll():
-            if time.time() > deadline:
+            if time.monotonic() > deadline:
                 os.killpg(os.getpgid(test_process.pid), signal.SIGKILL)
                 self.fail("Failed to run test under %s seconds" % timeout)
             time.sleep(0.05)
@@ -192,10 +192,10 @@ class LoaderTestFunctional(TestCaseTmpDir):
                                              mode=self.MODE_0664)
         test_script.save()
         cmd_line = ('%s -V list %s' % (AVOCADO, test_script.path))
-        initial_time = time.time()
+        initial_time = time.monotonic()
         result = process.run(cmd_line, ignore_status=True)
         test_script.remove()
-        actual_time = time.time() - initial_time
+        actual_time = time.monotonic() - initial_time
         self.assertLess(actual_time, 3.0,
                         ("Took more than 3 seconds to list tests. Loader "
                          "probably loaded/executed Python code and slept for "

--- a/selftests/functional/test_utils.py
+++ b/selftests/functional/test_utils.py
@@ -196,11 +196,11 @@ class FileLockTest(TestCaseTmpDir):
         :avocado: tags=parallel:1
         """
         # Calculate the timeout based on t_100_iter + 2e-5*players
-        start = time.time()
+        start = time.monotonic()
         for _ in range(100):
             with FileLock(self.tmpdir.name):
                 pass
-        timeout = 0.02 + (time.time() - start)
+        timeout = 0.02 + (time.monotonic() - start)
         players = 1000
         pool = multiprocessing.Pool(players)
         args = [(self.tmpdir.name, players, timeout)] * players

--- a/selftests/unit/utils/test_process.py
+++ b/selftests/unit/utils/test_process.py
@@ -31,9 +31,9 @@ for sig in range(64):
     except:
         pass
 
-end = time.time() + 120
+end = time.monotonic() + 120
 
-while time.time() < end:
+while time.monotonic() < end:
     time.sleep(1)"""
 
 


### PR DESCRIPTION
This should make Avocado more reliable when calculating times. It uses
the monotonic clock that can't go backwards.

This closes #3565

Reference: https://github.com/avocado-framework/avocado/issues/3565
Signed-off-by: Ana Guerrero Lopez <anguerre@redhat.com>