### PR TITLE
utils: avoid using root logger

### DIFF
--- a/avocado/utils/debug.py
+++ b/avocado/utils/debug.py
@@ -20,7 +20,7 @@ import os
 import time
 
 # Use this for debug logging
-LOGGER = logging.getLogger("avocado.app.debug")
+LOGGER = logging.getLogger(__name__)
 
 # measure_duration global storage
 __MEASURE_DURATION = {}

--- a/avocado/utils/download.py
+++ b/avocado/utils/download.py
@@ -28,7 +28,7 @@ from urllib.request import urlopen
 
 from avocado.utils import aurl, crypto, output
 
-log = logging.getLogger('avocado.utils.download')
+log = logging.getLogger(__name__)
 
 
 def url_open(url, data=None, timeout=5):

--- a/avocado/utils/stacktrace.py
+++ b/avocado/utils/stacktrace.py
@@ -27,13 +27,14 @@ def prepare_exc_info(exc_info):
     return "".join(tb_info(exc_info))
 
 
-def log_exc_info(exc_info, logger=''):
+def log_exc_info(exc_info, logger=None):
     """
     Log exception info to logger_name.
 
     :param exc_info: Exception info produced by sys.exc_info()
     :param logger: Name or logger instance (defaults to '')
     """
+    logger = logger or __name__
     if isinstance(logger, str):
         logger = logging.getLogger(logger)
     logger.error('')
@@ -46,13 +47,14 @@ def log_exc_info(exc_info, logger=''):
     logger.error('')
 
 
-def log_message(message, logger=''):
+def log_message(message, logger=None):
     """
     Log message to logger.
 
     :param message: Message
     :param logger: Name or logger instance (defaults to '')
     """
+    logger = logger or __name__
     if isinstance(logger, str):
         logger = logging.getLogger(logger)
     for line in message.splitlines():


### PR DESCRIPTION
Those are remaining calls to root logger and some small fixes with the
namespaces. Fixes #4997.

Signed-off-by: Beraldo Leal <bleal@redhat.com>