### PR TITLE
nrunner: adds support to failfast

### DIFF
--- a/avocado/core/messages.py
+++ b/avocado/core/messages.py
@@ -15,6 +15,8 @@
 import os
 import time
 
+from avocado.core.exceptions import TestSkipError
+
 from .test_id import TestID
 
 
@@ -152,6 +154,14 @@ class FinishMessageHandler(BaseMessageHandler):
             job.result.check_test(message)
             job.result_events_dispatcher.map_method('end_test', job.result,
                                                     message)
+
+            result = message.get('result')
+            failfast = task.runnable.config.get('run.failfast')
+            if failfast and result == 'fail':
+                msg = ("Task {} exited with return code = {}. Since failfast "
+                       "is enabled remaining tasks should be skipped.")
+                raise TestSkipError(msg.format(task.identifier,
+                                               message.get('returncode')))
 
 
 class BaseRunningMessageHandler(BaseMessageHandler):

--- a/selftests/functional/test_nrunner.py
+++ b/selftests/functional/test_nrunner.py
@@ -24,6 +24,27 @@ class NRunnerFeatures(unittest.TestCase):
         with Job.from_config(job_config=config) as job:
             self.assertEqual(job.run(), 0)
 
+    @skipUnlessPathExists('/bin/false')
+    @skipUnlessPathExists('/bin/true')
+    def test_failfast(self):
+        status_server = "127.0.0.1:%u" % find_free_port()
+        config = {'run.references': ['/bin/true',
+                                     '/bin/false',
+                                     '/bin/true',
+                                     '/bin/true'],
+                  'run.test_runner': 'nrunner',
+                  'run.failfast': True,
+                  'nrunner.shuffle': False,
+                  'nrunner.status_server_listen': status_server,
+                  'nrunner.status_server_uri': status_server,
+                  'nrunner.max_parallel_tasks': 1}
+        with Job.from_config(job_config=config) as job:
+            self.assertEqual(job.run(), 1)
+            self.assertEqual(job.result.passed, 1)
+            self.assertEqual(job.result.errors, 0)
+            self.assertEqual(job.result.failed, 1)
+            self.assertEqual(job.result.skipped, 2)
+
 
 class RunnableRun(unittest.TestCase):
 


### PR DESCRIPTION
Although nrunner has a distributed architecture and new concepts like
Workers and Spawners, we can deliver the failfast feature with some
limitations. Depending on the number of parallel tasks, some tasks might
have already started when an error occurs, because of that failfast
will work here in a "best-effort" assumption. This change will raise an
Exception when a test is failed if 'failfast' is enabled. Fixes #3870

Signed-off-by: Beraldo Leal <bleal@redhat.com>