### PR TITLE
Update cirrus distros and version setuptools requirement

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,6 +7,16 @@ redhat_version_task:
         matrix:
           - image: fedora:35
           - image: fedora:34
+          - image: registry.access.redhat.com/ubi9-beta/ubi
+
+redhat8_version_task:
+    version_script:
+       - dnf -y install python3 python3-pip
+       - pip3 install "setuptools==40.6.3"
+       - python3 setup.py develop --user
+       - python3 -m avocado --version
+    container:
+        matrix:
           - image: registry.access.redhat.com/ubi8/ubi
 
 fedora_develop_install_uninstall_task:
@@ -37,6 +47,20 @@ redhat_egg_task:
         matrix:
           - image: fedora:35
           - image: fedora:34
+          - image: registry.access.redhat.com/ubi9-beta/ubi
+
+redhat8_egg_task:
+    egg_script:
+       - dnf -y install python3 python3-pip
+       - pip3 install "setuptools==40.6.3"
+       - python3 setup.py bdist_egg
+       - mv dist/avocado_framework-*egg /tmp
+       - python3 setup.py clean --all
+       - python3 -c 'import sys; import glob; sys.path.insert(0, glob.glob("/tmp/avocado_framework-*.egg")[0]); from avocado.core.main import main; sys.exit(main())' run /bin/true
+       - cd /tmp
+       - python3 -c 'import sys; from pkg_resources import require; require("avocado-framework"); from avocado.core.main import main; sys.exit(main())' run /bin/true
+    container:
+        matrix:
           - image: registry.access.redhat.com/ubi8/ubi
 
 debian_version_task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -49,7 +49,7 @@ debian_version_task:
         matrix:
           - image: debian:10.10
           - image: debian:11.0
-          - image: ubuntu:18.04
+          - image: ubuntu:21.10
           - image: ubuntu:20.04
 
 debian_egg_task:
@@ -65,7 +65,7 @@ debian_egg_task:
         matrix:
           - image: debian:10.10
           - image: debian:11.0
-          - image: ubuntu:18.04
+          - image: ubuntu:21.10
           - image: ubuntu:20.04
 
 fedora_selftests_task:

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -28,7 +28,7 @@
 Summary: Framework with tools and libraries for Automated Testing
 Name: python-avocado
 Version: 93.0
-Release: 2%{?gitrel}%{?dist}
+Release: 3%{?gitrel}%{?dist}
 License: GPLv2+ and GPLv2 and MIT
 URL: https://avocado-framework.github.io/
 %if 0%{?rel_build}
@@ -45,7 +45,7 @@ BuildRequires: python3-devel
 BuildRequires: python3-docutils
 BuildRequires: python3-lxml
 BuildRequires: python3-psutil
-BuildRequires: python3-setuptools
+BuildRequires: python3-setuptools >= 40.6.3
 
 %if ! 0%{?rhel}
 %if ! 0%{?fedora} > 35
@@ -379,6 +379,9 @@ Again Shell code (and possibly other similar shells).
 %{_libexecdir}/avocado*
 
 %changelog
+* Mon Dec 13 2021 Ana Guerrero Lopez <anguerre@redhat.com> - 93.0-3
+- Require at least setuptools 40.6.3, needed for PEP420.
+
 * Wed Nov 17 2021 Ana Guerrero Lopez <anguerre@redhat.com> - 93.0-2
 - Adjust selftest/check.py to use new --skip option
 

--- a/setup.py
+++ b/setup.py
@@ -423,4 +423,4 @@ if __name__ == '__main__':
                     'man': Man,
                     'plugin': Plugin,
                     'test': Test},
-          install_requires=['setuptools'])
+          install_requires=['setuptools >= 40.6.3'])


### PR DESCRIPTION
Update Ubuntu and RHEL versions in cirrus. In the case of RHEL8, make sure a more recent setuptools is installed.
Make avocado to require at least setuptools 40.6.3 to support PEP 420.

References: https://github.com/avocado-framework/avocado/issues/5165