### PR TITLE
Safeloader: support compound, non-relative imports [v2]

### DIFF
--- a/avocado/core/safeloader/core.py
+++ b/avocado/core/safeloader/core.py
@@ -200,7 +200,7 @@ def _examine_class(target_module, target_class, determine_match, path,
     info = []
     disabled = set()
 
-    for klass in module.iter_classes():
+    for klass in module.iter_classes(class_name):
         if class_name != klass.name:
             continue
 
@@ -247,6 +247,23 @@ def _examine_class(target_module, target_class, determine_match, path,
                 disabled.update(_disabled)
             if _match is not match:
                 match = _match
+
+    if not match and module.interesting_klass_found:
+        imported_symbol = module.imported_symbols[class_name]
+        if imported_symbol:
+            found_spec = imported_symbol.get_importable_spec()
+            if found_spec:
+                _info, _disabled, _match = _examine_class(target_module,
+                                                          target_class,
+                                                          determine_match,
+                                                          found_spec.origin,
+                                                          class_name,
+                                                          match)
+                if _info:
+                    _extend_test_list(info, _info)
+                    disabled.update(_disabled)
+                if _match is not match:
+                    match = _match
 
     return info, disabled, match
 

--- a/avocado/core/safeloader/core.py
+++ b/avocado/core/safeloader/core.py
@@ -80,30 +80,60 @@ class ClassNotSuitable(Exception):
 
 
 def _get_attributes_for_further_examination(parent, module):
-    """Returns path, module and class for further examination."""
+    """Returns path, module and class for further examination.
+
+    This looks at one of the parents of an interesting class, so for the
+    example class Test bellow:
+
+    >>> class Test(unittest.TestCase, MixIn):
+    >>>   pass
+
+    This function should be called twice: once for unittest.TestCase,
+    and once for MixIn.
+
+    :param parent: parent is one of the possibly many parents from
+                   which the class being examined inherits from.
+    :type parent: :class:`ast.Attribute`
+    :param module: PythonModule instance with information about the
+                   module being inspected
+    :type module: :class:`avocado.core.safeloader.module.PythonModule`
+    :raises: ClassNotSuitable
+    :returns: the path, module and class name to be further examined
+    :rtype: tuple
+    """
     if hasattr(parent, 'value'):
-        if hasattr(parent.value, 'id'):
+        # A "value" in an "attribute" in this context means that
+        # there's a "module.class" notation.  It may be called that
+        # way, because it resembles "class" being an attribute of the
+        # "module" object.  In short, if "parent" has a "value"
+        # attribute, it means that this is given as a
+        # "module.parent_class" notation, meaning that:
+        # - parent is a module
+        # - parent.value *should* be a class, because there's
+        #   currently no support for the "module.module.parent_class"
+        #   notation.  See issue #4706.
+        klass = parent.value
+        if not hasattr(klass, 'id'):
+            # We don't support multi-level 'parent.parent.Class'
+            raise ClassNotSuitable
+        else:
             # We know 'parent.Class' or 'asparent.Class' and need
             # to get path and original_module_name. Class is given
             # by parent definition.
-            imported_symbol = module.imported_symbols.get(parent.value.id)
+            imported_symbol = module.imported_symbols.get(klass.id)
             if imported_symbol is None:
-                # We can't examine this parent (probably broken
-                # module)
+                # We can't examine this parent (probably broken module)
                 raise ClassNotSuitable
             parent_path = imported_symbol.get_parent_fs_path()
             parent_module = imported_symbol.symbol
             parent_class = parent.attr
-        else:
-            # We don't support multi-level 'parent.parent.Class'
-            raise ClassNotSuitable
     else:
         # We only know 'Class' or 'AsClass' and need to get
         # path, module and original class_name
-        imported_symbol = module.imported_symbols.get(parent.id)
+        klass = parent.id
+        imported_symbol = module.imported_symbols.get(klass)
         if imported_symbol is None:
-            # We can't examine this parent (probably broken
-            # module)
+            # We can't examine this parent (probably broken module)
             raise ClassNotSuitable
         parent_path = imported_symbol.get_compat_parent_path()
         parent_module = imported_symbol.get_compat_module_path()

--- a/avocado/core/safeloader/core.py
+++ b/avocado/core/safeloader/core.py
@@ -1,6 +1,5 @@
 import ast
 import collections
-import os
 import sys
 from importlib.machinery import PathFinder
 
@@ -99,8 +98,12 @@ def _get_attributes_for_further_examination(parent, module):
                    module being inspected
     :type module: :class:`avocado.core.safeloader.module.PythonModule`
     :raises: ClassNotSuitable
-    :returns: the path, module and class name to be further examined
-    :rtype: tuple
+    :returns: a tuple with three values: the class name, the imported
+              symbol instance matching the further examination step,
+              and a hint about the symbol name also being a module.
+    :rtype: tuple of (str,
+            :class:`avocado.core.safeloader.imported.ImportedSymbol`,
+            bool)
     """
     if hasattr(parent, 'value'):
         # A "value" in an "attribute" in this context means that
@@ -126,9 +129,6 @@ def _get_attributes_for_further_examination(parent, module):
                 # We can't examine this parent (probably broken module)
                 raise ClassNotSuitable
 
-            # The values for the most common conditions
-            parent_path = imported_symbol.get_parent_fs_path()
-            parent_module = imported_symbol.symbol
             parent_class = parent.attr
 
             # Special situation: in this case, because we know the parent
@@ -137,20 +137,8 @@ def _get_attributes_for_further_examination(parent, module):
             # *only* about the imports, and not about the class definitions,
             # can not tell if an import is a "from module import other_module"
             # or a "from module import class"
-            module_name_components = imported_symbol.module_name.split('.')
-            last = module_name_components[-1]
-            if klass.id == last:
-                parent_path = os.path.dirname(imported_symbol.importer_fs_path)
-                parent_module = imported_symbol.module_path
+            symbol_is_module = (klass.id == imported_symbol.symbol_name)
 
-            module_path_components = imported_symbol.module_path.strip('.').split('.')
-            # Special situation: if there is more than one component in the
-            # module path, the first one should be added to the path,
-            # so that the last module in the is found by the importlib
-            # machinery, so that the examination can continue on the upper levels
-            if len(module_path_components) > 1:
-                parent_path = os.path.join(parent_path, module_path_components[0])
-                parent_module = module_path_components[-1]
     else:
         # We only know 'Class' or 'AsClass' and need to get
         # path, module and original class_name
@@ -159,11 +147,11 @@ def _get_attributes_for_further_examination(parent, module):
         if imported_symbol is None:
             # We can't examine this parent (probably broken module)
             raise ClassNotSuitable
-        parent_path = imported_symbol.get_compat_parent_path()
-        parent_module = imported_symbol.get_compat_module_path()
-        parent_class = imported_symbol.get_compat_symbol()
 
-    return parent_path, parent_module, parent_class
+        parent_class = imported_symbol.symbol
+        symbol_is_module = False
+
+    return parent_class, imported_symbol, symbol_is_module
 
 
 def _find_import_match(parent_path, parent_module):
@@ -236,11 +224,15 @@ def _examine_class(target_module, target_class, determine_match, path,
         # might be in a different module.
         for parent in parents:
             try:
-                (parent_path,
-                 parent_module,
-                 parent_class) = _get_attributes_for_further_examination(parent,
-                                                                         module)
-                found_spec = _find_import_match(parent_path, parent_module)
+                (parent_class,
+                 imported_symbol,
+                 symbol_is_module) = _get_attributes_for_further_examination(parent,
+                                                                             module)
+
+                found_spec = imported_symbol.get_importable_spec(symbol_is_module)
+                if found_spec is None:
+                    continue
+
             except ClassNotSuitable:
                 continue
 
@@ -334,11 +326,15 @@ def find_python_tests(target_module, target_class, determine_match, path):
         # might be in a different module.
         for parent in parents:
             try:
-                (parent_path,
-                 parent_module,
-                 parent_class) = _get_attributes_for_further_examination(parent,
-                                                                         module)
-                found_spec = _find_import_match(parent_path, parent_module)
+                (parent_class,
+                 imported_symbol,
+                 symbol_is_module) = _get_attributes_for_further_examination(parent,
+                                                                             module)
+
+                found_spec = imported_symbol.get_importable_spec(symbol_is_module)
+                if found_spec is None:
+                    continue
+
             except ClassNotSuitable:
                 continue
 

--- a/avocado/core/safeloader/imported.py
+++ b/avocado/core/safeloader/imported.py
@@ -244,42 +244,6 @@ class ImportedSymbol:
             return os.path.join(parent_path, self.module_path)
         return parent_path
 
-    def get_compat_parent_path(self):
-        """Returns a "parent path" compatible with the path based notation.
-
-        This is intended for temporary compatibility purposes with the
-        single path based notation of keeping track of the path/module/class.
-        """
-        parent_path = self.get_relative_module_fs_path()
-        non_rel_mod_path = self.module_path.strip(".")
-        pure_module_path_to_fs = non_rel_mod_path.replace(".", os.path.sep)
-        if self.symbol:
-            pure_module_path_to_fs = os.path.dirname(pure_module_path_to_fs)
-        return os.path.join(parent_path, pure_module_path_to_fs)
-
-    def get_compat_module_path(self):
-        """Returns a "parent module" compatible with the path based notation.
-
-        This is intended for temporary compatibility purposes with the
-        single path based notation of keeping track of the path/module/class.
-        """
-        non_rel_mod_path = self.module_path.strip(".")
-        split = non_rel_mod_path.rsplit(".", 1)
-        if len(split) > 1:
-            return split[1]
-        return non_rel_mod_path
-
-    def get_compat_symbol(self):
-        """Returns a "parent symbol" compatible with the path based notation.
-
-        This is intended for temporary compatibility purposes with the
-        single path based notation of keeping track of the path/module/class.
-        """
-        split = self.symbol.rsplit(".", 1)
-        if len(split) > 1:
-            return split[1]
-        return self.symbol
-
     def __repr__(self):
         return ('<ImportedSymbol module_path="%s" symbol="%s" '
                 'importer_fs_path="%s">' % (self.module_path,

--- a/avocado/core/safeloader/imported.py
+++ b/avocado/core/safeloader/imported.py
@@ -105,8 +105,8 @@ class ImportedSymbol:
         return symbol, module_path
 
     @classmethod
-    def from_statement(cls, statement, importer_fs_path=None):
-        symbol, module_path = cls.get_symbol_module_path_from_statement(statement)
+    def from_statement(cls, statement, importer_fs_path=None, index=0):
+        symbol, module_path = cls.get_symbol_module_path_from_statement(statement, index)
         return cls(symbol, module_path, importer_fs_path)
 
     def to_str(self):

--- a/avocado/core/safeloader/module.py
+++ b/avocado/core/safeloader/module.py
@@ -100,17 +100,12 @@ class PythonModule:
         """
         Keeps track of symbol names and importable entities
         """
-        for name in statement.names:
+        for index, name in enumerate(statement.names):
             final_name = self._get_name_from_alias_statement(name)
-            # Currently, ImportedSymbol.from_statement() only supports the first
-            # symbol imported in the statement.  That's why where the final_name
-            # is used instead for the symbol, and the (correct) module comes
-            # from its utility method.
-            symbol_name = name.name if name.name else name.asname
-            module_name = ImportedSymbol.get_module_path_from_statement(statement)
-            self.imported_symbols[final_name] = ImportedSymbol(symbol_name,
-                                                               module_name,
-                                                               os.path.abspath(self.path))
+            imported_symbol = ImportedSymbol.from_statement(statement,
+                                                            os.path.abspath(self.path),
+                                                            index)
+            self.imported_symbols[final_name] = imported_symbol
 
     @staticmethod
     def _get_name_from_alias_statement(alias):

--- a/selftests/.data/safeloader/data/imports.py
+++ b/selftests/.data/safeloader/data/imports.py
@@ -50,8 +50,7 @@ class Test8(Class8):
     pass
 
 
-# Incorrect syntax, but detecting is more complicated than necessary
-# as it should fail on load-time... Let's include it.
+# Incorrect syntax, should not be included
 class Test9(AsClass9):
     pass
 

--- a/selftests/functional/test_resolver.py
+++ b/selftests/functional/test_resolver.py
@@ -2,12 +2,12 @@ import stat
 import unittest
 
 from avocado.utils import process, script
-from selftests.utils import AVOCADO
-
 # Use the same definitions from loader to make sure the behavior
 # is also the same
-from .test_loader import AVOCADO_TEST_OK as AVOCADO_INSTRUMENTED_TEST
-from .test_loader import SIMPLE_TEST as EXEC_TEST
+from selftests.functional.test_loader import \
+    AVOCADO_TEST_OK as AVOCADO_INSTRUMENTED_TEST
+from selftests.functional.test_loader import SIMPLE_TEST as EXEC_TEST
+from selftests.utils import AVOCADO
 
 
 class ResolverFunctional(unittest.TestCase):

--- a/selftests/safeloader.sh
+++ b/selftests/safeloader.sh
@@ -10,9 +10,7 @@ function cleanup()
 
 trap cleanup EXIT
 
-# test_safeloader_* are excluded because the refactor exposed them
-# to issue https://github.com/avocado-framework/avocado/issues/4625
-for PYTHON_FILE in $(grep -c -m1 -E 'import unittest$' selftests/unit/test_*.py selftests/unit/utils/test_*.py | grep -v test_safeloader_ | grep -v -E ':0$' | cut -d ':' -f 1); do
+for PYTHON_FILE in $(grep -c -m1 -E 'import unittest$' selftests/unit{,/plugin,/utils}/test_*.py selftests/functional{,/plugin}/test_*.py | grep -v -E ':0$' | cut -d ':' -f 1); do
     echo "*** Checking safeloader on $PYTHON_FILE ***";
     python3 contrib/scripts/find-python-unittest $PYTHON_FILE > $SAFELOADER_OUTPUT;
     AVOCADO_SAFELOADER_UNITTEST_ORDER_COMPAT=1 python3 contrib/scripts/avocado-safeloader-find-python-unittest $PYTHON_FILE > $DEFAULT_LOADER_OUTPUT;

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -382,7 +382,17 @@ class LoaderTest(unittest.TestCase):
         path = os.path.join(os.path.dirname(os.path.dirname(__file__)),
                             '.data', 'safeloader', 'data', 'dont_detect_non_avocado.py')
         tests = self.loader.discover(path)
-        self._check_discovery([], tests)
+        exps = [(test.PythonUnittest,
+                 'dont_detect_non_avocado.StaticallyNotAvocadoTest.test'),
+                (test.PythonUnittest,
+                 'dont_detect_non_avocado.StaticallyNotAvocadoTest.teststmpdir'),
+                (test.PythonUnittest,
+                 'dont_detect_non_avocado.NotTest.test2'),
+                (test.PythonUnittest,
+                 'dont_detect_non_avocado.NotTest.test'),
+                (test.PythonUnittest,
+                 'dont_detect_non_avocado.NotTest.teststmpdir')]
+        self._check_discovery(exps, tests)
 
     def test_infinite_recurse(self):
         """Checks we don't crash on infinite recursion"""

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -375,7 +375,6 @@ class LoaderTest(unittest.TestCase):
                 ('Test5', 'selftests/.data/safeloader/data/imports.py:Test5.test'),
                 ('Test6', 'selftests/.data/safeloader/data/imports.py:Test6.test'),
                 ('Test8', 'selftests/.data/safeloader/data/imports.py:Test8.test'),
-                ('Test9', 'selftests/.data/safeloader/data/imports.py:Test9.test'),
                 ('Test10', 'selftests/.data/safeloader/data/imports.py:Test10.test')]
         self._check_discovery(exps, tests)
 

--- a/selftests/unit/test_safeloader_core.py
+++ b/selftests/unit/test_safeloader_core.py
@@ -7,8 +7,7 @@ from collections import OrderedDict
 from avocado.core.safeloader.core import (find_avocado_tests,
                                           find_python_unittests)
 from avocado.utils import script
-
-from ..utils import TestCaseTmpDir, setup_avocado_loggers
+from selftests.utils import TestCaseTmpDir, setup_avocado_loggers
 
 setup_avocado_loggers()
 

--- a/selftests/unit/test_safeloader_imported.py
+++ b/selftests/unit/test_safeloader_imported.py
@@ -186,3 +186,39 @@ class ParentPath(unittest.TestCase):
                                                importer)
         self.assertEqual(symbol.get_parent_fs_path(),
                          "/abs/fs/location/of")
