### PR TITLE
selftests/check.py: Implement boolean arguments

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -71,7 +71,7 @@ debian_egg_task:
 fedora_selftests_task:
     selftests_script:
        - make develop
-       - PATH=$HOME/.local/bin:$PATH LANG=en_US.UTF-8 AVOCADO_CHECK_LEVEL=0 python3 selftests/check.py --job-api --nrunner-interface --unit --jobs --functional --optional-plugins
+       - PATH=$HOME/.local/bin:$PATH LANG=en_US.UTF-8 AVOCADO_CHECK_LEVEL=0 python3 selftests/check.py --skip --static-checks
     container:
         matrix:
           - image: quay.io/avocado-framework/avocado-ci-fedora-33

--- a/.github/workflows/check_py.yml
+++ b/.github/workflows/check_py.yml
@@ -1,0 +1,71 @@
+name: check.py tests
+
+on:
+  push:
+    paths:
+      - 'setup.py'
+      - 'selftests/check.py'
+  pull_request:
+    paths:
+      - 'setup.py'
+      - 'selftests/check.py'
+  workflow_dispatch:
+
+jobs:
+
+  check_py:
+    name: Test selftests/check.py
+    runs-on: ubuntu-20.04
+
+    steps:
+      - run: echo "Triggered by a ${{ github.event_name }} event on branch ${{ github.ref }}, repository ${{ github.repository }}, with runner ${{ runner.os }}"
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt
+      - name: Installing Avocado in develop mode
+        run: python3 setup.py develop --user
+      - run: python3 selftests/check.py --help
+      - run: python3 selftests/check.py --skip --select  # not allowed, should give error message and exit with error
+        continue-on-error: True
+      - run: python3 selftests/check.py --skip --job-api --optional-plugins  # not allowed, should give error message
+      - run: python3 selftests/check.py --select --no-static-checks # not allowed, should give error message
+      - run: python3 selftests/check.py --select --job-api --unit
+      - run: python3 selftests/check.py --select --static-check
+      - run: python3 selftests/check.py --select --optional-plugins
+      - run: python3 selftests/check.py --skip --no-static-checks --no-functional
+      - run: python3 selftests/check.py --skip --no-optional-plugins --no-unit
+      - run: python3 selftests/check.py --select --job-api --nrunner-interface --disable-plugin-checks html,golang,robot
+      - run: python3 selftests/check.py --skip --no-unit --disable-plugin-checks robot
+      - run: python3 selftests/check.py # should run all tests
+      - run: echo "🥑 This job's status is ${{ job.status }}."
+
+
+  setup_py:
+    name: Test setup.py tests
+    runs-on: ubuntu-20.04
+
+    steps:
+      - run: echo "Triggered by a ${{ github.event_name }} event on branch ${{ github.ref }}, repository ${{ github.repository }}, with runner ${{ runner.os }}"
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt
+      - name: Installing Avocado in develop mode
+        run: python3 setup.py develop --user
+      - run: python3 setup.py test --help
+      - run: python3 setup.py test --skip --select  # not allowed, should give error message and exit with error
+        continue-on-error: True
+      - run: python3 setup.py test --skip --job-api --optional-plugins  # not allowed, should give error message
+      - run: python3 setup.py test --select --no-static-checks # not allowed, should give error message
+      - run: python3 setup.py test --select --job-api --unit
+      - run: python3 setup.py test --select --static-check
+      - run: python3 setup.py test --select --optional-plugins
+      - run: python3 setup.py test --skip --no-static-checks --no-functional
+      - run: python3 setup.py test --skip --no-optional-plugins --no-unit
+      - run: python3 setup.py test --select --job-api --nrunner-interface --disable-plugin-checks html,golang,robot
+      - run: python3 setup.py test --skip --no-unit --disable-plugin-checks html
+      - run: python3 setup.py test # should run all tests
+      - run: echo "🥑 This job's status is ${{ job.status }}."

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -88,7 +88,7 @@ jobs:
         run: |
           export AVOCADO_LOG_DEBUG="yes"
           export AVOCADO_CHECK_LEVEL="1"
