### PR TITLE
Add custom setuptools command for 'develop' (v3)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -53,15 +53,6 @@ debian_egg_task:
           - image: ubuntu:18.04
           - image: ubuntu:20.04
 
-windows_smokecheck_task:
-    version_script:
-       - choco install -y python3 --version 3.9.0
-       - C:\Python39\python setup.py develop --user
-       - C:\Python39\python -m avocado --help
-       - C:\Python39\python -m avocado run --test-runner=nrunner examples\tests\passtest.py
-    windows_container:
-       image: cirrusci/windowsservercore:2019
-
 fedora_selftests_task:
     selftests_script:
        - make develop

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -26,7 +26,7 @@ redhat_egg_task:
 
 debian_version_task:
     version_script:
-       - python3 --version || (apt update && apt -y install python3 python3-setuptools)
+       - python3 --version || (apt update && apt -y install python3 python3-setuptools ca-certificates)
        - python3 setup.py develop --user
        - python3 -m avocado --version
 

--- a/Makefile
+++ b/Makefile
@@ -122,12 +122,7 @@ develop-external:
 ifndef AVOCADO_EXTERNAL_PLUGINS_PATH
 	$(error AVOCADO_EXTERNAL_PLUGINS_PATH is not defined)
 endif
-	for PLUGIN in $(shell find $(AVOCADO_EXTERNAL_PLUGINS_PATH) -maxdepth 1 -mindepth 1 -type d); do\
-		if test -f $$PLUGIN/Makefile -o -f $$PLUGIN/setup.py; then echo ">> LINK $$PLUGIN";\
-			if test -f $$PLUGIN/Makefile; then AVOCADO_DIRNAME=$(AVOCADO_DIRNAME) make -C $$PLUGIN PYTHON="$(PYTHON)" link &>/dev/null || echo ">> FAIL $$PLUGIN";\
-			elif test -f $$PLUGIN/setup.py; then cd $$PLUGIN; $(PYTHON) setup.py develop $(PYTHON_DEVELOP_ARGS); cd -; fi;\
-		else echo ">> SKIP $$PLUGIN"; fi;\
-	done
+	$(PYTHON) setup.py develop $(PYTHON_DEVELOP_ARGS) --external
 
 man: man/avocado.1
 

--- a/Makefile
+++ b/Makefile
@@ -94,12 +94,6 @@ clean:
 	$(PYTHON) setup.py clean --all
 
 uninstall:
-	for PLUGIN in $(AVOCADO_OPTIONAL_PLUGINS); do\
-		if test -f $$PLUGIN/Makefile -o -f $$PLUGIN/setup.py; then echo ">> UNLINK $$PLUGIN";\
-			if test -f $$PLUGIN/Makefile; then AVOCADO_DIRNAME=$(AVOCADO_DIRNAME) make -C $$PLUGIN unlink &>/dev/null || echo ">> FAIL $$PLUGIN";\
-			elif test -f $$PLUGIN/setup.py; then cd $$PLUGIN; $(PYTHON) setup.py develop --uninstall $(PYTHON_DEVELOP_ARGS); cd -; fi;\
-		else echo ">> SKIP $$PLUGIN"; fi;\
-	done
 	$(PYTHON) setup.py develop --uninstall $(PYTHON_DEVELOP_ARGS)
 
 requirements-plugins:
@@ -123,12 +117,6 @@ check: clean uninstall develop
 
 develop:
 	$(PYTHON) setup.py develop $(PYTHON_DEVELOP_ARGS)
-	for PLUGIN in $(AVOCADO_OPTIONAL_PLUGINS); do\
-		if test -f $$PLUGIN/Makefile -o -f $$PLUGIN/setup.py; then echo ">> LINK $$PLUGIN";\
-			if test -f $$PLUGIN/Makefile; then AVOCADO_DIRNAME=$(AVOCADO_DIRNAME) make -C $$PLUGIN PYTHON="$(PYTHON)" link &>/dev/null;\
-			elif test -f $$PLUGIN/setup.py; then cd $$PLUGIN; $(PYTHON) setup.py develop $(PYTHON_DEVELOP_ARGS); cd -; fi;\
-		else echo ">> SKIP $$PLUGIN"; fi;\
-	done
 
 develop-external:
 ifndef AVOCADO_EXTERNAL_PLUGINS_PATH

--- a/setup.py
+++ b/setup.py
@@ -178,7 +178,7 @@ class Man(SimpleCommand):
             sys.exit("rst2man not found, I can't build the manpage")
 
         try:
-            run('{} man/avocado.rst man/avocado.1'.format(cmd), shell=True, check=True)
+            run([cmd, "man/avocado.rst", "man/avocado.1"], check=True)
         except CalledProcessError as e:
             print("Failed manpage build: ", e)
             sys.exit(128)

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ from distutils.command.clean import clean
 from pathlib import Path
 from subprocess import CalledProcessError, check_call, run
 
+import setuptools.command.develop
 from setuptools import Command, find_packages, setup
 
 # pylint: disable=E0611
@@ -79,6 +80,29 @@ class Clean(clean):
     @staticmethod
     def clean_optional_plugins():
         walk_plugins_setup_py(action_name="CLEANING", action=["clean", "--all"])
+
+
+class Develop(setuptools.command.develop.develop):
+    """Custom develop command."""
+
+    def run(self):
+
+        # python setup.py develop --user --uninstall
+        # we uninstall the plugins before uninstalling avocado
+        if self.user and not self.external:
+            if not self.uninstall:
+                super().run()
+                walk_plugins_setup_py(action_name="LINK", action=["develop", "--user"])
+
+        # python setup.py develop --user
+        # we install the plugins after installing avocado
+            elif self.uninstall:
+                walk_plugins_setup_py(action_name="UNLINK", action=["develop", "--uninstall", "--user"])
+                super().run()
+
+        # other cases: do nothing and call parent function
+        else:
+            super().run()
 
 
 class SimpleCommand(Command):
@@ -267,6 +291,7 @@ if __name__ == '__main__':
           test_suite='selftests',
           python_requires='>=3.6',
           cmdclass={'clean': Clean,
+                    'develop': Develop,
                     'lint': Linter,
                     'man': Man},
           install_requires=['setuptools'])

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,15 @@ def get_long_description():
     return readme_contents
 
 
+def walk_plugins_setup_py(action_name="UNNAMED", action=None,
+                          directory=os.path.join(BASE_PATH, "optional_plugins")):
+
+    for plugin in list(Path(directory).glob("*/setup.py")):
+        parent_dir = plugin.parent
+        print(">> {} {}".format(action_name, parent_dir))
+        run([sys.executable, "setup.py"] + action, cwd=parent_dir, check=True)
+
+
 class Clean(clean):
     """Our custom command to get rid of junk files after build."""
 
@@ -69,11 +78,7 @@ class Clean(clean):
 
     @staticmethod
     def clean_optional_plugins():
-        for plugin in list(Path(os.getcwd()).rglob("./optional_plugins/*/setup.py")):
-            parent_dir = plugin.parent
-            print(">> CLEANING {}".format(parent_dir))
-            run('{} setup.py clean --all'.format(sys.executable),
-                shell=True, cwd=parent_dir, check=True)
+        walk_plugins_setup_py(action_name="CLEANING", action=["clean", "--all"])
 
 
 class SimpleCommand(Command):


### PR DESCRIPTION
Changes from v3 of https://github.com/avocado-framework/avocado/pull/4725

* Add the option --external to develop that will install and  uninstall external plugins.
* extra ball: Use the list-based version of run() for the manpage command, so there is no need for a shell.

