### PR TITLE
[nrunner] add access for EXEC test to some AVOCADO_* env variables [v5]

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -10,6 +10,7 @@ import json
 import multiprocessing
 import os
 import re
+import shutil
 import socket
 import subprocess
 import sys
@@ -497,6 +498,15 @@ class ExecTestRunner(BaseRunner):
         final_status['returncode'] = process.returncode
         return self.prepare_status('finished', final_status)
 
+    def _cleanup(self):
+        """Cleanup method for the exec-test tests"""
+        # cleanup temporary directories
+        workdir = self.runnable.kwargs.get('AVOCADO_TEST_WORKDIR')
+        if (workdir is not None and
+                self.runnable.config.get('run.keep_tmp') is not None and
+                os.path.exists(workdir)):
+            shutil.rmtree(workdir)
+
     def _create_params(self):
         """Create params for the test"""
         # inject the -p command-line / run.test_parameters option in the
@@ -512,12 +522,49 @@ class ExecTestRunner(BaseRunner):
 
         return params
 
+    @staticmethod
+    def _get_avocado_version():
+        """Return the Avocado package version, if installed"""
+        version = "unknown.unknown"
+        if PKG_RESOURCES_AVAILABLE:
+            try:
+                version = pkg_resources.get_distribution(
+                    'avocado-framework').version
+            except pkg_resources.DistributionNotFound:
+                pass
+        return version
+
+    def _get_env_variables(self):
+        """Get the default AVOCADO_* environment variables
+
+        These variables are available to the test environment during the test
+        execution.
+        """
+        # create the temporary work dir
+        workdir = tempfile.mkdtemp(prefix='.avocado-workdir-')
+        # create the avocado environment variable dictionary
+        avocado_test_env_variables = {
+            'AVOCADO_VERSION': self._get_avocado_version(),
+            'AVOCADO_TEST_WORKDIR': workdir,
+        }
+        return avocado_test_env_variables
+
     def run(self):
         env = None
         if self.runnable.kwargs:
             current = dict(os.environ)
             current.update(self.runnable.kwargs)
             env = current
+
+        # set default Avocado environment variables if running on a valid Task
+        if self.runnable.uri is not None:
+            avocado_test_env_variables = self._get_env_variables()
+            # save environment variables for further cleanup
+            self.runnable.kwargs.update(avocado_test_env_variables)
+            if env is None:
+                env = avocado_test_env_variables
+            else:
+                env.update(avocado_test_env_variables)
 
         params = self._create_params()
         if params:
@@ -536,6 +583,7 @@ class ExecTestRunner(BaseRunner):
             yield self.prepare_status('started')
             yield self.prepare_status('finished', {'result': 'error',
                                                    'fail_reason': str(e)})
+            self._cleanup()
             return
 
         yield self.prepare_status('started')
@@ -559,6 +607,7 @@ class ExecTestRunner(BaseRunner):
         yield self.prepare_status('running', {'type': 'stdout', 'log': stdout})
         yield self.prepare_status('running', {'type': 'stderr', 'log': stderr})
         yield self._process_final_status(process, stdout, stderr)
+        self._cleanup()
 
 
 RUNNERS_REGISTRY_PYTHON_CLASS['exec-test'] = ExecTestRunner

--- a/docs/source/guides/writer/chapters/writing.rst
+++ b/docs/source/guides/writer/chapters/writing.rst
@@ -1473,38 +1473,65 @@ Environment Variables for Tests
 Avocado exports some information, including test parameters, as environment
 variables to the running test.
 
-While these variables are available to all tests, they are usually
-more interesting to SIMPLE tests.  The reason is that SIMPLE tests can
-not make direct use of Avocado API.  INSTRUMENTED tests will usually
-have more powerful ways, to access the same information.
+The availability of the variable depends on the test type. A greater set of
+variables are available to INSTRUMENTED tests, while a reduced number of
+variables are available to EXEC tests. Although the availability of the
+variable, they are usually more interesting to EXEC tests. The reason is that
+EXEC tests can not make direct use of Avocado API. INSTRUMENTED tests will
+usually have more powerful ways to access the same information.
 
-Here is a list of the variables that Avocado currently exports to
+Here is a list of the variables that Avocado currently exports to INSTRUMENTED
 tests:
 
 +-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
 | Environment Variable        | Meaning                               | Example                                                                                             |
 +=============================+=======================================+=====================================================================================================+
-| AVOCADO_VERSION             | Version of Avocado test runner        | 0.12.0                                                                                              |
+| AVOCADO_VERSION             | Version of Avocado test runner        | 92.0                                                                                                |
 +-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
-| AVOCADO_TEST_BASEDIR        | Base directory of Avocado tests       | $HOME/Downloads/avocado-source/avocado                                                              |
+| AVOCADO_TEST_BASEDIR        | Base directory of Avocado tests       | $HOME/src/avocado/avocado.dev/examples/tests                                                        |
 +-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
