### PR TITLE
Sysinfo utility

### DIFF
--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -88,12 +88,6 @@ class Logfile(Collectible):
             return False
         return NotImplemented
 
-    def __ne__(self, other):
-        result = self.__eq__(other)
-        if result is NotImplemented:
-            return result
-        return not result
-
     def __hash__(self):
         return hash((self.path, self.log_path))
 
@@ -150,12 +144,6 @@ class Command(Collectible):
         elif isinstance(other, Collectible):
             return False
         return NotImplemented
-
-    def __ne__(self, other):
-        result = self.__eq__(other)
-        if result is NotImplemented:
-            return result
-        return not result
 
     def __hash__(self):
         return hash((self.cmd, self.log_path))
@@ -346,12 +334,6 @@ class LogWatcher(Collectible):
         elif isinstance(other, Collectible):
             return False
         return NotImplemented
-
-    def __ne__(self, other):
-        result = self.__eq__(other)
-        if result is NotImplemented:
-            return result
-        return not result
 
     def __hash__(self):
         return hash((self.path, self.log_path))

--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -58,7 +58,7 @@ class Collectible(ABC):
         return not result
 
     def __hash__(self):
-        return hash((self.log_path))
+        return hash((self.log_path, Collectible))
 
 
 class Logfile(Collectible):
@@ -89,7 +89,7 @@ class Logfile(Collectible):
         return NotImplemented
 
     def __hash__(self):
-        return hash((self.path, self.log_path))
+        return hash((self.path, self.log_path, Logfile))
 
     def run(self, logdir):
         """
@@ -146,7 +146,7 @@ class Command(Collectible):
         return NotImplemented
 
     def __hash__(self):
-        return hash((self.cmd, self.log_path))
+        return hash((self.cmd, self.log_path, Command))
 
     def run(self, logdir):
         """
@@ -224,6 +224,9 @@ class Daemon(Command):
             return False
         return NotImplemented
 
+    def __hash__(self):
+        return hash((self.cmd, self.log_path, Daemon))
+    
     def run(self, logdir):
         """
         Execute the daemon as a subprocess and log its output in logdir.
@@ -291,6 +294,9 @@ class JournalctlWatcher(Collectible):
         elif isinstance(other, Collectible):
             return False
         return NotImplemented
+
+    def __hash__(self):
+        return hash((self.log_path, JournalctlWatcher))
 
     @staticmethod
     def _get_cursor():
@@ -360,7 +366,7 @@ class LogWatcher(Collectible):
         return NotImplemented
 
     def __hash__(self):
-        return hash((self.path, self.log_path))
+        return hash((self.path, self.log_path, LogWatcher))
 
     def run(self, logdir):
         """

--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -212,6 +212,13 @@ class Daemon(Command):
         super(Daemon, self).__init__(*args, **kwargs)
         self.daemon_process = None
 
