### PR TITLE
nrunner: bind tasks to their rightful jobs [v2]

### DIFF
--- a/avocado/core/messages.py
+++ b/avocado/core/messages.py
@@ -15,6 +15,7 @@
 import os
 import time
 
+from .nrunner import TASK_DEFAULT_CATEGORY
 from .test_id import TestID
 
 
@@ -107,7 +108,7 @@ class StartMessageHandler(BaseMessageHandler):
                     'time_start': message['time'],
                     'actual_time_start': time.time(),
                     'name': task_id}
-        if task.category == 'test':
+        if task.category == TASK_DEFAULT_CATEGORY:
             job.result.start_test(metadata)
             job.result_events_dispatcher.map_method('start_test', job.result,
                                                     metadata)

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -42,6 +42,10 @@ RUNNERS_REGISTRY_STANDALONE_EXECUTABLE = {}
 #: SpawnMethod.PYTHON_CLASS
 RUNNERS_REGISTRY_PYTHON_CLASS = {}
 
+#: The default category for tasks, and the value that will cause the
+#: task results to be included in the job results
+TASK_DEFAULT_CATEGORY = 'test'
+
 
 def check_runnables_runner_requirements(runnables, runners_registry=None):
     """
@@ -796,7 +800,7 @@ class Task:
     """
 
     def __init__(self, runnable, identifier=None, status_uris=None,
-                 known_runners=None, category='test'):
+                 known_runners=None, category=TASK_DEFAULT_CATEGORY):
         """Instantiates a new Task.
 
         :param runnable: the "description" of what the task should run.
@@ -813,7 +817,8 @@ class Task:
         :type status_uri: list
         :param known_runners: a mapping of runnable kinds to runners.
         :type known_runners: dict
-        :param category: category of this task. Defaults to 'test'.
+        :param category: category of this task. Defaults to
+                         :data:`TASK_DEFAULT_CATEGORY`.
         :type category: str
         """
         self.runnable = runnable

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -838,7 +838,7 @@ class Task:
 
     def __repr__(self):
         fmt = ('<Task identifier="{}" runnable="{}" dependencies="{}"'
-               ' status_services="{}"')
+               ' status_services="{}">')
         return fmt.format(self.identifier, self.runnable, self.dependencies,
                           self.status_services)
 

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -976,6 +976,14 @@ class BaseRunnerApp:
     CMD_TASK_RUN_ARGS = (
         (('-i', '--identifier'),
          {'type': str, 'required': True, 'help': 'Task unique identifier'}),
+        (('-t', '--category'),
+         {'type': str, 'required': False, 'default': TASK_DEFAULT_CATEGORY,
+          'help': ('The category for tasks. Only tasks with category set '
+                   'to "%s" (the default) will be included in the '
+                   'test results of its parent job. Other categories '
+                   'may be used for purposes that do include test results '
+                   'such as requirements resolution tasks'
+                   % TASK_DEFAULT_CATEGORY)}),
         (('-s', '--status-uri'),
          {'action': 'append', 'default': None,
           'help': 'URIs of status services to report to'}),
@@ -1128,7 +1136,8 @@ class BaseRunnerApp:
         runnable = Runnable.from_args(args)
         task = Task(runnable, args.get('identifier'),
                     args.get('status_uri', []),
-                    known_runners=self.RUNNABLE_KINDS_CAPABLE)
+                    known_runners=self.RUNNABLE_KINDS_CAPABLE,
+                    category=args.get('category', TASK_DEFAULT_CATEGORY))
         for status in task.run():
             self.echo(status)
 

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -838,9 +838,9 @@ class Task:
 
     def __repr__(self):
         fmt = ('<Task identifier="{}" runnable="{}" dependencies="{}"'
-               ' status_services="{}">')
+               ' status_services="{}" category="{}">')
         return fmt.format(self.identifier, self.runnable, self.dependencies,
-                          self.status_services)
+                          self.status_services, self.category)
 
     def are_requirements_available(self, runners_registry=None):
         """Verifies if requirements needed to run this task are available.

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -800,7 +800,8 @@ class Task:
     """
 
     def __init__(self, runnable, identifier=None, status_uris=None,
-                 known_runners=None, category=TASK_DEFAULT_CATEGORY):
+                 known_runners=None, category=TASK_DEFAULT_CATEGORY,
+                 job_id=None):
         """Instantiates a new Task.
 
         :param runnable: the "description" of what the task should run.
@@ -820,12 +821,17 @@ class Task:
         :param category: category of this task. Defaults to
                          :data:`TASK_DEFAULT_CATEGORY`.
         :type category: str
+        :param job_id: the ID of the job, for authenticating messages that get
+                       sent to the destination job's status server and will make
+                       into the job's results.
+        :type job_id: str
         """
         self.runnable = runnable
         self.identifier = identifier or str(uuid1())
         #: Category of the task.  If the category is not "test", it
         #: will not be accounted for on a Job's test results.
         self.category = category
