### PR TITLE
runnable: introduce custom format f-strings (v2)

### DIFF
--- a/avocado/core/__init__.py
+++ b/avocado/core/__init__.py
@@ -188,6 +188,14 @@ def register_core_options():
                          key_type=list,
                          help_msg=help_msg)
 
+    help_msg = ('By default Avocado runners will use the {uri} of a test as '
+                'its identifier. Use a custom f-string identifier in order to '
+                'change it.')
+    stgs.register_option(section='runner',
+                         key='identifier_format',
+                         default="{uri}",
+                         help_msg=help_msg)
+
     help_msg = 'List of test references (aliases or paths)'
     stgs.register_option(section='resolver',
                          key='references',

--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -131,6 +131,57 @@ class Runnable:
                           self.kwargs, self.tags, self.requirements,
                           self.variant)
 
+    @property
+    def identifier(self):
+        """Runnable identifier respecting user's format string.
+
+        This is still experimental and we have room for improvements.
+
+        This property it will return an unique identifier for this runnable.
+        Please use this property in order to respect user's customization.
+
+        By default runnables has its '{uri}' as identifier.
+
+        Custom formatter can be configured and currently we accept the
+        following values as normal f-strings replacements: {uri}, {args},
+        and {kwargs}. "args" and "kwargs" are special cases.
+
+        For args, since it is a list, you can use in two different ways:
+        "{args}" for the entire list, or "{args[n]}" for a specific element
+        inside this list.  The same is valid when using "{kwargs}". With
+        kwargs, since it is a dictionary, you have to specify a key as index
+        and then the values are used. For instance if you have a kwargs value
+        named 'DEBUG', a valid usage could be: "{kwargs[DEBUG]}" and this will
+        print the current value to this variable (i.e: True or False).
+
+        Since this is formatter, combined values can be used. Example:
+        "{uri}-{args}".
+        """
+        fmt = self.config.get("runner.identifier_format")
+
+        # For the cases where there is no config (when calling the Runnable
+        # directly
+        if not fmt:
+            return self.uri
+
+        # For args we can use the entire list of arguments or with a specific
+        # index.
+        args = '-'.join(self.args)
+        if 'args' in fmt and '[' in fmt:
+            args = self.args
+
+        # For kwargs we can use the entire list of values or with a specific
+        # index.
+        kwargs = '-'.join(self.kwargs.values())
+        if 'kwargs' in fmt and '[' in fmt:
+            kwargs = self.kwargs
+
+        options = {'uri': self.uri,
+                   'args': args,
+                   'kwargs': kwargs}
+
+        return fmt.format(**options)
+
     @classmethod
     def from_args(cls, args):
         """Returns a runnable from arguments"""

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -218,7 +218,7 @@ class Runner(RunnerInterface):
         else:
             prefix = index
         test_id = TestID(prefix,
-                         runnable.uri,
+                         runnable.identifier,
                          variant,
                          no_digits)
         # inject variant on runnable

--- a/docs/source/guides/user/chapters/advanced.rst
+++ b/docs/source/guides/user/chapters/advanced.rst
@@ -1,6 +1,72 @@
 Advanced usage
 ==============
 
+Custom Runnable Identifier
+--------------------------
+
+In some cases, you might have a wrapper as an entry point for the tests, so
+Avocado will use only the wrapper as test id. For instance, imagine a Makefile
+with some targets ('foo', 'bar') and each target is one test. Having a single
+test suite with a test calling `foo`, it will make Avocado print something like
+this:
+
+
+```
+JOB ID     : b6e5bdf2c891382bbde7f24e906a168af351154a
+JOB LOG    : ~/avocado/job-results/job-2021-09-24T17.39-b6e5bdf/job.log
+ (1/1) make: STARTED
+ (1/1) make: PASS (2.72 s)
+RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
+JOB HTML   : ~/avocado/job-results/job-2021-09-24T17.39-b6e5bdf/results.html
+JOB TIME   : 5.49 s
+```
+
+This is happening because Avocado is using the 'uri' as identifier with in the
+current Runnables.
+
+You can change that by setting a custom format with the option
+`runner.identifier_format` in you `avocado.conf` file. For instance:
+
+```
+[runner]
+identifier_format = "{uri}-{args[0]}"
+```
+
+With the above adjustment, running the same suite it will produce something
+like this:
+
+```
+JOB ID     : 577b70b079e9a6f325ff3e73fd9b93f80ee7f221
+JOB LOG    : /home/local/avocado/job-results/job-2021-11-23T13.12-577b70b/job.log
+ (1/1) "/usr/bin/make-foo": STARTED
+ (1/1) "/usr/bin/make-foo": PASS (0.01 s)
+RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
+JOB HTML   : ~/avocado/job-results/job-2021-11-23T13.12-577b70b/results.html
+JOB TIME   : 0.97 s
+```
+
+For the `identifier_format` you can use any f-string that it will use `{uri}`,
+`{args}` or `{kwargs}`. By default it will use `{uri}`.
+
+When using args, since it is a list, you can use in two different ways:
+"{args}" for the entire list, or "{args[n]}" for a specific element inside this
+list.  The same is valid when using "{kwargs}". With kwargs, since it is a
+dictionary, you have to specify a key as index and then the values are used.
+
+For instance if you have a kwargs value named 'DEBUG', a valid usage could be:
+"{kwargs[DEBUG]}" and this will print the current value to this variable (i.e:
+True or False).
+
+
+.. note:: Please, keep in mind this is an experimental feature, and for now you
+   have to use it in combination with :ref:`documentation<the_hint_files>`.
+
+.. note:: Also, be aware this feature it is meant to set custom Runnable
+   identifiers strings only. Due some current limitations on hint files, this
+   will not fully solve the 'external runner' problem. For that, we have a
+   `pending Feature Request
+   <https://github.com/avocado-framework/avocado/issues/5137>`_
+
 Test Runner Selection
 ---------------------
 

--- a/selftests/unit/test_nrunner.py
+++ b/selftests/unit/test_nrunner.py
@@ -70,6 +70,12 @@ class Runnable(unittest.TestCase):
         self.assertEqual(runnable.args, ("/etc/profile",))
         self.assertEqual(runnable.kwargs, {"TERM": "vt3270"})
 
+    def test_identifier_args(self):
+        config = {'runner.identifier_format': '{uri}-{args[0]}'}
+        runnable = nrunner.Runnable('exec-text', 'uri', 'arg1', 'arg2',
+                                    config=config)
+        self.assertEqual(runnable.identifier, 'uri-arg1')
+
     def test_runnable_command_args(self):
         runnable = nrunner.Runnable('noop', 'uri', 'arg1', 'arg2')
         actual_args = runnable.get_command_args()


### PR DESCRIPTION
With this experimental change, we are enabling users to set custom
identifiers for the runnables/tests. By default we are still using {uri}
as identifier but any custom f-string using uri, args and/or kwargs can
be used. For now we have a global settings for all runners, since we
have the ability to create custom suites. However future improvements
can be added here.

Fixes #4980.

Signed-off-by: Beraldo Leal <bleal@redhat.com>

### Changes from v1:

* Added unit test;
* Added a doc section;
* Fixed setting variable name;