### PR TITLE
Makefile: fix "make -f Makefile.pkg rpm"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
-ifndef PYTHON
-PYTHON=$(shell which python3 2>/dev/null || which python 2>/dev/null)
-endif
-VERSION=$(shell $(PYTHON) setup.py --version 2>/dev/null)
+include Makefile.include
+
 PYTHON_DEVELOP_ARGS=$(shell if ($(PYTHON) setup.py develop --help 2>/dev/null | grep -q '\-\-user'); then echo "--user"; else echo ""; fi)
 DESTDIR=/
 AVOCADO_DIRNAME=$(shell basename ${PWD})

--- a/Makefile.gh
+++ b/Makefile.gh
@@ -1,11 +1,6 @@
 # This Makefile contains targets used by GitHub Actions
+include Makefile.include
 
-ifndef PYTHON
-PYTHON=$(shell which python3 2>/dev/null)
-endif
-ifndef VERSION
-VERSION=$(shell $(PYTHON) setup.py --version 2>/dev/null)
-endif
 ifndef AVOCADO_OPTIONAL_PLUGINS
 AVOCADO_OPTIONAL_PLUGINS=$(shell find ./optional_plugins -maxdepth 1 -mindepth 1 -type d)
 endif

--- a/Makefile.include
+++ b/Makefile.include
@@ -1,0 +1,9 @@
+# This Makefile contains snippets used on other Makefiles
+
+ifndef PYTHON
+PYTHON=$(shell which python3 2>/dev/null || which python 2>/dev/null)
+endif
+
+ifndef VERSION
+VERSION=$(shell $(PYTHON) setup.py --version 2>/dev/null)
+endif

--- a/Makefile.pkg
+++ b/Makefile.pkg
@@ -1,4 +1,6 @@
 # This Makefile contains RPM related targets
+include Makefile.include
+
 COMMIT=$(shell git log --pretty=format:'%H' -n 1)
 COMMIT_DATE=$(shell git log --pretty='format:%cd' --date='format:%Y%m%d' -n 1)
 SHORT_COMMIT=$(shell git rev-parse --short=9 HEAD)
@@ -6,9 +8,6 @@ MOCK_CONFIG=default
 ARCHIVE_BASE_NAME=avocado
 PYTHON_MODULE_NAME=avocado-framework
 RPM_BASE_NAME=python-avocado
-ifndef VERSION
-VERSION=$(shell $(PYTHON) setup.py --version 2>/dev/null)
-endif
 
 all:
 	@echo

--- a/avocado/core/__init__.py
+++ b/avocado/core/__init__.py
@@ -140,6 +140,7 @@ def register_core_options():
                          key_type=int,
                          help_msg=help_msg,
                          default=10)
+
     help_msg = ('Whether to display colored output in terminals that '
                 'support it')
     stgs.register_option(section='runner.output',

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -28,7 +28,7 @@
 Summary: Framework with tools and libraries for Automated Testing
 Name: python-avocado
 Version: 93.0
-Release: 2%{?gitrel}%{?dist}
+Release: 3%{?gitrel}%{?dist}
 License: GPLv2+ and GPLv2 and MIT
 URL: https://avocado-framework.github.io/
 %if 0%{?rel_build}
@@ -168,9 +168,6 @@ cp -r examples/varianter_cit %{buildroot}%{_docdir}/avocado
 find %{buildroot}%{_docdir}/avocado -type f -name '*.py' -exec chmod -c -x {} ';'
 mkdir -p %{buildroot}%{_libexecdir}/avocado
 mv %{buildroot}%{python3_sitelib}/avocado/libexec/* %{buildroot}%{_libexecdir}/avocado
-# adjust permissions for file containing shebang line needed for
-# spawning tasks in podman containers
-chmod -c +x %{buildroot}%{python3_sitelib}/avocado/core/nrunner.py
 
 %if %{with tests}
 %check
@@ -379,6 +376,9 @@ Again Shell code (and possibly other similar shells).
 %{_libexecdir}/avocado*
 
 %changelog
+* Mon Dec 13 2021 Cleber Rosa <crosa@redhat.com> - 93.0-3
+- Removed executable mode from avocado/core/nrunner.py
+
 * Wed Nov 17 2021 Ana Guerrero Lopez <anguerre@redhat.com> - 93.0-2
 - Adjust selftest/check.py to use new --skip option
 


### PR DESCRIPTION
The "rpm" target depends on VERSION, which depends on PYTHON, with the later not being defined in the Makefile.pkg file.
    
Instead of repeating definitions, let's put those common definitions in a single include file.

This also includes other misc fixes (one related to the RPM package).