### PR TITLE
GH Actions: remove unnecessary nrunner related options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,10 +109,10 @@ jobs:
           python setup.py develop --user
       - name: Show avocado help
         run: python -m avocado --help
-      - name: nrunner example test
-        run: python -m avocado run --test-runner=nrunner examples/tests/passtest.py
-      - name: resolver test
-        run: python -m avocado --verbose list --resolver selftests/unit/* selftests/functional/* selftests/*sh
+      - name: Example test
+        run: python -m avocado run examples/tests/passtest.py
+      - name: List test
+        run: python -m avocado --verbose list selftests/unit/* selftests/functional/* selftests/*sh
       # This test is known NOT to work
       #- name: unittest test
       #  run: python -m unittest discover -v selftests.unit
@@ -144,8 +144,8 @@ jobs:
         run: python setup.py develop --user
       - name: Show avocado help
         run: python -m avocado --help
-      - name: nrunner example test
-        run: python -m avocado run --test-runner=nrunner examples\tests\passtest.py
+      - name: Example test
+        run: python -m avocado run examples\tests\passtest.py
       - run: echo "🥑 This job's status is ${{ job.status }}."
 
 

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -46,9 +46,9 @@ jobs:
       - name: Avocado smoketest legacy runner
         run: avocado run --test-runner=runner examples/tests/passtest.py
       - name: Avocado smoketest
-        run: avocado run --test-runner=nrunner examples/tests/passtest.py
+        run: avocado run examples/tests/passtest.py
       - name: Avocado two tests
-        run: avocado run --test-runner=nrunner /usr/bin/true examples/tests/passtest.py
+        run: avocado run /usr/bin/true examples/tests/passtest.py
       - run: echo "🥑 This job's status is ${{ job.status }}."
 
 
@@ -88,9 +88,9 @@ jobs:
       - name: Avocado smoketest legacy runner
         run: avocado run --test-runner=runner examples/tests/passtest.py
       - name: Avocado smoketest
-        run: avocado run --test-runner=nrunner examples/tests/passtest.py
+        run: avocado run examples/tests/passtest.py
       - name: Avocado two tests
-        run: avocado run --test-runner=nrunner /usr/bin/true examples/tests/passtest.py
+        run: avocado run /usr/bin/true examples/tests/passtest.py
       - run: echo "🥑 This job's status is ${{ job.status }}."
 
 
@@ -122,7 +122,7 @@ jobs:
       - name: Avocado smoketest legacy runner
         run: avocado run --test-runner=runner examples/tests/passtest.py
       - name: Avocado smoketest
-        run: avocado run --test-runner=nrunner examples/tests/passtest.py
+        run: avocado run examples/tests/passtest.py
       - name: Avocado build manpage
         run: python3 setup.py man
       - name: Tree static check, unittests and fast functional tests
@@ -160,7 +160,7 @@ jobs:
       - name: Avocado smoketest legacy runner
         run: avocado run --test-runner=runner examples/tests/passtest.py
       - name: Avocado smoketest
-        run: avocado run --test-runner=nrunner examples/tests/passtest.py
+        run: avocado run examples/tests/passtest.py
       - name: Avocado build manpage
         run: python3 setup.py man
       - name: Tree static check, unittests and fast functional tests
@@ -199,7 +199,7 @@ jobs:
          python3 setup.py plugin --install=varianter_yaml_to_mux
          avocado --version
          avocado run --test-runner=runner examples/tests/passtest.py
-         avocado run --test-runner=nrunner examples/tests/passtest.py
+         avocado run examples/tests/passtest.py
          deactivate
       - run: echo "🥑 This job's status is ${{ job.status }}."
 
@@ -224,7 +224,7 @@ jobs:
          python3 setup.py develop
          avocado --version
          avocado run --test-runner=runner examples/tests/passtest.py
-         avocado run --test-runner=nrunner examples/tests/passtest.py
+         avocado run examples/tests/passtest.py
          python3 setup.py test
          deactivate
       - run: echo "🥑 This job's status is ${{ job.status }}."


### PR DESCRIPTION
Now with nrunner as the default runner implementation, resolver and
explicit nrunner options are no longer necessary.

Signed-off-by: Cleber Rosa <crosa@redhat.com>