### PR TITLE
Setup: add support for excluding optional plugins on develop

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,6 +9,21 @@ redhat_version_task:
           - image: fedora:34
           - image: registry.access.redhat.com/ubi8/ubi
 
+fedora_develop_install_uninstall_task:
+    develop_install_uninstall_script:
+       - python3 -c 'import setuptools' || dnf -y install python3 python3-setuptools
+       - python3 setup.py develop --user
+       - test `python3 -m avocado plugins | grep ^html | wc -l` -eq "3"
+       - test `python3 -m avocado plugins | grep ^robot | wc -l` -eq "2"
+       - python3 setup.py develop --user --uninstall
+       - python3 setup.py clean --all
+       - python3 setup.py develop --user --skip-optional-plugins
+       - python3 -m avocado --version
+       - test `python3 -m avocado plugins | grep ^html | wc -l` -eq "0"
+       - test `python3 -m avocado plugins | grep ^robot | wc -l` -eq "0"
+    container:
+      image: fedora:34
+
 redhat_egg_task:
     egg_script:
        - python3 -c 'import setuptools' || dnf -y install python3 python3-setuptools

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
       - run: echo "🥑 This job's status is ${{ job.status }}."
 
 
-# Windows checks on latest OS X
+# OS X smokecheck on latest Python
 
   smokecheck-osx:
 

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -169,7 +169,7 @@ find %{buildroot}%{_docdir}/avocado -type f -name '*.py' -exec %{__chmod} -c -x 
 
 %check
 %if %{with_tests}
-%{__python3} setup.py develop --user
+%{__python3} setup.py develop --user --skip-optional-plugins
 pushd optional_plugins/html
 %{__python3} setup.py develop --user
 popd
@@ -377,6 +377,10 @@ Again Shell code (and possibly other similar shells).
 %{_libexecdir}/avocado*
 
 %changelog
+* Fri Jul  9 2021 Cleber Rosa <crosa@redhat.com> - 89.0-1
+- Skip initialization of plugins previous to running test, as
+  the supported plugins are already explicitly included
+
 * Mon Jun 21 2021 Cleber Rosa <cleber@redhat.com> - 89.0-1
 - New release
 

--- a/setup.py
+++ b/setup.py
@@ -90,13 +90,18 @@ class Develop(setuptools.command.develop.develop):
 
     user_options = setuptools.command.develop.develop.user_options + [
         ("external", None, "Install external plugins in development mode"),
+        ("skip-optional-plugins", None,
+         "Do not include in-tree optional plugins in development mode")
     ]
 
-    boolean_options = setuptools.command.develop.develop.boolean_options + ['external']
+    boolean_options = setuptools.command.develop.develop.boolean_options + [
+        'external',
+        'skip-optional-plugins']
 
     def initialize_options(self):
         super().initialize_options()
         self.external = 0  # pylint: disable=W0201
+        self.skip_optional_plugins = 0  # pylint: disable=W0201
 
     def run(self):
 
@@ -114,14 +119,16 @@ class Develop(setuptools.command.develop.develop):
         if self.user and not self.external:
             if not self.uninstall:
                 super().run()
-                walk_plugins_setup_py(action=["develop"] + action_options,
-                                      action_name=action_name)
+                if not self.skip_optional_plugins:
+                    walk_plugins_setup_py(action=["develop"] + action_options,
+                                          action_name=action_name)
 
         # python setup.py develop --user
         # we install the plugins after installing avocado
             elif self.uninstall:
-                walk_plugins_setup_py(action=["develop"] + action_options,
-                                      action_name=action_name)
+                if not self.skip_optional_plugins:
+                    walk_plugins_setup_py(action=["develop"] + action_options,
+                                          action_name=action_name)
                 super().run()
 
         # if we're working with external plugins

--- a/setup.py
+++ b/setup.py
@@ -97,17 +97,23 @@ class Develop(setuptools.command.develop.develop):
 
     def run(self):
 
+        action_options = []
+        if self.uninstall:
+            action_options.append('--uninstall')
+        if self.user:
+            action_options.append('--user')
+
         # python setup.py develop --user --uninstall
         # we uninstall the plugins before uninstalling avocado
         if self.user and not self.external:
             if not self.uninstall:
                 super().run()
-                walk_plugins_setup_py(action_name="LINK", action=["develop", "--user"])
+                walk_plugins_setup_py(action_name="LINK", action=["develop"] + action_options)
 
         # python setup.py develop --user
         # we install the plugins after installing avocado
             elif self.uninstall:
-                walk_plugins_setup_py(action_name="UNLINK", action=["develop", "--uninstall", "--user"])
+                walk_plugins_setup_py(action_name="UNLINK", action=["develop"] + action_options)
                 super().run()
 
         # if we're working with external plugins
@@ -119,9 +125,9 @@ class Develop(setuptools.command.develop.develop):
             d = os.path.abspath(d)
 
             if self.uninstall:
-                walk_plugins_setup_py(action_name="UNLINK", action=["develop", "--uninstall", "--user"], directory=d)
+                walk_plugins_setup_py(action_name="UNLINK", action=["develop"] + action_options, directory=d)
             elif not self.uninstall:
-                walk_plugins_setup_py(action_name="LINK", action=["develop", "--user"], directory=d)
+                walk_plugins_setup_py(action_name="LINK", action=["develop"] + action_options, directory=d)
 
         # other cases: do nothing and call parent function
         else:

--- a/setup.py
+++ b/setup.py
@@ -116,8 +116,7 @@ class Develop(setuptools.command.develop.develop):
             d = os.getenv('AVOCADO_EXTERNAL_PLUGINS_PATH')
             if (d is None or not os.path.exists(d)):
                 sys.exit("The variable AVOCADO_EXTERNAL_PLUGINS_PATH isn't properly set")
-            if not os.path.isabs(d):
-                d = os.path.abspath(d)
+            d = os.path.abspath(d)
 
             if self.uninstall:
                 walk_plugins_setup_py(action_name="UNLINK", action=["develop", "--uninstall", "--user"], directory=d)


### PR DESCRIPTION
This introduces support for excluding optional plugins on "python3 setup.py develop", which is necessary to restore support for building RPMs.