### PR TITLE
Allow to run the selftests without testing the plugins

### DIFF
--- a/optional_plugins/html/tests/test_html_result.py
+++ b/optional_plugins/html/tests/test_html_result.py
@@ -6,11 +6,31 @@ from xml.dom import minidom
 
 from avocado.core import exit_codes
 from avocado.utils import genio, process
+from selftests.utils import AVOCADO
 
 
 class HtmlResultTest(unittest.TestCase):
+
     def setUp(self):
         self.tmpdir = tempfile.TemporaryDirectory(prefix='avocado_' + __name__)
+
+    def test_sysinfo_html_output(self):
+        html_output = "{}/output.html".format(self.tmpdir.name)
+        cmd_line = ('{} run --html {} --job-results-dir {} '
+                    'passtest.py'.format(AVOCADO, html_output,
+                                         self.tmpdir.name))
+        result = process.run(cmd_line)
+        expected_rc = exit_codes.AVOCADO_ALL_OK
+        self.assertEqual(result.exit_status, expected_rc,
+                         'Avocado did not return rc %d:\n%s' % (expected_rc,
+                                                                result))
+        with open(html_output, 'rt') as fp:
+            output = fp.read()
+
+        # Try to find some strings on HTML
+        self.assertNotEqual(output.find('Filesystem'), -1)
+        self.assertNotEqual(output.find('root='), -1)
+        self.assertNotEqual(output.find('MemAvailable'), -1)
 
     def check_output_files(self, debug_log):
         base_dir = os.path.dirname(debug_log)

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -356,16 +356,6 @@ def create_suites(args):
         'run.references': [check_file_exists],
         'run.test_runner': 'runner',
         'run.dict_variants': [
-            {'namespace': 'job.run.result.html.enabled',
-             'value': True,
-             'file': 'results.html',
-             'assert': True},
-
-            {'namespace': 'job.run.result.html.enabled',
-             'value': False,
-             'file': 'results.html',
-             'assert': False},
-
             {'namespace': 'job.run.result.json.enabled',
              'value': True,
              'file': 'results.json',
@@ -419,6 +409,20 @@ def create_suites(args):
         ]
     }
 
+    if 'html' not in args.disable_plugin_checks:
+
+        config_check_file_exists['run.dict_variants'].append(
+            {'namespace': 'job.run.result.html.enabled',
+             'value': True,
+             'file': 'results.html',
+             'assert': True})
+
+        config_check_file_exists['run.dict_variants'].append(
+            {'namespace': 'job.run.result.html.enabled',
+             'value': False,
+             'file': 'results.html',
+             'assert': False})
+
     suites.append(TestSuite.from_config(config_check_file_exists,
                                         "job-api-%s" % (len(suites) + 1)))
 
@@ -431,10 +435,6 @@ def create_suites(args):
         'run.references': [check_output_file],
         'run.test_runner': 'runner',
         'run.dict_variants': [
-            {'namespace': 'job.run.result.html.output',
-             'file': 'custom.html',
-             'assert': True},
-
             {'namespace': 'job.run.result.json.output',
              'file': 'custom.json',
              'assert': True},
@@ -449,6 +449,13 @@ def create_suites(args):
              'assert': True},
         ]
     }
+
+    if 'html' not in args.disable_plugin_checks:
+
+        config_check_output_file['run.dict_variants'].append(
+            {'namespace': 'job.run.result.html.output',
+             'file': 'custom.html',
+             'assert': True})
 
     suites.append(TestSuite.from_config(config_check_output_file,
                                         "job-api-%s" % (len(suites) + 1)))
@@ -484,9 +491,12 @@ def create_suites(args):
             {'runner': 'avocado-runner-python-unittest'},
             {'runner': 'avocado-runner-avocado-instrumented'},
             {'runner': 'avocado-runner-tap'},
-            {'runner': 'avocado-runner-golang'}
         ]
     }
+
+    if 'golang' not in args.disable_plugin_checks:
+        config_nrunner_interface['run.dict_variants'].append({
+            'runner': 'avocado-runner-golang'})
 
     if 'robot' not in args.disable_plugin_checks:
         config_nrunner_interface['run.dict_variants'].append({

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -520,26 +520,6 @@ class OutputPluginTest(TestCaseTmpDir):
                          (expected_rc, result))
         self.assertEqual(result.stdout, b"")
 
-    def test_default_enabled_plugins(self):
-        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
-                    '--tap-include-logs passtest.py'
-                    % (AVOCADO, self.tmpdir.name))
-        result = process.run(cmd_line, ignore_status=True)
-        output = result.stdout_text + result.stderr_text
-        expected_rc = exit_codes.AVOCADO_ALL_OK
-        self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" %
-                         (expected_rc, result))
-        output_lines = output.splitlines()
-        # The current human output produces 6 lines when running a single test,
-        # with an optional 7th line when the HTML report generation is enabled
-        self.assertGreaterEqual(len(output_lines), 6,
-                                ('Basic human interface did not produce the '
-                                 'expected output. Output produced: "%s"' % output))
-        second_line = output_lines[1]
-        debug_log = second_line.split()[-1]
-        self.check_output_files(debug_log)
-
     def test_verify_whiteboard_save(self):
         tmpfile = tempfile.mktemp(dir=self.tmpdir.name)
         config = os.path.join(self.tmpdir.name, "conf.ini")

--- a/selftests/functional/test_sysinfo.py
+++ b/selftests/functional/test_sysinfo.py
@@ -65,24 +65,6 @@ class SysInfoTest(TestCaseTmpDir):
                                                              result)
         self.assertFalse(os.path.isdir(sysinfo_dir), msg)
 
-    def test_sysinfo_html_output(self):
-        html_output = "{}/output.html".format(self.tmpdir.name)
-        cmd_line = ('{} run --html {} --job-results-dir {} '
-                    'passtest.py'.format(AVOCADO, html_output,
-                                         self.tmpdir.name))
-        result = process.run(cmd_line)
-        expected_rc = exit_codes.AVOCADO_ALL_OK
-        self.assertEqual(result.exit_status, expected_rc,
-                         'Avocado did not return rc %d:\n%s' % (expected_rc,
-                                                                result))
-        with open(html_output, 'rt') as fp:
-            output = fp.read()
-
-        # Try to find some strings on HTML
-        self.assertNotEqual(output.find('Filesystem'), -1)
-        self.assertNotEqual(output.find('root='), -1)
-        self.assertNotEqual(output.find('MemAvailable'), -1)
-
     def run_sysinfo_interrupted(self, sleep, timeout, exp_duration):
         commands_path = os.path.join(self.tmpdir.name, "commands")
         script.make_script(commands_path, "sleep %s" % sleep)


### PR DESCRIPTION
Updates to be able to opt-out all the plugins tests so we can split the plugins and still keep the tests in the avocado repository.