### PR TITLE
[utils] network/hosts: remove bonding_masters as a valid interface

### DIFF
--- a/avocado/utils/network/hosts.py
+++ b/avocado/utils/network/hosts.py
@@ -59,6 +59,9 @@ class Host:
         except Exception as ex:
             raise NWException("Failed to get interfaces: {}".format(ex))
 
+        if "bonding_masters" in names:
+            names.remove("bonding_masters")
+
         return [NetworkInterface(if_name=name, host=self) for name in names]
 
     def get_interface_by_ipaddr(self, ipaddr):


### PR DESCRIPTION
If there is a bond interface on a machine, the bonding driver will create a file
in `/sys/class/net` called `bonding_masters`. When read, the file just lists all
the bonding interfaces present in the machine. i.e. `bond0 bond1`. Therefore,
`bonding_masters` should not be considered an interface.

Signed-off-by: Cris Forno <fornosoccer12@gmail.com>