### PR TITLE
setup.py: add commands test&plugin, add a CI for setup.py and docs update

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -71,7 +71,7 @@ debian_egg_task:
 fedora_selftests_task:
     selftests_script:
        - make develop
-       - PATH=$HOME/.local/bin:$PATH LANG=en_US.UTF-8 AVOCADO_CHECK_LEVEL=0 python3 selftests/check.py --disable-static-checks
+       - PATH=$HOME/.local/bin:$PATH LANG=en_US.UTF-8 AVOCADO_CHECK_LEVEL=0 python3 selftests/check.py --job-api --nrunner-interface --unit --jobs --functional --optional-plugins
     container:
         matrix:
           - image: quay.io/avocado-framework/avocado-ci-fedora-33

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,6 @@ jobs:
         run: avocado --version
       - name: Avocado smoketest
         run: python -m avocado run passtest.py
-      - name: Quick lint checks
-        run: python setup.py lint
       - name: Tree static check, unittests and fast functional tests
         env:
           AVOCADO_LOG_DEBUG: "yes"

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -1,0 +1,230 @@
+name: Setup tests
+
+on:
+# Runs at 5:00 UTC on Mondays
+  schedule:
+    - cron: "0 5 * * 1"
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+
+  user-installation:
+    name: User installation commands
+    runs-on: ubuntu-20.04
+
+    strategy:
+      matrix:
+        python-version: [3.x]
+      fail-fast: false
+
+    steps:
+      - run: echo "Job triggered by a ${{ github.event_name }} event on branch is ${{ github.ref }} in repository is ${{ github.repository }}, runner on ${{ runner.os }}"
+      - name: Check out repository code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Installing Avocado
+        run: python3 setup.py install --user
+      - name: Installing plugins
+        run: |
+         python3 setup.py plugin --install=golang --user
+         python3 setup.py plugin --install=html --user
+         python3 setup.py plugin --install=result_upload --user
+         python3 setup.py plugin --install=resultsdb --user
+         python3 setup.py plugin --install=robot --user
+         python3 setup.py plugin --install=varianter_cit --user
+         python3 setup.py plugin --install=varianter_pict --user
+         python3 setup.py plugin --install=varianter_yaml_to_mux --user
+      - name: Avocado version
+        run: avocado --version
+      - name: Avocado smoketest legacy runner
+        run: avocado run --test-runner=runner examples/tests/passtest.py
+      - name: Avocado smoketest
+        run: avocado run --test-runner=nrunner examples/tests/passtest.py
+      - name: Avocado two tests
+        run: avocado run --test-runner=nrunner /usr/bin/true examples/tests/passtest.py
+      - run: echo "🥑 This job's status is ${{ job.status }}."
+
+
+  system-wide-installation:
+    name: System wide installation commands
+    runs-on: ubuntu-20.04
+
+    strategy:
+      matrix:
+        python-version: [3.x]
+      fail-fast: false
+
+    steps:
+      - run: echo "Job triggered by a ${{ github.event_name }} event on branch is ${{ github.ref }} in repository is ${{ github.repository }}, runner on ${{ runner.os }}"
+      - name: Check out repository code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Installing Avocado
+        run: python3 setup.py install
+      - name: Installing plugins
+        run: |
+         python3 setup.py plugin --install=golang
+         python3 setup.py plugin --install=html
+         python3 setup.py plugin --install=result_upload
+         python3 setup.py plugin --install=resultsdb
+         python3 setup.py plugin --install=robot
+         python3 setup.py plugin --install=varianter_cit
+         python3 setup.py plugin --install=varianter_pict
+         python3 setup.py plugin --install=varianter_yaml_to_mux
+      - name: Avocado version
+        run: avocado --version
+      - name: Avocado smoketest legacy runner
+        run: avocado run --test-runner=runner examples/tests/passtest.py
+      - name: Avocado smoketest
+        run: avocado run --test-runner=nrunner examples/tests/passtest.py
+      - name: Avocado two tests
+        run: avocado run --test-runner=nrunner /usr/bin/true examples/tests/passtest.py
+      - run: echo "🥑 This job's status is ${{ job.status }}."
+
+
+  devel-user-installation:
+    name: Developer user commands
+    runs-on: ubuntu-20.04
+
+    strategy:
+      matrix:
+        python-version: [3.x]
+      fail-fast: false
+
+    steps:
+      - run: echo "Job triggered by a ${{ github.event_name }} event on branch is ${{ github.ref }} in repository is ${{ github.repository }}, runner on ${{ runner.os }}"
+      - name: Check out repository code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: pip3 install -r requirements-dev.txt
+      - name: Installing Avocado in develop mode
+        run: python3 setup.py develop --user
+      - name: Avocado version
+        run: avocado --version
+      - name: Avocado smoketest legacy runner
+        run: avocado run --test-runner=runner examples/tests/passtest.py
+      - name: Avocado smoketest
+        run: avocado run --test-runner=nrunner examples/tests/passtest.py
+      - name: Avocado build manpage
+        run: python3 setup.py man
+      - name: Tree static check, unittests and fast functional tests
+        run: python3 setup.py test
+      - name: Uninstall avocado
+        run: python3 setup.py develop --user --uninstall
+      - run: echo "🥑 This job's status is ${{ job.status }}."
+
+
+  devel-wide-system-installation:
+    name: Developer system wide commands
+    runs-on: ubuntu-20.04
+
+    strategy:
+      matrix:
+        python-version: [3.x]
+      fail-fast: false
+
+    steps:
+      - run: echo "Job triggered by a ${{ github.event_name }} event on branch is ${{ github.ref }} in repository is ${{ github.repository }}, runner on ${{ runner.os }}"
+      - name: Check out repository code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: pip3 install -r requirements-dev.txt
+      - name: Installing Avocado in develop mode
+        run: python3 setup.py develop
+      - name: Avocado version
+        run: avocado --version
+      - name: Avocado smoketest legacy runner
+        run: avocado run --test-runner=runner examples/tests/passtest.py
+      - name: Avocado smoketest
+        run: avocado run --test-runner=nrunner examples/tests/passtest.py
+      - name: Avocado build manpage
+        run: python3 setup.py man
+      - name: Tree static check, unittests and fast functional tests
+        run: python3 setup.py test
+      - name: Uninstall avocado
+        run: python3 setup.py develop --uninstall
+      - run: echo "🥑 This job's status is ${{ job.status }}."
+
+
+  virtualenv-installation:
+    name: Virtualenv installation
+    runs-on: ubuntu-20.04
+
+    steps:
+      - run: echo "Job triggered by a ${{ github.event_name }} event on branch is ${{ github.ref }} in repository is ${{ github.repository }}, runner on ${{ runner.os }}"
+      - name: Check out repository code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Install packages
+        run: |
+         sudo apt-get update
+         sudo apt-get install -y  python3-virtualenv
+      - name: virtualenv
+        run: |
+         python3 -m venv env
+         source env/bin/activate
+         python3 setup.py install
+         python3 setup.py plugin --install=golang
+         python3 setup.py plugin --install=html
+         python3 setup.py plugin --install=result_upload
+         python3 setup.py plugin --install=resultsdb
+         python3 setup.py plugin --install=robot
+         python3 setup.py plugin --install=varianter_cit
+         python3 setup.py plugin --install=varianter_pict
+         python3 setup.py plugin --install=varianter_yaml_to_mux
+         avocado --version
+         avocado run --test-runner=runner examples/tests/passtest.py
+         avocado run --test-runner=nrunner examples/tests/passtest.py
+         deactivate
+      - run: echo "🥑 This job's status is ${{ job.status }}."
+
+  devel-virtualenv-installation:
+    name: Developer Virtualenv installation
+    runs-on: ubuntu-20.04
+
+    steps:
+      - run: echo "Job triggered by a ${{ github.event_name }} event on branch is ${{ github.ref }} in repository is ${{ github.repository }}, runner on ${{ runner.os }}"
+      - name: Check out repository code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Install packages
+        run: |
+         sudo apt-get update
+         sudo apt-get install -y  python3-virtualenv
+      - name: virtualenv
+        run: |
+         python3 -m venv env
+         source env/bin/activate
+         python3 setup.py develop
+         avocado --version
+         avocado run --test-runner=runner examples/tests/passtest.py
+         avocado run --test-runner=nrunner examples/tests/passtest.py
+         python3 setup.py test
+         deactivate
+      - run: echo "🥑 This job's status is ${{ job.status }}."

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -40,8 +40,6 @@ jobs:
         run: avocado --version
       - name: Avocado smoketest
         run: python -m avocado run passtest.py
