### PR TITLE
Add command plugin and update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,18 +19,19 @@ RPM_BASE_NAME=python-avocado
 
 all:
 	@echo
+	@echo "User related targets:"
+	@echo "install-user:      Install avocado for the local user"
+	@echo
 	@echo "Development related targets:"
-	@echo "check:             Runs tree static check, unittests and fast functional tests"
-	@echo "smokecheck:        Runs the simplest possible avocado test execution"
 	@echo "develop:           Runs 'python setup.py --develop' on this tree alone"
 	@echo "develop-external:  Install Avocado's external plugins in develop mode."
 	@echo "                   You need to set AVOCADO_EXTERNAL_PLUGINS_PATH"
+	@echo "check:             Runs tree static check, unittests and fast functional tests"
+	@echo "smokecheck:        Runs the simplest possible avocado test execution"
 	@echo "clean:             Get rid of build scratch from this project and subprojects"
+	@echo "requirements-selftests:  Install runtime and selftests requirements"
 	@echo "variables:         Show the value of variables as defined in this Makefile or"
 	@echo "                   given as input to make"
-	@echo
-	@echo "Package requirements related targets"
-	@echo "requirements-selftests:  Install runtime and selftests requirements"
 	@echo
 	@echo "Platform independent distribution/installation related targets:"
 	@echo "source:       Create single source package with commit info, suitable for RPMs"
@@ -39,7 +40,7 @@ all:
 	@echo "pypi:         Create both source and binary wheel packages and show how to"
 	@echo "              upload them to PyPI"
 	@echo "python_build: Installs the build package, needed for source-pypi and wheel"
-	@echo "install:      Install on local system"
+	@echo "install:      Install on local system for all users (needs root)"
 	@echo "uninstall:    Uninstall Avocado and also subprojects"
 	@echo "man:          Generate the avocado man page"
 	@echo
@@ -91,6 +92,13 @@ python_build: pip
 
 clean:
 	$(PYTHON) setup.py clean --all
+
+install-user:
+	$(PYTHON) setup.py install --user
+	@echo
+	@echo "To install the optional plugins, please use: python setup.py plugin --install=<plugin_name>"
+	@echo
+	$(PYTHON) setup.py plugin --list
 
 uninstall:
 	$(PYTHON) setup.py develop --uninstall $(PYTHON_DEVELOP_ARGS)
@@ -144,4 +152,4 @@ propagate-version:
 		else echo ">> Skipping $$DIR"; fi;\
 	done
 
-.PHONY: source source-pypi wheel pypi install clean uninstall requirements-selftests smokecheck check develop develop-external propagate-version variables
+.PHONY: source source-pypi wheel pypi install install-user clean uninstall requirements-selftests smokecheck check develop develop-external propagate-version variables

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,6 @@ all:
 	@echo
 	@echo "Package requirements related targets"
 	@echo "requirements-selftests:  Install runtime and selftests requirements"
-	@echo "requirements-plugins:    Install plugins requirements"
 	@echo
 	@echo "Platform independent distribution/installation related targets:"
 	@echo "source:       Create single source package with commit info, suitable for RPMs"
@@ -96,14 +95,6 @@ clean:
 uninstall:
 	$(PYTHON) setup.py develop --uninstall $(PYTHON_DEVELOP_ARGS)
 
-requirements-plugins:
-	for PLUGIN in $(AVOCADO_OPTIONAL_PLUGINS);do\
-		if test -f $$PLUGIN/Makefile; then echo ">> REQUIREMENTS (Makefile) $$PLUGIN"; AVOCADO_DIRNAME=$(AVOCADO_DIRNAME) make -C $$PLUGIN requirements &>/dev/null;\
-		elif test -f $$PLUGIN/requirements.txt; then echo ">> REQUIREMENTS (requirements.txt) $$PLUGIN"; pip install $(PYTHON_DEVELOP_ARGS) -r $$PLUGIN/requirements.txt;\
-		else echo ">> SKIP $$PLUGIN";\
-		fi;\
-	done;
-
 requirements-selftests: pip
 	- $(PYTHON) -m pip install -r requirements-selftests.txt
 
