### PR TITLE
show correct start time in HTML reports (v2)

### DIFF
--- a/avocado/core/messages.py
+++ b/avocado/core/messages.py
@@ -13,6 +13,7 @@
 # Authors: Jan Richter <jarichte@redhat.com>
 
 import os
+import time
 
 from .test_id import TestID
 
@@ -104,6 +105,7 @@ class StartMessageHandler(BaseMessageHandler):
                     'base_path': base_path,
                     'task_path': task_path,
                     'time_start': message['time'],
+                    'actual_time_start': time.time(),
                     'name': task_id}
         if task.category == 'test':
             job.result.start_test(metadata)
@@ -141,6 +143,7 @@ class FinishMessageHandler(BaseMessageHandler):
         time_end = message['time']
         time_elapsed = time_end - time_start
         message['time_end'] = time_end
+        message['actual_time_end'] = time.time()
         message['time_elapsed'] = time_elapsed
 
         message['logdir'] = task.metadata['task_path']

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -51,6 +51,7 @@ COMMON_TMPDIR_NAME = 'AVOCADO_TESTS_COMMON_TMPDIR'
 TEST_STATE_ATTRIBUTES = ('name', 'logdir', 'logfile',
                          'status', 'running', 'paused',
                          'time_start', 'time_elapsed', 'time_end',
+                         'actual_time_start', 'actual_time_end',
                          'fail_reason', 'fail_class', 'traceback',
                          'tags', 'timeout', 'whiteboard', 'phase')
 
@@ -217,13 +218,17 @@ class Test(unittest.TestCase, TestData):
     #: Arbitrary string which will be stored in `$logdir/whiteboard` location
     #: when the test finishes.
     whiteboard = ''
-    #: (unix) time when the test started (could be forced from test)
+    #: (unix) time when the test started, monotonic (could be forced from test)
     time_start = -1
-    #: (unix) time when the test finished (could be forced from test)
+    #: (unix) time when the test finished, monotonic (could be forced from test)
     time_end = -1
     #: duration of the test execution (always recalculated from time_end -
     #: time_start
     time_elapsed = -1
+    #: (unix) time when the test started, actual one to be shown to users
+    actual_time_start = -1
+    #: (unix) time when the test finished, actual one to be shown to users
+    actual_time_end = -1
     #: Test timeout (the timeout from params takes precedence)
     timeout = None
 
@@ -520,10 +525,12 @@ class Test(unittest.TestCase, TestData):
         self.log.info('START %s', self.name)
         self.__running = True
         self.time_start = time.monotonic()
+        self.actual_time_start = time.time()
 
     def _tag_end(self):
         self.__running = False
         self.time_end = time.monotonic()
+        self.actual_time_end = time.time()
         # for consistency sake, always use the same stupid method
         self._update_time_elapsed(self.time_end)
 

--- a/optional_plugins/html/avocado_result_html/__init__.py
+++ b/optional_plugins/html/avocado_result_html/__init__.py
@@ -119,7 +119,7 @@ class ReportModel:
                                                    self.html_output_dir)
             formatted['logfile_basename'] = os.path.basename(logfile)
             formatted['time'] = "%.2f" % tst['time_elapsed']
-            local_time_start = time.localtime(tst['time_start'])
+            local_time_start = time.localtime(tst['actual_time_start'])
             formatted['time_start'] = time.strftime("%Y-%m-%d %H:%M:%S",
                                                     local_time_start)
             formatted['row_class'] = mapping[tst['status']]


### PR DESCRIPTION
This is a v2 from https://github.com/avocado-framework/avocado/pull/4762
Reference bug: https://github.com/avocado-framework/avocado/issues/4709

The first and third commit are identical to v1 and what changes is the middle commit that adds both actual_time_start and actual_time_end with nrunner.

The problem with monotonic for the legacy runner was introduced in 14937705f15c8334220599edc1047e7563d04c80 from May this year. The problem with the new runner was introduced in b600a5fe08112ee15b41b1150d849fd63ef276f6 from September 2020, which means it has been around for 10 months without anyone noticing!
I'm wondering how we can test this - because it's a "visual" test - to avoid this problem or a similar one happening a third time.