-      - name: Quick lint checks
-        run: python setup.py lint
       - name: Tree static check, unittests and fast functional tests
         env:
           AVOCADO_LOG_DEBUG: "yes"

--- a/docs/source/guides/contributor/chapters/environment.rst
+++ b/docs/source/guides/contributor/chapters/environment.rst
@@ -29,7 +29,7 @@ registered. If you're hacking on Avocado and want to use the same, possibly
 modified, source for running your tests and experiments, you may do so with one
 additional step::
 
-  $ make develop
+  $ python3 setup.py develop [--user]
 
 On POSIX systems this will create an "egg link" to your original source tree under
 ``$HOME/.local/lib/pythonX.Y/site-packages``. Then, on your original source tree, an

--- a/docs/source/guides/user/chapters/installing.rst
+++ b/docs/source/guides/user/chapters/installing.rst
@@ -119,13 +119,25 @@ Installing from source code
 First make sure you have a basic set of packages installed. The following
 applies to Fedora based distributions, please adapt to your platform::
 
-    $ sudo dnf install -y python3 git gcc python3-devel python3-pip libvirt-devel libffi-devel openssl-devel libyaml-devel redhat-rpm-config xz-devel
+    $ sudo dnf install -y python3 git gcc python3-pip
 
 Then to install Avocado from the git repository run::
 
     $ git clone git://github.com/avocado-framework/avocado.git
     $ cd avocado
