### PR TITLE
Software manager: fix extraction of deb packages

### DIFF
--- a/avocado/utils/ar.py
+++ b/avocado/utils/ar.py
@@ -1,0 +1,105 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2021
+# Author: Cleber Rosa <crosa@redhat.com>
+"""
+Module to read UNIX ar files
+"""
+
+import struct
+
+#: The first eight bytes of all AR archives
+MAGIC = b'!<arch>\n'
+
+#: The header for each file in the archive
+FILE_HEADER_FMT = '16s12s6s6s8s10s2c'
+FILE_HEADER_SIZE = struct.calcsize(FILE_HEADER_FMT)
+
+
+class ArMember:
+    """A member of an UNIX ar archive."""
+
+    def __init__(self, identifier, size, offset):
+        self.identifier = identifier
+        self.size = size
+        self.offset = offset
+
+    def __repr__(self):
+        return '<ArMember "%s" size=%u offset=%u>' % (self.identifier,
+                                                      self.size,
+                                                      self.offset)
+
+
+class Ar:
+    """An UNIX ar archive."""
+
+    def __init__(self, path):
+        self._path = path
+        self._file = None
+        self._position = None
+        self._valid = False
+
+    def __enter__(self):
+        self._file = open(self._path, 'r+b')
+        return self._file
+
+    def __exit__(self, _exc_type, _exc_value, _traceback):
+        self._file.close()
+
+    def is_valid(self):
+        """Checks if a file looks like an AR archive.
+
+        :param path: path to a file
+        :returns: bool
+        """
+        with self as open_file:
+            return open_file.read(8) == MAGIC
+
+    def __iter__(self):
+        self._position = 8
+        self._valid = self.is_valid()
+        return self
+
+    def __next__(self):
+        if not self._valid:
+            raise StopIteration
+
+        with self as open_file:
+            open_file.seek(self._position)
+            try:
+                member = struct.unpack(FILE_HEADER_FMT,
+                                       open_file.read(FILE_HEADER_SIZE))
+            except struct.error:
+                raise StopIteration
+
+            # No support for extended file names
+            identifier = member[0].decode('ascii').strip()
+            # from bytes containing a decimal to int
+            size = int(member[5].decode('ascii').strip())
+
+            data_position = self._position + FILE_HEADER_SIZE
+            # All data sections is aligned at 2 bytes
+            data_position += data_position % 2
+            self._position += FILE_HEADER_SIZE + size
+            return ArMember(identifier, size, data_position)
+
+    def list(self):
+        """Return the name of the members in the archive."""
+        return [member.identifier for member in self]
+
+    def read_member(self, identifier):
+        """Returns the data for the given member identifier."""
+        for member in self:
+            if identifier == member.identifier:
+                with self as open_file:
+                    open_file.seek(member.offset)
+                    return open_file.read(member.size)

--- a/avocado/utils/software_manager/backends/dpkg.py
+++ b/avocado/utils/software_manager/backends/dpkg.py
@@ -1,6 +1,8 @@
+import io
 import logging
 import os
 import re
+import tarfile
 
 from ... import ar
 from ... import path as utils_path
@@ -86,12 +88,12 @@ class DpkgBackend(BaseBackend):
         """
         abs_path = os.path.abspath(os.path.expanduser(package_path))
         dest = dest_path or os.path.curdir
-
-        # 'ar' command does not creates the directory if doesn't exists
         os.makedirs(dest, exist_ok=True)
-
-        # If something goes wrong process.run will raise a CmdError exception
-        process.run("cd {} && ar -x {}".format(dest, abs_path), shell=True)
+        archive = ar.Ar(abs_path)
+        data_tarball_name = archive.list()[2]
+        member_data = archive.read_member(data_tarball_name)
+        tarball = tarfile.open(fileobj=io.BytesIO(member_data))
+        tarball.extractall(dest)
         return dest
 
     def list_files(self, package):

--- a/avocado/utils/software_manager/backends/rpm.py
+++ b/avocado/utils/software_manager/backends/rpm.py
@@ -235,7 +235,7 @@ class RpmBackend(BaseBackend):
         """
         abs_path = os.path.abspath(os.path.expanduser((package_path)))
         try:
-            result = process.run("rpm -qip {}".format(abs_path))
+            result = process.run("rpm -qp {}".format(abs_path))
         except process.CmdError:
             return False
         if result.exit_status == 0:

--- a/selftests/.data/guaca.a
+++ b/selftests/.data/guaca.a
@@ -1,0 +1,4 @@
+!<arch>
+shopping        1627526682  1000  1000  100664  14        `
+avocados, saltrecipe          1627526689  1000  1000  100664  8         `
+cut, mix

--- a/selftests/functional/test_software_manager.py
+++ b/selftests/functional/test_software_manager.py
@@ -5,6 +5,7 @@ from avocado.utils import software_manager
 from selftests.utils import BASEDIR, TestCaseTmpDir, skipUnlessPathExists
 
 
