### PR TITLE
ci.yml: Add experimental checks + Makefile.gh [v2]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,3 +188,26 @@ jobs:
         path: /home/runner/work/avocado/avocado/dist/
         retention-days: 1
     - run: echo "🥑 This job's status is ${{ job.status }}."
+
+  experimental-checks:
+    name: Experimental checks
+    runs-on: ubuntu-20.04
+    steps:
+      - run: echo "Job triggered by a ${{ github.event_name }} event on branch is ${{ github.ref }} in repository is ${{ github.repository }}, runner on ${{ runner.os }}"
+      - name: Check out repository code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Run Codespell Check
+        run: make -f Makefile.gh codespell
+        continue-on-error: True
+      - name: Run bandit check
+        run: make -f Makefile.gh bandit
+        continue-on-error: True
+      - name: Save bandit output as artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: bandit-results
+          path: /home/runner/work/avocado/avocado/bandit-output.txt
+          retention-days: 1
+      - run: echo "🥑 This job's status is ${{ job.status }}."

--- a/Makefile.gh
+++ b/Makefile.gh
@@ -1,0 +1,14 @@
+# This Makefile contains targets used by GitHub Actions
+
+all:
+	@echo
+	@echo "This file contains targets used by GitHub Actions."
+	@echo
+
+codespell:
+	pip install codespell
+	codespell --check-filenames --check-hidden --skip ".git,*.js,./selftests/unit/utils/test_cpu.py.data/*"
+
+bandit:
+	pip install bandit
+	bandit -o bandit-output.txt -r --skip B101,B105,B311,B404,B603 .


### PR DESCRIPTION
Re-implementation of https://github.com/avocado-framework/avocado/pull/4918

Add a couple of experimental checks:
   * codespell to complement pycheck's spellchecker
   * bandit to find common security issues in Python code
    
Both will output the problems found without any action.
    
The actions are run intentionally from a new makefile `Makefile.gh` instead of using pre-made GitHub Actions.
This allows reproducing the checks locally.
    
