### PR TITLE
Better handling of avocado temporal files during selftests - v2

### DIFF
--- a/avocado/core/runners/avocado_instrumented.py
+++ b/avocado/core/runners/avocado_instrumented.py
@@ -117,7 +117,7 @@ class AvocadoInstrumentedTestRunner(nrunner.BaseRunner):
                              'modulePath': module_path,
                              'params': (params, ["/"]),
                              'tags': runnable.tags,
-                             'run.results_dir': tempfile.mkdtemp(),
+                             'run.results_dir': tempfile.mkdtemp(prefix=".avocado-task"),
                              }]
 
             AvocadoInstrumentedTestRunner._start_logging(runnable, queue)

--- a/optional_plugins/robot/avocado_robot/runner.py
+++ b/optional_plugins/robot/avocado_robot/runner.py
@@ -31,7 +31,7 @@ class RobotRunner(nrunner.BaseRunner):
     def _run(self, uri, queue):
         stdout = io.StringIO()
         stderr = io.StringIO()
-        output_dir = tempfile.mkdtemp()
+        output_dir = tempfile.mkdtemp(prefix=".avocado-robot")
         file_name, suit_test = uri.split(':', 1)
         suite_name, test_name = suit_test.split('.', 1)
         native_robot_result = run(file_name,

--- a/selftests/functional/plugin/test_assets.py
+++ b/selftests/functional/plugin/test_assets.py
@@ -72,7 +72,7 @@ class AssetsFetchSuccess(TestCaseTmpDir):
             locations='https://mirrors.kernel.org/gnu/hello/hello-2.9.tar.gz')
         """
         test_content = TEST_TEMPLATE.format(content=fetch_content)
-        test_file = tempfile.NamedTemporaryFile(suffix=".py", delete=False)
+        test_file = tempfile.NamedTemporaryFile(suffix=".py", dir=self.base_dir.name, delete=False)
         test_file.write(test_content.encode())
         test_file.close()
 
@@ -119,7 +119,7 @@ class AssetsFetchSuccess(TestCaseTmpDir):
     def test_asset_purge(self):
         """Make sure that we can remove a asset from cache."""
         # creates a single byte asset
-        asset_file = tempfile.NamedTemporaryFile(delete=False)
+        asset_file = tempfile.NamedTemporaryFile(dir=self.base_dir.name, delete=False)
         asset_file.write(b'\xff')
         asset_file.close()
 
@@ -162,7 +162,7 @@ class AssetsFetchSuccess(TestCaseTmpDir):
     def test_asset_purge_by_overall_cache_size(self):
         """Make sure that we can set cache limits."""
         # creates a single byte asset
-        asset_file = tempfile.NamedTemporaryFile(delete=False)
+        asset_file = tempfile.NamedTemporaryFile(dir=self.base_dir.name, delete=False)
         asset_file.write(b'\xff')
         asset_file.close()
 
@@ -235,7 +235,7 @@ class AssetsPlugin(unittest.TestCase):
             locations='https://mirrors.kernel.org/gnu/hello/hello-2.9.tar.gz')
         """
         test_content = NOT_TEST_TEMPLATE.format(content=fetch_content)
-        test_file = tempfile.NamedTemporaryFile(suffix=".py", delete=False)
+        test_file = tempfile.NamedTemporaryFile(suffix=".py", dir=self.base_dir.name, delete=False)
         test_file.write(test_content.encode())
         test_file.close()
 
@@ -262,7 +262,7 @@ class AssetsPlugin(unittest.TestCase):
             locations='https://mirrors.kernel.org/gnu/hello/hello-2.9.tar.gz')
         """
         test_content = TEST_TEMPLATE.format(content=fetch_content)
-        test_file = tempfile.NamedTemporaryFile(suffix=".c", delete=False)
+        test_file = tempfile.NamedTemporaryFile(suffix=".c",  dir=self.base_dir.name, delete=False)
         test_file.write(test_content.encode())
         test_file.close()
 
@@ -290,7 +290,7 @@ class AssetsPlugin(unittest.TestCase):
             locations='http://localhost/hello-2.9.tar.gz')
         """
         test_content = TEST_TEMPLATE.format(content=fetch_content)
