### PR TITLE
Runner: set a command line parser for store logging stream

### DIFF
--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -215,7 +215,8 @@ class Run(CLICmd):
         settings.add_argparser_to_option('job.run.store_logging_stream',
                                          parser=parser.output,
                                          long_arg='--store-logging-stream',
-                                         metavar='LOGGING_STREAM')
+                                         metavar='LOGGING_STREAM',
+                                         argparse_type=lambda x: set(x.split(',')))
 
         help_msg = ('Logs the possible data directories for each test. This '
                     'is helpful when writing new tests and not being sure '

--- a/docs/source/guides/writer/chapters/logging.rst
+++ b/docs/source/guides/writer/chapters/logging.rst
@@ -6,66 +6,30 @@ be combined with the standard Python library APIs on tests.
 
 One common example is the need to follow specific progress on longer or more
 complex tests. Let's look at a very simple test example, but one multiple
-clear stages on a single test::
+clear stages on a single test:
 
-    import logging
-    import time
-
-    from avocado import Test
-
-    progress_log = logging.getLogger("progress")
-
-    class Plant(Test):
-
-        def test_plant_organic(self):
-            rows = int(self.params.get("rows", default=3))
-
-            # Preparing soil
-            for row in range(rows):
-                progress_log.info("%s: preparing soil on row %s",
-                                  self.name, row)
-
-            # Letting soil rest
-            progress_log.info("%s: letting soil rest before throwing seeds",
-                              self.name)
-            time.sleep(2)
-
-            # Throwing seeds
-            for row in range(rows):
-                progress_log.info("%s: throwing seeds on row %s",
-                                  self.name, row)
-
-            # Let them grow
-            progress_log.info("%s: waiting for Avocados to grow",
-                              self.name)
-            time.sleep(5)
-
-            # Harvest them
-            for row in range(rows):
-                progress_log.info("%s: harvesting organic avocados on row %s",
-                                  self.name, row)
-
+.. literalinclude:: ../../../../../examples/tests/logging_streams.py
 
 From this point on, you can ask Avocado to show your logging stream, either
 exclusively or in addition to other builtin streams::
 
-    $ avocado --show app,progress run plant.py
+    $ avocado --show app,progress run -- logging_streams.py
 
 The outcome should be similar to::
 
     JOB ID     : af786f86db530bff26cd6a92c36e99bedcdca95b
     JOB LOG    : /home/user/avocado/job-results/job-2016-03-18T10.29-af786f8/job.log
-     (1/1) plant.py:Plant.test_plant_organic: progress: 1-plant.py:Plant.test_plant_organic: preparing soil on row 0
-    progress: 1-plant.py:Plant.test_plant_organic: preparing soil on row 1
-    progress: 1-plant.py:Plant.test_plant_organic: preparing soil on row 2
-    progress: 1-plant.py:Plant.test_plant_organic: letting soil rest before throwing seeds
-    -progress: 1-plant.py:Plant.test_plant_organic: throwing seeds on row 0
-    progress: 1-plant.py:Plant.test_plant_organic: throwing seeds on row 1
-    progress: 1-plant.py:Plant.test_plant_organic: throwing seeds on row 2
-    progress: 1-plant.py:Plant.test_plant_organic: waiting for Avocados to grow
-    \progress: 1-plant.py:Plant.test_plant_organic: harvesting organic avocados on row 0
-    progress: 1-plant.py:Plant.test_plant_organic: harvesting organic avocados on row 1
-    progress: 1-plant.py:Plant.test_plant_organic: harvesting organic avocados on row 2
+     (1/1) logging_streams.py:Plant.test_plant_organic: progress: 1-logging_streams.py:Plant.test_plant_organic: preparing soil on row 0
+    progress: 1-logging_streams.py:Plant.test_plant_organic: preparing soil on row 1
+    progress: 1-logging_streams.py:Plant.test_plant_organic: preparing soil on row 2
+    progress: 1-logging_streams.py:Plant.test_plant_organic: letting soil rest before throwing seeds
+    -progress: 1-logging_streams.py:Plant.test_plant_organic: throwing seeds on row 0
+    progress: 1-logging_streams.py:Plant.test_plant_organic: throwing seeds on row 1
+    progress: 1-logging_streams.py:Plant.test_plant_organic: throwing seeds on row 2
+    progress: 1-logging_streams.py:Plant.test_plant_organic: waiting for Avocados to grow
+    \progress: 1-logging_streams.py:Plant.test_plant_organic: harvesting organic avocados on row 0
+    progress: 1-logging_streams.py:Plant.test_plant_organic: harvesting organic avocados on row 1
+    progress: 1-logging_streams.py:Plant.test_plant_organic: harvesting organic avocados on row 2
     PASS (7.01 s)
     RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0
     JOB TIME   : 7.11 s
@@ -76,24 +40,24 @@ may or may not suit your needs or preferences. If you want the ``progress``
 stream to be sent to a separate file, both for clarity and for persistence,
 you can run Avocado like this::
 
-    $ avocado run plant.py --store-logging-stream progress
+    $ avocado run --store-logging-stream=progress -- logging_streams.py
 
 The result is that, besides all the other log files commonly generated, there
 will be another log file named ``progress.INFO`` at the job results
 dir. During the test run, one could watch the progress with::
 
     $ tail -f ~/avocado/job-results/latest/progress.INFO
-    10:36:59 INFO | 1-plant.py:Plant.test_plant_organic: preparing soil on row 0
-    10:36:59 INFO | 1-plant.py:Plant.test_plant_organic: preparing soil on row 1
-    10:36:59 INFO | 1-plant.py:Plant.test_plant_organic: preparing soil on row 2
-    10:36:59 INFO | 1-plant.py:Plant.test_plant_organic: letting soil rest before throwing seeds
-    10:37:01 INFO | 1-plant.py:Plant.test_plant_organic: throwing seeds on row 0
-    10:37:01 INFO | 1-plant.py:Plant.test_plant_organic: throwing seeds on row 1
-    10:37:01 INFO | 1-plant.py:Plant.test_plant_organic: throwing seeds on row 2
-    10:37:01 INFO | 1-plant.py:Plant.test_plant_organic: waiting for Avocados to grow
-    10:37:06 INFO | 1-plant.py:Plant.test_plant_organic: harvesting organic avocados on row 0
-    10:37:06 INFO | 1-plant.py:Plant.test_plant_organic: harvesting organic avocados on row 1
-    10:37:06 INFO | 1-plant.py:Plant.test_plant_organic: harvesting organic avocados on row 2
+    10:36:59 INFO | 1-logging_streams.py:Plant.test_plant_organic: preparing soil on row 0
+    10:36:59 INFO | 1-logging_streams.py:Plant.test_plant_organic: preparing soil on row 1
+    10:36:59 INFO | 1-logging_streams.py:Plant.test_plant_organic: preparing soil on row 2
+    10:36:59 INFO | 1-logging_streams.py:Plant.test_plant_organic: letting soil rest before throwing seeds
+    10:37:01 INFO | 1-logging_streams.py:Plant.test_plant_organic: throwing seeds on row 0
+    10:37:01 INFO | 1-logging_streams.py:Plant.test_plant_organic: throwing seeds on row 1
+    10:37:01 INFO | 1-logging_streams.py:Plant.test_plant_organic: throwing seeds on row 2
+    10:37:01 INFO | 1-logging_streams.py:Plant.test_plant_organic: waiting for Avocados to grow
+    10:37:06 INFO | 1-logging_streams.py:Plant.test_plant_organic: harvesting organic avocados on row 0
+    10:37:06 INFO | 1-logging_streams.py:Plant.test_plant_organic: harvesting organic avocados on row 1
+    10:37:06 INFO | 1-logging_streams.py:Plant.test_plant_organic: harvesting organic avocados on row 2
 
 The very same ``progress`` logger, could be used across multiple test methods
 and across multiple test modules.  In the example given, the test name is used

--- a/examples/tests/logging_streams.py
+++ b/examples/tests/logging_streams.py
@@ -1,0 +1,37 @@
+import logging
+import time
+
+from avocado import Test
+
+
+class Plant(Test):
+    """Logs parts of the test progress in an specific logging stream."""
+
+    def test_plant_organic(self):
+        progress_log = logging.getLogger("progress")
+        rows = int(self.params.get("rows", default=3))
+
+        # Preparing soil
+        for row in range(rows):
+            progress_log.info("%s: preparing soil on row %s",
+                              self.name, row)
+
+        # Letting soil rest
+        progress_log.info("%s: letting soil rest before throwing seeds",
+                          self.name)
+        time.sleep(1)
+
+        # Throwing seeds
+        for row in range(rows):
+            progress_log.info("%s: throwing seeds on row %s",
+                              self.name, row)
+
+        # Let them grow
+        progress_log.info("%s: waiting for Avocados to grow",
+                          self.name)
+        time.sleep(2)
+
+        # Harvest them
+        for row in range(rows):
+            progress_log.info("%s: harvesting organic avocados on row %s",
+                              self.name, row)

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -576,6 +576,16 @@ class RunnerOperationTest(TestCaseTmpDir):
             with open(test_log_path, 'rb') as test_log:
                 self.assertIn(b'SHOULD BE ON debug.log', test_log.read())
 
+    def test_store_logging_stream(self):
+        cmd = ("%s run --job-results-dir %s --store-logging-stream=progress "
+               "--disable-sysinfo -- logging_streams.py" % (AVOCADO,
+                                                            self.tmpdir.name))
+        result = process.run(cmd)
+        self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
+
+        progress_info = os.path.join(self.tmpdir.name, 'latest', 'progress.INFO')
+        self.assertTrue(os.path.exists(progress_info))
+
 
 class DryRunTest(TestCaseTmpDir):
 

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -354,7 +354,7 @@ class OutputTest(TestCaseTmpDir):
         """
         with script.Script(os.path.join(self.tmpdir.name, "test_show.py"),
                            OUTPUT_SHOW_TEST, script.READ_ONLY_MODE) as test:
-            cmd = "%s run %s" % (AVOCADO, test.path)
+            cmd = "%s run --disable-sysinfo -- %s" % (AVOCADO, test.path)
             result = process.run(cmd)
             expected_job_id_number = 2
             expected_bin_true_number = 1
@@ -605,7 +605,7 @@ class OutputPluginTest(TestCaseTmpDir):
 
     def test_tap_totaltests(self):
         cmd_line = ("%s run passtest.py passtest.py passtest.py passtest.py "
-                    "--job-results-dir %s "
+                    "--job-results-dir %s --disable-sysinfo "
                     "--tap -" % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line)
         expr = b'1..4'


### PR DESCRIPTION
The `--store-logging-stream` parameter value is currently being incorrectly parsed as a list of characters.  If a "bar" value is given, it will generate the "b.INFO", "a.INFO", and "r.INFO" file.
    
This fixes the parsing of the command line arguments by treating the value as a comma separated list, that becomes a set.