-    $ sudo python3 setup.py install
+    $ python3 setup.py install --user
+
+Optionally, to install the plugins run:
+
+    $ python3 setup.py plugin --install=golang --user
+    $ python3 setup.py plugin --install=html --user
+    $ python3 setup.py plugin --install=result_upload --user
+    $ python3 setup.py plugin --install=resultsdb --user
+    $ python3 setup.py plugin --install=robot --user
+    $ python3 setup.py plugin --install=varianter_cit --user
+    $ python3 setup.py plugin --install=varianter_pict --user
+    $ python3 setup.py plugin --install=varianter_yaml_to_mux --user
+
 
 .. _Virtualization:Tests project in OpenSUSE build service: https://build.opensuse.org/project/show/Virtualization:Tests
 .. _Avocado-VT: https://avocado-vt.readthedocs.io/en/latest/GetStartedGuide.html#installing-avocado-vt

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -174,7 +174,7 @@ PATH=%{buildroot}%{_bindir}:%{buildroot}%{_libexecdir}/avocado:$PATH \
     PYTHONPATH=%{buildroot}%{python3_sitelib}:. \
     LANG=en_US.UTF-8 \
     AVOCADO_CHECK_LEVEL=0 \
-    %{python3} selftests/check.py --disable-static-checks --disable-plugin-checks=robot
+    %{python3} selftests/check.py --job-api --nrunner-interface --unit --jobs --functional --optional-plugins --disable-plugin-checks=robot
 %endif
 
 %files -n python3-avocado
@@ -368,6 +368,9 @@ Again Shell code (and possibly other similar shells).
 %{_libexecdir}/avocado*
 
 %changelog
+* Thu Aug 05 2021 Ana Guerrero Lopez <anguerre@redhat.com> - 90.0-2
+- Use new options of check.py to run tests.
+
 * Mon Jul 26 2021 Cleber Rosa <crosa@redhat.com> - 90.0-1
 - New release
 

--- a/setup.py
+++ b/setup.py
@@ -186,22 +186,13 @@ class SimpleCommand(Command):
 
 
 class Linter(SimpleCommand):
-    """Lint Python source code."""
+    """Lint Python source code. (Deprecated)"""
 
     description = 'Run logical, stylistic, analytical and formatter checks.'
 
     def run(self):
-        try:
-            run(['selftests/inspekt-indent.sh'], check=True)
-            run(['selftests/inspekt-style.sh'], check=True)
-            run(['selftests/isort.sh'], check=True)
-            run(['selftests/lint.sh'], check=True)
-            run(['selftests/signedoff-check.sh'], check=True)
-            run(['selftests/spell.sh'], check=True)
-            run(['selftests/modules-boundaries.sh'], check=True)
-        except CalledProcessError as e:
-            print("Failed during lint checks: ", e)
-            sys.exit(128)
+        print("This command is deprecated, please use instead: python3 setup.py test --static-checks")
+        sys.exit()
 
 
 class Test(SimpleCommand):

--- a/setup.py
+++ b/setup.py
@@ -269,6 +269,43 @@ class Man(SimpleCommand):
             sys.exit(128)
 
 
