### PR TITLE
CI/ci.yml: save more artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,13 @@ jobs:
           AVOCADO_LOG_DEBUG: "yes"
           AVOCADO_CHECK_LEVEL: "1"
         run: make check
+      - name: Archive failed tests logs
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: linux-logs-${{ matrix.python-version }}
+          path: /home/runner/avocado/job-results/
+          retention-days: 1
       - run: echo "🥑 This job's status is ${{ job.status }}."
 
   code-coverage:
@@ -174,4 +181,10 @@ jobs:
       run: python -m build
     - name: Build eggs
       run: python setup.py bdist_egg
+    - name: Save eggs as artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: egg-${{ matrix.python-version }}
+        path: /home/runner/work/avocado/avocado/dist/
+        retention-days: 1
     - run: echo "🥑 This job's status is ${{ job.status }}."


### PR DESCRIPTION
Save the logs if the tests fail.
Keep the Python Eggs as artifacts in case we want to test them.

Signed-off-by: Ana Guerrero Lopez <anguerre@redhat.com>