### PR TITLE
typo fix: hello_option -> hello for hello/setup.py

### DIFF
--- a/examples/plugins/cli-cmd/hello/setup.py
+++ b/examples/plugins/cli-cmd/hello/setup.py
@@ -1,11 +1,11 @@
 from setuptools import setup
 
 if __name__ == '__main__':
-    setup(name='avocado-hello-world-option',
+    setup(name='avocado-hello-world',
           version='1.0',
-          description='Avocado Hello World CLI command with config option',
-          py_modules=['hello_option'],
+          description='Avocado Hello World CLI command',
+          py_modules=['hello'],
           entry_points={
-              'avocado.plugins.cli.cmd': ['hello_option = hello_option:HelloWorld'],
+              'avocado.plugins.cli.cmd': ['hello = hello:HelloWorld'],
               }
           )


### PR DESCRIPTION
Revert hello/setup.py in commit 66514efe50cadea8b6d4e35539110920e825cb8e

Signed-off-by: Linggang Zeng <linggang.zeng@easystack.cn>