### PR TITLE
cirrus: update debian images

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -33,8 +33,8 @@ debian_version_task:
 
     container:
         matrix:
-          - image: debian:9.13
-          - image: debian:10.8
+          - image: debian:10.9
+          - image: debian:bullseye-20210511
           - image: ubuntu:18.04
           - image: ubuntu:20.04
 


### PR DESCRIPTION
Remove Debian 9 (stretch) and add instead Debian 11 (Bullseye),
that will be released next month.
Update tags to use codenames instead of versions. The codename
always point to the latest release, this saves us to update
the tag every time there is a new point release.

Fixes: #4680

Signed-off-by: Ana Guerrero Lopez <anguerre@redhat.com>