### PR TITLE
remove nrunner references when using command line

### DIFF
--- a/selftests/functional/plugin/test_jsonresult.py
+++ b/selftests/functional/plugin/test_jsonresult.py
@@ -8,8 +8,7 @@ from selftests.utils import AVOCADO, TestCaseTmpDir
 class JsonResultTest(TestCaseTmpDir):
 
     def test_logfile(self):
-        cmd_line = ('%s run --test-runner=nrunner '
-                    'examples/tests/failtest.py '
+        cmd_line = ('%s run examples/tests/failtest.py '
                     '--job-results-dir %s --disable-sysinfo ' %
                     (AVOCADO, self.tmpdir.name))
         process.run(cmd_line, ignore_status=True)
@@ -22,8 +21,7 @@ class JsonResultTest(TestCaseTmpDir):
             self.assertEqual(expected_logfile, test_data['logfile'])
 
     def test_fail_reason(self):
-        cmd_line = ('%s run --test-runner=nrunner '
-                    'examples/tests/failtest.py '
+        cmd_line = ('%s run examples/tests/failtest.py '
                     '--job-results-dir %s --disable-sysinfo ' %
                     (AVOCADO, self.tmpdir.name))
         process.run(cmd_line, ignore_status=True)

--- a/selftests/functional/plugin/test_logs.py
+++ b/selftests/functional/plugin/test_logs.py
@@ -66,7 +66,7 @@ class TestLogging(TestCaseTmpDir):
 
     def test_job_log(self):
         pass_test = os.path.join(BASEDIR, 'examples', 'tests', 'passtest.py')
-        cmd_line = ('%s run --job-results-dir %s --test-runner=nrunner %s' %
+        cmd_line = ('%s run --job-results-dir %s %s' %
                     (AVOCADO, self.tmpdir.name, pass_test))
         process.run(cmd_line)
         log_file = os.path.join(self.tmpdir.name, 'latest', 'job.log')

--- a/selftests/functional/test_requirements.py
+++ b/selftests/functional/test_requirements.py
@@ -78,7 +78,7 @@ class FailTest(Test):
 
 class BasicTest(TestCaseTmpDir):
 
-    command = '%s run --test-runner=nrunner %s'
+    command = '%s run %s'
     skip_install_message = ("This test runs on CI environments only as it"
                             " installs packages to test the feature, which"
                             " may not be desired locally, in the user's"


### PR DESCRIPTION
There is no need for those, since nrunner is the default one.

Signed-off-by: Beraldo Leal <bleal@redhat.com>