### PR TITLE
[sogtware-manager] Avoid using --output from `ar` command

### DIFF
--- a/avocado/utils/software_manager/backends/dpkg.py
+++ b/avocado/utils/software_manager/backends/dpkg.py
@@ -84,7 +84,7 @@ class DpkgBackend(BaseBackend):
         os.makedirs(dest, exist_ok=True)
 
         # If something goes wrong process.run will raise a CmdError exception
-        process.run("ar -x {} --output {}".format(abs_path, dest))
+        process.run("cd {} && ar -x {}".format(dest, abs_path), shell=True)
         return dest
 
     def list_files(self, package):


### PR DESCRIPTION
Some versions of `ar` do not have the --output parameter available. This patch uses a different approach changing the directory to the destination and then extracting the source file.

Signed-off-by: Willian Rampazzo <willianr@redhat.com>