### PR TITLE
Revert "setup.py: fix "test disable-plugin-checks""

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -207,7 +207,7 @@ class Test(SimpleCommand):
         ("jobs", None, "Run selftests/jobs/"),
         ("functional", None, "Run selftests/functional/"),
         ("optional-plugins", None, "Run optional_plugins/*/tests/"),
-        ("disable-plugin-checks=", None, "Disable checks for a plugin (by directory name)"),
+        ("disable-plugin-checks", None, "Disable checks for a plugin (by directory name)"),
         ("list-features", None, "Show the features tested by this test")
     ]
 
@@ -219,7 +219,7 @@ class Test(SimpleCommand):
         self.jobs = False  # pylint: disable=W0201
         self.functional = False  # pylint: disable=W0201
         self.optional_plugins = False  # pylint: disable=W0201
-        self.disable_plugin_checks = None  # pylint: disable=W0201
+        self.disable_plugin_checks = []  # pylint: disable=W0201
         self.list_features = False  # pylint: disable=W0201
 
     def run(self):


### PR DESCRIPTION
This reverts commit c14edca0bf19b009b395bfe1973e2f15f89f3097.
It doesn't fix the original problem - only one plugin can be disabled -
and was breaking --static-checks

Signed-off-by: Ana Guerrero Lopez <anguerre@redhat.com>