### PR TITLE
safeloader: remove legacy and unused find_class_and_methods() function

### DIFF
--- a/avocado/core/safeloader/core.py
+++ b/avocado/core/safeloader/core.py
@@ -4,53 +4,10 @@ import os
 import sys
 from importlib.machinery import PathFinder
 
-from ...utils import data_structures
 from .docstring import (check_docstring_directive, get_docstring_directives,
                         get_docstring_directives_requirements,
                         get_docstring_directives_tags)
 from .module import PythonModule
-
-
-def find_class_and_methods(path, method_pattern=None, base_class=None):
-    """
-    Attempts to find methods names from a given Python source file
-
-    :param path: path to a Python source code file
-    :type path: str
-    :param method_pattern: compiled regex to match against method name
-    :param base_class: only consider classes that inherit from a given
-                       base class (or classes that inherit from any class
-                       if None is given)
-    :type base_class: str or None
-    :returns: an ordered dictionary with classes as keys and methods as values
-    :rtype: collections.OrderedDict
-    """
-    def inherits_from_base_class(class_statement, base_class_name):
-        base_ids = [base.id for base in class_statement.bases
-                    if hasattr(base, 'id')]
-        return base_class_name in base_ids
-
-    result = collections.OrderedDict()
-    with open(path) as source_file:
-        mod = ast.parse(source_file.read(), path)
-
-    for statement in mod.body:
-        if isinstance(statement, ast.ClassDef):
-            if base_class is not None:
-                if not inherits_from_base_class(statement,
-                                                base_class):
-                    continue
-            if method_pattern is None:
-                methods = [st.name for st in statement.body if
-                           isinstance(st, ast.FunctionDef)]
-                methods = data_structures.ordered_list_unique(methods)
-            else:
-                methods = [st.name for st in statement.body if
-                           isinstance(st, ast.FunctionDef) and
-                           method_pattern.match(st.name)]
-                methods = data_structures.ordered_list_unique(methods)
-            result[statement.name] = methods
-    return result
 
 
 def get_methods_info(statement_body, class_tags, class_requirements):

--- a/selftests/unit/test_safeloader_core.py
+++ b/selftests/unit/test_safeloader_core.py
@@ -1,14 +1,14 @@
 import os
-import re
 import sys
 import unittest
 import unittest.mock
+from collections import OrderedDict
 
 from avocado.core.safeloader.core import (find_avocado_tests,
-                                          find_class_and_methods,
                                           find_python_unittests)
 from avocado.utils import script
-from selftests.utils import TestCaseTmpDir, setup_avocado_loggers
+
+from ..utils import TestCaseTmpDir, setup_avocado_loggers
 
 setup_avocado_loggers()
 
@@ -176,73 +176,23 @@ class UnlimitedDiff(unittest.TestCase):
 class FindClassAndMethods(UnlimitedDiff):
 
     def test_self(self):
-        reference = {
-            'FindClassAndMethods': ['test_self',
-                                    'test_with_pattern',
-                                    'test_with_base_class',
-                                    'test_with_pattern_and_base_class',
-                                    'test_methods_order',
-                                    'test_import_not_on_parent',
-                                    'test_recursive_discovery',
-                                    'test_recursive_discovery_python_unittest'],
-            'UnlimitedDiff': ['setUp'],
-            'MultiLevel': ['setUp',
-                           'test_base_level0',
-                           'test_relative_level0_name_from_level1',
-                           'test_relative_level0_from_level1',
-                           'test_relative_level0_name_from_level2',
-                           'test_relative_level0_from_level2',
-                           'test_non_relative_level0_from_level2'],
-        }
-        found = find_class_and_methods(get_this_file())
-        self.assertEqual(reference, found)
-
-    def test_with_pattern(self):
-        reference = {
-            'FindClassAndMethods': ['test_self',
-                                    'test_with_pattern',
-                                    'test_with_base_class',
-                                    'test_with_pattern_and_base_class',
-                                    'test_methods_order',
-                                    'test_import_not_on_parent',
-                                    'test_recursive_discovery',
-                                    'test_recursive_discovery_python_unittest'],
+        reference = OrderedDict({
             'UnlimitedDiff': [],
-            'MultiLevel': ['test_base_level0',
-                           'test_relative_level0_name_from_level1',
-                           'test_relative_level0_from_level1',
-                           'test_relative_level0_name_from_level2',
-                           'test_relative_level0_from_level2',
-                           'test_non_relative_level0_from_level2'],
-        }
-        found = find_class_and_methods(get_this_file(),
-                                       re.compile(r'test.*'))
-        self.assertEqual(reference, found)
 
-    def test_with_base_class(self):
-        reference = {
-            'FindClassAndMethods': ['test_self',
-                                    'test_with_pattern',
-                                    'test_with_base_class',
-                                    'test_with_pattern_and_base_class',
-                                    'test_methods_order',
-                                    'test_import_not_on_parent',
-                                    'test_recursive_discovery',
-                                    'test_recursive_discovery_python_unittest'],
-        }
-        found = find_class_and_methods(get_this_file(),
-                                       base_class='UnlimitedDiff')
-        self.assertEqual(reference, found)
+            'FindClassAndMethods': [('test_self', {}, []),
+                                    ('test_methods_order', {}, []),
+                                    ('test_import_not_on_parent', {}, []),
+                                    ('test_recursive_discovery', {}, []),
+                                    ('test_recursive_discovery_python_unittest', {}, [])],
 
-    def test_with_pattern_and_base_class(self):
-        reference = {
-            'FindClassAndMethods': ['test_with_pattern',
-                                    'test_with_base_class',
-                                    'test_with_pattern_and_base_class']
-        }
-        found = find_class_and_methods(get_this_file(),
-                                       re.compile(r'test_with.*'),
-                                       'UnlimitedDiff')
+            'MultiLevel': [('test_base_level0', {}, []),
+                           ('test_relative_level0_name_from_level1', {}, []),
+                           ('test_relative_level0_from_level1', {}, []),
+                           ('test_relative_level0_name_from_level2', {}, []),
+                           ('test_relative_level0_from_level2', {}, []),
+                           ('test_non_relative_level0_from_level2', {}, [])]
+             })
+        found = find_python_unittests(get_this_file())
         self.assertEqual(reference, found)
 
     def test_methods_order(self):


### PR DESCRIPTION
This function was once used for what it's named after: finding class
and method names in a Python source code file.

The problem with that function is that it is not being used to
actually power Avocado's safeloader method.  Worse, it was used in the
unittests, giving a false impression that all test classes in methods
on its own Python file were being properly found.

This removes this function, and some tests that depended on it.  Now
that the *actual* Avocado code to find tests is being used, and issue
#4625 is still not fixed, the import of "selftests.utils" was switched
to a relative import so that the "MultiLevel" class and its tests are
found, and the "FindClassAndMethods.test_self", which references all
tests in the file, passes.

Tests were removed here, but they covered unused code, so there should
be no loss in coverage.

Reference: https://github.com/avocado-framework/avocado/issues/4625
Signed-off-by: Cleber Rosa <crosa@redhat.com>