+    def __eq__(self, other):
+        if isinstance(other, Daemon):
+            return (self.cmd, self.log_path) == (other.cmd, other.log_path)
+        elif isinstance(other, Collectible):
+            return False
+        return NotImplemented
+
     def run(self, logdir):
         """
         Execute the daemon as a subprocess and log its output in logdir.
@@ -267,6 +274,13 @@ class JournalctlWatcher(Collectible):
 
         super(JournalctlWatcher, self).__init__(log_path)
         self.cursor = self._get_cursor()
+
+    def __eq__(self, other):
+        if isinstance(other, JournalctlWatcher):
+            return self.log_path == other.log_path
+        elif isinstance(other, Collectible):
+            return False
+        return NotImplemented
 
     @staticmethod
     def _get_cursor():
@@ -329,7 +343,7 @@ class LogWatcher(Collectible):
         return r
 
     def __eq__(self, other):
-        if isinstance(other, Logfile):
+        if isinstance(other, LogWatcher):
             return (self.path, self.log_path) == (other.path, other.log_path)
         elif isinstance(other, Collectible):
             return False

--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -12,384 +12,17 @@
 # client/shared/settings.py
 # Author: John Admanski <jadmanski@google.com>
 import filecmp
-import json
 import logging
 import os
-import shlex
-import subprocess
-import tempfile
 import time
-from abc import ABC, abstractmethod
 
-from ..utils import astring, genio
+from ..utils import genio
 from ..utils import path as utils_path
-from ..utils import process, software_manager
+from ..utils import software_manager, sysinfo
 from . import output
 from .settings import settings
 
 log = logging.getLogger("avocado.sysinfo")
-
-DATA_SIZE = 200000
-
-
-class CollectibleException(Exception):
-    """
-    Base exception for all collectible errors.
-    """
-
-
-class Collectible(ABC):
-
-    """
-    Abstract class for representing sysinfo collectibles.
-    """
-
-    def __init__(self, log_path):
-        self.log_path = astring.string_to_safe_path(log_path)
-        self._name = os.path.basename(log_path)
-
-    @abstractmethod
-    def collect(self):
-        pass
-
-    @property
-    def name(self):
-        return self._name
-
-    @staticmethod
-    def _read_file(path, bytes_to_skip=0):
-        """Method for lazy reading of file"""
-        with open(path, "rb") as in_messages:
-            in_messages.seek(bytes_to_skip)
-            while True:
-                # Read data in manageable chunks rather than
-                # all at once.
-                in_data = in_messages.read(DATA_SIZE)
-                if not in_data:
-                    break
-                yield in_data
-
-    def __eq__(self, other):
-        if hash(self) == hash(other):
-            return True
-        elif isinstance(other, Collectible):
-            return False
-        return NotImplemented
-
-    def __ne__(self, other):
-        result = self.__eq__(other)
-        if result is NotImplemented:
-            return result
-        return not result
-
-    def __hash__(self):
-        return hash((self.log_path, Collectible))
-
-
-class Logfile(Collectible):
-
-    """
-    Collectible system file.
-
-    :param path: Path to the log file.
-    :param log_path: Basename of the file where output is logged (optional).
-    """
-
-    def __init__(self, path, log_path=None):
-        if not log_path:
-            log_path = os.path.basename(path)
-        super(Logfile, self).__init__(log_path)
-        self.path = path
-
-    def __repr__(self):
-        r = "Logfile(%r, %r)"
-        r %= (self.path, self.log_path)
-        return r
-
-    def __eq__(self, other):
-        if isinstance(other, Logfile):
-            return (self.path, self.log_path) == (other.path, other.log_path)
-        elif isinstance(other, Collectible):
-            return False
-        return NotImplemented
-
-    def __hash__(self):
-        return hash((self.path, self.log_path, Logfile))
-
-    def collect(self):
-        """
-        Reads the log file.
-        :raise CollectibleException
-        """
-        if os.path.exists(self.path):
-            try:
-                yield from self._read_file(self.path)
-            except IOError:
-                raise CollectibleException("Not logging %s (lack of "
-                                           "permissions)" % self.path)
-        else:
-            raise CollectibleException("Not logging %s (file not found)" %
-                                       self.path)
-
-
-class Command(Collectible):
-
-    """
-    Collectible command.
-    :param cmd: String with the command.
-    :param timeout: Timeout for command execution.
-    :param locale: Force LANG for sysinfo collection
-    """
-
-    def __init__(self, cmd, timeout=-1, locale='C'):
-        super(Command, self).__init__(cmd)
-        self._name = self.log_path
-        self.cmd = cmd
-        self.timeout = timeout
-        self.locale = locale
-
-    def __repr__(self):
-        r = "Command(%r, %r)"
-        r %= (self.cmd, self.log_path)
-        return r
-
-    def __eq__(self, other):
-        if isinstance(other, Command):
-            return (self.cmd, self.log_path) == (other.cmd, other.log_path)
-        elif isinstance(other, Collectible):
-            return False
-        return NotImplemented
-
-    def __hash__(self):
-        return hash((self.cmd, self.log_path, Command))
-
-    def collect(self):
-        """
-        Execute the command as a subprocess and returns it's output.
-        :raise CollectibleException
-        """
-        env = os.environ.copy()
-        if "PATH" not in env:
-            env["PATH"] = "/usr/bin:/bin"
-        if self.locale:
-            env["LC_ALL"] = self.locale
-        # the sysinfo configuration supports negative or zero integer values
-        # but the avocado.utils.process APIs define no timeouts as "None"
-        if int(self.timeout) <= 0:
-            self.timeout = None
-        try:
-            result = process.run(self.cmd,
-                                 timeout=self.timeout,
-                                 verbose=False,
-                                 ignore_status=True,
-                                 allow_output_check='combined',
-                                 shell=True,
-                                 env=env)
-            yield result.stdout
-
-        except FileNotFoundError as exc_fnf:
-            raise CollectibleException("Not logging '%s' (command '%s' was not "
-                                       "found)" % (self.cmd, exc_fnf.filename))
-        except Exception as exc:  # pylint: disable=W0703
-            raise CollectibleException('Could not execute "%s": %s' %
-                                       (self.cmd, exc))
-
-
-class Daemon(Command):
-
-    """
-    Collectible daemon.
-    :param cmd: String with the command.
-    :param timeout: Timeout for command execution.
-    :param locale: Force LANG for sysinfo collection
-    """
-
-    def __init__(self, *args, **kwargs):
-        super(Daemon, self).__init__(*args, **kwargs)
-        self.daemon_process = None
-        self.temp_file = tempfile.NamedTemporaryFile()
-
-    def __repr__(self):
-        r = "Daemon(%r, %r)"
-        r %= (self.cmd, self.log_path)
-        return r
-
-    def __eq__(self, other):
-        if isinstance(other, Daemon):
-            return (self.cmd, self.log_path) == (other.cmd, other.log_path)
-        elif isinstance(other, Collectible):
-            return False
-        return NotImplemented
-
-    def __hash__(self):
-        return hash((self.cmd, self.log_path, Daemon))
-
-    def __del__(self):
-        self.temp_file.close()
-
-    def run(self):
-        """
-        Start running the daemon as a subprocess.
-        :raise CollectibleException
-        """
-        env = os.environ.copy()
-        if "PATH" not in env:
-            env["PATH"] = "/usr/bin:/bin"
-        if self.locale:
-            env["LC_ALL"] = self.locale
-        logf_path = self.temp_file.name
-        stdin = open(os.devnull, "r")
-        stdout = open(logf_path, "w")
-
-        try:
-            self.daemon_process = subprocess.Popen(shlex.split(self.cmd),
-                                                   stdin=stdin, stdout=stdout,
-                                                   stderr=subprocess.STDOUT,
-                                                   shell=False, env=env)
-        except OSError as os_err:
-            raise CollectibleException('Could not execute "%s": %s' % (self.cmd,
-                                                                       os_err))
-
-    def collect(self):
-        """
-        Stop daemon execution and returns it's logs.
-        :raise OSError
-        """
-        if self.daemon_process is not None:
-            retcode = self.daemon_process.poll()
-            if retcode is None:
-                process.kill_process_tree(self.daemon_process.pid)
-                self.daemon_process.wait()
-                for line in self.temp_file.readlines():
-                    yield line
-            else:
-                raise OSError("Daemon process '%s' (pid %d) terminated"
-                              " abnormally (code %d)" % (self.cmd,
-                                                         self.daemon_process.pid,
-                                                         retcode))
-
-
-class JournalctlWatcher(Collectible):
-
-    """
-    Track the content of systemd journal.
-
-    :param log_path: Basename of the file where output is logged (optional).
-    """
-
-    def __init__(self, log_path=None):
-        if not log_path:
-            log_path = 'journalctl.gz'
-
-        super(JournalctlWatcher, self).__init__(log_path)
-        self.cursor = self._get_cursor()
-
-    def __repr__(self):
-        r = "JournalctlWatcher(%r)"
-        r %= self.log_path
-        return r
-
-    def __eq__(self, other):
-        if isinstance(other, JournalctlWatcher):
-            return self.log_path == other.log_path
-        elif isinstance(other, Collectible):
-            return False
-        return NotImplemented
-
-    def __hash__(self):
-        return hash((self.log_path, JournalctlWatcher))
-
-    @staticmethod
-    def _get_cursor():
-        try:
-            cmd = 'journalctl --quiet --lines 1 --output json'
-            result = process.system_output(cmd, verbose=False)
-            last_record = json.loads(astring.to_text(result, "utf-8"))
-            return last_record['__CURSOR']
-        except Exception as detail:  # pylint: disable=W0703
-            raise CollectibleException("Journalctl collection failed: %s" %
-                                       detail)
-
-    def collect(self):
-        """
-        Returns the content of systemd journal
-        :raise CollectibleException
-        """
-        if self.cursor:
-            try:
-                cmd = 'journalctl --quiet --after-cursor %s' % self.cursor
-                log_diff = process.system_output(cmd, verbose=False)
-                yield log_diff
-            except Exception as detail:  # pylint: disable=W0703
-                raise CollectibleException("Journalctl collection failed: %s" %
-                                           detail)
-
-
-class LogWatcher(Collectible):
-
-    """
-    Keep track of the contents of a log file in another compressed file.
-
-    This object is normally used to track contents of the system log
-    (/var/log/messages), and the outputs are gzipped since they can be
-    potentially large, helping to save space.
-
-    :param path: Path to the log file.
-    :param log_path: Basename of the file where output is logged (optional).
-    """
-
-    def __init__(self, path, log_path=None):
-        if not log_path:
-            log_path = os.path.basename(path) + ".gz"
-        else:
-            log_path += ".gz"
-
-        super(LogWatcher, self).__init__(log_path)
-        self.path = path
-        self.size = 0
-        self.inode = 0
-        try:
-            stat = os.stat(path)
-            self.size = stat.st_size
-            self.inode = stat.st_ino
-        except (IOError, OSError):
-            raise CollectibleException("Not logging %s (lack of permissions)" %
-                                       self.path)
-
-    def __repr__(self):
-        r = "LogWatcher(%r, %r)"
-        r %= (self.path, self.log_path)
-        return r
-
-    def __eq__(self, other):
-        if isinstance(other, LogWatcher):
-            return (self.path, self.log_path) == (other.path, other.log_path)
-        elif isinstance(other, Collectible):
-            return False
-        return NotImplemented
-
-    def __hash__(self):
-        return hash((self.path, self.log_path, LogWatcher))
-
-    def collect(self):
-        """
-        Collect all of the new data present in the log file.
-        :raise CollectibleException
-        """
-        bytes_to_skip = 0
-        current_stat = os.stat(self.path)
-        current_inode = current_stat.st_ino
-        current_size = current_stat.st_size
-        if current_inode == self.inode:
-            bytes_to_skip = self.size
-
-        self.inode = current_inode
-        self.size = current_size
-        try:
-            yield from self._read_file(self.path, bytes_to_skip)
-        except (IOError, OSError):
-            raise CollectibleException("Not logging %s (lack of permissions)" %
-                                       self.path)
 
 
 class SysInfo:
@@ -492,7 +125,7 @@ class SysInfo:
         for logpath in logpaths:
             if os.path.exists(logpath):
                 try:
-                    return LogWatcher(logpath)
+                    return sysinfo.LogWatcher(logpath)
                 except PermissionError as e:
                     log.debug(e.args[0])
         raise ValueError("System log file not found (looked for %s)" %
@@ -503,28 +136,28 @@ class SysInfo:
         locale = self.config.get('sysinfo.collect.locale')
         if self.profiler:
             for cmd in self.sysinfo_files["profilers"]:
-                self.start_collectibles.add(Daemon(cmd, locale=locale))
+                self.start_collectibles.add(sysinfo.Daemon(cmd, locale=locale))
 
         for cmd in self.sysinfo_files["commands"]:
-            self.start_collectibles.add(Command(cmd, timeout=timeout,
-                                                locale=locale))
-            self.end_collectibles.add(Command(cmd, timeout=timeout,
-                                              locale=locale))
+            self.start_collectibles.add(sysinfo.Command(cmd, timeout=timeout,
+                                                        locale=locale))
+            self.end_collectibles.add(sysinfo.Command(cmd, timeout=timeout,
+                                                      locale=locale))
 
         for fail_cmd in self.sysinfo_files["fail_commands"]:
-            self.end_fail_collectibles.add(Command(fail_cmd, timeout=timeout,
-                                                   locale=locale))
+            self.end_fail_collectibles.add(sysinfo.Command(fail_cmd,
+                                                           timeout=timeout,
+                                                           locale=locale))
 
         for filename in self.sysinfo_files["files"]:
-            self.start_collectibles.add(Logfile(filename))
-            self.end_collectibles.add(Logfile(filename))
+            self.start_collectibles.add(sysinfo.Logfile(filename))
+            self.end_collectibles.add(sysinfo.Logfile(filename))
 
         for fail_filename in self.sysinfo_files["fail_files"]:
-            self.end_fail_collectibles.add(Logfile(fail_filename))
-
+            self.end_fail_collectibles.add(sysinfo.Logfile(fail_filename))
         try:
-            self.end_collectibles.add(JournalctlWatcher())
-        except CollectibleException as e:
+            self.end_collectibles.add(sysinfo.JournalctlWatcher())
+        except sysinfo.CollectibleException as e:
             log.debug(e.args[0])
 
     def _get_installed_packages(self):
@@ -559,7 +192,7 @@ class SysInfo:
                     log_file.write(data)
             if optimized:
                 self._optimize(log_hook)
-        except CollectibleException as e:
+        except sysinfo.CollectibleException as e:
             log.debug(e.args[0])
         except Exception as exc:  # pylint: disable=W0703
             log.error("Collection %s failed: %s", type(log_hook), exc)
@@ -575,10 +208,11 @@ class SysInfo:
         """Log all collectibles at the start of the event."""
         os.environ['AVOCADO_SYSINFODIR'] = self.pre_dir
         for log_hook in self.start_collectibles:
-            if isinstance(log_hook, Daemon):  # log daemons in profile directory
+            # log daemons in profile directory
+            if isinstance(log_hook, sysinfo.Daemon):
                 try:
                     log_hook.run()
-                except CollectibleException as e:
+                except sysinfo.CollectibleException as e:
                     log.debug(e.args[0])
             else:
                 self._save_sysinfo(log_hook, self.pre_dir)
@@ -601,9 +235,8 @@ class SysInfo:
 
         # Stop daemon(s) started previously
         for log_hook in self.start_collectibles:
-            if isinstance(log_hook, Daemon):
+            if isinstance(log_hook, sysinfo.Daemon):
                 self._save_sysinfo(log_hook, self.post_dir)
-
         if self.log_packages:
             self._log_modified_packages(self.post_dir)
 

--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -77,7 +77,7 @@ class Logfile(Collectible):
         self.path = path
 
     def __repr__(self):
-        r = "sysinfo.Logfile(%r, %r)"
+        r = "Logfile(%r, %r)"
         r %= (self.path, self.log_path)
         return r
 
@@ -140,7 +140,7 @@ class Command(Collectible):
         self._compress_log = compress_log
 
     def __repr__(self):
-        r = "sysinfo.Command(%r, %r, %r)"
+        r = "Command(%r, %r, %r)"
         r %= (self.cmd, self.log_path, self._compress_log)
         return r
 
@@ -336,7 +336,7 @@ class LogWatcher(Collectible):
             log.debug("Not logging %s (lack of permissions)", self.path)
 
     def __repr__(self):
-        r = "sysinfo.LogWatcher(%r, %r)"
+        r = "LogWatcher(%r, %r)"
         r %= (self.path, self.log_path)
         return r
 

--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -123,19 +123,17 @@ class Command(Collectible):
 
     :param cmd: String with the command.
     :param log_path: Basename of the file where output is logged (optional).
-    :param compress_log: Whether to compress the output of the command.
     """
 
