### PR TITLE
Debian: fix packaging errors

### DIFF
--- a/contrib/packages/debian/avocado.lintian-overrides
+++ b/contrib/packages/debian/avocado.lintian-overrides
@@ -1,0 +1,3 @@
+# Those files describes the purpose of the directory they are in
+avocado: package-contains-documentation-outside-usr-share-doc usr/lib/python3/dist-packages/avocado/etc/avocado/scripts/job/post.d/README
+avocado: package-contains-documentation-outside-usr-share-doc usr/lib/python3/dist-packages/avocado/etc/avocado/scripts/job/pre.d/README

--- a/contrib/packages/debian/avocado.manpages
+++ b/contrib/packages/debian/avocado.manpages
@@ -1,0 +1,1 @@
+man/avocado*.1

--- a/contrib/packages/debian/control
+++ b/contrib/packages/debian/control
@@ -2,12 +2,18 @@ Source: avocado
 Section: python
 Priority: optional
 Maintainer: Lucas Meneghel Rodrigues (lmr) <lookkas@gmail.com>
-Build-Depends: debhelper (>=7.0.50~), python3, python3-setuptools, dh-python, python3-docutils
-Standards-Version: 3.8.4
+Build-Depends: debhelper (>= 10), python3, python3-setuptools, dh-python, python3-docutils
+Standards-Version: 4.6.0
 
 Package: avocado
 Architecture: all
 Homepage: http://avocado-framework.github.io/
 X-Python-Version: ${python:Versions}
 Depends: ${misc:Depends}, ${python3:Depends}
-Description: Avocado is a framework for fully automated testing.
+Description: Framework with tools and libraries for Automated Testing
+ It is a set of tools and libraries to help with automated testing.
+ One can call it a test framework with benefits. Native tests are written
+ in Python and they follow the unittest pattern, but any executable can serve
+ as a test.
+ .
+ This package contains tools and libraries for avocado automated testing.

--- a/contrib/packages/debian/control
+++ b/contrib/packages/debian/control
@@ -2,7 +2,7 @@ Source: avocado
 Section: python
 Priority: optional
 Maintainer: Lucas Meneghel Rodrigues (lmr) <lookkas@gmail.com>
-Build-Depends: debhelper (>=7.0.50~), cdbs (>= 0.4.49), python3, python3-setuptools, dh-python, python3-docutils
+Build-Depends: debhelper (>=7.0.50~), python3, python3-setuptools, dh-python, python3-docutils
 Standards-Version: 3.8.4
 
 Package: avocado

--- a/contrib/packages/debian/control
+++ b/contrib/packages/debian/control
@@ -2,7 +2,7 @@ Source: avocado
 Section: python
 Priority: optional
 Maintainer: Lucas Meneghel Rodrigues (lmr) <lookkas@gmail.com>
-Build-Depends: debhelper (>=7.0.50~), cdbs (>= 0.4.49), python3, python3-setuptools, dh-python
+Build-Depends: debhelper (>=7.0.50~), cdbs (>= 0.4.49), python3, python3-setuptools, dh-python, python3-docutils
 Standards-Version: 3.8.4
 
 Package: avocado

--- a/contrib/packages/debian/rules
+++ b/contrib/packages/debian/rules
@@ -1,5 +1,6 @@
 #!/usr/bin/make -f
 # -*- makefile -*-
+export PYBUILD_AFTER_BUILD={interpreter} setup.py man
 
 clean::
 	rm -rf build build-stamp configure-stamp build/ MANIFEST


### PR DESCRIPTION
After checking avocado deb package with lintian tool several issues occurred:
```
$ lintian -I ../avocado_91.0_amd64.changes --no-tag-display-limit
E: avocado source: source-is-missing optional_plugins/html/avocado_result_html/templates/bootstrap.min.js
E: avocado source: source-is-missing optional_plugins/html/avocado_result_html/templates/datatables.min.js
E: avocado source: source-is-missing optional_plugins/html/avocado_result_html/templates/jquery.min.js
W: avocado source: unused-build-dependency-on-cdbs
W: avocado source: package-needs-versioned-debhelper-build-depends 10
W: avocado source: changelog-should-mention-nmu
W: avocado source: source-nmu-has-incorrect-version-number 91.0
W: avocado source: ancient-standards-version 3.8.4 (released 2010-01-27) (current is 4.3.0)
I: avocado source: testsuite-autopkgtest-missing
W: avocado source: debian-watch-file-in-native-package
E: avocado: description-starts-with-package-name
I: avocado: description-synopsis-might-not-be-phrased-properly "Avocado is a framework for fully automated testing."
E: avocado: extended-description-is-empty
I: avocado: package-contains-documentation-outside-usr-share-doc usr/lib/python3/dist-packages/avocado/etc/avocado/scripts/job/post.d/README
I: avocado: package-contains-documentation-outside-usr-share-doc usr/lib/python3/dist-packages/avocado/etc/avocado/scripts/job/pre.d/README
W: avocado: binary-without-manpage usr/bin/avocado
W: avocado: binary-without-manpage usr/bin/avocado-runner
W: avocado: binary-without-manpage usr/bin/avocado-runner-avocado-instrumented
W: avocado: binary-without-manpage usr/bin/avocado-runner-dry-run
W: avocado: binary-without-manpage usr/bin/avocado-runner-exec-test
W: avocado: binary-without-manpage usr/bin/avocado-runner-noop
W: avocado: binary-without-manpage usr/bin/avocado-runner-python-unittest
W: avocado: binary-without-manpage usr/bin/avocado-runner-requirement-asset
W: avocado: binary-without-manpage usr/bin/avocado-runner-requirement-package
W: avocado: binary-without-manpage usr/bin/avocado-runner-sysinfo
W: avocado: binary-without-manpage usr/bin/avocado-runner-tap
W: avocado: binary-without-manpage usr/bin/avocado-software-manager
```
Providing fixes to make avocado package satisfy [Debian Policy](https://www.debian.org/doc/debian-policy/index.html).