### PR TITLE
safeloader: introduce "imported symbol" module

### DIFF
--- a/avocado/core/safeloader/core.py
+++ b/avocado/core/safeloader/core.py
@@ -87,13 +87,13 @@ def _get_attributes_for_further_examination(parent, module):
             # We know 'parent.Class' or 'asparent.Class' and need
             # to get path and original_module_name. Class is given
             # by parent definition.
-            _parent = module.imported_objects.get(parent.value.id)
-            if _parent is None:
+            imported_symbol = module.imported_symbols.get(parent.value.id)
+            if imported_symbol is None:
                 # We can't examine this parent (probably broken
                 # module)
                 raise ClassNotSuitable
-            parent_path = os.path.dirname(_parent)
-            parent_module = os.path.basename(_parent)
+            parent_path = imported_symbol.get_parent_fs_path()
+            parent_module = imported_symbol.symbol
             parent_class = parent.attr
         else:
             # We don't support multi-level 'parent.parent.Class'
@@ -101,13 +101,14 @@ def _get_attributes_for_further_examination(parent, module):
     else:
         # We only know 'Class' or 'AsClass' and need to get
         # path, module and original class_name
-        _parent = module.imported_objects.get(parent.id)
-        if _parent is None:
+        imported_symbol = module.imported_symbols.get(parent.id)
+        if imported_symbol is None:
             # We can't examine this parent (probably broken
             # module)
             raise ClassNotSuitable
-        parent_path, parent_module, parent_class = (
-            _parent.rsplit(os.path.sep, 2))
+        parent_path = imported_symbol.get_compat_parent_path()
+        parent_module = imported_symbol.get_compat_module_path()
+        parent_class = imported_symbol.get_compat_symbol()
 
     return parent_path, parent_module, parent_class
 

--- a/avocado/core/safeloader/imported.py
+++ b/avocado/core/safeloader/imported.py
@@ -1,0 +1,168 @@
+import ast
+import os
+
+
+class ImportedSymbol:
+    """A representation of an importable symbol.
+
+    Attributes:
+
+    symbol : str
+    module_path : str
+    importer_fs_path: str or None
+    """
+
+    def __init__(self, symbol, module_path='', importer_fs_path=None):
+        #: The name of the imported symbol.  On a statement such as
+        #: "import os", the symbol is "os".  On a statement such as
+        #: "from unittest.mock import mock_open", the symbol is "mock_open"
+        self.symbol = symbol
+        #: Path from where the symbol was imported.  On a statement such as
+        #: "import os", module_path is None.  On a statement such as
+        #: "from unittest.mock import mock_open", the module_path is
+        #: "unittest.mock".  On a statement such as "from ..foo import bar",
+        #: module_path is "..foo" (relative).
+        self.module_path = module_path
+        #: The full, absolute filesystem path of the module importing
+        #: this symbol.  This is used for relative path calculations,
+        #: but it's limited to relative modules that also share the
+        #: filesystem location.  An example is "/path/to/mytest.py",
+        #: that can contain:
+        #:
+        #: from .base import BaseTestClass
+        #:
+        #: And thus will have a symbol of "BaseTestClass" and the
+        #: module as ".base".  The relative filesystem path of the
+        #: module (which should contain the symbol) will be
+        #: "/path/to".
+        #:
+        #: And if "/path/to/common/test.py" contains:
+        #:
+        #: from ..base import BaseTestClass
+        #:
+        #: The relative filesystem path of the module (which should
+        #: contain the symbol) will be "/path/to".
+        self.importer_fs_path = importer_fs_path
+
+    @staticmethod
+    def get_symbol_from_statement(statement):
+        if isinstance(statement, ast.ImportFrom):
+            return statement.names[0].name
+
+        if isinstance(statement, ast.Import):
+            if getattr(statement, 'module', None) is not None:
+                # Module has a name, so its path is absolute, and not relative
+                # to the directory structure
+                module_path = statement.module
+            else:
+                relative_level = getattr(statement, 'level', 0) or 0
+                relative_path = "".join(["." for _ in range(relative_level)])
+                name = statement.names[0].name
+                module_path = relative_path + name
+            return module_path
+
+        raise ValueError("Statement is not an import: %s" % statement)
+
+    @staticmethod
+    def get_module_path_from_statement(statement):
+        module_path = getattr(statement, 'module', None) or ''
+        if isinstance(statement, ast.Import):
+            if statement.names[0].asname:
+                module_path = statement.names[0].name
+                if '.' in module_path:
+                    module_path = module_path.rsplit('.', 1)[0]
+        # If this is an aliased import, module_path will be
+        # everything but the last component
+        relative_level = getattr(statement, 'level', 0) or 0
+        relative_level_prefix = "".join(["." for _ in range(relative_level)])
+        return relative_level_prefix + module_path
+
+    @classmethod
+    def from_statement(cls, statement, importer_fs_path=None):
+        return cls(cls.get_symbol_from_statement(statement),
+                   cls.get_module_path_from_statement(statement),
+                   importer_fs_path)
+
+    def to_str(self):
+        """Returns a string representation of the plausible statement used."""
+        if not self.module_path:
+            return "import %s" % self.symbol
+        return "from %s import %s" % (self.module_path, self.symbol)
+
+    def is_relative(self):
+        """Returns whether the imported symbol is on a relative path."""
+        return self.module_path.startswith(".")
+
+    def get_relative_module_fs_path(self):
+        """Returns the module base dir, based on its relative path
+
+        The base dir for the module is the directory where one is
+        expected to find the first module of the module path.  For a
+        module path of "..foo.bar", and its importer being at
+        "/abs/path/test.py", the base dir where "foo" is supposed to
+        be found would be "/abs".  And as a consequence, "bar" would
+        be found at "/abs/foo/bar".
+
+        This assumes that the module path is indeed related to the location
+        of its importer.  This may not be true if the namespaces match, but
+        are distributed across different filesystem paths.
+        """
+        path = os.path.dirname(self.importer_fs_path)
+        for char in self.module_path[1:]:
+            if char != ".":
+                break
+            path = os.path.dirname(path)
+        return path
+
+    def get_parent_fs_path(self):
+        if self.is_relative():
+            return self.get_relative_module_fs_path()
+        parent_path = os.path.dirname(self.importer_fs_path)
+        if self.module_path:
+            return os.path.join(parent_path, self.module_path)
+        return parent_path
+
+    def get_compat_parent_path(self):
+        """Returns a "parent path" compatible with the path based notation.
+
+        This is intended for temporary compatibility purposes with the
+        single path based notation of keeping track of the path/module/class.
+        """
+        parent_path = self.get_relative_module_fs_path()
+        non_rel_mod_path = self.module_path.strip(".")
+        pure_module_path_to_fs = non_rel_mod_path.replace(".", os.path.sep)
+        if self.symbol:
+            pure_module_path_to_fs = os.path.dirname(pure_module_path_to_fs)
+        return os.path.join(parent_path, pure_module_path_to_fs)
+
+    def get_compat_module_path(self):
+        """Returns a "parent module" compatible with the path based notation.
+
+        This is intended for temporary compatibility purposes with the
+        single path based notation of keeping track of the path/module/class.
+        """
+        non_rel_mod_path = self.module_path.strip(".")
+        split = non_rel_mod_path.rsplit(".", 1)
+        if len(split) > 1:
+            return split[1]
+        return non_rel_mod_path
+
+    def get_compat_symbol(self):
+        """Returns a "parent symbol" compatible with the path based notation.
+
+        This is intended for temporary compatibility purposes with the
+        single path based notation of keeping track of the path/module/class.
+        """
+        split = self.symbol.rsplit(".", 1)
+        if len(split) > 1:
+            return split[1]
+        return self.symbol
+
+    def __repr__(self):
+        return '<ImportedSymbol symbol="%s" module_path="%s">' % (self.symbol,
+                                                                  self.module_path)
+
+    def __eq__(self, other):
+        return ((self.symbol == other.symbol) and
+                (self.module_path == other.module_path) and
+                (self.importer_fs_path == other.importer_fs_path))

