### PR TITLE
Add setuptools command to build the man page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@ PYTHON=$(shell which python3 2>/dev/null || which python 2>/dev/null)
 endif
 VERSION=$(shell $(PYTHON) setup.py --version 2>/dev/null)
 PYTHON_DEVELOP_ARGS=$(shell if ($(PYTHON) setup.py develop --help 2>/dev/null | grep -q '\-\-user'); then echo "--user"; else echo ""; fi)
-RST2MAN=$(shell which rst2man.py 2>/dev/null || which rst2man 2>/dev/null)
 DESTDIR=/
 AVOCADO_DIRNAME=$(shell basename ${PWD})
 AVOCADO_OPTIONAL_PLUGINS=$(shell find ./optional_plugins -maxdepth 1 -mindepth 1 -type d)
@@ -142,6 +141,9 @@ endif
 
 man: man/avocado.1
 
+%.1: %.rst
+	$(PYTHON) setup.py man
+
 variables:
 	@echo "PYTHON: $(PYTHON)"
 	@echo "VERSION: $(VERSION)"
@@ -167,7 +169,3 @@ propagate-version:
 	done
 
 .PHONY: source install clean check variables
-
-# implicit rule/recipe for man page creation
-%.1: %.rst
-	$(RST2MAN) $< $@

--- a/setup.py
+++ b/setup.py
@@ -110,6 +110,26 @@ class Linter(SimpleCommand):
             sys.exit(128)
 
 
+class Man(SimpleCommand):
+    """Build man page"""
+
+    description = 'Build man page.'
+
+    def run(self):
+        if shutil.which("rst2man"):
+            cmd = "rst2man"
+        elif shutil.which("rst2man.py"):
+            cmd = "rst2man.py"
+        else:
+            sys.exit("rst2man not found, I can't build the manpage")
+
+        try:
+            run('{} man/avocado.rst man/avocado.1'.format(cmd), shell=True, check=True)
+        except CalledProcessError as e:
+            print("Failed manpage build: ", e)
+            sys.exit(128)
+
+
 if __name__ == '__main__':
     # Force "make develop" inside the "readthedocs.org" environment
     if os.environ.get("READTHEDOCS") and "install" in sys.argv:
@@ -241,5 +261,6 @@ if __name__ == '__main__':
           test_suite='selftests',
           python_requires='>=3.6',
           cmdclass={'clean': Clean,
-                    'lint': Linter},
+                    'lint': Linter,
+                    'man': Man},
           install_requires=['setuptools'])


### PR DESCRIPTION
Add a new setuptools command to build the avocado manpage independently.

Reference: https://github.com/avocado-framework/avocado/issues/4372