### PR TITLE
Remove codecov badge from "Build and Quality Status"

### DIFF
--- a/docs/source/quickstart/index.rst
+++ b/docs/source/quickstart/index.rst
@@ -263,9 +263,6 @@ Build and Quality Status
    :target: https://lgtm.com/projects/g/avocado-framework/avocado/context:javascript
    :alt: lgtm language grade for JavaScript
 
-.. image:: https://codecov.io/gh/avocado-framework/avocado/branch/master/graph/badge.svg
-   :target: https://codecov.io/gh/avocado-framework/avocado
-
 .. image:: https://readthedocs.org/projects/avocado-framework/badge/?version=latest
    :target: https://avocado-framework.readthedocs.io/en/latest/
    :alt: Documentation Status


### PR DESCRIPTION
The Avocado project moved from codecov to codeclimate. The codecov badge is outdated and needs to be removed.

Signed-off-by: Willian Rampazzo <willianr@redhat.com>