### PR TITLE
Adding autom confirmation for softwareraid creation

### DIFF
--- a/avocado/utils/softwareraid.py
+++ b/avocado/utils/softwareraid.py
@@ -109,7 +109,7 @@ class SoftwareRaid:
         :return: True if raid is created. False otherwise.
         :rtype: bool
         """
-        cmd = "mdadm --create --assume-clean %s" % self.name
+        cmd = "yes | mdadm --create --assume-clean %s" % self.name
         cmd += " --level=%s" % self.level
         cmd += " --raid-devices=%d %s" % (len(self.disks),
                                           " ".join(self.disks))


### PR DESCRIPTION
avocado tests are failing as it is aborting while creating
softwareraid. This is because it ask for confirmation
for disk over write with raid signiture before creating raid on it.
So for same to happen automatically, adding "yes" in the command
to over come this issue

Signed-off-by: Naresh Bannoth <nbannoth@in.ibm.com>