### PR TITLE
cirrus: update debian images (continuation)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -49,8 +49,8 @@ debian_egg_task:
        - python3 -c 'import sys; from pkg_resources import require; require("avocado-framework"); from avocado.core.main import main; sys.exit(main())' run /bin/true
     container:
         matrix:
-          - image: debian:9.13
-          - image: debian:10.8
+          - image: debian:10.9
+          - image: debian:bullseye-20210511
           - image: ubuntu:18.04
           - image: ubuntu:20.04
 


### PR DESCRIPTION
Remove Debian 9 (stretch) and add instead Debian 11 (Bullseye),
that will be released next month.

Update Debian 10 to 10.9.
For Debian 11, untils it's being released, used the codename with date.

Fixes: #4680

Signed-off-by: Ana Guerrero Lopez <anguerre@redhat.com>