### PR TITLE
avocado/core/teststatus.py: add a handy list of OK and NOT OK status

### DIFF
--- a/avocado/core/teststatus.py
+++ b/avocado/core/teststatus.py
@@ -25,3 +25,9 @@ STATUSES_MAPPING = {"SKIP": True,
 #: Valid test statuses, if a returned status is not listed here, it
 #: should be handled as error condition.
 STATUSES = [key for key in STATUSES_MAPPING.keys()]
+
+#: List of status that are considered OK (should not cause a job failure)
+STATUSES_OK = [key for (key, value) in STATUSES_MAPPING.items() if value]
+
+#: List of status that are NOT considered OK (should cause a job failure)
+STATUSES_NOT_OK = [key for (key, value) in STATUSES_MAPPING.items() if not value]


### PR DESCRIPTION
When checking if a test status is "good" or "not good", it's better to
refer to a canonical source for truth.  That currently exists as the
`STATUS_MAPPING` dictionary, but it's not straightforward to use.

Let's add a list of both "OK" and "NOT OK" statuses to make its usage
simpler.

Signed-off-by: Cleber Rosa <crosa@redhat.com>