### PR TITLE
Update vmimage tests

### DIFF
--- a/selftests/pre_release/tests/vmimage.py.data/variants.yml
+++ b/selftests/pre_release/tests/vmimage.py.data/variants.yml
@@ -20,10 +20,8 @@ distro: !mux
     ppc:
       arch: powerpc
     version: !mux
-      0.5.1:
-        version: 0.5.1
-      0.5.0:
-        version: 0.5.0
+      0.5.2:
+        version: 0.5.2
       0.4.0:
         version: 0.4.0
   debian:
@@ -39,8 +37,8 @@ distro: !mux
     x86_64:
       arch: amd64
     version: !mux
-      9.13.26:
-        version: 9.13.26-20210722
+      9.13.27:
+        version: 9.13.27-20210919
       10.10.3:
         version: 10.10.3-20210826
   fedora:


### PR DESCRIPTION
Update Debian versions and cirros to only use latest release 0.5.2 and 0.4.0

Tested at https://github.com/ana/avocado/runs/3733800797