### PR TITLE
Human UI Plugin: allow the configuration of status to be ommited

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -353,6 +353,7 @@ if __name__ == '__main__':
                   "podman = avocado.plugins.spawners.podman:PodmanSpawnerInit",
                   "nrunner = avocado.plugins.runner_nrunner:RunnerInit",
                   "testlogsui = avocado.plugins.testlogs:TestLogsUIInit",
+                  "human = avocado.plugins.human:HumanInit",
               ],
               'avocado.plugins.cli': [
                   'wrapper = avocado.plugins.wrapper:Wrapper',


### PR DESCRIPTION
With the nrunner especially, the UI can become crowded with "STARTED"
and then the actual test final status.  Let's allow any of the actual
status to be ommited from the UI if the user chooses to.

Signed-off-by: Cleber Rosa <crosa@redhat.com>