### PR TITLE
Switch default runner [v2]

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -30,9 +30,9 @@ redhat_egg_task:
        - python3 setup.py bdist_egg
        - mv dist/avocado_framework-*egg /tmp
        - python3 setup.py clean --all
-       - python3 -c 'import sys; import glob; sys.path.insert(0, glob.glob("/tmp/avocado_framework-*.egg")[0]); from avocado.core.main import main; sys.exit(main())' run /bin/true
+       - python3 -c 'import sys; import glob; sys.path.insert(0, glob.glob("/tmp/avocado_framework-*.egg")[0]); from avocado.core.main import main; sys.exit(main())' run --test-runner=runner /bin/true
        - cd /tmp
-       - python3 -c 'import sys; from pkg_resources import require; require("avocado-framework"); from avocado.core.main import main; sys.exit(main())' run /bin/true
+       - python3 -c 'import sys; from pkg_resources import require; require("avocado-framework"); from avocado.core.main import main; sys.exit(main())' run --test-runner=runner /bin/true
     container:
         matrix:
           - image: fedora:33
@@ -58,9 +58,9 @@ debian_egg_task:
        - python3 setup.py bdist_egg
        - mv dist/avocado_framework-*egg /tmp
        - python3 setup.py clean --all
-       - python3 -c 'import sys; import glob; sys.path.insert(0, glob.glob("/tmp/avocado_framework-*.egg")[0]); from avocado.core.main import main; sys.exit(main())' run /bin/true
+       - python3 -c 'import sys; import glob; sys.path.insert(0, glob.glob("/tmp/avocado_framework-*.egg")[0]); from avocado.core.main import main; sys.exit(main())' run --test-runner=runner /bin/true
        - cd /tmp
-       - python3 -c 'import sys; from pkg_resources import require; require("avocado-framework"); from avocado.core.main import main; sys.exit(main())' run /bin/true
+       - python3 -c 'import sys; from pkg_resources import require; require("avocado-framework"); from avocado.core.main import main; sys.exit(main())' run --test-runner=runner /bin/true
     container:
         matrix:
           - image: debian:10.10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Avocado version
         run: avocado --version
       - name: Avocado smoketest
-        run: python -m avocado run passtest.py
+        run: python -m avocado run examples/tests/passtest.py
       - name: Tree static check, unittests and fast functional tests
         env:
           AVOCADO_LOG_DEBUG: "yes"

--- a/avocado/plugins/list.py
+++ b/avocado/plugins/list.py
@@ -234,16 +234,30 @@ class List(CLICmd):
                                  positional_arg=True)
         loader.add_loader_options(parser, 'list')
 
-        help_msg = ('What is the method used to detect tests? If --resolver '
-                    'used, Avocado will use the Next Runner Resolver method. '
-                    'If not the legacy one will be used.')
+        help_msg = ('Uses the Avocado resolver method (part of the nrunner '
+                    'architecture) to detect tests. This is enabled by '
+                    'default and exists only for compatibility purposes, '
+                    'and will be removed soon. To use the legacy (loader) '
+                    'method for finding tests, set the "--loader" option')
         settings.register_option(section='list',
-                                 key='resolver',
+                                 key='compatiblity_with_resolver_noop',
                                  key_type=bool,
-                                 default=False,
+                                 default=True,
                                  help_msg=help_msg,
                                  parser=parser,
                                  long_arg='--resolver')
+
+        help_msg = ('Uses the Avocado legacy (loader) method for finding '
+                    'tests. This option will exist only for a transitional '
+                    'period until the legacy (loader) method is deprecated '
+                    'and removed')
+        settings.register_option(section='list',
+                                 key='resolver',
+                                 key_type=bool,
+                                 default=True,
+                                 help_msg=help_msg,
+                                 parser=parser,
+                                 long_arg='--loader')
 
         help_msg = ('Writes runnable recipe files to a directory. Valid only '
                     'when using --resolver.')

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -103,11 +103,12 @@ class Run(CLICmd):
                     'installed and active implementations.  You can run '
                     '"avocado plugins" and find the list of valid runners '
                     'under the "Plugins that run test suites on a job '
-                    '(runners) section.  Defaults to "runner", which is '
-                    'the conventional and traditional runner.')
+                    '(runners) section.  Defaults to "nrunner", which is '
+                    'the new runner.  To use the conventional and traditional '
+                    'runner, use "runner".')
         settings.register_option(section='run',
                                  key='test_runner',
-                                 default='runner',
+                                 default='nrunner',
                                  help_msg=help_msg,
                                  parser=parser,
                                  long_arg='--test-runner',

--- a/docs/source/guides/contributor/chapters/plugins.rst
+++ b/docs/source/guides/contributor/chapters/plugins.rst
@@ -260,14 +260,14 @@ Resolving magic tests
 ---------------------
 
 Resolving the "pass" and "fail" references that the magic plugin knows about
-can be seen by running ``avocado list --resolver pass fail``::
+can be seen by running ``avocado list pass fail``::
 
   magic pass
   magic fail
 
 And you may get more insight into the resolution results, by adding a
 verbose parameter and another reference.  Try running ``avocado -V
-list --resolver pass fail something-else``::
+list pass fail something-else``::
 
   Type  Test Tag(s)
   magic pass
@@ -310,9 +310,9 @@ tests is through a command starting with ``avocado
 run --test-runner=nrunner``.
 
 To run both the ``pass`` and ``fail`` magic tests, you'd run
-``avocado run --test-runner=nrunner -- pass fail``::
+``avocado run -- pass fail``::
 
-  $ avocado run --test-runner=nrunner -- pass fail
+  $ avocado run -- pass fail
   JOB ID     : 86fd45f8c1f2fe766c252eefbcac2704c2106db9
   JOB LOG    : $HOME/avocado/job-results/job-2021-02-05T12.43-86fd45f/job.log
    (1/2) pass: STARTED

--- a/man/avocado.rst
+++ b/man/avocado.rst
@@ -87,8 +87,9 @@ Options for subcommand `run` (`avocado run --help`)::
                             installed and active implementations. You can run
                             "avocado plugins" and find the list of valid runners
                             under the "Plugins that run test suites on a job
-                            (runners) section. Defaults to "runner", which is the
-                            conventional and traditional runner.
+                            (runners) section. Defaults to "nrunner", which is the
+                            new runner. To use the conventional and traditional
+                            runner, use "runner".
       -d, --dry-run         Instead of running the test only list them and log
                             their params.
       --dry-run-no-cleanup  Do not automatically clean up temporary directories
@@ -364,9 +365,15 @@ Options for subcommand `list` (`avocado list --help`)::
 
     optional arguments:
       -h, --help            show this help message and exit
-      --resolver            What is the method used to detect tests? If --resolver
-                            used, Avocado will use the Next Runner Resolver
-                            method. If not the legacy one will be used.
+      --resolver            Uses the Avocado resolver method (part of the nrunner
+                            architecture) to detect tests. This is enabled by
+                            default and exists only for compatibility purposes,
+                            and will be removed soon. To use the legacy (loader)
+                            method for finding tests, set the "--loader" option
+      --loader              Uses the Avocado legacy (loader) method for finding
+                            tests. This option will exist only for a transitional
+                            period until the legacy (loader) method is deprecated
+                            and removed
       --write-recipes-to-directory DIRECTORY
                             Writes runnable recipe files to a directory. Valid
                             only when using --resolver.

--- a/optional_plugins/html/tests/test_html_result.py
+++ b/optional_plugins/html/tests/test_html_result.py
@@ -17,8 +17,8 @@ class HtmlResultTest(unittest.TestCase):
     def test_sysinfo_html_output(self):
         html_output = "{}/output.html".format(self.tmpdir.name)
         cmd_line = ('{} run --html {} --job-results-dir {} '
-                    'passtest.py'.format(AVOCADO, html_output,
-                                         self.tmpdir.name))
+                    'examples/tests/passtest.py'.format(AVOCADO, html_output,
+                                                        self.tmpdir.name))
         result = process.run(cmd_line)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,

