### PR TITLE
Resolver and Discoverer plugins initialization fix

### DIFF
--- a/avocado/core/plugin_interfaces.py
+++ b/avocado/core/plugin_interfaces.py
@@ -15,8 +15,6 @@
 
 import abc
 
-from .resolver import ResolverMixin
-
 
 class Plugin(abc.ABC):
     """Base for all plugins."""
@@ -216,6 +214,14 @@ class Varianter(Plugin):
         :param kwargs: Other free-form arguments
         :rtype: str
         """
+
+
+class ResolverMixin:
+    """Common utilities for Resolver implementations."""
+
+    def __init__(self, config=None):
+        from avocado.core.settings import settings
+        self.config = config or settings.as_dict()
 
 
 class Resolver(Plugin, ResolverMixin):

--- a/avocado/core/resolver.py
+++ b/avocado/core/resolver.py
@@ -19,7 +19,6 @@ Test resolver module.
 import os
 from enum import Enum
 
-from .. import settings
 from .enabled_extension_manager import EnabledExtensionManager
 from .exceptions import JobTestSuiteReferenceResolutionError
 
@@ -79,13 +78,6 @@ class ReferenceResolution:
                'resolutions="{}" info="{}" origin="{}">')
         return fmt.format(self.reference, self.result, self.resolutions,
                           self.info, self.origin)
-
-
-class ResolverMixin:
-    """Common utilities for Resolver implementations."""
-
-    def __init__(self, config=None):
-        self.config = config or settings.as_dict()
 
 
 class Resolver(EnabledExtensionManager):


### PR DESCRIPTION
In the 43286b5fa3083fc0d3fb4381a4a40024d120eb81 the incompatibility with Setting plugin was introduced. Because of that, avocado doesn't respect plugin specific configuration. This commit adds `settings` variable import to the `plugin_interfaces.py` Because of that, the `circular import` bug is created when the plugins and Settings is initialized during avocado initialization. This will make this import local to specified plugins, which fix this problem.

Signed-off-by: Jan Richter <jarichte@redhat.com>