### PR TITLE
Update vmimage test with current versions of debian image

### DIFF
--- a/selftests/pre_release/tests/vmimage.py.data/variants.yml
+++ b/selftests/pre_release/tests/vmimage.py.data/variants.yml
@@ -41,8 +41,8 @@ distro: !mux
     version: !mux
       9.13.26:
         version: 9.13.26-20210722
-      10.10.2:
-        version: 10.10.2-20210723
+      10.10.3:
+        version: 10.10.3-20210826
   fedora:
     name: fedora
     !filter-out : /run/architectures/arm


### PR DESCRIPTION
After running the pre-release actions, the debian image from openstack needs to be updated:
https://github.com/avocado-framework/avocado/runs/3442978272