### PR TITLE
Convert test parameters to variants in tasks

### DIFF
--- a/avocado/core/messages.py
+++ b/avocado/core/messages.py
@@ -106,6 +106,13 @@ class StartMessageHandler(BaseMessageHandler):
         task_path = os.path.join(base_path, task_id.str_filesystem)
         logfile = os.path.join(task_path, DEFAULT_LOG_FILE)
         os.makedirs(task_path, exist_ok=True)
+        params = []
+        if task.runnable.variant is not None:
+            # convert variant into the list of parameters
+            params = [param for params in
+                      task.runnable.variant.get('variant', [])
+                      for param in params[1]]
+
         open(logfile, 'w').close()
         metadata = {'job_logdir': job.logdir,
                     'job_unique_id': job.unique_id,
@@ -114,7 +121,8 @@ class StartMessageHandler(BaseMessageHandler):
                     'task_path': task_path,
                     'time_start': message['time'],
                     'actual_time_start': time.time(),
-                    'name': task_id}
+                    'name': task_id,
+                    'params': params}
         if task.category == TASK_DEFAULT_CATEGORY:
             job.result.start_test(metadata)
             job.result_events_dispatcher.map_method('start_test', job.result,

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -499,17 +499,11 @@ class ExecTestRunner(BaseRunner):
 
     def _create_params(self):
         """Create params for the test"""
-        # inject the -p command-line / run.test_parameters option in the
-        # environment variables
-        params = dict(self.runnable.config.get('run.test_parameters', []))
+        if self.runnable.variant is None:
+            return {}
 
-        if self.runnable.variant is not None:
-            params_from_variant = dict([(str(key), str(val)) for _, key, val in
-                                        self.runnable.variant['variant'][0][1]])
-            # if we have params from the variant, replace the original params
-            if params_from_variant:
-                params = params_from_variant
-
+        params = dict([(str(key), str(val)) for _, key, val in
+                       self.runnable.variant['variant'][0][1]])
         return params
 
     def run(self):


### PR DESCRIPTION
After the 050bc33 the suite will raise an error when the variants and test parameters are used together. With this in mind, there is no difference between one variant and test parameters from the task perspective. Let's add test parameters to test tasks as a variant. In the future, we can discuss if the `variant` is the right variable name in tasks for holding data about parameters.

This change will fix the issue with representation of parameters in result plugins.

Reference: #4990
Signed-off-by: Jan Richter <jarichte@redhat.com>