### PR TITLE
CI: deployment of Avocado via different methods in a container with ansible

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -22,7 +22,9 @@ jobs:
       IMAGE: 'fedora:34'
     strategy:
       matrix:
-        extra: ["method=pip", "method=copr", "method=official", "method=pip avocado_vt=true", "method=copr avocado_vt=true", "method=official avocado_vt=true"]
+        #        extra: ["method=pip", "method=copr", "method=official", "method=pip avocado_vt=true", "method=copr avocado_vt=true", "method=official avocado_vt=true"]
+        #        lack of updated packages in the repos for python3-avocado-plugins-vt
+                extra: ["method=pip", "method=copr", "method=official", "method=pip avocado_vt=true"]
       fail-fast: false
 
     steps:

--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -1,0 +1,39 @@
+name: Ansible deployment test
+
+on:
+  pull_request:
+    branches: [ master ]
+  # Runs at 5:00 UTC on Mondays
+  schedule:
+    - cron: "0 5 * * 1"
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+
+  podman:
+    name: Ansible (${{matrix.extra}})
+    runs-on: ubuntu-latest
+    env:
+      RUN_BEFORE: 'dnf install -y git ansible'
+      GIT_URL: 'git://github.com/${{github.repository}}'
+      INVENTORY: 'selftests/deployment/inventory'
+      PLAYBOOK: 'selftests/deployment/deployment.yml'
+      IMAGE: 'fedora:34'
+    strategy:
+      matrix:
+        extra: ["method=pip", "method=copr", "method=official", "method=pip avocado_vt=true", "method=copr avocado_vt=true", "method=official avocado_vt=true"]
+      fail-fast: false
+
+    steps:
+      - name: Install podman
+        run: sudo apt-get -y install podman
+      - name: Check out repository code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Fetch container image
+        run: podman pull ${{env.IMAGE}}
+      - name: Run Ansible playbook
+        run: podman run --rm -ti ${{env.IMAGE}} /bin/bash -c '${{env.RUN_BEFORE}} && ansible-pull -v -U ${{env.GIT_URL}} -i ${{env.INVENTORY}} -c local ${{env.PLAYBOOK}} -e "${{matrix.extra}}" -e "avocado_git_url=${{env.GIT_URL}}"'
+

--- a/selftests/deployment/roles/avocado/tasks/main.yml
+++ b/selftests/deployment/roles/avocado/tasks/main.yml
@@ -9,4 +9,5 @@
 
 - name: Avocado examples must be installed via specific method
   include_tasks: "roles/avocado/tasks/{{ method }}/examples.yml"
-  when: method is defined
+  when:
+    - method == 'pip' or method == 'copr'

--- a/selftests/deployment/roles/avocado/tasks/pip/plugins.yml
+++ b/selftests/deployment/roles/avocado/tasks/pip/plugins.yml
@@ -29,19 +29,9 @@
     name: "git+{{ avocado_git_url}}@{{ avocado_git_branch }}#egg=avocado-framework-plugin-varianter-pict&subdirectory=optional_plugins/varianter_pict"
     virtualenv: "{{ temporary_dir.path }}"
 
-- name: Avocado glib loader plugin installation via pip
-  pip:
-    name: "git+{{ avocado_git_url}}@{{ avocado_git_branch }}#egg=avocado-framework-plugin-glib&subdirectory=optional_plugins/glib"
-    virtualenv: "{{ temporary_dir.path }}"
-
 - name: Avocado golang loader plugin installation via pip
   pip:
     name: "git+{{ avocado_git_url}}@{{ avocado_git_branch }}#egg=avocado-framework-plugin-golang&subdirectory=optional_plugins/golang"
-    virtualenv: "{{ temporary_dir.path }}"
-
-- name: Avocado YAML loader plugin installation via pip
-  pip:
-    name: "git+{{ avocado_git_url}}@{{ avocado_git_branch }}#egg=avocado-framework-plugin-loader-yaml&subdirectory=optional_plugins/loader_yaml"
     virtualenv: "{{ temporary_dir.path }}"
 
 # This is a workaround until we fix avocado-vt/issues/2193

