### PR TITLE
CI: deployment of Avocado via different methods [v2]

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -1,0 +1,34 @@
+name: Ansible deployment test
+
+on:
+  schedule:
+    - cron: "0 5 * * 1"
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+
+  podman:
+    name: Ansible (${{matrix.extra}})
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:34
+    env:
+      RUN_BEFORE: 'dnf install -y git ansible'
+      GIT_URL: 'git://github.com/${{github.repository}}'
+      INVENTORY: 'selftests/deployment/inventory'
+      PLAYBOOK: 'selftests/deployment/deployment.yml'
+    strategy:
+      matrix:
+        extra: ["method=pip", "method=copr", "method=official", "method=pip avocado_vt=true", "method=copr avocado_vt=true", "method=official avocado_vt=true"]
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: 'master'
+          fetch-depth: 0
+      - name: Install Ansible
+        run: dnf install -y git ansible
+      - name: Run Ansible playbook
+        run:  ansible-pull -v -U ${{env.GIT_URL}} -i ${{env.INVENTORY}} -c local ${{env.PLAYBOOK}} -e "${{matrix.extra}}"

--- a/selftests/deployment/roles/avocado/tasks/pip/plugins.yml
+++ b/selftests/deployment/roles/avocado/tasks/pip/plugins.yml
@@ -29,19 +29,9 @@
     name: "git+{{ avocado_git_url}}@{{ avocado_git_branch }}#egg=avocado-framework-plugin-varianter-pict&subdirectory=optional_plugins/varianter_pict"
     virtualenv: "{{ temporary_dir.path }}"
 
-- name: Avocado glib loader plugin installation via pip
-  pip:
-    name: "git+{{ avocado_git_url}}@{{ avocado_git_branch }}#egg=avocado-framework-plugin-glib&subdirectory=optional_plugins/glib"
-    virtualenv: "{{ temporary_dir.path }}"
-
 - name: Avocado golang loader plugin installation via pip
   pip:
     name: "git+{{ avocado_git_url}}@{{ avocado_git_branch }}#egg=avocado-framework-plugin-golang&subdirectory=optional_plugins/golang"
-    virtualenv: "{{ temporary_dir.path }}"
-
-- name: Avocado YAML loader plugin installation via pip
-  pip:
-    name: "git+{{ avocado_git_url}}@{{ avocado_git_branch }}#egg=avocado-framework-plugin-loader-yaml&subdirectory=optional_plugins/loader_yaml"
     virtualenv: "{{ temporary_dir.path }}"
 
 # This is a workaround until we fix avocado-vt/issues/2193

--- a/selftests/deployment/roles/avocado/tasks/pip/plugins.yml
+++ b/selftests/deployment/roles/avocado/tasks/pip/plugins.yml
@@ -34,12 +34,9 @@
     name: "git+{{ avocado_git_url}}@{{ avocado_git_branch }}#egg=avocado-framework-plugin-golang&subdirectory=optional_plugins/golang"
     virtualenv: "{{ temporary_dir.path }}"
 
-# This is a workaround until we fix avocado-vt/issues/2193
-- name: Avocado VT plugin installation via RPM
-  package:
-    name: python3-avocado-plugins-vt
-    state: latest
+- name: Avocado VT plugin installation via pip
+  pip:
+    name: "git+{{ avocado_vt_git_url}}@{{ avocado_vt_git_branch }}"
+    virtualenv: "{{ temporary_dir.path }}"
   when:
-    - ansible_facts['distribution_file_variety'] == "RedHat"
-    - ansible_facts['distribution'] != "Fedora"
     - avocado_vt|default(false)|bool == true

--- a/selftests/deployment/roles/avocado/tasks/rpm/examples.yml
+++ b/selftests/deployment/roles/avocado/tasks/rpm/examples.yml
@@ -4,3 +4,13 @@
     name:
       - python3-avocado-examples
     state: latest
+  when:
+    - method == 'copr'
+
+- name: Install Avocado examples using RPM
+  dnf:
+    name:
+      - python-avocado-examples
+    state: latest
+  when:
+    - method == 'official'

--- a/selftests/deployment/roles/common/tasks/dependencies.yml
+++ b/selftests/deployment/roles/common/tasks/dependencies.yml
@@ -15,6 +15,8 @@
      - git
      - gcc
      - nc
+     - python3-devel
+     - python3-pillow
      - python3-netaddr
      - python3-netifaces
      - qemu-img

