### PR TITLE
Allow customization of the Python command used in "make develop"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,12 +143,16 @@ check: clean develop
 	PYTHON=$(PYTHON) $(PYTHON) selftests/job_api/test_features.py
 	selftests/check_tmp_dirs
 
+ifndef PYTHON_DEVELOP_CMD_ARGS
+PYTHON_DEVELOP_CMD_ARGS=setup.py develop $(PYTHON_DEVELOP_ARGS)
+endif
+
 develop:
 	$(PYTHON) setup.py develop $(PYTHON_DEVELOP_ARGS)
 	for PLUGIN in $(AVOCADO_OPTIONAL_PLUGINS); do\
 		if test -f $$PLUGIN/Makefile -o -f $$PLUGIN/setup.py; then echo ">> LINK $$PLUGIN";\
 			if test -f $$PLUGIN/Makefile; then AVOCADO_DIRNAME=$(AVOCADO_DIRNAME) make -C $$PLUGIN PYTHON="$(PYTHON)" link &>/dev/null;\
-			elif test -f $$PLUGIN/setup.py; then cd $$PLUGIN; $(PYTHON) setup.py develop $(PYTHON_DEVELOP_ARGS); cd -; fi;\
+			elif test -f $$PLUGIN/setup.py; then cd $$PLUGIN; $(PYTHON) $(PYTHON_DEVELOP_CMD_ARGS); cd -; fi;\
 		else echo ">> SKIP $$PLUGIN"; fi;\
 	done
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ def get_long_description():
 if __name__ == '__main__':
     # Force "make develop" inside the "readthedocs.org" environment
     if os.environ.get("READTHEDOCS") and "install" in sys.argv:
-        os.system("make develop")
+        os.system("make PYTHON_DEVELOP_CMD_ARGS='-m pip install .' develop")
     setup(name='avocado-framework',
           version=VERSION,
           description='Avocado Test Framework',


### PR DESCRIPTION
Because of perceived and verified limitations on setuptools, which
installs dependencies of packages, but does not make them fully
available in the installation environment, let's allow users to
customize the command to be used.

This allows us to force a "pip install" based installation on
environments such as readthedocs.org, which may have conflicting
packages.

Fixes: https://github.com/avocado-framework/avocado/issues/5027
Signed-off-by: Cleber Rosa <crosa@redhat.com>

---

A readhtedocs.org build testing the change is available here: https://avocado-clebergnu.readthedocs.io/en/latest/releases/lts/82_1.html