-          python selftests/check.py --disable-plugin-checks golang --disable-plugin-checks html --disable-plugin-checks resultsdb --disable-plugin-checks result_upload --disable-plugin-checks robot --disable-plugin-checks varianter_cit --disable-plugin-checks varianter_pict --disable-plugin-checks varianter_yaml_to_mux
+          python selftests/check.py --disable-plugin-checks golang,html,resultsdb,result_upload,robot,varianter_cit,varianter_pict,varianter_yaml_to_mux
       - name: Archive test logs
         if: failure()
         uses: actions/upload-artifact@v2

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -174,7 +174,7 @@ PATH=%{buildroot}%{_bindir}:%{buildroot}%{_libexecdir}/avocado:$PATH \
     PYTHONPATH=%{buildroot}%{python3_sitelib}:. \
     LANG=en_US.UTF-8 \
     AVOCADO_CHECK_LEVEL=0 \
-    %{python3} selftests/check.py --job-api --nrunner-interface --unit --jobs --functional --optional-plugins --disable-plugin-checks robot
+    %{python3} selftests/check.py --skip --static-checks --disable-plugin-checks robot
 %endif
 
 %files -n python3-avocado
@@ -369,6 +369,9 @@ Again Shell code (and possibly other similar shells).
 %{_libexecdir}/avocado*
 
 %changelog
+* Fri Sep 17 2021 Ana Guerrero Lopez <anguerre@redhat.com> - 91.0-3
+- Adjust selftest/check.py to use new --skip option
+
 * Thu Sep 16 2021 Ana Guerrero Lopez <anguerre@redhat.com> - 91.0-2
 - Minor update to the selftest/check.py call
 

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -174,7 +174,7 @@ PATH=%{buildroot}%{_bindir}:%{buildroot}%{_libexecdir}/avocado:$PATH \
     PYTHONPATH=%{buildroot}%{python3_sitelib}:. \
     LANG=en_US.UTF-8 \
     AVOCADO_CHECK_LEVEL=0 \
-    %{python3} selftests/check.py --job-api --nrunner-interface --unit --jobs --functional --optional-plugins --disable-plugin-checks=robot
+    %{python3} selftests/check.py --job-api --nrunner-interface --unit --jobs --functional --optional-plugins --disable-plugin-checks robot
 %endif
 
 %files -n python3-avocado
@@ -369,6 +369,9 @@ Again Shell code (and possibly other similar shells).
 %{_libexecdir}/avocado*
 
 %changelog
+* Thu Sep 16 2021 Ana Guerrero Lopez <anguerre@redhat.com> - 91.0-2
+- Minor update to the selftest/check.py call
+
 * Mon Aug 30 2021 Cleber Rosa <crosa@redhat.com> - 91.0-1
 - New release
 

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -201,9 +201,6 @@ def parse_args():
     parser.add_argument('--job-api',
                         help='Run job API checks',
                         action='store_true')
-    parser.add_argument('--disable-plugin-checks',
-                        help='Disable checks for a plugin (by directory name)',
-                        action='append', default=[])
     parser.add_argument('--nrunner-interface',
                         help='Run selftests/functional/test_nrunner_interface.py',
                         action='store_true')
@@ -219,8 +216,15 @@ def parse_args():
     parser.add_argument('--optional-plugins',
                         help='Run optional_plugins/*/tests/',
                         action='store_true')
+    parser.add_argument('--disable-plugin-checks',
+                        help='Disable checks for one or more plugins (by directory name), separated by comma',
+                        action='append', default=[])
 
-    return parser.parse_args()
+    arg = parser.parse_args()
+    # Make a list of strings instead of a list with a single string
+    if len(arg.disable_plugin_checks) > 0:
+        arg.disable_plugin_checks = arg.disable_plugin_checks[0].split(",")
+    return arg
 
 
 def create_suite_job_api(args):  # pylint: disable=W0621

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -16,6 +16,30 @@ from selftests.utils import python_module_available
 BOOLEAN_ENABLED = [True, 'true', 'on', 1]
 BOOLEAN_DISABLED = [False, 'false', 'off', 0]
 