--- a/optional_plugins/varianter_yaml_to_mux/tests/test_functional.py
+++ b/optional_plugins/varianter_yaml_to_mux/tests/test_functional.py
@@ -199,7 +199,9 @@ class DryRun(unittest.TestCase):
         cmd = ("%s run --disable-sysinfo --dry-run --dry-run-no-cleanup --json - "
                "--mux-inject foo:1 bar:2 baz:3 foo:foo:a "
                "foo:bar:b foo:baz:c bar:bar:bar "
-               "-- passtest.py failtest.py gendata.py " % AVOCADO)
+               "-- examples/tests/passtest.py "
+               "examples/tests/failtest.py "
+               "examples/tests/gendata.py " % AVOCADO)
         number_of_tests = 3
         result = json.loads(process.run(cmd).stdout_text)
         log = ''

--- a/optional_plugins/varianter_yaml_to_mux/tests/test_functional.py
+++ b/optional_plugins/varianter_yaml_to_mux/tests/test_functional.py
@@ -136,6 +136,7 @@ class MultiplexTests(unittest.TestCase):
                             ('/run/long', 'This is very long\nmultiline\ntext.')):
             variant, msg = variant_msg
             cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
+                        '--test-runner=runner '
                         'examples/tests/env_variables.sh '
                         '-m examples/tests/env_variables.sh.data/env_variables.yaml '
                         '--mux-filter-only %s'
@@ -197,6 +198,7 @@ class DryRun(unittest.TestCase):
 
     def test_dry_run(self):
         cmd = ("%s run --disable-sysinfo --dry-run --dry-run-no-cleanup --json - "
+               "--test-runner=runner "
                "--mux-inject foo:1 bar:2 baz:3 foo:foo:a "
                "foo:bar:b foo:baz:c bar:bar:bar "
                "-- examples/tests/passtest.py "

--- a/selftests/functional/plugin/test_diff.py
+++ b/selftests/functional/plugin/test_diff.py
@@ -4,7 +4,7 @@ import tempfile
 import unittest
 
 from avocado.core import exit_codes
-from avocado.utils import process, script
+from avocado.utils import process
 from selftests.utils import AVOCADO, BASEDIR, TestCaseTmpDir
 
 
@@ -12,20 +12,17 @@ class DiffTests(TestCaseTmpDir):
 
     def setUp(self):
         super(DiffTests, self).setUp()
-        test = script.make_script(os.path.join(self.tmpdir.name, 'test'), 'exit 0')
-        cmd_line = ('%s run %s '
-                    '--external-runner /bin/bash '
+        cmd_line = ('%s run examples/tests/passtest.py '
                     '--job-results-dir %s --disable-sysinfo --json -' %
-                    (AVOCADO, test, self.tmpdir.name))
+                    (AVOCADO, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.run_and_check(cmd_line, expected_rc)
         self.jobdir = ''.join(glob.glob(os.path.join(self.tmpdir.name, 'job-*')))
 
         self.tmpdir2 = tempfile.TemporaryDirectory(prefix=self.tmpdir.name)
-        cmd_line = ('%s run %s '
-                    '--external-runner /bin/bash '
+        cmd_line = ('%s run examples/tests/warntest.py '
                     '--job-results-dir %s --disable-sysinfo --json -' %
-                    (AVOCADO, test, self.tmpdir2.name))
+                    (AVOCADO, self.tmpdir2.name))
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.run_and_check(cmd_line, expected_rc)
         self.jobdir2 = ''.join(glob.glob(os.path.join(self.tmpdir2.name, 'job-*')))

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -549,16 +549,23 @@ class RunnerOperationTest(TestCaseTmpDir):
                          % result)
 
     def test_runner_test_parameters(self):
-        cmd_line = ('%s --show=test run --disable-sysinfo --job-results-dir %s '
+        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
                     '-p "sleep_length=0.01" -- examples/tests/sleeptest.py '
                     % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %d:\n%s" % (expected_rc, result))
+
+        json_path = os.path.join(self.tmpdir.name, 'latest', 'results.json')
+        with open(json_path) as json_file:
+            result_json = json.load(json_file)
+        with open(result_json['tests'][0]['logfile'], 'r+b') as test_log_file:
+            test_log = test_log_file.read()
+
         self.assertIn(b"PARAMS (key=sleep_length, path=*, default=1) => '0.01'",
-                      result.stdout)
-        self.assertIn(b"Sleeping for 0.01 seconds", result.stdout)
+                      test_log)
+        self.assertIn(b"Sleeping for 0.01 seconds", test_log)
 
     def test_other_loggers(self):
         with script.TemporaryScript(

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -253,6 +253,7 @@ class RunnerOperationTest(TestCaseTmpDir):
                                     UNSUPPORTED_STATUS_TEST_CONTENTS,
                                     "avocado_unsupported_status") as tst:
             res = process.run("%s run --disable-sysinfo --job-results-dir %s %s"
+                              " --test-runner=runner"
                               " --json -" % (AVOCADO, self.tmpdir.name, tst),
                               ignore_status=True)
             self.assertEqual(res.exit_status, exit_codes.AVOCADO_TESTS_FAIL)
@@ -273,6 +274,7 @@ class RunnerOperationTest(TestCaseTmpDir):
                                     REPORTS_STATUS_AND_HANG,
                                     "hanged_test_with_status") as tst:
             res = process.run("%s run --disable-sysinfo --job-results-dir %s %s "
+                              "--test-runner=runner "
                               "--json - --job-timeout 1" % (AVOCADO, self.tmpdir.name, tst),
                               ignore_status=True)
             self.assertEqual(res.exit_status, exit_codes.AVOCADO_TESTS_FAIL)
@@ -295,6 +297,7 @@ class RunnerOperationTest(TestCaseTmpDir):
                                     DIE_WITHOUT_REPORTING_STATUS,
                                     "no_status_reported") as tst:
             res = process.run("%s run --disable-sysinfo --job-results-dir %s %s "
+                              "--test-runner=runner "
                               "--json -" % (AVOCADO, self.tmpdir.name, tst),
                               ignore_status=True)
             self.assertEqual(res.exit_status, exit_codes.AVOCADO_TESTS_FAIL)
