### PR TITLE
Nrunner helper methods for sending messages [v2]

### DIFF
--- a/avocado/core/runners/avocado_instrumented.py
+++ b/avocado/core/runners/avocado_instrumented.py
@@ -1,60 +1,12 @@
-import logging
 import multiprocessing
-import sys
 import tempfile
 import time
 import traceback
 
-from .. import loader, nrunner, output
+from .. import loader, nrunner
 from ..test import TestID
 from ..tree import TreeNode
-
-
-def _send_message(msg, queue, message_type, encoding='utf-8'):
-    status = {'type': message_type, 'log': msg.encode(encoding),
-              'encoding': encoding}
-    queue.put(status)
-
-
-class RunnerLogHandler(logging.Handler):
-
-    def __init__(self, queue, message_type):
-        """
-        Runner logger which will put every log to the runner queue
-
-        :param queue: queue for the runner messages
-        :type queue: multiprocessing.SimpleQueue
-        :param message_type: type of the log
-        :type message_type: string
-        """
-        super().__init__()
-        self.queue = queue
-        self.message_type = message_type
-
-    def emit(self, record):
-        msg = self.format(record)
-        _send_message(msg, self.queue, self.message_type)
-
-
-class StreamToQueue:
-
-    def __init__(self,  queue, message_type):
-        """
-        Runner Stream which will transfer every  to the runner queue
-
-        :param queue: queue for the runner messages
-        :type queue: multiprocessing.SimpleQueue
-        :param message_type: type of the log
-        :type message_type: string
-        """
-        self.queue = queue
-        self.message_type = message_type
-
-    def write(self, buf):
-        _send_message(buf, self.queue, self.message_type)
-
-    def flush(self):
-        pass
+from .utils import messages
 
 
 class AvocadoInstrumentedTestRunner(nrunner.BaseRunner):
