### PR TITLE
core.data_dir: make datadir.paths.base_dir consisent

### DIFF
--- a/avocado/core/__init__.py
+++ b/avocado/core/__init__.py
@@ -94,7 +94,7 @@ def register_core_options():
                          help_msg=help_msg)
 
     help_msg = 'Base directory for Avocado tests and auxiliary data'
-    default = prepend_base_path('/var/lib/avocado')
+    default = prepend_base_path('~/avocado')
     stgs.register_option(section='datadir.paths',
                          key='base_dir',
                          key_type=prepend_base_path,

--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -136,6 +136,9 @@ def get_data_dir():
         * GPG files
         * VM images
         * Reference bitmaps
+
+    .. warning:: This method is deprecated, get values from
+                 settings.as_dict() or self.config
     """
     warnings.warn(("get_data_dir() is deprecated, get values from "
                    "settings.as_dict() or self.config"), DeprecationWarning)
@@ -158,6 +161,9 @@ def get_logs_dir():
     Get the most appropriate log dir location.
 
     The log dir is where we store job/test logs in general.
+
+    .. warning:: This method is deprecated, get values from
+                 settings.as_dict() or self.config
     """
     warnings.warn(("get_logs_dir() is deprecated, get values from "
                    "settings.as_dict() or self.config"), DeprecationWarning)
@@ -210,6 +216,9 @@ def get_cache_dirs():
     Returns the list of cache dirs, according to configuration and convention.
 
     This will be deprecated. Please use settings.as_dict() or self.config.
+
+    .. warning:: This method is deprecated, get values from
+                 settings.as_dict() or self.config
     """
     warnings.warn(("get_cache_dirs() is deprecated, get values from "
                    "settings.as_dict() or self.config"), DeprecationWarning)

--- a/avocado/core/data_dir.py
+++ b/avocado/core/data_dir.py
@@ -89,8 +89,9 @@ def get_base_dir():
         * Data directory
         * Tests directory
     """
-    return _get_rw_dir(_get_settings_dir('base_dir'),
-                       SYSTEM_BASE_DIR, USER_BASE_DIR)
+    warnings.warn(("get_base_dir() is deprecated, get values from "
+                   "settings.as_dict() or self.config"), DeprecationWarning)
+    return settings.as_dict().get('datadir.paths.base_dir')
 
 
 def get_test_dir():

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -263,7 +263,7 @@ class Job:
     def _log_avocado_datadir(self):
         LOG_JOB.info('Avocado Data Directories:')
         LOG_JOB.info('')
-        LOG_JOB.info('base     %s', data_dir.get_base_dir())
+        LOG_JOB.info('base     %s', self.config.get('datadir.paths.base_dir'))
         LOG_JOB.info('tests    %s', data_dir.get_test_dir())
         LOG_JOB.info('data     %s', self.config.get('datadir.paths.data_dir'))
         LOG_JOB.info('logs     %s', self.logdir)

--- a/avocado/plugins/config.py
+++ b/avocado/plugins/config.py
@@ -100,7 +100,7 @@ class Config(CLICmd):
             LOG_UI.debug("file to customize values")
             LOG_UI.debug('')
             LOG_UI.info('Avocado Data Directories:')
-            LOG_UI.debug('   base    %s', data_dir.get_base_dir())
+            LOG_UI.debug('   base    %s', config.get('datadir.paths.base_dir'))
             LOG_UI.debug('   tests   %s', data_dir.get_test_dir())
             LOG_UI.debug('   data    %s', config.get('datadir.paths.data_dir'))
             LOG_UI.debug('   logs    %s', config.get('datadir.paths.logs_dir'))


### PR DESCRIPTION
data_dir module was created way before our new settings logic was
introduced, default values now are defined at registration time. When
users define a custom value, in some cases Avocado is replacing this
value with a default hardcoded value, instead of respecting users'
choice (for instance when users have no permissions). base_dir is
already defined as default at `~/avocado/`, let's get the values from
the config dict here too. This fixes #4443.

Signed-off-by: Beraldo Leal <bleal@redhat.com>