### PR TITLE
utils.vmimage: fix default version for Ubuntu

### DIFF
--- a/avocado/utils/vmimage.py
+++ b/avocado/utils/vmimage.py
@@ -290,11 +290,10 @@ class UbuntuImageProvider(ImageProviderBase):
         self.url_images = self.url_versions + 'releases/{version}/release/'
         self.image_pattern = 'ubuntu-(?P<version>{version})-server-cloudimg-(?P<arch>{arch}).img'
 
-    def get_versions(self):
-        """Return all available versions for the current parameters."""
-        parser = VMImageHtmlParser(self.version_pattern)
-        self._feed_html_parser(self.url_versions, parser)
-        return parser.items
+    def get_best_version(self, versions):
+        """ Return best (more recent) version """
+        max_float = max([float(item) for item in versions])
+        return str(f'{max_float:2.2f}')
 
 
 class DebianImageProvider(ImageProviderBase):


### PR DESCRIPTION
The current default version of Ubuntu is 21.10. When converting
this version to float, the last 0 is removed and this leads
to try to fetch version 21.1 instead of 21.10
Overriding get_best_version() to take care of that.

Remove overrided get_versions() since it's not longer required.

References: https://github.com/avocado-framework/avocado/issues/5073

Signed-off-by: Ana Guerrero Lopez <anguerre@redhat.com>