### PR TITLE
nrunner: update all runner classes as entrypoints

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -419,6 +419,14 @@ if __name__ == '__main__':
                   ('avocado-instrumented = avocado.core.'
                    'runners.avocado_instrumented:AvocadoInstrumentedTestRunner'),
                   'tap = avocado.core.runners.tap:TAPRunner',
+                  'noop = avocado.core.nrunner:NoOpRunner',
+                  'dry-run = avocado.core.nrunner:DryRunRunner',
+                  'exec = avocado.core.nrunner:ExecRunner',
+                  'exec-test = avocado.core.nrunner:ExecTestRunner',
+                  'python-unittest = avocado.core.nrunner:PythonUnittestRunner',
+                  'requirement-asset = avocado.core.runners.requirement_asset:RequirementAssetRunner',
+                  'requirement-package = avocado.core.runners.requirement_package:RequirementPackageRunner',
+                  'sysinfo = avocado.core.runners.sysinfo:SysinfoRunner',
                   ],
               'avocado.plugins.spawner': [
                   'process = avocado.plugins.spawners.process:ProcessSpawner',


### PR DESCRIPTION
On a system that has setuptools (which is an Avocado dependency, but
not, at this point, an "avocado.core.nrunner" dependency), it's
possible to find runner classes based on setuptools' entrypoints.

This adds all the missing classes' entrypoints.

Signed-off-by: Cleber Rosa <crosa@redhat.com>

---

This should fix CI jobs such as the ones in https://github.com/avocado-framework/avocado-vt/pull/3201 .