### PR TITLE
Runner: only pass configuration that potentially used

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -52,7 +52,7 @@ def check_runnables_runner_requirements(runnables, runners_registry=None):
     Checks if runnables have runner requirements fulfilled
 
     :param runnables: the tasks whose runner requirements will be checked
-    :type runnable: list of :class:`Runnable`
+    :type runnables: list of :class:`Runnable`
     :param runners_registry: a registry with previously found (and not found)
                              runners keyed by a task's runnable kind. Defaults
                              to :attr:`RUNNERS_REGISTRY_STANDALONE_EXECUTABLE`

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -36,6 +36,9 @@ RUNNER_RUN_STATUS_INTERVAL = 0.5
 #: SpawnMethod.STANDALONE_EXECUTABLE compatible spawners
 RUNNERS_REGISTRY_STANDALONE_EXECUTABLE = {}
 
+#: The configuration that is known to be used by standalone runners
+STANDALONE_EXECUTABLE_CONFIG_USED = {}
+
 #: All known runner Python classes.  This is a dictionary keyed by a
 #: runnable kind, and value is a class that inherits from
 #: :class:`BaseRunner`.  Suitable for spawners compatible with
@@ -262,9 +265,15 @@ class Runnable:
         out, _ = process.communicate()
 
         try:
-            return json.loads(out.decode())
+            capabilities = json.loads(out.decode())
         except json.decoder.JSONDecodeError:
-            return {}
+            capabilities = {}
+
+        # lists are not hashable, and here it'd make more sense to have
+        # a command as it'd be seen in a command line anyway
+        cmd = " ".join(runner_command)
+        STANDALONE_EXECUTABLE_CONFIG_USED[cmd] = capabilities.get('configuration_used', [])
+        return capabilities
 
     def is_kind_supported_by_runner_command(self, runner_command,
                                             capabilities=None):

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -79,6 +79,41 @@ def check_runnables_runner_requirements(runnables, runners_registry=None):
     return (ok, missing)
 
 
+def update_avocado_configuration_used_on_runnables(runnables, config,
+                                                   runners_registry=None,
+                                                   config_registry=None):
+    """Checks if runnables have runner requirements fulfilled
+
+    :param runnables: the tasks whose runner requirements will be checked
+    :type runnables: list of :class:`Runnable`
+    :param config: A config dict to be used on the desired test suite.
+    :type config: dict
+    :param runners_registry: a registry with previously found (and not found)
+                             runners keyed by a task's runnable kind. Defaults
+                             to :attr:`RUNNERS_REGISTRY_STANDALONE_EXECUTABLE`
+    :type runners_registry: dict
+    :param config_registry: a registry with previously recorded configuration
+                            used based on the standalone runner commands.
+                            Defaults to :attr:`STANDALONE_EXECUTABLE_CONFIG_USED`.
+    :type registry: dict
+    """
+    if runners_registry is None:
+        runners_registry = RUNNERS_REGISTRY_STANDALONE_EXECUTABLE
+
+    if config_registry is None:
+        config_registry = STANDALONE_EXECUTABLE_CONFIG_USED
+
+    for runnable in runnables:
+        command = runners_registry.get(runnable.kind)
+        if command is None:
+            continue
+        command = " ".join(command)
+        configuration_used = config_registry.get(command)
+        for config_item in configuration_used:
+            if config_item in config:
+                runnable.config[config_item] = config.get(config_item)
+
+
 class ConfigDecoder(json.JSONDecoder):
     """
     JSON Decoder for config options.

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -174,7 +174,7 @@ class Runnable:
             args.append('-u')
             args.append(self.uri)
 
-        if self.config is not None:
+        if self.config:
             args.append('-c')
             args.append(json.dumps(self.config, cls=ConfigEncoder))
 

--- a/avocado/core/runners/avocado_instrumented.py
+++ b/avocado/core/runners/avocado_instrumented.py
@@ -26,6 +26,8 @@ class AvocadoInstrumentedTestRunner(nrunner.BaseRunner):
     """
     DEFAULT_TIMEOUT = 86400
 
+    CONFIGURATION_USED = ['run.test_parameters']
+
     @staticmethod
     def _create_params(runnable):
         """Create params for the test"""

