### PR TITLE
add probe for uos systems in general

### DIFF
--- a/avocado/utils/distro.py
+++ b/avocado/utils/distro.py
@@ -435,6 +435,7 @@ class OpenEulerProbe(Probe):
     CHECK_FILE_DISTRO_NAME = 'openEuler'
     CHECK_VERSION_REGEX = re.compile(r'openEuler release (\d+)\.(\d+).*')
 
+
 class UnionTechProbe(Probe):
 
     """

--- a/avocado/utils/distro.py
+++ b/avocado/utils/distro.py
@@ -435,6 +435,17 @@ class OpenEulerProbe(Probe):
     CHECK_FILE_DISTRO_NAME = 'openEuler'
     CHECK_VERSION_REGEX = re.compile(r'openEuler release (\d+)\.(\d+).*')
 
+class UnionTechProbe(Probe):
+
+    """
+    Simple probe for uos systems in general
+    """
+
+    CHECK_FILE = '/etc/UnionTech-release'
+    CHECK_FILE_CONTAINS = 'uos release'
+    CHECK_FILE_DISTRO_NAME = 'uos'
+    CHECK_VERSION_REGEX = re.compile(r'uos release (\d+)\.(\d+).*')
+
 
 #: the complete list of probes that have been registered
 REGISTERED_PROBES = []
@@ -456,6 +467,7 @@ register_probe(DebianProbe)
 register_probe(SUSEProbe)
 register_probe(UbuntuProbe)
 register_probe(OpenEulerProbe)
+register_probe(UnionTechProbe)
 
 
 def detect(session=None):

--- a/avocado/utils/distro.py
+++ b/avocado/utils/distro.py
@@ -438,7 +438,7 @@ class OpenEulerProbe(Probe):
 class UnionTechProbe(Probe):
 
     """
-    Simple probe for uos systems in general
+    Simple probe for UnionTech systems in general
     """
 
     CHECK_FILE = '/etc/UnionTech-release'


### PR DESCRIPTION
Signed-off-by: shilei <shileib@uniontech.com>
add probe for uos systems in general
UnionTech is the name of the company ,Uos is the name of the operating system.
UnionTech Software Technology Co., Ltd. is a domestic basic software company, which was jointly established by operating system manufacturers in 2019 [3]. The company focuses on the development and service of operating system and other basic software, and is committed to providing operating system products and solutions for users in different industries.