### PR TITLE
nrunner: failfast: make failfast return AVOCADO_JOB_INTERRUPTED and nice message

### DIFF
--- a/avocado/core/exceptions.py
+++ b/avocado/core/exceptions.py
@@ -155,6 +155,17 @@ class TestFail(TestBaseException, AssertionError):
     status = "FAIL"
 
 
+class TestFailFast(TestBaseException):
+
+    """
+    Indicates that the test has failed because failfast is enabled.
+
+    Should be thrown when a test has failed and failfast is enabled. This will
+    indicate that other tests will be skipped.
+    """
+    status = "SKIP"
+
+
 class TestWarn(TestBaseException):
 
     """

--- a/avocado/core/task/statemachine.py
+++ b/avocado/core/task/statemachine.py
@@ -3,6 +3,8 @@ import collections
 import multiprocessing
 import time
 
+from avocado.core.exceptions import TestFailFast
+
 
 class TaskStateMachine:
     """Represents all phases that a task can go through its life."""
@@ -248,6 +250,7 @@ class Worker:
         result_stats = self._state_machine._status_repo.result_stats
         if failfast and 'fail' in result_stats:
             await self._state_machine.abort("FAILFAST is enabled")
+            raise TestFailFast("Interrupting job (failfast).")
 
         await self._state_machine.finish_task(runtime_task)
 

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -22,6 +22,7 @@ import random
 
 from avocado.core import nrunner
 from avocado.core.dispatcher import SpawnerDispatcher
+from avocado.core.exceptions import TestFailFast
 from avocado.core.messages import MessageHandler
 from avocado.core.plugin_interfaces import CLI, Init
 from avocado.core.plugin_interfaces import Runner as RunnerInterface
@@ -303,7 +304,7 @@ class Runner(RunnerInterface):
         try:
             loop.run_until_complete(asyncio.wait_for(asyncio.gather(*workers),
                                                      job.timeout or None))
-        except (KeyboardInterrupt, asyncio.TimeoutError):
+        except (KeyboardInterrupt, asyncio.TimeoutError, TestFailFast):
             summary.add("INTERRUPTED")
 
         # Wait until all messages may have been processed by the

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -24,6 +24,7 @@ from avocado.core import nrunner
 from avocado.core.dispatcher import SpawnerDispatcher
 from avocado.core.exceptions import TestFailFast
 from avocado.core.messages import MessageHandler
+from avocado.core.output import LOG_JOB
 from avocado.core.plugin_interfaces import CLI, Init
 from avocado.core.plugin_interfaces import Runner as RunnerInterface
 from avocado.core.requirements.resolver import RequirementsResolver
@@ -304,7 +305,9 @@ class Runner(RunnerInterface):
         try:
             loop.run_until_complete(asyncio.wait_for(asyncio.gather(*workers),
                                                      job.timeout or None))
-        except (KeyboardInterrupt, asyncio.TimeoutError, TestFailFast):
+        except (KeyboardInterrupt, asyncio.TimeoutError, TestFailFast) as ex:
+            LOG_JOB.info(str(ex))
+            job.interrupted_reason = str(ex)
             summary.add("INTERRUPTED")
 
         # Wait until all messages may have been processed by the

--- a/selftests/functional/test_nrunner.py
+++ b/selftests/functional/test_nrunner.py
@@ -39,7 +39,7 @@ class NRunnerFeatures(unittest.TestCase):
                   'nrunner.status_server_uri': status_server,
                   'nrunner.max_parallel_tasks': 1}
         with Job.from_config(job_config=config) as job:
-            self.assertEqual(job.run(), 1)
+            self.assertEqual(job.run(), 9)
             self.assertEqual(job.result.passed, 1)
             self.assertEqual(job.result.errors, 0)
             self.assertEqual(job.result.failed, 1)


### PR DESCRIPTION
It will make it consistent with the current runner returning
AVOCADO_JOB_INTERRUPTED, also this is adding a
message to the user about the failfast.

Signed-off-by: Beraldo Leal <bleal@redhat.com>