### PR TITLE
selftests: use complete example tests paths

### DIFF
--- a/optional_plugins/varianter_yaml_to_mux/tests/test_functional.py
+++ b/optional_plugins/varianter_yaml_to_mux/tests/test_functional.py
@@ -56,7 +56,7 @@ class MultiplexTests(unittest.TestCase):
 
     def test_run_mplex_passtest(self):
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
-                    'passtest.py -m '
+                    'examples/tests/passtest.py -m '
                     'examples/tests/sleeptest.py.data/sleeptest.yaml'
                     % (AVOCADO, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -70,7 +70,8 @@ class MultiplexTests(unittest.TestCase):
 
     def test_run_mplex_doublepass(self):
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
-                    'passtest.py passtest.py -m '
+                    'examples/tests/passtest.py '
+                    'examples/tests/passtest.py -m '
                     'examples/tests/sleeptest.py.data/sleeptest.yaml '
                     '--mux-path /foo/\\* /bar/\\* /baz/\\*'
                     % (AVOCADO, self.tmpdir.name))
@@ -85,32 +86,38 @@ class MultiplexTests(unittest.TestCase):
 
     def test_run_mplex_failtest(self):
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
-                    'passtest.py failtest.py -m '
+                    'examples/tests/passtest.py '
+                    'examples/tests/failtest.py -m '
                     'examples/tests/sleeptest.py.data/sleeptest.yaml'
                     % (AVOCADO, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         result = self.run_and_check(cmd_line, expected_rc, (4, 4))
-        self.assertIn(b"(1/8) passtest.py:PassTest.test;run-short-beaf", result.stdout)
-        self.assertIn(b"(2/8) passtest.py:PassTest.test;run-medium-5595", result.stdout)
-        self.assertIn(b"(8/8) failtest.py:FailTest.test;run-longest-efc4",
+        self.assertIn(b"(1/8) examples/tests/passtest.py:PassTest.test;run-short-beaf",
+                      result.stdout)
+        self.assertIn(b"(2/8) examples/tests/passtest.py:PassTest.test;run-medium-5595",
+                      result.stdout)
+        self.assertIn(b"(8/8) examples/tests/failtest.py:FailTest.test;run-longest-efc4",
                       result.stdout)
 
     def test_run_mplex_failtest_tests_per_variant(self):
         cmd_line = ("%s run --job-results-dir %s --disable-sysinfo "
-                    "passtest.py failtest.py -m "
+                    "examples/tests/passtest.py "
+                    "examples/tests/failtest.py -m "
                     "examples/tests/sleeptest.py.data/sleeptest.yaml "
                     "--execution-order tests-per-variant"
                     % (AVOCADO, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         result = self.run_and_check(cmd_line, expected_rc, (4, 4))
-        self.assertIn(b"(1/8) passtest.py:PassTest.test;run-short-beaf", result.stdout)
-        self.assertIn(b"(2/8) failtest.py:FailTest.test;run-short-beaf", result.stdout)
-        self.assertIn(b"(8/8) failtest.py:FailTest.test;run-longest-efc4",
+        self.assertIn(b"(1/8) examples/tests/passtest.py:PassTest.test;run-short-beaf",
+                      result.stdout)
+        self.assertIn(b"(2/8) examples/tests/failtest.py:FailTest.test;run-short-beaf",
+                      result.stdout)
+        self.assertIn(b"(8/8) examples/tests/failtest.py:FailTest.test;run-longest-efc4",
                       result.stdout)
 
     def test_run_double_mplex(self):
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
-                    'passtest.py -m '
+                    'examples/tests/passtest.py -m '
                     'examples/tests/sleeptest.py.data/sleeptest.yaml '
                     'examples/tests/sleeptest.py.data/sleeptest.yaml'
                     % (AVOCADO, self.tmpdir.name))
@@ -119,8 +126,8 @@ class MultiplexTests(unittest.TestCase):
 
     def test_empty_file(self):
         cmd_line = ("%s run --job-results-dir %s -m optional_plugins/"
-                    "varianter_yaml_to_mux/tests/.data/empty_file -- "
-                    "passtest.py" % (AVOCADO, self.tmpdir.name))
+                    "varianter_yaml_to_mux/tests/.data/empty_file "
+                    "-- examples/tests/passtest.py" % (AVOCADO, self.tmpdir.name))
         self.run_and_check(cmd_line, exit_codes.AVOCADO_ALL_OK, (1, 0))
 
     def test_run_mplex_params(self):

--- a/selftests/functional/plugin/test_jobscripts.py
+++ b/selftests/functional/plugin/test_jobscripts.py
@@ -87,8 +87,8 @@ class JobScriptsTest(TestCaseTmpDir):
                                         SCRIPT_NON_ZERO_CFG % self.pre_dir)
         with config:
             cmd = ('%s --config %s run --job-results-dir %s '
-                   '--disable-sysinfo passtest.py' % (AVOCADO, config,
-                                                      self.tmpdir.name))
+                   '--disable-sysinfo examples/tests/passtest.py'
+                   % (AVOCADO, config, self.tmpdir.name))
             result = process.run(cmd)
 
         # Pre/Post scripts failures do not (currently?) alter the exit status
@@ -110,8 +110,8 @@ class JobScriptsTest(TestCaseTmpDir):
                                         SCRIPT_NON_EXISTING_DIR_CFG % self.pre_dir)
         with config:
             cmd = ('%s --config %s run --job-results-dir %s '
-                   '--disable-sysinfo passtest.py' % (AVOCADO, config,
-                                                      self.tmpdir.name))
+                   '--disable-sysinfo examples/tests/passtest.py'
+                   % (AVOCADO, config, self.tmpdir.name))
             result = process.run(cmd)
 
         # Pre/Post scripts failures do not (currently?) alter the exit status

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -191,7 +191,7 @@ class RunnerOperationTest(TestCaseTmpDir):
 
     def test_runner_all_ok(self):
         cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
