### PR TITLE
Docs: Protect formatting inside a Note box, in the Intro guide

### DIFF
--- a/docs/source/guides/user/chapters/introduction.rst
+++ b/docs/source/guides/user/chapters/introduction.rst
@@ -46,7 +46,7 @@ instrumented and simple tests::
 .. note:: Although in most cases running ``avocado run $test1 $test3 ...`` is
           fine, it can lead to argument vs. test name clashes. The safest
           way to execute tests is ``avocado run --$argument1 --$argument2
-          -- $test1 $test2``. Everything after `--` will be considered
+          -- $test1 $test2``. Everything after ``--`` will be considered
           positional arguments, therefore test names (in case of
           ``avocado run``)
 


### PR DESCRIPTION
The missing double-` `` ` fencing around `--` in the Note is causing ReadTheDocs to format `--` as an en dash.