-        test_file = tempfile.NamedTemporaryFile(suffix=".py", delete=False)
+        test_file = tempfile.NamedTemporaryFile(suffix=".py", dir=self.base_dir.name, delete=False)
         test_file.write(test_content.encode())
         test_file.close()
 
@@ -317,7 +317,7 @@ class AssetsPlugin(unittest.TestCase):
             locations='http://localhost/hello-2.9.tar.gz')
         """
         test_content = TEST_TEMPLATE.format(content=fetch_content)
-        test_file = tempfile.NamedTemporaryFile(suffix=".py", delete=False)
+        test_file = tempfile.NamedTemporaryFile(suffix=".py", dir=self.base_dir.name, delete=False)
         test_file.write(test_content.encode())
         test_file.close()
 
@@ -337,7 +337,7 @@ class AssetsPlugin(unittest.TestCase):
     def test_asset_purge_by_days(self):
         """Make sure that we can remove assets by days."""
         # creates a single byte asset
-        asset_file = tempfile.NamedTemporaryFile(delete=False)
+        asset_file = tempfile.NamedTemporaryFile(dir=self.base_dir.name, delete=False)
         asset_file.write(b'\xff')
         asset_file.close()
 

--- a/selftests/functional/test_fetch_asset.py
+++ b/selftests/functional/test_fetch_asset.py
@@ -57,7 +57,7 @@ class FetchAsset(unittest.TestCase):
         print(foo)
         """ % (assetname, url)
         test_content = TEST_TEMPLATE.format(content=fetch_content)
-        test_file = tempfile.NamedTemporaryFile(suffix=".py", delete=False)
+        test_file = tempfile.NamedTemporaryFile(suffix=".py", dir=self.base_dir.name, delete=False)
         test_file.write(test_content.encode())
         test_file.close()
 
@@ -86,7 +86,7 @@ class FetchAsset(unittest.TestCase):
             raise OSError('Asset not found')
         """ % (fake_assetname, fake_url)
         test_content = TEST_TEMPLATE.format(content=fetch_content)
-        test_file = tempfile.NamedTemporaryFile(suffix=".py", delete=False)
+        test_file = tempfile.NamedTemporaryFile(suffix=".py", dir=self.base_dir.name, delete=False)
         test_file.write(test_content.encode())
         test_file.close()
 
@@ -117,7 +117,7 @@ class FetchAsset(unittest.TestCase):
             cancel_on_missing=True)
         """ % (fake_assetname, fake_url)
         test_content = TEST_TEMPLATE.format(content=fetch_content)
-        test_file = tempfile.NamedTemporaryFile(suffix=".py", delete=False)
+        test_file = tempfile.NamedTemporaryFile(suffix=".py", dir=self.base_dir.name, delete=False)
         test_file.write(test_content.encode())
         test_file.close()
 
