### PR TITLE
Update vmimage tests and bump development Python version to 3.11

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         # see list of available Python versions at https://github.com/actions/python-versions/blob/main/versions-manifest.json
-        python-version: [3.10.0]
+        python-version: [3.11.0-alpha.2]
       fail-fast: false
     outputs:
       job_status: ${{ job.status }}
@@ -63,7 +63,7 @@ jobs:
     strategy:
       matrix:
         # see list of available Python versions at https://github.com/actions/python-versions/blob/main/versions-manifest.json
-        python-version: [3.10.0]
+        python-version: [3.11.0-alpha.2]
       fail-fast: false
 
     steps:

--- a/selftests/pre_release/tests/vmimage.py.data/variants.yml
+++ b/selftests/pre_release/tests/vmimage.py.data/variants.yml
@@ -37,10 +37,10 @@ distro: !mux
     x86_64:
       arch: amd64
     version: !mux
-      9.13.28:
-        version: 9.13.28-20211002
-      10.11.0:
-        version: 10.11.0
+      9.13.30:
+        version: 9.13.30-20211105
+      10.11.1:
+        version: 10.11.1-20211029
   fedora:
     name: fedora
     !filter-out : /run/architectures/arm
@@ -52,6 +52,8 @@ distro: !mux
         version: 33
       34:
         version: 34
+      35:
+        version: 35
   ubuntu:
     name: ubuntu
     !filter-out : /run/architectures/arm
@@ -67,6 +69,8 @@ distro: !mux
         version: '20.10'
       21.04:
         version: '21.04'
+      21.10:
+        version: '21.10'
   opensuse:
     name: opensuse
     !filter-out : /run/architectures/arm


### PR DESCRIPTION
* `weekly.yml`: use current development Python 3.11
* Update vmimage tests
    * Add Fedora 35 and Ubuntu 21.10
    * Update Debian image versions
