### PR TITLE
nrunner: fixes loader.loadTestsFromName() resolution with absolute paths

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -583,7 +583,15 @@ class PythonUnittestRunner(BaseRunner):
         sys.path.insert(0, ".")
         stream = io.StringIO()
 
-        suite = unittest.TestLoader().loadTestsFromName(unittest_name)
+        try:
+            suite = unittest.TestLoader().loadTestsFromName(unittest_name)
+        except ValueError as ex:
+            msg = "loadTestsFromName error {}".format(str(ex))
+            queue.put({'status': 'finished',
+                       'result': 'error',
+                       'output': msg})
+            return
+
         runner = unittest.TextTestRunner(stream=stream, verbosity=0)
         unittest_result = runner.run(suite)
 

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -559,8 +559,7 @@ class PythonUnittestRunner(BaseRunner):
     """
 
     @property
-    def unittest_name(self):
-        """Convert a test reference (uri) to an unittest name reference."""
+    def unittest(self):
         uri = self.runnable.uri
         if not uri:
             return None
@@ -576,20 +575,47 @@ class PythonUnittestRunner(BaseRunner):
             if module.startswith(os.path.sep):
                 module = module[1:]
         module = module.replace(os.path.sep, ".")
-        return '%s.%s' % (module, class_method)
+        klass, method = class_method.rsplit('.', maxsplit=1)
+        return module, klass, method
+
+    @property
+    def unittest_name(self):
+        """Convert a test reference (uri) to an unittest name reference."""
+        if not self.unittest:
+            return None
+        return "{}.{}.{}".format(*self.unittest)
+
+    @property
+    def module_path(self):
+        if not self.unittest:
+            return None
+        module, _, _ = self.unittest
+        path = module.replace('.', os.path.sep)
+        # This will fix adding support to hidden directories
+        path = path.replace('//', '/.')
+        return os.path.dirname(path)
+
+    @property
+    def module_class_method(self):
+        """Return a dotted name with module + class + method."""
+        if not self.unittest:
+            return None
+
+        return '.'.join(".".join(self.unittest).rsplit('.', maxsplit=3)[-3:])
 
     @classmethod
-    def _run_unittest(cls, unittest_name, queue):
-        sys.path.insert(0, ".")
+    def _run_unittest(cls, module_path, module_class_method, queue):
+        sys.path.insert(0, module_path)
         stream = io.StringIO()
 
         try:
-            suite = unittest.TestLoader().loadTestsFromName(unittest_name)
+            loader = unittest.TestLoader()
+            suite = loader.loadTestsFromName(module_class_method)
         except ValueError as ex:
-            msg = "loadTestsFromName error {}".format(str(ex))
+            msg = "loadTestsFromName error finding unittest {}: {}"
             queue.put({'status': 'finished',
                        'result': 'error',
-                       'output': msg})
+                       'output': msg.format(module_class_method, str(ex))})
             return
 
         runner = unittest.TextTestRunner(stream=stream, verbosity=0)
@@ -620,7 +646,9 @@ class PythonUnittestRunner(BaseRunner):
 
         queue = multiprocessing.SimpleQueue()
         process = multiprocessing.Process(target=self._run_unittest,
-                                          args=(self.unittest_name, queue))
+                                          args=(self.module_path,
+                                                self.module_class_method,
+                                                queue))
         process.start()
         yield self.prepare_status('started')
 

--- a/selftests/unit/test_nrunner.py
+++ b/selftests/unit/test_nrunner.py
@@ -250,54 +250,6 @@ class Runner(unittest.TestCase):
         self.assertEqual(last_result['returncode'], 1)
         self.assertIn('time', last_result)
 
-    def test_runner_python_unittest_ok(self):
-        runnable = nrunner.Runnable('python-unittest', 'unittest.TestCase')
-        runner_klass = runnable.pick_runner_class()
-        runner = runner_klass(runnable)
-        results = [status for status in runner.run()]
-        output1 = (b'----------------------------------------------------------'
-                   b'------------\nRan 0 tests in ')
-        output2 = b's\n\nOK\n'
-        output = results[-2]
-        result = results[-1]
-        self.assertEqual(result['status'], 'finished')
-        self.assertEqual(result['result'], 'pass')
-        self.assertTrue(output['log'].startswith(output1))
-        self.assertTrue(output['log'].endswith(output2))
-
-    def test_runner_python_unittest_fail(self):
-        runnable = nrunner.Runnable('python-unittest', 'unittest.TestCase.fail')
-        runner_klass = runnable.pick_runner_class()
-        runner = runner_klass(runnable)
-        results = [status for status in runner.run()]
-        output1 = (b'============================================================='
-                   b'=========\nFAIL: fail (unittest.case.TestCase)'
-                   b'\nFail immediately, with the given message.')
-        output2 = b'\n\nFAILED (failures=1)\n'
-        output = results[-2]
-        result = results[-1]
-        self.assertEqual(result['status'], 'finished')
-        self.assertEqual(result['result'], 'fail')
-        self.assertTrue(output['log'].startswith(output1))
-        self.assertTrue(output['log'].endswith(output2))
-
-    def test_runner_python_unittest_skip(self):
-        runnable = nrunner.Runnable(
-            'python-unittest',
-            'selftests.unit.test_test.TestClassTestUnit.DummyTest.skip')
-        runner_klass = runnable.pick_runner_class()
-        runner = runner_klass(runnable)
-        results = [status for status in runner.run()]
-        output1 = (b'----------------------------------------------------------'
-                   b'------------\nRan 1 test in ')
-        output2 = b's\n\nOK (skipped=1)\n'
-        output = results[-2]
-        result = results[-1]
-        self.assertEqual(result['status'], 'finished')
-        self.assertEqual(result['result'], 'skip')
-        self.assertTrue(output['log'].startswith(output1))
-        self.assertTrue(output['log'].endswith(output2))
-
     def test_runner_python_unittest_error(self):
         runnable = nrunner.Runnable('python-unittest', 'error')
         runner_klass = runnable.pick_runner_class()

--- a/selftests/unit/test_nrunner.py
+++ b/selftests/unit/test_nrunner.py
@@ -303,22 +303,18 @@ class Runner(unittest.TestCase):
         runner_klass = runnable.pick_runner_class()
         runner = runner_klass(runnable)
         results = [status for status in runner.run()]
-        output1 = (b'============================================================='
-                   b'=========\nERROR: error')
-        output2 = b'\n\nFAILED (errors=1)\n'
-        output = results[-2]
+        output = 'URI is required but was not given or it is invalid.'
         result = results[-1]
         self.assertEqual(result['status'], 'finished')
         self.assertEqual(result['result'], 'error')
-        self.assertTrue(output['log'].startswith(output1))
-        self.assertTrue(output['log'].endswith(output2))
+        self.assertEqual(result['output'], output)
 
     def test_runner_python_unittest_empty_uri_error(self):
         runnable = nrunner.Runnable('python-unittest', '')
         runner_klass = runnable.pick_runner_class()
         runner = runner_klass(runnable)
         results = [status for status in runner.run()]
-        output = 'uri is required but was not given'
+        output = 'URI is required but was not given or it is invalid.'
         result = results[-1]
         self.assertEqual(result['status'], 'finished')
         self.assertEqual(result['result'], 'error')


### PR DESCRIPTION
Currently loader.loadTestsFromName() will only find tests that are part of
sys.path. We are adding current directory (.) to that path, assuming that test
references will always be a relative path to the current directory. With this
change we will be able to pass a absolute reference (i.e:
/tmp/foo.py:Bar.test_foo) and the nrunner will add the basedir to the sys.path
correctly. Fixes #4840

Signed-off-by: Beraldo Leal <bleal@redhat.com>