+
+
+class Importable(unittest.TestCase):
+
+    def test_single(self):
+        imported_symbol = ImportedSymbol("avocado", "", __file__)
+        self.assertTrue(imported_symbol.is_importable())
+
+    def test_compound(self):
+        imported_symbol = ImportedSymbol("avocado.utils",
+                                         "software_manager",
+                                         __file__)
+        self.assertTrue(imported_symbol.is_importable(True))
+
+    def test_compound_dont_know_if_symbol_is_module(self):
+        imported_symbol = ImportedSymbol("avocado.utils",
+                                         "BaseClass",
+                                         __file__)
+        self.assertTrue(imported_symbol.is_importable(False))
+
+    def test_non_existing_module(self):
+        imported_symbol = ImportedSymbol("avocado.utils",
+                                         "non_existing_symbol",
+                                         __file__)
+        self.assertFalse(imported_symbol.is_importable(True))
+
+    def test_non_existing_symbol(self):
+        imported_symbol = ImportedSymbol("non_existing_module", "",
+                                         __file__)
+        self.assertFalse(imported_symbol.is_importable())
+
+    def test_non_existing_module_path(self):
+        imported_symbol = ImportedSymbol("avocado.utils.non_existing",
+                                         "",
+                                         __file__)
+        self.assertFalse(imported_symbol.is_importable())

