### PR TITLE
selftests/check.py: Implement --select / --skip arguments (v2 reimplementation)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -71,7 +71,7 @@ debian_egg_task:
 fedora_selftests_task:
     selftests_script:
        - make develop
-       - PATH=$HOME/.local/bin:$PATH LANG=en_US.UTF-8 AVOCADO_CHECK_LEVEL=0 python3 selftests/check.py --job-api --nrunner-interface --unit --jobs --functional --optional-plugins
+       - PATH=$HOME/.local/bin:$PATH LANG=en_US.UTF-8 AVOCADO_CHECK_LEVEL=0 python3 selftests/check.py  --skip static-checks
     container:
         matrix:
           - image: quay.io/avocado-framework/avocado-ci-fedora-33

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -88,7 +88,7 @@ jobs:
         run: |
           export AVOCADO_LOG_DEBUG="yes"
           export AVOCADO_CHECK_LEVEL="1"
-          python selftests/check.py --disable-plugin-checks golang --disable-plugin-checks html --disable-plugin-checks resultsdb --disable-plugin-checks result_upload --disable-plugin-checks robot --disable-plugin-checks varianter_cit --disable-plugin-checks varianter_pict --disable-plugin-checks varianter_yaml_to_mux
+          python3 selftests/check.py --disable-plugin-checks golang,html,resultsdb,result_upload,robot,varianter_cit,varianter_pict,varianter_yaml_to_mux
       - name: Archive test logs
         if: failure()
         uses: actions/upload-artifact@v2

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -28,7 +28,7 @@
 Summary: Framework with tools and libraries for Automated Testing
 Name: python-avocado
 Version: 93.0
-Release: 1%{?gitrel}%{?dist}
+Release: 2%{?gitrel}%{?dist}
 License: GPLv2+ and GPLv2 and MIT
 URL: https://avocado-framework.github.io/
 %if 0%{?rel_build}
@@ -183,7 +183,7 @@ PATH=%{buildroot}%{_bindir}:%{buildroot}%{_libexecdir}/avocado:$PATH \
     PYTHONPATH=%{buildroot}%{python3_sitelib}:. \
     LANG=en_US.UTF-8 \
     AVOCADO_CHECK_LEVEL=0 \
-    %{python3} selftests/check.py --job-api --nrunner-interface --unit --jobs --functional --optional-plugins --disable-plugin-checks robot
+    %{python3} selftests/check.py --skip static-checks --disable-plugin-checks robot
 %endif
 
 %files -n python3-avocado
@@ -379,6 +379,9 @@ Again Shell code (and possibly other similar shells).
 %{_libexecdir}/avocado*
 
 %changelog
+* Wed Nov 17 2021 Ana Guerrero Lopez <anguerre@redhat.com> - 93.0-2
+- Adjust selftest/check.py to use new --skip option
+
 * Wed Nov 17 2021 Cleber Rosa <crosa@redhat.com> - 93.0-1
 - New release
 

--- a/setup.py
+++ b/setup.py
@@ -200,39 +200,23 @@ class Test(SimpleCommand):
 
     description = 'Run selftests'
     user_options = [
-        ("job-api", None, "Run job API checks"),
-        ("static-checks", None, "Run static checks (isort, lint, etc)"),
-        ("nrunner-interface", None, "Run selftests/functional/test_nrunner_interface.py"),
-        ("unit", None, "Run selftests/unit/"),
-        ("jobs", None, "Run selftests/jobs/"),
-        ("functional", None, "Run selftests/functional/"),
-        ("optional-plugins", None, "Run optional_plugins/*/tests/"),
+        ("skip=", None, "Run all tests and skip listed tests, separated by comma"),
+        ("select=", None, "Do not run any test, only these listed after, separated by comma"),
         ("disable-plugin-checks=", None, "Disable checks for one or more plugins (by directory name), separated by comma"),
         ("list-features", None, "Show the features tested by this test")
     ]
 
     def initialize_options(self):
-        self.job_api = False  # pylint: disable=W0201
-        self.static_checks = False  # pylint: disable=W0201
-        self.nrunner_interface = False  # pylint: disable=W0201
-        self.unit = False  # pylint: disable=W0201
-        self.jobs = False  # pylint: disable=W0201
-        self.functional = False  # pylint: disable=W0201
-        self.optional_plugins = False  # pylint: disable=W0201
+        self.skip = []  # pylint: disable=W0201
+        self.select = []  # pylint: disable=W0201
         self.disable_plugin_checks = []  # pylint: disable=W0201
         self.list_features = False  # pylint: disable=W0201
 
     def run(self):
-
         args = argparse.Namespace()
-        args.static_checks = self.static_checks
-        args.job_api = self.job_api
-        args.nrunner_interface = self.nrunner_interface
-        args.unit = self.unit
-        args.jobs = self.jobs
-        args.functional = self.functional
-        args.optional_plugins = self.optional_plugins
-        args.disable_plugin_checks = self.disable_plugin_checks
+        args.skip = self.skip if len(self.skip) == 0 else [self.skip]
+        args.select = self.select if len(self.select) == 0 else [self.select]
+        args.disable_plugin_checks = self.disable_plugin_checks if len(self.disable_plugin_checks) == 0 else [self.disable_plugin_checks]
         args.list_features = self.list_features
 
         # Import here on purpose, otherwise it'll mess with install/develop commands


### PR DESCRIPTION
This is a implementation of https://github.com/avocado-framework/avocado/pull/4954

With --select and --skip we have a bigger flexibility choosing the tests we want to run.
    
By default, with no argument, it'll run all tests
    
      python3 selftests/check.py
    
 To run all the test except a given one, we can use `--skip`
    
      python3 selftests/check.py --skip static-checks
    
 To run only one or several selected tests, use `--select`
    
      python3 selftests/check.py --select static-checks,unit
    
If we also want to avoid running the tests of one of the plugins:
    
      python3 selftests/check.py --skip nrunner-interface,static-check \
                                 --disable-plugin-checks golang,robot
    
 Add also a hidden argument `--dict-tests` that stores a dict with the list of tests provided by `--select` and `--skip`.

`setup.py` has been updated accordingly to handle all these options with the command `test`.

I have added a new GitHub action to test  extensively the options of `selfchecks/check.py`, you can see a run here: https://github.com/ana/avocado/actions/runs/1386076081

And finally updated all the scripts using `selfchecks/check.py`  to work with the new command options.

Once this is merged, the changes for https://github.com/avocado-framework/avocado/issues/4919 will be straightforward.