-| AVOCADO_TEST_WORKDIR        | Work directory for the test           | /var/tmp/avocado_Bjr_rd/my_test.sh                                                                  |
+| AVOCADO_TEST_WORKDIR        | Work directory for the test           | /var/tmp/.avocado-taskcx8of8di/test-results/tmp_dirfgqrnbu_/1-Env.test                              |
++-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
+| AVOCADO_TESTS_COMMON_TMPDIR | Temporary directory created by the    | /var/tmp/avocado_cp07qzd9                                                                           |
+|                             | `teststmpdir` plugin. The directory   |                                                                                                     |
+|                             | is persistent throughout the tests    |                                                                                                     |
+|                             | in the same Job                       |                                                                                                     |
++-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
+| AVOCADO_TEST_LOGDIR         | Log directory for the test            | /var/tmp/.avocado-task_5t_srpn/test-results/1-Env.test                                              |
++-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
+| AVOCADO_TEST_LOGFILE        | Log file for the test                 | /var/tmp/.avocado-taskcx8of8di/test-results/1-Env.test/debug.log                                    |
++-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
+| AVOCADO_TEST_OUTPUTDIR      | Output directory for the test         | /var/tmp/.avocado-taskcx8of8di/test-results/1-Env.test/data                                         |
++-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
+| AVOCADO_TEST_SYSINFODIR     | The system information directory      | $HOME/avocado/job-results/job-2021-10-26T17.23-98f17a2/sysinfo/pre                                  |
++-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
+| `***`                       | All variables from --mux-yaml         | TIMEOUT=60; IO_WORKERS=10; VM_BYTES=512M; ...                                                       |
++-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
+
+Here is a list of the variables that Avocado currently exports to exec-test
+tests:
+
++-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
+| Environment Variable        | Meaning                               | Example                                                                                             |
++=============================+=======================================+=====================================================================================================+
+| AVOCADO_VERSION             | Version of Avocado test runner        | 92.0                                                                                                |
++-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
+| AVOCADO_TEST_WORKDIR        | Work directory for the test           | /var/tmp/.avocado-task-_4qquwyq/workdir                                                             |
 +-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
 | AVOCADO_TESTS_COMMON_TMPDIR | Temporary directory created by the    | /var/tmp/avocado_XhEdo/                                                                             |
 |                             | `teststmpdir` plugin. The directory   |                                                                                                     |
 |                             | is persistent throughout the tests    |                                                                                                     |
 |                             | in the same Job                       |                                                                                                     |
 +-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
-| AVOCADO_TEST_LOGDIR         | Log directory for the test            | $HOME/logs/job-results/job-2014-09-16T14.38-ac332e6/test-results/$HOME/my_test.sh.1                 |
+| AVOCADO_TEST_OUTPUTDIR      | Output directory for the test         | /var/tmp/.avocado-task-_4qquwyq                                                                     |
 +-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
-| AVOCADO_TEST_LOGFILE        | Log file for the test                 | $HOME/logs/job-results/job-2014-09-16T14.38-ac332e6/test-results/$HOME/my_test.sh.1/debug.log       |
-+-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
-| AVOCADO_TEST_OUTPUTDIR      | Output directory for the test         | $HOME/logs/job-results/job-2014-09-16T14.38-ac332e6/test-results/$HOME/my_test.sh.1/data            |
-+-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
-| AVOCADO_TEST_SYSINFODIR     | The system information directory      | $HOME/logs/job-results/job-2014-09-16T14.38-ac332e6/test-results/$HOME/my_test.sh.1/sysinfo         |
+| AVOCADO_TEST_SYSINFODIR     | The system information directory      | $HOME/avocado/job-results/job-2021-10-26T17.03-d09ca41/sysinfo/pre                                  |
 +-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
 | `***`                       | All variables from --mux-yaml         | TIMEOUT=60; IO_WORKERS=10; VM_BYTES=512M; ...                                                       |
 +-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
+
+.. note:: The same variables listed for the INSTRUMENTED tests above are
+   available to all the test types when using the legacy runner.
 
 SIMPLE Tests BASH extensions
 ----------------------------


### PR DESCRIPTION
This adds support to the AVOCADO_VERSION and AVOCADO_TEST_WORKDIR to the
EXEC test on nrunner.

Other variables, like AVOCADO_TEST_BASEDIR, AVOCADO_TEST_LOGDIR and
AVOCADO_TEST_LOGFILE may not make sense as they would hold the
information where the avocado command started and not the environment
where the test is currently running.

Signed-off-by: Willian Rampazzo <willianr@redhat.com>

Changes from v4:
 - Fix documentation
 - Add a cleanup method