### PR TITLE
nrunner: bind tasks to their rightful jobs

### DIFF
--- a/avocado/core/messages.py
+++ b/avocado/core/messages.py
@@ -15,6 +15,7 @@
 import os
 import time
 
+from .nrunner import TASK_DEFAULT_CATEGORY
 from .test_id import TestID
 
 
@@ -107,7 +108,7 @@ class StartMessageHandler(BaseMessageHandler):
                     'time_start': message['time'],
                     'actual_time_start': time.time(),
                     'name': task_id}
-        if task.category == 'test':
+        if task.category == TASK_DEFAULT_CATEGORY:
             job.result.start_test(metadata)
             job.result_events_dispatcher.map_method('start_test', job.result,
                                                     metadata)

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -789,9 +789,9 @@ class Task:
 
     def __repr__(self):
         fmt = ('<Task identifier="{}" runnable="{}" dependencies="{}"'
-               ' status_services="{}">')
+               ' status_services="{}" category="{}">')
         return fmt.format(self.identifier, self.runnable, self.dependencies,
-                          self.status_services)
+                          self.status_services, self.category)
 
     def are_requirements_available(self, runners_registry=None):
         """Verifies if requirements needed to run this task are available.

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -42,6 +42,10 @@ RUNNERS_REGISTRY_STANDALONE_EXECUTABLE = {}
 #: SpawnMethod.PYTHON_CLASS
 RUNNERS_REGISTRY_PYTHON_CLASS = {}
 
+#: The default category for tasks, and the value that will cause the
+#: task results to be included in the job results
+TASK_DEFAULT_CATEGORY = 'test'
+
 
 def check_runnables_runner_requirements(runnables, runners_registry=None):
     """
@@ -747,7 +751,7 @@ class Task:
     """
 
     def __init__(self, runnable, identifier=None, status_uris=None,
-                 known_runners=None, category='test'):
+                 known_runners=None, category=TASK_DEFAULT_CATEGORY):
         """Instantiates a new Task.
 
         :param runnable: the "description" of what the task should run.
@@ -764,7 +768,8 @@ class Task:
         :type status_uri: list
         :param known_runners: a mapping of runnable kinds to runners.
         :type known_runners: dict
-        :param category: category of this task. Defaults to 'test'.
+        :param category: category of this task. Defaults to
+                         :data:`TASK_DEFAULT_CATEGORY`.
         :type category: str
         """
         self.runnable = runnable

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -834,7 +834,9 @@ class Task:
                             *runnable_recipe.get('args', ()),
                             config=runnable_recipe.get('config'))
         status_uris = recipe.get('status_uris')
-        return cls(runnable, identifier, status_uris, known_runners)
+        category = recipe.get('category')
+        return cls(runnable, identifier, status_uris, known_runners,
+                   category)
 
     def get_command_args(self):
         """

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -789,7 +789,7 @@ class Task:
 
     def __repr__(self):
         fmt = ('<Task identifier="{}" runnable="{}" dependencies="{}"'
-               ' status_services="{}"')
+               ' status_services="{}">')
         return fmt.format(self.identifier, self.runnable, self.dependencies,
                           self.status_services)
 

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -927,6 +927,11 @@ class BaseRunnerApp:
     CMD_TASK_RUN_ARGS = (
         (('-i', '--identifier'),
          {'type': str, 'required': True, 'help': 'Task unique identifier'}),
+        (('-t', '--category'),
+         {'type': str, 'required': False, 'default': TASK_DEFAULT_CATEGORY,
+          'help': ('The category for tasks.  If set to "%s" (the default), '
+                   'the results of this task will be included in the '
+                   'results of the job' % TASK_DEFAULT_CATEGORY)}),
         (('-s', '--status-uri'),
          {'action': 'append', 'default': None,
           'help': 'URIs of status services to report to'}),
@@ -1079,7 +1084,8 @@ class BaseRunnerApp:
         runnable = Runnable.from_args(args)
         task = Task(runnable, args.get('identifier'),
                     args.get('status_uri', []),
-                    known_runners=self.RUNNABLE_KINDS_CAPABLE)
+                    known_runners=self.RUNNABLE_KINDS_CAPABLE,
+                    category=args.get('category', TASK_DEFAULT_CATEGORY))
         for status in task.run():
             self.echo(status)
 

--- a/avocado/core/status/repo.py
+++ b/avocado/core/status/repo.py
@@ -12,7 +12,14 @@ class StatusMsgMissingDataError(Exception):
 class StatusRepo:
     """Maintains tasks' status related data and provides aggregated info."""
 
