### PR TITLE
Docs: remove warning about environment variables from version 62.0

### DIFF
--- a/docs/source/guides/writer/chapters/writing.rst
+++ b/docs/source/guides/writer/chapters/writing.rst
@@ -1510,17 +1510,6 @@ tests:
 | `***`                       | All variables from --mux-yaml         | TIMEOUT=60; IO_WORKERS=10; VM_BYTES=512M; ...                                                       |
 +-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
 
-.. warning:: ``AVOCADO_TEST_SRCDIR`` was present in earlier versions,
-             but has been deprecated on version 60.0, and removed on
-             version 62.0.  Please use ``AVOCADO_TEST_WORKDIR``
-             instead.
-
-.. warning:: ``AVOCADO_TEST_DATADIR`` was present in earlier versions,
-             but has been deprecated on version 60.0, and removed on
-             version 62.0.  The test data files (and directories) are
-             now dynamically evaluated and are not available as
-             environment variables
-
 SIMPLE Tests BASH extensions
 ----------------------------
 


### PR DESCRIPTION
These warnings are about features that have been deprecated in version
60.0, and removed in 62.0, more than two LTS versions ago.

It's not highly probably that this information will be of use to
users of the current version.

Signed-off-by: Cleber Rosa <crosa@redhat.com>