### PR TITLE
setup.py: replace subprocess.call with python

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,11 +45,12 @@ class Clean(clean):
 
     def run(self):
         super().run()
-        cleaning_list = ["MANIFEST", "BUILD", "BUILDROOT", "SPECS",
-                         "RPMS", "SRPMS", "SOURCES", "PYPI_UPLOAD",
-                         "./build", "./dist",
-                         "./man/avocado.1", "./docs/build",
-                         "/tmp/avocado/"]
+        cleaning_list = [Path("MANIFEST"), Path("BUILD"), Path("BUILDROOT"),
+                         Path("SPECS"), Path("RPMS"), Path("SRPMS"),
+                         Path("SOURCES"), Path("PYPI_UPLOAD"),
+                         Path("./build"), Path("./dist"),
+                         Path("./man/avocado.1"), Path("./docs/build"),
+                         Path("/tmp/avocado/")]
 
         cleaning_list += list(Path('/var/tmp/').glob(".avocado-task*"))
         cleaning_list += list(Path('/var/tmp/').glob("avocado*"))
@@ -59,9 +60,9 @@ class Clean(clean):
         cleaning_list += list(Path('./docs/source/api/').rglob("*.rst"))
 
         for e in cleaning_list:
-            if os.path.exists(e) and os.path.isfile(e):
-                os.remove(e)
-            if os.path.exists(e) and os.path.isdir(e):
+            if e.exists() and e.is_file():
+                e.remove()
+            if e.exists() and e.is_dir():
                 shutil.rmtree(e)
 
         self.clean_optional_plugins()

--- a/setup.py
+++ b/setup.py
@@ -15,9 +15,11 @@
 
 import glob
 import os
+import shutil
 import sys
 from abc import abstractmethod
 from distutils.command.clean import clean
+from pathlib import Path
 from subprocess import CalledProcessError, call, check_call
 
 from setuptools import Command, find_packages, setup
@@ -43,15 +45,25 @@ class Clean(clean):
 
     def run(self):
         super().run()
-        call(('rm -rf MANIFEST BUILD BUILDROOT SPECS RPMS SRPMS SOURCES',
-              'PYPI_UPLOAD ./build ./dist'), shell=True)
-        call('rm -rf ./man/avocado.1 ./docs/build', shell=True)
-        call('rm -rf /var/tmp/avocado* /tmp/avocado/*', shell=True)
-        call('find . -name "*.egg-info" -exec rm -rv {} +', shell=True)
-        call('find . -name "*.pyc" -exec rm -rv {} +', shell=True)
-        call('find . -name __pycache__ -type d -exec rm -rv {} +', shell=True)
-        call('find ./docs/source/api/ -name "*.rst" -exec rm -rv {} +',
-             shell=True)
+        cleaning_list = ["MANIFEST", "BUILD", "BUILDROOT", "SPECS",
+                         "RPMS", "SRPMS", "SOURCES", "PYPI_UPLOAD",
+                         "./build", "./dist",
+                         "./man/avocado.1", "./docs/build",
+                         "/tmp/avocado/"]
+
+        cleaning_list += list(Path('/var/tmp/').glob(".avocado-task*"))
+        cleaning_list += list(Path('/var/tmp/').glob("avocado*"))
+        cleaning_list += list(Path('.').rglob("*.egg-info"))
+        cleaning_list += list(Path('.').rglob("*.pyc"))
+        cleaning_list += list(Path('.').rglob("__pycache__"))
+        cleaning_list += list(Path('./docs/source/api/').rglob("*.rst"))
+
+        for e in cleaning_list:
+            if os.path.exists(e) and os.path.isfile(e):
+                os.remove(e)
+            if os.path.exists(e) and os.path.isdir(e):
+                shutil.rmtree(e)
+
         self.clean_optional_plugins()
 
     @staticmethod


### PR DESCRIPTION
This is a more pythonic approach to avoid the security implications of using shell=True .
Use remove_tree for removing directories recursively even when they're not empty.
Introduce the module pathlib to import bash globbing.
    
 Signed-off-by: Ana Guerrero Lopez <anguerre@redhat.com>
