### PR TITLE
Proper nrunner message saving [v2]

### DIFF
--- a/avocado/core/runners/avocado_instrumented.py
+++ b/avocado/core/runners/avocado_instrumented.py
@@ -10,8 +10,9 @@ from ..test import TestID
 from ..tree import TreeNode
 
 
-def _send_message(msg, queue, message_type):
-    status = {'type': message_type, 'log': msg}
+def _send_message(msg, queue, message_type, encoding='utf-8'):
+    status = {'type': message_type, 'log': msg.encode(encoding),
+              'encoding': encoding}
     queue.put(status)
 
 
@@ -124,8 +125,7 @@ class AvocadoInstrumentedTestRunner(nrunner.BaseRunner):
             queue.put({'status': 'finished',
                        'result': state['status'].lower()})
         except Exception:
-            _send_message(traceback.format_exc().encode('utf-8'), queue,
-                          'stderr')
+            _send_message(traceback.format_exc(), queue, 'stderr')
             queue.put({'status': 'finished', 'result': 'error'})
 
     def run(self):
@@ -177,8 +177,7 @@ class AvocadoInstrumentedTestRunner(nrunner.BaseRunner):
         except Exception:
             yield self.prepare_status('running',
                                       {'type': 'stderr',
-                                       'log': traceback.format_exc().encode(
-                                           'utf-8')})
+                                       'log': traceback.format_exc()})
             yield self.prepare_status('finished', {'result': 'error'})
 
 

--- a/avocado/core/runners/requirement_package.py
+++ b/avocado/core/runners/requirement_package.py
@@ -113,7 +113,8 @@ class RequirementPackageRunner(nrunner.BaseRunner):
             stderr = ("Invalid action %s. Use one of 'install', 'check' or"
                       " 'remove'" % cmd)
             yield self.prepare_status('running',
-                                      {'type': 'stderr', 'log': stderr})
+                                      {'type': 'stderr',
+                                       'log': stderr.encode()})
             yield self.prepare_status('finished', {'result': 'error'})
             return
 

--- a/docs/source/guides/contributor/chapters/runners.rst
+++ b/docs/source/guides/contributor/chapters/runners.rst
@@ -624,10 +624,12 @@ It will save the log to the debug.log file in the task directory.
 :param status: 'running'
 :param type: 'log'
 :param log: log message
-:type log: string
+:type log: bytes
+:param encoding: optional value for decoding messages
+:type encoding: str
 :param time: Time stamp of the message
 :type time: float
-:example: {'status': 'running', 'type': 'log', 'log': 'log message',
+:example: {'status': 'running', 'type': 'log', 'log': b'log message',
          'time': 18405.55351474}
 
 Stdout message
@@ -637,10 +639,12 @@ It will save the stdout to the stdout file in the task directory.
 :param status: 'running'
 :param type: 'stdout'
 :param log: stdout message
-:type log: string
+:type log: bytes
+:param encoding: optional value for decoding messages
+:type encoding: str
 :param time: Time stamp of the message
 :type time: float
-:example: {'status': 'running', 'type': 'stdout', 'log': 'stdout message',
+:example: {'status': 'running', 'type': 'stdout', 'log': b'stdout message',
          'time': 18405.55351474}
 
 Stderr message
@@ -650,10 +654,12 @@ It will save the stderr to the stderr file in the task directory.
 :param status: 'running'
 :param type: 'stderr'
 :param log: stderr message
-:type log: string
+:type log: bytes
+:param encoding: optional value for decoding messages
+:type encoding: str
 :param time: Time stamp of the message
 :type time: float
-:example: {'status': 'running', 'type': 'stderr', 'log': 'stderr message',
+:example: {'status': 'running', 'type': 'stderr', 'log': b'stderr message',
          'time': 18405.55351474}
 
 Whiteboard message
@@ -663,8 +669,10 @@ It will save the stderr to the whiteboard file in the task directory.
 :param status: 'running'
 :param type: 'whiteboard'
 :param log: whiteboard message
-:type log: string
+:type log: bytes
+:param encoding: optional value for decoding messages
+:type encoding: str
 :param time: Time stamp of the message
 :type time: float
 :example: {'status': 'running', 'type': 'whiteboard',
-         'log': 'whiteboard message', 'time': 18405.55351474}
+         'log': b'whiteboard message', 'time': 18405.55351474}

--- a/selftests/unit/test_runner_requirement_package.py
+++ b/selftests/unit/test_runner_requirement_package.py
@@ -36,7 +36,7 @@ class BasicTests(unittest.TestCase):
                 break
         result = 'error'
         self.assertIn(result, messages[-1]['result'])
-        stderr = "Invalid action foo. Use one of 'install', 'check' or 'remove'"
+        stderr = b"Invalid action foo. Use one of 'install', 'check' or 'remove'"
         self.assertIn(stderr, messages[-2]['log'])
 
 


### PR DESCRIPTION
The saving of the nrunner messages was too strict. The stdout and stderr
messages could be only bytes and the log messages could be only stings
without a new line at the end. This commit makes the saving more
flexible.

Signed-off-by: Jan Richter jarichte@redhat.com

---
Changes from v1 (#4526):
* Typo fixes
*  Moved `filename` argument to ` _save_to_file()`
*  All messages been made binary