### PR TITLE
Instrumented tests with fail reason [v2]

### DIFF
--- a/selftests/functional/plugin/test_jsonresult.py
+++ b/selftests/functional/plugin/test_jsonresult.py
@@ -32,6 +32,19 @@ class JsonResultTest(TestCaseTmpDir):
             expected_logfile = path.join(test_data['logdir'], 'debug.log')
             self.assertEqual(expected_logfile, test_data['logfile'])
 
+    def test_fail_reason(self):
+        cmd_line = ('%s --config %s run --test-runner=nrunner '
+                    'examples/tests/failtest.py '
+                    '--job-results-dir %s --disable-sysinfo ' %
+                    (AVOCADO, self.config_file.path, self.tmpdir.name))
+        process.run(cmd_line, ignore_status=True)
+        json_path = path.join(self.tmpdir.name, 'latest', 'results.json')
+        with open(json_path, 'r') as json_file:
+            data = json.load(json_file)
+            test_data = data['tests'].pop()
+            self.assertEqual('This test is supposed to fail',
+                             test_data['fail_reason'])
+
     def tearDown(self):
         super(JsonResultTest, self).tearDown()
         self.config_file.remove()


### PR DESCRIPTION
The avocado-instrumented runner wasn't gathering the fail-reason of
tests. This fix the problem and adds the appropriate test to catch
future bugs.

Reference: #4749
Signed-off-by: Jan Richter <jarichte@redhat.com>

---
Changes from v1 (#4753):
* Test fix - create its own status server.