### PR TITLE
Custom logger for `utils.process.run` [v2]

### DIFF
--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -346,21 +346,18 @@ class OutputTest(TestCaseTmpDir):
                            OUTPUT_CHECK_ON_OFF_CONTENT,
                            script.READ_ONLY_MODE) as test:
             command = ("%s run --job-results-dir %s --disable-sysinfo "
-                       "--test-runner=runner "
                        "--json - -- %s") % (AVOCADO, self.tmpdir.name, test.path)
             result = process.run(command)
             res = json.loads(result.stdout_text)
             testdir = res["tests"][0]["logdir"]
-            stdout_path = os.path.join(testdir, 'stdout')
-            self.assertTrue(os.path.exists(stdout_path))
-            with open(stdout_path, 'r') as stdout:
-                self.assertEqual(stdout.read(),
-                                 '__STDOUT_CONTENT____STDOUT_DO_RECORD_CONTENT__')
-            stderr_path = os.path.join(testdir, 'stderr')
-            self.assertTrue(os.path.exists(stderr_path))
-            with open(stderr_path, 'r') as stderr:
-                self.assertEqual(stderr.read(),
-                                 '__STDERR_CONTENT____STDERR_DO_RECORD_CONTENT__')
+            log_path = os.path.join(testdir, 'debug.log')
+            self.assertTrue(os.path.exists(log_path))
+            with open(log_path, 'r') as stdout:
+                content = stdout.read()
+            self.assertIn('[stdout] __STDOUT_CONTENT__', content)
+            self.assertIn('[stdout] __STDOUT_DO_RECORD_CONTENT__', content)
+            self.assertIn('[stderr] __STDERR_CONTENT__', content)
+            self.assertIn('[stderr] __STDERR_DO_RECORD_CONTENT__', content)
 
     @skipUnlessPathExists('/bin/true')
     def test_show(self):

--- a/selftests/functional/test_output_check.py
+++ b/selftests/functional/test_output_check.py
@@ -120,6 +120,7 @@ class PassTest(Test):
 """
 
 
+@unittest.skip('Skipping until output-check-record feature will be in nrunner #3882.')
 class RunnerSimpleTest(TestCaseTmpDir):
 
     def assertIsFile(self, path):
@@ -140,7 +141,6 @@ class RunnerSimpleTest(TestCaseTmpDir):
 
     def _check_output_record_all(self):
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
-                    '--test-runner=runner '
                     '--output-check-record all'
                     % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
@@ -157,7 +157,6 @@ class RunnerSimpleTest(TestCaseTmpDir):
 
     def _check_output_record_combined(self):
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
-                    '--test-runner=runner '
                     '--output-check-record combined'
                     % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
@@ -180,7 +179,6 @@ class RunnerSimpleTest(TestCaseTmpDir):
 
     def test_output_record_none(self):
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
-                    '--test-runner=runner '
                     '--output-check-record none'
                     % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
@@ -193,7 +191,6 @@ class RunnerSimpleTest(TestCaseTmpDir):
 
     def test_output_record_stdout(self):
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
-                    '--test-runner=runner '
                     '--output-check-record stdout'
                     % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
@@ -210,7 +207,6 @@ class RunnerSimpleTest(TestCaseTmpDir):
     def test_output_record_and_check(self):
         self._check_output_record_all()
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s'
-                    ' --test-runner=runner'
                     % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -221,7 +217,6 @@ class RunnerSimpleTest(TestCaseTmpDir):
     def test_output_record_and_check_combined(self):
         self._check_output_record_combined()
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s'
-                    ' --test-runner=runner'
                     % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -236,7 +231,6 @@ class RunnerSimpleTest(TestCaseTmpDir):
         with open(stdout_file, 'wb') as stdout_file_obj:
             stdout_file_obj.write(tampered_msg)
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s --xunit -'
-                    ' --test-runner=runner'
                     % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
@@ -252,7 +246,6 @@ class RunnerSimpleTest(TestCaseTmpDir):
         with open(output_file, 'wb') as output_file_obj:
             output_file_obj.write(tampered_msg)
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s --xunit -'
-                    ' --test-runner=runner'
                     % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
@@ -275,7 +268,6 @@ class RunnerSimpleTest(TestCaseTmpDir):
             stderr_file_obj.write(tampered_msg_stderr)
 
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s --json -'
-                    ' --test-runner=runner'
                     % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
@@ -319,7 +311,6 @@ class RunnerSimpleTest(TestCaseTmpDir):
             stdout_file_obj.write(tampered_msg)
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
                     '--disable-output-check --xunit -'
-                    ' --test-runner=runner'
                     % (AVOCADO, self.tmpdir.name, self.output_script.path))
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -336,7 +327,6 @@ class RunnerSimpleTest(TestCaseTmpDir):
         with open(simple_test, 'w') as file_obj:
             file_obj.write(TEST_WITH_SAME_EXPECTED_OUTPUT)
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
-                    '--test-runner=runner '
                     '--output-check-record both --json-variants-load %s' %
                     (AVOCADO, self.tmpdir.name, simple_test, variants_file))
         process.run(cmd_line, ignore_status=True)
@@ -347,7 +337,6 @@ class RunnerSimpleTest(TestCaseTmpDir):
         simple_test, variants_file = self._setup_simple_test(
             TEST_WITH_DIFFERENT_EXPECTED_OUTPUT)
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
-                    '--test-runner=runner '
                     '--output-check-record both --json-variants-load %s' %
                     (AVOCADO, self.tmpdir.name, simple_test, variants_file))
         process.run(cmd_line, ignore_status=True)
@@ -362,7 +351,6 @@ class RunnerSimpleTest(TestCaseTmpDir):
         simple_test, variants_file = self._setup_simple_test(
             TEST_WITH_DIFFERENT_EXPECTED_OUTPUT_VARIANTS)
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
-                    '--test-runner=runner '
                     '--output-check-record both --json-variants-load %s' %
                     (AVOCADO, self.tmpdir.name, simple_test, variants_file))
         process.run(cmd_line, ignore_status=True)
@@ -379,7 +367,6 @@ class RunnerSimpleTest(TestCaseTmpDir):
         simple_test, variants_file = self._setup_simple_test(
             TEST_WITH_DIFFERENT_AND_SAME_EXPECTED_OUTPUT)
         cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
-                    '--test-runner=runner '
                     '--output-check-record both --json-variants-load %s' %
                     (AVOCADO, self.tmpdir.name, simple_test, variants_file))
         process.run(cmd_line, ignore_status=True)


### PR DESCRIPTION
This PR adds a new attribute log to the utils.process.run
method. This will help users to set their own loggers for running
processes with utils.process.

Reference: #5099
Signed-off-by: Jan Richter jarichte@redhat.com

---
Changes from v1 (#5131):
* rename `log` to `logger`
* update of the output tests to correspond the new behavior
* skip of the `output-check` tests 