### PR TITLE
contrib/scripts/find-python-unittest: adapt to pre Python 3.8 behavior

### DIFF
--- a/contrib/scripts/find-python-unittest
+++ b/contrib/scripts/find-python-unittest
@@ -38,6 +38,10 @@ def get_tests(suite):
 
 
 if __name__ == '__main__':
+    if sys.version_info < (3, 8, 0):
+        abs_path = os.path.abspath(__file__)
+        top_path = os.path.dirname(os.path.dirname(os.path.dirname(abs_path)))
+        sys.path.insert(0, top_path)
     test_module_paths = sys.argv[1:]
     result = []
     loader = unittest.TestLoader()


### PR DESCRIPTION
Python's unittest.loader module, at _find_test_path(), when calling
_get_module_from_name(), may fail with a ModuleNotFoundError because
it doesn't include the current directory in the system path on Python
3.7 and earlier.  Python 3.8 and later changed that behavior.

In the specific case of ./selftests/safeloader.sh, it fails at some
tests with:

   ModuleNotFoundError: No module named 'selftests.utils'

Signed-off-by: Cleber Rosa <crosa@redhat.com>