### PR TITLE
Whiteboard results fix

### DIFF
--- a/avocado/core/messages.py
+++ b/avocado/core/messages.py
@@ -300,8 +300,14 @@ class WhiteboardMessageHandler(BaseRunningMessageHandler):
     """
 
     def handle(self, message, task, job):
-        self._save_message_to_file('whiteboard', message['log'], task,
-                                   message.get('encoding', None))
+        encoding = message.get('encoding', 'utf-8')
+        whiteboard = task.metadata.get('whiteboard', '')
+        whiteboard += message['log'].decode(encoding)
+        task.metadata['whiteboard'] = whiteboard
+        self._save_message_to_file('whiteboard',
+                                   message['log'],
+                                   task,
+                                   encoding)
 
 
 class FileMessageHandler(BaseRunningMessageHandler):


### PR DESCRIPTION
When the avocado receives a whiteboard message from runner. The
whiteboard is saved to the file, but it is not saved to the test
results. Because of this problem, the result plugins such as
`JSONResult` don't have access to the whiteboard value.

Reference: #4717
Signed-off-by: Jan Richter <jarichte@redhat.com>