@@ -400,6 +403,7 @@ class RunnerOperationTest(TestCaseTmpDir):
                                RAISE_CUSTOM_PATH_EXCEPTION_CONTENT)
         mytest.save()
         result = process.run("%s --show test run --disable-sysinfo "
+                             "--test-runner=runner "
                              "--job-results-dir %s %s"
                              % (AVOCADO, self.tmpdir.name, mytest))
         self.assertIn(b"mytest.py:SharedLibTest.test -> CancelExc: This "
@@ -432,6 +436,7 @@ class RunnerOperationTest(TestCaseTmpDir):
         :avocado: tags=parallel:1
         """
         cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
+                    '--test-runner=runner '
                     '--xunit - examples/tests/abort.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         excerpt = b'Test died without reporting the status.'
@@ -458,16 +463,17 @@ class RunnerOperationTest(TestCaseTmpDir):
                       result.stderr)
 
     def test_empty_test_list(self):
-        cmd_line = '%s run --disable-sysinfo --job-results-dir %s' \
-                   % (AVOCADO, self.tmpdir.name)
+        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s'
+                    '--test-runner=runner ' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_JOB_FAIL)
         self.assertIn(b'No test references provided nor any other arguments '
                       b'resolved into tests', result.stderr)
 
     def test_not_found(self):
-        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s sbrubles'
-                    % (AVOCADO, self.tmpdir.name))
+        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
+                    '--test-runner=runner '
+                    'sbrubles' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_JOB_FAIL)
         self.assertIn(b'Unable to resolve reference', result.stderr)
@@ -526,7 +532,9 @@ class RunnerOperationTest(TestCaseTmpDir):
         test = script.make_script(os.path.join(self.tmpdir.name, 'test.py'),
                                   INVALID_PYTHON_TEST)
         cmd_line = ('%s --show test run --disable-sysinfo '
-                    '--job-results-dir %s %s') % (AVOCADO, self.tmpdir.name, test)
+                    '--job-results-dir %s '
+                    '--test-runner=runner '
+                    '%s') % (AVOCADO, self.tmpdir.name, test)
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         self.assertEqual(result.exit_status, expected_rc,
@@ -575,6 +583,7 @@ class RunnerOperationTest(TestCaseTmpDir):
                 'avocado_functional_test_other_loggers') as mytest:
 
             cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
+                        '--test-runner=runner '
                         '-- %s' % (AVOCADO, self.tmpdir.name, mytest))
             result = process.run(cmd_line, ignore_status=True)
             expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -671,6 +680,7 @@ class RunnerHumanOutputTest(TestCaseTmpDir):
     def test_ugly_echo_cmd(self):
         cmd_line = ('%s --show=test run --external-runner "%s -ne" '
                     '"foo\\\\\\n\\\'\\\\\\"\\\\\\nbar/baz" --job-results-dir %s'
+                    ' --test-runner=runner '
                     ' --disable-sysinfo' %
                     (AVOCADO, GNU_ECHO_BINARY, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
@@ -699,6 +709,7 @@ class RunnerHumanOutputTest(TestCaseTmpDir):
         result = json.loads(result.stdout_text)
         jobid = str(result["job_id"])
         cmd = ("%s run --job-results-dir %s --replay %s "
+               "--test-runner=runner "
                "--replay-test-status PASS" % (AVOCADO, self.tmpdir.name, jobid))
         process.run(cmd)
 
@@ -791,6 +802,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
         # access to an installed location for the libexec scripts
         os.environ['PATH'] += ":" + os.path.join(BASEDIR, 'libexec')
         cmd_line = ('%s --show=test run --job-results-dir %s --disable-sysinfo '
+                    '--test-runner=runner '
                     'examples/tests/simplewarning.sh'
                     % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
@@ -817,6 +829,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
                            "[sysinfo.collectibles]\ncommands = %s"
                            % commands_path)
         cmd_line = ("%s --show all --config %s run --job-results-dir %s "
+                    "--test-runner=runner "
                     "--external-runner %s -- \"'\\\"\\/|?*<>'\""
                     % (AVOCADO, config_path, self.tmpdir.name, GNU_ECHO_BINARY))
         process.run(cmd_line)
@@ -848,6 +861,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
         os.chdir(test_base_dir)
         test_file_name = os.path.basename(self.pass_script.path)
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo'
+                    ' --test-runner=runner'
                     ' "%s"' % (AVOCADO, self.tmpdir.name,
                                test_file_name))
         result = process.run(cmd_line, ignore_status=True)
@@ -864,6 +878,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
         :avocado: tags=parallel:1
         """
         proc = aexpect.Expect("%s run 60 --job-results-dir %s "
+                              "--test-runner=runner "
                               "--external-runner %s --disable-sysinfo "
                               "--job-timeout 3"
                               % (AVOCADO, self.tmpdir.name, SLEEP_BINARY))
@@ -933,6 +948,7 @@ class RunnerSimpleTestStatus(TestCaseTmpDir):
                                              'functional')
         warn_script.save()
         cmd_line = ('%s --config %s run --job-results-dir %s --disable-sysinfo'
+                    ' --test-runner=runner'
                     ' %s --json -' % (AVOCADO, self.config_file.path,
                                       self.tmpdir.name, warn_script.path))
         result = process.run(cmd_line, ignore_status=True)
@@ -946,6 +962,7 @@ class RunnerSimpleTestStatus(TestCaseTmpDir):
                                              'functional')
         skip_script.save()
         cmd_line = ('%s --config %s run --job-results-dir %s --disable-sysinfo'
+                    ' --test-runner=runner'
                     ' %s --json -' % (AVOCADO, self.config_file.path,
                                       self.tmpdir.name, skip_script.path))
         result = process.run(cmd_line, ignore_status=True)
@@ -959,6 +976,7 @@ class RunnerSimpleTestStatus(TestCaseTmpDir):
                                               'functional')
         skip2_script.save()
         cmd_line = ('%s --config %s run --job-results-dir %s --disable-sysinfo'
+                    ' --test-runner=runner'
                     ' %s --json -' % (AVOCADO, self.config_file.path,
                                       self.tmpdir.name, skip2_script.path))
         result = process.run(cmd_line, ignore_status=True)
@@ -1007,6 +1025,7 @@ class RunnerSimpleTestFailureFields(TestCaseTmpDir):
     def test_simpletest_failure_fields(self):
         fail_test = os.path.join(BASEDIR, 'examples', 'tests', 'failtest.sh')
         cmd_line = ('%s --config %s run --job-results-dir %s --disable-sysinfo'
+                    ' --test-runner=runner'
                     ' -- %s' % (AVOCADO, self.config_file.path,
                                 self.tmpdir.name, fail_test))
         result = process.run(cmd_line, ignore_status=True)
@@ -1037,6 +1056,7 @@ class ExternalRunnerTest(TestCaseTmpDir):
 
     def test_externalrunner_pass(self):
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
+                    '--test-runner=runner '
                     '--external-runner=/bin/sh %s'
                     % (AVOCADO, self.tmpdir.name, self.pass_script.path))
         result = process.run(cmd_line, ignore_status=True)
@@ -1047,6 +1067,7 @@ class ExternalRunnerTest(TestCaseTmpDir):
 
     def test_externalrunner_fail(self):
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
+                    '--test-runner=runner '
                     '--external-runner=/bin/sh %s'
                     % (AVOCADO, self.tmpdir.name, self.fail_script.path))
         result = process.run(cmd_line, ignore_status=True)
@@ -1057,6 +1078,7 @@ class ExternalRunnerTest(TestCaseTmpDir):
 
     def test_externalrunner_chdir_no_testdir(self):
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
+                    '--test-runner=runner '
                     '--external-runner=/bin/sh --external-runner-chdir=test %s'
                     % (AVOCADO, self.tmpdir.name, self.pass_script.path))
         result = process.run(cmd_line, ignore_status=True)
@@ -1073,6 +1095,7 @@ class ExternalRunnerTest(TestCaseTmpDir):
         pass_abs = os.path.abspath(self.pass_script.path)
         os.chdir('/')
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
+                    '--test-runner=runner '
                     '--external-runner=bin/sh --external-runner-chdir=runner -- %s'
                     % (AVOCADO, self.tmpdir.name, pass_abs))
         result = process.run(cmd_line, ignore_status=True)
