### PR TITLE
 Nrunner helper methods for sending messages

### DIFF
--- a/avocado/core/runners/requirement_package.py
+++ b/avocado/core/runners/requirement_package.py
@@ -4,6 +4,7 @@ from multiprocessing import Process, SimpleQueue
 from ...utils.software_manager.main import MESSAGES
 from ...utils.software_manager.manager import SoftwareManager
 from .. import nrunner
+from .utils import messages
 
 
 class RequirementPackageRunner(nrunner.BaseRunner):
@@ -105,17 +106,15 @@ class RequirementPackageRunner(nrunner.BaseRunner):
         queue.put(output)
 
     def run(self):
-        yield self.prepare_status('started')
+        yield messages.get_started_message()
         # check if there is a valid 'action' argument
         cmd = self.runnable.kwargs.get('action', 'install')
         # avoid invalid arguments
         if cmd not in ['install', 'check', 'remove']:
             stderr = ("Invalid action %s. Use one of 'install', 'check' or"
                       " 'remove'" % cmd)
-            yield self.prepare_status('running',
-                                      {'type': 'stderr',
-                                       'log': stderr.encode()})
-            yield self.prepare_status('finished', {'result': 'error'})
+            yield messages.get_stderr_message(stderr.encode())
+            yield messages.get_finished_message('error')
             return
 
         package = self.runnable.kwargs.get('name')
@@ -131,7 +130,7 @@ class RequirementPackageRunner(nrunner.BaseRunner):
 
             while queue.empty():
                 time.sleep(nrunner.RUNNER_RUN_STATUS_INTERVAL)
-                yield self.prepare_status('running')
+                yield messages.get_running_message()
 
             output = queue.get()
             result = output['result']
@@ -144,13 +143,9 @@ class RequirementPackageRunner(nrunner.BaseRunner):
             stderr = ('Package name should be passed as kwargs using'
                       ' name="package_name".')
 
-        yield self.prepare_status('running',
-                                  {'type': 'stdout',
-                                   'log': stdout.encode()})
-        yield self.prepare_status('running',
-                                  {'type': 'stderr',
-                                   'log': stderr.encode()})
-        yield self.prepare_status('finished', {'result': result})
+        yield messages.get_stdout_message(stdout.encode())
+        yield messages.get_stderr_message(stderr.encode())
+        yield messages.get_finished_message(result)
 
 
 class RunnerApp(nrunner.BaseRunnerApp):

--- a/avocado/core/runners/tap.py
+++ b/avocado/core/runners/tap.py
@@ -2,6 +2,7 @@ import io
 
 from .. import nrunner
 from ..tapparser import TapParser, TestResult
+from .utils import messages
 
 
 class TAPRunner(nrunner.ExecRunner):
@@ -56,9 +57,8 @@ class TAPRunner(nrunner.ExecRunner):
 
     def _process_final_status(self, process,
                               stdout=None, stderr=None):  # pylint: disable=W0613
-        return self.prepare_status('finished',
-                                   {'result': self._get_tap_result(stdout),
-                                    'returncode': process.returncode})
+        return messages.get_finished_message(self._get_tap_result(stdout),
+                                             returncode=process.returncode)
 
 
 class RunnerApp(nrunner.BaseRunnerApp):

