### PR TITLE
Stripping the new line character for an output value in pci.py

### DIFF
--- a/avocado/utils/pci.py
+++ b/avocado/utils/pci.py
@@ -185,7 +185,7 @@ def get_slot_from_sysfs(full_pci_address):
     if not os.path.isfile('/sys/bus/pci/devices/%s/devspec' % full_pci_address):
         return
     devspec = genio.read_file("/sys/bus/pci/devices/%s/devspec"
-                              % full_pci_address)
+                              % full_pci_address).strip()
     if not os.path.isfile("/proc/device-tree/%s/ibm,loc-code" % devspec):
         return
     slot = genio.read_file("/proc/device-tree/%s/ibm,loc-code" % devspec)


### PR DESCRIPTION
Reading a file content of a file was added with new line character,
using the same output in next line without stripping is failing
to get the desire output. So added the strip() and the issue is
fixed and getting desired output without any issue.

Signed-off-by: Naresh Bannoth <nbannoth@in.ibm.com>