### PR TITLE
nrunner: add debugging aids to the Task/StateMachine/Repo system

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -73,7 +73,7 @@ def register_job_options():
                              key='store_logging_stream',
                              nargs='+',
                              help_msg=help_msg,
-                             default=[],
+                             default=['avocado.core:DEBUG'],
                              metavar='STREAM[:LEVEL]',
                              key_type=list)
 

--- a/avocado/core/status/repo.py
+++ b/avocado/core/status/repo.py
@@ -1,4 +1,8 @@
+import logging
+
 from .utils import json_loads
+
+LOG = logging.getLogger(__name__)
 
 
 class StatusMsgMissingDataError(Exception):
@@ -25,12 +29,16 @@ class StatusRepo:
         self._by_result = {}
 
     def _handle_task_finished(self, message):
+        task_id = message['id']
         self._set_by_result(message)
         self._set_task_data(message)
+        LOG.debug('Task "%s" finished message: "%s"', task_id, message)
 
     def _handle_task_started(self, message):
         if 'output_dir' not in message:
             raise StatusMsgMissingDataError('output_dir')
+        task_id = message['id']
+        LOG.debug('Task "%s" started message: "%s"', task_id, message)
         self._set_task_data(message)
 
     def _set_by_result(self, message):


### PR DESCRIPTION
The nrunner has a much more decoupled design with many more moving
parts (when compared to the legacy runner), for instance:

 * workers trying to get tasks to move over their life cycle stages
 * tasks being started by different spawner
 * tasks asynchronously reporting their status to status servers

It makes it non-trivial to debug where an Avocado internal failure may
be located.

This introduces the convention of the "avocado.core" logging
namespace, following the actual Python module implementation, so that
developers and advanced users can choose to see the nrunner internals
for troubleshooting, debugging, etc.

Because of the hierarchical nature of the namespaces, one can choose
to see all "avocado.core" information with:

  $ avocado --show=avocado.core run --test-runner=nrunner ...

Or choose a subset with:

  $ avocado --show=avocado.core.task run --test-runner=nrunner ...
  $ avocado --show=avocado.core.status run --test-runner=nrunner ...

By default, it stores the core, internal debugging information in a
separate file in the job results directory, because:

 * It's too much information that ends up polluting and disrupting
   "job.log"
 * It's really internal Avocado information, and not really meaningful
   to users expecting to see what happened to their tests in jobs
 * With the upcoming switch to nrunner being the default, having a
   log with internal information by default at least for the following
   few releases may help us to solve any issues users face with a
   readily available log file.

More (or less) debugging information can be added to the nrunner
related modules, or, for that matter, any other core module.

Fixes: https://github.com/avocado-framework/avocado/issues/4547
Signed-off-by: Cleber Rosa <crosa@redhat.com>