### PR TITLE
Sysinfo nrunner [v3]

### DIFF
--- a/avocado/core/runners/sysinfo.py
+++ b/avocado/core/runners/sysinfo.py
@@ -1,0 +1,185 @@
+import multiprocessing
+import os
+import time
+import traceback
+
+from avocado.core import nrunner
+from avocado.core.runners.utils import messages
+from avocado.utils import sysinfo as sysinfo_collectible
+from avocado.utils.software_manager import manager
+
+
+class PreSysInfo:
+    """
+    Log different system properties before start event.
+
+    An event may be a job, a test, or any other event with a
+    beginning and end.
+    """
+    sysinfo_dir = os.path.join('sysinfo', 'pre')
+
+    def __init__(self, config, sysinfo_config, queue):
+        """
+        Set sysinfo collectibles.
+
+        :param config: avocado configuration
+        :type config: dict
+        :param sysinfo_config: dictionary with commands/tasks which should be
+                              performed during the sysinfo collection.
+        :type sysinfo_config: dict
+        :param queue: queue for the runner messages
+        :type queue: multiprocessing.SimpleQueue
+        """
+        self.config = config
+        self.queue = queue
+        self.log_packages = self.config.get('sysinfo.collect.installed_packages')
+        self.timeout = self.config.get('sysinfo.collect.commands_timeout')
+        self.locale = self.config.get('sysinfo.collect.locale')
+
+        self.sysinfo_config = sysinfo_config
+        self.collectibles = set()
+
+    @property
+    def installed_pkgs(self):
+        sm = manager.SoftwareManager()
+        return sm.list_all()
+
+    def _set_collectibles(self):
+        for cmd in self.sysinfo_config.get("commands", []):
+            self.collectibles.add(
+                sysinfo_collectible.Command(cmd, timeout=self.timeout,
+                                            locale=self.locale))
+
+        for filename in self.sysinfo_config.get("files", []):
+            self.collectibles.add(sysinfo_collectible.Logfile(filename))
+
+    def _save_sysinfo(self, log_hook):
+        try:
+            file_path = os.path.join(self.sysinfo_dir, log_hook.name)
+            for data in log_hook.collect():
+                self.queue.put(messages.FileMessage.get(data, file_path))
+        except sysinfo_collectible.CollectibleException as e:
+            self.queue.put(messages.LogMessage.get(e.args[0]))
+        except Exception as exc:  # pylint: disable=W0703
+            self.queue.put(messages.StderrMessage.get("Collection %s failed: %s"
+                                                      % (type(log_hook), exc)))
+
+    def collect(self):
+        """Log all collectibles at the start of the event."""
+        self._set_collectibles()
+        for log_hook in self.collectibles:
+            self._save_sysinfo(log_hook)
+
+        if self.log_packages:
+            self._log_packages(self.sysinfo_dir)
+        self.queue.put(messages.FinishedMessage.get('pass'))
+
+    def _log_packages(self, path):
+        installed_path = os.path.join(path, "installed_packages")
+        installed_packages = "\n".join(self.installed_pkgs) + "\n"
+        self.queue.put(messages.FileMessage.get(installed_packages,
+                                                installed_path))
+
+
+class PostSysInfo(PreSysInfo):
+    """
+    Log different system properties after end event.
+
+    An event may be a job, a test, or any other event with a
+    beginning and end.
+    """
+
+    sysinfo_dir = os.path.join('sysinfo', 'post')
+
+    def __init__(self, config, sysinfo_config, queue, test_fail=False):
+        """
+        :param test_fail: flag for fail tests. Default False
+        :type test_fail: bool
+        """
+        self.test_fail = test_fail
+        super().__init__(config, sysinfo_config, queue)
+
+    def _set_collectibles(self):
+        super()._set_collectibles()
+        if self.test_fail:
+            for fail_cmd in self.sysinfo_config.get("fail_commands", []):
+                self.collectibles.add(
+                    sysinfo_collectible.Command(fail_cmd, timeout=self.timeout,
+                                                locale=self.locale))
+
+            for fail_filename in self.sysinfo_config.get("fail_files", []):
+                self.collectibles.add(sysinfo_collectible.Logfile(fail_filename))
+
+
+class SysinfoRunner(nrunner.BaseRunner):
+    """
+    Runner for gathering sysinfo
+
+    Runnable attributes usage:
+
+     * uri: sysinfo type pre/post. This variable decides if the sysinfo is
+            collected before or after the test.
+
+     * kwargs: "sysinfo" dictionary with commands/tasks which should be
+               performed during the sysinfo collection.
+    """
+
+    def run(self):
+        yield self.prepare_status('started')
+        sysinfo_config = self.runnable.kwargs.get('sysinfo', {})
+        test_fail = self.runnable.kwargs.get('test_fail', False)
+        if self.runnable.uri not in ['pre', 'post']:
+            yield messages.StderrMessage.get("Unsupported uri %s. Possible "
+                                             "values, 'pre', 'post'" %
+                                             self.runnable.uri)
+            yield messages.FinishedMessage.get('error')
+
+        try:
+            queue = multiprocessing.SimpleQueue()
+            if self.runnable.uri == 'pre':
+                sysinfo = PreSysInfo(self.runnable.config,
+                                     sysinfo_config,
+                                     queue)
+            else:
+                sysinfo = PostSysInfo(self.runnable.config,
+                                      sysinfo_config,
+                                      queue,
+                                      test_fail)
+            sysinfo_process = multiprocessing.Process(target=sysinfo.collect())
+
+            sysinfo_process.start()
+
+            most_current_execution_state_time = None
+            while True:
+                time.sleep(nrunner.RUNNER_RUN_CHECK_INTERVAL)
+                now = time.monotonic()
+                if queue.empty():
+                    if most_current_execution_state_time is not None:
+                        next_execution_state_mark = (most_current_execution_state_time +
+                                                     nrunner.RUNNER_RUN_STATUS_INTERVAL)
+                    if (most_current_execution_state_time is None or
+                            now > next_execution_state_mark):
+                        most_current_execution_state_time = now
+                        yield messages.RunningMessage.get()
+                else:
+                    message = queue.get()
+                    yield message
+                    if message.get('status') == 'finished':
+                        break
+        except Exception:  # pylint: disable=W0703
+            yield messages.StderrMessage.get(traceback.format_exc())
+            yield messages.FinishedMessage.get('error')
+
+
+class RunnerApp(nrunner.BaseRunnerApp):
+    PROG_NAME = 'avocado-runner-sysinfo'
+    PROG_DESCRIPTION = 'nrunner application for gathering sysinfo'
+    RUNNABLE_KINDS_CAPABLE = {'sysinfo': SysinfoRunner}
+
+
+def main():
+    nrunner.main(RunnerApp)
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/nrunner/recipes/runnables/sysinfo.json
+++ b/examples/nrunner/recipes/runnables/sysinfo.json
@@ -1,0 +1,4 @@
+{"config":{"sysinfo.collect.commands_timeout": -1, "sysinfo.collect.locale": "C", "sysinfo.collect.installed_packages": false},
+  "kind": "sysinfo",
+  "uri": "pre",
+  "kwargs": {"sysinfo": {"commands": ["uptime", "dmidecode"], "files": ["/proc/version", "/proc/meminfo"]}}}

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -192,6 +192,7 @@ PATH=%{buildroot}%{_bindir}:%{buildroot}%{_libexecdir}/avocado:$PATH \
 %{_bindir}/avocado-runner-tap
 %{_bindir}/avocado-runner-requirement-asset
 %{_bindir}/avocado-runner-requirement-package
