### PR TITLE
Variants and Parameters: move check to the test suite

### DIFF
--- a/avocado/plugins/runner.py
+++ b/avocado/plugins/runner.py
@@ -293,14 +293,6 @@ class TestRunner(Runner):
         """
         var = variant.get("variant")
         paths = variant.get("paths")
-        empty_variants = varianter.is_empty_variant(var)
-
-        if test_parameters and not empty_variants:
-            err_msg = ('Specifying test parameters (with config entry '
-                       '"run.test_parameters" or command line "-p") along with '
-                       'any varianter plugin (run "avocado plugins" for a list)'
-                       ' is not yet supported. Please use one or the other.')
-            raise NotImplementedError(err_msg)
 
         original_params_to_klass = template[1]
         if "params" not in original_params_to_klass:

--- a/avocado/plugins/runner.py
+++ b/avocado/plugins/runner.py
@@ -296,10 +296,11 @@ class TestRunner(Runner):
         empty_variants = varianter.is_empty_variant(var)
 
         if test_parameters and not empty_variants:
-            raise NotImplementedError("Specifying test params from test loader "
-                                      "and from varianter at the same time is "
-                                      "not yet supported. Either use variants "
-                                      "(-m) option or command-line params (-p).")
+            err_msg = ('Specifying test parameters (with config entry '
+                       '"run.test_parameters" or command line "-p") along with '
+                       'any varianter plugin (run "avocado plugins" for a list)'
+                       ' is not yet supported. Please use one or the other.')
+            raise NotImplementedError(err_msg)
 
         original_params_to_klass = template[1]
         if "params" not in original_params_to_klass:


### PR DESCRIPTION
The test suite has enough information to verify that the user has attempted to use both "plain" parameters and variants (through a compatible varianter plugin).  By moving the check to the test suite, we:
    
1. Avoid crashing Avocado (the current behavior)
2. Automatically give an UI error message
3. Set a meaninful exit code
4. Make it work with any runner (say nrunner and legacy one)