### PR TITLE
examples/jobs: add an example for a custom exec-test

### DIFF
--- a/examples/jobs/custom_exec_test.py
+++ b/examples/jobs/custom_exec_test.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+import sys
+
+from avocado.core.job import Job
+from avocado.core.nrunner import Runnable
+from avocado.core.suite import TestSuite
+
+config = {'run.test_runner': 'nrunner'}
+
+# an exec-test runnable consists of a runnable type (exec-test),
+# an uri (examples/tests/sleeptest.sh), followed by zero to n arguments
+# ending with zero to m keyword arguments.
+#
+# During the execution, arguments are appended to the uri and keyword
+# arguments are converted to environment variable.
+
+# here, SLEEP_LENGTH become an environment variable
+sleeptest = Runnable('exec-test', 'examples/tests/sleeptest.sh',
+                     SLEEP_LENGTH='2')
+# here, 'Hello World!' is appended to the uri (/usr/bin/echo)
+echo = Runnable('exec-test', '/usr/bin/echo', 'Hello World!')
+
+# the execution of examples/tests/sleeptest.sh takes around 2 seconds
+# and the output of the /usr/bin/echo test is available at the
+# job-results/latest/test-results/exec-test-2-_usr_bin_echo/stdout file.
+suite = TestSuite(config=config, tests=[sleeptest, echo], name="exec-test")
+
+with Job(config, [suite]) as j:
+    sys.exit(j.run())


### PR DESCRIPTION
This adds an example of a custom exec-test using the Job API. The main objective is to document how args and kwargs are used.

Signed-off-by: Willian Rampazzo <willianr@redhat.com>