--- a/selftests/deployment/roles/avocado/tasks/pip/plugins.yml
+++ b/selftests/deployment/roles/avocado/tasks/pip/plugins.yml
@@ -34,12 +34,9 @@
     name: "git+{{ avocado_git_url}}@{{ avocado_git_branch }}#egg=avocado-framework-plugin-golang&subdirectory=optional_plugins/golang"
     virtualenv: "{{ temporary_dir.path }}"
 
-# This is a workaround until we fix avocado-vt/issues/2193
-- name: Avocado VT plugin installation via RPM
-  package:
-    name: python3-avocado-plugins-vt
-    state: latest
+- name: Avocado VT plugin installation via pip
+  pip:
+    name: "git+{{ avocado_vt_git_url}}@{{ avocado_vt_git_branch }}"
+    virtualenv: "{{ temporary_dir.path }}"
   when:
-    - ansible_facts['distribution_file_variety'] == "RedHat"
-    - ansible_facts['distribution'] != "Fedora"
     - avocado_vt|default(false)|bool == true

--- a/selftests/deployment/roles/common/tasks/dependencies.yml
+++ b/selftests/deployment/roles/common/tasks/dependencies.yml
@@ -15,6 +15,8 @@
      - git
      - gcc
      - nc
+     - python3-devel
+     - python3-pillow
      - python3-netaddr
      - python3-netifaces
      - qemu-img

--- a/selftests/deployment/roles/common/tasks/repos.yml
+++ b/selftests/deployment/roles/common/tasks/repos.yml
@@ -19,30 +19,6 @@
     - method == 'official' or method == 'copr'
     - ansible_facts['distribution'] == "Fedora"
 
-# Official repos
-- name: Install Avocado EPEL Official Releases repo
-  yum_repository:
-    name: avocado
-    description: Avocado EPEL Official Releases repo
-    baseurl: https://avocado-project.org/data/repos/epel-$releasever-noarch/
-    gpgcheck: yes
-    gpgkey: https://avocado-project.org/data/repos/crosa_redhat_com.gpg
-  when:
-    - method == 'official'
-    - ansible_facts['distribution_file_variety'] == "RedHat"
-    - ansible_facts['distribution_major_version'] == "7"
-
-- name: Install Avocado Fedora Official Releases repo
-  yum_repository:
-    name: avocado
-    description: Avocado Fedora Official Releases repo
-    baseurl: https://avocado-project.org/data/repos/fedora-$releasever-noarch/
-    gpgcheck: yes
-    gpgkey: https://avocado-project.org/data/repos/crosa_redhat_com.gpg
-  when:
-    - method == 'official'
-    - ansible_facts['distribution'] == "Fedora"
-
 # Copr repos (Avocado)
 - name: Avocado EPEL Copr repo
   yum_repository:

--- a/selftests/deployment/roles/tests/tasks/main.yml
+++ b/selftests/deployment/roles/tests/tasks/main.yml
@@ -15,7 +15,7 @@
     - avocado_vt|default(false)|bool == true
 
 - name: Avocado-VT test 3/5 - dry-run execution
-  shell: avocado run --dry-run -- boot
+  shell: "{{ temporary_dir.path | default('/usr') }}/bin/avocado run --dry-run -- boot"
   changed_when: false
   when:
     - ansible_facts['distribution_file_variety'] == "RedHat"


### PR DESCRIPTION
This PR adds `ansible.yml` testing the deployment of Avocado with Ansible via different methods in a Fedora container, followed by several commits updating the current ansible playbook. 
Two of the commits are marked with RFC!! and I hope you can help me there. The repos at  https://avocado-project.org/ are not longer available and it seems like we don't provide anymore packages for python3-avocado-plugins-vt

You can see how the pipeline works at https://github.com/ana/avocado2/actions/runs/1134850293
Ignore the results from `ansible.yml`  here because it's fetching the current master branch 




References: https://github.com/avocado-framework/avocado/issues/4601