### PR TITLE
Safeloader: do not use module directory on import paths

### DIFF
--- a/avocado/core/safeloader/core.py
+++ b/avocado/core/safeloader/core.py
@@ -307,7 +307,6 @@ def find_python_tests(target_module, target_class, determine_match, path):
         # Only update the results if this was detected as 'avocado.Test'
         if match:
             result[klass.name] = info
-            disabled.update(disabled)
 
     return result, disabled
 

--- a/avocado/core/safeloader/core.py
+++ b/avocado/core/safeloader/core.py
@@ -1,6 +1,5 @@
 import ast
 import collections
-import os
 import sys
 from importlib.machinery import PathFinder
 
@@ -113,10 +112,9 @@ def _get_attributes_for_further_examination(parent, module):
     return parent_path, parent_module, parent_class
 
 
-def _find_import_match(parent_path, parent_module, module):
+def _find_import_match(parent_path, parent_module):
     """Attempts to find an importable module."""
-    modules_paths = [parent_path,
-                     os.path.dirname(module.path)] + sys.path
+    modules_paths = [parent_path] + sys.path
     found_spec = PathFinder.find_spec(parent_module, modules_paths)
     if found_spec is None:
         raise ClassNotSuitable
@@ -188,8 +186,7 @@ def _examine_class(target_module, target_class, determine_match, path,
                  parent_module,
                  parent_class) = _get_attributes_for_further_examination(parent,
                                                                          module)
-                found_spec = _find_import_match(parent_path, parent_module,
-                                                module)
+                found_spec = _find_import_match(parent_path, parent_module)
             except ClassNotSuitable:
                 continue
 
@@ -287,8 +284,7 @@ def find_python_tests(target_module, target_class, determine_match, path):
                  parent_module,
                  parent_class) = _get_attributes_for_further_examination(parent,
                                                                          module)
-                found_spec = _find_import_match(parent_path, parent_module,
-                                                module)
+                found_spec = _find_import_match(parent_path, parent_module)
             except ClassNotSuitable:
                 continue
 

--- a/contrib/scripts/avocado-safeloader-find-avocado-instrumented
+++ b/contrib/scripts/avocado-safeloader-find-avocado-instrumented
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2021
+# Author: Cleber Rosa <cleber@redhat.com>
+
+#
+# Simple script that, given Python file containing unittests, returns the canonical
+# location of each test, each one on its own line. The idea is to be able
+# to filter the tests you want to run by doing something like:
+#
+# $ avocado run `avocado-safeloader-find-avocado-instrumented <path-to-test.py> | <your-condition> | xargs`
+#
+
+import os
+import sys
+
+from avocado.core.safeloader import find_avocado_tests
+
+if __name__ == '__main__':
+    test_module_paths = sys.argv[1:]
+    result = []
+    for test_module_path in test_module_paths:
+        try:
+            test_class_methods, _ = find_avocado_tests(test_module_path)
+        except IOError as error:
+            continue
+        for klass, methods in test_class_methods.items():
+            test_module_name = os.path.relpath(test_module_path)
+            result += ["%s:%s.%s" % (test_module_name, klass, method_name)
+                       for (method_name, _, _) in methods]
+    if result:
+        print("\n".join(result))


### PR DESCRIPTION
We're currently manually adding the base directory of the module we're investigating, which is not standard Python behavior.

This this non-standard behavior, and prevents modules being found at non-expected places, and thus classes *not* being found on those non-expected places.