+%{_bindir}/avocado-runner-sysinfo
 %{_bindir}/avocado-software-manager
 %{python3_sitelib}/avocado*
 %exclude %{python3_sitelib}/avocado_result_html*

--- a/selftests/unit/test_runner_sysinfo.py
+++ b/selftests/unit/test_runner_sysinfo.py
@@ -1,0 +1,54 @@
+import os
+import unittest
+
+from avocado.core.nrunner import Runnable
+from avocado.core.runners.sysinfo import SysinfoRunner
+from avocado.core.settings import settings
+
+
+class BasicTests(unittest.TestCase):
+    """Basic unit tests for the RequirementPackageRunner class"""
+
+    def in_message_path(self, messages, path, sysinfo_type='pre'):
+        path = os.path.join('sysinfo', sysinfo_type, path)
+        for message in messages:
+            if message.get('path', '') == path:
+                return True
+        return False
+
+    def test_pre(self):
+        kwargs = {'sysinfo': {'commands': ['uptime', 'dmidecode'],
+                              'files': ['/proc/version', '/proc/meminfo']}}
+        runnable = Runnable('sysinfo', 'pre', **kwargs,
+                            config=settings.as_dict())
+        runner = SysinfoRunner(runnable)
+        status = runner.run()
+        messages = []
+        while True:
+            try:
+                messages.append(next(status))
+            except StopIteration:
+                break
+        self.assertTrue(self.in_message_path(messages, 'uptime'))
+        self.assertTrue(self.in_message_path(messages, 'dmidecode'))
+        self.assertTrue(self.in_message_path(messages, 'meminfo'))
+        self.assertTrue(self.in_message_path(messages, 'version'))
+
+    def test_post_fail(self):
+        kwargs = {'sysinfo': {'fail_commands': ['uptime', 'dmidecode'],
+                              'fail_files': ['/proc/version', '/proc/meminfo']},
+                  'test_fail': True}
+        runnable = Runnable('sysinfo', 'post', **kwargs,
+                            config=settings.as_dict())
+        runner = SysinfoRunner(runnable)
+        status = runner.run()
+        messages = []
+        while True:
+            try:
+                messages.append(next(status))
+            except StopIteration:
+                break
+        self.assertTrue(self.in_message_path(messages, 'uptime', 'post'))
+        self.assertTrue(self.in_message_path(messages, 'dmidecode', 'post'))
+        self.assertTrue(self.in_message_path(messages, 'meminfo', 'post'))
+        self.assertTrue(self.in_message_path(messages, 'version', 'post'))