@@ -1083,6 +1106,7 @@ class ExternalRunnerTest(TestCaseTmpDir):
 
     def test_externalrunner_no_url(self):
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
+                    '--test-runner=runner '
                     '--external-runner=%s' % (AVOCADO, self.tmpdir.name, TRUE_CMD))
         result = process.run(cmd_line, ignore_status=True)
         expected_output = (b'No test references provided nor any other '
@@ -1301,6 +1325,7 @@ class PluginsXunitTest(TestCaseTmpDir):
     def run_and_check(self, testname, e_rc, e_ntests, e_nerrors,
                       e_nfailures, e_nskip):
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo'
+                    ' --test-runner=runner'
                     ' --xunit - %s' % (AVOCADO, self.tmpdir.name, testname))
         result = process.run(cmd_line, ignore_status=True)
         xml_output = result.stdout
@@ -1374,8 +1399,9 @@ class PluginsJSONTest(TestCaseTmpDir):
 
     def run_and_check(self, testname, e_rc, e_ntests, e_nerrors,
                       e_nfailures, e_nskip, e_ncancel=0, external_runner=None):
-        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo --json - '
-                    '--archive %s' % (AVOCADO, self.tmpdir.name, testname))
+        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
+                    '--test-runner=runner '
+                    '--json - --archive %s' % (AVOCADO, self.tmpdir.name, testname))
         if external_runner is not None:
             cmd_line += " --external-runner '%s'" % external_runner
         result = process.run(cmd_line, ignore_status=True)

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -408,8 +408,12 @@ class RunnerOperationTest(TestCaseTmpDir):
 
     def test_runner_timeout(self):
         cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
-                    '--xunit - timeouttest.py' % (AVOCADO, self.tmpdir.name))
+                    'examples/tests/timeouttest.py'
+                    % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
+        json_path = os.path.join(self.tmpdir.name, 'latest', 'results.json')
+        with open(json_path) as json_file:
+            result_json = json.load(json_file)
         output = result.stdout
         expected_rc = exit_codes.AVOCADO_JOB_INTERRUPTED
         unexpected_rc = exit_codes.AVOCADO_FAIL
@@ -417,8 +421,7 @@ class RunnerOperationTest(TestCaseTmpDir):
                             "Avocado crashed (rc %d):\n%s" % (unexpected_rc, result))
         self.assertEqual(result.exit_status, expected_rc,
                          "Avocado did not return rc %d:\n%s" % (expected_rc, result))
-        self.assertIn(b"Runner error occurred: Timeout reached", output,
-                      "Timeout reached message not found in the output:\n%s" % output)
+        self.assertIn("timeout", result_json["tests"][0]["fail_reason"])
         # Ensure no test aborted error messages show up
         self.assertNotIn(b"TestAbortError: Test aborted unexpectedly", output)
 

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -216,7 +216,6 @@ class RunnerOperationTest(TestCaseTmpDir):
                     'examples/tests/passtest.py badtest.py --ignore-missing-references'
                     % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
-        self.assertIn(b"Unable to resolve reference(s) 'badtest.py'", result.stderr)
         self.assertIn(b'PASS 1 | ERROR 0 | FAIL 0 | SKIP 0', result.stdout)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
@@ -227,8 +226,6 @@ class RunnerOperationTest(TestCaseTmpDir):
                     'badtest.py badtest2.py --ignore-missing-references'
                     % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
-        self.assertIn(b"Unable to resolve reference(s) 'badtest.py', 'badtest2.py'",
-                      result.stderr)
         self.assertIn(b'Suite is empty. There is no tests to run.', result.stderr)
         expected_rc = exit_codes.AVOCADO_FAIL
         self.assertEqual(result.exit_status, expected_rc,

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -326,8 +326,8 @@ class RunnerOperationTest(TestCaseTmpDir):
                          "Avocado did not return rc %d:\n%s" % (expected_rc, result))
 
     def test_runner_doublefail(self):
