### PR TITLE
Pass user to scp command

### DIFF
--- a/avocado/utils/ssh.py
+++ b/avocado/utils/ssh.py
@@ -253,7 +253,10 @@ class Session:
             cmd = path_utils.find_command('scp')
         except path_utils.CmdNotFoundError as exc:
             raise exc
-        options = self._dash_o_opts_to_str(self.DEFAULT_OPTIONS)
+        options = list(self.DEFAULT_OPTIONS)
+        if self.user is not None:  # Prevent failure from unspecified user
+            options.append(("User", self.user))
+        options = self._dash_o_opts_to_str(options)
         if recursive:
             options += ' -r'
         options += " {} {}".format(source, destination)


### PR DESCRIPTION
When the user being used for ssh is different from the currently
logged in user, scp will stop and ask for a password because it
cannot find the ControlPath. Specifying the user solves this issue.

Signed-off-by: Jacob Root <otis@otisroot.com>