### PR TITLE
Travis CI: work around arm64 /proc/cmdline content

### DIFF
--- a/optional_plugins/html/tests/test_html_result.py
+++ b/optional_plugins/html/tests/test_html_result.py
@@ -29,8 +29,9 @@ class HtmlResultTest(unittest.TestCase):
 
         # Try to find some strings on HTML
         self.assertNotEqual(output.find('Filesystem'), -1)
-        self.assertNotEqual(output.find('root='), -1)
         self.assertNotEqual(output.find('MemAvailable'), -1)
+        self.assertRegex(output, r'(BOOT_IMAGE|root)\=',
+                         '/proc/cmdline content not found')
 
     def check_output_files(self, debug_log):
         base_dir = os.path.dirname(debug_log)


### PR DESCRIPTION
The arm64 jobs run on such an environment that contains a
"minimalistic" /proc/cmdline, with content such as:

   BOOT_IMAGE=/boot/vmlinuz-5.11.0-40-generic

While other systems /proc/cmdline will have both "BOOT_IMAGE" and
arguments such as "root=", let's use the one available "everywhere".

Signed-off-by: Cleber Rosa <crosa@redhat.com>