### PR TITLE
Spawners output_dir [v2]

### DIFF
--- a/avocado/core/nrunner.py
+++ b/avocado/core/nrunner.py
@@ -604,11 +604,9 @@ class ExecTestRunner(BaseRunner):
         return avocado_test_env_variables
 
     def run(self):
-        env = None
+        env = dict(os.environ)
         if self.runnable.kwargs:
-            current = dict(os.environ)
-            current.update(self.runnable.kwargs)
-            env = current
+            env.update(self.runnable.kwargs)
 
         # set default Avocado environment variables if running on a valid Task
         if self.runnable.uri is not None:

--- a/avocado/core/plugin_interfaces.py
+++ b/avocado/core/plugin_interfaces.py
@@ -308,6 +308,17 @@ class Spawner(Plugin):
         :type runtime_task: :class:`avocado.core.task.runtime.RuntimeTask`
         """
 
+    def create_task_output_dir(self, runtime_task):
+        """Creates output directory in the intended location, before the task spawn.
+
+        The output directory path will be saved to the `task.runnable.config`
+        for the usage by runners.
+
+        :param runtime_task: wrapper for a Task with additional runtime
+                             information.
+        :type runtime_task: :class:`avocado.core.task.runtime.RuntimeTask`
+        """
+
     @abc.abstractmethod
     async def wait_task(self, runtime_task):
         """Waits for a task to finish.

--- a/avocado/core/runners/avocado_instrumented.py
+++ b/avocado/core/runners/avocado_instrumented.py
@@ -57,6 +57,8 @@ class AvocadoInstrumentedTestRunner(nrunner.BaseRunner):
             klass, method = klass_method.split('.', 1)
 
             params = AvocadoInstrumentedTestRunner._create_params(runnable)
+            result_dir = (runnable.output_dir or
+                          tempfile.mkdtemp(prefix=".avocado-task"))
             test_factory = [klass,
                             {'name': TestID(1, runnable.uri),
                              'methodName': method,
@@ -64,7 +66,7 @@ class AvocadoInstrumentedTestRunner(nrunner.BaseRunner):
                              'modulePath': module_path,
                              'params': params,
                              'tags': runnable.tags,
-                             'run.results_dir': tempfile.mkdtemp(prefix=".avocado-task"),
+                             'run.results_dir': result_dir,
                              }]
 
             messages.start_logging(runnable.config, queue)

--- a/avocado/core/spawners/common.py
+++ b/avocado/core/spawners/common.py
@@ -1,4 +1,5 @@
 import enum
+import os
 from mmap import ACCESS_READ, mmap
 from pathlib import Path
 
@@ -32,6 +33,10 @@ class SpawnerMixin:
             config = settings.as_dict()
         self.config = config
         self.job_output_dir = None
+
+    def task_output_dir(self, runtime_task):
+        return os.path.join(self.job_output_dir,
+                            runtime_task.task.identifier.str_filesystem)
 
     @staticmethod
     def bytes_from_file(filename):

--- a/avocado/core/spawners/common.py
+++ b/avocado/core/spawners/common.py
@@ -31,6 +31,7 @@ class SpawnerMixin:
         if config is None:
             config = settings.as_dict()
         self.config = config
+        self.job_output_dir = None
 
     @staticmethod
     def bytes_from_file(filename):

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -276,13 +276,18 @@ class Test(unittest.TestCase, TestData):
             self.__base_logdir_tmp = tempfile.TemporaryDirectory(prefix=prefix)
             self.__base_logdir = self.__base_logdir_tmp.name
 
