### PR TITLE
core.main: Handling KeyboardInterrupt on early stages v2

### DIFF
--- a/avocado/core/main.py
+++ b/avocado/core/main.py
@@ -19,6 +19,7 @@ import time
 import traceback
 
 try:
+    from avocado.core import exit_codes
     from avocado.core.settings import settings
 except ImportError:
     sys.stderr.write("Unable to import Avocado libraries, please verify "
@@ -53,15 +54,13 @@ def handle_exception(*exc_info):
     os.close(tmp)
     if exc_info[0] is KeyboardInterrupt:
         msg = "%s\nYou can find details in %s\n" % (exc_info[0].__doc__, name)
-        exit_code = 8
+        exit_code = exit_codes.AVOCADO_JOB_INTERRUPTED
     else:
         # Print friendly message in console-like output
         msg = ("Avocado crashed unexpectedly: %s\nYou can find details in %s\n"
                % (exc_info[1], name))
-        exit_code = -1
+        exit_code = exit_codes.AVOCADO_GENERIC_CRASH
     os.write(2, msg.encode('utf-8'))
-    # This exit code is replicated from avocado/core/exit_codes.py and not
-    # imported because we are dealing with import failures
     sys.exit(exit_code)
 
 

--- a/avocado/core/main.py
+++ b/avocado/core/main.py
@@ -51,13 +51,18 @@ def handle_exception(*exc_info):
     tmp, name = tempfile.mkstemp(".log", prefix, get_crash_dir())
     os.write(tmp, msg.encode('utf-8'))
     os.close(tmp)
-    # Print friendly message in console-like output
-    msg = ("Avocado crashed unexpectedly: %s\nYou can find details in %s\n"
-           % (exc_info[1], name))
+    if exc_info[0] is KeyboardInterrupt:
+        msg = "%s\nYou can find details in %s\n" % (exc_info[0].__doc__, name)
+        exit_code = 8
+    else:
+        # Print friendly message in console-like output
+        msg = ("Avocado crashed unexpectedly: %s\nYou can find details in %s\n"
+               % (exc_info[1], name))
+        exit_code = -1
     os.write(2, msg.encode('utf-8'))
     # This exit code is replicated from avocado/core/exit_codes.py and not
     # imported because we are dealing with import failures
-    sys.exit(-1)
+    sys.exit(exit_code)
 
 
 def main():


### PR DESCRIPTION
When the SIGINT is sent to the avocado in the early stages the avocado
will crash. This will compare if the exception is a KeyboardInterrupt and
avoid a generic message, since it was intentional. Fixes #4613.

Signed-off-by: Beraldo Leal <bleal@redhat.com>

### Changes from v1:

 - Added a new line
 - Using class object instead of class name
 - Exit code now is  `AVOCADO_JOB_INTERRUPTED` 