### PR TITLE
[utils] distro.py: detect distro with Host rather than Session

### DIFF
--- a/avocado/utils/network/common.py
+++ b/avocado/utils/network/common.py
@@ -10,3 +10,9 @@ def run_command(command, host, sudo=False):
     if sudo:
         command = "sudo {}".format(command)
     return host.remote_session.cmd(command).stdout.decode('utf-8')
+
+def command_exit_status(command, host):
+    if host.__class__.__name__ == 'LocalHost':
+        return process.system(command)
+    else:
+        return host.remote_session.cmd(command).stdout_text.exit_status


### PR DESCRIPTION
Instead of optionally passing in a Session object and checking if it is present
at occasionally, distro.py uses avocado.utils.network.hosts.Host to run
commands.

Signed-off-by: Cris Forno <fornosoccer12@gmail.com>