### PR TITLE
[nrunner] fix runnable copy during task creation for variants (v3)

### DIFF
--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -35,7 +35,7 @@ from avocado.core.status.server import StatusServer
 from avocado.core.task.runtime import RuntimeTask
 from avocado.core.task.statemachine import TaskStateMachine, Worker
 from avocado.core.test_id import TestID
-from avocado.core.varianter import dump_variant
+from avocado.core.varianter import dump_variant, is_empty_variant
 
 
 class RunnerInit(Init):
@@ -192,8 +192,10 @@ class Runner(RunnerInterface):
         result = []
 
         # test related operations
-        # when creating variants, they need to have a copy of the runnable.
-        if len(test_suite.tests) == 1 and index > 1:
+        # when creating variants, the number of tasks created are greater than
+        # the number of tests on the test suite. In this case, these variants
+        # need a copy of the runnable.
+        if not is_empty_variant(variant):
             runnable = deepcopy(runnable)
         # create test ID
         if test_suite.name:


### PR DESCRIPTION
This fixes the case where more than one test file is used when running avocado with variants.

Ideally, decoupling variants from runnables would make things more flexible. Issue https://github.com/avocado-framework/avocado/issues/4853 tracks this enhancement.

Signed-off-by: Cleber Rosa <crosa@redhat.com>
Signed-off-by: Willian Rampazzo <willianr@redhat.com>