### PR TITLE
variants.yml: remove i386 in ubuntu

### DIFF
--- a/selftests/pre_release/tests/vmimage.py.data/variants.yml
+++ b/selftests/pre_release/tests/vmimage.py.data/variants.yml
@@ -57,6 +57,7 @@ distro: !mux
   ubuntu:
     name: ubuntu
     !filter-out : /run/architectures/arm
+    !filter-out : /run/architectures/i386
     !filter-out : /run/architectures/ppc
     !filter-out : /run/architectures/ppc64
     ppc64le:


### PR DESCRIPTION
After updating the ubuntu versions at 11649747d3ef5834172bf2fe9c525a1927f3a6a1 the pre-release pipeline fails because ubuntu doesn't include i386, see https://github.com/avocado-framework/avocado/actions/runs/1148234681