-        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
-                    '--xunit - doublefail.py' % (AVOCADO, self.tmpdir.name))
+        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s --xunit - '
+                    'examples/tests/doublefail.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         unexpected_rc = exit_codes.AVOCADO_FAIL
@@ -342,7 +342,8 @@ class RunnerOperationTest(TestCaseTmpDir):
 
     def test_uncaught_exception(self):
         cmd_line = ("%s run --disable-sysinfo --job-results-dir %s "
-                    "--json - uncaught_exception.py" % (AVOCADO, self.tmpdir.name))
+                    "--json - examples/tests/uncaught_exception.py"
+                    % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         self.assertEqual(result.exit_status, expected_rc,
@@ -352,7 +353,8 @@ class RunnerOperationTest(TestCaseTmpDir):
 
     def test_fail_on_exception(self):
         cmd_line = ("%s run --disable-sysinfo --job-results-dir %s "
-                    "--json - fail_on_exception.py" % (AVOCADO, self.tmpdir.name))
+                    "--json - examples/tests/fail_on_exception.py"
+                    % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         self.assertEqual(result.exit_status, expected_rc,
@@ -362,7 +364,8 @@ class RunnerOperationTest(TestCaseTmpDir):
 
     def test_cancel_on_exception(self):
         cmd_line = ("%s run --disable-sysinfo --job-results-dir %s "
-                    "--json - cancel_on_exception.py" % (AVOCADO, self.tmpdir.name))
+                    "--json - examples/tests/cancel_on_exception.py"
+                    % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
@@ -374,7 +377,7 @@ class RunnerOperationTest(TestCaseTmpDir):
 
     def test_assert_raises(self):
         cmd_line = ("%s run --disable-sysinfo --job-results-dir %s "
-                    "-- assert.py" % (AVOCADO, self.tmpdir.name))
+                    "-- examples/tests/assert.py" % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         self.assertEqual(result.exit_status, expected_rc,
@@ -425,7 +428,7 @@ class RunnerOperationTest(TestCaseTmpDir):
         :avocado: tags=parallel:1
         """
         cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
-                    '--xunit - abort.py' % (AVOCADO, self.tmpdir.name))
+                    '--xunit - examples/tests/abort.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         excerpt = b'Test died without reporting the status.'
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
@@ -544,8 +547,8 @@ class RunnerOperationTest(TestCaseTmpDir):
 
     def test_runner_test_parameters(self):
         cmd_line = ('%s --show=test run --disable-sysinfo --job-results-dir %s '
-                    '-p "sleep_length=0.01" -- sleeptest.py ' % (AVOCADO,
-                                                                 self.tmpdir.name))
+                    '-p "sleep_length=0.01" -- examples/tests/sleeptest.py '
+                    % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
@@ -576,8 +579,8 @@ class RunnerOperationTest(TestCaseTmpDir):
 
     def test_store_logging_stream(self):
         cmd = ("%s run --job-results-dir %s --store-logging-stream=progress "
-               "--disable-sysinfo -- logging_streams.py" % (AVOCADO,
-                                                            self.tmpdir.name))
+               "--disable-sysinfo -- examples/tests/logging_streams.py"
+               % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
 
@@ -632,7 +635,7 @@ class RunnerHumanOutputTest(TestCaseTmpDir):
 
     def test_output_error(self):
         cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
-                    'errortest.py' % (AVOCADO, self.tmpdir.name))
+                    'examples/tests/errortest.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         self.assertEqual(result.exit_status, expected_rc,
@@ -642,7 +645,7 @@ class RunnerHumanOutputTest(TestCaseTmpDir):
 
     def test_output_cancel(self):
         cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
-                    'cancelonsetup.py' % (AVOCADO, self.tmpdir.name))
+                    'examples/tests/cancelonsetup.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
@@ -680,7 +683,7 @@ class RunnerHumanOutputTest(TestCaseTmpDir):
 
     def test_replay_skip_skipped(self):
         cmd = ("%s run --job-results-dir %s --json - "
-               "cancelonsetup.py" % (AVOCADO, self.tmpdir.name))
+               "examples/tests/cancelonsetup.py" % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd)
         result = json.loads(result.stdout_text)
         jobid = str(result["job_id"])

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -615,7 +615,7 @@ class DryRunTest(TestCaseTmpDir):
         passtest = os.path.join(examples_path, 'passtest.py')
         failtest = os.path.join(examples_path, 'failtest.py')
         gendata = os.path.join(examples_path, 'gendata.py')
-        cmd = ("%s run --test-runner=nrunner --disable-sysinfo --dry-run "
+        cmd = ("%s run --disable-sysinfo --dry-run "
                "--dry-run-no-cleanup --json - -- %s %s %s " % (AVOCADO,
                                                                passtest,
                                                                failtest,
@@ -1146,13 +1146,14 @@ class PluginsTest(TestCaseTmpDir):
                          result.stdout)
 
     def test_list_error_output(self):
-        cmd_line = '%s list sbrubles' % AVOCADO
+        cmd_line = '%s list --loader sbrubles' % AVOCADO
         result = process.run(cmd_line, ignore_status=True)
         self.assertIn(b"Unable to resolve reference", result.stderr)
 
     def test_list_no_file_loader(self):
-        cmd_line = ("%s --verbose list --loaders external -- "
-                    "this-wont-be-matched" % AVOCADO)
+        cmd_line = ("%s --verbose list --loaders external "
+                    "--loader "
+                    "-- this-wont-be-matched" % AVOCADO)
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK,
                          "Avocado did not return rc %d:\n%s"
@@ -1171,8 +1172,9 @@ class PluginsTest(TestCaseTmpDir):
         """
         test = script.make_script(os.path.join(self.tmpdir.name, 'test.py'),
                                   VALID_PYTHON_TEST_WITH_TAGS)
-        cmd_line = ("%s --verbose list --loaders file -- %s" % (AVOCADO,
-                                                                test))
+        cmd_line = ("%s --verbose list "
+                    "--loader "
+                    "--loaders file -- %s" % (AVOCADO, test))
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK,
                          "Avocado did not return rc %d:\n%s"

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -202,7 +202,8 @@ class RunnerOperationTest(TestCaseTmpDir):
     def test_runner_failfast(self):
         cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
                     'examples/tests/passtest.py examples/tests/failtest.py '
-                    'examples/tests/passtest.py --failfast'
+                    'examples/tests/passtest.py --failfast '
+                    '--nrunner-max-parallel-tasks=1'
                     % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         self.assertIn(b'Interrupting job (failfast).', result.stdout)

--- a/selftests/functional/test_export_variables.py
+++ b/selftests/functional/test_export_variables.py
@@ -36,6 +36,7 @@ class EnvironmentVariablesTest(TestCaseTmpDir):
     def test_environment_vars(self):
         os.chdir(BASEDIR)
         cmd_line = ('%s run --job-results-dir %s %s'
+                    ' --test-runner=runner'
                     % (AVOCADO, self.tmpdir.name, self.script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK

--- a/selftests/functional/test_fetch_asset.py
+++ b/selftests/functional/test_fetch_asset.py
@@ -61,9 +61,11 @@ class FetchAsset(unittest.TestCase):
         test_file.close()
 
         expected_rc = exit_codes.AVOCADO_ALL_OK
-        cmd_line = "%s --config %s run %s " % (AVOCADO,
-                                               self.config_file.name,
-                                               test_file.name)
+        cmd_line = ("%s --config %s run "
+                    "--test-runner=runner "
+                    "%s" % (AVOCADO,
+                            self.config_file.name,
+                            test_file.name))
         result = process.run(cmd_line)
         os.remove(localpath)
         self.assertEqual(expected_rc, result.exit_status)
@@ -92,9 +94,11 @@ class FetchAsset(unittest.TestCase):
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         expected_stdout = "not found in the cache"
 
-        cmd_line = "%s --config %s run %s " % (AVOCADO,
-                                               self.config_file.name,
-                                               test_file.name)
+        cmd_line = ("%s --config %s run "
+                    "--test-runner=runner "
+                    "%s" % (AVOCADO,
+                            self.config_file.name,
+                            test_file.name))
 
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(expected_rc, result.exit_status)
@@ -123,9 +127,11 @@ class FetchAsset(unittest.TestCase):
         expected_rc = exit_codes.AVOCADO_ALL_OK
         expected_stdout = "Missing asset"
 
-        cmd_line = "%s --config %s run %s " % (AVOCADO,
-                                               self.config_file.name,
-                                               test_file.name)
+        cmd_line = ("%s --config %s run "
+                    "--test-runner=runner "
+                    "%s" % (AVOCADO,
+                            self.config_file.name,
+                            test_file.name))
 
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(expected_rc, result.exit_status)
@@ -153,9 +159,11 @@ class FetchAsset(unittest.TestCase):
         expected_rc = exit_codes.AVOCADO_ALL_OK
         expected_stdout = "Missing asset"
 
-        cmd_line = "%s --config %s run %s " % (AVOCADO,
-                                               self.config_file.name,
-                                               test_file.name)
+        cmd_line = ("%s --config %s run "
+                    "--test-runner=runner "
+                    "%s " % (AVOCADO,
+                             self.config_file.name,
+                             test_file.name))
 
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(expected_rc, result.exit_status)

--- a/selftests/functional/test_getdata.py
+++ b/selftests/functional/test_getdata.py
@@ -20,6 +20,7 @@ class GetData(TestCaseTmpDir):
         test_variants_path = os.path.join(BASEDIR, "selftests", ".data",
                                           "get_data.py.data", "get_data.json")
         cmd_line = ("%s run --disable-sysinfo --job-results-dir '%s' "
+                    "--test-runner=runner "
                     "--json-variants-load %s -- %s")
         cmd_line %= (AVOCADO, self.tmpdir.name, test_variants_path, test_path)
         result = process.run(cmd_line)

--- a/selftests/functional/test_interrupt.py
+++ b/selftests/functional/test_interrupt.py
@@ -112,8 +112,9 @@ class InterruptTest(TestCaseTmpDir):
         bad_test.save()
         self.test_module = bad_test.path
         os.chdir(BASEDIR)
-        cmd = ('%s run %s --disable-sysinfo --job-results-dir %s ' %
-               (AVOCADO, self.test_module, self.tmpdir.name))
+        cmd = ('%s run %s --disable-sysinfo --job-results-dir %s '
+               '--test-runner=runner'
+               % (AVOCADO, self.test_module, self.tmpdir.name))
         proc = subprocess.Popen(cmd.split(),
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.STDOUT)

--- a/selftests/functional/test_job_timeout.py
+++ b/selftests/functional/test_job_timeout.py
@@ -103,12 +103,14 @@ class JobTimeOutTest(TestCaseTmpDir):
     def test_sleep_longer_timeout(self):
         """:avocado: tags=parallel:1"""
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
+                    '--test-runner=runner '
                     '--xunit - --job-timeout=5 %s examples/tests/passtest.py' %
                     (AVOCADO, self.tmpdir.name, self.script.path))
         self.run_and_check(cmd_line, 0, 2, 0, 0, 0)
 
     def test_sleep_short_timeout(self):
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
+                    '--test-runner=runner '
                     '--xunit - --job-timeout=1 %s examples/tests/passtest.py' %
                     (AVOCADO, self.tmpdir.name, self.script.path))
         self.run_and_check(cmd_line, exit_codes.AVOCADO_JOB_INTERRUPTED,
@@ -117,6 +119,7 @@ class JobTimeOutTest(TestCaseTmpDir):
 
     def test_sleep_short_timeout_with_test_methods(self):
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
+                    '--test-runner=runner '
                     '--xunit - --job-timeout=1 %s' %
                     (AVOCADO, self.tmpdir.name, self.py.path))
         self.run_and_check(cmd_line, exit_codes.AVOCADO_JOB_INTERRUPTED,

--- a/selftests/functional/test_json_variants.py
+++ b/selftests/functional/test_json_variants.py
@@ -38,6 +38,7 @@ class VariantsDumpLoadTests(TestCaseTmpDir):
         with open(self.variants_file, 'w') as file_obj:
             file_obj.write(content)
         cmd_line = ('%s run examples/tests/passtest.py --json-variants-load %s '
+                    '--test-runner=runner '
                     '--job-results-dir %s --json -' %
                     (AVOCADO, self.variants_file, self.tmpdir.name))
         result = process.run(cmd_line)

--- a/selftests/functional/test_legacy_replay_basic.py
+++ b/selftests/functional/test_legacy_replay_basic.py
@@ -135,6 +135,7 @@ class ReplayTests(TestCaseTmpDir):
         """
         cmd_line = ('%s run --replay %s --replay-test-status '
                     'FAIL --job-results-dir %s --disable-sysinfo'
+                    ' --test-runner=runner'
                     % (AVOCADO, self.jobid, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_ALL_OK
         result = self.run_and_check(cmd_line, expected_rc)

--- a/selftests/functional/test_legacy_replay_external_runner.py
+++ b/selftests/functional/test_legacy_replay_external_runner.py
@@ -14,6 +14,7 @@ class ReplayExtRunnerTests(TestCaseTmpDir):
         test = script.make_script(os.path.join(self.tmpdir.name, 'test'), 'exit 0')
         cmd_line = ('%s run %s '
                     '--external-runner /bin/bash '
+                    '--test-runner=runner '
                     '--job-results-dir %s --disable-sysinfo --json -'
                     % (AVOCADO, test, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -33,6 +34,7 @@ class ReplayExtRunnerTests(TestCaseTmpDir):
     def test_run_replay_external_runner(self):
         cmd_line = ('%s run --replay %s '
                     '--external-runner /bin/sh '
+                    '--test-runner=runner '
                     '--job-results-dir %s --disable-sysinfo'
                     % (AVOCADO, self.jobid, self.tmpdir.name))
         expected_rc = exit_codes.AVOCADO_ALL_OK

--- a/selftests/functional/test_list.py
+++ b/selftests/functional/test_list.py
@@ -8,7 +8,7 @@ from selftests.utils import AVOCADO, BASEDIR
 
 class List(unittest.TestCase):
 
-    list_command = 'list'
+    list_command = 'list --loader'
 
     def test_list_filter_by_tags(self):
         examples_dir = os.path.join(BASEDIR, 'examples', 'tests')

--- a/selftests/functional/test_loader.py
+++ b/selftests/functional/test_loader.py
@@ -146,7 +146,7 @@ class LoaderTestFunctional(TestCaseTmpDir):
                                              'avocado_loader_test',
                                              mode=mode)
         test_script.save()
-        cmd_line = ('%s -V list %s' % (AVOCADO, test_script.path))
+        cmd_line = ('%s -V list --loader %s' % (AVOCADO, test_script.path))
         result = process.run(cmd_line)
         self.assertIn('%s: %s' % (exp_str, count), result.stdout_text)
         test_script.remove()
@@ -191,7 +191,7 @@ class LoaderTestFunctional(TestCaseTmpDir):
                                              'avocado_loader_test',
                                              mode=self.MODE_0664)
         test_script.save()
-        cmd_line = ('%s -V list %s' % (AVOCADO, test_script.path))
+        cmd_line = ('%s -V list --loader %s' % (AVOCADO, test_script.path))
         initial_time = time.monotonic()
         result = process.run(cmd_line, ignore_status=True)
         test_script.remove()
@@ -233,7 +233,7 @@ class LoaderTestFunctional(TestCaseTmpDir):
             AVOCADO_SIMPLE_PYTHON_LIKE_MULTIPLE_FILES)
         os.chdir(BASEDIR)
         mytest.save()
-        cmd_line = "%s -V list %s" % (AVOCADO, mytest)
+        cmd_line = "%s -V list --loader %s" % (AVOCADO, mytest)
         result = process.run(cmd_line)
         self.assertIn(b'simple: 1', result.stdout)
         # job should be able to finish under 5 seconds. If this fails, it's
@@ -290,7 +290,7 @@ class LoaderTestFunctional(TestCaseTmpDir):
         Check whether the subtests filter works for both INSTRUMENTED
         and SIMPLE in a directory list.
         """
-        cmd = "%s list examples/tests/:fail" % AVOCADO
+        cmd = "%s list --loader examples/tests/:fail" % AVOCADO
         result = process.run(cmd)
         expected = (b"INSTRUMENTED examples/tests/assert.py:Assert.test_fails_to_raise\n"
                     b"INSTRUMENTED examples/tests/doublefail.py:DoubleFail.test\n"

--- a/selftests/functional/test_loader.py
+++ b/selftests/functional/test_loader.py
@@ -238,8 +238,9 @@ class LoaderTestFunctional(TestCaseTmpDir):
         self.assertIn(b'simple: 1', result.stdout)
         # job should be able to finish under 5 seconds. If this fails, it's
         # possible that we hit the "simple test fork bomb" bug
-        cmd_line = ("%s run --disable-sysinfo --job-results-dir '%s' -- '%s'"
-                    % (AVOCADO, self.tmpdir.name, mytest))
+        cmd_line = ("%s run --disable-sysinfo --job-results-dir '%s' "
+                    "--test-runner=runner "
+                    "-- '%s'" % (AVOCADO, self.tmpdir.name, mytest))
         self._run_with_timeout(cmd_line, 5)
 
     @skipOnLevelsInferiorThan(2)
@@ -254,14 +255,16 @@ class LoaderTestFunctional(TestCaseTmpDir):
         os.chdir(BASEDIR)
         # job should be able to finish under 5 seconds. If this fails, it's
         # possible that we hit the "simple test fork bomb" bug
-        cmd_line = ("%s run --disable-sysinfo --job-results-dir '%s' -- '%s'"
-                    % (AVOCADO, self.tmpdir.name, mytest))
+        cmd_line = ("%s run --disable-sysinfo --job-results-dir '%s' "
+                    "--test-runner=runner "
+                    "-- '%s'" % (AVOCADO, self.tmpdir.name, mytest))
         self._run_with_timeout(cmd_line, 5)
 
     def test_python_unittest(self):
         test_path = os.path.join(BASEDIR, "selftests", ".data", "unittests.py")
-        cmd = ("%s run --disable-sysinfo --job-results-dir %s --json - -- %s"
-               % (AVOCADO, self.tmpdir.name, test_path))
+        cmd = ("%s run --disable-sysinfo --job-results-dir %s --json - "
+               "--test-runner=runner "
+               "-- %s" % (AVOCADO, self.tmpdir.name, test_path))
         result = process.run(cmd, ignore_status=True)
         jres = json.loads(result.stdout_text)
         self.assertEqual(result.exit_status, 1, result)
@@ -308,14 +311,15 @@ class LoaderTestFunctional(TestCaseTmpDir):
         test_script.save()
 
         cmd = ("%s run --loaders=FOO "
+               "--test-runner=runner "
                "--external-runner=/bin/sh %s") % (AVOCADO, test_script.path)
         result = process.run(cmd)
         expected_warning = ("The loaders and external-runner are incompatible."
                             "The values in loaders will be ignored.")
         self.assertIn(expected_warning, result.stderr_text)
 
-        cmd = "%s run --external-runner=/bin/sh %s" % (AVOCADO,
-                                                       test_script.path)
+        cmd = ("%s run --external-runner=/bin/sh %s "
+               "--test-runner=runner" % (AVOCADO, test_script.path))
         result = process.run(cmd)
         self.assertNotIn(expected_warning, result.stderr_text)
 

--- a/selftests/functional/test_nrunner.py
+++ b/selftests/functional/test_nrunner.py
@@ -180,7 +180,7 @@ class TaskRun(unittest.TestCase):
 class ResolveSerializeRun(TestCaseTmpDir):
     @skipUnlessPathExists('/bin/true')
     def test(self):
-        cmd = "%s list --resolver --write-recipes-to-directory=%s -- /bin/true"
+        cmd = "%s list --write-recipes-to-directory=%s -- /bin/true"
         cmd %= (AVOCADO, self.tmpdir.name)
         res = process.run(cmd)
         self.assertEqual(b'exec-test /bin/true\n', res.stdout)

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -164,6 +164,7 @@ class PassTest(Test):
 
 if __name__ == '__main__':
     config = {'run.references': [__file__],
+              'run.test_runner': 'nrunner',
               'core.show': ['app']}
     suite = TestSuite.from_config(config)
     with Job(config, [suite]) as j:
@@ -348,10 +349,11 @@ class OutputTest(TestCaseTmpDir):
         """
         with script.Script(os.path.join(self.tmpdir.name, "test_show.py"),
                            OUTPUT_SHOW_TEST, script.READ_ONLY_MODE) as test:
-            cmd = "%s run --disable-sysinfo -- %s" % (AVOCADO, test.path)
+            cmd = ("%s run --test-runner=nrunner --disable-sysinfo -- %s"
+                   % (AVOCADO, test.path))
             result = process.run(cmd)
-            expected_job_id_number = 2
-            expected_bin_true_number = 1
+            expected_job_id_number = 1
+            expected_bin_true_number = 0
             job_id_number = result.stdout_text.count('JOB ID')
             bin_true_number = result.stdout_text.count('/bin/true')
             self.assertEqual(expected_job_id_number, job_id_number)

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -353,8 +353,7 @@ class OutputTest(TestCaseTmpDir):
         """
         with script.Script(os.path.join(self.tmpdir.name, "test_show.py"),
                            OUTPUT_SHOW_TEST, script.READ_ONLY_MODE) as test:
-            cmd = ("%s run --test-runner=nrunner --disable-sysinfo -- %s"
-                   % (AVOCADO, test.path))
+            cmd = "%s run --disable-sysinfo -- %s" % (AVOCADO, test.path)
             result = process.run(cmd)
             expected_job_id_number = 1
             expected_bin_true_number = 0

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -218,7 +218,7 @@ class OutputTest(TestCaseTmpDir):
                      "C compiler is required by the underlying doublefree.py test")
     def test_output_doublefree(self):
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
-                    'doublefree.py' % (AVOCADO, self.tmpdir.name))
+                    'examples/tests/doublefree.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         output = result.stdout + result.stderr
@@ -524,7 +524,8 @@ class OutputPluginTest(TestCaseTmpDir):
                    % os.path.relpath(self.tmpdir.name, "."))
         script.Script(config, content).save()
         cmd_line = ('%s --config %s --show all run '
-                    '--job-results-dir %s --disable-sysinfo whiteboard.py '
+                    '--job-results-dir %s --disable-sysinfo '
+                    'examples/tests/whiteboard.py '
                     '--json %s' % (AVOCADO, config, self.tmpdir.name, tmpfile))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -542,7 +543,7 @@ class OutputPluginTest(TestCaseTmpDir):
     def test_gendata(self):
         tmpfile = tempfile.mktemp(dir=self.tmpdir.name)
         cmd_line = ("%s run --job-results-dir %s "
-                    "--disable-sysinfo gendata.py --json %s" %
+                    "--disable-sysinfo examples/tests/gendata.py --json %s" %
                     (AVOCADO, self.tmpdir.name, tmpfile))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -253,6 +253,7 @@ class OutputTest(TestCaseTmpDir):
                              OUTPUT_TEST_CONTENT)
         test.save()
         result = process.run("%s run --job-results-dir %s --disable-sysinfo "
+                             "--test-runner=runner "
                              "--json - -- %s" % (AVOCADO, self.tmpdir.name, test))
         res = json.loads(result.stdout_text)
         joblog = res["debuglog"]
@@ -279,6 +280,7 @@ class OutputTest(TestCaseTmpDir):
         # But this change will come later
         result = process.run("%s run --job-results-dir %s --disable-sysinfo "
                              "--output-check-record=combined "
+                             "--test-runner=runner "
                              "--json - -- %s" % (AVOCADO, self.tmpdir.name, test))
         res = json.loads(result.stdout_text)
         testdir = res["tests"][0]["logdir"]
@@ -303,6 +305,7 @@ class OutputTest(TestCaseTmpDir):
                            OUTPUT_MODE_NONE_CONTENT,
                            script.READ_ONLY_MODE) as test:
             command = ("%s run --job-results-dir %s --disable-sysinfo "
+                       "--test-runner=runner "
                        "--json - --output-check-record none -- %s") % (AVOCADO,
                                                                        self.tmpdir.name,
                                                                        test.path)
