### PR TITLE
selftests: allow to only use half of the cpus for some tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,8 @@ install:
     - pip install -r requirements-selftests.txt
 
 script:
-    - make check
+    - python -c "import multiprocessing; print(multiprocessing.cpu_count())"
+    - python3 setup.py lint
+    - python3 setup.py develop --user
+    - python3 selftests/check.py --disable-static-checks --disable-selftests-functional
+    - python3 selftests/check.py --disable-static-checks --disable-selftests-jobs --disable-selftests-unit --disable-selftests-nrunner --disable-selftests-optional-plugins --half-cpus

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -199,6 +199,22 @@ def parse_args():
     parser.add_argument('--disable-plugin-checks',
                         help='Disable checks for a plugin (by directory name)',
                         action='append', default=[])
+    parser.add_argument('--disable-selftests-nrunner',
+                        help='Disable selftests/functional/test_nrunner_interface.py',
+                        action='store_true')
+    parser.add_argument('--disable-selftests-unit',
+                        help='Disable selftests/unit/',
+                        action='store_true')
+    parser.add_argument('--disable-selftests-jobs',
+                        help='Disable selftests/jobs/',
+                        action='store_true')
+    parser.add_argument('--disable-selftests-functional',
+                        help='Disable selftests/functional/',
+                        action='store_true')
+    parser.add_argument('--disable-selftests-optional-plugins',
+                        help='Disable optional_plugins/*/tests/',
+                        action='store_true')
+
     return parser.parse_args()
 
 
@@ -502,17 +518,24 @@ def create_suites(args):
         config_nrunner_interface['run.dict_variants'].append({
             'runner': 'avocado-runner-robot'})
 
-    suites.append(TestSuite.from_config(config_nrunner_interface,
-                                        "nrunner-interface"))
+    if not args.disable_selftests_nrunner:
+        suites.append(TestSuite.from_config(config_nrunner_interface, "nrunner-interface"))
 
     # ========================================================================
     # Run all static checks, unit and functional tests
     # ========================================================================
+
+    selftests = []
+    if not args.disable_selftests_unit:
+        selftests.append('selftests/unit/')
+    if not args.disable_selftests_jobs:
+        selftests.append('selftests/jobs/')
+    if not args.disable_selftests_functional:
+        selftests.append('selftests/functional/')
+
     status_server = '127.0.0.1:%u' % find_free_port()
     config_check = {
-        'run.references': ['selftests/jobs/',
-                           'selftests/unit/',
-                           'selftests/functional/'],
+        'run.references': selftests,
         'run.test_runner': 'nrunner',
         'nrunner.status_server_listen': status_server,
         'nrunner.status_server_uri': status_server,
@@ -523,11 +546,12 @@ def create_suites(args):
     if not args.disable_static_checks:
         config_check['run.references'] += glob.glob('selftests/*.sh')
 
-    for optional_plugin in glob.glob('optional_plugins/*'):
-        plugin_name = os.path.basename(optional_plugin)
-        if plugin_name not in args.disable_plugin_checks:
-            pattern = '%s/tests/*' % optional_plugin
-            config_check['run.references'] += glob.glob(pattern)
+    if not args.disable_selftests_optional_plugins:
+        for optional_plugin in glob.glob('optional_plugins/*'):
+            plugin_name = os.path.basename(optional_plugin)
+            if plugin_name not in args.disable_plugin_checks:
+                pattern = '%s/tests/*' % optional_plugin
+                config_check['run.references'] += glob.glob(pattern)
 
     suites.append(TestSuite.from_config(config_check, "check"))
     return suites

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -2,6 +2,7 @@
 
 import argparse
 import glob
+import multiprocessing
 import os
 import sys
 
@@ -214,7 +215,9 @@ def parse_args():
     parser.add_argument('--disable-selftests-optional-plugins',
                         help='Disable optional_plugins/*/tests/',
                         action='store_true')
-
+    parser.add_argument('--half-cpus',
+                        help='Only use half of the CPUS',
+                        action='store_true')
     return parser.parse_args()
 
 
@@ -587,6 +590,12 @@ def main():
     # ========================================================================
     config = {'core.show': ['app'],
               'run.test_runner': 'nrunner'}
+
+    if args.half_cpus:
+        max_parallel = int(multiprocessing.cpu_count()/2)
+        for suite in suites:
+            suite.config['nrunner.max_parallel_tasks'] = max_parallel
+
     with Job(config, suites) as j:
         exit_code = j.run()
     print_failed_tests(j.get_failed_tests())


### PR DESCRIPTION
This should help with the current problem in travis on arm64.
Reference: https://github.com/avocado-framework/avocado/issues/4768