### PR TITLE
Safeloader test: support checking a single file

### DIFF
--- a/selftests/safeloader.sh
+++ b/selftests/safeloader.sh
@@ -10,9 +10,14 @@ function cleanup()
 
 trap cleanup EXIT
 
-for PYTHON_FILE in $(grep -c -m1 -E 'import unittest$' selftests/unit{,/plugin,/utils}/test_*.py selftests/functional{,/plugin}/test_*.py | grep -v -E ':0$' | cut -d ':' -f 1); do
-    echo "*** Checking safeloader on $PYTHON_FILE ***";
-    python3 contrib/scripts/find-python-unittest $PYTHON_FILE > $SAFELOADER_OUTPUT;
-    AVOCADO_SAFELOADER_UNITTEST_ORDER_COMPAT=1 python3 contrib/scripts/avocado-safeloader-find-python-unittest $PYTHON_FILE > $DEFAULT_LOADER_OUTPUT;
+function check()
+{
+    echo "*** Checking safeloader on $1 ***";
+    python3 contrib/scripts/find-python-unittest $1 > $SAFELOADER_OUTPUT;
+    AVOCADO_SAFELOADER_UNITTEST_ORDER_COMPAT=1 python3 contrib/scripts/avocado-safeloader-find-python-unittest $1 > $DEFAULT_LOADER_OUTPUT;
     diff -u $SAFELOADER_OUTPUT $DEFAULT_LOADER_OUTPUT;
-done;
+}
+
+for input_file in $(grep -c -m1 -E 'import unittest$' selftests/unit{,/plugin,/utils}/test_*.py selftests/functional{,/plugin}/test_*.py | grep -v -E ':0$' | cut -d ':' -f 1); do
+    check input_file
+done

--- a/selftests/safeloader.sh
+++ b/selftests/safeloader.sh
@@ -1,5 +1,10 @@
 #!/bin/bash -e
 
+# This script tests the "avocado.core.safeloader" module by processing
+# either one specific file (the first command line parameter given to
+# this script) or all unittest-like files in the selftests directories
+
+INPUT_FILE="${1:-}"
 SAFELOADER_OUTPUT=$(mktemp /tmp/safeloader-XXXXXX)
 DEFAULT_LOADER_OUTPUT=$(mktemp /tmp/safeloader-XXXXXX)
 
@@ -18,6 +23,10 @@ function check()
     diff -u $SAFELOADER_OUTPUT $DEFAULT_LOADER_OUTPUT;
 }
 
-for input_file in $(grep -c -m1 -E 'import unittest$' selftests/unit{,/plugin,/utils}/test_*.py selftests/functional{,/plugin}/test_*.py | grep -v -E ':0$' | cut -d ':' -f 1); do
-    check input_file
-done
+if [ -n "$INPUT_FILE" ]; then
+    check "$INPUT_FILE";
+else
+    for input_file in $(grep -c -m1 -E 'import unittest$' selftests/unit{,/plugin,/utils}/test_*.py selftests/functional{,/plugin}/test_*.py | grep -v -E ':0$' | cut -d ':' -f 1); do
+        check "$input_file"
+    done
+fi


### PR DESCRIPTION
This is some possible debugging aid, if needed in the future, to check an individual Python test file, instead of all of them.