### PR TITLE
[utils] Hosts: quit remote_session when RemoteHost exits

### DIFF
--- a/avocado/utils/network/hosts.py
+++ b/avocado/utils/network/hosts.py
@@ -124,6 +124,15 @@ class RemoteHost(Host):
         self.password = password
         self.remote_session = self._connect()
 
+    def __enter__(self):
+        if not self.remote_session:
+            self._connect()
+        return self
+
+    def __exit__(self, _type, _exc_value, _traceback):
+        if self.remote_session:
+            self.remote_session.quit()
+
     def _connect(self):
         session = Session(host=self.host,
                           port=self.port,


### PR DESCRIPTION
Hosts utils ensures that we quit the session object upon exit

Signed-off-by: Cris Forno <fornosoccer12@gmail.com>