### PR TITLE
nrunner: make sure any error will be captured, plus minor docs updates

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -460,12 +460,18 @@ class ExecRunner(BaseRunner):
 
         if env and 'PATH' not in env:
             env['PATH'] = os.environ.get('PATH')
-        process = subprocess.Popen(
-            [self.runnable.uri] + list(self.runnable.args),
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            env=env)
+        try:
+            process = subprocess.Popen(
+                [self.runnable.uri] + list(self.runnable.args),
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=env)
+        except Exception as e:
+            yield self.prepare_status('started')
+            yield self.prepare_status('finished', {'result': 'error',
+                                                   'fail_reason': str(e)})
+            return
 
         yield self.prepare_status('started')
         most_current_execution_state_time = None

--- a/docs/source/guides/user/chapters/introduction.rst
+++ b/docs/source/guides/user/chapters/introduction.rst
@@ -148,6 +148,12 @@ Let's suppose that you have 2 tests that matches ``./tests/unit/*.sh``:
 
 Avocado will run each one as a ``TAP`` test, as you desired.
 
+.. note:: Please, keep in mind that hint files needs absolute paths when
+   defining tests inside the ``[kinds]`` section.
+
+.. note:: Also, note that hint files are only supported when using the next
+   runner (``--test-runner='nrunner'``).
+
 Ignoring missing test references
 --------------------------------
 

--- a/docs/source/guides/user/chapters/introduction.rst
+++ b/docs/source/guides/user/chapters/introduction.rst
@@ -154,6 +154,13 @@ Avocado will run each one as a ``TAP`` test, as you desired.
 .. note:: Also, note that hint files are only supported when using the next
    runner (``--test-runner='nrunner'``).
 
+Since Avocado's next runner is capable of running tests not only in a
+subprocess but also in more isolated environments such as Podman containers,
+sending custom environment variables to the task executor can be achieved by
+using the ``kwargs`` parameter. Use a comma-separated list of variables here
+and Avocado will make sure your tests will receive those variables (regardless
+of the spawner type).
+
 Ignoring missing test references
 --------------------------------
 


### PR DESCRIPTION
If a script has not permission or has invalid syntax, subprocess.Popen
will raise exceptions that we aren't capturing. This will avoid some
tests being marked as SKIP without reason. Fixes #4793

Besides that, I'm also adding more info to our User's guide on hint files.

Signed-off-by: Beraldo Leal <bleal@redhat.com>

