### PR TITLE
nrunner: properly support UNIX domain sockets

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -770,10 +770,16 @@ class TaskStatusService:
         self.connection = None
 
     def post(self, status):
-        host, port = self.uri.split(':')
-        port = int(port)
-        if self.connection is None:
-            self.connection = socket.create_connection((host, port))
+        if ':' in self.uri:
+            host, port = self.uri.split(':')
+            port = int(port)
+            if self.connection is None:
+                self.connection = socket.create_connection((host, port))
+        else:
+            if self.connection is None:
+                self.connection = socket.socket(socket.AF_UNIX,
+                                                socket.SOCK_STREAM)
+                self.connection.connect(self.uri)
 
         data = json_dumps(status)
         self.connection.send(data.encode('ascii') + "\n".encode('ascii'))

--- a/avocado/core/status/server.py
+++ b/avocado/core/status/server.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import sys
 
 from ..settings import settings
@@ -50,6 +51,8 @@ class StatusServer:
 
     def close(self):
         self._server_task.close()
+        if os.path.exists(self._uri):
+            os.unlink(self._uri)
 
     async def cb(self, reader, _):
         while True:

--- a/avocado/core/status/server.py
+++ b/avocado/core/status/server.py
@@ -20,6 +20,10 @@ class StatusServer:
         self._repo = repo
         self._server_task = None
 
+    @property
+    def uri(self):
+        return self._uri
+
     async def create_server(self):
         limit = settings.as_dict().get('nrunner.status_server_buffer_size')
         if ':' in self._uri:

--- a/examples/jobs/nrunner_unix_status_server.py
+++ b/examples/jobs/nrunner_unix_status_server.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import tempfile
+
+from avocado.core.job import Job
+from avocado.core.suite import TestSuite
+
+status_server_dir = tempfile.TemporaryDirectory()
+status_server = os.path.join(status_server_dir.name, 'status_server.socket')
+
+config = {
+    'run.test_runner': 'nrunner',
+    'nrunner.status_server_listen': status_server,
+    'nrunner.status_server_uri': status_server,
+    'run.references': [
+        'examples/tests/passtest.py'
+    ],
+    }
+
+suite = TestSuite.from_config(config, name='1')
+with Job(config, [suite]) as j:
+    result = j.run()
+
+# Check that one test actually ran and results were recorded. The
+# test's success will be checked by the job execution result
+assert len(j.result.tests) == 1
+
+status_server_dir.cleanup()
+sys.exit(result)

--- a/selftests/jobs/example_nrunner_unix_status_server
+++ b/selftests/jobs/example_nrunner_unix_status_server
@@ -1,0 +1,1 @@
+../../examples/jobs/nrunner_unix_status_server.py


### PR DESCRIPTION
nrunner is supposed to also allow UNIX domain sockets to be used as the transport for status messages, but it has never been set to use.

This fixes a few issues, adding a job as a test that actually makes use of it.