### PR TITLE
utils.asset: use __name__ as logger namespace

### DIFF
--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -36,7 +36,7 @@ from . import path as utils_path
 from .download import url_download
 from .filelock import FileLock
 
-LOG = logging.getLogger('avocado.test')
+LOG = logging.getLogger(__name__)
 #: The default hash algorithm to use on asset cache operations
 DEFAULT_HASH_ALGORITHM = 'sha1'
 


### PR DESCRIPTION
This is part of bigger effort to better organize our log messages. Also
a proper alternative to #5119. More to come here, but I just would like
to test if this will fix the issue reported there.

Signed-off-by: Beraldo Leal <bleal@redhat.com>