-                    'passtest.py passtest.py' % (AVOCADO, self.tmpdir.name))
+                    'examples/tests/passtest.py examples/tests/passtest.py' % (AVOCADO, self.tmpdir.name))
         process.run(cmd_line)
         # Also check whether jobdata contains correct parameter paths
         variants = open(os.path.join(self.tmpdir.name, "latest", "jobdata",
@@ -201,7 +201,8 @@ class RunnerOperationTest(TestCaseTmpDir):
 
     def test_runner_failfast(self):
         cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
-                    'passtest.py failtest.py passtest.py --failfast'
+                    'examples/tests/passtest.py examples/tests/failtest.py '
+                    'examples/tests/passtest.py --failfast'
                     % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         self.assertIn(b'Interrupting job (failfast).', result.stdout)
@@ -212,7 +213,7 @@ class RunnerOperationTest(TestCaseTmpDir):
 
     def test_runner_ignore_missing_references_one_missing(self):
         cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
-                    'passtest.py badtest.py --ignore-missing-references'
+                    'examples/tests/passtest.py badtest.py --ignore-missing-references'
                     % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         self.assertIn(b"Unable to resolve reference(s) 'badtest.py'", result.stderr)
@@ -307,8 +308,10 @@ class RunnerOperationTest(TestCaseTmpDir):
                           results["tests"][0]["fail_reason"])
 
     def test_runner_tests_fail(self):
-        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s passtest.py '
-                    'failtest.py passtest.py' % (AVOCADO, self.tmpdir.name))
+        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
+                    'examples/tests/passtest.py '
+                    'examples/tests/failtest.py '
+                    'examples/tests/passtest.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         self.assertEqual(result.exit_status, expected_rc,
@@ -438,7 +441,7 @@ class RunnerOperationTest(TestCaseTmpDir):
 
     def test_silent_output(self):
         cmd_line = ('%s --show=none run --disable-sysinfo --job-results-dir %s '
-                    'passtest.py' % (AVOCADO, self.tmpdir.name))
+                    'examples/tests/passtest.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
         self.assertEqual(result.stdout, b'')
