### PR TITLE
utils/vmimage: download directly latest Debian image

### DIFF
--- a/avocado/utils/vmimage.py
+++ b/avocado/utils/vmimage.py
@@ -304,8 +304,7 @@ class DebianImageProvider(ImageProviderBase):
 
     name = 'Debian'
 
-    def __init__(self, version='[0-9]+.[0-9]+.[0-9]+.*', build=None,
-                 arch=DEFAULT_ARCH):
+    def __init__(self, version='[0-9]+', build=None, arch=DEFAULT_ARCH):
         # Debian uses 'amd64' instead of 'x86_64'
         if arch == 'x86_64':
             arch = 'amd64'
@@ -315,8 +314,25 @@ class DebianImageProvider(ImageProviderBase):
 
         super(DebianImageProvider, self).__init__(version, build, arch)
         self.url_versions = 'https://cdimage.debian.org/cdimage/openstack/'
-        self.url_images = self.url_versions + '{version}/'
+        self.url_images = self.url_versions + 'current-{version}/'
         self.image_pattern = 'debian-(?P<version>{version})-openstack-(?P<arch>{arch}).qcow2$'
+
+    @property
+    def version_pattern(self):
+        return '^current-%s' % self._version
+
+    @staticmethod
+    def _convert_version_numbers(versions):
+        """
+        Remove current- prefix and return only the version numbers
+        """
+        pattern = r'(^current-)?([0-9]+)'
+        replace = r'\2'
+        return [re.sub(pattern, replace, str(v)) for v in versions]
+
+    def get_versions(self):
+        versions = super().get_versions()
+        return self._convert_version_numbers(versions)
 
 
 class JeosImageProvider(ImageProviderBase):

--- a/selftests/pre_release/tests/vmimage.py.data/variants.yml
+++ b/selftests/pre_release/tests/vmimage.py.data/variants.yml
@@ -37,10 +37,10 @@ distro: !mux
     x86_64:
       arch: amd64
     version: !mux
-      9.13.28:
-        version: 9.13.28-20211002
-      10.11.0:
-        version: 10.11.0
+      9:
+        version: 9
+      10:
+        version: 10
   fedora:
     name: fedora
     !filter-out : /run/architectures/arm

--- a/selftests/unit/utils/test_vmimage.py
+++ b/selftests/unit/utils/test_vmimage.py
@@ -207,7 +207,7 @@ class DebianImageProvider(unittest.TestCase):
         urlread_mocked = unittest.mock.Mock(return_value=self.VERSION_LISTING)
         urlopen_mock.return_value = unittest.mock.Mock(read=urlread_mocked)
         provider = vmimage.DebianImageProvider()
-        self.assertEqual(provider.get_versions(), ['9.12.0', '10.3.0'])
+        self.assertEqual(provider.get_versions(), ['9', '10'])
 
 
 class OpenSUSEImageProvider(unittest.TestCase):


### PR DESCRIPTION
Download directly the latest image for a given Debian version.
This is done by downloading the the image pointed by the
`current-$VERSION` symlink.

Update `variants.yml ` accordingly.

---
Important note: **this is for 92.0 if we decide it's a good idea to include it.**  Eventually (if) we do a new release, `variants.yml `  will need to be updated with the Debian versions. With this change, it'll continue to work unless https://cdimage.debian.org/cdimage/openstack/ is retired.

If we don't accept this PR for 92.0,  I'll close it because for post-92.0 I'm sending a new PR migrating to http://cloud.debian.org (https://github.com/avocado-framework/avocado/issues/5029 )