### PR TITLE
interfaces.py: Support get the interface details without IP version

### DIFF
--- a/avocado/utils/network/interfaces.py
+++ b/avocado/utils/network/interfaces.py
@@ -61,8 +61,10 @@ class NetworkInterface:
             raise NWException(msg)
         return "{}/ifcfg-{}".format(path, self.name)
 
-    def _get_interface_details(self, version=4):
-        cmd = "ip -{} -j address show {}".format(version, self.name)
+    def _get_interface_details(self, version=None):
+        cmd = "ip -j link show {}".format(self.name)
+        if version:
+            cmd = "ip -{} -j address show {}".format(version, self.name)
         output = run_command(cmd, self.host)
         try:
             result = json.loads(output)
@@ -71,7 +73,7 @@ class NetworkInterface:
                     return item
             raise NWException("Interface not found")
         except (NWException, json.JSONDecodeError):
-            msg = "Unable to get IP address on interface {}".format(self.name)
+            msg = "Unable to get the details of interface {}".format(self.name)
             log.error(msg)
             raise NWException(msg)
 


### PR DESCRIPTION
Currently, if the interface does have not an IP address,
"_get_interface_details" will return an empty list, so this is a problem
to set default version=4. Most of the time, we only need the properties
of the interface itself(e.g: get_mtu), only "get_ipaddrs" will use IP addresses in
interface.py.

Signed-off-by: Yihuang Yu <yihyu@redhat.com>