### PR TITLE
debug.log tag change

### DIFF
--- a/avocado/core/messages.py
+++ b/avocado/core/messages.py
@@ -284,7 +284,7 @@ class LogMessageHandler(BaseRunningMessageHandler):
              'time': 18405.55351474}
     """
 
-    _tag = b'[debug] '
+    _tag = b'[stdlog] '
 
     def handle(self, message, task, job):
         """Logs a textual message to a file.


### PR DESCRIPTION
The tag `[debug]`, for log messages inside `debug.log` file, might be
confused with logging level `DEBUG` by users. Let's change the tag to
`[stdlog]`.

Reference: #4925
Signed-off-by: Jan Richter <jarichte@redhat.com>