-    def __init__(self):
+    def __init__(self, job_id):
+        """Initializes a new StatusRepo
+
+        :param job_id: the job unique identification for which the
+                       messages are destined to.
+        :type job_id: str
+        """
+        self.job_id = job_id
         #: Contains all received messages by a given task (by its ID)
         self._all_data = {}
         #: Contains the most up to date status of a task, and the time
@@ -96,8 +103,13 @@ class StatusRepo:
                 self._status[task_id] = (status, time)
 
     def process_message(self, message):
-        if 'id' not in message:
-            raise StatusMsgMissingDataError('id')
+        for required_field in ('id', 'job_id'):
+            if required_field not in message:
+                raise StatusMsgMissingDataError(required_field)
+
+        job_id = message.pop('job_id')
+        if job_id != self.job_id:
+            LOG.warning('Message received destined for job "%s"', job_id)
 
         self._update_status(message)
         handlers = {'started': self._handle_task_started,

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -265,7 +265,7 @@ class Runner(RunnerInterface):
 
     def _start_status_server(self, status_server_listen, job_id):
         # pylint: disable=W0201
-        self.status_repo = StatusRepo()
+        self.status_repo = StatusRepo(job_id)
         # pylint: disable=W0201
         self.status_server = StatusServer(status_server_listen,
                                           self.status_repo)

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -173,7 +173,7 @@ from avocado.utils.network.ports import find_free_port
 
 class RunnerNRunnerWithFixedTasks(runner_nrunner.Runner):
     @staticmethod
-    def _get_all_runtime_tasks(test_suite):
+    def _get_all_runtime_tasks(test_suite, job_id):
         runtime_tasks = []
         no_digits = len(str(len(test_suite)))
         status_uris = [test_suite.config.get('nrunner.status_server_uri')]
@@ -183,12 +183,14 @@ class RunnerNRunnerWithFixedTasks(runner_nrunner.Runner):
             if '/bin/true' in runnable.uri:
                 task = nrunner.Task(
                     runnable, test_id, status_uris,
-                    nrunner.RUNNERS_REGISTRY_PYTHON_CLASS)
+                    nrunner.RUNNERS_REGISTRY_PYTHON_CLASS,
+                    job_id=job_id)
             else:
                 task = nrunner.Task(
                     runnable, test_id, status_uris,
                     nrunner.RUNNERS_REGISTRY_PYTHON_CLASS,
-                    'non-test')
+                    'non-test',
+                    job_id=job_id)
             runtime_tasks.append(RuntimeTask(task))
         return runtime_tasks
 

--- a/selftests/unit/test_status_repo.py
+++ b/selftests/unit/test_status_repo.py
@@ -6,7 +6,8 @@ from avocado.core.status import repo, utils
 class StatusRepo(TestCase):
 
     def setUp(self):
-        self.status_repo = repo.StatusRepo()
+        job_id = '0000000000000000000000000000000000000000'
+        self.status_repo = repo.StatusRepo(job_id)
 
     def test_process_raw_message_invalid(self):
         with self.assertRaises(utils.StatusMsgInvalidJSONError):
@@ -14,7 +15,14 @@ class StatusRepo(TestCase):
 
     def test_process_raw_message_no_id(self):
         msg = ('{"status": "finished", "time": 1597774000.5140226, '
-               '"returncode": 0}')
+               '"returncode": 0, '
+               '"job_id": "0000000000000000000000000000000000000000"}')
+        with self.assertRaises(repo.StatusMsgMissingDataError):
+            self.status_repo.process_raw_message(msg)
+
+    def test_process_raw_message_no_job_id(self):
+        msg = ('{"status": "finished", "time": 1597774000.5140226, '
+               '"returncode": 0, "id": "1-foo"}')
         with self.assertRaises(repo.StatusMsgMissingDataError):
             self.status_repo.process_raw_message(msg)
 
@@ -49,38 +57,46 @@ class StatusRepo(TestCase):
         self.assertEqual(self.status_repo._by_result.get("pass"), ["1-foo"])
 
     def test_process_message_running(self):
-        msg = {"id": "1-foo", "status": "running"}
+        msg = {"id": "1-foo", "status": "running",
+               "job_id": "0000000000000000000000000000000000000000"}
         self.status_repo.process_message(msg)
         self.assertEqual(self.status_repo.get_all_task_data("1-foo"),
                          [{"status": "running"}])
 
     def test_process_raw_message_task_started(self):
-        msg = '{"id": "1-foo", "status": "started", "output_dir": "/fake/path"}'
+        msg = ('{"id": "1-foo", "status": "started", '
+               '"output_dir": "/fake/path", '
+               '"job_id": "0000000000000000000000000000000000000000"}')
         self.status_repo.process_raw_message(msg)
         self.assertEqual(self.status_repo.get_all_task_data("1-foo"),
                          [{"status": "started", "output_dir": "/fake/path"}])
 
     def test_process_raw_message_task_running(self):