@@ -147,7 +147,7 @@ class FetchAsset(unittest.TestCase):
             cancel_on_missing=True)
         """ % (fake_assetname, fake_url)
         test_content = TEST_TEMPLATE.format(content=fetch_content)
-        test_file = tempfile.NamedTemporaryFile(suffix=".py", delete=False)
+        test_file = tempfile.NamedTemporaryFile(suffix=".py", dir=self.base_dir.name, delete=False)
         test_file.write(test_content.encode())
         test_file.close()
 

--- a/selftests/unit/plugin/test_vmimage.py
+++ b/selftests/unit/plugin/test_vmimage.py
@@ -84,7 +84,7 @@ class VMImagePlugin(unittest.TestCase):
                          'base_dir = %(base_dir)s\n'
                          'data_dir = %(data_dir)s\n'
                          'cache_dirs = %(cache_dirs)s\n') % mapping
-        config_file = tempfile.NamedTemporaryFile('w', delete=False)
+        config_file = tempfile.NamedTemporaryFile('w', dir=base_dir.name, delete=False)
         config_file.write(temp_settings)
         config_file.close()
         return base_dir, mapping, config_file.name

--- a/selftests/unit/test_datadir.py
+++ b/selftests/unit/test_datadir.py
@@ -28,7 +28,7 @@ class Base(unittest.TestCase):
                          'test_dir = %(test_dir)s\n'
                          'data_dir = %(data_dir)s\n'
                          'logs_dir = %(logs_dir)s\n') % mapping
-        config_file = tempfile.NamedTemporaryFile('w', delete=False)
+        config_file = tempfile.NamedTemporaryFile('w', dir=base_dir.name, delete=False)
         config_file.write(temp_settings)
         config_file.close()
         return (base_dir, mapping, config_file.name)

--- a/selftests/unit/test_hintfiles.py
+++ b/selftests/unit/test_hintfiles.py
@@ -5,7 +5,7 @@ from avocado.core.nrunner import Runnable
 from avocado.core.parser import HintParser
 from avocado.core.resolver import ReferenceResolution
 from avocado.core.settings import SettingsError
-from selftests.utils import skipUnlessPathExists
+from selftests.utils import TestCaseTmpDir, skipUnlessPathExists
 
 BAD = """[kinds]
 tap = ./tests/*.t
@@ -18,13 +18,15 @@ uri = $testpath
 """
 
 
-class HintTest(unittest.TestCase):
+class HintTest(TestCaseTmpDir):
     def setUp(self):
-        self.wrong_file = tempfile.NamedTemporaryFile('w', delete=False)
+        super().setUp()
+
+        self.wrong_file = tempfile.NamedTemporaryFile('w', dir=self.tmpdir.name, delete=False)
         self.wrong_file.write(BAD)
         self.wrong_file.close()
 
-        self.good_file = tempfile.NamedTemporaryFile('w', delete=False)
+        self.good_file = tempfile.NamedTemporaryFile('w', dir=self.tmpdir.name, delete=False)
         self.good_file.write(GOOD)
         self.good_file.close()
 

--- a/selftests/unit/test_settings.py
+++ b/selftests/unit/test_settings.py
@@ -4,6 +4,7 @@ import tempfile
 import unittest
 
 from avocado.core import settings
+from selftests.utils import TestCaseTmpDir
 
 example = """[foo]
 bar = default from file
@@ -12,10 +13,11 @@ non_registered = this should be ignored
 """
 
 
-class SettingsTest(unittest.TestCase):
+class SettingsTest(TestCaseTmpDir):
 
     def setUp(self):
-        self.config_file = tempfile.NamedTemporaryFile('w', delete=False)
+        super().setUp()
+        self.config_file = tempfile.NamedTemporaryFile('w', dir=self.tmpdir.name, delete=False)
         self.config_file.write(example)
         self.config_file.close()
 
@@ -146,6 +148,7 @@ class SettingsTest(unittest.TestCase):
 
     def tearDown(self):
         os.unlink(self.config_file.name)
+        super().tearDown()
 
 
 class ConfigOption(unittest.TestCase):

--- a/selftests/utils.py
+++ b/selftests/utils.py
@@ -79,7 +79,7 @@ def get_temporary_config(module_name, klass, method):
                      'data_dir = %(data_dir)s\n'
                      'cache_dirs = ["%(cache_dir)s"]\n'
                      'logs_dir = %(logs_dir)s\n') % mapping
-    config_file = tempfile.NamedTemporaryFile('w', delete=False)
+    config_file = tempfile.NamedTemporaryFile('w', dir=base_dir.name, delete=False)
     config_file.write(temp_settings)
     config_file.close()
     return base_dir, mapping, config_file

--- a/setup.py
+++ b/setup.py
@@ -48,11 +48,10 @@ class Clean(clean):
         cleaning_list = ["MANIFEST", "BUILD", "BUILDROOT", "SPECS",
                          "RPMS", "SRPMS", "SOURCES", "PYPI_UPLOAD",
                          "./build", "./dist",
-                         "./man/avocado.1", "./docs/build",
-                         "/tmp/avocado/"]
+                         "./man/avocado.1", "./docs/build"]
 
-        cleaning_list += list(Path('/var/tmp/').glob(".avocado-task*"))
-        cleaning_list += list(Path('/var/tmp/').glob("avocado*"))
+        cleaning_list += list(Path('/tmp/').glob(".avocado-*"))
+        cleaning_list += list(Path('/var/tmp/').glob(".avocado-*"))
         cleaning_list += list(Path('.').rglob("*.egg-info"))
         cleaning_list += list(Path('.').rglob("*.pyc"))
         cleaning_list += list(Path('.').rglob("__pycache__"))


### PR DESCRIPTION
This is a v2 of https://github.com/avocado-framework/avocado/pull/4728
For the selftests, it's now reusing a temporary directory created by the class or inheriting from `TestCaseTmpDir`and using `self.tmpdir`