### PR TITLE
`--store-logging-stream` fix for the nrunner

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -212,27 +212,29 @@ class Job:
         fmt = '%(asctime)s %(levelname)-5.5s| %(message)s'
         formatter = logging.Formatter(fmt=fmt, datefmt='%H:%M:%S')
 
-        store_logging_stream = self.config.get('job.run.store_logging_stream')
-        for name in store_logging_stream:
-            name = re.split(r'(?<!\\):', name, maxsplit=1)
-            if len(name) == 1:
-                name = name[0]
-                level = logging.INFO
-            else:
-                level = (int(name[1]) if name[1].isdigit()
-                         else logging.getLevelName(name[1].upper()))
-                name = name[0]
-            try:
-                logname = "log" if name == "" else name
-                logfile = os.path.join(self.logdir, logname + "." +
-                                       logging.getLevelName(level))
-                handler = output.add_log_handler(name, logging.FileHandler,
-                                                 logfile, level, formatter)
-            except ValueError as details:
-                self.log.error("Failed to set log for --store-logging-stream "
-                               "%s:%s: %s.", name, level, details)
-            else:
-                self.__logging_handlers[handler] = [name]
+        # Store custom test loggers
+        if self.config.get("run.test_runner") == 'runner':
+            store_logging_stream = self.config.get('job.run.store_logging_stream')
+            for name in store_logging_stream:
+                name = re.split(r'(?<!\\):', name, maxsplit=1)
+                if len(name) == 1:
+                    name = name[0]
+                    level = logging.INFO
+                else:
+                    level = (int(name[1]) if name[1].isdigit()
+                             else logging.getLevelName(name[1].upper()))
+                    name = name[0]
+                try:
+                    logname = "log" if name == "" else name
+                    logfile = os.path.join(self.logdir, logname + "." +
+                                           logging.getLevelName(level))
+                    handler = output.add_log_handler(name, logging.FileHandler,
+                                                     logfile, level, formatter)
+                except ValueError as details:
+                    self.log.error("Failed to set log for --store-logging-stream "
+                                   "%s:%s: %s.", name, level, details)
+                else:
+                    self.__logging_handlers[handler] = [name]
 
         # Enable console loggers
         enabled_logs = self.config.get("core.show")

--- a/docs/source/guides/writer/chapters/logging.rst
+++ b/docs/source/guides/writer/chapters/logging.rst
@@ -72,37 +72,30 @@ The outcome should be similar to::
 Using --store-logging-stream
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The custom ``progress`` stream is combined with the application output, which
-may or may not suit your needs or preferences. If you want the ``progress``
+The custom ``avocado.test.progress`` stream is combined with the application output, which
+may or may not suit your needs or preferences. If you want the ``avocado.test.progress``
 stream to be sent to a separate file, both for clarity and for persistence,
 you can run Avocado like this::
 
-     $ avocado run --store-logging-stream=progress --test-runner=runner -- logging_streams.py
+     $ avocado run --store-logging-stream=avocado.test.progress -- examples/tests/logging_streams.py
 
 The result is that, besides all the other log files commonly generated, there
-will be another log file named ``progress.INFO`` at the job results
+will be another log file named ``avocado.test.progress`` at the test results
 dir. During the test run, one could watch the progress with::
 