+@skipUnlessPathExists('/usr/bin/rpm2cpio')
 class SoftwareManager(TestCaseTmpDir):
     def setUp(self):
         super().setUp()
@@ -13,24 +14,18 @@ class SoftwareManager(TestCaseTmpDir):
         self.rpm_path = os.path.join(assets_dir, "hello.rpm")
         self.deb_path = os.path.join(assets_dir, "hello.deb")
 
-    @skipUnlessPathExists('/usr/bin/ar')
-    @skipUnlessPathExists('/usr/bin/rpm2cpio')
     def test_extract_from_rpm(self):
         manager = software_manager.SoftwareManager()
         result = manager.extract_from_package(self.rpm_path,
                                               self.tmpdir.name)
         self.assertEqual(self.tmpdir.name, result)
 
-    @skipUnlessPathExists('/usr/bin/ar')
-    @skipUnlessPathExists('/usr/bin/rpm2cpio')
     def test_extract_from_deb(self):
         manager = software_manager.SoftwareManager()
         result = manager.extract_from_package(self.deb_path,
                                               self.tmpdir.name)
         self.assertEqual(self.tmpdir.name, result)
 
-    @skipUnlessPathExists('/usr/bin/ar')
-    @skipUnlessPathExists('/usr/bin/rpm2cpio')
     def test_extract_permission(self):
         manager = software_manager.SoftwareManager()
         with self.assertRaises(NotImplementedError) as context:

--- a/selftests/functional/test_software_manager.py
+++ b/selftests/functional/test_software_manager.py
@@ -5,6 +5,7 @@ from avocado.utils import software_manager
 from selftests.utils import BASEDIR, TestCaseTmpDir, skipUnlessPathExists
 
 
+@skipUnlessPathExists('/usr/bin/cpio')
 @skipUnlessPathExists('/usr/bin/rpm2cpio')
 class SoftwareManager(TestCaseTmpDir):
     def setUp(self):

--- a/selftests/unit/utils/test_ar.py
+++ b/selftests/unit/utils/test_ar.py
@@ -1,0 +1,38 @@
+import os
+import unittest
+
+from avocado.utils import ar
+from selftests.utils import BASEDIR
+
+
+class ArTest(unittest.TestCase):
+
+    def test_is_ar(self):
+        path = os.path.join(BASEDIR, "selftests", ".data", "hello.deb")
+        self.assertTrue(ar.Ar(path).is_valid())
+
+    def test_is_not_ar(self):
+        path = os.path.join(BASEDIR, "selftests", ".data", "hello.rpm")
+        self.assertFalse(ar.Ar(path).is_valid())
+
+    def test_iter(self):
+        path = os.path.join(BASEDIR, "selftests", ".data", "hello.deb")
+        expected = [("debian-binary", 4, 68),
+                    ("control.tar.xz", 1868, 132),
+                    ("data.tar.xz", 54072, 2060)]
+        for count, member in enumerate(ar.Ar(path)):
+            self.assertEqual(expected[count][0], member.identifier)
+            self.assertEqual(expected[count][1], member.size)
+            self.assertEqual(expected[count][2], member.offset)
+
+    def test_list(self):
+        path = os.path.join(BASEDIR, "selftests", ".data", "hello.deb")
+        self.assertEqual(ar.Ar(path).list(),
+                         ["debian-binary", "control.tar.xz", "data.tar.xz"])
+
+    def test_read_member(self):
+        path = os.path.join(BASEDIR, "selftests", ".data", "guaca.a")
+        self.assertEqual(ar.Ar(path).read_member('shopping'),
+                         b'avocados, salt')
+        self.assertEqual(ar.Ar(path).read_member('recipe'),
+                         b'cut, mix')

--- a/selftests/unit/utils/test_software_manager.py
+++ b/selftests/unit/utils/test_software_manager.py
@@ -2,7 +2,7 @@ import os
 import unittest
 
 from avocado.utils import distro, software_manager
-from selftests.utils import setup_avocado_loggers
+from selftests.utils import BASEDIR, setup_avocado_loggers
 
 setup_avocado_loggers()
 
@@ -21,6 +21,19 @@ class Apt(unittest.TestCase):
         self.assertEqual(sm.provides('/bin/login'), 'login')
         self.assertTrue(isinstance(sm.backend,
                                    software_manager.backends.apt.AptBackend))
+
+
+class Dpkg(unittest.TestCase):
+
+    def test_is_valid(self):
+        deb_path = os.path.join(BASEDIR, 'selftests', '.data', 'hello.deb')
+        dpkg = software_manager.backends.dpkg.DpkgBackend
+        self.assertTrue(dpkg.is_valid(deb_path))
+
+    def test_is_not_valid(self):
+        not_deb_path = os.path.join(BASEDIR, 'selftests', '.data', 'guaca.a')
+        dpkg = software_manager.backends.dpkg.DpkgBackend
+        self.assertFalse(dpkg.is_valid(not_deb_path))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The actual files that users will have access when installing deb packages are not the contents of the "ar" archive, but the contents of the "data.tar.*" tarball.