### PR TITLE
safeloader: do not choke on classes with generic parents

### DIFF
--- a/avocado/core/safeloader/core.py
+++ b/avocado/core/safeloader/core.py
@@ -129,6 +129,10 @@ def _get_attributes_for_further_examination(parent, module):
                 # We can't examine this parent (probably broken module)
                 raise ClassNotSuitable
 
+            # We currently don't support classes whose parents are generics
+            if isinstance(parent, ast.Subscript):
+                raise ClassNotSuitable
+
             parent_class = parent.attr
 
             # Special situation: in this case, because we know the parent

--- a/selftests/unit/test_safeloader_core.py
+++ b/selftests/unit/test_safeloader_core.py
@@ -14,6 +14,10 @@ setup_avocado_loggers()
 
 KEEP_METHODS_ORDER = '''
 from avocado import Test
+from collections.abs import Sequence
+
+class NotATest(Sequence[None]):
+    pass
 
 class MyClass(Test):
     def test2(self):


### PR DESCRIPTION
Avocado currently does not support test classes whose parents are
generics, but, it's choking and breaking the discovery of relevant
test classes when one exists.

Let's simply skip classes with generic parents.

Signed-off-by: Cleber Rosa <crosa@redhat.com>