### PR TITLE
.travis.yml: save some build credits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ arch:
 python:
     - "3.9"
 
-env:
-    - AVOCADO_PARALLEL_LINT_JOBS=1
-
 addons:
   apt:
     packages:
@@ -22,6 +19,7 @@ addons:
 
 install:
     - pip install -r requirements-dev.txt
+    - python3 setup.py develop
 
 script:
-    - make check
+    - python3 selftests/check.py --skip static-checks


### PR DESCRIPTION
Do not run static checks in travis, they're run in github actions
and this is enough since the statics checks are independant of the arch.

Not using 'make check' has also the advantage of not running
the targets clean and uninstall. This should save some build time
as well.

Do not set AVOCADO_PARALLEL_LINT_JOBS, it was used by the static
jobs.

Signed-off-by: Ana Guerrero Lopez <anguerre@redhat.com>