### PR TITLE
setup.py test exit code fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -219,7 +219,7 @@ class Test(SimpleCommand):
 
         # Import here on purpose, otherwise it'll mess with install/develop commands
         import selftests.check
-        selftests.check.main(args)
+        sys.exit(selftests.check.main(args))
 
 
 class Man(SimpleCommand):


### PR DESCRIPTION
The `setup.py test` was always returning exit code 0, because the exit
code from `check.py` wasn't respected. This will fix that, by exiting
`setup.py test` with code from `check.py`.

Reference: #5208
Signed-off-by: Jan Richter <jarichte@redhat.com>