+        self.job_id = job_id
         self.status_services = []
         status_uris = status_uris or self.runnable.config.get('nrunner.status_server_uri')
         if status_uris is not None:
@@ -843,9 +849,9 @@ class Task:
 
     def __repr__(self):
         fmt = ('<Task identifier="{}" runnable="{}" dependencies="{}"'
-               ' status_services="{}" category="{}">')
+               ' status_services="{}" category="{}" job_id="{}">')
         return fmt.format(self.identifier, self.runnable, self.dependencies,
-                          self.status_services, self.category)
+                          self.status_services, self.category, self.job_id)
 
     def are_requirements_available(self, runners_registry=None):
         """Verifies if requirements needed to run this task are available.
@@ -897,7 +903,7 @@ class Task:
         :returns: the arguments that can be used on an avocado-runner command
         :rtype: list
         """
-        args = ['-i', str(self.identifier)]
+        args = ['-i', str(self.identifier), '-j', str(self.job_id)]
         args += self.runnable.get_command_args()
 
         for status_service in self.status_services:
@@ -914,6 +920,8 @@ class Task:
             if status['status'] == 'started':
                 status.update({'output_dir': self.output_dir})
             status.update({"id": self.identifier})
+            if self.job_id is not None:
+                status.update({"job_id": self.job_id})
             for status_service in self.status_services:
                 status_service.post(status)
             yield status
@@ -989,6 +997,9 @@ class BaseRunnerApp:
         (('-s', '--status-uri'),
          {'action': 'append', 'default': None,
           'help': 'URIs of status services to report to'}),
+        (('-j', '--job-id'),
+         {'type': str, 'required': False, 'metavar': 'JOB_ID',
+          'help': 'Identifier of Job this task belongs to'}),
     )
     CMD_TASK_RUN_ARGS += CMD_RUNNABLE_RUN_ARGS
 
@@ -1139,7 +1150,8 @@ class BaseRunnerApp:
         task = Task(runnable, args.get('identifier'),
                     args.get('status_uri', []),
                     known_runners=self.RUNNABLE_KINDS_CAPABLE,
-                    category=args.get('category', TASK_DEFAULT_CATEGORY))
+                    category=args.get('category', TASK_DEFAULT_CATEGORY),
+                    job_id=args.get('job_id'))
         for status in task.run():
             self.echo(status)
 

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -883,7 +883,9 @@ class Task:
                             *runnable_recipe.get('args', ()),
                             config=runnable_recipe.get('config'))
         status_uris = recipe.get('status_uris')
