### PR TITLE
[Requirements Resolver] add config from test to requirement

### DIFF
--- a/avocado/core/requirements/resolver.py
+++ b/avocado/core/requirements/resolver.py
@@ -28,6 +28,7 @@ class RequirementsResolver:
             # original `requirements` dictionary from the test
             requirement_copy = requirement.copy()
             kind = 'requirement-%s' % requirement_copy.pop('type')
-            requirement_runnable = Runnable(kind, None, **requirement_copy)
+            requirement_runnable = Runnable(kind, None, config=runnable.config,
+                                            **requirement_copy)
             requirements_runnables.append(requirement_runnable)
         return requirements_runnables


### PR DESCRIPTION
When a test depends on a requirement, the requirement runnable needs to know which are the configurations from the test.

Signed-off-by: Willian Rampazzo <willianr@redhat.com>