--- a/selftests/deployment/roles/common/tasks/repos.yml
+++ b/selftests/deployment/roles/common/tasks/repos.yml
@@ -1,4 +1,4 @@
-# Official + Copr Modules disable
+# Copr Modules disable
 - name: Disable Fedora module to avoid conflict
   ini_file:
     path: /etc/yum.repos.d/fedora-modular.repo
@@ -6,7 +6,7 @@
     option: enabled
     value: '0'
   when:
-    - method == 'official' or method == 'copr'
+    - method == 'copr'
     - ansible_facts['distribution'] == "Fedora"
 
 - name: Disable Fedora module updates to avoid conflict
@@ -16,32 +16,23 @@
     option: enabled
     value: '0'
   when:
-    - method == 'official' or method == 'copr'
+    - method == 'copr'
     - ansible_facts['distribution'] == "Fedora"
 
-# Official repos
-- name: Install Avocado EPEL Official Releases repo
-  yum_repository:
-    name: avocado
-    description: Avocado EPEL Official Releases repo
-    baseurl: https://avocado-project.org/data/repos/epel-$releasever-noarch/
-    gpgcheck: yes
-    gpgkey: https://avocado-project.org/data/repos/crosa_redhat_com.gpg
+# Official repos (avocado)
+- name: enable avocado module
+  shell:
+    cmd: dnf module -y enable avocado:latest
   when:
     - method == 'official'
-    - ansible_facts['distribution_file_variety'] == "RedHat"
-    - ansible_facts['distribution_major_version'] == "7"
 
-- name: Install Avocado Fedora Official Releases repo
-  yum_repository:
-    name: avocado
-    description: Avocado Fedora Official Releases repo
-    baseurl: https://avocado-project.org/data/repos/fedora-$releasever-noarch/
-    gpgcheck: yes
-    gpgkey: https://avocado-project.org/data/repos/crosa_redhat_com.gpg
+# Official repos (avocado-vt)
+- name: enable avocado-vt module
+  shell:
+    cmd: dnf module -y enable avocado-vt:latest
   when:
     - method == 'official'
-    - ansible_facts['distribution'] == "Fedora"
+    - avocado_vt|default(false)|bool == true
 
 # Copr repos (Avocado)
 - name: Avocado EPEL Copr repo
@@ -70,13 +61,12 @@
   yum_repository:
     name: avocado-vt-latest
     description: Copr repo for avocado-vt-latest
-    baseurl: https://copr-be.cloud.fedoraproject.org/results/@avocado/avocado-vt-latest/epel-7-$basearch/
+    baseurl: https://copr-be.cloud.fedoraproject.org/results/@avocado/avocado-vt-latest/epel-$releasever-$basearch/
     gpgcheck: no
   when:
     - method == 'copr'
     - ansible_facts['distribution_file_variety'] == "RedHat"
     - ansible_facts['distribution'] != "Fedora"
-    - ansible_facts['distribution_major_version'] == "7"
     - avocado_vt|default(false)|bool == true
 
 - name: Avocado-VT Fedora Copr repo

--- a/selftests/deployment/roles/tests/tasks/main.yml
+++ b/selftests/deployment/roles/tests/tasks/main.yml
@@ -15,7 +15,7 @@
     - avocado_vt|default(false)|bool == true
 
 - name: Avocado-VT test 3/5 - dry-run execution
-  shell: avocado run --dry-run -- boot
+  shell: "{{ temporary_dir.path | default('/usr') }}/bin/avocado run --dry-run -- boot"
   changed_when: false
   when:
     - ansible_facts['distribution_file_variety'] == "RedHat"


### PR DESCRIPTION
This is a v2 of https://github.com/avocado-framework/avocado/pull/4849
Changes:
* enabled all the methods with avocado_vt, so the 6 combinations are run now
* improve the pipeline to use directly the container support provided by GitHub Actions
* Update the list of repositories used, notably for the official method.
* Some minor changes following discussion in the v1

The current pipeline can be browsed at https://github.com/ana/avocado2/runs/3363033419

The job `Ansible (method=official avocado_vt=true)` doesn't work because the packages of avocado-vt haven't been updated yet. I added the missing releases at https://copr.fedorainfracloud.org/coprs/g/avocado/avocado-vt-latest/ and right now it works when `method=copr`, but I don't know if it'll update eventually the module avocado-vt or there is something else to do.