--- a/selftests/unit/test_safeloader_imported.py
+++ b/selftests/unit/test_safeloader_imported.py
@@ -103,6 +103,33 @@ class SymbolAndModulePathImportFrom(SymbolAndModulePathCommon):
                     "from ..selftests.utils import mod")
 
 
+class Alias(unittest.TestCase):
+
+    def test_module_alias(self):
+        statement = ast.parse("import os as operatingsystem").body[0]
+        imported_symbol = ImportedSymbol.from_statement(statement)
+        self.assertEqual(imported_symbol.module_path, "os")
+        self.assertEqual(imported_symbol.module_name, "operatingsystem")
+
+    def test_module_noalias(self):
+        statement = ast.parse("import os").body[0]
+        imported_symbol = ImportedSymbol.from_statement(statement)
+        self.assertEqual(imported_symbol.module_path, "os")
+        self.assertEqual(imported_symbol.module_name, "os")
+
+    def test_symbol_alias(self):
+        statement = ast.parse("from os import path as os_path").body[0]
+        imported_symbol = ImportedSymbol.from_statement(statement)
+        self.assertEqual(imported_symbol.symbol, "path")
+        self.assertEqual(imported_symbol.symbol_name, "os_path")
+
+    def test_symbol_noalias(self):
+        statement = ast.parse("from os import path").body[0]
+        imported_symbol = ImportedSymbol.from_statement(statement)
+        self.assertEqual(imported_symbol.symbol, "path")
+        self.assertEqual(imported_symbol.symbol_name, "path")
+
+
 class SymbolAndModulePathErrors(unittest.TestCase):
 
     def test_incorrect_statement_type(self):

--- a/spell.ignore
+++ b/spell.ignore
@@ -745,3 +745,4 @@ libcap
 GiB
 jarichte
 teststatus
+importlib


### PR DESCRIPTION
Among other things, this supports compound import statements with non-relative imports.

It fixes #4625, and greatly extends the coverage of the safeloader by comparing every single Python unittest in our tree with the native (load/executable) approach of the `unittest` library.

At least two other bugs have been found and fixed too (info in the respective commits).

---

Changes from v1 (#4712):
 * New commit addressing issue #4611
 * Improved commit message on previous `ImportedSymbol.from_statement()` limitation
 * Removed all methods from `ImportedSymbol` that were required for compatibility with the filesystem-like method of keeping track of path/module/class imports. 