@@ -468,7 +471,7 @@ class RunnerOperationTest(TestCaseTmpDir):
 
     def test_invalid_unique_id(self):
         cmd_line = ('%s run --disable-sysinfo --job-results-dir %s --force-job-id '
-                    'foobar passtest.py' % (AVOCADO, self.tmpdir.name))
+                    'foobar examples/tests/passtest.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         self.assertNotEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
         self.assertIn(b'needs to be a 40 digit hex', result.stderr)
@@ -477,7 +480,7 @@ class RunnerOperationTest(TestCaseTmpDir):
     def test_valid_unique_id(self):
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
                     '--force-job-id 975de258ac05ce5e490648dec4753657b7ccc7d1 '
-                    'passtest.py' % (AVOCADO, self.tmpdir.name))
+                    'examples/tests/passtest.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
         self.assertNotIn(b'needs to be a 40 digit hex', result.stderr)
@@ -485,7 +488,7 @@ class RunnerOperationTest(TestCaseTmpDir):
 
     def test_automatic_unique_id(self):
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
-                    'passtest.py --json -' % (AVOCADO, self.tmpdir.name))
+                    'examples/tests/passtest.py --json -' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
         r = json.loads(result.stdout_text)
@@ -611,7 +614,7 @@ class RunnerHumanOutputTest(TestCaseTmpDir):
 
     def test_output_pass(self):
         cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
-                    'passtest.py' % (AVOCADO, self.tmpdir.name))
+                    'examples/tests/passtest.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
@@ -621,13 +624,14 @@ class RunnerHumanOutputTest(TestCaseTmpDir):
 
     def test_output_fail(self):
         cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
-                    'failtest.py' % (AVOCADO, self.tmpdir.name))
+                    'examples/tests/failtest.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %d:\n%s" %
                          (expected_rc, result))
-        self.assertIn(b'failtest.py:FailTest.test:  FAIL', result.stdout)
+        self.assertIn(b'examples/tests/failtest.py:FailTest.test:  FAIL',
+                      result.stdout)
 
     def test_output_error(self):
         cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
@@ -732,7 +736,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
 
         :avocado: tags=parallel:1
         """
-        one_hundred = 'failtest.py ' * 100
+        one_hundred = 'examples/tests/failtest.py ' * 100
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s'
                     % (AVOCADO, self.tmpdir.name, one_hundred))
         initial_time = time.monotonic()
@@ -751,8 +755,9 @@ class RunnerSimpleTest(TestCaseTmpDir):
 
         :avocado: tags=parallel:1
         """
-        sleep_fail_sleep = ('sleeptest.py ' + 'failtest.py ' * 100 +
-                            'sleeptest.py')
+        sleep_fail_sleep = ('examples/tests/sleeptest.py ' +
+                            'examples/tests/failtest.py ' * 100 +
+                            'examples/tests/sleeptest.py')
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s'
                     % (AVOCADO, self.tmpdir.name, sleep_fail_sleep))
         initial_time = time.monotonic()
