### PR TITLE
Config for every runnable

### DIFF
--- a/avocado/core/suite.py
+++ b/avocado/core/suite.py
@@ -97,6 +97,11 @@ class TestSuite:
         if config:
             self.config.update(config)
 
+        # Update the config of runnables.
+        if config.get('run.test_runner') == 'nrunner' and self.tests:
+            for test in self.tests:
+                test.config.update(self.config)
+
         self._variants = None
         self._references = None
         self._runner = None


### PR DESCRIPTION
The `Runnable` class has to have configuration because this information
are used by Tasks and Runners. When the runnable is created by
`from_config` method, everything works fine, but when the runnable is
created manually the config might be empty. This commit will set
runnables configuration same with the test suite configuration.

Reference: #4846
Signed-off-by: Jan Richter <jarichte@redhat.com>