### PR TITLE
core.tapparser: non tap messages should be ignored

### DIFF
--- a/avocado/core/tapparser.py
+++ b/avocado/core/tapparser.py
@@ -153,8 +153,6 @@ class TapParser:
             if line == '':
                 continue
 
-            yield self.Error('unexpected input at line %d' % (lineno,))
-
         if state == self._YAML:
             yield self.Error('YAML block not terminated (started on line %d)' % (yaml_lineno,))
 

--- a/selftests/unit/test_tap.py
+++ b/selftests/unit/test_tap.py
@@ -259,7 +259,6 @@ class TapParserTests(unittest.TestCase):
     def test_unexpected(self):
         events = self.parse_tap('1..1\ninvalid\nok 1')
         self.assert_plan(events, count=1, late=False)
-        self.assert_error(events)
         self.assert_test(events, number=1, name='', result=TestResult.PASS)
         self.assert_last(events)
 


### PR DESCRIPTION
From the the specs:

"A harness must only read TAP output from standard output and not from standard
error. Lines written to standard output matching /^(not )?ok\b/ must be
interpreted as test lines. All other lines must not be considered test output."

Signed-off-by: Beraldo Leal <bleal@redhat.com>