### PR TITLE
Nrunner: fix missing default when using the API [v2]

### DIFF
--- a/avocado/core/__init__.py
+++ b/avocado/core/__init__.py
@@ -195,6 +195,18 @@ def register_core_options():
                          default=[],
                          help_msg=help_msg)
 
+    help_msg = ('Selects the runner implementation from one of the '
+                'installed and active implementations.  You can run '
+                '"avocado plugins" and find the list of valid runners '
+                'under the "Plugins that run test suites on a job '
+                '(runners) section.  Defaults to "nrunner", which is '
+                'the new runner.  To use the conventional and traditional '
+                'runner, use "runner".')
+    stgs.register_option(section='run',
+                         key='test_runner',
+                         default='nrunner',
+                         help_msg=help_msg)
+
 
 def initialize_plugin_infrastructure():
     help_msg = 'Plugins that will not be loaded and executed'

--- a/avocado/core/runners/avocado_instrumented.py
+++ b/avocado/core/runners/avocado_instrumented.py
@@ -66,7 +66,7 @@ class AvocadoInstrumentedTestRunner(nrunner.BaseRunner):
                 runnable)
 
             test_factory = [klass,
-                            {'name': TestID(1, klass_method),
+                            {'name': TestID(1, runnable.uri),
                              'methodName': method,
                              'config': runnable.config,
                              'modulePath': module_path,

--- a/avocado/core/suite.py
+++ b/avocado/core/suite.py
@@ -256,7 +256,7 @@ class TestSuite:
     @property
     def runner(self):
         if self._runner is None:
-            runner_name = self.config.get('run.test_runner') or 'runner'
+            runner_name = self.config.get('run.test_runner')
             try:
                 runner_extension = RunnerDispatcher()[runner_name]
                 self._runner = runner_extension.obj
@@ -274,7 +274,7 @@ class TestSuite:
     @property
     def stats(self):
         """Return a statistics dict with the current tests."""
-        runner_name = self.config.get('run.test_runner') or 'runner'
+        runner_name = self.config.get('run.test_runner')
         if runner_name == 'runner':
             return self._get_stats_from_runner()
         elif runner_name == 'nrunner':
@@ -295,7 +295,7 @@ class TestSuite:
     @property
     def tags_stats(self):
         """Return a statistics dict with the current tests tags."""
-        runner_name = self.config.get('run.test_runner') or 'runner'
+        runner_name = self.config.get('run.test_runner')
         if runner_name == 'runner':
             return self._get_tags_stats_from_runner()
         elif runner_name == 'nrunner':
@@ -363,7 +363,7 @@ class TestSuite:
         config.update(suite_config)
         if job_config:
             config.update(job_config)
-        runner = config.get('run.test_runner') or 'runner'
+        runner = config.get('run.test_runner')
         if runner == 'nrunner':
             suite = cls._from_config_with_resolver(config, name)
         else:

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -94,20 +94,10 @@ class Run(CLICmd):
                                  long_arg='--test-parameter',
                                  short_arg='-p')
 
-        help_msg = ('Selects the runner implementation from one of the '
-                    'installed and active implementations.  You can run '
-                    '"avocado plugins" and find the list of valid runners '
-                    'under the "Plugins that run test suites on a job '
-                    '(runners) section.  Defaults to "nrunner", which is '
-                    'the new runner.  To use the conventional and traditional '
-                    'runner, use "runner".')
-        settings.register_option(section='run',
-                                 key='test_runner',
-                                 default='nrunner',
-                                 help_msg=help_msg,
-                                 parser=parser,
-                                 long_arg='--test-runner',
-                                 metavar='TEST_RUNNER')
+        settings.add_argparser_to_option(namespace='run.test_runner',
+                                         parser=parser,
+                                         long_arg='--test-runner',
+                                         metavar='TEST_RUNNER')
 
         help_msg = ('Instead of running the test only list them and log '
                     'their params.')

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -79,7 +79,7 @@ class JobAPIFeaturesTest(Test):
         """Run a Job"""
         config = self.create_config()
 
-        suite = TestSuite.from_config(config)
+        suite = TestSuite.from_config(config, '')
 
         # run the job
         with Job(config, [suite]) as j:
@@ -305,7 +305,8 @@ def create_suite_job_api(args):  # pylint: disable=W0621
             {'namespace': 'job.run.result.tap.include_logs',
              'value': True,
              'file': 'results.tap',
-             'content': "Command '/bin/true' finished with 0",
+             'reference': ['examples/tests/passtest.py:PassTest.test'],
+             'content': 'PASS 1-examples/tests/passtest.py:PassTest.test',
              'assert': True},
 
             {'namespace': 'job.run.result.tap.include_logs',
@@ -325,7 +326,7 @@ def create_suite_job_api(args):  # pylint: disable=W0621
              'file': 'results.xml',
              'content': '--[ CUT DUE TO XML PER TEST LIMIT ]--',
              'assert': True,
-             'reference': ['/bin/false'],
+             'reference': ['examples/tests/failtest.py:FailTest.test'],
              'exit_code': 1},
 
             {'namespace': 'run.failfast',

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -53,6 +53,9 @@ class JobAPIFeaturesTest(Test):
                   'resolver.references': reference}
         namespace = self.params.get('namespace')
         config[namespace] = value
+        extra_job_config = self.params.get('extra_job_config')
+        if extra_job_config is not None:
+            config.update(extra_job_config)
 
         return config
 
@@ -343,7 +346,8 @@ def create_suite_job_api(args):  # pylint: disable=W0621
              'content': '"skip": 1',
              'assert': True,
              'reference': ['/bin/false', '/bin/true'],
-             'exit_code': 9},
+             'exit_code': 9,
+             'extra_job_config': {'nrunner.max_parallel_tasks': 1}},
 
             {'namespace': 'run.ignore_missing_references',
              'value': 'on',

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -135,8 +135,8 @@ class JobTest(unittest.TestCase):
                             if not test_factory[1].get('name', '').endswith('time'):
                                 filtered_test_suite.append(test_factory)
                     elif self.config.get('run.test_runner') == 'nrunner':
-                        task = test_factory
-                        if not task.runnable.uri.endswith('time'):
+                        runnable = test_factory
+                        if not runnable.uri.endswith('time'):
                             filtered_test_suite.append(test_factory)
                 self.test_suite.tests = filtered_test_suite
                 super(JobFilterTime, self).pre_tests()
@@ -195,8 +195,8 @@ class JobTest(unittest.TestCase):
                                 if not test_factory[1].get('name', '').endswith('time'):
                                     filtered_test_suite.append(test_factory)
                         elif self.config.get('run.test_runner') == 'nrunner':
-                            task = test_factory
-                            if not task.runnable.uri.endswith('time'):
+                            runnable = test_factory
+                            if not runnable.uri.endswith('time'):
                                 filtered_test_suite.append(test_factory)
                     suite.tests = filtered_test_suite
                     super(JobFilterLog, self).pre_tests()


### PR DESCRIPTION
There are a number of places, which are triggered when using the API, that still defaults to the legacy runner.

This fixes that by always registering `run.test_runner`, and fixing the tests that wouldn't work properly under nrunner.

Fixes: https://github.com/avocado-framework/avocado/issues/5067

---

Changes from v1 (#5084):
* Have `run.test_runner` always registered, and thus, no need for hard coded defaults