@@ -327,6 +330,7 @@ class OutputTest(TestCaseTmpDir):
                            OUTPUT_CHECK_ON_OFF_CONTENT,
                            script.READ_ONLY_MODE) as test:
             command = ("%s run --job-results-dir %s --disable-sysinfo "
+                       "--test-runner=runner "
                        "--json - -- %s") % (AVOCADO, self.tmpdir.name, test.path)
             result = process.run(command)
             res = json.loads(result.stdout_text)
@@ -476,6 +480,7 @@ class OutputPluginTest(TestCaseTmpDir):
         cmd_line = ("%s run --external-runner /bin/ls "
                     "'NON_EXISTING_FILE_WITH_NONPRINTABLE_CHARS_IN_HERE\x1b' "
                     "--job-results-dir %s --disable-sysinfo --tap-include-logs"
+                    " --test-runner=runner"
                     % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd_line, ignore_status=True)
         output = result.stdout_text + result.stderr_text
@@ -545,6 +550,7 @@ class OutputPluginTest(TestCaseTmpDir):
     def test_gendata(self):
         tmpfile = tempfile.mktemp(dir=self.tmpdir.name)
         cmd_line = ("%s run --job-results-dir %s "
+                    "--test-runner=runner "
                     "--disable-sysinfo examples/tests/gendata.py --json %s" %
                     (AVOCADO, self.tmpdir.name, tmpfile))
         result = process.run(cmd_line, ignore_status=True)

