### PR TITLE
Adjust requirement_package.py runner to do not fail on collision

### DIFF
--- a/avocado/core/runners/requirement_package.py
+++ b/avocado/core/runners/requirement_package.py
@@ -46,9 +46,14 @@ class RequirementPackageRunner(nrunner.BaseRunner):
             if software_manager.install(package):
                 stdout = MESSAGES[cmd]['success'] % package
             else:
-                result = 'error'
-                stdout = ''
-                stderr = MESSAGES[cmd]['fail'] % package
+                # check if the error is a false negative because of package
+                # installation collision
+                if software_manager.check_installed(package):
+                    stdout = MESSAGES[cmd]['success'] % package
+                else:
+                    result = 'error'
+                    stdout = ''
+                    stderr = MESSAGES[cmd]['fail'] % package
         else:
             stdout = MESSAGES['check-installed']['success'] % package
         return result, stdout, stderr
@@ -61,9 +66,14 @@ class RequirementPackageRunner(nrunner.BaseRunner):
             if software_manager.remove(package):
                 stdout = MESSAGES[cmd]['success'] % package
             else:
-                result = 'error'
-                stdout = ''
-                stderr = MESSAGES[cmd]['fail'] % package
+                # check if the error is a false negative because of package
+                # installation collision
+                if not software_manager.check_installed(package):
+                    stdout = MESSAGES[cmd]['success'] % package
+                else:
+                    result = 'error'
+                    stdout = ''
+                    stderr = MESSAGES[cmd]['fail'] % package
         else:
             stdout = MESSAGES['check-installed']['fail'] % package
         return result, stdout, stderr

--- a/selftests/functional/test_requirements.py
+++ b/selftests/functional/test_requirements.py
@@ -104,7 +104,6 @@ class BasicTest(TestCaseTmpDir):
             self.assertIn('PASS 1', result.stdout_text,)
             self.assertNotIn('bash', result.stdout_text,)
 
-    @unittest.skip('Skipping until test collision is fixed (#4620).')
     @unittest.skipUnless(os.getenv('CI'), skip_package_manager_message)
     def test_single_fail(self):
         with script.Script(os.path.join(self.tmpdir.name,
@@ -118,7 +117,6 @@ class BasicTest(TestCaseTmpDir):
             self.assertIn('SKIP 1', result.stdout_text,)
             self.assertNotIn('-foo-bar-', result.stdout_text,)
 
-    @unittest.skip('Skipping until test collision is fixed (#4620).')
     @unittest.skipUnless(os.getenv('CI'), skip_install_message)
     def test_multiple_success(self):
         with script.Script(os.path.join(self.tmpdir.name,
@@ -131,7 +129,6 @@ class BasicTest(TestCaseTmpDir):
             self.assertIn('PASS 3', result.stdout_text,)
             self.assertNotIn('vim-common', result.stdout_text,)
 
-    @unittest.skip('Skipping until test collision is fixed (#4620).')
     @unittest.skipUnless(os.getenv('CI'), skip_install_message)
     def test_multiple_fails(self):
         with script.Script(os.path.join(self.tmpdir.name,

--- a/selftests/functional/test_runner_requirement_package.py
+++ b/selftests/functional/test_runner_requirement_package.py
@@ -10,7 +10,6 @@ RUNNER = "%s -m avocado.core.runners.requirement_package" % sys.executable
 
 class RunnableRun(unittest.TestCase):
 
-    @unittest.skip('Skipping until test collision is fixed (#4620).')
     def test_no_kwargs(self):
         res = process.run("%s runnable-run -k requirement-package" % RUNNER,
                           ignore_status=True)
@@ -19,7 +18,6 @@ class RunnableRun(unittest.TestCase):
         self.assertIn(b"'time': ", res.stdout)
         self.assertEqual(res.exit_status, 0)
 
-    @unittest.skip('Skipping until test collision is fixed (#4620).')
     def test_action_check_alone(self):
         action = 'action=check'
         res = process.run("%s runnable-run -k requirement-package %s"
@@ -31,7 +29,6 @@ class RunnableRun(unittest.TestCase):
                       res.stdout)
         self.assertEqual(res.exit_status, 0)
 
-    @unittest.skip('Skipping until test collision is fixed (#4620).')
     @unittest.skipUnless(os.getenv('CI'), "This test runs on CI environments"
                          " only as it depends on the system package manager,"
                          " and some environments don't have it available.")
@@ -57,7 +54,6 @@ class RunnableRun(unittest.TestCase):
 
 class TaskRun(unittest.TestCase):
 
-    @unittest.skip('Skipping until test collision is fixed (#4620).')
     def test_no_kwargs(self):
         res = process.run("%s task-run -i XXXreq-pacXXX -k requirement-package"
                           % RUNNER, ignore_status=True)


### PR DESCRIPTION
On issue https://github.com/avocado-framework/avocado/issues/4620, when two tasks try to fulfill a package, one is smart enough to wait for the other to finish, but as soon as the lock is released, one may fail if the other has still work to complete, like erase the cache.

This patch checks if the failure was not a false negative.

Fixes: #4620

Signed-off-by: Willian Rampazzo <willianr@redhat.com>