### PR TITLE
selftests: allow to run selftests and test in different steps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,54 @@ install:
     - pip install -r requirements-selftests.txt
 
 script:
-    - make check
+    - python3 setup.py lint
+    - python3 setup.py develop --user
+    - python3 selftests/check.py --disable-static-checks --disable-selftests-functional
+##    - python3 selftests/check.py --disable-static-checks --disable-selftests-jobs --disable-selftests-unit --disable-selftests-nrunner --disable-selftests-optional-plugins --disable-plugin-checks html
+# Instead:
+    - avocado run --test-runner=runner selftests/functional/test_requirements_cache.py
+    - avocado run --test-runner=nrunner selftests/functional/test_requirements_cache.py
+    - avocado run --test-runner=nrunner selftests/functional/test_argument_parsing.py
+    - avocado run --test-runner=nrunner selftests/functional/test_export_variables.py
+    - avocado run --test-runner=nrunner selftests/functional/test_fetch_asset.py
+    - avocado run --test-runner=nrunner selftests/functional/test_getdata.py
+    - avocado run --test-runner=nrunner selftests/functional/test_interrupt.py
+    - avocado run --test-runner=nrunner selftests/functional/test_job_api_features.py
+    - avocado run --test-runner=nrunner selftests/functional/test_job_timeout.py
+    - avocado run --test-runner=nrunner selftests/functional/test_journal.py
+    - avocado run --test-runner=nrunner selftests/functional/test_json_variants.py
+    - avocado run --test-runner=nrunner selftests/functional/test_legacy_replay_basic.py
+    - avocado run --test-runner=nrunner selftests/functional/test_legacy_replay_external_runner.py
+    - avocado run --test-runner=nrunner selftests/functional/test_legacy_replay_failfast.py
+    - avocado run --test-runner=nrunner selftests/functional/test_list.py
+    - avocado run --test-runner=nrunner selftests/functional/test_loader.py
+    - avocado run --test-runner=nrunner selftests/functional/test_lv_utils.py
+    - avocado run --test-runner=nrunner selftests/functional/test_nrunner_interface.py
+    - avocado run --test-runner=nrunner selftests/functional/test_nrunner.py
+    - avocado run --test-runner=nrunner selftests/functional/test_output_check.py
+    - avocado run --test-runner=nrunner selftests/functional/test_output.py
+    - avocado run --test-runner=nrunner selftests/functional/test_replay.py
+    - avocado run --test-runner=nrunner selftests/functional/test_requirements_cache.py
+    - avocado run --test-runner=nrunner selftests/functional/test_requirements.py
+    - avocado run --test-runner=nrunner selftests/functional/test_resolver.py
+    - avocado run --test-runner=nrunner selftests/functional/test_runner_requirement_asset.py
+    - avocado run --test-runner=nrunner selftests/functional/test_runner_requirement_package.py
+    - avocado run --test-runner=nrunner selftests/functional/test_skiptests.py
+    - avocado run --test-runner=nrunner selftests/functional/test_software_manager.py
+    - avocado run --test-runner=nrunner selftests/functional/test_statuses.py
+    - avocado run --test-runner=nrunner selftests/functional/test_streams.py
+    - avocado run --test-runner=nrunner selftests/functional/test_sysinfo.py
+    - avocado run --test-runner=nrunner selftests/functional/test_task_statemachine.py
+    - avocado run --test-runner=nrunner selftests/functional/test_task_timeout.py
+    - avocado run --test-runner=nrunner selftests/functional/test_teststmpdir.py
+    - avocado run --test-runner=nrunner selftests/functional/test_thirdparty_bugs.py
+    - avocado run --test-runner=nrunner selftests/functional/test_unittest_compat.py
+    - avocado run --test-runner=nrunner selftests/functional/test_utils_asset.py
+    - avocado run --test-runner=nrunner selftests/functional/test_utils.py
+    - avocado run --test-runner=nrunner selftests/functional/test_wrapper.py
+    - avocado run --test-runner=nrunner selftests/functional/plugin/test_assets.py
+    - avocado run --test-runner=nrunner selftests/functional/plugin/test_diff.py
+    - avocado run --test-runner=nrunner selftests/functional/plugin/test_jobscripts.py
+    - avocado run --test-runner=nrunner selftests/functional/plugin/test_logs.py
+    - avocado run --test-runner=nrunner selftests/functional/plugin/test_vmimage.py
+    - avocado run --test-runner=nrunner --nrunner-max-parallel-tasks=6 selftests/functional/test_basic.py

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -199,6 +199,22 @@ def parse_args():
     parser.add_argument('--disable-plugin-checks',
                         help='Disable checks for a plugin (by directory name)',
                         action='append', default=[])
+    parser.add_argument('--disable-selftests-nrunner',
+                        help='Disable selftests/functional/test_nrunner_interface.py',
+                        action='store_true')
+    parser.add_argument('--disable-selftests-unit',
+                        help='Disable selftests/unit/',
+                        action='store_true')
+    parser.add_argument('--disable-selftests-jobs',
+                        help='Disable selftests/jobs/',
+                        action='store_true')
+    parser.add_argument('--disable-selftests-functional',
+                        help='Disable selftests/functional/',
+                        action='store_true')
+    parser.add_argument('--disable-selftests-optional-plugins',
+                        help='Disable optional_plugins/*/tests/',
+                        action='store_true')
+
     return parser.parse_args()
 
 
@@ -502,17 +518,24 @@ def create_suites(args):
         config_nrunner_interface['run.dict_variants'].append({
             'runner': 'avocado-runner-robot'})
 
-    suites.append(TestSuite.from_config(config_nrunner_interface,
-                                        "nrunner-interface"))
+    if not args.disable_selftests_nrunner:
+        suites.append(TestSuite.from_config(config_nrunner_interface, "nrunner-interface"))
 
     # ========================================================================
     # Run all static checks, unit and functional tests
     # ========================================================================
+
+    selftests = []
+    if not args.disable_selftests_unit:
+        selftests.append('selftests/unit/')
+    if not args.disable_selftests_jobs:
+        selftests.append('selftests/jobs/')
+    if not args.disable_selftests_functional:
+        selftests.append('selftests/functional/')
+
     status_server = '127.0.0.1:%u' % find_free_port()
     config_check = {
-        'run.references': ['selftests/jobs/',
-                           'selftests/unit/',
-                           'selftests/functional/'],
+        'run.references': selftests,
         'run.test_runner': 'nrunner',
         'nrunner.status_server_listen': status_server,
         'nrunner.status_server_uri': status_server,
@@ -523,11 +546,12 @@ def create_suites(args):
     if not args.disable_static_checks:
         config_check['run.references'] += glob.glob('selftests/*.sh')
 
-    for optional_plugin in glob.glob('optional_plugins/*'):
-        plugin_name = os.path.basename(optional_plugin)
-        if plugin_name not in args.disable_plugin_checks:
-            pattern = '%s/tests/*' % optional_plugin
-            config_check['run.references'] += glob.glob(pattern)
+    if not args.disable_selftests_optional_plugins:
+        for optional_plugin in glob.glob('optional_plugins/*'):
+            plugin_name = os.path.basename(optional_plugin)
+            if plugin_name not in args.disable_plugin_checks:
+                pattern = '%s/tests/*' % optional_plugin
+                config_check['run.references'] += glob.glob(pattern)
 
     suites.append(TestSuite.from_config(config_check, "check"))
     return suites


### PR DESCRIPTION
This is a test running the tests by groups to see if that helps. Some tests, API and nrunner, are still run twice.

Reference: https://github.com/avocado-framework/avocado/issues/4768