### PR TITLE
Bugfix/mac os fixes

### DIFF
--- a/avocado/core/resolver.py
+++ b/avocado/core/resolver.py
@@ -17,13 +17,12 @@ Test resolver module.
 """
 
 import os
-from enum import Enum
+from enum import EnumMeta
 
 from .enabled_extension_manager import EnabledExtensionManager
 from .exceptions import JobTestSuiteReferenceResolutionError
 
-
-class ReferenceResolutionResult(Enum):
+class ReferenceResolutionResult(EnumMeta):
     #: Given test reference was properly resolved
     SUCCESS = object()
     #: Given test reference was not properly resolved
@@ -32,7 +31,7 @@ class ReferenceResolutionResult(Enum):
     ERROR = object()
 
 
-class ReferenceResolutionAction(Enum):
+class ReferenceResolutionAction(EnumMeta):
     #: Stop trying to resolve the reference
     RETURN = object()
     #: Continue to resolve the given reference

--- a/avocado/utils/gdb.py
+++ b/avocado/utils/gdb.py
@@ -28,6 +28,7 @@ import time
 
 from .external import gdbmi_parser
 from .network import ports
+from .path import find_command
 
 #: Contains a list of binary names that should be run via the GNU debugger
 #: and be stopped at a given point. That means that a breakpoint will be set
@@ -257,8 +258,9 @@ class GDB:
 
     DEFAULT_BREAK = 'main'
 
-    def __init__(self, path='/usr/bin/gdb', *extra_args):  # pylint: disable=W1113
-
+    def __init__(self, path=None, *extra_args):  # pylint: disable=W1113
+        if path is None:
+            path = find_command("gdb", default="/usr/bin/gdb")
         self.path = path
         args = [self.path]
         args += self.REQUIRED_ARGS
@@ -551,7 +553,7 @@ class GDBServer:
     #: ready to accept new connections
     INIT_TIMEOUT = 5.0
 
-    def __init__(self, path='/usr/bin/gdbserver', port=None,  # pylint: disable=W0613, W1113
+    def __init__(self, path=None, port=None,  # pylint: disable=W0613, W1113
                  wait_until_running=True, *extra_args):
         """
         Initializes a new gdbserver instance