@@ -1207,7 +1212,7 @@ class PluginsTest(TestCaseTmpDir):
         json and xunit output files *do* make into the archive.
         """
         def run_config(config_path):
-            cmd = ('%s --config %s run passtest.py --archive '
+            cmd = ('%s --config %s run examples/tests/passtest.py --archive '
                    '--job-results-dir %s --disable-sysinfo'
                    % (AVOCADO, config_path, self.tmpdir.name))
             result = process.run(cmd, ignore_status=True)
@@ -1330,19 +1335,23 @@ class PluginsXunitTest(TestCaseTmpDir):
                          "XML:\n%s" % xml_output)
 
     def test_xunit_plugin_passtest(self):
-        self.run_and_check('passtest.py', exit_codes.AVOCADO_ALL_OK,
+        self.run_and_check('examples/tests/passtest.py',
+                           exit_codes.AVOCADO_ALL_OK,
                            1, 0, 0, 0)
 
     def test_xunit_plugin_failtest(self):
-        self.run_and_check('failtest.py', exit_codes.AVOCADO_TESTS_FAIL,
+        self.run_and_check('examples/tests/failtest.py',
+                           exit_codes.AVOCADO_TESTS_FAIL,
                            1, 0, 1, 0)
 
     def test_xunit_plugin_skiponsetuptest(self):
-        self.run_and_check('cancelonsetup.py', exit_codes.AVOCADO_ALL_OK,
+        self.run_and_check('examples/tests/cancelonsetup.py',
+                           exit_codes.AVOCADO_ALL_OK,
                            1, 0, 0, 1)
 
     def test_xunit_plugin_errortest(self):
-        self.run_and_check('errortest.py', exit_codes.AVOCADO_TESTS_FAIL,
+        self.run_and_check('examples/tests/errortest.py',
+                           exit_codes.AVOCADO_TESTS_FAIL,
                            1, 1, 0, 0)
 
 
@@ -1388,19 +1397,23 @@ class PluginsJSONTest(TestCaseTmpDir):
         return json_data
 
     def test_json_plugin_passtest(self):
-        self.run_and_check('passtest.py', exit_codes.AVOCADO_ALL_OK,
+        self.run_and_check('examples/tests/passtest.py',
+                           exit_codes.AVOCADO_ALL_OK,
                            1, 0, 0, 0)
 
     def test_json_plugin_failtest(self):
-        self.run_and_check('failtest.py', exit_codes.AVOCADO_TESTS_FAIL,
+        self.run_and_check('examples/tests/failtest.py',
+                           exit_codes.AVOCADO_TESTS_FAIL,
                            1, 0, 1, 0)
 
     def test_json_plugin_skiponsetuptest(self):
-        self.run_and_check('cancelonsetup.py', exit_codes.AVOCADO_ALL_OK,
+        self.run_and_check('examples/tests/cancelonsetup.py',
+                           exit_codes.AVOCADO_ALL_OK,
                            1, 0, 0, 0, 1)
 
     def test_json_plugin_errortest(self):
-        self.run_and_check('errortest.py', exit_codes.AVOCADO_TESTS_FAIL,
+        self.run_and_check('examples/tests/errortest.py',
+                           exit_codes.AVOCADO_TESTS_FAIL,
                            1, 1, 0, 0)
 
     @unittest.skipIf(not GNU_ECHO_BINARY, 'echo binary not available')

--- a/selftests/functional/test_json_variants.py
+++ b/selftests/functional/test_json_variants.py
@@ -37,16 +37,16 @@ class VariantsDumpLoadTests(TestCaseTmpDir):
                    '  "variant_id": "bar-d06d"}]')
         with open(self.variants_file, 'w') as file_obj:
             file_obj.write(content)
-        cmd_line = ('%s run passtest.py --json-variants-load %s '
+        cmd_line = ('%s run examples/tests/passtest.py --json-variants-load %s '
                     '--job-results-dir %s --json -' %
                     (AVOCADO, self.variants_file, self.tmpdir.name))
         result = process.run(cmd_line)
         json_result = json.loads(result.stdout_text)
         self.assertEqual(json_result["pass"], 2)
         self.assertEqual(json_result["tests"][0]["id"],
-                         "1-passtest.py:PassTest.test;foo-0ead")
+                         "1-examples/tests/passtest.py:PassTest.test;foo-0ead")
         self.assertEqual(json_result["tests"][1]["id"],
-                         "2-passtest.py:PassTest.test;bar-d06d")
+                         "2-examples/tests/passtest.py:PassTest.test;bar-d06d")
 
 
 if __name__ == '__main__':

--- a/selftests/functional/test_legacy_replay_basic.py
+++ b/selftests/functional/test_legacy_replay_basic.py
@@ -11,9 +11,10 @@ class ReplayTests(TestCaseTmpDir):
 
     def setUp(self):
         super(ReplayTests, self).setUp()
-        cmd_line = ('%s run passtest.py passtest.py passtest.py passtest.py '
-                    '--job-results-dir %s --disable-sysinfo --json -'
-                    % (AVOCADO, self.tmpdir.name))
+        cmd_line = ('%s run examples/tests/passtest.py '
+                    'examples/tests/passtest.py examples/tests/passtest.py '
+                    'examples/tests/passtest.py --job-results-dir %s '
+                    '--disable-sysinfo --json -' % (AVOCADO, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.run_and_check(cmd_line, expected_rc)
         self.jobdir = ''.join(glob.glob(os.path.join(self.tmpdir.name, 'job-*')))

--- a/selftests/functional/test_legacy_replay_failfast.py
+++ b/selftests/functional/test_legacy_replay_failfast.py
@@ -11,7 +11,8 @@ class ReplayFailfastTests(TestCaseTmpDir):
 
     def setUp(self):
         super(ReplayFailfastTests, self).setUp()
-        cmd_line = ('%s run passtest.py failtest.py passtest.py '
+        cmd_line = ('%s run examples/tests/passtest.py '
+                    'examples/tests/failtest.py examples/tests/passtest.py '
                     '--failfast --job-results-dir %s --disable-sysinfo --json -'
                     % (AVOCADO, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL | exit_codes.AVOCADO_JOB_INTERRUPTED

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -19,7 +19,11 @@ AVOCADO_QUOTED = "', '".join(shlex.split(AVOCADO))
 PERL_TAP_PARSER_SNIPPET = """#!/bin/env perl
 use TAP::Parser;
 
