### PR TITLE
Test: support for coroutines as tests

### DIFF
--- a/avocado/core/safeloader/core.py
+++ b/avocado/core/safeloader/core.py
@@ -21,19 +21,23 @@ def get_methods_info(statement_body, class_tags, class_requirements):
     """
     methods_info = []
     for st in statement_body:
-        if (isinstance(st, ast.FunctionDef) and
-                st.name.startswith('test')):
-            docstring = ast.get_docstring(st)
+        if not (isinstance(st, (ast.FunctionDef, ast.AsyncFunctionDef))):
+            continue
 
-            mt_tags = get_docstring_directives_tags(docstring)
-            mt_tags.update(class_tags)
+        if not st.name.startswith('test'):
+            continue
 
-            mt_requirements = get_docstring_directives_requirements(docstring)
-            mt_requirements.extend(class_requirements)
+        docstring = ast.get_docstring(st)
 
-            methods = [method for method, _, _ in methods_info]
-            if st.name not in methods:
-                methods_info.append((st.name, mt_tags, mt_requirements))
+        mt_tags = get_docstring_directives_tags(docstring)
+        mt_tags.update(class_tags)
+
+        mt_requirements = get_docstring_directives_requirements(docstring)
+        mt_requirements.extend(class_requirements)
+
+        methods = [method for method, _, _ in methods_info]
+        if st.name not in methods:
+            methods_info.append((st.name, mt_tags, mt_requirements))
 
     return methods_info
 

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -18,6 +18,7 @@ Contains the base test implementation, used as a base for the actual
 framework tests.
 """
 
+import asyncio
 import inspect
 import io
 import logging
@@ -762,7 +763,11 @@ class Test(unittest.TestCase, TestData):
         else:
             try:
                 self.__phase = 'TEST'
-                testMethod()
+                if inspect.iscoroutinefunction(testMethod):
+                    loop = asyncio.get_event_loop()
+                    loop.run_until_complete(testMethod())
+                else:
+                    testMethod()
             except exceptions.TestCancel as details:
                 stacktrace.log_exc_info(sys.exc_info(), logger=LOG_JOB)
                 raise

--- a/docs/source/guides/writer/chapters/writing.rst
+++ b/docs/source/guides/writer/chapters/writing.rst
@@ -27,6 +27,10 @@ leveraging its API power.
 As can be seen in the example above, an Avocado test is a method that starts
 with ``test`` in a class that inherits from :mod:`avocado.Test`.
 
+.. note:: Avocado also supports coroutines as tests.  Simply declare
+          your test method using the ``async def`` syntax, and Avocado
+          will run it inside an asyncio loop.
+
 Multiple tests and naming conventions
 -------------------------------------
 

--- a/examples/tests/sleeptest_async.py
+++ b/examples/tests/sleeptest_async.py
@@ -1,0 +1,20 @@
+import asyncio
+
+from avocado import Test
+
+
+class AsyncSleepTest(Test):
+
+    """
+    This test sleeps for 1s by default
+
+    :param sleep_length: Sleep duration
+    """
+
+    async def test(self):
+        """
+        Sleep for length seconds.
+        """
+        sleep_length = float(self.params.get('sleep_length', default=1))
+        self.log.debug("Sleeping for %.2f seconds", sleep_length)
+        await asyncio.sleep(sleep_length)

--- a/selftests/functional/test_coroutine.py
+++ b/selftests/functional/test_coroutine.py
@@ -1,0 +1,19 @@
+import os
+
+from avocado.utils import process
+from selftests.utils import AVOCADO, BASEDIR, TestCaseTmpDir
+
+
+class Coroutine(TestCaseTmpDir):
+
+    def test(self):
+        test_path = os.path.join(BASEDIR,
+                                 "examples", "tests", "sleeptest_async.py")
+        os.environ['PYTHONASYNCIODEBUG'] = '1'
+        cmd = ("{} --show=test run --disable-sysinfo --job-results-dir {} "
+               "-p sleep_length=0 {}").format(AVOCADO, self.tmpdir.name,
+                                              test_path)
+        result = process.run(cmd, ignore_status=True)
+        self.assertEqual(result.exit_status, 0)
+        self.assertNotIn("RuntimeWarning: coroutine 'AsyncSleepTest.test' "
+                         "was never awaited", result.stdout_text)

