### PR TITLE
Selftests: print test logs for failures, errors and interruptions

### DIFF
--- a/selftests/check.py
+++ b/selftests/check.py
@@ -545,8 +545,7 @@ def create_suites(args):  # pylint: disable=W0621
     config_check = {
         'run.references': selftests,
         'run.test_runner': 'nrunner',
-        'run.ignore_missing_references': True,
-        'job.output.testlogs.statuses': ['FAIL']
+        'run.ignore_missing_references': True
     }
 
     if args.static_checks:
@@ -613,7 +612,9 @@ def main(args):  # pylint: disable=W0621
     # Job execution
     # ========================================================================
     config = {'core.show': ['app'],
-              'run.test_runner': 'nrunner'}
+              'run.test_runner': 'nrunner',
+              'job.output.testlogs.statuses': ['FAIL', 'ERROR', 'INTERRUPT'],
+              'job.output.testlogs.logfiles': ['debug.log']}
 
     # Workaround for travis problem on arm64 - https://github.com/avocado-framework/avocado/issues/4768
     if (platform.machine() == 'aarch64'):


### PR DESCRIPTION
The selftests are run via "check.py" on a number of different
environments, including ones which are hard or even impossible to
debug interactively.

To ease debugging, or sometimes enable any debugging whatsoever, lets
always print the test logs on any "not OK" situation.

Also, include standalone and "raw" stdout and stderr files.

Signed-off-by: Cleber Rosa <crosa@redhat.com>