### PR TITLE
selftests.utils: reduce length of temporary dirs

### DIFF
--- a/selftests/functional/plugin/test_assets.py
+++ b/selftests/functional/plugin/test_assets.py
@@ -54,8 +54,7 @@ class AssetsFetchSuccess(TestCaseTmpDir):
         Setup configuration file and folders
         """
         warnings.simplefilter("ignore", ResourceWarning)
-        self.base_dir, self.mapping, self.config_file = get_temporary_config(
-            __name__, self, 'setUp')
+        self.base_dir, self.mapping, self.config_file = get_temporary_config(self)
         asset_dir = os.path.join(self.mapping['cache_dir'], 'by_location',
                                  'a784600d3e01b346e8813bbd065d00048be8a482')
         os.makedirs(asset_dir)
@@ -205,8 +204,7 @@ class AssetsPlugin(unittest.TestCase):
         Setup configuration file and folders
         """
         warnings.simplefilter("ignore", ResourceWarning)
-        self.base_dir, self.mapping, self.config_file = get_temporary_config(
-            __name__, self, 'setUp')
+        self.base_dir, self.mapping, self.config_file = get_temporary_config(self)
 
     def test_asset_fetch(self):
         """

--- a/selftests/functional/plugin/test_vmimage.py
+++ b/selftests/functional/plugin/test_vmimage.py
@@ -28,8 +28,7 @@ class VMImagePlugin(unittest.TestCase):
     @unittest.skipUnless(os.environ.get('AVOCADO_SELFTESTS_NETWORK_ENABLED', False),
                          "Network required to run these tests")
     def setUp(self):
-        (self.base_dir, self.mapping, self.config_file) = get_temporary_config(
-            __name__, self, 'setUp')
+        (self.base_dir, self.mapping, self.config_file) = get_temporary_config(self)
 
     @unittest.skipIf(missing_binary('qemu-img'),
                      "QEMU disk image utility is required by the vmimage utility ")

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -235,8 +235,7 @@ class RunnerOperationTest(TestCaseTmpDir):
                          "Avocado did not return rc %d:\n%s" % (expected_rc, result))
 
     def test_runner_test_with_local_imports(self):
-        prefix = temp_dir_prefix(__name__, self,
-                                 'test_runner_test_with_local_imports')
+        prefix = temp_dir_prefix(self)
         with tempfile.TemporaryDirectory(prefix=prefix) as libdir:
             with script.Script(os.path.join(libdir, 'mylib.py'),
                                "def hello():\n    return 'Hello world'"):

--- a/selftests/functional/test_fetch_asset.py
+++ b/selftests/functional/test_fetch_asset.py
@@ -31,8 +31,7 @@ class FetchAsset(unittest.TestCase):
         Setup configuration file and folders
         """
         warnings.simplefilter("ignore", ResourceWarning)
