### PR TITLE
Job test-results directory for spawners default value

### DIFF
--- a/avocado/core/dispatcher.py
+++ b/avocado/core/dispatcher.py
@@ -126,6 +126,7 @@ class InitDispatcher(EnabledExtensionManager):
 
 class SpawnerDispatcher(EnabledExtensionManager):
 
-    def __init__(self, config=None):
+    def __init__(self, config=None, job=None):
         super(SpawnerDispatcher, self).__init__('avocado.plugins.spawner',
-                                                invoke_kwds={'config': config})
+                                                invoke_kwds={'job': job,
+                                                             'config': config})

--- a/avocado/core/spawners/common.py
+++ b/avocado/core/spawners/common.py
@@ -28,14 +28,16 @@ class SpawnerMixin:
 
     METHODS = []
 
-    def __init__(self, config=None):
+    def __init__(self, config=None, job=None):
         if config is None:
             config = settings.as_dict()
         self.config = config
-        self.job_output_dir = None
+        self._job = job
 
     def task_output_dir(self, runtime_task):
-        return os.path.join(self.job_output_dir,
+        if self._job is None:
+            raise SpawnerException("Job wasn't set properly")
+        return os.path.join(self._job.test_results_path,
                             runtime_task.task.identifier.str_filesystem)
 
     @staticmethod

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -359,8 +359,7 @@ class Runner(RunnerInterface):
                     if rt.task.category == 'test']
         tsm = TaskStateMachine(self.runtime_tasks, self.status_repo)
         spawner_name = test_suite.config.get('nrunner.spawner')
-        spawner = SpawnerDispatcher(test_suite.config)[spawner_name].obj
-        spawner.job_output_dir = job.test_results_path
+        spawner = SpawnerDispatcher(test_suite.config, job)[spawner_name].obj
         max_running = min(test_suite.config.get('nrunner.max_parallel_tasks'),
                           len(self.runtime_tasks))
         timeout = test_suite.config.get('task.timeout.running')


### PR DESCRIPTION
In b8d7ebaf9b4ff757fb6ab12b8f128d244cfb12d2 the test-results directory
was introduced inside spawners. With this change, there might occur a
situation when this variable wasn't set, which caused `NoneType` error.
This commit is adding the default value to avoid this problem.

Signed-off-by: Jan Richter <jarichte@redhat.com>