### PR TITLE
Option `--show` fix 

### DIFF
--- a/avocado/core/runners/utils/messages.py
+++ b/avocado/core/runners/utils/messages.py
@@ -29,7 +29,7 @@ class GenericMessage:
 
     @classmethod
     def get(cls, **kwargs):
-        """Creates message base on it's type with  all necessary information.
+        """Creates message base on it's type with all necessary information.
 
         :return: message dict which can be send to avocado server
         :rtype: dict
@@ -53,7 +53,7 @@ class FinishedMessage(GenericMessage):
 
     @classmethod
     def get(cls, result, fail_reason=None, returncode=None):  # pylint: disable=W0221
-        """Creates finished message with  all necessary information.
+        """Creates finished message with all necessary information.
 
         :param result: test result
         :type result values for the statuses defined in
@@ -92,7 +92,7 @@ class GenericRunningMessage(GenericMessage):
 
     @classmethod
     def get(cls, msg, **kwargs):  # pylint: disable=W0221
-        """Creates running message with  all necessary information.
+        """Creates running message with all necessary information.
 
         :param msg: log of running message
         :type msg: str
@@ -108,22 +108,22 @@ class LogMessage(GenericRunningMessage):
 
 
 class StdoutMessage(GenericRunningMessage):
-    """Creates stdout message with  all necessary information."""
+    """Creates stdout message with all necessary information."""
     message_type = 'stdout'
 
 
 class StderrMessage(GenericRunningMessage):
-    """Creates stderr message with  all necessary information."""
+    """Creates stderr message with all necessary information."""
     message_type = 'stderr'
 
 
 class WhiteboardMessage(GenericRunningMessage):
-    """Creates whiteboard message with  all necessary information."""
+    """Creates whiteboard message with all necessary information."""
     message_type = 'whiteboard'
 
 
 class FileMessage(GenericRunningMessage):
-    """Creates file message with  all necessary information."""
+    """Creates file message with all necessary information."""
     message_type = 'file'
 
     @classmethod

--- a/docs/source/guides/writer/chapters/logging.rst
+++ b/docs/source/guides/writer/chapters/logging.rst
@@ -46,24 +46,25 @@ Using --show
 Alternatively, you can ask Avocado to show your logging stream, either
 exclusively or in addition to other builtin streams::
 
-    $ avocado --show app,avocado.test.progress run --test-runner='runner' -- logging_streams.py
+    $ avocado --show app,avocado.test.progress run -- examples/tests/logging_streams.py
 
 The outcome should be similar to::
 
     JOB ID     : af786f86db530bff26cd6a92c36e99bedcdca95b
     JOB LOG    : /home/user/avocado/job-results/job-2016-03-18T10.29-af786f8/job.log
-     (1/1) logging_streams.py:Plant.test_plant_organic: avocado.test.progress: 1-logging_streams.py:Plant.test_plant_organic: preparing soil on row 0
-    avocado.test.progress: 1-logging_streams.py:Plant.test_plant_organic: preparing soil on row 1
-    avocado.test.progress: 1-logging_streams.py:Plant.test_plant_organic: preparing soil on row 2
-    avocado.test.progress: 1-logging_streams.py:Plant.test_plant_organic: letting soil rest before throwing seeds
-    avocado.test.progress: 1-logging_streams.py:Plant.test_plant_organic: throwing seeds on row 0
-    avocado.test.progress: 1-logging_streams.py:Plant.test_plant_organic: throwing seeds on row 1
-    avocado.test.progress: 1-logging_streams.py:Plant.test_plant_organic: throwing seeds on row 2
-    avocado.test.progress: 1-logging_streams.py:Plant.test_plant_organic: waiting for Avocados to grow
-    avocado.test.progress: 1-logging_streams.py:Plant.test_plant_organic: harvesting organic avocados on row 0
-    avocado.test.progress: 1-logging_streams.py:Plant.test_plant_organic: harvesting organic avocados on row 1
-    avocado.test.progress: 1-logging_streams.py:Plant.test_plant_organic: harvesting organic avocados on row 2
-    PASS (7.01 s)
+    (1/1) examples/tests/logging_streams.py:Plant.test_plant_organic: STARTED
+    1-examples/tests/logging_streams.py:Plant.test_plant_organic: avocado.test.progress: 1-Plant.test_plant_organic: preparing soil on row 0
+    1-examples/tests/logging_streams.py:Plant.test_plant_organic: avocado.test.progress: 1-Plant.test_plant_organic: preparing soil on row 1
+    1-examples/tests/logging_streams.py:Plant.test_plant_organic: avocado.test.progress: 1-Plant.test_plant_organic: preparing soil on row 2
+    1-examples/tests/logging_streams.py:Plant.test_plant_organic: avocado.test.progress: 1-Plant.test_plant_organic: letting soil rest before throwing seeds
+    1-examples/tests/logging_streams.py:Plant.test_plant_organic: avocado.test.progress: 1-Plant.test_plant_organic: throwing seeds on row 0
+    1-examples/tests/logging_streams.py:Plant.test_plant_organic: avocado.test.progress: 1-Plant.test_plant_organic: throwing seeds on row 1
+    1-examples/tests/logging_streams.py:Plant.test_plant_organic: avocado.test.progress: 1-Plant.test_plant_organic: throwing seeds on row 2
+    1-examples/tests/logging_streams.py:Plant.test_plant_organic: avocado.test.progress: 1-Plant.test_plant_organic: waiting for Avocados to grow
+    1-examples/tests/logging_streams.py:Plant.test_plant_organic: avocado.test.progress: 1-Plant.test_plant_organic: harvesting organic avocados on row 0
+    1-examples/tests/logging_streams.py:Plant.test_plant_organic: avocado.test.progress: 1-Plant.test_plant_organic: harvesting organic avocados on row 1
+    1-examples/tests/logging_streams.py:Plant.test_plant_organic: avocado.test.progress: 1-Plant.test_plant_organic: harvesting organic avocados on row 2
+     (1/1) examples/tests/logging_streams.py:Plant.test_plant_organic: PASS (3.02 s)
     RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0
     JOB TIME   : 7.11 s
     JOB HTML   : /home/user/avocado/job-results/job-2016-03-18T10.29-af786f8/html/results.html

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -455,6 +455,15 @@ class RunnerOperationTest(TestCaseTmpDir):
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
         self.assertEqual(result.stdout, b'')
 
+    def test_show_user_stream(self):
+        cmd_line = ('%s --show=app,avocado.test.progress run --disable-sysinfo '
+                    '--job-results-dir %s examples/tests/logging_streams.py' %
+                    (AVOCADO, self.tmpdir.name))
+        result = process.run(cmd_line, ignore_status=True)
+        self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
+        self.assertIn(b'Plant.test_plant_organic: preparing soil on row 0',
+                      result.stdout)
+
     def test_empty_args_list(self):
         cmd_line = AVOCADO
         result = process.run(cmd_line, ignore_status=True)


### PR DESCRIPTION
This adds the ability for the runners to print user-specific logging
streams to the console when the `--show` command is used.

Reference: #5014
Signed-off-by: Jan Richter <jarichte@redhat.com>