### PR TITLE
find_python_unittest: fixes on Python 3 9 6

### DIFF
--- a/contrib/scripts/find-python-unittest
+++ b/contrib/scripts/find-python-unittest
@@ -56,3 +56,6 @@ if __name__ == '__main__':
 
     if result:
         print("\n".join(result))
+
+    for err in loader.errors:
+        print("ERROR: ", err, file=sys.stderr)

--- a/contrib/scripts/find-python-unittest
+++ b/contrib/scripts/find-python-unittest
@@ -38,7 +38,7 @@ def get_tests(suite):
 
 
 if __name__ == '__main__':
-    if sys.version_info < (3, 8, 0):
+    if sys.version_info < (3, 8, 0) or sys.version_info >= (3, 9, 6):
         abs_path = os.path.abspath(__file__)
         top_path = os.path.dirname(os.path.dirname(os.path.dirname(abs_path)))
         sys.path.insert(0, top_path)


### PR DESCRIPTION
The behavior on Python 3.9.6(-2), as packaged in Fedora 34, has changed when compared to Python 3.9.5(-3), and is similar to the behavior before 3.8.0.

Reference: https://bodhi.fedoraproject.org/updates/FEDORA-2021-d613e00b72