### PR TITLE
Sysinfo: cleanups and preps for nrunner

### DIFF
--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -44,6 +44,22 @@ class Collectible(ABC):
     def run(self, logdir):
         pass
 
+    def __eq__(self, other):
+        if hash(self) == hash(other):
+            return True
+        elif isinstance(other, Collectible):
+            return False
+        return NotImplemented
+
+    def __ne__(self, other):
+        result = self.__eq__(other)
+        if result is NotImplemented:
+            return result
+        return not result
+
+    def __hash__(self):
+        return hash((self.log_path))
+
 
 class Logfile(Collectible):
 

--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -20,6 +20,7 @@ import shlex
 import shutil
 import subprocess
 import time
+from abc import ABC, abstractmethod
 
 from ..utils import astring, genio
 from ..utils import path as utils_path
@@ -30,7 +31,7 @@ from .settings import settings
 log = logging.getLogger("avocado.sysinfo")
 
 
-class Collectible:
+class Collectible(ABC):
 
     """
     Abstract class for representing collectibles by sysinfo.
@@ -38,6 +39,10 @@ class Collectible:
 
     def __init__(self, log_path):
         self.log_path = astring.string_to_safe_path(log_path)
+
+    @abstractmethod
+    def run(self, logdir):
+        pass
 
 
 class Logfile(Collectible):

--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -39,18 +39,6 @@ class Collectible:
     def __init__(self, log_path):
         self.log_path = astring.string_to_safe_path(log_path)
 
-    def readline(self, logdir):
-        """
-        Read one line of the collectible object.
-
-        :param logdir: Path to a log directory.
-        """
-        path = os.path.join(logdir, self.log_path)
-        if os.path.exists(path):
-            return genio.read_one_line(path)
-        else:
-            return ""
-
 
 class Logfile(Collectible):
 


### PR DESCRIPTION
While reviewing #4806, I had the impression that less code needed to be duplicated between the nrunner-based and the current sysinfo implementation.  This is an exercise at that, which also results in cleanups and overall improvements (shamelessly copied from @richtja's work).