### PR TITLE
avocado.utils: limit printed durations to nanosecond precision

### DIFF
--- a/avocado/utils/debug.py
+++ b/avocado/utils/debug.py
@@ -40,7 +40,7 @@ def measure_duration(func):
             duration = time.monotonic() - start
             __MEASURE_DURATION[func] = (__MEASURE_DURATION.get(func, 0) +
                                         duration)
-            LOGGER.debug("PERF: %s: (%ss, %ss)", func, duration,
+            LOGGER.debug("PERF: %s: (%.9fs, %.9fs)", func, duration,
                          __MEASURE_DURATION[func])
     return wrapper
 

--- a/avocado/utils/gdb.py
+++ b/avocado/utils/gdb.py
@@ -243,7 +243,7 @@ class CommandResult:
         return "".join([m.value for m in self.stream_messages])
 
     def __repr__(self):
-        return "%s at %s" % (self.command, self.timestamp)
+        return "%s at %.9f" % (self.command, self.timestamp)
 
 
 class GDB:

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -727,7 +727,7 @@ class SubProcess:
         if self.result.duration == 0:
             self.result.duration = time.monotonic() - self.start_time
         if self.verbose:
-            log.info("Command '%s' finished with %s after %ss", self.cmd, rc,
+            log.info("Command '%s' finished with %s after %.9fs", self.cmd, rc,
                      self.result.duration)
         self.result.pid = self._popen.pid
         self._fill_streams()
@@ -843,7 +843,7 @@ class SubProcess:
                     the specified timeout.
         """
         def nuke_myself():
-            self.result.interrupted = ("timeout after %ss"
+            self.result.interrupted = ("timeout after %.9fs"
                                        % (time.monotonic() - self.start_time))
             try:
                 kill_process_tree(self.get_pid(), sig, timeout=1)

--- a/avocado/utils/wait.py
+++ b/avocado/utils/wait.py
@@ -29,7 +29,7 @@ def wait_for(func, timeout, first=0.0, step=1.0, text=None, args=None, kwargs=No
 
     while time.monotonic() < end_time:
         if text:
-            log.debug("%s (%f secs)", text, (time.monotonic() - start_time))
+            log.debug("%s (%.9f secs)", text, (time.monotonic() - start_time))
 
         output = func(*args, **kwargs)
         if output:


### PR DESCRIPTION
We should limit printed elapsed times to nanosecond precision, i.e.
nine figures after the decimal point.

First, long decimal fractions are difficult to eyeball.  This
is annoying to read at a glance:

Command 'kill -19 1429623' finished with 0 after 0.0005124460049035922s

Whereas this is easier to read at a glance:

Command 'kill -19 1429623' finished with 0 after 0.000512446s

Second, the system call behind time.monotonic(), clock_gettime(2), has
a resolution of one nanosecond.  Additional figures are insignificant.

Signed-off-by: Scott Cheloha <cheloha@linux.ibm.com>