--- a/avocado/core/runners/utils/messages.py
+++ b/avocado/core/runners/utils/messages.py
@@ -1,0 +1,198 @@
+import logging
+import sys
+import time
+
+from ... import output
+
+
+def _prepare_message(status_type, additional_info=None):
+    """Prepare a message dict with some basic information.
+
+    This will add the keyword 'status' and 'time' to all messages.
+
+    :param status_type: The type of event ('started', 'running',
+                         'finished')
+    :param: addional_info: Any additional information that you
+                           would like to add to the message.
+    :type additional_info: dict
+
+    :rtype: dict
+    """
+    status = {}
+    if isinstance(additional_info, dict):
+        status = additional_info
+    status.update({'status': status_type,
+                   'time': time.monotonic()})
+    return status
+
+
+def _get_running_message(msg, message_type):
+    """Prepare a message dict with necessary information for specific type.
+
+    :param msg: message data. If the message is str, it will be encoded
+                with utf-8.
+    :type msg: str, bytes
+    :param message_type: specific type of message
+    :type message_type: str
+    :return: message dict which can be send to avocado server
+    :rtype: dict
+    """
+    message = {'type': message_type, 'log': msg}
+    if type(msg) is not bytes:
+        msg = msg.encode('utf-8')
+        message.update({'log': msg, 'encoding': 'utf-8'})
+    return _prepare_message('running', message)
+
+
+def get_started_message():
+    """Creates the started message.
+
+    :return: started message
+    :rtype: dict
+    """
+    return _prepare_message('started')
+
+
+def get_finished_message(result, fail_reason=None, returncode=None):
+    """Creates finished message with  all necessary information.
+
+    :param result: test result
+    :type result values for the statuses defined in
+                 :class: avocado.core.teststatus.STATUSES
+    :param fail_reason: parameter for brief specification, of the failed
+                        result.
+    :type fail_reason: str
+    :param returncode: exit status of runner
+    :return: finished message
+    :rtype: dict
+    """
+    message = {'result': result}
+    if fail_reason is not None:
+        message['fail_reason'] = fail_reason
+    if returncode is not None:
+        message['returncode'] = returncode
+    return _prepare_message('finished', message)
+
+
+def get_running_message():
+    """Creates running message without any additional info.
+
+    :return: running message
+    :rtype: dict
+    """
+    return _prepare_message('running')
+
+
+def get_log_message(message):
+    """Creates log message with  all necessary information.
+
+    :param message: log to be sent. The str will be encoded with utf-8.
+    :type message: str, bytes
+    :return: log message
+    :rtype: dict
+    """
+    return _get_running_message(message, 'log')
+
+
+def get_stdout_message(message):
+    """Creates stdout message with  all necessary information.
+
+    :param message: data to be sent. The str will be encoded with utf-8.
+    :type message: str, bytes
+    :return: stdout message
+    :rtype: dict
+    """
+    return _get_running_message(message, 'stdout')
+
+
+def get_stderr_message(message):
+    """Creates stderr message with  all necessary information.
+
+    :param message: data to be sent. The str will be encoded with utf-8.
+    :type message: str, bytes
+    :return: stderr message
+    :rtype: dict
+    """
+    return _get_running_message(message, 'stderr')
+
+
+def get_whiteboard_message(message):
+    """Creates whiteboard message with  all necessary information.
+
+    :param message: data to be sent. The str will be encoded with utf-8.
+    :type message: str, bytes
+    :return: whiteboard message
+    :rtype: dict
+    """
+    return _get_running_message(message, 'whiteboard')
+
+
+class RunnerLogHandler(logging.Handler):
+
+    def __init__(self, queue, message_type):
+        """
+        Runner logger which will put every log to the runner queue
+
+        :param queue: queue for the runner messages
+        :type queue: multiprocessing.SimpleQueue
+        :param message_type: type of the log
+        :type message_type: string
+        """
+        super().__init__()
+        self.queue = queue
+        self.message_type = message_type
+
+    def emit(self, record):
+        msg = self.format(record)
+        self.queue.put(_get_running_message(msg, self.message_type))
+
+
+class StreamToQueue:
+
+    def __init__(self,  queue, message_type):
+        """
+        Runner Stream which will transfer every  to the runner queue
+
+        :param queue: queue for the runner messages
+        :type queue: multiprocessing.SimpleQueue
+        :param message_type: type of the log
+        :type message_type: string
+        """
+        self.queue = queue
+        self.message_type = message_type
+
+    def write(self, buf):
+        self.queue.put(_get_running_message(buf, self.message_type))
+
+    def flush(self):
+        pass
+
+
+def start_logging(config, queue):
+    """Helper method for connecting the avocado logging with avocado messages.
+
+    It will add the logHandlers to the :class: avocado.core.output loggers,
+    which will convert the logs to the avocado messages and sent them to
+    processing queue.
+
+    :param config: avocado configuration
+    :type config: dict
+    :param queue: queue for the runner messages
+    :type queue: multiprocessing.SimpleQueue
+    """
+    log_level = config.get('job.output.loglevel', logging.DEBUG)
+    log_handler = RunnerLogHandler(queue, 'log')
+    fmt = ('%(asctime)s %(module)-16.16s L%(lineno)-.4d %('
+           'levelname)-5.5s| %(message)s')
+    formatter = logging.Formatter(fmt=fmt)
+    log_handler.setFormatter(formatter)
+    log = output.LOG_JOB
+    log.addHandler(log_handler)
+    log.setLevel(log_level)
+    log.propagate = False
+    root_logger = logging.getLogger()
+    root_logger.addHandler(log_handler)
+    output.LOG_UI.addHandler(RunnerLogHandler(queue, 'stdout'))
+
+    sys.stdout = StreamToQueue(queue, "stdout")
+    sys.stderr = StreamToQueue(queue, "stderr")