--- a/selftests/functional/test_output_check.py
+++ b/selftests/functional/test_output_check.py
@@ -140,6 +140,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
 
     def _check_output_record_all(self):
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
+                    '--test-runner=runner '
                     '--output-check-record all'
                     % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
@@ -156,6 +157,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
 
     def _check_output_record_combined(self):
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
+                    '--test-runner=runner '
                     '--output-check-record combined'
                     % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
@@ -178,6 +180,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
 
     def test_output_record_none(self):
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
+                    '--test-runner=runner '
                     '--output-check-record none'
                     % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
@@ -190,6 +193,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
 
     def test_output_record_stdout(self):
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
+                    '--test-runner=runner '
                     '--output-check-record stdout'
                     % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
@@ -206,6 +210,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
     def test_output_record_and_check(self):
         self._check_output_record_all()
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s'
+                    ' --test-runner=runner'
                     % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -216,6 +221,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
     def test_output_record_and_check_combined(self):
         self._check_output_record_combined()
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s'
+                    ' --test-runner=runner'
                     % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -230,6 +236,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
         with open(stdout_file, 'wb') as stdout_file_obj:
             stdout_file_obj.write(tampered_msg)
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s --xunit -'
+                    ' --test-runner=runner'
                     % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
@@ -245,6 +252,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
         with open(output_file, 'wb') as output_file_obj:
             output_file_obj.write(tampered_msg)
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s --xunit -'
+                    ' --test-runner=runner'
                     % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