@@ -567,6 +569,8 @@ class GDBServer:
         :type wait_until_running: bool
         :param extra_args: optional extra arguments to be passed to gdbserver
         """
+        if path is None:
+            path = find_command("gdbserver", default="/usr/bin/gdbserver")
         self.path = path
         args = [self.path]
         args += self.REQUIRED_ARGS

--- a/optional_plugins/html/avocado_result_html/__init__.py
+++ b/optional_plugins/html/avocado_result_html/__init__.py
@@ -21,6 +21,7 @@ import os
 import subprocess
 import sys
 import time
+import platform
 
 import jinja2 as jinja
 
@@ -29,6 +30,7 @@ from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLI, Init, Result
 from avocado.core.settings import settings
 from avocado.utils import astring
+from avocado.utils.path import find_command
 
 
 class ReportModel:
@@ -196,10 +198,15 @@ class HTMLResult(Result):
         if not setsid:
             setsid = getattr(os, 'setpgrp', None)
         inout = open(os.devnull, "r+")
-        cmd = ['xdg-open', html_path]
-        subprocess.Popen(cmd, close_fds=True, stdin=inout,  # pylint: disable=W1509
-                         stdout=inout, stderr=inout,
-                         preexec_fn=setsid)
+        if "macOS" in platform.platform():
+            open_path = find_command("open", default=None)
+        else:
+            open_path = find_command("xdg-open", default=None)
+        if open_path:
+            cmd = [open_path, html_path]
+            subprocess.Popen(cmd, close_fds=True, stdin=inout,  # pylint: disable=W1509
+                             stdout=inout, stderr=inout,
+                             preexec_fn=setsid)
 
     @staticmethod
     def _render(result, output_path):

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -10,9 +10,18 @@ from avocado.core import exit_codes
 from avocado.core.job import Job
 from avocado.core.suite import TestSuite
 from avocado.utils.network.ports import find_free_port
+from avocado.utils.path import find_command
 
 BOOLEAN_ENABLED = [True, 'true', 'on', 1]
 BOOLEAN_DISABLED = [False, 'false', 'off', 0]
+
+
+def _get_true_bin():
+    return find_command(cmd='true', default="/bin/true")
+
+
+def _get_false_bin():
+    return find_command(cmd='false', default="/bin/false")
 
 
 class JobAPIFeaturesTest(Test):
@@ -46,7 +55,7 @@ class JobAPIFeaturesTest(Test):
         """Creates the Job config."""
         if value is None:
             value = self.params.get('value')
-        reference = self.params.get('reference', default=['/bin/true'])
+        reference = self.params.get('reference', default=[_get_true_bin()])
         config = {'core.show': ['none'],
                   'run.results_dir': self.workdir,
                   'run.references': reference}
@@ -290,13 +299,13 @@ def create_suites(args):
             {'namespace': 'job.run.result.tap.include_logs',
              'value': True,
              'file': 'results.tap',
-             'content': "Command '/bin/true' finished with 0",
+             'content': "Command '{}' finished with 0".format(_get_true_bin()),
              'assert': True},
 
             {'namespace': 'job.run.result.tap.include_logs',
              'value': False,
              'file': 'results.tap',
-             'content': "Command '/bin/true' finished with 0",
+             'content': "Command '{}' finished with 0".format(_get_true_bin()),
              'assert': False},
 
             {'namespace': 'job.run.result.xunit.job_name',
@@ -310,7 +319,7 @@ def create_suites(args):
              'file': 'results.xml',
              'content': '--[ CUT DUE TO XML PER TEST LIMIT ]--',
              'assert': True,
-             'reference': ['/bin/false'],
+             'reference': [_get_false_bin()],
              'exit_code': 1},
 
             {'namespace': 'run.failfast',
@@ -318,7 +327,7 @@ def create_suites(args):
              'file': 'results.json',
              'content': '"skip": 1',
              'assert': True,
-             'reference': ['/bin/false', '/bin/true'],
+             'reference': [_get_false_bin(), _get_true_bin()],
              'exit_code': 9},
 
             {'namespace': 'run.ignore_missing_references',
@@ -326,7 +335,7 @@ def create_suites(args):
              'file': 'results.json',
              'content': '"pass": 1',
              'assert': True,
-             'reference': ['/bin/true', 'foo']},
+             'reference': [_get_true_bin(), 'foo']},
 
             {'namespace': 'run.unique_job_id',
              'value': 'abcdefghi',


### PR DESCRIPTION
Hi folks,

I wanted to have some fun during the weekend and decided to pick an old mac laptop I have as my current sole personal laptop and took avocado for a spin. I installed brew and the latest python and was off to the races.

I found a number of problems related to multiprocessing and pickling that may not be necessarily restricted to MacOS, so I might be onto something on a number of them, but haven't had much time to test on a Linux machine (where everything is working perfectly without my patches, probably).

I also added a nearly free patch to let me use --open-browser on the mac desktop.

I started running the functional tests and a lot of them are passing, but somehow things get stuck after check-469.

```
    $ make check
    /Users/lmr/Code/avocado-lmr/.venv/bin/python3 setup.py clean --all
    running clean
    ...
    (check-466/1000) selftests/unit/utils/test_iso9660.py:Capabilities.test_capabilities_pycdlib: STARTED
    (check-467/1000) selftests/unit/utils/test_iso9660.py:Capabilities.test_capabilities_nobackend: STARTED
    (check-468/1000) selftests/unit/utils/test_iso9660.py:Capabilities.test_non_existing_capabilities: STARTED
    (check-465/1000) selftests/unit/utils/test_genio.py:TestGenio.test_are_files_equal: PASS (1.94 s)
    (check-469/1000) selftests/unit/utils/test_iso9660.py:IsoInfo.test_basic_workflow: STARTED
```    
 I decided to send the PR anyways so that you guys can take a quick look and see if these patches make any sense.
 
 Thanks!
    
    
    