-    $ tail -f ~/avocado/job-results/latest/progress.INFO
-    10:36:59 INFO | 1-logging_streams.py:Plant.test_plant_organic: preparing soil on row 0
-    10:36:59 INFO | 1-logging_streams.py:Plant.test_plant_organic: preparing soil on row 1
-    10:36:59 INFO | 1-logging_streams.py:Plant.test_plant_organic: preparing soil on row 2
-    10:36:59 INFO | 1-logging_streams.py:Plant.test_plant_organic: letting soil rest before throwing seeds
-    10:37:01 INFO | 1-logging_streams.py:Plant.test_plant_organic: throwing seeds on row 0
-    10:37:01 INFO | 1-logging_streams.py:Plant.test_plant_organic: throwing seeds on row 1
-    10:37:01 INFO | 1-logging_streams.py:Plant.test_plant_organic: throwing seeds on row 2
-    10:37:01 INFO | 1-logging_streams.py:Plant.test_plant_organic: waiting for Avocados to grow
-    10:37:06 INFO | 1-logging_streams.py:Plant.test_plant_organic: harvesting organic avocados on row 0
-    10:37:06 INFO | 1-logging_streams.py:Plant.test_plant_organic: harvesting organic avocados on row 1
-    10:37:06 INFO | 1-logging_streams.py:Plant.test_plant_organic: harvesting organic avocados on row 2
+    $ tail -f ~/avocado/job-results/latest/test-results/1-examples_tests_logging_streams.py_Plant.test_plant_organic/avocado.test.progress 
+    2021-11-02 11:42:19,148 logging_streams  L0016 INFO | 1-Plant.test_plant_organic: preparing soil on row 1
+    2021-11-02 11:42:19,148 logging_streams  L0016 INFO | 1-Plant.test_plant_organic: preparing soil on row 2
+    2021-11-02 11:42:19,148 logging_streams  L0020 INFO | 1-Plant.test_plant_organic: letting soil rest before throwing seeds
+    2021-11-02 11:42:20,149 logging_streams  L0026 INFO | 1-Plant.test_plant_organic: throwing seeds on row 0
+    2021-11-02 11:42:20,149 logging_streams  L0026 INFO | 1-Plant.test_plant_organic: throwing seeds on row 1
+    2021-11-02 11:42:20,149 logging_streams  L0026 INFO | 1-Plant.test_plant_organic: throwing seeds on row 2
+    2021-11-02 11:42:20,149 logging_streams  L0030 INFO | 1-Plant.test_plant_organic: waiting for Avocados to grow
+    2021-11-02 11:42:22,151 logging_streams  L0036 INFO | 1-Plant.test_plant_organic: harvesting organic avocados on row 0
+    2021-11-02 11:42:22,152 logging_streams  L0036 INFO | 1-Plant.test_plant_organic: harvesting organic avocados on row 1
+    2021-11-02 11:42:22,152 logging_streams  L0036 INFO | 1-Plant.test_plant_organic: harvesting organic avocados on row 2
 
-The very same ``progress`` logger, could be used across multiple test methods
+The very same ``avocado.test.progress`` logger, could be used across multiple test methods
 and across multiple test modules.  In the example given, the test name is used
 to give extra context.
 
-.. note:: Keep in mind that the above example it is trying to bring to the job
-   level, a test level message. This is a legacy feature, and you need to run
-   with --test-runner='runner'. Since the new NRunner architecture is running
-   the tests in a much more isolated process, Avocado keeps test's log messages
-   inside the individual test folder at `test-results/test-id/debug.log` as
-   mentioned before.

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -597,14 +597,22 @@ class RunnerOperationTest(TestCaseTmpDir):
                 self.assertNotIn(b'SHOULD NOT BE ON debug.log', test_log.read())
 
     def test_store_logging_stream(self):
-        cmd = ("%s run --job-results-dir %s --store-logging-stream=progress "
+        cmd = ("%s run --job-results-dir %s "
+               "--store-logging-stream=avocado.test.progress "
                "--disable-sysinfo -- examples/tests/logging_streams.py"
                % (AVOCADO, self.tmpdir.name))
         result = process.run(cmd)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
 
-        progress_info = os.path.join(self.tmpdir.name, 'latest', 'progress.INFO')
+        progress_info = os.path.join(self.tmpdir.name, 'latest', 'test-results',
+                                     '1-examples_tests_logging_streams.py_Plant'
+                                     '.test_plant_organic',
+                                     'avocado.test.progress')
         self.assertTrue(os.path.exists(progress_info))
+        with open(progress_info) as file:
+            stream_line = file.readline()
+            self.assertIn('INFO | 1-Plant.test_plant_organic: '
+                          'preparing soil on row 0', stream_line)
 
 
 class DryRunTest(TestCaseTmpDir):


### PR DESCRIPTION
The `--store-logging-stream` option wasn't available for the nrunner.
This PR is fixing this. The change from the legacy solution is that
the streams are not saved inside the job results directory, but they are
split by the tests inside test-result directory. So each test has its
own files with the user stream logs.

Reference: #5081
Signed-off-by: Jan Richter <jarichte@redhat.com>