### PR TITLE
nrunner: fixes loader.loadTestsFromName() resolution with absolute paths (v2)

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -594,7 +594,15 @@ class PythonUnittestRunner(BaseRunner):
         sys.path.insert(0, ".")
         stream = io.StringIO()
 
-        suite = unittest.TestLoader().loadTestsFromName(unittest_name)
+        try:
+            suite = unittest.TestLoader().loadTestsFromName(unittest_name)
+        except ValueError as ex:
+            msg = "loadTestsFromName error {}".format(str(ex))
+            queue.put({'status': 'finished',
+                       'result': 'error',
+                       'output': msg})
+            return
+
         runner = unittest.TextTestRunner(stream=stream, verbosity=0)
         unittest_result = runner.run(suite)
 

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -570,13 +570,16 @@ class PythonUnittestRunner(BaseRunner):
 
      * kwargs: not used
     """
-    @staticmethod
-    def _uri_to_unittest_name(uri):
+
+    @property
+    def unittest_name(self):
+        """Convert a test reference (uri) to an unittest name reference."""
+        uri = self.runnable.uri
         if ':' in uri:
             module, class_method = uri.rsplit(':', 1)
         else:
-            module = uri
-            class_method = None
+            return None
+
         if module.endswith('.py'):
             module = module[:-3]
         if module.startswith(os.path.curdir):
@@ -584,15 +587,13 @@ class PythonUnittestRunner(BaseRunner):
             if module.startswith(os.path.sep):
                 module = module[1:]
         module = module.replace(os.path.sep, ".")
-        if class_method:
-            return '%s.%s' % (module, class_method)
-        return module
+        return '%s.%s' % (module, class_method)
 
     @classmethod
-    def _run_unittest(cls, uri, queue):
+    def _run_unittest(cls, unittest_name, queue):
         sys.path.insert(0, ".")
         stream = io.StringIO()
-        unittest_name = cls._uri_to_unittest_name(uri)
+
         suite = unittest.TestLoader().loadTestsFromName(unittest_name)
         runner = unittest.TextTestRunner(stream=stream, verbosity=0)
         unittest_result = runner.run(suite)
@@ -614,15 +615,16 @@ class PythonUnittestRunner(BaseRunner):
         queue.put(output)
 
     def run(self):
-        if not self.runnable.uri:
-            error_msg = 'uri is required but was not given'
+        if not self.unittest_name:
+            error_msg = ("Invalid URI: could not be converted to an unittest "
+                         "dotted name.")
             yield self.prepare_status('finished', {'result': 'error',
                                                    'output': error_msg})
             return
 
         queue = multiprocessing.SimpleQueue()
         process = multiprocessing.Process(target=self._run_unittest,
-                                          args=(self.runnable.uri, queue))
+                                          args=(self.unittest_name, queue))
         process.start()
         yield self.prepare_status('started')
 

--- a/selftests/unit/test_nrunner.py
+++ b/selftests/unit/test_nrunner.py
@@ -250,75 +250,25 @@ class Runner(unittest.TestCase):
         self.assertEqual(last_result['returncode'], 1)
         self.assertIn('time', last_result)
 
-    def test_runner_python_unittest_ok(self):
-        runnable = nrunner.Runnable('python-unittest', 'unittest.TestCase')
-        runner_klass = runnable.pick_runner_class()
-        runner = runner_klass(runnable)
-        results = [status for status in runner.run()]
-        output1 = (b'----------------------------------------------------------'
-                   b'------------\nRan 0 tests in ')
-        output2 = b's\n\nOK\n'
-        output = results[-2]
-        result = results[-1]
-        self.assertEqual(result['status'], 'finished')
-        self.assertEqual(result['result'], 'pass')
-        self.assertTrue(output['log'].startswith(output1))
-        self.assertTrue(output['log'].endswith(output2))
-
-    def test_runner_python_unittest_fail(self):
-        runnable = nrunner.Runnable('python-unittest', 'unittest.TestCase.fail')
-        runner_klass = runnable.pick_runner_class()
-        runner = runner_klass(runnable)
-        results = [status for status in runner.run()]
-        output1 = (b'============================================================='
-                   b'=========\nFAIL: fail (unittest.case.TestCase)'
-                   b'\nFail immediately, with the given message.')
-        output2 = b'\n\nFAILED (failures=1)\n'
-        output = results[-2]
-        result = results[-1]
-        self.assertEqual(result['status'], 'finished')
-        self.assertEqual(result['result'], 'fail')
-        self.assertTrue(output['log'].startswith(output1))
-        self.assertTrue(output['log'].endswith(output2))
-
-    def test_runner_python_unittest_skip(self):
-        runnable = nrunner.Runnable(
-            'python-unittest',
-            'selftests.unit.test_test.TestClassTestUnit.DummyTest.skip')
-        runner_klass = runnable.pick_runner_class()
-        runner = runner_klass(runnable)
-        results = [status for status in runner.run()]
-        output1 = (b'----------------------------------------------------------'
-                   b'------------\nRan 1 test in ')
-        output2 = b's\n\nOK (skipped=1)\n'
-        output = results[-2]
-        result = results[-1]
-        self.assertEqual(result['status'], 'finished')
-        self.assertEqual(result['result'], 'skip')
-        self.assertTrue(output['log'].startswith(output1))
-        self.assertTrue(output['log'].endswith(output2))
-
     def test_runner_python_unittest_error(self):
         runnable = nrunner.Runnable('python-unittest', 'error')
         runner_klass = runnable.pick_runner_class()
         runner = runner_klass(runnable)
         results = [status for status in runner.run()]
-        output1 = (b'============================================================='
-                   b'=========\nERROR: error')
-        output2 = b'\n\nFAILED (errors=1)\n'
-        output = results[-2]
+        output = ("Invalid URI: could not be converted to an unittest "
+                  "dotted name.")
         result = results[-1]
         self.assertEqual(result['status'], 'finished')
         self.assertEqual(result['result'], 'error')
-        self.assertTrue(output['log'].startswith(output1))
-        self.assertTrue(output['log'].endswith(output2))
+        self.assertEqual(result['output'], output)
 
     def test_runner_python_unittest_empty_uri_error(self):
         runnable = nrunner.Runnable('python-unittest', '')
         runner_klass = runnable.pick_runner_class()
         runner = runner_klass(runnable)
         results = [status for status in runner.run()]
-        output = 'uri is required but was not given'
+        output = ("Invalid URI: could not be converted to an unittest "
+                  "dotted name.")
         result = results[-1]
         self.assertEqual(result['status'], 'finished')
         self.assertEqual(result['result'], 'error')


### PR DESCRIPTION
Currently loader.loadTestsFromName() will only find tests that are part of
sys.path. We are adding current directory (.) to that path, assuming that test
references will always be a relative path to the current directory. With this
change we will be able to pass a absolute reference (i.e:
/tmp/foo.py:Bar.test_foo) and the nrunner will add the basedir to the sys.path
correctly. Fixes #4840

#### Changes from v1:

- s/unittestname/unitttest name/;
- Fixed commit message;
- Removed `if not uri` check;
- Fixed error msg string when invalid uri;
- Reduced the number of calls on property `unittest()`;
- Refactoring on complex property return line;
- Squashed the last commit;

Signed-off-by: Beraldo Leal <bleal@redhat.com>