### PR TITLE
optional_plugins: move tests and allow to run tests independently

### DIFF
--- a/optional_plugins/golang/tests/test_nrunner_interface.py
+++ b/optional_plugins/golang/tests/test_nrunner_interface.py
@@ -1,0 +1,30 @@
+import json
+import sys
+
+from avocado import Test, fail_on
+from avocado.utils import process
+
+
+class Interface(Test):
+
+    def get_runner(self):
+        default_runner = "%s -m avocado.core.nrunner" % sys.executable
+        return self.params.get("runner", default=default_runner)
+
+    @fail_on(process.CmdError)
+    def test_help(self):
+        """
+        Makes sure a runner can be called with --help and that the
+        basic required commands are present in the help message
+        """
+        cmd = "%s --help" % self.get_runner()
+        result = process.run(cmd)
+        self.assertIn(b"capabilities", result.stdout,
+                      "Mention to capabilities command not found")
+
+    @fail_on(process.CmdError)
+    def test_capabilities(self):
+        cmd = "%s capabilities" % self.get_runner()
+        result = process.run(cmd)
+        capabilities = json.loads(result.stdout_text)
+        self.assertIn("runnables", capabilities)

--- a/optional_plugins/html/examples/tests/passtest.py
+++ b/optional_plugins/html/examples/tests/passtest.py
@@ -1,0 +1,15 @@
+from avocado import Test
+
+
+class PassTest(Test):
+
+    """
+    Example test that passes.
+
+    :avocado: tags=fast
+    """
+
+    def test(self):
+        """
+        A test simply doesn't have to fail in order to pass
+        """

--- a/optional_plugins/html/setup.py
+++ b/optional_plugins/html/setup.py
@@ -13,9 +13,82 @@
 # Copyright: Red Hat Inc. 2016
 # Author: Cleber Rosa <crosa@redhat.com>
 
-from setuptools import find_packages, setup
+import glob
+
+from setuptools import Command, find_packages, setup
 
 VERSION = open("VERSION", "r").read().strip()
