### PR TITLE
s/SimpleQueue/Queue/ just for instrumented runner

### DIFF
--- a/avocado/core/runners/avocado_instrumented.py
+++ b/avocado/core/runners/avocado_instrumented.py
@@ -93,7 +93,7 @@ class AvocadoInstrumentedTestRunner(nrunner.BaseRunner):
     def run(self):
         yield messages.StartedMessage.get()
         try:
-            queue = multiprocessing.SimpleQueue()
+            queue = multiprocessing.Queue()
             process = multiprocessing.Process(target=self._run_avocado,
                                               args=(self.runnable, queue))
 


### PR DESCRIPTION
SimpleQueue it is a simplified Queue type, very close to a locked Pipe.
Because of the way it is implemented, signals and GC can cause deadlocks.
Replacing it with a Queue it will return a process shared queue
implemented using a pipe and a few locks/semaphores. This is not
replacing all SimpleQueues by Queues, instead I'm reaplacing only here
because of the issue #4935. Both API (for the cases used here) are the
same, so even with a more complete API there is no significant change
here.

Fixes ##4935.

Signed-off-by: Beraldo Leal <bleal@redhat.com>