### PR TITLE
Add custom setuptools command for 'develop' and 'develop-external' - v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,12 +92,6 @@ clean:
 	$(PYTHON) setup.py clean --all
 
 uninstall:
-	for PLUGIN in $(AVOCADO_OPTIONAL_PLUGINS); do\
-		if test -f $$PLUGIN/Makefile -o -f $$PLUGIN/setup.py; then echo ">> UNLINK $$PLUGIN";\
-			if test -f $$PLUGIN/Makefile; then AVOCADO_DIRNAME=$(AVOCADO_DIRNAME) make -C $$PLUGIN unlink &>/dev/null || echo ">> FAIL $$PLUGIN";\
-			elif test -f $$PLUGIN/setup.py; then cd $$PLUGIN; $(PYTHON) setup.py develop --uninstall $(PYTHON_DEVELOP_ARGS); cd -; fi;\
-		else echo ">> SKIP $$PLUGIN"; fi;\
-	done
 	$(PYTHON) setup.py develop --uninstall $(PYTHON_DEVELOP_ARGS)
 
 requirements-plugins:
@@ -121,12 +115,6 @@ check: clean uninstall develop
 
 develop:
 	$(PYTHON) setup.py develop $(PYTHON_DEVELOP_ARGS)
-	for PLUGIN in $(AVOCADO_OPTIONAL_PLUGINS); do\
-		if test -f $$PLUGIN/Makefile -o -f $$PLUGIN/setup.py; then echo ">> LINK $$PLUGIN";\
-			if test -f $$PLUGIN/Makefile; then AVOCADO_DIRNAME=$(AVOCADO_DIRNAME) make -C $$PLUGIN PYTHON="$(PYTHON)" link &>/dev/null;\
-			elif test -f $$PLUGIN/setup.py; then cd $$PLUGIN; $(PYTHON) setup.py develop $(PYTHON_DEVELOP_ARGS); cd -; fi;\
-		else echo ">> SKIP $$PLUGIN"; fi;\
-	done
 
 develop-external:
 ifndef AVOCADO_EXTERNAL_PLUGINS_PATH

--- a/Makefile
+++ b/Makefile
@@ -120,12 +120,7 @@ develop-external:
 ifndef AVOCADO_EXTERNAL_PLUGINS_PATH
 	$(error AVOCADO_EXTERNAL_PLUGINS_PATH is not defined)
 endif
-	for PLUGIN in $(shell find $(AVOCADO_EXTERNAL_PLUGINS_PATH) -maxdepth 1 -mindepth 1 -type d); do\
-		if test -f $$PLUGIN/Makefile -o -f $$PLUGIN/setup.py; then echo ">> LINK $$PLUGIN";\
-			if test -f $$PLUGIN/Makefile; then AVOCADO_DIRNAME=$(AVOCADO_DIRNAME) make -C $$PLUGIN PYTHON="$(PYTHON)" link &>/dev/null || echo ">> FAIL $$PLUGIN";\
-			elif test -f $$PLUGIN/setup.py; then cd $$PLUGIN; $(PYTHON) setup.py develop $(PYTHON_DEVELOP_ARGS); cd -; fi;\
-		else echo ">> SKIP $$PLUGIN"; fi;\
-	done
+	$(PYTHON) setup.py developexternal $(PYTHON_DEVELOP_ARGS)
 
 man: man/avocado.1
 

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,15 @@ def get_long_description():
     return readme_contents
 
 
+def walk_plugins_setup_py(action_name="UNNAMED", action=None,
+                          directory=os.path.join(BASE_PATH, "optional_plugins")):
+
+    for plugin in list(Path(directory).rglob("*/setup.py")):
+        parent_dir = plugin.parent
+        print(">> {} {}".format(action_name, parent_dir))
+        run([sys.executable, "setup.py"] + action, cwd=parent_dir, check=True)
+
+
 class Clean(clean):
     """Our custom command to get rid of junk files after build."""
 
@@ -69,11 +78,7 @@ class Clean(clean):
 
     @staticmethod
     def clean_optional_plugins():
-        for plugin in list(Path(os.getcwd()).rglob("./optional_plugins/*/setup.py")):
-            parent_dir = plugin.parent
-            print(">> CLEANING {}".format(parent_dir))
-            run('{} setup.py clean --all'.format(sys.executable),
-                shell=True, cwd=parent_dir, check=True)
+        walk_plugins_setup_py(action_name="CLEANING", action=["clean", "--all"])
 
 
 class SimpleCommand(Command):

--- a/setup.py
+++ b/setup.py
@@ -104,6 +104,26 @@ class Develop(setuptools.command.develop.develop):
             super().run()
 
 
+class DevelopExternal(setuptools.command.develop.develop):
+    """Install Avocado's external plugins in develop mode.."""
+
+    description = "Install Avocado's external plugins in develop mode. \
+                   You need to set AVOCADO_EXTERNAL_PLUGINS_PATH."
+
+    def run(self):
+
+        d = os.getenv('AVOCADO_EXTERNAL_PLUGINS_PATH')
+
+        if (d is None or not os.path.exists(d)):
+            sys.exit("The variable AVOCADO_EXTERNAL_PLUGINS_PATH isn't properly set")
+
+        if not os.path.isabs(d):
+            d = os.path.abspath(d)
+
+        if self.user:
+            walk_plugins_setup_py(action_name="LINK", action=["develop", "--user"], directory=d)
+
+
 class SimpleCommand(Command):
     """Make Command implementation simpler."""
 
@@ -290,6 +310,7 @@ if __name__ == '__main__':
           python_requires='>=3.6',
           cmdclass={'clean': Clean,
                     'develop': Develop,
+                    'developexternal': DevelopExternal,
                     'lint': Linter,
                     'man': Man},
           install_requires=['setuptools'])

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ from distutils.command.clean import clean
 from pathlib import Path
 from subprocess import CalledProcessError, check_call, run
 
+import setuptools.command.develop
 from setuptools import Command, find_packages, setup
 
 # pylint: disable=E0611
@@ -79,6 +80,28 @@ class Clean(clean):
     @staticmethod
     def clean_optional_plugins():
         walk_plugins_setup_py(action_name="CLEANING", action=["clean", "--all"])
+
+
+class Develop(setuptools.command.develop.develop):
+    """Custom develop command."""
+
+    def run(self):
+
+        # python setup.py develop --user --uninstall
+        # we uninstall the plugins before uninstalling avocado
+        if self.user and not self.uninstall:
+            super().run()
+            walk_plugins_setup_py(action_name="LINK", action=["develop", "--user"])
+
+        # python setup.py develop --user
+        # we install the plugins after installing avocado
+        elif self.user and self.uninstall:
+            walk_plugins_setup_py(action_name="UNLINK", action=["develop", "--uninstall", "--user"])
+            super().run()
+
+        # other cases: do nothing and call parent function
+        else:
+            super().run()
 
 
 class SimpleCommand(Command):
@@ -266,6 +289,7 @@ if __name__ == '__main__':
           test_suite='selftests',
           python_requires='>=3.6',
           cmdclass={'clean': Clean,
+                    'develop': Develop,
                     'lint': Linter,
                     'man': Man},
           install_requires=['setuptools'])


### PR DESCRIPTION
This is a v2 of https://github.com/avocado-framework/avocado/pull/4711

Migrate the extra steps of:
* `make develop`
* `make develop`
* `make develop-external`
to be performed by a customized 'develop' and 'developexternal' commands with setuptools.