--- a/avocado/core/runners/requirement_asset.py
+++ b/avocado/core/runners/requirement_asset.py
@@ -28,6 +28,8 @@ class RequirementAssetRunner(nrunner.BaseRunner):
         - expire: time in seconds for the asset to expire (optional)
     """
 
+    CONFIGURATION_USED = ['datadir.paths.cache_dirs']
+
     @staticmethod
     def _fetch_asset(name, asset_hash, algorithm, locations, cache_dirs,
                      expire, queue):

--- a/avocado/core/suite.py
+++ b/avocado/core/suite.py
@@ -77,7 +77,6 @@ def resolutions_to_runnables(resolutions, config):
                                                  include_empty,
                                                  include_empty_key):
                     continue
-            runnable.config = config
             result.append(runnable)
     return result
 
@@ -96,11 +95,6 @@ class TestSuite:
             self.config.update(job_config)
         if config:
             self.config.update(config)
-
-        # Update the config of runnables.
-        if config.get('run.test_runner') == 'nrunner' and self.tests:
-            for test in self.tests:
-                test.config.update(self.config)
 
         self._variants = None
         self._references = None

--- a/avocado/plugins/resolvers.py
+++ b/avocado/plugins/resolvers.py
@@ -41,13 +41,13 @@ class ExecTestResolver(Resolver):
         if criteria_check is not True:
             return criteria_check
 
-        runnable = Runnable('exec-test', reference, config=self.config)
+        runnable = Runnable('exec-test', reference)
         return ReferenceResolution(reference,
                                    ReferenceResolutionResult.SUCCESS,
                                    [runnable])
 
 
-def python_resolver(name, reference, find_tests, config):
+def python_resolver(name, reference, find_tests):
     module_path, tests_filter = reference_split(reference)
     if tests_filter is not None:
         tests_filter = re.compile(tests_filter)
@@ -68,8 +68,7 @@ def python_resolver(name, reference, find_tests, config):
             runnables.append(Runnable(name,
                                       uri=uri,
                                       tags=tags,
-                                      requirements=reqs,
-                                      config=config))
+                                      requirements=reqs))
     if runnables:
         return ReferenceResolution(reference,
                                    ReferenceResolutionResult.SUCCESS,
@@ -92,8 +91,7 @@ class PythonUnittestResolver(Resolver):
     def resolve(self, reference):
         return python_resolver(PythonUnittestResolver.name,
                                reference,
-                               PythonUnittestResolver._find_compat,
-                               self.config)
+                               PythonUnittestResolver._find_compat)
 
 
 class AvocadoInstrumentedResolver(Resolver):
@@ -104,8 +102,7 @@ class AvocadoInstrumentedResolver(Resolver):
     def resolve(self, reference):
         return python_resolver(AvocadoInstrumentedResolver.name,
                                reference,
-                               find_avocado_tests,
-                               self.config)
+                               find_avocado_tests)
 
 
 class TapResolver(Resolver):
@@ -122,7 +119,7 @@ class TapResolver(Resolver):
         if criteria_check is not True:
             return criteria_check
 
-        runnable = Runnable('tap', reference, cofig=self.config)
+        runnable = Runnable('tap', reference)
         return ReferenceResolution(reference,
                                    ReferenceResolutionResult.SUCCESS,
                                    [runnable])

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -349,10 +349,12 @@ class Runner(RunnerInterface):
         max_running = min(test_suite.config.get('nrunner.max_parallel_tasks'),
                           len(self.runtime_tasks))
         timeout = test_suite.config.get('task.timeout.running')
+        failfast = test_suite.config.get('run.failfast')
         workers = [Worker(state_machine=tsm,
                           spawner=spawner,
                           max_running=max_running,
-                          task_timeout=timeout).run()
+                          task_timeout=timeout,
+                          failfast=failfast).run()
                    for _ in range(max_running)]
         asyncio.ensure_future(self._update_status(job))
         loop = asyncio.get_event_loop()

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -329,6 +329,9 @@ class Runner(RunnerInterface):
             test_suite.tests)
         self._abort_if_missing_runners(missing_requirements)
 
+        nrunner.update_avocado_configuration_used_on_runnables(test_suite.tests,
+                                                               test_suite.config)
+
         job.result.tests_total = test_suite.variants.get_number_of_tests(test_suite.tests)
 
         self._create_status_server(test_suite, job)

--- a/selftests/functional/test_nrunner_interface.py
+++ b/selftests/functional/test_nrunner_interface.py
@@ -28,4 +28,5 @@ class Interface(Test):
         result = process.run(cmd)
         capabilities = json.loads(result.stdout_text)
         self.assertIn("runnables", capabilities)
+        self.assertIn("commands", capabilities)
         self.assertIn("configuration_used", capabilities)

--- a/selftests/functional/test_nrunner_interface.py
+++ b/selftests/functional/test_nrunner_interface.py
@@ -28,3 +28,4 @@ class Interface(Test):
         result = process.run(cmd)
         capabilities = json.loads(result.stdout_text)
         self.assertIn("runnables", capabilities)
+        self.assertIn("configuration_used", capabilities)

--- a/selftests/unit/test_nrunner.py
+++ b/selftests/unit/test_nrunner.py
@@ -73,8 +73,7 @@ class Runnable(unittest.TestCase):
     def test_runnable_command_args(self):
         runnable = nrunner.Runnable('noop', 'uri', 'arg1', 'arg2')
         actual_args = runnable.get_command_args()
-        exp_args = ['-k', 'noop', '-u', 'uri', '-c', '{}', '-a', 'arg1',
-                    '-a', 'arg2']
+        exp_args = ['-k', 'noop', '-u', 'uri', '-a', 'arg1', '-a', 'arg2']
         self.assertEqual(actual_args, exp_args)
 
     def test_get_dict(self):

--- a/spell.ignore
+++ b/spell.ignore
@@ -746,3 +746,4 @@ GiB
 jarichte
 teststatus
 importlib
+hashable


### PR DESCRIPTION
For simplicity's sake, the entire suite configuration is currently passed to the runner, but this does not scale and, in the case of variants, passes as lot of unrelated information to one task.

This let runners declare the configuration they use as part of the `capabilities` command, and Avocado will use that to select which of its own configuration to pass to runners.

Fixes: https://github.com/avocado-framework/avocado/issues/5075