### PR TITLE
avocado.utils.process.run(): provide a clearer exception on bad input

### DIFF
--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -86,6 +86,10 @@ class CmdError(Exception):
                 (self.command, self.result.stdout, self.result.stderr, self.additional_text))
 
 
+class CmdInputError(Exception):
+    """Raised when the command given is invalid, such as an empty command."""
+
+
 def can_sudo(cmd=None):
     """
     Check whether sudo is available (or running as root)
@@ -1074,6 +1078,8 @@ def run(cmd, timeout=None, verbose=True, ignore_status=False,
     :return: An :class:`CmdResult` object.
     :raise: :class:`CmdError`, if ``ignore_status=False``.
     """
+    if not cmd:
+        raise CmdInputError("Invalid empty command")
     if encoding is None:
         encoding = astring.ENCODING
     klass = get_sub_process_klass(cmd)

--- a/selftests/unit/utils/test_process.py
+++ b/selftests/unit/utils/test_process.py
@@ -502,6 +502,10 @@ class MiscProcessTests(unittest.TestCase):
                          process.kill_process_tree(31))
         self.assertEqual(sleep.call_count, 0)
 
+    def test_empty_command(self):
+        with self.assertRaises(process.CmdInputError):
+            process.run("")
+
 
 class CmdResultTests(unittest.TestCase):
 


### PR DESCRIPTION
An empty command is an example of an invalid input for run().  Instead
of letting secondary code choke on bad input, let's signal that
condition to the user as early and clearly as possible.

Fixes: https://github.com/avocado-framework/avocado/issues/5036
Signed-off-by: Cleber Rosa <crosa@redhat.com>