### PR TITLE
logfile value in results.json

### DIFF
--- a/avocado/core/messages.py
+++ b/avocado/core/messages.py
@@ -228,6 +228,9 @@ class LogMessageHandler(BaseRunningMessageHandler):
         This assumes that the log message will not contain a newline, and thus
         one is explicitly added here.
         """
+        if task.metadata.get('logfile') is None:
+            task.metadata['logfile'] = os.path.join(task.metadata['task_path'],
+                                                    'debug.log')
         self._save_message_to_file('debug.log', message['log'], task,
                                    message.get('encoding', None))
 

--- a/selftests/functional/plugin/test_jsonresult.py
+++ b/selftests/functional/plugin/test_jsonresult.py
@@ -1,0 +1,21 @@
+import json
+from os import path
+
+from avocado.utils import process
+from selftests.utils import AVOCADO, TestCaseTmpDir
+
+
+class JsonResultTest(TestCaseTmpDir):
+
+    def test_logfile(self):
+        cmd_line = ('%s run --test-runner=nrunner examples/tests/failtest.py '
+                    '--job-results-dir %s --disable-sysinfo ' %
+                    (AVOCADO, self.tmpdir.name))
+        process.run(cmd_line, ignore_status=True)
+        json_path = path.join(self.tmpdir.name, 'latest', 'results.json')
+
+        with open(json_path, 'r') as json_file:
+            data = json.load(json_file)
+            test_data = data['tests'].pop()
+            expected_logfile = path.join(test_data['logdir'], 'debug.log')
+            self.assertEqual(expected_logfile, test_data['logfile'])


### PR DESCRIPTION
The path to the test log file wasn't send to the `end_test` plugins.
This commit fix it and adds the appropriate test to catch future bugs.

Reference: #4750
Signed-off-by: Jan Richter <jarichte@redhat.com>