-        msg = '{"id": "1-foo", "status": "running"}'
+        msg = ('{"id": "1-foo", "status": "running", '
+               '"job_id": "0000000000000000000000000000000000000000"}')
         self.status_repo.process_raw_message(msg)
         self.assertEqual(self.status_repo.get_all_task_data("1-foo"),
                          [{"status": "running"}])
 
     def test_process_messages_running(self):
-        msg = {"id": "1-foo", "status": "running", "time": 1597894378.6080744}
+        msg = {"id": "1-foo", "status": "running", "time": 1597894378.6080744,
+               "job_id": "0000000000000000000000000000000000000000"}
         self.status_repo.process_message(msg)
-        msg = {"id": "1-foo", "status": "running", "time": 1597894378.6103745}
+        msg = {"id": "1-foo", "status": "running", "time": 1597894378.6103745,
+               "job_id": "0000000000000000000000000000000000000000"}
         self.status_repo.process_message(msg)
         self.assertEqual(self.status_repo.get_latest_task_data("1-foo"),
                          {"status": "running", "time": 1597894378.6103745})
 
     def test_task_status_time(self):
-        msg = {"id": "1-foo", "status": "running", "time": 1597894378.0000002}
+        msg = {"id": "1-foo", "status": "running", "time": 1597894378.0000002,
+               "job_id": "0000000000000000000000000000000000000000"}
         self.status_repo.process_message(msg)
         self.assertEqual(self.status_repo._status["1-foo"],
                          ("running", 1597894378.0000002))
         msg = {"id": "1-foo", "status": "started", "time": 1597894378.0000001,
-               "output_dir": "/fake/path"}
+               "output_dir": "/fake/path",
+               "job_id": "0000000000000000000000000000000000000000"}
         self.status_repo.process_message(msg)
         self.assertEqual(self.status_repo._status["1-foo"],
                          ("running", 1597894378.0000002))
@@ -89,24 +105,30 @@ class StatusRepo(TestCase):
         self.assertIsNone(self.status_repo.get_task_status("1-no-existing-id"))
 
     def test_get_task_status(self):
-        msg = {"id": "1-foo", "status": "running", "time": 1597894378.0000002}
+        msg = {"id": "1-foo", "status": "running", "time": 1597894378.0000002,
+               "job_id": "0000000000000000000000000000000000000000"}
         self.status_repo.process_message(msg)
         self.assertEqual(self.status_repo.get_task_status("1-foo"), "running")
         msg = {"id": "1-foo", "status": "started", "time": 1597894378.0000001,
-               "output_dir": "/fake/path"}
+               "output_dir": "/fake/path",
+               "job_id": "0000000000000000000000000000000000000000"}
         self.status_repo.process_message(msg)
         self.assertEqual(self.status_repo.get_task_status("1-foo"), "running")
 
     def test_get_task_status_journal_summary(self):
-        msg = {"id": "1-foo", "status": "running", "time": 1000000003.0}
+        msg = {"id": "1-foo", "status": "running", "time": 1000000003.0,
+               "job_id": "0000000000000000000000000000000000000000"}
         self.status_repo.process_message(msg)
-        msg = {"id": "1-foo", "status": "running", "time": 1000000002.0}
+        msg = {"id": "1-foo", "status": "running", "time": 1000000002.0,
+               "job_id": "0000000000000000000000000000000000000000"}
         self.status_repo.process_message(msg)
         msg = {"id": "1-foo", "status": "started", "time": 1000000001.0,
-               "output_dir": "/fake/path"}
+               "output_dir": "/fake/path",
+               "job_id": "0000000000000000000000000000000000000000"}
         self.status_repo.process_message(msg)
         msg = {"id": "1-foo", "status": "finished", "time": 1000000004.0,
-               "result": "pass"}
+               "result": "pass",
+               "job_id": "0000000000000000000000000000000000000000"}
         self.status_repo.process_message(msg)
         self.assertEqual(self.status_repo.get_task_status("1-foo"), "finished")
         self.assertEqual(self.status_repo.status_journal_summary.pop(),


### PR DESCRIPTION
This extends the nrunner Task, so that it can be set and report its rightful job.  This will help to identify erroneous situations where jobs receive information from other jobs tasks.

This can help, for instance, when a job runs another job as a test, or when some other bad actor tries to inject such data.

This is related to https://github.com/avocado-framework/avocado/issues/4308