+# The best solution would be BooleanOptionalAction, but it's only in Python3.9+
+# Using a custom action based on: https://stackoverflow.com/questions/9234258/in-python-argparse-is-it-possible-to-have-paired-no-something-something-arg/9236426
+
+
+class BooleanAction(argparse.Action):
+
+    def __init__(self, option_strings, dest, default=None, required=False, help=None):  # pylint: disable=W0622
+        if len(option_strings) != 1:
+            raise ValueError('Only single argument is allowed.')
+        opt = option_strings[0]
+        if not opt.startswith('--'):
+            raise ValueError('Boolean arguments must be prefixed with --')
+
+        opt = opt[2:]
+        opts = ['--' + opt, '--no-' + opt]
+        super(BooleanAction, self).__init__(opts, dest, nargs=0, const=None,
+                                            default=default, required=required, help=help)
+
+    def __call__(self, parser, namespace, values, option_strings=None):
+        if option_strings.startswith('--no-'):
+            setattr(namespace, self.dest, False)
+        else:
+            setattr(namespace, self.dest, True)
+
 
 class JobAPIFeaturesTest(Test):
 
@@ -191,31 +215,38 @@ class JobAPIFeaturesTest(Test):
 
 def parse_args():
     parser = argparse.ArgumentParser()
+    group = parser.add_mutually_exclusive_group()
     parser.add_argument('-f',
                         '--list-features',
                         help='show the list of features tested by this test.',
                         action='store_true')
+    group.add_argument('--skip',
+                       help='Run all tests and skip listed test with --no-X options',
+                       action='store_true')
+    group.add_argument('--select',
+                       help='Do not run any test, only these selected after with --X options',
+                       action='store_true')
     parser.add_argument('--static-checks',
                         help='Run static checks (isort, lint, etc)',
-                        action='store_true')
+                        action=BooleanAction, default=None)
     parser.add_argument('--job-api',
                         help='Run job API checks',
-                        action='store_true')
+                        action=BooleanAction, default=None)
     parser.add_argument('--nrunner-interface',
                         help='Run selftests/functional/test_nrunner_interface.py',
-                        action='store_true')
+                        action=BooleanAction, default=None)
     parser.add_argument('--unit',
                         help='Run selftests/unit/',
-                        action='store_true')
+                        action=BooleanAction, default=None)
     parser.add_argument('--jobs',
                         help='Run selftests/jobs/',
-                        action='store_true')
+                        action=BooleanAction, default=None)
     parser.add_argument('--functional',
                         help='Run selftests/functional/',
-                        action='store_true')
+                        action=BooleanAction, default=None)
     parser.add_argument('--optional-plugins',
                         help='Run optional_plugins/*/tests/',
-                        action='store_true')
+                        action=BooleanAction, default=None)
     parser.add_argument('--disable-plugin-checks',
                         help='Disable checks for one or more plugins (by directory name), separated by comma',
                         action='append', default=[])
@@ -584,11 +615,50 @@ def enable_all_tests(args):   # pylint: disable=W0621
 
 def main(args):  # pylint: disable=W0621
 
-    if not any([args.static_checks, args.job_api, args.nrunner_interface,
-                args.unit, args.jobs, args.functional,
-                args.optional_plugins, args.list_features]):
+    # Will only run the test you select, --select must be followed by --options
+    if args.select:
+        if not any([args.static_checks, args.job_api, args.nrunner_interface,
+                    args.unit, args.jobs, args.functional, args.optional_plugins]):
+            print("Option --select must be followed by the tests you wish to run, "
+                  "adding --X options.\nFor example: --select --static-checks")
+            exit(0)
+
+    # Will run all the tests except these you skip, --skip must be followed by --no-options
+    elif args.skip:
+        if any([args.static_checks, args.job_api, args.nrunner_interface,
+                args.unit, args.jobs, args.functional, args.optional_plugins]):
+            print("Option --skip must be followed by the test you want to exclude adding "
+                  "--no-X options.\nFor example: --skip --no-static-checks")
+            exit(0)
+        else:
+            # Set to True the options we haven't selected to skip!
+            if args.static_checks is None:
+                args.static_checks = True
+            if args.job_api is None:
+                args.job_api = True
+            if args.nrunner_interface is None:
+                args.nrunner_interface = True
+            if args.unit is None:
+                args.unit = True
+            if args.jobs is None:
+                args.jobs = True
+            if args.functional is None:
+                args.functional = True
+            if args.optional_plugins is None:
+                args.optional_plugins = True
+
+    # If no option was selected, run all tests!
+    elif not any([args.list_features, args.skip, args.select,
+                 args.static_checks, args.job_api, args.nrunner_interface,
+                 args.unit, args.jobs, args.functional, args.optional_plugins]):
         print("No test were selected to run, running all of them.")
         enable_all_tests(args)
