### PR TITLE
Extend runnable config options

### DIFF
--- a/avocado/core/suite.py
+++ b/avocado/core/suite.py
@@ -67,7 +67,6 @@ def resolutions_to_runnables(resolutions, config):
     filter_by_tags = config.get("filter.by_tags.tags")
     include_empty = config.get("filter.by_tags.include_empty")
     include_empty_key = config.get('filter.by_tags.include_empty_key')
-    runner_config = settings.filter_config(config, r'^runner\.')
     for resolution in resolutions:
         if resolution.result != ReferenceResolutionResult.SUCCESS:
             continue
@@ -78,7 +77,7 @@ def resolutions_to_runnables(resolutions, config):
                                                  include_empty,
                                                  include_empty_key):
                     continue
-            runnable.config = runner_config
+            runnable.config = config
             result.append(runnable)
     return result
 


### PR DESCRIPTION
This PR does 2 two changes to allow passing all the config options to a runnable:

* This handles the nrunner serialization/deserialization process involved in the config. It introduces a mechanism that converts sets into lists inside a dictionary. The dictionary key `__encoded_set__` is used in the decoding process to convert the option back to a set.
* Change the suite to pass all the config options to a runnable instead of filtering.