### PR TITLE
 Add github action for the release test plan [v2]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,159 @@
+# must do before using this action:
+# - set up RELEASE_TOKEN in secrets of the repository avocado-framework/avocado
+# - set up RTD_TOKEN in secrets to update readthedocs
+# - set up two tokens for twine: PYPI_USER and PYPI_PASSWD
+
+name: Release tests
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version'
+        required: true
+        default: '0.0'
+      devel_name:
+        description: 'Developer Name'
+        required: true
+        default: 'Avocado Developer'
+      devel_mail:
+        description: 'Developer mail'
+        required: true
+        default: 'avocado@redhat.com'
+      rtd_project:
+        description: 'readthedocs project name'
+        required: true
+        default: 'avocado-framework'
+
+jobs:
+
+  release:
+    name: Update versions
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:34
+
+    steps:
+      - name: install required packages
+        run:  dnf -y install rpmdevtools git
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Update VERSION files
+        run: |
+          echo ${{ github.event.inputs.version }} > VERSION
+          for DIR in optional_plugins/*; do
+                if test -f $DIR/VERSION; then
+                        echo ${{ github.event.inputs.version }} > $DIR/VERSION
+                fi
+          done
+      - name: Update python-avocado.spec
+        run: |
+          rpmdev-bumpspec -n ${{ github.event.inputs.version }} -u "${{ github.event.inputs.devel_name }} <${{ github.event.inputs.devel_mail }}>" -c "New release" python-avocado.spec
+          sed -i 's/^Release:.*/Release: 1%{?gitrel}%{?dist}/' python-avocado.spec
+      - name: Commit files
+        run: |
+          git config --local user.email "${{ github.event.inputs.devel_mail }}"
+          git config --local user.name "${{ github.event.inputs.devel_name }}"
+          git commit -m "Changes for release ${{ github.event.inputs.version }}" -a
+      - name: Tag test version
+        run: git tag ${{ github.event.inputs.version }} -m 'Release ${{ github.event.inputs.version }}'
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.RELEASE_TOKEN }}
+          branch: ${{ github.ref }}
+
+  build-rtd:
+    name: Update readthedocs
+    runs-on: ubuntu-latest
+    needs: release
+
+    steps:
+      - name: Build documentation readthedocs
+        env:
+          token: ${{ secrets.RTD_TOKEN }}
+          url: "https://readthedocs.org/api/v3/projects/${{ github.event.inputs.rtd_project }}"
+          version: ${{ github.event.inputs.version }}
+        run: |
+          # Activate version
+          curl \
+            -X PATCH \
+            -H "Authorization: Token $token" $url/versions/$version/ \
+            -H "Content-Type: application/json" \
+            -d '{"active": true, "hidden": false }'
+          # Build new version
+          curl \
+            -X POST \
+            -H "Authorization: Token $token" $url/versions/$version/builds/
+      - run: echo "In a few minutes the release documentation will be available in https://${{ github.event.inputs.rtd_project }}.readthedocs.io/en/${{ github.event.inputs.version }}/"
+
+  build-wheel-update-pypi:
+    name: Build wheel and upload to pypi
+    runs-on: ubuntu-latest
+    needs: release
+
+    steps:
+      - name: install required packages
+        run: sudo apt-get -y install git python3-pip
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.version }}
+      - name: Build wheel
+        run: |
+          pip3 install --user build
+          mkdir PYPI_UPLOAD
+          python3 -m build -o PYPI_UPLOAD
+          for PLUGIN in optional_plugins/*; do
+                if test -f $PLUGIN/setup.py; then
+                        cd $PLUGIN;
+                        python3 -m build -o ../../PYPI_UPLOAD;
+                        cd -
+                fi
+          done
+      - name: Upload to pypi
+        env:
+          TWINE_USERNAME: '${{ secrets.PYPI_USER }}'
+          TWINE_PASSWORD: '${{ secrets.PYPI_PASSWD }}'
+          TWINE_NON_INTERACTIVE: true
+        run: |
+          pip install twine
+          twine upload PYPI_UPLOAD/*.{tar.gz,whl}
+      - name: Save wheel as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: wheel
+          path: /__w/avocado-test/avocado-test/PYPI_UPLOAD/
+          retention-days: 3
+
+  build-and-publish-eggs:
+    name: Build eggs and publish them
+    runs-on: ubuntu-latest
+    needs: release
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9]
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.version }}
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Build eggs
+        run: python setup.py bdist_egg
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.RELEASE_TOKEN }}
+          file: ${{ github.workspace }}/dist/avocado_framework*
+          tag: ${{ github.event.inputs.version }}
+          overwrite: true
+          file_glob: true

--- a/examples/testplans/release/release.json
+++ b/examples/testplans/release/release.json
@@ -4,41 +4,17 @@
 
     "tests": [
          {
-	 "name": "Version Bump: Version number",
-         "description": "For the Avocado versioning, two files need to receive a manual version update: `VERSION` and `python-avocado.spec`."
-	 },
-         {
-	 "name": "Version Bump: Propagate to plugins",
-         "description": "Run the command: `make propagate-version` to propagate this change to all optional and “linkable” plugins sharing the parent dir (eg. avocado-vt)."
-	 },
-         {
 	 "name": "Write the release notes",
-         "description": "Under `docs/source/releases/` create a new .rst file describing the release changes. Also, update the `docs/source/releases/index.rst` file.  Look at the sprint issues and PRs on GitHub, specially the ones with the `comment-on-sprint-review` label."
+         "description": "Under `docs/source/releases/` create a new .rst file describing the release changes. Also, add the new release to the list of releases at `docs/source/releases/index.rst`. Look at the sprint issues and PRs on GitHub, specially the ones with the `comment-on-sprint-review` label. Commit your changes directly in the master branch."
 	 },
          {
-	 "name": "Version Bump: Commit the bump",
-         "description": "Commit the version bump, python-avocado.spec and release notes. Don't forget to commit the changes of 'linked' plugins as they live in different repositories."
+	 "name": "Check secrets are set in GitHub",
+         "description": "The secrets required by the GitHub Action must be set before running. Go to https://github.com/avocado-framework/avocado/settings/secrets/actions and check 'Repository secrets', there should be four tokens set and not expired: RELEASE_TOKEN, RTD_TOKEN and the tokens for twine/pypi.org PYPI_USER and PYPI_PASSWD."
 	 },
-         {
-	 "name": "Version Bump: Tag the repository",
-         "description": "Tagging the repository locally (but not pushing it yet), will let you do a `make rpm-release` in the next step. Run `git tag -u $(GPG_ID) -s $(RELEASE) -m 'Release $(RELEASE)'`"
-	 },
-         {
-	 "name": "Build RPMs",
-         "description": "Go to the source directory and do:\n\n`make rpm-release && echo $?`\n\nThis should be all. It will build packages using mock, targeting your default configuration. That usually means the same platform you’re currently on. Also make sure it builds on other supported distros, by setting the MOCK_CONFIG variable to values such as `epel-8-x86_64`."
-	 },
-         {
-	 "name": "Version Bump: Push the tag",
-         "description": "The tag should be pushed to the GIT repository with:\n\n`git push --tags`"
-	 },
-         {
-	 "name": "Upload package to PyPI",
-         "description": "Users may also want to get Avocado from the PyPI repository, so please upload there as well. To help with the process, please run:\n\n`make pypi`\n\nAnd follow the URL and brief instructions given."
-	 },
-         {
-	 "name": "Configure Read The Docs",
-         "description": "Visit the link below:\n\nhttps://readthedocs.org/dashboard/avocado-framework/edit/\n\n 1) Click in *Versions*. Under *Activate a Version*, find the version you're releasing and click the *Activate* button;\n 2) Click in *Admin*. Under *Advanced Settings*/*Global settings*/*Default Version*, select the new version you're releasing. Click the *Save* button at the bottom of the page."
-	 },
+        {
+    "name": "Run GitHub Action 'Release",
+        "description": "Run the GitHub Action 'Release' on the master branch at https://github.com/avocado-framework/avocado/actions/workflows/release.yml . All the jobs must pass. This action will update the `master` branch and a tag `VERSION`.\nIMPORTANT NOTE: the automatic tag won't be signed anymore by the release developer."
+    },
          {
 	 "name": "Update the Fedora and EPEL RPM packages and module",
          "description": "Follow the instructions on:\n\nhttps://avocado-framework.readthedocs.io/en/latest/guides/contributor/chapters/releasing.html#how-to-refresh-fedora-epel-modules\n\nand work with the package maintainer by sending a PR to update the Avocado version on the `avocado:latest` stream."


### PR DESCRIPTION
Add a new GitHub Action that will help with the release.
This Action will:
- update all the VERSION files and the spec file
- update and build the new version at readthedocs.org
- build and update the packages (tar.gz and wheel) at pypi.org
- build and publish for ach python version the egg packages  in GitHub Fix:#4692

For making some of this actions, it's required to set up four tokens in github:
 `RELEASE_TOKEN` to allow update the repository avocado-framework/avocado
 `RTD_TOKEN` to update readthedocs
 `PYPI_USER` and `PYPI_PASSWD` to allow twine update pypi.org

Update the release testplan to the use the new Action.

References:
https://github.com/avocado-framework/avocado/issues/3456
https://github.com/avocado-framework/avocado/issues/4692

Signed-off-by: Ana Guerrero Lopez <anguerre@redhat.com>