### PR TITLE
Ansible deployment updates after switching to nrunner

### DIFF
--- a/selftests/deployment/roles/avocado/tasks/rpm/plugins.yml
+++ b/selftests/deployment/roles/avocado/tasks/rpm/plugins.yml
@@ -12,8 +12,18 @@
 
 - name: Install the Avocado VT plugin using RPM
   dnf:
+    name: python3-avocado-vt
+    state: latest
+  when:
+    - ansible_facts['distribution_file_variety'] == "RedHat"
+    - avocado_vt|default(false)|bool == true
+    - method == 'official'
+
+- name: Install the Avocado VT plugin using RPM
+  dnf:
     name: python3-avocado-plugins-vt
     state: latest
   when:
     - ansible_facts['distribution_file_variety'] == "RedHat"
     - avocado_vt|default(false)|bool == true
+    - method == 'copr'

--- a/selftests/deployment/roles/tests/tasks/main.yml
+++ b/selftests/deployment/roles/tests/tasks/main.yml
@@ -16,7 +16,7 @@
 
 # PATH Workaround needed by method=pip, taken from https://github.com/avocado-framework/avocado-vt/pull/3204
 - name: Avocado-VT test 3/5 - dry-run execution
-  shell: "PATH={{ temporary_dir.path | default('/usr') }}/bin/:$PATH {{ temporary_dir.path | default('/usr') }}/bin/avocado run --dry-run -- boot"
+  shell: "PATH={{ temporary_dir.path | default('/usr') }}/bin/:$PATH {{ temporary_dir.path | default('/usr') }}/bin/avocado run --dry-run -- io-github-autotest-qemu.boot"
   changed_when: false
   when:
     - ansible_facts['distribution_file_variety'] == "RedHat"
@@ -30,7 +30,7 @@
 
 # PATH Workaround needed by method=pip, taken from https://github.com/avocado-framework/avocado-vt/pull/3204
 - name: Avocado-VT test 5/5 - boot and migrate execution
-  shell: "PATH={{ temporary_dir.path | default('/usr') }}/bin/:$PATH {{ temporary_dir.path | default('/usr') }}/bin/avocado run --vt-extra-params='nettype=user' -- boot migrate.default.tcp.default"
+  shell: "PATH={{ temporary_dir.path | default('/usr') }}/bin/:$PATH {{ temporary_dir.path | default('/usr') }}/bin/avocado run --vt-extra-params='nettype=user' -- io-github-autotest-qemu.boot type_specific.io-github-autotest-qemu.migrate.default.tcp.default"
   changed_when: false
   when:
     - ansible_facts['distribution_file_variety'] == "RedHat"

--- a/selftests/deployment/roles/tests/tasks/main.yml
+++ b/selftests/deployment/roles/tests/tasks/main.yml
@@ -14,8 +14,9 @@
     - ansible_facts['distribution_file_variety'] == "RedHat"
     - avocado_vt|default(false)|bool == true
 
+# PATH Workaround needed by method=pip, taken from https://github.com/avocado-framework/avocado-vt/pull/3204
 - name: Avocado-VT test 3/5 - dry-run execution
-  shell: "{{ temporary_dir.path | default('/usr') }}/bin/avocado run --dry-run -- boot"
+  shell: "PATH={{ temporary_dir.path | default('/usr') }}/bin/:$PATH {{ temporary_dir.path | default('/usr') }}/bin/avocado run --dry-run -- boot"
   changed_when: false
   when:
     - ansible_facts['distribution_file_variety'] == "RedHat"
@@ -27,8 +28,9 @@
     - ansible_facts['distribution_file_variety'] == "RedHat"
     - avocado_vt|default(false)|bool == true
 
+# PATH Workaround needed by method=pip, taken from https://github.com/avocado-framework/avocado-vt/pull/3204
 - name: Avocado-VT test 5/5 - boot and migrate execution
-  shell: "{{ temporary_dir.path | default('/usr') }}/bin/avocado run --vt-extra-params='nettype=user' -- boot migrate.default.tcp.default"
+  shell: "PATH={{ temporary_dir.path | default('/usr') }}/bin/:$PATH {{ temporary_dir.path | default('/usr') }}/bin/avocado run --vt-extra-params='nettype=user' -- boot migrate.default.tcp.default"
   changed_when: false
   when:
     - ansible_facts['distribution_file_variety'] == "RedHat"


### PR DESCRIPTION
Three updates:
* we have different names for the avocado-vt package: python3-avocado-plugins-vt in copr and python3-avocado-vt in "official". Handle this while we it solved.
* The installation via pip was failing with avocado-vt with the error: 
`Avocado job failed: JobError: Could not find runners for runnable(s) of kind(s): dry-run` I applied the same workaround found here with cirrus https://github.com/avocado-framework/avocado-vt/pull/3204
* For some unknown reason (to me), the boot job now is named `io-github-autotest-qemu.boot` instead of `migrate.default.tcp.default`

These changes are working when I test locally but when running in github actions, I get two methods (pip and copr) failing in one of the avocado-vt tests ( boot and migrate execution), see:
https://github.com/ana/avocado/runs/3534440269