### PR TITLE
[nrunner] add variants support to exec-test

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -452,6 +452,21 @@ class ExecRunner(BaseRunner):
         return self.prepare_status('finished',
                                    {'returncode': process.returncode})
 
+    def _create_params(self):
+        """Create params for the test"""
+        # inject the -p command-line / run.test_parameters option in the
+        # environment variables
+        params = dict(self.runnable.config.get('run.test_parameters', []))
+
+        if self.runnable.variant is not None:
+            params_from_variant = dict([(str(key), str(val)) for _, key, val in
+                                        self.runnable.variant['variant'][0][1]])
+            # if we have params from the variant, replace the original params
+            if params_from_variant:
+                params = params_from_variant
+
+        return params
+
     def run(self):
         env = None
         if self.runnable.kwargs:
@@ -459,9 +474,7 @@ class ExecRunner(BaseRunner):
             current.update(self.runnable.kwargs)
             env = current
 
-        # inject the run.test_parameters option in the environment variables
-        # this handles the -p command-line argument
-        params = dict(self.runnable.config.get('run.test_parameters', []))
+        params = self._create_params()
         if params:
             env.update(params)
 

--- a/examples/tests/sleeptest.sh
+++ b/examples/tests/sleeptest.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+if [[ -z ${SLEEP_LENGTH} ]]; then
+  SLEEP_LENGTH=1
+fi
+
+echo "Sleeping $SLEEP_LENGTH"
+sleep $SLEEP_LENGTH

--- a/examples/tests/sleeptest.sh.data/sleeptest.yaml
+++ b/examples/tests/sleeptest.sh.data/sleeptest.yaml
@@ -1,0 +1,9 @@
+!mux
+short:
+    SLEEP_LENGTH: 0.5
+medium:
+    SLEEP_LENGTH: 1
+long:
+    SLEEP_LENGTH: 5
+longest:
+    SLEEP_LENGTH: 10


### PR DESCRIPTION
This adds variants support to the exec-test test type and an example similar to the avocado-instrumented example.

Signed-off-by: Willian Rampazzo <willianr@redhat.com>