### PR TITLE
Introducing issues templates for bugs and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,24 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior with a reproducible whenever possible.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**System information (please complete the following information):**
+ - OS: `lsb_release -a`
+ - Avocado Version: `avocado -v`
+
+**Additional context**
+Add any other context about the problem here. Test details can be added here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always missing this feature when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
When creating bug reports inside this repository would be nice to have a
template to follow. This will save developers time when debugging the 
problem, since most of our requests don't have a reproducible today. The 
same for new features requests, since some features are small and don't
need a entire blueprint.