+    elif args.list_features:
+        # This will be handled later after all the suites have been created
+        pass
+    else:
+        print("Something went wrong, please report a bug!")
+        exit(1)
 
     suites = []
     if args.job_api:

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -234,7 +234,6 @@ def create_suite_job_api(args):  # pylint: disable=W0621
                                  % (__file__, test_class))
     config_check_archive_file_exists = {
         'run.references': [check_archive_file_exists],
-        'run.test_runner': 'runner',
         'run.dict_variants': [
             {'namespace': 'run.results.archive',
              'value': True,
@@ -253,7 +252,6 @@ def create_suite_job_api(args):  # pylint: disable=W0621
         % (__file__, test_class))
     config_check_category_directory_exists = {
         'run.references': [check_category_directory_exists],
-        'run.test_runner': 'runner',
         'run.dict_variants': [
             {'namespace': 'run.job_category',
              'value': 'foo',
@@ -271,7 +269,6 @@ def create_suite_job_api(args):  # pylint: disable=W0621
                               % (__file__, test_class))
     config_check_directory_exists = {
         'run.references': [check_directory_exists],
-        'run.test_runner': 'runner',
         'run.dict_variants': [
              {'namespace': 'sysinfo.collect.enabled',
               'value': True,
@@ -295,7 +292,6 @@ def create_suite_job_api(args):  # pylint: disable=W0621
                           % (__file__, test_class))
     config_check_file_content = {
         'run.references': [check_file_content],
-        'run.test_runner': 'runner',
         'run.dict_variants': [
             # finding the correct 'content' here is trick because any
             # simple string is added to the variant file name and is
@@ -375,7 +371,6 @@ def create_suite_job_api(args):  # pylint: disable=W0621
                          % (__file__, test_class))
     config_check_file_exists = {
         'run.references': [check_file_exists],
-        'run.test_runner': 'runner',
         'run.dict_variants': [
             {'namespace': 'job.run.result.json.enabled',
              'value': True,
@@ -455,7 +450,6 @@ def create_suite_job_api(args):  # pylint: disable=W0621
                          % (__file__, test_class))
     config_check_output_file = {
         'run.references': [check_output_file],
-        'run.test_runner': 'runner',
         'run.dict_variants': [
             {'namespace': 'job.run.result.json.output',
              'file': 'custom.json',
@@ -490,7 +484,6 @@ def create_suite_job_api(args):  # pylint: disable=W0621
                                   % (__file__, test_class))
     config_check_tmp_directory_exists = {
         'run.references': [check_tmp_directory_exists],
-        'run.test_runner': 'runner',
         'run.dict_variants': [
             {'namespace': 'run.keep_tmp',
              'value': True,

--- a/setup.py
+++ b/setup.py
@@ -207,7 +207,7 @@ class Test(SimpleCommand):
         ("jobs", None, "Run selftests/jobs/"),
         ("functional", None, "Run selftests/functional/"),
         ("optional-plugins", None, "Run optional_plugins/*/tests/"),
-        ("disable-plugin-checks", None, "Disable checks for a plugin (by directory name)"),
+        ("disable-plugin-checks=", None, "Disable checks for one or more plugins (by directory name), separated by comma"),
         ("list-features", None, "Show the features tested by this test")
     ]
 

--- a/setup.py
+++ b/setup.py
@@ -200,38 +200,65 @@ class Test(SimpleCommand):
 
     description = 'Run selftests'
     user_options = [
+        ("skip", None, "Run all tests and skip listed test with --no-X options"),
+        ("select", None, "Do not run any test, only these selected after with --X options"),
         ("job-api", None, "Run job API checks"),
+        ("no-job-api", None, "Do not run job API checks"),
         ("static-checks", None, "Run static checks (isort, lint, etc)"),
+        ("no-static-checks", None, "Do not run static checks (isort, lint, etc)"),
         ("nrunner-interface", None, "Run selftests/functional/test_nrunner_interface.py"),
+        ("no-nrunner-interface", None, "Do not run selftests/functional/test_nrunner_interface.py"),
         ("unit", None, "Run selftests/unit/"),
+        ("no-unit", None, "Do not run selftests/unit/"),
         ("jobs", None, "Run selftests/jobs/"),
+        ("no-jobs", None, "Do not run selftests/jobs/"),
         ("functional", None, "Run selftests/functional/"),
+        ("no-functional", None, "Do not run selftests/functional/"),
         ("optional-plugins", None, "Run optional_plugins/*/tests/"),
+        ("no-optional-plugins", None, "Do not run optional_plugins/*/tests/"),
         ("disable-plugin-checks=", None, "Disable checks for one or more plugins (by directory name), separated by comma"),
         ("list-features", None, "Show the features tested by this test")
     ]
 
     def initialize_options(self):
-        self.job_api = False  # pylint: disable=W0201
-        self.static_checks = False  # pylint: disable=W0201
-        self.nrunner_interface = False  # pylint: disable=W0201
-        self.unit = False  # pylint: disable=W0201
-        self.jobs = False  # pylint: disable=W0201
-        self.functional = False  # pylint: disable=W0201
-        self.optional_plugins = False  # pylint: disable=W0201
+        self.skip = None  # pylint: disable=W0201
+        self.select = None  # pylint: disable=W0201
+        self.job_api = None  # pylint: disable=W0201
+        self.no_job_api = None  # pylint: disable=W0201
+        self.static_checks = None  # pylint: disable=W0201
+        self.no_static_checks = None  # pylint: disable=W0201
+        self.nrunner_interface = None  # pylint: disable=W0201
+        self.no_nrunner_interface = None  # pylint: disable=W0201
+        self.unit = None  # pylint: disable=W0201
+        self.no_unit = None  # pylint: disable=W0201
+        self.jobs = None  # pylint: disable=W0201
+        self.no_jobs = None  # pylint: disable=W0201
+        self.functional = None  # pylint: disable=W0201
+        self.no_functional = None  # pylint: disable=W0201
+        self.optional_plugins = None  # pylint: disable=W0201
+        self.no_optional_plugins = None  # pylint: disable=W0201
         self.disable_plugin_checks = []  # pylint: disable=W0201
-        self.list_features = False  # pylint: disable=W0201
+        self.list_features = None  # pylint: disable=W0201
 
     def run(self):
 
         args = argparse.Namespace()
+        args.skip = self.skip
+        args.select = self.select
         args.static_checks = self.static_checks
+        args.no_static_checks = self.no_static_checks
         args.job_api = self.job_api
+        args.no_job_api = self.no_job_api
         args.nrunner_interface = self.nrunner_interface
+        args.no_nrunner_interface = self.no_nrunner_interface
         args.unit = self.unit
+        args.no_unit = self.no_unit
         args.jobs = self.jobs
+        args.no_jobs = self.no_jobs
         args.functional = self.functional
+        args.no_functional = self.no_functional
         args.optional_plugins = self.optional_plugins
+        args.no_optional_plugins = self.no_optional_plugins
         args.disable_plugin_checks = self.disable_plugin_checks
         args.list_features = self.list_features
 


### PR DESCRIPTION
Boolean arguments allow a bigger flexibility in choosing the tests we want to run. And with `--select `and ` --skip` we can handle exactly the tests we want to run or skip.
    
By default, with no argument, it'll continue running all tests:
    
` python3 selftests/check.py`
    
To run all the test except a given one, use `--skip`

` python3 selftests/check.py --skip --static-checks`
    
To run only one or several selected tests, use --select
    
`      python3 selftests/check.py --skip --static-checks`
    
If we also want to avoid running the tests of one of the plugins:
    
`python3 selftests/check.py --skip --nrunner-interface --static-check   --disable-plugin-checks golang,robot`
    
`setup.py` has been updated accordingly to handle all these options with the command `test`.

I have added a new GitHub action to test  extensively the options of `selfchecks/check.py`, you can see a run here: https://github.com/ana/avocado/actions/runs/1245180094

And finally updated all the scripts using `selfchecks/check.py`  to work with the new command options.

Once this is merged, the changes for https://github.com/avocado-framework/avocado/issues/4919 will be straighforward.


