### PR TITLE
.cirrus.yml: Update Fedora versions (remove 33, add 35)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,7 +5,7 @@ redhat_version_task:
        - python3 -m avocado --version
     container:
         matrix:
-          - image: fedora:33
+          - image: fedora:35
           - image: fedora:34
           - image: registry.access.redhat.com/ubi8/ubi
 
@@ -22,7 +22,7 @@ fedora_develop_install_uninstall_task:
        - test `python3 -m avocado plugins | grep ^html | wc -l` -eq "0"
        - test `python3 -m avocado plugins | grep ^robot | wc -l` -eq "0"
     container:
-      image: fedora:34
+      image: fedora:35
 
 redhat_egg_task:
     egg_script:
@@ -35,7 +35,7 @@ redhat_egg_task:
        - python3 -c 'import sys; from pkg_resources import require; require("avocado-framework"); from avocado.core.main import main; sys.exit(main())' run /bin/true
     container:
         matrix:
-          - image: fedora:33
+          - image: fedora:35
           - image: fedora:34
           - image: registry.access.redhat.com/ubi8/ubi
 
@@ -70,8 +70,8 @@ debian_egg_task:
 
 fedora_selftests_task:
     selftests_script:
-       - make develop
+       - python3 setup.py develop --user
        - PATH=$HOME/.local/bin:$PATH LANG=en_US.UTF-8 AVOCADO_CHECK_LEVEL=0 python3 selftests/check.py  --skip static-checks
     container:
         matrix:
-          - image: quay.io/avocado-framework/avocado-ci-fedora-33
+          - image: quay.io/avocado-framework/avocado-ci-fedora-35

--- a/contrib/containers/ci/selftests/fedora-35.docker
+++ b/contrib/containers/ci/selftests/fedora-35.docker
@@ -1,0 +1,6 @@
+FROM fedora:35
+LABEL description "Fedora image used on integration checks, such as cirrus-ci"
+RUN dnf -y module enable avocado:latest
+RUN dnf -y install dnf-plugins-core git findutils make which
+RUN dnf -y builddep python-avocado
+RUN dnf -y clean all

--- a/selftests/functional/test_lv_utils.py
+++ b/selftests/functional/test_lv_utils.py
@@ -114,6 +114,8 @@ class DiskSpace(unittest.TestCase):
                      'macOS does not support scsi_debug module')
     @unittest.skipIf(not process.can_sudo(), "This test requires root or "
                      "passwordless sudo configured.")
+    @unittest.skipIf(process.system("which modprobe", ignore_status=True),
+                     "kmod not installed (command modprobe is missing)")
     def test_get_diskspace(self):
         """
         Use scsi_debug device to check disk size


### PR DESCRIPTION
Remove Fedora 33 that reached EOL on 2021-11-30 and add Fedora 35.
Update fedora_selftests_task to use fedora 35 and add the steps that were handled by the custom container.

