### PR TITLE
loader: remove duplicate methods

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -713,22 +713,6 @@ class FileLoader(SimpleFileLoader):
                 result += candidates
         return result
 
-    def _make_simple_test(self, test_path, subtests_filter):
-        return self._make_test(test.SimpleTest, test_path,
-                               subtests_filter=subtests_filter,
-                               executable=test_path)
-
-    def _make_simple_or_broken_test(self, test_path, subtests_filter, make_broken):
-        if os.access(test_path, os.X_OK):
-            # Module does not have an avocado test class inside but
-            # it's executable, let's execute it.
-            return self._make_simple_test(test_path, subtests_filter)
-        else:
-            # Module does not have an avocado test class inside, and
-            # it's not executable. Not a Test.
-            return make_broken(NotATest, test_path,
-                               self.NOT_TEST_STR)
-
     def _make_python_file_tests(self, test_path, make_broken,
                                 subtests_filter, test_name=None):
         if test_name is None:


### PR DESCRIPTION
Two methods of FileLoader are the same as in the superclass,
delete them.