-        self.__base_logdir = os.path.join(self.__base_logdir, 'test-results')
-        logdir = os.path.join(self.__base_logdir, self.name.str_filesystem)
-        if os.path.exists(logdir):
-            raise exceptions.TestSetupFail("Log dir already exists, this "
-                                           "should never happen: %s"
-                                           % logdir)
-        self.__logdir = utils_path.init_dir(logdir)
+        if self._config.get("run.test_runner") == 'nrunner':
+            logdir = self.__base_logdir
+            self.__logdir = logdir
+        else:
+            self.__base_logdir = os.path.join(self.__base_logdir, 'test-results')
+            logdir = os.path.join(self.__base_logdir, self.name.str_filesystem)
+
+            if os.path.exists(logdir):
+                raise exceptions.TestSetupFail("Log dir already exists, this "
+                                               "should never happen: %s"
+                                               % logdir)
+            self.__logdir = utils_path.init_dir(logdir)
         self.__logfile = os.path.join(self.logdir, 'debug.log')
 
         self._stdout_file = os.path.join(self.logdir, 'stdout')
@@ -703,7 +708,8 @@ class Test(unittest.TestCase, TestData):
         Auxiliary method to run_avocado.
         """
         testMethod = getattr(self, self._testMethodName)
-        self._start_logging()
+        if self._config.get("run.test_runner") != 'nrunner':
+            self._start_logging()
         if self.__sysinfo_enabled:
             self.__sysinfo_logger.start()
         test_exception = None

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -360,6 +360,7 @@ class Runner(RunnerInterface):
         tsm = TaskStateMachine(self.runtime_tasks, self.status_repo)
         spawner_name = test_suite.config.get('nrunner.spawner')
         spawner = SpawnerDispatcher(test_suite.config)[spawner_name].obj
+        spawner.job_output_dir = job.test_results_path
         max_running = min(test_suite.config.get('nrunner.max_parallel_tasks'),
                           len(self.runtime_tasks))
         timeout = test_suite.config.get('task.timeout.running')

--- a/avocado/plugins/spawners/process.py
+++ b/avocado/plugins/spawners/process.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 
 from avocado.core.plugin_interfaces import Spawner
 from avocado.core.spawners.common import SpawnerMixin, SpawnMethod
@@ -19,6 +20,7 @@ class ProcessSpawner(Spawner, SpawnerMixin):
         return runtime_task.spawner_handle.returncode is None
 
     async def spawn_task(self, runtime_task):
+        self.create_task_output_dir(runtime_task)
         task = runtime_task.task
         runner = task.runnable.pick_runner_command()
         args = runner[1:] + ['task-run'] + task.get_command_args()
@@ -35,6 +37,11 @@ class ProcessSpawner(Spawner, SpawnerMixin):
             return False
         asyncio.ensure_future(self._collect_task(runtime_task.spawner_handle))
         return True
+
+    def create_task_output_dir(self, runtime_task):
+        output_dir_path = self.task_output_dir(runtime_task)
+        os.makedirs(output_dir_path, exist_ok=True)
+        runtime_task.task.setup_output_dir(output_dir_path)
 
     @staticmethod
     async def wait_task(runtime_task):

--- a/selftests/functional/plugin/spawners/test_process.py
+++ b/selftests/functional/plugin/spawners/test_process.py
@@ -1,0 +1,31 @@
+import json
+import os
+
+from avocado.utils import process, script
+from selftests.utils import AVOCADO, TestCaseTmpDir
+
+TEST_LOGDIR = """from avocado import Test
+
+
+class LogdirTest(Test):
+
+    def test(self):
+        self.log.debug("logdir is: %s" % self.logdir)
+"""
+
+
+class ProcessSpawnerTest(TestCaseTmpDir):
+
+    def test_logdir_path(self):
+        test = script.Script(os.path.join(self.tmpdir.name, "logdir_test.py"),
+                             TEST_LOGDIR)
+        test.save()
+        result = process.run("%s run --job-results-dir %s --disable-sysinfo "
+                             "--json - -- %s" % (AVOCADO, self.tmpdir.name,
+                                                 test))
+        res = json.loads(result.stdout_text)
+        logfile = res["tests"][0]["logfile"]
+        testdir = res["tests"][0]["logdir"]
+        with open(logfile, 'r') as debug_file:
+            expected = "logdir is: %s" % testdir
+            self.assertIn(expected, debug_file.read())

--- a/selftests/unit/test_test.py
+++ b/selftests/unit/test_test.py
@@ -51,8 +51,10 @@ class TestClassTestUnit(unittest.TestCase):
     def test_ugly_name(self):
         def run(name, path_name):
             """ Initialize test and check the dirs were created """
+            config = {"run.test_runner": 'runner'}
             tst = self.DummyTest("test", TestID(1, name),
-                                 base_logdir=self.tmpdir.name)
+                                 base_logdir=self.tmpdir.name,
+                                 config=config)
             self.assertEqual(os.path.basename(tst.logdir), path_name)
             self.assertTrue(os.path.exists(tst.logdir))
             self.assertEqual(os.path.dirname(os.path.dirname(tst.logdir)),
@@ -76,8 +78,10 @@ class TestClassTestUnit(unittest.TestCase):
 
     def test_long_name(self):
         def check(uid, name, variant, exp_logdir):
+            config = {"run.test_runner": 'runner'}
             tst = self.DummyTest("test", TestID(uid, name, variant),
-                                 base_logdir=self.tmpdir.name)
+                                 base_logdir=self.tmpdir.name,
+                                 config=config)
             self.assertEqual(os.path.basename(tst.logdir), exp_logdir)
             return tst
 
@@ -118,9 +122,11 @@ class TestClassTestUnit(unittest.TestCase):
         self.assertFalse(tst.get_data('', 'file', False))
 
     def test_all_dirs_exists_no_hang(self):
+        config = {"run.test_runner": 'runner'}
         with unittest.mock.patch('os.path.exists', return_value=True):
             self.assertRaises(exceptions.TestSetupFail, self.DummyTest, "test",
-                              TestID(1, "name"), base_logdir=self.tmpdir.name)
+                              TestID(1, "name"), base_logdir=self.tmpdir.name,
+                              config=config)
 
     def test_try_override_test_variable(self):
         dummy_test = self.DummyTest(base_logdir=self.tmpdir.name)
@@ -174,9 +180,11 @@ class TestClassTest(unittest.TestCase):
                 self.assertTrue(variable)
                 self.whiteboard = 'foo'
 
+        config = {"run.test_runner": 'runner'}
         prefix = temp_dir_prefix(self)
         self.base_logdir = tempfile.TemporaryDirectory(prefix=prefix)
-        self.tst_instance_pass = AvocadoPass(base_logdir=self.base_logdir.name)
+        self.tst_instance_pass = AvocadoPass(base_logdir=self.base_logdir.name,
+                                             config=config)
         self.tst_instance_pass.run_avocado()
 
     def test_class_attributes_name(self):
@@ -202,8 +210,9 @@ class TestClassTest(unittest.TestCase):
             def test(self):
                 pass
 
+        config = {"run.test_runner": 'runner'}
         self.assertRaises(exceptions.TestSetupFail, AvocadoPass,
-                          base_logdir=self.base_logdir.name)
+                          base_logdir=self.base_logdir.name, config=config)
 
     def tearDown(self):
         self.base_logdir.cleanup()


### PR DESCRIPTION
Right now, the test output directory is managed by runners, and it is separated from the job/test-results folder. Most of the runners are using the temporary directory for test output, and this information might be lost. Only possible way how to store this information to the avocado results is use the avocado messages or use the avocado jobs get-output-files script. For some spawners like ProcessSpawner this is an unnecessarily complicated process, because we have to save the same data twice even the tests are run in the same environment as avocado.

This PR will make spawners smart enough to set the output directory for runners, so for the avocado will be easier to manage those files. For example, the ProcessSpawner will set output dir to the job/test-reulst so there is no need for creating the temporary directory and copping to the job/test-results

Reference: #5083
Signed-off-by: Jan Richter jarichte@redhat.com

---
Changes from v1 (#5154):
* fix the problem with 'AVOCADO_TEST_OUTPUTDIR' for exec-tests.
* move the `_create_container_for_task` method form `create_task_output_dir` method
* remove the harcoded default
* rename the `test.output.enabled` to `test.output.fetch`
* better description inside commits
* typo fixes