### PR TITLE
nrunner: introduce status server auto mode

### DIFF
--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -18,6 +18,8 @@ NRunner based implementation of job compliant runner
 
 import asyncio
 import multiprocessing
+import os
+import platform
 import random
 from copy import deepcopy
 
@@ -51,6 +53,16 @@ class RunnerInit(Init):
                                  default=False,
                                  help_msg=help_msg,
                                  key_type=bool)
+
+        help_msg = ('If the status server should automatically choose '
+                    'a "status_server_listen" and "status_server_uri" '
+                    'configuration. Default is not to auto configure a '
+                    'status server.')
+        settings.register_option(section=section,
+                                 key='status_server_auto',
+                                 default=False,
+                                 key_type=bool,
+                                 help_msg=help_msg)
 
         help_msg = ('URI for listing the status server. Usually '
                     'a "HOST:PORT" string')
@@ -122,6 +134,12 @@ class RunnerCLI(CLI):
                                          action='store_true')
 
         settings.add_argparser_to_option(
+            namespace='nrunner.status_server_auto',
+            parser=parser,
+            long_arg='--nrunner-status-server-auto',
+            action='store_true')
+
+        settings.add_argparser_to_option(
             namespace='nrunner.status_server_listen',
             parser=parser,
             long_arg='--nrunner-status-server-listen',
@@ -154,8 +172,7 @@ class Runner(RunnerInterface):
     name = 'nrunner'
     description = 'nrunner based implementation of job compliant runner'
 
-    @staticmethod
-    def _get_requirements_runtime_tasks(runnable, prefix, job_id):
+    def _get_requirements_runtime_tasks(self, runnable, prefix, job_id):
         if runnable.requirements is None:
             return
 
@@ -177,6 +194,7 @@ class Runner(RunnerInterface):
             # creates the requirement task
             requirement_task = nrunner.Task(requirement_runnable,
                                             identifier=task_id,
+                                            status_uris=[self.status_server.uri],
                                             category='requirement',
                                             job_id=job_id)
             # make sure we track the dependencies of a task
@@ -186,8 +204,7 @@ class Runner(RunnerInterface):
 
         return requirements_runtime_tasks
 
-    @staticmethod
-    def _create_runtime_tasks_for_test(test_suite, runnable, no_digits,
+    def _create_runtime_tasks_for_test(self, test_suite, runnable, no_digits,
                                        index, variant, job_id):
         """Creates runtime tasks for both tests, and for its requirements."""
         result = []
@@ -209,15 +226,16 @@ class Runner(RunnerInterface):
         task = nrunner.Task(runnable,
                             identifier=test_id,
                             known_runners=nrunner.RUNNERS_REGISTRY_PYTHON_CLASS,
+                            status_uris=[self.status_server.uri],
                             job_id=job_id)
         runtime_task = RuntimeTask(task)
         result.append(runtime_task)
 
         # handles the requirements
         requirements_runtime_tasks = (
-            Runner._get_requirements_runtime_tasks(runnable,
-                                                   prefix,
-                                                   job_id))
+            self._get_requirements_runtime_tasks(runnable,
+                                                 prefix,
+                                                 job_id))
         # extend the list of tasks with the requirements runtime tasks
         if requirements_runtime_tasks is not None:
             for requirement_runtime_task in requirements_runtime_tasks:
@@ -228,8 +246,7 @@ class Runner(RunnerInterface):
 
         return result
 
-    @staticmethod
-    def _get_all_runtime_tasks(test_suite, job_id):
+    def _get_all_runtime_tasks(self, test_suite, job_id):
         runtime_tasks = []
         test_result_total = test_suite.variants.get_number_of_tests(test_suite.tests)
         no_digits = len(str(test_result_total))
@@ -250,7 +267,7 @@ class Runner(RunnerInterface):
         for index, (runnable, variant) in enumerate(test_variant, start=1):
             if copy_runnable:
                 runnable = deepcopy(runnable)
-            runtime_tasks.extend(Runner._create_runtime_tasks_for_test(
+            runtime_tasks.extend(self._create_runtime_tasks_for_test(
                 test_suite,
                 runnable,
                 no_digits,
@@ -259,13 +276,20 @@ class Runner(RunnerInterface):
                 job_id))
         return runtime_tasks
 
-    def _start_status_server(self, status_server_listen, job_id):
+    def _determine_status_server_uri(self, test_suite, job):
+        if test_suite.config.get('nrunner.status_server_auto'):
+            # no UNIX domain sockets on Windows
+            if platform.system() != 'Windows':
+                return os.path.join(job.logdir, '.status_server.sock')
+        return test_suite.config.get('nrunner.status_server_listen')
+
+    def _create_status_server(self, test_suite, job):
+        listen = self._determine_status_server_uri(test_suite, job)
         # pylint: disable=W0201
-        self.status_repo = StatusRepo(job_id)
+        self.status_repo = StatusRepo(job.unique_id)
         # pylint: disable=W0201
-        self.status_server = StatusServer(status_server_listen,
+        self.status_server = StatusServer(listen,
                                           self.status_repo)
-        asyncio.ensure_future(self.status_server.serve_forever())
 
     async def _update_status(self, job):
         tasks_by_id = {str(runtime_task.task.identifier): runtime_task.task
@@ -291,11 +315,14 @@ class Runner(RunnerInterface):
             test_suite.tests)
         job.result.tests_total = test_suite.variants.get_number_of_tests(test_suite.tests)
 
-        listen = test_suite.config.get('nrunner.status_server_listen')
-        self._start_status_server(listen, job.unique_id)
+        self._create_status_server(test_suite, job)
 
         # pylint: disable=W0201
         self.runtime_tasks = self._get_all_runtime_tasks(test_suite, job.unique_id)
+
+        # Start the status server
+        asyncio.ensure_future(self.status_server.serve_forever())
+
         if test_suite.config.get('nrunner.shuffle'):
             random.shuffle(self.runtime_tasks)
         test_ids = [rt.task.identifier for rt in self.runtime_tasks

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -56,11 +56,11 @@ class RunnerInit(Init):
 
         help_msg = ('If the status server should automatically choose '
                     'a "status_server_listen" and "status_server_uri" '
-                    'configuration. Default is not to auto configure a '
+                    'configuration. Default is to auto configure a '
                     'status server.')
         settings.register_option(section=section,
                                  key='status_server_auto',
-                                 default=False,
+                                 default=True,
                                  key_type=bool,
                                  help_msg=help_msg)
 
@@ -136,8 +136,8 @@ class RunnerCLI(CLI):
         settings.add_argparser_to_option(
             namespace='nrunner.status_server_auto',
             parser=parser,
-            long_arg='--nrunner-status-server-auto',
-            action='store_true')
+            long_arg='--nrunner-status-server-disable-auto',
+            action='store_false')
 
         settings.add_argparser_to_option(
             namespace='nrunner.status_server_listen',

--- a/examples/jobs/nrunner.py
+++ b/examples/jobs/nrunner.py
@@ -4,14 +4,9 @@ import sys
 
 from avocado.core.job import Job
 from avocado.core.suite import TestSuite
-from avocado.utils.network.ports import find_free_port
-
-status_server = '127.0.0.1:%u' % find_free_port()
 
 config = {
     'run.test_runner': 'nrunner',
-    'nrunner.status_server_listen': status_server,
-    'nrunner.status_server_uri': status_server,
     'run.references': [
         'selftests/unit/plugin/test_resolver.py',
         'selftests/functional/test_argument_parsing.py',

--- a/examples/jobs/nrunner_unix_status_server.py
+++ b/examples/jobs/nrunner_unix_status_server.py
@@ -12,6 +12,7 @@ status_server = os.path.join(status_server_dir.name, 'status_server.socket')
 
 config = {
     'run.test_runner': 'nrunner',
+    'nrunner.status_server_auto': False,
     'nrunner.status_server_listen': status_server,
     'nrunner.status_server_uri': status_server,
     'run.references': [

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -11,7 +11,6 @@ from avocado import Test
 from avocado.core import exit_codes
 from avocado.core.job import Job
 from avocado.core.suite import TestSuite
-from avocado.utils.network.ports import find_free_port
 
 BOOLEAN_ENABLED = [True, 'true', 'on', 1]
 BOOLEAN_DISABLED = [False, 'false', 'off', 0]
@@ -542,12 +541,9 @@ def create_suites(args):  # pylint: disable=W0621
     if args.functional:
         selftests.append('selftests/functional/')
 
-    status_server = '127.0.0.1:%u' % find_free_port()
     config_check = {
         'run.references': selftests,
         'run.test_runner': 'nrunner',
-        'nrunner.status_server_listen': status_server,
-        'nrunner.status_server_uri': status_server,
         'run.ignore_missing_references': True,
         'job.output.testlogs.statuses': ['FAIL']
     }

--- a/selftests/functional/plugin/test_jsonresult.py
+++ b/selftests/functional/plugin/test_jsonresult.py
@@ -1,28 +1,17 @@
 import json
 from os import path
 
-from avocado.utils import process, script
-from avocado.utils.network import find_free_port
+from avocado.utils import process
 from selftests.utils import AVOCADO, TestCaseTmpDir
 
 
 class JsonResultTest(TestCaseTmpDir):
 
-    def setUp(self):
-        super(JsonResultTest, self).setUp()
-        status_server = '127.0.0.1:%u' % find_free_port()
-        self.config_file = script.TemporaryScript(
-            'avocado.conf',
-            ("[nrunner]\n"
-             "status_server_listen = %s\n"
-             "status_server_uri = %s\n") % (status_server, status_server))
-        self.config_file.save()
-
     def test_logfile(self):
-        cmd_line = ('%s --config %s run --test-runner=nrunner '
+        cmd_line = ('%s run --test-runner=nrunner '
                     'examples/tests/failtest.py '
                     '--job-results-dir %s --disable-sysinfo ' %
-                    (AVOCADO, self.config_file.path, self.tmpdir.name))
+                    (AVOCADO, self.tmpdir.name))
         process.run(cmd_line, ignore_status=True)
         json_path = path.join(self.tmpdir.name, 'latest', 'results.json')
 
@@ -33,10 +22,10 @@ class JsonResultTest(TestCaseTmpDir):
             self.assertEqual(expected_logfile, test_data['logfile'])
 
     def test_fail_reason(self):
-        cmd_line = ('%s --config %s run --test-runner=nrunner '
+        cmd_line = ('%s run --test-runner=nrunner '
                     'examples/tests/failtest.py '
                     '--job-results-dir %s --disable-sysinfo ' %
-                    (AVOCADO, self.config_file.path, self.tmpdir.name))
+                    (AVOCADO, self.tmpdir.name))
         process.run(cmd_line, ignore_status=True)
         json_path = path.join(self.tmpdir.name, 'latest', 'results.json')
         with open(json_path, 'r') as json_file:
@@ -44,7 +33,3 @@ class JsonResultTest(TestCaseTmpDir):
             test_data = data['tests'].pop()
             self.assertEqual('This test is supposed to fail',
                              test_data['fail_reason'])
-
-    def tearDown(self):
-        super(JsonResultTest, self).tearDown()
-        self.config_file.remove()

--- a/selftests/functional/plugin/test_logs.py
+++ b/selftests/functional/plugin/test_logs.py
@@ -2,7 +2,6 @@ import os
 
 from avocado.core import exit_codes
 from avocado.utils import process, script
-from avocado.utils.network import find_free_port
 from selftests.utils import AVOCADO, BASEDIR, TestCaseTmpDir
 
 CONFIG = """[job.output.testlogs]
@@ -65,27 +64,13 @@ class TestLogsFilesUI(TestCaseTmpDir):
 
 class TestLogging(TestCaseTmpDir):
 
-    def setUp(self):
-        super(TestLogging, self).setUp()
-        status_server = '127.0.0.1:%u' % find_free_port()
-        self.config_file = script.TemporaryScript(
-            'avocado.conf',
-            ("[nrunner]\n"
-             "status_server_listen = %s\n"
-             "status_server_uri = %s\n") % (status_server, status_server))
-        self.config_file.save()
-
     def test_job_log(self):
         pass_test = os.path.join(BASEDIR, 'examples', 'tests', 'passtest.py')
-        cmd_line = ('%s --config %s run --job-results-dir %s --test-runner=nrunner %s' %
-                    (AVOCADO, self.config_file.path, self.tmpdir.name, pass_test))
+        cmd_line = ('%s run --job-results-dir %s --test-runner=nrunner %s' %
+                    (AVOCADO, self.tmpdir.name, pass_test))
         process.run(cmd_line)
         log_file = os.path.join(self.tmpdir.name, 'latest', 'job.log')
         with open(log_file, 'r') as fp:
             log = fp.read()
         self.assertIn('passtest.py:PassTest.test: STARTED', log)
         self.assertIn('passtest.py:PassTest.test: PASS', log)
-
-    def tearDown(self):
-        super(TestLogging, self).tearDown()
-        self.config_file.remove()

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -15,7 +15,6 @@ from avocado.core import exit_codes
 from avocado.utils import astring, genio
 from avocado.utils import path as utils_path
 from avocado.utils import process, script
-from avocado.utils.network import find_free_port
 from selftests.utils import (AVOCADO, BASEDIR, TestCaseTmpDir,
                              python_module_available, skipOnLevelsInferiorThan,
                              skipUnlessPathExists, temp_dir_prefix)
@@ -588,24 +587,13 @@ class RunnerOperationTest(TestCaseTmpDir):
 
 class DryRunTest(TestCaseTmpDir):
 
-    def setUp(self):
-        super(DryRunTest, self).setUp()
-        status_server = '127.0.0.1:%u' % find_free_port()
-        self.config_file = script.TemporaryScript(
-            'avocado.conf',
-            ("[nrunner]\n"
-             "status_server_listen = %s\n"
-             "status_server_uri = %s\n") % (status_server, status_server))
-        self.config_file.save()
-
     def test_dry_run(self):
         examples_path = os.path.join('examples', 'tests')
         passtest = os.path.join(examples_path, 'passtest.py')
         failtest = os.path.join(examples_path, 'failtest.py')
         gendata = os.path.join(examples_path, 'gendata.py')
-        cmd = ("%s --config %s run --test-runner=nrunner --disable-sysinfo --dry-run "
+        cmd = ("%s run --test-runner=nrunner --disable-sysinfo --dry-run "
                "--dry-run-no-cleanup --json - -- %s %s %s " % (AVOCADO,
-                                                               self.config_file.path,
                                                                passtest,
                                                                failtest,
                                                                gendata))
@@ -617,10 +605,6 @@ class DryRunTest(TestCaseTmpDir):
             test = result['tests'][i]
             self.assertEqual(test['fail_reason'],
                              u'Test cancelled due to --dry-run')
-
-    def tearDown(self):
-        super(DryRunTest, self).tearDown()
-        self.config_file.remove()
 
 
 class RunnerHumanOutputTest(TestCaseTmpDir):

--- a/selftests/functional/test_nrunner.py
+++ b/selftests/functional/test_nrunner.py
@@ -4,7 +4,6 @@ import unittest
 
 from avocado.core.job import Job
 from avocado.utils import process
-from avocado.utils.network.ports import find_free_port
 from selftests.utils import (AVOCADO, BASEDIR, TestCaseTmpDir,
                              skipUnlessPathExists)
 
@@ -14,12 +13,9 @@ RUNNER = "%s -m avocado.core.nrunner" % sys.executable
 class NRunnerFeatures(unittest.TestCase):
     @skipUnlessPathExists('/bin/false')
     def test_custom_exit_codes(self):
-        status_server = "127.0.0.1:%u" % find_free_port()
         config = {'run.references': ['/bin/false'],
                   'run.test_runner': 'nrunner',
                   'runner.exectest.exitcodes.skip': [1],
-                  'nrunner.status_server_listen': status_server,
-                  'nrunner.status_server_uri': status_server,
                   'run.keep_tmp': True}
         with Job.from_config(job_config=config) as job:
             self.assertEqual(job.run(), 0)
@@ -27,7 +23,6 @@ class NRunnerFeatures(unittest.TestCase):
     @skipUnlessPathExists('/bin/false')
     @skipUnlessPathExists('/bin/true')
     def test_failfast(self):
-        status_server = "127.0.0.1:%u" % find_free_port()
         config = {'run.references': ['/bin/true',
                                      '/bin/false',
                                      '/bin/true',
@@ -35,8 +30,6 @@ class NRunnerFeatures(unittest.TestCase):
                   'run.test_runner': 'nrunner',
                   'run.failfast': True,
                   'nrunner.shuffle': False,
-                  'nrunner.status_server_listen': status_server,
-                  'nrunner.status_server_uri': status_server,
                   'nrunner.max_parallel_tasks': 1}
         with Job.from_config(job_config=config) as job:
             self.assertEqual(job.run(), 9)

--- a/selftests/functional/test_task_timeout.py
+++ b/selftests/functional/test_task_timeout.py
@@ -1,6 +1,5 @@
 from avocado.core.job import Job
 from avocado.utils import script
-from avocado.utils.network.ports import find_free_port
 from selftests.utils import TestCaseTmpDir, skipUnlessPathExists
 
 SCRIPT_CONTENT = """#!/bin/bash
@@ -20,10 +19,7 @@ class TaskTimeOutTest(TestCaseTmpDir):
 
     @skipUnlessPathExists('/bin/sleep')
     def test_sleep_longer_timeout(self):
-        status_server = '127.0.0.1:%u' % find_free_port()
         config = {'run.references': [self.script.path],
-                  'nrunner.status_server_listen': status_server,
-                  'nrunner.status_server_uri': status_server,
                   'run.results_dir': self.tmpdir.name,
                   'run.keep_tmp': True,
                   'task.timeout.running': 2,


### PR DESCRIPTION
This introduces a mode under which the status server will set up its own "listen" and "uri" values.
    
The "listen" value is of course related to where the status server will be listening for status updates, from clients (tasks) which are given the "uri" value.
    
Instead of a TCP based socket, the auto mode defaults to using a UNIX domain socket created within the job's own directory, which better avoids clashes (no two jobs should be using the same job directory anyway).