### PR TITLE
exec-test like external runner

### DIFF
--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -216,7 +216,7 @@ class Runner(RunnerInterface):
         else:
             prefix = index
         test_id = TestID(prefix,
-                         runnable.uri,
+                         runnable.identifier,
                          variant,
                          no_digits)
         # inject variant on runnable

--- a/examples/jobs/exec_test_command.py
+++ b/examples/jobs/exec_test_command.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+import sys
+
+from avocado.core.job import Job
+
+job_config = {'resolver.references': ['https://avocado-project.org'],
+              'resolver.exec_test.command': '/usr/bin/curl',
+              'run.test_runner': 'nrunner'}
+
+with Job.from_config(job_config=job_config) as job:
+    sys.exit(job.run())

--- a/examples/jobs/exec_test_command_podman.py
+++ b/examples/jobs/exec_test_command_podman.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+import sys
+
+from avocado.core.job import Job
+
+job_config = {'resolver.references': ['/etc/fedora-release'],
+              'resolver.exec_test.command': '/bin/cat',
+              'nrunner.spawner': 'podman',
+              'spawner.podman.image': 'fedora:rawhide',
+              'run.test_runner': 'nrunner'}
+
+with Job.from_config(job_config=job_config) as job:
+    sys.exit(job.run())

--- a/selftests/unit/test_nrunner.py
+++ b/selftests/unit/test_nrunner.py
@@ -74,7 +74,7 @@ class Runnable(unittest.TestCase):
         runnable = nrunner.Runnable('noop', 'uri', 'arg1', 'arg2')
         actual_args = runnable.get_command_args()
         exp_args = ['-k', 'noop', '-u', 'uri', '-c', '{}', '-a', 'arg1',
-                    '-a', 'arg2']
+                    '-a', 'arg2', '-d', 'uri']
         self.assertEqual(actual_args, exp_args)
 
     def test_get_dict(self):
@@ -82,6 +82,7 @@ class Runnable(unittest.TestCase):
         self.assertEqual(runnable.get_dict(),
                          {'kind': 'noop', 'uri': '_uri_',
                           'args': ('arg1', 'arg2'),
+                          'id_attr': 'uri',
                           'config': {}})
 
     def test_get_json(self):
@@ -89,7 +90,8 @@ class Runnable(unittest.TestCase):
         expected = ('{"kind": "noop", '
                     '"uri": "_uri_", '
                     '"config": {}, '
-                    '"args": ["arg1", "arg2"]}')
+                    '"args": ["arg1", "arg2"], '
+                    '"id_attr": "uri"}')
         self.assertEqual(runnable.get_json(), expected)
 
     def test_runner_from_runnable_error(self):
@@ -98,6 +100,15 @@ class Runnable(unittest.TestCase):
             runnable.pick_runner_class()
         except ValueError as e:
             self.assertEqual(str(e), 'Unsupported kind of runnable: unsupported_kind')
+
+    def test_runnable_identifier_uri(self):
+        runnable = nrunner.Runnable('noop', 'uri', 'arg1', 'arg2')
+        self.assertEqual(runnable.identifier, 'uri')
+
+    def test_runnable_identifier_args(self):
+        runnable = nrunner.Runnable('noop', 'uri', 'arg1', 'arg2',
+                                    id_attr='args')
+        self.assertEqual(runnable.identifier, 'arg1-arg2')
 
 
 class RunnableFromCommandLineArgs(unittest.TestCase):

--- a/setup.py
+++ b/setup.py
@@ -354,6 +354,7 @@ if __name__ == '__main__':
                   "nrunner = avocado.plugins.runner_nrunner:RunnerInit",
                   "testlogsui = avocado.plugins.testlogs:TestLogsUIInit",
                   "human = avocado.plugins.human:HumanInit",
+                  "exec-test-resolver = avocado.plugins.resolvers:ExecTestResolverInit",
               ],
               'avocado.plugins.cli': [
                   'wrapper = avocado.plugins.wrapper:Wrapper',


### PR DESCRIPTION
This allow users to achieve the same behavior as the "external runner" feature of the legacy runner.
    
With the removal of the legacy runner, we can evaluate if a layer of compatibility for the `--external-runner` command line option should be added on top of this feature.