### PR TITLE
Safeloader: improve the checks and contrib scripts for python unittests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -71,3 +71,18 @@ fedora_selftests_task:
         matrix:
           - image: quay.io/avocado-framework/avocado-ci-fedora-32
           - image: quay.io/avocado-framework/avocado-ci-fedora-33
+
+#
+# This is a *partial* check for the behavior of the safeloader, that
+# compares it to Python's unittest behavior.  This is intended to help
+# in the resolution of https://github.com/avocado-framework/avocado/issues/4625
+# avoiding new regressions.  It should also be expanded (and/or converted
+# into a selftest) to include avocado-instrumented tests too.
+#
+safeloader_task:
+    selftests_script:
+       - dnf -y install diffutils
+       - make develop
+       - for i in $(git grep -c -E 'import unittest$' selftests/unit/test_*.py selftests/unit/utils/test_*.py | cut -d ':' -f 1); do echo "*** $i ***"; python3 contrib/scripts/find-python-unittest $i > /tmp/1; AVOCADO_SAFELOADER_UNITTEST_ORDER_COMPAT=1 python3 contrib/scripts/avocado-safeloader-find-python-unittest $i > /tmp/2; diff -u /tmp/1 /tmp/2; done;
+    container:
+        image: quay.io/avocado-framework/avocado-ci-fedora-32

--- a/contrib/scripts/avocado-find-unittests
+++ b/contrib/scripts/avocado-find-unittests
@@ -39,7 +39,7 @@ if __name__ == '__main__':
                 test_module_path = test_module_path[:-3]
             test_module_name = os.path.relpath(test_module_path)
             test_module_name = test_module_name.replace(os.path.sep, ".")
-            result += ["%s.%s.%s" % (test_module_name, klass, method)
-                       for method in methods]
+            result += ["%s.%s.%s" % (test_module_name, klass, method_name)
+                       for (method_name, _, _) in methods]
     if result:
         print("\n".join(result))

--- a/contrib/scripts/avocado-safeloader-find-python-unittest
+++ b/contrib/scripts/avocado-safeloader-find-python-unittest
@@ -18,7 +18,7 @@
 # location of each test, each one on its own line. The idea is to be able
 # to filter the tests you want to run by doing something like:
 #
-# $ avocado run `avocado-find-unittests <path-to-test.py> | <your-condition> | xargs`
+# $ avocado run `avocado-safeloader-find-python-unittests <path-to-test.py> | <your-condition> | xargs`
 #
 
 import os

--- a/contrib/scripts/avocado-safeloader-find-python-unittest
+++ b/contrib/scripts/avocado-safeloader-find-python-unittest
@@ -42,4 +42,8 @@ if __name__ == '__main__':
             result += ["%s.%s.%s" % (test_module_name, klass, method_name)
                        for (method_name, _, _) in methods]
     if result:
+        if os.environ.get('AVOCADO_SAFELOADER_UNITTEST_ORDER_COMPAT', False):
+            from functools import cmp_to_key
+            from unittest.util import three_way_cmp
+            result.sort(key=cmp_to_key(three_way_cmp))
         print("\n".join(result))

--- a/contrib/scripts/find-python-unittest
+++ b/contrib/scripts/find-python-unittest
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2021
+# Author: Cleber Rosa <cleber@redhat.com>
+
+#
+# Simple script that, given Python file containing unittests, returns the canonical
+# location of each test, each one on its own line.
+#
+# Warning: this script uses Python's unittest TestLoader.discover()
+# and will load (and thus eval) the Python files given in the command
+# as arguments.
+#
+
+import os
+import sys
+import unittest
+
+
+def get_tests(suite):
+    result = []
+    if hasattr(suite, '__iter__'):
+        for s in suite:
+            result.extend(get_tests(s))
+    else:
+        result.append(suite)
+    return result
+
+
+if __name__ == '__main__':
+    test_module_paths = sys.argv[1:]
+    result = []
+    loader = unittest.TestLoader()
+    for test_module_path in test_module_paths:
+
+        start_dir, pattern = os.path.split(test_module_path)
+        suite = loader.discover(start_dir, pattern)
+        tests = get_tests(suite)
+
+        module_name = start_dir.replace(os.path.sep, ".")
+        result.extend(["%s.%s" % (module_name, test.id()) for test in tests])
+
+    if result:
+        print("\n".join(result))


### PR DESCRIPTION
This fixes the contrib script and adds a new one that finds Python unittests.  It's also a prep work for #4625.
