### PR TITLE
suites: introduce the enabled concept

### DIFF
--- a/avocado/core/suite.py
+++ b/avocado/core/suite.py
@@ -84,10 +84,11 @@ def resolutions_to_runnables(resolutions, config):
 
 class TestSuite:
     def __init__(self, name, config=None, tests=None, job_config=None,
-                 resolutions=None):
+                 resolutions=None, enabled=True):
         self.name = name
         self.tests = tests
         self.resolutions = resolutions
+        self.enabled = enabled
 
         # Create a complete config dict with all registered options + custom
         # config

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -325,6 +325,10 @@ class Runner(RunnerInterface):
     def run_suite(self, job, test_suite):
         summary = set()
 
+        if not test_suite.enabled:
+            job.interrupted_reason = f"Suite {test_suite.name} is disabled."
+            return summary
+
         test_suite.tests, missing_requirements = nrunner.check_runnables_runner_requirements(
             test_suite.tests)
         self._abort_if_missing_runners(missing_requirements)

--- a/examples/jobs/passjob_custom.py
+++ b/examples/jobs/passjob_custom.py
@@ -13,6 +13,8 @@ from avocado.core.suite import TestSuite
 
 suite1 = TestSuite(name='suite1', tests=[Runnable("noop", "noop")])
 suite2 = TestSuite(name='suite2', tests=[Runnable("noop", "noop")])
+suite3 = TestSuite(name='suite3', enabled=False,
+                   tests=[Runnable("noop", "noop")])
 
-with Job(test_suites=[suite1, suite2]) as j:
+with Job(test_suites=[suite1, suite2, suite3]) as j:
     sys.exit(j.run())


### PR DESCRIPTION
By default all suites are enabled, but if we would like to skip any,
just set suite.enabled = False and this suite will not be executed.
Fixes #4832

Signed-off-by: Beraldo Leal <bleal@redhat.com>