### PR TITLE
release.yml: updates for setting up variables and move readthedocs step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,13 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: fedora:34
+    env:
+      VERSION: ${{ github.event.inputs.version }}
+      DEVEL_NAME: ${{ github.event.inputs.devel_name }}
+      DEVEL_MAIL: ${{ github.event.inputs.devel_mail }}
+      PYTHON: /usr/bin/python3
+      TOKEN_RTD: ${{ secrets.RTD_TOKEN }}
+      URL: "https://readthedocs.org/api/v3/projects/${{ github.event.inputs.rtd_project }}"
 
     steps:
       - name: install required packages
@@ -41,16 +48,10 @@ jobs:
           fetch-depth: 0
       - name: Update VERSION files and python-avocado.spec
         run: |
-          export VERSION=${{ github.event.inputs.version }}
-          export DEVEL_NAME=${{ github.event.inputs.devel_name }}
-          export DEVEL_MAIL=${{ github.event.inputs.devel_mail }}
           make -f Makefile.gh propagate-version
           make -f Makefile.gh release-update-spec
       - name: Commit files and tag
         run: |
-          export VERSION=${{ github.event.inputs.version }}
-          export DEVEL_NAME=${{ github.event.inputs.devel_name }}
-          export DEVEL_MAIL=${{ github.event.inputs.devel_mail }}
           git config --local user.email "${{ github.event.inputs.devel_mail }}"
           git config --local user.name "${{ github.event.inputs.devel_name }}"
           make -f Makefile.gh release-commit-tag
@@ -60,33 +61,23 @@ jobs:
           github_token: ${{ secrets.RELEASE_TOKEN }}
           branch: ${{ github.ref }}
       - name: Build documentation readthedocs
-        env:
-          token: ${{ secrets.RTD_TOKEN }}
-          url: "https://readthedocs.org/api/v3/projects/${{ github.event.inputs.rtd_project }}"
-          version: ${{ github.event.inputs.version }}
         run: |
-          export VERSION=$version
-          export URL=$url
-          export TOKEN=$token
           make -f Makefile.gh build-update-readthedocs
       - run: echo "In a few minutes the release documentation will be available in https://${{ github.event.inputs.rtd_project }}.readthedocs.io/en/${{ github.event.inputs.version }}/"
       - name: Build wheel
-        run: |
-          make -f Makefile.gh build-wheel
+        run: make -f Makefile.gh build-wheel
       - name: Save wheel as artifact
         uses: actions/upload-artifact@v2
         with:
           name: wheel
-          path: /__w/avocado-test/avocado-test/PYPI_UPLOAD/
+          path: ${{github.workspace}}/PYPI_UPLOAD/
           retention-days: 3
       - name: Upload to pypi
+        continue-on-error: true
         env:
-          TWINE_USERNAME: '${{ secrets.PYPI_USER }}'
-          TWINE_PASSWORD: '${{ secrets.PYPI_PASSWD }}'
-        run: |
-          export TWINE_USERNAME=$TWINE_USERNAME
-          export TWINE_PASSWORD=$TWINE_PASSWORD
-          make -f Makefile.gh update-pypi
+          TWINE_USERNAME: ${{ secrets.PYPI_USER }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWD }}
+        run: make -f Makefile.gh update-pypi
 
   build-and-publish-eggs:
     name: Build eggs and publish them
@@ -94,7 +85,7 @@ jobs:
     needs: release
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10.0]
       fail-fast: false
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,10 +60,6 @@ jobs:
         with:
           github_token: ${{ secrets.RELEASE_TOKEN }}
           branch: ${{ github.ref }}
-      - name: Build documentation readthedocs
-        run: |
-          make -f Makefile.gh build-update-readthedocs
-      - run: echo "In a few minutes the release documentation will be available in https://${{ github.event.inputs.rtd_project }}.readthedocs.io/en/${{ github.event.inputs.version }}/"
       - name: Build wheel
         run: make -f Makefile.gh build-wheel
       - name: Save wheel as artifact
@@ -72,6 +68,10 @@ jobs:
           name: wheel
           path: ${{github.workspace}}/PYPI_UPLOAD/
           retention-days: 3
+      - name: Build documentation readthedocs
+        run: |
+          make -f Makefile.gh build-update-readthedocs
+      - run: echo "In a few minutes the release documentation will be available in https://${{ github.event.inputs.rtd_project }}.readthedocs.io/en/${{ github.event.inputs.version }}/"
       - name: Upload to pypi
         continue-on-error: true
         env:

--- a/Makefile.gh
+++ b/Makefile.gh
@@ -47,20 +47,20 @@ release-commit-tag:
 	git tag "$(VERSION)" -m "Release $(VERSION)"
 
 build-update-readthedocs:
-ifndef TOKEN
-	$(error TOKEN is undefined)
+ifndef TOKEN_RTD
+	$(error TOKEN_RTD is undefined)
 endif
 ifndef URL
 	$(error URL is undefined)
 endif
 	# Activate version
 	curl -X PATCH \
-		-H "Authorization: Token $(TOKEN)" "$(URL)/versions/$(VERSION)/" \
+		-H "Authorization: Token $(TOKEN_RTD)" "$(URL)/versions/$(VERSION)/" \
 		-H "Content-Type: application/json" -d '{"active": true, "hidden": false }'
 
 	# Build new version
 	curl -X POST \
-		-H "Authorization: Token $(TOKEN)" "$(URL)/versions/$(VERSION)/builds/"
+		-H "Authorization: Token $(TOKEN_RTD)" "$(URL)/versions/$(VERSION)/builds/"
 
 build-wheel:
 	pip3 install --user build


### PR DESCRIPTION
This is a follow up of https://github.com/avocado-framework/avocado/pull/5127 with some updates after testing.

`release.yml`: use jobs.env for setting up variables
    
This makes the pipeline easier to read.

Rename TOKEN to TOKEN_RTD to make it clearer this token is for readthedocs.org
    
A couple of minor fixes:
    - use python 3.10.0 because github action don't recognise 3.10
    - use `${{github.workspace}}` variable instead of hardcode a path

`release.yml`: move readthedocs step to run later
    
readthedocs needs a couple of seconds to refresh it copy of the git repository. If we try to update readthedocs immediately after tagging the new release, it'll fail.
    


This pipeline can be seen in action at https://github.com/ana/avocado-test/runs/4211607135?check_suite_focus=true
After a commit adding "fake" release notes for 93.0 
Even if the steps are all in **green**, "upload to pypi" is made to fail on purpose.