### PR TITLE
nrunner: fix nrunner test_interrupt processes

### DIFF
--- a/selftests/functional/test_interrupt.py
+++ b/selftests/functional/test_interrupt.py
@@ -201,7 +201,7 @@ class InterruptTest(TestCaseTmpDir):
         good_test.save()
         self.test_module = good_test.path
         os.chdir(BASEDIR)
-        cmd = ('%s run %s --disable-sysinfo --job-results-dir %s ' %
+        cmd = ('%s run --test-runner=runner %s --disable-sysinfo --job-results-dir %s ' %
                (AVOCADO, self.test_module, self.tmpdir.name))
         proc = subprocess.Popen(cmd.split(),
                                 stdout=subprocess.PIPE,


### PR DESCRIPTION
nrunners does not support yet this kind of operation because of its
architecture.

Signed-off-by: Beraldo Leal <bleal@redhat.com>