### PR TITLE
[nrunner] Add support to variants on nrunner

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -116,13 +116,15 @@ class Runnable:
         self.args = args
         self.tags = kwargs.pop('tags', None)
         self.requirements = kwargs.pop('requirements', None)
+        self.variant = kwargs.pop('variant', None)
         self.kwargs = kwargs
 
     def __repr__(self):
         fmt = ('<Runnable kind="{}" uri="{}" config="{}" args="{}" '
-               'kwargs="{}" tags="{}" requirements="{}">')
+               'kwargs="{}" tags="{}" requirements="{}"> variant="{}"')
         return fmt.format(self.kind, self.uri, self.config, self.args,
-                          self.kwargs, self.tags, self.requirements)
+                          self.kwargs, self.tags, self.requirements,
+                          self.variant)
 
     @classmethod
     def from_args(cls, args):
@@ -181,6 +183,9 @@ class Runnable:
         if self.tags is not None:
             args.append('tags=json:%s' % json.dumps(self.get_serializable_tags()))
 
+        if self.variant is not None:
+            args.append('variant=json:%s' % json.dumps(self.variant))
+
         for key, val in self.kwargs.items():
             if not isinstance(val, str) or isinstance(val, int):
                 val = "json:%s" % json.dumps(val)
@@ -206,6 +211,8 @@ class Runnable:
         kwargs = self.kwargs.copy()
         if self.tags is not None:
             kwargs['tags'] = self.get_serializable_tags()
+        if self.variant is not None:
+            kwargs['variant'] = self.variant
         if kwargs:
             recipe['kwargs'] = kwargs
         return recipe

--- a/avocado/core/varianter.py
+++ b/avocado/core/varianter.py
@@ -112,9 +112,11 @@ def variant_to_str(variant, verbosity, out_args=None, debug=False):
     return out
 
 
-def dump_ivariants(ivariants):
-    """
-    Walks the iterable variants and dumps them into json-serializable object
+def dump_variant(variant):
+    """Dump a variant into a json-serializable representation
+
+    :param variant: Valid variant (list of TreeNode-like objects)
+    :return: json-serializable representation
     """
     def dump_tree_node(node):
         """
@@ -125,15 +127,22 @@ def dump_ivariants(ivariants):
                   astring.to_text(key), value)
                  for key, value in node.environment.items()])
 
+    safe_variant = {}
+    safe_variant["paths"] = [astring.to_text(pth)
+                             for pth in variant.get("paths")]
+    safe_variant["variant_id"] = variant.get("variant_id")
+    safe_variant["variant"] = [dump_tree_node(_)
+                               for _ in variant.get("variant", [])]
+    return safe_variant
+
+
+def dump_ivariants(ivariants):
+    """
+    Walks the iterable variants and dumps them into json-serializable object
+    """
     variants = []
     for variant in ivariants():
-        safe_variant = {}
-        safe_variant["paths"] = [astring.to_text(pth)
-                                 for pth in variant.get("paths")]
-        safe_variant["variant_id"] = variant.get("variant_id")
-        safe_variant["variant"] = [dump_tree_node(_)
-                                   for _ in variant.get("variant", [])]
-        variants.append(safe_variant)
+        variants.append(dump_variant(variant))
     return variants
 
 

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -19,6 +19,7 @@ NRunner based implementation of job compliant runner
 import asyncio
 import multiprocessing
 import random
+from copy import deepcopy
 
 from avocado.core import nrunner
 from avocado.core.dispatcher import SpawnerDispatcher
@@ -34,6 +35,7 @@ from avocado.core.status.server import StatusServer
 from avocado.core.task.runtime import RuntimeTask
 from avocado.core.task.statemachine import TaskStateMachine, Worker
 from avocado.core.test_id import TestID
+from avocado.core.varianter import dump_variant
 
 
 class RunnerInit(Init):
@@ -188,7 +190,12 @@ class Runner(RunnerInterface):
                                        index, variant):
         """Creates runtime tasks for both tests, and for its requirements."""
         result = []
+
         # test related operations
+        # when creating variants, they need to have a copy of the runnable.
+        if len(test_suite.tests) == 1 and index > 1:
+            runnable = deepcopy(runnable)
+        # create test ID
         if test_suite.name:
             prefix = "{}-{}".format(test_suite.name, index)
         else:
@@ -197,6 +204,9 @@ class Runner(RunnerInterface):
                          runnable.uri,
                          variant,
                          no_digits)
+        # inject variant on runnable
+        runnable.variant = dump_variant(variant)
+
         # handles the test task
         task = nrunner.Task(runnable,
                             identifier=test_id,


### PR DESCRIPTION
This PR adds support to variants on nrunner. Tests are still missing.

To test it you can use one of the available yaml files, like:

```
[wrampazz@wrampazz avocado.dev]$ avocado run --test-runner=nrunner -m examples/tests/sleeptest.py.data/sleeptest.yaml -- examples/tests/sleeptest.py
JOB ID     : 264b50b21a505011bf38aafac58f7cb40d73780f
JOB LOG    : /home/wrampazz/avocado/job-results/job-2021-08-05T16.51-264b50b/job.log
 (1/4) examples/tests/sleeptest.py:SleepTest.test;run-short-beaf: STARTED
 (3/4) examples/tests/sleeptest.py:SleepTest.test;run-long-f397: STARTED
 (2/4) examples/tests/sleeptest.py:SleepTest.test;run-medium-5595: STARTED
 (4/4) examples/tests/sleeptest.py:SleepTest.test;run-longest-efc4: STARTED
 (1/4) examples/tests/sleeptest.py:SleepTest.test;run-short-beaf: PASS (0.51 s)
 (2/4) examples/tests/sleeptest.py:SleepTest.test;run-medium-5595: PASS (1.01 s)
 (3/4) examples/tests/sleeptest.py:SleepTest.test;run-long-f397: PASS (5.02 s)
 (4/4) examples/tests/sleeptest.py:SleepTest.test;run-longest-efc4: PASS (10.03 s)
RESULTS    : PASS 4 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/wrampazz/avocado/job-results/job-2021-08-05T16.51-264b50b/results.html
JOB TIME   : 12.01 s
[wrampazz@wrampazz avocado.dev]$
```