### PR TITLE
runnable: introduce custom format f-strings

### DIFF
--- a/avocado/core/__init__.py
+++ b/avocado/core/__init__.py
@@ -188,6 +188,14 @@ def register_core_options():
                          key_type=list,
                          help_msg=help_msg)
 
+    help_msg = ('By default Avocado runners will use the {uri} of a test as '
+                'its identifier. Use a custom f-string identifer in order to '
+                'change it.')
+    stgs.register_option(section='runner',
+                         key='identifier_fmt',
+                         default="{uri}",
+                         help_msg=help_msg)
+
     help_msg = 'List of test references (aliases or paths)'
     stgs.register_option(section='resolver',
                          key='references',

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -130,6 +130,52 @@ class Runnable:
                           self.kwargs, self.tags, self.requirements,
                           self.variant)
 
+    @property
+    def identifier(self):
+        """Runnable identifier respecting user's format string.
+
+        This is still experimental and we have room for improvements.
+
+        This property it will return an unique identifier for this runnable.
+        Please use this property in order to respect user's customization.
+
+        By default runnables has its '{uri}' as identifier.
+
+        Custom formatter can be configured and currently we accept the
+        following values as normal f-strings replacements: {uri}, {args},
+        and {kwargs}. "args" and "kwargs" are special cases.
+
+        For args, since it is a list, you can use in two different ways:
+        "{args}" for the entire list, or "{args[n]}" for a specific element
+        inside this list.  The same is valid when using "{kwargs}". With
+        kwargs, since it is a dictionary, you have to specify a key as index
+        and then the values are used. For instance if you have a kwargs value
+        named 'DEBUG', a valid usage could be: "{kwargs[DEBUG]}" and this will
+        print the current value to this variable (i.e: True or False).
+
+        Since this is formatter, combined values can be used. Example:
+        "{uri}-{args}".
+        """
+        fmt = self.config.get("runner.identifier_fmt")
+
+        # For args we can use the entire list of arguments or with a specific
+        # index.
+        args = '-'.join(self.args)
+        if 'args' in fmt and '[' in fmt:
+            args = self.args
+
+        # For kwargs we can use the entire list of values or with a specific
+        # index.
+        kwargs = '-'.join(self.kwargs.values())
+        if 'kwargs' in fmt and '[' in fmt:
+            kwargs = self.kwargs
+
+        options = {'uri': self.uri,
+                   'args': args,
+                   'kwargs': kwargs}
+
+        return fmt.format(**options)
+
     @classmethod
     def from_args(cls, args):
         """Returns a runnable from arguments"""

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -218,7 +218,7 @@ class Runner(RunnerInterface):
         else:
             prefix = index
         test_id = TestID(prefix,
-                         runnable.uri,
+                         runnable.identifier,
                          variant,
                          no_digits)
         # inject variant on runnable


### PR DESCRIPTION
With this experimental change, we are enabling users to set custom
identifiers for the runnables/tests. By default we are still using {uri}
as identifier but any custom f-string using uri, args and/or kwargs can
be used. For now we have a global settings for all runners, since we
have the ability to create custom suites. However future improvements
can be added here.

Fixes #4980.

Signed-off-by: Beraldo Leal <bleal@redhat.com>