-        return cls(runnable, identifier, status_uris, known_runners)
+        category = recipe.get('category')
+        return cls(runnable, identifier, status_uris, known_runners,
+                   category)
 
     def get_command_args(self):
         """

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -261,7 +261,7 @@ class Runner(RunnerInterface):
 
     def _start_status_server(self, status_server_listen, job_id):
         # pylint: disable=W0201
-        self.status_repo = StatusRepo()
+        self.status_repo = StatusRepo(job_id)
         # pylint: disable=W0201
         self.status_server = StatusServer(status_server_listen,
                                           self.status_repo)

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -155,7 +155,7 @@ class Runner(RunnerInterface):
     description = 'nrunner based implementation of job compliant runner'
 
     @staticmethod
-    def _get_requirements_runtime_tasks(runnable, prefix):
+    def _get_requirements_runtime_tasks(runnable, prefix, job_id):
         if runnable.requirements is None:
             return
 
@@ -177,7 +177,8 @@ class Runner(RunnerInterface):
             # creates the requirement task
             requirement_task = nrunner.Task(requirement_runnable,
                                             identifier=task_id,
-                                            category='requirement')
+                                            category='requirement',
+                                            job_id=job_id)
             # make sure we track the dependencies of a task
             # runtime_task.task.dependencies.add(requirement_task)
             # created the requirement runtime task
@@ -187,7 +188,7 @@ class Runner(RunnerInterface):
 
     @staticmethod
     def _create_runtime_tasks_for_test(test_suite, runnable, no_digits,
-                                       index, variant):
+                                       index, variant, job_id):
         """Creates runtime tasks for both tests, and for its requirements."""
         result = []
 
@@ -207,14 +208,16 @@ class Runner(RunnerInterface):
         # handles the test task
         task = nrunner.Task(runnable,
                             identifier=test_id,
-                            known_runners=nrunner.RUNNERS_REGISTRY_PYTHON_CLASS)
+                            known_runners=nrunner.RUNNERS_REGISTRY_PYTHON_CLASS,
+                            job_id=job_id)
         runtime_task = RuntimeTask(task)
         result.append(runtime_task)
 
         # handles the requirements
         requirements_runtime_tasks = (
             Runner._get_requirements_runtime_tasks(runnable,
-                                                   prefix))
+                                                   prefix,
+                                                   job_id))
         # extend the list of tasks with the requirements runtime tasks
         if requirements_runtime_tasks is not None:
             for requirement_runtime_task in requirements_runtime_tasks:
@@ -226,7 +229,7 @@ class Runner(RunnerInterface):
         return result
 
     @staticmethod
-    def _get_all_runtime_tasks(test_suite):
+    def _get_all_runtime_tasks(test_suite, job_id):
         runtime_tasks = []
         test_result_total = test_suite.variants.get_number_of_tests(test_suite.tests)
         no_digits = len(str(test_result_total))
@@ -252,10 +255,11 @@ class Runner(RunnerInterface):
                 runnable,
                 no_digits,
                 index,
-                variant))
+                variant,
+                job_id))
         return runtime_tasks
 
-    def _start_status_server(self, status_server_listen):
+    def _start_status_server(self, status_server_listen, job_id):
         # pylint: disable=W0201
         self.status_repo = StatusRepo()
         # pylint: disable=W0201
@@ -288,10 +292,10 @@ class Runner(RunnerInterface):
         job.result.tests_total = test_suite.variants.get_number_of_tests(test_suite.tests)
 
         listen = test_suite.config.get('nrunner.status_server_listen')
-        self._start_status_server(listen)
+        self._start_status_server(listen, job.unique_id)
 
         # pylint: disable=W0201
-        self.runtime_tasks = self._get_all_runtime_tasks(test_suite)
+        self.runtime_tasks = self._get_all_runtime_tasks(test_suite, job.unique_id)
         if test_suite.config.get('nrunner.shuffle'):
             random.shuffle(self.runtime_tasks)
         test_ids = [rt.task.identifier for rt in self.runtime_tasks

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -173,7 +173,7 @@ from avocado.utils.network.ports import find_free_port
 
 class RunnerNRunnerWithFixedTasks(runner_nrunner.Runner):
     @staticmethod
-    def _get_all_runtime_tasks(test_suite):
+    def _get_all_runtime_tasks(test_suite, job_id):
         runtime_tasks = []
         no_digits = len(str(len(test_suite)))
         status_uris = [test_suite.config.get('nrunner.status_server_uri')]
@@ -183,12 +183,14 @@ class RunnerNRunnerWithFixedTasks(runner_nrunner.Runner):
             if '/bin/true' in runnable.uri:
                 task = nrunner.Task(
                     runnable, test_id, status_uris,
-                    nrunner.RUNNERS_REGISTRY_PYTHON_CLASS)
+                    nrunner.RUNNERS_REGISTRY_PYTHON_CLASS,
+                    job_id=job_id)
             else:
                 task = nrunner.Task(
                     runnable, test_id, status_uris,
                     nrunner.RUNNERS_REGISTRY_PYTHON_CLASS,
-                    'non-test')
+                    'non-test',
+                    job_id=job_id)
             runtime_tasks.append(RuntimeTask(task))
         return runtime_tasks
 

--- a/selftests/unit/test_status_repo.py
+++ b/selftests/unit/test_status_repo.py
@@ -6,7 +6,8 @@ from avocado.core.status import repo, utils
 class StatusRepo(TestCase):
 
     def setUp(self):
-        self.status_repo = repo.StatusRepo()
+        job_id = '0000000000000000000000000000000000000000'
+        self.status_repo = repo.StatusRepo(job_id)
 
     def test_process_raw_message_invalid(self):
         with self.assertRaises(utils.StatusMsgInvalidJSONError):
@@ -14,7 +15,14 @@ class StatusRepo(TestCase):
 
     def test_process_raw_message_no_id(self):
         msg = ('{"status": "finished", "time": 1597774000.5140226, '
-               '"returncode": 0}')
+               '"returncode": 0, '
+               '"job_id": "0000000000000000000000000000000000000000"}')
+        with self.assertRaises(repo.StatusMsgMissingDataError):
+            self.status_repo.process_raw_message(msg)
+
+    def test_process_raw_message_no_job_id(self):
+        msg = ('{"status": "finished", "time": 1597774000.5140226, '
+               '"returncode": 0, "id": "1-foo"}')
         with self.assertRaises(repo.StatusMsgMissingDataError):
             self.status_repo.process_raw_message(msg)
 
@@ -49,38 +57,46 @@ class StatusRepo(TestCase):
         self.assertEqual(self.status_repo._by_result.get("pass"), ["1-foo"])
 
     def test_process_message_running(self):
-        msg = {"id": "1-foo", "status": "running"}
+        msg = {"id": "1-foo", "status": "running",
+               "job_id": "0000000000000000000000000000000000000000"}
         self.status_repo.process_message(msg)
         self.assertEqual(self.status_repo.get_all_task_data("1-foo"),
                          [{"status": "running"}])
 
     def test_process_raw_message_task_started(self):
-        msg = '{"id": "1-foo", "status": "started", "output_dir": "/fake/path"}'
+        msg = ('{"id": "1-foo", "status": "started", '
+               '"output_dir": "/fake/path", '
+               '"job_id": "0000000000000000000000000000000000000000"}')
         self.status_repo.process_raw_message(msg)
         self.assertEqual(self.status_repo.get_all_task_data("1-foo"),
                          [{"status": "started", "output_dir": "/fake/path"}])
 
     def test_process_raw_message_task_running(self):
-        msg = '{"id": "1-foo", "status": "running"}'
+        msg = ('{"id": "1-foo", "status": "running", '
+               '"job_id": "0000000000000000000000000000000000000000"}')
         self.status_repo.process_raw_message(msg)
         self.assertEqual(self.status_repo.get_all_task_data("1-foo"),
                          [{"status": "running"}])
 
     def test_process_messages_running(self):
-        msg = {"id": "1-foo", "status": "running", "time": 1597894378.6080744}
+        msg = {"id": "1-foo", "status": "running", "time": 1597894378.6080744,
+               "job_id": "0000000000000000000000000000000000000000"}
         self.status_repo.process_message(msg)
-        msg = {"id": "1-foo", "status": "running", "time": 1597894378.6103745}
+        msg = {"id": "1-foo", "status": "running", "time": 1597894378.6103745,
+               "job_id": "0000000000000000000000000000000000000000"}
         self.status_repo.process_message(msg)
         self.assertEqual(self.status_repo.get_latest_task_data("1-foo"),
                          {"status": "running", "time": 1597894378.6103745})
 
     def test_task_status_time(self):
-        msg = {"id": "1-foo", "status": "running", "time": 1597894378.0000002}
+        msg = {"id": "1-foo", "status": "running", "time": 1597894378.0000002,
+               "job_id": "0000000000000000000000000000000000000000"}
         self.status_repo.process_message(msg)
         self.assertEqual(self.status_repo._status["1-foo"],
                          ("running", 1597894378.0000002))
         msg = {"id": "1-foo", "status": "started", "time": 1597894378.0000001,
-               "output_dir": "/fake/path"}
+               "output_dir": "/fake/path",
+               "job_id": "0000000000000000000000000000000000000000"}
         self.status_repo.process_message(msg)
         self.assertEqual(self.status_repo._status["1-foo"],
                          ("running", 1597894378.0000002))
@@ -89,24 +105,30 @@ class StatusRepo(TestCase):
         self.assertIsNone(self.status_repo.get_task_status("1-no-existing-id"))
 
     def test_get_task_status(self):
-        msg = {"id": "1-foo", "status": "running", "time": 1597894378.0000002}
+        msg = {"id": "1-foo", "status": "running", "time": 1597894378.0000002,
+               "job_id": "0000000000000000000000000000000000000000"}
         self.status_repo.process_message(msg)
         self.assertEqual(self.status_repo.get_task_status("1-foo"), "running")
         msg = {"id": "1-foo", "status": "started", "time": 1597894378.0000001,
-               "output_dir": "/fake/path"}
+               "output_dir": "/fake/path",
+               "job_id": "0000000000000000000000000000000000000000"}
         self.status_repo.process_message(msg)
         self.assertEqual(self.status_repo.get_task_status("1-foo"), "running")
 
     def test_get_task_status_journal_summary(self):
-        msg = {"id": "1-foo", "status": "running", "time": 1000000003.0}
+        msg = {"id": "1-foo", "status": "running", "time": 1000000003.0,
+               "job_id": "0000000000000000000000000000000000000000"}
         self.status_repo.process_message(msg)
-        msg = {"id": "1-foo", "status": "running", "time": 1000000002.0}
+        msg = {"id": "1-foo", "status": "running", "time": 1000000002.0,
+               "job_id": "0000000000000000000000000000000000000000"}
         self.status_repo.process_message(msg)
         msg = {"id": "1-foo", "status": "started", "time": 1000000001.0,
-               "output_dir": "/fake/path"}
+               "output_dir": "/fake/path",
+               "job_id": "0000000000000000000000000000000000000000"}
         self.status_repo.process_message(msg)
         msg = {"id": "1-foo", "status": "finished", "time": 1000000004.0,
-               "result": "pass"}
+               "result": "pass",
+               "job_id": "0000000000000000000000000000000000000000"}
         self.status_repo.process_message(msg)
         self.assertEqual(self.status_repo.get_task_status("1-foo"), "finished")
         self.assertEqual(self.status_repo.status_journal_summary.pop(),


### PR DESCRIPTION
This extends the nrunner Task, so that it can be set and report its rightful job.  This will help to identify erroneous situations where jobs receive information from other jobs tasks.

This can help, for instance, when a job runs another job as a test, or when some other bad actor tries to inject such data.

This is related to https://github.com/avocado-framework/avocado/issues/4308

---

Changes from v1 (#4864):
 * Changed help message of `--category` command line option
 * `StatusRepo` won't process messages that are destined for other jobs
 * `StatusRepo` will log the complete message when destined for another job