### PR TITLE
Forcing python3 as default environment alias

### DIFF
--- a/contrib/job-scripts/coredump-handling/post.d/002-link-core-to-tests
+++ b/contrib/job-scripts/coredump-handling/post.d/002-link-core-to-tests
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/contrib/scripts/avocado-get-job-results-dir.py
+++ b/contrib/scripts/avocado-get-job-results-dir.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/contrib/scripts/avocado-safeloader-find-avocado-instrumented
+++ b/contrib/scripts/avocado-safeloader-find-avocado-instrumented
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/contrib/scripts/avocado-safeloader-find-python-unittest
+++ b/contrib/scripts/avocado-safeloader-find-python-unittest
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/contrib/scripts/find-python-unittest
+++ b/contrib/scripts/find-python-unittest
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/contrib/scripts/summarize-job-failures.py
+++ b/contrib/scripts/summarize-job-failures.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Script supposed to be given paths to "results.json" files with same set

--- a/contrib/scripts/vmimage-populate-cache.py
+++ b/contrib/scripts/vmimage-populate-cache.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Script that downloads cloud images via avocado.utils.vmimage

--- a/docs/source/guides/writer/chapters/writing.rst
+++ b/docs/source/guides/writer/chapters/writing.rst
@@ -504,7 +504,7 @@ say you want to pick up a test suite written in C that it is in a tarball,
 uncompress it, compile the suite code, and then executing the test. Here's
 an example that does that::
 
-        #!/usr/bin/env python
+        #!/usr/bin/env python3
 
         import os
 

--- a/examples/tests/synctest.py
+++ b/examples/tests/synctest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 

--- a/examples/tests/whiteboard.py
+++ b/examples/tests/whiteboard.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import base64
 

--- a/optional_plugins/golang/setup.py
+++ b/optional_plugins/golang/setup.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/bin/env python3
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or

--- a/optional_plugins/html/setup.py
+++ b/optional_plugins/html/setup.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/bin/env python3
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or

--- a/optional_plugins/result_upload/setup.py
+++ b/optional_plugins/result_upload/setup.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/bin/env python3
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or

--- a/optional_plugins/resultsdb/setup.py
+++ b/optional_plugins/resultsdb/setup.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/bin/env python3
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or

--- a/optional_plugins/robot/setup.py
+++ b/optional_plugins/robot/setup.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/bin/env python3
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or

--- a/optional_plugins/varianter_cit/setup.py
+++ b/optional_plugins/varianter_cit/setup.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/bin/env python3
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or

--- a/optional_plugins/varianter_pict/setup.py
+++ b/optional_plugins/varianter_pict/setup.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/bin/env python3
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or

--- a/optional_plugins/varianter_yaml_to_mux/setup.py
+++ b/optional_plugins/varianter_yaml_to_mux/setup.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/bin/env python3
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or

--- a/scripts/avocado-run-testplan
+++ b/scripts/avocado-run-testplan
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/selftests/.data/unittests.py
+++ b/selftests/.data/unittests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import unittest
 
 

--- a/selftests/.data/whiteboard.py
+++ b/selftests/.data/whiteboard.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import base64
 

--- a/selftests/check_tmp_dirs
+++ b/selftests/check_tmp_dirs
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/selftests/run
+++ b/selftests/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 __author__ = 'Lucas Meneghel Rodrigues <lmr@redhat.com>'

--- a/selftests/unit/utils/test_diff_validator.py
+++ b/selftests/unit/utils/test_diff_validator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import tempfile

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/bin/env python3
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or


### PR DESCRIPTION
We are using python3 as dependency, and some distributions don't have 'python' symlink. Let's use python3 for all envs.

Signed-off-by: Beraldo Leal <bleal@redhat.com>