### PR TITLE
Python unittest support: use SKIP status for skipped tests

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -1307,7 +1307,7 @@ class PythonUnittest(ExternalRunnerTest):
                 self.error("Unknown failure executing the unittest")
         status = self._find_result("OK")
         if "skipped" in status:
-            self.cancel("Unittest reported skip")
+            raise exceptions.TestSkipError("Unittest reported skip")
 
 
 class TapTest(SimpleTest):

--- a/selftests/functional/test_loader.py
+++ b/selftests/functional/test_loader.py
@@ -263,15 +263,14 @@ class LoaderTestFunctional(TestCaseTmpDir):
     def test_python_unittest(self):
         test_path = os.path.join(BASEDIR, "selftests", ".data", "unittests.py")
         cmd = ("%s run --disable-sysinfo --job-results-dir %s --json - "
-               "--test-runner=runner "
                "-- %s" % (AVOCADO, self.tmpdir.name, test_path))
         result = process.run(cmd, ignore_status=True)
         jres = json.loads(result.stdout_text)
         self.assertEqual(result.exit_status, 1, result)
-        exps = [("unittests.Second.test_fail", "FAIL"),
-                ("unittests.Second.test_error", "ERROR"),
-                ("unittests.Second.test_skip", "SKIP"),
-                ("unittests.First.test_pass", "PASS")]
+        exps = [("unittests.py:Second.test_fail", "FAIL"),
+                ("unittests.py:Second.test_error", "ERROR"),
+                ("unittests.py:Second.test_skip", "SKIP"),
+                ("unittests.py:First.test_pass", "PASS")]
         for test in jres["tests"]:
             for exp in exps:
                 if exp[0] in test["id"]:

--- a/selftests/functional/test_loader.py
+++ b/selftests/functional/test_loader.py
@@ -270,7 +270,7 @@ class LoaderTestFunctional(TestCaseTmpDir):
         self.assertEqual(result.exit_status, 1, result)
         exps = [("unittests.Second.test_fail", "FAIL"),
                 ("unittests.Second.test_error", "ERROR"),
-                ("unittests.Second.test_skip", "CANCEL"),
+                ("unittests.Second.test_skip", "SKIP"),
                 ("unittests.First.test_pass", "PASS")]
         for test in jres["tests"]:
             for exp in exps:


### PR DESCRIPTION
Python's unittests do not have the concept of canceled tests, only skipped tests.  But, Avocado has been using `CANCEL` as a status for Python unittests, possibly out of the reasoning that Avocado itself ran "something" in its internal "avocado.core.test.PythonUnittest" class to get to the point of determining the unittest status.
    
Looking closely, and comparing to the nrunner behavior, I believe the current approach is wrong.  A Python unittest that is skipped, should be reported as `SKIP`, and not as `CANCEL`.