### PR TITLE
Nrunner File message

### DIFF
--- a/avocado/core/messages.py
+++ b/avocado/core/messages.py
@@ -84,12 +84,11 @@ class StartMessageHandler(BaseMessageHandler):
     It will create the test base directories and triggers the 'start_test'
     event.
 
-    This is triggered when the runner starts the test.
+    This have to be triggered when the runner starts the test.
 
-    The started message properties:
-    param status: 'started'
-    param time: start time of the test
-    type time: float
+    :param status: 'started'
+    :param time: start time of the test
+    :type time: float
 
     example: {'status': 'started', 'time': 16444.819830573}
     """
@@ -120,12 +119,14 @@ class FinishMessageHandler(BaseMessageHandler):
 
     This is triggered when the runner ends the test.
 
-    The finished message properties:
-    param status: 'finished'
-    param result: test result
-    type result: `avocado.core.teststatus.STATUSES`
-    param time: end time of the test
-    type time: float
+    :param status: 'finished'
+    :param result: test result
+    :type result: `avocado.core.teststatus.STATUSES`
+    :param time: end time of the test
+    :type time: float
+    :param fail_reason: Optional parameter for brief specification, of the
+                       failed result.
+    :type fail_reason: string
 
     example: {'status': 'finished', 'result': 'pass', 'time': 16444.819830573}
     """
@@ -209,13 +210,12 @@ class LogMessageHandler(BaseRunningMessageHandler):
 
     It will save the log to the debug.log file in the task directory.
 
-    The log message properties:
-    param status: 'running'
-    param type: 'log'
-    param log: log message
-    type log: string
-    param time: Time stamp of the message
-    type time: float
+    :param status: 'running'
+    :param type: 'log'
+    :param log: log message
+    :type log: string
+    :param time: Time stamp of the message
+    :type time: float
 
     example: {'status': 'running', 'type': 'log', 'log': 'log message',
              'time': 18405.55351474}
@@ -237,13 +237,14 @@ class StdoutMessageHandler(BaseRunningMessageHandler):
 
     It will save the stdout to the stdout file in the task directory.
 
-    The log message properties:
-    param status: 'running'
-    param type: 'stdout'
-    param log: stdout message
-    type log: string
-    param time: Time stamp of the message
-    type time: float
+    :param status: 'running'
+    :param type: 'stdout'
+    :param log: stdout message
+    :type log: bytes
+    :param encoding: optional value for decoding messages
+    :type encoding: str
+    :param time: Time stamp of the message
+    :type time: float
 
     example: {'status': 'running', 'type': 'stdout', 'log': 'stdout message',
              'time': 18405.55351474}
@@ -260,13 +261,14 @@ class StderrMessageHandler(BaseRunningMessageHandler):
 
     It will save the stderr to the stderr file in the task directory.
 
-    The log message properties:
-    param status: 'running'
-    param type: 'stderr'
-    param log: stderr message
-    type log: string
-    param time: Time stamp of the message
-    type time: float
+    :param status: 'running'
+    :param type: 'stderr'
+    :param log: stderr message
+    :type log: bytes
+    :param encoding: optional value for decoding messages
+    :type encoding: str
+    :param time: Time stamp of the message
+    :type time: float
 
     example: {'status': 'running', 'type': 'stderr', 'log': 'stderr message',
              'time': 18405.55351474}
@@ -283,13 +285,14 @@ class WhiteboardMessageHandler(BaseRunningMessageHandler):
 
     It will save the stderr to the whiteboard file in the task directory.
 
-    The log message properties:
-    param status: 'running'
-    param type: 'whiteboard'
-    param log: whiteboard message
-    type log: string
-    param time: Time stamp of the message
-    type time: float
+    :param status: 'running'
+    :param type: 'whiteboard'
+    :param log: whiteboard message
+    :type log: bytes
+    :param encoding: optional value for decoding messages
+    :type encoding: str
+    :param time: Time stamp of the message
+    :type time: float
 
     example: {'status': 'running', 'type': 'whiteboard',
              'log': 'whiteboard message', 'time': 18405.55351474}

--- a/avocado/core/messages.py
+++ b/avocado/core/messages.py
@@ -70,7 +70,8 @@ class RunningMessageHandler(BaseMessageHandler):
         self._handlers = {'log': [LogMessageHandler()],
                           'stdout': [StdoutMessageHandler()],
                           'stderr': [StderrMessageHandler()],
-                          'whiteboard': [WhiteboardMessageHandler()]}
+                          'whiteboard': [WhiteboardMessageHandler()],
+                          'file': [FileMessageHandler()]}
 
     def process_message(self, message, task, job):
         for handler in self._handlers.get(message.get('type'), []):
