### PR TITLE
nrunner: adds support to failfast (v3)

### DIFF
--- a/selftests/functional/test_nrunner.py
+++ b/selftests/functional/test_nrunner.py
@@ -24,6 +24,27 @@ class NRunnerFeatures(unittest.TestCase):
         with Job.from_config(job_config=config) as job:
             self.assertEqual(job.run(), 0)
 
+    @skipUnlessPathExists('/bin/false')
+    @skipUnlessPathExists('/bin/true')
+    def test_failfast(self):
+        status_server = "127.0.0.1:%u" % find_free_port()
+        config = {'run.references': ['/bin/true',
+                                     '/bin/false',
+                                     '/bin/true',
+                                     '/bin/true'],
+                  'run.test_runner': 'nrunner',
+                  'run.failfast': True,
+                  'nrunner.shuffle': False,
+                  'nrunner.status_server_listen': status_server,
+                  'nrunner.status_server_uri': status_server,
+                  'nrunner.max_parallel_tasks': 1}
+        with Job.from_config(job_config=config) as job:
+            self.assertEqual(job.run(), 1)
+            self.assertEqual(job.result.passed, 1)
+            self.assertEqual(job.result.errors, 0)
+            self.assertEqual(job.result.failed, 1)
+            self.assertEqual(job.result.skipped, 2)
+
 
 class RunnableRun(unittest.TestCase):
 

--- a/spell.ignore
+++ b/spell.ignore
@@ -336,6 +336,7 @@ rhs
 automagically
 preorder
 subtree
+failfast
 failtest
 failtests
 psutil


### PR DESCRIPTION
Although nrunner has a distributed architecture and new concepts like
Workers and Spawners, we can deliver the failfast feature with some
limitations. Depending on the number of parallel tasks, some tasks might
have already started when an error occurs, because of that, failfast will
work here in a "best-effort" assumption. This change will move all
non-started tasks to the finished queue when failfast is enabled. Fixes #3870

Signed-off-by: Beraldo Leal <bleal@redhat.com>

### Changes from v2:

 - Using `self._state_machine._status_repo.result_stats` as source of truth
 - Assuming that each test suite has its own StateMachine, so no need to double-check
 
### Changes from v1:

 - Complete new implementation using state-machine (Thanks to @willianrampazzo)