### PR TITLE
Moving asset warn message to info

### DIFF
--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -317,8 +317,7 @@ class Asset:
         If asset_hash is None then will consider a valid asset.
         """
         if asset_hash is None:
-            LOG.warning("No hash provided. Cannot check the asset file"
-                        " integrity.")
+            LOG.info("No hash provided. Cannot check the asset file integrity.")
             return True
 
         hash_path = cls._get_hash_file(asset_path)


### PR DESCRIPTION
Moving warn to info as while running misc test repo in every
run where we depend on using asset library it flash warning
and some time that is misleading on test front as we used test
warn tag for atual Test warn

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>