### PR TITLE
Safeloader: filter out properties from test methods results

### DIFF
--- a/avocado/core/safeloader/core.py
+++ b/avocado/core/safeloader/core.py
@@ -24,6 +24,11 @@ def get_methods_info(statement_body, class_tags, class_requirements):
         if not (isinstance(st, (ast.FunctionDef, ast.AsyncFunctionDef))):
             continue
 
+        decorators = getattr(st, 'decorator_list', [])
+        decorator_names = [getattr(_, 'id', None) for _ in decorators]
+        if 'property' in decorator_names:
+            continue
+
         if not st.name.startswith('test'):
             continue
 

--- a/examples/tests/property.py
+++ b/examples/tests/property.py
@@ -1,0 +1,19 @@
+from avocado import Test
+
+
+class Property(Test):
+
+    @property
+    def testing_the_existence_of_properties(self):
+        """
+        This is a bad name for property when writing an Avocado test.
+
+        Its name starts with "test", which would usually make it an
+        Avocado test, but, because it's a property, it's not
+        considered a valid test.
+        """
+        return True
+
+    def test(self):
+        self.log.info("Property exists: %s",
+                      self.testing_the_existence_of_properties)

--- a/selftests/functional/test_resolver.py
+++ b/selftests/functional/test_resolver.py
@@ -1,3 +1,4 @@
+import os
 import stat
 import unittest
 
@@ -7,7 +8,7 @@ from avocado.utils import process, script
 from selftests.functional.test_loader import \
     AVOCADO_TEST_OK as AVOCADO_INSTRUMENTED_TEST
 from selftests.functional.test_loader import SIMPLE_TEST as EXEC_TEST
-from selftests.utils import AVOCADO
+from selftests.utils import AVOCADO, BASEDIR
 
 
 class ResolverFunctional(unittest.TestCase):
@@ -43,6 +44,14 @@ class ResolverFunctional(unittest.TestCase):
             cmd_line = ('%s --verbose list %s' % (AVOCADO, test_file.path))
             result = process.run(cmd_line)
         self.assertIn('passtest.py:PassTest.test', result.stdout_text)
+        self.assertIn('avocado-instrumented: 1', result.stdout_text)
+
+    def test_property(self):
+        test_path = os.path.join(BASEDIR, 'examples', 'tests', 'property.py')
+        cmd_line = ('%s --verbose list %s' % (AVOCADO, test_path))
+        result = process.run(cmd_line)
+        self.assertIn('examples/tests/property.py:Property.test',
+                      result.stdout_text)
         self.assertIn('avocado-instrumented: 1', result.stdout_text)
 
 


### PR DESCRIPTION
Avocado can not currently run properties as tests, so it does not make
sense to present those as valid test methods.

Althought this change makes sense in itself, it is also related to the
existence of the "teststmpdir" property in the "avocado.Test" class,
and the fact that it should not be visible as a test method.

In the future, support for using properties as tests may be added,
along with the removal of "teststmpdir" as stated in eb5190962.

Signed-off-by: Cleber Rosa <crosa@redhat.com>