### PR TITLE
Add custom setuptools command for 'develop'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,12 +93,6 @@ clean:
 	$(PYTHON) setup.py clean --all
 
 uninstall:
-	for PLUGIN in $(AVOCADO_OPTIONAL_PLUGINS); do\
-		if test -f $$PLUGIN/Makefile -o -f $$PLUGIN/setup.py; then echo ">> UNLINK $$PLUGIN";\
-			if test -f $$PLUGIN/Makefile; then AVOCADO_DIRNAME=$(AVOCADO_DIRNAME) make -C $$PLUGIN unlink &>/dev/null || echo ">> FAIL $$PLUGIN";\
-			elif test -f $$PLUGIN/setup.py; then cd $$PLUGIN; $(PYTHON) setup.py develop --uninstall $(PYTHON_DEVELOP_ARGS); cd -; fi;\
-		else echo ">> SKIP $$PLUGIN"; fi;\
-	done
 	$(PYTHON) setup.py develop --uninstall $(PYTHON_DEVELOP_ARGS)
 
 requirements-plugins:
@@ -122,12 +116,6 @@ check: clean uninstall develop
 
 develop:
 	$(PYTHON) setup.py develop $(PYTHON_DEVELOP_ARGS)
-	for PLUGIN in $(AVOCADO_OPTIONAL_PLUGINS); do\
-		if test -f $$PLUGIN/Makefile -o -f $$PLUGIN/setup.py; then echo ">> LINK $$PLUGIN";\
-			if test -f $$PLUGIN/Makefile; then AVOCADO_DIRNAME=$(AVOCADO_DIRNAME) make -C $$PLUGIN PYTHON="$(PYTHON)" link &>/dev/null;\
-			elif test -f $$PLUGIN/setup.py; then cd $$PLUGIN; $(PYTHON) setup.py develop $(PYTHON_DEVELOP_ARGS); cd -; fi;\
-		else echo ">> SKIP $$PLUGIN"; fi;\
-	done
 
 develop-external:
 ifndef AVOCADO_EXTERNAL_PLUGINS_PATH

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,14 @@ def get_long_description():
     return readme_contents
 
 
+def walk_plugins_setup_py(action_name="UNNAMED", action="--help"):
+
+    for plugin in list(Path(os.getcwd()).rglob("./optional_plugins/*/setup.py")):
+        parent_dir = plugin.parent
+        print(">> {} {}".format(action_name, parent_dir))
+        run('{} setup.py {}'.format(sys.executable, action),
+            shell=True, cwd=parent_dir, check=True)
+
 class Clean(clean):
     """Our custom command to get rid of junk files after build."""
 
@@ -69,11 +77,7 @@ class Clean(clean):
 
     @staticmethod
     def clean_optional_plugins():
-        for plugin in list(Path(os.getcwd()).rglob("./optional_plugins/*/setup.py")):
-            parent_dir = plugin.parent
-            print(">> CLEANING {}".format(parent_dir))
-            run('{} setup.py clean --all'.format(sys.executable),
-                shell=True, cwd=parent_dir, check=True)
+        walk_plugins_setup_py(action_name="CLEANING", action="clean --all")
 
 
 class SimpleCommand(Command):


### PR DESCRIPTION
Migrate the extra steps of make develop and make uninstall  to be performed by a customized 'develop' command with setuptools.

Reference: https://github.com/avocado-framework/avocado/issues/4372
