### PR TITLE
Job: enforce suite name uniqueness within the scope of a job

### DIFF
--- a/avocado/core/exceptions.py
+++ b/avocado/core/exceptions.py
@@ -52,6 +52,14 @@ class JobTestSuiteEmptyError(JobTestSuiteError):
     status = "ERROR"
 
 
+class JobTestSuiteDuplicateNameError(JobTestSuiteError):
+
+    """
+    Error raised when a test suite name is not unique in a job
+    """
+    status = "ERROR"
+
+
 class JobTestSuiteReferenceResolutionError(JobTestSuiteError):
 
     """

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -138,6 +138,7 @@ class Job:
             self.config['sysinfo.collect.enabled'] = 'off'
 
         self.test_suites = test_suites or []
+        self._check_test_suite_uniqueness()
 
         #: The log directory for this job, also known as the job results
         #: directory.  If it's set to None, it means that the job results
@@ -645,6 +646,17 @@ class Job:
             self.exitcode |= exit_codes.AVOCADO_TESTS_FAIL
 
         return self.exitcode
+
+    def _check_test_suite_uniqueness(self):
+        names = []
+        for suite in self.test_suites:
+            if suite.name not in names:
+                names.append(suite.name)
+            else:
+                msg = ('Job contains multiple test suite named "%s" . Test '
+                       'suite names must be unique to guarantee that results '
+                       'will not be overwritten' % suite.name)
+                raise exceptions.JobTestSuiteDuplicateNameError(msg)
 
     def setup(self):
         """

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -4,7 +4,8 @@ import tempfile
 import unittest.mock
 
 from avocado.core import data_dir, exit_codes, job, nrunner, test
-from avocado.core.exceptions import JobBaseException
+from avocado.core.exceptions import (JobBaseException,
+                                     JobTestSuiteDuplicateNameError)
 from avocado.core.suite import TestSuite, TestSuiteStatus
 from avocado.utils import path as utils_path
 from selftests.utils import setup_avocado_loggers, temp_dir_prefix
@@ -346,6 +347,16 @@ class JobTest(unittest.TestCase):
         self.job.setup()
         self.job.run()
         self.assertEqual(self.job.result.cancelled, 2)
+
+    def test_job_duplicate_suite_names(self):
+        config = {'core.show': ['none'],
+                  'run.results_dir': self.tmpdir.name,
+                  'run.test_runner': 'nrunner'}
+        suite_config = {'run.references': ['/bin/true']}
+        suite_1 = TestSuite('suite', config=suite_config)
+        suite_2 = TestSuite('suite', config=suite_config)
+        with self.assertRaises(JobTestSuiteDuplicateNameError):
+            _ = job.Job(config, [suite_1, suite_2])
 
     def tearDown(self):
         data_dir._tmp_tracker.unittest_refresh_dir_tracker()


### PR DESCRIPTION
The test results uniqueness are guaranteed because of their unique
TestIDs, but the full result location of a test also takes into
account its suite name.

So far, there was no enforcement of unique suite names, allowing
results to be overwritten silently by tests of another suite with the
same name (if their TestIDs also match).

With this change, a very early and explicit exception will be raised,
allowing users of the Job API to fix their suite creation.

Signed-off-by: Cleber Rosa <crosa@redhat.com>