### PR TITLE
CI: add prerelease.yml to executes automatically some of the pre-release steps

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,99 @@
+name: Pre-release tests
+
+on:
+  # Runs at 5:00 UTC on Mondays
+  schedule:
+    - cron: "0 5 * * 1"
+  workflow_dispatch:
+
+jobs:
+
+  make-check:
+    name: Run 'make check'
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt
+      - name: Installing Avocado in develop mode
+        run: python3 setup.py develop --user
+      - name: Run make check
+        run: make check
+
+  avocado-pre-release:
+    name: Avocado pre-release job
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Install avocado
+        run: |
+          sudo python3 -m pip install -r requirements-dev.txt
+          sudo python3 setup.py develop
+      - name: Avocado pre-release job
+        run: ./selftests/pre_release/jobs/pre_release.py
+
+
+  # Re-implements ./selftests/pre_release/tests/check-copr-rpm-version.sh
+  check-rpm-available-copr:
+    name: Check the right RPM packages are available in COPR
+    runs-on: ubuntu-latest
+    env:
+      FEDORA_VERSION: '34'
+    container:
+      image: fedora:34
+    steps:
+      - name: install repos and packages
+        run: |
+          dnf -y install git
+          dnf -y module disable avocado
+          dnf -y install 'dnf-command(copr)'
+          dnf -y copr enable @avocado/avocado-latest
+      - uses: actions/checkout@v2
+        with:
+          ref: 'master'
+      - name: Check the right RPM packages are available
+        run: |
+          VERSION=$(python3 setup.py --version 2>/dev/null)
+          RPM_RELEASE_NUMBER=$(grep -E '^Release:\s([0-9]+)' python-avocado.spec | sed -E 's/Release:\s([0-9]+).*/\1/')
+          COMMIT_DATE=$(git log -n 1 --pretty='format:%cd' --date='format:%Y%m%d')
+          SHORT_COMMIT=$(git rev-parse --short=9 master)
+          dnf -y install python3-avocado-${VERSION}-${RPM_RELEASE_NUMBER}.${COMMIT_DATE}git${SHORT_COMMIT}.fc${{env.FEDORA_VERSION}}
+
+
+  avocado-deployment-copr:
+    name: Avocado deployment
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:34
+      volumes:
+        - /tmp/artifact:/tmp/artifact
+    env:
+      GIT_URL: 'git://github.com/avocado-framework/avocado'
+      INVENTORY: 'selftests/deployment/inventory'
+      PLAYBOOK: 'selftests/deployment/deployment.yml'
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Install Ansible
+        run: dnf install -y git ansible
+      - name: Run Ansible playbook
+        run:  ansible-pull -v -U ${{env.GIT_URL}} -i ${{env.INVENTORY}} -c local ${{env.PLAYBOOK}} -e "method=copr"
+      - name: Create artifact directory
+        run: mkdir -p /tmp/artifact
+      - name: Run test
+        run: avocado run /usr/bin/true --html /tmp/artifact/report.html
+      - name: Save artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: avocado-html
+          path: /tmp/artifact
+          retention-days: 1

--- a/examples/testplans/release/pre.json
+++ b/examples/testplans/release/pre.json
@@ -7,29 +7,16 @@
         {"name": "Check status of master branch",
          "description": "Navigate to:\n\n   https://github.com/avocado-framework/avocado#build-and-quality-status\n\nand make sure that all build and quality services report good indicators"},
 
-	{"name": "Avocado source is sound",
-	 "description": "On your development machine, on a fresh Avocado source to be released, run `$ make check`. Expected result: Make command should say OK."},
+        {"name": "Set the readthedocs.org token",
+        "description": "Generate and export the content of a token (from https://readthedocs.org/accounts/tokens/) as the AVOCADO_READTHEDOCS_TOKEN environment variable. For this step you have to be admin of avocado-framework project on readthedocs.org."},
 
