### PR TITLE
[utils] network/interface: check if interface is a bonding device

### DIFF
--- a/avocado/utils/network/interfaces.py
+++ b/avocado/utils/network/interfaces.py
@@ -477,6 +477,22 @@ class NetworkInterface:
             log.debug(msg)
             return False
 
+    def is_bond(self):
+        """Check if interface is a bonding device.
+
+        This method checks if the interface is a bonding device or not.
+
+        rtype: bool
+        """
+        cmd = 'cat /proc/net/bonding/{}'.format(self.name)
+        try:
+            run_command(cmd, self.host)
+            return True
+        except Exception as ex:
+            msg = "{} is not a bond device. {}".format(self.name, ex)
+            log.debug(msg)
+            return False
+
     def remove_cfg_file(self):
         """
         Remove any config files that is created as a part of the test


### PR DESCRIPTION
Added a method to interface.py to check if the interface is a bonding device. It
checks to see if /proc/net/bonding/<interface_name> is a valid file. Returns
True if it is, returns False otherwise.

Signed-off-by: Cris Forno <fornosoccer12@gmail.com>