### PR TITLE
RFC: Add github action for the release test plan

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,136 @@
+name: Release tests
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version'
+        required: true
+        default: '0.0'
+      devel_name:
+        description: 'Developer Name'
+        required: true
+        default: 'Avocado Developer'
+      devel_mail:
+        description: 'Developer mail'
+        required: true
+        default: 'avocado@redhat.com'
+
+
+jobs:
+
+  release:
+    name: Release test pipeline
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:34
+
+    steps:
+      - name: install required packages
+        run:  dnf -y install rpmdevtools git
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal access token.
+          fetch-depth: 0
+      - name: Add release notes initial template
+        run: |
+          version=`echo ${{ github.event.inputs.version }} | tr '.' '_'`
+          FILE=docs/source/releases/$version.rst
+          echo "====================" >> $FILE
+          echo "${{ github.event.inputs.version }}  RELEASE_NAME"  >> $FILE
+          echo "====================" >> $FILE
+          echo "" >> $FILE
+
+          echo "The Avocado team is proud to present another release: Avocado ${{ github.event.inputs.version }}," >> $FILE
+          echo "AKA RELEASE_NAME, is now available!" >> $FILE
+          echo "" >> $FILE
+          git add $FILE
+      - name: Update VERSION files
+        run: |
+          echo ${{ github.event.inputs.version }} > VERSION
+          for DIR in optional_plugins/*; do
+                if test -f $DIR/VERSION; then
+                        echo ${{ github.event.inputs.version }} > $DIR/VERSION
+                fi
+          done
+      - name: Update python-avocado.spec
+        run: |
+          rpmdev-bumpspec -n ${{ github.event.inputs.version }} -u "${{ github.event.inputs.devel_name }} <${{ github.event.inputs.devel_mail }}>" -c "New release" python-avocado.spec
+          sed -i 's/^Release:.*/Release: 1%{?gitrel}%{?dist}/' python-avocado.spec
+      - name: Commit files
+        run: |
+          git config --local user.email "${{ github.event.inputs.devel_mail }}"
+          git config --local user.name "${{ github.event.inputs.devel_name }}"
+          git commit -m "Changes for release ${{ github.event.inputs.version }}" -a
+      - name: Tag test version
+        run: git tag test-${{ github.event.inputs.version }} -m 'Release ${{ github.event.inputs.version }}'
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.RELEASE_TOKEN }}
+          branch: release-${{ github.event.inputs.version }}
+
+# TODO: update avocado-vt in its own pipeline!
+
+
+  build-rpm:
+    name: Build rpm ${{ matrix.mock-config }}
+    runs-on: ubuntu-latest
+    needs: release
+    strategy:
+      matrix:
+        mock-config: ["fedora-34-x86_64", "epel-8-x86_64"]
+      fail-fast: false
+    container:
+      image: fedora:34
+      options: --privileged  # https://github.com/rpm-software-management/mock/wiki#mock-inside-podman-fedora-toolbox-or-docker-container
+
+    steps:
+      - name: install required packages
+        run:  dnf -y install git findutils make mock python3 python3-setuptools bash rpm-build
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal access token.
+          fetch-depth: 0
+          ref: release-${{ github.event.inputs.version }}
+      - name: Build rpm
+        env:
+          rpm_base_name: python-avocado
+          archive_base_name: avocado
+          version: ${{ github.event.inputs.version }}
+        run: |
+          export PYTHON=/usr/bin/python3
+          export MOCK_CONFIG=${{ matrix.mock-config }}
+          export TAG_VERSION=test-${{ github.event.inputs.version }}
+          make rpm-release
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.RELEASE_TOKEN }}
+          branch: release-${{ github.event.inputs.version }}
+
+
+  build-wheel:
+    name: Build wheel
+    runs-on: ubuntu-latest
+    needs: release
+    container:
+      image: fedora:34
+
+    steps:
+      - name: install required packages
+        run:  dnf -y install git make mock python3 python3-setuptools
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal access token.
+          fetch-depth: 0
+          ref: release-${{ github.event.inputs.version }}
+      - name: Build wheel
+        run: |
+          export PYTHON=/usr/bin/python3
+          make wheel
+      - name: Save wheel as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: wheel
+          path: /__w/avocado-test/avocado-test/PYPI_UPLOAD/
+          retention-days: 3

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,6 @@ all:
 	@echo "source-release:  Create source package for the latest tagged release"
 	@echo "srpm-release:    Generate a source RPM package (.srpm) for the latest tagged release"
 	@echo "rpm-release:        Generate binary RPMs for the latest tagged release"
-	@echo "propagate-version:  Propagate './VERSION' to all plugins/modules"
 	@echo
 
 include Makefile.include
@@ -151,11 +150,4 @@ variables:
 	@echo "PYTHON_MODULE_NAME: $(PYTHON_MODULE_NAME)"
 	@echo "RPM_BASE_NAME: $(RPM_BASE_NAME)"
 
-propagate-version:
-	for DIR in $(AVOCADO_OPTIONAL_PLUGINS); do\
-		if test -f "$$DIR/VERSION"; then\
-			echo ">> Updating $$DIR"; echo "$(VERSION)" > "$$DIR/VERSION";\
-		else echo ">> Skipping $$DIR"; fi;\
-	done
-
-.PHONY: source source-pypi wheel pypi install clean uninstall requirements-plugins requirements-dev smokecheck check develop develop-external propagate-version variables
+.PHONY: source source-pypi wheel pypi install clean uninstall requirements-plugins requirements-dev smokecheck check develop develop-external variables

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@ ifndef PYTHON
 PYTHON=$(shell which python3 2>/dev/null || which python 2>/dev/null)
 endif
 VERSION=$(shell $(PYTHON) setup.py --version 2>/dev/null)