--- a/selftests/functional/test_task_statemachine.py
+++ b/selftests/functional/test_task_statemachine.py
@@ -15,7 +15,7 @@ from avocado.plugins.spawners.process import ProcessSpawner as Spawner
 
 class StateMachine(TestCase):
 
-    def test(self):
+    async def test(self):
         number_of_tasks = 80
         number_of_workers = 8
 
@@ -26,9 +26,8 @@ class StateMachine(TestCase):
         status_repo = StatusRepo()
 
         state_machine = statemachine.TaskStateMachine(runtime_tasks, status_repo)
-        loop = asyncio.get_event_loop()
         workers = [statemachine.Worker(state_machine, spawner).run()
                    for _ in range(number_of_workers)]
 
-        loop.run_until_complete(asyncio.gather(*workers))
+        await asyncio.gather(*workers)
         self.assertEqual(number_of_tasks, len(state_machine.finished))

--- a/selftests/unit/plugin/test_spawner.py
+++ b/selftests/unit/plugin/test_spawner.py
@@ -1,4 +1,3 @@
-import asyncio
 import unittest
 
 from avocado.core import nrunner
@@ -14,9 +13,8 @@ class Process(unittest.TestCase):
         self.runtime_task = RuntimeTask(task)
         self.spawner = ProcessSpawner()
 
-    def test_spawned(self):
-        loop = asyncio.get_event_loop()
-        spawned = loop.run_until_complete(self.spawner.spawn_task(self.runtime_task))
+    async def test_spawned(self):
+        spawned = await self.spawner.spawn_task(self.runtime_task)
         self.assertTrue(spawned)
 
     def test_never_spawned(self):
@@ -32,9 +30,8 @@ class Mock(Process):
         self.runtime_task = RuntimeTask(task)
         self.spawner = MockSpawner()
 
-    def test_spawned_is_alive(self):
-        loop = asyncio.get_event_loop()
-        loop.run_until_complete(self.spawner.spawn_task(self.runtime_task))
+    async def test_spawned_is_alive(self):
+        await self.spawner.spawn_task(self.runtime_task)
         self.assertTrue(self.spawner.is_task_alive(self.runtime_task))
         self.assertFalse(self.spawner.is_task_alive(self.runtime_task))
 
@@ -47,9 +44,8 @@ class RandomMock(Mock):
         self.runtime_task = RuntimeTask(task)
         self.spawner = MockRandomAliveSpawner()
 
-    def test_spawned_is_alive(self):
-        loop = asyncio.get_event_loop()
-        loop.run_until_complete(self.spawner.spawn_task(self.runtime_task))
+    async def test_spawned_is_alive(self):
+        await self.spawner.spawn_task(self.runtime_task)
         # The likelihood of the random spawner returning the task is
         # not alive is 1 in 5.  This gives the random code 10000
         # chances of returning False, so it should, famous last words,


### PR DESCRIPTION
Python coroutines, AKA "async def" methods, are a common use case when
the code under test is based on asyncio.

Instead of forcing the user to come up with boiler plate code to run
each of the coroutines in a loop within a test, it's easier to
identify such methods and handle them accordingly.

One further possible improvement on top of this is to let the user
configure how the coroutine should be executed.  In this initial
implementation it simply gets one event loop and runs the coroutine
until it finishes.

Reference: https://github.com/avocado-framework/avocado/issues/4767
Signed-off-by: Cleber Rosa <crosa@redhat.com>