### PR TITLE
nrunner: introduce status server auto mode [v2]

### DIFF
--- a/examples/jobs/nrunner.py
+++ b/examples/jobs/nrunner.py
@@ -4,14 +4,9 @@ import sys
 
 from avocado.core.job import Job
 from avocado.core.suite import TestSuite
-from avocado.utils.network.ports import find_free_port
-
-status_server = '127.0.0.1:%u' % find_free_port()
 
 config = {
     'run.test_runner': 'nrunner',
-    'nrunner.status_server_listen': status_server,
-    'nrunner.status_server_uri': status_server,
     'run.references': [
         'selftests/unit/plugin/test_resolver.py',
         'selftests/functional/test_argument_parsing.py',

--- a/examples/jobs/nrunner_unix_status_server.py
+++ b/examples/jobs/nrunner_unix_status_server.py
@@ -12,6 +12,7 @@ status_server = os.path.join(status_server_dir.name, 'status_server.socket')
 
 config = {
     'run.test_runner': 'nrunner',
+    'nrunner.status_server_auto': False,
     'nrunner.status_server_listen': status_server,
     'nrunner.status_server_uri': status_server,
     'run.references': [

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -11,7 +11,6 @@ from avocado import Test
 from avocado.core import exit_codes
 from avocado.core.job import Job
 from avocado.core.suite import TestSuite
-from avocado.utils.network.ports import find_free_port
 
 BOOLEAN_ENABLED = [True, 'true', 'on', 1]
 BOOLEAN_DISABLED = [False, 'false', 'off', 0]
@@ -542,12 +541,9 @@ def create_suites(args):  # pylint: disable=W0621
     if args.functional:
         selftests.append('selftests/functional/')
 
-    status_server = '127.0.0.1:%u' % find_free_port()
     config_check = {
         'run.references': selftests,
         'run.test_runner': 'nrunner',
-        'nrunner.status_server_listen': status_server,
-        'nrunner.status_server_uri': status_server,
         'run.ignore_missing_references': True,
         'job.output.testlogs.statuses': ['FAIL']
     }

--- a/selftests/functional/plugin/test_jsonresult.py
+++ b/selftests/functional/plugin/test_jsonresult.py
@@ -1,28 +1,17 @@
 import json
 from os import path
 
-from avocado.utils import process, script
-from avocado.utils.network import find_free_port
+from avocado.utils import process
 from selftests.utils import AVOCADO, TestCaseTmpDir
 
 
 class JsonResultTest(TestCaseTmpDir):
 
-    def setUp(self):
-        super(JsonResultTest, self).setUp()
-        status_server = '127.0.0.1:%u' % find_free_port()
-        self.config_file = script.TemporaryScript(
-            'avocado.conf',
-            ("[nrunner]\n"
-             "status_server_listen = %s\n"
-             "status_server_uri = %s\n") % (status_server, status_server))
-        self.config_file.save()
-
     def test_logfile(self):
-        cmd_line = ('%s --config %s run --test-runner=nrunner '
+        cmd_line = ('%s run --test-runner=nrunner '
                     'examples/tests/failtest.py '
                     '--job-results-dir %s --disable-sysinfo ' %
-                    (AVOCADO, self.config_file.path, self.tmpdir.name))
+                    (AVOCADO, self.tmpdir.name))
         process.run(cmd_line, ignore_status=True)
         json_path = path.join(self.tmpdir.name, 'latest', 'results.json')
 
@@ -33,10 +22,10 @@ class JsonResultTest(TestCaseTmpDir):
             self.assertEqual(expected_logfile, test_data['logfile'])
 
     def test_fail_reason(self):
-        cmd_line = ('%s --config %s run --test-runner=nrunner '
+        cmd_line = ('%s run --test-runner=nrunner '
                     'examples/tests/failtest.py '
                     '--job-results-dir %s --disable-sysinfo ' %
-                    (AVOCADO, self.config_file.path, self.tmpdir.name))
+                    (AVOCADO, self.tmpdir.name))
         process.run(cmd_line, ignore_status=True)
         json_path = path.join(self.tmpdir.name, 'latest', 'results.json')
         with open(json_path, 'r') as json_file:
@@ -44,7 +33,3 @@ class JsonResultTest(TestCaseTmpDir):
             test_data = data['tests'].pop()
             self.assertEqual('This test is supposed to fail',
                              test_data['fail_reason'])
-
-    def tearDown(self):
-        super(JsonResultTest, self).tearDown()
-        self.config_file.remove()

--- a/selftests/functional/plugin/test_logs.py
+++ b/selftests/functional/plugin/test_logs.py
@@ -2,7 +2,6 @@ import os
 
 from avocado.core import exit_codes
 from avocado.utils import process, script
-from avocado.utils.network import find_free_port
 from selftests.utils import AVOCADO, BASEDIR, TestCaseTmpDir
 
 CONFIG = """[job.output.testlogs]
@@ -65,27 +64,13 @@ class TestLogsFilesUI(TestCaseTmpDir):
 
 class TestLogging(TestCaseTmpDir):
 
-    def setUp(self):
-        super(TestLogging, self).setUp()
-        status_server = '127.0.0.1:%u' % find_free_port()
-        self.config_file = script.TemporaryScript(
-            'avocado.conf',
-            ("[nrunner]\n"
-             "status_server_listen = %s\n"
-             "status_server_uri = %s\n") % (status_server, status_server))
-        self.config_file.save()
-
     def test_job_log(self):
         pass_test = os.path.join(BASEDIR, 'examples', 'tests', 'passtest.py')
-        cmd_line = ('%s --config %s run --job-results-dir %s --test-runner=nrunner %s' %
-                    (AVOCADO, self.config_file.path, self.tmpdir.name, pass_test))
+        cmd_line = ('%s run --job-results-dir %s --test-runner=nrunner %s' %
+                    (AVOCADO, self.tmpdir.name, pass_test))
         process.run(cmd_line)
         log_file = os.path.join(self.tmpdir.name, 'latest', 'job.log')
         with open(log_file, 'r') as fp:
             log = fp.read()
         self.assertIn('passtest.py:PassTest.test: STARTED', log)
         self.assertIn('passtest.py:PassTest.test: PASS', log)
-
-    def tearDown(self):
-        super(TestLogging, self).tearDown()
-        self.config_file.remove()

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -15,7 +15,6 @@ from avocado.core import exit_codes
 from avocado.utils import astring, genio
 from avocado.utils import path as utils_path
 from avocado.utils import process, script
-from avocado.utils.network import find_free_port
 from selftests.utils import (AVOCADO, BASEDIR, TestCaseTmpDir,
                              python_module_available, skipOnLevelsInferiorThan,
                              skipUnlessPathExists, temp_dir_prefix)
@@ -588,24 +587,13 @@ class RunnerOperationTest(TestCaseTmpDir):
 
 class DryRunTest(TestCaseTmpDir):
 
-    def setUp(self):
-        super(DryRunTest, self).setUp()
-        status_server = '127.0.0.1:%u' % find_free_port()
-        self.config_file = script.TemporaryScript(
-            'avocado.conf',
-            ("[nrunner]\n"
-             "status_server_listen = %s\n"
-             "status_server_uri = %s\n") % (status_server, status_server))
-        self.config_file.save()
-
     def test_dry_run(self):
         examples_path = os.path.join('examples', 'tests')
         passtest = os.path.join(examples_path, 'passtest.py')
         failtest = os.path.join(examples_path, 'failtest.py')
         gendata = os.path.join(examples_path, 'gendata.py')
-        cmd = ("%s --config %s run --test-runner=nrunner --disable-sysinfo --dry-run "
+        cmd = ("%s run --test-runner=nrunner --disable-sysinfo --dry-run "
                "--dry-run-no-cleanup --json - -- %s %s %s " % (AVOCADO,
-                                                               self.config_file.path,
                                                                passtest,
                                                                failtest,
                                                                gendata))
@@ -617,10 +605,6 @@ class DryRunTest(TestCaseTmpDir):
             test = result['tests'][i]
             self.assertEqual(test['fail_reason'],
                              u'Test cancelled due to --dry-run')
-
-    def tearDown(self):
-        super(DryRunTest, self).tearDown()
-        self.config_file.remove()
 
 
 class RunnerHumanOutputTest(TestCaseTmpDir):

--- a/selftests/functional/test_nrunner.py
+++ b/selftests/functional/test_nrunner.py
@@ -4,7 +4,6 @@ import unittest
 
 from avocado.core.job import Job
 from avocado.utils import process
-from avocado.utils.network.ports import find_free_port
 from selftests.utils import (AVOCADO, BASEDIR, TestCaseTmpDir,
                              skipUnlessPathExists)
 
@@ -14,12 +13,9 @@ RUNNER = "%s -m avocado.core.nrunner" % sys.executable
 class NRunnerFeatures(unittest.TestCase):
     @skipUnlessPathExists('/bin/false')
     def test_custom_exit_codes(self):
-        status_server = "127.0.0.1:%u" % find_free_port()
         config = {'run.references': ['/bin/false'],
                   'run.test_runner': 'nrunner',
                   'runner.exectest.exitcodes.skip': [1],
-                  'nrunner.status_server_listen': status_server,
-                  'nrunner.status_server_uri': status_server,
                   'run.keep_tmp': True}
         with Job.from_config(job_config=config) as job:
             self.assertEqual(job.run(), 0)
@@ -27,7 +23,6 @@ class NRunnerFeatures(unittest.TestCase):
     @skipUnlessPathExists('/bin/false')
     @skipUnlessPathExists('/bin/true')
     def test_failfast(self):
-        status_server = "127.0.0.1:%u" % find_free_port()
         config = {'run.references': ['/bin/true',
                                      '/bin/false',
                                      '/bin/true',
@@ -35,8 +30,6 @@ class NRunnerFeatures(unittest.TestCase):
                   'run.test_runner': 'nrunner',
                   'run.failfast': True,
                   'nrunner.shuffle': False,
-                  'nrunner.status_server_listen': status_server,
-                  'nrunner.status_server_uri': status_server,
                   'nrunner.max_parallel_tasks': 1}
         with Job.from_config(job_config=config) as job:
             self.assertEqual(job.run(), 9)

--- a/selftests/functional/test_task_timeout.py
+++ b/selftests/functional/test_task_timeout.py
@@ -1,6 +1,5 @@
 from avocado.core.job import Job
 from avocado.utils import script
-from avocado.utils.network.ports import find_free_port
 from selftests.utils import TestCaseTmpDir, skipUnlessPathExists
 
 SCRIPT_CONTENT = """#!/bin/bash
@@ -20,10 +19,7 @@ class TaskTimeOutTest(TestCaseTmpDir):
 
     @skipUnlessPathExists('/bin/sleep')
     def test_sleep_longer_timeout(self):
-        status_server = '127.0.0.1:%u' % find_free_port()
         config = {'run.references': [self.script.path],
-                  'nrunner.status_server_listen': status_server,
-                  'nrunner.status_server_uri': status_server,
                   'run.results_dir': self.tmpdir.name,
                   'run.keep_tmp': True,
                   'task.timeout.running': 2,


### PR DESCRIPTION
This introduces a mode under which the status server will set up its own "listen" and "uri" values.

The "listen" value is of course related to where the status server will be listening for status updates, from clients (tasks) which are given the "uri" value.

Instead of a TCP based socket, the auto mode defaults to using a UNIX domain socket created within the job's own directory, which better avoids clashes (no two jobs should be using the same job directory anyway).

---

Changes from v1 (#4879):
* Squashed the original two commits to avoid enable/disable switch of auto mode
* Added support for podman spawner mapping of UNIX domain sockets status server uris