-        self.base_dir, self.mapping, self.config_file = get_temporary_config(
-            __name__, self, 'setUp')
+        self.base_dir, self.mapping, self.config_file = get_temporary_config(self)
 
         self.asset_dir = os.path.join(self.mapping['cache_dir'],
                                       'by_location',

--- a/selftests/functional/test_task_timeout.py
+++ b/selftests/functional/test_task_timeout.py
@@ -1,10 +1,7 @@
-import tempfile
-
 from avocado.core.job import Job
 from avocado.utils import script
 from avocado.utils.network.ports import find_free_port
-from selftests.utils import (TestCaseTmpDir, skipUnlessPathExists,
-                             temp_dir_prefix)
+from selftests.utils import TestCaseTmpDir, skipUnlessPathExists
 
 SCRIPT_CONTENT = """#!/bin/bash
 /bin/sleep 30
@@ -20,9 +17,6 @@ class TaskTimeOutTest(TestCaseTmpDir):
             SCRIPT_CONTENT,
             'avocado_timeout_functional')
         self.script.save()
-
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
 
     @skipUnlessPathExists('/bin/sleep')
     def test_sleep_longer_timeout(self):

--- a/selftests/unit/plugin/test_legacy_replay.py
+++ b/selftests/unit/plugin/test_legacy_replay.py
@@ -1,26 +1,18 @@
 import os
-import tempfile
 import unittest
 
 from avocado.core import test
 from avocado.plugins.legacy import replay as replay_legacy
-from selftests.utils import setup_avocado_loggers, temp_dir_prefix
+from selftests.utils import TestCaseTmpDir, setup_avocado_loggers
 
 setup_avocado_loggers()
 
 
-class Replay(unittest.TestCase):
+class Replay(TestCaseTmpDir):
 
     """
     avocado.plugins.Replay unittests
     """
-
-    def setUp(self):
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
-        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
-
-    def tearDown(self):
-        self.tmpdir.cleanup()
 
     def test_replay_map_interrupted_json(self):
         """

--- a/selftests/unit/plugin/test_vmimage.py
+++ b/selftests/unit/plugin/test_vmimage.py
@@ -71,7 +71,7 @@ class VMImagePlugin(unittest.TestCase):
         And returns a dictionary containing the temporary data dir paths and
         the path to a configuration file contain those same settings
         """
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        prefix = temp_dir_prefix(self)
         base_dir = tempfile.TemporaryDirectory(prefix=prefix)
         data_directory = os.path.join(base_dir.name, 'data')
         cache_directory = os.path.join(data_directory, 'cache')

--- a/selftests/unit/plugin/test_xunit.py
+++ b/selftests/unit/plugin/test_xunit.py
@@ -37,7 +37,7 @@ class xUnitSucceedTest(unittest.TestCase):
                 pass
 
         self.tmpfile = tempfile.mkstemp()
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        prefix = temp_dir_prefix(self)
         self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
         config = {'job.run.result.xunit.output': self.tmpfile[1],
                   'run.results_dir': self.tmpdir.name,

--- a/selftests/unit/test_datadir.py
+++ b/selftests/unit/test_datadir.py
@@ -15,7 +15,7 @@ class Base(unittest.TestCase):
         And returns a dictionary containing the temporary data dir paths and
         a the path to a configuration file contain those same settings
         """
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        prefix = temp_dir_prefix(self)
         base_dir = tempfile.TemporaryDirectory(prefix=prefix)
         test_dir = os.path.join(base_dir.name, 'tests')
         os.mkdir(test_dir)

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -17,7 +17,7 @@ class JobTest(unittest.TestCase):
     def setUp(self):
         self.job = None
         data_dir._tmp_tracker.unittest_refresh_dir_tracker()
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        prefix = temp_dir_prefix(self)
         self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
 
     @staticmethod

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -166,7 +166,7 @@ class LoaderTest(unittest.TestCase):
 
     def setUp(self):
         self.loader = loader.FileLoader(None, {})
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        prefix = temp_dir_prefix(self)
         self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
 
     def test_load_simple(self):

--- a/selftests/unit/test_nrunner.py
+++ b/selftests/unit/test_nrunner.py
@@ -152,7 +152,7 @@ class RunnableFromCommandLineArgs(unittest.TestCase):
 class RunnableToRecipe(unittest.TestCase):
 
     def setUp(self):
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        prefix = temp_dir_prefix(self)
         self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
 
     def test_runnable_to_recipe_noop(self):
@@ -278,7 +278,7 @@ class Runner(unittest.TestCase):
 class RunnerTmp(unittest.TestCase):
 
     def setUp(self):
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        prefix = temp_dir_prefix(self)
         self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
 
     @skipUnlessPathExists('/bin/sh')

--- a/selftests/unit/test_suite.py
+++ b/selftests/unit/test_suite.py
@@ -14,7 +14,7 @@ class TestSuiteTest(unittest.TestCase):
     def setUp(self):
         self.suite = None
         data_dir._tmp_tracker.unittest_refresh_dir_tracker()
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        prefix = temp_dir_prefix(self)
         self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
 
     @staticmethod

--- a/selftests/unit/test_sysinfo.py
+++ b/selftests/unit/test_sysinfo.py
@@ -9,7 +9,7 @@ from selftests.utils import temp_dir_prefix
 class SysinfoTest(unittest.TestCase):
 
     def setUp(self):
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        prefix = temp_dir_prefix(self)
         self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
 
     def test_loggables_equal(self):

--- a/selftests/unit/test_test.py
+++ b/selftests/unit/test_test.py
@@ -29,7 +29,7 @@ class TestClassTestUnit(unittest.TestCase):
             self.skipTest('dummy skip test')
 
     def setUp(self):
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        prefix = temp_dir_prefix(self)
         self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
 
     def _get_fake_filename_test(self, name):
@@ -177,7 +177,7 @@ class TestClassTest(unittest.TestCase):
                 self.assertTrue(variable)
                 self.whiteboard = 'foo'
 
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        prefix = temp_dir_prefix(self)
         self.base_logdir = tempfile.TemporaryDirectory(prefix=prefix)
         self.tst_instance_pass = AvocadoPass(base_logdir=self.base_logdir.name)
         self.tst_instance_pass.run_avocado()
@@ -215,7 +215,7 @@ class TestClassTest(unittest.TestCase):
 class SimpleTestClassTest(unittest.TestCase):
 
     def setUp(self):
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        prefix = temp_dir_prefix(self)
         self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
         self.script = None
 
@@ -252,7 +252,7 @@ class SimpleTestClassTest(unittest.TestCase):
 class MockingTest(unittest.TestCase):
 
     def setUp(self):
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        prefix = temp_dir_prefix(self)
         self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
 
     def test_init_minimal_params(self):

--- a/selftests/unit/utils/test_archive.py
+++ b/selftests/unit/utils/test_archive.py
@@ -11,7 +11,7 @@ from selftests.utils import BASEDIR, temp_dir_prefix
 class ArchiveTest(unittest.TestCase):
 
     def setUp(self):
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        prefix = temp_dir_prefix(self)
         self.basedir = tempfile.TemporaryDirectory(prefix=prefix)
         self.compressdir = tempfile.mkdtemp(dir=self.basedir.name)
         self.decompressdir = tempfile.mkdtemp(dir=self.basedir.name)

--- a/selftests/unit/utils/test_cloudinit.py
+++ b/selftests/unit/utils/test_cloudinit.py
@@ -24,7 +24,7 @@ class CloudInit(unittest.TestCase):
 class CloudInitISO(unittest.TestCase):
 
     def setUp(self):
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        prefix = temp_dir_prefix(self)
         self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
 
     @unittest.skipUnless(has_iso_create_write(),

--- a/selftests/unit/utils/test_diff_validator.py
+++ b/selftests/unit/utils/test_diff_validator.py
@@ -11,7 +11,7 @@ from selftests.utils import temp_dir_prefix
 class ChangeValidationTest(unittest.TestCase):
 
     def setUp(self):
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        prefix = temp_dir_prefix(self)
         self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
         self.change = diff_validator.Change()
         self.files = [os.path.join(self.tmpdir.name, "file1.cnf"),

--- a/selftests/unit/utils/test_filelock.py
+++ b/selftests/unit/utils/test_filelock.py
@@ -9,7 +9,7 @@ from selftests.utils import temp_dir_prefix
 class TestFileLock(unittest.TestCase):
 
     def setUp(self):
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        prefix = temp_dir_prefix(self)
         self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
         self.filename = os.path.join(self.tmpdir.name, 'file.img')
         self.content = 'Foo bar'

--- a/selftests/unit/utils/test_genio.py
+++ b/selftests/unit/utils/test_genio.py
@@ -12,7 +12,7 @@ setup_avocado_loggers()
 
 class TestGenio(unittest.TestCase):
     def test_check_pattern_in_directory(self):
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        prefix = temp_dir_prefix(self)
         tempdirname = tempfile.mkdtemp(prefix=prefix)
         with self.assertRaises(genio.GenIOError):
             genio.is_pattern_in_file(tempdirname, 'something')

--- a/selftests/unit/utils/test_iso9660.py
+++ b/selftests/unit/utils/test_iso9660.py
@@ -52,7 +52,7 @@ class BaseIso9660:
             os.path.join(os.path.dirname(os.path.dirname(__file__)),
                          os.path.pardir, ".data", "sample.iso"))
         self.iso = None
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        prefix = temp_dir_prefix(self)
         self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
 
     @unittest.skipIf(os.uname()[4] == 's390x',

--- a/selftests/unit/utils/test_partition.py
+++ b/selftests/unit/utils/test_partition.py
@@ -44,7 +44,7 @@ class Base(unittest.TestCase):
                      os.getenv('TRAVIS_CPU_ARCH') in ['arm64', 'ppc64le', 's390x'],
                      'TRAVIS Environment is unsuitable for these tests')
     def setUp(self):
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        prefix = temp_dir_prefix(self)
         self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
         self.mountpoint = os.path.join(self.tmpdir.name, "disk")
         os.mkdir(self.mountpoint)

--- a/selftests/utils.py
+++ b/selftests/utils.py
@@ -46,21 +46,20 @@ def setup_avocado_loggers():
             logger.handlers.append(logging.NullHandler())
 
 
-def temp_dir_prefix(module_name, klass, method):
+def temp_dir_prefix(klass):
     """
     Returns a standard name for the temp dir prefix used by the tests
     """
-    fmt = 'avocado__%s__%s__%s__'
-    return fmt % (module_name, klass.__class__.__name__, method)
+    return 'avocado_%s_' % klass.__class__.__name__
 
 
-def get_temporary_config(module_name, klass, method):
+def get_temporary_config(klass):
     """
     Creates a temporary bogus config file
     returns base directory, dictionary containing the temporary data dir
     paths and the configuration file contain those same settings
     """
-    prefix = temp_dir_prefix(module_name, klass, method)
+    prefix = temp_dir_prefix(klass)
     base_dir = tempfile.TemporaryDirectory(prefix=prefix)
     test_dir = os.path.join(base_dir.name, 'tests')
     os.mkdir(test_dir)
@@ -141,7 +140,7 @@ def skipUnlessPathExists(path):
 class TestCaseTmpDir(unittest.TestCase):
 
     def setUp(self):
-        prefix = temp_dir_prefix(__name__, self, 'setUp')
+        prefix = temp_dir_prefix(self)
         self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
         os.chdir(BASEDIR)
 


### PR DESCRIPTION
The very long and detailed temporary directory prefix used on `TestCaseTmpDir` was introduced to quickly identify selftests that may not be cleaning up after themselves.
    
But, it has one negative side effect: some files names such as sockets have length limitations, and the amount of detail makes it very easy to go beyond that limit.