### PR TITLE
Job results data: have a separate variants for each test suite

### DIFF
--- a/docs/source/guides/user/chapters/results.rst
+++ b/docs/source/guides/user/chapters/results.rst
@@ -16,7 +16,7 @@ results directory structure can be seen below ::
     │   ├── config
     │   ├── pwd
     │   ├── test_references
-    │   └── variants.json
+    │   └── variants-1.json
     ├── job.log
     ├── results.html
     ├── results.json

--- a/docs/source/guides/writer/chapters/parameters.rst
+++ b/docs/source/guides/writer/chapters/parameters.rst
@@ -165,12 +165,12 @@ There are two ways to acquire the JSON serialized variants file:
     variants.json: ASCII text, with very long lines, with no line terminators
 
 - Getting the auto-generated JSON serialized variants file after a Avocado Job
-  execution::
+  execution (named with a numeric index for each of the job's suites)::
 
     $ avocado run examples/tests/passtest.py --mux-yaml examples/yaml_to_mux/hw/hw.yaml
     ...
 
-    $ file $HOME/avocado/job-results/latest/jobdata/variants.json
+    $ file $HOME/avocado/job-results/latest/jobdata/variants-1.json
     $HOME/avocado/job-results/latest/jobdata/variants.json: ASCII text, with very long lines, with no line terminators
 
 Once you have the ``variants.json`` file, you can load it on the system where

--- a/optional_plugins/varianter_yaml_to_mux/tests/test_functional.py
+++ b/optional_plugins/varianter_yaml_to_mux/tests/test_functional.py
@@ -63,7 +63,7 @@ class MultiplexTests(unittest.TestCase):
         self.run_and_check(cmd_line, expected_rc, (4, 0))
         # Also check whether jobdata contains correct parameter paths
         with open(os.path.join(self.tmpdir.name, "latest", "jobdata",
-                               "variants.json")) as variants_file:
+                               "variants-1.json")) as variants_file:
             variants = variants_file.read()
         self.assertIn('["/run/*"]', variants, "parameter paths stored in "
                       "jobdata does not contains [\"/run/*\"]\n%s" % variants)
@@ -78,7 +78,7 @@ class MultiplexTests(unittest.TestCase):
         self.run_and_check(cmd_line, exit_codes.AVOCADO_ALL_OK, (8, 0))
         # Also check whether jobdata contains correct parameter paths
         with open(os.path.join(self.tmpdir.name, "latest", "jobdata",
-                               "variants.json")) as variants_file:
+                               "variants-1.json")) as variants_file:
             variants = variants_file.read()
         exp = '["/foo/*", "/bar/*", "/baz/*"]'
         self.assertIn(exp, variants, "parameter paths stored in jobdata "

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -195,9 +195,9 @@ class RunnerOperationTest(TestCaseTmpDir):
         process.run(cmd_line)
         # Also check whether jobdata contains correct parameter paths
         variants = open(os.path.join(self.tmpdir.name, "latest", "jobdata",
-                                     "variants.json")).read()
-        self.assertIn('["/run/*"]', variants, "paths stored in jobdata "
-                      "does not contains [\"/run/*\"]\n%s" % variants)
+                                     "variants-1.json")).read()
+        expected = '[{"paths": ["/run/*"], "variant_id": null, "variant": [["/", []]]}]'
+        self.assertEqual(variants, expected)
 
     def test_runner_failfast(self):
         cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '

--- a/selftests/functional/test_replay.py
+++ b/selftests/functional/test_replay.py
@@ -62,7 +62,7 @@ class ReplayTests(TestCaseTmpDir):
         """
         Checks if all expected files are there.
         """
-        file_list = ['variants.json', 'config', 'test_references', 'pwd',
+        file_list = ['variants-1.json', 'config', 'test_references', 'pwd',
                      'args.json', 'cmdline']
         for filename in file_list:
             path = os.path.join(self.jobdir, 'jobdata', filename)


### PR DESCRIPTION
The "jobdata/variants.json" file is currently saving a list of
variants, one for each test suite.  But, this is not the format
that is expected from it, as it can be seen with any attempt to
use it via "--json-variants-load".

This will create a single variants JSON file, named sequentially, and
if available, with the name of the suite too.

We could attempt to preserve compatibility with the "variants.json" by
creating a link with the first suite's variants, but, given that this
has been broken for a while, I don't expect many users to be relying
on it.

Also, further work to suite specific information preserved separately,
such as the suite's configuration (versus the global job configuration)
should be discussed and evaluated.

Fixes: https://github.com/avocado-framework/avocado/issues/5068
Signed-off-by: Cleber Rosa <crosa@redhat.com>