-    def __init__(self, cmd, log_path=None, compress_log=False):
+    def __init__(self, cmd, log_path=None):
         if not log_path:
             log_path = cmd
         super(Command, self).__init__(log_path)
         self.cmd = cmd
-        self._compress_log = compress_log
 
     def __repr__(self):
-        r = "Command(%r, %r, %r)"
-        r %= (self.cmd, self.log_path, self._compress_log)
+        r = "Command(%r, %r)"
+        r %= (self.cmd, self.log_path)
         return r
 
     def __eq__(self, other):
@@ -190,12 +188,9 @@ class Command(Collectible):
                         log.debug("Not logging %s (no change detected)",
                                   self.cmd)
                         return
-        if self._compress_log:
-            with gzip.GzipFile(logf_path, 'wb') as logf:
-                logf.write(result.stdout)
-        else:
-            with open(logf_path, 'wb') as logf:
-                logf.write(result.stdout)
+
+        with open(logf_path, 'wb') as logf:
+            logf.write(result.stdout)
 
 
 class Daemon(Command):

--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -212,6 +212,11 @@ class Daemon(Command):
         super(Daemon, self).__init__(*args, **kwargs)
         self.daemon_process = None
 
+    def __repr__(self):
+        r = "Daemon(%r, %r)"
+        r %= (self.cmd, self.log_path)
+        return r
+
     def __eq__(self, other):
         if isinstance(other, Daemon):
             return (self.cmd, self.log_path) == (other.cmd, other.log_path)