--- a/selftests/unit/test_safeloader_imported.py
+++ b/selftests/unit/test_safeloader_imported.py
@@ -1,0 +1,93 @@
+import ast
+import unittest
+
+from avocado.core.safeloader.imported import ImportedSymbol
+
+
+class SymbolAndModulePath(unittest.TestCase):
+
+    def _check(self, input_symbol, input_module_path, input_statement):
+        statement = ast.parse(input_statement).body[0]
+        symbol = ImportedSymbol.get_symbol_from_statement(statement)
+        self.assertEqual(symbol, input_symbol)
+        module_path = ImportedSymbol.get_module_path_from_statement(statement)
+        self.assertEqual(module_path, input_module_path)
+        imported_symbol = ImportedSymbol(symbol, module_path)
+        self.assertEqual(imported_symbol.to_str(), input_statement)
+        self.assertEqual(imported_symbol,
+                         ImportedSymbol.from_statement(statement))
+
+    def test_symbol_only(self):
+        self._check("os", "", "import os")
+
+    def test_symbol_module_path(self):
+        self._check("path", "os", "from os import path")
+
+    def test_symbol_module_path_compound(self):
+        self._check("mock_open", "unittest.mock",
+                    "from unittest.mock import mock_open")
+
+    def test_symbol_module_path_only_relative(self):
+        self._check("utils", "..", "from .. import utils")
+
+    def test_symbol_module_path_from_relative(self):
+        self._check("utils", "..selftests", "from ..selftests import utils")
+
+    def test_symbol_module_path_from_relative_multiple(self):
+        self._check("mod", "..selftests.utils",
+                    "from ..selftests.utils import mod")
+
+    def test_incorrect_statement_type(self):
+        statement = ast.parse("pass").body[0]
+        with self.assertRaises(ValueError):
+            _ = ImportedSymbol.get_symbol_from_statement(statement)
+
+
+class RelativePath(unittest.TestCase):
+
+    def test_same(self):
+        imported_symbol = ImportedSymbol("symbol", ".module",
+                                         "/abs/fs/location/test.py")
+        self.assertEqual(imported_symbol.get_relative_module_fs_path(),
+                         "/abs/fs/location")
+
+    def test_upper(self):
+        imported_symbol = ImportedSymbol("symbol", "..module",
+                                         "/abs/fs/location/test.py")
+        self.assertEqual(imported_symbol.get_relative_module_fs_path(),
+                         "/abs/fs")
+
+    def test_upper_from_statement(self):
+        statement = ast.parse("from ..utils import utility").body[0]
+        importer = "/abs/fs/location/of/selftests/unit/test_foo.py"
+        symbol = ImportedSymbol.from_statement(statement,
+                                               importer)
+        self.assertEqual(symbol.get_relative_module_fs_path(),
+                         "/abs/fs/location/of/selftests")
+
+    def test_same_from_statement(self):
+        statement = ast.parse("from .test_bar import symbol").body[0]
+        importer = "/abs/fs/location/of/selftests/unit/test_foo.py"
+        symbol = ImportedSymbol.from_statement(statement,
+                                               importer)
+        self.assertEqual(symbol.get_relative_module_fs_path(),
+                         "/abs/fs/location/of/selftests/unit")
+
+
+class ParentPath(unittest.TestCase):
+
+    def test_compound(self):
+        statement = ast.parse("from path import parent3").body[0]
+        importer = "/abs/fs/location/of/imports.py"
+        symbol = ImportedSymbol.from_statement(statement,
+                                               importer)
+        self.assertEqual(symbol.get_parent_fs_path(),
+                         "/abs/fs/location/of/path")
+
+    def test_compound_levels(self):
+        statement = ast.parse("from .path.parent8 import Class8").body[0]
+        importer = "/abs/fs/location/of/imports.py"
+        symbol = ImportedSymbol.from_statement(statement,
+                                               importer)
+        self.assertEqual(symbol.get_parent_fs_path(),
+                         "/abs/fs/location/of")