--- a/docs/source/guides/contributor/chapters/runners.rst
+++ b/docs/source/guides/contributor/chapters/runners.rst
@@ -589,6 +589,11 @@ send those. The running messages can contain different information
 during runner run-time like logs, warnings, errors .etc and that
 information will be processed by the avocado core.
 
+The messages are standard python dictionaries with specified structure.
+You can create it by yourself based on the table :ref:`Supported message types`,
+or you can use helper methods in :class:`avocado.core.runners.utils.messages`
+which will generate them for you.
+
 Supported message types
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/examples/nrunner/runners/avocado-runner-foo
+++ b/examples/nrunner/runners/avocado-runner-foo
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 
 from avocado.core import nrunner
+from avocado.core.runners.utils import messages
 
 
 class FooRunner(nrunner.BaseRunner):
     def run(self):
-        yield self.prepare_status('started')
-        yield self.prepare_status('finished', {'result': 'pass'})
+        yield messages.get_started_message()
+        yield messages.get_finished_message('pass')
 
 
 class RunnerApp(nrunner.BaseRunnerApp):

--- a/examples/plugins/tests/magic/avocado_magic/runner.py
+++ b/examples/plugins/tests/magic/avocado_magic/runner.py
@@ -1,4 +1,5 @@
 from avocado.core import nrunner
+from avocado.core.runners.utils import messages
 
 
 class MagicRunner(nrunner.BaseRunner):
@@ -21,12 +22,12 @@ class MagicRunner(nrunner.BaseRunner):
     """
 
     def run(self):
-        yield self.prepare_status('started')
+        yield messages.get_started_message()
         if self.runnable.uri in ['pass', 'fail']:
             result = self.runnable.uri
         else:
             result = 'error'
-        yield self.prepare_status('finished', {'result': result})
+        yield messages.get_finished_message(result)
 
 
 class RunnerApp(nrunner.BaseRunnerApp):

--- a/optional_plugins/golang/avocado_golang/runner.py
+++ b/optional_plugins/golang/avocado_golang/runner.py
@@ -4,6 +4,7 @@ import time
 from avocado_golang import GO_BIN
 
 from avocado.core import nrunner
+from avocado.core.runners.utils import messages
 
 
 class GolangRunner(nrunner.BaseRunner):
@@ -26,6 +27,7 @@ class GolangRunner(nrunner.BaseRunner):
     """
 
     def run(self):
+        yield messages.get_started_message()
         module, test = self.runnable.uri.split(':', 1)
 
         cmd = [GO_BIN, 'test', '-v', module]
@@ -40,14 +42,13 @@ class GolangRunner(nrunner.BaseRunner):
 
         while process.poll() is None:
             time.sleep(nrunner.RUNNER_RUN_STATUS_INTERVAL)
-            yield self.prepare_status('running')
+            yield messages.get_running_message()
 
         result = 'pass' if process.returncode == 0 else 'fail'
-        yield self.prepare_status('finished',
-                                  {'result': result,
-                                   'returncode': process.returncode,
-                                   'stdout': process.stdout.read(),
-                                   'stderr': process.stderr.read()})
+        yield messages.get_stdout_message(process.stdout.read())
+        yield messages.get_stderr_message(process.stderr.read())
+        yield messages.get_finished_message(result,
+                                            returncode=process.returncode)
 
 
 class RunnerApp(nrunner.BaseRunnerApp):

--- a/selftests/unit/test_nrunner.py
+++ b/selftests/unit/test_nrunner.py
@@ -322,7 +322,7 @@ class Runner(unittest.TestCase):
         result = results[-1]
         self.assertEqual(result['status'], 'finished')
         self.assertEqual(result['result'], 'error')
-        self.assertEqual(result['output'], output)
+        self.assertEqual(result['fail_reason'], output)
 
 
 class RunnerTmp(unittest.TestCase):


### PR DESCRIPTION
It brings helper methods for creating avocado messages. This will
simplify the usage of avocado messages for runners developers. Because
they will be able to use a messaging system without knowledge of the
internal structure.

Reference: #4627
Signed-off-by: Jan Richter <jarichte@redhat.com>