### PR TITLE
[nrunner] always copy runnable instead of guessing variants

### DIFF
--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -192,8 +192,10 @@ class Runner(RunnerInterface):
         result = []
 
         # test related operations
-        # when creating variants, they need to have a copy of the runnable.
-        if len(test_suite.tests) == 1 and index > 1:
+        # when creating variants, the number of tasks created are greater than
+        # the number of tests on the test suite. In this case, these variants
+        # need a copy of the runnable.
+        if index > len(test_suite.tests):
             runnable = deepcopy(runnable)
         # create test ID
         if test_suite.name:


### PR DESCRIPTION
Instead of adding complex code to determine if the test is a variant, let's always make a copy of the runnable for the new tasks.

Fixes: #4850 
Signed-off-by: Willian Rampazzo <willianr@redhat.com>