### PR TITLE
Config variable for resolvers

### DIFF
--- a/avocado/core/plugin_interfaces.py
+++ b/avocado/core/plugin_interfaces.py
@@ -220,12 +220,13 @@ class Resolver(Plugin):
     """Base plugin interface for resolving test references into resolutions."""
 
     @abc.abstractmethod
-    def resolve(self, reference):
+    def resolve(self, reference, config):
         """Resolves the given reference into a reference resolution.
 
         :param reference: a specification that can eventually be resolved
                           into a test (in the form of a
                           :class:`avocado.core.nrunner.Runnable`)
+        :param config: Avocado configuration
         :type reference: str
         :returns: the result of the resolution process, containing the
                   success, failure or error, along with zero or more
@@ -238,7 +239,7 @@ class Discoverer(Plugin):
     """Base plugin interface for discovering tests without reference."""
 
     @abc.abstractmethod
-    def discover(self):
+    def discover(self, config):
         """Discovers a test resolutions
 
         It will be used when the `test.references` variable is empty, but
@@ -246,6 +247,7 @@ class Discoverer(Plugin):
         resolutions. It work same as the Resolver, but without the test
         reference.
 
+        :param config: Avocado configuration
         :returns: the result of the resolution process, containing the
                   success, failure or error, along with zero or more
                   :class:`avocado.core.nrunner.Runnable` objects

--- a/avocado/core/resolver.py
+++ b/avocado/core/resolver.py
@@ -98,11 +98,11 @@ class Resolver(EnabledExtensionManager):
     def __init__(self):
         super(Resolver, self).__init__('avocado.plugins.resolver')
 
-    def resolve(self, reference):
+    def resolve(self, reference, config):
         resolution = []
         for ext in self.extensions:
             try:
-                result = ext.obj.resolve(reference)
+                result = ext.obj.resolve(reference, config)
                 if not result.origin:
                     result.origin = ext.name
             except Exception as exc:  # pylint: disable=W0703
@@ -130,11 +130,11 @@ class Discoverer(EnabledExtensionManager):
     def __init__(self):
         super(Discoverer, self).__init__('avocado.plugins.discoverer')
 
-    def discover(self):
+    def discover(self, config):
         resolutions = []
         for ext in self.extensions:
             try:
-                results = ext.obj.discover()
+                results = ext.obj.discover(config)
             except Exception as exc:  # pylint: disable=W0703
                 results = [ReferenceResolution('',
                                                ReferenceResolutionResult.ERROR,
@@ -191,7 +191,7 @@ def _extend_directory(path):
     return paths
 
 
-def resolve(references, hint=None, ignore_missing=True):
+def resolve(references, config, hint=None, ignore_missing=True):
     resolutions = []
     hint_resolutions = []
     hint_references = {}
@@ -217,10 +217,10 @@ def resolve(references, hint=None, ignore_missing=True):
             if reference in hint_references:
                 resolutions.append(hint_references[reference])
             else:
-                resolutions.extend(resolver.resolve(reference))
+                resolutions.extend(resolver.resolve(reference, config))
     else:
         discoverer = Discoverer()
-        resolutions.extend(discoverer.discover())
+        resolutions.extend(discoverer.discover(config))
 
     # This came up from a previous method and can be refactored to improve
     # performance since that we could merge with the loop above.

--- a/avocado/core/suite.py
+++ b/avocado/core/suite.py
@@ -169,6 +169,7 @@ class TestSuite:
             if os.path.exists(hint_filepath):
                 hint = HintParser(hint_filepath)
             resolutions = resolve(references,
+                                  config,
                                   hint=hint,
                                   ignore_missing=ignore_missing)
         except JobTestSuiteReferenceResolutionError as details:

--- a/examples/plugins/tests/magic/avocado_magic/resolver.py
+++ b/examples/plugins/tests/magic/avocado_magic/resolver.py
@@ -30,7 +30,7 @@ class MagicResolver(Resolver):
     description = 'Test resolver for magic words'
 
     @staticmethod
-    def resolve(reference):
+    def resolve(reference, config):
         if reference not in VALID_MAGIC_WORDS:
             return ReferenceResolution(
                 reference,
@@ -48,7 +48,7 @@ class MagicDiscoverer(Discoverer):
     description = 'Test discoverer for magic words'
 
     @staticmethod
-    def discover():
+    def discover(config):
         resolutions = []
         for reference in VALID_MAGIC_WORDS:
             resolutions.append(MagicResolver.resolve(reference))

--- a/optional_plugins/golang/avocado_golang/__init__.py
+++ b/optional_plugins/golang/avocado_golang/__init__.py
@@ -226,7 +226,7 @@ class GolangResolver(Resolver):
     description = 'Test resolver for Go language tests'
 
     @staticmethod
-    def resolve(reference):
+    def resolve(reference, config):
 
         if GO_BIN is None:
             return ReferenceResolution(reference,

--- a/optional_plugins/golang/tests/test_golang.py
+++ b/optional_plugins/golang/tests/test_golang.py
@@ -37,12 +37,12 @@ class LoaderResolverModule(unittest.TestCase):
 
     def test_resolver_no_go_bin(self):
         with unittest.mock.patch('avocado_golang.GO_BIN', None):
-            res = avocado_golang.GolangResolver().resolve('countavocados')
+            res = avocado_golang.GolangResolver().resolve('countavocados', {})
         self.assertEqual(res.reference, 'countavocados')
         self.assertEqual(res.result, ReferenceResolutionResult.NOTFOUND)
 
     def test_resolver(self):
-        res = avocado_golang.GolangResolver().resolve('countavocados')
+        res = avocado_golang.GolangResolver().resolve('countavocados', {})
         self.assertEqual(res.result, ReferenceResolutionResult.SUCCESS)
         self.assertEqual(len(res.resolutions), 3)
         empty_container = res.resolutions[0]

--- a/optional_plugins/robot/avocado_robot/__init__.py
+++ b/optional_plugins/robot/avocado_robot/__init__.py
@@ -139,7 +139,7 @@ class RobotResolver(Resolver):
     description = 'Test resolver for Robot Framework tests'
 
     @staticmethod
-    def resolve(reference):
+    def resolve(reference, config):
 
         # It may be possible to have Robot Framework tests in other
         # types of files such as reStructuredText (.rst), but given

--- a/selftests/unit/plugin/test_resolver.py
+++ b/selftests/unit/plugin/test_resolver.py
@@ -37,7 +37,7 @@ class AvocadoInstrumented(unittest.TestCase):
         passtest = os.path.join(BASEDIR, 'examples', 'tests', 'passtest.py')
         test = 'PassTest.test'
         uri = '%s:%s' % (passtest, test)
-        res = AvocadoInstrumentedResolver().resolve(passtest)
+        res = AvocadoInstrumentedResolver().resolve(passtest, {})
         self.assertEqual(res.reference, passtest)
         self.assertEqual(res.result, resolver.ReferenceResolutionResult.SUCCESS)
         self.assertIsNone(res.info)
@@ -54,7 +54,7 @@ class AvocadoInstrumented(unittest.TestCase):
         passtest = os.path.join(BASEDIR, 'examples', 'tests', 'passtest.py')
         test_filter = 'test'
         reference = '%s:%s' % (passtest, test_filter)
-        res = AvocadoInstrumentedResolver().resolve(reference)
+        res = AvocadoInstrumentedResolver().resolve(reference, {})
         self.assertEqual(res.reference, reference)
         self.assertEqual(res.result, resolver.ReferenceResolutionResult.SUCCESS)
         self.assertEqual(len(res.resolutions), 1)
@@ -63,7 +63,7 @@ class AvocadoInstrumented(unittest.TestCase):
         passtest = os.path.join(BASEDIR, 'examples', 'tests', 'passtest.py')
         test_filter = 'test_other'
         reference = '%s:%s' % (passtest, test_filter)
-        res = AvocadoInstrumentedResolver().resolve(reference)
+        res = AvocadoInstrumentedResolver().resolve(reference, {})
         self.assertEqual(res.reference, reference)
         self.assertEqual(res.result, resolver.ReferenceResolutionResult.NOTFOUND)
 
@@ -73,7 +73,7 @@ class ExecTest(unittest.TestCase):
     def test_exec_test(self):
         with script.TemporaryScript('exec-test.sh', "#!/bin/sh\ntrue",
                                     'test_resolver_exec_test') as simple_test:
-            res = ExecTestResolver().resolve(simple_test.path)
+            res = ExecTestResolver().resolve(simple_test.path, {})
             self.assertEqual(res.reference, simple_test.path)
             self.assertEqual(res.result, resolver.ReferenceResolutionResult.SUCCESS)
             self.assertEqual(len(res.resolutions), 1)


### PR DESCRIPTION
The resolvers don't have access to the config variable, and they are
using `settings.as_dict()`. Unfortunately, this method returns only
config from command line and config files. When the configuration is
created by Job API, the `settings.as_dict()` doesn't respect that. This
leads to the incompatibility between resolvers config and suite config
created by `TestSuite.from_config()` in Job API.

This problem was hidden because avocado default resolvers don't need
config for resolving references and `TestSuite.from_config()` rewrites
the runnables config created by resolvers.

It is not such a big problem for avocado default resolvers, but it is a
problem for vt resolver which is using config in resolving process.

Signed-off-by: Jan Richter <jarichte@redhat.com>