+class Plugin(SimpleCommand):
+    """Handle plugins"""
+
+    description = 'Handle plugins'
+    user_options = [
+        ("list", 'l', "List available plugins"),
+        ("install=", 'i', "Plugin to install"),
+        ("user", 'u', "User install")
+    ]
+
+    def initialize_options(self):
+        self.list = False  # pylint: disable=W0201
+        self.install = None  # pylint: disable=W0201
+        self.user = False  # pylint: disable=W0201
+
+    def run(self):
+
+        plugins_list = []
+        directory = os.path.join(BASE_PATH, "optional_plugins")
+        for plugin in list(Path(directory).glob("*/setup.py")):
+            plugins_list.append(plugin.parts[-2])
+
+        if self.list or (not self.list and not self.install):
+            print("List of available plugins:\n ", "\n  ".join(plugins_list))
+            return
+
+        if self.install in plugins_list:
+            action = ["install"]
+            if self.user:
+                action += ["--user"]
+            parent_dir = os.path.join(directory, self.install)
+            run([sys.executable, "setup.py"] + action, cwd=parent_dir, check=True)
+        else:
+            print(self.install, "is not a known plugin. Please, check the list of available plugins.")
+            return
+
+
 if __name__ == '__main__':
     # Force "make develop" inside the "readthedocs.org" environment
     if os.environ.get("READTHEDOCS") and "install" in sys.argv:
@@ -403,5 +440,6 @@ if __name__ == '__main__':
                     'develop': Develop,
                     'lint': Linter,
                     'man': Man,
+                    'plugin': Plugin,
                     'test': Test},
           install_requires=['setuptools'])

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@
 # Copyright: Red Hat Inc. 2013-2014
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
+import argparse
 import os
 import shutil
 import sys
@@ -203,6 +204,51 @@ class Linter(SimpleCommand):
             sys.exit(128)
 
 
+class Test(SimpleCommand):
+    """Run selftests"""
+
+    description = 'Run selftests'
+    user_options = [
+        ("job-api", None, "Run job API checks"),
+        ("static-checks", None, "Run static checks (isort, lint, etc)"),
+        ("nrunner-interface", None, "Run selftests/functional/test_nrunner_interface.py"),
+        ("unit", None, "Run selftests/unit/"),
+        ("jobs", None, "Run selftests/jobs/"),
+        ("functional", None, "Run selftests/functional/"),
+        ("optional-plugins", None, "Run optional_plugins/*/tests/"),
+        ("disable-plugin-checks", None, "Disable checks for a plugin (by directory name)"),
+        ("list-features", None, "Show the features tested by this test")
+    ]
+
+    def initialize_options(self):
+        self.job_api = False  # pylint: disable=W0201
+        self.static_checks = False  # pylint: disable=W0201
+        self.nrunner_interface = False  # pylint: disable=W0201
+        self.unit = False  # pylint: disable=W0201
+        self.jobs = False  # pylint: disable=W0201
+        self.functional = False  # pylint: disable=W0201
+        self.optional_plugins = False  # pylint: disable=W0201
+        self.disable_plugin_checks = []  # pylint: disable=W0201
+        self.list_features = False  # pylint: disable=W0201
+
+    def run(self):
+
+        args = argparse.Namespace()
+        args.static_checks = self.static_checks
+        args.job_api = self.job_api
+        args.nrunner_interface = self.nrunner_interface
+        args.unit = self.unit
+        args.jobs = self.jobs
+        args.functional = self.functional
+        args.optional_plugins = self.optional_plugins
+        args.disable_plugin_checks = self.disable_plugin_checks
+        args.list_features = self.list_features
+
+        # Import here on purpose, otherwise it'll mess with install/develop commands
+        import selftests.check
+        selftests.check.main(args)
+
+
 class Man(SimpleCommand):
     """Build man page"""
 
@@ -356,5 +402,6 @@ if __name__ == '__main__':
           cmdclass={'clean': Clean,
                     'develop': Develop,
                     'lint': Linter,
-                    'man': Man},
+                    'man': Man,
+                    'test': Test},
           install_requires=['setuptools'])


### PR DESCRIPTION
This is an intent to wrap up https://github.com/avocado-framework/avocado/issues/4372 and also includes a v2 of one of the commits from https://github.com/avocado-framework/avocado/pull/4798 (command plugin); I have chosen to leave the `Makefile` updates for a different PR

I'm adding two new commands to `setup.py`: plugin and selftests. A new CI pipeline to test well all the commands provided by `setup.py` and updating the documentation.
The new CI pipeline can be seen at https://github.com/ana/avocado/actions/runs/1090390582