### PR TITLE
Fetching Avocado's egg during installation process

### DIFF
--- a/avocado/core/exit_codes.py
+++ b/avocado/core/exit_codes.py
@@ -38,5 +38,9 @@ AVOCADO_FAIL = 0x0004
 #: hit CTRL+C while the job was still running.
 AVOCADO_JOB_INTERRUPTED = 0x0008
 
+#: Avocado had it was interrupted but not at the JOB level. Usually this means
+#: that something it was skipped but it is safe to ignore.
+AVOCADO_GRACEFULL_INTERRUPTED = 0x0016
+
 #: Avocado generic crash
 AVOCADO_GENERIC_CRASH = -1

--- a/avocado/plugins/assets.py
+++ b/avocado/plugins/assets.py
@@ -537,7 +537,7 @@ class Assets(CLICmd):
         try:
             asset.find_asset_file()
             LOG_UI.error("Asset with name %s already registered.", name)
-            return exit_codes.AVOCADO_FAIL
+            return exit_codes.AVOCADO_GRACEFULL_INTERRUPTED
         except OSError:
             try:
                 asset.fetch()

--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -353,7 +353,7 @@ class Asset:
         """
         # First let's search for the file in each one of the cache locations
         asset_file = None
-        error = "unknown"
+        error = "Can't fetch: 'urls' is not defined."
         timeout = timeout or DOWNLOAD_TIMEOUT
         try:
             return self.find_asset_file(create_metadata=True)

--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -86,7 +86,7 @@ class Asset:
         else:
             self.algorithm = algorithm
 
-        self.cache_dirs = cache_dirs
+        self.cache_dirs = cache_dirs or []
         self.expire = expire
         self.metadata = metadata
 

--- a/avocado/utils/download.py
+++ b/avocado/utils/download.py
@@ -23,6 +23,7 @@ import shutil
 import socket
 import sys
 from multiprocessing import Process
+from urllib.error import HTTPError
 from urllib.request import urlopen
 
 from . import aurl, crypto, output
@@ -45,8 +46,8 @@ def url_open(url, data=None, timeout=5):
     """
     try:
         result = urlopen(url, data=data, timeout=timeout)
-    except socket.timeout as ex:
-        msg = "Timeout was reached: {}".format(str(ex))
+    except (socket.timeout, HTTPError) as ex:
+        msg = "Failed downloading file: {}".format(str(ex))
         log.error(msg)
         return None
 

--- a/selftests/unit/test_runner_requirement_asset.py
+++ b/selftests/unit/test_runner_requirement_asset.py
@@ -36,7 +36,7 @@ class BasicTests(unittest.TestCase):
                 break
         result = 'error'
         self.assertIn(result, messages[-1]['result'])
-        stderr = b"Failed to fetch foo (unknown)."
+        stderr = b"Failed to fetch foo ("
         self.assertIn(stderr, messages[-2]['log'])
 
 


### PR DESCRIPTION
This is an experimental ideal to fetch and register avocado eggs during
the install process, for now it is only working when using the develop
mode, but if approved I will adapt the normal installs to do the same.
    
Basically this is downloading our egg for future use (i.e podman
spawner) so we can deploy avocado using local resources.
    
It is more likely users will have Internet connection  when installing
this software then when running it. This is an attempt to minimize
connectivity issues, so we can download only in case the asset is not
found.

Signed-off-by: Beraldo Leal <bleal@redhat.com>
