### PR TITLE
Rename requirements-selftests.txt to requirements-dev.txt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
       - name: Install dependencies
-        run: pip install -r requirements-selftests.txt
+        run: pip install -r requirements-dev.txt
       - name: Installing Avocado in develop mode
         run: python3 setup.py develop --user
       - name: Avocado version
@@ -65,7 +65,7 @@ jobs:
           SELF_CHECK_CONTINUOUS: "yes"
           CC_TEST_REPORTER_ID: "387887b88a76f31c2c376219fc749689ea5975c8fe7fcd9609f1dcc139e053a6"
         run: |
-         pip install -r requirements-selftests.txt
+         pip install -r requirements-dev.txt
          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
          chmod +x ./cc-test-reporter
          ./cc-test-reporter before-build
@@ -105,7 +105,7 @@ jobs:
         run: python -c "import sys; print(sys.version)"
       - name: Install avocado
         run: |
-          python3 -m pip install -r requirements-selftests.txt
+          python3 -m pip install -r requirements-dev.txt
           python setup.py develop --user
       - name: Show avocado help
         run: python -m avocado --help

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
       - name: Install dependencies
-        run: pip install -r requirements-selftests.txt
+        run: pip install -r requirements-dev.txt
       - name: Installing Avocado in develop mode
         run: python3 setup.py develop --user
       - name: Avocado version

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ addons:
     - golang
 
 install:
-    - pip install -r requirements-selftests.txt
+    - pip install -r requirements-dev.txt
 
 script:
     - make check

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,8 @@ all:
 	@echo "                   given as input to make"
 	@echo
 	@echo "Package requirements related targets"
-	@echo "requirements-selftests:  Install runtime and selftests requirements"
-	@echo "requirements-plugins:    Install plugins requirements"
+	@echo "requirements-dev:      Install development requirements"
+	@echo "requirements-plugins:  Install plugins requirements"
 	@echo
 	@echo "Platform independent distribution/installation related targets:"
 	@echo "source:       Create single source package with commit info, suitable for RPMs"
@@ -104,8 +104,8 @@ requirements-plugins:
 		fi;\
 	done;
 
-requirements-selftests: pip
-	- $(PYTHON) -m pip install -r requirements-selftests.txt
+requirements-dev: pip
+	- $(PYTHON) -m pip install -r requirements-dev.txt
 
 smokecheck: clean uninstall develop
 	PYTHON=$(PYTHON) $(PYTHON) -m avocado run passtest.py
@@ -153,4 +153,4 @@ propagate-version:
 		else echo ">> Skipping $$DIR"; fi;\
 	done
 
-.PHONY: source source-pypi wheel pypi install clean uninstall requirements-plugins requirements-selftests smokecheck check develop develop-external propagate-version variables
+.PHONY: source source-pypi wheel pypi install clean uninstall requirements-plugins requirements-dev smokecheck check develop develop-external propagate-version variables

--- a/docs/source/guides/contributor/chapters/environment.rst
+++ b/docs/source/guides/contributor/chapters/environment.rst
@@ -14,11 +14,11 @@ You need to install few dependencies before start coding::
 
 Then install all the python dependencies::
 
- $ make requirements-selftests
+ $ make requirements-dev
 
 Or if you already have pip installed, you can run directly::
 
- $ pip install -r requirements-selftests.txt
+ $ pip install -r requirements-dev.txt
 
 
 Installing in develop mode

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-# Avocado test requirements
+# Avocado development requirements
 
 # inspektor (static and style checks)
 isort==5.8.0


### PR DESCRIPTION
The selftests requirements are a subset of the requirements
needed for development. Renaming the file to requirements-dev.txt
allows us to use this file for all development requirements.

Signed-off-by: Ana Guerrero Lopez <anguerre@redhat.com>