### PR TITLE
Safeloader: respect disable on all Python tests and ignore teststmpdir

### DIFF
--- a/avocado/core/safeloader/core.py
+++ b/avocado/core/safeloader/core.py
@@ -382,9 +382,12 @@ def find_python_tests(target_module, target_class, determine_match, path):
     return result, disabled
 
 
-def _determine_match_avocado(module, klass, docstring):
+def _determine_match_python(module, klass, docstring):
     """
-    Implements the match check for Avocado Instrumented Tests
+    Implements the match check for all Python based test classes
+
+    Meaning that the enable/disabled/recursive tags are respected for
+    Avocado Instrumented Tests and Python unittests.
     """
     directives = get_docstring_directives(docstring)
     if 'disable' in directives:
@@ -398,19 +401,10 @@ def _determine_match_avocado(module, klass, docstring):
 
 
 def find_avocado_tests(path):
-    return find_python_tests('avocado', 'Test', _determine_match_avocado, path)
-
-
-def _determine_match_unittest(module, klass,
-                              docstring):  # pylint: disable=W0613
-    """
-    Implements the match check for Python Unittests
-    """
-    return module.is_matching_klass(klass)
+    return find_python_tests('avocado', 'Test', _determine_match_python, path)
 
 
 def find_python_unittests(path):
     found, _ = find_python_tests('unittest', 'TestCase',
-                                 _determine_match_unittest,
-                                 path)
+                                 _determine_match_python, path)
     return found

--- a/avocado/core/safeloader/core.py
+++ b/avocado/core/safeloader/core.py
@@ -388,7 +388,7 @@ def _determine_match_avocado(module, klass, docstring):
     """
     directives = get_docstring_directives(docstring)
     if 'disable' in directives:
-        return True
+        return False
     if 'enable' in directives:
         return True
     if 'recursive' in directives:

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -215,6 +215,8 @@ class Test(unittest.TestCase, TestData):
 
     You'll inherit from this to write your own tests. Typically you'll want
     to implement setUp(), test*() and tearDown() methods on your own tests.
+
+    :avocado: disable
     """
     #: Arbitrary string which will be stored in `$logdir/whiteboard` location
     #: when the test finishes.

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -382,17 +382,7 @@ class LoaderTest(unittest.TestCase):
         path = os.path.join(os.path.dirname(os.path.dirname(__file__)),
                             '.data', 'safeloader', 'data', 'dont_detect_non_avocado.py')
         tests = self.loader.discover(path)
-        exps = [(test.PythonUnittest,
-                 'dont_detect_non_avocado.StaticallyNotAvocadoTest.test'),
-                (test.PythonUnittest,
-                 'dont_detect_non_avocado.StaticallyNotAvocadoTest.teststmpdir'),
-                (test.PythonUnittest,
-                 'dont_detect_non_avocado.NotTest.test2'),
-                (test.PythonUnittest,
-                 'dont_detect_non_avocado.NotTest.test'),
-                (test.PythonUnittest,
-                 'dont_detect_non_avocado.NotTest.teststmpdir')]
-        self._check_discovery(exps, tests)
+        self._check_discovery([], tests)
 
     def test_infinite_recurse(self):
         """Checks we don't crash on infinite recursion"""


### PR DESCRIPTION
`avocado.Test.teststmpdir` property is badly named because it matches what is expected to be a test.
    
Because Avocado inherits from Python's `unittest.TestCase`, and the extended coverage for corner cases in the safeloader introduced, along with the characteristic of the resolver that will give other plugins a chance, this property is now being found as a Python unittest test method.

These changes prevent that from happening, resulting in a more straightforward resolution.  That is, the `python-unittest` resolver plugin will never find tests in a `avocado.Test` based class that contains a `:avocado: disable` tag. 

Besides this change, a method rename is desirable, but this will cause API compatibility issues, which we guarantee until a new LTS release. So, for now, let's disable all test* methods on avocado.Test from being recognized as Python unittest methods.