### PR TITLE
logging: we should not remove handlers when using the root log

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -164,6 +164,7 @@ class Job:
         self.time_elapsed = -1
         self.funcatexit = CallbackRegister("JobExit %s" % self.unique_id, LOG_JOB)
         self._stdout_stderr = None
+        self._old_root_level = None
         self.replay_sourcejob = self.config.get('replay_sourcejob')
         self.exitcode = exit_codes.AVOCADO_ALL_OK
 
@@ -201,6 +202,7 @@ class Job:
                                               logging.FileHandler,
                                               self.logfile, self.loglevel, fmt)
         root_logger = logging.getLogger()
+        self._old_root_level = root_logger.level
         root_logger.addHandler(test_handler)
         root_logger.setLevel(self.loglevel)
         self.__logging_handlers[test_handler] = [LOG_JOB.name, ""]
@@ -252,6 +254,7 @@ class Job:
         for handler, loggers in self.__logging_handlers.items():
             for logger in loggers:
                 logging.getLogger(logger).removeHandler(handler)
+        logging.root.level = self._old_root_level
 
     def _log_avocado_config(self):
         LOG_JOB.info('Avocado config:')

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -643,6 +643,8 @@ def add_log_handler(logger, klass=logging.StreamHandler, stream=sys.stdout,
 
 
 def disable_log_handler(logger):
+    if not logger:
+        return
     if isinstance(logger, str):
         logger = logging.getLogger(logger)
     # Handlers might be reused elsewhere, can't delete them


### PR DESCRIPTION
We are messing up with the root log. After finishing the run, we
need to restore back level  and handlers. Because logging is a singleton,
according to the documentation we should be using a context manager for
selective logging, but unfortunately this will not be trivial today. So this should fix it.

Signed-off-by: Beraldo Leal <bleal@redhat.com>