### PR TITLE
Revert "logging: we should not remove handlers when using the root log"

### DIFF
--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -643,8 +643,6 @@ def add_log_handler(logger, klass=logging.StreamHandler, stream=sys.stdout,
 
 
 def disable_log_handler(logger):
-    if not logger:
-        return
     if isinstance(logger, str):
         logger = logging.getLogger(logger)
     # Handlers might be reused elsewhere, can't delete them


### PR DESCRIPTION
While three of us (@beraldoleal , @willianrampazzo and myself) were not able to reproduce the issues in  #4797 and in https://github.com/avocado-framework/avocado/issues/4758#issuecomment-884247553, we do trust that the reports are accurate.

To avoid releasing Avocado 90.0 with a possible regression, let's revert this specific patch which @pevogam identified as the root cause (pun intended).

This reverts commit 470daaa080b59dcfc8fc041d0e146fdc5e3831fb.

Signed-off-by: Cleber Rosa <crosa@redhat.com>