### PR TITLE
utils.download: catches timeout errors and small fixes

### DIFF
--- a/avocado/utils/download.py
+++ b/avocado/utils/download.py
@@ -69,8 +69,6 @@ def url_download(url, filename, data=None, timeout=300):
     :return: `None`.
     """
     def download():
-        log.info('Fetching %s -> %s', url, filename)
-
         src_file = url_open(url, data=data)
         try:
             with open(filename, 'wb') as dest_file:
@@ -79,6 +77,7 @@ def url_download(url, filename, data=None, timeout=300):
             src_file.close()
 
     process = Process(target=download)
+    log.info('Fetching %s -> %s', url, filename)
     process.start()
     process.join(timeout)
     if process.is_alive():

--- a/avocado/utils/download.py
+++ b/avocado/utils/download.py
@@ -21,6 +21,7 @@ import logging
 import os
 import shutil
 import socket
+import sys
 from multiprocessing import Process
 from urllib.request import urlopen
 
@@ -70,6 +71,12 @@ def url_download(url, filename, data=None, timeout=300):
     """
     def download():
         src_file = url_open(url, data=data)
+        if not src_file:
+            msg = ("Failed to get file. Probably timeout was reach when "
+                   "connecting to the server.\n")
+            sys.stderr.write(msg)
+            sys.exit(1)
+
         try:
             with open(filename, 'wb') as dest_file:
                 shutil.copyfileobj(src_file, dest_file)

--- a/avocado/utils/download.py
+++ b/avocado/utils/download.py
@@ -20,6 +20,7 @@ Methods to download URLs and regular files.
 import logging
 import os
 import shutil
+import socket
 from multiprocessing import Process
 from urllib.request import urlopen
 
@@ -41,7 +42,13 @@ def url_open(url, data=None, timeout=5):
     :return: file-like object.
     :raises: `URLError`.
     """
-    result = urlopen(url, data=data, timeout=timeout)
+    try:
+        result = urlopen(url, data=data, timeout=timeout)
+    except socket.timeout as ex:
+        msg = "Timeout was reach: {}".format(str(ex))
+        log.error(msg)
+        return None
+
     msg = ('Retrieved URL "%s": content-length %s, date: "%s", '
            'last-modified: "%s"')
     log.debug(msg, url,

--- a/avocado/utils/download.py
+++ b/avocado/utils/download.py
@@ -25,7 +25,7 @@ from urllib.request import urlopen
 
 from . import aurl, crypto, output
 
-log = logging.getLogger('avocado.test')
+log = logging.getLogger('avocado.utils.download')
 
 
 def url_open(url, data=None, timeout=5):


### PR DESCRIPTION
Even before my previous change on this method, url_open can raise
exceptions and we need to catch as soon as possible. We need to make
sure that errors here are logged. Fixes #4829.

Signed-off-by: Beraldo Leal <bleal@redhat.com>