### PR TITLE
[examples/job] fix examples/jobs/passjob_with_test.py

### DIFF
--- a/examples/jobs/passjob_with_test.py
+++ b/examples/jobs/passjob_with_test.py
@@ -17,5 +17,5 @@ class PassTest(Test):
 
 
 if __name__ == '__main__':
-    with Job(config) as j:
+    with Job.from_config(job_config=config) as j:
         sys.exit(j.run())


### PR DESCRIPTION
The config needs to be loaded with 'from_config' method of the Job.

Signed-off-by: Willian Rampazzo <willianr@redhat.com>