+ifndef TAG_VERSION
+TAG_VERSION=$VERSION
+endif
 PYTHON_DEVELOP_ARGS=$(shell if ($(PYTHON) setup.py develop --help 2>/dev/null | grep -q '\-\-user'); then echo "--user"; else echo ""; fi)
 DESTDIR=/
 AVOCADO_DIRNAME=$(shell basename ${PWD})
@@ -11,7 +14,9 @@ RELEASE_SHORT_COMMIT=$(shell git rev-parse --short=9 $(VERSION))
 COMMIT=$(shell git log --pretty=format:'%H' -n 1)
 COMMIT_DATE=$(shell git log --pretty='format:%cd' --date='format:%Y%m%d' -n 1)
 SHORT_COMMIT=$(shell git rev-parse --short=9 HEAD)
+ifndef MOCK_CONFIG
 MOCK_CONFIG=default
+endif
 ARCHIVE_BASE_NAME=avocado
 PYTHON_MODULE_NAME=avocado-framework
 RPM_BASE_NAME=python-avocado

--- a/Makefile.include
+++ b/Makefile.include
@@ -4,7 +4,7 @@ source: clean
 
 source-release: clean
 	if test ! -d SOURCES; then mkdir SOURCES; fi
-	git archive --prefix="$(ARCHIVE_BASE_NAME)-$(VERSION)/" -o "SOURCES/$(ARCHIVE_BASE_NAME)-$(VERSION).tar.gz" $(VERSION)
+	git archive --prefix="$(ARCHIVE_BASE_NAME)-$(VERSION)/" -o "SOURCES/$(ARCHIVE_BASE_NAME)-$(VERSION).tar.gz" $(TAG_VERSION)
 
 install:
 	$(PYTHON) setup.py install --root $(DESTDIR) $(COMPILE)

--- a/examples/testplans/release/release.json
+++ b/examples/testplans/release/release.json
@@ -4,32 +4,16 @@
 
     "tests": [
          {
-	 "name": "Version Bump: Version number",
-         "description": "For the Avocado versioning, two files need to receive a manual version update: `VERSION` and `python-avocado.spec`."
-	 },
-         {
-	 "name": "Version Bump: Propagate to plugins",
-         "description": "Run the command: `make propagate-version` to propagate this change to all optional and “linkable” plugins sharing the parent dir (eg. avocado-vt)."
-	 },
+    "name": "Run GitHub Action 'Release",
+        "description": "Run the GitHub Action 'Release' on the master branch at https://github.com/avocado-framework/avocado/actions/workflows/release.yml , all the jobs must pass. This action will create a branch named `release-VERSION` and a tag `test-VERSION`, it WON'T touch the `master` branch."
+    },
          {
 	 "name": "Write the release notes",
-         "description": "Under `docs/source/releases/` create a new .rst file describing the release changes. Also, update the `docs/source/releases/index.rst` file.  Look at the sprint issues and PRs on GitHub, specially the ones with the `comment-on-sprint-review` label."
+         "description": "Check the branch named `release-VERSION` under `docs/source/releases/` edit the new .rst file describing the release changes. Also,add the new release to the list of releases at `docs/source/releases/index.rst`. Look at the sprint issues and PRs on GitHub, specially the ones with the `comment-on-sprint-review` label. Commit your changes directly in the working branch `release-VERSION`"
 	 },
          {
-	 "name": "Version Bump: Commit the bump",
-         "description": "Commit the version bump, python-avocado.spec and release notes. Don't forget to commit the changes of 'linked' plugins as they live in different repositories."
-	 },
-         {
-	 "name": "Version Bump: Tag the repository",
-         "description": "Tagging the repository locally (but not pushing it yet), will let you do a `make rpm-release` in the next step. Run `git tag -u $(GPG_ID) -s $(RELEASE) -m 'Release $(RELEASE)'`"
-	 },
-         {
-	 "name": "Build RPMs",
-         "description": "Go to the source directory and do:\n\n`make rpm-release && echo $?`\n\nThis should be all. It will build packages using mock, targeting your default configuration. That usually means the same platform you’re currently on. Also make sure it builds on other supported distros, by setting the MOCK_CONFIG variable to values such as `epel-8-x86_64`."
-	 },
-         {
-	 "name": "Version Bump: Push the tag",
-         "description": "The tag should be pushed to the GIT repository with:\n\n`git push --tags`"
+	 "name": "Re-tag and Release",
+         "description": "Time to add the final tag and release, follow these steps: \n1. Rebase the `master` branch with all the commits from `release-VERSION` in a single commit.\n2. Remove the test tag locally and remotely: `git push --delete origin test-$(RELEASE) && git tag -d test-$(RELEASE)`\n3. Add a signed tag `git tag -u $(GPG_ID) -s $(RELEASE) -m 'Release $(RELEASE)'`\n4. Push everything to github: `git push && git push --tags`"
 	 },
          {
 	 "name": "Upload package to PyPI",


### PR DESCRIPTION
 This new Action will update all the VERSION files, the spec file, add a template for the release notes and will build the RPM
 and wheel packages.

Some things that can be improved with your feedback:
* The RPM packages are only built for fedora-34-x86_64 and epel-8-x86_64. Any other target we should test?
* There are two actions more that could be run automatically: upload package to pypi and update readthedocs. It requires keeping a secret token in GitHub.  Should we try ? 
* We could commit the release notes as first step and then run everything automatically up to "Update the Fedora and EPEL RPM packages and module". Do we want this? :)

This action will be completed later with the egg packages (https://github.com/avocado-framework/avocado/issues/4692)
If you want to test the action in your own, fork this repository https://github.com/ana/avocado-test

Reference: https://github.com/avocado-framework/avocado/issues/3456