### PR TITLE
TravisCI fix for arm64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,6 @@ install:
     - pip install -r requirements-selftests.txt
 
 script:
-    - make check
+    - make clean uninstall develop
+    - python3 selftests/check.py --parallel-tasks=30
+    - python3 selftests/check_tmp_dirs 

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -199,6 +199,9 @@ def parse_args():
     parser.add_argument('--disable-plugin-checks',
                         help='Disable checks for a plugin (by directory name)',
                         action='append', default=[])
+    parser.add_argument('--parallel-tasks',
+                        help='Set the maximum parallel tasks for testing',
+                        type=int)
     return parser.parse_args()
 
 
@@ -563,6 +566,10 @@ def main():
     # ========================================================================
     config = {'core.show': ['app'],
               'run.test_runner': 'nrunner'}
+    if args.parallel_tasks:
+        for suite in suites:
+            suite.config['nrunner.max_parallel_tasks'] = args.parallel_tasks
+        config['nrunner.max_parallel_tasks'] = args.parallel_tasks
     with Job(config, suites) as j:
         exit_code = j.run()
     print_failed_tests(j.get_failed_tests())


### PR DESCRIPTION
The avocado selftests was able to exhaust the Travis resources. This
will decrease the selftests need for resources.

Reference: #4768
Signed-off-by: Jan Richter <jarichte@redhat.com>