### PR TITLE
asset: uses an unique identifier when name is not available

### DIFF
--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -76,6 +76,8 @@ class Asset:
         self.name = name or ''
         self.asset_hash = asset_hash
 
+        self._uid = str(uuid.uuid4())
+
         if isinstance(locations, str):
             self.locations = [locations]
         else:
@@ -449,6 +451,12 @@ class Asset:
 
     @property
     def asset_name(self):
+        # When using an http url as name we have some problems. For instance:
+        # Some urls has the same name endpoint for multiple files, depending on
+        # GET parameters. So we don't have an 'unique asset identifier here'.
+        # Lets use self._uid then.
+        if self.name_scheme in ['http', 'https']:
+            return self._uid
         return os.path.basename(self.parsed_name.path)
 
     @classmethod

--- a/avocado/utils/download.py
+++ b/avocado/utils/download.py
@@ -30,7 +30,7 @@ from . import aurl, crypto, output
 log = logging.getLogger('avocado.utils.download')
 
 
-def url_open(url, data=None, timeout=5):
+def url_open(url, data=None, timeout=30):
     """
     Wrapper to :func:`urllib2.urlopen` with timeout addition.
 


### PR DESCRIPTION
If an URL is providing multiple files (depending on the GET parameters), we
will replace the asset with the previous one downloaded because we are using
the same endpoint. For instance: `https://foo.bar/download?request=jasdf8d878`.
For those cases, lets use an uuid4() as unique identifier of the asset. Fixes #4824. 
    
Signed-off-by: Beraldo Leal <bleal@redhat.com>