### PR TITLE
nrunner: adds support to failfast (v2)

### DIFF
--- a/avocado/core/task/statemachine.py
+++ b/avocado/core/task/statemachine.py
@@ -130,7 +130,9 @@ class Worker:
                 for finished_rt_task in self._state_machine.finished:
                     if (finished_rt_task.task is task and
                             finished_rt_task.status == 'FAILED ON TRIAGE'):
-                        await fail_on_triage(runtime_task)
+
+                        await self._state_machine.finish_task(runtime_task,
+                                                              "FAILED ON TRIAGE")
                         return
                 # from here, this dependency `task` ran, so, let's check
                 # the its latest data in the status repo
@@ -145,15 +147,11 @@ class Worker:
                     return
                 # if this dependency task failed, skip the parent task
                 if latest_task_data['result'] not in ['pass']:
-                    await fail_on_triage(runtime_task)
+                    await self._state_machine.finish_task(runtime_task,
+                                                          "FAILED ON TRIAGE")
                     return
             # everything is fine!
             return True
-
-        async def fail_on_triage(runtime_task):
-            async with self._state_machine.lock:
-                self._state_machine.finished.append(runtime_task)
-                runtime_task.status = 'FAILED ON TRIAGE'
 
         try:
             async with self._state_machine.lock:
@@ -167,7 +165,8 @@ class Worker:
             requirements_ok = (
                     await self._spawner.check_task_requirements(runtime_task))
             if not requirements_ok:
-                await fail_on_triage(runtime_task)
+                await self._state_machine.finish_task(runtime_task,
+                                                      "FAILED ON TRIAGE")
                 return
 
         # handle task dependencies
@@ -223,8 +222,8 @@ class Worker:
             async with self._state_machine.lock:
                 self._state_machine.started.append(runtime_task)
         else:
-            async with self._state_machine.lock:
-                self._state_machine.finished.append(runtime_task)
+            await self._state_machine.finish_task(runtime_task,
+                                                  "FAILED ON START")
 
     async def monitor(self):
         """Reads from started, moves into finished."""
@@ -251,8 +250,7 @@ class Worker:
         if task_data and task_data.get('result') == "fail" and failfast:
             await self._state_machine.abort("FAILFAST is enabled")
 
-        async with self._state_machine.lock:
-            self._state_machine.finished.append(runtime_task)
+        await self._state_machine.finish_task(runtime_task)
 
     async def run(self):
         """Pushes Tasks forward and makes them do something with their lives."""

--- a/avocado/core/task/statemachine.py
+++ b/avocado/core/task/statemachine.py
@@ -47,6 +47,52 @@ class TaskStateMachine:
                            self._ready, self._started])
         return not pending
 
+    async def abort(self, status_reason=None):
+        """Abort all non-started tasks.
+
+        This method will move all non-started tasks to finished with a specific
+        reason.
+
+        :param status_reason: string reason. Optional.
+        """
+        await self.abort_queue('requested', status_reason)
+        await self.abort_queue('triaging', status_reason)
+        await self.abort_queue('ready', status_reason)
+
+    async def abort_queue(self, queue_name, status_reason=None):
+        """Abort all tasks inside a specific queue adding a status reason.
+
+        :param queue_name: a string with the queue name.
+        :param status_reason: string reason. Optional.
+        """
+        to_remove = []
+        async with self._lock:
+            queue = getattr(self, queue_name)
+            for _ in range(len(queue)):
+                if queue_name == 'requested':
+                    runtime_task = queue.popleft()
+                else:
+                    runtime_task = queue.pop(0)
+                to_remove.append(runtime_task)
+
+        for task in to_remove:
+            await self.finish_task(task, status_reason)
+
+    async def finish_task(self, runtime_task, status_reason=None):
+        """Include a task to the finished queue with a specific reason.
+
+        This method is assuming that you have removed (pop) the task from the
+        original queue.
+
+        :param runtime_task: A running task object.
+        :param status_reason: string reason. Optional.
+        """
+        async with self._lock:
+            if runtime_task not in self.finished:
+                if status_reason:
+                    runtime_task.status = status_reason
+                self.finished.append(runtime_task)
+
 
 class Worker:
 
@@ -199,6 +245,11 @@ class Worker:
                 runtime_task.status = 'FINISHED'
             except asyncio.TimeoutError:
                 runtime_task.status = 'FINISHED W/ TIMEOUT'
+        task = runtime_task.task
+        task_data = self._state_machine._status_repo.get_latest_task_data(str(task.identifier))
+        failfast = task.runnable.config.get('run.failfast')
+        if task_data and task_data.get('result') == "fail" and failfast:
+            await self._state_machine.abort("FAILFAST is enabled")
 
         async with self._state_machine.lock:
             self._state_machine.finished.append(runtime_task)

--- a/selftests/functional/test_nrunner.py
+++ b/selftests/functional/test_nrunner.py
@@ -24,6 +24,27 @@ class NRunnerFeatures(unittest.TestCase):
         with Job.from_config(job_config=config) as job:
             self.assertEqual(job.run(), 0)
 
+    @skipUnlessPathExists('/bin/false')
+    @skipUnlessPathExists('/bin/true')
+    def test_failfast(self):
+        status_server = "127.0.0.1:%u" % find_free_port()
+        config = {'run.references': ['/bin/true',
+                                     '/bin/false',
+                                     '/bin/true',
+                                     '/bin/true'],
+                  'run.test_runner': 'nrunner',
+                  'run.failfast': True,
+                  'nrunner.shuffle': False,
+                  'nrunner.status_server_listen': status_server,
+                  'nrunner.status_server_uri': status_server,
+                  'nrunner.max_parallel_tasks': 1}
+        with Job.from_config(job_config=config) as job:
+            self.assertEqual(job.run(), 1)
+            self.assertEqual(job.result.passed, 1)
+            self.assertEqual(job.result.errors, 0)
+            self.assertEqual(job.result.failed, 1)
+            self.assertEqual(job.result.skipped, 2)
+
 
 class RunnableRun(unittest.TestCase):
 

--- a/spell.ignore
+++ b/spell.ignore
@@ -336,6 +336,7 @@ rhs
 automagically
 preorder
 subtree
+failfast
 failtest
 failtests
 psutil


### PR DESCRIPTION
Although nrunner has a distributed architecture and new concepts like
Workers and Spawners, we can deliver the failfast feature with some
limitations. Depending on the number of parallel tasks, some tasks might
have already started when an error occurs, because of that, failfast will
work here in a "best-effort" assumption. This change will move all
non-started tasks to the finished queue when failfast is enabled. Fixes #3870

Signed-off-by: Beraldo Leal <bleal@redhat.com>

### Changes from v1:

 - Complete new implementation using state-machine (Thanks to @willianrampazzo)