--- a/selftests/unit/test_safeloader_module.py
+++ b/selftests/unit/test_safeloader_module.py
@@ -17,21 +17,21 @@ class PythonModuleSelf(unittest.TestCase):
         self.module = PythonModule(self.path)
 
     def test_add_imported_empty(self):
-        self.assertEqual(self.module.imported_objects, {})
+        self.assertEqual(self.module.imported_symbols, {})
 
-    def test_add_imported_object_from_module(self):
+    def test_add_imported_symbols_from_module(self):
         import_stm = ast.ImportFrom(module='foo', names=[ast.Name(name='bar',
                                                                   asname=None)])
-        self.module.add_imported_object(import_stm)
-        self.assertEqual(self.module.imported_objects['bar'],
-                         os.path.join(self.path, 'foo', 'bar'))
+        self.module.add_imported_symbol(import_stm)
+        self.assertEqual(self.module.imported_symbols['bar'].module_path, 'foo')
+        self.assertEqual(self.module.imported_symbols['bar'].symbol, 'bar')
 
     def test_add_imported_object_from_module_asname(self):
         import_stm = ast.ImportFrom(module='foo', names=[ast.Name(name='bar',
                                                                   asname='baz')])
-        self.module.add_imported_object(import_stm)
-        self.assertEqual(self.module.imported_objects['baz'],
-                         os.path.join(self.path, 'foo', 'bar'))
+        self.module.add_imported_symbol(import_stm)
+        self.assertEqual(self.module.imported_symbols['baz'].module_path, 'foo')
+        self.assertEqual(self.module.imported_symbols['baz'].symbol, 'bar')
 
     def test_is_not_avocado_test(self):
         self.assertFalse(self.module.is_matching_klass(ast.ClassDef()))
@@ -75,4 +75,4 @@ class PythonModuleTest(unittest.TestCase):
         module = PythonModule(path)
         for _ in module.iter_classes():
             pass
-        self.assertIn('TestCaseTmpDir', module.imported_objects)
+        self.assertIn('TestCaseTmpDir', module.imported_symbols)


### PR DESCRIPTION
Currently, the "data structure", if one can call it that, to keep track of "objects" imported by modules inspected by the safeloader code is a string.  In most situations, it's easy to pack/unpack the following pieces of information from it:

1. the base path of the module
2. the name of the module
3. the name of the object (usually a class, but optional)

But, once you construct a filesystem-like representation of that, you will fail to unpack the individual members correctly when, for instance, the module has multiple members, like "module.submodule", which becomes "module/submodule".  At that point, is "submodule" a component of 2 or 3? And is "module" a component of 1 or 2?

We need to know the individual components, because when looking at statements such as:

```python
from selftests.utils import TestCaseTmpDir
```

We need to attempt to find an importable spec of `utils` in `selftests`, and not, say, `TestCaseTmpDir` in `selftests.utils` (importlib won't like that).

This is the core problem behind issue #4625, because the `tests.vendor_tests` like imports are not found like in the example above.