### PR TITLE
[safeloader] stop trying to parse a perfect JSON string

### DIFF
--- a/avocado/core/safeloader/docstring.py
+++ b/avocado/core/safeloader/docstring.py
@@ -3,7 +3,7 @@ import re
 
 #: Gets the docstring directive value from a string. Used to tweak
 #: test behavior in various ways
-DOCSTRING_DIRECTIVE_RE_RAW = r'\s*:avocado:[ \t]+(([a-zA-Z0-9]+?[a-zA-Z0-9_:,\=\-\.]*)|(r[a-zA-Z0-9]+?[a-zA-Z0-9_:,\=\{\}\"\-\.\/ ]*))\s*$'
+DOCSTRING_DIRECTIVE_RE_RAW = r'\s*:avocado:[ \t]+(([a-zA-Z0-9]+?[a-zA-Z0-9_:,\=\-\.]*)|(requirement={.*}))\s*$'
 # the RE will match `:avocado: tags=category` or `:avocado: requirements={}`
 DOCSTRING_DIRECTIVE_RE = re.compile(DOCSTRING_DIRECTIVE_RE_RAW)
 


### PR DESCRIPTION
Instead of trying to parse a perfect JSON string, let the safeloader parse anything inside `requirement={}` and the JSON module handle malformed strings.

Signed-off-by: Willian Rampazzo <willianr@redhat.com>