### PR TITLE
Asset: support query parameters in an URI

### DIFF
--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -263,7 +263,12 @@ class Asset:
                 base_url = self.locations[0]
         else:
             # the URI is on self.parsed_name
-            base_url = os.path.dirname(self.parsed_name.geturl())
+            if self.parsed_name.query:
+                base_url = "%s://%s%s" % (self.parsed_name.scheme,
+                                          self.parsed_name.netloc,
+                                          self.parsed_name.path)
+            else:
+                base_url = os.path.dirname(self.parsed_name.geturl())
 
         base_url_hash = hashlib.new(DEFAULT_HASH_ALGORITHM,
                                     base_url.encode(astring.ENCODING))
@@ -449,6 +454,8 @@ class Asset:
 
     @property
     def asset_name(self):
+        if self.parsed_name.query:
+            return self.parsed_name.query
         return os.path.basename(self.parsed_name.path)
 
     @classmethod


### PR DESCRIPTION
Sometimes the URI that identifies an asset will contain a query, as
it's commonly the case in file server that have an HTTP interface.

Instead of using the path as the name of the file, which will be the
same most of the time, let's use the parameters as the differentiating
factor.  Using the example on RFC3986:

```
         foo://example.com:8042/over/there?name=ferret#nose
         \_/   \______________/\_________/ \_________/ \__/
          |           |            |            |        |
       scheme     authority       path        query   fragment
          |   _____________________|__
         / \ /                        \
         urn:example:animal:ferret:nose
```

If a query component exists, the base location in the Avocado cache
will be based on the components up to "path", and the asset name the
query itself.

Fixes: https://github.com/avocado-framework/avocado/issues/4824
Reference: https://datatracker.ietf.org/doc/html/rfc3986#section-3
Signed-off-by: Cleber Rosa <crosa@redhat.com>