### PR TITLE
nrunner: prep work for variants support

### DIFF
--- a/avocado/plugins/runner.py
+++ b/avocado/plugins/runner.py
@@ -361,12 +361,11 @@ class TestRunner(Runner):
         job.result.tests_total = test_result_total
         index = 1
         try:
-            for test_factory in test_suite.tests:
-                test_factory[1]["base_logdir"] = job.logdir
-                test_factory[1]["config"] = job.config
             for test_factory, variant in self._iter_suite(test_suite,
                                                           execution_order):
                 test_parameters = test_factory[1]
+                test_parameters["base_logdir"] = job.logdir
+                test_parameters["config"] = job.config
                 name = test_parameters.get("name")
                 if test_suite.name:
                     prefix = "{}-{}".format(test_suite.name, index)

--- a/avocado/plugins/runner.py
+++ b/avocado/plugins/runner.py
@@ -295,13 +295,15 @@ class TestRunner(Runner):
         paths = variant.get("paths")
         empty_variants = varianter.is_empty_variant(var)
 
-        if "params" not in template[1]:
-            factory = [template[0], template[1].copy()]
+        original_params_to_klass = template[1]
+        if "params" not in original_params_to_klass:
+            params_to_klass = original_params_to_klass.copy()
             if test_parameters and empty_variants:
                 var[0] = tree.TreeNode().get_node("/", True)
                 var[0].value = test_parameters
                 paths = ["/"]
-            factory[1]["params"] = (var, paths)
+            params_to_klass["params"] = (var, paths)
+            factory = [template[0], params_to_klass]
             return factory, variant
 
         if not empty_variants:


### PR DESCRIPTION
This is a preparatory work for variants support in the nrunner.  This adds focuses on the suite, accounting for the number and name of tests produced by variants.  The next step is to pass through the parameters (both from variants and from standalone parameters) to the runners.

By running `avocado run --test-runner=nrunner examples/tests/sleeptest.py -m examples/tests/sleeptest.py.data/sleeptest.yaml` before this PR one gets:

```
$ avocado run --test-runner=nrunner examples/tests/sleeptest.py -m examples/tests/sleeptest.py.data/sleeptest.yaml 
JOB ID     : cbcf5c6f66fdd90516afa40c613b6482d7c66e94
JOB LOG    : /home/cleber/avocado/job-results/job-2021-06-01T00.33-cbcf5c6/job.log
 (1/1) examples/tests/sleeptest.py:SleepTest.test: STARTED
 (1/1) examples/tests/sleeptest.py:SleepTest.test: PASS (1.06 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/cleber/avocado/job-results/job-2021-06-01T00.33-cbcf5c6/results.html
JOB TIME   : 2.33 s
```

And after:

```
$ avocado run --test-runner=nrunner examples/tests/sleeptest.py -m examples/tests/sleeptest.py.data/sleeptest.yaml 
JOB ID     : e668f6e6d5c71dcc24da721177d01594192714d1
JOB LOG    : /home/cleber/avocado/job-results/job-2021-06-01T00.33-e668f6e/job.log
 (2/4) examples/tests/sleeptest.py:SleepTest.test;run-medium-5595: STARTED
 (1/4) examples/tests/sleeptest.py:SleepTest.test;run-short-beaf: STARTED
 (3/4) examples/tests/sleeptest.py:SleepTest.test;run-long-f397: STARTED
 (4/4) examples/tests/sleeptest.py:SleepTest.test;run-longest-efc4: STARTED
 (3/4) examples/tests/sleeptest.py:SleepTest.test;run-long-f397: PASS (1.05 s)
 (2/4) examples/tests/sleeptest.py:SleepTest.test;run-medium-5595: PASS (1.06 s)
 (1/4) examples/tests/sleeptest.py:SleepTest.test;run-short-beaf: PASS (1.06 s)
 (4/4) examples/tests/sleeptest.py:SleepTest.test;run-longest-efc4: PASS (1.05 s)
RESULTS    : PASS 4 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/cleber/avocado/job-results/job-2021-06-01T00.33-e668f6e/results.html
JOB TIME   : 2.63 s
```

---

Related to #4569 