### PR TITLE
Nrunner: fix missing default when using the API

### DIFF
--- a/avocado/core/runners/avocado_instrumented.py
+++ b/avocado/core/runners/avocado_instrumented.py
@@ -66,7 +66,7 @@ class AvocadoInstrumentedTestRunner(nrunner.BaseRunner):
                 runnable)
 
             test_factory = [klass,
-                            {'name': TestID(1, klass_method),
+                            {'name': TestID(1, runnable.uri),
                              'methodName': method,
                              'config': runnable.config,
                              'modulePath': module_path,

--- a/avocado/core/suite.py
+++ b/avocado/core/suite.py
@@ -98,7 +98,8 @@ class TestSuite:
             self.config.update(config)
 
         # Update the config of runnables.
-        if config.get('run.test_runner') == 'nrunner' and self.tests:
+        test_runner = self.config.get('run.test_runner') or 'nrunner'
+        if test_runner == 'nrunner' and self.tests:
             for test in self.tests:
                 test.config.update(self.config)
 
@@ -141,7 +142,8 @@ class TestSuite:
         return self.size
 
     def _convert_to_dry_run(self):
-        if self.config.get('run.test_runner') == 'nrunner':
+        test_runner = self.config.get('run.test_runner') or 'nrunner'
+        if test_runner == 'nrunner':
             for runnable in self.tests:
                 runnable.kind = 'dry-run'
         else:
@@ -256,7 +258,7 @@ class TestSuite:
     @property
     def runner(self):
         if self._runner is None:
-            runner_name = self.config.get('run.test_runner') or 'runner'
+            runner_name = self.config.get('run.test_runner') or 'nrunner'
             try:
                 runner_extension = RunnerDispatcher()[runner_name]
                 self._runner = runner_extension.obj
@@ -274,7 +276,7 @@ class TestSuite:
     @property
     def stats(self):
         """Return a statistics dict with the current tests."""
-        runner_name = self.config.get('run.test_runner') or 'runner'
+        runner_name = self.config.get('run.test_runner') or 'nrunner'
         if runner_name == 'runner':
             return self._get_stats_from_runner()
         elif runner_name == 'nrunner':
@@ -295,7 +297,7 @@ class TestSuite:
     @property
     def tags_stats(self):
         """Return a statistics dict with the current tests tags."""
-        runner_name = self.config.get('run.test_runner') or 'runner'
+        runner_name = self.config.get('run.test_runner') or 'nrunner'
         if runner_name == 'runner':
             return self._get_tags_stats_from_runner()
         elif runner_name == 'nrunner':
@@ -363,7 +365,7 @@ class TestSuite:
         config.update(suite_config)
         if job_config:
             config.update(job_config)
-        runner = config.get('run.test_runner') or 'runner'
+        runner = config.get('run.test_runner') or 'nrunner'
         if runner == 'nrunner':
             suite = cls._from_config_with_resolver(config, name)
         else:

--- a/avocado/plugins/human.py
+++ b/avocado/plugins/human.py
@@ -54,7 +54,7 @@ class Human(ResultEvents):
         self.__throbber = output.Throbber()
         stdout_claimed_by = config.get('stdout_claimed_by', None)
         self.owns_stdout = not stdout_claimed_by
-        self.runner = config.get('run.test_runner')
+        self.runner = config.get('run.test_runner') or 'nrunner'
         self.omit_statuses = config.get('human_ui.omit.statuses')
 
     def pre_tests(self, job):

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -79,7 +79,7 @@ class JobAPIFeaturesTest(Test):
         """Run a Job"""
         config = self.create_config()
 
-        suite = TestSuite.from_config(config)
+        suite = TestSuite.from_config(config, '')
 
         # run the job
         with Job(config, [suite]) as j:
@@ -305,7 +305,8 @@ def create_suite_job_api(args):  # pylint: disable=W0621
             {'namespace': 'job.run.result.tap.include_logs',
              'value': True,
              'file': 'results.tap',
-             'content': "Command '/bin/true' finished with 0",
+             'reference': ['examples/tests/passtest.py:PassTest.test'],
+             'content': 'PASS 1-examples/tests/passtest.py:PassTest.test',
              'assert': True},
 
             {'namespace': 'job.run.result.tap.include_logs',
@@ -325,7 +326,7 @@ def create_suite_job_api(args):  # pylint: disable=W0621
              'file': 'results.xml',
              'content': '--[ CUT DUE TO XML PER TEST LIMIT ]--',
              'assert': True,
-             'reference': ['/bin/false'],
+             'reference': ['examples/tests/failtest.py:FailTest.test'],
              'exit_code': 1},
 
             {'namespace': 'run.failfast',

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -53,6 +53,9 @@ class JobAPIFeaturesTest(Test):
                   'resolver.references': reference}
         namespace = self.params.get('namespace')
         config[namespace] = value
+        extra_job_config = self.params.get('extra_job_config')
+        if extra_job_config is not None:
+            config.update(extra_job_config)
 
         return config
 
@@ -343,7 +346,8 @@ def create_suite_job_api(args):  # pylint: disable=W0621
              'content': '"skip": 1',
              'assert': True,
              'reference': ['/bin/false', '/bin/true'],
-             'exit_code': 9},
+             'exit_code': 9,
+             'extra_job_config': {'nrunner.max_parallel_tasks': 1}},
 
             {'namespace': 'run.ignore_missing_references',
              'value': 'on',


### PR DESCRIPTION
There are a number of places, which are triggered when using the API, that still defaults to the legacy runner.

This fixes all occurrences and addresses the tests that wouldn't work properly under nrunner.