### PR TITLE
Avocado CI checks: add weekly GHA and update cirrus

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,8 +5,8 @@ redhat_version_task:
        - python3 -m avocado --version
     container:
         matrix:
-          - image: fedora:32
           - image: fedora:33
+          - image: fedora:34
           - image: registry.access.redhat.com/ubi8/ubi
 
 redhat_egg_task:
@@ -20,7 +20,6 @@ redhat_egg_task:
        - python3 -c 'import sys; from pkg_resources import require; require("avocado-framework"); from avocado.core.main import main; sys.exit(main())' run /bin/true
     container:
         matrix:
-          - image: fedora:32
           - image: fedora:33
           - image: fedora:34
           - image: registry.access.redhat.com/ubi8/ubi
@@ -33,8 +32,8 @@ debian_version_task:
 
     container:
         matrix:
-          - image: debian:10.9
-          - image: debian:bullseye-20210511
+          - image: debian:10.10
+          - image: debian:bullseye-20210621
           - image: ubuntu:18.04
           - image: ubuntu:20.04
 
@@ -49,8 +48,8 @@ debian_egg_task:
        - python3 -c 'import sys; from pkg_resources import require; require("avocado-framework"); from avocado.core.main import main; sys.exit(main())' run /bin/true
     container:
         matrix:
-          - image: debian:10.9
-          - image: debian:bullseye-20210511
+          - image: debian:10.10
+          - image: debian:bullseye-20210621
           - image: ubuntu:18.04
           - image: ubuntu:20.04
 
@@ -69,5 +68,4 @@ fedora_selftests_task:
        - PATH=$HOME/.local/bin:$PATH LANG=en_US.UTF-8 AVOCADO_CHECK_LEVEL=0 python3 selftests/check.py --disable-static-checks
     container:
         matrix:
-          - image: quay.io/avocado-framework/avocado-ci-fedora-32
           - image: quay.io/avocado-framework/avocado-ci-fedora-33

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -1,0 +1,50 @@
+name: Weekly tests
+
+on:
+# Runs at 5:00 UTC on Mondays
+  schedule:
+    - cron: "0 5 * * 1"
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+
+  latest-python:
+    name: Linux with Python ${{ matrix.python-version }}
+    runs-on: ubuntu-20.04
+
+    strategy:
+      matrix:
+        # see list of available Python versions at https://github.com/actions/python-versions/blob/main/versions-manifest.json
+        python-version: [3.10.0-beta.3]
+      fail-fast: false
+
+    steps:
+      - run: echo "Job triggered by a ${{ github.event_name }} event on branch is ${{ github.ref }} in repository is ${{ github.repository }}, runner on ${{ runner.os }}"
+      - name: Check out repository code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+      - name: Install dependencies
+        run: pip install -r requirements-selftests.txt
+      - name: Installing Avocado in develop mode
+        run: python3 setup.py develop --user
+      - name: Avocado version
+        run: avocado --version
+      - name: Avocado smoketest
+        run: python -m avocado run passtest.py
+      - name: Quick lint checks
+        run: python setup.py lint
+      - name: Tree static check, unittests and fast functional tests
+        env:
+          AVOCADO_LOG_DEBUG: "yes"
+          AVOCADO_CHECK_LEVEL: "1"
+        run: make check
+      - run: echo "🥑 This job's status is ${{ job.status }}."


### PR DESCRIPTION
Add an initial weekly workflow testing with latest development Python. It'll run on Mondays at 5:00 UTC.