### PR TITLE
Python Unittest: add fail/error/skip reason

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -627,12 +627,16 @@ class PythonUnittestRunner(BaseRunner):
         runner = TextTestRunner(stream=stream, verbosity=0)
         unittest_result = runner.run(suite)
 
+        unittest_result_entries = None
         if len(unittest_result.errors) > 0:
             result = 'error'
+            unittest_result_entries = unittest_result.errors
         elif len(unittest_result.failures) > 0:
             result = 'fail'
+            unittest_result_entries = unittest_result.failures
         elif len(unittest_result.skipped) > 0:
             result = 'skip'
+            unittest_result_entries = unittest_result.skipped
         else:
             result = 'pass'
 
@@ -640,6 +644,13 @@ class PythonUnittestRunner(BaseRunner):
         output = {'status': 'finished',
                   'result': result,
                   'output': stream.read()}
+
+        if unittest_result_entries is not None:
+            last_entry = unittest_result_entries[-1]
+            lines = last_entry[1].splitlines()
+            fail_reason = lines[-1]
+            output['fail_reason'] = fail_reason
+
         stream.close()
         queue.put(output)
 

--- a/selftests/functional/test_loader.py
+++ b/selftests/functional/test_loader.py
@@ -267,16 +267,23 @@ class LoaderTestFunctional(TestCaseTmpDir):
         result = process.run(cmd, ignore_status=True)
         jres = json.loads(result.stdout_text)
         self.assertEqual(result.exit_status, 1, result)
-        exps = [("unittests.py:Second.test_fail", "FAIL"),
-                ("unittests.py:Second.test_error", "ERROR"),
-                ("unittests.py:Second.test_skip", "SKIP"),
-                ("unittests.py:First.test_pass", "PASS")]
+        exps = [("unittests.py:Second.test_fail", "FAIL",
+                 "AssertionError: this is suppose to fail"),
+                ("unittests.py:Second.test_error", "ERROR",
+                 "RuntimeError: This is suppose to error"),
+                ("unittests.py:Second.test_skip", "SKIP",
+                 "This is suppose to be skipped"),
+                ("unittests.py:First.test_pass", "PASS", None)]
         for test in jres["tests"]:
             for exp in exps:
                 if exp[0] in test["id"]:
                     self.assertEqual(test["status"], exp[1], "Status of %s not"
-                                     " as expected\n%s" % (exp, result))
+                                     " as expected: %s" % (exp, result))
                     exps.remove(exp)
+                    if exp[2] is not None:
+                        self.assertEqual(test["fail_reason"], exp[2],
+                                         'Fail reason "%s" not as expected: %s'
+                                         % (exp, result))
                     break
             else:
                 self.fail("No expected result for %s\n%s\n\nexps = %s"


### PR DESCRIPTION
While Python's unittest only preserves the reason as text, it's usually possible to give the user a significant reason for the test's fail/error or skip than no reason at all.