@@ -153,4 +144,4 @@ propagate-version:
 		else echo ">> Skipping $$DIR"; fi;\
 	done
 
-.PHONY: source source-pypi wheel pypi install clean uninstall requirements-plugins requirements-selftests smokecheck check develop develop-external propagate-version variables
+.PHONY: source source-pypi wheel pypi install clean uninstall requirements-selftests smokecheck check develop develop-external propagate-version variables

--- a/docs/source/guides/contributor/chapters/environment.rst
+++ b/docs/source/guides/contributor/chapters/environment.rst
@@ -48,10 +48,8 @@ specific plugin's maintainer recommendations.
 
 Plugins that are developed by the Avocado team, will try to follow the
 same Setuptools standard for distributing the packages. Because of that,
-as a facility, you can use ``make requirements-plugins`` from the main
-Avocado project to install requirements of the plugins and ``make
-develop-external`` to install plugins in develop mode to. You just need
-to set where your plugins are installed, by using the environment
+you can use ``make develop-external`` to install plugins in develop mode to.
+You just need to set where your plugins are installed, by using the environment
 variable ``$AVOCADO_EXTERNAL_PLUGINS_PATH``. The workflow could be::
 
     $ cd $AVOCADO_PROJECTS_DIR
@@ -59,8 +57,9 @@ variable ``$AVOCADO_EXTERNAL_PLUGINS_PATH``. The workflow could be::
     $ git clone $AVOCADO_PROJECT2
     $ # Add more projects
     $ cd avocado    # go into the main Avocado project dir
-    $ make requirements-plugins
     $ export AVOCADO_EXTERNAL_PLUGINS_PATH=$AVOCADO_PROJECTS_DIR
     $ make develop-external
 
-You should see the process and status of each directory.
+You should see the process and status of each directory. This process
+will also handle plugins requirements automatically if they're
+defined in the ``setup.py` of every plugin.

--- a/setup.py
+++ b/setup.py
@@ -223,6 +223,39 @@ class Man(SimpleCommand):
             sys.exit(128)
 
 
+class Plugin(SimpleCommand):
+    """Handle plugins"""
+
+    description = 'Handle plugins'
+    user_options = [
+        ("list", 'l', "List available plugins"),
+        ("install=", 'i', "Plugin to install")
+    ]
+
+    def initialize_options(self):
+        self.list = False  # pylint: disable=W0201
+        self.install = None  # pylint: disable=W0201
+
+    def run(self):
+
+        plugins_list = []
+        directory = os.path.join(BASE_PATH, "optional_plugins")
+        for plugin in list(Path(directory).glob("*/setup.py")):
+            plugins_list.append(plugin.parts[-2])
+
+        if self.list or (not self.list and not self.install):
+            print("List of available plugins:\n ", "\n  ".join(plugins_list))
+            return
+
+        if self.install in plugins_list:
+            action = ["install", "--user"]
+            parent_dir = os.path.join(directory, self.install)
+            run([sys.executable, "setup.py"] + action, cwd=parent_dir, check=True)
+        else:
+            print(self.install, "is not a known plugin. Please, check the list of available plugins.")
+            return
+
+
 if __name__ == '__main__':
     # Force "make develop" inside the "readthedocs.org" environment
     if os.environ.get("READTHEDOCS") and "install" in sys.argv:
@@ -356,5 +389,6 @@ if __name__ == '__main__':
           cmdclass={'clean': Clean,
                     'develop': Develop,
                     'lint': Linter,
-                    'man': Man},
+                    'man': Man,
+                    'plugin': Plugin},
           install_requires=['setuptools'])


### PR DESCRIPTION
`setup.py`: Add custom command "plugin". This will allow users to install optional plugins easily.

`Makefile`: remove target requirements-plugins because requirements are already handled in the setup.py file of each plugin and add new target `install-user`.
