### PR TITLE
Enhancing the get_disks_in_pci_address method in pci.py

### DIFF
--- a/avocado/utils/pci.py
+++ b/avocado/utils/pci.py
@@ -95,14 +95,10 @@ def get_disks_in_pci_address(pci_address):
 
     :return: list of disks in a PCI address.
     """
-    disks_path = "/dev/disk/by-path/"
     disk_list = []
-    if not os.path.exists(disks_path):
-        return disk_list
-    for dev in os.listdir(disks_path):
-        if pci_address in dev:
-            link = os.readlink(os.path.join(disks_path, dev))
-            disk_list.append(os.path.abspath(os.path.join(disks_path, link)))
+    for device in os.listdir('/sys/block'):
+        if pci_address in os.path.realpath(os.path.join('/sys/block', device)):
+            disk_list.append('/dev/%s' % device)
     return disk_list
 
 


### PR DESCRIPTION
Current method returns disks along with thier partition,
which is not required clumsy. Most of the script uses only the disk and
not its partitions. Hence modified it to get exact disks list
only omiting the partition details.

Signed-off-by: Naresh Bannoth <nbannoth@in.ibm.com>