### PR TITLE
Fixes tmpdirs leftovers

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -147,6 +147,7 @@ class Job:
         self.logfile = None
         self.tmpdir = None
         self.__keep_tmpdir = True
+        self._base_tmpdir = None
         self.status = "RUNNING"
         self.result = None
         self.interrupted_reason = None
@@ -489,6 +490,7 @@ class Job:
         self.__stop_job_logging()
         if not self.__keep_tmpdir and os.path.exists(self.tmpdir):
             shutil.rmtree(self.tmpdir)
+            shutil.rmtree(self._base_tmpdir)
         cleanup_conditionals = (
             self.config.get('run.dry_run.enabled'),
             not self.config.get('run.dry_run.no_cleanup')
@@ -674,9 +676,9 @@ class Job:
         self._setup_job_category()
         # Use "logdir" in case "keep_tmp" is enabled
         if self.config.get('run.keep_tmp'):
-            base_tmpdir = self.logdir
+            self._base_tmpdir = self.logdir
         else:
-            base_tmpdir = data_dir.get_tmp_dir()
+            self._base_tmpdir = tempfile.mkdtemp(prefix="avocado_tmp_")
             self.__keep_tmpdir = False
         self.tmpdir = tempfile.mkdtemp(prefix="avocado_job_",
-                                       dir=base_tmpdir)
+                                       dir=self._base_tmpdir)

--- a/selftests/check_tmp_dirs
+++ b/selftests/check_tmp_dirs
@@ -10,7 +10,9 @@ def check_tmp_dirs():
     fail = False
     for dir_to_check in dirs_to_check:
         dir_list = os.listdir(dir_to_check)
-        avocado_tmp_dirs = [d for d in dir_list if (d.startswith('avocado') and os.path.isdir(d))]
+        avocado_tmp_dirs = [d for d in dir_list
+                            if (d.startswith('avocado')
+                                and os.path.isdir(os.path.join(dir_to_check, d)))]
         try:
             assert len(avocado_tmp_dirs) == 0
             print('No temporary avocado dirs lying around in %s' %

--- a/selftests/check_tmp_dirs
+++ b/selftests/check_tmp_dirs
@@ -4,13 +4,6 @@ import os
 import sys
 import tempfile
 
-# simple magic for using scripts within a source tree
-basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if os.path.isdir(os.path.join(basedir, 'avocado')):
-    os.environ['PATH'] += ":" + os.path.join(basedir, 'scripts')
-    os.environ['PATH'] += ":" + os.path.join(basedir, 'libexec')
-    sys.path.append(basedir)
-
 
 def check_tmp_dirs():
     dirs_to_check = [tempfile.gettempdir()]

--- a/selftests/check_tmp_dirs
+++ b/selftests/check_tmp_dirs
@@ -18,8 +18,8 @@ def check_tmp_dirs():
             print('No temporary avocado dirs lying around in %s' %
                   dir_to_check)
         except AssertionError:
-            print('There are temporary avocado dirs lying around after test: %s',
-                  [os.path.join(dir_to_check, _) for _ in avocado_tmp_dirs])
+            print('There are temporary avocado dirs lying around after test:',
+                  ', '.join([os.path.join(dir_to_check, _) for _ in avocado_tmp_dirs]))
             fail = True
     if fail:
         sys.exit(1)

--- a/selftests/functional/test_job_api_features.py
+++ b/selftests/functional/test_job_api_features.py
@@ -16,14 +16,12 @@ class Test(TestCaseTmpDir):
         super(Test, self).setUp()
         self.base_config = {'core.show': ['none'],
                             'run.results_dir': self.tmpdir.name,
-                            'run.references': ['examples/tests/passtest.py'],
-                            'run.keep_tmp': True}
+                            'run.references': ['examples/tests/passtest.py']}
 
     def test_job_run_result_json_enabled(self):
         self.base_config['job.run.result.json.enabled'] = True
-        j = Job.from_config(self.base_config)
-        j.setup()
-        result = j.run()
+        with Job.from_config(self.base_config) as j:
+            result = j.run()
         self.assertEqual(result, exit_codes.AVOCADO_ALL_OK)
         json_results_path = os.path.join(self.tmpdir.name, 'latest', 'results.json')
         self.assertTrue(os.path.exists(json_results_path))
@@ -31,9 +29,8 @@ class Test(TestCaseTmpDir):
     def test_job_run_result_json_output(self):
         json_results_path = os.path.join(self.tmpdir.name, 'myresults.json')
         self.base_config['job.run.result.json.output'] = json_results_path
-        j = Job.from_config(self.base_config)
-        j.setup()
-        result = j.run()
+        with Job.from_config(self.base_config) as j:
+            result = j.run()
         self.assertEqual(result, exit_codes.AVOCADO_ALL_OK)
         self.assertTrue(os.path.exists(json_results_path))
 

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -198,6 +198,7 @@ if __name__ == '__main__':
     job.setup()
     job.test_suites[0]._runner = RunnerNRunnerWithFixedTasks()
     job.run()
