### PR TITLE
utils/assets: fixing FileExistsError when running in parallel

### DIFF
--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -367,7 +367,7 @@ class Asset:
                                       self.relative_dir)
             dirname = os.path.dirname(asset_file)
             if not os.path.isdir(dirname):
-                os.makedirs(dirname)
+                os.makedirs(dirname, exist_ok=True)
             try:
                 if fetch(urlobj, asset_file):
                     if self.metadata is not None:


### PR DESCRIPTION
If multiple tests in parallel uses the same image from the same
location, only one thread needs to create the directory. Fixes #4631.

Signed-off-by: Beraldo Leal <bleal@redhat.com>