### PR TITLE
Avocado replay command configuration fix

### DIFF
--- a/avocado/core/jobdata.py
+++ b/avocado/core/jobdata.py
@@ -75,7 +75,9 @@ def record(job, cmdline=None):
         os.fsync(pwd_file)
 
     with open(path_job_config, 'w') as job_config_file:
-        json.dump(job.config, job_config_file, default=lambda x: None)
+        json.dump(job.config, job_config_file,
+                  default=lambda x:
+                  {"__set__": list(x)} if isinstance(x, set) else None)
         job_config_file.flush()
         os.fsync(job_config_file)
 
@@ -128,7 +130,9 @@ def retrieve_job_config(resultsdir):
     recorded_job_config = _retrieve(resultsdir, JOB_CONFIG_FILENAME)
     if recorded_job_config:
         with open(recorded_job_config, 'r') as job_config_file:
-            return json.load(job_config_file)
+            return json.load(job_config_file,
+                             object_hook=lambda x:
+                             set(x['__set__']) if '__set__' in x else x)
 
 
 def retrieve_config(resultsdir):

--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -15,11 +15,11 @@
 """Replay Job Plugin"""
 
 import json
-import os
 import sys
 
 from avocado.core import exit_codes, job, output
 from avocado.core.data_dir import get_job_results_dir
+from avocado.core.jobdata import retrieve_job_config
 from avocado.core.plugin_interfaces import CLICmd
 from avocado.core.settings import settings
 
@@ -53,17 +53,17 @@ class Replay(CLICmd):
     def _retrieve_source_job_config(source_job_id):
         results_dir = get_job_results_dir(source_job_id)
         if not results_dir:
-            msg = 'Could not find the results directory for Job "%s"' % source_job_id
+            msg = ('Could not find the results directory for Job "%s"' %
+                   source_job_id)
             Replay._exit_fail(msg)
-        config_file_path = os.path.join(results_dir, 'jobdata', 'args.json')
         try:
-            with open(config_file_path, 'r') as config_file:
-                return json.load(config_file)
+            return retrieve_job_config(results_dir)
         except OSError:
-            msg = 'Could not open the source Job configuration "%s"' % config_file_path
+            msg = 'Could not open the %s Job configuration' % source_job_id
             Replay._exit_fail(msg)
         except json.decoder.JSONDecodeError:
-            msg = 'Could not read a valid configuration from file "%s"' % config_file_path
+            msg = ('Could not read a valid configuration of Job "%s"' %
+                   source_job_id)
             Replay._exit_fail(msg)
 
     def run(self, config):


### PR DESCRIPTION
This is and fix for storing job configuration values into the record. This bug was causing problems with replay command reported in #5060. This PR reserve a dict with key `__set__` as a flag for `set` type inside job configuration record. With this change the `sets` can be saved and restored from job configuration records, which wasn't possible before.