@@ -267,6 +275,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
             stderr_file_obj.write(tampered_msg_stderr)
 
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s --json -'
+                    ' --test-runner=runner'
                     % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
@@ -310,6 +319,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
             stdout_file_obj.write(tampered_msg)
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
                     '--disable-output-check --xunit -'
+                    ' --test-runner=runner'
                     % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -326,6 +336,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
         with open(simple_test, 'w') as file_obj:
             file_obj.write(TEST_WITH_SAME_EXPECTED_OUTPUT)
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
+                    '--test-runner=runner '
                     '--output-check-record both --json-variants-load %s' %
                     (AVOCADO, self.tmpdir.name, simple_test, variants_file))
         process.run(cmd_line, ignore_status=True)
@@ -336,6 +347,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
         simple_test, variants_file = self._setup_simple_test(
             TEST_WITH_DIFFERENT_EXPECTED_OUTPUT)
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
+                    '--test-runner=runner '
                     '--output-check-record both --json-variants-load %s' %
                     (AVOCADO, self.tmpdir.name, simple_test, variants_file))
         process.run(cmd_line, ignore_status=True)
@@ -350,6 +362,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
         simple_test, variants_file = self._setup_simple_test(
             TEST_WITH_DIFFERENT_EXPECTED_OUTPUT_VARIANTS)
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
+                    '--test-runner=runner '
                     '--output-check-record both --json-variants-load %s' %
                     (AVOCADO, self.tmpdir.name, simple_test, variants_file))
         process.run(cmd_line, ignore_status=True)
@@ -366,6 +379,7 @@ class RunnerSimpleTest(TestCaseTmpDir):
         simple_test, variants_file = self._setup_simple_test(
             TEST_WITH_DIFFERENT_AND_SAME_EXPECTED_OUTPUT)
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
+                    '--test-runner=runner '
                     '--output-check-record both --json-variants-load %s' %
                     (AVOCADO, self.tmpdir.name, simple_test, variants_file))
         process.run(cmd_line, ignore_status=True)

--- a/selftests/functional/test_resolver.py
+++ b/selftests/functional/test_resolver.py
@@ -24,7 +24,7 @@ class ResolverFunctional(unittest.TestCase):
         name = 'executable-test'
         with script.TemporaryScript(name, EXEC_TEST,
                                     name, self.MODE_0775) as test_file:
-            cmd_line = ('%s --verbose list --resolver %s' % (AVOCADO, test_file.path))
+            cmd_line = ('%s --verbose list %s' % (AVOCADO, test_file.path))
             result = process.run(cmd_line)
         self.assertIn('exec-test: 1', result.stdout_text)
 
@@ -32,7 +32,7 @@ class ResolverFunctional(unittest.TestCase):
         name = 'executable-test'
         with script.TemporaryScript(name, EXEC_TEST,
                                     name, self.MODE_0664) as test_file:
-            cmd_line = ('%s list --resolver %s' % (AVOCADO, test_file.path))
+            cmd_line = ('%s list %s' % (AVOCADO, test_file.path))
             result = process.run(cmd_line)
         self.assertNotIn('exec-test ', result.stdout_text)
 
@@ -40,7 +40,7 @@ class ResolverFunctional(unittest.TestCase):
         name = 'passtest.py'
         with script.TemporaryScript(name, AVOCADO_INSTRUMENTED_TEST,
                                     name, self.MODE_0664) as test_file:
-            cmd_line = ('%s --verbose list --resolver %s' % (AVOCADO, test_file.path))
+            cmd_line = ('%s --verbose list %s' % (AVOCADO, test_file.path))
             result = process.run(cmd_line)
         self.assertIn('passtest.py:PassTest.test', result.stdout_text)
         self.assertIn('avocado-instrumented: 1', result.stdout_text)

--- a/selftests/functional/test_statuses.py
+++ b/selftests/functional/test_statuses.py
@@ -131,8 +131,9 @@ class TestStatuses(TestCaseTmpDir):
                                                  ".data",
                                                  'test_statuses.py'))
 
-        cmd = ('%s run %s --disable-sysinfo --job-results-dir %s --json -' %
-               (AVOCADO, test_file, self.tmpdir.name))
+        cmd = ('%s run %s --disable-sysinfo --job-results-dir %s --json - '
+               '--test-runner=runner '
+               % (AVOCADO, test_file, self.tmpdir.name))
 
         results = process.run(cmd, ignore_status=True)
         self.results = json.loads(results.stdout_text)

--- a/selftests/functional/test_streams.py
+++ b/selftests/functional/test_streams.py
@@ -58,6 +58,7 @@ class StreamsTest(TestCaseTmpDir):
         Checks that the test stream (early in this case) goes to stdout
         """
         cmd = ('%s --show=test run --disable-sysinfo --job-results-dir %s '
+               '--test-runner=runner '
                'examples/tests/passtest.py' % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)

--- a/selftests/functional/test_wrapper.py
+++ b/selftests/functional/test_wrapper.py
@@ -46,6 +46,7 @@ class WrapperTest(TestCaseTmpDir):
     def test_global_wrapper(self):
         os.chdir(BASEDIR)
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo --wrapper %s '
+                    '--test-runner=runner '
                     'examples/tests/datadir.py'
                     % (AVOCADO, self.tmpdir.name, self.script.path))
         result = process.run(cmd_line, ignore_status=True)
@@ -63,6 +64,7 @@ class WrapperTest(TestCaseTmpDir):
     def test_process_wrapper(self):
         os.chdir(BASEDIR)
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
+                    '--test-runner=runner '
                     '--wrapper %s:*/datadir examples/tests/datadir.py'
                     % (AVOCADO, self.tmpdir.name, self.script.path))
         result = process.run(cmd_line, ignore_status=True)
@@ -80,6 +82,7 @@ class WrapperTest(TestCaseTmpDir):
     def test_both_wrappers(self):
         os.chdir(BASEDIR)
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo --wrapper %s '
+                    '--test-runner=runner '
                     '--wrapper %s:*/datadir examples/tests/datadir.py'
                     % (AVOCADO, self.tmpdir.name, self.dummy.path,
                        self.script.path))


### PR DESCRIPTION
This switches the default runner from the legacy (AKA "runner") to the new runner (AKA "nrunner"), and the accompanying legacy "loader" to the new "resolver".

A reasonable number of features are kept being tested under the legacy runner, because they are either only applicable to the legacy runner or there are known caveats about nrunner.

Closes: https://github.com/avocado-framework/avocado/issues/4802

---

Changes from v1 (#4905):
* Drop commit that adds `datadir` file transfer via messages
* Changes test `functional/test_output.py:OutputPluginTest.test_gendata` to use the legacy runner due to the previous point