--- a/setup.py
+++ b/setup.py
@@ -338,6 +338,7 @@ if __name__ == '__main__':
                   'avocado-runner-tap = avocado.core.runners.tap:main',
                   'avocado-runner-requirement-asset = avocado.core.runners.requirement_asset:main',
                   'avocado-runner-requirement-package = avocado.core.runners.requirement_package:main',
+                  'avocado-runner-sysinfo = avocado.core.runners.sysinfo:main',
                   'avocado-software-manager = avocado.utils.software_manager.main:main',
                   ],
               "avocado.plugins.init": [


### PR DESCRIPTION
The runner for gathering sysinfo. It supports the command and system
file collectible from the legacy runner and uses the
'sysinfo.collectibles' configuration. It is the part of work on #3877,
but it is just the runner and misses the configuration part in avocado
job.

You can test it by running the recipe in
'examples/nrunner/recipes/runnables/sysinfo.json'

Reference: #3877
Signed-off-by: Jan Richter <jarichte@redhat.com>

---
Changes form v1 (#4760):

*   usage of __all__
*  rename the log to log_path
*    remove the prefix inside the __repr__ methods
*   use hash for comparisons
*   set the timeout to 0 when the sysinfo.collect.commands_timeout is not defined
*   fix of the recipe example
*   fix the empty arguments bug
---
Changes form v2 (#4806): 
* Usage of sysinfo utils form #4842

