### PR TITLE
check.py/setup.py: fix --disable-plugin-checks

### DIFF
--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -174,7 +174,7 @@ PATH=%{buildroot}%{_bindir}:%{buildroot}%{_libexecdir}/avocado:$PATH \
     PYTHONPATH=%{buildroot}%{python3_sitelib}:. \
     LANG=en_US.UTF-8 \
     AVOCADO_CHECK_LEVEL=0 \
-    %{python3} selftests/check.py --job-api --nrunner-interface --unit --jobs --functional --optional-plugins --disable-plugin-checks=robot
+    %{python3} selftests/check.py --job-api --nrunner-interface --unit --jobs --functional --optional-plugins --disable-plugin-checks robot
 %endif
 
 %files -n python3-avocado
@@ -369,6 +369,9 @@ Again Shell code (and possibly other similar shells).
 %{_libexecdir}/avocado*
 
 %changelog
+* Thu Sep 16 2021 Ana Guerrero Lopez <anguerre@redhat.com> - 91.0-2
+- Minor update to the selftest/check.py call
+
 * Mon Aug 30 2021 Cleber Rosa <crosa@redhat.com> - 91.0-1
 - New release
 

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -201,9 +201,6 @@ def parse_args():
     parser.add_argument('--job-api',
                         help='Run job API checks',
                         action='store_true')
-    parser.add_argument('--disable-plugin-checks',
-                        help='Disable checks for a plugin (by directory name)',
-                        action='append', default=[])
     parser.add_argument('--nrunner-interface',
                         help='Run selftests/functional/test_nrunner_interface.py',
                         action='store_true')
@@ -219,8 +216,15 @@ def parse_args():
     parser.add_argument('--optional-plugins',
                         help='Run optional_plugins/*/tests/',
                         action='store_true')
+    parser.add_argument('--disable-plugin-checks',
+                        help='Disable checks for one or more plugins (by directory name), separated by comma',
+                        action='append', default=[])
 
-    return parser.parse_args()
+    arg = parser.parse_args()
+    # Make a list of strings instead of a list with a single string
+    if len(arg.disable_plugin_checks) > 0:
+        arg.disable_plugin_checks = arg.disable_plugin_checks[0].split(",")
+    return arg
 
 
 def create_suite_job_api(args):  # pylint: disable=W0621

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -234,7 +234,6 @@ def create_suite_job_api(args):  # pylint: disable=W0621
                                  % (__file__, test_class))
     config_check_archive_file_exists = {
         'run.references': [check_archive_file_exists],
-        'run.test_runner': 'runner',
         'run.dict_variants': [
             {'namespace': 'run.results.archive',
              'value': True,
@@ -253,7 +252,6 @@ def create_suite_job_api(args):  # pylint: disable=W0621
         % (__file__, test_class))
     config_check_category_directory_exists = {
         'run.references': [check_category_directory_exists],
-        'run.test_runner': 'runner',
         'run.dict_variants': [
             {'namespace': 'run.job_category',
              'value': 'foo',
@@ -271,7 +269,6 @@ def create_suite_job_api(args):  # pylint: disable=W0621
                               % (__file__, test_class))
     config_check_directory_exists = {
         'run.references': [check_directory_exists],
-        'run.test_runner': 'runner',
         'run.dict_variants': [
              {'namespace': 'sysinfo.collect.enabled',
               'value': True,
@@ -295,7 +292,6 @@ def create_suite_job_api(args):  # pylint: disable=W0621
                           % (__file__, test_class))
     config_check_file_content = {
         'run.references': [check_file_content],
-        'run.test_runner': 'runner',
         'run.dict_variants': [
             # finding the correct 'content' here is trick because any
             # simple string is added to the variant file name and is
@@ -375,7 +371,6 @@ def create_suite_job_api(args):  # pylint: disable=W0621
                          % (__file__, test_class))
     config_check_file_exists = {
         'run.references': [check_file_exists],
-        'run.test_runner': 'runner',
         'run.dict_variants': [
             {'namespace': 'job.run.result.json.enabled',
              'value': True,
@@ -455,7 +450,6 @@ def create_suite_job_api(args):  # pylint: disable=W0621
                          % (__file__, test_class))
     config_check_output_file = {
         'run.references': [check_output_file],
-        'run.test_runner': 'runner',
         'run.dict_variants': [
             {'namespace': 'job.run.result.json.output',
              'file': 'custom.json',
@@ -490,7 +484,6 @@ def create_suite_job_api(args):  # pylint: disable=W0621
                                   % (__file__, test_class))
     config_check_tmp_directory_exists = {
         'run.references': [check_tmp_directory_exists],
-        'run.test_runner': 'runner',
         'run.dict_variants': [
             {'namespace': 'run.keep_tmp',
              'value': True,

--- a/setup.py
+++ b/setup.py
@@ -207,7 +207,7 @@ class Test(SimpleCommand):
         ("jobs", None, "Run selftests/jobs/"),
         ("functional", None, "Run selftests/functional/"),
         ("optional-plugins", None, "Run optional_plugins/*/tests/"),
-        ("disable-plugin-checks", None, "Disable checks for a plugin (by directory name)"),
+        ("disable-plugin-checks=", None, "Disable checks for one or more plugins (by directory name), separated by comma"),
         ("list-features", None, "Show the features tested by this test")
     ]
 


### PR DESCRIPTION
Update `--disable-plugin-checks` to allow disabling several plugins with the same option
    
When running from the selftests/check.py, it needs to be used as:
`      python3 selftests/check.py ... --disable-plugin-checks html robot`
From the setup.py test command as:
`      python3 setup.py test ... --disable-plugin-checks "html robot"`

 
Fixes: #4904
References: https://github.com/avocado-framework/avocado/issues/4904

A second commit to force always using the default (n)runner.