@@ -274,6 +279,11 @@ class JournalctlWatcher(Collectible):
 
         super(JournalctlWatcher, self).__init__(log_path)
         self.cursor = self._get_cursor()
+
+    def __repr__(self):
+        r = "JournalctlWatcher(%r)"
+        r %= self.log_path
+        return r
 
     def __eq__(self, other):
         if isinstance(other, JournalctlWatcher):

--- a/avocado/utils/sysinfo.py
+++ b/avocado/utils/sysinfo.py
@@ -1,0 +1,386 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2021
+# Authors: Jan Richter <jarichte@redhat.com>
+#          John Admanski <jadmanski@google.com>
+
+import json
+import os
+import shlex
+import subprocess
+import tempfile
+from abc import ABC, abstractmethod
+
+from . import astring, process
+
+DATA_SIZE = 200000
+
+
+class CollectibleException(Exception):
+    """
+    Base exception for all collectible errors.
+    """
+
+
+class Collectible(ABC):
+
+    """
+    Abstract class for representing sysinfo collectibles.
+    """
+
+    def __init__(self, log_path):
+        self.log_path = astring.string_to_safe_path(log_path)
+        self._name = os.path.basename(log_path)
+
+    @abstractmethod
+    def collect(self):
+        pass
+
+    @property
+    def name(self):
+        return self._name
+
+    @staticmethod
+    def _read_file(path, bytes_to_skip=0):
+        """Method for lazy reading of file"""
+        with open(path, "rb") as in_messages:
+            in_messages.seek(bytes_to_skip)
+            while True:
+                # Read data in manageable chunks rather than
+                # all at once.
+                in_data = in_messages.read(DATA_SIZE)
+                if not in_data:
+                    break
+                yield in_data
+
+    def __eq__(self, other):
+        if hash(self) == hash(other):
+            return True
+        elif isinstance(other, Collectible):
+            return False
+        return NotImplemented
+
+    def __ne__(self, other):
+        result = self.__eq__(other)
+        if result is NotImplemented:
+            return result
+        return not result
+
+    def __hash__(self):
+        return hash((self.log_path, Collectible))
+
+
+class Logfile(Collectible):
+
+    """
+    Collectible system file.
+
+    :param path: Path to the log file.
+    :param log_path: Basename of the file where output is logged (optional).
+    """
+
+    def __init__(self, path, log_path=None):
+        if not log_path:
+            log_path = os.path.basename(path)
+        super(Logfile, self).__init__(log_path)
+        self.path = path
+
+    def __repr__(self):
+        r = "Logfile(%r, %r)"
+        r %= (self.path, self.log_path)
+        return r
+
+    def __eq__(self, other):
+        if isinstance(other, Logfile):
+            return (self.path, self.log_path) == (other.path, other.log_path)
+        elif isinstance(other, Collectible):
+            return False
+        return NotImplemented
+
+    def __hash__(self):
+        return hash((self.path, self.log_path, Logfile))
+
+    def collect(self):
+        """
+        Reads the log file.
+        :raise CollectibleException
+        """
+        if os.path.exists(self.path):
+            try:
+                yield from self._read_file(self.path)
+            except IOError:
+                raise CollectibleException("Not logging %s (lack of "
+                                           "permissions)" % self.path)
+        else:
+            raise CollectibleException("Not logging %s (file not found)" %
+                                       self.path)
+
+
+class Command(Collectible):
+
+    """
+    Collectible command.
+
+    :param cmd: String with the command.
+    :param timeout: Timeout for command execution.
+    :param locale: Force LANG for sysinfo collection
+    """
+
+    def __init__(self, cmd, timeout=-1, locale='C'):
+        super(Command, self).__init__(cmd)
+        self._name = self.log_path
+        self.cmd = cmd
+        self.timeout = timeout
+        self.locale = locale
+
+    def __repr__(self):
+        r = "Command(%r, %r)"
+        r %= (self.cmd, self.log_path)
+        return r
+
+    def __eq__(self, other):
+        if isinstance(other, Command):
+            return (self.cmd, self.log_path) == (other.cmd, other.log_path)
+        elif isinstance(other, Collectible):
+            return False
+        return NotImplemented
+
+    def __hash__(self):
+        return hash((self.cmd, self.log_path, Command))
+
+    def collect(self):
+        """
+        Execute the command as a subprocess and returns it's output.
+        :raise CollectibleException
+        """
+        env = os.environ.copy()
+        if "PATH" not in env:
+            env["PATH"] = "/usr/bin:/bin"
+        if self.locale:
+            env["LC_ALL"] = self.locale
+        # the sysinfo configuration supports negative or zero integer values
+        # but the avocado.utils.process APIs define no timeouts as "None"
+        if int(self.timeout) <= 0:
+            self.timeout = None
+        try:
+            result = process.run(self.cmd,
+                                 timeout=self.timeout,
+                                 verbose=False,
+                                 ignore_status=True,
+                                 allow_output_check='combined',
+                                 shell=True,
+                                 env=env)
+            yield result.stdout
+        except FileNotFoundError as exc_fnf:
+            raise CollectibleException("Not logging '%s' (command '%s' was not "
+                                       "found)" % (self.cmd, exc_fnf.filename))
+        except Exception as exc:  # pylint: disable=W0703
+            raise CollectibleException('Could not execute "%s": %s' %
+                                       (self.cmd, exc))
+
+
+class Daemon(Command):
+
+    """
+    Collectible daemon.
+
+    :param cmd: String with the command.
+    :param timeout: Timeout for command execution.
+    :param locale: Force LANG for sysinfo collection
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(Daemon, self).__init__(*args, **kwargs)
+        self.daemon_process = None
+        self.temp_file = tempfile.NamedTemporaryFile()
+
+    def __repr__(self):
+        r = "Daemon(%r, %r)"
+        r %= (self.cmd, self.log_path)
+        return r
+
+    def __eq__(self, other):
+        if isinstance(other, Daemon):
+            return (self.cmd, self.log_path) == (other.cmd, other.log_path)
+        elif isinstance(other, Collectible):
+            return False
+        return NotImplemented
+
+    def __hash__(self):
+        return hash((self.cmd, self.log_path, Daemon))
+
+    def __del__(self):
+        self.temp_file.close()
+
+    def run(self):
+        """
+        Start running the daemon as a subprocess.
+        :raise CollectibleException
+        """
+        env = os.environ.copy()
+        if "PATH" not in env:
+            env["PATH"] = "/usr/bin:/bin"
+        if self.locale:
+            env["LC_ALL"] = self.locale
+        logf_path = self.temp_file.name
+        stdin = open(os.devnull, "r")
+        stdout = open(logf_path, "w")
+
+        try:
+            self.daemon_process = subprocess.Popen(shlex.split(self.cmd),
+                                                   stdin=stdin, stdout=stdout,
+                                                   stderr=subprocess.STDOUT,
+                                                   shell=False, env=env)
+        except OSError as os_err:
+            raise CollectibleException('Could not execute "%s": %s' % (self.cmd,
+                                                                       os_err))
+
+    def collect(self):
+        """
+        Stop daemon execution and returns it's logs.
+        :raise OSError
+        """
+        if self.daemon_process is not None:
+            retcode = self.daemon_process.poll()
+            if retcode is None:
+                process.kill_process_tree(self.daemon_process.pid)
+                self.daemon_process.wait()
+                for line in self.temp_file.readlines():
+                    yield line
+            else:
+                raise OSError("Daemon process '%s' (pid %d) terminated"
+                              " abnormally (code %d)" % (self.cmd,
+                                                         self.daemon_process.pid,
+                                                         retcode))
+
+
+class JournalctlWatcher(Collectible):
+
+    """
+    Track the content of systemd journal.
+
+    :param log_path: Basename of the file where output is logged (optional).
+    """
+
+    def __init__(self, log_path=None):
+        if not log_path:
+            log_path = 'journalctl.gz'
+
+        super(JournalctlWatcher, self).__init__(log_path)
+        self.cursor = self._get_cursor()
+
+    def __repr__(self):
+        r = "JournalctlWatcher(%r)"
+        r %= self.log_path
+        return r
+
+    def __eq__(self, other):
+        if isinstance(other, JournalctlWatcher):
+            return self.log_path == other.log_path
+        elif isinstance(other, Collectible):
+            return False
+        return NotImplemented
+
+    def __hash__(self):
+        return hash((self.log_path, JournalctlWatcher))
+
+    @staticmethod
+    def _get_cursor():
+        try:
+            cmd = 'journalctl --quiet --lines 1 --output json'
+            result = process.system_output(cmd, verbose=False)
+            last_record = json.loads(astring.to_text(result, "utf-8"))
+            return last_record['__CURSOR']
+        except Exception as detail:  # pylint: disable=W0703
+            raise CollectibleException("Journalctl collection failed: %s" %
+                                       detail)
+
+    def collect(self):
+        """
+        Returns the content of systemd journal
+        :raise CollectibleException
+        """
+        if self.cursor:
+            try:
+                cmd = 'journalctl --quiet --after-cursor %s' % self.cursor
+                log_diff = process.system_output(cmd, verbose=False)
+                yield log_diff
+            except Exception as detail:  # pylint: disable=W0703
+                raise CollectibleException("Journalctl collection failed: %s" %
+                                           detail)
+
+
+class LogWatcher(Collectible):
+
+    """
+    Keep track of the contents of a log file in another compressed file.
+
+    This object is normally used to track contents of the system log
+    (/var/log/messages), and the outputs are gzipped since they can be
+    potentially large, helping to save space.
+
+    :param path: Path to the log file.
+    :param log_path: Basename of the file where output is logged (optional).
+    """
+
+    def __init__(self, path, log_path=None):
+        if not log_path:
+            log_path = os.path.basename(path) + ".gz"
+        else:
+            log_path += ".gz"
+
+        super(LogWatcher, self).__init__(log_path)
+        self.path = path
+        self.size = 0
+        self.inode = 0
+        try:
+            stat = os.stat(path)
+            self.size = stat.st_size
+            self.inode = stat.st_ino
+        except (IOError, OSError):
+            raise CollectibleException("Not logging %s (lack of permissions)" %
+                                       self.path)
+
+    def __repr__(self):
+        r = "LogWatcher(%r, %r)"
+        r %= (self.path, self.log_path)
+        return r
+
+    def __eq__(self, other):
+        if isinstance(other, LogWatcher):
+            return (self.path, self.log_path) == (other.path, other.log_path)
+        elif isinstance(other, Collectible):
+            return False
+        return NotImplemented
+
+    def __hash__(self):
+        return hash((self.path, self.log_path, LogWatcher))
+
+    def collect(self):
+        """
+        Collect all of the new data present in the log file.
+        :raise CollectibleException
+        """
+        bytes_to_skip = 0
+        current_stat = os.stat(self.path)
+        current_inode = current_stat.st_ino
+        current_size = current_stat.st_size
+        if current_inode == self.inode:
+            bytes_to_skip = self.size
+
+        self.inode = current_inode
+        self.size = current_size
+        try:
+            yield from self._read_file(self.path, bytes_to_skip)
+        except (IOError, OSError):
+            raise CollectibleException("Not logging %s (lack of permissions)" %
+                                       self.path)

--- a/selftests/unit/test_sysinfo.py
+++ b/selftests/unit/test_sysinfo.py
@@ -3,6 +3,7 @@ import tempfile
 import unittest
 
 from avocado.core import sysinfo
+from avocado.utils import sysinfo as sysinfo_collectible
 from selftests.utils import temp_dir_prefix
 
 
@@ -13,31 +14,31 @@ class SysinfoTest(unittest.TestCase):
         self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
 
     def test_loggables_equal(self):
-        cmd1 = sysinfo.Command("ls -l")
-        cmd2 = sysinfo.Command("ls -l")
+        cmd1 = sysinfo_collectible.Command("ls -l")
+        cmd2 = sysinfo_collectible.Command("ls -l")
         self.assertEqual(cmd1, cmd2)
-        file1 = sysinfo.Logfile("/proc/cpuinfo")
-        file2 = sysinfo.Logfile("/proc/cpuinfo")
+        file1 = sysinfo_collectible.Logfile("/proc/cpuinfo")
+        file2 = sysinfo_collectible.Logfile("/proc/cpuinfo")
         self.assertEqual(file1, file2)
 
     def test_loggables_not_equal(self):
-        cmd1 = sysinfo.Command("ls -l")
-        cmd2 = sysinfo.Command("ls -la")
+        cmd1 = sysinfo_collectible.Command("ls -l")
+        cmd2 = sysinfo_collectible.Command("ls -la")
         self.assertNotEqual(cmd1, cmd2)
-        file1 = sysinfo.Logfile("/proc/cpuinfo")
-        file2 = sysinfo.Logfile("/etc/fstab")
+        file1 = sysinfo_collectible.Logfile("/proc/cpuinfo")
+        file2 = sysinfo_collectible.Logfile("/etc/fstab")
         self.assertNotEqual(file1, file2)
 
     def test_loggables_set(self):
         container = set()
-        cmd1 = sysinfo.Command("ls -l")
-        cmd2 = sysinfo.Command("ls -l")
-        cmd3 = sysinfo.Command("ps -ef")
-        cmd4 = sysinfo.Command("uname -a")
-        file1 = sysinfo.Command("/proc/cpuinfo")
-        file2 = sysinfo.Command("/etc/fstab")
-        file3 = sysinfo.Command("/etc/fstab")
-        file4 = sysinfo.Command("/etc/fstab")
+        cmd1 = sysinfo_collectible.Command("ls -l")
+        cmd2 = sysinfo_collectible.Command("ls -l")
+        cmd3 = sysinfo_collectible.Command("ps -ef")
+        cmd4 = sysinfo_collectible.Command("uname -a")
+        file1 = sysinfo_collectible.Command("/proc/cpuinfo")
+        file2 = sysinfo_collectible.Command("/etc/fstab")
+        file3 = sysinfo_collectible.Command("/etc/fstab")
+        file4 = sysinfo_collectible.Command("/etc/fstab")
         # From the above 8 objects, only 5 are unique loggables.
         container.add(cmd1)
         container.add(cmd2)


### PR DESCRIPTION
This commit moves sysinfo collectibles to the avocado utils. It creates
api for collecting sysinfo. This api will be used in sysinfo runner and
sysinfo plugin. This is part of work on sysinfo support for nrunner.

Reference: #3877
Signed-off-by: Jan Richter <jarichte@redhat.com>