-	{"name": "Set the readthedocs.org token",
-	 "description": "Generate and export the content of a token (from https://readthedocs.org/accounts/tokens/) as the AVOCADO_READTHEDOCS_TOKEN environment variable. For this step you have to be admin of avocado-framework project on readthedocs.org."},
+        {"name": "Run GitHub Action 'Pre-release tests'",
+         "description": "Run the GitHub Action 'Pre-release tests' on the master branch at https://github.com/avocado-framework/avocado/actions/workflows/prerelease.yml and check all the tests pass. Make at least a quick visual check to the logs."},
 
-	{"name": "Avocado pre-release job",
-	 "description": "With a load as light as possible on your system, run `selftests/pre_release/jobs/pre_release.py`. Expected results: all tests PASSed"},
+        {"name": "Avocado Remote Machine HTML report",
+         "description": "Download the HTML artifact from the previous step and on a web browser, open the HTML report. Verify that all the links such as `job-YYYY-MM-DD...` (under `Results Dir`) or `debug.log` point to valid locations."},
 
-        {"name": "Check the right RPM packages are available in COPR",
-         "description": "Run `selftests/pre_release/tests/check-copr-rpm-version.sh`. Expected result: last line with: Complete!"},
-
-	{"name": "Avocado deployment",
-	 "description": "Execute the ansible playbook located at selftests/deployments/deployment.yml with '-e method=copr' on one or many fresh virtual machines."},
-
-	{"name": "Avocado Test Run on RPM based installation",
-	 "description": "On the same machine you just installed Avocado used during RPM packages ('Avocado RPM install'), run the simplest possible test with `$ avocado run passtest.py --html /tmp/report.html`. Expected results: `(1/1) passtest.py: PASS (0.00 s)`."},
-
-	{"name": "Avocado Remote Machine HTML report",
-	 "description": "On a web browser, open the previously generated  HTML report at `/tmp/report.html`. Verify that all the links such as `job-YYYY-MM-DD...` (under `Results Dir`), `1-/**/avocado/tests/**/examples/tests/passtest.py:PassTest.test` (under `Test ID`) and `debug.log` point to valid locations."},
-
-	{"name": "Paginator",
-	"description": "Start new terminal and store the stty setting by running `stty -a > /tmp/tty_state_pre`. Then run `AVOCADO_LOG_EARLY=y avocado config` and verify paginator is enabled, colored output is produced and quit. Then run `stty -a > /tmp/tty_state_post` followed by `diff /tmp/tty_state_{pre,post}` and verify the setting was not changed (no output)."}
-
+        {"name": "Paginator",
+         "description": "Start new terminal and store the stty setting by running `stty -a > /tmp/tty_state_pre`. Then run `AVOCADO_LOG_EARLY=y avocado config` and verify paginator is enabled, colored output is produced and quit. Then run `stty -a > /tmp/tty_state_post` followed by `diff /tmp/tty_state_{pre,post}` and verify the setting was not changed (no output)."}
     ]
 }


### PR DESCRIPTION
This pipeline performs 5 of the 9 steps outlined `examples/testplans/release/pre.json` and helps with a sixth one "Avocado Remote Machine HTML report" - the HTML is created and saved as an artifact that can be downloaded and checked locally.
There is a detail to take into account, the containers by GitHub Actions to run the step "Avocado Test Run on RPM based installation" have modifications to make them smaller, this means it avoids saving files under `/usr/share/doc`, and avocado packaging is installing there the examples. This is why I changed the the test to run `/usr/bin/true` instead of `passtest.py`
Also as result of using a container, there is not a hostname so the HTML job report says 
`Host: 	/bin/sh: line 1: hostname: command not found"`

The three remaining tasks are:
- check all build and quality services report good indicators 
- Set the readthedocs.org token
- paginator

The two first ones can't  be automatically executed. I'm unsure about paginator, I'd need to research it.
The result of the pipeline can be browsed at https://github.com/ana/avocado/runs/3351493931

References: https://github.com/avocado-framework/avocado/issues/4601