### PR TITLE
log: use namespace instead of module

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -198,8 +198,7 @@ class Job:
 
     def __start_job_logging(self):
         # Enable test logger
-        fmt = ('%(asctime)s %(module)-16.16s L%(lineno)-.4d %('
-               'levelname)-5.5s| %(message)s')
+        fmt = ('%(asctime)s %(name)s %(levelname)-5.5s| %(message)s')
         test_handler = output.add_log_handler(LOG_JOB,
                                               logging.FileHandler,
                                               self.logfile, self.loglevel, fmt)

--- a/avocado/core/runners/utils/messages.py
+++ b/avocado/core/runners/utils/messages.py
@@ -201,8 +201,7 @@ def start_logging(config, queue):
     """
     log_level = config.get('job.output.loglevel', logging.DEBUG)
     log_handler = RunnerLogHandler(queue, 'log')
-    fmt = ('%(asctime)s %(module)-16.16s L%(lineno)-.4d %('
-           'levelname)-5.5s| %(message)s')
+    fmt = ('%(asctime)s %(name)s %(levelname)-5.5s| %(message)s')
     formatter = logging.Formatter(fmt=fmt)
     log_handler.setFormatter(formatter)
 


### PR DESCRIPTION
For end-users, module name + line number is not an useful information.
Also, recent changes are using custom namespaces to better organize the
loggers. This patch it was postponed for post-lts and now is time to use
this new format.

Related to #5099.

Signed-off-by: Beraldo Leal <bleal@redhat.com>