+    job.cleanup()
 """
 
 

--- a/selftests/run
+++ b/selftests/run
@@ -3,54 +3,17 @@
 
 __author__ = 'Lucas Meneghel Rodrigues <lmr@redhat.com>'
 
-import gc
 import os
-import subprocess
 import sys
 import unittest
 
-from avocado.core import data_dir
 from selftests.utils import test_suite
 
-CHECK_TMP_DIRS = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                                              "check_tmp_dirs"))
-
-
-class CheckTmpDirResult(unittest.TextTestResult):
-
-    """
-    Checks after every single test if temp dirs were left in the filesystem
-    """
-
-    def stopTest(self, test):
-        # stopTestRun
-        super(CheckTmpDirResult, self).stopTest(test)
-        # Destroy the data_dir.get_tmpdir ...
-        data_dir._tmp_tracker.unittest_refresh_dir_tracker()
-        # Rung garbage collection (run __del__s) and force-sync disk
-        gc.collect()
-        os.sync()
-        test_name = str(test)
-        try:
-            test.tearDown()
-        except Exception:
-            pass
-        # ... and check whether some dirs were left behind
-        dir_check = subprocess.Popen([sys.executable, CHECK_TMP_DIRS], stdout=subprocess.PIPE,
-                                     stderr=subprocess.STDOUT)
-        if dir_check.wait():
-            raise AssertionError("Test %s left some tmp files behind:\n%s"
-                                 % (test_name, dir_check.stdout.read().decode()))
-
-
 if __name__ == '__main__':
-    if os.environ.get('AVOCADO_CHECK_TMPDIR', False):
-        result_class = CheckTmpDirResult
-    else:
-        result_class = unittest.TextTestResult
-
-    runner = unittest.TextTestRunner(failfast=not os.environ.get("SELF_CHECK_CONTINUOUS"),
-                                     verbosity=1, resultclass=result_class)
+    failfast = not os.environ.get("SELF_CHECK_CONTINUOUS")
+    runner = unittest.TextTestRunner(failfast=failfast,
+                                     verbosity=1,
+                                     resultclass=unittest.TextTestResult)
     result = runner.run(test_suite())
     if result.failures or result.errors:
         sys.exit(1)

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -3,7 +3,7 @@ import os
 import tempfile
 import unittest.mock
 
-from avocado.core import data_dir, exit_codes, job, nrunner, test
+from avocado.core import exit_codes, job, nrunner, test
 from avocado.core.exceptions import (JobBaseException,
                                      JobTestSuiteDuplicateNameError)
 from avocado.core.suite import TestSuite, TestSuiteStatus
@@ -17,7 +17,6 @@ class JobTest(unittest.TestCase):
 
     def setUp(self):
         self.job = None
-        data_dir._tmp_tracker.unittest_refresh_dir_tracker()
         prefix = temp_dir_prefix(self)
         self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
 
@@ -356,7 +355,6 @@ class JobTest(unittest.TestCase):
             _ = job.Job(config, [suite_1, suite_2])
 
     def tearDown(self):
-        data_dir._tmp_tracker.unittest_refresh_dir_tracker()
         self.tmpdir.cleanup()
         if self.job is not None:
             self.job.cleanup()

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -289,10 +289,9 @@ class JobTest(unittest.TestCase):
 
         # Manual/Custom method
         suite = TestSuite('foo-test', config=suite_config, job_config=config)
-        self.job = job.Job(config, [suite])
-        self.job.setup()
-        self.assertEqual(self.job.test_suites[0].config.get('run.results_dir'),
-                         self.tmpdir.name)
+        with job.Job(config, [suite]) as self.job:
+            self.assertEqual(self.job.test_suites[0].config.get('run.results_dir'),
+                             self.tmpdir.name)
 
         # Automatic method passing suites
         self.job = job.Job.from_config(job_config=config,

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -84,8 +84,6 @@ class JobTest(unittest.TestCase):
             self.assertNotEqual(job1.unique_id, job2.unique_id)
             self.assertNotEqual(job1.logdir, job2.logdir)
             self.assertNotEqual(job1.tmpdir, job2.tmpdir)
-            # tmpdirs should share the same base-dir per process
-            self.assertEqual(os.path.dirname(job1.tmpdir), os.path.dirname(job2.tmpdir))
             # due to config logdirs should share the same base-dir
             self.assertEqual(os.path.dirname(job1.logdir), os.path.dirname(job2.logdir))
 

--- a/selftests/unit/test_suite.py
+++ b/selftests/unit/test_suite.py
@@ -1,7 +1,6 @@
 import tempfile
 import unittest.mock
 
-from avocado.core import data_dir
 from avocado.core.suite import TestSuite
 from avocado.utils import path as utils_path
 from selftests.utils import setup_avocado_loggers, temp_dir_prefix
@@ -13,7 +12,6 @@ class TestSuiteTest(unittest.TestCase):
 
     def setUp(self):
         self.suite = None
-        data_dir._tmp_tracker.unittest_refresh_dir_tracker()
         prefix = temp_dir_prefix(self)
         self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
 
@@ -79,7 +77,6 @@ class TestSuiteTest(unittest.TestCase):
         self.assertEqual(self.suite.config.get('core.show'), ['none'])
 
     def tearDown(self):
-        data_dir._tmp_tracker.unittest_refresh_dir_tracker()
         self.tmpdir.cleanup()
 
 


### PR DESCRIPTION
Hi, this is a work on top of cleber's PR. And basically is fixing #4392.

@clebergnu I decided to not deprecate core/data_dir.py:get_tmp_dir()
because I saw a few calls for it on avocado-vt side. We need to decide
if the cleanup part will be delegated the same way we do with job
(enter/exit). So this could be another PR/discussion.