+
+
+class Test(Command):
+    """Run tests"""
+
+    description = "Run tests"
+    user_options = []
+
+    def run(self):
+        # This must go there otherwise avocado must be installed for all targets
+        from avocado.core.job import Job
+        from avocado.core.suite import TestSuite
+        suites = []
+        pattern = 'tests/*'
+        config_check = {
+            'run.references': glob.glob(pattern),
+            'run.test_runner': 'nrunner',
+            'run.ignore_missing_references': True,
+            'job.output.testlogs.statuses': ['FAIL']
+            }
+        suites.append(TestSuite.from_config(config_check, "PLUGIN_html"))
+
+        # Test if the result file was created
+        check_file_exists = ('%s:test_check_file_exists'
+                             % (__file__))
+        config_check_file_exists = {
+            'run.references': [check_file_exists],
+            'run.test_runner': 'runner',
+            'run.dict_variants': [
+                {'namespace': 'job.run.result.html.enabled',
+                 'value': True,
+                 'file': 'results.html',
+                 'assert': True},
+
+                {'namespace': 'job.run.result.html.enabled',
+                 'value': False,
+                 'file': 'results.html',
+                 'assert': False},
+            ]
+        }
+        suites.append(TestSuite.from_config(config_check_file_exists,
+                                            "PLUGIN_html-job-api-enabled"))
+
+        # Test if a file was created
+        check_output_file = ('%s:test_check_output_file'
+                             % (__file__))
+        config_check_output_file = {
+            'run.references': [check_output_file],
+            'run.test_runner': 'runner',
+            'run.dict_variants': [
+                {'namespace': 'job.run.result.html.output',
+                 'file': 'custom.html',
+                 'assert': True},
+            ]
+        }
+        suites.append(TestSuite.from_config(config_check_output_file,
+                                            "PLUGIN_html-job-api-output"))
+
+        config = {'core.show': ['app'],
+                  'run.test_runner': 'nrunner'}
+
+        with Job(config, suites) as j:
+            exit_code = j.run()
+        return exit_code
+
+    def initialize_options(self):
+        """Set default values for options."""
+
+    def finalize_options(self):
+        """Post-process options."""
+
 
 setup(name='avocado-framework-plugin-result-html',
       description='Avocado HTML Report for Jobs',
@@ -26,6 +99,7 @@ setup(name='avocado-framework-plugin-result-html',
       packages=find_packages(),
       include_package_data=True,
       install_requires=['avocado-framework==%s' % VERSION, 'jinja2'],
+      cmdclass={'test': Test},
       entry_points={
           'avocado.plugins.cli': [
               'html = avocado_result_html:HTML',

--- a/optional_plugins/robot/tests/test_nrunner_interface.py
+++ b/optional_plugins/robot/tests/test_nrunner_interface.py
@@ -1,0 +1,30 @@
+import json
+import sys
+
+from avocado import Test, fail_on
+from avocado.utils import process
+
+
+class Interface(Test):
+
+    def get_runner(self):
+        default_runner = "%s -m avocado.core.nrunner" % sys.executable
+        return self.params.get("runner", default=default_runner)
+
+    @fail_on(process.CmdError)
+    def test_help(self):
+        """
+        Makes sure a runner can be called with --help and that the
+        basic required commands are present in the help message
+        """
+        cmd = "%s --help" % self.get_runner()
+        result = process.run(cmd)
+        self.assertIn(b"capabilities", result.stdout,
+                      "Mention to capabilities command not found")
+
+    @fail_on(process.CmdError)
+    def test_capabilities(self):
+        cmd = "%s capabilities" % self.get_runner()
+        result = process.run(cmd)
+        capabilities = json.loads(result.stdout_text)
+        self.assertIn("runnables", capabilities)

--- a/optional_plugins/varianter_yaml_to_mux/examples/tests/failtest.py
+++ b/optional_plugins/varianter_yaml_to_mux/examples/tests/failtest.py
@@ -1,0 +1,16 @@
+from avocado import Test
+
+
+class FailTest(Test):
+
+    """
+    Example test for avocado. Straight up fail the test.
+
+    :avocado: tags=failure_expected
+    """
+
+    def test(self):
+        """
+        Should fail.
+        """
+        self.fail('This test is supposed to fail')

--- a/optional_plugins/varianter_yaml_to_mux/examples/tests/gendata.py
+++ b/optional_plugins/varianter_yaml_to_mux/examples/tests/gendata.py
@@ -1,0 +1,18 @@
+import os
+
+from avocado import Test
+
+
+class GenDataTest(Test):
+
+    """
+    Simple test that generates data to be persisted after the test is run
+    """
+
+    def test_json(self):
+        import json
+        output_path = os.path.join(self.outputdir, "test.json")
+        output = {"basedir": self.basedir,
+                  "outputdir": self.outputdir}
+        with open(output_path, "w") as output_file:
+            json.dump(output, output_file)

--- a/optional_plugins/varianter_yaml_to_mux/examples/tests/passtest.py
+++ b/optional_plugins/varianter_yaml_to_mux/examples/tests/passtest.py
@@ -1,0 +1,15 @@
+from avocado import Test
+
+
+class PassTest(Test):
+
+    """
+    Example test that passes.
+
+    :avocado: tags=fast
+    """
+
+    def test(self):
+        """
+        A test simply doesn't have to fail in order to pass
+        """

--- a/optional_plugins/varianter_yaml_to_mux/setup.py
+++ b/optional_plugins/varianter_yaml_to_mux/setup.py
@@ -13,9 +13,46 @@
 # Copyright: Red Hat Inc. 2017
 # Author: Cleber Rosa <crosa@redhat.com>
 
-from setuptools import find_packages, setup
+import glob
+
+from setuptools import Command, find_packages, setup
 
 VERSION = open("VERSION", "r").read().strip()
+
+
+class Test(Command):
+    """Run tests"""
+
+    description = "Run tests"
+    user_options = []
+
+    def run(self):
+        # This must go there otherwise avocado must be installed for all targets
+        from avocado.core.job import Job
+        from avocado.core.suite import TestSuite
+        suites = []
+        pattern = 'tests/*'
+        config_check = {
+            'run.references': glob.glob(pattern),
+            'run.test_runner': 'nrunner',
+            'run.ignore_missing_references': True,
+            'job.output.testlogs.statuses': ['FAIL']
+            }
+        suites.append(TestSuite.from_config(config_check, "PLUGIN_varianter-yaml-to-mux"))
+
+        config = {'core.show': ['app'],
+                  'run.test_runner': 'nrunner'}
+
+        with Job(config, suites) as j:
+            exit_code = j.run()
+        return exit_code
+
+    def initialize_options(self):
+        """Set default values for options."""
+
+    def finalize_options(self):
+        """Post-process options."""
+
 
 setup(name='avocado-framework-plugin-varianter-yaml-to-mux',
       description='Avocado Varianter plugin to parse YAML file into variants',
@@ -27,6 +64,7 @@ setup(name='avocado-framework-plugin-varianter-yaml-to-mux',
       include_package_data=True,
       install_requires=['avocado-framework==%s' % VERSION, 'PyYAML>=4.2b2'],
       test_suite='tests',
+      cmdclass={'test': Test},
       entry_points={
           "avocado.plugins.init": [
               "yaml_to_mux = avocado_varianter_yaml_to_mux:YamlToMuxInit",


### PR DESCRIPTION
This will allow to run all tests independently of avocado code source with: `python setup.py tests`

This is a first required step for:
- running the test plugins independently with a new avocado run. it'll be more clear than now when a plugin test fails
and it'll be easier to opt out of running the test of a plugin
- allowing splitting out the plugins, it's straightforward now

Fixes: https://github.com/avocado-framework/avocado/issues/4940


