### PR TITLE
Instrumented tests with fail reason

### DIFF
--- a/selftests/functional/plugin/test_jsonresult.py
+++ b/selftests/functional/plugin/test_jsonresult.py
@@ -1,0 +1,20 @@
+import json
+from os import path
+
+from avocado.utils import process
+from selftests.utils import AVOCADO, TestCaseTmpDir
+
+
+class JsonResultTest(TestCaseTmpDir):
+
+    def test_fail_reason(self):
+        cmd_line = ('%s run --test-runner=nrunner examples/tests/failtest.py '
+                    '--job-results-dir %s --disable-sysinfo ' %
+                    (AVOCADO, self.tmpdir.name))
+        process.run(cmd_line, ignore_status=True)
+        json_path = path.join(self.tmpdir.name, 'latest', 'results.json')
+        with open(json_path, 'r') as json_file:
+            data = json.load(json_file)
+            test_data = data['tests'].pop()
+            self.assertEqual('This test is supposed to fail',
+                             test_data['fail_reason'])


### PR DESCRIPTION
The avocado-instrumented runner wasn't gathering the fail-reason of
tests. This fix the problem and adds the appropriate test to catch
future bugs.

Reference: #4749
Signed-off-by: Jan Richter <jarichte@redhat.com>