### PR TITLE
 Sysinfo support for suites

### DIFF
--- a/avocado/core/sysinfo.py
+++ b/avocado/core/sysinfo.py
@@ -26,6 +26,19 @@ log = logging.getLogger("avocado.sysinfo")
 
 
 def gather_collectibles_config(config):
+    """Gather the collectibles form sysinfo files.
+
+     Sysinfo collectibles are based on sysinfo configuration files. The path to
+     those files is in job configuration in `sysinfo.collectibles.*`.
+     This method reads those files, and it creates a dictionary with
+     configuration of collectibles.
+
+    :param config: job configuration
+    :type config: dict
+    :return: dict with commands and files for sysinfo
+    :rtype: dict
+    """
+
     sysinfo_files = {}
 
     for collectible in ['commands', 'files', 'fail_commands', 'fail_files']:


### PR DESCRIPTION
This adds sysinfo gathering into the suite run. It creates `pre` and
`post` sysinfo tasks in a suite which will be run before and after the
testing. Those tasks will gather sysinfo by `sysinfo-runner` and save it
into the `test-results` folder.

This is just a temporary solution, until  the dependency graph form [BP002](https://avocado-framework.readthedocs.io/en/90.0/blueprints/BP002.html) will be created.

Reference: #3877
Signed-off-by: Jan Richter <jarichte@redhat.com>