@@ -71,24 +23,6 @@ class AvocadoInstrumentedTestRunner(nrunner.BaseRunner):
      * args: not used
     """
     DEFAULT_TIMEOUT = 86400
-
-    @staticmethod
-    def _start_logging(runnable, queue):
-        log_level = runnable.config.get('job.output.loglevel', logging.DEBUG)
-        log_handler = RunnerLogHandler(queue, 'log')
-        fmt = '%(asctime)s %(levelname)-5.5s| %(message)s'
-        formatter = logging.Formatter(fmt=fmt, datefmt='%H:%M:%S')
-        log_handler.setFormatter(formatter)
-        log = output.LOG_JOB
-        log.addHandler(log_handler)
-        log.setLevel(log_level)
-        log.propagate = False
-        root_logger = logging.getLogger()
-        root_logger.addHandler(log_handler)
-        output.LOG_UI.addHandler(RunnerLogHandler(queue, 'stdout'))
-
-        sys.stdout = StreamToQueue(queue, "stdout")
-        sys.stderr = StreamToQueue(queue, "stderr")
 
     @staticmethod
     def _run_avocado(runnable, queue):
@@ -114,22 +48,21 @@ class AvocadoInstrumentedTestRunner(nrunner.BaseRunner):
                              'run.results_dir': tempfile.mkdtemp(),
                              }]
 
-            AvocadoInstrumentedTestRunner._start_logging(runnable, queue)
+            messages.start_logging(runnable.config, queue)
             instance = loader.loader.load_test(test_factory)
             early_state = instance.get_state()
             early_state['type'] = "early_state"
             queue.put(early_state)
             instance.run_avocado()
             state = instance.get_state()
-            _send_message(state['whiteboard'], queue, 'whiteboard')
-            queue.put({'status': 'finished',
-                       'result': state['status'].lower()})
+            queue.put(messages.WhiteboardMessage.get(state['whiteboard']))
+            queue.put(messages.FinishedMessage.get(state['status'].lower()))
         except Exception:
-            _send_message(traceback.format_exc(), queue, 'stderr')
-            queue.put({'status': 'finished', 'result': 'error'})
+            queue.put(messages.StderrMessage.get(traceback.format_exc()))
+            queue.put(messages.FinishedMessage.get('error'))
 
     def run(self):
-        yield self.prepare_status('started')
+        yield messages.StartedMessage.get()
         try:
             queue = multiprocessing.SimpleQueue()
             process = multiprocessing.Process(target=self._run_avocado,
@@ -139,7 +72,6 @@ class AvocadoInstrumentedTestRunner(nrunner.BaseRunner):
 
             time_started = time.monotonic()
 
-            early_status = {}
             timeout = float(self.DEFAULT_TIMEOUT)
             most_current_execution_state_time = None
             while True:
@@ -152,33 +84,24 @@ class AvocadoInstrumentedTestRunner(nrunner.BaseRunner):
                     if (most_current_execution_state_time is None or
                             now > next_execution_state_mark):
                         most_current_execution_state_time = now
-                        yield self.prepare_status('running')
+                        yield messages.RunningMessage.get()
                     if (now - time_started) > timeout:
                         process.terminate()
-                        status = early_status
-                        status['result'] = 'interrupted'
-                        if 'name' in status:
-                            del status['name']
-                        if 'time_start' in status:
-                            del status['time_start']
-                        yield self.prepare_status('finished', status)
+                        yield messages.FinishedMessage.get('interrupted',
+                                                           'timeout')
                         break
                 else:
                     message = queue.get()
-                    if message.get('status') == 'finished':
-                        yield self.prepare_status('finished', message)
-                        break
-                    elif message.get('type') == 'early_state':
-                        early_status = message
-                        timeout = float(early_status.get('timeout') or
+                    if message.get('type') == 'early_state':
+                        timeout = float(message.get('timeout') or
                                         self.DEFAULT_TIMEOUT)
                     else:
-                        yield self.prepare_status('running', message)
+                        yield message
+                    if message.get('status') == 'finished':
+                        break
         except Exception:
-            yield self.prepare_status('running',
-                                      {'type': 'stderr',
-                                       'log': traceback.format_exc()})
-            yield self.prepare_status('finished', {'result': 'error'})
+            yield messages.StderrMessage.get(traceback.format_exc())
+            yield messages.FinishedMessage.get('error')
 
 
 class RunnerApp(nrunner.BaseRunnerApp):

--- a/avocado/core/runners/tap.py
+++ b/avocado/core/runners/tap.py
@@ -2,6 +2,7 @@ import io
 
 from .. import nrunner
 from ..tapparser import TapParser, TestResult
+from .utils.messages import FinishedMessage
 
 
 class TAPRunner(nrunner.ExecRunner):
@@ -56,9 +57,8 @@ class TAPRunner(nrunner.ExecRunner):
 
     def _process_final_status(self, process,
                               stdout=None, stderr=None):  # pylint: disable=W0613
-        return self.prepare_status('finished',
-                                   {'result': self._get_tap_result(stdout),
-                                    'returncode': process.returncode})
+        return FinishedMessage.get(self._get_tap_result(stdout),
+                                   returncode=process.returncode)
 
 
 class RunnerApp(nrunner.BaseRunnerApp):

--- a/avocado/core/runners/utils/messages.py
+++ b/avocado/core/runners/utils/messages.py
@@ -1,0 +1,209 @@
+import logging
+import sys
+import time
+
+from ... import output
+
+
+class GenericMessage:
+    message_status = None
+
+    @classmethod
+    def _prepare_message(cls, additional_info=None):
+        """Prepare a message dict with some basic information.
+
+        This will add the keyword 'status' and 'time' to all messages.
+
+        :param: addional_info: Any additional information that you
+                               would like to add to the message.
+        :type additional_info: dict
+        :return: message dict which can be send to avocado server
+        :rtype: dict
+        """
+        status = {}
+        if additional_info is not None:
+            status = additional_info
+        status.update({'status': cls.message_status,
+                       'time': time.monotonic()})
+        return status
+
+    @classmethod
+    def get(cls, **kwargs):
+        """Creates message base on it's type with  all necessary information.
+
+        :return: message dict which can be send to avocado server
+        :rtype: dict
+        """
+        kwargs = {key: value for (key, value) in kwargs.items()
+                  if value is not None}
+        return cls._prepare_message(additional_info=kwargs)
+
+
+class StartedMessage(GenericMessage):
+    message_status = 'started'
+
+
+class RunningMessage(GenericMessage):
+    """Creates running message without any additional info."""
+    message_status = 'running'
+
+
+class FinishedMessage(GenericMessage):
+    message_status = 'finished'
+
+    @classmethod
+    def get(cls, result, fail_reason=None, returncode=None):  # pylint: disable=W0221
+        """Creates finished message with  all necessary information.
+
+        :param result: test result
+        :type result values for the statuses defined in
+                     :class: avocado.core.teststatus.STATUSES
+        :param fail_reason: parameter for brief specification, of the failed
+                            result.
+        :type fail_reason: str
+        :param returncode: exit status of runner
+        :return: finished message
+        :rtype: dict
+        """
+        return super().get(result=result,
+                           fail_reason=fail_reason,
+                           returncode=returncode)
+
+
+class GenericRunningMessage(GenericMessage):
+    message_status = 'running'
+    message_type = None
+
+    @classmethod
+    def _get_running_message(cls, msg):
+        """Prepare a message dict with necessary information for specific type.
+
+        :param msg: message data. If the message is str, it will be encoded
+                    with utf-8.
+        :type msg: str, bytes
+        :return: message dict which can be send to avocado server
+        :rtype: dict
+        """
+        message = {'type': cls.message_type, 'log': msg}
+        if type(msg) is not bytes:
+            msg = msg.encode('utf-8')
+            message.update({'log': msg, 'encoding': 'utf-8'})
+        return message
+
+    @classmethod
+    def get(cls, msg, **kwargs):  # pylint: disable=W0221
+        """Creates running message with  all necessary information.
+
+        :param msg: log of running message
+        :type msg: str
+        :return: running message
+        :rtype: dict
+        """
+        kwargs.update(cls._get_running_message(msg))
+        return super().get(**kwargs)
+
+
+class LogMessage(GenericRunningMessage):
+    message_type = 'log'
+
+
+class StdoutMessage(GenericRunningMessage):
+    """Creates stdout message with  all necessary information."""
+    message_type = 'stdout'
+
+
+class StderrMessage(GenericRunningMessage):
+    """Creates stderr message with  all necessary information."""
+    message_type = 'stderr'
+
+
+class WhiteboardMessage(GenericRunningMessage):
+    """Creates whiteboard message with  all necessary information."""
+    message_type = 'whiteboard'
+
+
+class FileMessage(GenericRunningMessage):
+    """Creates file message with  all necessary information."""
+    message_type = 'file'
+
+    @classmethod
+    def get(cls, msg, path):  # pylint: disable=W0221
+        super().get(msg=msg, path=path)
+
+
+_supported_types = {LogMessage.message_type: LogMessage,
+                    StdoutMessage.message_type: StdoutMessage,
+                    StderrMessage.message_type: StderrMessage,
+                    WhiteboardMessage.message_type: WhiteboardMessage,
+                    FileMessage.message_type: FileMessage}
+
+
+class RunnerLogHandler(logging.Handler):
+
+    def __init__(self, queue, message_type):
+        """
+        Runner logger which will put every log to the runner queue
+
+        :param queue: queue for the runner messages
+        :type queue: multiprocessing.SimpleQueue
+        :param message_type: type of the log
+        :type message_type: string
+        """
+        super().__init__()
+        self.queue = queue
+        self.message = _supported_types[message_type]
+
+    def emit(self, record):
+        msg = self.format(record)
+        self.queue.put(self.message.get(msg))
+
+
+class StreamToQueue:
+
+    def __init__(self,  queue, message_type):
+        """
+        Runner Stream which will transfer data to the runner queue
+
+        :param queue: queue for the runner messages
+        :type queue: multiprocessing.SimpleQueue
+        :param message_type: type of the log
+        :type message_type: string
+        """
+        self.queue = queue
+        self.message = _supported_types[message_type]
+
+    def write(self, buf):
+        self.queue.put(self.message.get(buf))
+
+    def flush(self):
+        pass
+
+
+def start_logging(config, queue):
+    """Helper method for connecting the avocado logging with avocado messages.
+
+    It will add the logHandlers to the :class: avocado.core.output loggers,
+    which will convert the logs to the avocado messages and sent them to
+    processing queue.
+
+    :param config: avocado configuration
+    :type config: dict
+    :param queue: queue for the runner messages
+    :type queue: multiprocessing.SimpleQueue
+    """
+    log_level = config.get('job.output.loglevel', logging.DEBUG)
+    log_handler = RunnerLogHandler(queue, 'log')
+    fmt = ('%(asctime)s %(module)-16.16s L%(lineno)-.4d %('
+           'levelname)-5.5s| %(message)s')
+    formatter = logging.Formatter(fmt=fmt)
+    log_handler.setFormatter(formatter)
+    log = output.LOG_JOB
+    log.addHandler(log_handler)
+    log.setLevel(log_level)
+    log.propagate = False
+    root_logger = logging.getLogger()
+    root_logger.addHandler(log_handler)
+    output.LOG_UI.addHandler(RunnerLogHandler(queue, 'stdout'))
+
+    sys.stdout = StreamToQueue(queue, "stdout")
+    sys.stderr = StreamToQueue(queue, "stderr")

--- a/docs/source/guides/contributor/chapters/runners.rst
+++ b/docs/source/guides/contributor/chapters/runners.rst
@@ -589,6 +589,11 @@ send those. The running messages can contain different information
 during runner run-time like logs, warnings, errors .etc and that
 information will be processed by the avocado core.
 
+The messages are standard Python dictionaries with a specific structure.
+You can create it by yourself based on the table :ref:`Supported message types`,
+or you can use helper methods in :class:`avocado.core.runners.utils.messages`
+which will generate them for you.
+
 Supported message types
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/examples/nrunner/runners/avocado-runner-foo
+++ b/examples/nrunner/runners/avocado-runner-foo
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 
 from avocado.core import nrunner
+from avocado.core.runners.utils.messages import FinishedMessage, StartedMessage
 
 
 class FooRunner(nrunner.BaseRunner):
     def run(self):
-        yield self.prepare_status('started')
-        yield self.prepare_status('finished', {'result': 'pass'})
+        yield StartedMessage.get()
+        yield FinishedMessage.get('pass')
 
 
 class RunnerApp(nrunner.BaseRunnerApp):

--- a/examples/plugins/tests/magic/avocado_magic/runner.py
+++ b/examples/plugins/tests/magic/avocado_magic/runner.py
@@ -1,4 +1,5 @@
 from avocado.core import nrunner
+from avocado.core.runners.utils.messages import FinishedMessage, StartedMessage
 
 
 class MagicRunner(nrunner.BaseRunner):
@@ -21,12 +22,12 @@ class MagicRunner(nrunner.BaseRunner):
     """
 
     def run(self):
-        yield self.prepare_status('started')
+        yield StartedMessage.get()
         if self.runnable.uri in ['pass', 'fail']:
             result = self.runnable.uri
         else:
             result = 'error'
-        yield self.prepare_status('finished', {'result': result})
+        yield FinishedMessage.get(result)
 
 
 class RunnerApp(nrunner.BaseRunnerApp):


### PR DESCRIPTION
It brings helper methods for creating avocado messages. This will
simplify the usage of avocado messages for runners developers. Because
they will be able to use a messaging system without knowledge of the
internal structure.

Reference: #4627
Signed-off-by: Jan Richter jarichte@redhat.com

---
Changes form v1 (#4662)
* Documentation and docstring fixes.
* Removal of message helpers with base runners because of podman issue
* Usage of a OOP approach