@@ -300,4 +301,37 @@ class WhiteboardMessageHandler(BaseRunningMessageHandler):
 
     def handle(self, message, task, job):
         self._save_message_to_file('whiteboard', message['log'], task,
+                                   message.get('encoding', None))
+
+
+class FileMessageHandler(BaseRunningMessageHandler):
+    """
+    Handler for file message.
+
+    In task directory will save log into the runner specific file. When the
+    file doesn't exist, the file will be created. If the file exist,
+    the message data will be appended at the end.
+
+    :param status: 'running'
+    :param type: 'file'
+    :param path: relative path to the file. The file will be created under
+                the Task directory and the absolute path will be created
+                as `absolute_task_directory_path/relative_file_path`.
+    :type path: string
+    :param log: data to be saved inside file
+    :type log: bytes
+    :param time: Time stamp of the message
+    :type time: float
+
+    example: {'status': 'running', 'type': 'file', 'path':'foo/runner.log',
+             'log': 'this will be saved inside file',
+             'time': 18405.55351474}
+    """
+
+    def handle(self, message, task, job):
+        filename = os.path.relpath(os.path.join("/", message['path']), "/")
+        file = os.path.join(task.metadata['task_path'], filename)
+        if not os.path.exists(file):
+            os.makedirs(os.path.dirname(file))
+        self._save_message_to_file(filename, message['log'], task,
                                    message.get('encoding', None))

--- a/docs/source/guides/contributor/chapters/runners.rst
+++ b/docs/source/guides/contributor/chapters/runners.rst
@@ -592,89 +592,19 @@ information will be processed by the avocado core.
 Supported message types
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Started message
-+++++++++++++
-This message has to be sent when the runner starts the test.
+.. autoclass:: avocado.core.messages.StartMessageHandler
 
-:param status: 'started'
-:param time: start time of the test
-:type time: float
-:example: {'status': 'started', 'time': 16444.819830573}
-
-Finished message
-++++++++++++++++
-This message has to be sent when the runner finishes the test.
-
-:param status: 'finished'
-:param result: test result
-:type result: Lowercase values for the statuses defined in :data:`avocado.core.teststatus.STATUSES`
-:param time: end time of the test
-:type time: float
-:param fail_reason: Optional parameter for brief specification, of the failed result.
-:type fail_reason: str
-:example: {'status': 'finished', 'result': 'pass', 'time': 16444.819830573}
+.. autoclass:: avocado.core.messages.FinishMessageHandler
 
 Running messages
 ++++++++++++++++
 This message can be used during the run-time and has different properties
 based on the information which is being transmitted.
 
-Log message
-***********
-It will save the log to the debug.log file in the task directory.
+.. autoclass:: avocado.core.messages.LogMessageHandler
 
-:param status: 'running'
-:param type: 'log'
-:param log: log message
-:type log: bytes
-:param encoding: optional value for decoding messages
-:type encoding: str
-:param time: Time stamp of the message
-:type time: float
-:example: {'status': 'running', 'type': 'log', 'log': b'log message',
-         'time': 18405.55351474}
+.. autoclass:: avocado.core.messages.StdoutMessageHandler
 
-Stdout message
-**************
-It will save the stdout to the stdout file in the task directory.
+.. autoclass:: avocado.core.messages.StderrMessageHandler
 
-:param status: 'running'
-:param type: 'stdout'
-:param log: stdout message
-:type log: bytes
-:param encoding: optional value for decoding messages
-:type encoding: str
-:param time: Time stamp of the message
-:type time: float
-:example: {'status': 'running', 'type': 'stdout', 'log': b'stdout message',
-         'time': 18405.55351474}
-
-Stderr message
-**************
-It will save the stderr to the stderr file in the task directory.
-
-:param status: 'running'
-:param type: 'stderr'
-:param log: stderr message
-:type log: bytes
-:param encoding: optional value for decoding messages
-:type encoding: str
-:param time: Time stamp of the message
-:type time: float
-:example: {'status': 'running', 'type': 'stderr', 'log': b'stderr message',
-         'time': 18405.55351474}
-
-Whiteboard message
-******************
-It will save the stderr to the whiteboard file in the task directory.
-
-:param status: 'running'
-:param type: 'whiteboard'
-:param log: whiteboard message
-:type log: bytes
-:param encoding: optional value for decoding messages
-:type encoding: str
-:param time: Time stamp of the message
-:type time: float
-:example: {'status': 'running', 'type': 'whiteboard',
-         'log': b'whiteboard message', 'time': 18405.55351474}
+.. autoclass:: avocado.core.messages.WhiteboardMessageHandler

--- a/docs/source/guides/contributor/chapters/runners.rst
+++ b/docs/source/guides/contributor/chapters/runners.rst
@@ -608,3 +608,5 @@ based on the information which is being transmitted.
 .. autoclass:: avocado.core.messages.StderrMessageHandler
 
 .. autoclass:: avocado.core.messages.WhiteboardMessageHandler
+
+.. autoclass:: avocado.core.messages.FileMessageHandler


### PR DESCRIPTION
This PR adds a new type of nrunner messages, the `FileMessage`. This message comes with runners ability to create runner specific files and subdirectories in avocado Task directory. This feature can be used when you want to log some runner specific data. It will be used in sysinfo runner.