-my $parser = TAP::Parser->new( { exec => ['%s', 'run', 'passtest.py', 'errortest.py', 'warntest.py', '--tap', '-', '--disable-sysinfo', '--job-results-dir', '%%s'] } );
+my $parser = TAP::Parser->new( { exec => ['%s', 'run', 'examples/tests/passtest.py',
+                                          'examples/tests/errortest.py',
+                                          'examples/tests/warntest.py',
+                                          '--tap', '-', '--disable-sysinfo',
+                                          '--job-results-dir', '%%s'] } );
 
 while ( my $result = $parser->next ) {
         $result->is_unknown && die "Unknown line \\"" . $result->as_string . "\\" in the TAP output!\n";
@@ -33,7 +37,12 @@ $parser->plan eq '1..3' || die "Plan does not match what was expected!\n";
 PERL_TAP_PARSER_FAILFAST_SNIPPET = """#!/bin/env perl
 use TAP::Parser;
 
-my $parser = TAP::Parser->new( { exec => ['%s', 'run', 'failtest.py', 'errortest.py', 'warntest.py', '--tap', '-', '--failfast', '--disable-sysinfo', '--job-results-dir', '%%s'] } );
+my $parser = TAP::Parser->new( { exec => ['%s', 'run', 'examples/tests/failtest.py',
+                                          'examples/tests/errortest.py',
+                                          'examples/tests/warntest.py',
+                                          '--tap', '-', '--failfast',
+                                          '--disable-sysinfo', '--job-results-dir',
+                                          '%%s'] } );
 
 while ( my $result = $parser->next ) {
         $result->is_unknown && die "Unknown line \\"" . $result->as_string . "\\" in the TAP output!\n";
@@ -393,7 +402,8 @@ class OutputPluginTest(TestCaseTmpDir):
 
     def test_output_incompatible_setup(self):
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
-                    '--xunit - --json - passtest.py' % (AVOCADO, self.tmpdir.name))
+                    '--xunit - --json - examples/tests/passtest.py'
+                    % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_FAIL
         self.assertEqual(result.exit_status, expected_rc,
@@ -409,7 +419,7 @@ class OutputPluginTest(TestCaseTmpDir):
     def test_output_compatible_setup(self):
         tmpfile = tempfile.mktemp(dir=self.tmpdir.name)
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
-                    '--journal --xunit %s --json - passtest.py' %
+                    '--journal --xunit %s --json - examples/tests/passtest.py' %
                     (AVOCADO, self.tmpdir.name, tmpfile))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -423,7 +433,8 @@ class OutputPluginTest(TestCaseTmpDir):
     def test_output_compatible_setup_2(self):
         tmpfile = tempfile.mktemp(dir=self.tmpdir.name)
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
-                    '--xunit - --json %s --tap-include-logs passtest.py'
+                    '--xunit - --json %s --tap-include-logs '
+                    'examples/tests/passtest.py'
                     % (AVOCADO, self.tmpdir.name, tmpfile))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -443,7 +454,8 @@ class OutputPluginTest(TestCaseTmpDir):
         # Verify --show=none can be supplied as app argument
         cmd_line = ('%s --show=none run --job-results-dir %s '
                     '--disable-sysinfo --xunit %s --json %s --tap-include-logs '
-                    'passtest.py' % (AVOCADO, self.tmpdir.name, tmpfile, tmpfile2))
+                    'examples/tests/passtest.py' % (AVOCADO, self.tmpdir.name,
+                                                    tmpfile, tmpfile2))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
@@ -480,7 +492,7 @@ class OutputPluginTest(TestCaseTmpDir):
 
     def test_show_test(self):
         cmd_line = ('%s --show=test run --job-results-dir %s --disable-sysinfo '
-                    'passtest.py' % (AVOCADO, self.tmpdir.name))
+                    'examples/tests/passtest.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
@@ -496,7 +508,7 @@ class OutputPluginTest(TestCaseTmpDir):
     def test_silent_trumps_test(self):
         # Also verify --show=none can be supplied as run option
         cmd_line = ('%s --show=test --show=none run --job-results-dir %s '
-                    '--disable-sysinfo passtest.py'
+                    '--disable-sysinfo examples/tests/passtest.py'
                     % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -554,7 +566,7 @@ class OutputPluginTest(TestCaseTmpDir):
     def test_redirect_output(self):
         redirected_output_path = tempfile.mktemp(dir=self.tmpdir.name)
         cmd_line = ('%s run --job-results-dir %s '
-                    '--disable-sysinfo passtest.py > %s'
+                    '--disable-sysinfo examples/tests/passtest.py > %s'
                     % (AVOCADO, self.tmpdir.name, redirected_output_path))
         result = process.run(cmd_line, ignore_status=True, shell=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -589,7 +601,10 @@ class OutputPluginTest(TestCaseTmpDir):
             process.run("perl %s" % perl_script)
 
     def test_tap_totaltests(self):
-        cmd_line = ("%s run passtest.py passtest.py passtest.py passtest.py "
+        cmd_line = ("%s run examples/tests/passtest.py "
+                    "examples/tests/passtest.py "
+                    "examples/tests/passtest.py "
+                    "examples/tests/passtest.py "
                     "--job-results-dir %s --disable-sysinfo "
                     "--tap -" % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line)

--- a/selftests/functional/test_replay.py
+++ b/selftests/functional/test_replay.py
@@ -11,7 +11,10 @@ class ReplayTests(TestCaseTmpDir):
 
     def setUp(self):
         super(ReplayTests, self).setUp()
-        cmd_line = ('%s run passtest.py passtest.py passtest.py passtest.py '
+        cmd_line = ('%s run examples/tests/passtest.py '
+                    'examples/tests/passtest.py '
+                    'examples/tests/passtest.py '
+                    'examples/tests/passtest.py '
                     '--job-results-dir %s --disable-sysinfo --json -'
                     % (AVOCADO, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_ALL_OK

--- a/selftests/functional/test_streams.py
+++ b/selftests/functional/test_streams.py
@@ -38,10 +38,12 @@ class StreamsTest(TestCaseTmpDir):
         variable `AVOCADO_LOG_EARLY` being set.
         """
         cmds = (('%s --show early run --disable-sysinfo '
-                 '--job-results-dir %s passtest.py' % (AVOCADO, self.tmpdir.name),
+                 '--job-results-dir %s examples/tests/passtest.py'
+                 % (AVOCADO, self.tmpdir.name),
                  {}),
                 ('%s run --disable-sysinfo --job-results-dir'
-                 ' %s passtest.py' % (AVOCADO, self.tmpdir.name),
+                 ' %s examples/tests/passtest.py'
+                 % (AVOCADO, self.tmpdir.name),
                  {'AVOCADO_LOG_EARLY': 'y'}))
         for cmd, env in cmds:
             result = process.run(cmd, env=env, shell=True)
@@ -56,23 +58,24 @@ class StreamsTest(TestCaseTmpDir):
         Checks that the test stream (early in this case) goes to stdout
         """
         cmd = ('%s --show=test run --disable-sysinfo --job-results-dir %s '
-               'passtest.py' % (AVOCADO, self.tmpdir.name))
+               'examples/tests/passtest.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
         # Avocado will see the main module on the command line
         cmd_in_log = os.path.join(BASEDIR, 'avocado', '__main__.py')
         self.assertIn("Command line: %s" % cmd_in_log,
                       result.stdout_text)
-        self.assertIn(b"\nSTART 1-passtest.py:PassTest.test",
+        self.assertIn(b"\nSTART 1-examples/tests/passtest.py:PassTest.test",
                       result.stdout)
-        self.assertIn(b"PASS 1-passtest.py:PassTest.test", result.stdout)
+        self.assertIn(b"PASS 1-examples/tests/passtest.py:PassTest.test",
+                      result.stdout)
 
     def test_none_success(self):
         """
         Checks that only errors are output, and that they go to stderr
         """
         cmd = ('%s --show none run --disable-sysinfo --job-results-dir %s '
-               'passtest.py' % (AVOCADO, self.tmpdir.name))
+               'examples/tests/passtest.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
         self.assertEqual(b'', result.stdout)

--- a/selftests/functional/test_sysinfo.py
+++ b/selftests/functional/test_sysinfo.py
@@ -18,7 +18,7 @@ class SysInfoTest(TestCaseTmpDir):
 
     def test_sysinfo_enabled(self):
         cmd_line = ('%s run --job-results-dir %s '
-                    'passtest.py' % (AVOCADO, self.tmpdir.name))
+                    'examples/tests/passtest.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
@@ -45,7 +45,8 @@ class SysInfoTest(TestCaseTmpDir):
             self.assertTrue(os.path.exists(sysinfo_subdir), msg)
 
     def test_sysinfo_disabled(self):
-        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo passtest.py'
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
+                    'examples/tests/passtest.py'
                     % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line)
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -72,7 +73,7 @@ class SysInfoTest(TestCaseTmpDir):
         script.make_script(config_path,
                            COMMANDS_TIMEOUT_CONF % (timeout, commands_path))
         cmd_line = ("%s --show all --config %s run --job-results-dir %s "
-                    "passtest.py"
+                    "examples/tests/passtest.py"
                     % (AVOCADO, config_path, self.tmpdir.name))
         result = process.run(cmd_line)
         if timeout > 0:


### PR DESCRIPTION
With the upcoming switch to the nrunner, we have to take into account
the resolver behavior of requiring explicit paths (and not looking
into Avocado's "testsdir").

This replaces the test references from the implicit locations at the
"testsdir", to the explicit ones.

Signed-off-by: Cleber Rosa <crosa@redhat.com>